### PR TITLE
fix: replace vulnerable email regex with OWASP-safe pattern

### DIFF
--- a/frontend/src/components/teachers/teacher-form.tsx
+++ b/frontend/src/components/teachers/teacher-form.tsx
@@ -142,7 +142,12 @@ export function TeacherForm({
     if (!initialData.id) {
       if (!email.trim()) {
         newErrors.email = "E-Mail ist erforderlich";
-      } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      } else if (
+        email.length > 254 ||
+        !/^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(
+          email,
+        )
+      ) {
         newErrors.email = "Ungültige E-Mail-Adresse";
       }
 


### PR DESCRIPTION
## Summary

- Replace ReDoS-vulnerable email validation regex with OWASP-recommended pattern
- Add input length check (max 254 chars per RFC 5321) as defense-in-depth
- Resolves SonarCloud security hotspot S5852 (DoS via super-linear regex runtime)

## Changes

| Aspect | Before | After |
|--------|--------|-------|
| Pattern | `/^[^\s@]+@[^\s@]+\.[^\s@]+$/` | `/^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/` |
| Length check | None | `email.length > 254` |
| Character classes | Negated (overlap risk) | Specific (no overlap) |
| Groups | Capturing | Non-capturing `(?:...)` |
| TLD validation | None | Minimum 2 letters |

## Why the old regex was vulnerable

The pattern `[^\s@]+` matches "anything except whitespace and @" - a negated character class. When combined with adjacent quantifiers like `[^\s@]+@[^\s@]+`, the regex engine tries every possible split point on malicious input, causing exponential backtracking (O(2^n) time complexity).

## References

- [OWASP Validation Regex Repository](https://owasp.org/www-community/OWASP_Validation_Regex_Repository)
- [OWASP ReDoS Attack](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)
- [SonarQube Rule S5852](https://rules.sonarsource.com/typescript/S5852/)

## Test plan

- [x] `npm run check` passes (0 warnings, 0 type errors)
- [ ] SonarCloud analysis confirms hotspot resolved
- [ ] Manual test: valid emails accepted, invalid emails rejected