### PR TITLE
fix: serve favicon on operator sub-subdomains

### DIFF
--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -92,33 +92,9 @@ describe("middleware", () => {
       expect(redirect).toBeNull();
     });
 
-    it("passes through /favicon.ico", () => {
-      const res = middleware(
-        makeRequest(
-          `http://${OPERATOR_HOSTNAME}/favicon.ico`,
-          OPERATOR_HOSTNAME,
-        ),
-      );
-
-      const rewrite = res.headers.get("x-middleware-rewrite");
-      const redirect = res.headers.get("location");
-      expect(rewrite).toBeNull();
-      expect(redirect).toBeNull();
-    });
-
-    it("passes through /images/* routes", () => {
-      const res = middleware(
-        makeRequest(
-          `http://${OPERATOR_HOSTNAME}/images/logo.png`,
-          OPERATOR_HOSTNAME,
-        ),
-      );
-
-      const rewrite = res.headers.get("x-middleware-rewrite");
-      const redirect = res.headers.get("location");
-      expect(rewrite).toBeNull();
-      expect(redirect).toBeNull();
-    });
+    // Note: favicon.ico, favicon.png, apple-touch-icon.png, site.webmanifest,
+    // icons/, and images/ are excluded from middleware via the matcher config.
+    // They never reach the middleware function in production.
 
     it("uses x-forwarded-host header when present", () => {
       const req = new NextRequest(`http://internal-host/suggestions`);

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -85,14 +85,9 @@ function handleOperatorSubdomain(request: NextRequest): NextResponse {
   }
 
   // Pass through: operator API routes, static assets
-  if (
-    pathname.startsWith("/api/") ||
-    pathname.startsWith("/_next") ||
-    pathname === "/favicon.ico" ||
-    pathname === "/site.webmanifest" ||
-    pathname.startsWith("/icons/") ||
-    pathname.startsWith("/images")
-  ) {
+  // Note: favicon.ico, favicon.png, apple-touch-icon.png, site.webmanifest,
+  // icons/, and images/ are excluded from the middleware matcher entirely.
+  if (pathname.startsWith("/api/") || pathname.startsWith("/_next")) {
     return withSecurityHeaders(NextResponse.next());
   }
 
@@ -206,5 +201,7 @@ export function middleware(request: NextRequest): NextResponse {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|images/).*)"],
+  matcher: [
+    "/((?!_next/static|_next/image|favicon\\.ico|favicon\\.png|apple-touch-icon\\.png|site\\.webmanifest|icons/|images/).*)",
+  ],
 };


### PR DESCRIPTION
## Summary
- Middleware matcher only excluded `favicon.ico` and `images/`, but layout metadata references `favicon.png`, `apple-touch-icon.png`, and `site.webmanifest`
- On sub-subdomains like `operator.staging.moto-app.de`, these paths hit the middleware, matched no pass-through rule in the operator handler, and got redirected to `/`
- **Also fixes tenant subdomains** (e.g. `{slug}.staging.moto-app.de`): paths like `/site.webmanifest` and `/apple-touch-icon.png` were not excluded by the matcher and had no pass-through in the tenant handler, so they got rewritten to `/{tenantSlug}/site.webmanifest` → 404
- Expanded the matcher to exclude all static favicon/manifest assets so Next.js serves them directly from `public/` regardless of subdomain depth
- Bonus: escaped dots in the matcher regex (`favicon\.ico` instead of `favicon.ico`) for correctness

## Test plan
- [ ] Verify favicon loads on `operator.staging.moto-app.de`
- [ ] Verify favicon still loads on `staging.moto-app.de`
- [ ] Verify favicon loads on tenant subdomains (e.g. `{slug}.staging.moto-app.de`)
- [ ] Verify `site.webmanifest` loads on tenant subdomains (was silently 404ing before)