### PR TITLE
fix: stabilize SSE proxy and dashboard revalidation

### DIFF
--- a/backend/database/query_hook.go
+++ b/backend/database/query_hook.go
@@ -2,6 +2,8 @@ package database
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -38,6 +40,10 @@ func (h *QueryHook) AfterQuery(_ context.Context, event *bun.QueryEvent) {
 	}
 
 	if event.Err != nil {
+		if errors.Is(event.Err, sql.ErrNoRows) {
+			h.logger.LogAttrs(context.Background(), slog.LevelDebug, "query no rows", attrs...)
+			return
+		}
 		attrs = append(attrs, slog.String("error", event.Err.Error()))
 		h.logger.LogAttrs(context.Background(), slog.LevelError, "query error", attrs...)
 		return

--- a/backend/database/query_hook_test.go
+++ b/backend/database/query_hook_test.go
@@ -1,0 +1,87 @@
+package database
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+func newTestQueryHook(t *testing.T) (*QueryHook, *bytes.Buffer) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	return NewQueryHook(logger), &buf
+}
+
+func TestQueryHookAfterQuery_DemotesNoRowsToDebug(t *testing.T) {
+	hook, buf := newTestQueryHook(t)
+
+	hook.AfterQuery(context.Background(), &bun.QueryEvent{
+		Query:     `SELECT * FROM users.profiles WHERE account_id = 1`,
+		StartTime: time.Now(),
+		Err:       sql.ErrNoRows,
+	})
+
+	output := buf.String()
+	if !strings.Contains(output, `"level":"DEBUG"`) {
+		t.Fatalf("expected debug level log, got %q", output)
+	}
+	if !strings.Contains(output, `"msg":"query no rows"`) {
+		t.Fatalf("expected no-rows message, got %q", output)
+	}
+	if strings.Contains(output, `"msg":"query error"`) {
+		t.Fatalf("expected query error message to be skipped, got %q", output)
+	}
+}
+
+func TestQueryHookAfterQuery_LogsNonNoRowsErrorsAtError(t *testing.T) {
+	hook, buf := newTestQueryHook(t)
+
+	hook.AfterQuery(context.Background(), &bun.QueryEvent{
+		Query:     `SELECT * FROM users.profiles WHERE account_id = 1`,
+		StartTime: time.Now(),
+		Err:       errors.New("boom"),
+	})
+
+	output := buf.String()
+	if !strings.Contains(output, `"level":"ERROR"`) {
+		t.Fatalf("expected error level log, got %q", output)
+	}
+	if !strings.Contains(output, `"msg":"query error"`) {
+		t.Fatalf("expected query error message, got %q", output)
+	}
+	if !strings.Contains(output, `"error":"boom"`) {
+		t.Fatalf("expected original error in log, got %q", output)
+	}
+}
+
+func TestQueryHookAfterQuery_LogsSlowQueriesAtWarn(t *testing.T) {
+	hook, buf := newTestQueryHook(t)
+
+	hook.AfterQuery(context.Background(), &bun.QueryEvent{
+		Query:     `SELECT * FROM users.profiles WHERE account_id = 1`,
+		StartTime: time.Now().Add(-10 * time.Millisecond),
+	})
+
+	output := buf.String()
+	if !strings.Contains(output, `"level":"WARN"`) {
+		t.Fatalf("expected warn level log, got %q", output)
+	}
+	if !strings.Contains(output, `"msg":"slow query"`) {
+		t.Fatalf("expected slow query message, got %q", output)
+	}
+	if !strings.Contains(output, `"slow_query":true`) {
+		t.Fatalf("expected slow_query marker, got %q", output)
+	}
+}

--- a/frontend/src/app/api/sse/events/route.test.ts
+++ b/frontend/src/app/api/sse/events/route.test.ts
@@ -31,6 +31,16 @@ function createMockRequest(path: string): NextRequest {
   return new NextRequest(url);
 }
 
+function createAbortableRequest(
+  path: string,
+  signal: AbortSignal,
+): NextRequest {
+  return {
+    nextUrl: new URL(path, "http://localhost:3000"),
+    signal,
+  } as unknown as NextRequest;
+}
+
 const defaultSession: ExtendedSession = {
   user: { id: "1", token: "test-token", name: "Test User" },
   expires: "2099-01-01",
@@ -92,6 +102,7 @@ describe("GET /api/sse/events", () => {
           Accept: "text/event-stream",
         },
         cache: "no-store",
+        signal: expect.any(AbortSignal),
       }),
     );
 
