### PR TITLE
feat: add student arrival schedule system

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -273,21 +273,22 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Auth.CaregiverCapabilityService = api.Services.CaregiverCapability
 	api.Rooms = roomsAPI.NewResource(api.Services.Facilities, db)
 	api.Students = studentsAPI.NewResource(studentsAPI.ResourceConfig{
-		PersonService:         api.Services.Users,
-		StudentRepo:           repoFactory.Student,
-		EducationService:      api.Services.Education,
-		UserContextService:    api.Services.UserContext,
-		ActiveService:         api.Services.Active,
-		IoTService:            api.Services.IoT,
-		PrivacyConsentRepo:    repoFactory.PrivacyConsent,
-		PickupScheduleService: api.Services.PickupSchedule,
-		SchoolRepo:            repoFactory.School,
-		SettingsService:       api.Services.Settings,
-		AttendanceRepo:        repoFactory.Attendance,
-		VisitRepo:             repoFactory.ActiveVisit,
-		DataAccessLogRepo:     repoFactory.DataAccessLog,
-		Logger:                logger.With("handler", "students"),
-		DB:                    db,
+		PersonService:          api.Services.Users,
+		StudentRepo:            repoFactory.Student,
+		EducationService:       api.Services.Education,
+		UserContextService:     api.Services.UserContext,
+		ActiveService:          api.Services.Active,
+		IoTService:             api.Services.IoT,
+		PrivacyConsentRepo:     repoFactory.PrivacyConsent,
+		PickupScheduleService:  api.Services.PickupSchedule,
+		ArrivalScheduleService: api.Services.ArrivalSchedule,
+		SchoolRepo:             repoFactory.School,
+		SettingsService:        api.Services.Settings,
+		AttendanceRepo:         repoFactory.Attendance,
+		VisitRepo:              repoFactory.ActiveVisit,
+		DataAccessLogRepo:      repoFactory.DataAccessLog,
+		Logger:                 logger.With("handler", "students"),
+		DB:                     db,
 	})
 	api.Groups = groupsAPI.NewResource(api.Services.Education, api.Services.Active, api.Services.Users, api.Services.UserContext, repoFactory.Student, repoFactory.GroupSubstitution, db)
 	api.Guardians = guardiansAPI.NewResource(api.Services.Guardian, api.Services.Users, api.Services.Education, api.Services.UserContext, repoFactory.Student, db)

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -42,61 +42,64 @@ func renderError(w http.ResponseWriter, r *http.Request, errorResponse render.Re
 
 // Resource defines the students API resource
 type Resource struct {
-	PersonService         userService.PersonService
-	StudentRepo           users.StudentRepository
-	EducationService      educationService.Service
-	UserContextService    userContextService.UserContextService
-	ActiveService         activeService.Service
-	IoTService            iotSvc.Service
-	PrivacyConsentRepo    users.PrivacyConsentRepository
-	PickupScheduleService scheduleService.PickupScheduleService
-	SchoolRepo            platform.SchoolRepository
-	SettingsService       configService.SettingsService
-	AttendanceRepo        active.AttendanceRepository
-	VisitRepo             active.VisitRepository
-	DataAccessLogRepo     auditModels.DataAccessLogRepository
-	Logger                *slog.Logger
-	db                    *bun.DB
+	PersonService          userService.PersonService
+	StudentRepo            users.StudentRepository
+	EducationService       educationService.Service
+	UserContextService     userContextService.UserContextService
+	ActiveService          activeService.Service
+	IoTService             iotSvc.Service
+	PrivacyConsentRepo     users.PrivacyConsentRepository
+	PickupScheduleService  scheduleService.PickupScheduleService
+	ArrivalScheduleService scheduleService.ArrivalScheduleService
+	SchoolRepo             platform.SchoolRepository
+	SettingsService        configService.SettingsService
+	AttendanceRepo         active.AttendanceRepository
+	VisitRepo              active.VisitRepository
+	DataAccessLogRepo      auditModels.DataAccessLogRepository
+	Logger                 *slog.Logger
+	db                     *bun.DB
 }
 
 // ResourceConfig holds all dependencies for creating a students Resource.
 // Using a config struct instead of individual parameters improves maintainability.
 type ResourceConfig struct {
-	PersonService         userService.PersonService
-	StudentRepo           users.StudentRepository
-	EducationService      educationService.Service
-	UserContextService    userContextService.UserContextService
-	ActiveService         activeService.Service
-	IoTService            iotSvc.Service
-	PrivacyConsentRepo    users.PrivacyConsentRepository
-	PickupScheduleService scheduleService.PickupScheduleService
-	SchoolRepo            platform.SchoolRepository
-	SettingsService       configService.SettingsService
-	AttendanceRepo        active.AttendanceRepository
-	VisitRepo             active.VisitRepository
-	DataAccessLogRepo     auditModels.DataAccessLogRepository
-	Logger                *slog.Logger
-	DB                    *bun.DB
+	PersonService          userService.PersonService
+	StudentRepo            users.StudentRepository
+	EducationService       educationService.Service
+	UserContextService     userContextService.UserContextService
+	ActiveService          activeService.Service
+	IoTService             iotSvc.Service
+	PrivacyConsentRepo     users.PrivacyConsentRepository
+	PickupScheduleService  scheduleService.PickupScheduleService
+	ArrivalScheduleService scheduleService.ArrivalScheduleService
+	SchoolRepo             platform.SchoolRepository
+	SettingsService        configService.SettingsService
+	AttendanceRepo         active.AttendanceRepository
+	VisitRepo              active.VisitRepository
+	DataAccessLogRepo      auditModels.DataAccessLogRepository
+	Logger                 *slog.Logger
+	DB                     *bun.DB
 }
 
 // NewResource creates a new students resource from the provided configuration.
 func NewResource(cfg ResourceConfig) *Resource {
 	return &Resource{
-		PersonService:         cfg.PersonService,
-		StudentRepo:           cfg.StudentRepo,
-		EducationService:      cfg.EducationService,
-		UserContextService:    cfg.UserContextService,
-		ActiveService:         cfg.ActiveService,
-		IoTService:            cfg.IoTService,
-		PrivacyConsentRepo:    cfg.PrivacyConsentRepo,
-		PickupScheduleService: cfg.PickupScheduleService,
-		SchoolRepo:            cfg.SchoolRepo,
-		SettingsService:       cfg.SettingsService,
-		AttendanceRepo:        cfg.AttendanceRepo,
-		VisitRepo:             cfg.VisitRepo,
-		DataAccessLogRepo:     cfg.DataAccessLogRepo,
-		Logger:                cfg.Logger,
-		db:                    cfg.DB,
+		PersonService:          cfg.PersonService,
+		StudentRepo:            cfg.StudentRepo,
+		EducationService:       cfg.EducationService,
+		UserContextService:     cfg.UserContextService,
+		ActiveService:          cfg.ActiveService,
+		IoTService:             cfg.IoTService,
+		PrivacyConsentRepo:     cfg.PrivacyConsentRepo,
+		PickupScheduleService:  cfg.PickupScheduleService,
+		ArrivalScheduleService: cfg.ArrivalScheduleService,
+		SchoolRepo:             cfg.SchoolRepo,
+		SettingsService:        cfg.SettingsService,
+		AttendanceRepo:         cfg.AttendanceRepo,
+		VisitRepo:              cfg.VisitRepo,
+		DataAccessLogRepo:      cfg.DataAccessLogRepo,
+		Logger:                 cfg.Logger,
+		db:                     cfg.DB,
 	}
 }
 
@@ -151,6 +154,22 @@ func (rs *Resource) Router() chi.Router {
 
 		// Bulk pickup times endpoint (returns pickup times for multiple students)
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Post("/pickup-times/bulk", rs.getBulkPickupTimes)
+
+		// Arrival schedule routes (full access required - checked in handlers)
+		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/{id}/arrival-schedules", rs.getStudentArrivalSchedules)
+		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Put("/{id}/arrival-schedules", rs.updateStudentArrivalSchedules)
+		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Post("/{id}/arrival-exceptions", rs.createStudentArrivalException)
+		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Put("/{id}/arrival-exceptions/{exceptionId}", rs.updateStudentArrivalException)
+		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Delete("/{id}/arrival-exceptions/{exceptionId}", rs.deleteStudentArrivalException)
+
+		// Arrival note routes (full access required - checked in handlers)
+		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Post("/{id}/arrival-notes", rs.createStudentArrivalNote)
+		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Put("/{id}/arrival-notes/{noteId}", rs.updateStudentArrivalNote)
+		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Delete("/{id}/arrival-notes/{noteId}", rs.deleteStudentArrivalNote)
+
+		// Bulk arrival schedule and time endpoints
+		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Post("/arrival-schedules/bulk", rs.bulkUpsertArrivalSchedules)
+		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Post("/arrival-times/bulk", rs.getBulkArrivalTimes)
 	})
 
 	// Device-authenticated routes for RFID devices.

