### PR TITLE
fix: caregiver modal title em dash and footer button overlap

### DIFF
--- a/frontend/src/components/teachers/caregiver-capability-modal.tsx
+++ b/frontend/src/components/teachers/caregiver-capability-modal.tsx
@@ -258,7 +258,7 @@ export function CaregiverCapabilityModal({
     <FormModal
       isOpen={isOpen}
       onClose={onClose}
-      title={`Betreuung verwalten — ${accountLabel}`}
+      title={`Betreuung verwalten: ${accountLabel}`}
       size="lg"
       footer={
         <>

--- a/frontend/src/components/ui/form-modal.tsx
+++ b/frontend/src/components/ui/form-modal.tsx
@@ -194,7 +194,7 @@ export function FormModal({
 
         {/* Footer if provided - now sticky at bottom */}
         {footer && (
-          <div className="sticky bottom-0 flex justify-end gap-3 border-t border-gray-100 bg-gray-50/95 p-4 backdrop-blur-sm md:p-6">
+          <div className="sticky bottom-0 flex flex-wrap justify-end gap-3 border-t border-gray-100 bg-gray-50/95 p-4 backdrop-blur-sm md:p-6">
             {footer}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Remove em dash (`—`) from "Betreuung verwalten" modal title, replaced with colon
- Add `flex-wrap` to FormModal footer to prevent button overlap on narrow viewports

## Test plan
- [ ] Open "Betreuung verwalten" modal on database/personal page
- [ ] Verify title shows `Betreuung verwalten: Name` (no em dash)
- [ ] Resize browser to narrow width, confirm "Schließen" and "Betreuung deaktivieren" buttons wrap cleanly