### PR TITLE
fix: extract nested ternaries in UI components

### DIFF
--- a/frontend/src/app/database/page.tsx
+++ b/frontend/src/app/database/page.tsx
@@ -291,9 +291,10 @@ function DatabaseContent() {
             const countKey =
               section.id === "permissions" ? "permissionCount" : section.id;
             const count = counts[countKey as keyof typeof counts] ?? 0;
+            const entryLabel = count === 1 ? "Eintrag" : "Einträge";
             const countText = countsLoading
               ? "Lade..."
-              : `${count} ${count === 1 ? "Eintrag" : "Einträge"}`;
+              : `${count} ${entryLabel}`;
 
             return (
               <Link

--- a/frontend/src/app/rooms/[id]/page.tsx
+++ b/frontend/src/app/rooms/[id]/page.tsx
@@ -223,12 +223,17 @@ export default function RoomDetailPage() {
           const historyResponseData = (await historyResponse.json()) as
             | BackendRoomHistoryEntry[]
             | { data: BackendRoomHistoryEntry[] };
-          const backendHistoryEntries = Array.isArray(historyResponseData)
-            ? historyResponseData
-            : historyResponseData?.data &&
-                Array.isArray(historyResponseData.data)
-              ? historyResponseData.data
-              : [];
+          // Extract history entries from response (handles both array and wrapped formats)
+          const backendHistoryEntries = (() => {
+            if (Array.isArray(historyResponseData)) return historyResponseData;
+            if (
+              historyResponseData?.data &&
+              Array.isArray(historyResponseData.data)
+            ) {
+              return historyResponseData.data;
+            }
+            return [];
+          })();
 
           const frontendHistoryEntries = backendHistoryEntries.map(
             (entry: BackendRoomHistoryEntry) =>

--- a/frontend/src/app/students/[id]/feedback_history/page.tsx
+++ b/frontend/src/app/students/[id]/feedback_history/page.tsx
@@ -39,6 +39,13 @@ interface FeedbackEntry {
   is_valid?: boolean; // Neue Eigenschaft für die Validität
 }
 
+// Feedback type display labels
+const feedbackTypeLabels: Record<FeedbackEntry["feedback_type"], string> = {
+  positive: "Positives Feedback",
+  neutral: "Neutrales Feedback",
+  negative: "Negatives Feedback",
+};
+
 export default function StudentFeedbackHistoryPage() {
   const router = useRouter();
   const params = useParams();
@@ -505,11 +512,7 @@ export default function StudentFeedbackHistoryPage() {
                             {renderFeedbackEmoji(feedback.feedback_type)}
                             <div className="flex flex-col">
                               <span className="font-medium text-gray-900">
-                                {feedback.feedback_type === "positive"
-                                  ? "Positives Feedback"
-                                  : feedback.feedback_type === "neutral"
-                                    ? "Neutrales Feedback"
-                                    : "Negatives Feedback"}
+                                {feedbackTypeLabels[feedback.feedback_type]}
                                 <span className="ml-2 text-sm text-gray-500">
                                   {formatTime(feedback.timestamp)}
                                 </span>

--- a/frontend/src/components/guardians/guardian-form-modal.tsx
+++ b/frontend/src/components/guardians/guardian-form-modal.tsx
@@ -360,34 +360,35 @@ export default function GuardianFormModal({
             disabled={isLoading}
             className="flex-1 rounded-lg bg-gray-900 px-3 py-2 text-xs font-medium text-white transition-all duration-200 hover:bg-gray-700 hover:shadow-lg active:scale-100 disabled:cursor-not-allowed disabled:opacity-50 md:px-4 md:text-sm md:hover:scale-105"
           >
-            {isLoading ? (
-              <span className="flex items-center justify-center gap-2">
-                <svg
-                  className="h-4 w-4 animate-spin text-white"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  />
-                </svg>
-                Wird gespeichert...
-              </span>
-            ) : mode === "create" ? (
-              "Hinzufügen"
-            ) : (
-              "Speichern"
-            )}
+            {(() => {
+              if (isLoading) {
+                return (
+                  <span className="flex items-center justify-center gap-2">
+                    <svg
+                      className="h-4 w-4 animate-spin text-white"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      />
+                    </svg>
+                    Wird gespeichert...
+                  </span>
+                );
+              }
+              return mode === "create" ? "Hinzufügen" : "Speichern";
+            })()}
           </button>
         </div>
       </form>

--- a/frontend/src/components/ui/form-modal.tsx
+++ b/frontend/src/components/ui/form-modal.tsx
@@ -110,13 +110,11 @@ export function FormModal({
       />
       {/* Dialog container */}
       <div
-        className={`relative w-full ${sizeClasses[size]} ${mobilePosition === "bottom" ? "h-full" : "h-auto"} max-h-[90vh] md:h-auto md:max-h-[85vh] ${radiusClass} ${mobilePosition === "center" ? "mx-4" : ""} transform overflow-hidden border border-gray-200/50 shadow-2xl ${
-          isAnimating && !isExiting
-            ? "animate-modalEnter"
-            : isExiting
-              ? "animate-modalExit"
-              : "translate-y-8 scale-75 -rotate-1 opacity-0"
-        }`}
+        className={`relative w-full ${sizeClasses[size]} ${mobilePosition === "bottom" ? "h-full" : "h-auto"} max-h-[90vh] md:h-auto md:max-h-[85vh] ${radiusClass} ${mobilePosition === "center" ? "mx-4" : ""} transform overflow-hidden border border-gray-200/50 shadow-2xl ${(() => {
+          if (isAnimating && !isExiting) return "animate-modalEnter";
+          if (isExiting) return "animate-modalExit";
+          return "translate-y-8 scale-75 -rotate-1 opacity-0";
+        })()}`}
         {...dialogAriaProps}
         style={{
           background:


### PR DESCRIPTION
## Summary
Extracts 5 nested ternary operations across UI components for improved readability:

- **form-modal.tsx**: Animation state logic extracted to IIFE with early returns
- **guardian-form-modal.tsx**: Button content (loading/create/edit) extracted to IIFE
- **rooms/[id]/page.tsx**: Response parsing logic extracted to IIFE for clarity
- **feedback_history/page.tsx**: Feedback type labels moved to lookup object
- **database/page.tsx**: Entry label computed separately before countText

## Test Plan
- [x] `npm run check` passes (lint + typecheck)
- [ ] Form modals render correctly (create/edit modes)
- [ ] Room detail page displays history properly
- [ ] Feedback history shows correct type labels
- [ ] Database page displays entry counts correctly

Resolves SonarCloud S3358 violations