### PR TITLE
perf: eliminate N+1 queries in GET /api/groups

### DIFF
--- a/backend/api/groups/api.go
+++ b/backend/api/groups/api.go
@@ -500,34 +500,43 @@ func (rs *Resource) listGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build response
+	// Collect group IDs for batch operations
+	groupIDs := make([]int64, len(groups))
+	for i, g := range groups {
+		groupIDs[i] = g.ID
+	}
+
+	// Batch load student counts (1 query instead of N)
+	studentCounts, err := rs.StudentRepo.CountByGroupIDs(r.Context(), groupIDs)
+	if err != nil {
+		slog.Default().Warn("failed to batch load student counts", slog.String("error", err.Error()))
+		studentCounts = make(map[int64]int)
+	}
+
+	// Batch load teachers for all groups (2 queries instead of ~N*4)
+	teachersByGroup, err := rs.EducationService.GetTeachersForGroups(r.Context(), groupIDs)
+	if err != nil {
+		slog.Default().Warn("failed to batch load teachers", slog.String("error", err.Error()))
+		teachersByGroup = make(map[int64][]*users.Teacher)
+	}
+
+	// Build response using pre-loaded data
 	responses := make([]GroupResponse, 0, len(groups))
 	for _, group := range groups {
-		// If group has room ID but room isn't loaded, fetch the room details
-		if group.HasRoom() && group.Room == nil {
-			groupWithRoom, err := rs.EducationService.FindGroupWithRoom(r.Context(), group.ID)
-			if err == nil {
-				group = groupWithRoom
-			}
-		}
-
-		// Get teachers for this group to show representative in list
-		teachers, err := rs.EducationService.GetGroupTeachers(r.Context(), group.ID)
-		if err != nil {
-			// Log error but continue without teachers
-			slog.Default().Warn("failed to get teachers for group",
-				slog.Int64("group_id", group.ID),
-				slog.String("error", err.Error()))
-			teachers = []*users.Teacher{}
-		}
-
-		// Get student count for this group
-		studentCount := rs.getStudentCount(r.Context(), group.ID)
-
+		teachers := teachersByGroup[group.ID]
+		studentCount := studentCounts[group.ID]
 		responses = append(responses, newGroupResponse(group, teachers, studentCount))
 	}
 
-	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: page, PageSize: pageSize, Total: len(responses)}, "Groups retrieved successfully")
+	// Count total for pagination (same filters, no LIMIT/OFFSET)
+	countOptions := base.NewQueryOptions()
+	countOptions.Filter = filter
+	total, countErr := rs.EducationService.CountGroups(r.Context(), countOptions)
+	if countErr != nil {
+		total = len(responses)
+	}
+
+	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: page, PageSize: pageSize, Total: total}, "Groups retrieved successfully")
 }
 
 // getGroup handles getting a group by ID

--- a/backend/database/repositories/education/group.go
+++ b/backend/database/repositories/education/group.go
@@ -4,6 +4,7 @@ package education
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
@@ -220,15 +221,37 @@ func applyGroupFilterField(filter *modelBase.Filter, field string, value interfa
 	}
 }
 
+// groupWithRoom is used to scan LEFT JOIN results for group + room data
+type groupWithRoom struct {
+	Group *education.Group `bun:"group"`
+	Room  *facilities.Room `bun:"room"`
+}
+
 // ListWithOptions provides a type-safe way to list groups with query options
 func (r *GroupRepository) ListWithOptions(ctx context.Context, options *modelBase.QueryOptions) ([]*education.Group, error) {
-	var groups []*education.Group
+	var results []groupWithRoom
 	query := r.db.NewSelect().
-		Model(&groups).
-		ModelTableExpr(`education.groups AS "group"`)
+		Model(&results).
+		ModelTableExpr(`education.groups AS "group"`).
+		ColumnExpr(`"group".id AS "group__id", "group".created_at AS "group__created_at", "group".updated_at AS "group__updated_at"`).
+		ColumnExpr(`"group".name AS "group__name", "group".room_id AS "group__room_id"`).
+		ColumnExpr(`"room".id AS "room__id", "room".created_at AS "room__created_at", "room".updated_at AS "room__updated_at"`).
+		ColumnExpr(`"room".name AS "room__name", "room".building AS "room__building", "room".floor AS "room__floor"`).
+		ColumnExpr(`"room".capacity AS "room__capacity", "room".category AS "room__category", "room".color AS "room__color"`).
+		Join(`LEFT JOIN facilities.rooms AS "room" ON "room".id = "group".room_id`)
 
-	// Apply query options
+	// Apply query options (ensure table alias for JOINed queries to avoid ambiguous columns)
 	if options != nil {
+		if options.Filter != nil {
+			options.Filter.WithTableAlias("group")
+		}
+		if options.Sorting != nil {
+			for i, f := range options.Sorting.Fields {
+				if !strings.Contains(f.Field, ".") {
+					options.Sorting.Fields[i].Field = `group.` + f.Field
+				}
+			}
+		}
 		query = options.ApplyToQuery(query)
 	}
 
@@ -240,5 +263,40 @@ func (r *GroupRepository) ListWithOptions(ctx context.Context, options *modelBas
 		}
 	}
 
