### PR TITLE
fix: reduce cognitive complexity in backend API handlers

### DIFF
--- a/backend/api/groups/api.go
+++ b/backend/api/groups/api.go
@@ -25,6 +25,23 @@ import (
 	userService "github.com/moto-nrw/project-phoenix/services/users"
 )
 
+// GroupStudentResponse represents a student in a group response
+type GroupStudentResponse struct {
+	ID              int64  `json:"id"`
+	PersonID        int64  `json:"person_id"`
+	FirstName       string `json:"first_name"`
+	LastName        string `json:"last_name"`
+	SchoolClass     string `json:"school_class"`
+	GroupID         int64  `json:"group_id"`
+	GroupName       string `json:"group_name"`
+	GuardianName    string `json:"guardian_name,omitempty"`
+	GuardianContact string `json:"guardian_contact,omitempty"`
+	GuardianEmail   string `json:"guardian_email,omitempty"`
+	GuardianPhone   string `json:"guardian_phone,omitempty"`
+	Location        string `json:"location,omitempty"`
+	TagID           string `json:"tag_id,omitempty"`
+}
+
 // Resource defines the group API resource
 type Resource struct {
 	EducationService   educationSvc.Service
@@ -281,6 +298,165 @@ func (rs *Resource) userHasGroupAccess(r *http.Request, groupID int64) bool {
 	return false
 }
 
+// populateGuardianDetails fills in guardian fields based on access permissions
+func populateGuardianDetails(response *GroupStudentResponse, student *users.Student, person *users.Person, hasFullAccess bool) {
+	// Full access users get all guardian details and tag ID
+	if hasFullAccess {
+		if student.GuardianName != nil {
+			response.GuardianName = *student.GuardianName
+		}
+		if student.GuardianContact != nil {
+			response.GuardianContact = *student.GuardianContact
+		}
+		if student.GuardianEmail != nil {
+			response.GuardianEmail = *student.GuardianEmail
+		}
+		if student.GuardianPhone != nil {
+			response.GuardianPhone = *student.GuardianPhone
+		}
+		if person.TagID != nil {
+			response.TagID = *person.TagID
+		}
+		return
+	}
+
+	// Limited access: only guardian name visible
+	if student.GuardianName != nil {
+		response.GuardianName = *student.GuardianName
+	}
+}
+
+// buildStudentResponse creates a student response with all necessary data
+func (rs *Resource) buildStudentResponse(
+	ctx context.Context,
+	student *users.Student,
+	group *education.Group,
+	hasFullAccess bool,
+	locationSnapshot *common.StudentLocationSnapshot,
+) *GroupStudentResponse {
+	person, err := rs.UserService.Get(ctx, student.PersonID)
+	if err != nil {
+		log.Printf("Failed to get person data for student %d: %v", student.ID, err)
+		return nil
+	}
+
+	response := &GroupStudentResponse{
+		ID:          student.ID,
+		PersonID:    student.PersonID,
+		FirstName:   person.FirstName,
+		LastName:    person.LastName,
+		SchoolClass: student.SchoolClass,
+		GroupID:     group.ID,
+		GroupName:   group.Name,
+	}
+
+	populateGuardianDetails(response, student, person, hasFullAccess)
+	response.Location = rs.resolveLocationForStudent(ctx, student.ID, hasFullAccess, locationSnapshot)
+
+	return response
+}
+
+// resolveLocationForStudent determines student location from snapshot or fallback
+func (rs *Resource) resolveLocationForStudent(
+	ctx context.Context,
+	studentID int64,
+	hasFullAccess bool,
+	snapshot *common.StudentLocationSnapshot,
+) string {
+	if snapshot != nil {
+		return snapshot.ResolveStudentLocation(studentID, hasFullAccess)
+	}
+	return rs.resolveStudentLocation(ctx, studentID, hasFullAccess)
+}
+
+// getStudentVisit retrieves a student's current visit from snapshot or service
+func (rs *Resource) getStudentVisit(ctx context.Context, studentID int64, snapshot *common.StudentLocationSnapshot) *active.Visit {
+	if snapshot != nil {
+		return snapshot.Visits[studentID]
+	}
+	visit, err := rs.ActiveService.GetStudentCurrentVisit(ctx, studentID)
+	if err != nil {
+		return nil
+	}
+	return visit
+}
+
+// getVisitActiveGroup retrieves the active group for a visit from snapshot or service
+func (rs *Resource) getVisitActiveGroup(ctx context.Context, visit *active.Visit, snapshot *common.StudentLocationSnapshot) *active.Group {
+	if snapshot != nil {
+		return snapshot.Groups[visit.ActiveGroupID]
+	}
+	group, err := rs.ActiveService.GetActiveGroup(ctx, visit.ActiveGroupID)
+	if err != nil {
+		return nil
+	}
+	return group
+}
+
+// buildStudentRoomStatus creates the room status map for a single student
+func (rs *Resource) buildStudentRoomStatus(
+	ctx context.Context,
+	student *users.Student,
+	groupRoomID int64,
+	snapshot *common.StudentLocationSnapshot,
+) map[string]interface{} {
+	status := map[string]interface{}{
+		"in_group_room": false,
+		"reason":        "no_active_visit",
+	}
+
+	visit := rs.getStudentVisit(ctx, student.ID, snapshot)
+	if visit == nil {
+		rs.addPersonDataToStatus(ctx, status, student.PersonID)
+		return status
+	}
+
+	activeGroup := rs.getVisitActiveGroup(ctx, visit, snapshot)
+	if activeGroup == nil {
+		rs.addPersonDataToStatus(ctx, status, student.PersonID)
+		return status
+	}
+
+	inGroupRoom := activeGroup.RoomID == groupRoomID
+	status["in_group_room"] = inGroupRoom
+	status["current_room_id"] = activeGroup.RoomID
+
+	if inGroupRoom {
+		delete(status, "reason")
+	} else {
+		status["reason"] = "in_different_room"
+	}
+
+	rs.addPersonDataToStatus(ctx, status, student.PersonID)
+	return status
+}
+
+// addPersonDataToStatus adds first_name and last_name to status map
+func (rs *Resource) addPersonDataToStatus(ctx context.Context, status map[string]interface{}, personID int64) {
+	person, err := rs.UserService.Get(ctx, personID)
+	if err == nil && person != nil {
+		status["first_name"] = person.FirstName
+		status["last_name"] = person.LastName
+	}
+}
+
+// buildNoRoomResponse creates the response when group has no room assigned
+func buildNoRoomResponse(students []*users.Student) map[string]interface{} {
+	result := map[string]interface{}{
+		"group_has_room":      false,
+		"student_room_status": make(map[string]interface{}),
+	}
+
+	statusMap := result["student_room_status"].(map[string]interface{})
+	for _, student := range students {
+		statusMap[strconv.FormatInt(student.ID, 10)] = map[string]interface{}{
+			"in_group_room": false,
+			"reason":        "group_no_room",
+		}
+	}
+	return result
+}
+
 // =============================================================================
 // GROUP HANDLERS
 // =============================================================================
@@ -521,75 +697,12 @@ func (rs *Resource) getGroupStudents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build response with person data for each student
-	type StudentResponse struct {
-		ID              int64  `json:"id"`
-		PersonID        int64  `json:"person_id"`
-		FirstName       string `json:"first_name"`
-		LastName        string `json:"last_name"`
-		SchoolClass     string `json:"school_class"`
-		GroupID         int64  `json:"group_id"`
-		GroupName       string `json:"group_name"`
-		GuardianName    string `json:"guardian_name,omitempty"`
-		GuardianContact string `json:"guardian_contact,omitempty"`
-		GuardianEmail   string `json:"guardian_email,omitempty"`
-		GuardianPhone   string `json:"guardian_phone,omitempty"`
-		Location        string `json:"location,omitempty"`
-		TagID           string `json:"tag_id,omitempty"`
-	}
-
-	responses := make([]StudentResponse, 0, len(students))
+	responses := make([]GroupStudentResponse, 0, len(students))
 	for _, student := range students {
-		// Get person data
-		person, err := rs.UserService.Get(r.Context(), student.PersonID)
-		if err != nil {
-			// Skip this student if person not found
-			log.Printf("Failed to get person data for student %d: %v", student.ID, err)
-			continue
+		response := rs.buildStudentResponse(r.Context(), student, group, canAccessFullDetails, locationSnapshot)
+		if response != nil {
+			responses = append(responses, *response)
 		}
-
-		response := StudentResponse{
-			ID:          student.ID,
-			PersonID:    student.PersonID,
-			FirstName:   person.FirstName,
-			LastName:    person.LastName,
-			SchoolClass: student.SchoolClass,
-			GroupID:     id,
-			GroupName:   group.Name,
-		}
-
-		// Include sensitive data only for authorized users
-		if canAccessFullDetails {
-			if student.GuardianName != nil {
-				response.GuardianName = *student.GuardianName
-			}
-			if student.GuardianContact != nil {
-				response.GuardianContact = *student.GuardianContact
-			}
-			if student.GuardianEmail != nil {
-				response.GuardianEmail = *student.GuardianEmail
-			}
-			if student.GuardianPhone != nil {
-				response.GuardianPhone = *student.GuardianPhone
-			}
-			if person.TagID != nil {
-				response.TagID = *person.TagID
-			}
-
-		}
-
-		// Limited data for non-supervisor staff
-		if !canAccessFullDetails && student.GuardianName != nil {
-			response.GuardianName = *student.GuardianName
-		}
-
-		// Location is derived from real-time attendance data
-		if locationSnapshot != nil {
-			response.Location = locationSnapshot.ResolveStudentLocation(student.ID, canAccessFullDetails)
-		} else {
-			response.Location = rs.resolveStudentLocation(r.Context(), student.ID, canAccessFullDetails)
-		}
-
-		responses = append(responses, response)
 	}
 
 	common.Respond(w, r, http.StatusOK, responses, fmt.Sprintf("Found %d students in group", len(responses)))
@@ -646,112 +759,59 @@ func (rs *Resource) getGroupStudentsRoomStatus(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Get the educational group
 	group, err := rs.EducationService.GetGroup(r.Context(), id)
 	if err != nil {
 		common.RenderError(w, r, ErrorNotFound(errors.New(common.MsgGroupNotFound)))
 		return
 	}
 
-	// Check authorization - only group supervisors and admins can see this information
 	if !rs.userHasGroupAccess(r, id) {
 		common.RenderError(w, r, ErrorForbidden(errors.New("you do not supervise this group")))
 		return
 	}
 
-	// Get all students in the group
 	students, err := rs.StudentRepo.FindByGroupID(r.Context(), id)
 	if err != nil {
 		common.RenderError(w, r, ErrorInternalServer(errors.New("failed to get group students")))
 		return
 	}
 
-	// Check if the educational group has a room assigned
+	// Handle case where group has no room assigned
 	if group.RoomID == nil {
-		// No room assigned, all students are not in group room
-		result := make(map[string]interface{})
-		result["group_has_room"] = false
-		result["student_room_status"] = make(map[string]interface{})
-
-		for _, student := range students {
-			studentStatus := map[string]interface{}{
-				"in_group_room": false,
-				"reason":        "group_no_room",
-			}
-			result["student_room_status"].(map[string]interface{})[strconv.FormatInt(student.ID, 10)] = studentStatus
-		}
-
-		common.Respond(w, r, http.StatusOK, result, "Group has no assigned room")
+		common.Respond(w, r, http.StatusOK, buildNoRoomResponse(students), "Group has no assigned room")
 		return
 	}
 
-	// Group has a room, check each student's status
-	result := make(map[string]interface{})
-	result["group_has_room"] = true
-	result["group_room_id"] = *group.RoomID
-	studentStatuses := make(map[string]interface{})
+	// Build room status for each student
+	result := rs.buildRoomStatusResponse(r.Context(), students, *group.RoomID)
+	common.Respond(w, r, http.StatusOK, result, "Student room status retrieved successfully")
+}
+
+// buildRoomStatusResponse creates the full response for room status with student details
+func (rs *Resource) buildRoomStatusResponse(ctx context.Context, students []*users.Student, groupRoomID int64) map[string]interface{} {
+	result := map[string]interface{}{
+		"group_has_room": true,
+		"group_room_id":  groupRoomID,
+	}
 
 	studentIDs := make([]int64, 0, len(students))
 	for _, student := range students {
 		studentIDs = append(studentIDs, student.ID)
 	}
 
-	roomSnapshot, snapshotErr := common.LoadStudentLocationSnapshot(r.Context(), rs.ActiveService, studentIDs)
+	snapshot, snapshotErr := common.LoadStudentLocationSnapshot(ctx, rs.ActiveService, studentIDs)
 	if snapshotErr != nil {
 		log.Printf("Failed to batch load student room locations: %v", snapshotErr)
-		roomSnapshot = nil
+		snapshot = nil
 	}
 
+	studentStatuses := make(map[string]interface{})
 	for _, student := range students {
-		studentStatus := map[string]interface{}{
-			"in_group_room": false,
-			"reason":        "no_active_visit",
-		}
-
-		var visit *active.Visit
-		if roomSnapshot != nil {
-			visit = roomSnapshot.Visits[student.ID]
-		} else {
-			if v, err := rs.ActiveService.GetStudentCurrentVisit(r.Context(), student.ID); err == nil {
-				visit = v
-			}
-		}
-
-		if visit != nil {
-			var activeGroup *active.Group
-			if roomSnapshot != nil {
-				activeGroup = roomSnapshot.Groups[visit.ActiveGroupID]
-			} else {
-				if g, err := rs.ActiveService.GetActiveGroup(r.Context(), visit.ActiveGroupID); err == nil {
-					activeGroup = g
-				}
-			}
-
-			if activeGroup != nil {
-				inGroupRoom := activeGroup.RoomID == *group.RoomID
-				studentStatus["in_group_room"] = inGroupRoom
-				studentStatus["current_room_id"] = activeGroup.RoomID
-
-				if inGroupRoom {
-					delete(studentStatus, "reason")
-				} else {
-					studentStatus["reason"] = "in_different_room"
-				}
-			}
-		}
-
-		// Get student's person data for display
-		person, err := rs.UserService.Get(r.Context(), student.PersonID)
-		if err == nil && person != nil {
-			studentStatus["first_name"] = person.FirstName
-			studentStatus["last_name"] = person.LastName
-		}
-
-		studentStatuses[strconv.FormatInt(student.ID, 10)] = studentStatus
+		studentStatuses[strconv.FormatInt(student.ID, 10)] = rs.buildStudentRoomStatus(ctx, student, groupRoomID, snapshot)
 	}
 
 	result["student_room_status"] = studentStatuses
-	common.Respond(w, r, http.StatusOK, result, "Student room status retrieved successfully")
+	return result
 }
 
 // getGroupSubstitutions gets active substitutions for a specific group
@@ -826,6 +886,84 @@ func hasAdminPermissions(permissions []string) bool {
 	return false
 }
 
+// validateGroupLeaderAccess ensures current user is a teacher who leads the specified group
+func (rs *Resource) validateGroupLeaderAccess(w http.ResponseWriter, r *http.Request, groupID int64) (*users.Staff, *users.Teacher, bool) {
+	currentStaff, err := rs.UserContextService.GetCurrentStaff(r.Context())
+	if err != nil {
+		//nolint:staticcheck // ST1005: German user-facing message
+		common.RenderError(w, r, ErrorForbidden(errors.New("Du musst ein Mitarbeiter sein, um Gruppen zu übergeben")))
+		return nil, nil, false
+	}
+
+	currentTeacher, err := rs.UserContextService.GetCurrentTeacher(r.Context())
+	if err != nil {
+		//nolint:staticcheck // ST1005: German user-facing message
+		common.RenderError(w, r, ErrorForbidden(errors.New("Du musst ein Gruppenleiter sein, um Gruppen zu übergeben")))
+		return nil, nil, false
+	}
+
+	isGroupLeader, err := rs.isUserGroupLeader(r.Context(), currentTeacher.ID, groupID)
+	if err != nil {
+		common.RenderError(w, r, ErrorInternalServer(err))
+		return nil, nil, false
+	}
+
+	if !isGroupLeader {
+		//nolint:staticcheck // ST1005: German user-facing message
+		common.RenderError(w, r, ErrorForbidden(errors.New("Du bist kein Leiter dieser Gruppe. Nur der Original-Gruppenleiter kann Übertragungen vornehmen")))
+		return nil, nil, false
+	}
+
+	return currentStaff, currentTeacher, true
+}
+
+// resolveTargetStaff validates and retrieves the target staff for a group transfer
+func (rs *Resource) resolveTargetStaff(w http.ResponseWriter, r *http.Request, targetUserID int64) (*users.Person, *users.Staff, bool) {
+	targetPerson, err := rs.UserService.Get(r.Context(), targetUserID)
+	if err != nil {
+		//nolint:staticcheck // ST1005: German user-facing message
+		common.RenderError(w, r, ErrorNotFound(errors.New("Der ausgewählte Betreuer wurde nicht gefunden")))
+		return nil, nil, false
+	}
+
+	targetStaff, err := rs.StaffRepo.FindByPersonID(r.Context(), targetPerson.ID)
+	if err != nil {
+		//nolint:staticcheck // ST1005: German user-facing message
+		common.RenderError(w, r, ErrorInvalidRequest(errors.New("Der ausgewählte Betreuer ist kein Mitarbeiter")))
+		return nil, nil, false
+	}
+
+	return targetPerson, targetStaff, true
+}
+
+// translateTransferRequestError converts transfer request errors to German messages
+func (rs *Resource) translateTransferRequestError(err error) string {
+	if err.Error() == "target_user_id is required" {
+		return "Bitte wähle einen Betreuer aus"
+	}
+	return "Ungültige Anfrage"
+}
+
+// checkDuplicateTransfer verifies target doesn't already have access to this group
+func (rs *Resource) checkDuplicateTransfer(w http.ResponseWriter, r *http.Request, groupID int64, targetStaffID int64, targetPerson *users.Person) bool {
+	today := time.Date(time.Now().UTC().Year(), time.Now().UTC().Month(), time.Now().UTC().Day(), 0, 0, 0, 0, time.UTC)
+	existingTransfers, err := rs.EducationService.GetActiveGroupSubstitutions(r.Context(), groupID, today)
+	if err != nil {
+		common.RenderError(w, r, ErrorInternalServer(err))
+		return false
+	}
+
+	for _, transfer := range existingTransfers {
+		if transfer.RegularStaffID == nil && transfer.SubstituteStaffID == targetStaffID {
+			targetName := targetPerson.FirstName + " " + targetPerson.LastName
+			errorMsg := fmt.Sprintf("Du hast diese Gruppe bereits an %s übergeben", targetName)
+			common.RenderError(w, r, ErrorInvalidRequest(errors.New(errorMsg)))
+			return false
+		}
+	}
+	return true
+}
+
 // transferGroup handles POST /api/groups/{id}/transfer
 // Allows a group leader to grant temporary access to another user until end of day
 func (rs *Resource) transferGroup(w http.ResponseWriter, r *http.Request) {
@@ -834,91 +972,35 @@ func (rs *Resource) transferGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse request body
 	req := &TransferGroupRequest{}
 	if err := render.Bind(r, req); err != nil {
-		// Translate validation errors
-		errMsg := "Ungültige Anfrage"
-		if err.Error() == "target_user_id is required" {
-			errMsg = "Bitte wähle einen Betreuer aus"
-		}
+		errMsg := rs.translateTransferRequestError(err)
 		common.RenderError(w, r, ErrorInvalidRequest(errors.New(errMsg)))
 		return
 	}
 
-	// Get current user's staff record
-	currentStaff, err := rs.UserContextService.GetCurrentStaff(r.Context())
-	if err != nil {
-		//nolint:staticcheck // ST1005: German user-facing message, capitalization is correct
-		common.RenderError(w, r, ErrorForbidden(errors.New("Du musst ein Mitarbeiter sein, um Gruppen zu übergeben")))
+	currentStaff, _, ok := rs.validateGroupLeaderAccess(w, r, groupID)
+	if !ok {
 		return
 	}
 
-	// Get current user's teacher record (only teachers can lead groups)
-	currentTeacher, err := rs.UserContextService.GetCurrentTeacher(r.Context())
-	if err != nil {
-		//nolint:staticcheck // ST1005: German user-facing message, capitalization is correct
-		common.RenderError(w, r, ErrorForbidden(errors.New("Du musst ein Gruppenleiter sein, um Gruppen zu übergeben")))
+	targetPerson, targetStaff, ok := rs.resolveTargetStaff(w, r, req.TargetUserID)
+	if !ok {
 		return
 	}
 
-	// Verify that current user is actually a leader of this group
-	isGroupLeader, err := rs.isUserGroupLeader(r.Context(), currentTeacher.ID, groupID)
-	if err != nil {
-		common.RenderError(w, r, ErrorInternalServer(err))
-		return
-	}
-
-	if !isGroupLeader {
-		//nolint:staticcheck // ST1005: German user-facing message, capitalization is correct
-		common.RenderError(w, r, ErrorForbidden(errors.New("Du bist kein Leiter dieser Gruppe. Nur der Original-Gruppenleiter kann Übertragungen vornehmen")))
-		return
-	}
-
-	// Verify target user exists and get their person record
-	targetPerson, err := rs.UserService.Get(r.Context(), req.TargetUserID)
-	if err != nil {
-		//nolint:staticcheck // ST1005: German user-facing message, capitalization is correct
-		common.RenderError(w, r, ErrorNotFound(errors.New("Der ausgewählte Betreuer wurde nicht gefunden")))
-		return
-	}
-
-	// Get target user's staff record (must be staff to receive group access)
-	targetStaff, err := rs.StaffRepo.FindByPersonID(r.Context(), targetPerson.ID)
-	if err != nil {
-		//nolint:staticcheck // ST1005: German user-facing message, capitalization is correct
-		common.RenderError(w, r, ErrorInvalidRequest(errors.New("Der ausgewählte Betreuer ist kein Mitarbeiter")))
-		return
-	}
-
-	// Prevent self-transfer
 	if targetStaff.ID == currentStaff.ID {
-		//nolint:staticcheck // ST1005: German user-facing message, capitalization is correct
+		//nolint:staticcheck // ST1005: German user-facing message
 		common.RenderError(w, r, ErrorInvalidRequest(errors.New("Du kannst die Gruppe nicht an dich selbst übergeben")))
 		return
 	}
 
-	// Check if this specific user already has access to this group (prevent duplicate transfers to same user)
-	now := time.Now().UTC()
-	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	existingTransfers, err := rs.EducationService.GetActiveGroupSubstitutions(r.Context(), groupID, today)
-	if err != nil {
-		common.RenderError(w, r, ErrorInternalServer(err))
+	if !rs.checkDuplicateTransfer(w, r, groupID, targetStaff.ID, targetPerson) {
 		return
 	}
 
-	// Check if target user already has access to this group (prevent duplicate)
-	for _, transfer := range existingTransfers {
-		if transfer.RegularStaffID == nil && transfer.SubstituteStaffID == targetStaff.ID {
-			// Load target name for better error message
-			targetName := targetPerson.FirstName + " " + targetPerson.LastName
-			errorMsg := fmt.Sprintf("Du hast diese Gruppe bereits an %s übergeben", targetName)
-			common.RenderError(w, r, ErrorInvalidRequest(errors.New(errorMsg)))
-			return
-		}
-	}
-
-	// Calculate end of day (23:59:59 UTC)
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 	endOfDay := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, time.UTC)
 
 	// Create substitution (without regular_staff_id = additional access, not replacement)


### PR DESCRIPTION
## Summary
- Extract validation and response building logic into helper functions to reduce cognitive complexity
- Address SonarCloud S3776 issues across 3 API files (groups, staff, usercontext)
- All changes preserve original behavior and API contracts

## Changes by File

### api/groups/api.go (3 methods fixed)
| Method | Before | After | Helpers Added |
|--------|--------|-------|---------------|
| `getGroupStudents` | 32 | ~10 | `populateGuardianDetails`, `buildStudentResponse`, `resolveLocationForStudent` |
| `getGroupStudentsRoomStatus` | 45 | ~12 | `getStudentVisit`, `getVisitActiveGroup`, `buildStudentRoomStatus`, `buildRoomStatusResponse`, `buildNoRoomResponse` |
| `transferGroup` | 45 | ~12 | `validateGroupLeaderAccess`, `resolveTargetStaff`, `checkDuplicateTransfer`, `translateTransferRequestError` |

### api/staff/api.go (2 methods fixed)
| Method | Before | After | Helpers Added |
|--------|--------|-------|---------------|
| `getAvailableForSubstitution` | 44 | ~10 | `buildSubstitutionMap`, `filterAndBuildStaffResults`, `processStaffForSubstitution`, `buildStaffSubstitutionStatus` |
| `getStaffByRole` | 24 | ~8 | `filterStaffByRole`, `buildStaffRoleEntry`, `accountHasRole` |

### api/usercontext/api.go (1 method fixed)
| Method | Before | After | Helpers Added |
|--------|--------|-------|---------------|
| `getMyGroups` | 21 | ~8 | `getSubstitutedGroupIDs` |

## Test Plan
- [x] `go build ./...` passes
- [x] `golangci-lint run` passes with 0 issues
- [ ] SonarCloud analysis shows reduced complexity
- [ ] API endpoints function correctly (manual or integration test)