### PR TITLE
fix: sync AUTH_JWT_REFRESH_EXPIRY to 168h across all environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,7 @@ SECURITY_LOGGING_ENABLED=false
 # Authentication (use strong random strings in production)
 AUTH_JWT_SECRET=your_jwt_secret_at_least_32_chars_long
 AUTH_JWT_EXPIRY=15m
-AUTH_JWT_REFRESH_EXPIRY=24h
+AUTH_JWT_REFRESH_EXPIRY=168h
 
 # Frontend configuration
 NEXT_PUBLIC_API_URL=http://server:8080

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 | Backend | Go 1.23+, Chi router, BUN ORM |
 | Frontend | Next.js 16+, React 19+, Tailwind 4+ |
 | Database | PostgreSQL 17+ (multi-schema, SSL) |
-| Auth | JWT (15min access, 1hr refresh) |
+| Auth | JWT (15min access, 7 days refresh) |
 
 ## Ecosystem
 
@@ -148,8 +148,11 @@ Deployed environments (staging, demo, production) use **SOPS-encrypted env files
 ### How It Works
 
 ```
-environments/{env}.sops.env  →  CI decrypts with age key  →  SCP to server as .env
-environments/{env}.compose.yml  →  SCP to server as docker-compose.yml
+1. Developer edits:  sops environments/staging.sops.env   (decrypts → $EDITOR → re-encrypts)
+2. Commit + push:    git commit environments/staging.sops.env → push to development
+3. CI decrypts:      sops decrypt staging.sops.env > /tmp/staging.env
+4. CI deploys:       SCP .env + docker-compose.yml + deploy-remote.sh → server
+5. Server runs:      deploy-remote.sh (pull → backup DB → migrate → start → healthcheck)
 ```
 
 ### File Layout
@@ -165,6 +168,38 @@ environments/{env}.compose.yml  →  SCP to server as docker-compose.yml
 | `.sops.yaml` | SOPS config with age public key |
 | `scripts/sops-setup.sh` | One-time setup: generate age key, encrypt files |
 | `scripts/env-check.sh` | CI validation: key sync across all env files |
+| `scripts/deploy-remote.sh` | Runs on server: pull, backup, migrate, rollback |
+
+### Local SOPS Setup
+
+```bash
+# 1. One-time: generate age key and encrypt files
+./scripts/sops-setup.sh
+
+# Key location (macOS):
+#   ~/Library/Application Support/sops/age/keys.txt
+# Key location (Linux):
+#   ~/.config/sops/age/keys.txt
+#
+# Share the private key with team members via 1Password/Signal — NEVER Slack/email.
+# CI uses the same key as GitHub Secret: SOPS_AGE_KEY
+```
+
+### Common SOPS Commands
+
+```bash
+# Edit encrypted file (opens in $EDITOR, re-encrypts on save)
+sops environments/staging.sops.env
+
+# View decrypted values (stdout only, no file change)
+sops decrypt environments/staging.sops.env
+
+# View a single value
+sops decrypt environments/staging.sops.env | grep AUTH_JWT_REFRESH_EXPIRY
+
+# Verify all env files are in sync
+./scripts/env-check.sh
+```
 
 ### Key Rules
 
@@ -189,10 +224,60 @@ environments/{env}.compose.yml  →  SCP to server as docker-compose.yml
 | Demo | Merged PR + `deploy-demo` label | `development` | `demo.sops.env` |
 | Production | Push to `main` | `main` | `production.sops.env` |
 
