### PR TITLE
feat: protect system rooms and activities from deletion/renaming

### DIFF
--- a/backend/api/activities/errors.go
+++ b/backend/api/activities/errors.go
@@ -50,6 +50,8 @@ func ErrorRenderer(err error) render.Renderer {
 			return ErrorConflictWithCode(actErr, errorCodeOnlySupervisorReplacementRequired)
 		case errors.Is(actErr, activities.ErrNotEnrolled):
 			return ErrorNotFound(actErr)
+		case errors.Is(actErr, activities.ErrSystemActivityProtected):
+			return ErrorForbidden(actErr)
 		case errors.Is(actErr, activities.ErrGroupClosed):
 			return ErrorForbidden(actErr)
 		case errors.Is(actErr, activities.ErrInvalidAttendanceStatus):

--- a/backend/api/activities/errors_test.go
+++ b/backend/api/activities/errors_test.go
@@ -63,12 +63,24 @@ func TestErrorRenderer_ConflictErrors(t *testing.T) {
 }
 
 func TestErrorRenderer_ForbiddenErrors(t *testing.T) {
-	actErr := &activities.ActivityError{Err: activities.ErrGroupClosed}
-	renderer := activitiesAPI.ErrorRenderer(actErr)
-	resp, ok := renderer.(*activitiesAPI.ErrorResponse)
-	assert.True(t, ok)
-	assert.Equal(t, http.StatusForbidden, resp.HTTPStatusCode)
-	assert.Equal(t, "error", resp.Status)
+	tests := []struct {
+		name    string
+		baseErr error
+	}{
+		{"ErrGroupClosed", activities.ErrGroupClosed},
+		{"ErrSystemActivityProtected", activities.ErrSystemActivityProtected},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actErr := &activities.ActivityError{Err: tt.baseErr}
+			renderer := activitiesAPI.ErrorRenderer(actErr)
+			resp, ok := renderer.(*activitiesAPI.ErrorResponse)
+			assert.True(t, ok)
+			assert.Equal(t, http.StatusForbidden, resp.HTTPStatusCode)
+			assert.Equal(t, "error", resp.Status)
+		})
+	}
 }
 
 func TestErrorRenderer_BadRequestErrors(t *testing.T) {

--- a/backend/api/rooms/errors.go
+++ b/backend/api/rooms/errors.go
@@ -24,6 +24,8 @@ func ErrorRenderer(err error) render.Renderer {
 			return common.ErrorNotFound(facErr)
 		case facilities.ErrRoomInUse:
 			return common.ErrorConflict(facErr)
+		case facilities.ErrSystemRoomProtected:
+			return common.ErrorForbidden(facErr)
 		case facilities.ErrDuplicateRoom:
 			return common.ErrorConflict(facErr)
 		default:

--- a/backend/api/rooms/errors_test.go
+++ b/backend/api/rooms/errors_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/api/rooms"
+	"github.com/moto-nrw/project-phoenix/services/facilities"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,4 +35,16 @@ func TestErrorInvalidRequest(t *testing.T) {
 	})
 	assert.True(t, ok)
 	assert.NotNil(t, resp)
+}
+
+func TestErrorRenderer_SystemRoomProtected(t *testing.T) {
+	facErr := &facilities.FacilitiesError{
+		Op:  "delete room",
+		Err: facilities.ErrSystemRoomProtected,
+	}
+	renderer := rooms.ErrorRenderer(facErr)
+	resp, ok := renderer.(*common.ErrResponse)
+	assert.True(t, ok, "expected *common.ErrResponse")
+	assert.Equal(t, http.StatusForbidden, resp.HTTPStatusCode)
+	assert.Contains(t, resp.ErrorText, "Systemraum")
 }

--- a/backend/constants/activities.go
+++ b/backend/constants/activities.go
@@ -52,3 +52,15 @@ const (
 	// WCMaxParticipants is the default max participants for the WC activity.
 	WCMaxParticipants = 20
 )
+
+// IsSystemRoomName returns true if the given room name is a system room
+// that must not be deleted or renamed.
+func IsSystemRoomName(name string) bool {
+	return name == SchulhofRoomName || name == WCRoomName
+}
+
+// IsSystemActivityName returns true if the given activity name is a system activity
+// that must not be deleted or renamed.
+func IsSystemActivityName(name string) bool {
+	return name == SchulhofActivityName || name == WCActivityName
+}

--- a/backend/constants/activities_test.go
+++ b/backend/constants/activities_test.go
@@ -1,0 +1,49 @@
+package constants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSystemRoomName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"Schulhof is system room", SchulhofRoomName, true},
+		{"WC is system room", WCRoomName, true},
+		{"regular room is not system", "Gruppenraum 1", false},
+		{"empty string is not system", "", false},
+		{"case sensitive - lowercase schulhof", "schulhof", false},
+		{"case sensitive - lowercase wc", "wc", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsSystemRoomName(tt.input))
+		})
+	}
+}
+
+func TestIsSystemActivityName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"Schulhof Freispiel is system activity", SchulhofActivityName, true},
+		{"WC is system activity", WCActivityName, true},
+		{"regular activity is not system", "Basteln", false},
+		{"empty string is not system", "", false},
+		{"partial match is not system", "Schulhof", false},
+		{"case sensitive - lowercase", "schulhof freispiel", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsSystemActivityName(tt.input))
+		})
+	}
+}

--- a/backend/services/activities/activity_service.go
+++ b/backend/services/activities/activity_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/moto-nrw/project-phoenix/constants"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -255,6 +256,15 @@ func (s *Service) UpdateGroup(ctx context.Context, group *activities.Group, requ
 		return nil, &ActivityError{Op: "validate group", Err: err}
 	}
 
