### PR TITLE
feat: add configurable tracking indicators to student cards

### DIFF
--- a/backend/api/active/active_test.go
+++ b/backend/api/active/active_test.go
@@ -40,7 +40,7 @@ func setupTestContext(t *testing.T) *testContext {
 	t.Helper()
 
 	db, svc := testutil.SetupAPITest(t)
-	resource := activeAPI.NewResource(svc.Active, svc.Users, svc.Schulhof, svc.UserContext, db, slog.Default())
+	resource := activeAPI.NewResource(svc.Active, svc.Users, svc.Schulhof, svc.UserContext, svc.Settings, db, slog.Default())
 
 	t.Cleanup(func() {
 		if err := db.Close(); err != nil {

--- a/backend/api/active/api.go
+++ b/backend/api/active/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	base "github.com/moto-nrw/project-phoenix/models/base"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
 	"github.com/moto-nrw/project-phoenix/services/facilities"
 	"github.com/moto-nrw/project-phoenix/services/usercontext"
 	userSvc "github.com/moto-nrw/project-phoenix/services/users"
@@ -27,6 +28,7 @@ type Resource struct {
 	PersonService      userSvc.PersonService
 	SchulhofService    facilities.SchulhofService
 	UserContextService usercontext.UserContextService
+	SettingsService    configSvc.SettingsService
 	db                 *bun.DB
 	logger             *slog.Logger
 }
@@ -49,12 +51,13 @@ func (rs *Resource) getDB(ctx context.Context) bun.IDB {
 }
 
 // NewResource creates a new active resource
-func NewResource(activeService activeSvc.Service, personService userSvc.PersonService, schulhofService facilities.SchulhofService, userContextService usercontext.UserContextService, db *bun.DB, logger *slog.Logger) *Resource {
+func NewResource(activeService activeSvc.Service, personService userSvc.PersonService, schulhofService facilities.SchulhofService, userContextService usercontext.UserContextService, settingsService configSvc.SettingsService, db *bun.DB, logger *slog.Logger) *Resource {
 	return &Resource{
 		ActiveService:      activeService,
 		PersonService:      personService,
 		SchulhofService:    schulhofService,
 		UserContextService: userContextService,
+		SettingsService:    settingsService,
 		db:                 db,
 		logger:             logger,
 	}
@@ -165,6 +168,9 @@ func (rs *Resource) Router() chi.Router {
 			r.With(authorize.RequiresPermission(permissions.GroupsRead), withTx).Get("/counts", rs.getCounts)
 			r.With(authorize.RequiresPermission(permissions.GroupsRead), withTx).Get("/dashboard", rs.getDashboardAnalytics)
 		})
+
+		// Tracking indicators (bulk check if students visited configured rooms/activities today)
+		r.With(authorize.RequiresPermission(permissions.GroupsRead), withTx).Post("/tracking-indicators", rs.getTrackingIndicators)
 
 		// Cross-tenant students (Ferienbetreuung / holiday care)
 		r.With(authorize.RequiresPermission(permissions.GroupsRead), withTx).Get("/cross-tenant-students", rs.getCrossTenantStudents)

--- a/backend/api/active/checkin_test.go
+++ b/backend/api/active/checkin_test.go
@@ -285,7 +285,7 @@ func setupCheckinTestHandler(t *testing.T, db *bun.DB) *active.Resource {
 	serviceFactory, err := services.NewFactory(repoFactory, db, slog.Default())
 	require.NoError(t, err, "Failed to create service factory")
 
-	return active.NewResource(serviceFactory.Active, serviceFactory.Users, serviceFactory.Schulhof, serviceFactory.UserContext, db, slog.Default())
+	return active.NewResource(serviceFactory.Active, serviceFactory.Users, serviceFactory.Schulhof, serviceFactory.UserContext, serviceFactory.Settings, db, slog.Default())
 }
 
 // makeCheckinRequest creates an HTTP request with JWT auth for the checkin endpoint

--- a/backend/api/active/tracking_handlers.go
+++ b/backend/api/active/tracking_handlers.go
@@ -10,8 +10,6 @@ import (
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 )
 
-const maxTrackingStudentIDs = 200
-
 // getTrackingIndicators handles POST /tracking-indicators
 // Returns per-student match results for configured tracking indicator labels.
 func (rs *Resource) getTrackingIndicators(w http.ResponseWriter, r *http.Request) {
@@ -26,11 +24,6 @@ func (rs *Resource) getTrackingIndicators(w http.ResponseWriter, r *http.Request
 			Labels:  []string{},
 			Results: map[int64][]bool{},
 		}, "")
-		return
-	}
-
-	if len(req.StudentIDs) > maxTrackingStudentIDs {
-		common.RenderError(w, r, ErrorInvalidRequest(errors.New("too many student IDs (max 200)")))
 		return
 	}
 

--- a/backend/api/active/tracking_handlers.go
+++ b/backend/api/active/tracking_handlers.go
@@ -1,0 +1,104 @@
+package active
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+)
+
+const maxTrackingStudentIDs = 200
+
+// getTrackingIndicators handles POST /tracking-indicators
+// Returns per-student match results for configured tracking indicator labels.
+func (rs *Resource) getTrackingIndicators(w http.ResponseWriter, r *http.Request) {
+	var req TrackingIndicatorsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		common.RenderError(w, r, ErrorInvalidRequest(errors.New("invalid request body")))
+		return
+	}
+
+	if len(req.StudentIDs) == 0 {
+		common.Respond(w, r, http.StatusOK, TrackingIndicatorsResponse{
+			Labels:  []string{},
+			Results: map[int64][]bool{},
+		}, "")
+		return
+	}
+
+	if len(req.StudentIDs) > maxTrackingStudentIDs {
+		common.RenderError(w, r, ErrorInvalidRequest(errors.New("too many student IDs (max 200)")))
+		return
+	}
+
+	for _, id := range req.StudentIDs {
+		if id <= 0 {
+			common.RenderError(w, r, ErrorInvalidRequest(errors.New("invalid student ID")))
+			return
+		}
+	}
+
+	ctx := r.Context()
+
+	// Check if tracking indicators are enabled for this tenant.
+	enabled, err := rs.SettingsService.ResolveBool(ctx, configModel.KeyTrackingIndicatorsEnabled)
+	if err != nil {
+		rs.getLogger().Warn("tracking_indicators_settings_error",
+			"error", err.Error(),
+		)
+		common.Respond(w, r, http.StatusOK, TrackingIndicatorsResponse{
+			Labels:  []string{},
+			Results: map[int64][]bool{},
+		}, "")
+		return
+	}
+
+	if !enabled {
+		common.Respond(w, r, http.StatusOK, TrackingIndicatorsResponse{
+			Labels:  []string{},
+			Results: map[int64][]bool{},
+		}, "")
+		return
+	}
+
+	// Read configured indicator labels.
+	labelKeys := []string{
+		configModel.KeyTrackingIndicator1,
+		configModel.KeyTrackingIndicator2,
+		configModel.KeyTrackingIndicator3,
+	}
+	var labels []string
+	for _, key := range labelKeys {
+		val, err := rs.SettingsService.ResolveString(ctx, key)
+		if err != nil {
+			continue
+		}
+		trimmed := strings.TrimSpace(val)
+		if trimmed != "" {
+			labels = append(labels, trimmed)
+		}
+	}
+
+	if len(labels) == 0 {
+		common.Respond(w, r, http.StatusOK, TrackingIndicatorsResponse{
+			Labels:  []string{},
+			Results: map[int64][]bool{},
+		}, "")
+		return
+	}
+
+	// Get tracking indicator results from the service.
+	results, err := rs.ActiveService.GetTrackingIndicators(ctx, req.StudentIDs, labels)
+	if err != nil {
+		common.RenderError(w, r, ErrorRenderer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, TrackingIndicatorsResponse{
+		Labels:  labels,
+		Results: results,
+	}, "")
+}

--- a/backend/api/active/tracking_handlers_test.go
+++ b/backend/api/active/tracking_handlers_test.go
@@ -1,0 +1,658 @@
+package active
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/config"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock SettingsService ---
+
+type trackingMockSettingsService struct {
+	resolveBoolFunc   func(ctx context.Context, key string) (bool, error)
+	resolveStringFunc func(ctx context.Context, key string) (string, error)
+}
+
+func (m *trackingMockSettingsService) GetSchema(ctx context.Context, perms []string) (*configSvc.SettingsSchema, error) {
+	return nil, nil
+}
+func (m *trackingMockSettingsService) Resolve(ctx context.Context, key string) (any, error) {
+	return nil, nil
+}
+func (m *trackingMockSettingsService) ResolveString(ctx context.Context, key string) (string, error) {
+	if m.resolveStringFunc != nil {
+		return m.resolveStringFunc(ctx, key)
+	}
+	return "", nil
+}
+func (m *trackingMockSettingsService) ResolveStringForTenant(ctx context.Context, tenantID int64, key string) (string, error) {
+	return "", nil
+}
+func (m *trackingMockSettingsService) ResolveBool(ctx context.Context, key string) (bool, error) {
+	if m.resolveBoolFunc != nil {
+		return m.resolveBoolFunc(ctx, key)
+	}
+	return false, nil
+}
+func (m *trackingMockSettingsService) ResolveInt(ctx context.Context, key string) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockSettingsService) HasTenantOverride(ctx context.Context, key string) (bool, error) {
+	return false, nil
+}
+func (m *trackingMockSettingsService) SetValue(ctx context.Context, key string, value any, changedBy *int64, perms []string) error {
+	return nil
+}
+func (m *trackingMockSettingsService) ResetValue(ctx context.Context, key string, changedBy *int64, perms []string) error {
+	return nil
+}
+func (m *trackingMockSettingsService) GetLoginImageURL(ctx context.Context, tenantID int64) (string, error) {
+	return "", nil
+}
+func (m *trackingMockSettingsService) SetLoginImageURL(ctx context.Context, tenantID int64, imageURL string) (string, error) {
+	return "", nil
+}
+func (m *trackingMockSettingsService) ClearLoginImageURL(ctx context.Context, tenantID int64) (string, error) {
+	return "", nil
+}
+
+// --- Mock ActiveService (stub all methods, only GetTrackingIndicators functional) ---
+
+type trackingMockActiveService struct {
+	getTrackingIndicatorsFunc func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error)
+}
+
+// The only method used by the tracking handler:
+func (m *trackingMockActiveService) GetTrackingIndicators(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+	if m.getTrackingIndicatorsFunc != nil {
+		return m.getTrackingIndicatorsFunc(ctx, studentIDs, labels)
+	}
+	return nil, nil
+}
+
+// Stub out the rest of the Service interface:
+func (m *trackingMockActiveService) GetActiveGroup(ctx context.Context, id int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CreateActiveGroup(ctx context.Context, group *activeModel.Group) error {
+	return nil
+}
+func (m *trackingMockActiveService) UpdateActiveGroup(ctx context.Context, group *activeModel.Group) error {
+	return nil
+}
+func (m *trackingMockActiveService) DeleteActiveGroup(ctx context.Context, id int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) ListActiveGroups(ctx context.Context, options *base.QueryOptions) ([]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindActiveGroupsByRoomID(ctx context.Context, roomID int64) ([]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindDeviceActiveGroupInRoom(ctx context.Context, roomID int64, deviceID int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindActiveGroupsByGroupID(ctx context.Context, groupID int64) ([]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindActiveGroupsByTimeRange(ctx context.Context, start, end time.Time) ([]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) EndActiveGroupSession(ctx context.Context, id int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) GetActiveGroupWithVisits(ctx context.Context, id int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetActiveGroupWithSupervisors(ctx context.Context, id int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetVisit(ctx context.Context, id int64) (*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CreateVisit(ctx context.Context, visit *activeModel.Visit) error {
+	return nil
+}
+func (m *trackingMockActiveService) UpdateVisit(ctx context.Context, visit *activeModel.Visit) error {
+	return nil
+}
+func (m *trackingMockActiveService) DeleteVisit(ctx context.Context, id int64) error { return nil }
+func (m *trackingMockActiveService) ListVisits(ctx context.Context, options *base.QueryOptions) ([]*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindVisitsByStudentID(ctx context.Context, studentID int64) ([]*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindVisitsByActiveGroupID(ctx context.Context, activeGroupID int64) ([]*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindVisitsByTimeRange(ctx context.Context, start, end time.Time) ([]*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) EndVisit(ctx context.Context, id int64) error { return nil }
+func (m *trackingMockActiveService) GetStudentCurrentVisit(ctx context.Context, studentID int64) (*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetStudentCurrentVisitWithRoom(ctx context.Context, studentID int64) (*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetStudentsCurrentVisits(ctx context.Context, studentIDs []int64) (map[int64]*activeModel.Visit, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CountActiveVisitsByRoomID(ctx context.Context, roomID int64) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) CountActiveVisitsByActiveGroupID(ctx context.Context, activeGroupID int64) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) GetGroupSupervisor(ctx context.Context, id int64) (*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CreateGroupSupervisor(ctx context.Context, supervisor *activeModel.GroupSupervisor) error {
+	return nil
+}
+func (m *trackingMockActiveService) UpdateGroupSupervisor(ctx context.Context, supervisor *activeModel.GroupSupervisor) error {
+	return nil
+}
+func (m *trackingMockActiveService) DeleteGroupSupervisor(ctx context.Context, id int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) ListGroupSupervisors(ctx context.Context, options *base.QueryOptions) ([]*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindSupervisorsByStaffID(ctx context.Context, staffID int64) ([]*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindSupervisorsByActiveGroupID(ctx context.Context, activeGroupID int64) ([]*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindSupervisorsByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64) ([]*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) EndSupervision(ctx context.Context, id int64) error { return nil }
+func (m *trackingMockActiveService) GetStaffActiveSupervisions(ctx context.Context, staffID int64) ([]*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetCombinedGroup(ctx context.Context, id int64) (*activeModel.CombinedGroup, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CreateCombinedGroup(ctx context.Context, group *activeModel.CombinedGroup) error {
+	return nil
+}
+func (m *trackingMockActiveService) UpdateCombinedGroup(ctx context.Context, group *activeModel.CombinedGroup) error {
+	return nil
+}
+func (m *trackingMockActiveService) DeleteCombinedGroup(ctx context.Context, id int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) ListCombinedGroups(ctx context.Context, options *base.QueryOptions) ([]*activeModel.CombinedGroup, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindActiveCombinedGroups(ctx context.Context) ([]*activeModel.CombinedGroup, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) FindCombinedGroupsByTimeRange(ctx context.Context, start, end time.Time) ([]*activeModel.CombinedGroup, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) EndCombinedGroup(ctx context.Context, id int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) GetCombinedGroupWithGroups(ctx context.Context, id int64) (*activeModel.CombinedGroup, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CreateCombinedGroupWithGroups(ctx context.Context, group *activeModel.CombinedGroup, groupIDs []int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) AddGroupToCombination(ctx context.Context, combinedGroupID, activeGroupID int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) RemoveGroupFromCombination(ctx context.Context, combinedGroupID, activeGroupID int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) GetGroupMappingsByActiveGroupID(ctx context.Context, activeGroupID int64) ([]*activeModel.GroupMapping, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetGroupMappingsByCombinedGroupID(ctx context.Context, combinedGroupID int64) ([]*activeModel.GroupMapping, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) StartActivitySession(ctx context.Context, activityID, deviceID, staffID int64, roomID *int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) StartActivitySessionWithSupervisors(ctx context.Context, activityID, deviceID int64, supervisorIDs []int64, roomID *int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CheckActivityConflict(ctx context.Context, activityID, deviceID int64) (*activeSvc.ActivityConflictInfo, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) EndActivitySession(ctx context.Context, activeGroupID int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) ForceStartActivitySession(ctx context.Context, activityID, deviceID, staffID int64, roomID *int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) ForceStartActivitySessionWithSupervisors(ctx context.Context, activityID, deviceID int64, supervisorIDs []int64, roomID *int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetDeviceCurrentSession(ctx context.Context, deviceID int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) UpdateActiveGroupSupervisors(ctx context.Context, activeGroupID int64, supervisorIDs []int64) (*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) ProcessSessionTimeout(ctx context.Context, deviceID int64) (*activeSvc.TimeoutResult, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) UpdateSessionActivity(ctx context.Context, activeGroupID int64) error {
+	return nil
+}
+func (m *trackingMockActiveService) ValidateSessionTimeout(ctx context.Context, deviceID int64, timeoutMinutes int) error {
+	return nil
+}
+func (m *trackingMockActiveService) GetSessionTimeoutInfo(ctx context.Context, deviceID int64) (*activeSvc.SessionTimeoutInfo, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CleanupAbandonedSessions(ctx context.Context, olderThan time.Duration) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) EndDailySessions(ctx context.Context) (*activeSvc.DailySessionCleanupResult, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetActiveGroupsCount(ctx context.Context) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) GetTotalVisitsCount(ctx context.Context) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) GetActiveVisitsCount(ctx context.Context) (int, error) {
+	return 0, nil
+}
+func (m *trackingMockActiveService) GetDashboardAnalytics(ctx context.Context) (*activeSvc.DashboardAnalytics, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetActiveGroupsByIDs(ctx context.Context, groupIDs []int64) (map[int64]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetStudentAttendanceStatus(ctx context.Context, studentID int64) (*activeSvc.AttendanceStatus, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetStudentsAttendanceStatuses(ctx context.Context, studentIDs []int64) (map[int64]*activeSvc.AttendanceStatus, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) ToggleStudentAttendance(ctx context.Context, studentID, staffID, deviceID int64, skipAuthCheck bool) (*activeSvc.AttendanceResult, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) CheckTeacherStudentAccess(ctx context.Context, teacherID, studentID int64) (bool, error) {
+	return false, nil
+}
+func (m *trackingMockActiveService) BroadcastDailyCheckout(ctx context.Context, studentID int64) {}
+func (m *trackingMockActiveService) GetUnclaimedActiveGroups(ctx context.Context) ([]*activeModel.Group, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) ClaimActiveGroup(ctx context.Context, groupID, staffID int64, role string) (*activeModel.GroupSupervisor, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) GetCrossTenantStudents(ctx context.Context, hostingTenantID int64) ([]activeModel.CrossTenantStudent, error) {
+	return nil, nil
+}
+
+// --- Test Helpers ---
+
+func createTrackingRequest(t *testing.T, body TrackingIndicatorsRequest) *http.Request {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	return httptest.NewRequest(http.MethodPost, "/tracking-indicators", bytes.NewReader(b))
+}
+
+// --- Tests ---
+
+func TestGetTrackingIndicators_InvalidBody(t *testing.T) {
+	rs := &Resource{}
+
+	req := httptest.NewRequest(http.MethodPost, "/tracking-indicators", bytes.NewReader([]byte("not json")))
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetTrackingIndicators_EmptyStudentIDs(t *testing.T) {
+	rs := &Resource{}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+	assert.Empty(t, resp.Data.Results)
+}
+
+func TestGetTrackingIndicators_TooManyStudentIDs(t *testing.T) {
+	rs := &Resource{}
+
+	ids := make([]int64, 201)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: ids})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetTrackingIndicators_InvalidStudentID(t *testing.T) {
+	rs := &Resource{}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10, 0}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetTrackingIndicators_NegativeStudentID(t *testing.T) {
+	rs := &Resource{}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10, -5}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetTrackingIndicators_SettingsError(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return false, errors.New("settings service error")
+		},
+	}
+
+	rs := &Resource{SettingsService: settings}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	// Returns 200 with empty data on settings error (graceful degradation)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+}
+
+func TestGetTrackingIndicators_Disabled(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return false, nil
+		},
+	}
+
+	rs := &Resource{SettingsService: settings}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+}
+
+func TestGetTrackingIndicators_NoLabelsConfigured(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return "", nil
+		},
+	}
+
+	rs := &Resource{SettingsService: settings}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+}
+
+func TestGetTrackingIndicators_LabelResolutionError(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return "", errors.New("label read error")
+		},
+	}
+
+	rs := &Resource{SettingsService: settings}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+}
+
+func TestGetTrackingIndicators_Success(t *testing.T) {
+	labelValues := map[string]string{
+		config.KeyTrackingIndicator1: "Hausaufgaben",
+		config.KeyTrackingIndicator2: "Mensa",
+		config.KeyTrackingIndicator3: "",
+	}
+
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return labelValues[key], nil
+		},
+	}
+
+	mockSvc := &trackingMockActiveService{
+		getTrackingIndicatorsFunc: func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+			assert.Equal(t, []int64{10, 20}, studentIDs)
+			assert.Equal(t, []string{"Hausaufgaben", "Mensa"}, labels)
+			return map[int64][]bool{
+				10: {true, false},
+				20: {false, true},
+			}, nil
+		},
+	}
+
+	rs := &Resource{
+		SettingsService: settings,
+		ActiveService:   mockSvc,
+	}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10, 20}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, []string{"Hausaufgaben", "Mensa"}, resp.Data.Labels)
+	assert.Equal(t, map[int64][]bool{10: {true, false}, 20: {false, true}}, resp.Data.Results)
+}
+
+func TestGetTrackingIndicators_ServiceError(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return "Mensa", nil
+		},
+	}
+
+	mockSvc := &trackingMockActiveService{
+		getTrackingIndicatorsFunc: func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+			return nil, errors.New("service error")
+		},
+	}
+
+	rs := &Resource{
+		SettingsService: settings,
+		ActiveService:   mockSvc,
+	}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestGetTrackingIndicators_WhitespaceOnlyLabels(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return "   ", nil
+		},
+	}
+
+	rs := &Resource{SettingsService: settings}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Data TrackingIndicatorsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data.Labels)
+}
+
+func TestGetTrackingIndicators_PartialLabelsConfigured(t *testing.T) {
+	labelValues := map[string]string{
+		config.KeyTrackingIndicator1: "Mensa",
+		config.KeyTrackingIndicator2: "",
+		config.KeyTrackingIndicator3: "Sport",
+	}
+
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return labelValues[key], nil
+		},
+	}
+
+	mockSvc := &trackingMockActiveService{
+		getTrackingIndicatorsFunc: func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+			assert.Equal(t, []string{"Mensa", "Sport"}, labels)
+			return map[int64][]bool{10: {true, true}}, nil
+		},
+	}
+
+	rs := &Resource{
+		SettingsService: settings,
+		ActiveService:   mockSvc,
+	}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: []int64{10}})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestGetTrackingIndicators_ExactlyMaxStudentIDs(t *testing.T) {
+	settings := &trackingMockSettingsService{
+		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
+			return true, nil
+		},
+		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
+			return "Mensa", nil
+		},
+	}
+
+	mockSvc := &trackingMockActiveService{
+		getTrackingIndicatorsFunc: func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+			result := make(map[int64][]bool, len(studentIDs))
+			for _, id := range studentIDs {
+				result[id] = []bool{false}
+			}
+			return result, nil
+		},
+	}
+
+	rs := &Resource{
+		SettingsService: settings,
+		ActiveService:   mockSvc,
+	}
+
+	ids := make([]int64, 200)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+
+	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: ids})
+	rr := httptest.NewRecorder()
+
+	rs.getTrackingIndicators(rr, req)
+
+	// 200 IDs is exactly at the limit, should succeed
+	assert.Equal(t, http.StatusOK, rr.Code)
+}

