### PR TITLE
fix: add missing route handlers for operator persons tab

### DIFF
--- a/frontend/src/app/api/operator/provisioning/persons/[id]/route.test.ts
+++ b/frontend/src/app/api/operator/provisioning/persons/[id]/route.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { RouteContext } from "~/lib/route-wrapper-utils";
+
+const { mockAuth, mockFetch, mockGetServerApiUrl } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockFetch: vi.fn(),
+  mockGetServerApiUrl: vi.fn(() => "http://localhost:8080"),
+}));
+
+vi.mock("~/server/auth/operator", () => ({
+  operatorAuth: mockAuth,
+  uncachedOperatorAuth: mockAuth,
+}));
+
+vi.mock("~/server/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("~/lib/server-api-url", () => ({
+  getServerApiUrl: mockGetServerApiUrl,
+}));
+
+global.fetch = mockFetch as unknown as typeof fetch;
+
+import { DELETE } from "./route";
+
+describe("DELETE /api/operator/provisioning/persons/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("re-encodes decoded person ids before forwarding", async () => {
+    mockAuth.mockResolvedValue({ user: { token: "valid-token" } });
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 204,
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/operator/provisioning/persons/10%2Fevil%3Frole%3Dadmin",
+      {
+        method: "DELETE",
+      },
+    );
+    const context: RouteContext = {
+      params: Promise.resolve({ id: "10/evil?role=admin" }),
+    };
+
+    const response = await DELETE(request, context);
+
+    expect(response.status).toBe(204);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/operator/persons/10%2Fevil%3Frole%3Dadmin",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});

--- a/frontend/src/app/api/operator/provisioning/persons/[id]/route.ts
+++ b/frontend/src/app/api/operator/provisioning/persons/[id]/route.ts
@@ -4,12 +4,14 @@ import {
   isStringParam,
   operatorApiDelete,
 } from "~/lib/operator/route-wrapper";
+import { encodePathSegment } from "~/lib/route-wrapper-utils";
 
 export const DELETE = createOperatorDeleteHandler(
   async (_request: NextRequest, token: string, params) => {
     if (!isStringParam(params.id)) {
       throw new Error("Invalid id parameter");
     }
-    return await operatorApiDelete(`/operator/persons/${params.id}`, token);
+    const personId = encodePathSegment(params.id);
+    return await operatorApiDelete(`/operator/persons/${personId}`, token);
   },
 );

--- a/frontend/src/app/api/operator/provisioning/schools/[id]/persons/route.test.ts
+++ b/frontend/src/app/api/operator/provisioning/schools/[id]/persons/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { RouteContext } from "~/lib/route-wrapper-utils";
+
+const { mockAuth, mockFetch, mockGetServerApiUrl } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockFetch: vi.fn(),
+  mockGetServerApiUrl: vi.fn(() => "http://localhost:8080"),
+}));
+
+vi.mock("~/server/auth/operator", () => ({
+  operatorAuth: mockAuth,
+  uncachedOperatorAuth: mockAuth,
+}));
+
+vi.mock("~/server/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("~/lib/server-api-url", () => ({
+  getServerApiUrl: mockGetServerApiUrl,
+}));
+
+global.fetch = mockFetch as unknown as typeof fetch;
+
+import { GET } from "./route";
+
+describe("GET /api/operator/provisioning/schools/[id]/persons", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("re-encodes decoded school ids before forwarding", async () => {
+    mockAuth.mockResolvedValue({ user: { token: "valid-token" } });
+    const persons = [{ id: "person-1", first_name: "Ada" }];
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "success", data: persons }),
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/operator/provisioning/schools/10%2Fevil/persons",
+    );
+    const context: RouteContext = {
+      params: Promise.resolve({ id: "10/evil" }),
+    };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as { data?: unknown };
+    expect(json.data).toEqual(persons);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/operator/schools/10%2Fevil/persons",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+});

--- a/frontend/src/app/api/operator/provisioning/schools/[id]/persons/route.ts
+++ b/frontend/src/app/api/operator/provisioning/schools/[id]/persons/route.ts
@@ -4,15 +4,14 @@ import {
   isStringParam,
   operatorApiGet,
 } from "~/lib/operator/route-wrapper";
+import { encodePathSegment } from "~/lib/route-wrapper-utils";
 
 export const GET = createOperatorGetHandler(
   async (_request: NextRequest, token: string, params) => {
     if (!isStringParam(params.id)) {
       throw new Error("Invalid id parameter");
     }
-    return await operatorApiGet(
-      `/operator/schools/${params.id}/persons`,
-      token,
-    );
+    const schoolId = encodePathSegment(params.id);
+    return await operatorApiGet(`/operator/schools/${schoolId}/persons`, token);
   },
 );

--- a/frontend/src/lib/route-wrapper-utils.ts
+++ b/frontend/src/lib/route-wrapper-utils.ts
@@ -63,3 +63,7 @@ export function createUnauthorizedResponse(): NextResponse<ApiErrorResponse> {
 export function isStringParam(param: unknown): param is string {
   return typeof param === "string";
 }
+
+export function encodePathSegment(param: string): string {
+  return encodeURIComponent(param);
+}


### PR DESCRIPTION
## Summary
- The **Personen** tab in operator provisioning showed "Keine Personen" for all schools despite persons existing in the database
- Root cause: the Next.js API route handlers that proxy frontend requests to the backend were never created
- The backend endpoints (`GET /operator/schools/{id}/persons`, `DELETE /operator/persons/{id}`) exist and work correctly
- The frontend UI (tab, data fetching, display components) exists and works correctly
- Only the **bridge** (Next.js route handlers) was missing, causing 404s that the frontend silently treated as empty data

## Changes
- `GET /api/operator/provisioning/schools/[id]/persons` — proxies to backend person list
- `DELETE /api/operator/provisioning/persons/[id]` — proxies to backend soft-delete

## Test plan
- [ ] Open operator provisioning → Personen tab → select a school with persons → verify persons are listed
- [ ] Soft-delete a person → verify it disappears from the list