+	// Map results back to []*education.Group with room attached
+	groups := make([]*education.Group, len(results))
+	for i, result := range results {
+		groups[i] = result.Group
+		if result.Room != nil && result.Room.ID != 0 {
+			groups[i].Room = result.Room
+		}
+	}
+
 	return groups, nil
+}
+
+// CountWithOptions counts groups matching the query options (without pagination)
+func (r *GroupRepository) CountWithOptions(ctx context.Context, options *modelBase.QueryOptions) (int, error) {
+	query := r.db.NewSelect().
+		Model((*education.Group)(nil)).
+		ModelTableExpr(`education.groups AS "group"`).
+		Column("group.id")
+
+	// Apply only filters (not pagination) for counting
+	if options != nil {
+		if options.Filter != nil {
+			options.Filter.WithTableAlias("group")
+			query = options.Filter.ApplyToQuery(query)
+		}
+	}
+
+	count, err := query.Count(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "count with options",
+			Err: err,
+		}
+	}
+
+	return count, nil
 }

--- a/backend/database/repositories/education/group_teacher.go
+++ b/backend/database/repositories/education/group_teacher.go
@@ -63,6 +63,29 @@ func (r *GroupTeacherRepository) FindByTeacher(ctx context.Context, teacherID in
 	return groupTeachers, nil
 }
 
