### PR TITLE
fix: show read-only activity modal for non-creators

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/activities/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.tsx
@@ -480,7 +480,7 @@ export default function ActivitiesPage() {
           onSuccess={handleManagementSuccess}
           activity={selectedActivity}
           currentStaffId={currentStaff?.id}
-          readOnly={false}
+          readOnly={!isActivityCreator(selectedActivity, currentStaff?.id)}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Activity management modal was always editable (`readOnly={false}` hardcoded), regardless of who created the activity
- Now uses `isActivityCreator(selectedActivity, currentStaff?.id)` to determine edit permissions
- Non-creators see disabled fields, no save/delete buttons, and an info message

## Test plan
- [ ] Log in as staff, open an activity **you created** → full edit/delete UI
- [ ] Open an activity **someone else created** → read-only view with info text
- [ ] Verify `/database/activities` (OGS-Büro) is unaffected — admins can still edit all activities