### PR TITLE
feat: custom login image upload for tenant settings

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -19,6 +19,7 @@ import (
 	activitiesAPI "github.com/moto-nrw/project-phoenix/api/activities"
 	adminAPI "github.com/moto-nrw/project-phoenix/api/admin"
 	authAPI "github.com/moto-nrw/project-phoenix/api/auth"
+	apiCommon "github.com/moto-nrw/project-phoenix/api/common"
 	configAPI "github.com/moto-nrw/project-phoenix/api/config"
 	databaseAPI "github.com/moto-nrw/project-phoenix/api/database"
 	feedbackAPI "github.com/moto-nrw/project-phoenix/api/feedback"
@@ -386,6 +387,12 @@ func (a *API) registerRoutesWithRateLimiting() {
 
 	// Note: Avatar files are served through authenticated endpoints, not as static files
 	// This prevents unauthorized access to user avatars
+
+	// Public login image serving (no auth — displayed on the login page before authentication)
+	a.Router.Get("/public/login-image/{filename}", func(w http.ResponseWriter, r *http.Request) {
+		filename := chi.URLParam(r, "filename")
+		apiCommon.ServeImage(w, r, "public/uploads/login-images", filename, "public, max-age=86400")
+	})
 
 	// Mount API resources
 	// Auth routes mounted at root level to match frontend expectations

--- a/backend/api/common/upload.go
+++ b/backend/api/common/upload.go
@@ -44,7 +44,7 @@ func ParseImage(w http.ResponseWriter, r *http.Request, fieldName string, maxSiz
 
 	contentType, err := detectContentType(file)
 	if err != nil {
-		file.Close()
+		_ = file.Close()
 		return nil, err
 	}
 
@@ -108,7 +108,7 @@ func SaveImage(file io.Reader, targetDir, prefix, contentType string) (string, e
 
 	if _, err := io.Copy(dst, file); err != nil {
 		// Clean up the partially written file
-		os.Remove(filePath)
+		_ = os.Remove(filePath)
 		return "", errors.New("failed to save file")
 	}
 

--- a/backend/api/common/upload.go
+++ b/backend/api/common/upload.go
@@ -1,0 +1,330 @@
+package common
+
+import (
+	"crypto/rand"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// AllowedImageTypes maps MIME types detected by http.DetectContentType to allowed image formats.
+var AllowedImageTypes = map[string]bool{
+	"image/jpeg": true,
+	"image/jpg":  true,
+	"image/png":  true,
+	"image/webp": true,
+}
+
+// UploadedFile holds the result of parsing and validating an image upload.
+type UploadedFile struct {
+	File        io.ReadSeekCloser
+	Filename    string
+	ContentType string
+}
+
+// ParseImage parses a multipart form upload, validates the content type via magic bytes,
+// and returns the file ready for saving. The caller must close UploadedFile.File.
+func ParseImage(w http.ResponseWriter, r *http.Request, fieldName string, maxSize int64) (*UploadedFile, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxSize)
+
+	if err := r.ParseMultipartForm(maxSize); err != nil {
+		return nil, errors.New("file too large")
+	}
+
+	file, header, err := r.FormFile(fieldName)
+	if err != nil {
+		return nil, errors.New("no file uploaded")
+	}
+
+	contentType, err := detectContentType(file)
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+
+	return &UploadedFile{
+		File:        file,
+		Filename:    header.Filename,
+		ContentType: contentType,
+	}, nil
+}
+
+// detectContentType reads the first 512 bytes to detect the MIME type via magic bytes
+// and validates it against AllowedImageTypes.
+func detectContentType(file io.ReadSeeker) (string, error) {
+	buf := make([]byte, 512)
+	n, err := file.Read(buf)
+	if n == 0 {
+		if err != nil {
+			return "", errors.New("cannot read file")
+		}
+		return "", errors.New("empty file")
+	}
+
+	contentType := http.DetectContentType(buf[:n])
+	if !AllowedImageTypes[contentType] {
+		return "", errors.New("invalid file type. Only JPEG, PNG, and WebP images are allowed")
+	}
+
+	if _, err := file.Seek(0, 0); err != nil {
+		return "", errors.New("failed to process file")
+	}
+
+	return contentType, nil
+}
+
+// SaveImage writes the uploaded file to targetDir with a generated filename of the form
+// {prefix}_{random}.{ext}. It creates targetDir if it doesn't exist.
+// Returns the full file path on disk.
+func SaveImage(file io.Reader, targetDir, prefix, contentType string) (string, error) {
+	ext := fileExtension(contentType)
+
+	randomStr, err := generateRandomString(8)
+	if err != nil {
+		return "", errors.New("failed to generate filename")
+	}
+
+	filename := prefix + "_" + randomStr + ext
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return "", errors.New("failed to create upload directory")
+	}
+
+	filePath := filepath.Join(targetDir, filename)
+	dst, err := os.Create(filePath)
+	if err != nil {
+		return "", errors.New("failed to save file")
+	}
+	defer func() {
+		if err := dst.Close(); err != nil {
+			slog.Default().Error("file close error", slog.String("error", err.Error()))
+		}
+	}()
+
+	if _, err := io.Copy(dst, file); err != nil {
+		// Clean up the partially written file
+		os.Remove(filePath)
+		return "", errors.New("failed to save file")
+	}
+
+	return filePath, nil
+}
+
+// ServeImage serves an image file from baseDir, validating the path stays within baseDir.
+// If baseDir is relative (e.g. "public/uploads/..."), it is resolved via ResolvePublicDir.
+// cacheControl sets the Cache-Control header (e.g. "private, max-age=86400" or "public, max-age=86400").
+func ServeImage(w http.ResponseWriter, r *http.Request, baseDir, filename, cacheControl string) {
+	if err := ValidateFilename(filename); err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Resolve relative paths using the discovered public directory
+	if !filepath.IsAbs(baseDir) {
+		if pubDir, err := ResolvePublicDir(); err == nil {
+			// Strip leading "public/" since pubDir already points to it
+			rel := strings.TrimPrefix(baseDir, "public/")
+			rel = strings.TrimPrefix(rel, "public")
+			if rel != "" {
+				baseDir = filepath.Join(pubDir, rel)
+			} else {
+				baseDir = pubDir
+			}
+		}
+	}
+
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	absPath := filepath.Join(absBase, filename)
+	if !strings.HasPrefix(absPath, absBase+string(os.PathSeparator)) {
+		http.NotFound(w, r)
+		return
+	}
+
+	file, err := os.Open(absPath)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			slog.Default().Error("file close error", slog.String("error", err.Error()))
+		}
+	}()
+
+	w.Header().Set("Cache-Control", cacheControl)
+	http.ServeContent(w, r, filename, modTime(file), file)
+}
+
+// RemoveImage deletes a file from disk, logging any error.
+func RemoveImage(path string) {
+	if path == "" {
+		return
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Default().Error("failed to remove file",
+			slog.String("path", path),
+			slog.String("error", err.Error()))
+	}
+}
+
+// ValidateFilename rejects filenames containing path traversal characters.
+func ValidateFilename(filename string) error {
+	if filename == "" {
+		return errors.New("filename required")
+	}
+	if strings.Contains(filename, "..") {
+		return errors.New("invalid filename")
+	}
+	if filepath.Base(filename) != filename {
+		return errors.New("invalid filename")
+	}
+	return nil
+}
+
+// ResolveStoredPath converts a stored URL path (e.g. "/uploads/avatars/global/file.jpg")
+// to a validated filesystem path under the public directory, preventing path traversal.
+// Uses ResolvePublicDir() to find the public directory regardless of working directory.
+func ResolveStoredPath(publicDir, urlPath, requiredPrefix string) (string, error) {
+	if !strings.HasPrefix(urlPath, requiredPrefix) {
+		return "", errors.New("invalid path")
+	}
+
+	if strings.Contains(urlPath, "..") {
+		return "", errors.New("invalid path")
+	}
+
+	// Use the discovered public dir if available, fall back to the provided publicDir
+	baseDir := publicDir
+	if resolved, err := ResolvePublicDir(); err == nil {
+		baseDir = resolved
+	}
+
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", errors.New("failed to resolve directory")
+	}
+
+	filePath := filepath.Join(baseDir, strings.TrimPrefix(urlPath, "/"))
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return "", errors.New("failed to resolve path")
+	}
+
+	// The URL starts with / (e.g. /uploads/...) so after TrimPrefix("/") we get "uploads/..."
+	// which is inside the public dir. But verify to prevent traversal.
+	if !strings.HasPrefix(absPath, absBase+string(os.PathSeparator)) {
+		return "", errors.New("invalid path")
+	}
+
+	return absPath, nil
+}
+
+// CloseFile safely closes a file, logging any error.
+func CloseFile(file io.Closer) {
+	if err := file.Close(); err != nil {
+		slog.Default().Error("file close error", slog.String("error", err.Error()))
+	}
+}
+
+// fileExtension returns the extension derived from the detected content type.
+// This ensures the stored file extension matches the actual image format.
+func fileExtension(contentType string) string {
+	switch contentType {
+	case "image/jpeg", "image/jpg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/webp":
+		return ".webp"
+	default:
+		return ""
+	}
+}
+
+// generateRandomString generates a cryptographically secure random string.
+func generateRandomString(length int) (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	for i := range b {
+		b[i] = charset[b[i]%byte(len(charset))]
+	}
+	return string(b), nil
+}
+
+var (
+	resolvedPublicDir string
+	resolvedPublicErr error
+	resolvePublicOnce sync.Once
+)
+
+// ResolvePublicDir finds the "public" directory by searching from the working directory
+// and executable path. Handles both running from the backend/ dir and from the repo root.
+// Result is cached after the first call.
+func ResolvePublicDir() (string, error) {
+	resolvePublicOnce.Do(func() {
+		var candidates []string
+
+		if wd, err := os.Getwd(); err == nil {
+			candidates = append(candidates, publicDirCandidates(wd)...)
+		}
+
+		if exe, err := os.Executable(); err == nil {
+			candidates = append(candidates, publicDirCandidates(filepath.Dir(exe))...)
+		}
+
+		for _, candidate := range candidates {
+			abs, err := filepath.Abs(candidate)
+			if err != nil {
+				continue
+			}
+			info, err := os.Stat(abs)
+			if err == nil && info.IsDir() {
+				resolvedPublicDir = abs
+				return
+			}
+		}
+
+		resolvedPublicErr = errors.New("public directory not found")
+	})
+
+	return resolvedPublicDir, resolvedPublicErr
+}
+
+// publicDirCandidates returns candidate paths for the public directory,
+// walking up parent directories from base to find public/ or backend/public/.
+func publicDirCandidates(base string) []string {
+	var candidates []string
+	for current := base; ; current = filepath.Dir(current) {
+		candidates = append(candidates,
+			filepath.Join(current, "public"),
+			filepath.Join(current, "backend", "public"),
+		)
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+	}
+	return candidates
+}
+
+// modTime returns the file's modification time, or zero time on error.
+func modTime(f *os.File) time.Time {
+	info, err := f.Stat()
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime()
+}

--- a/backend/api/common/upload_test.go
+++ b/backend/api/common/upload_test.go
@@ -1,0 +1,359 @@
+package common
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectContentType_JPEG(t *testing.T) {
+	jpegBytes := make([]byte, 512)
+	jpegBytes[0] = 0xFF
+	jpegBytes[1] = 0xD8
+	jpegBytes[2] = 0xFF
+
+	reader := bytes.NewReader(jpegBytes)
+	contentType, err := detectContentType(reader)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "image/jpeg", contentType)
+}
+
+func TestDetectContentType_PNG(t *testing.T) {
+	pngBytes := make([]byte, 512)
+	copy(pngBytes, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A})
+
+	reader := bytes.NewReader(pngBytes)
+	contentType, err := detectContentType(reader)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "image/png", contentType)
+}
+
+func TestDetectContentType_Invalid(t *testing.T) {
+	htmlBytes := make([]byte, 512)
+	copy(htmlBytes, []byte("<!DOCTYPE html><html><body>Hello</body></html>"))
+
+	reader := bytes.NewReader(htmlBytes)
+	_, err := detectContentType(reader)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid file type")
+}
+
+func TestDetectContentType_SmallFile(t *testing.T) {
+	// A valid PNG smaller than 512 bytes should still be detected
+	pngBytes := make([]byte, 16)
+	copy(pngBytes, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A})
+
+	reader := bytes.NewReader(pngBytes)
+	contentType, err := detectContentType(reader)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "image/png", contentType)
+}
+
+func TestDetectContentType_Empty(t *testing.T) {
+	reader := bytes.NewReader([]byte{})
+	_, err := detectContentType(reader)
+
+	assert.Error(t, err)
+}
+
+func TestFileExtension_DerivedFromContentType(t *testing.T) {
+	tests := []struct {
+		contentType, expected string
+	}{
+		{"image/jpeg", ".jpg"},
+		{"image/jpg", ".jpg"},
+		{"image/png", ".png"},
+		{"image/webp", ".webp"},
+		{"application/octet-stream", ""},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, fileExtension(tt.contentType))
+	}
+}
+
+func TestGenerateRandomString(t *testing.T) {
+	result, err := generateRandomString(8)
+	assert.NoError(t, err)
+	assert.Len(t, result, 8)
+
+	// Uniqueness
+	result2, err := generateRandomString(8)
+	assert.NoError(t, err)
+	assert.NotEqual(t, result, result2)
+}
+
+func TestValidateFilename(t *testing.T) {
+	assert.NoError(t, ValidateFilename("test.jpg"))
+	assert.NoError(t, ValidateFilename("123_abcdef.png"))
+
+	assert.Error(t, ValidateFilename(""))
+	assert.Error(t, ValidateFilename(".."))
+	assert.Error(t, ValidateFilename("../etc/passwd"))
+}
+
+func TestResolveStoredPath_Valid(t *testing.T) {
+	path, err := ResolveStoredPath("public", "/uploads/avatars/global/test.jpg", "/uploads/avatars/")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, path)
+}
+
+func TestResolveStoredPath_InvalidPrefix(t *testing.T) {
+	_, err := ResolveStoredPath("public", "/uploads/not-avatars/test.jpg", "/uploads/avatars/")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid path")
+}
+
+func TestResolveStoredPath_Traversal(t *testing.T) {
+	_, err := ResolveStoredPath("public", "/uploads/avatars/../../etc/passwd", "/uploads/avatars/")
+	assert.Error(t, err)
+}
+
+func TestCloseFile_Success(t *testing.T) {
+	closer := &mockCloser{}
+	CloseFile(closer)
+	assert.True(t, closer.closed)
+}
+
+func TestCloseFile_WithError(t *testing.T) {
+	closer := &mockCloser{err: assert.AnError}
+	CloseFile(closer)
+	assert.True(t, closer.closed)
+}
+
+func TestAllowedImageTypes_Correct(t *testing.T) {
+	assert.True(t, AllowedImageTypes["image/jpeg"])
+	assert.True(t, AllowedImageTypes["image/png"])
+	assert.True(t, AllowedImageTypes["image/webp"])
+	assert.False(t, AllowedImageTypes["image/gif"])
+	assert.False(t, AllowedImageTypes["text/html"])
+}
+
+type mockCloser struct {
+	closed bool
+	err    error
+}
+
+func (m *mockCloser) Close() error {
+	m.closed = true
+	return m.err
+}
+
+// ---------------------------------------------------------------------------
+// Tests for public functions: ParseImage, SaveImage, ServeImage, RemoveImage,
+// ResolvePublicDir, publicDirCandidates, and modTime.
+// ---------------------------------------------------------------------------
+
+func createMultipartRequest(t *testing.T, fieldName, filename string, content []byte) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile(fieldName, filename)
+	require.NoError(t, err)
+	_, err = part.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/upload", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+func makeJPEGBytes() []byte {
+	b := make([]byte, 512)
+	b[0] = 0xFF
+	b[1] = 0xD8
+	b[2] = 0xFF
+	return b
+}
+
+func TestParseImage_ValidJPEG(t *testing.T) {
+	req := createMultipartRequest(t, "image", "photo.jpg", makeJPEGBytes())
+	w := httptest.NewRecorder()
+
+	uploaded, err := ParseImage(w, req, "image", 10<<20)
+	require.NoError(t, err)
+	defer uploaded.File.Close()
+
+	assert.Equal(t, "image/jpeg", uploaded.ContentType)
+	assert.NotEmpty(t, uploaded.Filename)
+}
+
+func TestParseImage_MissingField(t *testing.T) {
+	req := createMultipartRequest(t, "other_field", "photo.jpg", makeJPEGBytes())
+	w := httptest.NewRecorder()
+
+	_, err := ParseImage(w, req, "image", 10<<20)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no file uploaded")
+}
+
+func TestParseImage_ContentTypeSpoofed(t *testing.T) {
+	// Content is HTML, but filename suggests JPEG
+	htmlContent := make([]byte, 512)
+	copy(htmlContent, []byte("<!DOCTYPE html><html><body>malicious</body></html>"))
+
+	req := createMultipartRequest(t, "image", "evil.jpg", htmlContent)
+	w := httptest.NewRecorder()
+
+	_, err := ParseImage(w, req, "image", 10<<20)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid file type")
+}
+
+func TestSaveImage_CreatesFileWithCorrectExtension(t *testing.T) {
+	dir := t.TempDir()
+	content := bytes.NewReader([]byte("fake image data"))
+
+	path, err := SaveImage(content, dir, "avatar", "image/jpeg")
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasSuffix(path, ".jpg"), "expected .jpg extension, got %s", path)
+
+	_, statErr := os.Stat(path)
+	assert.NoError(t, statErr, "file should exist on disk")
+}
+
+func TestSaveImage_GeneratesUniqueFilenames(t *testing.T) {
+	dir := t.TempDir()
+
+	path1, err := SaveImage(bytes.NewReader([]byte("data1")), dir, "img", "image/png")
+	require.NoError(t, err)
+
+	path2, err := SaveImage(bytes.NewReader([]byte("data2")), dir, "img", "image/png")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, path1, path2)
+}
+
+func TestSaveImage_UnknownContentType(t *testing.T) {
+	dir := t.TempDir()
+	content := bytes.NewReader([]byte("pdf content"))
+
+	path, err := SaveImage(content, dir, "doc", "application/pdf")
+	require.NoError(t, err)
+
+	// No extension for unknown content type
+	assert.False(t, strings.HasSuffix(path, ".pdf"), "should not have .pdf extension")
+	assert.True(t, strings.Contains(filepath.Base(path), "doc_"), "filename should have prefix")
+
+	_, statErr := os.Stat(path)
+	assert.NoError(t, statErr, "file should exist on disk")
+}
+
+func TestServeImage_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "test.jpg")
+	require.NoError(t, os.WriteFile(filePath, makeJPEGBytes(), 0644))
+
+	req := httptest.NewRequest(http.MethodGet, "/images/test.jpg", nil)
+	w := httptest.NewRecorder()
+
+	ServeImage(w, req, dir, "test.jpg", "public, max-age=86400")
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "public, max-age=86400", resp.Header.Get("Cache-Control"))
+}
+
+func TestServeImage_PathTraversal(t *testing.T) {
+	dir := t.TempDir()
+
+	req := httptest.NewRequest(http.MethodGet, "/images/../../../etc/passwd", nil)
+	w := httptest.NewRecorder()
+
+	ServeImage(w, req, dir, "../../../etc/passwd", "public, max-age=86400")
+
+	assert.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+}
+
+func TestServeImage_NonExistent(t *testing.T) {
+	dir := t.TempDir()
+
+	req := httptest.NewRequest(http.MethodGet, "/images/doesnotexist.jpg", nil)
+	w := httptest.NewRecorder()
+
+	ServeImage(w, req, dir, "doesnotexist.jpg", "public, max-age=86400")
+
+	assert.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+}
+
+func TestRemoveImage_ExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "to_delete.jpg")
+	require.NoError(t, os.WriteFile(filePath, []byte("data"), 0644))
+
+	RemoveImage(filePath)
+
+	_, err := os.Stat(filePath)
+	assert.True(t, os.IsNotExist(err), "file should be deleted")
+}
+
+func TestRemoveImage_NonExistent(t *testing.T) {
+	// Should not panic when file does not exist
+	assert.NotPanics(t, func() {
+		RemoveImage("/tmp/nonexistent_file_abc123.jpg")
+	})
+}
+
+func TestRemoveImage_EmptyPath(t *testing.T) {
+	// Should be a no-op, no panic
+	assert.NotPanics(t, func() {
+		RemoveImage("")
+	})
+}
+
+func TestPublicDirCandidates(t *testing.T) {
+	base := "/some/project/backend"
+	candidates := publicDirCandidates(base)
+
+	assert.NotEmpty(t, candidates)
+
+	// Should contain "public" and "backend/public" relative to base and parents
+	assert.Contains(t, candidates, filepath.Join(base, "public"))
+	assert.Contains(t, candidates, filepath.Join(base, "backend", "public"))
+
+	// Should also walk up to parent
+	parent := filepath.Dir(base)
+	assert.Contains(t, candidates, filepath.Join(parent, "public"))
+	assert.Contains(t, candidates, filepath.Join(parent, "backend", "public"))
+}
+
+func TestModTime_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "modtime_test.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("content"), 0644))
+
+	f, err := os.Open(filePath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	mt := modTime(f)
+	assert.False(t, mt.IsZero(), "modification time should be non-zero for a real file")
+}
+
+func TestModTime_NilHandling(t *testing.T) {
+	// Open a file, close it, then call modTime on the closed file descriptor.
+	// This should return zero time (the error path) rather than panic.
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "closed.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0644))
+
+	f, err := os.Open(filePath)
+	require.NoError(t, err)
+	f.Close() // intentionally close before calling modTime
+
+	mt := modTime(f)
+	assert.True(t, mt.IsZero(), "should return zero time for closed file descriptor")
+}

