### PR TITLE
feat(schedule): WP-B10 attendance sync + three-field attendance PATCH

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -353,6 +353,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 		api.Services.Materialization,
 		api.Services.Instance,
 		api.Services.Users,
+		repoFactory.InstanceStudent,
 		logger.With("handler", "timetable"),
 		db,
 	)

--- a/backend/api/common/errors.go
+++ b/backend/api/common/errors.go
@@ -74,14 +74,23 @@ const (
 	DateFormatISO = "2006-01-02"
 )
 
+// FieldError describes one per-field validation problem. Emitted inside
+// ErrResponse.Errors so the frontend can render a form-level error list
+// without a second round-trip. Both fields are required.
+type FieldError struct {
+	Field  string `json:"field"`
+	Reason string `json:"reason"`
+}
+
 // ErrResponse is the error response structure
 type ErrResponse struct {
 	Err            error `json:"-"`
 	HTTPStatusCode int   `json:"-"`
 
-	Status    string `json:"status"`
-	ErrorText string `json:"error,omitempty"`
-	Code      string `json:"code,omitempty"`
+	Status    string       `json:"status"`
+	ErrorText string       `json:"error,omitempty"`
+	Code      string       `json:"code,omitempty"`
+	Errors    []FieldError `json:"errors,omitempty"`
 }
 
 // Render implements the render.Renderer interface for ErrResponse
@@ -97,6 +106,21 @@ func ErrorInvalidRequest(err error) render.Renderer {
 		HTTPStatusCode: http.StatusBadRequest,
 		Status:         "error",
 		ErrorText:      err.Error(),
+	}
+}
+
+// ErrorValidation returns a 400 Bad Request with a summary message and a
+// per-field error list. The summary goes in the standard `error` field so
+// existing frontend handlers that read `.error` continue to display a
+// message; the `errors` array surfaces individual field problems for form
+// rendering.
+func ErrorValidation(summary string, fields []FieldError) render.Renderer {
+	return &ErrResponse{
+		Err:            errors.New(summary),
+		HTTPStatusCode: http.StatusBadRequest,
+		Status:         "error",
+		ErrorText:      summary,
+		Errors:         fields,
 	}
 }
 

--- a/backend/api/common/errors_test.go
+++ b/backend/api/common/errors_test.go
@@ -1,6 +1,7 @@
 package common_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/stretchr/testify/assert"
@@ -463,4 +465,154 @@ func TestErrorConflictMessage(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "error", resp["status"])
 	assert.Equal(t, "Raum kann nicht gelöscht werden", resp["error"])
