### PR TITLE
fix: student creation modal not closing after successful creation

### DIFF
--- a/frontend/src/components/students/student-create-modal.tsx
+++ b/frontend/src/components/students/student-create-modal.tsx
@@ -91,8 +91,15 @@ export function StudentCreateModal({
       // Modal is closed by parent component after successful creation
     } catch (error) {
       console.error("Error creating student:", error);
+
+      // Extract error message if available
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Fehler beim Erstellen. Bitte versuchen Sie es erneut.";
+
       setErrors({
-        submit: "Fehler beim Erstellen. Bitte versuchen Sie es erneut.",
+        submit: errorMessage,
       });
     } finally {
       setSaveLoading(false);


### PR DESCRIPTION
## Summary

Fixes the student creation modal not closing and showing success messages after creating a student (#308).

## Problem

When creating a student in the database page:
- Modal did not close automatically
- No success message appeared
- Student was actually created (visible after manual refresh)
- Privacy consent creation logic was blocking the entire flow

## Root Cause

Privacy consent creation was triggered on **every** student creation (even with default values). When the privacy consent endpoint failed due to permissions or other issues, the entire operation appeared to fail even though the student was successfully created in the database.

## Changes

### `/frontend/src/app/api/students/route.ts`
- Privacy consent now only created when explicitly enabled or custom retention period is set
- Privacy consent creation is non-blocking - failures no longer prevent student creation
- Better logging for debugging consent issues

### `/frontend/src/components/students/student-create-modal.tsx`
- Improved error handling to show specific error messages
- Better user feedback when errors occur

## Testing

1. Navigate to Database → Students
2. Click "+" to create a new student
3. Fill in required fields (Vorname, Nachname, Klasse, Name LG, Kontakt LG)
4. Click "Erstellen"
5. **Expected**: Modal closes immediately, success toast appears, student is visible in list

## Closes

- Closes #308