### PR TITLE
fix: scope auth rate limiter to login endpoints only

### DIFF
--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -45,6 +45,12 @@ type Resource struct {
 	InvitationService authService.InvitationService
 	SchoolRepo        platform.SchoolRepository
 	db                *bun.DB
+	authRateLimiter   func(http.Handler) http.Handler
+}
+
+// SetAuthRateLimiter sets the rate limiter middleware for auth endpoints (login, register, password-reset).
+func (rs *Resource) SetAuthRateLimiter(mw func(http.Handler) http.Handler) {
+	rs.authRateLimiter = mw
 }
 
 // NewResource creates a new auth resource
@@ -65,11 +71,18 @@ func (rs *Resource) Router() chi.Router {
 	// Create JWT auth instance for middleware
 	tokenAuth, _ := jwt.NewTokenAuth()
 
-	// Public routes
-	r.Post("/login", rs.login)
-	r.Post("/register", rs.register)
-	r.Post("/password-reset", rs.initiatePasswordReset)
-	r.Post("/password-reset/confirm", rs.resetPassword)
+	// Rate-limited public routes (brute-force protection)
+	r.Group(func(r chi.Router) {
+		if rs.authRateLimiter != nil {
+			r.Use(rs.authRateLimiter)
+		}
+		r.Post("/login", rs.login)
+		r.Post("/register", rs.register)
+		r.Post("/password-reset", rs.initiatePasswordReset)
+		r.Post("/password-reset/confirm", rs.resetPassword)
+	})
+
+	// Public routes (no rate limiting — these are read-only lookups)
 	r.Get("/invitations/{token}", rs.validateInvitation)
 	r.Post("/invitations/{token}/accept", rs.acceptInvitation)
 	r.Get("/tenant/resolve", rs.resolveTenant)

--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -345,7 +345,7 @@ func (a *API) registerRoutesWithRateLimiting() {
 				authLimit = parsed
 			}
 		}
-		authRateLimiter = customMiddleware.NewRateLimiter(authLimit, 2) // small burst for auth
+		authRateLimiter = customMiddleware.NewRateLimiter(authLimit, 10) // allow reasonable burst for login attempts
 		if securityLogger != nil {
 			authRateLimiter.SetLogger(securityLogger)
 		}
@@ -363,15 +363,11 @@ func (a *API) registerRoutesWithRateLimiting() {
 
 	// Mount API resources
 	// Auth routes mounted at root level to match frontend expectations
-	// Apply stricter rate limiting to auth endpoints if enabled
+	// Rate limiting is applied per-route inside Auth.Router() (only login, register, password-reset)
 	if rateLimitEnabled && authRateLimiter != nil {
-		a.Router.Route("/auth", func(r chi.Router) {
-			r.Use(authRateLimiter.Middleware())
-			r.Mount("/", a.Auth.Router())
-		})
-	} else {
-		a.Router.Mount("/auth", a.Auth.Router())
+		a.Auth.SetAuthRateLimiter(authRateLimiter.Middleware())
 	}
+	a.Router.Mount("/auth", a.Auth.Router())
 
 	// Other API routes under /api prefix for organization
 	a.Router.Route("/api", func(r chi.Router) {


### PR DESCRIPTION
## Summary
- Rate limiter (burst=2) was applied to ALL `/auth/*` routes including `/auth/tenant/resolve`, which fires on every login page load — exhausting burst tokens before the actual login request
- Scoped rate limiter to only `POST /login`, `/register`, `/password-reset`, `/password-reset/confirm`
- Bumped burst from 2 → 10 to handle legitimate rapid retries

## Test plan
- [x] `go build ./...` compiles clean
- [x] All 13 rate limiter middleware tests pass
- [x] All lefthook pre-push checks pass (go-vet, golangci-lint, go-deadcode)
- [ ] Deploy to staging, verify login works on first attempt
- [ ] Verify rate limiting still blocks rapid login spam (>10 burst)