### PR TITLE
docs: draft parent enrollment system implementation plan

### DIFF
--- a/docs/parent-enrollment-implementation-plan.md
+++ b/docs/parent-enrollment-implementation-plan.md
@@ -192,7 +192,7 @@ known deviations from plan.
 - Existing staff invitation flow (separate table) is unaffected
 
 **Notes / gotchas:**
-- If PR 5 (email outbox) hasn't merged yet, dispatch directly via the existing mailer. Leave a TODO comment and a memory note to migrate to outbox when available.
+- If PR 5 (shared `platform.email_outbox`) hasn't merged yet, dispatch directly via the existing mailer. Leave a TODO comment and a memory note to migrate to outbox when available. PR 5's template registry design should make retrofitting cheap.
 - The existing `services/auth/invitation_service.go` is the reference — stay close to its structure for easier reviews.
 - `auth.accounts_parents` exists but is orphaned — DO NOT write to it. Accounts go into `auth.accounts`.
 
@@ -245,12 +245,21 @@ All of these with German labels + descriptions. See §5.6 for the full table. Do
 **Depends on:** PR 4 (settings keys exist for outbox retries/token TTL). Does NOT depend on PR 1 (calendar_periods — added in a later column-add migration by whichever plan ships it first).
 
 **Scope:**
