### PR TITLE
fix: use tenant transaction in repository queries

### DIFF
--- a/backend/database/repositories/active/group.go
+++ b/backend/database/repositories/active/group.go
@@ -67,7 +67,7 @@ func (r *GroupRepository) FindActiveByRoomID(ctx context.Context, roomID int64) 
 // FindActiveByRoomIDAndDeviceID finds the active group in a room for a specific device.
 func (r *GroupRepository) FindActiveByRoomIDAndDeviceID(ctx context.Context, roomID int64, deviceID int64) (*active.Group, error) {
 	group := new(active.Group)
-	err := r.db.NewSelect().
+	err := base.GetDB(ctx, r.db).NewSelect().
 		Model(group).
 		ModelTableExpr(`active.groups AS "group"`).
 		Where(`"group".room_id = ?`, roomID).

--- a/backend/database/repositories/active/visits.go
+++ b/backend/database/repositories/active/visits.go
@@ -217,7 +217,7 @@ func (r *VisitRepository) FindWithActiveGroup(ctx context.Context, id int64) (*a
 	// Load active group separately — BUN Relation("ActiveGroup") does not
 	// resolve the schema:active tag for relation sub-queries.
 	group := new(active.Group)
-	err = r.db.NewSelect().
+	err = base.GetDB(ctx, r.db).NewSelect().
 		Model(group).
 		ModelTableExpr(`active.groups AS "group"`).
 		Where(`"group".id = ?`, visit.ActiveGroupID).
@@ -445,7 +445,7 @@ func (r *VisitRepository) GetCurrentByStudentIDWithRoom(ctx context.Context, stu
 	}
 
 	row := new(currentVisitRow)
-	err := r.db.NewSelect().
+	err := base.GetDB(ctx, r.db).NewSelect().
 		TableExpr(`active.visits AS "visit"`).
 		ColumnExpr(`"visit".id AS visit_id`).
 		ColumnExpr(`"visit".student_id AS visit_student_id`).
@@ -580,7 +580,7 @@ func (r *VisitRepository) GetCurrentByStudentIDs(ctx context.Context, studentIDs
 
 // CountActiveByRoomID counts active visits across all active groups in the given room.
 func (r *VisitRepository) CountActiveByRoomID(ctx context.Context, roomID int64) (int, error) {
-	count, err := r.db.NewSelect().
+	count, err := base.GetDB(ctx, r.db).NewSelect().
 		TableExpr(`active.visits AS "visit"`).
 		Join(`JOIN active.groups AS "group" ON "group".id = "visit".active_group_id`).
 		Where(`"group".room_id = ?`, roomID).
@@ -599,7 +599,7 @@ func (r *VisitRepository) CountActiveByRoomID(ctx context.Context, roomID int64)
 
 // CountActiveByGroupID counts active visits in the given active group.
 func (r *VisitRepository) CountActiveByGroupID(ctx context.Context, activeGroupID int64) (int, error) {
-	count, err := r.db.NewSelect().
+	count, err := base.GetDB(ctx, r.db).NewSelect().
 		TableExpr(`active.visits AS "visit"`).
 		Where(`"visit".active_group_id = ?`, activeGroupID).
 		Where(`"visit".exit_time IS NULL`).

--- a/backend/database/repositories/suggestions/comment_repository.go
+++ b/backend/database/repositories/suggestions/comment_repository.go
@@ -84,7 +84,7 @@ func (r *CommentRepository) FindByID(ctx context.Context, id int64) (*suggestion
 func (r *CommentRepository) FindByIDWithAuthor(ctx context.Context, id int64) (*suggestions.Comment, error) {
 	comment := new(suggestions.Comment)
 
-	err := r.db.NewSelect().
+	err := base.GetDB(ctx, r.db).NewSelect().
 		Model(comment).
 		ModelTableExpr(tableSuggestionsCommentsAlias).
 		ColumnExpr(`"comment".*`).


### PR DESCRIPTION
## Summary

- Six repository methods used `r.db.NewSelect()` directly instead of `base.GetDB(ctx, r.db).NewSelect()`, bypassing the tenant-scoped transaction
- These queries ran as `phoenix_auth` (connection pool default role) which lacks `USAGE` on the `active` schema
- This caused `permission denied for schema active` errors on IoT checkin (`POST /api/iot/checkin`) while `/api/iot/session/current` worked fine (it uses different repository methods that were already correct)
- Also fixed the same pattern in `suggestions/comment_repository.go` and `active/group.go`

**Fixed methods:**
| File | Method |
|------|--------|
| `active/visits.go` | `GetCurrentByStudentIDWithRoom` |
| `active/visits.go` | `FindWithActiveGroup` (sub-query) |
| `active/visits.go` | `CountActiveByRoomID` |
| `active/visits.go` | `CountActiveByGroupID` |
| `active/group.go` | `FindActiveByRoomIDAndDeviceID` |
| `suggestions/comment_repository.go` | `FindByIDWithAuthor` |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./database/repositories/active/...` passes
- [x] All lefthook checks pass (go-vet, golangci-lint, go-deadcode, git-secrets)
- [ ] Deploy to staging and verify IoT checkin works (scan RFID tag)