### PR TITLE
fix(activities): eliminate double render on page load

### DIFF
--- a/frontend/src/app/activities/page.tsx
+++ b/frontend/src/app/activities/page.tsx
@@ -62,7 +62,8 @@ export default function ActivitiesPage() {
         ]);
         setActivities(activitiesData);
         setCategories(categoriesData);
-        setFilteredActivities(activitiesData);
+        // Note: Don't set filteredActivities here - the filter useEffect will handle it
+        // when activities state updates, avoiding a double render
         setCurrentStaff(staffData);
         setError(null);
       } catch (err) {
@@ -142,10 +143,10 @@ export default function ActivitiesPage() {
     }
 
     // Reload activities to show updated data
+    // Note: Only set activities - the filter useEffect will update filteredActivities
     try {
       const activitiesData = await fetchActivities();
       setActivities(activitiesData);
-      setFilteredActivities(activitiesData);
     } catch (err) {
       console.error("Error reloading activities:", err);
     }


### PR DESCRIPTION
## Summary
- Remove redundant `setFilteredActivities` call from the data loading effect
- The filter `useEffect` already handles setting `filteredActivities` when activities state updates

## Root Cause
Two state updates were triggering consecutive renders:
1. `setFilteredActivities(activitiesData)` in load effect → Render #1
2. `setFilteredActivities(filtered)` in filter effect (triggered by activities change) → Render #2

## Result
- **Before:** Loading → Render → Render (~1s delay between)
- **After:** Loading → Single Render

Closes #441