### PR TITLE
fix: shorten announcement subtitle text

### DIFF
--- a/frontend/src/components/platform/announcement-modal.test.tsx
+++ b/frontend/src/components/platform/announcement-modal.test.tsx
@@ -161,9 +161,7 @@ describe("AnnouncementModal", () => {
     render(<AnnouncementModal />);
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Wichtige Informationen für Sie"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Wichtige Informationen")).toBeInTheDocument();
     });
     expect(screen.getByText("Neuigkeiten")).toBeInTheDocument();
   });

--- a/frontend/src/components/platform/announcement-modal.tsx
+++ b/frontend/src/components/platform/announcement-modal.tsx
@@ -13,7 +13,7 @@ const logger = createLogger({ component: "AnnouncementModal" });
 const DEFAULT_HEADER = {
   icon: Megaphone,
   title: "Neuigkeiten",
-  subtitle: "Wichtige Informationen für Sie",
+  subtitle: "Wichtige Informationen",
 } as const;
 
 const TYPE_HEADERS: Record<


### PR DESCRIPTION
## Summary
- Removes "für Sie" from the default announcement modal subtitle
- Changes "Wichtige Informationen für Sie" → "Wichtige Informationen"
- Updates matching test assertion

## Test plan
- [x] Frontend lint + typecheck passes
- [x] Test assertion updated to match new text