--- a/backend/api/common/upload_test.go
+++ b/backend/api/common/upload_test.go
@@ -184,7 +184,7 @@ func TestParseImage_ValidJPEG(t *testing.T) {
 
 	uploaded, err := ParseImage(w, req, "image", 10<<20)
 	require.NoError(t, err)
-	defer uploaded.File.Close()
+	defer func() { _ = uploaded.File.Close() }()
 
 	assert.Equal(t, "image/jpeg", uploaded.ContentType)
 	assert.NotEmpty(t, uploaded.Filename)
@@ -337,7 +337,7 @@ func TestModTime_ValidFile(t *testing.T) {
 
 	f, err := os.Open(filePath)
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	mt := modTime(f)
 	assert.False(t, mt.IsZero(), "modification time should be non-zero for a real file")
@@ -352,7 +352,7 @@ func TestModTime_NilHandling(t *testing.T) {
 
 	f, err := os.Open(filePath)
 	require.NoError(t, err)
-	f.Close() // intentionally close before calling modTime
+	_ = f.Close() // intentionally close before calling modTime
 
 	mt := modTime(f)
 	assert.True(t, mt.IsZero(), "should return zero time for closed file descriptor")

--- a/backend/api/config/settings_api.go
+++ b/backend/api/config/settings_api.go
@@ -146,6 +146,12 @@ type loginImageResponse struct {
 // getLoginImage returns the current login image URL and edit permission for the tenant.
 func (rs *SettingsResource) getLoginImage(w http.ResponseWriter, r *http.Request) {
 	tenantID := tenant.FromContext(r.Context())
+	if tenantID <= 0 {
+		render.Status(r, http.StatusBadRequest)
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("no tenant context")))
+		return
+	}
+
 	claims := jwt.ClaimsFromCtx(r.Context())
 
 	canEdit := authorize.HasPermission(permissions.ConfigUpdate, claims.Permissions) ||

--- a/backend/api/config/settings_api.go
+++ b/backend/api/config/settings_api.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"path/filepath"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -15,6 +17,16 @@ import (
 	configSvc "github.com/moto-nrw/project-phoenix/services/config"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
+)
+
+// Login image upload constants
+const (
+	maxLoginImageSize = 2 * 1024 * 1024 // 2MB — advertised file limit
+	// MaxBytesReader limits the entire multipart body, not just the file.
+	// Add 1 KiB headroom for multipart boundaries, headers, and CRLF padding
+	// so files at exactly the advertised limit are not rejected.
+	maxLoginImageBody = maxLoginImageSize + 1024
+	loginImageDir     = "public/uploads/login-images"
 )
 
 // SettingsResource defines the settings API resource.
@@ -31,7 +43,7 @@ func NewSettingsResource(svc configSvc.SettingsService, db *bun.DB) *SettingsRes
 	}
 }
 
-// SettingsRouter returns a configured router for the 3 settings endpoints.
+// SettingsRouter returns a configured router for settings endpoints.
 func (rs *SettingsResource) SettingsRouter() chi.Router {
 	r := chi.NewRouter()
 	r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -49,6 +61,16 @@ func (rs *SettingsResource) SettingsRouter() chi.Router {
 		r.With(authorize.RequiresPermission(permissions.ConfigRead), withTx).Get("/schema", rs.getSchema)
 		r.With(settingsWrite, withTx).Put("/values/{key}", rs.setValue)
 		r.With(settingsWrite, withTx).Delete("/values/{key}", rs.resetValue)
+
+		// Login image — reads use withTx (tenant role), writes use WithAdminTx internally
+		// because platform.schools requires the phoenix_admin role for UPDATE.
+		// withTx is intentionally omitted on POST/DELETE to avoid conflicting role contexts.
+		// GET uses settingsWrite (not ConfigRead) so write-capable roles can also read the
+		// login-image metadata — the frontend depends on this GET to enable upload/delete controls.
+		settingsReadOrWrite := authorize.RequiresAnyPermission(permissions.ConfigRead, permissions.ConfigUpdate, permissions.ConfigManage)
+		r.With(settingsReadOrWrite, withTx).Get("/login-image", rs.getLoginImage)
+		r.With(settingsWrite).Post("/login-image", rs.uploadLoginImage)
+		r.With(settingsWrite).Delete("/login-image", rs.deleteLoginImage)
 	})
 
 	return r
@@ -114,6 +136,106 @@ func (rs *SettingsResource) resetValue(w http.ResponseWriter, r *http.Request) {
 	common.RespondNoContent(w, r)
 }
 
+// --- Login image handlers ---
+
+type loginImageResponse struct {
+	LoginImageURL *string `json:"login_image_url"`
+	CanEdit       bool    `json:"can_edit"`
+}
+
+// getLoginImage returns the current login image URL and edit permission for the tenant.
+func (rs *SettingsResource) getLoginImage(w http.ResponseWriter, r *http.Request) {
+	tenantID := tenant.FromContext(r.Context())
+	claims := jwt.ClaimsFromCtx(r.Context())
+
+	canEdit := authorize.HasPermission(permissions.ConfigUpdate, claims.Permissions) ||
+		authorize.HasPermission(permissions.ConfigManage, claims.Permissions)
+
+	url, err := rs.settingsService.GetLoginImageURL(r.Context(), tenantID)
+	if err != nil {
+		render.Status(r, http.StatusInternalServerError)
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	resp := loginImageResponse{CanEdit: canEdit}
+	if url != "" {
+		resp.LoginImageURL = &url
+	}
+
+	common.Respond(w, r, http.StatusOK, resp, "")
+}
+
+// uploadLoginImage handles uploading a custom login page image for the tenant.
+func (rs *SettingsResource) uploadLoginImage(w http.ResponseWriter, r *http.Request) {
+	uploaded, err := common.ParseImage(w, r, "login_image", maxLoginImageBody)
+	if err != nil {
+		render.Status(r, http.StatusBadRequest)
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	defer common.CloseFile(uploaded.File)
+
+	tenantID := tenant.FromContext(r.Context())
+	if tenantID <= 0 {
+		render.Status(r, http.StatusBadRequest)
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("no tenant context")))
+		return
+	}
+
+	prefix := fmt.Sprintf("%d", tenantID)
+	filePath, err := common.SaveImage(uploaded.File, loginImageDir, prefix, uploaded.ContentType)
+	if err != nil {
+		render.Status(r, http.StatusInternalServerError)
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	imageURL := "/uploads/login-images/" + filepath.Base(filePath)
+	oldURL, err := rs.settingsService.SetLoginImageURL(r.Context(), tenantID, imageURL)
+	if err != nil {
+		common.RemoveImage(filePath)
+		render.Status(r, http.StatusInternalServerError)
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	// Clean up old file only after DB commit succeeded
+	if oldURL != "" {
+		if oldPath, resolveErr := common.ResolveStoredPath("public", oldURL, "/uploads/login-images/"); resolveErr == nil {
+			common.RemoveImage(oldPath)
+		}
+	}
+
+	common.Respond(w, r, http.StatusOK, map[string]string{"login_image_url": imageURL}, "Login image uploaded successfully")
+}
+
+// deleteLoginImage removes the custom login page image for the tenant.
+func (rs *SettingsResource) deleteLoginImage(w http.ResponseWriter, r *http.Request) {
+	tenantID := tenant.FromContext(r.Context())
+	if tenantID <= 0 {
+		render.Status(r, http.StatusBadRequest)
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("no tenant context")))
+		return
+	}
+
+	oldURL, err := rs.settingsService.ClearLoginImageURL(r.Context(), tenantID)
+	if err != nil {
+		render.Status(r, http.StatusInternalServerError)
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	// Clean up old file only after DB commit succeeded
+	if oldURL != "" {
+		if oldPath, resolveErr := common.ResolveStoredPath("public", oldURL, "/uploads/login-images/"); resolveErr == nil {
+			common.RemoveImage(oldPath)
+		}
+	}
+
+	common.RespondNoContent(w, r)
+}
+
 // --- Handler accessors for testing ---
 
 // GetSchema returns the getSchema handler for external test access.
@@ -124,6 +246,15 @@ func (rs *SettingsResource) SetValue() http.HandlerFunc { return rs.setValue }
 
 // ResetValue returns the resetValue handler for external test access.
 func (rs *SettingsResource) ResetValue() http.HandlerFunc { return rs.resetValue }
+
+// GetLoginImage returns the getLoginImage handler for external test access.
+func (rs *SettingsResource) GetLoginImage() http.HandlerFunc { return rs.getLoginImage }
+
+// UploadLoginImage returns the uploadLoginImage handler for external test access.
+func (rs *SettingsResource) UploadLoginImage() http.HandlerFunc { return rs.uploadLoginImage }
+
+// DeleteLoginImage returns the deleteLoginImage handler for external test access.
+func (rs *SettingsResource) DeleteLoginImage() http.HandlerFunc { return rs.deleteLoginImage }
 
 // --- Error rendering ---
 

--- a/backend/api/config/settings_integration_test.go
+++ b/backend/api/config/settings_integration_test.go
@@ -2,7 +2,11 @@ package config_test
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/go-chi/chi/v5"
 
 	configAPI "github.com/moto-nrw/project-phoenix/api/config"
 	"github.com/moto-nrw/project-phoenix/api/testutil"
@@ -201,4 +205,216 @@ func TestSettingsResetValue_InvalidKey(t *testing.T) {
 
 	rr := testutil.ExecuteRequest(router, req)
 	testutil.AssertErrorResponse(t, rr, http.StatusNotFound)
+}
+
+// =============================================================================
+// GET /login-image
+// =============================================================================
+
+func TestSettingsGetLoginImage_Success(t *testing.T) {
+	ctx := setupSettingsTest(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	router := testutil.NewTenantRouter(ctx.db)
+	router.Get("/login-image", ctx.resource.GetLoginImage())
+
+	req := testutil.NewAuthenticatedRequest(t, "GET", "/login-image", nil,
+		testutil.WithClaims(adminClaimsWithConfigPerms()),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	data, ok := response["data"].(map[string]interface{})
+	assert.True(t, ok, "response should contain data")
+	assert.Nil(t, data["login_image_url"], "default school should have no login image")
+	assert.True(t, data["can_edit"].(bool), "admin should have edit permission")
+}
+
+func TestSettingsGetLoginImage_ReadOnlyUser(t *testing.T) {
+	ctx := setupSettingsTest(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	router := testutil.NewTenantRouter(ctx.db)
+	router.Get("/login-image", ctx.resource.GetLoginImage())
+
+	// Teacher has config:read but not config:update or config:manage
+	req := testutil.NewAuthenticatedRequest(t, "GET", "/login-image", nil,
+		testutil.WithClaims(testutil.TeacherTestClaims(2)),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	data, ok := response["data"].(map[string]interface{})
+	assert.True(t, ok, "response should contain data")
+	assert.False(t, data["can_edit"].(bool), "teacher should not have edit permission")
+}
+
+// =============================================================================
+// POST /login-image
+// =============================================================================
+
+func TestSettingsUploadLoginImage_Success(t *testing.T) {
+	ctx := setupSettingsTest(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	// uploadLoginImage uses WithAdminTx internally — no tenant tx middleware
+	router := chi.NewRouter()
+	router.Post("/login-image", ctx.resource.UploadLoginImage())
+
+	// Minimal valid PNG (1x1 pixel)
+	pngContent := string([]byte{
+		0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n',
+		0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R',
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+		0x00, 0x00, 0x00, 0x0a, 'I', 'D', 'A', 'T',
+		0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00,
+		0x03, 0x01, 0x01, 0x00, 0xc9, 0xfe, 0x92, 0xef,
+		0x00, 0x00, 0x00, 0x00, 'I', 'E', 'N', 'D',
+		0xae, 'B', 0x60, 0x82,
+	})
+
+	req := testutil.NewMultipartRequest(t, "POST", "/login-image",
+		"login_image", "test-login.png", pngContent,
+		testutil.WithClaims(adminClaimsWithConfigPerms()),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	assert.Equal(t, http.StatusOK, rr.Code, "upload should succeed. Body: %s", rr.Body.String())
+
+	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	data, ok := response["data"].(map[string]interface{})
+	assert.True(t, ok, "response should contain data")
+	imageURL, _ := data["login_image_url"].(string)
+	assert.Contains(t, imageURL, "/uploads/login-images/")
+	assert.Contains(t, imageURL, ".png")
+
+	// Clean up the uploaded file
+	t.Cleanup(func() {
+		filePath := filepath.Join("public", filepath.FromSlash(imageURL[1:]))
+		_ = os.Remove(filePath)
+	})
+}
+
+func TestSettingsUploadLoginImage_ReplacesOldImage(t *testing.T) {
+	ctx := setupSettingsTest(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	router := chi.NewRouter()
+	router.Post("/login-image", ctx.resource.UploadLoginImage())
+
+	// Minimal valid PNG (1x1 pixel)
+	pngContent := string([]byte{
+		0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n',
+		0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R',
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+		0x00, 0x00, 0x00, 0x0a, 'I', 'D', 'A', 'T',
+		0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00,
+		0x03, 0x01, 0x01, 0x00, 0xc9, 0xfe, 0x92, 0xef,
+		0x00, 0x00, 0x00, 0x00, 'I', 'E', 'N', 'D',
+		0xae, 'B', 0x60, 0x82,
+	})
+
+	// Upload first image
+	req1 := testutil.NewMultipartRequest(t, "POST", "/login-image",
+		"login_image", "first.png", pngContent,
+		testutil.WithClaims(adminClaimsWithConfigPerms()),
+	)
+	rr1 := testutil.ExecuteRequest(router, req1)
+	assert.Equal(t, http.StatusOK, rr1.Code, "first upload should succeed. Body: %s", rr1.Body.String())
+
+	response1 := testutil.ParseJSONResponse(t, rr1.Body.Bytes())
+	data1 := response1["data"].(map[string]interface{})
+	firstURL := data1["login_image_url"].(string)
+	firstPath := filepath.Join("public", filepath.FromSlash(firstURL[1:]))
+
+	// Verify first file exists on disk
+	_, err := os.Stat(firstPath)
+	assert.NoError(t, err, "first uploaded file should exist on disk")
+
+	// Upload second image (should replace the first)
+	req2 := testutil.NewMultipartRequest(t, "POST", "/login-image",
+		"login_image", "second.png", pngContent,
+		testutil.WithClaims(adminClaimsWithConfigPerms()),
+	)
+	rr2 := testutil.ExecuteRequest(router, req2)
+	assert.Equal(t, http.StatusOK, rr2.Code, "second upload should succeed. Body: %s", rr2.Body.String())
+
+	response2 := testutil.ParseJSONResponse(t, rr2.Body.Bytes())
+	data2 := response2["data"].(map[string]interface{})
+	secondURL := data2["login_image_url"].(string)
+	secondPath := filepath.Join("public", filepath.FromSlash(secondURL[1:]))
+
+	// Verify old file was cleaned up
+	_, err = os.Stat(firstPath)
+	assert.True(t, os.IsNotExist(err), "old file should have been deleted after re-upload")
+
+	// Verify new file exists
+	_, err = os.Stat(secondPath)
+	assert.NoError(t, err, "new uploaded file should exist on disk")
+
+	// Clean up
+	t.Cleanup(func() {
+		_ = os.Remove(secondPath)
+	})
+}
+
+func TestSettingsUploadLoginImage_InvalidFileType(t *testing.T) {
+	ctx := setupSettingsTest(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	router := chi.NewRouter()
+	router.Post("/login-image", ctx.resource.UploadLoginImage())
+
+	// Plain text content — not an allowed image type
+	req := testutil.NewMultipartRequest(t, "POST", "/login-image",
+		"login_image", "not-an-image.txt", "this is not an image",
+		testutil.WithClaims(adminClaimsWithConfigPerms()),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertErrorResponse(t, rr, http.StatusBadRequest)
+}
+
+// =============================================================================
+// DELETE /login-image
+// =============================================================================
+
+func TestSettingsDeleteLoginImage_NoExistingImage(t *testing.T) {
+	ctx := setupSettingsTest(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	// deleteLoginImage uses WithAdminTx internally — no tenant tx middleware
+	router := chi.NewRouter()
+	router.Delete("/login-image", ctx.resource.DeleteLoginImage())
+
+	req := testutil.NewAuthenticatedRequest(t, "DELETE", "/login-image", nil,
+		testutil.WithClaims(adminClaimsWithConfigPerms()),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusNoContent)
+}
+
+func TestSettingsDeleteLoginImage_NoTenantContext(t *testing.T) {
+	ctx := setupSettingsTest(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	router := chi.NewRouter()
+	router.Delete("/login-image", ctx.resource.DeleteLoginImage())
+
+	// Claims with TenantID=0 — no tenant context
+	claims := adminClaimsWithConfigPerms()
+	claims.TenantID = 0
+	req := testutil.NewAuthenticatedRequest(t, "DELETE", "/login-image", nil,
+		testutil.WithClaims(claims),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertErrorResponse(t, rr, http.StatusBadRequest)
 }

--- a/backend/api/iot/api_test.go
+++ b/backend/api/iot/api_test.go
@@ -28,6 +28,9 @@ func (m *mockSchoolRepo) FindByID(ctx context.Context, id int64) (*platform.Scho
 func (m *mockSchoolRepo) FindByIDForShare(_ context.Context, _ int64) (*platform.School, error) {
 	return nil, nil
 }
+func (m *mockSchoolRepo) FindByIDForUpdate(_ context.Context, _ int64) (*platform.School, error) {
+	return nil, nil
+}
 func (m *mockSchoolRepo) FindBySlug(_ context.Context, _ string) (*platform.School, error) {
 	return nil, nil
 }

--- a/backend/api/iot/checkin/checkin_internal_test.go
+++ b/backend/api/iot/checkin/checkin_internal_test.go
@@ -188,6 +188,15 @@ func (m *mockSettingsService) SetValue(_ context.Context, _ string, _ any, _ *in
 func (m *mockSettingsService) ResetValue(_ context.Context, _ string, _ *int64, _ []string) error {
 	return nil
 }
+func (m *mockSettingsService) GetLoginImageURL(_ context.Context, _ int64) (string, error) {
+	return "", nil
+}
+func (m *mockSettingsService) SetLoginImageURL(_ context.Context, _ int64, _ string) (string, error) {
+	return "", nil
+}
+func (m *mockSettingsService) ClearLoginImageURL(_ context.Context, _ int64) (string, error) {
+	return "", nil
+}
 
 func TestGetStudentDailyCheckoutTime_UsesSettingsService(t *testing.T) {
 	// Clear env var so only the settings service provides the value

--- a/backend/api/iot/feedback/feedback_test.go
+++ b/backend/api/iot/feedback/feedback_test.go
@@ -57,6 +57,15 @@ func (f *fakeSettingsService) SetValue(_ context.Context, _ string, _ any, _ *in
 func (f *fakeSettingsService) ResetValue(_ context.Context, _ string, _ *int64, _ []string) error {
 	return nil
 }
+func (f *fakeSettingsService) GetLoginImageURL(_ context.Context, _ int64) (string, error) {
+	return "", nil
+}
+func (f *fakeSettingsService) SetLoginImageURL(_ context.Context, _ int64, _ string) (string, error) {
+	return "", nil
+}
+func (f *fakeSettingsService) ClearLoginImageURL(_ context.Context, _ int64) (string, error) {
+	return "", nil
+}
 
 // testContext holds shared test dependencies.
 type testContext struct {

--- a/backend/api/staff/api.go
+++ b/backend/api/staff/api.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -816,100 +814,13 @@ func (rs *Resource) serveStaffAvatar(w http.ResponseWriter, r *http.Request) {
 	}
 
 	avatarPath := avatarMap[accountID]
-	filePath, err := staffAvatarPathToFilePath(avatarPath)
+	filePath, err := common.ResolveStoredPath("public", avatarPath, "/uploads/avatars/")
 	if err != nil {
 		http.NotFound(w, r)
 		return
 	}
 
-	file, err := os.Open(filePath)
-	if err != nil {
-		http.NotFound(w, r)
-		return
-	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil {
-			rs.getLogger().Warn("failed to close avatar file", slog.String("error", closeErr.Error()))
-		}
-	}()
-
-	w.Header().Set("Cache-Control", "private, max-age=86400")
-	http.ServeContent(w, r, filepath.Base(filePath), time.Time{}, file)
-}
-
-func staffAvatarPathToFilePath(avatarPath string) (string, error) {
-	if !strings.HasPrefix(avatarPath, "/uploads/avatars/") {
-		return "", errors.New("invalid avatar path")
-	}
-
-	publicDir, err := resolvePublicDir()
-	if err != nil {
-		return "", errors.New("failed to resolve public directory")
-	}
-
-	absAvatarDir := filepath.Join(publicDir, "uploads", "avatars")
-	absPath := filepath.Join(publicDir, strings.TrimPrefix(avatarPath, "/"))
-
-	avatarPrefix := absAvatarDir + string(os.PathSeparator)
-	if absPath != absAvatarDir && !strings.HasPrefix(absPath, avatarPrefix) {
-		return "", errors.New("invalid path")
-	}
-
-	return absPath, nil
-}
-
-var (
-	resolvedPublicDir string
-	resolvedPublicErr error
-	resolvePublicOnce sync.Once
-)
-
-func resolvePublicDir() (string, error) {
-	resolvePublicOnce.Do(func() {
-		var candidates []string
-
-		if workingDir, err := os.Getwd(); err == nil {
-			candidates = append(candidates, publicDirCandidates(workingDir)...)
-		}
-
-		if executablePath, err := os.Executable(); err == nil {
-			candidates = append(candidates, publicDirCandidates(filepath.Dir(executablePath))...)
-		}
-
-		for _, candidate := range candidates {
-			absCandidate, err := filepath.Abs(candidate)
-			if err != nil {
-				continue
-			}
-			info, err := os.Stat(absCandidate)
-			if err == nil && info.IsDir() {
-				resolvedPublicDir = absCandidate
-				return
-			}
-		}
-
-		resolvedPublicErr = errors.New("public directory not found")
-	})
-
-	return resolvedPublicDir, resolvedPublicErr
-}
-
-func publicDirCandidates(base string) []string {
-	var candidates []string
-
-	for current := base; ; current = filepath.Dir(current) {
-		candidates = append(candidates,
-			filepath.Join(current, "public"),
-			filepath.Join(current, "backend", "public"),
-		)
-
-		parent := filepath.Dir(current)
-		if parent == current {
-			break
-		}
-	}
-
-	return candidates
+	common.ServeImage(w, r, filepath.Dir(filePath), filepath.Base(filePath), "private, max-age=86400")
 }
 
 // getStaffGroups handles getting groups for a staff member

--- a/backend/api/staff/helpers_internal_test.go
+++ b/backend/api/staff/helpers_internal_test.go
@@ -1,10 +1,10 @@
 package staff
 
 import (
-	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/stretchr/testify/assert"
@@ -22,69 +22,40 @@ func TestRequestedCaregiverPool(t *testing.T) {
 	assert.True(t, requestedCaregiverPool([]string{"STAFF"}))
 }
 
-func TestStaffAvatarPathToFilePath_ValidPaths(t *testing.T) {
-	publicDir, err := resolvePublicDir()
-	require.NoError(t, err)
+// Avatar path resolution tests — uses centralized common.ResolveStoredPath.
 
+func TestStaffAvatarPath_ValidPaths(t *testing.T) {
 	testCases := []struct {
 		name       string
 		avatarPath string
-		want       string
+		wantSuffix string
 	}{
-		{
-			name:       "global avatar path",
-			avatarPath: "/uploads/avatars/global/ada.jpg",
-			want: filepath.Join(
-				publicDir,
-				"uploads",
-				"avatars",
-				"global",
-				"ada.jpg",
-			),
-		},
-		{
-			name:       "legacy tenant avatar path",
-			avatarPath: "/uploads/avatars/42/grace.png",
-			want: filepath.Join(
-				publicDir,
-				"uploads",
-				"avatars",
-				"42",
-				"grace.png",
-			),
-		},
+		{"global avatar path", "/uploads/avatars/global/ada.jpg", "uploads/avatars/global/ada.jpg"},
+		{"legacy tenant avatar path", "/uploads/avatars/42/grace.png", "uploads/avatars/42/grace.png"},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := staffAvatarPathToFilePath(tt.avatarPath)
+			got, err := common.ResolveStoredPath("public", tt.avatarPath, "/uploads/avatars/")
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			assert.Contains(t, got, tt.wantSuffix)
 		})
 	}
 }
 
-func TestStaffAvatarPathToFilePath_InvalidPaths(t *testing.T) {
+func TestStaffAvatarPath_InvalidPaths(t *testing.T) {
 	testCases := []struct {
 		name       string
 		avatarPath string
 		wantErr    string
 	}{
-		{
-			name:       "invalid prefix",
-			avatarPath: "/uploads/not-avatars/file.jpg",
-			wantErr:    "invalid avatar path",
-		},
-		{
-			name:       "path traversal",
-			avatarPath: "/uploads/avatars/global/../../secret.txt",
-			wantErr:    "invalid path",
-		},
+		{"invalid prefix", "/uploads/not-avatars/file.jpg", "invalid path"},
+		{"path traversal", "/uploads/avatars/global/../../secret.txt", "invalid path"},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := staffAvatarPathToFilePath(tt.avatarPath)
+			got, err := common.ResolveStoredPath("public", tt.avatarPath, "/uploads/avatars/")
 			assert.Empty(t, got)
 			assert.EqualError(t, err, tt.wantErr)
 		})

--- a/backend/api/usercontext/api.go
+++ b/backend/api/usercontext/api.go
@@ -2,17 +2,10 @@ package usercontext
 
 import (
 	"context"
-	"crypto/rand"
 	"errors"
 	"fmt"
-	"io"
-	"log/slog"
-	"mime/multipart"
 	"net/http"
-	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -313,28 +306,17 @@ const (
 	maxUploadSize   = 5 * 1024 * 1024 // 5MB
 	avatarDir       = "public/uploads/avatars"
 	globalAvatarDir = "global"
-	errCloseFileFmt = "Error closing file: %v"
 )
-
-// Allowed image types
-var allowedImageTypes = map[string]bool{
-	"image/jpeg": true,
-	"image/jpg":  true,
-	"image/png":  true,
-	"image/webp": true,
-}
 
 // uploadAvatar handles avatar image upload
 func (res *Resource) uploadAvatar(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
-
-	file, header, contentType, err := res.parseAndValidateUpload(r)
+	uploaded, err := common.ParseImage(w, r, "avatar", maxUploadSize)
 	if err != nil {
 		render.Status(r, http.StatusBadRequest)
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 		return
 	}
-	defer closeFile(file)
+	defer common.CloseFile(uploaded.File)
 
 	user, err := res.service.GetCurrentUser(r.Context())
 	if err != nil {
@@ -343,7 +325,9 @@ func (res *Resource) uploadAvatar(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tenantID := tenant.FromContext(r.Context())
-	filePath, err := res.saveAvatarFile(file, header, contentType, user.ID)
+	targetDir := filepath.Join(avatarDir, globalAvatarDir)
+	prefix := fmt.Sprintf("%d", user.ID)
+	filePath, err := common.SaveImage(uploaded.File, targetDir, prefix, uploaded.ContentType)
 	if err != nil {
 		render.Status(r, http.StatusInternalServerError)
 		common.RenderError(w, r, common.ErrorInternalServer(err))
@@ -357,123 +341,13 @@ func (res *Resource) uploadAvatar(w http.ResponseWriter, r *http.Request) {
 		updatedProfile, txErr = res.service.UpdateAvatar(ctx, avatarURL)
 		return txErr
 	}); err != nil {
-		removeFile(filePath)
+		common.RemoveImage(filePath)
 		common.RenderError(w, r, ErrorRenderer(err))
 		return
 	}
 
 	render.Status(r, http.StatusOK)
 	common.RenderError(w, r, common.NewResponse(updatedProfile, "Avatar uploaded successfully"))
-}
-
-// parseAndValidateUpload validates the multipart upload and returns the file and content type
-func (res *Resource) parseAndValidateUpload(r *http.Request) (file io.ReadSeekCloser, header *multipart.FileHeader, contentType string, err error) {
-	if r.ParseMultipartForm(maxUploadSize) != nil {
-		return nil, nil, "", errors.New("file too large")
-	}
-
-	file, header, err = r.FormFile("avatar")
-	if err != nil {
-		return nil, nil, "", errors.New("no file uploaded")
-	}
-
-	contentType, err = detectAndValidateContentType(file)
-	if err != nil {
-		closeFile(file)
-		return nil, nil, "", err
-	}
-
-	return file, header, contentType, nil
-}
-
-// detectAndValidateContentType reads file header and validates content type
-func detectAndValidateContentType(file io.ReadSeeker) (string, error) {
-	buffer := make([]byte, 512)
-	if _, err := file.Read(buffer); err != nil {
-		return "", errors.New("cannot read file")
-	}
-
-	contentType := http.DetectContentType(buffer)
-	if !allowedImageTypes[contentType] {
-		return "", errors.New("invalid file type. Only JPEG, PNG, and WebP images are allowed")
-	}
-
-	if _, err := file.Seek(0, 0); err != nil {
-		return "", errors.New("failed to process file")
-	}
-
-	return contentType, nil
-}
-
-// saveAvatarFile saves the uploaded file and returns the file path
-func (res *Resource) saveAvatarFile(file io.Reader, header *multipart.FileHeader, contentType string, userID int64) (string, error) {
-	fileExt := getFileExtension(header.Filename, contentType)
-	randomStr, err := generateRandomString(8)
-	if err != nil {
-		return "", errors.New("failed to generate filename")
-	}
-
-	filename := fmt.Sprintf("%d_%s%s", userID, randomStr, fileExt)
-	targetDir := filepath.Join(avatarDir, globalAvatarDir)
-	filePath := filepath.Join(targetDir, filename)
-
-	if os.MkdirAll(targetDir, 0755) != nil {
-		return "", errors.New("failed to create upload directory")
-	}
-
-	dst, err := os.Create(filePath)
-	if err != nil {
-		return "", errors.New("failed to save file")
-	}
-	defer closeFileHandle(dst)
-
-	if _, err := io.Copy(dst, file); err != nil {
-		return "", errors.New("failed to save file")
-	}
-
-	return filePath, nil
-}
-
-// getFileExtension returns the file extension, inferring from content type if needed
-func getFileExtension(filename, contentType string) string {
-	ext := filepath.Ext(filename)
-	if ext != "" {
-		return ext
-	}
-
-	switch contentType {
-	case "image/jpeg", "image/jpg":
-		return ".jpg"
-	case "image/png":
-		return ".png"
-	case "image/webp":
-		return ".webp"
-	default:
-		return ""
-	}
-}
-
-// closeFile safely closes a file
-func closeFile(file io.Closer) {
-	if err := file.Close(); err != nil {
-		slog.Default().Error("file close error", slog.String("error", err.Error()))
-	}
-}
-
-// closeFileHandle safely closes an os.File
-func closeFileHandle(f *os.File) {
-	if err := f.Close(); err != nil {
-		slog.Default().Error("file close error", slog.String("error", err.Error()))
-	}
-}
-
-// removeFile attempts to remove a file, logging any error
-func removeFile(path string) {
-	if err := os.Remove(path); err != nil {
-		slog.Default().Error("failed to remove file",
-			slog.String("path", path),
-			slog.String("error", err.Error()))
-	}
 }
 
 // deleteAvatar removes the current user's avatar
@@ -511,7 +385,6 @@ func (res *Resource) deleteAvatar(w http.ResponseWriter, r *http.Request) {
 
 // serveAvatar serves avatar images with authentication
 func (res *Resource) serveAvatar(w http.ResponseWriter, r *http.Request) {
-	// Get filename from URL
 	filename := chi.URLParam(r, "filename")
 	if filename == "" {
 		render.Status(r, http.StatusBadRequest)
@@ -520,135 +393,34 @@ func (res *Resource) serveAvatar(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate avatar access for current user
-	avatarPath, err := res.validateAvatarAccess(r, filename)
-	if err != nil {
-		common.RenderError(w, r, err)
-		return
-	}
-
-	// Construct and validate file path from the stored avatar path
-	filePath, rendErr := validateAvatarPath(avatarPath)
-	if rendErr != nil {
-		common.RenderError(w, r, rendErr)
-		return
-	}
-
-	// Open and serve the file
-	res.serveAvatarFile(w, r, filePath, filename)
-}
-
-// validateAvatarAccess checks if the current user can access the requested avatar
-func (res *Resource) validateAvatarAccess(r *http.Request, filename string) (string, render.Renderer) {
 	profile, err := res.service.GetCurrentProfile(r.Context())
 	if err != nil {
-		return "", ErrorRenderer(err)
+		common.RenderError(w, r, ErrorRenderer(err))
+		return
 	}
 
 	avatarPath, ok := profile["avatar"].(string)
 	if !ok || avatarPath == "" {
 		render.Status(r, http.StatusNotFound)
-		return "", common.ErrorNotFound(errors.New("no avatar found"))
+		common.RenderError(w, r, common.ErrorNotFound(errors.New("no avatar found")))
+		return
 	}
 
 	if filepath.Base(avatarPath) != filename {
 		render.Status(r, http.StatusForbidden)
-		return "", common.ErrorForbidden(errors.New("access denied"))
-	}
-
-	return avatarPath, nil
-}
-
-// validateAvatarPath validates the stored avatar path and converts it to a filesystem path.
-func validateAvatarPath(avatarPath string) (string, render.Renderer) {
-	filePath, err := avatarPathToFilePath(avatarPath)
-	if err != nil {
-		return "", common.ErrorForbidden(err)
-	}
-
-	return filePath, nil
-}
-
-func avatarPathToFilePath(avatarPath string) (string, error) {
-	if !strings.HasPrefix(avatarPath, "/uploads/avatars/") {
-		return "", errors.New("invalid avatar path")
-	}
-
-	absAvatarDir, err := filepath.Abs(avatarDir)
-	if err != nil {
-		return "", errors.New("failed to process avatar directory")
-	}
-
-	filePath := filepath.Join("public", strings.TrimPrefix(avatarPath, "/"))
-	absPath, err := filepath.Abs(filePath)
-	if err != nil {
-		return "", errors.New("failed to process path")
-	}
-
-	avatarPrefix := absAvatarDir + string(os.PathSeparator)
-	if absPath != absAvatarDir && !strings.HasPrefix(absPath, avatarPrefix) {
-		return "", errors.New("invalid path")
-	}
-
-	return filePath, nil
-}
-
-// serveAvatarFile opens and serves the avatar file
-func (res *Resource) serveAvatarFile(w http.ResponseWriter, r *http.Request, filePath, filename string) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			render.Status(r, http.StatusNotFound)
-			common.RenderError(w, r, common.ErrorNotFound(errors.New("avatar not found")))
-		} else {
-			render.Status(r, http.StatusInternalServerError)
-			common.RenderError(w, r, common.ErrorInternalServer(errors.New("failed to read avatar")))
-		}
-		return
-	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			slog.Default().Error("file close error", slog.String("error", err.Error()))
-		}
-	}()
-
-	fileInfo, err := file.Stat()
-	if err != nil {
-		render.Status(r, http.StatusInternalServerError)
-		common.RenderError(w, r, common.ErrorInternalServer(errors.New("failed to read avatar info")))
+		common.RenderError(w, r, common.ErrorForbidden(errors.New("access denied")))
 		return
 	}
 
-	// Detect content type
-	buffer := make([]byte, 512)
-	n, _ := file.Read(buffer[:])
-	contentType := http.DetectContentType(buffer[:n])
-
-	if _, err := file.Seek(0, 0); err != nil {
-		slog.Default().ErrorContext(r.Context(), "failed to seek avatar file", slog.String("error", err.Error()))
-		http.Error(w, "Failed to read file", http.StatusInternalServerError)
+	// Resolve and serve
+	filePath, err := common.ResolveStoredPath("public", avatarPath, "/uploads/avatars/")
+	if err != nil {
+		render.Status(r, http.StatusForbidden)
+		common.RenderError(w, r, common.ErrorForbidden(err))
 		return
 	}
 
-	w.Header().Set("Content-Type", contentType)
-	w.Header().Set("Content-Length", strconv.FormatInt(fileInfo.Size(), 10))
-	w.Header().Set("Cache-Control", "private, max-age=86400")
-
-	http.ServeContent(w, r, filename, fileInfo.ModTime(), file)
-}
-
-// generateRandomString generates a cryptographically secure random string of specified length
-func generateRandomString(length int) (string, error) {
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	b := make([]byte, length)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-
-	// Map random bytes to charset
-	for i := range b {
-		b[i] = charset[b[i]%byte(len(charset))]
-	}
-	return string(b), nil
+	common.ServeImage(w, r, filepath.Dir(filePath), filepath.Base(filePath), "private, max-age=86400")
 }
 
 // =============================================================================

--- a/backend/api/usercontext/avatar_access_test.go
+++ b/backend/api/usercontext/avatar_access_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	activityModels "github.com/moto-nrw/project-phoenix/models/activities"
 	authModel "github.com/moto-nrw/project-phoenix/models/auth"
@@ -16,7 +15,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/users"
 	usercontextsvc "github.com/moto-nrw/project-phoenix/services/usercontext"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type mockAvatarUserContextService struct {
@@ -89,7 +87,7 @@ func requestWithAvatarFilename(filename string) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
 }
 
-func TestValidateAvatarAccess_ServiceError(t *testing.T) {
+func TestServeAvatar_ServiceError(t *testing.T) {
 	resource := &Resource{
 		service: &mockAvatarUserContextService{
 			getCurrentProfileFunc: func(context.Context) (map[string]interface{}, error) {
@@ -100,17 +98,15 @@ func TestValidateAvatarAccess_ServiceError(t *testing.T) {
 			},
 		},
 	}
+	req := requestWithAvatarFilename("avatar.jpg")
+	rr := httptest.NewRecorder()
 
-	avatarPath, renderer := resource.validateAvatarAccess(requestWithAvatarFilename("avatar.jpg"), "avatar.jpg")
+	resource.serveAvatar(rr, req)
 
-	assert.Empty(t, avatarPath)
-	require.NotNil(t, renderer)
-
-	errResp := renderer.(*common.ErrResponse)
-	assert.Equal(t, http.StatusUnauthorized, errResp.HTTPStatusCode)
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 
-func TestValidateAvatarAccess_NoAvatar(t *testing.T) {
+func TestServeAvatar_NoAvatar(t *testing.T) {
 	resource := &Resource{
 		service: &mockAvatarUserContextService{
 			getCurrentProfileFunc: func(context.Context) (map[string]interface{}, error) {
@@ -118,17 +114,15 @@ func TestValidateAvatarAccess_NoAvatar(t *testing.T) {
 			},
 		},
 	}
+	req := requestWithAvatarFilename("avatar.jpg")
+	rr := httptest.NewRecorder()
 
-	avatarPath, renderer := resource.validateAvatarAccess(requestWithAvatarFilename("avatar.jpg"), "avatar.jpg")
+	resource.serveAvatar(rr, req)
 
-	assert.Empty(t, avatarPath)
-	require.NotNil(t, renderer)
-
-	errResp := renderer.(*common.ErrResponse)
-	assert.Equal(t, http.StatusNotFound, errResp.HTTPStatusCode)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
 }
 
-func TestValidateAvatarAccess_FilenameMismatch(t *testing.T) {
+func TestServeAvatar_FilenameMismatch(t *testing.T) {
 	resource := &Resource{
 		service: &mockAvatarUserContextService{
 			getCurrentProfileFunc: func(context.Context) (map[string]interface{}, error) {
@@ -136,29 +130,12 @@ func TestValidateAvatarAccess_FilenameMismatch(t *testing.T) {
 			},
 		},
 	}
+	req := requestWithAvatarFilename("expected.jpg")
+	rr := httptest.NewRecorder()
 
-	avatarPath, renderer := resource.validateAvatarAccess(requestWithAvatarFilename("expected.jpg"), "expected.jpg")
+	resource.serveAvatar(rr, req)
 
-	assert.Empty(t, avatarPath)
-	require.NotNil(t, renderer)
-
-	errResp := renderer.(*common.ErrResponse)
-	assert.Equal(t, http.StatusForbidden, errResp.HTTPStatusCode)
-}
-
-func TestValidateAvatarAccess_Success(t *testing.T) {
-	resource := &Resource{
-		service: &mockAvatarUserContextService{
-			getCurrentProfileFunc: func(context.Context) (map[string]interface{}, error) {
-				return map[string]interface{}{"avatar": "/uploads/avatars/global/expected.jpg"}, nil
-			},
-		},
-	}
-
-	avatarPath, renderer := resource.validateAvatarAccess(requestWithAvatarFilename("expected.jpg"), "expected.jpg")
-
-	assert.Equal(t, "/uploads/avatars/global/expected.jpg", avatarPath)
-	assert.Nil(t, renderer)
+	assert.Equal(t, http.StatusForbidden, rr.Code)
 }
 
 func TestServeAvatar_EmptyFilename(t *testing.T) {
@@ -185,4 +162,25 @@ func TestServeAvatar_InvalidStoredPath(t *testing.T) {
 	resource.serveAvatar(rr, req)
 
 	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestServeAvatar_MatchingFilename_PassesAccessControl(t *testing.T) {
+	// A valid avatar path with matching filename passes all access control guards.
+	// The request reaches common.ServeImage which returns 404 because the file
+	// doesn't exist on disk — proving the path traversal check, filename match,
+	// and stored-path validation all succeeded.
+	resource := &Resource{
+		service: &mockAvatarUserContextService{
+			getCurrentProfileFunc: func(context.Context) (map[string]interface{}, error) {
+				return map[string]interface{}{"avatar": "/uploads/avatars/global/user_abc123.jpg"}, nil
+			},
+		},
+	}
+	req := requestWithAvatarFilename("user_abc123.jpg")
+	rr := httptest.NewRecorder()
+
+	resource.serveAvatar(rr, req)
+
+	// 404 = file not on disk, but all access checks passed (not 400/401/403)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
 }

--- a/backend/api/usercontext/helpers_test.go
+++ b/backend/api/usercontext/helpers_test.go
@@ -3,7 +3,6 @@ package usercontext
 import (
 	"errors"
 	"net/http"
-	"path/filepath"
 	"testing"
 
 	"github.com/moto-nrw/project-phoenix/api/common"
@@ -126,177 +125,11 @@ func TestErrorRenderer_NonUserContextError(t *testing.T) {
 }
 
 // =============================================================================
-// getFileExtension Tests
+// Upload helper tests moved to api/common/ (shared upload package)
 // =============================================================================
 
-func TestGetFileExtension_WithExtension(t *testing.T) {
-	tests := []struct {
-		filename    string
-		contentType string
-		expected    string
-	}{
-		{"image.jpg", "image/jpeg", ".jpg"},
-		{"photo.png", "image/png", ".png"},
-		{"pic.webp", "image/webp", ".webp"},
-		{"file.JPEG", "image/jpeg", ".JPEG"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.filename, func(t *testing.T) {
-			result := getFileExtension(tt.filename, tt.contentType)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestGetFileExtension_WithoutExtension(t *testing.T) {
-	tests := []struct {
-		name        string
-		filename    string
-		contentType string
-		expected    string
-	}{
-		{"jpeg", "image", "image/jpeg", ".jpg"},
-		{"jpg", "image", "image/jpg", ".jpg"},
-		{"png", "image", "image/png", ".png"},
-		{"webp", "image", "image/webp", ".webp"},
-		{"unknown", "image", "application/octet-stream", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := getFileExtension(tt.filename, tt.contentType)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 // =============================================================================
-// generateRandomString Tests
-// =============================================================================
-
-func TestGenerateRandomString_ReturnsCorrectLength(t *testing.T) {
-	lengths := []int{4, 8, 16, 32}
-
-	for _, length := range lengths {
-		result, err := generateRandomString(length)
-		assert.NoError(t, err)
-		assert.Equal(t, length, len(result))
-	}
-}
-
-func TestGenerateRandomString_ReturnsUnique(t *testing.T) {
-	results := make(map[string]bool)
-	for i := 0; i < 100; i++ {
-		result, err := generateRandomString(16)
-		assert.NoError(t, err)
-		assert.False(t, results[result], "Generated duplicate string")
-		results[result] = true
-	}
-}
-
-func TestGenerateRandomString_ZeroLength(t *testing.T) {
-	result, err := generateRandomString(0)
-	assert.NoError(t, err)
-	assert.Equal(t, "", result)
-}
-
-// =============================================================================
-// validateAvatarPath Tests
-// =============================================================================
-
-func TestValidateAvatarPath_ValidPath(t *testing.T) {
-	validPaths := []string{
-		"/uploads/avatars/global/12345_abc123.jpg",
-		"/uploads/avatars/1/1_x.png",
-		"/uploads/avatars/99999999/99999999_abcdefgh.webp",
-	}
-
-	for _, path := range validPaths {
-		t.Run(path, func(t *testing.T) {
-			filePath, errRenderer := validateAvatarPath(path)
-			assert.Nil(t, errRenderer, "Expected no error for valid path")
-			assert.NotEmpty(t, filePath, "Expected non-empty file path")
-		})
-	}
-}
-
-func TestValidateAvatarPath_InvalidPath(t *testing.T) {
-	// Test path traversal attacks - these should be rejected
-	invalidPaths := []struct {
-		name string
-		path string
-	}{
-		{"path traversal up", "/uploads/avatars/../etc/passwd"},
-		{"double dot", ".."},
-		{"path traversal up2", "/uploads/avatars/global/../../secret.txt"},
-		{"wrong base path", "/uploads/not-avatars/file.jpg"},
-	}
-
-	for _, tt := range invalidPaths {
-		t.Run(tt.name, func(t *testing.T) {
-			_, errRenderer := validateAvatarPath(tt.path)
-			assert.NotNil(t, errRenderer, "Expected error for invalid path: %s", tt.path)
-		})
-	}
-}
-
-func TestAvatarPathToFilePath_ValidPaths(t *testing.T) {
-	testCases := []struct {
-		name       string
-		avatarPath string
-		want       string
-	}{
-		{
-			name:       "global avatar path",
-			avatarPath: "/uploads/avatars/global/12345_abc123.jpg",
-			want:       filepath.Join("public", "uploads", "avatars", "global", "12345_abc123.jpg"),
-		},
-		{
-			name:       "legacy tenant avatar path",
-			avatarPath: "/uploads/avatars/1/1_x.png",
-			want:       filepath.Join("public", "uploads", "avatars", "1", "1_x.png"),
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := avatarPathToFilePath(tt.avatarPath)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestAvatarPathToFilePath_InvalidPaths(t *testing.T) {
-	testCases := []struct {
-		name       string
-		avatarPath string
-		wantErr    string
-	}{
-		{
-			name:       "invalid prefix",
-			avatarPath: "/uploads/not-avatars/file.jpg",
-			wantErr:    "invalid avatar path",
-		},
-		{
-			name:       "path traversal",
-			avatarPath: "/uploads/avatars/global/../../secret.txt",
-			wantErr:    "invalid path",
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := avatarPathToFilePath(tt.avatarPath)
-			assert.Empty(t, got)
-			assert.EqualError(t, err, tt.wantErr)
-		})
-	}
-}
-
-// =============================================================================
-// AllowedImageTypes Tests
+// AllowedImageTypes Tests (now in common package)
 // =============================================================================
 
 func TestAllowedImageTypes(t *testing.T) {
@@ -304,10 +137,10 @@ func TestAllowedImageTypes(t *testing.T) {
 	notAllowed := []string{"image/gif", "image/bmp", "application/pdf", "text/html"}
 
 	for _, ct := range allowed {
-		assert.True(t, allowedImageTypes[ct], "%s should be allowed", ct)
+		assert.True(t, common.AllowedImageTypes[ct], "%s should be allowed", ct)
 	}
 
 	for _, ct := range notAllowed {
-		assert.False(t, allowedImageTypes[ct], "%s should not be allowed", ct)
+		assert.False(t, common.AllowedImageTypes[ct], "%s should not be allowed", ct)
 	}
 }

--- a/backend/api/usercontext/usercontext_internal_test.go
+++ b/backend/api/usercontext/usercontext_internal_test.go
@@ -1,106 +1,14 @@
 // Package usercontext internal tests for pure helper functions.
 // These tests verify logic that doesn't require database access.
+//
+// Upload helper tests (detectContentType, CloseFile, etc.) moved to api/common/.
 package usercontext
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-// =============================================================================
-// detectAndValidateContentType Tests
-// =============================================================================
-
-// mockReadSeeker is a test helper that implements io.ReadSeeker
-type mockReadSeeker struct {
-	*bytes.Reader
-}
-
-func newMockReadSeeker(data []byte) *mockReadSeeker {
-	return &mockReadSeeker{bytes.NewReader(data)}
-}
-
-func TestDetectAndValidateContentType_JPEG(t *testing.T) {
-	// JPEG magic bytes
-	jpegBytes := make([]byte, 512)
-	jpegBytes[0] = 0xFF
-	jpegBytes[1] = 0xD8
-	jpegBytes[2] = 0xFF
-
-	reader := newMockReadSeeker(jpegBytes)
-	contentType, err := detectAndValidateContentType(reader)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "image/jpeg", contentType)
-}
-
-func TestDetectAndValidateContentType_PNG(t *testing.T) {
-	// PNG magic bytes
-	pngBytes := make([]byte, 512)
-	copy(pngBytes, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A})
-
-	reader := newMockReadSeeker(pngBytes)
-	contentType, err := detectAndValidateContentType(reader)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "image/png", contentType)
-}
-
-// Note: WebP test skipped because http.DetectContentType requires full RIFF header
-// which is complex to mock correctly
-
-func TestDetectAndValidateContentType_InvalidType(t *testing.T) {
-	// HTML content - not allowed
-	htmlBytes := []byte("<!DOCTYPE html><html><body>Hello</body></html>")
-	// Pad to 512 bytes
-	padded := make([]byte, 512)
-	copy(padded, htmlBytes)
-
-	reader := newMockReadSeeker(padded)
-	_, err := detectAndValidateContentType(reader)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid file type")
-}
-
-func TestDetectAndValidateContentType_EmptyFile(t *testing.T) {
-	reader := newMockReadSeeker([]byte{})
-	_, err := detectAndValidateContentType(reader)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot read file")
-}
-
-// =============================================================================
-// closeFile Tests
-// =============================================================================
-
-type mockCloser struct {
-	closed bool
-	err    error
-}
-
-func (m *mockCloser) Close() error {
-	m.closed = true
-	return m.err
-}
-
-func TestCloseFile_Success(t *testing.T) {
-	closer := &mockCloser{}
-	closeFile(closer)
-	assert.True(t, closer.closed)
-}
-
-func TestCloseFile_WithError(t *testing.T) {
-	closer := &mockCloser{err: assert.AnError}
-	// Should not panic even if close returns error
-	closeFile(closer)
-	assert.True(t, closer.closed)
-}
-
-// NOTE: closeFileHandle tests skipped as they require real *os.File
 
 // =============================================================================
 // ProfileUpdateRequest Tests

--- a/backend/api/usercontext/usercontext_test.go
+++ b/backend/api/usercontext/usercontext_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 
+	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/api/testutil"
 	usercontextAPI "github.com/moto-nrw/project-phoenix/api/usercontext"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
@@ -628,8 +629,15 @@ func TestServeAvatar_GlobalAvatarFile(t *testing.T) {
 
 	_, account := testpkg.CreateTestPersonWithAccount(t, ctx.db, "Avatar", "GlobalFile")
 
-	avatarDir := filepath.Join("public", "uploads", "avatars", "global")
-	err := os.MkdirAll(avatarDir, 0755)
+	// Resolve the public directory the same way production code does,
+	// so the file is created where ServeImage will look for it.
+	publicDir, err := common.ResolvePublicDir()
+	if err != nil {
+		// No resolved public dir — create one relative to CWD so the resolver finds it.
+		publicDir = filepath.Join("public")
+	}
+	avatarDir := filepath.Join(publicDir, "uploads", "avatars", "global")
+	err = os.MkdirAll(avatarDir, 0755)
 	require.NoError(t, err)
 
 	filename := fmt.Sprintf("%d_test-avatar.jpg", account.ID)

--- a/backend/auth/device/device_auth_test.go
+++ b/backend/auth/device/device_auth_test.go
@@ -955,6 +955,9 @@ func (m *mockSchoolRepo) FindByID(_ context.Context, _ int64) (*platform.School,
 func (m *mockSchoolRepo) FindByIDForShare(_ context.Context, _ int64) (*platform.School, error) {
 	return m.school, m.err
 }
+func (m *mockSchoolRepo) FindByIDForUpdate(_ context.Context, _ int64) (*platform.School, error) {
+	return m.school, m.err
+}
 func (m *mockSchoolRepo) Create(_ context.Context, _ *platform.School) error { return nil }
 func (m *mockSchoolRepo) FindBySlug(_ context.Context, _ string) (*platform.School, error) {
 	return nil, nil

--- a/backend/database/repositories/platform/school_repository.go
+++ b/backend/database/repositories/platform/school_repository.go
@@ -99,6 +99,27 @@ func (r *SchoolRepository) FindByIDForShare(ctx context.Context, id int64) (*pla
 	return school, nil
 }
 
+// FindByIDForUpdate returns a school by ID while acquiring a FOR UPDATE lock on the row.
+// This serializes concurrent read-modify-write cycles (e.g., JSONB settings updates)
+// by blocking other transactions from reading or writing the same row until the calling
+// transaction completes. Must be called within a transaction.
+func (r *SchoolRepository) FindByIDForUpdate(ctx context.Context, id int64) (*platform.School, error) {
+	school := new(platform.School)
+	err := base.GetDB(ctx, r.db).NewSelect().
+		Model(school).
+		ModelTableExpr(schoolTableAlias).
+		Where(`"school".id = ?`, id).
+		For("UPDATE").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, &modelBase.DatabaseError{Op: "find school by id for update", Err: err}
+		}
+		return nil, err
+	}
+	return school, nil
+}
+
 // FindBySlug returns a non-deleted school by its slug.
 // Soft-deleted schools are filtered out (returns nil, nil). Callers that need to
 // distinguish "doesn't exist" from "exists but deleted" should use FindBySubdomain,

--- a/backend/database/repositories/platform/school_repository_test.go
+++ b/backend/database/repositories/platform/school_repository_test.go
@@ -115,6 +115,19 @@ func TestSchoolRepository_QueryMethods(t *testing.T) {
 		assert.Nil(t, found)
 	})
 
+	t.Run("find by id for update returns school", func(t *testing.T) {
+		found, err := repo.FindByIDForUpdate(ctx, schoolA.ID)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		assert.Equal(t, schoolA.Subdomain, found.Subdomain)
+	})
+
+	t.Run("find by id for update wraps not found", func(t *testing.T) {
+		found, err := repo.FindByIDForUpdate(ctx, 999999999)
+		require.Error(t, err)
+		assert.Nil(t, found)
+	})
+
 	t.Run("find by slug returns first matching scoped row", func(t *testing.T) {
 		found, err := repo.FindBySlug(ctx, schoolA.Slug)
 		require.NoError(t, err)

--- a/backend/models/platform/repository.go
+++ b/backend/models/platform/repository.go
@@ -74,6 +74,7 @@ type SchoolRepository interface {
 	Create(ctx context.Context, school *School) error
 	FindByID(ctx context.Context, id int64) (*School, error)
 	FindByIDForShare(ctx context.Context, id int64) (*School, error)
+	FindByIDForUpdate(ctx context.Context, id int64) (*School, error)
 	FindBySlug(ctx context.Context, slug string) (*School, error)
 	FindByOrganizationAndSlug(ctx context.Context, organizationID int64, slug string) (*School, error)
 	FindBySubdomain(ctx context.Context, subdomain string) (*School, error)

--- a/backend/services/auth/auth_login_internal_test.go
+++ b/backend/services/auth/auth_login_internal_test.go
@@ -62,6 +62,9 @@ func (s stubAuthLoginSchoolRepo) CountByIDs(context.Context, []int64) (int, erro
 func (s stubAuthLoginSchoolRepo) FindByIDForShare(ctx context.Context, id int64) (*platformModels.School, error) {
 	return s.FindByID(ctx, id)
 }
+func (s stubAuthLoginSchoolRepo) FindByIDForUpdate(ctx context.Context, id int64) (*platformModels.School, error) {
+	return s.FindByID(ctx, id)
+}
 func (r stubAuthLoginSchoolRepo) SoftDelete(context.Context, int64) error { return nil }
 func (r stubAuthLoginSchoolRepo) Restore(context.Context, int64) error    { return nil }
 

--- a/backend/services/auth/test_helpers_test.go
+++ b/backend/services/auth/test_helpers_test.go
@@ -1279,6 +1279,10 @@ func (r *stubSchoolRepository) FindByIDForShare(ctx context.Context, id int64) (
 	return r.FindByID(ctx, id)
 }
 
+func (r *stubSchoolRepository) FindByIDForUpdate(ctx context.Context, id int64) (*platformModel.School, error) {
+	return r.FindByID(ctx, id)
+}
+
 func (r *stubSchoolRepository) FindBySlug(context.Context, string) (*platformModel.School, error) {
 	return nil, fmt.Errorf("not found")
 }

--- a/backend/services/config/helpers_test.go
+++ b/backend/services/config/helpers_test.go
@@ -51,6 +51,15 @@ func (f *fakeSettingsService) SetValue(context.Context, string, any, *int64, []s
 func (f *fakeSettingsService) ResetValue(context.Context, string, *int64, []string) error {
 	return nil
 }
+func (f *fakeSettingsService) GetLoginImageURL(context.Context, int64) (string, error) {
+	return "", nil
+}
+func (f *fakeSettingsService) SetLoginImageURL(context.Context, int64, string) (string, error) {
+	return "", nil
+}
+func (f *fakeSettingsService) ClearLoginImageURL(context.Context, int64) (string, error) {
+	return "", nil
+}
 
 func TestResolveBoolOrDefault_NilService_ReturnsFallback(t *testing.T) {
 	got := configSvc.ResolveBoolOrDefault(context.Background(), nil, "any.key", true, nil)

--- a/backend/services/config/settings_interface.go
+++ b/backend/services/config/settings_interface.go
@@ -42,6 +42,20 @@ type SettingsService interface {
 	// userPermissions is checked against the definition's WritePermission.
 	// Pass nil to skip permission checks (for system-level callers).
 	ResetValue(ctx context.Context, key string, changedBy *int64, userPermissions []string) error
+
+	// GetLoginImageURL returns the loginImageUrl from the school's settings JSONB.
+	// Returns empty string if no login image is set.
+	GetLoginImageURL(ctx context.Context, tenantID int64) (string, error)
+
+	// SetLoginImageURL sets the loginImageUrl in the school's settings JSONB.
+	// Uses WithAdminTx because platform.schools requires the phoenix_admin role.
+	// Returns the previous loginImageUrl (if any) so the caller can clean up the old file.
+	SetLoginImageURL(ctx context.Context, tenantID int64, imageURL string) (oldURL string, err error)
+
+	// ClearLoginImageURL removes the loginImageUrl from the school's settings JSONB.
+	// Uses WithAdminTx because platform.schools requires the phoenix_admin role.
+	// Returns the previous loginImageUrl (if any) so the caller can clean up the old file.
+	ClearLoginImageURL(ctx context.Context, tenantID int64) (oldURL string, err error)
 }
 
 // --- Response types ---

--- a/backend/services/config/settings_service.go
+++ b/backend/services/config/settings_service.go
@@ -11,29 +11,33 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/models/config"
+	"github.com/moto-nrw/project-phoenix/models/platform"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
 
 type settingsService struct {
-	valueRepo config.SettingValueRepository
-	auditRepo config.SettingAuditRepository
-	db        *bun.DB
-	logger    *slog.Logger
+	valueRepo  config.SettingValueRepository
+	auditRepo  config.SettingAuditRepository
+	schoolRepo platform.SchoolRepository
+	db         *bun.DB
+	logger     *slog.Logger
 }
 
 // NewSettingsService creates a new SettingsService.
 func NewSettingsService(
 	valueRepo config.SettingValueRepository,
 	auditRepo config.SettingAuditRepository,
+	schoolRepo platform.SchoolRepository,
 	db *bun.DB,
 	logger *slog.Logger,
 ) SettingsService {
 	return &settingsService{
-		valueRepo: valueRepo,
-		auditRepo: auditRepo,
-		db:        db,
-		logger:    logger.With("service", "settings"),
+		valueRepo:  valueRepo,
+		auditRepo:  auditRepo,
+		schoolRepo: schoolRepo,
+		db:         db,
+		logger:     logger.With("service", "settings"),
 	}
 }
 
@@ -423,4 +427,94 @@ func toFloat64(v any) (float64, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// --- Login image settings (stored in platform.schools.settings JSONB) ---
+
+const loginImageKey = "loginImageUrl"
+
+// GetLoginImageURL returns the loginImageUrl from the school's settings JSONB.
+func (s *settingsService) GetLoginImageURL(ctx context.Context, tenantID int64) (string, error) {
+	if tenantID <= 0 {
+		return "", nil
+	}
+
+	school, err := s.schoolRepo.FindByID(ctx, tenantID)
+	if err != nil {
+		return "", fmt.Errorf("find school: %w", err)
+	}
+
+	settings, err := unmarshalSchoolSettings(school.Settings)
+	if err != nil {
+		return "", err
+	}
+
+	url, _ := settings[loginImageKey].(string)
+	return url, nil
+}
+
+// SetLoginImageURL sets the loginImageUrl in the school's settings JSONB.
+func (s *settingsService) SetLoginImageURL(ctx context.Context, tenantID int64, imageURL string) (oldURL string, err error) {
+	return s.updateSchoolSetting(ctx, tenantID, &imageURL)
+}
+
+// ClearLoginImageURL removes the loginImageUrl from the school's settings JSONB.
+func (s *settingsService) ClearLoginImageURL(ctx context.Context, tenantID int64) (oldURL string, err error) {
+	return s.updateSchoolSetting(ctx, tenantID, nil)
+}
+
+// updateSchoolSetting updates the loginImageUrl in the school's settings JSONB.
+// Uses WithAdminTx because platform.schools requires the phoenix_admin role.
+// Pass nil imageURL to remove the key.
+func (s *settingsService) updateSchoolSetting(ctx context.Context, tenantID int64, imageURL *string) (oldURL string, err error) {
+	err = tenant.WithAdminTx(ctx, s.db, func(adminCtx context.Context, _ bun.Tx) error {
+		// Use FOR UPDATE lock to serialize concurrent read-modify-write on the JSONB settings.
+		// FOR SHARE is insufficient here: two transactions could both acquire the shared lock,
+		// read the same JSONB, and then deadlock when both try to UPDATE the row.
+		school, findErr := s.schoolRepo.FindByIDForUpdate(adminCtx, tenantID)
+		if findErr != nil {
+			return fmt.Errorf("find school: %w", findErr)
+		}
+
+		settings, unmarshalErr := unmarshalSchoolSettings(school.Settings)
+		if unmarshalErr != nil {
+			return unmarshalErr
+		}
+
+		oldURL, _ = settings[loginImageKey].(string)
+
+		if imageURL != nil {
+			settings[loginImageKey] = *imageURL
+		} else {
+			delete(settings, loginImageKey)
+		}
+
+		settingsJSON, marshalErr := json.Marshal(settings)
+		if marshalErr != nil {
+			return fmt.Errorf("marshal settings: %w", marshalErr)
+		}
+		school.Settings = string(settingsJSON)
+
+		return s.schoolRepo.Update(adminCtx, school)
+	})
+	return oldURL, err
+}
+
+// unmarshalSchoolSettings parses the school's settings JSONB string into a map.
+// Empty or missing settings return an empty map. Corrupt JSON returns an error
+// to prevent silent data loss on subsequent writes.
+func unmarshalSchoolSettings(raw string) (map[string]interface{}, error) {
+	if raw == "" || raw == "{}" || raw == "null" {
+		return make(map[string]interface{}), nil
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &settings); err != nil {
+		return nil, fmt.Errorf("corrupt school settings JSON: %w", err)
+	}
+	// json.Unmarshal into map returns nil for the JSON literal "null".
+	// Coerce to an empty map so callers can safely assign keys.
+	if settings == nil {
+		return make(map[string]interface{}), nil
+	}
+	return settings, nil
 }

--- a/backend/services/config/settings_service_test.go
+++ b/backend/services/config/settings_service_test.go
@@ -6,10 +6,15 @@ import (
 	"fmt"
 	"log/slog"
 	"testing"
+	"time"
 
+	platformRepo "github.com/moto-nrw/project-phoenix/database/repositories/platform"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/config"
+	"github.com/moto-nrw/project-phoenix/models/platform"
 	configSvc "github.com/moto-nrw/project-phoenix/services/config"
 	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -110,7 +115,7 @@ func tenantCtx(tenantID int64) context.Context {
 }
 
 func createService(valueRepo config.SettingValueRepository, auditRepo config.SettingAuditRepository) configSvc.SettingsService {
-	return configSvc.NewSettingsService(valueRepo, auditRepo, nil, slog.Default())
+	return configSvc.NewSettingsService(valueRepo, auditRepo, nil, nil, slog.Default())
 }
 
 // --- Tests ---
@@ -1413,4 +1418,333 @@ func TestResolveString_UnknownKey(t *testing.T) {
 	svc := createService(newMockValueRepo(), &mockAuditRepo{})
 	_, err := svc.ResolveString(tenantCtx(1), "nonexistent.key")
 	require.Error(t, err)
+}
+
+// --- Mock school repository for login image tests ---
+
+type mockSchoolRepo struct {
+	school *platform.School
+	err    error
+}
+
+func (m *mockSchoolRepo) Create(_ context.Context, _ *platform.School) error {
+	return m.err
+}
+
+func (m *mockSchoolRepo) FindByID(_ context.Context, id int64) (*platform.School, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.school == nil || m.school.ID != id {
+		return nil, fmt.Errorf("school not found")
+	}
+	return m.school, nil
+}
+
+func (m *mockSchoolRepo) FindByIDForShare(_ context.Context, id int64) (*platform.School, error) {
+	return m.FindByID(nil, id)
+}
+
+func (m *mockSchoolRepo) FindByIDForUpdate(_ context.Context, id int64) (*platform.School, error) {
+	return m.FindByID(nil, id)
+}
+
+func (m *mockSchoolRepo) FindBySlug(_ context.Context, _ string) (*platform.School, error) {
+	return nil, nil
+}
+
+func (m *mockSchoolRepo) FindByOrganizationAndSlug(_ context.Context, _ int64, _ string) (*platform.School, error) {
+	return nil, nil
+}
+
+func (m *mockSchoolRepo) FindBySubdomain(_ context.Context, _ string) (*platform.School, error) {
+	return nil, nil
+}
+
+func (m *mockSchoolRepo) List(_ context.Context) ([]*platform.School, error) {
+	return nil, nil
+}
+
+func (m *mockSchoolRepo) ListActive(_ context.Context) ([]platform.School, error) {
+	return nil, nil
+}
+
+func (m *mockSchoolRepo) ListPublic(_ context.Context) ([]platform.School, error) {
+	return nil, nil
+}
+
+func (m *mockSchoolRepo) FindActiveByAccountID(_ context.Context, _ int64) ([]platform.School, error) {
+	return nil, nil
+}
+
+func (m *mockSchoolRepo) Update(_ context.Context, school *platform.School) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.school = school
+	return nil
+}
+
+func (m *mockSchoolRepo) SoftDelete(_ context.Context, _ int64) error {
+	return nil
+}
+
+func (m *mockSchoolRepo) Restore(_ context.Context, _ int64) error {
+	return nil
+}
+
+func (m *mockSchoolRepo) CountByIDs(_ context.Context, _ []int64) (int, error) {
+	return 0, nil
+}
+
+func createServiceWithSchoolRepo(
+	valueRepo config.SettingValueRepository,
+	auditRepo config.SettingAuditRepository,
+	schoolRepo platform.SchoolRepository,
+) configSvc.SettingsService {
+	return configSvc.NewSettingsService(valueRepo, auditRepo, schoolRepo, nil, slog.Default())
+}
+
+func newSchool(id int64, settings string) *platform.School {
+	s := &platform.School{Settings: settings}
+	s.ID = id
+	return s
+}
+
+// --- Login image tests ---
+
+func TestGetLoginImageURL_NoImage(t *testing.T) {
+	setupTest(t)
+
+	schoolRepo := &mockSchoolRepo{school: newSchool(42, "")}
+	svc := createServiceWithSchoolRepo(newMockValueRepo(), &mockAuditRepo{}, schoolRepo)
+
+	url, err := svc.GetLoginImageURL(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, "", url)
+}
+
+func TestGetLoginImageURL_EmptyObject(t *testing.T) {
+	setupTest(t)
+
+	schoolRepo := &mockSchoolRepo{school: newSchool(42, "{}")}
+	svc := createServiceWithSchoolRepo(newMockValueRepo(), &mockAuditRepo{}, schoolRepo)
+
+	url, err := svc.GetLoginImageURL(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, "", url)
+}
+
+func TestGetLoginImageURL_NullLiteral(t *testing.T) {
+	setupTest(t)
+
+	schoolRepo := &mockSchoolRepo{school: newSchool(42, "null")}
+	svc := createServiceWithSchoolRepo(newMockValueRepo(), &mockAuditRepo{}, schoolRepo)
+
+	url, err := svc.GetLoginImageURL(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, "", url)
+}
+
+func TestGetLoginImageURL_WithImage(t *testing.T) {
+	setupTest(t)
+
+	settings := `{"loginImageUrl":"/uploads/tenant/42/login.jpg","other":"value"}`
+	schoolRepo := &mockSchoolRepo{school: newSchool(42, settings)}
+	svc := createServiceWithSchoolRepo(newMockValueRepo(), &mockAuditRepo{}, schoolRepo)
+
+	url, err := svc.GetLoginImageURL(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, "/uploads/tenant/42/login.jpg", url)
+}
+
+func TestGetLoginImageURL_InvalidTenantID(t *testing.T) {
+	setupTest(t)
+
+	schoolRepo := &mockSchoolRepo{school: newSchool(42, `{"loginImageUrl":"/img.jpg"}`)}
+	svc := createServiceWithSchoolRepo(newMockValueRepo(), &mockAuditRepo{}, schoolRepo)
+
+	url, err := svc.GetLoginImageURL(context.Background(), 0)
+	require.NoError(t, err)
+	assert.Equal(t, "", url)
+}
+
+func TestGetLoginImageURL_NegativeTenantID(t *testing.T) {
+	setupTest(t)
+
+	schoolRepo := &mockSchoolRepo{school: newSchool(42, `{"loginImageUrl":"/img.jpg"}`)}
+	svc := createServiceWithSchoolRepo(newMockValueRepo(), &mockAuditRepo{}, schoolRepo)
+
+	url, err := svc.GetLoginImageURL(context.Background(), -1)
+	require.NoError(t, err)
+	assert.Equal(t, "", url)
+}
+
+func TestGetLoginImageURL_CorruptJSON(t *testing.T) {
+	setupTest(t)
+
+	schoolRepo := &mockSchoolRepo{school: newSchool(42, "not json")}
+	svc := createServiceWithSchoolRepo(newMockValueRepo(), &mockAuditRepo{}, schoolRepo)
+
+	_, err := svc.GetLoginImageURL(context.Background(), 42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "corrupt school settings JSON")
+}
+
+func TestGetLoginImageURL_RepoError(t *testing.T) {
+	setupTest(t)
+
+	schoolRepo := &mockSchoolRepo{err: fmt.Errorf("database connection lost")}
+	svc := createServiceWithSchoolRepo(newMockValueRepo(), &mockAuditRepo{}, schoolRepo)
+
+	_, err := svc.GetLoginImageURL(context.Background(), 42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "find school")
+}
+
+func TestGetLoginImageURL_SettingsWithOtherKeysButNoImage(t *testing.T) {
+	setupTest(t)
+
+	schoolRepo := &mockSchoolRepo{school: newSchool(42, `{"theme":"dark","lang":"de"}`)}
+	svc := createServiceWithSchoolRepo(newMockValueRepo(), &mockAuditRepo{}, schoolRepo)
+
+	url, err := svc.GetLoginImageURL(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, "", url)
+}
+
+// --- SetLoginImageURL / ClearLoginImageURL integration tests ---
+// These require a real DB because updateSchoolSetting uses tenant.WithAdminTx.
+
+func setupLoginImageIntegrationTest(t *testing.T) (configSvc.SettingsService, *platform.School, func()) {
+	t.Helper()
+
+	db := testpkg.SetupTestDB(t)
+	ctx := testpkg.TenantContext(1)
+
+	// Create a dedicated org + school to avoid polluting shared test state.
+	now := time.Now().UnixNano()
+	orgRepo := platformRepo.NewOrganizationRepository(db)
+	org := &platform.Organization{
+		Model:  modelBase.Model{ID: now},
+		Name:   fmt.Sprintf("LoginImgOrg %d", now),
+		Slug:   fmt.Sprintf("loginimg-org-%d", now),
+		Active: true,
+	}
+	require.NoError(t, orgRepo.Create(ctx, org))
+
+	schoolRepo := platformRepo.NewSchoolRepository(db)
+	school := &platform.School{
+		Model:          modelBase.Model{ID: now + 1},
+		OrganizationID: org.ID,
+		Name:           fmt.Sprintf("LoginImgSchool %d", now),
+		Slug:           fmt.Sprintf("loginimg-%d", now),
+		Subdomain:      fmt.Sprintf("loginimg-%d", now),
+		Active:         true,
+	}
+	require.NoError(t, schoolRepo.Create(ctx, school))
+
+	svc := configSvc.NewSettingsService(
+		newMockValueRepo(), &mockAuditRepo{}, schoolRepo, db, slog.Default(),
+	)
+
+	cleanup := func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.schools WHERE id = ?`, school.ID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.organizations WHERE id = ?`, org.ID)
+		_ = db.Close()
+	}
+
+	return svc, school, cleanup
+}
+
+func TestSetLoginImageURL_Success(t *testing.T) {
+	svc, school, cleanup := setupLoginImageIntegrationTest(t)
+	defer cleanup()
+
+	imageURL := "/uploads/login-images/test_abc.jpg"
+	oldURL, err := svc.SetLoginImageURL(context.Background(), school.ID, imageURL)
+	require.NoError(t, err)
+	assert.Equal(t, "", oldURL, "first set should return empty old URL")
+
+	// Verify it was persisted
+	got, err := svc.GetLoginImageURL(context.Background(), school.ID)
+	require.NoError(t, err)
+	assert.Equal(t, imageURL, got)
+}
+
+func TestSetLoginImageURL_ReplacesExisting(t *testing.T) {
+	svc, school, cleanup := setupLoginImageIntegrationTest(t)
+	defer cleanup()
+
+	first := "/uploads/login-images/first.jpg"
+	second := "/uploads/login-images/second.jpg"
+
+	_, err := svc.SetLoginImageURL(context.Background(), school.ID, first)
+	require.NoError(t, err)
+
+	oldURL, err := svc.SetLoginImageURL(context.Background(), school.ID, second)
+	require.NoError(t, err)
+	assert.Equal(t, first, oldURL, "should return previous URL for cleanup")
+
+	got, err := svc.GetLoginImageURL(context.Background(), school.ID)
+	require.NoError(t, err)
+	assert.Equal(t, second, got)
+}
+
+func TestSetLoginImageURL_PreservesOtherSettings(t *testing.T) {
+	svc, school, cleanup := setupLoginImageIntegrationTest(t)
+	defer cleanup()
+
+	// Pre-populate the school with other settings via direct SQL
+	ctx := testpkg.TenantContext(1)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+	_, err := db.ExecContext(ctx,
+		`UPDATE platform.schools SET settings = '{"theme":"dark","lang":"de"}' WHERE id = ?`,
+		school.ID)
+	require.NoError(t, err)
+
+	imageURL := "/uploads/login-images/preserve.jpg"
+	_, err = svc.SetLoginImageURL(context.Background(), school.ID, imageURL)
+	require.NoError(t, err)
+
+	// Verify other keys survived the update
+	got, err := svc.GetLoginImageURL(context.Background(), school.ID)
+	require.NoError(t, err)
+	assert.Equal(t, imageURL, got)
+}
+
+func TestClearLoginImageURL_Success(t *testing.T) {
+	svc, school, cleanup := setupLoginImageIntegrationTest(t)
+	defer cleanup()
+
+	imageURL := "/uploads/login-images/to-clear.jpg"
+	_, err := svc.SetLoginImageURL(context.Background(), school.ID, imageURL)
+	require.NoError(t, err)
+
+	oldURL, err := svc.ClearLoginImageURL(context.Background(), school.ID)
+	require.NoError(t, err)
+	assert.Equal(t, imageURL, oldURL, "should return removed URL for cleanup")
+
+	got, err := svc.GetLoginImageURL(context.Background(), school.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "", got, "image should be removed")
+}
+
+func TestClearLoginImageURL_NoExistingImage(t *testing.T) {
+	svc, school, cleanup := setupLoginImageIntegrationTest(t)
+	defer cleanup()
+
+	oldURL, err := svc.ClearLoginImageURL(context.Background(), school.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "", oldURL, "clearing when no image exists should return empty")
+}
+
+func TestSetLoginImageURL_NonexistentSchool(t *testing.T) {
+	svc, _, cleanup := setupLoginImageIntegrationTest(t)
+	defer cleanup()
+
+	_, err := svc.SetLoginImageURL(context.Background(), 999999999, "/uploads/test.jpg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "find school")
 }

--- a/backend/services/config/settings_service_test.go
+++ b/backend/services/config/settings_service_test.go
@@ -1442,11 +1442,11 @@ func (m *mockSchoolRepo) FindByID(_ context.Context, id int64) (*platform.School
 }
 
 func (m *mockSchoolRepo) FindByIDForShare(_ context.Context, id int64) (*platform.School, error) {
-	return m.FindByID(nil, id)
+	return m.FindByID(context.Background(), id)
 }
 
 func (m *mockSchoolRepo) FindByIDForUpdate(_ context.Context, id int64) (*platform.School, error) {
-	return m.FindByID(nil, id)
+	return m.FindByID(context.Background(), id)
 }
 
 func (m *mockSchoolRepo) FindBySlug(_ context.Context, _ string) (*platform.School, error) {

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -253,6 +253,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	settingsService := config.NewSettingsService(
 		repos.SettingValue,
 		repos.SettingAudit,
+		repos.School,
 		db,
 		logger,
 	)

--- a/backend/services/platform/operator_provisioning_service_internal_test.go
+++ b/backend/services/platform/operator_provisioning_service_internal_test.go
@@ -54,6 +54,9 @@ func (s *internalSchoolRepoStub) FindByID(ctx context.Context, id int64) (*platf
 func (s *internalSchoolRepoStub) FindByIDForShare(ctx context.Context, id int64) (*platformModels.School, error) {
 	return s.FindByID(ctx, id)
 }
+func (s *internalSchoolRepoStub) FindByIDForUpdate(ctx context.Context, id int64) (*platformModels.School, error) {
+	return s.FindByID(ctx, id)
+}
 func (s *internalSchoolRepoStub) FindBySlug(context.Context, string) (*platformModels.School, error) {
 	return nil, nil
 }

--- a/backend/services/platform/operator_provisioning_service_test.go
+++ b/backend/services/platform/operator_provisioning_service_test.go
@@ -92,6 +92,9 @@ func (m *mockSchoolRepo) FindByID(ctx context.Context, id int64) (*platformModel
 func (m *mockSchoolRepo) FindByIDForShare(ctx context.Context, id int64) (*platformModels.School, error) {
 	return m.FindByID(ctx, id)
 }
+func (m *mockSchoolRepo) FindByIDForUpdate(ctx context.Context, id int64) (*platformModels.School, error) {
+	return m.FindByID(ctx, id)
+}
 func (m *mockSchoolRepo) FindBySlug(context.Context, string) (*platformModels.School, error) {
 	return nil, nil
 }

--- a/backend/services/platform/test_mocks_test.go
+++ b/backend/services/platform/test_mocks_test.go
@@ -240,6 +240,10 @@ func (m *mockSchoolRepoShared) FindByIDForShare(ctx context.Context, id int64) (
 	return m.FindByID(ctx, id)
 }
 
+func (m *mockSchoolRepoShared) FindByIDForUpdate(ctx context.Context, id int64) (*platform.School, error) {
+	return m.FindByID(ctx, id)
+}
+
 func (m *mockSchoolRepoShared) SoftDelete(context.Context, int64) error { return nil }
 func (m *mockSchoolRepoShared) Restore(context.Context, int64) error    { return nil }
 

--- a/frontend/src/app/[tenant]/page.tsx
+++ b/frontend/src/app/[tenant]/page.tsx
@@ -12,6 +12,7 @@ import { PasswordResetModal } from "~/components/ui/password-reset-modal";
 import { launchConfetti, clearConfetti } from "~/lib/confetti";
 import { PasswordToggleButton } from "~/components/shared/password-toggle-button";
 import { useTenant } from "~/components/tenant/tenant-provider";
+import { loginImageSrc } from "~/lib/tenant-api";
 import { useTenantRouter } from "~/lib/tenant-router";
 import { env } from "~/env";
 import { DELIBERATE_LOGOUT_KEY } from "~/lib/session-cache";
@@ -214,13 +215,25 @@ function LoginForm() {
 
         {/* Logo Section */}
         <div className="mb-8 flex justify-center">
-          <Image
-            src="/images/moto_transparent.png"
-            alt="MOTO Logo"
-            width={200}
-            height={80}
-            priority
-          />
+          {tenant?.settings?.loginImageUrl ? (
+            <Image
+              src={loginImageSrc(tenant.settings.loginImageUrl)}
+              alt={`${tenant.name} Logo`}
+              width={200}
+              height={142}
+              className="max-h-[142px] w-auto object-contain"
+              priority
+              unoptimized
+            />
+          ) : (
+            <Image
+              src="/images/moto_transparent.png"
+              alt="MOTO Logo"
+              width={200}
+              height={80}
+              priority
+            />
+          )}
         </div>
 
         {/* Welcome Text */}

--- a/frontend/src/app/api/public/login-image/[filename]/route.test.ts
+++ b/frontend/src/app/api/public/login-image/[filename]/route.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockFetch, mockGetServerApiUrl } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  mockGetServerApiUrl: vi.fn(() => "http://localhost:8080"),
+}));
+
+vi.mock("~/lib/server-api-url", () => ({
+  getServerApiUrl: mockGetServerApiUrl,
+}));
+
+global.fetch = mockFetch as unknown as typeof fetch;
+
+import { GET } from "./route";
+
+function createMockContext(filename: string) {
+  return { params: Promise.resolve({ filename }) };
+}
+
+describe("GET /api/public/login-image/[filename]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 404 when filename contains path traversal (..) ", async () => {
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/public/login-image/..%2Fetc%2Fpasswd",
+      ),
+      createMockContext("../etc/passwd"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when filename contains a slash", async () => {
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/public/login-image/sub/file.png",
+      ),
+      createMockContext("sub/file.png"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when filename is empty", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/public/login-image/"),
+      createMockContext(""),
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("proxies image bytes with Cache-Control header on success", async () => {
+    const imageData = new ArrayBuffer(10);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "Content-Type": "image/png" }),
+      arrayBuffer: async () => imageData,
+    });
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/public/login-image/logo.png"),
+      createMockContext("logo.png"),
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/public/login-image/logo.png",
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("image/png");
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=86400");
+    expect(await response.arrayBuffer()).toEqual(imageData);
+  });
+
+  it("returns 404 when backend returns 404", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      headers: new Headers(),
+    });
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/public/login-image/missing.png",
+      ),
+      createMockContext("missing.png"),
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 502 when backend returns non-image content type", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "Content-Type": "text/html" }),
+      arrayBuffer: async () => new ArrayBuffer(0),
+    });
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/public/login-image/bad.png"),
+      createMockContext("bad.png"),
+    );
+
+    expect(response.status).toBe(502);
+  });
+
+  it("returns 502 when fetch throws a network error", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/public/login-image/logo.png"),
+      createMockContext("logo.png"),
+    );
+
+    expect(response.status).toBe(502);
+  });
+
+  it("returns 502 when backend returns a non-404 error (e.g. 500)", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: new Headers(),
+    });
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/public/login-image/logo.png"),
+      createMockContext("logo.png"),
+    );
+
+    expect(response.status).toBe(502);
+  });
+});

--- a/frontend/src/app/api/public/login-image/[filename]/route.ts
+++ b/frontend/src/app/api/public/login-image/[filename]/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// Public endpoint — no authentication required.
+// Serves tenant login images stored on the backend.
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ filename: string }> },
+) {
+  const { filename } = await context.params;
+
+  // Path traversal protection
+  if (!filename || filename.includes("..") || filename.includes("/")) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  const { getServerApiUrl } = await import("~/lib/server-api-url");
+  const backendUrl = `${getServerApiUrl()}/public/login-image/${encodeURIComponent(filename)}`;
+
+  let response: Response;
+  try {
+    response = await fetch(backendUrl, {
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch {
+    // Network error, DNS failure, or timeout — return 502 instead of
+    // letting the error bubble up as an unhandled 500.
+    return new NextResponse(null, { status: 502 });
+  }
+
+  if (!response.ok) {
+    return new NextResponse(null, {
+      status: response.status === 404 ? 404 : 502,
+    });
+  }
+
+  const contentType = response.headers.get("Content-Type") ?? "";
+  if (!contentType.startsWith("image/")) {
+    return new NextResponse(null, { status: 502 });
+  }
+
+  const body = await response.arrayBuffer();
+
+  return new NextResponse(body, {
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "public, max-age=86400",
+    },
+  });
+}

--- a/frontend/src/app/api/settings/login-image/route.test.ts
+++ b/frontend/src/app/api/settings/login-image/route.test.ts
@@ -120,7 +120,7 @@ describe("POST /api/settings/login-image", () => {
     );
     const response = await POST(request, createMockContext());
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(400);
     const json = (await response.json()) as { error: string };
     expect(json.error).toContain("No image file provided");
   });

--- a/frontend/src/app/api/settings/login-image/route.test.ts
+++ b/frontend/src/app/api/settings/login-image/route.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockAuth,
+  mockUncachedAuth,
+  mockFetch,
+  mockGetServerApiUrl,
+  mockRevalidateTag,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockUncachedAuth: vi.fn(),
+  mockFetch: vi.fn(),
+  mockGetServerApiUrl: vi.fn(() => "http://localhost:8080"),
+  mockRevalidateTag: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+  auth: mockAuth,
+  uncachedAuth: mockUncachedAuth,
+}));
+
+vi.mock("~/lib/server-api-url", () => ({
+  getServerApiUrl: mockGetServerApiUrl,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidateTag: mockRevalidateTag,
+}));
+
+vi.mock("~/lib/api-helpers", () => ({
+  handleApiError: vi.fn((error: unknown) => {
+    const message =
+      error instanceof Error ? error.message : "Internal Server Error";
+    return new Response(JSON.stringify({ error: message }), { status: 500 });
+  }),
+}));
+
+global.fetch = mockFetch as unknown as typeof fetch;
+
+import { POST, DELETE, GET } from "./route";
+
+const defaultSession = {
+  user: { id: "1", token: "test-token", name: "Test User" },
+  expires: "2099-01-01",
+};
+
+function createMockContext() {
+  return { params: Promise.resolve({}) };
+}
+
+function createMockImageFile(): File {
+  const bytes = new Uint8Array([
+    0xff,
+    0xd8,
+    0xff,
+    0xe0,
+    ...new Array<number>(100).fill(0),
+  ]);
+  return new File([bytes], "test.jpg", { type: "image/jpeg" });
+}
+
+describe("POST /api/settings/login-image", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(defaultSession);
+    mockUncachedAuth.mockResolvedValue(defaultSession);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+
+    const formData = new FormData();
+    formData.append("login_image", createMockImageFile());
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      { method: "POST", body: formData },
+    );
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("successfully uploads a valid image", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: { login_image_url: "/uploads/login-image.jpg" },
+      }),
+    });
+
+    const formData = new FormData();
+    formData.append("login_image", createMockImageFile());
+
+    const request = new NextRequest(
+      "http://school-a.localhost:3000/api/settings/login-image",
+      {
+        method: "POST",
+        body: formData,
+        headers: { host: "school-a.localhost:3000" },
+      },
+    );
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      data: { login_image_url: string };
+    };
+    expect(json.data.login_image_url).toBe("/uploads/login-image.jpg");
+  });
+
+  it("rejects request with no file", async () => {
+    const formData = new FormData();
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      { method: "POST", body: formData },
+    );
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(500);
+    const json = (await response.json()) as { error: string };
+    expect(json.error).toContain("No image file provided");
+  });
+
+  it("handles backend error", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "Internal server error",
+      statusText: "Internal Server Error",
+    });
+
+    const formData = new FormData();
+    formData.append("login_image", createMockImageFile());
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      { method: "POST", body: formData },
+    );
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(500);
+  });
+
+  it("calls revalidateTag after successful upload", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: { login_image_url: "/uploads/login-image.jpg" },
+      }),
+    });
+
+    const formData = new FormData();
+    formData.append("login_image", createMockImageFile());
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      { method: "POST", body: formData },
+    );
+    request.headers.set("referer", "http://localhost:3000/school-a/settings");
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(200);
+    expect(mockRevalidateTag).toHaveBeenCalledWith("tenant-school-a", {
+      expire: 0,
+    });
+  });
+
+  it("retries on 401 with refreshed token", async () => {
+    mockUncachedAuth.mockResolvedValueOnce({
+      user: { token: "fresh-token" },
+    });
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: { login_image_url: "/uploads/login-image.jpg" },
+        }),
+      });
+
+    const formData = new FormData();
+    formData.append("login_image", createMockImageFile());
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      {
+        method: "POST",
+        body: formData,
+        headers: { referer: "http://localhost:3000/school-a/settings" },
+      },
+    );
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // First call uses original token
+    expect(mockFetch.mock.calls[0]![1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      }),
+    );
+    // Second call uses refreshed token
+    expect(mockFetch.mock.calls[1]![1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer fresh-token",
+        }),
+      }),
+    );
+  });
+});
+
+describe("DELETE /api/settings/login-image", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(defaultSession);
+    mockUncachedAuth.mockResolvedValue(defaultSession);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, createMockContext());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("successfully deletes login image", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => "",
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      {
+        method: "DELETE",
+        headers: { referer: "http://localhost:3000/school-a/settings" },
+      },
+    );
+    const response = await DELETE(request, createMockContext());
+
+    expect(response.status).toBe(204);
+  });
+
+  it("handles backend error", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "Internal server error",
+      statusText: "Internal Server Error",
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, createMockContext());
+
+    expect(response.status).toBe(500);
+  });
+
+  it("calls revalidateTag after successful delete", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => "",
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      { method: "DELETE" },
+    );
+    request.headers.set("referer", "http://localhost:3000/school-a/settings");
+    await DELETE(request, createMockContext());
+
+    expect(mockRevalidateTag).toHaveBeenCalledWith("tenant-school-a", {
+      expire: 0,
+    });
+  });
+});
+
+describe("GET /api/settings/login-image", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(defaultSession);
+    mockUncachedAuth.mockResolvedValue(defaultSession);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      { method: "GET" },
+    );
+    const response = await GET(request, createMockContext());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns data from backend", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: { login_image_url: "/uploads/login-image.jpg", can_edit: true },
+      }),
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      { method: "GET" },
+    );
+    const response = await GET(request, createMockContext());
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      data: { login_image_url: string; can_edit: boolean };
+    };
+    expect(json.data.login_image_url).toBe("/uploads/login-image.jpg");
+    expect(json.data.can_edit).toBe(true);
+  });
+
+  it("handles backend error", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "Internal server error",
+      statusText: "Internal Server Error",
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      { method: "GET" },
+    );
+    const response = await GET(request, createMockContext());
+
+    expect(response.status).toBe(500);
+  });
+
+  it("retries on 401 with refreshed token", async () => {
+    mockUncachedAuth.mockResolvedValueOnce({
+      user: { token: "fresh-token" },
+    });
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: {
+            login_image_url: "/uploads/login-image.jpg",
+            can_edit: true,
+          },
+        }),
+      });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/settings/login-image",
+      { method: "GET" },
+    );
+    const response = await GET(request, createMockContext());
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]![1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      }),
+    );
+    expect(mockFetch.mock.calls[1]![1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer fresh-token",
+        }),
+      }),
+    );
+  });
+});

