### PR TITLE
fix: pin system time in flaky absence modal date tests

### DIFF
--- a/frontend/src/app/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/(protected)/time-tracking/page.test.tsx
@@ -2618,17 +2618,33 @@ describe("TimeTrackingPage", () => {
     });
 
     it("changes start date", () => {
-      openAbsenceModal();
-      const startInput = screen.getByLabelText("Von");
-      fireEvent.change(startInput, { target: { value: "2026-03-01" } });
-      expect((startInput as HTMLInputElement).value).toBe("2026-03-01");
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-15T10:00:00"));
+      try {
+        openAbsenceModal();
+        const startInput = screen.getByLabelText("Von");
+        fireEvent.change(startInput, {
+          target: { value: "2026-03-01" },
+        });
+        expect((startInput as HTMLInputElement).value).toBe("2026-03-01");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("changes end date", () => {
-      openAbsenceModal();
-      const endInput = screen.getByLabelText("Bis");
-      fireEvent.change(endInput, { target: { value: "2026-03-05" } });
-      expect((endInput as HTMLInputElement).value).toBe("2026-03-05");
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-15T10:00:00"));
+      try {
+        openAbsenceModal();
+        const endInput = screen.getByLabelText("Bis");
+        fireEvent.change(endInput, {
+          target: { value: "2026-03-05" },
+        });
+        expect((endInput as HTMLInputElement).value).toBe("2026-03-05");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("closes modal on Abbrechen", () => {


### PR DESCRIPTION
## Summary
- The `CreateAbsenceModal - comprehensive` > `changes end date` test fails after 2026-03-05 because it uses a hardcoded past date while the component enforces `min={today}` on the end date input
- Pin `vi.useFakeTimers()` to `2026-01-15` for the two date-dependent tests only (start date + end date), keeping async tests unaffected

## Test plan
- [x] `pnpm vitest run -t "CreateAbsenceModal - comprehensive"` passes locally (9/9)
- [ ] CI `test-frontend` passes