### PR TITLE
fix: remove styled-jsx in favor of Tailwind CSS utilities

### DIFF
--- a/frontend/src/app/activities/page.tsx
+++ b/frontend/src/app/activities/page.tsx
@@ -426,20 +426,6 @@ export default function ActivitiesPage() {
                 </div>
               );
             })}
-
-            {/* Add fadeInUp animation */}
-            <style jsx>{`
-              @keyframes fadeInUp {
-                from {
-                  opacity: 0;
-                  transform: translateY(20px);
-                }
-                to {
-                  opacity: 1;
-                  transform: translateY(0);
-                }
-              }
-            `}</style>
           </div>
         ) : (
           <div className="flex min-h-[300px] items-center justify-center">

--- a/frontend/src/app/database/activities/page.tsx
+++ b/frontend/src/app/database/activities/page.tsx
@@ -473,19 +473,6 @@ export default function ActivitiesPage() {
                 </div>
               );
             })}
-
-            <style jsx>{`
-              @keyframes fadeInUp {
-                from {
-                  opacity: 0;
-                  transform: translateY(20px);
-                }
-                to {
-                  opacity: 1;
-                  transform: translateY(0);
-                }
-              }
-            `}</style>
           </div>
         )}
       </div>

--- a/frontend/src/app/database/devices/page.tsx
+++ b/frontend/src/app/database/devices/page.tsx
@@ -419,18 +419,6 @@ export default function DevicesPage() {
                 <div className="pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-r from-transparent via-amber-100/30 to-transparent opacity-0 transition-opacity duration-300 md:group-hover:opacity-100"></div>
               </div>
             ))}
-            <style jsx>{`
-              @keyframes fadeInUp {
-                from {
-                  opacity: 0;
-                  transform: translateY(20px);
-                }
-                to {
-                  opacity: 1;
-                  transform: translateY(0);
-                }
-              }
-            `}</style>
           </div>
         )}
       </div>

--- a/frontend/src/app/database/groups/page.tsx
+++ b/frontend/src/app/database/groups/page.tsx
@@ -439,18 +439,6 @@ export default function GroupsPage() {
                 <div className="pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-r from-transparent via-green-100/30 to-transparent opacity-0 transition-opacity duration-300 md:group-hover:opacity-100"></div>
               </div>
             ))}
-            <style jsx>{`
-              @keyframes fadeInUp {
-                from {
-                  opacity: 0;
-                  transform: translateY(20px);
-                }
-                to {
-                  opacity: 1;
-                  transform: translateY(0);
-                }
-              }
-            `}</style>
           </div>
         )}
       </div>

