### PR TITLE
fix(frontend): prevent unhandled timer errors in logout-modal tests

### DIFF
--- a/frontend/src/components/ui/logout-modal.test.tsx
+++ b/frontend/src/components/ui/logout-modal.test.tsx
@@ -3,7 +3,7 @@
  * Tests the rendering and logout functionality
  */
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { LogoutModal } from "./logout-modal";
 
 // Mock next-auth/react
@@ -45,8 +45,14 @@ describe("LogoutModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     mockSignOut.mockResolvedValue(undefined);
     Element.prototype.animate = mockAnimate;
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
   });
 
   it("renders nothing when closed", () => {


### PR DESCRIPTION
## Summary
- Fix 11 unhandled `ReferenceError: document is not defined` errors reported by Vitest during CI
- Root cause: `launchConfetti()` spawns 100 `setTimeout` callbacks that fire after test teardown when the happy-dom environment is already torn down
- Use `vi.useFakeTimers({ shouldAdvanceTime: true })` to intercept timer callbacks, and flush them in `afterEach` cleanup

## Test plan
- [x] All 12 logout-modal tests pass
- [x] Full frontend suite passes (406 files, 5848 tests, 0 unhandled errors)