### PR TITLE
fix: SonarCloud frontend type safety quick wins

### DIFF
--- a/frontend/src/app/database/students/page.tsx
+++ b/frontend/src/app/database/students/page.tsx
@@ -137,7 +137,7 @@ export default function StudentsPage() {
 
   // Load groups on mount
   useEffect(() => {
-    void fetchGroups();
+    fetchGroups().catch(console.error);
   }, [fetchGroups]);
 
   // Apply filters

--- a/frontend/src/components/guardians/guardian-form-modal.tsx
+++ b/frontend/src/components/guardians/guardian-form-modal.tsx
@@ -17,7 +17,6 @@ interface GuardianFormModalProps {
   ) => Promise<void>;
   readonly initialData?: GuardianWithRelationship;
   readonly mode: "create" | "edit";
-  readonly isSubmitting?: boolean;
 }
 
 export interface RelationshipFormData {

--- a/frontend/src/components/guardians/student-guardian-manager.tsx
+++ b/frontend/src/components/guardians/student-guardian-manager.tsx
@@ -39,7 +39,6 @@ export default function StudentGuardianManager({
   const [editingGuardian, setEditingGuardian] = useState<
     GuardianWithRelationship | undefined
   >();
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deletingGuardian, setDeletingGuardian] = useState<
     GuardianWithRelationship | undefined
@@ -73,23 +72,18 @@ export default function StudentGuardianManager({
     guardianData: GuardianFormData,
     relationshipData: RelationshipFormData,
   ) => {
-    setIsSubmitting(true);
-    try {
-      // Create guardian profile
-      const newGuardian = await createGuardian(guardianData);
+    // Create guardian profile
+    const newGuardian = await createGuardian(guardianData);
 
-      // Link to student
-      await linkGuardianToStudent(studentId, {
-        guardianProfileId: newGuardian.id,
-        ...relationshipData,
-      });
+    // Link to student
+    await linkGuardianToStudent(studentId, {
+      guardianProfileId: newGuardian.id,
+      ...relationshipData,
+    });
 
-      // Reload guardians
-      await loadGuardians();
-      onUpdate?.();
-    } finally {
-      setIsSubmitting(false);
-    }
+    // Reload guardians
+    await loadGuardians();
+    onUpdate?.();
   };
 
   // Handle edit guardian
@@ -99,24 +93,19 @@ export default function StudentGuardianManager({
   ) => {
     if (!editingGuardian) return;
 
-    setIsSubmitting(true);
-    try {
-      // Update guardian profile
-      await updateGuardian(editingGuardian.id, guardianData);
+    // Update guardian profile
+    await updateGuardian(editingGuardian.id, guardianData);
 
-      // Update relationship
-      await updateStudentGuardianRelationship(
-        editingGuardian.relationshipId,
-        relationshipData,
-      );
+    // Update relationship
+    await updateStudentGuardianRelationship(
+      editingGuardian.relationshipId,
+      relationshipData,
+    );
 
-      // Reload guardians
-      await loadGuardians();
-      onUpdate?.();
-      setEditingGuardian(undefined);
-    } finally {
-      setIsSubmitting(false);
-    }
+    // Reload guardians
+    await loadGuardians();
+    onUpdate?.();
+    setEditingGuardian(undefined);
   };
 
   // Handle delete guardian - open confirmation modal
@@ -270,7 +259,6 @@ export default function StudentGuardianManager({
         onSubmit={editingGuardian ? handleEditGuardian : handleCreateGuardian}
         initialData={editingGuardian}
         mode={editingGuardian ? "edit" : "create"}
-        isSubmitting={isSubmitting}
       />
 
       {/* Delete Confirmation Modal */}

--- a/frontend/src/components/ui/database/database-select.tsx
+++ b/frontend/src/components/ui/database/database-select.tsx
@@ -228,7 +228,9 @@ function EntitySelect({ entityType, filters, ...props }: EntitySelectProps) {
  * Convenience components for specific entity types
  */
 
-export function GroupSelect(props: Omit<EntitySelectProps, "entityType">) {
+export function GroupSelect(
+  props: Readonly<Omit<EntitySelectProps, "entityType">>,
+) {
   return (
     <EntitySelect
       {...props}


### PR DESCRIPTION
## Summary
- Mark GroupSelect props as `Readonly<>` to ensure prop immutability (S6759)
- Remove unused `isSubmitting` prop from GuardianFormModal (S6767)
- Clean up redundant `isSubmitting` state from StudentGuardianManager
- Replace void operator with proper `.catch()` error handling (S3735)

## Files Changed
- `frontend/src/components/ui/database/database-select.tsx` - Readonly props
- `frontend/src/components/guardians/guardian-form-modal.tsx` - Remove unused prop
- `frontend/src/components/guardians/student-guardian-manager.tsx` - Clean up unused state
- `frontend/src/app/database/students/page.tsx` - Replace void operator

## Test plan
- [x] `npm run check` passes with zero warnings
- [ ] Verify guardian form modal still works (create/edit guardians)
- [ ] Verify student list page loads groups correctly