### PR TITLE
fix: add -y flag to yq for YAML output in simulator key sync

### DIFF
--- a/scripts/update-simulator-keys.sh
+++ b/scripts/update-simulator-keys.sh
@@ -21,7 +21,7 @@ while IFS=, read -r device_id api_key; do
     continue
   fi
   echo "Updating $device_id -> $api_key"
-  yq -i "
+  yq -y -i "
     (.devices[] | select(.device_id == \"$device_id\") | .api_key) = \"$api_key\"
   " "$tmp"
 done <<< "$rows"


### PR DESCRIPTION
## Summary
- Python `yq` (jq wrapper) defaults to JSON output when modifying files in-place
- The `update-simulator-keys.sh` script was converting `simulator.yaml` to JSON, breaking the IoT simulator
- Adding `-y` flag ensures yq outputs YAML format

## Test plan
- [x] Verified `yq -y -i` preserves YAML format in `simulator.yaml`
- [x] Confirmed simulator reads updated keys correctly after script execution