### PR TITLE
feat(schedule): WP-B9 instance lifecycle + conflict detection + re-plan-week

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -348,7 +348,14 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Database = databaseAPI.NewResource(api.Services.Database, db)
 	api.GradeTransitions = adminAPI.NewGradeTransitionResource(api.Services.GradeTransition, db)
 	api.TimeTracking = timeTrackingAPI.NewResource(api.Services.WorkSession, api.Services.StaffAbsence, api.Services.Users, db)
-	api.Timetable = timetableAPI.NewResource(api.Services.CalendarPeriod, api.Services.Materialization, db)
+	api.Timetable = timetableAPI.NewResource(
+		api.Services.CalendarPeriod,
+		api.Services.Materialization,
+		api.Services.Instance,
+		api.Services.Users,
+		logger.With("handler", "timetable"),
+		db,
+	)
 
 	// Initialize operator dashboard resources
 	api.Operator = operatorAPI.NewResource(operatorAPI.ResourceConfig{

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -74,6 +74,11 @@ func NewServer(logger *slog.Logger) (*Server, error) {
 		if api.Services.Materialization != nil {
 			srv.scheduler.SetMaterializer(api.Services.Materialization)
 		}
+		// WP-B9: overdue instance tick. Requires both the ActivityInstance
+		// repo and a broadcaster — either missing disables the tick.
+		if api.repos != nil && api.Services.RealtimeHub != nil {
+			srv.scheduler.SetInstanceOverdueDeps(api.repos.ActivityInstance, api.Services.RealtimeHub)
+		}
 	}
 
 	return srv, nil

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -3,6 +3,7 @@ package timetable
 import (
 	"database/sql"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -14,31 +15,46 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	userSvc "github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
 
 const dateLayout = "2006-01-02"
 
-// Resource defines the timetable API resource
+// Resource defines the timetable API resource.
+//
+// instanceService, personService, and logger are optional at construction
+// time: tests that only exercise /periods or /materialize can pass nil and
+// will get a 500 on the WP-B9 routes instead of a crash. Production wiring
+// must supply all of them via NewResource.
 type Resource struct {
 	calendarPeriodService  scheduleSvc.CalendarPeriodService
 	materializationService scheduleSvc.MaterializationService
+	instanceService        scheduleSvc.InstanceService
+	personService          userSvc.PersonService
+	logger                 *slog.Logger
 	db                     *bun.DB
 }
 
-// NewResource creates a new timetable resource. materializationService is
-// optional — if nil, the /materialize route returns 500 when hit (no silent
-// misconfiguration). Passing nil is useful in tests that only exercise the
-// periods endpoints.
+// NewResource creates a new timetable resource. Optional services (see the
+// Resource doc) may be nil; passing nil for the materialization or instance
+// service makes the corresponding routes return 500 instead of silently
+// misbehaving.
 func NewResource(
 	calendarPeriodService scheduleSvc.CalendarPeriodService,
 	materializationService scheduleSvc.MaterializationService,
+	instanceService scheduleSvc.InstanceService,
+	personService userSvc.PersonService,
+	logger *slog.Logger,
 	db *bun.DB,
 ) *Resource {
 	return &Resource{
 		calendarPeriodService:  calendarPeriodService,
 		materializationService: materializationService,
+		instanceService:        instanceService,
+		personService:          personService,
+		logger:                 logger,
 		db:                     db,
 	}
 }
@@ -70,6 +86,20 @@ func (rs *Resource) Router() chi.Router {
 		// admins can re-run ad hoc without waiting for the weekly cadence.
 		r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
 			Post("/materialize", rs.materialize)
+
+		// WP-B9: instance lifecycle + re-plan-week. All four routes gated on
+		// SchedulesManage. They share the tenant tx so start/complete/cancel
+		// are atomic end-to-end (no dangling bridge rows on rollback).
+		r.Route("/instances", func(r chi.Router) {
+			r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
+				Post("/re-plan-week", rs.replanWeek)
+			r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
+				Post("/{id}/start", rs.startInstance)
+			r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
+				Post("/{id}/complete", rs.completeInstance)
+			r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
+				Post("/{id}/cancel", rs.cancelInstance)
+		})
 	})
 
 	return r

--- a/backend/api/timetable/api_test.go
+++ b/backend/api/timetable/api_test.go
@@ -153,13 +153,13 @@ func newTestPeriod() *schedule.CalendarPeriod {
 // =============================================================================
 
 func TestNewResource(t *testing.T) {
-	res := NewResource(nil, nil, nil)
+	res := NewResource(nil, nil, nil, nil, nil, nil)
 	assert.NotNil(t, res)
 }
 
 func TestResource_Router(t *testing.T) {
 	mock := &mockCalendarPeriodService{}
-	res := NewResource(mock, nil, nil)
+	res := NewResource(mock, nil, nil, nil, nil, nil)
 	router := res.Router()
 	assert.NotNil(t, router)
 }
@@ -343,7 +343,7 @@ func TestListPeriods(t *testing.T) {
 		p1.UpdatedAt = time.Now()
 
 		mock := &mockCalendarPeriodService{periods: []*schedule.CalendarPeriod{p1}}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -354,7 +354,7 @@ func TestListPeriods(t *testing.T) {
 
 	t.Run("returns empty list", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{periods: []*schedule.CalendarPeriod{}}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -364,7 +364,7 @@ func TestListPeriods(t *testing.T) {
 
 	t.Run("returns 500 on service error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db error")}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -392,7 +392,7 @@ func TestGetPeriod(t *testing.T) {
 		p.UpdatedAt = time.Now()
 
 		mock := &mockCalendarPeriodService{period: p}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/42", nil)
@@ -403,7 +403,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/abc", nil)
@@ -413,7 +413,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 404 when not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/999", nil)
@@ -423,7 +423,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 500 on internal error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db connection failed")}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/42", nil)
@@ -439,7 +439,7 @@ func TestGetPeriod(t *testing.T) {
 func TestCreatePeriod(t *testing.T) {
 	t.Run("creates period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -461,7 +461,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("creates period with week cycle anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		anchor := "2025-09-01"
@@ -484,7 +484,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("defaults week cycle length to 1", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -505,7 +505,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for missing required fields", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{Name: "Only Name"}
@@ -517,7 +517,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid period_type", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -535,7 +535,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid start_date format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -553,7 +553,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid end_date format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -571,7 +571,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid week_cycle_anchor format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		badAnchor := "not-a-date"
@@ -592,7 +592,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for end_date before start_date", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -610,7 +610,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for cycle > 1 without anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -629,7 +629,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 409 for duplicate name", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: schedule.ErrCalendarPeriodNameConflict}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -650,7 +650,7 @@ func TestCreatePeriod(t *testing.T) {
 		mock := &mockCalendarPeriodService{
 			err: &scheduleSvcErr{op: "create calendar period", inner: schedule.ErrCalendarPeriodNameConflict},
 		}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -667,7 +667,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 500 on service error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("create failed")}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -692,7 +692,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("updates period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -714,7 +714,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("updates period with anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -752,7 +752,7 @@ func TestUpdatePeriod(t *testing.T) {
 		anchoredPeriod.WeekCycleAnchor = &anchorTime
 
 		mock := &mockCalendarPeriodService{period: anchoredPeriod}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -775,7 +775,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("defaults week cycle length to 1", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -799,7 +799,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -812,7 +812,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 404 when period not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -825,7 +825,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 500 on get internal error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db connection failed")}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -838,7 +838,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid start_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -858,7 +858,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid end_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -878,7 +878,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid anchor in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -901,7 +901,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for end_date before start_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -925,7 +925,7 @@ func TestUpdatePeriod(t *testing.T) {
 			period:    existingPeriod,
 			updateErr: schedule.ErrCalendarPeriodNameConflict,
 		}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -949,7 +949,7 @@ func TestUpdatePeriod(t *testing.T) {
 			period:    existingPeriod,
 			updateErr: errors.New("db write failed"),
 		}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -975,7 +975,7 @@ func TestUpdatePeriod(t *testing.T) {
 func TestDeletePeriod(t *testing.T) {
 	t.Run("deletes period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: newTestPeriod()}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/42", nil)
@@ -986,7 +986,7 @@ func TestDeletePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/abc", nil)
@@ -996,7 +996,7 @@ func TestDeletePeriod(t *testing.T) {
 
 	t.Run("returns 404 when period not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/999", nil)
@@ -1009,7 +1009,7 @@ func TestDeletePeriod(t *testing.T) {
 			period:    newTestPeriod(),
 			deleteErr: errors.New("delete failed"),
 		}
-		res := NewResource(mock, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/42", nil)

--- a/backend/api/timetable/instances.go
+++ b/backend/api/timetable/instances.go
@@ -1,0 +1,187 @@
+// Package timetable — instance lifecycle handlers (WP-B9).
+//
+// Three POST endpoints per instance:
+//
+//	POST /instances/{id}/start     planned → active   (creates active.group bridge)
+//	POST /instances/{id}/complete  active  → completed (ends active.group)
+//	POST /instances/{id}/cancel    planned|active → cancelled (ends active.group if active)
+//
+// All three gated on permissions.SchedulesManage. All three run inside the
+// shared TenantTxMiddleware tx — no per-handler transaction management.
+package timetable
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+)
+
+// StartInstanceResponse is the 200 body for POST /instances/{id}/start. Warnings
+// is always present (empty array when clean) so clients can iterate without a
+// nil check.
+type StartInstanceResponse struct {
+	InstanceID    int64                                 `json:"instance_id"`
+	Status        string                                `json:"status"`
+	ActiveGroupID int64                                 `json:"active_group_id"`
+	StartedAt     string                                `json:"started_at"`
+	Warnings      []scheduleSvc.InstanceConflictWarning `json:"warnings"`
+}
+
+// InstanceStatusResponse is the 200 body for complete and cancel — minimal
+// because the frontend already has the full instance in its cache.
+type InstanceStatusResponse struct {
+	InstanceID  int64  `json:"instance_id"`
+	Status      string `json:"status"`
+	CompletedAt string `json:"completed_at,omitempty"`
+}
+
+// startInstance handles POST /instances/{id}/start.
+func (rs *Resource) startInstance(w http.ResponseWriter, r *http.Request) {
+	id, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid instance id")))
+		return
+	}
+	if rs.instanceService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("instance service not wired")))
+		return
+	}
+
+	// started_by is optional: resolve staff id from the JWT account, but do
+	// not reject the request if the lookup fails — the transition itself is
+	// permission-gated upstream, and a missing staff mapping is a data issue
+	// the admin should not see as a 500.
+	startedByStaffID := rs.resolveStartedByStaffID(r.Context())
+
+	result, err := rs.instanceService.Start(r.Context(), id, startedByStaffID)
+	if err != nil {
+		renderInstanceLifecycleError(w, r, err)
+		return
+	}
+
+	resp := StartInstanceResponse{
+		InstanceID:    result.Instance.ID,
+		Status:        result.Instance.Status,
+		ActiveGroupID: result.ActiveGroupID,
+		Warnings:      result.Warnings,
+	}
+	if result.Warnings == nil {
+		resp.Warnings = []scheduleSvc.InstanceConflictWarning{}
+	}
+	if result.Instance.StartedAt != nil {
+		resp.StartedAt = result.Instance.StartedAt.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	common.Respond(w, r, http.StatusOK, resp, "Instance started")
+}
+
+// completeInstance handles POST /instances/{id}/complete.
+func (rs *Resource) completeInstance(w http.ResponseWriter, r *http.Request) {
+	id, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid instance id")))
+		return
+	}
+	if rs.instanceService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("instance service not wired")))
+		return
+	}
+
+	instance, err := rs.instanceService.Complete(r.Context(), id)
+	if err != nil {
+		renderInstanceLifecycleError(w, r, err)
+		return
+	}
+
+	resp := InstanceStatusResponse{InstanceID: instance.ID, Status: instance.Status}
+	if instance.CompletedAt != nil {
+		resp.CompletedAt = instance.CompletedAt.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	common.Respond(w, r, http.StatusOK, resp, "Instance completed")
+}
+
+// cancelInstance handles POST /instances/{id}/cancel.
+func (rs *Resource) cancelInstance(w http.ResponseWriter, r *http.Request) {
+	id, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid instance id")))
+		return
+	}
+	if rs.instanceService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("instance service not wired")))
+		return
+	}
+
+	instance, err := rs.instanceService.Cancel(r.Context(), id)
+	if err != nil {
+		renderInstanceLifecycleError(w, r, err)
+		return
+	}
+
+	resp := InstanceStatusResponse{InstanceID: instance.ID, Status: instance.Status}
+	if instance.CompletedAt != nil {
+		resp.CompletedAt = instance.CompletedAt.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	common.Respond(w, r, http.StatusOK, resp, "Instance cancelled")
+}
+
+// renderInstanceLifecycleError maps service-layer sentinel errors to HTTP
+// status codes. Unknown errors fall through to 500 to avoid leaking a
+// potentially wrong 4xx for a real database failure.
+func renderInstanceLifecycleError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, scheduleSvc.ErrInstanceNotFound):
+		common.RenderError(w, r, common.ErrorNotFound(err))
+	case errors.Is(err, scheduleSvc.ErrInvalidInstanceTransition):
+		common.RenderError(w, r, common.ErrorConflictWithCode(err, "invalid_transition"))
+	default:
+		common.RenderError(w, r, common.ErrorInternalServerWrap("instance lifecycle failed", err))
+	}
+}
+
+// resolveStartedByStaffID is best-effort: if the JWT carries an account that
+// resolves to a staff row, return its id. Missing claims, missing person, or
+// missing staff row all return 0 — StartedBy is nullable in the schema and
+// the transition is already authorised via SchedulesManage.
+func (rs *Resource) resolveStartedByStaffID(ctx context.Context) int64 {
+	if rs.personService == nil {
+		return 0
+	}
+	claims, ok := ctx.Value(jwt.CtxClaims).(jwt.AppClaims)
+	if !ok {
+		return 0
+	}
+	accountID := int64(claims.ID)
+	person, err := rs.personService.FindByAccountID(ctx, accountID)
+	if err != nil || person == nil {
+		rs.getLogger().Debug("started_by lookup: person not found",
+			slog.Int64("account_id", accountID),
+		)
+		return 0
+	}
+	staffRepo := rs.personService.StaffRepository()
+	if staffRepo == nil {
+		return 0
+	}
+	staff, err := staffRepo.FindByPersonID(ctx, person.ID)
+	if err != nil || staff == nil {
+		rs.getLogger().Debug("started_by lookup: staff not found",
+			slog.Int64("person_id", person.ID),
+		)
+		return 0
+	}
+	return staff.ID
+}
+
+// getLogger is a nil-safe accessor used by helpers that run outside the
+// chi handler's standard error-rendering path.
+func (rs *Resource) getLogger() *slog.Logger {
+	if rs.logger != nil {
+		return rs.logger
+	}
+	return slog.Default()
+}

--- a/backend/api/timetable/instances_test.go
+++ b/backend/api/timetable/instances_test.go
@@ -1,0 +1,875 @@
+// Tests for WP-B9 instance lifecycle handlers (startInstance, completeInstance,
+// cancelInstance) and re-plan-week handler. Pure HTTP unit tests using mock
+// services — behavioural coverage of the state machine lives in
+// services/schedule/instance_service_integration_test.go.
+package timetable
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// -----------------------------------------------------------------------------
+// Mock InstanceService — drives the handler's service-layer contract.
+// -----------------------------------------------------------------------------
+
+type mockInstanceService struct {
+	startResult   *scheduleSvc.StartInstanceResult
+	startErr      error
+	completeRes   *scheduleModel.ActivityInstance
+	completeErr   error
+	cancelRes     *scheduleModel.ActivityInstance
+	cancelErr     error
+	replanRes     *scheduleSvc.ReplanWeekResult
+	replanErr     error
+	lastStartID   int64
+	lastStartedBy int64
+	lastFrom      time.Time
+	lastTo        time.Time
+}
+
+func (m *mockInstanceService) Start(_ context.Context, id, startedBy int64) (*scheduleSvc.StartInstanceResult, error) {
+	m.lastStartID = id
+	m.lastStartedBy = startedBy
+	if m.startErr != nil {
+		return nil, m.startErr
+	}
+	return m.startResult, nil
+}
+
+func (m *mockInstanceService) Complete(_ context.Context, _ int64) (*scheduleModel.ActivityInstance, error) {
+	if m.completeErr != nil {
+		return nil, m.completeErr
+	}
+	return m.completeRes, nil
+}
+
+func (m *mockInstanceService) Cancel(_ context.Context, _ int64) (*scheduleModel.ActivityInstance, error) {
+	if m.cancelErr != nil {
+		return nil, m.cancelErr
+	}
+	return m.cancelRes, nil
+}
+
+func (m *mockInstanceService) ReplanWeek(_ context.Context, from, to time.Time) (*scheduleSvc.ReplanWeekResult, error) {
+	m.lastFrom = from
+	m.lastTo = to
+	if m.replanErr != nil {
+		return nil, m.replanErr
+	}
+	return m.replanRes, nil
+}
+
+// -----------------------------------------------------------------------------
+// Mock StaffRepository — needed for resolveStartedByStaffID coverage.
+// -----------------------------------------------------------------------------
+
+type instMockStaffRepo struct {
+	findByPersonIDFn func(ctx context.Context, personID int64) (*userModels.Staff, error)
+}
+
+func (m *instMockStaffRepo) Create(_ context.Context, _ *userModels.Staff) error { return nil }
+func (m *instMockStaffRepo) FindByID(_ context.Context, _ any) (*userModels.Staff, error) {
+	return nil, nil
+}
+func (m *instMockStaffRepo) FindByPersonID(ctx context.Context, personID int64) (*userModels.Staff, error) {
+	if m.findByPersonIDFn != nil {
+		return m.findByPersonIDFn(ctx, personID)
+	}
+	return nil, nil
+}
+func (m *instMockStaffRepo) Update(_ context.Context, _ *userModels.Staff) error { return nil }
+func (m *instMockStaffRepo) Delete(_ context.Context, _ any) error               { return nil }
+func (m *instMockStaffRepo) List(_ context.Context, _ map[string]any) ([]*userModels.Staff, error) {
+	return nil, nil
+}
+func (m *instMockStaffRepo) ListAllWithPerson(_ context.Context) ([]*userModels.Staff, error) {
+	return nil, nil
+}
+func (m *instMockStaffRepo) UpdateNotes(_ context.Context, _ int64, _ string) error { return nil }
+func (m *instMockStaffRepo) FindWithPerson(_ context.Context, _ int64) (*userModels.Staff, error) {
+	return nil, nil
+}
+func (m *instMockStaffRepo) FindByIDs(_ context.Context, _ []int64) (map[int64]*userModels.Staff, error) {
+	return nil, nil
+}
+func (m *instMockStaffRepo) FindWithPersonByIDs(_ context.Context, _ []int64) (map[int64]*userModels.Staff, error) {
+	return nil, nil
+}
+func (m *instMockStaffRepo) ListStaffByRoles(_ context.Context, _ []string) ([]*userModels.StaffWithRoleInfo, error) {
+	return nil, nil
+}
+
+// -----------------------------------------------------------------------------
+// Mock PersonService — only the two methods the handler touches carry logic.
+// -----------------------------------------------------------------------------
+
+type instMockPersonService struct {
+	findByAccountIDFn func(ctx context.Context, accountID int64) (*userModels.Person, error)
+	staffRepo         userModels.StaffRepository
+}
+
+func (m *instMockPersonService) WithTx(_ bun.Tx) any { return m }
+func (m *instMockPersonService) Get(_ context.Context, _ any) (*userModels.Person, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) GetByIDs(_ context.Context, _ []int64) (map[int64]*userModels.Person, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) Create(_ context.Context, _ *userModels.Person) error { return nil }
+func (m *instMockPersonService) Update(_ context.Context, _ *userModels.Person) error { return nil }
+func (m *instMockPersonService) Delete(_ context.Context, _ any) error                { return nil }
+func (m *instMockPersonService) DeleteStaff(_ context.Context, _ int64) error         { return nil }
+func (m *instMockPersonService) List(_ context.Context, _ *base.QueryOptions) ([]*userModels.Person, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) FindByTagID(_ context.Context, _ string) (*userModels.Person, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) FindByAccountID(ctx context.Context, accountID int64) (*userModels.Person, error) {
+	if m.findByAccountIDFn != nil {
+		return m.findByAccountIDFn(ctx, accountID)
+	}
+	return nil, nil
+}
+func (m *instMockPersonService) FindByName(_ context.Context, _, _ string) ([]*userModels.Person, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) LinkToAccount(_ context.Context, _ int64, _ int64) error { return nil }
+func (m *instMockPersonService) UnlinkFromAccount(_ context.Context, _ int64) error      { return nil }
+func (m *instMockPersonService) LinkToRFIDCard(_ context.Context, _ int64, _ string) error {
+	return nil
+}
+func (m *instMockPersonService) UnlinkFromRFIDCard(_ context.Context, _ int64) error { return nil }
+func (m *instMockPersonService) GetFullProfile(_ context.Context, _ int64) (*userModels.Person, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) FindByGuardianID(_ context.Context, _ int64) ([]*userModels.Person, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) StaffRepository() userModels.StaffRepository     { return m.staffRepo }
+func (m *instMockPersonService) TeacherRepository() userModels.TeacherRepository { return nil }
+func (m *instMockPersonService) StudentRepository() userModels.StudentRepository { return nil }
+func (m *instMockPersonService) ListAvailableRFIDCards(_ context.Context) ([]*userModels.RFIDCard, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) ValidateStaffPIN(_ context.Context, _ string) (*userModels.Staff, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) ValidateStaffPINForSpecificStaff(_ context.Context, _ int64, _ string) (*userModels.Staff, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) GetStudentsByTeacher(_ context.Context, _ int64) ([]*userModels.Student, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) GetStudentsWithGroupsByTeacher(_ context.Context, _ int64) ([]usersSvc.StudentWithGroup, error) {
+	return nil, nil
+}
+func (m *instMockPersonService) GetAllStudentsWithGroups(_ context.Context) ([]usersSvc.StudentWithGroup, error) {
+	return nil, nil
+}
+
+// -----------------------------------------------------------------------------
+// Router helpers — mirror setupMaterializeRouter, parameterised for each route.
+// -----------------------------------------------------------------------------
+
+func setupLifecycleRouter(rs *Resource, route string, handler http.HandlerFunc) chi.Router {
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	r.Post(route, handler)
+	_ = rs
+	return r
+}
+
+func doPost(t *testing.T, router chi.Router, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(http.MethodPost, path, reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// -----------------------------------------------------------------------------
+// startInstance handler tests.
+// -----------------------------------------------------------------------------
+
+func TestStartInstance_Success(t *testing.T) {
+	startedAt := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	mock := &mockInstanceService{
+		startResult: &scheduleSvc.StartInstanceResult{
+			Instance: &scheduleModel.ActivityInstance{
+				Status:    scheduleModel.InstanceStatusActive,
+				StartedAt: &startedAt,
+			},
+			ActiveGroupID: 42,
+			Warnings:      nil,
+		},
+	}
+	mock.startResult.Instance.ID = int64(7)
+
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
+
+	w := doPost(t, router, "/instances/7/start", nil)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, int64(7), mock.lastStartID)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data, ok := resp["data"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(7), data["instance_id"])
+	assert.Equal(t, "active", data["status"])
+	assert.Equal(t, float64(42), data["active_group_id"])
+	// Warnings must always be an array, never null.
+	warnings, ok := data["warnings"].([]any)
+	require.True(t, ok, "warnings must be an array")
+	assert.Empty(t, warnings)
+	assert.Equal(t, "2026-04-20T10:00:00Z", data["started_at"])
+}
+
+func TestStartInstance_WithWarnings(t *testing.T) {
+	mock := &mockInstanceService{
+		startResult: &scheduleSvc.StartInstanceResult{
+			Instance:      &scheduleModel.ActivityInstance{Status: scheduleModel.InstanceStatusActive},
+			ActiveGroupID: 1,
+			Warnings: []scheduleSvc.InstanceConflictWarning{
+				{Kind: scheduleSvc.ConflictKindRoom, ResourceID: 5, Message: "Raum belegt", CanOverride: true},
+			},
+		},
+	}
+	mock.startResult.Instance.ID = int64(3)
+
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
+
+	w := doPost(t, router, "/instances/3/start", nil)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]any)
+	warnings := data["warnings"].([]any)
+	assert.Len(t, warnings, 1)
+}
+
+func TestStartInstance_InvalidID(t *testing.T) {
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
+
+	w := doPost(t, router, "/instances/not-a-number/start", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestStartInstance_NilService(t *testing.T) {
+	rs := NewResource(nil, nil, nil, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
+
+	w := doPost(t, router, "/instances/1/start", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestStartInstance_NotFound(t *testing.T) {
+	mock := &mockInstanceService{startErr: scheduleSvc.ErrInstanceNotFound}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
+
+	w := doPost(t, router, "/instances/99/start", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestStartInstance_InvalidTransition(t *testing.T) {
+	mock := &mockInstanceService{startErr: errors.New("wrap: " + scheduleSvc.ErrInvalidInstanceTransition.Error())}
+	// Use an error that errors.Is matches via wrapping.
+	mock.startErr = &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
+
+	w := doPost(t, router, "/instances/1/start", nil)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid_transition")
+}
+
+func TestStartInstance_InternalError(t *testing.T) {
+	mock := &mockInstanceService{startErr: errors.New("db connection lost")}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
+
+	w := doPost(t, router, "/instances/1/start", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// wrappedErr exists so we can wrap a sentinel in an unexported type without
+// dragging the services.ScheduleError into this test package.
+type wrappedErr struct{ inner error }
+
+func (e *wrappedErr) Error() string { return "wrapped: " + e.inner.Error() }
+func (e *wrappedErr) Unwrap() error { return e.inner }
+
+// -----------------------------------------------------------------------------
+// completeInstance handler tests.
+// -----------------------------------------------------------------------------
+
+func TestCompleteInstance_Success(t *testing.T) {
+	completed := time.Date(2026, 4, 20, 12, 30, 0, 0, time.UTC)
+	instance := &scheduleModel.ActivityInstance{
+		Status:      scheduleModel.InstanceStatusCompleted,
+		CompletedAt: &completed,
+	}
+	instance.ID = int64(5)
+
+	mock := &mockInstanceService{completeRes: instance}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
+
+	w := doPost(t, router, "/instances/5/complete", nil)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, float64(5), data["instance_id"])
+	assert.Equal(t, "completed", data["status"])
+	assert.Equal(t, "2026-04-20T12:30:00Z", data["completed_at"])
+}
+
+func TestCompleteInstance_NoCompletedAt(t *testing.T) {
+	// When service returns an instance without CompletedAt (data anomaly),
+	// handler must still return 200 with omitted completed_at field.
+	instance := &scheduleModel.ActivityInstance{Status: scheduleModel.InstanceStatusCompleted}
+	instance.ID = int64(5)
+
+	mock := &mockInstanceService{completeRes: instance}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
+
+	w := doPost(t, router, "/instances/5/complete", nil)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, w.Body.String(), "completed_at")
+}
+
+func TestCompleteInstance_InvalidID(t *testing.T) {
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
+
+	w := doPost(t, router, "/instances/bad/complete", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCompleteInstance_NilService(t *testing.T) {
+	rs := NewResource(nil, nil, nil, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
+
+	w := doPost(t, router, "/instances/1/complete", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestCompleteInstance_NotFound(t *testing.T) {
+	mock := &mockInstanceService{completeErr: scheduleSvc.ErrInstanceNotFound}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
+
+	w := doPost(t, router, "/instances/1/complete", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCompleteInstance_InvalidTransition(t *testing.T) {
+	mock := &mockInstanceService{completeErr: &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
+
+	w := doPost(t, router, "/instances/1/complete", nil)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid_transition")
+}
+
+func TestCompleteInstance_InternalError(t *testing.T) {
+	mock := &mockInstanceService{completeErr: errors.New("db error")}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
+
+	w := doPost(t, router, "/instances/1/complete", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// -----------------------------------------------------------------------------
+// cancelInstance handler tests.
+// -----------------------------------------------------------------------------
+
+func TestCancelInstance_Success(t *testing.T) {
+	completed := time.Date(2026, 4, 20, 15, 0, 0, 0, time.UTC)
+	instance := &scheduleModel.ActivityInstance{
+		Status:      scheduleModel.InstanceStatusCancelled,
+		CompletedAt: &completed,
+	}
+	instance.ID = int64(11)
+
+	mock := &mockInstanceService{cancelRes: instance}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
+
+	w := doPost(t, router, "/instances/11/cancel", nil)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, float64(11), data["instance_id"])
+	assert.Equal(t, "cancelled", data["status"])
+	assert.Equal(t, "2026-04-20T15:00:00Z", data["completed_at"])
+}
+
+func TestCancelInstance_NoCompletedAt(t *testing.T) {
+	instance := &scheduleModel.ActivityInstance{Status: scheduleModel.InstanceStatusCancelled}
+	instance.ID = int64(12)
+	mock := &mockInstanceService{cancelRes: instance}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
+
+	w := doPost(t, router, "/instances/12/cancel", nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCancelInstance_InvalidID(t *testing.T) {
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
+
+	w := doPost(t, router, "/instances/nope/cancel", nil)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCancelInstance_NilService(t *testing.T) {
+	rs := NewResource(nil, nil, nil, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
+
+	w := doPost(t, router, "/instances/1/cancel", nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestCancelInstance_NotFound(t *testing.T) {
+	mock := &mockInstanceService{cancelErr: scheduleSvc.ErrInstanceNotFound}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
+
+	w := doPost(t, router, "/instances/1/cancel", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCancelInstance_InvalidTransition(t *testing.T) {
+	mock := &mockInstanceService{cancelErr: &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
+
+	w := doPost(t, router, "/instances/1/cancel", nil)
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestCancelInstance_InternalError(t *testing.T) {
+	mock := &mockInstanceService{cancelErr: errors.New("db failure")}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
+
+	w := doPost(t, router, "/instances/1/cancel", nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// -----------------------------------------------------------------------------
+// resolveStartedByStaffID tests — exercised directly because the other paths
+// only drive the JWT-absent branch through the handler.
+// -----------------------------------------------------------------------------
+
+func TestResolveStartedByStaffID_NilPersonService(t *testing.T) {
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil)
+	staffID := rs.resolveStartedByStaffID(context.Background())
+	assert.Equal(t, int64(0), staffID)
+}
+
+func TestResolveStartedByStaffID_NoClaimsInContext(t *testing.T) {
+	rs := NewResource(nil, nil, &mockInstanceService{}, &instMockPersonService{}, nil, nil)
+	staffID := rs.resolveStartedByStaffID(context.Background())
+	assert.Equal(t, int64(0), staffID)
+}
+
+func TestResolveStartedByStaffID_PersonNotFound(t *testing.T) {
+	ps := &instMockPersonService{
+		findByAccountIDFn: func(_ context.Context, _ int64) (*userModels.Person, error) {
+			return nil, errors.New("person not found")
+		},
+	}
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	claims := jwt.AppClaims{ID: 123}
+	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
+
+	staffID := rs.resolveStartedByStaffID(ctx)
+	assert.Equal(t, int64(0), staffID)
+}
+
+func TestResolveStartedByStaffID_PersonIsNil(t *testing.T) {
+	ps := &instMockPersonService{
+		findByAccountIDFn: func(_ context.Context, _ int64) (*userModels.Person, error) {
+			return nil, nil
+		},
+	}
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	claims := jwt.AppClaims{ID: 123}
+	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
+
+	staffID := rs.resolveStartedByStaffID(ctx)
+	assert.Equal(t, int64(0), staffID)
+}
+
+func TestResolveStartedByStaffID_StaffRepoNil(t *testing.T) {
+	person := &userModels.Person{}
+	person.ID = int64(55)
+	ps := &instMockPersonService{
+		findByAccountIDFn: func(_ context.Context, _ int64) (*userModels.Person, error) {
+			return person, nil
+		},
+		staffRepo: nil, // returns nil from StaffRepository()
+	}
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	claims := jwt.AppClaims{ID: 123}
+	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
+
+	staffID := rs.resolveStartedByStaffID(ctx)
+	assert.Equal(t, int64(0), staffID)
+}
+
+func TestResolveStartedByStaffID_StaffNotFound(t *testing.T) {
+	person := &userModels.Person{}
+	person.ID = int64(55)
+	staffRepo := &instMockStaffRepo{
+		findByPersonIDFn: func(_ context.Context, _ int64) (*userModels.Staff, error) {
+			return nil, errors.New("not found")
+		},
+	}
+	ps := &instMockPersonService{
+		findByAccountIDFn: func(_ context.Context, _ int64) (*userModels.Person, error) {
+			return person, nil
+		},
+		staffRepo: staffRepo,
+	}
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	claims := jwt.AppClaims{ID: 123}
+	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
+
+	staffID := rs.resolveStartedByStaffID(ctx)
+	assert.Equal(t, int64(0), staffID)
+}
+
+func TestResolveStartedByStaffID_StaffIsNil(t *testing.T) {
+	person := &userModels.Person{}
+	person.ID = int64(55)
+	staffRepo := &instMockStaffRepo{
+		findByPersonIDFn: func(_ context.Context, _ int64) (*userModels.Staff, error) {
+			return nil, nil
+		},
+	}
+	ps := &instMockPersonService{
+		findByAccountIDFn: func(_ context.Context, _ int64) (*userModels.Person, error) {
+			return person, nil
+		},
+		staffRepo: staffRepo,
+	}
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	claims := jwt.AppClaims{ID: 123}
+	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
+
+	staffID := rs.resolveStartedByStaffID(ctx)
+	assert.Equal(t, int64(0), staffID)
+}
+
+func TestResolveStartedByStaffID_Success(t *testing.T) {
+	person := &userModels.Person{}
+	person.ID = int64(55)
+	staff := &userModels.Staff{}
+	staff.ID = int64(777)
+	staffRepo := &instMockStaffRepo{
+		findByPersonIDFn: func(_ context.Context, personID int64) (*userModels.Staff, error) {
+			assert.Equal(t, int64(55), personID)
+			return staff, nil
+		},
+	}
+	ps := &instMockPersonService{
+		findByAccountIDFn: func(_ context.Context, accountID int64) (*userModels.Person, error) {
+			assert.Equal(t, int64(123), accountID)
+			return person, nil
+		},
+		staffRepo: staffRepo,
+	}
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	claims := jwt.AppClaims{ID: 123}
+	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
+
+	staffID := rs.resolveStartedByStaffID(ctx)
+	assert.Equal(t, int64(777), staffID)
+}
+
+// startInstance drives resolveStartedByStaffID with JWT claims threaded into
+// the request — ensures the handler wires the context through correctly.
+func TestStartInstance_PassesStartedByFromJWT(t *testing.T) {
+	person := &userModels.Person{}
+	person.ID = int64(55)
+	staff := &userModels.Staff{}
+	staff.ID = int64(888)
+	staffRepo := &instMockStaffRepo{
+		findByPersonIDFn: func(_ context.Context, _ int64) (*userModels.Staff, error) {
+			return staff, nil
+		},
+	}
+	ps := &instMockPersonService{
+		findByAccountIDFn: func(_ context.Context, _ int64) (*userModels.Person, error) {
+			return person, nil
+		},
+		staffRepo: staffRepo,
+	}
+
+	instance := &scheduleModel.ActivityInstance{Status: scheduleModel.InstanceStatusActive}
+	instance.ID = int64(1)
+	mock := &mockInstanceService{
+		startResult: &scheduleSvc.StartInstanceResult{
+			Instance:      instance,
+			ActiveGroupID: 1,
+		},
+	}
+	rs := NewResource(nil, nil, mock, ps, slog.Default(), nil)
+
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	// Inject JWT claims middleware before the handler.
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			claims := jwt.AppClaims{ID: 123}
+			ctx := context.WithValue(req.Context(), jwt.CtxClaims, claims)
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	})
+	r.Post("/instances/{id}/start", rs.startInstance)
+
+	w := doPost(t, r, "/instances/1/start", nil)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, int64(888), mock.lastStartedBy)
+}
+
+// -----------------------------------------------------------------------------
+// getLogger tests.
+// -----------------------------------------------------------------------------
+
+func TestResource_getLogger(t *testing.T) {
+	t.Run("returns injected logger", func(t *testing.T) {
+		custom := slog.Default()
+		rs := NewResource(nil, nil, nil, nil, custom, nil)
+		assert.NotNil(t, rs.getLogger())
+	})
+
+	t.Run("falls back to slog.Default when nil", func(t *testing.T) {
+		rs := NewResource(nil, nil, nil, nil, nil, nil)
+		assert.NotNil(t, rs.getLogger(), "must never return nil")
+	})
+}
+
+// -----------------------------------------------------------------------------
+// replanWeek handler tests.
+// -----------------------------------------------------------------------------
+
+func TestReplanWeekRequest_Bind_NoOp(t *testing.T) {
+	req := &replanWeekRequest{}
+	err := req.Bind(nil)
+	assert.NoError(t, err, "Bind is intentionally a no-op")
+}
+
+func TestReplanWeek_NilService(t *testing.T) {
+	rs := NewResource(nil, nil, nil, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
+
+	w := doPost(t, router, "/instances/re-plan-week", nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestReplanWeek_NoBody_DefaultsToNextWeek(t *testing.T) {
+	mock := &mockInstanceService{
+		replanRes: &scheduleSvc.ReplanWeekResult{
+			From:             time.Date(2026, 4, 27, 0, 0, 0, 0, time.UTC),
+			To:               time.Date(2026, 5, 3, 0, 0, 0, 0, time.UTC),
+			DeletedInstances: 5,
+			Materialization: &scheduleSvc.MaterializationResult{
+				InstancesCreated:          8,
+				CandidatesSkippedExisting: 0,
+				InstanceStaffCreated:      4,
+				InstanceStudentsCreated:   16,
+				DurationMS:                42,
+			},
+		},
+	}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
+
+	w := doPost(t, router, "/instances/re-plan-week", nil)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, "2026-04-27", data["from"])
+	assert.Equal(t, "2026-05-03", data["to"])
+	assert.Equal(t, float64(5), data["deleted_instances"])
+	assert.Equal(t, float64(8), data["instances_created"])
+	assert.Equal(t, float64(4), data["instance_staff_created"])
+	assert.Equal(t, float64(16), data["instance_students_created"])
+	assert.Equal(t, float64(42), data["duration_ms"])
+}
+
+func TestReplanWeek_ValidBody(t *testing.T) {
+	mock := &mockInstanceService{
+		replanRes: &scheduleSvc.ReplanWeekResult{
+			From:             time.Date(2026, 4, 27, 0, 0, 0, 0, time.UTC),
+			To:               time.Date(2026, 5, 3, 0, 0, 0, 0, time.UTC),
+			DeletedInstances: 2,
+			Materialization:  &scheduleSvc.MaterializationResult{InstancesCreated: 3},
+		},
+	}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
+
+	body := map[string]string{
+		"from_date": "2026-04-27",
+		"to_date":   "2026-05-03",
+	}
+	w := doPost(t, router, "/instances/re-plan-week", body)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "2026-04-27", mock.lastFrom.Format("2006-01-02"))
+	assert.Equal(t, "2026-05-03", mock.lastTo.Format("2006-01-02"))
+}
+
+func TestReplanWeek_NilMaterialization(t *testing.T) {
+	// Result with nil Materialization should still render a 200 with zero-valued
+	// counts — defensive branch in the handler.
+	mock := &mockInstanceService{
+		replanRes: &scheduleSvc.ReplanWeekResult{
+			From:             time.Date(2026, 4, 27, 0, 0, 0, 0, time.UTC),
+			To:               time.Date(2026, 5, 3, 0, 0, 0, 0, time.UTC),
+			DeletedInstances: 1,
+			Materialization:  nil,
+		},
+	}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
+
+	w := doPost(t, router, "/instances/re-plan-week", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, float64(0), data["instances_created"])
+}
+
+func TestReplanWeek_InvalidWindow(t *testing.T) {
+	mock := &mockInstanceService{}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
+
+	body := map[string]string{
+		"from_date": "2026-05-03",
+		"to_date":   "2026-04-27", // to < from
+	}
+	w := doPost(t, router, "/instances/re-plan-week", body)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestReplanWeek_InvalidJSON(t *testing.T) {
+	mock := &mockInstanceService{}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
+
+	req := httptest.NewRequest(http.MethodPost, "/instances/re-plan-week", bytes.NewReader([]byte("{not json")))
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = 9
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestReplanWeek_ServiceError(t *testing.T) {
+	mock := &mockInstanceService{replanErr: errors.New("db exploded")}
+	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
+
+	w := doPost(t, router, "/instances/re-plan-week", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// -----------------------------------------------------------------------------
+// renderInstanceLifecycleError — covered indirectly through the handler tests
+// above; this test pins the three branches with a minimal http.ResponseWriter.
+// -----------------------------------------------------------------------------
+
+func TestRenderInstanceLifecycleError(t *testing.T) {
+	t.Run("not-found", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		renderInstanceLifecycleError(w, r, scheduleSvc.ErrInstanceNotFound)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("invalid-transition", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		renderInstanceLifecycleError(w, r, scheduleSvc.ErrInvalidInstanceTransition)
+		assert.Equal(t, http.StatusConflict, w.Code)
+		assert.Contains(t, w.Body.String(), "invalid_transition")
+	})
+
+	t.Run("unknown-error-500", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		renderInstanceLifecycleError(w, r, errors.New("something broke"))
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}

--- a/backend/api/timetable/materialize_test.go
+++ b/backend/api/timetable/materialize_test.go
@@ -142,7 +142,7 @@ func TestMaterialize_NoBody_DefaultsToNextWeek(t *testing.T) {
 			InstanceStaffCreated:    2,
 		},
 	}
-	rs := NewResource(nil, mock, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -162,7 +162,7 @@ func TestMaterialize_ValidBody_ParsesAndForwards(t *testing.T) {
 	mock := &mockMaterializer{
 		result: &scheduleSvc.MaterializationResult{InstancesCreated: 1},
 	}
-	rs := NewResource(nil, mock, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	body, _ := json.Marshal(map[string]string{
@@ -188,7 +188,7 @@ func TestMaterialize_ValidBody_ParsesAndForwards(t *testing.T) {
 
 func TestMaterialize_InvalidWindow_Returns400(t *testing.T) {
 	mock := &mockMaterializer{}
-	rs := NewResource(nil, mock, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	body, _ := json.Marshal(map[string]string{
@@ -205,7 +205,7 @@ func TestMaterialize_InvalidWindow_Returns400(t *testing.T) {
 }
 
 func TestMaterialize_NilService_Returns500(t *testing.T) {
-	rs := NewResource(nil, nil, nil)
+	rs := NewResource(nil, nil, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -217,7 +217,7 @@ func TestMaterialize_NilService_Returns500(t *testing.T) {
 
 func TestMaterialize_ServiceError_Returns500(t *testing.T) {
 	mock := &mockMaterializer{err: errors.New("boom")}
-	rs := NewResource(nil, mock, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)

--- a/backend/api/timetable/replan_week.go
+++ b/backend/api/timetable/replan_week.go
@@ -1,0 +1,91 @@
+// Package timetable — re-plan-week handler (WP-B9).
+//
+// POST /instances/re-plan-week deletes protected-status='planned' non-spontaneous
+// instances in a date window and re-materializes. active/completed/cancelled
+// rows and spontaneous planned rows survive. Admin-only (SchedulesManage).
+package timetable
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+)
+
+// replanWeekRequest mirrors materializeRequest: both date fields optional,
+// both-or-neither rule, default = next Mon–Sun when omitted. Shared body
+// shape keeps admin UIs from having to special-case two near-identical
+// endpoints.
+type replanWeekRequest struct {
+	FromDate *string `json:"from_date,omitempty"`
+	ToDate   *string `json:"to_date,omitempty"`
+}
+
+// Bind is a no-op. Same rationale as materializeRequest.Bind: date parsing
+// and both-or-neither validation happen inside the handler via the shared
+// resolveMaterializationWindow helper, because chi/render rejects an empty
+// body when Bind returns a non-nil error, breaking the "no body = defaults"
+// path.
+func (req *replanWeekRequest) Bind(_ *http.Request) error {
+	return nil
+}
+
+// replanWeekResponse surfaces both the delete count and the materialization
+// counts so admins can sanity-check the operation.
+type replanWeekResponse struct {
+	From                      string `json:"from"`
+	To                        string `json:"to"`
+	DeletedInstances          int    `json:"deleted_instances"`
+	InstancesCreated          int    `json:"instances_created"`
+	CandidatesSkippedExisting int    `json:"candidates_skipped_existing"`
+	InstanceStaffCreated      int    `json:"instance_staff_created"`
+	InstanceStudentsCreated   int    `json:"instance_students_created"`
+	DurationMS                int64  `json:"duration_ms"`
+}
+
+// replanWeek handles POST /instances/re-plan-week.
+func (rs *Resource) replanWeek(w http.ResponseWriter, r *http.Request) {
+	if rs.instanceService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("instance service not wired")))
+		return
+	}
+
+	req := &replanWeekRequest{}
+	if r.ContentLength > 0 {
+		if err := render.Bind(r, req); err != nil {
+			common.RenderError(w, r, common.ErrorInvalidRequest(err))
+			return
+		}
+	}
+
+	// The shared window helper enforces the same validation as /materialize:
+	// ≤ 56 days, from ≤ to, both-or-neither. Keep the rule in one place.
+	bodyForWindow := &materializeRequest{FromDate: req.FromDate, ToDate: req.ToDate}
+	from, to, err := resolveMaterializationWindow(bodyForWindow, time.Now())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	result, err := rs.instanceService.ReplanWeek(r.Context(), from, to)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("replan week failed", err))
+		return
+	}
+
+	resp := replanWeekResponse{
+		From:             result.From.Format(dateLayout),
+		To:               result.To.Format(dateLayout),
+		DeletedInstances: result.DeletedInstances,
+	}
+	if result.Materialization != nil {
+		resp.InstancesCreated = result.Materialization.InstancesCreated
+		resp.CandidatesSkippedExisting = result.Materialization.CandidatesSkippedExisting
+		resp.InstanceStaffCreated = result.Materialization.InstanceStaffCreated
+		resp.InstanceStudentsCreated = result.Materialization.InstanceStudentsCreated
+		resp.DurationMS = result.Materialization.DurationMS
+	}
+	common.Respond(w, r, http.StatusOK, resp, "Week re-planned")
+}

--- a/backend/realtime/events.go
+++ b/backend/realtime/events.go
@@ -18,6 +18,15 @@ const (
 	EventActivityEnd    EventType = "activity_end"
 	EventActivityUpdate EventType = "activity_update"
 
+	// Instance lifecycle events (WP-B9). Instances are the "planned" layer
+	// between template (activities.*) and live (active.*). These fire on the
+	// lifecycle transitions driven by admin/staff via the planner — distinct
+	// from activity_start/end which are IoT/NFC driven and emit per active.group.
+	EventInstanceStarted   EventType = "instance_started"
+	EventInstanceCompleted EventType = "instance_completed"
+	EventInstanceCancelled EventType = "instance_cancelled"
+	EventInstanceOverdue   EventType = "instance_overdue"
+
 	// Global refresh event — tells all clients to re-fetch dashboard counts
 	EventDashboardCountsChanged EventType = "dashboard_counts_changed"
 )
@@ -44,6 +53,13 @@ type EventData struct {
 	RoomID        *string   `json:"room_id,omitempty"`
 	RoomName      *string   `json:"room_name,omitempty"`
 	SupervisorIDs *[]string `json:"supervisor_ids,omitempty"`
+
+	// Instance lifecycle fields (for instance_* events, WP-B9). String-typed
+	// so the Event envelope's ActiveGroupID convention stays consistent and
+	// so empty values serialize cleanly via omitempty.
+	InstanceID        *string `json:"instance_id,omitempty"`
+	InstanceDate      *string `json:"instance_date,omitempty"`       // YYYY-MM-DD
+	InstanceStartTime *string `json:"instance_start_time,omitempty"` // HH:MM:SS
 
 	// Source tracking
 	Source *string `json:"source,omitempty"` // "rfid", "manual", "automated"

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -59,6 +59,7 @@ type Factory struct {
 	ArrivalSchedule          schedule.ArrivalScheduleService
 	CalendarPeriod           schedule.CalendarPeriodService
 	Materialization          schedule.MaterializationService
+	Instance                 schedule.InstanceService
 	Users                    users.PersonService
 	CaregiverCapability      users.CaregiverCapabilityService
 	Guardian                 users.GuardianService
@@ -342,6 +343,27 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		logger.With("service", "materialization"),
 	)
 
+	// Initialize instance lifecycle service (WP-B9). Drives the state machine
+	// on schedule.activity_instances and its bridge to active.groups. Takes
+	// the active service as a dependency (for EndActivitySession) — when the
+	// bridge closes, visits + supervisors close and per-student checkout SSE
+	// events fire, matching today's observable behavior for a session ending.
+	instanceService := schedule.NewInstanceService(schedule.InstanceServiceDependencies{
+		InstanceRepo:      repos.ActivityInstance,
+		InstanceStaffRepo: repos.InstanceStaff,
+		InstanceStudents:  repos.InstanceStudent,
+		ActiveGroupRepo:   repos.ActiveGroup,
+		SupervisorRepo:    repos.GroupSupervisor,
+		VisitRepo:         repos.ActiveVisit,
+		RoomRepo:          repos.Room,
+		ActivityGroupRepo: repos.ActivityGroup,
+		ActiveService:     activeService,
+		Materialization:   materializationService,
+		Broadcaster:       realtimeHub,
+		DB:                db,
+		Logger:            logger.With("service", "instance-lifecycle"),
+	})
+
 	// Initialize arrival schedule service
 	arrivalScheduleService := schedule.NewArrivalScheduleService(
 		repos.StudentArrivalSchedule,
@@ -574,6 +596,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		ArrivalSchedule:          arrivalScheduleService,
 		CalendarPeriod:           calendarPeriodService,
 		Materialization:          materializationService,
+		Instance:                 instanceService,
 		Users:                    usersService,
 		CaregiverCapability:      caregiverCapabilityService,
 		Guardian:                 guardianService,

--- a/backend/services/schedule/instance_conflict.go
+++ b/backend/services/schedule/instance_conflict.go
@@ -1,0 +1,164 @@
+// Package schedule — instance conflict detection (WP-B9).
+//
+// Soft-warning detection fired on POST /instances/{id}/start. All three
+// sub-checks are read-only and NEVER block the transition: they run inside
+// the caller's tenant transaction so a roll-back discards them cleanly, and
+// the transition proceeds regardless of what they find. Every warning carries
+// can_override=true in v1; a future WP may introduce hard blocks.
+package schedule
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+// Conflict kinds — stable string values exported to clients so the frontend
+// can switch on kind rather than parsing German messages.
+const (
+	ConflictKindRoom    = "room"
+	ConflictKindStaff   = "staff"
+	ConflictKindStudent = "student"
+)
+
+// InstanceConflictWarning is a single soft warning surfaced on the start
+// response. One entry per (kind, resource) pair. Multiple warnings per kind
+// are possible (e.g. two staff already supervising elsewhere).
+//
+// This is a new type rather than a reuse of api/iot/sessions.ConflictInfoResponse
+// because that type's ConflictingDevice field is meaningless for planner-driven
+// transitions (no device is involved for staff/student conflicts). Keeping the
+// IoT shape unchanged lets both flows evolve independently.
+type InstanceConflictWarning struct {
+	Kind        string `json:"kind"`         // "room" | "staff" | "student"
+	ResourceID  int64  `json:"resource_id"`  // room_id / staff_id / student_id
+	Message     string `json:"message"`      // German user-facing copy
+	CanOverride bool   `json:"can_override"` // always true in v1
+}
+
+// ConflictDependencies groups the repos needed by DetectStartConflicts so
+// the service wiring is explicit. All fields are required; passing nil for
+// any of them is a programmer error and will panic on first call — there is
+// no graceful-degradation path here because the planner cannot reliably
+// decide whether to warn without all three checks.
+type ConflictDependencies struct {
+	GroupRepo         active.GroupRepository
+	SupervisorRepo    active.GroupSupervisorRepository
+	VisitRepo         active.VisitRepository
+	InstanceStaffRepo scheduleModel.InstanceStaffRepository
+	InstanceStudents  scheduleModel.InstanceStudentRepository
+}
+
+// DetectStartConflicts runs the three sub-checks for the given planned
+// instance and returns a (possibly empty) list of warnings. It mutates
+// nothing and never returns an error that should block the transition —
+// a DB error on one sub-check is logged and surfaces as zero warnings for
+// that kind; the caller continues.
+//
+// Ordering is deterministic: room first, then staff (sorted by instance_staff
+// row ID), then student (sorted by instance_students row ID). Tests rely on
+// that ordering; do not reorder without updating expectations.
+func DetectStartConflicts(
+	ctx context.Context,
+	deps ConflictDependencies,
+	instance *scheduleModel.ActivityInstance,
+	logger *slog.Logger,
+) []InstanceConflictWarning {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	var warnings []InstanceConflictWarning
+
+	// 1. Room — reuse existing CheckRoomConflict (models/active/repository.go:44).
+	// excludeGroupID=0 means "no exclusion": an instance is not yet bridged to
+	// an active.group at start time, so any hit is a real conflict.
+	has, conflicting, err := deps.GroupRepo.CheckRoomConflict(ctx, instance.RoomID, 0)
+	if err != nil {
+		logger.Warn("conflict detection: room check failed",
+			slog.Int64("instance_id", instance.ID),
+			slog.Int64("room_id", instance.RoomID),
+			slog.String("error", err.Error()),
+		)
+	} else if has && conflicting != nil {
+		warnings = append(warnings, InstanceConflictWarning{
+			Kind:        ConflictKindRoom,
+			ResourceID:  instance.RoomID,
+			Message:     fmt.Sprintf("Raum ist bereits durch aktive Gruppe #%d belegt", conflicting.ID),
+			CanOverride: true,
+		})
+	}
+
+	// 2. Staff — each assigned staff member must not already be supervising
+	// an active.group. FindActiveByStaffID filters on end_date IS NULL /
+	// end_date > NOW() at the repo level, so a result means "still supervising".
+	staffRows, err := deps.InstanceStaffRepo.FindByInstanceID(ctx, instance.ID)
+	if err != nil {
+		logger.Warn("conflict detection: load instance_staff failed",
+			slog.Int64("instance_id", instance.ID),
+			slog.String("error", err.Error()),
+		)
+	}
+	for _, row := range staffRows {
+		supervisions, err := deps.SupervisorRepo.FindActiveByStaffID(ctx, row.StaffID)
+		if err != nil {
+			logger.Warn("conflict detection: staff supervision lookup failed",
+				slog.Int64("staff_id", row.StaffID),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		if len(supervisions) == 0 {
+			continue
+		}
+		// Flag the first active supervision — listing them all gets noisy on
+		// a staff member with multiple overlapping roles, and the frontend
+		// only needs to know "there is at least one conflict" per staff_id.
+		sup := supervisions[0]
+		warnings = append(warnings, InstanceConflictWarning{
+			Kind:        ConflictKindStaff,
+			ResourceID:  row.StaffID,
+			Message:     fmt.Sprintf("Mitarbeiter betreut bereits aktive Gruppe #%d", sup.GroupID),
+			CanOverride: true,
+		})
+	}
+
+	// 3. Student — each expected student must not already have an open visit.
+	// A student mid-visit elsewhere would show up in two groups simultaneously;
+	// informational only, never blocking. The check ignores students already
+	// in statuses other than expected (present/absent are post-check-in states
+	// that belong to other instances in this tenant's day).
+	studentRows, err := deps.InstanceStudents.FindByInstanceID(ctx, instance.ID)
+	if err != nil {
+		logger.Warn("conflict detection: load instance_students failed",
+			slog.Int64("instance_id", instance.ID),
+			slog.String("error", err.Error()),
+		)
+	}
+	for _, row := range studentRows {
+		if row.Status != scheduleModel.AttendanceStatusExpected {
+			continue
+		}
+		visit, err := deps.VisitRepo.GetCurrentByStudentID(ctx, row.StudentID)
+		if err != nil {
+			logger.Warn("conflict detection: student current visit lookup failed",
+				slog.Int64("student_id", row.StudentID),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		if visit == nil {
+			continue
+		}
+		warnings = append(warnings, InstanceConflictWarning{
+			Kind:        ConflictKindStudent,
+			ResourceID:  row.StudentID,
+			Message:     fmt.Sprintf("Schüler hat bereits einen aktiven Aufenthalt in Gruppe #%d", visit.ActiveGroupID),
+			CanOverride: true,
+		})
+	}
+
+	return warnings
+}

--- a/backend/services/schedule/instance_conflict.go
+++ b/backend/services/schedule/instance_conflict.go
@@ -102,6 +102,13 @@ func DetectStartConflicts(
 		)
 	}
 	for _, row := range staffRows {
+		// Absent rows are not candidates for supervision on this instance;
+		// flagging them as "supervising elsewhere" would be misleading. Start()
+		// also skips them when copying to active.group_supervisors, so the two
+		// paths stay consistent.
+		if row.IsAbsent {
+			continue
+		}
 		supervisions, err := deps.SupervisorRepo.FindActiveByStaffID(ctx, row.StaffID)
 		if err != nil {
 			logger.Warn("conflict detection: staff supervision lookup failed",
@@ -130,6 +137,10 @@ func DetectStartConflicts(
 	// informational only, never blocking. The check ignores students already
 	// in statuses other than expected (present/absent are post-check-in states
 	// that belong to other instances in this tenant's day).
+	//
+	// Batched via GetCurrentByStudentIDs — per-student lookups would produce
+	// N queries on an instance with N expected students (20+ for a typical
+	// OGS group), measurable latency inside the tenant tx.
 	studentRows, err := deps.InstanceStudents.FindByInstanceID(ctx, instance.ID)
 	if err != nil {
 		logger.Warn("conflict detection: load instance_students failed",
@@ -137,27 +148,38 @@ func DetectStartConflicts(
 			slog.String("error", err.Error()),
 		)
 	}
+	expectedIDs := make([]int64, 0, len(studentRows))
 	for _, row := range studentRows {
 		if row.Status != scheduleModel.AttendanceStatusExpected {
 			continue
 		}
-		visit, err := deps.VisitRepo.GetCurrentByStudentID(ctx, row.StudentID)
+		expectedIDs = append(expectedIDs, row.StudentID)
+	}
+	if len(expectedIDs) > 0 {
+		visits, err := deps.VisitRepo.GetCurrentByStudentIDs(ctx, expectedIDs)
 		if err != nil {
-			logger.Warn("conflict detection: student current visit lookup failed",
-				slog.Int64("student_id", row.StudentID),
+			logger.Warn("conflict detection: student current visits lookup failed",
+				slog.Int64("instance_id", instance.ID),
+				slog.Int("student_count", len(expectedIDs)),
 				slog.String("error", err.Error()),
 			)
-			continue
+		} else {
+			// Iterate expectedIDs (not the map) so warning order stays
+			// deterministic — it mirrors the instance_students insertion
+			// order from materialization, which tests rely on.
+			for _, sid := range expectedIDs {
+				visit, ok := visits[sid]
+				if !ok || visit == nil {
+					continue
+				}
+				warnings = append(warnings, InstanceConflictWarning{
+					Kind:        ConflictKindStudent,
+					ResourceID:  sid,
+					Message:     fmt.Sprintf("Schüler hat bereits einen aktiven Aufenthalt in Gruppe #%d", visit.ActiveGroupID),
+					CanOverride: true,
+				})
+			}
 		}
-		if visit == nil {
-			continue
-		}
-		warnings = append(warnings, InstanceConflictWarning{
-			Kind:        ConflictKindStudent,
-			ResourceID:  row.StudentID,
-			Message:     fmt.Sprintf("Schüler hat bereits einen aktiven Aufenthalt in Gruppe #%d", visit.ActiveGroupID),
-			CanOverride: true,
-		})
 	}
 
 	return warnings

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -168,10 +168,22 @@ func (s *instanceService) Start(ctx context.Context, instanceID, startedByStaffI
 		return nil, &ScheduleError{Op: "start instance: create active.group", Err: err}
 	}
 
-	// Each staff row becomes a supervisor. Failure aborts — unlike the NFC
-	// best-effort path, a planner start with missing supervisors would
-	// silently undermine the conflict model for the staff's next start.
+	// Each non-absent staff row becomes a supervisor. IsAbsent=true rows are
+	// intentionally skipped — those staff are marked out for this instance
+	// (sick, substitution flow, etc.); copying them into active.group_supervisors
+	// would make the staff appear as actively supervising, pollute the staff
+	// conflict model for their next planner start elsewhere, and contradict
+	// the semantics of the absence flag.
+	//
+	// A full-row failure aborts the whole transition. Unlike the NFC best-
+	// effort path, a planner start with missing supervisors would silently
+	// undermine the conflict model the next time that staff starts elsewhere.
+	activeStaffRows := make([]*scheduleModel.InstanceStaff, 0, len(staffRows))
 	for _, row := range staffRows {
+		if row.IsAbsent {
+			continue
+		}
+		activeStaffRows = append(activeStaffRows, row)
 		sup := &activeModel.GroupSupervisor{
 			StaffID:   row.StaffID,
 			GroupID:   newGroup.ID,
@@ -201,7 +213,7 @@ func (s *instanceService) Start(ctx context.Context, instanceID, startedByStaffI
 		return nil, &ScheduleError{Op: "start instance: update instance", Err: err}
 	}
 
-	s.broadcastInstanceEvent(ctx, realtime.EventInstanceStarted, instance, newGroup, staffRows)
+	s.broadcastInstanceEvent(ctx, realtime.EventInstanceStarted, instance, newGroup, activeStaffRows)
 
 	return &StartInstanceResult{
 		Instance:      instance,
@@ -259,7 +271,15 @@ func (s *instanceService) Cancel(ctx context.Context, instanceID int64) (*schedu
 		return nil, fmt.Errorf("%w: cannot cancel instance in status %q", ErrInvalidInstanceTransition, instance.Status)
 	}
 
-	if instance.Status == scheduleModel.InstanceStatusActive && instance.ActiveGroupID != nil {
+	if instance.Status == scheduleModel.InstanceStatusActive {
+		if instance.ActiveGroupID == nil {
+			// Mirrors the Complete branch: an active instance without a bridge
+			// is data corruption, not a normal state. Aborting here is safer
+			// than silently "cancelling" a session that never actually ran —
+			// a staff member downstream might have assumed the visits were
+			// closed for them.
+			return nil, &ScheduleError{Op: "cancel instance", Err: fmt.Errorf("active instance %d has no active_group_id", instance.ID)}
+		}
 		if err := s.deps.ActiveService.EndActivitySession(ctx, *instance.ActiveGroupID); err != nil {
 			return nil, &ScheduleError{Op: "cancel instance: end active.group", Err: err}
 		}
@@ -312,6 +332,13 @@ func (s *instanceService) ReplanWeek(ctx context.Context, from, to time.Time) (*
 	}
 
 	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		// Defence-in-depth: if the route is ever hit without
+		// TenantTxMiddleware the DELETE would silently match zero rows (and
+		// MaterializeForTenant would operate on tenant 0 with nothing to
+		// find). Fail fast instead of silently no-oping the admin action.
+		return nil, &ScheduleError{Op: "replan week", Err: errors.New("no tenant in context")}
+	}
 
 	res, err := repoBase.GetDB(ctx, s.deps.DB).NewDelete().
 		Table("schedule.activity_instances").
@@ -367,6 +394,15 @@ func (s *instanceService) loadForTransition(ctx context.Context, instanceID int6
 // broadcastInstanceEvent is a nil-safe fire-and-forget SSE wrapper. Events
 // with a live active.group route to group subscribers; events without (i.e.
 // cancelled-from-planned) broadcast to all so the admin dashboard sees them.
+//
+// Timing caveat: the broadcast happens BEFORE the TenantTxMiddleware commit.
+// In the very narrow window where the tenant tx rolls back after a 2xx
+// response (e.g. late middleware panic, render failure), subscribers will
+// have already seen an instance_* event for a DB state that no longer exists.
+// We accept that trade-off: the alternative — broadcasting after commit —
+// would require either plumbing a post-commit hook through the middleware
+// stack, or running the service outside the ambient tx. Neither is worth the
+// complexity for a fire-and-forget UI notification.
 func (s *instanceService) broadcastInstanceEvent(
 	ctx context.Context,
 	eventType realtime.EventType,

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -1,0 +1,458 @@
+// Package schedule — instance lifecycle service (WP-B9).
+//
+// Drives the state machine on schedule.activity_instances:
+//
+//	          start                 complete
+//	planned  ─────────►  active  ─────────►  completed
+//	   │                   │
+//	   │ cancel            │ cancel
+//	   ▼                   ▼
+//	cancelled           cancelled
+//
+// Every illegal transition returns ErrInvalidInstanceTransition (→ 409).
+// Start creates an active.group bridge row + copies instance_staff rows to
+// active.group_supervisors in the caller's tenant transaction. Cancel from
+// active ends the active.group cleanly via active.EndActivitySession —
+// visits close, supervisors close, SSE checkout events fire — so no ghost
+// state is left behind.
+//
+// Re-plan-week is the admin escape hatch: delete all status='planned'
+// non-spontaneous rows in a date window, then re-materialize. active/
+// completed/cancelled and spontaneous planned rows are never touched.
+package schedule
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	facilitiesModel "github.com/moto-nrw/project-phoenix/models/facilities"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/realtime"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+// Sentinel errors callers branch on via errors.Is.
+var (
+	// ErrInstanceNotFound is returned when an instance id does not resolve in
+	// the current tenant's scope. Handlers map this to 404.
+	ErrInstanceNotFound = errors.New("activity instance not found")
+
+	// ErrInvalidInstanceTransition is returned when the requested lifecycle
+	// action is not legal from the instance's current status. Handlers map
+	// this to 409. The error message carries the current status so clients
+	// can show a useful diagnostic without re-fetching.
+	ErrInvalidInstanceTransition = errors.New("invalid instance transition")
+)
+
+// ActiveSessionEnder is the subset of active.Service used by Complete and
+// Cancel. Defined as a local interface so unit tests can stub the call
+// without constructing the full active service.
+type ActiveSessionEnder interface {
+	EndActivitySession(ctx context.Context, activeGroupID int64) error
+}
+
+// InstanceService drives lifecycle transitions on schedule.activity_instances.
+type InstanceService interface {
+	Start(ctx context.Context, instanceID, startedByStaffID int64) (*StartInstanceResult, error)
+	Complete(ctx context.Context, instanceID int64) (*scheduleModel.ActivityInstance, error)
+	Cancel(ctx context.Context, instanceID int64) (*scheduleModel.ActivityInstance, error)
+	ReplanWeek(ctx context.Context, from, to time.Time) (*ReplanWeekResult, error)
+}
+
+// StartInstanceResult bundles what the start endpoint returns. ActiveGroupID
+// mirrors instance.ActiveGroupID for clients that only consume the envelope.
+type StartInstanceResult struct {
+	Instance      *scheduleModel.ActivityInstance
+	ActiveGroupID int64
+	Warnings      []InstanceConflictWarning
+}
+
+// ReplanWeekResult wraps the materialization result plus the delete count so
+// admins see both numbers in one response.
+type ReplanWeekResult struct {
+	From             time.Time
+	To               time.Time
+	DeletedInstances int
+	Materialization  *MaterializationResult
+}
+
+// InstanceServiceDependencies aggregates wiring. All repo fields are required;
+// the optional-ish ones are Broadcaster (nil → no SSE), RoomRepo and
+// ActivityGroupRepo (nil → SSE lacks human-readable names, not a failure).
+type InstanceServiceDependencies struct {
+	InstanceRepo      scheduleModel.ActivityInstanceRepository
+	InstanceStaffRepo scheduleModel.InstanceStaffRepository
+	InstanceStudents  scheduleModel.InstanceStudentRepository
+	ActiveGroupRepo   activeModel.GroupRepository
+	SupervisorRepo    activeModel.GroupSupervisorRepository
+	VisitRepo         activeModel.VisitRepository
+	RoomRepo          facilitiesModel.RoomRepository
+	ActivityGroupRepo activitiesModel.GroupRepository
+	ActiveService     ActiveSessionEnder
+	Materialization   MaterializationService
+	Broadcaster       realtime.Broadcaster
+	DB                *bun.DB
+	Logger            *slog.Logger
+}
+
+type instanceService struct {
+	deps InstanceServiceDependencies
+}
+
+// NewInstanceService constructs an InstanceService. Panics if a required
+// dependency is nil — the service has no sensible degraded mode for lifecycle
+// transitions, so the factory must wire it completely at startup.
+func NewInstanceService(deps InstanceServiceDependencies) InstanceService {
+	if deps.InstanceRepo == nil || deps.InstanceStaffRepo == nil || deps.InstanceStudents == nil ||
+		deps.ActiveGroupRepo == nil || deps.SupervisorRepo == nil || deps.VisitRepo == nil ||
+		deps.ActiveService == nil || deps.Materialization == nil || deps.DB == nil {
+		panic("schedule.NewInstanceService: required dependency is nil")
+	}
+	return &instanceService{deps: deps}
+}
+
+func (s *instanceService) getLogger() *slog.Logger {
+	if s.deps.Logger != nil {
+		return s.deps.Logger
+	}
+	return slog.Default()
+}
+
+// Start implements planned → active. Runs inside the caller's tenant tx
+// (TenantTxMiddleware); any failure rolls back the whole thing — no dangling
+// active.group, no half-linked instance, no stale supervisors.
+func (s *instanceService) Start(ctx context.Context, instanceID, startedByStaffID int64) (*StartInstanceResult, error) {
+	instance, err := s.loadForTransition(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	if instance.Status != scheduleModel.InstanceStatusPlanned {
+		return nil, fmt.Errorf("%w: cannot start instance in status %q", ErrInvalidInstanceTransition, instance.Status)
+	}
+
+	// Conflict detection is read-only + advisory. Warnings reflect state
+	// inside the tx; they never block the transition.
+	warnings := DetectStartConflicts(ctx, ConflictDependencies{
+		GroupRepo:         s.deps.ActiveGroupRepo,
+		SupervisorRepo:    s.deps.SupervisorRepo,
+		VisitRepo:         s.deps.VisitRepo,
+		InstanceStaffRepo: s.deps.InstanceStaffRepo,
+		InstanceStudents:  s.deps.InstanceStudents,
+	}, instance, s.getLogger())
+
+	staffRows, err := s.deps.InstanceStaffRepo.FindByInstanceID(ctx, instance.ID)
+	if err != nil {
+		return nil, &ScheduleError{Op: "start instance: load instance_staff", Err: err}
+	}
+
+	now := time.Now()
+	newGroup := &activeModel.Group{
+		StartTime:      now,
+		LastActivity:   now,
+		TimeoutMinutes: 30,
+		GroupID:        instance.ActivityGroupID,
+		DeviceID:       nil,
+		RoomID:         instance.RoomID,
+	}
+	newGroup.SetTenantID(tenant.FromContext(ctx))
+	if err := s.deps.ActiveGroupRepo.Create(ctx, newGroup); err != nil {
+		return nil, &ScheduleError{Op: "start instance: create active.group", Err: err}
+	}
+
+	// Each staff row becomes a supervisor. Failure aborts — unlike the NFC
+	// best-effort path, a planner start with missing supervisors would
+	// silently undermine the conflict model for the staff's next start.
+	for _, row := range staffRows {
+		sup := &activeModel.GroupSupervisor{
+			StaffID:   row.StaffID,
+			GroupID:   newGroup.ID,
+			Role:      "supervisor",
+			StartDate: now,
+		}
+		sup.SetTenantID(tenant.FromContext(ctx))
+		if err := s.deps.SupervisorRepo.Create(ctx, sup); err != nil {
+			return nil, &ScheduleError{Op: "start instance: create supervisor", Err: err}
+		}
+	}
+
+	// Targeted UPDATE: only the columns affected by the transition. A full-row
+	// Update via the repo would re-marshal StartTime/EndTime (TIME columns)
+	// that bun decodes as year 0000 on read — Postgres rejects year 0000 on
+	// write, so a round-trip through repo.Update() breaks. Touch only what
+	// this transition actually changes.
+	instance.Status = scheduleModel.InstanceStatusActive
+	activeGroupID := newGroup.ID
+	instance.ActiveGroupID = &activeGroupID
+	if startedByStaffID > 0 {
+		startedByCopy := startedByStaffID
+		instance.StartedBy = &startedByCopy
+	}
+	instance.StartedAt = &now
+	if err := s.updateLifecycleColumns(ctx, instance, "status", "active_group_id", "started_at", "started_by"); err != nil {
+		return nil, &ScheduleError{Op: "start instance: update instance", Err: err}
+	}
+
+	s.broadcastInstanceEvent(ctx, realtime.EventInstanceStarted, instance, newGroup, staffRows)
+
+	return &StartInstanceResult{
+		Instance:      instance,
+		ActiveGroupID: newGroup.ID,
+		Warnings:      warnings,
+	}, nil
+}
+
+// Complete implements active → completed. The bridge active.group is ended
+// via active.EndActivitySession — this closes open visits, ends supervisors,
+// and fires per-student checkout SSE events, matching today's observable
+// behavior when a session ends.
+func (s *instanceService) Complete(ctx context.Context, instanceID int64) (*scheduleModel.ActivityInstance, error) {
+	instance, err := s.loadForTransition(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	if instance.Status != scheduleModel.InstanceStatusActive {
+		return nil, fmt.Errorf("%w: cannot complete instance in status %q", ErrInvalidInstanceTransition, instance.Status)
+	}
+	if instance.ActiveGroupID == nil {
+		// An active instance without a bridge shouldn't exist post WP-B9.
+		// Treat as data corruption — abort the tx rather than silently
+		// "completing" an instance that never actually ran.
+		return nil, &ScheduleError{Op: "complete instance", Err: fmt.Errorf("active instance %d has no active_group_id", instance.ID)}
+	}
+
+	if err := s.deps.ActiveService.EndActivitySession(ctx, *instance.ActiveGroupID); err != nil {
+		return nil, &ScheduleError{Op: "complete instance: end active.group", Err: err}
+	}
+
+	now := time.Now()
+	instance.Status = scheduleModel.InstanceStatusCompleted
+	instance.CompletedAt = &now
+	if err := s.updateLifecycleColumns(ctx, instance, "status", "completed_at"); err != nil {
+		return nil, &ScheduleError{Op: "complete instance: update", Err: err}
+	}
+
+	s.broadcastInstanceEvent(ctx, realtime.EventInstanceCompleted, instance, nil, nil)
+	return instance, nil
+}
+
+// Cancel implements planned|active → cancelled. From active, the bridge is
+// ended the same way Complete does (visits + supervisors close, checkout
+// events fire). From planned there is no bridge yet; just stamp the status.
+func (s *instanceService) Cancel(ctx context.Context, instanceID int64) (*scheduleModel.ActivityInstance, error) {
+	instance, err := s.loadForTransition(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	switch instance.Status {
+	case scheduleModel.InstanceStatusPlanned, scheduleModel.InstanceStatusActive:
+		// allowed
+	default:
+		return nil, fmt.Errorf("%w: cannot cancel instance in status %q", ErrInvalidInstanceTransition, instance.Status)
+	}
+
+	if instance.Status == scheduleModel.InstanceStatusActive && instance.ActiveGroupID != nil {
+		if err := s.deps.ActiveService.EndActivitySession(ctx, *instance.ActiveGroupID); err != nil {
+			return nil, &ScheduleError{Op: "cancel instance: end active.group", Err: err}
+		}
+	}
+
+	now := time.Now()
+	instance.Status = scheduleModel.InstanceStatusCancelled
+	instance.CompletedAt = &now
+	if err := s.updateLifecycleColumns(ctx, instance, "status", "completed_at"); err != nil {
+		return nil, &ScheduleError{Op: "cancel instance: update", Err: err}
+	}
+
+	s.broadcastInstanceEvent(ctx, realtime.EventInstanceCancelled, instance, nil, nil)
+	return instance, nil
+}
+
+// updateLifecycleColumns writes only the named columns on the given instance.
+// Rationale: the bun pgdriver decodes TIME columns (start_time, end_time) as
+// year 0000 on read, and Postgres rejects year 0000 on write — so a
+// repo.Update() round-trip breaks the instance. Restricting the UPDATE to
+// the columns this transition actually changes sidesteps that entirely and
+// is also semantically cleaner (we don't want lifecycle code accidentally
+// clobbering Title, etc.).
+func (s *instanceService) updateLifecycleColumns(ctx context.Context, instance *scheduleModel.ActivityInstance, columns ...string) error {
+	if len(columns) == 0 {
+		return nil
+	}
+	q := repoBase.GetDB(ctx, s.deps.DB).NewUpdate().
+		Model(instance).
+		ModelTableExpr(`schedule.activity_instances AS "activity_instance"`).
+		Where(`"activity_instance".id = ?`, instance.ID).
+		Where(`"activity_instance".tenant_id = ?`, tenant.FromContext(ctx))
+	for _, col := range columns {
+		q = q.Column(col)
+	}
+	_, err := q.Exec(ctx)
+	return err
+}
+
+// ReplanWeek deletes protected-status='planned' non-spontaneous rows in
+// [from, to] for the current tenant, then re-materializes the window.
+// Everything else survives. The DELETE is one raw statement so the predicate
+// stays explicit and readable; the cascade on instance_staff / instance_students
+// is declared at the DDL level (ON DELETE CASCADE).
+func (s *instanceService) ReplanWeek(ctx context.Context, from, to time.Time) (*ReplanWeekResult, error) {
+	from = truncateToDay(from)
+	to = truncateToDay(to)
+	if to.Before(from) {
+		return nil, &ScheduleError{Op: "replan week: validate window", Err: errors.New("to_date must not be before from_date")}
+	}
+
+	tenantID := tenant.FromContext(ctx)
+
+	res, err := repoBase.GetDB(ctx, s.deps.DB).NewDelete().
+		Table("schedule.activity_instances").
+		Where("tenant_id = ?", tenantID).
+		Where("date >= ?", from).
+		Where("date <= ?", to).
+		Where("status = ?", scheduleModel.InstanceStatusPlanned).
+		Where("is_spontaneous = ?", false).
+		Exec(ctx)
+	if err != nil {
+		return nil, &ScheduleError{Op: "replan week: delete planned", Err: err}
+	}
+	deleted, _ := res.RowsAffected() // nil-driver-safe: fall through with 0
+
+	mat, err := s.deps.Materialization.MaterializeForTenant(ctx, from, to, MaterializationSourceManual)
+	if err != nil {
+		return nil, &ScheduleError{Op: "replan week: materialize", Err: err}
+	}
+
+	s.getLogger().Info("replan week completed",
+		slog.Int64("tenant_id", tenantID),
+		slog.String("from", from.Format("2006-01-02")),
+		slog.String("to", to.Format("2006-01-02")),
+		slog.Int64("deleted_instances", deleted),
+		slog.Int("instances_created", mat.InstancesCreated),
+	)
+
+	return &ReplanWeekResult{
+		From:             from,
+		To:               to,
+		DeletedInstances: int(deleted),
+		Materialization:  mat,
+	}, nil
+}
+
+// loadForTransition is the shared load + not-found branch used by all three
+// transitions. The base repo wraps sql.ErrNoRows inside a DatabaseError so
+// errors.Is alone doesn't catch it — isNotFoundDBError unwraps.
+func (s *instanceService) loadForTransition(ctx context.Context, instanceID int64) (*scheduleModel.ActivityInstance, error) {
+	instance, err := s.deps.InstanceRepo.FindByID(ctx, instanceID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) || isNotFoundDBError(err) {
+			return nil, ErrInstanceNotFound
+		}
+		return nil, &ScheduleError{Op: "load instance", Err: err}
+	}
+	if instance == nil {
+		return nil, ErrInstanceNotFound
+	}
+	return instance, nil
+}
+
+// broadcastInstanceEvent is a nil-safe fire-and-forget SSE wrapper. Events
+// with a live active.group route to group subscribers; events without (i.e.
+// cancelled-from-planned) broadcast to all so the admin dashboard sees them.
+func (s *instanceService) broadcastInstanceEvent(
+	ctx context.Context,
+	eventType realtime.EventType,
+	instance *scheduleModel.ActivityInstance,
+	activeGroup *activeModel.Group,
+	staffRows []*scheduleModel.InstanceStaff,
+) {
+	if s.deps.Broadcaster == nil || instance == nil {
+		return
+	}
+
+	instanceIDStr := fmt.Sprintf("%d", instance.ID)
+	instanceDate := instance.Date.Format("2006-01-02")
+	instanceStart := instance.StartTime.Format("15:04:05")
+
+	data := realtime.EventData{
+		InstanceID:        &instanceIDStr,
+		InstanceDate:      &instanceDate,
+		InstanceStartTime: &instanceStart,
+	}
+
+	activeGroupIDStr := ""
+	if activeGroup != nil {
+		activeGroupIDStr = fmt.Sprintf("%d", activeGroup.ID)
+		roomIDStr := fmt.Sprintf("%d", activeGroup.RoomID)
+		data.RoomID = &roomIDStr
+		if s.deps.RoomRepo != nil {
+			if room, err := s.deps.RoomRepo.FindByID(ctx, activeGroup.RoomID); err == nil && room != nil {
+				name := room.Name
+				data.RoomName = &name
+			}
+		}
+		if instance.ActivityGroupID != nil && s.deps.ActivityGroupRepo != nil {
+			if ag, err := s.deps.ActivityGroupRepo.FindByID(ctx, *instance.ActivityGroupID); err == nil && ag != nil {
+				name := ag.Name
+				data.ActivityName = &name
+			}
+		}
+		if len(staffRows) > 0 {
+			ids := make([]string, 0, len(staffRows))
+			for _, r := range staffRows {
+				ids = append(ids, fmt.Sprintf("%d", r.StaffID))
+			}
+			data.SupervisorIDs = &ids
+		}
+	} else if instance.ActiveGroupID != nil {
+		activeGroupIDStr = fmt.Sprintf("%d", *instance.ActiveGroupID)
+	}
+
+	event := realtime.NewEvent(eventType, activeGroupIDStr, data)
+	tenantID := tenant.FromContext(ctx)
+	if activeGroupIDStr != "" {
+		if err := s.deps.Broadcaster.BroadcastToGroup(tenantID, activeGroupIDStr, event); err != nil {
+			s.getLogger().Warn("SSE broadcast failed",
+				slog.String("event_type", string(eventType)),
+				slog.String("active_group_id", activeGroupIDStr),
+				slog.String("error", err.Error()),
+			)
+		}
+		return
+	}
+	if err := s.deps.Broadcaster.BroadcastToAll(event); err != nil {
+		s.getLogger().Warn("SSE broadcast-all failed",
+			slog.String("event_type", string(eventType)),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// truncateToDay strips the time component to UTC midnight. Matches the civil-
+// date normalization the materialization service uses so the ReplanWeek
+// window aligns exactly with the re-materialization run.
+func truncateToDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// isNotFoundDBError unwraps models/base.DatabaseError and reports whether
+// the underlying error is sql.ErrNoRows. The repo layer wraps sql.ErrNoRows
+// in a DatabaseError; errors.Is(err, sql.ErrNoRows) alone misses that case.
+func isNotFoundDBError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var dbErr *modelBase.DatabaseError
+	if errors.As(err, &dbErr) {
+		return errors.Is(dbErr.Err, sql.ErrNoRows)
+	}
+	return false
+}

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -1,0 +1,497 @@
+// Hermetic integration tests for the WP-B9 instance lifecycle service.
+//
+// Covers:
+//   - State machine: start/complete/cancel per illegal prior status → 409.
+//   - Start happy-path: bridge active.group created, supervisors copied, flags set.
+//   - Complete happy-path: bridge ended, CompletedAt stamped.
+//   - Cancel from planned: status flip only, no active.group side effects.
+//   - Cancel from active: bridge ended (visits + supervisors close).
+//   - Conflict detection: room, staff, student sub-checks each produce a warning.
+//   - Re-plan-week: deletes only planned non-spontaneous; all other kinds survive.
+//
+// All fixtures via testpkg.CreateTest* + CleanupTableRecords — no hardcoded IDs.
+package schedule_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/services"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// lifecycleSetup bundles the wired service + common fixtures. Cleanup is
+// registered via t.Cleanup on construction; tests should NOT call cleanup()
+// explicitly. LIFO ordering of t.Cleanup ensures child rows (instances,
+// active.groups, supervisors) are dropped before the parent fixtures
+// (students, staff, template) so FK constraints pass.
+type lifecycleSetup struct {
+	svc      scheduleSvc.InstanceService
+	factory  *services.Factory
+	db       *bun.DB
+	ctx      context.Context
+	roomID   int64
+	staffID  int64
+	student1 int64
+	student2 int64
+	tmplID   int64
+}
+
+// buildLifecycle prepares the minimum scaffold for instance-lifecycle tests:
+// one tenant tx, one room, one staff, two students, one template (is_template).
+// Returns the setup + a runnable cleanup that removes everything we created.
+func buildLifecycle(t *testing.T) *lifecycleSetup {
+	t.Helper()
+	db := testpkg.SetupTestDB(t)
+	// Register DB close FIRST so it runs LAST (LIFO) — after every other
+	// t.Cleanup has released its row references.
+	t.Cleanup(func() { _ = db.Close() })
+
+	repoFactory := repositories.NewFactory(db)
+	serviceFactory, err := services.NewFactory(repoFactory, db, slog.Default())
+	require.NoError(t, err)
+
+	ctx := testpkg.TenantContext(1)
+	suffix := time.Now().UnixNano()
+
+	room := testpkg.CreateTestRoom(t, db, fmt.Sprintf("LC-Room-%d", suffix))
+	staff := testpkg.CreateTestStaff(t, db, "LC", fmt.Sprintf("Super-%d", suffix))
+	student1 := testpkg.CreateTestStudent(t, db, "LC-Alice", fmt.Sprintf("One-%d", suffix), "3a")
+	student2 := testpkg.CreateTestStudent(t, db, "LC-Bob", fmt.Sprintf("Two-%d", suffix), "3a")
+
+	// A template-ish activity group. IsTemplate flag is immaterial for the
+	// lifecycle path; we only need a non-nil FK target for the spontaneous=
+	// false branch to fire.
+	templateRow := testpkg.CreateTestActivityGroup(t, db, fmt.Sprintf("LC-Tmpl-%d", suffix))
+
+	// Parent-fixture cleanup registered BEFORE any per-test child cleanups,
+	// so LIFO orders children → parents → db.Close.
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, db, student1.ID, staff.ID, 0, templateRow.ID, room.ID)
+		testpkg.CleanupTableRecords(t, db, "users.students", student2.ID)
+	})
+
+	return &lifecycleSetup{
+		svc:      serviceFactory.Instance,
+		factory:  serviceFactory,
+		db:       db,
+		ctx:      ctx,
+		roomID:   room.ID,
+		staffID:  staff.ID,
+		student1: student1.ID,
+		student2: student2.ID,
+		tmplID:   templateRow.ID,
+	}
+}
+
+// seedInstance inserts one planned activity_instance plus optional staff
+// and student rows. Returns the instance for the caller to act on.
+func seedInstance(t *testing.T, s *lifecycleSetup, withStaff bool, withStudents bool) *scheduleModels.ActivityInstance {
+	t.Helper()
+	ai := &scheduleModels.ActivityInstance{
+		Date:            time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC),
+		ActivityGroupID: &s.tmplID,
+		Title:           "Lifecycle-Test",
+		StartTime:       time.Date(1, 1, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:         time.Date(1, 1, 1, 15, 0, 0, 0, time.UTC),
+		RoomID:          s.roomID,
+		Status:          scheduleModels.InstanceStatusPlanned,
+		IsSpontaneous:   false,
+	}
+	ai.SetTenantID(1)
+	_, err := s.db.NewInsert().Model(ai).ModelTableExpr(`schedule.activity_instances`).Exec(s.ctx)
+	require.NoError(t, err)
+
+	if withStaff {
+		row := &scheduleModels.InstanceStaff{InstanceID: ai.ID, StaffID: s.staffID, IsPrimary: true}
+		row.SetTenantID(1)
+		_, err = s.db.NewInsert().Model(row).ModelTableExpr(`schedule.instance_staff`).Exec(s.ctx)
+		require.NoError(t, err)
+	}
+	if withStudents {
+		for _, sid := range []int64{s.student1, s.student2} {
+			row := &scheduleModels.InstanceStudent{InstanceID: ai.ID, StudentID: sid, Status: scheduleModels.AttendanceStatusExpected}
+			row.SetTenantID(1)
+			_, err = s.db.NewInsert().Model(row).ModelTableExpr(`schedule.instance_students`).Exec(s.ctx)
+			require.NoError(t, err)
+		}
+	}
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", ai.ID)
+	})
+	return ai
+}
+
+// forceSetInstanceStatus rewrites the status column directly. Used by 409-path
+// tests to move an instance into a state that can't be reached via the public
+// API (e.g. cancelled-from-scratch).
+func forceSetInstanceStatus(t *testing.T, s *lifecycleSetup, id int64, status string) {
+	t.Helper()
+	_, err := s.db.NewUpdate().
+		Model((*scheduleModels.ActivityInstance)(nil)).
+		ModelTableExpr(`schedule.activity_instances AS "activity_instance"`).
+		Set("status = ?", status).
+		Where(`"activity_instance".id = ?`, id).
+		Where("tenant_id = ?", 1).
+		Exec(s.ctx)
+	require.NoError(t, err)
+}
+
+// --- State machine: happy paths ---------------------------------------------
+
+func TestInstance_Start_HappyPath(t *testing.T) {
+	s := buildLifecycle(t)
+
+	ai := seedInstance(t, s, true, true)
+
+	result, err := s.svc.Start(s.ctx, ai.ID, 0)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Instance)
+
+	assert.Equal(t, scheduleModels.InstanceStatusActive, result.Instance.Status)
+	require.NotNil(t, result.Instance.ActiveGroupID)
+	assert.Equal(t, result.ActiveGroupID, *result.Instance.ActiveGroupID)
+	assert.NotNil(t, result.Instance.StartedAt)
+
+	// active.group row exists and is in the same room.
+	group, err := s.factory.Active.GetActiveGroup(s.ctx, result.ActiveGroupID)
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	assert.Equal(t, s.roomID, group.RoomID)
+	assert.True(t, group.IsActive(), "bridge active.group should still be open")
+
+	// Supervisor row copied from instance_staff.
+	sups, err := s.factory.Active.FindSupervisorsByActiveGroupID(s.ctx, result.ActiveGroupID)
+	require.NoError(t, err)
+	assert.Len(t, sups, 1)
+	assert.Equal(t, s.staffID, sups[0].StaffID)
+
+	// Warnings should be empty in a clean-tenant scenario.
+	assert.Empty(t, result.Warnings)
+
+	// Cleanup — supervisors + active.group survive the instance cleanup.
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "active.group_supervisors", sups[0].ID)
+		testpkg.CleanupTableRecords(t, s.db, "active.groups", result.ActiveGroupID)
+	})
+}
+
+func TestInstance_Complete_HappyPath(t *testing.T) {
+	s := buildLifecycle(t)
+
+	ai := seedInstance(t, s, true, false)
+	started, err := s.svc.Start(s.ctx, ai.ID, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "active.groups", started.ActiveGroupID)
+	})
+
+	completed, err := s.svc.Complete(s.ctx, ai.ID)
+	require.NoError(t, err)
+	assert.Equal(t, scheduleModels.InstanceStatusCompleted, completed.Status)
+	require.NotNil(t, completed.CompletedAt)
+
+	// Bridge active.group must be closed.
+	group, err := s.factory.Active.GetActiveGroup(s.ctx, started.ActiveGroupID)
+	require.NoError(t, err)
+	require.NotNil(t, group.EndTime, "active.group should have been ended")
+}
+
+func TestInstance_Cancel_FromPlanned_LeavesNoActiveGroup(t *testing.T) {
+	s := buildLifecycle(t)
+
+	ai := seedInstance(t, s, true, false)
+
+	cancelled, err := s.svc.Cancel(s.ctx, ai.ID)
+	require.NoError(t, err)
+	assert.Equal(t, scheduleModels.InstanceStatusCancelled, cancelled.Status)
+	require.NotNil(t, cancelled.CompletedAt)
+	assert.Nil(t, cancelled.ActiveGroupID, "cancel-from-planned must not create a bridge")
+
+	// Sanity: no active.group rows for this room.
+	groups, err := s.factory.Active.FindActiveGroupsByRoomID(s.ctx, s.roomID)
+	require.NoError(t, err)
+	assert.Empty(t, groups, "planned→cancelled must not create active.group")
+}
+
+func TestInstance_Cancel_FromActive_EndsBridge(t *testing.T) {
+	s := buildLifecycle(t)
+
+	ai := seedInstance(t, s, true, false)
+	started, err := s.svc.Start(s.ctx, ai.ID, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "active.groups", started.ActiveGroupID)
+	})
+
+	cancelled, err := s.svc.Cancel(s.ctx, ai.ID)
+	require.NoError(t, err)
+	assert.Equal(t, scheduleModels.InstanceStatusCancelled, cancelled.Status)
+
+	group, err := s.factory.Active.GetActiveGroup(s.ctx, started.ActiveGroupID)
+	require.NoError(t, err)
+	require.NotNil(t, group.EndTime, "cancel-from-active must end active.group")
+}
+
+// --- State machine: 409 branches --------------------------------------------
+
+func TestInstance_Start_Rejects_NonPlanned(t *testing.T) {
+	for _, status := range []string{
+		scheduleModels.InstanceStatusActive,
+		scheduleModels.InstanceStatusCompleted,
+		scheduleModels.InstanceStatusCancelled,
+	} {
+		t.Run(status, func(t *testing.T) {
+			s := buildLifecycle(t)
+			ai := seedInstance(t, s, false, false)
+			forceSetInstanceStatus(t, s, ai.ID, status)
+
+			_, err := s.svc.Start(s.ctx, ai.ID, 0)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, scheduleSvc.ErrInvalidInstanceTransition,
+				"start on %q must return ErrInvalidInstanceTransition", status)
+		})
+	}
+}
+
+func TestInstance_Complete_Rejects_NonActive(t *testing.T) {
+	for _, status := range []string{
+		scheduleModels.InstanceStatusPlanned,
+		scheduleModels.InstanceStatusCompleted,
+		scheduleModels.InstanceStatusCancelled,
+	} {
+		t.Run(status, func(t *testing.T) {
+			s := buildLifecycle(t)
+			ai := seedInstance(t, s, false, false)
+			forceSetInstanceStatus(t, s, ai.ID, status)
+
+			_, err := s.svc.Complete(s.ctx, ai.ID)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, scheduleSvc.ErrInvalidInstanceTransition)
+		})
+	}
+}
+
+func TestInstance_Cancel_Rejects_Completed(t *testing.T) {
+	s := buildLifecycle(t)
+	ai := seedInstance(t, s, false, false)
+	forceSetInstanceStatus(t, s, ai.ID, scheduleModels.InstanceStatusCompleted)
+
+	_, err := s.svc.Cancel(s.ctx, ai.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, scheduleSvc.ErrInvalidInstanceTransition)
+}
+
+func TestInstance_Cancel_Rejects_AlreadyCancelled(t *testing.T) {
+	s := buildLifecycle(t)
+	ai := seedInstance(t, s, false, false)
+	forceSetInstanceStatus(t, s, ai.ID, scheduleModels.InstanceStatusCancelled)
+
+	_, err := s.svc.Cancel(s.ctx, ai.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, scheduleSvc.ErrInvalidInstanceTransition)
+}
+
+func TestInstance_Start_NotFound(t *testing.T) {
+	s := buildLifecycle(t)
+
+	_, err := s.svc.Start(s.ctx, 99999999, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, scheduleSvc.ErrInstanceNotFound)
+}
+
+// --- Conflict detection -----------------------------------------------------
+
+func TestInstance_Start_ConflictWarning_Room(t *testing.T) {
+	s := buildLifecycle(t)
+
+	// Pre-seed a live active.group in the same room. We do this through the
+	// repo so it mirrors production state exactly (tenant scoped, open-ended).
+	now := time.Now()
+	preGroup := &activeModels.Group{
+		StartTime: now, LastActivity: now, TimeoutMinutes: 30,
+		GroupID: &s.tmplID, RoomID: s.roomID,
+	}
+	preGroup.SetTenantID(1)
+	require.NoError(t, s.factory.Active.CreateActiveGroup(s.ctx, preGroup))
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "active.groups", preGroup.ID)
+	})
+
+	ai := seedInstance(t, s, true, false)
+	result, err := s.svc.Start(s.ctx, ai.ID, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "active.groups", result.ActiveGroupID)
+	})
+
+	hasRoomWarning := false
+	for _, w := range result.Warnings {
+		if w.Kind == scheduleSvc.ConflictKindRoom && w.ResourceID == s.roomID && w.CanOverride {
+			hasRoomWarning = true
+		}
+	}
+	assert.True(t, hasRoomWarning, "start in an occupied room must produce a room warning; got %+v", result.Warnings)
+	assert.Equal(t, scheduleModels.InstanceStatusActive, result.Instance.Status, "warnings never block the transition")
+}
+
+func TestInstance_Start_ConflictWarning_Staff(t *testing.T) {
+	s := buildLifecycle(t)
+
+	// Pre-seed an active.group + a live supervision by our staff member on it.
+	otherRoom := testpkg.CreateTestRoom(t, s.db, fmt.Sprintf("LC-OtherRoom-%d", time.Now().UnixNano()))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "facilities.rooms", otherRoom.ID) })
+
+	now := time.Now()
+	preGroup := &activeModels.Group{StartTime: now, LastActivity: now, TimeoutMinutes: 30, GroupID: &s.tmplID, RoomID: otherRoom.ID}
+	preGroup.SetTenantID(1)
+	require.NoError(t, s.factory.Active.CreateActiveGroup(s.ctx, preGroup))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.groups", preGroup.ID) })
+
+	sup := &activeModels.GroupSupervisor{StaffID: s.staffID, GroupID: preGroup.ID, Role: "supervisor", StartDate: now}
+	sup.SetTenantID(1)
+	require.NoError(t, s.factory.Active.CreateGroupSupervisor(s.ctx, sup))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.group_supervisors", sup.ID) })
+
+	ai := seedInstance(t, s, true, false)
+	result, err := s.svc.Start(s.ctx, ai.ID, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.groups", result.ActiveGroupID) })
+
+	hasStaffWarning := false
+	for _, w := range result.Warnings {
+		if w.Kind == scheduleSvc.ConflictKindStaff && w.ResourceID == s.staffID {
+			hasStaffWarning = true
+		}
+	}
+	assert.True(t, hasStaffWarning, "staff supervising elsewhere must produce a staff warning; got %+v", result.Warnings)
+}
+
+func TestInstance_Start_ConflictWarning_Student(t *testing.T) {
+	s := buildLifecycle(t)
+
+	// Pre-seed an active.group in a different room + an open visit by student1.
+	otherRoom := testpkg.CreateTestRoom(t, s.db, fmt.Sprintf("LC-OtherRoom2-%d", time.Now().UnixNano()))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "facilities.rooms", otherRoom.ID) })
+
+	now := time.Now()
+	preGroup := &activeModels.Group{StartTime: now, LastActivity: now, TimeoutMinutes: 30, GroupID: &s.tmplID, RoomID: otherRoom.ID}
+	preGroup.SetTenantID(1)
+	require.NoError(t, s.factory.Active.CreateActiveGroup(s.ctx, preGroup))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.groups", preGroup.ID) })
+
+	// Raw INSERT — factory.Active.CreateVisit triggers attendance-side-effect
+	// writes (checked_in_by on active.attendance) that need a full staff/
+	// account chain. We only need the visit row for the conflict check.
+	visit := &activeModels.Visit{StudentID: s.student1, ActiveGroupID: preGroup.ID, EntryTime: now}
+	visit.SetTenantID(1)
+	_, err := s.db.NewInsert().Model(visit).ModelTableExpr(`active.visits`).Exec(s.ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.visits", visit.ID) })
+
+	ai := seedInstance(t, s, true, true)
+	result, err := s.svc.Start(s.ctx, ai.ID, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.groups", result.ActiveGroupID) })
+
+	hasStudentWarning := false
+	for _, w := range result.Warnings {
+		if w.Kind == scheduleSvc.ConflictKindStudent && w.ResourceID == s.student1 {
+			hasStudentWarning = true
+		}
+	}
+	assert.True(t, hasStudentWarning, "student with open visit elsewhere must produce a student warning; got %+v", result.Warnings)
+}
+
+// --- Re-plan-week protection ------------------------------------------------
+
+func TestInstance_ReplanWeek_OnlyDeletesPlannedNonSpontaneous(t *testing.T) {
+	s := buildLifecycle(t)
+
+	from := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	to := from.AddDate(0, 0, 6)
+
+	// Five seeded rows inside the window — one of each protected kind.
+	plannedNormal := insertInstance(t, s, from, scheduleModels.InstanceStatusPlanned, false)
+	plannedSpont := insertInstance(t, s, from.AddDate(0, 0, 1), scheduleModels.InstanceStatusPlanned, true)
+	active := insertInstance(t, s, from.AddDate(0, 0, 2), scheduleModels.InstanceStatusActive, false)
+	completed := insertInstance(t, s, from.AddDate(0, 0, 3), scheduleModels.InstanceStatusCompleted, false)
+	cancelled := insertInstance(t, s, from.AddDate(0, 0, 4), scheduleModels.InstanceStatusCancelled, false)
+
+	// Manual cleanup for the survivors (the planned-normal row may be deleted
+	// by ReplanWeek; if so, the cleanup becomes a no-op).
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances",
+			plannedNormal, plannedSpont, active, completed, cancelled)
+	})
+
+	_, err := s.svc.ReplanWeek(s.ctx, from, to)
+	require.NoError(t, err)
+
+	assert.False(t, instanceExists(t, s, plannedNormal), "planned non-spontaneous must be deleted")
+	assert.True(t, instanceExists(t, s, plannedSpont), "spontaneous planned must survive")
+	assert.True(t, instanceExists(t, s, active), "active must survive")
+	assert.True(t, instanceExists(t, s, completed), "completed must survive")
+	assert.True(t, instanceExists(t, s, cancelled), "cancelled must survive")
+}
+
+func insertInstance(t *testing.T, s *lifecycleSetup, date time.Time, status string, spontaneous bool) int64 {
+	t.Helper()
+	row := &scheduleModels.ActivityInstance{
+		Date:          date,
+		Title:         fmt.Sprintf("Row-%s-%d", status, time.Now().UnixNano()),
+		StartTime:     time.Date(1, 1, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:       time.Date(1, 1, 1, 15, 0, 0, 0, time.UTC),
+		RoomID:        s.roomID,
+		Status:        status,
+		IsSpontaneous: spontaneous,
+	}
+	if !spontaneous {
+		row.ActivityGroupID = &s.tmplID
+	}
+	row.SetTenantID(1)
+	_, err := s.db.NewInsert().Model(row).ModelTableExpr(`schedule.activity_instances`).Exec(s.ctx)
+	require.NoError(t, err)
+	return row.ID
+}
+
+func instanceExists(t *testing.T, s *lifecycleSetup, id int64) bool {
+	t.Helper()
+	var count int
+	err := s.db.NewSelect().
+		TableExpr(`schedule.activity_instances AS "ai"`).
+		ColumnExpr("COUNT(*)").
+		Where(`"ai".id = ?`, id).
+		Where(`"ai".tenant_id = ?`, 1).
+		Scan(s.ctx, &count)
+	require.NoError(t, err)
+	return count > 0
+}
+
+// --- Conflict-detection pure unit (nil-safe + empty happy path) ------------
+
+func TestDetectStartConflicts_EmptyInstance_NoWarnings(t *testing.T) {
+	s := buildLifecycle(t)
+
+	ai := seedInstance(t, s, false, false)
+	repoFactory := repositories.NewFactory(s.db)
+	warnings := scheduleSvc.DetectStartConflicts(s.ctx, scheduleSvc.ConflictDependencies{
+		GroupRepo:         repoFactory.ActiveGroup,
+		SupervisorRepo:    repoFactory.GroupSupervisor,
+		VisitRepo:         repoFactory.ActiveVisit,
+		InstanceStaffRepo: repoFactory.InstanceStaff,
+		InstanceStudents:  repoFactory.InstanceStudent,
+	}, ai, slog.Default())
+	assert.Empty(t, warnings, "clean-room, no staff, no students → no warnings")
+}

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -311,6 +311,51 @@ func TestInstance_Start_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, scheduleSvc.ErrInstanceNotFound)
 }
 
+// Absent staff rows on instance_staff must NOT be copied into
+// active.group_supervisors on start. They represent staff marked out for
+// this instance (sick, substitution flow); copying them would make them
+// appear as actively supervising and contradict the absence flag.
+func TestInstance_Start_SkipsAbsentStaff(t *testing.T) {
+	s := buildLifecycle(t)
+
+	ai := seedInstance(t, s, false, false)
+
+	// Primary staff (present) + a second staff flagged absent.
+	primary := &scheduleModels.InstanceStaff{
+		InstanceID: ai.ID, StaffID: s.staffID, IsPrimary: true, IsAbsent: false,
+	}
+	primary.SetTenantID(1)
+	_, err := s.db.NewInsert().Model(primary).ModelTableExpr(`schedule.instance_staff`).Exec(s.ctx)
+	require.NoError(t, err)
+
+	absent := testpkg.CreateTestStaff(t, s.db, "Absent", fmt.Sprintf("Staff-%d", time.Now().UnixNano()))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "users.staff", absent.ID) })
+
+	absentRow := &scheduleModels.InstanceStaff{
+		InstanceID: ai.ID, StaffID: absent.ID, IsPrimary: false, IsAbsent: true,
+	}
+	absentRow.SetTenantID(1)
+	_, err = s.db.NewInsert().Model(absentRow).ModelTableExpr(`schedule.instance_staff`).Exec(s.ctx)
+	require.NoError(t, err)
+
+	result, err := s.svc.Start(s.ctx, ai.ID, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "active.groups", result.ActiveGroupID)
+	})
+
+	sups, err := s.factory.Active.FindSupervisorsByActiveGroupID(s.ctx, result.ActiveGroupID)
+	require.NoError(t, err)
+	require.Len(t, sups, 1, "only the non-absent staff should become a supervisor")
+	assert.Equal(t, s.staffID, sups[0].StaffID)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.group_supervisors", sups[0].ID) })
+
+	// And the SupervisorIDs on the SSE envelope (visible via start result)
+	// must not include the absent staff — handled through activeStaffRows,
+	// which the integration test can't introspect directly, but the
+	// supervisor count above is the authoritative proof.
+}
+
 // --- Conflict detection -----------------------------------------------------
 
 func TestInstance_Start_ConflictWarning_Room(t *testing.T) {

--- a/backend/services/scheduler/overdue_test.go
+++ b/backend/services/scheduler/overdue_test.go
@@ -1,0 +1,236 @@
+// WP-B9 scheduler overdue-tick tests.
+//
+// Covers the three observable behaviours of checkAndRunOverdue:
+//
+//  1. A planned instance whose start_time is past the threshold fires exactly
+//     one `instance_overdue` broadcast.
+//  2. A second tick on the same fixture does NOT re-fire (sync.Map guard).
+//  3. An active instance is NEVER broadcast (only planned triggers).
+//
+// Plus a unit test for the day-rollover cache clear, which is pure in-memory
+// so it doesn't need the DB.
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/realtime"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// spyBroadcaster captures BroadcastToAll calls for assertions. BroadcastToGroup
+// is not exercised by the overdue tick (instances are still planned → no
+// active.group yet) but we implement it for the interface.
+type spyBroadcaster struct {
+	mu   sync.Mutex
+	all  []realtime.Event
+	grp  []realtime.Event
+	fail bool
+}
+
+func (b *spyBroadcaster) BroadcastToGroup(_ int64, _ string, e realtime.Event) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.grp = append(b.grp, e)
+	if b.fail {
+		return fmt.Errorf("forced failure")
+	}
+	return nil
+}
+func (b *spyBroadcaster) BroadcastToAll(e realtime.Event) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.all = append(b.all, e)
+	if b.fail {
+		return fmt.Errorf("forced failure")
+	}
+	return nil
+}
+
+var _ realtime.Broadcaster = (*spyBroadcaster)(nil)
+
+// overdueSetup wires a scheduler instance just enough to exercise the
+// overdue tick. Real DB + real settings service; only the broadcaster is
+// faked.
+type overdueSetup struct {
+	sched *Scheduler
+	db    *bun.DB
+	ctx   context.Context
+	spy   *spyBroadcaster
+	room  int64
+}
+
+func buildOverdue(t *testing.T) *overdueSetup {
+	t.Helper()
+	db := testpkg.SetupTestDB(t)
+	// db.Close() registered FIRST so it runs LAST (LIFO). Deferring in the
+	// test would close the DB before t.Cleanup callbacks fire, leaking test
+	// fixtures into subsequent tests.
+	t.Cleanup(func() { _ = db.Close() })
+	repoFactory := repositories.NewFactory(db)
+
+	spy := &spyBroadcaster{}
+	sched := &Scheduler{
+		tasks:  make(map[string]*ScheduledTask),
+		done:   make(chan struct{}),
+		logger: slog.Default(),
+	}
+	sched.SetInstanceOverdueDeps(repoFactory.ActivityInstance, spy)
+
+	room := testpkg.CreateTestRoom(t, db, fmt.Sprintf("OVR-Room-%d", time.Now().UnixNano()))
+	return &overdueSetup{
+		sched: sched,
+		db:    db,
+		ctx:   testpkg.TenantContext(1),
+		spy:   spy,
+		room:  room.ID,
+	}
+}
+
+// seedPlanned inserts one planned activity_instance with a StartTime of
+// `minutesAgo` minutes before now, so callers can control the overdue
+// margin relative to the default 5-minute threshold.
+func seedPlanned(t *testing.T, s *overdueSetup, minutesAgo int) *scheduleModels.ActivityInstance {
+	t.Helper()
+	now := time.Now().UTC()
+	start := now.Add(-time.Duration(minutesAgo) * time.Minute)
+
+	ai := &scheduleModels.ActivityInstance{
+		Date:          time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC),
+		Title:         fmt.Sprintf("OVR-%d", time.Now().UnixNano()),
+		StartTime:     time.Date(1, 1, 1, start.Hour(), start.Minute(), start.Second(), 0, time.UTC),
+		EndTime:       time.Date(1, 1, 1, 23, 59, 0, 0, time.UTC),
+		RoomID:        s.room,
+		Status:        scheduleModels.InstanceStatusPlanned,
+		IsSpontaneous: true, // avoids needing a template FK
+	}
+	ai.SetTenantID(1)
+	_, err := s.db.NewInsert().Model(ai).ModelTableExpr(`schedule.activity_instances`).Exec(s.ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", ai.ID)
+	})
+	return ai
+}
+
+// setStatus forces the status column (for the active-not-overdue branch).
+func setStatus(t *testing.T, s *overdueSetup, id int64, status string) {
+	t.Helper()
+	_, err := s.db.NewUpdate().
+		Model((*scheduleModels.ActivityInstance)(nil)).
+		ModelTableExpr(`schedule.activity_instances AS "activity_instance"`).
+		Set("status = ?", status).
+		Where(`"activity_instance".id = ?`, id).
+		Where("tenant_id = ?", 1).
+		Exec(s.ctx)
+	require.NoError(t, err)
+}
+
+// The tests call runOverdueForTenant directly with the same tenant ctx used
+// to seed fixtures (testpkg.TenantContext(1)). checkAndRunOverdue's tenant-
+// iteration relies on a SchoolRepo + SettingsService stack we'd otherwise
+// need to stand up; the per-tenant helper is the real unit of behaviour
+// and is what the iteration delegates to in production.
+
+func TestOverdueTick_BroadcastsOncePerInstance(t *testing.T) {
+	s := buildOverdue(t)
+
+	// 30 minutes past — well beyond the 5-minute default threshold.
+	ai := seedPlanned(t, s, 30)
+
+	s.sched.runOverdueForTenant(s.ctx, 1, 5, time.Now())
+
+	assert.Equal(t, 1, spyFilter(s.spy, ai.ID), "one broadcast for the seeded instance expected")
+
+	evt := spyFindByInstance(s.spy, ai.ID)
+	require.NotNil(t, evt, "expected broadcast for instance id %d", ai.ID)
+	assert.Equal(t, realtime.EventInstanceOverdue, evt.Type)
+	require.NotNil(t, evt.Data.InstanceID)
+	assert.Equal(t, fmt.Sprintf("%d", ai.ID), *evt.Data.InstanceID)
+}
+
+func TestOverdueTick_ReFireGuard(t *testing.T) {
+	s := buildOverdue(t)
+
+	ai := seedPlanned(t, s, 30)
+
+	s.sched.runOverdueForTenant(s.ctx, 1, 5, time.Now())
+	s.sched.runOverdueForTenant(s.ctx, 1, 5, time.Now())
+
+	assert.Equal(t, 1, spyFilter(s.spy, ai.ID), "second tick on same instance must be suppressed")
+}
+
+func TestOverdueTick_ActiveInstancesNotBroadcast(t *testing.T) {
+	s := buildOverdue(t)
+
+	ai := seedPlanned(t, s, 30)
+	setStatus(t, s, ai.ID, scheduleModels.InstanceStatusActive)
+
+	s.sched.runOverdueForTenant(s.ctx, 1, 5, time.Now())
+
+	assert.Equal(t, 0, spyFilter(s.spy, ai.ID), "active instances must not trigger overdue broadcast")
+}
+
+// spyFilter counts broadcasts whose InstanceID matches the given id. Needed
+// because the test DB is shared across runs and may contain unrelated
+// today-dated rows from other tests; we care only about our fixture's
+// fire count, not the grand total.
+func spyFilter(b *spyBroadcaster, instanceID int64) int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n := 0
+	needle := fmt.Sprintf("%d", instanceID)
+	for _, e := range b.all {
+		if e.Data.InstanceID != nil && *e.Data.InstanceID == needle {
+			n++
+		}
+	}
+	return n
+}
+
+// spyFindByInstance returns the first recorded event matching instanceID,
+// or nil if none. Companion to spyFilter for envelope-shape assertions.
+func spyFindByInstance(b *spyBroadcaster, instanceID int64) *realtime.Event {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	needle := fmt.Sprintf("%d", instanceID)
+	for i := range b.all {
+		if b.all[i].Data.InstanceID != nil && *b.all[i].Data.InstanceID == needle {
+			return &b.all[i]
+		}
+	}
+	return nil
+}
+
+// Day-rollover is a pure-memory behaviour — test it without the DB.
+func TestRotateOverdueCacheIfNewDay(t *testing.T) {
+	sched := &Scheduler{
+		tasks:  make(map[string]*ScheduledTask),
+		done:   make(chan struct{}),
+		logger: slog.Default(),
+	}
+
+	// Seed: mark "yesterday" as the cache day, store one emitted key.
+	yesterday := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	sched.overdueEmittedDay = yesterday
+	key := overdueKey{tenantID: 1, instanceID: 42}
+	sched.overdueEmitted.Store(key, yesterday.Add(14*time.Hour))
+
+	// Rotate using "today" → cache must clear and the day must advance.
+	today := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	sched.rotateOverdueCacheIfNewDay(today)
+
+	_, present := sched.overdueEmitted.Load(key)
+	assert.False(t, present, "entry from yesterday must be evicted on day rollover")
+	assert.Equal(t, time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC), sched.overdueEmittedDay)
+}

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -13,6 +13,8 @@ import (
 	"github.com/getsentry/sentry-go"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/models/platform"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/realtime"
 	"github.com/moto-nrw/project-phoenix/services/active"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -103,6 +105,23 @@ type Scheduler struct {
 	lastDataCleanup     sync.Map // tenant_id → time.Time
 	lastSessionCleanup  sync.Map // tenant_id → time.Time
 	lastMaterialization sync.Map // tenant_id → time.Time
+
+	// Overdue instance tracking (WP-B9). Re-fire guard so the same instance
+	// does not emit `instance_overdue` every minute for the same planned
+	// row. Cleared explicitly on day boundary; see checkAndRunOverdue.
+	instanceRepo        scheduleModel.ActivityInstanceRepository
+	overdueBroadcaster  realtime.Broadcaster
+	overdueEmitted      sync.Map // overdueKey{tenantID, instanceID} → time.Time
+	overdueEmittedDay   time.Time
+	overdueEmittedDayMu sync.Mutex
+}
+
+// overdueKey composites tenant + instance so the sync.Map key cannot collide
+// across tenants. Using a struct literal avoids the ambiguity of a stringly-
+// typed "tenant:instance" key if either id ever contained a colon.
+type overdueKey struct {
+	tenantID   int64
+	instanceID int64
 }
 
 // ScheduledTask represents a scheduled task
@@ -175,6 +194,16 @@ func (s *Scheduler) SetSchoolRepo(repo platform.SchoolRepository) {
 // When set, the scheduler reads per-tenant settings instead of global env vars.
 func (s *Scheduler) SetSettingsService(svc SettingsResolver) {
 	s.settings = svc
+}
+
+// SetInstanceOverdueDeps wires the dependencies for the WP-B9 overdue
+// instance tick. Both parameters are required; passing nil for either
+// disables the tick entirely (no task registers, no SSE events fire). Same
+// opt-in shape as SetMaterializer: a partial wiring is never a silent
+// misconfiguration.
+func (s *Scheduler) SetInstanceOverdueDeps(repo scheduleModel.ActivityInstanceRepository, broadcaster realtime.Broadcaster) {
+	s.instanceRepo = repo
+	s.overdueBroadcaster = broadcaster
 }
 
 // forEachTenant executes fn for each active tenant inside a WithTenantTx.
@@ -272,6 +301,9 @@ func (s *Scheduler) Start() {
 
 	// Schedule weekly timetable materialization (WP-B8)
 	s.scheduleMaterializationTask()
+
+	// Schedule minute-polled overdue instance tick (WP-B9)
+	s.scheduleInstanceOverdueTask()
 }
 
 // Stop gracefully stops the scheduler
@@ -1401,4 +1433,210 @@ func isoWeekdayMatchesNow(wd int) bool {
 		return wd == 7
 	}
 	return wd == int(today)
+}
+
+// --- Instance overdue tick (WP-B9) ---
+//
+// Purpose: emit realtime.EventInstanceOverdue once per planned instance that
+// has exceeded its start_time by the tenant-configured threshold. Drives the
+// "Überfällig" badge in the staff "My Day" view.
+//
+// Cadence: same minute-polling shape as every other scheduler task. The tick
+// does NOT read timetable.auto_start_planned — that setting belongs to E19
+// level 3 (auto-start, WP-F10), a separate workpackage.
+//
+// Re-fire guard: an in-memory sync.Map keyed by (tenant_id, instance_id).
+// Cleared explicitly when the civil-date rolls over — do not rely on entries
+// decaying via planned-filter misses, that leaks memory for cancelled or
+// completed instances until restart. On a mid-day restart the cache is
+// empty and each still-overdue planned instance fires once more; subscribers
+// are idempotent, that cost is acceptable for zero disk state.
+
+// scheduleInstanceOverdueTask registers the tick when both dependencies are
+// wired. No repo or no broadcaster → no task; matches SetMaterializer's
+// opt-in pattern so partial wiring is never a silent misconfiguration.
+func (s *Scheduler) scheduleInstanceOverdueTask() {
+	if s.instanceRepo == nil || s.overdueBroadcaster == nil {
+		s.getLogger().Info("instance overdue tick not configured (missing repo or broadcaster)")
+		return
+	}
+
+	task := &ScheduledTask{
+		Name:     "instance-overdue",
+		Schedule: "1m-poll",
+	}
+
+	s.mu.Lock()
+	s.tasks[task.Name] = task
+	s.mu.Unlock()
+
+	s.wg.Add(1)
+	go s.runInstanceOverdueTaskPolling(task)
+}
+
+// runInstanceOverdueTaskPolling mirrors the minute-polling loops used by
+// cleanup / session-end / materialization. Startup check + minute alignment
+// + 60 s ticker + done-signal exit.
+func (s *Scheduler) runInstanceOverdueTaskPolling(task *ScheduledTask) {
+	defer s.wg.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			err := fmt.Errorf("panic in instance overdue task: %v", r)
+			s.getLogger().Error("goroutine panic recovered", slog.String("error", err.Error()))
+			sentry.CurrentHub().Recover(r)
+			sentry.Flush(2 * time.Second)
+		}
+	}()
+
+	s.getLogger().Info("instance overdue tick using minute-polling")
+
+	s.checkAndRunOverdue(task)
+
+	if !s.waitUntilNextMinute() {
+		return
+	}
+
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.checkAndRunOverdue(task)
+		case <-s.done:
+			return
+		}
+	}
+}
+
+// checkAndRunOverdue rotates the day-cache when midnight has been crossed,
+// then iterates active tenants and delegates the per-tenant work to
+// runOverdueForTenant. Extracted into two methods so unit tests can invoke
+// the inner loop directly with a synthetic tenant ctx without building the
+// full school repo + settings service stack.
+func (s *Scheduler) checkAndRunOverdue(task *ScheduledTask) {
+	task.mu.Lock()
+	if task.Running {
+		task.mu.Unlock()
+		return
+	}
+	task.Running = true
+	task.mu.Unlock()
+	defer func() {
+		task.mu.Lock()
+		task.Running = false
+		task.mu.Unlock()
+	}()
+
+	s.rotateOverdueCacheIfNewDay(time.Now())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	s.forEachTenantSettings(ctx, "instance-overdue", func(tenantCtx context.Context, tenantID int64) error {
+		threshold := s.resolveIntSetting(tenantCtx, configModel.KeyTimetableOverdueThresholdMinutes, "", 5)
+		s.runOverdueForTenant(tenantCtx, tenantID, threshold, time.Now())
+		return nil
+	})
+}
+
+// runOverdueForTenant iterates today's instances for a single tenant and
+// emits instance_overdue once per still-planned, past-threshold row. `now`
+// is injected for deterministic tests. `threshold` < 1 is a no-op.
+func (s *Scheduler) runOverdueForTenant(ctx context.Context, tenantID int64, threshold int, now time.Time) {
+	if threshold < 1 {
+		return
+	}
+
+	today := civilDateUTC(now)
+	instances, err := s.instanceRepo.FindByTenantAndDate(ctx, today)
+	if err != nil {
+		s.getLogger().Warn("overdue tick: load today's instances failed",
+			slog.Int64("tenant_id", tenantID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	cutoff := time.Duration(threshold) * time.Minute
+
+	for _, inst := range instances {
+		if inst.Status != scheduleModel.InstanceStatusPlanned {
+			continue
+		}
+		instanceStart := combineDayAndTime(today, inst.StartTime)
+		if now.Sub(instanceStart) < cutoff {
+			continue
+		}
+		key := overdueKey{tenantID: tenantID, instanceID: inst.ID}
+		if _, seen := s.overdueEmitted.Load(key); seen {
+			continue
+		}
+		s.emitInstanceOverdue(ctx, tenantID, inst)
+		s.overdueEmitted.Store(key, now)
+	}
+}
+
+// emitInstanceOverdue builds the SSE envelope and fires it as BroadcastToAll:
+// a planned instance has no bridged active.group yet, so there is no group-
+// scoped topic to route through. Admin dashboard subscribers pick it up.
+func (s *Scheduler) emitInstanceOverdue(ctx context.Context, tenantID int64, inst *scheduleModel.ActivityInstance) {
+	instanceIDStr := fmt.Sprintf("%d", inst.ID)
+	instanceDate := inst.Date.Format("2006-01-02")
+	instanceStart := inst.StartTime.Format("15:04:05")
+	roomIDStr := fmt.Sprintf("%d", inst.RoomID)
+
+	event := realtime.NewEvent(realtime.EventInstanceOverdue, "", realtime.EventData{
+		InstanceID:        &instanceIDStr,
+		InstanceDate:      &instanceDate,
+		InstanceStartTime: &instanceStart,
+		RoomID:            &roomIDStr,
+	})
+	if err := s.overdueBroadcaster.BroadcastToAll(event); err != nil {
+		s.getLogger().Warn("overdue tick: broadcast failed",
+			slog.Int64("tenant_id", tenantID),
+			slog.Int64("instance_id", inst.ID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	s.getLogger().Info("instance_overdue broadcast",
+		slog.Int64("tenant_id", tenantID),
+		slog.Int64("instance_id", inst.ID),
+		slog.String("start_time", instanceStart),
+	)
+	_ = ctx // reserved: if later the broadcaster needs ctx for cancellation.
+}
+
+// rotateOverdueCacheIfNewDay clears the re-fire guard on civil-date roll-
+// over. Called at the top of every tick so a restart mid-day does not
+// miss the rollover.
+func (s *Scheduler) rotateOverdueCacheIfNewDay(now time.Time) {
+	today := civilDateUTC(now)
+	s.overdueEmittedDayMu.Lock()
+	defer s.overdueEmittedDayMu.Unlock()
+	if !s.overdueEmittedDay.Equal(today) {
+		s.overdueEmitted.Range(func(k, _ any) bool {
+			s.overdueEmitted.Delete(k)
+			return true
+		})
+		s.overdueEmittedDay = today
+	}
+}
+
+// civilDateUTC strips the time component to UTC midnight. Duplicates the
+// materialization service's civilDate helper but staying in the scheduler
+// package avoids a circular import.
+func civilDateUTC(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// combineDayAndTime returns "day at time-of-day", reading the wall-clock
+// hour/minute/second from `tod` (typically an ActivityInstance.StartTime
+// which lives as a bare TIME). Stays in the server's local zone so the
+// comparison with time.Now() is apples-to-apples.
+func combineDayAndTime(day, tod time.Time) time.Time {
+	local := day.Local()
+	return time.Date(local.Year(), local.Month(), local.Day(),
+		tod.Hour(), tod.Minute(), tod.Second(), tod.Nanosecond(), time.Local)
 }

--- a/backend/services/scheduler/setters_test.go
+++ b/backend/services/scheduler/setters_test.go
@@ -1,0 +1,535 @@
+// Coverage tests for the scheduler's Set* injection methods, the
+// checkAndRunBreakAutoEnd fallback path, and the instance-overdue tick's
+// startup + shutdown loop. These paths are reachable without a real DB by
+// exercising the non-tenant-aware branches (forEachTenant / forEachTenantSettings
+// fall back to the plain ctx when db/schoolRepo aren't wired).
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Setter coverage — pure wiring methods that the factory calls at startup.
+// -----------------------------------------------------------------------------
+
+func TestScheduler_SetWorkSessionCleaner(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+	cleaner := &fakeWorkSessionCleaner{}
+	s.SetWorkSessionCleaner(cleaner)
+	assert.Same(t, cleaner, s.workSessionCleanup)
+}
+
+func TestScheduler_SetBreakAutoEnder(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+	ender := &mockBreakAutoEnder{}
+	s.SetBreakAutoEnder(ender)
+	assert.Same(t, ender, s.breakAutoEnder)
+}
+
+func TestScheduler_SetDB(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+	// Passing nil is legitimate at test time — the field is only consulted
+	// by forEachTenant, and a nil db falls back to the plain-ctx branch.
+	s.SetDB(nil)
+	assert.Nil(t, s.db)
+}
+
+func TestScheduler_SetSchoolRepo(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+	s.SetSchoolRepo(nil)
+	assert.Nil(t, s.schoolRepo)
+}
+
+func TestScheduler_SetSettingsService(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+	resolver := &stubSettingsResolver{}
+	s.SetSettingsService(resolver)
+	assert.Same(t, resolver, s.settings)
+}
+
+// -----------------------------------------------------------------------------
+// checkAndRunBreakAutoEnd — the non-tenant-aware branch is exercised by
+// leaving db/schoolRepo unset; forEachTenant then falls back to fn(ctx).
+// -----------------------------------------------------------------------------
+
+type fakeWorkSessionCleaner struct{}
+
+func (f *fakeWorkSessionCleaner) CleanupOpenSessions(_ context.Context) (int, error) {
+	return 0, nil
+}
+
+type countingBreakAutoEnder struct {
+	mu    sync.Mutex
+	calls int
+	count int
+	err   error
+}
+
+func (c *countingBreakAutoEnder) AutoEndExpiredBreaks(_ context.Context) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	return c.count, c.err
+}
+
+func TestCheckAndRunBreakAutoEnd_HappyPath(t *testing.T) {
+	ender := &countingBreakAutoEnder{count: 3}
+	s := &Scheduler{
+		breakAutoEnder: ender,
+		logger:         slog.Default(),
+	}
+	task := &ScheduledTask{Name: "break-auto-end", Schedule: "60s-poll"}
+
+	s.checkAndRunBreakAutoEnd(task)
+
+	assert.Equal(t, 1, ender.calls, "break auto-ender should run once")
+}
+
+func TestCheckAndRunBreakAutoEnd_ServiceError(t *testing.T) {
+	ender := &countingBreakAutoEnder{err: errors.New("db broke")}
+	s := &Scheduler{
+		breakAutoEnder: ender,
+		logger:         slog.Default(),
+	}
+	task := &ScheduledTask{Name: "break-auto-end", Schedule: "60s-poll"}
+
+	// Error path: the func inside forEachTenant returns the err, which
+	// logs and continues — no panic, no blocked task. Running is reset.
+	s.checkAndRunBreakAutoEnd(task)
+
+	task.mu.Lock()
+	defer task.mu.Unlock()
+	assert.False(t, task.Running, "Running flag must be reset after failure")
+}
+
+func TestCheckAndRunBreakAutoEnd_AlreadyRunning(t *testing.T) {
+	ender := &countingBreakAutoEnder{}
+	s := &Scheduler{
+		breakAutoEnder: ender,
+		logger:         slog.Default(),
+	}
+	task := &ScheduledTask{Name: "break-auto-end", Running: true}
+
+	s.checkAndRunBreakAutoEnd(task)
+
+	assert.Equal(t, 0, ender.calls, "must skip when task already running")
+}
+
+func TestCheckAndRunBreakAutoEnd_ZeroCount(t *testing.T) {
+	// count=0 path: the "if count > 0" branch is skipped, no Info log line.
+	ender := &countingBreakAutoEnder{count: 0}
+	s := &Scheduler{
+		breakAutoEnder: ender,
+		logger:         slog.Default(),
+	}
+	task := &ScheduledTask{Name: "break-auto-end"}
+
+	s.checkAndRunBreakAutoEnd(task)
+	assert.Equal(t, 1, ender.calls)
+}
+
+// -----------------------------------------------------------------------------
+// checkAndRunOverdue — exercised with a fake repo in non-tenant-aware mode.
+// -----------------------------------------------------------------------------
+
+type fakeInstanceRepo struct {
+	mu        sync.Mutex
+	calls     int
+	instances []*scheduleModel.ActivityInstance
+	err       error
+}
+
+func (f *fakeInstanceRepo) Create(_ context.Context, _ *scheduleModel.ActivityInstance) error {
+	return nil
+}
+func (f *fakeInstanceRepo) FindByID(_ context.Context, _ any) (*scheduleModel.ActivityInstance, error) {
+	return nil, nil
+}
+func (f *fakeInstanceRepo) Update(_ context.Context, _ *scheduleModel.ActivityInstance) error {
+	return nil
+}
+func (f *fakeInstanceRepo) Delete(_ context.Context, _ any) error { return nil }
+func (f *fakeInstanceRepo) FindByTenantAndDate(_ context.Context, _ time.Time) ([]*scheduleModel.ActivityInstance, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.instances, f.err
+}
+func (f *fakeInstanceRepo) List(_ context.Context, _ *base.QueryOptions) ([]*scheduleModel.ActivityInstance, error) {
+	return nil, nil
+}
+func (f *fakeInstanceRepo) FindByTenantAndDateRange(_ context.Context, _, _ time.Time) ([]*scheduleModel.ActivityInstance, error) {
+	return nil, nil
+}
+func (f *fakeInstanceRepo) FindByActivityGroupAndDate(_ context.Context, _ int64, _ time.Time) ([]*scheduleModel.ActivityInstance, error) {
+	return nil, nil
+}
+func (f *fakeInstanceRepo) FindByActiveGroupID(_ context.Context, _ int64) (*scheduleModel.ActivityInstance, error) {
+	return nil, nil
+}
+
+func TestCheckAndRunOverdue_AlreadyRunning(t *testing.T) {
+	repo := &fakeInstanceRepo{}
+	spy := &spyBroadcaster{}
+	s := &Scheduler{
+		instanceRepo:       repo,
+		overdueBroadcaster: spy,
+		logger:             slog.Default(),
+	}
+	task := &ScheduledTask{Name: "instance-overdue", Running: true}
+
+	s.checkAndRunOverdue(task)
+
+	assert.Equal(t, 0, repo.calls, "must skip when task running")
+}
+
+func TestCheckAndRunOverdue_NoTenantContext(t *testing.T) {
+	// Without db/schoolRepo, forEachTenantSettings calls fn(ctx, 0) once —
+	// the threshold is resolved from registry default (5), and runOverdueForTenant
+	// runs for tenant 0 with no instances, which means no broadcasts.
+	repo := &fakeInstanceRepo{instances: nil}
+	spy := &spyBroadcaster{}
+	s := &Scheduler{
+		instanceRepo:       repo,
+		overdueBroadcaster: spy,
+		logger:             slog.Default(),
+	}
+	task := &ScheduledTask{Name: "instance-overdue"}
+
+	s.checkAndRunOverdue(task)
+
+	assert.Equal(t, 1, repo.calls, "one per-tenant call in fallback mode")
+	spy.mu.Lock()
+	assert.Empty(t, spy.all, "no overdue instances → no broadcast")
+	spy.mu.Unlock()
+	// Running flag must be cleared after the call.
+	task.mu.Lock()
+	defer task.mu.Unlock()
+	assert.False(t, task.Running)
+}
+
+// -----------------------------------------------------------------------------
+// scheduleInstanceOverdueTask — registers when both deps set.
+// -----------------------------------------------------------------------------
+
+func TestScheduleInstanceOverdueTask_MissingRepo(t *testing.T) {
+	s := &Scheduler{
+		logger: slog.Default(),
+		tasks:  make(map[string]*ScheduledTask),
+		done:   make(chan struct{}),
+		// instanceRepo not set → task should not register
+		overdueBroadcaster: &spyBroadcaster{},
+	}
+	s.scheduleInstanceOverdueTask()
+	assert.Empty(t, s.tasks, "no repo → no task registered")
+}
+
+func TestScheduleInstanceOverdueTask_MissingBroadcaster(t *testing.T) {
+	s := &Scheduler{
+		logger:       slog.Default(),
+		tasks:        make(map[string]*ScheduledTask),
+		done:         make(chan struct{}),
+		instanceRepo: &fakeInstanceRepo{},
+	}
+	s.scheduleInstanceOverdueTask()
+	assert.Empty(t, s.tasks, "no broadcaster → no task registered")
+}
+
+func TestScheduleInstanceOverdueTask_Registers(t *testing.T) {
+	s := &Scheduler{
+		logger:             slog.Default(),
+		tasks:              make(map[string]*ScheduledTask),
+		done:               make(chan struct{}),
+		instanceRepo:       &fakeInstanceRepo{},
+		overdueBroadcaster: &spyBroadcaster{},
+	}
+	s.scheduleInstanceOverdueTask()
+
+	s.mu.RLock()
+	task, ok := s.tasks["instance-overdue"]
+	s.mu.RUnlock()
+	require.True(t, ok, "task should be registered")
+	assert.Equal(t, "1m-poll", task.Schedule)
+
+	// Shut down the goroutine to avoid leaking it across tests.
+	close(s.done)
+	s.wg.Wait()
+}
+
+func TestRunInstanceOverdueTaskPolling_ExitsOnDone(t *testing.T) {
+	// Pre-close done before launching so waitUntilNextMinute returns false
+	// immediately after the startup check.
+	repo := &fakeInstanceRepo{}
+	spy := &spyBroadcaster{}
+	s := &Scheduler{
+		logger:             slog.Default(),
+		tasks:              make(map[string]*ScheduledTask),
+		done:               make(chan struct{}),
+		instanceRepo:       repo,
+		overdueBroadcaster: spy,
+	}
+	close(s.done)
+	task := &ScheduledTask{Name: "instance-overdue"}
+
+	finished := make(chan struct{})
+	s.wg.Add(1)
+	go func() {
+		s.runInstanceOverdueTaskPolling(task)
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runInstanceOverdueTaskPolling did not exit on done signal")
+	}
+
+	// Startup check ran once before waitUntilNextMinute returned false.
+	assert.GreaterOrEqual(t, repo.calls, 1)
+}
+
+// emitInstanceOverdue's broadcaster-failure branch: spy with fail=true so the
+// broadcast call returns an error and the Warn log path is exercised.
+func TestRunOverdueForTenant_BroadcastFailure(t *testing.T) {
+	today := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	startTime := time.Date(1, 1, 1, 10, 0, 0, 0, time.UTC) // 10:00 local
+	inst := &scheduleModel.ActivityInstance{
+		Date:          today,
+		StartTime:     startTime,
+		EndTime:       time.Date(1, 1, 1, 11, 0, 0, 0, time.UTC),
+		Status:        scheduleModel.InstanceStatusPlanned,
+		IsSpontaneous: true,
+		RoomID:        42,
+	}
+	inst.ID = int64(101)
+
+	repo := &fakeInstanceRepo{instances: []*scheduleModel.ActivityInstance{inst}}
+	spy := &spyBroadcaster{fail: true}
+	s := &Scheduler{
+		logger:             slog.Default(),
+		instanceRepo:       repo,
+		overdueBroadcaster: spy,
+	}
+
+	// Use a `now` set to 10:30 local on the same day → 30 min past threshold=5.
+	now := time.Date(today.Year(), today.Month(), today.Day(), 10, 30, 0, 0, time.Local)
+	s.runOverdueForTenant(context.Background(), 1, 5, now)
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	assert.Len(t, spy.all, 1, "broadcast attempted even when failure is expected")
+}
+
+// threshold < 1 is a documented no-op — exercises the early-return branch.
+func TestRunOverdueForTenant_ThresholdZero(t *testing.T) {
+	repo := &fakeInstanceRepo{}
+	spy := &spyBroadcaster{}
+	s := &Scheduler{
+		logger:             slog.Default(),
+		instanceRepo:       repo,
+		overdueBroadcaster: spy,
+	}
+	s.runOverdueForTenant(context.Background(), 1, 0, time.Now())
+	assert.Equal(t, 0, repo.calls, "threshold < 1 must skip repo call")
+}
+
+// Exercises the repo error-log branch.
+func TestRunOverdueForTenant_RepoError(t *testing.T) {
+	repo := &fakeInstanceRepo{err: errors.New("db down")}
+	spy := &spyBroadcaster{}
+	s := &Scheduler{
+		logger:             slog.Default(),
+		instanceRepo:       repo,
+		overdueBroadcaster: spy,
+	}
+	s.runOverdueForTenant(context.Background(), 1, 5, time.Now())
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	assert.Empty(t, spy.all, "repo error must not result in any broadcast")
+}
+
+func TestRunInstanceOverdueTaskPolling_TickerFires(t *testing.T) {
+	// synctest: drive the fake clock past waitUntilNextMinute + a few ticker
+	// intervals so the ticker.C branch + done-exit branch both execute.
+	synctest.Test(t, func(t *testing.T) {
+		repo := &fakeInstanceRepo{}
+		spy := &spyBroadcaster{}
+		s := &Scheduler{
+			logger:             slog.Default(),
+			tasks:              make(map[string]*ScheduledTask),
+			done:               make(chan struct{}),
+			instanceRepo:       repo,
+			overdueBroadcaster: spy,
+		}
+		task := &ScheduledTask{Name: "instance-overdue"}
+
+		s.wg.Add(1)
+		go s.runInstanceOverdueTaskPolling(task)
+
+		// Advance the fake clock past 1 min alignment + 2 ticker intervals.
+		time.Sleep(3 * time.Minute)
+		synctest.Wait()
+
+		repo.mu.Lock()
+		calls := repo.calls
+		repo.mu.Unlock()
+		assert.GreaterOrEqual(t, calls, 2, "ticker should have fired checkAndRunOverdue at least twice (startup + 1 tick)")
+
+		close(s.done)
+		s.wg.Wait()
+	})
+}
+
+// -----------------------------------------------------------------------------
+// forEachTenant — fallback branch (no db/schoolRepo) + fn error.
+// -----------------------------------------------------------------------------
+
+func TestForEachTenant_NoTenantConfig_InvokesFn(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+	var called int
+	err := s.forEachTenant(context.Background(), "test-op", func(_ context.Context) error {
+		called++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, called)
+}
+
+func TestForEachTenant_NoTenantConfig_PropagatesErr(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+	fnErr := errors.New("boom")
+	err := s.forEachTenant(context.Background(), "test-op", func(_ context.Context) error {
+		return fnErr
+	})
+	assert.ErrorIs(t, err, fnErr)
+}
+
+func TestForEachTenantSettings_NoTenantConfig_InvokesFn(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+	var called int
+	var gotTenantID int64
+	s.forEachTenantSettings(context.Background(), "test-op", func(_ context.Context, tid int64) error {
+		called++
+		gotTenantID = tid
+		return nil
+	})
+	assert.Equal(t, 1, called)
+	assert.Equal(t, int64(0), gotTenantID, "fallback passes tenant id 0")
+}
+
+// -----------------------------------------------------------------------------
+// resolveStringSetting — override path (HasTenantOverride returns true).
+// resolveBoolSetting, resolveIntSetting — override check fails (err path).
+// -----------------------------------------------------------------------------
+
+type stubSettingsResolver struct {
+	hasOverride    bool
+	hasOverrideErr error
+	stringVal      string
+	stringErr      error
+	boolVal        bool
+	boolErr        error
+	intVal         int
+	intErr         error
+}
+
+func (s *stubSettingsResolver) HasTenantOverride(_ context.Context, _ string) (bool, error) {
+	return s.hasOverride, s.hasOverrideErr
+}
+func (s *stubSettingsResolver) ResolveString(_ context.Context, _ string) (string, error) {
+	return s.stringVal, s.stringErr
+}
+func (s *stubSettingsResolver) ResolveBool(_ context.Context, _ string) (bool, error) {
+	return s.boolVal, s.boolErr
+}
+func (s *stubSettingsResolver) ResolveInt(_ context.Context, _ string) (int, error) {
+	return s.intVal, s.intErr
+}
+
+func TestResolveStringSetting_TenantOverride(t *testing.T) {
+	s := &Scheduler{
+		settings: &stubSettingsResolver{hasOverride: true, stringVal: "override-value"},
+		logger:   slog.Default(),
+	}
+	val := s.resolveStringSetting(context.Background(), "some.key", "SOME_ENV", "default")
+	assert.Equal(t, "override-value", val)
+}
+
+func TestResolveStringSetting_OverrideCheckError(t *testing.T) {
+	// When HasTenantOverride returns err, fall through to env/default.
+	s := &Scheduler{
+		settings: &stubSettingsResolver{hasOverrideErr: errors.New("db down")},
+		logger:   slog.Default(),
+	}
+	val := s.resolveStringSetting(context.Background(), "some.key", "SOME_ENV_NEVER_SET_XYZ", "fallback")
+	assert.Equal(t, "fallback", val)
+}
+
+func TestResolveStringSetting_OverrideEmptyString(t *testing.T) {
+	// Override exists but the resolved value is empty → fall through to default.
+	s := &Scheduler{
+		settings: &stubSettingsResolver{hasOverride: true, stringVal: ""},
+		logger:   slog.Default(),
+	}
+	val := s.resolveStringSetting(context.Background(), "some.key", "NEVER_SET_YYZ", "fallback")
+	assert.Equal(t, "fallback", val)
+}
+
+func TestResolveBoolSetting_TenantOverride(t *testing.T) {
+	s := &Scheduler{
+		settings: &stubSettingsResolver{hasOverride: true, boolVal: true},
+		logger:   slog.Default(),
+	}
+	val := s.resolveBoolSetting(context.Background(), "some.key", "NEVER_SET_BBB", false)
+	assert.True(t, val)
+}
+
+func TestResolveBoolSetting_OverrideCheckError(t *testing.T) {
+	s := &Scheduler{
+		settings: &stubSettingsResolver{hasOverrideErr: errors.New("db down")},
+		logger:   slog.Default(),
+	}
+	val := s.resolveBoolSetting(context.Background(), "some.key", "NEVER_SET_CCC", true)
+	assert.True(t, val)
+}
+
+func TestResolveIntSetting_TenantOverride(t *testing.T) {
+	s := &Scheduler{
+		settings: &stubSettingsResolver{hasOverride: true, intVal: 99},
+		logger:   slog.Default(),
+	}
+	val := s.resolveIntSetting(context.Background(), "some.key", "NEVER_SET_III", 5)
+	assert.Equal(t, 99, val)
+}
+
+func TestResolveIntSetting_OverrideCheckError(t *testing.T) {
+	s := &Scheduler{
+		settings: &stubSettingsResolver{hasOverrideErr: errors.New("db down")},
+		logger:   slog.Default(),
+	}
+	val := s.resolveIntSetting(context.Background(), "some.key", "NEVER_SET_DDD", 7)
+	assert.Equal(t, 7, val)
+}
+
+func TestResolveIntSetting_OverrideZeroFallsThrough(t *testing.T) {
+	// When override resolves to 0 (or negative), resolveIntSetting falls
+	// through to env/default — documented invariant.
+	s := &Scheduler{
+		settings: &stubSettingsResolver{hasOverride: true, intVal: 0},
+		logger:   slog.Default(),
+	}
+	val := s.resolveIntSetting(context.Background(), "some.key", "NEVER_SET_EEE", 11)
+	assert.Equal(t, 11, val)
+}

--- a/backend/test/hermetic_verification_test.go
+++ b/backend/test/hermetic_verification_test.go
@@ -153,6 +153,7 @@ func checkHardcodedIDs(t *testing.T, root string) []string {
 		"api/iot/config_test.go",                // Uses mock settings service for unit testing config endpoint
 		"enrich_pickup_times_test.go",           // Uses mock PickupScheduleService for unit testing enrichment
 		"api/timetable/api_test.go",             // Uses mock CalendarPeriodService for unit testing handlers
+		"api/timetable/instances_test.go",       // Uses mock InstanceService + PersonService for unit testing handlers
 	}
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
## Summary

Adds the instance lifecycle state machine for `schedule.activity_instances`, soft conflict detection on start, and the admin re-plan-week escape hatch. Immediate successor to WP-B8 (#1293, materialization).

Four new endpoints under `/api/timetable`, all gated on `permissions.SchedulesManage`:

| Method | Path | Transition |
|---|---|---|
| POST | `/instances/{id}/start` | `planned` → `active` (creates `active.group` bridge) |
| POST | `/instances/{id}/complete` | `active` → `completed` (ends `active.group`) |
| POST | `/instances/{id}/cancel` | `planned` \| `active` → `cancelled` (ends bridge if active) |
| POST | `/instances/re-plan-week` | deletes planned non-spontaneous in window, re-materializes |

## State machine

| Current status | `start` | `complete` | `cancel` |
|---|---|---|---|
| `planned` | → `active` | **409** | → `cancelled` |
| `active` | **409** | → `completed` | → `cancelled` (ends bridge) |
| `completed` | **409** | **409** | **409** |
| `cancelled` | **409** | **409** | **409** |

409 responses carry `code: "invalid_transition"` with the current status in the message. All transitions run inside the `TenantTxMiddleware` tx — any failure rolls back the whole thing (no dangling active.group, no half-linked instance, no stale supervisors).

**Cancel-from-active and Complete both call `active.EndActivitySession`** so open visits close, supervisors close, and per-student checkout SSE events fire — matching today's observable behavior when a session ends. Leaving ghost student state was not an option.

## Conflict detection

Runs read-only inside the start tx. Warnings never block the transition; every warning carries `can_override=true` in v1.

Three sub-checks:
- **Room** — reuses existing `groupRepo.CheckRoomConflict` (any other active.group in the same room)
- **Staff** — `FindActiveByStaffID` for each `instance_staff` row (still supervising elsewhere)
- **Student** — `GetCurrentByStudentID` for each expected student (open visit elsewhere)

New type (shown here with full shape):

```go
type InstanceConflictWarning struct {
    Kind        string `json:"kind"`         // "room" | "staff" | "student"
    ResourceID  int64  `json:"resource_id"`  // room_id / staff_id / student_id
    Message     string `json:"message"`      // German user-facing copy
    CanOverride bool   `json:"can_override"` // always true in v1
}
```

Not reusing IoT's `ConflictInfoResponse` because its `ConflictingDevice *int64` field is meaningless for planner-driven transitions — would ship `null` on the wire for two of three sub-checks.

## SSE events

Four new `realtime.EventType` constants; `realtime.EventData` gains three optional pointer fields (`InstanceID`, `InstanceDate`, `InstanceStartTime`).

| Event | Routing |
|---|---|
| `instance_started` | `BroadcastToGroup` (bridged active.group subscribers) |
| `instance_completed` | `BroadcastToGroup` |
| `instance_cancelled` | `BroadcastToGroup` if bridge existed, else `BroadcastToAll` |
| `instance_overdue` | `BroadcastToAll` (no active.group yet — instance still planned) |

## Re-plan-week

Strict DELETE predicate:

```sql
DELETE FROM schedule.activity_instances
WHERE tenant_id = :tid
  AND date BETWEEN :from AND :to
  AND status = 'planned'
  AND is_spontaneous = false;
```

`ON DELETE CASCADE` cleans `instance_staff` + `instance_students`. Then `MaterializationService.MaterializeForTenant` for the same window. **Active, completed, cancelled, and spontaneous-planned rows survive** — covered by hermetic test `TestInstance_ReplanWeek_OnlyDeletesPlannedNonSpontaneous` which seeds one of each and asserts ID survival. Window validation reuses the WP-B8 helper (≤ 56 days, both-or-neither).

## Scheduler overdue tick

New minute-polling task in `services/scheduler/scheduler.go`, opt-in via `SetInstanceOverdueDeps(repo, broadcaster)` — nil → task not registered. Reads `timetable.overdue_threshold_minutes` per tenant via the existing `resolveIntSetting` helper.

Re-fire guard is an in-memory `sync.Map` keyed by `(tenant_id, instance_id)` with **explicit midnight clear** at the top of every tick (no "eventually the cache grows" reliance). A mid-day restart re-fires each still-overdue planned instance once more; subscribers are idempotent, zero disk state required.

## Implementation note (why targeted UPDATEs)

Lifecycle writes touch only the transition columns (`status`, `active_group_id`, `started_at/by`, `completed_at`). The base repo's `Update()` method round-trips TIME columns that bun decodes as year 0000 on read; Postgres rejects year 0000 on write, so a full-row `Update()` breaks. Targeted UPDATE (`NewUpdate().Column(...).Where(...)`) avoids that entirely and is semantically cleaner — lifecycle code can't accidentally clobber `Title`, `Notes`, etc.

## Not in scope (separate WPs)

- **WP-B10** (attendance sync `instance_students ↔ active.visits` at check-in) — next critical-path item.
- **WP-B12** (gap detection).
- **WP-F10** (auto-start level 3 — scheduler creates the bridge automatically). This PR does NOT consume `timetable.auto_start_planned`.
- **Spontaneous instance creation endpoint** (WP-F5) — lifecycle already handles both shapes (`ActivityGroupID nil` produces `active.group.GroupID nil` per WP-B6), but no code in this PR creates spontaneous rows.

## PyrePortal impact

**NONE.** This PR does not touch `/api/iot/*`. The IoT check-in flow is unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `TestHermeticTestPatterns` green
- [x] `services/schedule/instance_service_integration_test.go` — 14 test funcs covering happy paths, every illegal transition → 409, all 3 conflict kinds, re-plan-week protection, not-found
- [x] `services/scheduler/overdue_test.go` — broadcasts-once, re-fire guard, active-not-overdue, midnight clear
- [ ] Manual smoke: hit `/start` → `/complete` on a materialized instance via curl against a local tenant, verify SSE events land

### Known pre-existing failure (unrelated)

`TestArrivalScheduleService_BulkUpsertBySchoolClass` fails on a clean DB on `development` too — its subtests create "BC1" students whose cleanup hook uses `bun: Model(nil interface *interface {})` and doesn't run. Not from this PR.