### PR TITLE
fix: make PHOENIX_AUTH_PASSWORD mandatory, remove superuser fallback

### DIFF
--- a/backend/database/database_config.go
+++ b/backend/database/database_config.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"log"
-	"log/slog"
 	"net/url"
 	"os"
 
@@ -57,9 +56,9 @@ func GetDatabaseDSN() string {
 // Connects as the phoenix_auth role (NOINHERIT, can SET ROLE to phoenix_tenant/phoenix_admin)
 // instead of the postgres superuser. This enforces least-privilege at the connection level.
 //
-// The DSN is auto-constructed by replacing the user/password in the base DSN with
-// phoenix_auth and the PHOENIX_AUTH_PASSWORD environment variable. If the password
-// is not set, falls back to the superuser DSN with a warning.
+// PHOENIX_AUTH_PASSWORD is mandatory. The server will refuse to start without it.
+// Run migration V1.14.1 to create the phoenix_auth role, then set the password
+// in your env file (dev.env for local, .env for Docker).
 func GetServeDSN() string {
 	baseDSN := GetDatabaseDSN()
 
@@ -68,16 +67,13 @@ func GetServeDSN() string {
 		password = viper.GetString("phoenix_auth_password")
 	}
 	if password == "" {
-		slog.Warn("PHOENIX_AUTH_PASSWORD not set — serve command falling back to superuser connection. " +
-			"Set PHOENIX_AUTH_PASSWORD in your env file after running migration V1.14.1.")
-		return baseDSN
+		log.Fatal("PHOENIX_AUTH_PASSWORD is required for serve. " +
+			"Set it in your env file after running migration V1.14.1.")
 	}
 
 	parsed, err := url.Parse(baseDSN)
 	if err != nil {
-		slog.Warn("failed to parse DB_DSN for phoenix_auth substitution, using superuser connection",
-			"error", err)
-		return baseDSN
+		log.Fatalf("failed to parse DB_DSN for phoenix_auth substitution: %v", err)
 	}
 
 	parsed.User = url.UserPassword("phoenix_auth", password)


### PR DESCRIPTION
## Summary

- **Removes all superuser fallbacks from `GetServeDSN()`** — if `PHOENIX_AUTH_PASSWORD` is missing or `DB_DSN` can't be parsed, the server now calls `log.Fatal` instead of silently connecting as postgres superuser
- This prevents the server from running with full DB privileges when the password is misconfigured, which would bypass multi-tenancy RLS entirely

## Why

The fallback was dangerous:
- Wrong password → server silently runs as superuser → RLS policies meaningless
- Missing password → same silent degradation
- Masks real configuration errors behind warning logs nobody reads

Every deployment path already runs `migrate` before `serve` (Docker Compose, staging deploy script, migration test server). If someone skips migrations, the server **should** crash with a clear error, not silently bypass security.

## Context

This supersedes the `GetServeDSN` change in PR #990. That PR adds a *test-connect + fallback* on top of this code, which makes the problem worse. The other fixes in #990 (Dockerfile.prod build arg, docker-compose AUTH_TRUST_HOST, route.ts import fix, test mock) are good and should be merged separately.

## Test plan

- [ ] `docker compose up` with `PHOENIX_AUTH_PASSWORD` set and migration V1.14.1 run → server starts normally as `phoenix_auth`
- [ ] `docker compose up` with `PHOENIX_AUTH_PASSWORD` removed from `.env` → server exits with fatal error message
- [ ] `docker compose up` with wrong `PHOENIX_AUTH_PASSWORD` → server exits on first DB query (via `checkConn` in `DBConnForServe`)