### PR TITLE
fix: SonarCloud quick wins batch 2

### DIFF
--- a/backend/api/auth/invitation_handlers.go
+++ b/backend/api/auth/invitation_handlers.go
@@ -27,7 +27,7 @@ type CreateInvitationRequest struct {
 	Position  string `json:"position"`
 }
 
-func (req *CreateInvitationRequest) Bind(r *http.Request) error {
+func (req *CreateInvitationRequest) Bind(_ *http.Request) error {
 	req.Email = strings.TrimSpace(strings.ToLower(req.Email))
 	req.FirstName = strings.TrimSpace(req.FirstName)
 	req.LastName = strings.TrimSpace(req.LastName)
@@ -164,7 +164,7 @@ type AcceptInvitationRequest struct {
 	ConfirmPassword string `json:"confirm_password"`
 }
 
-func (req *AcceptInvitationRequest) Bind(r *http.Request) error {
+func (req *AcceptInvitationRequest) Bind(_ *http.Request) error {
 	req.FirstName = strings.TrimSpace(req.FirstName)
 	req.LastName = strings.TrimSpace(req.LastName)
 

--- a/backend/api/guardians/handlers.go
+++ b/backend/api/guardians/handlers.go
@@ -94,7 +94,7 @@ type StudentGuardianUpdateRequest struct {
 }
 
 // Bind validates the student-guardian update request
-func (req *StudentGuardianUpdateRequest) Bind(r *http.Request) error {
+func (req *StudentGuardianUpdateRequest) Bind(_ *http.Request) error {
 	// All fields are optional for update
 	return nil
 }
@@ -133,7 +133,7 @@ type GuardianWithRelationship struct {
 }
 
 // Bind validates the guardian create request
-func (req *GuardianCreateRequest) Bind(r *http.Request) error {
+func (req *GuardianCreateRequest) Bind(_ *http.Request) error {
 	if req.FirstName == "" {
 		return errors.New("first_name is required")
 	}
@@ -150,7 +150,7 @@ func (req *GuardianCreateRequest) Bind(r *http.Request) error {
 }
 
 // Bind validates the guardian update request
-func (req *GuardianUpdateRequest) Bind(r *http.Request) error {
+func (req *GuardianUpdateRequest) Bind(_ *http.Request) error {
 	if req.FirstName != nil && *req.FirstName == "" {
 		return errors.New("first_name cannot be empty")
 	}
@@ -161,7 +161,7 @@ func (req *GuardianUpdateRequest) Bind(r *http.Request) error {
 }
 
 // Bind validates the student-guardian link request
-func (req *StudentGuardianLinkRequest) Bind(r *http.Request) error {
+func (req *StudentGuardianLinkRequest) Bind(_ *http.Request) error {
 	if req.GuardianProfileID == 0 {
 		return errors.New("guardian_profile_id is required")
 	}
@@ -845,7 +845,7 @@ type GuardianInvitationAcceptRequest struct {
 }
 
 // Bind validates the invitation accept request
-func (req *GuardianInvitationAcceptRequest) Bind(r *http.Request) error {
+func (req *GuardianInvitationAcceptRequest) Bind(_ *http.Request) error {
 	if req.Password == "" {
 		return errors.New("password is required")
 	}

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -470,7 +470,7 @@ func resolveScheduledCheckoutFromSnapshot(snapshot *common.StudentDataSnapshot, 
 
 // newStudentResponseFromSnapshot creates a student response using pre-loaded snapshot data
 // This eliminates N+1 queries by using cached person, group, and scheduled checkout data
-func newStudentResponseFromSnapshot(ctx context.Context, student *users.Student, person *users.Person, group *education.Group, hasFullAccess bool, snapshot *common.StudentDataSnapshot) StudentResponse {
+func newStudentResponseFromSnapshot(_ context.Context, student *users.Student, person *users.Person, group *education.Group, hasFullAccess bool, snapshot *common.StudentDataSnapshot) StudentResponse {
 	response := StudentResponse{
 		ID:          student.ID,
 		PersonID:    student.PersonID,

--- a/backend/cmd/cleanup.go
+++ b/backend/cmd/cleanup.go
@@ -469,7 +469,7 @@ func runCleanupTokens(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runCleanupInvitations(cmd *cobra.Command, args []string) error {
+func runCleanupInvitations(_ *cobra.Command, _ []string) error {
 	db, err := database.InitDB()
 	if err != nil {
 		return fmt.Errorf("failed to initialize database: %w", err)
@@ -501,7 +501,7 @@ func runCleanupInvitations(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runCleanupRateLimits(cmd *cobra.Command, args []string) error {
+func runCleanupRateLimits(_ *cobra.Command, _ []string) error {
 	db, err := database.InitDB()
 	if err != nil {
 		return fmt.Errorf("failed to initialize database: %w", err)

--- a/backend/services/auth/auth_service.go
+++ b/backend/services/auth/auth_service.go
@@ -435,7 +435,7 @@ func (s *Service) logFailedLogin(ctx context.Context, accountID int64, ipAddress
 }
 
 // Register creates a new user account
-func (s *Service) Register(ctx context.Context, email, username, name, password string, roleID *int64) (*auth.Account, error) {
+func (s *Service) Register(ctx context.Context, email, username, _ /* name */, password string, roleID *int64) (*auth.Account, error) {
 	// Validate and normalize registration inputs
 	if err := s.validateRegistrationInputs(ctx, email, username, password); err != nil {
 		return nil, err

--- a/frontend/src/app/activities/[id]/page.tsx
+++ b/frontend/src/app/activities/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState, Suspense } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { PageHeader } from "@/components/dashboard";
-import type { Activity, ActivityStudent } from "@/lib/activity-helpers";
 import {
   fetchActivity,
   getEnrolledStudents,
@@ -12,6 +11,8 @@ import {
 import {
   getActivityCategoryColor,
   getWeekdayFullName,
+  type Activity,
+  type ActivityStudent,
   type Timeframe,
 } from "@/lib/activity-helpers";
 

--- a/frontend/src/components/dashboard/mobile-bottom-nav.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.tsx
@@ -2,10 +2,9 @@
 // Ultra-minimalist mobile navigation following Instagram/Twitter/Uber patterns
 "use client";
 
-import React, { useRef, useCallback } from "react";
+import React, { useRef, useCallback, useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
-import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { useSupervision } from "~/lib/supervision-context";
 import { isAdmin } from "~/lib/auth-utils";

--- a/frontend/src/components/ui/page-header/types.ts
+++ b/frontend/src/components/ui/page-header/types.ts
@@ -90,33 +90,33 @@ export interface PageHeaderProps {
 }
 
 export interface SearchBarProps {
-  value: string;
-  onChange: (value: string) => void;
-  placeholder?: string;
-  onClear?: () => void;
-  className?: string;
-  size?: "sm" | "md" | "lg";
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly placeholder?: string;
+  readonly onClear?: () => void;
+  readonly className?: string;
+  readonly size?: "sm" | "md" | "lg";
 }
 
 export interface MobileFilterPanelProps {
-  isOpen: boolean;
-  onClose: () => void;
-  filters: FilterConfig[];
-  onApply?: () => void;
-  onReset?: () => void;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly filters: FilterConfig[];
+  readonly onApply?: () => void;
+  readonly onReset?: () => void;
 }
 
 export interface ActiveFilterChipsProps {
-  filters: ActiveFilter[];
-  onClearAll?: () => void;
-  className?: string;
+  readonly filters: ActiveFilter[];
+  readonly onClearAll?: () => void;
+  readonly className?: string;
 }
 
 export interface NavigationTabsProps {
-  items: TabItem[];
-  activeTab: string;
-  onTabChange: (tabId: string) => void;
-  className?: string;
+  readonly items: TabItem[];
+  readonly activeTab: string;
+  readonly onTabChange: (tabId: string) => void;
+  readonly className?: string;
 }
 
 /**

--- a/frontend/src/lib/database/configs/activities.config.tsx
+++ b/frontend/src/lib/database/configs/activities.config.tsx
@@ -2,10 +2,7 @@
 
 import { defineEntityConfig } from "../types";
 import { databaseThemes } from "@/components/ui/database/themes";
-import type { Activity } from "@/lib/activity-helpers";
-
-// Import the correct type from activity helpers
-import type { ActivitySupervisor } from "@/lib/activity-helpers";
+import type { Activity, ActivitySupervisor } from "@/lib/activity-helpers";
 import { getSession } from "next-auth/react";
 
 export const activitiesConfig = defineEntityConfig<Activity>({

--- a/frontend/src/lib/profile-context.tsx
+++ b/frontend/src/lib/profile-context.tsx
@@ -29,7 +29,9 @@ const ProfileContext = createContext<ProfileContextType | undefined>(undefined);
  *
  * Pattern inspired by SupervisionProvider for consistency
  */
-export function ProfileProvider({ children }: { children: React.ReactNode }) {
+export function ProfileProvider({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
   const { data: session } = useSession();
 
   const [state, setState] = useState<ProfileState>({

--- a/frontend/src/lib/supervision-context.tsx
+++ b/frontend/src/lib/supervision-context.tsx
@@ -46,9 +46,9 @@ const SupervisionContext = createContext<SupervisionContextType | undefined>(
  */
 export function SupervisionProvider({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
+}>) {
   const { data: session } = useSession();
 
   const [state, setState] = useState<SupervisionState>({


### PR DESCRIPTION
## Summary
- Replace unused handler params with blank identifier in backend Go files (~13 issues across 5 files)
- Mark component props as readonly in frontend TypeScript interfaces (6 locations)
- Remove duplicate import statements (3 files)

## Changes

### Backend (Go)
| File | Fix |
|------|-----|
| `api/guardians/handlers.go` | 5 unused `r *http.Request` params in Bind methods |
| `api/auth/invitation_handlers.go` | 2 unused params in Bind methods |
| `cmd/cleanup.go` | 4 unused `cmd, args` params in run functions |
| `api/students/api.go` | 1 unused `ctx` param |
| `services/auth/auth_service.go` | 1 unused `name` param in Register |

### Frontend (TypeScript)
| File | Fix |
|------|-----|
| `components/ui/page-header/types.ts` | Added `readonly` to 4 interface props |
| `lib/profile-context.tsx` | Wrapped props with `Readonly<>` |
| `lib/supervision-context.tsx` | Wrapped props with `Readonly<>` |
| `app/activities/[id]/page.tsx` | Consolidated duplicate imports |
| `lib/database/configs/activities.config.tsx` | Consolidated duplicate imports |
| `components/dashboard/mobile-bottom-nav.tsx` | Consolidated duplicate imports |

## Test Plan
- [x] golangci-lint passes
- [x] npm run check passes
- [ ] CI passes