### PR TITLE
fix: broadcast dashboard_counts_changed on daily checkout

### DIFF
--- a/backend/services/active/attendance_service.go
+++ b/backend/services/active/attendance_service.go
@@ -362,6 +362,11 @@ func (s *service) BroadcastDailyCheckout(ctx context.Context, studentID int64) {
 
 	// Broadcast to educational (OGS) group topic so the "Meine Gruppe" page updates
 	s.broadcastToEducationalGroup(ctx, studentRec, event)
+
+	// Notify all clients so dashboard counts and search page refresh —
+	// the educational group broadcast only reaches staff in that group,
+	// but the search page is used by all staff.
+	_ = s.broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
 }
 
 // ======== Unclaimed Groups Management (Deviceless Claiming) ========

--- a/backend/services/active/broadcast_test.go
+++ b/backend/services/active/broadcast_test.go
@@ -168,3 +168,17 @@ func TestBroadcast_EndActivitySessionSendsDashboardCounts(t *testing.T) {
 	}
 	assert.True(t, found, "expected dashboard_counts_changed after EndActivitySession with active visits")
 }
+
+func TestBroadcast_DailyCheckoutSendsDashboardCounts(t *testing.T) {
+	svc, broadcaster := setupServiceWithBroadcaster(t)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, db, "Broadcast", "DailyCheckout", "3a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	svc.BroadcastDailyCheckout(testpkg.TenantContext(1), student.ID)
+
+	assert.True(t, broadcaster.hasEventType(realtime.EventDashboardCountsChanged),
+		"expected dashboard_counts_changed after BroadcastDailyCheckout")
+}


### PR DESCRIPTION
## Summary

- `BroadcastDailyCheckout` was the only broadcast path missing `BroadcastToAll(dashboard_counts_changed)`, so staff not subscribed to the student's educational group topic never received an SSE event when a student went "Zuhause"
- The search page SWR cache (`search-students-*`) was never invalidated for those users, requiring a manual refresh to see the updated location
- Adds `BroadcastToAll` call consistent with every other broadcast path (`broadcastVisitCreated`, `broadcastVisitCheckout`, `broadcastStudentCheckoutEvents`)

## Test plan

- [x] `TestBroadcast_DailyCheckoutSendsDashboardCounts` added and passing
- [x] All 4 broadcast tests pass (`go test ./services/active/... -run TestBroadcast -v`)
- [x] Hermetic test check passes (`go test ./test/ -run TestHermeticTestPatterns -v`)
- [x] All lefthook pre-push checks pass (go-vet, golangci-lint, go-deadcode)
- [ ] Deploy to staging and verify: daily checkout to "Zuhause" updates search page without manual refresh