### PR TITLE
fix: SSE daily checkout broadcast and cache invalidation

### DIFF
--- a/backend/api/iot/attendance/handlers.go
+++ b/backend/api/iot/attendance/handlers.go
@@ -238,6 +238,9 @@ func (rs *Resource) handleDailyCheckout(w http.ResponseWriter, r *http.Request, 
 				iotCommon.RenderError(w, r, iotCommon.ErrorInternalServer(err))
 				return
 			}
+
+			// Broadcast SSE event so the OGS Groups page updates in real time
+			rs.ActiveService.BroadcastDailyCheckout(r.Context(), student.ID)
 		}
 	}
 

--- a/backend/services/active/attendance_service.go
+++ b/backend/services/active/attendance_service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/device"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/realtime"
 )
 
 // Attendance tracking operations
@@ -332,6 +333,32 @@ func (s *service) CheckTeacherStudentAccess(ctx context.Context, teacherID, stud
 	}
 
 	return false, nil
+}
+
+// BroadcastDailyCheckout sends an SSE student_checkout event to the student's
+// educational (OGS) group topic so the "Meine Gruppe" page updates in real time.
+// Called after the daily checkout attendance toggle succeeds.
+func (s *service) BroadcastDailyCheckout(ctx context.Context, studentID int64) {
+	if s.broadcaster == nil {
+		return
+	}
+
+	studentIDStr := fmt.Sprintf("%d", studentID)
+	studentName, studentRec := s.getStudentDisplayData(ctx, studentID)
+
+	source := "daily_checkout"
+	event := realtime.NewEvent(
+		realtime.EventStudentCheckOut,
+		"", // no active group — student already left their room
+		realtime.EventData{
+			StudentID:   &studentIDStr,
+			StudentName: &studentName,
+			Source:      &source,
+		},
+	)
+
+	// Broadcast to educational (OGS) group topic so the "Meine Gruppe" page updates
+	s.broadcastToEducationalGroup(studentRec, event)
 }
 
 // ======== Unclaimed Groups Management (Deviceless Claiming) ========

