### PR TITLE
refactor(frontend): SonarCloud code quality fixes - Iteration 3

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -24,9 +24,8 @@ import {
   mapCombinedGroupsResponse,
 } from "./group-helpers";
 
-// Re-export for external consumers (mapGroupResponse used internally, so standard export)
-export { mapGroupResponse };
-export { mapCombinedGroupResponse } from "./group-helpers";
+// Re-export for external consumers
+export { mapGroupResponse, mapCombinedGroupResponse } from "./group-helpers";
 import type {
   BackendGroup,
   BackendCombinedGroup,
@@ -227,7 +226,7 @@ api.interceptors.response.use(
 
     // Only handle 401 errors that haven't been retried
     if (error.response?.status !== 401 || originalRequest._retry) {
-      return Promise.reject(error);
+      throw error;
     }
 
     const callerId = `axios-interceptor-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
@@ -239,7 +238,7 @@ api.interceptors.response.use(
     if (originalRequest._retryCount > 3) {
       console.error("Max retry attempts reached, giving up");
       redirectToLogin();
-      return Promise.reject(error);
+      throw error;
     }
 
     // Queue request if refresh is already in progress
@@ -255,7 +254,7 @@ api.interceptors.response.use(
       if (globalThis.window === undefined) {
         const result = await attemptServerSideRefresh(originalRequest);
         if (result) return result;
-        return Promise.reject(error);
+        throw error;
       }
 
       // Client-side refresh
@@ -268,7 +267,7 @@ api.interceptors.response.use(
       isRefreshing = false;
     }
 
-    return Promise.reject(error);
+    throw error;
   },
 );
 


### PR DESCRIPTION
## Summary

Third iteration of frontend code quality improvements addressing SonarCloud issues in `frontend/src/lib/api.ts`.

### Changes

- **S7763**: Use `export...from` syntax for pure re-exports (`mapCombinedGroupResponse`, `mapRoomResponse`)
- **S7764**: Replace all `window` references with `globalThis.window` (ES2020 compliance)
- **S3776**: Reduce cognitive complexity in axios response interceptor from 30 to ~10 by extracting helper functions

### Refactoring Details (S3776)

Extracted helper functions to flatten the axios interceptor structure:
- `redirectToLogin()` - browser redirect handling
- `setAuthorizationHeader()` - header setting (handles both `.set()` method and direct assignment)
- `queueRequestForRefresh()` - request queueing during ongoing refresh
- `attemptServerSideRefresh()` - server-side token refresh logic
- `attemptClientSideRefresh()` - client-side token refresh logic

All code paths, logging messages, and behavior are preserved - no functional changes.

## Test Plan

- [x] `npm run check` passes (lint + typecheck)
- [x] Manual testing of authentication flow (login, 401 handling)
- [ ] Testing of token refresh after 15 mins