### PR TITLE
fix: allow rooms without capacity for zero-capacity requests

### DIFF
--- a/backend/models/facilities/room.go
+++ b/backend/models/facilities/room.go
@@ -77,8 +77,11 @@ func (r *Room) Validate() error {
 
 // IsAvailable checks if the room is available for a given capacity
 func (r *Room) IsAvailable(requiredCapacity int) bool {
+	// Capacity is optional (see migration 1.1.5). Treat rooms without a
+	// specified capacity as available for neutral/zero-capacity requests so
+	// that devices still list them instead of filtering everything out.
 	if r.Capacity == nil {
-		return false
+		return requiredCapacity <= 0
 	}
 	return *r.Capacity >= requiredCapacity
 }

--- a/backend/models/facilities/room_test.go
+++ b/backend/models/facilities/room_test.go
@@ -1,0 +1,37 @@
+package facilities
+
+import "testing"
+
+func TestRoomIsAvailableWithNilCapacity(t *testing.T) {
+	room := &Room{Capacity: nil}
+
+	if !room.IsAvailable(0) {
+		t.Fatalf("expected room with nil capacity to be available for 0 requirement")
+	}
+
+	if room.IsAvailable(5) {
+		t.Fatalf("expected room with nil capacity to be unavailable for capacity > 0")
+	}
+}
+
+func TestRoomIsAvailableWithCapacityValue(t *testing.T) {
+	capacity := 10
+	room := &Room{Capacity: &capacity}
+
+	cases := []struct {
+		required int
+		expected bool
+	}{
+		{0, true},
+		{5, true},
+		{10, true},
+		{11, false},
+	}
+
+	for _, c := range cases {
+		if got := room.IsAvailable(c.required); got != c.expected {
+			t.Fatalf("IsAvailable(%d) = %v, expected %v", c.required, got, c.expected)
+		}
+	}
+}
+


### PR DESCRIPTION
## Summary

Fixes IoT device room availability filtering for rooms without capacity values.

## Problem

Migration 1.1.5 made `room.capacity` nullable, but `Room.IsAvailable()` filtered out all rooms with `nil` capacity. This caused IoT devices to receive empty room lists when calling `/api/iot/rooms/available`, even though rooms like "Raum 1" and "Spaßraum" existed in the database.

## Root Cause

The `IsAvailable()` method returned `false` for any room with `nil` capacity, regardless of the `requiredCapacity` parameter. When IoT devices requested available rooms without a capacity filter (`requiredCapacity = 0`), all rooms without capacity were excluded.

## Solution

Modified `Room.IsAvailable()` to:
- Return `true` for rooms with `nil` capacity when `requiredCapacity <= 0`
- Continue returning `false` for rooms with `nil` capacity when `requiredCapacity > 0`

This ensures:
- ✅ IoT devices see all rooms when no capacity filter is applied
- ✅ Rooms without capacity are not included when a specific capacity is required
- ✅ Backward compatible with existing capacity-based filtering

## Changes

- `backend/models/facilities/room.go`: Updated `IsAvailable()` logic
- `backend/models/facilities/room_test.go`: Added comprehensive test coverage

## Test Plan

- [x] Unit tests pass (`go test ./models/facilities`)
- [x] Tested with IoT device - rooms now appear in `/api/iot/rooms/available`
- [x] Verified rooms with defined capacity still filter correctly

## Testing

```bash
cd backend && go test ./models/facilities
```

All tests pass ✅