### PR TITLE
fix: distinguish backend error from empty tenant list on root page

### DIFF
--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -45,26 +45,29 @@ describe("RootPage", () => {
   });
 
   it("renders tenant options in select after loading", async () => {
-    mockListAllTenants.mockResolvedValue([
-      {
-        tenantId: 0,
-        slug: "school-a",
-        name: "Testschule A",
-        subdomain: "school-a",
-        organizationId: 0,
-        organizationName: "",
-        settings: {},
-      },
-      {
-        tenantId: 0,
-        slug: "school-b",
-        name: "Testschule B",
-        subdomain: "school-b",
-        organizationId: 0,
-        organizationName: "",
-        settings: {},
-      },
-    ]);
+    mockListAllTenants.mockResolvedValue({
+      status: "ok",
+      tenants: [
+        {
+          tenantId: 0,
+          slug: "school-a",
+          name: "Testschule A",
+          subdomain: "school-a",
+          organizationId: 0,
+          organizationName: "",
+          settings: {},
+        },
+        {
+          tenantId: 0,
+          slug: "school-b",
+          name: "Testschule B",
+          subdomain: "school-b",
+          organizationId: 0,
+          organizationName: "",
+          settings: {},
+        },
+      ],
+    });
 
     render(<RootPage />);
 
@@ -81,17 +84,20 @@ describe("RootPage", () => {
   });
 
   it("disables button when no tenant is selected", async () => {
-    mockListAllTenants.mockResolvedValue([
-      {
-        tenantId: 0,
-        slug: "school-a",
-        name: "School A",
-        subdomain: "school-a",
-        organizationId: 0,
-        organizationName: "",
-        settings: {},
-      },
-    ]);
+    mockListAllTenants.mockResolvedValue({
+      status: "ok",
+      tenants: [
+        {
+          tenantId: 0,
+          slug: "school-a",
+          name: "School A",
+          subdomain: "school-a",
+          organizationId: 0,
+          organizationName: "",
+          settings: {},
+        },
+      ],
+    });
 
     render(<RootPage />);
 
@@ -104,17 +110,20 @@ describe("RootPage", () => {
   });
 
   it("enables button when a tenant is selected", async () => {
-    mockListAllTenants.mockResolvedValue([
-      {
-        tenantId: 0,
-        slug: "school-a",
-        name: "School A",
-        subdomain: "school-a",
-        organizationId: 0,
-        organizationName: "",
-        settings: {},
-      },
-    ]);
+    mockListAllTenants.mockResolvedValue({
+      status: "ok",
+      tenants: [
+        {
+          tenantId: 0,
+          slug: "school-a",
+          name: "School A",
+          subdomain: "school-a",
+          organizationId: 0,
+          organizationName: "",
+          settings: {},
+        },
+      ],
+    });
 
     render(<RootPage />);
 
@@ -131,17 +140,20 @@ describe("RootPage", () => {
   });
 
   it("navigates to tenant subdomain when clicking Weiter", async () => {
-    mockListAllTenants.mockResolvedValue([
-      {
-        tenantId: 0,
-        slug: "school-a",
-        name: "School A",
-        subdomain: "school-a",
-        organizationId: 0,
-        organizationName: "",
-        settings: {},
-      },
-    ]);
+    mockListAllTenants.mockResolvedValue({
+      status: "ok",
+      tenants: [
+        {
+          tenantId: 0,
+          slug: "school-a",
+          name: "School A",
+          subdomain: "school-a",
+          organizationId: 0,
+          organizationName: "",
+          settings: {},
+        },
+      ],
+    });
 
     render(<RootPage />);
 
@@ -164,17 +176,20 @@ describe("RootPage", () => {
   });
 
   it("does not navigate when selected slug has no matching tenant", async () => {
-    mockListAllTenants.mockResolvedValue([
-      {
-        tenantId: 0,
-        slug: "school-a",
-        name: "School A",
-        subdomain: "school-a",
-        organizationId: 0,
-        organizationName: "",
-        settings: {},
-      },
-    ]);
+    mockListAllTenants.mockResolvedValue({
+      status: "ok",
+      tenants: [
+        {
+          tenantId: 0,
+          slug: "school-a",
+          name: "School A",
+          subdomain: "school-a",
+          organizationId: 0,
+          organizationName: "",
+          settings: {},
+        },
+      ],
+    });
 
     render(<RootPage />);
 
@@ -196,8 +211,8 @@ describe("RootPage", () => {
     hrefSpy.mockRestore();
   });
 
-  it("shows error message when error is not an Error instance", async () => {
-    mockListAllTenants.mockRejectedValue("string error");
+  it("shows backend error when listAllTenants returns error status", async () => {
+    mockListAllTenants.mockResolvedValue({ tenants: [], status: "error" });
 
     render(<RootPage />);
 
@@ -212,32 +227,14 @@ describe("RootPage", () => {
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
   });
 
-  it("shows error message when backend is unreachable", async () => {
-    mockListAllTenants.mockRejectedValue(new Error("Network error"));
+  it("shows empty message when backend returns no tenants", async () => {
+    mockListAllTenants.mockResolvedValue({ tenants: [], status: "ok" });
 
     render(<RootPage />);
 
     await waitFor(() => {
       expect(
-        screen.getByText(
-          "Backend nicht erreichbar — bitte versuchen Sie es später erneut.",
-        ),
-      ).toBeInTheDocument();
-    });
-
-    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
-  });
-
-  it("shows error message when API returns empty list", async () => {
-    mockListAllTenants.mockResolvedValue([]);
-
-    render(<RootPage />);
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Backend nicht erreichbar — bitte versuchen Sie es später erneut.",
-        ),
+        screen.getByText("Aktuell sind keine Einrichtungen verfügbar."),
       ).toBeInTheDocument();
     });
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,7 +9,7 @@
 import { useState, useEffect } from "react";
 import Image from "next/image";
 import { listAllTenants } from "~/lib/tenant-api";
-import type { TenantInfo } from "~/lib/tenant-api";
+import type { TenantInfo, TenantListResult } from "~/lib/tenant-api";
 import { createLogger } from "~/lib/logger";
 import { env } from "~/env";
 
@@ -18,24 +18,21 @@ const logger = createLogger({ component: "RootPage" });
 export default function RootPage() {
   const [tenants, setTenants] = useState<TenantInfo[]>([]);
   const [loading, setLoading] = useState(true);
-  const [isFallback, setIsFallback] = useState(false);
+  const [listStatus, setListStatus] =
+    useState<TenantListResult["status"]>("ok");
   const [selectedSlug, setSelectedSlug] = useState("");
 
   useEffect(() => {
-    listAllTenants()
+    void listAllTenants()
       .then((result) => {
-        if (result.length > 0) {
-          setTenants(result);
+        setListStatus(result.status);
+        if (result.tenants.length > 0) {
+          setTenants(result.tenants);
+        } else if (result.status === "error") {
+          logger.warn("tenant_list_fetch_failed");
         } else {
-          logger.warn("tenant_list_empty_or_failed");
-          setIsFallback(true);
+          logger.warn("tenant_list_empty");
         }
-      })
-      .catch((error: unknown) => {
-        logger.error("tenant_list_fetch_failed", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-        setIsFallback(true);
       })
       .finally(() => setLoading(false));
   }, []);
@@ -82,9 +79,13 @@ export default function RootPage() {
               </label>
               <div className="h-10 w-full animate-pulse rounded-lg bg-gray-200" />
             </div>
-          ) : isFallback ? (
+          ) : listStatus === "error" ? (
             <p className="text-sm text-gray-500">
               Backend nicht erreichbar — bitte versuchen Sie es später erneut.
+            </p>
+          ) : tenants.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              Aktuell sind keine Einrichtungen verfügbar.
             </p>
           ) : (
             <>

--- a/frontend/src/lib/tenant-api.test.ts
+++ b/frontend/src/lib/tenant-api.test.ts
@@ -127,7 +127,7 @@ describe("tenant-api", () => {
   // --------------------------------------------------------------------------
 
   describe("listAllTenants", () => {
-    it("returns mapped tenants without internal IDs", async () => {
+    it("returns mapped tenants with status ok", async () => {
       const data = {
         data: [
           {
@@ -153,11 +153,12 @@ describe("tenant-api", () => {
       );
 
       const { listAllTenants } = await import("./tenant-api");
-      const result = await listAllTenants();
+      const result = await listAllTenants(1);
 
       expect(global.fetch).toHaveBeenCalledWith("/api/tenant/list");
-      expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({
+      expect(result.status).toBe("ok");
+      expect(result.tenants).toHaveLength(2);
+      expect(result.tenants[0]).toEqual({
         tenantId: 0,
         slug: "school-a",
         name: "School A",
@@ -168,18 +169,18 @@ describe("tenant-api", () => {
       });
     });
 
-    it("returns empty array on error response", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce(
+    it("returns error status after exhausting retries on server error", async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
         new Response("Server Error", { status: 500 }),
       );
 
       const { listAllTenants } = await import("./tenant-api");
-      const result = await listAllTenants();
+      const result = await listAllTenants(1);
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({ tenants: [], status: "error" });
     });
 
-    it("returns empty array when data field is missing", async () => {
+    it("returns empty tenants with status ok when data field is missing", async () => {
       vi.mocked(global.fetch).mockResolvedValueOnce(
         new Response(JSON.stringify({}), {
           status: 200,
@@ -188,18 +189,47 @@ describe("tenant-api", () => {
       );
 
       const { listAllTenants } = await import("./tenant-api");
-      const result = await listAllTenants();
+      const result = await listAllTenants(1);
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({ tenants: [], status: "ok" });
     });
 
-    it("returns empty array on network error", async () => {
-      vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"));
+    it("returns error status after exhausting retries on network error", async () => {
+      vi.mocked(global.fetch).mockRejectedValue(new Error("Network error"));
 
       const { listAllTenants } = await import("./tenant-api");
-      const result = await listAllTenants();
+      const result = await listAllTenants(1);
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({ tenants: [], status: "error" });
+    });
+
+    it("retries on transient failure then succeeds", async () => {
+      const data = {
+        data: [
+          {
+            slug: "school-a",
+            name: "School A",
+            subdomain: "school-a",
+            organization_name: "Org Alpha",
+          },
+        ],
+      };
+
+      vi.mocked(global.fetch)
+        .mockRejectedValueOnce(new Error("Network error"))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(data), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+
+      const { listAllTenants } = await import("./tenant-api");
+      const result = await listAllTenants(2);
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(result.status).toBe("ok");
+      expect(result.tenants).toHaveLength(1);
     });
   });
 

--- a/frontend/src/lib/tenant-api.ts
+++ b/frontend/src/lib/tenant-api.ts
@@ -76,31 +76,69 @@ interface PublicTenantBackend {
   organization_name: string;
 }
 
+export interface TenantListResult {
+  tenants: TenantInfo[];
+  /** "ok" = backend responded successfully, "error" = network or server failure */
+  status: "ok" | "error";
+}
+
 /**
- * List all active tenants.
+ * List all active tenants with retry logic.
  * This is a public (no-auth) call used on the root tenant selector page.
  * The backend omits internal IDs from this public endpoint.
+ *
+ * Retries up to {@link maxAttempts} times with exponential backoff to
+ * handle transient failures (e.g. after registration redirect).
  */
-export async function listAllTenants(): Promise<TenantInfo[]> {
-  try {
-    const response = await fetch("/api/tenant/list");
-    if (!response.ok) {
-      return [];
+export async function listAllTenants(
+  maxAttempts = 3,
+): Promise<TenantListResult> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const response = await fetch("/api/tenant/list");
+      if (!response.ok) {
+        lastError = new Error(`HTTP ${response.status}`);
+        if (attempt < maxAttempts) {
+          await delay(1000 * 2 ** (attempt - 1));
+          continue;
+        }
+        return { tenants: [], status: "error" };
+      }
+
+      const json = (await response.json()) as {
+        data?: PublicTenantBackend[];
+      };
+      const items = json.data ?? [];
+      return {
+        tenants: items.map((t) => ({
+          tenantId: 0,
+          slug: t.slug,
+          name: t.name,
+          subdomain: t.subdomain,
+          organizationId: 0,
+          organizationName: t.organization_name,
+          settings: {},
+        })),
+        status: "ok",
+      };
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxAttempts) {
+        await delay(1000 * 2 ** (attempt - 1));
+        continue;
+      }
     }
-    const json = (await response.json()) as { data?: PublicTenantBackend[] };
-    const items = json.data ?? [];
-    return items.map((t) => ({
-      tenantId: 0,
-      slug: t.slug,
-      name: t.name,
-      subdomain: t.subdomain,
-      organizationId: 0,
-      organizationName: t.organization_name,
-      settings: {},
-    }));
-  } catch {
-    return [];
   }
+
+  // All attempts exhausted
+  void lastError; // acknowledged but not rethrown — callers check status
+  return { tenants: [], status: "error" };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /** Backend response shape for account tenants (snake_case) */


### PR DESCRIPTION
The root tenant selector page treated both network failures and empty tenant lists as "Backend nicht erreichbar", causing a confusing error after registration redirect. Now listAllTenants() returns a typed status ("ok" vs "error") with retry + exponential backoff (3 attempts), so transient failures after redirect are absorbed and the UI shows distinct messages for backend errors vs genuinely empty tenant lists.

# Pull Request

## Description
<!-- Explain the changes you've made and why they're needed -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Configuration change
- [ ] Security improvement
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition/modification
- [ ] CI/CD improvement

## Related Issues
<!-- List any related issues using the following syntax:
- Fixes #123
- Addresses #456
- Related to #789
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Testing documentation updated

## Security Checklist
<!-- This section is mandatory for all PRs -->
- [ ] I have followed the [security guidelines](../docs/security.md)
- [ ] No sensitive information is committed (secrets, credentials, certificates)
- [ ] Environment variables are properly managed with templates
- [ ] Code does not contain hardcoded secrets
- [ ] No potential security vulnerabilities introduced

## Screenshots or Examples
<!-- Add screenshots or code examples if applicable -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have updated the documentation as needed
- [ ] All tests are passing
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and resolved any merge conflicts

## Additional Notes
<!-- Add any other context about the PR here -->