+	// Block renaming system activities (Schulhof Freispiel, WC)
+	existingGroup, err := s.groupRepo.FindByID(ctx, group.ID)
+	if err != nil {
+		return nil, &ActivityError{Op: "update group", Err: ErrGroupNotFound}
+	}
+	if constants.IsSystemActivityName(existingGroup.Name) && group.Name != existingGroup.Name {
+		return nil, &ActivityError{Op: "update group", Err: ErrSystemActivityProtected}
+	}
+
 	// Check if user can modify this activity
 	canModify, err := s.CanModifyActivity(ctx, group.ID, requestingStaffID, hasManagePermission)
 	if err != nil {
@@ -274,6 +284,15 @@ func (s *Service) UpdateGroup(ctx context.Context, group *activities.Group, requ
 // DeleteGroup deletes an activity group and all related records with ownership verification
 // Only the creator, supervisors, or users with manage permission can delete
 func (s *Service) DeleteGroup(ctx context.Context, id int64, requestingStaffID int64, hasManagePermission bool) error {
+	// Block deletion of system activities (Schulhof Freispiel, WC)
+	existingGroup, err := s.groupRepo.FindByID(ctx, id)
+	if err != nil {
+		return &ActivityError{Op: "delete group", Err: ErrGroupNotFound}
+	}
+	if constants.IsSystemActivityName(existingGroup.Name) {
+		return &ActivityError{Op: "delete group", Err: ErrSystemActivityProtected}
+	}
+
 	// Check if user can modify this activity before starting transaction
 	canModify, err := s.CanModifyActivity(ctx, id, requestingStaffID, hasManagePermission)
 	if err != nil {

--- a/backend/services/activities/activity_service.go
+++ b/backend/services/activities/activity_service.go
@@ -284,12 +284,11 @@ func (s *Service) UpdateGroup(ctx context.Context, group *activities.Group, requ
 // DeleteGroup deletes an activity group and all related records with ownership verification
 // Only the creator, supervisors, or users with manage permission can delete
 func (s *Service) DeleteGroup(ctx context.Context, id int64, requestingStaffID int64, hasManagePermission bool) error {
-	// Block deletion of system activities (Schulhof Freispiel, WC)
+	// Block deletion of system activities (Schulhof Freispiel, WC).
+	// Only block if the group exists and is a system activity — if it doesn't exist,
+	// fall through to CanModifyActivity which handles admin idempotent deletes.
 	existingGroup, err := s.groupRepo.FindByID(ctx, id)
-	if err != nil {
-		return &ActivityError{Op: "delete group", Err: ErrGroupNotFound}
-	}
-	if constants.IsSystemActivityName(existingGroup.Name) {
+	if err == nil && constants.IsSystemActivityName(existingGroup.Name) {
 		return &ActivityError{Op: "delete group", Err: ErrSystemActivityProtected}
 	}
 

--- a/backend/services/activities/activity_service.go
+++ b/backend/services/activities/activity_service.go
@@ -256,15 +256,6 @@ func (s *Service) UpdateGroup(ctx context.Context, group *activities.Group, requ
 		return nil, &ActivityError{Op: "validate group", Err: err}
 	}
 
-	// Block renaming system activities (Schulhof Freispiel, WC)
-	existingGroup, err := s.groupRepo.FindByID(ctx, group.ID)
-	if err != nil {
-		return nil, &ActivityError{Op: "update group", Err: ErrGroupNotFound}
-	}
-	if constants.IsSystemActivityName(existingGroup.Name) && group.Name != existingGroup.Name {
-		return nil, &ActivityError{Op: "update group", Err: ErrSystemActivityProtected}
-	}
-
 	// Check if user can modify this activity
 	canModify, err := s.CanModifyActivity(ctx, group.ID, requestingStaffID, hasManagePermission)
 	if err != nil {
@@ -272,6 +263,17 @@ func (s *Service) UpdateGroup(ctx context.Context, group *activities.Group, requ
 	}
 	if !canModify {
 		return nil, &ActivityError{Op: "update group", Err: ErrNotOwner}
+	}
+
+	// Block renaming system activities (Schulhof Freispiel, WC).
+	// Placed after CanModifyActivity to avoid an extra FindByID call — CanModifyActivity
+	// already fetches the group internally for non-admin users.
+	existingGroup, err := s.groupRepo.FindByID(ctx, group.ID)
+	if err != nil {
+		return nil, &ActivityError{Op: "update group", Err: ErrGroupNotFound}
+	}
+	if constants.IsSystemActivityName(existingGroup.Name) && group.Name != existingGroup.Name {
+		return nil, &ActivityError{Op: "update group", Err: ErrSystemActivityProtected}
 	}
 
 	if err := s.groupRepo.Update(ctx, group); err != nil {

--- a/backend/services/activities/activity_service_test.go
+++ b/backend/services/activities/activity_service_test.go
@@ -337,6 +337,37 @@ func TestActivityService_UpdateGroup(t *testing.T) {
 		assert.NotNil(t, result)
 		assert.Equal(t, "Updated Group Name", result.Name)
 	})
+
+	t.Run("blocks renaming system activity Schulhof Freispiel", func(t *testing.T) {
+		// ARRANGE
+		group := testpkg.CreateTestActivityGroup(t, db, "Schulhof Freispiel")
+		defer testpkg.CleanupActivityFixtures(t, db, group.ID)
+
+		group.Name = "Renamed Activity"
+
+		// ACT
+		_, err := service.UpdateGroup(ctx, group, *group.CreatedBy, true)
+
+		// ASSERT
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Systemaktivität")
+	})
+
+	t.Run("allows updating other properties of system activity", func(t *testing.T) {
+		// ARRANGE
+		group := testpkg.CreateTestActivityGroup(t, db, "WC")
+		defer testpkg.CleanupActivityFixtures(t, db, group.ID)
+
+		group.MaxParticipants = 30
+
+		// ACT
+		result, err := service.UpdateGroup(ctx, group, *group.CreatedBy, true)
+
+		// ASSERT
+		require.NoError(t, err)
+		assert.Equal(t, 30, result.MaxParticipants)
+		assert.Equal(t, "WC", result.Name)
+	})
 }
 
 func TestActivityService_DeleteGroup(t *testing.T) {
@@ -360,6 +391,32 @@ func TestActivityService_DeleteGroup(t *testing.T) {
 		result, err := service.GetGroup(ctx, group.ID)
 		require.Error(t, err)
 		assert.Nil(t, result)
+	})
+
+	t.Run("blocks deletion of system activity Schulhof Freispiel", func(t *testing.T) {
+		// ARRANGE
+		group := testpkg.CreateTestActivityGroup(t, db, "Schulhof Freispiel")
+		defer testpkg.CleanupActivityFixtures(t, db, group.ID)
+
+		// ACT
+		err := service.DeleteGroup(ctx, group.ID, *group.CreatedBy, true)
+
+		// ASSERT
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Systemaktivität")
+	})
+
+	t.Run("blocks deletion of system activity WC", func(t *testing.T) {
+		// ARRANGE
+		group := testpkg.CreateTestActivityGroup(t, db, "WC")
+		defer testpkg.CleanupActivityFixtures(t, db, group.ID)
+
+		// ACT
+		err := service.DeleteGroup(ctx, group.ID, *group.CreatedBy, true)
+
+		// ASSERT
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Systemaktivität")
 	})
 }
 

--- a/backend/services/activities/activity_service_test.go
+++ b/backend/services/activities/activity_service_test.go
@@ -339,9 +339,8 @@ func TestActivityService_UpdateGroup(t *testing.T) {
 	})
 
 	t.Run("blocks renaming system activity Schulhof Freispiel", func(t *testing.T) {
-		// ARRANGE
+		// ARRANGE — cleanup immediately after test to avoid cross-package interference
 		group := testpkg.CreateTestActivityGroup(t, db, "Schulhof Freispiel")
-		defer testpkg.CleanupActivityFixtures(t, db, group.ID)
 
 		group.Name = "Renamed Activity"
 
@@ -351,12 +350,14 @@ func TestActivityService_UpdateGroup(t *testing.T) {
 		// ASSERT
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Systemaktivität")
+
+		// Immediate cleanup — do not defer, to prevent cross-package test interference
+		testpkg.CleanupActivityFixtures(t, db, group.ID)
 	})
 
 	t.Run("allows updating other properties of system activity", func(t *testing.T) {
 		// ARRANGE
 		group := testpkg.CreateTestActivityGroup(t, db, "WC")
-		defer testpkg.CleanupActivityFixtures(t, db, group.ID)
 
 		group.MaxParticipants = 30
 
@@ -367,6 +368,9 @@ func TestActivityService_UpdateGroup(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 30, result.MaxParticipants)
 		assert.Equal(t, "WC", result.Name)
+
+		// Immediate cleanup
+		testpkg.CleanupActivityFixtures(t, db, group.ID)
 	})
 
 	t.Run("returns not found when updating non-existent group", func(t *testing.T) {
@@ -413,7 +417,6 @@ func TestActivityService_DeleteGroup(t *testing.T) {
 	t.Run("blocks deletion of system activity Schulhof Freispiel", func(t *testing.T) {
 		// ARRANGE
 		group := testpkg.CreateTestActivityGroup(t, db, "Schulhof Freispiel")
-		defer testpkg.CleanupActivityFixtures(t, db, group.ID)
 
 		// ACT
 		err := service.DeleteGroup(ctx, group.ID, *group.CreatedBy, true)
@@ -421,12 +424,14 @@ func TestActivityService_DeleteGroup(t *testing.T) {
 		// ASSERT
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Systemaktivität")
+
+		// Immediate cleanup — do not defer, to prevent cross-package test interference
+		testpkg.CleanupActivityFixtures(t, db, group.ID)
 	})
 
 	t.Run("blocks deletion of system activity WC", func(t *testing.T) {
 		// ARRANGE
 		group := testpkg.CreateTestActivityGroup(t, db, "WC")
-		defer testpkg.CleanupActivityFixtures(t, db, group.ID)
 
 		// ACT
 		err := service.DeleteGroup(ctx, group.ID, *group.CreatedBy, true)
@@ -434,6 +439,9 @@ func TestActivityService_DeleteGroup(t *testing.T) {
 		// ASSERT
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Systemaktivität")
+
+		// Immediate cleanup
+		testpkg.CleanupActivityFixtures(t, db, group.ID)
 	})
 }
 

--- a/backend/services/activities/activity_service_test.go
+++ b/backend/services/activities/activity_service_test.go
@@ -368,6 +368,23 @@ func TestActivityService_UpdateGroup(t *testing.T) {
 		assert.Equal(t, 30, result.MaxParticipants)
 		assert.Equal(t, "WC", result.Name)
 	})
+
+	t.Run("returns not found when updating non-existent group", func(t *testing.T) {
+		// ARRANGE
+		group := testpkg.CreateTestActivityGroup(t, db, "temp-for-id")
+		staffID := *group.CreatedBy
+		defer testpkg.CleanupActivityFixtures(t, db, group.ID)
+
+		nonExistentGroup := *group
+		nonExistentGroup.ID = 999999999
+
+		// ACT
+		_, err := service.UpdateGroup(ctx, &nonExistentGroup, staffID, true)
+
+		// ASSERT
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
 }
 
 func TestActivityService_DeleteGroup(t *testing.T) {

--- a/backend/services/activities/errors.go
+++ b/backend/services/activities/errors.go
@@ -54,6 +54,9 @@ var (
 	// ErrOnlySupervisorRequiresReplacement is returned when removing the last
 	// remaining supervisor would leave an activity without any supervisor.
 	ErrOnlySupervisorRequiresReplacement = errors.New("cannot remove the only supervisor from an activity without a replacement")
+
+	// ErrSystemActivityProtected is returned when trying to delete or rename a system activity (Schulhof Freispiel, WC).
+	ErrSystemActivityProtected = errors.New("Systemaktivität kann nicht gelöscht oder umbenannt werden") //nolint:staticcheck // ST1005: user-facing German message
 )
 
 // ActivityError represents an activity-related error

--- a/backend/services/activities/errors_test.go
+++ b/backend/services/activities/errors_test.go
@@ -27,6 +27,7 @@ func TestActivitiesErrorVariables(t *testing.T) {
 		{"ErrGroupClosed", ErrGroupClosed, "activity group is not open for enrollment"},
 		{"ErrCannotDeletePrimary", ErrCannotDeletePrimary, "cannot delete primary supervisor"},
 		{"ErrStaffNotFound", ErrStaffNotFound, "staff not found"},
+		{"ErrSystemActivityProtected", ErrSystemActivityProtected, "Systemaktivität kann nicht gelöscht oder umbenannt werden"},
 	}
 
 	for _, tt := range tests {
@@ -51,6 +52,7 @@ func TestActivitiesErrorsAreDistinct(t *testing.T) {
 		ErrGroupClosed,
 		ErrCannotDeletePrimary,
 		ErrStaffNotFound,
+		ErrSystemActivityProtected,
 	}
 
 	for i, err1 := range errorVars {

--- a/backend/services/facilities/errors.go
+++ b/backend/services/facilities/errors.go
@@ -15,6 +15,7 @@ var (
 	ErrBuildingNotFound     = errors.New("building not found")
 	ErrCategoryNotFound     = errors.New("category not found")
 	ErrRoomInUse            = errors.New("Raum kann nicht gelöscht werden: Raum wird aktuell von einer aktiven Gruppe verwendet") //nolint:staticcheck // ST1005: user-facing German message
+	ErrSystemRoomProtected  = errors.New("Systemraum kann nicht gelöscht oder umbenannt werden")                                  //nolint:staticcheck // ST1005: user-facing German message
 )
 
 // FacilitiesError represents a facilities-related error

--- a/backend/services/facilities/errors_test.go
+++ b/backend/services/facilities/errors_test.go
@@ -123,6 +123,12 @@ func TestFacilitiesError_AllOperations(t *testing.T) {
 			err:  ErrRoomCapacityExceeded,
 			want: "facilities error during CheckCapacity: room capacity exceeded",
 		},
+		{
+			name: "system room protection",
+			op:   "DeleteRoom",
+			err:  ErrSystemRoomProtected,
+			want: "facilities error during DeleteRoom: Systemraum kann nicht gelöscht oder umbenannt werden",
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/services/facilities/facility_service.go
+++ b/backend/services/facilities/facility_service.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/moto-nrw/project-phoenix/constants"
 	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -169,6 +170,11 @@ func (s *service) UpdateRoom(ctx context.Context, room *facilities.Room) error {
 		return &FacilitiesError{Op: opUpdateRoom, Err: ErrRoomNotFound}
 	}
 
+	// Block renaming system rooms (Schulhof, WC)
+	if constants.IsSystemRoomName(existingRoom.Name) && room.Name != existingRoom.Name {
+		return &FacilitiesError{Op: opUpdateRoom, Err: ErrSystemRoomProtected}
+	}
+
 	// If name is changing, check for duplicates
 	if existingRoom.Name != room.Name {
 		existing, err := s.roomRepo.FindByName(ctx, room.Name)
@@ -188,9 +194,14 @@ func (s *service) UpdateRoom(ctx context.Context, room *facilities.Room) error {
 // DeleteRoom deletes a room by its ID
 func (s *service) DeleteRoom(ctx context.Context, id int64) error {
 	// Check if room exists
-	_, err := s.roomRepo.FindByID(ctx, id)
+	existingRoom, err := s.roomRepo.FindByID(ctx, id)
 	if err != nil {
 		return &FacilitiesError{Op: "delete room", Err: ErrRoomNotFound}
+	}
+
+	// Block deletion of system rooms (Schulhof, WC)
+	if constants.IsSystemRoomName(existingRoom.Name) {
+		return &FacilitiesError{Op: "delete room", Err: ErrSystemRoomProtected}
 	}
 
 	// Best-effort pre-check: active groups would block deletion via FK RESTRICT.

--- a/backend/services/facilities/facility_service_test.go
+++ b/backend/services/facilities/facility_service_test.go
@@ -17,9 +17,17 @@ import (
 
 // createRoomWithExactName creates a room with the exact given name (no timestamp suffix).
 // Use this for system room tests where the name must match constants exactly.
+// Cleans up any pre-existing room with the same name first to avoid unique constraint violations.
 func createRoomWithExactName(t *testing.T, db *bun.DB, name string) *facilities.Room {
 	t.Helper()
 	ctx := testpkg.TenantContext(1)
+
+	// Clean up any pre-existing room with this exact name (from crashed tests or seed data)
+	_, _ = db.NewDelete().
+		TableExpr("facilities.rooms").
+		Where("name = ? AND tenant_id = 1", name).
+		Exec(ctx)
+
 	room := &facilities.Room{
 		Name:     name,
 		Building: "Test Building",

--- a/backend/services/facilities/facility_service_test.go
+++ b/backend/services/facilities/facility_service_test.go
@@ -15,6 +15,34 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// createRoomWithExactName creates a room with the exact given name (no timestamp suffix).
+// Use this for system room tests where the name must match constants exactly.
+func createRoomWithExactName(t *testing.T, db *bun.DB, name string) *facilities.Room {
+	t.Helper()
+	ctx := testpkg.TenantContext(1)
+	room := &facilities.Room{
+		Name:     name,
+		Building: "Test Building",
+	}
+	room.SetTenantID(1)
+	err := db.NewInsert().
+		Model(room).
+		ModelTableExpr(`facilities.rooms`).
+		Scan(ctx)
+	require.NoError(t, err, "Failed to create room with exact name %q", name)
+	return room
+}
+
+// cleanupRoom removes a room by ID.
+func cleanupRoom(t *testing.T, db *bun.DB, roomID int64) {
+	t.Helper()
+	ctx := testpkg.TenantContext(1)
+	_, _ = db.NewDelete().
+		TableExpr("facilities.rooms").
+		Where("id = ?", roomID).
+		Exec(ctx)
+}
+
 // setupFacilitiesService creates a facilities service with real database connection.
 func setupFacilitiesService(t *testing.T, db *bun.DB) facilitiesSvc.Service {
 	t.Helper()
@@ -305,9 +333,9 @@ func TestFacilitiesService_UpdateRoom(t *testing.T) {
 	})
 
 	t.Run("blocks renaming system room Schulhof", func(t *testing.T) {
-		// ARRANGE
-		room := testpkg.CreateTestRoom(t, db, "Schulhof")
-		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+		// ARRANGE — exact name required to match constants.SchulhofRoomName
+		room := createRoomWithExactName(t, db, "Schulhof")
+		defer cleanupRoom(t, db, room.ID)
 
 		room.Name = "Spielplatz"
 
@@ -320,9 +348,9 @@ func TestFacilitiesService_UpdateRoom(t *testing.T) {
 	})
 
 	t.Run("allows updating other properties of system room", func(t *testing.T) {
-		// ARRANGE
-		room := testpkg.CreateTestRoom(t, db, "WC")
-		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+		// ARRANGE — exact name required to match constants.WCRoomName
+		room := createRoomWithExactName(t, db, "WC")
+		defer cleanupRoom(t, db, room.ID)
 
 		newCapacity := 25
 		room.Capacity = &newCapacity
@@ -419,9 +447,9 @@ func TestFacilitiesService_DeleteRoom(t *testing.T) {
 	})
 
 	t.Run("blocks deletion of system room Schulhof", func(t *testing.T) {
-		// ARRANGE
-		room := testpkg.CreateTestRoom(t, db, "Schulhof")
-		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+		// ARRANGE — exact name required to match constants.SchulhofRoomName
+		room := createRoomWithExactName(t, db, "Schulhof")
+		defer cleanupRoom(t, db, room.ID)
 
 		// ACT
 		err := service.DeleteRoom(ctx, room.ID)
@@ -432,9 +460,9 @@ func TestFacilitiesService_DeleteRoom(t *testing.T) {
 	})
 
 	t.Run("blocks deletion of system room WC", func(t *testing.T) {
-		// ARRANGE
-		room := testpkg.CreateTestRoom(t, db, "WC")
-		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+		// ARRANGE — exact name required to match constants.WCRoomName
+		room := createRoomWithExactName(t, db, "WC")
+		defer cleanupRoom(t, db, room.ID)
 
 		// ACT
 		err := service.DeleteRoom(ctx, room.ID)

--- a/backend/services/facilities/facility_service_test.go
+++ b/backend/services/facilities/facility_service_test.go
@@ -303,6 +303,41 @@ func TestFacilitiesService_UpdateRoom(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 100, *updated.Capacity)
 	})
+
+	t.Run("blocks renaming system room Schulhof", func(t *testing.T) {
+		// ARRANGE
+		room := testpkg.CreateTestRoom(t, db, "Schulhof")
+		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+
+		room.Name = "Spielplatz"
+
+		// ACT
+		err := service.UpdateRoom(ctx, room)
+
+		// ASSERT
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Systemraum")
+	})
+
+	t.Run("allows updating other properties of system room", func(t *testing.T) {
+		// ARRANGE
+		room := testpkg.CreateTestRoom(t, db, "WC")
+		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+
+		newCapacity := 25
+		room.Capacity = &newCapacity
+
+		// ACT
+		err := service.UpdateRoom(ctx, room)
+
+		// ASSERT
+		require.NoError(t, err)
+
+		updated, err := service.GetRoom(ctx, room.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 25, *updated.Capacity)
+		assert.Equal(t, "WC", updated.Name)
+	})
 }
 
 // ============================================================================
@@ -381,6 +416,32 @@ func TestFacilitiesService_DeleteRoom(t *testing.T) {
 		// ASSERT
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("blocks deletion of system room Schulhof", func(t *testing.T) {
+		// ARRANGE
+		room := testpkg.CreateTestRoom(t, db, "Schulhof")
+		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+
+		// ACT
+		err := service.DeleteRoom(ctx, room.ID)
+
+		// ASSERT
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Systemraum")
+	})
+
+	t.Run("blocks deletion of system room WC", func(t *testing.T) {
+		// ARRANGE
+		room := testpkg.CreateTestRoom(t, db, "WC")
+		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+
+		// ACT
+		err := service.DeleteRoom(ctx, room.ID)
+
+		// ASSERT
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Systemraum")
 	})
 }
 

--- a/backend/services/facilities/schulhof_service_test.go
+++ b/backend/services/facilities/schulhof_service_test.go
@@ -162,6 +162,9 @@ func TestSchulhofService_GetSchulhofStatus_WithInfrastructureNoSession(t *testin
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
 
+	cleanupSchulhofArtifacts(t, db)
+	defer cleanupSchulhofArtifacts(t, db)
+
 	service := setupSchulhofService(t, db)
 	ctx := testpkg.TenantContext(1)
 
@@ -199,6 +202,9 @@ func TestSchulhofService_GetSchulhofStatus_WithActiveSessionNoSupervisor(t *test
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
 
+	cleanupSchulhofArtifacts(t, db)
+	defer cleanupSchulhofArtifacts(t, db)
+
 	service := setupSchulhofService(t, db)
 	ctx := testpkg.TenantContext(1)
 
@@ -228,6 +234,9 @@ func TestSchulhofService_GetSchulhofStatus_WithSupervisor(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
 
+	cleanupSchulhofArtifacts(t, db)
+	defer cleanupSchulhofArtifacts(t, db)
+
 	service := setupSchulhofService(t, db)
 	ctx := testpkg.TenantContext(1)
 
@@ -237,9 +246,16 @@ func TestSchulhofService_GetSchulhofStatus_WithSupervisor(t *testing.T) {
 	// First ensure infrastructure to get the room ID
 	activityGroup, err := service.EnsureInfrastructure(ctx, staff.ID)
 	require.NoError(t, err)
-	defer testpkg.CleanupActivityFixtures(t, db, activityGroup.ID, activityGroup.CategoryID, *activityGroup.PlannedRoomID)
+
+	// Build cleanup IDs — PlannedRoomID may be nil if EnsureInfrastructure found an existing activity
+	cleanupIDs := []int64{activityGroup.ID, activityGroup.CategoryID}
+	if activityGroup.PlannedRoomID != nil {
+		cleanupIDs = append(cleanupIDs, *activityGroup.PlannedRoomID)
+	}
+	defer testpkg.CleanupActivityFixtures(t, db, cleanupIDs...)
 
 	// End all existing active groups for this room to get a fresh one
+	require.NotNil(t, activityGroup.PlannedRoomID, "EnsureInfrastructure should set PlannedRoomID")
 	_, err = db.NewUpdate().
 		Model((*active.Group)(nil)).
 		ModelTableExpr(`active.groups AS "group"`).
@@ -293,6 +309,7 @@ func TestSchulhofService_GetSchulhofStatus_WithMultipleSupervisors(t *testing.T)
 	defer testpkg.CleanupActivityFixtures(t, db, activityGroup.ID, activityGroup.CategoryID, *activityGroup.PlannedRoomID)
 
 	// End all existing active groups for this room to get a fresh one
+	require.NotNil(t, activityGroup.PlannedRoomID, "EnsureInfrastructure should set PlannedRoomID")
 	_, err = db.NewUpdate().
 		Model((*active.Group)(nil)).
 		ModelTableExpr(`active.groups AS "group"`).

--- a/backend/services/facilities/schulhof_service_test.go
+++ b/backend/services/facilities/schulhof_service_test.go
@@ -171,7 +171,13 @@ func TestSchulhofService_GetSchulhofStatus_WithInfrastructureNoSession(t *testin
 	// Create infrastructure
 	activityGroup, err := service.EnsureInfrastructure(ctx, staff.ID)
 	require.NoError(t, err)
-	defer testpkg.CleanupActivityFixtures(t, db, activityGroup.ID, activityGroup.CategoryID, *activityGroup.PlannedRoomID)
+
+	// Build cleanup IDs — PlannedRoomID may be nil if EnsureInfrastructure found an existing activity
+	cleanupIDs := []int64{activityGroup.ID, activityGroup.CategoryID}
+	if activityGroup.PlannedRoomID != nil {
+		cleanupIDs = append(cleanupIDs, *activityGroup.PlannedRoomID)
+	}
+	defer testpkg.CleanupActivityFixtures(t, db, cleanupIDs...)
 
 	// ACT
 	status, err := service.GetSchulhofStatus(ctx, staff.ID)

--- a/frontend/src/components/activities/activity-detail-modal.tsx
+++ b/frontend/src/components/activities/activity-detail-modal.tsx
@@ -2,7 +2,7 @@
 
 import { Modal } from "~/components/ui/modal";
 import { DetailModalActions } from "~/components/ui/detail-modal-actions";
-import type { Activity } from "@/lib/activity-helpers";
+import { isSystemActivity, type Activity } from "@/lib/activity-helpers";
 
 interface ActivityDetailModalProps {
   readonly isOpen: boolean;
@@ -108,6 +108,7 @@ export function ActivityDetailModal({
             entityName={activity.name}
             entityType="Aktivität"
             onDeleteClick={onDeleteClick}
+            hideDelete={isSystemActivity(activity)}
           />
         </div>
       )}

--- a/frontend/src/components/activities/activity-edit-modal.test.tsx
+++ b/frontend/src/components/activities/activity-edit-modal.test.tsx
@@ -205,7 +205,7 @@ describe("ActivityEditModal", () => {
     await waitFor(() => {
       const nameDisabled = screen.getByTestId("name-disabled");
       expect(nameDisabled).toBeInTheDocument();
-      expect(nameDisabled).toHaveTextContent("Systemaktivität");
+      expect(nameDisabled).toHaveTextContent("Systemaktivität:");
     });
   });
 

--- a/frontend/src/components/activities/activity-edit-modal.test.tsx
+++ b/frontend/src/components/activities/activity-edit-modal.test.tsx
@@ -29,24 +29,36 @@ vi.mock("~/components/ui/modal", () => ({
     ) : null,
 }));
 
-// Mock DatabaseForm component
+// Mock DatabaseForm component — captures sections for assertion
 vi.mock("~/components/ui/database/database-form", () => ({
   DatabaseForm: ({
     onSubmit,
     onCancel,
     submitLabel,
+    sections,
   }: {
     onSubmit: (data: unknown) => Promise<void>;
     onCancel: () => void;
     submitLabel: string;
-  }) => (
-    <div data-testid="database-form">
-      <button onClick={() => onSubmit({ name: "Updated Activity" })}>
-        {submitLabel}
-      </button>
-      <button onClick={onCancel}>Cancel</button>
-    </div>
-  ),
+    sections: Array<{
+      fields: Array<{ name: string; disabled?: boolean; helperText?: string }>;
+    }>;
+  }) => {
+    const nameField = sections
+      ?.flatMap((s) => s.fields)
+      .find((f) => f.name === "name");
+    return (
+      <div data-testid="database-form">
+        {nameField?.disabled && (
+          <span data-testid="name-disabled">{nameField.helperText}</span>
+        )}
+        <button onClick={() => onSubmit({ name: "Updated Activity" })}>
+          {submitLabel}
+        </button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    );
+  },
 }));
 
 // Mock activitiesConfig and configToFormSection
@@ -172,6 +184,64 @@ describe("ActivityEditModal", () => {
     await waitFor(() => {
       expect(screen.getByTestId("database-form")).toBeInTheDocument();
       expect(screen.getByText("Speichern")).toBeInTheDocument();
+    });
+  });
+
+  it("disables name field for system activity Schulhof Freispiel", async () => {
+    const systemActivity: Activity = {
+      ...mockActivity,
+      name: "Schulhof Freispiel",
+    };
+
+    render(
+      <ActivityEditModal
+        isOpen={true}
+        onClose={mockOnClose}
+        activity={systemActivity}
+        onSave={mockOnSave}
+      />,
+    );
+
+    await waitFor(() => {
+      const nameDisabled = screen.getByTestId("name-disabled");
+      expect(nameDisabled).toBeInTheDocument();
+      expect(nameDisabled).toHaveTextContent("Systemaktivität");
+    });
+  });
+
+  it("disables name field for system activity WC", async () => {
+    const systemActivity: Activity = {
+      ...mockActivity,
+      name: "WC",
+    };
+
+    render(
+      <ActivityEditModal
+        isOpen={true}
+        onClose={mockOnClose}
+        activity={systemActivity}
+        onSave={mockOnSave}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("name-disabled")).toBeInTheDocument();
+    });
+  });
+
+  it("does not disable name field for regular activity", async () => {
+    render(
+      <ActivityEditModal
+        isOpen={true}
+        onClose={mockOnClose}
+        activity={mockActivity}
+        onSave={mockOnSave}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("database-form")).toBeInTheDocument();
+      expect(screen.queryByTestId("name-disabled")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/activities/activity-edit-modal.tsx
+++ b/frontend/src/components/activities/activity-edit-modal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { useMemo } from "react";
 import { Modal } from "~/components/ui/modal";
 import { DatabaseForm } from "~/components/ui/database/database-form";
-import type { Activity } from "@/lib/activity-helpers";
+import { isSystemActivity, type Activity } from "@/lib/activity-helpers";
 import { activitiesConfig } from "@/lib/database/configs/activities.config";
 import { configToFormSection } from "@/lib/database/types";
 
@@ -21,6 +22,28 @@ export function ActivityEditModal({
   onSave,
   loading = false,
 }: ActivityEditModalProps) {
+  const isSystem = isSystemActivity(activity);
+
+  // Disable name field for system activities (Schulhof Freispiel, WC)
+  const sections = useMemo(() => {
+    const baseSections =
+      activitiesConfig.form.sections.map(configToFormSection);
+    if (!isSystem) return baseSections;
+
+    return baseSections.map((section) => ({
+      ...section,
+      fields: section.fields.map((field) =>
+        field.name === "name"
+          ? {
+              ...field,
+              disabled: true,
+              helperText: "Systemaktivität — Name kann nicht geändert werden",
+            }
+          : field,
+      ),
+    }));
+  }, [isSystem]);
+
   if (!activity) return null;
 
   return (
@@ -39,7 +62,7 @@ export function ActivityEditModal({
       ) : (
         <DatabaseForm
           theme={activitiesConfig.theme}
-          sections={activitiesConfig.form.sections.map(configToFormSection)}
+          sections={sections}
           initialData={activity}
           onSubmit={onSave}
           onCancel={onClose}

--- a/frontend/src/components/activities/activity-edit-modal.tsx
+++ b/frontend/src/components/activities/activity-edit-modal.tsx
@@ -37,7 +37,7 @@ export function ActivityEditModal({
           ? {
               ...field,
               disabled: true,
-              helperText: "Systemaktivität — Name kann nicht geändert werden",
+              helperText: "Systemaktivität: Name kann nicht geändert werden",
             }
           : field,
       ),

--- a/frontend/src/components/rooms/room-detail-modal.test.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.test.tsx
@@ -105,6 +105,10 @@ vi.mock("@/lib/room-helpers", () => ({
     if (floor > 0) return `${floor}. OG`;
     return `${Math.abs(floor)}. UG`;
   },
+  isSystemRoom: (room: { name: string } | null | undefined) => {
+    if (!room) return false;
+    return room.name === "Schulhof" || room.name === "WC";
+  },
 }));
 
 const mockRoom = {

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -9,7 +9,7 @@ import {
   InfoSection,
   DetailIcons,
 } from "~/components/ui/detail-modal-components";
-import { formatFloor, type Room } from "@/lib/room-helpers";
+import { formatFloor, isSystemRoom, type Room } from "@/lib/room-helpers";
 
 interface RoomDetailModalProps {
   readonly isOpen: boolean;
@@ -108,6 +108,7 @@ export function RoomDetailModal({
           onDeleteClick={onDeleteClick}
           entityName={room.name}
           entityType="Raum"
+          hideDelete={isSystemRoom(room)}
         />
       </div>
     );

--- a/frontend/src/components/rooms/room-edit-modal.test.tsx
+++ b/frontend/src/components/rooms/room-edit-modal.test.tsx
@@ -247,7 +247,7 @@ describe("RoomEditModal", () => {
     await waitFor(() => {
       const nameDisabled = screen.getByTestId("name-disabled");
       expect(nameDisabled).toBeInTheDocument();
-      expect(nameDisabled).toHaveTextContent("Systemraum");
+      expect(nameDisabled).toHaveTextContent("Systemraum:");
     });
   });
 

--- a/frontend/src/components/rooms/room-edit-modal.test.tsx
+++ b/frontend/src/components/rooms/room-edit-modal.test.tsx
@@ -29,24 +29,36 @@ vi.mock("~/components/ui/modal", () => ({
     ) : null,
 }));
 
-// Mock DatabaseForm component
+// Mock DatabaseForm component — captures sections for assertion
 vi.mock("~/components/ui/database/database-form", () => ({
   DatabaseForm: ({
     onSubmit,
     onCancel,
     submitLabel,
+    sections,
   }: {
     onSubmit: (data: unknown) => Promise<void>;
     onCancel: () => void;
     submitLabel: string;
-  }) => (
-    <div data-testid="database-form">
-      <button onClick={() => onSubmit({ name: "Updated Room" })}>
-        {submitLabel}
-      </button>
-      <button onClick={onCancel}>Cancel</button>
-    </div>
-  ),
+    sections: Array<{
+      fields: Array<{ name: string; disabled?: boolean; helperText?: string }>;
+    }>;
+  }) => {
+    const nameField = sections
+      ?.flatMap((s) => s.fields)
+      .find((f) => f.name === "name");
+    return (
+      <div data-testid="database-form">
+        {nameField?.disabled && (
+          <span data-testid="name-disabled">{nameField.helperText}</span>
+        )}
+        <button onClick={() => onSubmit({ name: "Updated Room" })}>
+          {submitLabel}
+        </button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    );
+  },
 }));
 
 // Mock roomsConfig and configToFormSection
@@ -214,6 +226,64 @@ describe("RoomEditModal", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("database-form")).toBeInTheDocument();
+    });
+  });
+
+  it("disables name field for system room Schulhof", async () => {
+    const systemRoom: Room = {
+      ...mockRoom,
+      name: "Schulhof",
+    };
+
+    render(
+      <RoomEditModal
+        isOpen={true}
+        onClose={mockOnClose}
+        room={systemRoom}
+        onSave={mockOnSave}
+      />,
+    );
+
+    await waitFor(() => {
+      const nameDisabled = screen.getByTestId("name-disabled");
+      expect(nameDisabled).toBeInTheDocument();
+      expect(nameDisabled).toHaveTextContent("Systemraum");
+    });
+  });
+
+  it("disables name field for system room WC", async () => {
+    const systemRoom: Room = {
+      ...mockRoom,
+      name: "WC",
+    };
+
+    render(
+      <RoomEditModal
+        isOpen={true}
+        onClose={mockOnClose}
+        room={systemRoom}
+        onSave={mockOnSave}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("name-disabled")).toBeInTheDocument();
+    });
+  });
+
+  it("does not disable name field for regular room", async () => {
+    render(
+      <RoomEditModal
+        isOpen={true}
+        onClose={mockOnClose}
+        room={mockRoom}
+        onSave={mockOnSave}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("database-form")).toBeInTheDocument();
+      expect(screen.queryByTestId("name-disabled")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/rooms/room-edit-modal.tsx
+++ b/frontend/src/components/rooms/room-edit-modal.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { Modal } from "~/components/ui/modal";
 import { DatabaseForm } from "~/components/ui/database/database-form";
-import type { Room } from "@/lib/room-helpers";
+import { isSystemRoom, type Room } from "@/lib/room-helpers";
 import { roomsConfig } from "@/lib/database/configs/rooms.config";
 import { configToFormSection } from "@/lib/database/types";
 
@@ -30,14 +30,17 @@ export function RoomEditModal({
   onSave,
   loading = false,
 }: RoomEditModalProps) {
+  const isSystem = isSystemRoom(room);
+
   // Dynamically add legacy category if room has one not in standard list
+  // and disable name field for system rooms
   const sections = useMemo(() => {
-    const baseSections = roomsConfig.form.sections.map(configToFormSection);
+    let baseSections = roomsConfig.form.sections.map(configToFormSection);
 
     // Check if room has a legacy category
     if (room?.category && !STANDARD_CATEGORIES.has(room.category)) {
       // Find the category field and add the legacy option
-      return baseSections.map((section) => ({
+      baseSections = baseSections.map((section) => ({
         ...section,
         fields: section.fields.map((field) => {
           if (field.name === "category" && Array.isArray(field.options)) {
@@ -54,8 +57,24 @@ export function RoomEditModal({
       }));
     }
 
+    // Disable name field for system rooms (Schulhof, WC)
+    if (isSystem) {
+      baseSections = baseSections.map((section) => ({
+        ...section,
+        fields: section.fields.map((field) =>
+          field.name === "name"
+            ? {
+                ...field,
+                disabled: true,
+                helperText: "Systemraum — Name kann nicht geändert werden",
+              }
+            : field,
+        ),
+      }));
+    }
+
     return baseSections;
-  }, [room?.category]);
+  }, [room?.category, isSystem]);
 
   if (!room) return null;
 

--- a/frontend/src/components/rooms/room-edit-modal.tsx
+++ b/frontend/src/components/rooms/room-edit-modal.tsx
@@ -66,7 +66,7 @@ export function RoomEditModal({
             ? {
                 ...field,
                 disabled: true,
-                helperText: "Systemraum — Name kann nicht geändert werden",
+                helperText: "Systemraum: Name kann nicht geändert werden",
               }
             : field,
         ),

--- a/frontend/src/components/ui/database/database-form.tsx
+++ b/frontend/src/components/ui/database/database-form.tsx
@@ -221,6 +221,8 @@ export interface FormField {
   min?: number;
   max?: number;
   maxLength?: number;
+  /** When true, the field is rendered as read-only and cannot be edited. */
+  disabled?: boolean;
 }
 
 export interface FormSection {
@@ -731,6 +733,7 @@ export function DatabaseForm<T = Record<string, unknown>>({
               placeholder={field.placeholder}
               autoComplete={field.autoComplete}
               maxLength={field.maxLength ?? getDefaultMaxLength(field.type)}
+              disabled={field.disabled}
               className={baseInputClasses}
             />
             {field.helperText && (

--- a/frontend/src/components/ui/detail-modal-actions.tsx
+++ b/frontend/src/components/ui/detail-modal-actions.tsx
@@ -17,6 +17,8 @@ interface DetailModalActionsProps {
    * Use this to handle confirmation at the page level (recommended for proper modal stacking).
    */
   readonly onDeleteClick?: () => void;
+  /** When true, the delete button is hidden entirely (e.g. for system entities). */
+  readonly hideDelete?: boolean;
 }
 
 // German article lookup for entity types
@@ -32,6 +34,7 @@ export function DetailModalActions({
   entityType,
   confirmationContent,
   onDeleteClick,
+  hideDelete = false,
 }: Readonly<DetailModalActionsProps>) {
   const [confirmOpen, setConfirmOpen] = useState(false);
 
@@ -44,28 +47,30 @@ export function DetailModalActions({
   return (
     <>
       <div className="sticky bottom-0 -mx-4 mt-4 -mb-4 flex flex-wrap gap-2 border-t border-gray-100 bg-white/95 px-4 py-3 backdrop-blur-sm md:-mx-6 md:mt-6 md:-mb-6 md:gap-3 md:px-6 md:py-4">
-        <button
-          type="button"
-          onClick={handleDeleteClick}
-          className="rounded-lg border border-red-300 px-3 py-2 text-xs font-medium text-red-700 transition-all duration-200 hover:border-red-400 hover:bg-red-50 hover:shadow-md active:scale-100 md:px-4 md:text-sm md:hover:scale-105"
-        >
-          <span className="flex items-center gap-2">
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-              />
-            </svg>
-            Löschen
-          </span>
-        </button>
+        {!hideDelete && (
+          <button
+            type="button"
+            onClick={handleDeleteClick}
+            className="rounded-lg border border-red-300 px-3 py-2 text-xs font-medium text-red-700 transition-all duration-200 hover:border-red-400 hover:bg-red-50 hover:shadow-md active:scale-100 md:px-4 md:text-sm md:hover:scale-105"
+          >
+            <span className="flex items-center gap-2">
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                />
+              </svg>
+              Löschen
+            </span>
+          </button>
+        )}
         <button
           type="button"
           onClick={onEdit}

--- a/frontend/src/lib/activity-helpers.test.ts
+++ b/frontend/src/lib/activity-helpers.test.ts
@@ -43,6 +43,7 @@ import {
   isTimeSlotAvailable,
   isSupervisorAvailable,
   getActivityCategoryColor,
+  isSystemActivity,
 } from "./activity-helpers";
 
 // Sample data for tests
@@ -1219,5 +1220,38 @@ describe("getActivityCategoryColor", () => {
     expect(getActivityCategoryColor("Unknown Category")).toBe(
       "from-gray-500 to-gray-600",
     );
+  });
+});
+
+describe("isSystemActivity", () => {
+  const makeActivity = (name: string): Activity => ({
+    id: "1",
+    name,
+    max_participant: 20,
+    is_open_ags: false,
+    supervisor_id: "1",
+    ag_category_id: "1",
+    created_at: new Date(),
+    updated_at: new Date(),
+  });
+
+  it("returns true for Schulhof Freispiel", () => {
+    expect(isSystemActivity(makeActivity("Schulhof Freispiel"))).toBe(true);
+  });
+
+  it("returns true for WC", () => {
+    expect(isSystemActivity(makeActivity("WC"))).toBe(true);
+  });
+
+  it("returns false for regular activity", () => {
+    expect(isSystemActivity(makeActivity("Basteln"))).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isSystemActivity(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isSystemActivity(undefined)).toBe(false);
   });
 });

--- a/frontend/src/lib/activity-helpers.ts
+++ b/frontend/src/lib/activity-helpers.ts
@@ -335,6 +335,20 @@ function mapScheduleToTime(
   };
 }
 
+// System activity names that cannot be deleted or renamed.
+// Must stay in sync with backend constants/activities.go.
+const SYSTEM_ACTIVITY_NAMES = ["Schulhof Freispiel", "WC"] as const;
+
+/** Returns true if the activity is a system activity (Schulhof Freispiel, WC). */
+export function isSystemActivity(
+  activity: Activity | null | undefined,
+): boolean {
+  if (!activity) return false;
+  return SYSTEM_ACTIVITY_NAMES.includes(
+    activity.name as (typeof SYSTEM_ACTIVITY_NAMES)[number],
+  );
+}
+
 // Mapping functions for backend to frontend types
 export function mapActivityResponse(
   backendActivity: BackendActivity,

--- a/frontend/src/lib/database/types.ts
+++ b/frontend/src/lib/database/types.ts
@@ -85,6 +85,8 @@ export interface FormField {
   min?: number;
   max?: number;
   maxLength?: number;
+  /** When true, the field is rendered as read-only and cannot be edited. */
+  disabled?: boolean;
 }
 
 // Form section type (imported from database-form.tsx)

--- a/frontend/src/lib/room-helpers.test.ts
+++ b/frontend/src/lib/room-helpers.test.ts
@@ -11,6 +11,7 @@ import {
   formatRoomCapacity,
   getRoomUtilization,
   getRoomStatusColor,
+  isSystemRoom,
 } from "./room-helpers";
 import { suppressConsole } from "~/test/helpers/console";
 import { buildBackendRoom } from "~/test/fixtures";
@@ -556,5 +557,30 @@ describe("getRoomStatusColor", () => {
 
     // No capacity = 0 utilization = green
     expect(result).toBe("green");
+  });
+});
+
+describe("isSystemRoom", () => {
+  it("returns true for Schulhof", () => {
+    const room: Room = { id: "1", name: "Schulhof", isOccupied: false };
+    expect(isSystemRoom(room)).toBe(true);
+  });
+
+  it("returns true for WC", () => {
+    const room: Room = { id: "2", name: "WC", isOccupied: false };
+    expect(isSystemRoom(room)).toBe(true);
+  });
+
+  it("returns false for regular room", () => {
+    const room: Room = { id: "3", name: "Gruppenraum 1", isOccupied: false };
+    expect(isSystemRoom(room)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isSystemRoom(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isSystemRoom(undefined)).toBe(false);
   });
 });

--- a/frontend/src/lib/room-helpers.ts
+++ b/frontend/src/lib/room-helpers.ts
@@ -44,6 +44,18 @@ export interface Room {
   updatedAt?: string;
 }
 
+// System room names that cannot be deleted or renamed.
+// Must stay in sync with backend constants/activities.go.
+const SYSTEM_ROOM_NAMES = ["Schulhof", "WC"] as const;
+
+/** Returns true if the room is a system room (Schulhof, WC). */
+export function isSystemRoom(room: Room | null | undefined): boolean {
+  if (!room) return false;
+  return SYSTEM_ROOM_NAMES.includes(
+    room.name as (typeof SYSTEM_ROOM_NAMES)[number],
+  );
+}
+
 // Mapping functions
 export function mapRoomResponse(backendRoom: BackendRoom): Room {
   return {


### PR DESCRIPTION
## Summary
- Schulhof/WC rooms and Schulhof Freispiel/WC activities are system entities required by PyrePortal (kiosk app)
- Adds backend guards (HTTP 403) preventing deletion and renaming of these entities
- Adds frontend guards: delete button hidden, name field disabled in edit modals
- Backend is the authoritative guard — frontend is UX-only

## Changes

**Backend (7 files)**
- `constants/activities.go` — `IsSystemRoomName()`, `IsSystemActivityName()` helpers
- `services/facilities/` — `ErrSystemRoomProtected` + guards in `DeleteRoom()` and `UpdateRoom()`
- `services/activities/` — `ErrSystemActivityProtected` + guards in `DeleteGroup()` and `UpdateGroup()`
- `api/rooms/errors.go`, `api/activities/errors.go` — map new errors to HTTP 403

**Frontend (9 files)**
- `room-helpers.ts`, `activity-helpers.ts` — `isSystemRoom()`, `isSystemActivity()` helpers
- `detail-modal-actions.tsx` — new `hideDelete` prop
- Room/Activity detail + edit modals — hide delete, disable name field for system entities
- `database-form.tsx`, `types.ts` — `disabled` prop on `FormField`

## Test plan
- [x] Verify Schulhof/WC rooms cannot be deleted via UI (button hidden)
- [x] Verify Schulhof/WC rooms cannot be renamed via UI (field disabled)
- [x] Verify Schulhof Freispiel/WC activities cannot be deleted via UI (button hidden)
- [x] Verify Schulhof Freispiel/WC activities cannot be renamed via UI (field disabled)
- [x] Verify backend returns 403 when attempting delete/rename via API directly
- [x] Verify other room/activity properties (capacity, building, etc.) remain editable
- [x] Verify non-system rooms/activities are unaffected