### PR TITLE
fix: align database config defaults with Docker Compose

### DIFF
--- a/backend/database/database_config.go
+++ b/backend/database/database_config.go
@@ -32,7 +32,8 @@ func GetDatabaseDSN() string {
 		return "postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable"
 	case "development":
 		// Development database with SSL (sslmode=require for GDPR compliance)
-		return "postgres://postgres:postgres@localhost:5432/phoenix?sslmode=require"
+		// Database name "postgres" matches Docker Compose default (no POSTGRES_DB override)
+		return "postgres://postgres:postgres@localhost:5432/postgres?sslmode=require"
 	case "production":
 		// Production requires explicit DB_DSN (fail fast if missing)
 		log.Fatal("APP_ENV=production requires explicit DB_DSN environment variable")
@@ -45,5 +46,5 @@ func GetDatabaseDSN() string {
 
 	// 4. Fallback to development default
 	// This allows: go run main.go serve (without setting APP_ENV explicitly)
-	return "postgres://postgres:postgres@localhost:5432/phoenix?sslmode=require"
+	return "postgres://postgres:postgres@localhost:5432/postgres?sslmode=require"
 }

--- a/backend/dev.env.example
+++ b/backend/dev.env.example
@@ -14,19 +14,15 @@ LOG_TEXTLOGGING=false
 APP_ENV=development
 
 # Database Connection
-# OPTIONAL - Only set for production/Docker deployments with non-standard configs
-# If not set, uses smart defaults based on APP_ENV:
-#   - APP_ENV=development → postgres://postgres:postgres@localhost:5432/phoenix?sslmode=require
-#   - APP_ENV=test → postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable
-#   - APP_ENV=production → MUST be set, otherwise fails at startup
+# DB_DSN is intentionally NOT set here. APP_ENV controls the database:
+#   APP_ENV=development → localhost:5432/postgres (sslmode=require)
+#   APP_ENV=test        → localhost:5433/phoenix_test (sslmode=disable)
+#   APP_ENV=production  → requires explicit DB_DSN
+# Only set DB_DSN for production/Docker deployments with non-standard configs.
+# See database/database_config.go for the full precedence logic.
 #
 # Example for custom production setup:
 # DB_DSN=postgres://user:pass@prod-db.example.com:5432/phoenix?sslmode=verify-full
-# DB_DSN=
-
-# Legacy database configuration (for backwards compatibility)
-# Only used if APP_ENV-based defaults don't apply and DB_DSN is not set
-# TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable
 
 AUTH_LOGIN_URL=http://localhost:8080/login
 AUTH_LOGIN_TOKEN_LENGTH=8


### PR DESCRIPTION
## Summary
- Fix development default DSN in `GetDatabaseDSN()` to use `postgres` database name (matches Docker Compose default) instead of `phoenix` (which doesn't exist)
- Remove `DB_DSN` and `TEST_DB_DSN` from `backend/dev.env.example` — `APP_ENV` is the single source of truth for dev/test database selection
- Remove dead BetterAuth env vars from `frontend/.env.local` (unused, no code references)

## Problem
The development default in `database_config.go` pointed to database `phoenix`, but Docker Compose creates database `postgres`. This forced everyone to set explicit `DB_DSN` in `dev.env`, which silently overrode `APP_ENV` for all environments — the same class of bug as [Rails #21441](https://github.com/rails/rails/issues/21441) where `DATABASE_URL` accidentally caused test runs to hit production.

The `dotenv-linter` env-sync check also flagged mismatches between `.env` files and their `.example` counterparts due to commented-out keys and dead BetterAuth config.

## Changes
| File | Change |
|------|--------|
| `backend/database/database_config.go` | Fix dev default: `phoenix` → `postgres` (matches Docker) |
| `backend/dev.env.example` | Document APP_ENV-only pattern, remove commented DB_DSN/TEST_DB_DSN |

**Local-only (git-ignored, not in this PR):**
- `backend/dev.env`: Removed redundant `DB_DSN` and `TEST_DB_DSN`
- `frontend/.env.local`: Removed dead BetterAuth keys (`INTERNAL_API_KEY`, `NEXT_PUBLIC_BASE_DOMAIN`, `BETTERAUTH_INTERNAL_URL`, `SAAS_ADMIN_EMAILS`)

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `dotenv-linter diff backend/dev.env backend/dev.env.example` — no missing keys
- [x] `dotenv-linter diff frontend/.env.local frontend/.env.example` — no missing keys
- [ ] `lefthook run post-merge` shows no env-sync warnings
- [ ] CI backend tests pass (uses explicit `DB_DSN`/`TEST_DB_DSN`, unaffected by default change)

Closes #753