### PR TITLE
refactor: extract common filter logic in student list helpers

### DIFF
--- a/backend/api/students/list_helpers.go
+++ b/backend/api/students/list_helpers.go
@@ -58,29 +58,8 @@ func (p *studentListParams) hasPersonFilters() bool {
 	return p.search != "" || p.firstName != "" || p.lastName != "" || p.location != ""
 }
 
-// buildQueryOptions creates query options from parameters
-func (p *studentListParams) buildQueryOptions() *base.QueryOptions {
-	queryOptions := base.NewQueryOptions()
-	filter := base.NewFilter()
-
-	if p.schoolClass != "" {
-		filter.ILike("school_class", "%"+p.schoolClass+"%")
-	}
-	if p.guardianName != "" {
-		filter.ILike("guardian_name", "%"+p.guardianName+"%")
-	}
-
-	// Add pagination only if no person-based filters
-	if !p.hasPersonFilters() {
-		queryOptions.WithPagination(p.page, p.pageSize)
-	}
-	queryOptions.Filter = filter
-
-	return queryOptions
-}
-
-// buildCountFilter creates a filter for counting records
-func (p *studentListParams) buildCountFilter() *base.Filter {
+// buildBaseFilter creates the base filter for both list and count
+func (p *studentListParams) buildBaseFilter() *base.Filter {
 	filter := base.NewFilter()
 	if p.schoolClass != "" {
 		filter.ILike("school_class", "%"+p.schoolClass+"%")
@@ -91,10 +70,23 @@ func (p *studentListParams) buildCountFilter() *base.Filter {
 	return filter
 }
 
+// buildQueryOptions creates query options from parameters
+func (p *studentListParams) buildQueryOptions() *base.QueryOptions {
+	queryOptions := base.NewQueryOptions()
+	queryOptions.Filter = p.buildBaseFilter()
+
+	// Add pagination only if no person-based filters
+	if !p.hasPersonFilters() {
+		queryOptions.WithPagination(p.page, p.pageSize)
+	}
+
+	return queryOptions
+}
+
 // buildCountOptions creates query options for counting records
 func (p *studentListParams) buildCountOptions() *base.QueryOptions {
 	countOptions := base.NewQueryOptions()
-	countOptions.Filter = p.buildCountFilter()
+	countOptions.Filter = p.buildBaseFilter()
 	return countOptions
 }
 


### PR DESCRIPTION
This PR refactors `backend/api/students/list_helpers.go` to eliminate duplication in the filter logic for student listing and counting.

Changes:
1. Extracted common filter logic into a new method `buildBaseFilter()`.
2. Updated `buildQueryOptions()` and `buildCountOptions()` to use `buildBaseFilter()`.
3. Removed the now redundant `buildCountFilter()` method.

The logic remains identical, including the preservation of pagination in `buildQueryOptions()` which is intentionally omitted from the count options.

Closes #1070