### PR TITLE
fix: allow pure admin accounts to connect to SSE

### DIFF
--- a/backend/api/sse/api.go
+++ b/backend/api/sse/api.go
@@ -63,15 +63,26 @@ func (rs *Resource) eventsHandler(w http.ResponseWriter, r *http.Request) {
 	var staff *users.Staff
 	var topics *sseTopics
 	err := tenant.WithTenantTx(ctx, rs.db, conn.tenantID, func(txCtx context.Context, _ bun.Tx) error {
-		// Step 3: Resolve staff member from JWT claims
+		// Step 3: Resolve staff member from JWT claims.
+		// Pure admins may not have a staff record — that's OK,
+		// they can still receive BroadcastToAll events and (if
+		// admin_supervision_overview is enabled) all group events.
 		resolved, errMsg, code := rs.resolveStaff(txCtx)
 		if resolved == nil {
-			return &sseSetupError{msg: errMsg, status: code}
+			claims := jwt.ClaimsFromCtx(txCtx)
+			if !claims.IsAdmin {
+				return &sseSetupError{msg: errMsg, status: code}
+			}
+		} else {
+			staff = resolved
 		}
-		staff = resolved
 
 		// Step 4: Build subscription topics (active groups + educational groups)
-		built, err := rs.buildSubscriptionTopics(txCtx, staff.ID)
+		var staffID int64
+		if staff != nil {
+			staffID = staff.ID
+		}
+		built, err := rs.buildSubscriptionTopics(txCtx, staffID)
 		if err != nil {
 			return err
 		}
@@ -88,7 +99,9 @@ func (rs *Resource) eventsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	conn.staffID = staff.ID
+	if staff != nil {
+		conn.staffID = staff.ID
+	}
 	conn.topics = topics
 
 	// Step 5: Send initial "connected" event

--- a/backend/api/sse/sse_test.go
+++ b/backend/api/sse/sse_test.go
@@ -210,25 +210,31 @@ func TestSSEEvents_StaffWithAccount(t *testing.T) {
 }
 
 func TestSSEEvents_AdminClaims(t *testing.T) {
-	ctx := setupTestContext(t)
-	defer func() { _ = ctx.db.Close() }()
+	tctx := setupTestContext(t)
+	defer func() { _ = tctx.db.Close() }()
 
-	// Create admin - admins may or may not be staff
-	_, account := testpkg.CreateTestPersonWithAccount(t, ctx.db, "Admin", "NoStaff")
+	// Create admin without staff record
+	_, account := testpkg.CreateTestPersonWithAccount(t, tctx.db, "Admin", "NoStaff")
 
 	router := chi.NewRouter()
-	router.Get("/events", ctx.resource.EventsHandler())
+	router.Get("/events", tctx.resource.EventsHandler())
 
-	// Admin without staff record should fail
-	req := testutil.NewAuthenticatedRequest(t, "GET", "/events", nil,
-		testutil.WithClaims(testutil.AdminTestClaims(int(account.ID))),
-	)
+	// Admin without staff record should reach the streaming path (not 403).
+	// Use a context timeout so the event loop exits cleanly.
+	baseCtx, cancel := context.WithTimeout(testpkg.TenantContext(1), 100*time.Millisecond)
+	defer cancel()
+
+	claims := testutil.AdminTestClaims(int(account.ID))
+	claimsCtx := context.WithValue(baseCtx, jwt.CtxClaims, claims)
+
+	req := testutil.NewRequest("GET", "/events", nil)
+	req = req.WithContext(claimsCtx)
 
 	rr := testutil.ExecuteRequest(router, req)
 
-	// Admin without staff record gets 403
-	assert.Equal(t, http.StatusForbidden, rr.Code,
-		"Expected 403 for admin without staff record")
+	// Admin should reach the streaming path (200), not be rejected (403)
+	assert.Contains(t, []int{http.StatusOK, http.StatusInternalServerError}, rr.Code,
+		"Expected streaming to start (200) or context timeout (500), got %d", rr.Code)
 }
 
 func TestSSEEvents_EmptyAuthClaims(t *testing.T) {

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -92,7 +92,7 @@ describe("useGlobalSSE", () => {
       );
     });
 
-    it("is disabled for admin-only users without staff role", () => {
+    it("is enabled for admin-only users without staff role", () => {
       vi.mocked(useSession).mockReturnValueOnce({
         status: "authenticated",
         data: {
@@ -106,7 +106,7 @@ describe("useGlobalSSE", () => {
       expect(useSSE).toHaveBeenCalledWith(
         "/api/sse/events",
         expect.objectContaining({
-          enabled: false,
+          enabled: true,
         }),
       );
     });

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -48,12 +48,15 @@ const DEBOUNCE_MS = 500;
 export function useGlobalSSE(): SSEHookState {
   const { data: session, status: sessionStatus } = useSession();
 
-  // Only enable SSE when authenticated AND user is staff (has "user" role).
-  // Admin-only accounts lack a person/staff record, so the backend SSE
-  // endpoint rejects them with 401 — skip the connection entirely.
+  // Enable SSE for staff (has "user" role) and admins.
+  // Pure admins without a staff record connect with zero supervised groups
+  // but still receive BroadcastToAll events (e.g. dashboard_counts_changed).
   const isStaff = session?.user?.roles?.includes("user") ?? false;
+  const isAdmin = session?.user?.roles?.includes("admin") ?? false;
   const isAuthenticated =
-    sessionStatus === "authenticated" && !!session?.user?.token && isStaff;
+    sessionStatus === "authenticated" &&
+    !!session?.user?.token &&
+    (isStaff || isAdmin);
 
   // Debounce state: collect affected group IDs, flush once after DEBOUNCE_MS
   const pendingGroupIds = useRef(new Set<string>());


### PR DESCRIPTION
## Summary
- Pure admin accounts (without Betreuer/staff record) were blocked from SSE — frontend skipped the connection, backend returned 403
- Backend now allows admins without a staff record to proceed with `staffID=0`; the existing `admin_supervision_overview` setting controls whether they get all group events or only `BroadcastToAll`
- Frontend now checks for `"admin"` role in addition to `"user"` when deciding to open SSE

## Test plan
- [ ] Log in as pure admin → verify SSE connection establishes (browser DevTools → Network → EventStream)
- [ ] With `admin_supervision_overview` **enabled**: verify admin receives group-level events (student check-in/out)
- [ ] With `admin_supervision_overview` **disabled**: verify admin only receives `dashboard_counts_changed` broadcasts
- [ ] Log in as Betreuer (staff) → verify SSE still works as before (no regression)
- [ ] Log in as Admin+Betreuer → verify SSE still works as before (no regression)