### PR TITLE
feat: add Abholzeit filter to Kindersuche and Klassenstufe filter to Aktive Aufsichten

### DIFF
--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -357,6 +357,13 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 		responses, totalCount = applyInMemoryPagination(responses, params.page, params.pageSize)
 	}
 
+	// Enrich the paginated slice with today's effective pickup times (single bulk query)
+	paginatedIDs := make([]int64, len(responses))
+	for i := range responses {
+		paginatedIDs[i] = responses[i].ID
+	}
+	rs.enrichWithPickupTimes(r.Context(), responses, paginatedIDs)
+
 	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: params.page, PageSize: params.pageSize, Total: totalCount}, "Students retrieved successfully")
 }
 
@@ -470,7 +477,6 @@ func (rs *Resource) getStudent(w http.ResponseWriter, r *http.Request) {
 			ActiveService: rs.ActiveService,
 			PersonService: rs.PersonService,
 		}),
-		HasFullAccess:        hasFullAccess,
 		HasWriteAccess:       hasWriteAccess,
 		AttendanceLogEnabled: attendanceLogEnabled,
 		FeedbackEnabled:      feedbackEnabled,

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -357,12 +357,17 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 		responses, totalCount = applyInMemoryPagination(responses, params.page, params.pageSize)
 	}
 
-	// Enrich the paginated slice with today's effective pickup times (single bulk query)
-	paginatedIDs := make([]int64, len(responses))
-	for i := range responses {
-		paginatedIDs[i] = responses[i].ID
+	// Optionally enrich the paginated slice with today's effective pickup times (single bulk query).
+	// Only query for students the caller has full access to (GDPR — skip redacted students).
+	if params.includePickupTimes {
+		fullAccessIDs := make([]int64, 0, len(responses))
+		for i := range responses {
+			if responses[i].HasFullAccess {
+				fullAccessIDs = append(fullAccessIDs, responses[i].ID)
+			}
+		}
+		rs.enrichWithPickupTimes(r.Context(), responses, fullAccessIDs, time.Now())
 	}
-	rs.enrichWithPickupTimes(r.Context(), responses, paginatedIDs)
 
 	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: params.page, PageSize: params.pageSize, Total: totalCount}, "Students retrieved successfully")
 }
@@ -477,6 +482,7 @@ func (rs *Resource) getStudent(w http.ResponseWriter, r *http.Request) {
 			ActiveService: rs.ActiveService,
 			PersonService: rs.PersonService,
 		}),
+		HasFullAccess:        hasFullAccess,
 		HasWriteAccess:       hasWriteAccess,
 		AttendanceLogEnabled: attendanceLogEnabled,
 		FeedbackEnabled:      feedbackEnabled,

--- a/backend/api/students/enrich_pickup_times_test.go
+++ b/backend/api/students/enrich_pickup_times_test.go
@@ -2,6 +2,7 @@ package students
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -124,4 +125,28 @@ func TestEnrichWithPickupTimes_NoPickupTime(t *testing.T) {
 	rs.enrichWithPickupTimes(context.Background(), responses, []int64{100}, now)
 
 	assert.Nil(t, responses[0].PickupTime, "should be nil when no pickup time is set")
+}
+
+func TestEnrichWithPickupTimes_ServiceError(t *testing.T) {
+	now := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+
+	mock := &mockPickupScheduleService{
+		bulkErr: fmt.Errorf("database connection lost"),
+	}
+
+	rs := &Resource{
+		PickupScheduleService: mock,
+		Logger:                slog.Default(),
+	}
+
+	responses := []StudentResponse{
+		{ID: 100, HasFullAccess: true},
+		{ID: 200, HasFullAccess: true},
+	}
+
+	rs.enrichWithPickupTimes(context.Background(), responses, []int64{100, 200}, now)
+
+	// No pickup times should be set when the service returns an error
+	assert.Nil(t, responses[0].PickupTime, "should be nil when service returns error")
+	assert.Nil(t, responses[1].PickupTime, "should be nil when service returns error")
 }

--- a/backend/api/students/enrich_pickup_times_test.go
+++ b/backend/api/students/enrich_pickup_times_test.go
@@ -1,0 +1,127 @@
+package students
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
+)
+
+// mockPickupScheduleService implements only GetBulkEffectivePickupTimesForDate.
+// All other methods panic — they are not used by enrichWithPickupTimes.
+type mockPickupScheduleService struct {
+	scheduleService.PickupScheduleService // embed interface to satisfy compiler for unused methods
+	bulkResult                            map[int64]*scheduleService.EffectivePickupTime
+	bulkErr                               error
+	calledWithIDs                         []int64
+}
+
+func (m *mockPickupScheduleService) GetBulkEffectivePickupTimesForDate(_ context.Context, studentIDs []int64, _ time.Time) (map[int64]*scheduleService.EffectivePickupTime, error) {
+	m.calledWithIDs = studentIDs
+	return m.bulkResult, m.bulkErr
+}
+
+// Stub out the embedded interface methods that would panic on nil receiver.
+func (m *mockPickupScheduleService) GetStudentPickupSchedules(_ context.Context, _ int64) ([]*schedule.StudentPickupSchedule, error) {
+	return nil, nil
+}
+
+func TestEnrichWithPickupTimes_FullAccessGating(t *testing.T) {
+	now := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+	pickupAt := time.Date(2026, 4, 14, 15, 30, 0, 0, time.UTC)
+
+	mock := &mockPickupScheduleService{
+		bulkResult: map[int64]*scheduleService.EffectivePickupTime{
+			100: {PickupTime: &pickupAt},
+			200: {PickupTime: &pickupAt},
+			300: {PickupTime: &pickupAt},
+		},
+	}
+
+	rs := &Resource{
+		PickupScheduleService: mock,
+		Logger:                slog.Default(),
+	}
+
+	responses := []StudentResponse{
+		{ID: 100, HasFullAccess: true},
+		{ID: 200, HasFullAccess: false}, // Should NOT get pickup time
+		{ID: 300, HasFullAccess: true},
+	}
+
+	// Only pass full-access IDs (mirrors the caller in listStudents)
+	fullAccessIDs := []int64{100, 300}
+
+	rs.enrichWithPickupTimes(context.Background(), responses, fullAccessIDs, now)
+
+	// Full-access students get their pickup time
+	assert.NotNil(t, responses[0].PickupTime, "full-access student 100 should have pickup time")
+	assert.Equal(t, "15:30", *responses[0].PickupTime)
+
+	// Non-full-access student must NOT have pickup time (GDPR)
+	assert.Nil(t, responses[1].PickupTime, "non-full-access student 200 must not have pickup time")
+
+	// Second full-access student also gets pickup time
+	assert.NotNil(t, responses[2].PickupTime, "full-access student 300 should have pickup time")
+	assert.Equal(t, "15:30", *responses[2].PickupTime)
+
+	// Verify the service was called only with full-access IDs
+	assert.Equal(t, []int64{100, 300}, mock.calledWithIDs, "should only query pickup times for full-access students")
+}
+
+func TestEnrichWithPickupTimes_NilService(t *testing.T) {
+	rs := &Resource{
+		PickupScheduleService: nil,
+		Logger:                slog.Default(),
+	}
+
+	responses := []StudentResponse{
+		{ID: 100, HasFullAccess: true},
+	}
+
+	// Should not panic
+	rs.enrichWithPickupTimes(context.Background(), responses, []int64{100}, time.Now())
+	assert.Nil(t, responses[0].PickupTime, "should be nil when service is nil")
+}
+
+func TestEnrichWithPickupTimes_EmptyIDs(t *testing.T) {
+	mock := &mockPickupScheduleService{}
+	rs := &Resource{
+		PickupScheduleService: mock,
+		Logger:                slog.Default(),
+	}
+
+	responses := []StudentResponse{}
+	rs.enrichWithPickupTimes(context.Background(), responses, []int64{}, time.Now())
+
+	// Should not have called the service
+	assert.Nil(t, mock.calledWithIDs, "should not call service with empty IDs")
+}
+
+func TestEnrichWithPickupTimes_NoPickupTime(t *testing.T) {
+	now := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+
+	mock := &mockPickupScheduleService{
+		bulkResult: map[int64]*scheduleService.EffectivePickupTime{
+			100: {PickupTime: nil}, // Student has no pickup schedule
+		},
+	}
+
+	rs := &Resource{
+		PickupScheduleService: mock,
+		Logger:                slog.Default(),
+	}
+
+	responses := []StudentResponse{
+		{ID: 100, HasFullAccess: true},
+	}
+
+	rs.enrichWithPickupTimes(context.Background(), responses, []int64{100}, now)
+
+	assert.Nil(t, responses[0].PickupTime, "should be nil when no pickup time is set")
+}

