### PR TITLE
fix: resolve SonarCloud security hotspots (Actions SHA + Docker non-root)

### DIFF
--- a/.github/actions/setup-go-and-deps/action.yml
+++ b/.github/actions/setup-go-and-deps/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: true

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       
       - name: Go and dependencies
         uses: ./.github/actions/setup-go-and-deps

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,9 @@ jobs:
   backend-deadcode:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Setup Go with cache
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
           go-version-file: backend/go.mod
           cache: true
@@ -68,15 +68,15 @@ jobs:
   backend-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Setup Go with cache
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
           go-version-file: backend/go.mod
           cache: true
           cache-dependency-path: backend/go.sum
       - name: golang ci lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: latest
           args: --timeout 10m
@@ -88,9 +88,9 @@ jobs:
       NEXT_PUBLIC_API_URL: "http://localhost:8080" # Default API URL for linting
       SKIP_ENV_VALIDATION: "true" # Skip validation during linting
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Go and dependencies
         uses: ./.github/actions/setup-go-and-deps
       - name: test

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,6 +23,10 @@ FROM alpine:3.21 AS production
 RUN apk --no-cache add ca-certificates bash tzdata
 ENV TZ=Europe/Berlin
 
+# Create non-root user for security
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -S appuser -u 1001 -G appgroup
+
 WORKDIR /app
 # Retrieve the binary from the previous stage
 COPY --from=builder /src/main .
@@ -30,6 +34,11 @@ COPY --from=builder /src/main .
 COPY templates templates
 # Copy frontend
 COPY public public
+
+# Set ownership and switch to non-root user
+RUN chown -R appuser:appgroup /app
+USER appuser
+
 # Expose port
 EXPOSE 8080
 # Set the binary as the entrypoint of the container

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -23,6 +23,12 @@ RUN npm run build
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Create non-root user for security
+RUN addgroup -g 1001 -S nodejs && \
+    adduser -S nextjs -u 1001 -G nodejs && \
+    chown -R nextjs:nodejs /app
+USER nextjs
+
 EXPOSE 3000
 
 # Run production server


### PR DESCRIPTION
## Summary

Resolves multiple SonarCloud security hotspots related to supply chain security and container privilege escalation.

## Changes

### 1. GitHub Actions - Pin to Full Commit SHAs (S7637)

| File | Action | SHA |
|------|--------|-----|
| `lint.yml` | `actions/checkout@v6` | `8e8c483db84b4bee98b60c0593521ed34d9990e8` |
| `lint.yml` | `actions/setup-go@v6` | `4dc6199c7b1a012772edbd06daecab0f50c9053c` |
| `lint.yml` | `golangci-lint-action@v6` | `55c2c1448f86e01eaae002a5a3a9624417608d84` |
| `lint.yml` | `actions/setup-node@v6` | `395ad3262231945c25e8478fd5baf05154b1d79f` |
| `test.yml` | `actions/checkout@v6` | `8e8c483db84b4bee98b60c0593521ed34d9990e8` |
| `dependencies.yml` | `actions/checkout@v6` | `8e8c483db84b4bee98b60c0593521ed34d9990e8` |
| `action.yml` | `actions/setup-go@v5` | `40f1582b2485089dde7abd97c1529aa768e1baff` |

**Why:** Version tags like `@v6` are mutable - if an attacker compromises a maintainer's account, they can move the tag to malicious code. Full SHAs are immutable.

### 2. Docker - Add Non-Root Users (S6470)

| File | User:Group | UID:GID |
|------|------------|---------|
| `backend/Dockerfile` | `appuser:appgroup` | `1001:1001` |
| `frontend/Dockerfile.prod` | `nextjs:nodejs` | `1001:1001` |

**Why:** Running containers as root allows container escapes to have full host privileges. Non-root users limit blast radius.

## Remaining Hotspots (Mark as Safe)

| Issue | Justification |
|-------|---------------|
| 4x COPY . . | `.dockerignore` excludes sensitive files |
| 6x HTTP URLs | Dev configs (localhost), SVG namespaces |
| 1x DB_DEBUG | Dev default, overridden in production |
| 1x PATH/exec.LookPath | Dev CLI tool (gendoc), not production |

## Test Plan

- [x] All workflow files have valid YAML syntax
- [ ] CI workflows run successfully with pinned SHAs
- [ ] Docker builds complete with non-root users
- [ ] Container starts and runs correctly as non-root