### PR TITLE
fix: translate permissions page fully to German

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/database/permissions/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/permissions/page.test.tsx
@@ -112,6 +112,8 @@ vi.mock("@/lib/permission-labels", () => ({
     `${resource}:${action}`,
   localizeAction: (action: string) => action,
   localizeResource: (resource: string) => resource,
+  localizeDescription: (_resource: string, _action: string, dbDesc?: string) =>
+    dbDesc ?? "",
 }));
 
 vi.mock("@/components/permissions", () => ({
@@ -241,13 +243,14 @@ describe("PermissionsPage", () => {
     mockGetOne.mockResolvedValue(mockPermissions[0]);
   });
 
-  it("renders permissions list", async () => {
+  it("renders permissions list with formatted display names", async () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
-      expect(screen.getByText("Write Students")).toBeInTheDocument();
-      expect(screen.getByText("Admin Access")).toBeInTheDocument();
+      // displayTitle now always uses formatPermissionDisplay (resource:action)
+      expect(screen.getByText("students:read")).toBeInTheDocument();
+      expect(screen.getByText("students:write")).toBeInTheDocument();
+      expect(screen.getByText("admin:all")).toBeInTheDocument();
     });
   });
 
@@ -293,15 +296,15 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
     const searchInput = screen.getByTestId("search-input");
     fireEvent.change(searchInput, { target: { value: "Admin" } });
 
     await waitFor(() => {
-      expect(screen.getByText("Admin Access")).toBeInTheDocument();
-      expect(screen.queryByText("Read Students")).not.toBeInTheDocument();
+      expect(screen.getByText("admin:all")).toBeInTheDocument();
+      expect(screen.queryByText("students:read")).not.toBeInTheDocument();
     });
   });
 
@@ -309,7 +312,7 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
     const createButtons = screen.getAllByLabelText("Berechtigung erstellen");
@@ -327,10 +330,10 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("Read Students"));
+    fireEvent.click(screen.getByText("students:read"));
 
     await waitFor(() => {
       expect(screen.getByTestId("detail-modal")).toBeInTheDocument();
@@ -341,10 +344,10 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("Read Students"));
+    fireEvent.click(screen.getByText("students:read"));
 
     await waitFor(() => {
       expect(screen.getByTestId("detail-modal")).toBeInTheDocument();
@@ -367,7 +370,7 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
     const createButtons = screen.getAllByLabelText("Berechtigung erstellen");
@@ -392,7 +395,7 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
     const createButtons = screen.getAllByLabelText("Berechtigung erstellen");
@@ -420,7 +423,7 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
     const createButtons = screen.getAllByLabelText("Berechtigung erstellen");
@@ -447,7 +450,7 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
     const createButtons = screen.getAllByLabelText("Berechtigung erstellen");
@@ -473,7 +476,7 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
     const createButtons = screen.getAllByLabelText("Berechtigung erstellen");
@@ -509,10 +512,10 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("Read Students"));
+    fireEvent.click(screen.getByText("students:read"));
     await waitFor(() =>
       expect(screen.getByTestId("detail-modal")).toBeInTheDocument(),
     );
@@ -538,10 +541,10 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("Read Students"));
+    fireEvent.click(screen.getByText("students:read"));
     await waitFor(() =>
       expect(screen.getByTestId("detail-modal")).toBeInTheDocument(),
     );
@@ -567,10 +570,10 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("Read Students"));
+    fireEvent.click(screen.getByText("students:read"));
     await waitFor(() =>
       expect(screen.getByTestId("detail-modal")).toBeInTheDocument(),
     );
@@ -596,15 +599,15 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
     const searchInput = screen.getByTestId("search-input");
     fireEvent.change(searchInput, { target: { value: "Full admin" } });
 
     await waitFor(() => {
-      expect(screen.getByText("Admin Access")).toBeInTheDocument();
-      expect(screen.queryByText("Read Students")).not.toBeInTheDocument();
+      expect(screen.getByText("admin:all")).toBeInTheDocument();
+      expect(screen.queryByText("students:read")).not.toBeInTheDocument();
     });
   });
 
@@ -614,7 +617,7 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
     const createButtons = screen.getAllByLabelText("Berechtigung erstellen");
@@ -626,7 +629,7 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
       expect(screen.getByText("Can read student data")).toBeInTheDocument();
     });
   });
@@ -647,12 +650,13 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Basic Permission")).toBeInTheDocument();
+      // displayTitle always uses formatPermissionDisplay now
+      expect(screen.getByText("users:read")).toBeInTheDocument();
       expect(screen.queryByText("Can read")).not.toBeInTheDocument();
     });
   });
 
