### PR TITLE
fix: stabilize tenant router ref and dev CSP

### DIFF
--- a/frontend/src/lib/tenant-router.ts
+++ b/frontend/src/lib/tenant-router.ts
@@ -2,6 +2,7 @@
 
 // eslint-disable-next-line no-restricted-imports -- this IS the tenant-aware wrapper
 import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 import { useTenant } from "~/components/tenant/tenant-provider";
 
 /**
@@ -16,12 +17,15 @@ export function useTenantRouter() {
   const { tenantSlug } = useTenant();
   const router = useRouter();
 
-  return {
-    push: (path: string) => router.push(`/${tenantSlug}${path}`),
-    replace: (path: string) => router.replace(`/${tenantSlug}${path}`),
-    back: () => router.back(),
-    forward: () => router.forward(),
-    refresh: () => router.refresh(),
-    prefetch: (path: string) => router.prefetch(`/${tenantSlug}${path}`),
-  };
+  return useMemo(
+    () => ({
+      push: (path: string) => router.push(`/${tenantSlug}${path}`),
+      replace: (path: string) => router.replace(`/${tenantSlug}${path}`),
+      back: () => router.back(),
+      forward: () => router.forward(),
+      refresh: () => router.refresh(),
+      prefetch: (path: string) => router.prefetch(`/${tenantSlug}${path}`),
+    }),
+    [tenantSlug, router],
+  );
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -11,9 +11,11 @@ import type { NextRequest } from "next/server";
  * Stateless: no DB calls, no auth checks. The [tenant]/layout.tsx validates the slug.
  */
 
+const isDev = process.env.NODE_ENV === "development";
+
 const CSP_HEADER = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob:",
   "connect-src 'self'",


### PR DESCRIPTION
## Summary

- **useTenantRouter re-render fix**: The `useTenantRouter()` hook returned a new object on every render, causing unnecessary re-renders in any component consuming it. Wrapped in `useMemo` to stabilize the reference.
- **Dev CSP `unsafe-eval`**: Next.js dev server needs `'unsafe-eval'` in `script-src` for HMR/Fast Refresh. Added it conditionally for `development` mode only — production CSP is unchanged.

## Test plan
- [ ] Verify dev server runs without CSP eval errors in browser console
- [ ] Verify components using `useTenantRouter()` don't re-render excessively