### PR TITLE
fix: replace fragile string comparisons with errors.Is for sql.ErrNoRows

### DIFF
--- a/backend/database/repositories/active/group.go
+++ b/backend/database/repositories/active/group.go
@@ -4,6 +4,7 @@ package active
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -292,7 +293,7 @@ func (r *GroupRepository) FindActiveByDeviceID(ctx context.Context, deviceID int
 		Scan(ctx, &result)
 
 	if err != nil {
-		if err.Error() == "sql: no rows in result set" {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil // No active session found - not an error
 		}
 		return nil, &modelBase.DatabaseError{
@@ -360,7 +361,7 @@ func (r *GroupRepository) FindActiveByDeviceIDWithNames(ctx context.Context, dev
 		Scan(ctx, &result)
 
 	if err != nil {
-		if err.Error() == "sql: no rows in result set" {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil // No active session found - not an error
 		}
 		return nil, &modelBase.DatabaseError{
@@ -420,7 +421,7 @@ func (r *GroupRepository) CheckRoomConflict(ctx context.Context, roomID int64, e
 
 	err := query.Scan(ctx)
 	if err != nil {
-		if err.Error() == "sql: no rows in result set" {
+		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil, nil // No conflict found
 		}
 		return false, nil, &modelBase.DatabaseError{

--- a/backend/services/usercontext/usercontext_service.go
+++ b/backend/services/usercontext/usercontext_service.go
@@ -2,6 +2,7 @@ package usercontext
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"log"
 	"os"
@@ -197,7 +198,7 @@ func (s *userContextService) GetCurrentStaff(ctx context.Context) (*users.Staff,
 	staff, err := s.staffRepo.FindByPersonID(ctx, person.ID)
 	if err != nil {
 		// Check if it's a "no rows" error
-		if err.Error() == "sql: no rows in result set" || strings.Contains(err.Error(), "no rows in result set") {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, &UserContextError{Op: "get current staff", Err: ErrUserNotLinkedToStaff}
 		}
 		return nil, &UserContextError{Op: "get current staff", Err: err}


### PR DESCRIPTION
## Summary
Replaces fragile string-based `sql.ErrNoRows` detection with robust `errors.Is()` checks, following Go best practices and improving code maintainability.

## Changes
- **database/repositories/active/group.go**: 3 instances updated
  - `FindActiveByDeviceID()`
  - `FindActiveByDeviceIDWithNames()`
  - `CheckRoomConflict()`
- **services/usercontext/usercontext_service.go**: 1 instance updated
  - `GetCurrentStaff()`

## Technical Details
### Before (fragile)
```go
if err.Error() == "sql: no rows in result set" {
    // handle no rows
}
```

### After (robust)
```go
if errors.Is(err, sql.ErrNoRows) {
    // handle no rows
}
```

## Why This Matters
1. **Future-proof**: Won't break if error messages change in Go/SQL driver updates
2. **Wrapped errors**: `errors.Is()` uses `DatabaseError.Unwrap()` to check error chains
3. **Best practice**: Aligns with Go's official error handling guidelines
4. **Consistency**: Codebase now uses `errors.Is()` uniformly (52 instances across 16 files)

## Testing
- ✅ Backend compiles successfully (Docker build passed)
- ✅ No string-based error checks remaining in codebase
- ✅ Consistent with existing `errors.Is()` usage patterns

## No Side Effects
The `DatabaseError` wrapper implements `Unwrap()`, ensuring `errors.Is()` correctly identifies `sql.ErrNoRows` in the error chain. This is actually **more robust** than the previous string matching approach.

Closes #223