### PR TITLE
fix: prevent deploy race conditions and orphan container failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,6 +288,9 @@ jobs:
   deploy-staging:
     needs: [check-environment, build-backend, build-frontend]
     if: needs.check-environment.outputs.should_deploy == 'true' && needs.check-environment.outputs.is_staging == 'true'
+    concurrency:
+      group: deploy-staging
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -360,6 +363,9 @@ jobs:
   deploy-demo:
     needs: [check-environment, build-backend, build-frontend]
     if: needs.check-environment.outputs.should_deploy == 'true' && needs.check-environment.outputs.is_demo == 'true'
+    concurrency:
+      group: deploy-demo
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -432,6 +438,9 @@ jobs:
   deploy-production:
     needs: [check-environment, build-backend, build-frontend]
     if: needs.check-environment.outputs.should_deploy == 'true' && needs.check-environment.outputs.is_staging == 'false' && needs.check-environment.outputs.is_demo == 'false'
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -28,6 +28,16 @@ echo "Starting $DEPLOY_DIR deployment ($DEPLOY_SHA)..."
 cp .env .env.rollback 2>/dev/null || true
 cp docker-compose.yml docker-compose.yml.rollback 2>/dev/null || true
 
+# ── Verify new config files were delivered by CI ──
+if [ ! -f .env.new ]; then
+  echo "FATAL: .env.new not found — SCP delivery failed or concurrent deploy consumed it"
+  exit 1
+fi
+if [ ! -f docker-compose.yml.new ]; then
+  echo "FATAL: docker-compose.yml.new not found — SCP delivery failed or concurrent deploy consumed it"
+  exit 1
+fi
+
 # ── Swap in new config ──
 mv .env.new .env
 mv docker-compose.yml.new docker-compose.yml
@@ -41,7 +51,7 @@ if ! docker compose pull; then
   echo "Pull failed, restoring old config"
   cp .env.rollback .env 2>/dev/null || true
   cp docker-compose.yml.rollback docker-compose.yml 2>/dev/null || true
-  docker compose up -d --wait 2>/dev/null || true
+  docker compose up -d --wait --remove-orphans 2>/dev/null || true
   exit 1
 fi
 
@@ -59,7 +69,7 @@ if [ ! -s "$BACKUP_FILE" ]; then
   cp .env.rollback .env 2>/dev/null || true
   cp docker-compose.yml.rollback docker-compose.yml 2>/dev/null || true
   docker compose pull 2>/dev/null || true
-  docker compose up -d --wait 2>/dev/null || true
+  docker compose up -d --wait --remove-orphans 2>/dev/null || true
   exit 1
 fi
 echo "Backup: $(basename "$BACKUP_FILE") ($(du -h "$BACKUP_FILE" | cut -f1))"
@@ -79,7 +89,7 @@ fi
 
 # ── Start services (skip if migration failed) ──
 if [ "$DEPLOY_FAILED" = "false" ]; then
-  if ! docker compose up -d --wait; then
+  if ! docker compose up -d --wait --remove-orphans; then
     echo "Healthcheck FAILED"
     DEPLOY_FAILED=true
   fi
@@ -116,7 +126,7 @@ fi
 cp .env.rollback .env 2>/dev/null || true
 cp docker-compose.yml.rollback docker-compose.yml 2>/dev/null || true
 
-if docker compose pull && docker compose up -d --wait; then
+if docker compose pull && docker compose up -d --wait --remove-orphans; then
   echo "Rollback successful — restored previous version"
   exit 10
 else


### PR DESCRIPTION
## Summary
- Add file existence checks in `deploy-remote.sh` to fail fast when `.env.new` or `docker-compose.yml.new` are missing, instead of silently continuing with stale config
- Add `--remove-orphans` to all `docker compose up` invocations to prevent orphan containers from blocking container name allocation
- Add `concurrency` groups to staging, demo, and production deploy jobs to serialize deploys per environment

## Context
Staging deploy failed on `3e2eb0ad` because `.env.new` and `docker-compose.yml.new` were missing on the server (likely consumed by a concurrent deploy from a rapid back-to-back merge). The `mv` commands failed silently, the deploy continued with stale config referencing a non-existent container ID, healthcheck failed, and rollback also failed because orphan containers from previous `docker compose run` commands held the container name.

## Test plan
- [ ] Merge this PR — the push to `development` will trigger a staging deploy, which validates the fix end-to-end
- [ ] Verify staging comes up on the latest SHA