--- a/backend/api/students/arrival_schedule_handlers.go
+++ b/backend/api/students/arrival_schedule_handlers.go
@@ -1,0 +1,779 @@
+package students
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+// ArrivalScheduleResponse represents an arrival schedule in API responses
+type ArrivalScheduleResponse struct {
+	ID              int64   `json:"id"`
+	StudentID       int64   `json:"student_id"`
+	Weekday         int     `json:"weekday"`
+	WeekdayName     string  `json:"weekday_name"`
+	ExpectedArrival string  `json:"expected_arrival"` // HH:MM format
+	Notes           *string `json:"notes,omitempty"`
+	CreatedBy       int64   `json:"created_by"`
+	CreatedAt       string  `json:"created_at"`
+	UpdatedAt       string  `json:"updated_at"`
+}
+
+// ArrivalExceptionResponse represents an arrival exception in API responses
+type ArrivalExceptionResponse struct {
+	ID              int64   `json:"id"`
+	StudentID       int64   `json:"student_id"`
+	ExceptionDate   string  `json:"exception_date"`             // YYYY-MM-DD format
+	ExpectedArrival *string `json:"expected_arrival,omitempty"` // HH:MM or null
+	Reason          *string `json:"reason,omitempty"`
+	CreatedBy       int64   `json:"created_by"`
+	CreatedAt       string  `json:"created_at"`
+	UpdatedAt       string  `json:"updated_at"`
+}
+
+// ArrivalNoteResponse represents an arrival note in API responses
+type ArrivalNoteResponse struct {
+	ID        int64  `json:"id"`
+	StudentID int64  `json:"student_id"`
+	NoteDate  string `json:"note_date"` // YYYY-MM-DD format
+	Content   string `json:"content"`
+	CreatedBy int64  `json:"created_by"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// ArrivalDataResponse represents combined arrival data
+type ArrivalDataResponse struct {
+	Schedules  []ArrivalScheduleResponse  `json:"schedules"`
+	Exceptions []ArrivalExceptionResponse `json:"exceptions"`
+	Notes      []ArrivalNoteResponse      `json:"notes"`
+}
+
+// BulkArrivalScheduleRequest represents a request to update all weekly arrival schedules for a student
+type BulkArrivalScheduleRequest struct {
+	Schedules []ArrivalScheduleRequestItem `json:"schedules"`
+}
+
+// ArrivalScheduleRequestItem represents a single arrival schedule entry in a request
+type ArrivalScheduleRequestItem struct {
+	Weekday         int     `json:"weekday"`
+	ExpectedArrival string  `json:"expected_arrival"` // HH:MM format
+	Notes           *string `json:"notes,omitempty"`
+}
+
+// ArrivalExceptionRequest represents a request to create/update an arrival exception
+type ArrivalExceptionRequest struct {
+	ExceptionDate   string  `json:"exception_date"`             // YYYY-MM-DD format
+	ExpectedArrival *string `json:"expected_arrival,omitempty"` // HH:MM or null (null = absent)
+	Reason          *string `json:"reason,omitempty"`
+}
+
+// ArrivalNoteRequest represents a request to create/update an arrival note
+type ArrivalNoteRequest struct {
+	NoteDate string `json:"note_date"` // YYYY-MM-DD format
+	Content  string `json:"content"`
+}
+
+// BulkUpsertArrivalScheduleRequest represents a request to bulk upsert arrival schedules for a school class
+type BulkUpsertArrivalScheduleRequest struct {
+	SchoolClass string                                 `json:"school_class"`
+	Schedules   []scheduleService.ArrivalScheduleInput `json:"schedules"`
+}
+
+// Bind implements render.Binder for ArrivalNoteRequest
+func (r *ArrivalNoteRequest) Bind(_ *http.Request) error {
+	if r.NoteDate == "" {
+		return errors.New("note_date is required")
+	}
+	if _, err := time.Parse(dateFormatISO, r.NoteDate); err != nil {
+		return errors.New("invalid note_date format, expected YYYY-MM-DD")
+	}
+	if r.Content == "" {
+		return errors.New("content is required")
+	}
+	if len(r.Content) > 500 {
+		return errors.New("content cannot exceed 500 characters")
+	}
+	return nil
+}
+
+// Bind implements render.Binder for BulkArrivalScheduleRequest
+func (r *BulkArrivalScheduleRequest) Bind(_ *http.Request) error {
+	if len(r.Schedules) == 0 {
+		return errors.New("schedules array cannot be empty")
+	}
+	seenWeekdays := make(map[int]bool)
+	for i, s := range r.Schedules {
+		if s.Weekday < schedule.WeekdayMonday || s.Weekday > schedule.WeekdayFriday {
+			return fmt.Errorf("schedule %d: weekday must be between 1 (Monday) and 5 (Friday)", i)
+		}
+		if seenWeekdays[s.Weekday] {
+			return fmt.Errorf("schedule %d: duplicate weekday %d", i, s.Weekday)
+		}
+		seenWeekdays[s.Weekday] = true
+		if s.ExpectedArrival == "" {
+			return fmt.Errorf("schedule %d: expected_arrival is required", i)
+		}
+		if _, err := time.Parse("15:04", s.ExpectedArrival); err != nil {
+			return fmt.Errorf("schedule %d: invalid expected_arrival format, expected HH:MM", i)
+		}
+		if s.Notes != nil && len(*s.Notes) > 500 {
+			return fmt.Errorf("schedule %d: notes cannot exceed 500 characters", i)
+		}
+	}
+	return nil
+}
+
+// Bind implements render.Binder for ArrivalExceptionRequest
+func (r *ArrivalExceptionRequest) Bind(_ *http.Request) error {
+	if r.ExceptionDate == "" {
+		return errors.New("exception_date is required")
+	}
+	if _, err := time.Parse(dateFormatISO, r.ExceptionDate); err != nil {
+		return errors.New("invalid exception_date format, expected YYYY-MM-DD")
+	}
+	// expected_arrival is optional (nil = absent/not coming)
+	// but if provided, it must be valid HH:MM format
+	if r.ExpectedArrival != nil && *r.ExpectedArrival != "" {
+		if _, err := time.Parse("15:04", *r.ExpectedArrival); err != nil {
+			return errors.New("invalid expected_arrival format, expected HH:MM")
+		}
+	}
+	if r.Reason != nil && len(*r.Reason) > 255 {
+		return errors.New("reason cannot exceed 255 characters")
+	}
+	return nil
+}
+
+// Bind implements render.Binder for BulkUpsertArrivalScheduleRequest
+func (r *BulkUpsertArrivalScheduleRequest) Bind(_ *http.Request) error {
+	if r.SchoolClass == "" {
+		return errors.New("school_class is required")
+	}
+	if len(r.Schedules) == 0 {
+		return errors.New("schedules array cannot be empty")
+	}
+	seenWeekdays := make(map[int]bool)
+	for i, s := range r.Schedules {
+		if s.Weekday < schedule.WeekdayMonday || s.Weekday > schedule.WeekdayFriday {
+			return fmt.Errorf("schedule %d: weekday must be between 1 (Monday) and 5 (Friday)", i)
+		}
+		if seenWeekdays[s.Weekday] {
+			return fmt.Errorf("schedule %d: duplicate weekday %d", i, s.Weekday)
+		}
+		seenWeekdays[s.Weekday] = true
+		if s.ArrivalTime == "" {
+			return fmt.Errorf("schedule %d: arrival_time is required", i)
+		}
+		if _, err := time.Parse("15:04", s.ArrivalTime); err != nil {
+			return fmt.Errorf("schedule %d: invalid arrival_time format, expected HH:MM", i)
+		}
+	}
+	return nil
+}
+
+// mapArrivalScheduleToResponse converts an arrival schedule model to API response
+func mapArrivalScheduleToResponse(s *schedule.StudentArrivalSchedule) ArrivalScheduleResponse {
+	return ArrivalScheduleResponse{
+		ID:              s.ID,
+		StudentID:       s.StudentID,
+		Weekday:         s.Weekday,
+		WeekdayName:     s.GetWeekdayName(),
+		ExpectedArrival: s.ExpectedArrival.Format("15:04"),
+		Notes:           s.Notes,
+		CreatedBy:       s.CreatedBy,
+		CreatedAt:       s.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:       s.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// mapArrivalExceptionToResponse converts an arrival exception model to API response
+func mapArrivalExceptionToResponse(e *schedule.StudentArrivalException) ArrivalExceptionResponse {
+	resp := ArrivalExceptionResponse{
+		ID:            e.ID,
+		StudentID:     e.StudentID,
+		ExceptionDate: e.ExceptionDate.Format(dateFormatISO),
+		Reason:        e.Reason,
+		CreatedBy:     e.CreatedBy,
+		CreatedAt:     e.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:     e.UpdatedAt.Format(time.RFC3339),
+	}
+	if e.ExpectedArrival != nil {
+		formatted := e.ExpectedArrival.Format("15:04")
+		resp.ExpectedArrival = &formatted
+	}
+	return resp
+}
+
+// mapArrivalNoteToResponse converts an arrival note model to API response
+func mapArrivalNoteToResponse(n *schedule.StudentArrivalNote) ArrivalNoteResponse {
+	return ArrivalNoteResponse{
+		ID:        n.ID,
+		StudentID: n.StudentID,
+		NoteDate:  n.NoteDate.Format(dateFormatISO),
+		Content:   n.Content,
+		CreatedBy: n.CreatedBy,
+		CreatedAt: n.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: n.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// verifyArrivalExceptionOwnership checks that an arrival exception exists and belongs to the given student.
+func (rs *Resource) verifyArrivalExceptionOwnership(w http.ResponseWriter, r *http.Request, exceptionID, studentID int64) *schedule.StudentArrivalException {
+	exception, err := rs.ArrivalScheduleService.GetStudentArrivalExceptionByID(r.Context(), exceptionID)
+	if err != nil || exception == nil {
+		renderError(w, r, ErrorNotFound(errors.New("arrival exception not found")))
+		return nil
+	}
+	if exception.StudentID != studentID {
+		renderError(w, r, ErrorForbidden(errors.New("exception does not belong to this student")))
+		return nil
+	}
+	return exception
+}
+
+// verifyArrivalNoteOwnership checks that an arrival note exists and belongs to the given student.
+func (rs *Resource) verifyArrivalNoteOwnership(w http.ResponseWriter, r *http.Request, noteID, studentID int64) *schedule.StudentArrivalNote {
+	note, err := rs.ArrivalScheduleService.GetStudentArrivalNoteByID(r.Context(), noteID)
+	if err != nil || note == nil {
+		renderError(w, r, ErrorNotFound(errors.New("arrival note not found")))
+		return nil
+	}
+	if note.StudentID != studentID {
+		renderError(w, r, ErrorForbidden(errors.New("note does not belong to this student")))
+		return nil
+	}
+	return note
+}
+
+// requireArrivalReadAccess parses the student from URL params and checks read access.
+func (rs *Resource) requireArrivalReadAccess(w http.ResponseWriter, r *http.Request) *users.Student {
+	student, ok := rs.parseAndGetStudent(w, r)
+	if !ok {
+		return nil
+	}
+	if !rs.checkStudentReadAccess(r, student) {
+		renderError(w, r, ErrorForbidden(fmt.Errorf("read access required to view arrival schedules")))
+		return nil
+	}
+	return student
+}
+
+// requireArrivalWriteAccess parses the student from URL params and verifies full access.
+func (rs *Resource) requireArrivalWriteAccess(w http.ResponseWriter, r *http.Request, action string) *users.Student {
+	student, ok := rs.parseAndGetStudent(w, r)
+	if !ok {
+		return nil
+	}
+	if !rs.checkStudentFullAccess(r, student) {
+		renderError(w, r, ErrorForbidden(fmt.Errorf("full access required to %s", action)))
+		return nil
+	}
+	return student
+}
+
+// getStudentArrivalSchedules handles GET /students/{id}/arrival-schedules
+func (rs *Resource) getStudentArrivalSchedules(w http.ResponseWriter, r *http.Request) {
+	student := rs.requireArrivalReadAccess(w, r)
+	if student == nil {
+		return
+	}
+
+	data, err := rs.ArrivalScheduleService.GetStudentArrivalData(r.Context(), student.ID)
+	if err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	response := buildArrivalDataResponse(data)
+	common.Respond(w, r, http.StatusOK, response, "Arrival schedules retrieved successfully")
+}
+
+// buildArrivalDataResponse converts service arrival data to API response
+func buildArrivalDataResponse(data *scheduleService.StudentArrivalData) ArrivalDataResponse {
+	response := ArrivalDataResponse{
+		Schedules:  make([]ArrivalScheduleResponse, 0, len(data.Schedules)),
+		Exceptions: make([]ArrivalExceptionResponse, 0, len(data.Exceptions)),
+		Notes:      make([]ArrivalNoteResponse, 0, len(data.Notes)),
+	}
+
+	for _, s := range data.Schedules {
+		response.Schedules = append(response.Schedules, mapArrivalScheduleToResponse(s))
+	}
+	for _, e := range data.Exceptions {
+		response.Exceptions = append(response.Exceptions, mapArrivalExceptionToResponse(e))
+	}
+	for _, n := range data.Notes {
+		response.Notes = append(response.Notes, mapArrivalNoteToResponse(n))
+	}
+
+	return response
+}
+
+// updateStudentArrivalSchedules handles PUT /students/{id}/arrival-schedules
+func (rs *Resource) updateStudentArrivalSchedules(w http.ResponseWriter, r *http.Request) {
+	student := rs.requireArrivalWriteAccess(w, r, "update arrival schedules")
+	if student == nil {
+		return
+	}
+
+	req := &BulkArrivalScheduleRequest{}
+	if err := render.Bind(r, req); err != nil {
+		renderError(w, r, ErrorInvalidRequest(err))
+		return
+	}
+
+	staffID, err := rs.getStaffIDFromJWT(r)
+	if err != nil {
+		renderError(w, r, ErrorForbidden(err))
+		return
+	}
+
+	schedules := make([]*schedule.StudentArrivalSchedule, 0, len(req.Schedules))
+	for _, s := range req.Schedules {
+		arrivalTime, _ := parseTimeOnly(s.ExpectedArrival)
+		schedules = append(schedules, &schedule.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         s.Weekday,
+			ExpectedArrival: arrivalTime,
+			Notes:           s.Notes,
+			CreatedBy:       staffID,
+		})
+	}
+
+	tenantID := tenant.FromContext(r.Context())
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return rs.ArrivalScheduleService.UpsertBulkStudentArrivalSchedules(ctx, student.ID, schedules)
+	}); err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	data, err := rs.ArrivalScheduleService.GetStudentArrivalData(r.Context(), student.ID)
+	if err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	response := buildArrivalDataResponse(data)
+	common.Respond(w, r, http.StatusOK, response, "Arrival schedules updated successfully")
+}
+
+// createStudentArrivalException handles POST /students/{id}/arrival-exceptions
+func (rs *Resource) createStudentArrivalException(w http.ResponseWriter, r *http.Request) {
+	student := rs.requireArrivalWriteAccess(w, r, "create arrival exceptions")
+	if student == nil {
+		return
+	}
+
+	req := &ArrivalExceptionRequest{}
+	if err := render.Bind(r, req); err != nil {
+		renderError(w, r, ErrorInvalidRequest(err))
+		return
+	}
+
+	staffID, err := rs.getStaffIDFromJWT(r)
+	if err != nil {
+		renderError(w, r, ErrorForbidden(err))
+		return
+	}
+
+	exceptionDate, _ := time.Parse(dateFormatISO, req.ExceptionDate)
+	exception := &schedule.StudentArrivalException{
+		StudentID:     student.ID,
+		ExceptionDate: exceptionDate,
+		Reason:        req.Reason,
+		CreatedBy:     staffID,
+	}
+
+	if req.ExpectedArrival != nil && *req.ExpectedArrival != "" {
+		arrivalTime, _ := parseTimeOnly(*req.ExpectedArrival)
+		exception.ExpectedArrival = &arrivalTime
+	}
+
+	tenantID := tenant.FromContext(r.Context())
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return rs.ArrivalScheduleService.CreateStudentArrivalException(ctx, exception)
+	}); err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusCreated, mapArrivalExceptionToResponse(exception), "Arrival exception created successfully")
+}
+
+// updateStudentArrivalException handles PUT /students/{id}/arrival-exceptions/{exceptionId}
+func (rs *Resource) updateStudentArrivalException(w http.ResponseWriter, r *http.Request) {
+	student := rs.requireArrivalWriteAccess(w, r, "update arrival exceptions")
+	if student == nil {
+		return
+	}
+
+	exceptionID, ok := parseEntityID(w, r, "exceptionId", "exception")
+	if !ok {
+		return
+	}
+
+	existingException := rs.verifyArrivalExceptionOwnership(w, r, exceptionID, student.ID)
+	if existingException == nil {
+		return
+	}
+
+	req := &ArrivalExceptionRequest{}
+	if err := render.Bind(r, req); err != nil {
+		renderError(w, r, ErrorInvalidRequest(err))
+		return
+	}
+
+	exceptionDate, _ := time.Parse(dateFormatISO, req.ExceptionDate)
+	exception := &schedule.StudentArrivalException{
+		StudentID:     student.ID,
+		ExceptionDate: exceptionDate,
+		Reason:        existingException.Reason,
+		CreatedBy:     existingException.CreatedBy,
+	}
+	exception.ID = exceptionID
+	exception.CreatedAt = existingException.CreatedAt
+	exception.SetTenantID(existingException.TenantID)
+
+	if req.Reason != nil {
+		exception.Reason = req.Reason
+	}
+
+	if req.ExpectedArrival != nil && *req.ExpectedArrival != "" {
+		arrivalTime, _ := parseTimeOnly(*req.ExpectedArrival)
+		exception.ExpectedArrival = &arrivalTime
+	}
+
+	tenantID := tenant.FromContext(r.Context())
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return rs.ArrivalScheduleService.UpdateStudentArrivalException(ctx, exception)
+	}); err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, mapArrivalExceptionToResponse(exception), "Arrival exception updated successfully")
+}
+
+// deleteStudentArrivalException handles DELETE /students/{id}/arrival-exceptions/{exceptionId}
+func (rs *Resource) deleteStudentArrivalException(w http.ResponseWriter, r *http.Request) {
+	student := rs.requireArrivalWriteAccess(w, r, "delete arrival exceptions")
+	if student == nil {
+		return
+	}
+
+	exceptionID, ok := parseEntityID(w, r, "exceptionId", "exception")
+	if !ok {
+		return
+	}
+
+	if rs.verifyArrivalExceptionOwnership(w, r, exceptionID, student.ID) == nil {
+		return
+	}
+
+	tenantID := tenant.FromContext(r.Context())
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return rs.ArrivalScheduleService.DeleteStudentArrivalException(ctx, exceptionID)
+	}); err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, nil, "Arrival exception deleted successfully")
+}
+
+// createStudentArrivalNote handles POST /students/{id}/arrival-notes
+func (rs *Resource) createStudentArrivalNote(w http.ResponseWriter, r *http.Request) {
+	student := rs.requireArrivalWriteAccess(w, r, "create arrival notes")
+	if student == nil {
+		return
+	}
+
+	req := &ArrivalNoteRequest{}
+	if err := render.Bind(r, req); err != nil {
+		renderError(w, r, ErrorInvalidRequest(err))
+		return
+	}
+
+	staffID, err := rs.getStaffIDFromJWT(r)
+	if err != nil {
+		renderError(w, r, ErrorForbidden(err))
+		return
+	}
+
+	noteDate, _ := time.Parse(dateFormatISO, req.NoteDate)
+	note := &schedule.StudentArrivalNote{
+		StudentID: student.ID,
+		NoteDate:  noteDate,
+		Content:   req.Content,
+		CreatedBy: staffID,
+	}
+
+	tenantID := tenant.FromContext(r.Context())
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return rs.ArrivalScheduleService.CreateStudentArrivalNote(ctx, note)
+	}); err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusCreated, mapArrivalNoteToResponse(note), "Arrival note created successfully")
+}
+
+// updateStudentArrivalNote handles PUT /students/{id}/arrival-notes/{noteId}
+func (rs *Resource) updateStudentArrivalNote(w http.ResponseWriter, r *http.Request) {
+	student := rs.requireArrivalWriteAccess(w, r, "update arrival notes")
+	if student == nil {
+		return
+	}
+
+	noteID, ok := parseEntityID(w, r, "noteId", "note")
+	if !ok {
+		return
+	}
+
+	existingNote := rs.verifyArrivalNoteOwnership(w, r, noteID, student.ID)
+	if existingNote == nil {
+		return
+	}
+
+	req := &ArrivalNoteRequest{}
+	if err := render.Bind(r, req); err != nil {
+		renderError(w, r, ErrorInvalidRequest(err))
+		return
+	}
+
+	noteDate, _ := time.Parse(dateFormatISO, req.NoteDate)
+	note := &schedule.StudentArrivalNote{
+		StudentID: student.ID,
+		NoteDate:  noteDate,
+		Content:   req.Content,
+		CreatedBy: existingNote.CreatedBy,
+	}
+	note.ID = noteID
+	note.CreatedAt = existingNote.CreatedAt
+	note.SetTenantID(existingNote.TenantID)
+
+	tenantID := tenant.FromContext(r.Context())
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return rs.ArrivalScheduleService.UpdateStudentArrivalNote(ctx, note)
+	}); err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, mapArrivalNoteToResponse(note), "Arrival note updated successfully")
+}
+
+// deleteStudentArrivalNote handles DELETE /students/{id}/arrival-notes/{noteId}
+func (rs *Resource) deleteStudentArrivalNote(w http.ResponseWriter, r *http.Request) {
+	student := rs.requireArrivalWriteAccess(w, r, "delete arrival notes")
+	if student == nil {
+		return
+	}
+
+	noteID, ok := parseEntityID(w, r, "noteId", "note")
+	if !ok {
+		return
+	}
+
+	existingNote := rs.verifyArrivalNoteOwnership(w, r, noteID, student.ID)
+	if existingNote == nil {
+		return
+	}
+
+	tenantID := tenant.FromContext(r.Context())
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return rs.ArrivalScheduleService.DeleteStudentArrivalNote(ctx, noteID)
+	}); err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, nil, "Arrival note deleted successfully")
+}
+
+// bulkUpsertArrivalSchedules handles POST /students/arrival-schedules/bulk
+func (rs *Resource) bulkUpsertArrivalSchedules(w http.ResponseWriter, r *http.Request) {
+	req := &BulkUpsertArrivalScheduleRequest{}
+	if err := render.Bind(r, req); err != nil {
+		renderError(w, r, ErrorInvalidRequest(err))
+		return
+	}
+
+	staffID, err := rs.getStaffIDFromJWT(r)
+	if err != nil {
+		renderError(w, r, ErrorForbidden(err))
+		return
+	}
+
+	result, err := rs.ArrivalScheduleService.BulkUpsertBySchoolClass(r.Context(), req.SchoolClass, req.Schedules, staffID)
+	if err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, result, "Bulk arrival schedules upserted successfully")
+}
+
+// BulkArrivalTimeRequest represents a request to get arrival times for multiple students
+type BulkArrivalTimeRequest struct {
+	StudentIDs []int64 `json:"student_ids"`
+	Date       *string `json:"date,omitempty"` // Optional date in YYYY-MM-DD format, defaults to today
+}
+
+// Bind implements render.Binder
+func (r *BulkArrivalTimeRequest) Bind(_ *http.Request) error {
+	if len(r.StudentIDs) == 0 {
+		return errors.New("student_ids array cannot be empty")
+	}
+	if len(r.StudentIDs) > 500 {
+		return errors.New("student_ids array cannot exceed 500 items")
+	}
+	if r.Date != nil && *r.Date != "" {
+		if _, err := time.Parse(dateFormatISO, *r.Date); err != nil {
+			return errors.New("invalid date format, expected YYYY-MM-DD")
+		}
+	}
+	return nil
+}
+
+// BulkArrivalDayNoteResponse represents a single day note in bulk arrival time responses
+type BulkArrivalDayNoteResponse struct {
+	ID      int64  `json:"id"`
+	Content string `json:"content"`
+}
+
+// BulkArrivalTimeResponse represents arrival time data for a single student
+type BulkArrivalTimeResponse struct {
+	StudentID       int64                        `json:"student_id"`
+	Date            string                       `json:"date"`
+	WeekdayName     string                       `json:"weekday_name"`
+	ExpectedArrival *string                      `json:"expected_arrival,omitempty"` // HH:MM format or null
+	IsException     bool                         `json:"is_exception"`
+	Notes           string                       `json:"notes,omitempty"`
+	DayNotes        []BulkArrivalDayNoteResponse `json:"day_notes,omitempty"`
+}
+
+// getBulkArrivalTimes handles POST /students/arrival-times/bulk
+func (rs *Resource) getBulkArrivalTimes(w http.ResponseWriter, r *http.Request) {
+	req := &BulkArrivalTimeRequest{}
+	if err := render.Bind(r, req); err != nil {
+		renderError(w, r, ErrorInvalidRequest(err))
+		return
+	}
+
+	// Filter student IDs to only those the user has access to
+	authorizedIDs, err := rs.filterAuthorizedStudentIDs(r, req.StudentIDs)
+	if err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	if len(authorizedIDs) == 0 {
+		common.Respond(w, r, http.StatusOK, []BulkArrivalTimeResponse{}, "Bulk arrival times retrieved successfully")
+		return
+	}
+
+	date := time.Now()
+	if req.Date != nil && *req.Date != "" {
+		parsedDate, _ := time.Parse(dateFormatISO, *req.Date)
+		date = parsedDate
+	}
+
+	arrivalTimes, err := rs.ArrivalScheduleService.GetBulkEffectiveArrivalTimesForDate(r.Context(), authorizedIDs, date)
+	if err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+
+	responses := make([]BulkArrivalTimeResponse, 0, len(arrivalTimes))
+	for studentID, eat := range arrivalTimes {
+		resp := BulkArrivalTimeResponse{
+			StudentID:   studentID,
+			Date:        eat.Date.Format(dateFormatISO),
+			WeekdayName: eat.WeekdayName,
+			IsException: eat.IsException,
+			Notes:       eat.Notes,
+		}
+		if eat.ArrivalTime != nil {
+			formatted := eat.ArrivalTime.Format("15:04")
+			resp.ExpectedArrival = &formatted
+		}
+		if len(eat.DayNotes) > 0 {
+			resp.DayNotes = make([]BulkArrivalDayNoteResponse, 0, len(eat.DayNotes))
+			for _, note := range eat.DayNotes {
+				resp.DayNotes = append(resp.DayNotes, BulkArrivalDayNoteResponse{
+					ID:      note.ID,
+					Content: note.Content,
+				})
+			}
+		}
+		responses = append(responses, resp)
+	}
+
+	common.Respond(w, r, http.StatusOK, responses, "Bulk arrival times retrieved successfully")
+}
+
+// Handler accessor methods for testing
+
+// GetStudentArrivalSchedulesHandler returns the handler for getting arrival schedules
+func (rs *Resource) GetStudentArrivalSchedulesHandler() http.HandlerFunc {
+	return rs.getStudentArrivalSchedules
+}
+
+// UpdateStudentArrivalSchedulesHandler returns the handler for updating arrival schedules
+func (rs *Resource) UpdateStudentArrivalSchedulesHandler() http.HandlerFunc {
+	return rs.updateStudentArrivalSchedules
+}
+
+// CreateStudentArrivalExceptionHandler returns the handler for creating arrival exceptions
+func (rs *Resource) CreateStudentArrivalExceptionHandler() http.HandlerFunc {
+	return rs.createStudentArrivalException
+}
+
+// UpdateStudentArrivalExceptionHandler returns the handler for updating arrival exceptions
+func (rs *Resource) UpdateStudentArrivalExceptionHandler() http.HandlerFunc {
+	return rs.updateStudentArrivalException
+}
+
+// DeleteStudentArrivalExceptionHandler returns the handler for deleting arrival exceptions
+func (rs *Resource) DeleteStudentArrivalExceptionHandler() http.HandlerFunc {
+	return rs.deleteStudentArrivalException
+}
+
+// CreateStudentArrivalNoteHandler returns the handler for creating arrival notes
+func (rs *Resource) CreateStudentArrivalNoteHandler() http.HandlerFunc {
+	return rs.createStudentArrivalNote
+}
+
+// UpdateStudentArrivalNoteHandler returns the handler for updating arrival notes
+func (rs *Resource) UpdateStudentArrivalNoteHandler() http.HandlerFunc {
+	return rs.updateStudentArrivalNote
+}
+
+// DeleteStudentArrivalNoteHandler returns the handler for deleting arrival notes
+func (rs *Resource) DeleteStudentArrivalNoteHandler() http.HandlerFunc {
+	return rs.deleteStudentArrivalNote
+}
+
+// BulkUpsertArrivalSchedulesHandler returns the handler for bulk upserting arrival schedules
+func (rs *Resource) BulkUpsertArrivalSchedulesHandler() http.HandlerFunc {
+	return rs.bulkUpsertArrivalSchedules
+}
+
+// GetBulkArrivalTimesHandler returns the handler for getting bulk arrival times
+func (rs *Resource) GetBulkArrivalTimesHandler() http.HandlerFunc {
+	return rs.getBulkArrivalTimes
+}

--- a/backend/api/students/arrival_schedule_handlers_test.go
+++ b/backend/api/students/arrival_schedule_handlers_test.go
@@ -1,0 +1,997 @@
+package students_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// =============================================================================
+// Get Arrival Schedules Tests
+// =============================================================================
+
+func TestGetStudentArrivalSchedules(t *testing.T) {
+	tc := setupTestContext(t)
+
+	student := testpkg.CreateTestStudent(t, tc.db, "ArrivalGet", "Test", "AG1")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+	router := setupRouter(tc.resource.GetStudentArrivalSchedulesHandler(), "id")
+
+	t.Run("success_returns_empty_schedules", func(t *testing.T) {
+		req := testutil.NewRequest("GET", fmt.Sprintf("/%d", student.ID), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusOK, rr.Code, "Expected 200 OK. Body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "schedules")
+		assert.Contains(t, rr.Body.String(), "exceptions")
+		assert.Contains(t, rr.Body.String(), "notes")
+	})
+
+	t.Run("success_returns_schedules_with_data", func(t *testing.T) {
+		studentWithData := testpkg.CreateTestStudent(t, tc.db, "ArrivalData", "Test", "AD1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, studentWithData.ID)
+
+		arrivalTime := time.Date(2000, 1, 1, 7, 45, 0, 0, time.UTC)
+		notes := "Kommt mit Schwester"
+		schedule := &scheduleModel.StudentArrivalSchedule{
+			StudentID:       studentWithData.ID,
+			Weekday:         1, // Monday
+			ExpectedArrival: arrivalTime,
+			Notes:           &notes,
+			CreatedBy:       1,
+		}
+		schedule.SetTenantID(1)
+		_, err := tc.db.NewInsert().Model(schedule).
+			ModelTableExpr("schedule.student_arrival_schedules").
+			Returning("id").
+			Exec(context.Background())
+		require.NoError(t, err)
+		defer func() {
+			_, _ = tc.db.NewDelete().Model((*scheduleModel.StudentArrivalSchedule)(nil)).
+				ModelTableExpr("schedule.student_arrival_schedules").
+				Where("student_id = ?", studentWithData.ID).
+				Exec(context.Background())
+		}()
+
+		// Insert an arrival exception
+		exceptionDate := time.Date(2026, 2, 15, 12, 0, 0, 0, timezone.Berlin)
+		exceptionTime := time.Date(2000, 1, 1, 9, 0, 0, 0, time.UTC)
+		arztterminReason := "Arzttermin"
+		exception := &scheduleModel.StudentArrivalException{
+			StudentID:       studentWithData.ID,
+			ExceptionDate:   exceptionDate,
+			ExpectedArrival: &exceptionTime,
+			Reason:          &arztterminReason,
+			CreatedBy:       1,
+		}
+		exception.SetTenantID(1)
+		_, err = tc.db.NewInsert().Model(exception).
+			ModelTableExpr("schedule.student_arrival_exceptions").
+			Returning("id").
+			Exec(context.Background())
+		require.NoError(t, err)
+		defer func() {
+			_, _ = tc.db.NewDelete().Model((*scheduleModel.StudentArrivalException)(nil)).
+				ModelTableExpr("schedule.student_arrival_exceptions").
+				Where("student_id = ?", studentWithData.ID).
+				Exec(context.Background())
+		}()
+
+		req := testutil.NewRequest("GET", fmt.Sprintf("/%d", studentWithData.ID), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusOK, rr.Code, "Expected 200 OK. Body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "07:45", "Should contain arrival time")
+		assert.Contains(t, rr.Body.String(), "Montag", "Should contain weekday name")
+		assert.Contains(t, rr.Body.String(), "Kommt mit Schwester", "Should contain notes")
+		assert.Contains(t, rr.Body.String(), "2026-02-15", "Should contain exception date")
+		assert.Contains(t, rr.Body.String(), "09:00", "Should contain exception arrival time")
+		assert.Contains(t, rr.Body.String(), "Arzttermin", "Should contain reason")
+	})
+
+	t.Run("not_found_for_nonexistent_student", func(t *testing.T) {
+		req := testutil.NewRequest("GET", "/999999", nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertNotFound(t, rr)
+	})
+
+	t.Run("forbidden_without_read_access", func(t *testing.T) {
+		staff, account := testpkg.CreateTestStaffWithAccount(t, tc.db, "NoAccess", "ArrStaff")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, staff.ID)
+
+		req := testutil.NewRequest("GET", fmt.Sprintf("/%d", student.ID), nil)
+		claims := testutil.TeacherTestClaims(int(account.ID))
+		rr := executeWithAuth(router, req, claims, []string{"students:read"})
+
+		assert.Equal(t, http.StatusForbidden, rr.Code, "Non-supervisor should be forbidden. Body: %s", rr.Body.String())
+	})
+}
+
+// =============================================================================
+// Update Arrival Schedules Tests
+// =============================================================================
+
+func TestUpdateStudentArrivalSchedules(t *testing.T) {
+	tc := setupTestContext(t)
+
+	router := setupRouterWithMethods(tc.resource.UpdateStudentArrivalSchedulesHandler(), "id", []string{"PUT"})
+
+	t.Run("success_updates_schedules", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrivalSuccess", "Test", "AST1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "Update", "ArrTeacher")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+		body := map[string]any{
+			"schedules": []map[string]any{
+				{"weekday": 1, "expected_arrival": "07:45"},
+				{"weekday": 3, "expected_arrival": "08:00"},
+			},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusOK, rr.Code, "Expected 200 OK. Body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "07:45", "Should contain first arrival time")
+		assert.Contains(t, rr.Body.String(), "08:00", "Should contain second arrival time")
+
+		// Cleanup created schedules
+		_, _ = tc.db.NewDelete().Model((*scheduleModel.StudentArrivalSchedule)(nil)).
+			ModelTableExpr("schedule.student_arrival_schedules").
+			Where("student_id = ?", student.ID).
+			Exec(context.Background())
+	})
+
+	t.Run("bad_request_empty_schedules", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrivalEmpty", "Test", "AE1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		body := map[string]any{
+			"schedules": []map[string]any{},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("bad_request_invalid_weekday", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrivalWeekday", "Test", "AW1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		body := map[string]any{
+			"schedules": []map[string]any{
+				{"weekday": 7, "expected_arrival": "08:00"},
+			},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("bad_request_invalid_time_format", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrivalTime", "Test", "AT1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		body := map[string]any{
+			"schedules": []map[string]any{
+				{"weekday": 1, "expected_arrival": "invalid"},
+			},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("bad_request_missing_time", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrivalNoTime", "Test", "ANT1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		body := map[string]any{
+			"schedules": []map[string]any{
+				{"weekday": 1},
+			},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("forbidden_without_full_access", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrivalForbidden", "Test", "AF1")
+		staff, account := testpkg.CreateTestStaffWithAccount(t, tc.db, "NoAccess", "ArrUpdateStaff")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID, staff.ID)
+
+		body := map[string]any{
+			"schedules": []map[string]any{
+				{"weekday": 1, "expected_arrival": "08:00"},
+			},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d", student.ID), body)
+		claims := testutil.TeacherTestClaims(int(account.ID))
+		rr := executeWithAuth(router, req, claims, []string{"students:write"})
+
+		testutil.AssertForbidden(t, rr)
+	})
+}
+
+// =============================================================================
+// Create Arrival Exception Tests
+// =============================================================================
+
+func TestCreateStudentArrivalException(t *testing.T) {
+	tc := setupTestContext(t)
+
+	router := setupRouterWithMethods(tc.resource.CreateStudentArrivalExceptionHandler(), "id", []string{"POST"})
+
+	t.Run("success_creates_exception", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcCreate", "Test", "AEC1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "Create", "ArrExcTeacher")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+		body := map[string]any{
+			"exception_date":   "2026-03-15",
+			"expected_arrival": "09:00",
+			"reason":           "Doctor appointment",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusCreated, rr.Code, "Expected 201 Created. Body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "2026-03-15", "Should contain exception date")
+		assert.Contains(t, rr.Body.String(), "09:00", "Should contain arrival time")
+		assert.Contains(t, rr.Body.String(), "Doctor appointment", "Should contain reason")
+
+		// Cleanup
+		_, _ = tc.db.NewDelete().Model((*scheduleModel.StudentArrivalException)(nil)).
+			ModelTableExpr("schedule.student_arrival_exceptions").
+			Where("student_id = ?", student.ID).
+			Exec(context.Background())
+	})
+
+	t.Run("success_creates_absent_exception", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcAbsent", "Test", "AEA1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "Absent", "ArrExcTeacher2")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+		body := map[string]any{
+			"exception_date": "2026-03-16",
+			"reason":         "Student is sick",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusCreated, rr.Code, "Expected 201 Created. Body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "2026-03-16", "Should contain exception date")
+		assert.Contains(t, rr.Body.String(), "Student is sick", "Should contain reason")
+
+		// Cleanup
+		_, _ = tc.db.NewDelete().Model((*scheduleModel.StudentArrivalException)(nil)).
+			ModelTableExpr("schedule.student_arrival_exceptions").
+			Where("student_id = ?", student.ID).
+			Exec(context.Background())
+	})
+
+	t.Run("bad_request_missing_date", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcNoDate", "Test", "AEND1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		body := map[string]any{
+			"expected_arrival": "09:00",
+			"reason":           "Test reason",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("bad_request_invalid_date_format", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcBadDate", "Test", "AEBD1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		body := map[string]any{
+			"exception_date":   "15-02-2026",
+			"expected_arrival": "09:00",
+			"reason":           "Test reason",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("bad_request_invalid_arrival_time_format", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcBadTime", "Test", "AEBT1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		body := map[string]any{
+			"exception_date":   "2026-02-15",
+			"expected_arrival": "invalid",
+			"reason":           "Test reason",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("bad_request_reason_too_long", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcLongReason", "Test", "AELR1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		longReason := make([]byte, 256)
+		for i := range longReason {
+			longReason[i] = 'a'
+		}
+		body := map[string]any{
+			"exception_date":   "2026-02-15",
+			"expected_arrival": "09:00",
+			"reason":           string(longReason),
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("forbidden_without_full_access", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcForbidden", "Test", "AEF1")
+		staff, account := testpkg.CreateTestStaffWithAccount(t, tc.db, "NoAccess", "ArrExcStaff")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID, staff.ID)
+
+		body := map[string]any{
+			"exception_date":   "2026-02-15",
+			"expected_arrival": "09:00",
+			"reason":           "Test reason",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		claims := testutil.TeacherTestClaims(int(account.ID))
+		rr := executeWithAuth(router, req, claims, []string{"students:write"})
+
+		testutil.AssertForbidden(t, rr)
+	})
+}
+
+// =============================================================================
+// Update Arrival Exception Tests
+// =============================================================================
+
+func TestUpdateStudentArrivalException(t *testing.T) {
+	tc := setupTestContext(t)
+
+	t.Run("success_updates_exception", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcUpdate", "Test", "AEU1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "Update", "ArrExcTeacher3")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+		exceptionDate := time.Date(2026, 4, 15, 12, 0, 0, 0, timezone.Berlin)
+		exceptionTime := time.Date(2000, 1, 1, 8, 0, 0, 0, time.UTC)
+		originalReason := "Original reason"
+		exception := &scheduleModel.StudentArrivalException{
+			StudentID:       student.ID,
+			ExceptionDate:   exceptionDate,
+			ExpectedArrival: &exceptionTime,
+			Reason:          &originalReason,
+			CreatedBy:       1,
+		}
+		exception.SetTenantID(1)
+		_, err := tc.db.NewInsert().Model(exception).
+			ModelTableExpr("schedule.student_arrival_exceptions").
+			Returning("id").
+			Exec(context.Background())
+		require.NoError(t, err)
+		defer func() {
+			_, _ = tc.db.NewDelete().Model((*scheduleModel.StudentArrivalException)(nil)).
+				ModelTableExpr("schedule.student_arrival_exceptions").
+				Where("id = ?", exception.ID).
+				Exec(context.Background())
+		}()
+
+		router := setupArrivalExceptionRouter(tc.resource.UpdateStudentArrivalExceptionHandler(), "PUT")
+
+		body := map[string]any{
+			"exception_date":   "2026-04-15",
+			"expected_arrival": "09:30",
+			"reason":           "Updated reason",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d/%d", student.ID, exception.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusOK, rr.Code, "Expected 200 OK. Body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "09:30", "Should contain updated arrival time")
+		assert.Contains(t, rr.Body.String(), "Updated reason", "Should contain updated reason")
+	})
+
+	t.Run("bad_request_invalid_exception_id", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcUpdateInvalid", "Test", "AEUI1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		router := setupArrivalExceptionRouter(tc.resource.UpdateStudentArrivalExceptionHandler(), "PUT")
+
+		body := map[string]any{
+			"exception_date":   "2026-02-15",
+			"expected_arrival": "09:00",
+			"reason":           "Updated reason",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d/abc", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("not_found_nonexistent_exception", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcUpdateNF", "Test", "AEUNF1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		router := setupArrivalExceptionRouter(tc.resource.UpdateStudentArrivalExceptionHandler(), "PUT")
+
+		body := map[string]any{
+			"exception_date":   "2026-02-15",
+			"expected_arrival": "09:00",
+			"reason":           "Updated reason",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d/999999", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertNotFound(t, rr)
+	})
+
+	t.Run("forbidden_without_full_access", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcUpdateForbid", "Test", "AEUF1")
+		staff, account := testpkg.CreateTestStaffWithAccount(t, tc.db, "NoAccess", "ArrUpdateExcStaff")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID, staff.ID)
+
+		router := setupArrivalExceptionRouter(tc.resource.UpdateStudentArrivalExceptionHandler(), "PUT")
+
+		body := map[string]any{
+			"exception_date":   "2026-02-15",
+			"expected_arrival": "09:00",
+			"reason":           "Updated reason",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d/1", student.ID), body)
+		claims := testutil.TeacherTestClaims(int(account.ID))
+		rr := executeWithAuth(router, req, claims, []string{"students:write"})
+
+		testutil.AssertForbidden(t, rr)
+	})
+}
+
+// =============================================================================
+// Delete Arrival Exception Tests
+// =============================================================================
+
+func TestDeleteStudentArrivalException(t *testing.T) {
+	tc := setupTestContext(t)
+
+	t.Run("success_deletes_exception", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcDelete", "Test", "AED1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		exceptionDate := time.Date(2026, 6, 15, 12, 0, 0, 0, timezone.Berlin)
+		deleteReason := "To be deleted"
+		exception := &scheduleModel.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: exceptionDate,
+			Reason:        &deleteReason,
+			CreatedBy:     1,
+		}
+		exception.SetTenantID(1)
+		_, err := tc.db.NewInsert().Model(exception).
+			ModelTableExpr("schedule.student_arrival_exceptions").
+			Returning("id").
+			Exec(context.Background())
+		require.NoError(t, err)
+
+		router := setupArrivalExceptionRouter(tc.resource.DeleteStudentArrivalExceptionHandler(), "DELETE")
+
+		req := testutil.NewRequest("DELETE", fmt.Sprintf("/%d/%d", student.ID, exception.ID), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusOK, rr.Code, "Expected 200 OK. Body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "deleted successfully")
+	})
+
+	t.Run("bad_request_invalid_exception_id", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcDeleteInvalid", "Test", "AEDI1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		router := setupArrivalExceptionRouter(tc.resource.DeleteStudentArrivalExceptionHandler(), "DELETE")
+
+		req := testutil.NewRequest("DELETE", fmt.Sprintf("/%d/invalid", student.ID), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("not_found_nonexistent_exception", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcDeleteNF", "Test", "AEDNF1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		router := setupArrivalExceptionRouter(tc.resource.DeleteStudentArrivalExceptionHandler(), "DELETE")
+
+		req := testutil.NewRequest("DELETE", fmt.Sprintf("/%d/999999", student.ID), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertNotFound(t, rr)
+	})
+
+	t.Run("forbidden_without_full_access", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrExcDeleteForbid", "Test", "AEDF1")
+		staff, account := testpkg.CreateTestStaffWithAccount(t, tc.db, "NoAccess", "ArrDeleteExcStaff")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID, staff.ID)
+
+		router := setupArrivalExceptionRouter(tc.resource.DeleteStudentArrivalExceptionHandler(), "DELETE")
+
+		req := testutil.NewRequest("DELETE", fmt.Sprintf("/%d/1", student.ID), nil)
+		claims := testutil.TeacherTestClaims(int(account.ID))
+		rr := executeWithAuth(router, req, claims, []string{"students:write"})
+
+		testutil.AssertForbidden(t, rr)
+	})
+}
+
+// =============================================================================
+// Create Arrival Note Tests
+// =============================================================================
+
+func TestCreateStudentArrivalNote(t *testing.T) {
+	tc := setupTestContext(t)
+
+	router := setupRouterWithMethods(tc.resource.CreateStudentArrivalNoteHandler(), "id", []string{"POST"})
+
+	t.Run("success_creates_note", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteCreate", "Test", "ANC1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "Create", "ArrNoteTeacher")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+		body := map[string]any{
+			"note_date": "2026-03-15",
+			"content":   "Arrives with school bus today",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusCreated, rr.Code, "Expected 201 Created. Body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "2026-03-15", "Should contain note date")
+		assert.Contains(t, rr.Body.String(), "Arrives with school bus today", "Should contain content")
+
+		// Cleanup
+		_, _ = tc.db.NewDelete().Model((*scheduleModel.StudentArrivalNote)(nil)).
+			ModelTableExpr("schedule.student_arrival_notes").
+			Where("student_id = ?", student.ID).
+			Exec(context.Background())
+	})
+
+	t.Run("bad_request_missing_date", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteNoDate", "Test", "ANND1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		body := map[string]any{
+			"content": "Test content",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+		assert.Contains(t, rr.Body.String(), "note_date is required")
+	})
+
+	t.Run("bad_request_invalid_date_format", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteBadDate", "Test", "ANBD1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		body := map[string]any{
+			"note_date": "15-03-2026",
+			"content":   "Test content",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+		assert.Contains(t, rr.Body.String(), "invalid note_date format")
+	})
+
+	t.Run("bad_request_missing_content", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteNoContent", "Test", "ANNC1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		body := map[string]any{
+			"note_date": "2026-03-15",
+			"content":   "",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+		assert.Contains(t, rr.Body.String(), "content is required")
+	})
+
+	t.Run("bad_request_content_too_long", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteLongContent", "Test", "ANLC1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		longContent := make([]byte, 501)
+		for i := range longContent {
+			longContent[i] = 'a'
+		}
+		body := map[string]any{
+			"note_date": "2026-03-15",
+			"content":   string(longContent),
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+		assert.Contains(t, rr.Body.String(), "content cannot exceed 500 characters")
+	})
+
+	t.Run("forbidden_without_full_access", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteForbidden", "Test", "ANF1")
+		staff, account := testpkg.CreateTestStaffWithAccount(t, tc.db, "NoAccess", "ArrNoteStaff")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID, staff.ID)
+
+		body := map[string]any{
+			"note_date": "2026-03-15",
+			"content":   "Test note",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d", student.ID), body)
+		claims := testutil.TeacherTestClaims(int(account.ID))
+		rr := executeWithAuth(router, req, claims, []string{"students:write"})
+
+		testutil.AssertForbidden(t, rr)
+	})
+}
+
+// =============================================================================
+// Update Arrival Note Tests
+// =============================================================================
+
+func TestUpdateStudentArrivalNote(t *testing.T) {
+	tc := setupTestContext(t)
+
+	t.Run("success_updates_note", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteUpdate", "Test", "ANU1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "Update", "ArrNoteTeacher2")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+		noteDate := time.Date(2026, 4, 15, 12, 0, 0, 0, timezone.Berlin)
+		note := &scheduleModel.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  noteDate,
+			Content:   "Original content",
+			CreatedBy: 1,
+		}
+		note.SetTenantID(1)
+		_, err := tc.db.NewInsert().Model(note).
+			ModelTableExpr("schedule.student_arrival_notes").
+			Returning("id").
+			Exec(context.Background())
+		require.NoError(t, err)
+		defer func() {
+			_, _ = tc.db.NewDelete().Model((*scheduleModel.StudentArrivalNote)(nil)).
+				ModelTableExpr("schedule.student_arrival_notes").
+				Where("id = ?", note.ID).
+				Exec(context.Background())
+		}()
+
+		router := setupArrivalNoteRouter(tc.resource.UpdateStudentArrivalNoteHandler(), "PUT")
+
+		body := map[string]any{
+			"note_date": "2026-04-15",
+			"content":   "Updated content",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d/%d", student.ID, note.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusOK, rr.Code, "Expected 200 OK. Body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "Updated content", "Should contain updated content")
+	})
+
+	t.Run("bad_request_invalid_note_id", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteUpdateInvalid", "Test", "ANUI1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		router := setupArrivalNoteRouter(tc.resource.UpdateStudentArrivalNoteHandler(), "PUT")
+
+		body := map[string]any{
+			"note_date": "2026-02-15",
+			"content":   "Updated content",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d/abc", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("not_found_nonexistent_note", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteUpdateNF", "Test", "ANUNF1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		router := setupArrivalNoteRouter(tc.resource.UpdateStudentArrivalNoteHandler(), "PUT")
+
+		body := map[string]any{
+			"note_date": "2026-02-15",
+			"content":   "Updated content",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "PUT", fmt.Sprintf("/%d/999999", student.ID), body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertNotFound(t, rr)
+	})
+}
+
+// =============================================================================
+// Delete Arrival Note Tests
+// =============================================================================
+
+func TestDeleteStudentArrivalNote(t *testing.T) {
+	tc := setupTestContext(t)
+
+	t.Run("success_deletes_note", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteDelete", "Test", "AND1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		noteDate := time.Date(2026, 6, 15, 12, 0, 0, 0, timezone.Berlin)
+		note := &scheduleModel.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  noteDate,
+			Content:   "To be deleted",
+			CreatedBy: 1,
+		}
+		note.SetTenantID(1)
+		_, err := tc.db.NewInsert().Model(note).
+			ModelTableExpr("schedule.student_arrival_notes").
+			Returning("id").
+			Exec(context.Background())
+		require.NoError(t, err)
+
+		router := setupArrivalNoteRouter(tc.resource.DeleteStudentArrivalNoteHandler(), "DELETE")
+
+		req := testutil.NewRequest("DELETE", fmt.Sprintf("/%d/%d", student.ID, note.ID), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusOK, rr.Code, "Expected 200 OK. Body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "deleted successfully")
+	})
+
+	t.Run("bad_request_invalid_note_id", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteDeleteInvalid", "Test", "ANDI1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		router := setupArrivalNoteRouter(tc.resource.DeleteStudentArrivalNoteHandler(), "DELETE")
+
+		req := testutil.NewRequest("DELETE", fmt.Sprintf("/%d/invalid", student.ID), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("not_found_nonexistent_note", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "ArrNoteDeleteNF", "Test", "ANDNF1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		router := setupArrivalNoteRouter(tc.resource.DeleteStudentArrivalNoteHandler(), "DELETE")
+
+		req := testutil.NewRequest("DELETE", fmt.Sprintf("/%d/999999", student.ID), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertNotFound(t, rr)
+	})
+}
+
+// =============================================================================
+// Bulk Upsert Arrival Schedules Tests
+// =============================================================================
+
+func TestBulkUpsertArrivalSchedules(t *testing.T) {
+	tc := setupTestContext(t)
+
+	router := chi.NewRouter()
+	router.Use(render.SetContentType(render.ContentTypeJSON))
+	router.Post("/", tc.resource.BulkUpsertArrivalSchedulesHandler())
+
+	t.Run("bad_request_missing_school_class", func(t *testing.T) {
+		body := map[string]any{
+			"school_class": "",
+			"schedules": []map[string]any{
+				{"weekday": 1, "arrival_time": "08:00"},
+			},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("bad_request_empty_schedules", func(t *testing.T) {
+		body := map[string]any{
+			"school_class": "1a",
+			"schedules":    []map[string]any{},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("bad_request_invalid_weekday", func(t *testing.T) {
+		body := map[string]any{
+			"school_class": "1a",
+			"schedules": []map[string]any{
+				{"weekday": 7, "arrival_time": "08:00"},
+			},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("success_with_valid_request", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "BulkArrival", "Test", "BAR1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "BulkArr", "Teacher")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+		body := map[string]any{
+			"school_class": "BAR1",
+			"schedules": []map[string]any{
+				{"weekday": 1, "arrival_time": "07:45"},
+				{"weekday": 3, "arrival_time": "08:15"},
+			},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusOK, rr.Code, "Expected 200 OK. Body: %s", rr.Body.String())
+
+		// Cleanup
+		_, _ = tc.db.NewDelete().Model((*scheduleModel.StudentArrivalSchedule)(nil)).
+			ModelTableExpr("schedule.student_arrival_schedules").
+			Where("student_id = ?", student.ID).
+			Exec(context.Background())
+	})
+}
+
+// =============================================================================
+// Get Bulk Arrival Times Tests
+// =============================================================================
+
+func TestGetBulkArrivalTimes(t *testing.T) {
+	tc := setupTestContext(t)
+
+	router := chi.NewRouter()
+	router.Use(render.SetContentType(render.ContentTypeJSON))
+	router.Post("/", tc.resource.GetBulkArrivalTimesHandler())
+
+	t.Run("bad_request_empty_student_ids", func(t *testing.T) {
+		body := map[string]any{
+			"student_ids": []int64{},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("bad_request_too_many_student_ids", func(t *testing.T) {
+		ids := make([]int64, 501)
+		for i := range ids {
+			ids[i] = int64(i + 1)
+		}
+		body := map[string]any{
+			"student_ids": ids,
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("bad_request_invalid_date_format", func(t *testing.T) {
+		body := map[string]any{
+			"student_ids": []int64{1, 2, 3},
+			"date":        "27-01-2026",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		testutil.AssertBadRequest(t, rr)
+	})
+
+	t.Run("success_with_valid_request", func(t *testing.T) {
+		student1 := testpkg.CreateTestStudent(t, tc.db, "BulkArrTime1", "Student", "BAT1")
+		student2 := testpkg.CreateTestStudent(t, tc.db, "BulkArrTime2", "Student", "BAT2")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student1.ID, student2.ID)
+
+		body := map[string]any{
+			"student_ids": []int64{student1.ID, student2.ID},
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("success_with_specific_date", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, tc.db, "BulkArrDateTest", "Student", "BADT1")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+
+		body := map[string]any{
+			"student_ids": []int64{student.ID},
+			"date":        "2026-01-27",
+		}
+		req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+// =============================================================================
+// Arrival-specific Helper Functions
+// =============================================================================
+
+// setupArrivalExceptionRouter creates a router for arrival exception endpoints with nested URL params
+func setupArrivalExceptionRouter(handler http.HandlerFunc, method string) chi.Router {
+	router := chi.NewRouter()
+	router.Use(render.SetContentType(render.ContentTypeJSON))
+	switch method {
+	case "GET":
+		router.Get("/{id}/{exceptionId}", handler)
+	case "POST":
+		router.Post("/{id}/{exceptionId}", handler)
+	case "PUT":
+		router.Put("/{id}/{exceptionId}", handler)
+	case "DELETE":
+		router.Delete("/{id}/{exceptionId}", handler)
+	}
+	return router
+}
+
+// setupArrivalNoteRouter creates a router for arrival note endpoints with nested URL params
+func setupArrivalNoteRouter(handler http.HandlerFunc, method string) chi.Router {
+	router := chi.NewRouter()
+	router.Use(render.SetContentType(render.ContentTypeJSON))
+	switch method {
+	case "GET":
+		router.Get("/{id}/{noteId}", handler)
+	case "POST":
+		router.Post("/{id}/{noteId}", handler)
+	case "PUT":
+		router.Put("/{id}/{noteId}", handler)
+	case "DELETE":
+		router.Delete("/{id}/{noteId}", handler)
+	}
+	return router
+}

--- a/backend/api/students/test_helpers_test.go
+++ b/backend/api/students/test_helpers_test.go
@@ -39,21 +39,22 @@ func setupTestContext(t *testing.T) *testContext {
 	require.NoError(t, err, "Failed to create service factory")
 
 	resource := studentsAPI.NewResource(studentsAPI.ResourceConfig{
-		PersonService:         svc.Users,
-		StudentRepo:           repoFactory.Student,
-		EducationService:      svc.Education,
-		UserContextService:    svc.UserContext,
-		ActiveService:         svc.Active,
-		IoTService:            svc.IoT,
-		PrivacyConsentRepo:    repoFactory.PrivacyConsent,
-		PickupScheduleService: svc.PickupSchedule,
-		SchoolRepo:            repoFactory.School,
-		SettingsService:       svc.Settings,
-		AttendanceRepo:        repoFactory.Attendance,
-		VisitRepo:             repoFactory.ActiveVisit,
-		DataAccessLogRepo:     repoFactory.DataAccessLog,
-		Logger:                slog.Default(),
-		DB:                    db,
+		PersonService:          svc.Users,
+		StudentRepo:            repoFactory.Student,
+		EducationService:       svc.Education,
+		UserContextService:     svc.UserContext,
+		ActiveService:          svc.Active,
+		IoTService:             svc.IoT,
+		PrivacyConsentRepo:     repoFactory.PrivacyConsent,
+		PickupScheduleService:  svc.PickupSchedule,
+		ArrivalScheduleService: svc.ArrivalSchedule,
+		SchoolRepo:             repoFactory.School,
+		SettingsService:        svc.Settings,
+		AttendanceRepo:         repoFactory.Attendance,
+		VisitRepo:              repoFactory.ActiveVisit,
+		DataAccessLogRepo:      repoFactory.DataAccessLog,
+		Logger:                 slog.Default(),
+		DB:                     db,
 	})
 
 	t.Cleanup(func() {

--- a/backend/database/migrations/001015032_create_arrival_schedules.go
+++ b/backend/database/migrations/001015032_create_arrival_schedules.go
@@ -1,0 +1,215 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	createArrivalSchedulesVersion     = "1.15.32"
+	createArrivalSchedulesDescription = "Create student arrival schedules, exceptions, and notes tables"
+)
+
+var CreateArrivalSchedulesDependsOn = []string{
+	UsersStudentsVersion, // Depends on students table (1.3.5)
+	"1.2.3",              // Depends on staff table
+	enableRLSVersion,     // Depends on RLS infrastructure (1.15.1)
+}
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     createArrivalSchedulesVersion,
+		Description: createArrivalSchedulesDescription,
+		DependsOn:   CreateArrivalSchedulesDependsOn,
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return createArrivalSchedulesUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return createArrivalSchedulesDown(ctx, db)
+		},
+	)
+}
+
+func createArrivalSchedulesUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.32: Creating student arrival schedules tables...")
+
+	// Create student_arrival_schedules table (weekly recurring)
+	_, err := db.NewRaw(`
+		CREATE TABLE IF NOT EXISTS schedule.student_arrival_schedules (
+			id BIGSERIAL PRIMARY KEY,
+			tenant_id BIGINT NOT NULL REFERENCES platform.schools(id),
+			student_id BIGINT NOT NULL REFERENCES users.students(id) ON DELETE CASCADE,
+			weekday INT NOT NULL CHECK (weekday BETWEEN 1 AND 5),
+			expected_arrival TIME NOT NULL,
+			notes VARCHAR(500),
+			created_by BIGINT NOT NULL REFERENCES users.staff(id),
+			created_at TIMESTAMPTZ DEFAULT NOW(),
+			updated_at TIMESTAMPTZ DEFAULT NOW(),
+			CONSTRAINT unique_arrival_student_weekday UNIQUE (tenant_id, student_id, weekday)
+		);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating student_arrival_schedules table: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		CREATE INDEX IF NOT EXISTS idx_arrival_schedules_student_id
+		ON schedule.student_arrival_schedules(student_id);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating index on student_id: %w", err)
+	}
+
+	// Enable RLS on arrival schedules
+	_, err = db.NewRaw(`ALTER TABLE schedule.student_arrival_schedules ENABLE ROW LEVEL SECURITY`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to enable RLS on student_arrival_schedules: %w", err)
+	}
+	_, err = db.NewRaw(`ALTER TABLE schedule.student_arrival_schedules FORCE ROW LEVEL SECURITY`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to force RLS on student_arrival_schedules: %w", err)
+	}
+	_, err = db.NewRaw(`
+		CREATE POLICY tenant_isolation_schedule_student_arrival_schedules
+		ON schedule.student_arrival_schedules FOR ALL
+		USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+		WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create RLS policy on student_arrival_schedules: %w", err)
+	}
+
+	// Create student_arrival_exceptions table (date-specific overrides)
+	_, err = db.NewRaw(`
+		CREATE TABLE IF NOT EXISTS schedule.student_arrival_exceptions (
+			id BIGSERIAL PRIMARY KEY,
+			tenant_id BIGINT NOT NULL REFERENCES platform.schools(id),
+			student_id BIGINT NOT NULL REFERENCES users.students(id) ON DELETE CASCADE,
+			exception_date DATE NOT NULL,
+			expected_arrival TIME,
+			reason VARCHAR(255),
+			created_by BIGINT NOT NULL REFERENCES users.staff(id),
+			created_at TIMESTAMPTZ DEFAULT NOW(),
+			updated_at TIMESTAMPTZ DEFAULT NOW(),
+			CONSTRAINT unique_arrival_student_exception_date UNIQUE (tenant_id, student_id, exception_date)
+		);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating student_arrival_exceptions table: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		CREATE INDEX IF NOT EXISTS idx_arrival_exceptions_student_id
+		ON schedule.student_arrival_exceptions(student_id);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating index on student_id: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		CREATE INDEX IF NOT EXISTS idx_arrival_exceptions_date
+		ON schedule.student_arrival_exceptions(exception_date);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating index on exception_date: %w", err)
+	}
+
+	// Enable RLS on arrival exceptions
+	_, err = db.NewRaw(`ALTER TABLE schedule.student_arrival_exceptions ENABLE ROW LEVEL SECURITY`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to enable RLS on student_arrival_exceptions: %w", err)
+	}
+	_, err = db.NewRaw(`ALTER TABLE schedule.student_arrival_exceptions FORCE ROW LEVEL SECURITY`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to force RLS on student_arrival_exceptions: %w", err)
+	}
+	_, err = db.NewRaw(`
+		CREATE POLICY tenant_isolation_schedule_student_arrival_exceptions
+		ON schedule.student_arrival_exceptions FOR ALL
+		USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+		WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create RLS policy on student_arrival_exceptions: %w", err)
+	}
+
+	// Create student_arrival_notes table
+	_, err = db.NewRaw(`
+		CREATE TABLE IF NOT EXISTS schedule.student_arrival_notes (
+			id BIGSERIAL PRIMARY KEY,
+			tenant_id BIGINT NOT NULL REFERENCES platform.schools(id),
+			student_id BIGINT NOT NULL REFERENCES users.students(id) ON DELETE CASCADE,
+			note_date DATE NOT NULL,
+			content VARCHAR(500) NOT NULL,
+			created_by BIGINT NOT NULL REFERENCES users.staff(id),
+			created_at TIMESTAMPTZ DEFAULT NOW(),
+			updated_at TIMESTAMPTZ DEFAULT NOW()
+		);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating student_arrival_notes table: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		CREATE INDEX IF NOT EXISTS idx_arrival_notes_student_date
+		ON schedule.student_arrival_notes(student_id, note_date);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating composite index on student_arrival_notes: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		CREATE INDEX IF NOT EXISTS idx_arrival_notes_student_id
+		ON schedule.student_arrival_notes(student_id);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating student_id index on student_arrival_notes: %w", err)
+	}
+
+	// Enable RLS on arrival notes
+	_, err = db.NewRaw(`ALTER TABLE schedule.student_arrival_notes ENABLE ROW LEVEL SECURITY`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to enable RLS on student_arrival_notes: %w", err)
+	}
+	_, err = db.NewRaw(`ALTER TABLE schedule.student_arrival_notes FORCE ROW LEVEL SECURITY`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to force RLS on student_arrival_notes: %w", err)
+	}
+	_, err = db.NewRaw(`
+		CREATE POLICY tenant_isolation_schedule_student_arrival_notes
+		ON schedule.student_arrival_notes FOR ALL
+		USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+		WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create RLS policy on student_arrival_notes: %w", err)
+	}
+
+	return nil
+}
+
+func createArrivalSchedulesDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.32: Dropping student arrival schedules tables...")
+
+	_, err := db.NewRaw(`DROP TABLE IF EXISTS schedule.student_arrival_notes CASCADE;`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed dropping student_arrival_notes table: %w", err)
+	}
+
+	_, err = db.NewRaw(`DROP TABLE IF EXISTS schedule.student_arrival_exceptions CASCADE;`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed dropping student_arrival_exceptions table: %w", err)
+	}
+
+	_, err = db.NewRaw(`DROP TABLE IF EXISTS schedule.student_arrival_schedules CASCADE;`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed dropping student_arrival_schedules table: %w", err)
+	}
+
+	return nil
+}

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -73,12 +73,15 @@ type Factory struct {
 	GradeTransition   educationModels.GradeTransitionRepository
 
 	// Schedule domain
-	Dateframe              scheduleModels.DateframeRepository
-	Timeframe              scheduleModels.TimeframeRepository
-	RecurrenceRule         scheduleModels.RecurrenceRuleRepository
-	StudentPickupSchedule  scheduleModels.StudentPickupScheduleRepository
-	StudentPickupException scheduleModels.StudentPickupExceptionRepository
-	StudentPickupNote      scheduleModels.StudentPickupNoteRepository
+	Dateframe               scheduleModels.DateframeRepository
+	Timeframe               scheduleModels.TimeframeRepository
+	RecurrenceRule          scheduleModels.RecurrenceRuleRepository
+	StudentPickupSchedule   scheduleModels.StudentPickupScheduleRepository
+	StudentPickupException  scheduleModels.StudentPickupExceptionRepository
+	StudentPickupNote       scheduleModels.StudentPickupNoteRepository
+	StudentArrivalSchedule  scheduleModels.StudentArrivalScheduleRepository
+	StudentArrivalException scheduleModels.StudentArrivalExceptionRepository
+	StudentArrivalNote      scheduleModels.StudentArrivalNoteRepository
 
 	// Activities domain
 	ActivityGroup      activitiesModels.GroupRepository
@@ -176,12 +179,15 @@ func NewFactory(db *bun.DB) *Factory {
 		GradeTransition:   education.NewGradeTransitionRepository(db),
 
 		// Schedule repositories
-		Dateframe:              schedule.NewDateframeRepository(db),
-		Timeframe:              schedule.NewTimeframeRepository(db),
-		RecurrenceRule:         schedule.NewRecurrenceRuleRepository(db),
-		StudentPickupSchedule:  schedule.NewStudentPickupScheduleRepository(db),
-		StudentPickupException: schedule.NewStudentPickupExceptionRepository(db),
-		StudentPickupNote:      schedule.NewStudentPickupNoteRepository(db),
+		Dateframe:               schedule.NewDateframeRepository(db),
+		Timeframe:               schedule.NewTimeframeRepository(db),
+		RecurrenceRule:          schedule.NewRecurrenceRuleRepository(db),
+		StudentPickupSchedule:   schedule.NewStudentPickupScheduleRepository(db),
+		StudentPickupException:  schedule.NewStudentPickupExceptionRepository(db),
+		StudentPickupNote:       schedule.NewStudentPickupNoteRepository(db),
+		StudentArrivalSchedule:  schedule.NewStudentArrivalScheduleRepository(db),
+		StudentArrivalException: schedule.NewStudentArrivalExceptionRepository(db),
+		StudentArrivalNote:      schedule.NewStudentArrivalNoteRepository(db),
 
 		// Activities repositories
 		ActivityGroup:      activities.NewGroupRepository(db),

--- a/backend/database/repositories/schedule/arrival_schedule_repo.go
+++ b/backend/database/repositories/schedule/arrival_schedule_repo.go
@@ -1,0 +1,724 @@
+package schedule
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/uptrace/bun"
+)
+
+// Table names for arrival schedule repositories.
+const (
+	tableArrivalSchedules  = "schedule.student_arrival_schedules"
+	tableArrivalExceptions = "schedule.student_arrival_exceptions"
+	tableArrivalNotes      = "schedule.student_arrival_notes"
+)
+
+// errArrivalScheduleNil is returned when a nil schedule is passed to a repository method.
+var errArrivalScheduleNil = fmt.Errorf("arrival schedule cannot be nil")
+
+// StudentArrivalScheduleRepository implements schedule.StudentArrivalScheduleRepository interface
+type StudentArrivalScheduleRepository struct {
+	*base.Repository[*schedule.StudentArrivalSchedule]
+	db *bun.DB
+}
+
+// NewStudentArrivalScheduleRepository creates a new StudentArrivalScheduleRepository
+func NewStudentArrivalScheduleRepository(db *bun.DB) schedule.StudentArrivalScheduleRepository {
+	repo := base.NewRepository[*schedule.StudentArrivalSchedule](db, tableArrivalSchedules, "StudentArrivalSchedule")
+	repo.TenantScoped = true
+	return &StudentArrivalScheduleRepository{
+		Repository: repo,
+		db:         db,
+	}
+}
+
+// FindByStudentID finds all arrival schedules for a student
+func (r *StudentArrivalScheduleRepository) FindByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalSchedule, error) {
+	var schedules []*schedule.StudentArrivalSchedule
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&schedules).
+		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`).
+		Where(`"student_arrival_schedule".student_id = ?`, studentID).
+		Order("weekday ASC")
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_schedule"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  opFindByStudentID,
+			Err: err,
+		}
+	}
+
+	return schedules, nil
+}
+
+// FindByStudentIDAndWeekday finds an arrival schedule for a specific student and weekday
+func (r *StudentArrivalScheduleRepository) FindByStudentIDAndWeekday(ctx context.Context, studentID int64, weekday int) (*schedule.StudentArrivalSchedule, error) {
+	var arrivalSchedule schedule.StudentArrivalSchedule
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&arrivalSchedule).
+		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`).
+		Where(`"student_arrival_schedule".student_id = ?`, studentID).
+		Where(`"student_arrival_schedule".weekday = ?`, weekday)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_schedule"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student id and weekday",
+			Err: err,
+		}
+	}
+
+	return &arrivalSchedule, nil
+}
+
+// FindByStudentIDsAndWeekday finds arrival schedules for multiple students and a specific weekday (bulk query)
+func (r *StudentArrivalScheduleRepository) FindByStudentIDsAndWeekday(ctx context.Context, studentIDs []int64, weekday int) ([]*schedule.StudentArrivalSchedule, error) {
+	if len(studentIDs) == 0 {
+		return []*schedule.StudentArrivalSchedule{}, nil
+	}
+
+	var schedules []*schedule.StudentArrivalSchedule
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&schedules).
+		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`).
+		Where(`"student_arrival_schedule".student_id IN (?)`, bun.List(studentIDs)).
+		Where(`"student_arrival_schedule".weekday = ?`, weekday)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_schedule"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student ids and weekday",
+			Err: err,
+		}
+	}
+
+	return schedules, nil
+}
+
+// UpsertSchedule creates or updates an arrival schedule for a student and weekday
+func (r *StudentArrivalScheduleRepository) UpsertSchedule(ctx context.Context, s *schedule.StudentArrivalSchedule) error {
+	if s == nil {
+		return errArrivalScheduleNil
+	}
+
+	if err := s.Validate(); err != nil {
+		return err
+	}
+
+	base.EnsureTenantID(ctx, s)
+
+	_, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(s).
+		ModelTableExpr(tableArrivalSchedules).
+		On("CONFLICT (tenant_id, student_id, weekday) DO UPDATE").
+		Set("expected_arrival = EXCLUDED.expected_arrival").
+		Set("notes = EXCLUDED.notes").
+		Set("updated_at = NOW()").
+		Returning("id").
+		Exec(ctx)
+
+	if err != nil {
+		return &modelBase.DatabaseError{
+			Op:  "upsert arrival schedule",
+			Err: err,
+		}
+	}
+
+	return nil
+}
+
+// DeleteByStudentID deletes all arrival schedules for a student
+func (r *StudentArrivalScheduleRepository) DeleteByStudentID(ctx context.Context, studentID int64) error {
+	query := base.GetDB(ctx, r.db).NewDelete().
+		Model((*schedule.StudentArrivalSchedule)(nil)).
+		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`).
+		Where(`"student_arrival_schedule".student_id = ?`, studentID)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_schedule"); ok {
+		query = query.Where(where, val)
+	}
+
+	_, err := query.Exec(ctx)
+	if err != nil {
+		return &modelBase.DatabaseError{
+			Op:  opDeleteByStudentID,
+			Err: err,
+		}
+	}
+
+	return nil
+}
+
+// Create overrides the base Create method to handle validation
+func (r *StudentArrivalScheduleRepository) Create(ctx context.Context, s *schedule.StudentArrivalSchedule) error {
+	if s == nil {
+		return errArrivalScheduleNil
+	}
+
+	if err := s.Validate(); err != nil {
+		return err
+	}
+
+	return r.Repository.Create(ctx, s)
+}
+
+// Update overrides the base Update method to handle validation
+func (r *StudentArrivalScheduleRepository) Update(ctx context.Context, s *schedule.StudentArrivalSchedule) error {
+	if s == nil {
+		return errArrivalScheduleNil
+	}
+
+	if err := s.Validate(); err != nil {
+		return err
+	}
+
+	return r.Repository.Update(ctx, s)
+}
+
+// List retrieves arrival schedules matching the provided query options
+func (r *StudentArrivalScheduleRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentArrivalSchedule, error) {
+	var schedules []*schedule.StudentArrivalSchedule
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&schedules).
+		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_schedule"); ok {
+		query = query.Where(where, val)
+	}
+
+	if options != nil {
+		query = options.ApplyToQuery(query)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list",
+			Err: err,
+		}
+	}
+
+	return schedules, nil
+}
+
+// FindByID overrides base method to ensure schema qualification
+func (r *StudentArrivalScheduleRepository) FindByID(ctx context.Context, id any) (*schedule.StudentArrivalSchedule, error) {
+	var arrivalSchedule schedule.StudentArrivalSchedule
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&arrivalSchedule).
+		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`).
+		Where(`"student_arrival_schedule".id = ?`, id)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_schedule"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  opFindByID,
+			Err: err,
+		}
+	}
+
+	return &arrivalSchedule, nil
+}
+
+// StudentArrivalExceptionRepository implements schedule.StudentArrivalExceptionRepository interface
+type StudentArrivalExceptionRepository struct {
+	*base.Repository[*schedule.StudentArrivalException]
+	db *bun.DB
+}
+
+// NewStudentArrivalExceptionRepository creates a new StudentArrivalExceptionRepository
+func NewStudentArrivalExceptionRepository(db *bun.DB) schedule.StudentArrivalExceptionRepository {
+	repo := base.NewRepository[*schedule.StudentArrivalException](db, tableArrivalExceptions, "StudentArrivalException")
+	repo.TenantScoped = true
+	return &StudentArrivalExceptionRepository{
+		Repository: repo,
+		db:         db,
+	}
+}
+
+// FindByStudentID finds all arrival exceptions for a student
+func (r *StudentArrivalExceptionRepository) FindByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error) {
+	var exceptions []*schedule.StudentArrivalException
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exceptions).
+		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
+		Where(`"student_arrival_exception".student_id = ?`, studentID).
+		Order("exception_date ASC")
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_exception"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  opFindByStudentID,
+			Err: err,
+		}
+	}
+
+	return exceptions, nil
+}
+
+// FindUpcomingByStudentID finds upcoming arrival exceptions for a student (from today onwards)
+func (r *StudentArrivalExceptionRepository) FindUpcomingByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error) {
+	var exceptions []*schedule.StudentArrivalException
+	today := timezone.Today()
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exceptions).
+		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
+		Where(`"student_arrival_exception".student_id = ?`, studentID).
+		Where(`"student_arrival_exception".exception_date >= ?`, today).
+		Order("exception_date ASC")
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_exception"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find upcoming by student id",
+			Err: err,
+		}
+	}
+
+	return exceptions, nil
+}
+
+// FindByStudentIDAndDate finds an arrival exception for a specific student and date
+func (r *StudentArrivalExceptionRepository) FindByStudentIDAndDate(ctx context.Context, studentID int64, date time.Time) (*schedule.StudentArrivalException, error) {
+	var exception schedule.StudentArrivalException
+	dateOnly := timezone.DateOfUTC(date)
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exception).
+		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
+		Where(`"student_arrival_exception".student_id = ?`, studentID).
+		Where(`"student_arrival_exception".exception_date = ?`, dateOnly)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_exception"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student id and date",
+			Err: err,
+		}
+	}
+
+	return &exception, nil
+}
+
+// FindByStudentIDsAndDate finds arrival exceptions for multiple students and a specific date (bulk query)
+func (r *StudentArrivalExceptionRepository) FindByStudentIDsAndDate(ctx context.Context, studentIDs []int64, date time.Time) ([]*schedule.StudentArrivalException, error) {
+	if len(studentIDs) == 0 {
+		return []*schedule.StudentArrivalException{}, nil
+	}
+
+	dateOnly := timezone.DateOfUTC(date)
+	var exceptions []*schedule.StudentArrivalException
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exceptions).
+		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
+		Where(`"student_arrival_exception".student_id IN (?)`, bun.List(studentIDs)).
+		Where(`"student_arrival_exception".exception_date = ?`, dateOnly)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_exception"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student ids and date",
+			Err: err,
+		}
+	}
+
+	return exceptions, nil
+}
+
+// DeleteByStudentID deletes all arrival exceptions for a student
+func (r *StudentArrivalExceptionRepository) DeleteByStudentID(ctx context.Context, studentID int64) error {
+	query := base.GetDB(ctx, r.db).NewDelete().
+		Model((*schedule.StudentArrivalException)(nil)).
+		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
+		Where(`"student_arrival_exception".student_id = ?`, studentID)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_exception"); ok {
+		query = query.Where(where, val)
+	}
+
+	_, err := query.Exec(ctx)
+	if err != nil {
+		return &modelBase.DatabaseError{
+			Op:  opDeleteByStudentID,
+			Err: err,
+		}
+	}
+
+	return nil
+}
+
+// DeletePastExceptions deletes all exceptions older than the given date
+func (r *StudentArrivalExceptionRepository) DeletePastExceptions(ctx context.Context, beforeDate time.Time) (int64, error) {
+	delQuery := base.GetDB(ctx, r.db).NewDelete().
+		Model((*schedule.StudentArrivalException)(nil)).
+		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
+		Where(`"student_arrival_exception".exception_date < ?`, beforeDate)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_exception"); ok {
+		delQuery = delQuery.Where(where, val)
+	}
+
+	result, err := delQuery.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "delete past exceptions",
+			Err: err,
+		}
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
+	return rowsAffected, nil
+}
+
+// Create overrides the base Create method to handle validation
+func (r *StudentArrivalExceptionRepository) Create(ctx context.Context, e *schedule.StudentArrivalException) error {
+	if e == nil {
+		return fmt.Errorf("exception cannot be nil")
+	}
+
+	if err := e.Validate(); err != nil {
+		return err
+	}
+
+	return r.Repository.Create(ctx, e)
+}
+
+// Update overrides the base Update method to handle validation
+func (r *StudentArrivalExceptionRepository) Update(ctx context.Context, e *schedule.StudentArrivalException) error {
+	if e == nil {
+		return fmt.Errorf("exception cannot be nil")
+	}
+
+	if err := e.Validate(); err != nil {
+		return err
+	}
+
+	return r.Repository.Update(ctx, e)
+}
+
+// List retrieves arrival exceptions matching the provided query options
+func (r *StudentArrivalExceptionRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentArrivalException, error) {
+	var exceptions []*schedule.StudentArrivalException
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exceptions).
+		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_exception"); ok {
+		query = query.Where(where, val)
+	}
+
+	if options != nil {
+		query = options.ApplyToQuery(query)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list",
+			Err: err,
+		}
+	}
+
+	return exceptions, nil
+}
+
+// FindByID overrides base method to ensure schema qualification
+func (r *StudentArrivalExceptionRepository) FindByID(ctx context.Context, id any) (*schedule.StudentArrivalException, error) {
+	var exception schedule.StudentArrivalException
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exception).
+		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
+		Where(`"student_arrival_exception".id = ?`, id)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_exception"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  opFindByID,
+			Err: err,
+		}
+	}
+
+	return &exception, nil
+}
+
+// StudentArrivalNoteRepository implements schedule.StudentArrivalNoteRepository interface
+type StudentArrivalNoteRepository struct {
+	*base.Repository[*schedule.StudentArrivalNote]
+	db *bun.DB
+}
+
+// NewStudentArrivalNoteRepository creates a new StudentArrivalNoteRepository
+func NewStudentArrivalNoteRepository(db *bun.DB) schedule.StudentArrivalNoteRepository {
+	repo := base.NewRepository[*schedule.StudentArrivalNote](db, tableArrivalNotes, "StudentArrivalNote")
+	repo.TenantScoped = true
+	return &StudentArrivalNoteRepository{
+		Repository: repo,
+		db:         db,
+	}
+}
+
+// FindByStudentID finds all arrival notes for a student
+func (r *StudentArrivalNoteRepository) FindByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalNote, error) {
+	var notes []*schedule.StudentArrivalNote
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&notes).
+		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
+		Where(`"student_arrival_note".student_id = ?`, studentID).
+		Order("note_date ASC", orderCreatedAtASC)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_note"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  opFindByStudentID,
+			Err: err,
+		}
+	}
+
+	return notes, nil
+}
+
+// FindByStudentIDAndDate finds all arrival notes for a student on a specific date
+func (r *StudentArrivalNoteRepository) FindByStudentIDAndDate(ctx context.Context, studentID int64, date time.Time) ([]*schedule.StudentArrivalNote, error) {
+	dateOnly := timezone.DateOfUTC(date)
+	var notes []*schedule.StudentArrivalNote
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&notes).
+		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
+		Where(`"student_arrival_note".student_id = ?`, studentID).
+		Where(`"student_arrival_note".note_date = ?`, dateOnly).
+		Order(orderCreatedAtASC)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_note"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student id and date",
+			Err: err,
+		}
+	}
+
+	return notes, nil
+}
+
+// FindByStudentIDsAndDate finds all arrival notes for multiple students on a specific date (bulk query)
+func (r *StudentArrivalNoteRepository) FindByStudentIDsAndDate(ctx context.Context, studentIDs []int64, date time.Time) ([]*schedule.StudentArrivalNote, error) {
+	if len(studentIDs) == 0 {
+		return []*schedule.StudentArrivalNote{}, nil
+	}
+
+	dateOnly := timezone.DateOfUTC(date)
+	var notes []*schedule.StudentArrivalNote
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&notes).
+		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
+		Where(`"student_arrival_note".student_id IN (?)`, bun.List(studentIDs)).
+		Where(`"student_arrival_note".note_date = ?`, dateOnly).
+		Order(orderCreatedAtASC)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_note"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student ids and date",
+			Err: err,
+		}
+	}
+
+	return notes, nil
+}
+
+// DeleteByStudentID deletes all arrival notes for a student
+func (r *StudentArrivalNoteRepository) DeleteByStudentID(ctx context.Context, studentID int64) error {
+	query := base.GetDB(ctx, r.db).NewDelete().
+		Model((*schedule.StudentArrivalNote)(nil)).
+		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
+		Where(`"student_arrival_note".student_id = ?`, studentID)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_note"); ok {
+		query = query.Where(where, val)
+	}
+
+	_, err := query.Exec(ctx)
+	if err != nil {
+		return &modelBase.DatabaseError{
+			Op:  opDeleteByStudentID,
+			Err: err,
+		}
+	}
+
+	return nil
+}
+
+// DeletePastNotes deletes all notes older than the given date
+func (r *StudentArrivalNoteRepository) DeletePastNotes(ctx context.Context, beforeDate time.Time) (int64, error) {
+	delQuery := base.GetDB(ctx, r.db).NewDelete().
+		Model((*schedule.StudentArrivalNote)(nil)).
+		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
+		Where(`"student_arrival_note".note_date < ?`, beforeDate)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_note"); ok {
+		delQuery = delQuery.Where(where, val)
+	}
+
+	result, err := delQuery.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "delete past notes",
+			Err: err,
+		}
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
+	return rowsAffected, nil
+}
+
+// Create overrides the base Create method to handle validation
+func (r *StudentArrivalNoteRepository) Create(ctx context.Context, n *schedule.StudentArrivalNote) error {
+	if n == nil {
+		return fmt.Errorf("note cannot be nil")
+	}
+
+	if err := n.Validate(); err != nil {
+		return err
+	}
+
+	return r.Repository.Create(ctx, n)
+}
+
+// Update overrides the base Update method to handle validation
+func (r *StudentArrivalNoteRepository) Update(ctx context.Context, n *schedule.StudentArrivalNote) error {
+	if n == nil {
+		return fmt.Errorf("note cannot be nil")
+	}
+
+	if err := n.Validate(); err != nil {
+		return err
+	}
+
+	return r.Repository.Update(ctx, n)
+}
+
+// List retrieves arrival notes matching the provided query options
+func (r *StudentArrivalNoteRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentArrivalNote, error) {
+	var notes []*schedule.StudentArrivalNote
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&notes).
+		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_note"); ok {
+		query = query.Where(where, val)
+	}
+
+	if options != nil {
+		query = options.ApplyToQuery(query)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list",
+			Err: err,
+		}
+	}
+
+	return notes, nil
+}
+
+// FindByID overrides base method to ensure schema qualification
+func (r *StudentArrivalNoteRepository) FindByID(ctx context.Context, id any) (*schedule.StudentArrivalNote, error) {
+	var note schedule.StudentArrivalNote
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&note).
+		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
+		Where(`"student_arrival_note".id = ?`, id)
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_note"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  opFindByID,
+			Err: err,
+		}
+	}
+
+	return &note, nil
+}

