### PR TITLE
chore: clarify migration dependency for users.profiles (1.2.2)

### DIFF
--- a/backend/database/migrations/001002002_users_profiles.go
+++ b/backend/database/migrations/001002002_users_profiles.go
@@ -19,7 +19,7 @@ func init() {
 	MigrationRegistry[UsersProfilesVersion] = &Migration{
 		Version:     UsersProfilesVersion,
 		Description: UsersProfilesDescription,
-		DependsOn:   []string{"1.0.9"}, // Depends on auth tables, not persons // TODO: Check why not dependent on persons
+		DependsOn:   []string{"1.0.9"}, // FK targets auth.accounts only — no dependency on users.persons needed
 	}
 
 	// Migration 1.2.2: Users profiles table


### PR DESCRIPTION
## Summary
- Remove open TODO in migration `001002002_users_profiles.go`
- Confirmed `users.profiles` has no dependency on `users.persons` (1.2.1)
- Replaced ambiguous comment with clear explanation

## Analysis

| Layer | Result |
|-------|--------|
| SQL DDL | Only FK: `account_id → auth.accounts(id)` — no reference to `users.persons` |
| Go Model (`profile.go`) | Only relation: `Account *auth.Account` — no `Person` field |
| Repository | All queries target `users.profiles` only — no JOINs with `users.persons` |
| Service Layer | `GetCurrentProfile` loads Account + Profile separately; Person loaded via separate service |

`Profile` and `Person` are independent concepts linked through `auth.accounts`, not through each other.

**Decision: Option A** — dependency on `1.0.9` is correct as-is. TODO removed, comment clarified.

## Test plan
- [x] `go vet ./database/migrations/` passes
- [x] `go build ./...` compiles
- [x] `go run main.go migrate validate` — all migrations validated successfully
- [x] `go run main.go migrate status` — correct order (V001002002 between V001002001 and V001002003)

Closes #1069