### PR TITLE
fix: remove unwanted rotation from card float animation

### DIFF
--- a/frontend/src/app/students/search/page.tsx
+++ b/frontend/src/app/students/search/page.tsx
@@ -373,10 +373,10 @@ function SearchPageContent() {
               @keyframes float {
                 0%,
                 100% {
-                  transform: translateY(0px) rotate(var(--rotation));
+                  transform: translateY(0px);
                 }
                 50% {
-                  transform: translateY(-4px) rotate(var(--rotation));
+                  transform: translateY(-4px);
                 }
               }
             `}</style>
@@ -392,7 +392,6 @@ function SearchPageContent() {
                     }
                     className={`group relative cursor-pointer overflow-hidden rounded-2xl border border-gray-100/50 bg-white/90 shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md transition-all duration-500 active:scale-[0.97] md:hover:-translate-y-3 md:hover:scale-[1.03] md:hover:border-[#5080D8]/30 md:hover:bg-white md:hover:shadow-[0_20px_50px_rgb(0,0,0,0.15)]`}
                     style={{
-                      transform: `rotate(${((index % 3) - 1) * 0.8}deg)`,
                       animation: `float 8s ease-in-out infinite ${index * 0.7}s`,
                     }}
                   >


### PR DESCRIPTION
## Problem
Student search cards were randomly rotating without user interaction. The rotation would occur every ~8 seconds with staggered timing, making cards appear to twist slightly before returning to their original position.

## Root Cause
The `@keyframes float` animation included `rotate(var(--rotation))`, but the CSS variable `--rotation` was never defined. This caused:

1. Each card had an initial rotation via inline styles: `-0.8deg`, `0deg`, or `+0.8deg` (based on index)
2. During the float animation cycle, the undefined `--rotation` variable would default to `0deg`
3. Cards would jump between their initial rotation and `0deg`, creating the unwanted twisting effect

## Changes
- ✅ Removed `rotate(var(--rotation))` from `@keyframes float` animation
- ✅ Removed initial `transform: rotate(...)` from card inline styles
- ✅ Animation now only performs vertical `translateY` movement (floating effect)
- ✅ Verified myroom and ogs_groups pages have no similar issues

## Files Changed
- `frontend/src/app/students/search/page.tsx`

## Testing
- [x] Frontend quality checks pass (`npm run check`)
- [x] Visual test: Cards should float vertically without any rotation
- [x] Hover animation should still work (scale + translateY)
- [x] Verify on different viewport sizes (mobile, tablet, desktop)

## Before / After

**Before:**
- Cards randomly rotate ±0.8° every 8 seconds
- Rotation conflicts with hover state
- Undefined CSS variable causes jump effect

**After:**
- Cards only float vertically (smooth translateY)
- No rotation during idle state
- Hover animations unaffected