### PR TITLE
feat: per-student daily checkout based on pickup times

### DIFF
--- a/backend/api/iot/checkin/checkin_internal_test.go
+++ b/backend/api/iot/checkin/checkin_internal_test.go
@@ -152,9 +152,11 @@ func TestGetStudentDailyCheckoutTime_EdgeCases(t *testing.T) {
 // Settings service wiring tests
 // =============================================================================
 
-// mockSettingsService is a minimal mock that only supports ResolveString.
+// mockSettingsService is a minimal mock that supports ResolveString, ResolveBool, and ResolveInt.
 type mockSettingsService struct {
-	values map[string]string
+	values     map[string]string
+	boolValues map[string]bool
+	intValues  map[string]int
 }
 
 func (m *mockSettingsService) GetSchema(_ context.Context, _ []string) (*configSvc.SettingsSchema, error) {
@@ -178,10 +180,20 @@ func (m *mockSettingsService) ResolveString(_ context.Context, key string) (stri
 func (m *mockSettingsService) ResolveStringForTenant(_ context.Context, _ int64, key string) (string, error) {
 	return m.ResolveString(context.Background(), key)
 }
-func (m *mockSettingsService) ResolveBool(_ context.Context, _ string) (bool, error) {
+func (m *mockSettingsService) ResolveBool(_ context.Context, key string) (bool, error) {
+	if m.boolValues != nil {
+		if v, ok := m.boolValues[key]; ok {
+			return v, nil
+		}
+	}
 	return false, nil
 }
-func (m *mockSettingsService) ResolveInt(_ context.Context, _ string) (int, error) {
+func (m *mockSettingsService) ResolveInt(_ context.Context, key string) (int, error) {
+	if m.intValues != nil {
+		if v, ok := m.intValues[key]; ok {
+			return v, nil
+		}
+	}
 	return 0, nil
 }
 func (m *mockSettingsService) HasTenantOverride(_ context.Context, key string) (bool, error) {
@@ -1699,6 +1711,17 @@ func TestSchulhofActivityGroup_NoStaffContext(t *testing.T) {
 	assert.Nil(t, group.CreatedBy, "system-created Schulhof group should have NULL created_by")
 }
 
+// mockPickupScheduleService is a minimal mock for testing isAfterCheckoutTimeGate.
+type mockPickupScheduleService struct {
+	scheduleSvc.PickupScheduleService
+	effectivePickupTime *scheduleSvc.EffectivePickupTime
+	err                 error
+}
+
+func (m *mockPickupScheduleService) GetEffectivePickupTimeForDate(_ context.Context, _ int64, _ time.Time) (*scheduleSvc.EffectivePickupTime, error) {
+	return m.effectivePickupTime, m.err
+}
+
 // mockEducationService is a minimal mock for testing shouldShowDailyCheckoutWithGroup.
 type mockEducationService struct {
 	educationSvc.Service
@@ -1745,4 +1768,169 @@ func TestGetStudentDailyCheckoutTime_HasTenantOverrideError_FallsBackToEnv(t *te
 	require.NotNil(t, checkoutTime)
 	assert.Equal(t, 15, checkoutTime.Hour())
 	assert.Equal(t, 0, checkoutTime.Minute())
+}
+
+// =============================================================================
+// isAfterCheckoutTimeGate TESTS
+// =============================================================================
+
+func TestIsAfterCheckoutTimeGate_PerStudentDisabled_FallsBackToGlobal(t *testing.T) {
+	// Per-student disabled (default) → should use global checkout time
+	_ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME")
+
+	rs := &Resource{
+		SettingsService: &mockSettingsService{values: map[string]string{}},
+	}
+	student := &users.Student{Model: base.Model{ID: 1}}
+
+	// No global time configured → always available
+	result := rs.isAfterCheckoutTimeGate(context.Background(), student)
+	assert.True(t, result, "should return true when per-student disabled and no global time")
+}
+
+func TestIsAfterCheckoutTimeGate_PerStudentDisabled_GlobalTimeInFuture(t *testing.T) {
+	// Set a global time far in the future
+	require.NoError(t, os.Setenv("STUDENT_DAILY_CHECKOUT_TIME", "23:59"))
+	defer func() { _ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME") }()
+
+	rs := &Resource{
+		SettingsService: &mockSettingsService{values: map[string]string{}},
+	}
+	student := &users.Student{Model: base.Model{ID: 1}}
+
+	result := rs.isAfterCheckoutTimeGate(context.Background(), student)
+	assert.False(t, result, "should return false when per-student disabled and global time is in future")
+}
+
+func TestIsAfterCheckoutTimeGate_PerStudentEnabled_BeforeDelta(t *testing.T) {
+	_ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME")
+
+	// Pickup time 2 hours from now, delta 15 min → too early
+	now := time.Now()
+	pickupTime := time.Date(2000, 1, 1, now.Hour()+2, 0, 0, 0, now.Location())
+
+	rs := &Resource{
+		SettingsService: &mockSettingsService{
+			values:     map[string]string{},
+			boolValues: map[string]bool{"operations.per_student_checkout_enabled": true},
+			intValues:  map[string]int{"operations.per_student_checkout_delta_minutes": 15},
+		},
+		PickupScheduleService: &mockPickupScheduleService{
+			effectivePickupTime: &scheduleSvc.EffectivePickupTime{PickupTime: &pickupTime},
+		},
+	}
+	student := &users.Student{Model: base.Model{ID: 1}}
+
+	result := rs.isAfterCheckoutTimeGate(context.Background(), student)
+	assert.False(t, result, "should return false when current time is before pickup_time - delta")
+}
+
+func TestIsAfterCheckoutTimeGate_PerStudentEnabled_AfterDelta(t *testing.T) {
+	_ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME")
+
+	// Pickup time 5 minutes from now, delta 15 min → already past threshold
+	now := time.Now()
+	pickupTime := time.Date(2000, 1, 1, now.Hour(), now.Minute()+5, 0, 0, now.Location())
+
+	rs := &Resource{
+		SettingsService: &mockSettingsService{
+			values:     map[string]string{},
+			boolValues: map[string]bool{"operations.per_student_checkout_enabled": true},
+			intValues:  map[string]int{"operations.per_student_checkout_delta_minutes": 15},
+		},
+		PickupScheduleService: &mockPickupScheduleService{
+			effectivePickupTime: &scheduleSvc.EffectivePickupTime{PickupTime: &pickupTime},
+		},
+	}
+	student := &users.Student{Model: base.Model{ID: 1}}
+
+	result := rs.isAfterCheckoutTimeGate(context.Background(), student)
+	assert.True(t, result, "should return true when current time is after pickup_time - delta")
+}
+
+func TestIsAfterCheckoutTimeGate_PerStudentEnabled_NoPickupTime_FallsBackToGlobal(t *testing.T) {
+	_ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME")
+
+	// Per-student enabled but student has no pickup time → fall back to global (no global = always available)
+	rs := &Resource{
+		SettingsService: &mockSettingsService{
+			values:     map[string]string{},
+			boolValues: map[string]bool{"operations.per_student_checkout_enabled": true},
+		},
+		PickupScheduleService: &mockPickupScheduleService{
+			effectivePickupTime: &scheduleSvc.EffectivePickupTime{PickupTime: nil},
+		},
+	}
+	student := &users.Student{Model: base.Model{ID: 1}}
+
+	result := rs.isAfterCheckoutTimeGate(context.Background(), student)
+	assert.True(t, result, "should fall back to global (no global = always available) when student has no pickup time")
+}
+
+func TestIsAfterCheckoutTimeGate_PerStudentEnabled_PickupServiceError_FallsBackToGlobal(t *testing.T) {
+	_ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME")
+
+	rs := &Resource{
+		SettingsService: &mockSettingsService{
+			values:     map[string]string{},
+			boolValues: map[string]bool{"operations.per_student_checkout_enabled": true},
+		},
+		PickupScheduleService: &mockPickupScheduleService{
+			err: fmt.Errorf("db error"),
+		},
+	}
+	student := &users.Student{Model: base.Model{ID: 1}}
+
+	result := rs.isAfterCheckoutTimeGate(context.Background(), student)
+	assert.True(t, result, "should fall back to global when pickup service errors")
+}
+
+func TestIsAfterCheckoutTimeGate_PerStudentEnabled_NilPickupService_FallsBackToGlobal(t *testing.T) {
+	_ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME")
+
+	rs := &Resource{
+		SettingsService: &mockSettingsService{
+			values:     map[string]string{},
+			boolValues: map[string]bool{"operations.per_student_checkout_enabled": true},
+		},
+		// PickupScheduleService is nil
+	}
+	student := &users.Student{Model: base.Model{ID: 1}}
+
+	result := rs.isAfterCheckoutTimeGate(context.Background(), student)
+	assert.True(t, result, "should fall back to global when PickupScheduleService is nil")
+}
+
+func TestIsAfterCheckoutTimeGate_PerStudentEnabled_DeltaZero(t *testing.T) {
+	_ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME")
+
+	// Pickup time 1 minute from now, delta 0 → not yet
+	now := time.Now()
+	pickupTime := time.Date(2000, 1, 1, now.Hour(), now.Minute()+1, 0, 0, now.Location())
+
+	rs := &Resource{
+		SettingsService: &mockSettingsService{
+			values:     map[string]string{},
+			boolValues: map[string]bool{"operations.per_student_checkout_enabled": true},
+			intValues:  map[string]int{"operations.per_student_checkout_delta_minutes": 0},
+		},
+		PickupScheduleService: &mockPickupScheduleService{
+			effectivePickupTime: &scheduleSvc.EffectivePickupTime{PickupTime: &pickupTime},
+		},
+	}
+	student := &users.Student{Model: base.Model{ID: 1}}
+
+	result := rs.isAfterCheckoutTimeGate(context.Background(), student)
+	assert.False(t, result, "should return false when delta is 0 and current time is before pickup time")
+}
+
+func TestIsAfterCheckoutTimeGate_NilSettingsService(t *testing.T) {
+	_ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME")
+
+	rs := &Resource{}
+	student := &users.Student{Model: base.Model{ID: 1}}
+
+	// No settings service → perStudentEnabled defaults to false → no global time → always available
+	result := rs.isAfterCheckoutTimeGate(context.Background(), student)
+	assert.True(t, result, "should return true when SettingsService is nil and no global time")
 }

--- a/backend/api/iot/checkin/helpers.go
+++ b/backend/api/iot/checkin/helpers.go
@@ -98,6 +98,51 @@ func (rs *Resource) shouldUpgradeToDailyCheckout(ctx context.Context, action str
 	return rs.shouldShowDailyCheckoutWithGroup(ctx, student, currentVisit)
 }
 
+// isAfterCheckoutTimeGate checks whether the current time is past the applicable
+// checkout time gate for this student. When per-student checkout is enabled and
+// the student has a pickup time, uses pickup_time - delta. Otherwise falls back
+// to the global daily checkout time.
+func (rs *Resource) isAfterCheckoutTimeGate(ctx context.Context, student *users.Student) bool {
+	// Check per-student mode (new setting, no env var fallback needed)
+	perStudentEnabled := false
+	if rs.SettingsService != nil {
+		if val, err := rs.SettingsService.ResolveBool(ctx, configModel.KeyPerStudentCheckoutEnabled); err == nil {
+			perStudentEnabled = val
+		}
+	}
+
+	if perStudentEnabled && rs.PickupScheduleService != nil {
+		now := time.Now()
+		effectivePickup, err := rs.PickupScheduleService.GetEffectivePickupTimeForDate(ctx, student.ID, now)
+		if err == nil && effectivePickup != nil && effectivePickup.PickupTime != nil {
+			// Student has a pickup time — use it with the delta
+			delta := 15
+			if rs.SettingsService != nil {
+				if val, err := rs.SettingsService.ResolveInt(ctx, configModel.KeyPerStudentCheckoutDeltaMinutes); err == nil {
+					delta = val
+				}
+			}
+
+			todayPickup := time.Date(now.Year(), now.Month(), now.Day(),
+				effectivePickup.PickupTime.Hour(), effectivePickup.PickupTime.Minute(),
+				0, 0, now.Location())
+			threshold := todayPickup.Add(-time.Duration(delta) * time.Minute)
+			return now.After(threshold)
+		}
+		// No pickup time for this student — fall through to global check
+	}
+
+	// Global checkout time check (existing behavior)
+	checkoutTime, err := rs.getStudentDailyCheckoutTime(ctx)
+	if err != nil {
+		return false
+	}
+	if checkoutTime == nil {
+		return true // No time gate — always available
+	}
+	return time.Now().After(*checkoutTime)
+}
+
 // shouldShowDailyCheckoutWithGroup checks if daily checkout should be shown by verifying education group room
 func (rs *Resource) shouldShowDailyCheckoutWithGroup(ctx context.Context, student *users.Student, currentVisit *active.Visit) bool {
 	if student.GroupID == nil {
@@ -107,13 +152,7 @@ func (rs *Resource) shouldShowDailyCheckoutWithGroup(ctx context.Context, studen
 		return false
 	}
 
-	checkoutTime, err := rs.getStudentDailyCheckoutTime(ctx)
-	if err != nil {
-		return false
-	}
-	// If a checkout time is configured, only allow after that time.
-	// If nil (no time configured), daily checkout is always available.
-	if checkoutTime != nil && !time.Now().After(*checkoutTime) {
+	if !rs.isAfterCheckoutTimeGate(ctx, student) {
 		return false
 	}
 

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -63,12 +63,14 @@ const (
 
 // Operations settings.
 const (
-	KeySessionEndEnabled             = "operations.session_end_enabled"
-	KeySessionEndTime                = "operations.session_end_time"
-	KeySessionEndTimeoutMinutes      = "operations.session_end_timeout_minutes"
-	KeyStudentDailyCheckoutTime      = "operations.student_daily_checkout_time"
-	KeySessionCleanupEnabled         = "operations.session_cleanup_enabled"
-	KeySessionCleanupIntervalMinutes = "operations.session_cleanup_interval_minutes"
-	KeySessionAbandonedThresholdMin  = "operations.session_abandoned_threshold_minutes"
-	KeyAdminSupervisionOverview      = "operations.admin_supervision_overview"
+	KeySessionEndEnabled              = "operations.session_end_enabled"
+	KeySessionEndTime                 = "operations.session_end_time"
+	KeySessionEndTimeoutMinutes       = "operations.session_end_timeout_minutes"
+	KeyStudentDailyCheckoutTime       = "operations.student_daily_checkout_time"
+	KeyPerStudentCheckoutEnabled      = "operations.per_student_checkout_enabled"
+	KeyPerStudentCheckoutDeltaMinutes = "operations.per_student_checkout_delta_minutes"
+	KeySessionCleanupEnabled          = "operations.session_cleanup_enabled"
+	KeySessionCleanupIntervalMinutes  = "operations.session_cleanup_interval_minutes"
+	KeySessionAbandonedThresholdMin   = "operations.session_abandoned_threshold_minutes"
+	KeyAdminSupervisionOverview       = "operations.admin_supervision_overview"
 )

--- a/backend/services/auth/auth_core_test.go
+++ b/backend/services/auth/auth_core_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -402,7 +403,10 @@ func TestAuthService_RefreshToken_ConcurrentSingleflight(t *testing.T) {
 	_, refreshToken, err := service.Login(ctx, email, testPassword)
 	require.NoError(t, err)
 
-	// ACT: fire 5 concurrent refresh requests with the same token
+	// ACT: fire 5 concurrent refresh requests with the same token.
+	// Use a barrier (WaitGroup) so all goroutines start at the same time —
+	// without this, goroutine 1 can complete the entire refresh (rotating the
+	// token in the DB) before goroutine 2 even starts, defeating singleflight.
 	const concurrency = 5
 	type result struct {
 		accessToken  string
@@ -411,8 +415,12 @@ func TestAuthService_RefreshToken_ConcurrentSingleflight(t *testing.T) {
 	}
 	results := make(chan result, concurrency)
 
+	var barrier sync.WaitGroup
+	barrier.Add(concurrency)
 	for range concurrency {
 		go func() {
+			barrier.Done()
+			barrier.Wait() // all goroutines unblock together
 			at, rt, e := service.RefreshToken(ctx, refreshToken)
 			results <- result{at, rt, e}
 		}()

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -20,6 +20,8 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"operations.session_end_time",
 		"operations.session_end_timeout_minutes",
 		"operations.student_daily_checkout_time",
+		"operations.per_student_checkout_enabled",
+		"operations.per_student_checkout_delta_minutes",
 		"operations.session_cleanup_enabled",
 		"operations.session_cleanup_interval_minutes",
 		"operations.session_abandoned_threshold_minutes",
@@ -52,7 +54,7 @@ func TestAllSettingsRegistered(t *testing.T) {
 		assert.NotEmpty(t, def.Category, "setting %q should have a category", key)
 	}
 
-	assert.GreaterOrEqual(t, len(all), 25, "at least 25 settings should be registered")
+	assert.GreaterOrEqual(t, len(all), 27, "at least 27 settings should be registered")
 }
 
 func TestOperationsSettings_Types(t *testing.T) {
@@ -64,6 +66,8 @@ func TestOperationsSettings_Types(t *testing.T) {
 		{"operations.session_end_time", config.FieldTime},
 		{"operations.session_end_timeout_minutes", config.FieldNumber},
 		{"operations.student_daily_checkout_time", config.FieldTime},
+		{"operations.per_student_checkout_enabled", config.FieldBoolean},
+		{"operations.per_student_checkout_delta_minutes", config.FieldNumber},
 		{"operations.session_cleanup_enabled", config.FieldBoolean},
 		{"operations.session_cleanup_interval_minutes", config.FieldNumber},
 		{"operations.session_abandoned_threshold_minutes", config.FieldNumber},
@@ -148,6 +152,20 @@ func TestDependsOn_GDPRGroup(t *testing.T) {
 	require.NotNil(t, timeoutDef)
 	require.NotNil(t, timeoutDef.DependsOn)
 	assert.Equal(t, "gdpr.data_cleanup_enabled", timeoutDef.DependsOn.Key)
+}
+
+func TestDependsOn_PerStudentCheckoutGroup(t *testing.T) {
+	deltaDef := config.GetDefinition("operations.per_student_checkout_delta_minutes")
+	require.NotNil(t, deltaDef)
+	require.NotNil(t, deltaDef.DependsOn)
+	assert.Equal(t, "operations.per_student_checkout_enabled", deltaDef.DependsOn.Key)
+	assert.Equal(t, "eq", deltaDef.DependsOn.Condition)
+	assert.Equal(t, true, deltaDef.DependsOn.Value)
+
+	// The toggle itself has no DependsOn
+	toggleDef := config.GetDefinition("operations.per_student_checkout_enabled")
+	require.NotNil(t, toggleDef)
+	assert.Nil(t, toggleDef.DependsOn)
 }
 
 func TestDependsOn_AttendanceLogGroup(t *testing.T) {
@@ -254,6 +272,7 @@ func TestValidation_NumberFields(t *testing.T) {
 		"gdpr.attendance_visible_days",
 		"gdpr.room_detail_visible_days",
 		"feedback.data_retention_days",
+		"operations.per_student_checkout_delta_minutes",
 	}
 
 	for _, key := range numberKeys {
@@ -274,6 +293,8 @@ func TestDefaults_HaveReasonableValues(t *testing.T) {
 		{"operations.session_end_time", "18:00"},
 		{"operations.session_end_timeout_minutes", 10},
 		{"operations.student_daily_checkout_time", ""},
+		{"operations.per_student_checkout_enabled", false},
+		{"operations.per_student_checkout_delta_minutes", 15},
 		{"operations.session_cleanup_enabled", false},
 		{"operations.session_cleanup_interval_minutes", 15},
 		{"operations.session_abandoned_threshold_minutes", 60},

--- a/backend/services/config/defaults/operations.go
+++ b/backend/services/config/defaults/operations.go
@@ -77,6 +77,40 @@ func init() {
 		SortOrder:       1,
 	})
 
+	config.Register(config.Definition{
+		Key:             config.KeyPerStudentCheckoutEnabled,
+		Label:           "Individuelle Abholzeiten verwenden",
+		Description:     "Wenn aktiviert, wird die Abmeldung anhand der individuellen Abholzeiten der Schüler angezeigt statt der globalen Abmeldezeit.",
+		Type:            config.FieldBoolean,
+		Default:         false,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "checkout",
+		SortOrder:       2,
+	})
+
+	minDelta := float64(0)
+	maxDelta := float64(120)
+	config.Register(config.Definition{
+		Key:             config.KeyPerStudentCheckoutDeltaMinutes,
+		Label:           "Vorlaufzeit vor Abholung (Minuten)",
+		Description:     "Minuten vor der Abholzeit, ab der die Abmeldung am Gerät angeboten wird. Beispiel: Bei Abholzeit 15:00 und Vorlaufzeit 15 Min. ist die Abmeldung ab 14:45 möglich.",
+		Type:            config.FieldNumber,
+		Default:         15,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "checkout",
+		SortOrder:       3,
+		Validation:      &config.ValidationRules{Min: &minDelta, Max: &maxDelta},
+		DependsOn: &config.Dependency{
+			Key:       config.KeyPerStudentCheckoutEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
 	// --- Abandoned Session Cleanup (system tab — automated background process) ---
 
 	config.Register(config.Definition{


### PR DESCRIPTION
## Summary

- Adds opt-in per-student checkout mode that uses individual pickup schedules instead of the global daily checkout time
- Configurable delta (default 15 min) controls how early before pickup time the "nach Hause" button appears on PyrePortal
- Students without a pickup time fall back to the global `student_daily_checkout_time` setting
- No PyrePortal changes needed — `daily_checkout_available` flag is already computed server-side

## New Settings (Operations > Checkout)

| Setting | Type | Default |
|---------|------|---------|
| Individuelle Abholzeiten verwenden | boolean | false |
| Vorlaufzeit vor Abholung (Minuten) | number | 15 (0-120) |

## Test plan

- [ ] Verify settings appear in admin UI under Betrieb > Checkout
- [ ] Toggle enabled → delta field appears; toggle disabled → delta field hidden
- [ ] With feature disabled: existing global checkout time behavior unchanged
- [ ] With feature enabled + student has pickup time at 15:00, delta 15 min → button appears at 14:45
- [ ] With feature enabled + student has no pickup time → falls back to global checkout time
- [ ] `go test ./api/iot/checkin/... -v` — all 8 new + existing tests pass
- [ ] `go test ./services/config/... -v` — settings registration tests pass