### PR TITLE
fix(frontend): batch fix 11 SonarCloud quick issues

### DIFF
--- a/frontend/src/app/api/active/groups/[id]/claim/route.ts
+++ b/frontend/src/app/api/active/groups/[id]/claim/route.ts
@@ -17,7 +17,7 @@ export const POST = createPostHandler(
     const { id } = params;
 
     if (typeof id !== "string") {
-      throw new Error("Invalid group ID");
+      throw new TypeError("Invalid group ID");
     }
 
     // Claim the group with default supervisor role

--- a/frontend/src/app/api/active/supervisors/route.ts
+++ b/frontend/src/app/api/active/supervisors/route.ts
@@ -1,8 +1,7 @@
 // app/api/active/supervisors/route.ts
 import type { NextRequest } from "next/server";
-import { apiGet, apiPost } from "~/lib/api-helpers";
+import { apiGet, apiPost, extractParams } from "~/lib/api-helpers";
 import { createGetHandler, createPostHandler } from "~/lib/route-wrapper";
-import { extractParams } from "~/lib/api-helpers";
 
 /**
  * Type definition for supervisor creation request

--- a/frontend/src/app/api/active/visits/route.ts
+++ b/frontend/src/app/api/active/visits/route.ts
@@ -1,8 +1,7 @@
 // app/api/active/visits/route.ts
 import type { NextRequest } from "next/server";
-import { apiGet, apiPost } from "~/lib/api-helpers";
+import { apiGet, apiPost, extractParams } from "~/lib/api-helpers";
 import { createGetHandler, createPostHandler } from "~/lib/route-wrapper";
-import { extractParams } from "~/lib/api-helpers";
 
 /**
  * Type definition for visit creation request

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,12 +1,11 @@
 // app/page.tsx
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { signIn, useSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { Input, Alert, HelpButton } from "~/components/ui";
-import { Suspense } from "react";
 import { refreshToken } from "~/lib/auth-api";
 import { SmartRedirect } from "~/components/auth/smart-redirect";
 import { SupervisionProvider } from "~/lib/supervision-context";

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -43,7 +43,7 @@ function ResetPasswordForm() {
     if (!/[a-z]/.test(pwd)) {
       return "Das Passwort muss mindestens einen Kleinbuchstaben enthalten.";
     }
-    if (!/[0-9]/.test(pwd)) {
+    if (!/\d/.test(pwd)) {
       return "Das Passwort muss mindestens eine Zahl enthalten.";
     }
     if (!/[^A-Za-z0-9]/.test(pwd)) {

--- a/frontend/src/components/auth/invitation-accept-form.tsx
+++ b/frontend/src/components/auth/invitation-accept-form.tsx
@@ -21,7 +21,7 @@ const PASSWORD_REQUIREMENTS: Array<{
   { label: "Mindestens 8 Zeichen", test: (value) => value.length >= 8 },
   { label: "Ein Großbuchstabe", test: (value) => /[A-Z]/.test(value) },
   { label: "Ein Kleinbuchstabe", test: (value) => /[a-z]/.test(value) },
-  { label: "Eine Zahl", test: (value) => /[0-9]/.test(value) },
+  { label: "Eine Zahl", test: (value) => /\d/.test(value) },
   { label: "Ein Sonderzeichen", test: (value) => /[^A-Za-z0-9]/.test(value) },
 ];
 

--- a/frontend/src/components/simple/student/ModernContactActions.tsx
+++ b/frontend/src/components/simple/student/ModernContactActions.tsx
@@ -16,7 +16,7 @@ export function ModernContactActions({
       const subject = studentName
         ? `Betreff: ${studentName}`
         : "Kontaktanfrage";
-      window.location.href = `mailto:${email}?subject=${encodeURIComponent(subject)}`;
+      globalThis.location.href = `mailto:${email}?subject=${encodeURIComponent(subject)}`;
     }
   };
 
@@ -24,7 +24,7 @@ export function ModernContactActions({
     if (phone) {
       // Remove spaces and special characters for tel: link
       const cleanPhone = phone.replaceAll(/\s+/g, "");
-      window.location.href = `tel:${cleanPhone}`;
+      globalThis.location.href = `tel:${cleanPhone}`;
     }
   };
 

--- a/frontend/src/lib/database/configs/activities.config.tsx
+++ b/frontend/src/lib/database/configs/activities.config.tsx
@@ -329,14 +329,14 @@ export const activitiesConfig = defineEntityConfig<Activity>({
         {
           label: "Schüler verwalten",
           onClick: (activity) => {
-            window.location.href = `/database/activities/${activity.id}/students`;
+            globalThis.location.href = `/database/activities/${activity.id}/students`;
           },
           color: "blue",
         },
         {
           label: "Zeiten verwalten",
           onClick: (activity) => {
-            window.location.href = `/database/activities/${activity.id}/times`;
+            globalThis.location.href = `/database/activities/${activity.id}/times`;
           },
           color: "green",
         },


### PR DESCRIPTION
## Summary
- Remove duplicate imports (S3863) - 3 files
- Use globalThis instead of window (S7764) - 2 files
- Use \d instead of [0-9] in regex (S6353) - 2 files
- Use TypeError for type errors (S7786) - 1 file

## Files Changed
| File | Issue | Fix |
|------|-------|-----|
| `page.tsx` | S3863 | Consolidate react imports |
| `supervisors/route.ts` | S3863 | Consolidate api-helpers imports |
| `visits/route.ts` | S3863 | Consolidate api-helpers imports |
| `ModernContactActions.tsx` | S7764 | window → globalThis |
| `activities.config.tsx` | S7764 | window → globalThis (2 occurrences) |
| `invitation-accept-form.tsx` | S6353 | [0-9] → \d |
| `reset-password/page.tsx` | S6353 | [0-9] → \d |
| `claim/route.ts` | S7786 | Error → TypeError |

## Test plan
- [x] `npm run check` passes (0 warnings)
- [x] No runtime behavior changes
- [x] Pre-commit hooks (prettier, eslint) passed