### PR TITLE
fix(iot): RFID room checkout no longer marks student as "Zuhause"

### DIFF
--- a/backend/api/active/handlers_integration_test.go
+++ b/backend/api/active/handlers_integration_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 
-"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/api/testutil"
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"

--- a/backend/api/active/handlers_unit_test.go
+++ b/backend/api/active/handlers_unit_test.go
@@ -74,8 +74,8 @@ func TestNewActiveGroupResponse_WithActiveSupervisors(t *testing.T) {
 		StartTime: now,
 		EndTime:   nil,
 		Supervisors: []*active.GroupSupervisor{
-			{Model: base.Model{ID: 1}, StaffID: 10, Role: "Teacher", StartDate: now, EndDate: nil},   // Active
-			{Model: base.Model{ID: 2}, StaffID: 20, Role: "Helper", StartDate: now, EndDate: &now},   // Inactive (has end date)
+			{Model: base.Model{ID: 1}, StaffID: 10, Role: "Teacher", StartDate: now, EndDate: nil},    // Active
+			{Model: base.Model{ID: 2}, StaffID: 20, Role: "Helper", StartDate: now, EndDate: &now},    // Inactive (has end date)
 			{Model: base.Model{ID: 3}, StaffID: 30, Role: "Supervisor", StartDate: now, EndDate: nil}, // Active
 		},
 	}

