### PR TITLE
fix: map custom tenant roles to system roles for announcement targeting (#1187)

### DIFF
--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -907,8 +907,8 @@ func normalizeBaseRole(br *string) *string {
 
 // validateBaseRoleValue checks that a non-nil base_role value is one of the allowed system roles.
 func validateBaseRoleValue(value string) error {
-	if !slices.Contains(authModel.ValidBaseRoles, value) {
-		return fmt.Errorf("base_role must be one of: %v", authModel.ValidBaseRoles)
+	if !slices.Contains(authModel.ValidBaseRoles(), value) {
+		return fmt.Errorf("base_role must be one of: %v", authModel.ValidBaseRoles())
 	}
 	return nil
 }
@@ -917,7 +917,7 @@ func validateBaseRoleValue(value string) error {
 // This runs at the request layer to return 400 (not 500) for invalid payloads.
 func validateBaseRole(br *string) error {
 	if br == nil {
-		return fmt.Errorf("base_role is required; must be one of: %v", authModel.ValidBaseRoles)
+		return fmt.Errorf("base_role is required; must be one of: %v", authModel.ValidBaseRoles())
 	}
 	return validateBaseRoleValue(*br)
 }

--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -4,9 +4,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -843,14 +845,20 @@ func (rs *Resource) getAccount(w http.ResponseWriter, r *http.Request) {
 
 // CreateRoleRequest represents the create role request payload
 type CreateRoleRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	BaseRole    *string `json:"base_role,omitempty"`
 }
 
 // Bind validates the create role request
 func (req *CreateRoleRequest) Bind(_ *http.Request) error {
 	req.Name = strings.TrimSpace(req.Name)
 	req.Description = strings.TrimSpace(req.Description)
+	req.BaseRole = normalizeBaseRole(req.BaseRole)
+
+	if err := validateBaseRole(req.BaseRole); err != nil {
+		return err
+	}
 
 	return validation.ValidateStruct(req,
 		validation.Field(&req.Name, validation.Required, validation.Length(1, 100)),
@@ -860,19 +868,58 @@ func (req *CreateRoleRequest) Bind(_ *http.Request) error {
 
 // UpdateRoleRequest represents the update role request payload
 type UpdateRoleRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	BaseRole    *string `json:"base_role,omitempty"`
 }
 
-// Bind validates the update role request
+// Bind validates the update role request.
+// BaseRole is optional on update — if omitted, the handler preserves the existing value.
 func (req *UpdateRoleRequest) Bind(_ *http.Request) error {
 	req.Name = strings.TrimSpace(req.Name)
 	req.Description = strings.TrimSpace(req.Description)
+	req.BaseRole = normalizeBaseRole(req.BaseRole)
+
+	// Only validate base_role if the caller explicitly sent one.
+	if req.BaseRole != nil {
+		if err := validateBaseRoleValue(*req.BaseRole); err != nil {
+			return err
+		}
+	}
 
 	return validation.ValidateStruct(req,
 		validation.Field(&req.Name, validation.Required, validation.Length(1, 100)),
 		validation.Field(&req.Description, validation.Length(0, 500)),
 	)
+}
+
+// normalizeBaseRole trims whitespace and converts empty strings to nil.
+func normalizeBaseRole(br *string) *string {
+	if br == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*br)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+// validateBaseRoleValue checks that a non-nil base_role value is one of the allowed system roles.
+func validateBaseRoleValue(value string) error {
+	if !slices.Contains(authModel.ValidBaseRoles, value) {
+		return fmt.Errorf("base_role must be one of: %v", authModel.ValidBaseRoles)
+	}
+	return nil
+}
+
+// validateBaseRole checks that base_role is provided and is one of the allowed system roles.
+// This runs at the request layer to return 400 (not 500) for invalid payloads.
+func validateBaseRole(br *string) error {
+	if br == nil {
+		return fmt.Errorf("base_role is required; must be one of: %v", authModel.ValidBaseRoles)
+	}
+	return validateBaseRoleValue(*br)
 }
 
 // RoleResponse represents a role response
@@ -881,9 +928,23 @@ type RoleResponse struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	IsSystem    bool     `json:"is_system"`
+	BaseRole    *string  `json:"base_role,omitempty"`
 	CreatedAt   string   `json:"created_at"`
 	UpdatedAt   string   `json:"updated_at"`
 	Permissions []string `json:"permissions,omitempty"`
+}
+
+// toRoleResponse maps a domain Role to its API response representation.
+func toRoleResponse(role *authModel.Role) *RoleResponse {
+	return &RoleResponse{
+		ID:          role.ID,
+		Name:        role.Name,
+		Description: role.Description,
+		IsSystem:    role.IsSystem,
+		BaseRole:    role.BaseRole,
+		CreatedAt:   role.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:   role.UpdatedAt.Format(time.RFC3339),
+	}
 }
 
 // Permission Management Request/Response Types
@@ -1056,22 +1117,13 @@ func (rs *Resource) createRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	role, err := rs.AuthService.CreateRole(r.Context(), req.Name, req.Description)
+	role, err := rs.AuthService.CreateRole(r.Context(), req.Name, req.Description, req.BaseRole)
 	if err != nil {
 		common.RenderError(w, r, ErrorInternalServer(err))
 		return
 	}
 
-	resp := &RoleResponse{
-		ID:          role.ID,
-		Name:        role.Name,
-		Description: role.Description,
-		IsSystem:    role.IsSystem,
-		CreatedAt:   role.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:   role.UpdatedAt.Format(time.RFC3339),
-	}
-
-	common.Respond(w, r, http.StatusCreated, resp, "Role created successfully")
+	common.Respond(w, r, http.StatusCreated, toRoleResponse(role), "Role created successfully")
 }
 
 // getRoleByID handles getting a role by ID
@@ -1094,15 +1146,8 @@ func (rs *Resource) getRoleByID(w http.ResponseWriter, r *http.Request) {
 		permissionNames = append(permissionNames, perm.GetFullName())
 	}
 
-	resp := &RoleResponse{
-		ID:          role.ID,
-		Name:        role.Name,
-		Description: role.Description,
-		IsSystem:    role.IsSystem,
-		CreatedAt:   role.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:   role.UpdatedAt.Format(time.RFC3339),
-		Permissions: permissionNames,
-	}
+	resp := toRoleResponse(role)
+	resp.Permissions = permissionNames
 
 	common.Respond(w, r, http.StatusOK, resp, "Role retrieved successfully")
 }
@@ -1128,6 +1173,10 @@ func (rs *Resource) updateRole(w http.ResponseWriter, r *http.Request) {
 
 	role.Name = req.Name
 	role.Description = req.Description
+	// Preserve existing base_role when the caller omits the field.
+	if req.BaseRole != nil {
+		role.BaseRole = req.BaseRole
+	}
 
 	if err := rs.AuthService.UpdateRole(r.Context(), role); err != nil {
 		common.RenderError(w, r, renderRoleMutationError(err))
@@ -1191,15 +1240,7 @@ func (rs *Resource) listRoles(w http.ResponseWriter, r *http.Request) {
 
 	responses := make([]*RoleResponse, 0, len(roles))
 	for _, role := range roles {
-		resp := &RoleResponse{
-			ID:          role.ID,
-			Name:        role.Name,
-			Description: role.Description,
-			IsSystem:    role.IsSystem,
-			CreatedAt:   role.CreatedAt.Format(time.RFC3339),
-			UpdatedAt:   role.UpdatedAt.Format(time.RFC3339),
-		}
-		responses = append(responses, resp)
+		responses = append(responses, toRoleResponse(role))
 	}
 
 	common.Respond(w, r, http.StatusOK, responses, "Roles retrieved successfully")
@@ -1260,15 +1301,7 @@ func (rs *Resource) getAccountRoles(w http.ResponseWriter, r *http.Request) {
 
 	responses := make([]*RoleResponse, 0, len(roles))
 	for _, role := range roles {
-		resp := &RoleResponse{
-			ID:          role.ID,
-			Name:        role.Name,
-			Description: role.Description,
-			IsSystem:    role.IsSystem,
-			CreatedAt:   role.CreatedAt.Format(time.RFC3339),
-			UpdatedAt:   role.UpdatedAt.Format(time.RFC3339),
-		}
-		responses = append(responses, resp)
+		responses = append(responses, toRoleResponse(role))
 	}
 
 	common.Respond(w, r, http.StatusOK, responses, "Account roles retrieved successfully")

--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -894,6 +894,9 @@ func (req *UpdateRoleRequest) Bind(_ *http.Request) error {
 }
 
 // normalizeBaseRole trims whitespace and converts empty strings to nil.
+// Intentionally: once a base_role is set, it cannot be cleared back to NULL via the API.
+// Empty string is treated as "field not sent" (preserve existing value), because every
+// custom role should have a base_role for announcement targeting to work correctly.
 func normalizeBaseRole(br *string) *string {
 	if br == nil {
 		return nil

--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -1174,7 +1174,8 @@ func (rs *Resource) updateRole(w http.ResponseWriter, r *http.Request) {
 	role.Name = req.Name
 	role.Description = req.Description
 	// Preserve existing base_role when the caller omits the field.
-	if req.BaseRole != nil {
+	// System roles must never carry a base_role — ignore silently.
+	if req.BaseRole != nil && !role.IsSystem {
 		role.BaseRole = req.BaseRole
 	}
 

--- a/backend/api/auth/auth_internal_test.go
+++ b/backend/api/auth/auth_internal_test.go
@@ -5,8 +5,12 @@ package auth
 import (
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	authModel "github.com/moto-nrw/project-phoenix/models/auth"
+	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // =============================================================================
@@ -155,23 +159,29 @@ func TestChangePasswordRequest_Fields(t *testing.T) {
 }
 
 func TestCreateRoleRequest_Fields(t *testing.T) {
+	baseRole := "user"
 	req := CreateRoleRequest{
 		Name:        "admin",
 		Description: "Administrator role",
+		BaseRole:    &baseRole,
 	}
 
 	assert.Equal(t, "admin", req.Name)
 	assert.Equal(t, "Administrator role", req.Description)
+	assert.Equal(t, "user", *req.BaseRole)
 }
 
 func TestUpdateRoleRequest_Fields(t *testing.T) {
+	baseRole := "admin"
 	req := UpdateRoleRequest{
 		Name:        "updated_role",
 		Description: "Updated description",
+		BaseRole:    &baseRole,
 	}
 
 	assert.Equal(t, "updated_role", req.Name)
 	assert.Equal(t, "Updated description", req.Description)
+	assert.Equal(t, "admin", *req.BaseRole)
 }
 
 func TestCreatePermissionRequest_Fields(t *testing.T) {
@@ -282,4 +292,200 @@ func TestNewResource_ReturnsResource(t *testing.T) {
 	resource := NewResource(nil, nil, nil, nil)
 
 	assert.NotNil(t, resource)
+}
+
+// =============================================================================
+// normalizeBaseRole Tests
+// =============================================================================
+
+func TestNormalizeBaseRole(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		assert.Nil(t, normalizeBaseRole(nil))
+	})
+
+	t.Run("empty string returns nil", func(t *testing.T) {
+		empty := ""
+		assert.Nil(t, normalizeBaseRole(&empty))
+	})
+
+	t.Run("whitespace-only returns nil", func(t *testing.T) {
+		spaces := "   "
+		assert.Nil(t, normalizeBaseRole(&spaces))
+	})
+
+	t.Run("trims whitespace", func(t *testing.T) {
+		padded := "  admin  "
+		result := normalizeBaseRole(&padded)
+		require.NotNil(t, result)
+		assert.Equal(t, "admin", *result)
+	})
+
+	t.Run("passes through clean value", func(t *testing.T) {
+		clean := "guardian"
+		result := normalizeBaseRole(&clean)
+		require.NotNil(t, result)
+		assert.Equal(t, "guardian", *result)
+	})
+}
+
+// =============================================================================
+// validateBaseRole / validateBaseRoleValue Tests
+// =============================================================================
+
+func TestValidateBaseRole(t *testing.T) {
+	t.Run("nil is rejected", func(t *testing.T) {
+		err := validateBaseRole(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base_role is required")
+	})
+
+	t.Run("valid values accepted", func(t *testing.T) {
+		for _, role := range []string{"admin", "user", "guardian"} {
+			r := role
+			assert.NoError(t, validateBaseRole(&r), "expected %q to be valid", role)
+		}
+	})
+
+	t.Run("invalid value rejected", func(t *testing.T) {
+		bad := "superadmin"
+		err := validateBaseRole(&bad)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base_role must be one of")
+	})
+
+	t.Run("case sensitive", func(t *testing.T) {
+		upper := "Admin"
+		err := validateBaseRole(&upper)
+		require.Error(t, err, "base_role validation must be case-sensitive")
+	})
+}
+
+func TestValidateBaseRoleValue(t *testing.T) {
+	t.Run("empty string rejected", func(t *testing.T) {
+		assert.Error(t, validateBaseRoleValue(""))
+	})
+
+	t.Run("unknown role rejected", func(t *testing.T) {
+		assert.Error(t, validateBaseRoleValue("staff"))
+	})
+
+	t.Run("all valid roles accepted", func(t *testing.T) {
+		for _, role := range authModel.ValidBaseRoles() {
+			assert.NoError(t, validateBaseRoleValue(role))
+		}
+	})
+}
+
+// =============================================================================
+// toRoleResponse Tests
+// =============================================================================
+
+func TestToRoleResponse(t *testing.T) {
+	now := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	baseRole := "admin"
+
+	t.Run("maps all fields including base_role", func(t *testing.T) {
+		role := &authModel.Role{
+			Model:       base.Model{ID: 42, CreatedAt: now, UpdatedAt: now},
+			Name:        "custom-admin",
+			Description: "A custom admin role",
+			IsSystem:    false,
+			BaseRole:    &baseRole,
+		}
+
+		resp := toRoleResponse(role)
+
+		assert.Equal(t, int64(42), resp.ID)
+		assert.Equal(t, "custom-admin", resp.Name)
+		assert.Equal(t, "A custom admin role", resp.Description)
+		assert.False(t, resp.IsSystem)
+		require.NotNil(t, resp.BaseRole)
+		assert.Equal(t, "admin", *resp.BaseRole)
+		assert.Equal(t, "2026-01-15T10:30:00Z", resp.CreatedAt)
+		assert.Equal(t, "2026-01-15T10:30:00Z", resp.UpdatedAt)
+		assert.Nil(t, resp.Permissions, "Permissions not set by toRoleResponse")
+	})
+
+	t.Run("nil base_role preserved", func(t *testing.T) {
+		role := &authModel.Role{
+			Model:    base.Model{ID: 1, CreatedAt: now, UpdatedAt: now},
+			Name:     "legacy-role",
+			BaseRole: nil,
+		}
+
+		resp := toRoleResponse(role)
+		assert.Nil(t, resp.BaseRole)
+	})
+
+	t.Run("system role flag preserved", func(t *testing.T) {
+		role := &authModel.Role{
+			Model:    base.Model{ID: 1, CreatedAt: now, UpdatedAt: now},
+			Name:     "admin",
+			IsSystem: true,
+			BaseRole: nil,
+		}
+
+		resp := toRoleResponse(role)
+		assert.True(t, resp.IsSystem)
+		assert.Nil(t, resp.BaseRole)
+	})
+}
+
+// =============================================================================
+// CreateRoleRequest.Bind / UpdateRoleRequest.Bind Tests
+// =============================================================================
+
+func TestCreateRoleRequest_Bind_BaseRoleValidation(t *testing.T) {
+	t.Run("missing base_role rejected", func(t *testing.T) {
+		req := &CreateRoleRequest{Name: "test", Description: "desc"}
+		err := req.Bind(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base_role is required")
+	})
+
+	t.Run("invalid base_role rejected", func(t *testing.T) {
+		bad := "manager"
+		req := &CreateRoleRequest{Name: "test", Description: "desc", BaseRole: &bad}
+		err := req.Bind(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base_role must be one of")
+	})
+
+	t.Run("valid base_role accepted", func(t *testing.T) {
+		valid := "guardian"
+		req := &CreateRoleRequest{Name: "test", Description: "desc", BaseRole: &valid}
+		err := req.Bind(nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("whitespace base_role normalized then rejected as nil", func(t *testing.T) {
+		spaces := "   "
+		req := &CreateRoleRequest{Name: "test", Description: "desc", BaseRole: &spaces}
+		err := req.Bind(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base_role is required")
+	})
+}
+
+func TestUpdateRoleRequest_Bind_BaseRoleValidation(t *testing.T) {
+	t.Run("nil base_role accepted on update", func(t *testing.T) {
+		req := &UpdateRoleRequest{Name: "test", Description: "desc"}
+		err := req.Bind(nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid base_role accepted on update", func(t *testing.T) {
+		valid := "admin"
+		req := &UpdateRoleRequest{Name: "test", Description: "desc", BaseRole: &valid}
+		err := req.Bind(nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid base_role rejected on update", func(t *testing.T) {
+		bad := "owner"
+		req := &UpdateRoleRequest{Name: "test", Description: "desc", BaseRole: &bad}
+		err := req.Bind(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base_role must be one of")
+	})
 }

--- a/backend/api/auth/auth_test.go
+++ b/backend/api/auth/auth_test.go
@@ -1108,6 +1108,145 @@ func TestRoleManagement(t *testing.T) {
 	})
 }
 
+// TestRoleManagement_BaseRole tests base_role validation on role endpoints.
+func TestRoleManagement_BaseRole(t *testing.T) {
+	tc, router := setupExtendedProtectedRouter(t)
+	adminClaims := testutil.AdminTestClaims(1)
+
+	t.Run("create without base_role returns 400", func(t *testing.T) {
+		body := map[string]string{
+			"name":        fmt.Sprintf("no-base-%d", time.Now().UnixNano()),
+			"description": "Missing base_role",
+		}
+		req := testutil.NewJSONRequest(t, "POST", "/auth/roles", body)
+		rr := executeWithAuth(router, req, adminClaims, []string{"roles:create"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("create with invalid base_role returns 400", func(t *testing.T) {
+		body := map[string]string{
+			"name":        fmt.Sprintf("bad-base-%d", time.Now().UnixNano()),
+			"description": "Invalid base_role",
+			"base_role":   "superadmin",
+		}
+		req := testutil.NewJSONRequest(t, "POST", "/auth/roles", body)
+		rr := executeWithAuth(router, req, adminClaims, []string{"roles:create"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("create with valid base_role succeeds and returns it", func(t *testing.T) {
+		roleName := fmt.Sprintf("base-role-test-%d", time.Now().UnixNano())
+		body := map[string]string{
+			"name":        roleName,
+			"description": "Has base_role",
+			"base_role":   "guardian",
+		}
+		req := testutil.NewJSONRequest(t, "POST", "/auth/roles", body)
+		rr := executeWithAuth(router, req, adminClaims, []string{"roles:create"})
+
+		testutil.AssertSuccessResponse(t, rr, http.StatusCreated)
+
+		response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+		data, ok := response["data"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "guardian", data["base_role"])
+
+		// Cleanup
+		roleID := int64(data["id"].(float64))
+		defer cleanupRoleRecords(t, tc.db, roleID)
+	})
+
+	t.Run("update preserves base_role when omitted", func(t *testing.T) {
+		// Create a role with base_role via DB fixture, then update without sending base_role
+		role := testpkg.CreateTestRole(t, tc.db, "preserve-base")
+		defer cleanupRoleRecords(t, tc.db, role.ID)
+
+		// Set base_role directly in DB
+		_, err := tc.db.NewUpdate().
+			TableExpr("auth.roles").
+			Set("base_role = ?", "admin").
+			Where("id = ?", role.ID).
+			Exec(testpkg.TenantContext(1))
+		require.NoError(t, err)
+
+		// Update name only — no base_role in payload
+		body := map[string]string{
+			"name":        fmt.Sprintf("renamed-%d", time.Now().UnixNano()),
+			"description": "Updated desc",
+		}
+		req := testutil.NewJSONRequest(t, "PUT", fmt.Sprintf("/auth/roles/%d", role.ID), body)
+		rr := executeWithAuth(router, req, adminClaims, []string{"roles:update"})
+		assert.Equal(t, http.StatusNoContent, rr.Code, "Body: %s", rr.Body.String())
+
+		// Verify base_role was preserved
+		getReq := testutil.NewJSONRequest(t, "GET", fmt.Sprintf("/auth/roles/%d", role.ID), nil)
+		getRr := executeWithAuth(router, getReq, adminClaims, []string{"roles:read"})
+		testutil.AssertSuccessResponse(t, getRr, http.StatusOK)
+
+		getResp := testutil.ParseJSONResponse(t, getRr.Body.Bytes())
+		getData := getResp["data"].(map[string]interface{})
+		assert.Equal(t, "admin", getData["base_role"], "base_role should be preserved when not sent in update")
+	})
+
+	t.Run("update system role is rejected", func(t *testing.T) {
+		// System roles cannot be updated at all — the service returns 403
+		var systemRole authModel.Role
+		err := tc.db.NewSelect().
+			Model(&systemRole).
+			ModelTableExpr(`auth.roles AS "role"`).
+			Where(`"role".is_system = true`).
+			Where(`"role".tenant_id IS NULL`).
+			Limit(1).
+			Scan(testpkg.TenantContext(1))
+		require.NoError(t, err, "Expected at least one system role in test DB")
+
+		body := map[string]string{
+			"name":        systemRole.Name,
+			"description": systemRole.Description,
+			"base_role":   "guardian",
+		}
+		req := testutil.NewJSONRequest(t, "PUT", fmt.Sprintf("/auth/roles/%d", systemRole.ID), body)
+		rr := executeWithAuth(router, req, adminClaims, []string{"roles:update"})
+
+		assert.Equal(t, http.StatusForbidden, rr.Code,
+			"system roles must not accept updates including base_role")
+	})
+
+	t.Run("update changes base_role value", func(t *testing.T) {
+		role := testpkg.CreateTestRole(t, tc.db, "change-base")
+		defer cleanupRoleRecords(t, tc.db, role.ID)
+
+		// Set initial base_role
+		_, err := tc.db.NewUpdate().
+			TableExpr("auth.roles").
+			Set("base_role = ?", "user").
+			Where("id = ?", role.ID).
+			Exec(testpkg.TenantContext(1))
+		require.NoError(t, err)
+
+		// Update to a different base_role
+		body := map[string]string{
+			"name":        fmt.Sprintf("changed-%d", time.Now().UnixNano()),
+			"description": "Changed base_role",
+			"base_role":   "guardian",
+		}
+		req := testutil.NewJSONRequest(t, "PUT", fmt.Sprintf("/auth/roles/%d", role.ID), body)
+		rr := executeWithAuth(router, req, adminClaims, []string{"roles:update"})
+		assert.Equal(t, http.StatusNoContent, rr.Code, "Body: %s", rr.Body.String())
+
+		// Verify base_role was changed
+		getReq := testutil.NewJSONRequest(t, "GET", fmt.Sprintf("/auth/roles/%d", role.ID), nil)
+		getRr := executeWithAuth(router, getReq, adminClaims, []string{"roles:read"})
+		testutil.AssertSuccessResponse(t, getRr, http.StatusOK)
+
+		getResp := testutil.ParseJSONResponse(t, getRr.Body.Bytes())
+		getData := getResp["data"].(map[string]interface{})
+		assert.Equal(t, "guardian", getData["base_role"], "base_role should be updated to new value")
+	})
+}
+
 // TestPermissionManagement tests permission CRUD endpoints (protected)
 func TestPermissionManagement(t *testing.T) {
 	tc, router := setupProtectedRouter(t)

--- a/backend/api/auth/auth_test.go
+++ b/backend/api/auth/auth_test.go
@@ -1050,6 +1050,7 @@ func TestRoleManagement(t *testing.T) {
 		body := map[string]string{
 			"name":        roleName,
 			"description": "A test role",
+			"base_role":   "user",
 		}
 
 		req := testutil.NewJSONRequest(t, "POST", "/auth/roles", body)
@@ -1088,6 +1089,7 @@ func TestRoleManagement(t *testing.T) {
 		body := map[string]string{
 			"name":        roleName,
 			"description": "A test role for get",
+			"base_role":   "user",
 		}
 
 		createReq := testutil.NewJSONRequest(t, "POST", "/auth/roles", body)

--- a/backend/database/migrations/001015030_roles_base_role.go
+++ b/backend/database/migrations/001015030_roles_base_role.go
@@ -1,0 +1,102 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	rolesBaseRoleVersion     = "1.15.30"
+	rolesBaseRoleDescription = "Add base_role column to auth.roles for mapping custom roles to system roles (announcement targeting)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     rolesBaseRoleVersion,
+		Description: rolesBaseRoleDescription,
+		DependsOn:   []string{"1.15.29", "1.0.4"},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return addRolesBaseRole(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return rollbackRolesBaseRole(ctx, db)
+		},
+	)
+}
+
+func addRolesBaseRole(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.30: Adding base_role column to auth.roles...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		ALTER TABLE auth.roles
+			ADD COLUMN IF NOT EXISTS base_role VARCHAR;
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to add base_role column: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		DO $$ BEGIN
+			ALTER TABLE auth.roles
+				ADD CONSTRAINT chk_roles_base_role
+				CHECK (base_role IS NULL OR base_role IN ('admin', 'user', 'guardian'));
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$;
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to add check constraint: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		CREATE INDEX IF NOT EXISTS idx_roles_base_role
+			ON auth.roles(base_role)
+			WHERE base_role IS NOT NULL;
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create index: %w", err)
+	}
+
+	fmt.Println("  Added base_role column with check constraint and partial index")
+	return tx.Commit()
+}
+
+func rollbackRolesBaseRole(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rollback 1.15.30: Removing base_role column from auth.roles...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		ALTER TABLE auth.roles
+			DROP COLUMN IF EXISTS base_role;
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to drop base_role column: %w", err)
+	}
+
+	fmt.Println("  Removed base_role column successfully")
+	return tx.Commit()
+}

--- a/backend/database/migrations/001015031_roles_base_role.go
+++ b/backend/database/migrations/001015031_roles_base_role.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	rolesBaseRoleVersion     = "1.15.30"
+	rolesBaseRoleVersion     = "1.15.31"
 	rolesBaseRoleDescription = "Add base_role column to auth.roles for mapping custom roles to system roles (announcement targeting)"
 )
 
@@ -17,7 +17,7 @@ func init() {
 	MigrationRegistry.Register(&Migration{
 		Version:     rolesBaseRoleVersion,
 		Description: rolesBaseRoleDescription,
-		DependsOn:   []string{"1.15.29", "1.0.4"},
+		DependsOn:   []string{"1.15.30", "1.0.4"},
 	})
 
 	Migrations.MustRegister(
@@ -31,7 +31,7 @@ func init() {
 }
 
 func addRolesBaseRole(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.30: Adding base_role column to auth.roles...")
+	fmt.Println("Migration 1.15.31: Adding base_role column to auth.roles...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
@@ -77,7 +77,7 @@ func addRolesBaseRole(ctx context.Context, db *bun.DB) error {
 }
 
 func rollbackRolesBaseRole(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rollback 1.15.30: Removing base_role column from auth.roles...")
+	fmt.Println("Rollback 1.15.31: Removing base_role column from auth.roles...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {

--- a/backend/database/migrations/001015031_roles_base_role.go
+++ b/backend/database/migrations/001015031_roles_base_role.go
@@ -17,7 +17,7 @@ func init() {
 	MigrationRegistry.Register(&Migration{
 		Version:     rolesBaseRoleVersion,
 		Description: rolesBaseRoleDescription,
-		DependsOn:   []string{"1.15.30", "1.0.4"},
+		DependsOn:   []string{"1.15.29", "1.0.4"},
 	})
 
 	Migrations.MustRegister(

--- a/backend/database/repositories/platform/announcement_targeting_test.go
+++ b/backend/database/repositories/platform/announcement_targeting_test.go
@@ -446,6 +446,182 @@ func TestAnnouncementTargeting_GetUnreadForUser_RolesWithOrgTargeting(t *testing
 	assert.Equal(t, 0, countB)
 }
 
+func TestAnnouncementTargeting_GetUnreadForUser_DualRoleNotDuplicated(t *testing.T) {
+	// Regression test: an account with BOTH a direct role match AND a custom role
+	// with matching base_role must see the announcement exactly once, not duplicated.
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	viewRepo := platform.NewAnnouncementViewRepository(db)
+	annoRepo := platform.NewAnnouncementRepository(db)
+
+	orgID := createTestOrganization(t, db, "Org Dual Role")
+	schoolID := createTestSchool(t, db, "School Dual Role", orgID)
+
+	operator := createTestOperator(t, db, "targeting-dual-role@example.com", "Dual Role Test")
+
+	// Role with name "user" (direct name match on target_roles)
+	sysRoleID := createTestRoleWithBaseRole(t, db, "user", "user", schoolID)
+
+	// Custom role with base_role = "user" (base_role match on target_roles)
+	customRoleID := createTestRoleWithBaseRole(t, db, "gruppenleitung-dual-delivery", "user", schoolID)
+
+	// Account has BOTH roles
+	userID := createTestAccount(t, db, "user-dual-delivery@example.com")
+	createTestAccountTenant(t, db, userID, schoolID)
+	assignTestRole(t, db, userID, sysRoleID, schoolID)
+	assignTestRole(t, db, userID, customRoleID, schoolID)
+
+	// Announcement targets "user" — both roles match (one by name, one by base_role)
+	announcement := &platformModels.Announcement{
+		Title:           "Dual Role Delivery",
+		Content:         "Should appear exactly once",
+		Type:            platformModels.TypeAnnouncement,
+		Severity:        platformModels.SeverityInfo,
+		Active:          true,
+		CreatedBy:       operator.ID,
+		TargetRoles:     []string{"user"},
+		TargetOrgIDs:    []int64{},
+		TargetTenantIDs: []int64{},
+	}
+	err := annoRepo.Create(ctx, announcement)
+	require.NoError(t, err)
+	publishTestAnnouncement(t, db, announcement.ID)
+
+	defer cleanupTargetingTestData(t, db,
+		[]int64{announcement.ID},
+		[]int64{userID},
+		[]int64{schoolID},
+		[]int64{orgID},
+	)
+	defer cleanupTestOperator(t, db, operator.ID)
+	defer cleanupTestRole(t, db, sysRoleID)
+	defer cleanupTestRole(t, db, customRoleID)
+	defer cleanupTestAccountRole(t, db, userID, sysRoleID)
+	defer cleanupTestAccountRole(t, db, userID, customRoleID)
+
+	// GetUnreadForUser should return the announcement exactly once
+	unread, err := viewRepo.GetUnreadForUser(ctx, userID, []string{"user", "gruppenleitung-dual-delivery"}, schoolID, orgID)
+	require.NoError(t, err)
+
+	matchCount := 0
+	for _, a := range unread {
+		if a.ID == announcement.ID {
+			matchCount++
+		}
+	}
+	assert.Equal(t, 1, matchCount, "announcement must appear exactly once even with both direct and base_role match")
+
+	// CountUnread should also be consistent
+	count, err := viewRepo.CountUnread(ctx, userID, []string{"user", "gruppenleitung-dual-delivery"}, schoolID, orgID)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, count, 1, "count should include the dual-matched announcement")
+}
+
+func TestAnnouncementTargeting_GetUnreadForUser_UpdateBaseRoleChangesDelivery(t *testing.T) {
+	// Test: changing a custom role's base_role should change which announcements
+	// the user receives via the base_role expansion path.
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	viewRepo := platform.NewAnnouncementViewRepository(db)
+	annoRepo := platform.NewAnnouncementRepository(db)
+
+	orgID := createTestOrganization(t, db, "Org BaseRole Update")
+	schoolID := createTestSchool(t, db, "School BaseRole Update", orgID)
+
+	operator := createTestOperator(t, db, "targeting-update-baserole@example.com", "Update BaseRole Test")
+
+	// Custom role initially with base_role = "user"
+	customRoleID := createTestRoleWithBaseRole(t, db, "dynamic-role-test", "user", schoolID)
+
+	userID := createTestAccount(t, db, "user-update-baserole@example.com")
+	createTestAccountTenant(t, db, userID, schoolID)
+	assignTestRole(t, db, userID, customRoleID, schoolID)
+
+	// Announcement targeting "admin"
+	annoAdmin := &platformModels.Announcement{
+		Title:           "Admin Only",
+		Content:         "For admins",
+		Type:            platformModels.TypeAnnouncement,
+		Severity:        platformModels.SeverityInfo,
+		Active:          true,
+		CreatedBy:       operator.ID,
+		TargetRoles:     []string{"admin"},
+		TargetOrgIDs:    []int64{},
+		TargetTenantIDs: []int64{},
+	}
+	err := annoRepo.Create(ctx, annoAdmin)
+	require.NoError(t, err)
+	publishTestAnnouncement(t, db, annoAdmin.ID)
+
+	// Announcement targeting "user"
+	annoUser := &platformModels.Announcement{
+		Title:           "User Only",
+		Content:         "For users",
+		Type:            platformModels.TypeAnnouncement,
+		Severity:        platformModels.SeverityInfo,
+		Active:          true,
+		CreatedBy:       operator.ID,
+		TargetRoles:     []string{"user"},
+		TargetOrgIDs:    []int64{},
+		TargetTenantIDs: []int64{},
+	}
+	err = annoRepo.Create(ctx, annoUser)
+	require.NoError(t, err)
+	publishTestAnnouncement(t, db, annoUser.ID)
+
+	defer cleanupTargetingTestData(t, db,
+		[]int64{annoAdmin.ID, annoUser.ID},
+		[]int64{userID},
+		[]int64{schoolID},
+		[]int64{orgID},
+	)
+	defer cleanupTestOperator(t, db, operator.ID)
+	defer cleanupTestRole(t, db, customRoleID)
+	defer cleanupTestAccountRole(t, db, userID, customRoleID)
+
+	// With base_role = "user", the user should see "User Only" but NOT "Admin Only"
+	unread, err := viewRepo.GetUnreadForUser(ctx, userID, []string{"dynamic-role-test"}, schoolID, orgID)
+	require.NoError(t, err)
+
+	hasUser, hasAdmin := false, false
+	for _, a := range unread {
+		if a.ID == annoUser.ID {
+			hasUser = true
+		}
+		if a.ID == annoAdmin.ID {
+			hasAdmin = true
+		}
+	}
+	assert.True(t, hasUser, "user with base_role='user' should see user-targeted announcement")
+	assert.False(t, hasAdmin, "user with base_role='user' should NOT see admin-targeted announcement")
+
+	// Now update the role's base_role to "admin"
+	updateCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = db.NewRaw(`UPDATE auth.roles SET base_role = 'admin' WHERE id = ?`, customRoleID).Exec(updateCtx)
+	require.NoError(t, err)
+
+	// After update: should see "Admin Only" but NOT "User Only"
+	unread2, err := viewRepo.GetUnreadForUser(ctx, userID, []string{"dynamic-role-test"}, schoolID, orgID)
+	require.NoError(t, err)
+
+	hasUser2, hasAdmin2 := false, false
+	for _, a := range unread2 {
+		if a.ID == annoUser.ID {
+			hasUser2 = true
+		}
+		if a.ID == annoAdmin.ID {
+			hasAdmin2 = true
+		}
+	}
+	assert.False(t, hasUser2, "after base_role change to 'admin', should NOT see user-targeted announcement")
+	assert.True(t, hasAdmin2, "after base_role change to 'admin', should see admin-targeted announcement")
+}
+
 func TestOrganizationRepository_CountByIDs(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/backend/database/repositories/platform/announcement_view_internal_test.go
+++ b/backend/database/repositories/platform/announcement_view_internal_test.go
@@ -1,0 +1,22 @@
+package platform
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildUnreadArgs_CountMatchesPlaceholders(t *testing.T) {
+	// The full query used by GetUnreadForUser and CountUnread has one ? in the
+	// JOIN clause (v.user_id = ?) plus all ?'s in unreadWhereClause. The args
+	// returned by buildUnreadArgs must match that total exactly.
+	joinPlaceholders := 1 // LEFT JOIN ... ON ... AND v.user_id = ?
+	wherePlaceholders := strings.Count(unreadWhereClause, "?")
+	expectedArgs := joinPlaceholders + wherePlaceholders
+
+	args := buildUnreadArgs(1, []string{"user"}, 2, 3)
+
+	if len(args) != expectedArgs {
+		t.Errorf("buildUnreadArgs returned %d args, but query has %d placeholders (JOIN: %d + WHERE: %d)",
+			len(args), expectedArgs, joinPlaceholders, wherePlaceholders)
+	}
+}

--- a/backend/database/repositories/platform/announcement_view_repository.go
+++ b/backend/database/repositories/platform/announcement_view_repository.go
@@ -83,28 +83,42 @@ func (r *AnnouncementViewRepository) MarkDismissed(ctx context.Context, userID, 
 	return nil
 }
 
-// buildUnreadArgs returns the fixed-size positional args for unreadWhereClause.
-// Arg order is always: userID, now, now, pgArray(userRoles), tenantID, orgID (6 args).
+// buildUnreadArgs returns the fixed-size positional args shared by the JOIN + WHERE
+// in the unread announcement query.
+// Arg order: userID (JOIN), now, now, pgArray(userRoles), userID (EXISTS), tenantID (EXISTS), tenantID (targeting), orgID (targeting) — 8 args.
 func buildUnreadArgs(userID int64, userRoles []string, tenantID int64, orgID int64) []any {
 	now := time.Now()
 	if userRoles == nil {
 		userRoles = []string{}
 	}
-	return []any{userID, now, now, pgdialect.Array(userRoles), tenantID, orgID}
+	return []any{userID, now, now, pgdialect.Array(userRoles), userID, tenantID, tenantID, orgID}
 }
 
 // unreadWhereClause is the shared SQL fragment used by both GetUnreadForUser
-// and CountUnread. Arg positions are fixed (always 6 — see buildUnreadArgs).
-// Role matching uses the && (overlap) operator: when userRoles is empty the
-// overlap with '{}' is false, so only global announcements (target_roles = '{}')
-// pass the filter — no branching or fmt.Sprintf needed.
+// and CountUnread. Arg positions are fixed (always 8 — see buildUnreadArgs).
+//
+// Role matching: a user matches if their JWT role names overlap with target_roles
+// (direct match) OR if any of their assigned roles in the current session tenant
+// has a base_role that appears in target_roles (base-role match via EXISTS).
+// The tenant scoping on the EXISTS prevents cross-tenant role leakage: a user's
+// custom role in Tenant B must not influence announcement delivery in Tenant A.
+// This mirrors the strategy used by GetStats to keep delivery and stats consistent.
 const unreadWhereClause = `
 	WHERE a.active = true
 		AND a.published_at IS NOT NULL
 		AND a.published_at <= ?
 		AND (a.expires_at IS NULL OR a.expires_at > ?)
 		AND v.seen_at IS NULL
-		AND (a.target_roles = '{}' OR a.target_roles && ?::text[])
+		AND (a.target_roles = '{}'
+			OR a.target_roles && ?::text[]
+			OR EXISTS (
+				SELECT 1 FROM auth.account_roles ar
+				JOIN auth.roles r ON r.id = ar.role_id
+				WHERE ar.account_id = ?
+				AND ar.tenant_id = ?
+				AND r.base_role IS NOT NULL
+				AND r.base_role = ANY(a.target_roles)
+			))
 		AND (
 			(a.target_org_ids = '{}' AND a.target_tenant_ids = '{}')
 			OR (a.target_tenant_ids != '{}' AND ? = ANY(a.target_tenant_ids))
@@ -216,8 +230,8 @@ func (r *AnnouncementViewRepository) GetStats(ctx context.Context, announcementI
 	queryParts = append(queryParts, `WHERE at.status = 'active'`)
 
 	if hasRoleFilter {
-		queryParts = append(queryParts, `AND r.name IN (?)`)
-		queryArgs = append(queryArgs, bun.List(targetRoles))
+		queryParts = append(queryParts, `AND (r.name IN (?) OR (r.base_role IS NOT NULL AND r.base_role IN (?)))`)
+		queryArgs = append(queryArgs, bun.List(targetRoles), bun.List(targetRoles))
 	}
 
 	if hasOrgFilter && hasTenantFilter {

--- a/backend/database/repositories/platform/announcement_view_repository_test.go
+++ b/backend/database/repositories/platform/announcement_view_repository_test.go
@@ -223,6 +223,20 @@ func createTestRole(t *testing.T, db *bun.DB, roleName string) int64 {
 	return id
 }
 
+func createTestRoleWithBaseRole(t *testing.T, db *bun.DB, roleName, baseRole string, tenantID int64) int64 {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var id int64
+	_, err := db.NewRaw(`
+		INSERT INTO auth.roles (name, tenant_id, base_role, created_at, updated_at)
+		VALUES (?, ?, ?, NOW(), NOW())
+		RETURNING id
+	`, roleName, tenantID, baseRole).Exec(ctx, &id)
+	require.NoError(t, err)
+	return id
+}
+
 func cleanupTestRole(t *testing.T, db *bun.DB, roleID int64) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -556,6 +570,57 @@ func TestAnnouncementViewRepository_GetUnreadForUser(t *testing.T) {
 
 		for _, a := range results {
 			assert.NotEqual(t, annoID, a.ID, "role-targeted announcement should NOT match user with different role")
+		}
+	})
+
+	t.Run("base_role maps custom role to system role for targeting", func(t *testing.T) {
+		// Create a custom role with base_role = "user" in the test tenant
+		customRoleID := createTestRoleWithBaseRole(t, db, "gruppenleitung-base-test", "user", schoolID)
+		defer cleanupTestRole(t, db, customRoleID)
+
+		// Assign the custom role to the user
+		assignTestRole(t, db, accountID, customRoleID, schoolID)
+		defer cleanupTestAccountRole(t, db, accountID, customRoleID)
+
+		// Create announcement targeting system role "user"
+		annoID := createTestAnnouncementWithTargeting(t, db, "base-role-match", operator.ID, []string{"user"}, []int64{}, []int64{})
+		defer cleanupTestAnnouncement(t, db, annoID)
+		publishTestAnnouncement(t, db, annoID)
+
+		// User's JWT roles don't include "user" — only the custom name
+		results, err := viewRepo.GetUnreadForUser(ctx, accountID, []string{"gruppenleitung-base-test"}, schoolID, orgID)
+		require.NoError(t, err)
+
+		found := false
+		for _, a := range results {
+			if a.ID == annoID {
+				found = true
+			}
+		}
+		assert.True(t, found, "announcement targeting 'user' should be visible to user with custom role base_role='user'")
+	})
+
+	t.Run("base_role does not leak across tenants", func(t *testing.T) {
+		// Create a custom role with base_role = "admin" in a DIFFERENT tenant
+		otherRoleID := createTestRoleWithBaseRole(t, db, "other-tenant-admin-test", "admin", otherSchoolID)
+		defer cleanupTestRole(t, db, otherRoleID)
+
+		// Assign it in the other tenant
+		assignTestRole(t, db, accountID, otherRoleID, otherSchoolID)
+		defer cleanupTestAccountRole(t, db, accountID, otherRoleID)
+
+		// Create announcement targeting "admin" — should NOT match because the
+		// base_role="admin" assignment is in otherSchoolID, not schoolID
+		annoID := createTestAnnouncementWithTargeting(t, db, "base-role-cross-tenant", operator.ID, []string{"admin"}, []int64{}, []int64{})
+		defer cleanupTestAnnouncement(t, db, annoID)
+		publishTestAnnouncement(t, db, annoID)
+
+		// Query with the user's actual tenant (schoolID) — the other-tenant role should not match
+		results, err := viewRepo.GetUnreadForUser(ctx, accountID, []string{"gruppenleitung-base-test"}, schoolID, orgID)
+		require.NoError(t, err)
+
+		for _, a := range results {
+			assert.NotEqual(t, annoID, a.ID, "base_role from a different tenant should NOT cause announcement match")
 		}
 	})
 
@@ -958,6 +1023,32 @@ func TestAnnouncementViewRepository_GetStats(t *testing.T) {
 		assert.Equal(t, 2, stats.TargetCount, "should count exactly the 2 accounts with this role")
 	})
 
+	t.Run("base_role-mapped custom role counted in stats", func(t *testing.T) {
+		bOrgID := createTestOrganization(t, db, "stats-base-role-org")
+		defer cleanupTestOrganization(t, db, bOrgID)
+		bSchoolID := createTestSchool(t, db, "stats-base-role-school", bOrgID)
+		defer cleanupTestSchool(t, db, bSchoolID)
+
+		// Create a custom role with base_role = "user"
+		customRoleID := createTestRoleWithBaseRole(t, db, "stats-gruppenleitung", "user", bSchoolID)
+		defer cleanupTestRole(t, db, customRoleID)
+
+		acc := createTestAccount(t, db, "stats-base-role-acc@test.com")
+		defer cleanupTestAccount(t, db, acc)
+		assignTestRole(t, db, acc, customRoleID, bSchoolID)
+		defer cleanupTestAccountRole(t, db, acc, customRoleID)
+		createTestAccountTenant(t, db, acc, bSchoolID)
+		defer cleanupTestAccountTenant(t, db, acc, bSchoolID)
+
+		// Announcement targets system role "user"
+		annoID := createTestAnnouncementWithTargeting(t, db, "stats-base-role", operator.ID, []string{"user"}, []int64{}, []int64{})
+		defer cleanupTestAnnouncement(t, db, annoID)
+
+		stats, err := viewRepo.GetStats(ctx, annoID)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, stats.TargetCount, 1, "stats should count user with custom role base_role='user'")
+	})
+
 	t.Run("org-filtered announcement counts org-matching accounts", func(t *testing.T) {
 		orgID := createTestOrganization(t, db, "stats-org")
 		defer cleanupTestOrganization(t, db, orgID)
@@ -1219,6 +1310,42 @@ func TestAnnouncementViewRepository_GetStats(t *testing.T) {
 
 		assert.GreaterOrEqual(t, stats.TargetCount, 1,
 			"global stats should include at least the active-school account")
+	})
+
+	t.Run("account with both direct role and base_role-mapped role counted once", func(t *testing.T) {
+		// Regression test: if an account has BOTH a direct role name match
+		// AND a custom role with matching base_role, the COUNT(DISTINCT at.account_id)
+		// must still return 1, not 2. Protects the DISTINCT keyword in GetStats.
+		dOrgID := createTestOrganization(t, db, "stats-dual-role-org")
+		defer cleanupTestOrganization(t, db, dOrgID)
+		dSchoolID := createTestSchool(t, db, "stats-dual-role-school", dOrgID)
+		defer cleanupTestSchool(t, db, dSchoolID)
+
+		// Role with name "user" (direct name match on target_roles)
+		directRoleID := createTestRoleWithBaseRole(t, db, "user", "user", dSchoolID)
+		defer cleanupTestRole(t, db, directRoleID)
+
+		// Custom role with base_role = "user" (base_role match on target_roles)
+		customRoleID := createTestRoleWithBaseRole(t, db, "gruppenleitung-dual-test", "user", dSchoolID)
+		defer cleanupTestRole(t, db, customRoleID)
+
+		// Single account has BOTH roles assigned
+		acc := createTestAccount(t, db, "stats-dual-role@test.com")
+		defer cleanupTestAccount(t, db, acc)
+		assignTestRole(t, db, acc, directRoleID, dSchoolID)
+		defer cleanupTestAccountRole(t, db, acc, directRoleID)
+		assignTestRole(t, db, acc, customRoleID, dSchoolID)
+		defer cleanupTestAccountRole(t, db, acc, customRoleID)
+		createTestAccountTenant(t, db, acc, dSchoolID)
+		defer cleanupTestAccountTenant(t, db, acc, dSchoolID)
+
+		// Scope to this tenant so we only count accounts in dSchoolID
+		annoID := createTestAnnouncementWithTargeting(t, db, "stats-dual-role", operator.ID, []string{"user"}, []int64{}, []int64{dSchoolID})
+		defer cleanupTestAnnouncement(t, db, annoID)
+
+		stats, err := viewRepo.GetStats(ctx, annoID)
+		require.NoError(t, err)
+		assert.Equal(t, 1, stats.TargetCount, "account with both direct and base_role match must be counted exactly once")
 	})
 
 	t.Run("seen and dismissed counts", func(t *testing.T) {

--- a/backend/models/auth/base_role_sync_test.go
+++ b/backend/models/auth/base_role_sync_test.go
@@ -1,0 +1,126 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+// TestBaseRoleSyncAcrossLayers ensures ValidBaseRoles, the DB CHECK constraint,
+// and the frontend BASE_ROLE_LABELS all define the same set of base roles.
+// If this test fails, someone added a role in one place but not all three.
+// See also: role.go comment on ValidBaseRoles.
+func TestBaseRoleSyncAcrossLayers(t *testing.T) {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		t.Skipf("Cannot locate project root: %v", err)
+	}
+
+	goRoles := make([]string, len(ValidBaseRoles))
+	copy(goRoles, ValidBaseRoles)
+	sort.Strings(goRoles)
+
+	t.Run("Go ValidBaseRoles matches DB CHECK constraint", func(t *testing.T) {
+		migrationPath := filepath.Join(projectRoot, "backend/database/migrations/001015030_roles_base_role.go")
+		content, err := os.ReadFile(migrationPath)
+		if err != nil {
+			t.Skipf("Cannot read migration file: %v", err)
+		}
+
+		dbRoles := extractCheckConstraintRoles(string(content))
+		if dbRoles == nil {
+			t.Fatal("Could not parse base_role CHECK constraint from migration file")
+		}
+		sort.Strings(dbRoles)
+
+		if !equal(goRoles, dbRoles) {
+			t.Errorf("ValidBaseRoles %v != DB CHECK constraint %v", goRoles, dbRoles)
+		}
+	})
+
+	t.Run("Go ValidBaseRoles matches frontend BASE_ROLE_LABELS", func(t *testing.T) {
+		frontendPath := filepath.Join(projectRoot, "frontend/src/lib/auth-helpers.ts")
+		content, err := os.ReadFile(frontendPath)
+		if err != nil {
+			t.Skipf("Cannot read frontend file: %v", err)
+		}
+
+		feRoles := extractBaseRoleLabelKeys(string(content))
+		if feRoles == nil {
+			t.Fatal("Could not parse BASE_ROLE_LABELS keys from auth-helpers.ts")
+		}
+		sort.Strings(feRoles)
+
+		if !equal(goRoles, feRoles) {
+			t.Errorf("ValidBaseRoles %v != frontend BASE_ROLE_LABELS %v", goRoles, feRoles)
+		}
+	})
+}
+
+// extractCheckConstraintRoles parses roles from: base_role IN ('admin', 'user', 'guardian')
+func extractCheckConstraintRoles(source string) []string {
+	re := regexp.MustCompile(`base_role\s+IN\s*\(([^)]+)\)`)
+	match := re.FindStringSubmatch(source)
+	if len(match) < 2 {
+		return nil
+	}
+	valueRe := regexp.MustCompile(`'([^']+)'`)
+	matches := valueRe.FindAllStringSubmatch(match[1], -1)
+	var roles []string
+	for _, m := range matches {
+		roles = append(roles, m[1])
+	}
+	return roles
+}
+
+// extractBaseRoleLabelKeys parses keys from: export const BASE_ROLE_LABELS = { admin: ..., user: ..., }
+func extractBaseRoleLabelKeys(source string) []string {
+	// Match the object block after BASE_ROLE_LABELS
+	blockRe := regexp.MustCompile(`BASE_ROLE_LABELS[^{]*\{([^}]+)\}`)
+	match := blockRe.FindStringSubmatch(source)
+	if len(match) < 2 {
+		return nil
+	}
+	// Extract keys (unquoted identifiers before colons)
+	keyRe := regexp.MustCompile(`(\w+)\s*:`)
+	matches := keyRe.FindAllStringSubmatch(match[1], -1)
+	var roles []string
+	for _, m := range matches {
+		roles = append(roles, m[1])
+	}
+	return roles
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// findProjectRoot is duplicated here (from test/helpers.go) to avoid importing
+// the testpkg package which pulls in database dependencies. This is a pure
+// filesystem helper that doesn't need any external packages.
+func findProjectRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Dir(dir), nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
+}

--- a/backend/models/auth/base_role_sync_test.go
+++ b/backend/models/auth/base_role_sync_test.go
@@ -18,8 +18,9 @@ func TestBaseRoleSyncAcrossLayers(t *testing.T) {
 		t.Skipf("Cannot locate project root: %v", err)
 	}
 
-	goRoles := make([]string, len(ValidBaseRoles))
-	copy(goRoles, ValidBaseRoles)
+	validRoles := ValidBaseRoles()
+	goRoles := make([]string, len(validRoles))
+	copy(goRoles, validRoles)
 	sort.Strings(goRoles)
 
 	t.Run("Go ValidBaseRoles matches DB CHECK constraint", func(t *testing.T) {

--- a/backend/models/auth/base_role_sync_test.go
+++ b/backend/models/auth/base_role_sync_test.go
@@ -24,7 +24,7 @@ func TestBaseRoleSyncAcrossLayers(t *testing.T) {
 	sort.Strings(goRoles)
 
 	t.Run("Go ValidBaseRoles matches DB CHECK constraint", func(t *testing.T) {
-		migrationPath := filepath.Join(projectRoot, "backend/database/migrations/001015030_roles_base_role.go")
+		migrationPath := filepath.Join(projectRoot, "backend/database/migrations/001015031_roles_base_role.go")
 		content, err := os.ReadFile(migrationPath)
 		if err != nil {
 			t.Skipf("Cannot read migration file: %v", err)

--- a/backend/models/auth/role.go
+++ b/backend/models/auth/role.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"errors"
+	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -9,13 +11,27 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// System role names used as base role targets for custom roles.
+const (
+	BaseRoleAdmin    = "admin"
+	BaseRoleUser     = "user"
+	BaseRoleGuardian = "guardian"
+)
+
+// ValidBaseRoles lists the system roles that custom roles can map to.
+// When adding a new base role, also update:
+//   - DB CHECK constraint in migration 001015030_roles_base_role.go
+//   - Frontend options in roles.config.tsx and role-detail-modal.tsx
+var ValidBaseRoles = []string{BaseRoleAdmin, BaseRoleUser, BaseRoleGuardian}
+
 // Role represents a user role
 type Role struct {
 	base.Model  `bun:"schema:auth,table:roles"`
-	TenantID    *int64 `bun:"tenant_id" json:"tenant_id,omitempty"`
-	Name        string `bun:"name,notnull" json:"name"`
-	Description string `bun:"description" json:"description"`
-	IsSystem    bool   `bun:"is_system,notnull,default:false" json:"is_system"`
+	TenantID    *int64  `bun:"tenant_id" json:"tenant_id,omitempty"`
+	Name        string  `bun:"name,notnull" json:"name"`
+	Description string  `bun:"description" json:"description"`
+	IsSystem    bool    `bun:"is_system,notnull,default:false" json:"is_system"`
+	BaseRole    *string `bun:"base_role" json:"base_role,omitempty"`
 
 	// Relations
 	Permissions []*Permission `bun:"-" json:"permissions,omitempty"`
@@ -44,6 +60,20 @@ func (r *Role) Validate() error {
 
 	// Normalize role name to lowercase
 	r.Name = strings.ToLower(r.Name)
+
+	if r.BaseRole != nil {
+		trimmed := strings.TrimSpace(*r.BaseRole)
+		if trimmed == "" {
+			r.BaseRole = nil
+		} else {
+			r.BaseRole = &trimmed
+		}
+	}
+	if r.BaseRole != nil {
+		if !slices.Contains(ValidBaseRoles, *r.BaseRole) {
+			return fmt.Errorf("base_role must be one of %v", ValidBaseRoles)
+		}
+	}
 
 	return nil
 }

--- a/backend/models/auth/role.go
+++ b/backend/models/auth/role.go
@@ -18,11 +18,13 @@ const (
 	BaseRoleGuardian = "guardian"
 )
 
-// ValidBaseRoles lists the system roles that custom roles can map to.
+// ValidBaseRoles returns the system roles that custom roles can map to.
 // When adding a new base role, also update:
 //   - DB CHECK constraint in migration 001015030_roles_base_role.go
 //   - Frontend options in roles.config.tsx and role-detail-modal.tsx
-var ValidBaseRoles = []string{BaseRoleAdmin, BaseRoleUser, BaseRoleGuardian}
+func ValidBaseRoles() []string {
+	return []string{BaseRoleAdmin, BaseRoleUser, BaseRoleGuardian}
+}
 
 // Role represents a user role
 type Role struct {
@@ -70,8 +72,8 @@ func (r *Role) Validate() error {
 		}
 	}
 	if r.BaseRole != nil {
-		if !slices.Contains(ValidBaseRoles, *r.BaseRole) {
-			return fmt.Errorf("base_role must be one of %v", ValidBaseRoles)
+		if !slices.Contains(ValidBaseRoles(), *r.BaseRole) {
+			return fmt.Errorf("base_role must be one of %v", ValidBaseRoles())
 		}
 	}
 

--- a/backend/models/auth/role.go
+++ b/backend/models/auth/role.go
@@ -20,7 +20,7 @@ const (
 
 // ValidBaseRoles returns the system roles that custom roles can map to.
 // When adding a new base role, also update:
-//   - DB CHECK constraint in migration 001015030_roles_base_role.go
+//   - DB CHECK constraint in migration 001015031_roles_base_role.go
 //   - Frontend options in roles.config.tsx and role-detail-modal.tsx
 func ValidBaseRoles() []string {
 	return []string{BaseRoleAdmin, BaseRoleUser, BaseRoleGuardian}

--- a/backend/models/auth/role_test.go
+++ b/backend/models/auth/role_test.go
@@ -94,6 +94,78 @@ func TestRole_Validate_Normalization(t *testing.T) {
 	}
 }
 
+func TestRole_Validate_BaseRole(t *testing.T) {
+	validUser := "user"
+	validAdmin := "admin"
+	validGuardian := "guardian"
+	invalid := "superuser"
+	empty := ""
+
+	tests := []struct {
+		name    string
+		role    *Role
+		wantErr bool
+	}{
+		{
+			name:    "nil base_role on custom role is valid (legacy roles)",
+			role:    &Role{Name: "custom", BaseRole: nil},
+			wantErr: false,
+		},
+		{
+			name:    "nil base_role on system role is valid",
+			role:    &Role{Name: "admin", IsSystem: true, BaseRole: nil},
+			wantErr: false,
+		},
+		{
+			name:    "base_role admin is valid",
+			role:    &Role{Name: "custom", BaseRole: &validAdmin},
+			wantErr: false,
+		},
+		{
+			name:    "base_role user is valid",
+			role:    &Role{Name: "custom", BaseRole: &validUser},
+			wantErr: false,
+		},
+		{
+			name:    "base_role guardian is valid",
+			role:    &Role{Name: "custom", BaseRole: &validGuardian},
+			wantErr: false,
+		},
+		{
+			name:    "invalid base_role is rejected",
+			role:    &Role{Name: "custom", BaseRole: &invalid},
+			wantErr: true,
+		},
+		{
+			name:    "empty base_role on custom role is valid (normalized to nil)",
+			role:    &Role{Name: "custom", BaseRole: &empty},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.role.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Role.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+
+	// Verify empty base_role normalization on system role (still becomes nil, which is valid)
+	t.Run("empty base_role on system role becomes nil after Validate", func(t *testing.T) {
+		empty := ""
+		role := &Role{Name: "admin", IsSystem: true, BaseRole: &empty}
+		err := role.Validate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if role.BaseRole != nil {
+			t.Errorf("expected BaseRole to be nil after normalization, got %q", *role.BaseRole)
+		}
+	})
+}
+
 func TestRole_HasPermission(t *testing.T) {
 	readPerm := &Permission{
 		Model: base.Model{ID: 1},

--- a/backend/services/auth/auth_core_test.go
+++ b/backend/services/auth/auth_core_test.go
@@ -865,7 +865,7 @@ func TestAuthService_CreateRole(t *testing.T) {
 		name := fmt.Sprintf("test-role-%d", time.Now().UnixNano())
 
 		// ACT
-		role, err := service.CreateRole(ctx, name, "Test role description")
+		role, err := service.CreateRole(ctx, name, "Test role description", strPtr("user"))
 
 		// ASSERT
 		require.NoError(t, err)
@@ -876,7 +876,7 @@ func TestAuthService_CreateRole(t *testing.T) {
 
 	t.Run("returns error for empty name", func(t *testing.T) {
 		// ACT
-		role, err := service.CreateRole(ctx, "", "description")
+		role, err := service.CreateRole(ctx, "", "description", strPtr("user"))
 
 		// ASSERT
 		require.Error(t, err)
@@ -894,7 +894,7 @@ func TestAuthService_GetRoleByID(t *testing.T) {
 	t.Run("returns role when found", func(t *testing.T) {
 		// ARRANGE
 		name := fmt.Sprintf("get-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, name, "description")
+		role, err := service.CreateRole(ctx, name, "description", strPtr("user"))
 		require.NoError(t, err)
 
 		// ACT
@@ -926,7 +926,7 @@ func TestAuthService_GetRoleByName(t *testing.T) {
 	t.Run("returns role when found", func(t *testing.T) {
 		// ARRANGE
 		name := fmt.Sprintf("find-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, name, "description")
+		role, err := service.CreateRole(ctx, name, "description", strPtr("user"))
 		require.NoError(t, err)
 
 		// ACT
@@ -958,7 +958,7 @@ func TestAuthService_UpdateRole(t *testing.T) {
 	t.Run("updates role successfully", func(t *testing.T) {
 		// ARRANGE
 		name := fmt.Sprintf("update-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, name, "original description")
+		role, err := service.CreateRole(ctx, name, "original description", strPtr("user"))
 		require.NoError(t, err)
 
 		role.Description = "updated description"
@@ -986,7 +986,7 @@ func TestAuthService_DeleteRole(t *testing.T) {
 	t.Run("deletes role successfully", func(t *testing.T) {
 		// ARRANGE
 		name := fmt.Sprintf("delete-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, name, "to delete")
+		role, err := service.CreateRole(ctx, name, "to delete", strPtr("user"))
 		require.NoError(t, err)
 
 		// ACT
@@ -1011,7 +1011,7 @@ func TestAuthService_ListRoles(t *testing.T) {
 	t.Run("returns roles", func(t *testing.T) {
 		// ARRANGE
 		name := fmt.Sprintf("list-role-%d", time.Now().UnixNano())
-		_, err := service.CreateRole(ctx, name, "for listing")
+		_, err := service.CreateRole(ctx, name, "for listing", strPtr("user"))
 		require.NoError(t, err)
 
 		// ACT
@@ -1038,7 +1038,7 @@ func TestAuthService_AssignRoleToAccount(t *testing.T) {
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 
 		roleName := fmt.Sprintf("assign-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, roleName, "for assignment")
+		role, err := service.CreateRole(ctx, roleName, "for assignment", strPtr("user"))
 		require.NoError(t, err)
 
 		// ACT
@@ -1069,7 +1069,7 @@ func TestAuthService_AssignRoleToAccount(t *testing.T) {
 		t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "auth.tokens", token.ID) })
 
 		roleName := fmt.Sprintf("assign-role-tx-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, roleName, "transaction rollback verification")
+		role, err := service.CreateRole(ctx, roleName, "transaction rollback verification", strPtr("user"))
 		require.NoError(t, err)
 		t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "auth.roles", role.ID) })
 
@@ -1105,7 +1105,7 @@ func TestAuthService_AssignRoleToAccount(t *testing.T) {
 		require.NoError(t, err)
 
 		roleName := fmt.Sprintf("assign-role-refresh-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, roleName, "refresh propagation verification")
+		role, err := service.CreateRole(ctx, roleName, "refresh propagation verification", strPtr("user"))
 		require.NoError(t, err)
 		t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "auth.roles", role.ID) })
 
@@ -1136,7 +1136,7 @@ func TestAuthService_RemoveRoleFromAccount(t *testing.T) {
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 
 		roleName := fmt.Sprintf("remove-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, roleName, "for removal")
+		role, err := service.CreateRole(ctx, roleName, "for removal", strPtr("user"))
 		require.NoError(t, err)
 
 		err = service.AssignRoleToAccount(ctx, int(account.ID), int(role.ID))
@@ -1164,7 +1164,7 @@ func TestAuthService_RemoveRoleFromAccount(t *testing.T) {
 		testpkg.EnsureAccountTenant(t, db, account.ID, 1)
 
 		roleName := fmt.Sprintf("remove-role-refresh-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, roleName, "refresh propagation verification")
+		role, err := service.CreateRole(ctx, roleName, "refresh propagation verification", strPtr("user"))
 		require.NoError(t, err)
 		t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "auth.roles", role.ID) })
 
@@ -1592,7 +1592,7 @@ func TestAuthService_AssignPermissionToRole(t *testing.T) {
 		// ARRANGE
 		uniqueID := fmt.Sprintf("%d", time.Now().UnixNano())
 		roleName := fmt.Sprintf("role-%s", uniqueID)
-		role, err := service.CreateRole(ctx, roleName, "Test role")
+		role, err := service.CreateRole(ctx, roleName, "Test role", strPtr("user"))
 		require.NoError(t, err)
 
 		permName := fmt.Sprintf("roleperm-%s", uniqueID)
@@ -1619,7 +1619,7 @@ func TestAuthService_RemovePermissionFromRole(t *testing.T) {
 		// ARRANGE
 		uniqueID := fmt.Sprintf("%d", time.Now().UnixNano())
 		roleName := fmt.Sprintf("role-remove-%s", uniqueID)
-		role, err := service.CreateRole(ctx, roleName, "Test role")
+		role, err := service.CreateRole(ctx, roleName, "Test role", strPtr("user"))
 		require.NoError(t, err)
 
 		permName := fmt.Sprintf("rolerem-%s", uniqueID)
@@ -1649,7 +1649,7 @@ func TestAuthService_GetRolePermissions(t *testing.T) {
 		// ARRANGE
 		uniqueID := fmt.Sprintf("%d", time.Now().UnixNano())
 		roleName := fmt.Sprintf("role-get-%s", uniqueID)
-		role, err := service.CreateRole(ctx, roleName, "Test role")
+		role, err := service.CreateRole(ctx, roleName, "Test role", strPtr("user"))
 		require.NoError(t, err)
 
 		permName := fmt.Sprintf("roleget-%s", uniqueID)

--- a/backend/services/auth/interface.go
+++ b/backend/services/auth/interface.go
@@ -26,7 +26,7 @@ type AuthService interface {
 	GetAccountByEmail(ctx context.Context, email string) (*auth.Account, error)
 
 	// Role Management
-	CreateRole(ctx context.Context, name, description string) (*auth.Role, error)
+	CreateRole(ctx context.Context, name, description string, baseRole *string) (*auth.Role, error)
 	GetRoleByID(ctx context.Context, id int) (*auth.Role, error)
 	GetRoleByName(ctx context.Context, name string) (*auth.Role, error)
 	UpdateRole(ctx context.Context, role *auth.Role) error

--- a/backend/services/auth/refactored_modules_test.go
+++ b/backend/services/auth/refactored_modules_test.go
@@ -40,7 +40,7 @@ func TestAuthService_DeleteRole_Extended(t *testing.T) {
 	t.Run("deletes role with all associations successfully", func(t *testing.T) {
 		// ARRANGE - create role with permission assignment
 		roleName := fmt.Sprintf("delete-full-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, roleName, "Role to delete with associations")
+		role, err := service.CreateRole(ctx, roleName, "Role to delete with associations", strPtr("user"))
 		require.NoError(t, err)
 
 		// Create permission and assign to role
@@ -178,7 +178,7 @@ func TestAuthService_AssignRoleToAccount_Extended(t *testing.T) {
 	t.Run("returns error for non-existent account", func(t *testing.T) {
 		// ARRANGE
 		roleName := fmt.Sprintf("assign-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, roleName, "Test role")
+		role, err := service.CreateRole(ctx, roleName, "Test role", strPtr("user"))
 		require.NoError(t, err)
 
 		// ACT
@@ -214,7 +214,7 @@ func TestAuthService_AssignRoleToAccount_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		roleName := fmt.Sprintf("idempotent-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, roleName, "Test role")
+		role, err := service.CreateRole(ctx, roleName, "Test role", strPtr("user"))
 		require.NoError(t, err)
 
 		// First assignment
@@ -257,7 +257,7 @@ func TestAuthService_RemoveRoleFromAccount_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		roleName := fmt.Sprintf("remove-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, roleName, "Test role")
+		role, err := service.CreateRole(ctx, roleName, "Test role", strPtr("user"))
 		require.NoError(t, err)
 
 		err = service.AssignRoleToAccount(ctx, int(account.ID), int(role.ID))
@@ -330,7 +330,7 @@ func TestAuthService_DeletePermission_Extended(t *testing.T) {
 
 		// Create role and assign permission
 		roleName := fmt.Sprintf("perm-role-%s", uniqueID)
-		role, err := service.CreateRole(ctx, roleName, "Test role")
+		role, err := service.CreateRole(ctx, roleName, "Test role", strPtr("user"))
 		require.NoError(t, err)
 
 		err = service.AssignPermissionToRole(ctx, int(role.ID), int(perm.ID))
@@ -460,7 +460,7 @@ func TestAuthService_AssignPermissionToRole_Extended(t *testing.T) {
 	t.Run("returns error for non-existent permission", func(t *testing.T) {
 		// ARRANGE
 		roleName := fmt.Sprintf("assign-perm-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, roleName, "Test role")
+		role, err := service.CreateRole(ctx, roleName, "Test role", strPtr("user"))
 		require.NoError(t, err)
 
 		// ACT
@@ -482,7 +482,7 @@ func TestAuthService_RemovePermissionFromRole_Extended(t *testing.T) {
 		// ARRANGE
 		uniqueID := fmt.Sprintf("%d", time.Now().UnixNano())
 		roleName := fmt.Sprintf("remove-perm-role-%s", uniqueID)
-		role, err := service.CreateRole(ctx, roleName, "Test role")
+		role, err := service.CreateRole(ctx, roleName, "Test role", strPtr("user"))
 		require.NoError(t, err)
 
 		permName := fmt.Sprintf("remove-from-role-%s", uniqueID)
@@ -518,7 +518,7 @@ func TestAuthService_GetRolePermissions_Extended(t *testing.T) {
 	t.Run("returns empty list for role with no permissions", func(t *testing.T) {
 		// ARRANGE
 		roleName := fmt.Sprintf("empty-perm-role-%d", time.Now().UnixNano())
-		role, err := service.CreateRole(ctx, roleName, "Test role")
+		role, err := service.CreateRole(ctx, roleName, "Test role", strPtr("user"))
 		require.NoError(t, err)
 
 		// ACT
@@ -533,7 +533,7 @@ func TestAuthService_GetRolePermissions_Extended(t *testing.T) {
 		// ARRANGE
 		uniqueID := fmt.Sprintf("%d", time.Now().UnixNano())
 		roleName := fmt.Sprintf("has-perm-role-%s", uniqueID)
-		role, err := service.CreateRole(ctx, roleName, "Test role")
+		role, err := service.CreateRole(ctx, roleName, "Test role", strPtr("user"))
 		require.NoError(t, err)
 
 		permName := fmt.Sprintf("role-perm-%s", uniqueID)
@@ -751,7 +751,7 @@ func TestAuthService_GetAccountsByRole_Extended(t *testing.T) {
 		// ARRANGE
 		uniqueID := fmt.Sprintf("%d", time.Now().UnixNano())
 		roleName := fmt.Sprintf("specific-role-%s", uniqueID)
-		role, err := service.CreateRole(ctx, roleName, "Specific role for testing")
+		role, err := service.CreateRole(ctx, roleName, "Specific role for testing", strPtr("user"))
 		require.NoError(t, err)
 
 		email := fmt.Sprintf("role-specific-%s@test.local", uniqueID)

--- a/backend/services/auth/role_management.go
+++ b/backend/services/auth/role_management.go
@@ -14,6 +14,10 @@ import (
 // CreateRole creates a new tenant-scoped role.
 // baseRole is required — it maps this custom role to a system role for announcement targeting.
 func (s *Service) CreateRole(ctx context.Context, name, description string, baseRole *string) (*auth.Role, error) {
+	if baseRole == nil || *baseRole == "" {
+		return nil, &AuthError{Op: "create role", Err: errors.New("base_role is required for custom roles")}
+	}
+
 	role := &auth.Role{
 		Name:        name,
 		Description: description,

--- a/backend/services/auth/role_management.go
+++ b/backend/services/auth/role_management.go
@@ -11,11 +11,13 @@ import (
 
 // Role Management
 
-// CreateRole creates a new tenant-scoped role
-func (s *Service) CreateRole(ctx context.Context, name, description string) (*auth.Role, error) {
+// CreateRole creates a new tenant-scoped role.
+// baseRole is required — it maps this custom role to a system role for announcement targeting.
+func (s *Service) CreateRole(ctx context.Context, name, description string, baseRole *string) (*auth.Role, error) {
 	role := &auth.Role{
 		Name:        name,
 		Description: description,
+		BaseRole:    baseRole,
 	}
 
 	// tenant_id is auto-set by base.Repository.Create via TenantScoped interface

--- a/backend/services/platform/announcement_service.go
+++ b/backend/services/platform/announcement_service.go
@@ -263,7 +263,9 @@ func (s *announcementService) UnpublishAnnouncement(ctx context.Context, id int6
 	return nil
 }
 
-// GetUnreadForUser retrieves unread announcements for a user scoped to the current session tenant/org
+// GetUnreadForUser retrieves unread announcements for a user scoped to the current session tenant/org.
+// Base-role expansion (custom role → system role matching) is handled at the SQL level
+// via an EXISTS subquery in the repository, consistent with the GetStats query strategy.
 func (s *announcementService) GetUnreadForUser(ctx context.Context, userID int64, userRoles []string, tenantID int64, orgID int64) ([]*platform.Announcement, error) {
 	return s.announcementViewRepo.GetUnreadForUser(ctx, userID, userRoles, tenantID, orgID)
 }

--- a/backend/services/platform/operator_provisioning_service_test.go
+++ b/backend/services/platform/operator_provisioning_service_test.go
@@ -337,7 +337,7 @@ func (m *mockAuthService) GetAccountByID(context.Context, int) (*authModels.Acco
 func (m *mockAuthService) GetAccountByEmail(context.Context, string) (*authModels.Account, error) {
 	return nil, nil
 }
-func (m *mockAuthService) CreateRole(context.Context, string, string) (*authModels.Role, error) {
+func (m *mockAuthService) CreateRole(context.Context, string, string, *string) (*authModels.Role, error) {
 	return nil, nil
 }
 func (m *mockAuthService) GetRoleByID(context.Context, int) (*authModels.Role, error) {

--- a/frontend/src/app/[tenant]/(protected)/database/roles/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/roles/page.tsx
@@ -31,6 +31,18 @@ import { useToast } from "~/contexts/ToastContext";
 import { useIsMobile } from "~/hooks/useIsMobile";
 import { useDeleteConfirmation } from "~/hooks/useDeleteConfirmation";
 
+function WarningIcon({ className }: { readonly className?: string }) {
+  return (
+    <svg className={className} fill="currentColor" viewBox="0 0 20 20">
+      <path
+        fillRule="evenodd"
+        d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
 export default function RolesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -105,6 +117,11 @@ export default function RolesPage() {
           ]
         : [],
     [searchTerm],
+  );
+
+  const unclassifiedCount = useMemo(
+    () => roles.filter((r) => !r.isSystem && !r.baseRole).length,
+    [roles],
   );
 
   const filteredRoles = useMemo(() => {
@@ -306,6 +323,26 @@ export default function RolesPage() {
         </div>
       )}
 
+      {unclassifiedCount > 0 && (
+        <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-4">
+          <div className="flex items-start gap-3">
+            <WarningIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600" />
+            <div>
+              <p className="text-sm font-medium text-amber-800">
+                {unclassifiedCount === 1
+                  ? "1 Rolle hat keine Systemrollen-Zuordnung"
+                  : `${unclassifiedCount} Rollen haben keine Systemrollen-Zuordnung`}
+              </p>
+              <p className="mt-1 text-sm text-amber-700">
+                Ankündigungen werden möglicherweise nicht korrekt zugestellt.
+                Bitte bearbeiten Sie die betroffenen Rollen und wählen Sie eine
+                Systemrolle aus.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
       {filteredRoles.length === 0 ? (
         <div className="flex min-h-[300px] items-center justify-center">
           <div className="text-center">
@@ -376,6 +413,12 @@ export default function RolesPage() {
                       {role.isSystem && (
                         <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">
                           System
+                        </span>
+                      )}
+                      {!role.isSystem && !role.baseRole && (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-700">
+                          <WarningIcon className="h-3 w-3" />
+                          Zuordnung fehlt
                         </span>
                       )}
                       {typeof role.permissions?.length === "number" && (

--- a/frontend/src/components/roles/role-detail-modal.tsx
+++ b/frontend/src/components/roles/role-detail-modal.tsx
@@ -6,6 +6,7 @@ import type { Role } from "@/lib/auth-helpers";
 import {
   getRoleDisplayName,
   getRoleDisplayDescription,
+  getBaseRoleLabel,
 } from "@/lib/auth-helpers";
 
 interface Props {
@@ -100,6 +101,12 @@ export function RoleDetailModal({
                     <dt className="text-xs text-gray-500">Berechtigungen</dt>
                     <dd className="mt-0.5 text-sm font-medium break-words text-gray-900">
                       {role.permissions?.length ?? 0}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Systemrolle</dt>
+                    <dd className="mt-0.5 text-sm font-medium break-words text-gray-900">
+                      {getBaseRoleLabel(role.baseRole)}
                     </dd>
                   </div>
                   <div className="sm:col-span-2">

--- a/frontend/src/lib/auth-helpers.ts
+++ b/frontend/src/lib/auth-helpers.ts
@@ -18,6 +18,7 @@ export interface BackendRole {
   Name: string;
   Description: string;
   IsSystem: boolean;
+  BaseRole?: string;
   CreatedAt: string;
   UpdatedAt: string;
   Permissions?: BackendPermission[];
@@ -64,11 +65,25 @@ export interface Account {
   updatedAt: string;
 }
 
+/** German display labels for system base roles used in announcement targeting. */
+export const BASE_ROLE_LABELS: Record<string, string> = {
+  admin: "Administrator",
+  user: "Betreuer",
+  guardian: "Erziehungsberechtigte",
+};
+
+/** Returns the German display label for a base role, or a fallback for unmapped/missing values. */
+export function getBaseRoleLabel(baseRole?: string): string {
+  if (!baseRole) return "Keine Zuordnung";
+  return BASE_ROLE_LABELS[baseRole] ?? baseRole;
+}
+
 export interface Role {
   id: string;
   name: string;
   description: string;
   isSystem: boolean;
+  baseRole?: string;
   createdAt: string;
   updatedAt: string;
   permissions?: Permission[];
@@ -127,6 +142,8 @@ interface FlexibleRoleData {
   description?: string;
   IsSystem?: boolean;
   is_system?: boolean;
+  BaseRole?: string;
+  base_role?: string;
   CreatedAt?: string;
   created_at?: string;
   UpdatedAt?: string;
@@ -145,6 +162,7 @@ export function mapRoleResponse(
     name: roleData.Name ?? roleData.name ?? "",
     description: roleData.Description ?? roleData.description ?? "",
     isSystem: roleData.IsSystem ?? roleData.is_system ?? false,
+    baseRole: roleData.BaseRole ?? roleData.base_role,
     createdAt: roleData.CreatedAt ?? roleData.created_at ?? "",
     updatedAt: roleData.UpdatedAt ?? roleData.updated_at ?? "",
     permissions:

--- a/frontend/src/lib/database/configs/roles.config.test.tsx
+++ b/frontend/src/lib/database/configs/roles.config.test.tsx
@@ -11,6 +11,12 @@ vi.mock("@/lib/auth-helpers", () => ({
   mapRoleResponse: vi.fn((data: unknown) => data),
   getRoleDisplayName: vi.fn((name: string) => name),
   getRoleDisplayDescription: vi.fn((_name: string, desc: string) => desc),
+  getBaseRoleLabel: vi.fn((role?: string) => role ?? "Keine Zuordnung"),
+  BASE_ROLE_LABELS: {
+    admin: "Administrator",
+    user: "Betreuer",
+    guardian: "Erziehungsberechtigte",
+  },
 }));
 
 describe("rolesConfig", () => {
@@ -37,6 +43,7 @@ describe("rolesConfig", () => {
 
     expect(fieldNames).toContain("name");
     expect(fieldNames).toContain("description");
+    expect(fieldNames).toContain("baseRole");
   });
 
   it("has detail header configuration", () => {

--- a/frontend/src/lib/database/configs/roles.config.tsx
+++ b/frontend/src/lib/database/configs/roles.config.tsx
@@ -164,7 +164,7 @@ export const rolesConfig = defineEntityConfig<Role>({
     mapRequest: (data: Partial<Role>): Record<string, unknown> => ({
       name: data.name,
       description: data.description,
-      base_role: data.baseRole,
+      ...(!data.isSystem && { base_role: data.baseRole }),
     }),
     mapResponse: (data: unknown): Role => {
       // Handle wrapped response format

--- a/frontend/src/lib/database/configs/roles.config.tsx
+++ b/frontend/src/lib/database/configs/roles.config.tsx
@@ -9,6 +9,8 @@ import {
   mapRoleResponse,
   getRoleDisplayName,
   getRoleDisplayDescription,
+  getBaseRoleLabel,
+  BASE_ROLE_LABELS,
 } from "@/lib/auth-helpers";
 
 export const rolesConfig = defineEntityConfig<Role>({
@@ -48,6 +50,19 @@ export const rolesConfig = defineEntityConfig<Role>({
             required: false,
             placeholder:
               "Beschreiben Sie die Aufgaben und Verantwortlichkeiten dieser Rolle",
+          },
+          {
+            name: "baseRole",
+            label: "Systemrolle",
+            type: "select",
+            required: true,
+            placeholder: "Systemrolle auswählen",
+            helperText:
+              "Ordnet diese Rolle einer Systemrolle zu, damit Ankündigungen korrekt zugestellt werden",
+            options: Object.entries(BASE_ROLE_LABELS).map(([value, label]) => ({
+              value,
+              label,
+            })),
           },
         ],
       },
@@ -90,6 +105,10 @@ export const rolesConfig = defineEntityConfig<Role>({
             value: (role: Role) =>
               getRoleDisplayDescription(role.name, role.description) ||
               "Keine Beschreibung",
+          },
+          {
+            label: "Systemrolle",
+            value: (role: Role) => getBaseRoleLabel(role.baseRole),
           },
           {
             label: "Berechtigungen",
@@ -142,6 +161,11 @@ export const rolesConfig = defineEntityConfig<Role>({
   },
 
   service: {
+    mapRequest: (data: Partial<Role>): Record<string, unknown> => ({
+      name: data.name,
+      description: data.description,
+      base_role: data.baseRole,
+    }),
     mapResponse: (data: unknown): Role => {
       // Handle wrapped response format
       let actualData = data;


### PR DESCRIPTION
## Summary

- Adds a `base_role` column to `auth.roles` so every custom tenant role **must be** mapped to a system role (`admin`, `user`, `guardian`) for announcement delivery
- Updates the announcement unread query and stats query to match users via `base_role` when their JWT role name doesn't directly match `target_roles`
- Exposes `base_role` in the role CRUD API — required on create, optional on update (preserves existing value when omitted), system roles are guarded from receiving a `base_role`
- Frontend: role create/edit form includes a required "Systemrolle" select field; role list and detail modal display the mapped base role

## Warning for existing custom roles

Pre-existing custom roles (created before this migration) will have `base_role = NULL`. The roles page shows a prominent amber warning banner:

> **"{n} Rollen haben keine Systemrollen-Zuordnung"**
> Ankündigungen werden möglicherweise nicht korrekt zugestellt. Bitte bearbeiten Sie die betroffenen Rollen und wählen Sie eine Systemrolle aus.

Individual unclassified roles are tagged with an amber **"Zuordnung fehlt"** badge in the role list.

## Migration

`001015031_roles_base_role` — adds `base_role VARCHAR` column with a `CHECK` constraint (`admin`, `user`, `guardian`) and a partial index on non-null values. Existing rows are left `NULL` intentionally (requires manual classification per tenant).

## Test plan

- [ ] Run migration on fresh and existing databases
- [ ] Verify announcement delivery reaches users with custom roles mapped via `base_role`
- [ ] Verify the warning banner appears when unclassified custom roles exist and disappears once all are mapped
- [ ] Verify system roles cannot be assigned a `base_role` via API
- [ ] Run `go test ./...` — hermetic test suite passes