### PR TITLE
fix: use Number.isNaN and String.replaceAll

### DIFF
--- a/frontend/src/app/api/activities/[id]/route.ts
+++ b/frontend/src/app/api/activities/[id]/route.ts
@@ -72,7 +72,7 @@ export const PUT = createPutHandler<Activity, UpdateActivityRequest>(
     const id = params.id as string;
     const activityId = Number.parseInt(id, 10);
 
-    if (isNaN(activityId)) {
+    if (Number.isNaN(activityId)) {
       throw new Error("Invalid activity ID");
     }
 
@@ -123,7 +123,7 @@ export const DELETE = createDeleteHandler(
     const id = params.id as string;
     const activityId = Number.parseInt(id, 10);
 
-    if (isNaN(activityId)) {
+    if (Number.isNaN(activityId)) {
       throw new Error("Invalid activity ID");
     }
 

--- a/frontend/src/components/activities/activity-management-modal.tsx
+++ b/frontend/src/components/activities/activity-management-modal.tsx
@@ -124,7 +124,7 @@ export function ActivityManagementModal({
       return "Please select a category";
     }
     const maxParticipants = Number.parseInt(form.max_participants, 10);
-    if (isNaN(maxParticipants) || maxParticipants < 1) {
+    if (Number.isNaN(maxParticipants) || maxParticipants < 1) {
       return "Max participants must be a positive number";
     }
     return null;

--- a/frontend/src/components/activities/quick-create-modal.tsx
+++ b/frontend/src/components/activities/quick-create-modal.tsx
@@ -112,7 +112,7 @@ export function QuickCreateActivityModal({
       return "Please select a category";
     }
     const maxParticipants = Number.parseInt(form.max_participants, 10);
-    if (isNaN(maxParticipants) || maxParticipants < 1) {
+    if (Number.isNaN(maxParticipants) || maxParticipants < 1) {
       return "Max participants must be a positive number";
     }
     return null;

--- a/frontend/src/components/simple/student/ModernContactActions.tsx
+++ b/frontend/src/components/simple/student/ModernContactActions.tsx
@@ -23,7 +23,7 @@ export function ModernContactActions({
   const handlePhoneClick = () => {
     if (phone) {
       // Remove spaces and special characters for tel: link
-      const cleanPhone = phone.replace(/\s+/g, "");
+      const cleanPhone = phone.replaceAll(/\s+/g, "");
       window.location.href = `tel:${cleanPhone}`;
     }
   };

--- a/frontend/src/components/ui/database/database-form.tsx
+++ b/frontend/src/components/ui/database/database-form.tsx
@@ -343,7 +343,7 @@ export function DatabaseForm<T = Record<string, unknown>>({
         const numValue = Number.parseInt(value, 10);
         setFormData((prev) => ({
           ...prev,
-          [name]: isNaN(numValue) ? "" : numValue,
+          [name]: Number.isNaN(numValue) ? "" : numValue,
         }));
       }
     } else {

--- a/frontend/src/lib/database/configs/rooms.config.tsx
+++ b/frontend/src/lib/database/configs/rooms.config.tsx
@@ -58,7 +58,7 @@ export const roomsConfig = defineEntityConfig<Room>({
             required: false, // Now optional
             placeholder: "z.B. 0, 1, 2",
             validation: (value) => {
-              if (value && isNaN(Number.parseInt(value as string, 10))) {
+              if (value && Number.isNaN(Number.parseInt(value as string, 10))) {
                 return "Bitte geben Sie eine gültige Etage ein";
               }
               return null;

--- a/frontend/src/lib/utils/date-helpers.ts
+++ b/frontend/src/lib/utils/date-helpers.ts
@@ -12,7 +12,7 @@ export function isValidDateString(
 ): boolean {
   if (!dateString) return false;
   const date = new Date(dateString);
-  return !isNaN(date.getTime());
+  return !Number.isNaN(date.getTime());
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace global `isNaN()` with `Number.isNaN()` for stricter NaN checking (7 instances)
- Replace `String.replace()` with `replaceAll()` for clarity (1 instance)

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes

## SonarCloud Issues Addressed
- S7773: Use `Number.isNaN()` instead of the global `isNaN()`
- S7781: Use `String.replaceAll()` instead of `String.replace()` with global regex