### PR TITLE
refactor: extract shared DB restore into restore-db.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,6 +328,7 @@ jobs:
           scp -i ~/.ssh/deploy_key /tmp/staging.env root@$SSH_HOST:~/staging/.env.new
           scp -i ~/.ssh/deploy_key environments/staging.compose.yml root@$SSH_HOST:~/staging/docker-compose.yml.new
           scp -i ~/.ssh/deploy_key scripts/deploy-remote.sh root@$SSH_HOST:~/deploy-remote.sh
+          scp -i ~/.ssh/deploy_key scripts/restore-db.sh root@$SSH_HOST:~/restore-db.sh
 
           set +e
           ssh -i ~/.ssh/deploy_key root@$SSH_HOST \
@@ -403,6 +404,7 @@ jobs:
           scp -i ~/.ssh/deploy_key /tmp/demo.env root@$SSH_HOST:~/demo/.env.new
           scp -i ~/.ssh/deploy_key environments/demo.compose.yml root@$SSH_HOST:~/demo/docker-compose.yml.new
           scp -i ~/.ssh/deploy_key scripts/deploy-remote.sh root@$SSH_HOST:~/deploy-remote.sh
+          scp -i ~/.ssh/deploy_key scripts/restore-db.sh root@$SSH_HOST:~/restore-db.sh
 
           set +e
           ssh -i ~/.ssh/deploy_key root@$SSH_HOST \
@@ -478,6 +480,7 @@ jobs:
           scp -i ~/.ssh/deploy_key /tmp/production.env root@$SSH_HOST:~/production/.env.new
           scp -i ~/.ssh/deploy_key environments/production.compose.yml root@$SSH_HOST:~/production/docker-compose.yml.new
           scp -i ~/.ssh/deploy_key scripts/deploy-remote.sh root@$SSH_HOST:~/deploy-remote.sh
+          scp -i ~/.ssh/deploy_key scripts/restore-db.sh root@$SSH_HOST:~/restore-db.sh
 
           set +e
           ssh -i ~/.ssh/deploy_key root@$SSH_HOST \

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -112,6 +112,7 @@ jobs:
           SSH_HOST: ${{ steps.ssh.outputs.host }}
         run: |
           scp -i ~/.ssh/deploy_key scripts/rollback-remote.sh root@$SSH_HOST:~/rollback-remote.sh
+          scp -i ~/.ssh/deploy_key scripts/restore-db.sh root@$SSH_HOST:~/restore-db.sh
 
           set +e
           ssh -i ~/.ssh/deploy_key "root@${SSH_HOST}" \

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -112,72 +112,8 @@ fi
 echo "Deploy failed, initiating rollback..."
 docker compose stop server frontend 2>/dev/null || true
 
