### PR TITLE
fix: add frontend-side deduplication for proactive token refresh

### DIFF
--- a/frontend/src/server/auth/config.test.ts
+++ b/frontend/src/server/auth/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { authConfig } from "./config";
+import { authConfig, _resetRefreshState } from "./config";
 import type { NextAuthConfig, User } from "next-auth";
 
 // Mock ~/env
@@ -18,6 +18,7 @@ describe("authConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal("fetch", mockFetch);
+    _resetRefreshState();
   });
 
   afterEach(() => {
@@ -249,6 +250,159 @@ describe("authConfig", () => {
       // Proactive refresh should NOT fire — the dedicated refresh handler will handle it
       expect(mockFetch).not.toHaveBeenCalled();
       expect(result?.token).toBe("old-access-token");
+    });
+
+    it("should deduplicate late-arriving callbacks via cache", async () => {
+      // First call: triggers actual refresh and caches result
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "new-access-1",
+          refresh_token: "new-refresh-1",
+        }),
+      });
+
+      const makeToken = () => ({
+        id: "123",
+        token: "old-access-token",
+        refreshToken: "dedup-refresh-token",
+        tokenExpiry: Date.now() + 2 * 60 * 1000,
+        refreshTokenExpiry: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      });
+
+      const callJwt = (token: Record<string, unknown>) =>
+        authConfig.callbacks?.jwt?.({
+          token,
+          user: undefined as unknown as User,
+          account: null,
+          profile: undefined,
+          trigger: "update",
+          isNewUser: false,
+          session: undefined,
+        });
+
+      // First callback: performs the actual refresh
+      const result1 = await callJwt(makeToken());
+      expect(result1?.token).toBe("new-access-1");
+      expect(result1?.refreshToken).toBe("new-refresh-1");
+      expect(mockFetch).toHaveBeenCalledOnce();
+
+      // Late-arriving callback with same OLD refresh token: served from cache
+      const result2 = await callJwt(makeToken());
+      expect(result2?.token).toBe("new-access-1");
+      expect(result2?.refreshToken).toBe("new-refresh-1");
+      // Still only 1 fetch call — second was served from cache
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it("should share in-flight refresh promise across concurrent callbacks", async () => {
+      // Single slow fetch that all concurrent calls share
+      let resolveRefresh: (value: unknown) => void;
+      mockFetch.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+
+      const makeToken = () => ({
+        id: "123",
+        token: "old-access-token",
+        refreshToken: "concurrent-refresh-token",
+        tokenExpiry: Date.now() + 2 * 60 * 1000,
+        refreshTokenExpiry: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      });
+
+      const callJwt = (token: Record<string, unknown>) =>
+        authConfig.callbacks?.jwt?.({
+          token,
+          user: undefined as unknown as User,
+          account: null,
+          profile: undefined,
+          trigger: "update",
+          isNewUser: false,
+          session: undefined,
+        });
+
+      // Fire 3 concurrent callbacks (simulates multiple SessionProvider refetches)
+      const p1 = callJwt(makeToken());
+      const p2 = callJwt(makeToken());
+      const p3 = callJwt(makeToken());
+
+      // Only 1 fetch should have been made
+      expect(mockFetch).toHaveBeenCalledOnce();
+
+      // Resolve the single fetch — all 3 callbacks get the same result
+      resolveRefresh!({
+        ok: true,
+        json: async () => ({
+          access_token: "shared-access",
+          refresh_token: "shared-refresh",
+        }),
+      });
+
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+      expect(r1?.token).toBe("shared-access");
+      expect(r2?.token).toBe("shared-access");
+      expect(r3?.token).toBe("shared-access");
+      expect(r1?.refreshToken).toBe("shared-refresh");
+      expect(r2?.refreshToken).toBe("shared-refresh");
+      expect(r3?.refreshToken).toBe("shared-refresh");
+      // Confirm only 1 fetch across all 3 callbacks
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it("should not use cache for a different refresh token", async () => {
+      // First: refresh with token-A
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "access-A",
+          refresh_token: "refresh-A-new",
+        }),
+      });
+
+      const callJwt = (token: Record<string, unknown>) =>
+        authConfig.callbacks?.jwt?.({
+          token,
+          user: undefined as unknown as User,
+          account: null,
+          profile: undefined,
+          trigger: "update",
+          isNewUser: false,
+          session: undefined,
+        });
+
+      await callJwt({
+        id: "123",
+        token: "old",
+        refreshToken: "token-A",
+        tokenExpiry: Date.now() + 2 * 60 * 1000,
+        refreshTokenExpiry: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      });
+      expect(mockFetch).toHaveBeenCalledOnce();
+
+      // Second: refresh with token-B (different token, must NOT use cache)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "access-B",
+          refresh_token: "refresh-B-new",
+        }),
+      });
+
+      const result = await callJwt({
+        id: "456",
+        token: "old",
+        refreshToken: "token-B",
+        tokenExpiry: Date.now() + 2 * 60 * 1000,
+        refreshTokenExpiry: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      });
+
+      expect(result?.token).toBe("access-B");
+      expect(result?.refreshToken).toBe("refresh-B-new");
+      // Two separate fetches — cache was not used
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     it("should mark token as expired when refresh token expired", async () => {

--- a/frontend/src/server/auth/config.ts
+++ b/frontend/src/server/auth/config.ts
@@ -202,6 +202,26 @@ function parseDurationToMs(duration: string): number {
 const accessTokenExpiry = parseDurationToMs(env.AUTH_JWT_EXPIRY);
 const refreshTokenExpiry = parseDurationToMs(env.AUTH_JWT_REFRESH_EXPIRY);
 
+// Frontend-side singleflight for proactive token refresh.
+// Deduplicates concurrent JWT callbacks that all try to refresh the same token.
+// The cache covers late-arriving callbacks after the in-flight promise resolves.
+type RefreshResult = { access_token: string; refresh_token: string };
+let activeRefreshPromise: Promise<RefreshResult | null> | null = null;
+let activeRefreshKey: string | null = null;
+let refreshCache: {
+  oldToken: string;
+  result: RefreshResult;
+  expiresAt: number;
+} | null = null;
+const REFRESH_CACHE_TTL_MS = 10_000; // 10s window for late-arriving callbacks
+
+/** @internal Reset module-level refresh state (test isolation only) */
+export function _resetRefreshState(): void {
+  activeRefreshPromise = null;
+  activeRefreshKey = null;
+  refreshCache = null;
+}
+
 /**
  * Options for NextAuth.js used to configure adapters, providers, callbacks, etc.
  *
@@ -356,6 +376,9 @@ export const authConfig = {
       // Proactive token refresh: refresh access token before it expires.
       // SessionProvider.refetchInterval (4 min) ensures this runs regularly.
       // Backend singleflight protects against concurrent refresh calls.
+      // Frontend singleflight + cache prevents stale token overwrites when
+      // multiple JWT callbacks race (the late-arriving callback would otherwise
+      // use the old refresh token, get 401, and overwrite good tokens).
       // Only fires in the pre-expiry window (not after expiry) to avoid
       // double-refreshing when the dedicated refresh handler (token-refresh.ts)
       // calls auth() on an already-expired token.
@@ -372,38 +395,86 @@ export const authConfig = {
         now < tokenExpiry && // Not yet expired — only pre-emptive
         now < (token.refreshTokenExpiry as number)
       ) {
-        try {
-          const response = await fetch(`${getServerApiUrl()}/auth/refresh`, {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${token.refreshToken as string}`,
-              "Content-Type": "application/json",
-            },
-            signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
-          });
+        const currentRefreshToken = token.refreshToken as string;
 
-          if (response.ok) {
-            const tokens = (await response.json()) as {
-              access_token: string;
-              refresh_token: string;
-            };
-            token.token = tokens.access_token;
-            token.refreshToken = tokens.refresh_token;
+        // Check cache: this refresh token was recently rotated by another callback
+        if (
+          refreshCache?.oldToken === currentRefreshToken &&
+          Date.now() < (refreshCache?.expiresAt ?? 0)
+        ) {
+          token.token = refreshCache.result.access_token;
+          token.refreshToken = refreshCache.result.refresh_token;
+          token.tokenExpiry = Date.now() + accessTokenExpiry;
+          token.refreshTokenExpiry = Date.now() + refreshTokenExpiry;
+          token.error = undefined;
+          token.needsRefresh = undefined;
+          logger.info("proactive_token_refresh_deduplicated");
+          return token;
+        }
+
+        // Join in-flight refresh if one exists for this token
+        if (activeRefreshPromise && activeRefreshKey === currentRefreshToken) {
+          const result = await activeRefreshPromise;
+          if (result) {
+            token.token = result.access_token;
+            token.refreshToken = result.refresh_token;
             token.tokenExpiry = Date.now() + accessTokenExpiry;
             token.refreshTokenExpiry = Date.now() + refreshTokenExpiry;
             token.error = undefined;
             token.needsRefresh = undefined;
             logger.info("proactive_token_refresh_succeeded");
-          } else {
+          }
+          return token;
+        }
+
+        // Start new refresh and share via module-level promise
+        activeRefreshKey = currentRefreshToken;
+        activeRefreshPromise = (async (): Promise<RefreshResult | null> => {
+          try {
+            const response = await fetch(`${getServerApiUrl()}/auth/refresh`, {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${currentRefreshToken}`,
+                "Content-Type": "application/json",
+              },
+              signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
+            });
+
+            if (response.ok) {
+              const tokens = (await response.json()) as RefreshResult;
+              // Cache result so late-arriving callbacks with the old token
+              // get the new tokens instead of sending a doomed request
+              refreshCache = {
+                oldToken: currentRefreshToken,
+                result: tokens,
+                expiresAt: Date.now() + REFRESH_CACHE_TTL_MS,
+              };
+              return tokens;
+            }
             logger.warn("proactive_token_refresh_failed", {
               status: response.status,
             });
-            // Don't set error — Axios interceptor handles as fallback
+            return null;
+          } catch (err) {
+            logger.warn("proactive_token_refresh_error", {
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return null;
+          } finally {
+            activeRefreshPromise = null;
+            activeRefreshKey = null;
           }
-        } catch (err) {
-          logger.warn("proactive_token_refresh_error", {
-            error: err instanceof Error ? err.message : String(err),
-          });
+        })();
+
+        const result = await activeRefreshPromise;
+        if (result) {
+          token.token = result.access_token;
+          token.refreshToken = result.refresh_token;
+          token.tokenExpiry = Date.now() + accessTokenExpiry;
+          token.refreshTokenExpiry = Date.now() + refreshTokenExpiry;
+          token.error = undefined;
+          token.needsRefresh = undefined;
+          logger.info("proactive_token_refresh_succeeded");
         }
       }
 


### PR DESCRIPTION
## Summary

- Adds frontend-side singleflight deduplication for the proactive token refresh in the NextAuth JWT callback
- Prevents stale token overwrites when multiple concurrent JWT callbacks race to refresh the same token
- Two-layer approach: in-flight promise sharing + 10-second result cache for late-arriving callbacks

## Problem

Staging logs confirmed that when `SessionProvider.refetchInterval` triggers multiple JWT callbacks simultaneously:
1. Backend singleflight correctly deduplicates and returns rotated tokens to all concurrent callers
2. A late-arriving callback (~400ms later) still holds the **old** refresh token
3. It sends the old token to the backend, gets 401 (token already rotated)
4. This 401 response overwrites the good tokens from step 1, cascading into a full session failure

## Solution

Module-level singleflight state in `config.ts`:
- **In-flight promise sharing**: Concurrent callbacks with the same refresh token await a single fetch
- **Result cache (10s TTL)**: Late-arriving callbacks that miss the in-flight window still get the cached result instead of sending a doomed request with the old token
- **`_resetRefreshState()` export**: Clears module state between tests for isolation

## Test plan

- [x] 3 new test cases added (24 total, all passing):
  - Late-arriving callback deduplication via cache
  - In-flight promise sharing across concurrent callbacks  
  - Cache miss with different refresh token
- [x] `pnpm run check` passes (zero warnings)
- [x] Pre-push hooks pass (git-secrets, knip, lint, typecheck)
- [ ] Deploy to staging, set `AUTH_JWT_EXPIRY=8m`, verify no 401 cascade in logs