### PR TITLE
fix: exclude test files from SonarCloud source analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,9 +15,10 @@ sonar.test.inclusions=**/*_test.go,**/*.test.ts,**/*.test.tsx,**/*.spec.ts
 sonar.go.coverage.reportPaths=backend/coverage.out
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
 
-# Exclusions (minimal - only non-code folders)
+# Exclusions — non-code folders + test files (test files are covered by sonar.tests/sonar.test.inclusions)
+# Test file exclusion prevents false-positive Security Hotspots (e.g. go:S1313 on fake IPs in fixtures)
 # Also exclude .sql files - SonarCloud doesn't support PostgreSQL, only Oracle PL/SQL
-sonar.exclusions=**/node_modules/**,**/.next/**,**/openspec/**,**/docs/**,**/templates/**,**/*.sql
+sonar.exclusions=**/node_modules/**,**/.next/**,**/openspec/**,**/docs/**,**/templates/**,**/*.sql,**/*_test.go,backend/test/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts
 
 # Coverage exclusions - non-production code that shouldn't affect coverage metrics
 # - backend/test/**: Test helpers/fixtures (not *_test.go but pure test infrastructure)
@@ -32,11 +33,6 @@ sonar.coverage.exclusions=backend/test/**,backend/database/database_config.go,ba
 
 # Duplication exclusions - test files have intentionally similar patterns
 sonar.cpd.exclusions=**/*_test.go,backend/test/**
-
-# Ignore hardcoded IP address rule in test files (fake IPs in test fixtures)
-sonar.issue.ignore.multicriteria=e1
-sonar.issue.ignore.multicriteria.e1.ruleKey=go:S1313
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
 
 # Encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Remove `sonar.issue.ignore.multicriteria` — does not work for Security Hotspots (only regular issues)
- Add test file patterns (`**/*_test.go`, `backend/test/**`, `**/*.test.ts`, etc.) to `sonar.exclusions`
- Test files remain in `sonar.tests` scope via `sonar.test.inclusions` for coverage/test metrics
- Fixes 128 false-positive Security Hotspots (go:S1313 hardcoded IP in test fixtures)

## Why the previous approach failed
`sonar.issue.ignore.multicriteria` only suppresses Issues (bugs, code smells, vulnerabilities) — not Security Hotspots, which are a separate concept in SonarCloud. Confirmed by community reports and the failed Quality Gate on #1197.

## Test plan
- [ ] SonarCloud Quality Gate passes (Security Rating ≥ A)
- [ ] Security Hotspots from test files no longer appear
- [ ] Coverage metrics still report correctly (coverage comes from `coverage.out`, not test file analysis)