### PR TITLE
fix: use staff count instead of teacher count on database overview page

### DIFF
--- a/backend/services/database/database_service.go
+++ b/backend/services/database/database_service.go
@@ -80,17 +80,18 @@ func collectStudentStats(ctx context.Context, s *databaseService, claims jwt.App
 	}
 }
 
-// collectTeacherStats collects teacher statistics
+// collectTeacherStats collects staff/personal statistics
+// Uses Staff.List (not Teacher.List) to match what the personal page actually shows
 func collectTeacherStats(ctx context.Context, s *databaseService, claims jwt.AppClaims, response *StatsResponse) {
 	if !checkUserPermission(claims, permissions.UsersRead, permissions.UsersList) {
 		return
 	}
 
 	response.Permissions.CanViewTeachers = true
-	if teachers, err := s.repos.Teacher.List(ctx, nil); err != nil {
-		s.getLogger().ErrorContext(ctx, "Error counting teachers", slog.String("error", err.Error()))
+	if staff, err := s.repos.Staff.List(ctx, nil); err != nil {
+		s.getLogger().ErrorContext(ctx, "Error counting staff", slog.String("error", err.Error()))
 	} else {
-		response.Teachers = len(teachers)
+		response.Teachers = len(staff)
 	}
 }
 


### PR DESCRIPTION
The "Personal" count on the database overview used Teacher.List() (only users.teachers records), but the personal list page shows all staff via /api/staff. This caused a count mismatch when staff without teacher records (e.g. admins) existed. Now uses Staff.List() to match.

# Pull Request

## Description
<!-- Explain the changes you've made and why they're needed -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Configuration change
- [ ] Security improvement
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition/modification
- [ ] CI/CD improvement

## Related Issues
<!-- List any related issues using the following syntax:
- Fixes #123
- Addresses #456
- Related to #789
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Testing documentation updated

## Security Checklist
<!-- This section is mandatory for all PRs -->
- [ ] I have followed the [security guidelines](../docs/security.md)
- [ ] No sensitive information is committed (secrets, credentials, certificates)
- [ ] Environment variables are properly managed with templates
- [ ] Code does not contain hardcoded secrets
- [ ] No potential security vulnerabilities introduced

## Screenshots or Examples
<!-- Add screenshots or code examples if applicable -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have updated the documentation as needed
- [ ] All tests are passing
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and resolved any merge conflicts

## Additional Notes
<!-- Add any other context about the PR here -->