### PR TITLE
chore: trigger SonarCloud visibility sync

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,5 +1,6 @@
 # SonarCloud Automatic Analysis Configuration
 # This file configures automatic analysis exclusions
+# Repository is now public - triggering visibility sync
 
 # Exclude non-production code to stay under free tier line limit
 sonar.exclusions=**/*_test.go,**/test/**,**/seed/**,**/migrations/**,**/simulator/**,**/openspec/**,**/docs/**,**/templates/**


### PR DESCRIPTION
## Summary
- Trigger SonarCloud automatic analysis to sync repository visibility status
- Repository changed from private to public

## Test plan
- [ ] SonarCloud scan triggers on PR
- [ ] Visibility status updates in SonarCloud dashboard