### PR TITLE
fix: default session cleanup to disabled (opt-in)

### DIFF
--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -216,7 +216,7 @@ func TestDefaults_HaveReasonableValues(t *testing.T) {
 		{"operations.session_end_time", "18:00"},
 		{"operations.session_end_timeout_minutes", 10},
 		{"operations.student_daily_checkout_time", ""},
-		{"operations.session_cleanup_enabled", true},
+		{"operations.session_cleanup_enabled", false},
 		{"operations.session_cleanup_interval_minutes", 15},
 		{"operations.session_abandoned_threshold_minutes", 60},
 		{"gdpr.data_cleanup_enabled", true},

--- a/backend/services/config/defaults/operations.go
+++ b/backend/services/config/defaults/operations.go
@@ -81,7 +81,7 @@ func init() {
 		Label:           "Bereinigung verlassener Sitzungen",
 		Description:     "Automatische Bereinigung von Sitzungen ohne Aktivität",
 		Type:            config.FieldBoolean,
-		Default:         true,
+		Default:         false,
 		ReadPermission:  "config:read",
 		WritePermission: "config:update",
 		Tab:             "operations",


### PR DESCRIPTION
## Summary
- Changes the default for `operations.session_cleanup_enabled` from `true` to `false`
- Schools must now explicitly enable abandoned session cleanup in the settings UI
- Prevents API errors on PyrePortal when students re-scan after their session was silently cleaned up

## Context
With the default set to `true`, schools that never touched the settings system got automatic cleanup — sessions inactive for 60 minutes were removed. This caused issues when PyrePortal devices still displayed the stale session and students tried to re-scan, resulting in an API error.

## Test plan
- [x] `go test ./services/config/...` — all 13 tests pass
- [ ] Verify existing tenant overrides (schools that explicitly set `true`) are unaffected
- [ ] Verify new schools get cleanup disabled by default