### PR TITLE
chore: sync docker-compose.example.yml with docker-compose.yml

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -18,7 +18,7 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-debug}
       LOG_TEXTLOGGING: ${LOG_TEXTLOGGING:-"true"}
       PORT: ${PORT:-8080}
-      DB_DSN: ${DB_DSN}
+      DB_DSN: ${DB_DSN:-postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres?sslmode=require}
       DB_DEBUG: ${DB_DEBUG:-"true"}
       AUTH_JWT_SECRET: ${AUTH_JWT_SECRET}
       AUTH_JWT_EXPIRY: ${AUTH_JWT_EXPIRY:-15m}
@@ -51,7 +51,7 @@ services:
       SESSION_CLEANUP_ENABLED: ${SESSION_CLEANUP_ENABLED:-"true"}
       SESSION_CLEANUP_INTERVAL_MINUTES: ${SESSION_CLEANUP_INTERVAL_MINUTES:-15}
       SESSION_ABANDONED_THRESHOLD_MINUTES: ${SESSION_ABANDONED_THRESHOLD_MINUTES:-60}
-      OGS_DEVICE_PIN: ${OGS_DEVICE_PIN}
+      OGS_DEVICE_PIN: ${OGS_DEVICE_PIN:-1234}
     # air handles the serve command via .air.toml
 
   frontend:
@@ -98,7 +98,7 @@ services:
       start_period: 10s
 
   postgres:
-    image: postgres:17-alpine
+    image: postgres:17
     restart: unless-stopped
     ports:
       - 5432:5432
@@ -129,7 +129,7 @@ services:
   # Start with: docker compose --profile test up -d postgres-test
   # Or run all tests: docker compose --profile test up -d
   postgres-test:
-    image: postgres:17-alpine
+    image: postgres:17
     profiles: ["test"]
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary
- Sync `docker-compose.example.yml` with `docker-compose.yml` to fix post-merge hook drift warnings
- Add default fallback for `DB_DSN` so Docker works out-of-box without `.env`
- Add default fallback for `OGS_DEVICE_PIN`
- Switch postgres images from `17-alpine` to `17` (full image)

## Test plan
- [x] Run `lefthook run post-merge` — `docker-compose-sync` should show no diff