### PR TITLE
fix: grant missing phoenix_auth permissions and wrap logout in WithAdminTx

### DIFF
--- a/backend/database/migrations/001015013_fix_phoenix_auth_token_grants.go
+++ b/backend/database/migrations/001015013_fix_phoenix_auth_token_grants.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	fixPhoenixAuthTokenGrantsVersion     = "1.15.13"
-	fixPhoenixAuthTokenGrantsDescription = "Grant missing UPDATE on auth.tokens and SELECT on users.profiles to phoenix_auth (fixes FOR UPDATE and profile lookup)"
+	fixPhoenixAuthTokenGrantsDescription = "Grant missing permissions to phoenix_auth for tokens, password reset, and profiles"
 )
 
 func init() {
@@ -21,36 +21,60 @@ func init() {
 
 	Migrations.MustRegister(
 		func(ctx context.Context, db *bun.DB) error {
-			fmt.Println("Migration 1.15.13: Fixing phoenix_auth token and profile grants...")
+			fmt.Println("Migration 1.15.13: Fixing phoenix_auth grants...")
 
-			// Fix 1: auth.tokens needs UPDATE for SELECT ... FOR UPDATE in refresh flow.
+			// Fix 1: auth.tokens — add UPDATE for SELECT ... FOR UPDATE (defense-in-depth).
 			// Migration 1.14.1 granted SELECT, INSERT, DELETE but missed UPDATE.
-			// The token refresh uses FindByTokenForUpdate which does FOR UPDATE row locking.
+			// The refresh flow uses WithAdminTx, but logout runs as phoenix_auth directly
+			// and may need UPDATE in the future. Harmless to grant now.
 			_, err := db.ExecContext(ctx, `GRANT UPDATE ON auth.tokens TO phoenix_auth;`)
 			if err != nil {
-				return fmt.Errorf("error granting UPDATE on auth.tokens to phoenix_auth: %w", err)
+				return fmt.Errorf("grant UPDATE on auth.tokens: %w", err)
 			}
 
-			// Fix 2: users.profiles needs SELECT for the /me/profile endpoint.
-			// This endpoint runs outside TenantTxMiddleware (auth context only),
-			// so it queries as phoenix_auth directly.
+			// Fix 2: users.profiles — add SELECT (defense-in-depth).
+			// Currently the /me/profile endpoint uses TenantTxMiddleware (phoenix_tenant),
+			// but phoenix_auth should also be able to read profiles for auth flows.
 			_, err = db.ExecContext(ctx, `GRANT SELECT ON users.profiles TO phoenix_auth;`)
 			if err != nil {
-				return fmt.Errorf("error granting SELECT on users.profiles to phoenix_auth: %w", err)
+				return fmt.Errorf("grant SELECT on users.profiles: %w", err)
+			}
+
+			// Fix 3: auth.password_reset_tokens — phoenix_auth has ZERO grants.
+			// The password reset flow (InitiatePasswordReset) uses RunInTx which runs
+			// as phoenix_auth directly (no WithAdminTx). It needs:
+			//   - SELECT: FindValidByToken (before WithAdminTx in ResetPassword)
+			//   - INSERT: Create new reset tokens
+			//   - UPDATE: InvalidateTokensByAccountID, MarkAsUsed, UpdateDeliveryResult
+			_, err = db.ExecContext(ctx, `GRANT SELECT, INSERT, UPDATE ON auth.password_reset_tokens TO phoenix_auth;`)
+			if err != nil {
+				return fmt.Errorf("grant on auth.password_reset_tokens: %w", err)
+			}
+
+			// Fix 4: auth.password_reset_rate_limits — phoenix_auth has ZERO grants.
+			// checkPasswordResetRateLimit runs as phoenix_auth and needs:
+			//   - SELECT: CheckRateLimit
+			//   - INSERT: IncrementAttempts (upsert)
+			//   - UPDATE: IncrementAttempts (upsert)
+			_, err = db.ExecContext(ctx, `GRANT SELECT, INSERT, UPDATE ON auth.password_reset_rate_limits TO phoenix_auth;`)
+			if err != nil {
+				return fmt.Errorf("grant on auth.password_reset_rate_limits: %w", err)
 			}
 
 			fmt.Println("Migration 1.15.13: Done")
 			return nil
 		},
 		func(ctx context.Context, db *bun.DB) error {
-			fmt.Println("Rolling back migration 1.15.13: Revoking phoenix_auth token and profile grants...")
+			fmt.Println("Rolling back migration 1.15.13: Revoking phoenix_auth grants...")
 
 			_, err := db.ExecContext(ctx, `
 				REVOKE UPDATE ON auth.tokens FROM phoenix_auth;
 				REVOKE SELECT ON users.profiles FROM phoenix_auth;
+				REVOKE SELECT, INSERT, UPDATE ON auth.password_reset_tokens FROM phoenix_auth;
+				REVOKE SELECT, INSERT, UPDATE ON auth.password_reset_rate_limits FROM phoenix_auth;
 			`)
 			if err != nil {
-				return fmt.Errorf("error revoking phoenix_auth token and profile grants: %w", err)
+				return fmt.Errorf("error revoking phoenix_auth grants: %w", err)
 			}
 
 			return nil

--- a/backend/services/auth/auth_login.go
+++ b/backend/services/auth/auth_login.go
@@ -970,7 +970,12 @@ func (s *Service) Logout(ctx context.Context, refreshTokenStr string) error {
 	return s.LogoutWithAudit(ctx, refreshTokenStr, "", "")
 }
 
-// LogoutWithAudit invalidates a refresh token with audit logging
+// LogoutWithAudit invalidates a refresh token with audit logging.
+//
+// Uses WithAdminTx (BYPASSRLS) because logout is a pre-deauthentication flow.
+// auth.tokens has RLS enabled — without setting app.current_tenant_id, the
+// tenant isolation policy silently filters out all rows, causing FindByToken
+// to return "not found" and tokens to never actually be deleted.
 func (s *Service) LogoutWithAudit(ctx context.Context, refreshTokenStr, ipAddress, userAgent string) error {
 	// Parse JWT refresh token
 	jwtToken, err := s.tokenAuth.JwtAuth.Decode(refreshTokenStr)
@@ -988,34 +993,39 @@ func (s *Service) LogoutWithAudit(ctx context.Context, refreshTokenStr, ipAddres
 		return &AuthError{Op: "parse refresh claims", Err: ErrInvalidToken}
 	}
 
-	// Get token from database to find the account ID
-	dbToken, err := s.repos.Token.FindByToken(ctx, refreshClaims.Token)
-	if err != nil {
-		// Token not found, consider logout successful
-		return nil
-	}
-
-	// Delete ALL tokens for this account to ensure complete logout
-	// This ensures that all sessions (access and refresh tokens) are invalidated
-	err = s.repos.Token.DeleteByAccountID(ctx, dbToken.AccountID)
-	if err != nil {
-		// Log the error but don't fail the logout
-		s.getLogger().Warn("failed to delete all tokens during logout",
-			slog.Int64("account_id", dbToken.AccountID),
-			slog.Any("error", err),
-		)
-		// Still try to delete the specific token
-		if deleteErr := s.repos.Token.Delete(ctx, dbToken.ID); deleteErr != nil {
-			return &AuthError{Op: "delete token", Err: deleteErr}
+	// Use WithAdminTx to bypass RLS on auth.tokens (same pattern as refreshTokenInTransaction)
+	err = tenant.WithAdminTx(ctx, s.db, func(ctx context.Context, tx bun.Tx) error {
+		// Get token from database to find the account ID
+		dbToken, err := s.repos.Token.FindByToken(ctx, refreshClaims.Token)
+		if err != nil {
+			// Token not found, consider logout successful
+			return nil
 		}
-	}
 
-	// Log successful logout
-	if ipAddress != "" {
-		s.logAuthEvent(ctx, dbToken.AccountID, audit.EventTypeLogout, true, ipAddress, userAgent, "")
-	}
+		// Delete ALL tokens for this account to ensure complete logout
+		// This ensures that all sessions (access and refresh tokens) are invalidated
+		err = s.repos.Token.DeleteByAccountID(ctx, dbToken.AccountID)
+		if err != nil {
+			// Log the error but don't fail the logout
+			s.getLogger().Warn("failed to delete all tokens during logout",
+				slog.Int64("account_id", dbToken.AccountID),
+				slog.Any("error", err),
+			)
+			// Still try to delete the specific token
+			if deleteErr := s.repos.Token.Delete(ctx, dbToken.ID); deleteErr != nil {
+				return &AuthError{Op: "delete token", Err: deleteErr}
+			}
+		}
 
-	return nil
+		// Log successful logout
+		if ipAddress != "" {
+			s.logAuthEvent(ctx, dbToken.AccountID, audit.EventTypeLogout, true, ipAddress, userAgent, "")
+		}
+
+		return nil
+	})
+
+	return err
 }
 
 // ChangePassword updates an account's password


### PR DESCRIPTION
## Summary

Fixes two categories of broken auth flows after the multi-tenancy deploy (PR #1013):

### Migration 1.15.13 — Missing `phoenix_auth` grants

| Table | Grants Added | Why |
|-------|-------------|-----|
| `auth.tokens` | UPDATE | Defense-in-depth for token operations (refresh uses `WithAdminTx`, but logout now does too) |
| `users.profiles` | SELECT | Defense-in-depth for auth-context profile access |
| `auth.password_reset_tokens` | SELECT, INSERT, UPDATE | **Completely broken** — `InitiatePasswordReset` uses `RunInTx` (no SET ROLE), so it runs as `phoenix_auth` which had zero grants |
| `auth.password_reset_rate_limits` | SELECT, INSERT, UPDATE | **Completely broken** — `checkPasswordResetRateLimit` runs as `phoenix_auth` which had zero grants |

### Logout fix — `WithAdminTx` wrapper

`LogoutWithAudit` previously queried `auth.tokens` directly as `phoenix_auth`. With RLS enabled (`FORCE ROW LEVEL SECURITY`) and no `app.current_tenant_id` set, the tenant isolation policy silently filtered out all rows — `FindByToken` returned "not found", and tokens were never actually deleted. Sessions lingered until natural expiry (7 days for refresh tokens).

Now wraps all token operations in `WithAdminTx` (BYPASSRLS), matching the pattern already used by `refreshTokenInTransaction`.

## Verified on staging server

- `phoenix_auth` had SELECT, INSERT, DELETE on `auth.tokens` — **no UPDATE**
- `phoenix_auth` had **zero grants** on `auth.password_reset_tokens`
- `phoenix_auth` had **zero grants** on `auth.password_reset_rate_limits`
- `auth.tokens` has `relforcerowsecurity=true` — RLS blocks all queries without `app.current_tenant_id`
- All repo methods use `base.GetDB(ctx, r.db)` which picks up the tx from `WithAdminTx` context

## Test plan

- [ ] CI passes (migration validates, backend compiles)
- [ ] After staging deploy: verify grants applied (`\dp auth.tokens`, `\dp auth.password_reset_tokens`)
- [ ] Log in on staging → token refresh works without "permission denied" errors
- [ ] Log out → verify tokens are actually deleted (not silently skipped by RLS)
- [ ] Trigger password reset → verify token is created and email is sent