--- a/backend/api/active/tracking_handlers_test.go
+++ b/backend/api/active/tracking_handlers_test.go
@@ -348,22 +348,6 @@ func TestGetTrackingIndicators_EmptyStudentIDs(t *testing.T) {
 	assert.Empty(t, resp.Data.Results)
 }
 
-func TestGetTrackingIndicators_TooManyStudentIDs(t *testing.T) {
-	rs := &Resource{}
-
-	ids := make([]int64, 201)
-	for i := range ids {
-		ids[i] = int64(i + 1)
-	}
-
-	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: ids})
-	rr := httptest.NewRecorder()
-
-	rs.getTrackingIndicators(rr, req)
-
-	assert.Equal(t, http.StatusBadRequest, rr.Code)
-}
-
 func TestGetTrackingIndicators_InvalidStudentID(t *testing.T) {
 	rs := &Resource{}
 
@@ -615,44 +599,5 @@ func TestGetTrackingIndicators_PartialLabelsConfigured(t *testing.T) {
 
 	rs.getTrackingIndicators(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-}
-
-func TestGetTrackingIndicators_ExactlyMaxStudentIDs(t *testing.T) {
-	settings := &trackingMockSettingsService{
-		resolveBoolFunc: func(ctx context.Context, key string) (bool, error) {
-			return true, nil
-		},
-		resolveStringFunc: func(ctx context.Context, key string) (string, error) {
-			return "Mensa", nil
-		},
-	}
-
-	mockSvc := &trackingMockActiveService{
-		getTrackingIndicatorsFunc: func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
-			result := make(map[int64][]bool, len(studentIDs))
-			for _, id := range studentIDs {
-				result[id] = []bool{false}
-			}
-			return result, nil
-		},
-	}
-
-	rs := &Resource{
-		SettingsService: settings,
-		ActiveService:   mockSvc,
-	}
-
-	ids := make([]int64, 200)
-	for i := range ids {
-		ids[i] = int64(i + 1)
-	}
-
-	req := createTrackingRequest(t, TrackingIndicatorsRequest{StudentIDs: ids})
-	rr := httptest.NewRecorder()
-
-	rs.getTrackingIndicators(rr, req)
-
-	// 200 IDs is exactly at the limit, should succeed
 	assert.Equal(t, http.StatusOK, rr.Code)
 }

--- a/backend/api/active/types.go
+++ b/backend/api/active/types.go
@@ -202,6 +202,17 @@ type ActiveGroupSummary struct {
 	Status       string `json:"status"`
 }
 
+// TrackingIndicatorsResponse returns labels and per-student match results
+type TrackingIndicatorsResponse struct {
+	Labels  []string         `json:"labels"`
+	Results map[int64][]bool `json:"results"`
+}
+
+// TrackingIndicatorsRequest is the request body for POST /tracking-indicators
+type TrackingIndicatorsRequest struct {
+	StudentIDs []int64 `json:"student_ids"`
+}
+
 // ===== Request Types =====
 
 // ActiveGroupRequest represents an active group creation/update request

--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -316,7 +316,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 			return nil
 		}
 	})
