### PR TITLE
fix(frontend): add missing /api/health endpoint for Docker health checks

### DIFF
--- a/frontend/src/app/api/health/route.ts
+++ b/frontend/src/app/api/health/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Health check endpoint for container orchestration and load balancers.
+ * Returns a simple 200 OK response with timestamp.
+ *
+ * Used by:
+ * - Docker health checks (docker-compose.prod.yml)
+ * - CI/CD deployment verification
+ * - Monitoring systems
+ */
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
+    service: "phoenix-frontend",
+    timestamp: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary
- Adds the missing `/api/health` endpoint that `docker-compose.prod.yml` references for container health checks
- Fixes silent health check failures in production deployments

## Problem
The `docker-compose.prod.yml` (line 97) specifies a health check for the frontend container:
```yaml
test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
```

However, this endpoint **did not exist**, causing health checks to fail or return 404.

## Solution
Simple health endpoint that:
- Returns JSON status with service name and timestamp
- No authentication required (health checks must work when auth is down)
- No database dependencies (lightweight for frequent polling)

## Test plan
- [x] Verified endpoint returns `200 OK` with JSON response
- [x] Verified `wget --spider` equivalent succeeds (Docker health check method)
- [x] ESLint passes (0 warnings)
- [x] TypeScript compiles without errors