### PR TITLE
feat: add gdpr.student_data_scope setting to relax student read access

### DIFF
--- a/backend/api/active/active_test.go
+++ b/backend/api/active/active_test.go
@@ -40,7 +40,7 @@ func setupTestContext(t *testing.T) *testContext {
 	t.Helper()
 
 	db, svc := testutil.SetupAPITest(t)
-	resource := activeAPI.NewResource(svc.Active, svc.Users, svc.Schulhof, svc.UserContext, db, slog.Default())
+	resource := activeAPI.NewResource(svc.Active, svc.Users, svc.Schulhof, svc.UserContext, svc.Settings, db, slog.Default())
 
 	t.Cleanup(func() {
 		if err := db.Close(); err != nil {

--- a/backend/api/active/api.go
+++ b/backend/api/active/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	base "github.com/moto-nrw/project-phoenix/models/base"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
 	"github.com/moto-nrw/project-phoenix/services/facilities"
 	"github.com/moto-nrw/project-phoenix/services/usercontext"
 	userSvc "github.com/moto-nrw/project-phoenix/services/users"
@@ -27,6 +28,7 @@ type Resource struct {
 	PersonService      userSvc.PersonService
 	SchulhofService    facilities.SchulhofService
 	UserContextService usercontext.UserContextService
+	SettingsService    configSvc.SettingsService
 	db                 *bun.DB
 	logger             *slog.Logger
 }
@@ -49,12 +51,13 @@ func (rs *Resource) getDB(ctx context.Context) bun.IDB {
 }
 
 // NewResource creates a new active resource
-func NewResource(activeService activeSvc.Service, personService userSvc.PersonService, schulhofService facilities.SchulhofService, userContextService usercontext.UserContextService, db *bun.DB, logger *slog.Logger) *Resource {
+func NewResource(activeService activeSvc.Service, personService userSvc.PersonService, schulhofService facilities.SchulhofService, userContextService usercontext.UserContextService, settingsService configSvc.SettingsService, db *bun.DB, logger *slog.Logger) *Resource {
 	return &Resource{
 		ActiveService:      activeService,
 		PersonService:      personService,
 		SchulhofService:    schulhofService,
 		UserContextService: userContextService,
+		SettingsService:    settingsService,
 		db:                 db,
 		logger:             logger,
 	}
@@ -165,6 +168,9 @@ func (rs *Resource) Router() chi.Router {
 			r.With(authorize.RequiresPermission(permissions.GroupsRead), withTx).Get("/counts", rs.getCounts)
 			r.With(authorize.RequiresPermission(permissions.GroupsRead), withTx).Get("/dashboard", rs.getDashboardAnalytics)
 		})
+
+		// Tracking indicators (bulk check if students visited configured rooms/activities today)
+		r.With(authorize.RequiresPermission(permissions.GroupsRead), withTx).Post("/tracking-indicators", rs.getTrackingIndicators)
 
 		// Cross-tenant students (Ferienbetreuung / holiday care)
 		r.With(authorize.RequiresPermission(permissions.GroupsRead), withTx).Get("/cross-tenant-students", rs.getCrossTenantStudents)

--- a/backend/api/active/checkin_test.go
+++ b/backend/api/active/checkin_test.go
@@ -285,7 +285,7 @@ func setupCheckinTestHandler(t *testing.T, db *bun.DB) *active.Resource {
 	serviceFactory, err := services.NewFactory(repoFactory, db, slog.Default())
 	require.NoError(t, err, "Failed to create service factory")
 
-	return active.NewResource(serviceFactory.Active, serviceFactory.Users, serviceFactory.Schulhof, serviceFactory.UserContext, db, slog.Default())
+	return active.NewResource(serviceFactory.Active, serviceFactory.Users, serviceFactory.Schulhof, serviceFactory.UserContext, serviceFactory.Settings, db, slog.Default())
 }
 
 // makeCheckinRequest creates an HTTP request with JWT auth for the checkin endpoint

--- a/backend/api/active/tracking_handlers.go
+++ b/backend/api/active/tracking_handlers.go
@@ -10,8 +10,6 @@ import (
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 )
 
-const maxTrackingStudentIDs = 200
-
 // getTrackingIndicators handles POST /tracking-indicators
 // Returns per-student match results for configured tracking indicator labels.
 func (rs *Resource) getTrackingIndicators(w http.ResponseWriter, r *http.Request) {
@@ -26,11 +24,6 @@ func (rs *Resource) getTrackingIndicators(w http.ResponseWriter, r *http.Request
 			Labels:  []string{},
 			Results: map[int64][]bool{},
 		}, "")
-		return
-	}
-
-	if len(req.StudentIDs) > maxTrackingStudentIDs {
-		common.RenderError(w, r, ErrorInvalidRequest(errors.New("too many student IDs (max 200)")))
 		return
 	}
 

--- a/backend/api/active/tracking_handlers.go
+++ b/backend/api/active/tracking_handlers.go
@@ -1,0 +1,104 @@
+package active
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+)
+
+const maxTrackingStudentIDs = 200
+
+// getTrackingIndicators handles POST /tracking-indicators
+// Returns per-student match results for configured tracking indicator labels.
+func (rs *Resource) getTrackingIndicators(w http.ResponseWriter, r *http.Request) {
+	var req TrackingIndicatorsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		common.RenderError(w, r, ErrorInvalidRequest(errors.New("invalid request body")))
+		return
+	}
+
+	if len(req.StudentIDs) == 0 {
+		common.Respond(w, r, http.StatusOK, TrackingIndicatorsResponse{
+			Labels:  []string{},
+			Results: map[int64][]bool{},
+		}, "")
+		return
+	}
+
+	if len(req.StudentIDs) > maxTrackingStudentIDs {
+		common.RenderError(w, r, ErrorInvalidRequest(errors.New("too many student IDs (max 200)")))
+		return
+	}
+
+	for _, id := range req.StudentIDs {
+		if id <= 0 {
+			common.RenderError(w, r, ErrorInvalidRequest(errors.New("invalid student ID")))
+			return
+		}
+	}
+
+	ctx := r.Context()
+
+	// Check if tracking indicators are enabled for this tenant.
+	enabled, err := rs.SettingsService.ResolveBool(ctx, configModel.KeyTrackingIndicatorsEnabled)
+	if err != nil {
+		rs.getLogger().Warn("tracking_indicators_settings_error",
+			"error", err.Error(),
+		)
+		common.Respond(w, r, http.StatusOK, TrackingIndicatorsResponse{
+			Labels:  []string{},
+			Results: map[int64][]bool{},
+		}, "")
+		return
+	}
+
+	if !enabled {
+		common.Respond(w, r, http.StatusOK, TrackingIndicatorsResponse{
+			Labels:  []string{},
+			Results: map[int64][]bool{},
+		}, "")
+		return
+	}
+
+	// Read configured indicator labels.
+	labelKeys := []string{
+		configModel.KeyTrackingIndicator1,
+		configModel.KeyTrackingIndicator2,
+		configModel.KeyTrackingIndicator3,
+	}
+	var labels []string
+	for _, key := range labelKeys {
+		val, err := rs.SettingsService.ResolveString(ctx, key)
+		if err != nil {
+			continue
+		}
+		trimmed := strings.TrimSpace(val)
+		if trimmed != "" {
+			labels = append(labels, trimmed)
+		}
+	}
+
+	if len(labels) == 0 {
+		common.Respond(w, r, http.StatusOK, TrackingIndicatorsResponse{
+			Labels:  []string{},
+			Results: map[int64][]bool{},
+		}, "")
+		return
+	}
+
+	// Get tracking indicator results from the service.
+	results, err := rs.ActiveService.GetTrackingIndicators(ctx, req.StudentIDs, labels)
+	if err != nil {
+		common.RenderError(w, r, ErrorRenderer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, TrackingIndicatorsResponse{
+		Labels:  labels,
+		Results: results,
+	}, "")
+}

--- a/backend/api/active/tracking_handlers_test.go
+++ b/backend/api/active/tracking_handlers_test.go
@@ -1,0 +1,658 @@
+package active
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/config"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock SettingsService ---
+
+type trackingMockSettingsService struct {
+	resolveBoolFunc   func(ctx context.Context, key string) (bool, error)
+	resolveStringFunc func(ctx context.Context, key string) (string, error)
+}
+
+func (m *trackingMockSettingsService) GetSchema(ctx context.Context, perms []string) (*configSvc.SettingsSchema, error) {
+	return nil, nil
+}
+func (m *trackingMockSettingsService) Resolve(ctx context.Context, key string) (any, error) {
+	return nil, nil
+}
+func (m *trackingMockSettingsService) ResolveString(ctx context.Context, key string) (string, error) {
+	if m.resolveStringFunc != nil {
+		return m.resolveStringFunc(ctx, key)
+	}
+	return "", nil
+}
+func (m *trackingMockSettingsService) ResolveStringForTenant(ctx context.Context, tenantID int64, key string) (string, error) {
+	return "", nil
+}
+func (m *trackingMockSettingsService) ResolveBool(ctx context.Context, key string) (bool, error) {
+	if m.resolveBoolFunc != nil {
+		return m.resolveBoolFunc(ctx, key)
+	}
+	return false, nil
+}
+func (m *trackingMockSettingsService) ResolveInt(ctx context.Context, key string) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockSettingsService) HasTenantOverride(ctx context.Context, key string) (bool, error) {
+	return false, nil
+}
+func (m *trackingMockSettingsService) SetValue(ctx context.Context, key string, value any, changedBy *int64, perms []string) error {
+	return nil
+}
+func (m *trackingMockSettingsService) ResetValue(ctx context.Context, key string, changedBy *int64, perms []string) error {
+	return nil
+}
+func (m *trackingMockSettingsService) GetLoginImageURL(ctx context.Context, tenantID int64) (string, error) {
+	return "", nil
+}
+func (m *trackingMockSettingsService) SetLoginImageURL(ctx context.Context, tenantID int64, imageURL string) (string, error) {
+	return "", nil
+}
+func (m *trackingMockSettingsService) ClearLoginImageURL(ctx context.Context, tenantID int64) (string, error) {
+	return "", nil
+}
+
+// --- Mock ActiveService (stub all methods, only GetTrackingIndicators functional) ---
+
+type trackingMockActiveService struct {
+	getTrackingIndicatorsFunc func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error)
+}
+
+// The only method used by the tracking handler:
+func (m *trackingMockActiveService) GetTrackingIndicators(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+	if m.getTrackingIndicatorsFunc != nil {
+		return m.getTrackingIndicatorsFunc(ctx, studentIDs, labels)
+	}
+	return nil, nil
+}
+
+// Stub out the rest of the Service interface:
+func (m *trackingMockActiveService) GetActiveGroup(ctx context.Context, id int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CreateActiveGroup(ctx context.Context, group *activeModel.Group) error {
+	return nil
+}
+func (m *trackingMockActiveService) UpdateActiveGroup(ctx context.Context, group *activeModel.Group) error {
+	return nil
+}
+func (m *trackingMockActiveService) DeleteActiveGroup(ctx context.Context, id int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) ListActiveGroups(ctx context.Context, options *base.QueryOptions) ([]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindActiveGroupsByRoomID(ctx context.Context, roomID int64) ([]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindDeviceActiveGroupInRoom(ctx context.Context, roomID int64, deviceID int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindActiveGroupsByGroupID(ctx context.Context, groupID int64) ([]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindActiveGroupsByTimeRange(ctx context.Context, start, end time.Time) ([]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) EndActiveGroupSession(ctx context.Context, id int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) GetActiveGroupWithVisits(ctx context.Context, id int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetActiveGroupWithSupervisors(ctx context.Context, id int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetVisit(ctx context.Context, id int64) (*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CreateVisit(ctx context.Context, visit *activeModel.Visit) error {
+	return nil
+}
+func (m *trackingMockActiveService) UpdateVisit(ctx context.Context, visit *activeModel.Visit) error {
+	return nil
+}
+func (m *trackingMockActiveService) DeleteVisit(ctx context.Context, id int64) error { return nil }
+func (m *trackingMockActiveService) ListVisits(ctx context.Context, options *base.QueryOptions) ([]*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindVisitsByStudentID(ctx context.Context, studentID int64) ([]*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindVisitsByActiveGroupID(ctx context.Context, activeGroupID int64) ([]*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindVisitsByTimeRange(ctx context.Context, start, end time.Time) ([]*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) EndVisit(ctx context.Context, id int64) error { return nil }
+func (m *trackingMockActiveService) GetStudentCurrentVisit(ctx context.Context, studentID int64) (*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetStudentCurrentVisitWithRoom(ctx context.Context, studentID int64) (*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetStudentsCurrentVisits(ctx context.Context, studentIDs []int64) (map[int64]*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CountActiveVisitsByRoomID(ctx context.Context, roomID int64) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) CountActiveVisitsByActiveGroupID(ctx context.Context, activeGroupID int64) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) GetGroupSupervisor(ctx context.Context, id int64) (*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CreateGroupSupervisor(ctx context.Context, supervisor *activeModel.GroupSupervisor) error {
+	return nil
+}
+func (m *trackingMockActiveService) UpdateGroupSupervisor(ctx context.Context, supervisor *activeModel.GroupSupervisor) error {
+	return nil
+}
+func (m *trackingMockActiveService) DeleteGroupSupervisor(ctx context.Context, id int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) ListGroupSupervisors(ctx context.Context, options *base.QueryOptions) ([]*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindSupervisorsByStaffID(ctx context.Context, staffID int64) ([]*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindSupervisorsByActiveGroupID(ctx context.Context, activeGroupID int64) ([]*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindSupervisorsByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64) ([]*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) EndSupervision(ctx context.Context, id int64) error { return nil }
+func (m *trackingMockActiveService) GetStaffActiveSupervisions(ctx context.Context, staffID int64) ([]*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetCombinedGroup(ctx context.Context, id int64) (*activeModel.CombinedGroup, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CreateCombinedGroup(ctx context.Context, group *activeModel.CombinedGroup) error {
+	return nil
+}
+func (m *trackingMockActiveService) UpdateCombinedGroup(ctx context.Context, group *activeModel.CombinedGroup) error {
+	return nil
+}
+func (m *trackingMockActiveService) DeleteCombinedGroup(ctx context.Context, id int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) ListCombinedGroups(ctx context.Context, options *base.QueryOptions) ([]*activeModel.CombinedGroup, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindActiveCombinedGroups(ctx context.Context) ([]*activeModel.CombinedGroup, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindCombinedGroupsByTimeRange(ctx context.Context, start, end time.Time) ([]*activeModel.CombinedGroup, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) EndCombinedGroup(ctx context.Context, id int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) GetCombinedGroupWithGroups(ctx context.Context, id int64) (*activeModel.CombinedGroup, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CreateCombinedGroupWithGroups(ctx context.Context, group *activeModel.CombinedGroup, groupIDs []int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) AddGroupToCombination(ctx context.Context, combinedGroupID, activeGroupID int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) RemoveGroupFromCombination(ctx context.Context, combinedGroupID, activeGroupID int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) GetGroupMappingsByActiveGroupID(ctx context.Context, activeGroupID int64) ([]*activeModel.GroupMapping, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetGroupMappingsByCombinedGroupID(ctx context.Context, combinedGroupID int64) ([]*activeModel.GroupMapping, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) StartActivitySession(ctx context.Context, activityID, deviceID, staffID int64, roomID *int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) StartActivitySessionWithSupervisors(ctx context.Context, activityID, deviceID int64, supervisorIDs []int64, roomID *int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CheckActivityConflict(ctx context.Context, activityID, deviceID int64) (*activeSvc.ActivityConflictInfo, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) EndActivitySession(ctx context.Context, activeGroupID int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) ForceStartActivitySession(ctx context.Context, activityID, deviceID, staffID int64, roomID *int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) ForceStartActivitySessionWithSupervisors(ctx context.Context, activityID, deviceID int64, supervisorIDs []int64, roomID *int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetDeviceCurrentSession(ctx context.Context, deviceID int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) UpdateActiveGroupSupervisors(ctx context.Context, activeGroupID int64, supervisorIDs []int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) ProcessSessionTimeout(ctx context.Context, deviceID int64) (*activeSvc.TimeoutResult, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) UpdateSessionActivity(ctx context.Context, activeGroupID int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) ValidateSessionTimeout(ctx context.Context, deviceID int64, timeoutMinutes int) error {
+	return nil
+}
+func (m *trackingMockActiveService) GetSessionTimeoutInfo(ctx context.Context, deviceID int64) (*activeSvc.SessionTimeoutInfo, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CleanupAbandonedSessions(ctx context.Context, olderThan time.Duration) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) EndDailySessions(ctx context.Context) (*activeSvc.DailySessionCleanupResult, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetActiveGroupsCount(ctx context.Context) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) GetTotalVisitsCount(ctx context.Context) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) GetActiveVisitsCount(ctx context.Context) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) GetDashboardAnalytics(ctx context.Context) (*activeSvc.DashboardAnalytics, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetActiveGroupsByIDs(ctx context.Context, groupIDs []int64) (map[int64]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetStudentAttendanceStatus(ctx context.Context, studentID int64) (*activeSvc.AttendanceStatus, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetStudentsAttendanceStatuses(ctx context.Context, studentIDs []int64) (map[int64]*activeSvc.AttendanceStatus, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) ToggleStudentAttendance(ctx context.Context, studentID, staffID, deviceID int64, skipAuthCheck bool) (*activeSvc.AttendanceResult, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CheckTeacherStudentAccess(ctx context.Context, teacherID, studentID int64) (bool, error) {
+	return false, nil
+}
+func (m *trackingMockActiveService) BroadcastDailyCheckout(ctx context.Context, studentID int64) {}
+func (m *trackingMockActiveService) GetUnclaimedActiveGroups(ctx context.Context) ([]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) ClaimActiveGroup(ctx context.Context, groupID, staffID int64, role string) (*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetCrossTenantStudents(ctx context.Context, hostingTenantID int64) ([]activeModel.CrossTenantStudent, error) {
+	return nil, nil
+}
+
+// --- Test Helpers ---
+
+func createTrackingRequest(t *testing.T, body TrackingIndicatorsRequest) *http.Request {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	return httptest.NewRequest(http.MethodPost, "/tracking-indicators", bytes.NewReader(b))
+}
+
+// --- Tests ---
+
+func TestGetTrackingIndicators_InvalidBody(t *testing.T) {
+	rs := &Resource{}
+
+	req := httptest.NewRequest(http.MethodPost, "/tracking-indicators", bytes.NewReader([]byte("not json")))
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetTrackingIndicators_EmptyStudentIDs(t *testing.T) {
+	rs := &Resource{}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+	assert.Empty(t, resp.Data.Results)
+}
+
+func TestGetTrackingIndicators_TooManyStudentIDs(t *testing.T) {
+	rs := &Resource{}
+
+	ids := make([]int64, 201)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: ids})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetTrackingIndicators_InvalidStudentID(t *testing.T) {
+	rs := &Resource{}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10, 0}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetTrackingIndicators_NegativeStudentID(t *testing.T) {
+	rs := &Resource{}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10, -5}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetTrackingIndicators_SettingsError(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return false, errors.New("settings service error")
+		},
+	}
+
+	rs := &Resource{SettingsService: settings}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	// Returns 200 with empty data on settings error (graceful degradation)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+}
+
+func TestGetTrackingIndicators_Disabled(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return false, nil
+		},
+	}
+
+	rs := &Resource{SettingsService: settings}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+}
+
+func TestGetTrackingIndicators_NoLabelsConfigured(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return "", nil
+		},
+	}
+
+	rs := &Resource{SettingsService: settings}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+}
+
+func TestGetTrackingIndicators_LabelResolutionError(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return "", errors.New("label read error")
+		},
+	}
+
+	rs := &Resource{SettingsService: settings}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+}
+
+func TestGetTrackingIndicators_Success(t *testing.T) {
+	labelValues := map[string]string{
+		config.KeyTrackingIndicator1: "Hausaufgaben",
+		config.KeyTrackingIndicator2: "Mensa",
+		config.KeyTrackingIndicator3: "",
+	}
+
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return labelValues[key], nil
+		},
+	}
+
+	mockSvc := &trackingMockActiveService{
+		getTrackingIndicatorsFunc: func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+			assert.Equal(t, []int64{10, 20}, studentIDs)
+			assert.Equal(t, []string{"Hausaufgaben", "Mensa"}, labels)
+			return map[int64][]bool{
+				10: {true, false},
+				20: {false, true},
+			}, nil
+		},
+	}
+
+	rs := &Resource{
+		SettingsService: settings,
+		ActiveService:   mockSvc,
+	}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10, 20}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, []string{"Hausaufgaben", "Mensa"}, resp.Data.Labels)
+	assert.Equal(t, map[int64][]bool{10: {true, false}, 20: {false, true}}, resp.Data.Results)
+}
+
+func TestGetTrackingIndicators_ServiceError(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return "Mensa", nil
+		},
+	}
+
+	mockSvc := &trackingMockActiveService{
+		getTrackingIndicatorsFunc: func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+			return nil, errors.New("service error")
+		},
+	}
+
+	rs := &Resource{
+		SettingsService: settings,
+		ActiveService:   mockSvc,
+	}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestGetTrackingIndicators_WhitespaceOnlyLabels(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return "   ", nil
+		},
+	}
+
+	rs := &Resource{SettingsService: settings}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+}
+
+func TestGetTrackingIndicators_PartialLabelsConfigured(t *testing.T) {
+	labelValues := map[string]string{
+		config.KeyTrackingIndicator1: "Mensa",
+		config.KeyTrackingIndicator2: "",
+		config.KeyTrackingIndicator3: "Sport",
+	}
+
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return labelValues[key], nil
+		},
+	}
+
+	mockSvc := &trackingMockActiveService{
+		getTrackingIndicatorsFunc: func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+			assert.Equal(t, []string{"Mensa", "Sport"}, labels)
+			return map[int64][]bool{10: {true, true}}, nil
+		},
+	}
+
+	rs := &Resource{
+		SettingsService: settings,
+		ActiveService:   mockSvc,
+	}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestGetTrackingIndicators_ExactlyMaxStudentIDs(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return "Mensa", nil
+		},
+	}
+
+	mockSvc := &trackingMockActiveService{
+		getTrackingIndicatorsFunc: func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+			result := make(map[int64][]bool, len(studentIDs))
+			for _, id := range studentIDs {
+				result[id] = []bool{false}
+			}
+			return result, nil
+		},
+	}
+
+	rs := &Resource{
+		SettingsService: settings,
+		ActiveService:   mockSvc,
+	}
+
+	ids := make([]int64, 200)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: ids})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	// 200 IDs is exactly at the limit, should succeed
+	assert.Equal(t, http.StatusOK, rr.Code)
+}

--- a/backend/api/active/tracking_handlers_test.go
+++ b/backend/api/active/tracking_handlers_test.go
@@ -348,22 +348,6 @@ func TestGetTrackingIndicators_EmptyStudentIDs(t *testing.T) {
 	assert.Empty(t, resp.Data.Results)
 }
 
-func TestGetTrackingIndicators_TooManyStudentIDs(t *testing.T) {
-	rs := &Resource{}
-
-	ids := make([]int64, 201)
-	for i := range ids {
-		ids[i] = int64(i + 1)
-	}
-
-	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: ids})
-	rr := httptest.NewRecorder()
-
-	rs.getTrackingIndicators(rr, req)
-
-	assert.Equal(t, http.StatusBadRequest, rr.Code)
-}
-
 func TestGetTrackingIndicators_InvalidStudentID(t *testing.T) {
 	rs := &Resource{}
 
@@ -615,44 +599,5 @@ func TestGetTrackingIndicators_PartialLabelsConfigured(t *testing.T) {
 
 	rs.getTrackingIndicators(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-}
-
-func TestGetTrackingIndicators_ExactlyMaxStudentIDs(t *testing.T) {
-	settings := &trackingMockSettingsService{
-		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
-			return true, nil
-		},
-		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
-			return "Mensa", nil
-		},
-	}
-
-	mockSvc := &trackingMockActiveService{
-		getTrackingIndicatorsFunc: func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
-			result := make(map[int64][]bool, len(studentIDs))
-			for _, id := range studentIDs {
-				result[id] = []bool{false}
-			}
-			return result, nil
-		},
-	}
-
-	rs := &Resource{
-		SettingsService: settings,
-		ActiveService:   mockSvc,
-	}
-
-	ids := make([]int64, 200)
-	for i := range ids {
-		ids[i] = int64(i + 1)
-	}
-
-	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: ids})
-	rr := httptest.NewRecorder()
-
-	rs.getTrackingIndicators(rr, req)
-
-	// 200 IDs is exactly at the limit, should succeed
 	assert.Equal(t, http.StatusOK, rr.Code)
 }

