### PR TITLE
fix: resolve ambiguous JSX spacing in student detail page

### DIFF
--- a/frontend/src/app/students/[id]/page.tsx
+++ b/frontend/src/app/students/[id]/page.tsx
@@ -1158,8 +1158,8 @@ export default function StudentDetailPage() {
                           student.sick ? (
                             <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                               <span className="inline-flex items-center gap-1.5 rounded-full bg-pink-100 px-2.5 py-1 text-xs font-medium text-pink-800">
-                                <span className="h-2 w-2 rounded-full bg-pink-500"></span>
-                                Krank gemeldet
+                                <span className="h-2 w-2 rounded-full bg-pink-500" />
+                                <span>Krank gemeldet</span>
                               </span>
                               {student.sick_since && (
                                 <span className="text-sm text-gray-500">
@@ -1172,8 +1172,8 @@ export default function StudentDetailPage() {
                             </div>
                           ) : (
                             <span className="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2.5 py-1 text-xs font-medium text-green-800">
-                              <span className="h-2 w-2 rounded-full bg-green-500"></span>
-                              Nicht krankgemeldet
+                              <span className="h-2 w-2 rounded-full bg-green-500" />
+                              <span>Nicht krankgemeldet</span>
                             </span>
                           )
                         }


### PR DESCRIPTION
## Summary
- Fixed SonarCloud S6772 violations (ambiguous spacing after previous element span) at lines 1161 and 1175 in `students/[id]/page.tsx`
- Wrapped status badge text in explicit `<span>` elements to eliminate ambiguous whitespace

## Changes
The "sick status" badges had text nodes directly following `<span>` elements with implicit whitespace:

```tsx
// Before (ambiguous whitespace between span and text)
<span className="inline-flex items-center gap-1.5 ...">
  <span className="h-2 w-2 rounded-full bg-pink-500"></span>
  Krank gemeldet
</span>

// After (explicit span wrapper for text)
<span className="inline-flex items-center gap-1.5 ...">
  <span className="h-2 w-2 rounded-full bg-pink-500" />
  <span>Krank gemeldet</span>
</span>
```

## Test plan
- [x] `npm run check` passes (0 warnings)
- [ ] SonarCloud scan confirms S6772 issues resolved