### PR TITLE
fix: resolve SonarCloud parameter count issues

### DIFF
--- a/backend/api/common/response.go
+++ b/backend/api/common/response.go
@@ -114,12 +114,6 @@ func (p *PaginatedResponse) Render(_ http.ResponseWriter, _ *http.Request) error
 	return nil
 }
 
-// RespondWithPagination sends a paginated response
-// Deprecated: Use RespondPaginated with PaginationParams instead for cleaner API
-func RespondWithPagination(w http.ResponseWriter, r *http.Request, status int, data interface{}, page, pageSize, total int, message string) {
-	RespondPaginated(w, r, status, data, PaginationParams{Page: page, PageSize: pageSize, Total: total}, message)
-}
-
 // RespondPaginated sends a paginated response using PaginationParams struct
 func RespondPaginated(w http.ResponseWriter, r *http.Request, status int, data interface{}, params PaginationParams, message string) {
 	render.Status(r, status)

--- a/backend/api/groups/api.go
+++ b/backend/api/groups/api.go
@@ -522,7 +522,7 @@ func (rs *Resource) listGroups(w http.ResponseWriter, r *http.Request) {
 		responses = append(responses, newGroupResponse(group, teachers, studentCount))
 	}
 
-	common.RespondWithPagination(w, r, http.StatusOK, responses, page, pageSize, len(responses), "Groups retrieved successfully")
+	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: page, PageSize: pageSize, Total: len(responses)}, "Groups retrieved successfully")
 }
 
 // getGroup handles getting a group by ID

--- a/backend/api/guardians/handlers.go
+++ b/backend/api/guardians/handlers.go
@@ -329,7 +329,7 @@ func (rs *Resource) listGuardians(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// For now, return without total count (would need separate count query)
-	common.RespondWithPagination(w, r, http.StatusOK, responses, page, pageSize, len(responses), "Guardians retrieved successfully")
+	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: page, PageSize: pageSize, Total: len(responses)}, "Guardians retrieved successfully")
 }
 
 // getGuardian handles getting a guardian by ID

--- a/backend/api/rooms/api.go
+++ b/backend/api/rooms/api.go
@@ -166,7 +166,7 @@ func (rs *Resource) listRooms(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Use common paginated response
-	common.RespondWithPagination(w, r, http.StatusOK, roomResponses, page, pageSize, len(roomsWithOccupancy), "Rooms retrieved successfully")
+	common.RespondPaginated(w, r, http.StatusOK, roomResponses, common.PaginationParams{Page: page, PageSize: pageSize, Total: len(roomsWithOccupancy)}, "Rooms retrieved successfully")
 }
 
 // getRoom handles getting a room by ID

--- a/backend/api/schedules/api.go
+++ b/backend/api/schedules/api.go
@@ -375,7 +375,7 @@ func (rs *Resource) listDateframes(w http.ResponseWriter, r *http.Request) {
 		responses[i] = newDateframeResponse(df)
 	}
 
-	common.RespondWithPagination(w, r, http.StatusOK, responses, page, pageSize, len(responses), "Dateframes retrieved successfully")
+	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: page, PageSize: pageSize, Total: len(responses)}, "Dateframes retrieved successfully")
 }
 
 func (rs *Resource) getDateframe(w http.ResponseWriter, r *http.Request) {
@@ -596,7 +596,7 @@ func (rs *Resource) listTimeframes(w http.ResponseWriter, r *http.Request) {
 		responses[i] = newTimeframeResponse(tf)
 	}
 
-	common.RespondWithPagination(w, r, http.StatusOK, responses, page, pageSize, len(responses), "Timeframes retrieved successfully")
+	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: page, PageSize: pageSize, Total: len(responses)}, "Timeframes retrieved successfully")
 }
 
 func (rs *Resource) getTimeframe(w http.ResponseWriter, r *http.Request) {
@@ -792,7 +792,7 @@ func (rs *Resource) listRecurrenceRules(w http.ResponseWriter, r *http.Request) 
 		responses[i] = newRecurrenceRuleResponse(rule)
 	}
 
-	common.RespondWithPagination(w, r, http.StatusOK, responses, page, pageSize, len(responses), msgRecurrenceRulesRetrieved)
+	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: page, PageSize: pageSize, Total: len(responses)}, msgRecurrenceRulesRetrieved)
 }
 
 func (rs *Resource) getRecurrenceRule(w http.ResponseWriter, r *http.Request) {

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -610,7 +610,7 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 		responses, totalCount = applyInMemoryPagination(responses, params.page, params.pageSize)
 	}
 
-	common.RespondWithPagination(w, r, http.StatusOK, responses, params.page, params.pageSize, totalCount, "Students retrieved successfully")
+	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: params.page, PageSize: params.pageSize, Total: totalCount}, "Students retrieved successfully")
 }
 
 // fetchStudentsForList fetches students based on the provided parameters

--- a/backend/api/substitutions/api.go
+++ b/backend/api/substitutions/api.go
@@ -166,7 +166,7 @@ func (rs *Resource) list(w http.ResponseWriter, r *http.Request) {
 		responses = append(responses, newSubstitutionResponse(sub))
 	}
 
-	common.RespondWithPagination(w, r, http.StatusOK, responses, page, pageSize, len(responses), "Substitutions retrieved successfully")
+	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: page, PageSize: pageSize, Total: len(responses)}, "Substitutions retrieved successfully")
 }
 
 // listActive handles GET /api/substitutions/active

