### PR TITLE
fix: use jq for deploy notification JSON to fix broken Resend emails

### DIFF
--- a/.github/actions/notify-deploy-failure/action.yml
+++ b/.github/actions/notify-deploy-failure/action.yml
@@ -83,8 +83,29 @@ runs:
 
         BODY="<p>${STATUS}</p><p><a href=\"${RUN_URL}\">${LINK_TEXT}</a></p><p>${COMMIT_HTML}Triggered by: ${ACTOR}</p>"
 
-        curl -sS -X POST https://api.resend.com/emails \
+        # Build JSON payload with jq to safely encode special characters for the Resend API.
+        # This entire block is best-effort — notification failures must never mask the real deploy failure.
+        if ! PAYLOAD=$(jq -n \
+          --arg from "Phoenix CI <ci@ci.moto-app.de>" \
+          --argjson to "$NOTIFY_EMAILS" \
+          --arg subject "$SUBJECT" \
+          --arg html "$BODY" \
+          '{from: $from, to: $to, subject: $subject, html: $html}' 2>&1); then
+          echo "::warning::Failed to build email payload (non-critical): $PAYLOAD"
+          exit 0
+        fi
+
+        if ! HTTP_RESPONSE=$(curl -sS -o /tmp/resend_response.txt -w "%{http_code}" \
+          -X POST https://api.resend.com/emails \
           -H "Authorization: Bearer $RESEND_API_KEY" \
           -H "Content-Type: application/json" \
-          -d "{\"from\":\"Phoenix CI <ci@ci.moto-app.de>\",\"to\":${NOTIFY_EMAILS},\"subject\":\"${SUBJECT}\",\"html\":\"${BODY}\"}" \
-          || echo "WARNING: Email notification failed (non-critical)"
+          -d "$PAYLOAD" 2>&1); then
+          echo "::warning::Email notification request failed (non-critical): $HTTP_RESPONSE"
+          exit 0
+        fi
+
+        if [ "$HTTP_RESPONSE" -ge 200 ] 2>/dev/null && [ "$HTTP_RESPONSE" -lt 300 ] 2>/dev/null; then
+          echo "Email notification sent (HTTP $HTTP_RESPONSE)"
+        else
+          echo "::warning::Email notification rejected (HTTP $HTTP_RESPONSE, non-critical): $(cat /tmp/resend_response.txt 2>/dev/null)"
+        fi


### PR DESCRIPTION
## Summary

- Deploy failure email notifications via Resend have been silently broken since the action was added — the JSON payload was built via bash string interpolation, which broke on HTML characters (`<`, `>`, `"`, `—`) in the email body. Resend rejected every request with `400: Request body must be valid JSON`.
- Confirmed in today's two failed staging deploys (runs [23425517913](https://github.com/moto-nrw/project-phoenix/actions/runs/23425517913) and [23425538005](https://github.com/moto-nrw/project-phoenix/actions/runs/23425538005), exit codes 10 and 11).
- Switches to `jq` for proper JSON encoding and wraps both `jq` and `curl` in non-fatal guards (`exit 0` on failure) so notification issues never mask the real deploy failure.

## Test plan

- [ ] Merge to `development`, wait for staging deploy to succeed, then manually trigger a failure (e.g. temporarily break the deploy script) to confirm the email arrives
- [ ] Verify `::warning::` annotations appear in the Actions UI when notification fails (e.g. temporarily set an invalid `RESEND_API_KEY`)