### PR TITLE
feat: make activities.groups.created_by nullable for system-created WC/Schulhof groups

### DIFF
--- a/backend/api/activities/api.go
+++ b/backend/api/activities/api.go
@@ -127,7 +127,7 @@ type ActivityResponse struct {
 	IsOpen          bool                 `json:"is_open"`
 	CategoryID      int64                `json:"category_id"`
 	PlannedRoomID   *int64               `json:"planned_room_id,omitempty"`
-	CreatedBy       int64                `json:"created_by"`
+	CreatedBy       *int64               `json:"created_by"`
 	CreatedByName   string               `json:"created_by_name,omitempty"`
 	Category        *CategoryResponse    `json:"category,omitempty"`
 	SupervisorID    *int64               `json:"supervisor_id,omitempty"`  // Primary supervisor
@@ -922,7 +922,7 @@ func (rs *Resource) createActivity(w http.ResponseWriter, r *http.Request) {
 		IsOpen:          req.IsOpen,
 		CategoryID:      req.CategoryID,
 		PlannedRoomID:   req.PlannedRoomID,
-		CreatedBy:       staffID,
+		CreatedBy:       &staffID,
 	}
 
 	// Prepare schedules
@@ -995,7 +995,7 @@ func (rs *Resource) quickCreateActivity(w http.ResponseWriter, r *http.Request) 
 		IsOpen:          true, // Default to true for quick-create
 		CategoryID:      req.CategoryID,
 		PlannedRoomID:   req.RoomID,
-		CreatedBy:       staff.ID,
+		CreatedBy:       &staff.ID,
 	}
 
 	// Auto-assign creator as primary supervisor

--- a/backend/api/iot/checkin/checkin_internal_test.go
+++ b/backend/api/iot/checkin/checkin_internal_test.go
@@ -1127,3 +1127,49 @@ func TestSchulhofActivityGroup_FindsExisting(t *testing.T) {
 
 	assert.Equal(t, group1.ID, group2.ID, "Should return same activity group, not create duplicate")
 }
+
+// =============================================================================
+// NO STAFF CONTEXT TESTS: system-created auto-create paths (created_by = NULL)
+// =============================================================================
+
+// TestWcActivityGroup_NoStaffContext verifies that wcActivityGroup succeeds
+// without any staff in the context (created_by = NULL = system-created).
+func TestWcActivityGroup_NoStaffContext(t *testing.T) {
+	tc := setupInternalTestResource(t)
+	defer func() { _ = tc.db.Close() }()
+
+	cleanupWCTestArtifacts(t, tc)
+	defer cleanupWCTestArtifacts(t, tc)
+
+	// No staff context — plain background context
+	ctx := context.Background()
+
+	group, err := tc.rs.wcActivityGroup(ctx)
+
+	require.NoError(t, err, "wcActivityGroup should succeed without staff context")
+	require.NotNil(t, group, "wcActivityGroup should return an activity group")
+	assert.Equal(t, constants.WCActivityName, group.Name)
+	assert.NotZero(t, group.ID)
+	assert.Nil(t, group.CreatedBy, "system-created WC group should have NULL created_by")
+}
+
+// TestSchulhofActivityGroup_NoStaffContext verifies that schulhofActivityGroup succeeds
+// without any staff in the context (created_by = NULL = system-created).
+func TestSchulhofActivityGroup_NoStaffContext(t *testing.T) {
+	tc := setupInternalTestResource(t)
+	defer func() { _ = tc.db.Close() }()
+
+	cleanupSchulhofTestArtifacts(t, tc)
+	defer cleanupSchulhofTestArtifacts(t, tc)
+
+	// No staff context — plain background context
+	ctx := context.Background()
+
+	group, err := tc.rs.schulhofActivityGroup(ctx)
+
+	require.NoError(t, err, "schulhofActivityGroup should succeed without staff context")
+	require.NotNil(t, group, "schulhofActivityGroup should return an activity group")
+	assert.Equal(t, constants.SchulhofActivityName, group.Name)
+	assert.NotZero(t, group.ID)
+	assert.Nil(t, group.CreatedBy, "system-created Schulhof group should have NULL created_by")
+}

