### PR TITLE
Release: full database backup with cluster globals

### DIFF
--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -62,10 +62,31 @@ docker compose stop server frontend
 mkdir -p ~/backups/"$DEPLOY_DIR"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 BACKUP_FILE=~/backups/$DEPLOY_DIR/backup-${TIMESTAMP}.dump
-docker compose exec -T postgres pg_dump -U postgres -d postgres -Fc > "$BACKUP_FILE"
-if [ ! -s "$BACKUP_FILE" ]; then
-  echo "Backup failed or empty, aborting deploy"
-  rm -f "$BACKUP_FILE"
+GLOBALS_FILE=~/backups/$DEPLOY_DIR/globals-${TIMESTAMP}.sql
+# Dump cluster globals (roles, passwords, tablespaces) — needed for full restore
+if ! docker compose exec -T postgres pg_dumpall -U postgres --globals-only > "$GLOBALS_FILE"; then
+  echo "pg_dumpall failed, aborting deploy"
+  rm -f "$GLOBALS_FILE"
+  cp .env.rollback .env 2>/dev/null || true
+  cp docker-compose.yml.rollback docker-compose.yml 2>/dev/null || true
+  docker compose pull 2>/dev/null || true
+  docker compose up -d --wait --remove-orphans 2>/dev/null || true
+  exit 1
+fi
+chmod 600 "$GLOBALS_FILE"
+# Dump database data + schema in custom format
+if ! docker compose exec -T postgres pg_dump -U postgres -d postgres -Fc > "$BACKUP_FILE"; then
+  echo "pg_dump failed, aborting deploy"
+  rm -f "$BACKUP_FILE" "$GLOBALS_FILE"
+  cp .env.rollback .env 2>/dev/null || true
+  cp docker-compose.yml.rollback docker-compose.yml 2>/dev/null || true
+  docker compose pull 2>/dev/null || true
+  docker compose up -d --wait --remove-orphans 2>/dev/null || true
+  exit 1
+fi
+if [ ! -s "$BACKUP_FILE" ] || [ ! -s "$GLOBALS_FILE" ]; then
+  echo "Backup files empty, aborting deploy"
+  rm -f "$BACKUP_FILE" "$GLOBALS_FILE"
   cp .env.rollback .env 2>/dev/null || true
   cp docker-compose.yml.rollback docker-compose.yml 2>/dev/null || true
   docker compose pull 2>/dev/null || true
@@ -104,6 +125,7 @@ if [ "$DEPLOY_FAILED" = "false" ]; then
   rm -f .env.rollback docker-compose.yml.rollback
   RETENTION_CUTOFF=$((BACKUP_RETENTION + 1))
   ls -t ~/backups/"$DEPLOY_DIR"/backup-*.dump 2>/dev/null | tail -n +"$RETENTION_CUTOFF" | xargs -r rm -v
+  ls -t ~/backups/"$DEPLOY_DIR"/globals-*.sql 2>/dev/null | tail -n +"$RETENTION_CUTOFF" | xargs -r rm -v
   echo "$DEPLOY_DIR deployment complete"
   exit 0
 fi

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -26,6 +26,36 @@ fi
 
 echo "Restoring database from: $(basename "$BACKUP_FILE")"
 
+# ── Restore cluster globals (roles, passwords) if available ──
+# Naming conventions:
+#   deploy-remote.sh: backup-YYYYMMDD-HHMMSS.dump → globals-YYYYMMDD-HHMMSS.sql
+#   backup.sh:        phoenix_env_YYYYMMDD_HHMMSS.dump → phoenix_env_YYYYMMDD_HHMMSS_globals.sql
+BACKUP_DIR=$(dirname "$BACKUP_FILE")
+BACKUP_BASE=$(basename "$BACKUP_FILE" .dump)
+GLOBALS_FILE=""
+
+# Try deploy-remote.sh naming: backup-* → globals-*
+if [[ "$BACKUP_BASE" == backup-* ]]; then
+  TIMESTAMP_PART="${BACKUP_BASE#backup-}"
+  GLOBALS_FILE="${BACKUP_DIR}/globals-${TIMESTAMP_PART}.sql"
+fi
+
+# Try backup.sh naming: phoenix_env_timestamp.dump → phoenix_env_timestamp_globals.sql
+if [ -z "$GLOBALS_FILE" ] || [ ! -f "$GLOBALS_FILE" ]; then
+  CANDIDATE="${BACKUP_DIR}/${BACKUP_BASE}_globals.sql"
+  if [ -f "$CANDIDATE" ]; then
+    GLOBALS_FILE="$CANDIDATE"
+  fi
+fi
+
+if [ -n "$GLOBALS_FILE" ] && [ -f "$GLOBALS_FILE" ]; then
+  echo "Restoring cluster globals from: $(basename "$GLOBALS_FILE")"
+  docker compose exec -T postgres psql -U postgres -d template1 < "$GLOBALS_FILE" 2>/dev/null || true
+  echo "Cluster globals restored (roles, passwords)"
+else
+  echo "WARNING: No globals file found — roles must already exist on this cluster"
+fi
+
 # ── Drop and recreate database from clean template ──
 docker compose exec -T postgres psql -U postgres -d template1 -c "DROP DATABASE IF EXISTS postgres WITH (FORCE);" 2>/dev/null || true
 docker compose exec -T postgres psql -U postgres -d template1 -c "CREATE DATABASE postgres OWNER postgres TEMPLATE template0;"


### PR DESCRIPTION
## Summary
- **Full backups**: All backup paths (CI deploy + cron) now include `pg_dumpall --globals-only` alongside `pg_dump`, capturing PostgreSQL roles (`phoenix_auth`, `phoenix_tenant`, `phoenix_admin`) and their passwords
- **Safer backups**: `pg_dump`/`pg_dumpall` exit codes are checked — corrupt partial dumps abort the deploy instead of proceeding silently
- **Globals-aware restore**: `restore-db.sh` auto-detects and applies the matching globals file before database restore
- **Security**: Globals files (`chmod 600`) are only readable by root since they contain role password hashes

## Also applied on server (not in this PR)
- `backup.sh` (cron): Updated with same fixes
- Staging cron backup added (`0 2 * * *`)
- Existing globals files secured with `chmod 600`

## Test plan
- [x] `backup.sh production` — globals file created with all 4 roles
- [x] `backup.sh staging` — globals file created
- [x] Verified restore-db.sh name matching for both naming conventions
- [x] Verified execution order: globals → DROP DB → CREATE DB → pg_restore
- [x] CI: 14/14 jobs green on development
- [x] Server checksums match repo