--- a/backend/api/students/list_helpers.go
+++ b/backend/api/students/list_helpers.go
@@ -14,15 +14,16 @@ import (
 
 // studentListParams holds all query parameters for student listing
 type studentListParams struct {
-	schoolClass  string
-	guardianName string
-	firstName    string
-	lastName     string
-	location     string
-	groupID      int64
-	search       string
-	page         int
-	pageSize     int
+	schoolClass        string
+	guardianName       string
+	firstName          string
+	lastName           string
+	location           string
+	groupID            int64
+	search             string
+	page               int
+	pageSize           int
+	includePickupTimes bool
 }
 
 // studentAccessContext holds access control information for student listing
@@ -49,6 +50,9 @@ func parseStudentListParams(r *http.Request) *studentListParams {
 			params.groupID = groupID
 		}
 	}
+
+	// Parse optional includes
+	params.includePickupTimes = r.URL.Query().Get("include_pickup_times") == "true"
 
 	// Parse pagination
 	params.page, params.pageSize = common.ParsePagination(r)

--- a/backend/api/students/response_helpers.go
+++ b/backend/api/students/response_helpers.go
@@ -291,12 +291,12 @@ func teacherToSupervisorContact(teacher *users.Teacher) *SupervisorContact {
 
 // enrichWithPickupTimes adds today's effective pickup time to each student response.
 // Uses a single bulk query via PickupScheduleService (handles schedule + exception merging).
-func (rs *Resource) enrichWithPickupTimes(ctx context.Context, responses []StudentResponse, studentIDs []int64) {
+// Only students with HasFullAccess=true receive pickup times (GDPR).
+func (rs *Resource) enrichWithPickupTimes(ctx context.Context, responses []StudentResponse, studentIDs []int64, now time.Time) {
 	if len(studentIDs) == 0 || rs.PickupScheduleService == nil {
 		return
 	}
 
-	now := time.Now()
 	pickupTimes, err := rs.PickupScheduleService.GetBulkEffectivePickupTimesForDate(ctx, studentIDs, now)
 	if err != nil {
 		rs.Logger.Warn("failed to bulk-fetch pickup times", "error", err.Error())

--- a/backend/api/students/response_helpers.go
+++ b/backend/api/students/response_helpers.go
@@ -288,3 +288,28 @@ func teacherToSupervisorContact(teacher *users.Teacher) *SupervisorContact {
 
 	return supervisor
 }
+
+// enrichWithPickupTimes adds today's effective pickup time to each student response.
+// Uses a single bulk query via PickupScheduleService (handles schedule + exception merging).
+func (rs *Resource) enrichWithPickupTimes(ctx context.Context, responses []StudentResponse, studentIDs []int64) {
+	if len(studentIDs) == 0 || rs.PickupScheduleService == nil {
+		return
+	}
+
+	now := time.Now()
+	pickupTimes, err := rs.PickupScheduleService.GetBulkEffectivePickupTimesForDate(ctx, studentIDs, now)
+	if err != nil {
+		rs.Logger.Warn("failed to bulk-fetch pickup times", "error", err.Error())
+		return
+	}
+
+	for i := range responses {
+		if !responses[i].HasFullAccess {
+			continue
+		}
+		if ept, ok := pickupTimes[responses[i].ID]; ok && ept.PickupTime != nil {
+			formatted := ept.PickupTime.Format("15:04")
+			responses[i].PickupTime = &formatted
+		}
+	}
+}

--- a/backend/api/students/students_test.go
+++ b/backend/api/students/students_test.go
@@ -1,16 +1,132 @@
 package students_test
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/moto-nrw/project-phoenix/api/testutil"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
+
+// =============================================================================
+// List Students with Pickup Times Tests
+// =============================================================================
+
+func TestListStudents_WithPickupTimes(t *testing.T) {
+	tc := setupTestContext(t)
+
+	// Create two students: one with a pickup schedule, one without
+	studentWithSchedule := testpkg.CreateTestStudent(t, tc.db, "Pickup", "WithSchedule", "PT1")
+	studentNoSchedule := testpkg.CreateTestStudent(t, tc.db, "Pickup", "NoSchedule", "PT2")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, studentWithSchedule.ID, studentNoSchedule.ID)
+
+	// Use a fixed Tuesday date to avoid weekend edge cases
+	// Jan 7, 2025 is a Tuesday (weekday 2)
+	testDate := time.Date(2025, 1, 7, 12, 0, 0, 0, time.UTC)
+	_ = testDate // used conceptually — the handler uses time.Now(), so we insert for today's weekday
+
+	// Determine today's ISO weekday (Mon=1..Fri=5) for the schedule to match
+	todayWeekday := int(time.Now().Weekday())
+	if todayWeekday == 0 {
+		todayWeekday = 7 // Sunday
+	}
+
+	// Skip on weekends — pickup schedules only apply Mon-Fri
+	if todayWeekday > scheduleModel.WeekdayFriday {
+		t.Skip("Skipping pickup time test on weekend — schedules only apply Mon-Fri")
+	}
+
+	// Insert a pickup schedule for today's weekday
+	pickupTime := time.Date(2000, 1, 1, 15, 30, 0, 0, time.UTC)
+	schedule := &scheduleModel.StudentPickupSchedule{
+		StudentID:  studentWithSchedule.ID,
+		Weekday:    todayWeekday,
+		PickupTime: pickupTime,
+		CreatedBy:  1,
+	}
+	schedule.SetTenantID(1)
+	_, err := tc.db.NewInsert().Model(schedule).
+		ModelTableExpr("schedule.student_pickup_schedules").
+		Returning("id").
+		Exec(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		_, _ = tc.db.NewDelete().Model((*scheduleModel.StudentPickupSchedule)(nil)).
+			ModelTableExpr("schedule.student_pickup_schedules").
+			Where("student_id = ?", studentWithSchedule.ID).
+			Exec(context.Background())
+	}()
+
+	t.Run("include_pickup_times_returns_pickup_time_field", func(t *testing.T) {
+		router := setupRouter(tc.resource.ListStudentsHandler(), "")
+		req := testutil.NewRequest("GET", "/?include_pickup_times=true&school_class=PT1&page_size=50", nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		require.Equal(t, http.StatusOK, rr.Code, "Expected 200 OK. Body: %s", rr.Body.String())
+
+		// Parse response to check pickup_time field
+		var resp struct {
+			Data []json.RawMessage `json:"data"`
+		}
+		err := json.Unmarshal(rr.Body.Bytes(), &resp)
+		require.NoError(t, err, "Failed to parse response JSON")
+		require.NotEmpty(t, resp.Data, "Expected at least one student in response")
+
+		// Find the student with schedule and verify pickup_time is set
+		found := false
+		for _, raw := range resp.Data {
+			var student struct {
+				ID         int64   `json:"id"`
+				PickupTime *string `json:"pickup_time"`
+			}
+			err := json.Unmarshal(raw, &student)
+			require.NoError(t, err)
+
+			if student.ID == studentWithSchedule.ID {
+				found = true
+				require.NotNil(t, student.PickupTime, "Student with schedule should have pickup_time")
+				assert.Equal(t, "15:30", *student.PickupTime, "Pickup time should match the schedule")
+			}
+
+			if student.ID == studentNoSchedule.ID {
+				assert.Nil(t, student.PickupTime, "Student without schedule should not have pickup_time")
+			}
+		}
+		assert.True(t, found, "Student with schedule should be in response")
+	})
+
+	t.Run("without_include_pickup_times_omits_field", func(t *testing.T) {
+		router := setupRouter(tc.resource.ListStudentsHandler(), "")
+		req := testutil.NewRequest("GET", "/?school_class=PT1&page_size=50", nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		require.Equal(t, http.StatusOK, rr.Code)
+
+		// Verify pickup_time is not present in any response
+		var resp struct {
+			Data []json.RawMessage `json:"data"`
+		}
+		err := json.Unmarshal(rr.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		for _, raw := range resp.Data {
+			var student map[string]interface{}
+			err := json.Unmarshal(raw, &student)
+			require.NoError(t, err)
+
+			_, hasPickupTime := student["pickup_time"]
+			assert.False(t, hasPickupTime, "pickup_time should not be present when include_pickup_times is not set")
+		}
+	})
+}
 
 // =============================================================================
 // List Students Tests

--- a/backend/api/students/students_test.go
+++ b/backend/api/students/students_test.go
@@ -28,10 +28,8 @@ func TestListStudents_WithPickupTimes(t *testing.T) {
 	studentNoSchedule := testpkg.CreateTestStudent(t, tc.db, "Pickup", "NoSchedule", "PT2")
 	defer testpkg.CleanupActivityFixtures(t, tc.db, studentWithSchedule.ID, studentNoSchedule.ID)
 
-	// Use a fixed Tuesday date to avoid weekend edge cases
-	// Jan 7, 2025 is a Tuesday (weekday 2)
-	testDate := time.Date(2025, 1, 7, 12, 0, 0, 0, time.UTC)
-	_ = testDate // used conceptually — the handler uses time.Now(), so we insert for today's weekday
+	// The handler uses time.Now() internally, so we insert schedules for today's weekday
+	// rather than a fixed date. This means the test dynamically adapts to the current day.
 
 	// Determine today's ISO weekday (Mon=1..Fri=5) for the schedule to match
 	todayWeekday := int(time.Now().Weekday())

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -32,6 +32,7 @@ type StudentResponse struct {
 	HealthInfo      string     `json:"health_info,omitempty"`
 	SupervisorNotes string     `json:"supervisor_notes,omitempty"`
 	PickupStatus    string     `json:"pickup_status,omitempty"`
+	PickupTime      *string    `json:"pickup_time,omitempty"` // Today's effective pickup time (HH:MM)
 	Bus             bool       `json:"bus"`
 	Sick            bool       `json:"sick"`
 	SickSince       *time.Time `json:"sick_since,omitempty"`
@@ -53,7 +54,6 @@ type SupervisorContact struct {
 // StudentDetailResponse represents a detailed student response with access control
 type StudentDetailResponse struct {
 	StudentResponse
-	HasFullAccess        bool                `json:"has_full_access"`
 	HasWriteAccess       bool                `json:"has_write_access"`
 	GroupSupervisors     []SupervisorContact `json:"group_supervisors,omitempty"`
 	AttendanceLogEnabled bool                `json:"attendance_log_enabled"`

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -54,6 +54,7 @@ type SupervisorContact struct {
 // StudentDetailResponse represents a detailed student response with access control
 type StudentDetailResponse struct {
 	StudentResponse
+	HasFullAccess        bool                `json:"has_full_access"`
 	HasWriteAccess       bool                `json:"has_write_access"`
 	GroupSupervisors     []SupervisorContact `json:"group_supervisors,omitempty"`
 	AttendanceLogEnabled bool                `json:"attendance_log_enabled"`

--- a/backend/test/hermetic_verification_test.go
+++ b/backend/test/hermetic_verification_test.go
@@ -151,6 +151,7 @@ func checkHardcodedIDs(t *testing.T, root string) []string {
 		"error_helpers_test.go",                 // Internal unit tests for helper functions (no DB)
 		"api/iot/api_test.go",                   // Uses mock SchoolRepo for unit testing handler
 		"api/iot/config_test.go",                // Uses mock settings service for unit testing config endpoint
+		"enrich_pickup_times_test.go",           // Uses mock PickupScheduleService for unit testing enrichment
 	}
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
@@ -7720,3 +7720,314 @@ describe("Tracking indicators rendering", () => {
     expect(trackingCall?.[0]).toContain("100");
   });
 });
+
+describe("Year filter (Klassenstufe) on active supervisions", () => {
+  const mockMutate = vi.fn();
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+    localStorage.clear();
+
+    // Override PageHeaderWithSearch to expose year filter
+    const mod = await import("~/components/ui/page-header");
+    vi.mocked(
+      mod.PageHeaderWithSearch as React.FC<Record<string, unknown>>,
+    ).mockImplementation((props: Record<string, unknown>) => {
+      const p = props;
+      const search = p.search as
+        | { value: string; onChange: (v: string) => void }
+        | undefined;
+      const filters = p.filters as
+        | Array<{
+            id: string;
+            value: string;
+            onChange: (v: string) => void;
+            options: Array<{ value: string; label: string }>;
+          }>
+        | undefined;
+      const activeFilters = p.activeFilters as
+        | Array<{ id: string; label: string; onRemove?: () => void }>
+        | undefined;
+      const onClearAllFilters = p.onClearAllFilters as (() => void) | undefined;
+
+      return (
+        <div data-testid="page-header">
+          {search && (
+            <input
+              data-testid="search-input"
+              value={search.value}
+              onChange={(e) => search.onChange(e.target.value)}
+            />
+          )}
+          {filters?.map((f) => (
+            <select
+              key={f.id}
+              data-testid={`filter-${f.id}`}
+              value={f.value}
+              onChange={(e) => f.onChange(e.target.value)}
+            >
+              {f.options.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          ))}
+          <div data-testid="active-filters">
+            {activeFilters?.map((f) => (
+              <button
+                key={f.id}
+                data-testid={`active-filter-${f.id}`}
+                onClick={f.onRemove}
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
+          {onClearAllFilters && (
+            <button data-testid="clear-filters" onClick={onClearAllFilters}>
+              Clear
+            </button>
+          )}
+        </div>
+      );
+    });
+  });
+
+  afterEach(() => cleanup());
+
+  function makeDashboardWithStudents(
+    students: Array<{
+      id: string;
+      name: string;
+      schoolClass: string;
+      groupName: string;
+    }>,
+  ) {
+    return {
+      supervisedGroups: [
+        {
+          id: "g1",
+          name: "OGS",
+          room_id: "r1",
+          room: { id: "r1", name: "Raum A" },
+        },
+      ],
+      unclaimedGroups: [],
+      currentStaff: { id: "staff-1" },
+      educationalGroups: [{ id: "eg1", name: "OGS", room: { name: "Raum A" } }],
+      firstRoomVisits: students.map((s) => ({
+        studentId: s.id,
+        studentName: s.name,
+        schoolClass: s.schoolClass,
+        groupName: s.groupName,
+        activeGroupId: "g1",
+        checkInTime: new Date().toISOString(),
+        isActive: true,
+      })),
+      firstRoomId: "r1",
+      schulhofStatus: null,
+    };
+  }
+
+  const fourStudents = [
+    { id: "s1", name: "Max Mustermann", schoolClass: "1a", groupName: "OGS" },
+    { id: "s2", name: "Anna Schmidt", schoolClass: "2b", groupName: "OGS" },
+    { id: "s3", name: "Tom Weber", schoolClass: "1c", groupName: "OGS" },
+    { id: "s4", name: "Lisa Müller", schoolClass: "3a", groupName: "OGS" },
+  ];
+
+  const swrNull = {
+    data: null,
+    isLoading: false,
+    error: null,
+    mutate: mockMutate,
+    isValidating: false,
+  } as never;
+
+  it("filters students by year 1 — shows only class 1 students", async () => {
+    vi.mocked(useSWRAuth)
+      .mockReturnValueOnce({
+        data: makeDashboardWithStudents(fourStudents),
+        isLoading: false,
+        error: null,
+        mutate: mockMutate,
+        isValidating: false,
+      } as never)
+      .mockReturnValue(swrNull);
+
+    render(<MeinRaumPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card").length).toBe(4);
+    });
+
+    // Filter by year 1
+    const yearFilter = screen.getByTestId("filter-year");
+    fireEvent.change(yearFilter, { target: { value: "1" } });
+
+    await waitFor(() => {
+      // Max (1a) and Tom (1c) should remain; Anna (2b) and Lisa (3a) filtered out
+      expect(screen.getAllByTestId("student-card").length).toBe(2);
+    });
+  });
+
+  it("filters students by year 3 — shows only class 3 students", async () => {
+    vi.mocked(useSWRAuth)
+      .mockReturnValueOnce({
+        data: makeDashboardWithStudents(fourStudents),
+        isLoading: false,
+        error: null,
+        mutate: mockMutate,
+        isValidating: false,
+      } as never)
+      .mockReturnValue(swrNull);
+
+    render(<MeinRaumPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card").length).toBe(4);
+    });
+
+    const yearFilter = screen.getByTestId("filter-year");
+    fireEvent.change(yearFilter, { target: { value: "3" } });
+
+    await waitFor(() => {
+      // Only Lisa (3a)
+      expect(screen.getAllByTestId("student-card").length).toBe(1);
+    });
+  });
+
+  it("shows all students when year filter is reset to 'all'", async () => {
+    vi.mocked(useSWRAuth)
+      .mockReturnValueOnce({
+        data: makeDashboardWithStudents(fourStudents),
+        isLoading: false,
+        error: null,
+        mutate: mockMutate,
+        isValidating: false,
+      } as never)
+      .mockReturnValue(swrNull);
+
+    render(<MeinRaumPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card").length).toBe(4);
+    });
+
+    const yearFilter = screen.getByTestId("filter-year");
+
+    // Filter by year 1
+    fireEvent.change(yearFilter, { target: { value: "1" } });
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card").length).toBe(2);
+    });
+
+    // Reset to all
+    fireEvent.change(yearFilter, { target: { value: "all" } });
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card").length).toBe(4);
+    });
+  });
+
+  it("shows year active filter chip with correct label", async () => {
+    vi.mocked(useSWRAuth)
+      .mockReturnValueOnce({
+        data: makeDashboardWithStudents(fourStudents),
+        isLoading: false,
+        error: null,
+        mutate: mockMutate,
+        isValidating: false,
+      } as never)
+      .mockReturnValue(swrNull);
+
+    render(<MeinRaumPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card").length).toBe(4);
+    });
+
+    const yearFilter = screen.getByTestId("filter-year");
+    fireEvent.change(yearFilter, { target: { value: "2" } });
+
+    await waitFor(() => {
+      const chip = screen.getByTestId("active-filter-year");
+      expect(chip).toBeInTheDocument();
+      expect(chip).toHaveTextContent("Jahr 2");
+    });
+  });
+
+  it("removes year filter when active filter chip is clicked", async () => {
+    vi.mocked(useSWRAuth)
+      .mockReturnValueOnce({
+        data: makeDashboardWithStudents(fourStudents),
+        isLoading: false,
+        error: null,
+        mutate: mockMutate,
+        isValidating: false,
+      } as never)
+      .mockReturnValue(swrNull);
+
+    render(<MeinRaumPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card").length).toBe(4);
+    });
+
+    // Set year filter
+    const yearFilter = screen.getByTestId("filter-year");
+    fireEvent.change(yearFilter, { target: { value: "1" } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-filter-year")).toBeInTheDocument();
+      expect(screen.getAllByTestId("student-card").length).toBe(2);
+    });
+
+    // Click chip to remove
+    fireEvent.click(screen.getByTestId("active-filter-year"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("active-filter-year"),
+      ).not.toBeInTheDocument();
+      expect(screen.getAllByTestId("student-card").length).toBe(4);
+    });
+  });
+
+  it("clears year filter when clear-all-filters is clicked", async () => {
+    vi.mocked(useSWRAuth)
+      .mockReturnValueOnce({
+        data: makeDashboardWithStudents(fourStudents),
+        isLoading: false,
+        error: null,
+        mutate: mockMutate,
+        isValidating: false,
+      } as never)
+      .mockReturnValue(swrNull);
+
+    render(<MeinRaumPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card").length).toBe(4);
+    });
+
+    // Set year filter
+    const yearFilter = screen.getByTestId("filter-year");
+    fireEvent.change(yearFilter, { target: { value: "1" } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-filter-year")).toBeInTheDocument();
+    });
+
+    // Click clear all
+    fireEvent.click(screen.getByTestId("clear-filters"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("active-filter-year"),
+      ).not.toBeInTheDocument();
+      expect(screen.getAllByTestId("student-card").length).toBe(4);
+    });
+  });
+});

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -34,6 +34,7 @@ import { isAdmin, isCaregiver } from "~/lib/auth-utils";
 import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
 import { TrackingIndicators } from "~/components/students/tracking-indicators";
 import type { Student } from "~/lib/student-helpers";
