### PR TITLE
refactor: rename CSV Import to generic Import and reorder mobile nav

### DIFF
--- a/frontend/src/app/(protected)/database/students/import/page.test.tsx
+++ b/frontend/src/app/(protected)/database/students/import/page.test.tsx
@@ -6,7 +6,7 @@ import {
   cleanup,
 } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import StudentCSVImportPage from "./page";
+import StudentImportPage from "./page";
 
 // Mock next-auth/react
 vi.mock("next-auth/react", () => ({
@@ -122,7 +122,7 @@ vi.mock("~/components/import", () => ({
   ),
 }));
 
-describe("StudentCSVImportPage", () => {
+describe("StudentImportPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     global.fetch = vi.fn();
@@ -133,16 +133,16 @@ describe("StudentCSVImportPage", () => {
   });
 
   it("renders the page with instruction section", () => {
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
-    expect(screen.getByText("CSV/Excel-Import Anleitung")).toBeInTheDocument();
+    expect(screen.getByText("Import-Anleitung")).toBeInTheDocument();
     expect(
       screen.getByText(/Laden Sie die Vorlage herunter/),
     ).toBeInTheDocument();
   });
 
   it("renders the template download section", () => {
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     expect(
       screen.getByText("Schritt 1: Vorlage herunterladen"),
@@ -152,13 +152,13 @@ describe("StudentCSVImportPage", () => {
   });
 
   it("renders the upload section", () => {
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     expect(screen.getByTestId("upload-section")).toBeInTheDocument();
   });
 
   it("allows selecting template format", () => {
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const select = screen.getByRole("combobox");
     expect(select).toHaveValue("csv");
@@ -178,7 +178,7 @@ describe("StudentCSVImportPage", () => {
     global.URL.createObjectURL = vi.fn(() => "blob:test-url");
     global.URL.revokeObjectURL = vi.fn();
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const downloadButton = screen.getByText("Vorlage herunterladen");
     fireEvent.click(downloadButton);
@@ -209,7 +209,7 @@ describe("StudentCSVImportPage", () => {
       json: () => Promise.resolve(mockPreviewResponse),
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const fileSelectButton = screen.getByTestId("file-select-trigger");
     fireEvent.click(fileSelectButton);
@@ -230,7 +230,7 @@ describe("StudentCSVImportPage", () => {
       json: () => Promise.resolve({ message: "API Error" }),
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const fileSelectButton = screen.getByTestId("file-select-trigger");
     fireEvent.click(fileSelectButton);
@@ -247,7 +247,7 @@ describe("StudentCSVImportPage", () => {
       json: () => Promise.resolve({ message: "Test Error" }),
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const fileSelectButton = screen.getByTestId("file-select-trigger");
     fireEvent.click(fileSelectButton);
@@ -263,7 +263,7 @@ describe("StudentCSVImportPage", () => {
   });
 
   it("shows loading state in upload section", () => {
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     // Initial state should not be loading
     expect(screen.getByTestId("is-loading")).toHaveTextContent("false");
@@ -306,7 +306,7 @@ describe("StudentCSVImportPage", () => {
       json: () => Promise.resolve(mockPreviewResponse),
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const fileSelectButton = screen.getByTestId("file-select-trigger");
     fireEvent.click(fileSelectButton);
@@ -354,7 +354,7 @@ describe("StudentCSVImportPage", () => {
       json: () => Promise.resolve(mockPreviewResponse),
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const fileSelectButton = screen.getByTestId("file-select-trigger");
     fireEvent.click(fileSelectButton);
@@ -418,7 +418,7 @@ describe("StudentCSVImportPage", () => {
       json: () => Promise.resolve(mockPreviewResponse),
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const fileSelectButton = screen.getByTestId("file-select-trigger");
     fireEvent.click(fileSelectButton);
@@ -466,7 +466,7 @@ describe("StudentCSVImportPage", () => {
       json: () => Promise.resolve(mockPreviewResponse),
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const fileSelectButton = screen.getByTestId("file-select-trigger");
     fireEvent.click(fileSelectButton);
@@ -492,7 +492,7 @@ describe("StudentCSVImportPage", () => {
       json: () => Promise.resolve(mockPreviewResponse),
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const fileSelectButton = screen.getByTestId("file-select-trigger");
     fireEvent.click(fileSelectButton);
@@ -509,7 +509,7 @@ describe("StudentCSVImportPage", () => {
       ok: false,
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const downloadButton = screen.getByText("Vorlage herunterladen");
     fireEvent.click(downloadButton);
@@ -535,7 +535,7 @@ describe("StudentCSVImportPage", () => {
       json: () => Promise.resolve(mockPreviewResponse),
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const fileSelectButton = screen.getByTestId("file-select-trigger");
     fireEvent.click(fileSelectButton);
@@ -578,7 +578,7 @@ describe("StudentCSVImportPage", () => {
         json: () => Promise.resolve(mockImportResponse),
       });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     // Upload file
     const fileSelectButton = screen.getByTestId("file-select-trigger");
@@ -654,7 +654,7 @@ describe("StudentCSVImportPage", () => {
         json: () => Promise.resolve(mockImportResponse),
       });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     // Upload file
     const fileSelectButton = screen.getByTestId("file-select-trigger");
@@ -705,7 +705,7 @@ describe("StudentCSVImportPage", () => {
         json: () => Promise.resolve({ message: "Import fehlgeschlagen" }),
       });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     // Upload file
     const fileSelectButton = screen.getByTestId("file-select-trigger");
@@ -761,7 +761,7 @@ describe("StudentCSVImportPage", () => {
       json: () => Promise.resolve(mockPreviewResponse),
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const fileSelectButton = screen.getByTestId("file-select-trigger");
     fireEvent.click(fileSelectButton);
@@ -781,7 +781,7 @@ describe("StudentCSVImportPage", () => {
       update: vi.fn(),
     });
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     expect(screen.getByTestId("loading")).toBeInTheDocument();
   });
@@ -795,7 +795,7 @@ describe("StudentCSVImportPage", () => {
       update: vi.fn(),
     } as unknown as ReturnType<typeof useSession.useSession>);
 
-    render(<StudentCSVImportPage />);
+    render(<StudentImportPage />);
 
     const fileSelectButton = screen.getByTestId("file-select-trigger");
     fireEvent.click(fileSelectButton);

--- a/frontend/src/app/(protected)/database/students/import/page.tsx
+++ b/frontend/src/app/(protected)/database/students/import/page.tsx
@@ -10,7 +10,7 @@ import { UploadSection, StatsCards, StudentRowCard } from "~/components/import";
 import { useToast } from "~/contexts/ToastContext";
 import { createLogger } from "~/lib/logger";
 
-const logger = createLogger({ component: "CsvImportPage" });
+const logger = createLogger({ component: "StudentImportPage" });
 
 // Types matching backend API response
 interface ImportError {
@@ -76,7 +76,7 @@ interface DisplayStudent {
   health_info: string;
 }
 
-export default function StudentCSVImportPage() {
+export default function StudentImportPage() {
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [previewData, setPreviewData] = useState<DisplayStudent[]>([]);
   const [isDragging, setIsDragging] = useState(false);
@@ -253,7 +253,7 @@ export default function StudentCSVImportPage() {
         setPreviewData(displayData);
         setImportResult(importData);
       } catch (err) {
-        logger.error("csv_preview_failed", {
+        logger.error("student_preview_failed", {
           error: err instanceof Error ? err.message : String(err),
         });
         setError(err instanceof Error ? err.message : "Unbekannter Fehler");
@@ -334,7 +334,7 @@ export default function StudentCSVImportPage() {
         resetForm();
       }
     } catch (err) {
-      logger.error("csv_import_failed", {
+      logger.error("student_import_failed", {
         error: err instanceof Error ? err.message : String(err),
       });
       setError(err instanceof Error ? err.message : "Unbekannter Fehler");
@@ -379,7 +379,7 @@ export default function StudentCSVImportPage() {
       ) {
         handleFileUpload(file).catch(() => undefined);
       } else {
-        setError("Bitte nur CSV- oder Excel-Dateien hochladen");
+        setError("Bitte nur CSV- oder Excel-Dateien (.csv, .xlsx) hochladen");
       }
     }
   };
@@ -418,17 +418,12 @@ export default function StudentCSVImportPage() {
           </div>
           <div className="flex-1">
             <h3 className="mb-2 text-sm font-semibold text-gray-900">
-              CSV/Excel-Import Anleitung
+              Import-Anleitung
             </h3>
             <ul className="list-inside list-disc space-y-1 text-sm text-gray-600">
-              <li>
-                Laden Sie die Vorlage herunter (CSV oder Excel - siehe unten)
-              </li>
+              <li>Laden Sie die Vorlage herunter (siehe unten)</li>
               <li>Füllen Sie die Datei mit Ihren Schülerdaten aus</li>
-              <li>
-                Speichern Sie die Datei (CSV behält das Format, Excel wird als
-                .xlsx gespeichert)
-              </li>
+              <li>Speichern Sie die ausgefüllte Datei</li>
               <li>
                 Laden Sie die Datei hier hoch und überprüfen Sie die Vorschau
               </li>
@@ -468,7 +463,7 @@ export default function StudentCSVImportPage() {
       <div className="rounded-xl border border-gray-100 bg-white p-6">
         <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-900">
           <svg
-            className="h-5 w-5 text-purple-600"
+            className="h-5 w-5 text-gray-600"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -497,7 +492,7 @@ export default function StudentCSVImportPage() {
                 onChange={(e) =>
                   setTemplateFormat(e.target.value as "csv" | "xlsx")
                 }
-                className="h-10 w-full appearance-none rounded-lg border border-gray-300 bg-white px-4 py-2 pr-10 text-sm text-gray-900 focus:border-purple-500 focus:ring-2 focus:ring-purple-500/20 focus:outline-none"
+                className="h-10 w-full appearance-none rounded-lg border border-gray-300 bg-white px-4 py-2 pr-10 text-sm text-gray-900 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 focus:outline-none"
               >
                 <option value="csv">CSV (Komma-getrennt)</option>
                 <option value="xlsx">Excel (.xlsx)</option>

--- a/frontend/src/app/(protected)/database/students/page.tsx
+++ b/frontend/src/app/(protected)/database/students/page.tsx
@@ -384,28 +384,24 @@ export default function StudentsPage() {
             !isMobile && (
               <div className="flex items-center gap-3">
                 <Link
-                  href="/database/students/csv-import"
-                  className="group relative flex h-10 items-center gap-2 rounded-full bg-gradient-to-br from-purple-500 to-purple-600 px-4 text-white shadow-lg transition-all duration-300 hover:scale-105 hover:shadow-xl active:scale-95"
-                  aria-label="CSV Import"
+                  href="/database/students/import"
+                  className="flex h-10 items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 active:bg-gray-100"
+                  aria-label="Schüler importieren"
                 >
-                  <div className="pointer-events-none absolute inset-[2px] rounded-full bg-gradient-to-br from-white/20 to-white/0 opacity-0 transition-opacity duration-150 group-hover:opacity-100"></div>
                   <svg
-                    className="relative h-5 w-5 transition-transform duration-300"
+                    className="h-4.5 w-4.5"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
-                    strokeWidth={2.5}
+                    strokeWidth={2}
                   >
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"
-                      d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
                     />
                   </svg>
-                  <span className="relative text-sm font-semibold">
-                    CSV Import
-                  </span>
-                  <div className="pointer-events-none absolute inset-0 scale-0 rounded-full bg-white/20 opacity-0 transition-transform duration-200 group-hover:scale-100 group-hover:opacity-100"></div>
+                  Importieren
                 </Link>
                 <button
                   onClick={() => setShowCreateModal(true)}

--- a/frontend/src/components/dashboard/header/breadcrumb-utils.test.ts
+++ b/frontend/src/components/dashboard/header/breadcrumb-utils.test.ts
@@ -146,10 +146,8 @@ describe("breadcrumb-utils", () => {
   });
 
   describe("getSubPageLabel", () => {
-    it("should return 'CSV-Import' for csv-import segment", () => {
-      expect(getSubPageLabel("/database/students/csv-import")).toBe(
-        "CSV-Import",
-      );
+    it("should return 'Importieren' for import segment", () => {
+      expect(getSubPageLabel("/database/students/import")).toBe("Importieren");
     });
 
     it("should return 'Erstellen' for create segment", () => {

--- a/frontend/src/components/dashboard/header/breadcrumb-utils.ts
+++ b/frontend/src/components/dashboard/header/breadcrumb-utils.ts
@@ -86,7 +86,7 @@ export function getSubPageLabel(pathname: string): string {
   const lastSegment = segments.at(-1);
 
   const subPageLabels: Record<string, string> = {
-    "csv-import": "CSV-Import",
+    import: "Importieren",
     create: "Erstellen",
     edit: "Bearbeiten",
     details: "Details",

--- a/frontend/src/components/dashboard/mobile-bottom-nav.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.tsx
@@ -137,9 +137,9 @@ const additionalNavItems: AdditionalNavItem[] = [
     requiresAdmin: true,
   },
   {
-    href: "/settings",
-    label: "Einstellungen",
-    iconKey: "settings",
+    href: "/time-tracking",
+    label: "Zeiterfassung",
+    iconKey: "clock",
     alwaysShow: true,
   },
   {
@@ -149,9 +149,9 @@ const additionalNavItems: AdditionalNavItem[] = [
     alwaysShow: true,
   },
   {
-    href: "/time-tracking",
-    label: "Zeiterfassung",
-    iconKey: "clock",
+    href: "/settings",
+    label: "Einstellungen",
+    iconKey: "settings",
     alwaysShow: true,
   },
   // Coming soon features - shown to all users

--- a/frontend/src/components/import/upload-section.test.tsx
+++ b/frontend/src/components/import/upload-section.test.tsx
@@ -17,9 +17,7 @@ describe("UploadSection", () => {
   it("renders upload section header", () => {
     render(<UploadSection {...defaultProps} />);
 
-    expect(
-      screen.getByText("Schritt 2: CSV- oder Excel-Datei hochladen"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Schritt 2: Datei hochladen")).toBeInTheDocument();
   });
 
   it("displays default drop zone text", () => {

--- a/frontend/src/components/import/upload-section.tsx
+++ b/frontend/src/components/import/upload-section.tsx
@@ -49,7 +49,7 @@ export function UploadSection({
             d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
           />
         </svg>
-        Schritt 2: CSV- oder Excel-Datei hochladen
+        Schritt 2: Datei hochladen
       </h3>
 
       {/* Hidden file input */}


### PR DESCRIPTION
## Summary
- Rename route `csv-import/` → `import/` (format-agnostic, Excel is primary import source)
- Replace purple gradient button with clean outline button + upload icon (SaaS best practice)
- Update all labels, breadcrumbs, logger names, and log events to remove "CSV" naming
- Move "Einstellungen" below "Zeiterfassung" in mobile bottom nav (less frequently used)

## Test plan
- [x] Navigate to `/database/students` — "Importieren" button visible with upload icon
- [x] Click "Importieren" — redirects to `/database/students/import`
- [x] Import flow works (template download, file upload, preview, import)
- [x] Breadcrumb shows "Importieren" on import page
- [x] Mobile nav: Zeiterfassung appears before Feedback, Einstellungen is last