### PR TITLE
fix: resolve flaky schulhof student count test

### DIFF
--- a/backend/services/facilities/schulhof_service_test.go
+++ b/backend/services/facilities/schulhof_service_test.go
@@ -308,12 +308,15 @@ func TestSchulhofService_GetSchulhofStatus_WithStudents(t *testing.T) {
 	require.NoError(t, err)
 	defer testpkg.CleanupActivityFixtures(t, db, activityGroup.ID, activityGroup.CategoryID, *activityGroup.PlannedRoomID)
 
-	// End all existing active groups for this room to get a fresh one
+	// End ALL existing active groups for this activity AND room to get a clean slate.
+	// This prevents flakiness from stale groups left by previous test runs that may
+	// reference different room IDs (each test creates its own infrastructure).
 	_, err = db.NewUpdate().
 		Model((*active.Group)(nil)).
 		ModelTableExpr(`active.groups AS "group"`).
 		Set("end_time = ?", time.Now()).
-		Where(`"group".room_id = ? AND "group".end_time IS NULL`, *activityGroup.PlannedRoomID).
+		Where(`"group".end_time IS NULL AND ("group".room_id = ? OR "group".group_id = ?)`,
+			*activityGroup.PlannedRoomID, activityGroup.ID).
 		Exec(ctx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- Replaced Go-side filtering in `findTodayActiveGroup` with a precise SQL query using all four conditions (`room_id`, `group_id`, `end_time IS NULL`, `start_time >= today`)
- Fixed midnight boundary bug in `endStaleActiveGroups` (`!After` → `Before`)

## Problem
`TestSchulhofService_GetSchulhofStatus_WithStudents` was intermittently failing in CI with `StudentCount=0` instead of `1`. The root cause was that `findTodayActiveGroup` fetched ALL open active groups for a room and filtered in Go, making it susceptible to test database pollution from concurrent or stale test runs.

## Test plan
- [x] All 21 schulhof service tests pass locally on clean DB
- [x] `golangci-lint` passes with 0 issues
- [x] All lefthook pre-push checks pass (go-vet, golangci-lint, go-deadcode)
- [ ] CI backend tests pass (previously 1 failure → should be 0)