### PR TITLE
fix: rollback workflow fails to restart services after DB restore

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -111,61 +111,11 @@ jobs:
           RESTORE_DB: ${{ inputs.restore_db }}
           SSH_HOST: ${{ steps.ssh.outputs.host }}
         run: |
+          scp -i ~/.ssh/deploy_key scripts/rollback-remote.sh root@$SSH_HOST:~/rollback-remote.sh
 
           set +e
           ssh -i ~/.ssh/deploy_key "root@${SSH_HOST}" \
-            "TARGET_SHA=$TARGET_SHA DEPLOY_DIR=$DEPLOY_DIR RESTORE_DB=$RESTORE_DB bash -s" << 'ROLLBACK_SCRIPT'
-            cd ~/$DEPLOY_DIR
-            echo "Starting manual rollback to ${TARGET_SHA}..."
-
-            # ── Database restore (if requested) ──
-            if [ "$RESTORE_DB" = "true" ]; then
-              BACKUP_FILE=$(ls -t ~/backups/$DEPLOY_DIR/backup-*.dump 2>/dev/null | head -1)
-              if [ -z "$BACKUP_FILE" ]; then
-                echo "No backup found in ~/backups/$DEPLOY_DIR/"
-                exit 1
-              fi
-              echo "Restoring DB from: $(basename $BACKUP_FILE)"
-
-              docker compose stop server frontend
-
-              docker compose exec -T postgres psql -U postgres -d template1 -c "DROP DATABASE IF EXISTS postgres WITH (FORCE);" 2>/dev/null || true
-              docker compose exec -T postgres psql -U postgres -d template1 -c "CREATE DATABASE postgres OWNER postgres;"
-              docker compose exec -T postgres pg_restore -U postgres -d postgres --no-owner --no-acl < "$BACKUP_FILE" || true
-
-              # Verify DB is usable after restore
-              if ! docker compose exec -T postgres psql -U postgres -d postgres -c "SELECT 1;" > /dev/null 2>&1; then
-                echo "CRITICAL: Database restore verification failed — DB may be corrupt"
-                exit 1
-              fi
-              echo "Database restored and verified"
-            else
-              docker compose stop server frontend
-            fi
-
-            # ── Override image tags to SHA-pinned versions ──
-            sed -i "s|ghcr.io/moto-nrw/phoenix-server:[^ ]*|ghcr.io/moto-nrw/phoenix-server:${TARGET_SHA}|" docker-compose.yml
-            sed -i "s|ghcr.io/moto-nrw/phoenix-frontend:[^ ]*|ghcr.io/moto-nrw/phoenix-frontend:${TARGET_SHA}|" docker-compose.yml
-
-            # ── Pull and start ──
-            docker compose pull
-            if ! docker compose up -d --wait; then
-              echo "CRITICAL: Rolled-back version also unhealthy!"
-              exit 1
-            fi
-
-            # ── Update deploy state ──
-            PREVIOUS_SHA=""
-            if [ -f .deploy-state ]; then
-              PREVIOUS_SHA=$(grep '^CURRENT_SHA=' .deploy-state | cut -d= -f2)
-            fi
-            echo "CURRENT_SHA=${TARGET_SHA}" > .deploy-state
-            echo "PREVIOUS_SHA=${PREVIOUS_SHA}" >> .deploy-state
-            echo "DEPLOYED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .deploy-state
-            echo "BACKUP_FILE=" >> .deploy-state
-
-            echo "Rollback to ${TARGET_SHA} complete"
-          ROLLBACK_SCRIPT
+            "TARGET_SHA=$TARGET_SHA DEPLOY_DIR=$DEPLOY_DIR RESTORE_DB=$RESTORE_DB bash ~/rollback-remote.sh"
           ROLLBACK_EXIT=$?
           set -e
 