+import { SCHOOL_YEAR_FILTER_OPTIONS } from "~/lib/student-helpers";
 import { UnclaimedRooms } from "~/components/active";
 import { SSEErrorBoundary } from "~/components/sse/SSEErrorBoundary";
 import { useSWRAuth } from "~/lib/swr";
@@ -119,11 +120,12 @@ interface BFFDashboardResponse {
 
 const GROUP_CARD_GRADIENT = "from-blue-50/80 to-cyan-100/80";
 
-/** Check if a student matches the current search and group filters */
+/** Check if a student matches the current search, group, and year filters */
 function matchesStudentFilters(
   student: StudentWithVisit,
   searchTerm: string,
   groupFilter: string,
+  yearFilter: string,
 ): boolean {
   if (searchTerm) {
     const searchLower = searchTerm.toLowerCase();
@@ -136,6 +138,11 @@ function matchesStudentFilters(
   if (groupFilter !== "all") {
     const studentGroupName = student.group_name ?? "Unbekannt";
     if (studentGroupName !== groupFilter) return false;
+  }
+  if (yearFilter !== "all") {
+    const yearMatch = /(\d)/.exec(student.school_class);
+    const studentYear = yearMatch ? yearMatch[1] : null;
+    if (studentYear !== yearFilter) return false;
   }
   return true;
 }
@@ -197,6 +204,7 @@ interface EmptyRoomsViewProps {
   searchTerm: string;
   setSearchTerm: (term: string) => void;
   setGroupFilter: (filter: string) => void;
+  setSelectedYear: (year: string) => void;
   filterConfigs: FilterConfig[];
   activeFilters: ActiveFilter[];
 }
@@ -209,6 +217,7 @@ function EmptyRoomsView({
   searchTerm,
   setSearchTerm,
   setGroupFilter,
+  setSelectedYear,
   filterConfigs,
   activeFilters,
 }: Readonly<EmptyRoomsViewProps>) {
@@ -236,6 +245,7 @@ function EmptyRoomsView({
         onClearAllFilters={() => {
           setSearchTerm("");
           setGroupFilter("all");
+          setSelectedYear("all");
         }}
       />
 
@@ -291,6 +301,7 @@ function MeinRaumPageContent() {
   const [students, setStudents] = useState<StudentWithVisit[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [groupFilter, setGroupFilter] = useState("all");
+  const [selectedYear, setSelectedYear] = useState("all");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -1107,7 +1118,8 @@ function MeinRaumPageContent() {
 
   // Apply filters to students (ensure students is an array)
   const filteredStudents = (Array.isArray(students) ? students : []).filter(
-    (student) => matchesStudentFilters(student, searchTerm, groupFilter),
+    (student) =>
+      matchesStudentFilters(student, searchTerm, groupFilter, selectedYear),
   );
 
   // Prepare filter configurations for PageHeaderWithSearch
@@ -1123,6 +1135,14 @@ function MeinRaumPageContent() {
 
     return [
       {
+        id: "year",
+        label: "Klassenstufe",
+        type: "buttons",
+        value: selectedYear,
+        onChange: (value) => setSelectedYear(value as string),
+        options: [...SCHOOL_YEAR_FILTER_OPTIONS],
+      },
+      {
         id: "group",
         label: "Gruppe",
         type: "dropdown",
@@ -1137,7 +1157,7 @@ function MeinRaumPageContent() {
         ],
       },
     ];
-  }, [groupFilter, students]);
+  }, [selectedYear, groupFilter, students]);
 
   // Prepare active filters for display
   const activeFilters: ActiveFilter[] = useMemo(() => {
@@ -1151,6 +1171,14 @@ function MeinRaumPageContent() {
       });
     }
 
+    if (selectedYear !== "all") {
+      filters.push({
+        id: "year",
+        label: `Jahr ${selectedYear}`,
+        onRemove: () => setSelectedYear("all"),
+      });
+    }
+
     if (groupFilter !== "all") {
       filters.push({
         id: "group",
@@ -1160,7 +1188,7 @@ function MeinRaumPageContent() {
     }
 
     return filters;
-  }, [searchTerm, groupFilter]);
+  }, [searchTerm, selectedYear, groupFilter]);
 
   if (status === "loading" || isLoading || hasAccess === null) {
     return <LoadingView />;
@@ -1182,6 +1210,7 @@ function MeinRaumPageContent() {
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
         setGroupFilter={setGroupFilter}
+        setSelectedYear={setSelectedYear}
         filterConfigs={filterConfigs}
         activeFilters={activeFilters}
       />
@@ -1427,6 +1456,7 @@ function MeinRaumPageContent() {
             onClearAllFilters={() => {
               setSearchTerm("");
               setGroupFilter("all");
+              setSelectedYear("all");
             }}
             actionButton={
               // Only show release button when user IS supervising Schulhof

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -140,7 +140,7 @@ function matchesStudentFilters(
     if (studentGroupName !== groupFilter) return false;
   }
   if (yearFilter !== "all") {
-    const yearMatch = /(\d)/.exec(student.school_class);
+    const yearMatch = /(\d+)/.exec(student.school_class);
     const studentYear = yearMatch ? yearMatch[1] : null;
     if (studentYear !== yearFilter) return false;
   }

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -34,7 +34,10 @@ import { isAdmin, isCaregiver } from "~/lib/auth-utils";
 import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
 import { TrackingIndicators } from "~/components/students/tracking-indicators";
 import type { Student } from "~/lib/student-helpers";
-import { SCHOOL_YEAR_FILTER_OPTIONS } from "~/lib/student-helpers";
+import {
+  SCHOOL_YEAR_FILTER_OPTIONS,
+  getSchoolYear,
+} from "~/lib/student-helpers";
 import { UnclaimedRooms } from "~/components/active";
 import { SSEErrorBoundary } from "~/components/sse/SSEErrorBoundary";
 import { useSWRAuth } from "~/lib/swr";
@@ -140,8 +143,7 @@ function matchesStudentFilters(
     if (studentGroupName !== groupFilter) return false;
   }
   if (yearFilter !== "all") {
-    const yearMatch = /(\d+)/.exec(student.school_class);
-    const studentYear = yearMatch ? yearMatch[1] : null;
+    const studentYear = getSchoolYear(student.school_class);
     if (studentYear !== yearFilter) return false;
   }
   return true;

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -174,6 +174,8 @@ const mockStudents = [
     school_class: "1a",
     group_name: "Gruppe A",
     current_location: "Raum 101",
+    pickup_time: "15:30",
+    has_full_access: true,
   },
   {
     id: "2",
@@ -182,6 +184,7 @@ const mockStudents = [
     school_class: "2b",
     group_name: "Gruppe B",
     current_location: "Zuhause",
+    has_full_access: true,
   },
   {
     id: "3",
@@ -190,6 +193,8 @@ const mockStudents = [
     school_class: "1a",
     group_name: "Gruppe A",
     current_location: "Unterwegs",
+    pickup_time: "16:00",
+    has_full_access: true,
   },
   {
     id: "4",
@@ -198,6 +203,7 @@ const mockStudents = [
     school_class: "3c",
     group_name: "Gruppe C",
     current_location: "Schulhof",
+    has_full_access: true,
   },
 ];
 
@@ -1029,6 +1035,179 @@ describe("StudentSearchPage", () => {
           screen.queryByTestId("active-filter-group"),
         ).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe("Pickup Time Filtering", () => {
+    it("filters students by specific pickup time", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Max")).toBeInTheDocument();
+      });
+
+      // Filter by 15:30 — only Max has this pickup time
+      const pickupFilter = screen.getByTestId("filter-pickupTime");
+      fireEvent.change(pickupFilter, { target: { value: "15:30" } });
+
+      await waitFor(() => {
+        expect(screen.getByText("Max")).toBeInTheDocument();
+        expect(screen.queryByText("Anna")).not.toBeInTheDocument();
+        expect(screen.queryByText("Tom")).not.toBeInTheDocument();
+        expect(screen.queryByText("Lisa")).not.toBeInTheDocument();
+      });
+    });
+
+    it("filters students with 'none' to show only students without pickup time", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Max")).toBeInTheDocument();
+      });
+
+      // Filter by "none" — Anna and Lisa have no pickup_time
+      const pickupFilter = screen.getByTestId("filter-pickupTime");
+      fireEvent.change(pickupFilter, { target: { value: "none" } });
+
+      await waitFor(() => {
+        // Anna has no pickup_time and has_full_access=true
+        expect(screen.getByText("Anna")).toBeInTheDocument();
+        // Lisa has no pickup_time and has_full_access=true
+        expect(screen.getByText("Lisa")).toBeInTheDocument();
+        // Max and Tom have pickup_time set, so they should be filtered out
+        expect(screen.queryByText("Max")).not.toBeInTheDocument();
+        expect(screen.queryByText("Tom")).not.toBeInTheDocument();
+      });
+    });
+
+    it("hides redacted students (has_full_access=false) when pickup time filter is active", async () => {
+      // Create mock students where one has has_full_access=false
+      const studentsWithRedacted = [
+        {
+          id: "10",
+          first_name: "Visible",
+          second_name: "Student",
+          school_class: "1a",
+          group_name: "Gruppe A",
+          current_location: "Raum 101",
+          has_full_access: true,
+        },
+        {
+          id: "11",
+          first_name: "Redacted",
+          second_name: "Student",
+          school_class: "1a",
+          group_name: "Gruppe A",
+          current_location: "Raum 102",
+          has_full_access: false,
+        },
+      ];
+
+      const swrModule = await import("~/lib/swr");
+      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+        data: { students: studentsWithRedacted },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Visible")).toBeInTheDocument();
+        expect(screen.getByText("Redacted")).toBeInTheDocument();
+      });
+
+      // Apply "none" pickup time filter — redacted student should be excluded (GDPR)
+      const pickupFilter = screen.getByTestId("filter-pickupTime");
+      fireEvent.change(pickupFilter, { target: { value: "none" } });
+
+      await waitFor(() => {
+        expect(screen.getByText("Visible")).toBeInTheDocument();
+        // Redacted student must NOT appear — has_full_access=false means we
+        // can't know their pickup status, so they're excluded from filtering
+        expect(screen.queryByText("Redacted")).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows active filter chips with correct labels and clears via chip click or clear-all", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-pickupTime")).toBeInTheDocument();
+      });
+
+      const pickupFilter = screen.getByTestId("filter-pickupTime");
+
+      // Verify "Keine Abholzeit" chip label for "none"
+      fireEvent.change(pickupFilter, { target: { value: "none" } });
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("active-filter-pickupTime"),
+        ).toHaveTextContent("Keine Abholzeit");
+      });
+
+      // Switch to specific time — verify chip label and clear-all
+      fireEvent.change(pickupFilter, { target: { value: "15:30" } });
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("active-filter-pickupTime"),
+        ).toHaveTextContent("Abholzeit 15:30 Uhr");
+      });
+
+      // Clear all filters
+      fireEvent.click(screen.getByTestId("clear-filters"));
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-pickupTime")).toHaveValue("all");
+        expect(
+          screen.queryByTestId("active-filter-pickupTime"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("displays pickup time on student cards when present", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        // Max has pickup_time="15:30"
+        expect(screen.getByText("Max")).toBeInTheDocument();
+      });
+
+      // Verify pickup time text appears for students with pickup_time
+      await waitFor(() => {
+        expect(screen.getByText("Abholzeit: 15:30 Uhr")).toBeInTheDocument();
+        expect(screen.getByText("Abholzeit: 16:00 Uhr")).toBeInTheDocument();
+      });
+    });
+
+    it("does not display pickup time row when student has no pickup_time", async () => {
+      // Use only one student without pickup_time
+      const studentsNoPickup = [
+        {
+          id: "20",
+          first_name: "NoPickup",
+          second_name: "Student",
+          school_class: "2a",
+          group_name: "Gruppe A",
+          current_location: "Raum 101",
+          has_full_access: true,
+        },
+      ];
+
+      const swrModule = await import("~/lib/swr");
+      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+        data: { students: studentsNoPickup },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("NoPickup")).toBeInTheDocument();
+      });
+
+      // No "Abholzeit:" text should appear
+      expect(screen.queryByText(/Abholzeit:/)).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -138,15 +138,19 @@ vi.mock("~/lib/location-helper", () => ({
 }));
 
 // Mock student-helpers
