### PR TITLE
fix(ci): scope workflow permissions to job level

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,6 @@ on:
         type: boolean
         default: true
 
-permissions:
-  contents: read
-
 defaults:
   run:
     shell: bash
@@ -21,6 +18,8 @@ jobs:
   backend-format:
     if: ${{ inputs.run-backend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Setup Go with cache
@@ -49,6 +48,8 @@ jobs:
   backend-deadcode:
     if: ${{ inputs.run-backend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Setup Go with cache
@@ -111,6 +112,8 @@ jobs:
   backend-lint:
     if: ${{ inputs.run-backend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Setup Go with cache
@@ -129,6 +132,8 @@ jobs:
   backend-migration-validate:
     if: ${{ inputs.run-backend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Setup Go with cache
@@ -144,6 +149,8 @@ jobs:
   backend-licenses:
     if: ${{ inputs.run-backend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Setup Go with cache
@@ -176,6 +183,8 @@ jobs:
   frontend-lint:
     if: ${{ inputs.run-frontend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     env:
       NEXT_PUBLIC_API_URL: "http://localhost:8080" # Default API URL for linting
       SKIP_ENV_VALIDATION: "true" # Skip validation during linting
@@ -203,6 +212,8 @@ jobs:
   frontend-typecheck:
     if: ${{ inputs.run-frontend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     env:
       NEXT_PUBLIC_API_URL: "http://localhost:8080" # Default API URL for linting
       SKIP_ENV_VALIDATION: "true" # Skip validation during linting
@@ -230,6 +241,8 @@ jobs:
   frontend-knip:
     if: ${{ inputs.run-frontend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     env:
       NEXT_PUBLIC_API_URL: "http://localhost:8080" # Default API URL for linting
       SKIP_ENV_VALIDATION: "true" # Skip validation during linting
@@ -257,6 +270,8 @@ jobs:
   frontend-build:
     if: ${{ inputs.run-frontend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     env:
       NEXT_PUBLIC_API_URL: "http://localhost:8080"
       SKIP_ENV_VALIDATION: "true"
@@ -284,6 +299,8 @@ jobs:
   docker-build-backend-smoke:
     if: ${{ inputs.run-backend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
@@ -303,6 +320,8 @@ jobs:
   docker-build-frontend-smoke:
     if: ${{ inputs.run-frontend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,6 @@ on:
         description: "SonarCloud authentication token"
         required: true
 
-permissions:
-  contents: read
-  checks: write
-
 defaults:
   run:
     shell: bash
@@ -26,6 +22,9 @@ jobs:
   test-backend:
     if: ${{ inputs.run-backend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      checks: write
 
     services:
       postgres:
@@ -105,6 +104,8 @@ jobs:
   test-frontend:
     if: ${{ inputs.run-frontend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -138,6 +139,8 @@ jobs:
 
   sonarcloud:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     needs: [test-backend, test-frontend]
     if: always()
 


### PR DESCRIPTION
## Summary
- Moves `permissions` declarations from workflow level to individual job level in `lint.yml` and `test.yml`
- Restricts `checks: write` to only the `test-backend` job (the only one publishing JUnit reports)
- All other jobs receive only `contents: read`

Follows the principle of least privilege to reduce blast radius if any single job is compromised.

Resolves 3 SonarCloud security findings (Major vulnerabilities).

## Test plan
- [ ] Verify all lint jobs pass (they only need `contents: read`)
- [ ] Verify `test-backend` can still publish JUnit reports (`checks: write`)
- [ ] Verify `test-frontend` and `sonarcloud` jobs pass with `contents: read` only