### PR TITLE
Release: Add active_students count to checkin response

### DIFF
--- a/backend/api/iot/checkin/checkin_test.go
+++ b/backend/api/iot/checkin/checkin_test.go
@@ -15,11 +15,17 @@ import (
 
 	checkinAPI "github.com/moto-nrw/project-phoenix/api/iot/checkin"
 	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/facilities"
 	"github.com/moto-nrw/project-phoenix/models/iot"
 	"github.com/moto-nrw/project-phoenix/services"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
+
+// intPtr returns a pointer to an int value.
+func intPtr(i int) *int {
+	return &i
+}
 
 // testContext holds shared test dependencies.
 type testContext struct {
@@ -1165,6 +1171,615 @@ func TestDeviceCheckin_SchulhofAutoCreate(t *testing.T) {
 // TestDeviceCheckin_SchulhofAutoCreateIdempotent verifies that the Schulhof
 // auto-create flow is idempotent: a second checkin reuses the already-created
 // activity group instead of failing or creating duplicates.
+// =============================================================================
+// ACTIVE STUDENTS COUNT TESTS
+// =============================================================================
+
+func TestDeviceCheckin_ResponseContainsActiveStudents(t *testing.T) {
+	// Verifies that a successful checkin response includes the active_students count
+	// when the device is linked to an active session.
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "active-count")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Count", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Count", "Student", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("COUNT%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	room := testpkg.CreateTestRoom(t, ctx.db, "Count Room")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, room.ID)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Count Activity")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activity.ID)
+
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activeGroup.ID)
+
+	// Link device to active group so getActiveStudentCountForRoom finds it
+	_, err := ctx.db.NewUpdate().
+		TableExpr("active.groups").
+		Set("device_id = ?", device.ID).
+		Where("id = ?", activeGroup.ID).
+		Exec(t.Context())
+	require.NoError(t, err)
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      room.ID,
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	data, ok := response["data"].(map[string]interface{})
+	assert.True(t, ok, "Response should have data field")
+	assert.Equal(t, "checked_in", data["action"])
+
+	// Verify active_students is present in the response
+	activeStudents, exists := data["active_students"]
+	assert.True(t, exists, "Response should contain active_students field")
+	// After checkin, there should be at least 1 active student
+	assert.GreaterOrEqual(t, activeStudents, float64(1), "Should have at least 1 active student after checkin")
+}
+
+func TestDeviceCheckin_ActiveStudentsCountWithMultipleStudents(t *testing.T) {
+	// Check in two students and verify the count increments correctly
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "multi-count")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Multi", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	// Create two students
+	student1 := testpkg.CreateTestStudent(t, ctx.db, "First", "Counter", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student1.ID)
+	tag1 := fmt.Sprintf("MC1%d", time.Now().UnixNano())
+	card1 := testpkg.CreateTestRFIDCard(t, ctx.db, tag1)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card1.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student1.PersonID, card1.ID)
+
+	student2 := testpkg.CreateTestStudent(t, ctx.db, "Second", "Counter", "1b")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student2.ID)
+	tag2 := fmt.Sprintf("MC2%d", time.Now().UnixNano())
+	card2 := testpkg.CreateTestRFIDCard(t, ctx.db, tag2)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card2.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student2.PersonID, card2.ID)
+
+	room := testpkg.CreateTestRoom(t, ctx.db, "Multi Count Room")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, room.ID)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Multi Count Activity")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activity.ID)
+
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activeGroup.ID)
+
+	// Link device to active group
+	_, err := ctx.db.NewUpdate().
+		TableExpr("active.groups").
+		Set("device_id = ?", device.ID).
+		Where("id = ?", activeGroup.ID).
+		Exec(t.Context())
+	require.NoError(t, err)
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	// Check in first student
+	body1 := map[string]interface{}{
+		"student_rfid": card1.ID,
+		"action":       "checkin",
+		"room_id":      room.ID,
+	}
+	req1 := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body1,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+	rr1 := testutil.ExecuteRequest(router, req1)
+	testutil.AssertSuccessResponse(t, rr1, http.StatusOK)
+
+	// Check in second student
+	body2 := map[string]interface{}{
+		"student_rfid": card2.ID,
+		"action":       "checkin",
+		"room_id":      room.ID,
+	}
+	req2 := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body2,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+	rr2 := testutil.ExecuteRequest(router, req2)
+	testutil.AssertSuccessResponse(t, rr2, http.StatusOK)
+
+	response := testutil.ParseJSONResponse(t, rr2.Body.Bytes())
+	data, ok := response["data"].(map[string]interface{})
+	assert.True(t, ok, "Response should have data field")
+
+	// After two checkins, active_students should be 2
+	activeStudents, exists := data["active_students"]
+	assert.True(t, exists, "Response should contain active_students field")
+	assert.Equal(t, float64(2), activeStudents, "Should have 2 active students after two checkins")
+}
+
+// =============================================================================
+// SAME ROOM SCAN (SKIP CHECKIN) TESTS
+// =============================================================================
+
+func TestDeviceCheckin_SameRoomScanSkipsCheckin(t *testing.T) {
+	// When a student scans out from a room and the same room_id is provided,
+	// the checkin should be skipped (student stays checked out from that room).
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "same-room")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Same", "Room")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Same", "RoomStudent", "2a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("SAME%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	room := testpkg.CreateTestRoom(t, ctx.db, "Same Room Test")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, room.ID)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Same Room Activity")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activity.ID)
+
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activeGroup.ID)
+
+	// Create an active visit in the same room
+	visit := testpkg.CreateTestVisit(t, ctx.db, student.ID, activeGroup.ID, time.Now().Add(-5*time.Minute), nil)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, visit.ID)
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	// Scan with the SAME room_id - this should checkout + skip re-checkin
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      room.ID,
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	data, ok := response["data"].(map[string]interface{})
+	assert.True(t, ok, "Response should have data field")
+
+	// Same room scan should result in checkout (not transfer or re-checkin)
+	assert.Equal(t, "checked_out", data["action"])
+}
+
+// =============================================================================
+// ROOM CAPACITY TESTS
+// =============================================================================
+
+func TestDeviceCheckin_RoomCapacityExceeded(t *testing.T) {
+	// Verifies that checkin fails when room is at capacity
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "capacity-test")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Cap", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	// Create a room with capacity of 1
+	dbCtx := t.Context()
+	capacityRoom := &facilities.Room{
+		Name:     fmt.Sprintf("Tiny Room-%d", time.Now().UnixNano()),
+		Building: "Test Building",
+		Capacity: intPtr(1),
+	}
+	err := ctx.db.NewInsert().
+		Model(capacityRoom).
+		ModelTableExpr("facilities.rooms").
+		Scan(dbCtx)
+	require.NoError(t, err)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, capacityRoom.ID)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Capacity Activity")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activity.ID)
+
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, capacityRoom.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activeGroup.ID)
+
+	// Fill the room to capacity with one student
+	existingStudent := testpkg.CreateTestStudent(t, ctx.db, "Existing", "Student", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, existingStudent.ID)
+
+	visit := testpkg.CreateTestVisit(t, ctx.db, existingStudent.ID, activeGroup.ID, time.Now().Add(-10*time.Minute), nil)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, visit.ID)
+
+	// Now try to check in another student
+	newStudent := testpkg.CreateTestStudent(t, ctx.db, "Over", "Capacity", "1b")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, newStudent.ID)
+
+	tagID := fmt.Sprintf("OVERCAP%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, newStudent.PersonID, card.ID)
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      capacityRoom.ID,
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	// Should fail due to room capacity being exceeded
+	assert.Equal(t, http.StatusConflict, rr.Code, "Expected 409 Conflict for capacity exceeded. Body: %s", rr.Body.String())
+}
+
+// =============================================================================
+// CHECKOUT WITH ROOM INFO TESTS
+// =============================================================================
+
+func TestDeviceCheckin_CheckoutResponseIncludesRoomName(t *testing.T) {
+	// Verifies that checkout response includes the room name from the active visit
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "checkout-room")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Room", "Info", "3c")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("RMINFO%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	room := testpkg.CreateTestRoom(t, ctx.db, "Info Room")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, room.ID)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Info Activity")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activity.ID)
+
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activeGroup.ID)
+
+	visit := testpkg.CreateTestVisit(t, ctx.db, student.ID, activeGroup.ID, time.Now().Add(-15*time.Minute), nil)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, visit.ID)
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkout",
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	data, ok := response["data"].(map[string]interface{})
+	assert.True(t, ok, "Response should have data field")
+	assert.Equal(t, "checked_out", data["action"])
+	assert.Equal(t, "success", data["status"])
+	// The student_name should be present
+	assert.Contains(t, data["student_name"], "Room")
+}
+
+// =============================================================================
+// NO ACTION EDGE CASE TEST
+// =============================================================================
+
+func TestDeviceCheckin_CheckoutWithNoRoomIDAndNoVisit(t *testing.T) {
+	// Student with no active visit and no room_id should get an error
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "no-action")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "NoAction", "Test", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("NOACT%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	// No room_id, no active visit - should fail
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	// Should fail because room_id is required and student has no active visit
+	testutil.AssertBadRequest(t, rr)
+}
+
+// =============================================================================
+// ACTIVITY CAPACITY TESTS
+// =============================================================================
+
+func TestDeviceCheckin_ActivityCapacityExceeded(t *testing.T) {
+	// Verifies that checkin fails when activity MaxParticipants is reached
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "act-cap")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "ActCap", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	room := testpkg.CreateTestRoom(t, ctx.db, "Activity Cap Room")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, room.ID)
+
+	// Create activity with MaxParticipants = 1
+	category := testpkg.CreateTestActivityCategory(t, ctx.db, fmt.Sprintf("Cap-Cat-%d", time.Now().UnixNano()))
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, category.ID)
+
+	creatorStaff := testpkg.CreateTestStaff(t, ctx.db, "Cap", "Creator")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, creatorStaff.ID)
+
+	dbCtx := t.Context()
+	activityGroup := &activities.Group{
+		Name:            fmt.Sprintf("Tiny Activity-%d", time.Now().UnixNano()),
+		MaxParticipants: 1, // Only 1 participant allowed
+		IsOpen:          true,
+		CategoryID:      category.ID,
+		CreatedBy:       creatorStaff.ID,
+	}
+	err := ctx.db.NewInsert().
+		Model(activityGroup).
+		ModelTableExpr(`activities.groups AS "group"`).
+		Scan(dbCtx)
+	require.NoError(t, err)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activityGroup.ID)
+
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activityGroup.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activeGroup.ID)
+
+	// Fill the activity to capacity with one student
+	existingStudent := testpkg.CreateTestStudent(t, ctx.db, "Existing", "ActCap", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, existingStudent.ID)
+
+	visit := testpkg.CreateTestVisit(t, ctx.db, existingStudent.ID, activeGroup.ID, time.Now().Add(-10*time.Minute), nil)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, visit.ID)
+
+	// Now try to check in another student - should fail
+	newStudent := testpkg.CreateTestStudent(t, ctx.db, "Over", "ActCap", "1b")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, newStudent.ID)
+
+	tagID := fmt.Sprintf("ACTCAP%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, newStudent.PersonID, card.ID)
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      room.ID,
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	// Should fail due to activity capacity being exceeded
+	assert.Equal(t, http.StatusConflict, rr.Code, "Expected 409 Conflict for activity capacity exceeded. Body: %s", rr.Body.String())
+}
+
+// =============================================================================
+// ACTIVE STUDENTS FALLBACK PATH TESTS
+// =============================================================================
+
+func TestDeviceCheckin_ActiveStudentsFallbackWithoutDeviceLink(t *testing.T) {
+	// When the device is NOT linked to an active group, getActiveStudentCountForRoom
+	// falls back to counting across all groups in the room
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "fallback-count")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Fallback", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Fallback", "Student", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("FALLBACK%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	room := testpkg.CreateTestRoom(t, ctx.db, "Fallback Room")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, room.ID)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Fallback Activity")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activity.ID)
+
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activeGroup.ID)
+
+	// NOTE: device_id is NOT set on the active group - this forces the fallback path
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      room.ID,
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	data, ok := response["data"].(map[string]interface{})
+	assert.True(t, ok, "Response should have data field")
+	assert.Equal(t, "checked_in", data["action"])
+
+	// active_students should still be present via fallback path
+	activeStudents, exists := data["active_students"]
+	assert.True(t, exists, "Response should contain active_students via fallback path")
+	assert.GreaterOrEqual(t, activeStudents, float64(1))
+}
+
+// =============================================================================
+// SESSION ACTIVITY UPDATE TESTS
+// =============================================================================
+
+func TestDeviceCheckin_UpdatesSessionActivity(t *testing.T) {
+	// Verifies that a checkin with room_id updates the session's last activity
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "session-update")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Session", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Session", "Update", "2a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("SESS%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	room := testpkg.CreateTestRoom(t, ctx.db, "Session Room")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, room.ID)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Session Activity")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activity.ID)
+
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activeGroup.ID)
+
+	// Link device to session
+	_, err := ctx.db.NewUpdate().
+		TableExpr("active.groups").
+		Set("device_id = ?", device.ID).
+		Where("id = ?", activeGroup.ID).
+		Exec(t.Context())
+	require.NoError(t, err)
+
+	// Record initial last_activity
+	var initialLastActivity time.Time
+	err = ctx.db.NewSelect().
+		TableExpr("active.groups").
+		Column("last_activity").
+		Where("id = ?", activeGroup.ID).
+		Scan(t.Context(), &initialLastActivity)
+	require.NoError(t, err)
+
+	// Small delay to ensure time difference
+	time.Sleep(10 * time.Millisecond)
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      room.ID,
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	// Verify last_activity was updated
+	var updatedLastActivity time.Time
+	err = ctx.db.NewSelect().
+		TableExpr("active.groups").
+		Column("last_activity").
+		Where("id = ?", activeGroup.ID).
+		Scan(t.Context(), &updatedLastActivity)
+	require.NoError(t, err)
+
+	assert.True(t, updatedLastActivity.After(initialLastActivity) || updatedLastActivity.Equal(initialLastActivity),
+		"last_activity should be updated after checkin")
+}
+
 func TestDeviceCheckin_SchulhofAutoCreateIdempotent(t *testing.T) {
 	ctx := setupTestContext(t)
 	defer func() { _ = ctx.db.Close() }()

--- a/backend/api/iot/checkin/handlers.go
+++ b/backend/api/iot/checkin/handlers.go
@@ -192,6 +192,11 @@ func (rs *Resource) deviceCheckin(w http.ResponseWriter, r *http.Request) {
 		rs.updateSessionActivityForDevice(ctx, *req.RoomID, deviceCtx.ID)
 	}
 
+	// Step 11b: Get active student count for response
+	if req.RoomID != nil {
+		result.ActiveStudents = rs.getActiveStudentCountForRoom(ctx, *req.RoomID, deviceCtx.ID)
+	}
+
 	// Step 12: Build and send response
 	response := buildCheckinResponse(student, result, now)
 	log.Printf("[CHECKIN] Final response: action='%s', student='%s %s', message='%s', visit_id=%v, room='%s'",


### PR DESCRIPTION
## Summary
- Add `active_students` count to the IoT checkin response, showing how many students are currently checked in across active groups
- Return `nil` for `active_students` when no active groups exist (instead of 0)
- Add comprehensive unit and integration tests for the checkin workflow

## Changes
- `backend/api/iot/checkin/workflow.go` — new logic to count active students
- `backend/api/iot/checkin/handlers.go` — wire active_students into response
- `backend/api/iot/checkin/checkin_test.go` — integration tests
- `backend/api/iot/checkin/checkin_internal_test.go` — unit tests

## Test plan
- [ ] Verify checkin response includes `active_students` count when groups are active
- [ ] Verify `active_students` is `null` when no active groups exist
- [ ] Run `go test ./api/iot/checkin/...` — all tests pass
- [ ] Run Bruno API tests for checkin endpoint