--- a/backend/database/repositories/schedule/arrival_schedule_test.go
+++ b/backend/database/repositories/schedule/arrival_schedule_test.go
@@ -1,0 +1,1203 @@
+package schedule_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// StudentArrivalScheduleRepository Tests
+// =============================================================================
+
+func TestStudentArrivalScheduleRepository_Create(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalScheduleRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates schedule successfully", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		schedule := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+
+		err := repo.Create(ctx, schedule)
+
+		require.NoError(t, err)
+		assert.Greater(t, schedule.ID, int64(0))
+	})
+
+	t.Run("fails validation on nil schedule", func(t *testing.T) {
+		err := repo.Create(ctx, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+
+	t.Run("fails validation on invalid schedule", func(t *testing.T) {
+		schedule := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       1,
+			Weekday:         10,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+
+		err := repo.Create(ctx, schedule)
+
+		require.Error(t, err)
+	})
+}
+
+func TestStudentArrivalScheduleRepository_FindByID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalScheduleRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds schedule by ID", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		schedule := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayTuesday,
+			ExpectedArrival: time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+		err := repo.Create(ctx, schedule)
+		require.NoError(t, err)
+
+		result, err := repo.FindByID(ctx, schedule.ID)
+
+		require.NoError(t, err)
+		assert.Equal(t, schedule.ID, result.ID)
+		assert.Equal(t, schedule.StudentID, result.StudentID)
+		assert.Equal(t, schedule.Weekday, result.Weekday)
+	})
+
+	t.Run("returns error when not found", func(t *testing.T) {
+		result, err := repo.FindByID(ctx, int64(99999999))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestStudentArrivalScheduleRepository_FindByStudentID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalScheduleRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds all schedules for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		for _, weekday := range []int{scheduleModels.WeekdayMonday, scheduleModels.WeekdayWednesday, scheduleModels.WeekdayFriday} {
+			schedule := &scheduleModels.StudentArrivalSchedule{
+				StudentID:       student.ID,
+				Weekday:         weekday,
+				ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+				CreatedBy:       1,
+			}
+			err := repo.Create(ctx, schedule)
+			require.NoError(t, err)
+		}
+
+		results, err := repo.FindByStudentID(ctx, student.ID)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+		assert.Equal(t, scheduleModels.WeekdayMonday, results[0].Weekday)
+		assert.Equal(t, scheduleModels.WeekdayWednesday, results[1].Weekday)
+		assert.Equal(t, scheduleModels.WeekdayFriday, results[2].Weekday)
+	})
+
+	t.Run("returns empty slice when no schedules found", func(t *testing.T) {
+		results, err := repo.FindByStudentID(ctx, int64(99999999))
+
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestStudentArrivalScheduleRepository_FindByStudentIDAndWeekday(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalScheduleRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds schedule for specific weekday", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		schedule := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayThursday,
+			ExpectedArrival: time.Date(2024, 1, 1, 8, 15, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+		err := repo.Create(ctx, schedule)
+		require.NoError(t, err)
+
+		result, err := repo.FindByStudentIDAndWeekday(ctx, student.ID, scheduleModels.WeekdayThursday)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, schedule.ID, result.ID)
+		assert.Equal(t, scheduleModels.WeekdayThursday, result.Weekday)
+	})
+
+	t.Run("returns nil when not found", func(t *testing.T) {
+		result, err := repo.FindByStudentIDAndWeekday(ctx, int64(99999999), scheduleModels.WeekdayMonday)
+
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestStudentArrivalScheduleRepository_FindByStudentIDsAndWeekday(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalScheduleRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds schedules for multiple students", func(t *testing.T) {
+		student1 := testpkg.CreateTestStudent(t, db, "ArrStudent", "One", "1a")
+		student2 := testpkg.CreateTestStudent(t, db, "ArrStudent", "Two", "1b")
+		defer testpkg.CleanupActivityFixtures(t, db, student1.ID, student2.ID)
+
+		for _, studentID := range []int64{student1.ID, student2.ID} {
+			schedule := &scheduleModels.StudentArrivalSchedule{
+				StudentID:       studentID,
+				Weekday:         scheduleModels.WeekdayFriday,
+				ExpectedArrival: time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC),
+				CreatedBy:       1,
+			}
+			err := repo.Create(ctx, schedule)
+			require.NoError(t, err)
+		}
+
+		results, err := repo.FindByStudentIDsAndWeekday(ctx, []int64{student1.ID, student2.ID}, scheduleModels.WeekdayFriday)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("returns empty slice for empty student IDs", func(t *testing.T) {
+		results, err := repo.FindByStudentIDsAndWeekday(ctx, []int64{}, scheduleModels.WeekdayMonday)
+
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestStudentArrivalScheduleRepository_UpsertSchedule(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalScheduleRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates new schedule when doesn't exist", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		schedule := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+
+		err := repo.UpsertSchedule(ctx, schedule)
+
+		require.NoError(t, err)
+		assert.Greater(t, schedule.ID, int64(0))
+	})
+
+	t.Run("updates existing schedule", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		schedule := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayTuesday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 30, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+		err := repo.UpsertSchedule(ctx, schedule)
+		require.NoError(t, err)
+
+		schedule.ExpectedArrival = time.Date(2024, 1, 1, 8, 15, 0, 0, time.UTC)
+		notes := "Updated notes"
+		schedule.Notes = &notes
+
+		err = repo.UpsertSchedule(ctx, schedule)
+
+		require.NoError(t, err)
+
+		result, err := repo.FindByStudentIDAndWeekday(ctx, student.ID, scheduleModels.WeekdayTuesday)
+		require.NoError(t, err)
+		assert.Equal(t, 8, result.ExpectedArrival.Hour())
+		assert.Equal(t, "Updated notes", *result.Notes)
+	})
+
+	t.Run("fails validation on nil schedule", func(t *testing.T) {
+		err := repo.UpsertSchedule(ctx, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+}
+
+func TestStudentArrivalScheduleRepository_Update(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalScheduleRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("updates schedule successfully", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		schedule := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+		err := repo.Create(ctx, schedule)
+		require.NoError(t, err)
+
+		schedule.ExpectedArrival = time.Date(2024, 1, 1, 9, 0, 0, 0, time.UTC)
+		notes := "Updated notes"
+		schedule.Notes = &notes
+
+		err = repo.Update(ctx, schedule)
+
+		require.NoError(t, err)
+
+		result, err := repo.FindByID(ctx, schedule.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 9, result.ExpectedArrival.Hour())
+		assert.Equal(t, "Updated notes", *result.Notes)
+	})
+
+	t.Run("fails validation on nil schedule", func(t *testing.T) {
+		err := repo.Update(ctx, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+
+	t.Run("fails validation on invalid schedule", func(t *testing.T) {
+		schedule := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       0, // Invalid
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+
+		err := repo.Update(ctx, schedule)
+
+		require.Error(t, err)
+	})
+}
+
+func TestStudentArrivalScheduleRepository_List(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalScheduleRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("lists all schedules", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		for _, weekday := range []int{scheduleModels.WeekdayMonday, scheduleModels.WeekdayTuesday} {
+			schedule := &scheduleModels.StudentArrivalSchedule{
+				StudentID:       student.ID,
+				Weekday:         weekday,
+				ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+				CreatedBy:       1,
+			}
+			err := repo.Create(ctx, schedule)
+			require.NoError(t, err)
+		}
+
+		results, err := repo.List(ctx, nil)
+
+		require.NoError(t, err)
+		// At least our 2 schedules should be present
+		assert.GreaterOrEqual(t, len(results), 2)
+	})
+
+	t.Run("lists with nil options", func(t *testing.T) {
+		results, err := repo.List(ctx, nil)
+
+		require.NoError(t, err)
+		assert.NotNil(t, results)
+	})
+}
+
+func TestStudentArrivalScheduleRepository_DeleteByStudentID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalScheduleRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes all schedules for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		for _, weekday := range []int{scheduleModels.WeekdayMonday, scheduleModels.WeekdayWednesday} {
+			schedule := &scheduleModels.StudentArrivalSchedule{
+				StudentID:       student.ID,
+				Weekday:         weekday,
+				ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+				CreatedBy:       1,
+			}
+			err := repo.Create(ctx, schedule)
+			require.NoError(t, err)
+		}
+
+		err := repo.DeleteByStudentID(ctx, student.ID)
+
+		require.NoError(t, err)
+
+		results, err := repo.FindByStudentID(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("succeeds when no schedules exist", func(t *testing.T) {
+		err := repo.DeleteByStudentID(ctx, int64(99999999))
+
+		require.NoError(t, err)
+	})
+}
+
+// =============================================================================
+// StudentArrivalExceptionRepository Tests
+// =============================================================================
+
+func TestStudentArrivalExceptionRepository_Create(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalExceptionRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates exception successfully", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: time.Date(2024, 2, 14, 12, 0, 0, 0, timezone.Berlin),
+			Reason:        strPtr("Doctor appointment"),
+			CreatedBy:     1,
+		}
+
+		err := repo.Create(ctx, exception)
+
+		require.NoError(t, err)
+		assert.Greater(t, exception.ID, int64(0))
+	})
+
+	t.Run("fails validation on nil exception", func(t *testing.T) {
+		err := repo.Create(ctx, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+}
+
+func TestStudentArrivalExceptionRepository_FindByStudentID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalExceptionRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds all exceptions for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		dates := []time.Time{
+			time.Date(2024, 2, 14, 12, 0, 0, 0, timezone.Berlin),
+			time.Date(2024, 2, 15, 12, 0, 0, 0, timezone.Berlin),
+		}
+
+		for _, date := range dates {
+			exception := &scheduleModels.StudentArrivalException{
+				StudentID:     student.ID,
+				ExceptionDate: date,
+				Reason:        strPtr("Test reason"),
+				CreatedBy:     1,
+			}
+			err := repo.Create(ctx, exception)
+			require.NoError(t, err)
+		}
+
+		results, err := repo.FindByStudentID(ctx, student.ID)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+		assert.True(t, results[0].ExceptionDate.Before(results[1].ExceptionDate))
+	})
+}
+
+func TestStudentArrivalExceptionRepository_FindUpcomingByStudentID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalExceptionRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds only upcoming exceptions", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		pastException := &scheduleModels.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: time.Now().AddDate(0, 0, -7),
+			Reason:        strPtr("Past exception"),
+			CreatedBy:     1,
+		}
+		err := repo.Create(ctx, pastException)
+		require.NoError(t, err)
+
+		futureException := &scheduleModels.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: time.Now().AddDate(0, 0, 7),
+			Reason:        strPtr("Future exception"),
+			CreatedBy:     1,
+		}
+		err = repo.Create(ctx, futureException)
+		require.NoError(t, err)
+
+		results, err := repo.FindUpcomingByStudentID(ctx, student.ID)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "Future exception", *results[0].Reason)
+	})
+}
+
+func TestStudentArrivalExceptionRepository_FindByStudentIDAndDate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalExceptionRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds exception for specific date", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		exceptionDate := time.Date(2024, 3, 20, 12, 0, 0, 0, timezone.Berlin)
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: exceptionDate,
+			Reason:        strPtr("Specific date exception"),
+			CreatedBy:     1,
+		}
+		err := repo.Create(ctx, exception)
+		require.NoError(t, err)
+
+		result, err := repo.FindByStudentIDAndDate(ctx, student.ID, exceptionDate)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, exception.ID, result.ID)
+	})
+
+	t.Run("returns nil when not found", func(t *testing.T) {
+		result, err := repo.FindByStudentIDAndDate(ctx, int64(99999999), time.Now())
+
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestStudentArrivalExceptionRepository_FindByStudentIDsAndDate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalExceptionRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds exceptions for multiple students on same date", func(t *testing.T) {
+		student1 := testpkg.CreateTestStudent(t, db, "ArrStudent", "One", "1a")
+		student2 := testpkg.CreateTestStudent(t, db, "ArrStudent", "Two", "1b")
+		defer testpkg.CleanupActivityFixtures(t, db, student1.ID, student2.ID)
+
+		exceptionDate := time.Date(2024, 4, 10, 12, 0, 0, 0, timezone.Berlin)
+
+		for _, studentID := range []int64{student1.ID, student2.ID} {
+			exception := &scheduleModels.StudentArrivalException{
+				StudentID:     studentID,
+				ExceptionDate: exceptionDate,
+				Reason:        strPtr("Group exception"),
+				CreatedBy:     1,
+			}
+			err := repo.Create(ctx, exception)
+			require.NoError(t, err)
+		}
+
+		results, err := repo.FindByStudentIDsAndDate(ctx, []int64{student1.ID, student2.ID}, exceptionDate)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("returns empty slice for empty student IDs", func(t *testing.T) {
+		results, err := repo.FindByStudentIDsAndDate(ctx, []int64{}, time.Now())
+
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestStudentArrivalExceptionRepository_FindByID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalExceptionRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds exception by ID", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: time.Date(2024, 5, 20, 12, 0, 0, 0, timezone.Berlin),
+			Reason:        strPtr("Test reason"),
+			CreatedBy:     1,
+		}
+		err := repo.Create(ctx, exception)
+		require.NoError(t, err)
+
+		result, err := repo.FindByID(ctx, exception.ID)
+
+		require.NoError(t, err)
+		assert.Equal(t, exception.ID, result.ID)
+		assert.Equal(t, "Test reason", *result.Reason)
+	})
+
+	t.Run("returns error when not found", func(t *testing.T) {
+		result, err := repo.FindByID(ctx, int64(99999999))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestStudentArrivalExceptionRepository_Update(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalExceptionRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("updates exception successfully", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		arrivalTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:       student.ID,
+			ExceptionDate:   time.Date(2024, 6, 15, 12, 0, 0, 0, timezone.Berlin),
+			ExpectedArrival: &arrivalTime,
+			Reason:          strPtr("Original reason"),
+			CreatedBy:       1,
+		}
+		err := repo.Create(ctx, exception)
+		require.NoError(t, err)
+
+		exception.Reason = strPtr("Updated reason")
+		newArrivalTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+		exception.ExpectedArrival = &newArrivalTime
+
+		err = repo.Update(ctx, exception)
+
+		require.NoError(t, err)
+
+		result, err := repo.FindByID(ctx, exception.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated reason", *result.Reason)
+		assert.Equal(t, 9, result.ExpectedArrival.Hour())
+	})
+
+	t.Run("fails validation on nil exception", func(t *testing.T) {
+		err := repo.Update(ctx, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+
+	t.Run("fails validation on invalid exception", func(t *testing.T) {
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:     0, // Invalid
+			ExceptionDate: time.Date(2024, 6, 15, 12, 0, 0, 0, timezone.Berlin),
+			Reason:        strPtr("Test"),
+			CreatedBy:     1,
+		}
+
+		err := repo.Update(ctx, exception)
+
+		require.Error(t, err)
+	})
+}
+
+func TestStudentArrivalExceptionRepository_List(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalExceptionRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("lists all exceptions", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		for i := 1; i <= 3; i++ {
+			exception := &scheduleModels.StudentArrivalException{
+				StudentID:     student.ID,
+				ExceptionDate: time.Now().AddDate(0, 0, i+100), // Far future to avoid conflicts
+				Reason:        strPtr("Test exception"),
+				CreatedBy:     1,
+			}
+			err := repo.Create(ctx, exception)
+			require.NoError(t, err)
+		}
+
+		results, err := repo.List(ctx, nil)
+
+		require.NoError(t, err)
+		// At least our 3 exceptions should be present
+		assert.GreaterOrEqual(t, len(results), 3)
+	})
+
+	t.Run("lists with nil options", func(t *testing.T) {
+		results, err := repo.List(ctx, nil)
+
+		require.NoError(t, err)
+		assert.NotNil(t, results)
+	})
+}
+
+func TestStudentArrivalExceptionRepository_DeleteByStudentID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalExceptionRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes all exceptions for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		for i := 0; i < 3; i++ {
+			exception := &scheduleModels.StudentArrivalException{
+				StudentID:     student.ID,
+				ExceptionDate: time.Now().AddDate(0, 0, i),
+				Reason:        strPtr("Exception"),
+				CreatedBy:     1,
+			}
+			err := repo.Create(ctx, exception)
+			require.NoError(t, err)
+		}
+
+		err := repo.DeleteByStudentID(ctx, student.ID)
+
+		require.NoError(t, err)
+
+		results, err := repo.FindByStudentID(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestStudentArrivalExceptionRepository_DeletePastExceptions(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalExceptionRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes only past exceptions", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		// Create past exceptions (will be deleted)
+		pastExceptionCount := 0
+		for i := -10; i < -5; i++ {
+			exception := &scheduleModels.StudentArrivalException{
+				StudentID:     student.ID,
+				ExceptionDate: time.Now().AddDate(0, 0, i),
+				Reason:        strPtr("Past exception"),
+				CreatedBy:     1,
+			}
+			err := repo.Create(ctx, exception)
+			require.NoError(t, err)
+			pastExceptionCount++
+		}
+
+		// Create future exceptions (should remain)
+		futureExceptionCount := 0
+		for i := 1; i <= 5; i++ {
+			exception := &scheduleModels.StudentArrivalException{
+				StudentID:     student.ID,
+				ExceptionDate: time.Now().AddDate(0, 0, i),
+				Reason:        strPtr("Future exception"),
+				CreatedBy:     1,
+			}
+			err := repo.Create(ctx, exception)
+			require.NoError(t, err)
+			futureExceptionCount++
+		}
+
+		cutoffDate := timezone.DateOfUTC(time.Now())
+		rowsAffected, err := repo.DeletePastExceptions(ctx, cutoffDate)
+
+		require.NoError(t, err)
+		// At minimum, our past exceptions should be deleted (may be more from other tests)
+		assert.GreaterOrEqual(t, rowsAffected, int64(pastExceptionCount))
+
+		// Verify THIS student's future exceptions remain intact
+		results, err := repo.FindByStudentID(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Len(t, results, futureExceptionCount)
+		for _, result := range results {
+			assert.True(t, result.ExceptionDate.After(cutoffDate) || result.ExceptionDate.Equal(cutoffDate))
+		}
+	})
+}
+
+// =============================================================================
+// StudentArrivalNoteRepository Tests
+// =============================================================================
+
+func TestStudentArrivalNoteRepository_Create(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalNoteRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates note successfully", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  time.Date(2024, 2, 14, 12, 0, 0, 0, timezone.Berlin),
+			Content:   "Arrives by school bus",
+			CreatedBy: 1,
+		}
+
+		err := repo.Create(ctx, note)
+
+		require.NoError(t, err)
+		assert.Greater(t, note.ID, int64(0))
+	})
+
+	t.Run("fails validation on nil note", func(t *testing.T) {
+		err := repo.Create(ctx, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+
+	t.Run("fails validation on invalid note", func(t *testing.T) {
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: 0, // Invalid
+			NoteDate:  time.Date(2024, 2, 14, 12, 0, 0, 0, timezone.Berlin),
+			Content:   "Test",
+			CreatedBy: 1,
+		}
+
+		err := repo.Create(ctx, note)
+
+		require.Error(t, err)
+	})
+}
+
+func TestStudentArrivalNoteRepository_FindByID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalNoteRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds note by ID", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  time.Date(2024, 5, 20, 12, 0, 0, 0, timezone.Berlin),
+			Content:   "Test note",
+			CreatedBy: 1,
+		}
+		err := repo.Create(ctx, note)
+		require.NoError(t, err)
+
+		result, err := repo.FindByID(ctx, note.ID)
+
+		require.NoError(t, err)
+		assert.Equal(t, note.ID, result.ID)
+		assert.Equal(t, "Test note", result.Content)
+	})
+
+	t.Run("returns error when not found", func(t *testing.T) {
+		result, err := repo.FindByID(ctx, int64(99999999))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestStudentArrivalNoteRepository_FindByStudentID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalNoteRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds all notes for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		dates := []time.Time{
+			time.Date(2024, 2, 14, 12, 0, 0, 0, timezone.Berlin),
+			time.Date(2024, 2, 15, 12, 0, 0, 0, timezone.Berlin),
+			time.Date(2024, 2, 16, 12, 0, 0, 0, timezone.Berlin),
+		}
+
+		for _, date := range dates {
+			note := &scheduleModels.StudentArrivalNote{
+				StudentID: student.ID,
+				NoteDate:  date,
+				Content:   "Test note",
+				CreatedBy: 1,
+			}
+			err := repo.Create(ctx, note)
+			require.NoError(t, err)
+		}
+
+		results, err := repo.FindByStudentID(ctx, student.ID)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+		// Results should be ordered by note_date ASC, then created_at ASC
+		assert.True(t, results[0].NoteDate.Before(results[1].NoteDate) || results[0].NoteDate.Equal(results[1].NoteDate))
+	})
+
+	t.Run("returns empty slice when no notes found", func(t *testing.T) {
+		results, err := repo.FindByStudentID(ctx, int64(99999999))
+
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestStudentArrivalNoteRepository_FindByStudentIDAndDate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalNoteRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds notes for specific date", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		targetDate := time.Date(2024, 3, 20, 12, 0, 0, 0, timezone.Berlin)
+
+		// Create multiple notes for target date
+		for i := 0; i < 2; i++ {
+			note := &scheduleModels.StudentArrivalNote{
+				StudentID: student.ID,
+				NoteDate:  targetDate,
+				Content:   fmt.Sprintf("Note %d", i),
+				CreatedBy: 1,
+			}
+			err := repo.Create(ctx, note)
+			require.NoError(t, err)
+		}
+
+		// Create note for different date
+		differentDate := targetDate.AddDate(0, 0, 1)
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  differentDate,
+			Content:   "Different date",
+			CreatedBy: 1,
+		}
+		err := repo.Create(ctx, note)
+		require.NoError(t, err)
+
+		results, err := repo.FindByStudentIDAndDate(ctx, student.ID, targetDate)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+		for _, result := range results {
+			assert.Equal(t, targetDate.Format("2006-01-02"), result.NoteDate.UTC().Format("2006-01-02"))
+		}
+	})
+
+	t.Run("returns empty slice when no notes found", func(t *testing.T) {
+		result, err := repo.FindByStudentIDAndDate(ctx, int64(99999999), time.Now())
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+}
+
+func TestStudentArrivalNoteRepository_FindByStudentIDsAndDate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalNoteRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds notes for multiple students on same date", func(t *testing.T) {
+		student1 := testpkg.CreateTestStudent(t, db, "ArrStudent", "One", "1a")
+		student2 := testpkg.CreateTestStudent(t, db, "ArrStudent", "Two", "1b")
+		defer testpkg.CleanupActivityFixtures(t, db, student1.ID, student2.ID)
+
+		noteDate := time.Date(2024, 4, 10, 12, 0, 0, 0, timezone.Berlin)
+
+		for _, studentID := range []int64{student1.ID, student2.ID} {
+			note := &scheduleModels.StudentArrivalNote{
+				StudentID: studentID,
+				NoteDate:  noteDate,
+				Content:   "Group note",
+				CreatedBy: 1,
+			}
+			err := repo.Create(ctx, note)
+			require.NoError(t, err)
+		}
+
+		results, err := repo.FindByStudentIDsAndDate(ctx, []int64{student1.ID, student2.ID}, noteDate)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("returns empty slice for empty student IDs", func(t *testing.T) {
+		results, err := repo.FindByStudentIDsAndDate(ctx, []int64{}, time.Now())
+
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestStudentArrivalNoteRepository_Update(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalNoteRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("updates note successfully", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  time.Date(2024, 6, 15, 12, 0, 0, 0, timezone.Berlin),
+			Content:   "Original content",
+			CreatedBy: 1,
+		}
+		err := repo.Create(ctx, note)
+		require.NoError(t, err)
+
+		note.Content = "Updated content"
+
+		err = repo.Update(ctx, note)
+
+		require.NoError(t, err)
+
+		result, err := repo.FindByID(ctx, note.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated content", result.Content)
+	})
+
+	t.Run("fails validation on nil note", func(t *testing.T) {
+		err := repo.Update(ctx, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+
+	t.Run("fails validation on invalid note", func(t *testing.T) {
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: 0, // Invalid
+			NoteDate:  time.Date(2024, 6, 15, 12, 0, 0, 0, timezone.Berlin),
+			Content:   "Test",
+			CreatedBy: 1,
+		}
+
+		err := repo.Update(ctx, note)
+
+		require.Error(t, err)
+	})
+}
+
+func TestStudentArrivalNoteRepository_List(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalNoteRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("lists all notes", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		for i := 1; i <= 3; i++ {
+			note := &scheduleModels.StudentArrivalNote{
+				StudentID: student.ID,
+				NoteDate:  time.Now().AddDate(0, 0, i+200), // Far future to avoid conflicts
+				Content:   "Test note",
+				CreatedBy: 1,
+			}
+			err := repo.Create(ctx, note)
+			require.NoError(t, err)
+		}
+
+		results, err := repo.List(ctx, nil)
+
+		require.NoError(t, err)
+		// At least our 3 notes should be present
+		assert.GreaterOrEqual(t, len(results), 3)
+	})
+
+	t.Run("lists with nil options", func(t *testing.T) {
+		results, err := repo.List(ctx, nil)
+
+		require.NoError(t, err)
+		assert.NotNil(t, results)
+	})
+}
+
+func TestStudentArrivalNoteRepository_DeleteByStudentID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalNoteRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes all notes for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		for i := 0; i < 3; i++ {
+			note := &scheduleModels.StudentArrivalNote{
+				StudentID: student.ID,
+				NoteDate:  time.Now().AddDate(0, 0, i),
+				Content:   "Note",
+				CreatedBy: 1,
+			}
+			err := repo.Create(ctx, note)
+			require.NoError(t, err)
+		}
+
+		err := repo.DeleteByStudentID(ctx, student.ID)
+
+		require.NoError(t, err)
+
+		results, err := repo.FindByStudentID(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("succeeds when no notes exist", func(t *testing.T) {
+		err := repo.DeleteByStudentID(ctx, int64(99999999))
+
+		require.NoError(t, err)
+	})
+}
+
+func TestStudentArrivalNoteRepository_DeletePastNotes(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewStudentArrivalNoteRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes only past notes", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		// Create past notes (will be deleted)
+		pastNoteCount := 0
+		for i := -10; i < -5; i++ {
+			note := &scheduleModels.StudentArrivalNote{
+				StudentID: student.ID,
+				NoteDate:  time.Now().AddDate(0, 0, i),
+				Content:   "Past note",
+				CreatedBy: 1,
+			}
+			err := repo.Create(ctx, note)
+			require.NoError(t, err)
+			pastNoteCount++
+		}
+
+		// Create future notes (should remain)
+		futureNoteCount := 0
+		for i := 1; i <= 5; i++ {
+			note := &scheduleModels.StudentArrivalNote{
+				StudentID: student.ID,
+				NoteDate:  time.Now().AddDate(0, 0, i),
+				Content:   "Future note",
+				CreatedBy: 1,
+			}
+			err := repo.Create(ctx, note)
+			require.NoError(t, err)
+			futureNoteCount++
+		}
+
+		cutoffDate := timezone.DateOfUTC(time.Now())
+		rowsAffected, err := repo.DeletePastNotes(ctx, cutoffDate)
+
+		require.NoError(t, err)
+		// At minimum, our past notes should be deleted (may be more from other tests)
+		assert.GreaterOrEqual(t, rowsAffected, int64(pastNoteCount))
+
+		// Verify THIS student's future notes remain intact
+		results, err := repo.FindByStudentID(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Len(t, results, futureNoteCount)
+		for _, result := range results {
+			assert.True(t, result.NoteDate.After(cutoffDate) || result.NoteDate.Equal(cutoffDate))
+		}
+	})
+}

--- a/backend/models/schedule/arrival_schedule.go
+++ b/backend/models/schedule/arrival_schedule.go
@@ -1,0 +1,274 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/uptrace/bun"
+)
+
+// Common validation error messages for arrival schedule models.
+const (
+	errMsgArrivalStudentIDRequired = "student_id is required"
+	errMsgArrivalCreatedByRequired = "created_by is required"
+)
+
+// StudentArrivalSchedule represents a recurring weekly arrival schedule for a student
+type StudentArrivalSchedule struct {
+	base.Model `bun:"schema:schedule,table:student_arrival_schedules"`
+	base.TenantModel
+
+	StudentID       int64     `bun:"student_id,notnull" json:"student_id"`
+	Weekday         int       `bun:"weekday,notnull" json:"weekday"`
+	ExpectedArrival time.Time `bun:"expected_arrival,notnull" json:"expected_arrival"`
+	Notes           *string   `bun:"notes" json:"notes,omitempty"`
+	CreatedBy       int64     `bun:"created_by,notnull" json:"created_by"`
+}
+
+func (s *StudentArrivalSchedule) BeforeAppendModel(query any) error {
+	if q, ok := query.(*bun.UpdateQuery); ok {
+		q.ModelTableExpr(`schedule.student_arrival_schedules AS "schedule"`)
+	}
+	if q, ok := query.(*bun.DeleteQuery); ok {
+		q.ModelTableExpr(`schedule.student_arrival_schedules AS "schedule"`)
+	}
+	return nil
+}
+
+// TableName returns the database table name
+func (s *StudentArrivalSchedule) TableName() string {
+	return "schedule.student_arrival_schedules"
+}
+
+// Validate ensures arrival schedule data is valid
+func (s *StudentArrivalSchedule) Validate() error {
+	if s.StudentID <= 0 {
+		return errors.New(errMsgArrivalStudentIDRequired)
+	}
+	if s.Weekday < WeekdayMonday || s.Weekday > WeekdayFriday {
+		return errors.New("weekday must be between 1 (Monday) and 5 (Friday)")
+	}
+	if s.ExpectedArrival.IsZero() {
+		return errors.New("expected_arrival is required")
+	}
+	if s.CreatedBy <= 0 {
+		return errors.New(errMsgArrivalCreatedByRequired)
+	}
+	if s.Notes != nil && len(*s.Notes) > 500 {
+		return errors.New("notes cannot exceed 500 characters")
+	}
+	return nil
+}
+
+// GetWeekdayName returns the German name for this schedule's weekday
+func (s *StudentArrivalSchedule) GetWeekdayName() string {
+	if name, ok := WeekdayNames[s.Weekday]; ok {
+		return name
+	}
+	return ""
+}
+
+// GetID implements the Entity interface
+func (s *StudentArrivalSchedule) GetID() any {
+	return s.ID
+}
+
+// GetCreatedAt implements the Entity interface
+func (s *StudentArrivalSchedule) GetCreatedAt() time.Time {
+	return s.CreatedAt
+}
+
+// GetUpdatedAt implements the Entity interface
+func (s *StudentArrivalSchedule) GetUpdatedAt() time.Time {
+	return s.UpdatedAt
+}
+
+// StudentArrivalException represents a date-specific arrival exception
+type StudentArrivalException struct {
+	base.Model `bun:"schema:schedule,table:student_arrival_exceptions"`
+	base.TenantModel
+
+	StudentID       int64      `bun:"student_id,notnull" json:"student_id"`
+	ExceptionDate   time.Time  `bun:"exception_date,notnull" json:"exception_date"`
+	ExpectedArrival *time.Time `bun:"expected_arrival" json:"expected_arrival,omitempty"`
+	Reason          *string    `bun:"reason" json:"reason,omitempty"`
+	CreatedBy       int64      `bun:"created_by,notnull" json:"created_by"`
+}
+
+func (e *StudentArrivalException) BeforeAppendModel(query any) error {
+	if q, ok := query.(*bun.UpdateQuery); ok {
+		q.ModelTableExpr(`schedule.student_arrival_exceptions AS "exception"`)
+	}
+	if q, ok := query.(*bun.DeleteQuery); ok {
+		q.ModelTableExpr(`schedule.student_arrival_exceptions AS "exception"`)
+	}
+	return nil
+}
+
+// TableName returns the database table name
+func (e *StudentArrivalException) TableName() string {
+	return "schedule.student_arrival_exceptions"
+}
+
+// Validate ensures arrival exception data is valid
+func (e *StudentArrivalException) Validate() error {
+	if e.StudentID <= 0 {
+		return errors.New(errMsgArrivalStudentIDRequired)
+	}
+	if e.ExceptionDate.IsZero() {
+		return errors.New("exception_date is required")
+	}
+	if e.Reason != nil && len(*e.Reason) > 255 {
+		return errors.New("reason cannot exceed 255 characters")
+	}
+	if e.CreatedBy <= 0 {
+		return errors.New(errMsgArrivalCreatedByRequired)
+	}
+	return nil
+}
+
+// IsAbsent returns true if this exception indicates the student will not arrive (no arrival)
+func (e *StudentArrivalException) IsAbsent() bool {
+	return e.ExpectedArrival == nil
+}
+
+// GetID implements the Entity interface
+func (e *StudentArrivalException) GetID() any {
+	return e.ID
+}
+
+// GetCreatedAt implements the Entity interface
+func (e *StudentArrivalException) GetCreatedAt() time.Time {
+	return e.CreatedAt
+}
+
+// GetUpdatedAt implements the Entity interface
+func (e *StudentArrivalException) GetUpdatedAt() time.Time {
+	return e.UpdatedAt
+}
+
+// StudentArrivalNote represents a date-specific note for a student's arrival
+type StudentArrivalNote struct {
+	base.Model `bun:"schema:schedule,table:student_arrival_notes"`
+	base.TenantModel
+
+	StudentID int64     `bun:"student_id,notnull" json:"student_id"`
+	NoteDate  time.Time `bun:"note_date,notnull" json:"note_date"`
+	Content   string    `bun:"content,notnull" json:"content"`
+	CreatedBy int64     `bun:"created_by,notnull" json:"created_by"`
+}
+
+func (n *StudentArrivalNote) BeforeAppendModel(query any) error {
+	if q, ok := query.(*bun.UpdateQuery); ok {
+		q.ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`)
+	}
+	if q, ok := query.(*bun.DeleteQuery); ok {
+		q.ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`)
+	}
+	return nil
+}
+
+// TableName returns the database table name
+func (n *StudentArrivalNote) TableName() string {
+	return "schedule.student_arrival_notes"
+}
+
+// Validate ensures arrival note data is valid
+func (n *StudentArrivalNote) Validate() error {
+	if n.StudentID <= 0 {
+		return errors.New(errMsgArrivalStudentIDRequired)
+	}
+	if n.NoteDate.IsZero() {
+		return errors.New("note_date is required")
+	}
+	if n.Content == "" {
+		return errors.New("content is required")
+	}
+	if len(n.Content) > 500 {
+		return errors.New("content cannot exceed 500 characters")
+	}
+	if n.CreatedBy <= 0 {
+		return errors.New(errMsgArrivalCreatedByRequired)
+	}
+	return nil
+}
+
+// GetID implements the Entity interface
+func (n *StudentArrivalNote) GetID() any {
+	return n.ID
+}
+
+// GetCreatedAt implements the Entity interface
+func (n *StudentArrivalNote) GetCreatedAt() time.Time {
+	return n.CreatedAt
+}
+
+// GetUpdatedAt implements the Entity interface
+func (n *StudentArrivalNote) GetUpdatedAt() time.Time {
+	return n.UpdatedAt
+}
+
+// StudentArrivalScheduleRepository defines operations for managing student arrival schedules
+type StudentArrivalScheduleRepository interface {
+	base.Repository[*StudentArrivalSchedule]
+
+	// FindByStudentID finds all arrival schedules for a student
+	FindByStudentID(ctx context.Context, studentID int64) ([]*StudentArrivalSchedule, error)
+
+	// FindByStudentIDAndWeekday finds an arrival schedule for a specific student and weekday
+	FindByStudentIDAndWeekday(ctx context.Context, studentID int64, weekday int) (*StudentArrivalSchedule, error)
+
+	// FindByStudentIDsAndWeekday finds arrival schedules for multiple students and a specific weekday (bulk query)
+	FindByStudentIDsAndWeekday(ctx context.Context, studentIDs []int64, weekday int) ([]*StudentArrivalSchedule, error)
+
+	// UpsertSchedule creates or updates an arrival schedule for a student and weekday
+	UpsertSchedule(ctx context.Context, schedule *StudentArrivalSchedule) error
+
+	// DeleteByStudentID deletes all arrival schedules for a student
+	DeleteByStudentID(ctx context.Context, studentID int64) error
+}
+
+// StudentArrivalExceptionRepository defines operations for managing student arrival exceptions
+type StudentArrivalExceptionRepository interface {
+	base.Repository[*StudentArrivalException]
+
+	// FindByStudentID finds all arrival exceptions for a student
+	FindByStudentID(ctx context.Context, studentID int64) ([]*StudentArrivalException, error)
+
+	// FindUpcomingByStudentID finds upcoming arrival exceptions for a student (from today onwards)
+	FindUpcomingByStudentID(ctx context.Context, studentID int64) ([]*StudentArrivalException, error)
+
+	// FindByStudentIDAndDate finds an arrival exception for a specific student and date
+	FindByStudentIDAndDate(ctx context.Context, studentID int64, date time.Time) (*StudentArrivalException, error)
+
+	// FindByStudentIDsAndDate finds arrival exceptions for multiple students and a specific date (bulk query)
+	FindByStudentIDsAndDate(ctx context.Context, studentIDs []int64, date time.Time) ([]*StudentArrivalException, error)
+
+	// DeleteByStudentID deletes all arrival exceptions for a student
+	DeleteByStudentID(ctx context.Context, studentID int64) error
+
+	// DeletePastExceptions deletes all exceptions older than the given date
+	DeletePastExceptions(ctx context.Context, beforeDate time.Time) (int64, error)
+}
+
+// StudentArrivalNoteRepository defines operations for managing student arrival notes
+type StudentArrivalNoteRepository interface {
+	base.Repository[*StudentArrivalNote]
+
+	// FindByStudentID finds all arrival notes for a student
+	FindByStudentID(ctx context.Context, studentID int64) ([]*StudentArrivalNote, error)
+
+	// FindByStudentIDAndDate finds all arrival notes for a student on a specific date
+	FindByStudentIDAndDate(ctx context.Context, studentID int64, date time.Time) ([]*StudentArrivalNote, error)
+
+	// FindByStudentIDsAndDate finds all arrival notes for multiple students on a specific date (bulk query)
+	FindByStudentIDsAndDate(ctx context.Context, studentIDs []int64, date time.Time) ([]*StudentArrivalNote, error)
+
+	// DeleteByStudentID deletes all arrival notes for a student
+	DeleteByStudentID(ctx context.Context, studentID int64) error
+
+	// DeletePastNotes deletes all notes older than the given date
+	DeletePastNotes(ctx context.Context, beforeDate time.Time) (int64, error)
+}

