### PR TITLE
feat: always show pickup time with urgency, exceptions, and notes

### DIFF
--- a/backend/api/students/enrich_pickup_times_test.go
+++ b/backend/api/students/enrich_pickup_times_test.go
@@ -127,6 +127,126 @@ func TestEnrichWithPickupTimes_NoPickupTime(t *testing.T) {
 	assert.Nil(t, responses[0].PickupTime, "should be nil when no pickup time is set")
 }
 
+func TestEnrichWithPickupTimes_ExceptionWithNotes(t *testing.T) {
+	now := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+	pickupAt := time.Date(2026, 4, 14, 14, 0, 0, 0, time.UTC)
+
+	mock := &mockPickupScheduleService{
+		bulkResult: map[int64]*scheduleService.EffectivePickupTime{
+			100: {
+				PickupTime:  &pickupAt,
+				IsException: true,
+				Notes:       "Arzttermin",
+				DayNotes: []scheduleService.NoteData{
+					{ID: 1, Content: "Früher abholen"},
+				},
+			},
+		},
+	}
+
+	rs := &Resource{
+		PickupScheduleService: mock,
+		Logger:                slog.Default(),
+	}
+
+	responses := []StudentResponse{
+		{ID: 100, HasFullAccess: true},
+	}
+
+	rs.enrichWithPickupTimes(context.Background(), responses, []int64{100}, now)
+
+	assert.NotNil(t, responses[0].PickupTime)
+	assert.Equal(t, "14:00", *responses[0].PickupTime)
+	assert.True(t, responses[0].PickupIsException, "should be marked as exception")
+	assert.Equal(t, "Arzttermin, Früher abholen", responses[0].PickupNotes, "should combine notes and day notes")
+}
+
+func TestEnrichWithPickupTimes_ExceptionWithoutPickupTime(t *testing.T) {
+	now := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+
+	mock := &mockPickupScheduleService{
+		bulkResult: map[int64]*scheduleService.EffectivePickupTime{
+			100: {
+				PickupTime:  nil,
+				IsException: true,
+				Notes:       "Ganztägig abwesend",
+			},
+		},
+	}
+
+	rs := &Resource{
+		PickupScheduleService: mock,
+		Logger:                slog.Default(),
+	}
+
+	responses := []StudentResponse{
+		{ID: 100, HasFullAccess: true},
+	}
+
+	rs.enrichWithPickupTimes(context.Background(), responses, []int64{100}, now)
+
+	assert.Nil(t, responses[0].PickupTime, "should be nil when exception has no pickup time")
+	assert.True(t, responses[0].PickupIsException, "should be marked as exception")
+	assert.Equal(t, "Ganztägig abwesend", responses[0].PickupNotes)
+}
+
+func TestBuildPickupNotes(t *testing.T) {
+	tests := []struct {
+		name     string
+		ept      *scheduleService.EffectivePickupTime
+		expected string
+	}{
+		{
+			name:     "empty when no notes",
+			ept:      &scheduleService.EffectivePickupTime{},
+			expected: "",
+		},
+		{
+			name:     "notes only",
+			ept:      &scheduleService.EffectivePickupTime{Notes: "Arzttermin"},
+			expected: "Arzttermin",
+		},
+		{
+			name: "day notes only",
+			ept: &scheduleService.EffectivePickupTime{
+				DayNotes: []scheduleService.NoteData{
+					{ID: 1, Content: "Früher abholen"},
+				},
+			},
+			expected: "Früher abholen",
+		},
+		{
+			name: "notes and day notes combined",
+			ept: &scheduleService.EffectivePickupTime{
+				Notes: "Arzttermin",
+				DayNotes: []scheduleService.NoteData{
+					{ID: 1, Content: "Früher abholen"},
+					{ID: 2, Content: "Oma holt ab"},
+				},
+			},
+			expected: "Arzttermin, Früher abholen, Oma holt ab",
+		},
+		{
+			name: "skips empty day note content",
+			ept: &scheduleService.EffectivePickupTime{
+				Notes: "Termin",
+				DayNotes: []scheduleService.NoteData{
+					{ID: 1, Content: ""},
+					{ID: 2, Content: "Wichtig"},
+				},
+			},
+			expected: "Termin, Wichtig",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildPickupNotes(tt.ept)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestEnrichWithPickupTimes_ServiceError(t *testing.T) {
 	now := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
 

--- a/backend/api/students/response_helpers.go
+++ b/backend/api/students/response_helpers.go
@@ -3,12 +3,14 @@ package students
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/models/education"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	activeService "github.com/moto-nrw/project-phoenix/services/active"
+	"github.com/moto-nrw/project-phoenix/services/schedule"
 	userService "github.com/moto-nrw/project-phoenix/services/users"
 )
 
@@ -307,9 +309,27 @@ func (rs *Resource) enrichWithPickupTimes(ctx context.Context, responses []Stude
 		if !responses[i].HasFullAccess {
 			continue
 		}
-		if ept, ok := pickupTimes[responses[i].ID]; ok && ept.PickupTime != nil {
-			formatted := ept.PickupTime.Format("15:04")
-			responses[i].PickupTime = &formatted
+		if ept, ok := pickupTimes[responses[i].ID]; ok {
+			if ept.PickupTime != nil {
+				formatted := ept.PickupTime.Format("15:04")
+				responses[i].PickupTime = &formatted
+			}
+			responses[i].PickupIsException = ept.IsException
+			responses[i].PickupNotes = buildPickupNotes(ept)
 		}
 	}
+}
+
+// buildPickupNotes combines exception reason and day notes into a single string.
+func buildPickupNotes(ept *schedule.EffectivePickupTime) string {
+	var parts []string
+	if ept.Notes != "" {
+		parts = append(parts, ept.Notes)
+	}
+	for _, n := range ept.DayNotes {
+		if n.Content != "" {
+			parts = append(parts, n.Content)
+		}
+	}
+	return strings.Join(parts, ", ")
 }

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -13,32 +13,34 @@ const (
 
 // StudentResponse represents a student response
 type StudentResponse struct {
-	ID              int64      `json:"id"`
-	PersonID        int64      `json:"person_id"`
-	FirstName       string     `json:"first_name"`
-	LastName        string     `json:"last_name"`
-	TagID           string     `json:"tag_id,omitempty"`
-	Birthday        string     `json:"birthday,omitempty"` // Date in YYYY-MM-DD format
-	SchoolClass     string     `json:"school_class"`
-	Location        string     `json:"current_location"`
-	LocationSince   *time.Time `json:"location_since,omitempty"` // When student entered current location
-	GuardianName    string     `json:"guardian_name,omitempty"`
-	GuardianContact string     `json:"guardian_contact,omitempty"`
-	GuardianEmail   string     `json:"guardian_email,omitempty"`
-	GuardianPhone   string     `json:"guardian_phone,omitempty"`
-	GroupID         int64      `json:"group_id,omitempty"`
-	GroupName       string     `json:"group_name,omitempty"`
-	ExtraInfo       string     `json:"extra_info,omitempty"`
-	HealthInfo      string     `json:"health_info,omitempty"`
-	SupervisorNotes string     `json:"supervisor_notes,omitempty"`
-	PickupStatus    string     `json:"pickup_status,omitempty"`
-	PickupTime      *string    `json:"pickup_time,omitempty"` // Today's effective pickup time (HH:MM)
-	Bus             bool       `json:"bus"`
-	Sick            bool       `json:"sick"`
-	SickSince       *time.Time `json:"sick_since,omitempty"`
-	HasFullAccess   bool       `json:"has_full_access"`
-	CreatedAt       time.Time  `json:"created_at"`
-	UpdatedAt       time.Time  `json:"updated_at"`
+	ID                int64      `json:"id"`
+	PersonID          int64      `json:"person_id"`
+	FirstName         string     `json:"first_name"`
+	LastName          string     `json:"last_name"`
+	TagID             string     `json:"tag_id,omitempty"`
+	Birthday          string     `json:"birthday,omitempty"` // Date in YYYY-MM-DD format
+	SchoolClass       string     `json:"school_class"`
+	Location          string     `json:"current_location"`
+	LocationSince     *time.Time `json:"location_since,omitempty"` // When student entered current location
+	GuardianName      string     `json:"guardian_name,omitempty"`
+	GuardianContact   string     `json:"guardian_contact,omitempty"`
+	GuardianEmail     string     `json:"guardian_email,omitempty"`
+	GuardianPhone     string     `json:"guardian_phone,omitempty"`
+	GroupID           int64      `json:"group_id,omitempty"`
+	GroupName         string     `json:"group_name,omitempty"`
+	ExtraInfo         string     `json:"extra_info,omitempty"`
+	HealthInfo        string     `json:"health_info,omitempty"`
+	SupervisorNotes   string     `json:"supervisor_notes,omitempty"`
+	PickupStatus      string     `json:"pickup_status,omitempty"`
+	PickupTime        *string    `json:"pickup_time,omitempty"`         // Today's effective pickup time (HH:MM)
+	PickupIsException bool       `json:"pickup_is_exception,omitempty"` // True if today's pickup time is an exception
+	PickupNotes       string     `json:"pickup_notes,omitempty"`        // Exception reason or schedule notes
+	Bus               bool       `json:"bus"`
+	Sick              bool       `json:"sick"`
+	SickSince         *time.Time `json:"sick_since,omitempty"`
+	HasFullAccess     bool       `json:"has_full_access"`
+	CreatedAt         time.Time  `json:"created_at"`
+	UpdatedAt         time.Time  `json:"updated_at"`
 }
 
 // SupervisorContact represents contact information for a group supervisor

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
@@ -140,6 +140,26 @@ vi.mock("~/components/ui/empty-student-results", () => ({
   EmptyStudentResults: () => <div data-testid="empty-results">No results</div>,
 }));
 
+// Mock location-helper
+vi.mock("~/lib/location-helper", () => ({
+  LOCATION_STATUSES: { PRESENT: "Anwesend" },
+  isHomeLocation: vi.fn(() => false),
+  isSchoolyardLocation: vi.fn(() => false),
+  isTransitLocation: vi.fn(() => false),
+  parseLocation: vi.fn(() => ({ room: "Room 1", status: "Anwesend" })),
+}));
+
+// Mock pickup-helpers
+vi.mock("~/lib/pickup-helpers", () => ({
+  useMinuteClock: () => new Date("2026-01-15T12:00:00"),
+  combinePickupNotes: () => undefined,
+}));
+
+// Mock pickup-schedule-api
+vi.mock("~/lib/pickup-schedule-api", () => ({
+  fetchBulkPickupTimes: vi.fn(() => Promise.resolve(new Map())),
+}));
+
 // Mock StudentCard components
 vi.mock("~/components/students/student-card", () => ({
   StudentCard: ({
@@ -158,6 +178,30 @@ vi.mock("~/components/students/student-card", () => ({
   ),
   SchoolClassIcon: () => <span data-testid="school-class-icon" />,
   GroupIcon: () => <span data-testid="group-icon" />,
+  PickupTimeRow: ({
+    pickupTime,
+    isException,
+    notes,
+    isHome,
+  }: {
+    pickupTime?: string;
+    isException: boolean;
+    notes?: string;
+    isHome: boolean;
+    now: Date;
+  }) => (
+    <div
+      data-testid="pickup-time-row"
+      data-pickup-time={pickupTime ?? ""}
+      data-is-exception={String(isException)}
+      data-is-home={String(isHome)}
+    >
+      {pickupTime && <>Abholzeit: {pickupTime} Uhr</>}
+      {!pickupTime && isException && (notes || "Abwesend")}
+      {!pickupTime && !isException && <>Abholzeit: —</>}
+      {notes && <span>({notes})</span>}
+    </div>
+  ),
 }));
 
 // Mock SWR hook

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -27,7 +27,12 @@ import {
   StudentInfoRow,
   SchoolClassIcon,
   GroupIcon,
+  PickupTimeRow,
 } from "~/components/students/student-card";
+import { fetchBulkPickupTimes } from "~/lib/pickup-schedule-api";
+import type { BulkPickupTime } from "~/lib/pickup-schedule-api";
+import { isHomeLocation } from "~/lib/location-helper";
+import { useMinuteClock, combinePickupNotes } from "~/lib/pickup-helpers";
 import { createLogger } from "~/lib/logger";
 import { activeService } from "~/lib/active-api";
 import { isAdmin, isCaregiver } from "~/lib/auth-utils";
@@ -945,6 +950,19 @@ function MeinRaumPageContent() {
     { keepPreviousData: true, revalidateOnFocus: false },
   );
 
+  // Current time for pickup urgency calculation (updates every minute)
+  const now = useMinuteClock();
+
+  // Pickup times: fetch when student list or date changes
+  const todayKey = now.toISOString().slice(0, 10);
+  const { data: pickupTimesData } = useSWRAuth<Map<string, BulkPickupTime>>(
+    trackingStudentIds.length > 0 && currentRoomId
+      ? `pickup-supervisions-${todayKey}-${trackingStudentIds.join(",")}`
+      : null,
+    async () => fetchBulkPickupTimes(trackingStudentIds),
+    { keepPreviousData: true, revalidateOnFocus: false },
+  );
+
   // Handle dashboard error
   useEffect(() => {
     if (dashboardError) {
@@ -1255,52 +1273,70 @@ function MeinRaumPageContent() {
       return (
         <div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
-            {filteredStudents.map((student) => (
-              <StudentCard
-                key={student.id}
-                studentId={student.id}
-                firstName={student.first_name}
-                lastName={student.second_name}
-                gradient={GROUP_CARD_GRADIENT}
-                onClick={() =>
-                  router.push(
-                    `/students/${student.id}?from=/active-supervisions`,
-                  )
-                }
-                locationBadge={
-                  <LocationBadge
-                    student={student}
-                    displayMode="contextAware"
-                    userGroups={myGroupIds}
-                    groupRooms={myGroupRooms}
-                    variant="modern"
-                    size="md"
-                  />
-                }
-                extraContent={
-                  <>
-                    {student.school_class && (
-                      <StudentInfoRow icon={<SchoolClassIcon />}>
-                        Klasse {student.school_class}
-                      </StudentInfoRow>
-                    )}
-                    {student.group_name && (
-                      <StudentInfoRow icon={<GroupIcon />}>
-                        Gruppe: {student.group_name}
-                      </StudentInfoRow>
-                    )}
-                  </>
-                }
-                trackingIndicators={
-                  trackingData?.labels.length ? (
-                    <TrackingIndicators
-                      labels={trackingData.labels}
-                      results={trackingData.results[student.id] ?? []}
+            {filteredStudents.map((student) => {
+              const studentPickup = pickupTimesData?.get(student.id.toString());
+
+              return (
+                <StudentCard
+                  key={student.id}
+                  studentId={student.id}
+                  firstName={student.first_name}
+                  lastName={student.second_name}
+                  gradient={GROUP_CARD_GRADIENT}
+                  onClick={() =>
+                    router.push(
+                      `/students/${student.id}?from=/active-supervisions`,
+                    )
+                  }
+                  locationBadge={
+                    <LocationBadge
+                      student={student}
+                      displayMode="contextAware"
+                      userGroups={myGroupIds}
+                      groupRooms={myGroupRooms}
+                      variant="modern"
+                      size="md"
                     />
-                  ) : undefined
-                }
-              />
-            ))}
+                  }
+                  extraContent={
+                    <>
+                      {student.school_class && (
+                        <StudentInfoRow icon={<SchoolClassIcon />}>
+                          Klasse {student.school_class}
+                        </StudentInfoRow>
+                      )}
+                      {student.group_name && (
+                        <StudentInfoRow icon={<GroupIcon />}>
+                          Gruppe: {student.group_name}
+                        </StudentInfoRow>
+                      )}
+                      <PickupTimeRow
+                        pickupTime={studentPickup?.pickupTime}
+                        isException={studentPickup?.isException ?? false}
+                        notes={
+                          studentPickup
+                            ? combinePickupNotes(
+                                studentPickup.notes,
+                                studentPickup.dayNotes,
+                              )
+                            : undefined
+                        }
+                        isHome={isHomeLocation(student.current_location)}
+                        now={now}
+                      />
+                    </>
+                  }
+                  trackingIndicators={
+                    trackingData?.labels.length ? (
+                      <TrackingIndicators
+                        labels={trackingData.labels}
+                        results={trackingData.results[student.id] ?? []}
+                      />
+                    ) : undefined
+                  }
+                />
+              );
+            })}
           </div>
         </div>
       );

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.test.ts
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import {
-  getPickupUrgency,
   isStudentInGroupRoom,
   matchesSearchFilter,
   matchesAttendanceFilter,
@@ -32,42 +31,6 @@ function makeGroup(overrides: Partial<OGSGroup> = {}): OGSGroup {
     ...overrides,
   };
 }
-
-describe("getPickupUrgency", () => {
-  it("returns 'none' when pickupTimeStr is undefined", () => {
-    expect(getPickupUrgency(undefined, new Date())).toBe("none");
-  });
-
-  it("returns 'overdue' when pickup time is in the past", () => {
-    const now = new Date("2025-01-15T15:00:00");
-    expect(getPickupUrgency("14:30", now)).toBe("overdue");
-  });
-
-  it("returns 'soon' when pickup time is within 30 minutes", () => {
-    const now = new Date("2025-01-15T14:45:00");
-    expect(getPickupUrgency("15:00", now)).toBe("soon");
-  });
-
-  it("returns 'soon' when pickup time is exactly now (0 minutes diff)", () => {
-    const now = new Date("2025-01-15T15:00:00");
-    expect(getPickupUrgency("15:00", now)).toBe("soon");
-  });
-
-  it("returns 'normal' when pickup time is more than 30 minutes away", () => {
-    const now = new Date("2025-01-15T13:00:00");
-    expect(getPickupUrgency("15:00", now)).toBe("normal");
-  });
-
-  it("returns 'soon' at exactly 30 minutes before pickup", () => {
-    const now = new Date("2025-01-15T14:30:00");
-    expect(getPickupUrgency("15:00", now)).toBe("soon");
-  });
-
-  it("returns 'normal' at 31 minutes before pickup", () => {
-    const now = new Date("2025-01-15T14:29:00");
-    expect(getPickupUrgency("15:00", now)).toBe("normal");
-  });
-});
 
 describe("isStudentInGroupRoom", () => {
   it("returns false when student has no current_location", () => {

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.ts
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.ts
@@ -18,29 +18,6 @@ export interface OGSGroup {
   viaSubstitution?: boolean;
 }
 
-// Pickup urgency constants and helper
-const PICKUP_URGENCY_SOON_MINUTES = 30;
-
-export type PickupUrgency = "overdue" | "soon" | "normal" | "none";
-
-export function getPickupUrgency(
-  pickupTimeStr: string | undefined,
-  now: Date,
-): PickupUrgency {
-  if (!pickupTimeStr) return "none";
-
-  const [hours, minutes] = pickupTimeStr.split(":").map(Number);
-  const pickupDate = new Date(now);
-  pickupDate.setHours(hours ?? 0, minutes ?? 0, 0, 0);
-
-  const diffMs = pickupDate.getTime() - now.getTime();
-  const diffMinutes = diffMs / 60000;
-
-  if (diffMinutes < 0) return "overdue";
-  if (diffMinutes <= PICKUP_URGENCY_SOON_MINUTES) return "soon";
-  return "normal";
-}
-
 export function isStudentInGroupRoom(
   student: Student,
   currentGroup?: OGSGroup | null,

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -240,8 +240,39 @@ vi.mock("~/components/students/student-card", () => ({
       {children}
     </div>
   ),
-  PickupTimeIcon: () => <span data-testid="pickup-time-icon">clock-gray</span>,
-  ExceptionIcon: () => <span data-testid="exception-icon">exception</span>,
+  renderPickupIcon: (urgency: string) => {
+    if (urgency === "overdue")
+      return <span data-testid="lucide-alert-triangle">alert</span>;
+    if (urgency === "soon")
+      return <span data-testid="lucide-clock">clock</span>;
+    return <span data-testid="pickup-time-icon">clock-gray</span>;
+  },
+  PickupTimeRow: ({
+    pickupTime,
+    isException,
+    notes,
+    isHome,
+  }: {
+    pickupTime?: string;
+    isException: boolean;
+    notes?: string;
+    isHome: boolean;
+    now: Date;
+  }) => {
+    return (
+      <div
+        data-testid="pickup-time-row"
+        data-pickup-time={pickupTime ?? ""}
+        data-is-exception={String(isException)}
+        data-is-home={String(isHome)}
+      >
+        {pickupTime && <>Abholzeit: {pickupTime} Uhr</>}
+        {!pickupTime && isException && (notes || "Abwesend")}
+        {!pickupTime && !isException && <>Abholzeit: —</>}
+        {notes && <span>({notes})</span>}
+      </div>
+    );
+  },
 }));
 
 // Mock pickup schedule API
@@ -2909,8 +2940,7 @@ describe("OGSGroupPage rendered pickup urgency", () => {
       } as never);
   }
 
-  it("renders pickup time with default gray icon when no urgency", async () => {
-    // Pickup far in the future (normal urgency) — frozen time is 14:00
+  it("passes pickup time props to PickupTimeRow", async () => {
     const pickupMap = new Map([
       ["1", { pickupTime: "23:59", isException: false }],
     ]);
@@ -2922,54 +2952,18 @@ describe("OGSGroupPage rendered pickup urgency", () => {
       expect(screen.getAllByTestId("student-card")).toHaveLength(3);
     });
 
-    // Should render pickup time text
+    // Should render pickup time text and pass correct props
     await waitFor(() => {
       expect(screen.getByText(/23:59 Uhr/)).toBeInTheDocument();
     });
-
-    // Should render default pickup time icon (gray clock from mock)
-    expect(screen.getByTestId("pickup-time-icon")).toBeInTheDocument();
+    const row = screen
+      .getAllByTestId("pickup-time-row")
+      .find((el) => el.dataset.pickupTime === "23:59");
+    expect(row).toBeDefined();
+    expect(row?.dataset.isException).toBe("false");
   });
 
-  it("renders pulsing orange clock when pickup is within 30 minutes", async () => {
-    // Frozen time is 14:00, so 14:15 is 15 minutes away → "soon"
-    const pickupMap = new Map([
-      ["1", { pickupTime: "14:15", isException: false }],
-    ]);
-    setupWithStudentsAndPickupTimes(pickupMap);
-
-    render(<OGSGroupPage />);
-
-    await waitFor(() => {
-      expect(screen.getAllByTestId("student-card")).toHaveLength(3);
-    });
-
-    // Should render lucide Clock icon (from mock)
-    await waitFor(() => {
-      expect(screen.getByTestId("lucide-clock")).toBeInTheDocument();
-    });
-  });
-
-  it("renders red alert triangle when pickup is overdue", async () => {
-    // Frozen time is 14:00, so 13:00 is 1 hour in the past → "overdue"
-    const pickupMap = new Map([
-      ["1", { pickupTime: "13:00", isException: false }],
-    ]);
-    setupWithStudentsAndPickupTimes(pickupMap);
-
-    render(<OGSGroupPage />);
-
-    await waitFor(() => {
-      expect(screen.getAllByTestId("student-card")).toHaveLength(3);
-    });
-
-    // Should render lucide AlertTriangle icon (from mock)
-    await waitFor(() => {
-      expect(screen.getByTestId("lucide-alert-triangle")).toBeInTheDocument();
-    });
-  });
-
-  it("renders exception icon when student has pickup exception", async () => {
+  it("passes exception flag and day notes to PickupTimeRow", async () => {
     const pickupMap = new Map([
       [
         "1",
@@ -2988,17 +2982,18 @@ describe("OGSGroupPage rendered pickup urgency", () => {
       expect(screen.getAllByTestId("student-card")).toHaveLength(3);
     });
 
-    // Exception icon should be used instead of urgency icon
+    // Exception flag and day note should be passed through
     await waitFor(() => {
-      expect(screen.getByTestId("exception-icon")).toBeInTheDocument();
+      expect(screen.getByText(/Arzttermin/)).toBeInTheDocument();
     });
-
-    // Day note should be displayed
-    expect(screen.getByText(/Arzttermin/)).toBeInTheDocument();
+    const row = screen
+      .getAllByTestId("pickup-time-row")
+      .find((el) => el.dataset.isException === "true");
+    expect(row).toBeDefined();
   });
 
-  it("does not show urgency icon for at-home students", async () => {
-    // Student 3 is "Zuhause" — should get no urgency even with overdue time
+  it("passes isHome=true to PickupTimeRow for at-home students", async () => {
+    // Student 3 is "Zuhause" — page should pass isHome=true
     const pickupMap = new Map([
       ["3", { pickupTime: "00:01", isException: false }],
     ]);
@@ -3012,15 +3007,46 @@ describe("OGSGroupPage rendered pickup urgency", () => {
       expect(screen.getAllByTestId("student-card")).toHaveLength(3);
     });
 
-    // At-home student with overdue time should get default gray icon, not alert triangle
+    // At-home student should have isHome=true passed to PickupTimeRow
     await waitFor(() => {
       expect(screen.getByText(/00:01 Uhr/)).toBeInTheDocument();
     });
-    // Should use PickupTimeIcon (default gray), not AlertTriangle
-    expect(screen.getByTestId("pickup-time-icon")).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("lucide-alert-triangle"),
-    ).not.toBeInTheDocument();
+    const row = screen
+      .getAllByTestId("pickup-time-row")
+      .find((el) => el.dataset.pickupTime === "00:01");
+    expect(row).toBeDefined();
+    expect(row?.dataset.isHome).toBe("true");
+  });
+
+  it("passes isHome=false to PickupTimeRow for present students", async () => {
+    // Student 1 is in "Raum 101" (not home) — page should pass isHome=false
+    const pickupMap = new Map([
+      ["1", { pickupTime: "14:00", isException: false }],
+      ["3", { pickupTime: "14:00", isException: false }],
+    ]);
+    setupWithStudentsAndPickupTimes(pickupMap, {
+      isHome: (loc) => loc === "Zuhause",
+    });
+
+    render(<OGSGroupPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card")).toHaveLength(3);
+    });
+
+    // Present student (id=1, "Raum 101") should have isHome=false
+    const rows = screen.getAllByTestId("pickup-time-row");
+    const presentRow = rows.find(
+      (el) =>
+        el.dataset.pickupTime === "14:00" && el.dataset.isHome === "false",
+    );
+    expect(presentRow).toBeDefined();
+
+    // At-home student (id=3, "Zuhause") should have isHome=true
+    const homeRow = rows.find(
+      (el) => el.dataset.pickupTime === "14:00" && el.dataset.isHome === "true",
+    );
+    expect(homeRow).toBeDefined();
   });
 
   it("renders sort filter with Alphabetisch and Nächste Abholung options", async () => {
@@ -3490,7 +3516,7 @@ describe("OGSGroupPage rendered pickup urgency", () => {
     });
   });
 
-  it("renders students without pickup time (no extra content)", async () => {
+  it("renders fallback pickup row when no pickup data exists", async () => {
     // No pickup times at all
     setupWithStudentsAndPickupTimes(new Map());
 
@@ -3500,8 +3526,9 @@ describe("OGSGroupPage rendered pickup urgency", () => {
       expect(screen.getAllByTestId("student-card")).toHaveLength(3);
     });
 
-    // No extra-content should be rendered (no pickup times)
-    expect(screen.queryByTestId("extra-content")).not.toBeInTheDocument();
+    // Always-show-pickup-time: fallback "Abholzeit: —" row is rendered
+    const fallbackRows = screen.getAllByText("Abholzeit: —");
+    expect(fallbackRows).toHaveLength(3);
   });
 });
 
@@ -3705,12 +3732,12 @@ describe("OGSGroupPage loadAvailableUsers", () => {
 // ===== Tests for exported helper functions (direct coverage) =====
 
 import {
-  getPickupUrgency as actualGetPickupUrgency,
   isStudentInGroupRoom as actualIsStudentInGroupRoom,
   matchesSearchFilter as actualMatchesSearchFilter,
   matchesAttendanceFilter as actualMatchesAttendanceFilter,
   matchesForeignRoomFilter as actualMatchesForeignRoomFilter,
 } from "./ogs-group-helpers";
+import { getPickupUrgency as actualGetPickupUrgency } from "~/lib/pickup-helpers";
 
 // Helper to build a minimal Student for direct function tests
 function makeTestStudent(

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -7,7 +7,6 @@ import {
   useMemo,
   useCallback,
   useRef,
-  type JSX,
 } from "react";
 import { useSession } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
@@ -27,12 +26,16 @@ import {
   parseLocation,
 } from "~/lib/location-helper";
 import {
-  getPickupUrgency,
   isStudentInGroupRoom,
   matchesSearchFilter,
   matchesAttendanceFilter,
 } from "./ogs-group-helpers";
-import type { OGSGroup, PickupUrgency } from "./ogs-group-helpers";
+import {
+  getPickupUrgency,
+  useMinuteClock,
+  combinePickupNotes,
+} from "~/lib/pickup-helpers";
+import type { OGSGroup } from "./ogs-group-helpers";
 import { SSEErrorBoundary } from "~/components/sse/SSEErrorBoundary";
 import { GroupTransferModal } from "~/components/groups/group-transfer-modal";
 import { groupTransferService } from "~/lib/group-transfer-api";
@@ -44,18 +47,13 @@ import { useUserContext } from "~/lib/hooks/use-user-context";
 import { Loading } from "~/components/ui/loading";
 import { LocationBadge } from "@/components/ui/location-badge";
 import { EmptyStudentResults } from "~/components/ui/empty-student-results";
-import {
-  StudentCard,
-  StudentInfoRow,
-  PickupTimeIcon,
-  ExceptionIcon,
-} from "~/components/students/student-card";
+import { StudentCard, PickupTimeRow } from "~/components/students/student-card";
 import { fetchBulkPickupTimes } from "~/lib/pickup-schedule-api";
 import type { BulkPickupTime } from "~/lib/pickup-schedule-api";
 import { activeService } from "~/lib/active-api";
 import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
 import { TrackingIndicators } from "~/components/students/tracking-indicators";
-import { Clock, AlertTriangle } from "lucide-react";
+
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "OgsGroupsPage" });
@@ -127,17 +125,6 @@ interface OGSDashboardBFFResponse {
   firstGroupId: string | null;
 }
 
-function renderPickupIcon(urgency: PickupUrgency): JSX.Element {
-  if (urgency === "overdue") {
-    return <AlertTriangle className="h-3.5 w-3.5 text-red-500" />;
-  }
-  if (urgency === "soon") {
-    return <Clock className="h-3.5 w-3.5 animate-pulse text-orange-500" />;
-  }
-  // normal / none — default gray clock
-  return <PickupTimeIcon />;
-}
-
 function OGSGroupPageContent() {
   const router = useTenantRouter();
   const searchParams = useSearchParams();
@@ -191,12 +178,7 @@ function OGSGroupPageContent() {
   const [sortMode, setSortMode] = useState<"default" | "pickup">("default");
 
   // Current time for urgency calculation (updates every minute)
-  const [now, setNow] = useState(() => new Date());
-
-  useEffect(() => {
-    const interval = setInterval(() => setNow(new Date()), 60_000);
-    return () => clearInterval(interval);
-  }, []);
+  const now = useMinuteClock();
 
   // State for group transfer modal
   const [showTransferModal, setShowTransferModal] = useState(false);
@@ -1152,10 +1134,6 @@ function OGSGroupPageContent() {
               const inGroupRoom = isStudentInGroupRoom(student, currentGroup);
               const cardGradient = getCardGradient(student);
               const studentPickup = pickupTimes.get(student.id.toString());
-              const isAtHome = isHomeLocation(student.current_location);
-              const urgency = isAtHome
-                ? ("none" as PickupUrgency)
-                : getPickupUrgency(studentPickup?.pickupTime, now);
 
               return (
                 <StudentCard
@@ -1177,28 +1155,20 @@ function OGSGroupPageContent() {
                     />
                   }
                   extraContent={
-                    studentPickup?.pickupTime ? (
-                      <StudentInfoRow
-                        icon={
-                          studentPickup.isException ? (
-                            <ExceptionIcon />
-                          ) : (
-                            renderPickupIcon(urgency)
-                          )
-                        }
-                      >
-                        Abholung: {studentPickup.pickupTime} Uhr
-                        {studentPickup.dayNotes?.length > 0 && (
-                          <span className="ml-1 text-gray-500">
-                            (
-                            {studentPickup.dayNotes
-                              .map((n) => n.content)
-                              .join(", ")}
+                    <PickupTimeRow
+                      pickupTime={studentPickup?.pickupTime}
+                      isException={studentPickup?.isException ?? false}
+                      notes={
+                        studentPickup
+                          ? combinePickupNotes(
+                              studentPickup.notes,
+                              studentPickup.dayNotes,
                             )
-                          </span>
-                        )}
-                      </StudentInfoRow>
-                    ) : null
+                          : undefined
+                      }
+                      isHome={isHomeLocation(student.current_location)}
+                      now={now}
+                    />
                   }
                   trackingIndicators={
                     swrStudentsData?.trackingIndicators?.labels.length ? (

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -1183,7 +1183,7 @@ describe("StudentSearchPage", () => {
       });
     });
 
-    it("does not display pickup time row when student has no pickup_time", async () => {
+    it("displays fallback pickup row when student has no pickup_time but has full access", async () => {
       // Use only one student without pickup_time
       const studentsNoPickup = [
         {
@@ -1210,8 +1210,8 @@ describe("StudentSearchPage", () => {
         expect(screen.getByText("NoPickup")).toBeInTheDocument();
       });
 
-      // No "Abholzeit:" text should appear
-      expect(screen.queryByText(/Abholzeit:/)).not.toBeInTheDocument();
+      // Should show "Abholzeit: —" fallback for students with full access but no pickup time
+      expect(screen.getByText("Abholzeit: —")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -23,12 +23,13 @@ import {
   SCHOOL_YEAR_FILTER_OPTIONS,
   getSchoolYear,
 } from "~/lib/student-helpers";
+import { useMinuteClock } from "~/lib/pickup-helpers";
 import {
   StudentCard,
   SchoolClassIcon,
   GroupIcon,
-  PickupTimeIcon,
   StudentInfoRow,
+  PickupTimeRow,
 } from "~/components/students/student-card";
 import { useSWRAuth, useImmutableSWR } from "~/lib/swr";
 import { activeService } from "~/lib/active-api";
@@ -72,6 +73,9 @@ function SearchPageContent() {
     initialAttendanceFilter,
   );
   const [pickupTimeFilter, setPickupTimeFilter] = useState("all");
+
+  // Current time for pickup urgency calculation (updates every minute)
+  const now = useMinuteClock();
 
   // OGS group tracking via shared BFF endpoint with SWR caching
   // This eliminates 2 separate API calls with 2 auth() calls each
@@ -373,7 +377,7 @@ function SearchPageContent() {
     if (pickupTimeFilter !== "all") {
       if (student.has_full_access === false) return false;
       if (pickupTimeFilter === "none") {
-        if (student.pickup_time) return false;
+        if (student.pickup_time || student.pickup_is_exception) return false;
       } else if (student.pickup_time !== pickupTimeFilter) {
         return false;
       }
@@ -533,10 +537,14 @@ function SearchPageContent() {
                           Gruppe: {student.group_name}
                         </StudentInfoRow>
                       )}
-                      {student.pickup_time && (
-                        <StudentInfoRow icon={<PickupTimeIcon />}>
-                          Abholzeit: {student.pickup_time} Uhr
-                        </StudentInfoRow>
+                      {student.has_full_access !== false && (
+                        <PickupTimeRow
+                          pickupTime={student.pickup_time ?? undefined}
+                          isException={student.pickup_is_exception ?? false}
+                          notes={student.pickup_notes}
+                          isHome={isHomeLocation(student.current_location)}
+                          now={now}
+                        />
                       )}
                     </>
                   }

--- a/frontend/src/components/students/student-card.test.tsx
+++ b/frontend/src/components/students/student-card.test.tsx
@@ -7,6 +7,8 @@ import {
   StudentInfoRow,
   PickupTimeIcon,
   ExceptionIcon,
+  PickupTimeRow,
+  renderPickupIcon,
 } from "./student-card";
 
 describe("StudentCard", () => {
@@ -160,6 +162,125 @@ describe("ExceptionIcon", () => {
     const svg = container.querySelector("svg");
     expect(svg).toBeInTheDocument();
     expect(svg?.className).toContain("text-orange-500");
+  });
+});
+
+describe("PickupTimeRow", () => {
+  // Fixed "now" for deterministic urgency calculations.
+  // 14:00 means a pickup at 23:59 is "normal", at 14:15 is "soon", at 13:00 is "overdue".
+  const now = new Date("2025-01-15T14:00:00");
+
+  it("renders pickup time with urgency icon when pickupTime is provided", () => {
+    render(
+      <PickupTimeRow
+        pickupTime="15:30"
+        isException={false}
+        isHome={false}
+        now={now}
+      />,
+    );
+
+    expect(screen.getByText(/Abholzeit:/)).toBeInTheDocument();
+    expect(screen.getByText(/15:30 Uhr/)).toBeInTheDocument();
+  });
+
+  it("renders notes alongside pickup time", () => {
+    render(
+      <PickupTimeRow
+        pickupTime="15:30"
+        isException={false}
+        notes="Arzttermin"
+        isHome={false}
+        now={now}
+      />,
+    );
+
+    expect(screen.getByText(/15:30 Uhr/)).toBeInTheDocument();
+    expect(screen.getByText("(Arzttermin)")).toBeInTheDocument();
+  });
+
+  it("renders exception icon when isException is true and has pickup time", () => {
+    const { container } = render(
+      <PickupTimeRow
+        pickupTime="14:00"
+        isException={true}
+        isHome={false}
+        now={now}
+      />,
+    );
+
+    // Exception icon is an orange SVG, not the urgency AlertTriangle
+    const orangeSvg = container.querySelector("svg.text-orange-500");
+    expect(orangeSvg).toBeInTheDocument();
+    // Should NOT render AlertTriangle (red)
+    expect(container.querySelector("svg.text-red-500")).not.toBeInTheDocument();
+  });
+
+  it("renders exception reason when isException is true and no pickup time", () => {
+    render(
+      <PickupTimeRow
+        isException={true}
+        notes="Ganztägig abwesend"
+        isHome={false}
+        now={now}
+      />,
+    );
+
+    expect(screen.getByText("Ganztägig abwesend")).toBeInTheDocument();
+    expect(screen.queryByText(/Abholzeit:/)).not.toBeInTheDocument();
+  });
+
+  it("renders 'Abwesend' fallback when isException is true but no notes", () => {
+    render(<PickupTimeRow isException={true} isHome={false} now={now} />);
+
+    expect(screen.getByText("Abwesend")).toBeInTheDocument();
+  });
+
+  it("renders dash fallback when no pickup time and no exception", () => {
+    render(<PickupTimeRow isException={false} isHome={false} now={now} />);
+
+    expect(screen.getByText("Abholzeit: —")).toBeInTheDocument();
+  });
+
+  it("suppresses urgency for at-home students (isHome=true)", () => {
+    const { container } = render(
+      <PickupTimeRow
+        pickupTime="13:00"
+        isException={false}
+        isHome={true}
+        now={now}
+      />,
+    );
+
+    // 13:00 is overdue, but isHome=true should yield gray clock, not red triangle
+    expect(screen.getByText(/13:00 Uhr/)).toBeInTheDocument();
+    expect(container.querySelector("svg.text-red-500")).not.toBeInTheDocument();
+    // Should render gray PickupTimeIcon
+    expect(container.querySelector("svg.text-gray-400")).toBeInTheDocument();
+  });
+});
+
+describe("renderPickupIcon", () => {
+  it("renders red AlertTriangle for overdue", () => {
+    const { container } = render(<>{renderPickupIcon("overdue")}</>);
+    expect(container.querySelector("svg.text-red-500")).toBeInTheDocument();
+  });
+
+  it("renders pulsing orange Clock for soon", () => {
+    const { container } = render(<>{renderPickupIcon("soon")}</>);
+    const clock = container.querySelector("svg.text-orange-500");
+    expect(clock).toBeInTheDocument();
+    expect(clock?.className).toContain("animate-pulse");
+  });
+
+  it("renders gray PickupTimeIcon for normal", () => {
+    const { container } = render(<>{renderPickupIcon("normal")}</>);
+    expect(container.querySelector("svg.text-gray-400")).toBeInTheDocument();
+  });
+
+  it("renders gray PickupTimeIcon for none", () => {
+    const { container } = render(<>{renderPickupIcon("none")}</>);
+    expect(container.querySelector("svg.text-gray-400")).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/students/student-card.tsx
+++ b/frontend/src/components/students/student-card.tsx
@@ -2,6 +2,8 @@
 // Shared student card component used across OGS groups and active supervisions pages
 
 import type { ReactNode } from "react";
+import { Clock, AlertTriangle } from "lucide-react";
+import { getPickupUrgency, type PickupUrgency } from "~/lib/pickup-helpers";
 
 interface StudentCardProps {
   /** Unique student ID */
@@ -205,4 +207,64 @@ export function ExceptionIcon() {
       />
     </svg>
   );
+}
+
+/**
+ * Shared pickup time display row used across OGS groups, active supervisions,
+ * and student search pages. Normalizes the three rendering branches:
+ *   1. Has pickup time → show time with urgency/exception icon
+ *   2. Exception without time → show exception reason
+ *   3. Neither → show "Abholzeit: —" fallback
+ */
+export function PickupTimeRow({
+  pickupTime,
+  isException,
+  notes,
+  isHome,
+  now,
+}: Readonly<{
+  pickupTime?: string;
+  isException: boolean;
+  notes?: string;
+  isHome: boolean;
+  now: Date;
+}>) {
+  const urgency = isHome
+    ? ("none" as const)
+    : getPickupUrgency(pickupTime, now);
+
+  if (pickupTime) {
+    return (
+      <StudentInfoRow
+        icon={isException ? <ExceptionIcon /> : renderPickupIcon(urgency)}
+      >
+        Abholzeit: {pickupTime} Uhr
+        {notes && <span className="ml-1 text-gray-500">({notes})</span>}
+      </StudentInfoRow>
+    );
+  }
+
+  if (isException) {
+    return (
+      <StudentInfoRow icon={<ExceptionIcon />}>
+        {notes || "Abwesend"}
+      </StudentInfoRow>
+    );
+  }
+
+  return (
+    <StudentInfoRow icon={<PickupTimeIcon />}>Abholzeit: —</StudentInfoRow>
+  );
+}
+
+/** Renders the appropriate pickup icon based on urgency level */
+export function renderPickupIcon(urgency: PickupUrgency): ReactNode {
+  if (urgency === "overdue") {
+    return <AlertTriangle className="h-3.5 w-3.5 text-red-500" />;
+  }
+  if (urgency === "soon") {
+    return <Clock className="h-3.5 w-3.5 animate-pulse text-orange-500" />;
+  }
+  // normal / none — default gray clock
+  return <PickupTimeIcon />;
 }

--- a/frontend/src/lib/pickup-helpers.test.ts
+++ b/frontend/src/lib/pickup-helpers.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { combinePickupNotes, getPickupUrgency } from "./pickup-helpers";
+
+describe("combinePickupNotes", () => {
+  it("returns undefined when no notes and no day notes", () => {
+    expect(combinePickupNotes(undefined, undefined)).toBeUndefined();
+  });
+
+  it("returns notes only when no day notes", () => {
+    expect(combinePickupNotes("Arzttermin", undefined)).toBe("Arzttermin");
+  });
+
+  it("returns notes only when day notes array is empty", () => {
+    expect(combinePickupNotes("Arzttermin", [])).toBe("Arzttermin");
+  });
+
+  it("returns day notes only when no notes", () => {
+    expect(combinePickupNotes(undefined, [{ content: "Früher abholen" }])).toBe(
+      "Früher abholen",
+    );
+  });
+
+  it("combines notes and day notes with comma separator", () => {
+    expect(
+      combinePickupNotes("Arzttermin", [{ content: "Früher abholen" }]),
+    ).toBe("Arzttermin, Früher abholen");
+  });
+
+  it("combines notes with multiple day notes", () => {
+    expect(
+      combinePickupNotes("Termin", [
+        { content: "Früher abholen" },
+        { content: "Oma holt ab" },
+      ]),
+    ).toBe("Termin, Früher abholen, Oma holt ab");
+  });
+
+  it("skips empty day note content", () => {
+    expect(
+      combinePickupNotes("Termin", [{ content: "" }, { content: "Wichtig" }]),
+    ).toBe("Termin, Wichtig");
+  });
+
+  it("returns undefined when notes is empty and day notes are empty", () => {
+    expect(combinePickupNotes("", [{ content: "" }])).toBeUndefined();
+  });
+});
+
+describe("getPickupUrgency", () => {
+  it("returns 'none' when pickupTimeStr is undefined", () => {
+    expect(getPickupUrgency(undefined, new Date())).toBe("none");
+  });
+
+  it("returns 'overdue' when pickup time is in the past", () => {
+    const now = new Date("2025-01-15T15:00:00");
+    expect(getPickupUrgency("14:30", now)).toBe("overdue");
+  });
+
+  it("returns 'soon' when pickup time is within 30 minutes", () => {
+    const now = new Date("2025-01-15T14:45:00");
+    expect(getPickupUrgency("15:00", now)).toBe("soon");
+  });
+
+  it("returns 'soon' when pickup time is exactly now (0 minutes diff)", () => {
+    const now = new Date("2025-01-15T15:00:00");
+    expect(getPickupUrgency("15:00", now)).toBe("soon");
+  });
+
+  it("returns 'normal' when pickup time is more than 30 minutes away", () => {
+    const now = new Date("2025-01-15T13:00:00");
+    expect(getPickupUrgency("15:00", now)).toBe("normal");
+  });
+
+  it("returns 'soon' at exactly 30 minutes before pickup", () => {
+    const now = new Date("2025-01-15T14:30:00");
+    expect(getPickupUrgency("15:00", now)).toBe("soon");
+  });
+
+  it("returns 'normal' at 31 minutes before pickup", () => {
+    const now = new Date("2025-01-15T14:29:00");
+    expect(getPickupUrgency("15:00", now)).toBe("normal");
+  });
+});

--- a/frontend/src/lib/pickup-helpers.ts
+++ b/frontend/src/lib/pickup-helpers.ts
@@ -1,0 +1,57 @@
+"use client";
+
+// lib/pickup-helpers.ts
+// Shared pickup time urgency helpers used across OGS groups, active supervisions,
+// and student search pages.
+
+import { useState, useEffect } from "react";
+
+const PICKUP_URGENCY_SOON_MINUTES = 30;
+
+export type PickupUrgency = "overdue" | "soon" | "normal" | "none";
+
+/**
+ * Hook that returns a Date updated every 60 seconds.
+ * Used for pickup time urgency calculations across pages.
+ */
+export function useMinuteClock(): Date {
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+  return now;
+}
+
+/**
+ * Combine separate notes and day notes into a single display string.
+ * Used to normalize the two data paths: bulk pickup API (separate fields)
+ * and student list API (pre-combined pickup_notes).
+ */
+export function combinePickupNotes(
+  notes?: string,
+  dayNotes?: ReadonlyArray<{ content: string }>,
+): string | undefined {
+  const combined = [notes, ...(dayNotes?.map((n) => n.content) ?? [])]
+    .filter(Boolean)
+    .join(", ");
+  return combined || undefined;
+}
+
+export function getPickupUrgency(
+  pickupTimeStr: string | undefined,
+  now: Date,
+): PickupUrgency {
+  if (!pickupTimeStr) return "none";
+
+  const [hours, minutes] = pickupTimeStr.split(":").map(Number);
+  const pickupDate = new Date(now);
+  pickupDate.setHours(hours ?? 0, minutes ?? 0, 0, 0);
+
+  const diffMs = pickupDate.getTime() - now.getTime();
+  const diffMinutes = diffMs / 60000;
+
+  if (diffMinutes < 0) return "overdue";
+  if (diffMinutes <= PICKUP_URGENCY_SOON_MINUTES) return "soon";
+  return "normal";
+}

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -66,6 +66,8 @@ export interface BackendStudent {
   supervisor_notes?: string;
   pickup_status?: string;
   pickup_time?: string; // Today's effective pickup time (HH:MM)
+  pickup_is_exception?: boolean; // True if today's pickup time is an exception
+  pickup_notes?: string; // Exception reason or schedule notes
   has_full_access?: boolean;
   created_at: string;
   updated_at: string;
@@ -168,6 +170,8 @@ export interface Student {
   supervisor_notes?: string;
   pickup_status?: string;
   pickup_time?: string; // Today's effective pickup time (HH:MM)
+  pickup_is_exception?: boolean; // True if today's pickup time is an exception
+  pickup_notes?: string; // Exception reason or schedule notes
 }
 
 // Mapping functions
@@ -212,6 +216,8 @@ export function mapStudentResponse(
     supervisor_notes: backendStudent.supervisor_notes,
     pickup_status: backendStudent.pickup_status,
     pickup_time: backendStudent.pickup_time,
+    pickup_is_exception: backendStudent.pickup_is_exception,
+    pickup_notes: backendStudent.pickup_notes,
     has_full_access: backendStudent.has_full_access,
   };
 


### PR DESCRIPTION
## Summary

- **Always display a pickup time row** on student cards across all three pages — OGS groups and student search previously only rendered pickup info when a time existed, active supervisions had no pickup display at all. Now all three pages show a consistent row: time with urgency icon, exception reason, or "Abholzeit: —" fallback
- **Surface exception and notes data**: backend now returns `pickup_is_exception` and `pickup_notes` on the student response, frontend renders exception icons and combined notes/day-notes inline
- **Extract shared `PickupTimeRow` component** and `pickup-helpers.ts` module to consolidate pickup rendering logic that would otherwise be duplicated across three pages

## What changed

### Backend
- `types.go`: Added `PickupIsException` and `PickupNotes` fields to `StudentResponse`
- `response_helpers.go`: `enrichWithPickupTimes` now populates exception flag and notes; new `buildPickupNotes()` combines exception reason + day notes into a single string

### Frontend
- **New** `lib/pickup-helpers.ts`: Extracted `getPickupUrgency` (from `ogs-group-helpers.ts`) and `useMinuteClock` (from inline state in OGS groups page); added new `combinePickupNotes` helper for normalizing notes + day-notes into a single display string
- **New** `PickupTimeRow` + `renderPickupIcon` in `student-card.tsx`: Shared component with three rendering branches (time+urgency, exception-only, dash fallback)
- `ogs-groups/page.tsx`: Replaced ~30 lines of inline pickup rendering with `<PickupTimeRow />`
- `active-supervisions/page.tsx`: Added bulk pickup time fetch via SWR + `<PickupTimeRow />`
- `students/search/page.tsx`: Replaced basic pickup display with `<PickupTimeRow />`, updated "none" filter to also exclude exceptions
- `ogs-group-helpers.ts`: Removed `getPickupUrgency` and `PickupUrgency` (moved to shared module)

## Test plan

- [x] `pickup-helpers.test.ts` — 15 tests covering `combinePickupNotes` and `getPickupUrgency` edge cases
- [x] `student-card.test.tsx` — 11 new tests for `PickupTimeRow` (all three branches, notes, exception icon, home suppression) and `renderPickupIcon` (all urgency levels)
- [x] `enrich_pickup_times_test.go` — 8 tests including exception+notes, exception-without-time, service error, nil service, empty IDs, and buildPickupNotes table-driven cases
- [x] Updated mocks in active-supervisions and ogs-groups page tests
- [x] Backend tests pass: `go test ./api/students/...`
- [x] Frontend checks pass: `pnpm run check` (zero warnings)
- [ ] Manual: verify pickup row renders on OGS groups page for students with/without pickup times
- [ ] Manual: verify active supervisions page shows pickup times after bulk fetch
- [ ] Manual: verify student search "keine Abholzeit" filter excludes exception-only students