### PR TITLE
fix(frontend): use shared StudentCard in student search

### DIFF
--- a/frontend/src/app/students/search/page.tsx
+++ b/frontend/src/app/students/search/page.tsx
@@ -28,6 +28,12 @@ import {
   isTransitLocation,
 } from "~/lib/location-helper";
 import { SCHOOL_YEAR_FILTER_OPTIONS } from "~/lib/student-helpers";
+import {
+  StudentCard,
+  SchoolClassIcon,
+  GroupIcon,
+  StudentInfoRow,
+} from "~/components/students/student-card";
 
 function SearchPageContent() {
   const { data: session, status } = useSession();
@@ -521,121 +527,42 @@ function SearchPageContent() {
           return (
             <div>
               <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
-                {filteredStudents.map((student) => {
-                  const handleClick = () =>
-                    router.push(
-                      `/students/${student.id}?from=/students/search`,
-                    );
-                  return (
-                    <button
-                      type="button"
-                      key={student.id}
-                      onClick={handleClick}
-                      className="group relative w-full cursor-pointer overflow-hidden rounded-2xl border border-gray-100/50 bg-white/90 text-left shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md transition-all duration-500 active:scale-[0.97] md:hover:-translate-y-3 md:hover:scale-[1.03] md:hover:border-[#5080D8]/30 md:hover:bg-white md:hover:shadow-[0_20px_50px_rgb(0,0,0,0.15)]"
-                    >
-                      {/* Modern gradient overlay */}
-                      <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-blue-50/80 to-cyan-100/80 opacity-[0.03]"></div>
-                      {/* Subtle inner glow */}
-                      <div className="absolute inset-px rounded-2xl bg-gradient-to-br from-white/80 to-white/20"></div>
-                      {/* Modern border highlight */}
-                      <div className="absolute inset-0 rounded-2xl ring-1 ring-white/20 transition-all duration-300 md:group-hover:ring-blue-200/60"></div>
-
-                      <div className="relative p-6">
-                        {/* Header with student name */}
-                        <div className="mb-3 flex items-center justify-between">
-                          {/* Student Name */}
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-center gap-2">
-                              <h3 className="overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap text-gray-800 transition-colors duration-300 md:group-hover:text-blue-600">
-                                {student.first_name}
-                              </h3>
-                              {/* Subtle integrated arrow */}
-                              <svg
-                                className="h-4 w-4 flex-shrink-0 text-gray-300 transition-all duration-300 md:group-hover:translate-x-1 md:group-hover:text-blue-500"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth={2}
-                                  d="M9 5l7 7-7 7"
-                                />
-                              </svg>
-                            </div>
-                            <p className="overflow-hidden text-base font-semibold text-ellipsis whitespace-nowrap text-gray-700 transition-colors duration-300 md:group-hover:text-blue-500">
-                              {student.second_name}
-                            </p>
-                          </div>
-
-                          {/* Status Badge */}
-                          <LocationBadge
-                            student={student}
-                            displayMode="contextAware"
-                            userGroups={myGroups}
-                            groupRooms={myGroupRooms}
-                            supervisedRooms={mySupervisedRooms}
-                            variant="modern"
-                            size="md"
-                          />
-                        </div>
-
-                        {/* Additional Info */}
-                        <div className="mb-3 space-y-1">
-                          <div className="flex items-center text-sm text-gray-600">
-                            <svg
-                              className="mr-2 h-4 w-4 text-gray-400"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                              />
-                            </svg>
-                            <span>Klasse {student.school_class}</span>
-                          </div>
-                          {student.group_name && (
-                            <div className="flex items-center text-sm text-gray-600">
-                              <svg
-                                className="mr-2 h-4 w-4 text-gray-400"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth={2}
-                                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                                />
-                              </svg>
-                              Gruppe: {student.group_name}
-                            </div>
-                          )}
-                        </div>
-
-                        {/* Bottom row with click hint */}
-                        <div className="flex justify-start">
-                          <p className="text-xs text-gray-400 transition-colors duration-300 md:group-hover:text-blue-400">
-                            Tippen für mehr Infos
-                          </p>
-                        </div>
-
-                        {/* Decorative elements */}
-                        <div className="absolute top-3 left-3 h-5 w-5 animate-ping rounded-full bg-white/20"></div>
-                        <div className="absolute right-3 bottom-3 h-3 w-3 rounded-full bg-white/30"></div>
-                      </div>
-
-                      {/* Glowing border effect */}
-                      <div className="absolute inset-0 rounded-2xl bg-gradient-to-r from-transparent via-blue-100/30 to-transparent opacity-0 transition-opacity duration-300 md:group-hover:opacity-100"></div>
-                    </button>
-                  );
-                })}
+                {filteredStudents.map((student) => (
+                  <StudentCard
+                    key={student.id}
+                    studentId={student.id}
+                    firstName={student.first_name}
+                    lastName={student.second_name}
+                    onClick={() =>
+                      router.push(
+                        `/students/${student.id}?from=/students/search`,
+                      )
+                    }
+                    locationBadge={
+                      <LocationBadge
+                        student={student}
+                        displayMode="contextAware"
+                        userGroups={myGroups}
+                        groupRooms={myGroupRooms}
+                        supervisedRooms={mySupervisedRooms}
+                        variant="modern"
+                        size="md"
+                      />
+                    }
+                    extraContent={
+                      <>
+                        <StudentInfoRow icon={<SchoolClassIcon />}>
+                          Klasse {student.school_class}
+                        </StudentInfoRow>
+                        {student.group_name && (
+                          <StudentInfoRow icon={<GroupIcon />}>
+                            Gruppe: {student.group_name}
+                          </StudentInfoRow>
+                        )}
+                      </>
+                    }
+                  />
+                ))}
               </div>
             </div>
           );


### PR DESCRIPTION
## Summary
- Replace duplicate card implementation with shared `StudentCard` component
- Align border-radius (`rounded-2xl` → `rounded-3xl`) for visual consistency
- Display both "Klasse" and "Gruppe" using shared `StudentInfoRow` helpers

## Test plan
- [x] Open `/students/search` page
- [x] Verify cards have consistent border-radius with OGS Groups page
- [x] Verify "Klasse 3A" and "Gruppe: 1A" are displayed correctly

Closes #613