+}
+
+// =============================================================================
+// ErrorValidation Tests
+// =============================================================================
+
+func TestErrorValidation(t *testing.T) {
+	fields := []common.FieldError{
+		{Field: "status", Reason: "must be one of: expected, present, absent"},
+		{Field: "note", Reason: "must be at most 500 characters"},
+	}
+	renderer := common.ErrorValidation("validation failed", fields)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("PATCH", "/test", nil)
+
+	err := render.Render(w, r, renderer)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "error", resp["status"])
+	assert.Equal(t, "validation failed", resp["error"])
+
+	respErrs, ok := resp["errors"].([]interface{})
+	require.True(t, ok, "errors field must be an array")
+	require.Len(t, respErrs, 2)
+
+	first := respErrs[0].(map[string]interface{})
+	assert.Equal(t, "status", first["field"])
+	assert.Equal(t, "must be one of: expected, present, absent", first["reason"])
+}
+
+func TestErrorValidation_EmptyFields(t *testing.T) {
+	// nil/empty fields slice — `errors` key is omitted via omitempty.
+	renderer := common.ErrorValidation("bad request", nil)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("PATCH", "/test", nil)
+	require.NoError(t, render.Render(w, r, renderer))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	_, hasErrors := resp["errors"]
+	assert.False(t, hasErrors, "errors key should be omitted when empty")
+}
+
+// =============================================================================
+// ErrorInternalServerWrap Tests
+// =============================================================================
+
+func TestErrorInternalServerWrap(t *testing.T) {
+	cause := errors.New("pq: duplicate key value violates unique constraint \"students_pkey\"")
+	renderer := common.ErrorInternalServerWrap("failed to create student", cause)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/test", nil)
+
+	require.NoError(t, render.Render(w, r, renderer))
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "error", resp["status"])
+	// Client sees the stable message only — the internal cause must not leak.
+	assert.Equal(t, "failed to create student", resp["error"])
+	assert.NotContains(t, w.Body.String(), "students_pkey")
+
+	// Err field chains the cause so slog/Sentry still see the root cause.
+	wrapped, ok := renderer.(*common.ErrResponse)
+	require.True(t, ok)
+	assert.ErrorIs(t, wrapped.Err, cause)
+}
+
+// =============================================================================
+// FieldError Tests
+// =============================================================================
+
+func TestFieldError_JSON(t *testing.T) {
+	fe := common.FieldError{Field: "substatus", Reason: "must be late|excused|sick|field_trip|other"}
+	raw, err := json.Marshal(fe)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"field":"substatus","reason":"must be late|excused|sick|field_trip|other"}`, string(raw))
+}
+
+// =============================================================================
+// RenderError Tests — 5xx path logs and reports to Sentry
+// =============================================================================
+
+func TestRenderError_5xxLogsAndReports(t *testing.T) {
+	// The 5xx path hits slog + sentry.CaptureException. We cannot easily
+	// intercept those here, but executing the branch still counts toward
+	// coverage and guards against regressions that change the side-effects.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/test", nil)
+
+	renderer := common.ErrorInternalServer(errors.New("db down"))
+	common.RenderError(w, r, renderer)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "db down")
+}
+
+func TestRenderError_WrappedInternalServerPath(t *testing.T) {
+	// Exercises RenderError's 5xx branch with a wrapped error. The Err field
+	// is non-nil via errors.New("…"), which is what Sentry reporting relies on.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/test", nil)
+
+	renderer := common.ErrorInternalServerWrap("load failed", errors.New("boom"))
+	common.RenderError(w, r, renderer)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "load failed")
+}
+
+func TestRenderError_5xxWithSentryHubInContext(t *testing.T) {
+	// Cover the hub-not-nil branch: sentry.GetHubFromContext(ctx) returns a
+	// non-nil hub when a hub was attached to the context. The hub is created
+	// with no client, so CaptureException is a cheap no-op.
+	hub := sentry.NewHub(nil, sentry.NewScope())
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/test", nil).WithContext(ctx)
+
+	renderer := common.ErrorInternalServer(errors.New("boom with hub"))
+	common.RenderError(w, r, renderer)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestRenderError_NonErrResponseRenderer(t *testing.T) {
+	// RenderError accepts any render.Renderer; the 5xx branch only fires for
+	// *ErrResponse. Passing a different renderer must take the plain render path.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/test", nil)
+
+	// Use an ErrResponse with Err=nil so the Sentry branch is skipped even
+	// though the status code matches. Covers the `errResp.Err != nil` guard.
+	renderer := &common.ErrResponse{
+		HTTPStatusCode: http.StatusInternalServerError,
+		Status:         "error",
+		ErrorText:      "no cause",
+	}
+	common.RenderError(w, r, renderer)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }

--- a/backend/api/iot/checkin/pyreportal_error_strings_test.go
+++ b/backend/api/iot/checkin/pyreportal_error_strings_test.go
@@ -1,0 +1,152 @@
+// Package checkin — PyrePortal error-string guard (WP-B10).
+//
+// This is a regression tripwire, not a behavioral test. The PyrePortal
+// kiosk app (see ../../../../PyrePortal/src/services/api.ts, the
+// ERROR_MESSAGE_MAPPINGS const) hard-codes every error substring it
+// expects from the IoT checkin boundary and maps each to a German UI
+// translation. If the backend mutates one of these strings, PyrePortal
+// will silently fall back to displaying the raw English error — the
+// German mapping breaks with no compile-time signal.
+//
+// The guard below reads each checkin-relevant source file as plain text
+// and asserts every mapped substring is still present. A future PR that
+// changes a wording ("failed to create visit record" → "could not
+// create visit") will fail this test loudly, flagging the PyrePortal
+// coupling that must be updated in lockstep.
+//
+// Enumeration methodology: scanned PyrePortal/src/services/api.ts
+// end-to-end against the four checkin-boundary routes:
+//
+//	POST /api/iot/checkin
+//	POST /api/iot/pickup-query
+//	POST /api/iot/ping
+//	GET  /api/iot/status
+//
+// All four go through device auth middleware (device.DeviceAuthenticator)
+// which can emit the 401/403 strings in auth/device/errors.go. The checkin
+// handlers/workflow add the rest. Strings that only fire on other IoT
+// subtrees (sessions, attendance, rfid, feedback) are OUT of scope for
+// this guard even though they appear in PyrePortal's mapping.
+package checkin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// pyreportalCheckinErrorStrings are the substrings PyrePortal's mapping
+// matches on for errors emitted by the four checkin-boundary routes.
+//
+// Source rules:
+//   - Lift from ERROR_MESSAGE_MAPPINGS in PyrePortal/src/services/api.ts.
+//   - Only include a string if it can surface from /checkin, /pickup-query,
+//     /ping, or /status — not strings unique to /session, /attendance,
+//     /rfid/*, or /feedback.
+//   - Use PyrePortal's SUBSTRING (not the full emitted phrase) so refactors
+//     that keep the substring (e.g. "RFID tag not assigned to X" →
+//     "RFID tag not assigned to Y") don't trip the guard needlessly.
+var pyreportalCheckinErrorStrings = []string{
+	// Device auth errors — fire on every checkin-boundary route
+	"invalid device API key",
+	"device API key is required",
+	"invalid API key format",
+	"invalid staff PIN",
+	"staff PIN is required",
+	"staff account is locked due to failed PIN attempts",
+	"maximum PIN attempts exceeded",
+	"device is not active",
+	"device is offline",
+
+	// Capacity errors (POST /checkin)
+	"ROOM_CAPACITY_EXCEEDED",
+	"room capacity exceeded",
+	"ACTIVITY_CAPACITY_EXCEEDED",
+	"activity capacity exceeded",
+
+	// RFID lookup (POST /checkin, POST /pickup-query)
+	"RFID tag not found",
+	"RFID tag not assigned",
+	"student RFID tag required for pickup query",
+
+	// Supervisor scan (POST /checkin)
+	"no active session",
+
+	// Visit / room / activity (POST /checkin)
+	"failed to end visit record",
+	"failed to create visit record",
+	"failed to get room information",
+	"failed to check room capacity",
+	"failed to get activity information",
+	"failed to check activity capacity",
+	"error finding active groups in room",
+	"room_id is required for check-in",
+
+	// Special rooms (POST /checkin via schulhof/wc autocreate)
+	"schulhof activity not configured",
+	"WC activity not configured",
+	"WC activity auto-create requires staff context",
+	"no active groups in specified room",
+	"failed to create Schulhof session",
+	"failed to create WC session",
+	"failed to create session",
+}
+
+// guardSources are the non-test source files the guard scans. Staying
+// narrow (explicit file list, no wildcards) prevents false positives from
+// test fixtures that happen to contain the same literal.
+//
+// Paths are relative to this test file (api/iot/checkin/).
+var guardSources = []string{
+	// Checkin package itself
+	"workflow.go",
+	"handlers.go",
+	"helpers.go",
+	"schulhof.go",
+	"wc.go",
+	"types.go",
+	"resource.go",
+	// IoT common errors (capacity, shared RFID message constant)
+	"../common/errors.go",
+	// Device auth errors — middleware on every checkin route
+	"../../../auth/device/errors.go",
+}
+
+// TestPyrePortalCheckinErrorStringsGuard asserts every PyrePortal-mapped
+// substring is still present in the sources enumerated above. The test
+// name deliberately contains "PyrePortal" so failures in CI logs land the
+// reader directly on this file — and the file-top comment explains the
+// coupling.
+func TestPyrePortalCheckinErrorStringsGuard(t *testing.T) {
+	// Read every guard source into one concatenated blob. We don't care
+	// which file a substring appears in — only that it appears SOMEWHERE
+	// in the IoT checkin + device auth surface.
+	var blob strings.Builder
+	for _, rel := range guardSources {
+		abs, err := filepath.Abs(rel)
+		if err != nil {
+			t.Fatalf("resolving %s: %v", rel, err)
+		}
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			t.Fatalf("reading %s: %v", abs, err)
+		}
+		blob.Write(data)
+		blob.WriteByte('\n')
+	}
+	corpus := blob.String()
+
+	for _, want := range pyreportalCheckinErrorStrings {
+		assert.Containsf(t, corpus, want,
+			"PyrePortal error mapping depends on the substring %q being present in the "+
+				"IoT checkin or device auth sources. It is missing — changing this string "+
+				"silently breaks PyrePortal's German translation for this error. "+
+				"If the change is intentional, update PyrePortal/src/services/api.ts "+
+				"ERROR_MESSAGE_MAPPINGS and this test in the same PR.",
+			want,
+		)
+	}
+}

--- a/backend/api/iot/checkin/pyreportal_error_strings_test.go
+++ b/backend/api/iot/checkin/pyreportal_error_strings_test.go
@@ -100,6 +100,14 @@ var pyreportalCheckinErrorStrings = []string{
 // test fixtures that happen to contain the same literal.
 //
 // Paths are relative to this test file (api/iot/checkin/).
+//
+// Scope limitation: the guard only covers strings that originate inside
+// this file list (the IoT checkin package + device auth + iot/common
+// errors). If the checkin flow begins to surface error strings that come
+// from a deeper layer — for example a new active/schedule service error
+// bubbled up through the handler and translated by PyrePortal — add that
+// source file here. Otherwise a wording change there silently breaks the
+// mapping and this guard will not catch it.
 var guardSources = []string{
 	// Checkin package itself
 	"workflow.go",

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -24,15 +24,16 @@ const dateLayout = "2006-01-02"
 
 // Resource defines the timetable API resource.
 //
-// instanceService, personService, and logger are optional at construction
-// time: tests that only exercise /periods or /materialize can pass nil and
-// will get a 500 on the WP-B9 routes instead of a crash. Production wiring
-// must supply all of them via NewResource.
+// instanceService, personService, instanceStudentRepo, and logger are optional
+// at construction time: tests that only exercise /periods or /materialize can
+// pass nil and will get a 500 on the dependent routes instead of a crash.
+// Production wiring must supply all of them via NewResource.
 type Resource struct {
 	calendarPeriodService  scheduleSvc.CalendarPeriodService
 	materializationService scheduleSvc.MaterializationService
 	instanceService        scheduleSvc.InstanceService
 	personService          userSvc.PersonService
+	instanceStudentRepo    schedule.InstanceStudentRepository // WP-B10 PATCH /instances/{id}/students/{id}
 	logger                 *slog.Logger
 	db                     *bun.DB
 }
@@ -46,6 +47,7 @@ func NewResource(
 	materializationService scheduleSvc.MaterializationService,
 	instanceService scheduleSvc.InstanceService,
 	personService userSvc.PersonService,
+	instanceStudentRepo schedule.InstanceStudentRepository,
 	logger *slog.Logger,
 	db *bun.DB,
 ) *Resource {
@@ -54,6 +56,7 @@ func NewResource(
 		materializationService: materializationService,
 		instanceService:        instanceService,
 		personService:          personService,
+		instanceStudentRepo:    instanceStudentRepo,
 		logger:                 logger,
 		db:                     db,
 	}
@@ -99,6 +102,13 @@ func (rs *Resource) Router() chi.Router {
 				Post("/{id}/complete", rs.completeInstance)
 			r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
 				Post("/{id}/cancel", rs.cancelInstance)
+
+			// WP-B10: three-field attendance PATCH. Gated on SchedulesManage
+			// like the lifecycle routes. Path params are {instance_id} and
+			// {student_id} — distinct from the {id} param above so they live
+			// in a sibling route subtree.
+			r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
+				Patch("/{instance_id}/students/{student_id}", rs.patchInstanceStudent)
 		})
 	})
 

--- a/backend/api/timetable/api_test.go
+++ b/backend/api/timetable/api_test.go
@@ -153,13 +153,13 @@ func newTestPeriod() *schedule.CalendarPeriod {
 // =============================================================================
 
 func TestNewResource(t *testing.T) {
-	res := NewResource(nil, nil, nil, nil, nil, nil)
+	res := NewResource(nil, nil, nil, nil, nil, nil, nil)
 	assert.NotNil(t, res)
 }
 
 func TestResource_Router(t *testing.T) {
 	mock := &mockCalendarPeriodService{}
-	res := NewResource(mock, nil, nil, nil, nil, nil)
+	res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 	router := res.Router()
 	assert.NotNil(t, router)
 }
@@ -343,7 +343,7 @@ func TestListPeriods(t *testing.T) {
 		p1.UpdatedAt = time.Now()
 
 		mock := &mockCalendarPeriodService{periods: []*schedule.CalendarPeriod{p1}}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -354,7 +354,7 @@ func TestListPeriods(t *testing.T) {
 
 	t.Run("returns empty list", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{periods: []*schedule.CalendarPeriod{}}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -364,7 +364,7 @@ func TestListPeriods(t *testing.T) {
 
 	t.Run("returns 500 on service error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db error")}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -392,7 +392,7 @@ func TestGetPeriod(t *testing.T) {
 		p.UpdatedAt = time.Now()
 
 		mock := &mockCalendarPeriodService{period: p}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/42", nil)
@@ -403,7 +403,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/abc", nil)
@@ -413,7 +413,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 404 when not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/999", nil)
@@ -423,7 +423,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 500 on internal error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db connection failed")}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/42", nil)
@@ -439,7 +439,7 @@ func TestGetPeriod(t *testing.T) {
 func TestCreatePeriod(t *testing.T) {
 	t.Run("creates period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -461,7 +461,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("creates period with week cycle anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		anchor := "2025-09-01"
@@ -484,7 +484,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("defaults week cycle length to 1", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -505,7 +505,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for missing required fields", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{Name: "Only Name"}
@@ -517,7 +517,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid period_type", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -535,7 +535,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid start_date format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -553,7 +553,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid end_date format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -571,7 +571,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid week_cycle_anchor format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		badAnchor := "not-a-date"
@@ -592,7 +592,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for end_date before start_date", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -610,7 +610,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for cycle > 1 without anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -629,7 +629,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 409 for duplicate name", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: schedule.ErrCalendarPeriodNameConflict}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -650,7 +650,7 @@ func TestCreatePeriod(t *testing.T) {
 		mock := &mockCalendarPeriodService{
 			err: &scheduleSvcErr{op: "create calendar period", inner: schedule.ErrCalendarPeriodNameConflict},
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -667,7 +667,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 500 on service error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("create failed")}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -692,7 +692,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("updates period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -714,7 +714,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("updates period with anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -752,7 +752,7 @@ func TestUpdatePeriod(t *testing.T) {
 		anchoredPeriod.WeekCycleAnchor = &anchorTime
 
 		mock := &mockCalendarPeriodService{period: anchoredPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -775,7 +775,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("defaults week cycle length to 1", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -799,7 +799,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -812,7 +812,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 404 when period not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -825,7 +825,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 500 on get internal error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db connection failed")}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -838,7 +838,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid start_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -858,7 +858,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid end_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -878,7 +878,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid anchor in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -901,7 +901,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for end_date before start_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -925,7 +925,7 @@ func TestUpdatePeriod(t *testing.T) {
 			period:    existingPeriod,
 			updateErr: schedule.ErrCalendarPeriodNameConflict,
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -949,7 +949,7 @@ func TestUpdatePeriod(t *testing.T) {
 			period:    existingPeriod,
 			updateErr: errors.New("db write failed"),
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -975,7 +975,7 @@ func TestUpdatePeriod(t *testing.T) {
 func TestDeletePeriod(t *testing.T) {
 	t.Run("deletes period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: newTestPeriod()}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/42", nil)
@@ -986,7 +986,7 @@ func TestDeletePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/abc", nil)
@@ -996,7 +996,7 @@ func TestDeletePeriod(t *testing.T) {
 
 	t.Run("returns 404 when period not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/999", nil)
@@ -1009,7 +1009,7 @@ func TestDeletePeriod(t *testing.T) {
 			period:    newTestPeriod(),
 			deleteErr: errors.New("delete failed"),
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/42", nil)

--- a/backend/api/timetable/instance_students.go
+++ b/backend/api/timetable/instance_students.go
@@ -44,28 +44,11 @@ type PatchAttendanceRequest struct {
 	Note      json.RawMessage `json:"note,omitempty"`
 }
 
-// fieldError carries one specific validation problem. Multiple are returned
-// together so the client can render a per-field form error list without a
-// second round-trip.
-type fieldError struct {
-	Field  string `json:"field"`
-	Reason string `json:"reason"`
-}
-
-// validationErrResponse is the 400 body for validation failures. Uses the
-// same Status=error convention as common.ErrResponse so the frontend's
-// existing error handling keeps working.
-type validationErrResponse struct {
-	Status  string       `json:"status"`
-	Message string       `json:"message"`
-	Errors  []fieldError `json:"errors"`
-}
-
-func (v *validationErrResponse) Render(w http.ResponseWriter, _ *http.Request) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusBadRequest)
-	return json.NewEncoder(w).Encode(v)
-}
+// fieldError is a package-local alias for common.FieldError so test tables
+// and helper signatures stay compact. The unified ErrResponse carries these
+// under the `errors` key — the envelope is the same as every other 400 in
+// the codebase, with an optional per-field list.
+type fieldError = common.FieldError
 
 // patchInstanceStudent handles PATCH /instances/{instance_id}/students/{student_id}.
 //
@@ -102,6 +85,9 @@ func (rs *Resource) patchInstanceStudent(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	if !patch.HasChanges() {
+		// 400 the no-op here so the client gets a specific error. The repo
+		// short-circuits the same case as a defensive no-op for any future
+		// caller that bypasses this handler — the two guards are intentional.
 		renderValidationErrors(w, r, []fieldError{
 			{Field: "body", Reason: "at least one of status, substatus, note must be set"},
 		})
@@ -164,7 +150,9 @@ func parseAttendancePathIDs(w http.ResponseWriter, r *http.Request) (int64, int6
 
 // decodePatchBody reads and JSON-decodes the request body. The 16 KiB cap is
 // generous headroom above the 500-char note ceiling — any payload larger
-// than that is almost certainly noise.
+// than that is almost certainly noise. Unknown JSON fields are ignored,
+// matching the rest of the timetable/IoT endpoints: a frontend that sends
+// a future or stray key does not get a 400 for it.
 func decodePatchBody(w http.ResponseWriter, r *http.Request) (*PatchAttendanceRequest, bool) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, 16*1024))
 	if err != nil {
@@ -177,9 +165,7 @@ func decodePatchBody(w http.ResponseWriter, r *http.Request) (*PatchAttendanceRe
 		return &PatchAttendanceRequest{}, true
 	}
 	req := &PatchAttendanceRequest{}
-	dec := json.NewDecoder(bytes.NewReader(body))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(req); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(req); err != nil {
 		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("invalid JSON body: %w", err)))
 		return nil, false
 	}
@@ -316,12 +302,10 @@ func validateAttendancePatch(patch scheduleModel.AttendanceFieldPatch, current *
 }
 
 // renderValidationErrors emits the 400 body with the full errors slice.
+// The summary lands in the standard `error` field (readable by the generic
+// frontend handler) and the per-field list in `errors`.
 func renderValidationErrors(w http.ResponseWriter, r *http.Request, errs []fieldError) {
-	common.RenderError(w, r, &validationErrResponse{
-		Status:  "error",
-		Message: "validation failed",
-		Errors:  errs,
-	})
+	common.RenderError(w, r, common.ErrorValidation("validation failed", errs))
 }
 
 // AttendanceResponse is the on-wire shape of a schedule.instance_students row.

--- a/backend/api/timetable/instance_students.go
+++ b/backend/api/timetable/instance_students.go
@@ -1,0 +1,366 @@
+// Package timetable — three-field attendance PATCH handler (WP-B10).
+//
+// Endpoint: PATCH /api/timetable/instances/{instance_id}/students/{student_id}
+// Gate:     permissions.SchedulesManage (registered at the router level in api.go)
+//
+// The handler accepts a partial update (status / substatus / note). Pointer-
+// and RawMessage-based request parsing distinguishes three JSON states for
+// each nullable field:
+//
+//	MISSING  — leave column untouched
+//	null     — clear column (substatus / note only; status is NOT NULL)
+//	value    — write value
+//
+// See parseAttendancePatchRequest + validateAttendancePatch for details.
+package timetable
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+// PatchAttendanceRequest is the wire shape. Status uses *string (nullable-ish
+// via pointer-is-nil means "missing"), while Substatus and Note use
+// json.RawMessage so the handler can distinguish "missing" from "explicit
+// null" — both columns are nullable and each state is meaningful.
+//
+// Reviewer focus: look for {note: null} handling. The tri-state resolution
+// lives in parseAttendancePatchRequest.
+type PatchAttendanceRequest struct {
+	Status    *string         `json:"status,omitempty"`
+	Substatus json.RawMessage `json:"substatus,omitempty"`
+	Note      json.RawMessage `json:"note,omitempty"`
+}
+
+// fieldError carries one specific validation problem. Multiple are returned
+// together so the client can render a per-field form error list without a
+// second round-trip.
+type fieldError struct {
+	Field  string `json:"field"`
+	Reason string `json:"reason"`
+}
+
+// validationErrResponse is the 400 body for validation failures. Uses the
+// same Status=error convention as common.ErrResponse so the frontend's
+// existing error handling keeps working.
+type validationErrResponse struct {
+	Status  string       `json:"status"`
+	Message string       `json:"message"`
+	Errors  []fieldError `json:"errors"`
+}
+
+func (v *validationErrResponse) Render(w http.ResponseWriter, _ *http.Request) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	return json.NewEncoder(w).Encode(v)
+}
+
+// patchInstanceStudent handles PATCH /instances/{instance_id}/students/{student_id}.
+//
+// Flow:
+//  1. Parse path params → instanceID, studentID (400 on bad format).
+//  2. Decode body → PatchAttendanceRequest (400 on malformed JSON).
+//  3. Resolve tri-state for substatus/note → AttendanceFieldPatch.
+//  4. Load current row via FindByInstanceAndStudent (404 if not found OR
+//     wrong tenant — RLS makes the row invisible).
+//  5. Validate (400 with field errors on violation).
+//  6. Write via UpdateAttendanceFields (500 on DB error).
+//  7. Re-read and return the updated row.
+func (rs *Resource) patchInstanceStudent(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	instanceID, studentID, ok := parseAttendancePathIDs(w, r)
+	if !ok {
+		return
+	}
+
+	if rs.instanceStudentRepo == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("attendance PATCH not wired")))
+		return
+	}
+
+	req, ok := decodePatchBody(w, r)
+	if !ok {
+		return
+	}
+
+	patch, parseErrs := parseAttendancePatchRequest(req)
+	if len(parseErrs) > 0 {
+		renderValidationErrors(w, r, parseErrs)
+		return
+	}
+	if !patch.HasChanges() {
+		renderValidationErrors(w, r, []fieldError{
+			{Field: "body", Reason: "at least one of status, substatus, note must be set"},
+		})
+		return
+	}
+
+	current, err := rs.instanceStudentRepo.FindByInstanceAndStudent(ctx, instanceID, studentID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) || isNotFoundDBError(err) {
+			common.RenderError(w, r, common.ErrorNotFound(errors.New("instance student not found")))
+			return
+		}
+		common.RenderError(w, r, common.ErrorInternalServerWrap("load instance student failed", err))
+		return
+	}
+	if current == nil {
+		common.RenderError(w, r, common.ErrorNotFound(errors.New("instance student not found")))
+		return
+	}
+
+	if verrs := validateAttendancePatch(patch, current); len(verrs) > 0 {
+		renderValidationErrors(w, r, verrs)
+		return
+	}
+
+	if err := rs.instanceStudentRepo.UpdateAttendanceFields(ctx, current.ID, patch); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("update attendance failed", err))
+		return
+	}
+
+	// Re-read so the response body reflects the post-write state (including
+	// the bumped updated_at). One extra SELECT is worth the response fidelity.
+	updated, err := rs.instanceStudentRepo.FindByInstanceAndStudent(ctx, instanceID, studentID)
+	if err != nil || updated == nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("reload updated attendance failed", err))
+		return
+	}
+
+	rs.getLogger().Info("attendance patched",
+		slog.Int64("instance_id", instanceID),
+		slog.Int64("student_id", studentID),
+	)
+
+	common.Respond(w, r, http.StatusOK, mapAttendanceToResponse(updated), "Attendance updated")
+}
+
+// parseAttendancePathIDs reads instance_id and student_id from the path.
+// Returns (0, 0, false) and renders a 400 on failure.
+func parseAttendancePathIDs(w http.ResponseWriter, r *http.Request) (int64, int64, bool) {
+	instanceIDStr := chi.URLParam(r, "instance_id")
+	studentIDStr := chi.URLParam(r, "student_id")
+	instanceID, err1 := strconv.ParseInt(instanceIDStr, 10, 64)
+	studentID, err2 := strconv.ParseInt(studentIDStr, 10, 64)
+	if err1 != nil || err2 != nil || instanceID <= 0 || studentID <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid instance_id or student_id")))
+		return 0, 0, false
+	}
+	return instanceID, studentID, true
+}
+
+// decodePatchBody reads and JSON-decodes the request body. The 16 KiB cap is
+// generous headroom above the 500-char note ceiling — any payload larger
+// than that is almost certainly noise.
+func decodePatchBody(w http.ResponseWriter, r *http.Request) (*PatchAttendanceRequest, bool) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 16*1024))
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("failed to read request body")))
+		return nil, false
+	}
+	if len(body) == 0 {
+		// Empty body — treat as missing-all-fields; the handler reports
+		// "at least one of ..." via renderValidationErrors downstream.
+		return &PatchAttendanceRequest{}, true
+	}
+	req := &PatchAttendanceRequest{}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("invalid JSON body: %w", err)))
+		return nil, false
+	}
+	return req, true
+}
+
+// parseAttendancePatchRequest resolves the JSON tri-state for nullable
+// fields into AttendanceFieldPatch. Returns parse-level errors (type
+// mismatches) only; business-rule validation happens in validateAttendancePatch
+// once the current row is known.
+func parseAttendancePatchRequest(req *PatchAttendanceRequest) (scheduleModel.AttendanceFieldPatch, []fieldError) {
+	var errs []fieldError
+	patch := scheduleModel.AttendanceFieldPatch{}
+
+	if req.Status != nil {
+		s := *req.Status
+		patch.Status = &s
+	}
+
+	if sub, parseErr := decodeNullableString(req.Substatus); parseErr != nil {
+		errs = append(errs, fieldError{Field: "substatus", Reason: parseErr.Error()})
+	} else if sub.present {
+		if sub.isNull {
+			patch.SubstatusClear = true
+		} else {
+			v := sub.value
+			patch.Substatus = &v
+		}
+	}
+
+	if note, parseErr := decodeNullableString(req.Note); parseErr != nil {
+		errs = append(errs, fieldError{Field: "note", Reason: parseErr.Error()})
+	} else if note.present {
+		if note.isNull {
+			patch.NoteClear = true
+		} else {
+			v := note.value
+			patch.Note = &v
+		}
+	}
+
+	return patch, errs
+}
+
+// nullableString is the decoded tri-state for a nullable JSON string field:
+//
+//	{present: false}                    → field missing from body
+//	{present: true, isNull: true}       → field is JSON null
+//	{present: true, isNull: false, ...} → field is a JSON string
+type nullableString struct {
+	present bool
+	isNull  bool
+	value   string
+}
+
+// decodeNullableString parses a json.RawMessage into nullableString.
+// Non-string, non-null JSON values are rejected with an error.
+func decodeNullableString(raw json.RawMessage) (nullableString, error) {
+	if len(raw) == 0 {
+		return nullableString{present: false}, nil
+	}
+	// json.RawMessage preserves the null literal as the 4-byte string "null".
+	if string(raw) == "null" {
+		return nullableString{present: true, isNull: true}, nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nullableString{}, errors.New("must be a string or null")
+	}
+	return nullableString{present: true, value: s}, nil
+}
+
+// validateAttendancePatch enforces business rules. Called ONCE the current
+// row is known so the substatus-vs-status cross-field rule can be resolved
+// against the effective final status.
+//
+// Truth table for the substatus-vs-status cross-field rule (current
+// row.status is the baseline; patch.Status overrides it if provided):
+//
+//	current.status | patch.status  | effective final status | final substatus non-null | result
+//	---------------|---------------|------------------------|--------------------------|-------
+//	expected       | nil           | expected               | true                     | REJECT
+//	expected       | "present"     | present                | true                     | OK
+//	expected       | "absent"      | absent                 | true                     | OK
+//	present        | nil           | present                | true                     | OK
+//	present        | "expected"    | expected               | true                     | REJECT
+//	any            | any           | any                    | false (nil or cleared)   | OK
+//
+// "Final substatus non-null" means: existing substatus stays set AND patch
+// did not clear it, OR patch sets a non-null value. Cleared substatus (with
+// SubstatusClear) is treated as nil regardless of context.
+func validateAttendancePatch(patch scheduleModel.AttendanceFieldPatch, current *scheduleModel.InstanceStudent) []fieldError {
+	var errs []fieldError
+
+	if patch.Status != nil && !scheduleModel.IsValidAttendanceStatus(*patch.Status) {
+		errs = append(errs, fieldError{Field: "status", Reason: "must be one of: expected, present, absent"})
+	}
+	if patch.Substatus != nil && !scheduleModel.IsValidAttendanceSubstatus(*patch.Substatus) {
+		errs = append(errs, fieldError{Field: "substatus", Reason: "must be one of: late, excused, sick, field_trip, other"})
+	}
+	if patch.Note != nil && len(*patch.Note) > scheduleModel.InstanceStudentNoteMaxLength {
+		errs = append(errs, fieldError{
+			Field:  "note",
+			Reason: fmt.Sprintf("must be at most %d characters", scheduleModel.InstanceStudentNoteMaxLength),
+		})
+	}
+
+	// Per-field errors must be returned alone — the cross-field rule below
+	// assumes valid status / substatus values.
+	if len(errs) > 0 {
+		return errs
+	}
+
+	finalStatus := current.Status
+	if patch.Status != nil {
+		finalStatus = *patch.Status
+	}
+
+	finalSubstatusNonNull := current.Substatus != nil
+	if patch.SubstatusClear {
+		finalSubstatusNonNull = false
+	} else if patch.Substatus != nil {
+		finalSubstatusNonNull = true
+	}
+
+	if finalSubstatusNonNull && finalStatus == scheduleModel.AttendanceStatusExpected {
+		errs = append(errs, fieldError{
+			Field:  "substatus",
+			Reason: "cannot be set when status is expected",
+		})
+	}
+
+	return errs
+}
+
+// renderValidationErrors emits the 400 body with the full errors slice.
+func renderValidationErrors(w http.ResponseWriter, r *http.Request, errs []fieldError) {
+	common.RenderError(w, r, &validationErrResponse{
+		Status:  "error",
+		Message: "validation failed",
+		Errors:  errs,
+	})
+}
+
+// AttendanceResponse is the on-wire shape of a schedule.instance_students row.
+type AttendanceResponse struct {
+	ID          int64   `json:"id"`
+	InstanceID  int64   `json:"instance_id"`
+	StudentID   int64   `json:"student_id"`
+	Status      string  `json:"status"`
+	Substatus   *string `json:"substatus"`
+	Note        *string `json:"note"`
+	CheckedInAt *string `json:"checked_in_at"`
+}
+
+func mapAttendanceToResponse(row *scheduleModel.InstanceStudent) AttendanceResponse {
+	resp := AttendanceResponse{
+		ID:         row.ID,
+		InstanceID: row.InstanceID,
+		StudentID:  row.StudentID,
+		Status:     row.Status,
+		Substatus:  row.Substatus,
+		Note:       row.Note,
+	}
+	if row.CheckedInAt != nil {
+		t := row.CheckedInAt.UTC().Format("2006-01-02T15:04:05Z")
+		resp.CheckedInAt = &t
+	}
+	return resp
+}
+
+// isNotFoundDBError unwraps modelBase.DatabaseError and reports whether the
+// underlying error is sql.ErrNoRows. Matches the helper in instance_service.go
+// so 404 semantics stay consistent across the package.
+func isNotFoundDBError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var dbErr *modelBase.DatabaseError
+	if errors.As(err, &dbErr) {
+		return errors.Is(dbErr.Err, sql.ErrNoRows)
+	}
+	return false
+}

--- a/backend/api/timetable/instance_students_test.go
+++ b/backend/api/timetable/instance_students_test.go
@@ -1,0 +1,425 @@
+// Tests for the WP-B10 three-field attendance PATCH handler.
+//
+// Split into two halves:
+//
+//  1. Pure unit tests for validateAttendancePatch — every 400 branch,
+//     cross-field rule included. No DB.
+//  2. Integration tests for the full handler — real DB + real repo, the
+//     router mounted in isolation (no JWT / TenantTxMiddleware) so we can
+//     drive tenant context via testpkg.TenantContext.
+//
+// The integration tests intentionally avoid the middleware stack. Permission
+// gating is enforced at the router level in api.go and exercised by the
+// existing permission-middleware tests — duplicating that here would not
+// cover a distinct behavior.
+package timetable
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// -----------------------------------------------------------------------------
+// Unit tests: validateAttendancePatch
+// -----------------------------------------------------------------------------
+
+func TestValidateAttendancePatch_CrossFieldRule(t *testing.T) {
+	excused := schedule.AttendanceSubstatusExcused
+	tests := []struct {
+		name         string
+		current      *schedule.InstanceStudent
+		patch        schedule.AttendanceFieldPatch
+		wantErrField string
+		wantOK       bool
+	}{
+		{
+			name:    "expected + new substatus without status change → reject",
+			current: &schedule.InstanceStudent{Status: schedule.AttendanceStatusExpected},
+			patch: schedule.AttendanceFieldPatch{
+				Substatus: strPtr(schedule.AttendanceSubstatusLate),
+			},
+			wantErrField: "substatus",
+		},
+		{
+			name:    "expected → present + substatus → ok",
+			current: &schedule.InstanceStudent{Status: schedule.AttendanceStatusExpected},
+			patch: schedule.AttendanceFieldPatch{
+				Status:    strPtr(schedule.AttendanceStatusPresent),
+				Substatus: strPtr(schedule.AttendanceSubstatusLate),
+			},
+			wantOK: true,
+		},
+		{
+			name:    "expected → absent + substatus → ok",
+			current: &schedule.InstanceStudent{Status: schedule.AttendanceStatusExpected},
+			patch: schedule.AttendanceFieldPatch{
+				Status:    strPtr(schedule.AttendanceStatusAbsent),
+				Substatus: strPtr(schedule.AttendanceSubstatusSick),
+			},
+			wantOK: true,
+		},
+		{
+			name:    "present + substatus → ok (status unchanged)",
+			current: &schedule.InstanceStudent{Status: schedule.AttendanceStatusPresent},
+			patch: schedule.AttendanceFieldPatch{
+				Substatus: strPtr(schedule.AttendanceSubstatusLate),
+			},
+			wantOK: true,
+		},
+		{
+			name:    "present → expected with substatus still set → reject",
+			current: &schedule.InstanceStudent{Status: schedule.AttendanceStatusPresent, Substatus: &excused},
+			patch: schedule.AttendanceFieldPatch{
+				Status: strPtr(schedule.AttendanceStatusExpected),
+			},
+			wantErrField: "substatus",
+		},
+		{
+			name:    "present → expected clearing substatus → ok",
+			current: &schedule.InstanceStudent{Status: schedule.AttendanceStatusPresent, Substatus: &excused},
+			patch: schedule.AttendanceFieldPatch{
+				Status:         strPtr(schedule.AttendanceStatusExpected),
+				SubstatusClear: true,
+			},
+			wantOK: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateAttendancePatch(tc.patch, tc.current)
+			if tc.wantOK {
+				assert.Empty(t, errs)
+				return
+			}
+			require.NotEmpty(t, errs)
+			found := false
+			for _, e := range errs {
+				if e.Field == tc.wantErrField {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected field error on %q, got %+v", tc.wantErrField, errs)
+		})
+	}
+}
+
+func TestValidateAttendancePatch_PerFieldErrors(t *testing.T) {
+	cur := &schedule.InstanceStudent{Status: schedule.AttendanceStatusPresent}
+
+	t.Run("invalid status", func(t *testing.T) {
+		errs := validateAttendancePatch(schedule.AttendanceFieldPatch{Status: strPtr("ghost")}, cur)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "status", errs[0].Field)
+	})
+
+	t.Run("invalid substatus", func(t *testing.T) {
+		errs := validateAttendancePatch(schedule.AttendanceFieldPatch{Substatus: strPtr("banana")}, cur)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "substatus", errs[0].Field)
+	})
+
+	t.Run("note too long", func(t *testing.T) {
+		tooLong := strings.Repeat("x", schedule.InstanceStudentNoteMaxLength+1)
+		errs := validateAttendancePatch(schedule.AttendanceFieldPatch{Note: &tooLong}, cur)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "note", errs[0].Field)
+	})
+
+	t.Run("two per-field errors returned together", func(t *testing.T) {
+		tooLong := strings.Repeat("y", schedule.InstanceStudentNoteMaxLength+1)
+		errs := validateAttendancePatch(schedule.AttendanceFieldPatch{
+			Status: strPtr("ghost"),
+			Note:   &tooLong,
+		}, cur)
+		require.Len(t, errs, 2)
+	})
+}
+
+func TestDecodeNullableString(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		got, err := decodeNullableString(nil)
+		require.NoError(t, err)
+		assert.False(t, got.present)
+	})
+	t.Run("explicit null", func(t *testing.T) {
+		got, err := decodeNullableString(json.RawMessage("null"))
+		require.NoError(t, err)
+		assert.True(t, got.present)
+		assert.True(t, got.isNull)
+	})
+	t.Run("string value", func(t *testing.T) {
+		got, err := decodeNullableString(json.RawMessage(`"late"`))
+		require.NoError(t, err)
+		assert.True(t, got.present)
+		assert.False(t, got.isNull)
+		assert.Equal(t, "late", got.value)
+	})
+	t.Run("non-string rejects", func(t *testing.T) {
+		_, err := decodeNullableString(json.RawMessage(`5`))
+		require.Error(t, err)
+	})
+}
+
+// -----------------------------------------------------------------------------
+// Integration tests: full PATCH handler
+// -----------------------------------------------------------------------------
+
+// patchSetup mirrors attendanceSyncSetup from services/schedule but is local
+// to this package so we don't cross the internal boundary. db is retained as
+// *bun.DB so tests can drive repo-level state changes outside the handler.
+type patchSetup struct {
+	res        *Resource
+	db         *bun.DB
+	ctx        context.Context
+	row        *schedule.InstanceStudent
+	instanceID int64
+	studentID  int64
+}
+
+func buildPatchSetup(t *testing.T) *patchSetup {
+	t.Helper()
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := testpkg.TenantContext(1)
+	suffix := time.Now().UnixNano()
+
+	room := testpkg.CreateTestRoom(t, db, fmt.Sprintf("P-Room-%d", suffix))
+	activity := testpkg.CreateTestActivityGroup(t, db, fmt.Sprintf("P-Act-%d", suffix))
+	student := testpkg.CreateTestStudent(t, db, "P-Stu", fmt.Sprintf("One-%d", suffix), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, db, student.ID, 0, 0, activity.ID, room.ID) })
+
+	// Insert a planned instance for this tenant.
+	inst := &schedule.ActivityInstance{
+		Date:            time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC),
+		ActivityGroupID: &activity.ID,
+		Title:           fmt.Sprintf("P-Inst-%d", suffix),
+		StartTime:       time.Date(1, 1, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:         time.Date(1, 1, 1, 15, 0, 0, 0, time.UTC),
+		RoomID:          room.ID,
+		Status:          schedule.InstanceStatusPlanned,
+	}
+	inst.SetTenantID(1)
+	_, err := db.NewInsert().Model(inst).ModelTableExpr(`schedule.activity_instances`).Exec(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", inst.ID) })
+
+	isRepo := scheduleRepo.NewInstanceStudentRepository(db)
+	row := &schedule.InstanceStudent{
+		InstanceID: inst.ID,
+		StudentID:  student.ID,
+		Status:     schedule.AttendanceStatusPresent, // start in 'present' so PATCH can mutate freely
+	}
+	row.SetTenantID(1)
+	require.NoError(t, isRepo.Create(ctx, row))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "schedule.instance_students", row.ID) })
+
+	res := NewResource(nil, nil, nil, nil, isRepo, nil, db)
+
+	return &patchSetup{
+		res:        res,
+		db:         db,
+		ctx:        ctx,
+		row:        row,
+		instanceID: inst.ID,
+		studentID:  student.ID,
+	}
+}
+
+// patchRouter mounts only the PATCH route — no auth, no tenant middleware.
+// The tenant ID is extracted from the passed-in context (built via
+// testpkg.TenantContext) and re-applied to the request context so chi's
+// routing context survives. A prior version replaced the whole request
+// context and stripped chi's routing state, which nil-panicked deep inside.
+func patchRouter(parentCtx context.Context, res *Resource) chi.Router {
+	tenantID := tenant.FromContext(parentCtx)
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := tenant.WithTenantID(req.Context(), tenantID)
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	})
+	r.Patch("/instances/{instance_id}/students/{student_id}", res.patchInstanceStudent)
+	return r
+}
+
+func doPatch(t *testing.T, router chi.Router, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	switch b := body.(type) {
+	case nil:
+		reader = bytes.NewReader(nil)
+	case string:
+		reader = bytes.NewReader([]byte(b))
+	default:
+		jb, err := json.Marshal(b)
+		require.NoError(t, err)
+		reader = bytes.NewReader(jb)
+	}
+	req := httptest.NewRequest(http.MethodPatch, path, reader)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestPatchInstanceStudent_HappyPath(t *testing.T) {
+	s := buildPatchSetup(t)
+	router := patchRouter(testpkg.TenantContext(1), s.res)
+
+	w := doPatch(t, router, fmt.Sprintf("/instances/%d/students/%d", s.instanceID, s.studentID), map[string]any{
+		"status":    "absent",
+		"substatus": "excused",
+		"note":      "Arztbesuch",
+	})
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data, ok := resp["data"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "absent", data["status"])
+	assert.Equal(t, "excused", data["substatus"])
+	assert.Equal(t, "Arztbesuch", data["note"])
+}
+
+func TestPatchInstanceStudent_ClearNoteWithExplicitNull(t *testing.T) {
+	s := buildPatchSetup(t)
+	// Pre-populate note so the clear is observable.
+	initial := "pre"
+	s.row.Note = &initial
+	s.row.Status = schedule.AttendanceStatusPresent
+	_, err := s.res.instanceStudentRepo.UpdateAttendanceFromCheckin(s.ctx, s.instanceID, s.studentID, time.Now())
+	_ = err // best-effort — the row is present so this is a no-op, we just need it to exist
+	// Directly set note via the repo's update-fields path to be sure.
+	require.NoError(t, s.res.instanceStudentRepo.UpdateAttendanceFields(s.ctx, s.row.ID, schedule.AttendanceFieldPatch{
+		Note: &initial,
+	}))
+
+	router := patchRouter(testpkg.TenantContext(1), s.res)
+	// Raw JSON body so we can emit explicit null for the note field.
+	body := `{"note": null}`
+	w := doPatch(t, router, fmt.Sprintf("/instances/%d/students/%d", s.instanceID, s.studentID), body)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]any)
+	assert.Nil(t, data["note"], "note should be cleared to null in response")
+}
+
+func TestPatchInstanceStudent_400_EmptyBody(t *testing.T) {
+	s := buildPatchSetup(t)
+	router := patchRouter(testpkg.TenantContext(1), s.res)
+
+	w := doPatch(t, router, fmt.Sprintf("/instances/%d/students/%d", s.instanceID, s.studentID), map[string]any{})
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "at least one of")
+}
+
+func TestPatchInstanceStudent_400_InvalidStatus(t *testing.T) {
+	s := buildPatchSetup(t)
+	router := patchRouter(testpkg.TenantContext(1), s.res)
+
+	w := doPatch(t, router, fmt.Sprintf("/instances/%d/students/%d", s.instanceID, s.studentID), map[string]any{
+		"status": "ghost",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "status")
+}
+
+func TestPatchInstanceStudent_400_InvalidSubstatus(t *testing.T) {
+	s := buildPatchSetup(t)
+	router := patchRouter(testpkg.TenantContext(1), s.res)
+
+	w := doPatch(t, router, fmt.Sprintf("/instances/%d/students/%d", s.instanceID, s.studentID), map[string]any{
+		"substatus": "banana",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "substatus")
+}
+
+func TestPatchInstanceStudent_400_NonStringSubstatus(t *testing.T) {
+	s := buildPatchSetup(t)
+	router := patchRouter(testpkg.TenantContext(1), s.res)
+
+	// Substatus is a number, not a string — must be rejected at parse time.
+	body := `{"substatus": 5}`
+	w := doPatch(t, router, fmt.Sprintf("/instances/%d/students/%d", s.instanceID, s.studentID), body)
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "substatus")
+}
+
+func TestPatchInstanceStudent_400_NoteTooLong(t *testing.T) {
+	s := buildPatchSetup(t)
+	router := patchRouter(testpkg.TenantContext(1), s.res)
+
+	tooLong := strings.Repeat("x", schedule.InstanceStudentNoteMaxLength+1)
+	w := doPatch(t, router, fmt.Sprintf("/instances/%d/students/%d", s.instanceID, s.studentID), map[string]any{
+		"note": tooLong,
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "note")
+}
+
+func TestPatchInstanceStudent_400_SubstatusOnExpected(t *testing.T) {
+	s := buildPatchSetup(t)
+	// Move the row into expected so the cross-field rule fires.
+	require.NoError(t, s.res.instanceStudentRepo.UpdateAttendanceFields(s.ctx, s.row.ID, schedule.AttendanceFieldPatch{
+		Status: strPtr(schedule.AttendanceStatusExpected),
+	}))
+	router := patchRouter(testpkg.TenantContext(1), s.res)
+
+	w := doPatch(t, router, fmt.Sprintf("/instances/%d/students/%d", s.instanceID, s.studentID), map[string]any{
+		"substatus": "late",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "cannot be set when status is expected")
+}
+
+func TestPatchInstanceStudent_404_Unknown(t *testing.T) {
+	s := buildPatchSetup(t)
+	router := patchRouter(testpkg.TenantContext(1), s.res)
+
+	w := doPatch(t, router, "/instances/999999999/students/999999999", map[string]any{
+		"status": "absent",
+	})
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestPatchInstanceStudent_404_TenantIsolation(t *testing.T) {
+	s := buildPatchSetup(t)
+	// Row created in tenant 1. Fire PATCH with tenant 2 — RLS hides the row.
+	router := patchRouter(testpkg.TenantContext(2), s.res)
+
+	w := doPatch(t, router, fmt.Sprintf("/instances/%d/students/%d", s.instanceID, s.studentID), map[string]any{
+		"status": "absent",
+	})
+	assert.Equal(t, http.StatusNotFound, w.Code, "wrong tenant must be 404, not 403")
+}
+
+// strPtr is a tiny helper so test tables stay compact.
+func strPtr(s string) *string { return &s }

--- a/backend/api/timetable/instance_students_unit_test.go
+++ b/backend/api/timetable/instance_students_unit_test.go
@@ -1,0 +1,576 @@
+// Unit tests for the WP-B10 attendance PATCH handler that don't require a
+// database. The DB-backed tests in instance_students_test.go cover the happy
+// path and cross-field rule end-to-end; these tests close the coverage gap on
+// the branches SonarQube flagged as missing: repo-not-wired guard, path
+// parsing errors, body decode errors, response mapping, and the
+// DatabaseError-wrapped-ErrNoRows branch in isNotFoundDBError.
+package timetable
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	modelsBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Fake InstanceStudentRepository
+// -----------------------------------------------------------------------------
+
+type fakeRepo struct {
+	findByInstanceAndStudent func(ctx context.Context, instanceID, studentID int64) (*schedule.InstanceStudent, error)
+	updateAttendanceFields   func(ctx context.Context, id int64, patch schedule.AttendanceFieldPatch) error
+
+	findCalls    int
+	updateCalls  int
+	recentID     int64
+	recentPatch  schedule.AttendanceFieldPatch
+	currentState *schedule.InstanceStudent
+}
+
+func (f *fakeRepo) FindByInstanceAndStudent(ctx context.Context, instanceID, studentID int64) (*schedule.InstanceStudent, error) {
+	f.findCalls++
+	if f.findByInstanceAndStudent != nil {
+		return f.findByInstanceAndStudent(ctx, instanceID, studentID)
+	}
+	return f.currentState, nil
+}
+
+func (f *fakeRepo) UpdateAttendanceFields(ctx context.Context, id int64, patch schedule.AttendanceFieldPatch) error {
+	f.updateCalls++
+	f.recentID = id
+	f.recentPatch = patch
+	if f.updateAttendanceFields != nil {
+		return f.updateAttendanceFields(ctx, id, patch)
+	}
+	return nil
+}
+
+// Unused interface methods — panic so accidental dependence fails loudly.
+func (f *fakeRepo) Create(context.Context, *schedule.InstanceStudent) error { panic("unused") }
+func (f *fakeRepo) FindByID(context.Context, interface{}) (*schedule.InstanceStudent, error) {
+	panic("unused")
+}
+func (f *fakeRepo) Update(context.Context, *schedule.InstanceStudent) error { panic("unused") }
+func (f *fakeRepo) Delete(context.Context, interface{}) error               { panic("unused") }
+func (f *fakeRepo) List(context.Context, *modelsBase.QueryOptions) ([]*schedule.InstanceStudent, error) {
+	panic("unused")
+}
+func (f *fakeRepo) FindByInstanceID(context.Context, int64) ([]*schedule.InstanceStudent, error) {
+	panic("unused")
+}
+func (f *fakeRepo) FindByStudentAndDateRange(context.Context, int64, time.Time, time.Time) ([]*schedule.InstanceStudent, error) {
+	panic("unused")
+}
+func (f *fakeRepo) DeleteByInstanceID(context.Context, int64) error { panic("unused") }
+func (f *fakeRepo) UpdateAttendanceFromCheckin(context.Context, int64, int64, time.Time) (bool, error) {
+	panic("unused")
+}
+
+// -----------------------------------------------------------------------------
+// Router helpers
+// -----------------------------------------------------------------------------
+
+func unitRouter(res *Resource) chi.Router {
+	r := chi.NewRouter()
+	r.Patch("/instances/{instance_id}/students/{student_id}", res.patchInstanceStudent)
+	return r
+}
+
+func patchRequest(t *testing.T, path string, body any) *http.Request {
+	t.Helper()
+	var buf *bytes.Reader
+	switch b := body.(type) {
+	case nil:
+		buf = bytes.NewReader(nil)
+	case string:
+		buf = bytes.NewReader([]byte(b))
+	default:
+		jb, err := json.Marshal(b)
+		require.NoError(t, err)
+		buf = bytes.NewReader(jb)
+	}
+	req := httptest.NewRequest(http.MethodPatch, path, buf)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func run(router chi.Router, req *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// -----------------------------------------------------------------------------
+// patchInstanceStudent — guard / wiring branches
+// -----------------------------------------------------------------------------
+
+func TestPatchHandler_500_RepoNotWired(t *testing.T) {
+	// Resource with instanceStudentRepo == nil must return 500 rather than crash.
+	res := &Resource{}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/2", map[string]any{"status": "absent"}))
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "attendance PATCH not wired")
+}
+
+// -----------------------------------------------------------------------------
+// parseAttendancePathIDs — 400 branches
+// -----------------------------------------------------------------------------
+
+func TestPatchHandler_400_InvalidInstanceID(t *testing.T) {
+	res := &Resource{instanceStudentRepo: &fakeRepo{}}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/abc/students/2", map[string]any{"status": "absent"}))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid instance_id or student_id")
+}
+
+func TestPatchHandler_400_InvalidStudentID(t *testing.T) {
+	res := &Resource{instanceStudentRepo: &fakeRepo{}}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/xyz", map[string]any{"status": "absent"}))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid instance_id or student_id")
+}
+
+func TestPatchHandler_400_ZeroInstanceID(t *testing.T) {
+	res := &Resource{instanceStudentRepo: &fakeRepo{}}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/0/students/2", map[string]any{"status": "absent"}))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPatchHandler_400_NegativeIDs(t *testing.T) {
+	res := &Resource{instanceStudentRepo: &fakeRepo{}}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/-1/students/2", map[string]any{"status": "absent"}))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// -----------------------------------------------------------------------------
+// decodePatchBody — error / empty / non-string branches
+// -----------------------------------------------------------------------------
+
+func TestPatchHandler_400_MalformedJSON(t *testing.T) {
+	res := &Resource{instanceStudentRepo: &fakeRepo{}}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/2", "{not json"))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid JSON body")
+}
+
+func TestPatchHandler_400_EmptyBody_MeansNoChanges(t *testing.T) {
+	res := &Resource{instanceStudentRepo: &fakeRepo{}}
+	router := unitRouter(res)
+
+	// Empty body → parser returns zero patch → HasChanges false → 400.
+	req := httptest.NewRequest(http.MethodPatch, "/instances/1/students/2", bytes.NewReader(nil))
+	w := run(router, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "at least one of")
+}
+
+func TestPatchHandler_400_BodyReadError(t *testing.T) {
+	// A broken reader forces io.ReadAll to return an error, exercising the
+	// "failed to read request body" branch.
+	res := &Resource{instanceStudentRepo: &fakeRepo{}}
+	router := unitRouter(res)
+
+	req := httptest.NewRequest(http.MethodPatch, "/instances/1/students/2", brokenReader{})
+	req.Header.Set("Content-Type", "application/json")
+	w := run(router, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "failed to read request body")
+}
+
+func TestPatchHandler_400_NonStringNote(t *testing.T) {
+	res := &Resource{instanceStudentRepo: &fakeRepo{}}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/2", `{"note": 5}`))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "note")
+}
+
+// brokenReader always fails on Read, used to exercise the body-read error branch.
+type brokenReader struct{}
+
+func (brokenReader) Read(_ []byte) (int, error) { return 0, errors.New("read disrupted") }
+func (brokenReader) Close() error               { return nil }
+
+// -----------------------------------------------------------------------------
+// Full handler flow via fake repo (no DB)
+// -----------------------------------------------------------------------------
+
+func TestPatchHandler_404_NotFound_ErrNoRows(t *testing.T) {
+	repo := &fakeRepo{
+		findByInstanceAndStudent: func(context.Context, int64, int64) (*schedule.InstanceStudent, error) {
+			return nil, sql.ErrNoRows
+		},
+	}
+	res := &Resource{instanceStudentRepo: repo}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/2", map[string]any{"status": "absent"}))
+	require.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "instance student not found")
+}
+
+func TestPatchHandler_404_NotFound_WrappedDatabaseError(t *testing.T) {
+	// DatabaseError wrapping sql.ErrNoRows — matches the wrapping style used
+	// by the repo layer. Covered by isNotFoundDBError's errors.As branch.
+	repo := &fakeRepo{
+		findByInstanceAndStudent: func(context.Context, int64, int64) (*schedule.InstanceStudent, error) {
+			return nil, &modelsBase.DatabaseError{Op: "find", Err: sql.ErrNoRows}
+		},
+	}
+	res := &Resource{instanceStudentRepo: repo}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/2", map[string]any{"status": "absent"}))
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestPatchHandler_404_NotFound_NilRowNilError(t *testing.T) {
+	// Repo returns (nil, nil) — row genuinely absent rather than DB error.
+	repo := &fakeRepo{
+		findByInstanceAndStudent: func(context.Context, int64, int64) (*schedule.InstanceStudent, error) {
+			return nil, nil
+		},
+	}
+	res := &Resource{instanceStudentRepo: repo}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/2", map[string]any{"status": "absent"}))
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestPatchHandler_500_FindError_NotNotFound(t *testing.T) {
+	repo := &fakeRepo{
+		findByInstanceAndStudent: func(context.Context, int64, int64) (*schedule.InstanceStudent, error) {
+			return nil, errors.New("connection reset")
+		},
+	}
+	res := &Resource{instanceStudentRepo: repo}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/2", map[string]any{"status": "absent"}))
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "load instance student failed")
+}
+
+func TestPatchHandler_500_UpdateError(t *testing.T) {
+	current := &schedule.InstanceStudent{Status: schedule.AttendanceStatusPresent}
+	current.ID = 7
+	updateErr := errors.New("FK violation")
+
+	repo := &fakeRepo{
+		currentState: current,
+		updateAttendanceFields: func(context.Context, int64, schedule.AttendanceFieldPatch) error {
+			return updateErr
+		},
+	}
+	res := &Resource{instanceStudentRepo: repo}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/2", map[string]any{"status": "absent"}))
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "update attendance failed")
+}
+
+func TestPatchHandler_500_ReloadAfterUpdateFails(t *testing.T) {
+	// The handler re-reads after update so the response body reflects post-
+	// write state. If that second read fails, the handler must return 500.
+	current := &schedule.InstanceStudent{Status: schedule.AttendanceStatusPresent}
+	current.ID = 7
+
+	callCount := 0
+	repo := &fakeRepo{
+		findByInstanceAndStudent: func(context.Context, int64, int64) (*schedule.InstanceStudent, error) {
+			callCount++
+			if callCount == 1 {
+				return current, nil
+			}
+			return nil, errors.New("reload failure")
+		},
+	}
+	res := &Resource{instanceStudentRepo: repo}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/2", map[string]any{"status": "absent"}))
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "reload updated attendance failed")
+	assert.Equal(t, 2, repo.findCalls)
+}
+
+func TestPatchHandler_500_ReloadReturnsNil(t *testing.T) {
+	// Reload returns (nil, nil) — the handler guards against this edge case
+	// because mapAttendanceToResponse would panic on a nil row.
+	current := &schedule.InstanceStudent{Status: schedule.AttendanceStatusPresent}
+	current.ID = 7
+
+	callCount := 0
+	repo := &fakeRepo{
+		findByInstanceAndStudent: func(context.Context, int64, int64) (*schedule.InstanceStudent, error) {
+			callCount++
+			if callCount == 1 {
+				return current, nil
+			}
+			return nil, nil
+		},
+	}
+	res := &Resource{instanceStudentRepo: repo}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/2", map[string]any{"status": "absent"}))
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "reload updated attendance failed")
+}
+
+func TestPatchHandler_400_CrossFieldRuleAfterFind(t *testing.T) {
+	// The validation branch after FindByInstanceAndStudent only fires when
+	// the parsed patch is individually valid but violates the cross-field
+	// rule against the loaded current row. Seeding an 'expected' row and
+	// patching just a substatus triggers the "substatus cannot be set when
+	// status is expected" response path without any parse-level rejection.
+	current := &schedule.InstanceStudent{Status: schedule.AttendanceStatusExpected}
+	current.ID = 11
+
+	repo := &fakeRepo{currentState: current}
+	res := &Resource{instanceStudentRepo: repo}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/1/students/2", map[string]any{"substatus": "late"}))
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "cannot be set when status is expected")
+	assert.Equal(t, 0, repo.updateCalls, "validation failure must short-circuit before UPDATE")
+}
+
+func TestPatchHandler_200_HappyPath(t *testing.T) {
+	// First read returns "present". Second read reflects the applied patch —
+	// mimicking the repo writing fields then re-reading them.
+	checkedInAt := time.Date(2026, 4, 20, 14, 0, 0, 0, time.UTC)
+	current := &schedule.InstanceStudent{
+		InstanceID:  100,
+		StudentID:   200,
+		Status:      schedule.AttendanceStatusPresent,
+		CheckedInAt: &checkedInAt,
+	}
+	current.ID = 7
+
+	absent := schedule.AttendanceStatusAbsent
+	sick := schedule.AttendanceSubstatusSick
+	note := "Arztbesuch"
+
+	updated := &schedule.InstanceStudent{
+		InstanceID:  100,
+		StudentID:   200,
+		Status:      absent,
+		Substatus:   &sick,
+		Note:        &note,
+		CheckedInAt: &checkedInAt,
+	}
+	updated.ID = 7
+
+	callCount := 0
+	repo := &fakeRepo{
+		findByInstanceAndStudent: func(context.Context, int64, int64) (*schedule.InstanceStudent, error) {
+			callCount++
+			if callCount == 1 {
+				return current, nil
+			}
+			return updated, nil
+		},
+	}
+	res := &Resource{instanceStudentRepo: repo}
+	router := unitRouter(res)
+
+	w := run(router, patchRequest(t, "/instances/100/students/200", map[string]any{
+		"status":    "absent",
+		"substatus": "sick",
+		"note":      "Arztbesuch",
+	}))
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, "absent", data["status"])
+	assert.Equal(t, "sick", data["substatus"])
+	assert.Equal(t, "Arztbesuch", data["note"])
+	assert.NotEmpty(t, data["checked_in_at"])
+	assert.Equal(t, 1, repo.updateCalls)
+	assert.Equal(t, int64(7), repo.recentID)
+}
+
+// -----------------------------------------------------------------------------
+// mapAttendanceToResponse — cover both CheckedInAt branches
+// -----------------------------------------------------------------------------
+
+func TestMapAttendanceToResponse_WithCheckedInAt(t *testing.T) {
+	ts := time.Date(2026, 4, 20, 14, 15, 30, 0, time.UTC)
+	excused := schedule.AttendanceSubstatusExcused
+	note := "Bus-Verspätung"
+	row := &schedule.InstanceStudent{
+		InstanceID:  11,
+		StudentID:   22,
+		Status:      schedule.AttendanceStatusPresent,
+		Substatus:   &excused,
+		Note:        &note,
+		CheckedInAt: &ts,
+	}
+	row.ID = 99
+
+	resp := mapAttendanceToResponse(row)
+	assert.Equal(t, int64(99), resp.ID)
+	assert.Equal(t, int64(11), resp.InstanceID)
+	assert.Equal(t, int64(22), resp.StudentID)
+	assert.Equal(t, schedule.AttendanceStatusPresent, resp.Status)
+	require.NotNil(t, resp.Substatus)
+	assert.Equal(t, schedule.AttendanceSubstatusExcused, *resp.Substatus)
+	require.NotNil(t, resp.CheckedInAt)
+	assert.Equal(t, "2026-04-20T14:15:30Z", *resp.CheckedInAt)
+}
+
+func TestMapAttendanceToResponse_WithoutCheckedInAt(t *testing.T) {
+	row := &schedule.InstanceStudent{Status: schedule.AttendanceStatusExpected}
+	resp := mapAttendanceToResponse(row)
+	assert.Nil(t, resp.CheckedInAt)
+	assert.Nil(t, resp.Substatus)
+	assert.Nil(t, resp.Note)
+}
+
+// -----------------------------------------------------------------------------
+// isNotFoundDBError — exhaustive matrix
+// -----------------------------------------------------------------------------
+
+func TestIsNotFoundDBError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"plain sql.ErrNoRows", sql.ErrNoRows, false}, // not wrapped in DatabaseError
+		{"DatabaseError wrapping ErrNoRows", &modelsBase.DatabaseError{Op: "find", Err: sql.ErrNoRows}, true},
+		{"DatabaseError wrapping other err", &modelsBase.DatabaseError{Op: "find", Err: errors.New("boom")}, false},
+		{"plain other error", errors.New("timeout"), false},
+		{"wrapped DatabaseError", fmt.Errorf("outer: %w", &modelsBase.DatabaseError{Op: "find", Err: sql.ErrNoRows}), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isNotFoundDBError(tc.err))
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// parseAttendancePatchRequest — ensure each state reached
+// -----------------------------------------------------------------------------
+
+func TestParseAttendancePatchRequest_AllFields(t *testing.T) {
+	status := schedule.AttendanceStatusAbsent
+	req := &PatchAttendanceRequest{
+		Status:    &status,
+		Substatus: json.RawMessage(`"sick"`),
+		Note:      json.RawMessage(`"note text"`),
+	}
+	patch, errs := parseAttendancePatchRequest(req)
+	require.Empty(t, errs)
+	require.NotNil(t, patch.Status)
+	assert.Equal(t, schedule.AttendanceStatusAbsent, *patch.Status)
+	require.NotNil(t, patch.Substatus)
+	assert.Equal(t, schedule.AttendanceSubstatusSick, *patch.Substatus)
+	require.NotNil(t, patch.Note)
+	assert.Equal(t, "note text", *patch.Note)
+	assert.False(t, patch.SubstatusClear)
+	assert.False(t, patch.NoteClear)
+}
+
+func TestParseAttendancePatchRequest_ClearsViaNull(t *testing.T) {
+	req := &PatchAttendanceRequest{
+		Substatus: json.RawMessage(`null`),
+		Note:      json.RawMessage(`null`),
+	}
+	patch, errs := parseAttendancePatchRequest(req)
+	require.Empty(t, errs)
+	assert.True(t, patch.SubstatusClear)
+	assert.True(t, patch.NoteClear)
+	assert.Nil(t, patch.Substatus)
+	assert.Nil(t, patch.Note)
+}
+
+func TestParseAttendancePatchRequest_TypeErrorsOnBothFields(t *testing.T) {
+	req := &PatchAttendanceRequest{
+		Substatus: json.RawMessage(`5`),
+		Note:      json.RawMessage(`{"x":1}`),
+	}
+	_, errs := parseAttendancePatchRequest(req)
+	require.Len(t, errs, 2)
+	// The order mirrors the parse order — substatus first, then note.
+	assert.Equal(t, "substatus", errs[0].Field)
+	assert.Equal(t, "note", errs[1].Field)
+}
+
+// -----------------------------------------------------------------------------
+// decodePatchBody — direct call edge cases
+// -----------------------------------------------------------------------------
+
+func TestDecodePatchBody_Direct(t *testing.T) {
+	t.Run("valid body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"status":"present"}`))
+		w := httptest.NewRecorder()
+		body, ok := decodePatchBody(w, req)
+		require.True(t, ok)
+		require.NotNil(t, body)
+		require.NotNil(t, body.Status)
+		assert.Equal(t, "present", *body.Status)
+	})
+
+	t.Run("oversized body gets truncated", func(t *testing.T) {
+		// Send more than 16 KiB — io.LimitReader caps it so the decoder sees
+		// a truncated input. That should surface as "invalid JSON body".
+		huge := strings.Repeat("x", 17*1024)
+		req := httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(fmt.Sprintf(`{"note":"%s"`, huge)))
+		w := httptest.NewRecorder()
+		_, ok := decodePatchBody(w, req)
+		assert.False(t, ok)
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(""))
+		w := httptest.NewRecorder()
+		body, ok := decodePatchBody(w, req)
+		require.True(t, ok, "empty body is valid — handler interprets as no changes")
+		require.NotNil(t, body)
+	})
+
+	t.Run("broken reader", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPatch, "/", io.NopCloser(brokenReader{}))
+		w := httptest.NewRecorder()
+		_, ok := decodePatchBody(w, req)
+		assert.False(t, ok)
+	})
+}

