### PR TITLE
fix: use TodayUTC/DateOfUTC for attendance DATE columns

### DIFF
--- a/backend/api/iot/checkin/checkin_test.go
+++ b/backend/api/iot/checkin/checkin_test.go
@@ -1135,12 +1135,12 @@ func cleanupSchulhofInfrastructure(t *testing.T, db *bun.DB, roomID int64) {
 	// All queries are scoped to the specific room ID to avoid interfering
 	// with Schulhof tests running in parallel from other packages.
 	stmts := []string{
-		fmt.Sprintf(`DELETE FROM active.attendance WHERE visit_id IN (SELECT v.id FROM active.visits v JOIN active.groups ag ON ag.id = v.active_group_id WHERE ag.room_id = %d)`, roomID),
+		fmt.Sprintf(`DELETE FROM active.attendance WHERE student_id IN (SELECT v.student_id FROM active.visits v JOIN active.groups ag ON ag.id = v.active_group_id WHERE ag.room_id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM active.visits WHERE active_group_id IN (SELECT id FROM active.groups WHERE room_id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM active.group_supervisors WHERE group_id IN (SELECT id FROM active.groups WHERE room_id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM active.groups WHERE room_id = %d`, roomID),
-		fmt.Sprintf(`DELETE FROM activities.schedules WHERE group_id IN (SELECT ag.id FROM activities.groups ag JOIN activities.categories ac ON ac.id = ag.category_id JOIN facilities.rooms r ON r.name = ac.name WHERE r.id = %d)`, roomID),
-		fmt.Sprintf(`DELETE FROM activities.student_enrollments WHERE group_id IN (SELECT ag.id FROM activities.groups ag JOIN activities.categories ac ON ac.id = ag.category_id JOIN facilities.rooms r ON r.name = ac.name WHERE r.id = %d)`, roomID),
+		fmt.Sprintf(`DELETE FROM activities.schedules WHERE activity_group_id IN (SELECT ag.id FROM activities.groups ag JOIN activities.categories ac ON ac.id = ag.category_id JOIN facilities.rooms r ON r.name = ac.name WHERE r.id = %d)`, roomID),
+		fmt.Sprintf(`DELETE FROM activities.student_enrollments WHERE activity_group_id IN (SELECT ag.id FROM activities.groups ag JOIN activities.categories ac ON ac.id = ag.category_id JOIN facilities.rooms r ON r.name = ac.name WHERE r.id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM activities.groups WHERE category_id IN (SELECT ac.id FROM activities.categories ac JOIN facilities.rooms r ON r.name = ac.name WHERE r.id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM activities.categories WHERE name = (SELECT name FROM facilities.rooms WHERE id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM facilities.rooms WHERE id = %d`, roomID),
@@ -1173,8 +1173,8 @@ func createSchulhofRoom(t *testing.T, db *bun.DB) *facilities.Room {
 
 	// Also clean up any pre-existing Schulhof activity and category (auto-created artifacts)
 	schulhofCleanupStmts := []string{
-		`DELETE FROM activities.schedules WHERE group_id IN (SELECT id FROM activities.groups WHERE name = 'Schulhof Freispiel')`,
-		`DELETE FROM activities.student_enrollments WHERE group_id IN (SELECT id FROM activities.groups WHERE name = 'Schulhof Freispiel')`,
+		`DELETE FROM activities.schedules WHERE activity_group_id IN (SELECT id FROM activities.groups WHERE name = 'Schulhof Freispiel')`,
+		`DELETE FROM activities.student_enrollments WHERE activity_group_id IN (SELECT id FROM activities.groups WHERE name = 'Schulhof Freispiel')`,
 		`DELETE FROM activities.groups WHERE name = 'Schulhof Freispiel'`,
 		`DELETE FROM activities.categories WHERE name = 'Schulhof'`,
 	}
@@ -1971,12 +1971,12 @@ func cleanupWCInfrastructure(t *testing.T, db *bun.DB, roomID int64) {
 
 	// Delete in FK-safe order: child tables first, then parents.
 	stmts := []string{
-		fmt.Sprintf(`DELETE FROM active.attendance WHERE visit_id IN (SELECT v.id FROM active.visits v JOIN active.groups ag ON ag.id = v.active_group_id WHERE ag.room_id = %d)`, roomID),
+		fmt.Sprintf(`DELETE FROM active.attendance WHERE student_id IN (SELECT v.student_id FROM active.visits v JOIN active.groups ag ON ag.id = v.active_group_id WHERE ag.room_id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM active.visits WHERE active_group_id IN (SELECT id FROM active.groups WHERE room_id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM active.group_supervisors WHERE group_id IN (SELECT id FROM active.groups WHERE room_id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM active.groups WHERE room_id = %d`, roomID),
-		fmt.Sprintf(`DELETE FROM activities.schedules WHERE group_id IN (SELECT ag.id FROM activities.groups ag JOIN activities.categories ac ON ac.id = ag.category_id JOIN facilities.rooms r ON r.name = ac.name WHERE r.id = %d)`, roomID),
-		fmt.Sprintf(`DELETE FROM activities.student_enrollments WHERE group_id IN (SELECT ag.id FROM activities.groups ag JOIN activities.categories ac ON ac.id = ag.category_id JOIN facilities.rooms r ON r.name = ac.name WHERE r.id = %d)`, roomID),
+		fmt.Sprintf(`DELETE FROM activities.schedules WHERE activity_group_id IN (SELECT ag.id FROM activities.groups ag JOIN activities.categories ac ON ac.id = ag.category_id JOIN facilities.rooms r ON r.name = ac.name WHERE r.id = %d)`, roomID),
+		fmt.Sprintf(`DELETE FROM activities.student_enrollments WHERE activity_group_id IN (SELECT ag.id FROM activities.groups ag JOIN activities.categories ac ON ac.id = ag.category_id JOIN facilities.rooms r ON r.name = ac.name WHERE r.id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM activities.groups WHERE category_id IN (SELECT ac.id FROM activities.categories ac JOIN facilities.rooms r ON r.name = ac.name WHERE r.id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM activities.categories WHERE name = (SELECT name FROM facilities.rooms WHERE id = %d)`, roomID),
 		fmt.Sprintf(`DELETE FROM facilities.rooms WHERE id = %d`, roomID),
@@ -2009,8 +2009,8 @@ func createWCRoom(t *testing.T, db *bun.DB) *facilities.Room {
 
 	// Also clean up any pre-existing WC activity and category (auto-created artifacts)
 	wcCleanupStmts := []string{
-		`DELETE FROM activities.schedules WHERE group_id IN (SELECT id FROM activities.groups WHERE name = 'WC')`,
-		`DELETE FROM activities.student_enrollments WHERE group_id IN (SELECT id FROM activities.groups WHERE name = 'WC')`,
+		`DELETE FROM activities.schedules WHERE activity_group_id IN (SELECT id FROM activities.groups WHERE name = 'WC')`,
+		`DELETE FROM activities.student_enrollments WHERE activity_group_id IN (SELECT id FROM activities.groups WHERE name = 'WC')`,
 		`DELETE FROM activities.groups WHERE name = 'WC'`,
 		`DELETE FROM activities.categories WHERE name = 'WC'`,
 	}
@@ -2278,7 +2278,7 @@ func TestDeviceCheckin_WCAutoCreateWithoutStaff(t *testing.T) {
 	// student reaches the WC reader.
 	setupStaff := testpkg.CreateTestStaff(t, ctx.db, "SetupStaff", "WCNoStaff")
 	defer testpkg.CleanupActivityFixtures(t, ctx.db, setupStaff.ID)
-	today := timezone.Today() // Berlin date — matches FindByStudentAndDate's timezone.DateOf()
+	today := timezone.TodayUTC() // UTC midnight of Berlin date — matches FindByStudentAndDate's DateOfUTC()
 	var attendanceID int64
 	err := ctx.db.NewRaw(
 		`INSERT INTO active.attendance (student_id, date, check_in_time, checked_in_by, device_id, tenant_id)
@@ -2339,7 +2339,7 @@ func TestDeviceCheckin_SchulhofAutoCreateWithoutStaff(t *testing.T) {
 	// student reaches the Schulhof reader.
 	setupStaff := testpkg.CreateTestStaff(t, ctx.db, "SetupStaff", "SchulhofNoStaff")
 	defer testpkg.CleanupActivityFixtures(t, ctx.db, setupStaff.ID)
-	today := timezone.Today() // Berlin date — matches FindByStudentAndDate's timezone.DateOf()
+	today := timezone.TodayUTC() // UTC midnight of Berlin date — matches FindByStudentAndDate's DateOfUTC()
 	var attendanceID int64
 	err := ctx.db.NewRaw(
 		`INSERT INTO active.attendance (student_id, date, check_in_time, checked_in_by, device_id, tenant_id)

--- a/backend/api/students/attendance_history_handlers_test.go
+++ b/backend/api/students/attendance_history_handlers_test.go
@@ -184,12 +184,14 @@ func TestGetStudentAttendanceHistory_ScopeAllStaff_NonAdminCanAccess(t *testing.
 	})
 
 	student := testpkg.CreateTestStudent(t, tc.db, "ScopeAll", "Student", "3b")
-	defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+	// Create a real account so the audit log FK constraint is satisfied
+	account := testpkg.CreateTestAccount(t, tc.db, "scopeall-teacher")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID, account.ID)
 
 	router := setupRouter(tc.resource.GetStudentAttendanceHistoryHandler(), "id")
 	req := testutil.NewRequest("GET", fmt.Sprintf("/%d", student.ID), nil)
-	// Use teacher claims (non-admin) with UsersRead permission
-	rr := executeWithAuth(router, req, testutil.TeacherTestClaims(99), []string{"users:read"})
+	// Use teacher claims (non-admin) with UsersRead permission — account ID must exist in auth.accounts
+	rr := executeWithAuth(router, req, testutil.TeacherTestClaims(int(account.ID)), []string{"users:read"})
 
 	assert.Equal(t, http.StatusOK, rr.Code, "all_staff scope should allow any staff with UsersRead. Body: %s", rr.Body.String())
 }

--- a/backend/database/repositories/active/attendance_repository.go
+++ b/backend/database/repositories/active/attendance_repository.go
@@ -33,9 +33,10 @@ func NewAttendanceRepository(db *bun.DB) active.AttendanceRepository {
 func (r *AttendanceRepository) FindByStudentAndDate(ctx context.Context, studentID int64, date time.Time) ([]*active.Attendance, error) {
 	var attendance []*active.Attendance
 
-	// Extract date only using Berlin timezone since the school operates in Germany.
-	// This ensures consistency with CURRENT_DATE queries (PostgreSQL timezone = Europe/Berlin).
-	dateOnly := timezone.DateOf(date)
+	// Use DateOfUTC: the PG session runs in UTC, so Berlin-midnight timestamptz
+	// gets cast to the previous UTC day. DateOfUTC yields UTC midnight of the
+	// Berlin calendar date, which round-trips correctly through DATE columns.
+	dateOnly := timezone.DateOfUTC(date)
 
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&attendance).
@@ -124,10 +125,10 @@ func (r *AttendanceRepository) FindLatestByStudent(ctx context.Context, studentI
 func (r *AttendanceRepository) GetStudentCurrentStatus(ctx context.Context, studentID int64) (*active.Attendance, error) {
 	attendance := new(active.Attendance)
 
-	// Use timezone.Today() for consistent Europe/Berlin timezone handling.
-	// This ensures the date comparison matches records created via CreateVisit,
-	// which also uses timezone.Today().
-	today := timezone.Today()
+	// Use TodayUTC: the PG session runs in UTC, so Berlin-midnight gets cast to
+	// the previous UTC day. TodayUTC yields UTC midnight of the Berlin calendar
+	// date, which round-trips correctly through DATE columns.
+	today := timezone.TodayUTC()
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(attendance).
 		ModelTableExpr(`active.attendance AS "attendance"`).
@@ -207,9 +208,9 @@ func (r *AttendanceRepository) GetTodayByStudentIDs(ctx context.Context, student
 		uniqueIDs = append(uniqueIDs, id)
 	}
 
-	// Use timezone.Today() for consistent Europe/Berlin timezone handling.
-	// This ensures the date comparison matches records created via CreateVisit.
-	today := timezone.Today()
+	// Use TodayUTC: PG session runs in UTC, so Berlin-midnight gets cast to the
+	// previous UTC day. TodayUTC round-trips correctly through DATE columns.
+	today := timezone.TodayUTC()
 	var attendances []*active.Attendance
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&attendances).
@@ -244,9 +245,10 @@ func (r *AttendanceRepository) GetTodayByStudentIDs(ctx context.Context, student
 func (r *AttendanceRepository) FindForDate(ctx context.Context, date time.Time) ([]*active.Attendance, error) {
 	var attendance []*active.Attendance
 
-	// Extract date only using Berlin timezone since the school operates in Germany.
-	// This ensures consistency with CURRENT_DATE queries (PostgreSQL timezone = Europe/Berlin).
-	dateOnly := timezone.DateOf(date)
+	// Use DateOfUTC: the PG session runs in UTC, so Berlin-midnight timestamptz
+	// gets cast to the previous UTC day. DateOfUTC yields UTC midnight of the
+	// Berlin calendar date, which round-trips correctly through DATE columns.
+	dateOnly := timezone.DateOfUTC(date)
 
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&attendance).

--- a/backend/database/repositories/active/attendance_repository_test.go
+++ b/backend/database/repositories/active/attendance_repository_test.go
@@ -63,7 +63,7 @@ func TestAttendanceRepository_Create(t *testing.T) {
 
 	t.Run("create valid attendance record", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		attendance := &active.Attendance{
 			StudentID:   data.Student1.ID,
@@ -87,7 +87,7 @@ func TestAttendanceRepository_Create(t *testing.T) {
 
 	t.Run("create with check-out time", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 		checkOutTime := now.Add(2 * time.Hour)
 		checkedOutBy := data.Staff2.ID
 
@@ -120,7 +120,7 @@ func TestAttendanceRepository_Create(t *testing.T) {
 
 	t.Run("verify IsCheckedIn helper method", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		// Create attendance without check-out
 		attendanceCheckedIn := &active.Attendance{
@@ -177,7 +177,7 @@ func TestAttendanceRepository_FindByStudentAndDate(t *testing.T) {
 
 	t.Run("single record for student on date", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		attendance := &active.Attendance{
 			StudentID:   data.Student1.ID,
@@ -210,7 +210,7 @@ func TestAttendanceRepository_FindByStudentAndDate(t *testing.T) {
 
 	t.Run("multiple records for student on same date ordered by check-in time", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		// Create three attendance records with different check-in times
 		attendance1 := &active.Attendance{
@@ -271,7 +271,7 @@ func TestAttendanceRepository_FindByStudentAndDate(t *testing.T) {
 
 	t.Run("date filtering ignores time component", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		attendance := &active.Attendance{
 			StudentID:   data.Student1.ID,
@@ -286,7 +286,7 @@ func TestAttendanceRepository_FindByStudentAndDate(t *testing.T) {
 		createdIDs = append(createdIDs, attendance.ID)
 
 		// Query with different time component but same date
-		queryDate := timezone.Today().Add(14*time.Hour + 30*time.Minute + 45*time.Second)
+		queryDate := timezone.TodayUTC().Add(14*time.Hour + 30*time.Minute + 45*time.Second)
 
 		records, err := repo.FindByStudentAndDate(ctx, data.Student1.ID, queryDate)
 		require.NoError(t, err)
@@ -303,7 +303,7 @@ func TestAttendanceRepository_FindByStudentAndDate(t *testing.T) {
 
 	t.Run("different students on same date", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		// Create attendance for student1
 		attendance1 := &active.Attendance{
@@ -346,7 +346,7 @@ func TestAttendanceRepository_FindByStudentAndDate(t *testing.T) {
 
 	t.Run("different dates for same student", func(t *testing.T) {
 		now := time.Now()
-		date1 := timezone.Today()
+		date1 := timezone.TodayUTC()
 		date2 := date1.AddDate(0, 0, 1) // Next day
 
 		// Create attendance for date1
@@ -418,9 +418,9 @@ func TestAttendanceRepository_FindLatestByStudent(t *testing.T) {
 
 	t.Run("latest record across multiple dates", func(t *testing.T) {
 		now := time.Now()
-		date1 := timezone.Today().AddDate(0, 0, -2) // 2 days ago
-		date2 := timezone.Today().AddDate(0, 0, -1) // Yesterday
-		date3 := timezone.Today()                   // Today
+		date1 := timezone.TodayUTC().AddDate(0, 0, -2) // 2 days ago
+		date2 := timezone.TodayUTC().AddDate(0, 0, -1) // Yesterday
+		date3 := timezone.TodayUTC()                   // Today
 
 		// Create attendance for date1 (oldest)
 		attendance1 := &active.Attendance{
@@ -466,7 +466,7 @@ func TestAttendanceRepository_FindLatestByStudent(t *testing.T) {
 
 	t.Run("latest record same day with multiple check-ins", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		// Create multiple attendance records on same day with different check-in times
 		attendance1 := &active.Attendance{
@@ -518,7 +518,7 @@ func TestAttendanceRepository_FindLatestByStudent(t *testing.T) {
 		defer testpkg.CleanupActivityFixtures(t, db, singleStudent.ID)
 
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		attendance := &active.Attendance{
 			StudentID:   singleStudent.ID,
@@ -547,7 +547,7 @@ func TestAttendanceRepository_FindLatestByStudent(t *testing.T) {
 		defer testpkg.CleanupActivityFixtures(t, db, complexStudent.ID)
 
 		now := time.Now()
-		today := timezone.Today()
+		today := timezone.TodayUTC()
 		yesterday := today.AddDate(0, 0, -1)
 
 		// Yesterday: multiple records
@@ -594,7 +594,7 @@ func TestAttendanceRepository_FindLatestByStudent(t *testing.T) {
 
 	t.Run("different students do not interfere", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		// Create attendance for student1 (earlier)
 		attendanceStudent1 := &active.Attendance{
@@ -670,7 +670,7 @@ func TestAttendanceRepository_GetStudentCurrentStatus(t *testing.T) {
 		defer testpkg.CleanupActivityFixtures(t, db, checkedInStudent.ID)
 
 		now := time.Now()
-		today := timezone.Today()
+		today := timezone.TodayUTC()
 
 		attendance := &active.Attendance{
 			StudentID:   checkedInStudent.ID,
@@ -702,7 +702,7 @@ func TestAttendanceRepository_GetStudentCurrentStatus(t *testing.T) {
 		defer testpkg.CleanupActivityFixtures(t, db, checkedOutStudent.ID)
 
 		now := time.Now()
-		today := timezone.Today()
+		today := timezone.TodayUTC()
 		checkOutTime := now.Add(2 * time.Hour)
 		checkedOutBy := data.Staff2.ID
 
@@ -737,7 +737,7 @@ func TestAttendanceRepository_GetStudentCurrentStatus(t *testing.T) {
 		defer testpkg.CleanupActivityFixtures(t, db, multiRecordStudent.ID)
 
 		now := time.Now()
-		today := timezone.Today()
+		today := timezone.TodayUTC()
 
 		// First check-in (earlier)
 		attendance1 := &active.Attendance{
@@ -792,7 +792,7 @@ func TestAttendanceRepository_GetStudentCurrentStatus(t *testing.T) {
 		defer testpkg.CleanupActivityFixtures(t, db, historicalStudent.ID)
 
 		now := time.Now()
-		yesterday := timezone.Today().AddDate(0, 0, -1)
+		yesterday := timezone.TodayUTC().AddDate(0, 0, -1)
 
 		// Create attendance for yesterday
 		attendance := &active.Attendance{
@@ -821,7 +821,7 @@ func TestAttendanceRepository_GetStudentCurrentStatus(t *testing.T) {
 		defer testpkg.CleanupActivityFixtures(t, db, diffStudent1.ID, diffStudent2.ID)
 
 		now := time.Now()
-		today := timezone.Today()
+		today := timezone.TodayUTC()
 
 		// Create attendance for student1
 		attendance1 := &active.Attendance{
@@ -873,7 +873,7 @@ func TestAttendanceRepository_GetStudentCurrentStatus(t *testing.T) {
 		tzStudent := testpkg.CreateTestStudent(t, db, "Timezone", "StatusTest", "2h")
 		defer testpkg.CleanupActivityFixtures(t, db, tzStudent.ID)
 
-		today := timezone.Today()
+		today := timezone.TodayUTC()
 
 		// Create attendance record for today but late in the day
 		attendance := &active.Attendance{
@@ -916,7 +916,7 @@ func TestAttendanceRepository_Update(t *testing.T) {
 
 	t.Run("updates attendance with check-out time", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		attendance := &active.Attendance{
 			StudentID:   data.Student1.ID,
@@ -973,7 +973,7 @@ func TestAttendanceRepository_FindByID(t *testing.T) {
 
 	t.Run("finds existing attendance by ID", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		attendance := &active.Attendance{
 			StudentID:   data.Student1.ID,
@@ -1011,7 +1011,7 @@ func TestAttendanceRepository_Delete(t *testing.T) {
 
 	t.Run("deletes existing attendance record", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		attendance := &active.Attendance{
 			StudentID:   data.Student1.ID,
@@ -1051,7 +1051,7 @@ func TestAttendanceRepository_GetTodayByStudentID(t *testing.T) {
 
 	t.Run("gets today's attendance for student", func(t *testing.T) {
 		now := time.Now()
-		today := timezone.Today()
+		today := timezone.TodayUTC()
 
 		attendance := &active.Attendance{
 			StudentID:   data.Student1.ID,
@@ -1099,7 +1099,7 @@ func TestAttendanceRepository_FindForDate(t *testing.T) {
 
 	t.Run("finds all attendance for specific date", func(t *testing.T) {
 		now := time.Now()
-		date := timezone.Today()
+		date := timezone.TodayUTC()
 
 		// Create multiple attendance records for same date
 		attendance1 := &active.Attendance{

--- a/backend/services/active/attendance_service.go
+++ b/backend/services/active/attendance_service.go
@@ -126,8 +126,9 @@ func (s *service) ToggleStudentAttendance(ctx context.Context, studentID, staffI
 	}
 
 	now := time.Now()
-	// Use timezone.Today() for consistent Europe/Berlin timezone handling
-	today := timezone.Today()
+	// Use TodayUTC() so the Berlin calendar date is stored as UTC midnight,
+	// which round-trips correctly through PostgreSQL DATE columns (PG session is UTC).
+	today := timezone.TodayUTC()
 
 	if currentStatus.Status == "not_checked_in" || currentStatus.Status == "checked_out" {
 		return s.performCheckIn(ctx, studentID, authorizedStaffID, deviceID, now, today)

--- a/backend/services/active/visit_helpers.go
+++ b/backend/services/active/visit_helpers.go
@@ -46,9 +46,9 @@ func (s *service) resolveStaffIDForAttendance(ctx context.Context, staffID, devi
 
 // ensureOrUpdateAttendance handles attendance creation or re-entry update
 func (s *service) ensureOrUpdateAttendance(ctx context.Context, visit *active.Visit, staffID, deviceID int64) error {
-	// Use Berlin timezone for date calculation since the school operates in Germany.
-	// This ensures a check-in at 00:30 CET is recorded for the correct day.
-	visitDate := timezone.DateOf(visit.EntryTime)
+	// Use DateOfUTC: extract the Berlin calendar date but return as UTC midnight,
+	// so the value round-trips correctly through PostgreSQL DATE columns (PG session is UTC).
+	visitDate := timezone.DateOfUTC(visit.EntryTime)
 	attendanceRecords, err := s.attendanceRepo.FindByStudentAndDate(ctx, visit.StudentID, visitDate)
 	if err != nil {
 		return &ActiveError{Op: "CreateVisit", Err: err}

--- a/backend/services/active/visit_helpers_test.go
+++ b/backend/services/active/visit_helpers_test.go
@@ -144,7 +144,7 @@ func getAttendanceForStudent(t *testing.T, db *bun.DB, studentID int64) *activeM
 		Model(&attendance).
 		ModelTableExpr(`active.attendance`). // NOTE: singular, not plural!
 		Where("student_id = ?", studentID).
-		Where("date = ?", timezone.Today()).
+		Where("date = ?", timezone.TodayUTC()).
 		Order("check_in_time DESC").
 		Limit(1).
 		Scan(context.Background())
@@ -161,7 +161,7 @@ func createAttendanceWithCheckout(t *testing.T, db *bun.DB, studentID, staffID, 
 	checkedOutBy := staffID
 	attendance := &activeModels.Attendance{
 		StudentID:    studentID,
-		Date:         timezone.Today(),
+		Date:         timezone.TodayUTC(),
 		CheckInTime:  time.Now().Add(-4 * time.Hour),
 		CheckOutTime: &checkoutTime,
 		CheckedInBy:  staffID,

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -317,9 +317,9 @@ func CreateTestAttendance(tb testing.TB, db *bun.DB, studentID, staffID, deviceI
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// Use timezone.Today() for consistent Europe/Berlin timezone handling.
-	// This matches the repository queries which also use timezone.Today().
-	today := timezone.Today()
+	// Use TodayUTC() so the DATE column gets UTC midnight of the Berlin calendar
+	// date, matching how performCheckIn stores attendance records in production.
+	today := timezone.TodayUTC()
 
 	attendance := &active.Attendance{
 		StudentID:    studentID,


### PR DESCRIPTION
## Summary

- **Bug**: Every attendance record was stored with the date shifted one day behind because `timezone.Today()` (Berlin midnight) gets cast to the previous UTC day by PostgreSQL DATE columns (PG session runs in UTC)
- **Impact**: Anwesenheitsprotokoll showed Friday check-ins under Thursday. 5500+ records affected since at least March. Daily check-in/out operations were unaffected because both write and read paths had the same bug (errors cancelled out)
- **Fix**: Switch all attendance DATE column operations to `TodayUTC()`/`DateOfUTC()` which return UTC midnight of the Berlin calendar date, round-tripping correctly through PostgreSQL

## Changes

| File | Change |
|------|--------|
| `services/active/attendance_service.go` | `Today()` → `TodayUTC()` in `performCheckIn` |
| `database/repositories/active/attendance_repository.go` | 4 methods: `DateOf`/`Today` → `DateOfUTC`/`TodayUTC` |
| `test/fixtures.go` | Test fixture aligned with production write path |
| `api/students/attendance_history_handlers_test.go` | Fix pre-existing hardcoded account ID (99) → real DB account for audit FK constraint |

## Deployment note

Deploy outside school hours (after 18:00 or before 07:00). Records created earlier on deployment day use the old wrong date format — students checked in before deployment could appear as "not_checked_in" until the next day.

Old records (date shifted by -1 day) will age out naturally via the 30-day attendance cap. No data migration needed.

## Test plan

- [x] All 9 attendance history handler tests pass (were 4/9 before)
- [x] All attendance service tests pass
- [x] Hermetic test patterns check passes
- [x] Build + lint + vet + deadcode clean
- [x] Verified in production DB: all records since March have `date != (check_in_time AT TIME ZONE 'Europe/Berlin')::date`