-vi.mock("~/lib/student-helpers", () => ({
-  SCHOOL_YEAR_FILTER_OPTIONS: [
-    { value: "all", label: "Alle" },
-    { value: "1", label: "1" },
-    { value: "2", label: "2" },
-    { value: "3", label: "3" },
-    { value: "4", label: "4" },
-  ],
-}));
+vi.mock("~/lib/student-helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/lib/student-helpers")>();
+  return {
+    ...actual,
+    SCHOOL_YEAR_FILTER_OPTIONS: [
+      { value: "all", label: "Alle" },
+      { value: "1", label: "1" },
+      { value: "2", label: "2" },
+      { value: "3", label: "3" },
+      { value: "4", label: "4" },
+    ],
+  };
+});
 
 // Mock SSE hook
 vi.mock("~/lib/hooks/use-sse", () => ({

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -19,7 +19,10 @@ import {
   isSchoolyardLocation,
   isTransitLocation,
 } from "~/lib/location-helper";
-import { SCHOOL_YEAR_FILTER_OPTIONS } from "~/lib/student-helpers";
+import {
+  SCHOOL_YEAR_FILTER_OPTIONS,
+  getSchoolYear,
+} from "~/lib/student-helpers";
 import {
   StudentCard,
   SchoolClassIcon,
@@ -359,8 +362,7 @@ function SearchPageContent() {
 
     // Apply year filter - extract year from school_class (e.g., "Klasse 3a" → year 3)
     if (selectedYear !== "all") {
-      const yearMatch = /(\d)/.exec(student.school_class);
-      const studentYear = yearMatch ? yearMatch[1] : null;
+      const studentYear = getSchoolYear(student.school_class);
       if (studentYear !== selectedYear) {
         return false;
       }

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -123,6 +123,7 @@ function SearchPageContent() {
       return await studentService.getStudents({
         search: debouncedSearchTerm,
         groupId: selectedGroup,
+        includePickupTimes: true,
       });
     },
     {

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -24,6 +24,7 @@ import {
   StudentCard,
   SchoolClassIcon,
   GroupIcon,
+  PickupTimeIcon,
   StudentInfoRow,
 } from "~/components/students/student-card";
 import { useSWRAuth, useImmutableSWR } from "~/lib/swr";
@@ -67,6 +68,7 @@ function SearchPageContent() {
   const [attendanceFilter, setAttendanceFilter] = useState(
     initialAttendanceFilter,
   );
+  const [pickupTimeFilter, setPickupTimeFilter] = useState("all");
 
   // OGS group tracking via shared BFF endpoint with SWR caching
   // This eliminates 2 separate API calls with 2 auth() calls each
@@ -221,8 +223,35 @@ function SearchPageContent() {
           { value: "schulhof", label: "Schulhof" },
         ],
       },
+      {
+        id: "pickupTime",
+        label: "Abholzeit",
+        type: "dropdown",
+        value: pickupTimeFilter,
+        onChange: (value) => setPickupTimeFilter(value as string),
+        options: [
+          { value: "all", label: "Alle Abholzeiten" },
+          ...Array.from(
+            new Set(
+              (studentsData?.students ?? [])
+                .map((s) => s.pickup_time)
+                .filter((t): t is string => !!t),
+            ),
+          )
+            .sort()
+            .map((time) => ({ value: time, label: `${time} Uhr` })),
+          { value: "none", label: "Keine Abholzeit" },
+        ],
+      },
     ],
-    [selectedYear, selectedGroup, attendanceFilter, groups],
+    [
+      selectedYear,
+      selectedGroup,
+      attendanceFilter,
+      pickupTimeFilter,
+      groups,
+      studentsData,
+    ],
   );
 
   // Prepare active filters for display
@@ -269,8 +298,26 @@ function SearchPageContent() {
       });
     }
 
+    if (pickupTimeFilter !== "all") {
+      filters.push({
+        id: "pickupTime",
+        label:
+          pickupTimeFilter === "none"
+            ? "Keine Abholzeit"
+            : `Abholzeit ${pickupTimeFilter} Uhr`,
+        onRemove: () => setPickupTimeFilter("all"),
+      });
+    }
+
     return filters;
-  }, [searchTerm, selectedYear, selectedGroup, attendanceFilter, groups]);
+  }, [
+    searchTerm,
+    selectedYear,
+    selectedGroup,
+    attendanceFilter,
+    pickupTimeFilter,
+    groups,
+  ]);
 
   // Apply additional client-side filtering for attendance statuses and year
   const filteredStudents = students.filter((student) => {
@@ -318,6 +365,17 @@ function SearchPageContent() {
       }
     }
 
+    // Apply pickup time filter (skip redacted students — missing pickup_time
+    // due to has_full_access=false is not the same as "no schedule")
+    if (pickupTimeFilter !== "all") {
+      if (student.has_full_access === false) return false;
+      if (pickupTimeFilter === "none") {
+        if (student.pickup_time) return false;
+      } else {
+        if (student.pickup_time !== pickupTimeFilter) return false;
+      }
+    }
+
     return true;
   });
 