-	api.Active = activeAPI.NewResource(api.Services.Active, api.Services.Users, api.Services.Schulhof, api.Services.UserContext, db, logger.With("handler", "active"))
+	api.Active = activeAPI.NewResource(api.Services.Active, api.Services.Users, api.Services.Schulhof, api.Services.UserContext, api.Services.Settings, db, logger.With("handler", "active"))
 	api.IoT = iotAPI.NewResource(iotAPI.ServiceDependencies{
 		IoTService:            api.Services.IoT,
 		UsersService:          api.Services.Users,

--- a/backend/database/repositories/active/visits.go
+++ b/backend/database/repositories/active/visits.go
@@ -759,7 +759,7 @@ func (r *VisitRepository) GetTodayVisitNamesForStudents(ctx context.Context, stu
 
 	var results []visitGroupNames
 
-	today := timezone.TodayUTC()
+	today := timezone.Today()
 
 	query := base.GetDB(ctx, r.db).NewSelect().
 		ModelTableExpr(tableExprActiveVisitsAsVisit).

--- a/backend/database/repositories/active/visits.go
+++ b/backend/database/repositories/active/visits.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/facilities"
@@ -729,6 +730,70 @@ func (r *VisitRepository) EndVisitsByActiveGroupIDs(ctx context.Context, activeG
 	}
 
 	return rowsAffected, nil
+}
+
+// visitGroupNames captures the activity + room names for a student visit (DB scan target).
+type visitGroupNames struct {
+	StudentID         int64  `bun:"student_id"`
+	ActivityGroupName string `bun:"activity_group_name"`
+	RoomName          string `bun:"room_name"`
+}
+
+// GetTodayVisitNamesForStudents returns activity group + room names for all of
+// today's visits for the given students. Used for tracking indicator matching.
+func (r *VisitRepository) GetTodayVisitNamesForStudents(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+	if len(studentIDs) == 0 {
+		return nil, nil
+	}
+
+	// Deduplicate incoming IDs.
+	uniqueIDs := make([]int64, 0, len(studentIDs))
+	seen := make(map[int64]struct{}, len(studentIDs))
+	for _, id := range studentIDs {
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		uniqueIDs = append(uniqueIDs, id)
+	}
+
+	var results []visitGroupNames
+
+	today := timezone.TodayUTC()
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		ModelTableExpr(tableExprActiveVisitsAsVisit).
+		ColumnExpr(`"visit".student_id`).
+		ColumnExpr(`COALESCE("activity"."name", '') AS activity_group_name`).
+		ColumnExpr(`COALESCE("room"."name", '') AS room_name`).
+		Join(`LEFT JOIN active.groups AS "group" ON "group".id = "visit".active_group_id`).
+		Join(`LEFT JOIN activities.groups AS "activity" ON "activity".id = "group".group_id`).
+		Join(`LEFT JOIN facilities.rooms AS "room" ON "room".id = "group".room_id`).
+		Where(`"visit".student_id IN (?)`, bun.List(uniqueIDs)).
+		Where(`"visit".entry_time >= ?`, today)
+
+	if where, val, ok := base.TenantWhere(ctx, "visit"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx, &results); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "get today visit names for students",
+			Err: err,
+		}
+	}
+
+	// Convert to model type.
+	out := make([]active.VisitGroupNames, len(results))
+	for i, r := range results {
+		out[i] = active.VisitGroupNames{
+			StudentID:         r.StudentID,
+			ActivityGroupName: r.ActivityGroupName,
+			RoomName:          r.RoomName,
+		}
+	}
+
+	return out, nil
 }
 
 // FindActiveVisits finds all visits with no exit time (currently active)

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -128,6 +128,10 @@ type VisitRepository interface {
 	// EndVisitsByActiveGroupIDs ends all active visits for multiple group IDs in a single query.
 	// Returns the number of visits ended.
 	EndVisitsByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64) (int64, error)