--- a/backend/api/active/types.go
+++ b/backend/api/active/types.go
@@ -202,6 +202,17 @@ type ActiveGroupSummary struct {
 	Status       string `json:"status"`
 }
 
+// TrackingIndicatorsResponse returns labels and per-student match results
+type TrackingIndicatorsResponse struct {
+	Labels  []string         `json:"labels"`
+	Results map[int64][]bool `json:"results"`
+}
+
+// TrackingIndicatorsRequest is the request body for POST /tracking-indicators
+type TrackingIndicatorsRequest struct {
+	StudentIDs []int64 `json:"student_ids"`
+}
+
 // ===== Request Types =====
 
 // ActiveGroupRequest represents an active group creation/update request

--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -316,7 +316,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 			return nil
 		}
 	})
-	api.Active = activeAPI.NewResource(api.Services.Active, api.Services.Users, api.Services.Schulhof, api.Services.UserContext, db, logger.With("handler", "active"))
+	api.Active = activeAPI.NewResource(api.Services.Active, api.Services.Users, api.Services.Schulhof, api.Services.UserContext, api.Services.Settings, db, logger.With("handler", "active"))
 	api.IoT = iotAPI.NewResource(iotAPI.ServiceDependencies{
 		IoTService:            api.Services.IoT,
 		UsersService:          api.Services.Users,

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -216,13 +216,26 @@ func (rs *Resource) getStudentGroup(ctx context.Context, student *users.Student)
 	return group
 }
 
-// checkStudentFullAccess determines if the current user has full access to a student's data.
-// Returns true if the user is an admin, the tenant's student_data_scope is set to all_staff,
-// or the user supervises the student's education group.
+// checkStudentFullAccess determines if the current user has full access to
+// a student's data for write operations (update, delete, privacy consent, etc.).
+// Returns true if the user is an admin or supervises the student's group.
 //
-// This function gates READ access only. Write operations (update, delete, check-in, etc.)
-// remain restricted to the student's group supervisors regardless of this setting.
+// The gdpr.student_data_scope setting intentionally does NOT apply here —
+// write operations remain restricted to group supervisors regardless of scope.
+// For read access checks, use checkStudentReadAccess instead.
 func (rs *Resource) checkStudentFullAccess(r *http.Request, student *users.Student) bool {
+	return rs.isGroupSupervisorOrAdmin(r, student)
+}
+
+// checkStudentReadAccess determines if the current user has full read access
+// to a student's data (profile, location, visit info, privacy details, pickup
+// schedules). Returns true if the user is an admin, a verified staff member
+// when the tenant's student_data_scope is set to all_staff, or a supervisor
+// of the student's education group.
+//
+// This function MUST only be used on read paths. Write operations must use
+// checkStudentFullAccess which ignores the scope setting.
+func (rs *Resource) checkStudentReadAccess(r *http.Request, student *users.Student) bool {
 	userPermissions := jwt.PermissionsFromCtx(r.Context())
 	if hasAdminPermissions(userPermissions) {
 		return true
@@ -230,6 +243,8 @@ func (rs *Resource) checkStudentFullAccess(r *http.Request, student *users.Stude
 
 	// Tenant-configurable: when student_data_scope is set to all_staff, any
 	// authenticated staff member gets full read access to any student.
+	// Verify the caller is actually a staff member — other roles (guest,
+	// guardian) with users:read must NOT get unredacted access.
 	scope := configService.ResolveStringOrDefault(
 		r.Context(),
 		rs.SettingsService,
@@ -238,6 +253,35 @@ func (rs *Resource) checkStudentFullAccess(r *http.Request, student *users.Stude
 		rs.Logger,
 	)
 	if scope == configModel.StudentDataScopeAllStaff {
+		if staff, err := rs.UserContextService.GetCurrentStaff(r.Context()); err == nil && staff != nil {
+			return true
+		}
+	}
+
+	if student.GroupID == nil {
+		return false
+	}
+
+	educationGroups, err := rs.UserContextService.GetMyGroups(r.Context())
+	if err != nil {
+		return false
+	}
+
+	for _, group := range educationGroups {
+		if group.ID == *student.GroupID {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isGroupSupervisorOrAdmin checks if the caller is an admin or supervises the
+// student's education group. This is the core authorization logic shared by
+// both read and write access paths (before scope overrides are applied).
+func (rs *Resource) isGroupSupervisorOrAdmin(r *http.Request, student *users.Student) bool {
+	userPermissions := jwt.PermissionsFromCtx(r.Context())
+	if hasAdminPermissions(userPermissions) {
 		return true
 	}
 
@@ -410,7 +454,7 @@ func (rs *Resource) getStudent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	group := rs.getStudentGroup(r.Context(), student)
-	hasFullAccess := rs.checkStudentFullAccess(r, student)
+	hasFullAccess := rs.checkStudentReadAccess(r, student)
 
 	attendanceLogEnabled := configService.ResolveBoolOrDefault(r.Context(), rs.SettingsService, configModel.KeyAttendanceLogEnabled, false, rs.Logger)
 	feedbackEnabled := configService.ResolveBoolOrDefault(r.Context(), rs.SettingsService, configModel.KeyFeedbackEnabled, false, rs.Logger)

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -216,11 +216,28 @@ func (rs *Resource) getStudentGroup(ctx context.Context, student *users.Student)
 	return group
 }
 
-// checkStudentFullAccess determines if the current user has full access to a student's data
-// Returns true if user is admin or supervises the student's group
+// checkStudentFullAccess determines if the current user has full access to a student's data.
+// Returns true if the user is an admin, the tenant's student_data_scope is set to all_staff,
+// or the user supervises the student's education group.
+//
+// This function gates READ access only. Write operations (update, delete, check-in, etc.)
+// remain restricted to the student's group supervisors regardless of this setting.
 func (rs *Resource) checkStudentFullAccess(r *http.Request, student *users.Student) bool {
 	userPermissions := jwt.PermissionsFromCtx(r.Context())
 	if hasAdminPermissions(userPermissions) {
+		return true
+	}
+
+	// Tenant-configurable: when student_data_scope is set to all_staff, any
+	// authenticated staff member gets full read access to any student.
+	scope := configService.ResolveStringOrDefault(
+		r.Context(),
+		rs.SettingsService,
+		configModel.KeyStudentDataScope,
+		configModel.StudentDataScopeGroupSupervisorsOnly,
+		rs.Logger,
+	)
+	if scope == configModel.StudentDataScopeAllStaff {
 		return true
 	}
 

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -455,6 +455,7 @@ func (rs *Resource) getStudent(w http.ResponseWriter, r *http.Request) {
 
 	group := rs.getStudentGroup(r.Context(), student)
 	hasFullAccess := rs.checkStudentReadAccess(r, student)
+	hasWriteAccess := rs.checkStudentFullAccess(r, student)
 
 	attendanceLogEnabled := configService.ResolveBoolOrDefault(r.Context(), rs.SettingsService, configModel.KeyAttendanceLogEnabled, false, rs.Logger)
 	feedbackEnabled := configService.ResolveBoolOrDefault(r.Context(), rs.SettingsService, configModel.KeyFeedbackEnabled, false, rs.Logger)
@@ -470,6 +471,7 @@ func (rs *Resource) getStudent(w http.ResponseWriter, r *http.Request) {
 			PersonService: rs.PersonService,
 		}),
 		HasFullAccess:        hasFullAccess,
+		HasWriteAccess:       hasWriteAccess,
 		AttendanceLogEnabled: attendanceLogEnabled,
 		FeedbackEnabled:      feedbackEnabled,
 	}

--- a/backend/api/students/authorization_test.go
+++ b/backend/api/students/authorization_test.go
@@ -267,11 +267,13 @@ func TestStudentDataScope_AllStaff_GrantsFullReadAccess(t *testing.T) {
 
 	var resp struct {
 		Data struct {
-			HasFullAccess bool `json:"has_full_access"`
+			HasFullAccess  bool `json:"has_full_access"`
+			HasWriteAccess bool `json:"has_write_access"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-	assert.True(t, resp.Data.HasFullAccess, "all_staff scope should grant full access to non-supervisors")
+	assert.True(t, resp.Data.HasFullAccess, "all_staff scope should grant full read access to non-supervisors")
+	assert.False(t, resp.Data.HasWriteAccess, "all_staff scope should NOT grant write access to non-supervisors")
 }
 
 // TestStudentDataScope_GroupSupervisorsOnly_RedactsForNonSupervisor verifies that
@@ -299,11 +301,13 @@ func TestStudentDataScope_GroupSupervisorsOnly_RedactsForNonSupervisor(t *testin
 
 	var resp struct {
 		Data struct {
-			HasFullAccess bool `json:"has_full_access"`
+			HasFullAccess  bool `json:"has_full_access"`
+			HasWriteAccess bool `json:"has_write_access"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
 	assert.False(t, resp.Data.HasFullAccess, "group_supervisors_only should redact non-supervisors")
+	assert.False(t, resp.Data.HasWriteAccess, "group_supervisors_only should not grant write access to non-supervisors")
 }
 
 // TestStudentDataScope_AllStaff_GrantsAccessToGrouplessStudent covers the edge
@@ -326,11 +330,13 @@ func TestStudentDataScope_AllStaff_GrantsAccessToGrouplessStudent(t *testing.T) 
 
 	var resp struct {
 		Data struct {
-			HasFullAccess bool `json:"has_full_access"`
+			HasFullAccess  bool `json:"has_full_access"`
+			HasWriteAccess bool `json:"has_write_access"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
 	assert.True(t, resp.Data.HasFullAccess, "all_staff scope should grant access even to students without groups")
+	assert.False(t, resp.Data.HasWriteAccess, "all_staff scope should NOT grant write access even for groupless students")
 }
 
 // TestStudentDataScope_DoesNotAffectWrites confirms that flipping the scope to

--- a/backend/api/students/authorization_test.go
+++ b/backend/api/students/authorization_test.go
@@ -1,6 +1,7 @@
 package students_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -9,8 +10,21 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/moto-nrw/project-phoenix/api/testutil"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
+
+// setStudentDataScope overrides gdpr.student_data_scope for tenant 1 and
+// registers a cleanup to reset it at the end of the test.
+func setStudentDataScope(t *testing.T, tc *testContext, scope string) {
+	t.Helper()
+	ctx := testpkg.TenantContext(1)
+	err := tc.services.Settings.SetValue(ctx, configModel.KeyStudentDataScope, scope, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tc.services.Settings.ResetValue(ctx, configModel.KeyStudentDataScope, nil, nil)
+	})
+}
 
 // =============================================================================
 // Authorization Tests (Non-Admin Access)
@@ -220,4 +234,208 @@ func TestGetStudent_WithTeacherAccess(t *testing.T) {
 	rr := executeWithAuth(router, req, claims, []string{"students:read"})
 
 	assert.Equal(t, http.StatusOK, rr.Code, "Teacher should get student")
+}
+
+// =============================================================================
+// Student Data Scope Setting Tests (gdpr.student_data_scope)
+// =============================================================================
+
+// TestStudentDataScope_AllStaff_GrantsFullReadAccess verifies that when a tenant
+// sets gdpr.student_data_scope = all_staff, any authenticated staff member with
+// users:read permission sees the full student profile, not just the redacted view.
+func TestStudentDataScope_AllStaff_GrantsFullReadAccess(t *testing.T) {
+	tc := setupTestContext(t)
+	setStudentDataScope(t, tc, configModel.StudentDataScopeAllStaff)
+
+	// Create a student assigned to a group, plus an unrelated staff member
+	// who does NOT supervise that group. Under the default scope this staff
+	// would only see the limited/redacted fields; with all_staff they should
+	// see the full profile.
+	group := testpkg.CreateTestEducationGroup(t, tc.db, "DataScopeGroup")
+	student := testpkg.CreateTestStudent(t, tc.db, "Scope", "Student", "DS1")
+	otherStaff, otherAccount := testpkg.CreateTestStaffWithAccount(t, tc.db, "Other", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, group.ID, student.ID, otherStaff.ID)
+
+	testpkg.AssignStudentToGroup(t, tc.db, student.ID, group.ID)
+
+	router := setupRouter(tc.resource.GetStudentHandler(), "id")
+	req := testutil.NewRequest("GET", fmt.Sprintf("/%d", student.ID), nil)
+	claims := testutil.TeacherTestClaims(int(otherAccount.ID))
+	rr := executeWithAuth(router, req, claims, []string{"users:read"})
+
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+
+	var resp struct {
+		Data struct {
+			HasFullAccess bool `json:"has_full_access"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.True(t, resp.Data.HasFullAccess, "all_staff scope should grant full access to non-supervisors")
+}
+
+// TestStudentDataScope_GroupSupervisorsOnly_RedactsForNonSupervisor verifies that
+// the default scope still redacts non-supervisor access. This is the pre-existing
+// behavior — the test locks it in to catch regressions from the scope rewrite.
+func TestStudentDataScope_GroupSupervisorsOnly_RedactsForNonSupervisor(t *testing.T) {
+	tc := setupTestContext(t)
+	// Explicitly set the default value so the test is independent of
+	// whatever the tenant happens to have persisted in the DB.
+	setStudentDataScope(t, tc, configModel.StudentDataScopeGroupSupervisorsOnly)
+
+	group := testpkg.CreateTestEducationGroup(t, tc.db, "DefaultScopeGroup")
+	student := testpkg.CreateTestStudent(t, tc.db, "Default", "Student", "DS2")
+	otherStaff, otherAccount := testpkg.CreateTestStaffWithAccount(t, tc.db, "Unrelated", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, group.ID, student.ID, otherStaff.ID)
+
+	testpkg.AssignStudentToGroup(t, tc.db, student.ID, group.ID)
+
+	router := setupRouter(tc.resource.GetStudentHandler(), "id")
+	req := testutil.NewRequest("GET", fmt.Sprintf("/%d", student.ID), nil)
+	claims := testutil.TeacherTestClaims(int(otherAccount.ID))
+	rr := executeWithAuth(router, req, claims, []string{"users:read"})
+
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+
+	var resp struct {
+		Data struct {
+			HasFullAccess bool `json:"has_full_access"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.False(t, resp.Data.HasFullAccess, "group_supervisors_only should redact non-supervisors")
+}
+
+// TestStudentDataScope_AllStaff_GrantsAccessToGrouplessStudent covers the edge
+// case where a student has no group assigned. Under the default scope, the only
+// way to see full data is to be an admin. With all_staff, any staff should see it.
+func TestStudentDataScope_AllStaff_GrantsAccessToGrouplessStudent(t *testing.T) {
+	tc := setupTestContext(t)
+	setStudentDataScope(t, tc, configModel.StudentDataScopeAllStaff)
+
+	student := testpkg.CreateTestStudent(t, tc.db, "NoGroup", "Scoped", "DS3")
+	staff, account := testpkg.CreateTestStaffWithAccount(t, tc.db, "AnyStaff", "Member")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID, staff.ID)
+
+	router := setupRouter(tc.resource.GetStudentHandler(), "id")
+	req := testutil.NewRequest("GET", fmt.Sprintf("/%d", student.ID), nil)
+	claims := testutil.TeacherTestClaims(int(account.ID))
+	rr := executeWithAuth(router, req, claims, []string{"users:read"})
+
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+
+	var resp struct {
+		Data struct {
+			HasFullAccess bool `json:"has_full_access"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.True(t, resp.Data.HasFullAccess, "all_staff scope should grant access even to students without groups")
+}
+
+// TestStudentDataScope_DoesNotAffectWrites confirms that flipping the scope to
+// all_staff does NOT relax write authorization — update/delete remain restricted
+// to group supervisors. This is the critical invariant of this feature.
+func TestStudentDataScope_DoesNotAffectWrites(t *testing.T) {
+	tc := setupTestContext(t)
+	setStudentDataScope(t, tc, configModel.StudentDataScopeAllStaff)
+
+	group := testpkg.CreateTestEducationGroup(t, tc.db, "WriteScopeGroup")
+	student := testpkg.CreateTestStudent(t, tc.db, "Write", "Student", "DS4")
+	otherStaff, otherAccount := testpkg.CreateTestStaffWithAccount(t, tc.db, "WriteDenied", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, group.ID, student.ID, otherStaff.ID)
+
+	testpkg.AssignStudentToGroup(t, tc.db, student.ID, group.ID)
+
+	// A non-supervisor attempts to update → must still be forbidden even
+	// though the read scope is fully open.
+	router := setupRouter(tc.resource.UpdateStudentHandler(), "id")
+	body := map[string]interface{}{"first_name": "ShouldNotChange"}
+	req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d", student.ID), body)
+	claims := testutil.TeacherTestClaims(int(otherAccount.ID))
+	rr := executeWithAuth(router, req, claims, []string{"students:write"})
+
+	testutil.AssertForbidden(t, rr)
+}
+
+// TestStudentDataScope_AllStaff_ListReturnsFullAccess verifies that the student
+// LIST endpoint uses the per-request access context, and with all_staff scope
+// non-supervisor staff see sensitive fields (like extra_info) that would normally
+// be redacted. This covers studentAccessContext.hasFullAccessToStudent.
+func TestStudentDataScope_AllStaff_ListReturnsFullAccess(t *testing.T) {
+	tc := setupTestContext(t)
+	setStudentDataScope(t, tc, configModel.StudentDataScopeAllStaff)
+
+	group := testpkg.CreateTestEducationGroup(t, tc.db, "ListScopeGroup")
+	student := testpkg.CreateTestStudent(t, tc.db, "ListScope", "Student", "DS5")
+	otherStaff, otherAccount := testpkg.CreateTestStaffWithAccount(t, tc.db, "ListViewer", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, group.ID, student.ID, otherStaff.ID)
+
+	testpkg.AssignStudentToGroup(t, tc.db, student.ID, group.ID)
+
+	// Add a sensitive field that only appears when hasFullAccessToStudent returns true.
+	// extra_info is a supervisor-visible field redacted from non-supervisors under the
+	// default scope. With all_staff scope it should appear for any staff viewer.
+	ctx := testpkg.TenantContext(1)
+	_, err := tc.db.ExecContext(ctx,
+		"UPDATE users.students SET extra_info = ? WHERE id = ?",
+		"LIST_SCOPE_MARKER_d5s", student.ID)
+	require.NoError(t, err)
+
+	router := setupRouter(tc.resource.ListStudentsHandler(), "")
+	// Filter by search query so we only get our specific student back and
+	// aren't fooled by leftover test data from other tests in the same run.
+	req := testutil.NewRequest("GET", "/?search=ListScope", nil)
+	claims := testutil.TeacherTestClaims(int(otherAccount.ID))
+	rr := executeWithAuth(router, req, claims, []string{"users:read"})
+
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+	// The extra_info field should only be present when the viewer has full access.
+	// Under all_staff scope, this non-supervisor must see it.
+	assert.Contains(t, rr.Body.String(), "LIST_SCOPE_MARKER_d5s",
+		"all_staff scope should expose extra_info to non-supervisors in list responses")
+}
+
+// TestStudentDataScope_AllStaff_GroupRoomAccessible verifies that the
+// in-group-room endpoint works for non-supervisor staff when scope is all_staff.
+func TestStudentDataScope_AllStaff_GroupRoomAccessible(t *testing.T) {
+	tc := setupTestContext(t)
+	setStudentDataScope(t, tc, configModel.StudentDataScopeAllStaff)
+
+	group := testpkg.CreateTestEducationGroup(t, tc.db, "GroupRoomScopeGroup")
+	student := testpkg.CreateTestStudent(t, tc.db, "GroupRoom", "Scoped", "DS6")
+	otherStaff, otherAccount := testpkg.CreateTestStaffWithAccount(t, tc.db, "GroupRoom", "Viewer")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, group.ID, student.ID, otherStaff.ID)
+
+	testpkg.AssignStudentToGroup(t, tc.db, student.ID, group.ID)
+
+	router := setupRouter(tc.resource.GetStudentInGroupRoomHandler(), "id")
+	req := testutil.NewRequest("GET", fmt.Sprintf("/%d", student.ID), nil)
+	claims := testutil.TeacherTestClaims(int(otherAccount.ID))
+	rr := executeWithAuth(router, req, claims, []string{"users:read"})
+
+	// Under the default scope this would be 403; with all_staff it should be 200.
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+}
+
+// TestStudentDataScope_GroupSupervisorsOnly_GroupRoomForbidden verifies the
+// default behavior — a non-supervisor accessing the in-group-room endpoint is
+// forbidden. Locks in the pre-existing restriction to catch regressions.
+func TestStudentDataScope_GroupSupervisorsOnly_GroupRoomForbidden(t *testing.T) {
+	tc := setupTestContext(t)
+	setStudentDataScope(t, tc, configModel.StudentDataScopeGroupSupervisorsOnly)
+
+	group := testpkg.CreateTestEducationGroup(t, tc.db, "GroupRoomForbiddenGroup")
+	student := testpkg.CreateTestStudent(t, tc.db, "GroupRoom", "Forbidden", "DS7")
+	otherStaff, otherAccount := testpkg.CreateTestStaffWithAccount(t, tc.db, "GroupRoom", "Denied")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, group.ID, student.ID, otherStaff.ID)
+
+	testpkg.AssignStudentToGroup(t, tc.db, student.ID, group.ID)
+
+	router := setupRouter(tc.resource.GetStudentInGroupRoomHandler(), "id")
+	req := testutil.NewRequest("GET", fmt.Sprintf("/%d", student.ID), nil)
+	claims := testutil.TeacherTestClaims(int(otherAccount.ID))
+	rr := executeWithAuth(router, req, claims, []string{"users:read"})
+
+	testutil.AssertForbidden(t, rr)
 }

--- a/backend/api/students/list_helpers.go
+++ b/backend/api/students/list_helpers.go
@@ -7,7 +7,9 @@ import (
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/models/base"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/models/users"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
 )
 
 // studentListParams holds all query parameters for student listing
@@ -25,8 +27,9 @@ type studentListParams struct {
 
 // studentAccessContext holds access control information for student listing
 type studentAccessContext struct {
-	isAdmin    bool
-	myGroupIDs map[int64]struct{}
+	isAdmin       bool
+	allStaffScope bool // true when gdpr.student_data_scope = all_staff
+	myGroupIDs    map[int64]struct{}
 }
 
 // parseStudentListParams extracts query parameters from the request
@@ -98,11 +101,23 @@ func (p *studentListParams) buildCountOptions() *base.QueryOptions {
 	return countOptions
 }
 
-// determineStudentAccess determines access level and group IDs for the current user
+// determineStudentAccess determines access level and group IDs for the current user.
+// Resolves the tenant-configurable student_data_scope once per request so that
+// per-student access checks remain cheap when iterating a list of students.
 func (rs *Resource) determineStudentAccess(r *http.Request) *studentAccessContext {
 	ctx := &studentAccessContext{
 		isAdmin: hasAdminPermissions(jwt.PermissionsFromCtx(r.Context())),
 	}
+
+	// Resolve student_data_scope once; this governs read-access for non-admin staff.
+	scope := configService.ResolveStringOrDefault(
+		r.Context(),
+		rs.SettingsService,
+		configModel.KeyStudentDataScope,
+		configModel.StudentDataScopeGroupSupervisorsOnly,
+		rs.Logger,
+	)
+	ctx.allStaffScope = scope == configModel.StudentDataScopeAllStaff
 
 	if !ctx.isAdmin {
 		if staff, err := rs.UserContextService.GetCurrentStaff(r.Context()); err == nil && staff != nil {
@@ -118,9 +133,11 @@ func (rs *Resource) determineStudentAccess(r *http.Request) *studentAccessContex
 	return ctx
 }
 
-// hasFullAccessToStudent checks if user has full access to a specific student
+// hasFullAccessToStudent checks if user has full access to a specific student.
+// Returns true for admins, when the tenant-wide all_staff scope is enabled,
+// or when the user supervises the student's education group.
 func (ac *studentAccessContext) hasFullAccessToStudent(student *users.Student) bool {
-	if ac.isAdmin {
+	if ac.isAdmin || ac.allStaffScope {
 		return true
 	}
 	if student.GroupID != nil && ac.myGroupIDs != nil {

--- a/backend/api/students/list_helpers.go
+++ b/backend/api/students/list_helpers.go
@@ -109,18 +109,20 @@ func (rs *Resource) determineStudentAccess(r *http.Request) *studentAccessContex
 		isAdmin: hasAdminPermissions(jwt.PermissionsFromCtx(r.Context())),
 	}
 
-	// Resolve student_data_scope once; this governs read-access for non-admin staff.
-	scope := configService.ResolveStringOrDefault(
-		r.Context(),
-		rs.SettingsService,
-		configModel.KeyStudentDataScope,
-		configModel.StudentDataScopeGroupSupervisorsOnly,
-		rs.Logger,
-	)
-	ctx.allStaffScope = scope == configModel.StudentDataScopeAllStaff
-
 	if !ctx.isAdmin {
 		if staff, err := rs.UserContextService.GetCurrentStaff(r.Context()); err == nil && staff != nil {
+			// Resolve student_data_scope once; this governs read-access for non-admin staff.
+			// Only apply the all_staff scope if the caller is a verified staff member —
+			// other roles (guest, guardian) with users:read must NOT get unredacted access.
+			scope := configService.ResolveStringOrDefault(
+				r.Context(),
+				rs.SettingsService,
+				configModel.KeyStudentDataScope,
+				configModel.StudentDataScopeGroupSupervisorsOnly,
+				rs.Logger,
+			)
+			ctx.allStaffScope = scope == configModel.StudentDataScopeAllStaff
+
 			if educationGroups, err := rs.UserContextService.GetMyGroups(r.Context()); err == nil {
 				ctx.myGroupIDs = make(map[int64]struct{}, len(educationGroups))
 				for _, eduGroup := range educationGroups {

--- a/backend/api/students/pickup_schedule_handlers.go
+++ b/backend/api/students/pickup_schedule_handlers.go
@@ -276,12 +276,17 @@ func (rs *Resource) getStaffIDFromJWT(r *http.Request) (int64, error) {
 	return staff.ID, nil
 }
 
-// requirePickupReadAccess parses the student from URL params without checking full access.
-// Used for read-only operations that should be visible to all authenticated staff.
+// requirePickupReadAccess parses the student from URL params and checks read access.
+// Respects the gdpr.student_data_scope setting: with group_supervisors_only only
+// supervisors and admins can view pickup data; with all_staff any verified staff can.
 // Returns the student on success or writes an error response and returns nil.
 func (rs *Resource) requirePickupReadAccess(w http.ResponseWriter, r *http.Request) *users.Student {
 	student, ok := rs.parseAndGetStudent(w, r)
 	if !ok {
+		return nil
+	}
+	if !rs.checkStudentReadAccess(r, student) {
+		renderError(w, r, ErrorForbidden(fmt.Errorf("read access required to view pickup schedules")))
 		return nil
 	}
 	return student
@@ -315,7 +320,7 @@ func parseEntityID(w http.ResponseWriter, r *http.Request, param string, label s
 }
 
 // getStudentPickupSchedules handles GET /students/{id}/pickup-schedules
-// This endpoint is accessible to all authenticated staff (read-only)
+// Access is controlled by the gdpr.student_data_scope tenant setting.
 func (rs *Resource) getStudentPickupSchedules(w http.ResponseWriter, r *http.Request) {
 	student := rs.requirePickupReadAccess(w, r)
 	if student == nil {
@@ -794,29 +799,26 @@ func (rs *Resource) DeleteStudentPickupNoteHandler() http.HandlerFunc {
 }
 
 // filterAuthorizedStudentIDs filters the requested student IDs to only those
-// the current user has access to (admin sees all, others see only their groups' students)
+// the current user has read access to. Respects the gdpr.student_data_scope
+// setting: admins see all, all_staff scope lets any verified staff see all,
+// otherwise only students in the user's supervised groups are returned.
 func (rs *Resource) filterAuthorizedStudentIDs(r *http.Request, requestedIDs []int64) ([]int64, error) {
-	userPermissions := jwt.PermissionsFromCtx(r.Context())
+	accessCtx := rs.determineStudentAccess(r)
 
-	// Admins have access to all students
-	if hasAdminPermissions(userPermissions) {
+	// Admins and all_staff scope see all requested students
+	if accessCtx.isAdmin || accessCtx.allStaffScope {
 		return requestedIDs, nil
 	}
 
-	// Get groups the user supervises
-	educationGroups, err := rs.UserContextService.GetMyGroups(r.Context())
-	if err != nil {
-		return nil, err
-	}
-
-	if len(educationGroups) == 0 {
+	// No supervised groups → no access
+	if len(accessCtx.myGroupIDs) == 0 {
 		return []int64{}, nil
 	}
 
-	// Extract group IDs
-	groupIDs := make([]int64, 0, len(educationGroups))
-	for _, group := range educationGroups {
-		groupIDs = append(groupIDs, group.ID)
+	// Extract group IDs from access context
+	groupIDs := make([]int64, 0, len(accessCtx.myGroupIDs))
+	for gid := range accessCtx.myGroupIDs {
+		groupIDs = append(groupIDs, gid)
 	}
 
 	// Get all students in these groups

--- a/backend/api/students/pickup_schedule_handlers_test.go
+++ b/backend/api/students/pickup_schedule_handlers_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/api/testutil"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
@@ -113,8 +114,8 @@ func TestGetStudentPickupSchedules(t *testing.T) {
 		testutil.AssertNotFound(t, rr)
 	})
 
-	t.Run("success_any_staff_can_read_schedules", func(t *testing.T) {
-		// Any authenticated staff can read pickup schedules (read-only access)
+	t.Run("forbidden_non_supervisor_with_default_scope", func(t *testing.T) {
+		// Default scope (group_supervisors_only): non-supervisors cannot read pickup schedules
 		staff, account := testpkg.CreateTestStaffWithAccount(t, tc.db, "NoAccess", "Staff")
 		defer testpkg.CleanupActivityFixtures(t, tc.db, staff.ID)
 
@@ -122,7 +123,21 @@ func TestGetStudentPickupSchedules(t *testing.T) {
 		claims := testutil.TeacherTestClaims(int(account.ID))
 		rr := executeWithAuth(router, req, claims, []string{"students:read"})
 
-		assert.Equal(t, http.StatusOK, rr.Code, "Expected 200 OK - any staff can read pickup schedules. Body: %s", rr.Body.String())
+		assert.Equal(t, http.StatusForbidden, rr.Code, "Non-supervisor should be forbidden with default scope. Body: %s", rr.Body.String())
+	})
+
+	t.Run("success_any_staff_can_read_with_all_staff_scope", func(t *testing.T) {
+		// all_staff scope: any verified staff member can read pickup schedules
+		setStudentDataScope(t, tc, configModel.StudentDataScopeAllStaff)
+
+		staff, account := testpkg.CreateTestStaffWithAccount(t, tc.db, "AllStaff", "Reader")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, staff.ID)
+
+		req := testutil.NewRequest("GET", fmt.Sprintf("/%d", student.ID), nil)
+		claims := testutil.TeacherTestClaims(int(account.ID))
+		rr := executeWithAuth(router, req, claims, []string{"students:read"})
+
+		assert.Equal(t, http.StatusOK, rr.Code, "Any staff should read pickup schedules with all_staff scope. Body: %s", rr.Body.String())
 	})
 }
 

--- a/backend/api/students/privacy_handlers.go
+++ b/backend/api/students/privacy_handlers.go
@@ -23,7 +23,7 @@ func (rs *Resource) getStudentPrivacyConsent(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Check if user has permission to view this student's data
-	hasFullAccess := rs.checkStudentFullAccess(r, student)
+	hasFullAccess := rs.checkStudentReadAccess(r, student)
 	if !hasFullAccess {
 		renderError(w, r, ErrorForbidden(errors.New("insufficient permissions to access this student's data")))
 		return

--- a/backend/api/students/response_helpers.go
+++ b/backend/api/students/response_helpers.go
@@ -196,6 +196,8 @@ func newStudentResponseWithOpts(ctx context.Context, opts StudentResponseOpts, s
 		response.GuardianContact = *student.GuardianContact
 	}
 
+	response.HasFullAccess = hasFullAccess
+
 	// Resolve location
 	if locationOverride != nil {
 		response.Location = *locationOverride
@@ -233,6 +235,8 @@ func newStudentResponseFromSnapshot(_ context.Context, student *users.Student, p
 	if student.GuardianContact != nil {
 		response.GuardianContact = *student.GuardianContact
 	}
+
+	response.HasFullAccess = hasFullAccess
 
 	locationInfo := snapshot.ResolveLocationWithTime(student.ID, hasFullAccess)
 	response.Location = locationInfo.Location

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -35,6 +35,7 @@ type StudentResponse struct {
 	Bus             bool       `json:"bus"`
 	Sick            bool       `json:"sick"`
 	SickSince       *time.Time `json:"sick_since,omitempty"`
+	HasFullAccess   bool       `json:"has_full_access"`
 	CreatedAt       time.Time  `json:"created_at"`
 	UpdatedAt       time.Time  `json:"updated_at"`
 }

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -53,6 +53,7 @@ type SupervisorContact struct {
 type StudentDetailResponse struct {
 	StudentResponse
 	HasFullAccess        bool                `json:"has_full_access"`
+	HasWriteAccess       bool                `json:"has_write_access"`
 	GroupSupervisors     []SupervisorContact `json:"group_supervisors,omitempty"`
 	AttendanceLogEnabled bool                `json:"attendance_log_enabled"`
 	FeedbackEnabled      bool                `json:"feedback_enabled"`

--- a/backend/api/students/visit_handlers.go
+++ b/backend/api/students/visit_handlers.go
@@ -31,7 +31,7 @@ func (rs *Resource) getStudentCurrentLocation(w http.ResponseWriter, r *http.Req
 	group := rs.getStudentGroup(r.Context(), student)
 
 	// Determine if user has full access to student location details
-	hasFullAccess := rs.checkStudentFullAccess(r, student)
+	hasFullAccess := rs.checkStudentReadAccess(r, student)
 
 	// Build student response
 	response := newStudentResponseWithOpts(r.Context(), StudentResponseOpts{

--- a/backend/api/students/visit_handlers.go
+++ b/backend/api/students/visit_handlers.go
@@ -9,6 +9,8 @@ import (
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
 )
 
 // getStudentCurrentLocation handles getting a student's current location with scheduled checkout info
@@ -65,11 +67,30 @@ func (rs *Resource) getStudentCurrentLocation(w http.ResponseWriter, r *http.Req
 	common.Respond(w, r, http.StatusOK, locationResponse, "Student location retrieved successfully")
 }
 
-// checkGroupRoomAccessAuthorization verifies if the user can view student room status
-// Returns an error if unauthorized, nil if authorized
+// checkGroupRoomAccessAuthorization verifies if the user can view student room status.
+// Returns an error if unauthorized, nil if authorized.
+//
+// Grants access to: admins, any staff when gdpr.student_data_scope = all_staff,
+// and the student's group supervisors. This endpoint is read-only.
 func (rs *Resource) checkGroupRoomAccessAuthorization(r *http.Request, studentGroupID int64) error {
 	if hasAdminPermissions(getPermissionsFromRequest(r)) {
 		return nil
+	}
+
+	// Tenant-configurable read scope: when set to all_staff, any authenticated
+	// staff member can view this information.
+	scope := configService.ResolveStringOrDefault(
+		r.Context(),
+		rs.SettingsService,
+		configModel.KeyStudentDataScope,
+		configModel.StudentDataScopeGroupSupervisorsOnly,
+		rs.Logger,
+	)
+	if scope == configModel.StudentDataScopeAllStaff {
+		if staff, err := rs.UserContextService.GetCurrentStaff(r.Context()); err == nil && staff != nil {
+			return nil
+		}
+		return errors.New("unauthorized to view student room status")
 	}
 
 	staff, err := rs.UserContextService.GetCurrentStaff(r.Context())

--- a/backend/database/repositories/active/visits.go
+++ b/backend/database/repositories/active/visits.go
@@ -759,7 +759,7 @@ func (r *VisitRepository) GetTodayVisitNamesForStudents(ctx context.Context, stu
 
 	var results []visitGroupNames
 
-	today := timezone.TodayUTC()
+	today := timezone.Today()
 
 	query := base.GetDB(ctx, r.db).NewSelect().
 		ModelTableExpr(tableExprActiveVisitsAsVisit).

--- a/backend/database/repositories/active/visits.go
+++ b/backend/database/repositories/active/visits.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/facilities"
@@ -729,6 +730,70 @@ func (r *VisitRepository) EndVisitsByActiveGroupIDs(ctx context.Context, activeG
 	}
 
 	return rowsAffected, nil
+}
+
+// visitGroupNames captures the activity + room names for a student visit (DB scan target).
+type visitGroupNames struct {
+	StudentID         int64  `bun:"student_id"`
+	ActivityGroupName string `bun:"activity_group_name"`
+	RoomName          string `bun:"room_name"`
+}
+
+// GetTodayVisitNamesForStudents returns activity group + room names for all of
+// today's visits for the given students. Used for tracking indicator matching.
+func (r *VisitRepository) GetTodayVisitNamesForStudents(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+	if len(studentIDs) == 0 {
+		return nil, nil
+	}
+
+	// Deduplicate incoming IDs.
+	uniqueIDs := make([]int64, 0, len(studentIDs))
+	seen := make(map[int64]struct{}, len(studentIDs))
+	for _, id := range studentIDs {
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		uniqueIDs = append(uniqueIDs, id)
+	}
+
+	var results []visitGroupNames
+
+	today := timezone.TodayUTC()
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		ModelTableExpr(tableExprActiveVisitsAsVisit).
+		ColumnExpr(`"visit".student_id`).
+		ColumnExpr(`COALESCE("activity"."name", '') AS activity_group_name`).
+		ColumnExpr(`COALESCE("room"."name", '') AS room_name`).
+		Join(`LEFT JOIN active.groups AS "group" ON "group".id = "visit".active_group_id`).
+		Join(`LEFT JOIN activities.groups AS "activity" ON "activity".id = "group".group_id`).
+		Join(`LEFT JOIN facilities.rooms AS "room" ON "room".id = "group".room_id`).
+		Where(`"visit".student_id IN (?)`, bun.List(uniqueIDs)).
+		Where(`"visit".entry_time >= ?`, today)
+
+	if where, val, ok := base.TenantWhere(ctx, "visit"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx, &results); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "get today visit names for students",
+			Err: err,
+		}
+	}
+
+	// Convert to model type.
+	out := make([]active.VisitGroupNames, len(results))
+	for i, r := range results {
+		out[i] = active.VisitGroupNames{
+			StudentID:         r.StudentID,
+			ActivityGroupName: r.ActivityGroupName,
+			RoomName:          r.RoomName,
+		}
+	}
+
+	return out, nil
 }
 
 // FindActiveVisits finds all visits with no exit time (currently active)

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -128,6 +128,10 @@ type VisitRepository interface {
 	// EndVisitsByActiveGroupIDs ends all active visits for multiple group IDs in a single query.
 	// Returns the number of visits ended.
 	EndVisitsByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64) (int64, error)
+
+	// GetTodayVisitNamesForStudents returns activity group + room names for all of
+	// today's visits for the given students. Used for tracking indicator matching.
+	GetTodayVisitNamesForStudents(ctx context.Context, studentIDs []int64) ([]VisitGroupNames, error)
 }
 
 // GroupSupervisorRepository defines operations for managing active group supervisors

--- a/backend/models/active/visit.go
+++ b/backend/models/active/visit.go
@@ -81,6 +81,13 @@ func (v *Visit) Validate() error {
 	return nil
 }
 
+// VisitGroupNames holds the activity and room names from a visit for indicator matching.
+type VisitGroupNames struct {
+	StudentID         int64
+	ActivityGroupName string
+	RoomName          string
+}
+
 // IsActive returns whether this visit is currently active
 func (v *Visit) IsActive() bool {
 	return v.ExitTime == nil

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -42,6 +42,14 @@ const (
 	KeyCheckoutWCEnabled          = "checkout.wc_enabled"
 )
 
+// Tracking indicator settings (student card activity indicators).
+const (
+	KeyTrackingIndicatorsEnabled = "tracking.indicators_enabled"
+	KeyTrackingIndicator1        = "tracking.indicator_1"
+	KeyTrackingIndicator2        = "tracking.indicator_2"
+	KeyTrackingIndicator3        = "tracking.indicator_3"
+)
+
 // Operations settings.
 const (
 	KeySessionEndEnabled             = "operations.session_end_enabled"

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -29,6 +29,17 @@ const (
 	AttendanceLogScopeAllStaff             = "all_staff"
 )
 
+// Student data scope / who can read full student profile data.
+const (
+	KeyStudentDataScope = "gdpr.student_data_scope"
+)
+
+// StudentDataScope option values for KeyStudentDataScope.
+const (
+	StudentDataScopeGroupSupervisorsOnly = "group_supervisors_only"
+	StudentDataScopeAllStaff             = "all_staff"
+)
+
 // Feedback settings.
 const (
 	KeyFeedbackEnabled           = "feedback.enabled"

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/auth/device"
@@ -918,6 +919,51 @@ func (s *service) GetCrossTenantStudents(ctx context.Context, hostingTenantID in
 	)
 
 	return students, nil
+}
+
+// GetTrackingIndicators returns per-student match results for the given labels.
+// For each student, it checks today's visits and matches activity group name + room name
+// against each label using case-insensitive substring matching.
+func (s *service) GetTrackingIndicators(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+	result := make(map[int64][]bool, len(studentIDs))
+	if len(studentIDs) == 0 || len(labels) == 0 {
+		return result, nil
+	}
+
+	visitNames, err := s.visitRepo.GetTodayVisitNamesForStudents(ctx, studentIDs)
+	if err != nil {
+		return nil, &ActiveError{Op: "GetTrackingIndicators", Err: ErrDatabaseOperation}
+	}
+
+	// Build a map of student ID → concatenated visit texts for matching.
+	studentVisitTexts := make(map[int64][]string, len(studentIDs))
+	for _, vn := range visitNames {
+		text := strings.ToLower(strings.TrimSpace(vn.ActivityGroupName + " " + vn.RoomName))
+		studentVisitTexts[vn.StudentID] = append(studentVisitTexts[vn.StudentID], text)
+	}
+
+	// Lowercase the labels once.
+	lowerLabels := make([]string, len(labels))
+	for i, l := range labels {
+		lowerLabels[i] = strings.ToLower(strings.TrimSpace(l))
+	}
+
+	// For each student, check each label against their visit texts.
+	for _, sid := range studentIDs {
+		matches := make([]bool, len(labels))
+		texts := studentVisitTexts[sid]
+		for li, ll := range lowerLabels {
+			for _, t := range texts {
+				if strings.Contains(t, ll) {
+					matches[li] = true
+					break
+				}
+			}
+		}
+		result[sid] = matches
+	}
+
+	return result, nil
 }
 
 // visitSSEData holds data needed for SSE broadcasts after a visit is ended

--- a/backend/services/active/cleanup_service.go
+++ b/backend/services/active/cleanup_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/audit"
@@ -368,7 +369,9 @@ func (s *cleanupService) CleanupStaleAttendance(ctx context.Context) (*Attendanc
 		CheckInTime time.Time `bun:"check_in_time"`
 	}
 
-	err := s.db.NewSelect().
+	db := repoBase.GetDB(ctx, s.db)
+
+	err := db.NewSelect().
 		Table(attendanceTableName).
 		Column("id", "student_id", "date", "check_in_time").
 		Where("date < ?", today).
@@ -406,7 +409,7 @@ func (s *cleanupService) CleanupStaleAttendance(ctx context.Context) (*Attendanc
 		}
 
 		// Update the record
-		_, err := s.db.NewUpdate().
+		_, err := db.NewUpdate().
 			Table(attendanceTableName).
 			Set("check_out_time = ?", checkOutTime).
 			Set("updated_at = ?", time.Now()).
@@ -452,7 +455,9 @@ func (s *cleanupService) PreviewAttendanceCleanup(ctx context.Context) (*Attenda
 		Date      time.Time `bun:"date"`
 	}
 
-	err := s.db.NewSelect().
+	db := repoBase.GetDB(ctx, s.db)
+
+	err := db.NewSelect().
 		Table(attendanceTableName).
 		Column("student_id", "date").
 		Where("date < ?", today).

--- a/backend/services/active/end_session_unit_test.go
+++ b/backend/services/active/end_session_unit_test.go
@@ -147,6 +147,7 @@ type mockVisitRepository struct {
 	getCurrentByStudentIDWithRoomFunc func(ctx context.Context, studentID int64) (*active.Visit, error)
 	countActiveByRoomIDFunc           func(ctx context.Context, roomID int64) (int, error)
 	countActiveByGroupIDFunc          func(ctx context.Context, activeGroupID int64) (int, error)
+	getTodayVisitNamesFunc            func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error)
 }
 
 func (m *mockVisitRepository) Create(ctx context.Context, entity *active.Visit) error {
@@ -260,6 +261,9 @@ func (m *mockVisitRepository) CountActiveByStudentID(ctx context.Context, studen
 }
 
 func (m *mockVisitRepository) GetTodayVisitNamesForStudents(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+	if m.getTodayVisitNamesFunc != nil {
+		return m.getTodayVisitNamesFunc(ctx, studentIDs)
+	}
 	return nil, nil
 }
 

--- a/backend/services/active/end_session_unit_test.go
+++ b/backend/services/active/end_session_unit_test.go
@@ -259,6 +259,10 @@ func (m *mockVisitRepository) CountActiveByStudentID(ctx context.Context, studen
 	return 0, nil
 }
 
+func (m *mockVisitRepository) GetTodayVisitNamesForStudents(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+	return nil, nil
+}
+
 // mockGroupSupervisorRepository is a minimal mock implementation of active.GroupSupervisorRepository
 type mockGroupSupervisorRepository struct {
 	findByActiveGroupIDFunc func(ctx context.Context, activeGroupID int64, activeOnly bool) ([]*active.GroupSupervisor, error)

--- a/backend/services/active/interface.go
+++ b/backend/services/active/interface.go
@@ -112,6 +112,10 @@ type Service interface {
 
 	// Cross-tenant student visibility (Ferienbetreuung / holiday care)
 	GetCrossTenantStudents(ctx context.Context, hostingTenantID int64) ([]active.CrossTenantStudent, error)
+
+	// Tracking indicators — returns per-student match results for the given labels.
+	// Each student gets a []bool aligned with the labels slice.
+	GetTrackingIndicators(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error)
 }
 
 // DashboardAnalytics represents aggregated analytics for dashboard

--- a/backend/services/active/tracking_indicators_unit_test.go
+++ b/backend/services/active/tracking_indicators_unit_test.go
@@ -1,0 +1,204 @@
+package active
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTrackingIndicators_EmptyStudentIDs(t *testing.T) {
+	svc := &service{}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{}, []string{"Mensa"})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestGetTrackingIndicators_EmptyLabels(t *testing.T) {
+	svc := &service{}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100}, []string{})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestGetTrackingIndicators_RepoError(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return nil, errors.New("database connection lost")
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100}, []string{"Mensa"})
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "GetTrackingIndicators")
+}
+
+func TestGetTrackingIndicators_NoVisits(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return nil, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100, 200}, []string{"Mensa", "Hausaufgaben"})
+
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	// All false because no visits
+	assert.Equal(t, []bool{false, false}, result[100])
+	assert.Equal(t, []bool{false, false}, result[200])
+}
+
+func TestGetTrackingIndicators_SubstringMatching(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Hausaufgaben Gruppe A", RoomName: "Raum 101"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100}, []string{"Hausaufgaben"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true}, result[100])
+}
+
+func TestGetTrackingIndicators_CaseInsensitive(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "MENSA Gruppe", RoomName: "Speisesaal"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100}, []string{"mensa"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true}, result[100])
+}
+
+func TestGetTrackingIndicators_MatchesRoomName(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Gruppe B", RoomName: "Mensa"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100}, []string{"Mensa"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true}, result[100])
+}
+
+func TestGetTrackingIndicators_MultipleLabelsPartialMatch(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Hausaufgaben", RoomName: "Raum 1"},
+				{StudentID: 100, ActivityGroupName: "Sport", RoomName: "Turnhalle"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(
+		context.Background(),
+		[]int64{100},
+		[]string{"Hausaufgaben", "Mensa", "Sport"},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true, false, true}, result[100])
+}
+
+func TestGetTrackingIndicators_MultipleStudents(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Mensa", RoomName: "Speisesaal"},
+				{StudentID: 200, ActivityGroupName: "Hausaufgaben", RoomName: "Raum 3"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(
+		context.Background(),
+		[]int64{100, 200},
+		[]string{"Mensa", "Hausaufgaben"},
+	)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, []bool{true, false}, result[100])
+	assert.Equal(t, []bool{false, true}, result[200])
+}
+
+func TestGetTrackingIndicators_StudentWithNoVisits(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			// Only student 100 has visits, student 200 has none
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Mensa", RoomName: "Speisesaal"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(
+		context.Background(),
+		[]int64{100, 200},
+		[]string{"Mensa"},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true}, result[100])
+	assert.Equal(t, []bool{false}, result[200])
+}
+
+func TestGetTrackingIndicators_WhitespaceInLabels(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Hausaufgaben", RoomName: "Raum 1"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(
+		context.Background(),
+		[]int64{100},
+		[]string{"  Hausaufgaben  "},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true}, result[100])
+}

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -30,6 +30,7 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"gdpr.attendance_visible_days",
 		"gdpr.room_detail_visible_days",
 		"gdpr.attendance_log_scope",
+		"gdpr.student_data_scope",
 		"feedback.enabled",
 		"feedback.data_retention_days",
 		"security.ogs_device_pin",
@@ -46,7 +47,7 @@ func TestAllSettingsRegistered(t *testing.T) {
 		assert.NotEmpty(t, def.Category, "setting %q should have a category", key)
 	}
 
-	assert.GreaterOrEqual(t, len(all), 20, "at least 20 settings should be registered")
+	assert.GreaterOrEqual(t, len(all), 21, "at least 21 settings should be registered")
 }
 
 func TestOperationsSettings_Types(t *testing.T) {
@@ -82,6 +83,7 @@ func TestGDPRSettings_Types(t *testing.T) {
 		{"gdpr.attendance_visible_days", config.FieldNumber},
 		{"gdpr.room_detail_visible_days", config.FieldNumber},
 		{"gdpr.attendance_log_scope", config.FieldSelect},
+		{"gdpr.student_data_scope", config.FieldSelect},
 		{"feedback.enabled", config.FieldBoolean},
 		{"feedback.data_retention_days", config.FieldNumber},
 	}
@@ -187,6 +189,23 @@ func TestAttendanceLogScope_Options(t *testing.T) {
 	assert.Contains(t, values, config.AttendanceLogScopeAllStaff)
 }
 
+func TestStudentDataScope_Options(t *testing.T) {
+	def := config.GetDefinition("gdpr.student_data_scope")
+	require.NotNil(t, def)
+	assert.Equal(t, "gdpr", def.Tab)
+	assert.Equal(t, "student_data", def.Category)
+	assert.Equal(t, config.FieldSelect, def.Type)
+	assert.Equal(t, config.StudentDataScopeGroupSupervisorsOnly, def.Default)
+	assert.Equal(t, "config:manage", def.WritePermission)
+	assert.Nil(t, def.DependsOn, "student_data_scope should stand alone, no DependsOn")
+
+	require.NotNil(t, def.Options)
+	require.Len(t, def.Options.Static, 2)
+	values := []any{def.Options.Static[0].Value, def.Options.Static[1].Value}
+	assert.Contains(t, values, config.StudentDataScopeGroupSupervisorsOnly)
+	assert.Contains(t, values, config.StudentDataScopeAllStaff)
+}
+
 func TestDevicesSettings(t *testing.T) {
 	keys := []string{
 		"checkout.raumwechsel_enabled",
@@ -259,6 +278,7 @@ func TestDefaults_HaveReasonableValues(t *testing.T) {
 		{"gdpr.attendance_visible_days", 30},
 		{"gdpr.room_detail_visible_days", 7},
 		{"gdpr.attendance_log_scope", config.AttendanceLogScopeGroupSupervisorsOnly},
+		{"gdpr.student_data_scope", config.StudentDataScopeGroupSupervisorsOnly},
 		{"feedback.enabled", false},
 		{"feedback.data_retention_days", 90},
 		{"security.ogs_device_pin", "1234"},

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -52,7 +52,6 @@ func TestAllSettingsRegistered(t *testing.T) {
 	}
 
 	assert.GreaterOrEqual(t, len(all), 25, "at least 25 settings should be registered")
-
 }
 
 func TestOperationsSettings_Types(t *testing.T) {
@@ -198,8 +197,7 @@ func TestStudentDataScope_Options(t *testing.T) {
 	def := config.GetDefinition("gdpr.student_data_scope")
 	require.NotNil(t, def)
 	assert.Equal(t, "gdpr", def.Tab)
-
-	assert.Equal(t, "student_data", def.Category)
+	assert.Equal(t, "schülerdaten", def.Category)
 	assert.Equal(t, config.FieldSelect, def.Type)
 	assert.Equal(t, config.StudentDataScopeGroupSupervisorsOnly, def.Default)
 	assert.Equal(t, "config:manage", def.WritePermission)

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -30,6 +30,7 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"gdpr.attendance_visible_days",
 		"gdpr.room_detail_visible_days",
 		"gdpr.attendance_log_scope",
+		"gdpr.student_data_scope",
 		"feedback.enabled",
 		"feedback.data_retention_days",
 		"security.ogs_device_pin",
@@ -50,7 +51,7 @@ func TestAllSettingsRegistered(t *testing.T) {
 		assert.NotEmpty(t, def.Category, "setting %q should have a category", key)
 	}
 
-	assert.GreaterOrEqual(t, len(all), 24, "at least 24 settings should be registered")
+	assert.GreaterOrEqual(t, len(all), 25, "at least 25 settings should be registered")
 }
 
 func TestOperationsSettings_Types(t *testing.T) {
@@ -86,6 +87,7 @@ func TestGDPRSettings_Types(t *testing.T) {
 		{"gdpr.attendance_visible_days", config.FieldNumber},
 		{"gdpr.room_detail_visible_days", config.FieldNumber},
 		{"gdpr.attendance_log_scope", config.FieldSelect},
+		{"gdpr.student_data_scope", config.FieldSelect},
 		{"feedback.enabled", config.FieldBoolean},
 		{"feedback.data_retention_days", config.FieldNumber},
 	}
@@ -191,6 +193,23 @@ func TestAttendanceLogScope_Options(t *testing.T) {
 	assert.Contains(t, values, config.AttendanceLogScopeAllStaff)
 }
 
+func TestStudentDataScope_Options(t *testing.T) {
+	def := config.GetDefinition("gdpr.student_data_scope")
+	require.NotNil(t, def)
+	assert.Equal(t, "gdpr", def.Tab)
+	assert.Equal(t, "schülerdaten", def.Category)
+	assert.Equal(t, config.FieldSelect, def.Type)
+	assert.Equal(t, config.StudentDataScopeGroupSupervisorsOnly, def.Default)
+	assert.Equal(t, "config:manage", def.WritePermission)
+	assert.Nil(t, def.DependsOn, "student_data_scope should stand alone, no DependsOn")
+
+	require.NotNil(t, def.Options)
+	require.Len(t, def.Options.Static, 2)
+	values := []any{def.Options.Static[0].Value, def.Options.Static[1].Value}
+	assert.Contains(t, values, config.StudentDataScopeGroupSupervisorsOnly)
+	assert.Contains(t, values, config.StudentDataScopeAllStaff)
+}
+
 func TestDevicesSettings(t *testing.T) {
 	keys := []string{
 		"checkout.raumwechsel_enabled",
@@ -263,6 +282,7 @@ func TestDefaults_HaveReasonableValues(t *testing.T) {
 		{"gdpr.attendance_visible_days", 30},
 		{"gdpr.room_detail_visible_days", 7},
 		{"gdpr.attendance_log_scope", config.AttendanceLogScopeGroupSupervisorsOnly},
+		{"gdpr.student_data_scope", config.StudentDataScopeGroupSupervisorsOnly},
 		{"feedback.enabled", false},
 		{"feedback.data_retention_days", 90},
 		{"security.ogs_device_pin", "1234"},

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -36,6 +36,10 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"checkout.raumwechsel_enabled",
 		"checkout.schulhof_enabled",
 		"checkout.wc_enabled",
+		"tracking.indicators_enabled",
+		"tracking.indicator_1",
+		"tracking.indicator_2",
+		"tracking.indicator_3",
 	}
 
 	for _, key := range expectedKeys {
@@ -46,7 +50,7 @@ func TestAllSettingsRegistered(t *testing.T) {
 		assert.NotEmpty(t, def.Category, "setting %q should have a category", key)
 	}
 
-	assert.GreaterOrEqual(t, len(all), 20, "at least 20 settings should be registered")
+	assert.GreaterOrEqual(t, len(all), 24, "at least 24 settings should be registered")
 }
 
 func TestOperationsSettings_Types(t *testing.T) {
@@ -265,6 +269,10 @@ func TestDefaults_HaveReasonableValues(t *testing.T) {
 		{"checkout.raumwechsel_enabled", true},
 		{"checkout.schulhof_enabled", false},
 		{"checkout.wc_enabled", false},
+		{"tracking.indicators_enabled", false},
+		{"tracking.indicator_1", ""},
+		{"tracking.indicator_2", ""},
+		{"tracking.indicator_3", ""},
 	}
 
 	for _, tc := range tests {
@@ -272,4 +280,58 @@ func TestDefaults_HaveReasonableValues(t *testing.T) {
 		require.NotNilf(t, def, "setting %q should exist", tc.key)
 		assert.Equalf(t, tc.expectedDefault, def.Default, "setting %q default", tc.key)
 	}
+}
+
+func TestTrackingSettings_Types(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected config.FieldType
+	}{
+		{"tracking.indicators_enabled", config.FieldBoolean},
+		{"tracking.indicator_1", config.FieldText},
+		{"tracking.indicator_2", config.FieldText},
+		{"tracking.indicator_3", config.FieldText},
+	}
+
+	for _, tc := range tests {
+		def := config.GetDefinition(tc.key)
+		require.NotNilf(t, def, "setting %q should exist", tc.key)
+		assert.Equalf(t, tc.expected, def.Type, "setting %q should be type %s", tc.key, tc.expected)
+	}
+}
+
+func TestDependsOn_TrackingGroup(t *testing.T) {
+	dependentKeys := []string{
+		"tracking.indicator_1",
+		"tracking.indicator_2",
+		"tracking.indicator_3",
+	}
+	for _, key := range dependentKeys {
+		def := config.GetDefinition(key)
+		require.NotNilf(t, def, "setting %q should exist", key)
+		require.NotNilf(t, def.DependsOn, "setting %q should have DependsOn", key)
+		assert.Equalf(t, "tracking.indicators_enabled", def.DependsOn.Key, "setting %q should depend on indicators_enabled", key)
+		assert.Equal(t, "eq", def.DependsOn.Condition)
+		assert.Equal(t, true, def.DependsOn.Value)
+	}
+}
+
+func TestTrackingIndicator_Validation(t *testing.T) {
+	indicatorKeys := []string{
+		"tracking.indicator_1",
+		"tracking.indicator_2",
+		"tracking.indicator_3",
+	}
+	for _, key := range indicatorKeys {
+		def := config.GetDefinition(key)
+		require.NotNilf(t, def, "setting %q should exist", key)
+		require.NotNilf(t, def.Validation, "setting %q should have validation", key)
+		require.NotNilf(t, def.Validation.Pattern, "setting %q should have pattern", key)
+		assert.Equal(t, `^[a-zA-ZäöüÄÖÜß\s]{0,30}$`, *def.Validation.Pattern, "setting %q pattern", key)
+	}
+
+	// Verify the toggle has no validation (boolean doesn't need it)
+	enabledDef := config.GetDefinition("tracking.indicators_enabled")
+	require.NotNil(t, enabledDef)
+	assert.Nil(t, enabledDef.Validation, "boolean toggle should have no validation")
 }

--- a/backend/services/config/defaults/gdpr.go
+++ b/backend/services/config/defaults/gdpr.go
@@ -135,4 +135,25 @@ func init() {
 			Value:     true,
 		},
 	})
+
+	// --- Schülerdaten-Zugriff (who can read full student profile data) ---
+
+	config.Register(config.Definition{
+		Key:             config.KeyStudentDataScope,
+		Label:           "Schülerdaten-Zugriff",
+		Description:     "Legt fest, welche Mitarbeitenden vollständige Schülerdaten (Profil, aktueller Aufenthaltsort, Besuchsinformationen, Datenschutzangaben und Abholpläne) einsehen dürfen. Schreiboperationen bleiben stets auf die Gruppenbetreuer des Schülers beschränkt.",
+		Type:            config.FieldSelect,
+		Default:         config.StudentDataScopeGroupSupervisorsOnly,
+		ReadPermission:  "config:read",
+		WritePermission: "config:manage",
+		Tab:             "gdpr",
+		Category:        "schülerdaten",
+		SortOrder:       20,
+		Options: &config.SelectOptions{
+			Static: []config.SelectOption{
+				{Label: "Nur Gruppenbetreuer des Schülers", Value: config.StudentDataScopeGroupSupervisorsOnly},
+				{Label: "Alle berechtigten Mitarbeitenden", Value: config.StudentDataScopeAllStaff},
+			},
+		},
+	})
 }

--- a/backend/services/config/defaults/gdpr.go
+++ b/backend/services/config/defaults/gdpr.go
@@ -147,7 +147,7 @@ func init() {
 		ReadPermission:  "config:read",
 		WritePermission: "config:manage",
 		Tab:             "gdpr",
-		Category:        "student_data",
+		Category:        "schülerdaten",
 		SortOrder:       20,
 		Options: &config.SelectOptions{
 			Static: []config.SelectOption{

--- a/backend/services/config/defaults/gdpr.go
+++ b/backend/services/config/defaults/gdpr.go
@@ -135,4 +135,25 @@ func init() {
 			Value:     true,
 		},
 	})
+
+	// --- Schülerdaten-Zugriff (who can read full student profile data) ---
+
+	config.Register(config.Definition{
+		Key:             config.KeyStudentDataScope,
+		Label:           "Schülerdaten-Zugriff",
+		Description:     "Legt fest, welche Mitarbeitenden vollständige Schülerdaten (Profil, aktueller Aufenthaltsort, Besuchsinformationen, Datenschutzangaben und Abholpläne) einsehen dürfen. Schreiboperationen bleiben stets auf die Gruppenbetreuer des Schülers beschränkt.",
+		Type:            config.FieldSelect,
+		Default:         config.StudentDataScopeGroupSupervisorsOnly,
+		ReadPermission:  "config:read",
+		WritePermission: "config:manage",
+		Tab:             "gdpr",
+		Category:        "student_data",
+		SortOrder:       20,
+		Options: &config.SelectOptions{
+			Static: []config.SelectOption{
+				{Label: "Nur Gruppenbetreuer des Schülers", Value: config.StudentDataScopeGroupSupervisorsOnly},
+				{Label: "Alle berechtigten Mitarbeitenden", Value: config.StudentDataScopeAllStaff},
+			},
+		},
+	})
 }

--- a/backend/services/config/defaults/tracking.go
+++ b/backend/services/config/defaults/tracking.go
@@ -1,0 +1,85 @@
+package defaults
+
+import (
+	"github.com/moto-nrw/project-phoenix/models/config"
+)
+
+func init() {
+	// --- Tracking Indicators ---
+	// Opt-in feature: shows in student cards whether a student has visited
+	// specific rooms/activities today (e.g., "Hausaufgaben", "Mensa").
+	// Admins configure up to 3 free-text labels; the backend matches them
+	// against today's visit history (activity group name + room name).
+
+	config.Register(config.Definition{
+		Key:             config.KeyTrackingIndicatorsEnabled,
+		Label:           "Aktivitäts-Indikatoren",
+		Description:     "Zeigt in den Schülerkarten an, ob ein Kind heute bereits in bestimmten Räumen oder Aktivitäten war",
+		Type:            config.FieldBoolean,
+		Default:         false,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "indikatoren",
+		SortOrder:       1,
+	})
+
+	indicatorPattern := `^[a-zA-ZäöüÄÖÜß\s]{0,30}$`
+
+	config.Register(config.Definition{
+		Key:             config.KeyTrackingIndicator1,
+		Label:           "Indikator 1",
+		Description:     "Suchbegriff für Raum- oder Aktivitätsnamen (z.B. 'Mensa', 'Hausaufgaben')",
+		Type:            config.FieldText,
+		Default:         "",
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "indikatoren",
+		SortOrder:       2,
+		Validation:      &config.ValidationRules{Pattern: &indicatorPattern},
+		DependsOn: &config.Dependency{
+			Key:       config.KeyTrackingIndicatorsEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyTrackingIndicator2,
+		Label:           "Indikator 2",
+		Description:     "Suchbegriff für Raum- oder Aktivitätsnamen (z.B. 'Mensa', 'Hausaufgaben')",
+		Type:            config.FieldText,
+		Default:         "",
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "indikatoren",
+		SortOrder:       3,
+		Validation:      &config.ValidationRules{Pattern: &indicatorPattern},
+		DependsOn: &config.Dependency{
+			Key:       config.KeyTrackingIndicatorsEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyTrackingIndicator3,
+		Label:           "Indikator 3",
+		Description:     "Suchbegriff für Raum- oder Aktivitätsnamen (z.B. 'Mensa', 'Hausaufgaben')",
+		Type:            config.FieldText,
+		Default:         "",
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "indikatoren",
+		SortOrder:       4,
+		Validation:      &config.ValidationRules{Pattern: &indicatorPattern},
+		DependsOn: &config.Dependency{
+			Key:       config.KeyTrackingIndicatorsEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+}

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -414,6 +414,20 @@ func (s *Scheduler) executeCleanupForTenant(ctx context.Context, tenantID int64)
 		)
 	}
 
+	// Cleanup stale attendance records (open from previous days)
+	if attendanceResult, err := s.cleanupService.CleanupStaleAttendance(ctx); err != nil {
+		s.getLogger().Error("attendance cleanup failed",
+			slog.Int64("tenant_id", tenantID),
+			slog.String("error", err.Error()),
+		)
+	} else if attendanceResult != nil && attendanceResult.RecordsClosed > 0 {
+		s.getLogger().Info("attendance cleanup completed",
+			slog.Int64("tenant_id", tenantID),
+			slog.Int("records_closed", attendanceResult.RecordsClosed),
+			slog.Int("students_affected", attendanceResult.StudentsAffected),
+		)
+	}
+
 	// Cleanup open work sessions
 	if s.workSessionCleanup != nil {
 		if closedCount, err := s.workSessionCleanup.CleanupOpenSessions(ctx); err != nil {

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -420,12 +420,20 @@ func (s *Scheduler) executeCleanupForTenant(ctx context.Context, tenantID int64)
 			slog.Int64("tenant_id", tenantID),
 			slog.String("error", err.Error()),
 		)
-	} else if attendanceResult != nil && attendanceResult.RecordsClosed > 0 {
-		s.getLogger().Info("attendance cleanup completed",
-			slog.Int64("tenant_id", tenantID),
-			slog.Int("records_closed", attendanceResult.RecordsClosed),
-			slog.Int("students_affected", attendanceResult.StudentsAffected),
-		)
+	} else if attendanceResult != nil {
+		if !attendanceResult.Success {
+			s.getLogger().Warn("attendance cleanup partial failure",
+				slog.Int64("tenant_id", tenantID),
+				slog.Int("records_closed", attendanceResult.RecordsClosed),
+				slog.Int("errors", len(attendanceResult.Errors)),
+			)
+		} else if attendanceResult.RecordsClosed > 0 {
+			s.getLogger().Info("attendance cleanup completed",
+				slog.Int64("tenant_id", tenantID),
+				slog.Int("records_closed", attendanceResult.RecordsClosed),
+				slog.Int("students_affected", attendanceResult.StudentsAffected),
+			)
+		}
 	}
 
 	// Cleanup open work sessions

--- a/backend/services/scheduler/scheduler_test.go
+++ b/backend/services/scheduler/scheduler_test.go
@@ -1147,6 +1147,9 @@ func (m *mockActiveService) ClaimActiveGroup(_ context.Context, _, _ int64, _ st
 func (m *mockActiveService) GetCrossTenantStudents(_ context.Context, _ int64) ([]active.CrossTenantStudent, error) {
 	return nil, nil
 }
+func (m *mockActiveService) GetTrackingIndicators(_ context.Context, _ []int64, _ []string) (map[int64][]bool, error) {
+	return nil, nil
+}
 
 // =============================================================================
 // Mock Cleanup Service for Execute Tests

--- a/backend/services/scheduler/scheduler_test.go
+++ b/backend/services/scheduler/scheduler_test.go
@@ -1167,6 +1167,7 @@ type mockCleanupService struct {
 	previewCalls           int
 	previewErr             error
 	attendanceCalls        int
+	attendanceResult       *activeService.AttendanceCleanupResult
 	attendanceErr          error
 	attendancePreviewCalls int
 	attendancePreviewErr   error
@@ -1204,7 +1205,7 @@ func (m *mockCleanupService) CleanupStaleAttendance(_ context.Context) (*activeS
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.attendanceCalls++
-	return nil, m.attendanceErr
+	return m.attendanceResult, m.attendanceErr
 }
 
 func (m *mockCleanupService) PreviewAttendanceCleanup(_ context.Context) (*activeService.AttendanceCleanupPreview, error) {
@@ -2358,6 +2359,78 @@ func TestExecuteCleanupForTenant_ReturnsTrueOnSuccess(t *testing.T) {
 	s := &Scheduler{
 		cleanupService: &mockCleanupService{
 			cleanupResult: &activeService.CleanupResult{},
+		},
+		logger: slog.Default(),
+	}
+	result := s.executeCleanupForTenant(context.Background(), 1)
+	assert.True(t, result)
+}
+
+func TestExecuteCleanupForTenant_AttendanceError(t *testing.T) {
+	s := &Scheduler{
+		cleanupService: &mockCleanupService{
+			cleanupResult: &activeService.CleanupResult{},
+			attendanceErr: errors.New("attendance db error"),
+		},
+		logger: slog.Default(),
+	}
+	result := s.executeCleanupForTenant(context.Background(), 1)
+	// Returns true because primary cleanup (expired visits) succeeded
+	assert.True(t, result)
+}
+
+func TestExecuteCleanupForTenant_AttendancePartialFailure(t *testing.T) {
+	s := &Scheduler{
+		cleanupService: &mockCleanupService{
+			cleanupResult: &activeService.CleanupResult{},
+			attendanceResult: &activeService.AttendanceCleanupResult{
+				Success:       false,
+				RecordsClosed: 3,
+				Errors:        []string{"record 1 failed", "record 2 failed"},
+			},
+		},
+		logger: slog.Default(),
+	}
+	result := s.executeCleanupForTenant(context.Background(), 1)
+	assert.True(t, result)
+}
+
+func TestExecuteCleanupForTenant_AttendanceSuccess(t *testing.T) {
+	s := &Scheduler{
+		cleanupService: &mockCleanupService{
+			cleanupResult: &activeService.CleanupResult{},
+			attendanceResult: &activeService.AttendanceCleanupResult{
+				Success:          true,
+				RecordsClosed:    5,
+				StudentsAffected: 3,
+			},
+		},
+		logger: slog.Default(),
+	}
+	result := s.executeCleanupForTenant(context.Background(), 1)
+	assert.True(t, result)
+}
+
+func TestExecuteCleanupForTenant_AttendanceNoRecords(t *testing.T) {
+	s := &Scheduler{
+		cleanupService: &mockCleanupService{
+			cleanupResult: &activeService.CleanupResult{},
+			attendanceResult: &activeService.AttendanceCleanupResult{
+				Success:       true,
+				RecordsClosed: 0,
+			},
+		},
+		logger: slog.Default(),
+	}
+	result := s.executeCleanupForTenant(context.Background(), 1)
+	assert.True(t, result)
+}
+
+func TestExecuteCleanupForTenant_AttendanceNilResult(t *testing.T) {
+	s := &Scheduler{
+		cleanupService: &mockCleanupService{
+			cleanupResult:    &activeService.CleanupResult{},
+			attendanceResult: nil,
 		},
 		logger: slog.Default(),
 	}

--- a/docs/settings/future-settings-backlog.md
+++ b/docs/settings/future-settings-backlog.md
@@ -7,21 +7,20 @@ This document catalogs every hardcoded business-logic decision in Project Phoeni
 
 ---
 
-## Currently Implemented (17 settings)
+## Currently Implemented (21 settings)
 
 For reference, these settings already exist in the registry (`services/config/defaults/`):
 
 | Key | Type | Default | Tab | File |
 |-----|------|---------|-----|------|
-| `security.ogs_device_pin` | password | `""` | security | `defaults/security.go` |
+| `security.ogs_device_pin` | password | `"1234"` | security | `defaults/security.go` |
 | `operations.session_end_enabled` | boolean | `true` | operations | `defaults/operations.go` |
 | `operations.session_end_time` | time | `"18:00"` | operations | `defaults/operations.go` |
 | `operations.session_end_timeout_minutes` | number | `10` | operations | `defaults/operations.go` |
 | `operations.student_daily_checkout_time` | time | `""` (optional — empty = always available) | operations | `defaults/operations.go` |
-| `operations.session_cleanup_enabled` | boolean | `true` | operations | `defaults/operations.go` |
+| `operations.session_cleanup_enabled` | boolean | `false` | operations | `defaults/operations.go` |
 | `operations.session_cleanup_interval_minutes` | number | `15` | operations | `defaults/operations.go` |
 | `operations.session_abandoned_threshold_minutes` | number | `60` | operations | `defaults/operations.go` |
-| `feedback.enabled` | boolean | `true` | operations | `defaults/feedback.go` |
 | `gdpr.data_cleanup_enabled` | boolean | `true` | gdpr | `defaults/gdpr.go` |
 | `gdpr.data_cleanup_time` | time | `"02:00"` | gdpr | `defaults/gdpr.go` |
 | `gdpr.data_cleanup_timeout_minutes` | number | `30` | gdpr | `defaults/gdpr.go` |
@@ -29,7 +28,12 @@ For reference, these settings already exist in the registry (`services/config/de
 | `gdpr.attendance_visible_days` | number | `30` | gdpr | `defaults/gdpr.go` |
 | `gdpr.room_detail_visible_days` | number | `7` | gdpr | `defaults/gdpr.go` |
 | `gdpr.attendance_log_scope` | select | `"group_supervisors_only"` | gdpr | `defaults/gdpr.go` |
+| `gdpr.student_data_scope` | select | `"group_supervisors_only"` | gdpr | `defaults/gdpr.go` |
+| `feedback.enabled` | boolean | `false` | gdpr | `defaults/feedback.go` |
 | `feedback.data_retention_days` | number | `90` | gdpr | `defaults/feedback.go` |
+| `checkout.raumwechsel_enabled` | boolean | `true` | devices | `defaults/devices.go` |
+| `checkout.schulhof_enabled` | boolean | `false` | devices | `defaults/devices.go` |
+| `checkout.wc_enabled` | boolean | `false` | devices | `defaults/devices.go` |
 
 ---
 

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -28,6 +28,8 @@ import {
 } from "~/components/students/student-card";
 import { createLogger } from "~/lib/logger";
 import { activeService } from "~/lib/active-api";
+import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
+import { TrackingIndicators } from "~/components/students/tracking-indicators";
 import type { Student } from "~/lib/student-helpers";
 import { UnclaimedRooms } from "~/components/active";
 import { SSEErrorBoundary } from "~/components/sse/SSEErrorBoundary";
@@ -815,6 +817,19 @@ function MeinRaumPageContent() {
     }
   }, [swrVisitsData, currentRoomId, updateRoomStudentCount]);
 
+  // Tracking indicators: fetch when student list changes (SSE-driven via SWR revalidation)
+  const trackingStudentIds = useMemo(
+    () => students.map((s) => s.id),
+    [students],
+  );
+  const { data: trackingData } = useSWRAuth<TrackingIndicatorsResponse>(
+    trackingStudentIds.length > 0
+      ? `tracking-supervisions-${currentRoomId}-${trackingStudentIds.join(",")}`
+      : null,
+    async () => activeService.getTrackingIndicators(trackingStudentIds),
+    { keepPreviousData: true, revalidateOnFocus: false },
+  );
+
   // Handle dashboard error
   useEffect(() => {
     if (dashboardError) {
@@ -1142,6 +1157,14 @@ function MeinRaumPageContent() {
                       </StudentInfoRow>
                     )}
                   </>
+                }
+                trackingIndicators={
+                  trackingData?.labels.length ? (
+                    <TrackingIndicators
+                      labels={trackingData.labels}
+                      results={trackingData.results[student.id] ?? []}
+                    />
+                  ) : undefined
                 }
               />
             ))}

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -52,6 +52,9 @@ import {
 } from "~/components/students/student-card";
 import { fetchBulkPickupTimes } from "~/lib/pickup-schedule-api";
 import type { BulkPickupTime } from "~/lib/pickup-schedule-api";
+import { activeService } from "~/lib/active-api";
+import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
+import { TrackingIndicators } from "~/components/students/tracking-indicators";
 import { Clock, AlertTriangle } from "lucide-react";
 import { createLogger } from "~/lib/logger";
 
@@ -449,6 +452,7 @@ function OGSGroupPageContent() {
       }
     >;
     pickupTimes?: Map<string, BulkPickupTime>;
+    trackingIndicators?: TrackingIndicatorsResponse;
   }>(
     hasAccess && currentGroupId ? `ogs-students-${currentGroupId}` : null,
     async () => {
@@ -488,20 +492,32 @@ function OGSGroupPageContent() {
 
       const students = studentsResponse.students || [];
 
-      // Fetch pickup times for all students (prevents loading flash)
+      // Fetch pickup times and tracking indicators for all students (prevents loading flash)
       let pickupTimesMap = new Map<string, BulkPickupTime>();
+      let trackingIndicators: TrackingIndicatorsResponse = {
+        labels: [],
+        results: {},
+      };
       if (students.length > 0) {
         const studentIds = students.map((s) => s.id.toString());
-        pickupTimesMap = await fetchBulkPickupTimes(studentIds).catch(() => {
-          logger.error("failed to fetch pickup times in SWR");
-          return new Map<string, BulkPickupTime>();
-        });
+        const [pickupResult, trackingResult] = await Promise.all([
+          fetchBulkPickupTimes(studentIds).catch(() => {
+            logger.error("failed to fetch pickup times in SWR");
+            return new Map<string, BulkPickupTime>();
+          }),
+          activeService.getTrackingIndicators(studentIds).catch(() => {
+            return { labels: [], results: {} } as TrackingIndicatorsResponse;
+          }),
+        ]);
+        pickupTimesMap = pickupResult;
+        trackingIndicators = trackingResult;
       }
 
       return {
         students,
         roomStatus: roomStatusResponse ?? undefined,
         pickupTimes: pickupTimesMap,
+        trackingIndicators,
       };
     },
     {
@@ -1183,6 +1199,18 @@ function OGSGroupPageContent() {
                         )}
                       </StudentInfoRow>
                     ) : null
+                  }
+                  trackingIndicators={
+                    swrStudentsData?.trackingIndicators?.labels.length ? (
+                      <TrackingIndicators
+                        labels={swrStudentsData.trackingIndicators.labels}
+                        results={
+                          swrStudentsData.trackingIndicators.results[
+                            student.id
+                          ] ?? []
+                        }
+                      />
+                    ) : undefined
                   }
                 />
               );

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
@@ -328,6 +328,7 @@ interface MockStudentDataResult {
   loading: boolean;
   error: string | null;
   hasFullAccess: boolean;
+  hasWriteAccess: boolean;
   supervisors: Array<{ name: string; phone?: string }>;
   myGroups: string[];
   myGroupRooms: string[];
@@ -421,6 +422,7 @@ describe("StudentDetailPage", () => {
       loading: false,
       error: null,
       hasFullAccess: true,
+      hasWriteAccess: true,
       supervisors: [{ name: "Frau Schmidt", phone: "0123456" }],
       myGroups: ["1"],
       myGroupRooms: ["Raum 101"],
@@ -448,6 +450,7 @@ describe("StudentDetailPage", () => {
         loading: true,
         error: null,
         hasFullAccess: false,
+        hasWriteAccess: false,
         supervisors: [],
         myGroups: [],
         myGroupRooms: [],
@@ -469,6 +472,7 @@ describe("StudentDetailPage", () => {
         loading: false,
         error: "Schüler nicht gefunden",
         hasFullAccess: false,
+        hasWriteAccess: false,
         supervisors: [],
         myGroups: [],
         myGroupRooms: [],
@@ -488,6 +492,7 @@ describe("StudentDetailPage", () => {
         loading: false,
         error: null,
         hasFullAccess: false,
+        hasWriteAccess: false,
         supervisors: [],
         myGroups: [],
         myGroupRooms: [],
@@ -506,6 +511,7 @@ describe("StudentDetailPage", () => {
         loading: false,
         error: "Error",
         hasFullAccess: false,
+        hasWriteAccess: false,
         supervisors: [],
         myGroups: [],
         myGroupRooms: [],
@@ -564,6 +570,7 @@ describe("StudentDetailPage", () => {
         loading: false,
         error: null,
         hasFullAccess: false,
+        hasWriteAccess: false,
         supervisors: [{ name: "Frau Schmidt", phone: "0123456" }],
         myGroups: ["1"],
         myGroupRooms: ["Raum 101"],
@@ -767,6 +774,7 @@ describe("StudentDetailPage", () => {
         loading: false,
         error: null,
         hasFullAccess: true,
+        hasWriteAccess: true,
         supervisors: [],
         myGroups: ["1"],
         myGroupRooms: [],
@@ -1007,6 +1015,7 @@ describe("StudentDetailPage", () => {
         loading: false,
         error: null,
         hasFullAccess: true,
+        hasWriteAccess: true,
         supervisors: [],
         myGroups: ["1"],
         myGroupRooms: [],
@@ -1068,6 +1077,7 @@ describe("StudentDetailPage", () => {
         loading: false,
         error: null,
         hasFullAccess: true,
+        hasWriteAccess: true,
         supervisors: [],
         myGroups: ["1"],
         myGroupRooms: [],
@@ -1116,6 +1126,7 @@ describe("StudentDetailPage", () => {
         loading: false,
         error: null,
         hasFullAccess: false,
+        hasWriteAccess: false,
         supervisors: [{ name: "Frau Schmidt" }],
         myGroups: ["1"],
         myGroupRooms: [],
@@ -1157,6 +1168,7 @@ describe("StudentDetailPage", () => {
         loading: false,
         error: null,
         hasFullAccess: true,
+        hasWriteAccess: true,
         supervisors: [],
         myGroups: ["1"],
         myGroupRooms: [],

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -57,6 +57,7 @@ export default function StudentDetailPage() {
     loading,
     error,
     hasFullAccess,
+    hasWriteAccess,
     attendanceLogEnabled,
     feedbackEnabled,
     supervisors,
@@ -144,9 +145,9 @@ export default function StudentDetailPage() {
     void loadActiveGroups();
   }, [showConfirmCheckin]);
 
-  // Load today's pickup time for header (only for full access users)
+  // Load today's pickup time for header
   useEffect(() => {
-    if (!hasFullAccess || !studentId) {
+    if (!studentId) {
       setTodayPickup({});
       return;
     }
@@ -180,7 +181,7 @@ export default function StudentDetailPage() {
     };
 
     void loadTodayPickup();
-  }, [hasFullAccess, studentId, student?.sick]);
+  }, [studentId, student?.sick]);
 
   // Show loading state
   if (loading) {
@@ -403,6 +404,7 @@ export default function StudentDetailPage() {
           <FullAccessView
             student={student}
             studentId={studentId}
+            hasWriteAccess={hasWriteAccess}
             attendanceLogEnabled={attendanceLogEnabled}
             feedbackEnabled={feedbackEnabled}
             showCheckout={showCheckout}
@@ -574,6 +576,7 @@ function LimitedAccessView({
 interface FullAccessViewProps {
   student: ExtendedStudent;
   studentId: string;
+  hasWriteAccess: boolean;
   attendanceLogEnabled: boolean;
   feedbackEnabled: boolean;
   showCheckout: boolean;
@@ -592,6 +595,7 @@ interface FullAccessViewProps {
 function FullAccessView({
   student,
   studentId,
+  hasWriteAccess,
   attendanceLogEnabled,
   feedbackEnabled,
   showCheckout,
@@ -609,39 +613,43 @@ function FullAccessView({
   const historyRouter = useTenantRouter();
   return (
     <>
-      <div className="mb-4 flex gap-3 sm:mb-6 sm:gap-4">
-        {showCheckout && (
-          <StudentCheckoutSection onCheckoutClick={onCheckoutClick} />
-        )}
-        {showCheckin && (
-          <StudentCheckinSection onCheckinClick={onCheckinClick} />
-        )}
-        <StudentSickReportSection
-          isSick={student.sick ?? false}
-          sickSince={student.sick_since}
-          onToggle={onSickClick}
-          isLoading={sickLoading}
-        />
-      </div>
+      {(showCheckout || showCheckin || hasWriteAccess) && (
+        <div className="mb-4 flex gap-3 sm:mb-6 sm:gap-4">
+          {showCheckout && (
+            <StudentCheckoutSection onCheckoutClick={onCheckoutClick} />
+          )}
+          {showCheckin && (
+            <StudentCheckinSection onCheckinClick={onCheckinClick} />
+          )}
+          {hasWriteAccess && (
+            <StudentSickReportSection
+              isSick={student.sick ?? false}
+              sickSince={student.sick_since}
+              onToggle={onSickClick}
+              isLoading={sickLoading}
+            />
+          )}
+        </div>
+      )}
 
       <div className="space-y-4 sm:space-y-6">
         <PickupScheduleManager
           studentId={studentId}
-          readOnly={false}
-          onUpdate={onRefreshData}
+          readOnly={!hasWriteAccess}
+          onUpdate={hasWriteAccess ? onRefreshData : undefined}
           isSick={student.sick}
         />
 
         <PersonalInfoReadOnly
           student={student}
-          showEditButton={true}
-          onEditClick={onOpenPersonalInfoModal}
+          showEditButton={hasWriteAccess}
+          onEditClick={hasWriteAccess ? onOpenPersonalInfoModal : undefined}
         />
 
         <StudentGuardianManager
           studentId={studentId}
-          readOnly={false}
-          onUpdate={onRefreshData}
+          readOnly={!hasWriteAccess}
+          onUpdate={hasWriteAccess ? onRefreshData : undefined}
         />
 
         <StudentHistorySection
@@ -652,12 +660,14 @@ function FullAccessView({
         />
       </div>
 
-      <PersonalInfoFormModal
-        isOpen={showPersonalInfoModal}
-        onClose={onClosePersonalInfoModal}
-        student={student}
-        onSave={onSavePersonal}
-      />
+      {hasWriteAccess && (
+        <PersonalInfoFormModal
+          isOpen={showPersonalInfoModal}
+          onClose={onClosePersonalInfoModal}
+          student={student}
+          onSave={onSavePersonal}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -145,9 +145,9 @@ export default function StudentDetailPage() {
     void loadActiveGroups();
   }, [showConfirmCheckin]);
 
-  // Load today's pickup time for header
+  // Load today's pickup time for header (requires read access to student data)
   useEffect(() => {
-    if (!studentId) {
+    if (!hasFullAccess || !studentId) {
       setTodayPickup({});
       return;
     }
@@ -181,7 +181,7 @@ export default function StudentDetailPage() {
     };
 
     void loadTodayPickup();
-  }, [studentId, student?.sick]);
+  }, [hasFullAccess, studentId, student?.sick]);
 
   // Show loading state
   if (loading) {
@@ -548,12 +548,6 @@ function LimitedAccessView({
       )}
 
       <SupervisorsCard supervisors={supervisors} studentName={student.name} />
-
-      <PickupScheduleManager
-        studentId={student.id}
-        readOnly={true}
-        isSick={student.sick}
-      />
 
       <PersonalInfoReadOnly student={student} />
 

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -557,6 +557,7 @@ function LimitedAccessView({
         studentId={studentId}
         attendanceLogEnabled={attendanceLogEnabled}
         feedbackEnabled={feedbackEnabled}
+        readOnly={true}
         onNavigate={(path) => historyRouter.push(path)}
       />
     </div>

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -474,7 +474,8 @@ function SearchPageContent() {
                     </>
                   }
                   trackingIndicators={
-                    trackingData?.labels?.length ? (
+                    trackingData?.labels?.length &&
+                    student.has_full_access !== false ? (
                       <TrackingIndicators
                         labels={trackingData.labels}
                         results={trackingData.results[student.id] ?? []}

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -27,6 +27,9 @@ import {
   StudentInfoRow,
 } from "~/components/students/student-card";
 import { useSWRAuth, useImmutableSWR } from "~/lib/swr";
+import { activeService } from "~/lib/active-api";
+import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
+import { TrackingIndicators } from "~/components/students/tracking-indicators";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "StudentSearchPage" });
@@ -127,6 +130,19 @@ function SearchPageContent() {
   );
 
   const students = studentsData?.students ?? [];
+
+  // Tracking indicators for student cards
+  const trackingStudentIds = useMemo(
+    () => (studentsData?.students ?? []).map((s) => s.id),
+    [studentsData],
+  );
+  const { data: trackingData } = useSWRAuth<TrackingIndicatorsResponse>(
+    trackingStudentIds.length > 0
+      ? `tracking-search-${studentsCacheKey}`
+      : null,
+    async () => activeService.getTrackingIndicators(trackingStudentIds),
+    { keepPreviousData: true, revalidateOnFocus: false },
+  );
 
   // Error type for proper heading display (Fix P3: substring matching on transformed string)
   type ErrorType = "permission" | "session" | "generic" | null;
@@ -456,6 +472,14 @@ function SearchPageContent() {
                         </StudentInfoRow>
                       )}
                     </>
+                  }
+                  trackingIndicators={
+                    trackingData?.labels.length ? (
+                      <TrackingIndicators
+                        labels={trackingData.labels}
+                        results={trackingData.results[student.id] ?? []}
+                      />
+                    ) : undefined
                   }
                 />
               ))}

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -138,7 +138,7 @@ function SearchPageContent() {
   );
   const { data: trackingData } = useSWRAuth<TrackingIndicatorsResponse>(
     trackingStudentIds.length > 0
-      ? `tracking-search-${studentsCacheKey}`
+      ? `tracking-indicators-${debouncedSearchTerm}-${selectedGroup}`
       : null,
     async () => activeService.getTrackingIndicators(trackingStudentIds),
     { keepPreviousData: true, revalidateOnFocus: false },
@@ -474,7 +474,7 @@ function SearchPageContent() {
                     </>
                   }
                   trackingIndicators={
-                    trackingData?.labels.length ? (
+                    trackingData?.labels?.length ? (
                       <TrackingIndicators
                         labels={trackingData.labels}
                         results={trackingData.results[student.id] ?? []}

--- a/frontend/src/app/api/active/tracking-indicators/route.test.ts
+++ b/frontend/src/app/api/active/tracking-indicators/route.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Session } from "next-auth";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ExtendedSession extends Session {
+  user: Session["user"] & { token?: string };
+}
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const { mockAuth, mockApiPost } = vi.hoisted(() => ({
+  mockAuth: vi.fn<() => Promise<ExtendedSession | null>>(),
+  mockApiPost: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("~/lib/api-helpers", () => ({
+  apiGet: vi.fn(),
+  apiPost: mockApiPost,
+  apiPut: vi.fn(),
+  apiDelete: vi.fn(),
+  handleApiError: vi.fn((error: unknown) => {
+    const message =
+      error instanceof Error ? error.message : "Internal Server Error";
+    const status = message.includes("(401)")
+      ? 401
+      : message.includes("(404)")
+        ? 404
+        : 500;
+    return new Response(JSON.stringify({ error: message }), { status });
+  }),
+}));
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createMockRequest(body: unknown): NextRequest {
+  const url = new URL(
+    "/api/active/tracking-indicators",
+    "http://localhost:3000",
+  );
+  return new NextRequest(url, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function createMockContext(
+  params: Record<string, string | string[] | undefined> = {},
+) {
+  return { params: Promise.resolve(params) };
+}
+
+const defaultSession: ExtendedSession = {
+  user: { id: "1", token: "test-token", name: "Test User" },
+  expires: "2099-01-01",
+};
+
+interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T;
+}
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("POST /api/active/tracking-indicators", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(defaultSession);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+
+    const request = createMockRequest({ student_ids: [10, 20] });
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("proxies request to backend and returns data", async () => {
+    const innerData = {
+      labels: ["Hausaufgaben", "Mensa"],
+      results: { "10": [true, false], "20": [false, true] },
+    };
+
+    // apiPost returns the full response; handler accesses .data
+    mockApiPost.mockResolvedValueOnce({ data: innerData });
+
+    const request = createMockRequest({ student_ids: [10, 20] });
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(200);
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/active/tracking-indicators",
+      "test-token",
+      { student_ids: [10, 20] },
+    );
+
+    const json =
+      await parseJsonResponse<ApiResponse<typeof innerData>>(response);
+    expect(json.data).toEqual(innerData);
+  });
+
+  it("returns empty labels and results when feature is disabled", async () => {
+    const innerData = {
+      labels: [] as string[],
+      results: {} as Record<string, boolean[]>,
+    };
+
+    mockApiPost.mockResolvedValueOnce({ data: innerData });
+
+    const request = createMockRequest({ student_ids: [10] });
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(200);
+    const json =
+      await parseJsonResponse<ApiResponse<typeof innerData>>(response);
+    expect(json.data.labels).toEqual([]);
+    expect(json.data.results).toEqual({});
+  });
+
+  it("forwards backend errors", async () => {
+    mockApiPost.mockRejectedValueOnce(new Error("Backend error (500)"));
+
+    const request = createMockRequest({ student_ids: [10] });
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/frontend/src/app/api/active/tracking-indicators/route.ts
+++ b/frontend/src/app/api/active/tracking-indicators/route.ts
@@ -1,0 +1,14 @@
+import { createPostHandler } from "@/lib/route-wrapper";
+import { apiPost } from "@/lib/api-helpers";
+import type { ApiResponse } from "@/lib/api-helpers";
+import type { TrackingIndicatorsResponse } from "@/lib/active-helpers";
+
+// POST /api/active/tracking-indicators - Bulk check if students visited configured rooms/activities today
+export const POST = createPostHandler(async (_request, body, token) => {
+  const response = await apiPost<ApiResponse<TrackingIndicatorsResponse>>(
+    "/api/active/tracking-indicators",
+    token,
+    body,
+  );
+  return response.data;
+});

--- a/frontend/src/app/api/students/[id]/route.ts
+++ b/frontend/src/app/api/students/[id]/route.ts
@@ -87,6 +87,7 @@ export const GET = createGetHandler(
         name?: string;
         first_name?: string;
         has_full_access?: boolean;
+        has_write_access?: boolean;
         group_supervisors?: Array<{
           id: number;
           first_name: string;
@@ -106,6 +107,7 @@ export const GET = createGetHandler(
 
       // Extract access control fields from response data
       const hasFullAccess = studentData.has_full_access ?? false;
+      const hasWriteAccess = studentData.has_write_access ?? false;
       const groupSupervisors = studentData.group_supervisors ?? [];
       const attendanceLogEnabled =
         (studentData.attendance_log_enabled as boolean) ?? false;
@@ -135,6 +137,7 @@ export const GET = createGetHandler(
         ...mappedStudent,
         ...consentData,
         has_full_access: hasFullAccess,
+        has_write_access: hasWriteAccess,
         group_supervisors: groupSupervisors,
         attendance_log_enabled: attendanceLogEnabled,
         feedback_enabled: feedbackEnabled,

--- a/frontend/src/components/students/student-card.test.tsx
+++ b/frontend/src/components/students/student-card.test.tsx
@@ -5,6 +5,8 @@ import {
   SchoolClassIcon,
   GroupIcon,
   StudentInfoRow,
+  PickupTimeIcon,
+  ExceptionIcon,
 } from "./student-card";
 
 describe("StudentCard", () => {
@@ -82,6 +84,31 @@ describe("StudentCard", () => {
     const gradientDiv = container.querySelector(".from-blue-50\\/80");
     expect(gradientDiv).toBeInTheDocument();
   });
+
+  it("wraps location badge and tracking indicators in flex-col when trackingIndicators provided", () => {
+    render(
+      <StudentCard
+        {...defaultProps}
+        trackingIndicators={<span data-testid="tracking">Indicators</span>}
+      />,
+    );
+
+    expect(screen.getByTestId("tracking")).toBeInTheDocument();
+    expect(screen.getByTestId("location-badge")).toBeInTheDocument();
+    // Both should be inside a flex-col wrapper
+    const trackingEl = screen.getByTestId("tracking");
+    const wrapper = trackingEl.parentElement;
+    expect(wrapper?.className).toContain("flex");
+    expect(wrapper?.className).toContain("flex-col");
+  });
+
+  it("renders location badge alone without wrapper when no trackingIndicators", () => {
+    const { container } = render(<StudentCard {...defaultProps} />);
+
+    expect(screen.getByTestId("location-badge")).toBeInTheDocument();
+    // No tracking indicators present
+    expect(container.querySelector("[data-testid='tracking']")).toBeNull();
+  });
 });
 
 describe("SchoolClassIcon", () => {
@@ -117,6 +144,22 @@ describe("GroupIcon", () => {
     expect(svg?.className).toContain("h-3.5");
     expect(svg?.className).toContain("w-3.5");
     expect(svg?.className).toContain("text-gray-400");
+  });
+});
+
+describe("PickupTimeIcon", () => {
+  it("renders an SVG icon", () => {
+    const { container } = render(<PickupTimeIcon />);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+});
+
+describe("ExceptionIcon", () => {
+  it("renders an SVG icon with orange color", () => {
+    const { container } = render(<ExceptionIcon />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+    expect(svg?.className).toContain("text-orange-500");
   });
 });
 

--- a/frontend/src/components/students/student-card.tsx
+++ b/frontend/src/components/students/student-card.tsx
@@ -18,6 +18,8 @@ interface StudentCardProps {
   readonly locationBadge: ReactNode;
   /** Optional extra content between name and click hint */
   readonly extraContent?: ReactNode;
+  /** Optional tracking indicators (right-aligned, below location badge) */
+  readonly trackingIndicators?: ReactNode;
 }
 
 /**
@@ -32,6 +34,7 @@ export function StudentCard({
   onClick,
   locationBadge,
   extraContent,
+  trackingIndicators,
 }: StudentCardProps) {
   return (
     <button
@@ -81,8 +84,15 @@ export function StudentCard({
             {extraContent}
           </div>
 
-          {/* Location Badge */}
-          {locationBadge}
+          {/* Location Badge + optional Tracking Indicators */}
+          {trackingIndicators ? (
+            <div className="flex flex-col items-end gap-1">
+              {locationBadge}
+              {trackingIndicators}
+            </div>
+          ) : (
+            locationBadge
+          )}
         </div>
 
         {/* Bottom row with click hint */}

--- a/frontend/src/components/students/student-detail-components.tsx
+++ b/frontend/src/components/students/student-detail-components.tsx
@@ -300,6 +300,7 @@ export function StudentDetailHeader({
     group_name: student.group_name,
     sick: student.sick,
     sick_since: student.sick_since,
+    has_full_access: student.has_full_access,
   };
 
   return (

--- a/frontend/src/components/students/student-detail-components.tsx
+++ b/frontend/src/components/students/student-detail-components.tsx
@@ -579,6 +579,7 @@ interface StudentHistorySectionProps {
   studentId: string;
   attendanceLogEnabled: boolean;
   feedbackEnabled: boolean;
+  readOnly?: boolean;
   onNavigate: (path: string) => void;
 }
 
@@ -592,8 +593,12 @@ export function StudentHistorySection({
   studentId,
   attendanceLogEnabled,
   feedbackEnabled,
+  readOnly = false,
   onNavigate,
 }: Readonly<StudentHistorySectionProps>) {
+  const attendanceDisabled = readOnly || !attendanceLogEnabled;
+  const feedbackDisabled = readOnly || !feedbackEnabled;
+
   return (
     <InfoCard title="Historien" icon={<ClockIcon />}>
       <div className="grid grid-cols-1 gap-2">
@@ -601,14 +606,16 @@ export function StudentHistorySection({
           icon={<BuildingIcon />}
           title="Anwesenheitsprotokoll"
           description={
-            attendanceLogEnabled
-              ? "Anwesenheit und besuchte Räume"
-              : "Für Ihre Schule deaktiviert"
+            readOnly
+              ? "Nur für Gruppenbetreuer"
+              : attendanceLogEnabled
+                ? "Anwesenheit und besuchte Räume"
+                : "Für Ihre Schule deaktiviert"
           }
           bgColor="bg-[#5080D8]"
-          disabled={!attendanceLogEnabled}
+          disabled={attendanceDisabled}
           onClick={
-            attendanceLogEnabled
+            !attendanceDisabled
               ? () => onNavigate(`/students/${studentId}/room-history`)
               : undefined
           }
@@ -617,14 +624,16 @@ export function StudentHistorySection({
           icon={<ChatIcon />}
           title="Feedbackhistorie"
           description={
-            feedbackEnabled
-              ? "Feedback und Bewertungen"
-              : "Für Ihre Schule deaktiviert"
+            readOnly
+              ? "Nur für Gruppenbetreuer"
+              : feedbackEnabled
+                ? "Feedback und Bewertungen"
+                : "Für Ihre Schule deaktiviert"
           }
           bgColor="bg-[#83CD2D]"
-          disabled={!feedbackEnabled}
+          disabled={feedbackDisabled}
           onClick={
-            feedbackEnabled
+            !feedbackDisabled
               ? () => onNavigate(`/students/${studentId}/feedback_history`)
               : undefined
           }

--- a/frontend/src/components/students/tracking-indicators.test.tsx
+++ b/frontend/src/components/students/tracking-indicators.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { TrackingIndicators } from "./tracking-indicators";
+
+describe("TrackingIndicators", () => {
+  it("returns null when labels are empty", () => {
+    const { container } = render(
+      <TrackingIndicators labels={[]} results={[]} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders one indicator per label", () => {
+    render(
+      <TrackingIndicators
+        labels={["Hausaufgaben", "Mensa"]}
+        results={[true, false]}
+      />,
+    );
+
+    expect(screen.getByText("Hausaufgaben")).toBeInTheDocument();
+    expect(screen.getByText("Mensa")).toBeInTheDocument();
+  });
+
+  it("renders green checkmark SVG for matched labels", () => {
+    render(<TrackingIndicators labels={["Hausaufgaben"]} results={[true]} />);
+
+    const svg = screen.getByLabelText("Hausaufgaben: erledigt");
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveClass("text-green-500");
+  });
+
+  it("renders gray circle SVG for unmatched labels", () => {
+    render(<TrackingIndicators labels={["Mensa"]} results={[false]} />);
+
+    const svg = screen.getByLabelText("Mensa: ausstehend");
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveClass("text-gray-300");
+  });
+
+  it("treats missing results as false (unmatched)", () => {
+    render(
+      <TrackingIndicators
+        labels={["Hausaufgaben", "Sport"]}
+        results={[true]}
+      />,
+    );
+
+    // First label matched
+    expect(screen.getByLabelText("Hausaufgaben: erledigt")).toBeInTheDocument();
+    // Second label has no result entry → defaults to false
+    expect(screen.getByLabelText("Sport: ausstehend")).toBeInTheDocument();
+  });
+
+  it("renders multiple indicators with mixed results", () => {
+    render(
+      <TrackingIndicators
+        labels={["Hausaufgaben", "Mensa", "Sport"]}
+        results={[true, false, true]}
+      />,
+    );
+
+    expect(screen.getByLabelText("Hausaufgaben: erledigt")).toBeInTheDocument();
+    expect(screen.getByLabelText("Mensa: ausstehend")).toBeInTheDocument();
+    expect(screen.getByLabelText("Sport: erledigt")).toBeInTheDocument();
+  });
+
+  it("renders label text with correct styling", () => {
+    render(<TrackingIndicators labels={["Hausaufgaben"]} results={[false]} />);
+
+    const label = screen.getByText("Hausaufgaben");
+    expect(label.tagName).toBe("SPAN");
+    expect(label).toHaveClass("text-xs", "font-medium", "text-gray-500");
+  });
+});

--- a/frontend/src/components/students/tracking-indicators.tsx
+++ b/frontend/src/components/students/tracking-indicators.tsx
@@ -1,0 +1,60 @@
+// components/students/tracking-indicators.tsx
+// Displays tracking indicator checkmarks/circles in student cards
+
+interface TrackingIndicatorsProps {
+  /** Configured indicator labels (e.g., ["Hausaufgaben", "Mensa"]) */
+  readonly labels: string[];
+  /** Match results aligned with labels (true = visited today) */
+  readonly results: boolean[];
+}
+
+/**
+ * Renders right-aligned tracking indicators showing whether a student
+ * has visited configured rooms/activities today.
+ * Returns null if no labels are configured.
+ */
+export function TrackingIndicators({
+  labels,
+  results,
+}: TrackingIndicatorsProps) {
+  if (labels.length === 0) return null;
+
+  return (
+    <div className="mt-1.5 flex flex-col items-end gap-0.5">
+      {labels.map((label, i) => {
+        const matched = results[i] ?? false;
+        return (
+          <div key={label} className="flex items-center gap-1.5">
+            <span className="text-xs font-medium text-gray-500">{label}</span>
+            {matched ? (
+              <svg
+                className="h-4 w-4 text-green-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-label={`${label}: erledigt`}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2.5}
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            ) : (
+              <svg
+                className="h-4 w-4 text-gray-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-label={`${label}: ausstehend`}
+              >
+                <circle cx="12" cy="12" r="9" strokeWidth={2} />
+              </svg>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/lib/active-helpers.ts
+++ b/frontend/src/lib/active-helpers.ts
@@ -1,6 +1,12 @@
 // lib/active-helpers.ts
 // Type definitions for active entities
 
+// Tracking indicators response from POST /api/active/tracking-indicators
+export interface TrackingIndicatorsResponse {
+  labels: string[];
+  results: Record<string, boolean[]>; // student_id → [matched1, matched2, ...]
+}
+
 // Backend types (from Go structs)
 export interface BackendActiveGroup {
   id: number;

--- a/frontend/src/lib/active-service.test.ts
+++ b/frontend/src/lib/active-service.test.ts
@@ -1280,4 +1280,106 @@ describe("active-service", () => {
       });
     });
   });
+
+  describe("getTrackingIndicators", () => {
+    it("returns empty response when studentIds is empty", async () => {
+      const result = await activeService.getTrackingIndicators([]);
+
+      expect(result).toEqual({ labels: [], results: {} });
+    });
+
+    it("returns empty response when session has no token", async () => {
+      // Clear the session cache so a fresh getSession call happens
+      const { clearSessionCache } = await import("./session-cache");
+      clearSessionCache();
+      mockedGetSession.mockResolvedValueOnce(null);
+
+      const result = await activeService.getTrackingIndicators(["10", "20"]);
+
+      expect(result).toEqual({ labels: [], results: {} });
+    });
+
+    it("fetches tracking indicators and returns data on success", async () => {
+      const { clearSessionCache } = await import("./session-cache");
+      clearSessionCache();
+
+      const mockResponse = {
+        data: {
+          labels: ["Hausaufgaben", "Mensa"],
+          results: { "10": [true, false], "20": [false, true] },
+        },
+      };
+
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      const result = await activeService.getTrackingIndicators(["10", "20"]);
+
+      expect(result).toEqual(mockResponse.data);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/active/tracking-indicators",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ student_ids: [10, 20] }),
+        }),
+      );
+    });
+
+    it("converts string student IDs to integers in request", async () => {
+      const { clearSessionCache } = await import("./session-cache");
+      clearSessionCache();
+
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { labels: [], results: {} } }),
+      } as Response);
+
+      await activeService.getTrackingIndicators(["42", "99"]);
+
+      const callBody = JSON.parse(
+        (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+      ) as { student_ids: number[] };
+      expect(callBody.student_ids).toEqual([42, 99]);
+    });
+
+    it("returns empty response on non-ok HTTP status", async () => {
+      const { clearSessionCache } = await import("./session-cache");
+      clearSessionCache();
+
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      } as Response);
+
+      const result = await activeService.getTrackingIndicators(["10"]);
+
+      expect(result).toEqual({ labels: [], results: {} });
+    });
+
+    it("includes authorization header from session token", async () => {
+      const { clearSessionCache } = await import("./session-cache");
+      clearSessionCache();
+
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { labels: [], results: {} } }),
+      } as Response);
+
+      await activeService.getTrackingIndicators(["10"]);
+
+      const callBody = mockFetch.mock.calls.find(
+        (call: unknown[]) => call[0] === "/api/active/tracking-indicators",
+      ) as [string, RequestInit] | undefined;
+      expect(callBody).toBeDefined();
+      const headers = callBody![1].headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer test-token");
+      expect(headers["Content-Type"]).toBe("application/json");
+    });
+  });
 });

--- a/frontend/src/lib/active-service.ts
+++ b/frontend/src/lib/active-service.ts
@@ -39,6 +39,7 @@ import {
   type CreateVisitInput,
   type CreateSupervisorInput,
   type CreateCombinedGroupInput,
+  type TrackingIndicatorsResponse,
 } from "./active-helpers";
 
 // Generic API response interface
@@ -1012,5 +1013,42 @@ export const activeService = {
       mapToggleSupervisionResponse,
       "Toggle Schulhof supervision",
     );
+  },
+
+  /**
+   * Fetch tracking indicators for a set of students.
+   * Returns configured labels and per-student match results (boolean array aligned with labels).
+   * Returns empty labels/results when the feature is disabled or no labels are configured.
+   */
+  getTrackingIndicators: async (
+    studentIds: string[],
+  ): Promise<TrackingIndicatorsResponse> => {
+    const empty: TrackingIndicatorsResponse = { labels: [], results: {} };
+    if (studentIds.length === 0) return empty;
+
+    const session = await getCachedSession();
+    if (!session?.user?.token) return empty;
+
+    const response = await fetch("/api/active/tracking-indicators", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.user.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        student_ids: studentIds.map((id) => Number.parseInt(id, 10)),
+      }),
+    });
+
+    if (!response.ok) {
+      logger.warn("tracking_indicators_fetch_failed", {
+        status: response.status,
+      });
+      return empty;
+    }
+
+    const data =
+      (await response.json()) as ApiResponse<TrackingIndicatorsResponse>;
+    return data.data;
   },
 };

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -348,6 +348,12 @@ describe("useGlobalSSE", () => {
         );
       });
       expect(ogsStudentCall).toBeDefined();
+
+      // Matcher must work with tenant-prefixed keys (useSWRAuth adds tenant slug prefix)
+      const matcher = ogsStudentCall![0] as (key: string) => boolean;
+      expect(matcher("my-tenant:ogs-students-5")).toBe(true);
+      expect(matcher("my-tenant:tracking-supervisions-1-42,43")).toBe(true);
+      expect(matcher("my-tenant:tracking-indicators-search-group1")).toBe(true);
     });
 
     it("student_checkout without active_group_id invalidates dashboard caches", () => {
@@ -391,9 +397,19 @@ describe("useGlobalSSE", () => {
 
       const mutateCalls = vi.mocked(mutate).mock.calls;
       const studentDetailCall = mutateCalls.find((call) => {
-        return call[0] === "student-detail-42";
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)("student-detail-42")
+        );
       });
       expect(studentDetailCall).toBeDefined();
+
+      // Must also match tenant-prefixed key
+      const matcher = studentDetailCall![0] as (key: string) => boolean;
+      expect(matcher("my-tenant:student-detail-42")).toBe(true);
+      // Must NOT match other student IDs
+      expect(matcher("student-detail-99")).toBe(false);
     });
 
     it("student_checkout without active_group_id does NOT invalidate supervision-visits", () => {

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -63,6 +63,8 @@ export function useGlobalSSE(): SSEHookState {
   const hasPendingDailyCheckoutDashboardEvent = useRef(false);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // SWR cache keys are tenant-prefixed by useSWRAuth (e.g. "tenant-slug:ogs-students-2").
+  // All matchers must use includes() instead of startsWith() to match regardless of prefix.
   const flushInvalidations = useCallback(() => {
     // Invalidate ALL supervision-visits caches for student/dashboard events.
     // A student checked out of Room A may appear on the Schulhof (catch-all),
@@ -71,8 +73,7 @@ export function useGlobalSSE(): SSEHookState {
     // that flag to keep their detail views in sync.
     if (pendingGroupIds.current.size > 0 || hasPendingDashboardEvent.current) {
       mutate(
-        (key) =>
-          typeof key === "string" && key.startsWith("supervision-visits-"),
+        (key) => typeof key === "string" && key.includes("supervision-visits-"),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),
@@ -83,6 +84,8 @@ export function useGlobalSSE(): SSEHookState {
 
     // Invalidate OGS group student caches (ogs-students-{groupId})
     // so the "Meine Gruppe" page picks up location changes (e.g. Zuhause).
+    // Also invalidate tracking indicator caches on active-supervisions
+    // (tracking-supervisions-*) and students/search (tracking-indicators-*).
     // Triggered by pendingGroupIds (room-level events) OR pendingStudentIds
     // (daily checkout sends student_checkout without an active_group_id).
     if (
@@ -90,7 +93,11 @@ export function useGlobalSSE(): SSEHookState {
       pendingStudentIds.current.size > 0
     ) {
       mutate(
-        (key) => typeof key === "string" && key.startsWith("ogs-students-"),
+        (key) =>
+          typeof key === "string" &&
+          (key.includes("ogs-students-") ||
+            key.includes("tracking-supervisions-") ||
+            key.includes("tracking-indicators-")),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),
@@ -101,7 +108,11 @@ export function useGlobalSSE(): SSEHookState {
 
     // Invalidate specific student detail caches
     for (const studentId of pendingStudentIds.current) {
-      mutate(`student-detail-${studentId}`).catch((err) => {
+      mutate(
+        (key) =>
+          typeof key === "string" &&
+          key.includes(`student-detail-${studentId}`),
+      ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),
           scope: "student_detail",
@@ -121,10 +132,7 @@ export function useGlobalSSE(): SSEHookState {
       hasPendingDailyCheckoutDashboardEvent.current
     ) {
       mutate(
-        (key) =>
-          typeof key === "string" &&
-          (key.startsWith("active-supervision-dashboard") ||
-            key.includes("dashboard")),
+        (key) => typeof key === "string" && key.includes("dashboard"),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),

--- a/frontend/src/lib/hooks/use-student-data.test.ts
+++ b/frontend/src/lib/hooks/use-student-data.test.ts
@@ -121,6 +121,7 @@ describe("useStudentData", () => {
         data: {
           student: mockStudent,
           hasFullAccess: true,
+          hasWriteAccess: true,
           supervisors: mockSupervisors,
           myGroups: ["100", "101"],
           myGroupRooms: ["Room A", "Room B"],
@@ -172,6 +173,7 @@ describe("useStudentData", () => {
         data: {
           student: mockStudent,
           hasFullAccess: true,
+          hasWriteAccess: true,
           supervisors: mockSupervisors,
           myGroups: ["100"],
           myGroupRooms: ["Room A"],
@@ -263,6 +265,7 @@ describe("useStudentData", () => {
         group_name: "Group A",
         current_location: "Room 101",
         has_full_access: true,
+        has_write_access: true,
         group_supervisors: mockSupervisors,
       });
 
@@ -320,6 +323,7 @@ describe("useStudentData", () => {
         group_name: "Group A",
         current_location: "Room 101",
         has_full_access: true,
+        has_write_access: true,
         group_supervisors: mockSupervisors,
       });
 
@@ -381,6 +385,7 @@ describe("useStudentData", () => {
             sick_since: "2024-01-10T08:00:00Z",
           },
           hasFullAccess: true,
+          hasWriteAccess: true,
           supervisors: mockSupervisors,
           myGroups: ["100"],
           myGroupRooms: ["Room A"],
@@ -419,6 +424,8 @@ describe("useStudentData", () => {
 
       // Default value should be true according to the implementation
       expect(result.current.hasFullAccess).toBe(true);
+      // Write access defaults to false (deny-by-default)
+      expect(result.current.hasWriteAccess).toBe(false);
     });
   });
 
@@ -436,6 +443,7 @@ describe("useStudentData", () => {
         data: {
           student: mockStudent,
           hasFullAccess: true,
+          hasWriteAccess: true,
           supervisors: mockSupervisors,
           myGroups: ["100"],
           myGroupRooms: ["Room A"],
@@ -470,6 +478,7 @@ describe("useStudentData", () => {
         data: {
           student: mockStudent,
           hasFullAccess: true,
+          hasWriteAccess: true,
           supervisors: mockSupervisors,
           myGroups: ["100"],
           myGroupRooms: ["Room A"],

--- a/frontend/src/lib/hooks/use-student-data.ts
+++ b/frontend/src/lib/hooks/use-student-data.ts
@@ -32,6 +32,7 @@ interface StudentDataState {
   loading: boolean;
   error: string | null;
   hasFullAccess: boolean;
+  hasWriteAccess: boolean;
   attendanceLogEnabled: boolean;
   feedbackEnabled: boolean;
   supervisors: SupervisorContact[];
@@ -103,6 +104,7 @@ function extractRoomNames(
 interface StudentDetailResponse {
   student: ExtendedStudent;
   hasFullAccess: boolean;
+  hasWriteAccess: boolean;
   attendanceLogEnabled: boolean;
   feedbackEnabled: boolean;
   supervisors: SupervisorContact[];
@@ -153,12 +155,14 @@ export function useStudentData(studentId: string): UseStudentDataResult {
 
       const mappedStudent = rawStudentData as Student & {
         has_full_access?: boolean;
+        has_write_access?: boolean;
         group_supervisors?: SupervisorContact[];
         attendance_log_enabled?: boolean;
         feedback_enabled?: boolean;
       };
 
       const hasAccess = mappedStudent.has_full_access ?? false;
+      const hasWriteAccess = mappedStudent.has_write_access ?? false;
       const attendanceLogEnabled =
         mappedStudent.attendance_log_enabled ?? false;
       const feedbackEnabled = mappedStudent.feedback_enabled ?? false;
@@ -172,6 +176,7 @@ export function useStudentData(studentId: string): UseStudentDataResult {
       return {
         student: extendedStudent,
         hasFullAccess: hasAccess,
+        hasWriteAccess,
         attendanceLogEnabled,
         feedbackEnabled,
         supervisors: groupSupervisors,
@@ -209,6 +214,7 @@ export function useStudentData(studentId: string): UseStudentDataResult {
     loading,
     error,
     hasFullAccess: studentData?.hasFullAccess ?? true,
+    hasWriteAccess: studentData?.hasWriteAccess ?? false,
     attendanceLogEnabled: studentData?.attendanceLogEnabled ?? false,
     feedbackEnabled: studentData?.feedbackEnabled ?? false,
     supervisors: studentData?.supervisors ?? [],

--- a/frontend/src/lib/hooks/use-student-data.ts
+++ b/frontend/src/lib/hooks/use-student-data.ts
@@ -89,6 +89,7 @@ function mapStudentResponse(
     pickup_status: mappedStudent.pickup_status ?? undefined,
     sick: hasAccess ? (mappedStudent.sick ?? false) : false,
     sick_since: hasAccess ? (mappedStudent.sick_since ?? undefined) : undefined,
+    has_full_access: hasAccess,
   };
 }
 

--- a/frontend/src/lib/location-helper.ts
+++ b/frontend/src/lib/location-helper.ts
@@ -22,6 +22,7 @@ export interface StudentLocationContext {
   group_name?: string | null;
   sick?: boolean;
   sick_since?: string | null;
+  has_full_access?: boolean;
 }
 
 export const LOCATION_STATUSES = {
@@ -257,7 +258,12 @@ export function canSeeDetailedLocation(
   userGroups?: string[],
   _supervisedRooms?: string[],
 ): boolean {
-  // Check if student is in user's OGS group (ONLY way to get detailed location)
+  // Backend grants full read access via student_data_scope setting
+  if (student.has_full_access) {
+    return true;
+  }
+
+  // Check if student is in user's OGS group
   if (
     student.group_id &&
     Array.isArray(userGroups) &&
@@ -267,7 +273,6 @@ export function canSeeDetailedLocation(
     return true;
   }
 
-  // Supervisors do NOT get detailed location for students outside their OGS groups
   return false;
 }
 

--- a/frontend/src/lib/student-helpers.test.ts
+++ b/frontend/src/lib/student-helpers.test.ts
@@ -222,6 +222,7 @@ describe("mapStudentDetailResponse", () => {
     const detailStudent: BackendStudentDetail = {
       ...sampleBackendStudent,
       has_full_access: true,
+      has_write_access: true,
       attendance_log_enabled: true,
       group_supervisors: [
         {
@@ -238,6 +239,7 @@ describe("mapStudentDetailResponse", () => {
     const result = mapStudentDetailResponse(detailStudent);
 
     expect(result.has_full_access).toBe(true);
+    expect(result.has_write_access).toBe(true);
     expect(result.attendance_log_enabled).toBe(true);
     expect(result.group_supervisors).toHaveLength(1);
     expect(result.group_supervisors?.[0]?.first_name).toBe("John");
@@ -247,12 +249,14 @@ describe("mapStudentDetailResponse", () => {
     const detailStudent: BackendStudentDetail = {
       ...sampleBackendStudent,
       has_full_access: false,
+      has_write_access: false,
       attendance_log_enabled: false,
     };
 
     const result = mapStudentDetailResponse(detailStudent);
 
     expect(result.has_full_access).toBe(false);
+    expect(result.has_write_access).toBe(false);
     expect(result.group_supervisors).toBeUndefined();
   });
 });

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -56,6 +56,7 @@ export interface BackendStudent {
   health_info?: string;
   supervisor_notes?: string;
   pickup_status?: string;
+  has_full_access?: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -199,6 +200,7 @@ export function mapStudentResponse(
     health_info: backendStudent.health_info,
     supervisor_notes: backendStudent.supervisor_notes,
     pickup_status: backendStudent.pickup_status,
+    has_full_access: backendStudent.has_full_access,
   };
 
   // Add scheduled checkout info if present

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -73,6 +73,7 @@ export interface SupervisorContact {
 // Detailed student response with access control
 export interface BackendStudentDetail extends BackendStudent {
   has_full_access: boolean;
+  has_write_access: boolean;
   group_supervisors?: SupervisorContact[];
   attendance_log_enabled: boolean;
 }
@@ -145,6 +146,7 @@ export interface Student {
   data_retention_days?: number;
   // Additional fields for access control
   has_full_access?: boolean;
+  has_write_access?: boolean;
   group_supervisors?: SupervisorContact[];
   // Feature flag: tenant has attendance log enabled
   attendance_log_enabled?: boolean;
@@ -233,6 +235,7 @@ export function mapStudentDetailResponse(
 
   // Then add the additional fields
   student.has_full_access = backendStudent.has_full_access;
+  student.has_write_access = backendStudent.has_write_access;
   student.group_supervisors = backendStudent.group_supervisors;
   student.attendance_log_enabled = backendStudent.attendance_log_enabled;
 


### PR DESCRIPTION
## Summary

Add a new tenant-scoped GDPR setting `gdpr.student_data_scope` that controls whether full student data is visible to all staff or restricted to the student's education group supervisors.

- **New setting**: `gdpr.student_data_scope` (select, GDPR tab)
  - `group_supervisors_only` (default) — existing behavior, only group supervisors see full student profiles
  - `all_staff` — any authenticated staff member can read full student data
- **Read/write separation**: The scope setting only relaxes **read** access (profile, location, visit info, privacy consent, pickup schedules, tracking indicators). Write operations (update, delete, check-in) remain restricted to group supervisors regardless of scope.
- **Staff identity verification**: `all_staff` scope requires the caller to be a verified staff member — non-staff roles (guest, guardian) with `users:read` don't get elevated access.
- **Frontend access flags**: Adds `has_write_access` alongside `has_full_access` on student detail responses so the frontend correctly shows/hides edit controls vs. read-only data.
- **Frontend integration**: Location badges, tracking indicators, and pickup schedules all respect `has_full_access` from the backend instead of re-checking group membership client-side.

## Backend Changes

- Split `checkStudentFullAccess` into read (`checkStudentReadAccess`) and write (`checkStudentFullAccess`) authorization paths
- `checkStudentReadAccess` resolves the `gdpr.student_data_scope` setting and verifies staff identity before granting `all_staff` access
- Pickup schedule handlers now use scope-aware authorization (`requirePickupReadAccess`, `filterAuthorizedStudentIDs`)
- `StudentDetailResponse` gains `has_write_access` field (admin/supervisor only)
- Student list endpoint exposes `has_full_access` per student for frontend rendering decisions
- New setting registered in `services/config/defaults/gdpr.go` with key constant in `models/config/keys.go`

## Frontend Changes

- Student detail page uses `has_full_access` for data visibility, `has_write_access` for edit controls (buttons, action bar)
- `LocationBadge` respects `has_full_access` instead of recalculating group membership
- Tracking indicators hidden for students outside user's data scope
- Pickup schedule removed from `LimitedAccessView`
- Empty action bar div no longer renders when all buttons are hidden

## Type of Change
- [x] New feature
- [x] Security improvement

## Testing
- [x] Integration tests added/updated
- [x] Unit tests added/updated
- [x] Manual testing performed

**Backend tests:**
- `authorization_test.go`: Integration tests covering all scope scenarios (default read, all_staff read, write-not-affected, staff identity verification)
- `pickup_schedule_handlers_test.go`: Updated for scope-aware access control (403 for non-supervisors with default scope, 200 with all_staff scope)
- `defaults_test.go`: Updated to include the new setting registration

**Frontend tests:**
- Student detail page test extended with `has_write_access` coverage
- `use-student-data` hook test updated for new response fields
- `student-helpers` test updated for `has_full_access` mapping

## Security Checklist
- [x] I have followed the security guidelines
- [x] No sensitive information is committed
- [x] Environment variables are properly managed with templates
- [x] Code does not contain hardcoded secrets
- [x] No potential security vulnerabilities introduced

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] All tests are passing
- [x] My changes generate no new warnings or errors
- [x] I have checked for and resolved any merge conflicts