### PR TITLE
Remove Schulhof room and outdoor activities from seeder

### DIFF
--- a/backend/seed/api/data.go
+++ b/backend/seed/api/data.go
@@ -48,7 +48,6 @@ func floor(f int) *int { return &f }
 //
 //	Hauptgebäude: EG (Mensa, Aula, OGS-1), 1.OG (OGS-2, OGS-3, Kreativ, Musik), 2.OG (Werk, Lese)
 //	Sporthalle: EG (Sporthalle, Bewegungsraum)
-//	Außenbereich: Schulhof (no floor)
 var DemoRooms = []DemoRoom{
 	// Hauptgebäude - Erdgeschoss (Ground Floor)
 	{Name: "OGS-Raum 1", Category: "Gruppenraum", Capacity: 25, Building: "Hauptgebäude", Floor: floor(0)},
@@ -65,8 +64,7 @@ var DemoRooms = []DemoRoom{
 	// Sporthalle - Separate Building
 	{Name: "Sporthalle", Category: "Sport", Capacity: 40, Building: "Sporthalle", Floor: floor(0)},
 	{Name: "Bewegungsraum", Category: "Sport", Capacity: 15, Building: "Sporthalle", Floor: floor(0)},
-	// Außenbereich - Outdoor (no floor)
-	{Name: "Schulhof", Category: "Normaler Raum", Capacity: 100, Building: "Außenbereich", Floor: nil},
+	// Note: Schulhof is auto-created as a system room by schulhof_service
 }
 
 // DemoStaff defines staff members for the demo environment
@@ -233,8 +231,6 @@ var DemoActivities = []DemoActivity{
 	{Name: "Musik", DefaultRoom: "OGS-Raum 1", DurationMins: 60},
 	{Name: "Tanzen", DefaultRoom: "Sporthalle", DurationMins: 60},
 	{Name: "Schach", DefaultRoom: "OGS-Raum 2", DurationMins: 45},
-	{Name: "Garten", DefaultRoom: "Schulhof", DurationMins: 90},
-	{Name: "Freispiel", DefaultRoom: "Schulhof", DurationMins: 60},
 }
 
 // DemoDevices defines IoT devices for check-in/check-out
@@ -247,7 +243,7 @@ var DemoDevices = []DemoDevice{
 	{DeviceID: "demo-device-005", Name: "Sporthalle Scanner"},
 	{DeviceID: "demo-device-006", Name: "Kreativraum Scanner"},
 	{DeviceID: "demo-device-007", Name: "Mensa Scanner"},
-	{DeviceID: "demo-device-008", Name: "Schulhof Scanner"},
+	{DeviceID: "demo-device-008", Name: "Aula Scanner"},
 	{DeviceID: "demo-device-009", Name: "Musikraum Scanner"},
 	{DeviceID: "demo-device-010", Name: "Bewegungsraum Scanner"},
 }

--- a/backend/seed/api/simulator_config_test.go
+++ b/backend/seed/api/simulator_config_test.go
@@ -33,7 +33,6 @@ func TestWriteSimulatorConfig_GeneratesValidYAML(t *testing.T) {
 			"Kreativraum": 3,
 			"Mensa":       4,
 			"OGS-Raum 2":  5,
-			"Schulhof":    6,
 		},
 		Activities: map[string]int64{
 			"Hausaufgaben": 50,
@@ -44,8 +43,6 @@ func TestWriteSimulatorConfig_GeneratesValidYAML(t *testing.T) {
 			"Musik":        55,
 			"Tanzen":       56,
 			"Schach":       57,
-			"Garten":       58,
-			"Freispiel":    59,
 		},
 	}
 

--- a/backend/seed/api/stammdaten.go
+++ b/backend/seed/api/stammdaten.go
@@ -878,8 +878,6 @@ func (s *FixedSeeder) seedActivities(_ context.Context, result *FixedResult) err
 		"Musik":        "Musik",
 		"Tanzen":       "Sport",
 		"Schach":       "Spiele",
-		"Garten":       "Draußen",
-		"Freispiel":    "Draußen",
 	}
 
 	for _, activity := range DemoActivities {

--- a/backend/seed/api/stammdaten_test.go
+++ b/backend/seed/api/stammdaten_test.go
@@ -604,10 +604,10 @@ func TestDemoData_GuardiansHaveRequiredFields(t *testing.T) {
 }
 
 func TestDemoData_Counts(t *testing.T) {
-	assert.Equal(t, 12, len(DemoRooms))
+	assert.Equal(t, 11, len(DemoRooms))
 	assert.Equal(t, 20, len(DemoStaff))
 	assert.Equal(t, 100, len(DemoStudents))
-	assert.Equal(t, 10, len(DemoActivities))
+	assert.Equal(t, 8, len(DemoActivities))
 	assert.Equal(t, 10, len(DemoDevices))
 }
 

--- a/backend/services/config/defaults/devices.go
+++ b/backend/services/config/defaults/devices.go
@@ -21,7 +21,7 @@ func init() {
 	config.Register(config.Definition{
 		Key:             config.KeyCheckoutSchulhofEnabled,
 		Label:           "Schulhof-Button anzeigen",
-		Description:     "Zeigt den Schulhof-Button auf dem Geräte-Checkout-Bildschirm an (setzt voraus, dass ein Schulhof-Raum existiert)",
+		Description:     "Zeigt den Schulhof-Button auf dem Geräte-Checkout-Bildschirm an (Schulhof-Raum wird automatisch erstellt)",
 		Type:            config.FieldBoolean,
 		Default:         false,
 		ReadPermission:  "config:read",
@@ -34,7 +34,7 @@ func init() {
 	config.Register(config.Definition{
 		Key:             config.KeyCheckoutWCEnabled,
 		Label:           "Toilette-Button anzeigen",
-		Description:     "Zeigt den Toilette-Button auf dem Geräte-Checkout-Bildschirm an (setzt voraus, dass ein WC-Raum existiert)",
+		Description:     "Zeigt den Toilette-Button auf dem Geräte-Checkout-Bildschirm an (WC-Raum wird automatisch erstellt)",
 		Type:            config.FieldBoolean,
 		Default:         false,
 		ReadPermission:  "config:read",


### PR DESCRIPTION
## Summary
- Removed Schulhof from `DemoRooms` — it's auto-created as a system room by `schulhof_service`
- Removed Garten and Freispiel activities that depended on the Schulhof room
- Cleaned up dead category map entries and updated test assertions
- Updated setting descriptions for Schulhof-Button and Toilette-Button to reflect auto-created system rooms (removed "setzt voraus" notice)

## Test plan
- [x] `go test ./seed/...` passes
- [x] All lefthook checks pass (pre-commit + pre-push)