### PR TITLE
fix(ogs-groups): prevent modal from switching groups after transfer

### DIFF
--- a/frontend/src/app/ogs-groups/page.tsx
+++ b/frontend/src/app/ogs-groups/page.tsx
@@ -166,8 +166,8 @@ function OGSGroupPageContent() {
   const currentGroupId = currentGroup?.id;
   useEffect(() => {
     if (showTransferModal && currentGroupId) {
-      void loadAvailableUsers();
-      void checkActiveTransfers(currentGroupId);
+      loadAvailableUsers().catch(console.error);
+      checkActiveTransfers(currentGroupId).catch(console.error);
     }
   }, [showTransferModal, currentGroupId, loadAvailableUsers, checkActiveTransfers]);
 


### PR DESCRIPTION
## Summary

After creating a transfer in the OGS groups modal, the modal would unexpectedly switch to a different group, making the transfer appear to "disappear". This happened because `setAllGroups()` returned groups in a different order while `selectedGroupIndex` stayed the same.

**Root cause**: `setAllGroups()` was called after transfers, but transfers only modify the substitution table - not group data. Reloading groups could return them in a different order.

## Changes

- Remove unnecessary `setAllGroups()` calls from `handleTransferGroup` and `handleCancelTransfer` 
- Use `currentGroupId` (string) as useEffect dependency instead of `currentGroup` (object) to prevent unnecessary re-triggers when object references change
- Load active transfers on page load and group switch to show badge indicator
- Add transfer count badge to desktop button: `Gruppe übergeben (1)`
- Add mobile-responsive badge showing active transfer count

## Test plan

- [x] Create a transfer for a group → transfer should stay visible in modal
- [x] Cancel a transfer → modal should stay on same group
- [x] Badge shows correct count on desktop button
- [x] Badge shows on mobile button
- [x] Switching groups updates the badge correctly

Closes #453