-echo "Restoring database from backup..."
-docker compose exec -T postgres psql -U postgres -d template1 -c "DROP DATABASE IF EXISTS postgres WITH (FORCE);" 2>/dev/null || true
-docker compose exec -T postgres psql -U postgres -d template1 -c "CREATE DATABASE postgres OWNER postgres TEMPLATE template0;"
-
-RESTORE_LOG=$(mktemp)
-if ! docker compose exec -T postgres pg_restore -U postgres -d postgres --exit-on-error < "$BACKUP_FILE" 2>"$RESTORE_LOG"; then
-  echo "CRITICAL: pg_restore failed with errors:"
-  cat "$RESTORE_LOG"
-  rm -f "$RESTORE_LOG"
-  exit 11
-fi
-rm -f "$RESTORE_LOG"
-
-# Verify restored DB has the role grants the app needs to function.
-# Checks all three roles the request path uses:
-#   phoenix_auth   — connection role, pre-auth queries (login, tenant resolve, operator refresh)
-#   phoenix_tenant — SET LOCAL ROLE per tenant request (tenant/tx.go:33)
-#   phoenix_admin  — SET LOCAL ROLE for cross-tenant ops (tenant/tx.go:63)
-if ! docker compose exec -T postgres psql -U postgres -d postgres -c "
-  DO \$\$ BEGIN
-    -- Role membership: phoenix_auth can SET ROLE to both
-    IF NOT pg_has_role('phoenix_auth', 'phoenix_tenant', 'MEMBER') THEN
-      RAISE EXCEPTION 'phoenix_auth is not a member of phoenix_tenant';
-    END IF;
-    IF NOT pg_has_role('phoenix_auth', 'phoenix_admin', 'MEMBER') THEN
-      RAISE EXCEPTION 'phoenix_auth is not a member of phoenix_admin';
-    END IF;
-
-    -- phoenix_auth: pre-auth paths (login, token refresh, operator auth)
-    IF NOT has_schema_privilege('phoenix_auth', 'auth', 'USAGE') THEN
-      RAISE EXCEPTION 'phoenix_auth lacks USAGE on schema auth';
-    END IF;
-    IF NOT has_schema_privilege('phoenix_auth', 'platform', 'USAGE') THEN
-      RAISE EXCEPTION 'phoenix_auth lacks USAGE on schema platform';
-    END IF;
-    IF NOT has_table_privilege('phoenix_auth', 'auth.accounts', 'SELECT') THEN
-      RAISE EXCEPTION 'phoenix_auth lacks SELECT on auth.accounts';
-    END IF;
-    IF NOT has_table_privilege('phoenix_auth', 'platform.operators', 'SELECT') THEN
-      RAISE EXCEPTION 'phoenix_auth lacks SELECT on platform.operators';
-    END IF;
-
-    -- phoenix_tenant: tenant-scoped request path (all CRUD after SET LOCAL ROLE)
-    IF NOT has_schema_privilege('phoenix_tenant', 'auth', 'USAGE') THEN
-      RAISE EXCEPTION 'phoenix_tenant lacks USAGE on schema auth';
-    END IF;
-    IF NOT has_schema_privilege('phoenix_tenant', 'active', 'USAGE') THEN
-      RAISE EXCEPTION 'phoenix_tenant lacks USAGE on schema active';
-    END IF;
-    IF NOT has_table_privilege('phoenix_tenant', 'auth.account_tenants', 'SELECT') THEN
-      RAISE EXCEPTION 'phoenix_tenant lacks SELECT on auth.account_tenants';
-    END IF;
-    IF NOT has_table_privilege('phoenix_tenant', 'active.visits', 'INSERT') THEN
-      RAISE EXCEPTION 'phoenix_tenant lacks INSERT on active.visits';
-    END IF;
-
-    -- phoenix_admin: cross-tenant ops (migrations, operator routes, exports)
-    IF NOT has_schema_privilege('phoenix_admin', 'platform', 'USAGE') THEN
-      RAISE EXCEPTION 'phoenix_admin lacks USAGE on schema platform';
-    END IF;
-    IF NOT has_table_privilege('phoenix_admin', 'platform.operators', 'SELECT') THEN
-      RAISE EXCEPTION 'phoenix_admin lacks SELECT on platform.operators';
-    END IF;
-  END \$\$;
-" > /dev/null 2>&1; then
-  echo "CRITICAL: Database restored but role privileges are missing — restore may have dropped ACLs"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if ! "$SCRIPT_DIR/restore-db.sh" "$BACKUP_FILE"; then
   exit 11
 fi
 

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# restore-db.sh — Restore a PostgreSQL database from a pg_dump backup.
+# Shared by deploy-remote.sh (rollback path) and rollback-remote.sh.
+#
+# Usage: ./restore-db.sh <backup_file>
+#
+# Expects a running postgres container reachable via `docker compose exec`.
+# Drops and recreates the database from template0, restores with
+# --exit-on-error, then verifies role grants for all three app roles.
+#
+# Exit codes:
+#   0  — Restore and verification succeeded
+#   1  — Restore or verification failed
+
+BACKUP_FILE="$1"
+
+if [ -z "$BACKUP_FILE" ]; then
+  echo "FATAL: Usage: restore-db.sh <backup_file>"
+  exit 1
+fi
+
+if [ ! -f "$BACKUP_FILE" ]; then
+  echo "FATAL: Backup file not found: $BACKUP_FILE"
+  exit 1
+fi
+
+echo "Restoring database from: $(basename "$BACKUP_FILE")"
+
+# ── Drop and recreate database from clean template ──
+docker compose exec -T postgres psql -U postgres -d template1 -c "DROP DATABASE IF EXISTS postgres WITH (FORCE);" 2>/dev/null || true
+docker compose exec -T postgres psql -U postgres -d template1 -c "CREATE DATABASE postgres OWNER postgres TEMPLATE template0;"
+
+# ── Restore with strict error handling ──
+RESTORE_LOG=$(mktemp)
+if ! docker compose exec -T postgres pg_restore -U postgres -d postgres --exit-on-error < "$BACKUP_FILE" 2>"$RESTORE_LOG"; then
+  echo "CRITICAL: pg_restore failed with errors:"
+  cat "$RESTORE_LOG"
+  rm -f "$RESTORE_LOG"
+  exit 1
+fi
+rm -f "$RESTORE_LOG"
+
+# ── Verify restored DB has the role grants the app needs to function ──
+# Checks all three roles the request path uses:
+#   phoenix_auth   — connection role, pre-auth queries (login, tenant resolve, operator refresh)
+#   phoenix_tenant — SET LOCAL ROLE per tenant request (tenant/tx.go:33)
+#   phoenix_admin  — SET LOCAL ROLE for cross-tenant ops (tenant/tx.go:63)
+if ! docker compose exec -T postgres psql -U postgres -d postgres -c "
+  DO \$\$ BEGIN
+    -- Role membership: phoenix_auth can SET ROLE to both
+    IF NOT pg_has_role('phoenix_auth', 'phoenix_tenant', 'MEMBER') THEN
+      RAISE EXCEPTION 'phoenix_auth is not a member of phoenix_tenant';
+    END IF;
+    IF NOT pg_has_role('phoenix_auth', 'phoenix_admin', 'MEMBER') THEN
+      RAISE EXCEPTION 'phoenix_auth is not a member of phoenix_admin';
+    END IF;
+
+    -- phoenix_auth: pre-auth paths (login, token refresh, operator auth)
+    IF NOT has_schema_privilege('phoenix_auth', 'auth', 'USAGE') THEN
+      RAISE EXCEPTION 'phoenix_auth lacks USAGE on schema auth';
+    END IF;
+    IF NOT has_schema_privilege('phoenix_auth', 'platform', 'USAGE') THEN
+      RAISE EXCEPTION 'phoenix_auth lacks USAGE on schema platform';
+    END IF;
+    IF NOT has_table_privilege('phoenix_auth', 'auth.accounts', 'SELECT') THEN
+      RAISE EXCEPTION 'phoenix_auth lacks SELECT on auth.accounts';
+    END IF;
+    IF NOT has_table_privilege('phoenix_auth', 'platform.operators', 'SELECT') THEN
+      RAISE EXCEPTION 'phoenix_auth lacks SELECT on platform.operators';
+    END IF;
+
+    -- phoenix_tenant: tenant-scoped request path (all CRUD after SET LOCAL ROLE)
+    IF NOT has_schema_privilege('phoenix_tenant', 'auth', 'USAGE') THEN
+      RAISE EXCEPTION 'phoenix_tenant lacks USAGE on schema auth';
+    END IF;
+    IF NOT has_schema_privilege('phoenix_tenant', 'active', 'USAGE') THEN
+      RAISE EXCEPTION 'phoenix_tenant lacks USAGE on schema active';
+    END IF;
+    IF NOT has_table_privilege('phoenix_tenant', 'auth.account_tenants', 'SELECT') THEN
+      RAISE EXCEPTION 'phoenix_tenant lacks SELECT on auth.account_tenants';
+    END IF;
+    IF NOT has_table_privilege('phoenix_tenant', 'active.visits', 'INSERT') THEN
+      RAISE EXCEPTION 'phoenix_tenant lacks INSERT on active.visits';
+    END IF;
+
+    -- phoenix_admin: cross-tenant ops (migrations, operator routes, exports)
+    IF NOT has_schema_privilege('phoenix_admin', 'platform', 'USAGE') THEN
+      RAISE EXCEPTION 'phoenix_admin lacks USAGE on schema platform';
+    END IF;
+    IF NOT has_table_privilege('phoenix_admin', 'platform.operators', 'SELECT') THEN
+      RAISE EXCEPTION 'phoenix_admin lacks SELECT on platform.operators';
+    END IF;
+  END \$\$;
+" > /dev/null 2>&1; then
+  echo "CRITICAL: Database restored but role privileges are missing — restore may have dropped ACLs"
+  exit 1
+fi
+
+echo "Database restored and verified"
+exit 0

