### PR TITLE
refactor: major complexity reduction in SSE handler (48→12)

### DIFF
--- a/backend/api/sse/api.go
+++ b/backend/api/sse/api.go
@@ -33,14 +33,14 @@ func (rs *Resource) eventsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	// Step 1: Setup SSE connection (headers, flusher validation)
-	conn, statusCode := rs.setupSSEConnection(w, r)
+	conn, statusCode := rs.setupSSEConnection(w)
 	if conn == nil {
 		http.Error(w, "Streaming unsupported", statusCode)
 		return
 	}
 
 	// Step 2: Resolve staff member from JWT claims
-	staff, errMsg, statusCode := rs.resolveStaff(ctx, r)
+	staff, errMsg, statusCode := rs.resolveStaff(ctx)
 	if staff == nil {
 		http.Error(w, errMsg, statusCode)
 		return
@@ -56,7 +56,7 @@ func (rs *Resource) eventsHandler(w http.ResponseWriter, r *http.Request) {
 	conn.topics = topics
 
 	// Step 4: Send initial "connected" event
-	if err := conn.sendConnectedEvent(topics); err != nil {
+	if conn.sendConnectedEvent(topics) != nil {
 		http.Error(w, "Failed to initialize SSE stream", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary

Reduces cognitive complexity of the `eventsHandler` function from 48 to approximately 12 through systematic decomposition into focused helper functions.

## Approach

### Before (48 complexity)
```go
func (rs *Resource) eventsHandler(w http.ResponseWriter, r *http.Request) {
    // 236 lines with deeply nested conditionals
    // Multiple responsibilities mixed together
    // Hard to test individual components
}
```

### After (~12 complexity)
```go
func (rs *Resource) eventsHandler(w http.ResponseWriter, r *http.Request) {
    // Step 1: Setup SSE connection
    conn, statusCode := rs.setupSSEConnection(w, r)
    
    // Step 2: Resolve staff member from JWT
    staff, errMsg, statusCode := rs.resolveStaff(ctx, r)
    
    // Step 3: Build subscription topics
    topics, err := rs.buildSubscriptionTopics(ctx, staff.ID)
    
    // Step 4: Send initial "connected" event
    conn.sendConnectedEvent(topics)
    
    // Step 5-6: Run appropriate event loop
    if len(topics.allTopics) == 0 {
        conn.runHeartbeatOnlyLoop(ctx)
    } else {
        rs.createAndRegisterClient(conn)
        rs.runEventLoop(ctx, conn)
    }
}
```

## Extracted Components

| Function | Responsibility |
|----------|----------------|
| `setupSSEConnection` | Validates flusher, sets SSE headers |
| `resolveStaff` | JWT claims → person → staff resolution |
| `buildSubscriptionTopics` | Builds active group + edu group topic lists |
| `sendConnectedEvent` | Marshals and sends initial event |
| `runHeartbeatOnlyLoop` | Handles no-subscription case |
| `runEventLoop` | Main event streaming with heartbeat |
| `sendEvent` | Marshals and sends single SSE event |
| `sendHeartbeat` | Sends keepalive comment |
| `writeSSEMessage` | Low-level SSE message formatting |

## Files Changed

- `api/sse/api.go` - Simplified to 6-step orchestrator (236 → 75 lines)
- `api/sse/sse_helpers.go` - New file with extracted helpers (~280 lines)

## Test Plan

- [x] `go build ./...` passes
- [x] `golangci-lint run ./api/sse/...` passes (0 issues)
- [ ] SSE connections work in browser
- [ ] Real-time updates flow correctly
- [ ] Heartbeat keeps connection alive
- [ ] No connection stability issues