### PR TITLE
refactor: reorganize settings page tabs for better admin UX

### DIFF
--- a/backend/models/config/registry.go
+++ b/backend/models/config/registry.go
@@ -80,9 +80,9 @@ type SelectOption struct {
 // TabOrder defines the display ordering of setting tabs.
 var TabOrder = []string{
 	"operations",
-	"gdpr",
-	"security",
 	"devices",
+	"gdpr",
+	"system",
 	"general",
 }
 

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -105,8 +105,8 @@ func TestSecuritySettings(t *testing.T) {
 	def := config.GetDefinition("security.ogs_device_pin")
 	require.NotNil(t, def)
 	assert.Equal(t, config.FieldPassword, def.Type)
-	assert.Equal(t, "security", def.Tab)
-	assert.Equal(t, "auth", def.Category)
+	assert.Equal(t, "devices", def.Tab)
+	assert.Equal(t, "pin", def.Category)
 	assert.Equal(t, "config:manage", def.WritePermission)
 }
 

--- a/backend/services/config/defaults/devices.go
+++ b/backend/services/config/defaults/devices.go
@@ -15,7 +15,7 @@ func init() {
 		WritePermission: "config:update",
 		Tab:             "devices",
 		Category:        "checkout",
-		SortOrder:       1,
+		SortOrder:       10,
 	})
 
 	config.Register(config.Definition{
@@ -28,7 +28,7 @@ func init() {
 		WritePermission: "config:update",
 		Tab:             "devices",
 		Category:        "checkout",
-		SortOrder:       2,
+		SortOrder:       11,
 	})
 
 	config.Register(config.Definition{
@@ -41,6 +41,6 @@ func init() {
 		WritePermission: "config:update",
 		Tab:             "devices",
 		Category:        "checkout",
-		SortOrder:       3,
+		SortOrder:       12,
 	})
 }

--- a/backend/services/config/defaults/gdpr.go
+++ b/backend/services/config/defaults/gdpr.go
@@ -5,6 +5,8 @@ import (
 )
 
 func init() {
+	// --- Data cleanup (system tab — automated background process) ---
+
 	config.Register(config.Definition{
 		Key:             config.KeyDataCleanupEnabled,
 		Label:           "Automatische Datenbereinigung",
@@ -13,9 +15,9 @@ func init() {
 		Default:         true,
 		ReadPermission:  "config:read",
 		WritePermission: "config:manage",
-		Tab:             "gdpr",
-		Category:        "cleanup",
-		SortOrder:       1,
+		Tab:             "system",
+		Category:        "datenbereinigung",
+		SortOrder:       20,
 	})
 
 	config.Register(config.Definition{
@@ -26,9 +28,9 @@ func init() {
 		Default:         "02:00",
 		ReadPermission:  "config:read",
 		WritePermission: "config:manage",
-		Tab:             "gdpr",
-		Category:        "cleanup",
-		SortOrder:       2,
+		Tab:             "system",
+		Category:        "datenbereinigung",
+		SortOrder:       21,
 		DependsOn: &config.Dependency{
 			Key:       config.KeyDataCleanupEnabled,
 			Condition: "eq",
@@ -46,9 +48,9 @@ func init() {
 		Default:         30,
 		ReadPermission:  "config:read",
 		WritePermission: "config:manage",
-		Tab:             "gdpr",
-		Category:        "cleanup",
-		SortOrder:       3,
+		Tab:             "system",
+		Category:        "datenbereinigung",
+		SortOrder:       22,
 		Validation:      &config.ValidationRules{Min: &minTimeout, Max: &maxTimeout},
 		DependsOn: &config.Dependency{
 			Key:       config.KeyDataCleanupEnabled,

--- a/backend/services/config/defaults/operations.go
+++ b/backend/services/config/defaults/operations.go
@@ -5,7 +5,7 @@ import (
 )
 
 func init() {
-	// --- Session End ---
+	// --- Session End (system tab — automated background process) ---
 
 	config.Register(config.Definition{
 		Key:             config.KeySessionEndEnabled,
@@ -15,8 +15,8 @@ func init() {
 		Default:         true,
 		ReadPermission:  "config:read",
 		WritePermission: "config:update",
-		Tab:             "operations",
-		Category:        "sessions",
+		Tab:             "system",
+		Category:        "sitzungsende",
 		SortOrder:       1,
 	})
 
@@ -28,8 +28,8 @@ func init() {
 		Default:         "18:00",
 		ReadPermission:  "config:read",
 		WritePermission: "config:update",
-		Tab:             "operations",
-		Category:        "sessions",
+		Tab:             "system",
+		Category:        "sitzungsende",
 		SortOrder:       2,
 		DependsOn: &config.Dependency{
 			Key:       config.KeySessionEndEnabled,
@@ -48,8 +48,8 @@ func init() {
 		Default:         10,
 		ReadPermission:  "config:read",
 		WritePermission: "config:update",
-		Tab:             "operations",
-		Category:        "sessions",
+		Tab:             "system",
+		Category:        "sitzungsende",
 		SortOrder:       3,
 		Validation:      &config.ValidationRules{Min: &minTimeout, Max: &maxTimeout},
 		DependsOn: &config.Dependency{
@@ -74,7 +74,7 @@ func init() {
 		SortOrder:       1,
 	})
 
-	// --- Abandoned Session Cleanup ---
+	// --- Abandoned Session Cleanup (system tab — automated background process) ---
 
 	config.Register(config.Definition{
 		Key:             config.KeySessionCleanupEnabled,
@@ -84,9 +84,9 @@ func init() {
 		Default:         false,
 		ReadPermission:  "config:read",
 		WritePermission: "config:update",
-		Tab:             "operations",
-		Category:        "cleanup",
-		SortOrder:       1,
+		Tab:             "system",
+		Category:        "sitzungsbereinigung",
+		SortOrder:       10,
 	})
 
 	minInterval := float64(5)
@@ -99,9 +99,9 @@ func init() {
 		Default:         15,
 		ReadPermission:  "config:read",
 		WritePermission: "config:update",
-		Tab:             "operations",
-		Category:        "cleanup",
-		SortOrder:       2,
+		Tab:             "system",
+		Category:        "sitzungsbereinigung",
+		SortOrder:       11,
 		Validation:      &config.ValidationRules{Min: &minInterval, Max: &maxInterval},
 		DependsOn: &config.Dependency{
 			Key:       config.KeySessionCleanupEnabled,
@@ -120,9 +120,9 @@ func init() {
 		Default:         60,
 		ReadPermission:  "config:read",
 		WritePermission: "config:update",
-		Tab:             "operations",
-		Category:        "cleanup",
-		SortOrder:       3,
+		Tab:             "system",
+		Category:        "sitzungsbereinigung",
+		SortOrder:       12,
 		Validation:      &config.ValidationRules{Min: &minThreshold, Max: &maxThreshold},
 		DependsOn: &config.Dependency{
 			Key:       config.KeySessionCleanupEnabled,
@@ -142,8 +142,8 @@ func init() {
 		ReadPermission:  "config:read",
 		WritePermission: "config:update",
 		Tab:             "operations",
-		Category:        "sessions",
-		SortOrder:       8,
+		Category:        "aufsicht",
+		SortOrder:       1,
 	})
 
 	// Break auto-end interval is NOT registered here — it controls a global ticker

--- a/backend/services/config/defaults/security.go
+++ b/backend/services/config/defaults/security.go
@@ -14,8 +14,8 @@ func init() {
 		Default:         "1234",
 		ReadPermission:  "config:read",
 		WritePermission: "config:manage",
-		Tab:             "security",
-		Category:        "auth",
+		Tab:             "devices",
+		Category:        "pin",
 		SortOrder:       1,
 		Validation:      &config.ValidationRules{Pattern: &pinPattern},
 	})

--- a/backend/services/config/schema_builder.go
+++ b/backend/services/config/schema_builder.go
@@ -93,7 +93,8 @@ func buildSchema(
 			Label: tabKey,
 		}
 
-		// Collect and sort categories
+		// Collect and sort categories by minimum SortOrder of their items,
+		// with alphabetical as tiebreaker.
 		var categoryKeys []string
 		seen := make(map[string]bool)
 		for ck := range catItems {
@@ -102,7 +103,14 @@ func buildSchema(
 				seen[ck.category] = true
 			}
 		}
-		sort.Strings(categoryKeys)
+		sort.Slice(categoryKeys, func(i, j int) bool {
+			minI := minCategorySortOrder(catItems[catKey{tab: tabKey, category: categoryKeys[i]}])
+			minJ := minCategorySortOrder(catItems[catKey{tab: tabKey, category: categoryKeys[j]}])
+			if minI != minJ {
+				return minI < minJ
+			}
+			return categoryKeys[i] < categoryKeys[j]
+		})
 
 		for _, catName := range categoryKeys {
 			ck := catKey{tab: tabKey, category: catName}
@@ -166,6 +174,20 @@ func jsonValuesEqual(a, b any) bool {
 		return false
 	}
 	return string(aj) == string(bj)
+}
+
+// minCategorySortOrder returns the minimum SortOrder among items in a category.
+func minCategorySortOrder(items []*ResolvedSetting) int {
+	if len(items) == 0 {
+		return 0
+	}
+	min := items[0].SortOrder
+	for _, item := range items[1:] {
+		if item.SortOrder < min {
+			min = item.SortOrder
+		}
+	}
+	return min
 }
 
 // orderTabs returns tab keys ordered by TabOrder, with unknown tabs appended alphabetically.

--- a/frontend/src/components/settings/settings-page.tsx
+++ b/frontend/src/components/settings/settings-page.tsx
@@ -324,8 +324,8 @@ export function useSettingsTabs(): {
   const tabLabels: Record<string, string> = {
     operations: "Betrieb",
     gdpr: "Datenschutz",
-    security: "Sicherheit",
     devices: "Geräte",
+    system: "System",
     general: "Allgemein",
   };
 
@@ -336,10 +336,9 @@ export function useSettingsTabs(): {
     operations:
       "M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z",
     gdpr: "M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z",
-    security:
-      "M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z",
     devices:
       "M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z",
+    system: "M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z",
     general:
       "M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4",
   };
@@ -348,7 +347,7 @@ export function useSettingsTabs(): {
   // When the schema fetch failed, render placeholder tabs so SettingsContent
   // mounts and can show its own error/retry UI instead of silently dropping
   // all schema tabs.
-  const fallbackTabKeys = ["operations", "gdpr", "security"];
+  const fallbackTabKeys = ["operations", "gdpr", "devices", "system"];
   const schemaTabs = schemaFetchFailed
     ? fallbackTabKeys.map((key) => ({
         id: `settings-${key}`,


### PR DESCRIPTION
## Summary
- Regroup 26 settings from 5 tabs into 4 intuitive tabs: **Betrieb**, **Geräte**, **Datenschutz**, **System**
- Remove single-setting "Sicherheit" tab — PIN moves to Geräte
- Consolidate duplicate "cleanup" categories (was in both Betrieb and Datenschutz) into System tab
- Change category sorting from alphabetical to SortOrder-based for logical ordering within tabs

## What changed
- **Backend**: Tab/Category/SortOrder fields on registry definitions (no key, value, permission, or consuming code changes)
- **Backend**: Schema builder sorts categories by min SortOrder instead of alphabetically
- **Frontend**: Tab labels, icons, and fallback keys updated (security → system)
- **Tests**: Updated `TestSecuritySettings` assertions for new tab/category

## No impact on
- Setting keys, values, defaults, validation, or permissions
- Database (`config.setting_values` stores keys only)
- Consuming code (scheduler, IoT, device auth — all use keys, not tabs)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./services/config/defaults/ -v` — all 19 tests pass
- [x] `pnpm run check` — lint + typecheck pass
- [x] All pre-push hooks pass (go-vet, golangci-lint, deadcode, knip, frontend-check)
- [ ] Visual verification on staging after deploy