### PR TITLE
fix: use double brackets for bash conditionals

### DIFF
--- a/config/ssl/postgres/check-cert-expiration.sh
+++ b/config/ssl/postgres/check-cert-expiration.sh
@@ -5,7 +5,7 @@
 CERT_DIR="certs"
 WARN_DAYS=30
 
-if [ ! -d "$CERT_DIR" ]; then
+if [[ ! -d "$CERT_DIR" ]]; then
   echo "Error: Certificate directory not found at $CERT_DIR"
   exit 1
 fi
@@ -14,7 +14,7 @@ check_expiration() {
   local cert=$1
   local cert_file="$CERT_DIR/$cert"
   
-  if [ ! -f "$cert_file" ]; then
+  if [[ ! -f "$cert_file" ]]; then
     echo "Warning: Certificate file $cert_file not found"
     return
   fi
@@ -31,7 +31,7 @@ check_expiration() {
     exp_seconds=$(date -d "$exp_date" +%s 2>/dev/null)
   fi
   
-  if [ -z "$exp_seconds" ]; then
+  if [[ -z "$exp_seconds" ]]; then
     echo "Error: Could not parse expiration date for $cert"
     return
   fi
@@ -45,7 +45,7 @@ check_expiration() {
   
   echo "$cert expires in $days_left days (on $exp_date)"
   
-  if [ $days_left -lt $WARN_DAYS ]; then
+  if [[ $days_left -lt $WARN_DAYS ]]; then
     echo "WARNING: $cert will expire in less than $WARN_DAYS days!"
     echo "Please regenerate certificates using ./create-certs.sh"
   fi

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -11,7 +11,7 @@ echo "Project Phoenix - Development Environment Setup"
 echo "==============================================="
 
 # Check if running from repository root
-if [ ! -f "docker-compose.example.yml" ]; then
+if [[ ! -f "docker-compose.example.yml" ]]; then
   echo "Error: This script must be run from the repository root"
   exit 1
 fi
@@ -31,7 +31,7 @@ generate_secret() {
 echo -e "\n${YELLOW}Creating environment files from templates...${NC}"
 
 # 1.1 Main .env file
-if [ ! -f ".env" ]; then
+if [[ ! -f ".env" ]]; then
   echo "Creating .env file..."
   cp .env.example .env
   
@@ -51,7 +51,7 @@ else
 fi
 
 # 1.2 Backend dev.env file
-if [ ! -f "backend/dev.env" ]; then
+if [[ ! -f "backend/dev.env" ]]; then
   echo "Creating backend/dev.env file..."
   cp backend/dev.env.example backend/dev.env
   
@@ -68,7 +68,7 @@ else
 fi
 
 # 1.3 Frontend .env.local file
-if [ ! -f "frontend/.env.local" ]; then
+if [[ ! -f "frontend/.env.local" ]]; then
   echo "Creating frontend/.env.local file..."
   cp frontend/.env.example frontend/.env.local
   
@@ -85,7 +85,7 @@ else
 fi
 
 # 1.4 Docker compose file
-if [ ! -f "docker-compose.yml" ]; then
+if [[ ! -f "docker-compose.yml" ]]; then
   echo "Creating docker-compose.yml file..."
   cp docker-compose.example.yml docker-compose.yml
   echo -e "${GREEN}Created docker-compose.yml file${NC}"
@@ -97,7 +97,7 @@ fi
 echo -e "\n${YELLOW}Setting up SSL certificates...${NC}"
 
 # Check if certificates already exist
-if [ ! -d "config/ssl/postgres/certs" ] || [ ! -f "config/ssl/postgres/certs/server.crt" ]; then
+if [[ ! -d "config/ssl/postgres/certs" || ! -f "config/ssl/postgres/certs/server.crt" ]]; then
   echo "Generating PostgreSQL SSL certificates..."
   cd config/ssl/postgres
   chmod +x create-certs.sh
@@ -131,7 +131,7 @@ elif command -v docker-compose &> /dev/null; then
   echo -e "${GREEN}Docker Compose V1 detected${NC}"
 fi
 
-if [ "$DOCKER_COMPOSE_FOUND" = false ]; then
+if [[ "$DOCKER_COMPOSE_FOUND" = false ]]; then
   echo -e "${RED}Error: Docker Compose is not installed. Please install Docker Compose first.${NC}"
   echo "Visit https://docs.docker.com/compose/install/ for installation instructions."
   exit 1


### PR DESCRIPTION
## Summary
- Replace `[ ]` with `[[ ]]` in shell scripts for safer conditional testing
- Fixes 12 SonarCloud issues across 2 files

## Changes
- `config/ssl/postgres/check-cert-expiration.sh`: 4 conditionals updated
- `scripts/setup-dev.sh`: 8 conditionals updated (including compound condition on line 100)

## Why `[[` over `[`?
- `[` is a command (`/usr/bin/[`), `[[` is a bash keyword
- `[[` handles word splitting and glob expansion safely
- `[[` won't break if a variable is empty/unset
- Supports pattern matching and regex without quoting issues

## Test plan
- [x] `bash -n` syntax validation passes for both scripts
- [ ] Run `./scripts/setup-dev.sh` (manual)
- [ ] Run `./config/ssl/postgres/check-cert-expiration.sh` (manual)