### PR TITLE
fix: SSE cache invalidation for search page badges

### DIFF
--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -82,20 +82,25 @@ export function useGlobalSSE(): SSEHookState {
       });
     }
 
-    // Invalidate OGS group student caches (ogs-students-{groupId})
-    // so the "Meine Gruppe" page picks up location changes (e.g. Zuhause).
+    // Invalidate student list caches so "Meine Gruppe" and students/search
+    // pick up location changes (e.g. Zuhause) without a manual refresh.
     // Also invalidate tracking indicator caches on active-supervisions
     // (tracking-supervisions-*) and students/search (tracking-indicators-*).
-    // Triggered by pendingGroupIds (room-level events) OR pendingStudentIds
-    // (daily checkout sends student_checkout without an active_group_id).
+    // Triggered by pendingGroupIds (room-level events), pendingStudentIds
+    // (daily checkout sends student_checkout without an active_group_id),
+    // or hasPendingDashboardEvent (dashboard_counts_changed is broadcast
+    // to ALL clients on every check-in/out — ensures search page updates
+    // even when the user doesn't supervise the affected room/group).
     if (
       pendingGroupIds.current.size > 0 ||
-      pendingStudentIds.current.size > 0
+      pendingStudentIds.current.size > 0 ||
+      hasPendingDashboardEvent.current
     ) {
       mutate(
         (key) =>
           typeof key === "string" &&
           (key.includes("ogs-students-") ||
+            key.includes("search-students-") ||
             key.includes("tracking-supervisions-") ||
             key.includes("tracking-indicators-")),
       ).catch((err) => {


### PR DESCRIPTION
## Summary

- Add `search-students-*` to the SWR invalidation matcher in `useGlobalSSE` — it was missing, so the search page never refetched after SSE events
- Add `hasPendingDashboardEvent` to the condition gate that triggers student list cache invalidation — `dashboard_counts_changed` is the only event broadcast to ALL clients, but it wasn't triggering the block that contains the `search-students-*` matcher. Staff not supervising the affected room/group only receive this event, so their search page never updated.

## Test plan

- [ ] Open `/students/search` as a staff member who is **not** supervising any room
- [ ] Have another user check a student in/out via RFID or manual action
- [ ] Verify the LocationBadge on the search page updates within ~500ms
- [ ] Verify existing SSE behavior on supervision pages and dashboard is unaffected