### PR TITLE
fix: stop password reset modal flicker

### DIFF
--- a/frontend/src/components/ui/password-reset-modal.test.tsx
+++ b/frontend/src/components/ui/password-reset-modal.test.tsx
@@ -6,6 +6,8 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { PasswordResetModal } from "./password-reset-modal";
 
+const modalOnCloseHistory: Array<() => void> = [];
+
 // Mock UI components
 vi.mock("./modal", () => ({
   Modal: ({
@@ -16,13 +18,16 @@ vi.mock("./modal", () => ({
     isOpen: boolean;
     children: React.ReactNode;
     onClose: () => void;
-  }) =>
-    isOpen ? (
+  }) => {
+    modalOnCloseHistory.push(onClose);
+
+    return isOpen ? (
       <div data-testid="modal">
         <button onClick={onClose}>Close Modal</button>
         {children}
       </div>
-    ) : null,
+    ) : null;
+  },
 }));
 
 vi.mock("./index", () => ({
@@ -93,6 +98,7 @@ describe("PasswordResetModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorageMock.clear();
+    modalOnCloseHistory.length = 0;
     mockRequestPasswordReset.mockResolvedValue({});
   });
 
@@ -139,6 +145,17 @@ describe("PasswordResetModal", () => {
     fireEvent.change(emailInput, { target: { value: "test@example.com" } });
 
     expect(emailInput).toHaveValue("test@example.com");
+  });
+
+  it("keeps a stable modal close handler while typing", () => {
+    render(<PasswordResetModal isOpen={true} onClose={mockOnClose} />);
+
+    const initialOnClose = modalOnCloseHistory.at(-1);
+    const emailInput = screen.getByTestId("input-reset-email");
+
+    fireEvent.change(emailInput, { target: { value: "y.we" } });
+
+    expect(modalOnCloseHistory.at(-1)).toBe(initialOnClose);
   });
 
   it("displays success state after successful submission", async () => {

--- a/frontend/src/components/ui/password-reset-modal.tsx
+++ b/frontend/src/components/ui/password-reset-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Modal } from "./modal";
 import { Input, Alert } from "./index";
 import { requestPasswordReset, type ApiError } from "~/lib/auth-api";
@@ -116,13 +116,13 @@ export function PasswordResetModal({
     rateLimitUntil !== null && rateLimitUntil > Date.now();
 
   // Reset state when modal closes
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setEmail("");
     setError("");
     setIsSuccess(false);
     setIsLoading(false);
     onClose();
-  };
+  }, [onClose]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Wrapped `handleClose` in `useCallback` to stabilize the function reference passed to `<Modal>`, preventing unnecessary re-renders (flickering) when the user types in the email input
- Added test verifying the modal close handler stays referentially stable across re-renders

## Test plan
- [x] Existing tests pass
- [x] New test `keeps a stable modal close handler while typing` confirms fix
- [ ] Manual: open password reset modal, type in email field — modal should not flicker