### PR TITLE
fix: remove unnecessary search_path modification that breaks migration status

### DIFF
--- a/backend/database/db.go
+++ b/backend/database/db.go
@@ -34,11 +34,6 @@ func DBConn() (*bun.DB, error) {
 		return nil, err
 	}
 
-	// Set the search_path to include auth schema
-	_, err := db.Exec("SET search_path TO auth, public")
-	if err != nil {
-		return nil, err
-	}
 
 	if viper.GetBool("db_debug") {
 		db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))


### PR DESCRIPTION
## Summary
- Fixes migration status not being correctly updated when running migrations via Docker
- Removes redundant `SET search_path TO auth, public` from database connection

## Problem
When running migrations with `docker compose run server ./main migrate`, the migration status was not being correctly updated. This was caused by the `SET search_path` modification interfering with BUN ORM's ability to access its migration tracking tables (`bun_migrations` and `bun_migration_locks`) in the public schema.

## Solution
Removed the unnecessary search_path modification since all database queries already use schema-qualified table names (e.g., `auth.accounts`, `users.persons`, `education.groups`).

## Test plan
- [x] Run `docker compose run server ./main migrate status` - verify it shows correct status
- [x] Run `docker compose run server ./main migrate` - verify migrations run and status updates
- [x] Verify application still works correctly without search_path modification
- [x] All existing functionality continues to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)