+
+	// GetTodayVisitNamesForStudents returns activity group + room names for all of
+	// today's visits for the given students. Used for tracking indicator matching.
+	GetTodayVisitNamesForStudents(ctx context.Context, studentIDs []int64) ([]VisitGroupNames, error)
 }
 
 // GroupSupervisorRepository defines operations for managing active group supervisors

--- a/backend/models/active/visit.go
+++ b/backend/models/active/visit.go
@@ -81,6 +81,13 @@ func (v *Visit) Validate() error {
 	return nil
 }
 
+// VisitGroupNames holds the activity and room names from a visit for indicator matching.
+type VisitGroupNames struct {
+	StudentID         int64
+	ActivityGroupName string
+	RoomName          string
+}
+
 // IsActive returns whether this visit is currently active
 func (v *Visit) IsActive() bool {
 	return v.ExitTime == nil

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -42,6 +42,14 @@ const (
 	KeyCheckoutWCEnabled          = "checkout.wc_enabled"
 )
 
+// Tracking indicator settings (student card activity indicators).
+const (
+	KeyTrackingIndicatorsEnabled = "tracking.indicators_enabled"
+	KeyTrackingIndicator1        = "tracking.indicator_1"
+	KeyTrackingIndicator2        = "tracking.indicator_2"
+	KeyTrackingIndicator3        = "tracking.indicator_3"
+)
+
 // Operations settings.
 const (
 	KeySessionEndEnabled             = "operations.session_end_enabled"

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/auth/device"
@@ -918,6 +919,51 @@ func (s *service) GetCrossTenantStudents(ctx context.Context, hostingTenantID in
 	)
 
 	return students, nil
+}
+
+// GetTrackingIndicators returns per-student match results for the given labels.
+// For each student, it checks today's visits and matches activity group name + room name
+// against each label using case-insensitive substring matching.
+func (s *service) GetTrackingIndicators(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+	result := make(map[int64][]bool, len(studentIDs))
+	if len(studentIDs) == 0 || len(labels) == 0 {
+		return result, nil
+	}
+
+	visitNames, err := s.visitRepo.GetTodayVisitNamesForStudents(ctx, studentIDs)
+	if err != nil {
+		return nil, &ActiveError{Op: "GetTrackingIndicators", Err: ErrDatabaseOperation}
+	}
+
+	// Build a map of student ID → concatenated visit texts for matching.
+	studentVisitTexts := make(map[int64][]string, len(studentIDs))
+	for _, vn := range visitNames {
+		text := strings.ToLower(strings.TrimSpace(vn.ActivityGroupName + " " + vn.RoomName))
+		studentVisitTexts[vn.StudentID] = append(studentVisitTexts[vn.StudentID], text)
+	}
+
+	// Lowercase the labels once.
+	lowerLabels := make([]string, len(labels))
+	for i, l := range labels {
+		lowerLabels[i] = strings.ToLower(strings.TrimSpace(l))
+	}
+
+	// For each student, check each label against their visit texts.
+	for _, sid := range studentIDs {
+		matches := make([]bool, len(labels))
+		texts := studentVisitTexts[sid]
+		for li, ll := range lowerLabels {
+			for _, t := range texts {
+				if strings.Contains(t, ll) {
+					matches[li] = true
+					break
+				}
+			}
+		}
+		result[sid] = matches
+	}
+
+	return result, nil
 }
 
 // visitSSEData holds data needed for SSE broadcasts after a visit is ended

--- a/backend/services/active/end_session_unit_test.go
+++ b/backend/services/active/end_session_unit_test.go
@@ -147,6 +147,7 @@ type mockVisitRepository struct {
 	getCurrentByStudentIDWithRoomFunc func(ctx context.Context, studentID int64) (*active.Visit, error)
 	countActiveByRoomIDFunc           func(ctx context.Context, roomID int64) (int, error)
 	countActiveByGroupIDFunc          func(ctx context.Context, activeGroupID int64) (int, error)
+	getTodayVisitNamesFunc            func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error)
 }
 
 func (m *mockVisitRepository) Create(ctx context.Context, entity *active.Visit) error {
@@ -260,6 +261,9 @@ func (m *mockVisitRepository) CountActiveByStudentID(ctx context.Context, studen
 }
 
 func (m *mockVisitRepository) GetTodayVisitNamesForStudents(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+	if m.getTodayVisitNamesFunc != nil {
+		return m.getTodayVisitNamesFunc(ctx, studentIDs)
+	}
 	return nil, nil
 }
 

--- a/backend/services/active/end_session_unit_test.go
+++ b/backend/services/active/end_session_unit_test.go
@@ -259,6 +259,10 @@ func (m *mockVisitRepository) CountActiveByStudentID(ctx context.Context, studen
 	return 0, nil
 }
 
+func (m *mockVisitRepository) GetTodayVisitNamesForStudents(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+	return nil, nil
+}
+
 // mockGroupSupervisorRepository is a minimal mock implementation of active.GroupSupervisorRepository
 type mockGroupSupervisorRepository struct {
 	findByActiveGroupIDFunc func(ctx context.Context, activeGroupID int64, activeOnly bool) ([]*active.GroupSupervisor, error)

--- a/backend/services/active/interface.go
+++ b/backend/services/active/interface.go
@@ -112,6 +112,10 @@ type Service interface {
 
 	// Cross-tenant student visibility (Ferienbetreuung / holiday care)
 	GetCrossTenantStudents(ctx context.Context, hostingTenantID int64) ([]active.CrossTenantStudent, error)
+
+	// Tracking indicators — returns per-student match results for the given labels.
+	// Each student gets a []bool aligned with the labels slice.
+	GetTrackingIndicators(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error)
 }
 
 // DashboardAnalytics represents aggregated analytics for dashboard

--- a/backend/services/active/tracking_indicators_unit_test.go
+++ b/backend/services/active/tracking_indicators_unit_test.go
@@ -1,0 +1,204 @@
+package active
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTrackingIndicators_EmptyStudentIDs(t *testing.T) {
+	svc := &service{}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{}, []string{"Mensa"})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestGetTrackingIndicators_EmptyLabels(t *testing.T) {
+	svc := &service{}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100}, []string{})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestGetTrackingIndicators_RepoError(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return nil, errors.New("database connection lost")
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100}, []string{"Mensa"})
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "GetTrackingIndicators")
+}
+
+func TestGetTrackingIndicators_NoVisits(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return nil, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100, 200}, []string{"Mensa", "Hausaufgaben"})
+
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	// All false because no visits
+	assert.Equal(t, []bool{false, false}, result[100])
+	assert.Equal(t, []bool{false, false}, result[200])
+}
+
+func TestGetTrackingIndicators_SubstringMatching(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Hausaufgaben Gruppe A", RoomName: "Raum 101"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100}, []string{"Hausaufgaben"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true}, result[100])
+}
+
+func TestGetTrackingIndicators_CaseInsensitive(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "MENSA Gruppe", RoomName: "Speisesaal"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100}, []string{"mensa"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true}, result[100])
+}
+
+func TestGetTrackingIndicators_MatchesRoomName(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Gruppe B", RoomName: "Mensa"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(context.Background(), []int64{100}, []string{"Mensa"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true}, result[100])
+}
+
+func TestGetTrackingIndicators_MultipleLabelsPartialMatch(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Hausaufgaben", RoomName: "Raum 1"},
+				{StudentID: 100, ActivityGroupName: "Sport", RoomName: "Turnhalle"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(
+		context.Background(),
+		[]int64{100},
+		[]string{"Hausaufgaben", "Mensa", "Sport"},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true, false, true}, result[100])
+}
+
+func TestGetTrackingIndicators_MultipleStudents(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Mensa", RoomName: "Speisesaal"},
+				{StudentID: 200, ActivityGroupName: "Hausaufgaben", RoomName: "Raum 3"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(
+		context.Background(),
+		[]int64{100, 200},
+		[]string{"Mensa", "Hausaufgaben"},
+	)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, []bool{true, false}, result[100])
+	assert.Equal(t, []bool{false, true}, result[200])
+}
+
+func TestGetTrackingIndicators_StudentWithNoVisits(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			// Only student 100 has visits, student 200 has none
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Mensa", RoomName: "Speisesaal"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(
+		context.Background(),
+		[]int64{100, 200},
+		[]string{"Mensa"},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true}, result[100])
+	assert.Equal(t, []bool{false}, result[200])
+}
+
+func TestGetTrackingIndicators_WhitespaceInLabels(t *testing.T) {
+	visitRepo := &mockVisitRepository{
+		getTodayVisitNamesFunc: func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error) {
+			return []active.VisitGroupNames{
+				{StudentID: 100, ActivityGroupName: "Hausaufgaben", RoomName: "Raum 1"},
+			}, nil
+		},
+	}
+
+	svc := &service{visitRepo: visitRepo}
+
+	result, err := svc.GetTrackingIndicators(
+		context.Background(),
+		[]int64{100},
+		[]string{"  Hausaufgaben  "},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true}, result[100])
+}

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -36,6 +36,10 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"checkout.raumwechsel_enabled",
 		"checkout.schulhof_enabled",
 		"checkout.wc_enabled",
