### PR TITLE
[codex] Move deploy scripts into ~/scripts/ on server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,14 +272,15 @@ jobs:
 
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
 
+          ssh -i ~/.ssh/deploy_key root@$SSH_HOST "mkdir -p ~/scripts"
           scp -i ~/.ssh/deploy_key /tmp/staging.env root@$SSH_HOST:~/staging/.env.new
           scp -i ~/.ssh/deploy_key environments/staging.compose.yml root@$SSH_HOST:~/staging/docker-compose.yml.new
-          scp -i ~/.ssh/deploy_key scripts/deploy-remote.sh root@$SSH_HOST:~/deploy-remote.sh
-          scp -i ~/.ssh/deploy_key scripts/restore-db.sh root@$SSH_HOST:~/restore-db.sh
+          scp -i ~/.ssh/deploy_key scripts/deploy-remote.sh root@$SSH_HOST:~/scripts/deploy-remote.sh
+          scp -i ~/.ssh/deploy_key scripts/restore-db.sh root@$SSH_HOST:~/scripts/restore-db.sh
 
           set +e
           ssh -i ~/.ssh/deploy_key root@$SSH_HOST \
-            "DEPLOY_DIR=staging DEPLOY_SHA=$SHORT_SHA BACKUP_RETENTION=3 bash ~/deploy-remote.sh"
+            "DEPLOY_DIR=staging DEPLOY_SHA=$SHORT_SHA BACKUP_RETENTION=3 bash ~/scripts/deploy-remote.sh"
           DEPLOY_EXIT=$?
           set -e
 
@@ -348,14 +349,15 @@ jobs:
 
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
 
+          ssh -i ~/.ssh/deploy_key root@$SSH_HOST "mkdir -p ~/scripts"
           scp -i ~/.ssh/deploy_key /tmp/production.env root@$SSH_HOST:~/production/.env.new
           scp -i ~/.ssh/deploy_key environments/production.compose.yml root@$SSH_HOST:~/production/docker-compose.yml.new
-          scp -i ~/.ssh/deploy_key scripts/deploy-remote.sh root@$SSH_HOST:~/deploy-remote.sh
-          scp -i ~/.ssh/deploy_key scripts/restore-db.sh root@$SSH_HOST:~/restore-db.sh
+          scp -i ~/.ssh/deploy_key scripts/deploy-remote.sh root@$SSH_HOST:~/scripts/deploy-remote.sh
+          scp -i ~/.ssh/deploy_key scripts/restore-db.sh root@$SSH_HOST:~/scripts/restore-db.sh
 
           set +e
           ssh -i ~/.ssh/deploy_key root@$SSH_HOST \
-            "DEPLOY_DIR=production DEPLOY_SHA=$SHORT_SHA BACKUP_RETENTION=7 bash ~/deploy-remote.sh"
+            "DEPLOY_DIR=production DEPLOY_SHA=$SHORT_SHA BACKUP_RETENTION=7 bash ~/scripts/deploy-remote.sh"
           DEPLOY_EXIT=$?
           set -e
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -109,12 +109,13 @@ jobs:
           RESTORE_DB: ${{ inputs.restore_db }}
           SSH_HOST: ${{ steps.ssh.outputs.host }}
         run: |
-          scp -i ~/.ssh/deploy_key scripts/rollback-remote.sh root@$SSH_HOST:~/rollback-remote.sh
-          scp -i ~/.ssh/deploy_key scripts/restore-db.sh root@$SSH_HOST:~/restore-db.sh
+          ssh -i ~/.ssh/deploy_key "root@${SSH_HOST}" "mkdir -p ~/scripts"
+          scp -i ~/.ssh/deploy_key scripts/rollback-remote.sh root@$SSH_HOST:~/scripts/rollback-remote.sh
+          scp -i ~/.ssh/deploy_key scripts/restore-db.sh root@$SSH_HOST:~/scripts/restore-db.sh
 
           set +e
           ssh -i ~/.ssh/deploy_key "root@${SSH_HOST}" \
-            "TARGET_SHA=$TARGET_SHA DEPLOY_DIR=$DEPLOY_DIR RESTORE_DB=$RESTORE_DB bash ~/rollback-remote.sh"
+            "TARGET_SHA=$TARGET_SHA DEPLOY_DIR=$DEPLOY_DIR RESTORE_DB=$RESTORE_DB bash ~/scripts/rollback-remote.sh"
           ROLLBACK_EXIT=$?
           set -e
 

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # deploy-remote.sh — Runs ON the remote server during CI deployment.
-# SCP'd by CI alongside .env.new and docker-compose.yml.new.
+# SCP'd by CI into ~/scripts/ alongside restore-db.sh.
 #
 # Required env vars:
 #   DEPLOY_DIR        — Server directory (staging/demo/production)
@@ -123,6 +123,7 @@ if [ "$DEPLOY_FAILED" = "false" ]; then
   echo "DEPLOYED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .deploy-state
   echo "BACKUP_FILE=${BACKUP_FILE}" >> .deploy-state
   rm -f .env.rollback docker-compose.yml.rollback
+  rm -f ~/deploy-remote.sh ~/restore-db.sh
   RETENTION_CUTOFF=$((BACKUP_RETENTION + 1))
   ls -t ~/backups/"$DEPLOY_DIR"/backup-*.dump 2>/dev/null | tail -n +"$RETENTION_CUTOFF" | xargs -r rm -v
   ls -t ~/backups/"$DEPLOY_DIR"/globals-*.sql 2>/dev/null | tail -n +"$RETENTION_CUTOFF" | xargs -r rm -v

--- a/scripts/rollback-remote.sh
+++ b/scripts/rollback-remote.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # rollback-remote.sh — Runs ON the remote server during manual rollback.
-# SCP'd by CI, same pattern as deploy-remote.sh to avoid heredoc stdin bugs.
+# SCP'd by CI into ~/scripts/, same pattern as deploy-remote.sh to avoid heredoc stdin bugs.
 #
 # Required env vars:
 #   DEPLOY_DIR   — Server directory (staging/demo/production)
@@ -59,6 +59,8 @@ echo "CURRENT_SHA=${TARGET_SHA}" > .deploy-state
 echo "PREVIOUS_SHA=${PREVIOUS_SHA}" >> .deploy-state
 echo "DEPLOYED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .deploy-state
 echo "BACKUP_FILE=" >> .deploy-state
+
+rm -f ~/rollback-remote.sh ~/restore-db.sh
 
 echo "Rollback to ${TARGET_SHA} complete"
 exit 0


### PR DESCRIPTION
## Summary
Move the remote deploy helper scripts into `~/scripts/` instead of copying them into the server home directory.

## What Changed
- updated deploy workflows to create `~/scripts/`, copy `deploy-remote.sh` and `restore-db.sh` there, and execute the deploy helper from that location
- updated the rollback workflow to copy `rollback-remote.sh` and `restore-db.sh` into `~/scripts/` and execute the rollback helper from there
- kept the remote helper scripts resolving `restore-db.sh` relative to their own directory and added best-effort cleanup of stale legacy copies in `~/` after successful runs

## Validation
- `bash -n scripts/deploy-remote.sh`
- `bash -n scripts/rollback-remote.sh`
- `git diff --check -- .github/workflows/build.yml .github/workflows/rollback.yml scripts/deploy-remote.sh scripts/rollback-remote.sh`

Closes #1061