--- a/backend/api/iot/checkin/checkin_test.go
+++ b/backend/api/iot/checkin/checkin_test.go
@@ -16,6 +16,7 @@ import (
 
 	checkinAPI "github.com/moto-nrw/project-phoenix/api/iot/checkin"
 	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/facilities"
 	"github.com/moto-nrw/project-phoenix/models/iot"
@@ -1612,7 +1613,7 @@ func TestDeviceCheckin_ActivityCapacityExceeded(t *testing.T) {
 		MaxParticipants: 1, // Only 1 participant allowed
 		IsOpen:          true,
 		CategoryID:      category.ID,
-		CreatedBy:       creatorStaff.ID,
+		CreatedBy:       &creatorStaff.ID,
 	}
 	err := ctx.db.NewInsert().
 		Model(activityGroup).
@@ -2074,11 +2075,14 @@ func TestDeviceCheckin_WCCheckoutFromWC(t *testing.T) {
 	assert.Equal(t, "checked_out", checkoutData["action"])
 }
 
-// TestDeviceCheckin_WCAutoCreateWithoutStaff verifies that attempting WC checkin
-// without staff context returns a 500 error because WC activity auto-creation
-// requires staff context (the created_by FK constraint).
-// Covers: wc.go:143-145 (staff nil check) + workflow.go:605-614 (WC error handling
-// with "staff context" string detection).
+// TestDeviceCheckin_WCAutoCreateWithoutStaff verifies that WC checkin succeeds
+// when the request has no staff context (no staff PIN scanned at the WC reader).
+// The WC activity group is auto-created with created_by = NULL (nullable after our migration).
+//
+// Pre-condition: In production a student can only be at WC after first checking
+// into a normal room with staff present — that earlier check-in creates the
+// attendance record. We insert the record directly to satisfy that invariant
+// without needing a full two-step checkin/checkout flow.
 func TestDeviceCheckin_WCAutoCreateWithoutStaff(t *testing.T) {
 	ctx := setupTestContext(t)
 	defer func() { _ = ctx.db.Close() }()
@@ -2097,6 +2101,21 @@ func TestDeviceCheckin_WCAutoCreateWithoutStaff(t *testing.T) {
 	room := createWCRoom(t, ctx.db)
 	defer cleanupWCInfrastructure(t, ctx.db, room.ID)
 
+	// Pre-condition: simulate prior morning check-in (with staff) by inserting the
+	// attendance record directly. In production this record always exists before a
+	// student reaches the WC reader.
+	setupStaff := testpkg.CreateTestStaff(t, ctx.db, "SetupStaff", "WCNoStaff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, setupStaff.ID)
+	today := timezone.Today() // Berlin date — matches FindByStudentAndDate's timezone.DateOf()
+	var attendanceID int64
+	err := ctx.db.NewRaw(
+		`INSERT INTO active.attendance (student_id, date, check_in_time, checked_in_by, device_id)
+		 VALUES (?, ?, ?, ?, ?) RETURNING id`,
+		student.ID, today, today.Add(8*time.Hour), setupStaff.ID, device.ID,
+	).Scan(context.Background(), &attendanceID)
+	require.NoError(t, err, "test setup: failed to insert attendance record")
+	defer func() { testpkg.CleanupTableRecords(t, ctx.db, "active.attendance", attendanceID) }()
+
 	router := chi.NewRouter()
 	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
 
@@ -2106,22 +2125,77 @@ func TestDeviceCheckin_WCAutoCreateWithoutStaff(t *testing.T) {
 		"room_id":      room.ID,
 	}
 
-	// Deliberately omit WithStaffContext to trigger the staff nil check
+	// No staff context — simulates a student scanning at the WC reader without a PIN.
 	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
 		testutil.WithDeviceContext(createTestDeviceContext(device)),
 	)
 
 	rr := testutil.ExecuteRequest(router, req)
 
-	// Should return 500 because WC activity auto-create requires staff context
-	assert.Equal(t, http.StatusInternalServerError, rr.Code,
-		"Expected 500 when WC auto-create has no staff context. Body: %s", rr.Body.String())
+	// The WC activity group is auto-created with created_by = NULL.
+	assert.Equal(t, http.StatusOK, rr.Code,
+		"Expected 200 when WC auto-create has no staff context. Body: %s", rr.Body.String())
+}
 
-	// Verify the error message mentions staff context
-	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
-	errMsg, ok := response["error"].(string)
-	assert.True(t, ok, "Response should have error field")
-	assert.Contains(t, errMsg, "staff context", "Error should mention staff context requirement")
+// TestDeviceCheckin_SchulhofAutoCreateWithoutStaff verifies that Schulhof checkin
+// succeeds when the request has no staff context (no staff PIN scanned).
+// The Schulhof activity group is auto-created with created_by = NULL (nullable after
+// our migration).
+//
+// Pre-condition: same as WC — students reach Schulhof only after a prior check-in
+// with staff that created today's attendance record. We insert it directly here.
+func TestDeviceCheckin_SchulhofAutoCreateWithoutStaff(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "schulhof-no-staff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "SchulhofNoStaff", "Student", "1b")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("SHNS%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	room := createSchulhofRoom(t, ctx.db)
+	defer cleanupSchulhofInfrastructure(t, ctx.db, room.ID)
+
+	// Pre-condition: simulate prior morning check-in (with staff) by inserting the
+	// attendance record directly. In production this record always exists before a
+	// student reaches the Schulhof reader.
+	setupStaff := testpkg.CreateTestStaff(t, ctx.db, "SetupStaff", "SchulhofNoStaff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, setupStaff.ID)
+	today := timezone.Today() // Berlin date — matches FindByStudentAndDate's timezone.DateOf()
+	var attendanceID int64
+	err := ctx.db.NewRaw(
+		`INSERT INTO active.attendance (student_id, date, check_in_time, checked_in_by, device_id)
+		 VALUES (?, ?, ?, ?, ?) RETURNING id`,
+		student.ID, today, today.Add(8*time.Hour), setupStaff.ID, device.ID,
+	).Scan(context.Background(), &attendanceID)
+	require.NoError(t, err, "test setup: failed to insert attendance record")
+	defer func() { testpkg.CleanupTableRecords(t, ctx.db, "active.attendance", attendanceID) }()
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      room.ID,
+	}
+
+	// No staff context — simulates a student scanning at the Schulhof reader without a PIN.
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	// The Schulhof activity group is auto-created with created_by = NULL.
+	assert.Equal(t, http.StatusOK, rr.Code,
+		"Expected 200 when Schulhof auto-create has no staff context. Body: %s", rr.Body.String())
 }
 
 func TestDeviceCheckin_SchulhofAutoCreateIdempotent(t *testing.T) {

--- a/backend/api/iot/checkin/schulhof.go
+++ b/backend/api/iot/checkin/schulhof.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/moto-nrw/project-phoenix/auth/device"
 	"github.com/moto-nrw/project-phoenix/constants"
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -138,20 +137,13 @@ func (rs *Resource) schulhofActivityGroup(ctx context.Context) (*activities.Grou
 		return nil, fmt.Errorf("failed to ensure Schulhof category: %w", err)
 	}
 
-	// Step 3: Create the Schulhof activity group
-	// Get staff ID from device authentication context - required for created_by FK
-	staffCtx := device.StaffFromCtx(ctx)
-	if staffCtx == nil {
-		return nil, fmt.Errorf("schulhof activity auto-create requires staff context (scan staff RFID first)")
-	}
-
+	// Step 3: Create the Schulhof activity group (created_by is NULL = system-created)
 	newActivity := &activities.Group{
 		Name:            constants.SchulhofActivityName,
 		MaxParticipants: constants.SchulhofMaxParticipants,
 		IsOpen:          true, // Open activity - anyone can join
 		CategoryID:      category.ID,
 		PlannedRoomID:   &room.ID,
-		CreatedBy:       staffCtx.ID,
 	}
 
 	// CreateGroup requires supervisorIDs and schedules - pass empty slices for auto-created activity

--- a/backend/api/iot/checkin/wc.go
+++ b/backend/api/iot/checkin/wc.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/moto-nrw/project-phoenix/auth/device"
 	"github.com/moto-nrw/project-phoenix/constants"
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -137,20 +136,13 @@ func (rs *Resource) wcActivityGroup(ctx context.Context) (*activities.Group, err
 		return nil, fmt.Errorf("failed to ensure WC category: %w", err)
 	}
 
-	// Step 3: Create the WC activity group
-	// Get staff ID from device authentication context - required for created_by FK
-	staffCtx := device.StaffFromCtx(ctx)
-	if staffCtx == nil {
-		return nil, fmt.Errorf("WC activity auto-create requires staff context (scan staff RFID first)")
-	}
-
+	// Step 3: Create the WC activity group (created_by is NULL = system-created)
 	newActivity := &activities.Group{
 		Name:            constants.WCActivityName,
 		MaxParticipants: constants.WCMaxParticipants,
 		IsOpen:          true, // Open activity - anyone can join
 		CategoryID:      category.ID,
 		PlannedRoomID:   &room.ID,
-		CreatedBy:       staffCtx.ID,
 	}
 
 	// CreateGroup requires supervisorIDs and schedules - pass empty slices for auto-created activity

--- a/backend/database/migrations/001012007_activities_groups_created_by_nullable.go
+++ b/backend/database/migrations/001012007_activities_groups_created_by_nullable.go
@@ -1,0 +1,121 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	activitiesGroupsCreatedByNullableVersion     = "1.12.7"
+	activitiesGroupsCreatedByNullableDescription = "Make created_by nullable in activities.groups for system-created activities"
+)
+
+func init() {
+	MigrationRegistry[activitiesGroupsCreatedByNullableVersion] = &Migration{
+		Version:     activitiesGroupsCreatedByNullableVersion,
+		Description: activitiesGroupsCreatedByNullableDescription,
+		DependsOn:   []string{"1.8.3"}, // migration that added the created_by NOT NULL column
+	}
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return makeActivitiesGroupsCreatedByNullable(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return rollbackActivitiesGroupsCreatedByNullable(ctx, db)
+		},
+	)
+}
+
+func makeActivitiesGroupsCreatedByNullable(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.12.7: Making activities.groups.created_by nullable...")
+
+	// Idempotency: skip if already nullable
+	var isNullable string
+	err := db.QueryRowContext(ctx, `
+		SELECT is_nullable FROM information_schema.columns
+		WHERE table_schema = 'activities'
+		AND table_name = 'groups'
+		AND column_name = 'created_by'
+	`).Scan(&isNullable)
+	if err != nil {
+		return fmt.Errorf("error checking created_by nullable status: %w", err)
+	}
+	if isNullable == "YES" {
+		fmt.Println("  created_by is already nullable - skipping migration")
+		return nil
+	}
+
+	// Drop NOT NULL constraint (FK is retained, nullable FK is valid in Postgres)
+	_, err = db.ExecContext(ctx, `
+		ALTER TABLE activities.groups
+		ALTER COLUMN created_by DROP NOT NULL
+	`)
+	if err != nil {
+		return fmt.Errorf("error dropping NOT NULL from created_by: %w", err)
+	}
+
+	fmt.Println("Migration 1.12.7 completed: activities.groups.created_by is now nullable")
+	return nil
+}
+
+func rollbackActivitiesGroupsCreatedByNullable(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.12.7: Restoring NOT NULL on activities.groups.created_by...")
+
+	// Backfill any NULL values before re-adding NOT NULL constraint
+	result, err := db.ExecContext(ctx, `
+		UPDATE activities.groups g
+		SET created_by = (
+			SELECT s.staff_id
+			FROM activities.supervisors s
+			WHERE s.group_id = g.id
+			ORDER BY s.is_primary DESC, s.id
+			LIMIT 1
+		)
+		WHERE g.created_by IS NULL
+	`)
+	if err != nil {
+		return fmt.Errorf("error backfilling NULL created_by from supervisors: %w", err)
+	}
+	rowsUpdated, _ := result.RowsAffected()
+	if rowsUpdated > 0 {
+		fmt.Printf("  Backfilled %d rows from supervisors\n", rowsUpdated)
+	}
+
+	// Fallback: any still-NULL rows get the first available staff member
+	_, err = db.ExecContext(ctx, `
+		UPDATE activities.groups
+		SET created_by = (
+			SELECT s.id FROM users.staff s ORDER BY s.id LIMIT 1
+		)
+		WHERE created_by IS NULL
+	`)
+	if err != nil {
+		return fmt.Errorf("error backfilling NULL created_by with fallback staff: %w", err)
+	}
+
+	// Verify no NULLs remain
+	var nullCount int
+	err = db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM activities.groups WHERE created_by IS NULL
+	`).Scan(&nullCount)
+	if err != nil {
+		return fmt.Errorf("error verifying no nulls: %w", err)
+	}
+	if nullCount > 0 {
+		return fmt.Errorf("cannot restore NOT NULL: %d groups still have NULL created_by (no staff found)", nullCount)
+	}
+
+	_, err = db.ExecContext(ctx, `
+		ALTER TABLE activities.groups
+		ALTER COLUMN created_by SET NOT NULL
+	`)
+	if err != nil {
+		return fmt.Errorf("error restoring NOT NULL on created_by: %w", err)
+	}
+
+	fmt.Println("Rollback 1.12.7 completed: activities.groups.created_by is NOT NULL again")
+	return nil
+}

--- a/backend/database/migrations/00_migrations.go
+++ b/backend/database/migrations/00_migrations.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/uptrace/bun/migrate"
@@ -14,6 +15,33 @@ var Migrations = migrate.NewMigrations()
 // MigrationRegistry keeps track of all registered migrations with their metadata
 var MigrationRegistry = make(map[string]*Migration)
 
+// compareVersionsSemantic compares two "X.Y.Z" version strings numerically per segment.
+// Returns true if a < b (a should be ordered before b).
+// Lexicographic comparison would incorrectly order "1.12.7" < "1.8.3" because "1" < "8".
+func compareVersionsSemantic(a, b string) bool {
+	partsA := strings.Split(a, ".")
+	partsB := strings.Split(b, ".")
+
+	maxLen := len(partsA)
+	if len(partsB) > maxLen {
+		maxLen = len(partsB)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		var numA, numB int
+		if i < len(partsA) {
+			numA, _ = strconv.Atoi(partsA[i])
+		}
+		if i < len(partsB) {
+			numB, _ = strconv.Atoi(partsB[i])
+		}
+		if numA != numB {
+			return numA < numB
+		}
+	}
+	return false
+}
+
 // RegisteredMigrations returns all registered migrations sorted by version
 func RegisteredMigrations() []*Migration {
 	migrations := make([]*Migration, 0, len(MigrationRegistry))
@@ -21,9 +49,9 @@ func RegisteredMigrations() []*Migration {
 		migrations = append(migrations, m)
 	}
 
-	// Sort migrations by version (semantically)
+	// Sort migrations by version semantically (numeric per segment, not lexicographic)
 	sort.Slice(migrations, func(i, j int) bool {
-		return migrations[i].Version < migrations[j].Version
+		return compareVersionsSemantic(migrations[i].Version, migrations[j].Version)
 	})
 
 	return migrations

--- a/backend/database/migrations/reset.go
+++ b/backend/database/migrations/reset.go
@@ -23,7 +23,8 @@ func ResetDatabase() error {
 		return fmt.Errorf("failed to disable triggers: %w", err)
 	}
 
-	// List of schemas to drop and recreate
+	// List of schemas to drop and recreate.
+	// NOTE: keep in sync with all CREATE SCHEMA calls across migrations.
 	schemas := []string{
 		"auth",
 		"users",
@@ -36,6 +37,9 @@ func ResetDatabase() error {
 		"active",
 		"config",
 		"meta",
+		"audit",       // created by migration 1.3.7
+		"suggestions", // created by migration 1.9.1
+		"platform",    // created by migration 1.11.1
 	}
 
 	// 1. Drop all schemas with CASCADE to remove all objects inside them

--- a/backend/database/repositories/activities/group_repository_test.go
+++ b/backend/database/repositories/activities/group_repository_test.go
@@ -36,7 +36,7 @@ func TestActivityGroupRepository_Create(t *testing.T) {
 			CategoryID:      category.ID,
 			MaxParticipants: 20,
 			IsOpen:          true,
-			CreatedBy:       staff.ID,
+			CreatedBy:       &staff.ID,
 		}
 
 		err := repo.Create(ctx, group)
@@ -57,7 +57,7 @@ func TestActivityGroupRepository_Create(t *testing.T) {
 			CategoryID:      category.ID,
 			MaxParticipants: 15,
 			IsOpen:          false,
-			CreatedBy:       staff.ID,
+			CreatedBy:       &staff.ID,
 		}
 
 		err := repo.Create(ctx, group)

--- a/backend/models/activities/group.go
+++ b/backend/models/activities/group.go
@@ -18,7 +18,7 @@ type Group struct {
 	IsOpen          bool   `bun:"is_open,notnull,default:false" json:"is_open"`
 	CategoryID      int64  `bun:"category_id,notnull" json:"category_id"`
 	PlannedRoomID   *int64 `bun:"planned_room_id" json:"planned_room_id,omitempty"`
-	CreatedBy       int64  `bun:"created_by,notnull" json:"created_by"`
+	CreatedBy       *int64 `bun:"created_by" json:"created_by"`
 
 	// Relations - populated when using the ORM's relations
 	Category       *Category            `bun:"rel:belongs-to,join:category_id=id" json:"category,omitempty"`
@@ -76,16 +76,12 @@ func (g *Group) Validate() error {
 		return errors.New("category ID is required")
 	}
 
-	if g.CreatedBy <= 0 {
-		return errors.New("created_by is required")
-	}
-
 	return nil
 }
 
 // IsOwnedBy checks if the group was created by the given staff member
 func (g *Group) IsOwnedBy(staffID int64) bool {
-	return g.CreatedBy == staffID
+	return g.CreatedBy != nil && *g.CreatedBy == staffID
 }
 
 // IsSupervisedBy checks if the given staff member is a supervisor of this group

--- a/backend/models/activities/group_test.go
+++ b/backend/models/activities/group_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/base"
 )
 
+// int64Ptr returns a pointer to the given int64 value.
+func int64Ptr(v int64) *int64 { return &v }
+
 func TestGroupValidate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -20,7 +23,7 @@ func TestGroupValidate(t *testing.T) {
 				MaxParticipants: 10,
 				IsOpen:          true,
 				CategoryID:      1,
-				CreatedBy:       1,
+				CreatedBy:       int64Ptr(1),
 			},
 			wantErr: false,
 		},
@@ -31,8 +34,19 @@ func TestGroupValidate(t *testing.T) {
 				MaxParticipants: 15,
 				IsOpen:          false,
 				CategoryID:      2,
-				CreatedBy:       1,
+				CreatedBy:       int64Ptr(1),
 				PlannedRoomID:   func() *int64 { id := int64(3); return &id }(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid group with nil CreatedBy (system-created)",
+			group: &Group{
+				Name:            "System Group",
+				MaxParticipants: 10,
+				IsOpen:          true,
+				CategoryID:      1,
+				CreatedBy:       nil,
 			},
 			wantErr: false,
 		},
@@ -42,7 +56,7 @@ func TestGroupValidate(t *testing.T) {
 				MaxParticipants: 10,
 				IsOpen:          true,
 				CategoryID:      1,
-				CreatedBy:       1,
+				CreatedBy:       int64Ptr(1),
 			},
 			wantErr: true,
 		},
@@ -53,7 +67,7 @@ func TestGroupValidate(t *testing.T) {
 				MaxParticipants: 0,
 				IsOpen:          true,
 				CategoryID:      1,
-				CreatedBy:       1,
+				CreatedBy:       int64Ptr(1),
 			},
 			wantErr: true,
 		},
@@ -64,7 +78,7 @@ func TestGroupValidate(t *testing.T) {
 				MaxParticipants: -5,
 				IsOpen:          true,
 				CategoryID:      1,
-				CreatedBy:       1,
+				CreatedBy:       int64Ptr(1),
 			},
 			wantErr: true,
 		},
@@ -74,7 +88,7 @@ func TestGroupValidate(t *testing.T) {
 				Name:            "Test Group",
 				MaxParticipants: 10,
 				IsOpen:          true,
-				CreatedBy:       1,
+				CreatedBy:       int64Ptr(1),
 			},
 			wantErr: true,
 		},
@@ -85,7 +99,7 @@ func TestGroupValidate(t *testing.T) {
 				MaxParticipants: 10,
 				IsOpen:          true,
 				CategoryID:      -1,
-				CreatedBy:       1,
+				CreatedBy:       int64Ptr(1),
 			},
 			wantErr: true,
 		},
@@ -263,6 +277,8 @@ func TestGroup_GetUpdatedAt(t *testing.T) {
 	}
 }
 
+// TestGroupValidate_CreatedBy verifies that Validate() does not require CreatedBy.
+// CreatedBy is nullable (system-created groups have created_by = NULL).
 func TestGroupValidate_CreatedBy(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -270,37 +286,26 @@ func TestGroupValidate_CreatedBy(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Valid group with CreatedBy",
+			name: "Valid group with CreatedBy set",
 			group: &Group{
 				Name:            "Test Group",
 				MaxParticipants: 10,
 				IsOpen:          true,
 				CategoryID:      1,
-				CreatedBy:       42,
+				CreatedBy:       int64Ptr(42),
 			},
 			wantErr: false,
 		},
 		{
-			name: "Missing CreatedBy (zero)",
+			name: "Valid group with nil CreatedBy (system-created)",
 			group: &Group{
 				Name:            "Test Group",
 				MaxParticipants: 10,
 				IsOpen:          true,
 				CategoryID:      1,
-				CreatedBy:       0,
+				CreatedBy:       nil,
 			},
-			wantErr: true,
-		},
-		{
-			name: "Invalid CreatedBy (negative)",
-			group: &Group{
-				Name:            "Test Group",
-				MaxParticipants: 10,
-				IsOpen:          true,
-				CategoryID:      1,
-				CreatedBy:       -1,
-			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 
@@ -324,7 +329,7 @@ func TestGroup_IsOwnedBy(t *testing.T) {
 		{
 			name: "Staff is owner",
 			group: &Group{
-				CreatedBy: 42,
+				CreatedBy: int64Ptr(42),
 			},
 			staffID: 42,
 			want:    true,
@@ -332,7 +337,7 @@ func TestGroup_IsOwnedBy(t *testing.T) {
 		{
 			name: "Staff is not owner",
 			group: &Group{
-				CreatedBy: 42,
+				CreatedBy: int64Ptr(42),
 			},
 			staffID: 99,
 			want:    false,
@@ -340,9 +345,17 @@ func TestGroup_IsOwnedBy(t *testing.T) {
 		{
 			name: "Staff ID is zero",
 			group: &Group{
-				CreatedBy: 42,
+				CreatedBy: int64Ptr(42),
 			},
 			staffID: 0,
+			want:    false,
+		},
+		{
+			name: "System-created group (nil CreatedBy) is not owned by any staff",
+			group: &Group{
+				CreatedBy: nil,
+			},
+			staffID: 42,
 			want:    false,
 		},
 	}

--- a/backend/seed/fixed/activities.go
+++ b/backend/seed/fixed/activities.go
@@ -161,9 +161,9 @@ func (s *Seeder) seedActivities(ctx context.Context) error {
 			existing.PlannedRoomID = roomID
 			existing.IsOpen = true
 			existing.UpdatedAt = time.Now()
-			// Update created_by if it's 0 (legacy data)
-			if existing.CreatedBy == 0 {
-				existing.CreatedBy = defaultCreatorID
+			// Update created_by if it's nil (legacy / system-created data)
+			if existing.CreatedBy == nil {
+				existing.CreatedBy = &defaultCreatorID
 			}
 
 			if _, err := s.tx.NewUpdate().Model(existing).
@@ -184,7 +184,7 @@ func (s *Seeder) seedActivities(ctx context.Context) error {
 				MaxParticipants: data.maxParticipants,
 				PlannedRoomID:   roomID,
 				IsOpen:          true,
-				CreatedBy:       creatorID,
+				CreatedBy:       &creatorID,
 			}
 			group.CreatedAt = time.Now()
 			group.UpdatedAt = group.CreatedAt

--- a/backend/services/activities/activity_service.go
+++ b/backend/services/activities/activity_service.go
@@ -552,8 +552,8 @@ func (s *Service) CanModifyActivity(ctx context.Context, groupID int64, staffID 
 		return false, &ActivityError{Op: opCheckPermissions, Err: err}
 	}
 
-	// Check if user is the creator
-	if group.CreatedBy == staffID {
+	// Check if user is the creator (system-created groups with NULL created_by are not owned by any staff)
+	if group.CreatedBy != nil && *group.CreatedBy == staffID {
 		return true, nil
 	}
 

--- a/backend/services/activities/activity_service_test.go
+++ b/backend/services/activities/activity_service_test.go
@@ -329,7 +329,7 @@ func TestActivityService_UpdateGroup(t *testing.T) {
 		group.MaxParticipants = 50
 
 		// ACT - use creator's staff ID and give manage permission for test
-		result, err := service.UpdateGroup(ctx, group, group.CreatedBy, true)
+		result, err := service.UpdateGroup(ctx, group, *group.CreatedBy, true)
 
 		// ASSERT
 		require.NoError(t, err)
@@ -350,7 +350,7 @@ func TestActivityService_DeleteGroup(t *testing.T) {
 		group := testpkg.CreateTestActivityGroup(t, db, "to-delete-grp")
 
 		// ACT - use creator's staff ID and give manage permission for test
-		err := service.DeleteGroup(ctx, group.ID, group.CreatedBy, true)
+		err := service.DeleteGroup(ctx, group.ID, *group.CreatedBy, true)
 
 		// ASSERT
 		require.NoError(t, err)
@@ -864,7 +864,7 @@ func TestActivityService_CreateGroup(t *testing.T) {
 			MaxParticipants: 20,
 			IsOpen:          true,
 			CategoryID:      category.ID,
-			CreatedBy:       staff.ID,
+			CreatedBy:       &staff.ID,
 		}
 
 		// ACT
@@ -891,7 +891,7 @@ func TestActivityService_CreateGroup(t *testing.T) {
 			MaxParticipants: 15,
 			IsOpen:          false,
 			CategoryID:      category.ID,
-			CreatedBy:       staff.ID,
+			CreatedBy:       &staff.ID,
 		}
 
 		// ACT
@@ -919,7 +919,7 @@ func TestActivityService_CreateGroup(t *testing.T) {
 			Name:            "Invalid Category Group",
 			MaxParticipants: 10,
 			CategoryID:      99999999, // nonexistent
-			CreatedBy:       staff.ID,
+			CreatedBy:       &staff.ID,
 		}
 
 		// ACT
@@ -1353,7 +1353,7 @@ func TestActivityService_CreateGroup_WithSchedules(t *testing.T) {
 			MaxParticipants: 25,
 			IsOpen:          true,
 			CategoryID:      category.ID,
-			CreatedBy:       staff.ID,
+			CreatedBy:       &staff.ID,
 		}
 
 		schedules := []*activitiesModels.Schedule{
@@ -1524,7 +1524,7 @@ func TestActivityService_DeleteGroup_WithEnrollments(t *testing.T) {
 		require.NoError(t, err)
 
 		// ACT - delete group (using creator's staff ID with manage permission for test)
-		err = service.DeleteGroup(ctx, group.ID, group.CreatedBy, true)
+		err = service.DeleteGroup(ctx, group.ID, *group.CreatedBy, true)
 
 		// ASSERT
 		require.NoError(t, err)
@@ -1967,7 +1967,7 @@ func TestActivityService_CreateGroup_WithCategoryValidation(t *testing.T) {
 			Name:            "Test Group",
 			CategoryID:      99999999, // nonexistent
 			MaxParticipants: 10,
-			CreatedBy:       staff.ID,
+			CreatedBy:       &staff.ID,
 		}
 
 		// ACT
@@ -2208,7 +2208,7 @@ func TestActivityService_CreateGroup_ValidationError(t *testing.T) {
 			Name:            "", // Invalid: empty
 			CategoryID:      1,
 			MaxParticipants: 10,
-			CreatedBy:       staff.ID,
+			CreatedBy:       &staff.ID,
 		}
 
 		// ACT
@@ -2239,7 +2239,7 @@ func TestActivityService_UpdateGroup_ValidationError(t *testing.T) {
 		grp.Name = "" // Invalid: empty name
 
 		// ACT
-		result, err := service.UpdateGroup(ctx, grp, grp.CreatedBy, true)
+		result, err := service.UpdateGroup(ctx, grp, *grp.CreatedBy, true)
 
 		// ASSERT
 		require.Error(t, err)
@@ -2405,7 +2405,7 @@ func TestActivityService_CreateGroup_InvalidSupervisor(t *testing.T) {
 			Name:            "Test Group Invalid Sup",
 			CategoryID:      category.ID,
 			MaxParticipants: 20,
-			CreatedBy:       staff.ID,
+			CreatedBy:       &staff.ID,
 		}
 
 		// ACT - non-existent staff ID
@@ -2434,7 +2434,7 @@ func TestActivityService_CreateGroup_InvalidScheduleWeekday(t *testing.T) {
 			Name:            "Test Group Invalid Sched",
 			CategoryID:      category.ID,
 			MaxParticipants: 20,
-			CreatedBy:       staff.ID,
+			CreatedBy:       &staff.ID,
 		}
 
 		// Invalid weekday (should be 0-6)
@@ -2469,7 +2469,7 @@ func TestActivityService_DeleteGroup_CascadesSupervisors(t *testing.T) {
 		supervisorID := supervisor.ID
 
 		// ACT - delete group (using creator's staff ID with manage permission)
-		err = service.DeleteGroup(ctx, group.ID, group.CreatedBy, true)
+		err = service.DeleteGroup(ctx, group.ID, *group.CreatedBy, true)
 
 		// ASSERT
 		require.NoError(t, err)
@@ -2500,7 +2500,7 @@ func TestActivityService_DeleteGroup_CascadesSchedules(t *testing.T) {
 		scheduleID := created.ID
 
 		// ACT - delete group (using creator's staff ID with manage permission)
-		err = service.DeleteGroup(ctx, group.ID, group.CreatedBy, true)
+		err = service.DeleteGroup(ctx, group.ID, *group.CreatedBy, true)
 
 		// ASSERT
 		require.NoError(t, err)
@@ -2597,7 +2597,7 @@ func TestActivityService_UpdateGroup_Success(t *testing.T) {
 		group.Name = "Updated Group Name"
 
 		// ACT (using creator's staff ID with manage permission)
-		result, err := service.UpdateGroup(ctx, group, group.CreatedBy, true)
+		result, err := service.UpdateGroup(ctx, group, *group.CreatedBy, true)
 
 		// ASSERT
 		require.NoError(t, err)
@@ -2621,7 +2621,7 @@ func TestActivityService_CreateGroup_InvalidCategoryID(t *testing.T) {
 			Name:            "Test Group Invalid Cat",
 			CategoryID:      99999999, // Non-existent
 			MaxParticipants: 20,
-			CreatedBy:       staff.ID,
+			CreatedBy:       &staff.ID,
 		}
 
 		// ACT
@@ -2975,7 +2975,7 @@ func TestActivityService_CanModifyActivity_AdminBypassesOwnership(t *testing.T) 
 		Name:            "Admin Test Activity",
 		MaxParticipants: 10,
 		CategoryID:      category.ID,
-		CreatedBy:       staff.ID,
+		CreatedBy:       &staff.ID,
 	}
 	created, err := service.CreateGroup(ctx, group, []int64{staff.ID}, nil)
 	require.NoError(t, err)
@@ -3007,7 +3007,7 @@ func TestActivityService_CanModifyActivity_CreatorCanModify(t *testing.T) {
 		Name:            "Creator Test Activity",
 		MaxParticipants: 10,
 		CategoryID:      category.ID,
-		CreatedBy:       staff.ID,
+		CreatedBy:       &staff.ID,
 	}
 	created, err := service.CreateGroup(ctx, group, []int64{staff.ID}, nil)
 	require.NoError(t, err)
@@ -3040,7 +3040,7 @@ func TestActivityService_CanModifyActivity_SupervisorCanModify(t *testing.T) {
 		Name:            "Supervisor Test Activity",
 		MaxParticipants: 10,
 		CategoryID:      category.ID,
-		CreatedBy:       creator.ID,
+		CreatedBy:       &creator.ID,
 	}
 	created, err := service.CreateGroup(ctx, group, []int64{creator.ID, supervisor.ID}, nil)
 	require.NoError(t, err)
@@ -3072,7 +3072,7 @@ func TestActivityService_CanModifyActivity_NonOwnerCannotModify(t *testing.T) {
 		Name:            "Non-Owner Test Activity",
 		MaxParticipants: 10,
 		CategoryID:      category.ID,
-		CreatedBy:       creator.ID,
+		CreatedBy:       &creator.ID,
 	}
 	created, err := service.CreateGroup(ctx, group, []int64{creator.ID}, nil)
 	require.NoError(t, err)
@@ -3121,7 +3121,7 @@ func TestActivityService_UpdateGroup_OwnershipEnforced(t *testing.T) {
 		Name:            "Update Owner Test",
 		MaxParticipants: 10,
 		CategoryID:      category.ID,
-		CreatedBy:       creator.ID,
+		CreatedBy:       &creator.ID,
 	}
 	created, err := service.CreateGroup(ctx, group, []int64{creator.ID}, nil)
 	require.NoError(t, err)
@@ -3154,7 +3154,7 @@ func TestActivityService_DeleteGroup_OwnershipEnforced(t *testing.T) {
 		Name:            "Delete Owner Test",
 		MaxParticipants: 10,
 		CategoryID:      category.ID,
-		CreatedBy:       creator.ID,
+		CreatedBy:       &creator.ID,
 	}
 	created, err := service.CreateGroup(ctx, group, []int64{creator.ID}, nil)
 	require.NoError(t, err)

--- a/backend/services/facilities/schulhof_service.go
+++ b/backend/services/facilities/schulhof_service.go
@@ -280,7 +280,7 @@ func (s *schulhofService) EnsureInfrastructure(ctx context.Context, createdBy in
 		IsOpen:          true, // Open activity - anyone can join
 		CategoryID:      category.ID,
 		PlannedRoomID:   &room.ID,
-		CreatedBy:       createdBy,
+		CreatedBy:       &createdBy,
 	}
 
 	createdActivity, err := s.activityService.CreateGroup(ctx, newActivity, []int64{}, []*activityModels.Schedule{})

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -95,7 +95,7 @@ func CreateTestActivityGroup(tb testing.TB, db *bun.DB, name string) *activities
 		MaxParticipants: 20,
 		IsOpen:          true,
 		CategoryID:      category.ID,
-		CreatedBy:       staff.ID,
+		CreatedBy:       &staff.ID,
 	}
 
 	err := db.NewInsert().


### PR DESCRIPTION
## Summary

- **Migration 1.12.7**: `ALTER TABLE activities.groups ALTER COLUMN created_by DROP NOT NULL` — WC and Schulhof activity groups are auto-created on first student scan; they have no owning staff member, so `created_by = NULL` (system-created)
- **Model** (`models/activities/group.go`): `CreatedBy int64` → `*int64`, remove `notnull` BUN tag, update `Validate()` and `IsOwnedBy()` for nil-safety
- **Auto-create guards removed** (`wc.go`, `schulhof.go`): deleted the `staffCtx != nil` guard that was blocking auto-create without a staff PIN scan
- **Service** (`activity_service.go`): nil-safe pointer deref in `CanModifyActivity`
- **API** (`api/activities/api.go`): `GroupResponse.CreatedBy *int64`, pointer address-of in `createActivity` / `quickCreateActivity`
- **Compile fixes** (mechanical `int64` → `*int64` updates): `activity_service_test`, `group_repository_test`, `schulhof_service`, `seed/fixed/activities`, `test/fixtures`

### Infrastructure fixes (discovered during implementation)

- **Migration sort bug** (`00_migrations.go`): added `compareVersionsSemantic()` — lexicographic sort made `"1.12.7" < "1.8.3"`, breaking `ValidateMigrations()` for any version with a two-digit minor segment
- **`reset.go`** missing schemas: `audit`, `suggestions`, `platform` were not dropped on `migrate reset`, causing subsequent fresh-run failures in migration 1.12.1

## Test plan

- [ ] `APP_ENV=test go run main.go migrate reset` completes all 104 migrations including 1.12.7
- [ ] `go test ./...` — all 96 packages pass
- [ ] New integration tests: `TestDeviceCheckin_WCAutoCreateWithoutStaff`, `TestDeviceCheckin_SchulhofAutoCreateWithoutStaff` — verify HTTP 200 when no staff PIN is scanned (attendance pre-condition satisfied per the invariant that students were checked in earlier with staff)
- [ ] New internal tests: `TestWcActivityGroup_NoStaffContext`, `TestSchulhofActivityGroup_NoStaffContext` — unit-test the auto-create functions directly; verify `group.CreatedBy == nil`
- [ ] Manual E2E: set up a WC/Schulhof room in admin UI, scan student RFID without staff PIN → HTTP 200; confirm `activities.groups WHERE name = 'WC'` has `created_by IS NULL`