### PR TITLE
feat: make feedback history and IoT feedback opt-in (GDPR)

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -294,7 +294,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Import = importAPI.NewResource(api.Services.Import, repoFactory.DataImport, api.Services.Users, db)
 	api.Activities = activitiesAPI.NewResource(api.Services.Activities, api.Services.Schedule, api.Services.Users, api.Services.UserContext, db)
 	api.Staff = staffAPI.NewResource(api.Services.Users, api.Services.Education, api.Services.Auth, repoFactory.GroupSupervisor, api.Services.WorkSession, repoFactory.StaffAbsence, db, logger.With("handler", "staff"))
-	api.Feedback = feedbackAPI.NewResource(api.Services.Feedback, db)
+	api.Feedback = feedbackAPI.NewResource(api.Services.Feedback, api.Services.Settings, db)
 	api.Suggestions = suggestionsAPI.NewResource(api.Services.Suggestions, db)
 	api.Schedules = schedulesAPI.NewResource(api.Services.Schedule, db)
 	api.Config = configAPI.NewResource(api.Services.Config, api.Services.ActiveCleanup, db)

--- a/backend/api/feedback/api.go
+++ b/backend/api/feedback/api.go
@@ -3,6 +3,7 @@ package feedback
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -13,7 +14,9 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/models/feedback"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
 	feedbackSvc "github.com/moto-nrw/project-phoenix/services/feedback"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
