### PR TITLE
fix: use MOTO brand green for tracking indicator checkmarks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,22 @@ Changing tenant resolution, auth headers, or error messages affects PyrePortal's
 
 ## Critical Patterns
 
+### 0. Frontend: Reuse Existing Components and Design Standards (MANDATORY)
+
+**ABSOLUTE RULE: Before creating ANY new UI element, color, or component, search the existing codebase first.** Do not reinvent what already exists.
+
+**Brand Colors** — MOTO uses specific brand hex codes, NOT generic Tailwind color classes. Before using any color:
+
+1. **Check `frontend/src/lib/location-helper.ts` → `LOCATION_COLORS`** — the single source of truth for all semantic brand colors (green, blue, red, orange, purple, gray, amber). Read the file and use the exact hex values defined there.
+2. **Check `frontend/src/contexts/ToastContext.tsx`** — established color patterns for success/error/info states.
+3. **Check `frontend/src/styles/globals.css`** — logo gradient and other global color definitions.
+
+**NEVER use generic Tailwind color classes** (`text-green-500`, `bg-blue-500`, etc.) when a MOTO brand color exists for that semantic purpose. Tailwind defaults are different hues. Always use arbitrary value syntax with the brand hex: `text-[#HEX]`, `bg-[#HEX]`.
+
+**Reuse before rebuild:**
+- **ALWAYS search `frontend/src/components/`** for existing components before building new ones.
+- **ALWAYS check `frontend/src/lib/`** for existing helpers, hooks, and utilities before writing new logic.
+
 ### 1. BUN ORM: Quote Aliases (MANDATORY)
 ```go
 ModelTableExpr(`education.groups AS "group"`)   // CORRECT — quoted

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -122,6 +122,34 @@ src/app/
 - **`lib/tenant-api.ts`**: `resolveTenant(slug)`, `listTenants()`, `switchTenant(slug)`
 - **Error contract**: Backend returns `"account does not have access to this tenant"` — hardcoded mapping in `tenant-api.ts`. Changing this backend string breaks tenant switching silently.
 
+## Reuse Existing Components and Design Standards (MANDATORY)
+
+**ABSOLUTE RULE: Before creating ANY new UI element, color, or component, search the existing codebase first.** Do not reinvent what already exists. Duplication is a bug.
+
+### Brand Colors — NEVER Use Generic Tailwind Colors
+
+MOTO has specific brand hex codes. Using generic Tailwind colors (like `text-green-500`, `bg-blue-500`) instead of the correct brand hex is **wrong** and will be rejected in review. Tailwind defaults are different hues than the MOTO brand.
+
+**Before using ANY color, read these files and use the exact hex values defined there:**
+
+| File | What it defines |
+|------|----------------|
+| **`src/lib/location-helper.ts` → `LOCATION_COLORS`** | Single source of truth for all semantic brand colors (green, blue, red, orange, purple, gray, amber). Every status color in the app derives from here. |
+| **`src/contexts/ToastContext.tsx`** | Established color patterns for success/error/info toast states. |
+| **`src/styles/globals.css`** | Logo gradient and global color definitions. |
+
+**Rules:**
+- **ALWAYS read `LOCATION_COLORS` first** to get the correct hex values. Do not guess or use Tailwind defaults.
+- **Use arbitrary value syntax** with the brand hex: `text-[#HEX]`, `bg-[#HEX]`, `border-[#HEX]`.
+- **NEVER use `text-green-500`, `bg-blue-500`**, or any other generic Tailwind color utility when a MOTO brand color exists for that semantic purpose.
+
+### Before Writing Any New Frontend Code
+
+1. **Search `src/components/`** for existing components that do what you need. Reuse and extend, don't rebuild.
+2. **Search `src/lib/`** for existing helpers, hooks, API clients, and type mappings.
+3. **Check `src/components/ui/`** for shared UI primitives (modals, buttons, inputs, badges, etc.).
+4. **Read the color source files above** before picking any color.
+
 ## Code Architecture
 
 ### High-Level Architecture

--- a/frontend/src/components/students/tracking-indicators.test.tsx
+++ b/frontend/src/components/students/tracking-indicators.test.tsx
@@ -28,7 +28,7 @@ describe("TrackingIndicators", () => {
 
     const svg = screen.getByLabelText("Hausaufgaben: erledigt");
     expect(svg).toBeInTheDocument();
-    expect(svg).toHaveClass("text-green-500");
+    expect(svg).toHaveClass("text-[#83CD2D]");
   });
 
   it("renders gray circle SVG for unmatched labels", () => {

--- a/frontend/src/components/students/tracking-indicators.tsx
+++ b/frontend/src/components/students/tracking-indicators.tsx
@@ -28,7 +28,7 @@ export function TrackingIndicators({
             <span className="text-xs font-medium text-gray-500">{label}</span>
             {matched ? (
               <svg
-                className="h-4 w-4 text-green-500"
+                className="h-4 w-4 text-[#83CD2D]"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"


### PR DESCRIPTION
## Summary
- Replaces generic Tailwind `text-green-500` (`#22c55e`) with correct MOTO brand hex `#83CD2D` in tracking indicator checkmarks
- Adds mandatory rules to `CLAUDE.md` and `frontend/CLAUDE.md` to always check existing brand colors in `LOCATION_COLORS` before using Tailwind defaults

## Test plan
- [ ] Verify tracking indicator checkmarks render in correct MOTO green (`#83CD2D`)
- [ ] Confirm no other components are affected