--- a/backend/api/users/handlers.go
+++ b/backend/api/users/handlers.go
@@ -187,7 +187,7 @@ func (rs *Resource) listPersons(w http.ResponseWriter, r *http.Request) {
 		responses[i] = newPersonResponse(person)
 	}
 
-	common.RespondWithPagination(w, r, http.StatusOK, responses, page, pageSize, len(responses), "Persons retrieved successfully")
+	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: page, PageSize: pageSize, Total: len(responses)}, "Persons retrieved successfully")
 }
 
 // getPerson handles getting a person by ID

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -49,7 +49,7 @@ type Factory struct {
 	UserContext              usercontext.UserContextService
 	Database                 database.DatabaseService
 	Import                   *importService.ImportService[importModels.StudentImportRow] // Student import service
-	RealtimeHub              *realtime.Hub                                                // SSE event hub (shared by services and API)
+	RealtimeHub              *realtime.Hub                                               // SSE event hub (shared by services and API)
 	Mailer                   email.Mailer
 	DefaultFrom              email.Email
 	FrontendURL              string
@@ -266,21 +266,20 @@ func NewFactory(repos *repositories.Factory, db *bun.DB) (*Factory, error) {
 	)
 
 	// Initialize user context service
-	userContextService := usercontext.NewUserContextService(
-		repos.Account,
-		repos.Person,
-		repos.Staff,
-		repos.Teacher,
-		repos.Student,
-		repos.Group,
-		repos.ActivityGroup,
-		repos.ActiveGroup,
-		repos.ActiveVisit,
-		repos.GroupSupervisor,
-		repos.Profile,
-		repos.GroupSubstitution,
-		db,
-	)
+	userContextService := usercontext.NewUserContextServiceWithRepos(usercontext.UserContextRepositories{
+		AccountRepo:        repos.Account,
+		PersonRepo:         repos.Person,
+		StaffRepo:          repos.Staff,
+		TeacherRepo:        repos.Teacher,
+		StudentRepo:        repos.Student,
+		EducationGroupRepo: repos.Group,
+		ActivityGroupRepo:  repos.ActivityGroup,
+		ActiveGroupRepo:    repos.ActiveGroup,
+		VisitsRepo:         repos.ActiveVisit,
+		SupervisorRepo:     repos.GroupSupervisor,
+		ProfileRepo:        repos.Profile,
+		SubstitutionRepo:   repos.GroupSubstitution,
+	}, db)
 
 	// Initialize database stats service
 	databaseService := database.NewService(repos)

--- a/backend/services/usercontext/usercontext_service.go
+++ b/backend/services/usercontext/usercontext_service.go
@@ -57,39 +57,6 @@ type userContextService struct {
 	txHandler          *base.TxHandler
 }
 
-// NewUserContextService creates a new user context service
-// Deprecated: Use NewUserContextServiceWithRepos instead for cleaner API
-func NewUserContextService(
-	accountRepo auth.AccountRepository,
-	personRepo users.PersonRepository,
-	staffRepo users.StaffRepository,
-	teacherRepo users.TeacherRepository,
-	studentRepo users.StudentRepository,
-	educationGroupRepo education.GroupRepository,
-	activityGroupRepo activities.GroupRepository,
-	activeGroupRepo active.GroupRepository,
-	visitsRepo active.VisitRepository,
-	supervisorRepo active.GroupSupervisorRepository,
-	profileRepo users.ProfileRepository,
-	substitutionRepo education.GroupSubstitutionRepository,
-	db *bun.DB,
-) UserContextService {
-	return NewUserContextServiceWithRepos(UserContextRepositories{
-		AccountRepo:        accountRepo,
-		PersonRepo:         personRepo,
-		StaffRepo:          staffRepo,
-		TeacherRepo:        teacherRepo,
-		StudentRepo:        studentRepo,
-		EducationGroupRepo: educationGroupRepo,
-		ActivityGroupRepo:  activityGroupRepo,
-		ActiveGroupRepo:    activeGroupRepo,
-		VisitsRepo:         visitsRepo,
-		SupervisorRepo:     supervisorRepo,
-		ProfileRepo:        profileRepo,
-		SubstitutionRepo:   substitutionRepo,
-	}, db)
-}
-
 // NewUserContextServiceWithRepos creates a new user context service using a repositories struct
 func NewUserContextServiceWithRepos(repos UserContextRepositories, db *bun.DB) UserContextService {
 	return &userContextService{


### PR DESCRIPTION
## Summary
- Remove deprecated `RespondWithPagination` function (8 parameters) from `api/common/response.go`
- Remove deprecated `NewUserContextService` function (13 parameters) from `services/usercontext/usercontext_service.go`
- Update all 9 callers of `RespondWithPagination` to use `RespondPaginated` with `PaginationParams` struct
- Update factory.go to use `NewUserContextServiceWithRepos` with `UserContextRepositories` struct

## Test plan
- [x] Go build passes without errors
- [x] golangci-lint passes with 0 issues
- [ ] CI pipeline passes

## SonarCloud Issues Fixed
- `backend/api/common/response.go` L119: "This function has 8 parameters, which is greater than the 7 authorized"
- `backend/services/usercontext/usercontext_service.go` L62: "This function has 13 parameters, which is greater than the 7 authorized"