+### Deploy Flow (CI → Server)
+
+CI (`build.yml`) runs on push/merge:
+1. **Decrypt**: `sops decrypt environments/{env}.sops.env > /tmp/{env}.env`
+2. **SCP to server**: `.env.new`, `docker-compose.yml.new`, `deploy-remote.sh`
+3. **`deploy-remote.sh`** runs on the server:
+   - Saves rollback copies (`.env.rollback`, `docker-compose.yml.rollback`)
+   - Swaps in new config, pins Docker images to commit SHA
+   - `docker compose pull` (fails → restore old config, abort)
+   - Stops `server` + `frontend` (postgres stays up for backup)
+   - `pg_dump` backup to `~/backups/{env}/` (fails → restore, abort)
+   - `docker compose run --rm server ./main migrate` (fails → rollback DB + config)
+   - `docker compose up -d --wait` + healthcheck (fails → rollback)
+   - On success: writes `.deploy-state`, prunes old backups
+
+**Exit codes**: `0` = success, `1` = aborted before migration, `10` = rollback succeeded, `11` = rollback failed (CRITICAL)
+
+### Server Directory Structure
+
+```
+~/staging/          ← staging deployment
+  .env              ← decrypted from staging.sops.env (by CI)
+  docker-compose.yml ← from staging.compose.yml (images pinned to SHA)
+  .deploy-state     ← CURRENT_SHA, PREVIOUS_SHA, DEPLOYED_AT, BACKUP_FILE
+~/demo/             ← demo deployment (same structure)
+~/production/       ← production deployment (same structure)
+~/backups/{env}/    ← pg_dump backups (retention: 3 staging, 7 production)
+```
+
+### GitHub Secrets Required
+
+| Secret | Purpose |
+|--------|---------|
+| `SOPS_AGE_KEY` | Age private key for decrypting `.sops.env` files |
+| `STAGING_SSH_KEY` | SSH deploy key for staging server |
+| `STAGING_SSH_HOST` | Staging server hostname/IP |
+| `STAGING_SSH_KNOWN_HOSTS` | SSH host verification |
+| `DEMO_SSH_KEY` / `DEMO_SSH_HOST` / `DEMO_SSH_KNOWN_HOSTS` | Same for demo |
+| `PRODUCTION_SSH_KEY` / `PRODUCTION_SSH_HOST` / `PRODUCTION_SSH_KNOWN_HOSTS` | Same for production |
+| `DEPLOY_NOTIFY_*` | Email notification recipients for deploy failures |
+
 ### CI Guards
 
 - **`env-sync-check`** job runs on every PR — blocks merge if keys are out of sync or plaintext values detected
 - **Lefthook pre-commit** — runs env key sync + unencrypted secrets guard on staged `.sops.env` changes
+
+### Whitelisted Key Exceptions
+
+| Key | Scope | Reason |
+|-----|-------|--------|
+| `COMPOSE_BAKE`, `COMPOSE_DOCKER_CLI_BUILD`, `DOCKER_BUILDKIT` | dev-only | Docker build optimization, not needed on server |
+| `DB_DEBUG`, `TEST_DB_DSN`, `TEST_DB_PORT` | dev-only | Local testing only |
+| `AUTH_TRUST_HOST`, `TENANT_DOMAIN`, `NEXT_PUBLIC_TENANT_DOMAIN` | deploy-only | Multi-tenancy, not needed for local dev |
+| `PHOENIX_AUTH_PASSWORD` | deploy-only | Server DB role password |
 
 ## Git Conventions
 

--- a/backend/dev.env.example
+++ b/backend/dev.env.example
@@ -35,7 +35,7 @@ AUTH_LOGIN_URL=http://localhost:8080/login
 AUTH_LOGIN_TOKEN_LENGTH=8
 AUTH_LOGIN_TOKEN_EXPIRY=11m
 AUTH_JWT_SECRET=your_jwt_secret_at_least_32_chars_long
-AUTH_JWT_EXPIRY=1h
+AUTH_JWT_EXPIRY=15m
 AUTH_JWT_REFRESH_EXPIRY=168h
 
 # Test JWT secret (used by automated tests)

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -21,7 +21,7 @@ services:
       DB_DSN: ${DB_DSN:-postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres?sslmode=require}
       DB_DEBUG: ${DB_DEBUG:-"true"}
       AUTH_JWT_SECRET: ${AUTH_JWT_SECRET}
-      AUTH_JWT_EXPIRY: ${AUTH_JWT_EXPIRY:-1h}
+      AUTH_JWT_EXPIRY: ${AUTH_JWT_EXPIRY:-15m}
       AUTH_JWT_REFRESH_EXPIRY: ${AUTH_JWT_REFRESH_EXPIRY:-168h}
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
@@ -69,6 +69,7 @@ services:
       - "3000:3000"
     environment:
       TZ: ${TZ:-Europe/Berlin}
+      AUTH_JWT_EXPIRY: ${AUTH_JWT_EXPIRY:-15m}
       AUTH_JWT_REFRESH_EXPIRY: ${AUTH_JWT_REFRESH_EXPIRY:-168h}
       # Server-side API URL (internal Docker network, never leaves container network)
       API_URL: "http://server:8080"

