### PR TITLE
feat(students): add check-in button for students at home

### DIFF
--- a/backend/api/active/api.go
+++ b/backend/api/active/api.go
@@ -123,6 +123,9 @@ func (rs *Resource) Router() chi.Router {
 
 			// Immediate checkout for students
 			r.With(authorize.RequiresPermission(permissions.VisitsUpdate)).Post("/student/{studentId}/checkout", rs.checkoutStudent)
+
+			// Manual check-in for students at home
+			r.With(authorize.RequiresPermission(permissions.VisitsUpdate)).Post("/student/{studentId}/checkin", rs.checkinStudent)
 		})
 
 		// Supervisors

--- a/backend/api/active/checkin.go
+++ b/backend/api/active/checkin.go
@@ -1,0 +1,156 @@
+package active
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/logging"
+)
+
+// CheckinRequest represents the request body for manual check-in
+type CheckinRequest struct {
+	ActiveGroupID int64 `json:"active_group_id"`
+}
+
+// checkinStudent handles manual check-in of a student who is at home
+// The request body must contain an active_group_id to specify which room to check into
+func (rs *Resource) checkinStudent(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Get user from JWT context
+	userClaims := jwt.ClaimsFromCtx(ctx)
+	if userClaims.ID == 0 {
+		common.RespondWithError(w, r, http.StatusUnauthorized, "Invalid token")
+		return
+	}
+
+	// Get student ID from URL
+	studentIDStr := chi.URLParam(r, "studentId")
+	studentID, err := strconv.ParseInt(studentIDStr, 10, 64)
+	if err != nil {
+		common.RespondWithError(w, r, http.StatusBadRequest, "Invalid student ID")
+		return
+	}
+
+	// Parse request body
+	var req CheckinRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		common.RespondWithError(w, r, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	// Validate active_group_id is provided
+	if req.ActiveGroupID <= 0 {
+		common.RespondWithError(w, r, http.StatusBadRequest, "active_group_id is required")
+		return
+	}
+
+	// Get and validate the active group
+	activeGroup, err := rs.ActiveService.GetActiveGroup(ctx, req.ActiveGroupID)
+	if err != nil || activeGroup == nil {
+		common.RespondWithError(w, r, http.StatusNotFound, "Active group not found")
+		return
+	}
+
+	// Verify the group is still active
+	if !activeGroup.IsActive() {
+		common.RespondWithError(w, r, http.StatusConflict, "The selected room session is no longer active")
+		return
+	}
+
+	// Check attendance status
+	attendanceStatus, err := rs.ActiveService.GetStudentAttendanceStatus(ctx, studentID)
+	if err != nil {
+		common.RespondWithError(w, r, http.StatusInternalServerError, "Failed to get attendance status")
+		return
+	}
+
+	// Student must be at home (checked_out or not_checked_in) to check in
+	if attendanceStatus.Status == "checked_in" {
+		common.RespondWithError(w, r, http.StatusConflict, "Student is already checked in")
+		return
+	}
+
+	// Check authorization - get staff info
+	person, err := rs.PersonService.FindByAccountID(ctx, int64(userClaims.ID))
+	if err != nil || person == nil {
+		common.RespondWithError(w, r, http.StatusInternalServerError, "Failed to get user information")
+		return
+	}
+
+	staff, err := rs.PersonService.StaffRepository().FindByPersonID(ctx, person.ID)
+	if err != nil || staff == nil {
+		common.RespondWithError(w, r, http.StatusForbidden, "Only staff members can check in students")
+		return
+	}
+
+	// Check if teacher has access to this student (is assigned to their group)
+	hasAccess, err := rs.ActiveService.CheckTeacherStudentAccess(ctx, staff.ID, studentID)
+	if err != nil {
+		common.RespondWithError(w, r, http.StatusInternalServerError, "Failed to check access permissions")
+		return
+	}
+
+	if !hasAccess {
+		common.RespondWithError(w, r, http.StatusForbidden,
+			"You are not authorized to check in this student. You must be their group teacher.")
+		return
+	}
+
+	// Create visit for the selected active group
+	visit := &activeModels.Visit{
+		StudentID:     studentID,
+		ActiveGroupID: req.ActiveGroupID,
+		EntryTime:     time.Now(),
+	}
+
+	if err := rs.ActiveService.CreateVisit(ctx, visit); err != nil {
+		if logging.Logger != nil {
+			logging.Logger.WithFields(map[string]interface{}{
+				"student_id":      studentID,
+				"active_group_id": req.ActiveGroupID,
+				"error":           err.Error(),
+			}).Error("Failed to create visit during check-in")
+		}
+		common.RespondWithError(w, r, http.StatusInternalServerError, "Failed to check in student to room")
+		return
+	}
+
+	// Get updated attendance status for response
+	updatedAttendance, statusErr := rs.ActiveService.GetStudentAttendanceStatus(ctx, studentID)
+	if statusErr != nil {
+		if logging.Logger != nil {
+			logging.Logger.WithFields(map[string]interface{}{
+				"student_id": studentID,
+				"error":      statusErr.Error(),
+			}).Warn("Failed to get updated attendance status after checkin")
+		}
+	}
+
+	responseData := map[string]interface{}{
+		"student_id":      studentID,
+		"action":          "checked_in",
+		"visit_id":        visit.ID,
+		"active_group_id": req.ActiveGroupID,
+		"room_id":         activeGroup.RoomID,
+	}
+
+	if statusErr == nil && updatedAttendance != nil {
+		responseData["attendance_status"] = updatedAttendance.Status
+		responseData["check_in_time"] = updatedAttendance.CheckInTime
+		responseData["checked_in_by"] = updatedAttendance.CheckedInBy
+	}
+
+	common.RespondWithJSON(w, r, http.StatusOK, map[string]interface{}{
+		"status":  "success",
+		"message": "Student checked in successfully",
+		"data":    responseData,
+	})
+}

--- a/frontend/src/app/api/active/visits/student/[studentId]/checkin/route.ts
+++ b/frontend/src/app/api/active/visits/student/[studentId]/checkin/route.ts
@@ -1,0 +1,51 @@
+// API route for immediate student check-in
+
+import { createPostHandler } from "~/lib/route-wrapper";
+
+interface CheckinBody {
+  active_group_id: number;
+}
+
+export const POST = createPostHandler<unknown, CheckinBody>(
+  async (_request, body, token, params) => {
+    const studentId = params.studentId as string;
+
+    if (!studentId) {
+      throw new Error("Student ID is required");
+    }
+
+    if (!body.active_group_id) {
+      throw new Error("active_group_id is required");
+    }
+
+    // Use internal Docker network URL for server-side calls
+    const apiUrl =
+      process.env.NODE_ENV === "production" || process.env.DOCKER_ENV
+        ? "http://server:8080"
+        : (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080");
+
+    const response = await fetch(
+      `${apiUrl}/api/active/visits/student/${studentId}/checkin`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ active_group_id: body.active_group_id }),
+      },
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(error || "Failed to check in student");
+    }
+
+    const data = (await response.json()) as {
+      status: string;
+      message: string;
+      data: unknown;
+    };
+    return data.data;
+  },
+);

