### PR TITLE
fix: use tenant-aware SWR mutate for correct cache invalidation in mu…

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/database/activities/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/activities/page.test.tsx
@@ -18,7 +18,7 @@ vi.mock("next/navigation", () => ({
 // Mock SWR hooks
 vi.mock("~/lib/swr", () => ({
   useSWRAuth: vi.fn(),
-  mutate: vi.fn(),
+  useTenantMutate: vi.fn(() => vi.fn()),
 }));
 
 // Mock service factory

--- a/frontend/src/app/[tenant]/(protected)/database/activities/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/activities/page.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/activities";
 import { ConfirmationModal } from "~/components/ui/modal";
 import { useDeleteConfirmation } from "~/hooks/useDeleteConfirmation";
-import { useSWRAuth, mutate } from "~/lib/swr";
+import { useSWRAuth, useTenantMutate } from "~/lib/swr";
 
 const logger = createLogger({ component: "DatabaseActivitiesPage" });
 
@@ -53,6 +53,7 @@ export default function ActivitiesPage() {
   // Secondary management modals (disabled for now)
 
   const { success: toastSuccess } = useToast();
+  const mutate = useTenantMutate();
 
   const { status } = useSession({
     required: true,

--- a/frontend/src/app/[tenant]/(protected)/database/groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/groups/page.test.tsx
@@ -18,7 +18,7 @@ vi.mock("next/navigation", () => ({
 // Mock SWR hooks
 vi.mock("~/lib/swr", () => ({
   useSWRAuth: vi.fn(),
-  mutate: vi.fn(),
+  useTenantMutate: vi.fn(() => vi.fn()),
 }));
 
 // Mock service factory

--- a/frontend/src/app/[tenant]/(protected)/database/groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/groups/page.tsx
@@ -22,7 +22,7 @@ import { ConfirmationModal } from "~/components/ui/modal";
 import { useToast } from "~/contexts/ToastContext";
 import { useIsMobile } from "~/hooks/useIsMobile";
 import { useDeleteConfirmation } from "~/hooks/useDeleteConfirmation";
-import { useSWRAuth, mutate } from "~/lib/swr";
+import { useSWRAuth, useTenantMutate } from "~/lib/swr";
 
 export default function GroupsPage() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -45,6 +45,7 @@ export default function GroupsPage() {
   } = useDeleteConfirmation(setShowDetailModal);
 
   const { success: toastSuccess } = useToast();
+  const mutate = useTenantMutate();
 
   const { status } = useSession({
     required: true,

--- a/frontend/src/app/[tenant]/(protected)/database/rooms/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/rooms/page.test.tsx
@@ -18,7 +18,7 @@ vi.mock("next/navigation", () => ({
 // Mock SWR hooks
 vi.mock("~/lib/swr", () => ({
   useSWRAuth: vi.fn(),
-  mutate: vi.fn(),
+  useTenantMutate: vi.fn(() => vi.fn()),
 }));
 
 // Mock service factory

--- a/frontend/src/app/[tenant]/(protected)/database/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/rooms/page.tsx
@@ -25,7 +25,7 @@ import { ConfirmationModal } from "~/components/ui/modal";
 import { useToast } from "~/contexts/ToastContext";
 import { useIsMobile } from "~/hooks/useIsMobile";
 import { useDeleteConfirmation } from "~/hooks/useDeleteConfirmation";
-import { useSWRAuth, mutate } from "~/lib/swr";
+import { useSWRAuth, useTenantMutate } from "~/lib/swr";
 
 export default function RoomsPage() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -50,6 +50,7 @@ export default function RoomsPage() {
   } = useDeleteConfirmation(setShowDetailModal);
 
   const { success: toastSuccess } = useToast();
+  const mutate = useTenantMutate();
 
   const { status } = useSession({
     required: true,

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
@@ -19,7 +19,7 @@ vi.mock("next/navigation", () => ({
 // Mock SWR hooks
 vi.mock("~/lib/swr", () => ({
   useSWRAuth: vi.fn(),
-  mutate: vi.fn(),
+  useTenantMutate: vi.fn(() => vi.fn()),
 }));
 
 // Mock service factory

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -24,7 +24,7 @@ import { createCrudService } from "@/lib/database/service-factory";
 import { studentsConfig } from "@/lib/database/configs/students.config";
 import { useDeleteConfirmation } from "~/hooks/useDeleteConfirmation";
 import type { Student } from "@/lib/api";
-import { useSWRAuth, mutate } from "~/lib/swr";
+import { useSWRAuth, useTenantMutate } from "~/lib/swr";
 
 export default function StudentsPage() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -49,6 +49,7 @@ export default function StudentsPage() {
   } = useDeleteConfirmation(setShowDetailModal);
 
   const { success: toastSuccess, error: toastError } = useToast();
+  const mutate = useTenantMutate();
 
   // Track mounted state to prevent race conditions
   const isMountedRef = useRef(true);

--- a/frontend/src/app/[tenant]/(protected)/database/teachers/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/teachers/page.test.tsx
@@ -19,7 +19,7 @@ vi.mock("next/navigation", () => ({
 // Mock SWR hooks
 vi.mock("~/lib/swr", () => ({
   useSWRAuth: vi.fn(),
-  mutate: vi.fn(),
+  useTenantMutate: vi.fn(() => vi.fn()),
 }));
 
 // Mock service factory

--- a/frontend/src/app/[tenant]/(protected)/database/teachers/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/teachers/page.tsx
@@ -25,7 +25,7 @@ import { teachersConfig } from "@/lib/database/configs/teachers.config";
 import type { Teacher } from "@/lib/teacher-api";
 import { Modal, ConfirmationModal } from "~/components/ui/modal";
 import { useDeleteConfirmation } from "~/hooks/useDeleteConfirmation";
-import { useSWRAuth, mutate } from "~/lib/swr";
+import { useSWRAuth, useTenantMutate } from "~/lib/swr";
 
 // Helper function to get teacher initials without nested ternary
 function getTeacherInitials(
@@ -74,6 +74,7 @@ export default function TeachersPage() {
   const [permissionModalOpen, setPermissionModalOpen] = useState(false);
 
   const { success: toastSuccess } = useToast();
+  const mutate = useTenantMutate();
 
   const { status } = useSession({
     required: true,

--- a/frontend/src/lib/swr/hooks.ts
+++ b/frontend/src/lib/swr/hooks.ts
@@ -16,6 +16,8 @@
 import useSWR, { type SWRConfiguration, type SWRResponse } from "swr";
 import { useSession } from "next-auth/react";
 import { swrConfig, immutableConfig } from "./config";
+import { useSWRConfig } from "swr";
+import { useCallback } from "react";
 import { useTenantSlugSafe } from "~/components/tenant/tenant-provider";
 
 /**
@@ -134,5 +136,28 @@ export function useSWRWithId<T, E = Error>(
       ...swrConfig,
       ...options,
     },
+  );
+}
+
+/**
+ * Returns a tenant-aware mutate function.
+ *
+ * The global `mutate("key")` from SWR won't work with `useSWRAuth` because
+ * cache keys are prefixed with the tenant slug (e.g., `school-a:key`).
+ * This hook returns a mutate function that automatically applies the same prefix.
+ *
+ * @example
+ * ```tsx
+ * const mutate = useTenantMutate();
+ * await mutate("database-rooms-list"); // actually mutates "school-a:database-rooms-list"
+ * ```
+ */
+export function useTenantMutate() {
+  const { mutate } = useSWRConfig();
+  const slug = useTenantSlugSafe();
+
+  return useCallback(
+    (key: string) => mutate(slug ? `${slug}:${key}` : key),
+    [mutate, slug],
   );
 }

--- a/frontend/src/lib/swr/index.ts
+++ b/frontend/src/lib/swr/index.ts
@@ -18,7 +18,12 @@
  */
 
 // Re-export hooks
-export { useSWRAuth, useImmutableSWR, useSWRWithId } from "./hooks";
+export {
+  useSWRAuth,
+  useImmutableSWR,
+  useSWRWithId,
+  useTenantMutate,
+} from "./hooks";
 
 // Re-export config for advanced usage
 export { swrConfig, immutableConfig } from "./config";


### PR DESCRIPTION
…lti-tenant mode

Global mutate() didn't include the tenant slug prefix on cache keys, so cache invalidation after CRUD operations silently failed when using tenant-prefixed SWR keys (e.g., "school-a:database-rooms-list").

# Pull Request

## Description
<!-- Explain the changes you've made and why they're needed -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Configuration change
- [ ] Security improvement
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition/modification
- [ ] CI/CD improvement

## Related Issues
<!-- List any related issues using the following syntax:
- Fixes #123
- Addresses #456
- Related to #789
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Testing documentation updated

## Security Checklist
<!-- This section is mandatory for all PRs -->
- [ ] I have followed the [security guidelines](../docs/security.md)
- [ ] No sensitive information is committed (secrets, credentials, certificates)
- [ ] Environment variables are properly managed with templates
- [ ] Code does not contain hardcoded secrets
- [ ] No potential security vulnerabilities introduced

## Screenshots or Examples
<!-- Add screenshots or code examples if applicable -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have updated the documentation as needed
- [ ] All tests are passing
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and resolved any merge conflicts

## Additional Notes
<!-- Add any other context about the PR here -->