--- a/environments/production.sops.env
+++ b/environments/production.sops.env
@@ -25,7 +25,7 @@ RATE_LIMIT_AUTH_REQUESTS_PER_MINUTE=ENC[AES256_GCM,data:mA==,iv:m05AFyd1P9MRN47s
 SECURITY_LOGGING_ENABLED=ENC[AES256_GCM,data:6M8tZg==,iv:r5lhmdrPDuJz7pHJAKoI2yMth6EakKvCW65OwAdqYNU=,tag:+Eg6A83iTnpr7dJCHFwrew==,type:str]
 #ENC[AES256_GCM,data:rf4fiFWsUpL8pIwn8/ao,iv:QxPeK0Ce/jF0N9QuyLnVP+hYv0LSRMoXgIunfxiQkFE=,tag:ND7SAi5uF4orlcAh3nOa8w==,type:comment]
 AUTH_JWT_SECRET=ENC[AES256_GCM,data:Fp09vzvglDLMDdmVdnM4+rCJmb1z1kP8kZnqeGGqy9YfxTcjqmW1eAzZIpg=,iv:kLDplN1T/GSDy6XeihIqgrQsj6YiU/FhBpV4YVjmpjA=,tag:zVftWOw9doLWbDBP4i9u6w==,type:str]
-AUTH_JWT_EXPIRY=ENC[AES256_GCM,data:A9mJ,iv:IRL2X6UbgHgoVyv7Am7nDfwD3n5kl7aN9sbUvsiyiBM=,tag:75FFNrsbFz/Peisnfr+W0g==,type:str]
+AUTH_JWT_EXPIRY=ENC[AES256_GCM,data:KzZv,iv:YWPvTVbFAyN+DQW3M+KZmrsQj4B8oieJP8AjebRtx1E=,tag:vPY+Iz4MDjcEwyDpFA6G3Q==,type:str]
 AUTH_JWT_REFRESH_EXPIRY=ENC[AES256_GCM,data:b+NZ4w==,iv:YQ051Yp7TUpgK7NqV+Y/QX8Nkh6egNzekgiN9GXc/lM=,tag:2NOU/Rhwbe6G96efRP8lPA==,type:str]
 #ENC[AES256_GCM,data:qJdzvvvtRUsS,iv:79mhgvMgX8ySZKdOsLnZ12T68z7DHhyQLfBsgPgbtlM=,tag:1fBBtipis0o8z8QwsJbVtQ==,type:comment]
 NEXT_PUBLIC_API_URL=ENC[AES256_GCM,data:ggT05/ZKUKjQByZpuYdGbFwpUWAhWP0=,iv:qCWA4gnKLvFJm7mJ9Vujrb2MhvmUoEf3sVMeX1owuc8=,tag:w3aSBXFKlHaRHvE89IUMrw==,type:str]
@@ -79,7 +79,7 @@ SESSION_ABANDONED_THRESHOLD_MINUTES=ENC[AES256_GCM,data:+D0=,iv:EXIdiBgod3nCT7gP
 OGS_DEVICE_PIN=ENC[AES256_GCM,data:pMQp9A==,iv:7xo7dwANQaZlwlI/NAhmYSqN4YhR+0h4LeklD7K670E=,tag:7vJw7DOzGJjOhZVbZyzfNg==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxQUZjSyswaXcybHRRdUVX\nQy9EUU40dmQ1Yy9jL2ZROUpWYUFxTWhNU3lnCk03cnhOa2lWYXllaUIrNU0wMUpO\ndnUwZUpJRjJPYWZLNUFFQWhJMGFsQVkKLS0tIFZEbjUzdTR0QzI5RnVJdFluNzgv\nMkdvQkhZRkVTK1VTQklqVzJUQ21FOHcK5g3vUuwLDfVr8WJEO+o8EPG6nL/PuZ8A\nMMmBAJWCOjklX5rg+G1+D3GsaBa8CSFgClQ2HCef1F4RM/YUJRMELA==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1r5cffurwgs70ntsg3q7njv40xdfk8ejlfz8vud9fg8wej370sqxqxj5esd
-sops_lastmodified=2026-03-20T21:52:52Z
-sops_mac=ENC[AES256_GCM,data:yH3Br+fmpCNV63lIGT+tCOCokQhIjv6/GX3OTUhWWO8wgzvSlv/vBeln8zDzLg5kHSQFqg29EGPXlkYkjt9AKU+3Pwk/WNnqwdUAVrmOUXhZ39NE78Xae5V1ZP+0tmmTyOqsOzAzFP0A1eJZ02R6m1ORZQNSWMufEBFITBNjgUU=,iv:dcrSbUU7EZmpOtBTOosz3iiQD1K9XVkxXbEwOEfeE00=,tag:qAZIZ0HWPXTqLtwsJxM3+w==,type:str]
+sops_lastmodified=2026-03-21T16:41:09Z
+sops_mac=ENC[AES256_GCM,data:jwE+ahU3HlaDrM87pFgYOK/5yTnMmlSgouAnYgNbv2gKauQgNQUvI/2b4SbjwsrW7ZeP4Bw0L0xVawjQe/gDv97pR2vXdV/FHaNpG5eQvLFwv2XDxHxCWe8qp3sNgzAJ5z4N/w5TEFyyE+fC28ly+9B4dTN/msjAcSFQHUd8fUQ=,iv:ivVOVogcStRdb0mHIvIToWpm4zoMh+BYwGQrIyiXRkA=,tag:HHHIPNqLJZRcFIMu1mluUQ==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.2

--- a/environments/staging.sops.env
+++ b/environments/staging.sops.env
@@ -26,7 +26,7 @@ SECURITY_LOGGING_ENABLED=ENC[AES256_GCM,data:1JVOOg==,iv:zjAGw9cgVJkucD+ZP4Bkln9
 #ENC[AES256_GCM,data:sIe4f/00eaMgFoE5Lybe,iv:l4QTzgoqWnBCB8kAKfHNDoT0DTvMl5wPpvtOPJhNBbg=,tag:0V2sSIML6h8xm4DfuuQC9w==,type:comment]
 AUTH_JWT_SECRET=ENC[AES256_GCM,data:LCXLec9v51UEhJADaAL44cFJXjBbuEShsu0T2C3GEtmaPThYlv5t+ts0EW0=,iv:eX/FnYTDylpjjTvSKzeAsA4l2UDQJxBrEVq1MWiQXg0=,tag:TUaTau+cTZn1h9b1RlzyCw==,type:str]
 AUTH_JWT_EXPIRY=ENC[AES256_GCM,data:2MRN,iv:aDxXrBSUBUewoRh61hyzaAz0/j33mQimBS2EpYdZMxA=,tag:XIRc1Cw9ADD/zibEPYa3gw==,type:str]
-AUTH_JWT_REFRESH_EXPIRY=ENC[AES256_GCM,data:e2I=,iv:Uh7K1qeh+cgj7oSH659G2+udLLeDK2A2XfYTxowXils=,tag:dkxgz2Qrs2Jy0zHS5GsYQw==,type:str]
+AUTH_JWT_REFRESH_EXPIRY=ENC[AES256_GCM,data:maSvVw==,iv:tWrBNcUIqLb8jNalOWnAgbJT6wboRwHvLRdyAZvst9Y=,tag:h5I8LZDvbuYnCtbrw8Zn3g==,type:str]
 #ENC[AES256_GCM,data:RhgYifN8HpSU,iv:abTumxuRkCbXFqenY1mxUyGWEx/2mMVlje78PYj5YWs=,tag:wM3z1ySQOJk1I2qsP0nVNQ==,type:comment]
 NEXT_PUBLIC_API_URL=ENC[AES256_GCM,data:DouFOYq2ZgN1bmLv0fREy0hXf4vbLN9lQBuVEYqUvw==,iv:jB2QdqNHzSmAa1aaCu3hcu7gmDi3CwUwkQp9Px8QhBA=,tag:9pqT+ieCrYcA1CpOOrR1/A==,type:str]
 NEXTAUTH_URL=ENC[AES256_GCM,data:DS5UJmCF+jj9UYd7ma3LwiiSZOVwhQzCeyPl,iv:MGV/m3S4YKxvLQzWUWWOMOdARNP/8syFpjLVeFdznjY=,tag:lXyGvpkRPazO4Fw9/AcIyA==,type:str]
@@ -79,7 +79,7 @@ SESSION_ABANDONED_THRESHOLD_MINUTES=ENC[AES256_GCM,data:3nE=,iv:VUyF6DrQYrzfTuVv
 OGS_DEVICE_PIN=ENC[AES256_GCM,data:RPb6oQ==,iv:iOQhIhA6nObe1/OMeVpvRPwN1zm8T7Zs3PeHL/g/Tt4=,tag:nrBeMs6xJqoxvJqdPBpU+A==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtbW82U21lQWw4elI4amJJ\nS0NzdUsvYVk2TlFCL2VzSFpjemlocG9qS3pZClpxK0JJVDRCTTJJcDZyOGZETjg3\nazU2d2V1QjV2TjlYcVBYbExYRWtVUmMKLS0tIDZxejQ1Wnk0cFVqZXN1L0wxZEgw\ncU0yU0ZrS1FiMjdJZWp2VUtyM09PaTgKX56Cd+Oooj+lUQgR/kXphYlwy5jvsoV7\nxUT8lV4R4P9PfJvjpp1Dxfo+3XtXKy5f8yrNJHx28sj3VAOTQ9A28Q==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1r5cffurwgs70ntsg3q7njv40xdfk8ejlfz8vud9fg8wej370sqxqxj5esd
-sops_lastmodified=2026-03-20T21:52:51Z
-sops_mac=ENC[AES256_GCM,data:onFU+yEH/NTs2IliqyJ9LK3gOT8A87hQnIOFFLqQDhHPnfu+Y2DnJgfCBU27jpOrwAxfBBMdzpK24MPdvdyIUduwEQdl2fhwHFPmDbGSWqpBy/HWVXtgBfSG8D65NZwiGl0f5PQj1T5hP4jCraJHn2xrgM1IFa0q/il2s3sSG78=,iv:y7F890+9iJ8J7Vs2losbl2EzA/zTybDVny0aC932rYs=,tag:9N739Ge5NkVQPcZoXZRnhg==,type:str]
+sops_lastmodified=2026-03-21T16:37:45Z
+sops_mac=ENC[AES256_GCM,data:NyGm6Yoz3TdTlmyeKO6i2BqPSRxOQNJKpI6ZME19d7k1UBqQP7EWEuSTvGqXA37aRzt4kZtCj9Kgh9mZvB7fuD5TG82kDWJgb3CmmeCMabLjJuHZlnhjRqLZXsNcc5nYTMYsyFNBJoJLg2LPNmU/hfceFj5wUzU41KVjt//Z/Rw=,iv:2phY4CnQpWY63s3+wEB/wDEXlJvNeL1a8M5JdLd2c/Y=,tag:J8nVJzFyBAErrNOf67ZOJg==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.2

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,7 +6,7 @@
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET="your_nextauth_secret" # In production, generate with: openssl rand -base64 32
 AUTH_SECRET="your_auth_secret_key" # Legacy - use NEXTAUTH_SECRET instead
-AUTH_JWT_EXPIRY=1h
+AUTH_JWT_EXPIRY=15m
 AUTH_JWT_REFRESH_EXPIRY=168h
 
 # API Configuration


### PR DESCRIPTION
## Summary

- **Root cause**: Staging had `AUTH_JWT_REFRESH_EXPIRY=1h`, causing users to be logged out after ~55 minutes of inactivity. The NextAuth session cookie and refresh token both expired after 1 hour, so any break longer than that forced a re-login.
- **Missing config**: `AUTH_JWT_EXPIRY` was not passed to the frontend Docker container, causing it to fall back to `env.js` default of `1h` instead of the backend's `15m`.
- **Docs**: Added comprehensive SOPS workflow documentation to CLAUDE.md (setup, commands, deploy flow, server structure, GitHub secrets).

### Changes

| File | Change |
|------|--------|
| `environments/staging.sops.env` | `AUTH_JWT_REFRESH_EXPIRY`: `1h` → `168h` |
| `environments/production.sops.env` | `AUTH_JWT_EXPIRY`: verified `15m` |
| `.env.example` | `AUTH_JWT_REFRESH_EXPIRY`: `24h` → `168h` |
| `docker-compose.example.yml` | Add `AUTH_JWT_EXPIRY` to frontend block, fix server fallback `1h` → `15m` |
| `frontend/.env.example` | `AUTH_JWT_EXPIRY`: `1h` → `15m` |
| `backend/dev.env.example` | `AUTH_JWT_EXPIRY`: `1h` → `15m` |
| `CLAUDE.md` | Document SOPS workflow, fix auth description |

## Test plan

- [ ] Deploy to staging, verify `docker compose exec frontend env | grep AUTH_JWT` shows `15m` / `168h`
- [ ] Login on staging, wait >1 hour, confirm session persists
- [ ] Verify `./scripts/env-check.sh` passes (already confirmed by pre-commit hook)