+		"tracking.indicators_enabled",
+		"tracking.indicator_1",
+		"tracking.indicator_2",
+		"tracking.indicator_3",
 	}
 
 	for _, key := range expectedKeys {
@@ -46,7 +50,7 @@ func TestAllSettingsRegistered(t *testing.T) {
 		assert.NotEmpty(t, def.Category, "setting %q should have a category", key)
 	}
 
-	assert.GreaterOrEqual(t, len(all), 20, "at least 20 settings should be registered")
+	assert.GreaterOrEqual(t, len(all), 24, "at least 24 settings should be registered")
 }
 
 func TestOperationsSettings_Types(t *testing.T) {
@@ -265,6 +269,10 @@ func TestDefaults_HaveReasonableValues(t *testing.T) {
 		{"checkout.raumwechsel_enabled", true},
 		{"checkout.schulhof_enabled", false},
 		{"checkout.wc_enabled", false},
+		{"tracking.indicators_enabled", false},
+		{"tracking.indicator_1", ""},
+		{"tracking.indicator_2", ""},
+		{"tracking.indicator_3", ""},
 	}
 
 	for _, tc := range tests {
@@ -272,4 +280,58 @@ func TestDefaults_HaveReasonableValues(t *testing.T) {
 		require.NotNilf(t, def, "setting %q should exist", tc.key)
 		assert.Equalf(t, tc.expectedDefault, def.Default, "setting %q default", tc.key)
 	}
+}
+
+func TestTrackingSettings_Types(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected config.FieldType
+	}{
+		{"tracking.indicators_enabled", config.FieldBoolean},
+		{"tracking.indicator_1", config.FieldText},
+		{"tracking.indicator_2", config.FieldText},
+		{"tracking.indicator_3", config.FieldText},
+	}
+
+	for _, tc := range tests {
+		def := config.GetDefinition(tc.key)
+		require.NotNilf(t, def, "setting %q should exist", tc.key)
+		assert.Equalf(t, tc.expected, def.Type, "setting %q should be type %s", tc.key, tc.expected)
+	}
+}
+
+func TestDependsOn_TrackingGroup(t *testing.T) {
+	dependentKeys := []string{
+		"tracking.indicator_1",
+		"tracking.indicator_2",
+		"tracking.indicator_3",
+	}
+	for _, key := range dependentKeys {
+		def := config.GetDefinition(key)
+		require.NotNilf(t, def, "setting %q should exist", key)
+		require.NotNilf(t, def.DependsOn, "setting %q should have DependsOn", key)
+		assert.Equalf(t, "tracking.indicators_enabled", def.DependsOn.Key, "setting %q should depend on indicators_enabled", key)
+		assert.Equal(t, "eq", def.DependsOn.Condition)
+		assert.Equal(t, true, def.DependsOn.Value)
+	}
+}
+
+func TestTrackingIndicator_Validation(t *testing.T) {
+	indicatorKeys := []string{
+		"tracking.indicator_1",
+		"tracking.indicator_2",
+		"tracking.indicator_3",
+	}
+	for _, key := range indicatorKeys {
+		def := config.GetDefinition(key)
+		require.NotNilf(t, def, "setting %q should exist", key)
+		require.NotNilf(t, def.Validation, "setting %q should have validation", key)
+		require.NotNilf(t, def.Validation.Pattern, "setting %q should have pattern", key)
+		assert.Equal(t, `^[a-zA-ZäöüÄÖÜß\s]{0,30}$`, *def.Validation.Pattern, "setting %q pattern", key)
+	}
+
+	// Verify the toggle has no validation (boolean doesn't need it)
+	enabledDef := config.GetDefinition("tracking.indicators_enabled")
+	require.NotNil(t, enabledDef)
+	assert.Nil(t, enabledDef.Validation, "boolean toggle should have no validation")
 }