@@ -27,13 +30,15 @@ const (
 // Resource defines the feedback API resource
 type Resource struct {
 	FeedbackService feedbackSvc.Service
+	SettingsService configService.SettingsService
 	db              *bun.DB
 }
 
 // NewResource creates a new feedback resource
-func NewResource(feedbackService feedbackSvc.Service, db *bun.DB) *Resource {
+func NewResource(feedbackService feedbackSvc.Service, settingsService configService.SettingsService, db *bun.DB) *Resource {
 	return &Resource{
 		FeedbackService: feedbackService,
+		SettingsService: settingsService,
 		db:              db,
 	}
 }
@@ -274,6 +279,12 @@ func (rs *Resource) getFeedback(w http.ResponseWriter, r *http.Request) {
 
 // getStudentFeedback handles getting feedback entries for a specific student
 func (rs *Resource) getStudentFeedback(w http.ResponseWriter, r *http.Request) {
+	// Feature gate: feedback must be enabled for this tenant
+	if !configService.ResolveBoolOrDefault(r.Context(), rs.SettingsService, configModel.KeyFeedbackEnabled, false, slog.Default()) {
+		common.RenderError(w, r, ErrorForbidden(errors.New("feature_disabled")))
+		return
+	}
+
 	// Parse student ID from URL
 	studentID, err := common.ParseID(r)
 	if err != nil {

--- a/backend/api/feedback/errors.go
+++ b/backend/api/feedback/errors.go
@@ -75,3 +75,13 @@ func ErrorInternalServer(err error) render.Renderer {
 		ErrorText:      err.Error(),
 	}
 }
+
+// ErrorForbidden returns an ErrResponse for forbidden requests
+func ErrorForbidden(err error) render.Renderer {
+	return &ErrResponse{
+		Err:            err,
+		HTTPStatusCode: http.StatusForbidden,
+		StatusText:     "Forbidden",
+		ErrorText:      err.Error(),
+	}
+}

--- a/backend/api/feedback/errors_test.go
+++ b/backend/api/feedback/errors_test.go
@@ -80,6 +80,16 @@ func TestErrorInternalServer(t *testing.T) {
 	assert.Equal(t, "database error", resp.ErrorText)
 }
 
+func TestErrorForbidden(t *testing.T) {
+	testErr := errors.New("feature_disabled")
+	renderer := feedback.ErrorForbidden(testErr)
+	resp, ok := renderer.(*feedback.ErrResponse)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusForbidden, resp.HTTPStatusCode)
+	assert.Equal(t, "Forbidden", resp.StatusText)
+	assert.Equal(t, "feature_disabled", resp.ErrorText)
+}
+
 func TestErrResponse_Render(t *testing.T) {
 	errResp := &feedback.ErrResponse{
 		Err:            errors.New("test error"),

--- a/backend/api/feedback/feedback_test.go
+++ b/backend/api/feedback/feedback_test.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 
 	feedbackAPI "github.com/moto-nrw/project-phoenix/api/feedback"
 	"github.com/moto-nrw/project-phoenix/api/testutil"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/services"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
@@ -35,6 +37,18 @@ func setupTestContext(t *testing.T) *testContext {
 		services: svc,
 		resource: resource,
 	}
+}
+
+// enableFeedback turns on the feedback feature for tenant 1
+// via a real DB setting override. Cleanup is deferred automatically.
+func enableFeedback(t *testing.T, ctx *testContext) {
+	t.Helper()
+	tenantCtx := testpkg.TenantContext(1)
+	err := ctx.services.Settings.SetValue(tenantCtx, configModel.KeyFeedbackEnabled, true, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = ctx.services.Settings.ResetValue(tenantCtx, configModel.KeyFeedbackEnabled, nil, nil)
+	})
 }
 
 // =============================================================================
@@ -154,6 +168,7 @@ func TestGetFeedback_InvalidID(t *testing.T) {
 func TestGetStudentFeedback_Success(t *testing.T) {
 	ctx := setupTestContext(t)
 	defer func() { _ = ctx.db.Close() }()
+	enableFeedback(t, ctx)
 
 	// Create test student
 	student := testpkg.CreateTestStudent(t, ctx.db, "Feedback", "Student", "1a")
@@ -175,6 +190,7 @@ func TestGetStudentFeedback_Success(t *testing.T) {
 func TestGetStudentFeedback_InvalidID(t *testing.T) {
 	ctx := setupTestContext(t)
 	defer func() { _ = ctx.db.Close() }()
+	enableFeedback(t, ctx)
 
 	router := chi.NewRouter()
 	router.Get("/feedback/student/{id}", ctx.resource.GetStudentFeedbackHandler())

--- a/backend/api/feedback/feedback_test.go
+++ b/backend/api/feedback/feedback_test.go
@@ -28,7 +28,7 @@ func setupTestContext(t *testing.T) *testContext {
 
 	db, svc := testutil.SetupAPITest(t)
 
-	resource := feedbackAPI.NewResource(svc.Feedback, db)
+	resource := feedbackAPI.NewResource(svc.Feedback, svc.Settings, db)
 
 	return &testContext{
 		db:       db,

--- a/backend/api/iot/checkin/handlers.go
+++ b/backend/api/iot/checkin/handlers.go
@@ -322,7 +322,7 @@ func (rs *Resource) deviceCheckin(w http.ResponseWriter, r *http.Request) {
 		result.DailyCheckoutAvailable = rs.shouldShowDailyCheckoutWithGroup(ctx, student, currentVisit)
 
 		// Resolve feedback_enabled so PyrePortal knows whether to show the feedback modal
-		result.FeedbackEnabled = true // default
+		result.FeedbackEnabled = false // default: opt-in (GDPR)
 		if rs.SettingsService != nil {
 			if val, err := rs.SettingsService.ResolveBool(ctx, configModel.KeyFeedbackEnabled); err == nil {
 				result.FeedbackEnabled = val

--- a/backend/api/iot/config.go
+++ b/backend/api/iot/config.go
@@ -46,7 +46,7 @@ func (rs *Resource) getDeviceConfig(w http.ResponseWriter, r *http.Request) {
 	raumwechsel := true
 	schulhof := true
 	wc := true
-	feedbackEnabled := true
+	feedbackEnabled := false
 
 	if rs.SettingsService != nil {
 		if val, err := rs.SettingsService.ResolveBool(r.Context(), configModel.KeyCheckoutRaumwechselEnabled); err == nil {

--- a/backend/api/iot/config_test.go
+++ b/backend/api/iot/config_test.go
@@ -253,12 +253,13 @@ func TestGetDeviceConfig_NilSettingsService(t *testing.T) {
 	data := response["data"].(map[string]any)
 	checkout := data["checkout"].(map[string]any)
 
-	// All defaults to true when no settings service
+	// Checkout buttons default to true when no settings service
 	assert.Equal(t, true, checkout["raumwechsel_enabled"])
 	assert.Equal(t, true, checkout["schulhof_enabled"])
 	assert.Equal(t, true, checkout["wc_enabled"])
 	assert.Nil(t, checkout["daily_checkout_time"])
 
+	// Feedback defaults to false (opt-in / GDPR) when no settings service
 	feedback := data["feedback"].(map[string]any)
-	assert.Equal(t, true, feedback["enabled"])
+	assert.Equal(t, false, feedback["enabled"])
 }

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -396,6 +396,7 @@ func (rs *Resource) getStudent(w http.ResponseWriter, r *http.Request) {
 	hasFullAccess := rs.checkStudentFullAccess(r, student)
 
 	attendanceLogEnabled := configService.ResolveBoolOrDefault(r.Context(), rs.SettingsService, configModel.KeyAttendanceLogEnabled, false, rs.Logger)
+	feedbackEnabled := configService.ResolveBoolOrDefault(r.Context(), rs.SettingsService, configModel.KeyFeedbackEnabled, false, rs.Logger)
 
 	response := StudentDetailResponse{
 		StudentResponse: newStudentResponseWithOpts(r.Context(), StudentResponseOpts{
@@ -409,6 +410,7 @@ func (rs *Resource) getStudent(w http.ResponseWriter, r *http.Request) {
 		}),
 		HasFullAccess:        hasFullAccess,
 		AttendanceLogEnabled: attendanceLogEnabled,
+		FeedbackEnabled:      feedbackEnabled,
 	}
 
 	// Add supervisor contacts for users without full access

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -55,6 +55,7 @@ type StudentDetailResponse struct {
 	HasFullAccess        bool                `json:"has_full_access"`
 	GroupSupervisors     []SupervisorContact `json:"group_supervisors,omitempty"`
 	AttendanceLogEnabled bool                `json:"attendance_log_enabled"`
+	FeedbackEnabled      bool                `json:"feedback_enabled"`
 }
 
 // StudentRequest represents a student creation request with person details

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -30,6 +30,8 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"gdpr.attendance_visible_days",
 		"gdpr.room_detail_visible_days",
 		"gdpr.attendance_log_scope",
+		"feedback.enabled",
+		"feedback.data_retention_days",
 		"security.ogs_device_pin",
 		"checkout.raumwechsel_enabled",
 		"checkout.schulhof_enabled",
@@ -44,7 +46,7 @@ func TestAllSettingsRegistered(t *testing.T) {
 		assert.NotEmpty(t, def.Category, "setting %q should have a category", key)
 	}
 
-	assert.GreaterOrEqual(t, len(all), 18, "at least 18 settings should be registered")
+	assert.GreaterOrEqual(t, len(all), 20, "at least 20 settings should be registered")
 }
 
 func TestOperationsSettings_Types(t *testing.T) {
@@ -80,6 +82,8 @@ func TestGDPRSettings_Types(t *testing.T) {
 		{"gdpr.attendance_visible_days", config.FieldNumber},
 		{"gdpr.room_detail_visible_days", config.FieldNumber},
 		{"gdpr.attendance_log_scope", config.FieldSelect},
+		{"feedback.enabled", config.FieldBoolean},
+		{"feedback.data_retention_days", config.FieldNumber},
 	}
 
 	for _, tc := range tests {
@@ -154,6 +158,25 @@ func TestDependsOn_AttendanceLogGroup(t *testing.T) {
 	}
 }
 
+func TestDependsOn_FeedbackGroup(t *testing.T) {
+	retentionDef := config.GetDefinition("feedback.data_retention_days")
+	require.NotNil(t, retentionDef)
+	require.NotNil(t, retentionDef.DependsOn)
+	assert.Equal(t, "feedback.enabled", retentionDef.DependsOn.Key)
+	assert.Equal(t, "eq", retentionDef.DependsOn.Condition)
+	assert.Equal(t, true, retentionDef.DependsOn.Value)
+}
+
+func TestFeedbackSettings(t *testing.T) {
+	def := config.GetDefinition("feedback.enabled")
+	require.NotNil(t, def)
+	assert.Equal(t, config.FieldBoolean, def.Type)
+	assert.Equal(t, "gdpr", def.Tab)
+	assert.Equal(t, "feedback", def.Category)
+	assert.Equal(t, false, def.Default, "feedback should default to false (opt-in)")
+	assert.Equal(t, "config:manage", def.WritePermission)
+}
+
 func TestAttendanceLogScope_Options(t *testing.T) {
 	def := config.GetDefinition("gdpr.attendance_log_scope")
 	require.NotNil(t, def)
@@ -205,6 +228,7 @@ func TestValidation_NumberFields(t *testing.T) {
 		"gdpr.data_cleanup_timeout_minutes",
 		"gdpr.attendance_visible_days",
 		"gdpr.room_detail_visible_days",
+		"feedback.data_retention_days",
 	}
 
 	for _, key := range numberKeys {
@@ -235,6 +259,8 @@ func TestDefaults_HaveReasonableValues(t *testing.T) {
 		{"gdpr.attendance_visible_days", 30},
 		{"gdpr.room_detail_visible_days", 7},
 		{"gdpr.attendance_log_scope", config.AttendanceLogScopeGroupSupervisorsOnly},
+		{"feedback.enabled", false},
+		{"feedback.data_retention_days", 90},
 		{"security.ogs_device_pin", "1234"},
 		{"checkout.raumwechsel_enabled", true},
 		{"checkout.schulhof_enabled", false},

--- a/backend/services/config/defaults/feedback.go
+++ b/backend/services/config/defaults/feedback.go
@@ -8,14 +8,14 @@ func init() {
 	config.Register(config.Definition{
 		Key:             config.KeyFeedbackEnabled,
 		Label:           "Feedback aktiviert",
-		Description:     "Feedback-Modal beim täglichen Checkout anzeigen",
+		Description:     "Ermöglicht das Erfassen und Anzeigen von Feedback. Feedback-Modal beim täglichen Checkout und Feedbackhistorie in der Schülerdetailansicht. Aus Datenschutzgründen standardmäßig deaktiviert.",
 		Type:            config.FieldBoolean,
-		Default:         true,
+		Default:         false,
 		ReadPermission:  "config:read",
-		WritePermission: "config:update",
-		Tab:             "operations",
+		WritePermission: "config:manage",
+		Tab:             "gdpr",
 		Category:        "feedback",
-		SortOrder:       1,
+		SortOrder:       20,
 	})
 
 	minDays := float64(7)
@@ -30,7 +30,8 @@ func init() {
 		WritePermission: "config:manage",
 		Tab:             "gdpr",
 		Category:        "feedback",
-		SortOrder:       10,
+		SortOrder:       21,
 		Validation:      &config.ValidationRules{Min: &minDays, Max: &maxDays},
+		DependsOn:       &config.Dependency{Key: config.KeyFeedbackEnabled, Condition: "eq", Value: true},
 	})
 }

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/components/HistoryLinks.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/components/HistoryLinks.test.tsx
@@ -24,29 +24,50 @@ vi.mock("~/lib/tenant-router", () => ({
 
 describe("HistoryLinks", () => {
   it("renders Historien title", () => {
-    render(<HistoryLinks studentId="42" attendanceLogEnabled={false} />);
+    render(
+      <HistoryLinks
+        studentId="42"
+        attendanceLogEnabled={false}
+        feedbackEnabled={false}
+      />,
+    );
     expect(screen.getByText("Historien")).toBeInTheDocument();
   });
 
   it("renders all three history link buttons", () => {
-    render(<HistoryLinks studentId="42" attendanceLogEnabled={true} />);
+    render(
+      <HistoryLinks
+        studentId="42"
+        attendanceLogEnabled={true}
+        feedbackEnabled={true}
+      />,
+    );
 
     expect(screen.getByText("Anwesenheitsprotokoll")).toBeInTheDocument();
     expect(screen.getByText("Feedbackhistorie")).toBeInTheDocument();
     expect(screen.getByText("Mensaverlauf")).toBeInTheDocument();
   });
 
-  it("feedback and mensa buttons remain disabled", () => {
-    render(<HistoryLinks studentId="42" attendanceLogEnabled={true} />);
+  it("mensa button remains disabled", () => {
+    render(
+      <HistoryLinks
+        studentId="42"
+        attendanceLogEnabled={true}
+        feedbackEnabled={true}
+      />,
+    );
 
-    expect(
-      screen.getByText("Feedbackhistorie").closest("button"),
-    ).toBeDisabled();
     expect(screen.getByText("Mensaverlauf").closest("button")).toBeDisabled();
   });
 
   it("raumverlauf button is enabled when attendanceLogEnabled is true", () => {
-    render(<HistoryLinks studentId="42" attendanceLogEnabled={true} />);
+    render(
+      <HistoryLinks
+        studentId="42"
+        attendanceLogEnabled={true}
+        feedbackEnabled={false}
+      />,
+    );
 
     const raumButton = screen
       .getByText("Anwesenheitsprotokoll")
@@ -58,12 +79,61 @@ describe("HistoryLinks", () => {
   });
 
   it("raumverlauf button is disabled when attendanceLogEnabled is false", () => {
-    render(<HistoryLinks studentId="42" attendanceLogEnabled={false} />);
+    render(
+      <HistoryLinks
+        studentId="42"
+        attendanceLogEnabled={false}
+        feedbackEnabled={false}
+      />,
+    );
 
     const raumButton = screen
       .getByText("Anwesenheitsprotokoll")
       .closest("button");
     expect(raumButton).toBeDisabled();
-    expect(screen.getByText("Für Ihre Schule deaktiviert")).toBeInTheDocument();
+  });
+
+  it("feedback button is enabled when feedbackEnabled is true", () => {
+    render(
+      <HistoryLinks
+        studentId="42"
+        attendanceLogEnabled={false}
+        feedbackEnabled={true}
+      />,
+    );
+
+    const feedbackButton = screen
+      .getByText("Feedbackhistorie")
+      .closest("button");
+    expect(feedbackButton).not.toBeDisabled();
+    expect(screen.getByText("Feedback und Bewertungen")).toBeInTheDocument();
+  });
+
+  it("feedback button is disabled when feedbackEnabled is false", () => {
+    render(
+      <HistoryLinks
+        studentId="42"
+        attendanceLogEnabled={false}
+        feedbackEnabled={false}
+      />,
+    );
+
+    const feedbackButton = screen
+      .getByText("Feedbackhistorie")
+      .closest("button");
+    expect(feedbackButton).toBeDisabled();
+  });
+
+  it("shows deaktiviert text for disabled features", () => {
+    render(
+      <HistoryLinks
+        studentId="42"
+        attendanceLogEnabled={false}
+        feedbackEnabled={false}
+      />,
+    );
+
+    const deactivatedTexts = screen.getAllByText("Für Ihre Schule deaktiviert");
+    expect(deactivatedTexts).toHaveLength(2);
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/components/HistoryLinks.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/components/HistoryLinks.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { HistoryLinks } from "./HistoryLinks";
 
@@ -18,11 +18,16 @@ vi.mock("~/components/ui/info-card", () => ({
   ),
 }));
 
+const mockPush = vi.fn();
 vi.mock("~/lib/tenant-router", () => ({
-  useTenantRouter: () => ({ push: vi.fn() }),
+  useTenantRouter: () => ({ push: mockPush }),
 }));
 
 describe("HistoryLinks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders Historien title", () => {
     render(
       <HistoryLinks
@@ -135,5 +140,22 @@ describe("HistoryLinks", () => {
 
     const deactivatedTexts = screen.getAllByText("Für Ihre Schule deaktiviert");
     expect(deactivatedTexts).toHaveLength(2);
+  });
+
+  it("navigates to feedback history when feedback button is clicked", () => {
+    render(
+      <HistoryLinks
+        studentId="42"
+        attendanceLogEnabled={false}
+        feedbackEnabled={true}
+      />,
+    );
+
+    const feedbackButton = screen
+      .getByText("Feedbackhistorie")
+      .closest("button");
+    fireEvent.click(feedbackButton!);
+
+    expect(mockPush).toHaveBeenCalledWith("/students/42/feedback_history");
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/components/HistoryLinks.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/components/HistoryLinks.tsx
@@ -12,16 +12,22 @@ interface HistoryLinksProps {
    * `gdpr.attendance_log_enabled` setting.
    */
   readonly attendanceLogEnabled: boolean;
+  /**
+   * When true, the Feedbackhistorie button is active and navigates to the
+   * feedback history page. Should mirror the tenant's `feedback.enabled` setting.
+   */
+  readonly feedbackEnabled: boolean;
 }
 
 /**
  * History links section. The Raumverlauf button is gated by the tenant's
- * GDPR setting; feedback and mensa history are future features and remain
- * disabled as visual placeholders.
+ * GDPR setting; the Feedbackhistorie button is gated by the tenant's
+ * feedback.enabled setting; mensa history remains a disabled placeholder.
  */
 export function HistoryLinks({
   studentId,
   attendanceLogEnabled,
+  feedbackEnabled,
 }: HistoryLinksProps) {
   const router = useTenantRouter();
 
@@ -48,8 +54,17 @@ export function HistoryLinks({
           icon={<ChatIcon />}
           iconBgColor="bg-[#83CD2D]"
           title="Feedbackhistorie"
-          subtitle="Feedback und Bewertungen"
-          disabled
+          subtitle={
+            feedbackEnabled
+              ? "Feedback und Bewertungen"
+              : "Für Ihre Schule deaktiviert"
+          }
+          disabled={!feedbackEnabled}
+          onClick={
+            feedbackEnabled
+              ? () => router.push(`/students/${studentId}/feedback_history`)
+              : undefined
+          }
         />
         <HistoryLinkButton
           icon={<ForkKnifeIcon />}

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/feedback_history/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/feedback_history/page.tsx
@@ -85,10 +85,17 @@ export default function StudentFeedbackHistoryPage() {
         setFeedbackHistory(feedbackData);
       } catch (err) {
         if (cancelled) return;
+        const errMsg = err instanceof Error ? err.message : String(err);
         logger.error("failed_to_fetch_feedback_history", {
-          error: err instanceof Error ? err.message : String(err),
+          error: errMsg,
         });
-        setError("Fehler beim Laden der Daten.");
+        if (errMsg === "feature_disabled") {
+          setError(
+            "Diese Funktion ist für Ihre Schule deaktiviert. Sie kann in den Einstellungen unter Datenschutz aktiviert werden.",
+          );
+        } else {
+          setError("Fehler beim Laden der Daten.");
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -58,6 +58,7 @@ export default function StudentDetailPage() {
     error,
     hasFullAccess,
     attendanceLogEnabled,
+    feedbackEnabled,
     supervisors,
     myGroups,
     myGroupRooms,
@@ -403,6 +404,7 @@ export default function StudentDetailPage() {
             student={student}
             studentId={studentId}
             attendanceLogEnabled={attendanceLogEnabled}
+            feedbackEnabled={feedbackEnabled}
             showCheckout={showCheckout}
             showCheckin={showCheckin}
             showPersonalInfoModal={showPersonalInfoModal}
@@ -420,6 +422,7 @@ export default function StudentDetailPage() {
             student={student}
             studentId={studentId}
             attendanceLogEnabled={attendanceLogEnabled}
+            feedbackEnabled={feedbackEnabled}
             supervisors={supervisors}
             showCheckout={showCheckout}
             showCheckin={showCheckin}
@@ -509,6 +512,7 @@ interface LimitedAccessViewProps {
   student: ExtendedStudent;
   studentId: string;
   attendanceLogEnabled: boolean;
+  feedbackEnabled: boolean;
   supervisors: SupervisorContact[];
   showCheckout: boolean;
   showCheckin: boolean;
@@ -520,6 +524,7 @@ function LimitedAccessView({
   student,
   studentId,
   attendanceLogEnabled,
+  feedbackEnabled,
   supervisors,
   showCheckout,
   showCheckin,
@@ -555,6 +560,7 @@ function LimitedAccessView({
       <StudentHistorySection
         studentId={studentId}
         attendanceLogEnabled={attendanceLogEnabled}
+        feedbackEnabled={feedbackEnabled}
         onNavigate={(path) => historyRouter.push(path)}
       />
     </div>
@@ -569,6 +575,7 @@ interface FullAccessViewProps {
   student: ExtendedStudent;
   studentId: string;
   attendanceLogEnabled: boolean;
+  feedbackEnabled: boolean;
   showCheckout: boolean;
   showCheckin: boolean;
   showPersonalInfoModal: boolean;
@@ -586,6 +593,7 @@ function FullAccessView({
   student,
   studentId,
   attendanceLogEnabled,
+  feedbackEnabled,
   showCheckout,
   showCheckin,
   showPersonalInfoModal,
@@ -639,6 +647,7 @@ function FullAccessView({
         <StudentHistorySection
           studentId={studentId}
           attendanceLogEnabled={attendanceLogEnabled}
+          feedbackEnabled={feedbackEnabled}
           onNavigate={(path) => historyRouter.push(path)}
         />
       </div>

--- a/frontend/src/app/api/feedback/student/[id]/route.test.ts
+++ b/frontend/src/app/api/feedback/student/[id]/route.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Session } from "next-auth";
+import { NextRequest } from "next/server";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ExtendedSession extends Session {
+  user: Session["user"] & { token?: string };
+}
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const { mockAuth, mockApiGet } = vi.hoisted(() => ({
+  mockAuth: vi.fn<() => Promise<ExtendedSession | null>>(),
+  mockApiGet: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("~/lib/api-helpers", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, apiGet: mockApiGet };
+});
+
+const { GET } = await import("./route");
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createMockRequest(path: string): NextRequest {
+  const url = new URL(path, "http://localhost:3000");
+  return new NextRequest(url);
+}
+
+const defaultSession: ExtendedSession = {
+  user: { id: "1", token: "test-token", name: "Test User" },
+  expires: "2099-01-01",
+};
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("GET /api/feedback/student/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(defaultSession);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+
+    const request = createMockRequest("/api/feedback/student/123");
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    const json = await parseJsonResponse<{ error: string }>(response);
+    expect(json.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 when session has no token", async () => {
+    mockAuth.mockResolvedValueOnce({
+      user: { id: "1", name: "Test User" },
+      expires: "2099-01-01",
+    } as ExtendedSession);
+
+    const request = createMockRequest("/api/feedback/student/123");
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when student ID is missing from path", async () => {
+    const request = createMockRequest("/api/feedback/other/path");
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+    const json = await parseJsonResponse<{ error: string }>(response);
+    expect(json.error).toBe("Invalid id parameter");
+  });
+
+  it("returns feedback data on success", async () => {
+    const backendResponse = {
+      data: [
+        {
+          id: 10,
+          value: "positive",
+          day: "2026-04-01",
+          time: "15:30:23",
+          student_id: 123,
+          is_mensa_feedback: false,
+          created_at: "2026-04-01T15:30:23Z",
+          updated_at: "2026-04-01T15:30:23Z",
+        },
+      ],
+    };
+    mockApiGet.mockResolvedValueOnce(backendResponse);
+
+    const request = createMockRequest("/api/feedback/student/123");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mockApiGet).toHaveBeenCalledWith(
+      "/api/feedback/student/123",
+      "test-token",
+    );
+
+    const json = await parseJsonResponse<{
+      status: string;
+      data: unknown[];
+    }>(response);
+    expect(json.status).toBe("success");
+    expect(json.data).toHaveLength(1);
+
+    // Verify Cache-Control header
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("returns 403 when backend returns feature_disabled", async () => {
+    mockApiGet.mockRejectedValueOnce(
+      new Error("API error (403): feature_disabled"),
+    );
+
+    const request = createMockRequest("/api/feedback/student/123");
+    const response = await GET(request);
+
+    expect(response.status).toBe(403);
+    const json = await parseJsonResponse<{ error: string }>(response);
+    expect(json.error).toBe("feature_disabled");
+  });
+
+  it("returns 404 when backend returns not found", async () => {
+    mockApiGet.mockRejectedValueOnce(new Error("API error (404): not found"));
+
+    const request = createMockRequest("/api/feedback/student/123");
+    const response = await GET(request);
+
+    expect(response.status).toBe(404);
+    const json = await parseJsonResponse<{ error: string }>(response);
+    expect(json.error).toBe("not_found");
+  });
+
+  it("returns 500 on generic backend error", async () => {
+    mockApiGet.mockRejectedValueOnce(new Error("Network failure"));
+
+    const request = createMockRequest("/api/feedback/student/123");
+    const response = await GET(request);
+
+    expect(response.status).toBe(500);
+    const json = await parseJsonResponse<{ error: string }>(response);
+    expect(json.error).toContain("Network failure");
+  });
+
+  it("extracts status code from API error message", async () => {
+    mockApiGet.mockRejectedValueOnce(new Error("API error (502): Bad Gateway"));
+
+    const request = createMockRequest("/api/feedback/student/123");
+    const response = await GET(request);
+
+    expect(response.status).toBe(502);
+  });
+
+  it("handles non-Error thrown values", async () => {
+    mockApiGet.mockRejectedValueOnce("string error");
+
+    const request = createMockRequest("/api/feedback/student/123");
+    const response = await GET(request);
+
+    expect(response.status).toBe(500);
+    const json = await parseJsonResponse<{ error: string }>(response);
+    expect(json.error).toContain("string error");
+  });
+});

--- a/frontend/src/app/api/feedback/student/[id]/route.ts
+++ b/frontend/src/app/api/feedback/student/[id]/route.ts
@@ -1,5 +1,10 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { apiGet } from "~/lib/api-helpers";
-import { createGetHandler } from "~/lib/route-wrapper";
+import { createLogger } from "~/lib/logger";
+import { auth } from "~/server/auth";
+
+const logger = createLogger({ component: "StudentFeedbackRoute" });
 
 interface BackendFeedbackEntry {
   id: number;
@@ -23,11 +28,61 @@ interface BackendFeedbackResponse {
   message: string;
 }
 
-export const GET = createGetHandler(async (_request, token: string, params) => {
-  const studentId = params.id as string;
-  const response = await apiGet<BackendFeedbackResponse>(
-    `/api/feedback/student/${studentId}`,
-    token,
-  );
-  return response.data;
-});
+/**
+ * Proxy for GET /api/feedback/student/[id].
+ *
+ * The backend enforces the feature flag (`feedback.enabled`). When the
+ * feature is disabled, it returns 403 with "feature_disabled". We forward
+ * this error code so the frontend page can show the appropriate message.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const session = await auth();
+
+  if (!session?.user?.token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const pathParts = request.nextUrl.pathname.split("/");
+  const studentIndex = pathParts.indexOf("student");
+  const studentId = studentIndex >= 0 ? pathParts[studentIndex + 1] : undefined;
+
+  if (!studentId) {
+    return NextResponse.json(
+      { error: "Invalid id parameter" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const response = await apiGet<BackendFeedbackResponse>(
+      `/api/feedback/student/${studentId}`,
+      session.user.token,
+    );
+    return NextResponse.json(
+      { status: "success", data: response.data },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (apiError) {
+    const message =
+      apiError instanceof Error ? apiError.message : String(apiError);
+
+    const statusMatch = message.match(/API error \((\d+)\)/);
+    const status = statusMatch?.[1] ? Number.parseInt(statusMatch[1], 10) : 500;
+
+    if (status === 403) {
+      return NextResponse.json({ error: "feature_disabled" }, { status: 403 });
+    }
+    if (status === 404) {
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    }
+
+    logger.error("feedback_fetch_failed", {
+      student_id: studentId,
+      error: message,
+    });
+    return NextResponse.json(
+      { error: `Backend API error: ${message}` },
+      { status },
+    );
+  }
+}

--- a/frontend/src/app/api/students/[id]/route.ts
+++ b/frontend/src/app/api/students/[id]/route.ts
@@ -109,6 +109,8 @@ export const GET = createGetHandler(
       const groupSupervisors = studentData.group_supervisors ?? [];
       const attendanceLogEnabled =
         (studentData.attendance_log_enabled as boolean) ?? false;
+      const feedbackEnabled =
+        (studentData.feedback_enabled as boolean) ?? false;
 
       // Check if we need to extract last_name from the name field
       if (!studentData.last_name && studentData.name) {
@@ -135,6 +137,7 @@ export const GET = createGetHandler(
         has_full_access: hasFullAccess,
         group_supervisors: groupSupervisors,
         attendance_log_enabled: attendanceLogEnabled,
+        feedback_enabled: feedbackEnabled,
       };
     } catch (error) {
       logger.error("student fetch failed", {

--- a/frontend/src/components/students/student-detail-components.test.tsx
+++ b/frontend/src/components/students/student-detail-components.test.tsx
@@ -549,6 +549,7 @@ describe("StudentHistorySection", () => {
   const defaultProps = {
     studentId: "123",
     attendanceLogEnabled: true,
+    feedbackEnabled: true,
     onNavigate: vi.fn(),
   };
 
@@ -573,13 +574,12 @@ describe("StudentHistorySection", () => {
       <StudentHistorySection {...defaultProps} attendanceLogEnabled={false} />,
     );
     expect(screen.getByText("Anwesenheitsprotokoll")).toBeInTheDocument();
-    expect(screen.getByText("Für Ihre Schule deaktiviert")).toBeInTheDocument();
     expect(
       screen.getByText("Anwesenheitsprotokoll").closest("button"),
     ).toBeDisabled();
   });
 
-  it("renders feedback history button as enabled", () => {
+  it("renders feedback history button as enabled when feature is on", () => {
     render(<StudentHistorySection {...defaultProps} />);
     expect(screen.getByText("Feedbackhistorie")).toBeInTheDocument();
     expect(screen.getByText("Feedback und Bewertungen")).toBeInTheDocument();
@@ -587,6 +587,14 @@ describe("StudentHistorySection", () => {
       .getByText("Feedbackhistorie")
       .closest("button");
     expect(feedbackButton).not.toBeDisabled();
+  });
+
+  it("renders feedback history button as disabled when feature is off", () => {
+    render(<StudentHistorySection {...defaultProps} feedbackEnabled={false} />);
+    expect(screen.getByText("Feedbackhistorie")).toBeInTheDocument();
+    expect(
+      screen.getByText("Feedbackhistorie").closest("button"),
+    ).toBeDisabled();
   });
 
   it("renders meal history button as disabled", () => {
@@ -602,6 +610,7 @@ describe("StudentHistorySection", () => {
       <StudentHistorySection
         studentId="456"
         attendanceLogEnabled={true}
+        feedbackEnabled={true}
         onNavigate={onNavigate}
       />,
     );
@@ -618,6 +627,7 @@ describe("StudentHistorySection", () => {
       <StudentHistorySection
         studentId="456"
         attendanceLogEnabled={false}
+        feedbackEnabled={true}
         onNavigate={onNavigate}
       />,
     );
@@ -628,12 +638,13 @@ describe("StudentHistorySection", () => {
     expect(onNavigate).not.toHaveBeenCalled();
   });
 
-  it("feedback button navigates on click", () => {
+  it("feedback button navigates on click when enabled", () => {
     const onNavigate = vi.fn();
     render(
       <StudentHistorySection
         studentId="456"
         attendanceLogEnabled={true}
+        feedbackEnabled={true}
         onNavigate={onNavigate}
       />,
     );

--- a/frontend/src/components/students/student-detail-components.tsx
+++ b/frontend/src/components/students/student-detail-components.tsx
@@ -577,18 +577,20 @@ function HistoryButton({
 interface StudentHistorySectionProps {
   studentId: string;
   attendanceLogEnabled: boolean;
+  feedbackEnabled: boolean;
   onNavigate: (path: string) => void;
 }
 
 /**
  * History section on the student detail page. The Anwesenheitsprotokoll button
- * is gated by the tenant's `gdpr.attendance_log_enabled` setting. Scope checks
- * (group supervisor) are handled by the destination page. Mensa history remains
- * a disabled placeholder (future feature).
+ * is gated by the tenant's `gdpr.attendance_log_enabled` setting. The
+ * Feedbackhistorie button is gated by the tenant's `feedback.enabled` setting.
+ * Mensa history remains a disabled placeholder (future feature).
  */
 export function StudentHistorySection({
   studentId,
   attendanceLogEnabled,
+  feedbackEnabled,
   onNavigate,
 }: Readonly<StudentHistorySectionProps>) {
   return (
@@ -613,9 +615,18 @@ export function StudentHistorySection({
         <HistoryButton
           icon={<ChatIcon />}
           title="Feedbackhistorie"
-          description="Feedback und Bewertungen"
+          description={
+            feedbackEnabled
+              ? "Feedback und Bewertungen"
+              : "Für Ihre Schule deaktiviert"
+          }
           bgColor="bg-[#83CD2D]"
-          onClick={() => onNavigate(`/students/${studentId}/feedback_history`)}
+          disabled={!feedbackEnabled}
+          onClick={
+            feedbackEnabled
+              ? () => onNavigate(`/students/${studentId}/feedback_history`)
+              : undefined
+          }
         />
         <HistoryButton
           icon={<ForkKnifeIcon />}

--- a/frontend/src/lib/feedback-api.test.ts
+++ b/frontend/src/lib/feedback-api.test.ts
@@ -75,6 +75,16 @@ describe("fetchStudentFeedback", () => {
     expect(result).toEqual([]);
   });
 
+  it("throws feature_disabled on 403", async () => {
+    mockSessionFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+    });
+
+    await expect(fetchStudentFeedback("1")).rejects.toThrow("feature_disabled");
+  });
+
   it("throws on non-404 error", async () => {
     mockSessionFetch.mockResolvedValue({
       ok: false,

--- a/frontend/src/lib/feedback-api.ts
+++ b/frontend/src/lib/feedback-api.ts
@@ -47,6 +47,9 @@ export async function fetchStudentFeedback(
 
     if (!response.ok) {
       if (response.status === 404) return [];
+      if (response.status === 403) {
+        throw new Error("feature_disabled");
+      }
       throw new Error(
         `Failed to fetch feedback: ${response.status} ${response.statusText}`,
       );

--- a/frontend/src/lib/hooks/use-student-data.ts
+++ b/frontend/src/lib/hooks/use-student-data.ts
@@ -33,6 +33,7 @@ interface StudentDataState {
   error: string | null;
   hasFullAccess: boolean;
   attendanceLogEnabled: boolean;
+  feedbackEnabled: boolean;
   supervisors: SupervisorContact[];
   myGroups: string[];
   myGroupRooms: string[];
@@ -103,6 +104,7 @@ interface StudentDetailResponse {
   student: ExtendedStudent;
   hasFullAccess: boolean;
   attendanceLogEnabled: boolean;
+  feedbackEnabled: boolean;
   supervisors: SupervisorContact[];
   myGroups: string[];
   myGroupRooms: string[];
@@ -153,11 +155,13 @@ export function useStudentData(studentId: string): UseStudentDataResult {
         has_full_access?: boolean;
         group_supervisors?: SupervisorContact[];
         attendance_log_enabled?: boolean;
+        feedback_enabled?: boolean;
       };
 
       const hasAccess = mappedStudent.has_full_access ?? false;
       const attendanceLogEnabled =
         mappedStudent.attendance_log_enabled ?? false;
+      const feedbackEnabled = mappedStudent.feedback_enabled ?? false;
       const groupSupervisors = mappedStudent.group_supervisors ?? [];
       const extendedStudent = mapStudentResponse(studentResponse, hasAccess);
 
@@ -169,6 +173,7 @@ export function useStudentData(studentId: string): UseStudentDataResult {
         student: extendedStudent,
         hasFullAccess: hasAccess,
         attendanceLogEnabled,
+        feedbackEnabled,
         supervisors: groupSupervisors,
         myGroups: groupIds,
         myGroupRooms: ogsGroupRoomNames,
@@ -205,6 +210,7 @@ export function useStudentData(studentId: string): UseStudentDataResult {
     error,
     hasFullAccess: studentData?.hasFullAccess ?? true,
     attendanceLogEnabled: studentData?.attendanceLogEnabled ?? false,
+    feedbackEnabled: studentData?.feedbackEnabled ?? false,
     supervisors: studentData?.supervisors ?? [],
     myGroups: studentData?.myGroups ?? [],
     myGroupRooms: studentData?.myGroupRooms ?? [],


### PR DESCRIPTION
## Summary
- Change `feedback.enabled` setting default from `true` to `false` (opt-in), mirroring the Anwesenheitsprotokoll pattern
- Move setting to GDPR tab with `config:manage` permission; add `DependsOn` for `feedback.data_retention_days`
- Gate feedback history API (`GET /api/feedback/student/{id}`) with 403 `feature_disabled` and gate the frontend button with "Für Ihre Schule deaktiviert"
- Align IoT fallback defaults to `false` (fail-closed) in config, checkin, and feedback handlers

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./services/config/defaults/...` — all 15 tests pass (includes new feedback settings tests)
- [x] `go test ./api/iot/...` — all IoT tests pass (including updated `NilSettingsService` test)
- [x] `pnpm run check` — oxlint 0 errors, tsc 0 errors
- [x] Pre-push hooks all green (golangci-lint, go-vet, go-deadcode, frontend-knip, frontend-check)
- [ ] Verify feedback history button shows "Für Ihre Schule deaktiviert" when `feedback.enabled` is off
- [ ] Verify enabling `feedback.enabled` in GDPR settings activates the button and allows IoT feedback
- [ ] Verify PyrePortal receives `feedback.enabled: false` by default and skips feedback modal