--- a/scripts/rollback-remote.sh
+++ b/scripts/rollback-remote.sh
@@ -29,78 +29,12 @@ if [ "$RESTORE_DB" = "true" ]; then
     echo "No backup found in ~/backups/$DEPLOY_DIR/"
     exit 1
   fi
-  echo "Restoring DB from: $(basename "$BACKUP_FILE")"
-
   docker compose stop server frontend
 
-  docker compose exec -T postgres psql -U postgres -d template1 -c "DROP DATABASE IF EXISTS postgres WITH (FORCE);" 2>/dev/null || true
-  docker compose exec -T postgres psql -U postgres -d template1 -c "CREATE DATABASE postgres OWNER postgres TEMPLATE template0;"
-
-  RESTORE_LOG=$(mktemp)
-  if ! docker compose exec -T postgres pg_restore -U postgres -d postgres --exit-on-error < "$BACKUP_FILE" 2>"$RESTORE_LOG"; then
-    echo "CRITICAL: pg_restore failed with errors:"
-    cat "$RESTORE_LOG"
-    rm -f "$RESTORE_LOG"
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  if ! "$SCRIPT_DIR/restore-db.sh" "$BACKUP_FILE"; then
     exit 1
   fi
-  rm -f "$RESTORE_LOG"
-
-  # Verify restored DB has the role grants the app needs to function.
-  # Checks all three roles the request path uses:
-  #   phoenix_auth   — connection role, pre-auth queries (login, tenant resolve, operator refresh)
-  #   phoenix_tenant — SET LOCAL ROLE per tenant request (tenant/tx.go:33)
-  #   phoenix_admin  — SET LOCAL ROLE for cross-tenant ops (tenant/tx.go:63)
-  if ! docker compose exec -T postgres psql -U postgres -d postgres -c "
-    DO \$\$ BEGIN
-      -- Role membership: phoenix_auth can SET ROLE to both
-      IF NOT pg_has_role('phoenix_auth', 'phoenix_tenant', 'MEMBER') THEN
-        RAISE EXCEPTION 'phoenix_auth is not a member of phoenix_tenant';
-      END IF;
-      IF NOT pg_has_role('phoenix_auth', 'phoenix_admin', 'MEMBER') THEN
-        RAISE EXCEPTION 'phoenix_auth is not a member of phoenix_admin';
-      END IF;
-
-      -- phoenix_auth: pre-auth paths (login, token refresh, operator auth)
-      IF NOT has_schema_privilege('phoenix_auth', 'auth', 'USAGE') THEN
-        RAISE EXCEPTION 'phoenix_auth lacks USAGE on schema auth';
-      END IF;
-      IF NOT has_schema_privilege('phoenix_auth', 'platform', 'USAGE') THEN
-        RAISE EXCEPTION 'phoenix_auth lacks USAGE on schema platform';
-      END IF;
-      IF NOT has_table_privilege('phoenix_auth', 'auth.accounts', 'SELECT') THEN
-        RAISE EXCEPTION 'phoenix_auth lacks SELECT on auth.accounts';
-      END IF;
-      IF NOT has_table_privilege('phoenix_auth', 'platform.operators', 'SELECT') THEN
-        RAISE EXCEPTION 'phoenix_auth lacks SELECT on platform.operators';
-      END IF;
-
-      -- phoenix_tenant: tenant-scoped request path (all CRUD after SET LOCAL ROLE)
-      IF NOT has_schema_privilege('phoenix_tenant', 'auth', 'USAGE') THEN
-        RAISE EXCEPTION 'phoenix_tenant lacks USAGE on schema auth';
-      END IF;
-      IF NOT has_schema_privilege('phoenix_tenant', 'active', 'USAGE') THEN
-        RAISE EXCEPTION 'phoenix_tenant lacks USAGE on schema active';
-      END IF;
-      IF NOT has_table_privilege('phoenix_tenant', 'auth.account_tenants', 'SELECT') THEN
-        RAISE EXCEPTION 'phoenix_tenant lacks SELECT on auth.account_tenants';
-      END IF;
-      IF NOT has_table_privilege('phoenix_tenant', 'active.visits', 'INSERT') THEN
-        RAISE EXCEPTION 'phoenix_tenant lacks INSERT on active.visits';
-      END IF;
-
-      -- phoenix_admin: cross-tenant ops (migrations, operator routes, exports)
-      IF NOT has_schema_privilege('phoenix_admin', 'platform', 'USAGE') THEN
-        RAISE EXCEPTION 'phoenix_admin lacks USAGE on schema platform';
-      END IF;
-      IF NOT has_table_privilege('phoenix_admin', 'platform.operators', 'SELECT') THEN
-        RAISE EXCEPTION 'phoenix_admin lacks SELECT on platform.operators';
-      END IF;
-    END \$\$;
-  " > /dev/null 2>&1; then
-    echo "CRITICAL: Database restored but role privileges are missing — restore may have dropped ACLs"
-    exit 1
-  fi
-  echo "Database restored and verified"
 else
   docker compose stop server frontend
 fi


### PR DESCRIPTION
## Summary

- Extract the duplicated drop/create/restore/verify block (~65 lines) from `deploy-remote.sh` and `rollback-remote.sh` into a shared `scripts/restore-db.sh` helper
- Update CI workflows (`build.yml`, `rollback.yml`) to SCP the helper to the server alongside the deploy scripts
- No behavioral changes — same restore logic, same exit codes, same privilege verification

## Why

`deploy-remote.sh` (rollback path) and `rollback-remote.sh` had identical restore logic that would inevitably drift if only one was updated. Single source of truth for the restore flow.

## Test plan

- [ ] Verify `restore-db.sh` is executable and has correct shebang
- [ ] Verify `deploy-remote.sh` rollback still maps helper failure → exit 11
- [ ] Verify `rollback-remote.sh` maps helper failure → exit 1
- [ ] Verify all 4 SCP lines added (3 deploy envs + 1 rollback workflow)
- [ ] Next staging deploy validates the script is deployed and callable