### PR TITLE
fix: address review findings — use PersonService and improve error handling

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -277,7 +277,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	})
 	api.Groups = groupsAPI.NewResource(api.Services.Education, api.Services.Active, api.Services.Users, api.Services.UserContext, repoFactory.Student, repoFactory.GroupSubstitution, db)
 	api.Guardians = guardiansAPI.NewResource(api.Services.Guardian, api.Services.Users, api.Services.Education, api.Services.UserContext, repoFactory.Student, db)
-	api.Import = importAPI.NewResource(api.Services.Import, repoFactory.DataImport, repoFactory.Person, repoFactory.Staff, db)
+	api.Import = importAPI.NewResource(api.Services.Import, repoFactory.DataImport, api.Services.Users, db)
 	api.Activities = activitiesAPI.NewResource(api.Services.Activities, api.Services.Schedule, api.Services.Users, api.Services.UserContext, db)
 	api.Staff = staffAPI.NewResource(api.Services.Users, api.Services.Education, api.Services.Auth, repoFactory.GroupSupervisor, api.Services.WorkSession, repoFactory.StaffAbsence, db)
 	api.Feedback = feedbackAPI.NewResource(api.Services.Feedback, db)

--- a/backend/api/import/api.go
+++ b/backend/api/import/api.go
@@ -17,8 +17,8 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/models/audit"
 	importModels "github.com/moto-nrw/project-phoenix/models/import"
-	"github.com/moto-nrw/project-phoenix/models/users"
 	importService "github.com/moto-nrw/project-phoenix/services/import"
+	userSvc "github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
@@ -39,8 +39,7 @@ const (
 type Resource struct {
 	studentImportService *importService.ImportService[importModels.StudentImportRow]
 	auditRepo            audit.DataImportRepository
-	personRepo           users.PersonRepository
-	staffRepo            users.StaffRepository
+	personService        userSvc.PersonService
 	db                   *bun.DB
 }
 
@@ -48,15 +47,13 @@ type Resource struct {
 func NewResource(
 	studentImportService *importService.ImportService[importModels.StudentImportRow],
 	auditRepo audit.DataImportRepository,
-	personRepo users.PersonRepository,
-	staffRepo users.StaffRepository,
+	personService userSvc.PersonService,
 	db *bun.DB,
 ) *Resource {
 	return &Resource{
 		studentImportService: studentImportService,
 		auditRepo:            auditRepo,
-		personRepo:           personRepo,
-		staffRepo:            staffRepo,
+		personService:        personService,
 		db:                   db,
 	}
 }
@@ -518,14 +515,20 @@ func (rs *Resource) getStaffIDFromJWT(ctx context.Context) (int64, error) {
 		return 0, err
 	}
 
-	person, err := rs.personRepo.FindByAccountID(ctx, accountID)
-	if err != nil || person == nil {
+	person, err := rs.personService.FindByAccountID(ctx, accountID)
+	if err != nil {
+		return 0, fmt.Errorf("find person for account %d: %w", accountID, err)
+	}
+	if person == nil {
 		return 0, fmt.Errorf("person not found for account %d", accountID)
 	}
 
-	staff, err := rs.staffRepo.FindByPersonID(ctx, person.ID)
-	if err != nil || staff == nil {
-		return 0, fmt.Errorf("user is not a staff member")
+	staff, err := rs.personService.StaffRepository().FindByPersonID(ctx, person.ID)
+	if err != nil {
+		return 0, fmt.Errorf("find staff for person %d: %w", person.ID, err)
+	}
+	if staff == nil {
+		return 0, fmt.Errorf("user is not a staff member (person %d)", person.ID)
 	}
 
 	return staff.ID, nil

--- a/backend/api/import/import_test.go
+++ b/backend/api/import/import_test.go
@@ -41,7 +41,7 @@ func setupTestContext(t *testing.T) *testContext {
 	}
 
 	// Create import resource
-	resource := importAPI.NewResource(svc.Import, repos.DataImport, repos.Person, repos.Staff, db)
+	resource := importAPI.NewResource(svc.Import, repos.DataImport, svc.Users, db)
 
 	return &testContext{
 		db:       db,
@@ -449,6 +449,29 @@ func TestImportStudents_AccountWithoutPerson(t *testing.T) {
 	// Import handler wraps staff resolution in WithTenantTx, so failure returns 500
 	assert.Equal(t, http.StatusInternalServerError, rr.Code,
 		"Expected 500 when account has no person record in import")
+}
+
+func TestImportStudents_PersonWithoutStaff(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	// Create account + person but no staff record
+	_, account := testpkg.CreateTestPersonWithAccount(t, ctx.db, "NoStaff", "Import")
+
+	router := chi.NewRouter()
+	router.Post("/import", ctx.resource.ImportStudentsHandler())
+
+	csvContent := "Vorname,Nachname,Klasse\nMax,Mustermann,1a"
+
+	req := testutil.NewMultipartRequest(t, "POST", "/import", "file", "students.csv", csvContent,
+		testutil.WithClaims(testutil.AdminTestClaims(int(account.ID))),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	// Import handler wraps staff resolution in WithTenantTx, so failure returns 500
+	assert.Equal(t, http.StatusInternalServerError, rr.Code,
+		"Expected 500 when person has no staff record in import")
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Addresses review findings from #1023:

- **Use PersonService instead of raw repos** — replaced `PersonRepository`/`StaffRepository` injection with `PersonService`, matching the pattern used by all other handlers (`pickup_schedule_handlers.go`, `checkin.go`, `groups_handlers.go`, `sse_helpers.go`). This removes the extra params from `NewResource()` and `base.go`.
- **Preserve actual DB errors** — split `err != nil || obj == nil` checks into separate branches so DB timeouts, RLS violations etc. get wrapped with `%w` instead of being masked as "person not found"
- **Add missing test** — `TestImportStudents_PersonWithoutStaff` covers the import handler's error path (500) for person-without-staff, complementing the existing preview handler test (401)

## Test plan

- [x] All 20 import tests pass locally
- [x] `go build ./...` clean
- [x] `pnpm run check` clean