### PR TITLE
fix: wrap audit event INSERT in tenant transaction for RLS compliance

### DIFF
--- a/backend/services/auth/token_cleanup.go
+++ b/backend/services/auth/token_cleanup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/audit"
 	"github.com/moto-nrw/project-phoenix/models/auth"
 	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
 )
 
 // Token Management
@@ -88,15 +89,24 @@ func (s *Service) logAuthEvent(ctx context.Context, accountID int64, eventType s
 
 	// Log asynchronously to avoid blocking auth operations
 	go func() {
-		// Create a fresh context with tenant info only (no stale tx from parent)
+		if tenantID == 0 {
+			s.getLogger().Warn("skipping auth event logging: no tenant context",
+				"account_id", accountID,
+				"event_type", eventType,
+			)
+			return
+		}
+
 		logCtx, cancel := context.WithTimeout(
 			tenant.WithTenantID(context.Background(), tenantID),
 			5*time.Second,
 		)
 		defer cancel()
 
-		if err := s.repos.AuthEvent.Create(logCtx, event); err != nil {
-			// Log the error but don't fail the auth operation
+		err := tenant.WithTenantTx(logCtx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+			return s.repos.AuthEvent.Create(ctx, event)
+		})
+		if err != nil {
 			s.getLogger().Error("failed to log auth event", "error", err)
 		}
 	}()


### PR DESCRIPTION
logAuthEvent() runs in a fire-and-forget goroutine with a fresh context.Background(). While tenant.WithTenantID() was set, the PostgreSQL session variables required by RLS policies were missing:
- SET LOCAL ROLE phoenix_tenant
- SELECT set_config('app.current_tenant_id', '...', true)

This caused every login (success or failure) to fail with "permission denied for table auth_events" in multi-tenant deployments.

Fix: wrap the audit INSERT in tenant.WithTenantTx() so the goroutine gets a proper tenant-scoped transaction with RLS variables set. When tenantID == 0 (e.g. failed login with no matching account), skip the write and log a warning instead.

# Pull Request

## Description
<!-- Explain the changes you've made and why they're needed -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Configuration change
- [ ] Security improvement
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition/modification
- [ ] CI/CD improvement

## Related Issues
<!-- List any related issues using the following syntax:
- Fixes #123
- Addresses #456
- Related to #789
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Testing documentation updated

## Security Checklist
<!-- This section is mandatory for all PRs -->
- [ ] I have followed the [security guidelines](../docs/security.md)
- [ ] No sensitive information is committed (secrets, credentials, certificates)
- [ ] Environment variables are properly managed with templates
- [ ] Code does not contain hardcoded secrets
- [ ] No potential security vulnerabilities introduced

## Screenshots or Examples
<!-- Add screenshots or code examples if applicable -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have updated the documentation as needed
- [ ] All tests are passing
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and resolved any merge conflicts

## Additional Notes
<!-- Add any other context about the PR here -->