--- a/backend/api/admin/grade_transitions.go
+++ b/backend/api/admin/grade_transitions.go
@@ -109,20 +109,20 @@ type MappingRequest struct {
 
 // TransitionResponse represents a transition in API responses
 type TransitionResponse struct {
-	ID           int64                    `json:"id"`
-	AcademicYear string                   `json:"academic_year"`
-	Status       string                   `json:"status"`
-	AppliedAt    *string                  `json:"applied_at,omitempty"`
-	AppliedBy    *int64                   `json:"applied_by,omitempty"`
-	RevertedAt   *string                  `json:"reverted_at,omitempty"`
-	RevertedBy   *int64                   `json:"reverted_by,omitempty"`
-	CreatedAt    string                   `json:"created_at"`
-	CreatedBy    int64                    `json:"created_by"`
-	Notes        *string                  `json:"notes,omitempty"`
-	Mappings     []MappingResponse        `json:"mappings,omitempty"`
-	CanModify    bool                     `json:"can_modify"`
-	CanApply     bool                     `json:"can_apply"`
-	CanRevert    bool                     `json:"can_revert"`
+	ID           int64             `json:"id"`
+	AcademicYear string            `json:"academic_year"`
+	Status       string            `json:"status"`
+	AppliedAt    *string           `json:"applied_at,omitempty"`
+	AppliedBy    *int64            `json:"applied_by,omitempty"`
+	RevertedAt   *string           `json:"reverted_at,omitempty"`
+	RevertedBy   *int64            `json:"reverted_by,omitempty"`
+	CreatedAt    string            `json:"created_at"`
+	CreatedBy    int64             `json:"created_by"`
+	Notes        *string           `json:"notes,omitempty"`
+	Mappings     []MappingResponse `json:"mappings,omitempty"`
+	CanModify    bool              `json:"can_modify"`
+	CanApply     bool              `json:"can_apply"`
+	CanRevert    bool              `json:"can_revert"`
 }
 
 // MappingResponse represents a mapping in API responses
@@ -471,10 +471,14 @@ func (rs *GradeTransitionResource) ApplyHandler() http.HandlerFunc { return rs.a
 func (rs *GradeTransitionResource) RevertHandler() http.HandlerFunc { return rs.revert }
 
 // GetDistinctClassesHandler returns the getDistinctClasses handler for testing
-func (rs *GradeTransitionResource) GetDistinctClassesHandler() http.HandlerFunc { return rs.getDistinctClasses }
+func (rs *GradeTransitionResource) GetDistinctClassesHandler() http.HandlerFunc {
+	return rs.getDistinctClasses
+}
 
 // SuggestMappingsHandler returns the suggestMappings handler for testing
-func (rs *GradeTransitionResource) SuggestMappingsHandler() http.HandlerFunc { return rs.suggestMappings }
+func (rs *GradeTransitionResource) SuggestMappingsHandler() http.HandlerFunc {
+	return rs.suggestMappings
+}
 
 // GetHistoryHandler returns the getHistory handler for testing
 func (rs *GradeTransitionResource) GetHistoryHandler() http.HandlerFunc { return rs.getHistory }

--- a/backend/database/repositories/education/grade_transition.go
+++ b/backend/database/repositories/education/grade_transition.go
@@ -68,7 +68,7 @@ func (r *GradeTransitionRepository) FindByID(ctx context.Context, id int64) (*ed
 	t := new(education.GradeTransition)
 	err := r.db.NewSelect().
 		Model(t).
-		ModelTableExpr(tableGradeTransitions + ` AS "grade_transition"`).
+		ModelTableExpr(tableGradeTransitions+` AS "grade_transition"`).
 		Where(`"grade_transition".id = ?`, id).
 		Scan(ctx)
 
@@ -87,7 +87,7 @@ func (r *GradeTransitionRepository) FindByIDWithMappings(ctx context.Context, id
 	t := new(education.GradeTransition)
 	err := r.db.NewSelect().
 		Model(t).
-		ModelTableExpr(tableGradeTransitions + ` AS "grade_transition"`).
+		ModelTableExpr(tableGradeTransitions+` AS "grade_transition"`).
 		Where(`"grade_transition".id = ?`, id).
 		Scan(ctx)
 
@@ -149,7 +149,7 @@ func (r *GradeTransitionRepository) Delete(ctx context.Context, id int64) error 
 
 	_, err := db.NewDelete().
 		Model((*education.GradeTransition)(nil)).
-		ModelTableExpr(tableGradeTransitions + ` AS "grade_transition"`).
+		ModelTableExpr(tableGradeTransitions+` AS "grade_transition"`).
 		Where(`"grade_transition".id = ?`, id).
 		Exec(ctx)
 	if err != nil {

--- a/backend/models/education/grade_transition.go
+++ b/backend/models/education/grade_transition.go
@@ -156,8 +156,8 @@ type GradeTransitionRepository interface {
 
 // StudentClassInfo contains basic student information for class transitions
 type StudentClassInfo struct {
-	StudentID  int64  `bun:"student_id"`
-	PersonID   int64  `bun:"person_id"`
-	PersonName string `bun:"person_name"`
+	StudentID   int64  `bun:"student_id"`
+	PersonID    int64  `bun:"person_id"`
+	PersonName  string `bun:"person_name"`
 	SchoolClass string `bun:"school_class"`
 }

--- a/backend/models/education/grade_transition_history.go
+++ b/backend/models/education/grade_transition_history.go
@@ -10,20 +10,20 @@ import (
 
 // Transition action constants
 const (
-	ActionPromoted   = "promoted"
-	ActionGraduated  = "graduated"
-	ActionUnchanged  = "unchanged"
+	ActionPromoted  = "promoted"
+	ActionGraduated = "graduated"
+	ActionUnchanged = "unchanged"
 )
 
 // GradeTransitionHistory records individual student changes during a grade transition
 type GradeTransitionHistory struct {
 	base.Model   `bun:"schema:education,table:grade_transition_history"`
 	TransitionID int64   `bun:"transition_id,notnull" json:"transition_id"`
-	StudentID    int64   `bun:"student_id,notnull" json:"student_id"` // Keep even if student deleted
+	StudentID    int64   `bun:"student_id,notnull" json:"student_id"`   // Keep even if student deleted
 	PersonName   string  `bun:"person_name,notnull" json:"person_name"` // Snapshot for audit trail
 	FromClass    string  `bun:"from_class,notnull" json:"from_class"`
 	ToClass      *string `bun:"to_class" json:"to_class,omitempty"` // NULL = graduated/deleted
-	Action       string  `bun:"action,notnull" json:"action"` // 'promoted', 'graduated', 'unchanged'
+	Action       string  `bun:"action,notnull" json:"action"`       // 'promoted', 'graduated', 'unchanged'
 }
 
 // TableName returns the database table name

--- a/backend/services/education/grade_transition_service.go
+++ b/backend/services/education/grade_transition_service.go
@@ -59,22 +59,22 @@ type MappingRequest struct {
 
 // TransitionPreview contains information about what will happen when applied
 type TransitionPreview struct {
-	TransitionID    int64                `json:"transition_id"`
-	AcademicYear    string               `json:"academic_year"`
-	TotalStudents   int                  `json:"total_students"`
-	ToPromote       int                  `json:"to_promote"`
-	ToGraduate      int                  `json:"to_graduate"`
-	ByMapping       []MappingPreview     `json:"by_mapping"`
-	UnmappedClasses []UnmappedClassInfo  `json:"unmapped_classes"`
-	Warnings        []string             `json:"warnings"`
+	TransitionID    int64               `json:"transition_id"`
+	AcademicYear    string              `json:"academic_year"`
+	TotalStudents   int                 `json:"total_students"`
+	ToPromote       int                 `json:"to_promote"`
+	ToGraduate      int                 `json:"to_graduate"`
+	ByMapping       []MappingPreview    `json:"by_mapping"`
+	UnmappedClasses []UnmappedClassInfo `json:"unmapped_classes"`
+	Warnings        []string            `json:"warnings"`
 }
 
 // MappingPreview shows the impact of a single mapping
 type MappingPreview struct {
-	FromClass    string `json:"from_class"`
+	FromClass    string  `json:"from_class"`
 	ToClass      *string `json:"to_class,omitempty"`
-	StudentCount int    `json:"student_count"`
-	Action       string `json:"action"` // "promote" or "graduate"
+	StudentCount int     `json:"student_count"`
+	Action       string  `json:"action"` // "promote" or "graduate"
 }
 
 // UnmappedClassInfo shows classes not included in the transition


### PR DESCRIPTION
## Summary
- **Bug**: When a student was checked out of a room via RFID (same-room scan), the frontend displayed "Zuhause" (at home) instead of "Unterwegs" (in transit)
- **Root cause**: `processCheckout` in `workflow.go` called `EndVisit(WithAttendanceAutoSync(...))`, which set the daily `attendance.check_out_time` when the student had no remaining room visits, causing the backend to return `"Abwesend"` → frontend mapped to `"Zuhause"`
- **Fix**: Removed `WithAttendanceAutoSync` from the RFID checkout path so only the room visit is ended, keeping daily attendance as `checked_in` with no active visit → correctly resolves to `"Unterwegs"`

## Test plan
- [x] Check in a student via RFID to a room → shows as "Anwesend" in correct room
- [x] Check out same student via RFID (same room scan) → now shows as "Unterwegs" instead of "Zuhause"
- [ ] Verify room transfer still works (scan at different room after checkout)
- [ ] Verify pending daily checkout flow still works (scan after STUDENT_DAILY_CHECKOUT_TIME in education group room)
- [ ] Verify manual checkout from UI still correctly marks student as "Zuhause"