### PR TITLE
perf: batch person loading and deduplicate identity queries

### DIFF
--- a/backend/api/groups/api.go
+++ b/backend/api/groups/api.go
@@ -402,6 +402,7 @@ func (rs *Resource) buildStudentRoomStatus(
 	student *users.Student,
 	groupRoomID int64,
 	snapshot *common.StudentLocationSnapshot,
+	personMap map[int64]*users.Person,
 ) map[string]interface{} {
 	status := map[string]interface{}{
 		"in_group_room": false,
@@ -410,13 +411,19 @@ func (rs *Resource) buildStudentRoomStatus(
 
 	visit := rs.getStudentVisit(ctx, student.ID, snapshot)
 	if visit == nil {
-		rs.addPersonDataToStatus(ctx, status, student.PersonID)
+		if person, ok := personMap[student.PersonID]; ok {
+			status["first_name"] = person.FirstName
+			status["last_name"] = person.LastName
+		}
 		return status
 	}
 
 	activeGroup := rs.getVisitActiveGroup(ctx, visit, snapshot)
 	if activeGroup == nil {
-		rs.addPersonDataToStatus(ctx, status, student.PersonID)
+		if person, ok := personMap[student.PersonID]; ok {
+			status["first_name"] = person.FirstName
+			status["last_name"] = person.LastName
+		}
 		return status
 	}
 
@@ -430,17 +437,11 @@ func (rs *Resource) buildStudentRoomStatus(
 		status["reason"] = "in_different_room"
 	}
 
-	rs.addPersonDataToStatus(ctx, status, student.PersonID)
-	return status
-}
-
-// addPersonDataToStatus adds first_name and last_name to status map
-func (rs *Resource) addPersonDataToStatus(ctx context.Context, status map[string]interface{}, personID int64) {
-	person, err := rs.UserService.Get(ctx, personID)
-	if err == nil && person != nil {
+	if person, ok := personMap[student.PersonID]; ok {
 		status["first_name"] = person.FirstName
 		status["last_name"] = person.LastName
 	}
+	return status
 }
 
 // buildNoRoomResponse creates the response when group has no room assigned
@@ -818,9 +819,21 @@ func (rs *Resource) buildRoomStatusResponse(ctx context.Context, students []*use
 		snapshot = nil
 	}
 
+	// Batch-load all persons to avoid N+1 queries
+	personIDs := make([]int64, 0, len(students))
+	for _, student := range students {
+		personIDs = append(personIDs, student.PersonID)
+	}
+	personMap, personErr := rs.UserService.GetByIDs(ctx, personIDs)
+	if personErr != nil {
+		slog.Default().Warn("failed to batch load persons",
+			slog.String("error", personErr.Error()))
+		personMap = make(map[int64]*users.Person)
+	}
+
 	studentStatuses := make(map[string]interface{})
 	for _, student := range students {
-		studentStatuses[strconv.FormatInt(student.ID, 10)] = rs.buildStudentRoomStatus(ctx, student, groupRoomID, snapshot)
+		studentStatuses[strconv.FormatInt(student.ID, 10)] = rs.buildStudentRoomStatus(ctx, student, groupRoomID, snapshot, personMap)
 	}
 
 	result["student_room_status"] = studentStatuses

--- a/backend/services/usercontext/usercontext_service.go
+++ b/backend/services/usercontext/usercontext_service.go
@@ -249,7 +249,22 @@ func (s *userContextService) GetCurrentTeacher(ctx context.Context) (*users.Teac
 // GetMyGroups retrieves educational groups associated with the current user
 func (s *userContextService) GetMyGroups(ctx context.Context) ([]*education.Group, error) {
 	staff, staffErr := s.GetCurrentStaff(ctx)
-	teacher, teacherErr := s.GetCurrentTeacher(ctx)
+
+	// Derive teacher from the already-resolved staff to avoid duplicate identity queries.
+	// GetCurrentTeacher would call GetCurrentStaff again (which calls GetCurrentPerson),
+	// duplicating 2 DB round-trips. Instead, reuse the staff result directly.
+	var teacher *users.Teacher
+	var teacherErr error
+	if staffErr == nil && staff != nil {
+		teacher, teacherErr = s.teacherRepo.FindByStaffID(ctx, staff.ID)
+		if teacher == nil && teacherErr == nil {
+			teacherErr = &UserContextError{Op: "get current teacher", Err: ErrUserNotLinkedToTeacher}
+		} else if teacherErr != nil {
+			teacherErr = &UserContextError{Op: "get current teacher", Err: teacherErr}
+		}
+	} else {
+		teacherErr = staffErr
+	}
 
 	// Check for valid linkage and unexpected errors
 	valid, unexpectedErr := s.hasValidStaffOrTeacher(staffErr, teacherErr)


### PR DESCRIPTION
## Summary

Fixes the slow `GET /api/groups/{id}/students/room-status` endpoint (93ms avg, ~33 DB queries for 20-student group).

- **Batch person loading**: Replaced N+1 `addPersonDataToStatus` calls with a single `GetByIDs` batch query and map lookup (~19 fewer queries)
- **Deduplicate identity queries**: Reused `GetCurrentStaff` result in `GetMyGroups` instead of calling `GetCurrentTeacher` which redundantly re-resolves person+staff (~2 fewer queries)

Expected result: ~33 queries → ~12 queries, ~93ms → ~25-35ms response time.

Closes #863

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `go test ./api/groups/...` — all pass
- [x] `go test ./services/usercontext/...` — all pass
- [x] `go test ./services/users/...` — all pass
- [x] `go test ./...` — all pass (1 pre-existing flaky test in suggestions module, unrelated)
- [x] Pre-push hooks: go-vet, golangci-lint, go-deadcode, git-secrets — all pass
- [ ] Bruno API tests: `./dev-test.sh groups` (requires running backend)
- [ ] Verify query count reduction in Grafana after deploy