### PR TITLE
fix: student search filters from first character

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -79,9 +79,7 @@ function SearchPageContent() {
     }
 
     searchTimeoutRef.current = setTimeout(() => {
-      if (searchTerm.length >= 2 || searchTerm.length === 0) {
-        setDebouncedSearchTerm(searchTerm);
-      }
+      setDebouncedSearchTerm(searchTerm);
     }, 300);
 
     return () => {


### PR DESCRIPTION
## Summary
- Removed the `searchTerm.length >= 2` guard in the debounce logic on the student search page
- Search now triggers after any character input (with 300ms debounce), not only from the second character onwards
- Backend already handles single-character queries correctly — this was purely a frontend restriction

## Test plan
- [x] Type a single character in the student search — results should filter immediately
- [x] Verify clearing the search input resets the list
- [ ] Verify multi-character search still works as before