### PR TITLE
fix: invalidate ogs-students SWR cache on SSE checkout events

### DIFF
--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -74,6 +74,19 @@ export function useGlobalSSE(): SSEHookState {
           scope: "supervision_visits",
         });
       });
+
+      // Invalidate OGS group student caches (ogs-students-{groupId})
+      // so the "Meine Gruppe" page picks up location changes (e.g. Zuhause)
+      mutate(
+        (key) => typeof key === "string" && key.startsWith("ogs-students-"),
+        undefined,
+        { revalidate: true },
+      ).catch((err) => {
+        logger.debug("swr_revalidation_failed", {
+          error: err instanceof Error ? err.message : String(err),
+          scope: "ogs_students",
+        });
+      });
     }
 
     // Invalidate specific student detail caches


### PR DESCRIPTION
## Summary

- The OGS Groups page (`/ogs-groups`) uses `ogs-students-{groupId}` SWR keys to fetch student location data
- These keys were never invalidated by `student_checkin`/`student_checkout` SSE events, so the "Zuhause" badge didn't update in real time
- Added `ogs-students-*` cache invalidation in `flushInvalidations()` alongside the existing `supervision-visits-*` block

## Test plan

- [x] `pnpm run check` passes with zero warnings
- [x] All 10 existing SSE tests pass (`use-global-sse.test.ts`)
- [ ] Manual: open OGS Groups page, check out a student from another tab/device, confirm "Zuhause" badge appears in real time