@@ -178,5 +189,99 @@ describe("GET /api/sse/events", () => {
     expect(response.status).toBe(500);
     const text = await response.text();
     expect(text).toBe("Internal server error");
+  });
+
+  it("aborts the upstream fetch when the client request aborts", async () => {
+    mockFetch.mockImplementationOnce((_url, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        if (init?.signal?.aborted) {
+          reject(new DOMException("Client disconnected", "AbortError"));
+          return;
+        }
+
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("Client disconnected", "AbortError")),
+          { once: true },
+        );
+      });
+    });
+
+    const controller = new AbortController();
+    const request = createAbortableRequest(
+      "/api/sse/events",
+      controller.signal,
+    );
+    const responsePromise = GET(request);
+
+    controller.abort();
+
+    const response = await responsePromise;
+
+    expect(response.status).toBe(204);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/sse/events",
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("cancels the upstream reader when the response body is cancelled", async () => {
+    const cancelSpy = vi.fn();
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: test\n\n"));
+      },
+      cancel() {
+        cancelSpy();
+      },
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      body: mockStream,
+    });
+
+    const request = createMockRequest("/api/sse/events");
+    const response = await GET(request);
+
+    await response.body?.cancel();
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a pending upstream read as normal cleanup after downstream cancellation", async () => {
+    let resolveRead:
+      | ((value: ReadableStreamReadResult<Uint8Array>) => void)
+      | null = null;
+    const cancelSpy = vi.fn(async () => {
+      resolveRead?.({ done: true, value: undefined });
+    });
+
+    const mockReader = {
+      read: vi.fn(
+        () =>
+          new Promise<ReadableStreamReadResult<Uint8Array>>((resolve) => {
+            resolveRead = resolve;
+          }),
+      ),
+      cancel: cancelSpy,
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      body: {
+        getReader: () => mockReader,
+      },
+    });
+
+    const request = createMockRequest("/api/sse/events");
+    const response = await GET(request);
+
+    const cancelPromise = response.body?.cancel();
+    await cancelPromise;
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/app/api/sse/events/route.ts
+++ b/frontend/src/app/api/sse/events/route.ts
@@ -8,6 +8,10 @@ const logger = createLogger({ component: "SSEEventsRoute" });
 // REQUIRED for streaming - must use Node.js runtime
 export const runtime = "nodejs";
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
 /**
  * SSE (Server-Sent Events) proxy endpoint
  * Streams real-time updates from backend to browser
@@ -27,6 +31,25 @@ export async function GET(request: NextRequest) {
     return new Response("Unauthorized", { status: 401 });
   }
 
+  const upstreamController = new AbortController();
+  let cleanedUp = false;
+
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    request.signal.removeEventListener("abort", handleClientAbort);
+  };
+
+  const handleClientAbort = () => {
+    upstreamController.abort();
+  };
+
+  if (request.signal.aborted) {
+    upstreamController.abort();
+  } else {
+    request.signal.addEventListener("abort", handleClientAbort, { once: true });
+  }
+
   try {
     // Fetch SSE stream from Go backend with JWT token
     // Preserve query params (e.g., cache busters) though backend ignores them
@@ -39,10 +62,12 @@ export async function GET(request: NextRequest) {
           Accept: "text/event-stream",
         },
         cache: "no-store",
+        signal: upstreamController.signal,
       },
     );
 
     if (!backendResponse.ok) {
+      cleanup();
       const body = await backendResponse.text().catch(() => "");
       logger.error("SSE backend connection failed", {
         status: backendResponse.status,
@@ -55,11 +80,58 @@ export async function GET(request: NextRequest) {
     }
 
     if (!backendResponse.body) {
+      cleanup();
       return new Response("No response body from backend", { status: 502 });
     }
 
+    const reader = backendResponse.body.getReader();
+    let downstreamCancelled = false;
+
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        try {
+          const { done, value } = await reader.read();
+
+          if (done) {
+            cleanup();
+            if (!downstreamCancelled) {
+              controller.close();
+            }
+            return;
+          }
+
+          if (value && !downstreamCancelled) {
+            controller.enqueue(value);
+          }
+        } catch (error) {
+          cleanup();
+
+          if (
+            downstreamCancelled ||
+            request.signal.aborted ||
+            isAbortError(error)
+          ) {
+            return;
+          }
+
+          controller.error(error);
+        }
+      },
+      async cancel() {
+        downstreamCancelled = true;
+        cleanup();
+        upstreamController.abort();
+
+        try {
+          await reader.cancel();
+        } catch {
+          // Upstream may already be closed when the client disconnects.
+        }
+      },
+    });
+
     // Stream backend SSE response to browser
-    return new Response(backendResponse.body, {
+    return new Response(stream, {
       headers: {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -69,6 +141,15 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (error) {
+    cleanup();
+
+    if (request.signal.aborted || isAbortError(error)) {
+      logger.debug("SSE proxy aborted", {
+        aborted_by_client: request.signal.aborted,
+      });
+      return new Response(null, { status: 204 });
+    }
+
     logger.error("SSE proxy error", {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -187,7 +187,7 @@ describe("useGlobalSSE", () => {
   });
 
   describe("event handling", () => {
-    it("invalidates student caches on student_checkin event", () => {
+    it("invalidates dashboard caches on student_checkin event as a fallback", () => {
       renderHook(() => useGlobalSSE());
 
       // Get the onMessage callback
@@ -210,9 +210,19 @@ describe("useGlobalSSE", () => {
 
       // Should call mutate with pattern matching function
       expect(mutate).toHaveBeenCalled();
+
+      const mutateCalls = vi.mocked(mutate).mock.calls;
+      const dashboardCall = mutateCalls.find((call) => {
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)("active-supervision-dashboard")
+        );
+      });
+      expect(dashboardCall).toBeDefined();
     });
 
-    it("invalidates student caches on student_checkout event", () => {
+    it("invalidates dashboard caches on student_checkout event as a fallback", () => {
       renderHook(() => useGlobalSSE());
 
       const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
@@ -226,7 +236,15 @@ describe("useGlobalSSE", () => {
 
       vi.advanceTimersByTime(500);
 
-      expect(mutate).toHaveBeenCalled();
+      const mutateCalls = vi.mocked(mutate).mock.calls;
+      const dashboardCall = mutateCalls.find((call) => {
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)("dashboard-analytics")
+        );
+      });
+      expect(dashboardCall).toBeDefined();
     });
 
     it("invalidates activity caches on activity_start event", () => {
@@ -467,7 +485,7 @@ describe("useGlobalSSE", () => {
       consoleSpy.mockRestore();
     });
 
-    it("handles mutate rejection for dashboard gracefully", async () => {
+    it("handles mutate rejection for dashboard gracefully on daily checkout", async () => {
       vi.mocked(mutate).mockRejectedValue(new Error("SWR error"));
 
       const consoleSpy = vi

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -60,6 +60,7 @@ export function useGlobalSSE(): SSEHookState {
   const pendingStudentIds = useRef(new Set<string>());
   const hasPendingActivityEvent = useRef(false);
   const hasPendingDashboardEvent = useRef(false);
+  const hasPendingDailyCheckoutDashboardEvent = useRef(false);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const flushInvalidations = useCallback(() => {
@@ -108,12 +109,16 @@ export function useGlobalSSE(): SSEHookState {
       });
     }
 
-    // Invalidate dashboard (student counts changed) — single broad invalidation
+    // Invalidate dashboard for activity events, explicit dashboard broadcasts,
+    // and student movement fallbacks. BroadcastToAll is best-effort, so a
+    // delivered student_checkin/student_checkout may be the only signal that
+    // counts changed if dashboard_counts_changed gets dropped under backpressure.
     if (
       pendingGroupIds.current.size > 0 ||
       pendingStudentIds.current.size > 0 ||
       hasPendingActivityEvent.current ||
-      hasPendingDashboardEvent.current
+      hasPendingDashboardEvent.current ||
+      hasPendingDailyCheckoutDashboardEvent.current
     ) {
       mutate(
         (key) =>
@@ -149,6 +154,7 @@ export function useGlobalSSE(): SSEHookState {
     pendingStudentIds.current.clear();
     hasPendingActivityEvent.current = false;
     hasPendingDashboardEvent.current = false;
+    hasPendingDailyCheckoutDashboardEvent.current = false;
   }, []);
 
   const scheduleFlush = useCallback(() => {
@@ -169,6 +175,11 @@ export function useGlobalSSE(): SSEHookState {
           // Target the specific student detail cache
           if (event.data.student_id) {
             pendingStudentIds.current.add(event.data.student_id);
+          }
+          // Daily "nach Hause" checkout emits only student_checkout on the
+          // educational group topic without a companion dashboard event.
+          if (event.type === "student_checkout" && !event.active_group_id) {
+            hasPendingDailyCheckoutDashboardEvent.current = true;
           }
           scheduleFlush();
           break;


### PR DESCRIPTION
## Summary
- abort upstream SSE proxy fetches when browser clients disconnect and guard downstream cancellation cleanup
- keep dashboard cache revalidation as a fallback for delivered student movement events while narrowing the heavier live invalidations
- demote expected `sql.ErrNoRows` query-hook noise to debug and add focused regression coverage

## Testing
- `cd frontend && pnpm exec vitest run 'src/app/api/sse/events/route.test.ts' 'src/lib/hooks/__tests__/use-global-sse.test.ts'`
- `cd frontend && pnpm run check`
- `cd backend && go test ./database -run TestQueryHook -v`

Closes #1006