### PR TITLE
fix: remove guardian target role from announcements

### DIFF
--- a/backend/database/migrations/001015024_remove_guardian_announcement_role.go
+++ b/backend/database/migrations/001015024_remove_guardian_announcement_role.go
@@ -1,0 +1,83 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	removeGuardianAnnouncementRoleVersion     = "1.15.24"
+	removeGuardianAnnouncementRoleDescription = "Remove guardian from announcement target_roles (no guardian frontend exists)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     removeGuardianAnnouncementRoleVersion,
+		Description: removeGuardianAnnouncementRoleDescription,
+		DependsOn:   []string{"1.15.23"},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return createRemoveGuardianAnnouncementRole(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return rollbackRemoveGuardianAnnouncementRole(ctx, db)
+		},
+	)
+}
+
+func createRemoveGuardianAnnouncementRole(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.24: Removing guardian from announcement target_roles...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	// Remove 'guardian' from any existing target_roles arrays
+	_, err = tx.ExecContext(ctx, `
+		UPDATE platform.announcements
+		SET target_roles = array_remove(target_roles, 'guardian')
+		WHERE 'guardian' = ANY(target_roles);
+	`)
+	if err != nil {
+		return fmt.Errorf("error removing guardian from target_roles: %w", err)
+	}
+
+	// Update the column comment to reflect valid roles
+	_, err = tx.ExecContext(ctx, `
+		COMMENT ON COLUMN platform.announcements.target_roles IS
+		'Array of system role names (admin, user) that can see this announcement. Empty array means all roles.';
+	`)
+	if err != nil {
+		return fmt.Errorf("error updating column comment: %w", err)
+	}
+
+	fmt.Println("Migration 1.15.24: Successfully removed guardian from announcement target_roles")
+	return tx.Commit()
+}
+
+func rollbackRemoveGuardianAnnouncementRole(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.24: Restoring guardian column comment...")
+
+	// Restore original comment — we cannot restore removed array values
+	_, err := db.ExecContext(ctx, `
+		COMMENT ON COLUMN platform.announcements.target_roles IS
+		'Array of system role names (admin, user, guardian) that can see this announcement. Empty array means all roles.';
+	`)
+	if err != nil {
+		return fmt.Errorf("error restoring column comment: %w", err)
+	}
+
+	return nil
+}

--- a/backend/models/platform/announcement.go
+++ b/backend/models/platform/announcement.go
@@ -25,9 +25,8 @@ const (
 
 // Target role constants
 const (
-	RoleAdmin    = "admin"
-	RoleUser     = "user"
-	RoleGuardian = "guardian"
+	RoleAdmin = "admin"
+	RoleUser  = "user"
 )
 
 // MaxTargetIDs is the upper bound for target_org_ids and target_tenant_ids arrays.

--- a/frontend/src/app/operator/announcements/page.tsx
+++ b/frontend/src/app/operator/announcements/page.tsx
@@ -654,7 +654,7 @@ export default function OperatorAnnouncementsPage() {
               role="group"
               aria-labelledby="announcement-roles-label"
             >
-              {(["admin", "user", "guardian"] as const).map((role) => {
+              {(["admin", "user"] as const).map((role) => {
                 const isChecked = formData.targetRoles.includes(role);
                 return (
                   <button

--- a/frontend/src/lib/operator/announcements-helpers.test.ts
+++ b/frontend/src/lib/operator/announcements-helpers.test.ts
@@ -139,7 +139,6 @@ describe("label constants", () => {
 
   it("SYSTEM_ROLE_LABELS covers all roles", () => {
     expect(SYSTEM_ROLE_LABELS.admin).toBe("Administratoren");
-    expect(SYSTEM_ROLE_LABELS.user).toBe("Lehrer/Personal");
-    expect(SYSTEM_ROLE_LABELS.guardian).toBe("Erziehungsberechtigte");
+    expect(SYSTEM_ROLE_LABELS.user).toBe("Betreuer");
   });
 });

--- a/frontend/src/lib/operator/announcements-helpers.ts
+++ b/frontend/src/lib/operator/announcements-helpers.ts
@@ -1,12 +1,11 @@
 export type AnnouncementType = "announcement" | "release" | "maintenance";
 export type AnnouncementSeverity = "info" | "warning" | "critical";
 export type AnnouncementStatus = "draft" | "published" | "expired";
-export type SystemRole = "admin" | "user" | "guardian";
+export type SystemRole = "admin" | "user";
 
 export const SYSTEM_ROLE_LABELS: Record<SystemRole, string> = {
   admin: "Administratoren",
-  user: "Lehrer/Personal",
-  guardian: "Erziehungsberechtigte",
+  user: "Betreuer",
 };
 
 export interface BackendAnnouncement {


### PR DESCRIPTION
## Summary

- **Remove guardian (Erziehungsberechtigte) from announcement target roles** — guardians have no frontend portal, so targeting them in announcements had zero effect. The operator UI now only shows "Administratoren" and "Betreuer" as target audiences.
- **Rename user role label** from "Lehrer/Personal" to "Betreuer" to match the actual system role names.
- **Data migration (1.15.24)** strips `guardian` from any existing `target_roles` arrays in the database and updates the column comment.

## Changes

| File | What |
|------|------|
| `backend/models/platform/announcement.go` | Removed `RoleGuardian` constant |
| `backend/database/migrations/001015024_...go` | Migration: `array_remove(target_roles, 'guardian')` + updated column comment |
| `frontend/src/lib/operator/announcements-helpers.ts` | Removed `guardian` from `SystemRole` type, renamed label to "Betreuer" |
| `frontend/src/lib/operator/announcements-helpers.test.ts` | Updated test assertions |
| `frontend/src/app/operator/announcements/page.tsx` | Removed `guardian` from role checkbox list |

## Test plan

- [x] Backend compiles clean
- [x] Frontend `pnpm run check` passes (0 warnings, 0 errors)
- [x] Frontend unit tests pass (9/9)
- [x] All lefthook pre-push checks pass (go-vet, golangci-lint, knip, frontend-check)
- [x] Verify operator announcements page shows only "Administratoren" and "Betreuer" checkboxes
- [ ] Verify migration runs without error on test DB