### PR TITLE
docs: document multi-tenancy architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,51 @@ Project Phoenix is part of a three-repo system. All repos live side-by-side (`..
 
 **If you change IoT endpoints, error messages, or auth headers**: PyrePortal will break silently. Error messages are hardcoded in `PyrePortal/src/services/api.ts` and mapped to German UI text. Coordinate changes across repos.
 
+## Multi-Tenancy
+
+### Tenant Hierarchy
+
+```
+Platform Operator (moto)
+ └── Organization (Träger)           → platform.organizations
+      └── School (OGS) = tenant      → platform.schools (school.id = tenant_id)
+```
+
+**School ID is the tenant boundary.** All 58+ tenant-scoped tables have a `tenant_id` FK to `platform.schools`. Account-to-school mappings live in `auth.account_tenants` (with lifecycle: pending → active → inactive).
+
+### Scoping Mechanisms
+
+| Layer | How |
+|-------|-----|
+| **JWT** | Claims include `tenant_id`, `org_id`, `scope` ("" = tenant, "org" = organization, "platform" = operator) |
+| **Context** | `tenant.WithTenantID(ctx, id)` / `tenant.FromContext(ctx)` propagate tenant through request lifecycle |
+| **Database** | `TenantTxMiddleware` sets PostgreSQL `LOCAL ROLE` + RLS config per request; auto-rollback on 5xx |
+| **Models** | `base.TenantModel` (embeds `TenantID int64`) + `TenantScoped` interface on all tenant-aware entities |
+| **Repositories** | `base.GetDB(ctx, db)` picks up tenant transaction; `base.EnsureTenantID(ctx, entity)` auto-populates tenant_id |
+
+### Frontend Routing
+
+- **Subdomain mode**: `{slug}.localhost:3000` → middleware rewrites to `/[tenant]/*` internally
+- **Operator isolation**: `operator.localhost:3000` → rewrites to `/operator/*`, separate session
+- **Tenant resolution**: `[tenant]/layout.tsx` validates slug via `/auth/tenant/resolve?slug=...` (cached 5min)
+- **Tenant switching**: `POST /auth/switch-tenant` returns new JWT scoped to target school
+
+### Key Env Vars
+
+| Var | Purpose |
+|-----|---------|
+| `TENANT_DOMAIN` | Base domain for subdomain extraction (e.g., `localhost`, `moto-app.de`) |
+| `NEXT_PUBLIC_TENANT_DOMAIN` | Client-side tenant domain |
+| `NEXT_PUBLIC_OPERATOR_HOSTNAME` | Operator subdomain (e.g., `operator.localhost:3000`) |
+
+### Reserved Slugs
+
+Both backend (`models/platform/organization.go`) and frontend (`lib/reserved-slugs.ts`) maintain matching lists of reserved slugs (www, api, operator, grafana, etc.) that cannot be used as tenant subdomains. **These must stay in sync.**
+
+### Cross-Repo Impact
+
+Changing tenant resolution, auth headers, or error messages affects PyrePortal's device auth flow. The IoT API (`/api/iot/*`) uses device API keys (not tenant JWTs), but devices are scoped to schools.
+
 ## Core Architecture
 
 **Handler → Service → Repository → Database** (always, no exceptions)
@@ -287,7 +332,7 @@ CI (`build.yml`) runs on push/merge:
 
 ## Database Schemas
 
-`auth` · `users` · `education` · `facilities` · `activities` · `active` · `schedule` · `iot` · `feedback` · `config` · `meta` · `audit`
+`platform` · `auth` · `users` · `education` · `facilities` · `activities` · `active` · `schedule` · `iot` · `feedback` · `config` · `suggestions` · `meta` · `audit`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ Project Phoenix is a comprehensive room and student management system designed f
 
 ---
 
+## 🏢 Multi-Tenancy
+
+Project Phoenix supports multiple after-school care providers (Träger) and their schools (OGS) on a single deployment. Data is fully isolated at the database level via Row-Level Security.
+
+### Tenant Hierarchy
+
+```
+Platform Operator (moto)
+ └── Träger (Organization)          e.g. "AWO Köln"
+      ├── OGS Sonnenschule (School)  → sonnenschule.moto-app.de
+      ├── OGS Waldschule (School)    → waldschule.moto-app.de
+      └── ...
+```
+
+| Concept | Model | Role |
+|---------|-------|------|
+| **Organization** (Träger) | `platform.organizations` | Groups schools under one administrative body |
+| **School** (OGS) | `platform.schools` | The tenant boundary — all data is scoped to `tenant_id` (= school ID) |
+| **Operator** | Platform scope | moto team — provisions organizations and schools |
+
+### How It Works
+
+- **Subdomain routing**: Each school gets a subdomain (`{slug}.moto-app.de`). Middleware extracts the slug and resolves the tenant.
+- **JWT scoping**: Login returns tokens with `tenant_id`, `org_id`, and `scope` (tenant / org / platform).
+- **Database isolation**: 58+ tables carry a `tenant_id` FK. PostgreSQL Row-Level Security enforces isolation at the DB level.
+- **Tenant switching**: Staff with access to multiple schools can switch via `/auth/switch-tenant` without re-authenticating.
+- **Operator dashboard**: Runs on a separate subdomain (`operator.moto-app.de`) with session isolation from tenant dashboards.
+
+---
+
 ## 🚀 Quick Start
 
 ### Prerequisites
@@ -229,7 +259,8 @@ The database uses PostgreSQL schemas to organize tables by domain:
 
 | Schema | Purpose |
 |--------|---------|
-| `auth` | Authentication, tokens, permissions |
+| `platform` | Organizations, schools (tenant definitions) |
+| `auth` | Authentication, tokens, permissions, account-tenant mappings |
 | `users` | User profiles, students, teachers, staff |
 | `education` | Groups and educational structures |
 | `facilities` | Rooms and physical locations |
@@ -306,6 +337,7 @@ This project handles sensitive student data and implements comprehensive securit
 - [x] GDPR compliance features (data retention, audit logging)
 - [x] Email invitation workflow
 - [x] Password reset with rate limiting
+- [x] Multi-tenancy (Träger → OGS isolation)
 - [ ] Mobile companion app
 - [ ] Real-time push notifications
 - [ ] Advanced analytics and reporting

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -82,6 +82,46 @@ import { getServerApiUrl } from "~/lib/server-api-url";
 
 Both `api-helpers.ts` and `operator/route-wrapper.ts` use this pattern. The same applies to any server-only import (`auth`, `refreshSessionTokensOnServer`, etc.).
 
+## Multi-Tenancy & Routing
+
+### Subdomain-Based Tenant Resolution
+
+Middleware (`src/middleware.ts`) handles all tenant routing:
+
+1. **Operator requests** (`NEXT_PUBLIC_OPERATOR_HOSTNAME`): rewritten to `/operator/*` internally
+2. **Tenant requests** (`{slug}.TENANT_DOMAIN`): rewritten to `/[tenant]/*` for the dynamic segment
+3. **Reserved slugs** (`src/lib/reserved-slugs.ts`): blocked from tenant resolution (www, api, operator, etc.)
+
+### App Directory Structure
+
+```
+src/app/
+├── operator/              # Operator dashboard (separate subdomain)
+│   ├── login/
+│   ├── provisioning/      # Create/manage organizations + schools
+│   └── suggestions/
+├── [tenant]/              # Dynamic tenant segment (resolved by middleware)
+│   ├── layout.tsx         # Validates slug via /auth/tenant/resolve, wraps in TenantProvider
+│   ├── (protected)/       # Auth-required routes (dashboard, students, rooms, etc.)
+│   └── (public)/          # Pre-auth routes (invite, reset-password)
+└── api/
+    ├── auth/tenant/       # Tenant resolution + listing endpoints
+    └── auth/switch-tenant/# Switch JWT scope to different school
+```
+
+### Tenant Context & Navigation
+
+- **`TenantProvider`** (`components/tenant/tenant-provider.tsx`): React context holding `tenantSlug` + resolved `tenant` metadata
+- **`useTenant()`**: Throws outside provider — use in tenant-scoped pages
+- **`useTenantSlugSafe()`**: Returns `null` outside provider — use for SWR cache key prefixing
+- **`useTenantRouter()`** (`lib/tenant-router.ts`): Auto-detects subdomain vs path mode for navigation. In subdomain mode pushes bare paths; in path mode prefixes with slug.
+- **`TenantGuard`** (`components/tenant/tenant-guard.tsx`): Detects session/URL tenant mismatch (e.g., multi-tab) and auto-switches the session to match the current URL tenant.
+
+### Tenant API Helpers
+
+- **`lib/tenant-api.ts`**: `resolveTenant(slug)`, `listTenants()`, `switchTenant(slug)`
+- **Error contract**: Backend returns `"account does not have access to this tenant"` — hardcoded mapping in `tenant-api.ts`. Changing this backend string breaks tenant switching silently.
+
 ## Code Architecture
 
 ### High-Level Architecture
@@ -169,12 +209,13 @@ export const env = createEnv({
 
 ### Authentication Flow
 
-1. User logs in via `/app/api/auth/login` route
-2. Backend returns JWT access token (15min) and refresh token (1hr)
+1. User navigates to `{slug}.TENANT_DOMAIN` and logs in via `/app/api/auth/login`
+2. Backend returns JWT with `tenant_id`, `org_id`, `scope` + access token (15min) and refresh token (7d)
 3. NextAuth stores tokens in session
 4. Route handlers extract token from session for API calls
 5. API clients include token in Authorization header
 6. Refresh token used automatically when access token expires
+7. Tenant switching: `POST /auth/switch-tenant` returns new JWT scoped to a different school
 
 ### Error Handling
 
@@ -507,6 +548,7 @@ The frontend proxies all API calls through Next.js route handlers to the Go back
 - Int64 IDs from backend stored as strings in frontend
 
 **Major API domains:**
+- `/api/auth/tenant/*` - Tenant resolution, listing, switching
 - `/api/auth/*` - Login, logout, refresh tokens
 - `/api/students/*` - Student CRUD and enrollment
 - `/api/rooms/*` - Room management and occupancy


### PR DESCRIPTION
## Summary
- Added multi-tenancy documentation to **CLAUDE.md** (tenant hierarchy, scoping mechanisms, frontend routing, env vars, reserved slugs)
- Added multi-tenancy section to **README.md** (Träger → OGS hierarchy, how it works, updated DB schemas table + roadmap)
- Added tenant routing & context docs to **frontend/CLAUDE.md** (subdomain resolution, app structure, TenantProvider/Guard, tenant API helpers)
- Added missing `platform` and `suggestions` schemas to DB schema lists

## Test plan
- [ ] Verify docs render correctly on GitHub
- [ ] Cross-check reserved slugs list matches code