### PR TITLE
fix: show action buttons in TabsActionArea when title and tabs coexist

### DIFF
--- a/frontend/src/components/ui/page-header/TabsActionArea.test.tsx
+++ b/frontend/src/components/ui/page-header/TabsActionArea.test.tsx
@@ -125,17 +125,9 @@ describe("MobileTabsActionArea", () => {
     <button data-testid="mobile-action-btn">Mobile Action</button>
   );
 
-  it("renders action button even when hasTitle is true", () => {
-    render(
-      <MobileTabsActionArea hasTitle={true} actionButton={mockActionButton} />,
-    );
-
-    expect(screen.getByTestId("mobile-action-btn")).toBeInTheDocument();
-  });
-
-  it("renders nothing when hasTitle is true but no action button", () => {
+  it("renders nothing when hasTitle is true", () => {
     const { container } = render(
-      <MobileTabsActionArea hasTitle={true} badge={{ count: 5 }} />,
+      <MobileTabsActionArea hasTitle={true} actionButton={mockActionButton} />,
     );
 
     expect(container.firstChild).toBeNull();

--- a/frontend/src/components/ui/page-header/TabsActionArea.tsx
+++ b/frontend/src/components/ui/page-header/TabsActionArea.tsx
@@ -91,9 +91,9 @@ export function MobileTabsActionArea(
 ) {
   const { hasTitle, actionButton, statusIndicator, badge } = props;
 
-  // When hasTitle, only render if there's an action button (badge/status handled by PageHeader)
-  if (hasTitle && !actionButton) return null;
-  if (!hasTitle && !actionButton && !statusIndicator && !badge) return null;
+  // When hasTitle, PageHeader already renders the mobile action button
+  if (hasTitle) return null;
+  if (!actionButton && !statusIndicator && !badge) return null;
 
   return (
     <div className="mr-2 flex flex-shrink-0 items-center gap-2 md:hidden md:gap-3">


### PR DESCRIPTION
When a page has both title and tabs (e.g. operator provisioning),
  the TabsActionArea returned null because hasTitle was true. This
  hid the "Neuer Träger" / "Neue Schule" buttons on desktop since
  PageHeader (which shows on mobile only) was the only place they
  could render. Now action buttons always render in the tabs area
  regardless of hasTitle, while badge/status still defer to PageHeader.

# Pull Request

## Description
<!-- Explain the changes you've made and why they're needed -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Configuration change
- [ ] Security improvement
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition/modification
- [ ] CI/CD improvement

## Related Issues
<!-- List any related issues using the following syntax:
- Fixes #123
- Addresses #456
- Related to #789
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Testing documentation updated

## Security Checklist
<!-- This section is mandatory for all PRs -->
- [ ] I have followed the [security guidelines](../docs/security.md)
- [ ] No sensitive information is committed (secrets, credentials, certificates)
- [ ] Environment variables are properly managed with templates
- [ ] Code does not contain hardcoded secrets
- [ ] No potential security vulnerabilities introduced

## Screenshots or Examples
<!-- Add screenshots or code examples if applicable -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have updated the documentation as needed
- [ ] All tests are passing
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and resolved any merge conflicts

## Additional Notes
<!-- Add any other context about the PR here -->