### PR TITLE
chore: ignore hardcoded IP hotspots in test files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -33,5 +33,10 @@ sonar.coverage.exclusions=backend/test/**,backend/database/database_config.go,ba
 # Duplication exclusions - test files have intentionally similar patterns
 sonar.cpd.exclusions=**/*_test.go,backend/test/**
 
+# Ignore hardcoded IP address rule in test files (fake IPs in test fixtures)
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=go:S1313
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
+
 # Encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Suppress SonarCloud rule `go:S1313` (hardcoded IP address) in `*_test.go` files
- Clears 128 false-positive security hotspots caused by fake IPs in test fixtures

## Test plan
- [ ] Verify SonarCloud analysis no longer reports hardcoded IP hotspots from test files