### PR TITLE
fix: replace Math.random() with crypto.randomUUID() in axios interceptor

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -516,9 +516,8 @@ async function attemptServerSideRefresh(
   console.log("Server-side context detected, attempting token refresh");
 
   try {
-    const { refreshSessionTokensOnServer } = await import(
-      "~/server/auth/token-refresh"
-    );
+    const { refreshSessionTokensOnServer } =
+      await import("~/server/auth/token-refresh");
     const refreshed = await refreshSessionTokensOnServer();
 
     if (!refreshed?.accessToken) {
@@ -578,7 +577,7 @@ api.interceptors.response.use(
       throw error;
     }
 
-    const callerId = `axios-interceptor-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+    const callerId = `axios-interceptor-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
     console.log(`\n[${callerId}] Axios interceptor: 401 error detected`);
     originalRequest._retry = true;
     originalRequest._retryCount = (originalRequest._retryCount ?? 0) + 1;


### PR DESCRIPTION
## Summary

Replace `Math.random()` with `crypto.randomUUID()` in the axios interceptor for generating logging correlation IDs.

## Context

SonarCloud flagged 25 security hotspots for "Weak Cryptography" (`S2245`) related to `Math.random()` usage. After thorough audit:

| Category | Count | Risk | Action |
|----------|-------|------|--------|
| Visual Effects (confetti) | 22 | None | Mark Safe in SonarCloud |
| UI Component IDs (toast) | 1 | None | Mark Safe in SonarCloud |
| Dev-Only Logging | 1 | None | Mark Safe (isDev check) |
| **Runtime Logging** | **1** | Low | **Fixed in this PR** |

## Changes

**File:** `frontend/src/lib/api.ts:581`

```diff
- const callerId = `axios-interceptor-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+ const callerId = `axios-interceptor-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
```

## Why this change?

While not a security vulnerability (used only for console logging), using `crypto.randomUUID()`:
- Follows security best practices
- Resolves SonarCloud security hotspot
- Uses cryptographically secure randomness
- Available in all modern browsers and Node.js 19+

## Remaining Security Hotspots

The other 24 `Math.random()` usages should be marked as **Safe** in SonarCloud UI:
- 22 confetti visual effects (page.tsx, logout-modal.tsx)
- 1 toast notification ID (ToastContext.tsx)
- 1 dev-only logging (auth/config.ts - isDev check)

## Test plan

- [x] `npm run check` passes (0 warnings, 0 type errors)
- [ ] SonarCloud analysis confirms hotspot resolved
- [ ] Axios 401 retry logging still works correctly