@@ -362,6 +420,7 @@ function SearchPageContent() {
           setSelectedGroup("");
           setSelectedYear("all");
           setAttendanceFilter("all");
+          setPickupTimeFilter("all");
         }}
       />
 
@@ -469,6 +528,11 @@ function SearchPageContent() {
                       {student.group_name && (
                         <StudentInfoRow icon={<GroupIcon />}>
                           Gruppe: {student.group_name}
+                        </StudentInfoRow>
+                      )}
+                      {student.pickup_time && (
+                        <StudentInfoRow icon={<PickupTimeIcon />}>
+                          Abholzeit: {student.pickup_time} Uhr
                         </StudentInfoRow>
                       )}
                     </>

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -239,7 +239,7 @@ function SearchPageContent() {
                 .filter((t): t is string => !!t),
             ),
           )
-            .sort()
+            .sort((a, b) => a.localeCompare(b))
             .map((time) => ({ value: time, label: `${time} Uhr` })),
           { value: "none", label: "Keine Abholzeit" },
         ],
@@ -372,8 +372,8 @@ function SearchPageContent() {
       if (student.has_full_access === false) return false;
       if (pickupTimeFilter === "none") {
         if (student.pickup_time) return false;
-      } else {
-        if (student.pickup_time !== pickupTimeFilter) return false;
+      } else if (student.pickup_time !== pickupTimeFilter) {
+        return false;
       }
     }
 

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -785,6 +785,53 @@ describe("api.ts helper functions", () => {
         restore();
       }
     });
