### PR TITLE
fix: deduplicate students in IoT student list

### DIFF
--- a/backend/database/repositories/users/student.go
+++ b/backend/database/repositories/users/student.go
@@ -596,6 +596,7 @@ func (r *StudentRepository) FindAllWithGroups(ctx context.Context) ([]*users.Stu
 	err := r.newStudentWithGroupQuery(ctx, &results).
 		ColumnExpr(`COALESCE("group".name, '') AS "group_name"`).
 		Join(`LEFT JOIN education.groups AS "group" ON "group".id = "student".group_id`).
+		Distinct().
 		OrderExpr(`"person".last_name, "person".first_name`).
 		Scan(ctx)
 


### PR DESCRIPTION
## Summary
- `FindAllWithGroups()` LEFT JOINs `education.groups` without `DISTINCT`, causing duplicate student rows when a student has multiple group associations
- The sibling method `FindByTeacherIDWithGroups()` already had `.Distinct()` — this was just missing it
- Reported via PyrePortal: "Anna Meier" appeared twice in the student selection list

## Test plan
- [ ] Verify the `/api/iot/students` endpoint returns each student exactly once
- [ ] Check PyrePortal student list no longer shows duplicates