--- a/backend/models/schedule/arrival_schedule_test.go
+++ b/backend/models/schedule/arrival_schedule_test.go
@@ -1,0 +1,594 @@
+package schedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// StudentArrivalSchedule Validation Tests
+// =============================================================================
+
+func TestStudentArrivalSchedule_Validate(t *testing.T) {
+	validTime := time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		setup   func() *StudentArrivalSchedule
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid schedule",
+			setup: func() *StudentArrivalSchedule {
+				return &StudentArrivalSchedule{
+					StudentID:       1,
+					Weekday:         WeekdayMonday,
+					ExpectedArrival: validTime,
+					CreatedBy:       1,
+					Notes:           nil,
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid schedule with notes",
+			setup: func() *StudentArrivalSchedule {
+				notes := "Arrives with older sibling"
+				return &StudentArrivalSchedule{
+					StudentID:       1,
+					Weekday:         WeekdayFriday,
+					ExpectedArrival: validTime,
+					CreatedBy:       1,
+					Notes:           &notes,
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing student_id",
+			setup: func() *StudentArrivalSchedule {
+				return &StudentArrivalSchedule{
+					StudentID:       0,
+					Weekday:         WeekdayMonday,
+					ExpectedArrival: validTime,
+					CreatedBy:       1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "student_id is required",
+		},
+		{
+			name: "negative student_id",
+			setup: func() *StudentArrivalSchedule {
+				return &StudentArrivalSchedule{
+					StudentID:       -1,
+					Weekday:         WeekdayMonday,
+					ExpectedArrival: validTime,
+					CreatedBy:       1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "student_id is required",
+		},
+		{
+			name: "weekday too low",
+			setup: func() *StudentArrivalSchedule {
+				return &StudentArrivalSchedule{
+					StudentID:       1,
+					Weekday:         0,
+					ExpectedArrival: validTime,
+					CreatedBy:       1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "weekday must be between 1 (Monday) and 5 (Friday)",
+		},
+		{
+			name: "weekday too high (weekend)",
+			setup: func() *StudentArrivalSchedule {
+				return &StudentArrivalSchedule{
+					StudentID:       1,
+					Weekday:         6,
+					ExpectedArrival: validTime,
+					CreatedBy:       1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "weekday must be between 1 (Monday) and 5 (Friday)",
+		},
+		{
+			name: "negative weekday",
+			setup: func() *StudentArrivalSchedule {
+				return &StudentArrivalSchedule{
+					StudentID:       1,
+					Weekday:         -1,
+					ExpectedArrival: validTime,
+					CreatedBy:       1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "weekday must be between 1 (Monday) and 5 (Friday)",
+		},
+		{
+			name: "missing expected_arrival",
+			setup: func() *StudentArrivalSchedule {
+				return &StudentArrivalSchedule{
+					StudentID: 1,
+					Weekday:   WeekdayMonday,
+					CreatedBy: 1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "expected_arrival is required",
+		},
+		{
+			name: "missing created_by",
+			setup: func() *StudentArrivalSchedule {
+				return &StudentArrivalSchedule{
+					StudentID:       1,
+					Weekday:         WeekdayMonday,
+					ExpectedArrival: validTime,
+					CreatedBy:       0,
+				}
+			},
+			wantErr: true,
+			errMsg:  "created_by is required",
+		},
+		{
+			name: "notes too long",
+			setup: func() *StudentArrivalSchedule {
+				longNotes := string(make([]byte, 501))
+				return &StudentArrivalSchedule{
+					StudentID:       1,
+					Weekday:         WeekdayMonday,
+					ExpectedArrival: validTime,
+					CreatedBy:       1,
+					Notes:           &longNotes,
+				}
+			},
+			wantErr: true,
+			errMsg:  "notes cannot exceed 500 characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.setup()
+			err := s.Validate()
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStudentArrivalSchedule_GetWeekdayName(t *testing.T) {
+	tests := []struct {
+		name         string
+		weekday      int
+		expectedName string
+	}{
+		{"Monday", WeekdayMonday, "Montag"},
+		{"Tuesday", WeekdayTuesday, "Dienstag"},
+		{"Wednesday", WeekdayWednesday, "Mittwoch"},
+		{"Thursday", WeekdayThursday, "Donnerstag"},
+		{"Friday", WeekdayFriday, "Freitag"},
+		{"Saturday", WeekdaySaturday, "Samstag"},
+		{"Sunday", WeekdaySunday, "Sonntag"},
+		{"Invalid weekday", 0, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &StudentArrivalSchedule{Weekday: tt.weekday}
+			result := s.GetWeekdayName()
+			assert.Equal(t, tt.expectedName, result)
+		})
+	}
+}
+
+func TestStudentArrivalSchedule_TableName(t *testing.T) {
+	s := &StudentArrivalSchedule{}
+	assert.Equal(t, "schedule.student_arrival_schedules", s.TableName())
+}
+
+func TestStudentArrivalSchedule_GetID(t *testing.T) {
+	s := &StudentArrivalSchedule{}
+	s.ID = 42
+	assert.Equal(t, int64(42), s.GetID())
+}
+
+func TestStudentArrivalSchedule_GetCreatedAt(t *testing.T) {
+	now := time.Now()
+	s := &StudentArrivalSchedule{}
+	s.CreatedAt = now
+	assert.Equal(t, now, s.GetCreatedAt())
+}
+
+func TestStudentArrivalSchedule_GetUpdatedAt(t *testing.T) {
+	now := time.Now()
+	s := &StudentArrivalSchedule{}
+	s.UpdatedAt = now
+	assert.Equal(t, now, s.GetUpdatedAt())
+}
+
+// =============================================================================
+// StudentArrivalException Validation Tests
+// =============================================================================
+
+func TestStudentArrivalException_Validate(t *testing.T) {
+	validDate := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	validTime := time.Date(2024, 1, 15, 8, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		setup   func() *StudentArrivalException
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid exception with arrival time",
+			setup: func() *StudentArrivalException {
+				return &StudentArrivalException{
+					StudentID:       1,
+					ExceptionDate:   validDate,
+					ExpectedArrival: &validTime,
+					Reason:          strPtr("Doctor appointment"),
+					CreatedBy:       1,
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid exception without arrival time (absent)",
+			setup: func() *StudentArrivalException {
+				return &StudentArrivalException{
+					StudentID:       1,
+					ExceptionDate:   validDate,
+					ExpectedArrival: nil,
+					Reason:          strPtr("Student is sick"),
+					CreatedBy:       1,
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing student_id",
+			setup: func() *StudentArrivalException {
+				return &StudentArrivalException{
+					StudentID:     0,
+					ExceptionDate: validDate,
+					Reason:        strPtr("Test reason"),
+					CreatedBy:     1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "student_id is required",
+		},
+		{
+			name: "negative student_id",
+			setup: func() *StudentArrivalException {
+				return &StudentArrivalException{
+					StudentID:     -1,
+					ExceptionDate: validDate,
+					Reason:        strPtr("Test reason"),
+					CreatedBy:     1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "student_id is required",
+		},
+		{
+			name: "missing exception_date",
+			setup: func() *StudentArrivalException {
+				return &StudentArrivalException{
+					StudentID: 1,
+					Reason:    strPtr("Test reason"),
+					CreatedBy: 1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "exception_date is required",
+		},
+		{
+			name: "missing reason (nil is valid)",
+			setup: func() *StudentArrivalException {
+				return &StudentArrivalException{
+					StudentID:     1,
+					ExceptionDate: validDate,
+					Reason:        nil,
+					CreatedBy:     1,
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "reason too long",
+			setup: func() *StudentArrivalException {
+				return &StudentArrivalException{
+					StudentID:     1,
+					ExceptionDate: validDate,
+					Reason:        strPtr(string(make([]byte, 256))),
+					CreatedBy:     1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "reason cannot exceed 255 characters",
+		},
+		{
+			name: "missing created_by",
+			setup: func() *StudentArrivalException {
+				return &StudentArrivalException{
+					StudentID:     1,
+					ExceptionDate: validDate,
+					Reason:        strPtr("Test reason"),
+					CreatedBy:     0,
+				}
+			},
+			wantErr: true,
+			errMsg:  "created_by is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exception := tt.setup()
+			err := exception.Validate()
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStudentArrivalException_IsAbsent(t *testing.T) {
+	validDate := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	validTime := time.Date(2024, 1, 15, 8, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		setup    func() *StudentArrivalException
+		expected bool
+	}{
+		{
+			name: "with arrival time - not absent",
+			setup: func() *StudentArrivalException {
+				return &StudentArrivalException{
+					StudentID:       1,
+					ExceptionDate:   validDate,
+					ExpectedArrival: &validTime,
+					Reason:          strPtr("Late arrival"),
+					CreatedBy:       1,
+				}
+			},
+			expected: false,
+		},
+		{
+			name: "without arrival time - absent",
+			setup: func() *StudentArrivalException {
+				return &StudentArrivalException{
+					StudentID:       1,
+					ExceptionDate:   validDate,
+					ExpectedArrival: nil,
+					Reason:          strPtr("Student is sick"),
+					CreatedBy:       1,
+				}
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exception := tt.setup()
+			result := exception.IsAbsent()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestStudentArrivalException_TableName(t *testing.T) {
+	exception := &StudentArrivalException{}
+	assert.Equal(t, "schedule.student_arrival_exceptions", exception.TableName())
+}
+
+func TestStudentArrivalException_GetID(t *testing.T) {
+	exception := &StudentArrivalException{}
+	exception.ID = 42
+	assert.Equal(t, int64(42), exception.GetID())
+}
+
+func TestStudentArrivalException_GetCreatedAt(t *testing.T) {
+	now := time.Now()
+	exception := &StudentArrivalException{}
+	exception.CreatedAt = now
+	assert.Equal(t, now, exception.GetCreatedAt())
+}
+
+func TestStudentArrivalException_GetUpdatedAt(t *testing.T) {
+	now := time.Now()
+	exception := &StudentArrivalException{}
+	exception.UpdatedAt = now
+	assert.Equal(t, now, exception.GetUpdatedAt())
+}
+
+// =============================================================================
+// StudentArrivalNote Validation Tests
+// =============================================================================
+
+func TestStudentArrivalNote_Validate(t *testing.T) {
+	validDate := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		setup   func() *StudentArrivalNote
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid note",
+			setup: func() *StudentArrivalNote {
+				return &StudentArrivalNote{
+					StudentID: 1,
+					NoteDate:  validDate,
+					Content:   "Arrives by bus today",
+					CreatedBy: 1,
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing student_id",
+			setup: func() *StudentArrivalNote {
+				return &StudentArrivalNote{
+					StudentID: 0,
+					NoteDate:  validDate,
+					Content:   "Test note",
+					CreatedBy: 1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "student_id is required",
+		},
+		{
+			name: "negative student_id",
+			setup: func() *StudentArrivalNote {
+				return &StudentArrivalNote{
+					StudentID: -1,
+					NoteDate:  validDate,
+					Content:   "Test note",
+					CreatedBy: 1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "student_id is required",
+		},
+		{
+			name: "missing note_date",
+			setup: func() *StudentArrivalNote {
+				return &StudentArrivalNote{
+					StudentID: 1,
+					Content:   "Test note",
+					CreatedBy: 1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "note_date is required",
+		},
+		{
+			name: "missing content",
+			setup: func() *StudentArrivalNote {
+				return &StudentArrivalNote{
+					StudentID: 1,
+					NoteDate:  validDate,
+					Content:   "",
+					CreatedBy: 1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "content is required",
+		},
+		{
+			name: "content too long",
+			setup: func() *StudentArrivalNote {
+				return &StudentArrivalNote{
+					StudentID: 1,
+					NoteDate:  validDate,
+					Content:   string(make([]byte, 501)),
+					CreatedBy: 1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "content cannot exceed 500 characters",
+		},
+		{
+			name: "content exactly 500 characters",
+			setup: func() *StudentArrivalNote {
+				return &StudentArrivalNote{
+					StudentID: 1,
+					NoteDate:  validDate,
+					Content:   string(make([]byte, 500)),
+					CreatedBy: 1,
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing created_by",
+			setup: func() *StudentArrivalNote {
+				return &StudentArrivalNote{
+					StudentID: 1,
+					NoteDate:  validDate,
+					Content:   "Test note",
+					CreatedBy: 0,
+				}
+			},
+			wantErr: true,
+			errMsg:  "created_by is required",
+		},
+		{
+			name: "negative created_by",
+			setup: func() *StudentArrivalNote {
+				return &StudentArrivalNote{
+					StudentID: 1,
+					NoteDate:  validDate,
+					Content:   "Test note",
+					CreatedBy: -1,
+				}
+			},
+			wantErr: true,
+			errMsg:  "created_by is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			note := tt.setup()
+			err := note.Validate()
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStudentArrivalNote_TableName(t *testing.T) {
+	note := &StudentArrivalNote{}
+	assert.Equal(t, "schedule.student_arrival_notes", note.TableName())
+}
+
+func TestStudentArrivalNote_GetID(t *testing.T) {
+	note := &StudentArrivalNote{}
+	note.ID = 42
+	assert.Equal(t, int64(42), note.GetID())
+}
+
+func TestStudentArrivalNote_GetCreatedAt(t *testing.T) {
+	now := time.Now()
+	note := &StudentArrivalNote{}
+	note.CreatedAt = now
+	assert.Equal(t, now, note.GetCreatedAt())
+}
+
+func TestStudentArrivalNote_GetUpdatedAt(t *testing.T) {
+	now := time.Now()
+	note := &StudentArrivalNote{}
+	note.UpdatedAt = now
+	assert.Equal(t, now, note.GetUpdatedAt())
+}

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -56,6 +56,7 @@ type Factory struct {
 	Settings                 config.SettingsService
 	Schedule                 schedule.Service
 	PickupSchedule           schedule.PickupScheduleService
+	ArrivalSchedule          schedule.ArrivalScheduleService
 	Users                    users.PersonService
 	CaregiverCapability      users.CaregiverCapabilityService
 	Guardian                 users.GuardianService
@@ -312,6 +313,17 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		db,
 	)
 
+	// Initialize arrival schedule service
+	arrivalScheduleService := schedule.NewArrivalScheduleService(
+		repos.StudentArrivalSchedule,
+		repos.StudentArrivalException,
+		repos.StudentArrivalNote,
+		repos.Student,
+		repos.Person,
+		db,
+		logger.With("service", "arrival-schedule"),
+	)
+
 	// Initialize auth service with validated config
 	authConfig, err := auth.NewServiceConfig(
 		dispatcher,
@@ -530,6 +542,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Settings:                 settingsService,
 		Schedule:                 scheduleService,
 		PickupSchedule:           pickupScheduleService,
+		ArrivalSchedule:          arrivalScheduleService,
 		Users:                    usersService,
 		CaregiverCapability:      caregiverCapabilityService,
 		Guardian:                 guardianService,

--- a/backend/services/schedule/arrival_service.go
+++ b/backend/services/schedule/arrival_service.go
@@ -1,0 +1,724 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+// ArrivalScheduleService defines operations for managing student arrival schedules
+type ArrivalScheduleService interface {
+	// Schedule operations
+	GetStudentArrivalSchedules(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalSchedule, error)
+	GetStudentArrivalScheduleForWeekday(ctx context.Context, studentID int64, weekday int) (*schedule.StudentArrivalSchedule, error)
+	UpsertStudentArrivalSchedule(ctx context.Context, scheduleData *schedule.StudentArrivalSchedule) error
+	UpsertBulkStudentArrivalSchedules(ctx context.Context, studentID int64, schedules []*schedule.StudentArrivalSchedule) error
+	DeleteStudentArrivalSchedule(ctx context.Context, scheduleID int64) error
+	DeleteAllStudentArrivalSchedules(ctx context.Context, studentID int64) error
+
+	// Exception operations
+	GetStudentArrivalExceptionByID(ctx context.Context, exceptionID int64) (*schedule.StudentArrivalException, error)
+	GetStudentArrivalExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error)
+	GetUpcomingStudentArrivalExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error)
+	CreateStudentArrivalException(ctx context.Context, exception *schedule.StudentArrivalException) error
+	UpdateStudentArrivalException(ctx context.Context, exception *schedule.StudentArrivalException) error
+	DeleteStudentArrivalException(ctx context.Context, exceptionID int64) error
+	DeleteAllStudentArrivalExceptions(ctx context.Context, studentID int64) error
+
+	// Note operations
+	GetStudentArrivalNoteByID(ctx context.Context, noteID int64) (*schedule.StudentArrivalNote, error)
+	GetStudentArrivalNotes(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalNote, error)
+	GetStudentArrivalNotesForDate(ctx context.Context, studentID int64, date time.Time) ([]*schedule.StudentArrivalNote, error)
+	CreateStudentArrivalNote(ctx context.Context, note *schedule.StudentArrivalNote) error
+	UpdateStudentArrivalNote(ctx context.Context, note *schedule.StudentArrivalNote) error
+	DeleteStudentArrivalNote(ctx context.Context, noteID int64) error
+	DeleteAllStudentArrivalNotes(ctx context.Context, studentID int64) error
+
+	// Computed operations
+	GetStudentArrivalData(ctx context.Context, studentID int64) (*StudentArrivalData, error)
+	GetEffectiveArrivalTimeForDate(ctx context.Context, studentID int64, date time.Time) (*EffectiveArrivalTime, error)
+	GetBulkEffectiveArrivalTimesForDate(ctx context.Context, studentIDs []int64, date time.Time) (map[int64]*EffectiveArrivalTime, error)
+
+	// Bulk class operation
+	BulkUpsertBySchoolClass(ctx context.Context, schoolClass string, schedules []ArrivalScheduleInput, createdBy int64) (*BulkUpsertResult, error)
+}
+
+// StudentArrivalData contains combined arrival schedule and exception data
+type StudentArrivalData struct {
+	Schedules  []*schedule.StudentArrivalSchedule  `json:"schedules"`
+	Exceptions []*schedule.StudentArrivalException `json:"exceptions"`
+	Notes      []*schedule.StudentArrivalNote      `json:"notes"`
+}
+
+// ArrivalNoteData represents a single note in the effective arrival time response
+type ArrivalNoteData struct {
+	ID      int64  `json:"id"`
+	Content string `json:"content"`
+}
+
+// EffectiveArrivalTime represents the arrival time for a specific date
+type EffectiveArrivalTime struct {
+	Date        time.Time         `json:"date"`
+	ArrivalTime *time.Time        `json:"arrival_time"`
+	WeekdayName string            `json:"weekday_name"`
+	IsException bool              `json:"is_exception"`
+	Notes       string            `json:"notes,omitempty"`
+	DayNotes    []ArrivalNoteData `json:"day_notes,omitempty"`
+}
+
+// ArrivalScheduleInput represents input for a single weekday's arrival schedule
+type ArrivalScheduleInput struct {
+	Weekday     int    `json:"weekday"`
+	ArrivalTime string `json:"arrival_time"` // HH:MM
+}
+
+// BulkUpsertResult contains the result of a bulk class upsert operation
+type BulkUpsertResult struct {
+	StudentsAffected    int                `json:"students_affected"`
+	OverwrittenStudents []OverwriteWarning `json:"overwritten_students,omitempty"`
+}
+
+// OverwriteWarning warns that a student had an existing individual schedule that was overwritten
+type OverwriteWarning struct {
+	StudentID    int64  `json:"student_id"`
+	StudentName  string `json:"student_name"`
+	Weekday      int    `json:"weekday"`
+	WeekdayName  string `json:"weekday_name"`
+	PreviousTime string `json:"previous_time"`
+	NewTime      string `json:"new_time"`
+}
+
+// Operation names for ScheduleError.
+const (
+	opCreateStudentArrivalException     = "create student arrival exception"
+	opUpdateStudentArrivalException     = "update student arrival exception"
+	opUpsertBulkStudentArrivalSchedules = "upsert bulk student arrival schedules"
+	opGetStudentArrivalData             = "get student arrival data"
+	opGetEffectiveArrivalTime           = "get effective arrival time"
+	opGetBulkEffectiveArrivalTimes      = "get bulk effective arrival times"
+	opBulkUpsertBySchoolClass           = "bulk upsert arrival schedules by school class"
+)
+
+// arrivalScheduleService implements ArrivalScheduleService
+type arrivalScheduleService struct {
+	scheduleRepo  schedule.StudentArrivalScheduleRepository
+	exceptionRepo schedule.StudentArrivalExceptionRepository
+	noteRepo      schedule.StudentArrivalNoteRepository
+	studentRepo   users.StudentRepository
+	personRepo    users.PersonRepository
+	db            *bun.DB
+	logger        *slog.Logger
+}
+
+// NewArrivalScheduleService creates a new arrival schedule service
+func NewArrivalScheduleService(
+	scheduleRepo schedule.StudentArrivalScheduleRepository,
+	exceptionRepo schedule.StudentArrivalExceptionRepository,
+	noteRepo schedule.StudentArrivalNoteRepository,
+	studentRepo users.StudentRepository,
+	personRepo users.PersonRepository,
+	db *bun.DB,
+	logger *slog.Logger,
+) ArrivalScheduleService {
+	return &arrivalScheduleService{
+		scheduleRepo:  scheduleRepo,
+		exceptionRepo: exceptionRepo,
+		noteRepo:      noteRepo,
+		studentRepo:   studentRepo,
+		personRepo:    personRepo,
+		db:            db,
+		logger:        logger,
+	}
+}
+
+func (s *arrivalScheduleService) getLogger() *slog.Logger {
+	if s.logger != nil {
+		return s.logger
+	}
+	return slog.Default()
+}
+
+// Schedule operations
+
+// GetStudentArrivalSchedules returns all arrival schedules for a student
+func (s *arrivalScheduleService) GetStudentArrivalSchedules(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalSchedule, error) {
+	schedules, err := s.scheduleRepo.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get student arrival schedules", Err: err}
+	}
+	return schedules, nil
+}
+
+// GetStudentArrivalScheduleForWeekday returns the arrival schedule for a specific weekday
+func (s *arrivalScheduleService) GetStudentArrivalScheduleForWeekday(ctx context.Context, studentID int64, weekday int) (*schedule.StudentArrivalSchedule, error) {
+	if weekday < schedule.WeekdayMonday || weekday > schedule.WeekdayFriday {
+		return nil, &ScheduleError{Op: "get student arrival schedule for weekday", Err: errors.New("invalid weekday")}
+	}
+
+	arrivalSchedule, err := s.scheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, weekday)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get student arrival schedule for weekday", Err: err}
+	}
+	return arrivalSchedule, nil
+}
+
+// UpsertStudentArrivalSchedule creates or updates an arrival schedule
+func (s *arrivalScheduleService) UpsertStudentArrivalSchedule(ctx context.Context, scheduleData *schedule.StudentArrivalSchedule) error {
+	if err := scheduleData.Validate(); err != nil {
+		return &ScheduleError{Op: "upsert student arrival schedule", Err: err}
+	}
+
+	if err := s.scheduleRepo.UpsertSchedule(ctx, scheduleData); err != nil {
+		return &ScheduleError{Op: "upsert student arrival schedule", Err: err}
+	}
+	return nil
+}
+
+// UpsertBulkStudentArrivalSchedules replaces all arrival schedules for a student.
+// This deletes existing schedules and inserts the new ones atomically,
+// ensuring that cleared weekdays are properly removed.
+func (s *arrivalScheduleService) UpsertBulkStudentArrivalSchedules(ctx context.Context, studentID int64, schedules []*schedule.StudentArrivalSchedule) error {
+	// Use transaction from context if available (handler's WithTenantTx), otherwise fall back to db
+	var db bun.IDB = s.db
+	if tx, ok := base.TxFromContext(ctx); ok && tx != nil {
+		db = tx
+	}
+
+	// Delete all existing schedules for this student first
+	_, err := db.NewDelete().
+		Model((*schedule.StudentArrivalSchedule)(nil)).
+		ModelTableExpr("schedule.student_arrival_schedules").
+		Where("student_id = ?", studentID).
+		Exec(ctx)
+	if err != nil {
+		return &ScheduleError{Op: opUpsertBulkStudentArrivalSchedules, Err: fmt.Errorf("failed to delete existing schedules: %w", err)}
+	}
+
+	// Insert new schedules
+	for _, sched := range schedules {
+		sched.StudentID = studentID
+		if err := sched.Validate(); err != nil {
+			return &ScheduleError{Op: opUpsertBulkStudentArrivalSchedules, Err: fmt.Errorf("invalid schedule for weekday %d: %w", sched.Weekday, err)}
+		}
+		sched.SetTenantID(tenant.FromContext(ctx))
+
+		_, err := db.NewInsert().
+			Model(sched).
+			ModelTableExpr("schedule.student_arrival_schedules").
+			Returning("id").
+			Exec(ctx)
+		if err != nil {
+			return &ScheduleError{Op: opUpsertBulkStudentArrivalSchedules, Err: err}
+		}
+	}
+	return nil
+}
+
+// DeleteStudentArrivalSchedule deletes an arrival schedule by ID
+func (s *arrivalScheduleService) DeleteStudentArrivalSchedule(ctx context.Context, scheduleID int64) error {
+	if err := s.scheduleRepo.Delete(ctx, scheduleID); err != nil {
+		return &ScheduleError{Op: "delete student arrival schedule", Err: err}
+	}
+	return nil
+}
+
+// DeleteAllStudentArrivalSchedules deletes all arrival schedules for a student
+func (s *arrivalScheduleService) DeleteAllStudentArrivalSchedules(ctx context.Context, studentID int64) error {
+	if err := s.scheduleRepo.DeleteByStudentID(ctx, studentID); err != nil {
+		return &ScheduleError{Op: "delete all student arrival schedules", Err: err}
+	}
+	return nil
+}
+
+// Exception operations
+
+// GetStudentArrivalExceptionByID returns an arrival exception by its ID
+func (s *arrivalScheduleService) GetStudentArrivalExceptionByID(ctx context.Context, exceptionID int64) (*schedule.StudentArrivalException, error) {
+	exception, err := s.exceptionRepo.FindByID(ctx, exceptionID)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get student arrival exception by id", Err: err}
+	}
+	return exception, nil
+}
+
+// GetStudentArrivalExceptions returns all arrival exceptions for a student
+func (s *arrivalScheduleService) GetStudentArrivalExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error) {
+	exceptions, err := s.exceptionRepo.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get student arrival exceptions", Err: err}
+	}
+	return exceptions, nil
+}
+
+// GetUpcomingStudentArrivalExceptions returns upcoming arrival exceptions for a student
+func (s *arrivalScheduleService) GetUpcomingStudentArrivalExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error) {
+	exceptions, err := s.exceptionRepo.FindUpcomingByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get upcoming student arrival exceptions", Err: err}
+	}
+	return exceptions, nil
+}
+
+// CreateStudentArrivalException creates a new arrival exception
+func (s *arrivalScheduleService) CreateStudentArrivalException(ctx context.Context, exception *schedule.StudentArrivalException) error {
+	if err := exception.Validate(); err != nil {
+		return &ScheduleError{Op: opCreateStudentArrivalException, Err: err}
+	}
+
+	// Check for existing exception on the same date
+	existing, err := s.exceptionRepo.FindByStudentIDAndDate(ctx, exception.StudentID, exception.ExceptionDate)
+	if err != nil {
+		return &ScheduleError{Op: opCreateStudentArrivalException, Err: err}
+	}
+	if existing != nil {
+		return &ScheduleError{Op: opCreateStudentArrivalException, Err: errors.New("exception already exists for this date")}
+	}
+
+	exception.SetTenantID(tenant.FromContext(ctx))
+	if err := s.exceptionRepo.Create(ctx, exception); err != nil {
+		return &ScheduleError{Op: opCreateStudentArrivalException, Err: err}
+	}
+	return nil
+}
+
+// UpdateStudentArrivalException updates an existing arrival exception
+func (s *arrivalScheduleService) UpdateStudentArrivalException(ctx context.Context, exception *schedule.StudentArrivalException) error {
+	if err := exception.Validate(); err != nil {
+		return &ScheduleError{Op: opUpdateStudentArrivalException, Err: err}
+	}
+
+	// Check if changing date would conflict with another exception
+	existing, err := s.exceptionRepo.FindByStudentIDAndDate(ctx, exception.StudentID, exception.ExceptionDate)
+	if err != nil {
+		return &ScheduleError{Op: opUpdateStudentArrivalException, Err: err}
+	}
+	if existing != nil && existing.ID != exception.ID {
+		return &ScheduleError{Op: opUpdateStudentArrivalException, Err: errors.New("exception already exists for this date")}
+	}
+
+	if err := s.exceptionRepo.Update(ctx, exception); err != nil {
+		return &ScheduleError{Op: opUpdateStudentArrivalException, Err: err}
+	}
+	return nil
+}
+
+// DeleteStudentArrivalException deletes an arrival exception by ID
+func (s *arrivalScheduleService) DeleteStudentArrivalException(ctx context.Context, exceptionID int64) error {
+	if err := s.exceptionRepo.Delete(ctx, exceptionID); err != nil {
+		return &ScheduleError{Op: "delete student arrival exception", Err: err}
+	}
+	return nil
+}
+
+// DeleteAllStudentArrivalExceptions deletes all arrival exceptions for a student
+func (s *arrivalScheduleService) DeleteAllStudentArrivalExceptions(ctx context.Context, studentID int64) error {
+	if err := s.exceptionRepo.DeleteByStudentID(ctx, studentID); err != nil {
+		return &ScheduleError{Op: "delete all student arrival exceptions", Err: err}
+	}
+	return nil
+}
+
+// Note operations
+
+// GetStudentArrivalNoteByID returns an arrival note by its ID
+func (s *arrivalScheduleService) GetStudentArrivalNoteByID(ctx context.Context, noteID int64) (*schedule.StudentArrivalNote, error) {
+	note, err := s.noteRepo.FindByID(ctx, noteID)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get student arrival note by id", Err: err}
+	}
+	return note, nil
+}
+
+// GetStudentArrivalNotes returns all arrival notes for a student
+func (s *arrivalScheduleService) GetStudentArrivalNotes(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalNote, error) {
+	notes, err := s.noteRepo.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get student arrival notes", Err: err}
+	}
+	return notes, nil
+}
+
+// GetStudentArrivalNotesForDate returns arrival notes for a student on a specific date
+func (s *arrivalScheduleService) GetStudentArrivalNotesForDate(ctx context.Context, studentID int64, date time.Time) ([]*schedule.StudentArrivalNote, error) {
+	notes, err := s.noteRepo.FindByStudentIDAndDate(ctx, studentID, date)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get student arrival notes for date", Err: err}
+	}
+	return notes, nil
+}
+
+// CreateStudentArrivalNote creates a new arrival note
+func (s *arrivalScheduleService) CreateStudentArrivalNote(ctx context.Context, note *schedule.StudentArrivalNote) error {
+	if err := note.Validate(); err != nil {
+		return &ScheduleError{Op: "create student arrival note", Err: err}
+	}
+
+	note.SetTenantID(tenant.FromContext(ctx))
+	if err := s.noteRepo.Create(ctx, note); err != nil {
+		return &ScheduleError{Op: "create student arrival note", Err: err}
+	}
+	return nil
+}
+
+// UpdateStudentArrivalNote updates an existing arrival note
+func (s *arrivalScheduleService) UpdateStudentArrivalNote(ctx context.Context, note *schedule.StudentArrivalNote) error {
+	if err := note.Validate(); err != nil {
+		return &ScheduleError{Op: "update student arrival note", Err: err}
+	}
+
+	if err := s.noteRepo.Update(ctx, note); err != nil {
+		return &ScheduleError{Op: "update student arrival note", Err: err}
+	}
+	return nil
+}
+
+// DeleteStudentArrivalNote deletes an arrival note by ID
+func (s *arrivalScheduleService) DeleteStudentArrivalNote(ctx context.Context, noteID int64) error {
+	if err := s.noteRepo.Delete(ctx, noteID); err != nil {
+		return &ScheduleError{Op: "delete student arrival note", Err: err}
+	}
+	return nil
+}
+
+// DeleteAllStudentArrivalNotes deletes all arrival notes for a student
+func (s *arrivalScheduleService) DeleteAllStudentArrivalNotes(ctx context.Context, studentID int64) error {
+	if err := s.noteRepo.DeleteByStudentID(ctx, studentID); err != nil {
+		return &ScheduleError{Op: "delete all student arrival notes", Err: err}
+	}
+	return nil
+}
+
+// Computed operations
+
+// GetStudentArrivalData returns combined schedule, exception, and note data for a student.
+// Returns all exceptions and notes (not just upcoming) to support week view navigation to past weeks.
+func (s *arrivalScheduleService) GetStudentArrivalData(ctx context.Context, studentID int64) (*StudentArrivalData, error) {
+	schedules, err := s.scheduleRepo.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{Op: opGetStudentArrivalData, Err: err}
+	}
+
+	exceptions, err := s.exceptionRepo.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{Op: opGetStudentArrivalData, Err: err}
+	}
+
+	notes, err := s.noteRepo.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{Op: opGetStudentArrivalData, Err: err}
+	}
+
+	return &StudentArrivalData{
+		Schedules:  schedules,
+		Exceptions: exceptions,
+		Notes:      notes,
+	}, nil
+}
+
+// GetEffectiveArrivalTimeForDate calculates the effective arrival time for a specific date
+func (s *arrivalScheduleService) GetEffectiveArrivalTimeForDate(ctx context.Context, studentID int64, date time.Time) (*EffectiveArrivalTime, error) {
+	dateOnly := timezone.DateOf(date)
+	weekday := int(dateOnly.Weekday())
+
+	// Convert Go weekday (Sunday=0) to ISO weekday (Monday=1)
+	if weekday == 0 {
+		weekday = 7
+	}
+
+	result := &EffectiveArrivalTime{
+		Date:        dateOnly,
+		WeekdayName: schedule.WeekdayNames[weekday],
+	}
+
+	// Weekend check
+	if weekday > schedule.WeekdayFriday {
+		return result, nil
+	}
+
+	// Check for exception on this date first
+	exception, err := s.exceptionRepo.FindByStudentIDAndDate(ctx, studentID, dateOnly)
+	if err != nil {
+		return nil, &ScheduleError{Op: opGetEffectiveArrivalTime, Err: err}
+	}
+
+	if exception != nil {
+		result.IsException = true
+		result.ArrivalTime = exception.ExpectedArrival
+		if reason := arrivalNoteOverride(exception.Reason); reason != "" {
+			result.Notes = reason
+		} else {
+			sched, err := s.scheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, weekday)
+			if err != nil {
+				return nil, &ScheduleError{Op: opGetEffectiveArrivalTime, Err: err}
+			}
+			result.Notes = arrivalScheduleNotes(sched)
+		}
+	} else {
+		// Fall back to regular schedule
+		sched, err := s.scheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, weekday)
+		if err != nil {
+			return nil, &ScheduleError{Op: opGetEffectiveArrivalTime, Err: err}
+		}
+
+		if sched != nil {
+			result.ArrivalTime = &sched.ExpectedArrival
+			result.Notes = arrivalScheduleNotes(sched)
+		}
+	}
+
+	// Load day notes
+	dayNotes, err := s.noteRepo.FindByStudentIDAndDate(ctx, studentID, dateOnly)
+	if err != nil {
+		return nil, &ScheduleError{Op: opGetEffectiveArrivalTime, Err: err}
+	}
+	for _, n := range dayNotes {
+		result.DayNotes = append(result.DayNotes, ArrivalNoteData{ID: n.ID, Content: n.Content})
+	}
+
+	return result, nil
+}
+
+// GetBulkEffectiveArrivalTimesForDate calculates effective arrival times for multiple students on a given date
+// Uses bulk database queries for optimal performance (O(3) queries instead of O(N))
+func (s *arrivalScheduleService) GetBulkEffectiveArrivalTimesForDate(ctx context.Context, studentIDs []int64, date time.Time) (map[int64]*EffectiveArrivalTime, error) {
+	if len(studentIDs) == 0 {
+		return make(map[int64]*EffectiveArrivalTime), nil
+	}
+
+	dateOnly := timezone.DateOf(date)
+	weekday := int(dateOnly.Weekday())
+
+	// Convert Go weekday (Sunday=0) to ISO weekday (Monday=1)
+	if weekday == 0 {
+		weekday = 7
+	}
+
+	result := make(map[int64]*EffectiveArrivalTime, len(studentIDs))
+
+	// Initialize results for all students
+	for _, studentID := range studentIDs {
+		result[studentID] = &EffectiveArrivalTime{
+			Date:        dateOnly,
+			WeekdayName: schedule.WeekdayNames[weekday],
+		}
+	}
+
+	// Weekend check - all students have no arrival time
+	if weekday > schedule.WeekdayFriday {
+		return result, nil
+	}
+
+	// Bulk fetch all exceptions for the given date (single query)
+	exceptions, err := s.exceptionRepo.FindByStudentIDsAndDate(ctx, studentIDs, dateOnly)
+	if err != nil {
+		return nil, &ScheduleError{Op: opGetBulkEffectiveArrivalTimes, Err: err}
+	}
+
+	// Build exception map for O(1) lookup
+	exceptionMap := make(map[int64]*schedule.StudentArrivalException, len(exceptions))
+	for _, exc := range exceptions {
+		exceptionMap[exc.StudentID] = exc
+	}
+
+	// Bulk fetch all schedules for the given weekday (single query)
+	schedules, err := s.scheduleRepo.FindByStudentIDsAndWeekday(ctx, studentIDs, weekday)
+	if err != nil {
+		return nil, &ScheduleError{Op: opGetBulkEffectiveArrivalTimes, Err: err}
+	}
+
+	// Build schedule map for O(1) lookup
+	scheduleMap := make(map[int64]*schedule.StudentArrivalSchedule, len(schedules))
+	for _, sched := range schedules {
+		scheduleMap[sched.StudentID] = sched
+	}
+
+	// Bulk fetch all notes for the given date (single query)
+	notes, err := s.noteRepo.FindByStudentIDsAndDate(ctx, studentIDs, dateOnly)
+	if err != nil {
+		return nil, &ScheduleError{Op: opGetBulkEffectiveArrivalTimes, Err: err}
+	}
+
+	// Build notes map for grouping by student
+	notesMap := make(map[int64][]*schedule.StudentArrivalNote)
+	for _, n := range notes {
+		notesMap[n.StudentID] = append(notesMap[n.StudentID], n)
+	}
+
+	// Merge results: exception takes precedence over schedule
+	mergeArrivalResults(studentIDs, result, exceptionMap, scheduleMap, notesMap)
+
+	return result, nil
+}
+
+// mergeArrivalResults merges exception, schedule, and note data into effective arrival times
+func mergeArrivalResults(
+	studentIDs []int64,
+	result map[int64]*EffectiveArrivalTime,
+	exceptionMap map[int64]*schedule.StudentArrivalException,
+	scheduleMap map[int64]*schedule.StudentArrivalSchedule,
+	notesMap map[int64][]*schedule.StudentArrivalNote,
+) {
+	for _, studentID := range studentIDs {
+		r := result[studentID]
+		sched := scheduleMap[studentID]
+
+		// Check for exception first (takes priority)
+		if exc, ok := exceptionMap[studentID]; ok {
+			r.IsException = true
+			r.ArrivalTime = exc.ExpectedArrival
+			if reason := arrivalNoteOverride(exc.Reason); reason != "" {
+				r.Notes = reason
+			} else {
+				r.Notes = arrivalScheduleNotes(sched)
+			}
+		} else if sched != nil {
+			// Fall back to regular schedule
+			r.ArrivalTime = &sched.ExpectedArrival
+			r.Notes = arrivalScheduleNotes(sched)
+		}
+
+		// Attach day notes
+		if dayNotes, ok := notesMap[studentID]; ok {
+			for _, n := range dayNotes {
+				r.DayNotes = append(r.DayNotes, ArrivalNoteData{ID: n.ID, Content: n.Content})
+			}
+		}
+	}
+}
+
+// BulkUpsertBySchoolClass upserts arrival schedules for all students in a school class
+func (s *arrivalScheduleService) BulkUpsertBySchoolClass(ctx context.Context, schoolClass string, schedules []ArrivalScheduleInput, createdBy int64) (*BulkUpsertResult, error) {
+	if schoolClass == "" {
+		return nil, &ScheduleError{Op: opBulkUpsertBySchoolClass, Err: errors.New("school_class is required")}
+	}
+	if len(schedules) == 0 {
+		return nil, &ScheduleError{Op: opBulkUpsertBySchoolClass, Err: errors.New("schedules cannot be empty")}
+	}
+
+	// Query all students in this school class within the current tenant
+	students, err := s.studentRepo.FindBySchoolClass(ctx, schoolClass)
+	if err != nil {
+		return nil, &ScheduleError{Op: opBulkUpsertBySchoolClass, Err: fmt.Errorf("failed to find students for class %s: %w", schoolClass, err)}
+	}
+
+	if len(students) == 0 {
+		return &BulkUpsertResult{StudentsAffected: 0}, nil
+	}
+
+	tenantID := tenant.FromContext(ctx)
+	warnings := make([]OverwriteWarning, 0)
+
+	// Parse arrival times upfront
+	parsedTimes := make(map[int]time.Time, len(schedules))
+	for _, input := range schedules {
+		t, err := time.Parse("2006-01-02 15:04", "2000-01-01 "+input.ArrivalTime)
+		if err != nil {
+			return nil, &ScheduleError{Op: opBulkUpsertBySchoolClass, Err: fmt.Errorf("invalid arrival_time %q for weekday %d: %w", input.ArrivalTime, input.Weekday, err)}
+		}
+		parsedTimes[input.Weekday] = t
+	}
+
+	// Wrap everything in a transaction
+	if err := tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
+		for _, student := range students {
+			// Fetch existing schedules for this student to detect overwrites
+			existing, err := s.scheduleRepo.FindByStudentID(txCtx, student.ID)
+			if err != nil {
+				return fmt.Errorf("failed to fetch existing schedules for student %d: %w", student.ID, err)
+			}
+
+			// Build map of existing schedules by weekday for overwrite detection
+			existingByWeekday := make(map[int]*schedule.StudentArrivalSchedule, len(existing))
+			for _, ex := range existing {
+				existingByWeekday[ex.Weekday] = ex
+			}
+
+			// Upsert each weekday
+			for _, input := range schedules {
+				arrivalTime := parsedTimes[input.Weekday]
+
+				// Check for overwrite
+				if ex, ok := existingByWeekday[input.Weekday]; ok {
+					if ex.ExpectedArrival.Format("15:04") != arrivalTime.Format("15:04") {
+						// Get student name for the warning
+						studentName := s.getStudentName(txCtx, student)
+						warnings = append(warnings, OverwriteWarning{
+							StudentID:    student.ID,
+							StudentName:  studentName,
+							Weekday:      input.Weekday,
+							WeekdayName:  schedule.WeekdayNames[input.Weekday],
+							PreviousTime: ex.ExpectedArrival.Format("15:04"),
+							NewTime:      arrivalTime.Format("15:04"),
+						})
+					}
+				}
+
+				sched := &schedule.StudentArrivalSchedule{
+					StudentID:       student.ID,
+					Weekday:         input.Weekday,
+					ExpectedArrival: arrivalTime,
+					CreatedBy:       createdBy,
+				}
+				sched.SetTenantID(tenantID)
+
+				if err := s.scheduleRepo.UpsertSchedule(txCtx, sched); err != nil {
+					return fmt.Errorf("failed to upsert schedule for student %d weekday %d: %w", student.ID, input.Weekday, err)
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, &ScheduleError{Op: opBulkUpsertBySchoolClass, Err: err}
+	}
+
+	s.getLogger().Info("bulk upsert arrival schedules by school class",
+		slog.String("school_class", schoolClass),
+		slog.Int("students_affected", len(students)),
+		slog.Int("weekdays_set", len(schedules)),
+		slog.Int("overwrites", len(warnings)),
+	)
+
+	return &BulkUpsertResult{
+		StudentsAffected:    len(students),
+		OverwrittenStudents: warnings,
+	}, nil
+}
+
+// getStudentName resolves a student's display name from their person record.
+// Returns a fallback string on any error so callers can always produce a warning.
+func (s *arrivalScheduleService) getStudentName(ctx context.Context, student *users.Student) string {
+	if s.personRepo == nil {
+		return fmt.Sprintf("Student %d", student.ID)
+	}
+	person, err := s.personRepo.FindByID(ctx, student.PersonID)
+	if err != nil || person == nil {
+		return fmt.Sprintf("Student %d", student.ID)
+	}
+	return person.FirstName + " " + person.LastName
+}
+
+func arrivalNoteOverride(reason *string) string {
+	if reason == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(*reason)
+}
+
+func arrivalScheduleNotes(sched *schedule.StudentArrivalSchedule) string {
+	if sched == nil || sched.Notes == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(*sched.Notes)
+}

--- a/backend/services/schedule/arrival_service_test.go
+++ b/backend/services/schedule/arrival_service_test.go
@@ -1,0 +1,1315 @@
+package schedule_test
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/services"
+	"github.com/moto-nrw/project-phoenix/services/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// setupArrivalScheduleService creates an ArrivalScheduleService with real database connection
+func setupArrivalScheduleService(t *testing.T, db *bun.DB) schedule.ArrivalScheduleService {
+	repoFactory := repositories.NewFactory(db)
+	serviceFactory, err := services.NewFactory(repoFactory, db, slog.Default())
+	require.NoError(t, err, "Failed to create service factory")
+	return serviceFactory.ArrivalSchedule
+}
+
+// =============================================================================
+// Schedule Operations Tests
+// =============================================================================
+
+func TestArrivalScheduleService_GetStudentArrivalSchedules(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns all schedules for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		for _, weekday := range []int{scheduleModels.WeekdayMonday, scheduleModels.WeekdayWednesday} {
+			sched := &scheduleModels.StudentArrivalSchedule{
+				StudentID:       student.ID,
+				Weekday:         weekday,
+				ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+				CreatedBy:       1,
+			}
+			err := service.UpsertStudentArrivalSchedule(ctx, sched)
+			require.NoError(t, err)
+		}
+
+		results, err := service.GetStudentArrivalSchedules(ctx, student.ID)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("returns empty slice when no schedules", func(t *testing.T) {
+		results, err := service.GetStudentArrivalSchedules(ctx, int64(99999999))
+
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestArrivalScheduleService_GetStudentArrivalScheduleForWeekday(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns schedule for specific weekday", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayTuesday,
+			ExpectedArrival: time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+		require.NoError(t, err)
+
+		result, err := service.GetStudentArrivalScheduleForWeekday(ctx, student.ID, scheduleModels.WeekdayTuesday)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, scheduleModels.WeekdayTuesday, result.Weekday)
+	})
+
+	t.Run("returns error for invalid weekday", func(t *testing.T) {
+		result, err := service.GetStudentArrivalScheduleForWeekday(ctx, int64(1), 10)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "invalid weekday")
+	})
+}
+
+func TestArrivalScheduleService_UpsertStudentArrivalSchedule(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates new schedule", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayFriday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 30, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+
+		require.NoError(t, err)
+		assert.Greater(t, sched.ID, int64(0))
+	})
+
+	t.Run("updates existing schedule", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 30, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+		require.NoError(t, err)
+
+		sched.ExpectedArrival = time.Date(2024, 1, 1, 8, 15, 0, 0, time.UTC)
+
+		err = service.UpsertStudentArrivalSchedule(ctx, sched)
+
+		require.NoError(t, err)
+
+		result, err := service.GetStudentArrivalScheduleForWeekday(ctx, student.ID, scheduleModels.WeekdayMonday)
+		require.NoError(t, err)
+		assert.Equal(t, 8, result.ExpectedArrival.Hour())
+	})
+
+	t.Run("fails validation for invalid schedule", func(t *testing.T) {
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       0,
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 30, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+
+		require.Error(t, err)
+	})
+}
+
+func TestArrivalScheduleService_UpsertBulkStudentArrivalSchedules(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates multiple schedules in transaction", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		schedules := []*scheduleModels.StudentArrivalSchedule{
+			{
+				Weekday:         scheduleModels.WeekdayMonday,
+				ExpectedArrival: time.Date(2024, 1, 1, 7, 30, 0, 0, time.UTC),
+				CreatedBy:       1,
+			},
+			{
+				Weekday:         scheduleModels.WeekdayWednesday,
+				ExpectedArrival: time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC),
+				CreatedBy:       1,
+			},
+			{
+				Weekday:         scheduleModels.WeekdayFriday,
+				ExpectedArrival: time.Date(2024, 1, 1, 7, 45, 0, 0, time.UTC),
+				CreatedBy:       1,
+			},
+		}
+
+		err := service.UpsertBulkStudentArrivalSchedules(ctx, student.ID, schedules)
+
+		require.NoError(t, err)
+
+		results, err := service.GetStudentArrivalSchedules(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+	})
+
+	t.Run("rolls back on validation error", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		schedules := []*scheduleModels.StudentArrivalSchedule{
+			{
+				Weekday:         scheduleModels.WeekdayMonday,
+				ExpectedArrival: time.Date(2024, 1, 1, 7, 30, 0, 0, time.UTC),
+				CreatedBy:       1,
+			},
+			{
+				Weekday:         10,
+				ExpectedArrival: time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC),
+				CreatedBy:       1,
+			},
+		}
+
+		// Wrap in transaction so partial writes are rolled back on error
+		tx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		txCtx := base.ContextWithTx(ctx, &tx)
+
+		err = service.UpsertBulkStudentArrivalSchedules(txCtx, student.ID, schedules)
+
+		require.Error(t, err)
+		require.NoError(t, tx.Rollback())
+
+		results, err := service.GetStudentArrivalSchedules(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestArrivalScheduleService_DeleteStudentArrivalSchedule(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes schedule by ID", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayThursday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+		require.NoError(t, err)
+
+		err = service.DeleteStudentArrivalSchedule(ctx, sched.ID)
+
+		require.NoError(t, err)
+
+		results, err := service.GetStudentArrivalSchedules(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestArrivalScheduleService_DeleteAllStudentArrivalSchedules(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes all schedules for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		for _, weekday := range []int{scheduleModels.WeekdayMonday, scheduleModels.WeekdayWednesday, scheduleModels.WeekdayFriday} {
+			sched := &scheduleModels.StudentArrivalSchedule{
+				StudentID:       student.ID,
+				Weekday:         weekday,
+				ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+				CreatedBy:       1,
+			}
+			err := service.UpsertStudentArrivalSchedule(ctx, sched)
+			require.NoError(t, err)
+		}
+
+		err := service.DeleteAllStudentArrivalSchedules(ctx, student.ID)
+
+		require.NoError(t, err)
+
+		results, err := service.GetStudentArrivalSchedules(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+// =============================================================================
+// Exception Operations Tests
+// =============================================================================
+
+func TestArrivalScheduleService_CreateStudentArrivalException(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates exception successfully", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: time.Date(2024, 3, 15, 12, 0, 0, 0, timezone.Berlin),
+			Reason:        strPtr("Doctor appointment"),
+			CreatedBy:     1,
+		}
+
+		err := service.CreateStudentArrivalException(ctx, exception)
+
+		require.NoError(t, err)
+		assert.Greater(t, exception.ID, int64(0))
+	})
+
+	t.Run("returns error when exception already exists for date", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		exceptionDate := time.Date(2024, 3, 20, 12, 0, 0, 0, timezone.Berlin)
+		exception1 := &scheduleModels.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: exceptionDate,
+			Reason:        strPtr("First exception"),
+			CreatedBy:     1,
+		}
+		err := service.CreateStudentArrivalException(ctx, exception1)
+		require.NoError(t, err)
+
+		exception2 := &scheduleModels.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: exceptionDate,
+			Reason:        strPtr("Second exception"),
+			CreatedBy:     1,
+		}
+		err = service.CreateStudentArrivalException(ctx, exception2)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exception already exists for this date")
+	})
+
+	t.Run("fails validation for invalid exception", func(t *testing.T) {
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:     0,
+			ExceptionDate: time.Date(2024, 3, 15, 12, 0, 0, 0, timezone.Berlin),
+			Reason:        strPtr("Test"),
+			CreatedBy:     1,
+		}
+
+		err := service.CreateStudentArrivalException(ctx, exception)
+
+		require.Error(t, err)
+	})
+}
+
+func TestArrivalScheduleService_GetStudentArrivalExceptions(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns all exceptions for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		baseDate := timezone.Today()
+		for i := -2; i <= 2; i++ {
+			exception := &scheduleModels.StudentArrivalException{
+				StudentID:     student.ID,
+				ExceptionDate: baseDate.AddDate(0, 0, i),
+				Reason:        strPtr("Exception"),
+				CreatedBy:     1,
+			}
+			err := service.CreateStudentArrivalException(ctx, exception)
+			require.NoError(t, err)
+		}
+
+		results, err := service.GetStudentArrivalExceptions(ctx, student.ID)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 5)
+	})
+}
+
+func TestArrivalScheduleService_GetUpcomingStudentArrivalExceptions(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns only upcoming exceptions", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		baseDate := timezone.Today()
+
+		for i := -5; i < 0; i++ {
+			exception := &scheduleModels.StudentArrivalException{
+				StudentID:     student.ID,
+				ExceptionDate: baseDate.AddDate(0, 0, i),
+				Reason:        strPtr("Past"),
+				CreatedBy:     1,
+			}
+			err := service.CreateStudentArrivalException(ctx, exception)
+			require.NoError(t, err)
+		}
+
+		for i := 1; i <= 3; i++ {
+			exception := &scheduleModels.StudentArrivalException{
+				StudentID:     student.ID,
+				ExceptionDate: baseDate.AddDate(0, 0, i),
+				Reason:        strPtr("Future"),
+				CreatedBy:     1,
+			}
+			err := service.CreateStudentArrivalException(ctx, exception)
+			require.NoError(t, err)
+		}
+
+		results, err := service.GetUpcomingStudentArrivalExceptions(ctx, student.ID)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+		for _, result := range results {
+			assert.Equal(t, "Future", *result.Reason)
+		}
+	})
+}
+
+func TestArrivalScheduleService_UpdateStudentArrivalException(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("updates exception successfully", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+			Reason:        strPtr("Original reason"),
+			CreatedBy:     1,
+		}
+		err := service.CreateStudentArrivalException(ctx, exception)
+		require.NoError(t, err)
+
+		exception.Reason = strPtr("Updated reason")
+
+		err = service.UpdateStudentArrivalException(ctx, exception)
+
+		require.NoError(t, err)
+
+		exceptions, err := service.GetStudentArrivalExceptions(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Len(t, exceptions, 1)
+		assert.Equal(t, "Updated reason", *exceptions[0].Reason)
+	})
+}
+
+func TestArrivalScheduleService_DeleteStudentArrivalException(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes exception by ID", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC),
+			Reason:        strPtr("Test"),
+			CreatedBy:     1,
+		}
+		err := service.CreateStudentArrivalException(ctx, exception)
+		require.NoError(t, err)
+
+		err = service.DeleteStudentArrivalException(ctx, exception.ID)
+
+		require.NoError(t, err)
+
+		results, err := service.GetStudentArrivalExceptions(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestArrivalScheduleService_DeleteAllStudentArrivalExceptions(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes all exceptions for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		baseDate := timezone.Today()
+		for i := 1; i <= 5; i++ {
+			exception := &scheduleModels.StudentArrivalException{
+				StudentID:     student.ID,
+				ExceptionDate: baseDate.AddDate(0, 0, i),
+				Reason:        strPtr("Exception"),
+				CreatedBy:     1,
+			}
+			err := service.CreateStudentArrivalException(ctx, exception)
+			require.NoError(t, err)
+		}
+
+		err := service.DeleteAllStudentArrivalExceptions(ctx, student.ID)
+
+		require.NoError(t, err)
+
+		results, err := service.GetStudentArrivalExceptions(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+// =============================================================================
+// Note Operations Tests
+// =============================================================================
+
+func TestArrivalScheduleService_CreateStudentArrivalNote(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates note successfully", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  time.Date(2024, 3, 15, 12, 0, 0, 0, timezone.Berlin),
+			Content:   "Arrives by bus today",
+			CreatedBy: 1,
+		}
+
+		err := service.CreateStudentArrivalNote(ctx, note)
+
+		require.NoError(t, err)
+		assert.Greater(t, note.ID, int64(0))
+	})
+
+	t.Run("fails validation for invalid note", func(t *testing.T) {
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: 0, // Invalid
+			NoteDate:  time.Date(2024, 3, 15, 12, 0, 0, 0, timezone.Berlin),
+			Content:   "Test",
+			CreatedBy: 1,
+		}
+
+		err := service.CreateStudentArrivalNote(ctx, note)
+
+		require.Error(t, err)
+	})
+
+	t.Run("fails validation for empty content", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  time.Date(2024, 3, 15, 12, 0, 0, 0, timezone.Berlin),
+			Content:   "",
+			CreatedBy: 1,
+		}
+
+		err := service.CreateStudentArrivalNote(ctx, note)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "content is required")
+	})
+}
+
+func TestArrivalScheduleService_GetStudentArrivalNoteByID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns note by ID", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  time.Date(2024, 3, 16, 12, 0, 0, 0, timezone.Berlin),
+			Content:   "Test note",
+			CreatedBy: 1,
+		}
+		err := service.CreateStudentArrivalNote(ctx, note)
+		require.NoError(t, err)
+
+		result, err := service.GetStudentArrivalNoteByID(ctx, note.ID)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, note.ID, result.ID)
+		assert.Equal(t, "Test note", result.Content)
+	})
+}
+
+func TestArrivalScheduleService_GetStudentArrivalNotes(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns all notes for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		baseDate := timezone.Today()
+		for i := 0; i < 3; i++ {
+			note := &scheduleModels.StudentArrivalNote{
+				StudentID: student.ID,
+				NoteDate:  baseDate.AddDate(0, 0, i),
+				Content:   "Note content",
+				CreatedBy: 1,
+			}
+			err := service.CreateStudentArrivalNote(ctx, note)
+			require.NoError(t, err)
+		}
+
+		results, err := service.GetStudentArrivalNotes(ctx, student.ID)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+	})
+
+	t.Run("returns empty slice when no notes", func(t *testing.T) {
+		results, err := service.GetStudentArrivalNotes(ctx, int64(99999999))
+
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestArrivalScheduleService_GetStudentArrivalNotesForDate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns notes for specific date", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		targetDate := time.Date(2024, 3, 20, 12, 0, 0, 0, timezone.Berlin)
+
+		// Create notes for target date
+		for i := 0; i < 2; i++ {
+			note := &scheduleModels.StudentArrivalNote{
+				StudentID: student.ID,
+				NoteDate:  targetDate,
+				Content:   fmt.Sprintf("Note %d", i),
+				CreatedBy: 1,
+			}
+			err := service.CreateStudentArrivalNote(ctx, note)
+			require.NoError(t, err)
+		}
+
+		// Create note for different date
+		differentDate := targetDate.AddDate(0, 0, 1)
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  differentDate,
+			Content:   "Different date note",
+			CreatedBy: 1,
+		}
+		err := service.CreateStudentArrivalNote(ctx, note)
+		require.NoError(t, err)
+
+		results, err := service.GetStudentArrivalNotesForDate(ctx, student.ID, targetDate)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+}
+
+func TestArrivalScheduleService_UpdateStudentArrivalNote(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("updates note successfully", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+			Content:   "Original content",
+			CreatedBy: 1,
+		}
+		err := service.CreateStudentArrivalNote(ctx, note)
+		require.NoError(t, err)
+
+		note.Content = "Updated content"
+
+		err = service.UpdateStudentArrivalNote(ctx, note)
+
+		require.NoError(t, err)
+
+		notes, err := service.GetStudentArrivalNotes(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Len(t, notes, 1)
+		assert.Equal(t, "Updated content", notes[0].Content)
+	})
+
+	t.Run("fails validation on invalid note", func(t *testing.T) {
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: 0, // Invalid
+			NoteDate:  time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+			Content:   "Test",
+			CreatedBy: 1,
+		}
+
+		err := service.UpdateStudentArrivalNote(ctx, note)
+
+		require.Error(t, err)
+	})
+}
+
+func TestArrivalScheduleService_DeleteStudentArrivalNote(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes note by ID", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC),
+			Content:   "Test",
+			CreatedBy: 1,
+		}
+		err := service.CreateStudentArrivalNote(ctx, note)
+		require.NoError(t, err)
+
+		err = service.DeleteStudentArrivalNote(ctx, note.ID)
+
+		require.NoError(t, err)
+
+		results, err := service.GetStudentArrivalNotes(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestArrivalScheduleService_DeleteAllStudentArrivalNotes(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes all notes for student", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		baseDate := timezone.Today()
+		for i := 1; i <= 5; i++ {
+			note := &scheduleModels.StudentArrivalNote{
+				StudentID: student.ID,
+				NoteDate:  baseDate.AddDate(0, 0, i),
+				Content:   "Note",
+				CreatedBy: 1,
+			}
+			err := service.CreateStudentArrivalNote(ctx, note)
+			require.NoError(t, err)
+		}
+
+		err := service.DeleteAllStudentArrivalNotes(ctx, student.ID)
+
+		require.NoError(t, err)
+
+		results, err := service.GetStudentArrivalNotes(ctx, student.ID)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+// =============================================================================
+// Computed Operations Tests
+// =============================================================================
+
+func TestArrivalScheduleService_GetStudentArrivalData(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns combined schedule, exception, and note data", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+		require.NoError(t, err)
+
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:     student.ID,
+			ExceptionDate: timezone.Today().AddDate(0, 0, 5),
+			Reason:        strPtr("Future exception"),
+			CreatedBy:     1,
+		}
+		err = service.CreateStudentArrivalException(ctx, exception)
+		require.NoError(t, err)
+
+		note := &scheduleModels.StudentArrivalNote{
+			StudentID: student.ID,
+			NoteDate:  timezone.Today(),
+			Content:   "Test note",
+			CreatedBy: 1,
+		}
+		err = service.CreateStudentArrivalNote(ctx, note)
+		require.NoError(t, err)
+
+		result, err := service.GetStudentArrivalData(ctx, student.ID)
+
+		require.NoError(t, err)
+		assert.Len(t, result.Schedules, 1)
+		assert.Len(t, result.Exceptions, 1)
+		assert.Len(t, result.Notes, 1)
+	})
+}
+
+func TestArrivalScheduleService_GetEffectiveArrivalTimeForDate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns exception when present", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		recurringNote := "Arrives at side gate"
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+			Notes:           &recurringNote,
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+		require.NoError(t, err)
+
+		// January 8, 2024 is a Monday, noon UTC stays Monday in Berlin
+		testDate := time.Date(2024, 1, 8, 12, 0, 0, 0, time.UTC)
+
+		earlyTime := time.Date(2024, 1, 1, 9, 0, 0, 0, time.UTC)
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:       student.ID,
+			ExceptionDate:   testDate,
+			ExpectedArrival: &earlyTime,
+			Reason:          strPtr("Late arrival"),
+			CreatedBy:       1,
+		}
+		err = service.CreateStudentArrivalException(ctx, exception)
+		require.NoError(t, err)
+
+		result, err := service.GetEffectiveArrivalTimeForDate(ctx, student.ID, testDate)
+
+		require.NoError(t, err)
+		assert.True(t, result.IsException)
+		assert.NotNil(t, result.ArrivalTime)
+		assert.Equal(t, 9, result.ArrivalTime.Hour())
+		assert.Equal(t, "Late arrival", result.Notes)
+	})
+
+	t.Run("returns schedule when no exception", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayTuesday,
+			ExpectedArrival: time.Date(2024, 1, 1, 8, 15, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+		require.NoError(t, err)
+
+		// January 9, 2024 is a Tuesday, noon UTC stays Tuesday in Berlin
+		testDate := time.Date(2024, 1, 9, 12, 0, 0, 0, time.UTC)
+
+		result, err := service.GetEffectiveArrivalTimeForDate(ctx, student.ID, testDate)
+
+		require.NoError(t, err)
+		assert.False(t, result.IsException)
+		assert.NotNil(t, result.ArrivalTime)
+		assert.Equal(t, 8, result.ArrivalTime.Hour())
+		assert.Equal(t, 15, result.ArrivalTime.Minute())
+	})
+
+	t.Run("returns nil arrival time for weekend", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		// January 13, 2024 is a Saturday, noon UTC stays Saturday in Berlin
+		testDate := time.Date(2024, 1, 13, 12, 0, 0, 0, time.UTC)
+
+		result, err := service.GetEffectiveArrivalTimeForDate(ctx, student.ID, testDate)
+
+		require.NoError(t, err)
+		assert.Nil(t, result.ArrivalTime)
+	})
+
+	t.Run("returns nil when no schedule and no exception", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		// January 10, 2024 is a Wednesday
+		testDate := time.Date(2024, 1, 10, 12, 0, 0, 0, time.UTC)
+
+		result, err := service.GetEffectiveArrivalTimeForDate(ctx, student.ID, testDate)
+
+		require.NoError(t, err)
+		assert.Nil(t, result.ArrivalTime)
+		assert.False(t, result.IsException)
+	})
+
+	t.Run("returns schedule with notes", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		notes := "Walks with sibling"
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayFriday,
+			ExpectedArrival: time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC),
+			Notes:           &notes,
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+		require.NoError(t, err)
+
+		// January 12, 2024 is a Friday
+		testDate := time.Date(2024, 1, 12, 12, 0, 0, 0, time.UTC)
+
+		result, err := service.GetEffectiveArrivalTimeForDate(ctx, student.ID, testDate)
+
+		require.NoError(t, err)
+		assert.False(t, result.IsException)
+		assert.NotNil(t, result.ArrivalTime)
+		assert.Equal(t, "Walks with sibling", result.Notes)
+	})
+
+	t.Run("falls back to recurring schedule notes when exception reason is blank", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		recurringNote := "Wait at the side entrance"
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+			Notes:           &recurringNote,
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+		require.NoError(t, err)
+
+		testDate := time.Date(2024, 1, 8, 12, 0, 0, 0, time.UTC)
+		updatedTime := time.Date(2024, 1, 1, 9, 30, 0, 0, time.UTC)
+		blankReason := "   "
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:       student.ID,
+			ExceptionDate:   testDate,
+			ExpectedArrival: &updatedTime,
+			Reason:          &blankReason,
+			CreatedBy:       1,
+		}
+		err = service.CreateStudentArrivalException(ctx, exception)
+		require.NoError(t, err)
+
+		result, err := service.GetEffectiveArrivalTimeForDate(ctx, student.ID, testDate)
+
+		require.NoError(t, err)
+		assert.True(t, result.IsException)
+		assert.Equal(t, "Wait at the side entrance", result.Notes)
+	})
+
+	t.Run("handles Sunday correctly", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		// January 14, 2024 is a Sunday
+		testDate := time.Date(2024, 1, 14, 12, 0, 0, 0, time.UTC)
+
+		result, err := service.GetEffectiveArrivalTimeForDate(ctx, student.ID, testDate)
+
+		require.NoError(t, err)
+		assert.Nil(t, result.ArrivalTime)
+	})
+
+	t.Run("absent exception returns nil arrival time", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		// January 8, 2024 is a Monday
+		testDate := time.Date(2024, 1, 8, 12, 0, 0, 0, time.UTC)
+
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:       student.ID,
+			ExceptionDate:   testDate,
+			ExpectedArrival: nil, // absent
+			Reason:          strPtr("Sick"),
+			CreatedBy:       1,
+		}
+		err := service.CreateStudentArrivalException(ctx, exception)
+		require.NoError(t, err)
+
+		result, err := service.GetEffectiveArrivalTimeForDate(ctx, student.ID, testDate)
+
+		require.NoError(t, err)
+		assert.True(t, result.IsException)
+		assert.Nil(t, result.ArrivalTime)
+		assert.Equal(t, "Sick", result.Notes)
+	})
+}
+
+func TestArrivalScheduleService_GetBulkEffectiveArrivalTimesForDate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns effective times for multiple students", func(t *testing.T) {
+		student1 := testpkg.CreateTestStudent(t, db, "ArrStudent", "One", "1a")
+		student2 := testpkg.CreateTestStudent(t, db, "ArrStudent", "Two", "1b")
+		student3 := testpkg.CreateTestStudent(t, db, "ArrStudent", "Three", "1c")
+		defer testpkg.CleanupActivityFixtures(t, db, student1.ID, student2.ID, student3.ID)
+
+		// January 11, 2024 is a Thursday
+		testDate := time.Date(2024, 1, 11, 12, 0, 0, 0, time.UTC)
+
+		sched1 := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student1.ID,
+			Weekday:         scheduleModels.WeekdayThursday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 50, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, sched1)
+		require.NoError(t, err)
+
+		earlyTime := time.Date(2024, 1, 1, 9, 0, 0, 0, time.UTC)
+		exception2 := &scheduleModels.StudentArrivalException{
+			StudentID:       student2.ID,
+			ExceptionDate:   testDate,
+			ExpectedArrival: &earlyTime,
+			Reason:          strPtr("Doctor appointment"),
+			CreatedBy:       1,
+		}
+		err = service.CreateStudentArrivalException(ctx, exception2)
+		require.NoError(t, err)
+
+		exception3 := &scheduleModels.StudentArrivalException{
+			StudentID:       student3.ID,
+			ExceptionDate:   testDate,
+			ExpectedArrival: nil,
+			Reason:          strPtr("Sick"),
+			CreatedBy:       1,
+		}
+		err = service.CreateStudentArrivalException(ctx, exception3)
+		require.NoError(t, err)
+
+		results, err := service.GetBulkEffectiveArrivalTimesForDate(ctx, []int64{student1.ID, student2.ID, student3.ID}, testDate)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+
+		assert.False(t, results[student1.ID].IsException)
+		assert.NotNil(t, results[student1.ID].ArrivalTime)
+		assert.Equal(t, 7, results[student1.ID].ArrivalTime.Hour())
+
+		assert.True(t, results[student2.ID].IsException)
+		assert.NotNil(t, results[student2.ID].ArrivalTime)
+		assert.Equal(t, 9, results[student2.ID].ArrivalTime.Hour())
+		assert.Equal(t, "Doctor appointment", results[student2.ID].Notes)
+
+		assert.True(t, results[student3.ID].IsException)
+		assert.Nil(t, results[student3.ID].ArrivalTime)
+		assert.Equal(t, "Sick", results[student3.ID].Notes)
+	})
+
+	t.Run("returns empty map for empty student IDs", func(t *testing.T) {
+		results, err := service.GetBulkEffectiveArrivalTimesForDate(ctx, []int64{}, time.Now())
+
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("handles weekend correctly for all students", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		// January 14, 2024 is a Sunday
+		testDate := time.Date(2024, 1, 14, 12, 0, 0, 0, time.UTC)
+
+		results, err := service.GetBulkEffectiveArrivalTimesForDate(ctx, []int64{student.ID}, testDate)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Nil(t, results[student.ID].ArrivalTime)
+	})
+
+	t.Run("returns schedule notes in bulk lookup", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		// January 8, 2024 is a Monday
+		testDate := time.Date(2024, 1, 8, 12, 0, 0, 0, time.UTC)
+
+		notes := "Walked to school by aunt"
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC),
+			Notes:           &notes,
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+		require.NoError(t, err)
+
+		results, err := service.GetBulkEffectiveArrivalTimesForDate(ctx, []int64{student.ID}, testDate)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.NotNil(t, results[student.ID].ArrivalTime)
+		assert.Equal(t, "Walked to school by aunt", results[student.ID].Notes)
+		assert.False(t, results[student.ID].IsException)
+	})
+
+	t.Run("falls back to recurring schedule notes in bulk lookup when exception reason is blank", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Test", "ArrStudent", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		testDate := time.Date(2024, 1, 8, 12, 0, 0, 0, time.UTC)
+
+		recurringNote := "Ring the side entrance bell"
+		sched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC),
+			Notes:           &recurringNote,
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, sched)
+		require.NoError(t, err)
+
+		updatedTime := time.Date(2024, 1, 1, 9, 15, 0, 0, time.UTC)
+		blankReason := " "
+		exception := &scheduleModels.StudentArrivalException{
+			StudentID:       student.ID,
+			ExceptionDate:   testDate,
+			ExpectedArrival: &updatedTime,
+			Reason:          &blankReason,
+			CreatedBy:       1,
+		}
+		err = service.CreateStudentArrivalException(ctx, exception)
+		require.NoError(t, err)
+
+		results, err := service.GetBulkEffectiveArrivalTimesForDate(ctx, []int64{student.ID}, testDate)
+
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.True(t, results[student.ID].IsException)
+		assert.Equal(t, "Ring the side entrance bell", results[student.ID].Notes)
+	})
+}
+
+// =============================================================================
+// Bulk Class Upsert Tests
+// =============================================================================
+
+func TestArrivalScheduleService_BulkUpsertBySchoolClass(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupArrivalScheduleService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns error for empty school class", func(t *testing.T) {
+		result, err := service.BulkUpsertBySchoolClass(ctx, "", []schedule.ArrivalScheduleInput{
+			{Weekday: 1, ArrivalTime: "08:00"},
+		}, 1)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "school_class is required")
+	})
+
+	t.Run("returns error for empty schedules", func(t *testing.T) {
+		result, err := service.BulkUpsertBySchoolClass(ctx, "1a", []schedule.ArrivalScheduleInput{}, 1)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "schedules cannot be empty")
+	})
+
+	t.Run("returns zero students affected for empty class", func(t *testing.T) {
+		result, err := service.BulkUpsertBySchoolClass(ctx, "NONEXISTENT_CLASS_XYZ", []schedule.ArrivalScheduleInput{
+			{Weekday: 1, ArrivalTime: "08:00"},
+		}, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.StudentsAffected)
+	})
+
+	t.Run("upserts schedules for class with students", func(t *testing.T) {
+		// Create students in the same class
+		student1 := testpkg.CreateTestStudent(t, db, "BulkArr", "Student1", "BC1")
+		student2 := testpkg.CreateTestStudent(t, db, "BulkArr", "Student2", "BC1")
+		defer testpkg.CleanupActivityFixtures(t, db, student1.ID, student2.ID)
+
+		schedules := []schedule.ArrivalScheduleInput{
+			{Weekday: 1, ArrivalTime: "07:45"},
+			{Weekday: 3, ArrivalTime: "08:15"},
+		}
+
+		result, err := service.BulkUpsertBySchoolClass(ctx, "BC1", schedules, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.StudentsAffected)
+
+		// Verify schedules were created for both students
+		for _, studentID := range []int64{student1.ID, student2.ID} {
+			results, err := service.GetStudentArrivalSchedules(ctx, studentID)
+			require.NoError(t, err)
+			assert.Len(t, results, 2)
+		}
+	})
+
+	t.Run("returns overwrite warnings when schedules differ", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "BulkOverwrite", "Student", "BOW1")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		// Create existing schedule with a different time
+		existingSched := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       student.ID,
+			Weekday:         scheduleModels.WeekdayMonday,
+			ExpectedArrival: time.Date(2024, 1, 1, 7, 30, 0, 0, time.UTC),
+			CreatedBy:       1,
+		}
+		err := service.UpsertStudentArrivalSchedule(ctx, existingSched)
+		require.NoError(t, err)
+
+		schedules := []schedule.ArrivalScheduleInput{
+			{Weekday: 1, ArrivalTime: "08:00"}, // Different time
+		}
+
+		result, err := service.BulkUpsertBySchoolClass(ctx, "BOW1", schedules, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.StudentsAffected)
+		assert.GreaterOrEqual(t, len(result.OverwrittenStudents), 1)
+	})
+
+	t.Run("returns error for invalid arrival time format", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "BulkBadTime", "Student", "BBT1")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		schedules := []schedule.ArrivalScheduleInput{
+			{Weekday: 1, ArrivalTime: "invalid"},
+		}
+
+		result, err := service.BulkUpsertBySchoolClass(ctx, "BBT1", schedules, 1)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds student arrival schedule system mirroring the existing pickup schedule architecture
- 3 new tables in `schedule` schema: `student_arrival_schedules`, `student_arrival_exceptions`, `student_arrival_notes` (all with RLS)
- Full backend stack: migration, models, repositories, service, API handlers
- New bulk class operation: set arrival times for all students in a school class at once, with overwrite warnings
- Phase 0 of the timetable system — fully independent, no timetable dependency

