### PR TITLE
chore(ci): switch SonarCloud from automatic to CI-based analysis

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,25 @@
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - development
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones disabled for better analysis relevancy
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -452,7 +452,7 @@ sonar-reports/
 **/golangci-lint-report.xml
 .env.sonar
 docker-compose.sonar.yml
-sonar-project.properties
+# sonar-project.properties is now safe to track (no secrets)
 
 .cursor/*
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,50 @@
+# SonarCloud Configuration
+# Required: Project and organization identifiers
+sonar.projectKey=moto-nrw_project-phoenix
+sonar.organization=moto-nrw
+sonar.projectName=Project Phoenix
+sonar.projectVersion=1.0
+
+# Source directories (Go backend + TypeScript frontend)
+sonar.sources=backend,frontend/src
+
+# Test directories
+sonar.tests=backend
+sonar.test.inclusions=**/*_test.go
+
+# Go backend configuration
+sonar.go.coverage.reportPaths=backend/coverage.out
+
+# TypeScript/JavaScript frontend configuration
+sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
+sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
+
+# Exclusions - files to skip during analysis
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/vendor/**,\
+  **/*.pb.go,\
+  **/migrations/**,\
+  **/.next/**,\
+  **/dist/**,\
+  **/build/**,\
+  **/*.min.js,\
+  **/*.d.ts,\
+  **/coverage/**,\
+  **/bruno/**,\
+  **/config/**,\
+  **/scripts/**
+
+# Test exclusions
+sonar.test.exclusions=\
+  **/*_test.go,\
+  **/*.test.ts,\
+  **/*.test.tsx,\
+  **/*.spec.ts,\
+  **/*.spec.tsx
+
+# Go linter report paths (optional - for enhanced analysis)
+sonar.go.golangci-lint.reportPaths=backend/golangci-lint-report.xml
+
+# Source encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow for SonarCloud analysis on PRs and branch pushes
- Configure `sonar-project.properties` for SonarCloud (was incorrectly configured for local SonarQube)
- Remove hardcoded token from config (now uses `SONAR_TOKEN` GitHub secret)
- Un-ignore `sonar-project.properties` since it no longer contains secrets

## Problem

SonarCloud's automatic analysis doesn't support branch analysis - only PRs and main branch. This caused all pushes to `development` to show "cancelled" status, which was confusing.

## Solution

Switch to CI-based analysis via GitHub Actions, which:
- ✅ Properly analyzes PRs
- ✅ Properly analyzes branch pushes (development, main)
- ✅ Supports coverage reports (future enhancement)
- ✅ Gives us control over analysis timing

## Manual Step Required

⚠️ **Before merging**: Disable Automatic Analysis in SonarCloud UI:
1. Go to: https://sonarcloud.io → project-phoenix → Administration → Analysis Method
2. Click "Switch off Automatic Analysis"

## Test Plan

- [ ] Verify this PR triggers the new `SonarCloud Analysis` GitHub Action
- [ ] Verify SonarCloud analysis completes successfully
- [ ] After merge, verify branch push to `development` shows successful analysis (not "cancelled")