### PR TITLE
feat(students): Aktivitäten-heute filter in Kindersuche

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -7,6 +7,7 @@ import {
   act,
 } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
 import StudentSearchPage from "./page";
 
 // Mock next-auth/react
@@ -1212,6 +1213,232 @@ describe("StudentSearchPage", () => {
 
       // Should show "Abholzeit: —" fallback for students with full access but no pickup time
       expect(screen.getByText("Abholzeit: —")).toBeInTheDocument();
+    });
+  });
+
+  describe("Tracking Filter (Aktivitäten heute)", () => {
+    // Fixture: two students, two configured labels; student "1" completed
+    // Hausaufgaben, student "2" has done nothing yet.
+    const trackingStudents = [
+      {
+        id: "1",
+        first_name: "Felix",
+        second_name: "Schneider",
+        school_class: "1a",
+        group_name: "Sterne",
+        current_location: "Raum 101",
+        has_full_access: true,
+      },
+      {
+        id: "2",
+        first_name: "Emma",
+        second_name: "Meyer",
+        school_class: "1a",
+        group_name: "Sterne",
+        current_location: "Raum 101",
+        has_full_access: true,
+      },
+    ];
+
+    const trackingTwoLabels: TrackingIndicatorsResponse = {
+      labels: ["Hausaufgaben", "Mensa"],
+      results: {
+        "1": [true, false],
+        "2": [false, false],
+      },
+    };
+
+    // Configures useSWRAuth to return students for the students key and
+    // the provided tracking response for the tracking-indicators key.
+    async function primeTracking(opts: {
+      tracking?: TrackingIndicatorsResponse;
+      students?: typeof trackingStudents;
+    }) {
+      const swrModule = await import("~/lib/swr");
+      const studentsResult = {
+        data: { students: opts.students ?? trackingStudents },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>;
+      const trackingResult = {
+        data: opts.tracking,
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>;
+      vi.mocked(swrModule.useSWRAuth).mockImplementation((key: unknown) => {
+        if (typeof key === "string" && key.startsWith("tracking-indicators-")) {
+          return trackingResult;
+        }
+        return studentsResult;
+      });
+    }
+
+    it("does not render the tracking dropdown when no labels are configured", async () => {
+      await primeTracking({ tracking: { labels: [], results: {} } });
+      render(<StudentSearchPage />);
+
+      await waitFor(() =>
+        expect(screen.getByText("Felix")).toBeInTheDocument(),
+      );
+      expect(screen.queryByTestId("filter-tracking")).not.toBeInTheDocument();
+    });
+
+    it("renders the dropdown with Alle / per-label / Noch nichts erledigt options", async () => {
+      await primeTracking({ tracking: trackingTwoLabels });
+      render(<StudentSearchPage />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId("filter-tracking")).toBeInTheDocument(),
+      );
+      const select = screen.getByTestId("filter-tracking");
+      expect(select.querySelector('option[value="all"]')).toHaveTextContent(
+        "Alle Aktivitäten heute",
+      );
+      expect(
+        select.querySelector('option[value="missing:0"]'),
+      ).toHaveTextContent("Noch nicht in Hausaufgaben");
+      expect(
+        select.querySelector('option[value="missing:1"]'),
+      ).toHaveTextContent("Noch nicht in Mensa");
+      expect(
+        select.querySelector('option[value="none_visited"]'),
+      ).toHaveTextContent("Noch nichts erledigt");
+    });
+
+    it("selecting 'missing:0' hides students who already completed that label", async () => {
+      await primeTracking({ tracking: trackingTwoLabels });
+      render(<StudentSearchPage />);
+
+      await waitFor(() =>
+        expect(screen.getByText("Felix")).toBeInTheDocument(),
+      );
+
+      fireEvent.change(screen.getByTestId("filter-tracking"), {
+        target: { value: "missing:0" },
+      });
+
+      await waitFor(() => {
+        // Felix completed Hausaufgaben (results[0] === true) → hidden.
+        expect(screen.queryByText("Felix")).not.toBeInTheDocument();
+        // Emma hasn't → visible.
+        expect(screen.getByText("Emma")).toBeInTheDocument();
+      });
+    });
+
+    it("'none_visited' keeps only students missing every configured indicator", async () => {
+      await primeTracking({ tracking: trackingTwoLabels });
+      render(<StudentSearchPage />);
+
+      await waitFor(() =>
+        expect(screen.getByText("Felix")).toBeInTheDocument(),
+      );
+
+      fireEvent.change(screen.getByTestId("filter-tracking"), {
+        target: { value: "none_visited" },
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText("Felix")).not.toBeInTheDocument();
+        expect(screen.getByText("Emma")).toBeInTheDocument();
+      });
+    });
+
+    it("shows the chip with the correct label and clears it when clicked", async () => {
+      await primeTracking({ tracking: trackingTwoLabels });
+      render(<StudentSearchPage />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId("filter-tracking")).toBeInTheDocument(),
+      );
+
+      fireEvent.change(screen.getByTestId("filter-tracking"), {
+        target: { value: "missing:1" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("active-filter-tracking")).toHaveTextContent(
+          "Noch nicht in Mensa",
+        );
+      });
+
+      fireEvent.click(screen.getByTestId("active-filter-tracking"));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("active-filter-tracking"),
+        ).not.toBeInTheDocument();
+        expect(screen.getByTestId("filter-tracking")).toHaveValue("all");
+      });
+    });
+
+    it("'Alle zurücksetzen' clears the tracking filter", async () => {
+      await primeTracking({ tracking: trackingTwoLabels });
+      render(<StudentSearchPage />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId("filter-tracking")).toBeInTheDocument(),
+      );
+
+      fireEvent.change(screen.getByTestId("filter-tracking"), {
+        target: { value: "none_visited" },
+      });
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("active-filter-tracking"),
+        ).toBeInTheDocument(),
+      );
+
+      fireEvent.click(screen.getByTestId("clear-filters"));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("active-filter-tracking"),
+        ).not.toBeInTheDocument();
+        expect(screen.getByTestId("filter-tracking")).toHaveValue("all");
+      });
+    });
+
+    it("hides redacted students (has_full_access === false) while a tracking filter is active", async () => {
+      const mixed = [
+        trackingStudents[0],
+        {
+          id: "9",
+          first_name: "Redacted",
+          second_name: "Kid",
+          school_class: "1a",
+          group_name: "Sterne",
+          current_location: "Raum 101",
+          has_full_access: false,
+        },
+      ];
+      // Only include tracking data for id "1"; redacted student has no row.
+      await primeTracking({
+        tracking: {
+          labels: ["Hausaufgaben"],
+          results: { "1": [false] },
+        },
+        students: mixed as typeof trackingStudents,
+      });
+      render(<StudentSearchPage />);
+
+      await waitFor(() =>
+        expect(screen.getByText("Redacted")).toBeInTheDocument(),
+      );
+
+      // Initially both visible.
+      expect(screen.getByText("Felix")).toBeInTheDocument();
+      expect(screen.getByText("Redacted")).toBeInTheDocument();
+
+      fireEvent.change(screen.getByTestId("filter-tracking"), {
+        target: { value: "missing:0" },
+      });
+
+      await waitFor(() => {
+        // Felix missing HA → shown.
+        expect(screen.getByText("Felix")).toBeInTheDocument();
+        // Redacted kid hidden — no tracking data AND has_full_access false.
+        expect(screen.queryByText("Redacted")).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -36,6 +36,12 @@ import { activeService } from "~/lib/active-api";
 import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
 import { TrackingIndicators } from "~/components/students/tracking-indicators";
 import { createLogger } from "~/lib/logger";
+import {
+  matchesTrackingFilter,
+  resolveTrackingFilterAfterLabelChange,
+  trackingFilterChipLabel,
+  type TrackingFilter,
+} from "./tracking-filter";
 
 const logger = createLogger({ component: "StudentSearchPage" });
 
@@ -73,6 +79,7 @@ function SearchPageContent() {
     initialAttendanceFilter,
   );
   const [pickupTimeFilter, setPickupTimeFilter] = useState("all");
+  const [trackingFilter, setTrackingFilter] = useState<TrackingFilter>("all");
 
   // Current time for pickup urgency calculation (updates every minute)
   const now = useMinuteClock();
@@ -153,6 +160,18 @@ function SearchPageContent() {
     async () => activeService.getTrackingIndicators(trackingStudentIds),
     { keepPreviousData: true, revalidateOnFocus: false },
   );
+
+  // Reset tracking filter if labels vanish or the selected label index becomes stale.
+  // Without this, the active-filter chip (guarded by trackingData.labels) can hide
+  // while trackingFilter remains set, leaving an invisible filter applied.
+  const trackingLabels = trackingData?.labels;
+  useEffect(() => {
+    const next = resolveTrackingFilterAfterLabelChange(
+      trackingFilter,
+      trackingData,
+    );
+    if (next !== trackingFilter) setTrackingFilter(next);
+  }, [trackingData, trackingFilter]);
 
   // Error type for proper heading display (Fix P3: substring matching on transformed string)
   type ErrorType = "permission" | "session" | "generic" | null;
@@ -251,12 +270,34 @@ function SearchPageContent() {
           { value: "none", label: "Keine Abholzeit" },
         ],
       },
+      ...(trackingLabels && trackingLabels.length > 0
+        ? [
+            {
+              id: "tracking",
+              label: "Aktivitäten heute",
+              type: "dropdown" as const,
+              value: trackingFilter,
+              onChange: (value: string | string[]) =>
+                setTrackingFilter(value as TrackingFilter),
+              options: [
+                { value: "all", label: "Alle Aktivitäten heute" },
+                ...trackingLabels.map((lbl, idx) => ({
+                  value: `missing:${idx}`,
+                  label: `Noch nicht in ${lbl}`,
+                })),
+                { value: "none_visited", label: "Noch nichts erledigt" },
+              ],
+            },
+          ]
+        : []),
     ],
     [
       selectedYear,
       selectedGroup,
       attendanceFilter,
       pickupTimeFilter,
+      trackingFilter,
+      trackingLabels,
       groups,
       studentsData,
     ],
@@ -317,6 +358,17 @@ function SearchPageContent() {
       });
     }
 
