### PR TITLE
fix: prevent long suggestion titles from overflowing

### DIFF
--- a/frontend/src/app/operator/suggestions/page.tsx
+++ b/frontend/src/app/operator/suggestions/page.tsx
@@ -244,7 +244,7 @@ function OperatorSuggestionCard({
     <div className="rounded-3xl border border-gray-100/50 bg-white/90 shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md">
       <div className="p-5">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-          <h3 className="flex items-center gap-2 text-base font-semibold text-gray-900">
+          <h3 className="flex min-w-0 items-center gap-2 text-base font-semibold break-words text-gray-900">
             {suggestion.title}
             {suggestion.isNew && (
               <span className="shrink-0 rounded-full bg-blue-500 px-2 py-0.5 text-[10px] font-semibold text-white">

--- a/frontend/src/components/suggestions/suggestion-card.tsx
+++ b/frontend/src/components/suggestions/suggestion-card.tsx
@@ -58,7 +58,7 @@ export function SuggestionCard({
         {/* Content */}
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
-            <h3 className="text-base font-semibold text-gray-900">
+            <h3 className="min-w-0 text-base font-semibold break-words text-gray-900">
               {suggestion.title}
             </h3>
             <div className="flex shrink-0 items-center gap-2">


### PR DESCRIPTION
## Summary
- Add `break-words` to suggestion title `<h3>` in both tenant and operator cards
- Add `min-w-0` to operator card title to allow flex child shrinking
- Long unbreakable strings (e.g. "AAAA...") now wrap instead of overflowing horizontally

## Test plan
- [ ] Create a suggestion with a very long title (no spaces) — verify it wraps within the card
- [ ] Verify normal titles still render correctly
- [ ] Check both tenant and operator suggestion pages