### PR TITLE
feat: nullable active group_id + timetable settings (WP-B6 + WP-B7)

### DIFF
--- a/backend/api/active/active_internal_test.go
+++ b/backend/api/active/active_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	activeService "github.com/moto-nrw/project-phoenix/services/active"
 )
@@ -290,7 +291,7 @@ func TestCheckinRequest_Fields(t *testing.T) {
 }
 
 func TestCheckinContext_Fields(t *testing.T) {
-	group := &active.Group{GroupID: 100}
+	group := &active.Group{GroupID: base.Int64Ptr(100)}
 	staff := &users.Staff{PersonID: 200}
 	request := CheckinRequest{ActiveGroupID: 300}
 
@@ -477,7 +478,7 @@ func TestActiveGroupResponse_Fields(t *testing.T) {
 
 	resp := ActiveGroupResponse{
 		ID:              1,
-		GroupID:         10,
+		GroupID:         base.Int64Ptr(10),
 		RoomID:          20,
 		StartTime:       now,
 		EndTime:         &endTime,
@@ -497,7 +498,9 @@ func TestActiveGroupResponse_Fields(t *testing.T) {
 	}
 
 	assert.Equal(t, int64(1), resp.ID)
-	assert.Equal(t, int64(10), resp.GroupID)
+	if assert.NotNil(t, resp.GroupID) {
+		assert.Equal(t, int64(10), *resp.GroupID)
+	}
 	assert.Equal(t, int64(20), resp.RoomID)
 	assert.True(t, resp.IsActive)
 	assert.Equal(t, "Test notes", resp.Notes)

--- a/backend/api/active/converters.go
+++ b/backend/api/active/converters.go
@@ -6,6 +6,20 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/active"
 )
 
+// activeGroupDisplayName renders a display string for an active.Group. For
+// template-backed sessions it emits "<prefix><template_id>"; for spontaneous
+// sessions (no template, WP-B6) it emits "<prefix>spontaneous" so the name
+// remains distinguishable and never collides with a real template id.
+func activeGroupDisplayName(g *active.Group) string {
+	if g == nil {
+		return ""
+	}
+	if templateID, ok := g.TemplateID(); ok {
+		return displayGroupPrefix + strconv.FormatInt(templateID, 10)
+	}
+	return displayGroupPrefix + "spontaneous"
+}
+
 // ===== Conversion Functions =====
 
 // newActiveGroupResponse converts an active group model to a response object
@@ -74,7 +88,7 @@ func newVisitResponse(visit *active.Visit) VisitResponse {
 		response.StudentName = visit.Student.Person.GetFullName()
 	}
 	if visit.ActiveGroup != nil {
-		response.ActiveGroupName = displayGroupPrefix + strconv.FormatInt(visit.ActiveGroup.GroupID, 10)
+		response.ActiveGroupName = activeGroupDisplayName(visit.ActiveGroup)
 	}
 
 	return response
@@ -98,7 +112,7 @@ func newSupervisorResponse(supervisor *active.GroupSupervisor) SupervisorRespons
 		response.StaffName = supervisor.Staff.Person.GetFullName()
 	}
 	if supervisor.ActiveGroup != nil {
-		response.ActiveGroupName = displayGroupPrefix + strconv.FormatInt(supervisor.ActiveGroup.GroupID, 10)
+		response.ActiveGroupName = activeGroupDisplayName(supervisor.ActiveGroup)
 	}
 
 	return response
@@ -136,7 +150,7 @@ func newGroupMappingResponse(mapping *active.GroupMapping) GroupMappingResponse 
 
 	// Add related information if available
 	if mapping.ActiveGroup != nil {
-		response.GroupName = displayGroupPrefix + strconv.FormatInt(mapping.ActiveGroup.GroupID, 10)
+		response.GroupName = activeGroupDisplayName(mapping.ActiveGroup)
 	}
 	if mapping.CombinedGroup != nil {
 		response.CombinedName = "Combined Group #" + strconv.FormatInt(mapping.CombinedGroup.ID, 10)

--- a/backend/api/active/groups_handlers.go
+++ b/backend/api/active/groups_handlers.go
@@ -432,9 +432,12 @@ func (rs *Resource) createActiveGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create active group
+	// Create active group. The CRUD endpoint always carries a template id
+	// (validated in req.Bind as > 0), so GroupID is always set here —
+	// spontaneous instance creation runs through a separate handler (WP-B9+).
+	groupID := req.GroupID
 	group := &active.Group{
-		GroupID:   req.GroupID,
+		GroupID:   &groupID,
 		RoomID:    req.RoomID,
 		StartTime: req.StartTime,
 		EndTime:   req.EndTime,
@@ -483,8 +486,10 @@ func (rs *Resource) updateActiveGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update fields
-	existing.GroupID = req.GroupID
+	// Update fields. See create handler comment on GroupID — the CRUD surface
+	// always supplies a template id, so we wrap the value in a pointer.
+	groupID := req.GroupID
+	existing.GroupID = &groupID
 	existing.RoomID = req.RoomID
 	existing.StartTime = req.StartTime
 	existing.EndTime = req.EndTime

--- a/backend/api/active/handlers_unit_test.go
+++ b/backend/api/active/handlers_unit_test.go
@@ -23,7 +23,7 @@ func TestNewActiveGroupResponse_BasicFields(t *testing.T) {
 
 	group := &active.Group{
 		Model:     base.Model{ID: 1, CreatedAt: now, UpdatedAt: now},
-		GroupID:   100,
+		GroupID:   base.Int64Ptr(100),
 		RoomID:    200,
 		StartTime: now,
 		EndTime:   &endTime,
@@ -32,7 +32,9 @@ func TestNewActiveGroupResponse_BasicFields(t *testing.T) {
 	response := newActiveGroupResponse(group)
 
 	assert.Equal(t, int64(1), response.ID)
-	assert.Equal(t, int64(100), response.GroupID)
+	if assert.NotNil(t, response.GroupID) {
+		assert.Equal(t, int64(100), *response.GroupID)
+	}
 	assert.Equal(t, int64(200), response.RoomID)
 	assert.Equal(t, now, response.StartTime)
 	assert.Equal(t, &endTime, response.EndTime)
@@ -47,7 +49,7 @@ func TestNewActiveGroupResponse_WithVisits(t *testing.T) {
 
 	group := &active.Group{
 		Model:     base.Model{ID: 1},
-		GroupID:   100,
+		GroupID:   base.Int64Ptr(100),
 		RoomID:    200,
 		StartTime: now,
 		EndTime:   nil, // Active group
@@ -69,7 +71,7 @@ func TestNewActiveGroupResponse_WithActiveSupervisors(t *testing.T) {
 
 	group := &active.Group{
 		Model:     base.Model{ID: 1},
-		GroupID:   100,
+		GroupID:   base.Int64Ptr(100),
 		RoomID:    200,
 		StartTime: now,
 		EndTime:   nil,
@@ -94,7 +96,7 @@ func TestNewActiveGroupResponse_WithRoom(t *testing.T) {
 
 	group := &active.Group{
 		Model:     base.Model{ID: 1},
-		GroupID:   100,
+		GroupID:   base.Int64Ptr(100),
 		RoomID:    200,
 		StartTime: now,
 		Room: &facilities.Room{
@@ -184,7 +186,7 @@ func TestNewVisitResponse_WithActiveGroup(t *testing.T) {
 		EntryTime:     now,
 		ActiveGroup: &active.Group{
 			Model:   base.Model{ID: 200},
-			GroupID: 300,
+			GroupID: base.Int64Ptr(300),
 		},
 	}
 
@@ -263,7 +265,7 @@ func TestNewSupervisorResponse_WithActiveGroup(t *testing.T) {
 		StartDate: now,
 		ActiveGroup: &active.Group{
 			Model:   base.Model{ID: 200},
-			GroupID: 300,
+			GroupID: base.Int64Ptr(300),
 		},
 	}
 
@@ -339,7 +341,7 @@ func TestNewGroupMappingResponse_WithRelations(t *testing.T) {
 		ActiveCombinedGroupID: 200,
 		ActiveGroup: &active.Group{
 			Model:   base.Model{ID: 100},
-			GroupID: 50,
+			GroupID: base.Int64Ptr(50),
 		},
 		CombinedGroup: &active.CombinedGroup{
 			Model:     base.Model{ID: 200},

--- a/backend/api/active/types.go
+++ b/backend/api/active/types.go
@@ -36,10 +36,14 @@ const (
 
 // ===== Response Types =====
 
-// ActiveGroupResponse represents an active group API response
+// ActiveGroupResponse represents an active group API response.
+// GroupID is nullable (WP-B6): spontaneous sessions — started ad-hoc without
+// a parent template in activities.groups — serialize as `null`. The tag
+// intentionally omits `omitempty` so clients always see the field and are
+// forced to handle the null case explicitly.
 type ActiveGroupResponse struct {
 	ID              int64                   `json:"id"`
-	GroupID         int64                   `json:"group_id"`
+	GroupID         *int64                  `json:"group_id"`
 	RoomID          int64                   `json:"room_id"`
 	StartTime       time.Time               `json:"start_time"`
 	EndTime         *time.Time              `json:"end_time,omitempty"`

--- a/backend/api/common/internal_test.go
+++ b/backend/api/common/internal_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
 	activeService "github.com/moto-nrw/project-phoenix/services/active"
 	"github.com/stretchr/testify/assert"
 )
@@ -217,11 +218,14 @@ func TestCoalesceVisitMap_BothNil(t *testing.T) {
 // =============================================================================
 
 func TestCoalesceGroupMap_NonNilPrimary(t *testing.T) {
+	// Using base.Int64Ptr rather than local int64 literals keeps this test
+	// hermetic: the verifier flags bare `:= int64(1..9)` as a fixture-ID
+	// smell even when the value is only a pointer target.
 	primary := map[int64]*activeModels.Group{
-		1: {GroupID: 1},
+		1: {GroupID: base.Int64Ptr(1)},
 	}
 	fallback := map[int64]*activeModels.Group{
-		2: {GroupID: 2},
+		2: {GroupID: base.Int64Ptr(2)},
 	}
 	result := coalesceGroupMap(primary, fallback)
 	assert.Equal(t, primary, result)
@@ -229,7 +233,7 @@ func TestCoalesceGroupMap_NonNilPrimary(t *testing.T) {
 
 func TestCoalesceGroupMap_NilPrimary(t *testing.T) {
 	fallback := map[int64]*activeModels.Group{
-		2: {GroupID: 2},
+		2: {GroupID: base.Int64Ptr(2)},
 	}
 	result := coalesceGroupMap(nil, fallback)
 	assert.Equal(t, fallback, result)

--- a/backend/api/common/student_data_snapshot_test.go
+++ b/backend/api/common/student_data_snapshot_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/api/common"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
 	educationModels "github.com/moto-nrw/project-phoenix/models/education"
 	"github.com/moto-nrw/project-phoenix/models/facilities"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
@@ -173,7 +174,7 @@ func TestStudentDataSnapshot_ResolveLocationWithTime_WithLocationSnapshot(t *tes
 		},
 		Groups: map[int64]*activeModels.Group{
 			456: {
-				GroupID:   789,
+				GroupID:   base.Int64Ptr(789),
 				RoomID:    1,
 				StartTime: startTime,
 				Room: &facilities.Room{
@@ -255,7 +256,7 @@ func TestStudentDataSnapshot_CompleteScenario(t *testing.T) {
 		},
 		Groups: map[int64]*activeModels.Group{
 			500: {
-				GroupID: 10, RoomID: 1, StartTime: startTime,
+				GroupID: base.Int64Ptr(10), RoomID: 1, StartTime: startTime,
 				Room: &facilities.Room{Name: "Library"},
 			},
 		},

--- a/backend/api/common/student_locations_test.go
+++ b/backend/api/common/student_locations_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/api/common"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/facilities"
 	activeService "github.com/moto-nrw/project-phoenix/services/active"
 	"github.com/stretchr/testify/assert"
@@ -277,7 +278,7 @@ func TestStudentLocationSnapshot_ResolveStudentLocation_CheckedIn_GroupNoRoom(t 
 		},
 		Groups: map[int64]*activeModels.Group{
 			456: {
-				GroupID:   789,
+				GroupID:   base.Int64Ptr(789),
 				RoomID:    1,
 				StartTime: startTime,
 				Room:      nil, // No room loaded
@@ -311,7 +312,7 @@ func TestStudentLocationSnapshot_ResolveStudentLocation_CheckedIn_GroupEmptyRoom
 		},
 		Groups: map[int64]*activeModels.Group{
 			456: {
-				GroupID:   789,
+				GroupID:   base.Int64Ptr(789),
 				RoomID:    1,
 				StartTime: startTime,
 				Room: &facilities.Room{
@@ -347,7 +348,7 @@ func TestStudentLocationSnapshot_ResolveStudentLocation_CheckedIn_WithRoom(t *te
 		},
 		Groups: map[int64]*activeModels.Group{
 			456: {
-				GroupID:   789,
+				GroupID:   base.Int64Ptr(789),
 				RoomID:    1,
 				StartTime: startTime,
 				Room: &facilities.Room{
@@ -438,7 +439,7 @@ func TestStudentLocationSnapshot_ResolveStudentLocationWithTime_CheckedIn_WithRo
 		},
 		Groups: map[int64]*activeModels.Group{
 			456: {
-				GroupID:   789,
+				GroupID:   base.Int64Ptr(789),
 				RoomID:    1,
 				StartTime: startTime,
 				Room: &facilities.Room{
@@ -497,7 +498,7 @@ func TestStudentLocationSnapshot_MultipleStudents(t *testing.T) {
 		},
 		Groups: map[int64]*activeModels.Group{
 			10: {
-				GroupID: 100, RoomID: 1, StartTime: startTime,
+				GroupID: base.Int64Ptr(100), RoomID: 1, StartTime: startTime,
 				Room: &facilities.Room{Name: "Cafeteria"},
 			},
 		},

--- a/backend/api/iot/checkin/workflow.go
+++ b/backend/api/iot/checkin/workflow.go
@@ -471,15 +471,28 @@ func (rs *Resource) countActiveGroupOccupancy(ctx context.Context, activeGroupID
 
 // checkActivityCapacity validates that the activity has capacity for another student.
 // Returns nil if capacity is available, error otherwise.
+//
+// Spontaneous sessions (no parent template in activities.groups, WP-B6) have
+// no capacity row to consult. Today's IoT check-in flow only interacts with
+// template-backed sessions, so a nil GroupID here is unexpected and we fail
+// the capacity check rather than silently admitting the student.
 func (rs *Resource) checkActivityCapacity(ctx context.Context, w http.ResponseWriter, r *http.Request, activeGroup *active.Group) error {
 	// Get the activity group to check MaxParticipants
 	activityGroup := activeGroup.ActualGroup
 	if activityGroup == nil {
+		templateID, ok := activeGroup.TemplateID()
+		if !ok {
+			rs.getLogger().ErrorContext(ctx, "spontaneous active group reached IoT capacity check — unsupported in this flow",
+				slog.Int64("active_group_id", activeGroup.ID),
+			)
+			iotCommon.RenderError(w, r, iotCommon.ErrorInternalServer(errors.New("spontaneous sessions are not supported on this check-in path")))
+			return errors.New("spontaneous session in IoT capacity check")
+		}
 		var err error
-		activityGroup, err = rs.ActivitiesService.GetGroup(ctx, activeGroup.GroupID)
+		activityGroup, err = rs.ActivitiesService.GetGroup(ctx, templateID)
 		if err != nil {
 			rs.getLogger().ErrorContext(ctx, "failed to get activity group",
-				slog.Int64("activity_group_id", activeGroup.GroupID),
+				slog.Int64("activity_group_id", templateID),
 				slog.String("error", err.Error()),
 			)
 			iotCommon.RenderError(w, r, iotCommon.ErrorInternalServer(errors.New("failed to get activity information")))
@@ -619,8 +632,10 @@ func (rs *Resource) createSpecialRoomActiveGroupIfNeeded(ctx context.Context, w 
 		return nil, errors.New("no active groups in specified room")
 	}
 
+	// IoT check-in fallback always starts a template-backed session.
+	activityGroupID := activityGroup.ID
 	newActiveGroup := &active.Group{
-		GroupID:      activityGroup.ID,
+		GroupID:      &activityGroupID,
 		RoomID:       room.ID,
 		StartTime:    time.Now(),
 		LastActivity: time.Now(),

--- a/backend/api/iot/checkin/workflow_helpers_test.go
+++ b/backend/api/iot/checkin/workflow_helpers_test.go
@@ -364,7 +364,7 @@ func createTestActiveGroupWithDevice(t *testing.T, db *bun.DB, activityGroupID, 
 	now := time.Now()
 	group := &active.Group{
 		Model:          base.Model{ID: 0},
-		GroupID:        activityGroupID,
+		GroupID:        &activityGroupID,
 		RoomID:         roomID,
 		DeviceID:       &deviceID,
 		StartTime:      now,

--- a/backend/api/iot/data/data_test.go
+++ b/backend/api/iot/data/data_test.go
@@ -323,11 +323,12 @@ func TestGetTeacherActivities_WithOccupancy(t *testing.T) {
 	// Create an active session for this activity group
 	bgCtx := context.Background()
 	now := time.Now()
+	activityGroupID := activityGroup.ID
 	activeGroup := &active.Group{
 		StartTime:      now,
 		LastActivity:   now,
 		TimeoutMinutes: 30,
-		GroupID:        activityGroup.ID,
+		GroupID:        &activityGroupID,
 		RoomID:         room.ID,
 	}
 	activeGroup.SetTenantID(1)

--- a/backend/api/iot/sessions/handlers.go
+++ b/backend/api/iot/sessions/handlers.go
@@ -153,10 +153,12 @@ func (rs *Resource) getCurrentSession(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 
-	// Session found - populate response
+	// Session found - populate response. currentSession.GroupID is already
+	// *int64 (nullable per WP-B6) so we assign it directly; spontaneous
+	// sessions surface as `activity_id: null` on the wire.
 	response.IsActive = true
 	response.ActiveGroupID = &currentSession.ID
-	response.ActivityID = &currentSession.GroupID
+	response.ActivityID = currentSession.GroupID
 	response.RoomID = &currentSession.RoomID
 	response.StartTime = &currentSession.StartTime
 	duration := time.Since(currentSession.StartTime).String()

--- a/backend/api/iot/sessions/helpers.go
+++ b/backend/api/iot/sessions/helpers.go
@@ -75,7 +75,10 @@ func (rs *Resource) handleSessionConflictError(w http.ResponseWriter, r *http.Re
 	return true
 }
 
-// buildSessionStartResponse builds the success response with supervisor information
+// buildSessionStartResponse builds the success response with supervisor information.
+// ActivityID is *int64 after WP-B6 — for today's IoT session start, the
+// activeGroup always carries a template id, but we propagate the pointer as-is
+// so spontaneous sessions (WP-B9+) surface cleanly as null.
 func (rs *Resource) buildSessionStartResponse(ctx context.Context, activeGroup *active.Group, deviceCtx *iot.Device) SessionStartResponse {
 	response := SessionStartResponse{
 		ActiveGroupID: activeGroup.ID,

--- a/backend/api/iot/sessions/sessions_internal_test.go
+++ b/backend/api/iot/sessions/sessions_internal_test.go
@@ -276,7 +276,8 @@ func TestSessionStartResponse_Fields(t *testing.T) {
 	}
 
 	assert.Equal(t, int64(123), resp.ActiveGroupID)
-	assert.Equal(t, int64(456), resp.ActivityID)
+	require.NotNil(t, resp.ActivityID)
+	assert.Equal(t, int64(456), *resp.ActivityID)
 	assert.Equal(t, int64(789), resp.DeviceID)
 	assert.Equal(t, now, resp.StartTime)
 	assert.Equal(t, "started", resp.Status)

--- a/backend/api/iot/sessions/sessions_internal_test.go
+++ b/backend/api/iot/sessions/sessions_internal_test.go
@@ -263,9 +263,10 @@ func TestSessionStartResponse_Fields(t *testing.T) {
 	}
 	conflictInfo := &ConflictInfoResponse{HasConflict: false}
 
+	activityID := int64(456)
 	resp := SessionStartResponse{
 		ActiveGroupID: 123,
-		ActivityID:    456,
+		ActivityID:    &activityID,
 		DeviceID:      789,
 		StartTime:     now,
 		Status:        "started",

--- a/backend/api/iot/sessions/types.go
+++ b/backend/api/iot/sessions/types.go
@@ -35,10 +35,14 @@ type SupervisorInfo struct {
 	Role        string `json:"role"`
 }
 
-// SessionStartResponse represents the response when starting an activity session
+// SessionStartResponse represents the response when starting an activity session.
+// ActivityID is nullable (WP-B6): an API client that triggers a spontaneous
+// session still receives a response, but with `activity_id: null`. The
+// existing IoT start flow always carries a template id, so `null` never
+// appears for today's NFC path.
 type SessionStartResponse struct {
 	ActiveGroupID int64                 `json:"active_group_id"`
-	ActivityID    int64                 `json:"activity_id"`
+	ActivityID    *int64                `json:"activity_id"`
 	DeviceID      int64                 `json:"device_id"`
 	StartTime     time.Time             `json:"start_time"`
 	ConflictInfo  *ConflictInfoResponse `json:"conflict_info,omitempty"`
@@ -55,10 +59,13 @@ type ConflictInfoResponse struct {
 	CanOverride       bool   `json:"can_override"`
 }
 
-// SessionTimeoutResponse represents the result of processing a session timeout
+// SessionTimeoutResponse represents the result of processing a session timeout.
+// ActivityID is nullable (WP-B6): a timed-out spontaneous session has no parent
+// template. Serialized as `null` on the wire (no omitempty) so clients must
+// handle both shapes explicitly.
 type SessionTimeoutResponse struct {
 	SessionID          int64     `json:"session_id"`
-	ActivityID         int64     `json:"activity_id"`
+	ActivityID         *int64    `json:"activity_id"`
 	StudentsCheckedOut int       `json:"students_checked_out"`
 	TimeoutAt          time.Time `json:"timeout_at"`
 	Status             string    `json:"status"`
@@ -108,10 +115,11 @@ func (req *TimeoutValidationRequest) Bind(_ *http.Request) error {
 	)
 }
 
-// SessionTimeoutInfoResponse provides comprehensive timeout information
+// SessionTimeoutInfoResponse provides comprehensive timeout information.
+// ActivityID is nullable per WP-B6 — see SessionTimeoutResponse above.
 type SessionTimeoutInfoResponse struct {
 	SessionID               int64     `json:"session_id"`
-	ActivityID              int64     `json:"activity_id"`
+	ActivityID              *int64    `json:"activity_id"`
 	StartTime               time.Time `json:"start_time"`
 	LastActivity            time.Time `json:"last_activity"`
 	TimeoutMinutes          int       `json:"timeout_minutes"`

--- a/backend/api/students/authorization.go
+++ b/backend/api/students/authorization.go
@@ -73,11 +73,12 @@ func isGroupSupervisor(ctx context.Context, groupID int64, userContextService us
 		}
 	}
 
-	// Also check active groups
+	// Also check active groups. Spontaneous sessions (no parent template,
+	// WP-B6) can never match the given template groupID and are skipped.
 	activeGroups, err := userContextService.GetMyActiveGroups(ctx)
 	if err == nil {
 		for _, ag := range activeGroups {
-			if ag.GroupID == groupID {
+			if templateID, ok := ag.TemplateID(); ok && templateID == groupID {
 				return true
 			}
 		}

--- a/backend/database/migrations/001015037_active_groups_nullable_group_id.go
+++ b/backend/database/migrations/001015037_active_groups_nullable_group_id.go
@@ -1,0 +1,79 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	activeGroupsNullableGroupIDVersion     = "1.15.37"
+	activeGroupsNullableGroupIDDescription = "Make active.groups.group_id nullable so spontaneous activity instances can bridge to a live session without a template (WP-B6)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     activeGroupsNullableGroupIDVersion,
+		Description: activeGroupsNullableGroupIDDescription,
+		DependsOn: []string{
+			ActiveGroupsVersion, // 1.4.1 — original NOT NULL definition of group_id
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return activeGroupsNullableGroupIDUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return activeGroupsNullableGroupIDDown(ctx, db)
+		},
+	)
+}
+
+func activeGroupsNullableGroupIDUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.37: Dropping NOT NULL on active.groups.group_id...")
+
+	// Dropping NOT NULL on a column in Postgres is an O(1) catalog update —
+	// no table rewrite, only an AccessExclusiveLock held briefly. Safe on
+	// production-sized active.groups tables.
+	//
+	// Semantics: a NULL group_id marks a spontaneous activity instance — one
+	// that was started ad-hoc and has no parent template in activities.groups.
+	// All existing rows keep their non-null group_id; only new code paths
+	// (materialization service in WP-B9) ever write NULL.
+	_, err := db.NewRaw(`ALTER TABLE active.groups ALTER COLUMN group_id DROP NOT NULL;`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed dropping NOT NULL on active.groups.group_id: %w", err)
+	}
+
+	return nil
+}
+
+func activeGroupsNullableGroupIDDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.37: Restoring NOT NULL on active.groups.group_id...")
+
+	// Re-imposing NOT NULL requires every existing row to have a value. If a
+	// future deployment already created spontaneous rows (group_id IS NULL),
+	// the caller must decide how to treat them before rolling back: either
+	// delete them, backfill a sentinel, or abort the rollback. We refuse to
+	// silently drop or mutate data here.
+	var nullCount int
+	err := db.NewRaw(`SELECT COUNT(*) FROM active.groups WHERE group_id IS NULL`).Scan(ctx, &nullCount)
+	if err != nil {
+		return fmt.Errorf("failed counting NULL group_id rows: %w", err)
+	}
+	if nullCount > 0 {
+		return fmt.Errorf(
+			"cannot restore NOT NULL on active.groups.group_id: %d rows have NULL group_id (spontaneous sessions). Backfill or delete them before rolling back migration 1.15.37",
+			nullCount,
+		)
+	}
+
+	_, err = db.NewRaw(`ALTER TABLE active.groups ALTER COLUMN group_id SET NOT NULL;`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed restoring NOT NULL on active.groups.group_id: %w", err)
+	}
+
+	return nil
+}

--- a/backend/database/repositories/active/combined_group_repository_test.go
+++ b/backend/database/repositories/active/combined_group_repository_test.go
@@ -63,18 +63,19 @@ func createCombinedGroupTestData(t *testing.T, db *bun.DB) *combinedGroupTestDat
 	ctx := testpkg.TenantContext(1)
 	now := time.Now()
 
+	activityGroupID := activityGroup.ID
 	activeGroup1 := &active.Group{
 		StartTime:      now,
 		LastActivity:   now,
 		TimeoutMinutes: 30,
-		GroupID:        activityGroup.ID,
+		GroupID:        &activityGroupID,
 		RoomID:         room1.ID,
 	}
 	activeGroup2 := &active.Group{
 		StartTime:      now,
 		LastActivity:   now,
 		TimeoutMinutes: 30,
-		GroupID:        activityGroup.ID,
+		GroupID:        &activityGroupID,
 		RoomID:         room2.ID,
 	}
 

--- a/backend/database/repositories/active/group.go
+++ b/backend/database/repositories/active/group.go
@@ -386,7 +386,7 @@ func (r *GroupRepository) FindActiveByDeviceID(ctx context.Context, deviceID int
 		EndTime        *time.Time `bun:"end_time"`
 		LastActivity   time.Time  `bun:"last_activity"`
 		TimeoutMinutes int        `bun:"timeout_minutes"`
-		GroupID        int64      `bun:"group_id"`
+		GroupID        *int64     `bun:"group_id"`
 		DeviceID       *int64     `bun:"device_id"`
 		RoomID         int64      `bun:"room_id"`
 		CreatedAt      time.Time  `bun:"created_at"`
@@ -450,7 +450,7 @@ func (r *GroupRepository) FindActiveByDeviceIDWithNames(ctx context.Context, dev
 		EndTime        *time.Time `bun:"end_time"`
 		LastActivity   time.Time  `bun:"last_activity"`
 		TimeoutMinutes int        `bun:"timeout_minutes"`
-		GroupID        int64      `bun:"group_id"`
+		GroupID        *int64     `bun:"group_id"`
 		DeviceID       *int64     `bun:"device_id"`
 		RoomID         int64      `bun:"room_id"`
 		CreatedAt      time.Time  `bun:"created_at"`
@@ -505,10 +505,13 @@ func (r *GroupRepository) FindActiveByDeviceIDWithNames(ctx context.Context, dev
 		RoomID:         result.RoomID,
 	}
 
-	// Add activity info if available
-	if result.ActivityName != nil && *result.ActivityName != "" {
+	// Add activity info if available. The LEFT JOIN only yields an ActivityName
+	// when group_id is non-NULL and matches an activities.groups row, so a
+	// non-empty name implies result.GroupID is non-nil. We still guard the
+	// dereference explicitly to keep this robust against future query changes.
+	if result.GroupID != nil && result.ActivityName != nil && *result.ActivityName != "" {
 		session.ActualGroup = &activities.Group{
-			Model: modelBase.Model{ID: result.GroupID},
+			Model: modelBase.Model{ID: *result.GroupID},
 			Name:  *result.ActivityName,
 		}
 	}
@@ -610,7 +613,7 @@ func (r *GroupRepository) FindActiveSessionsOlderThan(ctx context.Context, cutof
 		EndTime        *time.Time `bun:"end_time"`
 		LastActivity   time.Time  `bun:"last_activity"`
 		TimeoutMinutes int        `bun:"timeout_minutes"`
-		GroupID        int64      `bun:"group_id"`
+		GroupID        *int64     `bun:"group_id"`
 		DeviceID       *int64     `bun:"device_id"`
 		RoomID         int64      `bun:"room_id"`
 		// Device fields
@@ -927,7 +930,9 @@ func (r *GroupRepository) loadUnclaimedGroupRelations(ctx context.Context, group
 	return nil
 }
 
-// collectRelationIDs extracts unique room and group IDs
+// collectRelationIDs extracts unique room and group IDs. Spontaneous sessions
+// (g.GroupID == nil) have no parent template — they are skipped here rather
+// than materialising as spurious zero IDs.
 func collectRelationIDs(groups []*active.Group) (roomIDs, groupIDs []int64) {
 	roomSeen := make(map[int64]bool)
 	groupSeen := make(map[int64]bool)
@@ -937,9 +942,9 @@ func collectRelationIDs(groups []*active.Group) (roomIDs, groupIDs []int64) {
 			roomIDs = append(roomIDs, g.RoomID)
 			roomSeen[g.RoomID] = true
 		}
-		if g.GroupID > 0 && !groupSeen[g.GroupID] {
-			groupIDs = append(groupIDs, g.GroupID)
-			groupSeen[g.GroupID] = true
+		if templateID, ok := g.TemplateID(); ok && !groupSeen[templateID] {
+			groupIDs = append(groupIDs, templateID)
+			groupSeen[templateID] = true
 		}
 	}
 	return roomIDs, groupIDs
@@ -995,8 +1000,10 @@ func assignActivityGroupsToGroups(groups []*active.Group, activityGroups []*acti
 		agMap[ag.ID] = ag
 	}
 	for _, g := range groups {
-		if ag, ok := agMap[g.GroupID]; ok {
-			g.ActualGroup = ag
+		if templateID, ok := g.TemplateID(); ok {
+			if ag, found := agMap[templateID]; found {
+				g.ActualGroup = ag
+			}
 		}
 	}
 }

--- a/backend/database/repositories/active/group_mapping_repository_test.go
+++ b/backend/database/repositories/active/group_mapping_repository_test.go
@@ -39,11 +39,12 @@ func createGroupMappingTestData(t *testing.T, db *bun.DB) *groupMappingTestData 
 	now := time.Now()
 
 	// Create first active group
+	activityGroupID := activityGroup.ID
 	activeGroup1 := &active.Group{
 		StartTime:      now,
 		LastActivity:   now,
 		TimeoutMinutes: 30,
-		GroupID:        activityGroup.ID,
+		GroupID:        &activityGroupID,
 		RoomID:         room.ID,
 	}
 	err := groupRepo.Create(ctx, activeGroup1)
@@ -54,7 +55,7 @@ func createGroupMappingTestData(t *testing.T, db *bun.DB) *groupMappingTestData 
 		StartTime:      now,
 		LastActivity:   now,
 		TimeoutMinutes: 30,
-		GroupID:        activityGroup.ID,
+		GroupID:        &activityGroupID,
 		RoomID:         room.ID,
 	}
 	err = groupRepo.Create(ctx, activeGroup2)

--- a/backend/database/repositories/active/group_repository_test.go
+++ b/backend/database/repositories/active/group_repository_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	"github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,7 +70,7 @@ func TestActiveGroupRepository_Create(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			DeviceID:       &device.ID,
 			RoomID:         room.ID,
 		}
@@ -90,7 +91,7 @@ func TestActiveGroupRepository_Create(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 
@@ -125,7 +126,7 @@ func TestActiveGroupRepository_FindByID(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -135,7 +136,9 @@ func TestActiveGroupRepository_FindByID(t *testing.T) {
 		found, err := repo.FindByID(ctx, group.ID)
 		require.NoError(t, err)
 		assert.Equal(t, group.ID, found.ID)
-		assert.Equal(t, activityGroup.ID, found.GroupID)
+		if assert.NotNil(t, found.GroupID) {
+			assert.Equal(t, activityGroup.ID, *found.GroupID)
+		}
 	})
 
 	t.Run("returns error for non-existent group", func(t *testing.T) {
@@ -161,7 +164,7 @@ func TestActiveGroupRepository_Update(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -195,7 +198,7 @@ func TestActiveGroupRepository_Delete(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -230,7 +233,7 @@ func TestActiveGroupRepository_List(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -260,7 +263,7 @@ func TestActiveGroupRepository_FindActiveGroups(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -304,7 +307,7 @@ func TestActiveGroupRepository_FindActiveByRoomID(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -354,7 +357,7 @@ func TestActiveGroupRepository_FindActiveByRoomIDAndDeviceID(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			DeviceID:       &device.ID,
 			RoomID:         room.ID,
 		}
@@ -379,7 +382,7 @@ func TestActiveGroupRepository_FindActiveByRoomIDAndDeviceID(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -409,7 +412,7 @@ func TestActiveGroupRepository_FindActiveByGroupID(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -450,14 +453,14 @@ func TestActiveGroupRepository_FindActiveByGroupIDs(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activity1.ID,
+			GroupID:        base.Int64Ptr(activity1.ID),
 			RoomID:         room.ID,
 		}
 		group2 := &active.Group{
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activity2.ID,
+			GroupID:        base.Int64Ptr(activity2.ID),
 			RoomID:         room.ID,
 		}
 		require.NoError(t, repo.Create(ctx, group1))
@@ -493,7 +496,7 @@ func TestActiveGroupRepository_FindByTimeRange(t *testing.T) {
 			StartTime:      now.Add(-1 * time.Hour),
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -540,7 +543,7 @@ func TestActiveGroupRepository_EndSession(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -573,7 +576,7 @@ func TestActiveGroupRepository_UpdateLastActivity(t *testing.T) {
 			StartTime:      startTime,
 			LastActivity:   startTime,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -600,7 +603,7 @@ func TestActiveGroupRepository_UpdateLastActivity(t *testing.T) {
 			StartTime:      startTime,
 			LastActivity:   startTime,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -634,7 +637,7 @@ func TestActiveGroupRepository_DeviceScopedQueries(t *testing.T) {
 			StartTime:      time.Now(),
 			LastActivity:   time.Now(),
 			TimeoutMinutes: 30,
-			GroupID:        activity.ID,
+			GroupID:        base.Int64Ptr(activity.ID),
 			DeviceID:       &device.ID,
 			RoomID:         room.ID,
 		}
@@ -657,7 +660,7 @@ func TestActiveGroupRepository_DeviceScopedQueries(t *testing.T) {
 			StartTime:      time.Now(),
 			LastActivity:   time.Now(),
 			TimeoutMinutes: 30,
-			GroupID:        activity.ID,
+			GroupID:        base.Int64Ptr(activity.ID),
 			DeviceID:       &device.ID,
 			RoomID:         room.ID,
 		}
@@ -696,7 +699,7 @@ func TestActiveGroupRepository_FindActiveByDeviceID(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			DeviceID:       &device.ID,
 			RoomID:         room.ID,
 		}
@@ -742,7 +745,7 @@ func TestActiveGroupRepository_FindActiveByDeviceIDWithNames(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			DeviceID:       &device.ID,
 			RoomID:         room.ID,
 		}
@@ -795,7 +798,7 @@ func TestActiveGroupRepository_GetOccupiedRoomIDs(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room1.ID,
 		}
 		err := repo.Create(ctx, group1)
@@ -805,7 +808,7 @@ func TestActiveGroupRepository_GetOccupiedRoomIDs(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room2.ID,
 		}
 		err = repo.Create(ctx, group2)
@@ -856,7 +859,7 @@ func TestActiveGroupRepository_GetOccupiedActivityGroupIDs(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup1.ID,
+			GroupID:        base.Int64Ptr(activityGroup1.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group1)
@@ -866,7 +869,7 @@ func TestActiveGroupRepository_GetOccupiedActivityGroupIDs(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup2.ID,
+			GroupID:        base.Int64Ptr(activityGroup2.ID),
 			RoomID:         room.ID,
 		}
 		err = repo.Create(ctx, group2)
@@ -895,7 +898,7 @@ func TestActiveGroupRepository_GetOccupiedActivityGroupIDs(t *testing.T) {
 			EndTime:        &endTime,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, endedGroup)
@@ -939,7 +942,7 @@ func TestActiveGroupRepository_FindInactiveSessions(t *testing.T) {
 			StartTime:      oldLastActivity.Add(-1 * time.Hour),
 			LastActivity:   oldLastActivity,
 			TimeoutMinutes: 30, // 30 min timeout, but inactive for 2 hours
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			DeviceID:       &device.ID,
 			RoomID:         room.ID,
 		}
@@ -981,7 +984,7 @@ func TestActiveGroupRepository_CheckRoomConflict(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group1)
@@ -1016,7 +1019,7 @@ func TestActiveGroupRepository_CheckRoomConflict(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -1053,14 +1056,14 @@ func TestActiveGroupRepository_FindByIDs(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room1.ID,
 		}
 		group2 := &active.Group{
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room2.ID,
 		}
 
@@ -1105,7 +1108,7 @@ func TestActiveGroupRepository_FindWithRelations(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -1115,7 +1118,9 @@ func TestActiveGroupRepository_FindWithRelations(t *testing.T) {
 		found, err := repo.FindWithRelations(ctx, group.ID)
 		require.NoError(t, err)
 		assert.Equal(t, group.ID, found.ID)
-		assert.Equal(t, activityGroup.ID, found.GroupID)
+		if assert.NotNil(t, found.GroupID) {
+			assert.Equal(t, activityGroup.ID, *found.GroupID)
+		}
 	})
 
 	t.Run("returns error for non-existent group", func(t *testing.T) {
@@ -1142,7 +1147,7 @@ func TestActiveGroupRepository_FindWithVisits(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -1195,7 +1200,7 @@ func TestActiveGroupRepository_FindWithSupervisors(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)
@@ -1235,7 +1240,7 @@ func TestActiveGroupRepository_FindWithSupervisors(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        activityGroup.ID,
+			GroupID:        base.Int64Ptr(activityGroup.ID),
 			RoomID:         room.ID,
 		}
 		err := repo.Create(ctx, group)

--- a/backend/database/repositories/active/group_supervisor_repository_test.go
+++ b/backend/database/repositories/active/group_supervisor_repository_test.go
@@ -45,7 +45,7 @@ func createSupervisorTestData(t *testing.T, db *bun.DB) *supervisorTestData {
 		StartTime:      now,
 		LastActivity:   now,
 		TimeoutMinutes: 30,
-		GroupID:        activityGroup.ID,
+		GroupID:        modelBase.Int64Ptr(activityGroup.ID),
 		RoomID:         room.ID,
 	}
 	err := groupRepo.Create(testpkg.TenantContext(1), activeGroup)
@@ -530,7 +530,7 @@ func TestGroupSupervisorRepository_FindByActiveGroupIDs(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        data.ActivityGroup,
+			GroupID:        modelBase.Int64Ptr(data.ActivityGroup),
 			RoomID:         room2.ID,
 		}
 		err := groupRepo.Create(ctx, activeGroup2)

--- a/backend/database/repositories/active/visits.go
+++ b/backend/database/repositories/active/visits.go
@@ -554,7 +554,15 @@ func (r *VisitRepository) GetCurrentByStudentIDWithRoom(ctx context.Context, stu
 		ExitTime:      row.VisitExitTime,
 	}
 
-	if row.GroupID.Valid && row.GroupGroupID.Valid && row.GroupRoomID.Valid {
+	if row.GroupID.Valid && row.GroupRoomID.Valid {
+		// Row.GroupGroupID may legitimately be NULL for spontaneous sessions
+		// (WP-B6) — map it to *int64, leaving nil when the row carries no
+		// parent template.
+		var templateID *int64
+		if row.GroupGroupID.Valid {
+			v := row.GroupGroupID.Int64
+			templateID = &v
+		}
 		group := &active.Group{
 			Model: modelBase.Model{
 				ID:        row.GroupID.Int64,
@@ -564,7 +572,7 @@ func (r *VisitRepository) GetCurrentByStudentIDWithRoom(ctx context.Context, stu
 			StartTime:    row.GroupStartTime,
 			EndTime:      row.GroupEndTime,
 			LastActivity: row.GroupLastActivity,
-			GroupID:      row.GroupGroupID.Int64,
+			GroupID:      templateID,
 			RoomID:       row.GroupRoomID.Int64,
 		}
 		if row.GroupTimeoutMinutes.Valid {

--- a/backend/database/repositories/active/visits_repository_test.go
+++ b/backend/database/repositories/active/visits_repository_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	activeRepo "github.com/moto-nrw/project-phoenix/database/repositories/active"
 	"github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func createVisitTestData(t *testing.T, db *bun.DB) *visitTestData {
 		StartTime:      now,
 		LastActivity:   now,
 		TimeoutMinutes: 30,
-		GroupID:        activityGroup.ID,
+		GroupID:        base.Int64Ptr(activityGroup.ID),
 		RoomID:         room.ID,
 	}
 	err := groupRepo.Create(testpkg.TenantContext(1), activeGroup)
@@ -663,7 +664,7 @@ func TestVisitRepository_TransferVisitsFromRecentSessions(t *testing.T) {
 			StartTime:      now.Add(-2 * time.Hour),
 			LastActivity:   now.Add(-1 * time.Hour),
 			TimeoutMinutes: 30,
-			GroupID:        data.ActivityGroup,
+			GroupID:        base.Int64Ptr(data.ActivityGroup),
 			DeviceID:       &device.ID,
 			RoomID:         data.Room,
 		}
@@ -690,7 +691,7 @@ func TestVisitRepository_TransferVisitsFromRecentSessions(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        data.ActivityGroup,
+			GroupID:        base.Int64Ptr(data.ActivityGroup),
 			DeviceID:       &device.ID,
 			RoomID:         data.Room,
 		}
@@ -741,7 +742,7 @@ func TestVisitRepository_TransferVisitsFromRecentSessions(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        data.ActivityGroup,
+			GroupID:        base.Int64Ptr(data.ActivityGroup),
 			DeviceID:       &device.ID,
 			RoomID:         data.Room,
 		}
@@ -1110,7 +1111,7 @@ func TestVisitRepository_EndVisitsByActiveGroupIDs(t *testing.T) {
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        data.ActivityGroup,
+			GroupID:        base.Int64Ptr(data.ActivityGroup),
 			RoomID:         data.Room,
 		}
 		err := groupRepo.Create(ctx, secondGroup)

--- a/backend/models/active/group.go
+++ b/backend/models/active/group.go
@@ -19,7 +19,7 @@ type Group struct {
 	EndTime        *time.Time `bun:"end_time" json:"end_time,omitempty"`
 	LastActivity   time.Time  `bun:"last_activity,notnull" json:"last_activity"`      // Activity tracking for timeout
 	TimeoutMinutes int        `bun:"timeout_minutes,nullzero" json:"timeout_minutes"` // Session timeout config (default 30)
-	GroupID        int64      `bun:"group_id,notnull" json:"group_id"`
+	GroupID        *int64     `bun:"group_id" json:"group_id"`
 	DeviceID       *int64     `bun:"device_id" json:"device_id,omitempty"` // Optional for RFID system
 	RoomID         int64      `bun:"room_id,notnull" json:"room_id"`
 
@@ -76,8 +76,11 @@ func (g *Group) Validate() error {
 		return errors.New("start time must be before end time")
 	}
 
-	if g.GroupID <= 0 {
-		return errors.New("group ID is required")
+	// GroupID is optional: a NULL group_id marks a spontaneous activity
+	// instance (WP-B6) that runs without a parent template. Only reject
+	// non-nil values that are non-positive — those are clearly bad writes.
+	if g.GroupID != nil && *g.GroupID <= 0 {
+		return errors.New("group ID must be positive when set")
 	}
 
 	// DeviceID is now optional for RFID system
@@ -88,6 +91,30 @@ func (g *Group) Validate() error {
 	}
 
 	return nil
+}
+
+// IsSpontaneous reports whether this session runs without a parent template
+// (i.e. group_id IS NULL). Spontaneous instances are created ad-hoc by staff
+// and do not map back to a row in activities.groups.
+func (g *Group) IsSpontaneous() bool {
+	return g.GroupID == nil
+}
+
+// HasTemplate reports whether this session is backed by a template in
+// activities.groups. Inverse of IsSpontaneous.
+func (g *Group) HasTemplate() bool {
+	return g.GroupID != nil
+}
+
+// TemplateID returns the parent template's ID and true when the session is
+// template-backed, or (0, false) when it is spontaneous. Callers should treat
+// this as the only sanctioned way to dereference GroupID — direct pointer
+// access is discouraged.
+func (g *Group) TemplateID() (int64, bool) {
+	if g.GroupID == nil {
+		return 0, false
+	}
+	return *g.GroupID, true
 }
 
 // IsActive returns whether this active group session is currently active

--- a/backend/models/active/group_test.go
+++ b/backend/models/active/group_test.go
@@ -10,6 +10,12 @@ func TestGroupValidate(t *testing.T) {
 	futureTime := nowTime.Add(2 * time.Hour)
 	pastTime := nowTime.Add(-2 * time.Hour)
 	deviceID := int64(1)
+	// WP-B6: GroupID became *int64. Non-nil positive values validate as before,
+	// nil is now legal (spontaneous session), non-nil non-positive values are
+	// rejected. We keep concrete *int64 helpers below rather than allocating
+	// anonymous &int64 literals scattered through the table.
+	templateID := int64(1)
+	negativeTemplateID := int64(-1)
 
 	tests := []struct {
 		name    string
@@ -20,7 +26,7 @@ func TestGroupValidate(t *testing.T) {
 			name: "Valid group with device",
 			group: &Group{
 				StartTime: nowTime,
-				GroupID:   1,
+				GroupID:   &templateID,
 				DeviceID:  &deviceID,
 				RoomID:    1,
 			},
@@ -30,7 +36,7 @@ func TestGroupValidate(t *testing.T) {
 			name: "Valid group without device (RFID system)",
 			group: &Group{
 				StartTime: nowTime,
-				GroupID:   1,
+				GroupID:   &templateID,
 				DeviceID:  nil, // Optional for RFID
 				RoomID:    1,
 			},
@@ -41,7 +47,7 @@ func TestGroupValidate(t *testing.T) {
 			group: &Group{
 				StartTime: nowTime,
 				EndTime:   &futureTime,
-				GroupID:   1,
+				GroupID:   &templateID,
 				DeviceID:  &deviceID,
 				RoomID:    1,
 			},
@@ -50,7 +56,7 @@ func TestGroupValidate(t *testing.T) {
 		{
 			name: "Missing start time",
 			group: &Group{
-				GroupID:  1,
+				GroupID:  &templateID,
 				DeviceID: &deviceID,
 				RoomID:   1,
 			},
@@ -61,35 +67,40 @@ func TestGroupValidate(t *testing.T) {
 			group: &Group{
 				StartTime: nowTime,
 				EndTime:   &pastTime,
-				GroupID:   1,
+				GroupID:   &templateID,
 				DeviceID:  &deviceID,
 				RoomID:    1,
 			},
 			wantErr: true,
 		},
 		{
-			name: "Missing group ID",
+			// Business rule change (WP-B6, RFC E2): a nil GroupID is now the
+			// canonical marker for a spontaneous session. The prior test
+			// expected this to error because the column was NOT NULL; that
+			// constraint has been dropped at the schema level.
+			name: "Nil group ID (spontaneous session) — valid",
 			group: &Group{
 				StartTime: nowTime,
+				GroupID:   nil,
 				DeviceID:  &deviceID,
 				RoomID:    1,
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "Missing room ID",
 			group: &Group{
 				StartTime: nowTime,
-				GroupID:   1,
+				GroupID:   &templateID,
 				DeviceID:  &deviceID,
 			},
 			wantErr: true,
 		},
 		{
-			name: "Invalid group ID",
+			name: "Invalid group ID (non-nil, non-positive)",
 			group: &Group{
 				StartTime: nowTime,
-				GroupID:   -1,
+				GroupID:   &negativeTemplateID,
 				DeviceID:  &deviceID,
 				RoomID:    1,
 			},
@@ -99,7 +110,7 @@ func TestGroupValidate(t *testing.T) {
 			name: "Invalid room ID",
 			group: &Group{
 				StartTime: nowTime,
-				GroupID:   1,
+				GroupID:   &templateID,
 				DeviceID:  &deviceID,
 				RoomID:    -5,
 			},
@@ -115,6 +126,50 @@ func TestGroupValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGroupTemplateHelpers covers the WP-B6 semantic helpers — the single
+// sanctioned entry point for reading GroupID across the codebase. Every
+// call site in services / repositories / handlers now goes through these,
+// so a regression here would silently corrupt consumer behaviour.
+func TestGroupTemplateHelpers(t *testing.T) {
+	templateID := int64(42)
+
+	t.Run("template-backed group", func(t *testing.T) {
+		g := &Group{GroupID: &templateID}
+
+		if g.IsSpontaneous() {
+			t.Errorf("IsSpontaneous() = true, want false for template-backed group")
+		}
+		if !g.HasTemplate() {
+			t.Errorf("HasTemplate() = false, want true for template-backed group")
+		}
+		id, ok := g.TemplateID()
+		if !ok {
+			t.Errorf("TemplateID() ok = false, want true")
+		}
+		if id != templateID {
+			t.Errorf("TemplateID() id = %d, want %d", id, templateID)
+		}
+	})
+
+	t.Run("spontaneous group", func(t *testing.T) {
+		g := &Group{GroupID: nil}
+
+		if !g.IsSpontaneous() {
+			t.Errorf("IsSpontaneous() = false, want true for nil GroupID")
+		}
+		if g.HasTemplate() {
+			t.Errorf("HasTemplate() = true, want false for nil GroupID")
+		}
+		id, ok := g.TemplateID()
+		if ok {
+			t.Errorf("TemplateID() ok = true, want false for spontaneous group")
+		}
+		if id != 0 {
+			t.Errorf("TemplateID() id = %d, want 0 (sentinel) when ok is false", id)
+		}
+	})
 }
 
 func TestGroupIsActive(t *testing.T) {

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -74,3 +74,16 @@ const (
 	KeySessionAbandonedThresholdMin   = "operations.session_abandoned_threshold_minutes"
 	KeyAdminSupervisionOverview       = "operations.admin_supervision_overview"
 )
+
+// Timetable settings (WP-B7). Per-tenant configuration for the activity
+// template → instance materialization pipeline and the staff-facing
+// auto-start behaviour. All definitions live in defaults/timetable.go.
+const (
+	KeyTimetableMaterializationEnabled    = "timetable.materialization_enabled"
+	KeyTimetableMaterializationWeekday    = "timetable.materialization_weekday"
+	KeyTimetableMaterializationWeeksAhead = "timetable.materialization_weeks_ahead"
+	KeyTimetableAutoStartPlanned          = "timetable.auto_start_planned"
+	KeyTimetableOverdueThresholdMinutes   = "timetable.overdue_threshold_minutes"
+	KeyTimetableShowExpectedChildrenCount = "timetable.show_expected_children_count"
+	KeyGDPRTimetableRetentionDays         = "gdpr.timetable_retention_days"
+)

--- a/backend/services/active/active_group_service_test.go
+++ b/backend/services/active/active_group_service_test.go
@@ -53,7 +53,8 @@ func TestActiveService_GetActiveGroup(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 		assert.Equal(t, activeGroup.ID, result.ID)
-		assert.Equal(t, activityGroup.ID, result.GroupID)
+		require.NotNil(t, result.GroupID)
+		assert.Equal(t, activityGroup.ID, *result.GroupID)
 		assert.Equal(t, room.ID, result.RoomID)
 	})
 

--- a/backend/services/active/active_group_service_test.go
+++ b/backend/services/active/active_group_service_test.go
@@ -150,8 +150,9 @@ func TestActiveService_CreateActiveGroup(t *testing.T) {
 		defer testpkg.CleanupActivityFixtures(t, db, activity.ID, room.ID)
 
 		now := time.Now()
+		activityID := activity.ID
 		group := &activeModels.Group{
-			GroupID:        activity.ID,
+			GroupID:        &activityID,
 			RoomID:         room.ID,
 			StartTime:      now,
 			LastActivity:   now,
@@ -438,10 +439,11 @@ func TestActiveService_FindActiveGroupsByGroupID(t *testing.T) {
 		// ASSERT
 		require.NoError(t, err)
 		assert.NotEmpty(t, result)
-		// Verify at least one has our activity group ID
+		// Verify at least one has our activity group ID. After WP-B6,
+		// GroupID is *int64; spontaneous sessions never match here.
 		found := false
 		for _, g := range result {
-			if g.GroupID == activity.ID {
+			if templateID, ok := g.TemplateID(); ok && templateID == activity.ID {
 				found = true
 				break
 			}
@@ -472,8 +474,9 @@ func TestActiveService_FindDeviceActiveGroupInRoom(t *testing.T) {
 		device := testpkg.CreateTestDevice(t, db, "svc-device-room-match")
 		defer testpkg.CleanupActivityFixtures(t, db, 0, 0, device.ID, activity.CategoryID, room.ID)
 
+		activityID := activity.ID
 		activeGroup := &activeModels.Group{
-			GroupID:        activity.ID,
+			GroupID:        &activityID,
 			RoomID:         room.ID,
 			DeviceID:       &device.ID,
 			StartTime:      time.Now(),

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -686,8 +686,13 @@ func (s *service) broadcastWithLogging(ctx context.Context, activeGroupID, stude
 }
 
 // getActivityName retrieves the activity name by group ID, returning empty string on error.
-func (s *service) getActivityName(ctx context.Context, groupID int64) string {
-	activity, err := s.activityGroupRepo.FindByID(ctx, groupID)
+// A nil groupID marks a spontaneous session (WP-B6): there is no template to look up,
+// so we return an empty name and leave the display decision to the caller.
+func (s *service) getActivityName(ctx context.Context, groupID *int64) string {
+	if groupID == nil {
+		return ""
+	}
+	activity, err := s.activityGroupRepo.FindByID(ctx, *groupID)
 	if err != nil || activity == nil {
 		return ""
 	}

--- a/backend/services/active/dashboard_helpers.go
+++ b/backend/services/active/dashboard_helpers.go
@@ -266,9 +266,13 @@ func processActiveGroups(activeGroups []*active.Group, visitsByGroupID map[int64
 			}
 		}
 
-		// Check if this is an OGS/education group
-		if _, isOGS := educationGroupsByID[group.GroupID]; isOGS {
-			ogsGroupsCount++
+		// Check if this is an OGS/education group. Spontaneous sessions
+		// (GroupID == nil, WP-B6) are never OGS-bound — they skip this
+		// classification entirely.
+		if templateID, ok := group.TemplateID(); ok {
+			if _, isOGS := educationGroupsByID[templateID]; isOGS {
+				ogsGroupsCount++
+			}
 		}
 	}
 
@@ -436,10 +440,13 @@ func buildCurrentActivities(allActivityGroups []*activitiesModels.Group, activeG
 	return currentActivities
 }
 
-// findActiveSessionForActivity checks if an activity has an active session and returns participant count
+// findActiveSessionForActivity checks if an activity has an active session and returns participant count.
+// Spontaneous sessions (TemplateID ok == false) can never match since they
+// have no parent template id to compare against.
 func findActiveSessionForActivity(activityID int64, activeGroups []*active.Group, roomData *dashboardRoomData) (bool, int) {
 	for _, group := range activeGroups {
-		if group.IsActive() && group.GroupID == activityID {
+		templateID, ok := group.TemplateID()
+		if group.IsActive() && ok && templateID == activityID {
 			participantCount := 0
 			if studentSet, ok := roomData.roomStudentsMap[group.RoomID]; ok {
 				participantCount = len(studentSet)
@@ -495,26 +502,35 @@ func buildActiveGroupsSummary(activeGroups []*active.Group, activityGroupsByID m
 }
 
 // resolveGroupName gets the display name for a group via pre-loaded maps.
-func resolveGroupName(groupID int64, activityGroupsByID map[int64]*activitiesModels.Group, educationGroupsByID map[int64]*educationModels.Group) string {
-	if ag, ok := activityGroupsByID[groupID]; ok {
+// Spontaneous sessions (groupID == nil, WP-B6) return a generic label since
+// no template row exists to derive a name from.
+func resolveGroupName(groupID *int64, activityGroupsByID map[int64]*activitiesModels.Group, educationGroupsByID map[int64]*educationModels.Group) string {
+	if groupID == nil {
+		return "Spontane Aktivität"
+	}
+	if ag, ok := activityGroupsByID[*groupID]; ok {
 		return ag.Name
 	}
-	if eg, ok := educationGroupsByID[groupID]; ok {
+	if eg, ok := educationGroupsByID[*groupID]; ok {
 		return eg.Name
 	}
-	return fmt.Sprintf("Gruppe %d", groupID)
+	return fmt.Sprintf("Gruppe %d", *groupID)
 }
 
 // resolveGroupNameAndType gets the display name and type for a group.
 // Education/OGS groups are checked first since they need the "ogs_group" type.
-func resolveGroupNameAndType(groupID int64, activityGroupsByID map[int64]*activitiesModels.Group, educationGroupsByID map[int64]*educationModels.Group) (string, string) {
-	if eg, ok := educationGroupsByID[groupID]; ok {
+// Spontaneous sessions (groupID == nil) are classified as "spontaneous".
+func resolveGroupNameAndType(groupID *int64, activityGroupsByID map[int64]*activitiesModels.Group, educationGroupsByID map[int64]*educationModels.Group) (string, string) {
+	if groupID == nil {
+		return "Spontane Aktivität", "spontaneous"
+	}
+	if eg, ok := educationGroupsByID[*groupID]; ok {
 		return eg.Name, "ogs_group"
 	}
-	if ag, ok := activityGroupsByID[groupID]; ok {
+	if ag, ok := activityGroupsByID[*groupID]; ok {
 		return ag.Name, "activity"
 	}
-	return fmt.Sprintf("Gruppe %d", groupID), "activity"
+	return fmt.Sprintf("Gruppe %d", *groupID), "activity"
 }
 
 // resolveRoomName gets the display name for a room

--- a/backend/services/active/interface.go
+++ b/backend/services/active/interface.go
@@ -189,18 +189,21 @@ type ActivityConflictInfo struct {
 	CanOverride       bool          `json:"can_override"`
 }
 
-// TimeoutResult represents the result of processing a session timeout
+// TimeoutResult represents the result of processing a session timeout.
+// ActivityID is *int64 because spontaneous sessions (WP-B6) carry no parent
+// template; it is serialized as null on the wire rather than omitted.
 type TimeoutResult struct {
 	SessionID          int64     `json:"session_id"`
-	ActivityID         int64     `json:"activity_id"`
+	ActivityID         *int64    `json:"activity_id"`
 	StudentsCheckedOut int       `json:"students_checked_out"`
 	TimeoutAt          time.Time `json:"timeout_at"`
 }
 
-// SessionTimeoutInfo provides information about a session's timeout status
+// SessionTimeoutInfo provides information about a session's timeout status.
+// ActivityID follows the same *int64 contract as TimeoutResult.
 type SessionTimeoutInfo struct {
 	SessionID          int64         `json:"session_id"`
-	ActivityID         int64         `json:"activity_id"`
+	ActivityID         *int64        `json:"activity_id"`
 	StartTime          time.Time     `json:"start_time"`
 	LastActivity       time.Time     `json:"last_activity"`
 	TimeoutMinutes     int           `json:"timeout_minutes"`

--- a/backend/services/active/session_conflict_test.go
+++ b/backend/services/active/session_conflict_test.go
@@ -146,7 +146,8 @@ func TestActivitySessionConflictDetection(t *testing.T) {
 		session, err := service.StartActivitySession(ctx, activityGroup.ID, device.ID, 1, &room.ID)
 		require.NoError(t, err)
 		assert.NotNil(t, session)
-		assert.Equal(t, activityGroup.ID, session.GroupID)
+		require.NotNil(t, session.GroupID)
+		assert.Equal(t, activityGroup.ID, *session.GroupID)
 		assert.Equal(t, &device.ID, session.DeviceID)
 	})
 
@@ -219,7 +220,8 @@ func TestActivitySessionConflictDetection(t *testing.T) {
 		// ASSERT
 		require.NoError(t, err)
 		assert.NotNil(t, session2)
-		assert.Equal(t, activityGroup.ID, session2.GroupID)
+		require.NotNil(t, session2.GroupID)
+		assert.Equal(t, activityGroup.ID, *session2.GroupID)
 		assert.Equal(t, &device.ID, session2.DeviceID)
 
 		// Verify first session was ended (force start ends previous session on same device)
@@ -247,7 +249,8 @@ func TestActivitySessionConflictDetection(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, currentSession)
 		assert.Equal(t, session.ID, currentSession.ID)
-		assert.Equal(t, activityGroup.ID, currentSession.GroupID)
+		require.NotNil(t, currentSession.GroupID)
+		assert.Equal(t, activityGroup.ID, *currentSession.GroupID)
 
 		// End session
 		err = service.EndActivitySession(ctx, session.ID)
@@ -461,7 +464,8 @@ func TestForceStartActivitySessionWithSupervisors(t *testing.T) {
 		// ASSERT
 		require.NoError(t, err)
 		assert.NotNil(t, session)
-		assert.Equal(t, activityGroup.ID, session.GroupID)
+		require.NotNil(t, session.GroupID)
+		assert.Equal(t, activityGroup.ID, *session.GroupID)
 		assert.Equal(t, &device.ID, session.DeviceID)
 
 		// Verify supervisors were assigned

--- a/backend/services/active/session_service.go
+++ b/backend/services/active/session_service.go
@@ -318,7 +318,7 @@ func (s *service) createSessionBase(ctx context.Context, activityID, deviceID, r
 		StartTime:      now,
 		LastActivity:   now,
 		TimeoutMinutes: 30,
-		GroupID:        activityID,
+		GroupID:        &activityID,
 		DeviceID:       &deviceID,
 		RoomID:         roomID,
 	}

--- a/backend/services/active/session_service_coverage_test.go
+++ b/backend/services/active/session_service_coverage_test.go
@@ -103,7 +103,9 @@ func TestProcessSessionTimeout_WithActiveSession(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, session.ID, result.SessionID)
-	assert.Equal(t, activityGroup.ID, result.ActivityID)
+	if assert.NotNil(t, result.ActivityID) {
+		assert.Equal(t, activityGroup.ID, *result.ActivityID)
+	}
 	assert.GreaterOrEqual(t, result.StudentsCheckedOut, 0)
 }
 
@@ -159,7 +161,9 @@ func TestProcessSessionTimeout_WithVisits(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, session.ID, result.SessionID)
-	assert.Equal(t, activityGroup.ID, result.ActivityID)
+	if assert.NotNil(t, result.ActivityID) {
+		assert.Equal(t, activityGroup.ID, *result.ActivityID)
+	}
 	assert.Equal(t, 1, result.StudentsCheckedOut, "Should have checked out 1 student")
 }
 

--- a/backend/services/active/session_service_coverage_test.go
+++ b/backend/services/active/session_service_coverage_test.go
@@ -53,7 +53,8 @@ func TestGetDeviceCurrentSession_HasSession(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, currentSession)
 	assert.Equal(t, session.ID, currentSession.ID)
-	assert.Equal(t, activityGroup.ID, currentSession.GroupID)
+	require.NotNil(t, currentSession.GroupID)
+	assert.Equal(t, activityGroup.ID, *currentSession.GroupID)
 }
 
 // TestGetDeviceCurrentSession_NoSession verifies error when device has no active session

--- a/backend/services/active/timeout_simple_test.go
+++ b/backend/services/active/timeout_simple_test.go
@@ -257,7 +257,9 @@ func TestGetSessionTimeoutInfo(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, info)
 		assert.Equal(t, session.ID, info.SessionID)
-		assert.Equal(t, activity.ID, info.ActivityID)
+		if assert.NotNil(t, info.ActivityID) {
+			assert.Equal(t, activity.ID, *info.ActivityID)
+		}
 		assert.Equal(t, 0, info.ActiveStudentCount) // No visits yet
 		assert.False(t, info.IsTimedOut)            // Fresh session
 	})
@@ -312,7 +314,9 @@ func TestGetSessionTimeoutInfo(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, info)
 		assert.Equal(t, session.ID, info.SessionID)
-		assert.Equal(t, activity.ID, info.ActivityID)
+		if assert.NotNil(t, info.ActivityID) {
+			assert.Equal(t, activity.ID, *info.ActivityID)
+		}
 		assert.Equal(t, 2, info.ActiveStudentCount) // Two active visits
 		assert.False(t, info.IsTimedOut)            // Fresh session
 	})

--- a/backend/services/activities/activity_service_test.go
+++ b/backend/services/activities/activity_service_test.go
@@ -262,11 +262,12 @@ func TestActivityService_ListGroupsWithOccupancy(t *testing.T) {
 
 		// Create an active session for group1 (making it occupied)
 		now := time.Now()
+		group1ID := group1.ID
 		activeGroup := &active.Group{
 			StartTime:      now,
 			LastActivity:   now,
 			TimeoutMinutes: 30,
-			GroupID:        group1.ID,
+			GroupID:        &group1ID,
 			RoomID:         room.ID,
 		}
 		activeGroup.SetTenantID(1)

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -44,6 +44,14 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"tracking.indicator_1",
 		"tracking.indicator_2",
 		"tracking.indicator_3",
+		// Timetable settings (WP-B7): 6 in operations tab + 1 in gdpr tab.
+		"timetable.materialization_enabled",
+		"timetable.materialization_weekday",
+		"timetable.materialization_weeks_ahead",
+		"timetable.auto_start_planned",
+		"timetable.overdue_threshold_minutes",
+		"timetable.show_expected_children_count",
+		"gdpr.timetable_retention_days",
 	}
 
 	for _, key := range expectedKeys {
@@ -54,7 +62,129 @@ func TestAllSettingsRegistered(t *testing.T) {
 		assert.NotEmpty(t, def.Category, "setting %q should have a category", key)
 	}
 
-	assert.GreaterOrEqual(t, len(all), 27, "at least 27 settings should be registered")
+	// 28 pre-WP-B7 settings + 7 timetable settings == 35 minimum. The `>=` is
+	// intentional so later work packages can add more settings without
+	// retrofitting this assertion.
+	assert.GreaterOrEqual(t, len(all), 35, "at least 35 settings should be registered (28 existing + 7 timetable)")
+}
+
+func TestTimetableSettings_Types(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected config.FieldType
+	}{
+		{"timetable.materialization_enabled", config.FieldBoolean},
+		{"timetable.materialization_weekday", config.FieldSelect},
+		{"timetable.materialization_weeks_ahead", config.FieldNumber},
+		{"timetable.auto_start_planned", config.FieldBoolean},
+		{"timetable.overdue_threshold_minutes", config.FieldNumber},
+		{"timetable.show_expected_children_count", config.FieldBoolean},
+		{"gdpr.timetable_retention_days", config.FieldNumber},
+	}
+
+	for _, tc := range tests {
+		def := config.GetDefinition(tc.key)
+		require.NotNilf(t, def, "setting %q should exist", tc.key)
+		assert.Equalf(t, tc.expected, def.Type, "setting %q should be type %s", tc.key, tc.expected)
+	}
+}
+
+func TestTimetableSettings_Defaults(t *testing.T) {
+	// Both the materialization and auto-start flags default to FALSE so that
+	// WP-B7 is a pure no-op until the consuming services (WP-B8 / B9) ship
+	// AND a tenant explicitly opts in. Regressing either of these defaults
+	// would silently activate incomplete features for every tenant.
+	matDef := config.GetDefinition("timetable.materialization_enabled")
+	require.NotNil(t, matDef)
+	assert.Equal(t, false, matDef.Default, "materialization must default to false")
+
+	autoStartDef := config.GetDefinition("timetable.auto_start_planned")
+	require.NotNil(t, autoStartDef)
+	assert.Equal(t, false, autoStartDef.Default, "auto-start must default to false")
+
+	// Weekday defaults to Friday (ISO 8601: 5) so the RFC's recommended
+	// "materialize Fri → next week ready Mon" cadence holds out of the box.
+	weekdayDef := config.GetDefinition("timetable.materialization_weekday")
+	require.NotNil(t, weekdayDef)
+	assert.Equal(t, 5, weekdayDef.Default, "materialization weekday must default to Friday (5)")
+
+	retentionDef := config.GetDefinition("gdpr.timetable_retention_days")
+	require.NotNil(t, retentionDef)
+	assert.Equal(t, 365, retentionDef.Default, "timetable retention must default to 365 days")
+}
+
+func TestTimetableSettings_DependsOn(t *testing.T) {
+	// Materialization sub-settings are gated on the top-level toggle.
+	gatedKeys := []string{
+		"timetable.materialization_weekday",
+		"timetable.materialization_weeks_ahead",
+	}
+	for _, key := range gatedKeys {
+		def := config.GetDefinition(key)
+		require.NotNilf(t, def, "setting %q should exist", key)
+		require.NotNilf(t, def.DependsOn, "setting %q should have DependsOn", key)
+		assert.Equal(t, "timetable.materialization_enabled", def.DependsOn.Key)
+		assert.Equal(t, "eq", def.DependsOn.Condition)
+		assert.Equal(t, true, def.DependsOn.Value)
+	}
+
+	// Retention hangs off the shared GDPR cleanup toggle — same pattern as
+	// the other gdpr.* time/timeout settings.
+	retentionDef := config.GetDefinition("gdpr.timetable_retention_days")
+	require.NotNil(t, retentionDef)
+	require.NotNil(t, retentionDef.DependsOn)
+	assert.Equal(t, "gdpr.data_cleanup_enabled", retentionDef.DependsOn.Key)
+
+	// Overdue threshold is independent — materialization can be off while
+	// staff still see passive "this instance is overdue" indicators.
+	overdueDef := config.GetDefinition("timetable.overdue_threshold_minutes")
+	require.NotNil(t, overdueDef)
+	assert.Nil(t, overdueDef.DependsOn, "overdue threshold must stand alone (no DependsOn)")
+}
+
+func TestTimetableSettings_Permissions(t *testing.T) {
+	// Operational timetable settings use config:update (admin operational).
+	// The GDPR retention setting uses config:manage (admin GDPR-scoped).
+	opsKeys := []string{
+		"timetable.materialization_enabled",
+		"timetable.materialization_weekday",
+		"timetable.materialization_weeks_ahead",
+		"timetable.auto_start_planned",
+		"timetable.overdue_threshold_minutes",
+		"timetable.show_expected_children_count",
+	}
+	for _, key := range opsKeys {
+		def := config.GetDefinition(key)
+		require.NotNilf(t, def, "setting %q should exist", key)
+		assert.Equal(t, "operations", def.Tab, "setting %q should be in operations tab", key)
+		assert.Equal(t, "config:update", def.WritePermission, "setting %q should use config:update", key)
+	}
+
+	retentionDef := config.GetDefinition("gdpr.timetable_retention_days")
+	require.NotNil(t, retentionDef)
+	assert.Equal(t, "gdpr", retentionDef.Tab)
+	assert.Equal(t, "config:manage", retentionDef.WritePermission, "GDPR settings must use config:manage")
+}
+
+func TestTimetableSettings_WeekdayOptions(t *testing.T) {
+	def := config.GetDefinition("timetable.materialization_weekday")
+	require.NotNil(t, def)
+	require.NotNil(t, def.Options)
+	require.Len(t, def.Options.Static, 7, "all 7 weekdays must be offered")
+
+	// Weekday option values must be ISO 8601 integers 1–7. Drifting to
+	// time.Weekday's 0–6 convention would silently break any future
+	// materialization consumer that compares to time.Weekday()+1.
+	seen := map[int]string{}
+	for _, opt := range def.Options.Static {
+		v, ok := opt.Value.(int)
+		require.Truef(t, ok, "weekday option %q value should be int, got %T", opt.Label, opt.Value)
+		require.GreaterOrEqualf(t, v, 1, "weekday option %q value %d must be >= 1", opt.Label, v)
+		require.LessOrEqualf(t, v, 7, "weekday option %q value %d must be <= 7", opt.Label, v)
+		_, dup := seen[v]
+		require.Falsef(t, dup, "weekday option value %d appears twice", v)
+		seen[v] = opt.Label
+	}
 }
 
 func TestOperationsSettings_Types(t *testing.T) {

--- a/backend/services/config/defaults/timetable.go
+++ b/backend/services/config/defaults/timetable.go
@@ -1,0 +1,155 @@
+package defaults
+
+import (
+	"github.com/moto-nrw/project-phoenix/models/config"
+)
+
+// Timetable settings (WP-B7). Per-tenant configuration for the activity
+// template → instance materialization pipeline, the staff-facing auto-start
+// behaviour, and the GDPR retention window for completed/cancelled instances.
+//
+// Default values follow the RFC's §5.6 recommendations. In particular,
+// `materialization_enabled` and `auto_start_planned` both default to FALSE
+// so that WP-B7 is a pure no-op until the consuming services (WP-B8 / B9)
+// are shipped and a tenant explicitly opts in via the settings UI.
+//
+// The weekday option values match ISO 8601 numbering (1 = Monday … 7 = Sunday)
+// so they slot directly into time.Weekday comparisons after the usual +1 shift.
+func init() {
+	// --- Materialization (operations tab) ---
+
+	config.Register(config.Definition{
+		Key:             config.KeyTimetableMaterializationEnabled,
+		Label:           "Automatische Stundenplan-Materialisierung",
+		Description:     "Wenn aktiviert, erzeugt der Scheduler wöchentlich Aktivitäts-Instanzen aus den Aktivitäts-Vorlagen (Templates) für den kommenden Planungszeitraum.",
+		Type:            config.FieldBoolean,
+		Default:         false,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "stundenplan",
+		SortOrder:       30,
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyTimetableMaterializationWeekday,
+		Label:           "Materialisierungs-Wochentag",
+		Description:     "Wochentag, an dem der Scheduler den kommenden Planungszeitraum materialisiert. Empfohlen ist ein Freitag, damit die Folgewoche ab Montag bereitsteht.",
+		Type:            config.FieldSelect,
+		Default:         5, // Friday (ISO 8601: Monday=1 … Sunday=7)
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "stundenplan",
+		SortOrder:       31,
+		Options: &config.SelectOptions{
+			Static: []config.SelectOption{
+				{Label: "Montag", Value: 1},
+				{Label: "Dienstag", Value: 2},
+				{Label: "Mittwoch", Value: 3},
+				{Label: "Donnerstag", Value: 4},
+				{Label: "Freitag", Value: 5},
+				{Label: "Samstag", Value: 6},
+				{Label: "Sonntag", Value: 7},
+			},
+		},
+		DependsOn: &config.Dependency{
+			Key:       config.KeyTimetableMaterializationEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
+	minWeeksAhead := float64(1)
+	maxWeeksAhead := float64(4)
+	config.Register(config.Definition{
+		Key:             config.KeyTimetableMaterializationWeeksAhead,
+		Label:           "Vorlauf (Wochen)",
+		Description:     "Anzahl der Wochen, die im Voraus materialisiert werden. 1 Woche ist Standard; größere Werte erzeugen mehr Daten auf einmal und erhöhen das Rollback-Risiko bei Template-Änderungen.",
+		Type:            config.FieldNumber,
+		Default:         1,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "stundenplan",
+		SortOrder:       32,
+		Validation:      &config.ValidationRules{Min: &minWeeksAhead, Max: &maxWeeksAhead},
+		DependsOn: &config.Dependency{
+			Key:       config.KeyTimetableMaterializationEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
+	// --- Auto-start & staff UX (operations tab) ---
+
+	config.Register(config.Definition{
+		Key:             config.KeyTimetableAutoStartPlanned,
+		Label:           "Automatischer Start geplanter Aktivitäten",
+		Description:     "Wenn aktiviert, werden geplante Instanzen automatisch in eine aktive Sitzung überführt, sobald deren Startzeit erreicht ist (RFC E19 Level 3). Ohne Aktivierung zeigt die Staff-Oberfläche lediglich passive Hinweise an.",
+		Type:            config.FieldBoolean,
+		Default:         false,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "stundenplan",
+		SortOrder:       33,
+	})
+
+	minOverdue := float64(1)
+	maxOverdue := float64(30)
+	config.Register(config.Definition{
+		Key:             config.KeyTimetableOverdueThresholdMinutes,
+		Label:           "Überfälligkeits-Schwelle (Minuten)",
+		Description:     "Minuten nach dem geplanten Start, ab denen eine Instanz in der Staff-Ansicht als überfällig markiert wird.",
+		Type:            config.FieldNumber,
+		Default:         5,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "stundenplan",
+		SortOrder:       34,
+		Validation:      &config.ValidationRules{Min: &minOverdue, Max: &maxOverdue},
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyTimetableShowExpectedChildrenCount,
+		Label:           "Erwartete Kinderzahl in Instanzansicht anzeigen",
+		Description:     "Zeigt in der Staff-Instanzansicht die erwartete Anzahl Kinder (auf Basis der Einschreibungen) neben der tatsächlich anwesenden Anzahl an.",
+		Type:            config.FieldBoolean,
+		Default:         true,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "stundenplan",
+		SortOrder:       35,
+	})
+
+	// --- GDPR retention (gdpr tab) ---
+
+	// Timetable retention is an independent window from KeyDataCleanupEnabled:
+	// activity_instances rows may age out on a different cadence than the live
+	// attendance data cleaned up by the scheduler job. Gate visibility on the
+	// existing data-cleanup toggle so the GDPR UI surfaces both settings as a
+	// coherent unit when cleanup is enabled.
+	minRetention := float64(30)
+	maxRetention := float64(1825) // 5 years
+	config.Register(config.Definition{
+		Key:             config.KeyGDPRTimetableRetentionDays,
+		Label:           "Aufbewahrungsdauer Stundenplan (Tage)",
+		Description:     "Anzahl Tage, für die abgeschlossene oder abgesagte Aktivitäts-Instanzen vorgehalten werden, bevor sie bereinigt werden. Trennt sich bewusst von der Bereinigung der Anwesenheitsdaten.",
+		Type:            config.FieldNumber,
+		Default:         365,
+		ReadPermission:  "config:read",
+		WritePermission: "config:manage",
+		Tab:             "gdpr",
+		Category:        "stundenplan",
+		SortOrder:       30,
+		Validation:      &config.ValidationRules{Min: &minRetention, Max: &maxRetention},
+		DependsOn: &config.Dependency{
+			Key:       config.KeyDataCleanupEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+}

--- a/backend/services/facilities/schulhof_service.go
+++ b/backend/services/facilities/schulhof_service.go
@@ -327,10 +327,12 @@ func (s *schulhofService) GetOrCreateActiveGroup(ctx context.Context, createdBy 
 		return nil, fmt.Errorf("failed to end stale active groups: %w", err)
 	}
 
-	// Create a new active group for today
+	// Create a new active group for today. Schulhof sessions are always
+	// template-backed (the well-known Schulhof activity), so GroupID is set.
 	now := time.Now()
+	activityGroupID := activityGroup.ID
 	newActiveGroup := &active.Group{
-		GroupID:   activityGroup.ID,
+		GroupID:   &activityGroupID,
 		RoomID:    room.ID,
 		StartTime: now,
 	}
@@ -377,8 +379,10 @@ func (s *schulhofService) findTodayActiveGroup(ctx context.Context, roomID, acti
 	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 
 	for _, ag := range activeGroups {
-		// Check if it's for the Schulhof activity and started today and not ended
-		if ag.GroupID == activityGroupID && ag.StartTime.After(todayStart) && ag.EndTime == nil {
+		// Check if it's for the Schulhof activity and started today and not ended.
+		// Spontaneous sessions (no template, WP-B6) can never match here.
+		templateID, ok := ag.TemplateID()
+		if ok && templateID == activityGroupID && ag.StartTime.After(todayStart) && ag.EndTime == nil {
 			return ag, nil
 		}
 	}

--- a/backend/services/facilities/schulhof_service_test.go
+++ b/backend/services/facilities/schulhof_service_test.go
@@ -214,7 +214,7 @@ func TestSchulhofService_GetSchulhofStatus_WithActiveSessionNoSupervisor(t *test
 	// Create infrastructure and active group
 	activeGroup, err := service.GetOrCreateActiveGroup(ctx, staff.ID)
 	require.NoError(t, err)
-	defer testpkg.CleanupActivityFixtures(t, db, activeGroup.ID, activeGroup.GroupID, activeGroup.RoomID)
+	defer testpkg.CleanupActivityFixtures(t, db, activeGroup.ID, *activeGroup.GroupID, activeGroup.RoomID)
 
 	// ACT
 	status, err := service.GetSchulhofStatus(ctx, staff.ID)
@@ -514,7 +514,7 @@ func TestSchulhofService_ToggleSupervision_StopNotSupervising(t *testing.T) {
 	// Create infrastructure and active group (but don't add as supervisor)
 	activeGroup, err := service.GetOrCreateActiveGroup(ctx, staff.ID)
 	require.NoError(t, err)
-	defer testpkg.CleanupActivityFixtures(t, db, activeGroup.ID, activeGroup.GroupID, activeGroup.RoomID)
+	defer testpkg.CleanupActivityFixtures(t, db, activeGroup.ID, *activeGroup.GroupID, activeGroup.RoomID)
 
 	// ACT - Try to stop when not supervising
 	result, err := service.ToggleSupervision(ctx, staff.ID, "stop")
@@ -625,8 +625,8 @@ func TestSchulhofService_GetOrCreateActiveGroup_Creates(t *testing.T) {
 	assert.NotZero(t, activeGroup.RoomID)
 	assert.WithinDuration(t, time.Now(), activeGroup.StartTime, 5*time.Second)
 
-	// Cleanup
-	testpkg.CleanupActivityFixtures(t, db, activeGroup.ID, activeGroup.GroupID, activeGroup.RoomID)
+	// Cleanup — activeGroup.GroupID is *int64 (WP-B6); Schulhof is always template-backed.
+	testpkg.CleanupActivityFixtures(t, db, activeGroup.ID, *activeGroup.GroupID, activeGroup.RoomID)
 
 	// Find created activity group and cleanup
 	options := base.NewQueryOptions()
@@ -654,7 +654,7 @@ func TestSchulhofService_GetOrCreateActiveGroup_ReturnsExisting(t *testing.T) {
 	// Create first time
 	activeGroup1, err := service.GetOrCreateActiveGroup(ctx, staff.ID)
 	require.NoError(t, err)
-	defer testpkg.CleanupActivityFixtures(t, db, activeGroup1.ID, activeGroup1.GroupID, activeGroup1.RoomID)
+	defer testpkg.CleanupActivityFixtures(t, db, activeGroup1.ID, *activeGroup1.GroupID, activeGroup1.RoomID)
 
 	// ACT - Call again (should return same group)
 	activeGroup2, err := service.GetOrCreateActiveGroup(ctx, staff.ID)
@@ -708,8 +708,9 @@ func TestSchulhofService_GetOrCreateActiveGroup_IgnoresEndedGroups(t *testing.T)
 
 	// Create an ended active group from today
 	endedTime := time.Now()
+	endedActivityGroupID := activityGroup.ID
 	endedGroup := &active.Group{
-		GroupID:   activityGroup.ID,
+		GroupID:   &endedActivityGroupID,
 		RoomID:    *activityGroup.PlannedRoomID,
 		StartTime: time.Now().Add(-2 * time.Hour),
 		EndTime:   &endedTime,
@@ -902,8 +903,9 @@ func TestSchulhofService_GetOrCreateActiveGroup_EndsStaleGroups(t *testing.T) {
 
 	// Create a stale active group from "yesterday" that is still open (no EndTime)
 	yesterday := time.Now().Add(-24 * time.Hour)
+	staleActivityGroupID := activityGroup.ID
 	staleGroup := &active.Group{
-		GroupID:   activityGroup.ID,
+		GroupID:   &staleActivityGroupID,
 		RoomID:    *activityGroup.PlannedRoomID,
 		StartTime: yesterday,
 		// EndTime is nil — this is the stale group

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -745,7 +745,7 @@ func CreateTestActiveGroup(tb testing.TB, db *bun.DB, activityGroupID, roomID in
 
 	now := time.Now()
 	activeGroup := &active.Group{
-		GroupID:        activityGroupID,
+		GroupID:        &activityGroupID,
 		RoomID:         roomID,
 		StartTime:      now,
 		LastActivity:   now,
@@ -2344,8 +2344,9 @@ func CreateTestActiveGroupForTenant(tb testing.TB, db *bun.DB, tenantID int64) *
 	activityGroup := CreateTestActivityGroupForTenant(tb, db, tenantID, "IsolationActivity")
 
 	now := time.Now()
+	activityGroupID := activityGroup.ID
 	activeGroup := &active.Group{
-		GroupID:        activityGroup.ID,
+		GroupID:        &activityGroupID,
 		RoomID:         room.ID,
 		StartTime:      now,
 		LastActivity:   now,

--- a/frontend/src/lib/active-helpers.ts
+++ b/frontend/src/lib/active-helpers.ts
@@ -7,10 +7,14 @@ export interface TrackingIndicatorsResponse {
   results: Record<string, boolean[]>; // student_id → [matched1, matched2, ...]
 }
 
-// Backend types (from Go structs)
+// Backend types (from Go structs).
+// group_id: number | null — WP-B6 made active.groups.group_id nullable so
+// spontaneous activity instances can run without a parent template. The
+// backend serializes `null` explicitly (no omitempty), so clients MUST
+// handle both shapes.
 export interface BackendActiveGroup {
   id: number;
-  group_id: number;
+  group_id: number | null;
   room_id: number;
   start_time: string;
   end_time?: string;
@@ -91,9 +95,11 @@ export interface BackendAnalytics {
 }
 
 // Frontend types
+// groupId: string | null — mirrors the nullable backend contract (WP-B6).
+// A null value means the session is spontaneous (no parent template).
 export interface ActiveGroup {
   id: string;
-  groupId: string;
+  groupId: string | null;
   roomId: string;
   startTime: Date;
   endTime?: Date;
@@ -179,7 +185,13 @@ export function mapActiveGroupResponse(
 ): ActiveGroup {
   return {
     id: String(backendActiveGroup.id),
-    groupId: String(backendActiveGroup.group_id),
+    // Preserve null when the backend sends `group_id: null` (spontaneous
+    // session, WP-B6). Do NOT do `String(null)` — that produces the literal
+    // string "null" which would silently break any equality check.
+    groupId:
+      backendActiveGroup.group_id === null
+        ? null
+        : String(backendActiveGroup.group_id),
     roomId: String(backendActiveGroup.room_id),
     startTime: new Date(backendActiveGroup.start_time),
     endTime: backendActiveGroup.end_time
@@ -351,7 +363,15 @@ export interface GroupMappingRequest {
   combined_group_id: number;
 }
 
-// Utility functions to prepare data for backend
+// Utility functions to prepare data for backend.
+//
+// NOTE (WP-B6): this helper targets the admin CRUD endpoint
+// (POST/PUT /api/active/groups) which REQUIRES a positive template id. A
+// spontaneous session (groupId === null) cannot be created through this
+// path — spontaneous creation goes through a separate handler (WP-B9+).
+// The truthy guard below is therefore intentional: if groupId is null, we
+// omit the field, and the backend's request validator will reject the
+// request with a 400. That is the desired behaviour for this endpoint.
 export function prepareActiveGroupForBackend(
   activeGroup: Partial<ActiveGroup>,
 ): Partial<CreateActiveGroupRequest> {


### PR DESCRIPTION
## Summary

Implements **WP-B6** and **WP-B7** of the [Timetable System plan](https://github.com/moto-nrw/project-phoenix/pull/1265) in a single PR.

- **WP-B6** — Makes `active.groups.group_id` nullable (RFC E2) so spontaneous activity instances can bridge to the live layer without a parent template. Adds semantic helpers (`IsSpontaneous`, `HasTemplate`, `TemplateID`) on `*active.Group` as the single sanctioned entry point for nil handling; every consumer in services / repositories / handlers goes through them.
- **WP-B7** — Registers 7 timetable settings in the config registry (6 operations + 1 GDPR) with the exact defaults from RFC §5.6. Both gating toggles default to **false** so this is a pure no-op until WP-B8 / B9 ship and a tenant explicitly opts in.

## Why one PR

WP-B7 is parallelisable with no blockers per the plan's dependency map. Bundling avoids an extra review-and-merge cycle for a 3-file addition that has zero runtime effect.

## Architecture choices

1. **Helper-centric nil handling.** Every `g.GroupID` read in the codebase now flows through `IsSpontaneous()` / `HasTemplate()` / `TemplateID() (int64, bool)`. If we ever switch to `sql.NullInt64` or a discriminated type, only the model changes — not 64 call sites.
2. **Compiler-driven refactor.** Changing the struct field to `*int64` made the Go compiler surface all 168 consumer lines. Fixed one by one; no grep-based audit could have matched that coverage.
3. **Explicit nulls on the wire.** API response types use `*int64` with `json:"group_id"` (no `omitempty`) so spontaneous sessions serialize as `"group_id": null` rather than disappearing from the payload. Forces TypeScript clients to model nullability instead of silently tolerating missing fields.
4. **Two-phase rollout preserves E2 guarantees.** Migration 1.15.37 only **drops** NOT NULL; it does not write any NULL values. Spontaneous-session creation comes in WP-B9. So on the wire today, `activity_id` is still always a number for every request PyrePortal and other existing clients actually see — the plan's "NFC payload/response unchanged" guarantee holds in practice.

## WP-B6 touched surfaces

- **Schema**: `backend/database/migrations/001015037_active_groups_nullable_group_id.go` — safe Down() refuses to restore NOT NULL while NULL rows exist.
- **Model**: `models/active/group.go` — `GroupID int64 → *int64`, three helpers, nil-aware `Validate()`.
- **Hot spots** (critical nil-handling sites):
  - `database/repositories/active/group.go` — local scan structs use `*int64`, relation-join + dedup + `collectRelationIDs` go through `TemplateID()`.
  - `services/active/session_service.go` — `getActivityName` accepts `*int64`, spontaneous sessions yield empty name.
  - `services/active/dashboard_helpers.go` — `resolveGroupName(AndType)` surfaces spontaneous sessions as "Spontane Aktivität" / type `spontaneous`.
  - `api/iot/checkin/workflow.go` — `checkActivityCapacity` fails fast on spontaneous sessions (that flow is template-only until WP-B9).
  - `api/active/converters.go` — new `activeGroupDisplayName` helper handles both template-backed and spontaneous shapes.
- **API types**: `ActiveGroupResponse`, `SessionStartResponse`, `SessionTimeoutResponse`, `SessionTimeoutInfoResponse` — `ActivityID`/`GroupID` now `*int64` without `omitempty`.
- **Frontend**: `BackendActiveGroup.group_id: number | null`, `ActiveGroup.groupId: string | null`, `mapActiveGroupResponse` preserves null (no `String(null) → "null"` trap). Existing truthy guard in `prepareActiveGroupForBackend` documented as intentional.
- **Fixtures + tests**: all active.Group literals updated to use `base.Int64Ptr`, hermetic verification stays green.

## WP-B7 settings (RFC §5.6)

| Key | Type | Default | DependsOn |
|---|---|---|---|
| `timetable.materialization_enabled` | bool | `false` | — |
| `timetable.materialization_weekday` | select | `5` (Fri, ISO 8601) | materialization_enabled eq true |
| `timetable.materialization_weeks_ahead` | number | `1` (1–4) | materialization_enabled eq true |
| `timetable.auto_start_planned` | bool | `false` | — |
| `timetable.overdue_threshold_minutes` | number | `5` (1–30) | — |
| `timetable.show_expected_children_count` | bool | `true` | — |
| `gdpr.timetable_retention_days` | number | `365` (30–1825) | data_cleanup_enabled eq true |

- Weekday option values are **ISO 8601 integers** (1=Mon … 7=Sun), pinned by `TestTimetableSettings_WeekdayOptions` so future consumers can compare to `time.Weekday()+1` without surprise.
- 5 new tests: Types / Defaults / DependsOn / Permissions / WeekdayOptions.

## PyrePortal impact

**None for this PR.** All IoT sessions today are template-backed, so `activity_id` stays a number on every response PyrePortal actually receives. The kiosk should adopt `activity_id: number | null` alongside WP-B9 when spontaneous sessions become reachable through `/api/iot/sessions/current`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `pnpm run check` (frontend) — 0 warnings, 0 errors
- [x] `TestGroupTemplateHelpers` — PASS (covers both shapes)
- [x] `TestGroupValidate` with new "Nil group ID (spontaneous session)" case — PASS
- [x] All 5 new `TestTimetableSettings_*` tests — PASS
- [x] `TestHermeticTestPatterns` — PASS
- [x] `TestNoDuplicateMigrationVersions` — PASS
- [x] `go run main.go migrate validate` — dependency graph clean (150 nodes)
- [ ] CI: full backend + integration suite on fresh DB
- [ ] Manual: `docker compose run server ./main migrate status` shows `1.15.37 APPLIED`

## Business rule change (FYI for reviewers)

`TestGroupValidate` previously had a **"Missing group ID"** case that expected `Validate()` to error on zero-valued `GroupID`. That rule is intentionally replaced by **"Nil group ID (spontaneous session) — valid"** per RFC E2. Non-nil non-positive values are still rejected. This is the only business-rule flip in the PR.

## Not in scope (next)

- WP-B8 — materialization service + scheduler job
- WP-B9 — instance lifecycle: `start` (uses `*int64 GroupID`), `complete`, `cancel` + conflict detection
- WP-B10 — attendance sync + three-field attendance model