### PR TITLE
fix: remove unused profile API call from user context

### DIFF
--- a/frontend/src/components/dashboard/header.tsx
+++ b/frontend/src/components/dashboard/header.tsx
@@ -4,7 +4,6 @@
 import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
-import { useCurrentPerson } from "~/lib/usercontext-context";
 import { useSession } from "next-auth/react";
 
 interface HeaderProps {
@@ -32,12 +31,11 @@ const LogoutIcon = ({ className }: { className?: string }) => (
 );
 
 export function Header({ userName = "Benutzer" }: HeaderProps) {
-    const { person } = useCurrentPerson();
     const { data: session } = useSession();
     
     // Determine the display name with proper fallback logic
-    // Now firstName is available immediately from session, no flash!
-    const displayName = session?.user?.firstName ?? person?.first_name ?? userName ?? session?.user?.name ?? "Benutzer";
+    // firstName is available immediately from session JWT token
+    const displayName = session?.user?.firstName ?? userName ?? session?.user?.name ?? "Benutzer";
     
     return (
         <header className="w-full bg-white/80 py-4 shadow-sm backdrop-blur-sm">

--- a/frontend/src/lib/usercontext-api.ts
+++ b/frontend/src/lib/usercontext-api.ts
@@ -7,21 +7,18 @@ import {
     mapActivityGroupResponse,
     mapActiveGroupResponse,
     mapUserProfileResponse,
-    mapPersonResponse,
     mapStaffResponse,
     mapTeacherResponse,
     type EducationalGroup,
     type ActivityGroup,
     type ActiveGroup,
     type UserProfile,
-    type Person,
     type Staff,
     type Teacher,
     type BackendEducationalGroup,
     type BackendActivityGroup,
     type BackendActiveGroup,
     type BackendUserProfile,
-    type BackendPerson,
     type BackendStaff,
     type BackendTeacher,
 } from "./usercontext-helpers";
@@ -65,41 +62,6 @@ export const userContextService = {
             }
         } catch (error) {
             console.error("Get current user error:", error);
-            throw error;
-        }
-    },
-
-    // Get current user's person profile
-    getCurrentPerson: async (): Promise<Person> => {
-        const useProxyApi = typeof window !== "undefined";
-        const url = useProxyApi
-            ? "/api/me/profile"
-            : `${env.NEXT_PUBLIC_API_URL}/me/profile`;
-
-        try {
-            if (useProxyApi) {
-                const session = await getSession();
-                const response = await fetch(url, {
-                    headers: {
-                        Authorization: `Bearer ${session?.user?.token}`,
-                        "Content-Type": "application/json",
-                    },
-                });
-
-                if (!response.ok) {
-                    const errorText = await response.text();
-                    console.error(`Get current person error: ${response.status}`, errorText);
-                    throw new Error(`Get current person failed: ${response.status}`);
-                }
-
-                const responseData = await response.json() as ApiResponse<BackendPerson>;
-                return mapPersonResponse(responseData.data);
-            } else {
-                const response = await api.get<ApiResponse<BackendPerson>>(url);
-                return mapPersonResponse(response.data.data);
-            }
-        } catch (error) {
-            console.error("Get current person error:", error);
             throw error;
         }
     },


### PR DESCRIPTION
## Summary
Removes the redundant `/me/profile` API call from the header component, as the user's first name is already available in the JWT token.

## Changes
- Removed `getCurrentPerson` method from usercontext-api.ts
- Updated Header component to use `session?.user?.firstName` directly
- Removed person-related state and hooks from UserContext
- Simplified UserContextProvider to only fetch educational groups

## Benefits
- 🚀 Improved performance: One less API call on every page load
- 🎯 Simpler code: Reduced complexity in UserContext
- 💾 Efficiency: Uses data already available in the JWT token
- 🔒 Security: Less data exposure (no DOB transmitted unnecessarily)

## Related Issues
Fixes #58 - This completes the fix for displaying user's first name instead of email in the header

## Test plan
[x] Header displays user's first name correctly
[x] No console errors or warnings
[x] All linting and type checking passes
[x] Application continues to function normally

🤖 Generated with [Claude Code](https://claude.ai/code)