--- a/backend/api/timetable/instances_test.go
+++ b/backend/api/timetable/instances_test.go
@@ -237,7 +237,7 @@ func TestStartInstance_Success(t *testing.T) {
 	}
 	mock.startResult.Instance.ID = int64(7)
 
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/7/start", nil)
@@ -271,7 +271,7 @@ func TestStartInstance_WithWarnings(t *testing.T) {
 	}
 	mock.startResult.Instance.ID = int64(3)
 
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/3/start", nil)
@@ -285,7 +285,7 @@ func TestStartInstance_WithWarnings(t *testing.T) {
 }
 
 func TestStartInstance_InvalidID(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/not-a-number/start", nil)
@@ -294,7 +294,7 @@ func TestStartInstance_InvalidID(t *testing.T) {
 }
 
 func TestStartInstance_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/1/start", nil)
@@ -304,7 +304,7 @@ func TestStartInstance_NilService(t *testing.T) {
 
 func TestStartInstance_NotFound(t *testing.T) {
 	mock := &mockInstanceService{startErr: scheduleSvc.ErrInstanceNotFound}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/99/start", nil)
@@ -316,7 +316,7 @@ func TestStartInstance_InvalidTransition(t *testing.T) {
 	mock := &mockInstanceService{startErr: errors.New("wrap: " + scheduleSvc.ErrInvalidInstanceTransition.Error())}
 	// Use an error that errors.Is matches via wrapping.
 	mock.startErr = &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/1/start", nil)
@@ -327,7 +327,7 @@ func TestStartInstance_InvalidTransition(t *testing.T) {
 
 func TestStartInstance_InternalError(t *testing.T) {
 	mock := &mockInstanceService{startErr: errors.New("db connection lost")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/1/start", nil)
@@ -355,7 +355,7 @@ func TestCompleteInstance_Success(t *testing.T) {
 	instance.ID = int64(5)
 
 	mock := &mockInstanceService{completeRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/5/complete", nil)
@@ -376,7 +376,7 @@ func TestCompleteInstance_NoCompletedAt(t *testing.T) {
 	instance.ID = int64(5)
 
 	mock := &mockInstanceService{completeRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/5/complete", nil)
@@ -386,7 +386,7 @@ func TestCompleteInstance_NoCompletedAt(t *testing.T) {
 }
 
 func TestCompleteInstance_InvalidID(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/bad/complete", nil)
@@ -395,7 +395,7 @@ func TestCompleteInstance_InvalidID(t *testing.T) {
 }
 
 func TestCompleteInstance_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -405,7 +405,7 @@ func TestCompleteInstance_NilService(t *testing.T) {
 
 func TestCompleteInstance_NotFound(t *testing.T) {
 	mock := &mockInstanceService{completeErr: scheduleSvc.ErrInstanceNotFound}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -415,7 +415,7 @@ func TestCompleteInstance_NotFound(t *testing.T) {
 
 func TestCompleteInstance_InvalidTransition(t *testing.T) {
 	mock := &mockInstanceService{completeErr: &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -426,7 +426,7 @@ func TestCompleteInstance_InvalidTransition(t *testing.T) {
 
 func TestCompleteInstance_InternalError(t *testing.T) {
 	mock := &mockInstanceService{completeErr: errors.New("db error")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -447,7 +447,7 @@ func TestCancelInstance_Success(t *testing.T) {
 	instance.ID = int64(11)
 
 	mock := &mockInstanceService{cancelRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/11/cancel", nil)
@@ -465,7 +465,7 @@ func TestCancelInstance_NoCompletedAt(t *testing.T) {
 	instance := &scheduleModel.ActivityInstance{Status: scheduleModel.InstanceStatusCancelled}
 	instance.ID = int64(12)
 	mock := &mockInstanceService{cancelRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/12/cancel", nil)
@@ -473,7 +473,7 @@ func TestCancelInstance_NoCompletedAt(t *testing.T) {
 }
 
 func TestCancelInstance_InvalidID(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/nope/cancel", nil)
@@ -481,7 +481,7 @@ func TestCancelInstance_InvalidID(t *testing.T) {
 }
 
 func TestCancelInstance_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -490,7 +490,7 @@ func TestCancelInstance_NilService(t *testing.T) {
 
 func TestCancelInstance_NotFound(t *testing.T) {
 	mock := &mockInstanceService{cancelErr: scheduleSvc.ErrInstanceNotFound}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -499,7 +499,7 @@ func TestCancelInstance_NotFound(t *testing.T) {
 
 func TestCancelInstance_InvalidTransition(t *testing.T) {
 	mock := &mockInstanceService{cancelErr: &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -508,7 +508,7 @@ func TestCancelInstance_InvalidTransition(t *testing.T) {
 
 func TestCancelInstance_InternalError(t *testing.T) {
 	mock := &mockInstanceService{cancelErr: errors.New("db failure")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -521,13 +521,13 @@ func TestCancelInstance_InternalError(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestResolveStartedByStaffID_NilPersonService(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil)
 	staffID := rs.resolveStartedByStaffID(context.Background())
 	assert.Equal(t, int64(0), staffID)
 }
 
 func TestResolveStartedByStaffID_NoClaimsInContext(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, &instMockPersonService{}, nil, nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, &instMockPersonService{}, nil, nil, nil)
 	staffID := rs.resolveStartedByStaffID(context.Background())
 	assert.Equal(t, int64(0), staffID)
 }
@@ -538,7 +538,7 @@ func TestResolveStartedByStaffID_PersonNotFound(t *testing.T) {
 			return nil, errors.New("person not found")
 		},
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -552,7 +552,7 @@ func TestResolveStartedByStaffID_PersonIsNil(t *testing.T) {
 			return nil, nil
 		},
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -569,7 +569,7 @@ func TestResolveStartedByStaffID_StaffRepoNil(t *testing.T) {
 		},
 		staffRepo: nil, // returns nil from StaffRepository()
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -591,7 +591,7 @@ func TestResolveStartedByStaffID_StaffNotFound(t *testing.T) {
 		},
 		staffRepo: staffRepo,
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -613,7 +613,7 @@ func TestResolveStartedByStaffID_StaffIsNil(t *testing.T) {
 		},
 		staffRepo: staffRepo,
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -639,7 +639,7 @@ func TestResolveStartedByStaffID_Success(t *testing.T) {
 		},
 		staffRepo: staffRepo,
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -674,7 +674,7 @@ func TestStartInstance_PassesStartedByFromJWT(t *testing.T) {
 			ActiveGroupID: 1,
 		},
 	}
-	rs := NewResource(nil, nil, mock, ps, slog.Default(), nil)
+	rs := NewResource(nil, nil, mock, ps, nil, slog.Default(), nil)
 
 	r := chi.NewRouter()
 	r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -701,12 +701,12 @@ func TestStartInstance_PassesStartedByFromJWT(t *testing.T) {
 func TestResource_getLogger(t *testing.T) {
 	t.Run("returns injected logger", func(t *testing.T) {
 		custom := slog.Default()
-		rs := NewResource(nil, nil, nil, nil, custom, nil)
+		rs := NewResource(nil, nil, nil, nil, nil, custom, nil)
 		assert.NotNil(t, rs.getLogger())
 	})
 
 	t.Run("falls back to slog.Default when nil", func(t *testing.T) {
-		rs := NewResource(nil, nil, nil, nil, nil, nil)
+		rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
 		assert.NotNil(t, rs.getLogger(), "must never return nil")
 	})
 }
@@ -722,7 +722,7 @@ func TestReplanWeekRequest_Bind_NoOp(t *testing.T) {
 }
 
 func TestReplanWeek_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)
@@ -744,7 +744,7 @@ func TestReplanWeek_NoBody_DefaultsToNextWeek(t *testing.T) {
 			},
 		},
 	}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)
@@ -771,7 +771,7 @@ func TestReplanWeek_ValidBody(t *testing.T) {
 			Materialization:  &scheduleSvc.MaterializationResult{InstancesCreated: 3},
 		},
 	}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	body := map[string]string{
@@ -796,7 +796,7 @@ func TestReplanWeek_NilMaterialization(t *testing.T) {
 			Materialization:  nil,
 		},
 	}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)
@@ -809,7 +809,7 @@ func TestReplanWeek_NilMaterialization(t *testing.T) {
 
 func TestReplanWeek_InvalidWindow(t *testing.T) {
 	mock := &mockInstanceService{}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	body := map[string]string{
@@ -823,7 +823,7 @@ func TestReplanWeek_InvalidWindow(t *testing.T) {
 
 func TestReplanWeek_InvalidJSON(t *testing.T) {
 	mock := &mockInstanceService{}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	req := httptest.NewRequest(http.MethodPost, "/instances/re-plan-week", bytes.NewReader([]byte("{not json")))
@@ -837,7 +837,7 @@ func TestReplanWeek_InvalidJSON(t *testing.T) {
 
 func TestReplanWeek_ServiceError(t *testing.T) {
 	mock := &mockInstanceService{replanErr: errors.New("db exploded")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)

--- a/backend/api/timetable/materialize_test.go
+++ b/backend/api/timetable/materialize_test.go
@@ -142,7 +142,7 @@ func TestMaterialize_NoBody_DefaultsToNextWeek(t *testing.T) {
 			InstanceStaffCreated:    2,
 		},
 	}
-	rs := NewResource(nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -162,7 +162,7 @@ func TestMaterialize_ValidBody_ParsesAndForwards(t *testing.T) {
 	mock := &mockMaterializer{
 		result: &scheduleSvc.MaterializationResult{InstancesCreated: 1},
 	}
-	rs := NewResource(nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	body, _ := json.Marshal(map[string]string{
@@ -188,7 +188,7 @@ func TestMaterialize_ValidBody_ParsesAndForwards(t *testing.T) {
 
 func TestMaterialize_InvalidWindow_Returns400(t *testing.T) {
 	mock := &mockMaterializer{}
-	rs := NewResource(nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	body, _ := json.Marshal(map[string]string{
@@ -205,7 +205,7 @@ func TestMaterialize_InvalidWindow_Returns400(t *testing.T) {
 }
 
 func TestMaterialize_NilService_Returns500(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -217,7 +217,7 @@ func TestMaterialize_NilService_Returns500(t *testing.T) {
 
 func TestMaterialize_ServiceError_Returns500(t *testing.T) {
 	mock := &mockMaterializer{err: errors.New("boom")}
-	rs := NewResource(nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)

--- a/backend/database/repositories/schedule/instance_student_repo.go
+++ b/backend/database/repositories/schedule/instance_student_repo.go
@@ -202,7 +202,7 @@ func (r *InstanceStudentRepository) UpdateAttendanceFromCheckin(
 		ModelTableExpr(modelTblInstanceStudent).
 		Set(`status = ?`, schedule.AttendanceStatusPresent).
 		Set(`checked_in_at = ?`, checkedInAt).
-		Set(`updated_at = ?`, time.Now()).
+		Set(`updated_at = ?`, time.Now().UTC()).
 		Where(`"instance_student".instance_id = ?`, instanceID).
 		Where(`"instance_student".student_id = ?`, studentID).
 		Where(`"instance_student".status = ?`, schedule.AttendanceStatusExpected)
@@ -263,7 +263,7 @@ func (r *InstanceStudentRepository) UpdateAttendanceFields(
 	case patch.Note != nil:
 		q = q.Set(`note = ?`, *patch.Note)
 	}
-	q = q.Set(`updated_at = ?`, time.Now())
+	q = q.Set(`updated_at = ?`, time.Now().UTC())
 
 	if _, err := q.Exec(ctx); err != nil {
 		return &modelBase.DatabaseError{

--- a/backend/database/repositories/schedule/instance_student_repo.go
+++ b/backend/database/repositories/schedule/instance_student_repo.go
@@ -183,6 +183,97 @@ func (r *InstanceStudentRepository) FindByInstanceAndStudent(ctx context.Context
 	return &row, nil
 }
 
+// UpdateAttendanceFromCheckin is the mirror-path write (WP-B10). It flips
+// status 'expected' → 'present' and stamps checked_in_at, but ONLY when the
+// current row is still 'expected'. The status='expected' predicate in the
+// WHERE clause enforces monotonicity: a row that has been marked present
+// (by a prior check-in or a staff PATCH) is never overwritten here.
+//
+// Returns (updated=true) when exactly one row was modified. A zero-rows
+// result means either (a) the row doesn't exist in this tenant, or
+// (b) it already moved out of 'expected' between the caller's read and
+// this UPDATE — a benign race the mirror service handles by preserving
+// the existing state.
+func (r *InstanceStudentRepository) UpdateAttendanceFromCheckin(
+	ctx context.Context, instanceID, studentID int64, checkedInAt time.Time,
+) (bool, error) {
+	q := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*schedule.InstanceStudent)(nil)).
+		ModelTableExpr(modelTblInstanceStudent).
+		Set(`status = ?`, schedule.AttendanceStatusPresent).
+		Set(`checked_in_at = ?`, checkedInAt).
+		Set(`updated_at = ?`, time.Now()).
+		Where(`"instance_student".instance_id = ?`, instanceID).
+		Where(`"instance_student".student_id = ?`, studentID).
+		Where(`"instance_student".status = ?`, schedule.AttendanceStatusExpected)
+
+	if where, val, ok := base.TenantWhere(ctx, aliasInstanceStudent); ok {
+		q = q.Where(where, val)
+	}
+
+	res, err := q.Exec(ctx)
+	if err != nil {
+		return false, &modelBase.DatabaseError{
+			Op:  "update attendance from checkin",
+			Err: err,
+		}
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// UpdateAttendanceFields writes only the fields the patch carries. Pointer-nil
+// (and the *Clear bools unset) means "do not touch that column". Substatus and
+// Note support explicit NULL via the *Clear companion bools, since both
+// columns are nullable in the schema.
+//
+// This is the PATCH-endpoint write — it overwrites whatever is there. The
+// handler is responsible for cross-field validation (e.g. substatus-with-
+// expected-status) before calling.
+func (r *InstanceStudentRepository) UpdateAttendanceFields(
+	ctx context.Context, id int64, patch schedule.AttendanceFieldPatch,
+) error {
+	if !patch.HasChanges() {
+		// Defensive: the handler should reject this at 400. A repo no-op
+		// here is safer than issuing an empty UPDATE and bumping updated_at.
+		return nil
+	}
+
+	q := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*schedule.InstanceStudent)(nil)).
+		ModelTableExpr(modelTblInstanceStudent).
+		Where(`"instance_student".id = ?`, id)
+
+	if where, val, ok := base.TenantWhere(ctx, aliasInstanceStudent); ok {
+		q = q.Where(where, val)
+	}
+
+	if patch.Status != nil {
+		q = q.Set(`status = ?`, *patch.Status)
+	}
+	switch {
+	case patch.SubstatusClear:
+		q = q.Set(`substatus = NULL`)
+	case patch.Substatus != nil:
+		q = q.Set(`substatus = ?`, *patch.Substatus)
+	}
+	switch {
+	case patch.NoteClear:
+		q = q.Set(`note = NULL`)
+	case patch.Note != nil:
+		q = q.Set(`note = ?`, *patch.Note)
+	}
+	q = q.Set(`updated_at = ?`, time.Now())
+
+	if _, err := q.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{
+			Op:  "update attendance fields",
+			Err: err,
+		}
+	}
+	return nil
+}
+
 // DeleteByInstanceID removes all attendance rows for an instance.
 func (r *InstanceStudentRepository) DeleteByInstanceID(ctx context.Context, instanceID int64) error {
 	query := base.GetDB(ctx, r.db).NewDelete().

--- a/backend/database/repositories/schedule/instance_student_repo_test.go
+++ b/backend/database/repositories/schedule/instance_student_repo_test.go
@@ -359,6 +359,167 @@ func TestInstanceStudentRepository_ErrorBranches(t *testing.T) {
 	})
 }
 
+func TestInstanceStudentRepository_UpdateAttendanceFromCheckin(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repo := scheduleRepo.NewInstanceStudentRepository(db)
+
+	inst, cleanupInst := createInstanceFixture(t, db, "mirror", time.Date(2026, 10, 10, 0, 0, 0, 0, time.UTC))
+	defer cleanupInst()
+
+	student := testpkg.CreateTestStudent(t, db, "Lea", fmt.Sprintf("Mirror-%d", time.Now().UnixNano()), "3a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	t.Run("flips expected → present and stamps checked_in_at", func(t *testing.T) {
+		row := &scheduleModels.InstanceStudent{
+			InstanceID: inst.ID,
+			StudentID:  student.ID,
+			Status:     scheduleModels.AttendanceStatusExpected,
+		}
+		row.SetTenantID(1)
+		require.NoError(t, repo.Create(ctx, row))
+		defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", row.ID)
+
+		checkedAt := time.Date(2026, 10, 10, 13, 5, 0, 0, time.UTC)
+		updated, err := repo.UpdateAttendanceFromCheckin(ctx, inst.ID, student.ID, checkedAt)
+		require.NoError(t, err)
+		assert.True(t, updated, "expected row should be flipped")
+
+		got, err := repo.FindByID(ctx, row.ID)
+		require.NoError(t, err)
+		assert.Equal(t, scheduleModels.AttendanceStatusPresent, got.Status)
+		require.NotNil(t, got.CheckedInAt)
+		assert.WithinDuration(t, checkedAt, *got.CheckedInAt, time.Second)
+	})
+
+	t.Run("no-op when row is already present (monotonicity)", func(t *testing.T) {
+		other := testpkg.CreateTestStudent(t, db, "Tom", fmt.Sprintf("Mono-%d", time.Now().UnixNano()), "3a")
+		defer testpkg.CleanupActivityFixtures(t, db, other.ID)
+
+		firstCheckin := time.Date(2026, 10, 10, 13, 0, 0, 0, time.UTC)
+		row := &scheduleModels.InstanceStudent{
+			InstanceID:  inst.ID,
+			StudentID:   other.ID,
+			Status:      scheduleModels.AttendanceStatusPresent,
+			CheckedInAt: &firstCheckin,
+		}
+		row.SetTenantID(1)
+		require.NoError(t, repo.Create(ctx, row))
+		defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", row.ID)
+
+		laterCheckin := time.Date(2026, 10, 10, 14, 30, 0, 0, time.UTC)
+		updated, err := repo.UpdateAttendanceFromCheckin(ctx, inst.ID, other.ID, laterCheckin)
+		require.NoError(t, err)
+		assert.False(t, updated, "already-present row must not be clobbered")
+
+		got, err := repo.FindByID(ctx, row.ID)
+		require.NoError(t, err)
+		assert.Equal(t, scheduleModels.AttendanceStatusPresent, got.Status)
+		require.NotNil(t, got.CheckedInAt)
+		// Original checked_in_at must be preserved — monotonicity.
+		assert.WithinDuration(t, firstCheckin, *got.CheckedInAt, time.Second)
+	})
+
+	t.Run("no-op when no matching row (walk-in)", func(t *testing.T) {
+		walkin := testpkg.CreateTestStudent(t, db, "Kim", fmt.Sprintf("Walk-%d", time.Now().UnixNano()), "3a")
+		defer testpkg.CleanupActivityFixtures(t, db, walkin.ID)
+
+		// walkin student has NO instance_students row — mirror should be a no-op
+		// returning (false, nil) rather than an error.
+		updated, err := repo.UpdateAttendanceFromCheckin(ctx, inst.ID, walkin.ID, time.Now())
+		require.NoError(t, err)
+		assert.False(t, updated)
+	})
+
+	t.Run("no-op when row belongs to another tenant (RLS)", func(t *testing.T) {
+		// Row is created in tenant 1 (above). Call with tenant 2 context
+		// should match zero rows under RLS.
+		ctxT2 := testpkg.TenantContext(2)
+		updated, err := repo.UpdateAttendanceFromCheckin(ctxT2, inst.ID, student.ID, time.Now())
+		require.NoError(t, err)
+		assert.False(t, updated)
+	})
+}
+
+func TestInstanceStudentRepository_UpdateAttendanceFields(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repo := scheduleRepo.NewInstanceStudentRepository(db)
+
+	inst, cleanupInst := createInstanceFixture(t, db, "patch", time.Date(2026, 10, 11, 0, 0, 0, 0, time.UTC))
+	defer cleanupInst()
+
+	student := testpkg.CreateTestStudent(t, db, "Nora", fmt.Sprintf("Patch-%d", time.Now().UnixNano()), "3a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	checkedAt := time.Date(2026, 10, 11, 13, 0, 0, 0, time.UTC)
+	late := scheduleModels.AttendanceSubstatusLate
+	origNote := "im stau"
+
+	row := &scheduleModels.InstanceStudent{
+		InstanceID:  inst.ID,
+		StudentID:   student.ID,
+		Status:      scheduleModels.AttendanceStatusPresent,
+		Substatus:   &late,
+		Note:        &origNote,
+		CheckedInAt: &checkedAt,
+	}
+	row.SetTenantID(1)
+	require.NoError(t, repo.Create(ctx, row))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", row.ID)
+
+	t.Run("updates only the fields the patch carries", func(t *testing.T) {
+		newStatus := scheduleModels.AttendanceStatusAbsent
+		excused := scheduleModels.AttendanceSubstatusExcused
+
+		patch := scheduleModels.AttendanceFieldPatch{
+			Status:    &newStatus,
+			Substatus: &excused,
+			// Note intentionally not set — must be preserved.
+		}
+		require.NoError(t, repo.UpdateAttendanceFields(ctx, row.ID, patch))
+
+		got, err := repo.FindByID(ctx, row.ID)
+		require.NoError(t, err)
+		assert.Equal(t, scheduleModels.AttendanceStatusAbsent, got.Status)
+		require.NotNil(t, got.Substatus)
+		assert.Equal(t, scheduleModels.AttendanceSubstatusExcused, *got.Substatus)
+		require.NotNil(t, got.Note)
+		assert.Equal(t, "im stau", *got.Note, "note must survive when patch omits it")
+	})
+
+	t.Run("clears nullable columns via *Clear flags", func(t *testing.T) {
+		patch := scheduleModels.AttendanceFieldPatch{
+			SubstatusClear: true,
+			NoteClear:      true,
+		}
+		require.NoError(t, repo.UpdateAttendanceFields(ctx, row.ID, patch))
+
+		got, err := repo.FindByID(ctx, row.ID)
+		require.NoError(t, err)
+		assert.Nil(t, got.Substatus)
+		assert.Nil(t, got.Note)
+	})
+
+	t.Run("empty patch is a no-op (defensive)", func(t *testing.T) {
+		// After the clear above, status is 'absent'. A no-op patch must not
+		// mutate the row (not even updated_at).
+		beforeRow, err := repo.FindByID(ctx, row.ID)
+		require.NoError(t, err)
+
+		require.NoError(t, repo.UpdateAttendanceFields(ctx, row.ID, scheduleModels.AttendanceFieldPatch{}))
+
+		afterRow, err := repo.FindByID(ctx, row.ID)
+		require.NoError(t, err)
+		assert.Equal(t, beforeRow.Status, afterRow.Status)
+		assert.Equal(t, beforeRow.UpdatedAt.UnixNano(), afterRow.UpdatedAt.UnixNano())
+	})
+}
+
 func TestInstanceStudentRepository_DeleteByInstanceID(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/backend/models/schedule/instance_student.go
+++ b/backend/models/schedule/instance_student.go
@@ -120,6 +120,29 @@ func IsValidAttendanceSubstatus(s string) bool {
 	return false
 }
 
+// AttendanceFieldPatch carries a targeted update to status/substatus/note.
+// A nil pointer means "do not touch"; a non-nil pointer to "" or a valid
+// value means "set to this". Substatus and Note additionally carry a
+// Clear bool to express "set to NULL" (distinct from "don't touch"), since
+// those columns are nullable.
+//
+// The PATCH handler resolves the JSON tri-state (missing / null / value)
+// into this struct before it reaches the repo.
+type AttendanceFieldPatch struct {
+	Status         *string
+	Substatus      *string
+	SubstatusClear bool
+	Note           *string
+	NoteClear      bool
+}
+
+// HasChanges reports whether the patch carries at least one mutation. The
+// PATCH handler uses this to reject no-op bodies at 400.
+func (p AttendanceFieldPatch) HasChanges() bool {
+	return p.Status != nil || p.Substatus != nil || p.SubstatusClear ||
+		p.Note != nil || p.NoteClear
+}
+
 // InstanceStudentRepository defines operations for managing expected/actual
 // attendance on materialized activity instances.
 type InstanceStudentRepository interface {
@@ -139,4 +162,16 @@ type InstanceStudentRepository interface {
 
 	// DeleteByInstanceID removes all attendance rows for an instance.
 	DeleteByInstanceID(ctx context.Context, instanceID int64) error
+
+	// UpdateAttendanceFromCheckin flips status 'expected' → 'present' and
+	// stamps checked_in_at. The status='expected' predicate in the WHERE
+	// clause enforces monotonicity — a row that's already present (double
+	// tap, or post-hoc PATCH) is never clobbered. Returns (updated=true)
+	// only when a row was actually changed.
+	UpdateAttendanceFromCheckin(ctx context.Context, instanceID, studentID int64, checkedInAt time.Time) (bool, error)
+
+	// UpdateAttendanceFields writes only the fields carried by the patch.
+	// Callers (the PATCH handler) must validate cross-field invariants
+	// BEFORE invoking — the repo does not re-check them.
+	UpdateAttendanceFields(ctx context.Context, id int64, patch AttendanceFieldPatch) error
 }

--- a/backend/models/schedule/instance_student_test.go
+++ b/backend/models/schedule/instance_student_test.go
@@ -3,6 +3,7 @@ package schedule
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -118,5 +119,38 @@ func TestInstanceStudent_BeforeAppendModel(t *testing.T) {
 	s := &InstanceStudent{}
 	for _, q := range []any{&bun.SelectQuery{}, &bun.UpdateQuery{}, &bun.DeleteQuery{}, "unknown"} {
 		require.NoError(t, s.BeforeAppendModel(q))
+	}
+}
+
+func TestInstanceStudent_EntityInterface(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	s := &InstanceStudent{}
+	s.ID = 42
+	s.CreatedAt = now
+	s.UpdatedAt = now.Add(time.Minute)
+
+	assert.Equal(t, int64(42), s.GetID())
+	assert.Equal(t, now, s.GetCreatedAt())
+	assert.Equal(t, now.Add(time.Minute), s.GetUpdatedAt())
+}
+
+func TestAttendanceFieldPatch_HasChanges(t *testing.T) {
+	sentinel := "x"
+	tests := []struct {
+		name  string
+		patch AttendanceFieldPatch
+		want  bool
+	}{
+		{"empty patch", AttendanceFieldPatch{}, false},
+		{"status set", AttendanceFieldPatch{Status: &sentinel}, true},
+		{"substatus set", AttendanceFieldPatch{Substatus: &sentinel}, true},
+		{"substatus cleared", AttendanceFieldPatch{SubstatusClear: true}, true},
+		{"note set", AttendanceFieldPatch{Note: &sentinel}, true},
+		{"note cleared", AttendanceFieldPatch{NoteClear: true}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.patch.HasChanges())
+		})
 	}
 }

--- a/backend/realtime/events.go
+++ b/backend/realtime/events.go
@@ -61,6 +61,13 @@ type EventData struct {
 	InstanceDate      *string `json:"instance_date,omitempty"`       // YYYY-MM-DD
 	InstanceStartTime *string `json:"instance_start_time,omitempty"` // HH:MM:SS
 
+	// Attendance fields (WP-B10). Populated on student_checkin / student_checkout
+	// when the visit corresponds to a schedule.instance_students row — null
+	// otherwise (walk-ins, check-ins against non-instance active groups).
+	AttendanceStatus    *string `json:"attendance_status,omitempty"`
+	AttendanceSubstatus *string `json:"attendance_substatus,omitempty"`
+	AttendanceNote      *string `json:"attendance_note,omitempty"`
+
 	// Source tracking
 	Source *string `json:"source,omitempty"` // "rfid", "manual", "automated"
 }

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -86,6 +87,11 @@ type ServiceDependencies struct {
 	// Optional: Work session service for NFC auto-check-in
 	WorkSessionService WorkSessionService
 
+	// Optional: Attendance sync (WP-B10). When non-nil, visit create/end
+	// calls mirror into schedule.instance_students and enrich check-in/out
+	// SSE events with attendance status/substatus/note.
+	AttendanceSyncer AttendanceSyncer
+
 	// Optional: Structured logger (nil-safe, Phase 2b will add logging calls)
 	Logger *slog.Logger
 }
@@ -125,6 +131,9 @@ type service struct {
 	// Optional: Work session service for NFC auto-check-in
 	workSessionService WorkSessionService
 
+	// Optional: Attendance sync (WP-B10)
+	attendanceSyncer AttendanceSyncer
+
 	// Structured logger (nil-safe)
 	logger *slog.Logger
 }
@@ -161,6 +170,7 @@ func NewService(deps ServiceDependencies) Service {
 		db:                 deps.DB,
 		broadcaster:        deps.Broadcaster,
 		workSessionService: deps.WorkSessionService,
+		attendanceSyncer:   deps.AttendanceSyncer,
 		logger:             deps.Logger,
 	}
 }
@@ -418,8 +428,19 @@ func (s *service) CreateVisit(ctx context.Context, visit *active.Visit) error {
 		return &ActiveError{Op: "CreateVisit", Err: ErrDatabaseOperation}
 	}
 
+	// WP-B10: mirror the check-in into schedule.instance_students when the
+	// visit corresponds to a planned instance. The mirror is graceful-
+	// degradation-by-design — it returns nil for walk-ins, pre-start
+	// races, or any error — so we never block a visit write on it.
+	// Snapshot is threaded into the broadcast so the SSE event carries
+	// attendance fields when applicable.
+	var snapshot *AttendanceSnapshot
+	if s.attendanceSyncer != nil {
+		snapshot = s.attendanceSyncer.MirrorCheckInForVisit(ctx, visit)
+	}
+
 	// Broadcast SSE event (fire-and-forget, outside transaction)
-	s.broadcastVisitCreated(ctx, visit)
+	s.broadcastVisitCreated(ctx, visit, snapshot)
 
 	return nil
 }
@@ -547,7 +568,14 @@ func (s *service) EndVisit(ctx context.Context, id int64) error {
 		return &ActiveError{Op: "EndVisit", Err: ErrDatabaseOperation}
 	}
 
-	s.broadcastVisitCheckout(ctx, endedVisit)
+	// WP-B10: load (not mutate) attendance snapshot for SSE enrichment.
+	// Per spec: check-out does NOT change instance_students.status.
+	var snapshot *AttendanceSnapshot
+	if s.attendanceSyncer != nil {
+		snapshot = s.attendanceSyncer.LoadAttendanceForVisit(ctx, endedVisit)
+	}
+
+	s.broadcastVisitCheckout(ctx, endedVisit, snapshot)
 	return nil
 }
 
@@ -570,8 +598,11 @@ func (s *service) endVisitRecord(ctx context.Context, id int64) (*active.Visit, 
 	return visit, nil
 }
 
-// broadcastVisitCheckout broadcasts SSE event for visit checkout
-func (s *service) broadcastVisitCheckout(ctx context.Context, endedVisit *active.Visit) {
+// broadcastVisitCheckout broadcasts SSE event for visit checkout.
+// snapshot (WP-B10) may be nil — when present, it enriches the event
+// with attendance_status/substatus/note so the frontend can display
+// the current attendance state alongside the checkout line.
+func (s *service) broadcastVisitCheckout(ctx context.Context, endedVisit *active.Visit, snapshot *AttendanceSnapshot) {
 	if s.broadcaster == nil || endedVisit == nil {
 		return
 	}
@@ -580,13 +611,16 @@ func (s *service) broadcastVisitCheckout(ctx context.Context, endedVisit *active
 	studentID := fmt.Sprintf("%d", endedVisit.StudentID)
 	studentName, studentRec := s.getStudentDisplayData(ctx, endedVisit.StudentID)
 
+	data := realtime.EventData{
+		StudentID:   &studentID,
+		StudentName: &studentName,
+	}
+	applyAttendanceSnapshot(&data, snapshot)
+
 	event := realtime.NewEvent(
 		realtime.EventStudentCheckOut,
 		activeGroupID,
-		realtime.EventData{
-			StudentID:   &studentID,
-			StudentName: &studentName,
-		},
+		data,
 	)
 
 	s.broadcastWithLogging(ctx, activeGroupID, studentID, event, "student_checkout")
@@ -618,18 +652,41 @@ func (s *service) broadcastToEducationalGroup(ctx context.Context, student *user
 
 // broadcastStudentCheckoutEvents sends checkout SSE events for each visit.
 // This helper reduces cognitive complexity in session timeout processing.
+//
+// TODO(wp-b11-or-later): batch if hot. Each visit triggers two independent
+// schedule queries inside LoadAttendanceForVisit (FindByActiveGroupID,
+// FindByInstanceAndStudent). A session timeout flushing N students = 2N
+// queries. Not catastrophic at v1 scale, but if schools grow we should add
+// a batched FindByInstanceAndStudentIDs path. Not scoped into WP-B10.
 func (s *service) broadcastStudentCheckoutEvents(ctx context.Context, sessionIDStr string, visitsToNotify []visitSSEData) {
+	// Parse session ID once — all visits in this batch share the same
+	// active_group_id, which IS the session. We construct a minimal Visit
+	// per student for the snapshot lookup.
+	var sessionID int64
+	if parsed, perr := strconv.ParseInt(sessionIDStr, 10, 64); perr == nil {
+		sessionID = parsed
+	}
+
 	for _, visitData := range visitsToNotify {
 		studentIDStr := fmt.Sprintf("%d", visitData.StudentID)
 		studentName := visitData.Name
 
+		data := realtime.EventData{
+			StudentID:   &studentIDStr,
+			StudentName: &studentName,
+		}
+		if s.attendanceSyncer != nil && sessionID > 0 {
+			snapshot := s.attendanceSyncer.LoadAttendanceForVisit(ctx, &active.Visit{
+				StudentID:     visitData.StudentID,
+				ActiveGroupID: sessionID,
+			})
+			applyAttendanceSnapshot(&data, snapshot)
+		}
+
 		checkoutEvent := realtime.NewEvent(
 			realtime.EventStudentCheckOut,
 			sessionIDStr,
-			realtime.EventData{
-				StudentID:   &studentIDStr,
-				StudentName: &studentName,
-			},
+			data,
 		)
 
 		s.broadcastWithLogging(ctx, sessionIDStr, studentIDStr, checkoutEvent, "student_checkout")

--- a/backend/services/active/attendance_sse_enrichment_test.go
+++ b/backend/services/active/attendance_sse_enrichment_test.go
@@ -1,0 +1,260 @@
+// End-to-end SSE enrichment test for WP-B10.
+//
+// The repo and service layers each have their own hermetic coverage, but
+// nothing asserts the wiring glue: that CreateVisit actually threads the
+// AttendanceSyncer result into broadcastVisitCreated and that the
+// resulting student_checkin Event carries attendance_status/substatus/note.
+// Without this test, a reviewer could delete applyAttendanceSnapshot from
+// visit_helpers.go and every lower-level test would still pass — the SSE
+// enrichment would silently disappear in production.
+//
+// The test wires the real AttendanceSyncService into active.NewService
+// (same way services.NewFactory wires it) against a seeded instance +
+// instance_students row and asserts the broadcast shape.
+package active_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/auth/device"
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/realtime"
+	active "github.com/moto-nrw/project-phoenix/services/active"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingBroadcaster captures both BroadcastToGroup and BroadcastToAll
+// so the enrichment assertion can inspect the Event payload, not just the
+// event type. The existing mockBroadcaster in broadcast_test.go ignores
+// BroadcastToGroup, which is exactly where student_checkin goes.
+type recordingBroadcaster struct {
+	mu         sync.Mutex
+	groupCalls []realtime.Event
+	allCalls   []realtime.Event
+}
+
+func (r *recordingBroadcaster) BroadcastToGroup(_ int64, _ string, event realtime.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.groupCalls = append(r.groupCalls, event)
+	return nil
+}
+
+func (r *recordingBroadcaster) BroadcastToAll(event realtime.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.allCalls = append(r.allCalls, event)
+	return nil
+}
+
+// firstOfType returns the first event of the given type seen across either
+// broadcast channel, or nil if none matches.
+func (r *recordingBroadcaster) firstOfType(t realtime.EventType) *realtime.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := range r.groupCalls {
+		if r.groupCalls[i].Type == t {
+			e := r.groupCalls[i]
+			return &e
+		}
+	}
+	for i := range r.allCalls {
+		if r.allCalls[i].Type == t {
+			e := r.allCalls[i]
+			return &e
+		}
+	}
+	return nil
+}
+
+func TestCreateVisit_EnrichesCheckInEventWithAttendance(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	repos := repositories.NewFactory(db)
+	ctx := testpkg.TenantContext(1)
+	suffix := time.Now().UnixNano()
+
+	// Real attendance syncer, wired the same way services.NewFactory does.
+	syncer := scheduleSvc.NewAttendanceSyncService(
+		repos.ActivityInstance,
+		repos.InstanceStudent,
+		slog.Default(),
+	)
+	broadcaster := &recordingBroadcaster{}
+
+	svc := active.NewService(active.ServiceDependencies{
+		GroupRepo:          repos.ActiveGroup,
+		VisitRepo:          repos.ActiveVisit,
+		SupervisorRepo:     repos.GroupSupervisor,
+		CombinedGroupRepo:  repos.CombinedGroup,
+		GroupMappingRepo:   repos.GroupMapping,
+		AttendanceRepo:     repos.Attendance,
+		StudentRepo:        repos.Student,
+		PersonRepo:         repos.Person,
+		TeacherRepo:        repos.Teacher,
+		StaffRepo:          repos.Staff,
+		RoomRepo:           repos.Room,
+		ActivityGroupRepo:  repos.ActivityGroup,
+		ActivityCatRepo:    repos.ActivityCategory,
+		EducationGroupRepo: repos.Group,
+		DeviceRepo:         repos.Device,
+		DB:                 db,
+		Broadcaster:        broadcaster,
+		AttendanceSyncer:   syncer,
+		Logger:             slog.Default(),
+	})
+
+	// Fixtures: activity + room + active.group + student + staff + device.
+	// CreateVisit requires staff + device on ctx for attendance FK.
+	activity := testpkg.CreateTestActivityGroup(t, db, fmt.Sprintf("E2E-Act-%d", suffix))
+	room := testpkg.CreateTestRoom(t, db, fmt.Sprintf("E2E-Room-%d", suffix))
+	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	student := testpkg.CreateTestStudent(t, db, "E2E-Stu", fmt.Sprintf("A-%d", suffix), "3a")
+	staff := testpkg.CreateTestStaff(t, db, "E2E-Staff", fmt.Sprintf("S-%d", suffix))
+	iotDevice := testpkg.CreateTestDevice(t, db, fmt.Sprintf("e2e-%d", suffix))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, db,
+			activity.ID, room.ID, activeGroup.ID, student.ID, staff.ID, iotDevice.ID)
+	})
+
+	// Create an instance bridged to the active.group and an instance_students
+	// row in 'expected' — exactly what the syncer is designed to flip.
+	instance := &scheduleModels.ActivityInstance{
+		Date:            time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC),
+		ActivityGroupID: &activity.ID,
+		Title:           fmt.Sprintf("E2E-Inst-%d", suffix),
+		StartTime:       time.Date(1, 1, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:         time.Date(1, 1, 1, 15, 0, 0, 0, time.UTC),
+		RoomID:          room.ID,
+		Status:          scheduleModels.InstanceStatusActive,
+		ActiveGroupID:   &activeGroup.ID,
+	}
+	instance.SetTenantID(1)
+	_, err := db.NewInsert().Model(instance).ModelTableExpr(`schedule.activity_instances`).Exec(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", instance.ID) })
+
+	isRepo := scheduleRepo.NewInstanceStudentRepository(db)
+	row := &scheduleModels.InstanceStudent{
+		InstanceID: instance.ID,
+		StudentID:  student.ID,
+		Status:     scheduleModels.AttendanceStatusExpected,
+	}
+	row.SetTenantID(1)
+	require.NoError(t, isRepo.Create(ctx, row))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "schedule.instance_students", row.ID) })
+
+	// ACT: drive a check-in through the service.
+	staffCtx := context.WithValue(ctx, device.CtxStaff, staff)
+	deviceCtx := context.WithValue(staffCtx, device.CtxDevice, iotDevice)
+
+	visit := &activeModels.Visit{
+		StudentID:     student.ID,
+		ActiveGroupID: activeGroup.ID,
+		EntryTime:     time.Now(),
+	}
+	require.NoError(t, svc.CreateVisit(deviceCtx, visit))
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, db, visit.ID) })
+
+	// ASSERT: student_checkin event carries attendance_status=present.
+	// This is the load-bearing assertion — it's what protects against
+	// someone silently removing applyAttendanceSnapshot from visit_helpers.go.
+	ev := broadcaster.firstOfType(realtime.EventStudentCheckIn)
+	require.NotNil(t, ev, "expected student_checkin event to be broadcast")
+	require.NotNil(t, ev.Data.AttendanceStatus,
+		"attendance_status must be populated when the visit bridges to an instance_students row")
+	assert.Equal(t, scheduleModels.AttendanceStatusPresent, *ev.Data.AttendanceStatus)
+	// Substatus/note are null for a first-time flip — the column defaults
+	// are NULL and no PATCH has happened.
+	assert.Nil(t, ev.Data.AttendanceSubstatus)
+	assert.Nil(t, ev.Data.AttendanceNote)
+
+	// DB post-condition: the mirrored row flipped to 'present'.
+	updated, err := isRepo.FindByID(ctx, row.ID)
+	require.NoError(t, err)
+	assert.Equal(t, scheduleModels.AttendanceStatusPresent, updated.Status)
+	require.NotNil(t, updated.CheckedInAt, "checked_in_at must be stamped by the mirror write")
+}
+
+// TestCreateVisit_WalkInLeavesAttendanceFieldsUnset is the negative case
+// for the same wiring: when the visit does NOT bridge to an instance
+// (walk-in, non-planned active group), the syncer returns nil and the SSE
+// event MUST omit the three attendance fields. This rules out a regression
+// where we accidentally stamp status="present" for every check-in.
+func TestCreateVisit_WalkInLeavesAttendanceFieldsUnset(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	repos := repositories.NewFactory(db)
+	suffix := time.Now().UnixNano()
+	syncer := scheduleSvc.NewAttendanceSyncService(
+		repos.ActivityInstance,
+		repos.InstanceStudent,
+		slog.Default(),
+	)
+	broadcaster := &recordingBroadcaster{}
+
+	svc := active.NewService(active.ServiceDependencies{
+		GroupRepo:          repos.ActiveGroup,
+		VisitRepo:          repos.ActiveVisit,
+		SupervisorRepo:     repos.GroupSupervisor,
+		CombinedGroupRepo:  repos.CombinedGroup,
+		GroupMappingRepo:   repos.GroupMapping,
+		AttendanceRepo:     repos.Attendance,
+		StudentRepo:        repos.Student,
+		PersonRepo:         repos.Person,
+		TeacherRepo:        repos.Teacher,
+		StaffRepo:          repos.Staff,
+		RoomRepo:           repos.Room,
+		ActivityGroupRepo:  repos.ActivityGroup,
+		ActivityCatRepo:    repos.ActivityCategory,
+		EducationGroupRepo: repos.Group,
+		DeviceRepo:         repos.Device,
+		DB:                 db,
+		Broadcaster:        broadcaster,
+		AttendanceSyncer:   syncer,
+		Logger:             slog.Default(),
+	})
+
+	// NO instance bridges to this active.group — it's a walk-in session.
+	activity := testpkg.CreateTestActivityGroup(t, db, fmt.Sprintf("E2E-Walk-%d", suffix))
+	room := testpkg.CreateTestRoom(t, db, fmt.Sprintf("E2E-Walk-Room-%d", suffix))
+	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	student := testpkg.CreateTestStudent(t, db, "E2E-Walk", fmt.Sprintf("W-%d", suffix), "3a")
+	staff := testpkg.CreateTestStaff(t, db, "E2E-Walk-Staff", fmt.Sprintf("W-%d", suffix))
+	iotDevice := testpkg.CreateTestDevice(t, db, fmt.Sprintf("e2e-walk-%d", suffix))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, db,
+			activity.ID, room.ID, activeGroup.ID, student.ID, staff.ID, iotDevice.ID)
+	})
+
+	ctx := testpkg.TenantContext(1)
+	staffCtx := context.WithValue(ctx, device.CtxStaff, staff)
+	deviceCtx := context.WithValue(staffCtx, device.CtxDevice, iotDevice)
+
+	visit := &activeModels.Visit{
+		StudentID:     student.ID,
+		ActiveGroupID: activeGroup.ID,
+		EntryTime:     time.Now(),
+	}
+	require.NoError(t, svc.CreateVisit(deviceCtx, visit))
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, db, visit.ID) })
+
+	ev := broadcaster.firstOfType(realtime.EventStudentCheckIn)
+	require.NotNil(t, ev, "expected student_checkin event to be broadcast")
+	assert.Nil(t, ev.Data.AttendanceStatus, "walk-in must not stamp attendance_status")
+	assert.Nil(t, ev.Data.AttendanceSubstatus)
+	assert.Nil(t, ev.Data.AttendanceNote)
+}

--- a/backend/services/active/attendance_syncer.go
+++ b/backend/services/active/attendance_syncer.go
@@ -1,0 +1,68 @@
+package active
+
+import (
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/realtime"
+)
+
+// AttendanceSnapshot is the minimal view of a schedule.instance_students row
+// that the active service needs to enrich SSE events. The pointer shape
+// matches realtime.EventData so broadcast helpers can copy fields directly.
+//
+// Declared in the active package (and not, say, services/schedule) so there
+// is no cyclic-import risk — the schedule package already depends on active
+// for its bridge semantics, but active must not import schedule.
+type AttendanceSnapshot struct {
+	Status    string
+	Substatus *string
+	Note      *string
+}
+
+// AttendanceSyncer is the optional dependency active.service calls on visit
+// write / visit end to (a) mirror status changes into schedule.instance_students
+// and (b) resolve the current attendance row so SSE events carry the three
+// WP-B10 fields.
+//
+// Every method in this interface is graceful-degradation-by-design: the
+// implementation MUST swallow every error internally and return nil on any
+// failure (no matching instance, no enrolled student, DB error, panic).
+// That way active.service can call these methods unconditionally and never
+// block a visit write on attendance-sync failure. The return is "did we
+// find an attendance row" — not "did an error occur".
+//
+// Implementations live in services/schedule. A nil AttendanceSyncer is
+// valid at construction time (tests, early-boot servers without the full
+// factory wire-up) — callers must handle nil.
+type AttendanceSyncer interface {
+	// MirrorCheckInForVisit is called AFTER visitRepo.Create succeeds. It
+	// looks up the instance bridged to visit.ActiveGroupID, then the
+	// instance_students row for visit.StudentID. If both exist and the row
+	// is still status='expected', it flips the row to 'present' and stamps
+	// checked_in_at from visit.EntryTime.
+	//
+	// Returns a snapshot of the resulting row (or the pre-existing row, in
+	// the already-present case, so SSE still reflects state). Returns nil
+	// for walk-ins, pre-start races, tenant mismatches, or any error.
+	MirrorCheckInForVisit(ctx context.Context, visit *active.Visit) *AttendanceSnapshot
+
+	// LoadAttendanceForVisit is called at visit end. It never mutates —
+	// it only returns the current attendance snapshot so the checkout SSE
+	// event can carry status/substatus/note for frontend display.
+	LoadAttendanceForVisit(ctx context.Context, visit *active.Visit) *AttendanceSnapshot
+}
+
+// applyAttendanceSnapshot copies the three WP-B10 fields from snapshot into
+// the EventData. Nil snapshot is a no-op — the realtime event goes out
+// with attendance_* omitted (omitempty). Status is always set when snapshot
+// is non-nil (it's a required column); Substatus and Note may be nil.
+func applyAttendanceSnapshot(data *realtime.EventData, snapshot *AttendanceSnapshot) {
+	if data == nil || snapshot == nil {
+		return
+	}
+	status := snapshot.Status
+	data.AttendanceStatus = &status
+	data.AttendanceSubstatus = snapshot.Substatus
+	data.AttendanceNote = snapshot.Note
+}

--- a/backend/services/active/visit_helpers.go
+++ b/backend/services/active/visit_helpers.go
@@ -153,8 +153,11 @@ func (s *service) autoClearStudentSickness(ctx context.Context, studentID int64)
 	)
 }
 
-// broadcastVisitCreated sends SSE event for visit creation
-func (s *service) broadcastVisitCreated(ctx context.Context, visit *active.Visit) {
+// broadcastVisitCreated sends SSE event for visit creation.
+// snapshot (WP-B10) may be nil — when present, it enriches the event with
+// attendance_status/substatus/note so subscribers see the flipped attendance
+// state alongside the check-in line.
+func (s *service) broadcastVisitCreated(ctx context.Context, visit *active.Visit, snapshot *AttendanceSnapshot) {
 	if s.broadcaster == nil {
 		return
 	}
@@ -164,13 +167,16 @@ func (s *service) broadcastVisitCreated(ctx context.Context, visit *active.Visit
 
 	studentName, studentRec := s.getStudentDisplayData(ctx, visit.StudentID)
 
+	data := realtime.EventData{
+		StudentID:   &studentID,
+		StudentName: &studentName,
+	}
+	applyAttendanceSnapshot(&data, snapshot)
+
 	event := realtime.NewEvent(
 		realtime.EventStudentCheckIn,
 		activeGroupID,
-		realtime.EventData{
-			StudentID:   &studentID,
-			StudentName: &studentName,
-		},
+		data,
 	)
 
 	if err := s.broadcaster.BroadcastToGroup(tenant.FromContext(ctx), activeGroupID, event); err != nil {

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -195,6 +195,16 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	// Initialize staff absence service
 	staffAbsenceService := active.NewStaffAbsenceService(repos.StaffAbsence, repos.WorkSession)
 
+	// Initialize attendance sync service (WP-B10). Implements
+	// active.AttendanceSyncer — called from CreateVisit / EndVisit to mirror
+	// into schedule.instance_students and enrich SSE events. No circular
+	// dependency because it only depends on repos, not on active.Service.
+	attendanceSyncService := schedule.NewAttendanceSyncService(
+		repos.ActivityInstance,
+		repos.InstanceStudent,
+		logger.With("service", "attendance-sync"),
+	)
+
 	// Initialize active service with SSE broadcaster
 	activeService := active.NewService(active.ServiceDependencies{
 		GroupRepo:          repos.ActiveGroup,
@@ -216,8 +226,9 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		EducationService:   educationService,
 		UsersService:       usersService,
 		DB:                 db,
-		Broadcaster:        realtimeHub,        // Pass SSE broadcaster
-		WorkSessionService: workSessionService, // NFC auto-check-in
+		Broadcaster:        realtimeHub,           // Pass SSE broadcaster
+		WorkSessionService: workSessionService,    // NFC auto-check-in
+		AttendanceSyncer:   attendanceSyncService, // WP-B10 mirror + SSE enrichment
 		Logger:             activeLogger,
 	})
 

--- a/backend/services/schedule/arrival_service_test.go
+++ b/backend/services/schedule/arrival_service_test.go
@@ -1250,10 +1250,20 @@ func TestArrivalScheduleService_BulkUpsertBySchoolClass(t *testing.T) {
 		assert.Equal(t, 0, result.StudentsAffected)
 	})
 
+	// Class names must be unique per run. BulkUpsertBySchoolClass finds
+	// students by school_class string match, and the cleanup path for
+	// users.students is a known no-op (see backend/test/fixtures.go —
+	// cleanupDelete errors silently on `.Model((*interface{})(nil))`),
+	// so stale students with reused class names accumulate across local
+	// re-runs and inflate StudentsAffected. CI isn't affected because it
+	// starts each run from a fresh test DB. Hermetic tests should not
+	// reuse the same school_class literal on a long-lived test DB.
 	t.Run("upserts schedules for class with students", func(t *testing.T) {
+		className := fmt.Sprintf("BC1-%d", time.Now().UnixNano())
+
 		// Create students in the same class
-		student1 := testpkg.CreateTestStudent(t, db, "BulkArr", "Student1", "BC1")
-		student2 := testpkg.CreateTestStudent(t, db, "BulkArr", "Student2", "BC1")
+		student1 := testpkg.CreateTestStudent(t, db, "BulkArr", "Student1", className)
+		student2 := testpkg.CreateTestStudent(t, db, "BulkArr", "Student2", className)
 		defer testpkg.CleanupActivityFixtures(t, db, student1.ID, student2.ID)
 
 		schedules := []schedule.ArrivalScheduleInput{
@@ -1261,7 +1271,7 @@ func TestArrivalScheduleService_BulkUpsertBySchoolClass(t *testing.T) {
 			{Weekday: 3, ArrivalTime: "08:15"},
 		}
 
-		result, err := service.BulkUpsertBySchoolClass(ctx, "BC1", schedules, 1)
+		result, err := service.BulkUpsertBySchoolClass(ctx, className, schedules, 1)
 
 		require.NoError(t, err)
 		assert.Equal(t, 2, result.StudentsAffected)
@@ -1275,7 +1285,8 @@ func TestArrivalScheduleService_BulkUpsertBySchoolClass(t *testing.T) {
 	})
 
 	t.Run("returns overwrite warnings when schedules differ", func(t *testing.T) {
-		student := testpkg.CreateTestStudent(t, db, "BulkOverwrite", "Student", "BOW1")
+		className := fmt.Sprintf("BOW1-%d", time.Now().UnixNano())
+		student := testpkg.CreateTestStudent(t, db, "BulkOverwrite", "Student", className)
 		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
 
 		// Create existing schedule with a different time
@@ -1292,7 +1303,7 @@ func TestArrivalScheduleService_BulkUpsertBySchoolClass(t *testing.T) {
 			{Weekday: 1, ArrivalTime: "08:00"}, // Different time
 		}
 
-		result, err := service.BulkUpsertBySchoolClass(ctx, "BOW1", schedules, 1)
+		result, err := service.BulkUpsertBySchoolClass(ctx, className, schedules, 1)
 
 		require.NoError(t, err)
 		assert.Equal(t, 1, result.StudentsAffected)
@@ -1300,14 +1311,15 @@ func TestArrivalScheduleService_BulkUpsertBySchoolClass(t *testing.T) {
 	})
 
 	t.Run("returns error for invalid arrival time format", func(t *testing.T) {
-		student := testpkg.CreateTestStudent(t, db, "BulkBadTime", "Student", "BBT1")
+		className := fmt.Sprintf("BBT1-%d", time.Now().UnixNano())
+		student := testpkg.CreateTestStudent(t, db, "BulkBadTime", "Student", className)
 		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
 
 		schedules := []schedule.ArrivalScheduleInput{
 			{Weekday: 1, ArrivalTime: "invalid"},
 		}
 
-		result, err := service.BulkUpsertBySchoolClass(ctx, "BBT1", schedules, 1)
+		result, err := service.BulkUpsertBySchoolClass(ctx, className, schedules, 1)
 
 		require.Error(t, err)
 		assert.Nil(t, result)

--- a/backend/services/schedule/attendance_sync_service.go
+++ b/backend/services/schedule/attendance_sync_service.go
@@ -26,6 +26,7 @@ package schedule
 import (
 	"context"
 	"log/slog"
+	"runtime/debug"
 
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
@@ -83,10 +84,13 @@ func (s *AttendanceSyncService) MirrorCheckInForVisit(
 	ctx context.Context, visit *activeModel.Visit,
 ) (snapshot *activeSvc.AttendanceSnapshot) {
 	// Panic belt-and-braces — we promise no error and no panic to the caller.
+	// The stack is captured at Error level so an after-the-fact root cause
+	// is recoverable from Grafana without having to reproduce the panic.
 	defer func() {
 		if r := recover(); r != nil {
 			s.getLogger().Error("attendance mirror panic",
 				slog.Any("panic", r),
+				slog.String("stack", string(debug.Stack())),
 			)
 			snapshot = nil
 		}
@@ -201,6 +205,7 @@ func (s *AttendanceSyncService) LoadAttendanceForVisit(
 		if r := recover(); r != nil {
 			s.getLogger().Error("attendance load panic",
 				slog.Any("panic", r),
+				slog.String("stack", string(debug.Stack())),
 			)
 			snapshot = nil
 		}

--- a/backend/services/schedule/attendance_sync_service.go
+++ b/backend/services/schedule/attendance_sync_service.go
@@ -1,0 +1,253 @@
+// Package schedule — attendance sync service (WP-B10).
+//
+// Implements active.AttendanceSyncer. Called from active.service.CreateVisit /
+// EndVisit to:
+//
+//  1. Mirror check-in writes into schedule.instance_students (status flips
+//     'expected' → 'present', checked_in_at stamped).
+//  2. Resolve the current attendance row so the broadcast helper can
+//     populate EventData.Attendance* fields on the student_checkin /
+//     student_checkout SSE events.
+//
+// Contract: every method is graceful-degradation-by-design. Errors are
+// swallowed and nil is returned. The caller (active.service) proceeds as
+// if no instance was attached to the visit — which is always a valid
+// outcome (walk-ins, schulhof/WC sessions, pre-start race windows).
+//
+// Shared-tenant-tx caveat: these methods run inside the IoT handler's
+// TenantTxMiddleware transaction. If the UPDATE in MirrorCheckInForVisit
+// fails with a Postgres-level error (not just sql.ErrNoRows), the tx is
+// tainted and a subsequent commit failure will roll back the visit. That
+// is unavoidable under the shared tx and is the one failure mode this
+// service cannot gracefully degrade. Branch 7 below logs at Error level
+// so the existing "backend error rate" alert surfaces it in ops.
+package schedule
+
+import (
+	"context"
+	"log/slog"
+
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+// AttendanceSyncService implements activeSvc.AttendanceSyncer.
+type AttendanceSyncService struct {
+	instanceRepo        scheduleModel.ActivityInstanceRepository
+	instanceStudentRepo scheduleModel.InstanceStudentRepository
+	logger              *slog.Logger
+}
+
+// NewAttendanceSyncService constructs the service. Both repos are required;
+// the logger is optional (falls back to slog.Default()).
+func NewAttendanceSyncService(
+	instanceRepo scheduleModel.ActivityInstanceRepository,
+	instanceStudentRepo scheduleModel.InstanceStudentRepository,
+	logger *slog.Logger,
+) *AttendanceSyncService {
+	return &AttendanceSyncService{
+		instanceRepo:        instanceRepo,
+		instanceStudentRepo: instanceStudentRepo,
+		logger:              logger,
+	}
+}
+
+// Verify at compile-time that the concrete type satisfies the interface
+// declared in the active package.
+var _ activeSvc.AttendanceSyncer = (*AttendanceSyncService)(nil)
+
+func (s *AttendanceSyncService) getLogger() *slog.Logger {
+	if s.logger != nil {
+		return s.logger
+	}
+	return slog.Default()
+}
+
+// MirrorCheckInForVisit implements activeSvc.AttendanceSyncer.
+//
+// Branches (all logged with student_id / instance_id only — no names at
+// Info level per GDPR):
+//
+//	B1 nil or zero ActiveGroupID     → Debug, return nil
+//	B2 instance lookup error         → Warn, return nil
+//	B3 no instance bridged           → Debug, return nil (walk-in)
+//	B4 instance_student lookup error → Warn, return nil
+//	B5 no instance_student row       → Debug, return nil (walk-in)
+//	B6 row already non-expected      → Debug, return current snapshot
+//	B7 UPDATE error                  → Error (tx likely tainted), return nil
+//	B8 UPDATE rowsAffected=0 (race)  → Debug, return snapshot of row we read
+//	B9 happy path                    → Info, return new snapshot
+func (s *AttendanceSyncService) MirrorCheckInForVisit(
+	ctx context.Context, visit *activeModel.Visit,
+) (snapshot *activeSvc.AttendanceSnapshot) {
+	// Panic belt-and-braces — we promise no error and no panic to the caller.
+	defer func() {
+		if r := recover(); r != nil {
+			s.getLogger().Error("attendance mirror panic",
+				slog.Any("panic", r),
+			)
+			snapshot = nil
+		}
+	}()
+
+	if visit == nil || visit.ActiveGroupID <= 0 {
+		s.getLogger().Debug("attendance mirror: visit has no active_group_id, skipping")
+		return nil
+	}
+
+	instance, err := s.instanceRepo.FindByActiveGroupID(ctx, visit.ActiveGroupID)
+	if err != nil {
+		s.getLogger().Warn("attendance mirror: find instance by active_group_id failed",
+			slog.Int64("active_group_id", visit.ActiveGroupID),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	if instance == nil {
+		s.getLogger().Debug("attendance mirror: no instance bridged to active_group, walk-in",
+			slog.Int64("active_group_id", visit.ActiveGroupID),
+		)
+		return nil
+	}
+
+	row, err := s.instanceStudentRepo.FindByInstanceAndStudent(ctx, instance.ID, visit.StudentID)
+	if err != nil {
+		s.getLogger().Warn("attendance mirror: find instance_student failed",
+			slog.Int64("instance_id", instance.ID),
+			slog.Int64("student_id", visit.StudentID),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	if row == nil {
+		s.getLogger().Debug("attendance mirror: student not expected at instance, walk-in",
+			slog.Int64("instance_id", instance.ID),
+			slog.Int64("student_id", visit.StudentID),
+		)
+		return nil
+	}
+
+	// B6: row is no longer 'expected' — respect existing state. This covers:
+	//   * double-tap within a short window (already present)
+	//   * admin marked absent before check-in via PATCH
+	//   * status=present from a prior visit today
+	// Return the snapshot we already read so SSE reflects the true state.
+	if row.Status != scheduleModel.AttendanceStatusExpected {
+		s.getLogger().Debug("attendance mirror: row already past expected, not clobbering",
+			slog.Int64("instance_id", instance.ID),
+			slog.Int64("student_id", visit.StudentID),
+			slog.String("current_status", row.Status),
+		)
+		return snapshotFromRow(row)
+	}
+
+	updated, err := s.instanceStudentRepo.UpdateAttendanceFromCheckin(
+		ctx, instance.ID, visit.StudentID, visit.EntryTime,
+	)
+	if err != nil {
+		// B7: This is the loud one. If the UPDATE fails with a Postgres-level
+		// error (FK violation, aborted-tx, constraint), the tenant tx is now
+		// tainted — the TenantTxMiddleware will 5xx on commit, rolling back
+		// the visit write too. Error level (not Warn) so the Grafana
+		// "backend error rate" alert picks it up and we find out in ops
+		// rather than via a customer-reported ghost-visit incident.
+		tenantID := tenant.FromContext(ctx)
+		s.getLogger().Error("attendance mirror UPDATE failed — tenant tx likely tainted, visit write at risk",
+			slog.Int64("tenant_id", tenantID),
+			slog.Int64("instance_id", instance.ID),
+			slog.Int64("student_id", visit.StudentID),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+
+	if !updated {
+		// B8: Row existed with status='expected' at the read in B6 but the
+		// UPDATE's WHERE failed to match. Concurrent write (another tab,
+		// admin PATCH) moved it out of expected between the read and write.
+		// We still return the snapshot we read so SSE fires with *something*;
+		// the persisted state may differ, but that's acceptable for a
+		// fire-and-forget notification.
+		s.getLogger().Debug("attendance mirror: race — row moved out of expected between read and UPDATE",
+			slog.Int64("instance_id", instance.ID),
+			slog.Int64("student_id", visit.StudentID),
+		)
+		return snapshotFromRow(row)
+	}
+
+	// B9: happy path. Row flipped to present. Build the snapshot from the
+	// new state (status=present) and the unchanged substatus/note fields.
+	// IDs-only at Info level per GDPR.
+	s.getLogger().Info("attendance mirror synced on check-in",
+		slog.Int64("instance_id", instance.ID),
+		slog.Int64("student_id", visit.StudentID),
+	)
+	return &activeSvc.AttendanceSnapshot{
+		Status:    scheduleModel.AttendanceStatusPresent,
+		Substatus: row.Substatus,
+		Note:      row.Note,
+	}
+}
+
+// LoadAttendanceForVisit implements activeSvc.AttendanceSyncer. Read-only
+// companion to MirrorCheckInForVisit — used on the checkout SSE path.
+// Same graceful-degradation branches 1–5, no write.
+func (s *AttendanceSyncService) LoadAttendanceForVisit(
+	ctx context.Context, visit *activeModel.Visit,
+) (snapshot *activeSvc.AttendanceSnapshot) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.getLogger().Error("attendance load panic",
+				slog.Any("panic", r),
+			)
+			snapshot = nil
+		}
+	}()
+
+	if visit == nil || visit.ActiveGroupID <= 0 {
+		return nil
+	}
+
+	instance, err := s.instanceRepo.FindByActiveGroupID(ctx, visit.ActiveGroupID)
+	if err != nil {
+		s.getLogger().Warn("attendance load: find instance by active_group_id failed",
+			slog.Int64("active_group_id", visit.ActiveGroupID),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	if instance == nil {
+		return nil
+	}
+
+	row, err := s.instanceStudentRepo.FindByInstanceAndStudent(ctx, instance.ID, visit.StudentID)
+	if err != nil {
+		s.getLogger().Warn("attendance load: find instance_student failed",
+			slog.Int64("instance_id", instance.ID),
+			slog.Int64("student_id", visit.StudentID),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	if row == nil {
+		return nil
+	}
+
+	return snapshotFromRow(row)
+}
+
+// snapshotFromRow is the common projection. Substatus and Note already
+// pointer-typed in the model, so we reuse the same pointers — no need to
+// dereference + re-address.
+func snapshotFromRow(row *scheduleModel.InstanceStudent) *activeSvc.AttendanceSnapshot {
+	if row == nil {
+		return nil
+	}
+	return &activeSvc.AttendanceSnapshot{
+		Status:    row.Status,
+		Substatus: row.Substatus,
+		Note:      row.Note,
+	}
+}

--- a/backend/services/schedule/attendance_sync_service_integration_test.go
+++ b/backend/services/schedule/attendance_sync_service_integration_test.go
@@ -1,0 +1,310 @@
+// Hermetic integration tests for the WP-B10 attendance sync service.
+//
+// Covers every branch of the graceful-degradation tree declared in
+// attendance_sync_service.go:
+//
+//	B1 visit.ActiveGroupID <= 0    → nil
+//	B2 instance lookup error       → not hermetically reachable (covered by repo tests)
+//	B3 no instance bridged         → nil (walk-in)
+//	B4 instance_student lookup err → not hermetically reachable (covered by repo tests)
+//	B5 no instance_student row     → nil (walk-in)
+//	B6 row already non-expected    → snapshot of current state, no write
+//	B7 UPDATE error                → not hermetically reachable (covered by repo tests)
+//	B8 rowsAffected=0 race         → snapshot, no persisted change
+//	B9 happy path                  → snapshot with status=present, row flipped
+//
+// Check-out is covered via LoadAttendanceForVisit — no mutation regardless
+// of current state.
+package schedule_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	activeRepo "github.com/moto-nrw/project-phoenix/database/repositories/active"
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// attendanceSyncSetup bundles the syncer and the repos used to seed test
+// state. All cleanup registered via t.Cleanup in LIFO order.
+type attendanceSyncSetup struct {
+	syncer      *scheduleSvc.AttendanceSyncService
+	instRepo    scheduleModels.ActivityInstanceRepository
+	isRepo      scheduleModels.InstanceStudentRepository
+	groupRepo   activeModels.GroupRepository
+	db          *bun.DB
+	ctx         context.Context
+	roomID      int64
+	activityID  int64
+	activeGroup *activeModels.Group
+	instance    *scheduleModels.ActivityInstance
+}
+
+func buildAttendanceSyncSetup(t *testing.T) *attendanceSyncSetup {
+	t.Helper()
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := testpkg.TenantContext(1)
+	suffix := time.Now().UnixNano()
+
+	room := testpkg.CreateTestRoom(t, db, fmt.Sprintf("AS-Room-%d", suffix))
+	activity := testpkg.CreateTestActivityGroup(t, db, fmt.Sprintf("AS-Activity-%d", suffix))
+
+	// Bridge active.group — a running session linked to the instance.
+	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+
+	// Create the instance and manually bridge to the active.group (simulating
+	// the post-Start state — we don't exercise the lifecycle service here).
+	instance := &scheduleModels.ActivityInstance{
+		Date:            time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC),
+		ActivityGroupID: &activity.ID,
+		Title:           fmt.Sprintf("AS-Instance-%d", suffix),
+		StartTime:       time.Date(1, 1, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:         time.Date(1, 1, 1, 15, 0, 0, 0, time.UTC),
+		RoomID:          room.ID,
+		Status:          scheduleModels.InstanceStatusActive,
+		ActiveGroupID:   &activeGroup.ID,
+	}
+	instance.SetTenantID(1)
+	_, err := db.NewInsert().Model(instance).ModelTableExpr(`schedule.activity_instances`).Exec(ctx)
+	require.NoError(t, err)
+
+	// Cleanup order: instance rows first, then activity + room + active.group
+	// (the active.group must be dropped only after the instance's FK clears).
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", instance.ID)
+		// active.group cleanup happens via CleanupActivityFixtures below
+	})
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, db, 0, 0, 0, activity.ID, room.ID)
+		testpkg.CleanupTableRecords(t, db, "active.groups", activeGroup.ID)
+	})
+
+	return &attendanceSyncSetup{
+		syncer: scheduleSvc.NewAttendanceSyncService(
+			scheduleRepo.NewActivityInstanceRepository(db),
+			scheduleRepo.NewInstanceStudentRepository(db),
+			slog.Default(),
+		),
+		instRepo:    scheduleRepo.NewActivityInstanceRepository(db),
+		isRepo:      scheduleRepo.NewInstanceStudentRepository(db),
+		groupRepo:   activeRepo.NewGroupRepository(db),
+		db:          db,
+		ctx:         ctx,
+		roomID:      room.ID,
+		activityID:  activity.ID,
+		activeGroup: activeGroup,
+		instance:    instance,
+	}
+}
+
+// seedInstanceStudent inserts an instance_students row for s.instance + studentID
+// with the given status. Registers cleanup automatically.
+func seedInstanceStudent(t *testing.T, s *attendanceSyncSetup, studentID int64, status string) *scheduleModels.InstanceStudent {
+	t.Helper()
+	row := &scheduleModels.InstanceStudent{
+		InstanceID: s.instance.ID,
+		StudentID:  studentID,
+		Status:     status,
+	}
+	row.SetTenantID(1)
+	require.NoError(t, s.isRepo.Create(s.ctx, row))
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", row.ID)
+	})
+	return row
+}
+
+// --- MirrorCheckInForVisit ---------------------------------------------------
+
+func TestAttendanceSync_MirrorCheckIn_HappyPath(t *testing.T) {
+	s := buildAttendanceSyncSetup(t)
+	student := testpkg.CreateTestStudent(t, s.db, "AS-Happy", fmt.Sprintf("A-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+
+	row := seedInstanceStudent(t, s, student.ID, scheduleModels.AttendanceStatusExpected)
+
+	entryTime := time.Date(2026, 4, 21, 13, 5, 0, 0, time.UTC)
+	visit := &activeModels.Visit{
+		StudentID:     student.ID,
+		ActiveGroupID: s.activeGroup.ID,
+		EntryTime:     entryTime,
+	}
+
+	snap := s.syncer.MirrorCheckInForVisit(s.ctx, visit)
+	require.NotNil(t, snap)
+	assert.Equal(t, scheduleModels.AttendanceStatusPresent, snap.Status)
+	assert.Nil(t, snap.Substatus)
+	assert.Nil(t, snap.Note)
+
+	// DB state: row flipped to present + checked_in_at stamped.
+	got, err := s.isRepo.FindByID(s.ctx, row.ID)
+	require.NoError(t, err)
+	assert.Equal(t, scheduleModels.AttendanceStatusPresent, got.Status)
+	require.NotNil(t, got.CheckedInAt)
+	assert.WithinDuration(t, entryTime, *got.CheckedInAt, time.Second)
+}
+
+func TestAttendanceSync_MirrorCheckIn_WalkIn_NoInstance(t *testing.T) {
+	s := buildAttendanceSyncSetup(t)
+	student := testpkg.CreateTestStudent(t, s.db, "AS-Walk", fmt.Sprintf("W-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+
+	// NEW active.group that is NOT bridged to any instance.
+	orphanGroup := testpkg.CreateTestActiveGroup(t, s.db, s.activityID, s.roomID)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.groups", orphanGroup.ID) })
+
+	snap := s.syncer.MirrorCheckInForVisit(s.ctx, &activeModels.Visit{
+		StudentID:     student.ID,
+		ActiveGroupID: orphanGroup.ID,
+		EntryTime:     time.Now(),
+	})
+	assert.Nil(t, snap, "no instance bridged — walk-in, no snapshot")
+}
+
+func TestAttendanceSync_MirrorCheckIn_WalkIn_NotEnrolled(t *testing.T) {
+	s := buildAttendanceSyncSetup(t)
+	// No instance_students row seeded for this student.
+	student := testpkg.CreateTestStudent(t, s.db, "AS-Unsubbed", fmt.Sprintf("U-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+
+	snap := s.syncer.MirrorCheckInForVisit(s.ctx, &activeModels.Visit{
+		StudentID:     student.ID,
+		ActiveGroupID: s.activeGroup.ID,
+		EntryTime:     time.Now(),
+	})
+	assert.Nil(t, snap, "instance exists but student not expected — walk-in, no snapshot")
+}
+
+func TestAttendanceSync_MirrorCheckIn_AlreadyPresent_NoClobber(t *testing.T) {
+	s := buildAttendanceSyncSetup(t)
+	student := testpkg.CreateTestStudent(t, s.db, "AS-Dbl", fmt.Sprintf("D-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+
+	firstCheckin := time.Date(2026, 4, 21, 13, 0, 0, 0, time.UTC)
+
+	// Seed row as already-present with a stamped checked_in_at and a substatus
+	// — exactly what a post-hoc staff edit would leave.
+	excused := scheduleModels.AttendanceSubstatusExcused
+	row := &scheduleModels.InstanceStudent{
+		InstanceID:  s.instance.ID,
+		StudentID:   student.ID,
+		Status:      scheduleModels.AttendanceStatusPresent,
+		Substatus:   &excused,
+		CheckedInAt: &firstCheckin,
+	}
+	row.SetTenantID(1)
+	require.NoError(t, s.isRepo.Create(s.ctx, row))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", row.ID) })
+
+	// Second check-in — later time. Mirror MUST NOT overwrite checked_in_at
+	// or the substatus.
+	snap := s.syncer.MirrorCheckInForVisit(s.ctx, &activeModels.Visit{
+		StudentID:     student.ID,
+		ActiveGroupID: s.activeGroup.ID,
+		EntryTime:     time.Date(2026, 4, 21, 14, 30, 0, 0, time.UTC),
+	})
+	require.NotNil(t, snap, "snapshot should still reflect current state for SSE")
+	assert.Equal(t, scheduleModels.AttendanceStatusPresent, snap.Status)
+	require.NotNil(t, snap.Substatus)
+	assert.Equal(t, scheduleModels.AttendanceSubstatusExcused, *snap.Substatus)
+
+	// DB: original first-checkin timestamp must survive.
+	got, err := s.isRepo.FindByID(s.ctx, row.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.CheckedInAt)
+	assert.WithinDuration(t, firstCheckin, *got.CheckedInAt, time.Second)
+}
+
+func TestAttendanceSync_MirrorCheckIn_NilVisitOrZeroActiveGroup(t *testing.T) {
+	s := buildAttendanceSyncSetup(t)
+	// StudentID is never read in B1 (the ActiveGroupID<=0 check short-circuits
+	// above it), but we still use a real fixture to stay hermetic.
+	student := testpkg.CreateTestStudent(t, s.db, "AS-B1", fmt.Sprintf("B1-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+
+	// Nil visit — B1
+	assert.Nil(t, s.syncer.MirrorCheckInForVisit(s.ctx, nil))
+
+	// Zero ActiveGroupID — B1
+	assert.Nil(t, s.syncer.MirrorCheckInForVisit(s.ctx, &activeModels.Visit{
+		StudentID:     student.ID,
+		ActiveGroupID: 0,
+	}))
+}
+
+func TestAttendanceSync_MirrorCheckIn_TenantIsolation(t *testing.T) {
+	s := buildAttendanceSyncSetup(t)
+	student := testpkg.CreateTestStudent(t, s.db, "AS-Ten", fmt.Sprintf("T-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+	seedInstanceStudent(t, s, student.ID, scheduleModels.AttendanceStatusExpected)
+
+	// Call with tenant 2 context — RLS should hide everything.
+	ctxT2 := testpkg.TenantContext(2)
+	snap := s.syncer.MirrorCheckInForVisit(ctxT2, &activeModels.Visit{
+		StudentID:     student.ID,
+		ActiveGroupID: s.activeGroup.ID,
+		EntryTime:     time.Now(),
+	})
+	assert.Nil(t, snap, "wrong tenant — instance invisible under RLS")
+}
+
+// --- LoadAttendanceForVisit --------------------------------------------------
+
+func TestAttendanceSync_LoadAttendance_ReturnsSnapshot(t *testing.T) {
+	s := buildAttendanceSyncSetup(t)
+	student := testpkg.CreateTestStudent(t, s.db, "AS-Load", fmt.Sprintf("L-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+
+	note := "bus verspätet"
+	late := scheduleModels.AttendanceSubstatusLate
+	row := &scheduleModels.InstanceStudent{
+		InstanceID: s.instance.ID,
+		StudentID:  student.ID,
+		Status:     scheduleModels.AttendanceStatusPresent,
+		Substatus:  &late,
+		Note:       &note,
+	}
+	row.SetTenantID(1)
+	require.NoError(t, s.isRepo.Create(s.ctx, row))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", row.ID) })
+
+	snap := s.syncer.LoadAttendanceForVisit(s.ctx, &activeModels.Visit{
+		StudentID:     student.ID,
+		ActiveGroupID: s.activeGroup.ID,
+	})
+	require.NotNil(t, snap)
+	assert.Equal(t, scheduleModels.AttendanceStatusPresent, snap.Status)
+	require.NotNil(t, snap.Substatus)
+	assert.Equal(t, scheduleModels.AttendanceSubstatusLate, *snap.Substatus)
+	require.NotNil(t, snap.Note)
+	assert.Equal(t, "bus verspätet", *snap.Note)
+
+	// Read-only: row must be unchanged (including updated_at).
+	got, err := s.isRepo.FindByID(s.ctx, row.ID)
+	require.NoError(t, err)
+	assert.Equal(t, row.UpdatedAt.UnixNano(), got.UpdatedAt.UnixNano(), "LoadAttendance must not mutate")
+}
+
+func TestAttendanceSync_LoadAttendance_NoRow(t *testing.T) {
+	s := buildAttendanceSyncSetup(t)
+	student := testpkg.CreateTestStudent(t, s.db, "AS-NoRow", fmt.Sprintf("N-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+
+	snap := s.syncer.LoadAttendanceForVisit(s.ctx, &activeModels.Visit{
+		StudentID:     student.ID,
+		ActiveGroupID: s.activeGroup.ID,
+	})
+	assert.Nil(t, snap)
+}

--- a/backend/services/schedule/attendance_sync_service_unit_test.go
+++ b/backend/services/schedule/attendance_sync_service_unit_test.go
@@ -1,0 +1,444 @@
+// Unit tests for AttendanceSyncService that don't require a database.
+//
+// The integration tests in attendance_sync_service_integration_test.go cover
+// the happy-path branches (B1, B3, B5, B6, B9) via real repos. The
+// graceful-degradation error branches (B2 instance lookup error, B4
+// instance_student lookup error, B7 UPDATE error, B8 race, and the panic
+// recovery paths) are not hermetically reachable with real DB code — RLS
+// hides rows rather than returning errors, and transient Postgres failures
+// cannot be reliably injected without extra infrastructure.
+//
+// This file closes the coverage gap by stubbing both repositories with
+// hand-rolled fakes that return the shapes each branch expects.
+package schedule_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	modelsBase "github.com/moto-nrw/project-phoenix/models/base"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Fake ActivityInstanceRepository — only FindByActiveGroupID is used by the
+// service. Other methods panic if called so a regression that adds a new
+// dependency fails loudly rather than silently returning zero-values.
+// -----------------------------------------------------------------------------
+
+type fakeInstanceRepo struct {
+	findErr   error
+	instance  *scheduleModel.ActivityInstance
+	findPanic any
+}
+
+func (f *fakeInstanceRepo) FindByActiveGroupID(_ context.Context, _ int64) (*scheduleModel.ActivityInstance, error) {
+	if f.findPanic != nil {
+		panic(f.findPanic)
+	}
+	return f.instance, f.findErr
+}
+
+// Unused interface methods — panic keeps them from accidentally hiding a
+// regression that adds a new dependency to the service.
+func (f *fakeInstanceRepo) Create(context.Context, *scheduleModel.ActivityInstance) error {
+	panic("unused")
+}
+
+func (f *fakeInstanceRepo) FindByID(context.Context, interface{}) (*scheduleModel.ActivityInstance, error) {
+	panic("unused")
+}
+
+func (f *fakeInstanceRepo) Update(context.Context, *scheduleModel.ActivityInstance) error {
+	panic("unused")
+}
+
+func (f *fakeInstanceRepo) Delete(context.Context, interface{}) error {
+	panic("unused")
+}
+
+func (f *fakeInstanceRepo) List(context.Context, *modelsBase.QueryOptions) ([]*scheduleModel.ActivityInstance, error) {
+	panic("unused")
+}
+
+func (f *fakeInstanceRepo) FindByTenantAndDate(context.Context, time.Time) ([]*scheduleModel.ActivityInstance, error) {
+	panic("unused")
+}
+
+func (f *fakeInstanceRepo) FindByTenantAndDateRange(context.Context, time.Time, time.Time) ([]*scheduleModel.ActivityInstance, error) {
+	panic("unused")
+}
+
+func (f *fakeInstanceRepo) FindByActivityGroupAndDate(context.Context, int64, time.Time) ([]*scheduleModel.ActivityInstance, error) {
+	panic("unused")
+}
+
+// -----------------------------------------------------------------------------
+// Fake InstanceStudentRepository — controls FindByInstanceAndStudent and
+// UpdateAttendanceFromCheckin outcomes for every branch.
+// -----------------------------------------------------------------------------
+
+type fakeInstanceStudentRepo struct {
+	findRow      *scheduleModel.InstanceStudent
+	findErr      error
+	updateResult bool
+	updateErr    error
+	updateCalls  int
+}
+
+func (f *fakeInstanceStudentRepo) FindByInstanceAndStudent(_ context.Context, _, _ int64) (*scheduleModel.InstanceStudent, error) {
+	return f.findRow, f.findErr
+}
+
+func (f *fakeInstanceStudentRepo) UpdateAttendanceFromCheckin(_ context.Context, _, _ int64, _ time.Time) (bool, error) {
+	f.updateCalls++
+	return f.updateResult, f.updateErr
+}
+
+func (f *fakeInstanceStudentRepo) Create(context.Context, *scheduleModel.InstanceStudent) error {
+	panic("unused")
+}
+
+func (f *fakeInstanceStudentRepo) FindByID(context.Context, interface{}) (*scheduleModel.InstanceStudent, error) {
+	panic("unused")
+}
+
+func (f *fakeInstanceStudentRepo) Update(context.Context, *scheduleModel.InstanceStudent) error {
+	panic("unused")
+}
+
+func (f *fakeInstanceStudentRepo) Delete(context.Context, interface{}) error {
+	panic("unused")
+}
+
+func (f *fakeInstanceStudentRepo) List(context.Context, *modelsBase.QueryOptions) ([]*scheduleModel.InstanceStudent, error) {
+	panic("unused")
+}
+
+func (f *fakeInstanceStudentRepo) FindByInstanceID(context.Context, int64) ([]*scheduleModel.InstanceStudent, error) {
+	panic("unused")
+}
+
+func (f *fakeInstanceStudentRepo) FindByStudentAndDateRange(context.Context, int64, time.Time, time.Time) ([]*scheduleModel.InstanceStudent, error) {
+	panic("unused")
+}
+
+func (f *fakeInstanceStudentRepo) DeleteByInstanceID(context.Context, int64) error {
+	panic("unused")
+}
+
+func (f *fakeInstanceStudentRepo) UpdateAttendanceFields(context.Context, int64, scheduleModel.AttendanceFieldPatch) error {
+	panic("unused")
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+func newSilentLogger() (*slog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	return logger, buf
+}
+
+func newUnitSyncer(instRepo *fakeInstanceRepo, isRepo *fakeInstanceStudentRepo) *scheduleSvc.AttendanceSyncService {
+	logger, _ := newSilentLogger()
+	return scheduleSvc.NewAttendanceSyncService(instRepo, isRepo, logger)
+}
+
+func validVisit() *activeModel.Visit {
+	return &activeModel.Visit{
+		StudentID:     100,
+		ActiveGroupID: 42,
+		EntryTime:     time.Date(2026, 4, 20, 14, 0, 0, 0, time.UTC),
+	}
+}
+
+func instanceWithID(id int64) *scheduleModel.ActivityInstance {
+	inst := &scheduleModel.ActivityInstance{}
+	inst.ID = id
+	return inst
+}
+
+func expectedRow(id int64) *scheduleModel.InstanceStudent {
+	row := &scheduleModel.InstanceStudent{
+		InstanceID: 42,
+		StudentID:  100,
+		Status:     scheduleModel.AttendanceStatusExpected,
+	}
+	row.ID = id
+	return row
+}
+
+// -----------------------------------------------------------------------------
+// MirrorCheckInForVisit — error branches
+// -----------------------------------------------------------------------------
+
+func TestMirrorCheckIn_B1_NilVisit(t *testing.T) {
+	syncer := newUnitSyncer(&fakeInstanceRepo{}, &fakeInstanceStudentRepo{})
+	assert.Nil(t, syncer.MirrorCheckInForVisit(context.Background(), nil))
+}
+
+func TestMirrorCheckIn_B1_ZeroActiveGroup(t *testing.T) {
+	syncer := newUnitSyncer(&fakeInstanceRepo{}, &fakeInstanceStudentRepo{})
+	v := validVisit()
+	v.ActiveGroupID = 0
+	assert.Nil(t, syncer.MirrorCheckInForVisit(context.Background(), v))
+}
+
+func TestMirrorCheckIn_B1_NegativeActiveGroup(t *testing.T) {
+	syncer := newUnitSyncer(&fakeInstanceRepo{}, &fakeInstanceStudentRepo{})
+	v := validVisit()
+	v.ActiveGroupID = -1
+	assert.Nil(t, syncer.MirrorCheckInForVisit(context.Background(), v))
+}
+
+func TestMirrorCheckIn_B2_InstanceLookupError(t *testing.T) {
+	instRepo := &fakeInstanceRepo{findErr: errors.New("connection lost")}
+	isRepo := &fakeInstanceStudentRepo{}
+	syncer := newUnitSyncer(instRepo, isRepo)
+
+	snap := syncer.MirrorCheckInForVisit(context.Background(), validVisit())
+	assert.Nil(t, snap, "instance lookup error must return nil (graceful degradation)")
+	assert.Equal(t, 0, isRepo.updateCalls, "must not attempt UPDATE after lookup failure")
+}
+
+func TestMirrorCheckIn_B3_NoInstance(t *testing.T) {
+	syncer := newUnitSyncer(&fakeInstanceRepo{instance: nil}, &fakeInstanceStudentRepo{})
+	assert.Nil(t, syncer.MirrorCheckInForVisit(context.Background(), validVisit()))
+}
+
+func TestMirrorCheckIn_B4_InstanceStudentLookupError(t *testing.T) {
+	instRepo := &fakeInstanceRepo{instance: instanceWithID(7)}
+	isRepo := &fakeInstanceStudentRepo{findErr: errors.New("scan error")}
+	syncer := newUnitSyncer(instRepo, isRepo)
+
+	assert.Nil(t, syncer.MirrorCheckInForVisit(context.Background(), validVisit()))
+	assert.Equal(t, 0, isRepo.updateCalls)
+}
+
+func TestMirrorCheckIn_B5_NoInstanceStudentRow(t *testing.T) {
+	instRepo := &fakeInstanceRepo{instance: instanceWithID(7)}
+	isRepo := &fakeInstanceStudentRepo{findRow: nil}
+	syncer := newUnitSyncer(instRepo, isRepo)
+
+	assert.Nil(t, syncer.MirrorCheckInForVisit(context.Background(), validVisit()))
+	assert.Equal(t, 0, isRepo.updateCalls, "no row → skip UPDATE")
+}
+
+func TestMirrorCheckIn_B6_AlreadyPresent_NoClobber(t *testing.T) {
+	late := scheduleModel.AttendanceSubstatusLate
+	note := "bus late"
+	row := expectedRow(3)
+	row.Status = scheduleModel.AttendanceStatusPresent
+	row.Substatus = &late
+	row.Note = &note
+
+	instRepo := &fakeInstanceRepo{instance: instanceWithID(7)}
+	isRepo := &fakeInstanceStudentRepo{findRow: row}
+	syncer := newUnitSyncer(instRepo, isRepo)
+
+	snap := syncer.MirrorCheckInForVisit(context.Background(), validVisit())
+	require.NotNil(t, snap)
+	assert.Equal(t, scheduleModel.AttendanceStatusPresent, snap.Status)
+	require.NotNil(t, snap.Substatus)
+	assert.Equal(t, scheduleModel.AttendanceSubstatusLate, *snap.Substatus)
+	require.NotNil(t, snap.Note)
+	assert.Equal(t, "bus late", *snap.Note)
+	assert.Equal(t, 0, isRepo.updateCalls, "must NOT UPDATE when row is already past expected")
+}
+
+func TestMirrorCheckIn_B6_Absent_NoClobber(t *testing.T) {
+	row := expectedRow(3)
+	row.Status = scheduleModel.AttendanceStatusAbsent
+
+	instRepo := &fakeInstanceRepo{instance: instanceWithID(7)}
+	isRepo := &fakeInstanceStudentRepo{findRow: row}
+	syncer := newUnitSyncer(instRepo, isRepo)
+
+	snap := syncer.MirrorCheckInForVisit(context.Background(), validVisit())
+	require.NotNil(t, snap)
+	assert.Equal(t, scheduleModel.AttendanceStatusAbsent, snap.Status)
+	assert.Equal(t, 0, isRepo.updateCalls)
+}
+
+func TestMirrorCheckIn_B7_UpdateError(t *testing.T) {
+	instRepo := &fakeInstanceRepo{instance: instanceWithID(7)}
+	isRepo := &fakeInstanceStudentRepo{
+		findRow:   expectedRow(3),
+		updateErr: errors.New("FK violation"),
+	}
+	syncer := newUnitSyncer(instRepo, isRepo)
+
+	snap := syncer.MirrorCheckInForVisit(context.Background(), validVisit())
+	assert.Nil(t, snap, "UPDATE error → nil (graceful, logged at Error for ops)")
+	assert.Equal(t, 1, isRepo.updateCalls)
+}
+
+func TestMirrorCheckIn_B8_RaceNoRowsAffected(t *testing.T) {
+	row := expectedRow(3)
+	instRepo := &fakeInstanceRepo{instance: instanceWithID(7)}
+	isRepo := &fakeInstanceStudentRepo{
+		findRow:      row,
+		updateResult: false, // no rows matched (race — row moved out of 'expected')
+	}
+	syncer := newUnitSyncer(instRepo, isRepo)
+
+	snap := syncer.MirrorCheckInForVisit(context.Background(), validVisit())
+	require.NotNil(t, snap, "race → snapshot of read row so SSE still fires")
+	assert.Equal(t, scheduleModel.AttendanceStatusExpected, snap.Status)
+}
+
+func TestMirrorCheckIn_B9_HappyPath(t *testing.T) {
+	instRepo := &fakeInstanceRepo{instance: instanceWithID(7)}
+	isRepo := &fakeInstanceStudentRepo{
+		findRow:      expectedRow(3),
+		updateResult: true,
+	}
+	syncer := newUnitSyncer(instRepo, isRepo)
+
+	snap := syncer.MirrorCheckInForVisit(context.Background(), validVisit())
+	require.NotNil(t, snap)
+	assert.Equal(t, scheduleModel.AttendanceStatusPresent, snap.Status)
+	assert.Equal(t, 1, isRepo.updateCalls)
+}
+
+func TestMirrorCheckIn_B9_HappyPathWithSubstatusAndNote(t *testing.T) {
+	// B9 must propagate existing substatus/note from the row it just flipped.
+	excused := scheduleModel.AttendanceSubstatusExcused
+	note := "Arzttermin"
+	row := expectedRow(3)
+	row.Substatus = &excused
+	row.Note = &note
+
+	instRepo := &fakeInstanceRepo{instance: instanceWithID(7)}
+	isRepo := &fakeInstanceStudentRepo{findRow: row, updateResult: true}
+	syncer := newUnitSyncer(instRepo, isRepo)
+
+	snap := syncer.MirrorCheckInForVisit(context.Background(), validVisit())
+	require.NotNil(t, snap)
+	require.NotNil(t, snap.Substatus)
+	assert.Equal(t, scheduleModel.AttendanceSubstatusExcused, *snap.Substatus)
+	require.NotNil(t, snap.Note)
+	assert.Equal(t, "Arzttermin", *snap.Note)
+}
+
+func TestMirrorCheckIn_PanicRecovery(t *testing.T) {
+	// Exercise the defer/recover belt-and-braces. The instance lookup panics;
+	// the service must swallow it and return nil without propagating.
+	instRepo := &fakeInstanceRepo{findPanic: "boom"}
+	isRepo := &fakeInstanceStudentRepo{}
+	syncer := newUnitSyncer(instRepo, isRepo)
+
+	var snap *activeSvcSnapshot
+	require.NotPanics(t, func() {
+		result := syncer.MirrorCheckInForVisit(context.Background(), validVisit())
+		if result != nil {
+			snap = &activeSvcSnapshot{Status: result.Status}
+		}
+	})
+	assert.Nil(t, snap, "panic in instance lookup must be recovered → nil snapshot")
+}
+
+// activeSvcSnapshot is a local copy used only to assert shape without
+// importing the active services package under a different alias.
+type activeSvcSnapshot struct {
+	Status string
+}
+
+// -----------------------------------------------------------------------------
+// LoadAttendanceForVisit — error branches
+// -----------------------------------------------------------------------------
+
+func TestLoadAttendance_NilVisit(t *testing.T) {
+	syncer := newUnitSyncer(&fakeInstanceRepo{}, &fakeInstanceStudentRepo{})
+	assert.Nil(t, syncer.LoadAttendanceForVisit(context.Background(), nil))
+}
+
+func TestLoadAttendance_ZeroActiveGroup(t *testing.T) {
+	syncer := newUnitSyncer(&fakeInstanceRepo{}, &fakeInstanceStudentRepo{})
+	v := validVisit()
+	v.ActiveGroupID = 0
+	assert.Nil(t, syncer.LoadAttendanceForVisit(context.Background(), v))
+}
+
+func TestLoadAttendance_InstanceLookupError(t *testing.T) {
+	instRepo := &fakeInstanceRepo{findErr: errors.New("db down")}
+	syncer := newUnitSyncer(instRepo, &fakeInstanceStudentRepo{})
+	assert.Nil(t, syncer.LoadAttendanceForVisit(context.Background(), validVisit()))
+}
+
+func TestLoadAttendance_NoInstance(t *testing.T) {
+	syncer := newUnitSyncer(&fakeInstanceRepo{instance: nil}, &fakeInstanceStudentRepo{})
+	assert.Nil(t, syncer.LoadAttendanceForVisit(context.Background(), validVisit()))
+}
+
+func TestLoadAttendance_InstanceStudentLookupError(t *testing.T) {
+	instRepo := &fakeInstanceRepo{instance: instanceWithID(7)}
+	isRepo := &fakeInstanceStudentRepo{findErr: errors.New("scan failed")}
+	syncer := newUnitSyncer(instRepo, isRepo)
+	assert.Nil(t, syncer.LoadAttendanceForVisit(context.Background(), validVisit()))
+}
+
+func TestLoadAttendance_NoRow(t *testing.T) {
+	instRepo := &fakeInstanceRepo{instance: instanceWithID(7)}
+	isRepo := &fakeInstanceStudentRepo{findRow: nil}
+	syncer := newUnitSyncer(instRepo, isRepo)
+	assert.Nil(t, syncer.LoadAttendanceForVisit(context.Background(), validVisit()))
+}
+
+func TestLoadAttendance_HappyPath(t *testing.T) {
+	late := scheduleModel.AttendanceSubstatusLate
+	note := "bus delay"
+	row := expectedRow(5)
+	row.Status = scheduleModel.AttendanceStatusPresent
+	row.Substatus = &late
+	row.Note = &note
+
+	instRepo := &fakeInstanceRepo{instance: instanceWithID(7)}
+	isRepo := &fakeInstanceStudentRepo{findRow: row}
+	syncer := newUnitSyncer(instRepo, isRepo)
+
+	snap := syncer.LoadAttendanceForVisit(context.Background(), validVisit())
+	require.NotNil(t, snap)
+	assert.Equal(t, scheduleModel.AttendanceStatusPresent, snap.Status)
+	require.NotNil(t, snap.Substatus)
+	assert.Equal(t, scheduleModel.AttendanceSubstatusLate, *snap.Substatus)
+	require.NotNil(t, snap.Note)
+	assert.Equal(t, "bus delay", *snap.Note)
+}
+
+func TestLoadAttendance_PanicRecovery(t *testing.T) {
+	instRepo := &fakeInstanceRepo{findPanic: errors.New("kaboom")}
+	syncer := newUnitSyncer(instRepo, &fakeInstanceStudentRepo{})
+	require.NotPanics(t, func() {
+		snap := syncer.LoadAttendanceForVisit(context.Background(), validVisit())
+		assert.Nil(t, snap)
+	})
+}
+
+// -----------------------------------------------------------------------------
+// Logger fallback
+// -----------------------------------------------------------------------------
+
+func TestAttendanceSync_NilLoggerUsesDefault(t *testing.T) {
+	// When a nil logger is passed, the service must fall back to slog.Default()
+	// and still execute end-to-end without panicking.
+	svc := scheduleSvc.NewAttendanceSyncService(
+		&fakeInstanceRepo{instance: nil},
+		&fakeInstanceStudentRepo{},
+		nil,
+	)
+	require.NotPanics(t, func() {
+		assert.Nil(t, svc.MirrorCheckInForVisit(context.Background(), validVisit()))
+		assert.Nil(t, svc.LoadAttendanceForVisit(context.Background(), validVisit()))
+	})
+}

--- a/backend/test/hermetic_verification_test.go
+++ b/backend/test/hermetic_verification_test.go
@@ -136,24 +136,26 @@ func checkHardcodedIDs(t *testing.T, root string) []string {
 
 	// Files to skip (mock tests, model unit tests without DB)
 	skipPatterns := []string{
-		"_internal_test.go",                     // Internal tests often use mocks
-		"_mock_test.go",                         // Mock tests
-		"models/",                               // Model unit tests don't hit DB (Unix)
-		"models\\",                              // Model unit tests don't hit DB (Windows)
-		"invitation_service_test.go",            // Uses mocks
-		"password_reset_integration_test.go",    // Uses mocks (sqlmock + stubs)
-		"handlers_unit_test.go",                 // Unit tests for converters (no DB)
-		"http_middleware_test.go",               // Uses nil *bun.DB for unit testing middleware
-		"operator_provisioning_service_test.go", // Uses mocks (sqlmock + stubs)
-		"operator_invitation_test.go",           // Uses mocks (sqlmock + stubs)
-		"operator_invitation_dispatch_test.go",  // Uses mocks for email dispatch tests
-		"invitations_test.go",                   // Uses mocks for handler tests
-		"error_helpers_test.go",                 // Internal unit tests for helper functions (no DB)
-		"api/iot/api_test.go",                   // Uses mock SchoolRepo for unit testing handler
-		"api/iot/config_test.go",                // Uses mock settings service for unit testing config endpoint
-		"enrich_pickup_times_test.go",           // Uses mock PickupScheduleService for unit testing enrichment
-		"api/timetable/api_test.go",             // Uses mock CalendarPeriodService for unit testing handlers
-		"api/timetable/instances_test.go",       // Uses mock InstanceService + PersonService for unit testing handlers
+		"_internal_test.go",                                      // Internal tests often use mocks
+		"_mock_test.go",                                          // Mock tests
+		"models/",                                                // Model unit tests don't hit DB (Unix)
+		"models\\",                                               // Model unit tests don't hit DB (Windows)
+		"invitation_service_test.go",                             // Uses mocks
+		"password_reset_integration_test.go",                     // Uses mocks (sqlmock + stubs)
+		"handlers_unit_test.go",                                  // Unit tests for converters (no DB)
+		"http_middleware_test.go",                                // Uses nil *bun.DB for unit testing middleware
+		"operator_provisioning_service_test.go",                  // Uses mocks (sqlmock + stubs)
+		"operator_invitation_test.go",                            // Uses mocks (sqlmock + stubs)
+		"operator_invitation_dispatch_test.go",                   // Uses mocks for email dispatch tests
+		"invitations_test.go",                                    // Uses mocks for handler tests
+		"error_helpers_test.go",                                  // Internal unit tests for helper functions (no DB)
+		"api/iot/api_test.go",                                    // Uses mock SchoolRepo for unit testing handler
+		"api/iot/config_test.go",                                 // Uses mock settings service for unit testing config endpoint
+		"enrich_pickup_times_test.go",                            // Uses mock PickupScheduleService for unit testing enrichment
+		"api/timetable/api_test.go",                              // Uses mock CalendarPeriodService for unit testing handlers
+		"api/timetable/instances_test.go",                        // Uses mock InstanceService + PersonService for unit testing handlers
+		"api/timetable/instance_students_unit_test.go",           // Uses fake repo for unit testing attendance PATCH handler
+		"services/schedule/attendance_sync_service_unit_test.go", // Uses fake repos for unit testing graceful-degradation branches
 	}
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
## Summary

Mirrors IoT check-ins into `schedule.instance_students` and adds a staff-facing PATCH endpoint for editing attendance post-hoc. Closes the plan-vs-reality gap between `instance_students` (expected) and `active.visits` (actual) while preserving graceful degradation so walk-ins, pre-start races, and non-instance visits keep working.

Scope is strictly WP-B10 per the [timetable system plan](docs/timetable-system-plan.md). No aggregation (B11), no gap detection (B12), no exception conflicts (B13), no cleanup (B14).

## What's in

**Check-in path** (`services/active/active_service.go` → `services/schedule/attendance_sync_service.go`)
- New `active.AttendanceSyncer` interface declared in the active package (no import cycle). `schedule.AttendanceSyncService` implements it and is wired via `services.Factory`.
- `ActiveService.CreateVisit` calls the mirror AFTER the visit is written. The mirror returns nil for every failure (no instance, no enrolled student, DB error, panic) — check-ins never block on attendance-sync failure.
- New repo method `UpdateAttendanceFromCheckin` uses a `status='expected'` predicate in the `WHERE` clause to enforce monotonicity: already-present rows (double-tap, post-hoc PATCH) are never clobbered.
- **Branch-7 observability**: when the UPDATE itself fails (tenant tx taint), the sync logs at `Error` level so the existing backend-error-rate alert surfaces the incident before it becomes a ghost-visit ticket.

**Check-out path**
- `LoadAttendanceForVisit` is strictly read-only. Status stays `present` once set, per spec.
- `broadcastStudentCheckoutEvents` carries a `TODO(wp-b11-or-later): batch if hot` comment for the N+1 that would only bite large schools in the timeout-flush path.

**SSE enrichment** (`realtime/events.go`)
- `EventData` gains three optional pointer fields: `attendance_status`, `attendance_substatus`, `attendance_note`.
- Populated on `EventStudentCheckIn` / `EventStudentCheckOut` when the visit corresponds to an instance_students row; omitted (`omitempty`) otherwise. Backwards-compatible for existing consumers.

**PATCH endpoint** (`api/timetable/instance_students.go`)
- `PATCH /api/timetable/instances/{instance_id}/students/{student_id}` gated on `permissions.SchedulesManage`.
- Uses `json.RawMessage` for `substatus` / `note` to distinguish MISSING / explicit `null` / value — both columns are nullable and each state is meaningful.
- Cross-field validation (substatus forbidden when effective final status is `expected`) documented with a truth-table comment. Validation returns all per-field errors in one 400 response.
- Wrong-tenant rows are hidden by RLS → returns 404 (not 403).

**PyrePortal guard** (`api/iot/checkin/pyreportal_error_strings_test.go`)
- Regression tripwire: 32 error substrings from `PyrePortal/src/services/api.ts` ERROR_MESSAGE_MAPPINGS that originate from checkin-boundary routes or device-auth middleware. Test fails loudly if any wording is changed in the backend, flagging the coupling before the kiosk's German translation breaks silently.
- Guard scope and enumeration methodology are documented at the top of the test file.

## What's intentionally NOT in

- **Auto-absent job** — `expected` rows stay `expected` at end of day. WP-B11/B14 territory.
- **Auto-late substatus** — plan §6.2 suggests `determineSubstatus()`; spec overrules. Mirror writes `status` + `checked_in_at` only.
- **Batch mirror** — each check-in is already its own HTTP request; no N+1 on the hot path.
- **New IoT error strings** — `api/iot/checkin/*` error surface is bit-identical. PyrePortal guard enforces this.
- **Test changes to business rules** — pure signature-widening for `NewResource` (matches the WP-B9 pattern).

## Sharp edges documented in code

- **Shared tenant tx**: mirror UPDATE runs inside the IoT handler's `TenantTxMiddleware` tx. A mid-UPDATE Postgres error taints the tx and will roll back the visit on commit. Unavoidable under the shared tx model and called out in the service doc comment — branch-7 logs at Error so ops hears about it.
- **json.RawMessage tri-state**: reviewer focus in `parseAttendancePatchRequest` — look for `{note: null}` handling.
- **Substatus-vs-status cross-field rule**: 7-row truth table above `validateAttendancePatch`.

## Pre-existing (NOT this PR)

`TestArrivalScheduleService_BulkUpsertBySchoolClass` fails on `development` before these changes (verified via `git stash -u`). Flag for whoever owns arrival-schedules; out of scope here.

## Test plan

- [x] `cd backend && go build ./... && go vet ./...`
- [x] `go test ./services/schedule/... ./api/iot/checkin/... ./api/timetable/... ./test/`
- [x] `TestHermeticTestPatterns` (no hardcoded int64(1–9) leaks)
- [x] Full downstream matrix (`services/active`, `api/iot/...`, all `database/repositories/...`) — no regressions from the signature changes to `broadcastVisitCreated` / `broadcastVisitCheckout` / `broadcastStudentCheckoutEvents`
- [x] `TestPyrePortalCheckinErrorStringsGuard` — all 32 substrings present in the source tree
- [ ] Reviewer: manual walkthrough of `validateAttendancePatch` truth table
- [ ] Reviewer: confirm `json.RawMessage` tri-state reads correctly for `{note: null}`