### PR TITLE
fix: invalidate OGS groups SWR cache after pickup schedule changes

### DIFF
--- a/frontend/src/components/students/pickup-schedule-manager.tsx
+++ b/frontend/src/components/students/pickup-schedule-manager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { mutate } from "swr";
 import {
   Calendar,
   ChevronLeft,
@@ -38,6 +39,19 @@ import {
 } from "@/lib/pickup-schedule-api";
 
 const logger = createLogger({ component: "PickupScheduleManager" });
+
+/** Invalidate SWR caches that contain pickup time data (OGS groups, dashboard). */
+function invalidatePickupCaches() {
+  try {
+    mutate(
+      (key) =>
+        typeof key === "string" &&
+        (key.includes("ogs-students-") || key.includes("dashboard")),
+    ).catch(() => {});
+  } catch {
+    // SWR cache not available (e.g. in tests)
+  }
+}
 
 interface PickupScheduleManagerProps {
   readonly studentId: string;
@@ -121,6 +135,7 @@ export default function PickupScheduleManager({
     await loadPickupData();
     onUpdate?.();
     setIsScheduleModalOpen(false);
+    invalidatePickupCaches();
   };
 
   // Open day edit modal
@@ -130,10 +145,12 @@ export default function PickupScheduleManager({
   };
 
   // Refresh day data after changes (keeps modal open with fresh data)
+  // Also invalidates OGS groups SWR caches so pickup times update on navigation back
   const refreshAndKeepModal = useCallback(async () => {
     const data = await fetchStudentPickupData(studentId);
     setPickupData(data);
     onUpdate?.();
+    invalidatePickupCaches();
   }, [studentId, onUpdate]);
 
   // Day edit modal: exception handlers


### PR DESCRIPTION
## Summary
- Follow-up to #1268 — after editing a pickup exception or weekly schedule on the student detail page, the OGS groups page kept showing stale pickup times because its SWR cache was never invalidated
- Adds `invalidatePickupCaches()` to the `PickupScheduleManager` component which calls SWR `mutate()` to flush `ogs-students-*` and `dashboard` caches after any pickup data change (exception create/update/delete, note create/update/delete, weekly schedule update)

## Test plan
- [x] `pnpm run check` passes (0 warnings, 0 errors)
- [x] `pickup-schedule-manager.test.tsx` — 27/27 tests pass, 0 errors
- [x] Pre-push hooks pass (knip, oxlint, tsc)
- [ ] Manual: edit pickup exception on student detail → navigate back to "Meine Gruppe" → verify card shows updated time