### PR TITLE
ci: add auto-deploy to staging and production

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,8 @@ jobs:
         run: echo "Frontend image pushed with digest ${{ steps.meta.outputs.digest }}"
 
   # Deploy to staging (development branch)
+  # Note: Currently staging runs on same server as production (different ports/dirs)
+  # Using separate secrets allows easy migration to dedicated staging server later
   deploy-staging:
     if: github.ref == 'refs/heads/development'
     needs: [build-backend, build-frontend]
@@ -181,9 +183,9 @@ jobs:
       - name: Deploy to staging
         uses: appleboy/ssh-action@7eaf76671a0d7eec5d98ee897acda4f968735a17 # v1.2.0
         with:
-          host: ${{ secrets.PRODUCTION_HOST }}
+          host: ${{ secrets.STAGING_HOST }}
           username: root
-          key: ${{ secrets.PRODUCTION_SSH_KEY }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
           script: |
             cd ~/staging
             docker compose pull


### PR DESCRIPTION
## Summary
- Adds automatic deployment after successful Docker builds
- Development branch → deploys to staging (staging.moto-app.de)
- Main branch → deploys to production (moto-app.de)
- Updates frontend build to use staging API URL for development builds

## How it works
Uses `appleboy/ssh-action` to SSH into the server and run:
```bash
docker compose pull
docker compose up -d
```

## Prerequisites (already done)
- [x] SSH deploy key generated
- [x] Public key added to server's `~/.ssh/authorized_keys`
- [x] GitHub secrets configured (`PRODUCTION_HOST`, `PRODUCTION_SSH_KEY`)

## Test plan
- [ ] Merge this PR
- [ ] Push a change to development branch
- [ ] Verify staging auto-deploys
- [ ] (Later) Push to main and verify production auto-deploys