-  it("uses resource:action when name is empty", async () => {
+  it("always shows formatted display name regardless of name field", async () => {
     mockGetList.mockResolvedValue({
       data: [
         {
@@ -696,10 +700,10 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("Read Students"));
+    fireEvent.click(screen.getByText("students:read"));
     await waitFor(() =>
       expect(screen.getByTestId("detail-modal")).toBeInTheDocument(),
     );
@@ -723,10 +727,10 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("Read Students"));
+    fireEvent.click(screen.getByText("students:read"));
 
     await waitFor(() => {
       expect(screen.getByTestId("detail-modal")).toBeInTheDocument();
@@ -769,16 +773,17 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
+      // displayTitle uses formatPermissionDisplay → resource:action
       const buttons = screen
         .getAllByRole("button")
         .filter((btn) =>
-          ["A Permission", "M Permission", "Z Permission"].some((name) =>
-            btn.textContent?.includes(name),
+          ["admin:read", "users:read", "users:write"].some((key) =>
+            btn.textContent?.includes(key),
           ),
         );
-      expect(buttons[0]?.textContent).toContain("A Permission");
-      expect(buttons[1]?.textContent).toContain("M Permission");
-      expect(buttons[2]?.textContent).toContain("Z Permission");
+      expect(buttons[0]?.textContent).toContain("admin:read");
+      expect(buttons[1]?.textContent).toContain("users:read");
+      expect(buttons[2]?.textContent).toContain("users:write");
     });
   });
 
@@ -788,7 +793,7 @@ describe("PermissionsPage", () => {
     render(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Read Students")).toBeInTheDocument();
+      expect(screen.getByText("students:read")).toBeInTheDocument();
     });
   });
 });
@@ -852,27 +857,24 @@ describe("PermissionsPage filtering logic", () => {
 });
 
 describe("displayTitle helper logic", () => {
-  it("returns name when name is present", () => {
+  // displayTitle now always uses formatPermissionDisplay (resource:action)
+  const formatPermissionDisplay = (resource: string, action: string) =>
+    `${resource}:${action}`;
+  const displayTitle = (p: { resource: string; action: string }) =>
+    formatPermissionDisplay(p.resource, p.action);
+
+  it("always returns formatted display regardless of name", () => {
     const perm = { name: "Test Permission", resource: "test", action: "read" };
-    const displayTitle = (p: typeof perm) =>
-      p.name?.trim() ? p.name : `${p.resource}:${p.action}`;
-
-    expect(displayTitle(perm)).toBe("Test Permission");
-  });
-
-  it("returns resource:action when name is empty", () => {
-    const perm = { name: "", resource: "test", action: "read" };
-    const displayTitle = (p: typeof perm) =>
-      p.name?.trim() ? p.name : `${p.resource}:${p.action}`;
-
     expect(displayTitle(perm)).toBe("test:read");
   });
 
-  it("returns resource:action when name is whitespace", () => {
-    const perm = { name: "   ", resource: "test", action: "read" };
-    const displayTitle = (p: typeof perm) =>
-      p.name?.trim() ? p.name : `${p.resource}:${p.action}`;
+  it("returns formatted display when name is empty", () => {
+    const perm = { name: "", resource: "test", action: "read" };
+    expect(displayTitle(perm)).toBe("test:read");
+  });
 
+  it("returns formatted display when name is whitespace", () => {
+    const perm = { name: "   ", resource: "test", action: "read" };
     expect(displayTitle(perm)).toBe("test:read");
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/database/permissions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/permissions/page.tsx
@@ -25,6 +25,7 @@ import { ConfirmationModal } from "~/components/ui/modal";
 import {
   formatPermissionDisplay,
   localizeAction,
+  localizeDescription,
   localizeResource,
 } from "@/lib/permission-labels";
 import { useToast } from "~/contexts/ToastContext";
@@ -97,9 +98,12 @@ export default function PermissionsPage() {
   const toDisplay = (p: Permission) =>
     formatPermissionDisplay(p.resource, p.action);
 
-  // Anzeigename + Beschreibung exakt wie in den Daten anzeigen; bei fehlendem Anzeigenamen auf Ressource:Aktion ausweichen
-  const displayTitle = (p: Permission) =>
-    p.name?.trim() ? p.name : toDisplay(p);
+  // Immer den deutschen Anzeigenamen verwenden (Ressource: Aktion)
+  const displayTitle = (p: Permission) => toDisplay(p);
+
+  // Deutsche Beschreibung aus der Label-Map, Fallback auf DB-Beschreibung
+  const displayDescription = (p: Permission) =>
+    localizeDescription(p.resource, p.action, p.description);
 
   const filters: FilterConfig[] = useMemo(() => [], []);
   const activeFilters: ActiveFilter[] = useMemo(
@@ -125,7 +129,9 @@ export default function PermissionsPage() {
           p.name.toLowerCase().includes(q) ||
           (p.description?.toLowerCase().includes(q) ?? false) ||
           p.resource.toLowerCase().includes(q) ||
-          p.action.toLowerCase().includes(q),
+          p.action.toLowerCase().includes(q) ||
+          displayDescription(p).toLowerCase().includes(q) ||
+          toDisplay(p).toLowerCase().includes(q),
       );
     }
     arr.sort((a, b) => {
@@ -429,9 +435,9 @@ export default function PermissionsPage() {
                     <h3 className="truncate text-lg font-semibold text-gray-900 transition-colors duration-300 md:group-hover:text-pink-600">
                       {displayTitle(perm)}
                     </h3>
-                    {perm.description && (
+                    {displayDescription(perm) && (
                       <p className="mt-0.5 line-clamp-1 text-sm text-gray-600">
-                        {perm.description}
+                        {displayDescription(perm)}
                       </p>
                     )}
                     <div className="mt-1 flex flex-wrap items-center gap-2">

--- a/frontend/src/components/permissions/permission-detail-modal.test.tsx
+++ b/frontend/src/components/permissions/permission-detail-modal.test.tsx
@@ -62,6 +62,13 @@ vi.mock("~/components/ui/detail-modal-actions", () => ({
 vi.mock("@/lib/permission-labels", () => ({
   formatPermissionDisplay: (resource: string, action: string) =>
     `${resource}: ${action}`,
+  localizeResource: (resource: string) =>
+    resource === "users" ? "Benutzer" : resource,
+  localizeAction: (action: string) => (action === "read" ? "Lesen" : action),
+  localizeDescription: (resource: string, action: string, dbDesc?: string) =>
+    resource === "users" && action === "read"
+      ? "Benutzerinformationen ansehen"
+      : (dbDesc ?? ""),
 }));
 
 describe("PermissionDetailModal", () => {
@@ -128,7 +135,7 @@ describe("PermissionDetailModal", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("displays permission resource", async () => {
+  it("displays localized permission resource", async () => {
     render(
       <PermissionDetailModal
         isOpen={true}
@@ -140,11 +147,11 @@ describe("PermissionDetailModal", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("users")).toBeInTheDocument();
+      expect(screen.getByText("Benutzer")).toBeInTheDocument();
     });
   });
 
-  it("displays permission action", async () => {
+  it("displays localized permission action", async () => {
     render(
       <PermissionDetailModal
         isOpen={true}
@@ -156,11 +163,11 @@ describe("PermissionDetailModal", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("read")).toBeInTheDocument();
+      expect(screen.getByText("Lesen")).toBeInTheDocument();
     });
   });
 
-  it("displays permission name", async () => {
+  it("displays technical permission name", async () => {
     render(
       <PermissionDetailModal
         isOpen={true}
@@ -176,7 +183,7 @@ describe("PermissionDetailModal", () => {
     });
   });
 
-  it("displays permission description", async () => {
+  it("displays localized permission description", async () => {
     render(
       <PermissionDetailModal
         isOpen={true}
@@ -188,7 +195,9 @@ describe("PermissionDetailModal", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Allows reading user data")).toBeInTheDocument();
+      expect(
+        screen.getByText("Benutzerinformationen ansehen"),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/permissions/permission-detail-modal.tsx
+++ b/frontend/src/components/permissions/permission-detail-modal.tsx
@@ -4,7 +4,12 @@ import React from "react";
 import { Modal } from "~/components/ui/modal";
 import { DetailModalActions } from "~/components/ui/detail-modal-actions";
 import type { Permission } from "@/lib/auth-helpers";
-import { formatPermissionDisplay } from "@/lib/permission-labels";
+import {
+  formatPermissionDisplay,
+  localizeAction,
+  localizeDescription,
+  localizeResource,
+} from "@/lib/permission-labels";
 
 interface Props {
   readonly isOpen: boolean;
@@ -86,25 +91,32 @@ export function PermissionDetailModal({
                 <div>
                   <dt className="text-xs text-gray-500">Ressource</dt>
                   <dd className="mt-0.5 text-sm font-medium break-words text-gray-900">
-                    {permission.resource}
+                    {localizeResource(permission.resource)}
                   </dd>
                 </div>
                 <div>
                   <dt className="text-xs text-gray-500">Aktion</dt>
                   <dd className="mt-0.5 text-sm font-medium break-words text-gray-900">
-                    {permission.action}
+                    {localizeAction(permission.action)}
                   </dd>
                 </div>
                 <div className="sm:col-span-2">
-                  <dt className="text-xs text-gray-500">Anzeigename</dt>
+                  <dt className="text-xs text-gray-500">Technischer Name</dt>
                   <dd className="mt-0.5 text-sm font-medium break-words text-gray-900">
-                    {permission.name || "—"}
+                    <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-sm">
+                      {permission.name ||
+                        permission.resource + ":" + permission.action}
+                    </code>
                   </dd>
                 </div>
                 <div className="sm:col-span-2">
                   <dt className="text-xs text-gray-500">Beschreibung</dt>
                   <dd className="mt-0.5 text-xs break-words whitespace-pre-wrap text-gray-700 md:text-sm">
-                    {permission.description || "Keine Beschreibung"}
+                    {localizeDescription(
+                      permission.resource,
+                      permission.action,
+                      permission.description,
+                    ) || "Keine Beschreibung"}
                   </dd>
                 </div>
               </dl>

--- a/frontend/src/components/permissions/permission-selector.test.tsx
+++ b/frontend/src/components/permissions/permission-selector.test.tsx
@@ -135,7 +135,7 @@ describe("PermissionSelector", () => {
     render(<PermissionSelector value={value} onChange={mockOnChange} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Permission-Name:")).toBeInTheDocument();
+      expect(screen.getByText("Berechtigungsname:")).toBeInTheDocument();
       expect(screen.getByText("users:read")).toBeInTheDocument();
     });
   });

--- a/frontend/src/components/permissions/permission-selector.tsx
+++ b/frontend/src/components/permissions/permission-selector.tsx
@@ -5,6 +5,8 @@ import { useState, useEffect, useRef, useCallback } from "react";
 // Resource definitions with German labels
 const RESOURCES = [
   { value: "users", label: "Benutzer" },
+  { value: "roles", label: "Rollen" },
+  { value: "permissions", label: "Berechtigungen" },
   { value: "activities", label: "Aktivitäten" },
   { value: "rooms", label: "Räume" },
   { value: "groups", label: "Gruppen" },
@@ -15,6 +17,11 @@ const RESOURCES = [
   { value: "config", label: "Konfiguration" },
   { value: "iot", label: "IoT-Geräte" },
   { value: "auth", label: "Authentifizierung" },
+  { value: "suggestions", label: "Vorschläge" },
+  { value: "time_tracking", label: "Zeiterfassung" },
+  { value: "grade_transitions", label: "Klassenwechsel" },
+  { value: "system", label: "System" },
+  { value: "admin", label: "Administration" },
 ] as const;
 
 // Action labels in German
@@ -27,11 +34,15 @@ const ACTION_LABELS: Record<string, string> = {
   manage: "Verwalten",
   enroll: "Einschreiben",
   assign: "Zuweisen",
+  own: "Eigene",
+  apply: "Anwenden",
 };
 
 // Actions available per resource (matching Go backend constants)
 const RESOURCE_ACTIONS: Record<string, string[]> = {
   users: ["create", "read", "update", "delete", "list", "manage"],
+  roles: ["create", "read", "update", "delete"],
+  permissions: ["create", "read", "update", "delete"],
   activities: [
     "create",
     "read",
@@ -47,10 +58,15 @@ const RESOURCE_ACTIONS: Record<string, string[]> = {
   substitutions: ["create", "read", "update", "delete", "list", "manage"],
   schedules: ["create", "read", "update", "delete", "list", "manage"],
   visits: ["create", "read", "update", "delete", "list", "manage"],
-  feedback: ["create", "read", "delete", "list", "manage"], // no update
-  config: ["read", "update", "manage"], // no create/delete/list
-  iot: ["read", "update", "manage"], // no create/delete/list
-  auth: ["manage"], // only manage
+  feedback: ["create", "read", "delete", "list", "manage"],
+  config: ["read", "update", "manage"],
+  iot: ["read", "update", "manage"],
+  auth: ["manage"],
+  suggestions: ["create", "read", "update", "delete", "list", "manage"],
+  time_tracking: ["own"],
+  grade_transitions: ["read", "create", "update", "delete", "apply"],
+  system: ["manage"],
+  admin: ["*"],
 };
 
 export interface PermissionSelectorValue {
@@ -229,7 +245,7 @@ export function PermissionSelector({
       {resource && action && (
         <div className="md:col-span-2">
           <p className="text-xs text-gray-500">
-            Permission-Name:{" "}
+            Berechtigungsname:{" "}
             <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-pink-600">
               {resource}:{action}
             </code>

--- a/frontend/src/lib/database/configs/permissions.config.test.tsx
+++ b/frontend/src/lib/database/configs/permissions.config.test.tsx
@@ -13,6 +13,9 @@ vi.mock("@/lib/auth-helpers", () => ({
 
 vi.mock("@/lib/permission-labels", () => ({
   formatPermissionDisplay: vi.fn((resource, action) => `${resource}:${action}`),
+  localizeResource: vi.fn((resource) => resource),
+  localizeAction: vi.fn((action) => action),
+  localizeDescription: vi.fn((_resource, _action, dbDesc) => dbDesc ?? ""),
 }));
 
 vi.mock("@/components/permissions/permission-selector", () => ({

--- a/frontend/src/lib/database/configs/permissions.config.tsx
+++ b/frontend/src/lib/database/configs/permissions.config.tsx
@@ -6,7 +6,12 @@ import { defineEntityConfig } from "../types";
 import { databaseThemes } from "@/components/ui/database/themes";
 import type { Permission, BackendPermission } from "@/lib/auth-helpers";
 import { mapPermissionResponse } from "@/lib/auth-helpers";
-import { formatPermissionDisplay } from "@/lib/permission-labels";
+import {
+  formatPermissionDisplay,
+  localizeAction,
+  localizeDescription,
+  localizeResource,
+} from "@/lib/permission-labels";
 import {
   PermissionSelector,
   type PermissionSelectorValue,
@@ -132,7 +137,9 @@ export const permissionsConfig = defineEntityConfig<Permission>({
   detail: {
     header: {
       title: (p: Permission) => displayName(p),
-      subtitle: (p: Permission) => p.description || "Keine Beschreibung",
+      subtitle: (p: Permission) =>
+        localizeDescription(p.resource, p.action, p.description) ||
+        "Keine Beschreibung",
       avatar: {
         text: (p: Permission) => (p.resource?.[0] ?? "P").toUpperCase(),
         size: "lg",
@@ -150,12 +157,23 @@ export const permissionsConfig = defineEntityConfig<Permission>({
         title: "Technische Daten",
         titleColor: "text-indigo-800",
         items: [
-          { label: "Ressource", value: (p: Permission) => p.resource },
-          { label: "Aktion", value: (p: Permission) => p.action },
-          { label: "Anzeigename", value: (p: Permission) => p.name },
+          {
+            label: "Ressource",
+            value: (p: Permission) => localizeResource(p.resource),
+          },
+          {
+            label: "Aktion",
+            value: (p: Permission) => localizeAction(p.action),
+          },
+          {
+            label: "Technischer Name",
+            value: (p: Permission) => p.name || `${p.resource}:${p.action}`,
+          },
           {
             label: "Beschreibung",
-            value: (p: Permission) => p.description || "Keine Beschreibung",
+            value: (p: Permission) =>
+              localizeDescription(p.resource, p.action, p.description) ||
+              "Keine Beschreibung",
           },
           { label: "ID", value: (p: Permission) => p.id },
           {
@@ -193,7 +211,8 @@ export const permissionsConfig = defineEntityConfig<Permission>({
     item: {
       title: (p: Permission) => displayName(p),
       subtitle: (p: Permission) => p.name,
-      description: (p: Permission) => p.description || "",
+      description: (p: Permission) =>
+        localizeDescription(p.resource, p.action, p.description),
       avatar: {
         text: (p: Permission) => (p.resource?.[0] ?? "P").toUpperCase(),
       },

--- a/frontend/src/lib/permission-labels.test.ts
+++ b/frontend/src/lib/permission-labels.test.ts
@@ -5,6 +5,7 @@ import {
   localizeResource,
   localizeAction,
   formatPermissionDisplay,
+  localizeDescription,
 } from "./permission-labels";
 
 describe("permission-labels", () => {
@@ -17,25 +18,31 @@ describe("permission-labels", () => {
       expect(resourceLabels.rooms).toBe("Räume");
       expect(resourceLabels.groups).toBe("Gruppen");
       expect(resourceLabels.visits).toBe("Besuche");
+      expect(resourceLabels.substitutions).toBe("Vertretungen");
       expect(resourceLabels.schedules).toBe("Zeitpläne");
       expect(resourceLabels.config).toBe("Konfiguration");
       expect(resourceLabels.feedback).toBe("Feedback");
       expect(resourceLabels.iot).toBe("Geräte");
       expect(resourceLabels.system).toBe("System");
       expect(resourceLabels.admin).toBe("Administration");
+      expect(resourceLabels.suggestions).toBe("Vorschläge");
+      expect(resourceLabels.time_tracking).toBe("Zeiterfassung");
+      expect(resourceLabels.grade_transitions).toBe("Klassenwechsel");
     });
   });
 
   describe("actionLabels", () => {
     it("should contain expected action mappings", () => {
       expect(actionLabels.create).toBe("Erstellen");
-      expect(actionLabels.read).toBe("Ansehen");
+      expect(actionLabels.read).toBe("Lesen");
       expect(actionLabels.update).toBe("Bearbeiten");
       expect(actionLabels.delete).toBe("Löschen");
       expect(actionLabels.list).toBe("Auflisten");
       expect(actionLabels.manage).toBe("Verwalten");
       expect(actionLabels.assign).toBe("Zuweisen");
-      expect(actionLabels.enroll).toBe("Anmelden");
+      expect(actionLabels.enroll).toBe("Einschreiben");
+      expect(actionLabels.own).toBe("Eigene");
+      expect(actionLabels.apply).toBe("Anwenden");
       expect(actionLabels["*"]).toBe("Alle");
     });
   });
@@ -69,7 +76,7 @@ describe("permission-labels", () => {
   describe("localizeAction", () => {
     it("should return German label for known actions", () => {
       expect(localizeAction("create")).toBe("Erstellen");
-      expect(localizeAction("read")).toBe("Ansehen");
+      expect(localizeAction("read")).toBe("Lesen");
       expect(localizeAction("update")).toBe("Bearbeiten");
       expect(localizeAction("delete")).toBe("Löschen");
       expect(localizeAction("*")).toBe("Alle");
@@ -98,7 +105,7 @@ describe("permission-labels", () => {
       expect(formatPermissionDisplay("users", "create")).toBe(
         "Benutzer: Erstellen",
       );
-      expect(formatPermissionDisplay("rooms", "read")).toBe("Räume: Ansehen");
+      expect(formatPermissionDisplay("rooms", "read")).toBe("Räume: Lesen");
       expect(formatPermissionDisplay("activities", "update")).toBe(
         "Aktivitäten: Bearbeiten",
       );
@@ -118,7 +125,7 @@ describe("permission-labels", () => {
       expect(formatPermissionDisplay("unknown_resource", "create")).toBe(
         "unknown_resource: Erstellen",
       );
-      expect(formatPermissionDisplay("custom", "read")).toBe("custom: Ansehen");
+      expect(formatPermissionDisplay("custom", "read")).toBe("custom: Lesen");
     });
 
     it("should handle known resources with unknown actions", () => {
@@ -154,6 +161,87 @@ describe("permission-labels", () => {
       expect(formatPermissionDisplay("xyz", "create")).toBe("xyz: Erstellen");
       // Both unknown
       expect(formatPermissionDisplay("xyz", "abc")).toBe("xyz: abc");
+    });
+  });
+
+  describe("localizeDescription", () => {
+    it("should return German description for known permissions", () => {
+      expect(localizeDescription("users", "create")).toBe(
+        "Neue Benutzer erstellen",
+      );
+      expect(localizeDescription("activities", "assign")).toBe(
+        "Betreuer zu Aktivitäten zuweisen",
+      );
+      expect(localizeDescription("rooms", "manage")).toBe(
+        "Raumverwaltung (Vollzugriff)",
+      );
+      expect(localizeDescription("time_tracking", "own")).toBe(
+        "Eigene Arbeitszeiten erfassen",
+      );
+      expect(localizeDescription("grade_transitions", "apply")).toBe(
+        "Klassenwechsel anwenden/zurücksetzen",
+      );
+    });
+
+    it("should return German description for legacy permission names", () => {
+      expect(localizeDescription("user", "create")).toBe(
+        "Neue Benutzer erstellen",
+      );
+      expect(localizeDescription("role", "read")).toBe(
+        "Rolleninformationen ansehen",
+      );
+      expect(localizeDescription("permission", "delete")).toBe(
+        "Berechtigungen löschen",
+      );
+    });
+
+    it("should fall back to DB description for unknown permissions", () => {
+      expect(localizeDescription("unknown", "action", "DB description")).toBe(
+        "DB description",
+      );
+    });
+
+    it("should return empty string when no translation and no DB description", () => {
+      expect(localizeDescription("unknown", "action")).toBe("");
+      expect(localizeDescription("unknown", "action", undefined)).toBe("");
+    });
+
+    it("should prefer German translation over DB description", () => {
+      expect(localizeDescription("users", "create", "Create new users")).toBe(
+        "Neue Benutzer erstellen",
+      );
+    });
+
+    it("should cover all major resource categories", () => {
+      // Verify each resource category has at least one description
+      expect(localizeDescription("substitutions", "manage")).toBe(
+        "Vertretungsverwaltung (Vollzugriff)",
+      );
+      expect(localizeDescription("schedules", "create")).toBe(
+        "Neue Stundenpläne erstellen",
+      );
+      expect(localizeDescription("visits", "read")).toBe("Besuche ansehen");
+      expect(localizeDescription("feedback", "list")).toBe(
+        "Feedback auflisten",
+      );
+      expect(localizeDescription("config", "update")).toBe(
+        "Konfiguration bearbeiten",
+      );
+      expect(localizeDescription("iot", "manage")).toBe(
+        "IoT-Geräteverwaltung (Vollzugriff)",
+      );
+      expect(localizeDescription("auth", "manage")).toBe(
+        "Authentifizierungsverwaltung (Vollzugriff)",
+      );
+      expect(localizeDescription("suggestions", "create")).toBe(
+        "Neue Vorschläge erstellen",
+      );
+      expect(localizeDescription("system", "manage")).toBe(
+        "Systemeinstellungen verwalten",
+      );
+      expect(localizeDescription("admin", "*")).toBe(
+        "Vollzugriff auf alle Ressourcen",
+      );
     });
   });
 });

--- a/frontend/src/lib/permission-labels.ts
+++ b/frontend/src/lib/permission-labels.ts
@@ -8,23 +8,29 @@ export const resourceLabels: Record<string, string> = {
   rooms: "Räume",
   groups: "Gruppen",
   visits: "Besuche",
+  substitutions: "Vertretungen",
   schedules: "Zeitpläne",
   config: "Konfiguration",
   feedback: "Feedback",
   iot: "Geräte",
   system: "System",
   admin: "Administration",
+  suggestions: "Vorschläge",
+  time_tracking: "Zeiterfassung",
+  grade_transitions: "Klassenwechsel",
 };
 
 export const actionLabels: Record<string, string> = {
   create: "Erstellen",
-  read: "Ansehen",
+  read: "Lesen",
   update: "Bearbeiten",
   delete: "Löschen",
   list: "Auflisten",
   manage: "Verwalten",
   assign: "Zuweisen",
-  enroll: "Anmelden",
+  enroll: "Einschreiben",
+  own: "Eigene",
+  apply: "Anwenden",
   "*": "Alle",
 };
 
@@ -41,4 +47,139 @@ export function formatPermissionDisplay(
   action: string,
 ): string {
   return `${localizeResource(resource)}: ${localizeAction(action)}`;
+}
+
+/**
+ * German descriptions for permissions, keyed by "resource:action".
+ * Used to override English descriptions stored in the database.
+ */
+const permissionDescriptions: Record<string, string> = {
+  // Users
+  "users:create": "Neue Benutzer erstellen",
+  "users:read": "Benutzerinformationen ansehen",
+  "users:update": "Benutzerinformationen bearbeiten",
+  "users:delete": "Benutzer löschen",
+  "users:list": "Benutzer auflisten",
+  "users:manage": "Benutzerverwaltung (Vollzugriff)",
+
+  // Activities
+  "activities:create": "Neue Aktivitäten erstellen",
+  "activities:read": "Aktivitäten ansehen",
+  "activities:update": "Aktivitäten bearbeiten",
+  "activities:delete": "Aktivitäten löschen",
+  "activities:list": "Aktivitäten auflisten",
+  "activities:manage": "Aktivitätenverwaltung (Vollzugriff)",
+  "activities:enroll": "Kinder in Aktivitäten einschreiben",
+  "activities:assign": "Betreuer zu Aktivitäten zuweisen",
+
+  // Rooms
+  "rooms:create": "Neue Räume erstellen",
+  "rooms:read": "Räume ansehen",
+  "rooms:update": "Räume bearbeiten",
+  "rooms:delete": "Räume löschen",
+  "rooms:list": "Räume auflisten",
+  "rooms:manage": "Raumverwaltung (Vollzugriff)",
+
+  // Groups
+  "groups:create": "Neue Gruppen erstellen",
+  "groups:read": "Gruppen ansehen",
+  "groups:update": "Gruppen bearbeiten",
+  "groups:delete": "Gruppen löschen",
+  "groups:list": "Gruppen auflisten",
+  "groups:manage": "Gruppenverwaltung (Vollzugriff)",
+  "groups:assign": "Kinder zu Gruppen zuweisen",
+
+  // Substitutions
+  "substitutions:create": "Neue Vertretungen erstellen",
+  "substitutions:read": "Vertretungen ansehen",
+  "substitutions:update": "Vertretungen bearbeiten",
+  "substitutions:delete": "Vertretungen löschen",
+  "substitutions:list": "Vertretungen auflisten",
+  "substitutions:manage": "Vertretungsverwaltung (Vollzugriff)",
+
+  // Schedules
+  "schedules:create": "Neue Stundenpläne erstellen",
+  "schedules:read": "Stundenpläne ansehen",
+  "schedules:update": "Stundenpläne bearbeiten",
+  "schedules:delete": "Stundenpläne löschen",
+  "schedules:list": "Stundenpläne auflisten",
+  "schedules:manage": "Stundenplanverwaltung (Vollzugriff)",
+
+  // Visits
+  "visits:create": "Neue Besuche erstellen",
+  "visits:read": "Besuche ansehen",
+  "visits:update": "Besuche bearbeiten",
+  "visits:delete": "Besuche löschen",
+  "visits:list": "Besuche auflisten",
+  "visits:manage": "Besuchsverwaltung (Vollzugriff)",
+
+  // Feedback
+  "feedback:create": "Neues Feedback erstellen",
+  "feedback:read": "Feedback ansehen",
+  "feedback:delete": "Feedback löschen",
+  "feedback:list": "Feedback auflisten",
+  "feedback:manage": "Feedbackverwaltung (Vollzugriff)",
+
+  // Config
+  "config:read": "Konfiguration ansehen",
+  "config:update": "Konfiguration bearbeiten",
+  "config:manage": "Konfigurationsverwaltung (Vollzugriff)",
+
+  // IoT
+  "iot:read": "IoT-Geräte ansehen",
+  "iot:update": "IoT-Geräte bearbeiten",
+  "iot:manage": "IoT-Geräteverwaltung (Vollzugriff)",
+
+  // Auth
+  "auth:manage": "Authentifizierungsverwaltung (Vollzugriff)",
+
+  // Suggestions
+  "suggestions:create": "Neue Vorschläge erstellen",
+  "suggestions:read": "Vorschläge ansehen",
+  "suggestions:update": "Vorschläge bearbeiten",
+  "suggestions:delete": "Vorschläge löschen",
+  "suggestions:list": "Vorschläge auflisten",
+  "suggestions:manage": "Vorschlagsverwaltung (Vollzugriff)",
+
+  // Time Tracking
+  "time_tracking:own": "Eigene Arbeitszeiten erfassen",
+
+  // Grade Transitions
+  "grade_transitions:read": "Klassenwechsel ansehen",
+  "grade_transitions:create": "Klassenwechsel erstellen",
+  "grade_transitions:update": "Klassenwechsel bearbeiten",
+  "grade_transitions:delete": "Klassenwechsel löschen",
+  "grade_transitions:apply": "Klassenwechsel anwenden/zurücksetzen",
+
+  // System & Admin
+  "system:manage": "Systemeinstellungen verwalten",
+  "admin:*": "Vollzugriff auf alle Ressourcen",
+  "*:*": "Vollzugriff auf alle Ressourcen",
+
+  // Legacy names (from initial migration)
+  "user:create": "Neue Benutzer erstellen",
+  "user:read": "Benutzerinformationen ansehen",
+  "user:update": "Benutzerinformationen bearbeiten",
+  "user:delete": "Benutzer löschen",
+  "role:create": "Neue Rollen erstellen",
+  "role:read": "Rolleninformationen ansehen",
+  "role:update": "Rolleninformationen bearbeiten",
+  "role:delete": "Rollen löschen",
+  "permission:create": "Neue Berechtigungen erstellen",
+  "permission:read": "Berechtigungsinformationen ansehen",
+  "permission:update": "Berechtigungsinformationen bearbeiten",
+  "permission:delete": "Berechtigungen löschen",
+};
+
+/**
+ * Returns a German description for the given permission.
+ * Falls back to the DB description if no German translation exists.
+ */
+export function localizeDescription(
+  resource: string,
+  action: string,
+  dbDescription?: string,
+): string {
+  const key = `${resource}:${action}`;
+  return permissionDescriptions[key] ?? dbDescription ?? "";
 }


### PR DESCRIPTION
## Summary

- Add German description map in `permission-labels.ts` to override English DB descriptions in the frontend (no migration needed)
- Translate "Permission-Name:" to "Berechtigungsname:" in the permission selector
- Add missing resources (suggestions, time_tracking, grade_transitions, roles, permissions, system, admin) and actions (own, apply) to label maps and selector dropdown
- Fix inconsistent action labels (read: "Ansehen" → "Lesen", enroll: "Anmelden" → "Einschreiben")
- Show localized resource/action names in detail modal instead of raw English values
- Rename "Anzeigename" to "Technischer Name" in detail view (shows technical permission key as code badge)
- Use German display title instead of technical DB name in the permission list
- Extend search to also match German labels and descriptions

## Test plan
- [ ] Open permissions page → all titles and descriptions in German
- [ ] Open detail modal → resource, action, description in German, technical name as code badge
- [ ] Create new permission → all resources and actions in dropdown in German
- [ ] Test search with German terms (e.g. "Aktivitäten", "Löschen")