### PR TITLE
refactor(backend): reduce complexity 16→15 in 6 functions (S3776)

### DIFF
--- a/backend/api/common/student_data_snapshot.go
+++ b/backend/api/common/student_data_snapshot.go
@@ -38,45 +38,34 @@ func LoadStudentDataSnapshot(
 		ScheduledCheckouts: make(map[int64]*activeModels.ScheduledCheckout),
 	}
 
-	// Load persons
+	// Load persons (continue with empty map on error)
 	if len(personIDs) > 0 {
-		persons, err := personService.GetByIDs(ctx, personIDs)
-		if err != nil {
+		if persons, err := personService.GetByIDs(ctx, personIDs); err != nil {
 			log.Printf("Failed to bulk load persons: %v", err)
-			// Continue with empty map rather than failing completely
 		} else {
 			snapshot.Persons = persons
 		}
 	}
 
-	// Load groups
+	// Load groups (continue with empty map on error)
 	if len(groupIDs) > 0 {
-		groups, err := educationSvc.GetGroupsByIDs(ctx, groupIDs)
-		if err != nil {
+		if groups, err := educationSvc.GetGroupsByIDs(ctx, groupIDs); err != nil {
 			log.Printf("Failed to bulk load groups: %v", err)
-			// Continue with empty map rather than failing completely
 		} else {
 			snapshot.Groups = groups
 		}
 	}
 
-	// Load scheduled checkouts
+	// Load scheduled checkouts and location snapshot (continue on error)
 	if len(studentIDs) > 0 {
-		checkouts, err := activeSvc.GetPendingScheduledCheckouts(ctx, studentIDs)
-		if err != nil {
+		if checkouts, err := activeSvc.GetPendingScheduledCheckouts(ctx, studentIDs); err != nil {
 			log.Printf("Failed to bulk load scheduled checkouts: %v", err)
-			// Continue with empty map rather than failing completely
 		} else {
 			snapshot.ScheduledCheckouts = checkouts
 		}
-	}
 
-	// Load location snapshot
-	if len(studentIDs) > 0 {
-		locationSnapshot, err := LoadStudentLocationSnapshot(ctx, activeSvc, studentIDs)
-		if err != nil {
+		if locationSnapshot, err := LoadStudentLocationSnapshot(ctx, activeSvc, studentIDs); err != nil {
 			log.Printf("Failed to load student location snapshot: %v", err)
-			// Continue without location data rather than failing completely
 		} else {
 			snapshot.LocationSnapshot = locationSnapshot
 		}

--- a/backend/models/users/guardian_profile.go
+++ b/backend/models/users/guardian_profile.go
@@ -124,32 +124,41 @@ func (g *GuardianProfile) GetFullName() string {
 
 // GetPreferredContact returns the contact information based on preference
 func (g *GuardianProfile) GetPreferredContact() string {
-	switch g.PreferredContactMethod {
-	case "email":
-		if g.Email != nil && *g.Email != "" {
-			return *g.Email
-		}
-	case "mobile", "sms":
-		if g.MobilePhone != nil && *g.MobilePhone != "" {
-			return *g.MobilePhone
-		}
-	case "phone":
-		if g.Phone != nil && *g.Phone != "" {
-			return *g.Phone
-		}
+	// Try preferred contact method first
+	if contact := g.getContactByMethod(g.PreferredContactMethod); contact != "" {
+		return contact
 	}
 
-	// Fallback to any available contact
-	if g.MobilePhone != nil && *g.MobilePhone != "" {
-		return *g.MobilePhone
+	// Fallback to any available contact (mobile > phone > email)
+	if val := ptrString(g.MobilePhone); val != "" {
+		return val
 	}
-	if g.Phone != nil && *g.Phone != "" {
-		return *g.Phone
+	if val := ptrString(g.Phone); val != "" {
+		return val
 	}
-	if g.Email != nil && *g.Email != "" {
-		return *g.Email
+	return ptrString(g.Email)
+}
+
+// getContactByMethod returns the contact value for the specified method
+func (g *GuardianProfile) getContactByMethod(method string) string {
+	switch method {
+	case "email":
+		return ptrString(g.Email)
+	case "mobile", "sms":
+		return ptrString(g.MobilePhone)
+	case "phone":
+		return ptrString(g.Phone)
+	default:
+		return ""
 	}
-	return ""
+}
+
+// ptrString safely dereferences a string pointer, returning empty string if nil
+func ptrString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // CanInvite checks if guardian can be invited to create an account

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -600,23 +600,34 @@ func (s *Scheduler) executeCheckoutProcessing(task *ScheduledTask) {
 		return
 	}
 
-	// Only log if there were checkouts to process
-	if result.CheckoutsExecuted > 0 {
-		if result.Success {
-			log.Printf("Scheduled checkout processing: processed %d checkouts (%d visits ended, %d attendance updated)",
-				result.CheckoutsExecuted, result.VisitsEnded, result.AttendanceUpdated)
-		} else {
-			log.Printf("Scheduled checkout processing: partial success - processed %d checkouts with %d errors",
-				result.CheckoutsExecuted, len(result.Errors))
-			for i, errMsg := range result.Errors {
-				if i < 5 { // Log first 5 errors
-					log.Printf("  - Error: %s", errMsg)
-				}
-			}
-			if len(result.Errors) > 5 {
-				log.Printf("  ... and %d more errors", len(result.Errors)-5)
-			}
+	logCheckoutResult(result)
+}
+
+// logCheckoutResult logs the result of checkout processing if any checkouts were executed
+func logCheckoutResult(result *active.ScheduledCheckoutResult) {
+	if result.CheckoutsExecuted == 0 {
+		return
+	}
+
+	if result.Success {
+		log.Printf("Scheduled checkout processing: processed %d checkouts (%d visits ended, %d attendance updated)",
+			result.CheckoutsExecuted, result.VisitsEnded, result.AttendanceUpdated)
+		return
+	}
+
+	log.Printf("Scheduled checkout processing: partial success - processed %d checkouts with %d errors",
+		result.CheckoutsExecuted, len(result.Errors))
+	logFirstNErrors(result.Errors, 5)
+}
+
+// logFirstNErrors logs up to n errors with summary if more exist
+func logFirstNErrors(errors []string, n int) {
+	for i, errMsg := range errors {
+		if i >= n {
+			log.Printf("  ... and %d more errors", len(errors)-n)
+			return
 		}
+		log.Printf("  - Error: %s", errMsg)
 	}
 }
 


### PR DESCRIPTION
## Summary
Minimal refactors to bring 6 functions from complexity 16 to ≤15, resolving SonarCloud S3776 cognitive complexity issues.

**Files refactored:**
- `auth/jwt/tokenauth.go:25` - Extract `resolveRandomSecret` helper for random secret handling
- `api/common/student_data_snapshot.go:26` - Merge duplicate `studentIDs` condition blocks
- `models/users/guardian_profile.go:126` - Extract `getContactByMethod` and `ptrString` helpers
- `services/scheduler/scheduler.go:577` - Extract `logCheckoutResult` and `logFirstNErrors` helpers
- `api/usercontext/api.go:464` - Extract `validateAvatarAccess`, `validateAvatarPath`, `serveAvatarFile` helpers
- `database/repositories/users/privacy_consent.go:276` - Extract `buildPrivacyConsentFilter` and `applyPrivacyConsentFilterField` helpers

## Refactoring patterns used
- **Extract helper function** (-3+ complexity): Move cohesive logic blocks into dedicated functions
- **Flatten nested conditions** (-1 complexity): Merge duplicate outer if statements
- **Early returns** (-2 complexity): Replace nested if-else with guard clauses

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run --timeout 5m` passes (0 issues)
- [ ] SonarCloud analysis confirms complexity reduction