--- a/backend/services/active/attendance_service_test.go
+++ b/backend/services/active/attendance_service_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/device"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
+	activeService "github.com/moto-nrw/project-phoenix/services/active"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -758,5 +759,89 @@ func TestGetStudentAttendanceStatus_WithStaffNames(t *testing.T) {
 		assert.NotEmpty(t, result.CheckedOutBy, "Expected check-out staff name")
 		assert.Contains(t, result.CheckedInBy, "CheckIn")
 		assert.Contains(t, result.CheckedOutBy, "CheckOut")
+	})
+}
+
+// =============================================================================
+// BroadcastDailyCheckout Tests
+// =============================================================================
+
+// TestBroadcastDailyCheckout_WithStudent tests the happy path: student exists,
+// has a person record. Verifies the method completes without panic.
+func TestBroadcastDailyCheckout_WithStudent(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := context.Background()
+
+	// ARRANGE: Create a student (has person record via CreateTestStudent)
+	student := testpkg.CreateTestStudent(t, db, "Broadcast", "Student", "9a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	// ACT: Should complete without panic — broadcaster exists but has no connected clients
+	service.BroadcastDailyCheckout(ctx, student.ID)
+
+	// ASSERT: No panic, no error — method is fire-and-forget
+}
+
+// TestBroadcastDailyCheckout_NonExistentStudent tests the path where the student ID
+// doesn't exist in the database. getStudentDisplayData returns ("", nil), and
+// broadcastToEducationalGroup exits early on nil student.
+func TestBroadcastDailyCheckout_NonExistentStudent(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := context.Background()
+
+	// ACT: Call with a non-existent student ID — should not panic
+	service.BroadcastDailyCheckout(ctx, 99999999)
+
+	// ASSERT: No panic, no error — broadcastToEducationalGroup returns early on nil student
+}
+
+// TestBroadcastDailyCheckout_StudentWithEducationGroup tests the full broadcast path:
+// student exists and is assigned to an education (OGS) group (GroupID != nil).
+// This exercises broadcastToEducationalGroup with a real group topic.
+func TestBroadcastDailyCheckout_StudentWithEducationGroup(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := context.Background()
+
+	// ARRANGE: Create education group and student assigned to it
+	eduGroup := testpkg.CreateTestEducationGroup(t, db, "OGS-Broadcast")
+	student := testpkg.CreateTestStudent(t, db, "EduBroadcast", "Student", "9b")
+	defer testpkg.CleanupActivityFixtures(t, db, eduGroup.ID, student.ID)
+
+	// Assign student to education group (set GroupID)
+	_, err := db.NewUpdate().
+		Model(student).
+		ModelTableExpr(`users.students`).
+		Set("group_id = ?", eduGroup.ID).
+		Where("id = ?", student.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	// ACT: Should complete without panic — exercises broadcastToEducationalGroup
+	// with a real edu:{groupID} topic. No connected SSE clients, so BroadcastToGroup
+	// succeeds silently.
+	service.BroadcastDailyCheckout(ctx, student.ID)
+
+	// ASSERT: No panic, no error — fire-and-forget broadcast completed
+}
+
+// TestBroadcastDailyCheckout_NilBroadcaster tests the nil-broadcaster early-return guard.
+// When the service is constructed without a broadcaster, BroadcastDailyCheckout should
+// return immediately without panicking or accessing any repository.
+func TestBroadcastDailyCheckout_NilBroadcaster(t *testing.T) {
+	// ARRANGE: Construct service with all nil deps — no broadcaster
+	svc := activeService.NewService(activeService.ServiceDependencies{})
+
+	// ACT: Should hit the `if s.broadcaster == nil { return }` guard and exit safely
+	assert.NotPanics(t, func() {
+		svc.BroadcastDailyCheckout(context.Background(), 12345)
 	})
 }

--- a/backend/services/active/interface.go
+++ b/backend/services/active/interface.go
@@ -104,6 +104,7 @@ type Service interface {
 	GetStudentsAttendanceStatuses(ctx context.Context, studentIDs []int64) (map[int64]*AttendanceStatus, error)
 	ToggleStudentAttendance(ctx context.Context, studentID, staffID, deviceID int64, skipAuthCheck bool) (*AttendanceResult, error)
 	CheckTeacherStudentAccess(ctx context.Context, teacherID, studentID int64) (bool, error)
+	BroadcastDailyCheckout(ctx context.Context, studentID int64)
 
 	// Unclaimed groups management (deviceless claiming)
 	GetUnclaimedActiveGroups(ctx context.Context) ([]*active.Group, error)

--- a/backend/services/scheduler/scheduler_test.go
+++ b/backend/services/scheduler/scheduler_test.go
@@ -1130,6 +1130,7 @@ func (m *mockActiveService) ToggleStudentAttendance(_ context.Context, _, _, _ i
 func (m *mockActiveService) CheckTeacherStudentAccess(_ context.Context, _, _ int64) (bool, error) {
 	return false, nil
 }
+func (m *mockActiveService) BroadcastDailyCheckout(_ context.Context, _ int64) {}
 func (m *mockActiveService) GetUnclaimedActiveGroups(_ context.Context) ([]*active.Group, error) {
 	return nil, nil
 }

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -204,6 +204,197 @@ describe("useGlobalSSE", () => {
       expect(mutate).toHaveBeenCalled();
     });
 
+    it("student_checkout without active_group_id invalidates ogs-students caches", () => {
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      // Daily checkout: has student_id but NO active_group_id
+      onMessage?.({
+        type: "student_checkout",
+        active_group_id: "",
+        data: { student_id: "42" },
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+
+      // Find the mutate call with the ogs-students matcher
+      const mutateCalls = vi.mocked(mutate).mock.calls;
+      const ogsStudentCall = mutateCalls.find((call) => {
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)("ogs-students-5")
+        );
+      });
+      expect(ogsStudentCall).toBeDefined();
+    });
+
+    it("student_checkout without active_group_id invalidates dashboard caches", () => {
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      onMessage?.({
+        type: "student_checkout",
+        active_group_id: "",
+        data: { student_id: "42" },
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+
+      const mutateCalls = vi.mocked(mutate).mock.calls;
+      const dashboardCall = mutateCalls.find((call) => {
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)("active-supervision-dashboard")
+        );
+      });
+      expect(dashboardCall).toBeDefined();
+    });
+
+    it("student_checkout without active_group_id invalidates student-detail cache", () => {
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      onMessage?.({
+        type: "student_checkout",
+        active_group_id: "",
+        data: { student_id: "42" },
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+
+      const mutateCalls = vi.mocked(mutate).mock.calls;
+      const studentDetailCall = mutateCalls.find((call) => {
+        return call[0] === "student-detail-42";
+      });
+      expect(studentDetailCall).toBeDefined();
+    });
+
+    it("student_checkout without active_group_id does NOT invalidate supervision-visits", () => {
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      // Daily checkout: no active_group_id means pendingGroupIds stays empty
+      onMessage?.({
+        type: "student_checkout",
+        active_group_id: "",
+        data: { student_id: "42" },
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+
+      // supervision-visits should NOT be invalidated (requires pendingGroupIds)
+      const mutateCalls = vi.mocked(mutate).mock.calls;
+      const supervisionCall = mutateCalls.find((call) => {
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)("supervision-visits-999")
+        );
+      });
+      expect(supervisionCall).toBeUndefined();
+    });
+
+    it("handles mutate rejection for ogs-students gracefully", async () => {
+      // Make mutate reject to exercise the .catch() error handler
+      vi.mocked(mutate).mockRejectedValue(new Error("SWR error"));
+
+      const consoleSpy = vi
+        .spyOn(console, "debug")
+        .mockImplementation(() => undefined);
+
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      // Daily checkout: has student_id but empty active_group_id
+      onMessage?.({
+        type: "student_checkout",
+        active_group_id: "",
+        data: { student_id: "42" },
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+
+      // Flush microtask queue so .catch() handlers execute
+      await vi.runAllTimersAsync();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "swr_revalidation_failed",
+        expect.objectContaining({ scope: "ogs_students" }),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("handles mutate rejection for student-detail gracefully", async () => {
+      vi.mocked(mutate).mockRejectedValue(new Error("SWR error"));
+
+      const consoleSpy = vi
+        .spyOn(console, "debug")
+        .mockImplementation(() => undefined);
+
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      onMessage?.({
+        type: "student_checkout",
+        active_group_id: "",
+        data: { student_id: "42" },
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+      await vi.runAllTimersAsync();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "swr_revalidation_failed",
+        expect.objectContaining({ scope: "student_detail" }),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("handles mutate rejection for dashboard gracefully", async () => {
+      vi.mocked(mutate).mockRejectedValue(new Error("SWR error"));
+
+      const consoleSpy = vi
+        .spyOn(console, "debug")
+        .mockImplementation(() => undefined);
+
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      onMessage?.({
+        type: "student_checkout",
+        active_group_id: "",
+        data: { student_id: "42" },
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+      await vi.runAllTimersAsync();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "swr_revalidation_failed",
+        expect.objectContaining({ scope: "dashboard" }),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
     it("silently ignores unknown event types without invalidating caches", () => {
       renderHook(() => useGlobalSSE());
 

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -74,9 +74,16 @@ export function useGlobalSSE(): SSEHookState {
           scope: "supervision_visits",
         });
       });
+    }
 
-      // Invalidate OGS group student caches (ogs-students-{groupId})
-      // so the "Meine Gruppe" page picks up location changes (e.g. Zuhause)
+    // Invalidate OGS group student caches (ogs-students-{groupId})
+    // so the "Meine Gruppe" page picks up location changes (e.g. Zuhause).
+    // Triggered by pendingGroupIds (room-level events) OR pendingStudentIds
+    // (daily checkout sends student_checkout without an active_group_id).
+    if (
+      pendingGroupIds.current.size > 0 ||
+      pendingStudentIds.current.size > 0
+    ) {
       mutate(
         (key) => typeof key === "string" && key.startsWith("ogs-students-"),
         undefined,
@@ -100,7 +107,11 @@ export function useGlobalSSE(): SSEHookState {
     }
 
     // Invalidate dashboard (student counts changed) — single broad invalidation
-    if (pendingGroupIds.current.size > 0 || hasPendingActivityEvent.current) {
+    if (
+      pendingGroupIds.current.size > 0 ||
+      pendingStudentIds.current.size > 0 ||
+      hasPendingActivityEvent.current
+    ) {
       mutate(
         (key) =>
           typeof key === "string" &&


### PR DESCRIPTION
## Summary

- Broadcast SSE `student_checkout` event on daily checkout so the OGS Groups page updates in real time
- Invalidate `ogs-students` SWR cache for daily checkout events (no `active_group_id`)
- Invalidate `student-detail` and `dashboard` caches on daily checkout
- Full test coverage for nil-broadcaster guard, mutate rejection error handlers, and broadcast paths

## Commits

- `fix: broadcast SSE event on daily checkout so OGS Groups page updates in real time`
- `fix: invalidate ogs-students cache for daily checkout events without group ID`
- `fix: invalidate ogs-students SWR cache on SSE checkout events`
- `test: add coverage for BroadcastDailyCheckout and daily checkout SSE cache invalidation`
- `test: cover nil-broadcaster guard and mutate rejection error handlers`

## Test plan

- [x] Backend tests pass (`go test ./services/active/... -v`)
- [x] Frontend tests pass (`pnpm test:run`)
- [x] Frontend lint + typecheck pass (`pnpm run check`)
- [x] SonarCloud quality gate passed on development CI
- [x] Docker images built and pushed successfully
- [x] Verified working on staging