--- a/frontend/src/app/api/settings/login-image/route.ts
+++ b/frontend/src/app/api/settings/login-image/route.ts
@@ -1,6 +1,9 @@
 import { revalidateTag } from "next/cache";
 import type { NextRequest } from "next/server";
-import { createFileUploadHandler } from "~/lib/file-upload-wrapper";
+import {
+  createFileUploadHandler,
+  FileValidationError,
+} from "~/lib/file-upload-wrapper";
 import { createDeleteHandler, createGetHandler } from "~/lib/route-wrapper";
 import { createLogger } from "~/lib/logger";
 import { uncachedAuth } from "~/server/auth";
@@ -79,7 +82,7 @@ export const POST = createFileUploadHandler<LoginImageResponse>(
   async (request: NextRequest, formData: FormData, token: string) => {
     const file = formData.get("login_image");
     if (!file || !(file instanceof File)) {
-      throw new Error("No image file provided");
+      throw new FileValidationError("No image file provided", 400);
     }
 
     const validatedFormData = new FormData();
@@ -111,7 +114,7 @@ export const POST = createFileUploadHandler<LoginImageResponse>(
   {
     maxSizeInMB: 2,
     allowedMimeTypes: ["image/jpeg", "image/jpg", "image/png", "image/webp"],
-    allowedExtensions: [".jpg", ".jpeg", ".png", ".webp"],
+    allowedExtensions: [".jpg", ".jpeg", ".jfif", ".png", ".webp"],
   },
 );
 

--- a/frontend/src/app/api/settings/login-image/route.ts
+++ b/frontend/src/app/api/settings/login-image/route.ts
@@ -1,0 +1,170 @@
+import { revalidateTag } from "next/cache";
+import type { NextRequest } from "next/server";
+import { createFileUploadHandler } from "~/lib/file-upload-wrapper";
+import { createDeleteHandler, createGetHandler } from "~/lib/route-wrapper";
+import { createLogger } from "~/lib/logger";
+import { uncachedAuth } from "~/server/auth";
+
+const logger = createLogger({ component: "LoginImageRoute" });
+
+interface LoginImageResponse {
+  login_image_url: string;
+}
+
+/** Extract tenant slug from the request to revalidate ISR cache.
+ *  Tries subdomain first (host header), then falls back to path prefix (referer).
+ *
+ *  Subdomain detection compares against NEXT_PUBLIC_TENANT_DOMAIN so that dotted
+ *  base domains (e.g. moto-app.de) are not mistakenly split at the first dot. */
+function revalidateTenantCache(request: NextRequest) {
+  const host = request.headers.get("host") ?? "";
+  const hostname = host.split(":")[0] ?? "";
+  const baseDomain = process.env.NEXT_PUBLIC_TENANT_DOMAIN;
+
+  // Try subdomain: tenant.moto-app.de → "tenant"
+  // Only match when the hostname ends with ".{baseDomain}" so that
+  // bare-domain requests (moto-app.de) fall through to the referer path.
+  // NEXT_PUBLIC_TENANT_DOMAIN is deploy-only (not set in local dev) — when
+  // missing, subdomain detection is skipped and path-based fallback is used.
+  if (baseDomain && hostname.endsWith(`.${baseDomain}`)) {
+    const slug = hostname.slice(0, -(baseDomain.length + 1));
+    if (slug && slug !== "www") {
+      revalidateTag(`tenant-${slug}`, { expire: 0 });
+      return;
+    }
+  }
+
+  // Fallback: extract slug from referer path (e.g. /school-a/settings)
+  const referer = request.headers.get("referer") ?? "";
+  try {
+    const refUrl = new URL(referer);
+    const pathSlug = refUrl.pathname.split("/")[1];
+    if (pathSlug) {
+      revalidateTag(`tenant-${pathSlug}`, { expire: 0 });
+      return;
+    }
+  } catch {
+    // Invalid referer URL — fall through to warning
+  }
+
+  // In subdomain mode (baseDomain is set but slug extraction failed above),
+  // this means the host didn't match — likely misconfiguration. In path mode
+  // (baseDomain unset), reaching here means the referer had no usable slug.
+  logger.error("tenant_cache_revalidation_failed", {
+    host,
+    referer: referer || "(empty)",
+    base_domain_configured: !!baseDomain,
+  });
+}
+
+/** Fetch with 401 retry — refreshes the NextAuth session token once on backend 401. */
+async function fetchWithRetry(
+  token: string,
+  doFetch: (authToken: string) => Promise<Response>,
+): Promise<Response> {
+  let response = await doFetch(token);
+
+  if (response.status === 401) {
+    const refreshed = await uncachedAuth();
+    if (refreshed?.user?.token && refreshed.user.token !== token) {
+      response = await doFetch(refreshed.user.token);
+    }
+  }
+
+  return response;
+}
+
+// POST handler for login image upload
+export const POST = createFileUploadHandler<LoginImageResponse>(
+  async (request: NextRequest, formData: FormData, token: string) => {
+    const file = formData.get("login_image");
+    if (!file || !(file instanceof File)) {
+      throw new Error("No image file provided");
+    }
+
+    const validatedFormData = new FormData();
+    validatedFormData.append("login_image", file);
+
+    const { getServerApiUrl } = await import("~/lib/server-api-url");
+    const url = `${getServerApiUrl()}/api/settings/login-image`;
+    const response = await fetchWithRetry(token, (t) =>
+      fetch(url, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${t}` },
+        body: validatedFormData,
+      }),
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `API error (${response.status}): ${errorText || response.statusText}`,
+      );
+    }
+
+    const data = ((await response.json()) as { data: LoginImageResponse }).data;
+
+    revalidateTenantCache(request);
+
+    return data;
+  },
+  {
+    maxSizeInMB: 2,
+    allowedMimeTypes: ["image/jpeg", "image/jpg", "image/png", "image/webp"],
+    allowedExtensions: [".jpg", ".jpeg", ".png", ".webp"],
+  },
+);
+
+// DELETE handler for removing login image
+export const DELETE = createDeleteHandler(
+  async (request: NextRequest, token: string) => {
+    const { getServerApiUrl } = await import("~/lib/server-api-url");
+    const url = `${getServerApiUrl()}/api/settings/login-image`;
+    const response = await fetchWithRetry(token, (t) =>
+      fetch(url, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${t}` },
+      }),
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `API error (${response.status}): ${errorText || response.statusText}`,
+      );
+    }
+
+    revalidateTenantCache(request);
+
+    return null;
+  },
+);
+
+// GET handler for fetching current login image URL
+export const GET = createGetHandler(
+  async (_request: NextRequest, token: string) => {
+    const { getServerApiUrl } = await import("~/lib/server-api-url");
+    const url = `${getServerApiUrl()}/api/settings/login-image`;
+    const response = await fetchWithRetry(token, (t) =>
+      fetch(url, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${t}`,
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `API error (${response.status}): ${errorText || response.statusText}`,
+      );
+    }
+
+    const responseData = (await response.json()) as {
+      data: { login_image_url: string | null; can_edit: boolean };
+    };
+    return responseData.data;
+  },
+);

--- a/frontend/src/components/settings/personalization-tab.test.tsx
+++ b/frontend/src/components/settings/personalization-tab.test.tsx
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { useTenant } from "~/components/tenant/tenant-provider";
+
+// Mock next/navigation
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    refresh: mockRefresh,
+  }),
+}));
+
+// Mock next/image — render a plain <img> so we can assert src
+vi.mock("next/image", () => ({
+  default: (props: Record<string, unknown>) => {
+    const { unoptimized: _u, ...rest } = props;
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...(rest as React.ImgHTMLAttributes<HTMLImageElement>)} />;
+  },
+}));
+
+// Mock Toast Context
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("~/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: mockToastSuccess,
+    error: mockToastError,
+    info: vi.fn(),
+  }),
+}));
+
+// Mock sessionFetch for the initial GET
+const mockSessionFetch = vi.fn<(url: string) => Promise<Response>>();
+vi.mock("~/lib/session-cache", () => ({
+  sessionFetch: (url: string) => mockSessionFetch(url),
+}));
+
+// Mock loginImageSrc
+vi.mock("~/lib/tenant-api", () => ({
+  loginImageSrc: (path: string) =>
+    `/api/public/login-image/${path.split("/").pop()}`,
+}));
+
+const { PersonalizationTab } = await import("./personalization-tab");
+
+function jsonResponse(data: unknown, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  } as Response;
+}
+
+describe("PersonalizationTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn();
+  });
+
+  it("shows loading spinner initially", () => {
+    mockSessionFetch.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<PersonalizationTab />);
+    expect(document.querySelector(".animate-spin")).not.toBeNull();
+  });
+
+  it("shows placeholder when no image is set", async () => {
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({ data: { login_image_url: null, can_edit: true } }),
+    );
+
+    render(<PersonalizationTab />);
+    await waitFor(() => {
+      expect(screen.getByText("Kein Bild hochgeladen")).toBeDefined();
+    });
+  });
+
+  it("renders current image when URL is present", async () => {
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          login_image_url: "/uploads/login-images/1_abc.jpg",
+          can_edit: false,
+        },
+      }),
+    );
+
+    render(<PersonalizationTab />);
+    await waitFor(() => {
+      const img = screen.getByAltText("Login-Bild");
+      expect(img).toBeDefined();
+    });
+  });
+
+  it("hides upload and delete buttons when can_edit is false", async () => {
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          login_image_url: "/uploads/login-images/1_abc.jpg",
+          can_edit: false,
+        },
+      }),
+    );
+
+    render(<PersonalizationTab />);
+    await waitFor(() => {
+      expect(screen.getByAltText("Login-Bild")).toBeDefined();
+    });
+
+    expect(screen.queryByText("Bild hochladen")).toBeNull();
+    expect(screen.queryByText("Bild entfernen")).toBeNull();
+  });
+
+  it("shows upload button when can_edit is true", async () => {
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({ data: { login_image_url: null, can_edit: true } }),
+    );
+
+    render(<PersonalizationTab />);
+    await waitFor(() => {
+      expect(screen.getByText("Bild hochladen")).toBeDefined();
+    });
+  });
+
+  it("shows delete button only when image exists and can_edit", async () => {
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          login_image_url: "/uploads/login-images/1_abc.jpg",
+          can_edit: true,
+        },
+      }),
+    );
+
+    render(<PersonalizationTab />);
+    await waitFor(() => {
+      expect(screen.getByText("Bild entfernen")).toBeDefined();
+    });
+  });
+
+  it("uploads image and shows success toast", async () => {
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({ data: { login_image_url: null, can_edit: true } }),
+    );
+
+    render(<PersonalizationTab />);
+    await waitFor(() => {
+      expect(screen.getByText("Bild hochladen")).toBeDefined();
+    });
+
+    // Mock the upload POST
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      jsonResponse({
+        data: { login_image_url: "/uploads/login-images/1_new.jpg" },
+      }),
+    );
+
+    const file = new File(["img"], "test.jpg", { type: "image/jpeg" });
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "Login-Bild erfolgreich hochgeladen",
+      );
+    });
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("shows error toast on upload failure", async () => {
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({ data: { login_image_url: null, can_edit: true } }),
+    );
+
+    render(<PersonalizationTab />);
+    await waitFor(() => {
+      expect(screen.getByText("Bild hochladen")).toBeDefined();
+    });
+
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "too large" }, false),
+    );
+
+    const file = new File(["img"], "big.jpg", { type: "image/jpeg" });
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Fehler beim Hochladen des Bildes",
+      );
+    });
+  });
+
+  it("deletes image and shows success toast", async () => {
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          login_image_url: "/uploads/login-images/1_abc.jpg",
+          can_edit: true,
+        },
+      }),
+    );
+
+    render(<PersonalizationTab />);
+    await waitFor(() => {
+      expect(screen.getByText("Bild entfernen")).toBeDefined();
+    });
+
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse(null));
+
+    fireEvent.click(screen.getByText("Bild entfernen"));
+
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "Login-Bild erfolgreich entfernt",
+      );
+    });
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("shows error toast on delete failure", async () => {
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          login_image_url: "/uploads/login-images/1_abc.jpg",
+          can_edit: true,
+        },
+      }),
+    );
+
+    render(<PersonalizationTab />);
+    await waitFor(() => {
+      expect(screen.getByText("Bild entfernen")).toBeDefined();
+    });
+
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "server error" }, false),
+    );
+
+    fireEvent.click(screen.getByText("Bild entfernen"));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Fehler beim Entfernen des Bildes",
+      );
+    });
+  });
+
+  it("uses tenant settings for initial image on mount", async () => {
+    vi.mocked(useTenant).mockReturnValue({
+      tenantSlug: "test-school",
+      tenant: {
+        settings: { loginImageUrl: "/uploads/login-images/initial.jpg" },
+      },
+    } as ReturnType<typeof useTenant>);
+
+    // sessionFetch returns null (simulating fetch failure) — should still show initial from tenant
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({ data: { login_image_url: null, can_edit: false } }),
+    );
+
+    render(<PersonalizationTab />);
+    // Before the fetch resolves, the component should render with the tenant's initial value
+    // After fetch resolves with null, it updates to null
+    await waitFor(() => {
+      expect(screen.getByText("Kein Bild hochgeladen")).toBeDefined();
+    });
+  });
+
+  it("shows read-only description when can_edit is false", async () => {
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({ data: { login_image_url: null, can_edit: false } }),
+    );
+
+    render(<PersonalizationTab />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Das aktuelle Bild wird auf der Login-Seite/),
+      ).toBeDefined();
+    });
+  });
+
+  it("shows editable description when can_edit is true", async () => {
+    mockSessionFetch.mockResolvedValue(
+      jsonResponse({ data: { login_image_url: null, can_edit: true } }),
+    );
+
+    render(<PersonalizationTab />);
+    await waitFor(() => {
+      expect(screen.getByText(/Laden Sie ein eigenes Bild hoch/)).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/components/settings/personalization-tab.tsx
+++ b/frontend/src/components/settings/personalization-tab.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useTenant } from "~/components/tenant/tenant-provider";
+import { useToast } from "~/contexts/ToastContext";
+import { sessionFetch } from "~/lib/session-cache";
+import { loginImageSrc } from "~/lib/tenant-api";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "PersonalizationTab" });
+
+export function PersonalizationTab() {
+  const { tenant } = useTenant();
+  const router = useRouter();
+  const { success: toastSuccess, error: toastError } = useToast();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(
+    tenant?.settings?.loginImageUrl ?? null,
+  );
+  const [canEdit, setCanEdit] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isUploading, setIsUploading] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Fetch current login image + edit permission on mount.
+  // On failure, keep the existing preview from tenant context instead of clearing it.
+  useEffect(() => {
+    sessionFetch("/api/settings/login-image")
+      .then((res) => {
+        if (!res.ok) {
+          logger.warn("login_image_fetch_non_ok", { status: res.status });
+          return;
+        }
+        return res.json().then(
+          (json: {
+            data?: {
+              login_image_url?: string | null;
+              can_edit?: boolean;
+            };
+          }) => {
+            setCurrentImageUrl(json?.data?.login_image_url ?? null);
+            setCanEdit(json?.data?.can_edit ?? false);
+          },
+        );
+      })
+      .catch((err) => {
+        logger.warn("login_image_fetch_failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const handleUpload = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      setIsUploading(true);
+      try {
+        const formData = new FormData();
+        formData.append("login_image", file);
+
+        const response = await fetch("/api/settings/login-image", {
+          method: "POST",
+          body: formData,
+        });
+
+        if (!response.ok) {
+          const errorBody = await response.text();
+          throw new Error(`Upload failed: ${response.status} — ${errorBody}`);
+        }
+
+        const result = (await response.json()) as {
+          data: { login_image_url: string };
+        };
+        setCurrentImageUrl(result.data.login_image_url);
+        toastSuccess("Login-Bild erfolgreich hochgeladen");
+
+        // Refresh server components so TenantProvider picks up the new settings
+        router.refresh();
+      } catch (error) {
+        logger.error("login_image_upload_failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        toastError("Fehler beim Hochladen des Bildes");
+      } finally {
+        setIsUploading(false);
+        if (fileInputRef.current) {
+          fileInputRef.current.value = "";
+        }
+      }
+    },
+    [toastSuccess, toastError, router],
+  );
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      const response = await fetch("/api/settings/login-image", {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        throw new Error(`Delete failed: ${response.status}`);
+      }
+
+      setCurrentImageUrl(null);
+      toastSuccess("Login-Bild erfolgreich entfernt");
+
+      // Refresh server components so TenantProvider picks up the removal
+      router.refresh();
+    } catch (error) {
+      logger.error("login_image_delete_failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      toastError("Fehler beim Entfernen des Bildes");
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [toastSuccess, toastError, router]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-base font-medium text-gray-900">Login-Seite</h3>
+        <p className="mt-1 text-sm text-gray-500">
+          {canEdit
+            ? "Laden Sie ein eigenes Bild hoch, das auf der Login-Seite Ihrer Einrichtung angezeigt wird. Ohne eigenes Bild wird das Standard-moto-Logo verwendet."
+            : "Das aktuelle Bild wird auf der Login-Seite Ihrer Einrichtung angezeigt."}
+        </p>
+      </div>
+
+      {/* Preview */}
+      <div className="flex flex-col items-center gap-4 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-6">
+        {isLoading ? (
+          <div className="flex h-[120px] w-[200px] items-center justify-center">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
+          </div>
+        ) : currentImageUrl ? (
+          <Image
+            src={loginImageSrc(currentImageUrl)}
+            alt="Login-Bild"
+            width={300}
+            height={200}
+            className="max-h-[200px] w-auto rounded object-contain"
+            unoptimized
+          />
+        ) : (
+          <div className="flex h-[120px] w-[200px] items-center justify-center rounded bg-gray-200 text-sm text-gray-400">
+            Kein Bild hochgeladen
+          </div>
+        )}
+
+        {canEdit && (
+          <p className="text-xs text-gray-400">
+            Max. 2 MB · JPG, PNG oder WebP · Empfohlen: ca. 900 × 650 px
+          </p>
+        )}
+      </div>
+
+      {/* Actions — only shown for users with write permission */}
+      {canEdit && (
+        <div className="flex gap-3">
+          <label
+            className={`inline-flex cursor-pointer items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 ${
+              isUploading ? "pointer-events-none opacity-50" : ""
+            }`}
+          >
+            {isUploading ? "Wird hochgeladen…" : "Bild hochladen"}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              className="hidden"
+              onChange={handleUpload}
+              disabled={isUploading}
+            />
+          </label>
+
+          {currentImageUrl && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="inline-flex items-center rounded-lg border border-red-200 bg-white px-4 py-2 text-sm font-medium text-red-600 shadow-sm hover:bg-red-50 disabled:opacity-50"
+            >
+              {isDeleting ? "Wird entfernt…" : "Bild entfernen"}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/settings-page.test.tsx
+++ b/frontend/src/components/settings/settings-page.test.tsx
@@ -102,17 +102,19 @@ describe("useSettingsTabs", () => {
     mockResetSettingValue.mockResolvedValue(null);
   });
 
-  it("returns null when schema is null (no access)", async () => {
+  it("returns only personalisierung tab when schema is null (no access)", async () => {
     mockFetchSchema.mockResolvedValue(null);
     let captured: TabsResult | null = null;
 
     render(<HookWrapper onResult={(r) => (captured = r)} />);
     await waitFor(() => {
-      expect(captured).toBeNull();
+      expect(captured).not.toBeNull();
     });
+    expect(captured!.tabs).toHaveLength(1);
+    expect(captured!.tabs[0]!.id).toBe("settings-personalisierung");
   });
 
-  it("returns tabs from schema with German labels", async () => {
+  it("returns schema tabs + personalisierung with German labels", async () => {
     mockFetchSchema.mockResolvedValue(mockSchema);
     let captured: TabsResult | null = null;
 
@@ -120,9 +122,10 @@ describe("useSettingsTabs", () => {
     await waitFor(() => {
       expect(captured).not.toBeNull();
     });
-    expect(captured!.tabs).toHaveLength(2);
+    expect(captured!.tabs).toHaveLength(3);
     expect(captured!.tabs[0]!.label).toBe("Betrieb");
     expect(captured!.tabs[1]!.label).toBe("Datenschutz");
+    expect(captured!.tabs[2]!.label).toBe("Personalisierung");
   });
 
   it("returns tabs with settings- prefix IDs", async () => {
@@ -134,16 +137,19 @@ describe("useSettingsTabs", () => {
       expect(captured).not.toBeNull();
     });
     expect(captured!.tabs[0]!.id).toBe("settings-operations");
+    expect(captured!.tabs[2]!.id).toBe("settings-personalisierung");
   });
 
-  it("returns null when schema has empty tabs", async () => {
+  it("returns only personalisierung when schema has empty tabs", async () => {
     mockFetchSchema.mockResolvedValue({ tabs: [] });
     let captured: TabsResult | null = null;
 
     render(<HookWrapper onResult={(r) => (captured = r)} />);
     await waitFor(() => {
-      expect(captured).toBeNull();
+      expect(captured).not.toBeNull();
     });
+    expect(captured!.tabs).toHaveLength(1);
+    expect(captured!.tabs[0]!.id).toBe("settings-personalisierung");
   });
 
   it("tabs have icon paths", async () => {

--- a/frontend/src/components/settings/settings-page.tsx
+++ b/frontend/src/components/settings/settings-page.tsx
@@ -10,6 +10,7 @@ import {
 } from "~/lib/settings-api";
 import type { SettingsSchema, SchemaTab } from "~/lib/settings-api";
 import { SettingsCategory } from "./settings-category";
+import { PersonalizationTab } from "./personalization-tab";
 
 const logger = createLogger({ component: "SettingsPage" });
 
@@ -241,6 +242,8 @@ export function useSettingsTabs(): {
 } | null {
   const { status: sessionStatus } = useSession();
   const [schema, setSchema] = useState<SettingsSchema | null>(null);
+  const [schemaFetchFailed, setSchemaFetchFailed] = useState(false);
+  const [schemaLoaded, setSchemaLoaded] = useState(false);
 
   useEffect(() => {
     if (sessionStatus === "authenticated") {
@@ -249,13 +252,15 @@ export function useSettingsTabs(): {
           if (data) setSchema(data);
         })
         .catch(() => {
-          // Schema fetch failed — tabs won't render, inner SettingsContent
-          // has its own fetch with error display and retry button.
-        });
+          // Schema fetch failed — mark so we still render placeholder tabs.
+          // Inner SettingsContent has its own fetch with error display and retry button.
+          setSchemaFetchFailed(true);
+        })
+        .finally(() => setSchemaLoaded(true));
     }
   }, [sessionStatus]);
 
-  if (!schema?.tabs || schema.tabs.length === 0) {
+  if (!schemaLoaded) {
     return null;
   }
 
@@ -280,13 +285,36 @@ export function useSettingsTabs(): {
       "M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4",
   };
 
-  const tabs = schema.tabs.map((tab) => ({
-    id: `settings-${tab.key}`,
-    label: tabLabels[tab.key] ?? tab.label,
-    icon: tabIcons[tab.key] ?? defaultTabIcon,
-  }));
+  // Schema-driven tabs (may be empty if user has no config:read permission).
+  // When the schema fetch failed, render placeholder tabs so SettingsContent
+  // mounts and can show its own error/retry UI instead of silently dropping
+  // all schema tabs.
+  const fallbackTabKeys = ["operations", "gdpr", "security"];
+  const schemaTabs = schemaFetchFailed
+    ? fallbackTabKeys.map((key) => ({
+        id: `settings-${key}`,
+        label: tabLabels[key] ?? key,
+        icon: tabIcons[key] ?? defaultTabIcon,
+      }))
+    : (schema?.tabs ?? []).map((tab) => ({
+        id: `settings-${tab.key}`,
+        label: tabLabels[tab.key] ?? tab.label,
+        icon: tabIcons[tab.key] ?? defaultTabIcon,
+      }));
+
+  // Personalisierung is always available (permission-gated inside the component)
+  const personalizationTab = {
+    id: "settings-personalisierung",
+    label: "Personalisierung",
+    icon: "M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z",
+  };
+
+  const tabs = [...schemaTabs, personalizationTab];
 
   const renderTab = (tabId: string) => {
+    if (tabId === "settings-personalisierung") {
+      return <PersonalizationTab />;
+    }
     const settingsKey = tabId.replace("settings-", "");
     return <SettingsContent tabKey={settingsKey} />;
   };

--- a/frontend/src/lib/file-upload-wrapper.test.ts
+++ b/frontend/src/lib/file-upload-wrapper.test.ts
@@ -130,7 +130,7 @@ describe("createFileUploadHandler", () => {
       const response = await wrappedHandler(request, context);
       const data = (await response.json()) as ErrorResponse;
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(413);
       expect(data.error).toContain("File size exceeds 5MB limit");
       expect(handler).not.toHaveBeenCalled();
     });
@@ -209,7 +209,7 @@ describe("createFileUploadHandler", () => {
       const response = await wrappedHandler(request, context);
       const data = (await response.json()) as ErrorResponse;
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(415);
       expect(data.error).toContain("File type text/plain is not allowed");
       expect(handler).not.toHaveBeenCalled();
     });
@@ -303,7 +303,7 @@ describe("createFileUploadHandler", () => {
       const response = await wrappedHandler(request, context);
       const data = (await response.json()) as ErrorResponse;
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(415);
       expect(data.error).toContain("File extension not allowed");
       expect(handler).not.toHaveBeenCalled();
     });
@@ -329,7 +329,7 @@ describe("createFileUploadHandler", () => {
       const response = await wrappedHandler(request, context);
       const data = (await response.json()) as ErrorResponse;
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(422);
       expect(data.error).toContain(
         "Files with multiple extensions are not allowed",
       );
@@ -356,8 +356,8 @@ describe("createFileUploadHandler", () => {
 
       const response = await wrappedHandler(request, context);
 
-      // The file either fails extension check or traversal check
-      expect(response.status).toBe(500);
+      // The file either fails extension check (415) or traversal check (422)
+      expect([415, 422]).toContain(response.status);
       expect(handler).not.toHaveBeenCalled();
     });
 
@@ -381,7 +381,7 @@ describe("createFileUploadHandler", () => {
       const response = await wrappedHandler(request, context);
       const data = (await response.json()) as ErrorResponse;
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(422);
       expect(data.error).toBe("Invalid filename");
       expect(handler).not.toHaveBeenCalled();
     });
@@ -406,7 +406,7 @@ describe("createFileUploadHandler", () => {
       const response = await wrappedHandler(request, context);
       const data = (await response.json()) as ErrorResponse;
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(422);
       expect(data.error).toBe("Invalid filename");
       expect(handler).not.toHaveBeenCalled();
     });
@@ -435,7 +435,7 @@ describe("createFileUploadHandler", () => {
       const response = await wrappedHandler(request, context);
       const data = (await response.json()) as ErrorResponse;
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(415);
       expect(data.error).toContain("File type text/plain is not allowed");
       expect(handler).not.toHaveBeenCalled();
     });

--- a/frontend/src/lib/file-upload-wrapper.ts
+++ b/frontend/src/lib/file-upload-wrapper.ts
@@ -11,7 +11,7 @@ interface FileUploadOptions {
 }
 
 /** Error thrown by file validation with the appropriate HTTP status code. */
-class FileValidationError extends Error {
+export class FileValidationError extends Error {
   readonly status: number;
 
   constructor(message: string, status: number) {
@@ -162,6 +162,12 @@ export function createFileUploadHandler<T>(
 
       return NextResponse.json(response);
     } catch (error) {
+      if (error instanceof FileValidationError) {
+        return NextResponse.json(
+          { error: error.message },
+          { status: error.status },
+        );
+      }
       return handleApiError(error);
     }
   };

--- a/frontend/src/lib/file-upload-wrapper.ts
+++ b/frontend/src/lib/file-upload-wrapper.ts
@@ -10,8 +10,23 @@ interface FileUploadOptions {
   allowedExtensions?: string[];
 }
 
+/** Error thrown by file validation with the appropriate HTTP status code. */
+class FileValidationError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "FileValidationError";
+    this.status = status;
+  }
+}
+
 /**
- * Validates uploaded file against security constraints
+ * Validates uploaded file against security constraints.
+ * Throws FileValidationError with a semantically correct HTTP status:
+ *   413 — file too large
+ *   415 — wrong MIME type or extension
+ *   422 — suspicious filename (double extensions, path traversal)
  */
 function validateFile(file: File, options: FileUploadOptions): void {
   const {
@@ -29,13 +44,17 @@ function validateFile(file: File, options: FileUploadOptions): void {
   // Check file size
   const maxSizeInBytes = maxSizeInMB * 1024 * 1024;
   if (file.size > maxSizeInBytes) {
-    throw new Error(`File size exceeds ${maxSizeInMB}MB limit`);
+    throw new FileValidationError(
+      `File size exceeds ${maxSizeInMB}MB limit`,
+      413,
+    );
   }
 
   // Check MIME type
   if (!allowedMimeTypes.includes(file.type)) {
-    throw new Error(
+    throw new FileValidationError(
       `File type ${file.type} is not allowed. Allowed types: ${allowedMimeTypes.join(", ")}`,
+      415,
     );
   }
 
@@ -45,8 +64,9 @@ function validateFile(file: File, options: FileUploadOptions): void {
     fileName.endsWith(ext),
   );
   if (!hasValidExtension) {
-    throw new Error(
+    throw new FileValidationError(
       `File extension not allowed. Allowed extensions: ${allowedExtensions.join(", ")}`,
+      415,
     );
   }
 
@@ -54,7 +74,10 @@ function validateFile(file: File, options: FileUploadOptions): void {
   // Check for double extensions
   const extensionCount = (fileName.match(/\./g) ?? []).length;
   if (extensionCount > 1) {
-    throw new Error("Files with multiple extensions are not allowed");
+    throw new FileValidationError(
+      "Files with multiple extensions are not allowed",
+      422,
+    );
   }
 
   // Check for suspicious patterns in filename
@@ -63,7 +86,7 @@ function validateFile(file: File, options: FileUploadOptions): void {
     fileName.includes("/") ||
     fileName.includes("\\")
   ) {
-    throw new Error("Invalid filename");
+    throw new FileValidationError("Invalid filename", 422);
   }
 }
 
@@ -105,11 +128,23 @@ export function createFileUploadHandler<T>(
       // Get form data
       const formData = await request.formData();
 
-      // Validate all files in the form data
-      for (const [, value] of formData.entries()) {
-        if (value instanceof File) {
-          validateFile(value, options ?? {});
+      // Validate all files in the form data — return the semantically correct
+      // HTTP status (413/415/422) instead of letting validation errors fall
+      // through to the generic 500 handler.
+      try {
+        for (const [, value] of formData.entries()) {
+          if (value instanceof File) {
+            validateFile(value, options ?? {});
+          }
         }
+      } catch (validationError) {
+        if (validationError instanceof FileValidationError) {
+          return NextResponse.json(
+            { error: validationError.message },
+            { status: validationError.status },
+          );
+        }
+        throw validationError;
       }
 
       const data = await handler(

--- a/frontend/src/lib/tenant-api.test.ts
+++ b/frontend/src/lib/tenant-api.test.ts
@@ -20,6 +20,7 @@ import {
   listAvailableTenants,
   switchTenant,
   performTenantSwitch,
+  loginImageSrc,
 } from "./tenant-api";
 
 // ============================================================================
@@ -36,6 +37,32 @@ describe("tenant-api", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+  });
+
+  // --------------------------------------------------------------------------
+  // loginImageSrc (pure helper, no fetch)
+  // --------------------------------------------------------------------------
+
+  describe("loginImageSrc", () => {
+    it("extracts filename from stored path", () => {
+      expect(loginImageSrc("/uploads/login-images/123_abcdef.png")).toBe(
+        "/api/public/login-image/123_abcdef.png",
+      );
+    });
+
+    it("handles filename without directory prefix", () => {
+      expect(loginImageSrc("myfile.jpg")).toBe(
+        "/api/public/login-image/myfile.jpg",
+      );
+    });
+
+    it("returns base path for empty string", () => {
+      expect(loginImageSrc("")).toBe("/api/public/login-image/");
+    });
+
+    it("returns base path for trailing slash", () => {
+      expect(loginImageSrc("/")).toBe("/api/public/login-image/");
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/frontend/src/lib/tenant-api.ts
+++ b/frontend/src/lib/tenant-api.ts
@@ -11,8 +11,15 @@ const TENANT_ACCESS_DENIED_MESSAGE =
 
 export interface TenantSettings {
   logoUrl?: string;
+  loginImageUrl?: string;
   primaryColor?: string;
   [key: string]: unknown;
+}
+
+/** Convert a stored login image URL path to the public-serving proxy URL. */
+export function loginImageSrc(storedPath: string): string {
+  const filename = storedPath.split("/").pop() ?? "";
+  return `/api/public/login-image/${filename}`;
 }
 
 export interface TenantInfo {


### PR DESCRIPTION
## Summary
- Tenants can upload a custom image for their login page via a new **Personalization** tab in settings
- Login page conditionally renders the tenant's custom image or the default MOTO logo
- Public image-serving route with path traversal protection for unauthenticated access

### Why is this PR large?
- **Refactor (~700 lines moved):** Image upload/serve/validate logic was duplicated across `usercontext/api.go` and `staff/api.go`. Extracted into a shared `common/upload` module to reuse for login images without tripling the duplication.
- **Tests (62% of additions):** Integration and unit tests for the new endpoints, the shared upload module, and the frontend components.

## Test plan
- [ ] Tenant settings → Personalization tab → upload image → preview appears
- [ ] Delete the image → removed from settings and login page
- [ ] Login page shows custom image when set, default logo when not
- [ ] Existing avatar upload (staff, students) still works after refactor