### PR TITLE
chore: remove unused type exports flagged by knip

### DIFF
--- a/frontend/src/components/shared/settings-layout.tsx
+++ b/frontend/src/components/shared/settings-layout.tsx
@@ -157,7 +157,7 @@ function MobileBackHeader({
   );
 }
 
-export interface SettingsLayoutProps {
+interface SettingsLayoutProps {
   readonly profileTab: ReactNode;
   readonly mobileProfileCard: ReactNode;
   readonly extraTabs?: Tab[];

--- a/frontend/src/components/students/student-checkout-section.tsx
+++ b/frontend/src/components/students/student-checkout-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 // Type for the action the user can perform
-export type StudentActionType = "checkout" | "checkin" | "none";
+type StudentActionType = "checkout" | "checkin" | "none";
 
 interface StudentCheckoutSectionProps {
   readonly onCheckoutClick: () => void;

--- a/frontend/src/components/ui/database/database-form.tsx
+++ b/frontend/src/components/ui/database/database-form.tsx
@@ -229,7 +229,7 @@ export interface FormSection {
   iconPath?: string; // Optional small header icon (heroicons path)
 }
 
-export interface DatabaseFormProps<T = Record<string, unknown>> {
+interface DatabaseFormProps<T = Record<string, unknown>> {
   readonly theme: DatabaseTheme;
   readonly sections: FormSection[];
   readonly onSubmit: (data: T) => Promise<void>;

--- a/frontend/src/components/ui/location-badge.tsx
+++ b/frontend/src/components/ui/location-badge.tsx
@@ -57,7 +57,7 @@ function getSickDisplayMode(
   return "additional";
 }
 
-export interface LocationBadgeProps {
+interface LocationBadgeProps {
   readonly student: StudentLocationContext;
   readonly displayMode: DisplayMode;
   readonly userGroups?: string[];

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -16,7 +16,7 @@ const logger = createLogger({ component: "ToastContext" });
 
 type ToastType = "success" | "error" | "info" | "warning";
 
-export interface ToastOptions {
+interface ToastOptions {
   id?: string;
   duration?: number; // ms
 }


### PR DESCRIPTION
## Summary
- Remove `export` from 5 types/interfaces only used within their own files
- Fixes knip CI failures blocking Dependabot PR #887

## Changed files
- `settings-layout.tsx`: `SettingsLayoutProps`
- `student-checkout-section.tsx`: `StudentActionType`
- `database-form.tsx`: `DatabaseFormProps`
- `location-badge.tsx`: `LocationBadgeProps`
- `ToastContext.tsx`: `ToastOptions`

## Test plan
- [x] `pnpm knip` — no issues found
- [x] `pnpm run check` (lint + typecheck) — clean
- [x] All lefthook pre-push hooks pass
- [ ] CI passes