--- a/frontend/src/app/database/permissions/page.tsx
+++ b/frontend/src/app/database/permissions/page.tsx
@@ -161,8 +161,7 @@ export default function PermissionsPage() {
       await fetchPermissions();
     } catch (err) {
       // Check for duplicate key error and show in modal
-      const errorMessage =
-        err instanceof Error ? err.message : String(err);
+      const errorMessage = err instanceof Error ? err.message : String(err);
       if (
         errorMessage.includes("duplicate key") ||
         errorMessage.includes("23505")
@@ -206,8 +205,7 @@ export default function PermissionsPage() {
       setShowDetailModal(true);
       await fetchPermissions();
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : String(err);
+      const errorMessage = err instanceof Error ? err.message : String(err);
       if (
         errorMessage.includes("duplicate key") ||
         errorMessage.includes("23505")
@@ -324,10 +322,11 @@ export default function PermissionsPage() {
                   onClick={() => setShowCreateModal(true)}
                   className="group relative flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-pink-500 to-rose-600 text-white shadow-lg transition-all duration-300 hover:scale-110 hover:shadow-xl active:scale-95"
                   style={{
-                    background: 'linear-gradient(135deg, rgb(236, 72, 153) 0%, rgb(225, 29, 72) 100%)',
-                    willChange: 'transform, opacity',
-                    WebkitTransform: 'translateZ(0)',
-                    transform: 'translateZ(0)',
+                    background:
+                      "linear-gradient(135deg, rgb(236, 72, 153) 0%, rgb(225, 29, 72) 100%)",
+                    willChange: "transform, opacity",
+                    WebkitTransform: "translateZ(0)",
+                    transform: "translateZ(0)",
                   }}
                   aria-label="Berechtigung erstellen"
                 >
@@ -356,10 +355,11 @@ export default function PermissionsPage() {
           onClick={() => setShowCreateModal(true)}
           className="group pointer-events-auto fixed right-4 bottom-24 z-40 flex h-14 w-14 translate-y-0 items-center justify-center rounded-full bg-gradient-to-br from-pink-500 to-rose-600 text-white opacity-100 shadow-[0_8px_30px_rgb(0,0,0,0.12)] transition-all duration-300 ease-out hover:shadow-[0_8px_40px_rgba(244,114,182,0.3)] active:scale-95 md:hidden"
           style={{
-            background: 'linear-gradient(135deg, rgb(236, 72, 153) 0%, rgb(225, 29, 72) 100%)',
-            willChange: 'transform, opacity',
-            WebkitTransform: 'translateZ(0)',
-            transform: 'translateZ(0)',
+            background:
+              "linear-gradient(135deg, rgb(236, 72, 153) 0%, rgb(225, 29, 72) 100%)",
+            willChange: "transform, opacity",
+            WebkitTransform: "translateZ(0)",
+            transform: "translateZ(0)",
           }}
           aria-label="Berechtigung erstellen"
         >
@@ -478,18 +478,6 @@ export default function PermissionsPage() {
                 <div className="pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-r from-transparent via-pink-100/30 to-transparent opacity-0 transition-opacity duration-300 md:group-hover:opacity-100"></div>
               </div>
             ))}
-            <style jsx>{`
-              @keyframes fadeInUp {
-                from {
-                  opacity: 0;
-                  transform: translateY(20px);
-                }
-                to {
-                  opacity: 1;
-                  transform: translateY(0);
-                }
-              }
-            `}</style>
           </div>
         )}
       </div>

--- a/frontend/src/app/database/roles/page.tsx
+++ b/frontend/src/app/database/roles/page.tsx
@@ -411,18 +411,6 @@ export default function RolesPage() {
                 <div className="pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-r from-transparent via-purple-100/30 to-transparent opacity-0 transition-opacity duration-300 md:group-hover:opacity-100"></div>
               </div>
             ))}
-            <style jsx>{`
-              @keyframes fadeInUp {
-                from {
-                  opacity: 0;
-                  transform: translateY(20px);
-                }
-                to {
-                  opacity: 1;
-                  transform: translateY(0);
-                }
-              }
-            `}</style>
           </div>
         )}
       </div>

--- a/frontend/src/app/database/rooms/page.tsx
+++ b/frontend/src/app/database/rooms/page.tsx
@@ -484,19 +484,6 @@ export default function RoomsPage() {
                 </div>
               );
             })}
-
-            <style jsx>{`
-              @keyframes fadeInUp {
-                from {
-                  opacity: 0;
-                  transform: translateY(20px);
-                }
-                to {
-                  opacity: 1;
-                  transform: translateY(0);
-                }
-              }
-            `}</style>
           </div>
         )}
       </div>

--- a/frontend/src/app/database/students/page.tsx
+++ b/frontend/src/app/database/students/page.tsx
@@ -633,20 +633,6 @@ export default function StudentsPage() {
                 </div>
               );
             })}
-
-            {/* Add fadeInUp animation */}
-            <style jsx>{`
-              @keyframes fadeInUp {
-                from {
-                  opacity: 0;
-                  transform: translateY(20px);
-                }
-                to {
-                  opacity: 1;
-                  transform: translateY(0);
-                }
-              }
-            `}</style>
           </div>
         )}
       </div>

