### PR TITLE
fix: rename user role label from Lehrer/Personal to Betreuer

### DIFF
--- a/frontend/src/lib/operator/announcements-helpers.test.ts
+++ b/frontend/src/lib/operator/announcements-helpers.test.ts
@@ -139,7 +139,7 @@ describe("label constants", () => {
 
   it("SYSTEM_ROLE_LABELS covers all roles", () => {
     expect(SYSTEM_ROLE_LABELS.admin).toBe("Administratoren");
-    expect(SYSTEM_ROLE_LABELS.user).toBe("Lehrer/Personal");
+    expect(SYSTEM_ROLE_LABELS.user).toBe("Betreuer");
     expect(SYSTEM_ROLE_LABELS.guardian).toBe("Erziehungsberechtigte");
   });
 });

--- a/frontend/src/lib/operator/announcements-helpers.ts
+++ b/frontend/src/lib/operator/announcements-helpers.ts
@@ -5,7 +5,7 @@ export type SystemRole = "admin" | "user" | "guardian";
 
 export const SYSTEM_ROLE_LABELS: Record<SystemRole, string> = {
   admin: "Administratoren",
-  user: "Lehrer/Personal",
+  user: "Betreuer",
   guardian: "Erziehungsberechtigte",
 };
 


### PR DESCRIPTION
## Summary
- Rename announcement target role label from "Lehrer/Personal" to "Betreuer" to match actual system role names
- Update test assertion accordingly

Extracted from #1166 (closed) — only the label rename, guardian role remains untouched.

## Test plan
- [x] Frontend `pnpm run check` passes (0 warnings, 0 errors)
- [x] Frontend unit tests pass (9/9)
- [x] All lefthook pre-push checks pass
- [x] Verify operator announcements page shows "Betreuer" instead of "Lehrer/Personal"