--- a/frontend/src/components/students/student-checkout-section.tsx
+++ b/frontend/src/components/students/student-checkout-section.tsx
@@ -2,6 +2,9 @@
 
 import { ScheduledCheckoutInfo } from "~/components/scheduled-checkout/scheduled-checkout-info";
 
+// Type for the action the user can perform
+export type StudentActionType = "checkout" | "checkin" | "none";
+
 interface StudentCheckoutSectionProps {
   studentId: string;
   hasScheduledCheckout: boolean;
@@ -20,7 +23,7 @@ export function StudentCheckoutSection({
   return (
     <div className="mb-6 rounded-2xl border border-gray-100 bg-white/50 p-4 backdrop-blur-sm sm:p-6">
       <div className="mb-4 flex items-center gap-3">
-        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-600 sm:h-10 sm:w-10">
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-[#FF3130] text-white sm:h-10 sm:w-10">
           <svg
             className="h-5 w-5"
             fill="none"
@@ -67,4 +70,95 @@ export function StudentCheckoutSection({
       )}
     </div>
   );
+}
+
+// New component for check-in action (when student is at home)
+interface StudentCheckinSectionProps {
+  onCheckinClick: () => void;
+}
+
+export function StudentCheckinSection({
+  onCheckinClick,
+}: StudentCheckinSectionProps) {
+  return (
+    <div className="mb-6 rounded-2xl border border-gray-100 bg-white/50 p-4 backdrop-blur-sm sm:p-6">
+      <div className="mb-4 flex items-center gap-3">
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-[#83CD2D] text-white sm:h-10 sm:w-10">
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"
+            />
+          </svg>
+        </div>
+        <h3 className="text-base font-semibold text-gray-900 sm:text-lg">
+          Anmeldung
+        </h3>
+      </div>
+      <button
+        onClick={onCheckinClick}
+        className="flex w-full items-center justify-center gap-2 rounded-lg bg-gray-900 px-4 py-3 text-sm font-medium text-white transition-all duration-200 hover:scale-[1.01] hover:bg-gray-700 hover:shadow-lg active:scale-[0.99] sm:py-2.5"
+      >
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"
+          />
+        </svg>
+        Kind anmelden
+      </button>
+    </div>
+  );
+}
+
+// Helper function to determine what action is available for a student
+export function getStudentActionType(
+  student: {
+    group_id?: string;
+    current_location?: string;
+  },
+  myGroups: string[],
+  mySupervisedRooms: string[],
+): StudentActionType {
+  const isInMyGroup = Boolean(
+    student.group_id && myGroups.includes(student.group_id),
+  );
+  const isInMySupervisedRoom = Boolean(
+    student.current_location &&
+    mySupervisedRooms.some((room) => student.current_location?.includes(room)),
+  );
+
+  // User must have access (be in student's group or supervising their room)
+  const hasAccess = isInMyGroup || isInMySupervisedRoom;
+
+  if (!hasAccess) {
+    return "none";
+  }
+
+  // Check if student is at home
+  const isAtHome =
+    !student.current_location || student.current_location.startsWith("Zuhause");
+
+  if (isAtHome) {
+    // Student is at home - can check in (but only if user is in student's group)
+    // Room supervisors can't check in students who aren't in a room
+    return isInMyGroup ? "checkin" : "none";
+  }
+
+  // Student is checked in (in OGS) - can check out
+  return "checkout";
 }

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -238,6 +238,7 @@ interface ConfirmationModalProps {
   confirmText?: string;
   cancelText?: string;
   isConfirmLoading?: boolean;
+  isConfirmDisabled?: boolean;
   confirmButtonClass?: string;
 }
 
@@ -250,6 +251,7 @@ export function ConfirmationModal({
   confirmText = "Bestätigen",
   cancelText = "Abbrechen",
   isConfirmLoading = false,
+  isConfirmDisabled = false,
   confirmButtonClass = "bg-blue-500 hover:bg-blue-600",
 }: ConfirmationModalProps) {
   const modalFooter = (
@@ -265,7 +267,7 @@ export function ConfirmationModal({
       <button
         type="button"
         onClick={onConfirm}
-        disabled={isConfirmLoading}
+        disabled={isConfirmLoading || isConfirmDisabled}
         className={`flex-1 rounded-lg px-4 py-2 ${confirmButtonClass} text-sm font-medium text-white transition-all duration-200 hover:scale-105 hover:shadow-lg active:scale-100 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:scale-100`}
       >
         {isConfirmLoading ? (

--- a/frontend/src/lib/scheduled-checkout-api.ts
+++ b/frontend/src/lib/scheduled-checkout-api.ts
@@ -110,3 +110,19 @@ export async function performImmediateCheckout(
     },
   );
 }
+
+// Perform immediate check-in of a student who is at home
+// activeGroupId is required - specifies which room session to check into
+export async function performImmediateCheckin(
+  studentId: number,
+  activeGroupId: number,
+  token?: string,
+): Promise<void> {
+  await api.post(
+    `/api/active/visits/student/${studentId}/checkin`,
+    { active_group_id: activeGroupId },
+    {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add backend checkin endpoint that accepts `active_group_id` and creates a Visit record (with auto-created attendance)
- Add frontend check-in section with green icon accent (matching dashboard "Aktive Gruppen" color `#83CD2D`)
- Add room selection dropdown in check-in confirmation modal
- Update checkout section with red icon accent (matching dashboard "Aktive Aktivitäten" color `#FF3130`)
- Add `isConfirmDisabled` prop to `ConfirmationModal` component

## Test plan
- [ ] Open a student detail page where student location is "Zuhause"
- [ ] Verify "Anmeldung" section appears with green icon
- [ ] Click "Kind anmelden" button
- [ ] Verify modal shows room dropdown with active rooms
- [ ] Select a room and click "Kind jetzt anmelden"
- [ ] Verify student's location updates to the selected room
- [ ] Verify "Abmeldung" section has red icon for checked-in students

Closes #609