### PR TITLE
fix: allow daily checkout without group room and fix empty select options

### DIFF
--- a/backend/api/iot/checkin/helpers.go
+++ b/backend/api/iot/checkin/helpers.go
@@ -75,8 +75,13 @@ func (rs *Resource) shouldShowDailyCheckoutWithGroup(ctx context.Context, studen
 	}
 
 	educationGroup, err := rs.EducationService.GetGroup(ctx, *student.GroupID)
-	if err != nil || educationGroup == nil || educationGroup.RoomID == nil {
+	if err != nil || educationGroup == nil {
 		return false
+	}
+
+	// If the group has no room assigned, daily checkout is available from any room
+	if educationGroup.RoomID == nil {
+		return true
 	}
 
 	return currentVisit.ActiveGroup.RoomID == *educationGroup.RoomID

--- a/frontend/src/components/ui/database/database-form.tsx
+++ b/frontend/src/components/ui/database/database-form.tsx
@@ -517,6 +517,11 @@ export function DatabaseForm<T = Record<string, unknown>>({
           ? field.options
           : (asyncOptions[field.name] ?? []);
 
+        // Check if options already include an empty-value option (e.g. "Kein Gruppenraum")
+        const hasEmptyOption = selectOptions.some(
+          (option) => option.value === "",
+        );
+
         return (
           <div>
             <label htmlFor={field.name} className={labelClasses}>
@@ -533,11 +538,13 @@ export function DatabaseForm<T = Record<string, unknown>>({
                 className={`${baseInputClasses} appearance-none pr-10`}
                 disabled={loadingOptions[field.name]}
               >
-                <option value="">
-                  {loadingOptions[field.name]
-                    ? "Optionen werden geladen..."
-                    : (field.placeholder ?? "Bitte wählen")}
-                </option>
+                {!hasEmptyOption && (
+                  <option value="">
+                    {loadingOptions[field.name]
+                      ? "Optionen werden geladen..."
+                      : (field.placeholder ?? "Bitte wählen")}
+                  </option>
+                )}
                 {selectOptions.map((option) => (
                   <option key={option.value} value={option.value}>
                     {option.label}


### PR DESCRIPTION
## Summary
- **Backend**: When an OGS group has no room assigned (`RoomID == nil`), daily checkout is now available from any room instead of being blocked entirely
- **Frontend**: Fix select dropdowns where options like "Kein Gruppenraum" with `value=""` were unselectable because they conflicted with the hardcoded placeholder option (also `value=""`)

## Test plan
- [ ] Create a group without a Gruppenraum → verify "Kein Gruppenraum" is selectable in the dropdown
- [ ] Edit an existing group → verify switching to "Kein Gruppenraum" works
- [ ] Student in a group without Gruppenraum → verify daily checkout appears after checkout time from any room
- [ ] Student in a group with Gruppenraum → verify daily checkout still only appears when in the group's room