### PR TITLE
fix: return 409 instead of 500 when inviting account with existing tenant access

### DIFF
--- a/backend/api/auth/invitation_handlers.go
+++ b/backend/api/auth/invitation_handlers.go
@@ -128,6 +128,11 @@ func (rs *Resource) createInvitation(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if errors.Is(err, authService.ErrAccountAlreadyHasTenantAccess) {
+			common.RenderError(w, r, common.ErrorConflictWithCode(authService.ErrAccountAlreadyHasTenantAccess, "ACCOUNT_ALREADY_HAS_TENANT_ACCESS"))
+			return
+		}
+
 		if renderInvitationError(w, r, err) {
 			return
 		}

--- a/backend/api/auth/invitation_handlers_internal_test.go
+++ b/backend/api/auth/invitation_handlers_internal_test.go
@@ -127,6 +127,27 @@ func TestInvitationHandlers_CreateInvitationAndListPending(t *testing.T) {
 	assert.Equal(t, float64(0), item["created_by"])
 }
 
+func TestInvitationHandlers_CreateInvitation_AccountAlreadyHasTenantAccess(t *testing.T) {
+	service := &mockInvitationService{
+		createFn: func(context.Context, authService.InvitationRequest) (*authModels.InvitationToken, error) {
+			return nil, &authService.AuthError{Op: "create invitation", Err: authService.ErrAccountAlreadyHasTenantAccess}
+		},
+	}
+
+	resource := NewResource(nil, service, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/invitations", bytes.NewBufferString(`{"email":"existing@example.com","role_id":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), jwt.CtxClaims, jwt.AppClaims{ID: 1}))
+	rr := httptest.NewRecorder()
+	resource.createInvitation(rr, req)
+
+	require.Equal(t, http.StatusConflict, rr.Code)
+	body := decodeJSONBody(t, rr)
+	assert.Equal(t, "error", body["status"])
+	assert.Equal(t, "ACCOUNT_ALREADY_HAS_TENANT_ACCESS", body["code"])
+}
+
 func TestInvitationHandlers_ValidateAndAccept(t *testing.T) {
 	service := &mockInvitationService{
 		validateFn: func(_ context.Context, token string) (*authService.InvitationValidationResult, error) {

--- a/backend/api/common/errors.go
+++ b/backend/api/common/errors.go
@@ -81,6 +81,7 @@ type ErrResponse struct {
 
 	Status    string `json:"status"`
 	ErrorText string `json:"error,omitempty"`
+	Code      string `json:"code,omitempty"`
 }
 
 // Render implements the render.Renderer interface for ErrResponse
@@ -159,6 +160,17 @@ func ErrorConflict(err error) render.Renderer {
 		HTTPStatusCode: http.StatusConflict,
 		Status:         "error",
 		ErrorText:      err.Error(),
+	}
+}
+
+// ErrorConflictWithCode returns a 409 Conflict with a stable error code for frontend disambiguation.
+func ErrorConflictWithCode(err error, code string) render.Renderer {
+	return &ErrResponse{
+		Err:            err,
+		HTTPStatusCode: http.StatusConflict,
+		Status:         "error",
+		ErrorText:      err.Error(),
+		Code:           code,
 	}
 }
 

--- a/backend/api/common/errors_test.go
+++ b/backend/api/common/errors_test.go
@@ -404,6 +404,46 @@ func TestIsConstraintViolation(t *testing.T) {
 }
 
 // =============================================================================
+// ErrorConflictWithCode Tests
+// =============================================================================
+
+func TestErrorConflictWithCode(t *testing.T) {
+	testErr := errors.New("account already has access to tenant")
+	renderer := common.ErrorConflictWithCode(testErr, "ACCOUNT_ALREADY_HAS_TENANT_ACCESS")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/test", nil)
+
+	err := render.Render(w, r, renderer)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	var resp map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "error", resp["status"])
+	assert.Equal(t, "account already has access to tenant", resp["error"])
+	assert.Equal(t, "ACCOUNT_ALREADY_HAS_TENANT_ACCESS", resp["code"])
+}
+
+func TestErrorConflictWithCode_OmitsEmptyCode(t *testing.T) {
+	testErr := errors.New("conflict")
+	renderer := common.ErrorConflict(testErr)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/test", nil)
+
+	err := render.Render(w, r, renderer)
+	require.NoError(t, err)
+
+	var resp map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	_, hasCode := resp["code"]
+	assert.False(t, hasCode, "code field should be omitted when empty")
+}
+
+// =============================================================================
 // ErrorConflictMessage Tests
 // =============================================================================
 

--- a/backend/services/auth/errors.go
+++ b/backend/services/auth/errors.go
@@ -61,11 +61,12 @@ var (
 	ErrTenantAccessDenied = errors.New("account does not have access to this tenant")
 
 	// Invitation errors
-	ErrInvitationNotFound      = errors.New("invitation not found")
-	ErrInvitationExpired       = errors.New("invitation has expired")
-	ErrInvitationUsed          = errors.New("invitation has already been used")
-	ErrInvitationTenantDeleted = errors.New("the school for this invitation has been deleted")
-	ErrInvitationNameRequired  = errors.New("first name and last name are required")
+	ErrInvitationNotFound            = errors.New("invitation not found")
+	ErrInvitationExpired             = errors.New("invitation has expired")
+	ErrInvitationUsed                = errors.New("invitation has already been used")
+	ErrInvitationTenantDeleted       = errors.New("the school for this invitation has been deleted")
+	ErrInvitationNameRequired        = errors.New("first name and last name are required")
+	ErrAccountAlreadyHasTenantAccess = errors.New("account already has access to tenant")
 
 	// Deletion constraint errors
 	ErrRoleInUse       = errors.New("Rolle kann nicht gelöscht werden: Rolle ist aktuell Konten zugewiesen")                           //nolint:staticcheck // ST1005: user-facing German message

--- a/backend/services/auth/errors_test.go
+++ b/backend/services/auth/errors_test.go
@@ -33,6 +33,7 @@ func TestErrorVariables(t *testing.T) {
 		{"ErrInvitationExpired", ErrInvitationExpired, "invitation has expired"},
 		{"ErrInvitationUsed", ErrInvitationUsed, "invitation has already been used"},
 		{"ErrInvitationNameRequired", ErrInvitationNameRequired, "first name and last name are required"},
+		{"ErrAccountAlreadyHasTenantAccess", ErrAccountAlreadyHasTenantAccess, "account already has access to tenant"},
 	}
 
 	for _, tt := range tests {
@@ -63,6 +64,7 @@ func TestErrorVariablesAreDistinct(t *testing.T) {
 		ErrInvitationExpired,
 		ErrInvitationUsed,
 		ErrInvitationNameRequired,
+		ErrAccountAlreadyHasTenantAccess,
 	}
 
 	// Each error should be distinguishable with errors.Is

--- a/backend/services/auth/invitation_service.go
+++ b/backend/services/auth/invitation_service.go
@@ -553,7 +553,7 @@ func (s *invitationService) ensureInvitationTargetAllowed(ctx context.Context, e
 		return &AuthError{Op: opCreateInvitation, Err: err}
 	}
 	if exists {
-		return &AuthError{Op: opCreateInvitation, Err: fmt.Errorf("account already has access to tenant")}
+		return &AuthError{Op: opCreateInvitation, Err: ErrAccountAlreadyHasTenantAccess}
 	}
 	return nil
 }

--- a/frontend/src/components/admin/invitation-form.test.tsx
+++ b/frontend/src/components/admin/invitation-form.test.tsx
@@ -336,7 +336,38 @@ describe("InvitationForm", () => {
     });
   });
 
-  it("shows error for duplicate email (409)", async () => {
+  it("shows error for account already has tenant access (409 with code)", async () => {
+    mockCreateInvitation.mockRejectedValue({
+      status: 409,
+      code: "ACCOUNT_ALREADY_HAS_TENANT_ACCESS",
+      message: "account already has access to tenant",
+    });
+
+    render(<InvitationForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Betreuer")).toBeInTheDocument();
+    });
+
+    const emailInput = screen.getByTestId("invitation-email");
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+
+    const roleSelect = screen.getByLabelText("Rolle");
+    fireEvent.change(roleSelect, { target: { value: "1" } });
+
+    const submitButton = screen.getByText("Einladung senden");
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /Dieser Account hat bereits Zugang zu dieser Einrichtung/,
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows error for duplicate email (409 without code)", async () => {
     mockCreateInvitation.mockRejectedValue({
       status: 409,
       message: "Conflict",

--- a/frontend/src/components/admin/invitation-form.tsx
+++ b/frontend/src/components/admin/invitation-form.tsx
@@ -157,9 +157,13 @@ export function InvitationForm({
 
       // Handle specific error cases with user-friendly messages
       if (apiError?.status === 409) {
-        setError(
-          "Für diese E-Mail-Adresse existiert bereits ein Account. Bitte verwende eine andere E-Mail-Adresse.",
-        );
+        if (apiError.code === "ACCOUNT_ALREADY_HAS_TENANT_ACCESS") {
+          setError("Dieser Account hat bereits Zugang zu dieser Einrichtung.");
+        } else {
+          setError(
+            "Für diese E-Mail-Adresse existiert bereits ein Account. Bitte verwende eine andere E-Mail-Adresse.",
+          );
+        }
         setErrorFieldName("email");
       } else {
         setError(

--- a/frontend/src/lib/api-helpers.test.ts
+++ b/frontend/src/lib/api-helpers.test.ts
@@ -136,6 +136,37 @@ describe("handleApiError", () => {
     expect(response.status).toBe(500);
     expect(body.error).toBe("Internal Server Error");
   });
+
+  it("extracts error and code from embedded backend JSON", async () => {
+    const backendJson = JSON.stringify({
+      status: "error",
+      error: "account already has access to tenant",
+      code: "ACCOUNT_ALREADY_HAS_TENANT_ACCESS",
+    });
+    const error = new Error(`API error (409): ${backendJson}`);
+
+    const response = handleApiError(error);
+    const body = (await response.json()) as { error: string; code?: string };
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe("account already has access to tenant");
+    expect(body.code).toBe("ACCOUNT_ALREADY_HAS_TENANT_ACCESS");
+  });
+
+  it("omits code field when backend JSON has no code", async () => {
+    const backendJson = JSON.stringify({
+      status: "error",
+      error: "email already exists",
+    });
+    const error = new Error(`API error (409): ${backendJson}`);
+
+    const response = handleApiError(error);
+    const body = (await response.json()) as { error: string; code?: string };
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe("email already exists");
+    expect(body.code).toBeUndefined();
+  });
 });
 
 describe("handleDomainApiError", () => {

--- a/frontend/src/lib/api-helpers.ts
+++ b/frontend/src/lib/api-helpers.ts
@@ -27,6 +27,7 @@ export interface ApiResponse<T> {
 export interface ApiErrorResponse {
   error: string;
   status?: number;
+  code?: string;
 }
 
 /**
@@ -245,7 +246,29 @@ export function handleApiError(error: unknown): NextResponse<ApiErrorResponse> {
           error: error.message,
         });
       }
-      return NextResponse.json({ error: error.message }, { status });
+
+      // Try to extract structured fields from embedded backend JSON response
+      const response: ApiErrorResponse = { error: error.message };
+      const jsonStart = error.message.indexOf("{");
+      if (jsonStart !== -1) {
+        try {
+          const parsed = JSON.parse(error.message.substring(jsonStart)) as {
+            error?: string;
+            message?: string;
+            code?: string;
+          };
+          if (parsed.error ?? parsed.message) {
+            response.error = (parsed.error ?? parsed.message) as string;
+          }
+          if (parsed.code) {
+            response.code = parsed.code;
+          }
+        } catch {
+          // Not valid JSON, keep original error message
+        }
+      }
+
+      return NextResponse.json(response, { status });
     }
   }
 

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -156,7 +156,11 @@ export async function handleAuthFailure(): Promise<boolean> {
   }
 }
 
-export type ApiError = Error & { status?: number; retryAfterSeconds?: number };
+export type ApiError = Error & {
+  status?: number;
+  retryAfterSeconds?: number;
+  code?: string;
+};
 
 function parseRetryAfter(value: string | null): number | null {
   if (!value) {

--- a/frontend/src/lib/invitation-api.ts
+++ b/frontend/src/lib/invitation-api.ts
@@ -35,6 +35,7 @@ const createApiError = async (
   fallbackMessage: string,
 ): Promise<ApiError> => {
   let message = fallbackMessage;
+  let code: string | undefined;
 
   try {
     const contentType = response.headers.get("Content-Type") ?? "";
@@ -42,8 +43,10 @@ const createApiError = async (
       const payload = (await response.json()) as {
         error?: string;
         message?: string;
+        code?: string;
       };
       message = payload.error ?? payload.message ?? fallbackMessage;
+      code = payload.code;
     } else {
       const text = (await response.text()).trim();
       if (text) {
@@ -58,6 +61,7 @@ const createApiError = async (
 
   const apiError = new Error(message) as ApiError;
   apiError.status = response.status;
+  apiError.code = code;
   const retry = parseRetryAfter(response.headers.get("Retry-After"));
   if (retry !== undefined) {
     apiError.retryAfterSeconds = retry;


### PR DESCRIPTION
## Summary

Caught by Sentry in production: `POST /auth/invitations` returned HTTP 500 when inviting an account that already has access to the tenant, triggering false error alerts.

- Reclassify the error from 500 → 409 Conflict with a stable error code (`ACCOUNT_ALREADY_HAS_TENANT_ACCESS`)
- Add `Code` field to `common.ErrResponse` (`omitempty` — fully backward compatible, no behavior change for existing responses)
- Frontend parses the error code and shows the correct German message ("Dieser Account hat bereits Zugang zu dieser Einrichtung")

## Test plan

- [x] Backend compiles (`go build ./...`)
- [x] Frontend passes lint + typecheck (`pnpm run check`)
- [x] `api/common` tests pass
- [x] `services/auth` tests pass
- [x] All lefthook pre-push checks pass (go-vet, golangci-lint, deadcode, knip, frontend-check)