### PR TITLE
fix: mark React component props as readonly (S6759)

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -95,13 +95,13 @@ function getColorTheme(color: string): ColorTheme {
 
 // Stat Card Component - matches database page style
 interface StatCardProps {
-  title: string;
-  value: string | number;
-  icon: string;
-  color: string;
-  subtitle?: string;
-  loading?: boolean;
-  href?: string;
+  readonly title: string;
+  readonly value: string | number;
+  readonly icon: string;
+  readonly color: string;
+  readonly subtitle?: string;
+  readonly loading?: boolean;
+  readonly href?: string;
 }
 
 const StatCard: React.FC<StatCardProps> = ({
@@ -165,11 +165,11 @@ const StatCard: React.FC<StatCardProps> = ({
 
 // Info Card Component for lists
 interface InfoCardProps {
-  title: string;
-  children: React.ReactNode;
-  icon?: string;
-  href?: string;
-  linkText?: string;
+  readonly title: string;
+  readonly children: React.ReactNode;
+  readonly icon?: string;
+  readonly href?: string;
+  readonly linkText?: string;
 }
 
 const InfoCard: React.FC<InfoCardProps> = ({

--- a/frontend/src/components/active/unclaimed-rooms.tsx
+++ b/frontend/src/components/active/unclaimed-rooms.tsx
@@ -16,11 +16,11 @@ interface MinimalActiveGroup {
 }
 
 interface UnclaimedRoomsProps {
-  onClaimed: () => void;
+  readonly onClaimed: () => void;
   /** Pre-fetched active groups to avoid duplicate API call */
-  activeGroups?: MinimalActiveGroup[];
+  readonly activeGroups?: ReadonlyArray<MinimalActiveGroup>;
   /** Current staff ID to check supervisor status without extra API call */
-  currentStaffId?: string;
+  readonly currentStaffId?: string;
 }
 
 interface SchulhofState {

--- a/frontend/src/components/activities/activity-create-modal.tsx
+++ b/frontend/src/components/activities/activity-create-modal.tsx
@@ -7,10 +7,10 @@ import { activitiesConfig } from "@/lib/database/configs/activities.config";
 import { configToFormSection } from "@/lib/database/types";
 
 interface ActivityCreateModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onCreate: (data: Partial<Activity>) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onCreate: (data: Partial<Activity>) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function ActivityCreateModal({

--- a/frontend/src/components/activities/activity-detail-modal.tsx
+++ b/frontend/src/components/activities/activity-detail-modal.tsx
@@ -5,12 +5,12 @@ import { DetailModalActions } from "~/components/ui/detail-modal-actions";
 import type { Activity } from "@/lib/activity-helpers";
 
 interface ActivityDetailModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  activity: Activity | null;
-  onEdit: () => void;
-  onDelete: () => void;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly activity: Activity | null;
+  readonly onEdit: () => void;
+  readonly onDelete: () => void;
+  readonly loading?: boolean;
 }
 
 export function ActivityDetailModal({

--- a/frontend/src/components/activities/activity-edit-modal.tsx
+++ b/frontend/src/components/activities/activity-edit-modal.tsx
@@ -7,11 +7,11 @@ import { activitiesConfig } from "@/lib/database/configs/activities.config";
 import { configToFormSection } from "@/lib/database/types";
 
 interface ActivityEditModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  activity: Activity | null;
-  onSave: (data: Partial<Activity>) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly activity: Activity | null;
+  readonly onSave: (data: Partial<Activity>) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function ActivityEditModal({

--- a/frontend/src/components/activities/activity-management-modal.tsx
+++ b/frontend/src/components/activities/activity-management-modal.tsx
@@ -13,12 +13,12 @@ import { getDbOperationMessage } from "~/lib/use-notification";
 import { useScrollLock } from "~/hooks/useScrollLock";
 
 interface ActivityManagementModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSuccess?: (message?: string) => void;
-  activity: Activity;
-  currentStaffId?: string | null;
-  readOnly?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onSuccess?: (message?: string) => void;
+  readonly activity: Activity;
+  readonly currentStaffId?: string | null;
+  readonly readOnly?: boolean;
 }
 
 interface EditForm {

--- a/frontend/src/components/activities/quick-create-modal.tsx
+++ b/frontend/src/components/activities/quick-create-modal.tsx
@@ -8,9 +8,9 @@ import { useScrollLock } from "~/hooks/useScrollLock";
 import { useToast } from "~/contexts/ToastContext";
 
 interface QuickCreateActivityModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSuccess?: () => void;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onSuccess?: () => void;
 }
 
 interface QuickCreateForm {

--- a/frontend/src/components/admin/invitation-form.tsx
+++ b/frontend/src/components/admin/invitation-form.tsx
@@ -12,7 +12,7 @@ import type {
 import type { ApiError } from "~/lib/auth-api";
 
 interface InvitationFormProps {
-  onCreated?: (invitation: PendingInvitation) => void;
+  readonly onCreated?: (invitation: PendingInvitation) => void;
 }
 
 interface RoleOption {

--- a/frontend/src/components/admin/pending-invitations-list.tsx
+++ b/frontend/src/components/admin/pending-invitations-list.tsx
@@ -13,7 +13,7 @@ import type { ApiError } from "~/lib/auth-api";
 import { isValidDateString, isDateExpired } from "~/lib/utils/date-helpers";
 
 interface PendingInvitationsListProps {
-  refreshKey: number;
+  readonly refreshKey: number;
 }
 
 export function PendingInvitationsList({

--- a/frontend/src/components/auth/invitation-accept-form.tsx
+++ b/frontend/src/components/auth/invitation-accept-form.tsx
@@ -10,8 +10,8 @@ import type { InvitationValidation } from "~/lib/invitation-helpers";
 import type { ApiError } from "~/lib/auth-api";
 
 interface InvitationAcceptFormProps {
-  token: string;
-  invitation: InvitationValidation;
+  readonly token: string;
+  readonly invitation: InvitationValidation;
 }
 
 const PASSWORD_REQUIREMENTS: Array<{

--- a/frontend/src/components/auth/role-permission-management-modal.tsx
+++ b/frontend/src/components/auth/role-permission-management-modal.tsx
@@ -13,10 +13,10 @@ import {
 import type { Role, Permission } from "~/lib/auth-helpers";
 
 interface RolePermissionManagementModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  role: Role;
-  onUpdate: () => void;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly role: Role;
+  readonly onUpdate: () => void;
 }
 
 export function RolePermissionManagementModal({

--- a/frontend/src/components/auth/smart-redirect.tsx
+++ b/frontend/src/components/auth/smart-redirect.tsx
@@ -7,7 +7,7 @@ import { useSupervision } from "~/lib/supervision-context";
 import { useSmartRedirectPath } from "~/lib/redirect-utils";
 
 interface SmartRedirectProps {
-  onRedirect?: (path: string) => void;
+  readonly onRedirect?: (path: string) => void;
 }
 
 /**

--- a/frontend/src/components/background-wrapper.tsx
+++ b/frontend/src/components/background-wrapper.tsx
@@ -3,7 +3,7 @@
 import { AnimatedBackground } from "./animated-background";
 
 interface BackgroundWrapperProps {
-  children: React.ReactNode;
+  readonly children: React.ReactNode;
 }
 
 export function BackgroundWrapper({ children }: BackgroundWrapperProps) {

--- a/frontend/src/components/dashboard/header.tsx
+++ b/frontend/src/components/dashboard/header.tsx
@@ -106,20 +106,20 @@ function getSubPageLabel(pathname: string): string {
 }
 
 interface HeaderProps {
-  userName?: string;
-  userEmail?: string;
-  userRole?: string;
-  customPageTitle?: string;
-  studentName?: string; // For student detail pages
-  roomName?: string; // For room detail pages
-  activityName?: string; // For activity detail pages
-  referrerPage?: string; // Where the user came from (for contextual breadcrumbs)
-  activeSupervisionName?: string; // For active supervision breadcrumb (e.g., "Schulhof")
-  ogsGroupName?: string; // For OGS group breadcrumb (e.g., "Sonngruppe")
+  readonly userName?: string;
+  readonly userEmail?: string;
+  readonly userRole?: string;
+  readonly customPageTitle?: string;
+  readonly studentName?: string; // For student detail pages
+  readonly roomName?: string; // For room detail pages
+  readonly activityName?: string; // For activity detail pages
+  readonly referrerPage?: string; // Where the user came from (for contextual breadcrumbs)
+  readonly activeSupervisionName?: string; // For active supervision breadcrumb (e.g., "Schulhof")
+  readonly ogsGroupName?: string; // For OGS group breadcrumb (e.g., "Sonngruppe")
 }
 
 // Logout Icon als React Component
-const LogoutIcon = ({ className }: { className?: string }) => (
+const LogoutIcon = ({ className }: Readonly<{ className?: string }>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="16"
@@ -143,11 +143,11 @@ const UserAvatar = ({
   avatarUrl,
   userName,
   size = "sm",
-}: {
+}: Readonly<{
   avatarUrl?: string | null;
   userName: string;
   size?: "sm" | "md";
-}) => {
+}>) => {
   const sizeClasses = size === "sm" ? "w-8 h-8 text-sm" : "w-11 h-11 text-base";
   const initials =
     (userName?.trim() || "")

--- a/frontend/src/components/dashboard/mobile-bottom-nav.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.tsx
@@ -50,7 +50,12 @@ interface NavItem {
 const ADMIN_MAIN_ITEMS: NavItem[] = [
   { href: "/dashboard", label: "Home", iconKey: "home", alwaysShow: true },
   { href: "/ogs-groups", label: "Gruppe", iconKey: "group", alwaysShow: true },
-  { href: "/active-supervisions", label: "Aufsicht", iconKey: "supervision", alwaysShow: true },
+  {
+    href: "/active-supervisions",
+    label: "Aufsicht",
+    iconKey: "supervision",
+    alwaysShow: true,
+  },
   {
     href: "/students/search",
     label: "Suchen",
@@ -61,7 +66,12 @@ const ADMIN_MAIN_ITEMS: NavItem[] = [
 
 const STAFF_MAIN_ITEMS: NavItem[] = [
   { href: "/ogs-groups", label: "Gruppe", iconKey: "group", alwaysShow: true },
-  { href: "/active-supervisions", label: "Aufsicht", iconKey: "supervision", alwaysShow: true },
+  {
+    href: "/active-supervisions",
+    label: "Aufsicht",
+    iconKey: "supervision",
+    alwaysShow: true,
+  },
   {
     href: "/students/search",
     label: "Suchen",
@@ -117,7 +127,7 @@ const additionalNavItems: AdditionalNavItem[] = [
 ];
 
 interface MobileBottomNavProps {
-  className?: string;
+  readonly className?: string;
 }
 
 export function MobileBottomNav({ className = "" }: MobileBottomNavProps) {

--- a/frontend/src/components/dashboard/page-header.tsx
+++ b/frontend/src/components/dashboard/page-header.tsx
@@ -6,9 +6,9 @@ import { Button } from "@/components/ui/button";
 import React from "react";
 
 interface PageHeaderProps {
-  title: string | React.ReactNode;
-  description?: string;
-  backUrl?: string;
+  readonly title: string | React.ReactNode;
+  readonly description?: string;
+  readonly backUrl?: string;
 }
 
 export function PageHeader({

--- a/frontend/src/components/dashboard/responsive-layout.tsx
+++ b/frontend/src/components/dashboard/responsive-layout.tsx
@@ -8,14 +8,14 @@ import { Sidebar } from "./sidebar";
 import { MobileBottomNav } from "./mobile-bottom-nav";
 
 interface ResponsiveLayoutProps {
-  children: React.ReactNode;
-  pageTitle?: string;
-  studentName?: string; // For student detail page breadcrumbs
-  roomName?: string; // For room detail page breadcrumbs
-  activityName?: string; // For activity detail page breadcrumbs
-  referrerPage?: string; // Where the user came from (for contextual breadcrumbs)
-  activeSupervisionName?: string; // For active supervision breadcrumb (e.g., "Schulhof")
-  ogsGroupName?: string; // For OGS group breadcrumb (e.g., "Sonngruppe")
+  readonly children: React.ReactNode;
+  readonly pageTitle?: string;
+  readonly studentName?: string; // For student detail page breadcrumbs
+  readonly roomName?: string; // For room detail page breadcrumbs
+  readonly activityName?: string; // For activity detail page breadcrumbs
+  readonly referrerPage?: string; // Where the user came from (for contextual breadcrumbs)
+  readonly activeSupervisionName?: string; // For active supervision breadcrumb (e.g., "Schulhof")
+  readonly ogsGroupName?: string; // For OGS group breadcrumb (e.g., "Sonngruppe")
 }
 
 export default function ResponsiveLayout({

--- a/frontend/src/components/dashboard/section-title.tsx
+++ b/frontend/src/components/dashboard/section-title.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 
 interface SectionTitleProps {
-  title: string;
+  readonly title: string;
 }
 
 export function SectionTitle({ title }: SectionTitleProps) {

--- a/frontend/src/components/dashboard/sidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar.tsx
@@ -95,7 +95,7 @@ const NAV_ITEMS: NavItem[] = [
 ];
 
 interface SidebarProps {
-  className?: string;
+  readonly className?: string;
 }
 
 function SidebarContent({ className = "" }: SidebarProps) {

--- a/frontend/src/components/devices/device-create-modal.tsx
+++ b/frontend/src/components/devices/device-create-modal.tsx
@@ -6,10 +6,10 @@ import { devicesConfig } from "@/lib/database/configs/devices.config";
 import type { Device } from "@/lib/iot-helpers";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
-  onCreate: (data: Partial<Device>) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onCreate: (data: Partial<Device>) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function DeviceCreateModal({

--- a/frontend/src/components/devices/device-detail-modal.tsx
+++ b/frontend/src/components/devices/device-detail-modal.tsx
@@ -11,12 +11,12 @@ import {
 } from "@/lib/iot-helpers";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
-  device: Device | null;
-  onEdit: () => void;
-  onDelete: () => void;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly device: Device | null;
+  readonly onEdit: () => void;
+  readonly onDelete: () => void;
+  readonly loading?: boolean;
 }
 
 export function DeviceDetailModal({

--- a/frontend/src/components/devices/device-edit-modal.tsx
+++ b/frontend/src/components/devices/device-edit-modal.tsx
@@ -6,11 +6,11 @@ import { devicesConfig } from "@/lib/database/configs/devices.config";
 import type { Device } from "@/lib/iot-helpers";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
-  device: Device | null;
-  onSave: (data: Partial<Device>) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly device: Device | null;
+  readonly onSave: (data: Partial<Device>) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function DeviceEditModal({

--- a/frontend/src/components/groups/combined-group-form.tsx
+++ b/frontend/src/components/groups/combined-group-form.tsx
@@ -4,12 +4,12 @@ import { useState, useEffect } from "react";
 import type { CombinedGroup } from "@/lib/api";
 
 interface CombinedGroupFormProps {
-  initialData?: Partial<CombinedGroup>;
-  onSubmitAction: (groupData: Partial<CombinedGroup>) => Promise<void>;
-  onCancelAction: () => void;
-  isLoading: boolean;
-  formTitle: string;
-  submitLabel: string;
+  readonly initialData?: Partial<CombinedGroup>;
+  readonly onSubmitAction: (groupData: Partial<CombinedGroup>) => Promise<void>;
+  readonly onCancelAction: () => void;
+  readonly isLoading: boolean;
+  readonly formTitle: string;
+  readonly submitLabel: string;
 }
 
 export default function CombinedGroupForm({

--- a/frontend/src/components/groups/group-create-modal.tsx
+++ b/frontend/src/components/groups/group-create-modal.tsx
@@ -6,10 +6,10 @@ import { groupsConfig } from "@/lib/database/configs/groups.config";
 import type { Group } from "@/lib/group-helpers";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
-  onCreate: (data: Partial<Group>) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onCreate: (data: Partial<Group>) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function GroupCreateModal({

--- a/frontend/src/components/groups/group-detail-modal.tsx
+++ b/frontend/src/components/groups/group-detail-modal.tsx
@@ -5,12 +5,12 @@ import { DetailModalActions } from "~/components/ui/detail-modal-actions";
 import type { Group } from "@/lib/group-helpers";
 
 interface GroupDetailModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  group: Group | null;
-  onEdit: () => void;
-  onDelete: () => void;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly group: Group | null;
+  readonly onEdit: () => void;
+  readonly onDelete: () => void;
+  readonly loading?: boolean;
 }
 
 export function GroupDetailModal({

--- a/frontend/src/components/groups/group-edit-modal.tsx
+++ b/frontend/src/components/groups/group-edit-modal.tsx
@@ -6,11 +6,11 @@ import { groupsConfig } from "@/lib/database/configs/groups.config";
 import type { Group } from "@/lib/group-helpers";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
-  group: Group | null;
-  onSave: (data: Partial<Group>) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly group: Group | null;
+  readonly onSave: (data: Partial<Group>) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function GroupEditModal({

--- a/frontend/src/components/groups/group-transfer-modal.tsx
+++ b/frontend/src/components/groups/group-transfer-modal.tsx
@@ -4,29 +4,32 @@ import { useState, useEffect } from "react";
 import { Modal } from "~/components/ui/modal";
 
 interface GroupTransferModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  group: {
-    id: string;
-    name: string;
-    studentCount?: number;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly group: {
+    readonly id: string;
+    readonly name: string;
+    readonly studentCount?: number;
   } | null;
-  availableUsers: Array<{
-    id: string;
-    personId: string;
-    firstName: string;
-    lastName: string;
-    fullName: string;
-    email: string;
+  readonly availableUsers: ReadonlyArray<{
+    readonly id: string;
+    readonly personId: string;
+    readonly firstName: string;
+    readonly lastName: string;
+    readonly fullName: string;
+    readonly email: string;
   }>;
-  onTransfer: (targetPersonId: string, targetName: string) => Promise<void>;
-  existingTransfers?: Array<{
-    targetName: string;
-    substitutionId: string;
-    targetStaffId: string;
+  readonly onTransfer: (
+    targetPersonId: string,
+    targetName: string,
+  ) => Promise<void>;
+  readonly existingTransfers?: ReadonlyArray<{
+    readonly targetName: string;
+    readonly substitutionId: string;
+    readonly targetStaffId: string;
   }>;
-  onCancelTransfer?: (substitutionId: string) => Promise<void>;
-  onRefreshTransfers?: () => Promise<void>;
+  readonly onCancelTransfer?: (substitutionId: string) => Promise<void>;
+  readonly onRefreshTransfers?: () => Promise<void>;
 }
 
 export function GroupTransferModal({

--- a/frontend/src/components/guardians/guardian-delete-modal.tsx
+++ b/frontend/src/components/guardians/guardian-delete-modal.tsx
@@ -3,11 +3,11 @@
 import { Modal } from "~/components/ui/modal";
 
 interface GuardianDeleteModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onConfirm: () => void;
-  guardianName: string;
-  isLoading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onConfirm: () => void;
+  readonly guardianName: string;
+  readonly isLoading?: boolean;
 }
 
 export function GuardianDeleteModal({

--- a/frontend/src/components/guardians/guardian-form-modal.tsx
+++ b/frontend/src/components/guardians/guardian-form-modal.tsx
@@ -9,24 +9,24 @@ import type {
 import { RELATIONSHIP_TYPES } from "@/lib/guardian-helpers";
 
 interface GuardianFormModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSubmit: (
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onSubmit: (
     guardianData: GuardianFormData,
     relationshipData: RelationshipFormData,
   ) => Promise<void>;
-  initialData?: GuardianWithRelationship;
-  mode: "create" | "edit";
-  isSubmitting?: boolean;
+  readonly initialData?: GuardianWithRelationship;
+  readonly mode: "create" | "edit";
+  readonly isSubmitting?: boolean;
 }
 
 export interface RelationshipFormData {
-  relationshipType: string;
-  isPrimary: boolean;
-  isEmergencyContact: boolean;
-  canPickup: boolean;
-  pickupNotes?: string;
-  emergencyPriority: number;
+  readonly relationshipType: string;
+  readonly isPrimary: boolean;
+  readonly isEmergencyContact: boolean;
+  readonly canPickup: boolean;
+  readonly pickupNotes?: string;
+  readonly emergencyPriority: number;
 }
 
 export default function GuardianFormModal({
@@ -129,7 +129,11 @@ export default function GuardianFormModal({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={modalTitle}>
-      <form onSubmit={handleSubmit} noValidate className="space-y-4 md:space-y-6">
+      <form
+        onSubmit={handleSubmit}
+        noValidate
+        className="space-y-4 md:space-y-6"
+      >
         {/* Submit Error */}
         {error && (
           <div className="rounded-lg border border-red-200 bg-red-50 p-2 md:p-3">

--- a/frontend/src/components/guardians/guardian-list.tsx
+++ b/frontend/src/components/guardians/guardian-list.tsx
@@ -9,11 +9,11 @@ import { ModernContactActions } from "~/components/simple/student";
 import { Trash2, Edit, UserCheck, Phone, AlertCircle } from "lucide-react";
 
 interface GuardianListProps {
-  guardians: GuardianWithRelationship[];
-  onEdit?: (guardian: GuardianWithRelationship) => void;
-  onDelete?: (guardian: GuardianWithRelationship) => void;
-  readOnly?: boolean;
-  showRelationship?: boolean;
+  readonly guardians: ReadonlyArray<GuardianWithRelationship>;
+  readonly onEdit?: (guardian: GuardianWithRelationship) => void;
+  readonly onDelete?: (guardian: GuardianWithRelationship) => void;
+  readonly readOnly?: boolean;
+  readonly showRelationship?: boolean;
 }
 
 export default function GuardianList({

--- a/frontend/src/components/guardians/student-guardian-manager.tsx
+++ b/frontend/src/components/guardians/student-guardian-manager.tsx
@@ -22,9 +22,9 @@ import {
 import { getGuardianFullName } from "@/lib/guardian-helpers";
 
 interface StudentGuardianManagerProps {
-  studentId: string;
-  readOnly?: boolean;
-  onUpdate?: () => void;
+  readonly studentId: string;
+  readonly readOnly?: boolean;
+  readonly onUpdate?: () => void;
 }
 
 export default function StudentGuardianManager({

--- a/frontend/src/components/import/stats-cards.tsx
+++ b/frontend/src/components/import/stats-cards.tsx
@@ -1,11 +1,16 @@
 interface StatsCardsProps {
-  total: number;
-  newCount: number;
-  existing: number;
-  errors: number;
+  readonly total: number;
+  readonly newCount: number;
+  readonly existing: number;
+  readonly errors: number;
 }
 
-export function StatsCards({ total, newCount, existing, errors }: StatsCardsProps) {
+export function StatsCards({
+  total,
+  newCount,
+  existing,
+  errors,
+}: StatsCardsProps) {
   return (
     <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
       <div className="rounded-xl border border-gray-100 bg-white p-4">

--- a/frontend/src/components/import/student-row-card.tsx
+++ b/frontend/src/components/import/student-row-card.tsx
@@ -13,8 +13,8 @@ interface DisplayStudent {
 }
 
 interface StudentRowCardProps {
-  student: DisplayStudent;
-  index: number;
+  readonly student: DisplayStudent;
+  readonly index: number;
 }
 
 function getStatusBadge(rowStatus: RowStatus) {

--- a/frontend/src/components/import/upload-section.tsx
+++ b/frontend/src/components/import/upload-section.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 
 interface UploadSectionProps {
-  isDragging: boolean;
-  isLoading: boolean;
-  uploadedFile: File | null;
-  onDragEnter: (e: React.DragEvent) => void;
-  onDragLeave: (e: React.DragEvent) => void;
-  onDragOver: (e: React.DragEvent) => void;
-  onDrop: (e: React.DragEvent) => void;
-  onFileSelect: (file: File) => void;
+  readonly isDragging: boolean;
+  readonly isLoading: boolean;
+  readonly uploadedFile: File | null;
+  readonly onDragEnter: (e: React.DragEvent) => void;
+  readonly onDragLeave: (e: React.DragEvent) => void;
+  readonly onDragOver: (e: React.DragEvent) => void;
+  readonly onDrop: (e: React.DragEvent) => void;
+  readonly onFileSelect: (file: File) => void;
 }
 
 export function UploadSection({

--- a/frontend/src/components/permissions/permission-create-modal.tsx
+++ b/frontend/src/components/permissions/permission-create-modal.tsx
@@ -6,11 +6,11 @@ import { permissionsConfig } from "@/lib/database/configs/permissions.config";
 import type { Permission } from "@/lib/auth-helpers";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
-  onCreate: (data: Partial<Permission>) => Promise<void>;
-  loading?: boolean;
-  error?: string | null;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onCreate: (data: Partial<Permission>) => Promise<void>;
+  readonly loading?: boolean;
+  readonly error?: string | null;
 }
 
 export function PermissionCreateModal({

--- a/frontend/src/components/permissions/permission-detail-modal.tsx
+++ b/frontend/src/components/permissions/permission-detail-modal.tsx
@@ -7,12 +7,12 @@ import type { Permission } from "@/lib/auth-helpers";
 import { formatPermissionDisplay } from "@/lib/permission-labels";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
-  permission: Permission | null;
-  onEdit: () => void;
-  onDelete: () => void;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly permission: Permission | null;
+  readonly onEdit: () => void;
+  readonly onDelete: () => void;
+  readonly loading?: boolean;
 }
 
 export function PermissionDetailModal({
@@ -32,96 +32,96 @@ export function PermissionDetailModal({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="">
-        {loading ? (
-          <div className="flex items-center justify-center py-12">
-            <div className="flex flex-col items-center gap-4">
-              <div className="h-12 w-12 animate-spin rounded-full border-2 border-gray-200 border-t-pink-600" />
-              <p className="text-gray-600">Daten werden geladen...</p>
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="flex flex-col items-center gap-4">
+            <div className="h-12 w-12 animate-spin rounded-full border-2 border-gray-200 border-t-pink-600" />
+            <p className="text-gray-600">Daten werden geladen...</p>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4 md:space-y-6">
+          {/* Header */}
+          <div className="flex items-center gap-3 border-b border-gray-100 pb-3 md:gap-4 md:pb-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-pink-500 to-rose-600 text-xl font-semibold text-white shadow-md md:h-16 md:w-16">
+              {initials}
+            </div>
+            <div className="min-w-0">
+              <h2 className="truncate text-lg font-semibold text-gray-900 md:text-xl">
+                {displayTitle}
+              </h2>
+              <p className="truncate text-sm text-gray-500">
+                {permission.name || "Systemberechtigung"}
+              </p>
             </div>
           </div>
-        ) : (
-          <div className="space-y-4 md:space-y-6">
-            {/* Header */}
-            <div className="flex items-center gap-3 border-b border-gray-100 pb-3 md:gap-4 md:pb-4">
-              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-pink-500 to-rose-600 text-xl font-semibold text-white shadow-md md:h-16 md:w-16">
-                {initials}
-              </div>
-              <div className="min-w-0">
-                <h2 className="truncate text-lg font-semibold text-gray-900 md:text-xl">
-                  {displayTitle}
-                </h2>
-                <p className="truncate text-sm text-gray-500">
-                  {permission.name || "Systemberechtigung"}
-                </p>
-              </div>
-            </div>
 
-            {/* Details */}
-            <div className="space-y-3 md:space-y-4">
-              <div className="rounded-xl border border-gray-100 bg-pink-50/30 p-3 md:p-4">
-                <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold text-gray-900 md:mb-3 md:text-sm">
-                  <svg
-                    className="h-3.5 w-3.5 text-pink-600 md:h-4 md:w-4"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
-                    />
-                  </svg>
-                  Berechtigungsdetails
-                </h3>
-                <dl className="grid grid-cols-1 gap-x-3 gap-y-2 sm:grid-cols-2 md:gap-x-4 md:gap-y-3">
-                  <div>
-                    <dt className="text-xs text-gray-500">Ressource</dt>
-                    <dd className="mt-0.5 text-sm font-medium break-words text-gray-900">
-                      {permission.resource}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="text-xs text-gray-500">Aktion</dt>
-                    <dd className="mt-0.5 text-sm font-medium break-words text-gray-900">
-                      {permission.action}
-                    </dd>
-                  </div>
-                  <div className="sm:col-span-2">
-                    <dt className="text-xs text-gray-500">Anzeigename</dt>
-                    <dd className="mt-0.5 text-sm font-medium break-words text-gray-900">
-                      {permission.name || "—"}
-                    </dd>
-                  </div>
-                  <div className="sm:col-span-2">
-                    <dt className="text-xs text-gray-500">Beschreibung</dt>
-                    <dd className="mt-0.5 text-xs break-words whitespace-pre-wrap text-gray-700 md:text-sm">
-                      {permission.description || "Keine Beschreibung"}
-                    </dd>
-                  </div>
-                </dl>
-              </div>
+          {/* Details */}
+          <div className="space-y-3 md:space-y-4">
+            <div className="rounded-xl border border-gray-100 bg-pink-50/30 p-3 md:p-4">
+              <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold text-gray-900 md:mb-3 md:text-sm">
+                <svg
+                  className="h-3.5 w-3.5 text-pink-600 md:h-4 md:w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+                  />
+                </svg>
+                Berechtigungsdetails
+              </h3>
+              <dl className="grid grid-cols-1 gap-x-3 gap-y-2 sm:grid-cols-2 md:gap-x-4 md:gap-y-3">
+                <div>
+                  <dt className="text-xs text-gray-500">Ressource</dt>
+                  <dd className="mt-0.5 text-sm font-medium break-words text-gray-900">
+                    {permission.resource}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-gray-500">Aktion</dt>
+                  <dd className="mt-0.5 text-sm font-medium break-words text-gray-900">
+                    {permission.action}
+                  </dd>
+                </div>
+                <div className="sm:col-span-2">
+                  <dt className="text-xs text-gray-500">Anzeigename</dt>
+                  <dd className="mt-0.5 text-sm font-medium break-words text-gray-900">
+                    {permission.name || "—"}
+                  </dd>
+                </div>
+                <div className="sm:col-span-2">
+                  <dt className="text-xs text-gray-500">Beschreibung</dt>
+                  <dd className="mt-0.5 text-xs break-words whitespace-pre-wrap text-gray-700 md:text-sm">
+                    {permission.description || "Keine Beschreibung"}
+                  </dd>
+                </div>
+              </dl>
             </div>
-
-            <DetailModalActions
-              onEdit={onEdit}
-              onDelete={onDelete}
-              entityName={`${permission.resource}: ${permission.action}`}
-              entityType="Berechtigung"
-              confirmationContent={
-                <p className="text-sm text-gray-700">
-                  Möchten Sie die Berechtigung{" "}
-                  <span className="font-medium">
-                    {permission.resource}: {permission.action}
-                  </span>{" "}
-                  wirklich löschen? Diese Aktion kann nicht rückgängig gemacht
-                  werden.
-                </p>
-              }
-            />
           </div>
-        )}
-      </Modal>
+
+          <DetailModalActions
+            onEdit={onEdit}
+            onDelete={onDelete}
+            entityName={`${permission.resource}: ${permission.action}`}
+            entityType="Berechtigung"
+            confirmationContent={
+              <p className="text-sm text-gray-700">
+                Möchten Sie die Berechtigung{" "}
+                <span className="font-medium">
+                  {permission.resource}: {permission.action}
+                </span>{" "}
+                wirklich löschen? Diese Aktion kann nicht rückgängig gemacht
+                werden.
+              </p>
+            }
+          />
+        </div>
+      )}
+    </Modal>
   );
 }

--- a/frontend/src/components/permissions/permission-edit-modal.tsx
+++ b/frontend/src/components/permissions/permission-edit-modal.tsx
@@ -8,12 +8,12 @@ import { configToFormSection } from "@/lib/database/types";
 import type { Permission } from "@/lib/auth-helpers";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
-  permission: Permission | null;
-  onSave: (data: Partial<Permission>) => Promise<void>;
-  loading?: boolean;
-  error?: string | null;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly permission: Permission | null;
+  readonly onSave: (data: Partial<Permission>) => Promise<void>;
+  readonly loading?: boolean;
+  readonly error?: string | null;
 }
 
 export function PermissionEditModal({

--- a/frontend/src/components/permissions/permission-selector.tsx
+++ b/frontend/src/components/permissions/permission-selector.tsx
@@ -59,10 +59,10 @@ export interface PermissionSelectorValue {
 }
 
 interface PermissionSelectorProps {
-  value: PermissionSelectorValue | undefined;
-  onChange: (value: PermissionSelectorValue) => void;
-  label?: string;
-  required?: boolean;
+  readonly value: PermissionSelectorValue | undefined;
+  readonly onChange: (value: PermissionSelectorValue) => void;
+  readonly label?: string;
+  readonly required?: boolean;
 }
 
 export function PermissionSelector({

--- a/frontend/src/components/roles/role-create-modal.tsx
+++ b/frontend/src/components/roles/role-create-modal.tsx
@@ -6,10 +6,10 @@ import { rolesConfig } from "@/lib/database/configs/roles.config";
 import type { Role } from "@/lib/auth-helpers";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
-  onCreate: (data: Partial<Role>) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onCreate: (data: Partial<Role>) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function RoleCreateModal({

--- a/frontend/src/components/roles/role-detail-modal.tsx
+++ b/frontend/src/components/roles/role-detail-modal.tsx
@@ -5,13 +5,13 @@ import { Modal, ConfirmationModal } from "~/components/ui/modal";
 import type { Role } from "@/lib/auth-helpers";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
-  role: Role | null;
-  onEdit: () => void;
-  onDelete: () => void;
-  onManagePermissions?: () => void;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly role: Role | null;
+  readonly onEdit: () => void;
+  readonly onDelete: () => void;
+  readonly onManagePermissions?: () => void;
+  readonly loading?: boolean;
 }
 
 export function RoleDetailModal({

--- a/frontend/src/components/roles/role-edit-modal.tsx
+++ b/frontend/src/components/roles/role-edit-modal.tsx
@@ -6,11 +6,11 @@ import { rolesConfig } from "@/lib/database/configs/roles.config";
 import type { Role } from "@/lib/auth-helpers";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
-  role: Role | null;
-  onSave: (data: Partial<Role>) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly role: Role | null;
+  readonly onSave: (data: Partial<Role>) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function RoleEditModal({

--- a/frontend/src/components/rooms/room-create-modal.tsx
+++ b/frontend/src/components/rooms/room-create-modal.tsx
@@ -7,10 +7,10 @@ import { roomsConfig } from "@/lib/database/configs/rooms.config";
 import { configToFormSection } from "@/lib/database/types";
 
 interface RoomCreateModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onCreate: (data: Partial<Room>) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onCreate: (data: Partial<Room>) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function RoomCreateModal({

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -7,12 +7,12 @@ import { DetailModalActions } from "~/components/ui/detail-modal-actions";
 import type { Room } from "@/lib/room-helpers";
 
 interface RoomDetailModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  room: Room | null;
-  onEdit: () => void;
-  onDelete: () => void;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly room: Room | null;
+  readonly onEdit: () => void;
+  readonly onDelete: () => void;
+  readonly loading?: boolean;
 }
 
 export function RoomDetailModal({

--- a/frontend/src/components/rooms/room-edit-modal.tsx
+++ b/frontend/src/components/rooms/room-edit-modal.tsx
@@ -16,11 +16,11 @@ const STANDARD_CATEGORIES = [
 ];
 
 interface RoomEditModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  room: Room | null;
-  onSave: (data: Partial<Room>) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly room: Room | null;
+  readonly onSave: (data: Partial<Room>) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function RoomEditModal({

--- a/frontend/src/components/scheduled-checkout/scheduled-checkout-info.tsx
+++ b/frontend/src/components/scheduled-checkout/scheduled-checkout-info.tsx
@@ -25,9 +25,9 @@ function formatTime(date: Date): string {
 }
 
 interface ScheduledCheckoutInfoProps {
-  studentId: string;
-  onUpdate?: () => void;
-  onScheduledCheckoutChange?: (hasScheduledCheckout: boolean) => void;
+  readonly studentId: string;
+  readonly onUpdate?: () => void;
+  readonly onScheduledCheckoutChange?: (hasScheduledCheckout: boolean) => void;
 }
 
 export function ScheduledCheckoutInfo({

--- a/frontend/src/components/simple/SimpleAlert.tsx
+++ b/frontend/src/components/simple/SimpleAlert.tsx
@@ -4,11 +4,11 @@ import React, { useEffect, useState, useRef, useContext } from "react";
 import { AlertContext } from "~/contexts/AlertContext";
 
 interface SimpleAlertProps {
-  type: "success" | "error" | "info" | "warning";
-  message: string;
-  onClose?: () => void;
-  autoClose?: boolean;
-  duration?: number;
+  readonly type: "success" | "error" | "info" | "warning";
+  readonly message: string;
+  readonly onClose?: () => void;
+  readonly autoClose?: boolean;
+  readonly duration?: number;
 }
 
 const alertStyles = {

--- a/frontend/src/components/simple/student/ModernContactActions.tsx
+++ b/frontend/src/components/simple/student/ModernContactActions.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 interface ModernContactActionsProps {
-  email?: string;
-  phone?: string;
-  studentName?: string;
+  readonly email?: string;
+  readonly phone?: string;
+  readonly studentName?: string;
 }
 
 export function ModernContactActions({

--- a/frontend/src/components/sse/SSEErrorBoundary.tsx
+++ b/frontend/src/components/sse/SSEErrorBoundary.tsx
@@ -3,12 +3,12 @@
 import React from "react";
 
 interface SSEErrorBoundaryProps {
-  children: React.ReactNode;
-  fallback?: React.ReactNode;
+  readonly children: React.ReactNode;
+  readonly fallback?: React.ReactNode;
 }
 
 interface SSEErrorBoundaryState {
-  hasError: boolean;
+  readonly hasError: boolean;
 }
 
 export class SSEErrorBoundary extends React.Component<

--- a/frontend/src/components/students/privacy-consent-section.tsx
+++ b/frontend/src/components/students/privacy-consent-section.tsx
@@ -5,7 +5,7 @@ import { fetchStudentPrivacyConsent } from "~/lib/student-api";
 import type { PrivacyConsent } from "~/lib/student-helpers";
 
 interface PrivacyConsentSectionProps {
-  studentId: string;
+  readonly studentId: string;
 }
 
 export function PrivacyConsentSection({

--- a/frontend/src/components/students/student-card.tsx
+++ b/frontend/src/components/students/student-card.tsx
@@ -5,19 +5,19 @@ import type { ReactNode } from "react";
 
 interface StudentCardProps {
   /** Unique student ID */
-  studentId: string;
+  readonly studentId: string;
   /** Student's first name */
-  firstName?: string;
+  readonly firstName?: string;
   /** Student's last name */
-  lastName?: string;
+  readonly lastName?: string;
   /** Gradient class for the card overlay */
-  gradient?: string;
+  readonly gradient?: string;
   /** Click handler for navigation */
-  onClick: () => void;
+  readonly onClick: () => void;
   /** Location badge component to render */
-  locationBadge: ReactNode;
+  readonly locationBadge: ReactNode;
   /** Optional extra content between name and click hint */
-  extraContent?: ReactNode;
+  readonly extraContent?: ReactNode;
 }
 
 /**
@@ -145,10 +145,10 @@ export function GroupIcon() {
 export function StudentInfoRow({
   icon,
   children,
-}: {
+}: Readonly<{
   icon: ReactNode;
   children: ReactNode;
-}) {
+}>) {
   return (
     <div className="mt-1 flex items-center gap-1.5">
       {icon}

--- a/frontend/src/components/students/student-checkout-section.tsx
+++ b/frontend/src/components/students/student-checkout-section.tsx
@@ -3,11 +3,11 @@
 import { ScheduledCheckoutInfo } from "~/components/scheduled-checkout/scheduled-checkout-info";
 
 interface StudentCheckoutSectionProps {
-  studentId: string;
-  hasScheduledCheckout: boolean;
-  onUpdate: () => void;
-  onScheduledCheckoutChange: (hasCheckout: boolean) => void;
-  onCheckoutClick: () => void;
+  readonly studentId: string;
+  readonly hasScheduledCheckout: boolean;
+  readonly onUpdate: () => void;
+  readonly onScheduledCheckoutChange: (hasCheckout: boolean) => void;
+  readonly onCheckoutClick: () => void;
 }
 
 export function StudentCheckoutSection({

--- a/frontend/src/components/students/student-create-modal.tsx
+++ b/frontend/src/components/students/student-create-modal.tsx
@@ -9,13 +9,16 @@ import {
   PickupStatusSection,
 } from "./student-form-fields";
 import { StudentCommonFormSections } from "./student-common-form-sections";
-import { validateStudentForm, handleStudentFormSubmit } from "~/lib/student-form-validation";
+import {
+  validateStudentForm,
+  handleStudentFormSubmit,
+} from "~/lib/student-form-validation";
 
 interface StudentCreateModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onCreate: (data: Partial<Student>) => Promise<void>;
-  groups?: Array<{ value: string; label: string }>;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onCreate: (data: Partial<Student>) => Promise<void>;
+  readonly groups?: Array<{ readonly value: string; readonly label: string }>;
 }
 
 export function StudentCreateModal({
@@ -100,7 +103,11 @@ export function StudentCreateModal({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Neuer Schüler">
-      <form onSubmit={handleSubmit} noValidate className="space-y-4 md:space-y-6">
+      <form
+        onSubmit={handleSubmit}
+        noValidate
+        className="space-y-4 md:space-y-6"
+      >
         {/* Submit Error */}
         {errors.submit && (
           <div className="rounded-lg border border-red-200 bg-red-50 p-2 md:p-3">

--- a/frontend/src/components/students/student-detail-modal.tsx
+++ b/frontend/src/components/students/student-detail-modal.tsx
@@ -16,13 +16,13 @@ interface Guardian {
 }
 
 interface StudentDetailModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  student: Student | null;
-  onEdit: () => void;
-  onDelete: () => void;
-  loading?: boolean;
-  error?: string | null;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly student: Student | null;
+  readonly onEdit: () => void;
+  readonly onDelete: () => void;
+  readonly loading?: boolean;
+  readonly error?: string | null;
 }
 
 export function StudentDetailModal({

--- a/frontend/src/components/students/student-edit-modal.tsx
+++ b/frontend/src/components/students/student-edit-modal.tsx
@@ -9,15 +9,18 @@ import {
   PickupStatusSection,
 } from "./student-form-fields";
 import { StudentCommonFormSections } from "./student-common-form-sections";
-import { validateStudentForm, handleStudentFormSubmit } from "~/lib/student-form-validation";
+import {
+  validateStudentForm,
+  handleStudentFormSubmit,
+} from "~/lib/student-form-validation";
 
 interface StudentEditModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  student: Student | null;
-  onSave: (data: Partial<Student>) => Promise<void>;
-  loading?: boolean;
-  groups?: Array<{ value: string; label: string }>;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly student: Student | null;
+  readonly onSave: (data: Partial<Student>) => Promise<void>;
+  readonly loading?: boolean;
+  readonly groups?: Array<{ readonly value: string; readonly label: string }>;
 }
 
 export function StudentEditModal({
@@ -101,7 +104,11 @@ export function StudentEditModal({
           </div>
         </div>
       ) : (
-        <form onSubmit={handleSubmit} noValidate className="space-y-4 md:space-y-6">
+        <form
+          onSubmit={handleSubmit}
+          noValidate
+          className="space-y-4 md:space-y-6"
+        >
           {/* Submit Error */}
           {errors.submit && (
             <div className="rounded-lg border border-red-200 bg-red-50 p-2 md:p-3">
@@ -115,7 +122,11 @@ export function StudentEditModal({
             onChange={handleChange}
             errors={errors}
             groups={groups}
-            requiredFields={{ firstName: true, lastName: true, schoolClass: false }}
+            requiredFields={{
+              firstName: true,
+              lastName: true,
+              schoolClass: false,
+            }}
           />
 
           {/* Guardian Information - Link to Student Detail Page */}

--- a/frontend/src/components/teachers/teacher-create-modal.tsx
+++ b/frontend/src/components/teachers/teacher-create-modal.tsx
@@ -5,10 +5,12 @@ import { TeacherForm } from "./teacher-form";
 import type { Teacher } from "@/lib/teacher-api";
 
 interface TeacherCreateModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onCreate: (data: Partial<Teacher> & { password?: string }) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onCreate: (
+    data: Partial<Teacher> & { password?: string },
+  ) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function TeacherCreateModal({

--- a/frontend/src/components/teachers/teacher-detail-modal.tsx
+++ b/frontend/src/components/teachers/teacher-detail-modal.tsx
@@ -7,12 +7,12 @@ import { DetailModalActions } from "~/components/ui/detail-modal-actions";
 import type { Teacher } from "@/lib/teacher-api";
 
 interface TeacherDetailModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  teacher: Teacher | null;
-  onEdit: () => void;
-  onDelete: () => void;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly teacher: Teacher | null;
+  readonly onEdit: () => void;
+  readonly onDelete: () => void;
+  readonly loading?: boolean;
 }
 
 export function TeacherDetailModal({

--- a/frontend/src/components/teachers/teacher-edit-modal.tsx
+++ b/frontend/src/components/teachers/teacher-edit-modal.tsx
@@ -5,11 +5,13 @@ import { TeacherForm } from "./teacher-form";
 import type { Teacher } from "@/lib/teacher-api";
 
 interface TeacherEditModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  teacher: Teacher | null;
-  onSave: (data: Partial<Teacher> & { password?: string }) => Promise<void>;
-  loading?: boolean;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly teacher: Teacher | null;
+  readonly onSave: (
+    data: Partial<Teacher> & { password?: string },
+  ) => Promise<void>;
+  readonly loading?: boolean;
 }
 
 export function TeacherEditModal({

--- a/frontend/src/components/teachers/teacher-form.tsx
+++ b/frontend/src/components/teachers/teacher-form.tsx
@@ -8,19 +8,19 @@ interface RoleOption {
 }
 
 interface TeacherFormProps {
-  initialData: Partial<Teacher>;
-  onSubmitAction: (
+  readonly initialData: Partial<Teacher>;
+  readonly onSubmitAction: (
     data: Partial<Teacher> & { password?: string; role_id?: number },
   ) => Promise<void>;
-  onCancelAction: () => void;
-  isLoading: boolean;
-  formTitle?: string;
-  submitLabel?: string;
-  rfidCards?: Array<{ id: string; label: string }>;
+  readonly onCancelAction: () => void;
+  readonly isLoading: boolean;
+  readonly formTitle?: string;
+  readonly submitLabel?: string;
+  readonly rfidCards?: ReadonlyArray<{ id: string; label: string }>;
   // When false, render without outer card container/headline (for edit modal minimal UI)
-  wrapInCard?: boolean;
+  readonly wrapInCard?: boolean;
   // Show/hide RFID UI block (kept off by default to avoid confusion)
-  showRFID?: boolean;
+  readonly showRFID?: boolean;
 }
 
 export function TeacherForm({
@@ -230,7 +230,11 @@ export function TeacherForm({
         </div>
       )}
 
-      <form onSubmit={handleSubmit} noValidate className="space-y-4 md:space-y-6">
+      <form
+        onSubmit={handleSubmit}
+        noValidate
+        className="space-y-4 md:space-y-6"
+      >
         {/* Personal Information Section */}
         <div className="rounded-xl border border-gray-100 bg-orange-50/30 p-3 md:p-4">
           <h4 className="mb-3 flex items-center gap-2 text-xs font-semibold text-gray-900 md:mb-4 md:text-sm">
@@ -512,7 +516,9 @@ export function TeacherForm({
                   disabled={isLoading}
                 >
                   <option value="">Position auswählen</option>
-                  <option value="Pädagogische Fachkraft">Pädagogische Fachkraft</option>
+                  <option value="Pädagogische Fachkraft">
+                    Pädagogische Fachkraft
+                  </option>
                   <option value="OGS-Büro">OGS-Büro</option>
                   <option value="Extern">Extern</option>
                 </select>

--- a/frontend/src/components/teachers/teacher-permission-management-modal.tsx
+++ b/frontend/src/components/teachers/teacher-permission-management-modal.tsx
@@ -9,10 +9,10 @@ import type { Permission } from "~/lib/auth-helpers";
 import type { Teacher } from "~/lib/teacher-api";
 
 interface TeacherPermissionManagementModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  teacher: Teacher;
-  onUpdate: () => void;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly teacher: Teacher;
+  readonly onUpdate: () => void;
 }
 
 export function TeacherPermissionManagementModal({

--- a/frontend/src/components/teachers/teacher-role-management-modal.tsx
+++ b/frontend/src/components/teachers/teacher-role-management-modal.tsx
@@ -9,10 +9,10 @@ import type { Role } from "~/lib/auth-helpers";
 import type { Teacher } from "~/lib/teacher-api";
 
 interface TeacherRoleManagementModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  teacher: Teacher;
-  onUpdate: () => void;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly teacher: Teacher;
+  readonly onUpdate: () => void;
 }
 
 export function TeacherRoleManagementModal({

--- a/frontend/src/components/ui/database/database-select.tsx
+++ b/frontend/src/components/ui/database/database-select.tsx
@@ -3,36 +3,36 @@
 import { useState, useEffect, useCallback } from "react";
 
 interface SelectOption {
-  value: string;
-  label: string;
-  disabled?: boolean;
+  readonly value: string;
+  readonly label: string;
+  readonly disabled?: boolean;
 }
 
 interface DatabaseSelectProps {
   // Core props
-  id?: string;
-  name: string;
-  label?: string;
-  value: string;
-  onChange: (value: string) => void;
+  readonly id?: string;
+  readonly name: string;
+  readonly label?: string;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
 
   // Options - either static or async
-  options?: SelectOption[];
-  loadOptions?: () => Promise<SelectOption[]>;
+  readonly options?: ReadonlyArray<SelectOption>;
+  readonly loadOptions?: () => Promise<ReadonlyArray<SelectOption>>;
 
   // UI props
-  placeholder?: string;
-  emptyOptionLabel?: string;
-  required?: boolean;
-  disabled?: boolean;
-  loading?: boolean;
-  error?: string;
-  helperText?: string;
-  className?: string;
-  includeEmpty?: boolean;
+  readonly placeholder?: string;
+  readonly emptyOptionLabel?: string;
+  readonly required?: boolean;
+  readonly disabled?: boolean;
+  readonly loading?: boolean;
+  readonly error?: string;
+  readonly helperText?: string;
+  readonly className?: string;
+  readonly includeEmpty?: boolean;
 
   // For theme-aware styling
-  focusRingColor?: string;
+  readonly focusRingColor?: string;
 }
 
 function DatabaseSelect({
@@ -54,7 +54,9 @@ function DatabaseSelect({
   includeEmpty = true,
   focusRingColor = "focus:ring-blue-500",
 }: DatabaseSelectProps) {
-  const [options, setOptions] = useState<SelectOption[]>(staticOptions ?? []);
+  const [options, setOptions] = useState<readonly SelectOption[]>(
+    staticOptions ?? [],
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -174,8 +176,8 @@ interface EntitySelectProps extends Omit<
   DatabaseSelectProps,
   "loadOptions" | "options"
 > {
-  entityType: "groups" | "rooms" | "teachers" | "activities";
-  filters?: Record<string, unknown>;
+  readonly entityType: "groups" | "rooms" | "teachers" | "activities";
+  readonly filters?: Record<string, unknown>;
 }
 
 function EntitySelect({ entityType, filters, ...props }: EntitySelectProps) {

--- a/frontend/src/components/ui/detail-modal-actions.tsx
+++ b/frontend/src/components/ui/detail-modal-actions.tsx
@@ -5,18 +5,18 @@ import type { ReactNode } from "react";
 import { ConfirmationModal } from "~/components/ui/modal";
 
 interface DetailModalActionsProps {
-  onEdit: () => void;
-  onDelete: () => void;
-  entityName: string;
-  entityType: string; // e.g. "Gruppe", "Aktivität", "Raum", "Gerät"
+  readonly onEdit: () => void;
+  readonly onDelete: () => void;
+  readonly entityName: string;
+  readonly entityType: string; // e.g. "Gruppe", "Aktivität", "Raum", "Gerät"
   /** Custom confirmation message content (optional) */
-  confirmationContent?: ReactNode;
+  readonly confirmationContent?: ReactNode;
   /**
    * Optional custom click handler for delete button.
    * When provided, the component will NOT render its own ConfirmationModal.
    * Use this for inline confirmation patterns where the parent handles confirmation.
    */
-  onDeleteClick?: () => void;
+  readonly onDeleteClick?: () => void;
 }
 
 // German article lookup for entity types

--- a/frontend/src/components/ui/empty-student-results.tsx
+++ b/frontend/src/components/ui/empty-student-results.tsx
@@ -3,9 +3,9 @@
 
 interface EmptyStudentResultsProps {
   /** Total number of students before filtering */
-  totalCount: number;
+  readonly totalCount: number;
   /** Number of students after filtering */
-  filteredCount: number;
+  readonly filteredCount: number;
 }
 
 /**

--- a/frontend/src/components/ui/form-modal.tsx
+++ b/frontend/src/components/ui/form-modal.tsx
@@ -12,15 +12,15 @@ import {
 } from "./modal-utils";
 
 interface FormModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  title: string;
-  children: ReactNode;
-  footer?: ReactNode;
-  size?: "sm" | "md" | "lg" | "xl";
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly title: string;
+  readonly children: ReactNode;
+  readonly footer?: ReactNode;
+  readonly size?: "sm" | "md" | "lg" | "xl";
   // Where to position the modal on mobile viewports
   // 'bottom' mimics a bottom sheet; 'center' behaves like a classic modal
-  mobilePosition?: "bottom" | "center";
+  readonly mobilePosition?: "bottom" | "center";
 }
 
 export function FormModal({

--- a/frontend/src/components/ui/help_button.tsx
+++ b/frontend/src/components/ui/help_button.tsx
@@ -6,9 +6,9 @@ import { usePathname } from "next/navigation";
 import { Modal } from "./modal";
 
 interface HelpButtonProps {
-  title: string;
-  content: string | React.ReactNode;
-  buttonClassName?: string;
+  readonly title: string;
+  readonly content: string | React.ReactNode;
+  readonly buttonClassName?: string;
 }
 
 export function HelpButton({

--- a/frontend/src/components/ui/inline-delete-confirmation.tsx
+++ b/frontend/src/components/ui/inline-delete-confirmation.tsx
@@ -4,13 +4,13 @@ import type { ReactNode } from "react";
 
 interface InlineDeleteConfirmationProps {
   /** Title shown at the top, e.g. "Raum löschen?" */
-  title: string;
+  readonly title: string;
   /** Main confirmation message content */
-  children: ReactNode;
+  readonly children: ReactNode;
   /** Called when user clicks "Abbrechen" */
-  onCancel: () => void;
+  readonly onCancel: () => void;
   /** Called when user clicks "Löschen" */
-  onConfirm: () => void;
+  readonly onConfirm: () => void;
 }
 
 /**

--- a/frontend/src/components/ui/loading.tsx
+++ b/frontend/src/components/ui/loading.tsx
@@ -6,8 +6,8 @@
 import { Skeleton } from "~/components/ui/skeleton";
 
 interface LoadingProps {
-  message?: string;
-  fullPage?: boolean;
+  readonly message?: string;
+  readonly fullPage?: boolean;
 }
 
 export function Loading({

--- a/frontend/src/components/ui/logout-modal.tsx
+++ b/frontend/src/components/ui/logout-modal.tsx
@@ -5,8 +5,8 @@ import { signOut } from "next-auth/react";
 import { Modal } from "./modal";
 
 interface LogoutModalProps {
-  isOpen: boolean;
-  onClose: () => void;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
 }
 
 // Confetti animation constants for better maintainability

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -12,11 +12,11 @@ import {
 } from "./modal-utils";
 
 interface ModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  title: string;
-  children: React.ReactNode;
-  footer?: React.ReactNode;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly title: string;
+  readonly children: React.ReactNode;
+  readonly footer?: React.ReactNode;
 }
 
 export function Modal({
@@ -239,15 +239,15 @@ export function Modal({
 
 // A specialized confirmation modal with yes/no buttons
 interface ConfirmationModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onConfirm: () => void;
-  title: string;
-  children: React.ReactNode;
-  confirmText?: string;
-  cancelText?: string;
-  isConfirmLoading?: boolean;
-  confirmButtonClass?: string;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onConfirm: () => void;
+  readonly title: string;
+  readonly children: React.ReactNode;
+  readonly confirmText?: string;
+  readonly cancelText?: string;
+  readonly isConfirmLoading?: boolean;
+  readonly confirmButtonClass?: string;
 }
 
 export function ConfirmationModal({

--- a/frontend/src/components/ui/page-header/DesktopFilters.tsx
+++ b/frontend/src/components/ui/page-header/DesktopFilters.tsx
@@ -4,8 +4,8 @@ import React, { useState, useRef, useEffect } from "react";
 import type { FilterConfig } from "./types";
 
 interface DesktopFiltersProps {
-  filters: FilterConfig[];
-  className?: string;
+  readonly filters: ReadonlyArray<FilterConfig>;
+  readonly className?: string;
 }
 
 export function DesktopFilters({

--- a/frontend/src/components/ui/page-header/MobileFilterButton.tsx
+++ b/frontend/src/components/ui/page-header/MobileFilterButton.tsx
@@ -3,10 +3,10 @@
 import React from "react";
 
 interface MobileFilterButtonProps {
-  isOpen: boolean;
-  onClick: () => void;
-  hasActiveFilters: boolean;
-  className?: string;
+  readonly isOpen: boolean;
+  readonly onClick: () => void;
+  readonly hasActiveFilters: boolean;
+  readonly className?: string;
 }
 
 export function MobileFilterButton({

--- a/frontend/src/components/ui/password-change-modal.tsx
+++ b/frontend/src/components/ui/password-change-modal.tsx
@@ -5,9 +5,9 @@ import { Modal } from "./modal";
 import { Alert } from "./alert";
 
 interface PasswordChangeModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSuccess?: () => void;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onSuccess?: () => void;
 }
 
 export function PasswordChangeModal({

--- a/frontend/src/components/ui/password-reset-modal.tsx
+++ b/frontend/src/components/ui/password-reset-modal.tsx
@@ -6,8 +6,8 @@ import { Input, Alert } from "./index";
 import { requestPasswordReset, type ApiError } from "~/lib/auth-api";
 
 interface PasswordResetModalProps {
-  isOpen: boolean;
-  onClose: () => void;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
 }
 
 // Email Icon Component


### PR DESCRIPTION
## Summary

- Add `readonly` modifier to all React component Props interfaces across 73 frontend files
- Improves type safety and prevents accidental prop mutation
- Addresses SonarCloud rule S6759 (~47 issues)

## Changes

This PR adds the `readonly` modifier to every property in Props interfaces throughout the frontend codebase, following React's immutable props philosophy.

### Files Modified (73 total)

- **components/dashboard/**: 6 files (header, sidebar, responsive-layout, page-header, section-title, mobile-bottom-nav)
- **components/students/**: 7 files (modals, cards, forms)
- **components/groups/**: 5 files
- **components/activities/**: 5 files
- **components/teachers/**: 6 files
- **components/rooms/**: 3 files
- **components/permissions/**: 4 files
- **components/roles/**: 3 files
- **components/devices/**: 3 files
- **components/guardians/**: 4 files
- **components/auth/**: 3 files
- **components/ui/**: 14 files
- **components/import/**: 3 files
- **components/admin/**: 2 files
- **app/dashboard/**: 1 file
- Plus 4 other component files

## Test plan

- [x] `npm run check` passes (lint + typecheck)
- [x] No runtime behavior changes - readonly is a compile-time only check
- [ ] SonarCloud analysis shows reduction in S6759 issues