### PR TITLE
chore: fix license references and add frontend license check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -166,19 +166,58 @@ jobs:
         run: |
           echo "🔍 Checking Go dependency licenses..."
 
-          # Disallowed licenses for an Apache-2.0 project (copyleft / network-copyleft)
+          # Disallowed licenses for a source-available project (copyleft / network-copyleft)
           DISALLOWED="AGPL-3.0,GPL-3.0,LGPL-3.0,SSPL-1.0,EUPL-1.2"
 
           # go-licenses check exits non-zero if disallowed licenses are found
           go-licenses check ./... --disallowed_types=restricted,reciprocal 2>&1 || {
             echo ""
             echo "❌ Disallowed licenses found in Go dependencies."
-            echo "GDPR/Apache-2.0 project cannot use restricted or reciprocal licenses."
+            echo "Source-available project cannot use restricted or reciprocal licenses."
             echo "Review the output above and replace the offending dependency."
             exit 1
           }
 
           echo "All Go dependency licenses are compatible"
+
+  frontend-licenses:
+    if: ${{ inputs.run-frontend }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: "frontend/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Check npm dependency licenses
+        working-directory: frontend
+        run: |
+          echo "🔍 Checking npm dependency licenses..."
+
+          npx license-checker --production --failOn \
+            "AGPL-1.0-only;AGPL-1.0-or-later;AGPL-3.0-only;AGPL-3.0-or-later;GPL-2.0-only;GPL-2.0-or-later;GPL-3.0-only;GPL-3.0-or-later;LGPL-2.0-only;LGPL-2.0-or-later;LGPL-2.1-only;LGPL-2.1-or-later;LGPL-3.0-only;LGPL-3.0-or-later;SSPL-1.0;EUPL-1.2" \
+            --summary || {
+            echo ""
+            echo "❌ Disallowed licenses found in npm dependencies."
+            echo "Source-available project cannot use restricted or reciprocal licenses."
+            echo "Review the output above and replace the offending dependency."
+            exit 1
+          }
+
+          echo "All npm dependency licenses are compatible"
 
   frontend-lint:
     if: ${{ inputs.run-frontend }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | Database | PostgreSQL 17+ (multi-schema, SSL) |
 | Auth | JWT (15min access, 1hr refresh) |
 | Testing | Go tests + Bruno API tests |
+| License | Source-Available (see [LICENSE](LICENSE)) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/moto-nrw/project-phoenix?style=flat-square)](https://github.com/moto-nrw/project-phoenix/stargazers)
 [![GitHub Issues](https://img.shields.io/github/issues/moto-nrw/project-phoenix?style=flat-square)](https://github.com/moto-nrw/project-phoenix/issues)
 [![GitHub Pull Requests](https://img.shields.io/github/issues-pr/moto-nrw/project-phoenix?style=flat-square)](https://github.com/moto-nrw/project-phoenix/pulls)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue?style=flat-square)](LICENSE)
+[![License](https://img.shields.io/badge/License-Source--Available-blue?style=flat-square)](LICENSE)
 [![GDPR](https://img.shields.io/badge/GDPR-Compliant-success?style=flat-square)](SECURITY.md#gdpr-compliance)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](CONTRIBUTING.md)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-3.0-4baaaa?style=flat-square)](CODE_OF_CONDUCT.md)
@@ -336,7 +336,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 
 ## 📄 License
 
-Distributed under the Apache License 2.0. See [LICENSE](LICENSE) for more information.
+Distributed under a Source-Available License. See [LICENSE](LICENSE) for more information.
 
 ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "phoenix-frontend",
   "version": "0.1.0",
   "private": true,
-  "license": "Apache-2.0",
+  "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
## Summary
- Fix all stale Apache-2.0 references to match the actual source-available license
- Add `frontend-licenses` CI job to check npm dependencies for copyleft licenses (mirrors the existing `backend-licenses` job)
- Update CLAUDE.md with license info so AI assistants know the correct license

## Changes
- **`.github/workflows/lint.yml`**: Fix backend CI error messages; add new `frontend-licenses` job using `license-checker` with `--failOn` for AGPL/GPL/LGPL/SSPL/EUPL
- **`README.md`**: Fix badge (`Apache 2.0` → `Source-Available`) and license section text
- **`frontend/package.json`**: Fix license field (`Apache-2.0` → `SEE LICENSE IN LICENSE`)
- **`CLAUDE.md`**: Add license row to project overview table

## Test plan
- [ ] CI `frontend-licenses` job passes on this branch
- [ ] CI `backend-licenses` job still passes (only comment/message changed)
- [ ] README badge renders correctly on GitHub