+    if (trackingLabels) {
+      const chipLabel = trackingFilterChipLabel(trackingFilter, trackingLabels);
+      if (chipLabel !== null) {
+        filters.push({
+          id: "tracking",
+          label: chipLabel,
+          onRemove: () => setTrackingFilter("all"),
+        });
+      }
+    }
+
     return filters;
   }, [
     searchTerm,
@@ -324,6 +376,8 @@ function SearchPageContent() {
     selectedGroup,
     attendanceFilter,
     pickupTimeFilter,
+    trackingFilter,
+    trackingLabels,
     groups,
   ]);
 
@@ -383,6 +437,10 @@ function SearchPageContent() {
       }
     }
 
+    if (!matchesTrackingFilter(student, trackingFilter, trackingData)) {
+      return false;
+    }
+
     return true;
   });
 
@@ -428,6 +486,7 @@ function SearchPageContent() {
           setSelectedYear("all");
           setAttendanceFilter("all");
           setPickupTimeFilter("all");
+          setTrackingFilter("all");
         }}
       />
 

--- a/frontend/src/app/[tenant]/(protected)/students/search/tracking-filter.test.ts
+++ b/frontend/src/app/[tenant]/(protected)/students/search/tracking-filter.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect } from "vitest";
+import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
+import {
+  parseTrackingFilter,
+  matchesTrackingFilter,
+  trackingFilterChipLabel,
+  resolveTrackingFilterAfterLabelChange,
+  type TrackingFilter,
+} from "./tracking-filter";
+
+describe("parseTrackingFilter", () => {
+  it('returns { kind: "all" } for "all"', () => {
+    expect(parseTrackingFilter("all")).toEqual({ kind: "all" });
+  });
+
+  it('returns { kind: "none_visited" } for "none_visited"', () => {
+    expect(parseTrackingFilter("none_visited")).toEqual({
+      kind: "none_visited",
+    });
+  });
+
+  it("parses a valid missing:N value", () => {
+    expect(parseTrackingFilter("missing:0")).toEqual({
+      kind: "missing",
+      idx: 0,
+    });
+    expect(parseTrackingFilter("missing:2")).toEqual({
+      kind: "missing",
+      idx: 2,
+    });
+  });
+
+  it('rejects "missing:" with an empty index', () => {
+    // Guards against Number("") === 0 silently matching the first label.
+    expect(parseTrackingFilter("missing:")).toEqual({ kind: "invalid" });
+  });
+
+  it("rejects non-numeric indices", () => {
+    expect(parseTrackingFilter("missing:abc")).toEqual({ kind: "invalid" });
+    expect(parseTrackingFilter("missing:-1")).toEqual({ kind: "invalid" });
+    expect(parseTrackingFilter("missing:1.5")).toEqual({ kind: "invalid" });
+  });
+
+  it("rejects unknown values", () => {
+    expect(parseTrackingFilter("")).toEqual({ kind: "invalid" });
+    expect(parseTrackingFilter("foobar")).toEqual({ kind: "invalid" });
+  });
+});
+
+describe("matchesTrackingFilter", () => {
+  const data: TrackingIndicatorsResponse = {
+    labels: ["Hausaufgaben", "Mensa"],
+    results: {
+      "1": [true, true], // both done
+      "2": [true, false], // HA done, Mensa pending
+      "3": [false, true], // HA pending, Mensa done
+      "4": [false, false], // neither
+    },
+  };
+
+  describe('filter "all"', () => {
+    it("keeps every student regardless of tracking state", () => {
+      expect(matchesTrackingFilter({ id: "1" }, "all", data)).toBe(true);
+      expect(matchesTrackingFilter({ id: "999" }, "all", data)).toBe(true);
+      expect(matchesTrackingFilter({ id: "1" }, "all", undefined)).toBe(true);
+    });
+
+    it("keeps redacted students under 'all'", () => {
+      expect(
+        matchesTrackingFilter({ id: "1", has_full_access: false }, "all", data),
+      ).toBe(true);
+    });
+  });
+
+  describe("redaction (has_full_access === false)", () => {
+    it("hides redacted students when a tracking filter is active", () => {
+      expect(
+        matchesTrackingFilter(
+          { id: "4", has_full_access: false },
+          "none_visited",
+          data,
+        ),
+      ).toBe(false);
+      expect(
+        matchesTrackingFilter(
+          { id: "4", has_full_access: false },
+          "missing:0",
+          data,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("stale/missing tracking data (SWR revalidation)", () => {
+    it("hides students whose id is not in the results map", () => {
+      expect(matchesTrackingFilter({ id: "999" }, "none_visited", data)).toBe(
+        false,
+      );
+      expect(matchesTrackingFilter({ id: "999" }, "missing:0", data)).toBe(
+        false,
+      );
+    });
+
+    it("hides all students when trackingData is undefined", () => {
+      expect(
+        matchesTrackingFilter({ id: "1" }, "none_visited", undefined),
+      ).toBe(false);
+      expect(matchesTrackingFilter({ id: "1" }, "missing:0", undefined)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('filter "none_visited"', () => {
+    it("keeps students with every indicator false", () => {
+      expect(matchesTrackingFilter({ id: "4" }, "none_visited", data)).toBe(
+        true,
+      );
+    });
+
+    it("hides students with at least one indicator true", () => {
+      expect(matchesTrackingFilter({ id: "1" }, "none_visited", data)).toBe(
+        false,
+      );
+      expect(matchesTrackingFilter({ id: "2" }, "none_visited", data)).toBe(
+        false,
+      );
+      expect(matchesTrackingFilter({ id: "3" }, "none_visited", data)).toBe(
+        false,
+      );
+    });
+
+    it("hides everyone when no labels are configured", () => {
+      const emptyLabels: TrackingIndicatorsResponse = {
+        labels: [],
+        results: { "1": [] },
+      };
+      expect(
+        matchesTrackingFilter({ id: "1" }, "none_visited", emptyLabels),
+      ).toBe(false);
+    });
+  });
+
+  describe('filter "missing:idx"', () => {
+    it("keeps students whose label at idx is false", () => {
+      expect(matchesTrackingFilter({ id: "3" }, "missing:0", data)).toBe(true); // HA pending
+      expect(matchesTrackingFilter({ id: "2" }, "missing:1", data)).toBe(true); // Mensa pending
+      expect(matchesTrackingFilter({ id: "4" }, "missing:0", data)).toBe(true);
+      expect(matchesTrackingFilter({ id: "4" }, "missing:1", data)).toBe(true);
+    });
+
+    it("hides students whose label at idx is true", () => {
+      expect(matchesTrackingFilter({ id: "2" }, "missing:0", data)).toBe(false); // HA done
+      expect(matchesTrackingFilter({ id: "3" }, "missing:1", data)).toBe(false); // Mensa done
+      expect(matchesTrackingFilter({ id: "1" }, "missing:0", data)).toBe(false);
+      expect(matchesTrackingFilter({ id: "1" }, "missing:1", data)).toBe(false);
+    });
+
+    it("hides everyone when idx is out of range (stale after admin removed a label)", () => {
+      expect(matchesTrackingFilter({ id: "4" }, "missing:2", data)).toBe(false);
+      expect(matchesTrackingFilter({ id: "4" }, "missing:99", data)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("defensive: results array shorter than labels", () => {
+    // Backend guarantees results.length === labels.length, but document the
+    // fallback: missing slots are treated as undefined (falsy), so a short array
+    // with no truthy entries still counts as "none_visited", and missing:<idx>
+    // beyond the array reads undefined !== true → shown.
+    const short: TrackingIndicatorsResponse = {
+      labels: ["A", "B"],
+      results: { "1": [true], "2": [false] },
+    };
+
+    it("keeps a student under missing:<oob> because results[oob] is undefined", () => {
+      expect(matchesTrackingFilter({ id: "1" }, "missing:1", short)).toBe(true);
+    });
+
+    it("hides a student under none_visited if any present entry is true", () => {
+      expect(matchesTrackingFilter({ id: "1" }, "none_visited", short)).toBe(
+        false,
+      );
+    });
+
+    it("keeps a student under none_visited if every present entry is false", () => {
+      expect(matchesTrackingFilter({ id: "2" }, "none_visited", short)).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("invalid filter values", () => {
+    it("hides everyone on garbage input", () => {
+      expect(
+        matchesTrackingFilter({ id: "4" }, "garbage" as TrackingFilter, data),
+      ).toBe(false);
+    });
+  });
+});
+
+describe("trackingFilterChipLabel", () => {
+  const labels = ["Hausaufgaben", "Mensa"];
+
+  it('returns null for "all" (chip should not render)', () => {
+    expect(trackingFilterChipLabel("all", labels)).toBeNull();
+  });
+
+  it('returns "Noch nichts erledigt" for none_visited', () => {
+    expect(trackingFilterChipLabel("none_visited", labels)).toBe(
+      "Noch nichts erledigt",
+    );
+  });
+
+  it("returns Noch nicht in <label> for a valid missing:idx", () => {
+    expect(trackingFilterChipLabel("missing:0", labels)).toBe(
+      "Noch nicht in Hausaufgaben",
+    );
+    expect(trackingFilterChipLabel("missing:1", labels)).toBe(
+      "Noch nicht in Mensa",
+    );
+  });
+
+  it("returns null when missing:idx points past the labels array", () => {
+    expect(trackingFilterChipLabel("missing:5", labels)).toBeNull();
+  });
+
+  it("returns null for invalid filter values", () => {
+    expect(
+      trackingFilterChipLabel("garbage" as TrackingFilter, labels),
+    ).toBeNull();
+  });
+});
+
+describe("resolveTrackingFilterAfterLabelChange", () => {
+  const data: TrackingIndicatorsResponse = {
+    labels: ["Hausaufgaben", "Mensa"],
+    results: {},
+  };
+
+  it("returns the filter unchanged while trackingData is still loading", () => {
+    expect(resolveTrackingFilterAfterLabelChange("missing:0", undefined)).toBe(
+      "missing:0",
+    );
+    expect(
+      resolveTrackingFilterAfterLabelChange("none_visited", undefined),
+    ).toBe("none_visited");
+  });
+
+  it('leaves "all" alone in every state', () => {
+    expect(resolveTrackingFilterAfterLabelChange("all", undefined)).toBe("all");
+    expect(resolveTrackingFilterAfterLabelChange("all", data)).toBe("all");
+    expect(
+      resolveTrackingFilterAfterLabelChange("all", {
+        labels: [],
+        results: {},
+      }),
+    ).toBe("all");
+  });
+
+  it("leaves a valid missing:idx and none_visited unchanged", () => {
+    expect(resolveTrackingFilterAfterLabelChange("missing:0", data)).toBe(
+      "missing:0",
+    );
+    expect(resolveTrackingFilterAfterLabelChange("missing:1", data)).toBe(
+      "missing:1",
+    );
+    expect(resolveTrackingFilterAfterLabelChange("none_visited", data)).toBe(
+      "none_visited",
+    );
+  });
+
+  it('resets to "all" when labels shrink past the selected index', () => {
+    expect(resolveTrackingFilterAfterLabelChange("missing:5", data)).toBe(
+      "all",
+    );
+    expect(resolveTrackingFilterAfterLabelChange("missing:2", data)).toBe(
+      "all",
+    );
+  });
+
+  it('resets to "all" when labels are empty', () => {
+    const empty: TrackingIndicatorsResponse = { labels: [], results: {} };
+    expect(resolveTrackingFilterAfterLabelChange("missing:0", empty)).toBe(
+      "all",
+    );
+    expect(resolveTrackingFilterAfterLabelChange("none_visited", empty)).toBe(
+      "all",
+    );
+  });
+
+  it('resets to "all" on invalid filter input', () => {
+    expect(
+      resolveTrackingFilterAfterLabelChange("garbage" as TrackingFilter, data),
+    ).toBe("all");
+  });
+});

--- a/frontend/src/app/[tenant]/(protected)/students/search/tracking-filter.ts
+++ b/frontend/src/app/[tenant]/(protected)/students/search/tracking-filter.ts
@@ -1,0 +1,90 @@
+import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
+
+export type TrackingFilter = "all" | "none_visited" | `missing:${number}`;
+
+export type ParsedTrackingFilter =
+  | { readonly kind: "all" }
+  | { readonly kind: "none_visited" }
+  | { readonly kind: "missing"; readonly idx: number }
+  | { readonly kind: "invalid" };
+
+const MISSING_PATTERN = /^missing:(\d+)$/;
+
+export function parseTrackingFilter(value: string): ParsedTrackingFilter {
+  if (value === "all") return { kind: "all" };
+  if (value === "none_visited") return { kind: "none_visited" };
+  const match = MISSING_PATTERN.exec(value);
+  // \d+ guarantees a non-empty digit string, so Number() cannot produce NaN here.
+  if (match) return { kind: "missing", idx: Number(match[1]) };
+  return { kind: "invalid" };
+}
+
+interface StudentLike {
+  readonly id: string;
+  readonly has_full_access?: boolean;
+}
+
+// Returns true if the student should be shown under the given tracking filter.
+// Redacted students (has_full_access === false) are always hidden when the filter
+// is active, matching the card-render rule that hides indicators for them.
+// Students whose tracking row hasn't arrived yet (SWR keepPreviousData during
+// revalidation) are treated as unknown → hidden, to avoid false positives.
+export function matchesTrackingFilter(
+  student: StudentLike,
+  filter: TrackingFilter,
+  trackingData: TrackingIndicatorsResponse | undefined,
+): boolean {
+  const parsed = parseTrackingFilter(filter);
+  if (parsed.kind === "all") return true;
+  if (parsed.kind === "invalid") return false;
+
+  if (student.has_full_access === false) return false;
+
+  const results = trackingData?.results?.[student.id];
+  if (!results) return false;
+
+  const labelCount = trackingData?.labels?.length ?? 0;
+
+  if (parsed.kind === "none_visited") {
+    if (labelCount === 0) return false;
+    return results.every((r) => !r);
+  }
+
+  // parsed.kind === "missing"
+  if (parsed.idx < 0 || parsed.idx >= labelCount) return false;
+  return results[parsed.idx] !== true;
+}
+
+// Returns the German chip label for an active tracking filter, or null when
+// the filter is "all" / invalid / points at a label index that no longer exists.
+// Centralises the chip copy so the dropdown option label and the active-filter
+// chip can't drift apart.
+export function trackingFilterChipLabel(
+  filter: TrackingFilter,
+  labels: readonly string[],
+): string | null {
+  const parsed = parseTrackingFilter(filter);
+  if (parsed.kind === "none_visited") return "Noch nichts erledigt";
+  if (parsed.kind === "missing") {
+    const lbl = labels[parsed.idx];
+    return lbl ? `Noch nicht in ${lbl}` : null;
+  }
+  return null;
+}
+
+// Decides what trackingFilter should be after the configured labels change
+// (admin add/remove/disable). Returns the input unchanged while tracking data
+// is still loading so a pre-set filter isn't wiped on mount. Callers should
+// only invoke setTrackingFilter when the return value differs from `filter`.
+export function resolveTrackingFilterAfterLabelChange(
+  filter: TrackingFilter,
+  trackingData: TrackingIndicatorsResponse | undefined,
+): TrackingFilter {
+  if (trackingData === undefined) return filter;
+  const labelCount = trackingData.labels?.length ?? 0;
+  const parsed = parseTrackingFilter(filter);
+  if (parsed.kind === "all") return filter;
+  if (parsed.kind === "invalid" || labelCount === 0) return "all";
+  if (parsed.kind === "missing" && parsed.idx >= labelCount) return "all";
+  return filter;
+}


### PR DESCRIPTION
## Summary

- New filter **Aktivitäten heute** in der Kindersuche. Options: `Alle Aktivitäten heute` / `Noch nicht in <Label>` (eine pro konfiguriertem Tracking-Indikator) / `Noch nichts erledigt`.
- Dropdown erscheint nur, wenn mindestens ein Tracking-Indikator konfiguriert ist. Reine Frontend-Änderung — nutzt die `/tracking-indicators`-Antwort, die bereits für die Kacheln geladen wird.
- Filterlogik in separates, rein-funktionales Modul `tracking-filter.ts` ausgelagert; Unit-Tests + RTL-Test auf `page.tsx`.

## Test plan

- [ ] Kindersuche öffnen → Dropdown **Aktivitäten heute** erscheint nach **Abholzeit**
- [ ] `Noch nicht in Hausaufgaben` wählen → Liste filtert korrekt; Chip zeigt **Noch nicht in Hausaufgaben**; Chip-X setzt zurück
- [ ] `Noch nicht in Mensa` analog
- [ ] `Noch nichts erledigt` zeigt nur Kinder, die heute weder Mensa noch Hausaufgaben hatten
- [ ] `Alle zurücksetzen` entfernt den Tracking-Filter zusammen mit den übrigen
- [ ] In den Einstellungen Tracking-Indikatoren deaktivieren → Dropdown verschwindet, laufender Filter wird stillschweigend zurückgesetzt