### PR TITLE
fix: resolve final accessibility issues in upload and toast components

### DIFF
--- a/frontend/src/components/import/upload-section.tsx
+++ b/frontend/src/components/import/upload-section.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 
 interface UploadSectionProps {
   readonly isDragging: boolean;
@@ -21,6 +21,18 @@ export function UploadSection({
   onDrop,
   onFileSelect,
 }: UploadSectionProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleZoneClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      fileInputRef.current?.click();
+    }
+  };
   return (
     <div className="rounded-xl border border-gray-100 bg-white p-6">
       <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-900">
@@ -40,24 +52,49 @@ export function UploadSection({
         Schritt 2: CSV- oder Excel-Datei hochladen
       </h3>
 
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".csv,.xlsx"
+        tabIndex={-1}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) onFileSelect(file);
+        }}
+        className="sr-only"
+        aria-label="Datei auswählen"
+      />
+
+      {/* Drop zone container with native button overlay for accessibility */}
       <div
-        onDragEnter={onDragEnter}
-        onDragLeave={onDragLeave}
-        onDragOver={onDragOver}
-        onDrop={onDrop}
         className={`relative rounded-xl border-2 border-dashed p-12 text-center transition-all duration-300 ${
           isDragging
             ? "border-green-500 bg-green-50"
             : "border-gray-300 bg-gray-50 hover:border-gray-400"
         }`}
+        onDragEnter={onDragEnter}
+        onDragLeave={onDragLeave}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
       >
+        {/* Native button overlay - handles click/keyboard, covers entire zone */}
+        <button
+          type="button"
+          onClick={handleZoneClick}
+          onKeyDown={handleKeyDown}
+          aria-label="Datei hochladen - ziehen Sie eine Datei hierher oder klicken Sie zum Auswählen"
+          className="absolute inset-0 z-10 cursor-pointer rounded-xl bg-transparent focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:outline-none"
+        />
+
+        {/* Visual content - non-interactive, pointer-events handled by button above */}
         {isLoading ? (
-          <div className="flex flex-col items-center gap-4">
+          <div className="pointer-events-none flex flex-col items-center gap-4">
             <div className="h-12 w-12 animate-spin rounded-full border-4 border-gray-300 border-t-green-600"></div>
             <p className="text-sm text-gray-600">Datei wird analysiert...</p>
           </div>
         ) : (
-          <div className="flex flex-col items-center gap-4">
+          <div className="pointer-events-none flex flex-col items-center gap-4">
             <svg
               className={`h-16 w-16 transition-colors ${isDragging ? "text-green-500" : "text-gray-400"}`}
               fill="none"
@@ -77,33 +114,22 @@ export function UploadSection({
               </p>
               <p className="text-sm text-gray-500">oder</p>
             </div>
-            <label className="cursor-pointer">
-              <span className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-6 py-3 text-white transition-colors hover:bg-gray-700">
-                <svg
-                  className="h-5 w-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
-                  />
-                </svg>
-                Datei auswählen
-              </span>
-              <input
-                type="file"
-                accept=".csv,.xlsx"
-                onChange={(e) => {
-                  const file = e.target.files?.[0];
-                  if (file) onFileSelect(file);
-                }}
-                className="hidden"
-              />
-            </label>
+            <span className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-6 py-3 text-white">
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
+                />
+              </svg>
+              Datei auswählen
+            </span>
             {uploadedFile && (
               <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm text-gray-600">
                 <svg

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -221,17 +221,21 @@ function ToastRow({
   return (
     <>
       {/* Mobile: Center-Overlay Modal Style - tap to dismiss */}
-      <div
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
+      <button
+        type="button"
+        aria-label={`${modalTitles[item.type]}: ${item.message}. Tippen zum Schließen`}
         aria-hidden={isDesktopRef.current}
         onClick={handleMobileDismiss}
-        className={`pointer-events-auto ${mobileStyles.bg} ${mobileStyles.border} rounded-2xl border shadow-lg backdrop-blur-sm transition-all md:hidden ${reducedMotion ? "" : "duration-300 ease-out"} w-full max-w-xs cursor-pointer ${
+        className={`pointer-events-auto ${mobileStyles.bg} ${mobileStyles.border} rounded-2xl border shadow-lg backdrop-blur-sm transition-all md:hidden ${reducedMotion ? "" : "duration-300 ease-out"} w-full max-w-xs cursor-pointer focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:outline-none ${
           visible && !exiting ? "scale-100 opacity-100" : "scale-95 opacity-0"
         }`}
       >
-        <div className="flex flex-col items-center gap-3 p-6 text-center">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="flex flex-col items-center gap-3 p-6 text-center"
+        >
           <div className={mobileStyles.iconColor}>
             <svg
               className="h-12 w-12"
@@ -256,7 +260,7 @@ function ToastRow({
             </p>
           </div>
         </div>
-      </div>
+      </button>
 
       {/* Desktop: Original bottom-right notification style */}
       <div


### PR DESCRIPTION
## Summary
- Convert upload drop zone `<div>` to semantic `<button>` element with keyboard accessibility
- Replace mobile toast interactive `<div>` with `<button>` element for proper ARIA semantics
- Add focus ring styles for keyboard navigation visibility

## Changes

### `upload-section.tsx`
- Changed drop zone from `<div>` to `<button type="button">` element
- Added `onClick` and `onKeyDown` handlers to trigger file input on click/Enter/Space
- Added `aria-label` describing the upload action in German
- Added focus ring styles for keyboard navigation
- Replaced nested `<label>` with `<span>` since outer button handles interaction
- Used `sr-only` class for hidden file input (screen reader accessible)

### `ToastContext.tsx`
- Changed mobile toast container from `<div>` to `<button type="button">`
- Moved `role="status"` and `aria-live="polite"` to inner container for proper ARIA live region
- Added dynamic `aria-label` with toast type and message in German
- Added focus ring styles for keyboard navigation

## Test plan
- [ ] Upload zone responds to keyboard (Tab to focus, Enter/Space to open file dialog)
- [ ] Drag-and-drop file upload still works
- [ ] Mobile toast can be dismissed via tap
- [ ] Toast announcements work with screen readers
- [ ] Focus styles visible when navigating with keyboard
- [ ] `npm run check` passes (verified)