### PR TITLE
feat(dx): add fix-docker-dependencies skill for team

### DIFF
--- a/.claude/skills/fix-docker-dependencies/SKILL.md
+++ b/.claude/skills/fix-docker-dependencies/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: fix-docker-dependencies
+description: Diagnose and fix "Module not found" errors caused by stale Docker dependency caches. Use when a dependency was added/removed/swapped but the Docker container still has old node_modules.
+metadata:
+  author: moto-nrw
+  version: "1.0.0"
+---
+
+# Fix Docker Dependency Sync Issues
+
+Use this when the frontend Docker container throws `Module not found: Can't resolve '<package>'` but `package.json` and `pnpm-lock.yaml` are correct.
+
+## Root Cause
+
+Docker caches the `pnpm install --frozen-lockfile` layer in the `dev-deps` build stage. When dependencies change in `package.json`/`pnpm-lock.yaml`, Docker may reuse a stale cached layer containing old `node_modules`. This is especially aggressive with `BUILDKIT_INLINE_CACHE: 1`.
+
+`docker compose up --build` only checks file hashes — if the lockfile hasn't changed since the last build, Docker reuses the cached install. This fails when switching packages (e.g., `better-auth` to `next-auth`).
+
+## Diagnosis Steps
+
+### 1. Confirm the package is in package.json and lockfile
+
+```bash
+cd frontend
+grep "<package>" package.json
+grep "<package>" pnpm-lock.yaml | head -5
+```
+
+Both should return results. If not, run `pnpm install` first.
+
+### 2. Check local node_modules
+
+```bash
+ls node_modules/<package>/ 2>&1 | head -5
+```
+
+If missing locally, run `pnpm install`.
+
+### 3. Check inside the running Docker container
+
+```bash
+docker compose exec frontend ls node_modules/<package>/ 2>&1 | head -5
+```
+
+If missing inside the container but present locally, the Docker cache is stale.
+
+## Fix Steps
+
+### Quick Fix (usually sufficient)
+
+```bash
+# 1. Sync local node_modules
+cd frontend && pnpm install
+
+# 2. Rebuild Docker without cache
+docker compose build --no-cache frontend
+
+# 3. Recreate the container
+docker compose up -d frontend
+
+# 4. Verify
+docker compose exec frontend ls node_modules/<package>/
+```
+
+### Nuclear Fix (if quick fix doesn't work)
+
+```bash
+# 1. Clean everything locally
+cd frontend
+rm -rf node_modules .next
+pnpm install
+
+# 2. Full Docker reset
+cd ..
+docker compose down
+docker builder prune -f
+docker compose build --no-cache frontend
+docker compose up -d
+
+# 3. Verify
+docker compose exec frontend ls node_modules/<package>/
+```
+
+## Key Takeaway
+
+- `docker compose up --build` reuses cached layers — it does NOT reinstall dependencies.
+- `docker compose build --no-cache <service>` forces a fresh install.
+- Always verify inside the container, not just locally: `docker compose exec frontend ls node_modules/<pkg>/`.
+
+## Prevention
+
+After changing dependencies in `package.json`, always rebuild with `--no-cache`:
+
+```bash
+pnpm install && docker compose build --no-cache frontend && docker compose up -d frontend
+```


### PR DESCRIPTION
## Summary
- Adds a new Claude Code skill (`fix-docker-dependencies`) that guides diagnosis and resolution of "Module not found" errors caused by stale Docker dependency caches
- Covers the full troubleshooting flow: verify package.json/lockfile, check local vs container node_modules, rebuild with `--no-cache`
- Auto-discovered by the existing skill-reminder hook — no config changes needed

## Context
After the `better-auth` → `next-auth` dependency swap, the Docker container kept serving stale `node_modules` with the old package. This skill documents the root cause and fix steps so the team can resolve this faster in the future.

## Test plan
- [ ] Verify skill appears in Claude Code skill list (check `skill-reminder` hook output)
- [ ] Invoke skill with `Skill` tool and confirm content loads correctly
- [ ] Confirm no other files were modified