### PR TITLE
ci: implement label-based staging deployments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,10 @@
 name: Build and Push Docker Images
 
 on:
-  # Build and deploy on merge to main (production) or development (staging)
+  # Production: Build and deploy on push to main
   push:
     branches:
       - main
-      - development
     paths:
       - 'backend/**'
       - 'frontend/**'
@@ -14,6 +13,12 @@ on:
       - '!docs/**'
       - '!bruno/**'
       - '!.vscode/**'
+
+  # Staging: Build and deploy when PR with 'deploy-staging' label is merged
+  pull_request:
+    types: [closed]
+    branches:
+      - development
 
   # Manual trigger for emergencies
   workflow_dispatch:
@@ -37,39 +42,62 @@ env:
   FRONTEND_IMAGE: ghcr.io/moto-nrw/phoenix-frontend
 
 jobs:
-  # Determine target environment based on branch
+  # Determine target environment and whether to proceed
   check-environment:
     runs-on: ubuntu-latest
     outputs:
+      should_deploy: ${{ steps.check.outputs.should_deploy }}
       is_staging: ${{ steps.check.outputs.is_staging }}
     steps:
       - name: Determine environment
         id: check
         run: |
+          # Production: Push to main
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+            echo "is_staging=false" >> $GITHUB_OUTPUT
+            echo "✅ Push to main - will build and deploy to production"
+
+          # Staging: PR merged with 'deploy-staging' label
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'deploy-staging') }}" == "true" ]]; then
+                echo "should_deploy=true" >> $GITHUB_OUTPUT
+                echo "is_staging=true" >> $GITHUB_OUTPUT
+                echo "✅ PR #${{ github.event.pull_request.number }} merged with 'deploy-staging' label - will build and deploy to staging"
+              else
+                echo "should_deploy=false" >> $GITHUB_OUTPUT
+                echo "is_staging=false" >> $GITHUB_OUTPUT
+                echo "⏭️ PR #${{ github.event.pull_request.number }} merged without 'deploy-staging' label - skipping deployment"
+              fi
+            else
+              echo "should_deploy=false" >> $GITHUB_OUTPUT
               echo "is_staging=false" >> $GITHUB_OUTPUT
-              echo "✅ Push to main - will deploy to production"
-            elif [[ "${{ github.ref }}" == "refs/heads/development" ]]; then
-              echo "is_staging=true" >> $GITHUB_OUTPUT
-              echo "✅ Push to development - will deploy to staging"
+              echo "⏭️ PR #${{ github.event.pull_request.number }} closed without merge - skipping"
             fi
+
+          # Manual dispatch
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
             if [[ "${{ github.event.inputs.environment }}" == "staging" ]]; then
               echo "is_staging=true" >> $GITHUB_OUTPUT
             else
               echo "is_staging=false" >> $GITHUB_OUTPUT
             fi
             echo "✅ Manual trigger for ${{ github.event.inputs.environment }}"