## New API Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/students/{id}/arrival-schedules` | Get student's weekly arrival schedule |
| PUT | `/students/{id}/arrival-schedules` | Bulk update student's weekly schedules |
| POST | `/students/{id}/arrival-exceptions` | Create date-specific exception |
| PUT | `/students/{id}/arrival-exceptions/{exceptionId}` | Update exception |
| DELETE | `/students/{id}/arrival-exceptions/{exceptionId}` | Delete exception |
| POST | `/students/{id}/arrival-notes` | Create date-specific note |
| PUT | `/students/{id}/arrival-notes/{noteId}` | Update note |
| DELETE | `/students/{id}/arrival-notes/{noteId}` | Delete note |
| POST | `/students/arrival-schedules/bulk` | Bulk upsert by school class |
| POST | `/students/arrival-times/bulk` | Bulk effective time resolution |

## Test plan

- [ ] Run migration: `docker compose run server ./main migrate`
- [ ] Verify tables created: `student_arrival_schedules`, `student_arrival_exceptions`, `student_arrival_notes`
- [ ] Test per-student CRUD via API (GET/PUT schedules, POST/PUT/DELETE exceptions and notes)
- [ ] Test bulk class upsert: POST to `/students/arrival-schedules/bulk` with `school_class` + schedules
- [ ] Verify overwrite warnings returned when students have existing individual schedules
- [ ] Test effective time resolution: exception overrides schedule, NULL arrival = absent
- [ ] Verify RLS tenant isolation (student from tenant A not visible to tenant B)
- [ ] `cd backend && go build ./...` compiles cleanly
- [ ] `cd backend && go test ./...` passes