### PR TITLE
chore: auto-install Chromium for agent-browser

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -49,7 +49,7 @@
       "which grepai > /dev/null 2>&1 || (curl -sSL https://raw.githubusercontent.com/yoanbernabeu/grepai/main/install.sh | sh > /dev/null 2>&1)",
       "ollama list 2>/dev/null | grep -q nomic-embed-text || (echo 'pulling nomic-embed-text model...' && ollama pull nomic-embed-text > /dev/null 2>&1 &)",
       "pgrep -f 'grepai watch' > /dev/null || echo '💡 grepai watch not running — run: grepai watch &'",
-      "which agent-browser > /dev/null 2>&1 || npm install -g agent-browser > /dev/null 2>&1",
+      "which agent-browser > /dev/null 2>&1 || (npm install -g agent-browser > /dev/null 2>&1 && agent-browser install > /dev/null 2>&1)",
       "[ ! -d frontend/node_modules ] && echo 'installing frontend deps...' && cd frontend && nci --silent || true",
       "echo \"go $(go version | cut -d' ' -f3 | sed 's/go//') node $(node -v | sed 's/v//') pnpm $(pnpm -v) | bat eza fzf rg fd tree jq yq glow xh btop curl | ni pgcli air gotestsum lazygit lazydocker gh swag govulncheck\""
     ]


### PR DESCRIPTION
## Summary
- Adds `agent-browser install` (Chromium download) to the devbox init_hook, chained after `npm install -g agent-browser`
- Without this step, the CLI is installed but fails on first use because there's no browser binary

## Test plan
- [ ] Remove `agent-browser` globally (`npm uninstall -g agent-browser`)
- [ ] Re-enter the project directory (triggers devbox init_hook)
- [ ] Verify `agent-browser --version` works and `agent-browser open https://example.com` launches Chromium