### PR TITLE
fix: RLS bypass in active group visits/display endpoint

### DIFF
--- a/backend/api/active/api.go
+++ b/backend/api/active/api.go
@@ -1,6 +1,7 @@
 package active
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
 	"github.com/moto-nrw/project-phoenix/auth/authorize/policy"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	base "github.com/moto-nrw/project-phoenix/models/base"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 	"github.com/moto-nrw/project-phoenix/services/facilities"
 	"github.com/moto-nrw/project-phoenix/services/usercontext"
@@ -35,6 +37,15 @@ func (rs *Resource) getLogger() *slog.Logger {
 		return rs.logger
 	}
 	return slog.Default()
+}
+
+// getDB returns the tenant-scoped transaction from context if available, otherwise the base DB.
+// Raw rs.db queries bypass RLS — always use this instead.
+func (rs *Resource) getDB(ctx context.Context) bun.IDB {
+	if tx, ok := base.TxFromContext(ctx); ok && tx != nil {
+		return tx
+	}
+	return rs.db
 }
 
 // NewResource creates a new active resource

--- a/backend/api/active/groups_handlers.go
+++ b/backend/api/active/groups_handlers.go
@@ -80,7 +80,8 @@ func (rs *Resource) loadRoomsMap(r *http.Request, groups []*active.Group) map[in
 
 	if len(roomIDs) > 0 {
 		var rooms []*facilities.Room
-		err := rs.db.NewSelect().
+		db := rs.getDB(r.Context())
+		err := db.NewSelect().
 			Model(&rooms).
 			ModelTableExpr(`facilities.rooms AS "room"`).
 			Where(`"room".id IN (?)`, bun.List(roomIDs)).
@@ -329,7 +330,8 @@ type visitWithStudent struct {
 // fetchVisitsWithDisplayData fetches visits with student display data
 func (rs *Resource) fetchVisitsWithDisplayData(r *http.Request, activeGroupID int64) ([]visitWithStudent, error) {
 	var results []visitWithStudent
-	err := rs.db.NewSelect().
+	db := rs.getDB(r.Context())
+	err := db.NewSelect().
 		ColumnExpr("v.id AS visit_id").
 		ColumnExpr("v.student_id").
 		ColumnExpr("v.active_group_id").


### PR DESCRIPTION
## Summary

- Two raw `rs.db.NewSelect()` queries in `groups_handlers.go` bypassed the tenant-scoped transaction opened by `TenantTxMiddleware`, causing RLS to block all requests to `GET /api/active/groups/{id}/visits/display` since the multi-tenancy launch (2026-03-25)
- Added `getDB(ctx)` helper to the active Resource that extracts the tenant TX from context (same `TxFromContext` pattern used throughout services/repos), falling back to the base DB
- Fixes both `fetchVisitsWithDisplayData` (line 332 — the 500 errors) and `loadRoomsMap` (line 83 — silently returned empty room data)

## Context

**Production impact**: 5 x 500 errors on 2026-03-26 at 16:09, all from a single staff member opening the room supervision view. This endpoint will break for all staff tomorrow morning when the OGS day starts.

**Root cause**: `rs.db` runs on the `phoenix_auth` connection pool role (NOINHERIT, no privileges). The `TenantTxMiddleware` does `SET LOCAL ROLE phoenix_tenant` + `set_config('app.current_tenant_id', ...)` inside a transaction — but `rs.db.NewSelect()` bypasses that entirely. With FORCE RLS on `active.visits`, the RLS policy `tenant_id = current_setting('app.current_tenant_id')` evaluates to `tenant_id = NULL` → always false → error.

## Test plan

- [ ] Verify `go build ./api/active/...` passes (confirmed locally)
- [ ] Verify all lefthook pre-push checks pass (go-vet, golangci-lint, go-deadcode — confirmed locally)
- [ ] CI integration tests pass
- [ ] After deploy to staging: log in as staff, open supervised group view → visits load successfully
- [ ] Verify room data appears on active group list (loadRoomsMap fix)