### PR TITLE
feat: add Mailpit for local email testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,14 +83,14 @@ OPERATOR_PASSWORD=your_secure_operator_password
 OPERATOR_DISPLAY_NAME=Administrator
 
 # Email configuration
-# SMTP settings for sending password reset and invitation emails
-# Port 465: Implicit SSL/TLS (recommended) - Port 587: STARTTLS (alternative)
-EMAIL_SMTP_HOST=smtp.example.com
-EMAIL_SMTP_PORT=465
-EMAIL_SMTP_USER=your_email@example.com
-EMAIL_SMTP_PASSWORD=your_smtp_password
-EMAIL_FROM_NAME=Your Organization
-EMAIL_FROM_ADDRESS=noreply@example.com
+# Local dev uses Mailpit (catches all emails, web UI at http://localhost:8025)
+# Production: Port 465 (implicit SSL/TLS) or 587 (STARTTLS) with real SMTP credentials
+EMAIL_SMTP_HOST=mailpit
+EMAIL_SMTP_PORT=1025
+EMAIL_SMTP_USER=
+EMAIL_SMTP_PASSWORD=
+EMAIL_FROM_NAME=moto Dev
+EMAIL_FROM_ADDRESS=noreply@localhost
 # In production environments FRONTEND_URL must use https:// scheme
 FRONTEND_URL=http://localhost:3000
 INVITATION_TOKEN_EXPIRY_HOURS=48

--- a/backend/dev.env.example
+++ b/backend/dev.env.example
@@ -74,14 +74,15 @@ OPERATOR_PASSWORD=your_secure_operator_password
 OPERATOR_DISPLAY_NAME=Administrator
 
 # Email configuration
-# SMTP settings for sending password reset and invitation emails
-# Port 465: Implicit SSL/TLS (recommended) - Port 587: STARTTLS (alternative)
-EMAIL_SMTP_HOST=smtp.example.com
-EMAIL_SMTP_PORT=465
-EMAIL_SMTP_USER=your_email@example.com
-EMAIL_SMTP_PASSWORD=your_smtp_password
-EMAIL_FROM_NAME=Your Organization
-EMAIL_FROM_ADDRESS=noreply@example.com
+# Local dev uses Mailpit (catches all emails, web UI at http://localhost:8025)
+# For local dev outside Docker, Mailpit is reachable at localhost:1025
+# Production: Port 465 (implicit SSL/TLS) or 587 (STARTTLS) with real SMTP credentials
+EMAIL_SMTP_HOST=localhost
+EMAIL_SMTP_PORT=1025
+EMAIL_SMTP_USER=
+EMAIL_SMTP_PASSWORD=
+EMAIL_FROM_NAME=moto Dev
+EMAIL_FROM_ADDRESS=noreply@localhost
 # In production environments FRONTEND_URL must use https:// scheme
 FRONTEND_URL=http://localhost:3000
 INVITATION_TOKEN_EXPIRY_HOURS=48

--- a/backend/email/smtp.go
+++ b/backend/email/smtp.go
@@ -38,9 +38,16 @@ func NewMailer() (Mailer, error) {
 
 	defaultFrom := NewEmail(viper.GetString("email_from_name"), viper.GetString("email_from_address"))
 
-	// Configure TLS based on port
+	// Configure TLS and auth based on port and credentials
 	var clientOpts []mail.Option
-	if smtp.Port == 465 {
+	switch {
+	case smtp.User == "" && smtp.Password == "":
+		// No credentials: plain SMTP without TLS (e.g., Mailpit on port 1025)
+		clientOpts = []mail.Option{
+			mail.WithPort(smtp.Port),
+			mail.WithTLSPolicy(mail.NoTLS),
+		}
+	case smtp.Port == 465:
 		// Port 465: Implicit SSL/TLS (SSL from connection start)
 		clientOpts = []mail.Option{
 			mail.WithSSLPort(false), // Use implicit SSL
@@ -48,7 +55,7 @@ func NewMailer() (Mailer, error) {
 			mail.WithUsername(smtp.User),
 			mail.WithPassword(smtp.Password),
 		}
-	} else {
+	default:
 		// Port 587: STARTTLS (upgrade to TLS after connect)
 		clientOpts = []mail.Option{
 			mail.WithPort(smtp.Port),

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -146,6 +146,16 @@ services:
       timeout: 1s
       retries: 2
 
+  # Local email testing — catches all SMTP emails and shows them in a web UI
+  # Web UI: http://localhost:8025 — API: http://localhost:8025/api/v1/messages
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "8025:8025"   # Web UI
+      - "1025:1025"   # SMTP
+    environment:
+      MP_MAX_MESSAGES: 500
+
   # Test database for integration tests
   # Start with: docker compose --profile test up -d postgres-test
   # Or run all tests: docker compose --profile test up -d


### PR DESCRIPTION
## Summary

- Adds **Mailpit** as a Docker Compose service for catching and viewing all dev emails in a web UI (http://localhost:8025)
- Updates SMTP client to support plain connections (no TLS, no auth) when credentials are empty — used by Mailpit on port 1025
- Updates `.env.example` and `backend/dev.env.example` with Mailpit-ready defaults

Replaces the MockMailer (stdout logging only) with a proper email testing tool so devs can visually inspect rendered HTML emails, verify links/tokens, and use the REST API for automated test assertions.

**Production is unaffected** — when SMTP credentials are set (as in SOPS env files), the existing TLS+auth paths are used.

## Setup

Zero config — works out of the box after `cp .env.example .env`:

```
EMAIL_SMTP_HOST=mailpit      # Docker service name, resolves automatically
EMAIL_SMTP_PORT=1025
EMAIL_SMTP_USER=             # empty = plain SMTP, no TLS
EMAIL_SMTP_PASSWORD=         # empty
EMAIL_FROM_NAME=moto Dev
EMAIL_FROM_ADDRESS=noreply@localhost
```

Just `docker compose up -d` and open http://localhost:8025 to see all captured emails. No accounts, no configuration needed.

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go vet ./email/...` passes
- [x] All 44 email package tests pass
- [x] All lefthook pre-commit + pre-push hooks pass
- [x] Mailpit container starts and accepts SMTP on :1025
- [x] Test email arrives and is visible in web UI at :8025
- [x] Mailpit REST API returns captured messages
- [ ] Verify invitation/password-reset emails render correctly in Mailpit after full stack `docker compose up`