### PR TITLE
fix: prevent invitation accept from hanging when signOut fails

### DIFF
--- a/frontend/src/components/auth/invitation-accept-form.test.tsx
+++ b/frontend/src/components/auth/invitation-accept-form.test.tsx
@@ -568,7 +568,7 @@ describe("InvitationAcceptForm", () => {
       await waitFor(() => {
         // Should show the final fallback message, not redirect
         expect(
-          screen.getByText(/schließe alle Browser-Tabs/i),
+          screen.getByText(/lösche die Websitedaten/i),
         ).toBeInTheDocument();
         // Button should be gone
         expect(

--- a/frontend/src/components/auth/invitation-accept-form.tsx
+++ b/frontend/src/components/auth/invitation-accept-form.tsx
@@ -225,8 +225,9 @@ export function InvitationAcceptForm({
         </h3>
         {signOutRetryFailed ? (
           <p className="mb-4 text-sm text-gray-500">
-            Die vorherige Sitzung konnte nicht beendet werden. Bitte schließe
-            alle Browser-Tabs und öffne die Anmeldeseite in einem neuen Fenster.
+            Die vorherige Sitzung konnte nicht beendet werden. Bitte lösche die
+            Websitedaten in deinen Browsereinstellungen oder versuche es später
+            erneut.
           </p>
         ) : signOutFailed ? (
           <>


### PR DESCRIPTION
## Summary

- Wrap `signOut()` in try/catch during invitation acceptance so a rejected logout no longer strands the user on the "Konto erstellt" screen forever
- Move `setIsAccepted(true)` after `signOut()` attempt to prevent showing success state before session cleanup is attempted
- Update success message to "Bitte melde dich mit deinen neuen Zugangsdaten an." (clearer expectation that manual login follows)
- Add regression test: "redirects even when signOut fails"

## Test plan

- [x] `pnpm vitest run src/components/auth/invitation-accept-form.test.tsx` — 24/24 green
- [x] `pnpm run check` — 0 warnings, 0 errors
- [x] Lefthook pre-push hooks passed (knip, check, secrets)