### PR TITLE
fix: resolve React synthetic event error in device API key copy handler

### DIFF
--- a/frontend/src/components/devices/device-detail-modal.tsx
+++ b/frontend/src/components/devices/device-detail-modal.tsx
@@ -159,9 +159,9 @@ export function DeviceDetailModal({
                       <button
                         type="button"
                         onClick={async (e) => {
-                          await navigator.clipboard.writeText(device.api_key!);
                           const btn = e.currentTarget as HTMLButtonElement;
                           const original = btn.textContent;
+                          await navigator.clipboard.writeText(device.api_key!);
                           btn.textContent = "Kopiert!";
                           setTimeout(() => {
                             if (btn) btn.textContent = original ?? "Kopieren";


### PR DESCRIPTION
## Summary
Fixed a React synthetic event error in the device detail modal's copy API key button that caused a "Cannot read properties of null (reading 'textContent')" error when clicked.

## Root Cause
React's synthetic event object is reused/pooled after async operations complete. The original code tried to access `e.currentTarget` after the `await navigator.clipboard.writeText()` promise resolved, by which point the event object was no longer available, causing `e.currentTarget` to be null.

## Solution
Capture the button element reference synchronously before the async operation. This keeps a stable DOM reference that remains valid after the async boundary.

## Test Plan
- Click the "Kopieren" (Copy) button on the device detail modal
- Verify the button text changes to "Kopiert!" without console errors
- Verify the button text reverts back to "Kopieren" after 1.5 seconds
- Confirm the API key is successfully copied to clipboard