+
+    it("appends include_pickup_times=true when includePickupTimes is true", async () => {
+      const { fetchWithRetry } = await import("./api-helpers");
+      vi.mocked(fetchWithRetry).mockResolvedValue({
+        data: [],
+        response: new Response(),
+      });
+
+      const { studentService } = await import("./api");
+
+      const restore = setupBrowserEnv();
+      try {
+        await studentService.getStudents({
+          search: "Test",
+          includePickupTimes: true,
+          token: "test-token",
+        });
+
+        const callUrl = vi.mocked(fetchWithRetry).mock.calls[0]?.[0];
+        expect(callUrl).toContain("include_pickup_times=true");
+      } finally {
+        restore();
+      }
+    });
+
+    it("omits include_pickup_times when includePickupTimes is falsy", async () => {
+      const { fetchWithRetry } = await import("./api-helpers");
+      vi.mocked(fetchWithRetry).mockResolvedValue({
+        data: [],
+        response: new Response(),
+      });
+
+      const { studentService } = await import("./api");
+
+      const restore = setupBrowserEnv();
+      try {
+        await studentService.getStudents({
+          search: "Test",
+          token: "test-token",
+        });
+
+        const callUrl = vi.mocked(fetchWithRetry).mock.calls[0]?.[0];
+        expect(callUrl).not.toContain("include_pickup_times");
+      } finally {
+        restore();
+      }
+    });
   });
 
   describe("studentService.getStudent", () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -175,6 +175,7 @@ function buildStudentQueryParams(filters?: {
   groupId?: string;
   page?: number;
   pageSize?: number;
+  includePickupTimes?: boolean;
 }): URLSearchParams {
   const params = new URLSearchParams();
   if (filters?.search) params.append("search", filters.search);
@@ -184,6 +185,8 @@ function buildStudentQueryParams(filters?: {
   if (filters?.page) params.append("page", filters.page.toString());
   if (filters?.pageSize)
     params.append("page_size", filters.pageSize.toString());
+  if (filters?.includePickupTimes)
+    params.append("include_pickup_times", "true");
   return params;
 }
 
@@ -740,6 +743,7 @@ export const studentService = {
     groupId?: string;
     page?: number;
     pageSize?: number;
+    includePickupTimes?: boolean;
     token?: string; // Optional: pass token to skip getSession()
   }): Promise<StudentsResult> => {
     const params = buildStudentQueryParams(filters);

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -56,6 +56,7 @@ export interface BackendStudent {
   health_info?: string;
   supervisor_notes?: string;
   pickup_status?: string;
+  pickup_time?: string; // Today's effective pickup time (HH:MM)
   has_full_access?: boolean;
   created_at: string;
   updated_at: string;
@@ -157,6 +158,7 @@ export interface Student {
   health_info?: string;
   supervisor_notes?: string;
   pickup_status?: string;
+  pickup_time?: string; // Today's effective pickup time (HH:MM)
 }
 
 // Mapping functions
@@ -200,6 +202,7 @@ export function mapStudentResponse(
     health_info: backendStudent.health_info,
     supervisor_notes: backendStudent.supervisor_notes,
     pickup_status: backendStudent.pickup_status,
+    pickup_time: backendStudent.pickup_time,
     has_full_access: backendStudent.has_full_access,
   };
 

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -23,6 +23,15 @@ export const SCHOOL_YEAR_FILTER_OPTIONS = [
   { value: "4", label: "4" },
 ] as const;
 
+/**
+ * Extract the school year (Klassenstufe) from a school_class string.
+ * E.g. "Klasse 3a" → "3", "2b" → "2", "unknown" → null
+ */
+export function getSchoolYear(schoolClass: string): string | null {
+  const match = /(\d+)/.exec(schoolClass);
+  return match ? match[1]! : null;
+}
+
 // Scheduled checkout information
 export interface ScheduledCheckoutInfo {
   id: number;


### PR DESCRIPTION
## Summary
- Adds Abholzeit dropdown filter and displays pickup times on student cards in Kindersuche (backend exposes today's effective pickup time per student via bulk query)
- Adds Klassenstufe filter buttons (1-4) to Aktive Aufsichten to filter students by year level
- Both features are GDPR-safe — pickup times only shown for students the user has full access to

## Test plan
- [ ] Log in as admin → Kindersuche → pickup times visible on student cards
- [ ] Filter by a specific Abholzeit → only matching students shown
- [ ] Filter by "Keine Abholzeit" → only students without pickup schedule shown
- [ ] Log in as Betreuer → pickup times hidden for students outside own group
- [ ] Aktive Aufsichten → Klassenstufe filter buttons (1-4) visible
- [ ] Click a year → only students from that Klassenstufe shown
- [ ] Clear filters → all students visible again
- [ ] `cd backend && go test ./api/students/... -v` passes
- [ ] `cd frontend && pnpm run check` passes