### PR TITLE
fix: upsert pickup exception when one already exists for the date

### DIFF
--- a/backend/services/schedule/pickup_schedule_service.go
+++ b/backend/services/schedule/pickup_schedule_service.go
@@ -237,7 +237,13 @@ func (s *pickupScheduleService) CreateStudentPickupException(ctx context.Context
 		return &ScheduleError{Op: opCreateStudentPickupException, Err: err}
 	}
 	if existing != nil {
-		return &ScheduleError{Op: opCreateStudentPickupException, Err: errors.New("exception already exists for this date")}
+		existing.PickupTime = exception.PickupTime
+		existing.Reason = exception.Reason
+		if err := s.exceptionRepo.Update(ctx, existing); err != nil {
+			return &ScheduleError{Op: opCreateStudentPickupException, Err: err}
+		}
+		*exception = *existing
+		return nil
 	}
 
 	exception.SetTenantID(tenant.FromContext(ctx))

--- a/backend/services/schedule/pickup_schedule_service_test.go
+++ b/backend/services/schedule/pickup_schedule_service_test.go
@@ -330,32 +330,39 @@ func TestPickupScheduleService_CreateStudentPickupException(t *testing.T) {
 		assert.Greater(t, exception.ID, int64(0))
 	})
 
-	t.Run("fails when exception already exists for date", func(t *testing.T) {
+	t.Run("upserts when exception already exists for date", func(t *testing.T) {
 		student := testpkg.CreateTestStudent(t, db, "Test", "Student", "1a")
 		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
 
 		// Use Berlin timezone for consistent date handling
 		exceptionDate := time.Date(2024, 3, 20, 12, 0, 0, 0, timezone.Berlin)
+		firstPickupTime := time.Date(2000, 1, 1, 15, 0, 0, 0, time.UTC)
 		exception1 := &scheduleModels.StudentPickupException{
 			StudentID:     student.ID,
 			ExceptionDate: exceptionDate,
+			PickupTime:    &firstPickupTime,
 			Reason:        strPtr("First exception"),
 			CreatedBy:     1,
 		}
 		err := service.CreateStudentPickupException(ctx, exception1)
 		require.NoError(t, err)
+		originalID := exception1.ID
 
+		secondPickupTime := time.Date(2000, 1, 1, 13, 0, 0, 0, time.UTC)
 		exception2 := &scheduleModels.StudentPickupException{
 			StudentID:     student.ID,
 			ExceptionDate: exceptionDate,
-			Reason:        strPtr("Second exception"),
+			PickupTime:    &secondPickupTime,
+			Reason:        strPtr("Changed pickup"),
 			CreatedBy:     1,
 		}
 
 		err = service.CreateStudentPickupException(ctx, exception2)
 
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "already exists")
+		require.NoError(t, err)
+		assert.Equal(t, originalID, exception2.ID, "should update existing exception, not create new")
+		assert.Equal(t, 13, exception2.PickupTime.Hour(), "should have updated pickup time")
+		assert.Equal(t, "Changed pickup", *exception2.Reason, "should have updated reason")
 	})
 
 	t.Run("fails validation for invalid exception", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- When staff created a pickup time exception for a student on a date that already had one (e.g. from another staff member or stale UI state), the backend rejected with *"exception already exists for this date"* causing a Sentry error and leaving the student card showing stale/missing pickup times
- `CreateStudentPickupException` now updates the existing exception's PickupTime and Reason instead of rejecting, matching the upsert pattern already used for weekly pickup schedules

## Test plan
- [x] Updated existing test to verify upsert behavior (same ID preserved, fields updated)
- [x] Full `services/schedule` test suite passes
- [x] Hermetic test patterns check passes
- [ ] Manual: create exception for student → change it again from another tab → verify update succeeds