### PR TITLE
Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,84 @@
+# Getting Started
+
+## Prerequisites
+
+Install these before cloning:
+
+1. **direnv** -- https://direnv.net/docs/installation.html
+2. **devbox** -- https://www.jetpack.io/devbox/docs/installing_devbox/
+3. **Docker Desktop** -- https://docs.docker.com/get-docker/
+
+## Setup
+
+```bash
+git clone git@github.com:moto-nrw/project-phoenix.git
+cd project-phoenix
+direnv allow
+```
+
+Wait for devbox to install all dependencies (Go, Node, pnpm, etc.). This only happens once.
+
+Then run the setup script:
+
+```bash
+./scripts/setup-dev.sh
+```
+
+The script will:
+- Ask for your operator email and password (or generate random ones)
+- Create all config files (.env, docker-compose.yml, backend/dev.env, frontend/.env.local)
+- Generate SSL certificates for the local database
+- Print your credentials at the end
+
+**Save the credentials from the output. They won't be shown again.**
+
+## Starting the App
+
+```bash
+docker compose up -d
+```
+
+Wait for all services to start. First boot takes a minute because the backend runs all database migrations automatically.
+
+## Seeding Test Data
+
+The setup script prints the exact seed command with your credentials. It looks like this:
+
+```bash
+docker compose run server go run . seed \
+  --email operator@example.com \
+  --password 'YOUR_PASSWORD' \
+  --pin 1234 \
+  --url http://server:8080
+```
+
+The server container must be running (`docker compose up -d`) before you seed.
+
+After seeding, you get 20 staff accounts, 100 students, rooms, groups, and activities.
+
+## Logging In
+
+| URL | Purpose | Credentials |
+|-----|---------|-------------|
+| http://localhost:3000 | Tenant (school) app | Any staff account from seeder output (e.g. `demo1@mail.de` / `sdlXK26%`) |
+| http://operator.localhost:3000 | Operator dashboard | The operator email/password you chose during setup |
+
+## Common Commands
+
+| Task | Command |
+|------|---------|
+| Start all services | `docker compose up -d` |
+| Stop all services | `docker compose down` |
+| View logs | `docker compose logs -f server` |
+| Rebuild backend after Go changes | `docker compose build server && docker compose up -d server` |
+| Reset database | `docker compose run server go run . migrate reset` |
+| Run backend tests | `cd backend && go test ./...` |
+| Run frontend checks | `cd frontend && pnpm run check` |
+
+## Troubleshooting
+
+**"account is inactive" on login** -- The legacy admin account (`admin@example.com`) is disabled by design. Use a staff account from the seeder output or the operator dashboard.
+
+**SMTP errors in logs** -- Normal for local development. Email features (invitations, password reset) require SMTP configuration, which is not needed for development.
+
+**"no matching decryption secret"** -- Clear your browser cookies for localhost:3000 and try again. This happens when the NEXTAUTH_SECRET changes between sessions.

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,154 +1,232 @@
-#!/bin/bash
-# Development environment setup script for Project Phoenix
-# This script sets up a secure development environment by generating
-# configuration files from templates and generating SSL certificates.
+#!/usr/bin/env bash
+# ==============================================================================
+# Project Phoenix — Interactive Development Environment Setup
+#
+# Creates all git-ignored config files from templates, generates SSL certs,
+# and prints credentials at the end. Idempotent: existing files are never
+# overwritten (delete them first if you want to re-run).
+#
+# Usage:  ./scripts/setup-dev.sh
+# ==============================================================================
 
-# Exit on error
-set -e
+set -euo pipefail
 
-echo "==============================================="
-echo "Project Phoenix - Development Environment Setup"
-echo "==============================================="
-
-# Check if running from repository root
-if [[ ! -f "docker-compose.example.yml" ]]; then
-  echo "Error: This script must be run from the repository root" >&2
-  exit 1
+# ---------- colours (no-op when stdout is not a terminal) --------------------
+if [[ -t 1 ]]; then
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  RED='\033[0;31m'
+  BOLD='\033[1m'
+  DIM='\033[2m'
+  NC='\033[0m'
+else
+  GREEN='' YELLOW='' RED='' BOLD='' DIM='' NC=''
 fi
 
