### PR TITLE
fix: add TenantTxMiddleware to auth admin routes

### DIFF
--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -24,6 +24,7 @@ import (
 	authModel "github.com/moto-nrw/project-phoenix/models/auth"
 	"github.com/moto-nrw/project-phoenix/models/platform"
 	authService "github.com/moto-nrw/project-phoenix/services/auth"
+	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
 // Constants for permission strings, headers, route patterns, and error messages (S1192 - avoid duplicate string literals)
@@ -114,7 +115,13 @@ func (rs *Resource) Router() chi.Router {
 		r.Post("/password", rs.changePassword)
 
 		// Admin routes - require admin role or specific permissions
+		// TenantTxMiddleware wraps each request in a DB transaction as phoenix_tenant
+		// with RLS scoping (SET LOCAL ROLE + set_config). Without this, queries run
+		// as phoenix_auth which only has SELECT on auth tables.
+		withTx := tenant.TenantTxMiddleware(rs.db)
 		r.Group(func(r chi.Router) {
+			r.Use(withTx)
+
 			// Link existing account to current tenant (for multi-tenant staff creation)
 			r.With(authorize.RequiresPermission(permUsersCreate)).Post("/link-to-tenant", rs.linkToTenant)
 


### PR DESCRIPTION
## Summary
- Auth admin routes (`/auth/roles`, `/auth/permissions`, `/auth/accounts`) were missing `TenantTxMiddleware`, causing all DB queries to run as `phoenix_auth` instead of `phoenix_tenant`
- This caused `permission denied for table roles (SQLSTATE=42501)` when creating custom roles on staging
- GET endpoints were silently broken too — only system roles (NULL `tenant_id`) were visible since RLS had no tenant context

## Root Cause
Every other API module (`database`, `schedules`, `config`) applies `TenantTxMiddleware` correctly. The auth admin routes were missed during multi-tenancy integration.

## Test plan
- [x] `go test ./api/auth/...` — all pass
- [x] `go build ./...` — compiles clean
- [x] All lefthook checks pass (go-vet, golangci-lint, go-deadcode)
- [ ] After deploy to staging: create a custom role via `/database/roles` UI
- [ ] Verify existing system roles still display correctly