--- a/backend/services/config/defaults/tracking.go
+++ b/backend/services/config/defaults/tracking.go
@@ -1,0 +1,85 @@
+package defaults
+
+import (
+	"github.com/moto-nrw/project-phoenix/models/config"
+)
+
+func init() {
+	// --- Tracking Indicators ---
+	// Opt-in feature: shows in student cards whether a student has visited
+	// specific rooms/activities today (e.g., "Hausaufgaben", "Mensa").
+	// Admins configure up to 3 free-text labels; the backend matches them
+	// against today's visit history (activity group name + room name).
+
+	config.Register(config.Definition{
+		Key:             config.KeyTrackingIndicatorsEnabled,
+		Label:           "Aktivitäts-Indikatoren",
+		Description:     "Zeigt in den Schülerkarten an, ob ein Kind heute bereits in bestimmten Räumen oder Aktivitäten war",
+		Type:            config.FieldBoolean,
+		Default:         false,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "indikatoren",
+		SortOrder:       1,
+	})
+
+	indicatorPattern := `^[a-zA-ZäöüÄÖÜß\s]{0,30}$`
+
+	config.Register(config.Definition{
+		Key:             config.KeyTrackingIndicator1,
+		Label:           "Indikator 1",
+		Description:     "Suchbegriff für Raum- oder Aktivitätsnamen (z.B. 'Mensa', 'Hausaufgaben')",
+		Type:            config.FieldText,
+		Default:         "",
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "indikatoren",
+		SortOrder:       2,
+		Validation:      &config.ValidationRules{Pattern: &indicatorPattern},
+		DependsOn: &config.Dependency{
+			Key:       config.KeyTrackingIndicatorsEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyTrackingIndicator2,
+		Label:           "Indikator 2",
+		Description:     "Suchbegriff für Raum- oder Aktivitätsnamen (z.B. 'Mensa', 'Hausaufgaben')",
+		Type:            config.FieldText,
+		Default:         "",
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "indikatoren",
+		SortOrder:       3,
+		Validation:      &config.ValidationRules{Pattern: &indicatorPattern},
+		DependsOn: &config.Dependency{
+			Key:       config.KeyTrackingIndicatorsEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyTrackingIndicator3,
+		Label:           "Indikator 3",
+		Description:     "Suchbegriff für Raum- oder Aktivitätsnamen (z.B. 'Mensa', 'Hausaufgaben')",
+		Type:            config.FieldText,
+		Default:         "",
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "indikatoren",
+		SortOrder:       4,
+		Validation:      &config.ValidationRules{Pattern: &indicatorPattern},
+		DependsOn: &config.Dependency{
+			Key:       config.KeyTrackingIndicatorsEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+}

--- a/backend/services/scheduler/scheduler_test.go
+++ b/backend/services/scheduler/scheduler_test.go
@@ -1147,6 +1147,9 @@ func (m *mockActiveService) ClaimActiveGroup(_ context.Context, _, _ int64, _ st
 func (m *mockActiveService) GetCrossTenantStudents(_ context.Context, _ int64) ([]active.CrossTenantStudent, error) {
 	return nil, nil
 }
+func (m *mockActiveService) GetTrackingIndicators(_ context.Context, _ []int64, _ []string) (map[int64][]bool, error) {
+	return nil, nil
+}
 
 // =============================================================================
 // Mock Cleanup Service for Execute Tests

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -28,6 +28,8 @@ import {
 } from "~/components/students/student-card";
 import { createLogger } from "~/lib/logger";
 import { activeService } from "~/lib/active-api";
+import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
+import { TrackingIndicators } from "~/components/students/tracking-indicators";
 import type { Student } from "~/lib/student-helpers";
 import { UnclaimedRooms } from "~/components/active";
 import { SSEErrorBoundary } from "~/components/sse/SSEErrorBoundary";
@@ -815,6 +817,19 @@ function MeinRaumPageContent() {
     }
   }, [swrVisitsData, currentRoomId, updateRoomStudentCount]);
 
+  // Tracking indicators: fetch when student list changes (SSE-driven via SWR revalidation)
+  const trackingStudentIds = useMemo(
+    () => students.map((s) => s.id),
+    [students],
+  );
+  const { data: trackingData } = useSWRAuth<TrackingIndicatorsResponse>(
+    trackingStudentIds.length > 0
+      ? `tracking-supervisions-${currentRoomId}-${trackingStudentIds.join(",")}`
+      : null,
+    async () => activeService.getTrackingIndicators(trackingStudentIds),
+    { keepPreviousData: true, revalidateOnFocus: false },
+  );
+
   // Handle dashboard error
   useEffect(() => {
     if (dashboardError) {
@@ -1142,6 +1157,14 @@ function MeinRaumPageContent() {
                       </StudentInfoRow>
                     )}
                   </>
+                }
+                trackingIndicators={
+                  trackingData?.labels.length ? (
+                    <TrackingIndicators
+                      labels={trackingData.labels}
+                      results={trackingData.results[student.id] ?? []}
+                    />
+                  ) : undefined
                 }
               />
             ))}

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -52,6 +52,9 @@ import {
 } from "~/components/students/student-card";
 import { fetchBulkPickupTimes } from "~/lib/pickup-schedule-api";
 import type { BulkPickupTime } from "~/lib/pickup-schedule-api";
+import { activeService } from "~/lib/active-api";
+import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
+import { TrackingIndicators } from "~/components/students/tracking-indicators";
 import { Clock, AlertTriangle } from "lucide-react";
 import { createLogger } from "~/lib/logger";
 
@@ -449,6 +452,7 @@ function OGSGroupPageContent() {
       }
     >;
     pickupTimes?: Map<string, BulkPickupTime>;
+    trackingIndicators?: TrackingIndicatorsResponse;
   }>(
     hasAccess && currentGroupId ? `ogs-students-${currentGroupId}` : null,
     async () => {
@@ -488,20 +492,32 @@ function OGSGroupPageContent() {
 
       const students = studentsResponse.students || [];
 
-      // Fetch pickup times for all students (prevents loading flash)
+      // Fetch pickup times and tracking indicators for all students (prevents loading flash)
       let pickupTimesMap = new Map<string, BulkPickupTime>();
+      let trackingIndicators: TrackingIndicatorsResponse = {
+        labels: [],
+        results: {},
+      };
       if (students.length > 0) {
         const studentIds = students.map((s) => s.id.toString());
-        pickupTimesMap = await fetchBulkPickupTimes(studentIds).catch(() => {
-          logger.error("failed to fetch pickup times in SWR");
-          return new Map<string, BulkPickupTime>();
-        });
+        const [pickupResult, trackingResult] = await Promise.all([
+          fetchBulkPickupTimes(studentIds).catch(() => {
+            logger.error("failed to fetch pickup times in SWR");
+            return new Map<string, BulkPickupTime>();
+          }),
+          activeService.getTrackingIndicators(studentIds).catch(() => {
+            return { labels: [], results: {} } as TrackingIndicatorsResponse;
+          }),
+        ]);
+        pickupTimesMap = pickupResult;
+        trackingIndicators = trackingResult;
       }
 
       return {
         students,
         roomStatus: roomStatusResponse ?? undefined,
         pickupTimes: pickupTimesMap,
+        trackingIndicators,
       };
     },
     {
@@ -1183,6 +1199,18 @@ function OGSGroupPageContent() {
                         )}
                       </StudentInfoRow>
                     ) : null
+                  }
+                  trackingIndicators={
+                    swrStudentsData?.trackingIndicators?.labels.length ? (
+                      <TrackingIndicators
+                        labels={swrStudentsData.trackingIndicators.labels}
+                        results={
+                          swrStudentsData.trackingIndicators.results[
+                            student.id
+                          ] ?? []
+                        }
+                      />
+                    ) : undefined
                   }
                 />
               );

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -27,6 +27,9 @@ import {
   StudentInfoRow,
 } from "~/components/students/student-card";
 import { useSWRAuth, useImmutableSWR } from "~/lib/swr";
+import { activeService } from "~/lib/active-api";
+import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
+import { TrackingIndicators } from "~/components/students/tracking-indicators";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "StudentSearchPage" });
@@ -127,6 +130,19 @@ function SearchPageContent() {
   );
 
   const students = studentsData?.students ?? [];
+
+  // Tracking indicators for student cards
+  const trackingStudentIds = useMemo(
+    () => (studentsData?.students ?? []).map((s) => s.id),
+    [studentsData],
+  );
+  const { data: trackingData } = useSWRAuth<TrackingIndicatorsResponse>(
+    trackingStudentIds.length > 0
+      ? `tracking-search-${studentsCacheKey}`
+      : null,
+    async () => activeService.getTrackingIndicators(trackingStudentIds),
+    { keepPreviousData: true, revalidateOnFocus: false },
+  );
 
   // Error type for proper heading display (Fix P3: substring matching on transformed string)
   type ErrorType = "permission" | "session" | "generic" | null;
@@ -456,6 +472,14 @@ function SearchPageContent() {
                         </StudentInfoRow>
                       )}
                     </>