+// FindByGroupIDs retrieves all group-teacher relationships for multiple groups in a single query
+func (r *GroupTeacherRepository) FindByGroupIDs(ctx context.Context, groupIDs []int64) ([]*education.GroupTeacher, error) {
+	if len(groupIDs) == 0 {
+		return []*education.GroupTeacher{}, nil
+	}
+
+	var groupTeachers []*education.GroupTeacher
+	err := r.db.NewSelect().
+		Model(&groupTeachers).
+		ModelTableExpr(`education.group_teacher AS "group_teacher"`).
+		Where(`"group_teacher".group_id IN (?)`, bun.In(groupIDs)).
+		Scan(ctx)
+
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by group IDs",
+			Err: err,
+		}
+	}
+
+	return groupTeachers, nil
+}
+
 // Create overrides the base Create method to handle validation
 func (r *GroupTeacherRepository) Create(ctx context.Context, groupTeacher *education.GroupTeacher) error {
 	if groupTeacher == nil {

--- a/backend/database/repositories/users/student.go
+++ b/backend/database/repositories/users/student.go
@@ -269,6 +269,40 @@ func (r *StudentRepository) CountWithOptions(ctx context.Context, options *model
 	return count, nil
 }
 
+// CountByGroupIDs counts students per group for multiple groups in a single query
+func (r *StudentRepository) CountByGroupIDs(ctx context.Context, groupIDs []int64) (map[int64]int, error) {
+	if len(groupIDs) == 0 {
+		return make(map[int64]int), nil
+	}
+
+	type countResult struct {
+		GroupID int64 `bun:"group_id"`
+		Count   int   `bun:"count"`
+	}
+
+	var results []countResult
+	err := r.db.NewSelect().
+		TableExpr("users.students").
+		ColumnExpr("group_id").
+		ColumnExpr("COUNT(*) AS count").
+		Where("group_id IN (?)", bun.In(groupIDs)).
+		GroupExpr("group_id").
+		Scan(ctx, &results)
+
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "count by group IDs",
+			Err: err,
+		}
+	}
+
+	counts := make(map[int64]int, len(results))
+	for _, r := range results {
+		counts[r.GroupID] = r.Count
+	}
+	return counts, nil
+}
+
 // FindWithPerson retrieves a student with their associated person data
 func (r *StudentRepository) FindWithPerson(ctx context.Context, id int64) (*users.Student, error) {
 	student := new(users.Student)

--- a/backend/database/repositories/users/teacher.go
+++ b/backend/database/repositories/users/teacher.go
@@ -351,3 +351,59 @@ func (r *TeacherRepository) ListAllWithStaffAndPerson(ctx context.Context) ([]*u
 
 	return teachers, nil
 }
+
+// FindWithStaffAndPersonByIDs retrieves teachers with staff and person data for multiple IDs in a single query
+func (r *TeacherRepository) FindWithStaffAndPersonByIDs(ctx context.Context, ids []int64) ([]*users.Teacher, error) {
+	if len(ids) == 0 {
+		return []*users.Teacher{}, nil
+	}
+
+	type teacherResult struct {
+		Teacher *users.Teacher `bun:"teacher"`
+		Staff   *users.Staff   `bun:"staff"`
+		Person  *users.Person  `bun:"person"`
+	}
+
+	var results []teacherResult
+
+	err := r.db.NewSelect().
+		Model(&results).
+		ModelTableExpr(`users.teachers AS "teacher"`).
+		// Teacher columns with proper aliasing
+		ColumnExpr(`"teacher".id AS "teacher__id", "teacher".created_at AS "teacher__created_at", "teacher".updated_at AS "teacher__updated_at"`).
+		ColumnExpr(`"teacher".staff_id AS "teacher__staff_id", "teacher".specialization AS "teacher__specialization"`).
+		ColumnExpr(`"teacher".role AS "teacher__role", "teacher".qualifications AS "teacher__qualifications"`).
+		// Staff columns
+		ColumnExpr(`"staff".id AS "staff__id", "staff".created_at AS "staff__created_at", "staff".updated_at AS "staff__updated_at"`).
+		ColumnExpr(`"staff".person_id AS "staff__person_id", "staff".staff_notes AS "staff__staff_notes"`).
+		// Person columns
+		ColumnExpr(`"person".id AS "person__id", "person".created_at AS "person__created_at", "person".updated_at AS "person__updated_at"`).
+		ColumnExpr(`"person".first_name AS "person__first_name", "person".last_name AS "person__last_name"`).
+		ColumnExpr(`"person".tag_id AS "person__tag_id", "person".account_id AS "person__account_id"`).
+		// JOINs
+		Join(`INNER JOIN users.staff AS "staff" ON "staff".id = "teacher".staff_id`).
+		Join(`INNER JOIN users.persons AS "person" ON "person".id = "staff".person_id`).
+		Where(`"teacher".id IN (?)`, bun.In(ids)).
+		Scan(ctx)
+
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find with staff and person by IDs",
+			Err: err,
+		}
+	}
+
+	// Convert results to Teacher objects with Staff and Person attached
+	teachers := make([]*users.Teacher, len(results))
+	for i, result := range results {
+		teachers[i] = result.Teacher
+		if result.Staff != nil && result.Staff.ID != 0 {
+			result.Teacher.Staff = result.Staff
+			if result.Person != nil && result.Person.ID != 0 {
+				result.Staff.Person = result.Person
+			}
+		}
+	}
+
+	return teachers, nil
+}

--- a/backend/models/education/repository.go
+++ b/backend/models/education/repository.go
@@ -20,6 +20,7 @@ type GroupRepository interface {
 	FindByRoom(ctx context.Context, roomID int64) ([]*Group, error)
 	FindByTeacher(ctx context.Context, teacherID int64) ([]*Group, error)
 	FindWithRoom(ctx context.Context, groupID int64) (*Group, error)
+	CountWithOptions(ctx context.Context, options *base.QueryOptions) (int, error)
 }
 
 // GroupTeacherRepository defines operations for managing group-teacher relationships
@@ -31,6 +32,7 @@ type GroupTeacherRepository interface {
 	List(ctx context.Context, filters map[string]interface{}) ([]*GroupTeacher, error)
 	FindByGroup(ctx context.Context, groupID int64) ([]*GroupTeacher, error)
 	FindByTeacher(ctx context.Context, teacherID int64) ([]*GroupTeacher, error)
+	FindByGroupIDs(ctx context.Context, groupIDs []int64) ([]*GroupTeacher, error)
 }
 
 // GroupSubstitutionRepository defines operations for managing group substitutions

