### PR TITLE
fix(activities): lower FAB z-index to appear behind drawer modal

### DIFF
--- a/frontend/src/app/activities/page.tsx
+++ b/frontend/src/app/activities/page.tsx
@@ -316,10 +316,10 @@ export default function ActivitiesPage() {
           />
         </div>
 
-        {/* Mobile FAB Create Button */}
+        {/* Mobile FAB Create Button - z-40 to appear below drawer modal (z-50) */}
         <button
           onClick={() => setIsQuickCreateOpen(true)}
-          className="group fixed right-4 bottom-24 z-[9999] flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-[#FF3130] to-[#e02020] text-white shadow-[0_8px_30px_rgb(0,0,0,0.12)] transition-all duration-300 hover:shadow-[0_8px_40px_rgb(255,49,48,0.3)] active:scale-95 md:hidden"
+          className="group fixed right-4 bottom-24 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-[#FF3130] to-[#e02020] text-white shadow-[0_8px_30px_rgb(0,0,0,0.12)] transition-all duration-300 hover:shadow-[0_8px_40px_rgb(255,49,48,0.3)] active:scale-95 md:hidden"
           style={{
             background:
               "linear-gradient(135deg, rgb(255, 49, 48) 0%, rgb(224, 32, 32) 100%)",


### PR DESCRIPTION
## Summary
- Fix mobile FAB button appearing over the burger menu drawer modal
- Changed z-index from `z-[9999]` to `z-40` (below drawer's `z-50`)

## z-index hierarchy
| Element | z-index |
|---------|---------|
| Drawer Modal | z-50 |
| FAB Button | z-40 |
| Mobile Bottom Nav | z-30 |

## Test plan
- [x] Open `/activities` on mobile viewport
- [x] Tap burger menu to open drawer
- [x] Verify red + button is hidden behind the modal

Closes #630