--- a/scripts/rollback-remote.sh
+++ b/scripts/rollback-remote.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# rollback-remote.sh — Runs ON the remote server during manual rollback.
+# SCP'd by CI, same pattern as deploy-remote.sh to avoid heredoc stdin bugs.
+#
+# Required env vars:
+#   DEPLOY_DIR   — Server directory (staging/demo/production)
+#   TARGET_SHA   — Short commit SHA to roll back to
+#   RESTORE_DB   — "true" to restore database from latest backup
+#
+# Exit codes:
+#   0  — Rollback succeeded
+#   1  — Rollback failed
+
+for var in DEPLOY_DIR TARGET_SHA RESTORE_DB; do
+  eval "val=\${$var:-}"
+  if [ -z "$val" ]; then
+    echo "FATAL: $var is not set"
+    exit 1
+  fi
+done
+
+cd ~/"$DEPLOY_DIR"
+echo "Starting manual rollback to ${TARGET_SHA}..."
+
+# ── Database restore (if requested) ──
+if [ "$RESTORE_DB" = "true" ]; then
+  BACKUP_FILE=$(ls -t ~/backups/"$DEPLOY_DIR"/backup-*.dump 2>/dev/null | head -1)
+  if [ -z "$BACKUP_FILE" ]; then
+    echo "No backup found in ~/backups/$DEPLOY_DIR/"
+    exit 1
+  fi
+  echo "Restoring DB from: $(basename "$BACKUP_FILE")"
+
+  docker compose stop server frontend
+
+  docker compose exec -T postgres psql -U postgres -d template1 -c "DROP DATABASE IF EXISTS postgres WITH (FORCE);" 2>/dev/null || true
+  docker compose exec -T postgres psql -U postgres -d template1 -c "CREATE DATABASE postgres OWNER postgres;"
+  docker compose exec -T postgres pg_restore -U postgres -d postgres --no-owner --no-acl < "$BACKUP_FILE" || true
+
+  # Verify DB is usable after restore (pg_restore returns non-zero on harmless warnings)
+  if ! docker compose exec -T postgres psql -U postgres -d postgres -c "SELECT 1;" > /dev/null 2>&1; then
+    echo "CRITICAL: Database restore verification failed — DB may be corrupt"
+    exit 1
+  fi
+  echo "Database restored and verified"
+else
+  docker compose stop server frontend
+fi
+
+# ── Override image tags to SHA-pinned versions ──
+sed -i "s|phoenix-server:[^ ]*|phoenix-server:${TARGET_SHA}|" docker-compose.yml
+sed -i "s|phoenix-frontend:[^ ]*|phoenix-frontend:${TARGET_SHA}|" docker-compose.yml
+
+# ── Pull and start ──
+docker compose pull
+if ! docker compose up -d --wait; then
+  echo "CRITICAL: Rolled-back version also unhealthy!"
+  exit 1
+fi
+
+# ── Update deploy state ──
+PREVIOUS_SHA=""
+if [ -f .deploy-state ]; then
+  PREVIOUS_SHA=$(grep '^CURRENT_SHA=' .deploy-state | cut -d= -f2)
+fi
+echo "CURRENT_SHA=${TARGET_SHA}" > .deploy-state
+echo "PREVIOUS_SHA=${PREVIOUS_SHA}" >> .deploy-state
+echo "DEPLOYED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .deploy-state
+echo "BACKUP_FILE=" >> .deploy-state
+
+echo "Rollback to ${TARGET_SHA} complete"
+exit 0


### PR DESCRIPTION
## Summary

- The manual rollback workflow used an inline heredoc (`ssh bash -s << 'SCRIPT'`). The `docker compose exec -T` commands inside consumed stdin (the heredoc data), causing bash to silently skip all subsequent commands (sed, pull, up)
- Result: DB was restored but **services were never restarted** — staging went down with 502
- Extract rollback logic to `scripts/rollback-remote.sh` (SCP + execute), matching the proven pattern from `deploy-remote.sh`

## Root cause

`bash -s` reads the script from stdin. `docker compose exec -T` passes stdin through to the container process. The exec commands consumed the remaining heredoc bytes, so bash never saw the `sed`, `docker compose pull`, or `docker compose up` commands.

## Test plan

- [ ] Trigger manual rollback on staging: `gh workflow run rollback.yml -f environment=staging -f target_sha=38c2252 -f restore_db=true`
- [ ] Verify services come up after rollback (`docker compose ps` shows server + frontend healthy)
- [ ] Verify `.deploy-state` is updated with correct SHA