--- a/frontend/src/app/database/teachers/page.tsx
+++ b/frontend/src/app/database/teachers/page.tsx
@@ -482,20 +482,6 @@ export default function TeachersPage() {
                 </div>
               );
             })}
-
-            {/* Add fadeInUp animation */}
-            <style jsx>{`
-              @keyframes fadeInUp {
-                from {
-                  opacity: 0;
-                  transform: translateY(20px);
-                }
-                to {
-                  opacity: 1;
-                  transform: translateY(0);
-                }
-              }
-            `}</style>
           </div>
         )}
       </div>

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -191,7 +191,7 @@ export function Modal({
 
         {/* Content area with hidden scrollbar and reveal animation */}
         <div
-          className="modal-scrollbar-hidden max-h-[calc(100vh-8rem)] overflow-y-auto md:max-h-[70vh]"
+          className="scrollbar-hidden max-h-[calc(100vh-8rem)] overflow-y-auto md:max-h-[70vh]"
           data-modal-content="true"
         >
           <div
@@ -202,17 +202,6 @@ export function Modal({
             {children}
           </div>
         </div>
-
-        {/* Hide scrollbar CSS */}
-        <style jsx>{`
-          .modal-scrollbar-hidden::-webkit-scrollbar {
-            display: none;
-          }
-          .modal-scrollbar-hidden {
-            -ms-overflow-style: none;
-            scrollbar-width: none;
-          }
-        `}</style>
 
         {/* Footer if provided */}
         {footer && (

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -409,6 +409,18 @@ html {
   }
 }
 
+/* fadeInUp animation for card lists */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* Utility classes */
 .animate-slideInRight {
   animation: slideInRight 400ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
@@ -416,4 +428,17 @@ html {
 
 .animate-fadeIn {
   animation: fadeIn 300ms ease-out forwards;
+}
+
+.animate-fadeInUp {
+  animation: fadeInUp 600ms ease-out forwards;
+}
+
+/* Hide scrollbar utility */
+.scrollbar-hidden::-webkit-scrollbar {
+  display: none;
+}
+.scrollbar-hidden {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }


### PR DESCRIPTION
## Summary

- Remove `<style jsx>` tags from 9 page files and 1 modal component that were causing SonarCloud S6847 "unknown 'jsx' property" issues
- Centralize animation keyframes and utility classes in `globals.css` for consistency with Tailwind CSS approach
- Add `fadeInUp` animation keyframe and `.animate-fadeInUp` utility class
- Add `.scrollbar-hidden` utility class for hiding scrollbars

## Changes

| File | Change |
|------|--------|
| `frontend/src/styles/globals.css` | Added fadeInUp keyframe, animate-fadeInUp, scrollbar-hidden utilities |
| `frontend/src/app/activities/page.tsx` | Removed `<style jsx>` block |
| `frontend/src/app/database/activities/page.tsx` | Removed `<style jsx>` block |
| `frontend/src/app/database/devices/page.tsx` | Removed `<style jsx>` block |
| `frontend/src/app/database/groups/page.tsx` | Removed `<style jsx>` block |
| `frontend/src/app/database/permissions/page.tsx` | Removed `<style jsx>` block |
| `frontend/src/app/database/roles/page.tsx` | Removed `<style jsx>` block |
| `frontend/src/app/database/rooms/page.tsx` | Removed `<style jsx>` block |
| `frontend/src/app/database/students/page.tsx` | Removed `<style jsx>` block |
| `frontend/src/app/database/teachers/page.tsx` | Removed `<style jsx>` block |
| `frontend/src/components/ui/modal.tsx` | Replaced `modal-scrollbar-hidden` with `scrollbar-hidden` |

## Test plan

- [x] `npm run check` passes (lint + typecheck)
- [x] `npm run build` succeeds
- [ ] Verify staggered fadeInUp animations still work on database list pages
- [ ] Verify modal scrollbar hiding still works

## Resolves

SonarCloud S6847 issues (10 instances of unknown 'jsx' property)