### PR TITLE
fix(frontend): reduce cognitive complexity in ActivityManagementModal (S3776)

### DIFF
--- a/frontend/src/components/activities/activity-management-modal.tsx
+++ b/frontend/src/components/activities/activity-management-modal.tsx
@@ -31,6 +31,21 @@ interface ActivityManagementModalProps {
   readonly readOnly?: boolean;
 }
 
+/** Maps delete error to user-friendly German message */
+function getDeleteErrorMessage(err: unknown): string {
+  if (!(err instanceof Error)) {
+    return "Fehler beim Löschen der Aktivität";
+  }
+  const message = err.message;
+  if (message.includes("students enrolled")) {
+    return "Diese Aktivität kann nicht gelöscht werden, da noch Schüler eingeschrieben sind. Bitte entfernen Sie zuerst alle Schüler aus der Aktivität.";
+  }
+  if (message.includes("401") || message.includes("403")) {
+    return "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an.";
+  }
+  return message;
+}
+
 export function ActivityManagementModal({
   isOpen,
   onClose,
@@ -141,21 +156,6 @@ export function ActivityManagementModal({
     } finally {
       setIsSubmitting(false);
     }
-  };
-
-  // Helper to map delete error to user-friendly message
-  const getDeleteErrorMessage = (err: unknown): string => {
-    if (!(err instanceof Error)) {
-      return "Fehler beim Löschen der Aktivität";
-    }
-    const message = err.message;
-    if (message.includes("students enrolled")) {
-      return "Diese Aktivität kann nicht gelöscht werden, da noch Schüler eingeschrieben sind. Bitte entfernen Sie zuerst alle Schüler aus der Aktivität.";
-    }
-    if (message.includes("401") || message.includes("403")) {
-      return "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an.";
-    }
-    return message;
   };
 
   const handleDelete = async () => {


### PR DESCRIPTION
## Summary
- Move `getDeleteErrorMessage` helper function from inside the component to module level
- This pure function has no dependencies on component state or props, making it safe to extract
- Reduces SonarCloud cognitive complexity from 17 to ~15 (threshold is 15)

## Changes
- **activity-management-modal.tsx**: Extracted `getDeleteErrorMessage` to module level with JSDoc comment

## Test Plan
- [x] `npm run check` passes (lint + typecheck)
- [ ] Verify modal edit/delete functionality still works
- [ ] SonarCloud analysis confirms complexity reduction