### PR TITLE
fix(frontend): mark page header component props as readonly (S6759)

### DIFF
--- a/frontend/src/components/ui/page-header/types.ts
+++ b/frontend/src/components/ui/page-header/types.ts
@@ -2,91 +2,91 @@
 
 export interface PageHeaderWithSearchProps {
   // Header configuration
-  title: string;
-  badge?: {
-    icon?: React.ReactNode;
-    count: number;
-    label?: string;
+  readonly title: string;
+  readonly badge?: {
+    readonly icon?: React.ReactNode;
+    readonly count: number;
+    readonly label?: string;
   };
-  statusIndicator?: {
-    color: "green" | "yellow" | "red" | "gray";
-    tooltip?: string;
+  readonly statusIndicator?: {
+    readonly color: "green" | "yellow" | "red" | "gray";
+    readonly tooltip?: string;
   };
 
   // Optional navigation tabs (like in OGS groups or MyRoom)
-  tabs?: {
-    items: TabItem[];
-    activeTab: string;
-    onTabChange: (tabId: string) => void;
+  readonly tabs?: {
+    readonly items: TabItem[];
+    readonly activeTab: string;
+    readonly onTabChange: (tabId: string) => void;
   };
 
   // Search configuration
-  search?: {
-    value: string;
-    onChange: (value: string) => void;
-    placeholder?: string;
-    className?: string;
+  readonly search?: {
+    readonly value: string;
+    readonly onChange: (value: string) => void;
+    readonly placeholder?: string;
+    readonly className?: string;
   };
 
   // Filter configuration
-  filters?: FilterConfig[];
+  readonly filters?: FilterConfig[];
 
   // Active filters for display
-  activeFilters?: ActiveFilter[];
-  onClearAllFilters?: () => void;
+  readonly activeFilters?: ActiveFilter[];
+  readonly onClearAllFilters?: () => void;
 
   // Custom action buttons
-  actionButton?: React.ReactNode; // Desktop action button (shown in tab row with full styling)
-  mobileActionButton?: React.ReactNode; // Mobile action button (compact version in tab row)
+  readonly actionButton?: React.ReactNode; // Desktop action button (shown in tab row with full styling)
+  readonly mobileActionButton?: React.ReactNode; // Mobile action button (compact version in tab row)
 
   // Layout options
-  className?: string;
+  readonly className?: string;
 }
 
 export interface TabItem {
-  id: string;
-  label: string;
-  count?: number;
+  readonly id: string;
+  readonly label: string;
+  readonly count?: number;
 }
 
 export interface FilterConfig {
-  id: string;
-  label: string;
-  type: "buttons" | "grid" | "dropdown";
-  value: string | string[];
-  onChange: (value: string | string[]) => void;
-  options: FilterOption[];
-  multiSelect?: boolean;
-  className?: string;
+  readonly id: string;
+  readonly label: string;
+  readonly type: "buttons" | "grid" | "dropdown";
+  readonly value: string | string[];
+  readonly onChange: (value: string | string[]) => void;
+  readonly options: FilterOption[];
+  readonly multiSelect?: boolean;
+  readonly className?: string;
 }
 
 export interface FilterOption {
-  value: string;
-  label: string;
-  icon?: string; // SVG path data for grid-style buttons
-  count?: number;
+  readonly value: string;
+  readonly label: string;
+  readonly icon?: string; // SVG path data for grid-style buttons
+  readonly count?: number;
 }
 
 export interface ActiveFilter {
-  id: string;
-  label: string;
-  onRemove: () => void;
+  readonly id: string;
+  readonly label: string;
+  readonly onRemove: () => void;
 }
 
 // Props for individual components
 export interface PageHeaderProps {
-  title: string;
-  badge?: {
-    icon?: React.ReactNode;
-    count: number;
-    label?: string;
+  readonly title: string;
+  readonly badge?: {
+    readonly icon?: React.ReactNode;
+    readonly count: number;
+    readonly label?: string;
   };
-  statusIndicator?: {
-    color: "green" | "yellow" | "red" | "gray";
-    tooltip?: string;
+  readonly statusIndicator?: {
+    readonly color: "green" | "yellow" | "red" | "gray";
+    readonly tooltip?: string;
   };
-  actionButton?: React.ReactNode;
-  className?: string;
+  readonly actionButton?: React.ReactNode;
+  readonly className?: string;
 }
 
 export interface SearchBarProps {


### PR DESCRIPTION
## Summary
- Mark all interface properties as `readonly` in page-header component types
- Fixes SonarCloud rule S6759 (4 reported issues + related types)
- Affected interfaces: PageHeaderWithSearchProps, TabItem, FilterConfig, FilterOption, ActiveFilter, PageHeaderProps

## Changes
Single file modified: `frontend/src/components/ui/page-header/types.ts`

The `readonly` modifier ensures props cannot be accidentally mutated, catching potential bugs at compile time rather than runtime.

## Test plan
- [x] `npm run check` passes (lint + typecheck)
- [x] No runtime behavior changes (readonly is compile-time only)