### PR TITLE
chore: replace playwright plugin with agent-browser CLI

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -17,7 +17,7 @@ claude
 
 ## What You Get (Out of the Box)
 
-### Plugins (12 active)
+### Plugins (11 active)
 
 | Plugin | Purpose |
 |--------|---------|
@@ -30,7 +30,7 @@ claude
 | **backend-api-security** | API security best practices |
 | **api-scaffolding** | API endpoint scaffolding |
 | **codebase-cleanup** | Dead code detection and cleanup |
-| **playwright** | Browser automation testing |
+| **agent-browser** | Browser automation CLI for AI agents |
 | **typescript-lsp** | TypeScript language server |
 | **gopls-lsp** | Go language server |
 
@@ -45,7 +45,7 @@ claude
 | **deep-dive-investigator** | Complex debugging, tracing code execution paths |
 | **research-thinker** | Research topics, compare alternatives, gather info |
 
-### Skills (7 available)
+### Skills (8 available)
 
 | Skill | Purpose |
 |-------|---------|
@@ -56,6 +56,7 @@ claude
 | **ui-skills** | UI/UX design constraints |
 | **web-design-guidelines** | Web interface guidelines |
 | **ralph-setup** | Set up iterative AI development loops |
+| **agent-browser** | Browser automation for web testing |
 
 ### Slash Commands
 
@@ -117,7 +118,8 @@ Comprehensive security guidelines covering:
 │   ├── sonarqube-mcp/
 │   ├── ui-skills/
 │   ├── web-design-guidelines/
-│   └── ralph-setup/
+│   ├── ralph-setup/
+│   └── agent-browser/
 └── rules/                 # 23 security guidelines
     ├── openspec.md
     └── security/
@@ -144,7 +146,7 @@ All project MCP servers are auto-enabled. Current MCPs include:
 - Context7 (documentation lookup)
 - Brave Search (web search)
 - SonarQube (code quality)
-- Playwright (browser automation)
+- agent-browser (browser automation CLI)
 - Sequential Thinking (complex reasoning)
 
 ## Personal Customization

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -92,6 +92,7 @@
       "Bash(ninja:*)",
       "Bash(deno:*)",
       "Bash(bun:*)",
+      "Bash(agent-browser:*)",
       "Bash(docker:*)",
       "Bash(osv-scanner:*)",
       "Bash(snyk:*)",
@@ -206,8 +207,7 @@
     "backend-api-security@claude-code-workflows": true,
     "api-scaffolding@claude-code-workflows": true,
     "codebase-cleanup@claude-code-workflows": true,
-    "playwright@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true,
+        "typescript-lsp@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true
   },
   "alwaysThinkingEnabled": true,

--- a/devbox.json
+++ b/devbox.json
@@ -45,6 +45,7 @@
       "lefthook install --force > /dev/null 2>&1 || true",
       "which goimports > /dev/null 2>&1 || go install golang.org/x/tools/cmd/goimports@latest > /dev/null 2>&1",
       "which deadcode > /dev/null 2>&1 || go install golang.org/x/tools/cmd/deadcode@latest > /dev/null 2>&1",
+      "which agent-browser > /dev/null 2>&1 || npm install -g agent-browser > /dev/null 2>&1",
       "[ ! -d frontend/node_modules ] && echo 'installing frontend deps...' && cd frontend && nci --silent || true",
       "echo \"go $(go version | cut -d' ' -f3 | sed 's/go//') node $(node -v | sed 's/v//') pnpm $(pnpm -v) | bat eza fzf rg fd tree jq yq glow xh btop curl | ni pgcli air gotestsum lazygit lazydocker gh swag govulncheck\""
     ]


### PR DESCRIPTION
## Summary
- Remove `playwright@claude-plugins-official` from `.claude/settings.json`
- Add `agent-browser` Bash permission to `.claude/settings.json`
- Add `agent-browser` auto-install in `devbox.json` init_hook
- Update `.claude/README.md` to document agent-browser skill

## Why
`agent-browser` is a lightweight CLI tool for browser automation that works well with AI agents. It uses refs (`@e1`, `@e2`) for deterministic element selection, making it more reliable for automated workflows than the MCP-based playwright plugin.

## Test plan
- [ ] Run `devbox install` and verify `agent-browser` is available
- [ ] Test with `agent-browser open example.com && agent-browser snapshot -i && agent-browser close`