### PR TITLE
fix: prevent operator redirect loop for non-platform sessions

### DIFF
--- a/frontend/src/app/operator/layout.tsx
+++ b/frontend/src/app/operator/layout.tsx
@@ -27,14 +27,15 @@ export default function OperatorLayout({
   const isLoginPage = pathname === "/operator/login" || pathname === "/login";
   const { data: session, status } = useSession();
 
-  // Redirect non-operator authenticated users away
+  // Redirect non-operator authenticated users to operator login
+  // (pushing to "/" causes a loop on the operator subdomain since middleware rewrites "/" → /operator)
   useEffect(() => {
     if (
       !isLoginPage &&
       status === "authenticated" &&
       session?.user?.scope !== "platform"
     ) {
-      router.push("/");
+      router.push(operatorPath("/operator/login"));
     }
   }, [isLoginPage, status, session, router]);
 


### PR DESCRIPTION
## Summary

- When a user with a tenant token visits `operator.localhost`, the layout detected `scope !== "platform"` and redirected to `/`
- On the operator subdomain, middleware rewrites `/` → `/operator` → `/operator/suggestions` → layout redirects to `/` again → infinite loop
- Now redirects to the operator login page instead, breaking the loop

## Root cause

The operator layout assumed `router.push("/")` would take the user away from the operator subdomain, but middleware always rewrites `/` back to `/operator` on that subdomain.

## Test plan

- [x] Open `operator.localhost:3000` with stale/tenant session cookie → should show login page (no loop)
- [ ] Open `operator.localhost:3000` without any session → should redirect to login
- [ ] Login as operator → should work normally