### PR TITLE
fix: operator manifest syntax error

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -81,6 +81,8 @@ function handleOperatorSubdomain(request: NextRequest): NextResponse {
     pathname.startsWith("/api/") ||
     pathname.startsWith("/_next") ||
     pathname === "/favicon.ico" ||
+    pathname === "/site.webmanifest" ||
+    pathname.startsWith("/icons/") ||
     pathname.startsWith("/images")
   ) {
     return withSecurityHeaders(NextResponse.next());


### PR DESCRIPTION
## Summary
- Operator subdomain middleware was redirecting `/site.webmanifest` and `/icons/*` to `/`, causing the browser to receive HTML instead of JSON
- This triggered "manifest line 1 col 1 syntax error" in the browser console
- Added both paths to the static asset passthrough list in `handleOperatorSubdomain`

## Test plan
- [ ] Open operator dashboard, verify no manifest error in browser console
- [ ] Verify PWA manifest loads correctly on operator subdomain
- [ ] Verify icon files (`/icons/icon-192x192.png`, `/icons/icon-512x512.png`) load on operator subdomain