### PR TITLE
fix: bypass RLS in device type rename migration

### DIFF
--- a/backend/database/migrations/001015016_rename_device_types.go
+++ b/backend/database/migrations/001015016_rename_device_types.go
@@ -32,13 +32,30 @@ func init() {
 func renameDeviceTypes(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Migration 1.15.16: Renaming legacy device types to 'terminal'...")
 
+	// Temporarily disable RLS on iot.devices so this cross-tenant UPDATE can reach all rows.
+	// Without this, the tenant isolation policy filters out every row (no app.current_tenant_id set).
+	if _, err := db.ExecContext(ctx, `ALTER TABLE iot.devices DISABLE ROW LEVEL SECURITY`); err != nil {
+		return fmt.Errorf("error disabling RLS on iot.devices: %w", err)
+	}
+
 	result, err := db.ExecContext(ctx, `
 		UPDATE iot.devices
 		SET device_type = 'terminal'
 		WHERE device_type IN ('rfid_reader', 'rfid_scanner', 'scanner', 'tablet', 'sensor', 'camera', 'beacon')
 	`)
 	if err != nil {
+		// Re-enable RLS even on failure
+		_, _ = db.ExecContext(ctx, `ALTER TABLE iot.devices ENABLE ROW LEVEL SECURITY`)
+		_, _ = db.ExecContext(ctx, `ALTER TABLE iot.devices FORCE ROW LEVEL SECURITY`)
 		return fmt.Errorf("error renaming device types: %w", err)
+	}
+
+	// Re-enable RLS + FORCE (matches the state set by migration 1.15.1)
+	if _, err := db.ExecContext(ctx, `ALTER TABLE iot.devices ENABLE ROW LEVEL SECURITY`); err != nil {
+		return fmt.Errorf("error re-enabling RLS on iot.devices: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE iot.devices FORCE ROW LEVEL SECURITY`); err != nil {
+		return fmt.Errorf("error re-forcing RLS on iot.devices: %w", err)
 	}
 
 	rows, _ := result.RowsAffected()
@@ -49,13 +66,26 @@ func renameDeviceTypes(ctx context.Context, db *bun.DB) error {
 func revertDeviceTypes(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Rolling back migration 1.15.16: Reverting device types to 'rfid_reader'...")
 
+	if _, err := db.ExecContext(ctx, `ALTER TABLE iot.devices DISABLE ROW LEVEL SECURITY`); err != nil {
+		return fmt.Errorf("error disabling RLS on iot.devices: %w", err)
+	}
+
 	_, err := db.ExecContext(ctx, `
 		UPDATE iot.devices
 		SET device_type = 'rfid_reader'
 		WHERE device_type = 'terminal'
 	`)
 	if err != nil {
+		_, _ = db.ExecContext(ctx, `ALTER TABLE iot.devices ENABLE ROW LEVEL SECURITY`)
+		_, _ = db.ExecContext(ctx, `ALTER TABLE iot.devices FORCE ROW LEVEL SECURITY`)
 		return fmt.Errorf("error reverting device types: %w", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `ALTER TABLE iot.devices ENABLE ROW LEVEL SECURITY`); err != nil {
+		return fmt.Errorf("error re-enabling RLS on iot.devices: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE iot.devices FORCE ROW LEVEL SECURITY`); err != nil {
+		return fmt.Errorf("error re-forcing RLS on iot.devices: %w", err)
 	}
 
 	fmt.Println("Migration 1.15.16: Successfully reverted device types")

--- a/backend/database/migrations/001015017_backfill_role_tenant_ids.go
+++ b/backend/database/migrations/001015017_backfill_role_tenant_ids.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	backfillRoleTenantIDsVersion     = "1.15.16"
+	backfillRoleTenantIDsVersion     = "1.15.17"
 	backfillRoleTenantIDsDescription = "Backfill tenant_id on custom roles from existing references, delete truly orphaned ones"
 )
 
@@ -49,7 +49,7 @@ func init() {
 // System roles (is_system = true) intentionally have NULL tenant_id and are
 // shared across all tenants, so they are left untouched.
 func backfillRoleTenantIDs(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.16: Backfilling tenant_id on non-system roles with NULL tenant_id...")
+	fmt.Println("Migration 1.15.17: Backfilling tenant_id on non-system roles with NULL tenant_id...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
@@ -84,7 +84,7 @@ func backfillRoleTenantIDs(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("error backfilling role tenant_id from account_roles: %w", err)
 	}
 	backfilledFromAR, _ := result.RowsAffected()
-	fmt.Printf("Migration 1.15.16: Backfilled %d role(s) from account_roles\n", backfilledFromAR)
+	fmt.Printf("Migration 1.15.17: Backfilled %d role(s) from account_roles\n", backfilledFromAR)
 
 	// Step 2: Backfill remaining NULL roles from invitation_tokens.
 	// invitation_tokens also has tenant_id (set by migration 1.14.2).
@@ -107,7 +107,7 @@ func backfillRoleTenantIDs(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("error backfilling role tenant_id from invitation_tokens: %w", err)
 	}
 	backfilledFromIT, _ := result.RowsAffected()
-	fmt.Printf("Migration 1.15.16: Backfilled %d role(s) from invitation_tokens\n", backfilledFromIT)
+	fmt.Printf("Migration 1.15.17: Backfilled %d role(s) from invitation_tokens\n", backfilledFromIT)
 
 	// Step 3: Mark pending invitation_tokens as expired for truly orphaned roles.
 	// These roles have no derivable tenant — the invitations are unusable anyway.
@@ -126,7 +126,7 @@ func backfillRoleTenantIDs(ctx context.Context, db *bun.DB) error {
 	}
 	expiredInvites, _ := result.RowsAffected()
 	if expiredInvites > 0 {
-		fmt.Printf("Migration 1.15.16: Expired %d invitation(s) referencing orphaned roles\n", expiredInvites)
+		fmt.Printf("Migration 1.15.17: Expired %d invitation(s) referencing orphaned roles\n", expiredInvites)
 	}
 
 	// Step 4: Clean up account_roles and role_permissions for truly orphaned roles.
@@ -161,7 +161,7 @@ func backfillRoleTenantIDs(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("error deleting orphaned non-system roles: %w", err)
 	}
 	deleted, _ := result.RowsAffected()
-	fmt.Printf("Migration 1.15.16: Deleted %d truly orphaned role(s) with no derivable tenant\n", deleted)
+	fmt.Printf("Migration 1.15.17: Deleted %d truly orphaned role(s) with no derivable tenant\n", deleted)
 
 	return tx.Commit()
 }


### PR DESCRIPTION
## Summary
- **Device type rename migration (1.15.16)** silently updated 0 rows because RLS tenant isolation policies filter all rows when `app.current_tenant_id` is not set. Now temporarily disables/re-enables RLS around the UPDATE.
- **Version collision fix** — `backfill_role_tenant_ids` was also registered as `1.15.16`, causing a `MigrationRegistry` map key collision. Bumped to `1.15.17`.
- Staging data was manually fixed via direct SQL UPDATE.

## Test plan
- [ ] Verify `migrate status` shows both `V001015016` and `V001015017` separately
- [ ] On a fresh DB with RLS enabled, confirm the rename migration updates device types correctly