### PR TITLE
merge: sync development into feature/multi-tenancy

### DIFF
--- a/backend/auth/jwt/authenticator.go
+++ b/backend/auth/jwt/authenticator.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/lestrrat-go/jwx/v3/jwt"
 
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/go-chi/render"

--- a/backend/auth/jwt/claims.go
+++ b/backend/auth/jwt/claims.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/lestrrat-go/jwx/v3/jwt"
 )
 
 type CommonClaims struct {

--- a/backend/auth/jwt/tokenauth_test.go
+++ b/backend/auth/jwt/tokenauth_test.go
@@ -1,7 +1,6 @@
 package jwt
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -104,7 +103,8 @@ func TestTokenAuth_CreateJWT_SetsExpiry(t *testing.T) {
 	require.NotNil(t, decoded)
 
 	// Check expiration is in the future
-	expTime := decoded.Expiration()
+	expTime, ok := decoded.Expiration()
+	require.True(t, ok, "token should have expiration")
 	assert.True(t, expTime.After(beforeCreate))
 	assert.True(t, expTime.Before(beforeCreate.Add(auth.JwtExpiry+time.Minute)))
 }
@@ -198,7 +198,8 @@ func TestTokenAuth_CreateRefreshJWT_SetsExpiry(t *testing.T) {
 	require.NotNil(t, decoded)
 
 	// Check expiration is in the future
-	expTime := decoded.Expiration()
+	expTime, ok := decoded.Expiration()
+	require.True(t, ok, "token should have expiration")
 	assert.True(t, expTime.After(beforeCreate))
 	assert.True(t, expTime.Before(beforeCreate.Add(auth.JwtRefreshExpiry+time.Minute)))
 }
@@ -470,10 +471,11 @@ func TestTokenAuth_CreateJWT_SpecialCharactersInClaims(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, decoded)
 
-	claimsMap, err := decoded.AsMap(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, "José", claimsMap["first_name"])
-	assert.Equal(t, "O'Connor-Smith", claimsMap["last_name"])
+	var firstName, lastName string
+	require.NoError(t, decoded.Get("first_name", &firstName))
+	require.NoError(t, decoded.Get("last_name", &lastName))
+	assert.Equal(t, "José", firstName)
+	assert.Equal(t, "O'Connor-Smith", lastName)
 }
 
 func TestTokenAuth_CreateJWT_EmptyUsername(t *testing.T) {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/joho/godotenv v1.5.1
 	github.com/k3a/html2text v1.3.0
-	github.com/lestrrat-go/jwx/v2 v2.1.6
+	github.com/lestrrat-go/jwx/v3 v3.0.2
 	github.com/samber/slog-chi v1.19.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
@@ -51,10 +51,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.3 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
-	github.com/lestrrat-go/httprc v1.0.6 // indirect
 	github.com/lestrrat-go/httprc/v3 v3.0.0-beta2 // indirect
-	github.com/lestrrat-go/iter v1.0.2 // indirect
-	github.com/lestrrat-go/jwx/v3 v3.0.2 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -78,14 +78,8 @@ github.com/lestrrat-go/blackmagic v1.0.3 h1:94HXkVLxkZO9vJI/w2u1T0DAoprShFd13xtn
 github.com/lestrrat-go/blackmagic v1.0.3/go.mod h1:6AWFyKNNj0zEXQYfTMPfZrAXUWUfTIZ5ECEUEJaijtw=
 github.com/lestrrat-go/httpcc v1.0.1 h1:ydWCStUeJLkpYyjLDHihupbn2tYmZ7m22BGkcvZZrIE=
 github.com/lestrrat-go/httpcc v1.0.1/go.mod h1:qiltp3Mt56+55GPVCbTdM9MlqhvzyuL6W/NMDA8vA5E=
-github.com/lestrrat-go/httprc v1.0.6 h1:qgmgIRhpvBqexMJjA/PmwSvhNk679oqD1RbovdCGW8k=
-github.com/lestrrat-go/httprc v1.0.6/go.mod h1:mwwz3JMTPBjHUkkDv/IGJ39aALInZLrhBp0X7KGUZlo=
 github.com/lestrrat-go/httprc/v3 v3.0.0-beta2 h1:SDxjGoH7qj0nBXVrcrxX8eD94wEnjR+EEuqqmeqQYlY=
 github.com/lestrrat-go/httprc/v3 v3.0.0-beta2/go.mod h1:Nwo81sMxE0DcvTB+rJyynNhv/DUu2yZErV7sscw9pHE=
-github.com/lestrrat-go/iter v1.0.2 h1:gMXo1q4c2pHmC3dn8LzRhJfP1ceCbgSiT9lUydIzltI=
-github.com/lestrrat-go/iter v1.0.2/go.mod h1:Momfcq3AnRlRjI5b5O8/G5/BvpzrhoFTZcn06fEOPt4=
-github.com/lestrrat-go/jwx/v2 v2.1.6 h1:hxM1gfDILk/l5ylers6BX/Eq1m/pnxe9NBwW6lVfecA=
-github.com/lestrrat-go/jwx/v2 v2.1.6/go.mod h1:Y722kU5r/8mV7fYDifjug0r8FK8mZdw0K0GpJw/l8pU=
 github.com/lestrrat-go/jwx/v3 v3.0.2 h1:N+XLjTJEzDZRP3S0SezclXFAfopwL+o5vaL+qg6rX1I=
 github.com/lestrrat-go/jwx/v3 v3.0.2/go.mod h1:qO9w1qkQH77a0r9OXNM33YQPnV/evetKYRg58h1rBNE=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=

--- a/backend/services/auth/auth_login.go
+++ b/backend/services/auth/auth_login.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	jwx "github.com/lestrrat-go/jwx/v2/jwt"
+	jwx "github.com/lestrrat-go/jwx/v3/jwt"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/auth/userpass"
 	"github.com/moto-nrw/project-phoenix/models/audit"
@@ -821,17 +821,12 @@ func (s *Service) GetAccountByEmail(ctx context.Context, email string) (*auth.Ac
 func extractClaims(token jwx.Token) map[string]interface{} {
 	claims := make(map[string]interface{})
 
-	// Extract private claims
-	for k, v := range token.PrivateClaims() {
-		claims[k] = v
-	}
-
-	// Add registered claims if present
-	if sub, ok := token.Get(jwx.SubjectKey); ok {
-		claims[jwx.SubjectKey] = sub
-	}
-	if exp, ok := token.Get(jwx.ExpirationKey); ok {
-		claims[jwx.ExpirationKey] = exp
+	// Extract all claims via Keys() + Get()
+	for _, k := range token.Keys() {
+		var v interface{}
+		if err := token.Get(k, &v); err == nil {
+			claims[k] = v
+		}
 	}
 
 	return claims


### PR DESCRIPTION
## Summary

- Sync latest development changes into the multi-tenancy feature branch
- Resolve 16 merge conflicts (bun.In→bun.List migration combined with tenant query separation)
- Fix jwx v2→v3 migration (broken by dependabot jwtauth v5.4.0 bump in PR #939)
- Fix remaining deprecated bun.In usage in test fixtures

## Changes from development

- Dependabot dependency updates (uptrace-bun, go-chi/jwtauth, excelize, go-premailer)
- CI workflow updates (actions/setup-go, actions/upload-artifact)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./auth/jwt/...` — all 97 tests pass
- [x] All pre-push hooks pass (go-vet, golangci-lint, go-deadcode)