+
+          # Release: Deploy to production
           elif [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
             echo "is_staging=false" >> $GITHUB_OUTPUT
-            echo "✅ Release - will deploy to production"
+            echo "✅ Release - will build and deploy to production"
           fi
 
   # Build and push backend image
   build-backend:
     runs-on: ubuntu-latest
     needs: [check-environment]
+    if: needs.check-environment.outputs.should_deploy == 'true'
     permissions:
       contents: read
       packages: write
@@ -77,6 +105,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # For merged PRs, checkout the merge commit on development
+          ref: ${{ github.event_name == 'pull_request' && 'development' || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -94,13 +125,13 @@ jobs:
         with:
           images: ${{ env.BACKEND_IMAGE }}
           tags: |
-            # Branch name (development, main)
+            # Branch name (main for production)
             type=ref,event=branch
             # Short SHA for traceability
             type=sha,prefix=,format=short
-            # 'staging' tag for development branch
-            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/development' }}
-            # 'latest' tag for main branch
+            # 'staging' tag for staging deployments (merged PRs with label)
+            type=raw,value=staging,enable=${{ needs.check-environment.outputs.is_staging == 'true' }}
+            # 'latest' tag for production (main branch)
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             # Semantic version from release tags
             type=semver,pattern={{version}}
@@ -127,6 +158,7 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     needs: [check-environment]
+    if: needs.check-environment.outputs.should_deploy == 'true'
     permissions:
       contents: read
       packages: write
@@ -134,6 +166,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # For merged PRs, checkout the merge commit on development
+          ref: ${{ github.event_name == 'pull_request' && 'development' || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -151,13 +186,13 @@ jobs:
         with:
           images: ${{ env.FRONTEND_IMAGE }}
           tags: |
-            # Branch name (development, main)
+            # Branch name (main for production)
             type=ref,event=branch
             # Short SHA for traceability
             type=sha,prefix=,format=short
-            # 'staging' tag for development branch
-            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/development' }}
-            # 'latest' tag for main branch
+            # 'staging' tag for staging deployments (merged PRs with label)
+            type=raw,value=staging,enable=${{ needs.check-environment.outputs.is_staging == 'true' }}
+            # 'latest' tag for production (main branch)
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             # Semantic version from release tags
             type=semver,pattern={{version}}
@@ -166,11 +201,10 @@ jobs:
       - name: Determine API URL
         id: api_url
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "url=https://api.moto-app.de" >> $GITHUB_OUTPUT
-          else
-            # Development branch uses staging API
+          if [[ "${{ needs.check-environment.outputs.is_staging }}" == "true" ]]; then
             echo "url=https://api-staging.moto-app.de" >> $GITHUB_OUTPUT
+          else
+            echo "url=https://api.moto-app.de" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push frontend
@@ -192,12 +226,12 @@ jobs:
       - name: Image digest
         run: echo "Frontend image pushed with digest ${{ steps.meta.outputs.digest }}"
 
-  # Deploy to staging (push to development or manual dispatch)
+  # Deploy to staging (merged PR with label or manual dispatch)
   # Note: Currently staging runs on same server as production (different ports/dirs)
   # Using separate secrets allows easy migration to dedicated staging server later
   deploy-staging:
     needs: [check-environment, build-backend, build-frontend]
-    if: needs.check-environment.outputs.is_staging == 'true'
+    if: needs.check-environment.outputs.should_deploy == 'true' && needs.check-environment.outputs.is_staging == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to staging
@@ -219,7 +253,7 @@ jobs:
   # Deploy to production (push to main, release, or manual dispatch to production)
   deploy-production:
     needs: [check-environment, build-backend, build-frontend]
-    if: needs.check-environment.outputs.is_staging == 'false'
+    if: needs.check-environment.outputs.should_deploy == 'true' && needs.check-environment.outputs.is_staging == 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to production
@@ -242,7 +276,7 @@ jobs:
   build-status:
     runs-on: ubuntu-latest
     needs: [check-environment, build-backend, build-frontend]
-    if: always()
+    if: always() && needs.check-environment.outputs.should_deploy == 'true'
     steps:
       - name: Check build status
         run: |


### PR DESCRIPTION
## Summary
- Implements label-based staging deployments to save CI minutes
- Staging builds only trigger when a PR with `deploy-staging` label is **merged**
- PRs without the label or closed without merge are skipped entirely

## Changes
- **Triggers**: Removed `development` from push branches, added `pull_request: types: [closed]`
- **Gating logic**: Check `github.event.pull_request.merged == true` AND `contains(labels, 'deploy-staging')`
- **Checkout**: For merged PRs, explicitly checkout `development` branch to get merge commit
- **Tags**: `:staging` tag generated based on `is_staging` output, not branch ref

## New Workflow

| Action | Result |
|--------|--------|
| Create PR → development | Lint/test only (main.yml) |
| Add `deploy-staging` label | Nothing happens |
| Merge PR (without label) | Nothing happens |
| Merge PR (with label) | ✅ Build + Deploy to staging |

## Usage
```bash
# When ready to deploy to staging:
gh pr edit <PR-NUMBER> --add-label "deploy-staging"
# Then merge the PR
```

## Benefits
- Saves ~300 CI minutes/month by avoiding automatic staging builds
- Explicit control over when staging is updated
- Production deploys unchanged (push to main)
- Manual `workflow_dispatch` still available for emergencies

## Test plan
- [ ] Create a PR without label → merge → verify NO build triggered
- [ ] Create a PR with `deploy-staging` label → merge → verify build AND deploy triggered
- [ ] Test manual workflow_dispatch for staging
- [ ] Verify production deploy still works on push to main

## Sources
- [Events that trigger workflows - GitHub Docs](https://docs.github.com/actions/learn-github-actions/events-that-trigger-workflows)
- [Trigger workflow only on pull request MERGE](https://github.com/orgs/community/discussions/26724)