### PR TITLE
fix: wire CleanupStaleAttendance into scheduler nightly cleanup

### DIFF
--- a/backend/services/active/cleanup_service.go
+++ b/backend/services/active/cleanup_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/audit"
@@ -368,7 +369,9 @@ func (s *cleanupService) CleanupStaleAttendance(ctx context.Context) (*Attendanc
 		CheckInTime time.Time `bun:"check_in_time"`
 	}
 
-	err := s.db.NewSelect().
+	db := repoBase.GetDB(ctx, s.db)
+
+	err := db.NewSelect().
 		Table(attendanceTableName).
 		Column("id", "student_id", "date", "check_in_time").
 		Where("date < ?", today).
@@ -406,7 +409,7 @@ func (s *cleanupService) CleanupStaleAttendance(ctx context.Context) (*Attendanc
 		}
 
 		// Update the record
-		_, err := s.db.NewUpdate().
+		_, err := db.NewUpdate().
 			Table(attendanceTableName).
 			Set("check_out_time = ?", checkOutTime).
 			Set("updated_at = ?", time.Now()).
@@ -452,7 +455,9 @@ func (s *cleanupService) PreviewAttendanceCleanup(ctx context.Context) (*Attenda
 		Date      time.Time `bun:"date"`
 	}
 
-	err := s.db.NewSelect().
+	db := repoBase.GetDB(ctx, s.db)
+
+	err := db.NewSelect().
 		Table(attendanceTableName).
 		Column("student_id", "date").
 		Where("date < ?", today).

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -414,6 +414,20 @@ func (s *Scheduler) executeCleanupForTenant(ctx context.Context, tenantID int64)
 		)
 	}
 
+	// Cleanup stale attendance records (open from previous days)
+	if attendanceResult, err := s.cleanupService.CleanupStaleAttendance(ctx); err != nil {
+		s.getLogger().Error("attendance cleanup failed",
+			slog.Int64("tenant_id", tenantID),
+			slog.String("error", err.Error()),
+		)
+	} else if attendanceResult != nil && attendanceResult.RecordsClosed > 0 {
+		s.getLogger().Info("attendance cleanup completed",
+			slog.Int64("tenant_id", tenantID),
+			slog.Int("records_closed", attendanceResult.RecordsClosed),
+			slog.Int("students_affected", attendanceResult.StudentsAffected),
+		)
+	}
+
 	// Cleanup open work sessions
 	if s.workSessionCleanup != nil {
 		if closedCount, err := s.workSessionCleanup.CleanupOpenSessions(ctx); err != nil {

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -420,12 +420,20 @@ func (s *Scheduler) executeCleanupForTenant(ctx context.Context, tenantID int64)
 			slog.Int64("tenant_id", tenantID),
 			slog.String("error", err.Error()),
 		)
-	} else if attendanceResult != nil && attendanceResult.RecordsClosed > 0 {
-		s.getLogger().Info("attendance cleanup completed",
-			slog.Int64("tenant_id", tenantID),
-			slog.Int("records_closed", attendanceResult.RecordsClosed),
-			slog.Int("students_affected", attendanceResult.StudentsAffected),
-		)
+	} else if attendanceResult != nil {
+		if !attendanceResult.Success {
+			s.getLogger().Warn("attendance cleanup partial failure",
+				slog.Int64("tenant_id", tenantID),
+				slog.Int("records_closed", attendanceResult.RecordsClosed),
+				slog.Int("errors", len(attendanceResult.Errors)),
+			)
+		} else if attendanceResult.RecordsClosed > 0 {
+			s.getLogger().Info("attendance cleanup completed",
+				slog.Int64("tenant_id", tenantID),
+				slog.Int("records_closed", attendanceResult.RecordsClosed),
+				slog.Int("students_affected", attendanceResult.StudentsAffected),
+			)
+		}
 	}
 
 	// Cleanup open work sessions

