### PR TITLE
WP-B14: GDPR cleanup job for timetable data

### DIFF
--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -74,6 +74,10 @@ func NewServer(logger *slog.Logger) (*Server, error) {
 		if api.Services.Materialization != nil {
 			srv.scheduler.SetMaterializer(api.Services.Materialization)
 		}
+		// WP-B14: timetable GDPR cleanup. Nil service → task does not register.
+		if api.Services.TimetableCleanup != nil {
+			srv.scheduler.SetTimetableCleanup(api.Services.TimetableCleanup)
+		}
 		// WP-B9: overdue instance tick. Requires both the ActivityInstance
 		// repo and a broadcaster — either missing disables the tick.
 		if api.repos != nil && api.Services.RealtimeHub != nil {

--- a/backend/cmd/cleanup.go
+++ b/backend/cmd/cleanup.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"text/tabwriter"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/services/active"
+	"github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/spf13/cobra"
 )
 
@@ -35,7 +38,34 @@ var cleanupCmd = &cobra.Command{
 	Long: `Clean up expired data based on retention policies configured in privacy consents.
 This command will delete visit records that are older than the configured retention period for each student.
 
-Available subcommands: visits, preview, stats, tokens, invitations, rate-limits, attendance, sessions, supervisors.`,
+Available subcommands: visits, preview, stats, tokens, invitations, rate-limits, attendance, sessions, supervisors, timetable.`,
+}
+
+// cleanupTimetableCmd represents the timetable subcommand (WP-B14).
+var cleanupTimetableCmd = &cobra.Command{
+	Use:   "timetable",
+	Short: "Delete expired timetable instances + exceptions (GDPR retention)",
+	Long: `Delete schedule.activity_instances (CASCADE → instance_staff + instance_students)
+and schedule.activity_exceptions older than gdpr.timetable_retention_days for each
+active tenant. Writes per-student audit rows to audit.data_deletions before the
+deletes; exceptions carry no PII and are slog-only.`,
+	RunE: runCleanupTimetable,
+}
+
+// cleanupTimetablePreviewCmd shows what would be deleted without deleting.
+var cleanupTimetablePreviewCmd = &cobra.Command{
+	Use:   "preview",
+	Short: "Preview timetable cleanup without deleting",
+	Long:  `Count activity_instances, activity_exceptions, and distinct affected students per tenant.`,
+	RunE:  runCleanupTimetablePreview,
+}
+
+// cleanupTimetableStatsCmd shows table totals and oldest dates.
+var cleanupTimetableStatsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show timetable retention statistics",
+	Long:  `Total row counts and oldest timestamps across schedule.activity_instances and schedule.activity_exceptions per tenant.`,
+	RunE:  runCleanupTimetableStats,
 }
 
 // cleanupVisitsCmd represents the visits subcommand
@@ -132,6 +162,15 @@ func init() {
 	cleanupCmd.AddCommand(cleanupAttendanceCmd)
 	cleanupCmd.AddCommand(cleanupSessionsCmd)
 	cleanupCmd.AddCommand(cleanupSupervisorsCmd)
+	cleanupCmd.AddCommand(cleanupTimetableCmd)
+	cleanupTimetableCmd.AddCommand(cleanupTimetablePreviewCmd)
+	cleanupTimetableCmd.AddCommand(cleanupTimetableStatsCmd)
+
+	// Flags for timetable commands
+	cleanupTimetableCmd.Flags().BoolVar(&dryRun, flagDryRun, false, flagDescDryRun)
+	cleanupTimetableCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, flagDescShowDetails)
+	cleanupTimetablePreviewCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, flagDescShowDetails)
+	cleanupTimetableStatsCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, flagDescShowDetails)
 
 	// Flags for cleanup visits command
 	cleanupVisitsCmd.Flags().BoolVar(&dryRun, flagDryRun, false, "Show what would be deleted without deleting")
@@ -653,4 +692,162 @@ func printStaffBreakdown(header string, countHeader string, data map[int64]int) 
 	if err := w.Flush(); err != nil {
 		log.Printf(errFlushWriter, err)
 	}
+}
+
+// --- Timetable GDPR cleanup (WP-B14) ---
+
+func runCleanupTimetable(_ *cobra.Command, _ []string) error {
+	ctx, err := newCleanupContextWithTimetableCleanup()
+	if err != nil {
+		return err
+	}
+	defer ctx.Close()
+
+	if dryRun {
+		return forEachTenantTimetablePreview(ctx)
+	}
+	return forEachTenantTimetableCleanup(ctx)
+}
+
+func runCleanupTimetablePreview(_ *cobra.Command, _ []string) error {
+	ctx, err := newCleanupContextWithTimetableCleanup()
+	if err != nil {
+		return err
+	}
+	defer ctx.Close()
+	return forEachTenantTimetablePreview(ctx)
+}
+
+func runCleanupTimetableStats(_ *cobra.Command, _ []string) error {
+	ctx, err := newCleanupContextWithTimetableCleanup()
+	if err != nil {
+		return err
+	}
+	defer ctx.Close()
+	return forEachTenantTimetableStats(ctx)
+}
+
+// forEachTenantTimetableCleanup runs the actual DELETE per tenant, using the
+// same tenant.ForEachActive helper the scheduler uses — so CLI and scheduler
+// agree on tenant iteration semantics.
+func forEachTenantTimetableCleanup(cc *cleanupContext) error {
+	totalInstances, totalExceptions, totalStudents := 0, 0, 0
+	tenantCount := 0
+	errs := make([]error, 0)
+
+	err := tenant.ForEachActive(context.Background(), cc.DB, cc.RepoFactory.School,
+		slog.Default(), "cli-timetable-cleanup",
+		func(txCtx context.Context, tenantID int64) error {
+			tenantCount++
+			result, err := cc.TimetableCleanupService.CleanupExpiredTimetableData(txCtx)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("tenant %d: %w", tenantID, err))
+				return err
+			}
+			totalInstances += result.InstancesDeleted
+			totalExceptions += result.ExceptionsDeleted
+			totalStudents += result.StudentsAffected
+			printTimetableCleanupLine(tenantID, result)
+			return nil
+		})
+	if err != nil {
+		return fmt.Errorf("list active tenants: %w", err)
+	}
+
+	fmt.Println("\nTimetable Cleanup Summary")
+	fmt.Println("=========================")
+	fmt.Printf("Tenants processed:    %d\n", tenantCount)
+	fmt.Printf("Instances deleted:    %d\n", totalInstances)
+	fmt.Printf("Exceptions deleted:   %d\n", totalExceptions)
+	fmt.Printf("Students affected:    %d\n", totalStudents)
+	fmt.Printf("Errors:               %d\n", len(errs))
+	if verbose {
+		for _, e := range errs {
+			fmt.Printf("  - %s\n", e.Error())
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%d tenant(s) failed; see output above", len(errs))
+	}
+	return nil
+}
+
+func forEachTenantTimetablePreview(cc *cleanupContext) error {
+	fmt.Println("DRY RUN MODE - No data will be deleted")
+	fmt.Println("\nTimetable Cleanup Preview")
+	fmt.Println("=========================")
+
+	totalInstances, totalExceptions, totalStudents := 0, 0, 0
+	err := tenant.ForEachActive(context.Background(), cc.DB, cc.RepoFactory.School,
+		slog.Default(), "cli-timetable-preview",
+		func(txCtx context.Context, tenantID int64) error {
+			p, err := cc.TimetableCleanupService.PreviewExpiredTimetableData(txCtx)
+			if err != nil {
+				return err
+			}
+			totalInstances += p.InstancesToDelete
+			totalExceptions += p.ExceptionsToDelete
+			totalStudents += p.StudentsAffected
+			printTimetablePreviewLine(tenantID, p)
+			return nil
+		})
+	if err != nil {
+		return fmt.Errorf("list active tenants: %w", err)
+	}
+
+	fmt.Printf("\nTOTAL: %d instances, %d exceptions, %d students across all tenants\n",
+		totalInstances, totalExceptions, totalStudents)
+	return nil
+}
+
+func forEachTenantTimetableStats(cc *cleanupContext) error {
+	fmt.Println("Timetable Retention Statistics")
+	fmt.Println("==============================")
+
+	err := tenant.ForEachActive(context.Background(), cc.DB, cc.RepoFactory.School,
+		slog.Default(), "cli-timetable-stats",
+		func(txCtx context.Context, tenantID int64) error {
+			stats, err := cc.TimetableCleanupService.GetStats(txCtx)
+			if err != nil {
+				return err
+			}
+			printTimetableStatsLine(tenantID, stats)
+			return nil
+		})
+	if err != nil {
+		return fmt.Errorf("list active tenants: %w", err)
+	}
+	return nil
+}
+
+func printTimetableCleanupLine(tenantID int64, r *schedule.TimetableCleanupResult) {
+	fmt.Printf("[tenant %d] instances=%d exceptions=%d students=%d retention=%dd cutoff=%s duration_ms=%d\n",
+		tenantID, r.InstancesDeleted, r.ExceptionsDeleted, r.StudentsAffected,
+		r.RetentionDays, r.CutoffDate.Format(dateFormat), r.DurationMS)
+}
+
+func printTimetablePreviewLine(tenantID int64, p *schedule.TimetableCleanupPreview) {
+	fmt.Printf("[tenant %d] would-delete instances=%d exceptions=%d students=%d retention=%dd cutoff=%s",
+		tenantID, p.InstancesToDelete, p.ExceptionsToDelete, p.StudentsAffected,
+		p.RetentionDays, p.CutoffDate.Format(dateFormat))
+	if p.OldestInstance != nil {
+		fmt.Printf(" oldest_instance=%s", p.OldestInstance.Format(dateFormat))
+	}
+	if p.OldestException != nil {
+		fmt.Printf(" oldest_exception=%s", p.OldestException.Format(dateFormat))
+	}
+	fmt.Println()
+}
+
+func printTimetableStatsLine(tenantID int64, s *schedule.TimetableCleanupStats) {
+	fmt.Printf("[tenant %d] instances_total=%d exceptions_total=%d retention=%dd cutoff=%s",
+		tenantID, s.TotalInstances, s.TotalExceptions,
+		s.RetentionDays, s.CutoffDate.Format(dateFormat))
+	if s.OldestInstance != nil {
+		fmt.Printf(" oldest_instance=%s", s.OldestInstance.Format(dateFormat))
+	}
+	if s.OldestException != nil {
+		fmt.Printf(" oldest_exception=%s", s.OldestException.Format(dateFormat))
+	}
+	fmt.Println()
 }

--- a/backend/cmd/cleanup_helpers.go
+++ b/backend/cmd/cleanup_helpers.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/database"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	auditRepo "github.com/moto-nrw/project-phoenix/database/repositories/audit"
 	"github.com/moto-nrw/project-phoenix/services"
 	"github.com/moto-nrw/project-phoenix/services/active"
+	"github.com/moto-nrw/project-phoenix/services/schedule"
 	"github.com/uptrace/bun"
 )
 
@@ -34,10 +36,11 @@ const (
 // Note: Context should be passed as a parameter to methods that need it,
 // rather than stored in the struct (per Go best practices).
 type cleanupContext struct {
-	DB             *bun.DB
-	RepoFactory    *repositories.Factory
-	ServiceFactory *services.Factory
-	CleanupService active.CleanupService
+	DB                      *bun.DB
+	RepoFactory             *repositories.Factory
+	ServiceFactory          *services.Factory
+	CleanupService          active.CleanupService
+	TimetableCleanupService schedule.TimetableCleanupService
 }
 
 // newCleanupContext initializes database and repository factory.
@@ -91,6 +94,24 @@ func newCleanupContextWithCleanupService() (*cleanupContext, error) {
 		ctx.DB,
 	)
 
+	return ctx, nil
+}
+
+// newCleanupContextWithTimetableCleanup initializes database + timetable
+// GDPR cleanup service (WP-B14). Uses settingsService from the full service
+// factory so tenant overrides of gdpr.timetable_retention_days are honored.
+// The caller must call Close() when done.
+func newCleanupContextWithTimetableCleanup() (*cleanupContext, error) {
+	ctx, err := newCleanupContextWithServices()
+	if err != nil {
+		return nil, err
+	}
+	ctx.TimetableCleanupService = schedule.NewTimetableCleanupService(
+		ctx.DB,
+		auditRepo.NewDataDeletionRepository(ctx.DB),
+		ctx.ServiceFactory.Settings,
+		slog.Default().With("service", "timetable-cleanup-cli"),
+	)
 	return ctx, nil
 }
 

--- a/backend/cmd/cleanup_test.go
+++ b/backend/cmd/cleanup_test.go
@@ -925,10 +925,11 @@ func TestCleanupCmd_HasSubcommands(t *testing.T) {
 	assert.Contains(t, names, "attendance")
 	assert.Contains(t, names, "sessions")
 	assert.Contains(t, names, "supervisors")
+	assert.Contains(t, names, "timetable") // WP-B14
 }
 
 func TestCleanupCmd_SubcommandCount(t *testing.T) {
-	assert.Len(t, cleanupCmd.Commands(), 9, "cleanupCmd should have exactly 9 subcommands")
+	assert.Len(t, cleanupCmd.Commands(), 10, "cleanupCmd should have exactly 10 subcommands")
 }
 
 func TestCleanupVisitsCmd_Metadata(t *testing.T) {
@@ -954,6 +955,12 @@ func TestCleanupTokensCmd_Metadata(t *testing.T) {
 	assert.Equal(t, "tokens", cleanupTokensCmd.Use)
 	assert.Contains(t, cleanupTokensCmd.Short, "expired authentication tokens")
 	assert.NotNil(t, cleanupTokensCmd.RunE)
+}
+
+func TestCleanupTimetableCmd_Metadata(t *testing.T) {
+	assert.Equal(t, "timetable", cleanupTimetableCmd.Use)
+	assert.Contains(t, cleanupTimetableCmd.Short, "timetable")
+	assert.NotNil(t, cleanupTimetableCmd.RunE)
 }
 
 func TestCleanupInvitationsCmd_Metadata(t *testing.T) {

--- a/backend/models/audit/data_deletion.go
+++ b/backend/models/audit/data_deletion.go
@@ -22,9 +22,10 @@ type DataDeletion struct {
 
 // DeletionType constants
 const (
-	DeletionTypeVisitRetention = "visit_retention"
-	DeletionTypeManual         = "manual"
-	DeletionTypeGDPRRequest    = "gdpr_request"
+	DeletionTypeVisitRetention     = "visit_retention"
+	DeletionTypeManual             = "manual"
+	DeletionTypeGDPRRequest        = "gdpr_request"
+	DeletionTypeTimetableRetention = "timetable_retention"
 )
 
 // TableName returns the database table name
@@ -44,7 +45,7 @@ func (dd *DataDeletion) Validate() error {
 
 	// Validate deletion type
 	switch dd.DeletionType {
-	case DeletionTypeVisitRetention, DeletionTypeManual, DeletionTypeGDPRRequest:
+	case DeletionTypeVisitRetention, DeletionTypeManual, DeletionTypeGDPRRequest, DeletionTypeTimetableRetention:
 		// Valid types
 	default:
 		return errors.New("invalid deletion type")

--- a/backend/models/audit/data_deletion_test.go
+++ b/backend/models/audit/data_deletion_test.go
@@ -252,4 +252,17 @@ func TestDeletionTypeConstants(t *testing.T) {
 	if DeletionTypeGDPRRequest != "gdpr_request" {
 		t.Errorf("DeletionTypeGDPRRequest = %q, want gdpr_request", DeletionTypeGDPRRequest)
 	}
+	if DeletionTypeTimetableRetention != "timetable_retention" {
+		t.Errorf("DeletionTypeTimetableRetention = %q, want timetable_retention", DeletionTypeTimetableRetention)
+	}
+}
+
+// TestDataDeletion_Validate_AcceptsTimetableRetentionType ensures the new
+// DeletionTypeTimetableRetention constant is whitelisted by Validate(). Guards
+// against the "added the constant but forgot to update the switch" regression.
+func TestDataDeletion_Validate_AcceptsTimetableRetentionType(t *testing.T) {
+	dd := NewDataDeletion(42, DeletionTypeTimetableRetention, 1, "system")
+	if err := dd.Validate(); err != nil {
+		t.Fatalf("Validate() with timetable_retention type failed: %v", err)
+	}
 }

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -59,6 +59,7 @@ type Factory struct {
 	ArrivalSchedule          schedule.ArrivalScheduleService
 	CalendarPeriod           schedule.CalendarPeriodService
 	Materialization          schedule.MaterializationService
+	TimetableCleanup         schedule.TimetableCleanupService
 	Instance                 schedule.InstanceService
 	Users                    users.PersonService
 	CaregiverCapability      users.CaregiverCapabilityService
@@ -359,6 +360,17 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		logger.With("service", "materialization"),
 	)
 
+	// Initialize timetable GDPR cleanup service (WP-B14). Deletes
+	// schedule.activity_instances (CASCADE → instance_staff + instance_students)
+	// and schedule.activity_exceptions older than the tenant's retention window.
+	// Per-student audit rows via DataDeletion; exceptions slog-only.
+	timetableCleanupService := schedule.NewTimetableCleanupService(
+		db,
+		repos.DataDeletion,
+		settingsService,
+		logger.With("service", "timetable-cleanup"),
+	)
+
 	// Initialize instance lifecycle service (WP-B9). Drives the state machine
 	// on schedule.activity_instances and its bridge to active.groups. Takes
 	// the active service as a dependency (for EndActivitySession) — when the
@@ -612,6 +624,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		ArrivalSchedule:          arrivalScheduleService,
 		CalendarPeriod:           calendarPeriodService,
 		Materialization:          materializationService,
+		TimetableCleanup:         timetableCleanupService,
 		Instance:                 instanceService,
 		Users:                    usersService,
 		CaregiverCapability:      caregiverCapabilityService,

--- a/backend/services/schedule/timetable_cleanup_gaps_test.go
+++ b/backend/services/schedule/timetable_cleanup_gaps_test.go
@@ -1,0 +1,340 @@
+package schedule_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	auditRepoPkg "github.com/moto-nrw/project-phoenix/database/repositories/audit"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	configModels "github.com/moto-nrw/project-phoenix/models/config"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// --- SettingsService stub ---
+
+// stubSettingsService is a minimal configSvc.SettingsService that lets tests
+// exercise the resolveRetentionDays branches without a real settings DB.
+type stubSettingsService struct {
+	hasOverride    bool
+	hasOverrideErr error
+	intVal         int
+	intErr         error
+}
+
+func (s *stubSettingsService) GetSchema(context.Context, []string) (*configSvc.SettingsSchema, error) {
+	return nil, nil
+}
+func (s *stubSettingsService) GetSchemaForOperator(context.Context, []string) (*configSvc.SettingsSchema, error) {
+	return nil, nil
+}
+func (s *stubSettingsService) Resolve(context.Context, string) (any, error) { return nil, nil }
+func (s *stubSettingsService) ResolveString(context.Context, string) (string, error) {
+	return "", nil
+}
+func (s *stubSettingsService) ResolveStringForTenant(context.Context, int64, string) (string, error) {
+	return "", nil
+}
+func (s *stubSettingsService) ResolveBool(context.Context, string) (bool, error) { return false, nil }
+func (s *stubSettingsService) ResolveInt(_ context.Context, _ string) (int, error) {
+	return s.intVal, s.intErr
+}
+func (s *stubSettingsService) HasTenantOverride(_ context.Context, _ string) (bool, error) {
+	return s.hasOverride, s.hasOverrideErr
+}
+func (s *stubSettingsService) SetValue(context.Context, string, any, *int64, []string) error {
+	return nil
+}
+func (s *stubSettingsService) ResetValue(context.Context, string, *int64, []string) error {
+	return nil
+}
+func (s *stubSettingsService) GetLoginImageURL(context.Context, int64) (string, error) {
+	return "", nil
+}
+func (s *stubSettingsService) SetLoginImageURL(context.Context, int64, string) (string, error) {
+	return "", nil
+}
+func (s *stubSettingsService) ClearLoginImageURL(context.Context, int64) (string, error) {
+	return "", nil
+}
+
+// buildSvc wires a TimetableCleanupService with the given settings stub.
+func buildSvc(db *bun.DB, settings configSvc.SettingsService) scheduleSvc.TimetableCleanupService {
+	return scheduleSvc.NewTimetableCleanupService(
+		db,
+		auditRepoPkg.NewDataDeletionRepository(db),
+		settings,
+		slog.Default(),
+	)
+}
+
+// -----------------------------------------------------------------------------
+// Missing-tenant-context guards for all three public methods.
+// -----------------------------------------------------------------------------
+
+func TestCleanupExpiredTimetableData_NoTenantInContext_ReturnsError(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	svc := buildSvc(db, nil)
+
+	_, err := svc.CleanupExpiredTimetableData(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no tenant in context")
+}
+
+func TestPreviewExpiredTimetableData_NoTenantInContext_ReturnsError(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	svc := buildSvc(db, nil)
+
+	_, err := svc.PreviewExpiredTimetableData(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no tenant in context")
+}
+
+func TestGetStats_NoTenantInContext_ReturnsError(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	svc := buildSvc(db, nil)
+
+	_, err := svc.GetStats(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no tenant in context")
+}
+
+// -----------------------------------------------------------------------------
+// PreviewExpiredTimetableData happy path — counts without deleting, returns
+// oldest timestamps. Exercises scanOldestTimestamp.
+// -----------------------------------------------------------------------------
+
+func TestPreviewExpiredTimetableData_CountsOldRows(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := buildSvc(f.db, nil)
+
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	recent := time.Now().UTC().AddDate(0, 0, -30)
+
+	oldInstID := f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+	recentInstID := f.newInstance(t, recent, scheduleModels.InstanceStatusPlanned, roomID, nil)
+
+	preview, err := svc.PreviewExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, preview.InstancesToDelete, "1 old instance counted")
+	assert.Equal(t, 0, preview.ExceptionsToDelete)
+	assert.Equal(t, 365, preview.RetentionDays)
+	require.NotNil(t, preview.OldestInstance, "oldest instance timestamp must be populated when rows match")
+
+	// Preview MUST NOT mutate the DB.
+	assertRowExists(t, f, "schedule.activity_instances", oldInstID, true, "preview must not delete")
+	assertRowExists(t, f, "schedule.activity_instances", recentInstID, true)
+}
+
+func TestPreviewExpiredTimetableData_EmptyTenant_OldestIsNil(t *testing.T) {
+	f, _ := setupFixture(t)
+	svc := buildSvc(f.db, nil)
+
+	// No data → counts are 0, oldest pointers are nil.
+	preview, err := svc.PreviewExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, preview.InstancesToDelete)
+	assert.Equal(t, 0, preview.ExceptionsToDelete)
+	assert.Nil(t, preview.OldestInstance, "no matching rows → nil oldest")
+	assert.Nil(t, preview.OldestException)
+}
+
+// -----------------------------------------------------------------------------
+// GetStats — total row counts + oldest timestamps regardless of window.
+// -----------------------------------------------------------------------------
+
+func TestGetStats_ReportsTotals(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := buildSvc(f.db, nil)
+
+	// Seed: 2 instances (1 old, 1 recent), both count toward totals.
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	recent := time.Now().UTC().AddDate(0, 0, -30)
+	f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+	f.newInstance(t, recent, scheduleModels.InstanceStatusPlanned, roomID, nil)
+
+	stats, err := svc.GetStats(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, stats.TotalInstances, "stats counts all instances regardless of age")
+	assert.Equal(t, 0, stats.TotalExceptions)
+	assert.Equal(t, 365, stats.RetentionDays, "retention reflects registry default")
+	require.NotNil(t, stats.OldestInstance, "oldest must be populated when rows exist")
+	assert.Nil(t, stats.OldestException, "no exceptions → nil oldest exception")
+}
+
+// -----------------------------------------------------------------------------
+// resolveRetentionDays — cover the branches not exercised by the existing
+// env-var / nil-settings tests.
+// -----------------------------------------------------------------------------
+
+func TestResolveRetentionDays_TenantOverride_UsesOverriddenValue(t *testing.T) {
+	// HasTenantOverride = true, ResolveInt returns a positive value → use it.
+	f, roomID := setupFixture(t)
+	settings := &stubSettingsService{hasOverride: true, intVal: 42}
+	svc := buildSvc(f.db, settings)
+
+	// Nothing old in this tenant → instances=0, but retention must reflect override.
+	// Insert a 50-day-old instance to verify: 42-day window deletes it, 400-day
+	// registry default would too but 42 is specific.
+	fiftyDaysOld := time.Now().UTC().AddDate(0, 0, -50)
+	f.newInstance(t, fiftyDaysOld, scheduleModels.InstanceStatusCompleted, roomID, nil)
+
+	result, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 42, result.RetentionDays, "tenant override must win over env/default")
+	assert.Equal(t, 1, result.InstancesDeleted, "50-day row past 42-day window")
+}
+
+func TestResolveRetentionDays_HasOverrideError_FallsBackToDefault(t *testing.T) {
+	// HasTenantOverride returns err — Warn-log, skip settings.ResolveInt, fall
+	// through to env var (unset) and finally the final `if s.settings != nil`
+	// block which calls ResolveInt without the gate.
+	f, roomID := setupFixture(t)
+	// Final `if s.settings != nil` path: ResolveInt returns 365 (simulates
+	// registry default). Even though HasTenantOverride errors, resolveInt is
+	// still consulted as a last-ditch resort in the post-env-var block.
+	settings := &stubSettingsService{
+		hasOverrideErr: errors.New("settings DB down"),
+		intVal:         365,
+	}
+	svc := buildSvc(f.db, settings)
+
+	f.newInstance(t, time.Now().UTC().AddDate(0, 0, -400), scheduleModels.InstanceStatusCompleted, roomID, nil)
+
+	result, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 365, result.RetentionDays, "override-check error must fall through to settings default")
+}
+
+func TestResolveRetentionDays_NoOverrideNoEnv_UsesRegistryDefault(t *testing.T) {
+	// HasTenantOverride = false, no env var → the final `if s.settings != nil`
+	// block returns the registry default via ResolveInt.
+	f, _ := setupFixture(t)
+	settings := &stubSettingsService{hasOverride: false, intVal: 180}
+	svc := buildSvc(f.db, settings)
+
+	// Call Preview to inspect RetentionDays without having to seed data.
+	preview, err := svc.PreviewExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 180, preview.RetentionDays, "no tenant override + no env var → registry default via settings.ResolveInt")
+}
+
+func TestResolveRetentionDays_HasOverrideTrue_InvalidValue_FallsThrough(t *testing.T) {
+	// HasTenantOverride = true but ResolveInt returns 0 (simulating a bad
+	// stored value). The service should skip the override and fall through to
+	// the env/default chain — we use the final `if s.settings != nil` block
+	// with intVal > 0 after the bad branch.
+	//
+	// This specifically covers the `v > 0` guard inside the HasTenantOverride
+	// branch (line 331 in the source).
+	f, _ := setupFixture(t)
+	settings := &stubSettingsService{hasOverride: true, intVal: 0}
+	svc := buildSvc(f.db, settings)
+
+	// Override resolves to 0 → both inner guards fail → final `if s.settings != nil`
+	// block is reached. intVal is still 0, so the literal `timetableRetentionDefaultDays`
+	// (365) is the final value.
+	preview, err := svc.PreviewExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 365, preview.RetentionDays, "override with non-positive value falls through to literal default")
+}
+
+// Sanity check — the registered key constant is what the service reads.
+func TestResolveRetentionDays_UsesCorrectConfigKey(t *testing.T) {
+	// Documents the expected key: a regression test would catch someone
+	// renaming KeyGDPRTimetableRetentionDays without updating the service.
+	assert.Equal(t, "gdpr.timetable_retention_days", configModels.KeyGDPRTimetableRetentionDays)
+}
+
+// -----------------------------------------------------------------------------
+// writeStudentAuditRows — nil audit repo must error before any DB write.
+// -----------------------------------------------------------------------------
+
+func TestCleanup_NilAuditRepo_ReturnsError(t *testing.T) {
+	f, roomID := setupFixture(t)
+
+	// Seed one affected student so writeStudentAuditRows has work to do.
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	instID := f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+	stud := testpkg.CreateTestStudent(t, f.db, "Nil", "AuditRepo", "3a")
+	f.studentIDs = append(f.studentIDs, stud.ID)
+	f.attachStudent(t, instID, stud.ID, nil)
+
+	// Build service with nil audit repo.
+	svc := scheduleSvc.NewTimetableCleanupService(f.db, nil, nil, slog.Default())
+
+	_, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "audit repo not configured")
+
+	// The deletes never ran because the audit step failed first.
+	assertRowExists(t, f, "schedule.activity_instances", instID, true)
+}
+
+// -----------------------------------------------------------------------------
+// NewTimetableCleanupService — nil logger substitution path.
+// -----------------------------------------------------------------------------
+
+func TestNewTimetableCleanupService_NilLogger_FallsBackToDefault(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+
+	// Pass nil logger — constructor must substitute slog.Default() so calls
+	// inside the service do not panic.
+	svc := scheduleSvc.NewTimetableCleanupService(
+		db,
+		auditRepoPkg.NewDataDeletionRepository(db),
+		nil,
+		nil,
+	)
+	require.NotNil(t, svc)
+
+	// Exercise a codepath that uses the logger (no tenant → early error return
+	// avoids logger use, so we use a tenant ctx that makes it into slog.Info).
+	ctx := tenant.WithTenantID(context.Background(), 1)
+	_, err := svc.CleanupExpiredTimetableData(ctx)
+	// Real DB under tenant_id=1 with no seeded rows → cleanup succeeds with
+	// zeros. The critical assertion is "no panic".
+	require.NoError(t, err)
+}
+
+// -----------------------------------------------------------------------------
+// Metadata shape — ensure writeStudentAuditRows attaches the sample when there
+// are enough instance IDs (exercises the `len(sample) > 0` branch in the
+// already-partially-covered helper).
+// -----------------------------------------------------------------------------
+
+func TestCleanup_AuditMetadata_HasInstanceIDsSample(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := buildSvc(f.db, nil)
+
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	inst := f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+
+	stud := testpkg.CreateTestStudent(t, f.db, "Sample", "Student", "3a")
+	f.studentIDs = append(f.studentIDs, stud.ID)
+	f.attachStudent(t, inst, stud.ID, nil)
+
+	_, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+
+	var row auditModels.DataDeletion
+	err = f.db.NewSelect().Model(&row).
+		Where("tenant_id = ? AND student_id = ? AND deletion_type = ?",
+			testTenantID, stud.ID, auditModels.DeletionTypeTimetableRetention).
+		Scan(f.ctx)
+	require.NoError(t, err)
+	assert.Contains(t, row.Metadata, "instance_ids_sample")
+
+	// The rows were deleted by the service; tell fixture tracker to skip them.
+	f.instanceIDs = nil
+	f.instStudentIDs = nil
+}

--- a/backend/services/schedule/timetable_cleanup_gaps_test.go
+++ b/backend/services/schedule/timetable_cleanup_gaps_test.go
@@ -173,7 +173,8 @@ func TestGetStats_ReportsTotals(t *testing.T) {
 
 // -----------------------------------------------------------------------------
 // resolveRetentionDays — cover the branches not exercised by the existing
-// env-var / nil-settings tests.
+// nil-settings tests. The chain is: tenant DB override → registry default
+// (both via SettingsService) → literal 365 only when settings is nil.
 // -----------------------------------------------------------------------------
 
 func TestResolveRetentionDays_TenantOverride_UsesOverriddenValue(t *testing.T) {
@@ -182,26 +183,22 @@ func TestResolveRetentionDays_TenantOverride_UsesOverriddenValue(t *testing.T) {
 	settings := &stubSettingsService{hasOverride: true, intVal: 42}
 	svc := buildSvc(f.db, settings)
 
-	// Nothing old in this tenant → instances=0, but retention must reflect override.
-	// Insert a 50-day-old instance to verify: 42-day window deletes it, 400-day
-	// registry default would too but 42 is specific.
+	// Insert a 50-day-old instance to verify: 42-day window deletes it, a
+	// 365-day default would have spared it.
 	fiftyDaysOld := time.Now().UTC().AddDate(0, 0, -50)
 	f.newInstance(t, fiftyDaysOld, scheduleModels.InstanceStatusCompleted, roomID, nil)
 
 	result, err := svc.CleanupExpiredTimetableData(f.ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 42, result.RetentionDays, "tenant override must win over env/default")
+	assert.Equal(t, 42, result.RetentionDays, "tenant override must win over registry default")
 	assert.Equal(t, 1, result.InstancesDeleted, "50-day row past 42-day window")
 }
 
 func TestResolveRetentionDays_HasOverrideError_FallsBackToDefault(t *testing.T) {
-	// HasTenantOverride returns err — Warn-log, skip settings.ResolveInt, fall
-	// through to env var (unset) and finally the final `if s.settings != nil`
-	// block which calls ResolveInt without the gate.
+	// HasTenantOverride returns err — service warn-logs and falls through to
+	// ResolveInt, which returns the registry default even when no override
+	// exists.
 	f, roomID := setupFixture(t)
-	// Final `if s.settings != nil` path: ResolveInt returns 365 (simulates
-	// registry default). Even though HasTenantOverride errors, resolveInt is
-	// still consulted as a last-ditch resort in the post-env-var block.
 	settings := &stubSettingsService{
 		hasOverrideErr: errors.New("settings DB down"),
 		intVal:         365,
@@ -215,9 +212,11 @@ func TestResolveRetentionDays_HasOverrideError_FallsBackToDefault(t *testing.T) 
 	assert.Equal(t, 365, result.RetentionDays, "override-check error must fall through to settings default")
 }
 
-func TestResolveRetentionDays_NoOverrideNoEnv_UsesRegistryDefault(t *testing.T) {
-	// HasTenantOverride = false, no env var → the final `if s.settings != nil`
-	// block returns the registry default via ResolveInt.
+func TestResolveRetentionDays_NoOverride_UsesRegistryDefault(t *testing.T) {
+	// HasTenantOverride = false → service still calls ResolveInt, which
+	// returns the registry default. No tenant override means no per-school
+	// customization; the default 180 (via stub) is what the service should
+	// use.
 	f, _ := setupFixture(t)
 	settings := &stubSettingsService{hasOverride: false, intVal: 180}
 	svc := buildSvc(f.db, settings)
@@ -225,27 +224,20 @@ func TestResolveRetentionDays_NoOverrideNoEnv_UsesRegistryDefault(t *testing.T) 
 	// Call Preview to inspect RetentionDays without having to seed data.
 	preview, err := svc.PreviewExpiredTimetableData(f.ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 180, preview.RetentionDays, "no tenant override + no env var → registry default via settings.ResolveInt")
+	assert.Equal(t, 180, preview.RetentionDays, "no tenant override → registry default via settings.ResolveInt")
 }
 
-func TestResolveRetentionDays_HasOverrideTrue_InvalidValue_FallsThrough(t *testing.T) {
+func TestResolveRetentionDays_ResolveIntReturnsZero_FallsThroughToLiteral(t *testing.T) {
 	// HasTenantOverride = true but ResolveInt returns 0 (simulating a bad
-	// stored value). The service should skip the override and fall through to
-	// the env/default chain — we use the final `if s.settings != nil` block
-	// with intVal > 0 after the bad branch.
-	//
-	// This specifically covers the `v > 0` guard inside the HasTenantOverride
-	// branch (line 331 in the source).
+	// stored value or misconfigured registry default). The `v > 0` guard
+	// rejects it and the function falls through to the literal default 365.
 	f, _ := setupFixture(t)
 	settings := &stubSettingsService{hasOverride: true, intVal: 0}
 	svc := buildSvc(f.db, settings)
 
-	// Override resolves to 0 → both inner guards fail → final `if s.settings != nil`
-	// block is reached. intVal is still 0, so the literal `timetableRetentionDefaultDays`
-	// (365) is the final value.
 	preview, err := svc.PreviewExpiredTimetableData(f.ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 365, preview.RetentionDays, "override with non-positive value falls through to literal default")
+	assert.Equal(t, 365, preview.RetentionDays, "non-positive resolved value falls through to literal default")
 }
 
 // Sanity check — the registered key constant is what the service reads.

--- a/backend/services/schedule/timetable_cleanup_service.go
+++ b/backend/services/schedule/timetable_cleanup_service.go
@@ -26,19 +26,16 @@
 //     to audit.data_deletions — slog-only. The audit writes land BEFORE the
 //     deletes; a failure anywhere rolls back everything atomically.
 //
-//   - Retention resolution: tenant DB override → env var → registry default.
-//     The 365 literal in the service is a last-resort fallback only reached
-//     when both settings service and env var are unavailable; in production
-//     the registry definition in services/config/defaults/timetable.go:142
-//     supplies the default.
+//   - Retention resolution: tenant DB override → registry default. The 365
+//     literal in the service is a last-resort fallback only reached when the
+//     settings service is not wired (tests); in production the registry
+//     definition in services/config/defaults/timetable.go supplies the default.
 package schedule
 
 import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
-	"strconv"
 	"time"
 
 	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
@@ -59,12 +56,6 @@ const auditInstanceIDSampleCap = 10
 // services/config/defaults/timetable.go registers 365 at init time. Kept so
 // the service is callable in tests without settings wiring.
 const timetableRetentionDefaultDays = 365
-
-// timetableRetentionEnvVar is the backward-compat env var for tenants that
-// pre-date the settings system. Per CLAUDE.md, new per-tenant runtime config
-// MUST use the settings system — this env var exists for migration paths and
-// is intentionally not documented in dev.env.example or docker-compose.
-const timetableRetentionEnvVar = "TIMETABLE_RETENTION_DAYS"
 
 // TimetableCleanupResult summarises one cleanup run.
 type TimetableCleanupResult struct {
@@ -118,8 +109,7 @@ type timetableCleanupService struct {
 }
 
 // NewTimetableCleanupService constructs the cleanup service. settings may be
-// nil in tests; when nil, retention resolves via env var or the last-resort
-// default 365.
+// nil in tests; when nil, retention resolves to the last-resort default 365.
 func NewTimetableCleanupService(
 	db *bun.DB,
 	auditRepo audit.DataDeletionRepository,
@@ -312,39 +302,27 @@ func (s *timetableCleanupService) GetStats(ctx context.Context) (*TimetableClean
 
 // --- Internal helpers ---
 
-// resolveRetentionDays picks the tenant's retention days following the
-// documented chain: tenant DB override → env var → registry default.
+// resolveRetentionDays picks the tenant's retention days: tenant DB override
+// → registry default (both via the settings service). The literal fallback
+// is only reached when the settings service is not wired (tests).
 //
-// HasTenantOverride distinguishes "tenant explicitly set a value" from
-// "returning registry default" so the env var fallback isn't silently
-// skipped when no tenant override exists. Env var path is backward-compat
-// only — per CLAUDE.md, new per-tenant runtime config MUST use settings.
+// Per CLAUDE.md, this service does NOT consult environment variables —
+// per-tenant runtime config lives exclusively in the settings system.
 func (s *timetableCleanupService) resolveRetentionDays(ctx context.Context) int {
-	if s.settings != nil {
-		has, err := s.settings.HasTenantOverride(ctx, configModel.KeyGDPRTimetableRetentionDays)
-		if err != nil {
-			s.logger.Warn("settings override check failed, falling back",
-				slog.String("key", configModel.KeyGDPRTimetableRetentionDays),
-				slog.String("error", err.Error()),
-			)
-		} else if has {
-			if v, err := s.settings.ResolveInt(ctx, configModel.KeyGDPRTimetableRetentionDays); err == nil && v > 0 {
-				return v
-			}
-		}
+	if s.settings == nil {
+		return timetableRetentionDefaultDays
 	}
-	if env := os.Getenv(timetableRetentionEnvVar); env != "" {
-		if parsed, err := strconv.Atoi(env); err == nil && parsed > 0 {
-			return parsed
-		}
+	// Log a warning if the override check fails, but fall through to the
+	// registry-default path below so the cleanup still runs on a sane value.
+	if _, err := s.settings.HasTenantOverride(ctx, configModel.KeyGDPRTimetableRetentionDays); err != nil {
+		s.logger.Warn("settings override check failed, falling back to registry default",
+			slog.String("key", configModel.KeyGDPRTimetableRetentionDays),
+			slog.String("error", err.Error()),
+		)
 	}
-	// Fall back to registry default when settings service is wired; otherwise
-	// the last-resort literal. ResolveInt returns the registry default even
-	// without a tenant override, which is exactly what we want here.
-	if s.settings != nil {
-		if v, err := s.settings.ResolveInt(ctx, configModel.KeyGDPRTimetableRetentionDays); err == nil && v > 0 {
-			return v
-		}
+	// ResolveInt returns the tenant override if set, else the registry default.
+	if v, err := s.settings.ResolveInt(ctx, configModel.KeyGDPRTimetableRetentionDays); err == nil && v > 0 {
+		return v
 	}
 	return timetableRetentionDefaultDays
 }

--- a/backend/services/schedule/timetable_cleanup_service.go
+++ b/backend/services/schedule/timetable_cleanup_service.go
@@ -1,0 +1,476 @@
+// Package schedule — timetable cleanup service (WP-B14).
+//
+// GDPR retention cleanup for the timetable tables: deletes
+// schedule.activity_instances (and via CASCADE, schedule.instance_staff +
+// schedule.instance_students) and schedule.activity_exceptions rows older
+// than the tenant-configured retention window.
+//
+// Design notes:
+//
+//   - Two separate deletes per tenant run. activity_instances and
+//     activity_exceptions are independent tables with different "age"
+//     predicates (date vs exception_date). CASCADE handles the instance_*
+//     children automatically.
+//
+//   - All statuses past retention are deleted (planned / active / completed /
+//     cancelled). Materialization never produces past-dated rows, so any
+//     planned row older than retention is orphaned data.
+//
+//   - Caller supplies tenant context. The service trusts ctx has an active
+//     WithTenantTx — both deletes run inside the caller's transaction and
+//     RLS enforces the tenant boundary. Explicit `tenant_id = ?` predicates
+//     are defense-in-depth.
+//
+//   - Per-student audit rows (one row per affected student, not per run).
+//     activity_exceptions carry no PII (template-scoped) and are not logged
+//     to audit.data_deletions — slog-only. The audit writes land BEFORE the
+//     deletes; a failure anywhere rolls back everything atomically.
+//
+//   - Retention resolution: tenant DB override → env var → registry default.
+//     The 365 literal in the service is a last-resort fallback only reached
+//     when both settings service and env var are unavailable; in production
+//     the registry definition in services/config/defaults/timetable.go:142
+//     supplies the default.
+package schedule
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+
+	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/models/audit"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	"github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+// auditInstanceIDSampleCap bounds the number of instance IDs sampled into a
+// per-student audit row's metadata. Keeps the metadata JSONB small while still
+// giving compliance a handful of row identifiers for forensic lookup.
+const auditInstanceIDSampleCap = 10
+
+// timetableRetentionDefaultDays is a last-resort fallback. In production this
+// is unreachable because the registry definition in
+// services/config/defaults/timetable.go registers 365 at init time. Kept so
+// the service is callable in tests without settings wiring.
+const timetableRetentionDefaultDays = 365
+
+// timetableRetentionEnvVar is the backward-compat env var for tenants that
+// pre-date the settings system. Per CLAUDE.md, new per-tenant runtime config
+// MUST use the settings system — this env var exists for migration paths and
+// is intentionally not documented in dev.env.example or docker-compose.
+const timetableRetentionEnvVar = "TIMETABLE_RETENTION_DAYS"
+
+// TimetableCleanupResult summarises one cleanup run.
+type TimetableCleanupResult struct {
+	Success           bool
+	InstancesDeleted  int
+	ExceptionsDeleted int
+	StudentsAffected  int
+	RetentionDays     int
+	CutoffDate        time.Time
+	DurationMS        int64
+}
+
+// TimetableCleanupPreview is returned by PreviewExpiredTimetableData —
+// identical shape to Result except nothing was deleted.
+type TimetableCleanupPreview struct {
+	InstancesToDelete  int
+	ExceptionsToDelete int
+	StudentsAffected   int
+	RetentionDays      int
+	CutoffDate         time.Time
+	OldestInstance     *time.Time
+	OldestException    *time.Time
+}
+
+// TimetableCleanupStats returns row counts and oldest timestamps across the
+// tenant's timetable data for the CLI `stats` subcommand.
+type TimetableCleanupStats struct {
+	TotalInstances  int
+	TotalExceptions int
+	OldestInstance  *time.Time
+	OldestException *time.Time
+	RetentionDays   int
+	CutoffDate      time.Time
+}
+
+// TimetableCleanupService drives GDPR retention cleanup for the timetable
+// tables. All methods assume tenant context has been established by the
+// caller (WithTenantTx).
+type TimetableCleanupService interface {
+	CleanupExpiredTimetableData(ctx context.Context) (*TimetableCleanupResult, error)
+	PreviewExpiredTimetableData(ctx context.Context) (*TimetableCleanupPreview, error)
+	GetStats(ctx context.Context) (*TimetableCleanupStats, error)
+}
+
+// timetableCleanupService implements TimetableCleanupService.
+type timetableCleanupService struct {
+	db        *bun.DB
+	auditRepo audit.DataDeletionRepository
+	settings  config.SettingsService
+	logger    *slog.Logger
+}
+
+// NewTimetableCleanupService constructs the cleanup service. settings may be
+// nil in tests; when nil, retention resolves via env var or the last-resort
+// default 365.
+func NewTimetableCleanupService(
+	db *bun.DB,
+	auditRepo audit.DataDeletionRepository,
+	settings config.SettingsService,
+	logger *slog.Logger,
+) TimetableCleanupService {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &timetableCleanupService{
+		db:        db,
+		auditRepo: auditRepo,
+		settings:  settings,
+		logger:    logger,
+	}
+}
+
+// CleanupExpiredTimetableData deletes activity_instances + activity_exceptions
+// older than the resolved retention window for the tenant in ctx. Writes one
+// audit.data_deletions row per affected student before the deletes.
+func (s *timetableCleanupService) CleanupExpiredTimetableData(ctx context.Context) (*TimetableCleanupResult, error) {
+	tenantID := tenant.FromContext(ctx)
+	if tenantID == 0 {
+		return nil, fmt.Errorf("timetable cleanup: no tenant in context")
+	}
+
+	start := time.Now()
+	retentionDays := s.resolveRetentionDays(ctx)
+	cutoff := cutoffFor(retentionDays)
+
+	db := repoBase.GetDB(ctx, s.db)
+
+	// 1. Collect per-student impact for the audit log.
+	studentCounts, sampleIDs, err := s.collectStudentImpact(ctx, db, tenantID, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("collect student impact: %w", err)
+	}
+
+	// 2. Write one audit row per affected student BEFORE the deletes. Inside
+	//    the caller's WithTenantTx, so an audit failure rolls back the
+	//    deletes. No audit rows for exceptions (template-scoped, no PII).
+	if err := s.writeStudentAuditRows(ctx, tenantID, retentionDays, cutoff, studentCounts, sampleIDs); err != nil {
+		return nil, fmt.Errorf("write audit rows: %w", err)
+	}
+
+	// 3. Delete activity_instances. CASCADE handles instance_staff + instance_students.
+	instancesDeleted, err := deleteOldInstances(ctx, db, tenantID, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("delete activity_instances: %w", err)
+	}
+
+	// 4. Delete activity_exceptions.
+	exceptionsDeleted, err := deleteOldExceptions(ctx, db, tenantID, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("delete activity_exceptions: %w", err)
+	}
+
+	result := &TimetableCleanupResult{
+		Success:           true,
+		InstancesDeleted:  instancesDeleted,
+		ExceptionsDeleted: exceptionsDeleted,
+		StudentsAffected:  len(studentCounts),
+		RetentionDays:     retentionDays,
+		CutoffDate:        cutoff,
+		DurationMS:        time.Since(start).Milliseconds(),
+	}
+
+	s.logger.Info("timetable cleanup completed",
+		slog.Int64("tenant_id", tenantID),
+		slog.Int("instances_deleted", instancesDeleted),
+		slog.Int("exceptions_deleted", exceptionsDeleted),
+		slog.Int("students_affected", result.StudentsAffected),
+		slog.Int("retention_days", retentionDays),
+		slog.String("cutoff_date", cutoff.Format("2006-01-02")),
+		slog.Int64("duration_ms", result.DurationMS),
+	)
+
+	return result, nil
+}
+
+// PreviewExpiredTimetableData counts what would be deleted without mutating.
+func (s *timetableCleanupService) PreviewExpiredTimetableData(ctx context.Context) (*TimetableCleanupPreview, error) {
+	tenantID := tenant.FromContext(ctx)
+	if tenantID == 0 {
+		return nil, fmt.Errorf("timetable cleanup preview: no tenant in context")
+	}
+
+	retentionDays := s.resolveRetentionDays(ctx)
+	cutoff := cutoffFor(retentionDays)
+	db := repoBase.GetDB(ctx, s.db)
+
+	instancesToDelete, err := db.NewSelect().
+		Table("schedule.activity_instances").
+		Where("tenant_id = ?", tenantID).
+		Where("date < ?", cutoff).
+		Count(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("count activity_instances: %w", err)
+	}
+
+	exceptionsToDelete, err := db.NewSelect().
+		Table("schedule.activity_exceptions").
+		Where("tenant_id = ?", tenantID).
+		Where("exception_date < ?", cutoff).
+		Count(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("count activity_exceptions: %w", err)
+	}
+
+	studentCounts, _, err := s.collectStudentImpact(ctx, db, tenantID, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("collect student impact: %w", err)
+	}
+
+	oldestInstance, err := scanOldestTimestamp(ctx, db,
+		`SELECT MIN(date) AS t FROM schedule.activity_instances WHERE tenant_id = ? AND date < ?`,
+		tenantID, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("oldest activity_instance: %w", err)
+	}
+	oldestException, err := scanOldestTimestamp(ctx, db,
+		`SELECT MIN(exception_date) AS t FROM schedule.activity_exceptions WHERE tenant_id = ? AND exception_date < ?`,
+		tenantID, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("oldest activity_exception: %w", err)
+	}
+
+	return &TimetableCleanupPreview{
+		InstancesToDelete:  instancesToDelete,
+		ExceptionsToDelete: exceptionsToDelete,
+		StudentsAffected:   len(studentCounts),
+		RetentionDays:      retentionDays,
+		CutoffDate:         cutoff,
+		OldestInstance:     oldestInstance,
+		OldestException:    oldestException,
+	}, nil
+}
+
+// GetStats reports total row counts and oldest timestamps regardless of the
+// retention window — useful for the CLI `stats` subcommand to gauge overall
+// table size.
+func (s *timetableCleanupService) GetStats(ctx context.Context) (*TimetableCleanupStats, error) {
+	tenantID := tenant.FromContext(ctx)
+	if tenantID == 0 {
+		return nil, fmt.Errorf("timetable cleanup stats: no tenant in context")
+	}
+
+	retentionDays := s.resolveRetentionDays(ctx)
+	cutoff := cutoffFor(retentionDays)
+	db := repoBase.GetDB(ctx, s.db)
+
+	totalInstances, err := db.NewSelect().
+		Table("schedule.activity_instances").
+		Where("tenant_id = ?", tenantID).
+		Count(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("count activity_instances: %w", err)
+	}
+
+	totalExceptions, err := db.NewSelect().
+		Table("schedule.activity_exceptions").
+		Where("tenant_id = ?", tenantID).
+		Count(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("count activity_exceptions: %w", err)
+	}
+
+	oldestInstance, err := scanOldestTimestamp(ctx, db,
+		`SELECT MIN(date) AS t FROM schedule.activity_instances WHERE tenant_id = ?`,
+		tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("oldest activity_instance: %w", err)
+	}
+	oldestException, err := scanOldestTimestamp(ctx, db,
+		`SELECT MIN(exception_date) AS t FROM schedule.activity_exceptions WHERE tenant_id = ?`,
+		tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("oldest activity_exception: %w", err)
+	}
+
+	return &TimetableCleanupStats{
+		TotalInstances:  totalInstances,
+		TotalExceptions: totalExceptions,
+		OldestInstance:  oldestInstance,
+		OldestException: oldestException,
+		RetentionDays:   retentionDays,
+		CutoffDate:      cutoff,
+	}, nil
+}
+
+// --- Internal helpers ---
+
+// resolveRetentionDays picks the tenant's retention days following the
+// documented chain: tenant DB override → env var → registry default.
+//
+// HasTenantOverride distinguishes "tenant explicitly set a value" from
+// "returning registry default" so the env var fallback isn't silently
+// skipped when no tenant override exists. Env var path is backward-compat
+// only — per CLAUDE.md, new per-tenant runtime config MUST use settings.
+func (s *timetableCleanupService) resolveRetentionDays(ctx context.Context) int {
+	if s.settings != nil {
+		has, err := s.settings.HasTenantOverride(ctx, configModel.KeyGDPRTimetableRetentionDays)
+		if err != nil {
+			s.logger.Warn("settings override check failed, falling back",
+				slog.String("key", configModel.KeyGDPRTimetableRetentionDays),
+				slog.String("error", err.Error()),
+			)
+		} else if has {
+			if v, err := s.settings.ResolveInt(ctx, configModel.KeyGDPRTimetableRetentionDays); err == nil && v > 0 {
+				return v
+			}
+		}
+	}
+	if env := os.Getenv(timetableRetentionEnvVar); env != "" {
+		if parsed, err := strconv.Atoi(env); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	// Fall back to registry default when settings service is wired; otherwise
+	// the last-resort literal. ResolveInt returns the registry default even
+	// without a tenant override, which is exactly what we want here.
+	if s.settings != nil {
+		if v, err := s.settings.ResolveInt(ctx, configModel.KeyGDPRTimetableRetentionDays); err == nil && v > 0 {
+			return v
+		}
+	}
+	return timetableRetentionDefaultDays
+}
+
+// cutoffFor returns the UTC start-of-day cutoff for the retention window.
+func cutoffFor(retentionDays int) time.Time {
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	return today.AddDate(0, 0, -retentionDays)
+}
+
+// studentImpact holds the per-student count and a bounded sample of instance
+// IDs for the audit metadata.
+type perStudentCounts map[int64]int
+type perStudentSamples map[int64][]int64
+
+// collectStudentImpact returns per-student counts of instance_students rows
+// that will be cleaned up (by way of CASCADE from activity_instances), plus
+// a bounded sample of instance IDs per student for forensic lookup.
+func (s *timetableCleanupService) collectStudentImpact(
+	ctx context.Context,
+	db bun.IDB,
+	tenantID int64,
+	cutoff time.Time,
+) (perStudentCounts, perStudentSamples, error) {
+	type row struct {
+		StudentID  int64 `bun:"student_id"`
+		InstanceID int64 `bun:"instance_id"`
+	}
+	var rows []row
+	err := db.NewSelect().
+		TableExpr("schedule.instance_students AS i_s").
+		ColumnExpr("i_s.student_id AS student_id").
+		ColumnExpr("i_s.instance_id AS instance_id").
+		Join(`JOIN schedule.activity_instances AS i ON i.id = i_s.instance_id`).
+		Where("i.tenant_id = ?", tenantID).
+		Where("i.date < ?", cutoff).
+		Order("i_s.student_id", "i_s.instance_id").
+		Scan(ctx, &rows)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	counts := make(perStudentCounts)
+	samples := make(perStudentSamples)
+	for _, r := range rows {
+		counts[r.StudentID]++
+		if len(samples[r.StudentID]) < auditInstanceIDSampleCap {
+			samples[r.StudentID] = append(samples[r.StudentID], r.InstanceID)
+		}
+	}
+	return counts, samples, nil
+}
+
+// writeStudentAuditRows inserts one audit.data_deletions row per affected
+// student. Called BEFORE the deletes so any failure rolls back everything.
+func (s *timetableCleanupService) writeStudentAuditRows(
+	ctx context.Context,
+	tenantID int64,
+	retentionDays int,
+	cutoff time.Time,
+	counts perStudentCounts,
+	samples perStudentSamples,
+) error {
+	if s.auditRepo == nil {
+		return fmt.Errorf("audit repo not configured")
+	}
+	cutoffStr := cutoff.Format("2006-01-02")
+	for studentID, n := range counts {
+		deletion := audit.NewDataDeletion(
+			studentID,
+			audit.DeletionTypeTimetableRetention,
+			n,
+			"system",
+		)
+		deletion.SetTenantID(tenantID)
+		deletion.DeletionReason = "automated timetable retention cleanup"
+		deletion.SetMetadata("retention_days", retentionDays)
+		deletion.SetMetadata("cutoff_date", cutoffStr)
+		if sample := samples[studentID]; len(sample) > 0 {
+			deletion.SetMetadata("instance_ids_sample", sample)
+		}
+		if err := s.auditRepo.Create(ctx, deletion); err != nil {
+			return fmt.Errorf("audit row for student %d: %w", studentID, err)
+		}
+	}
+	return nil
+}
+
+// deleteOldInstances issues the DELETE and returns the affected count.
+func deleteOldInstances(ctx context.Context, db bun.IDB, tenantID int64, cutoff time.Time) (int, error) {
+	res, err := db.NewDelete().
+		Table("schedule.activity_instances").
+		Where("tenant_id = ?", tenantID).
+		Where("date < ?", cutoff).
+		Exec(ctx)
+	if err != nil {
+		return 0, err
+	}
+	affected, _ := res.RowsAffected()
+	return int(affected), nil
+}
+
+// deleteOldExceptions mirrors deleteOldInstances for exceptions.
+func deleteOldExceptions(ctx context.Context, db bun.IDB, tenantID int64, cutoff time.Time) (int, error) {
+	res, err := db.NewDelete().
+		Table("schedule.activity_exceptions").
+		Where("tenant_id = ?", tenantID).
+		Where("exception_date < ?", cutoff).
+		Exec(ctx)
+	if err != nil {
+		return 0, err
+	}
+	affected, _ := res.RowsAffected()
+	return int(affected), nil
+}
+
+// scanOldestTimestamp runs a MIN() query and returns nil when no rows match.
+// The caller must include `AS t` on the MIN() column so bun can map it.
+func scanOldestTimestamp(ctx context.Context, db bun.IDB, query string, args ...any) (*time.Time, error) {
+	var nt struct {
+		T *time.Time `bun:"t"`
+	}
+	err := db.NewRaw(query, args...).Scan(ctx, &nt)
+	if err != nil {
+		return nil, err
+	}
+	return nt.T, nil
+}

--- a/backend/services/schedule/timetable_cleanup_service_test.go
+++ b/backend/services/schedule/timetable_cleanup_service_test.go
@@ -1,0 +1,645 @@
+package schedule_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	auditRepoPkg "github.com/moto-nrw/project-phoenix/database/repositories/audit"
+	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// Hermetic: every instance/exception row is created per-subtest with a unique
+// suffix and cleaned up via registerCleanup. No hardcoded entity IDs.
+// tenant_id=1 is whitelisted by the hermetic linter.
+
+const testTenantID int64 = 1
+
+// instFixture holds the DB rows a test created so runCleanup can remove them
+// in child-first order.
+type instFixture struct {
+	db               *bun.DB
+	ctx              context.Context
+	instanceIDs      []int64
+	exceptionIDs     []int64
+	instanceStaffIDs []int64
+	instStudentIDs   []int64
+	studentIDs       []int64
+	staffIDs         []int64
+	roomIDs          []int64
+	activityGrpIDs   []int64
+	templateIDs      []int64
+	categoryIDs      []int64
+}
+
+func (f *instFixture) cleanup(t *testing.T) {
+	t.Helper()
+	// Children first. Most instance_students + instance_staff rows disappear
+	// via CASCADE when the instance row is deleted by the test, but some
+	// tests intentionally leave rows un-deleted and want the child tables
+	// cleared explicitly.
+	if len(f.instStudentIDs) > 0 {
+		testpkg.CleanupTableRecords(t, f.db, "schedule.instance_students", f.instStudentIDs...)
+	}
+	if len(f.instanceStaffIDs) > 0 {
+		testpkg.CleanupTableRecords(t, f.db, "schedule.instance_staff", f.instanceStaffIDs...)
+	}
+	if len(f.instanceIDs) > 0 {
+		testpkg.CleanupTableRecords(t, f.db, "schedule.activity_instances", f.instanceIDs...)
+	}
+	if len(f.exceptionIDs) > 0 {
+		testpkg.CleanupTableRecords(t, f.db, "schedule.activity_exceptions", f.exceptionIDs...)
+	}
+	if len(f.templateIDs) > 0 {
+		testpkg.CleanupTableRecords(t, f.db, "activities.groups", f.templateIDs...)
+	}
+	if len(f.activityGrpIDs) > 0 {
+		testpkg.CleanupTableRecords(t, f.db, "activities.groups", f.activityGrpIDs...)
+	}
+	if len(f.categoryIDs) > 0 {
+		testpkg.CleanupTableRecords(t, f.db, "activities.categories", f.categoryIDs...)
+	}
+	if len(f.studentIDs) > 0 {
+		testpkg.CleanupTableRecords(t, f.db, "users.students", f.studentIDs...)
+	}
+	if len(f.staffIDs) > 0 {
+		testpkg.CleanupTableRecords(t, f.db, "users.staff", f.staffIDs...)
+	}
+	if len(f.roomIDs) > 0 {
+		testpkg.CleanupTableRecords(t, f.db, "facilities.rooms", f.roomIDs...)
+	}
+	// Clean up orphaned audit rows for the test's affected students. Audit
+	// rows are tenant-scoped and use DELETE CASCADE on student_id, so most
+	// are gone when the student is deleted — but rows written by tests
+	// where we prevent the DELETE (mock rollback) remain.
+	for _, sid := range f.studentIDs {
+		_, _ = f.db.NewDelete().Table("audit.data_deletions").
+			Where("student_id = ? AND deletion_type = ?", sid, auditModels.DeletionTypeTimetableRetention).
+			Exec(f.ctx)
+	}
+}
+
+// newInstanceFixture inserts an ActivityInstance row and returns the ID. The
+// template-backed flag controls whether activity_group_id is set.
+func (f *instFixture) newInstance(t *testing.T, date time.Time, status string, roomID int64, templateID *int64) int64 {
+	t.Helper()
+	title := fmt.Sprintf("Inst-%d-%s", date.Unix(), status)
+	inst := &scheduleModels.ActivityInstance{
+		Date:            date,
+		Title:           title,
+		StartTime:       time.Date(1, 1, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:         time.Date(1, 1, 1, 15, 0, 0, 0, time.UTC),
+		RoomID:          roomID,
+		Status:          status,
+		ActivityGroupID: templateID,
+	}
+	inst.SetTenantID(testTenantID)
+	_, err := f.db.NewInsert().Model(inst).
+		ModelTableExpr(`schedule.activity_instances`).
+		Exec(f.ctx)
+	require.NoError(t, err, "insert activity_instance")
+	f.instanceIDs = append(f.instanceIDs, inst.ID)
+	return inst.ID
+}
+
+// newException inserts an ActivityException row for the given date.
+func (f *instFixture) newException(t *testing.T, activityGroupID int64, date time.Time, exceptionType string) int64 {
+	t.Helper()
+	exc := &scheduleModels.ActivityException{
+		ActivityGroupID: activityGroupID,
+		ExceptionDate:   date,
+		ExceptionType:   exceptionType,
+	}
+	exc.SetTenantID(testTenantID)
+	_, err := f.db.NewInsert().Model(exc).
+		ModelTableExpr(`schedule.activity_exceptions`).
+		Exec(f.ctx)
+	require.NoError(t, err, "insert activity_exception")
+	f.exceptionIDs = append(f.exceptionIDs, exc.ID)
+	return exc.ID
+}
+
+// attachStudent inserts an instance_students row linking studentID to
+// instanceID. Optionally attaches a GDPR-sensitive note (WP-B10 field).
+func (f *instFixture) attachStudent(t *testing.T, instanceID, studentID int64, note *string) int64 {
+	t.Helper()
+	row := &scheduleModels.InstanceStudent{
+		InstanceID: instanceID,
+		StudentID:  studentID,
+		Note:       note,
+	}
+	row.SetTenantID(testTenantID)
+	_, err := f.db.NewInsert().Model(row).
+		ModelTableExpr(`schedule.instance_students`).
+		Exec(f.ctx)
+	require.NoError(t, err, "insert instance_students")
+	f.instStudentIDs = append(f.instStudentIDs, row.ID)
+	return row.ID
+}
+
+// attachStaff inserts an instance_staff row linking staffID to instanceID.
+func (f *instFixture) attachStaff(t *testing.T, instanceID, staffID int64) int64 {
+	t.Helper()
+	row := &scheduleModels.InstanceStaff{
+		InstanceID: instanceID,
+		StaffID:    staffID,
+	}
+	row.SetTenantID(testTenantID)
+	_, err := f.db.NewInsert().Model(row).
+		ModelTableExpr(`schedule.instance_staff`).
+		Exec(f.ctx)
+	require.NoError(t, err, "insert instance_staff")
+	f.instanceStaffIDs = append(f.instanceStaffIDs, row.ID)
+	return row.ID
+}
+
+// setupFixture sets up db + ctx + a room for cleanup tests.
+func setupFixture(t *testing.T) (*instFixture, int64) {
+	t.Helper()
+	db := testpkg.SetupTestDB(t)
+	ctx := testpkg.TenantContext(testTenantID)
+	suffix := time.Now().UnixNano()
+	room := testpkg.CreateTestRoom(t, db, fmt.Sprintf("Room-%d", suffix))
+	f := &instFixture{db: db, ctx: ctx, roomIDs: []int64{room.ID}}
+	t.Cleanup(func() { f.cleanup(t) })
+	return f, room.ID
+}
+
+// newCleanupSvc builds a TimetableCleanupService wired against the real
+// audit repo + no settings service (so retention falls to the env/default).
+// Tests that need the settings service build it themselves.
+func newCleanupSvc(db *bun.DB) scheduleSvc.TimetableCleanupService {
+	return scheduleSvc.NewTimetableCleanupService(
+		db,
+		auditRepoPkg.NewDataDeletionRepository(db),
+		nil, // no settings — retention falls to env var or 365 default
+		slog.Default(),
+	)
+}
+
+// --- Tests ---
+
+func TestCleanup_HappyPath_DeletesOldRowsKeepsFreshRows(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := newCleanupSvc(f.db)
+
+	old := time.Now().UTC().AddDate(0, 0, -400) // past 365d retention
+	recent := time.Now().UTC().AddDate(0, 0, -30)
+
+	// 3 instances: 2 old (should delete), 1 recent (should survive).
+	oldID1 := f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+	oldID2 := f.newInstance(t, old, scheduleModels.InstanceStatusCancelled, roomID, nil)
+	recentID := f.newInstance(t, recent, scheduleModels.InstanceStatusPlanned, roomID, nil)
+
+	// 2 exceptions: 1 old (delete), 1 recent (survive). Needs a template parent.
+	cat := testpkg.CreateTestActivityCategory(t, f.db, fmt.Sprintf("Cat-%d", time.Now().UnixNano()))
+	f.categoryIDs = append(f.categoryIDs, cat.ID)
+	template := createTemplate(t, f, roomID, cat.ID)
+	oldExcID := f.newException(t, template.ID, old, scheduleModels.ActivityExceptionCancelled)
+	recentExcID := f.newException(t, template.ID, recent, scheduleModels.ActivityExceptionCancelled)
+	_ = recentExcID
+
+	result, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, 2, result.InstancesDeleted, "2 old instances deleted")
+	assert.Equal(t, 1, result.ExceptionsDeleted, "1 old exception deleted")
+	assert.Equal(t, 365, result.RetentionDays)
+
+	// Verify: old IDs gone, recent IDs still present.
+	assertInstanceExists(t, f, oldID1, false)
+	assertInstanceExists(t, f, oldID2, false)
+	assertInstanceExists(t, f, recentID, true)
+	assertExceptionExists(t, f, oldExcID, false)
+}
+
+func TestCleanup_EmptyTenant_WritesNoAuditRowsForStudents(t *testing.T) {
+	f, _ := setupFixture(t)
+	svc := newCleanupSvc(f.db)
+
+	// No instances, no exceptions, no students.
+	result, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.InstancesDeleted)
+	assert.Equal(t, 0, result.ExceptionsDeleted)
+	assert.Equal(t, 0, result.StudentsAffected)
+
+	// No audit rows for a non-existent affected student — the per-student
+	// policy means nothing gets logged when nothing was about a student.
+	count, err := f.db.NewSelect().
+		Table("audit.data_deletions").
+		Where("tenant_id = ? AND deletion_type = ?", testTenantID, auditModels.DeletionTypeTimetableRetention).
+		Count(f.ctx)
+	require.NoError(t, err)
+	// The "zero rows" assertion is indirect: an empty-tenant run should add
+	// zero new audit rows. We measure delta by running cleanup twice — both
+	// runs should yield the same count.
+	result2, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result2.StudentsAffected)
+	count2, err := f.db.NewSelect().
+		Table("audit.data_deletions").
+		Where("tenant_id = ? AND deletion_type = ?", testTenantID, auditModels.DeletionTypeTimetableRetention).
+		Count(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, count, count2, "empty-tenant cleanup adds no audit rows")
+}
+
+func TestCleanup_Idempotent_SecondRunDeletesZero(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := newCleanupSvc(f.db)
+
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+
+	r1, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r1.InstancesDeleted)
+
+	r2, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, r2.InstancesDeleted, "second run is a no-op")
+	assert.True(t, r2.Success)
+}
+
+func TestCleanup_CASCADE_DeletesInstanceChildren(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := newCleanupSvc(f.db)
+
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	instID := f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+
+	staff := testpkg.CreateTestStaff(t, f.db, "Cascade", fmt.Sprintf("Staff-%d", time.Now().UnixNano()))
+	student := testpkg.CreateTestStudent(t, f.db, "Cascade", fmt.Sprintf("Stud-%d", time.Now().UnixNano()), "3a")
+	f.staffIDs = append(f.staffIDs, staff.ID)
+	f.studentIDs = append(f.studentIDs, student.ID)
+
+	staffRowID := f.attachStaff(t, instID, staff.ID)
+	studRowID := f.attachStudent(t, instID, student.ID, nil)
+
+	_, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+
+	// CASCADE should have removed both child rows.
+	assertRowExists(t, f, "schedule.instance_staff", staffRowID, false)
+	assertRowExists(t, f, "schedule.instance_students", studRowID, false)
+	// Our fixture tracker should not try to delete them again on teardown.
+	f.instanceStaffIDs = nil
+	f.instStudentIDs = nil
+	f.instanceIDs = nil
+}
+
+func TestCleanup_RetentionOverride_UsesOverriddenDays(t *testing.T) {
+	// Tests the env-var fallback path in resolveRetentionDays. Setting the
+	// env var narrows the window to 30 days; a 60-day-old instance becomes
+	// deletable even though the registry default (365) would have spared it.
+	t.Setenv("TIMETABLE_RETENTION_DAYS", "30")
+
+	f, roomID := setupFixture(t)
+	svc := newCleanupSvc(f.db)
+
+	sixtyDaysOld := time.Now().UTC().AddDate(0, 0, -60)
+	tenDaysOld := time.Now().UTC().AddDate(0, 0, -10)
+
+	oldID := f.newInstance(t, sixtyDaysOld, scheduleModels.InstanceStatusCompleted, roomID, nil)
+	freshID := f.newInstance(t, tenDaysOld, scheduleModels.InstanceStatusCompleted, roomID, nil)
+
+	r, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 30, r.RetentionDays, "env var overrides default 365")
+	assert.Equal(t, 1, r.InstancesDeleted, "60-day-old row past 30-day window")
+
+	assertRowExists(t, f, "schedule.activity_instances", oldID, false)
+	assertRowExists(t, f, "schedule.activity_instances", freshID, true)
+}
+
+func TestCleanup_AllStatuses_DeletesPlannedActiveCompletedCancelled(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := newCleanupSvc(f.db)
+
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	for _, status := range []string{
+		scheduleModels.InstanceStatusPlanned,
+		scheduleModels.InstanceStatusActive,
+		scheduleModels.InstanceStatusCompleted,
+		scheduleModels.InstanceStatusCancelled,
+	} {
+		f.newInstance(t, old, status, roomID, nil)
+	}
+
+	r, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 4, r.InstancesDeleted, "all four statuses deleted past retention")
+}
+
+func TestCleanup_TemplatesUntouched_OnlyInstancesAndExceptionsDeleted(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := newCleanupSvc(f.db)
+
+	cat := testpkg.CreateTestActivityCategory(t, f.db, fmt.Sprintf("Cat-%d", time.Now().UnixNano()))
+	f.categoryIDs = append(f.categoryIDs, cat.ID)
+	template := createTemplate(t, f, roomID, cat.ID)
+
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, &template.ID)
+	f.newException(t, template.ID, old, scheduleModels.ActivityExceptionCancelled)
+
+	r, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.InstancesDeleted)
+	assert.Equal(t, 1, r.ExceptionsDeleted)
+
+	// Template survives.
+	exists, err := f.db.NewSelect().
+		Table("activities.groups").
+		Where("id = ?", template.ID).
+		Exists(f.ctx)
+	require.NoError(t, err)
+	assert.True(t, exists, "template must survive the cleanup — only instances + exceptions are retention-scoped")
+}
+
+func TestCleanup_PerStudentAuditRows_OneRowPerAffectedStudent(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := newCleanupSvc(f.db)
+
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	inst1 := f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+	inst2 := f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+
+	s1 := testpkg.CreateTestStudent(t, f.db, "Audit", fmt.Sprintf("One-%d", time.Now().UnixNano()), "3a")
+	s2 := testpkg.CreateTestStudent(t, f.db, "Audit", fmt.Sprintf("Two-%d", time.Now().UnixNano()), "3a")
+	f.studentIDs = append(f.studentIDs, s1.ID, s2.ID)
+
+	// s1 attends both instances (2 rows), s2 attends one (1 row).
+	f.attachStudent(t, inst1, s1.ID, nil)
+	f.attachStudent(t, inst2, s1.ID, nil)
+	f.attachStudent(t, inst1, s2.ID, nil)
+
+	r, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, r.StudentsAffected)
+
+	// The DELETE has fired — student IDs are gone via CASCADE? No: students
+	// are in users.students, which is not cascaded by activity_instances
+	// deletion. So s1/s2 still exist, and their audit rows persist.
+	var auditCount int
+	auditCount, err = f.db.NewSelect().
+		Table("audit.data_deletions").
+		Where("tenant_id = ? AND deletion_type = ?", testTenantID, auditModels.DeletionTypeTimetableRetention).
+		Where("student_id IN (?, ?)", s1.ID, s2.ID).
+		Count(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, auditCount, "one audit row per affected student")
+
+	// Verify per-student counts.
+	var s1Row auditModels.DataDeletion
+	err = f.db.NewSelect().Model(&s1Row).
+		Where("tenant_id = ? AND student_id = ? AND deletion_type = ?",
+			testTenantID, s1.ID, auditModels.DeletionTypeTimetableRetention).
+		Scan(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, s1Row.RecordsDeleted, "s1 had 2 instance_students rows")
+	assert.Equal(t, "system", s1Row.DeletedBy)
+	assert.Contains(t, s1Row.Metadata, "retention_days")
+	assert.Contains(t, s1Row.Metadata, "cutoff_date")
+	assert.Contains(t, s1Row.Metadata, "instance_ids_sample")
+
+	// Tracker cleanup: instances are gone, skip them. instance_students
+	// rows were CASCADEd.
+	f.instanceIDs = nil
+	f.instStudentIDs = nil
+}
+
+func TestCleanup_DeletesGDPRSensitiveNotesViaCascade(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := newCleanupSvc(f.db)
+
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	instID := f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+
+	student := testpkg.CreateTestStudent(t, f.db, "Sensitive", fmt.Sprintf("Note-%d", time.Now().UnixNano()), "3a")
+	f.studentIDs = append(f.studentIDs, student.ID)
+	sensitiveNote := "contains GDPR-sensitive free text about this student's behavior"
+	studRowID := f.attachStudent(t, instID, student.ID, &sensitiveNote)
+
+	// Verify the note exists before cleanup.
+	var existing struct {
+		Note *string `bun:"note"`
+	}
+	err := f.db.NewSelect().Table("schedule.instance_students").
+		Column("note").
+		Where("id = ?", studRowID).
+		Scan(f.ctx, &existing)
+	require.NoError(t, err)
+	require.NotNil(t, existing.Note)
+	require.Equal(t, sensitiveNote, *existing.Note)
+
+	// Run cleanup.
+	_, err = svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+
+	// The instance_students row (with its note) must be gone via CASCADE.
+	assertRowExists(t, f, "schedule.instance_students", studRowID, false)
+	f.instStudentIDs = nil
+	f.instanceIDs = nil
+}
+
+func TestCleanup_TenantIsolation_OtherTenantDataUntouched(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := newCleanupSvc(f.db)
+
+	// Tenant A (testTenantID=1) has one old instance.
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+
+	// Insert a row for a different tenant_id (2) directly to bypass the
+	// fixture helper. Track manually so we can assert presence then clean up.
+	otherTenantID := int64(2)
+	// Ensure tenant 2 exists (platform.schools). testpkg doesn't create tenants;
+	// insert a minimal school so the FK is satisfied.
+	otherSchoolID := ensureOtherSchool(t, f.db, f.ctx, otherTenantID)
+
+	otherRoom := testpkg.CreateTestRoom(t, f.db, fmt.Sprintf("Other-Room-%d", time.Now().UnixNano()))
+	// Hack: the test room is created under tenant 1; move it to tenant 2 for this test.
+	_, err := f.db.NewUpdate().Table("facilities.rooms").
+		Set("tenant_id = ?", otherTenantID).
+		Where("id = ?", otherRoom.ID).
+		Exec(f.ctx)
+	require.NoError(t, err)
+
+	otherInst := &scheduleModels.ActivityInstance{
+		Date:      old,
+		Title:     fmt.Sprintf("OtherTenant-%d", time.Now().UnixNano()),
+		StartTime: time.Date(1, 1, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(1, 1, 1, 15, 0, 0, 0, time.UTC),
+		RoomID:    otherRoom.ID,
+		Status:    scheduleModels.InstanceStatusCompleted,
+	}
+	otherInst.SetTenantID(otherTenantID)
+	_, err = f.db.NewInsert().Model(otherInst).
+		ModelTableExpr(`schedule.activity_instances`).
+		Exec(f.ctx)
+	require.NoError(t, err)
+
+	// Run cleanup under tenant 1.
+	_, err = svc.CleanupExpiredTimetableData(f.ctx)
+	require.NoError(t, err)
+
+	// Other tenant's row must survive.
+	assertRowExists(t, f, "schedule.activity_instances", otherInst.ID, true)
+
+	// Manual cleanup of the "other" tenant's fixture rows.
+	_, _ = f.db.NewDelete().Table("schedule.activity_instances").Where("id = ?", otherInst.ID).Exec(f.ctx)
+	_, _ = f.db.NewDelete().Table("facilities.rooms").Where("id = ?", otherRoom.ID).Exec(f.ctx)
+	// Only delete the school if we created it (ensureOtherSchool returns 0 when pre-existing).
+	if otherSchoolID != 0 {
+		_, _ = f.db.NewDelete().Table("platform.schools").Where("id = ?", otherSchoolID).Exec(f.ctx)
+	}
+}
+
+// --- Audit rollback test (mock repo) ---
+
+// failingAuditRepo implements audit.DataDeletionRepository and returns a
+// predetermined error from Create; everything else panics because the
+// test shouldn't exercise other paths.
+type failingAuditRepo struct {
+	err error
+}
+
+func (r *failingAuditRepo) Create(_ context.Context, _ *auditModels.DataDeletion) error {
+	return r.err
+}
+func (r *failingAuditRepo) FindByID(context.Context, interface{}) (*auditModels.DataDeletion, error) {
+	panic("not implemented")
+}
+func (r *failingAuditRepo) FindByStudentID(context.Context, int64) ([]*auditModels.DataDeletion, error) {
+	panic("not implemented")
+}
+func (r *failingAuditRepo) FindByDateRange(context.Context, time.Time, time.Time) ([]*auditModels.DataDeletion, error) {
+	panic("not implemented")
+}
+func (r *failingAuditRepo) FindByType(context.Context, string) ([]*auditModels.DataDeletion, error) {
+	panic("not implemented")
+}
+func (r *failingAuditRepo) List(context.Context, map[string]interface{}) ([]*auditModels.DataDeletion, error) {
+	panic("not implemented")
+}
+func (r *failingAuditRepo) GetDeletionStats(context.Context, time.Time) (map[string]interface{}, error) {
+	panic("not implemented")
+}
+func (r *failingAuditRepo) CountByType(context.Context, string, time.Time) (int64, error) {
+	panic("not implemented")
+}
+
+func TestCleanup_AuditWriteFailure_BubblesError(t *testing.T) {
+	f, roomID := setupFixture(t)
+
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	instID := f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+
+	student := testpkg.CreateTestStudent(t, f.db, "AuditFail", fmt.Sprintf("Stud-%d", time.Now().UnixNano()), "3a")
+	f.studentIDs = append(f.studentIDs, student.ID)
+	f.attachStudent(t, instID, student.ID, nil)
+
+	svc := scheduleSvc.NewTimetableCleanupService(
+		f.db,
+		&failingAuditRepo{err: errors.New("simulated audit failure")},
+		nil,
+		slog.Default(),
+	)
+
+	// The service bubbles the error. Because we do NOT wrap in
+	// tenant.WithTenantTx in this integration test (tests run as the
+	// postgres superuser), the DELETEs never fire — the service returns
+	// before executing them on error. Confirm the row is still present.
+	_, err := svc.CleanupExpiredTimetableData(f.ctx)
+	require.Error(t, err, "audit failure must bubble up")
+	assertRowExists(t, f, "schedule.activity_instances", instID, true,
+		"audit-before-delete ordering means the DELETE did not fire")
+}
+
+// --- Helpers ---
+
+// createTemplate inserts an activity_groups row with is_template=true.
+func createTemplate(t *testing.T, f *instFixture, roomID, categoryID int64) *activitiesModels.Group {
+	t.Helper()
+	tpl := &activitiesModels.Group{
+		Name:            fmt.Sprintf("Template-%d", time.Now().UnixNano()),
+		MaxParticipants: 20,
+		IsOpen:          true,
+		CategoryID:      categoryID,
+		PlannedRoomID:   &roomID,
+		IsTemplate:      true,
+	}
+	tpl.SetTenantID(testTenantID)
+	_, err := f.db.NewInsert().Model(tpl).ModelTableExpr(`activities.groups AS "group"`).Exec(f.ctx)
+	require.NoError(t, err)
+	f.templateIDs = append(f.templateIDs, tpl.ID)
+	return tpl
+}
+
+func assertInstanceExists(t *testing.T, f *instFixture, id int64, wantExists bool) {
+	t.Helper()
+	assertRowExists(t, f, "schedule.activity_instances", id, wantExists)
+}
+
+func assertExceptionExists(t *testing.T, f *instFixture, id int64, wantExists bool) {
+	t.Helper()
+	assertRowExists(t, f, "schedule.activity_exceptions", id, wantExists)
+}
+
+func assertRowExists(t *testing.T, f *instFixture, table string, id int64, wantExists bool, msgAndArgs ...any) {
+	t.Helper()
+	got, err := f.db.NewSelect().Table(table).Where("id = ?", id).Exists(f.ctx)
+	require.NoError(t, err)
+	if wantExists {
+		assert.True(t, got, append([]any{fmt.Sprintf("%s row %d should exist", table, id)}, msgAndArgs...)...)
+	} else {
+		assert.False(t, got, append([]any{fmt.Sprintf("%s row %d should be deleted", table, id)}, msgAndArgs...)...)
+	}
+}
+
+// ensureOtherSchool returns the ID of a school with the given ID. If the
+// tenant ID is already taken, returns 0 to signal "skip deletion on cleanup".
+// If we created it, returns the created ID for cleanup. We use a fixed ID of
+// 2 here — tenant_id=2 is whitelisted.
+func ensureOtherSchool(t *testing.T, db *bun.DB, ctx context.Context, tenantID int64) int64 {
+	t.Helper()
+	exists, err := db.NewSelect().Table("platform.schools").Where("id = ?", tenantID).Exists(ctx)
+	require.NoError(t, err)
+	if exists {
+		return 0
+	}
+	// Create a minimal organization + school so we can use tenant_id=2.
+	suffix := time.Now().UnixNano()
+	orgName := fmt.Sprintf("test-org-%d", suffix)
+	var orgID int64
+	err = db.NewRaw(
+		`INSERT INTO platform.organizations (name, slug) VALUES (?, ?) RETURNING id`,
+		orgName, fmt.Sprintf("org-%d", suffix),
+	).Scan(ctx, &orgID)
+	require.NoError(t, err)
+	_, err = db.NewRaw(
+		`INSERT INTO platform.schools (id, organization_id, name, slug, subdomain)
+		 VALUES (?, ?, ?, ?, ?)`,
+		tenantID, orgID,
+		fmt.Sprintf("other-school-%d", suffix),
+		fmt.Sprintf("other-%d", suffix),
+		fmt.Sprintf("sub-%d", suffix),
+	).Exec(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.NewDelete().Table("platform.organizations").Where("id = ?", orgID).Exec(ctx)
+	})
+	return tenantID
+}

--- a/backend/services/schedule/timetable_cleanup_service_test.go
+++ b/backend/services/schedule/timetable_cleanup_service_test.go
@@ -13,6 +13,7 @@ import (
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -176,13 +177,14 @@ func setupFixture(t *testing.T) (*instFixture, int64) {
 }
 
 // newCleanupSvc builds a TimetableCleanupService wired against the real
-// audit repo + no settings service (so retention falls to the env/default).
-// Tests that need the settings service build it themselves.
+// audit repo + no settings service (so retention falls to the 365-day
+// literal default). Tests that need to override retention build their own
+// service with a stubSettingsService.
 func newCleanupSvc(db *bun.DB) scheduleSvc.TimetableCleanupService {
 	return scheduleSvc.NewTimetableCleanupService(
 		db,
 		auditRepoPkg.NewDataDeletionRepository(db),
-		nil, // no settings — retention falls to env var or 365 default
+		nil, // no settings — retention falls through to the 365-day default
 		slog.Default(),
 	)
 }
@@ -300,13 +302,18 @@ func TestCleanup_CASCADE_DeletesInstanceChildren(t *testing.T) {
 }
 
 func TestCleanup_RetentionOverride_UsesOverriddenDays(t *testing.T) {
-	// Tests the env-var fallback path in resolveRetentionDays. Setting the
-	// env var narrows the window to 30 days; a 60-day-old instance becomes
-	// deletable even though the registry default (365) would have spared it.
-	t.Setenv("TIMETABLE_RETENTION_DAYS", "30")
-
+	// Tenant override narrows the window to 30 days; a 60-day-old instance
+	// becomes deletable even though the registry default (365) would have
+	// spared it. Wires a stubSettingsService that reports HasTenantOverride
+	// = true and ResolveInt = 30 — the same contract the real settings
+	// service provides when a school admin sets the value in the UI.
 	f, roomID := setupFixture(t)
-	svc := newCleanupSvc(f.db)
+	svc := scheduleSvc.NewTimetableCleanupService(
+		f.db,
+		auditRepoPkg.NewDataDeletionRepository(f.db),
+		&stubSettingsService{hasOverride: true, intVal: 30},
+		slog.Default(),
+	)
 
 	sixtyDaysOld := time.Now().UTC().AddDate(0, 0, -60)
 	tenDaysOld := time.Now().UTC().AddDate(0, 0, -10)
@@ -316,7 +323,7 @@ func TestCleanup_RetentionOverride_UsesOverriddenDays(t *testing.T) {
 
 	r, err := svc.CleanupExpiredTimetableData(f.ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 30, r.RetentionDays, "env var overrides default 365")
+	assert.Equal(t, 30, r.RetentionDays, "tenant override must win over registry default")
 	assert.Equal(t, 1, r.InstancesDeleted, "60-day-old row past 30-day window")
 
 	assertRowExists(t, f, "schedule.activity_instances", oldID, false)
@@ -566,6 +573,66 @@ func TestCleanup_AuditWriteFailure_BubblesError(t *testing.T) {
 	require.Error(t, err, "audit failure must bubble up")
 	assertRowExists(t, f, "schedule.activity_instances", instID, true,
 		"audit-before-delete ordering means the DELETE did not fire")
+}
+
+// TestCleanup_InsideWithTenantTx_Rollback_UndoesEverything proves the
+// atomicity claim in the package doc: when the caller wraps
+// CleanupExpiredTimetableData in tenant.WithTenantTx and the tx body returns
+// an error, the audit rows AND the DELETEs are both rolled back — so the
+// tenant's data is left exactly as it was before the cleanup attempt.
+//
+// This is the production contract: the scheduler and CLI both invoke the
+// service inside a WithTenantTx, so a DB failure anywhere during or after
+// cleanup must leave no partial state behind. The ordering-only test
+// (TestCleanup_AuditWriteFailure_BubblesError) runs outside a tx and can't
+// prove this — this test does.
+func TestCleanup_InsideWithTenantTx_Rollback_UndoesEverything(t *testing.T) {
+	f, roomID := setupFixture(t)
+	svc := newCleanupSvc(f.db)
+
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	inst1 := f.newInstance(t, old, scheduleModels.InstanceStatusCompleted, roomID, nil)
+	inst2 := f.newInstance(t, old, scheduleModels.InstanceStatusCancelled, roomID, nil)
+
+	stud := testpkg.CreateTestStudent(t, f.db, "Rollback", fmt.Sprintf("Stud-%d", time.Now().UnixNano()), "3a")
+	f.studentIDs = append(f.studentIDs, stud.ID)
+	f.attachStudent(t, inst1, stud.ID, nil)
+	f.attachStudent(t, inst2, stud.ID, nil)
+
+	rollbackErr := errors.New("simulated caller-side failure after cleanup")
+	txCtx := tenant.WithTenantID(context.Background(), testTenantID)
+	err := tenant.WithTenantTx(txCtx, f.db, testTenantID, func(innerCtx context.Context, _ bun.Tx) error {
+		// Cleanup succeeds inside the tx: audit row is written, both
+		// instances are DELETEd (CASCADE removes the instance_students rows).
+		result, cErr := svc.CleanupExpiredTimetableData(innerCtx)
+		require.NoError(t, cErr, "cleanup itself must succeed")
+		require.Equal(t, 2, result.InstancesDeleted)
+		require.Equal(t, 1, result.StudentsAffected)
+		// Return an error so the tx rolls back. In production this simulates
+		// any failure that happens in the caller after cleanup returns —
+		// e.g., a scheduler-level commit failure or a chained operation that
+		// errors. The atomicity guarantee says cleanup's writes must be
+		// undone.
+		return rollbackErr
+	})
+	require.ErrorIs(t, err, rollbackErr)
+
+	// Both instance rows are back — the DELETEs were rolled back.
+	assertRowExists(t, f, "schedule.activity_instances", inst1, true,
+		"rollback must restore inst1")
+	assertRowExists(t, f, "schedule.activity_instances", inst2, true,
+		"rollback must restore inst2")
+
+	// The audit row is gone — the INSERT was rolled back too. This is the
+	// key check: without atomicity, we'd have an audit row claiming data
+	// was deleted when it actually wasn't.
+	auditCount, err := f.db.NewSelect().Table("audit.data_deletions").
+		Where("tenant_id = ? AND student_id = ? AND deletion_type = ?",
+			testTenantID, stud.ID, auditModels.DeletionTypeTimetableRetention).
+		Count(f.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, auditCount,
+		"rollback must undo audit rows — otherwise compliance log lies about deleted data")
 }
 
 // --- Helpers ---

--- a/backend/services/scheduler/for_each_tenant_wired_test.go
+++ b/backend/services/scheduler/for_each_tenant_wired_test.go
@@ -1,0 +1,95 @@
+// Integration coverage for the wired branches of forEachTenant and
+// forEachTenantSettings — the paths that delegate to tenant.ForEachActive when
+// both db and schoolRepo are set. The fallback branches (nil db / nil
+// schoolRepo) are covered in setters_test.go.
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	platformRepo "github.com/moto-nrw/project-phoenix/database/repositories/platform"
+	"github.com/moto-nrw/project-phoenix/models/platform"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// erroringSchoolRepo embeds the real repo and overrides only ListActive so the
+// admin-tx listing step in tenant.ForEachActive returns an error. The rest of
+// the interface is delegated — we only care about the one method ForEachActive
+// exercises.
+type erroringSchoolRepo struct {
+	platform.SchoolRepository
+	err error
+}
+
+func (e *erroringSchoolRepo) ListActive(_ context.Context) ([]platform.School, error) {
+	return nil, e.err
+}
+
+func TestForEachTenant_Wired_InvokesFnPerTenant(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+
+	s := &Scheduler{
+		db:         db,
+		schoolRepo: platformRepo.NewSchoolRepository(db),
+		logger:     slog.Default(),
+	}
+
+	var invocations int
+	err := s.forEachTenant(context.Background(), "wired-iter", func(_ context.Context) error {
+		invocations++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, invocations, 1,
+		"wired iteration must invoke fn at least once for the seeded test tenant")
+}
+
+func TestForEachTenantSettings_Wired_InvokesFnWithTenantID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+
+	s := &Scheduler{
+		db:         db,
+		schoolRepo: platformRepo.NewSchoolRepository(db),
+		logger:     slog.Default(),
+	}
+
+	var gotTenantID int64
+	var invocations int
+	s.forEachTenantSettings(context.Background(), "wired-settings", func(_ context.Context, tenantID int64) error {
+		invocations++
+		gotTenantID = tenantID
+		return nil
+	})
+
+	assert.GreaterOrEqual(t, invocations, 1, "wired path must invoke fn for seeded tenant")
+	assert.NotZero(t, gotTenantID, "wired path must supply the real tenant ID")
+}
+
+func TestForEachTenantSettings_Wired_ListerError_IsLogged(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+
+	// Real repo provides the embedded type plus TxFromContext wiring; the
+	// lister error comes from our override.
+	s := &Scheduler{
+		db: db,
+		schoolRepo: &erroringSchoolRepo{
+			SchoolRepository: platformRepo.NewSchoolRepository(db),
+			err:              errors.New("listing exploded"),
+		},
+		logger: slog.Default(),
+	}
+
+	var invoked bool
+	s.forEachTenantSettings(context.Background(), "wired-err", func(_ context.Context, _ int64) error {
+		invoked = true
+		return nil
+	})
+	// The error path logs and returns — fn is never invoked because the
+	// tenant list failed before iteration could start.
+	assert.False(t, invoked, "fn must not run when the admin listing fails")
+}

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -209,6 +209,8 @@ func (s *Scheduler) SetInstanceOverdueDeps(repo scheduleModel.ActivityInstanceRe
 
 // forEachTenant executes fn for each active tenant inside a WithTenantTx.
 // If schoolRepo or db is not set, falls back to running fn with plain ctx (non-tenant-aware mode).
+// Thin wrapper over tenant.ForEachActive; the scheduler-owned fallback to non-tenant-aware mode
+// is preserved so existing tests that do not wire a school repo keep working.
 func (s *Scheduler) forEachTenant(ctx context.Context, opName string, fn func(ctx context.Context) error) error {
 	if s.db == nil || s.schoolRepo == nil {
 		s.getLogger().Warn("tenant iteration not configured, running without tenant context",
@@ -216,35 +218,14 @@ func (s *Scheduler) forEachTenant(ctx context.Context, opName string, fn func(ct
 		return fn(ctx)
 	}
 
-	// List active tenants using admin context
-	var schools []platform.School
-	err := tenant.WithAdminTx(ctx, s.db, func(txCtx context.Context, tx bun.Tx) error {
-		var listErr error
-		schools, listErr = s.schoolRepo.ListActive(txCtx)
-		return listErr
+	return tenant.ForEachActive(ctx, s.db, s.schoolRepo, s.getLogger(), opName, func(txCtx context.Context, _ int64) error {
+		return fn(txCtx)
 	})
-	if err != nil {
-		return fmt.Errorf("scheduler: list active tenants for %s: %w", opName, err)
-	}
-
-	for _, school := range schools {
-		tenantErr := tenant.WithTenantTx(ctx, s.db, school.ID, func(txCtx context.Context, tx bun.Tx) error {
-			return fn(txCtx)
-		})
-		if tenantErr != nil {
-			s.getLogger().Error("tenant operation failed, continuing to next tenant",
-				slog.String("operation", opName),
-				slog.Int64("tenant_id", school.ID),
-				slog.Any("error", tenantErr))
-			continue
-		}
-	}
-
-	return nil
 }
 
 // forEachTenantSettings executes fn for each active tenant, passing tenant ID for settings resolution.
-// Falls back to non-tenant-aware mode if schoolRepo/db is not set.
+// Falls back to non-tenant-aware mode if schoolRepo/db is not set (tests, local dev without
+// seeded schools). Shared with the CLI via tenant.ForEachActive.
 func (s *Scheduler) forEachTenantSettings(ctx context.Context, opName string, fn func(ctx context.Context, tenantID int64) error) {
 	if s.db == nil || s.schoolRepo == nil {
 		s.getLogger().Warn("tenant iteration not configured, running without tenant context",
@@ -253,31 +234,11 @@ func (s *Scheduler) forEachTenantSettings(ctx context.Context, opName string, fn
 		return
 	}
 
-	var schools []platform.School
-	err := tenant.WithAdminTx(ctx, s.db, func(txCtx context.Context, _ bun.Tx) error {
-		var listErr error
-		schools, listErr = s.schoolRepo.ListActive(txCtx)
-		return listErr
-	})
-	if err != nil {
+	if err := tenant.ForEachActive(ctx, s.db, s.schoolRepo, s.getLogger(), opName, fn); err != nil {
 		s.getLogger().Error("failed to list active tenants",
 			slog.String("operation", opName),
 			slog.String("error", err.Error()),
 		)
-		return
-	}
-
-	for _, school := range schools {
-		tenantErr := tenant.WithTenantTx(ctx, s.db, school.ID, func(txCtx context.Context, _ bun.Tx) error {
-			return fn(txCtx, school.ID)
-		})
-		if tenantErr != nil {
-			s.getLogger().Error("tenant operation failed, continuing to next tenant",
-				slog.String("operation", opName),
-				slog.Int64("tenant_id", school.ID),
-				slog.Any("error", tenantErr),
-			)
-		}
 	}
 }
 

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -82,6 +82,7 @@ type Scheduler struct {
 	breakAutoEnder     BreakAutoEnder
 	feedbackCleaner    FeedbackCleaner
 	materializer       scheduleSvc.MaterializationService
+	timetableCleanup   scheduleSvc.TimetableCleanupService
 	settings           SettingsResolver
 	db                 *bun.DB
 	schoolRepo         platform.SchoolRepository
@@ -101,11 +102,12 @@ type Scheduler struct {
 	breakAutoEndIntervalSeconds int
 
 	// Per-tenant tracking for minute-polling (keyed by tenant ID)
-	lastSessionEnd      sync.Map // tenant_id → time.Time
-	lastDataCleanup     sync.Map // tenant_id → time.Time
-	lastSessionCleanup  sync.Map // tenant_id → time.Time
-	lastStatusFlagClear sync.Map // tenant_id → time.Time
-	lastMaterialization sync.Map // tenant_id → time.Time
+	lastSessionEnd       sync.Map // tenant_id → time.Time
+	lastDataCleanup      sync.Map // tenant_id → time.Time
+	lastSessionCleanup   sync.Map // tenant_id → time.Time
+	lastStatusFlagClear  sync.Map // tenant_id → time.Time
+	lastMaterialization  sync.Map // tenant_id → time.Time
+	lastTimetableCleanup sync.Map // tenant_id → time.Time (WP-B14)
 
 	// Overdue instance tracking (WP-B9). Re-fire guard so the same instance
 	// does not emit `instance_overdue` every minute for the same planned
@@ -181,6 +183,14 @@ func (s *Scheduler) SetMaterializer(m scheduleSvc.MaterializationService) {
 	s.materializer = m
 }
 
+// SetTimetableCleanup wires the timetable GDPR cleanup service (WP-B14). When
+// set, the scheduler registers the daily timetable-cleanup task in Start().
+// Nil is a valid configuration — the task simply does not register, matching
+// the opt-in shape of SetMaterializer.
+func (s *Scheduler) SetTimetableCleanup(svc scheduleSvc.TimetableCleanupService) {
+	s.timetableCleanup = svc
+}
+
 // SetDB sets the database connection for tenant-aware operations.
 func (s *Scheduler) SetDB(db *bun.DB) {
 	s.db = db
@@ -248,6 +258,11 @@ func (s *Scheduler) Start() {
 
 	// Schedule daily data cleanup at 2 AM
 	s.scheduleCleanupTask()
+
+	// Schedule daily timetable GDPR cleanup (WP-B14). Shares the same toggle
+	// and time as scheduleCleanupTask so admins configure one nightly window
+	// for all retention jobs.
+	s.scheduleTimetableCleanupTask()
 
 	// Schedule daily session end at configurable time (default 6 PM)
 	s.scheduleSessionEndTask()
@@ -1752,4 +1767,141 @@ func combineDayAndTime(day, tod time.Time) time.Time {
 	local := day.Local()
 	return time.Date(local.Year(), local.Month(), local.Day(),
 		tod.Hour(), tod.Minute(), tod.Second(), tod.Nanosecond(), time.Local)
+}
+
+// --- Timetable GDPR cleanup (WP-B14) ---
+//
+// Runs daily, gated on the SAME KeyDataCleanupEnabled toggle as the visits
+// cleanup. Admins configure one nightly window; both retention jobs honor it.
+// Deletes activity_instances (CASCADEs to instance_staff + instance_students)
+// and activity_exceptions older than the tenant's gdpr.timetable_retention_days.
+// Per-tenant iteration via forEachTenantSettings; dedupe via lastTimetableCleanup.
+
+// scheduleTimetableCleanupTask registers the daily timetable cleanup task
+// when a TimetableCleanupService has been wired in. Nil service → no task.
+func (s *Scheduler) scheduleTimetableCleanupTask() {
+	if s.timetableCleanup == nil {
+		s.getLogger().Info("timetable GDPR cleanup not configured (no TimetableCleanupService)")
+		return
+	}
+
+	task := &ScheduledTask{
+		Name:     "timetable-cleanup",
+		Schedule: "1m-poll",
+	}
+
+	s.mu.Lock()
+	s.tasks[task.Name] = task
+	s.mu.Unlock()
+
+	s.wg.Add(1)
+	go s.runTimetableCleanupTaskPolling(task)
+}
+
+// runTimetableCleanupTaskPolling ticks every minute and defers to
+// checkAndRunTimetableCleanup. Minute-aligned so HH:MM:00 ticks land
+// deterministically.
+func (s *Scheduler) runTimetableCleanupTaskPolling(task *ScheduledTask) {
+	defer s.wg.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			err := fmt.Errorf("panic in timetable cleanup task: %v", r)
+			s.getLogger().Error("goroutine panic recovered", slog.String("error", err.Error()))
+			sentry.CurrentHub().Recover(r)
+			sentry.Flush(2 * time.Second)
+		}
+	}()
+
+	s.getLogger().Info("timetable cleanup task using minute-polling for per-tenant scheduling")
+
+	s.checkAndRunTimetableCleanup(task)
+
+	if !s.waitUntilNextMinute() {
+		return
+	}
+
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.checkAndRunTimetableCleanup(task)
+		case <-s.done:
+			return
+		}
+	}
+}
+
+// checkAndRunTimetableCleanup evaluates each tenant's cleanup settings and
+// runs timetable cleanup if the configured cleanup time matches now. Shares
+// KeyDataCleanupEnabled + KeyDataCleanupTime + KeyDataCleanupTimeoutMinutes
+// with the visits cleanup task — one admin switch for all nightly retention.
+func (s *Scheduler) checkAndRunTimetableCleanup(task *ScheduledTask) {
+	task.mu.Lock()
+	if task.Running {
+		task.mu.Unlock()
+		return
+	}
+	task.Running = true
+	task.mu.Unlock()
+	defer func() {
+		task.mu.Lock()
+		task.Running = false
+		task.mu.Unlock()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
+	defer cancel()
+
+	s.forEachTenantSettings(ctx, "timetable-cleanup-check", func(tenantCtx context.Context, tenantID int64) error {
+		enabled := s.resolveBoolSetting(tenantCtx, configModel.KeyDataCleanupEnabled, "CLEANUP_SCHEDULER_ENABLED", true)
+		if !enabled {
+			return nil
+		}
+
+		cleanupTime := s.resolveStringSetting(tenantCtx, configModel.KeyDataCleanupTime, "CLEANUP_SCHEDULER_TIME", "02:00")
+		if !timeMatchesNow(cleanupTime) {
+			return nil
+		}
+
+		if wasRunToday(&s.lastTimetableCleanup, tenantID) {
+			return nil
+		}
+
+		// Mark immediately to prevent double-fire from concurrent ticks
+		markRunToday(&s.lastTimetableCleanup, tenantID)
+
+		s.getLogger().Info("running timetable GDPR cleanup for tenant",
+			slog.Int64("tenant_id", tenantID),
+			slog.String("cleanup_time", cleanupTime),
+		)
+
+		timeoutMinutes := s.resolveIntSetting(tenantCtx, configModel.KeyDataCleanupTimeoutMinutes, "CLEANUP_SCHEDULER_TIMEOUT_MINUTES", 30)
+		cleanupCtx, cleanupCancel := context.WithTimeout(tenantCtx, time.Duration(timeoutMinutes)*time.Minute)
+		defer cleanupCancel()
+
+		result, err := s.timetableCleanup.CleanupExpiredTimetableData(cleanupCtx)
+		if err != nil {
+			s.getLogger().Error("timetable cleanup failed for tenant",
+				slog.Int64("tenant_id", tenantID),
+				slog.String("error", err.Error()),
+			)
+			// Clear today-mark so retry on next matching minute succeeds.
+			s.lastTimetableCleanup.Delete(tenantID)
+			return nil
+		}
+
+		if result.InstancesDeleted > 0 || result.ExceptionsDeleted > 0 {
+			s.getLogger().Info("timetable cleanup completed for tenant",
+				slog.Int64("tenant_id", tenantID),
+				slog.Int("instances_deleted", result.InstancesDeleted),
+				slog.Int("exceptions_deleted", result.ExceptionsDeleted),
+				slog.Int("students_affected", result.StudentsAffected),
+				slog.Int("retention_days", result.RetentionDays),
+				slog.Int64("duration_ms", result.DurationMS),
+			)
+		}
+		return nil
+	})
 }

--- a/backend/services/scheduler/timetable_cleanup_test.go
+++ b/backend/services/scheduler/timetable_cleanup_test.go
@@ -1,0 +1,351 @@
+// Coverage tests for the WP-B14 timetable cleanup scheduler task:
+// SetTimetableCleanup wiring, scheduleTimetableCleanupTask nil-vs-registered
+// branches, the runTimetableCleanupTaskPolling loop (startup + done-exit +
+// ticker fires), and every branch of checkAndRunTimetableCleanup (disabled,
+// wrong time, wasRunToday dedupe, happy path, service error, zero-counter
+// log suppression).
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTimetableCleanup is a test double for scheduleSvc.TimetableCleanupService.
+type fakeTimetableCleanup struct {
+	mu           sync.Mutex
+	cleanupCalls int
+	result       *scheduleSvc.TimetableCleanupResult
+	err          error
+}
+
+func (f *fakeTimetableCleanup) CleanupExpiredTimetableData(_ context.Context) (*scheduleSvc.TimetableCleanupResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cleanupCalls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.result != nil {
+		return f.result, nil
+	}
+	return &scheduleSvc.TimetableCleanupResult{Success: true}, nil
+}
+
+func (f *fakeTimetableCleanup) PreviewExpiredTimetableData(_ context.Context) (*scheduleSvc.TimetableCleanupPreview, error) {
+	return nil, nil
+}
+
+func (f *fakeTimetableCleanup) GetStats(_ context.Context) (*scheduleSvc.TimetableCleanupStats, error) {
+	return nil, nil
+}
+
+// -----------------------------------------------------------------------------
+// SetTimetableCleanup — pure setter
+// -----------------------------------------------------------------------------
+
+func TestSetTimetableCleanup(t *testing.T) {
+	s := NewScheduler(nil, nil, nil, nil, nil, nil, slog.Default())
+	assert.Nil(t, s.timetableCleanup)
+
+	svc := &fakeTimetableCleanup{}
+	s.SetTimetableCleanup(svc)
+	assert.Same(t, svc, s.timetableCleanup)
+}
+
+// -----------------------------------------------------------------------------
+// scheduleTimetableCleanupTask — nil service vs. registered
+// -----------------------------------------------------------------------------
+
+func TestScheduleTimetableCleanupTask_NilService(t *testing.T) {
+	s := &Scheduler{
+		done:   make(chan struct{}),
+		logger: slog.Default(),
+		tasks:  make(map[string]*ScheduledTask),
+	}
+	s.scheduleTimetableCleanupTask()
+	assert.Empty(t, s.tasks, "nil service → no task registered")
+}
+
+func TestScheduleTimetableCleanupTask_RegistersTask(t *testing.T) {
+	s := &Scheduler{
+		done:             make(chan struct{}),
+		logger:           slog.Default(),
+		tasks:            make(map[string]*ScheduledTask),
+		timetableCleanup: &fakeTimetableCleanup{},
+	}
+	// Pre-close done so the spawned goroutine exits promptly after the startup
+	// check and waitUntilNextMinute returns false.
+	close(s.done)
+
+	s.scheduleTimetableCleanupTask()
+	s.wg.Wait()
+
+	s.mu.RLock()
+	task, ok := s.tasks["timetable-cleanup"]
+	s.mu.RUnlock()
+	require.True(t, ok, "timetable-cleanup task must be registered")
+	assert.Equal(t, "1m-poll", task.Schedule)
+}
+
+// -----------------------------------------------------------------------------
+// runTimetableCleanupTaskPolling — startup + done-exit + ticker
+// -----------------------------------------------------------------------------
+
+func TestRunTimetableCleanupTaskPolling_ExitsOnDone(t *testing.T) {
+	// Pre-close done so waitUntilNextMinute returns false right after the
+	// startup check completes.
+	svc := &fakeTimetableCleanup{}
+	s := &Scheduler{
+		done:             make(chan struct{}),
+		logger:           slog.Default(),
+		tasks:            make(map[string]*ScheduledTask),
+		timetableCleanup: svc,
+	}
+	close(s.done)
+	task := &ScheduledTask{Name: "timetable-cleanup"}
+
+	finished := make(chan struct{})
+	s.wg.Add(1)
+	go func() {
+		s.runTimetableCleanupTaskPolling(task)
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runTimetableCleanupTaskPolling did not exit on done signal")
+	}
+}
+
+func TestRunTimetableCleanupTaskPolling_TickerFires(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		svc := &fakeTimetableCleanup{}
+		s := &Scheduler{
+			done:             make(chan struct{}),
+			logger:           slog.Default(),
+			tasks:            make(map[string]*ScheduledTask),
+			timetableCleanup: svc,
+		}
+		task := &ScheduledTask{Name: "timetable-cleanup"}
+
+		s.wg.Add(1)
+		go s.runTimetableCleanupTaskPolling(task)
+
+		// Advance the fake clock past waitUntilNextMinute + a couple of ticker
+		// intervals so the ticker.C branch + done-exit branch both execute.
+		time.Sleep(3 * time.Minute)
+		synctest.Wait()
+
+		close(s.done)
+		s.wg.Wait()
+
+		// At minimum: the startup check + at least one ticker tick.
+		// No enabled tenant → cleanupCalls stays at 0, but the polling loop
+		// itself has run. Verify via the task's internal state instead.
+	})
+}
+
+// -----------------------------------------------------------------------------
+// checkAndRunTimetableCleanup — every branch
+// -----------------------------------------------------------------------------
+
+func TestCheckAndRunTimetableCleanup_AlreadyRunning(t *testing.T) {
+	svc := &fakeTimetableCleanup{}
+	s := &Scheduler{
+		logger:           slog.Default(),
+		timetableCleanup: svc,
+	}
+	task := &ScheduledTask{Name: "timetable-cleanup", Running: true}
+
+	s.checkAndRunTimetableCleanup(task)
+
+	assert.Equal(t, 0, svc.cleanupCalls, "must skip work when task is already running")
+}
+
+func TestCheckAndRunTimetableCleanup_Disabled(t *testing.T) {
+	// When the KeyDataCleanupEnabled setting resolves to false, cleanup must
+	// skip. With no settings resolver and no env vars, resolveBoolSetting
+	// returns the defaultVal (true) — so flip it explicitly via the resolver.
+	svc := &fakeTimetableCleanup{}
+	s := &Scheduler{
+		logger:           slog.Default(),
+		timetableCleanup: svc,
+		settings: &fakeSettingsResolver{
+			boolValues: map[string]bool{
+				configModel.KeyDataCleanupEnabled: false,
+			},
+		},
+	}
+	task := &ScheduledTask{Name: "timetable-cleanup"}
+
+	s.checkAndRunTimetableCleanup(task)
+
+	assert.Equal(t, 0, svc.cleanupCalls, "disabled tenant must not invoke cleanup")
+	task.mu.Lock()
+	assert.False(t, task.Running, "Running flag must be cleared after run")
+	task.mu.Unlock()
+}
+
+func TestCheckAndRunTimetableCleanup_WrongTime(t *testing.T) {
+	// Enabled, but the configured cleanup time doesn't match now. Use a string
+	// that is guaranteed to differ from the current wall clock minute.
+	future := time.Now().Add(2 * time.Hour).Format("15:04")
+
+	svc := &fakeTimetableCleanup{}
+	s := &Scheduler{
+		logger:           slog.Default(),
+		timetableCleanup: svc,
+		settings: &fakeSettingsResolver{
+			boolValues: map[string]bool{
+				configModel.KeyDataCleanupEnabled: true,
+			},
+			stringValues: map[string]string{
+				configModel.KeyDataCleanupTime: future,
+			},
+		},
+	}
+	task := &ScheduledTask{Name: "timetable-cleanup"}
+
+	s.checkAndRunTimetableCleanup(task)
+	assert.Equal(t, 0, svc.cleanupCalls, "wrong time must skip cleanup")
+}
+
+func TestCheckAndRunTimetableCleanup_WasRunToday(t *testing.T) {
+	// Enabled + matching time, but lastTimetableCleanup is already stamped for
+	// today → dedupe must prevent a second run.
+	now := time.Now().Format("15:04")
+
+	svc := &fakeTimetableCleanup{}
+	s := &Scheduler{
+		logger:           slog.Default(),
+		timetableCleanup: svc,
+		settings: &fakeSettingsResolver{
+			boolValues: map[string]bool{
+				configModel.KeyDataCleanupEnabled: true,
+			},
+			stringValues: map[string]string{
+				configModel.KeyDataCleanupTime: now,
+			},
+		},
+	}
+	// forEachTenantSettings falls back to tenantID=0 when db/schoolRepo are nil.
+	s.lastTimetableCleanup.Store(int64(0), time.Now())
+	task := &ScheduledTask{Name: "timetable-cleanup"}
+
+	s.checkAndRunTimetableCleanup(task)
+	assert.Equal(t, 0, svc.cleanupCalls, "already-ran-today dedupe must skip cleanup")
+}
+
+func TestCheckAndRunTimetableCleanup_HappyPath(t *testing.T) {
+	now := time.Now().Format("15:04")
+
+	svc := &fakeTimetableCleanup{
+		result: &scheduleSvc.TimetableCleanupResult{
+			Success:           true,
+			InstancesDeleted:  5,
+			ExceptionsDeleted: 2,
+			StudentsAffected:  3,
+			RetentionDays:     365,
+			CutoffDate:        time.Now(),
+			DurationMS:        42,
+		},
+	}
+	s := &Scheduler{
+		logger:           slog.Default(),
+		timetableCleanup: svc,
+		settings: &fakeSettingsResolver{
+			boolValues: map[string]bool{
+				configModel.KeyDataCleanupEnabled: true,
+			},
+			stringValues: map[string]string{
+				configModel.KeyDataCleanupTime: now,
+			},
+			intValues: map[string]int{
+				configModel.KeyDataCleanupTimeoutMinutes: 30,
+			},
+		},
+	}
+	task := &ScheduledTask{Name: "timetable-cleanup"}
+
+	s.checkAndRunTimetableCleanup(task)
+
+	assert.Equal(t, 1, svc.cleanupCalls, "matching time + enabled + not-run-today → cleanup fires")
+
+	// The today-stamp must be set so a second poll in the same minute is a no-op.
+	_, ok := s.lastTimetableCleanup.Load(int64(0))
+	assert.True(t, ok, "lastTimetableCleanup must record that tenant ran today")
+}
+
+func TestCheckAndRunTimetableCleanup_ServiceError_ClearsTodayStamp(t *testing.T) {
+	now := time.Now().Format("15:04")
+
+	svc := &fakeTimetableCleanup{err: errors.New("cleanup blew up")}
+	s := &Scheduler{
+		logger:           slog.Default(),
+		timetableCleanup: svc,
+		settings: &fakeSettingsResolver{
+			boolValues: map[string]bool{
+				configModel.KeyDataCleanupEnabled: true,
+			},
+			stringValues: map[string]string{
+				configModel.KeyDataCleanupTime: now,
+			},
+		},
+	}
+	task := &ScheduledTask{Name: "timetable-cleanup"}
+
+	assert.NotPanics(t, func() {
+		s.checkAndRunTimetableCleanup(task)
+	})
+	assert.Equal(t, 1, svc.cleanupCalls, "cleanup must be attempted")
+
+	// On service error, the today-stamp is cleared so a retry on the next
+	// matching minute can succeed.
+	_, ok := s.lastTimetableCleanup.Load(int64(0))
+	assert.False(t, ok, "service error must clear today-mark to permit retry")
+}
+
+func TestCheckAndRunTimetableCleanup_ZeroCounters_SuppressesInfoLog(t *testing.T) {
+	// When InstancesDeleted == 0 and ExceptionsDeleted == 0, the success Info
+	// log is suppressed — but the call still counts and the today-mark is set.
+	now := time.Now().Format("15:04")
+
+	svc := &fakeTimetableCleanup{
+		result: &scheduleSvc.TimetableCleanupResult{
+			Success:           true,
+			InstancesDeleted:  0,
+			ExceptionsDeleted: 0,
+		},
+	}
+	s := &Scheduler{
+		logger:           slog.Default(),
+		timetableCleanup: svc,
+		settings: &fakeSettingsResolver{
+			boolValues: map[string]bool{
+				configModel.KeyDataCleanupEnabled: true,
+			},
+			stringValues: map[string]string{
+				configModel.KeyDataCleanupTime: now,
+			},
+		},
+	}
+	task := &ScheduledTask{Name: "timetable-cleanup"}
+
+	s.checkAndRunTimetableCleanup(task)
+
+	assert.Equal(t, 1, svc.cleanupCalls)
+	_, ok := s.lastTimetableCleanup.Load(int64(0))
+	assert.True(t, ok, "zero-counter success path still stamps today-mark")
+}

--- a/backend/tenant/iteration.go
+++ b/backend/tenant/iteration.go
@@ -1,0 +1,66 @@
+package tenant
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/moto-nrw/project-phoenix/models/platform"
+	"github.com/uptrace/bun"
+)
+
+// ActiveSchoolLister lists active tenants for iteration helpers.
+// platform.SchoolRepository satisfies this interface.
+type ActiveSchoolLister interface {
+	ListActive(ctx context.Context) ([]platform.School, error)
+}
+
+// ForEachActive executes fn once per active tenant, each call wrapped in
+// WithTenantTx. Per-tenant errors are logged and swallowed so one broken
+// tenant does not halt the loop — the scheduler and the CLI both want
+// best-effort iteration. The admin listing is wrapped in WithAdminTx.
+//
+// Returns a non-nil error only when the admin listing itself fails. Use
+// opName for structured-log correlation across iteration runs.
+func ForEachActive(
+	ctx context.Context,
+	db *bun.DB,
+	lister ActiveSchoolLister,
+	logger *slog.Logger,
+	opName string,
+	fn func(ctx context.Context, tenantID int64) error,
+) error {
+	if db == nil {
+		return fmt.Errorf("tenant.ForEachActive: db is required")
+	}
+	if lister == nil {
+		return fmt.Errorf("tenant.ForEachActive: lister is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	var schools []platform.School
+	if err := WithAdminTx(ctx, db, func(txCtx context.Context, _ bun.Tx) error {
+		var e error
+		schools, e = lister.ListActive(txCtx)
+		return e
+	}); err != nil {
+		return fmt.Errorf("list active tenants for %s: %w", opName, err)
+	}
+
+	for _, school := range schools {
+		tenantErr := WithTenantTx(ctx, db, school.ID, func(txCtx context.Context, _ bun.Tx) error {
+			return fn(txCtx, school.ID)
+		})
+		if tenantErr != nil {
+			logger.Error("tenant operation failed, continuing to next tenant",
+				slog.String("operation", opName),
+				slog.Int64("tenant_id", school.ID),
+				slog.String("error", tenantErr.Error()),
+			)
+		}
+	}
+
+	return nil
+}

--- a/backend/tenant/iteration_test.go
+++ b/backend/tenant/iteration_test.go
@@ -1,0 +1,148 @@
+package tenant_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/models/platform"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeLister is a test double for tenant.ActiveSchoolLister. It returns the
+// pre-seeded schools (or error) without touching the DB.
+type fakeLister struct {
+	schools []platform.School
+	err     error
+	calls   int32
+}
+
+func (f *fakeLister) ListActive(_ context.Context) ([]platform.School, error) {
+	atomic.AddInt32(&f.calls, 1)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.schools, nil
+}
+
+// --- Guard paths (unit, no DB) ---
+
+func TestForEachActive_NilDB_ReturnsError(t *testing.T) {
+	err := tenant.ForEachActive(context.Background(), nil, &fakeLister{}, slog.Default(), "op",
+		func(_ context.Context, _ int64) error { return nil })
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db is required")
+}
+
+func TestForEachActive_NilLister_ReturnsError(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+
+	err := tenant.ForEachActive(context.Background(), db, nil, slog.Default(), "op",
+		func(_ context.Context, _ int64) error { return nil })
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lister is required")
+}
+
+// --- Integration paths (real DB + fake lister) ---
+
+func TestForEachActive_HappyPath_InvokesFnPerTenant(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+
+	// testpkg.SetupTestDB guarantees tenant_id=1 exists via EnsureTestTenant.
+	lister := &fakeLister{
+		schools: []platform.School{{}, {}},
+	}
+	// Use the real tenant ID so WithTenantTx can SET LOCAL ROLE against an
+	// existing FK target.
+	lister.schools[0].ID = 1
+	lister.schools[1].ID = 1
+
+	var observed []int64
+	err := tenant.ForEachActive(context.Background(), db, lister, slog.Default(), "happy-path",
+		func(_ context.Context, tenantID int64) error {
+			observed = append(observed, tenantID)
+			return nil
+		})
+	require.NoError(t, err)
+	assert.Equal(t, []int64{1, 1}, observed, "fn must run once per listed tenant")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&lister.calls),
+		"ListActive must be called exactly once")
+}
+
+func TestForEachActive_ListerError_BubblesError(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+
+	listErr := errors.New("admin list blew up")
+	lister := &fakeLister{err: listErr}
+
+	err := tenant.ForEachActive(context.Background(), db, lister, slog.Default(), "list-fails",
+		func(_ context.Context, _ int64) error {
+			t.Fatal("fn must not be invoked when listing fails")
+			return nil
+		})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, listErr, "original error must be wrapped, not swallowed")
+	assert.Contains(t, err.Error(), "list-fails", "wrap must include the operation name")
+}
+
+func TestForEachActive_PerTenantError_Swallowed(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+
+	lister := &fakeLister{
+		schools: []platform.School{{}, {}},
+	}
+	lister.schools[0].ID = 1
+	lister.schools[1].ID = 1
+
+	fnErr := errors.New("one tenant fails")
+	var invocations int
+	err := tenant.ForEachActive(context.Background(), db, lister, slog.Default(), "per-tenant-err",
+		func(_ context.Context, _ int64) error {
+			invocations++
+			// Fail on the first tenant; second tenant must still be invoked.
+			if invocations == 1 {
+				return fnErr
+			}
+			return nil
+		})
+	// Per-tenant errors are logged + swallowed; outer ForEachActive returns nil.
+	require.NoError(t, err, "per-tenant errors must be swallowed, not surfaced")
+	assert.Equal(t, 2, invocations, "iteration must continue past per-tenant failures")
+}
+
+func TestForEachActive_NilLogger_FallsBackToDefault(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+
+	lister := &fakeLister{
+		schools: []platform.School{{}},
+	}
+	lister.schools[0].ID = 1
+
+	// Pass nil logger + a failing fn to exercise the logger nil-fallback path
+	// (the error branch that writes to logger).
+	err := tenant.ForEachActive(context.Background(), db, lister, nil, "nil-logger",
+		func(_ context.Context, _ int64) error {
+			return errors.New("boom")
+		})
+	require.NoError(t, err, "nil logger must not panic — ForEachActive substitutes slog.Default()")
+}
+
+func TestForEachActive_EmptyTenantList_Succeeds(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+
+	lister := &fakeLister{schools: nil}
+	var called bool
+
+	err := tenant.ForEachActive(context.Background(), db, lister, slog.Default(), "empty-list",
+		func(_ context.Context, _ int64) error {
+			called = true
+			return nil
+		})
+	require.NoError(t, err)
+	assert.False(t, called, "fn must not be invoked when there are no active tenants")
+}

--- a/backend/test/hermetic_verification_test.go
+++ b/backend/test/hermetic_verification_test.go
@@ -156,6 +156,7 @@ func checkHardcodedIDs(t *testing.T, root string) []string {
 		"api/timetable/instances_test.go",                        // Uses mock InstanceService + PersonService for unit testing handlers
 		"api/timetable/instance_students_unit_test.go",           // Uses fake repo for unit testing attendance PATCH handler
 		"services/schedule/attendance_sync_service_unit_test.go", // Uses fake repos for unit testing graceful-degradation branches
+		"services/schedule/timetable_cleanup_service_test.go",    // Uses failingAuditRepo mock for audit-write-failure rollback coverage (WP-B14)
 	}
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
## Summary

WP-B14 — gives `gdpr.timetable_retention_days` (registered in WP-B7) its first consumer. Daily per-tenant scheduler task + CLI commands that delete `schedule.activity_instances` (CASCADE → `instance_staff` + `instance_students`) and `schedule.activity_exceptions` older than the tenant-configured retention window.

Prioritized over WP-B11 / WP-B12 / WP-B13 because WP-B10 (merged yesterday in #1295) just started writing real student attendance data — including a free-text `note` field up to 500 chars — into `instance_students`. Shipping that without a cleanup job was the wrong ordering for compliance.

## Design decisions worth flagging for review

**Per-student audit rows, not sentinel-0 aggregate.** The original plan proposed one `audit.data_deletions` row per cleanup run with `student_id = 0`. Rejected:
- `audit.data_deletions.student_id` has a `NOT NULL` constraint and `REFERENCES users.students(id) ON DELETE CASCADE` (migration 001003007:180-181). Sentinel `0` would fail at insert with an FK violation.
- More importantly: the audit table exists to answer the GDPR auditor's question *"show me every time student Jane's data was deleted."* A sentinel row makes that query a lie.

So: cleanup queries `instance_students → activity_instances` for distinct students past cutoff, writes one audit row per affected student (real `student_id`, `RecordsDeleted` = per-student count, metadata includes `retention_days`, `cutoff_date`, `instance_ids_sample`). `activity_exceptions` are template-scoped (no PII) and are slog-only. `audit.DataDeletion.Validate()` is **untouched**.

**`tenant.ForEachActive` refactor (scope: kept minimal).** The scheduler had two near-identical tenant-loop helpers (`forEachTenant` / `forEachTenantSettings`) wrapping `WithAdminTx` + per-tenant `WithTenantTx`. WP-B14 adds a CLI path that needs the same iteration. Factoring into `tenant/iteration.go` kills the duplication; scheduler methods collapse to thin wrappers over the new helper. No behavior change — it's strictly a refactor.

**Shared master switch.** The daily timetable cleanup task reuses `KeyDataCleanupEnabled` / `KeyDataCleanupTime` / `KeyDataCleanupTimeoutMinutes`. Admins get one nightly window for all retention jobs. If the platform team later wants a separate toggle, that's a future PR, not WP-B14's call.

**Audit before delete, same transaction.** Per-student audit rows land first, then both `DELETE`s. Everything runs inside the caller's `WithTenantTx` — an audit-write failure rolls back the deletes atomically. Covered by `TestCleanup_AuditWriteFailure_BubblesError` (mock-based, added to `skipPatterns` in `test/hermetic_verification_test.go`).

**All statuses deleted past retention.** Planned / active / completed / cancelled all go. Materialization never produces past-dated rows, so any planned instance older than retention is orphan data. No status filtering.

## What's NOT touched

- **`active.visits`** — existing cleanup (services/active/cleanup_service.go) owns that path. No change.
- **`activities.groups` (templates)**, schedules, enrollments, supervisors — configuration, not operational data. Explicitly covered by `TestCleanup_TemplatesUntouched_OnlyInstancesAndExceptionsDeleted`.
- **IoT boundary** — zero changes under `api/iot/*`. No PyrePortal impact. No error-message changes.

## Consumer for a pre-registered setting

`gdpr.timetable_retention_days` was registered in WP-B7 (`services/config/defaults/timetable.go:137-154`) with default 365, min 30, max 1825, `DependsOn: gdpr.data_cleanup_enabled`. It has had no consumer until now. This PR wires it up end-to-end: admins in the settings UI now see a setting that actually does something.

## Test coverage

`services/schedule/timetable_cleanup_service_test.go` — 11 hermetic integration tests:

- `TestCleanup_HappyPath_DeletesOldRowsKeepsFreshRows`
- `TestCleanup_EmptyTenant_WritesNoAuditRowsForStudents`
- `TestCleanup_Idempotent_SecondRunDeletesZero`
- `TestCleanup_CASCADE_DeletesInstanceChildren`
- `TestCleanup_RetentionOverride_UsesOverriddenDays`
- `TestCleanup_AllStatuses_DeletesPlannedActiveCompletedCancelled`
- `TestCleanup_TemplatesUntouched_OnlyInstancesAndExceptionsDeleted`
- `TestCleanup_PerStudentAuditRows_OneRowPerAffectedStudent`
- `TestCleanup_DeletesGDPRSensitiveNotesViaCascade` — directly validates the compliance motivation: seeds an `instance_students.note` with sensitive text and asserts it's gone via CASCADE
- `TestCleanup_TenantIsolation_OtherTenantDataUntouched`
- `TestCleanup_AuditWriteFailure_BubblesError` (mock)

Plus the unit test for the new `DeletionTypeTimetableRetention` constant.

## Test plan

- [ ] `cd backend && go build ./... && go vet ./...` clean
- [ ] `go test ./services/schedule/ -run TestCleanup` — 11/11 pass
- [ ] `go test ./services/scheduler/... ./cmd/... ./tenant/... ./models/audit/...` — all green
- [ ] `go test ./test/ -run TestHermeticTestPatterns` — pass
- [ ] Manual: `APP_ENV=test go run main.go cleanup timetable preview` against seeded test DB shows per-tenant counts without deleting
- [ ] Manual: seed old instances → `cleanup timetable` → verify instances gone, per-student audit rows written with correct metadata

## Indexes

Both cleanup queries hit existing composite indexes:
- `idx_activity_instances_tenant_date (tenant_id, date)` — migration 001015036:103-104
- `idx_activity_exceptions_date (tenant_id, exception_date)` — migration 001015036:340-341

No new indexes needed.

## Cross-repo impact

None. PyrePortal untouched. IoT endpoints untouched. moto-balenaOS untouched.