### PR TITLE
feat: add info alert to pickup note modals about NFC tablet visibility

### DIFF
--- a/frontend/src/components/students/pickup-day-edit-modal.tsx
+++ b/frontend/src/components/students/pickup-day-edit-modal.tsx
@@ -10,6 +10,7 @@ import {
   getWeekdayLabel,
   formatShortDate,
 } from "@/lib/pickup-schedule-helpers";
+import { Alert } from "~/components/ui/alert";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "PickupDayEdit" });
@@ -315,6 +316,13 @@ export function PickupDayEditModal({
                 Notiz hinzufügen
               </button>
             )}
+          </div>
+
+          <div className="mb-3">
+            <Alert
+              type="info"
+              message="Diese Notiz wird auch auf den NFC-Tablets angezeigt und ist für Kinder einsehbar."
+            />
           </div>
 
           {/* Existing notes */}

--- a/frontend/src/components/students/pickup-schedule-form-modal.tsx
+++ b/frontend/src/components/students/pickup-schedule-form-modal.tsx
@@ -9,6 +9,7 @@ import type {
   PickupScheduleFormData,
 } from "@/lib/pickup-schedule-helpers";
 import { WEEKDAYS } from "@/lib/pickup-schedule-helpers";
+import { Alert } from "~/components/ui/alert";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "PickupScheduleForm" });
@@ -130,6 +131,12 @@ export function PickupScheduleFormModal({
           Zeiten und Notizen gelten wöchentlich wiederkehrend für jeden
           Wochentag.
         </p>
+        <div className="mb-4">
+          <Alert
+            type="info"
+            message="Abholzeiten und Notizen werden auch auf den NFC-Tablets angezeigt und sind für Kinder einsehbar."
+          />
+        </div>
         {error && (
           <div
             ref={errorRef}


### PR DESCRIPTION
## Summary
- Adds an inline info alert to the **daily note modal** (PickupDayEditModal) and the **weekly schedule editor** (PickupScheduleFormModal)
- Informs staff that pickup notes and times are visible to children on the NFC tablets
- Reuses the existing `Alert` component (`ui/alert.tsx`) with `type="info"`

## Test plan
- [ ] Open a student detail page → click a day in the pickup schedule → verify the blue info banner appears above the notes section
- [ ] Click "Wöchentlichen Abholplan bearbeiten" → verify the info banner appears below the description text
- [ ] Verify both modals still function correctly (create/edit/delete notes, save schedules)