--- a/backend/models/users/repository.go
+++ b/backend/models/users/repository.go
@@ -111,6 +111,9 @@ type StudentRepository interface {
 	// CountWithOptions counts students matching the query options
 	CountWithOptions(ctx context.Context, options *base.QueryOptions) (int, error)
 
+	// CountByGroupIDs counts students per group for multiple groups in a single query
+	CountByGroupIDs(ctx context.Context, groupIDs []int64) (map[int64]int, error)
+
 	// AssignToGroup assigns a student to a group
 	AssignToGroup(ctx context.Context, studentID int64, groupID int64) error
 
@@ -201,6 +204,9 @@ type TeacherRepository interface {
 
 	// ListAllWithStaffAndPerson retrieves all teachers with their staff and person data in a single query
 	ListAllWithStaffAndPerson(ctx context.Context) ([]*Teacher, error)
+
+	// FindWithStaffAndPersonByIDs retrieves teachers with staff and person data for multiple IDs
+	FindWithStaffAndPersonByIDs(ctx context.Context, ids []int64) ([]*Teacher, error)
 }
 
 // GuestRepository defines operations for managing guests

--- a/backend/services/auth/test_helpers_test.go
+++ b/backend/services/auth/test_helpers_test.go
@@ -1126,6 +1126,10 @@ func (r *stubTeacherRepository) ListAllWithStaffAndPerson(context.Context) ([]*u
 	panic("ListAllWithStaffAndPerson not implemented")
 }
 
+func (r *stubTeacherRepository) FindWithStaffAndPersonByIDs(context.Context, []int64) ([]*userModel.Teacher, error) {
+	panic("FindWithStaffAndPersonByIDs not implemented")
+}
+
 // helper to build default email used in tests.
 func newDefaultFromEmail() email.Email {
 	return email.NewEmail("moto", "no-reply@moto.example")

--- a/backend/services/education/education_service.go
+++ b/backend/services/education/education_service.go
@@ -287,6 +287,15 @@ func (s *service) ListGroups(ctx context.Context, options *base.QueryOptions) ([
 	return groups, nil
 }
 
+// CountGroups counts groups matching the query options (filters only, no pagination)
+func (s *service) CountGroups(ctx context.Context, options *base.QueryOptions) (int, error) {
+	count, err := s.groupRepo.CountWithOptions(ctx, options)
+	if err != nil {
+		return 0, &EducationError{Op: "CountGroups", Err: err}
+	}
+	return count, nil
+}
+
 // FindGroupByName finds a group by its name
 func (s *service) FindGroupByName(ctx context.Context, name string) (*education.Group, error) {
 	group, err := s.groupRepo.FindByName(ctx, name)
@@ -572,6 +581,67 @@ func (s *service) GetGroupTeachers(ctx context.Context, groupID int64) ([]*users
 	}
 
 	return filteredTeachers, nil
+}
+
+// GetTeachersForGroups batch-loads all teachers for multiple groups in 2 queries
+func (s *service) GetTeachersForGroups(ctx context.Context, groupIDs []int64) (map[int64][]*users.Teacher, error) {
+	if len(groupIDs) == 0 {
+		return make(map[int64][]*users.Teacher), nil
+	}
+
+	// 1. Batch fetch all group-teacher relationships (1 query)
+	relations, err := s.groupTeacherRepo.FindByGroupIDs(ctx, groupIDs)
+	if err != nil {
+		return nil, &EducationError{Op: "GetTeachersForGroups", Err: err}
+	}
+
+	// 2. Collect unique teacher IDs
+	teacherIDSet := make(map[int64]bool)
+	for _, rel := range relations {
+		teacherIDSet[rel.TeacherID] = true
+	}
+
+	teacherIDs := make([]int64, 0, len(teacherIDSet))
+	for id := range teacherIDSet {
+		teacherIDs = append(teacherIDs, id)
+	}
+
+	if len(teacherIDs) == 0 {
+		result := make(map[int64][]*users.Teacher)
+		for _, gid := range groupIDs {
+			result[gid] = []*users.Teacher{}
+		}
+		return result, nil
+	}
+
+	// 3. Batch fetch all teachers with staff+person (1 query)
+	teachers, err := s.teacherRepo.FindWithStaffAndPersonByIDs(ctx, teacherIDs)
+	if err != nil {
+		return nil, &EducationError{Op: "GetTeachersForGroups", Err: err}
+	}
+
+	// 4. Build teacher lookup map
+	teacherMap := make(map[int64]*users.Teacher, len(teachers))
+	for _, t := range teachers {
+		teacherMap[t.ID] = t
+	}
+
+	// 5. Build result: groupID -> []Teacher
+	result := make(map[int64][]*users.Teacher, len(groupIDs))
+	for _, rel := range relations {
+		if teacher, ok := teacherMap[rel.TeacherID]; ok {
+			result[rel.GroupID] = append(result[rel.GroupID], teacher)
+		}
+	}
+
+	// Ensure all requested group IDs have an entry
+	for _, gid := range groupIDs {
+		if _, ok := result[gid]; !ok {
+			result[gid] = []*users.Teacher{}
+		}
+	}
+
+	return result, nil
 }
 
 // GetTeacherGroups gets all groups for a teacher

--- a/backend/services/education/interface.go
+++ b/backend/services/education/interface.go
@@ -20,6 +20,7 @@ type Service interface {
 	UpdateGroup(ctx context.Context, group *education.Group) error
 	DeleteGroup(ctx context.Context, id int64) error
 	ListGroups(ctx context.Context, options *base.QueryOptions) ([]*education.Group, error)
+	CountGroups(ctx context.Context, options *base.QueryOptions) (int, error)
 	FindGroupByName(ctx context.Context, name string) (*education.Group, error)
 	FindGroupsByRoom(ctx context.Context, roomID int64) ([]*education.Group, error)
 	FindGroupWithRoom(ctx context.Context, groupID int64) (*education.Group, error)
@@ -31,6 +32,7 @@ type Service interface {
 	RemoveTeacherFromGroup(ctx context.Context, groupID, teacherID int64) error
 	UpdateGroupTeachers(ctx context.Context, groupID int64, teacherIDs []int64) error
 	GetGroupTeachers(ctx context.Context, groupID int64) ([]*users.Teacher, error)
+	GetTeachersForGroups(ctx context.Context, groupIDs []int64) (map[int64][]*users.Teacher, error)
 	GetTeacherGroups(ctx context.Context, teacherID int64) ([]*education.Group, error)
 
 	// Substitution operations

--- a/backend/services/import/relationship_resolver_test.go
+++ b/backend/services/import/relationship_resolver_test.go
@@ -354,6 +354,9 @@ func (m *mockGroupRepo) FindByTeacher(_ context.Context, _ int64) ([]*education.
 func (m *mockGroupRepo) FindWithRoom(_ context.Context, _ int64) (*education.Group, error) {
 	return nil, nil
 }
+func (m *mockGroupRepo) CountWithOptions(_ context.Context, _ *base.QueryOptions) (int, error) {
+	return len(m.groups), nil
+}
 
 func TestRelationshipResolver_PreloadGroups(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Reduces **~164 sequential DB queries to 3-5 batch queries** for the groups list endpoint
- Adds room LEFT JOIN to `ListWithOptions` (eliminates 25 per-group room fetches)
- Adds `CountByGroupIDs` batch student count query (1 GROUP BY replaces 25 individual queries)
- Adds `FindByGroupIDs` + `FindWithStaffAndPersonByIDs` for batch teacher loading (2 queries replace ~113)
- Adds `GetTeachersForGroups` education service method to orchestrate batch teacher loading
- Adds `CountWithOptions` for accurate pagination total count
- Qualifies filter/sort column references with table alias to prevent ambiguous column errors from JOINs

### Production benchmark (before fix)

Measured on production server (`localhost:8080`, bypassing proxy layers):

```
Run 1: 0.210s
Run 2: 0.205s
Run 3: 0.152s
Run 4: 0.213s
Run 5: 0.169s
Average: ~190ms
```

**Expected improvement: ~190ms → ~10-15ms (90-95% reduction)**

Each of the ~164 DB roundtrips costs ~1.15ms on the production VPS (SSL-enabled PostgreSQL). Reducing to 3-5 batch queries eliminates the per-query overhead.

### Additional discoveries (not fixed in this PR)
- Search parameter inconsistency: handler uses `?name=X` but some clients may expect `?search=X`
- No `page_size` cap — callers can request unlimited rows

Closes #863

## Test plan
- [x] All existing `TestListGroups_*` tests pass (success, name filter, pagination, room ID filter, permissions, large page size)
- [x] All `TestGroupRepository_ListWithOptions*` repository tests pass (pagination, sorting, filter+pagination)
- [x] Full `go test ./...` passes (pre-existing unrelated failure in suggestions repo excluded)
- [x] Pre-push hooks pass: go-vet, go-deadcode, golangci-lint (0 issues)
- [ ] Bruno API integration tests: `./dev-test.sh groups`
- [ ] Production benchmark after deployment