### PR TITLE
fix: use timezone-aware date handling in pickup schedule seeder

### DIFF
--- a/backend/seed/fixed/pickup_schedules.go
+++ b/backend/seed/fixed/pickup_schedules.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/models/users"
 )
@@ -234,16 +235,19 @@ func (s *Seeder) createException(ctx context.Context, rng *rand.Rand, studentID 
 }
 
 // generateExceptionDate generates a random weekday within the next 2 weeks
+// Returns UTC midnight of the date in Berlin timezone for consistent DB storage
 func generateExceptionDate(rng *rand.Rand) time.Time {
 	daysFromNow := rng.Intn(14) + 1
-	date := time.Now().AddDate(0, 0, daysFromNow)
+	// Use Berlin timezone to ensure consistent date calculation
+	date := timezone.Now().AddDate(0, 0, daysFromNow)
 
 	// Skip weekends
 	for date.Weekday() == time.Saturday || date.Weekday() == time.Sunday {
 		date = date.AddDate(0, 0, 1)
 	}
 
-	return date
+	// Return as UTC midnight for consistent DB storage
+	return timezone.DateOfUTC(date)
 }
 
 // parseTimeOnly parses a time string (HH:MM) into a time.Time with only hour/minute set

--- a/frontend/src/app/students/[id]/page.tsx
+++ b/frontend/src/app/students/[id]/page.tsx
@@ -137,8 +137,8 @@ export default function StudentDetailPage() {
         } else {
           setTodayPickup({});
         }
-      } catch (err) {
-        console.error("Failed to load pickup data:", err);
+      } catch {
+        // Silently handle errors (e.g., permission denied for non-full-access users)
         setTodayPickup({});
       }
     };


### PR DESCRIPTION
## Summary
- Use `timezone.Now()` instead of `time.Now()` in pickup schedule seeder for consistent Berlin timezone handling
- Return UTC midnight via `timezone.DateOfUTC()` for consistent DB storage
- Silence console errors in frontend when pickup data fetch fails (e.g., permission denied for non-full-access users)

## Test plan
- [ ] Verify seeder creates pickup schedules with correct dates
- [ ] Verify frontend doesn't show console errors for restricted users