### PR TITLE
fix: handle nil school in resolveTenant to prevent panic

### DIFF
--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -217,7 +217,7 @@ func (rs *Resource) resolveTenant(w http.ResponseWriter, r *http.Request) {
 	}
 
 	school, err := rs.SchoolRepo.FindBySubdomain(r.Context(), slug)
-	if err != nil {
+	if err != nil || school == nil {
 		common.RenderError(w, r, ErrorNotFound(errors.New("tenant not found")))
 		return
 	}


### PR DESCRIPTION
## Summary

- `FindBySubdomain` returns `(nil, nil)` when no rows match (e.g. `slug=robots.txt`)
- The handler only checked `err != nil` before dereferencing `school.Active` on line 225
- This caused a nil pointer panic, recovered by middleware as a 500
- Fix: add `|| school == nil` to the existing error check, returning a clean 404

Observed in staging logs — bots/crawlers hitting `/auth/tenant/resolve?slug=robots.txt`.

## Test plan

- [x] `go build ./...` passes
- [ ] Verify invalid slugs return 404 instead of 500