### PR TITLE
feat(ci): add automated Docker image build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,13 +58,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Extract metadata for backend
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.BACKEND_IMAGE }}
           tags: |
@@ -87,7 +87,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push backend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ./backend
           file: ./backend/Dockerfile
@@ -115,13 +115,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Extract metadata for frontend
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.FRONTEND_IMAGE }}
           tags: |
@@ -155,7 +155,7 @@ jobs:
           fi
 
       - name: Build and push frontend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ./frontend
           file: ./frontend/Dockerfile.prod


### PR DESCRIPTION
## Summary
Adds GitHub Actions workflow to automatically build and push Docker images to GHCR when code is pushed to `main` or `development` branches.

This is **Phase 2** of the CI/CD implementation plan documented in `md-files/production/CI-CD-ARCHITECTURE.md`.

## Features

| Feature | Description |
|---------|-------------|
| **Parallel builds** | Backend and frontend build simultaneously |
| **Test gating** | Lint + tests must pass before build starts |
| **Docker caching** | GHA cache with separate scopes (~2-5x faster rebuilds) |
| **Smart tagging** | Branch name, short SHA, semver for releases |
| **Path filters** | Skips build when only docs/tests change |
| **Manual trigger** | Emergency builds with option to skip tests |

## Tagging Strategy

| Trigger | Tags Generated |
|---------|----------------|
| Push to `development` | `:development`, `:abc1234` |
| Push to `main` | `:main`, `:latest`, `:abc1234` |
| Release `v1.2.3` | `:1.2.3`, `:1.2`, `:latest` |

## Secrets Required

**None!** Uses `GITHUB_TOKEN` which is auto-provided with `write:packages` permission.

## Test Plan
- [x] YAML syntax validated
- [x] Verified reusable workflow compatibility (test.yml, lint.yml have `workflow_call`)
- [x] Verified cache scope separation (backend/frontend don't overwrite each other)
- [x] Verified path filter syntax (using `!` prefix, not `paths-ignore`)
- [ ] Test actual workflow execution after merge

## Next Steps (Phase 3)
- Create private `phoenix-deploy` repository
- Add deployment workflows that trigger on image push