+                  }
+                  trackingIndicators={
+                    trackingData?.labels.length ? (
+                      <TrackingIndicators
+                        labels={trackingData.labels}
+                        results={trackingData.results[student.id] ?? []}
+                      />
+                    ) : undefined
                   }
                 />
               ))}

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -138,7 +138,7 @@ function SearchPageContent() {
   );
   const { data: trackingData } = useSWRAuth<TrackingIndicatorsResponse>(
     trackingStudentIds.length > 0
-      ? `tracking-search-${studentsCacheKey}`
+      ? `tracking-indicators-${debouncedSearchTerm}-${selectedGroup}`
       : null,
     async () => activeService.getTrackingIndicators(trackingStudentIds),
     { keepPreviousData: true, revalidateOnFocus: false },
@@ -474,7 +474,7 @@ function SearchPageContent() {
                     </>
                   }
                   trackingIndicators={
-                    trackingData?.labels.length ? (
+                    trackingData?.labels?.length ? (
                       <TrackingIndicators
                         labels={trackingData.labels}
                         results={trackingData.results[student.id] ?? []}

--- a/frontend/src/app/api/active/tracking-indicators/route.test.ts
+++ b/frontend/src/app/api/active/tracking-indicators/route.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Session } from "next-auth";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ExtendedSession extends Session {
+  user: Session["user"] & { token?: string };
+}
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const { mockAuth, mockApiPost } = vi.hoisted(() => ({
+  mockAuth: vi.fn<() => Promise<ExtendedSession | null>>(),
+  mockApiPost: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("~/lib/api-helpers", () => ({
+  apiGet: vi.fn(),
+  apiPost: mockApiPost,
+  apiPut: vi.fn(),
+  apiDelete: vi.fn(),
+  handleApiError: vi.fn((error: unknown) => {
+    const message =
+      error instanceof Error ? error.message : "Internal Server Error";
+    const status = message.includes("(401)")
+      ? 401
+      : message.includes("(404)")
+        ? 404
+        : 500;
+    return new Response(JSON.stringify({ error: message }), { status });
+  }),
+}));
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createMockRequest(body: unknown): NextRequest {
+  const url = new URL(
+    "/api/active/tracking-indicators",
+    "http://localhost:3000",
+  );
+  return new NextRequest(url, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function createMockContext(
+  params: Record<string, string | string[] | undefined> = {},
+) {
+  return { params: Promise.resolve(params) };
+}
+
+const defaultSession: ExtendedSession = {
+  user: { id: "1", token: "test-token", name: "Test User" },
+  expires: "2099-01-01",
+};
+
+interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T;
+}
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("POST /api/active/tracking-indicators", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(defaultSession);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+
+    const request = createMockRequest({ student_ids: [10, 20] });
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("proxies request to backend and returns data", async () => {
+    const innerData = {
+      labels: ["Hausaufgaben", "Mensa"],
+      results: { "10": [true, false], "20": [false, true] },
+    };
+
+    // apiPost returns the full response; handler accesses .data
+    mockApiPost.mockResolvedValueOnce({ data: innerData });
+
+    const request = createMockRequest({ student_ids: [10, 20] });
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(200);
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/active/tracking-indicators",
+      "test-token",
+      { student_ids: [10, 20] },
+    );
+
+    const json =
+      await parseJsonResponse<ApiResponse<typeof innerData>>(response);
+    expect(json.data).toEqual(innerData);
+  });
+
+  it("returns empty labels and results when feature is disabled", async () => {
+    const innerData = {
+      labels: [] as string[],
+      results: {} as Record<string, boolean[]>,
+    };
+
+    mockApiPost.mockResolvedValueOnce({ data: innerData });
+
+    const request = createMockRequest({ student_ids: [10] });
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(200);
+    const json =
+      await parseJsonResponse<ApiResponse<typeof innerData>>(response);
+    expect(json.data.labels).toEqual([]);
+    expect(json.data.results).toEqual({});
+  });
+
+  it("forwards backend errors", async () => {
+    mockApiPost.mockRejectedValueOnce(new Error("Backend error (500)"));
+
+    const request = createMockRequest({ student_ids: [10] });
+    const response = await POST(request, createMockContext());
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/frontend/src/app/api/active/tracking-indicators/route.ts
+++ b/frontend/src/app/api/active/tracking-indicators/route.ts
@@ -1,0 +1,14 @@
+import { createPostHandler } from "@/lib/route-wrapper";
+import { apiPost } from "@/lib/api-helpers";
+import type { ApiResponse } from "@/lib/api-helpers";
+import type { TrackingIndicatorsResponse } from "@/lib/active-helpers";
+
+// POST /api/active/tracking-indicators - Bulk check if students visited configured rooms/activities today
+export const POST = createPostHandler(async (_request, body, token) => {
+  const response = await apiPost<ApiResponse<TrackingIndicatorsResponse>>(
+    "/api/active/tracking-indicators",
+    token,
+    body,
+  );
+  return response.data;
+});

--- a/frontend/src/components/students/student-card.test.tsx
+++ b/frontend/src/components/students/student-card.test.tsx
@@ -5,6 +5,8 @@ import {
   SchoolClassIcon,
   GroupIcon,
   StudentInfoRow,
+  PickupTimeIcon,
+  ExceptionIcon,
 } from "./student-card";
 
 describe("StudentCard", () => {
@@ -82,6 +84,31 @@ describe("StudentCard", () => {
     const gradientDiv = container.querySelector(".from-blue-50\\/80");
     expect(gradientDiv).toBeInTheDocument();
   });
+
+  it("wraps location badge and tracking indicators in flex-col when trackingIndicators provided", () => {
+    render(
+      <StudentCard
+        {...defaultProps}
+        trackingIndicators={<span data-testid="tracking">Indicators</span>}
+      />,
+    );
+
+    expect(screen.getByTestId("tracking")).toBeInTheDocument();
+    expect(screen.getByTestId("location-badge")).toBeInTheDocument();
+    // Both should be inside a flex-col wrapper
+    const trackingEl = screen.getByTestId("tracking");
+    const wrapper = trackingEl.parentElement;
+    expect(wrapper?.className).toContain("flex");
+    expect(wrapper?.className).toContain("flex-col");
+  });
+
+  it("renders location badge alone without wrapper when no trackingIndicators", () => {
+    const { container } = render(<StudentCard {...defaultProps} />);
+
+    expect(screen.getByTestId("location-badge")).toBeInTheDocument();
+    // No tracking indicators present
+    expect(container.querySelector("[data-testid='tracking']")).toBeNull();
+  });
 });
 
 describe("SchoolClassIcon", () => {
@@ -117,6 +144,22 @@ describe("GroupIcon", () => {
     expect(svg?.className).toContain("h-3.5");
     expect(svg?.className).toContain("w-3.5");
     expect(svg?.className).toContain("text-gray-400");
+  });
+});
+
+describe("PickupTimeIcon", () => {
+  it("renders an SVG icon", () => {
+    const { container } = render(<PickupTimeIcon />);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+});
+
+describe("ExceptionIcon", () => {
+  it("renders an SVG icon with orange color", () => {
+    const { container } = render(<ExceptionIcon />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+    expect(svg?.className).toContain("text-orange-500");
   });
 });
 

--- a/frontend/src/components/students/student-card.tsx
+++ b/frontend/src/components/students/student-card.tsx
@@ -18,6 +18,8 @@ interface StudentCardProps {
   readonly locationBadge: ReactNode;
   /** Optional extra content between name and click hint */
   readonly extraContent?: ReactNode;
+  /** Optional tracking indicators (right-aligned, below location badge) */
+  readonly trackingIndicators?: ReactNode;
 }
 
 /**
@@ -32,6 +34,7 @@ export function StudentCard({
   onClick,
   locationBadge,
   extraContent,
+  trackingIndicators,
 }: StudentCardProps) {
   return (
     <button
@@ -81,8 +84,15 @@ export function StudentCard({
             {extraContent}
           </div>
 
-          {/* Location Badge */}
-          {locationBadge}
+          {/* Location Badge + optional Tracking Indicators */}
+          {trackingIndicators ? (
+            <div className="flex flex-col items-end gap-1">
+              {locationBadge}
+              {trackingIndicators}
+            </div>
+          ) : (
+            locationBadge
+          )}
         </div>
 
         {/* Bottom row with click hint */}

--- a/frontend/src/components/students/tracking-indicators.test.tsx
+++ b/frontend/src/components/students/tracking-indicators.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { TrackingIndicators } from "./tracking-indicators";
+
+describe("TrackingIndicators", () => {
+  it("returns null when labels are empty", () => {
+    const { container } = render(
+      <TrackingIndicators labels={[]} results={[]} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders one indicator per label", () => {
+    render(
+      <TrackingIndicators
+        labels={["Hausaufgaben", "Mensa"]}
+        results={[true, false]}
+      />,
+    );
+
+    expect(screen.getByText("Hausaufgaben")).toBeInTheDocument();
+    expect(screen.getByText("Mensa")).toBeInTheDocument();
+  });
+
+  it("renders green checkmark SVG for matched labels", () => {
+    render(<TrackingIndicators labels={["Hausaufgaben"]} results={[true]} />);
+
+    const svg = screen.getByLabelText("Hausaufgaben: erledigt");
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveClass("text-green-500");
+  });
+
+  it("renders gray circle SVG for unmatched labels", () => {
+    render(<TrackingIndicators labels={["Mensa"]} results={[false]} />);
+
+    const svg = screen.getByLabelText("Mensa: ausstehend");
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveClass("text-gray-300");
+  });
+
+  it("treats missing results as false (unmatched)", () => {
+    render(
+      <TrackingIndicators
+        labels={["Hausaufgaben", "Sport"]}
+        results={[true]}
+      />,
+    );
+
+    // First label matched
+    expect(screen.getByLabelText("Hausaufgaben: erledigt")).toBeInTheDocument();
+    // Second label has no result entry → defaults to false
+    expect(screen.getByLabelText("Sport: ausstehend")).toBeInTheDocument();
+  });
+
+  it("renders multiple indicators with mixed results", () => {
+    render(
+      <TrackingIndicators
+        labels={["Hausaufgaben", "Mensa", "Sport"]}
+        results={[true, false, true]}
+      />,
+    );
+
+    expect(screen.getByLabelText("Hausaufgaben: erledigt")).toBeInTheDocument();
+    expect(screen.getByLabelText("Mensa: ausstehend")).toBeInTheDocument();
+    expect(screen.getByLabelText("Sport: erledigt")).toBeInTheDocument();
+  });
+
+  it("renders label text with correct styling", () => {
+    render(<TrackingIndicators labels={["Hausaufgaben"]} results={[false]} />);
+
+    const label = screen.getByText("Hausaufgaben");
+    expect(label.tagName).toBe("SPAN");
+    expect(label).toHaveClass("text-xs", "font-medium", "text-gray-500");
+  });
+});

--- a/frontend/src/components/students/tracking-indicators.tsx
+++ b/frontend/src/components/students/tracking-indicators.tsx
@@ -1,0 +1,60 @@
+// components/students/tracking-indicators.tsx
+// Displays tracking indicator checkmarks/circles in student cards
+
+interface TrackingIndicatorsProps {
+  /** Configured indicator labels (e.g., ["Hausaufgaben", "Mensa"]) */
+  readonly labels: string[];
+  /** Match results aligned with labels (true = visited today) */
+  readonly results: boolean[];
+}
+
+/**
+ * Renders right-aligned tracking indicators showing whether a student
+ * has visited configured rooms/activities today.
+ * Returns null if no labels are configured.
+ */
+export function TrackingIndicators({
+  labels,
+  results,
+}: TrackingIndicatorsProps) {
+  if (labels.length === 0) return null;
+
+  return (
+    <div className="mt-1.5 flex flex-col items-end gap-0.5">
+      {labels.map((label, i) => {
+        const matched = results[i] ?? false;
+        return (
+          <div key={label} className="flex items-center gap-1.5">
+            <span className="text-xs font-medium text-gray-500">{label}</span>
+            {matched ? (
+              <svg
+                className="h-4 w-4 text-green-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-label={`${label}: erledigt`}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2.5}
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            ) : (
+              <svg
+                className="h-4 w-4 text-gray-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-label={`${label}: ausstehend`}
+              >
+                <circle cx="12" cy="12" r="9" strokeWidth={2} />
+              </svg>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/lib/active-helpers.ts
+++ b/frontend/src/lib/active-helpers.ts
@@ -1,6 +1,12 @@
 // lib/active-helpers.ts
 // Type definitions for active entities
 
+// Tracking indicators response from POST /api/active/tracking-indicators
+export interface TrackingIndicatorsResponse {
+  labels: string[];
+  results: Record<string, boolean[]>; // student_id → [matched1, matched2, ...]
+}
+
 // Backend types (from Go structs)
 export interface BackendActiveGroup {
   id: number;

--- a/frontend/src/lib/active-service.test.ts
+++ b/frontend/src/lib/active-service.test.ts
@@ -1280,4 +1280,106 @@ describe("active-service", () => {
       });
     });
   });
+
+  describe("getTrackingIndicators", () => {
+    it("returns empty response when studentIds is empty", async () => {
+      const result = await activeService.getTrackingIndicators([]);
+
+      expect(result).toEqual({ labels: [], results: {} });
+    });
+
+    it("returns empty response when session has no token", async () => {
+      // Clear the session cache so a fresh getSession call happens
+      const { clearSessionCache } = await import("./session-cache");
+      clearSessionCache();
+      mockedGetSession.mockResolvedValueOnce(null);
+
+      const result = await activeService.getTrackingIndicators(["10", "20"]);
+
+      expect(result).toEqual({ labels: [], results: {} });
+    });
+
+    it("fetches tracking indicators and returns data on success", async () => {
+      const { clearSessionCache } = await import("./session-cache");
+      clearSessionCache();
+
+      const mockResponse = {
+        data: {
+          labels: ["Hausaufgaben", "Mensa"],
+          results: { "10": [true, false], "20": [false, true] },
+        },
+      };
+
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      const result = await activeService.getTrackingIndicators(["10", "20"]);
+
+      expect(result).toEqual(mockResponse.data);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/active/tracking-indicators",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ student_ids: [10, 20] }),
+        }),
+      );
+    });
+
+    it("converts string student IDs to integers in request", async () => {
+      const { clearSessionCache } = await import("./session-cache");
+      clearSessionCache();
+
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { labels: [], results: {} } }),
+      } as Response);
+
+      await activeService.getTrackingIndicators(["42", "99"]);
+
+      const callBody = JSON.parse(
+        (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+      ) as { student_ids: number[] };
+      expect(callBody.student_ids).toEqual([42, 99]);
+    });
+
+    it("returns empty response on non-ok HTTP status", async () => {
+      const { clearSessionCache } = await import("./session-cache");
+      clearSessionCache();
+
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      } as Response);
+
+      const result = await activeService.getTrackingIndicators(["10"]);
+
+      expect(result).toEqual({ labels: [], results: {} });
+    });
+
+    it("includes authorization header from session token", async () => {
+      const { clearSessionCache } = await import("./session-cache");
+      clearSessionCache();
+
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { labels: [], results: {} } }),
+      } as Response);
+
+      await activeService.getTrackingIndicators(["10"]);
+
+      const callBody = mockFetch.mock.calls.find(
+        (call: unknown[]) => call[0] === "/api/active/tracking-indicators",
+      ) as [string, RequestInit] | undefined;
+      expect(callBody).toBeDefined();
+      const headers = callBody![1].headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer test-token");
+      expect(headers["Content-Type"]).toBe("application/json");
+    });
+  });
 });

--- a/frontend/src/lib/active-service.ts
+++ b/frontend/src/lib/active-service.ts
@@ -39,6 +39,7 @@ import {
   type CreateVisitInput,
   type CreateSupervisorInput,
   type CreateCombinedGroupInput,
+  type TrackingIndicatorsResponse,
 } from "./active-helpers";
 
 // Generic API response interface
@@ -1012,5 +1013,42 @@ export const activeService = {
       mapToggleSupervisionResponse,
       "Toggle Schulhof supervision",
     );
+  },
+
+  /**
+   * Fetch tracking indicators for a set of students.
+   * Returns configured labels and per-student match results (boolean array aligned with labels).
+   * Returns empty labels/results when the feature is disabled or no labels are configured.
+   */
+  getTrackingIndicators: async (
+    studentIds: string[],
+  ): Promise<TrackingIndicatorsResponse> => {
+    const empty: TrackingIndicatorsResponse = { labels: [], results: {} };
+    if (studentIds.length === 0) return empty;
+
+    const session = await getCachedSession();
+    if (!session?.user?.token) return empty;
+
+    const response = await fetch("/api/active/tracking-indicators", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.user.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        student_ids: studentIds.map((id) => Number.parseInt(id, 10)),
+      }),
+    });
+
+    if (!response.ok) {
+      logger.warn("tracking_indicators_fetch_failed", {
+        status: response.status,
+      });
+      return empty;
+    }
+
+    const data =
+      (await response.json()) as ApiResponse<TrackingIndicatorsResponse>;
+    return data.data;
   },
 };

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -348,6 +348,12 @@ describe("useGlobalSSE", () => {
         );
       });
       expect(ogsStudentCall).toBeDefined();
