### PR TITLE
fix: skip loading dev.env inside Docker containers

### DIFF
--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -46,7 +46,11 @@ func initConfig() {
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
-	} else {
+	} else if !isDocker() {
+		// Only load dev.env for local development (go run main.go serve).
+		// In Docker, all config comes from the docker-compose environment block.
+		// Loading dev.env inside Docker causes conflicts (e.g., DB_DSN pointing
+		// to localhost instead of the Docker network hostname).
 		viper.AddConfigPath(".")
 		viper.SetConfigName("dev")
 		viper.SetConfigType("env")
@@ -58,4 +62,10 @@ func initConfig() {
 	if viper.ReadInConfig() == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}
+}
+
+// isDocker reports whether the process is running inside a Docker container.
+func isDocker() bool {
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
 }

--- a/backend/dev.env.example
+++ b/backend/dev.env.example
@@ -15,11 +15,8 @@ DB_DEBUG=true
 APP_ENV=development
 
 # Database Connection
-# APP_ENV controls which defaults are used (see database/database_config.go).
-# Setting DB_DSN explicitly overrides the APP_ENV defaults.
-#   APP_ENV=development (default) → localhost:5432/postgres (sslmode=require)
-#   APP_ENV=test                  → localhost:5433/phoenix_test (sslmode=disable)
-#   APP_ENV=production            → requires explicit DB_DSN
+# DB_DSN overrides APP_ENV defaults. See database/database_config.go.
+# Docker ignores this file (/.dockerenv detection in cmd/root.go).
 DB_DSN=postgres://postgres:your_db_password@localhost:5432/postgres?sslmode=verify-ca&sslrootcert=../config/ssl/postgres/certs/ca.crt
 
 # Test database connection (used by automated tests via testpkg.SetupTestDB)


### PR DESCRIPTION
## Summary
- Detect Docker containers via `/.dockerenv` in `cmd/root.go` and skip loading `dev.env`
- In Docker, all config now comes exclusively from the docker-compose `environment:` block via `viper.AutomaticEnv()`
- Streamlined `dev.env.example` comments to reflect the new behavior

## Problem
The backend volume mount (`./backend:/app`) makes `dev.env` visible inside Docker. Viper loads it and values like `DB_DSN=postgres://...@localhost:5432/...` override the docker-compose environment block (`DB_DSN=postgres://...@postgres:5432/...`), causing connection failures.

## How it works
```
initConfig():
  1. --config flag?     → use that file (unchanged)
  2. !isDocker()?       → load ./dev.env (local dev, unchanged)
  3. isDocker()?        → skip file, AutomaticEnv() reads docker-compose env block
```

## Test plan
- [x] `go test ./cmd/...` — all 38 tests pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint` — 0 issues
- [x] `dotenv-linter diff` — dev.env and dev.env.example in sync
- [x] Lefthook pre-commit and pre-push hooks pass
- [ ] `docker compose build server && docker compose up` — server connects to postgres without auth errors