### PR TITLE
fix: add TenantTxMiddleware to student RFID device routes

### DIFF
--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -130,9 +130,13 @@ func (rs *Resource) Router() chi.Router {
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Post("/pickup-times/bulk", rs.getBulkPickupTimes)
 	})
 
-	// Device-authenticated routes for RFID devices
+	// Device-authenticated routes for RFID devices.
+	// DeviceAuthenticator validates API key + PIN and sets tenant context,
+	// then TenantTxMiddleware wraps each handler in a tenant-scoped transaction
+	// (SET LOCAL ROLE phoenix_tenant + set_config) so RLS is enforced.
 	r.Group(func(r chi.Router) {
 		r.Use(device.DeviceAuthenticator(rs.IoTService, rs.PersonService))
+		r.Use(tenant.TenantTxMiddleware(rs.db))
 
 		// RFID tag assignment endpoint
 		r.Post("/{id}/rfid", rs.assignRFIDTag)


### PR DESCRIPTION
## Summary
- Device-authenticated RFID routes (`POST/DELETE /api/students/{id}/rfid`) were missing `TenantTxMiddleware`
- Without it, queries ran without `SET LOCAL ROLE phoenix_tenant` or `set_config('app.current_tenant_id')`, causing PostgreSQL RLS to block access to `users.students` with "permission denied" (SQLSTATE=42501)
- PyrePortal received a 404 when trying to assign RFID tags to students on staging

## Root Cause
The IoT routes (`api/iot/api.go`) correctly chain `DeviceAuthenticator` + `TenantTxMiddleware`, but the student RFID routes (`api/students/api.go`) only had `DeviceAuthenticator` — the tenant DB middleware was never added when these routes were created.

## Fix
Added `r.Use(tenant.TenantTxMiddleware(rs.db))` to the device route group, matching the established pattern in `api/iot/api.go`.

## Test plan
- [ ] Deploy to staging and verify RFID tag assignment works from PyrePortal
- [ ] Confirm `POST /api/students/{id}/rfid` returns 200 (not 404) with valid device auth
- [ ] Confirm `DELETE /api/students/{id}/rfid` also works