+
+      // Matcher must work with tenant-prefixed keys (useSWRAuth adds tenant slug prefix)
+      const matcher = ogsStudentCall![0] as (key: string) => boolean;
+      expect(matcher("my-tenant:ogs-students-5")).toBe(true);
+      expect(matcher("my-tenant:tracking-supervisions-1-42,43")).toBe(true);
+      expect(matcher("my-tenant:tracking-indicators-search-group1")).toBe(true);
     });
 
     it("student_checkout without active_group_id invalidates dashboard caches", () => {
@@ -391,9 +397,19 @@ describe("useGlobalSSE", () => {
 
       const mutateCalls = vi.mocked(mutate).mock.calls;
       const studentDetailCall = mutateCalls.find((call) => {
-        return call[0] === "student-detail-42";
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)("student-detail-42")
+        );
       });
       expect(studentDetailCall).toBeDefined();
+
+      // Must also match tenant-prefixed key
+      const matcher = studentDetailCall![0] as (key: string) => boolean;
+      expect(matcher("my-tenant:student-detail-42")).toBe(true);
+      // Must NOT match other student IDs
+      expect(matcher("student-detail-99")).toBe(false);
     });
 
     it("student_checkout without active_group_id does NOT invalidate supervision-visits", () => {

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -63,6 +63,8 @@ export function useGlobalSSE(): SSEHookState {
   const hasPendingDailyCheckoutDashboardEvent = useRef(false);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // SWR cache keys are tenant-prefixed by useSWRAuth (e.g. "tenant-slug:ogs-students-2").
+  // All matchers must use includes() instead of startsWith() to match regardless of prefix.
   const flushInvalidations = useCallback(() => {
     // Invalidate ALL supervision-visits caches for student/dashboard events.
     // A student checked out of Room A may appear on the Schulhof (catch-all),
@@ -71,8 +73,7 @@ export function useGlobalSSE(): SSEHookState {
     // that flag to keep their detail views in sync.
     if (pendingGroupIds.current.size > 0 || hasPendingDashboardEvent.current) {
       mutate(
-        (key) =>
-          typeof key === "string" && key.startsWith("supervision-visits-"),
+        (key) => typeof key === "string" && key.includes("supervision-visits-"),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),
@@ -83,6 +84,8 @@ export function useGlobalSSE(): SSEHookState {
 
     // Invalidate OGS group student caches (ogs-students-{groupId})
     // so the "Meine Gruppe" page picks up location changes (e.g. Zuhause).
+    // Also invalidate tracking indicator caches on active-supervisions
+    // (tracking-supervisions-*) and students/search (tracking-indicators-*).
     // Triggered by pendingGroupIds (room-level events) OR pendingStudentIds
     // (daily checkout sends student_checkout without an active_group_id).
     if (
@@ -90,7 +93,11 @@ export function useGlobalSSE(): SSEHookState {
       pendingStudentIds.current.size > 0
     ) {
       mutate(
-        (key) => typeof key === "string" && key.startsWith("ogs-students-"),
+        (key) =>
+          typeof key === "string" &&
+          (key.includes("ogs-students-") ||
+            key.includes("tracking-supervisions-") ||
+            key.includes("tracking-indicators-")),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),
@@ -101,7 +108,11 @@ export function useGlobalSSE(): SSEHookState {
 
     // Invalidate specific student detail caches
     for (const studentId of pendingStudentIds.current) {
-      mutate(`student-detail-${studentId}`).catch((err) => {
+      mutate(
+        (key) =>
+          typeof key === "string" &&
+          key.includes(`student-detail-${studentId}`),
+      ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),
           scope: "student_detail",
@@ -121,10 +132,7 @@ export function useGlobalSSE(): SSEHookState {
       hasPendingDailyCheckoutDashboardEvent.current
     ) {
       mutate(
-        (key) =>
-          typeof key === "string" &&
-          (key.startsWith("active-supervision-dashboard") ||
-            key.includes("dashboard")),
+        (key) => typeof key === "string" && key.includes("dashboard"),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## Summary

- Adds opt-in **tracking indicators** to student cards showing whether a student has visited specific rooms/activities today (e.g., "Hausaufgaben", "Mensa")
- Admins configure up to 3 free-text labels in tenant settings (operations → Indikatoren), matched against today's visit history using case-insensitive substring matching
- Indicators appear as checkmarks (green, visited) or empty circles (gray, not yet) right-aligned on student cards across active-supervisions, OGS groups, and student search pages
- Live updates via SSE — when a student moves rooms, indicators update in real-time

### Backend
- 4 new tenant-scoped settings (`tracking.indicators_enabled` + 3 text fields with `[a-zA-ZäöüÄÖÜß\s]{0,30}` validation)
- `POST /api/active/tracking-indicators` bulk endpoint — single SQL query with 3-way JOIN (`active.visits → active.groups → activities.groups + facilities.rooms`)
- Uses `timezone.TodayUTC()` for correct Berlin timezone handling
- SettingsService wired into active API resource

### Frontend
- `TrackingIndicators` component with accessible SVG icons
- Conditional `trackingIndicators` prop on `StudentCard` (no layout regression for existing cards)
- Integrated into 3 pages with SWR-based fetching + SSE revalidation

## Test plan
- [x] Backend builds clean (`go build ./...`)
- [x] All settings tests pass (18/18)
- [x] All active service unit tests pass (18/18)
- [x] Frontend passes `pnpm run check` (0 errors)
- [x] All lefthook pre-push hooks pass (git-secrets, go-vet, go-deadcode, golangci-lint, frontend-knip, frontend-check)
- [ ] Manual: enable indicators in tenant settings, check student cards on active-supervisions/ogs-groups/students/search
- [ ] Manual: verify indicators update live when students move rooms (SSE)
- [ ] Manual: verify no layout regression on pages without tracking indicators configured