-- Migration: `enrollment.form_schemas`, `enrollment.requests` (calendar_period_id column nullable for now — see emergency plan §3 below), `enrollment.request_children`, `enrollment.email_outbox`. RLS policies on all four.
+- Migration: **`platform.email_outbox`** (shared platform-level table, not enrollment-scoped — see plan §5.1 and §11). RLS policy for tenant isolation.
+- Migration: `enrollment.form_schemas`, `enrollment.requests` (calendar_period_id column — assumes Yannick's `schedule.calendar_periods` is live; if not, coordinate before merging), `enrollment.request_children`. RLS on all three.
 - Models + repositories for each
+- `services/platform/outbox_service.go` + `services/platform/outbox_worker.go` — shared worker. Picks up `pending` rows with `FOR UPDATE SKIP LOCKED`, renders template by `kind`, dispatches, handles retry. Wire into scheduler.
+- Template registry: a `kind → template renderer` mapping so each feature registers its own renderers without the worker knowing about them
 - `services/enrollment/form_schema_service.go` — active schema getter, create-version, validate-submission-against-schema
-- `services/enrollment/outbox_worker.go` — picks up `pending` rows with `FOR UPDATE SKIP LOCKED`, renders + dispatches, handles retry. Wire into scheduler.
+- Enrollment registers its initial kinds: `guardian_invitation`, `enrollment_submitted`, `enrollment_admin_notification`, `enrollment_decision_digest`, `enrollment_approved`, `enrollment_waitlisted`, `enrollment_rejected`
 - Admin form editor UI at `/{tenant}/admin/enrollment-form` — simple table: add/edit/delete/reorder fields
 - Admin API: schema CRUD endpoints
+
+**Platform outbox table shape (confirmed from plan rev 2.3):**
+- Keyed by `kind` (text, extensible) — no enum, new kinds register their renderer at startup
+- Polymorphic `related_entity_type` + `related_entity_id` — no FK constraints
+- Common fields: `tenant_id`, `status`, `attempts`, `last_error`, `next_retry_at`, `payload JSONB`
+- Settings-driven retry policy (max attempts, backoff schedule)
 
 **Tests:**
 - Schema versioning: creating a new version marks the old inactive; submissions pin to their version_id; editing an active schema doesn't break old submissions
@@ -348,61 +357,21 @@ All of these with German labels + descriptions. See §5.6 for the full table. Do
 
 ---
 
-## 3. Calendar Periods Emergency Plan
+## 3. Calendar Periods Coordination (no longer an emergency — confirmed 2026-04-16)
 
-**Trigger:** PR 6 or PR 7 is ready to ship and `schedule.calendar_periods` has not been created by Yannick's Timetable RFC work.
+**Resolution:** Yannick has agreed to ship `schedule.calendar_periods` as part of the Timetable RFC work. The enrollment plan no longer needs a fallback migration.
 
-**Action:** Ship a minimal version of the table as part of PR 6 (not a separate PR — keep coordination surface small).
+**What this means:**
 
-### Minimal migration
+- PR 6 (care offerings) depends on Yannick's calendar_periods table being live before it can merge
+- If PR 6 is ready and calendar_periods isn't yet merged, coordinate with Yannick on timing — don't re-open the emergency plan without explicit approval from Christian + Yannick
+- PR 7 and PR 8 depend on `activities.student_enrollments` having the `valid_from`/`valid_until` columns (Timetable RFC E17). Confirm these are live before PR 8 merges.
 
-```sql
--- backend/database/migrations/<next>_calendar_periods_minimal.up.sql
+**Still open (ask Yannick before PR 6):**
 
-CREATE TABLE IF NOT EXISTS schedule.calendar_periods (
-  id            bigserial PRIMARY KEY,
-  tenant_id     bigint NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
-  name          text NOT NULL,
-  period_type   text NOT NULL DEFAULT 'school_year'
-    CHECK (period_type IN ('school_year','semester','holiday','custom')),
-  start_date    date NOT NULL,
-  end_date      date NOT NULL,
-  is_active     boolean NOT NULL DEFAULT false,
-  created_at    timestamptz NOT NULL DEFAULT now(),
-  updated_at    timestamptz NOT NULL DEFAULT now(),
-  UNIQUE (tenant_id, name),
-  CHECK (end_date > start_date)
-);
-
--- RLS to match existing tenant-scoped tables
-ALTER TABLE schedule.calendar_periods ENABLE ROW LEVEL SECURITY;
--- (policy following the existing pattern — copy from a nearby tenant-scoped table)
-
-CREATE INDEX IF NOT EXISTS idx_calendar_periods_tenant_active
-  ON schedule.calendar_periods (tenant_id) WHERE is_active;
-CREATE INDEX IF NOT EXISTS idx_calendar_periods_tenant_type
-  ON schedule.calendar_periods (tenant_id, period_type);
-```
-
-### Notes for Yannick's later extension
-
-Yannick's full RFC spec adds:
-- `week_cycle_length SMALLINT DEFAULT 1`
-- `week_cycle_anchor DATE`
-
-These are additive. His migration just runs `ALTER TABLE schedule.calendar_periods ADD COLUMN ...`. No data migration needed. We should flag this explicitly to him in the PR description so he's not surprised.
-
-### Minimal service
-
-Ship `backend/services/schedule/calendar_period_service.go` with just `Get`, `List`, `Create`, `Update`, `Delete`. Admin UI at `/{tenant}/admin/calendar-periods` — simple list + form. Yannick can extend later.
-
-### Communication
-
-The PR 6 description should include a `### Coordination` section noting:
-- We shipped the minimal `schedule.calendar_periods` because the Timetable RFC hadn't landed
-- The columns added are a strict subset of the RFC's spec
-- Additive extension is safe; no data migration needed
-- Link to the Timetable RFC and the enrollment plan's §11
+- Does Yannick's delivery auto-create a default `school_year` period per tenant, or do we need to add this to enrollment setup flow?
+- What's `ON DELETE` behavior if an admin tries to delete a calendar_period that enrollment rows reference? Enrollment wants `ON DELETE RESTRICT` — confirm Yannick agrees.
+- Any additional fields on `activities.student_enrollments` beyond `valid_from`/`valid_until`/`calendar_period_id` that we should know about?
 
 ---
 
@@ -504,19 +473,21 @@ If a merged PR misbehaves in staging, revert first and debug the revert commit l
 
 These are open questions that don't block starting PR 2 but should be resolved before their respective later PR:
 
-| Question | Blocks PR | Source |
-|----------|-----------|--------|
-| Required consent checkboxes for GDPR (AGB, data processing, contact, photo?) | PR 7 | plan §4 Q1 |
-| Default rejection retention in days | PR 5 or PR 8 | plan §4 Q2 (proposed 90) |
-| Spam provider choice (Turnstile / hCaptcha / other) | PR 7 | plan §4 Q5 |
-| Email sender identity (tenant-specific vs global) | PR 7 | plan §4 Q6 |
-| Grade level max (restrict to 4 for OGS or allow 13?) | PR 7 | plan §4 Q7 |
-| Care overflow behavior (reject / waitlist / allow) | PR 7 | plan §4 Q9 |
-| Digest vs immediate default | PR 8 | plan §4 Q10 |
-| Outbox scope (enrollment-only vs platform-shared) | PR 5 | plan §4 Q11 |
-| Status token TTL (1 year?) | PR 5 | plan §4 Q12 |
-| Calendar period ownership (skip PR 1 / ship minimal in PR 6) | PR 6 | plan §4 Q13 |
-| Default school-year period auto-gen | PR 6 | plan §4 Q14 |
+| Question | Blocks PR | Source | Status |
+|----------|-----------|--------|--------|
+| Required consent checkboxes for GDPR (AGB, data processing, contact, photo?) | PR 7 | plan §4 Q1 | **open** — Christian will discuss; ask again before PR 7 |
+| Default rejection retention in days | PR 5 or PR 8 | plan §4 Q2 (proposed 90) | tentative default 90; confirm before PR 5 |
+| Spam provider choice (Turnstile / hCaptcha / other) | PR 7 | plan §4 Q5 | **tentative: Cloudflare Turnstile** (Chris thinks we already use Cloudflare — verify before PR 7) |
+| Email sender identity (tenant-specific vs global) | PR 7 | plan §4 Q6 | open — ask again before PR 7 |
+| Grade level max (restrict to 4 for OGS or allow 13?) | PR 7 | plan §4 Q7 | open — ask again before PR 7 |
+| Care overflow behavior (reject / waitlist / allow) | PR 7 | plan §4 Q9 | open — ask again before PR 7 |
+| Digest vs immediate default | PR 8 | plan §4 Q10 | open — ask before PR 8 (my recommendation: `digest`) |
+| Outbox scope (enrollment-only vs platform-shared) | PR 5 | plan §4 Q11 | **RESOLVED: `platform.email_outbox` (shared)** |
+| Status token TTL (1 year?) | PR 5 | plan §4 Q12 | **RESOLVED: 1 year default, operator-only editable per tenant (new `platform:config:update` write permission)** |
+| Calendar period ownership | PR 6 | plan §4 Q13 | **RESOLVED: Yannick ships it** |
+| Default school-year period auto-gen | PR 6 | plan §4 Q14 | depends on Yannick's delivery — ask before PR 6 |
+
+**Protocol for re-asking open questions:** Claude must re-read this table at the start of every session starting from PR 5 onward, and explicitly ask the user for answers to the open items before writing code that depends on them. Don't assume; ask.
 
 ---
 
@@ -533,3 +504,4 @@ Do NOT rewrite history — keep a changelog at the top.
 ### Changelog
 
 - **2026-04-16 (v1):** Initial execution plan drafted by Claude for team review.
+- **2026-04-16 (v1.1):** Resolved Q11 (outbox → `platform.email_outbox` shared), Q12 (status token TTL 1 year, operator-only editable — introduces new `platform:config:update` permission pattern), Q13 (Yannick ships calendar_periods). Emergency fallback replaced by coordination notes. PR-7 open questions marked as re-ask-before-PR-7.

--- a/docs/parent-enrollment-implementation-plan.md
+++ b/docs/parent-enrollment-implementation-plan.md
@@ -1,0 +1,535 @@
+# Parent Enrollment — Implementation Execution Plan
+
+**Companion to:** `docs/parent-enrollment-plan.md`
+**Audience:** Claude (across multiple sessions) + human reviewer
+**Status:** Drafted 2026-04-16
+
+This document is the step-by-step execution plan for implementing the parent enrollment feature. The main plan describes **what** we're building. This document describes **how** to build it PR-by-PR, how to start each session cleanly, and how to hand off state between sessions.
+
+---
+
+## 0. How to Run This Across Multiple Claude Sessions
+
+### Recommendation: one session per PR
+
+Running one session per PR is the right default. Reasons:
+
+- Each PR is a discrete shippable unit; scope fits cleanly in a single session's context
+- Earlier PRs land on `development` and become part of the readable repo — Claude doesn't need the full history of how they were built, only what they now do
+- Long sessions accumulate noise: failed commands, stale file reads, old tool outputs. A fresh session is faster, cheaper, and more focused
+- Context is preserved **through artifacts** (the plan docs, the memory system, CLAUDE.md), not through chat history
+
+### When NOT to start a new session
+
+Stay in the same session if:
+
+- The current PR is still in progress (obvious)
+- You're actively iterating with a reviewer in the same sitting
+- A tightly-coupled follow-up PR is being prepared and recent context (file layouts, naming choices, test helpers) is still load-bearing
+
+### Context-feeding protocol per new session
+
+At the start of each PR's session, paste this bootstrap to Claude:
+
+```
+We are implementing the parent enrollment feature. Read:
+1. docs/parent-enrollment-plan.md (the plan — what we're building)
+2. docs/parent-enrollment-implementation-plan.md (this doc — how)
+
+Today we're working on PR <N> — <short title>. Start by reading the
+"PR N" section of the implementation plan, then the existing code it
+depends on. Check memory for prior-PR outcomes. Ask me any clarifying
+questions before editing code.
+```
+
+Claude will:
+1. Read both docs
+2. Read any relevant CLAUDE.md rules (auto-loaded)
+3. Read the existing files it will modify
+4. Check memory for post-PR handoff notes from earlier PRs
+5. Confirm scope before writing code
+
+### End-of-session handoff protocol
+
+Before ending a session, Claude MUST write a single memory entry summarizing:
+
+- Which PR number + title was completed
+- Final commit SHA and PR URL
+- Any deviations from the implementation plan and why
+- Anything surprising for future PRs (unexpected refactors, convention discoveries, test helper additions)
+- Anything deliberately deferred that a later PR must pick up
+
+Memory entry name: `enrollment_pr_<N>_handoff.md`, type: `project`. Keep it under 200 words.
+
+### What lives where
+
+| State | Lives in |
+|-------|----------|
+| What we're building | `docs/parent-enrollment-plan.md` |
+| How we're building it | This doc |
+| What's been finished | Git history + per-PR memory handoff notes |
+| Session-only state | Stays in the session (don't persist) |
+| Open questions awaiting team answers | §4 of the plan doc |
+
+---
+
+## 1. Pre-flight checks (once, before PR 2)
+
+Before starting the first implementation PR, Claude should verify:
+
+- [ ] `docs/student-enrollment-plan-v2` branch merged to `development` (or the plan doc is otherwise accessible on the working branch)
+- [ ] The `guardian_invitation` table exists (migration `001006016`)
+- [ ] The `accounts_parents` table exists but is unwired (we are deliberately NOT touching it)
+- [ ] Recent CLAUDE.md rules loaded: hermetic tests, settings system, no-fallbacks, env-docker-sync
+- [ ] `cd backend && go test ./...` passes on a clean `development` checkout
+- [ ] `cd frontend && pnpm run check` passes on a clean `development` checkout
+
+If any check fails, STOP and surface it to the user before proceeding.
+
+---
+
+## 2. PR-by-PR Execution Plan
+
+Each PR section is self-contained: read it, do it, ship it. PRs 2–5 can be worked in parallel by separate sessions if needed (see dependency table at the end).
+
+Feature flag: every user-visible addition is gated by `enrollment.enabled` (default `false`) — set up in PR 4. Until PR 4 lands, PRs 2/3 ship silent scaffolding only.
+
+---
+
+### PR 2 — Student lifecycle + activation scheduler
+
+**Goal:** Introduce `pending`/`active`/`inactive`/`alumnus` status on students, plus `enrolled_from`/`enrolled_until` date fields, and a daily scheduler job that flips `pending → active` when the date arrives.
+
+**Why first:** zero external dependencies (no calendar_periods, no guardian service). Pure backend change. Enables later PRs to create students in `pending` state.
+
+**Scope:**
+- Migration: add `status`, `enrolled_from`, `enrolled_until` to `users.students`
+  - Default `status='active'` for existing rows (no behavior change)
+  - Indexes: `(tenant_id, status)` and `(tenant_id, enrolled_from) WHERE status='pending'`
+- Model: extend `users/student.go` with the new fields + `StudentStatus` typed string constants
+- Repository: helper `UpdateStatus(ctx, studentID, newStatus)` + a query method `FindPendingDueForActivation(ctx, tenantID, asOf time.Time)`
+- Service: `services/scheduler/activate_students.go` — per-tenant iteration following `forEachTenantSettings()` pattern. Idempotent — safe to run multiple times per day.
+- Wire into the scheduler bootstrap in `services/scheduler/scheduler.go`
+- Setting: `students.activation_scheduler_interval_minutes` (default 60)
+
+**Files touched (estimate):**
+- `backend/database/migrations/<next>_student_lifecycle.up.sql` + `.down.sql`
+- `backend/models/users/student.go`
+- `backend/database/repositories/users/student_repo.go`
+- `backend/services/scheduler/activate_students.go` (new)
+- `backend/services/scheduler/scheduler.go` (wire in)
+- `backend/services/config/defaults/operations.go` (register setting)
+- `backend/models/config/keys.go` (key constant)
+- Tests for all of the above
+
+**Tests:**
+- Model: status enum round-trip, field marshaling
+- Repo: `FindPendingDueForActivation` returns only pending students with `enrolled_from <= asOf` and respects tenant scope
+- Scheduler: job flips exactly the due rows, leaves others, respects tenant RLS
+- Hermetic: use `testpkg.CreateTestStudent`; no hardcoded IDs
+
+**Acceptance criteria:**
+- Existing students keep working (status defaults to `active`)
+- A student created with `status='pending'` and `enrolled_from=yesterday` is flipped to `active` on the next scheduler tick
+- A student with `enrolled_until=today` is flipped to `inactive` at the next tick
+- Slog at info level: `"student status transition" student_id=X from=Y to=Z` (no names)
+
+**Before merging:**
+- `go test ./backend/...` green
+- `go test ./backend/test/ -run TestHermeticTestPatterns` green
+- Docker rebuild + manual smoke check that scheduler starts without error
+
+**Session handoff note template:**
+```
+PR 2 merged as <SHA>. Student lifecycle fields live. Scheduler job named
+ActivateStudents runs every X minutes. Setting key is <keyname>. No
+known deviations from plan.
+```
+
+---
+
+### PR 3 — Complete `guardian_invitation_service`
+
+**Goal:** Fill in the missing service layer behind the existing `auth.guardian_invitations` table and email template. Mirror `invitation_service.go` (staff) patterns. Ship the accept-invite frontend page.
+
+**Why it can be PR 3 in parallel:** zero dependency on PR 2. Unblocks enrollment approval (PR 8) AND any other feature that wants to invite guardians.
+
+**Scope:**
+- Backend service: `backend/services/auth/guardian_invitation_service.go`
+  - `Create(ctx, guardianProfileID, email, createdBy) → *GuardianInvitation`
+  - `SendEmail(ctx, invitation)` — dispatches via existing mailer using `guardian-invitation.html`
+  - `Accept(ctx, token, password) → (*Account, error)` — creates `auth.accounts` row with the `guardian` base role, marks invitation `accepted_at`
+  - `Resend(ctx, invitationID)` — re-issues token if expired, re-sends email
+  - `CleanupExpired(ctx)` — scheduler-callable
+- API handlers: `backend/api/auth/guardian_invitation_handlers.go`
+  - `POST /api/auth/guardian-invitations/accept`
+  - `POST /api/auth/guardian-invitations/{id}/resend`
+- Frontend: `/accept-guardian-invite/[token]` — mirror the existing `/accept-invite` page. Collect password, confirm password, show guardian's name + email pre-filled.
+- Email template: `backend/templates/email/guardian-invitation.html` exists — verify rendering with test context
+- Settings: `invitations.guardian_token_expiry_hours` (default 48)
+
+**Files touched (estimate):**
+- `backend/services/auth/guardian_invitation_service.go` (new)
+- `backend/services/auth/guardian_invitation_service_test.go` (new)
+- `backend/api/auth/guardian_invitation_handlers.go` (new)
+- `backend/api/auth/guardian_invitation_handlers_test.go` (new)
+- `frontend/src/app/accept-guardian-invite/[token]/page.tsx` (new)
+- `frontend/src/app/api/auth/guardian-invitations/**` (proxy routes)
+- `backend/services/config/defaults/invitations.go` (setting if not already present)
+
+**Tests:**
+- Create → token unique, expiry set, email outbox row written (or direct dispatch if we're not doing outbox yet — coordinate with PR 5)
+- Accept valid token → account created with guardian role, invitation marked accepted
+- Accept expired token → 410 Gone
+- Accept reused token → 409 Conflict
+- Resend → new token issued, old invalidated
+- Hermetic: use `testpkg.CreateTestAccount` etc.
+
+**Acceptance criteria:**
+- A row in `auth.guardian_invitations` + a valid token produces a working accept-invite page
+- Accepted invitation creates a real `auth.accounts` row with `guardian` role and the correct tenant link
+- Expired tokens return a clear German error ("Einladung abgelaufen")
+- Existing staff invitation flow (separate table) is unaffected
+
+**Notes / gotchas:**
+- If PR 5 (email outbox) hasn't merged yet, dispatch directly via the existing mailer. Leave a TODO comment and a memory note to migrate to outbox when available.
+- The existing `services/auth/invitation_service.go` is the reference — stay close to its structure for easier reviews.
+- `auth.accounts_parents` exists but is orphaned — DO NOT write to it. Accounts go into `auth.accounts`.
+
+---
+
+### PR 4 — Enrollment settings registry + tab
+
+**Goal:** Register all settings the enrollment feature will consume, create the "Enrollment" tab in the admin settings UI, and land the master feature flag `enrollment.enabled` (default `false`). No behavior changes yet — this is plumbing.
+
+**Why it's PR 4 in parallel:** pure additive work on the settings system. Independent of PR 2/3. Lets later PRs ship behind the flag.
+
+**Scope:**
+- Register definitions in `backend/services/config/defaults/enrollment.go` (new file)
+- Register all keys in `backend/models/config/keys.go`
+- Add `enrollment` tab to the schema builder if not already present (tab definition, German label "Anmeldung")
+- Frontend: add the new tab to the settings page. Since the settings page is auto-generated, this is just a registry-side change plus any tab label translation
+- Acceptance permissions: `config:update` for operational toggles, `config:manage` for sensitive settings (captcha, retention)
+
+**Settings to register (from §5.6 of the plan):**
+
+All of these with German labels + descriptions. See §5.6 for the full table. Don't forget the rev-2.1 and rev-2.2 additions (care offerings, application windows, outbox, per-decision, etc.).
+
+**Files touched:**
+- `backend/services/config/defaults/enrollment.go` (new)
+- `backend/models/config/keys.go` (many new constants)
+- `backend/services/config/schema_builder.go` (maybe — if tab registry is declarative, likely not)
+- Tests in `backend/services/config/defaults/defaults_test.go`
+
+**Tests:**
+- All new keys are registered (count, names)
+- Each definition has a label, description, valid type, and correct permission
+- Select-type settings have `Options.Static` filled
+- Boolean dependencies (e.g., `waitlist_enabled`) referenced by other settings are valid keys
+
+**Acceptance criteria:**
+- `GET /api/settings/schema` returns the new tab with all enrollment settings
+- Admin can toggle `enrollment.enabled` in the UI (even though it controls nothing yet)
+- Settings with `depends_on` conditions render correctly (child fields hide when parent is off)
+
+**Gotcha:** Labels and descriptions MUST be in German. See `.claude/rules/settings-system.md`.
+
+---
+
+### PR 5 — Enrollment core tables + form_schema service + email outbox + form editor UI
+
+**Goal:** Ship the `enrollment` schema tables (except care offerings), the form_schemas service with versioning, the email outbox worker, and the admin form editor UI. No public submission endpoint yet — that's PR 7.
+
+**Why this PR is bigger:** all three pieces are tightly coupled. Tables reference each other; form editor consumes the schema service; outbox will be filled by PR 8 but needs to exist so PR 7 can write confirmation emails to it.
+
+**Depends on:** PR 4 (settings keys exist for outbox retries/token TTL). Does NOT depend on PR 1 (calendar_periods — added in a later column-add migration by whichever plan ships it first).
+
+**Scope:**
+- Migration: `enrollment.form_schemas`, `enrollment.requests` (calendar_period_id column nullable for now — see emergency plan §3 below), `enrollment.request_children`, `enrollment.email_outbox`. RLS policies on all four.
+- Models + repositories for each
+- `services/enrollment/form_schema_service.go` — active schema getter, create-version, validate-submission-against-schema
+- `services/enrollment/outbox_worker.go` — picks up `pending` rows with `FOR UPDATE SKIP LOCKED`, renders + dispatches, handles retry. Wire into scheduler.
+- Admin form editor UI at `/{tenant}/admin/enrollment-form` — simple table: add/edit/delete/reorder fields
+- Admin API: schema CRUD endpoints
+
+**Tests:**
+- Schema versioning: creating a new version marks the old inactive; submissions pin to their version_id; editing an active schema doesn't break old submissions
+- Outbox worker: picks up pending rows, retries on failure, marks failed after max attempts, handles concurrent workers (two goroutines don't double-process the same row)
+- Form editor backend: validates field types, rejects duplicate keys, enforces required core fields
+- Hermetic: new test file using real tables + tenants
+
+**Acceptance criteria:**
+- Admin can create / edit the active schema via UI
+- Outbox worker runs and processes test-dispatched emails (use mock mailer in test env)
+- RLS verified: tenant A cannot read tenant B's form_schemas or email_outbox rows
+
+**Gotchas:**
+- `email_outbox.kind` enum must be comprehensive from day one (avoid migration pain later)
+- Form schema version pinning: when the admin edits, the running form should not suddenly change underneath submitters — cache the version ID in the submission flow per PR 7
+
+---
+
+### PR 6 — Care offerings catalog + admin UI
+
+**Goal:** Ship `enrollment.care_offerings` table + admin editor UI for managing the catalog (add/edit/delete/clone for next year). Parent-facing form doesn't consume it yet (PR 7).
+
+**Depends on:** Something has to own `schedule.calendar_periods` before this merges. See §3 "Calendar Periods Emergency Plan" below — if Yannick hasn't shipped the table by the time we reach this PR, ship the minimal subset as part of this PR (not a separate PR).
+
+**Scope:**
+- Migration: `enrollment.care_offerings` + `enrollment.request_child_offerings` (the latter is empty until PR 7 writes to it). RLS.
+- Model + repo + service per offering entity
+- Admin UI at `/{tenant}/admin/care-offerings` — list by calendar period, create/edit/delete/clone form
+- API: offering CRUD + parent-facing open-window endpoint (returns offerings filterable by school year + window open)
+
+**Tests:**
+- Capacity check logic (null = unlimited)
+- Application window filter: offerings with window in the past / future excluded from parent-facing endpoint
+- Clone-to-next-year helper: new offerings created with shifted dates but identical module structure
+- Admin can see closed offerings; parent endpoint cannot
+
+**Acceptance criteria:**
+- Admin UI lets them build a realistic catalog (e.g., "Regelbetreuung", "Ferienbetreuung Ostern", "Ferienbetreuung Sommer")
+- Calendar period FK works: deleting a period with offerings is blocked (`ON DELETE RESTRICT`)
+
+---
+
+### PR 7 — Public enrollment form + submission + confirmation email + status/edit page
+
+**Goal:** The public-facing flow. Parents can submit; they get a confirmation email with a status/edit token link; they can view/edit/withdraw from the status page (subject to rules from §6.3 of the plan).
+
+**Depends on:** PR 4 (settings), PR 5 (schemas + outbox), PR 6 (care offerings), PR 3 (so the guardian invite outbox kind is valid — even though we don't invite yet).
+
+**Scope:**
+- Public endpoints per plan §5.3
+- Public form at `/{tenant}/enroll` — dynamic renderer consuming form_schema + care_offerings
+- Confirmation page `/{tenant}/enroll/submitted`
+- Status/edit page `/{tenant}/enroll/status/[token]` — displays per-child status (everything will show `submitted` until PR 8 decisions land), withdraw button
+- Captcha integration gated by setting `enrollment.require_captcha`
+- Rate limiting on the public submit endpoint (per-IP, per-email)
+- Outbox row written on submission: `enrollment-submitted` to parent, `enrollment-admin-notification` to the configured admins
+
+**Tests:**
+- Submission validates against pinned schema version
+- Care offering with closed application window is rejected server-side even if client sends it (defense-in-depth)
+- Capacity overflow behavior per setting (blocked/warned/waitlisted)
+- Status token auth: parent with token can view/edit/withdraw; without token returns 404
+- Edit disabled once any child has a non-`submitted` status (rule from §6.3)
+- Withdrawal rules from §6.3 enforced
+- Hermetic
+
+**Acceptance criteria:**
+- End-to-end manual test: fresh browser → open `/{tenantSlug}/enroll` → fill form → submit → receive email (mock mailer log) → click status link → see submitted state → withdraw → status updated
+
+---
+
+### PR 8 — Admin review UI + per-child decision service + delivery status panel + resend
+
+**Goal:** The big finale. Admin can approve/waitlist/reject per child, decisions write to DB atomically with outbox, status page reflects decisions, guardian invitation triggers on first approval.
+
+**Depends on:** all prior PRs.
+
+**Scope:**
+- Admin pages: `/{tenant}/admin/enrollments` list + `/{tenant}/admin/enrollments/[id]` detail
+- `services/enrollment/decision_service.go` — the core transactional logic from plan §6.1
+- API endpoints per plan §5.3 (admin section)
+- Email delivery status panel on the detail page (reads `email_outbox`)
+- Resend button → re-enqueues outbox row
+- XLSX export endpoint (could be split to a PR 9 if PR 8 gets too big)
+
+**Tests:**
+- Decision transaction: student + guardian_profile + students_guardians + activities.student_enrollments + outbox rows all written atomically (rollback test: force a failure mid-transaction, verify no partial state)
+- Idempotency: promoting a waitlisted child to approved doesn't duplicate student rows
+- Digest vs. immediate notification mode: correct number of outbox rows written per mode
+- Guardian invitation only enqueued once per request (even when multiple children are approved)
+- RLS: tenant isolation on all admin endpoints
+
+**Acceptance criteria:**
+- End-to-end test run by a human: parent submits → admin approves some children / waitlists one / rejects one → parent gets digest email → parent clicks status link → sees correct per-child state → guardian gets invitation email → guardian clicks link → creates account → can log in
+
+---
+
+## 3. Calendar Periods Emergency Plan
+
+**Trigger:** PR 6 or PR 7 is ready to ship and `schedule.calendar_periods` has not been created by Yannick's Timetable RFC work.
+
+**Action:** Ship a minimal version of the table as part of PR 6 (not a separate PR — keep coordination surface small).
+
+### Minimal migration
+
+```sql
+-- backend/database/migrations/<next>_calendar_periods_minimal.up.sql
+
+CREATE TABLE IF NOT EXISTS schedule.calendar_periods (
+  id            bigserial PRIMARY KEY,
+  tenant_id     bigint NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+  name          text NOT NULL,
+  period_type   text NOT NULL DEFAULT 'school_year'
+    CHECK (period_type IN ('school_year','semester','holiday','custom')),
+  start_date    date NOT NULL,
+  end_date      date NOT NULL,
+  is_active     boolean NOT NULL DEFAULT false,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, name),
+  CHECK (end_date > start_date)
+);
+
+-- RLS to match existing tenant-scoped tables
+ALTER TABLE schedule.calendar_periods ENABLE ROW LEVEL SECURITY;
+-- (policy following the existing pattern — copy from a nearby tenant-scoped table)
+
+CREATE INDEX IF NOT EXISTS idx_calendar_periods_tenant_active
+  ON schedule.calendar_periods (tenant_id) WHERE is_active;
+CREATE INDEX IF NOT EXISTS idx_calendar_periods_tenant_type
+  ON schedule.calendar_periods (tenant_id, period_type);
+```
+
+### Notes for Yannick's later extension
+
+Yannick's full RFC spec adds:
+- `week_cycle_length SMALLINT DEFAULT 1`
+- `week_cycle_anchor DATE`
+
+These are additive. His migration just runs `ALTER TABLE schedule.calendar_periods ADD COLUMN ...`. No data migration needed. We should flag this explicitly to him in the PR description so he's not surprised.
+
+### Minimal service
+
+Ship `backend/services/schedule/calendar_period_service.go` with just `Get`, `List`, `Create`, `Update`, `Delete`. Admin UI at `/{tenant}/admin/calendar-periods` — simple list + form. Yannick can extend later.
+
+### Communication
+
+The PR 6 description should include a `### Coordination` section noting:
+- We shipped the minimal `schedule.calendar_periods` because the Timetable RFC hadn't landed
+- The columns added are a strict subset of the RFC's spec
+- Additive extension is safe; no data migration needed
+- Link to the Timetable RFC and the enrollment plan's §11
+
+---
+
+## 4. PR Dependency Graph
+
+```
+                ┌────────────────────┐
+                │ PR 2: student      │
+                │   lifecycle        │
+                └──────────┬─────────┘
+                           │
+                ┌──────────▼─────────┐
+                │ PR 3: guardian     │
+                │   invitation svc   │
+                └──────────┬─────────┘
+                           │ (can be parallel with PR 2)
+                           │
+                ┌──────────▼─────────┐
+                │ PR 4: enrollment   │
+                │   settings + tab   │
+                └──────────┬─────────┘
+                           │
+                ┌──────────▼─────────┐
+                │ PR 5: schemas +    │
+                │   outbox + editor  │
+                └──────────┬─────────┘
+                           │
+                ┌──────────▼─────────┐
+                │ PR 6: care offer.  │  ←── may bundle calendar_periods
+                │   catalog + UI     │      emergency migration
+                └──────────┬─────────┘
+                           │
+                ┌──────────▼─────────┐
+                │ PR 7: public form  │
+                │   + submission     │
+                └──────────┬─────────┘
+                           │
+                ┌──────────▼─────────┐
+                │ PR 8: admin review │
+                │   + decisions      │
+                └────────────────────┘
+```
+
+### Parallelizable
+
+- PR 2, PR 3, PR 4 can all start immediately and be worked in parallel — zero cross-dependencies
+- PR 5 waits for PR 4 (needs the settings registered)
+- PR 6 waits for PR 4 (settings) — can otherwise run parallel with PR 5
+- PR 7 waits for PR 5, PR 6, and ideally PR 3 (for invitation kind in outbox)
+- PR 8 is the integration PR — needs everything
+
+### If human review capacity is limited
+
+Ship in this strict linear order: 2 → 3 → 4 → 5 → 6 → 7 → 8. Each is shippable behind `enrollment.enabled=false`.
+
+---
+
+## 5. Per-PR Checklist (use every time)
+
+Before opening a PR:
+
+- [ ] Branch targets `development`
+- [ ] Commit messages follow `feat:` / `fix:` / `refactor:` / `test:` / `docs:` / `chore:` conventions
+- [ ] No "Co-Authored-By: Claude" line
+- [ ] `go test ./backend/...` green locally
+- [ ] `go test ./backend/test/ -run TestHermeticTestPatterns` green
+- [ ] `cd frontend && pnpm run check` green (if frontend touched)
+- [ ] Docker rebuild verified if backend changed: `docker compose build server && docker compose up -d server`
+- [ ] Migration version numbers don't collide with other in-flight PRs
+- [ ] No direct `Resolve*()` calls without `HasTenantOverride` guard (per `.claude/rules/settings-system.md`)
+- [ ] All user-facing strings in German
+- [ ] No new env vars for per-tenant config — use settings registry
+- [ ] All new backend tables have RLS policies
+- [ ] All new tests use `testpkg.Create*` helpers, no hardcoded IDs
+- [ ] PR description links to the enrollment plan doc + implementation plan
+- [ ] For PRs that touch deployed env or frontend env.js: followed `.claude/rules/env-docker-sync.md` checklist
+
+Post-merge:
+
+- [ ] Write handoff memory entry (`enrollment_pr_<N>_handoff.md`)
+- [ ] Update this doc if scope/plan deviated meaningfully
+- [ ] If the PR introduced new CLAUDE.md-worthy conventions, propose updating CLAUDE.md in a follow-up
+
+---
+
+## 6. Rollback Plan
+
+Every PR must be reversible by a simple revert of its commit(s). Rules:
+
+- DB migrations must have working `.down.sql` files
+- Feature flag `enrollment.enabled=false` must fully hide the feature from users — if a merged PR makes anything user-visible even with the flag off, that's a bug to fix before moving on
+- Avoid backfills or destructive data changes until the feature has been live and exercised by a real tenant
+
+If a merged PR misbehaves in staging, revert first and debug the revert commit locally.
+
+---
+
+## 7. Known Unknowns (carry forward across sessions)
+
+These are open questions that don't block starting PR 2 but should be resolved before their respective later PR:
+
+| Question | Blocks PR | Source |
+|----------|-----------|--------|
+| Required consent checkboxes for GDPR (AGB, data processing, contact, photo?) | PR 7 | plan §4 Q1 |
+| Default rejection retention in days | PR 5 or PR 8 | plan §4 Q2 (proposed 90) |
+| Spam provider choice (Turnstile / hCaptcha / other) | PR 7 | plan §4 Q5 |
+| Email sender identity (tenant-specific vs global) | PR 7 | plan §4 Q6 |
+| Grade level max (restrict to 4 for OGS or allow 13?) | PR 7 | plan §4 Q7 |
+| Care overflow behavior (reject / waitlist / allow) | PR 7 | plan §4 Q9 |
+| Digest vs immediate default | PR 8 | plan §4 Q10 |
+| Outbox scope (enrollment-only vs platform-shared) | PR 5 | plan §4 Q11 |
+| Status token TTL (1 year?) | PR 5 | plan §4 Q12 |
+| Calendar period ownership (skip PR 1 / ship minimal in PR 6) | PR 6 | plan §4 Q13 |
+| Default school-year period auto-gen | PR 6 | plan §4 Q14 |
+
+---
+
+## 8. Meta: Updating This Document
+
+This plan is a living document for as long as the enrollment feature is under construction. Claude should update it when:
+
+- A PR's actual scope diverged meaningfully from its section above
+- A new convention or gotcha emerged that future PRs should inherit
+- An open question was resolved (move the answer into the relevant PR section, delete the question from §7)
+
+Do NOT rewrite history — keep a changelog at the top.
+
+### Changelog
+
+- **2026-04-16 (v1):** Initial execution plan drafted by Claude for team review.

--- a/docs/parent-enrollment-plan.md
+++ b/docs/parent-enrollment-plan.md
@@ -1,0 +1,285 @@
+# Parent-Facing Student Enrollment System — Implementation Plan
+
+**Status:** Draft for team discussion
+**Target branch:** `development`
+**Author:** Drafted with Claude Code, 2026-04-13
+
+---
+
+## 1. Goal
+
+Enable parents to submit a sign-up request for a child (or multiple children) for a future or current OGS school year via a public form on the tenant subdomain. School admins review requests, approve or reject them, and on approval the system creates the student records and invites the parent to create an account — all without manual data entry from the admin.
+
+## 2. Requirements Summary
+
+- Public submission form per tenant (`/{tenant}/enroll`), no login required
+- If submitter is logged in as a guardian, prefill their data (optional convenience)
+- One submission can include multiple children
+- Admin review UI: see all requests, edit fields before approval, approve/reject with note
+- On approval: create student records (initially in `pending` status), link guardian, send email invitation to create account
+- Guardians without an account get an invitation email with a token; existing accounts get a "new child linked" confirmation
+- Admins can edit the enrollment form per tenant (add/remove/reorder custom fields) — core fields are fixed
+- Optional behaviors (which fields to collect, activation timing, duplicate handling) go into the settings system
+- XLSX export of requests (Phase 2)
+- Ability for parents to view/edit/withdraw their submission before approval via a tokenized link in the confirmation email
+- File attachments deferred to Phase 2
+- Re-enrollment of existing students deferred (not in scope for v1)
+
+## 3. Key Decisions (confirmed)
+
+| Topic | Decision |
+|-------|----------|
+| **Parent role** | No new role. Reuse existing `guardian` base role, `guardian_profiles`, `guardian_invitations`, and `students_guardians`. The orphaned `auth.accounts_parents` table is NOT wired in — leave it alone or remove in a separate cleanup task. |
+| **Student creation timing** | On approval, create `users.students` rows with `status='pending'`. A daily scheduler job flips them to `active` when `enrolled_from <= today`. Schools can choose `immediate` or `scheduled` activation via settings. |
+| **School year model** | Add a new `platform.school_years` table (tenant-scoped). Student class assignments become year-scoped via a new `users.student_year_assignments` table. The existing `users.students.school_class` field is kept as a legacy "current class" cache during transition. |
+| **Grade level vs class** | Collect **grade level** (integer 1–13) on the form, not specific class ("1a" vs "1b"). Whether the form asks for it is toggled by setting `enrollment.collect_grade_level`. The concrete class (e.g., "1a") is assigned by the admin post-approval. |
+| **Year picker** | Parent chooses the target school year from available open years (tenant has ~4 open years max). No setting needed. |
+| **Edit/withdraw** | Tokenized link in the confirmation email lets the parent view/edit/withdraw their pending submission. |
+| **Form schema editor** | Simple table (add/edit/delete/reorder fields), reusing the settings system's field-type vocabulary. No drag-and-drop layout builder. Versioned — submitted requests pin to their schema version. |
+| **Attachments** | Deferred to Phase 2. |
+| **Re-enrollment** | Deferred — this form is first-time signup only for v1. |
+
+## 4. Open Questions for Team Review
+
+1. **GDPR / consent checkboxes** — what fixed consent items are legally required on a first-time signup form? Proposed defaults: (a) AGB/terms acceptance, (b) data processing, (c) contact by email. Are there more (photo, emergency contact sharing)?
+2. **Rejected-request retention** — how long should rejected submissions stay in the DB before automatic deletion? Proposed default: 90 days, settings-configurable.
+3. **School-year management ownership** — who creates school year entries in the admin UI? Operator-level (moto) or tenant-level (school admin)? The current proposal is tenant admin, gated by `config:manage`.
+4. **Existing `school_class` string field** — acceptable to keep as a legacy cache that mirrors the current-year assignment, or should we migrate callers immediately? A hard cutover risks breaking multiple features.
+5. **Spam protection** — is Turnstile/hCaptcha acceptable, or do we need a different provider? Gated behind `enrollment.require_captcha` setting.
+6. **Email sender identity** — emails sent from a tenant-specific from-address, or a global `enrollment@moto-app.de`? DNS/DKIM implications.
+7. **Grade levels beyond OGS** — OGS is typically grades 1–4, but the migration allows 1–13. Keep permissive or restrict?
+
+---
+
+## 5. Architecture
+
+### 5.1 Domain model additions
+
+**New schema: `enrollment`**
+
+```
+enrollment.form_schemas
+  id, tenant_id, version, fields JSONB, is_active, created_by, created_at
+
+enrollment.requests
+  id, tenant_id, schema_id (version snapshot), school_year_id,
+  status ('submitted'|'under_review'|'approved'|'rejected'|'withdrawn'),
+  guardian_first_name, guardian_last_name, guardian_email, guardian_phone,
+  guardian_account_id (nullable — set if submitter was logged in),
+  consent_flags JSONB,
+  custom_data JSONB,
+  activation_mode ('immediate'|'scheduled'),
+  activate_on DATE (nullable),
+  review_note TEXT,
+  reviewed_at, reviewed_by,
+  edit_token (unique, tokenized edit/withdraw link),
+  edit_token_expires,
+  submitted_at, updated_at
+
+enrollment.request_children
+  id, request_id, first_name, last_name, date_of_birth,
+  target_grade_level (nullable, 1–13),
+  custom_data JSONB,
+  created_student_id (nullable — filled on approval),
+  sort_order
+```
+
+**New in `platform` schema**
+
+```
+platform.school_years
+  id, tenant_id, label ("2026/2027"), start_date, end_date, is_current,
+  UNIQUE(tenant_id, label), UNIQUE(tenant_id) WHERE is_current
+```
+
+**Additions to existing tables**
+
+```
+users.students
+  + status text ('pending'|'active'|'inactive'|'alumnus'), default 'active'
+  + enrolled_from DATE, enrolled_until DATE
+  Indexes on (tenant_id, status) and (tenant_id, enrolled_from) WHERE status='pending'
+
+users.student_year_assignments  (new table)
+  id, tenant_id, student_id, school_year_id,
+  grade_level (int 1–13), class_name (text, nullable),
+  group_id (FK education.groups, nullable),
+  UNIQUE(student_id, school_year_id)
+```
+
+All new tables get RLS policies matching the existing tenant-isolation pattern.
+
+### 5.2 Service layer
+
+- **`services/enrollment/form_schema_service.go`** — get active schema, create versions, validate submissions
+- **`services/enrollment/request_service.go`** — public submit/withdraw/edit (token-auth), admin list/get/patch
+- **`services/enrollment/approval_service.go`** — orchestrates the full approval transaction: create student(s) (status=pending), guardian_profile, students_guardians link, student_year_assignment, then call guardian_invitation_service to issue the invite
+- **`services/auth/guardian_invitation_service.go`** — complete the half-built service that mirrors the staff `invitation_service`. Issue token, send email via existing dispatcher, accept-and-create-account, cleanup expired, resend
+- **`services/scheduler/activate_students.go`** — daily job: `UPDATE users.students SET status='active' WHERE status='pending' AND enrolled_from <= CURRENT_DATE`, and the inverse for `enrolled_until`
+
+### 5.3 API surface
+
+**Public (no auth, token- or tenant-slug-gated):**
+- `POST /api/enrollment/{tenantSlug}/submit`
+- `GET /api/enrollment/requests/{editToken}`
+- `PATCH /api/enrollment/requests/{editToken}`
+- `POST /api/enrollment/requests/{editToken}/withdraw`
+
+**Admin (tenant JWT, `config:update` or custom `enrollment:manage`):**
+- `GET/PATCH /api/enrollment/requests`
+- `POST /api/enrollment/requests/{id}/approve`
+- `POST /api/enrollment/requests/{id}/reject`
+- `GET/POST/PUT /api/enrollment/schema` — form schema CRUD (versioned)
+- `GET /api/enrollment/requests/export.xlsx`
+
+**Guardian invitation endpoints** (fill missing pieces):
+- `POST /api/auth/guardian-invitations/accept`
+- `POST /api/auth/guardian-invitations/{id}/resend`
+
+### 5.4 Frontend pages
+
+- `/{tenant}/enroll` — public form, dynamic from schema, multi-child
+- `/{tenant}/enroll/submitted` — confirmation + edit link
+- `/{tenant}/enroll/edit/[token]` — token-auth edit/withdraw
+- `/{tenant}/admin/enrollments` — list with filters
+- `/{tenant}/admin/enrollments/[id]` — detail + inline edit + approve/reject
+- `/{tenant}/admin/enrollment-form` — schema editor (add/edit/delete/reorder fields)
+- `/accept-guardian-invite` — mirrors existing `/accept-invite` for staff
+
+Dynamic field rendering reuses the component set built for the settings page.
+
+### 5.5 Email templates
+
+- `enrollment-submitted.html` — confirmation to parent, includes edit/withdraw link
+- `enrollment-admin-notification.html` — to admins on new submission
+- `enrollment-approved.html` — includes guardian invitation link
+- `enrollment-rejected.html` — with optional admin note
+- `guardian-invitation.html` — exists, needs the service layer behind it completed
+
+### 5.6 Settings to expose
+
+Registered in `services/config/defaults/enrollment.go`, new "Enrollment" tab. All write-gated by `config:update` (or `config:manage` for sensitive ones):
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `enrollment.enabled` | boolean | `false` | Master toggle for the public form |
+| `enrollment.open_window_start` | date | — | Accept submissions from |
+| `enrollment.open_window_end` | date | — | Accept submissions until |
+| `enrollment.collect_grade_level` | boolean | `true` | Show grade level field |
+| `enrollment.default_activation_mode` | select (`immediate`/`scheduled`) | `scheduled` | When approved students become active |
+| `enrollment.notification_emails` | text | — | CSV of admin emails to notify on new submission |
+| `enrollment.auto_invite_guardian_on_approval` | boolean | `true` | Some schools handle accounts manually |
+| `enrollment.duplicate_handling` | select (`block`/`warn`/`ignore`) | `warn` | How to treat repeat submissions |
+| `enrollment.allow_submission_edit` | boolean | `true` | Enable parent edit/withdraw link |
+| `enrollment.require_captcha` | boolean | `true` | Spam protection on public form |
+| `enrollment.rejected_retention_days` | number | `90` | Auto-delete rejected submissions after N days |
+
+---
+
+## 6. Value Resolution & Approval Flow
+
+### 6.1 Approval (transactional)
+
+On admin approving a request with N children:
+
+1. For each child:
+   - Create `guardian_profile` if not already present (matched by email)
+   - Create `users.students` row, `status='pending'`, `enrolled_from` = `request.activate_on` or `school_year.start_date`
+   - Create `users.students_guardians` link (relationship='parent', is_primary=true)
+   - Create `users.student_year_assignments` row with grade level
+2. If guardian has no account yet → create `auth.guardian_invitations` row, send invitation email
+3. If guardian already has an account → send "new child linked" notification
+4. Mark `request.status='approved'`, `reviewed_at=now()`, `reviewed_by=adminID`
+5. Set `created_student_id` on each `request_children` row
+6. Audit log entry (reuse settings audit pattern or existing audit schema)
+
+All in one DB transaction; email sends happen via the async dispatcher after commit.
+
+### 6.2 Activation (scheduled)
+
+Daily scheduler job per tenant:
+```sql
+UPDATE users.students
+SET status = 'active', updated_at = now()
+WHERE tenant_id = $1
+  AND status = 'pending'
+  AND enrolled_from <= CURRENT_DATE;
+```
+
+Inverse for `active → inactive` when `enrolled_until <= CURRENT_DATE`.
+
+Slog entries use student IDs only (GDPR — no names at info level).
+
+---
+
+## 7. Phased Delivery
+
+### Phase 1: Foundation (no user-visible enrollment feature yet)
+
+- **PR 1** — `platform.school_years` table + model + repo + admin CRUD API + admin UI
+- **PR 2** — Student lifecycle fields (`status`, `enrolled_from`, `enrolled_until`) + `student_year_assignments` table + data migration for existing students + scheduler activation job + tests
+- **PR 3** — Complete `guardian_invitation_service` + `/accept-guardian-invite` frontend page
+
+### Phase 2: Enrollment MVP
+
+- **PR 4** — Enrollment settings registry entries + new "Enrollment" settings tab
+- **PR 5** — Enrollment schema tables (`form_schemas`, `requests`, `request_children`) + form_schema service + admin schema editor UI
+- **PR 6** — Public enrollment form + submission endpoint + confirmation email + edit/withdraw token flow
+- **PR 7** — Admin review UI + approval service (wiring together Phase 1 + 2)
+
+### Phase 3: Polish
+
+- **PR 8** — XLSX export
+- **PR 9** — File attachments (storage + virus scan — separate design)
+- **PR 10** — Re-enrollment flow for existing students
+
+Each PR is independently shippable and gated by `enrollment.enabled` (off by default) until Phase 2 lands.
+
+---
+
+## 8. Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| **Legacy `school_class` field consumers break during migration** | Keep the string column populated from current-year assignment via a repository hook; plan a dedicated cleanup PR once all consumers read the new table |
+| **Form schema version drift** | Submitted requests pin to `schema_id`; rendering fetches by ID, not "active" |
+| **Edit-token abuse / enumeration** | Token is cryptographically random (256-bit), short TTL (7 days), single-purpose, rate-limited endpoint |
+| **Spam submissions on public form** | Turnstile/hCaptcha (setting-gated), per-IP rate limit, per-email rate limit |
+| **GDPR — rejected submissions linger** | Auto-delete after `enrollment.rejected_retention_days` (default 90) via scheduler |
+| **PyrePortal impact** | None. Enrollment is tenant admin UI + public form only. No IoT endpoint changes. |
+| **Cross-tenant leakage** | All new tables get RLS policies matching existing tenant-scoped tables; integration tests verify isolation |
+| **Email deliverability for guardian invites** | Reuse existing SMTP infra; verify DKIM/SPF on the from-domain; add `enrollment-submitted` to existing email audit trail if one exists |
+
+---
+
+## 9. Out of Scope (v1)
+
+- Re-enrollment of existing students for the following year
+- File attachments (birth certificate, vaccination record)
+- Drag-and-drop form layout editor
+- Per-child guardian (different guardian for child A vs child B in one submission) — v1 uses one guardian per request
+- Payment/fees collection
+- Class capacity enforcement (admin assigns class manually post-approval)
+- Auto-promotion of students between school years (admin action only)
+
+---
+
+## 10. Sharp Edges for Implementation
+
+- **`UNIQUE (tenant_id) WHERE is_current`** on `school_years` — flipping requires a transaction that unsets the old current first
+- **Schema versioning** — old submitted requests must still render against their pinned schema after an admin edits the form
+- **Hermetic tests** — all new tests MUST use `testpkg.CreateTestStudent` etc.; no hardcoded IDs (see CLAUDE.md)
+- **Settings consumers** — anywhere enrollment code reads a setting, follow the `HasTenantOverride` → `Resolve*` → env var → fallback pattern from `.claude/rules/settings-system.md`
+- **Migration version uniqueness** — new migration version numbers must not collide in `MigrationRegistry`
+- **German UI** — all setting labels/descriptions and email templates in German
+- **No production requests from Claude** — local dev / staging only
+
+---
+
+## 11. Estimated Scope
+
+- Phase 1: ~1 week of focused work (mostly scaffolding, low risk)
+- Phase 2: ~2 weeks (the bulk — form editor, public submission, admin review, approval transaction)
+- Phase 3: ~1 week (export, attachments if prioritized)
+
+Total: ~4 engineering weeks for a full v1 + polish.

--- a/docs/parent-enrollment-plan.md
+++ b/docs/parent-enrollment-plan.md
@@ -1,8 +1,12 @@
 # Parent-Facing Student Enrollment System — Implementation Plan
 
-**Status:** Draft for team discussion
+**Status:** Draft for team discussion (revision 2)
 **Target branch:** `development`
-**Author:** Drafted with Claude Code, 2026-04-13
+**Author:** Drafted with Claude Code, 2026-04-13 (revised 2026-04-15 based on team feedback)
+
+## Changelog
+
+- **2026-04-15 (rev 2):** Added structured Betreuungsangebote (care offerings), email outbox/delivery-failure visibility, waitlist status + parent status page, per-child approval decisions, refined withdrawal rules. Updated domain model, API, settings, phasing, and risks sections accordingly.
 
 ---
 
@@ -15,13 +19,18 @@ Enable parents to submit a sign-up request for a child (or multiple children) fo
 - Public submission form per tenant (`/{tenant}/enroll`), no login required
 - If submitter is logged in as a guardian, prefill their data (optional convenience)
 - One submission can include multiple children
-- Admin review UI: see all requests, edit fields before approval, approve/reject with note
+- **Structured Betreuungsangebote (care offerings)** — modules, days, holiday care, lunch — selected by parents as first-class typed data, not freeform custom fields
+- **Per-child admin decisions** — admin can approve, waitlist, or reject each child independently; the parent is still treated as one unit (one account, one status link)
+- Admin review UI: see all requests, edit fields before approval, approve/waitlist/reject with per-child reason notes
 - On approval: create student records (initially in `pending` status), link guardian, send email invitation to create account
 - Guardians without an account get an invitation email with a token; existing accounts get a "new child linked" confirmation
+- **Waitlist support** with reason captured and visible to the parent
+- **Parent status page** accessible via the same tokenized link in the confirmation email — stays accessible after decisions to let the parent track status per child
+- **Email outbox with retry + admin visibility** — approval writes email jobs atomically with DB changes; delivery failures surface in admin UI with a resend action
 - Admins can edit the enrollment form per tenant (add/remove/reorder custom fields) — core fields are fixed
-- Optional behaviors (which fields to collect, activation timing, duplicate handling) go into the settings system
+- Optional behaviors (which fields to collect, activation timing, duplicate handling, waitlist on/off) go into the settings system
 - XLSX export of requests (Phase 2)
-- Ability for parents to view/edit/withdraw their submission before approval via a tokenized link in the confirmation email
+- Ability for parents to view/edit/withdraw their submission via a tokenized link in the confirmation email (withdrawal limited to non-terminal statuses; approved children must go through admin)
 - File attachments deferred to Phase 2
 - Re-enrollment of existing students deferred (not in scope for v1)
 
@@ -38,6 +47,12 @@ Enable parents to submit a sign-up request for a child (or multiple children) fo
 | **Form schema editor** | Simple table (add/edit/delete/reorder fields), reusing the settings system's field-type vocabulary. No drag-and-drop layout builder. Versioned — submitted requests pin to their schema version. |
 | **Attachments** | Deferred to Phase 2. |
 | **Re-enrollment** | Deferred — this form is first-time signup only for v1. |
+| **Betreuungsangebote (care offerings)** | First-class structured model. Admin defines a catalog per school year (`enrollment.care_offerings`); parent selects; selection stored on `request_child_offerings`. Not treated as custom form fields — structure is required for capacity, reporting, and export. |
+| **Approval granularity** | Per-child. Admin decides approve/waitlist/reject for each child independently. The parent is still one unit: one guardian profile, one account (if created), one status token, one status page. |
+| **Waitlist** | Supported as first-class status alongside approved/rejected. Setting `enrollment.waitlist_enabled` toggles visibility in admin UI. Admin can promote waitlisted children to approved (same code path as initial approval). |
+| **Parent status visibility** | Tokenized status page accessible from the confirmation email stays live throughout the lifecycle. Parent sees per-child status + optional reason. Same token also powers edit/withdraw (gated by rules in §6.3). |
+| **Email reliability** | Outbox pattern (`enrollment.email_outbox`) — all approval-related emails written atomically with DB changes, dispatched by a worker with exponential backoff retry. Admin UI shows per-request delivery status with resend button. No more silent send failures. |
+| **Decision notification style** | Configurable per tenant via `enrollment.notify_per_decision` — default `digest` (one email summarizing all children's decisions after admin saves), alternative `immediate` (one email per child decision). |
 
 ## 4. Open Questions for Team Review
 
@@ -48,6 +63,11 @@ Enable parents to submit a sign-up request for a child (or multiple children) fo
 5. **Spam protection** — is Turnstile/hCaptcha acceptable, or do we need a different provider? Gated behind `enrollment.require_captcha` setting.
 6. **Email sender identity** — emails sent from a tenant-specific from-address, or a global `enrollment@moto-app.de`? DNS/DKIM implications.
 7. **Grade levels beyond OGS** — OGS is typically grades 1–4, but the migration allows 1–13. Keep permissive or restrict?
+8. **Care offerings — downstream representation** — how should approved care selections map to the existing student/scheduling model? We'll likely need a new `users.student_care_enrollments` table linking student ↔ offering ↔ school_year. Does this interact with the existing timetable/schedule system in a way we should plan for now?
+9. **Care offering capacity overflow behavior** — when a parent submits but the chosen offering is full, should we: (a) reject the submission with an error, (b) auto-place the child on waitlist and let the admin decide, or (c) allow submission and surface the overflow in admin UI? (b) feels most parent-friendly.
+10. **Digest vs. immediate notification default** — default proposed as `digest` (one email after admin saves all decisions). Is that right, or do schools expect immediate per-child emails?
+11. **Outbox scope** — scope to enrollment only (table `enrollment.email_outbox`) for v1, or invest in a shared `platform.outbox` that other features can use? Shared is more work up-front but pays dividends.
+12. **Status token lifetime** — proposal is 1 year so parents can revisit status long after submission. Is that acceptable under data protection review?
 
 ---
 
@@ -61,28 +81,60 @@ Enable parents to submit a sign-up request for a child (or multiple children) fo
 enrollment.form_schemas
   id, tenant_id, version, fields JSONB, is_active, created_by, created_at
 
+enrollment.care_offerings
+  id, tenant_id, school_year_id, name, description,
+  days_of_week_mode ('fixed'|'parent_choice'),   -- fixed = Mon–Fri always, choice = parent picks
+  available_days JSONB,                            -- e.g. ["mon","tue","wed","thu","fri"]
+  includes_holiday_care boolean,
+  includes_lunch boolean,
+  capacity int (nullable),                         -- null = unlimited
+  price_cents int (nullable),                      -- informational only; not billing-grade
+  is_active boolean,
+  sort_order, created_at, updated_at
+
 enrollment.requests
   id, tenant_id, schema_id (version snapshot), school_year_id,
-  status ('submitted'|'under_review'|'approved'|'rejected'|'withdrawn'),
+  -- request-level status is DERIVED from children: submitted | under_review | partial | finalized | withdrawn
   guardian_first_name, guardian_last_name, guardian_email, guardian_phone,
   guardian_account_id (nullable — set if submitter was logged in),
   consent_flags JSONB,
   custom_data JSONB,
-  activation_mode ('immediate'|'scheduled'),
-  activate_on DATE (nullable),
-  review_note TEXT,
-  reviewed_at, reviewed_by,
-  edit_token (unique, tokenized edit/withdraw link),
-  edit_token_expires,
-  submitted_at, updated_at
+  status_token (unique, used for edit + status page),
+  status_token_expires (nullable — extended on state transitions so the link keeps working)
+  submitted_at, updated_at, withdrawn_at
 
 enrollment.request_children
   id, request_id, first_name, last_name, date_of_birth,
   target_grade_level (nullable, 1–13),
   custom_data JSONB,
+  status ('submitted'|'under_review'|'approved'|'waitlisted'|'rejected'|'withdrawn'),
+  status_reason TEXT (nullable — admin's explanation, shown to parent if setting enabled),
+  activation_mode ('immediate'|'scheduled'),
+  activate_on DATE (nullable),
+  reviewed_at, reviewed_by,
   created_student_id (nullable — filled on approval),
   sort_order
+
+enrollment.request_child_offerings
+  id, request_child_id, care_offering_id,
+  selected_days JSONB (nullable — if offering uses parent_choice mode),
+  notes TEXT (nullable)
+  UNIQUE(request_child_id, care_offering_id)
+
+enrollment.email_outbox
+  id, tenant_id, kind ('guardian_invitation'|'admin_notification'|'enrollment_submitted'
+                      |'enrollment_approved'|'enrollment_waitlisted'|'enrollment_rejected'),
+  related_request_id (nullable FK),
+  payload JSONB (rendered template context),
+  status ('pending'|'sending'|'sent'|'failed'),
+  attempts int default 0,
+  last_error TEXT (nullable),
+  next_retry_at timestamptz,
+  created_at, sent_at (nullable)
+  Indexes: (status, next_retry_at) for the worker pickup query
 ```
+
+**Why `email_outbox` over a pure async dispatcher:** the approval flow writes student + guardian + outbox rows in ONE transaction. The worker reads outbox rows independently. A dispatcher crash or SMTP outage no longer leaves the database in a state where records exist but the invitation was never sent. Admin UI reads from `email_outbox` to show delivery status; resend re-enqueues a new outbox row.
 
 **New in `platform` schema**
 
@@ -112,24 +164,32 @@ All new tables get RLS policies matching the existing tenant-isolation pattern.
 ### 5.2 Service layer
 
 - **`services/enrollment/form_schema_service.go`** — get active schema, create versions, validate submissions
-- **`services/enrollment/request_service.go`** — public submit/withdraw/edit (token-auth), admin list/get/patch
-- **`services/enrollment/approval_service.go`** — orchestrates the full approval transaction: create student(s) (status=pending), guardian_profile, students_guardians link, student_year_assignment, then call guardian_invitation_service to issue the invite
-- **`services/auth/guardian_invitation_service.go`** — complete the half-built service that mirrors the staff `invitation_service`. Issue token, send email via existing dispatcher, accept-and-create-account, cleanup expired, resend
+- **`services/enrollment/care_offering_service.go`** — admin CRUD over the care offerings catalog, capacity checks, per-year cloning for next year's setup
+- **`services/enrollment/request_service.go`** — public submit/withdraw/edit (token-auth), admin list/get/patch; derives request-level status from child statuses; enforces withdrawal rules (only non-terminal children)
+- **`services/enrollment/decision_service.go`** — per-child approve/waitlist/reject. On `approved`: creates student (status=pending), guardian_profile, students_guardians, student_year_assignment, selected care offering links. Writes outbox rows atomically. Idempotent per child — promoting a waitlisted child to approved works via the same entry point.
+- **`services/enrollment/outbox_worker.go`** — scheduler-driven worker. Picks up `pending` outbox rows where `next_retry_at <= now()`, renders template, dispatches via existing mailer. Exponential backoff on failure (1min, 5min, 30min, 2h, 12h, then `failed` at 6 attempts). Marks `sent` on success.
+- **`services/auth/guardian_invitation_service.go`** — complete the half-built service that mirrors the staff `invitation_service`. Issue token, render email via outbox (not direct dispatch), accept-and-create-account, cleanup expired, resend.
 - **`services/scheduler/activate_students.go`** — daily job: `UPDATE users.students SET status='active' WHERE status='pending' AND enrolled_from <= CURRENT_DATE`, and the inverse for `enrolled_until`
 
 ### 5.3 API surface
 
 **Public (no auth, token- or tenant-slug-gated):**
 - `POST /api/enrollment/{tenantSlug}/submit`
-- `GET /api/enrollment/requests/{editToken}`
-- `PATCH /api/enrollment/requests/{editToken}`
-- `POST /api/enrollment/requests/{editToken}/withdraw`
+- `GET /api/enrollment/{tenantSlug}/care-offerings` — active offerings for the chosen school year
+- `GET /api/enrollment/requests/{statusToken}` — returns current status for each child + per-child reasons (gated by setting)
+- `PATCH /api/enrollment/requests/{statusToken}` — edit payload; allowed only while ALL children are still `submitted`
+- `POST /api/enrollment/requests/{statusToken}/withdraw` — optional `child_id` in body; omit to withdraw all non-terminal children
 
 **Admin (tenant JWT, `config:update` or custom `enrollment:manage`):**
 - `GET/PATCH /api/enrollment/requests`
-- `POST /api/enrollment/requests/{id}/approve`
-- `POST /api/enrollment/requests/{id}/reject`
+- `POST /api/enrollment/requests/{id}/children/{childId}/approve`
+- `POST /api/enrollment/requests/{id}/children/{childId}/waitlist`
+- `POST /api/enrollment/requests/{id}/children/{childId}/reject`
+- `POST /api/enrollment/requests/{id}/decisions` — bulk per-child decisions in one payload (preferred UX path)
+- `GET/POST/PUT/DELETE /api/enrollment/care-offerings` — catalog CRUD per school year
 - `GET/POST/PUT /api/enrollment/schema` — form schema CRUD (versioned)
+- `GET /api/enrollment/requests/{id}/email-status` — per-request outbox rows (status, attempts, last_error)
+- `POST /api/enrollment/requests/{id}/resend-invitation` — re-enqueue a `guardian_invitation` outbox row
 - `GET /api/enrollment/requests/export.xlsx`
 
 **Guardian invitation endpoints** (fill missing pieces):
@@ -138,23 +198,26 @@ All new tables get RLS policies matching the existing tenant-isolation pattern.
 
 ### 5.4 Frontend pages
 
-- `/{tenant}/enroll` — public form, dynamic from schema, multi-child
-- `/{tenant}/enroll/submitted` — confirmation + edit link
-- `/{tenant}/enroll/edit/[token]` — token-auth edit/withdraw
-- `/{tenant}/admin/enrollments` — list with filters
-- `/{tenant}/admin/enrollments/[id]` — detail + inline edit + approve/reject
+- `/{tenant}/enroll` — public form, dynamic from schema, multi-child, includes care-offering selection
+- `/{tenant}/enroll/submitted` — confirmation + status/edit link
+- `/{tenant}/enroll/status/[token]` — persistent parent status page: per-child status, reasons (if setting allows), per-child withdraw button (only for non-terminal children), edit button (only if request is still fully `submitted`)
+- `/{tenant}/admin/enrollments` — list with filters (status, school year, submission date, care offering)
+- `/{tenant}/admin/enrollments/[id]` — detail + inline edit + per-child approve/waitlist/reject controls + email delivery status panel with resend button
 - `/{tenant}/admin/enrollment-form` — schema editor (add/edit/delete/reorder fields)
+- `/{tenant}/admin/care-offerings` — care-offering catalog editor (per school year)
 - `/accept-guardian-invite` — mirrors existing `/accept-invite` for staff
 
 Dynamic field rendering reuses the component set built for the settings page.
 
 ### 5.5 Email templates
 
-- `enrollment-submitted.html` — confirmation to parent, includes edit/withdraw link
+- `enrollment-submitted.html` — confirmation to parent, includes status/edit link
 - `enrollment-admin-notification.html` — to admins on new submission
-- `enrollment-approved.html` — includes guardian invitation link
-- `enrollment-rejected.html` — with optional admin note
-- `guardian-invitation.html` — exists, needs the service layer behind it completed
+- `enrollment-decision-digest.html` — parent email summarizing per-child decisions (approved / waitlisted / rejected) with status page link and — if any child approved — the guardian invitation link
+- `enrollment-waitlisted.html` — optional standalone waitlist notification (used only when `notify_per_decision = immediate`)
+- `enrollment-approved.html` — optional standalone approval notification (used only when `notify_per_decision = immediate`)
+- `enrollment-rejected.html` — optional standalone rejection notification (used only when `notify_per_decision = immediate`)
+- `guardian-invitation.html` — exists, needs the service layer behind it completed; now rendered via outbox rather than dispatched directly
 
 ### 5.6 Settings to expose
 
@@ -166,36 +229,84 @@ Registered in `services/config/defaults/enrollment.go`, new "Enrollment" tab. Al
 | `enrollment.open_window_start` | date | — | Accept submissions from |
 | `enrollment.open_window_end` | date | — | Accept submissions until |
 | `enrollment.collect_grade_level` | boolean | `true` | Show grade level field |
+| `enrollment.care_offerings_enabled` | boolean | `true` | Show care-offering selection on the form |
+| `enrollment.care_offerings_required` | boolean | `false` | Force parents to pick at least one offering |
 | `enrollment.default_activation_mode` | select (`immediate`/`scheduled`) | `scheduled` | When approved students become active |
 | `enrollment.notification_emails` | text | — | CSV of admin emails to notify on new submission |
 | `enrollment.auto_invite_guardian_on_approval` | boolean | `true` | Some schools handle accounts manually |
 | `enrollment.duplicate_handling` | select (`block`/`warn`/`ignore`) | `warn` | How to treat repeat submissions |
-| `enrollment.allow_submission_edit` | boolean | `true` | Enable parent edit/withdraw link |
+| `enrollment.allow_submission_edit` | boolean | `true` | Enable parent edit link (while fully `submitted`) |
 | `enrollment.require_captcha` | boolean | `true` | Spam protection on public form |
 | `enrollment.rejected_retention_days` | number | `90` | Auto-delete rejected submissions after N days |
+| `enrollment.waitlist_enabled` | boolean | `true` | Show waitlist as an admin decision option |
+| `enrollment.show_status_reason_to_parent` | boolean | `true` | Include admin's per-child reason on the status page + email |
+| `enrollment.notify_per_decision` | select (`digest`/`immediate`) | `digest` | One email after admin saves all decisions vs. email per child decision |
+| `enrollment.outbox_max_attempts` | number | `6` | Retries before outbox rows are marked `failed` |
+| `enrollment.status_token_ttl_days` | number | `365` | How long the parent status/edit token remains valid |
 
 ---
 
 ## 6. Value Resolution & Approval Flow
 
-### 6.1 Approval (transactional)
+### 6.1 Per-child decisions (transactional)
 
-On admin approving a request with N children:
+Admin submits decisions for one or more children in a request. For each child in one DB transaction:
 
-1. For each child:
-   - Create `guardian_profile` if not already present (matched by email)
-   - Create `users.students` row, `status='pending'`, `enrolled_from` = `request.activate_on` or `school_year.start_date`
-   - Create `users.students_guardians` link (relationship='parent', is_primary=true)
-   - Create `users.student_year_assignments` row with grade level
-2. If guardian has no account yet → create `auth.guardian_invitations` row, send invitation email
-3. If guardian already has an account → send "new child linked" notification
-4. Mark `request.status='approved'`, `reviewed_at=now()`, `reviewed_by=adminID`
-5. Set `created_student_id` on each `request_children` row
-6. Audit log entry (reuse settings audit pattern or existing audit schema)
+**Approve:**
+1. Create `guardian_profile` if not already present (matched by email, tenant-scoped)
+2. Create `users.students` row, `status='pending'`, `enrolled_from` = `child.activate_on` or `school_year.start_date`
+3. Create `users.students_guardians` link (relationship='parent', is_primary=true if first child for this guardian)
+4. Create `users.student_year_assignments` row with grade level
+5. Copy `request_child_offerings` selections onto the student record (exact downstream representation TBD — likely a `users.student_care_enrollments` table created in Phase 1)
+6. Set `request_children.status='approved'`, `reviewed_at`, `reviewed_by`, `created_student_id`
+7. If this is the FIRST approved child in the request AND no prior guardian invitation outbox row exists: enqueue one `guardian_invitation` outbox row
 
-All in one DB transaction; email sends happen via the async dispatcher after commit.
+**Waitlist:**
+- Set `request_children.status='waitlisted'`, `status_reason`, `reviewed_at`, `reviewed_by`. No student created.
 
-### 6.2 Activation (scheduled)
+**Reject:**
+- Set `request_children.status='rejected'`, `status_reason`, `reviewed_at`, `reviewed_by`. No student created.
+
+**Notification outbox rows** (written in the same transaction):
+- If `notify_per_decision = digest`: enqueue exactly one `enrollment-decision-digest` row addressed to the parent after all children in the payload have been processed.
+- If `notify_per_decision = immediate`: enqueue one `enrollment-approved` / `enrollment-waitlisted` / `enrollment-rejected` row per child.
+
+Request-level `status` is derived (not stored): `submitted` while every child is still `submitted`, `under_review` while at least one admin has viewed but no decisions exist, `partial` if some decisions made but others pending, `finalized` once all children are in a terminal status. This is a materialized view or a computed getter on the model — not a column.
+
+Audit log entries are written per child decision (reuse existing audit schema or settings audit pattern).
+
+### 6.2 Outbox worker
+
+Runs every 30–60 seconds via the scheduler. Pseudocode:
+
+```
+SELECT id, kind, payload FROM enrollment.email_outbox
+  WHERE status = 'pending' AND next_retry_at <= now()
+  ORDER BY created_at
+  FOR UPDATE SKIP LOCKED
+  LIMIT N;
+
+for each row:
+  UPDATE status='sending'
+  try: render template, dispatch via mailer
+  success: UPDATE status='sent', sent_at=now()
+  failure: attempts++, last_error=err,
+           if attempts >= enrollment.outbox_max_attempts: status='failed'
+           else: status='pending', next_retry_at = now() + backoff(attempts)
+```
+
+`FOR UPDATE SKIP LOCKED` allows multiple workers safely (future scale).
+
+### 6.3 Withdrawal rules
+
+- **Before any admin action** (all children `submitted`): parent can withdraw individual children or the whole request; can also edit the payload.
+- **After any decision** (any child is not `submitted`):
+  - `submitted`, `under_review`, `waitlisted` children → parent can still withdraw (becomes `withdrawn`, no student impact)
+  - `approved` children → withdrawal disabled in UI; parent must contact admin (student record exists)
+  - `rejected` children → withdrawal unnecessary (terminal)
+- Editing the payload is disabled once any child has a non-`submitted` status.
+
+### 6.4 Activation (scheduled)
 
 Daily scheduler job per tenant:
 ```sql
@@ -223,15 +334,17 @@ Slog entries use student IDs only (GDPR — no names at info level).
 ### Phase 2: Enrollment MVP
 
 - **PR 4** — Enrollment settings registry entries + new "Enrollment" settings tab
-- **PR 5** — Enrollment schema tables (`form_schemas`, `requests`, `request_children`) + form_schema service + admin schema editor UI
-- **PR 6** — Public enrollment form + submission endpoint + confirmation email + edit/withdraw token flow
-- **PR 7** — Admin review UI + approval service (wiring together Phase 1 + 2)
+- **PR 5** — Enrollment schema tables (`form_schemas`, `requests`, `request_children`, `email_outbox`) + form_schema service + admin schema editor UI + outbox worker skeleton
+- **PR 6** — Care offerings (`care_offerings`, `request_child_offerings`) + admin catalog editor UI
+- **PR 7** — Public enrollment form + submission endpoint + confirmation email (via outbox) + status/edit token flow + parent status page
+- **PR 8** — Admin review UI + per-child decision service + outbox delivery status panel + resend button (wires Phase 1 + 2 together)
 
 ### Phase 3: Polish
 
-- **PR 8** — XLSX export
-- **PR 9** — File attachments (storage + virus scan — separate design)
-- **PR 10** — Re-enrollment flow for existing students
+- **PR 9** — XLSX export (structured columns for care offerings + custom fields)
+- **PR 10** — File attachments (storage + virus scan — separate design)
+- **PR 11** — Re-enrollment flow for existing students
+- **PR 12** — Waitlist promotion UX refinements (drag-order waitlist, auto-promote on capacity free, etc.) — only if demand appears
 
 Each PR is independently shippable and gated by `enrollment.enabled` (off by default) until Phase 2 lands.
 
@@ -243,12 +356,16 @@ Each PR is independently shippable and gated by `enrollment.enabled` (off by def
 |------|------------|
 | **Legacy `school_class` field consumers break during migration** | Keep the string column populated from current-year assignment via a repository hook; plan a dedicated cleanup PR once all consumers read the new table |
 | **Form schema version drift** | Submitted requests pin to `schema_id`; rendering fetches by ID, not "active" |
-| **Edit-token abuse / enumeration** | Token is cryptographically random (256-bit), short TTL (7 days), single-purpose, rate-limited endpoint |
+| **Status token abuse / enumeration** | Token is cryptographically random (256-bit), long TTL for status view but write actions (edit/withdraw) are rule-gated; rate-limited endpoint |
 | **Spam submissions on public form** | Turnstile/hCaptcha (setting-gated), per-IP rate limit, per-email rate limit |
 | **GDPR — rejected submissions linger** | Auto-delete after `enrollment.rejected_retention_days` (default 90) via scheduler |
 | **PyrePortal impact** | None. Enrollment is tenant admin UI + public form only. No IoT endpoint changes. |
 | **Cross-tenant leakage** | All new tables get RLS policies matching existing tenant-scoped tables; integration tests verify isolation |
-| **Email deliverability for guardian invites** | Reuse existing SMTP infra; verify DKIM/SPF on the from-domain; add `enrollment-submitted` to existing email audit trail if one exists |
+| **Email deliverability for guardian invites** | Outbox pattern + retry with exponential backoff; admin-visible delivery status; verify DKIM/SPF on the from-domain |
+| **Outbox worker stalls / duplicates** | `FOR UPDATE SKIP LOCKED` on pickup; idempotent dispatch keyed by outbox ID; monitoring/alert if `failed` count grows |
+| **Care offering capacity race** | Capacity check on submit uses `SELECT ... FOR UPDATE` within the submission transaction; over-capacity requests get a friendly error or land on waitlist automatically (setting TBD) |
+| **Partial decisions leaving requests in limbo** | Derived request status makes "partial" visible to admin; admin list has a filter "has pending children"; digest emails only fire when a decision batch is complete |
+| **Approved child already has a student record if parent withdraws** | Withdrawal of approved children disabled in parent UI; admin must delete/archive the student manually |
 
 ---
 
@@ -258,9 +375,11 @@ Each PR is independently shippable and gated by `enrollment.enabled` (off by def
 - File attachments (birth certificate, vaccination record)
 - Drag-and-drop form layout editor
 - Per-child guardian (different guardian for child A vs child B in one submission) — v1 uses one guardian per request
-- Payment/fees collection
+- Payment/fees collection (price field on care offerings is informational only)
 - Class capacity enforcement (admin assigns class manually post-approval)
 - Auto-promotion of students between school years (admin action only)
+- Automatic waitlist promotion when capacity frees up (manual admin move in v1)
+- Parent self-service account creation outside the enrollment flow
 
 ---
 

--- a/docs/parent-enrollment-plan.md
+++ b/docs/parent-enrollment-plan.md
@@ -9,6 +9,7 @@
 - **2026-04-15 (rev 2):** Added structured Betreuungsangebote (care offerings), email outbox/delivery-failure visibility, waitlist status + parent status page, per-child approval decisions, refined withdrawal rules. Updated domain model, API, settings, phasing, and risks sections accordingly.
 - **2026-04-15 (rev 2.1):** Added per-offering application windows (`application_window_start`/`_end`) and service date fields on `care_offerings` so parents can't apply for offerings whose intake period has closed (e.g. holiday care after holidays begin).
 - **2026-04-16 (rev 2.2):** Aligned with Yannick's Timetable RFC (`docs/timetable-system-plan.md`). Dropped `platform.school_years` in favor of `schedule.calendar_periods` (filter by `period_type='school_year'`). Dropped `users.student_year_assignments` in favor of the validity-scoped pattern (`valid_from`/`valid_until`). Approved care offering selections now create `activities.student_enrollments` rows instead of a new `users.student_care_enrollments` table. Added §11 Cross-dependencies.
+- **2026-04-16 (rev 2.3):** Resolved team questions. Q11: outbox is **shared platform-level** (`platform.email_outbox`), not enrollment-scoped. Q12: status token TTL default 1 year, **operator-editable only** per tenant (new `platform:config:update` write permission for this setting). Q13: Yannick will ship `schedule.calendar_periods` — emergency fallback plan removed from Phase 1 PR 1 / PR 6.
 
 ---
 
@@ -53,7 +54,7 @@ Enable parents to submit a sign-up request for a child (or multiple children) fo
 | **Approval granularity** | Per-child. Admin decides approve/waitlist/reject for each child independently. The parent is still one unit: one guardian profile, one account (if created), one status token, one status page. |
 | **Waitlist** | Supported as first-class status alongside approved/rejected. Setting `enrollment.waitlist_enabled` toggles visibility in admin UI. Admin can promote waitlisted children to approved (same code path as initial approval). |
 | **Parent status visibility** | Tokenized status page accessible from the confirmation email stays live throughout the lifecycle. Parent sees per-child status + optional reason. Same token also powers edit/withdraw (gated by rules in §6.3). |
-| **Email reliability** | Outbox pattern (`enrollment.email_outbox`) — all approval-related emails written atomically with DB changes, dispatched by a worker with exponential backoff retry. Admin UI shows per-request delivery status with resend button. No more silent send failures. |
+| **Email reliability** | Outbox pattern (`platform.email_outbox`) — all approval-related emails written atomically with DB changes, dispatched by a worker with exponential backoff retry. Admin UI shows per-request delivery status with resend button. No more silent send failures. |
 | **Decision notification style** | Configurable per tenant via `enrollment.notify_per_decision` — default `digest` (one email summarizing all children's decisions after admin saves), alternative `immediate` (one email per child decision). |
 | **Care-offering ↔ activity-group mapping** | Each `enrollment.care_offerings` row optionally references an `activities.groups` row (care-type). Approving a child's care selection creates an `activities.student_enrollments` row linking student to that activity group, with `valid_from`/`valid_until` derived from the selected `calendar_period`. The offering row stays in the `enrollment` schema as the intake-side catalog; the activity group stays in the `activities` schema as the schedule-side entity. Clean separation. |
 
@@ -69,10 +70,10 @@ Enable parents to submit a sign-up request for a child (or multiple children) fo
 8. **Care offerings — downstream representation** — **RESOLVED (rev 2.2):** Approved care selections create `activities.student_enrollments` rows scoped by `valid_from`/`valid_until` from the calendar period, following the Timetable RFC's E17 pattern. Offerings without a linked `activity_group_id` stay as catalog-only records.
 9. **Care offering capacity overflow behavior** — when a parent submits but the chosen offering is full, should we: (a) reject the submission with an error, (b) auto-place the child on waitlist and let the admin decide, or (c) allow submission and surface the overflow in admin UI? (b) feels most parent-friendly.
 10. **Digest vs. immediate notification default** — default proposed as `digest` (one email after admin saves all decisions). Is that right, or do schools expect immediate per-child emails?
-11. **Outbox scope** — scope to enrollment only (table `enrollment.email_outbox`) for v1, or invest in a shared `platform.outbox` that other features can use? Shared is more work up-front but pays dividends.
-12. **Status token lifetime** — proposal is 1 year so parents can revisit status long after submission. Is that acceptable under data protection review?
-13. **Coordination with Timetable RFC delivery** — if Yannick's full `schedule.calendar_periods` table lands before this plan's Phase 1 PR 1, we skip PR 1. If it lands after, do we ship the minimal subset (§7 Phase 1 PR 1) and let him extend, or do we block on his delivery? Depends on timing alignment — conversation with Yannick needed.
-14. **Auto-generated default school-year period** — the Timetable RFC (E15) says the system auto-creates a default `school_year` period per tenant. Does this plan rely on that behavior (i.e., we assume a school-year period always exists for a tenant and the parent picks from open ones)? If yes, our plan depends on that feature shipping too.
+11. **Outbox scope** — **RESOLVED (rev 2.3):** build `platform.email_outbox` (shared across features), not an enrollment-scoped table.
+12. **Status token lifetime** — **RESOLVED (rev 2.3):** default 1 year. Operator-only editable per tenant (new permission pattern — see §11 coordination notes).
+13. **Coordination with Timetable RFC delivery** — **RESOLVED (rev 2.3):** Yannick will ship `schedule.calendar_periods`. Enrollment Phase 1 no longer needs its own calendar_periods PR; we consume his.
+14. **Auto-generated default school-year period** — still open: does Yannick's delivery auto-create a `school_year` period per tenant? If not, the enrollment admin UI (PR 6 or earlier) needs a setup step. Ask him.
 15. **Care offering ↔ activity group wiring UX** — since `care_offerings.activity_group_id` is nullable, admins can create offerings before the matching `activities.groups` row exists. When a care offering has no linked activity group and a child is approved, what should happen? Proposed: log a warning, still approve the enrollment request, but skip the `student_enrollments` insert — admin can wire it later via an "attach activity group" action.
 
 ---
@@ -139,10 +140,10 @@ enrollment.request_child_offerings
   notes TEXT (nullable)
   UNIQUE(request_child_id, care_offering_id)
 
-enrollment.email_outbox
-  id, tenant_id, kind ('guardian_invitation'|'admin_notification'|'enrollment_submitted'
-                      |'enrollment_approved'|'enrollment_waitlisted'|'enrollment_rejected'),
-  related_request_id (nullable FK),
+platform.email_outbox                          -- SHARED ACROSS FEATURES, not enrollment-only
+  id, tenant_id, kind (text, extensible — initial kinds listed below),
+  related_entity_type (text, nullable — e.g. 'enrollment_request', 'invitation'),
+  related_entity_id (bigint, nullable — polymorphic reference, no FK constraint),
   payload JSONB (rendered template context),
   status ('pending'|'sending'|'sent'|'failed'),
   attempts int default 0,
@@ -153,6 +154,8 @@ enrollment.email_outbox
 ```
 
 **Why `email_outbox` over a pure async dispatcher:** the approval flow writes student + guardian + outbox rows in ONE transaction. The worker reads outbox rows independently. A dispatcher crash or SMTP outage no longer leaves the database in a state where records exist but the invitation was never sent. Admin UI reads from `email_outbox` to show delivery status; resend re-enqueues a new outbox row.
+
+**Why `platform.email_outbox` (shared) instead of `enrollment.email_outbox`:** per-feature outboxes would duplicate worker logic, retry policy, monitoring, and admin UI. A single platform-level table keyed by `kind` + `related_entity_type` is reused for guardian invitations (enrollment), staff invitations, audit email notifications, and any future feature. The enrollment feature only adds new `kind` values and a small wrapper on the admin UI to filter by request-related rows. Initial `kind` values registered by enrollment: `guardian_invitation`, `enrollment_submitted`, `enrollment_admin_notification`, `enrollment_decision_digest`, `enrollment_approved`, `enrollment_waitlisted`, `enrollment_rejected`.
 
 **No `platform.school_years` / `users.student_year_assignments` tables.** Earlier revisions of this plan proposed new tables for year tracking and year-scoped class assignment. The Timetable RFC (`docs/timetable-system-plan.md`) introduces `schedule.calendar_periods` with `period_type IN ('school_year'|'semester'|'holiday'|'custom')` — a superset of what we need — and establishes the `valid_from`/`valid_until` pattern on existing rows (`activities.student_enrollments`, `activities.supervisors`) for year-scoped progression. We defer to that model:
 
@@ -269,7 +272,7 @@ Registered in `services/config/defaults/enrollment.go`, new "Enrollment" tab. Al
 | `enrollment.show_status_reason_to_parent` | boolean | `true` | Include admin's per-child reason on the status page + email |
 | `enrollment.notify_per_decision` | select (`digest`/`immediate`) | `digest` | One email after admin saves all decisions vs. email per child decision |
 | `enrollment.outbox_max_attempts` | number | `6` | Retries before outbox rows are marked `failed` |
-| `enrollment.status_token_ttl_days` | number | `365` | How long the parent status/edit token remains valid |
+| `enrollment.status_token_ttl_days` | number | `365` | How long the parent status/edit token remains valid. **Operator-only writeable** (write permission `platform:config:update`); tenant admins can read but not edit. |
 
 ---
 
@@ -306,7 +309,7 @@ Audit log entries are written per child decision (reuse existing audit schema or
 Runs every 30–60 seconds via the scheduler. Pseudocode:
 
 ```
-SELECT id, kind, payload FROM enrollment.email_outbox
+SELECT id, kind, payload FROM platform.email_outbox
   WHERE status = 'pending' AND next_retry_at <= now()
   ORDER BY created_at
   FOR UPDATE SKIP LOCKED
@@ -444,11 +447,24 @@ This plan intentionally defers several concepts to Yannick's Timetable RFC (`doc
 
 ### Required Coordination Points
 
-- Table ownership for `schedule.calendar_periods` migration — decide before the first PR lands
+- Table ownership for `schedule.calendar_periods` migration — **Yannick ships it (rev 2.3)**; enrollment consumes
 - Migration version numbers across both plans must not collide (`MigrationRegistry` is a map — collisions silently overwrite)
 - `activities.student_enrollments` column additions — agree who writes them and who runs the data migration
 - Confirm `activities.groups.type='care'` is the right mapping for holiday care, daily care, Mensa, etc.
 - Error handling when a calendar period is deleted while an enrollment request still references it (FK strategy: `ON DELETE RESTRICT` on both sides)
+- Auto-generated default `school_year` period — confirm with Yannick whether his delivery handles this, or enrollment admin UI must create the first period manually
+
+### New Permission Pattern: `platform:config:update`
+
+Rev 2.3 introduces settings that tenant admins can read but only operators (platform scope) can write. This is new — existing settings are tenant-admin-editable. Implementation:
+
+- Add a new write permission `platform:config:update` to the permission catalog
+- Grant only to operator role(s)
+- Settings declaration uses the new permission in `WritePermission`
+- The settings service's permission check already supports this (string compare with wildcard); no service-layer changes needed
+- Frontend `writable` flag in the schema response correctly reflects: tenant admin sees the setting as read-only with a "Nur Operator" / "Systemverwaltung" badge; operator UI shows it editable
+
+Apply this to `enrollment.status_token_ttl_days` (first user of the pattern). Other sensitive platform-level knobs should use the same pattern going forward.
 
 ---
 

--- a/docs/parent-enrollment-plan.md
+++ b/docs/parent-enrollment-plan.md
@@ -7,6 +7,7 @@
 ## Changelog
 
 - **2026-04-15 (rev 2):** Added structured Betreuungsangebote (care offerings), email outbox/delivery-failure visibility, waitlist status + parent status page, per-child approval decisions, refined withdrawal rules. Updated domain model, API, settings, phasing, and risks sections accordingly.
+- **2026-04-15 (rev 2.1):** Added per-offering application windows (`application_window_start`/`_end`) and service date fields on `care_offerings` so parents can't apply for offerings whose intake period has closed (e.g. holiday care after holidays begin).
 
 ---
 
@@ -89,8 +90,16 @@ enrollment.care_offerings
   includes_lunch boolean,
   capacity int (nullable),                         -- null = unlimited
   price_cents int (nullable),                      -- informational only; not billing-grade
+  application_window_start timestamptz (nullable), -- parents can apply from this moment
+  application_window_end timestamptz (nullable),   -- parents can no longer apply after this
+  service_start_date date (nullable),              -- informational: when the offering actually begins (e.g. first day of holiday care)
+  service_end_date date (nullable),                -- informational: when it ends
   is_active boolean,
   sort_order, created_at, updated_at
+  CHECK (application_window_end IS NULL OR application_window_start IS NULL
+         OR application_window_end > application_window_start)
+  CHECK (service_end_date IS NULL OR service_start_date IS NULL
+         OR service_end_date >= service_start_date)
 
 enrollment.requests
   id, tenant_id, schema_id (version snapshot), school_year_id,
@@ -164,7 +173,7 @@ All new tables get RLS policies matching the existing tenant-isolation pattern.
 ### 5.2 Service layer
 
 - **`services/enrollment/form_schema_service.go`** — get active schema, create versions, validate submissions
-- **`services/enrollment/care_offering_service.go`** — admin CRUD over the care offerings catalog, capacity checks, per-year cloning for next year's setup
+- **`services/enrollment/care_offering_service.go`** — admin CRUD over the care offerings catalog, capacity checks, per-year cloning for next year's setup, **application-window enforcement** (offerings outside their `application_window_start..application_window_end` are hidden from the public form and rejected server-side even if a stale client submits them)
 - **`services/enrollment/request_service.go`** — public submit/withdraw/edit (token-auth), admin list/get/patch; derives request-level status from child statuses; enforces withdrawal rules (only non-terminal children)
 - **`services/enrollment/decision_service.go`** — per-child approve/waitlist/reject. On `approved`: creates student (status=pending), guardian_profile, students_guardians, student_year_assignment, selected care offering links. Writes outbox rows atomically. Idempotent per child — promoting a waitlisted child to approved works via the same entry point.
 - **`services/enrollment/outbox_worker.go`** — scheduler-driven worker. Picks up `pending` outbox rows where `next_retry_at <= now()`, renders template, dispatches via existing mailer. Exponential backoff on failure (1min, 5min, 30min, 2h, 12h, then `failed` at 6 attempts). Marks `sent` on success.
@@ -175,7 +184,7 @@ All new tables get RLS policies matching the existing tenant-isolation pattern.
 
 **Public (no auth, token- or tenant-slug-gated):**
 - `POST /api/enrollment/{tenantSlug}/submit`
-- `GET /api/enrollment/{tenantSlug}/care-offerings` — active offerings for the chosen school year
+- `GET /api/enrollment/{tenantSlug}/care-offerings` — active offerings for the chosen school year whose application window is currently open (`application_window_start <= now() <= application_window_end`, nulls = unbounded); admin view uses a separate endpoint that returns all regardless of window
 - `GET /api/enrollment/requests/{statusToken}` — returns current status for each child + per-child reasons (gated by setting)
 - `PATCH /api/enrollment/requests/{statusToken}` — edit payload; allowed only while ALL children are still `submitted`
 - `POST /api/enrollment/requests/{statusToken}/withdraw` — optional `child_id` in body; omit to withdraw all non-terminal children
@@ -364,6 +373,7 @@ Each PR is independently shippable and gated by `enrollment.enabled` (off by def
 | **Email deliverability for guardian invites** | Outbox pattern + retry with exponential backoff; admin-visible delivery status; verify DKIM/SPF on the from-domain |
 | **Outbox worker stalls / duplicates** | `FOR UPDATE SKIP LOCKED` on pickup; idempotent dispatch keyed by outbox ID; monitoring/alert if `failed` count grows |
 | **Care offering capacity race** | Capacity check on submit uses `SELECT ... FOR UPDATE` within the submission transaction; over-capacity requests get a friendly error or land on waitlist automatically (setting TBD) |
+| **Stale care-offering catalog (parent applies after service started)** | Each offering carries its own `application_window_start`/`_end`; public endpoint filters to offerings with an open window; service validates on submit so a cached browser can't bypass; admin view still lists closed offerings so they can be reopened or cloned |
 | **Partial decisions leaving requests in limbo** | Derived request status makes "partial" visible to admin; admin list has a filter "has pending children"; digest emails only fire when a decision batch is complete |
 | **Approved child already has a student record if parent withdraws** | Withdrawal of approved children disabled in parent UI; admin must delete/archive the student manually |
 

--- a/docs/parent-enrollment-plan.md
+++ b/docs/parent-enrollment-plan.md
@@ -8,6 +8,7 @@
 
 - **2026-04-15 (rev 2):** Added structured Betreuungsangebote (care offerings), email outbox/delivery-failure visibility, waitlist status + parent status page, per-child approval decisions, refined withdrawal rules. Updated domain model, API, settings, phasing, and risks sections accordingly.
 - **2026-04-15 (rev 2.1):** Added per-offering application windows (`application_window_start`/`_end`) and service date fields on `care_offerings` so parents can't apply for offerings whose intake period has closed (e.g. holiday care after holidays begin).
+- **2026-04-16 (rev 2.2):** Aligned with Yannick's Timetable RFC (`docs/timetable-system-plan.md`). Dropped `platform.school_years` in favor of `schedule.calendar_periods` (filter by `period_type='school_year'`). Dropped `users.student_year_assignments` in favor of the validity-scoped pattern (`valid_from`/`valid_until`). Approved care offering selections now create `activities.student_enrollments` rows instead of a new `users.student_care_enrollments` table. Added §11 Cross-dependencies.
 
 ---
 
@@ -41,7 +42,7 @@ Enable parents to submit a sign-up request for a child (or multiple children) fo
 |-------|----------|
 | **Parent role** | No new role. Reuse existing `guardian` base role, `guardian_profiles`, `guardian_invitations`, and `students_guardians`. The orphaned `auth.accounts_parents` table is NOT wired in — leave it alone or remove in a separate cleanup task. |
 | **Student creation timing** | On approval, create `users.students` rows with `status='pending'`. A daily scheduler job flips them to `active` when `enrolled_from <= today`. Schools can choose `immediate` or `scheduled` activation via settings. |
-| **School year model** | Add a new `platform.school_years` table (tenant-scoped). Student class assignments become year-scoped via a new `users.student_year_assignments` table. The existing `users.students.school_class` field is kept as a legacy "current class" cache during transition. |
+| **School year model** | **Reuse `schedule.calendar_periods`** from Yannick's Timetable RFC (filter by `period_type='school_year'`). Do NOT introduce a separate `platform.school_years` table. Year-scoped class progression uses the validity pattern (`valid_from`/`valid_until`) on the relevant student/enrollment rows, matching the Timetable RFC's E17 decision. |
 | **Grade level vs class** | Collect **grade level** (integer 1–13) on the form, not specific class ("1a" vs "1b"). Whether the form asks for it is toggled by setting `enrollment.collect_grade_level`. The concrete class (e.g., "1a") is assigned by the admin post-approval. |
 | **Year picker** | Parent chooses the target school year from available open years (tenant has ~4 open years max). No setting needed. |
 | **Edit/withdraw** | Tokenized link in the confirmation email lets the parent view/edit/withdraw their pending submission. |
@@ -54,21 +55,25 @@ Enable parents to submit a sign-up request for a child (or multiple children) fo
 | **Parent status visibility** | Tokenized status page accessible from the confirmation email stays live throughout the lifecycle. Parent sees per-child status + optional reason. Same token also powers edit/withdraw (gated by rules in §6.3). |
 | **Email reliability** | Outbox pattern (`enrollment.email_outbox`) — all approval-related emails written atomically with DB changes, dispatched by a worker with exponential backoff retry. Admin UI shows per-request delivery status with resend button. No more silent send failures. |
 | **Decision notification style** | Configurable per tenant via `enrollment.notify_per_decision` — default `digest` (one email summarizing all children's decisions after admin saves), alternative `immediate` (one email per child decision). |
+| **Care-offering ↔ activity-group mapping** | Each `enrollment.care_offerings` row optionally references an `activities.groups` row (care-type). Approving a child's care selection creates an `activities.student_enrollments` row linking student to that activity group, with `valid_from`/`valid_until` derived from the selected `calendar_period`. The offering row stays in the `enrollment` schema as the intake-side catalog; the activity group stays in the `activities` schema as the schedule-side entity. Clean separation. |
 
 ## 4. Open Questions for Team Review
 
 1. **GDPR / consent checkboxes** — what fixed consent items are legally required on a first-time signup form? Proposed defaults: (a) AGB/terms acceptance, (b) data processing, (c) contact by email. Are there more (photo, emergency contact sharing)?
 2. **Rejected-request retention** — how long should rejected submissions stay in the DB before automatic deletion? Proposed default: 90 days, settings-configurable.
-3. **School-year management ownership** — who creates school year entries in the admin UI? Operator-level (moto) or tenant-level (school admin)? The current proposal is tenant admin, gated by `config:manage`.
-4. **Existing `school_class` string field** — acceptable to keep as a legacy cache that mirrors the current-year assignment, or should we migrate callers immediately? A hard cutover risks breaking multiple features.
+3. **Calendar period management ownership** — who creates `calendar_periods` entries (with `period_type='school_year'`) in the admin UI? Operator-level (moto) or tenant-level (school admin)? Since the Timetable RFC auto-generates a default school-year period per tenant (E15), the practical answer may be "automatically by the system; admins only add extra periods (holiday, custom)." Confirm with Yannick.
+4. **Existing `school_class` string field** — Yannick's RFC (E11) keeps `students.school_class` as the canonical source for class identity and uses it as the filter for arrival-schedule bulk endpoints. Our plan no longer needs a year-scoped assignment table, so we can leave `school_class` untouched. Grade-level progression across years becomes the Timetable RFC's concern.
 5. **Spam protection** — is Turnstile/hCaptcha acceptable, or do we need a different provider? Gated behind `enrollment.require_captcha` setting.
 6. **Email sender identity** — emails sent from a tenant-specific from-address, or a global `enrollment@moto-app.de`? DNS/DKIM implications.
 7. **Grade levels beyond OGS** — OGS is typically grades 1–4, but the migration allows 1–13. Keep permissive or restrict?
-8. **Care offerings — downstream representation** — how should approved care selections map to the existing student/scheduling model? We'll likely need a new `users.student_care_enrollments` table linking student ↔ offering ↔ school_year. Does this interact with the existing timetable/schedule system in a way we should plan for now?
+8. **Care offerings — downstream representation** — **RESOLVED (rev 2.2):** Approved care selections create `activities.student_enrollments` rows scoped by `valid_from`/`valid_until` from the calendar period, following the Timetable RFC's E17 pattern. Offerings without a linked `activity_group_id` stay as catalog-only records.
 9. **Care offering capacity overflow behavior** — when a parent submits but the chosen offering is full, should we: (a) reject the submission with an error, (b) auto-place the child on waitlist and let the admin decide, or (c) allow submission and surface the overflow in admin UI? (b) feels most parent-friendly.
 10. **Digest vs. immediate notification default** — default proposed as `digest` (one email after admin saves all decisions). Is that right, or do schools expect immediate per-child emails?
 11. **Outbox scope** — scope to enrollment only (table `enrollment.email_outbox`) for v1, or invest in a shared `platform.outbox` that other features can use? Shared is more work up-front but pays dividends.
 12. **Status token lifetime** — proposal is 1 year so parents can revisit status long after submission. Is that acceptable under data protection review?
+13. **Coordination with Timetable RFC delivery** — if Yannick's full `schedule.calendar_periods` table lands before this plan's Phase 1 PR 1, we skip PR 1. If it lands after, do we ship the minimal subset (§7 Phase 1 PR 1) and let him extend, or do we block on his delivery? Depends on timing alignment — conversation with Yannick needed.
+14. **Auto-generated default school-year period** — the Timetable RFC (E15) says the system auto-creates a default `school_year` period per tenant. Does this plan rely on that behavior (i.e., we assume a school-year period always exists for a tenant and the parent picks from open ones)? If yes, our plan depends on that feature shipping too.
+15. **Care offering ↔ activity group wiring UX** — since `care_offerings.activity_group_id` is nullable, admins can create offerings before the matching `activities.groups` row exists. When a care offering has no linked activity group and a child is approved, what should happen? Proposed: log a warning, still approve the enrollment request, but skip the `student_enrollments` insert — admin can wire it later via an "attach activity group" action.
 
 ---
 
@@ -83,7 +88,10 @@ enrollment.form_schemas
   id, tenant_id, version, fields JSONB, is_active, created_by, created_at
 
 enrollment.care_offerings
-  id, tenant_id, school_year_id, name, description,
+  id, tenant_id,
+  calendar_period_id bigint NOT NULL FK → schedule.calendar_periods,  -- replaces school_year_id; period_type is typically 'school_year' or 'holiday'
+  activity_group_id bigint (nullable FK → activities.groups),          -- care-type group this offering maps to (may be NULL for pure catalog entries until the admin wires a group)
+  name, description,
   days_of_week_mode ('fixed'|'parent_choice'),   -- fixed = Mon–Fri always, choice = parent picks
   available_days JSONB,                            -- e.g. ["mon","tue","wed","thu","fri"]
   includes_holiday_care boolean,
@@ -102,7 +110,8 @@ enrollment.care_offerings
          OR service_end_date >= service_start_date)
 
 enrollment.requests
-  id, tenant_id, schema_id (version snapshot), school_year_id,
+  id, tenant_id, schema_id (version snapshot),
+  calendar_period_id bigint NOT NULL FK → schedule.calendar_periods,  -- which school-year period the request targets
   -- request-level status is DERIVED from children: submitted | under_review | partial | finalized | withdrawn
   guardian_first_name, guardian_last_name, guardian_email, guardian_phone,
   guardian_account_id (nullable — set if submitter was logged in),
@@ -145,6 +154,15 @@ enrollment.email_outbox
 
 **Why `email_outbox` over a pure async dispatcher:** the approval flow writes student + guardian + outbox rows in ONE transaction. The worker reads outbox rows independently. A dispatcher crash or SMTP outage no longer leaves the database in a state where records exist but the invitation was never sent. Admin UI reads from `email_outbox` to show delivery status; resend re-enqueues a new outbox row.
 
+**No `platform.school_years` / `users.student_year_assignments` tables.** Earlier revisions of this plan proposed new tables for year tracking and year-scoped class assignment. The Timetable RFC (`docs/timetable-system-plan.md`) introduces `schedule.calendar_periods` with `period_type IN ('school_year'|'semester'|'holiday'|'custom')` — a superset of what we need — and establishes the `valid_from`/`valid_until` pattern on existing rows (`activities.student_enrollments`, `activities.supervisors`) for year-scoped progression. We defer to that model:
+
+- **Year identity** → `schedule.calendar_periods` rows with `period_type='school_year'`
+- **Year-scoped care enrollment** → `activities.student_enrollments` rows with `valid_from`/`valid_until` scoped by the selected calendar period
+- **Class progression across years** → the Timetable RFC's enrollment-validity pattern (bulk rollover endpoint from the RFC's §5.4); we don't model this in the enrollment plan
+- **Grade level at time of enrollment** → still collected on `request_children.target_grade_level`, but recorded on the created student via existing student fields (not a new assignment table)
+
+This removes duplicate concepts and avoids competing schemas. If the Timetable RFC's `calendar_periods` table has not landed by the time this plan starts, Phase 1 PR 1 becomes a thin helper migration that introduces just `schedule.calendar_periods` (subset of Yannick's spec — `period_type`, `start_date`, `end_date`, `is_active`) so this plan can proceed without blocking on the full timetable system.
+
 **New in `platform` schema**
 
 ```
@@ -175,7 +193,7 @@ All new tables get RLS policies matching the existing tenant-isolation pattern.
 - **`services/enrollment/form_schema_service.go`** — get active schema, create versions, validate submissions
 - **`services/enrollment/care_offering_service.go`** — admin CRUD over the care offerings catalog, capacity checks, per-year cloning for next year's setup, **application-window enforcement** (offerings outside their `application_window_start..application_window_end` are hidden from the public form and rejected server-side even if a stale client submits them)
 - **`services/enrollment/request_service.go`** — public submit/withdraw/edit (token-auth), admin list/get/patch; derives request-level status from child statuses; enforces withdrawal rules (only non-terminal children)
-- **`services/enrollment/decision_service.go`** — per-child approve/waitlist/reject. On `approved`: creates student (status=pending), guardian_profile, students_guardians, student_year_assignment, selected care offering links. Writes outbox rows atomically. Idempotent per child — promoting a waitlisted child to approved works via the same entry point.
+- **`services/enrollment/decision_service.go`** — per-child approve/waitlist/reject. On `approved`: creates student (status=pending), guardian_profile, students_guardians, and — for each selected care offering with a non-null `activity_group_id` — an `activities.student_enrollments` row with `valid_from`/`valid_until` derived from the calendar period. Writes outbox rows atomically. Idempotent per child — promoting a waitlisted child to approved works via the same entry point. Depends on `schedule.calendar_periods` (from Timetable RFC) and `activities.student_enrollments` (existing).
 - **`services/enrollment/outbox_worker.go`** — scheduler-driven worker. Picks up `pending` outbox rows where `next_retry_at <= now()`, renders template, dispatches via existing mailer. Exponential backoff on failure (1min, 5min, 30min, 2h, 12h, then `failed` at 6 attempts). Marks `sent` on success.
 - **`services/auth/guardian_invitation_service.go`** — complete the half-built service that mirrors the staff `invitation_service`. Issue token, render email via outbox (not direct dispatch), accept-and-create-account, cleanup expired, resend.
 - **`services/scheduler/activate_students.go`** — daily job: `UPDATE users.students SET status='active' WHERE status='pending' AND enrolled_from <= CURRENT_DATE`, and the inverse for `enrolled_until`
@@ -263,12 +281,11 @@ Admin submits decisions for one or more children in a request. For each child in
 
 **Approve:**
 1. Create `guardian_profile` if not already present (matched by email, tenant-scoped)
-2. Create `users.students` row, `status='pending'`, `enrolled_from` = `child.activate_on` or `school_year.start_date`
+2. Create `users.students` row, `status='pending'`, `enrolled_from` = `child.activate_on` or the `calendar_period.start_date`; write grade level into the existing student field (no new assignment table)
 3. Create `users.students_guardians` link (relationship='parent', is_primary=true if first child for this guardian)
-4. Create `users.student_year_assignments` row with grade level
-5. Copy `request_child_offerings` selections onto the student record (exact downstream representation TBD — likely a `users.student_care_enrollments` table created in Phase 1)
-6. Set `request_children.status='approved'`, `reviewed_at`, `reviewed_by`, `created_student_id`
-7. If this is the FIRST approved child in the request AND no prior guardian invitation outbox row exists: enqueue one `guardian_invitation` outbox row
+4. For each `request_child_offerings` selection where the referenced `care_offering.activity_group_id IS NOT NULL`: insert an `activities.student_enrollments` row with `valid_from=calendar_period.start_date`, `valid_until=calendar_period.end_date`, `calendar_period_id=...`. Care offerings without a linked activity group are recorded on the request but not materialized into activities.student_enrollments (admin can wire the group later).
+5. Set `request_children.status='approved'`, `reviewed_at`, `reviewed_by`, `created_student_id`
+6. If this is the FIRST approved child in the request AND no prior guardian invitation outbox row exists: enqueue one `guardian_invitation` outbox row
 
 **Waitlist:**
 - Set `request_children.status='waitlisted'`, `status_reason`, `reviewed_at`, `reviewed_by`. No student created.
@@ -336,8 +353,8 @@ Slog entries use student IDs only (GDPR — no names at info level).
 
 ### Phase 1: Foundation (no user-visible enrollment feature yet)
 
-- **PR 1** — `platform.school_years` table + model + repo + admin CRUD API + admin UI
-- **PR 2** — Student lifecycle fields (`status`, `enrolled_from`, `enrolled_until`) + `student_year_assignments` table + data migration for existing students + scheduler activation job + tests
+- **PR 1** — `schedule.calendar_periods` table + model + repo + admin CRUD API + admin UI. **Coordinate with Yannick** — if the Timetable RFC ships the full table first, this PR becomes a no-op. Otherwise ship a minimal subset (`id, tenant_id, name, period_type, start_date, end_date, is_active`) that the Timetable RFC can extend later with the week-cycle columns.
+- **PR 2** — Student lifecycle fields (`status`, `enrolled_from`, `enrolled_until`) + scheduler activation job + tests. No `student_year_assignments` table — year-scoped progression is handled by the Timetable RFC's enrollment-validity pattern on `activities.student_enrollments`.
 - **PR 3** — Complete `guardian_invitation_service` + `/accept-guardian-invite` frontend page
 
 ### Phase 2: Enrollment MVP
@@ -395,7 +412,6 @@ Each PR is independently shippable and gated by `enrollment.enabled` (off by def
 
 ## 10. Sharp Edges for Implementation
 
-- **`UNIQUE (tenant_id) WHERE is_current`** on `school_years` — flipping requires a transaction that unsets the old current first
 - **Schema versioning** — old submitted requests must still render against their pinned schema after an admin edits the form
 - **Hermetic tests** — all new tests MUST use `testpkg.CreateTestStudent` etc.; no hardcoded IDs (see CLAUDE.md)
 - **Settings consumers** — anywhere enrollment code reads a setting, follow the `HasTenantOverride` → `Resolve*` → env var → fallback pattern from `.claude/rules/settings-system.md`
@@ -405,10 +421,41 @@ Each PR is independently shippable and gated by `enrollment.enabled` (off by def
 
 ---
 
-## 11. Estimated Scope
+## 11. Cross-Dependencies with Timetable RFC
 
-- Phase 1: ~1 week of focused work (mostly scaffolding, low risk)
+This plan intentionally defers several concepts to Yannick's Timetable RFC (`docs/timetable-system-plan.md`) rather than building parallel structures. The overlap is substantial and listed here for coordination.
+
+| Concept | Owner | Consumed by this plan |
+|---------|-------|-----------------------|
+| `schedule.calendar_periods` table | Timetable RFC (E15) | Year picker on submission form; `enrollment.requests.calendar_period_id`; `enrollment.care_offerings.calendar_period_id`; `valid_from`/`valid_until` on created `activities.student_enrollments` rows |
+| Auto-generated default `school_year` period per tenant | Timetable RFC (E15) | We assume at least one `school_year` calendar period exists for each active tenant |
+| `activities.student_enrollments` with `valid_from`/`valid_until` | Timetable RFC (E17) — extends an existing table | Approval service writes rows here to record approved care offerings |
+| `activities.groups` with `type='care'` | Timetable RFC (existing + extension) | `enrollment.care_offerings.activity_group_id` points here |
+| Bulk semester rollover endpoint | Timetable RFC (E17, §5.4) | Not consumed directly; relevant for post-v1 re-enrollment flow |
+| Student progression across school years | Timetable RFC (enrollment-validity pattern) | Not modeled in this plan; once a year ends, the Timetable RFC's rollover mechanism handles continuation |
+
+### Delivery Scenarios
+
+**Scenario A — Timetable RFC lands first:** This plan's Phase 1 PR 1 is unnecessary. Start from Phase 1 PR 2.
+
+**Scenario B — This plan lands first:** Ship a minimal `schedule.calendar_periods` table in Phase 1 PR 1 (just `id, tenant_id, name, period_type, start_date, end_date, is_active`). Yannick's RFC extends the same table later with the week-cycle columns (additive migration). Similarly ship the additive migration on `activities.student_enrollments` (`valid_from`/`valid_until` nullable, `calendar_period_id` nullable).
+
+**Scenario C — Parallel delivery:** Weekly sync to decide table ownership per PR to avoid migration-number collisions (see Sharp Edges §10).
+
+### Required Coordination Points
+
+- Table ownership for `schedule.calendar_periods` migration — decide before the first PR lands
+- Migration version numbers across both plans must not collide (`MigrationRegistry` is a map — collisions silently overwrite)
+- `activities.student_enrollments` column additions — agree who writes them and who runs the data migration
+- Confirm `activities.groups.type='care'` is the right mapping for holiday care, daily care, Mensa, etc.
+- Error handling when a calendar period is deleted while an enrollment request still references it (FK strategy: `ON DELETE RESTRICT` on both sides)
+
+---
+
+## 12. Estimated Scope
+
+- Phase 1: ~1 week of focused work (mostly scaffolding, low risk). Reduced if Timetable RFC's PRs land first.
 - Phase 2: ~2 weeks (the bulk — form editor, public submission, admin review, approval transaction)
 - Phase 3: ~1 week (export, attachments if prioritized)
 
-Total: ~4 engineering weeks for a full v1 + polish.
+Total: ~4 engineering weeks for a full v1 + polish, assuming Timetable RFC coordination lands cleanly.


### PR DESCRIPTION
**DON'T MERGE**

Initial plan for team discussion covering public signup form, admin review, guardian invitations, school-year model, and the settings-driven form schema editor. Phased delivery across foundation (school years, student lifecycle), enrollment MVP, and polish. Open questions for team flagged in section 4.
