### PR TITLE
fix: rename pre-checkin status from "Zuhause" to "Unterricht"

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.test.ts
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.test.ts
@@ -243,6 +243,15 @@ describe("matchesAttendanceFilter", () => {
     expect(matchesAttendanceFilter(presentStudent, "at_home", {})).toBe(false);
   });
 
+  it("filters by in_class (Unterricht) location", () => {
+    const absentStudent = makeStudent({ current_location: "Unterricht" });
+    const presentStudent = makeStudent({
+      current_location: "Anwesend - Raum 1",
+    });
+    expect(matchesAttendanceFilter(absentStudent, "in_class", {})).toBe(true);
+    expect(matchesAttendanceFilter(presentStudent, "in_class", {})).toBe(false);
+  });
+
   it("returns true for unknown filter values (default case)", () => {
     const student = makeStudent();
     expect(matchesAttendanceFilter(student, "unknown_filter", {})).toBe(true);

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.ts
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.ts
@@ -1,10 +1,5 @@
 import type { Student } from "~/lib/api";
-import {
-  isHomeLocation,
-  isSchoolyardLocation,
-  isTransitLocation,
-  parseLocation,
-} from "~/lib/location-helper";
+import { matchesLocationFilter, parseLocation } from "~/lib/location-helper";
 
 // Define OGSGroup type based on EducationalGroup with additional fields
 export interface OGSGroup {
@@ -100,14 +95,8 @@ export function matchesAttendanceFilter(
       return studentRoomStatus?.in_group_room ?? false;
     case "foreign_room":
       return matchesForeignRoomFilter(studentRoomStatus);
-    case "transit":
-      return isTransitLocation(student.current_location);
-    case "schoolyard":
-      return isSchoolyardLocation(student.current_location);
-    case "at_home":
-      return isHomeLocation(student.current_location);
     default:
-      return true;
+      return matchesLocationFilter(student.current_location, attendanceFilter);
   }
 }
 

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -141,7 +141,25 @@ vi.mock("~/lib/location-helper", () => ({
   isHomeLocation: vi.fn(() => false),
   isSchoolyardLocation: vi.fn(() => false),
   isTransitLocation: vi.fn(() => false),
+  isAbsentLocation: vi.fn(() => false),
   parseLocation: vi.fn(() => ({ room: "Room 1", status: "Anwesend" })),
+  matchesLocationFilter: vi.fn(
+    (loc: string | undefined | null, filter: string) => {
+      switch (filter) {
+        case "transit":
+          return loc === "Unterwegs";
+        case "schoolyard":
+          return loc === "Schulhof";
+        case "at_home":
+          return loc === "Zuhause";
+        case "in_class":
+        case "abwesend":
+          return loc === "Unterricht";
+        default:
+          return true;
+      }
+    },
+  ),
 }));
 
 // Mock student-helpers

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -892,6 +892,11 @@ function OGSGroupPageContent() {
             icon: "M21 12a9 9 0 11-18 0 9 9 0 0118 0zM12 12a8 8 0 008 4M7.5 13.5a12 12 0 008.5 6.5M12 12a8 8 0 00-7.464 4.928M12.951 7.353a12 12 0 00-9.88 4.111M12 12a8 8 0 00-.536-8.928M15.549 15.147a12 12 0 001.38-10.611",
           },
           {
+            value: "in_class",
+            label: "Unterricht",
+            icon: "M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253",
+          },
+          {
             value: "at_home",
             label: "Zuhause",
             icon: "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6",
@@ -926,6 +931,7 @@ function OGSGroupPageContent() {
       const locationLabels: Record<string, string> = {
         in_room: "Gruppenraum",
         foreign_room: "Fremder Raum",
+        in_class: "Unterricht",
         transit: "Unterwegs",
         schoolyard: "Schulhof",
         at_home: "Zuhause",

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -132,9 +132,33 @@ vi.mock("~/lib/location-helper", () => ({
     loc !== "Zuhause" &&
     loc !== "" &&
     loc !== "Unterwegs" &&
-    loc !== "Schulhof",
+    loc !== "Schulhof" &&
+    loc !== "Unterricht",
   isTransitLocation: (loc: string) => loc === "Unterwegs",
   isSchoolyardLocation: (loc: string) => loc === "Schulhof",
+  isAbsentLocation: (loc: string) => loc === "Unterricht",
+  matchesLocationFilter: (loc: string | undefined | null, filter: string) => {
+    switch (filter) {
+      case "anwesend":
+        return (
+          loc !== "Zuhause" &&
+          loc !== "" &&
+          loc !== "Unterricht" &&
+          loc !== undefined &&
+          loc !== null
+        );
+      case "abwesend":
+        return loc === "Unterricht";
+      case "unterwegs":
+        return loc === "Unterwegs";
+      case "schulhof":
+        return loc === "Schulhof";
+      case "at_home":
+        return loc === "Zuhause" || loc === "";
+      default:
+        return true;
+    }
+  },
 }));
 
 // Mock student-helpers
@@ -181,7 +205,7 @@ const mockStudents = [
     second_name: "Schmidt",
     school_class: "2b",
     group_name: "Gruppe B",
-    current_location: "Zuhause",
+    current_location: "Unterricht",
   },
   {
     id: "3",
@@ -351,18 +375,18 @@ describe("StudentSearchPage", () => {
         expect(screen.getByText("Max")).toBeInTheDocument();
         expect(screen.getByText("Tom")).toBeInTheDocument();
         expect(screen.getByText("Lisa")).toBeInTheDocument();
-        // Anna (Zuhause) should be filtered out
+        // Anna (Unterricht) should be filtered out
         expect(screen.queryByText("Anna")).not.toBeInTheDocument();
       });
     });
 
-    it("filters to show only home students when 'abwesend' is selected", async () => {
+    it("filters to show only absent (Unterricht) students when 'abwesend' is selected", async () => {
       mockSearchParams.set("status", "abwesend");
 
       render(<StudentSearchPage />);
 
       await waitFor(() => {
-        // Only Anna (Zuhause) should be visible
+        // Only Anna (Unterricht) should be visible
         expect(screen.getByText("Anna")).toBeInTheDocument();
         expect(screen.queryByText("Max")).not.toBeInTheDocument();
         expect(screen.queryByText("Tom")).not.toBeInTheDocument();

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -13,12 +13,7 @@ import type { Student, Group } from "~/lib/api";
 import { useUserContext } from "~/lib/hooks/use-user-context";
 import { Loading } from "~/components/ui/loading";
 import { LocationBadge } from "@/components/ui/location-badge";
-import {
-  isHomeLocation,
-  isPresentLocation,
-  isSchoolyardLocation,
-  isTransitLocation,
-} from "~/lib/location-helper";
+import { matchesLocationFilter } from "~/lib/location-helper";
 import { SCHOOL_YEAR_FILTER_OPTIONS } from "~/lib/student-helpers";
 import {
   StudentCard,
@@ -202,7 +197,7 @@ function SearchPageContent() {
         options: [
           { value: "all", label: "Alle Status" },
           { value: "anwesend", label: "Anwesend" },
-          { value: "abwesend", label: "Zuhause" },
+          { value: "abwesend", label: "Unterricht" },
           { value: "unterwegs", label: "Unterwegs" },
           { value: "schulhof", label: "Schulhof" },
         ],
@@ -244,7 +239,7 @@ function SearchPageContent() {
     if (attendanceFilter !== "all") {
       const statusLabels: Record<string, string> = {
         anwesend: "Anwesend",
-        abwesend: "Zuhause",
+        abwesend: "Unterricht",
         unterwegs: "Unterwegs",
         schulhof: "Schulhof",
       };
@@ -261,38 +256,11 @@ function SearchPageContent() {
   // Apply additional client-side filtering for attendance statuses and year
   const filteredStudents = students.filter((student) => {
     // Apply attendance filter
-    if (attendanceFilter !== "all") {
-      const isOnSite =
-        isPresentLocation(student.current_location) ||
-        isTransitLocation(student.current_location) ||
-        isSchoolyardLocation(student.current_location);
-
-      if (attendanceFilter === "anwesend" && !isOnSite) {
-        return false;
-      }
-
-      if (
-        attendanceFilter === "abwesend" &&
-        !isHomeLocation(student.current_location)
-      ) {
-        return false;
-      }
-
-      // Filter for "Unterwegs" status specifically
-      if (
-        attendanceFilter === "unterwegs" &&
-        !isTransitLocation(student.current_location)
-      ) {
-        return false;
-      }
-
-      // Filter for "Schulhof" status specifically
-      if (
-        attendanceFilter === "schulhof" &&
-        !isSchoolyardLocation(student.current_location)
-      ) {
-        return false;
-      }
+    if (
+      attendanceFilter !== "all" &&
+      !matchesLocationFilter(student.current_location, attendanceFilter)
+    ) {
+      return false;
     }
 
     // Apply year filter - extract year from school_class (e.g., "Klasse 3a" → year 3)

--- a/frontend/src/components/ui/location-badge.tsx
+++ b/frontend/src/components/ui/location-badge.tsx
@@ -12,6 +12,7 @@ import {
   getLocationColor,
   getLocationDisplay,
   getLocationGlowEffect,
+  isAbsentLocation,
   isHomeLocation,
   parseLocation,
 } from "@/lib/location-helper";
@@ -48,8 +49,11 @@ function getSickDisplayMode(
 ): "replace" | "additional" | "none" {
   if (!student.sick) return "none";
 
-  // If at home and sick, replace the badge entirely
-  if (isHomeLocation(student.current_location)) {
+  // If at home or in class (pre-checkin) and sick, replace the badge entirely
+  if (
+    isHomeLocation(student.current_location) ||
+    isAbsentLocation(student.current_location)
+  ) {
     return "replace";
   }
 

--- a/frontend/src/lib/database/configs/students.config.tsx
+++ b/frontend/src/lib/database/configs/students.config.tsx
@@ -207,8 +207,8 @@ export const studentsConfig = defineEntityConfig<Student>({
           showWhen: (student) => isHomeLocation(student.current_location),
         },
         {
-          label: "Nicht angemeldet",
-          color: "bg-gray-400/80",
+          label: "Unterricht",
+          color: "bg-blue-400/80",
           showWhen: (student) =>
             parseLocation(student.current_location).status ===
             LOCATION_STATUSES.ABSENT,

--- a/frontend/src/lib/database/configs/students.config.tsx
+++ b/frontend/src/lib/database/configs/students.config.tsx
@@ -11,6 +11,7 @@ import {
   isPresentLocation,
   isSchoolyardLocation,
   isTransitLocation,
+  parseLocation,
 } from "@/lib/location-helper";
 
 const PrivacyConsentSection = dynamic(
@@ -204,6 +205,13 @@ export const studentsConfig = defineEntityConfig<Student>({
           label: "Zuhause",
           color: "bg-red-400/80",
           showWhen: (student) => isHomeLocation(student.current_location),
+        },
+        {
+          label: "Nicht angemeldet",
+          color: "bg-gray-400/80",
+          showWhen: (student) =>
+            parseLocation(student.current_location).status ===
+            LOCATION_STATUSES.ABSENT,
         },
         {
           label: "Bus",

--- a/frontend/src/lib/location-helper.test.ts
+++ b/frontend/src/lib/location-helper.test.ts
@@ -10,8 +10,10 @@ import {
   canSeeDetailedLocation,
   isPresentLocation,
   isHomeLocation,
+  isAbsentLocation,
   isSchoolyardLocation,
   isTransitLocation,
+  matchesLocationFilter,
   type StudentLocationContext,
 } from "./location-helper";
 
@@ -40,6 +42,7 @@ describe("LOCATION_COLORS", () => {
     expect(LOCATION_COLORS.GROUP_ROOM).toBe("#83CD2D");
     expect(LOCATION_COLORS.OTHER_ROOM).toBe("#5080D8");
     expect(LOCATION_COLORS.HOME).toBe("#FF3130");
+    expect(LOCATION_COLORS.ABSENT).toBe("#3B82F6");
     expect(LOCATION_COLORS.SCHOOLYARD).toBe("#F78C10");
     expect(LOCATION_COLORS.TRANSIT).toBe("#D946EF");
     expect(LOCATION_COLORS.UNKNOWN).toBe("#6B7280");
@@ -261,6 +264,102 @@ describe("location check helpers", () => {
 
     it("returns false for other statuses", () => {
       expect(isTransitLocation("Anwesend")).toBe(false);
+    });
+  });
+
+  describe("isAbsentLocation", () => {
+    it("returns true for Unterricht", () => {
+      expect(isAbsentLocation("Unterricht")).toBe(true);
+    });
+
+    it("returns true for legacy abwesend (maps to Unterricht)", () => {
+      expect(isAbsentLocation("abwesend")).toBe(true);
+    });
+
+    it("returns false for other statuses", () => {
+      expect(isAbsentLocation("Anwesend")).toBe(false);
+      expect(isAbsentLocation("Zuhause")).toBe(false);
+      expect(isAbsentLocation("Unterwegs")).toBe(false);
+    });
+
+    it("returns false for null/undefined", () => {
+      expect(isAbsentLocation(null)).toBe(false);
+      expect(isAbsentLocation(undefined)).toBe(false);
+    });
+  });
+});
+
+// =============================================================================
+// LOCATION FILTER TESTS
+// =============================================================================
+
+describe("matchesLocationFilter", () => {
+  it("returns true for unknown filter values (default case)", () => {
+    expect(matchesLocationFilter("Anwesend", "all")).toBe(true);
+    expect(matchesLocationFilter("Anwesend", "unknown")).toBe(true);
+  });
+
+  describe("anwesend filter", () => {
+    it("matches present, transit, and schoolyard locations", () => {
+      expect(matchesLocationFilter("Anwesend - Raum 1", "anwesend")).toBe(true);
+      expect(matchesLocationFilter("Unterwegs", "anwesend")).toBe(true);
+      expect(matchesLocationFilter("Schulhof", "anwesend")).toBe(true);
+    });
+
+    it("does not match absent or home locations", () => {
+      expect(matchesLocationFilter("Unterricht", "anwesend")).toBe(false);
+      expect(matchesLocationFilter("Zuhause", "anwesend")).toBe(false);
+    });
+  });
+
+  describe("abwesend filter", () => {
+    it("matches absent (Unterricht) locations", () => {
+      expect(matchesLocationFilter("Unterricht", "abwesend")).toBe(true);
+      expect(matchesLocationFilter("abwesend", "abwesend")).toBe(true);
+    });
+
+    it("does not match present or home locations", () => {
+      expect(matchesLocationFilter("Anwesend", "abwesend")).toBe(false);
+      expect(matchesLocationFilter("Zuhause", "abwesend")).toBe(false);
+    });
+  });
+
+  describe("in_class filter", () => {
+    it("matches absent (Unterricht) locations (same as abwesend)", () => {
+      expect(matchesLocationFilter("Unterricht", "in_class")).toBe(true);
+      expect(matchesLocationFilter("abwesend", "in_class")).toBe(true);
+    });
+  });
+
+  describe("transit/unterwegs filter", () => {
+    it("matches transit locations with either key", () => {
+      expect(matchesLocationFilter("Unterwegs", "unterwegs")).toBe(true);
+      expect(matchesLocationFilter("Unterwegs", "transit")).toBe(true);
+    });
+
+    it("does not match other locations", () => {
+      expect(matchesLocationFilter("Anwesend", "unterwegs")).toBe(false);
+    });
+  });
+
+  describe("schoolyard/schulhof filter", () => {
+    it("matches schoolyard locations with either key", () => {
+      expect(matchesLocationFilter("Schulhof", "schulhof")).toBe(true);
+      expect(matchesLocationFilter("Schulhof", "schoolyard")).toBe(true);
+    });
+
+    it("does not match other locations", () => {
+      expect(matchesLocationFilter("Anwesend", "schulhof")).toBe(false);
+    });
+  });
+
+  describe("at_home filter", () => {
+    it("matches home locations", () => {
+      expect(matchesLocationFilter("Zuhause", "at_home")).toBe(true);
+    });
+
+    it("does not match absent (Unterricht) locations", () => {
+      expect(matchesLocationFilter("Unterricht", "at_home")).toBe(false);
     });
   });
 });

--- a/frontend/src/lib/location-helper.test.ts
+++ b/frontend/src/lib/location-helper.test.ts
@@ -79,7 +79,7 @@ describe("parseLocation", () => {
   });
 
   it("normalizes legacy status keywords", () => {
-    expect(parseLocation("abwesend").status).toBe("Nicht angemeldet");
+    expect(parseLocation("abwesend").status).toBe("Unterricht");
     expect(parseLocation("home").status).toBe("Zuhause");
     expect(parseLocation("anwesend").status).toBe("Anwesend");
   });
@@ -232,7 +232,7 @@ describe("location check helpers", () => {
       expect(isHomeLocation("home")).toBe(true);
     });
 
-    it("returns false for abwesend (maps to Nicht angemeldet, not Zuhause)", () => {
+    it("returns false for abwesend (maps to Unterricht, not Zuhause)", () => {
       expect(isHomeLocation("abwesend")).toBe(false);
     });
 

--- a/frontend/src/lib/location-helper.test.ts
+++ b/frontend/src/lib/location-helper.test.ts
@@ -79,7 +79,7 @@ describe("parseLocation", () => {
   });
 
   it("normalizes legacy status keywords", () => {
-    expect(parseLocation("abwesend").status).toBe("Zuhause");
+    expect(parseLocation("abwesend").status).toBe("Nicht angemeldet");
     expect(parseLocation("home").status).toBe("Zuhause");
     expect(parseLocation("anwesend").status).toBe("Anwesend");
   });
@@ -229,8 +229,11 @@ describe("location check helpers", () => {
     });
 
     it("returns true for legacy home status", () => {
-      expect(isHomeLocation("abwesend")).toBe(true);
       expect(isHomeLocation("home")).toBe(true);
+    });
+
+    it("returns false for abwesend (maps to Nicht angemeldet, not Zuhause)", () => {
+      expect(isHomeLocation("abwesend")).toBe(false);
     });
 
     it("returns false for other statuses", () => {

--- a/frontend/src/lib/location-helper.ts
+++ b/frontend/src/lib/location-helper.ts
@@ -27,6 +27,7 @@ export interface StudentLocationContext {
 export const LOCATION_STATUSES = {
   PRESENT: "Anwesend",
   HOME: "Zuhause",
+  ABSENT: "Nicht angemeldet",
   SCHOOLYARD: "Schulhof",
   TRANSIT: "Unterwegs",
   UNKNOWN: "Unbekannt",
@@ -37,6 +38,7 @@ export const LOCATION_COLORS = {
   GROUP_ROOM: "#83CD2D", // Green - student in their group's assigned room
   OTHER_ROOM: "#5080D8", // Blue - student in external/other room
   HOME: "#FF3130",
+  ABSENT: "#9CA3AF", // Gray - not checked in yet
   SCHOOLYARD: "#F78C10",
   TRANSIT: "#D946EF",
   UNKNOWN: "#6B7280",
@@ -47,7 +49,7 @@ const LOCATION_SEPARATOR = "-";
 const UNKNOWN_STATUS = LOCATION_STATUSES.UNKNOWN;
 
 const LEGACY_STATUS_MAP: Record<string, string> = {
-  abwesend: LOCATION_STATUSES.HOME,
+  abwesend: LOCATION_STATUSES.ABSENT,
   zuhause: LOCATION_STATUSES.HOME,
   home: LOCATION_STATUSES.HOME,
   unbekannt: LOCATION_STATUSES.UNKNOWN,
@@ -126,6 +128,7 @@ export function parseLocation(location?: string | null): ParsedLocation {
 // Status-based color lookup for simple cases
 const STATUS_COLOR_MAP: Record<string, string> = {
   [LOCATION_STATUSES.HOME]: LOCATION_COLORS.HOME,
+  [LOCATION_STATUSES.ABSENT]: LOCATION_COLORS.ABSENT,
   [LOCATION_STATUSES.SCHOOLYARD]: LOCATION_COLORS.SCHOOLYARD,
   [LOCATION_STATUSES.TRANSIT]: LOCATION_COLORS.TRANSIT,
 };

--- a/frontend/src/lib/location-helper.ts
+++ b/frontend/src/lib/location-helper.ts
@@ -313,6 +313,44 @@ export function isTransitLocation(location?: string | null): boolean {
   return parseLocation(location).status === LOCATION_STATUSES.TRANSIT;
 }
 
+/**
+ * Indicates whether the student has the "Unterricht" (absent/in class) status.
+ */
+export function isAbsentLocation(location?: string | null): boolean {
+  return parseLocation(location).status === LOCATION_STATUSES.ABSENT;
+}
+
+/**
+ * Matches a student's location against a simple location-based filter.
+ * For OGS-specific room filters (in_room, foreign_room), use matchesAttendanceFilter instead.
+ */
+export function matchesLocationFilter(
+  location: string | undefined | null,
+  filter: string,
+): boolean {
+  switch (filter) {
+    case "anwesend":
+      return (
+        isPresentLocation(location) ||
+        isTransitLocation(location) ||
+        isSchoolyardLocation(location)
+      );
+    case "abwesend":
+    case "in_class":
+      return isAbsentLocation(location);
+    case "unterwegs":
+    case "transit":
+      return isTransitLocation(location);
+    case "schulhof":
+    case "schoolyard":
+      return isSchoolyardLocation(location);
+    case "at_home":
+      return isHomeLocation(location);
+    default:
+      return true;
+  }
+}
+
 interface RgbColor {
   r: number;
   g: number;

--- a/frontend/src/lib/location-helper.ts
+++ b/frontend/src/lib/location-helper.ts
@@ -27,7 +27,7 @@ export interface StudentLocationContext {
 export const LOCATION_STATUSES = {
   PRESENT: "Anwesend",
   HOME: "Zuhause",
-  ABSENT: "Nicht angemeldet",
+  ABSENT: "Unterricht",
   SCHOOLYARD: "Schulhof",
   TRANSIT: "Unterwegs",
   UNKNOWN: "Unbekannt",
@@ -38,7 +38,7 @@ export const LOCATION_COLORS = {
   GROUP_ROOM: "#83CD2D", // Green - student in their group's assigned room
   OTHER_ROOM: "#5080D8", // Blue - student in external/other room
   HOME: "#FF3130",
-  ABSENT: "#9CA3AF", // Gray - not checked in yet
+  ABSENT: "#3B82F6", // Blue - student in class/school
   SCHOOLYARD: "#F78C10",
   TRANSIT: "#D946EF",
   UNKNOWN: "#6B7280",

--- a/frontend/src/lib/student-helpers.test.ts
+++ b/frontend/src/lib/student-helpers.test.ts
@@ -127,8 +127,8 @@ describe("mapStudentResponse", () => {
 
     const result = mapStudentResponse(student);
 
-    // "Abwesend" should be normalized to "Nicht angemeldet"
-    expect(result.current_location).toBe("Nicht angemeldet");
+    // "Abwesend" should be normalized to "Unterricht"
+    expect(result.current_location).toBe("Unterricht");
   });
 
   it("handles null current_location", () => {

--- a/frontend/src/lib/student-helpers.test.ts
+++ b/frontend/src/lib/student-helpers.test.ts
@@ -127,8 +127,8 @@ describe("mapStudentResponse", () => {
 
     const result = mapStudentResponse(student);
 
-    // "Abwesend" should be normalized to "Zuhause"
-    expect(result.current_location).toBe("Zuhause");
+    // "Abwesend" should be normalized to "Nicht angemeldet"
+    expect(result.current_location).toBe("Nicht angemeldet");
   });
 
   it("handles null current_location", () => {


### PR DESCRIPTION
Students without an attendance record (before first daily checkin) were shown as "Zuhause" because the backend returns "Abwesend" which the frontend mapped to "Zuhause". Renamed this to "Unterricht" to better reflect that the student is still in school, not at home.

## Changes

**Core rename** (initial commits)
- Added `ABSENT` status ("Unterricht") to distinguish pre-checkin students from those explicitly sent home
- Updated legacy status mapping: `abwesend` → "Unterricht" instead of "Zuhause"

**Follow-up fixes** (latest commit)
- Added `isAbsentLocation()` helper and `matchesLocationFilter()` to centralize location-based filtering
- Fixed sick student badge: pre-checkin sick students showed "Unterricht + Krank" instead of just "Krank"
- Fixed search page: updated "abwesend" filter label from "Zuhause" to "Unterricht", replaced inline filter logic with shared helper
- Added "Unterricht" filter option to OGS groups page
- Simplified `matchesAttendanceFilter` to delegate location filters to shared helper

## Type of Change
- [x] Bug fix
- [x] Refactoring

## Testing
- [x] Unit tests added/updated
- [x] All 1422 tests passing
- [x] ESLint + TypeScript checks clean
- [x] Knip found no unused exports