### PR TITLE
fix: associate form labels with input controls

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -206,6 +206,7 @@ function SettingsContent() {
                     </div>
                     <label
                       htmlFor="avatar-upload"
+                      aria-label="Profilbild ändern"
                       className="absolute inset-0 flex cursor-pointer items-center justify-center rounded-full bg-black/50 opacity-0 transition-opacity group-hover:opacity-100"
                     >
                       <svg

--- a/frontend/src/app/students/[id]/page.tsx
+++ b/frontend/src/app/students/[id]/page.tsx
@@ -809,10 +809,14 @@ export default function StudentDetailPage() {
                   {isEditingPersonal && editedStudent ? (
                     <>
                       <div>
-                        <label className="mb-1 block text-xs text-gray-500">
+                        <label
+                          htmlFor="student-first-name"
+                          className="mb-1 block text-xs text-gray-500"
+                        >
                           Vorname
                         </label>
                         <input
+                          id="student-first-name"
                           type="text"
                           value={editedStudent.first_name}
                           onChange={(e) =>
@@ -825,10 +829,14 @@ export default function StudentDetailPage() {
                         />
                       </div>
                       <div>
-                        <label className="mb-1 block text-xs text-gray-500">
+                        <label
+                          htmlFor="student-last-name"
+                          className="mb-1 block text-xs text-gray-500"
+                        >
                           Nachname
                         </label>
                         <input
+                          id="student-last-name"
                           type="text"
                           value={editedStudent.second_name}
                           onChange={(e) =>
@@ -841,10 +849,14 @@ export default function StudentDetailPage() {
                         />
                       </div>
                       <div>
-                        <label className="mb-1 block text-xs text-gray-500">
+                        <label
+                          htmlFor="student-school-class"
+                          className="mb-1 block text-xs text-gray-500"
+                        >
                           Klasse
                         </label>
                         <input
+                          id="student-school-class"
                           type="text"
                           value={editedStudent.school_class}
                           onChange={(e) =>
@@ -857,10 +869,14 @@ export default function StudentDetailPage() {
                         />
                       </div>
                       <div>
-                        <label className="mb-1 block text-xs text-gray-500">
+                        <label
+                          htmlFor="student-birthday"
+                          className="mb-1 block text-xs text-gray-500"
+                        >
                           Geburtsdatum
                         </label>
                         <input
+                          id="student-birthday"
                           type="date"
                           value={
                             editedStudent.birthday
@@ -877,11 +893,15 @@ export default function StudentDetailPage() {
                         />
                       </div>
                       <div>
-                        <label className="mb-1 block text-xs text-gray-500">
+                        <label
+                          htmlFor="student-buskind"
+                          className="mb-1 block text-xs text-gray-500"
+                        >
                           Buskind
                         </label>
                         <div className="relative">
                           <select
+                            id="student-buskind"
                             value={editedStudent.buskind ? "true" : "false"}
                             onChange={(e) =>
                               setEditedStudent({
@@ -910,11 +930,15 @@ export default function StudentDetailPage() {
                         </div>
                       </div>
                       <div>
-                        <label className="mb-1 block text-xs text-gray-500">
+                        <label
+                          htmlFor="student-pickup-status"
+                          className="mb-1 block text-xs text-gray-500"
+                        >
                           Abholstatus
                         </label>
                         <div className="relative">
                           <select
+                            id="student-pickup-status"
                             value={editedStudent.pickup_status ?? ""}
                             onChange={(e) =>
                               setEditedStudent({
@@ -1016,10 +1040,14 @@ export default function StudentDetailPage() {
                         </div>
                       </div>
                       <div>
-                        <label className="mb-1 block text-xs text-gray-500">
+                        <label
+                          htmlFor="student-health-info"
+                          className="mb-1 block text-xs text-gray-500"
+                        >
                           Gesundheitsinformationen
                         </label>
                         <textarea
+                          id="student-health-info"
                           value={editedStudent.health_info ?? ""}
                           onChange={(e) =>
                             setEditedStudent({
@@ -1033,10 +1061,14 @@ export default function StudentDetailPage() {
                         />
                       </div>
                       <div>
-                        <label className="mb-1 block text-xs text-gray-500">
+                        <label
+                          htmlFor="student-supervisor-notes"
+                          className="mb-1 block text-xs text-gray-500"
+                        >
                           Betreuernotizen
                         </label>
                         <textarea
+                          id="student-supervisor-notes"
                           value={editedStudent.supervisor_notes ?? ""}
                           onChange={(e) =>
                             setEditedStudent({
@@ -1050,10 +1082,14 @@ export default function StudentDetailPage() {
                         />
                       </div>
                       <div>
-                        <label className="mb-1 block text-xs text-gray-500">
+                        <label
+                          htmlFor="student-extra-info"
+                          className="mb-1 block text-xs text-gray-500"
+                        >
                           Elternnotizen
                         </label>
                         <textarea
+                          id="student-extra-info"
                           value={editedStudent.extra_info ?? ""}
                           onChange={(e) =>
                             setEditedStudent({

--- a/frontend/src/app/substitutions/page.tsx
+++ b/frontend/src/app/substitutions/page.tsx
@@ -922,11 +922,15 @@ function SubstitutionPageContent() {
 
           {/* Group selection */}
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700">
+            <label
+              htmlFor="substitution-group-select"
+              className="mb-2 block text-sm font-medium text-gray-700"
+            >
               OGS-Gruppe auswählen
             </label>
             <div className="relative">
               <select
+                id="substitution-group-select"
                 value={selectedGroup}
                 onChange={(e) => setSelectedGroup(e.target.value)}
                 className="block w-full cursor-pointer appearance-none rounded-lg border border-gray-200 bg-white py-3 pr-10 pl-4 text-lg text-gray-900 transition-colors focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8]"
@@ -957,7 +961,10 @@ function SubstitutionPageContent() {
 
           {/* Days selection with stepper */}
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700">
+            <label
+              htmlFor="substitution-days-input"
+              className="mb-2 block text-sm font-medium text-gray-700"
+            >
               Anzahl der Tage
             </label>
             <div className="flex items-center justify-center gap-3">
@@ -988,6 +995,7 @@ function SubstitutionPageContent() {
 
               {/* Editable input */}
               <input
+                id="substitution-days-input"
                 type="text"
                 inputMode="numeric"
                 pattern="[0-9]*"

--- a/frontend/src/components/auth/invitation-accept-form.tsx
+++ b/frontend/src/components/auth/invitation-accept-form.tsx
@@ -185,9 +185,9 @@ export function InvitationAcceptForm({
 
       <div className="space-y-2 rounded-lg border border-gray-200 bg-gray-50 p-3">
         <div>
-          <label className="block text-xs font-medium text-gray-600">
+          <span className="block text-xs font-medium text-gray-600">
             Gültig bis
-          </label>
+          </span>
           <p className="mt-0.5 text-sm font-semibold text-gray-900">
             {new Date(invitation.expiresAt).toLocaleDateString("de-DE", {
               day: "2-digit",
@@ -200,9 +200,9 @@ export function InvitationAcceptForm({
         </div>
         {invitation.position && (
           <div>
-            <label className="block text-xs font-medium text-gray-600">
+            <span className="block text-xs font-medium text-gray-600">
               Zugewiesene Position
-            </label>
+            </span>
             <p className="mt-0.5 text-sm font-semibold text-gray-900">
               {invitation.position}
             </p>

--- a/frontend/src/components/guardians/guardian-form-modal.tsx
+++ b/frontend/src/components/guardians/guardian-form-modal.tsx
@@ -161,10 +161,14 @@ export default function GuardianFormModal({
           </h3>
           <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4">
             <div>
-              <label className="mb-1 block text-xs font-medium text-gray-700">
+              <label
+                htmlFor="guardian-first-name"
+                className="mb-1 block text-xs font-medium text-gray-700"
+              >
                 Vorname <span className="text-red-500">*</span>
               </label>
               <input
+                id="guardian-first-name"
                 type="text"
                 value={firstName}
                 onChange={(e) => setFirstName(e.target.value)}
@@ -176,10 +180,14 @@ export default function GuardianFormModal({
             </div>
 
             <div>
-              <label className="mb-1 block text-xs font-medium text-gray-700">
+              <label
+                htmlFor="guardian-last-name"
+                className="mb-1 block text-xs font-medium text-gray-700"
+              >
                 Nachname <span className="text-red-500">*</span>
               </label>
               <input
+                id="guardian-last-name"
                 type="text"
                 value={lastName}
                 onChange={(e) => setLastName(e.target.value)}
@@ -191,11 +199,15 @@ export default function GuardianFormModal({
             </div>
 
             <div>
-              <label className="mb-1 block text-xs font-medium text-gray-700">
+              <label
+                htmlFor="guardian-relationship-type"
+                className="mb-1 block text-xs font-medium text-gray-700"
+              >
                 Beziehung zum Kind
               </label>
               <div className="relative">
                 <select
+                  id="guardian-relationship-type"
                   value={relationshipType}
                   onChange={(e) => setRelationshipType(e.target.value)}
                   className="block w-full appearance-none rounded-lg border border-gray-200 bg-white px-3 py-2 pr-10 text-sm transition-colors focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8]"
@@ -311,6 +323,7 @@ export default function GuardianFormModal({
               onChange={(e) => setIsEmergencyContact(e.target.checked)}
               className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-600"
               disabled={isLoading}
+              aria-label="Als Notfallkontakt markieren"
             />
             <div className="flex items-center gap-2">
               <svg

--- a/frontend/src/components/teachers/teacher-permission-management-modal.tsx
+++ b/frontend/src/components/teachers/teacher-permission-management-modal.tsx
@@ -217,6 +217,7 @@ export function TeacherPermissionManagementModal({
                 checked={selectedPermissions.includes(permission.id)}
                 onChange={() => handleTogglePermission(permission.id)}
                 className="mr-3 h-4 w-4 rounded text-blue-600 focus:ring-blue-500"
+                aria-label={`Berechtigung ${permission.name} aktivieren`}
               />
               <div className="flex-1">
                 <div className="font-medium">{permission.name}</div>

--- a/frontend/src/lib/database/configs/teachers.config.tsx
+++ b/frontend/src/lib/database/configs/teachers.config.tsx
@@ -143,9 +143,9 @@ export const teachersConfig = defineEntityConfig<Teacher>({
             type: "custom",
             component: () => (
               <div>
-                <label className="mb-1 block text-xs font-medium text-gray-400 md:text-sm">
+                <span className="mb-1 block text-xs font-medium text-gray-400 md:text-sm">
                   RFID-Karte (Funktion nicht verfügbar)
-                </label>
+                </span>
                 <div className="w-full cursor-not-allowed rounded-lg border border-gray-200 bg-gray-100 px-3 py-2 text-sm text-gray-400 md:px-4 md:py-2 md:text-base">
                   RFID-Funktion deaktiviert
                 </div>


### PR DESCRIPTION
## Summary

- Add `htmlFor`/`id` associations to 18 form labels across 7 files
- Replace non-associated `<label>` elements with `<span>` for display-only text
- Add `aria-label` attributes for icon-only labels and checkboxes with nested text

## Files Changed

| File | Issues Fixed | Fix Type |
|------|-------------|----------|
| `students/[id]/page.tsx` | 9 | `htmlFor` + `id` associations |
| `guardian-form-modal.tsx` | 4 | `htmlFor` + `id` + `aria-label` |
| `substitutions/page.tsx` | 2 | `htmlFor` + `id` associations |
| `invitation-accept-form.tsx` | 2 | `<label>` → `<span>` for display text |
| `teachers.config.tsx` | 1 | `<label>` → `<span>` for disabled field |
| `settings/page.tsx` | 1 | `aria-label` for icon-only label |
| `teacher-permission-management-modal.tsx` | 1 | `aria-label` on checkbox |

## Why This Matters

Properly associated labels:
- Enable screen readers to announce what each input is for
- Make labels clickable to focus their associated input (larger tap targets on mobile)
- Pass accessibility audits (WCAG 2.1 Level A)

## Test Plan

- [x] `npm run check` passes (lint + typecheck)
- [ ] Verify forms still function correctly in browser
- [ ] Test with screen reader (VoiceOver/NVDA) to confirm labels are announced

Addresses SonarCloud S6853 form label issues.