### PR TITLE
fix(groups): show correct supervisors in edit modal (#444)

### DIFF
--- a/frontend/src/lib/database/configs/groups.config.tsx
+++ b/frontend/src/lib/database/configs/groups.config.tsx
@@ -77,12 +77,14 @@ export const groupsConfig = defineEntityConfig<Group>({
                         id: string;
                         name: string;
                         specialization?: string;
+                        teacher_id?: string;
                       }>;
                     }
                   | Array<{
                       id: string;
                       name: string;
                       specialization?: string;
+                      teacher_id?: string;
                     }>;
 
                 // Handle both array and wrapped response formats
@@ -90,12 +92,15 @@ export const groupsConfig = defineEntityConfig<Group>({
                   ? result
                   : (result.data ?? []);
 
-                return teachers.map((teacher) => ({
-                  value: teacher.id.toString(),
-                  label: teacher.specialization
-                    ? `${teacher.name} (${teacher.specialization})`
-                    : teacher.name,
-                }));
+                // Use teacher_id (not staff id) to match backend group teacher assignments
+                return teachers
+                  .filter((teacher) => teacher.teacher_id)
+                  .map((teacher) => ({
+                    value: teacher.teacher_id!,
+                    label: teacher.specialization
+                      ? `${teacher.name} (${teacher.specialization})`
+                      : teacher.name,
+                  }));
               } catch (error) {
                 console.error("Failed to fetch teachers:", error);
                 return [];


### PR DESCRIPTION
## Summary
- Fixes supervisor multiselect not showing pre-selected values in group edit modal
- Root cause: ID mismatch between staff API (returning `staff.id`) and groups API (returning `teacher.id`)
- Changed multiselect options to use `teacher_id` field from staff API to match group data

## Problem
When editing a group in `/database/groups`, the supervisors multiselect field was empty even though supervisors were assigned to the group. The detail modal showed the supervisors correctly, but the edit modal's form didn't pre-populate the multiselect.

## Root Cause Analysis
1. The staff API (`/api/staff?teachers_only=true`) returns:
   - `id` = staff ID
   - `teacher_id` = teacher ID

2. The groups API (`/api/groups/{id}`) returns teachers with:
   - `id` = teacher ID

3. The multiselect options were using `id` (staff ID) as the value
4. The initial form data contained `teacher_ids` with teacher IDs
5. IDs didn't match → multiselect showed no selections

## Fix
Changed `groups.config.tsx` to use `teacher_id` instead of `id` for the multiselect option values.

## Test Plan
1. Navigate to Database → Groups
2. Click on a group that has supervisors assigned
3. Verify supervisors are shown in detail modal
4. Click "Edit"
5. Verify supervisors are pre-selected in the multiselect
6. Add/remove supervisors and save
7. Verify changes persist correctly

Closes #444