--- a/backend/services/scheduler/scheduler_test.go
+++ b/backend/services/scheduler/scheduler_test.go
@@ -1167,6 +1167,7 @@ type mockCleanupService struct {
 	previewCalls           int
 	previewErr             error
 	attendanceCalls        int
+	attendanceResult       *activeService.AttendanceCleanupResult
 	attendanceErr          error
 	attendancePreviewCalls int
 	attendancePreviewErr   error
@@ -1204,7 +1205,7 @@ func (m *mockCleanupService) CleanupStaleAttendance(_ context.Context) (*activeS
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.attendanceCalls++
-	return nil, m.attendanceErr
+	return m.attendanceResult, m.attendanceErr
 }
 
 func (m *mockCleanupService) PreviewAttendanceCleanup(_ context.Context) (*activeService.AttendanceCleanupPreview, error) {
@@ -2358,6 +2359,78 @@ func TestExecuteCleanupForTenant_ReturnsTrueOnSuccess(t *testing.T) {
 	s := &Scheduler{
 		cleanupService: &mockCleanupService{
 			cleanupResult: &activeService.CleanupResult{},
+		},
+		logger: slog.Default(),
+	}
+	result := s.executeCleanupForTenant(context.Background(), 1)
+	assert.True(t, result)
+}
+
+func TestExecuteCleanupForTenant_AttendanceError(t *testing.T) {
+	s := &Scheduler{
+		cleanupService: &mockCleanupService{
+			cleanupResult: &activeService.CleanupResult{},
+			attendanceErr: errors.New("attendance db error"),
+		},
+		logger: slog.Default(),
+	}
+	result := s.executeCleanupForTenant(context.Background(), 1)
+	// Returns true because primary cleanup (expired visits) succeeded
+	assert.True(t, result)
+}
+
+func TestExecuteCleanupForTenant_AttendancePartialFailure(t *testing.T) {
+	s := &Scheduler{
+		cleanupService: &mockCleanupService{
+			cleanupResult: &activeService.CleanupResult{},
+			attendanceResult: &activeService.AttendanceCleanupResult{
+				Success:       false,
+				RecordsClosed: 3,
+				Errors:        []string{"record 1 failed", "record 2 failed"},
+			},
+		},
+		logger: slog.Default(),
+	}
+	result := s.executeCleanupForTenant(context.Background(), 1)
+	assert.True(t, result)
+}
+
+func TestExecuteCleanupForTenant_AttendanceSuccess(t *testing.T) {
+	s := &Scheduler{
+		cleanupService: &mockCleanupService{
+			cleanupResult: &activeService.CleanupResult{},
+			attendanceResult: &activeService.AttendanceCleanupResult{
+				Success:          true,
+				RecordsClosed:    5,
+				StudentsAffected: 3,
+			},
+		},
+		logger: slog.Default(),
+	}
+	result := s.executeCleanupForTenant(context.Background(), 1)
+	assert.True(t, result)
+}
+
+func TestExecuteCleanupForTenant_AttendanceNoRecords(t *testing.T) {
+	s := &Scheduler{
+		cleanupService: &mockCleanupService{
+			cleanupResult: &activeService.CleanupResult{},
+			attendanceResult: &activeService.AttendanceCleanupResult{
+				Success:       true,
+				RecordsClosed: 0,
+			},
+		},
+		logger: slog.Default(),
+	}
+	result := s.executeCleanupForTenant(context.Background(), 1)
+	assert.True(t, result)
+}
+
+func TestExecuteCleanupForTenant_AttendanceNilResult(t *testing.T) {
+	s := &Scheduler{
+		cleanupService: &mockCleanupService{
+			cleanupResult:    &activeService.CleanupResult{},
+			attendanceResult: nil,
 		},
 		logger: slog.Default(),
 	}


### PR DESCRIPTION
## Summary

- `CleanupStaleAttendance` was implemented and tested but never wired into the scheduler's `executeCleanupForTenant` — attendance records with NULL `check_out_time` from previous days were never automatically closed
- ~13% of production attendance records had open `check_out_time` because students left without confirming "nach Hause" on the IoT device, and `EndDailySessions` only closes visits/sessions, not attendance
- The nightly cleanup job (2:00 AM per tenant) now calls `CleanupStaleAttendance` after supervisor cleanup, closing stale records with `23:59:59` Berlin time of the record's date

## Context

Discovered while investigating shifted attendance dates (PR #1246). Production had 1,399 open attendance records dating back to January. All 10,453 attendance records were deleted from production (all had the -1 day date shift bug). This fix ensures new records are properly closed going forward.

## Test plan

- [x] All scheduler tests pass (`go test ./services/scheduler/... -v`)
- [x] `go build ./...` clean
- [x] Lefthook pre-push checks pass (vet, lint, deadcode, secrets)
- [x] Existing `CleanupStaleAttendance` unit tests cover the function behavior