### PR TITLE
feat: calendar periods + template extensions for timetable system

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -36,6 +36,7 @@ import (
 	substitutionsAPI "github.com/moto-nrw/project-phoenix/api/substitutions"
 	suggestionsAPI "github.com/moto-nrw/project-phoenix/api/suggestions"
 	timeTrackingAPI "github.com/moto-nrw/project-phoenix/api/time-tracking"
+	timetableAPI "github.com/moto-nrw/project-phoenix/api/timetable"
 	usercontextAPI "github.com/moto-nrw/project-phoenix/api/usercontext"
 	usersAPI "github.com/moto-nrw/project-phoenix/api/users"
 
@@ -79,6 +80,7 @@ type API struct {
 	Database         *databaseAPI.Resource
 	GradeTransitions *adminAPI.GradeTransitionResource
 	TimeTracking     *timeTrackingAPI.Resource
+	Timetable        *timetableAPI.Resource
 
 	// Operator Dashboard (platform domain)
 	Operator *operatorAPI.Resource
@@ -346,6 +348,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Database = databaseAPI.NewResource(api.Services.Database, db)
 	api.GradeTransitions = adminAPI.NewGradeTransitionResource(api.Services.GradeTransition, db)
 	api.TimeTracking = timeTrackingAPI.NewResource(api.Services.WorkSession, api.Services.StaffAbsence, api.Services.Users, db)
+	api.Timetable = timetableAPI.NewResource(api.Services.CalendarPeriod, db)
 
 	// Initialize operator dashboard resources
 	api.Operator = operatorAPI.NewResource(operatorAPI.ResourceConfig{
@@ -494,6 +497,9 @@ func (a *API) registerRoutesWithRateLimiting() {
 
 		// Mount time-tracking resources
 		r.Mount("/time-tracking", a.TimeTracking.Router())
+
+		// Mount timetable resources
+		r.Mount("/timetable", a.Timetable.Router())
 
 		// Mount admin resources
 		r.Mount("/admin/grade-transitions", a.GradeTransitions.Router())

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -121,6 +121,34 @@ func mapPeriodToResponse(p *schedule.CalendarPeriod) CalendarPeriodResponse {
 	return resp
 }
 
+// parseDates extracts start_date, end_date, and optional week_cycle_anchor from a request.
+// Returns parsed times and true on success, or renders an error and returns false.
+func parseDates(w http.ResponseWriter, r *http.Request, req *CalendarPeriodRequest) (startDate, endDate time.Time, anchor *time.Time, ok bool) {
+	var err error
+	startDate, err = time.Parse(dateLayout, req.StartDate)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid start_date format, expected YYYY-MM-DD")))
+		return time.Time{}, time.Time{}, nil, false
+	}
+
+	endDate, err = time.Parse(dateLayout, req.EndDate)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid end_date format, expected YYYY-MM-DD")))
+		return time.Time{}, time.Time{}, nil, false
+	}
+
+	if req.WeekCycleAnchor != nil {
+		a, err := time.Parse(dateLayout, *req.WeekCycleAnchor)
+		if err != nil {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid week_cycle_anchor format, expected YYYY-MM-DD")))
+			return time.Time{}, time.Time{}, nil, false
+		}
+		anchor = &a
+	}
+
+	return startDate, endDate, anchor, true
+}
+
 // Handlers
 
 func (rs *Resource) listPeriods(w http.ResponseWriter, r *http.Request) {
@@ -161,15 +189,8 @@ func (rs *Resource) createPeriod(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	startDate, err := time.Parse(dateLayout, req.StartDate)
-	if err != nil {
-		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid start_date format, expected YYYY-MM-DD")))
-		return
-	}
-
-	endDate, err := time.Parse(dateLayout, req.EndDate)
-	if err != nil {
-		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid end_date format, expected YYYY-MM-DD")))
+	startDate, endDate, anchor, ok := parseDates(w, r, req)
+	if !ok {
 		return
 	}
 
@@ -179,16 +200,8 @@ func (rs *Resource) createPeriod(w http.ResponseWriter, r *http.Request) {
 		StartDate:       startDate,
 		EndDate:         endDate,
 		WeekCycleLength: req.WeekCycleLength,
+		WeekCycleAnchor: anchor,
 		IsActive:        req.IsActive,
-	}
-
-	if req.WeekCycleAnchor != nil {
-		anchor, err := time.Parse(dateLayout, *req.WeekCycleAnchor)
-		if err != nil {
-			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid week_cycle_anchor format, expected YYYY-MM-DD")))
-			return
-		}
-		period.WeekCycleAnchor = &anchor
 	}
 
 	if period.WeekCycleLength == 0 {
@@ -222,15 +235,8 @@ func (rs *Resource) updatePeriod(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	startDate, err := time.Parse(dateLayout, req.StartDate)
-	if err != nil {
-		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid start_date format, expected YYYY-MM-DD")))
-		return
-	}
-
-	endDate, err := time.Parse(dateLayout, req.EndDate)
-	if err != nil {
-		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid end_date format, expected YYYY-MM-DD")))
+	startDate, endDate, anchor, ok := parseDates(w, r, req)
+	if !ok {
 		return
 	}
 
@@ -239,18 +245,8 @@ func (rs *Resource) updatePeriod(w http.ResponseWriter, r *http.Request) {
 	existing.StartDate = startDate
 	existing.EndDate = endDate
 	existing.WeekCycleLength = req.WeekCycleLength
+	existing.WeekCycleAnchor = anchor
 	existing.IsActive = req.IsActive
-
-	if req.WeekCycleAnchor != nil {
-		anchor, err := time.Parse(dateLayout, *req.WeekCycleAnchor)
-		if err != nil {
-			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid week_cycle_anchor format, expected YYYY-MM-DD")))
-			return
-		}
-		existing.WeekCycleAnchor = &anchor
-	} else {
-		existing.WeekCycleAnchor = nil
-	}
 
 	if existing.WeekCycleLength == 0 {
 		existing.WeekCycleLength = 1

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -1,8 +1,10 @@
 package timetable
 
 import (
+	"database/sql"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -76,14 +78,23 @@ func (req *CalendarPeriodRequest) Bind(_ *http.Request) error {
 	if req.Name == "" {
 		return errors.New("name is required")
 	}
+	if len(req.Name) > 255 {
+		return errors.New("name cannot exceed 255 characters")
+	}
 	if req.PeriodType == "" {
 		return errors.New("period_type is required")
+	}
+	if !schedule.IsValidPeriodType(req.PeriodType) {
+		return errors.New("invalid period_type, must be one of: school_year, semester, holiday, custom")
 	}
 	if req.StartDate == "" {
 		return errors.New("start_date is required")
 	}
 	if req.EndDate == "" {
 		return errors.New("end_date is required")
+	}
+	if req.WeekCycleLength <= 0 {
+		req.WeekCycleLength = 1
 	}
 	return nil
 }
@@ -149,6 +160,20 @@ func parseDates(w http.ResponseWriter, r *http.Request, req *CalendarPeriodReque
 	return startDate, endDate, anchor, true
 }
 
+// validatePeriodRules checks business rules after dates have been parsed.
+// Returns true on success, or renders an error and returns false.
+func validatePeriodRules(w http.ResponseWriter, r *http.Request, req *CalendarPeriodRequest, startDate, endDate time.Time, anchor *time.Time) bool {
+	if !endDate.After(startDate) {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("end_date must be after start_date")))
+		return false
+	}
+	if req.WeekCycleLength > 1 && anchor == nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("week_cycle_anchor is required when week_cycle_length > 1")))
+		return false
+	}
+	return true
+}
+
 // Handlers
 
 func (rs *Resource) listPeriods(w http.ResponseWriter, r *http.Request) {
@@ -175,7 +200,11 @@ func (rs *Resource) getPeriod(w http.ResponseWriter, r *http.Request) {
 
 	period, err := rs.calendarPeriodService.GetPeriodByID(r.Context(), id)
 	if err != nil {
-		common.RenderError(w, r, common.ErrorNotFound(errors.New("calendar period not found")))
+		if errors.Is(err, sql.ErrNoRows) {
+			common.RenderError(w, r, common.ErrorNotFound(errors.New("calendar period not found")))
+		} else {
+			common.RenderError(w, r, common.ErrorInternalServer(err))
+		}
 		return
 	}
 
@@ -194,6 +223,10 @@ func (rs *Resource) createPeriod(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !validatePeriodRules(w, r, req, startDate, endDate, anchor) {
+		return
+	}
+
 	period := &schedule.CalendarPeriod{
 		Name:            req.Name,
 		PeriodType:      req.PeriodType,
@@ -204,12 +237,12 @@ func (rs *Resource) createPeriod(w http.ResponseWriter, r *http.Request) {
 		IsActive:        req.IsActive,
 	}
 
-	if period.WeekCycleLength == 0 {
-		period.WeekCycleLength = 1
-	}
-
 	if err := rs.calendarPeriodService.CreatePeriod(r.Context(), period); err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(err))
+		if strings.Contains(err.Error(), "already exists") {
+			common.RenderError(w, r, common.ErrorConflict(errors.New("a period with this name already exists")))
+		} else {
+			common.RenderError(w, r, common.ErrorInternalServer(err))
+		}
 		return
 	}
 
@@ -225,7 +258,11 @@ func (rs *Resource) updatePeriod(w http.ResponseWriter, r *http.Request) {
 
 	existing, err := rs.calendarPeriodService.GetPeriodByID(r.Context(), id)
 	if err != nil {
-		common.RenderError(w, r, common.ErrorNotFound(errors.New("calendar period not found")))
+		if errors.Is(err, sql.ErrNoRows) {
+			common.RenderError(w, r, common.ErrorNotFound(errors.New("calendar period not found")))
+		} else {
+			common.RenderError(w, r, common.ErrorInternalServer(err))
+		}
 		return
 	}
 
@@ -240,6 +277,10 @@ func (rs *Resource) updatePeriod(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !validatePeriodRules(w, r, req, startDate, endDate, anchor) {
+		return
+	}
+
 	existing.Name = req.Name
 	existing.PeriodType = req.PeriodType
 	existing.StartDate = startDate
@@ -248,12 +289,12 @@ func (rs *Resource) updatePeriod(w http.ResponseWriter, r *http.Request) {
 	existing.WeekCycleAnchor = anchor
 	existing.IsActive = req.IsActive
 
-	if existing.WeekCycleLength == 0 {
-		existing.WeekCycleLength = 1
-	}
-
 	if err := rs.calendarPeriodService.UpdatePeriod(r.Context(), existing); err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(err))
+		if strings.Contains(err.Error(), "already exists") {
+			common.RenderError(w, r, common.ErrorConflict(errors.New("a period with this name already exists")))
+		} else {
+			common.RenderError(w, r, common.ErrorInternalServer(err))
+		}
 		return
 	}
 
@@ -264,6 +305,15 @@ func (rs *Resource) deletePeriod(w http.ResponseWriter, r *http.Request) {
 	id, err := common.ParseID(r)
 	if err != nil {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid period ID")))
+		return
+	}
+
+	if _, err := rs.calendarPeriodService.GetPeriodByID(r.Context(), id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			common.RenderError(w, r, common.ErrorNotFound(errors.New("calendar period not found")))
+		} else {
+			common.RenderError(w, r, common.ErrorInternalServer(err))
+		}
 		return
 	}
 

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -1,0 +1,280 @@
+package timetable
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+const dateLayout = "2006-01-02"
+
+// Resource defines the timetable API resource
+type Resource struct {
+	calendarPeriodService scheduleSvc.CalendarPeriodService
+	db                    *bun.DB
+}
+
+// NewResource creates a new timetable resource
+func NewResource(calendarPeriodService scheduleSvc.CalendarPeriodService, db *bun.DB) *Resource {
+	return &Resource{
+		calendarPeriodService: calendarPeriodService,
+		db:                    db,
+	}
+}
+
+// Router returns a configured router for timetable endpoints
+func (rs *Resource) Router() chi.Router {
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+
+	tokenAuth := jwt.MustNewTokenAuth()
+
+	r.Group(func(r chi.Router) {
+		r.Use(tokenAuth.Verifier())
+		r.Use(jwt.Authenticator)
+		r.Use(jwt.TenantMiddleware)
+		withTx := tenant.TenantTxMiddleware(rs.db)
+
+		r.Route("/periods", func(r chi.Router) {
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).Get("/", rs.listPeriods)
+			r.With(authorize.RequiresPermission(permissions.SchedulesCreate), withTx).Post("/", rs.createPeriod)
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).Get("/{id}", rs.getPeriod)
+			r.With(authorize.RequiresPermission(permissions.SchedulesUpdate), withTx).Put("/{id}", rs.updatePeriod)
+			r.With(authorize.RequiresPermission(permissions.SchedulesDelete), withTx).Delete("/{id}", rs.deletePeriod)
+		})
+	})
+
+	return r
+}
+
+// Request / Response types
+
+// CalendarPeriodRequest represents a create/update request for a calendar period
+type CalendarPeriodRequest struct {
+	Name            string  `json:"name"`
+	PeriodType      string  `json:"period_type"`
+	StartDate       string  `json:"start_date"`
+	EndDate         string  `json:"end_date"`
+	WeekCycleLength int     `json:"week_cycle_length"`
+	WeekCycleAnchor *string `json:"week_cycle_anchor,omitempty"`
+	IsActive        bool    `json:"is_active"`
+}
+
+// Bind validates the request
+func (req *CalendarPeriodRequest) Bind(_ *http.Request) error {
+	if req.Name == "" {
+		return errors.New("name is required")
+	}
+	if req.PeriodType == "" {
+		return errors.New("period_type is required")
+	}
+	if req.StartDate == "" {
+		return errors.New("start_date is required")
+	}
+	if req.EndDate == "" {
+		return errors.New("end_date is required")
+	}
+	return nil
+}
+
+// CalendarPeriodResponse represents a calendar period in API responses
+type CalendarPeriodResponse struct {
+	ID              int64   `json:"id"`
+	Name            string  `json:"name"`
+	PeriodType      string  `json:"period_type"`
+	StartDate       string  `json:"start_date"`
+	EndDate         string  `json:"end_date"`
+	WeekCycleLength int     `json:"week_cycle_length"`
+	WeekCycleAnchor *string `json:"week_cycle_anchor,omitempty"`
+	IsActive        bool    `json:"is_active"`
+	CreatedAt       string  `json:"created_at"`
+	UpdatedAt       string  `json:"updated_at"`
+}
+
+func mapPeriodToResponse(p *schedule.CalendarPeriod) CalendarPeriodResponse {
+	resp := CalendarPeriodResponse{
+		ID:              p.ID,
+		Name:            p.Name,
+		PeriodType:      p.PeriodType,
+		StartDate:       p.StartDate.Format(dateLayout),
+		EndDate:         p.EndDate.Format(dateLayout),
+		WeekCycleLength: p.WeekCycleLength,
+		IsActive:        p.IsActive,
+		CreatedAt:       p.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:       p.UpdatedAt.Format(time.RFC3339),
+	}
+	if p.WeekCycleAnchor != nil {
+		anchor := p.WeekCycleAnchor.Format(dateLayout)
+		resp.WeekCycleAnchor = &anchor
+	}
+	return resp
+}
+
+// Handlers
+
+func (rs *Resource) listPeriods(w http.ResponseWriter, r *http.Request) {
+	periods, err := rs.calendarPeriodService.GetAllPeriods(r.Context())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	responses := make([]CalendarPeriodResponse, len(periods))
+	for i, p := range periods {
+		responses[i] = mapPeriodToResponse(p)
+	}
+
+	common.Respond(w, r, http.StatusOK, responses, "Calendar periods retrieved successfully")
+}
+
+func (rs *Resource) getPeriod(w http.ResponseWriter, r *http.Request) {
+	id, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid period ID")))
+		return
+	}
+
+	period, err := rs.calendarPeriodService.GetPeriodByID(r.Context(), id)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorNotFound(errors.New("calendar period not found")))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, mapPeriodToResponse(period), "Calendar period retrieved successfully")
+}
+
+func (rs *Resource) createPeriod(w http.ResponseWriter, r *http.Request) {
+	req := &CalendarPeriodRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	startDate, err := time.Parse(dateLayout, req.StartDate)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid start_date format, expected YYYY-MM-DD")))
+		return
+	}
+
+	endDate, err := time.Parse(dateLayout, req.EndDate)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid end_date format, expected YYYY-MM-DD")))
+		return
+	}
+
+	period := &schedule.CalendarPeriod{
+		Name:            req.Name,
+		PeriodType:      req.PeriodType,
+		StartDate:       startDate,
+		EndDate:         endDate,
+		WeekCycleLength: req.WeekCycleLength,
+		IsActive:        req.IsActive,
+	}
+
+	if req.WeekCycleAnchor != nil {
+		anchor, err := time.Parse(dateLayout, *req.WeekCycleAnchor)
+		if err != nil {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid week_cycle_anchor format, expected YYYY-MM-DD")))
+			return
+		}
+		period.WeekCycleAnchor = &anchor
+	}
+
+	if period.WeekCycleLength == 0 {
+		period.WeekCycleLength = 1
+	}
+
+	if err := rs.calendarPeriodService.CreatePeriod(r.Context(), period); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusCreated, mapPeriodToResponse(period), "Calendar period created successfully")
+}
+
+func (rs *Resource) updatePeriod(w http.ResponseWriter, r *http.Request) {
+	id, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid period ID")))
+		return
+	}
+
+	existing, err := rs.calendarPeriodService.GetPeriodByID(r.Context(), id)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorNotFound(errors.New("calendar period not found")))
+		return
+	}
+
+	req := &CalendarPeriodRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	startDate, err := time.Parse(dateLayout, req.StartDate)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid start_date format, expected YYYY-MM-DD")))
+		return
+	}
+
+	endDate, err := time.Parse(dateLayout, req.EndDate)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid end_date format, expected YYYY-MM-DD")))
+		return
+	}
+
+	existing.Name = req.Name
+	existing.PeriodType = req.PeriodType
+	existing.StartDate = startDate
+	existing.EndDate = endDate
+	existing.WeekCycleLength = req.WeekCycleLength
+	existing.IsActive = req.IsActive
+
+	if req.WeekCycleAnchor != nil {
+		anchor, err := time.Parse(dateLayout, *req.WeekCycleAnchor)
+		if err != nil {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid week_cycle_anchor format, expected YYYY-MM-DD")))
+			return
+		}
+		existing.WeekCycleAnchor = &anchor
+	} else {
+		existing.WeekCycleAnchor = nil
+	}
+
+	if existing.WeekCycleLength == 0 {
+		existing.WeekCycleLength = 1
+	}
+
+	if err := rs.calendarPeriodService.UpdatePeriod(r.Context(), existing); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, mapPeriodToResponse(existing), "Calendar period updated successfully")
+}
+
+func (rs *Resource) deletePeriod(w http.ResponseWriter, r *http.Request) {
+	id, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid period ID")))
+		return
+	}
+
+	if err := rs.calendarPeriodService.DeletePeriod(r.Context(), id); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, nil, "Calendar period deleted successfully")
+}

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -238,8 +237,8 @@ func (rs *Resource) createPeriod(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := rs.calendarPeriodService.CreatePeriod(r.Context(), period); err != nil {
-		if strings.Contains(err.Error(), "already exists") {
-			common.RenderError(w, r, common.ErrorConflict(errors.New("a period with this name already exists")))
+		if errors.Is(err, schedule.ErrCalendarPeriodNameConflict) {
+			common.RenderError(w, r, common.ErrorConflict(schedule.ErrCalendarPeriodNameConflict))
 		} else {
 			common.RenderError(w, r, common.ErrorInternalServer(err))
 		}
@@ -290,8 +289,8 @@ func (rs *Resource) updatePeriod(w http.ResponseWriter, r *http.Request) {
 	existing.IsActive = req.IsActive
 
 	if err := rs.calendarPeriodService.UpdatePeriod(r.Context(), existing); err != nil {
-		if strings.Contains(err.Error(), "already exists") {
-			common.RenderError(w, r, common.ErrorConflict(errors.New("a period with this name already exists")))
+		if errors.Is(err, schedule.ErrCalendarPeriodNameConflict) {
+			common.RenderError(w, r, common.ErrorConflict(schedule.ErrCalendarPeriodNameConflict))
 		} else {
 			common.RenderError(w, r, common.ErrorInternalServer(err))
 		}

--- a/backend/api/timetable/api_test.go
+++ b/backend/api/timetable/api_test.go
@@ -3,6 +3,7 @@ package timetable
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -24,7 +25,9 @@ import (
 type mockCalendarPeriodService struct {
 	periods           []*schedule.CalendarPeriod
 	period            *schedule.CalendarPeriod
-	err               error
+	err               error // default error for all methods
+	updateErr         error // if set, UpdatePeriod returns this instead of err
+	deleteErr         error // if set, DeletePeriod returns this instead of err
 	lastCreated       *schedule.CalendarPeriod
 	lastUpdated       *schedule.CalendarPeriod
 	lastDeletedID     int64
@@ -56,11 +59,17 @@ func (m *mockCalendarPeriodService) CreatePeriod(_ context.Context, p *schedule.
 
 func (m *mockCalendarPeriodService) UpdatePeriod(_ context.Context, p *schedule.CalendarPeriod) error {
 	m.lastUpdated = p
+	if m.updateErr != nil {
+		return m.updateErr
+	}
 	return m.err
 }
 
 func (m *mockCalendarPeriodService) DeletePeriod(_ context.Context, id int64) error {
 	m.lastDeletedID = id
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
 	return m.err
 }
 
@@ -113,20 +122,19 @@ func executeRequest(router chi.Router, method, path string, body interface{}) *h
 	return w
 }
 
-func makePeriod(id int64, name string) *schedule.CalendarPeriod {
-	return &schedule.CalendarPeriod{
-		Name:            name,
+func newTestPeriod() *schedule.CalendarPeriod {
+	p := &schedule.CalendarPeriod{
+		Name:            "Test Period",
 		PeriodType:      schedule.PeriodTypeSchoolYear,
 		StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
 		EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
 		WeekCycleLength: 1,
 		IsActive:        true,
 	}
-}
-
-func init() {
-	// makePeriod sets ID on the embedded Model
-	_ = makePeriod(0, "")
+	p.ID = int64(42)
+	p.CreatedAt = time.Now()
+	p.UpdatedAt = time.Now()
+	return p
 }
 
 // =============================================================================
@@ -172,6 +180,22 @@ func TestCalendarPeriodRequest_Bind(t *testing.T) {
 		assert.Contains(t, err.Error(), "name is required")
 	})
 
+	t.Run("name too long", func(t *testing.T) {
+		longName := ""
+		for i := 0; i < 256; i++ {
+			longName += "x"
+		}
+		req := &CalendarPeriodRequest{
+			Name:       longName,
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-07-31",
+		}
+		err := req.Bind(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name cannot exceed 255 characters")
+	})
+
 	t.Run("missing period_type", func(t *testing.T) {
 		req := &CalendarPeriodRequest{
 			Name:      "Test",
@@ -181,6 +205,18 @@ func TestCalendarPeriodRequest_Bind(t *testing.T) {
 		err := req.Bind(nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "period_type is required")
+	})
+
+	t.Run("invalid period_type", func(t *testing.T) {
+		req := &CalendarPeriodRequest{
+			Name:       "Test",
+			PeriodType: "invalid_type",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-07-31",
+		}
+		err := req.Bind(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid period_type")
 	})
 
 	t.Run("missing start_date", func(t *testing.T) {
@@ -203,6 +239,19 @@ func TestCalendarPeriodRequest_Bind(t *testing.T) {
 		err := req.Bind(nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "end_date is required")
+	})
+
+	t.Run("defaults week_cycle_length to 1 when zero", func(t *testing.T) {
+		req := &CalendarPeriodRequest{
+			Name:            "Test",
+			PeriodType:      "school_year",
+			StartDate:       "2025-08-01",
+			EndDate:         "2026-07-31",
+			WeekCycleLength: 0,
+		}
+		err := req.Bind(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, req.WeekCycleLength)
 	})
 }
 
@@ -352,13 +401,23 @@ func TestGetPeriod(t *testing.T) {
 	})
 
 	t.Run("returns 404 when not found", func(t *testing.T) {
-		mock := &mockCalendarPeriodService{err: errors.New("not found")}
+		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
 		res := NewResource(mock, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/999", nil)
 
 		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("returns 500 on internal error", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{err: errors.New("db connection failed")}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
+
+		w := executeRequest(router, http.MethodGet, "/42", nil)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
 	})
 }
 
@@ -445,6 +504,24 @@ func TestCreatePeriod(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
+	t.Run("returns 400 for invalid period_type", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		body := CalendarPeriodRequest{
+			Name:       "Bad Type",
+			PeriodType: "invalid_type",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-07-31",
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "invalid period_type")
+	})
+
 	t.Run("returns 400 for invalid start_date format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
 		res := NewResource(mock, nil)
@@ -502,6 +579,61 @@ func TestCreatePeriod(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "week_cycle_anchor")
 	})
 
+	t.Run("returns 400 for end_date before start_date", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		body := CalendarPeriodRequest{
+			Name:       "Bad Dates",
+			PeriodType: "school_year",
+			StartDate:  "2026-08-01",
+			EndDate:    "2025-07-31",
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "end_date must be after start_date")
+	})
+
+	t.Run("returns 400 for cycle > 1 without anchor", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		body := CalendarPeriodRequest{
+			Name:            "No Anchor",
+			PeriodType:      "school_year",
+			StartDate:       "2025-08-01",
+			EndDate:         "2026-07-31",
+			WeekCycleLength: 2,
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "week_cycle_anchor is required")
+	})
+
+	t.Run("returns 409 for duplicate name", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{err: errors.New("a period with this name already exists")}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		body := CalendarPeriodRequest{
+			Name:       "Duplicate",
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-07-31",
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
+		assert.Contains(t, w.Body.String(), "already exists")
+	})
+
 	t.Run("returns 500 on service error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("create failed")}
 		res := NewResource(mock, nil)
@@ -525,17 +657,7 @@ func TestCreatePeriod(t *testing.T) {
 // =============================================================================
 
 func TestUpdatePeriod(t *testing.T) {
-	existingPeriod := &schedule.CalendarPeriod{
-		Name:            "Existing Period",
-		PeriodType:      schedule.PeriodTypeSchoolYear,
-		StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
-		EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
-		WeekCycleLength: 1,
-		IsActive:        true,
-	}
-	existingPeriod.ID = int64(42)
-	existingPeriod.CreatedAt = time.Now()
-	existingPeriod.UpdatedAt = time.Now()
+	existingPeriod := newTestPeriod()
 
 	t.Run("updates period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
@@ -658,7 +780,7 @@ func TestUpdatePeriod(t *testing.T) {
 	})
 
 	t.Run("returns 404 when period not found", func(t *testing.T) {
-		mock := &mockCalendarPeriodService{err: errors.New("not found")}
+		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
 		res := NewResource(mock, nil)
 
 		r := chi.NewRouter()
@@ -668,6 +790,19 @@ func TestUpdatePeriod(t *testing.T) {
 		w := executeRequest(r, http.MethodPut, "/999", nil)
 
 		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("returns 500 on get internal error", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{err: errors.New("db connection failed")}
+		res := NewResource(mock, nil)
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
+
+		w := executeRequest(r, http.MethodPut, "/42", nil)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
 	})
 
 	t.Run("returns 400 for invalid start_date in update", func(t *testing.T) {
@@ -733,32 +868,61 @@ func TestUpdatePeriod(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
-	t.Run("returns 500 on service update error", func(t *testing.T) {
-		// First call (GetPeriodByID) succeeds, second call (UpdatePeriod) fails
-		// We need a more sophisticated mock for this
-		callCount := 0
+	t.Run("returns 400 for end_date before start_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
 		res := NewResource(mock, nil)
 
-		// Override the service to fail on update
-		updateErr := errors.New("update failed")
-		mock2 := &mockCalendarPeriodService{period: existingPeriod, err: updateErr}
-		// Use a wrapping approach: the handler calls GetPeriodByID first, then UpdatePeriod
-		// Since our mock returns the same error for all methods, we need to handle this differently
-		// Instead, test with a service that fails only on update
-		res2 := NewResource(&updateOnlyErrorService{
-			period:    existingPeriod,
-			updateErr: updateErr,
-		}, nil)
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
 
-		_ = mock
-		_ = res
-		_ = callCount
-		_ = mock2
+		body := CalendarPeriodRequest{
+			Name:       "Bad Dates",
+			PeriodType: "school_year",
+			StartDate:  "2026-08-01",
+			EndDate:    "2025-07-31",
+		}
+
+		w := executeRequest(r, http.MethodPut, "/42", body)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "end_date must be after start_date")
+	})
+
+	t.Run("returns 409 for duplicate name on update", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{
+			period:    existingPeriod,
+			updateErr: errors.New("a period with this name already exists"),
+		}
+		res := NewResource(mock, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
-		r.Put("/{id}", res2.updatePeriod)
+		r.Put("/{id}", res.updatePeriod)
+
+		body := CalendarPeriodRequest{
+			Name:       "Duplicate Name",
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-07-31",
+		}
+
+		w := executeRequest(r, http.MethodPut, "/42", body)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
+		assert.Contains(t, w.Body.String(), "already exists")
+	})
+
+	t.Run("returns 500 on service update error", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{
+			period:    existingPeriod,
+			updateErr: errors.New("db write failed"),
+		}
+		res := NewResource(mock, nil)
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
 
 		body := CalendarPeriodRequest{
 			Name:       "Will Fail",
@@ -773,42 +937,13 @@ func TestUpdatePeriod(t *testing.T) {
 	})
 }
 
-// updateOnlyErrorService fails only on UpdatePeriod
-type updateOnlyErrorService struct {
-	period    *schedule.CalendarPeriod
-	updateErr error
-}
-
-func (s *updateOnlyErrorService) GetAllPeriods(_ context.Context) ([]*schedule.CalendarPeriod, error) {
-	return nil, nil
-}
-func (s *updateOnlyErrorService) GetActivePeriods(_ context.Context) ([]*schedule.CalendarPeriod, error) {
-	return nil, nil
-}
-func (s *updateOnlyErrorService) GetPeriodByID(_ context.Context, _ int64) (*schedule.CalendarPeriod, error) {
-	return s.period, nil
-}
-func (s *updateOnlyErrorService) CreatePeriod(_ context.Context, _ *schedule.CalendarPeriod) error {
-	return nil
-}
-func (s *updateOnlyErrorService) UpdatePeriod(_ context.Context, _ *schedule.CalendarPeriod) error {
-	return s.updateErr
-}
-func (s *updateOnlyErrorService) DeletePeriod(_ context.Context, _ int64) error { return nil }
-func (s *updateOnlyErrorService) GetOrCreateDefaultPeriod(_ context.Context) (*schedule.CalendarPeriod, error) {
-	return nil, nil
-}
-func (s *updateOnlyErrorService) ShouldMaterialize(_ int, _ time.Time, _ *schedule.CalendarPeriod) bool {
-	return true
-}
-
 // =============================================================================
 // deletePeriod Handler Tests
 // =============================================================================
 
 func TestDeletePeriod(t *testing.T) {
 	t.Run("deletes period successfully", func(t *testing.T) {
-		mock := &mockCalendarPeriodService{}
+		mock := &mockCalendarPeriodService{period: newTestPeriod()}
 		res := NewResource(mock, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
@@ -828,8 +963,21 @@ func TestDeletePeriod(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
+	t.Run("returns 404 when period not found", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
+
+		w := executeRequest(router, http.MethodDelete, "/999", nil)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
 	t.Run("returns 500 on service error", func(t *testing.T) {
-		mock := &mockCalendarPeriodService{err: errors.New("delete failed")}
+		mock := &mockCalendarPeriodService{
+			period:    newTestPeriod(),
+			deleteErr: errors.New("delete failed"),
+		}
 		res := NewResource(mock, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 

--- a/backend/api/timetable/api_test.go
+++ b/backend/api/timetable/api_test.go
@@ -1,0 +1,840 @@
+package timetable
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Mock CalendarPeriodService
+// =============================================================================
+
+type mockCalendarPeriodService struct {
+	periods           []*schedule.CalendarPeriod
+	period            *schedule.CalendarPeriod
+	err               error
+	lastCreated       *schedule.CalendarPeriod
+	lastUpdated       *schedule.CalendarPeriod
+	lastDeletedID     int64
+	shouldMaterialize bool
+}
+
+func (m *mockCalendarPeriodService) GetAllPeriods(_ context.Context) ([]*schedule.CalendarPeriod, error) {
+	return m.periods, m.err
+}
+
+func (m *mockCalendarPeriodService) GetActivePeriods(_ context.Context) ([]*schedule.CalendarPeriod, error) {
+	return m.periods, m.err
+}
+
+func (m *mockCalendarPeriodService) GetPeriodByID(_ context.Context, _ int64) (*schedule.CalendarPeriod, error) {
+	return m.period, m.err
+}
+
+func (m *mockCalendarPeriodService) CreatePeriod(_ context.Context, p *schedule.CalendarPeriod) error {
+	m.lastCreated = p
+	if m.err != nil {
+		return m.err
+	}
+	p.ID = int64(100)
+	p.CreatedAt = time.Now()
+	p.UpdatedAt = time.Now()
+	return nil
+}
+
+func (m *mockCalendarPeriodService) UpdatePeriod(_ context.Context, p *schedule.CalendarPeriod) error {
+	m.lastUpdated = p
+	return m.err
+}
+
+func (m *mockCalendarPeriodService) DeletePeriod(_ context.Context, id int64) error {
+	m.lastDeletedID = id
+	return m.err
+}
+
+func (m *mockCalendarPeriodService) GetOrCreateDefaultPeriod(_ context.Context) (*schedule.CalendarPeriod, error) {
+	return m.period, m.err
+}
+
+func (m *mockCalendarPeriodService) ShouldMaterialize(_ int, _ time.Time, _ *schedule.CalendarPeriod) bool {
+	return m.shouldMaterialize
+}
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+func setupTestRouter(handler http.HandlerFunc, method string, hasID bool) chi.Router {
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	if hasID {
+		switch method {
+		case http.MethodGet:
+			r.Get("/{id}", handler)
+		case http.MethodPut:
+			r.Put("/{id}", handler)
+		case http.MethodDelete:
+			r.Delete("/{id}", handler)
+		}
+	} else {
+		switch method {
+		case http.MethodGet:
+			r.Get("/", handler)
+		case http.MethodPost:
+			r.Post("/", handler)
+		}
+	}
+	return r
+}
+
+func executeRequest(router chi.Router, method, path string, body interface{}) *httptest.ResponseRecorder {
+	var req *http.Request
+	if body != nil {
+		jsonBody, _ := json.Marshal(body)
+		req = httptest.NewRequest(method, path, bytes.NewReader(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func makePeriod(id int64, name string) *schedule.CalendarPeriod {
+	return &schedule.CalendarPeriod{
+		Name:            name,
+		PeriodType:      schedule.PeriodTypeSchoolYear,
+		StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+		WeekCycleLength: 1,
+		IsActive:        true,
+	}
+}
+
+func init() {
+	// makePeriod sets ID on the embedded Model
+	_ = makePeriod(0, "")
+}
+
+// =============================================================================
+// NewResource / Router Tests
+// =============================================================================
+
+func TestNewResource(t *testing.T) {
+	res := NewResource(nil, nil)
+	assert.NotNil(t, res)
+}
+
+func TestResource_Router(t *testing.T) {
+	mock := &mockCalendarPeriodService{}
+	res := NewResource(mock, nil)
+	router := res.Router()
+	assert.NotNil(t, router)
+}
+
+// =============================================================================
+// Bind Validation Tests
+// =============================================================================
+
+func TestCalendarPeriodRequest_Bind(t *testing.T) {
+	t.Run("valid request", func(t *testing.T) {
+		req := &CalendarPeriodRequest{
+			Name:       "Test Period",
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-07-31",
+		}
+		err := req.Bind(nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		req := &CalendarPeriodRequest{
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-07-31",
+		}
+		err := req.Bind(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name is required")
+	})
+
+	t.Run("missing period_type", func(t *testing.T) {
+		req := &CalendarPeriodRequest{
+			Name:      "Test",
+			StartDate: "2025-08-01",
+			EndDate:   "2026-07-31",
+		}
+		err := req.Bind(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "period_type is required")
+	})
+
+	t.Run("missing start_date", func(t *testing.T) {
+		req := &CalendarPeriodRequest{
+			Name:       "Test",
+			PeriodType: "school_year",
+			EndDate:    "2026-07-31",
+		}
+		err := req.Bind(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "start_date is required")
+	})
+
+	t.Run("missing end_date", func(t *testing.T) {
+		req := &CalendarPeriodRequest{
+			Name:       "Test",
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+		}
+		err := req.Bind(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "end_date is required")
+	})
+}
+
+// =============================================================================
+// mapPeriodToResponse Tests
+// =============================================================================
+
+func TestMapPeriodToResponse(t *testing.T) {
+	t.Run("maps period without anchor", func(t *testing.T) {
+		p := &schedule.CalendarPeriod{
+			Name:            "School Year 2025/2026",
+			PeriodType:      schedule.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		p.ID = int64(42)
+		p.CreatedAt = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		p.UpdatedAt = time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+
+		resp := mapPeriodToResponse(p)
+
+		assert.Equal(t, int64(42), resp.ID)
+		assert.Equal(t, "School Year 2025/2026", resp.Name)
+		assert.Equal(t, "school_year", resp.PeriodType)
+		assert.Equal(t, "2025-08-01", resp.StartDate)
+		assert.Equal(t, "2026-07-31", resp.EndDate)
+		assert.Equal(t, 1, resp.WeekCycleLength)
+		assert.Nil(t, resp.WeekCycleAnchor)
+		assert.True(t, resp.IsActive)
+		assert.NotEmpty(t, resp.CreatedAt)
+		assert.NotEmpty(t, resp.UpdatedAt)
+	})
+
+	t.Run("maps period with anchor", func(t *testing.T) {
+		anchor := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+		p := &schedule.CalendarPeriod{
+			Name:            "AB Week Period",
+			PeriodType:      schedule.PeriodTypeSemester,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 2,
+			WeekCycleAnchor: &anchor,
+			IsActive:        false,
+		}
+		p.ID = int64(43)
+		p.CreatedAt = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		p.UpdatedAt = time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+
+		resp := mapPeriodToResponse(p)
+
+		assert.Equal(t, int64(43), resp.ID)
+		assert.Equal(t, "semester", resp.PeriodType)
+		assert.Equal(t, 2, resp.WeekCycleLength)
+		require.NotNil(t, resp.WeekCycleAnchor)
+		assert.Equal(t, "2025-09-01", *resp.WeekCycleAnchor)
+		assert.False(t, resp.IsActive)
+	})
+}
+
+// =============================================================================
+// listPeriods Handler Tests
+// =============================================================================
+
+func TestListPeriods(t *testing.T) {
+	t.Run("returns periods list", func(t *testing.T) {
+		p1 := &schedule.CalendarPeriod{
+			Name:            "Period A",
+			PeriodType:      schedule.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		p1.ID = int64(10)
+		p1.CreatedAt = time.Now()
+		p1.UpdatedAt = time.Now()
+
+		mock := &mockCalendarPeriodService{periods: []*schedule.CalendarPeriod{p1}}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
+
+		w := executeRequest(router, http.MethodGet, "/", nil)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "Period A")
+	})
+
+	t.Run("returns empty list", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{periods: []*schedule.CalendarPeriod{}}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
+
+		w := executeRequest(router, http.MethodGet, "/", nil)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("returns 500 on service error", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{err: errors.New("db error")}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
+
+		w := executeRequest(router, http.MethodGet, "/", nil)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}
+
+// =============================================================================
+// getPeriod Handler Tests
+// =============================================================================
+
+func TestGetPeriod(t *testing.T) {
+	t.Run("returns period by ID", func(t *testing.T) {
+		p := &schedule.CalendarPeriod{
+			Name:            "Found Period",
+			PeriodType:      schedule.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		p.ID = int64(42)
+		p.CreatedAt = time.Now()
+		p.UpdatedAt = time.Now()
+
+		mock := &mockCalendarPeriodService{period: p}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
+
+		w := executeRequest(router, http.MethodGet, "/42", nil)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "Found Period")
+	})
+
+	t.Run("returns 400 for invalid ID", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
+
+		w := executeRequest(router, http.MethodGet, "/abc", nil)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 404 when not found", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{err: errors.New("not found")}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
+
+		w := executeRequest(router, http.MethodGet, "/999", nil)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
+// =============================================================================
+// createPeriod Handler Tests
+// =============================================================================
+
+func TestCreatePeriod(t *testing.T) {
+	t.Run("creates period successfully", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		body := CalendarPeriodRequest{
+			Name:            "New Period",
+			PeriodType:      "school_year",
+			StartDate:       "2025-08-01",
+			EndDate:         "2026-07-31",
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusCreated, w.Code)
+		assert.Contains(t, w.Body.String(), "New Period")
+		assert.NotNil(t, mock.lastCreated)
+		assert.Equal(t, "New Period", mock.lastCreated.Name)
+	})
+
+	t.Run("creates period with week cycle anchor", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		anchor := "2025-09-01"
+		body := CalendarPeriodRequest{
+			Name:            "AB Period",
+			PeriodType:      "school_year",
+			StartDate:       "2025-08-01",
+			EndDate:         "2026-07-31",
+			WeekCycleLength: 2,
+			WeekCycleAnchor: &anchor,
+			IsActive:        true,
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusCreated, w.Code)
+		require.NotNil(t, mock.lastCreated)
+		assert.NotNil(t, mock.lastCreated.WeekCycleAnchor)
+	})
+
+	t.Run("defaults week cycle length to 1", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		body := CalendarPeriodRequest{
+			Name:            "Default Cycle",
+			PeriodType:      "school_year",
+			StartDate:       "2025-08-01",
+			EndDate:         "2026-07-31",
+			WeekCycleLength: 0,
+			IsActive:        true,
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusCreated, w.Code)
+		require.NotNil(t, mock.lastCreated)
+		assert.Equal(t, 1, mock.lastCreated.WeekCycleLength)
+	})
+
+	t.Run("returns 400 for missing required fields", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		body := CalendarPeriodRequest{Name: "Only Name"}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 400 for invalid start_date format", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		body := CalendarPeriodRequest{
+			Name:       "Bad Start",
+			PeriodType: "school_year",
+			StartDate:  "not-a-date",
+			EndDate:    "2026-07-31",
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "start_date")
+	})
+
+	t.Run("returns 400 for invalid end_date format", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		body := CalendarPeriodRequest{
+			Name:       "Bad End",
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+			EndDate:    "not-a-date",
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "end_date")
+	})
+
+	t.Run("returns 400 for invalid week_cycle_anchor format", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		badAnchor := "not-a-date"
+		body := CalendarPeriodRequest{
+			Name:            "Bad Anchor",
+			PeriodType:      "school_year",
+			StartDate:       "2025-08-01",
+			EndDate:         "2026-07-31",
+			WeekCycleLength: 2,
+			WeekCycleAnchor: &badAnchor,
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "week_cycle_anchor")
+	})
+
+	t.Run("returns 500 on service error", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{err: errors.New("create failed")}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		body := CalendarPeriodRequest{
+			Name:       "Fail Create",
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-07-31",
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}
+
+// =============================================================================
+// updatePeriod Handler Tests
+// =============================================================================
+
+func TestUpdatePeriod(t *testing.T) {
+	existingPeriod := &schedule.CalendarPeriod{
+		Name:            "Existing Period",
+		PeriodType:      schedule.PeriodTypeSchoolYear,
+		StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+		WeekCycleLength: 1,
+		IsActive:        true,
+	}
+	existingPeriod.ID = int64(42)
+	existingPeriod.CreatedAt = time.Now()
+	existingPeriod.UpdatedAt = time.Now()
+
+	t.Run("updates period successfully", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{period: existingPeriod}
+		res := NewResource(mock, nil)
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
+
+		body := CalendarPeriodRequest{
+			Name:       "Updated Period",
+			PeriodType: "semester",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-01-31",
+			IsActive:   false,
+		}
+
+		w := executeRequest(r, http.MethodPut, "/42", body)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "Updated Period")
+	})
+
+	t.Run("updates period with anchor", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{period: existingPeriod}
+		res := NewResource(mock, nil)
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
+
+		anchor := "2025-09-01"
+		body := CalendarPeriodRequest{
+			Name:            "With Anchor",
+			PeriodType:      "school_year",
+			StartDate:       "2025-08-01",
+			EndDate:         "2026-07-31",
+			WeekCycleLength: 2,
+			WeekCycleAnchor: &anchor,
+			IsActive:        true,
+		}
+
+		w := executeRequest(r, http.MethodPut, "/42", body)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("clears anchor when not provided", func(t *testing.T) {
+		anchoredPeriod := &schedule.CalendarPeriod{
+			Name:            "Anchored",
+			PeriodType:      schedule.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		anchoredPeriod.ID = int64(42)
+		anchoredPeriod.CreatedAt = time.Now()
+		anchoredPeriod.UpdatedAt = time.Now()
+		anchorTime := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+		anchoredPeriod.WeekCycleAnchor = &anchorTime
+
+		mock := &mockCalendarPeriodService{period: anchoredPeriod}
+		res := NewResource(mock, nil)
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
+
+		body := CalendarPeriodRequest{
+			Name:       "No Anchor",
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-07-31",
+			IsActive:   true,
+		}
+
+		w := executeRequest(r, http.MethodPut, "/42", body)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		require.NotNil(t, mock.lastUpdated)
+		assert.Nil(t, mock.lastUpdated.WeekCycleAnchor)
+	})
+
+	t.Run("defaults week cycle length to 1", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{period: existingPeriod}
+		res := NewResource(mock, nil)
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
+
+		body := CalendarPeriodRequest{
+			Name:            "Zero Cycle",
+			PeriodType:      "school_year",
+			StartDate:       "2025-08-01",
+			EndDate:         "2026-07-31",
+			WeekCycleLength: 0,
+			IsActive:        true,
+		}
+
+		w := executeRequest(r, http.MethodPut, "/42", body)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		require.NotNil(t, mock.lastUpdated)
+		assert.Equal(t, 1, mock.lastUpdated.WeekCycleLength)
+	})
+
+	t.Run("returns 400 for invalid ID", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
+
+		w := executeRequest(r, http.MethodPut, "/abc", nil)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 404 when period not found", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{err: errors.New("not found")}
+		res := NewResource(mock, nil)
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
+
+		w := executeRequest(r, http.MethodPut, "/999", nil)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("returns 400 for invalid start_date in update", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{period: existingPeriod}
+		res := NewResource(mock, nil)
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
+
+		body := CalendarPeriodRequest{
+			Name:       "Bad Start",
+			PeriodType: "school_year",
+			StartDate:  "bad-date",
+			EndDate:    "2026-07-31",
+		}
+
+		w := executeRequest(r, http.MethodPut, "/42", body)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 400 for invalid end_date in update", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{period: existingPeriod}
+		res := NewResource(mock, nil)
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
+
+		body := CalendarPeriodRequest{
+			Name:       "Bad End",
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+			EndDate:    "bad-date",
+		}
+
+		w := executeRequest(r, http.MethodPut, "/42", body)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 400 for invalid anchor in update", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{period: existingPeriod}
+		res := NewResource(mock, nil)
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res.updatePeriod)
+
+		badAnchor := "bad-date"
+		body := CalendarPeriodRequest{
+			Name:            "Bad Anchor",
+			PeriodType:      "school_year",
+			StartDate:       "2025-08-01",
+			EndDate:         "2026-07-31",
+			WeekCycleLength: 2,
+			WeekCycleAnchor: &badAnchor,
+		}
+
+		w := executeRequest(r, http.MethodPut, "/42", body)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 500 on service update error", func(t *testing.T) {
+		// First call (GetPeriodByID) succeeds, second call (UpdatePeriod) fails
+		// We need a more sophisticated mock for this
+		callCount := 0
+		mock := &mockCalendarPeriodService{period: existingPeriod}
+		res := NewResource(mock, nil)
+
+		// Override the service to fail on update
+		updateErr := errors.New("update failed")
+		mock2 := &mockCalendarPeriodService{period: existingPeriod, err: updateErr}
+		// Use a wrapping approach: the handler calls GetPeriodByID first, then UpdatePeriod
+		// Since our mock returns the same error for all methods, we need to handle this differently
+		// Instead, test with a service that fails only on update
+		res2 := NewResource(&updateOnlyErrorService{
+			period:    existingPeriod,
+			updateErr: updateErr,
+		}, nil)
+
+		_ = mock
+		_ = res
+		_ = callCount
+		_ = mock2
+
+		r := chi.NewRouter()
+		r.Use(render.SetContentType(render.ContentTypeJSON))
+		r.Put("/{id}", res2.updatePeriod)
+
+		body := CalendarPeriodRequest{
+			Name:       "Will Fail",
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-07-31",
+		}
+
+		w := executeRequest(r, http.MethodPut, "/42", body)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}
+
+// updateOnlyErrorService fails only on UpdatePeriod
+type updateOnlyErrorService struct {
+	period    *schedule.CalendarPeriod
+	updateErr error
+}
+
+func (s *updateOnlyErrorService) GetAllPeriods(_ context.Context) ([]*schedule.CalendarPeriod, error) {
+	return nil, nil
+}
+func (s *updateOnlyErrorService) GetActivePeriods(_ context.Context) ([]*schedule.CalendarPeriod, error) {
+	return nil, nil
+}
+func (s *updateOnlyErrorService) GetPeriodByID(_ context.Context, _ int64) (*schedule.CalendarPeriod, error) {
+	return s.period, nil
+}
+func (s *updateOnlyErrorService) CreatePeriod(_ context.Context, _ *schedule.CalendarPeriod) error {
+	return nil
+}
+func (s *updateOnlyErrorService) UpdatePeriod(_ context.Context, _ *schedule.CalendarPeriod) error {
+	return s.updateErr
+}
+func (s *updateOnlyErrorService) DeletePeriod(_ context.Context, _ int64) error { return nil }
+func (s *updateOnlyErrorService) GetOrCreateDefaultPeriod(_ context.Context) (*schedule.CalendarPeriod, error) {
+	return nil, nil
+}
+func (s *updateOnlyErrorService) ShouldMaterialize(_ int, _ time.Time, _ *schedule.CalendarPeriod) bool {
+	return true
+}
+
+// =============================================================================
+// deletePeriod Handler Tests
+// =============================================================================
+
+func TestDeletePeriod(t *testing.T) {
+	t.Run("deletes period successfully", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
+
+		w := executeRequest(router, http.MethodDelete, "/42", nil)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, int64(42), mock.lastDeletedID)
+	})
+
+	t.Run("returns 400 for invalid ID", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
+
+		w := executeRequest(router, http.MethodDelete, "/abc", nil)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 500 on service error", func(t *testing.T) {
+		mock := &mockCalendarPeriodService{err: errors.New("delete failed")}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
+
+		w := executeRequest(router, http.MethodDelete, "/42", nil)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}

--- a/backend/api/timetable/api_test.go
+++ b/backend/api/timetable/api_test.go
@@ -81,6 +81,17 @@ func (m *mockCalendarPeriodService) ShouldMaterialize(_ int, _ time.Time, _ *sch
 	return m.shouldMaterialize
 }
 
+// scheduleSvcErr is a minimal stand-in for services/schedule.ScheduleError.
+// It lets the test verify errors.Is traverses a wrapping layer without pulling
+// the services package into the handler test.
+type scheduleSvcErr struct {
+	op    string
+	inner error
+}
+
+func (e *scheduleSvcErr) Error() string { return e.op + ": " + e.inner.Error() }
+func (e *scheduleSvcErr) Unwrap() error { return e.inner }
+
 // =============================================================================
 // Helper functions
 // =============================================================================
@@ -617,7 +628,7 @@ func TestCreatePeriod(t *testing.T) {
 	})
 
 	t.Run("returns 409 for duplicate name", func(t *testing.T) {
-		mock := &mockCalendarPeriodService{err: errors.New("a period with this name already exists")}
+		mock := &mockCalendarPeriodService{err: schedule.ErrCalendarPeriodNameConflict}
 		res := NewResource(mock, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
@@ -632,6 +643,26 @@ func TestCreatePeriod(t *testing.T) {
 
 		assert.Equal(t, http.StatusConflict, w.Code)
 		assert.Contains(t, w.Body.String(), "already exists")
+	})
+
+	t.Run("returns 409 when service wraps the sentinel", func(t *testing.T) {
+		// Services wrap the sentinel in ScheduleError — errors.Is must still match.
+		mock := &mockCalendarPeriodService{
+			err: &scheduleSvcErr{op: "create calendar period", inner: schedule.ErrCalendarPeriodNameConflict},
+		}
+		res := NewResource(mock, nil)
+		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
+
+		body := CalendarPeriodRequest{
+			Name:       "Duplicate",
+			PeriodType: "school_year",
+			StartDate:  "2025-08-01",
+			EndDate:    "2026-07-31",
+		}
+
+		w := executeRequest(router, http.MethodPost, "/", body)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
 	})
 
 	t.Run("returns 500 on service error", func(t *testing.T) {
@@ -892,7 +923,7 @@ func TestUpdatePeriod(t *testing.T) {
 	t.Run("returns 409 for duplicate name on update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{
 			period:    existingPeriod,
-			updateErr: errors.New("a period with this name already exists"),
+			updateErr: schedule.ErrCalendarPeriodNameConflict,
 		}
 		res := NewResource(mock, nil)
 

--- a/backend/database/migrations/001015033_create_calendar_periods.go
+++ b/backend/database/migrations/001015033_create_calendar_periods.go
@@ -91,20 +91,8 @@ func createCalendarPeriodsUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("failed to create RLS policy on calendar_periods: %w", err)
 	}
 
-	// Grant permissions to phoenix_app role
-	_, err = db.NewRaw(`
-		GRANT SELECT, INSERT, UPDATE, DELETE ON schedule.calendar_periods TO phoenix_app;
-	`).Exec(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to grant permissions on calendar_periods: %w", err)
-	}
-
-	_, err = db.NewRaw(`
-		GRANT USAGE, SELECT ON SEQUENCE schedule.calendar_periods_id_seq TO phoenix_app;
-	`).Exec(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to grant sequence permissions: %w", err)
-	}
+	// Grants are handled automatically via ALTER DEFAULT PRIVILEGES in migration 1.14.1
+	// (phoenix_tenant gets SELECT/INSERT/UPDATE/DELETE on all tables in the schedule schema)
 
 	return nil
 }

--- a/backend/database/migrations/001015033_create_calendar_periods.go
+++ b/backend/database/migrations/001015033_create_calendar_periods.go
@@ -1,0 +1,121 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	createCalendarPeriodsVersion     = "1.15.33"
+	createCalendarPeriodsDescription = "Create calendar periods table for timetable system"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     createCalendarPeriodsVersion,
+		Description: createCalendarPeriodsDescription,
+		DependsOn: []string{
+			enableRLSVersion, // Depends on RLS infrastructure (1.15.1)
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return createCalendarPeriodsUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return createCalendarPeriodsDown(ctx, db)
+		},
+	)
+}
+
+func createCalendarPeriodsUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.33: Creating calendar periods table...")
+
+	_, err := db.NewRaw(`
+		CREATE TABLE IF NOT EXISTS schedule.calendar_periods (
+			id BIGSERIAL PRIMARY KEY,
+			tenant_id BIGINT NOT NULL REFERENCES platform.schools(id),
+			name VARCHAR(255) NOT NULL,
+			period_type TEXT NOT NULL CHECK (period_type IN ('school_year', 'semester', 'holiday', 'custom')),
+			start_date DATE NOT NULL,
+			end_date DATE NOT NULL,
+			week_cycle_length SMALLINT NOT NULL DEFAULT 1,
+			week_cycle_anchor DATE,
+			is_active BOOLEAN NOT NULL DEFAULT false,
+			created_at TIMESTAMPTZ DEFAULT NOW(),
+			updated_at TIMESTAMPTZ DEFAULT NOW(),
+			CONSTRAINT unique_calendar_period_name UNIQUE (tenant_id, name),
+			CONSTRAINT check_calendar_period_dates CHECK (start_date < end_date),
+			CONSTRAINT check_week_cycle_length CHECK (week_cycle_length >= 1)
+		);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating calendar_periods table: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		CREATE INDEX IF NOT EXISTS idx_calendar_periods_tenant_id
+		ON schedule.calendar_periods(tenant_id);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating index on tenant_id: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		CREATE INDEX IF NOT EXISTS idx_calendar_periods_active
+		ON schedule.calendar_periods(tenant_id, is_active) WHERE is_active = true;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating partial index on is_active: %w", err)
+	}
+
+	// Enable RLS
+	_, err = db.NewRaw(`ALTER TABLE schedule.calendar_periods ENABLE ROW LEVEL SECURITY`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to enable RLS on calendar_periods: %w", err)
+	}
+	_, err = db.NewRaw(`ALTER TABLE schedule.calendar_periods FORCE ROW LEVEL SECURITY`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to force RLS on calendar_periods: %w", err)
+	}
+	_, err = db.NewRaw(`
+		CREATE POLICY tenant_isolation_schedule_calendar_periods
+		ON schedule.calendar_periods FOR ALL
+		USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+		WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create RLS policy on calendar_periods: %w", err)
+	}
+
+	// Grant permissions to phoenix_app role
+	_, err = db.NewRaw(`
+		GRANT SELECT, INSERT, UPDATE, DELETE ON schedule.calendar_periods TO phoenix_app;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to grant permissions on calendar_periods: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		GRANT USAGE, SELECT ON SEQUENCE schedule.calendar_periods_id_seq TO phoenix_app;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to grant sequence permissions: %w", err)
+	}
+
+	return nil
+}
+
+func createCalendarPeriodsDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.33: Dropping calendar periods table...")
+
+	_, err := db.NewRaw(`DROP TABLE IF EXISTS schedule.calendar_periods CASCADE;`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed dropping calendar_periods table: %w", err)
+	}
+
+	return nil
+}

--- a/backend/database/migrations/001015034_template_extensions.go
+++ b/backend/database/migrations/001015034_template_extensions.go
@@ -1,0 +1,220 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	templateExtensionsVersion     = "1.15.34"
+	templateExtensionsDescription = "Add template extension columns to activities tables for timetable system"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     templateExtensionsVersion,
+		Description: templateExtensionsDescription,
+		DependsOn: []string{
+			ActivitiesGroupsVersion,             // 1.3.2
+			ActivitiesSchedulesVersion,          // 1.3.3
+			ActivitySupervisorsVersion,          // 1.3.4
+			ActivitiesStudentEnrollmentsVersion, // 1.3.8
+			createCalendarPeriodsVersion,        // 1.15.33
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return templateExtensionsUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return templateExtensionsDown(ctx, db)
+		},
+	)
+}
+
+func templateExtensionsUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.34: Adding template extension columns to activities tables...")
+
+	// 1. activities.groups — add type, education_group_id, is_template
+	_, err := db.NewRaw(`
+		ALTER TABLE activities.groups
+			ADD COLUMN IF NOT EXISTS type TEXT NOT NULL DEFAULT 'activity',
+			ADD COLUMN IF NOT EXISTS education_group_id BIGINT REFERENCES education.groups(id),
+			ADD COLUMN IF NOT EXISTS is_template BOOLEAN NOT NULL DEFAULT true;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed adding columns to activities.groups: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		ALTER TABLE activities.groups
+			ADD CONSTRAINT check_group_type CHECK (type IN ('activity', 'care', 'external'));
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed adding type check constraint to activities.groups: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		CREATE INDEX IF NOT EXISTS idx_activities_groups_type
+		ON activities.groups(type);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating index on activities.groups.type: %w", err)
+	}
+
+	// 2. activities.schedules — add week_pattern, calendar_period_id
+	_, err = db.NewRaw(`
+		ALTER TABLE activities.schedules
+			ADD COLUMN IF NOT EXISTS week_pattern SMALLINT NOT NULL DEFAULT 0,
+			ADD COLUMN IF NOT EXISTS calendar_period_id BIGINT REFERENCES schedule.calendar_periods(id);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed adding columns to activities.schedules: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		ALTER TABLE activities.schedules
+			ADD CONSTRAINT check_week_pattern CHECK (week_pattern >= 0);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed adding week_pattern check constraint: %w", err)
+	}
+
+	// 3. activities.student_enrollments — rename enrollment_date to valid_from, add valid_until, calendar_period_id
+	_, err = db.NewRaw(`
+		ALTER TABLE activities.student_enrollments
+			RENAME COLUMN enrollment_date TO valid_from;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed renaming enrollment_date to valid_from: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		ALTER TABLE activities.student_enrollments
+			ADD COLUMN IF NOT EXISTS valid_until DATE,
+			ADD COLUMN IF NOT EXISTS calendar_period_id BIGINT REFERENCES schedule.calendar_periods(id);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed adding columns to activities.student_enrollments: %w", err)
+	}
+
+	// Drop old unique index and create partial unique index
+	_, err = db.NewRaw(`
+		DROP INDEX IF EXISTS activities.idx_student_enrollments_tenant;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed dropping old enrollment unique index: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		CREATE UNIQUE INDEX idx_student_enrollments_active
+		ON activities.student_enrollments (tenant_id, student_id, activity_group_id)
+		WHERE valid_until IS NULL;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating partial unique index on student_enrollments: %w", err)
+	}
+
+	// Rename the old enrollment_date index
+	_, err = db.NewRaw(`
+		ALTER INDEX IF EXISTS activities.idx_student_enrollments_date RENAME TO idx_student_enrollments_valid_from;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed renaming enrollment_date index: %w", err)
+	}
+
+	// 4. activities.supervisors — add valid_from, valid_until, calendar_period_id
+	_, err = db.NewRaw(`
+		ALTER TABLE activities.supervisors
+			ADD COLUMN IF NOT EXISTS valid_from DATE NOT NULL DEFAULT CURRENT_DATE,
+			ADD COLUMN IF NOT EXISTS valid_until DATE,
+			ADD COLUMN IF NOT EXISTS calendar_period_id BIGINT REFERENCES schedule.calendar_periods(id);
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed adding columns to activities.supervisors: %w", err)
+	}
+
+	// Drop old unique index and create partial unique index
+	_, err = db.NewRaw(`
+		DROP INDEX IF EXISTS activities.idx_supervisors_planned_tenant;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed dropping old supervisor unique index: %w", err)
+	}
+
+	_, err = db.NewRaw(`
+		CREATE UNIQUE INDEX idx_supervisors_active
+		ON activities.supervisors (tenant_id, staff_id, group_id)
+		WHERE valid_until IS NULL;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating partial unique index on supervisors: %w", err)
+	}
+
+	return nil
+}
+
+func templateExtensionsDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.34: Removing template extension columns...")
+
+	// Reverse supervisors changes
+	_, _ = db.NewRaw(`DROP INDEX IF EXISTS activities.idx_supervisors_active;`).Exec(ctx)
+	_, _ = db.NewRaw(`
+		CREATE UNIQUE INDEX idx_supervisors_planned_tenant
+		ON activities.supervisors (tenant_id, staff_id, group_id);
+	`).Exec(ctx)
+	_, _ = db.NewRaw(`
+		ALTER TABLE activities.supervisors
+			DROP COLUMN IF EXISTS calendar_period_id,
+			DROP COLUMN IF EXISTS valid_until,
+			DROP COLUMN IF EXISTS valid_from;
+	`).Exec(ctx)
+
+	// Reverse student_enrollments changes
+	_, _ = db.NewRaw(`DROP INDEX IF EXISTS activities.idx_student_enrollments_active;`).Exec(ctx)
+	_, _ = db.NewRaw(`
+		ALTER INDEX IF EXISTS activities.idx_student_enrollments_valid_from RENAME TO idx_student_enrollments_date;
+	`).Exec(ctx)
+	_, _ = db.NewRaw(`
+		CREATE UNIQUE INDEX idx_student_enrollments_tenant
+		ON activities.student_enrollments (tenant_id, student_id, activity_group_id);
+	`).Exec(ctx)
+	_, _ = db.NewRaw(`
+		ALTER TABLE activities.student_enrollments
+			DROP COLUMN IF EXISTS calendar_period_id,
+			DROP COLUMN IF EXISTS valid_until;
+	`).Exec(ctx)
+	_, _ = db.NewRaw(`
+		ALTER TABLE activities.student_enrollments
+			RENAME COLUMN valid_from TO enrollment_date;
+	`).Exec(ctx)
+
+	// Reverse schedules changes
+	_, _ = db.NewRaw(`
+		ALTER TABLE activities.schedules
+			DROP CONSTRAINT IF EXISTS check_week_pattern;
+	`).Exec(ctx)
+	_, _ = db.NewRaw(`
+		ALTER TABLE activities.schedules
+			DROP COLUMN IF EXISTS calendar_period_id,
+			DROP COLUMN IF EXISTS week_pattern;
+	`).Exec(ctx)
+
+	// Reverse groups changes
+	_, _ = db.NewRaw(`DROP INDEX IF EXISTS activities.idx_activities_groups_type;`).Exec(ctx)
+	_, _ = db.NewRaw(`
+		ALTER TABLE activities.groups
+			DROP CONSTRAINT IF EXISTS check_group_type;
+	`).Exec(ctx)
+	_, _ = db.NewRaw(`
+		ALTER TABLE activities.groups
+			DROP COLUMN IF EXISTS is_template,
+			DROP COLUMN IF EXISTS education_group_id,
+			DROP COLUMN IF EXISTS type;
+	`).Exec(ctx)
+
+	return nil
+}

--- a/backend/database/migrations/001015034_template_extensions.go
+++ b/backend/database/migrations/001015034_template_extensions.go
@@ -43,7 +43,7 @@ func templateExtensionsUp(ctx context.Context, db *bun.DB) error {
 		ALTER TABLE activities.groups
 			ADD COLUMN IF NOT EXISTS type TEXT NOT NULL DEFAULT 'activity',
 			ADD COLUMN IF NOT EXISTS education_group_id BIGINT REFERENCES education.groups(id),
-			ADD COLUMN IF NOT EXISTS is_template BOOLEAN NOT NULL DEFAULT true;
+			ADD COLUMN IF NOT EXISTS is_template BOOLEAN NOT NULL DEFAULT false;
 	`).Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed adding columns to activities.groups: %w", err)

--- a/backend/database/migrations/001015034_template_extensions.go
+++ b/backend/database/migrations/001015034_template_extensions.go
@@ -65,11 +65,13 @@ func templateExtensionsUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("failed creating index on activities.groups.type: %w", err)
 	}
 
-	// 2. activities.schedules — add week_pattern, calendar_period_id
+	// 2. activities.schedules — add week_pattern, calendar_period_id.
+	// ON DELETE SET NULL: deleting a calendar period clears references
+	// instead of blocking the delete with a FK violation.
 	_, err = db.NewRaw(`
 		ALTER TABLE activities.schedules
 			ADD COLUMN IF NOT EXISTS week_pattern SMALLINT NOT NULL DEFAULT 0,
-			ADD COLUMN IF NOT EXISTS calendar_period_id BIGINT REFERENCES schedule.calendar_periods(id);
+			ADD COLUMN IF NOT EXISTS calendar_period_id BIGINT REFERENCES schedule.calendar_periods(id) ON DELETE SET NULL;
 	`).Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed adding columns to activities.schedules: %w", err)
@@ -95,7 +97,7 @@ func templateExtensionsUp(ctx context.Context, db *bun.DB) error {
 	_, err = db.NewRaw(`
 		ALTER TABLE activities.student_enrollments
 			ADD COLUMN IF NOT EXISTS valid_until DATE,
-			ADD COLUMN IF NOT EXISTS calendar_period_id BIGINT REFERENCES schedule.calendar_periods(id);
+			ADD COLUMN IF NOT EXISTS calendar_period_id BIGINT REFERENCES schedule.calendar_periods(id) ON DELETE SET NULL;
 	`).Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed adding columns to activities.student_enrollments: %w", err)
@@ -131,7 +133,7 @@ func templateExtensionsUp(ctx context.Context, db *bun.DB) error {
 		ALTER TABLE activities.supervisors
 			ADD COLUMN IF NOT EXISTS valid_from DATE NOT NULL DEFAULT CURRENT_DATE,
 			ADD COLUMN IF NOT EXISTS valid_until DATE,
-			ADD COLUMN IF NOT EXISTS calendar_period_id BIGINT REFERENCES schedule.calendar_periods(id);
+			ADD COLUMN IF NOT EXISTS calendar_period_id BIGINT REFERENCES schedule.calendar_periods(id) ON DELETE SET NULL;
 	`).Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed adding columns to activities.supervisors: %w", err)

--- a/backend/database/repositories/activities/group_repository_test.go
+++ b/backend/database/repositories/activities/group_repository_test.go
@@ -277,7 +277,7 @@ func TestActivityGroupRepository_FindWithEnrollmentCounts(t *testing.T) {
 		enrollment1 := &activities.StudentEnrollment{
 			StudentID:       student1.ID,
 			ActivityGroupID: group.ID,
-			EnrollmentDate:  time.Now(),
+			ValidFrom:       time.Now(),
 		}
 		enrollment1.SetTenantID(1)
 		_, _ = db.NewInsert().
@@ -288,7 +288,7 @@ func TestActivityGroupRepository_FindWithEnrollmentCounts(t *testing.T) {
 		enrollment2 := &activities.StudentEnrollment{
 			StudentID:       student2.ID,
 			ActivityGroupID: group.ID,
-			EnrollmentDate:  time.Now(),
+			ValidFrom:       time.Now(),
 		}
 		enrollment2.SetTenantID(1)
 		_, _ = db.NewInsert().

--- a/backend/database/repositories/activities/student_enrollment.go
+++ b/backend/database/repositories/activities/student_enrollment.go
@@ -51,7 +51,7 @@ func (r *StudentEnrollmentRepository) FindByStudentID(ctx context.Context, stude
 	}
 
 	err := query.
-		Order("enrollment_date DESC").
+		Order("valid_from DESC").
 		Scan(ctx)
 
 	if err != nil {
@@ -85,7 +85,9 @@ func (r *StudentEnrollmentRepository) FindByGroupID(ctx context.Context, groupID
 		ColumnExpr(`"student_enrollment".tenant_id AS "student_enrollment__tenant_id"`).
 		ColumnExpr(`"student_enrollment".student_id AS "student_enrollment__student_id"`).
 		ColumnExpr(`"student_enrollment".activity_group_id AS "student_enrollment__activity_group_id"`).
-		ColumnExpr(`"student_enrollment".enrollment_date AS "student_enrollment__enrollment_date"`).
+		ColumnExpr(`"student_enrollment".valid_from AS "student_enrollment__valid_from"`).
+		ColumnExpr(`"student_enrollment".valid_until AS "student_enrollment__valid_until"`).
+		ColumnExpr(`"student_enrollment".calendar_period_id AS "student_enrollment__calendar_period_id"`).
 		ColumnExpr(`"student_enrollment".attendance_status AS "student_enrollment__attendance_status"`).
 		ColumnExpr(`"student".id AS "student__id"`).
 		ColumnExpr(`"student".created_at AS "student__created_at"`).
@@ -115,7 +117,7 @@ func (r *StudentEnrollmentRepository) FindByGroupID(ctx context.Context, groupID
 	}
 
 	err := query.
-		Order("student_enrollment.enrollment_date DESC").
+		Order("student_enrollment.valid_from DESC").
 		Scan(ctx)
 
 	if err != nil {
@@ -161,27 +163,25 @@ func (r *StudentEnrollmentRepository) CountByGroupID(ctx context.Context, groupI
 	return count, nil
 }
 
-// FindByEnrollmentDateRange finds enrollments within a date range
-func (r *StudentEnrollmentRepository) FindByEnrollmentDateRange(ctx context.Context, start, end time.Time) ([]*activities.StudentEnrollment, error) {
+// FindByValidFromRange finds enrollments within a valid_from date range
+func (r *StudentEnrollmentRepository) FindByValidFromRange(ctx context.Context, start, end time.Time) ([]*activities.StudentEnrollment, error) {
 	enrollments := make([]*activities.StudentEnrollment, 0)
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&enrollments).
 		ModelTableExpr(tableExprActivitiesEnrollmentsAsEnrollment).
-		// Note: Relation() doesn't work with multi-schema tables
-		// The caller should load Student, Student.Person, and ActivityGroup separately if needed
-		Where("enrollment_date >= ? AND enrollment_date <= ?", start, end)
+		Where("valid_from >= ? AND valid_from <= ?", start, end)
 
 	if where, val, ok := base.TenantWhere(ctx, "student_enrollment"); ok {
 		query = query.Where(where, val)
 	}
 
 	err := query.
-		Order("enrollment_date DESC").
+		Order("valid_from DESC").
 		Scan(ctx)
 
 	if err != nil {
 		return nil, &modelBase.DatabaseError{
-			Op:  "find by enrollment date range",
+			Op:  "find by valid_from date range",
 			Err: err,
 		}
 	}

--- a/backend/database/repositories/activities/student_enrollment_repository_test.go
+++ b/backend/database/repositories/activities/student_enrollment_repository_test.go
@@ -25,7 +25,7 @@ func createEnrollment(t *testing.T, db *bun.DB, studentID, groupID int64, enroll
 	enrollment := &activities.StudentEnrollment{
 		StudentID:        studentID,
 		ActivityGroupID:  groupID,
-		EnrollmentDate:   enrollmentDate,
+		ValidFrom:        enrollmentDate,
 		AttendanceStatus: status,
 	}
 	enrollment.SetTenantID(1)
@@ -59,7 +59,7 @@ func TestStudentEnrollmentRepository_Create(t *testing.T) {
 		enrollment := &activities.StudentEnrollment{
 			StudentID:       student.ID,
 			ActivityGroupID: group.ID,
-			EnrollmentDate:  time.Now(),
+			ValidFrom:       time.Now(),
 		}
 
 		err := repo.Create(ctx, enrollment)
@@ -79,7 +79,7 @@ func TestStudentEnrollmentRepository_Create(t *testing.T) {
 		enrollment := &activities.StudentEnrollment{
 			StudentID:        student.ID,
 			ActivityGroupID:  group.ID,
-			EnrollmentDate:   time.Now(),
+			ValidFrom:        time.Now(),
 			AttendanceStatus: &status,
 		}
 
@@ -373,7 +373,7 @@ func TestStudentEnrollmentRepository_CountByGroupID(t *testing.T) {
 	})
 }
 
-func TestStudentEnrollmentRepository_FindByEnrollmentDateRange(t *testing.T) {
+func TestStudentEnrollmentRepository_FindByValidFromRange(t *testing.T) {
 
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
@@ -406,7 +406,7 @@ func TestStudentEnrollmentRepository_FindByEnrollmentDateRange(t *testing.T) {
 		start := now.Add(-60 * time.Hour)
 		end := now
 
-		enrollments, err := repo.FindByEnrollmentDateRange(ctx, start, end)
+		enrollments, err := repo.FindByValidFromRange(ctx, start, end)
 		require.NoError(t, err)
 		assert.NotEmpty(t, enrollments)
 
@@ -427,7 +427,7 @@ func TestStudentEnrollmentRepository_FindByEnrollmentDateRange(t *testing.T) {
 		futureStart := time.Now().Add(365 * 24 * time.Hour)
 		futureEnd := futureStart.Add(24 * time.Hour)
 
-		enrollments, err := repo.FindByEnrollmentDateRange(ctx, futureStart, futureEnd)
+		enrollments, err := repo.FindByValidFromRange(ctx, futureStart, futureEnd)
 		require.NoError(t, err)
 		assert.Empty(t, enrollments)
 	})

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -82,6 +82,7 @@ type Factory struct {
 	StudentArrivalSchedule  scheduleModels.StudentArrivalScheduleRepository
 	StudentArrivalException scheduleModels.StudentArrivalExceptionRepository
 	StudentArrivalNote      scheduleModels.StudentArrivalNoteRepository
+	CalendarPeriod          scheduleModels.CalendarPeriodRepository
 
 	// Activities domain
 	ActivityGroup      activitiesModels.GroupRepository
@@ -188,6 +189,7 @@ func NewFactory(db *bun.DB) *Factory {
 		StudentArrivalSchedule:  schedule.NewStudentArrivalScheduleRepository(db),
 		StudentArrivalException: schedule.NewStudentArrivalExceptionRepository(db),
 		StudentArrivalNote:      schedule.NewStudentArrivalNoteRepository(db),
+		CalendarPeriod:          schedule.NewCalendarPeriodRepository(db),
 
 		// Activities repositories
 		ActivityGroup:      activities.NewGroupRepository(db),

--- a/backend/database/repositories/schedule/calendar_period_repo.go
+++ b/backend/database/repositories/schedule/calendar_period_repo.go
@@ -129,27 +129,19 @@ func (r *CalendarPeriodRepository) FindByID(ctx context.Context, id any) (*sched
 	return &period, nil
 }
 
-// Create overrides the base Create method to handle validation
+// Create overrides the base Create method with nil guard
 func (r *CalendarPeriodRepository) Create(ctx context.Context, p *schedule.CalendarPeriod) error {
 	if p == nil {
 		return errCalendarPeriodNil
 	}
 
-	if err := p.Validate(); err != nil {
-		return err
-	}
-
 	return r.Repository.Create(ctx, p)
 }
 
-// Update overrides the base Update method to handle validation
+// Update overrides the base Update method with nil guard
 func (r *CalendarPeriodRepository) Update(ctx context.Context, p *schedule.CalendarPeriod) error {
 	if p == nil {
 		return errCalendarPeriodNil
-	}
-
-	if err := p.Validate(); err != nil {
-		return err
 	}
 
 	return r.Repository.Update(ctx, p)

--- a/backend/database/repositories/schedule/calendar_period_repo.go
+++ b/backend/database/repositories/schedule/calendar_period_repo.go
@@ -1,0 +1,182 @@
+package schedule
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/uptrace/bun"
+)
+
+const tableCalendarPeriods = "schedule.calendar_periods"
+
+var errCalendarPeriodNil = fmt.Errorf("calendar period cannot be nil")
+
+// CalendarPeriodRepository implements schedule.CalendarPeriodRepository
+type CalendarPeriodRepository struct {
+	*base.Repository[*schedule.CalendarPeriod]
+	db *bun.DB
+}
+
+// NewCalendarPeriodRepository creates a new CalendarPeriodRepository
+func NewCalendarPeriodRepository(db *bun.DB) schedule.CalendarPeriodRepository {
+	repo := base.NewRepository[*schedule.CalendarPeriod](db, tableCalendarPeriods, "CalendarPeriod")
+	repo.TenantScoped = true
+	return &CalendarPeriodRepository{
+		Repository: repo,
+		db:         db,
+	}
+}
+
+// FindByTenantID finds all calendar periods for the current tenant
+func (r *CalendarPeriodRepository) FindByTenantID(ctx context.Context) ([]*schedule.CalendarPeriod, error) {
+	var periods []*schedule.CalendarPeriod
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&periods).
+		ModelTableExpr(`schedule.calendar_periods AS "calendar_period"`).
+		Order("start_date ASC")
+
+	if where, val, ok := base.TenantWhere(ctx, "calendar_period"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by tenant id",
+			Err: err,
+		}
+	}
+
+	return periods, nil
+}
+
+// FindActiveByTenantID finds all active calendar periods for the current tenant
+func (r *CalendarPeriodRepository) FindActiveByTenantID(ctx context.Context) ([]*schedule.CalendarPeriod, error) {
+	var periods []*schedule.CalendarPeriod
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&periods).
+		ModelTableExpr(`schedule.calendar_periods AS "calendar_period"`).
+		Where(`"calendar_period".is_active = ?`, true).
+		Order("start_date ASC")
+
+	if where, val, ok := base.TenantWhere(ctx, "calendar_period"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find active by tenant id",
+			Err: err,
+		}
+	}
+
+	return periods, nil
+}
+
+// FindByName finds a calendar period by name within the current tenant
+func (r *CalendarPeriodRepository) FindByName(ctx context.Context, name string) (*schedule.CalendarPeriod, error) {
+	var period schedule.CalendarPeriod
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&period).
+		ModelTableExpr(`schedule.calendar_periods AS "calendar_period"`).
+		Where(`"calendar_period".name = ?`, name)
+
+	if where, val, ok := base.TenantWhere(ctx, "calendar_period"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by name",
+			Err: err,
+		}
+	}
+
+	return &period, nil
+}
+
+// FindByID overrides base method to ensure schema qualification
+func (r *CalendarPeriodRepository) FindByID(ctx context.Context, id any) (*schedule.CalendarPeriod, error) {
+	var period schedule.CalendarPeriod
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&period).
+		ModelTableExpr(`schedule.calendar_periods AS "calendar_period"`).
+		Where(`"calendar_period".id = ?`, id)
+
+	if where, val, ok := base.TenantWhere(ctx, "calendar_period"); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  opFindByID,
+			Err: err,
+		}
+	}
+
+	return &period, nil
+}
+
+// Create overrides the base Create method to handle validation
+func (r *CalendarPeriodRepository) Create(ctx context.Context, p *schedule.CalendarPeriod) error {
+	if p == nil {
+		return errCalendarPeriodNil
+	}
+
+	if err := p.Validate(); err != nil {
+		return err
+	}
+
+	return r.Repository.Create(ctx, p)
+}
+
+// Update overrides the base Update method to handle validation
+func (r *CalendarPeriodRepository) Update(ctx context.Context, p *schedule.CalendarPeriod) error {
+	if p == nil {
+		return errCalendarPeriodNil
+	}
+
+	if err := p.Validate(); err != nil {
+		return err
+	}
+
+	return r.Repository.Update(ctx, p)
+}
+
+// List retrieves calendar periods matching the provided query options
+func (r *CalendarPeriodRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.CalendarPeriod, error) {
+	var periods []*schedule.CalendarPeriod
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&periods).
+		ModelTableExpr(`schedule.calendar_periods AS "calendar_period"`)
+
+	if where, val, ok := base.TenantWhere(ctx, "calendar_period"); ok {
+		query = query.Where(where, val)
+	}
+
+	if options != nil {
+		query = options.ApplyToQuery(query)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list",
+			Err: err,
+		}
+	}
+
+	return periods, nil
+}

--- a/backend/database/repositories/schedule/calendar_period_repo_test.go
+++ b/backend/database/repositories/schedule/calendar_period_repo_test.go
@@ -1,0 +1,387 @@
+package schedule_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// CalendarPeriodRepository Tests
+// =============================================================================
+
+func createTestCalendarPeriod(t *testing.T, repo scheduleModels.CalendarPeriodRepository, name string) *scheduleModels.CalendarPeriod {
+	t.Helper()
+	ctx := testpkg.TenantContext(1)
+
+	period := &scheduleModels.CalendarPeriod{
+		Name:            name,
+		PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+		StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+		WeekCycleLength: 1,
+		IsActive:        true,
+	}
+	period.SetTenantID(1)
+
+	err := repo.Create(ctx, period)
+	require.NoError(t, err)
+	require.Greater(t, period.ID, int64(0))
+	return period
+}
+
+func TestCalendarPeriodRepository_Create(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewCalendarPeriodRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates period successfully", func(t *testing.T) {
+		name := fmt.Sprintf("Test-Create-%d", time.Now().UnixNano())
+		period := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		period.SetTenantID(1)
+
+		err := repo.Create(ctx, period)
+
+		require.NoError(t, err)
+		assert.Greater(t, period.ID, int64(0))
+		assert.False(t, period.CreatedAt.IsZero())
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+	})
+
+	t.Run("creates period with week cycle anchor", func(t *testing.T) {
+		name := fmt.Sprintf("Test-Anchor-%d", time.Now().UnixNano())
+		anchor := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+		period := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 2,
+			WeekCycleAnchor: &anchor,
+			IsActive:        true,
+		}
+		period.SetTenantID(1)
+
+		err := repo.Create(ctx, period)
+
+		require.NoError(t, err)
+		assert.Greater(t, period.ID, int64(0))
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+	})
+
+	t.Run("fails on nil period", func(t *testing.T) {
+		err := repo.Create(ctx, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+
+	t.Run("fails validation on missing name", func(t *testing.T) {
+		period := &scheduleModels.CalendarPeriod{
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+		}
+		period.SetTenantID(1)
+
+		err := repo.Create(ctx, period)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name is required")
+	})
+
+	t.Run("fails validation on invalid period type", func(t *testing.T) {
+		period := &scheduleModels.CalendarPeriod{
+			Name:            fmt.Sprintf("Test-InvalidType-%d", time.Now().UnixNano()),
+			PeriodType:      "invalid_type",
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+		}
+		period.SetTenantID(1)
+
+		err := repo.Create(ctx, period)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid period type")
+	})
+
+	t.Run("fails validation on end date before start date", func(t *testing.T) {
+		period := &scheduleModels.CalendarPeriod{
+			Name:            fmt.Sprintf("Test-BadDates-%d", time.Now().UnixNano()),
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2025, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+		}
+		period.SetTenantID(1)
+
+		err := repo.Create(ctx, period)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "end_date must be after start_date")
+	})
+
+	t.Run("fails validation on week cycle without anchor", func(t *testing.T) {
+		period := &scheduleModels.CalendarPeriod{
+			Name:            fmt.Sprintf("Test-NoAnchor-%d", time.Now().UnixNano()),
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 2,
+		}
+		period.SetTenantID(1)
+
+		err := repo.Create(ctx, period)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "week_cycle_anchor is required")
+	})
+}
+
+func TestCalendarPeriodRepository_FindByID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewCalendarPeriodRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds period by ID", func(t *testing.T) {
+		name := fmt.Sprintf("Test-FindByID-%d", time.Now().UnixNano())
+		created := createTestCalendarPeriod(t, repo, name)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", created.ID)
+
+		found, err := repo.FindByID(ctx, created.ID)
+
+		require.NoError(t, err)
+		assert.Equal(t, created.ID, found.ID)
+		assert.Equal(t, name, found.Name)
+		assert.Equal(t, scheduleModels.PeriodTypeSchoolYear, found.PeriodType)
+		assert.True(t, found.IsActive)
+	})
+
+	t.Run("returns error for non-existent ID", func(t *testing.T) {
+		_, err := repo.FindByID(ctx, int64(999999999))
+
+		require.Error(t, err)
+	})
+}
+
+func TestCalendarPeriodRepository_Update(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewCalendarPeriodRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("updates period successfully", func(t *testing.T) {
+		name := fmt.Sprintf("Test-Update-%d", time.Now().UnixNano())
+		period := createTestCalendarPeriod(t, repo, name)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+
+		period.Name = fmt.Sprintf("Updated-%d", time.Now().UnixNano())
+		period.PeriodType = scheduleModels.PeriodTypeSemester
+		period.IsActive = false
+
+		err := repo.Update(ctx, period)
+
+		require.NoError(t, err)
+
+		updated, err := repo.FindByID(ctx, period.ID)
+		require.NoError(t, err)
+		assert.Equal(t, period.Name, updated.Name)
+		assert.Equal(t, scheduleModels.PeriodTypeSemester, updated.PeriodType)
+		assert.False(t, updated.IsActive)
+	})
+
+	t.Run("fails on nil period", func(t *testing.T) {
+		err := repo.Update(ctx, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+
+	t.Run("fails validation on empty name", func(t *testing.T) {
+		name := fmt.Sprintf("Test-UpdateBad-%d", time.Now().UnixNano())
+		period := createTestCalendarPeriod(t, repo, name)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+
+		period.Name = ""
+
+		err := repo.Update(ctx, period)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name is required")
+	})
+}
+
+func TestCalendarPeriodRepository_FindByTenantID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewCalendarPeriodRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns all periods for tenant", func(t *testing.T) {
+		suffix := time.Now().UnixNano()
+		p1 := createTestCalendarPeriod(t, repo, fmt.Sprintf("Test-Tenant-A-%d", suffix))
+		p2Name := fmt.Sprintf("Test-Tenant-B-%d", suffix)
+		p2 := &scheduleModels.CalendarPeriod{
+			Name:            p2Name,
+			PeriodType:      scheduleModels.PeriodTypeSemester,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        false,
+		}
+		p2.SetTenantID(1)
+		err := repo.Create(ctx, p2)
+		require.NoError(t, err)
+
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", p1.ID, p2.ID)
+
+		periods, err := repo.FindByTenantID(ctx)
+
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(periods), 2)
+
+		foundP1, foundP2 := false, false
+		for _, p := range periods {
+			if p.ID == p1.ID {
+				foundP1 = true
+			}
+			if p.ID == p2.ID {
+				foundP2 = true
+			}
+		}
+		assert.True(t, foundP1, "should find first period")
+		assert.True(t, foundP2, "should find second period")
+	})
+}
+
+func TestCalendarPeriodRepository_FindActiveByTenantID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewCalendarPeriodRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns only active periods", func(t *testing.T) {
+		suffix := time.Now().UnixNano()
+
+		activePeriod := createTestCalendarPeriod(t, repo, fmt.Sprintf("Test-Active-%d", suffix))
+
+		inactivePeriod := &scheduleModels.CalendarPeriod{
+			Name:            fmt.Sprintf("Test-Inactive-%d", suffix),
+			PeriodType:      scheduleModels.PeriodTypeSemester,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        false,
+		}
+		inactivePeriod.SetTenantID(1)
+		err := repo.Create(ctx, inactivePeriod)
+		require.NoError(t, err)
+
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", activePeriod.ID, inactivePeriod.ID)
+
+		periods, err := repo.FindActiveByTenantID(ctx)
+
+		require.NoError(t, err)
+
+		foundActive, foundInactive := false, false
+		for _, p := range periods {
+			if p.ID == activePeriod.ID {
+				foundActive = true
+			}
+			if p.ID == inactivePeriod.ID {
+				foundInactive = true
+			}
+		}
+		assert.True(t, foundActive, "should find active period")
+		assert.False(t, foundInactive, "should not find inactive period")
+	})
+}
+
+func TestCalendarPeriodRepository_FindByName(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewCalendarPeriodRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("finds period by name", func(t *testing.T) {
+		name := fmt.Sprintf("Test-FindByName-%d", time.Now().UnixNano())
+		created := createTestCalendarPeriod(t, repo, name)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", created.ID)
+
+		found, err := repo.FindByName(ctx, name)
+
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		assert.Equal(t, created.ID, found.ID)
+		assert.Equal(t, name, found.Name)
+	})
+
+	t.Run("returns nil for non-existent name", func(t *testing.T) {
+		found, err := repo.FindByName(ctx, "non-existent-period-name-xyz")
+
+		require.NoError(t, err)
+		assert.Nil(t, found)
+	})
+}
+
+func TestCalendarPeriodRepository_Delete(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewCalendarPeriodRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes period successfully", func(t *testing.T) {
+		name := fmt.Sprintf("Test-Delete-%d", time.Now().UnixNano())
+		period := createTestCalendarPeriod(t, repo, name)
+
+		err := repo.Delete(ctx, period.ID)
+
+		require.NoError(t, err)
+
+		_, findErr := repo.FindByID(ctx, period.ID)
+		assert.Error(t, findErr)
+	})
+}
+
+func TestCalendarPeriodRepository_List(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewCalendarPeriodRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("lists periods with nil options", func(t *testing.T) {
+		name := fmt.Sprintf("Test-List-%d", time.Now().UnixNano())
+		period := createTestCalendarPeriod(t, repo, name)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+
+		periods, err := repo.List(ctx, nil)
+
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(periods), 1)
+	})
+}

--- a/backend/database/repositories/schedule/calendar_period_repo_test.go
+++ b/backend/database/repositories/schedule/calendar_period_repo_test.go
@@ -367,6 +367,46 @@ func TestCalendarPeriodRepository_Delete(t *testing.T) {
 	})
 }
 
+// TestCalendarPeriodFKOnDelete verifies that the three FK columns pointing to
+// schedule.calendar_periods are declared ON DELETE SET NULL, so deleting a
+// period clears references instead of failing with a constraint violation.
+// Catalog code 'n' = SET NULL, 'a' = NO ACTION (default RESTRICT-equivalent),
+// 'c' = CASCADE, 'r' = RESTRICT, 'd' = SET DEFAULT.
+func TestCalendarPeriodFKOnDelete(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+
+	tables := []string{
+		"activities.schedules",
+		"activities.student_enrollments",
+		"activities.supervisors",
+	}
+
+	for _, table := range tables {
+		t.Run(table, func(t *testing.T) {
+			var confdeltype string
+			err := db.NewRaw(`
+				SELECT c.confdeltype
+				FROM pg_constraint c
+				JOIN pg_class t ON t.oid = c.conrelid
+				JOIN pg_namespace ns ON ns.oid = t.relnamespace
+				JOIN pg_class rt ON rt.oid = c.confrelid
+				JOIN pg_namespace rns ON rns.oid = rt.relnamespace
+				WHERE c.contype = 'f'
+				  AND ns.nspname || '.' || t.relname = ?
+				  AND rns.nspname = 'schedule'
+				  AND rt.relname = 'calendar_periods'
+				LIMIT 1
+			`, table).Scan(ctx, &confdeltype)
+			require.NoError(t, err, "FK to schedule.calendar_periods must exist on %s", table)
+			assert.Equal(t, "n", confdeltype,
+				"%s.calendar_period_id must be ON DELETE SET NULL (got %q)", table, confdeltype)
+		})
+	}
+}
+
 func TestCalendarPeriodRepository_List(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/backend/models/activities/group.go
+++ b/backend/models/activities/group.go
@@ -10,16 +10,26 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// Group type constants
+const (
+	GroupTypeActivity = "activity"
+	GroupTypeCare     = "care"
+	GroupTypeExternal = "external"
+)
+
 // Group represents an activity group
 type Group struct {
 	base.Model `bun:"schema:activities,table:groups"`
 	base.TenantModel
-	Name            string `bun:"name,notnull" json:"name"`
-	MaxParticipants int    `bun:"max_participants,notnull" json:"max_participants"`
-	IsOpen          bool   `bun:"is_open,notnull,default:false" json:"is_open"`
-	CategoryID      int64  `bun:"category_id,notnull" json:"category_id"`
-	PlannedRoomID   *int64 `bun:"planned_room_id" json:"planned_room_id,omitempty"`
-	CreatedBy       *int64 `bun:"created_by" json:"created_by"`
+	Name             string `bun:"name,notnull" json:"name"`
+	MaxParticipants  int    `bun:"max_participants,notnull" json:"max_participants"`
+	IsOpen           bool   `bun:"is_open,notnull,default:false" json:"is_open"`
+	CategoryID       int64  `bun:"category_id,notnull" json:"category_id"`
+	PlannedRoomID    *int64 `bun:"planned_room_id" json:"planned_room_id,omitempty"`
+	CreatedBy        *int64 `bun:"created_by" json:"created_by"`
+	Type             string `bun:"type,notnull,default:'activity'" json:"type"`
+	EducationGroupID *int64 `bun:"education_group_id" json:"education_group_id,omitempty"`
+	IsTemplate       bool   `bun:"is_template,notnull,default:true" json:"is_template"`
 
 	// Relations - populated when using the ORM's relations
 	Category       *Category            `bun:"rel:belongs-to,join:category_id=id" json:"category,omitempty"`

--- a/backend/models/activities/group.go
+++ b/backend/models/activities/group.go
@@ -29,7 +29,7 @@ type Group struct {
 	CreatedBy        *int64 `bun:"created_by" json:"created_by"`
 	Type             string `bun:"type,notnull,default:'activity'" json:"type"`
 	EducationGroupID *int64 `bun:"education_group_id" json:"education_group_id,omitempty"`
-	IsTemplate       bool   `bun:"is_template,notnull,default:true" json:"is_template"`
+	IsTemplate       bool   `bun:"is_template,notnull,default:false" json:"is_template"`
 
 	// Relations - populated when using the ORM's relations
 	Category       *Category            `bun:"rel:belongs-to,join:category_id=id" json:"category,omitempty"`

--- a/backend/models/activities/repository.go
+++ b/backend/models/activities/repository.go
@@ -91,8 +91,8 @@ type StudentEnrollmentRepository interface {
 	// CountByGroupID counts the number of students enrolled in a specific group
 	CountByGroupID(ctx context.Context, groupID int64) (int, error)
 
-	// FindByEnrollmentDateRange finds enrollments within a date range
-	FindByEnrollmentDateRange(ctx context.Context, start, end time.Time) ([]*StudentEnrollment, error)
+	// FindByValidFromRange finds enrollments within a valid_from date range
+	FindByValidFromRange(ctx context.Context, start, end time.Time) ([]*StudentEnrollment, error)
 
 	// UpdateAttendanceStatus updates the attendance status for a specific enrollment
 	UpdateAttendanceStatus(ctx context.Context, id int64, status *string) error

--- a/backend/models/activities/schedule.go
+++ b/backend/models/activities/schedule.go
@@ -26,9 +26,11 @@ const tableActivitiesSchedules = "activities.schedules"
 type Schedule struct {
 	base.Model `bun:"schema:activities,table:schedules"`
 	base.TenantModel
-	Weekday         int    `bun:"weekday,notnull" json:"weekday"`
-	TimeframeID     *int64 `bun:"timeframe_id" json:"timeframe_id,omitempty"`
-	ActivityGroupID int64  `bun:"activity_group_id,notnull" json:"activity_group_id"`
+	Weekday          int    `bun:"weekday,notnull" json:"weekday"`
+	TimeframeID      *int64 `bun:"timeframe_id" json:"timeframe_id,omitempty"`
+	ActivityGroupID  int64  `bun:"activity_group_id,notnull" json:"activity_group_id"`
+	WeekPattern      int    `bun:"week_pattern,notnull,default:0" json:"week_pattern"`
+	CalendarPeriodID *int64 `bun:"calendar_period_id" json:"calendar_period_id,omitempty"`
 
 	// Relations - these would be populated when using the ORM's relations
 	// ActivityGroup *Group `bun:"rel:belongs-to,join:activity_group_id=id" json:"activity_group,omitempty"`

--- a/backend/models/activities/student_enrollment.go
+++ b/backend/models/activities/student_enrollment.go
@@ -26,10 +26,12 @@ const (
 type StudentEnrollment struct {
 	base.Model `bun:"schema:activities,table:student_enrollments"`
 	base.TenantModel
-	StudentID        int64     `bun:"student_id,notnull" json:"student_id"`
-	ActivityGroupID  int64     `bun:"activity_group_id,notnull" json:"activity_group_id"`
-	EnrollmentDate   time.Time `bun:"enrollment_date,notnull" json:"enrollment_date"`
-	AttendanceStatus *string   `bun:"attendance_status" json:"attendance_status,omitempty"`
+	StudentID        int64      `bun:"student_id,notnull" json:"student_id"`
+	ActivityGroupID  int64      `bun:"activity_group_id,notnull" json:"activity_group_id"`
+	ValidFrom        time.Time  `bun:"valid_from,notnull" json:"valid_from"`
+	ValidUntil       *time.Time `bun:"valid_until" json:"valid_until,omitempty"`
+	CalendarPeriodID *int64     `bun:"calendar_period_id" json:"calendar_period_id,omitempty"`
+	AttendanceStatus *string    `bun:"attendance_status" json:"attendance_status,omitempty"`
 
 	// Relations - populated when using the ORM's relations
 	Student       *users.Student `bun:"rel:belongs-to,join:student_id=id" json:"student,omitempty"`
@@ -90,8 +92,8 @@ func (se *StudentEnrollment) Validate() error {
 		return errors.New("activity group ID is required")
 	}
 
-	if se.EnrollmentDate.IsZero() {
-		se.EnrollmentDate = time.Now()
+	if se.ValidFrom.IsZero() {
+		se.ValidFrom = time.Now()
 	}
 
 	if se.AttendanceStatus != nil && !IsValidAttendanceStatus(*se.AttendanceStatus) {

--- a/backend/models/activities/student_enrollment_test.go
+++ b/backend/models/activities/student_enrollment_test.go
@@ -76,7 +76,7 @@ func TestStudentEnrollmentValidate(t *testing.T) {
 			studentEnrollment: &StudentEnrollment{
 				StudentID:       1,
 				ActivityGroupID: 1,
-				EnrollmentDate:  now,
+				ValidFrom:       now,
 			},
 			wantErr: false,
 		},
@@ -85,7 +85,7 @@ func TestStudentEnrollmentValidate(t *testing.T) {
 			studentEnrollment: &StudentEnrollment{
 				StudentID:        1,
 				ActivityGroupID:  1,
-				EnrollmentDate:   now,
+				ValidFrom:        now,
 				AttendanceStatus: &present,
 			},
 			wantErr: false,
@@ -95,7 +95,7 @@ func TestStudentEnrollmentValidate(t *testing.T) {
 			studentEnrollment: &StudentEnrollment{
 				StudentID:        1,
 				ActivityGroupID:  1,
-				EnrollmentDate:   now,
+				ValidFrom:        now,
 				AttendanceStatus: &absent,
 			},
 			wantErr: false,
@@ -104,7 +104,7 @@ func TestStudentEnrollmentValidate(t *testing.T) {
 			name: "Missing student ID",
 			studentEnrollment: &StudentEnrollment{
 				ActivityGroupID: 1,
-				EnrollmentDate:  now,
+				ValidFrom:       now,
 			},
 			wantErr: true,
 		},
@@ -113,15 +113,15 @@ func TestStudentEnrollmentValidate(t *testing.T) {
 			studentEnrollment: &StudentEnrollment{
 				StudentID:       -1,
 				ActivityGroupID: 1,
-				EnrollmentDate:  now,
+				ValidFrom:       now,
 			},
 			wantErr: true,
 		},
 		{
 			name: "Missing activity group ID",
 			studentEnrollment: &StudentEnrollment{
-				StudentID:      1,
-				EnrollmentDate: now,
+				StudentID: 1,
+				ValidFrom: now,
 			},
 			wantErr: true,
 		},
@@ -130,12 +130,12 @@ func TestStudentEnrollmentValidate(t *testing.T) {
 			studentEnrollment: &StudentEnrollment{
 				StudentID:       1,
 				ActivityGroupID: -1,
-				EnrollmentDate:  now,
+				ValidFrom:       now,
 			},
 			wantErr: true,
 		},
 		{
-			name: "Missing enrollment date will be set automatically",
+			name: "Missing valid_from will be set automatically",
 			studentEnrollment: &StudentEnrollment{
 				StudentID:       1,
 				ActivityGroupID: 1,
@@ -147,7 +147,7 @@ func TestStudentEnrollmentValidate(t *testing.T) {
 			studentEnrollment: &StudentEnrollment{
 				StudentID:        1,
 				ActivityGroupID:  1,
-				EnrollmentDate:   now,
+				ValidFrom:        now,
 				AttendanceStatus: &invalid,
 			},
 			wantErr: true,
@@ -162,7 +162,7 @@ func TestStudentEnrollmentValidate(t *testing.T) {
 			}
 
 			// Verify enrollment date is set when missing
-			if tt.name == "Missing enrollment date will be set automatically" && tt.studentEnrollment.EnrollmentDate.IsZero() {
+			if tt.name == "Missing valid_from will be set automatically" && tt.studentEnrollment.ValidFrom.IsZero() {
 				t.Errorf("StudentEnrollment.Validate() did not set enrollment date")
 			}
 		})

--- a/backend/models/activities/supervisor_planned.go
+++ b/backend/models/activities/supervisor_planned.go
@@ -12,9 +12,12 @@ import (
 type SupervisorPlanned struct {
 	base.Model `bun:"schema:activities,table:supervisors"`
 	base.TenantModel
-	StaffID   int64 `bun:"staff_id,notnull" json:"staff_id"`
-	GroupID   int64 `bun:"group_id,notnull" json:"group_id"`
-	IsPrimary bool  `bun:"is_primary,notnull,default:false" json:"is_primary"`
+	StaffID          int64      `bun:"staff_id,notnull" json:"staff_id"`
+	GroupID          int64      `bun:"group_id,notnull" json:"group_id"`
+	IsPrimary        bool       `bun:"is_primary,notnull,default:false" json:"is_primary"`
+	ValidFrom        time.Time  `bun:"valid_from,notnull,default:current_date" json:"valid_from"`
+	ValidUntil       *time.Time `bun:"valid_until" json:"valid_until,omitempty"`
+	CalendarPeriodID *int64     `bun:"calendar_period_id" json:"calendar_period_id,omitempty"`
 
 	// Relations - these would be populated when using the ORM's relations
 	Staff *users.Staff `bun:"rel:belongs-to,join:staff_id=id" json:"staff,omitempty"`

--- a/backend/models/schedule/calendar_period.go
+++ b/backend/models/schedule/calendar_period.go
@@ -17,6 +17,14 @@ const (
 	PeriodTypeCustom     = "custom"
 )
 
+// Sentinel errors for the calendar period domain. Callers should compare via
+// errors.Is rather than matching on error strings.
+var (
+	// ErrCalendarPeriodNameConflict is returned when a create or update would
+	// violate the per-tenant name uniqueness rule.
+	ErrCalendarPeriodNameConflict = errors.New("calendar period name already exists")
+)
+
 // tableCalendarPeriods is the schema-qualified table name.
 const tableCalendarPeriods = "schedule.calendar_periods"
 

--- a/backend/models/schedule/calendar_period.go
+++ b/backend/models/schedule/calendar_period.go
@@ -1,0 +1,130 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/uptrace/bun"
+)
+
+// Period type constants
+const (
+	PeriodTypeSchoolYear = "school_year"
+	PeriodTypeSemester   = "semester"
+	PeriodTypeHoliday    = "holiday"
+	PeriodTypeCustom     = "custom"
+)
+
+// tableCalendarPeriods is the schema-qualified table name.
+const tableCalendarPeriods = "schedule.calendar_periods"
+
+// CalendarPeriod represents a time period in the school calendar (e.g. school year, semester, holiday).
+type CalendarPeriod struct {
+	base.Model `bun:"schema:schedule,table:calendar_periods"`
+	base.TenantModel
+
+	Name            string     `bun:"name,notnull" json:"name"`
+	PeriodType      string     `bun:"period_type,notnull" json:"period_type"`
+	StartDate       time.Time  `bun:"start_date,notnull" json:"start_date"`
+	EndDate         time.Time  `bun:"end_date,notnull" json:"end_date"`
+	WeekCycleLength int        `bun:"week_cycle_length,notnull,default:1" json:"week_cycle_length"`
+	WeekCycleAnchor *time.Time `bun:"week_cycle_anchor" json:"week_cycle_anchor,omitempty"`
+	IsActive        bool       `bun:"is_active,notnull,default:false" json:"is_active"`
+}
+
+func (p *CalendarPeriod) BeforeAppendModel(query any) error {
+	if q, ok := query.(*bun.UpdateQuery); ok {
+		q.ModelTableExpr(`schedule.calendar_periods AS "calendar_period"`)
+	}
+	if q, ok := query.(*bun.DeleteQuery); ok {
+		q.ModelTableExpr(`schedule.calendar_periods AS "calendar_period"`)
+	}
+	return nil
+}
+
+// TableName returns the database table name
+func (p *CalendarPeriod) TableName() string {
+	return tableCalendarPeriods
+}
+
+// GetID implements the Entity interface
+func (p *CalendarPeriod) GetID() any {
+	return p.ID
+}
+
+// GetCreatedAt implements the Entity interface
+func (p *CalendarPeriod) GetCreatedAt() time.Time {
+	return p.CreatedAt
+}
+
+// GetUpdatedAt implements the Entity interface
+func (p *CalendarPeriod) GetUpdatedAt() time.Time {
+	return p.UpdatedAt
+}
+
+// Validate ensures calendar period data is valid
+func (p *CalendarPeriod) Validate() error {
+	if p.Name == "" {
+		return errors.New("name is required")
+	}
+	if len(p.Name) > 255 {
+		return errors.New("name cannot exceed 255 characters")
+	}
+	if !IsValidPeriodType(p.PeriodType) {
+		return errors.New("invalid period type")
+	}
+	if p.StartDate.IsZero() {
+		return errors.New("start_date is required")
+	}
+	if p.EndDate.IsZero() {
+		return errors.New("end_date is required")
+	}
+	if !p.EndDate.After(p.StartDate) {
+		return errors.New("end_date must be after start_date")
+	}
+	if p.WeekCycleLength < 1 {
+		return errors.New("week_cycle_length must be at least 1")
+	}
+	if p.WeekCycleLength > 1 && p.WeekCycleAnchor == nil {
+		return errors.New("week_cycle_anchor is required when week_cycle_length > 1")
+	}
+	return nil
+}
+
+// IsValidPeriodType checks if the given string is a valid period type
+func IsValidPeriodType(t string) bool {
+	switch t {
+	case PeriodTypeSchoolYear, PeriodTypeSemester, PeriodTypeHoliday, PeriodTypeCustom:
+		return true
+	}
+	return false
+}
+
+// HasWeekCycle returns true if this period uses A/B week alternation
+func (p *CalendarPeriod) HasWeekCycle() bool {
+	return p.WeekCycleLength > 1
+}
+
+// ContainsDate returns true if the given date falls within this period
+func (p *CalendarPeriod) ContainsDate(date time.Time) bool {
+	d := date.Truncate(24 * time.Hour)
+	start := p.StartDate.Truncate(24 * time.Hour)
+	end := p.EndDate.Truncate(24 * time.Hour)
+	return !d.Before(start) && !d.After(end)
+}
+
+// CalendarPeriodRepository defines operations for managing calendar periods
+type CalendarPeriodRepository interface {
+	base.Repository[*CalendarPeriod]
+
+	// FindByTenantID finds all calendar periods for a tenant
+	FindByTenantID(ctx context.Context) ([]*CalendarPeriod, error)
+
+	// FindActiveByTenantID finds all active calendar periods for a tenant
+	FindActiveByTenantID(ctx context.Context) ([]*CalendarPeriod, error)
+
+	// FindByName finds a calendar period by name within the current tenant
+	FindByName(ctx context.Context, name string) (*CalendarPeriod, error)
+}

--- a/backend/models/schedule/calendar_period_test.go
+++ b/backend/models/schedule/calendar_period_test.go
@@ -1,0 +1,200 @@
+package schedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func TestCalendarPeriod_Validate(t *testing.T) {
+	anchor := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		period  *CalendarPeriod
+		wantErr string
+	}{
+		{
+			name: "valid period without cycle",
+			period: &CalendarPeriod{
+				Name:            "Schuljahr 2025/2026",
+				PeriodType:      PeriodTypeSchoolYear,
+				StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+				EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+				WeekCycleLength: 1,
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid period with A/B cycle",
+			period: &CalendarPeriod{
+				Name:            "Schuljahr 2025/2026",
+				PeriodType:      PeriodTypeSchoolYear,
+				StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+				EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+				WeekCycleLength: 2,
+				WeekCycleAnchor: &anchor,
+			},
+			wantErr: "",
+		},
+		{
+			name: "missing name",
+			period: &CalendarPeriod{
+				PeriodType:      PeriodTypeSchoolYear,
+				StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+				EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+				WeekCycleLength: 1,
+			},
+			wantErr: "name is required",
+		},
+		{
+			name: "invalid period type",
+			period: &CalendarPeriod{
+				Name:            "Test",
+				PeriodType:      "invalid",
+				StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+				EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+				WeekCycleLength: 1,
+			},
+			wantErr: "invalid period type",
+		},
+		{
+			name: "end date before start date",
+			period: &CalendarPeriod{
+				Name:            "Test",
+				PeriodType:      PeriodTypeSemester,
+				StartDate:       time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+				EndDate:         time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+				WeekCycleLength: 1,
+			},
+			wantErr: "end_date must be after start_date",
+		},
+		{
+			name: "same start and end date",
+			period: &CalendarPeriod{
+				Name:            "Test",
+				PeriodType:      PeriodTypeSemester,
+				StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+				EndDate:         time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+				WeekCycleLength: 1,
+			},
+			wantErr: "end_date must be after start_date",
+		},
+		{
+			name: "cycle length > 1 without anchor",
+			period: &CalendarPeriod{
+				Name:            "Test",
+				PeriodType:      PeriodTypeSchoolYear,
+				StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+				EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+				WeekCycleLength: 2,
+			},
+			wantErr: "week_cycle_anchor is required when week_cycle_length > 1",
+		},
+		{
+			name: "zero cycle length",
+			period: &CalendarPeriod{
+				Name:            "Test",
+				PeriodType:      PeriodTypeSchoolYear,
+				StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+				EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+				WeekCycleLength: 0,
+			},
+			wantErr: "week_cycle_length must be at least 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.period.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsValidPeriodType(t *testing.T) {
+	assert.True(t, IsValidPeriodType(PeriodTypeSchoolYear))
+	assert.True(t, IsValidPeriodType(PeriodTypeSemester))
+	assert.True(t, IsValidPeriodType(PeriodTypeHoliday))
+	assert.True(t, IsValidPeriodType(PeriodTypeCustom))
+	assert.False(t, IsValidPeriodType("invalid"))
+	assert.False(t, IsValidPeriodType(""))
+}
+
+func TestCalendarPeriod_HasWeekCycle(t *testing.T) {
+	p := &CalendarPeriod{WeekCycleLength: 1}
+	assert.False(t, p.HasWeekCycle())
+
+	p.WeekCycleLength = 2
+	assert.True(t, p.HasWeekCycle())
+}
+
+func TestCalendarPeriod_ContainsDate(t *testing.T) {
+	p := &CalendarPeriod{
+		StartDate: time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+	}
+
+	assert.True(t, p.ContainsDate(time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC)))   // start inclusive
+	assert.True(t, p.ContainsDate(time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC)))  // end inclusive
+	assert.True(t, p.ContainsDate(time.Date(2025, 12, 15, 0, 0, 0, 0, time.UTC))) // middle
+	assert.False(t, p.ContainsDate(time.Date(2025, 7, 31, 0, 0, 0, 0, time.UTC))) // before
+	assert.False(t, p.ContainsDate(time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)))  // after
+}
+
+func TestCalendarPeriod_TableName(t *testing.T) {
+	p := &CalendarPeriod{}
+	assert.Equal(t, "schedule.calendar_periods", p.TableName())
+}
+
+func TestCalendarPeriod_GetID(t *testing.T) {
+	p := &CalendarPeriod{}
+	p.ID = 42
+	assert.Equal(t, int64(42), p.GetID())
+}
+
+func TestCalendarPeriod_GetCreatedAt(t *testing.T) {
+	now := time.Now()
+	p := &CalendarPeriod{}
+	p.CreatedAt = now
+	assert.Equal(t, now, p.GetCreatedAt())
+}
+
+func TestCalendarPeriod_GetUpdatedAt(t *testing.T) {
+	now := time.Now()
+	p := &CalendarPeriod{}
+	p.UpdatedAt = now
+	assert.Equal(t, now, p.GetUpdatedAt())
+}
+
+func TestCalendarPeriod_BeforeAppendModel(t *testing.T) {
+	p := &CalendarPeriod{}
+
+	t.Run("handles SelectQuery", func(t *testing.T) {
+		err := p.BeforeAppendModel(&bun.SelectQuery{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("handles UpdateQuery", func(t *testing.T) {
+		err := p.BeforeAppendModel(&bun.UpdateQuery{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("handles DeleteQuery", func(t *testing.T) {
+		err := p.BeforeAppendModel(&bun.DeleteQuery{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("handles unknown query type", func(t *testing.T) {
+		err := p.BeforeAppendModel("unknown")
+		assert.NoError(t, err)
+	})
+}

--- a/backend/services/activities/enrollment_operations.go
+++ b/backend/services/activities/enrollment_operations.go
@@ -41,7 +41,7 @@ func (s *Service) EnrollStudent(ctx context.Context, groupID, studentID int64) e
 	enrollment := &activities.StudentEnrollment{
 		StudentID:       studentID,
 		ActivityGroupID: groupID,
-		EnrollmentDate:  time.Now(),
+		ValidFrom:       time.Now(),
 	}
 	enrollment.SetTenantID(tenant.FromContext(ctx))
 
@@ -145,7 +145,7 @@ func (s *Service) addNewEnrollmentsInTx(ctx context.Context, txService ActivityS
 			enrollment := &activities.StudentEnrollment{
 				StudentID:       studentID,
 				ActivityGroupID: groupID,
-				EnrollmentDate:  time.Now(),
+				ValidFrom:       time.Now(),
 			}
 			enrollment.SetTenantID(tenant.FromContext(ctx))
 
@@ -277,8 +277,8 @@ func (s *Service) GetEnrollmentsByDate(ctx context.Context, date time.Time) ([]*
 	// This would require a custom repository method with SQL join between enrollments and schedules
 	// For now, we just use the date range finder with the date as both start and end
 
-	// Using the repository's FindByEnrollmentDateRange method
-	enrollments, err := s.enrollmentRepo.FindByEnrollmentDateRange(ctx, date, date)
+	// Using the repository's FindByValidFromRange method
+	enrollments, err := s.enrollmentRepo.FindByValidFromRange(ctx, date, date)
 	if err != nil {
 		return nil, &ActivityError{Op: "get enrollments by date", Err: err}
 	}
@@ -300,7 +300,7 @@ func (s *Service) GetEnrollmentHistory(ctx context.Context, studentID int64, sta
 	// Filter by date range (simplified logic, actual implementation would be more complex)
 	var filteredEnrollments []*activities.StudentEnrollment
 	for _, enrollment := range enrollments {
-		if !enrollment.EnrollmentDate.Before(startDate) && !enrollment.EnrollmentDate.After(endDate) {
+		if !enrollment.ValidFrom.Before(startDate) && !enrollment.ValidFrom.After(endDate) {
 			filteredEnrollments = append(filteredEnrollments, enrollment)
 		}
 	}

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -57,6 +57,7 @@ type Factory struct {
 	Schedule                 schedule.Service
 	PickupSchedule           schedule.PickupScheduleService
 	ArrivalSchedule          schedule.ArrivalScheduleService
+	CalendarPeriod           schedule.CalendarPeriodService
 	Users                    users.PersonService
 	CaregiverCapability      users.CaregiverCapabilityService
 	Guardian                 users.GuardianService
@@ -313,6 +314,13 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		db,
 	)
 
+	// Initialize calendar period service
+	calendarPeriodService := schedule.NewCalendarPeriodService(
+		repos.CalendarPeriod,
+		db,
+		logger.With("service", "calendar-period"),
+	)
+
 	// Initialize arrival schedule service
 	arrivalScheduleService := schedule.NewArrivalScheduleService(
 		repos.StudentArrivalSchedule,
@@ -543,6 +551,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Schedule:                 scheduleService,
 		PickupSchedule:           pickupScheduleService,
 		ArrivalSchedule:          arrivalScheduleService,
+		CalendarPeriod:           calendarPeriodService,
 		Users:                    usersService,
 		CaregiverCapability:      caregiverCapabilityService,
 		Guardian:                 guardianService,

--- a/backend/services/schedule/calendar_period_integration_test.go
+++ b/backend/services/schedule/calendar_period_integration_test.go
@@ -1,0 +1,499 @@
+package schedule_test
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/services"
+	"github.com/moto-nrw/project-phoenix/services/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func setupCalendarPeriodService(t *testing.T, db *bun.DB) schedule.CalendarPeriodService {
+	t.Helper()
+	repoFactory := repositories.NewFactory(db)
+	serviceFactory, err := services.NewFactory(repoFactory, db, slog.Default())
+	require.NoError(t, err, "Failed to create service factory")
+	return serviceFactory.CalendarPeriod
+}
+
+// =============================================================================
+// GetAllPeriods Tests
+// =============================================================================
+
+func TestCalendarPeriodService_GetAllPeriods(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc := setupCalendarPeriodService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns all periods for tenant", func(t *testing.T) {
+		suffix := time.Now().UnixNano()
+		p1 := &scheduleModels.CalendarPeriod{
+			Name:            fmt.Sprintf("GetAll-A-%d", suffix),
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err := svc.CreatePeriod(ctx, p1)
+		require.NoError(t, err)
+
+		p2 := &scheduleModels.CalendarPeriod{
+			Name:            fmt.Sprintf("GetAll-B-%d", suffix),
+			PeriodType:      scheduleModels.PeriodTypeSemester,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        false,
+		}
+		err = svc.CreatePeriod(ctx, p2)
+		require.NoError(t, err)
+
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", p1.ID, p2.ID)
+
+		periods, err := svc.GetAllPeriods(ctx)
+
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(periods), 2)
+	})
+}
+
+// =============================================================================
+// GetActivePeriods Tests
+// =============================================================================
+
+func TestCalendarPeriodService_GetActivePeriods(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc := setupCalendarPeriodService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns only active periods", func(t *testing.T) {
+		suffix := time.Now().UnixNano()
+		active := &scheduleModels.CalendarPeriod{
+			Name:            fmt.Sprintf("Active-%d", suffix),
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err := svc.CreatePeriod(ctx, active)
+		require.NoError(t, err)
+
+		inactive := &scheduleModels.CalendarPeriod{
+			Name:            fmt.Sprintf("Inactive-%d", suffix),
+			PeriodType:      scheduleModels.PeriodTypeSemester,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        false,
+		}
+		err = svc.CreatePeriod(ctx, inactive)
+		require.NoError(t, err)
+
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", active.ID, inactive.ID)
+
+		periods, err := svc.GetActivePeriods(ctx)
+
+		require.NoError(t, err)
+		for _, p := range periods {
+			assert.True(t, p.IsActive, "all returned periods should be active")
+		}
+	})
+}
+
+// =============================================================================
+// GetPeriodByID Tests
+// =============================================================================
+
+func TestCalendarPeriodService_GetPeriodByID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc := setupCalendarPeriodService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("returns period by ID", func(t *testing.T) {
+		name := fmt.Sprintf("GetByID-%d", time.Now().UnixNano())
+		period := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err := svc.CreatePeriod(ctx, period)
+		require.NoError(t, err)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+
+		found, err := svc.GetPeriodByID(ctx, period.ID)
+
+		require.NoError(t, err)
+		assert.Equal(t, period.ID, found.ID)
+		assert.Equal(t, name, found.Name)
+	})
+
+	t.Run("returns error for non-existent ID", func(t *testing.T) {
+		_, err := svc.GetPeriodByID(ctx, int64(999999999))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "schedule error")
+	})
+}
+
+// =============================================================================
+// CreatePeriod Tests
+// =============================================================================
+
+func TestCalendarPeriodService_CreatePeriod(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc := setupCalendarPeriodService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates period successfully", func(t *testing.T) {
+		name := fmt.Sprintf("Create-%d", time.Now().UnixNano())
+		period := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+
+		err := svc.CreatePeriod(ctx, period)
+
+		require.NoError(t, err)
+		assert.Greater(t, period.ID, int64(0))
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+	})
+
+	t.Run("creates period with week cycle", func(t *testing.T) {
+		name := fmt.Sprintf("Create-Cycle-%d", time.Now().UnixNano())
+		anchor := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+		period := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 2,
+			WeekCycleAnchor: &anchor,
+			IsActive:        true,
+		}
+
+		err := svc.CreatePeriod(ctx, period)
+
+		require.NoError(t, err)
+		assert.Greater(t, period.ID, int64(0))
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+	})
+
+	t.Run("rejects duplicate name", func(t *testing.T) {
+		name := fmt.Sprintf("Duplicate-%d", time.Now().UnixNano())
+		first := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err := svc.CreatePeriod(ctx, first)
+		require.NoError(t, err)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", first.ID)
+
+		second := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSemester,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err = svc.CreatePeriod(ctx, second)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("rejects invalid period data", func(t *testing.T) {
+		period := &scheduleModels.CalendarPeriod{
+			Name:            "",
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+		}
+
+		err := svc.CreatePeriod(ctx, period)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name is required")
+	})
+
+	t.Run("rejects end date before start date", func(t *testing.T) {
+		period := &scheduleModels.CalendarPeriod{
+			Name:            fmt.Sprintf("BadDates-%d", time.Now().UnixNano()),
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2025, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+		}
+
+		err := svc.CreatePeriod(ctx, period)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "end_date must be after start_date")
+	})
+}
+
+// =============================================================================
+// UpdatePeriod Tests
+// =============================================================================
+
+func TestCalendarPeriodService_UpdatePeriod(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc := setupCalendarPeriodService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("updates period successfully", func(t *testing.T) {
+		name := fmt.Sprintf("Update-%d", time.Now().UnixNano())
+		period := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err := svc.CreatePeriod(ctx, period)
+		require.NoError(t, err)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+
+		newName := fmt.Sprintf("Updated-%d", time.Now().UnixNano())
+		period.Name = newName
+		period.PeriodType = scheduleModels.PeriodTypeSemester
+		period.IsActive = false
+
+		err = svc.UpdatePeriod(ctx, period)
+
+		require.NoError(t, err)
+
+		found, err := svc.GetPeriodByID(ctx, period.ID)
+		require.NoError(t, err)
+		assert.Equal(t, newName, found.Name)
+		assert.Equal(t, scheduleModels.PeriodTypeSemester, found.PeriodType)
+		assert.False(t, found.IsActive)
+	})
+
+	t.Run("allows updating with same name (self)", func(t *testing.T) {
+		name := fmt.Sprintf("SameName-%d", time.Now().UnixNano())
+		period := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err := svc.CreatePeriod(ctx, period)
+		require.NoError(t, err)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+
+		period.IsActive = false
+		err = svc.UpdatePeriod(ctx, period)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects duplicate name from another period", func(t *testing.T) {
+		suffix := time.Now().UnixNano()
+		first := &scheduleModels.CalendarPeriod{
+			Name:            fmt.Sprintf("First-%d", suffix),
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err := svc.CreatePeriod(ctx, first)
+		require.NoError(t, err)
+
+		second := &scheduleModels.CalendarPeriod{
+			Name:            fmt.Sprintf("Second-%d", suffix),
+			PeriodType:      scheduleModels.PeriodTypeSemester,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err = svc.CreatePeriod(ctx, second)
+		require.NoError(t, err)
+
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", first.ID, second.ID)
+
+		second.Name = first.Name
+		err = svc.UpdatePeriod(ctx, second)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("rejects invalid update data", func(t *testing.T) {
+		name := fmt.Sprintf("InvalidUpdate-%d", time.Now().UnixNano())
+		period := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err := svc.CreatePeriod(ctx, period)
+		require.NoError(t, err)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+
+		period.Name = ""
+		err = svc.UpdatePeriod(ctx, period)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name is required")
+	})
+}
+
+// =============================================================================
+// DeletePeriod Tests
+// =============================================================================
+
+func TestCalendarPeriodService_DeletePeriod(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc := setupCalendarPeriodService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("deletes period successfully", func(t *testing.T) {
+		name := fmt.Sprintf("Delete-%d", time.Now().UnixNano())
+		period := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err := svc.CreatePeriod(ctx, period)
+		require.NoError(t, err)
+
+		err = svc.DeletePeriod(ctx, period.ID)
+
+		require.NoError(t, err)
+
+		_, err = svc.GetPeriodByID(ctx, period.ID)
+		assert.Error(t, err)
+	})
+}
+
+// =============================================================================
+// GetOrCreateDefaultPeriod Tests
+// =============================================================================
+
+func TestCalendarPeriodService_GetOrCreateDefaultPeriod(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc := setupCalendarPeriodService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates default period when none exist", func(t *testing.T) {
+		// Clean any existing periods for this tenant first
+		existingPeriods, err := svc.GetAllPeriods(ctx)
+		require.NoError(t, err)
+		for _, p := range existingPeriods {
+			_ = svc.DeletePeriod(ctx, p.ID)
+		}
+
+		period, err := svc.GetOrCreateDefaultPeriod(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, period)
+		assert.Greater(t, period.ID, int64(0))
+		assert.Contains(t, period.Name, "Schuljahr")
+		assert.Equal(t, scheduleModels.PeriodTypeSchoolYear, period.PeriodType)
+		assert.True(t, period.IsActive)
+		assert.Equal(t, 1, period.WeekCycleLength)
+
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID)
+	})
+
+	t.Run("returns existing active period", func(t *testing.T) {
+		// Clean any existing periods
+		existingPeriods, err := svc.GetAllPeriods(ctx)
+		require.NoError(t, err)
+		for _, p := range existingPeriods {
+			_ = svc.DeletePeriod(ctx, p.ID)
+		}
+
+		name := fmt.Sprintf("Existing-%d", time.Now().UnixNano())
+		existing := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSemester,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        true,
+		}
+		err = svc.CreatePeriod(ctx, existing)
+		require.NoError(t, err)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", existing.ID)
+
+		period, err := svc.GetOrCreateDefaultPeriod(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, existing.ID, period.ID)
+	})
+
+	t.Run("returns first period if none are active", func(t *testing.T) {
+		// Clean any existing periods
+		existingPeriods, err := svc.GetAllPeriods(ctx)
+		require.NoError(t, err)
+		for _, p := range existingPeriods {
+			_ = svc.DeletePeriod(ctx, p.ID)
+		}
+
+		name := fmt.Sprintf("InactiveOnly-%d", time.Now().UnixNano())
+		inactive := &scheduleModels.CalendarPeriod{
+			Name:            name,
+			PeriodType:      scheduleModels.PeriodTypeSemester,
+			StartDate:       time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:         time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+			WeekCycleLength: 1,
+			IsActive:        false,
+		}
+		err = svc.CreatePeriod(ctx, inactive)
+		require.NoError(t, err)
+		defer testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", inactive.ID)
+
+		period, err := svc.GetOrCreateDefaultPeriod(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, inactive.ID, period.ID)
+	})
+}

--- a/backend/services/schedule/calendar_period_integration_test.go
+++ b/backend/services/schedule/calendar_period_integration_test.go
@@ -228,7 +228,7 @@ func TestCalendarPeriodService_CreatePeriod(t *testing.T) {
 		err = svc.CreatePeriod(ctx, second)
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "already exists")
+		assert.ErrorIs(t, err, scheduleModels.ErrCalendarPeriodNameConflict)
 	})
 
 	t.Run("rejects invalid period data", func(t *testing.T) {
@@ -353,7 +353,7 @@ func TestCalendarPeriodService_UpdatePeriod(t *testing.T) {
 		err = svc.UpdatePeriod(ctx, second)
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "already exists")
+		assert.ErrorIs(t, err, scheduleModels.ErrCalendarPeriodNameConflict)
 	})
 
 	t.Run("rejects invalid update data", func(t *testing.T) {

--- a/backend/services/schedule/calendar_period_service.go
+++ b/backend/services/schedule/calendar_period_service.go
@@ -1,0 +1,234 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+// CalendarPeriodService defines operations for managing calendar periods
+type CalendarPeriodService interface {
+	// CRUD
+	GetAllPeriods(ctx context.Context) ([]*schedule.CalendarPeriod, error)
+	GetActivePeriods(ctx context.Context) ([]*schedule.CalendarPeriod, error)
+	GetPeriodByID(ctx context.Context, id int64) (*schedule.CalendarPeriod, error)
+	CreatePeriod(ctx context.Context, period *schedule.CalendarPeriod) error
+	UpdatePeriod(ctx context.Context, period *schedule.CalendarPeriod) error
+	DeletePeriod(ctx context.Context, id int64) error
+
+	// Auto-creation
+	GetOrCreateDefaultPeriod(ctx context.Context) (*schedule.CalendarPeriod, error)
+
+	// A/B week resolution — weekPattern: 0=every, 1=week A, 2=week B
+	ShouldMaterialize(weekPattern int, instanceDate time.Time, period *schedule.CalendarPeriod) bool
+}
+
+// calendarPeriodService implements CalendarPeriodService
+type calendarPeriodService struct {
+	repo   schedule.CalendarPeriodRepository
+	db     *bun.DB
+	logger *slog.Logger
+}
+
+// NewCalendarPeriodService creates a new calendar period service
+func NewCalendarPeriodService(
+	repo schedule.CalendarPeriodRepository,
+	db *bun.DB,
+	logger *slog.Logger,
+) CalendarPeriodService {
+	return &calendarPeriodService{
+		repo:   repo,
+		db:     db,
+		logger: logger,
+	}
+}
+
+func (s *calendarPeriodService) getLogger() *slog.Logger {
+	if s.logger != nil {
+		return s.logger
+	}
+	return slog.Default()
+}
+
+// GetAllPeriods returns all calendar periods for the current tenant
+func (s *calendarPeriodService) GetAllPeriods(ctx context.Context) ([]*schedule.CalendarPeriod, error) {
+	periods, err := s.repo.FindByTenantID(ctx)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get all calendar periods", Err: err}
+	}
+	return periods, nil
+}
+
+// GetActivePeriods returns all active calendar periods for the current tenant
+func (s *calendarPeriodService) GetActivePeriods(ctx context.Context) ([]*schedule.CalendarPeriod, error) {
+	periods, err := s.repo.FindActiveByTenantID(ctx)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get active calendar periods", Err: err}
+	}
+	return periods, nil
+}
+
+// GetPeriodByID returns a calendar period by its ID
+func (s *calendarPeriodService) GetPeriodByID(ctx context.Context, id int64) (*schedule.CalendarPeriod, error) {
+	period, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get calendar period by id", Err: err}
+	}
+	return period, nil
+}
+
+// CreatePeriod creates a new calendar period
+func (s *calendarPeriodService) CreatePeriod(ctx context.Context, period *schedule.CalendarPeriod) error {
+	if err := period.Validate(); err != nil {
+		return &ScheduleError{Op: "create calendar period", Err: err}
+	}
+
+	// Check for duplicate name
+	existing, err := s.repo.FindByName(ctx, period.Name)
+	if err != nil {
+		return &ScheduleError{Op: "create calendar period", Err: err}
+	}
+	if existing != nil {
+		return &ScheduleError{Op: "create calendar period", Err: errors.New("a period with this name already exists")}
+	}
+
+	period.SetTenantID(tenant.FromContext(ctx))
+	if err := s.repo.Create(ctx, period); err != nil {
+		return &ScheduleError{Op: "create calendar period", Err: err}
+	}
+
+	s.getLogger().Info("calendar period created",
+		slog.Int64("period_id", period.ID),
+		slog.String("name", period.Name),
+		slog.String("period_type", period.PeriodType),
+	)
+
+	return nil
+}
+
+// UpdatePeriod updates an existing calendar period
+func (s *calendarPeriodService) UpdatePeriod(ctx context.Context, period *schedule.CalendarPeriod) error {
+	if err := period.Validate(); err != nil {
+		return &ScheduleError{Op: "update calendar period", Err: err}
+	}
+
+	// Check for duplicate name (excluding self)
+	existing, err := s.repo.FindByName(ctx, period.Name)
+	if err != nil {
+		return &ScheduleError{Op: "update calendar period", Err: err}
+	}
+	if existing != nil && existing.ID != period.ID {
+		return &ScheduleError{Op: "update calendar period", Err: errors.New("a period with this name already exists")}
+	}
+
+	if err := s.repo.Update(ctx, period); err != nil {
+		return &ScheduleError{Op: "update calendar period", Err: err}
+	}
+
+	return nil
+}
+
+// DeletePeriod deletes a calendar period by ID
+func (s *calendarPeriodService) DeletePeriod(ctx context.Context, id int64) error {
+	if err := s.repo.Delete(ctx, id); err != nil {
+		return &ScheduleError{Op: "delete calendar period", Err: err}
+	}
+	return nil
+}
+
+// GetOrCreateDefaultPeriod returns the default school-year period for the tenant,
+// creating one if none exists. Uses the current school year dates (Aug 1 - Jul 31).
+func (s *calendarPeriodService) GetOrCreateDefaultPeriod(ctx context.Context) (*schedule.CalendarPeriod, error) {
+	periods, err := s.repo.FindByTenantID(ctx)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get or create default period", Err: err}
+	}
+
+	if len(periods) > 0 {
+		// Return the first active period, or the first period if none are active
+		for _, p := range periods {
+			if p.IsActive {
+				return p, nil
+			}
+		}
+		return periods[0], nil
+	}
+
+	// No periods exist — create a default school year
+	now := time.Now()
+	year := now.Year()
+
+	// German school year: Aug 1 - Jul 31
+	// If we're past Aug 1, current year starts this Aug; otherwise last Aug
+	var startDate, endDate time.Time
+	if now.Month() >= time.August {
+		startDate = time.Date(year, time.August, 1, 0, 0, 0, 0, time.UTC)
+		endDate = time.Date(year+1, time.July, 31, 0, 0, 0, 0, time.UTC)
+	} else {
+		startDate = time.Date(year-1, time.August, 1, 0, 0, 0, 0, time.UTC)
+		endDate = time.Date(year, time.July, 31, 0, 0, 0, 0, time.UTC)
+	}
+
+	defaultName := fmt.Sprintf("Schuljahr %d/%d", startDate.Year(), endDate.Year())
+
+	period := &schedule.CalendarPeriod{
+		Name:            defaultName,
+		PeriodType:      schedule.PeriodTypeSchoolYear,
+		StartDate:       startDate,
+		EndDate:         endDate,
+		WeekCycleLength: 1,
+		IsActive:        true,
+	}
+	period.SetTenantID(tenant.FromContext(ctx))
+
+	if err := s.repo.Create(ctx, period); err != nil {
+		return nil, &ScheduleError{Op: "get or create default period", Err: err}
+	}
+
+	s.getLogger().Info("default calendar period created",
+		slog.Int64("period_id", period.ID),
+		slog.String("name", period.Name),
+	)
+
+	return period, nil
+}
+
+// ShouldMaterialize determines whether a schedule with the given weekPattern should
+// produce an instance on instanceDate, considering the period's A/B week cycle.
+//
+// Uses day-based difference calculation (NOT ISO week numbers) to avoid
+// year-boundary bugs. See timetable-system-plan.md §6.1 for algorithm details.
+//
+// weekPattern: 0=every week, 1=week A, 2=week B (maps to currentPattern 1, 2, ...)
+func (s *calendarPeriodService) ShouldMaterialize(weekPattern int, instanceDate time.Time, period *schedule.CalendarPeriod) bool {
+	if weekPattern == 0 {
+		return true // every week
+	}
+	if period == nil || period.WeekCycleLength <= 1 {
+		return true // no alternation configured
+	}
+	if period.WeekCycleAnchor == nil {
+		return true // no anchor set, can't compute — allow by default
+	}
+
+	// Day-based difference from anchor to instance date
+	anchorDate := period.WeekCycleAnchor.Truncate(24 * time.Hour)
+	instDate := instanceDate.Truncate(24 * time.Hour)
+
+	daysDiff := instDate.Sub(anchorDate).Hours() / 24
+	weeksDiff := int(math.Floor(daysDiff / 7))
+
+	// Modulo that handles negative values correctly
+	cycleLen := period.WeekCycleLength
+	currentPattern := ((weeksDiff % cycleLen) + cycleLen) % cycleLen
+	currentPattern++ // 1-based: 1=A, 2=B, etc.
+
+	return currentPattern == weekPattern
+}

--- a/backend/services/schedule/calendar_period_service.go
+++ b/backend/services/schedule/calendar_period_service.go
@@ -2,7 +2,6 @@ package schedule
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -96,7 +95,7 @@ func (s *calendarPeriodService) CreatePeriod(ctx context.Context, period *schedu
 		return &ScheduleError{Op: "create calendar period", Err: err}
 	}
 	if existing != nil {
-		return &ScheduleError{Op: "create calendar period", Err: errors.New("a period with this name already exists")}
+		return &ScheduleError{Op: "create calendar period", Err: schedule.ErrCalendarPeriodNameConflict}
 	}
 
 	period.SetTenantID(tenant.FromContext(ctx))
@@ -125,7 +124,7 @@ func (s *calendarPeriodService) UpdatePeriod(ctx context.Context, period *schedu
 		return &ScheduleError{Op: "update calendar period", Err: err}
 	}
 	if existing != nil && existing.ID != period.ID {
-		return &ScheduleError{Op: "update calendar period", Err: errors.New("a period with this name already exists")}
+		return &ScheduleError{Op: "update calendar period", Err: schedule.ErrCalendarPeriodNameConflict}
 	}
 
 	if err := s.repo.Update(ctx, period); err != nil {

--- a/backend/services/schedule/calendar_period_service_test.go
+++ b/backend/services/schedule/calendar_period_service_test.go
@@ -1,0 +1,159 @@
+package schedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldMaterialize(t *testing.T) {
+	svc := &calendarPeriodService{}
+
+	// Anchor: Monday 2025-09-01 = "Week A"
+	anchor := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+
+	abPeriod := &schedule.CalendarPeriod{
+		WeekCycleLength: 2,
+		WeekCycleAnchor: &anchor,
+	}
+
+	noCyclePeriod := &schedule.CalendarPeriod{
+		WeekCycleLength: 1,
+	}
+
+	t.Run("week_pattern 0 always materializes", func(t *testing.T) {
+		date := time.Date(2025, 9, 8, 0, 0, 0, 0, time.UTC)
+		assert.True(t, svc.ShouldMaterialize(0, date, abPeriod))
+	})
+
+	t.Run("no cycle period always materializes", func(t *testing.T) {
+		date := time.Date(2025, 9, 8, 0, 0, 0, 0, time.UTC)
+		assert.True(t, svc.ShouldMaterialize(1, date, noCyclePeriod))
+	})
+
+	t.Run("nil period always materializes", func(t *testing.T) {
+		date := time.Date(2025, 9, 8, 0, 0, 0, 0, time.UTC)
+		assert.True(t, svc.ShouldMaterialize(1, date, nil))
+	})
+
+	t.Run("nil anchor always materializes", func(t *testing.T) {
+		p := &schedule.CalendarPeriod{
+			WeekCycleLength: 2,
+			WeekCycleAnchor: nil,
+		}
+		date := time.Date(2025, 9, 8, 0, 0, 0, 0, time.UTC)
+		assert.True(t, svc.ShouldMaterialize(1, date, p))
+	})
+
+	t.Run("anchor week is week A (pattern 1)", func(t *testing.T) {
+		// 2025-09-01 is the anchor itself — should be week A
+		date := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+		assert.True(t, svc.ShouldMaterialize(1, date, abPeriod))
+		assert.False(t, svc.ShouldMaterialize(2, date, abPeriod))
+	})
+
+	t.Run("week after anchor is week B (pattern 2)", func(t *testing.T) {
+		// 2025-09-08 is 7 days after anchor — should be week B
+		date := time.Date(2025, 9, 8, 0, 0, 0, 0, time.UTC)
+		assert.False(t, svc.ShouldMaterialize(1, date, abPeriod))
+		assert.True(t, svc.ShouldMaterialize(2, date, abPeriod))
+	})
+
+	t.Run("two weeks after anchor is week A again", func(t *testing.T) {
+		// 2025-09-15 is 14 days after anchor — should be week A
+		date := time.Date(2025, 9, 15, 0, 0, 0, 0, time.UTC)
+		assert.True(t, svc.ShouldMaterialize(1, date, abPeriod))
+		assert.False(t, svc.ShouldMaterialize(2, date, abPeriod))
+	})
+
+	t.Run("mid-week day follows week pattern", func(t *testing.T) {
+		// 2025-09-03 (Wednesday) is still in the anchor week — week A
+		date := time.Date(2025, 9, 3, 0, 0, 0, 0, time.UTC)
+		assert.True(t, svc.ShouldMaterialize(1, date, abPeriod))
+		assert.False(t, svc.ShouldMaterialize(2, date, abPeriod))
+	})
+
+	t.Run("mid-week day in week B", func(t *testing.T) {
+		// 2025-09-10 (Wednesday) is in the second week — week B
+		date := time.Date(2025, 9, 10, 0, 0, 0, 0, time.UTC)
+		assert.False(t, svc.ShouldMaterialize(1, date, abPeriod))
+		assert.True(t, svc.ShouldMaterialize(2, date, abPeriod))
+	})
+
+	t.Run("date before anchor works correctly", func(t *testing.T) {
+		// 2025-08-25 is 7 days BEFORE anchor — should be week B (negative modulo)
+		date := time.Date(2025, 8, 25, 0, 0, 0, 0, time.UTC)
+		assert.False(t, svc.ShouldMaterialize(1, date, abPeriod))
+		assert.True(t, svc.ShouldMaterialize(2, date, abPeriod))
+	})
+
+	t.Run("date two weeks before anchor is week A", func(t *testing.T) {
+		// 2025-08-18 is 14 days before anchor — should be week A
+		date := time.Date(2025, 8, 18, 0, 0, 0, 0, time.UTC)
+		assert.True(t, svc.ShouldMaterialize(1, date, abPeriod))
+		assert.False(t, svc.ShouldMaterialize(2, date, abPeriod))
+	})
+
+	t.Run("year boundary does not break A/B pattern", func(t *testing.T) {
+		// This is the critical test. Using day-based math, the pattern should
+		// continue correctly across Dec 31 → Jan 1 without ISO week jumps.
+
+		// Anchor is 2025-09-01 (Monday).
+		// 2025-12-29 is a Monday.
+		// Days diff = (2025-12-29) - (2025-09-01) = 119 days
+		// 119 / 7 = 17 weeks
+		// 17 % 2 = 1 → pattern = 2 (week B)
+		dec29 := time.Date(2025, 12, 29, 0, 0, 0, 0, time.UTC)
+		assert.False(t, svc.ShouldMaterialize(1, dec29, abPeriod))
+		assert.True(t, svc.ShouldMaterialize(2, dec29, abPeriod))
+
+		// 2026-01-05 is the next Monday (126 days after anchor)
+		// 126 / 7 = 18 weeks
+		// 18 % 2 = 0 → pattern = 1 (week A)
+		jan5 := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+		assert.True(t, svc.ShouldMaterialize(1, jan5, abPeriod))
+		assert.False(t, svc.ShouldMaterialize(2, jan5, abPeriod))
+	})
+
+	t.Run("three-week cycle (A/B/C)", func(t *testing.T) {
+		threeCycle := &schedule.CalendarPeriod{
+			WeekCycleLength: 3,
+			WeekCycleAnchor: &anchor,
+		}
+
+		// Anchor week = pattern 1
+		date := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+		assert.True(t, svc.ShouldMaterialize(1, date, threeCycle))
+		assert.False(t, svc.ShouldMaterialize(2, date, threeCycle))
+		assert.False(t, svc.ShouldMaterialize(3, date, threeCycle))
+
+		// +1 week = pattern 2
+		date = time.Date(2025, 9, 8, 0, 0, 0, 0, time.UTC)
+		assert.False(t, svc.ShouldMaterialize(1, date, threeCycle))
+		assert.True(t, svc.ShouldMaterialize(2, date, threeCycle))
+		assert.False(t, svc.ShouldMaterialize(3, date, threeCycle))
+
+		// +2 weeks = pattern 3
+		date = time.Date(2025, 9, 15, 0, 0, 0, 0, time.UTC)
+		assert.False(t, svc.ShouldMaterialize(1, date, threeCycle))
+		assert.False(t, svc.ShouldMaterialize(2, date, threeCycle))
+		assert.True(t, svc.ShouldMaterialize(3, date, threeCycle))
+
+		// +3 weeks = back to pattern 1
+		date = time.Date(2025, 9, 22, 0, 0, 0, 0, time.UTC)
+		assert.True(t, svc.ShouldMaterialize(1, date, threeCycle))
+	})
+
+	t.Run("large week offset still correct", func(t *testing.T) {
+		// 52 weeks (364 days) after anchor
+		// 364 / 7 = 52, 52 % 2 = 0 → pattern 1 (week A)
+		date := time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC) // ~364 days after 2025-09-01
+		// Actually compute exactly: 2025-09-01 + 364 days = 2026-08-31
+		exactDate := anchor.AddDate(0, 0, 364)
+		assert.True(t, svc.ShouldMaterialize(1, exactDate, abPeriod))
+		assert.False(t, svc.ShouldMaterialize(2, exactDate, abPeriod))
+		_ = date // used for documentation
+	})
+}

--- a/backend/services/schedule/calendar_period_service_test.go
+++ b/backend/services/schedule/calendar_period_service_test.go
@@ -1,12 +1,22 @@
 package schedule
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestScheduleErrorUnwrapsSentinel verifies that the ScheduleError wrapper used
+// by the calendar period service preserves errors.Is semantics for the
+// ErrCalendarPeriodNameConflict sentinel. Callers (API handler) rely on this.
+func TestScheduleErrorUnwrapsSentinel(t *testing.T) {
+	wrapped := &ScheduleError{Op: "create calendar period", Err: schedule.ErrCalendarPeriodNameConflict}
+	assert.True(t, errors.Is(wrapped, schedule.ErrCalendarPeriodNameConflict),
+		"ScheduleError must unwrap to the sentinel so handlers can detect via errors.Is")
+}
 
 func TestShouldMaterialize(t *testing.T) {
 	svc := &calendarPeriodService{}

--- a/backend/test/hermetic_verification_test.go
+++ b/backend/test/hermetic_verification_test.go
@@ -152,6 +152,7 @@ func checkHardcodedIDs(t *testing.T, root string) []string {
 		"api/iot/api_test.go",                   // Uses mock SchoolRepo for unit testing handler
 		"api/iot/config_test.go",                // Uses mock settings service for unit testing config endpoint
 		"enrich_pickup_times_test.go",           // Uses mock PickupScheduleService for unit testing enrichment
+		"api/timetable/api_test.go",             // Uses mock CalendarPeriodService for unit testing handlers
 	}
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
## Summary

- **Calendar Periods** — New `schedule.calendar_periods` table with full CRUD stack (migration, model, repository, service, API at `/api/timetable/periods`). Includes A/B week resolution using day-based difference calculation to avoid ISO week year-boundary bugs.
- **Template Extensions** — Add `type`/`education_group_id`/`is_template` to `activities.groups`, `week_pattern`/`calendar_period_id` to `activities.schedules`, rename `enrollment_date` → `valid_from` + add `valid_until`/`calendar_period_id` to `student_enrollments`, add `valid_from`/`valid_until`/`calendar_period_id` to `supervisors`. Replace full UNIQUE indexes with partial indexes (`WHERE valid_until IS NULL`).
- All existing tests updated for the field rename (compile-time changes only, no behavioral changes)

Implements PR 2 + PR 3 from the [timetable system plan](../docs/timetable-system-plan.md).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./models/activities/...` passes (all renamed field tests)
- [x] `go test ./models/schedule/...` passes (calendar period model + validation)
- [x] `go test ./services/schedule/ -run TestShouldMaterialize` passes (15 A/B week tests including year boundary)
- [x] `go test ./test/ -run TestHermeticTestPatterns` passes
- [x] All pre-commit hooks pass (goimports, git-secrets)
- [x] All pre-push hooks pass (go-vet, go-deadcode, golangci-lint — 0 issues)
- [ ] Run migrations on test DB and verify schema changes
- [ ] Verify API endpoints via `curl` against local dev server