### PR TITLE
fix: frontend quick wins batch 3

### DIFF
--- a/frontend/src/app/api/invitations/[id]/resend/route.ts
+++ b/frontend/src/app/api/invitations/[id]/resend/route.ts
@@ -11,7 +11,7 @@ export const POST = createPostHandler<null, Record<string, never>>(
   ) => {
     const rawId = params.id ?? params.invitationId;
     if (typeof rawId !== "string" && typeof rawId !== "number") {
-      throw new Error("Missing invitation id");
+      throw new TypeError("Missing invitation id");
     }
 
     const invitationId = String(rawId);

--- a/frontend/src/app/api/invitations/[id]/route.ts
+++ b/frontend/src/app/api/invitations/[id]/route.ts
@@ -10,7 +10,7 @@ export const DELETE = createDeleteHandler<null>(
   ) => {
     const rawId = params.id ?? params.invitationId;
     if (typeof rawId !== "string" && typeof rawId !== "number") {
-      throw new Error("Missing invitation id");
+      throw new TypeError("Missing invitation id");
     }
 
     const invitationId = String(rawId);

--- a/frontend/src/app/api/invitations/route.ts
+++ b/frontend/src/app/api/invitations/route.ts
@@ -69,7 +69,7 @@ export const POST = createPostHandler<
     const roleId = body.role_id ?? body.roleId;
 
     if (typeof roleId !== "number") {
-      throw new Error("Invalid invitation payload: role id missing");
+      throw new TypeError("Invalid invitation payload: role id missing");
     }
 
     const payload: BackendCreateInvitationPayload = {

--- a/frontend/src/app/database/students/page.tsx
+++ b/frontend/src/app/database/students/page.tsx
@@ -84,7 +84,7 @@ export default function StudentsPage() {
 
   // Load students on mount
   useEffect(() => {
-    void fetchStudents();
+    fetchStudents().catch(console.error);
   }, [fetchStudents]);
 
   // Fetch all groups for the dropdown

--- a/frontend/src/app/rooms/[id]/page.tsx
+++ b/frontend/src/app/rooms/[id]/page.tsx
@@ -149,7 +149,7 @@ function mapBackendToFrontendHistoryEntry(
 }
 
 // Status Badge Component
-function StatusBadge({ isOccupied }: { isOccupied: boolean }) {
+function StatusBadge({ isOccupied }: Readonly<{ isOccupied: boolean }>) {
   return (
     <span
       className={`inline-flex items-center rounded-full px-3 py-1.5 text-xs font-semibold ${

--- a/frontend/src/components/admin/invitation-form.tsx
+++ b/frontend/src/components/admin/invitation-form.tsx
@@ -75,8 +75,8 @@ export function InvitationForm({ onCreated }: InvitationFormProps) {
   }, []);
 
   const inviteBaseUrl = useMemo(() => {
-    if (typeof window !== "undefined") {
-      return window.location.origin;
+    if (typeof globalThis !== "undefined" && "location" in globalThis) {
+      return globalThis.location.origin;
     }
     return "";
   }, []);

--- a/frontend/src/components/admin/pending-invitations-list.tsx
+++ b/frontend/src/components/admin/pending-invitations-list.tsx
@@ -22,9 +22,6 @@ export function PendingInvitationsList({
   const [invitations, setInvitations] = useState<PendingInvitation[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  // Local inline success feedback removed in favor of global toasts
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [feedback, setFeedback] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<number | null>(null);
   const [revokeTarget, setRevokeTarget] = useState<PendingInvitation | null>(
     null,
@@ -54,7 +51,6 @@ export function PendingInvitationsList({
   }, [loadInvitations, refreshKey]);
 
   const handleResend = async (id: number) => {
-    setFeedback(null);
     setError(null);
     try {
       setActionLoading(id);
@@ -74,7 +70,6 @@ export function PendingInvitationsList({
 
   const handleRevoke = async () => {
     if (!revokeTarget) return;
-    setFeedback(null);
     setError(null);
     try {
       setActionLoading(revokeTarget.id);

--- a/frontend/src/components/guardians/guardian-list.tsx
+++ b/frontend/src/components/guardians/guardian-list.tsx
@@ -148,11 +148,11 @@ function InfoItem({
   label,
   value,
   icon,
-}: {
+}: Readonly<{
   label: string;
   value: string;
   icon?: React.ReactNode;
-}) {
+}>) {
   return (
     <div className="min-w-0">
       <div className="mb-1 flex items-center gap-1 text-xs text-gray-500">

--- a/frontend/src/components/ui/database/database-form.tsx
+++ b/frontend/src/components/ui/database/database-form.tsx
@@ -223,16 +223,16 @@ export interface FormSection {
 }
 
 export interface DatabaseFormProps<T = Record<string, unknown>> {
-  theme: DatabaseTheme;
-  sections: FormSection[];
-  onSubmit: (data: T) => Promise<void>;
-  onCancel: () => void;
-  initialData?: Partial<T>;
-  isLoading?: boolean;
-  error?: string | null;
-  submitLabel: string;
-  submitButtonGradient?: string; // Override default gradient
-  stickyActions?: boolean; // Render sticky action bar like other entity forms
+  readonly theme: DatabaseTheme;
+  readonly sections: FormSection[];
+  readonly onSubmit: (data: T) => Promise<void>;
+  readonly onCancel: () => void;
+  readonly initialData?: Partial<T>;
+  readonly isLoading?: boolean;
+  readonly error?: string | null;
+  readonly submitLabel: string;
+  readonly submitButtonGradient?: string; // Override default gradient
+  readonly stickyActions?: boolean; // Render sticky action bar like other entity forms
 }
 
 export function DatabaseForm<T = Record<string, unknown>>({

--- a/frontend/src/components/ui/location-badge.tsx
+++ b/frontend/src/components/ui/location-badge.tsx
@@ -38,16 +38,16 @@ function formatLocationSince(
 }
 
 export interface LocationBadgeProps {
-  student: StudentLocationContext;
-  displayMode: DisplayMode;
-  userGroups?: string[];
-  groupRooms?: string[]; // Räume der eigenen OGS-Gruppen (für grüne Farbe)
-  supervisedRooms?: string[];
-  isGroupRoom?: boolean;
-  variant?: "simple" | "modern";
-  size?: "sm" | "md" | "lg";
+  readonly student: StudentLocationContext;
+  readonly displayMode: DisplayMode;
+  readonly userGroups?: string[];
+  readonly groupRooms?: string[]; // Räume der eigenen OGS-Gruppen (für grüne Farbe)
+  readonly supervisedRooms?: string[];
+  readonly isGroupRoom?: boolean;
+  readonly variant?: "simple" | "modern";
+  readonly size?: "sm" | "md" | "lg";
   /** Show "seit XX:XX Uhr" below the badge for Anwesend/Zuhause status. Default: false */
-  showLocationSince?: boolean;
+  readonly showLocationSince?: boolean;
 }
 
 const MODERN_BASE_CLASS =

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -137,11 +137,11 @@ function ToastRow({
   item,
   onClose,
   reducedMotion,
-}: {
+}: Readonly<{
   item: ToastItemData;
   onClose: (id: string) => void;
   reducedMotion: boolean;
-}) {
+}>) {
   const mobileStyles = mobileStylesByType[item.type];
   const desktopStyles = desktopStylesByType[item.type];
 
@@ -313,7 +313,9 @@ function ToastRow({
   );
 }
 
-export function ToastProvider({ children }: { children: React.ReactNode }) {
+export function ToastProvider({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
   const [items, setItems] = useState<ToastItemData[]>([]);
   const reducedMotion = useReducedMotion();
 

--- a/frontend/src/lib/database/configs/permissions.config.tsx
+++ b/frontend/src/lib/database/configs/permissions.config.tsx
@@ -23,12 +23,12 @@ function PermissionSelectorField({
   value,
   onChange,
   required,
-}: {
+}: Readonly<{
   value: unknown;
   onChange: (value: unknown) => void;
   label: string;
   required?: boolean;
-}) {
+}>) {
   // Extract resource and action from the form value
   const selectorValue: PermissionSelectorValue | undefined =
     value && typeof value === "object" && "resource" in value


### PR DESCRIPTION
## Summary
~15 quick fixes across frontend components addressing SonarCloud rules:

- **S6759 Readonly Props** (7 files): Added `readonly` modifiers to component props
  - `DatabaseFormProps`, `LocationBadgeProps`, `ToastRow`, `ToastProvider`
  - `InfoItem`, `StatusBadge`, `PermissionSelectorField`
  
- **S3735 Void Operator** (1 file): Replaced `void fetchStudents()` with `.catch(console.error)`

- **S7786 TypeError** (3 files): Changed `throw new Error()` to `throw new TypeError()` for type validation in invitation routes

- **S7764 globalThis** (1 file): Replaced `window` with `globalThis` in invitation-form

- **S1854 Unused Variable** (1 file): Removed unused `feedback` state in pending-invitations-list

## Test Plan
- [x] `npm run check` passes (lint + typecheck)
- [ ] SonarCloud analysis confirms fixes