### PR TITLE
feat: increase default Schulhof capacity to 300

### DIFF
--- a/backend/constants/activities.go
+++ b/backend/constants/activities.go
@@ -23,10 +23,10 @@ const (
 	SchulhofRoomName = "Schulhof"
 
 	// SchulhofRoomCapacity is the default capacity for the Schulhof room.
-	SchulhofRoomCapacity = 100
+	SchulhofRoomCapacity = 300
 
 	// SchulhofMaxParticipants is the default max participants for the Schulhof activity.
-	SchulhofMaxParticipants = 100
+	SchulhofMaxParticipants = 300
 
 	// WCActivityName is the name of the permanent WC (toilet) activity.
 	// This activity is auto-created on first use if not found.

--- a/backend/seed/fixed/rooms.go
+++ b/backend/seed/fixed/rooms.go
@@ -76,7 +76,7 @@ func (s *Seeder) seedRooms(ctx context.Context) error {
 		{Name: "Lehrerzimmer", RoomNumber: "STAFF", Building: BuildingMain, Floor: 0, Capacity: 40, RoomType: "staff_room", IsAccessible: true, HasProjector: true, HasSmartboard: true, Description: "Lehrerzimmer mit Arbeitsplätzen"},
 
 		// Outdoor areas
-		{Name: "Schulhof", RoomNumber: "OUTDOOR", Building: "Außenbereich", Floor: 0, Capacity: 100, RoomType: "schulhof", IsAccessible: true, HasProjector: false, HasSmartboard: false, Description: "Schulhof für Freispiel und Pausen"},
+		{Name: "Schulhof", RoomNumber: "OUTDOOR", Building: "Außenbereich", Floor: 0, Capacity: 300, RoomType: "schulhof", IsAccessible: true, HasProjector: false, HasSmartboard: false, Description: "Schulhof für Freispiel und Pausen"},
 	}
 
 	for _, data := range rooms {


### PR DESCRIPTION
## Summary
- Increases default Schulhof room capacity and max participants from 100 to 300
- OGS requested higher limit — on sunny days far more than 50-100 children want to use the schoolyard
- Only affects **new auto-created** Schulhof rooms/activities; existing installations were already updated directly in the DB

## Changed files
- `backend/constants/activities.go` — `SchulhofRoomCapacity` and `SchulhofMaxParticipants` → 300
- `backend/seed/fixed/rooms.go` — Schulhof seed capacity → 300

## Test plan
- [x] Verified all usages reference the constants (no hardcoded values)
- [x] Confirmed runtime enforcement reads from DB, not constants
- [x] All hooks pass (go-vet, golangci-lint, go-deadcode, git-secrets)