### PR TITLE
feat: show warning when reopening a manually edited work session

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -74,6 +74,7 @@ vi.mock("~/components/ui/modal", () => ({
   }) =>
     isOpen ? (
       <div data-testid="modal" data-title={title}>
+        {title && <h3>{title}</h3>}
         <button data-testid="modal-close" onClick={onClose}>
           close
         </button>

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -3851,9 +3851,6 @@ function TimeTrackingContent() {
               />
             </svg>
           </div>
-          <h2 className="text-xl font-bold text-gray-800">
-            Session manuell bearbeitet
-          </h2>
           <p className="mt-2 text-gray-600">
             Du hast diese Session manuell bearbeitet. Beim erneuten Einstempeln
             wird die Ausstempelzeit zurückgesetzt. Trotzdem einstempeln?
@@ -3865,7 +3862,7 @@ function TimeTrackingContent() {
       <Modal
         isOpen={pendingCheckIn !== null}
         onClose={handleClosePendingCheckIn}
-        title=""
+        title="Abwesenheit eingetragen"
         footer={
           <div className="flex w-full gap-3">
             <button
@@ -3903,9 +3900,6 @@ function TimeTrackingContent() {
               />
             </svg>
           </div>
-          <h2 className="text-xl font-bold text-gray-800">
-            Abwesenheit eingetragen
-          </h2>
           <p className="mt-2 text-gray-600">
             Für heute ist eine Abwesenheit eingetragen
             {todayAbsence


### PR DESCRIPTION
## Summary

Closes #1119

When a staff member manually edits a work session (e.g. adjusting check-in time or breaks) and then clicks check-in again, the session was reopened without any warning. This could be confusing since the check-out time gets reset while manual edits to check-in time and breaks are preserved.

- Add confirmation dialog when re-checking in after a manually edited session: "Du hast diese Session manuell bearbeitet. Beim erneuten Einstempeln wird die Ausstempelzeit zurückgesetzt. Trotzdem einstempeln?"
- Detect edits via existing `editCount` field on history data — no backend changes needed
- Chain correctly with the existing absence confirmation dialog (manual-edit warning shows first, then absence warning if applicable)
- Fix empty `title` on the new modal for screen reader accessibility
- Add 6 tests covering: modal show/hide, cancel, confirm, absence chaining, and active-session guard

## Test plan

- [x] `pnpm run check` passes (0 warnings, 0 errors)
- [x] All 171 tests pass including 6 new ones
- [x] Manual test: edit session → re-checkin → warning appears
- [x] Manual test: no edit → re-checkin → no warning
- [x] Manual test: cancel → no check-in
- [x] Manual test: confirm → check-in proceeds