### PR TITLE
fix: show specific error for duplicate email in teacher create

### DIFF
--- a/frontend/src/components/teachers/teacher-form.tsx
+++ b/frontend/src/components/teachers/teacher-form.tsx
@@ -220,12 +220,18 @@ export function TeacherForm({
       // Submit the form
       await onSubmitAction(formData);
     } catch (err) {
-      logger.error("failed to submit form", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      setSubmitError(
-        "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.",
-      );
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      logger.error("failed to submit form", { error: errorMsg });
+
+      if (errorMsg.includes("email already exists")) {
+        setSubmitError(
+          "Es existiert bereits ein Konto mit dieser E-Mail-Adresse.",
+        );
+      } else {
+        setSubmitError(
+          "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.",
+        );
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
Map backend "email already exists" error to German user-facing message in teacher create form: "Es existiert bereits ein Konto mit dieser E-Mail-Adresse."

## Test plan
- [ ] Create teacher with email that already exists → shows specific error
- [ ] Create teacher with new email → works normally