-# Colors for output
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
+# ---------- helpers ----------------------------------------------------------
+info()  { printf "${GREEN}✓${NC} %s\n" "$*"; }
+warn()  { printf "${YELLOW}⚠${NC} %s\n" "$*"; }
+err()   { printf "${RED}✗${NC} %s\n" "$*" >&2; }
+header() { printf "\n${BOLD}[%s]${NC} %s\n" "$1" "$2"; }
 
-# Function to generate random string for secrets
-generate_secret() {
-  openssl rand -base64 32 | tr -d '\n'
-  return 0
+generate_secret() { openssl rand -base64 32 | tr -d '/+\n' | cut -c1-44; }
+generate_password() { openssl rand -base64 16 | tr -d '/+\n' | cut -c1-22; }
+
+# Prompt with default. Usage: ask "Label" "default_value"
+# Sets REPLY to the user's answer (or default on empty input).
+ask() {
+  local label="$1" default="$2"
+  printf "  %s ${DIM}[%s]${NC}: " "$label" "$default"
+  read -r REPLY
+  REPLY="${REPLY:-$default}"
 }
 
-# 1. Creating environment files from templates
-echo -e "\n${YELLOW}Creating environment files from templates...${NC}"
+# Prompt yes/no with default Y. Usage: ask_yn "Question?"
+# Returns 0 (true) for yes, 1 (false) for no.
+ask_yn() {
+  local label="$1"
+  printf "  %s ${DIM}[Y/n]${NC}: " "$label"
+  read -r REPLY
+  [[ "${REPLY:-Y}" =~ ^[Yy]$ ]]
+}
 
-# 1.1 Main .env file
-if [[ ! -f ".env" ]]; then
-  echo "Creating .env file..."
+# Replace a placeholder value in a file. Pure bash, no sed.
+# Usage: replace_value FILE "PLACEHOLDER" "NEW_VALUE"
+replace_value() {
+  local file="$1" placeholder="$2" new_value="$3"
+  local tmp="${file}.tmp.$$"
+  while IFS= read -r line; do
+    printf '%s\n' "${line//$placeholder/$new_value}"
+  done < "$file" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+# ---------- pre-flight checks -----------------------------------------------
+if [[ ! -f "docker-compose.example.yml" ]]; then
+  err "This script must be run from the repository root."
+  exit 1
+fi
+
+echo ""
+echo "==========================================="
+echo " Project Phoenix — Dev Environment Setup"
+echo "==========================================="
+
+# ---------- Step 1: Collect credentials --------------------------------------
+header "1/4" "Database"
+
+if ask_yn "Generate a random database password?"; then
+  DB_PASSWORD="$(generate_password)"
+  info "Generated database password"
+else
+  ask "Database password" "postgres"
+  DB_PASSWORD="$REPLY"
+fi
+
+header "2/3" "Operator Account (platform admin)"
+
+ask "Email" "operator@example.com"
+OPERATOR_EMAIL="$REPLY"
+
+if ask_yn "Generate a random operator password?"; then
+  OPERATOR_PASSWORD="$(generate_password)"
+  info "Generated operator password"
+else
+  ask "Password" ""
+  OPERATOR_PASSWORD="$REPLY"
+  if [[ -z "$OPERATOR_PASSWORD" ]]; then
+    OPERATOR_PASSWORD="$(generate_password)"
+    warn "Empty password — generated one instead"
+  fi
+fi
+
+OPERATOR_DISPLAY_NAME="Administrator"
+
+# Secrets the user never needs to choose
+JWT_SECRET="$(generate_secret)"
+NEXTAUTH_SECRET="$(generate_secret)"
+PHOENIX_AUTH_PASSWORD="$(generate_password)"
+
+# ---------- Step 2: Create config files --------------------------------------
+header "3/3" "Creating config files"
+
+FILES_CREATED=()
+
+# --- .env (root) ---
+if [[ -f ".env" ]]; then
+  warn "Skipping .env — already exists"
+else
   cp .env.example .env
-  
-  # Generate secure random secrets
-  JWT_SECRET=$(generate_secret)
-  NEXTAUTH_SECRET=$(generate_secret)
-  DB_PASSWORD=$(openssl rand -base64 16 | tr -d '\n')
-  
-  # Replace placeholders with generated values
-  sed -i.bak "s/your_secure_db_password/$DB_PASSWORD/g" .env
-  sed -i.bak "s/your_jwt_secret_at_least_32_chars_long/$JWT_SECRET/g" .env
-  sed -i.bak "s/your_nextauth_secret_at_least_32_chars/$NEXTAUTH_SECRET/g" .env
-  rm .env.bak
-  echo -e "${GREEN}Created .env file with secure random secrets${NC}"
-else
-  echo -e "${YELLOW}Skipping .env - file already exists${NC}"
+  replace_value .env "your_secure_db_password"              "$DB_PASSWORD"
+  replace_value .env "your_jwt_secret_at_least_32_chars_long" "$JWT_SECRET"
+  replace_value .env "your_nextauth_secret_at_least_32_chars" "$NEXTAUTH_SECRET"
+  replace_value .env "OPERATOR_EMAIL=operator@example.com"  "OPERATOR_EMAIL=$OPERATOR_EMAIL"
+  replace_value .env "your_secure_operator_password"        "$OPERATOR_PASSWORD"
+  replace_value .env "OPERATOR_DISPLAY_NAME=Administrator"  "OPERATOR_DISPLAY_NAME=$OPERATOR_DISPLAY_NAME"
+  replace_value .env "PHOENIX_AUTH_PASSWORD=phoenix_auth_dev" "PHOENIX_AUTH_PASSWORD=$PHOENIX_AUTH_PASSWORD"
+  FILES_CREATED+=(".env")
+  info "Created .env"
 fi
 
-# 1.2 Backend dev.env file
-if [[ ! -f "backend/dev.env" ]]; then
-  echo "Creating backend/dev.env file..."
-  cp backend/dev.env.example backend/dev.env
-  
-  # Use the same JWT secret for consistency
-  grep -q "AUTH_JWT_SECRET" .env && JWT_SECRET=$(grep "AUTH_JWT_SECRET" .env | cut -d'=' -f2)
-  
-  # Replace placeholders
-  sed -i.bak "s/your_jwt_secret_at_least_32_chars_long/$JWT_SECRET/g" backend/dev.env
-  sed -i.bak "s/your_secure_admin_password/admin_dev_password/g" backend/dev.env
-  rm backend/dev.env.bak
-  echo -e "${GREEN}Created backend/dev.env file${NC}"
+# --- docker-compose.yml ---
+if [[ -f "docker-compose.yml" ]]; then
+  warn "Skipping docker-compose.yml — already exists"
 else
-  echo -e "${YELLOW}Skipping backend/dev.env - file already exists${NC}"
-fi
-
-# 1.3 Frontend .env.local file
-if [[ ! -f "frontend/.env.local" ]]; then
-  echo "Creating frontend/.env.local file..."
-  cp frontend/.env.example frontend/.env.local
-  
-  # Use the same NextAuth secret for consistency
-  grep -q "NEXTAUTH_SECRET" .env && NEXTAUTH_SECRET=$(grep "NEXTAUTH_SECRET" .env | cut -d'=' -f2)
-  
-  # Replace placeholders
-  sed -i.bak "s/your_nextauth_secret/$NEXTAUTH_SECRET/g" frontend/.env.local
-  sed -i.bak "s/your_auth_secret_key/$NEXTAUTH_SECRET/g" frontend/.env.local
-  rm frontend/.env.local.bak
-  echo -e "${GREEN}Created frontend/.env.local file${NC}"
-else
-  echo -e "${YELLOW}Skipping frontend/.env.local - file already exists${NC}"
-fi
-
-# 1.4 Docker compose file
-if [[ ! -f "docker-compose.yml" ]]; then
-  echo "Creating docker-compose.yml file..."
   cp docker-compose.example.yml docker-compose.yml
-  echo -e "${GREEN}Created docker-compose.yml file${NC}"
-else
-  echo -e "${YELLOW}Skipping docker-compose.yml - file already exists${NC}"
+  FILES_CREATED+=("docker-compose.yml")
+  info "Created docker-compose.yml"
 fi
 
-# 2. Generate SSL certificates for development
-echo -e "\n${YELLOW}Setting up SSL certificates...${NC}"
-
-# Check if certificates already exist
-if [[ ! -d "config/ssl/postgres/certs" || ! -f "config/ssl/postgres/certs/server.crt" ]]; then
-  echo "Generating PostgreSQL SSL certificates..."
-  cd config/ssl/postgres
-  chmod +x create-certs.sh
-  ./create-certs.sh
-  cd ../../..
-  echo -e "${GREEN}SSL certificates generated${NC}"
+# --- backend/dev.env ---
+if [[ -f "backend/dev.env" ]]; then
+  warn "Skipping backend/dev.env — already exists"
 else
-  echo -e "${YELLOW}Skipping SSL certificate generation - certificates already exist${NC}"
+  cp backend/dev.env.example backend/dev.env
+  replace_value backend/dev.env "your_jwt_secret_at_least_32_chars_long" "$JWT_SECRET"
+  replace_value backend/dev.env "your_db_password"                       "$DB_PASSWORD"
+  replace_value backend/dev.env "OPERATOR_EMAIL=operator@example.com"    "OPERATOR_EMAIL=$OPERATOR_EMAIL"
+  replace_value backend/dev.env "your_secure_operator_password"          "$OPERATOR_PASSWORD"
+  replace_value backend/dev.env "OPERATOR_DISPLAY_NAME=Administrator"    "OPERATOR_DISPLAY_NAME=$OPERATOR_DISPLAY_NAME"
+  replace_value backend/dev.env "PHOENIX_AUTH_PASSWORD=phoenix_auth_dev"  "PHOENIX_AUTH_PASSWORD=$PHOENIX_AUTH_PASSWORD"
+  FILES_CREATED+=("backend/dev.env")
+  info "Created backend/dev.env"
 fi
 
-# 3. Check Docker and Docker Compose
-echo -e "\n${YELLOW}Checking Docker and Docker Compose installation...${NC}"
+# --- frontend/.env.local ---
+if [[ -f "frontend/.env.local" ]]; then
+  warn "Skipping frontend/.env.local — already exists"
+else
+  cp frontend/.env.example frontend/.env.local
+  replace_value frontend/.env.local 'your_nextauth_secret'   "$NEXTAUTH_SECRET"
+  replace_value frontend/.env.local 'your_auth_secret_key'   "$NEXTAUTH_SECRET"
+  FILES_CREATED+=("frontend/.env.local")
+  info "Created frontend/.env.local"
+fi
 
-# Check for Docker
+# ---------- Step 3: SSL certificates ----------------------------------------
+echo ""
+if [[ -f "config/ssl/postgres/certs/server.crt" ]]; then
+  warn "Skipping SSL certificates — already exist"
+else
+  echo "  Generating PostgreSQL SSL certificates..."
+  (cd config/ssl/postgres && chmod +x create-certs.sh && ./create-certs.sh) > /dev/null 2>&1
+  info "Generated SSL certificates"
+fi
+
+# ---------- Step 4: Docker check --------------------------------------------
+echo ""
 if ! command -v docker &> /dev/null; then
-  echo -e "${RED}Error: Docker is not installed. Please install Docker first.${NC}" >&2
-  echo "Visit https://docs.docker.com/get-docker/ for installation instructions." >&2
+  err "Docker is not installed. Install it from https://docs.docker.com/get-docker/"
   exit 1
 fi
 
-# Check for Docker Compose - supports both V2 (built into Docker) and V1 (standalone)
-DOCKER_COMPOSE_FOUND=false
-
-# Try Docker Compose V2 (docker compose)
 if docker compose version &> /dev/null; then
-  DOCKER_COMPOSE_FOUND=true
-  echo -e "${GREEN}Docker Compose V2 detected${NC}"
-# Try Docker Compose V1 (docker-compose)
+  info "Docker Compose V2 detected"
 elif command -v docker-compose &> /dev/null; then
-  DOCKER_COMPOSE_FOUND=true
-  echo -e "${GREEN}Docker Compose V1 detected${NC}"
-fi
-
-if [[ "$DOCKER_COMPOSE_FOUND" = false ]]; then
-  echo -e "${RED}Error: Docker Compose is not installed. Please install Docker Compose first.${NC}" >&2
-  echo "Visit https://docs.docker.com/compose/install/ for installation instructions." >&2
+  info "Docker Compose V1 detected"
+else
+  err "Docker Compose is not installed. Install it from https://docs.docker.com/compose/install/"
   exit 1
 fi
 
-echo -e "${GREEN}Docker and Docker Compose are properly installed${NC}"
+# ---------- Summary ----------------------------------------------------------
+echo ""
+echo "==========================================="
+echo " Setup Complete!"
+echo "==========================================="
+echo ""
 
-# 4. Setup complete
-echo -e "\n${GREEN}Development environment setup complete!${NC}"
-echo -e "You can now start the development environment with: ${YELLOW}docker-compose up -d${NC}"
-echo -e "Access the application at: ${YELLOW}http://localhost:3000${NC}"
-echo -e "API will be available at: ${YELLOW}http://localhost:8080${NC}"
+if [[ ${#FILES_CREATED[@]} -gt 0 ]]; then
+  printf "${BOLD}Files created:${NC}\n"
+  for f in "${FILES_CREATED[@]}"; do
+    echo "  • $f"
+  done
+  echo ""
+fi
 
-echo -e "\n${YELLOW}Security Reminder:${NC}"
-echo "- NEVER commit .env, dev.env, or .env.local files to Git"
-echo "- Keep SSL certificates out of version control"
-echo "- For more information, read docs/security.md"
-
-exit 0
+printf "${BOLD}Your credentials:${NC}\n"
+echo ""
+printf "  ${DIM}Database${NC}\n"
+echo "  Password:          $DB_PASSWORD"
+echo ""
+printf "  ${DIM}Operator (platform admin)${NC}\n"
+echo "  Email:             $OPERATOR_EMAIL"
+echo "  Password:          $OPERATOR_PASSWORD"
+echo ""
+printf "  ${YELLOW}⚠ Save these credentials! They won't be shown again.${NC}\n"
+echo ""
+printf "${BOLD}Next steps:${NC}\n"
+echo "  1. docker compose up -d"
+echo "  2. docker compose run server go run . seed \\"
+echo "       --email $OPERATOR_EMAIL \\"
+echo "       --password '$OPERATOR_PASSWORD' \\"
+echo "       --pin 1234 \\"
+echo "       --url http://server:8080"
+echo ""
+echo "  3. Operator dashboard: http://operator.localhost:3000"
+echo "  4. Tenant login:       http://localhost:3000"
+echo "     (use any staff account from the seeder output)"
+echo ""
+printf "  ${DIM}SMTP is not configured — email features (invitations, password${NC}\n"
+printf "  ${DIM}reset) won't work. That's normal for local development.${NC}\n"
+echo ""


### PR DESCRIPTION
## Summary
- Rewrites `scripts/setup-dev.sh` as an interactive wizard with secure random defaults
- Adds `docs/getting-started.md` for new developer onboarding

## Changes
- **setup-dev.sh**: Interactive prompts for DB password and operator credentials (Enter = random). Pure bash string replacement (no `sed -i`). Prints credentials and copy-paste-ready seeder command at the end. Removes legacy admin account prompts.
- **getting-started.md**: Step-by-step guide from clone to running app (prerequisites, setup, seeding, login, common commands, troubleshooting).

## Test plan
- [x] Run `./scripts/setup-dev.sh` on a clean checkout (no .env files)
- [x] Verify all config files are created with correct values
- [x] `docker compose up -d` starts all services
- [x] Seeder runs successfully with printed command
- [x] Login works with staff account from seeder output