### PR TITLE
refactor(ci): split test workflow into parallel jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,9 @@ defaults:
     shell: bash
 
 jobs:
-  test-and-coverage:
+  test-backend:
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
-    # PostgreSQL service for integration tests
     services:
       postgres:
         image: postgres:17
@@ -33,13 +32,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Required for SonarCloud
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
-      # Go Setup & Tests
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
           go-version-file: backend/go.mod
           cache: true
@@ -66,12 +62,26 @@ jobs:
           # From: github.com/moto-nrw/project-phoenix/... → backend/...
           sed -i 's|github.com/moto-nrw/project-phoenix/|backend/|g' backend/coverage.out
 
-      # Node Setup & Tests
+      - name: Upload backend coverage
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: coverage-backend
+          path: backend/coverage.out
+          retention-days: 7
+        if: always()
+
+  test-frontend:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
       - name: Enable corepack
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -85,18 +95,36 @@ jobs:
         working-directory: frontend
         run: pnpm run test:run --coverage
 
-      # Upload coverage artifacts for debugging
-      - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v6
+      - name: Upload frontend coverage
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: coverage-reports
-          path: |
-            backend/coverage.out
-            frontend/coverage/lcov.info
+          name: coverage-frontend
+          path: frontend/coverage/lcov.info
           retention-days: 7
         if: always()
 
-      # SonarCloud Scan
+  sonarcloud:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [test-backend, test-frontend]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0 # Required for SonarCloud PR analysis and SCM blame
+
+      - name: Download backend coverage
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: coverage-backend
+          path: backend/
+
+      - name: Download frontend coverage
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: coverage-frontend
+          path: frontend/coverage/
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
         env:


### PR DESCRIPTION
## Summary
- Split monolithic `test-and-coverage` job into 3 parallel jobs: `test-backend`, `test-frontend`, and `sonarcloud`
- Backend and frontend tests now run simultaneously, reducing CI wall-clock time to ~max(backend, frontend) + sonar overhead
- SHA-pin all actions to match `lint.yml` convention

## Test plan
- [ ] Verify `test-backend` and `test-frontend` start simultaneously in GitHub Actions UI
- [ ] Verify `sonarcloud` starts only after both test jobs complete
- [ ] Verify SonarCloud reports coverage correctly on the PR
- [ ] Check artifacts tab: `coverage-backend` and `coverage-frontend` both present