### PR TITLE
feat(timetable): WP-B11 student day/week endpoints + B10 complete-marks-absent fix

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -45,7 +45,6 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/database"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
-	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	customMiddleware "github.com/moto-nrw/project-phoenix/middleware"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/services"
@@ -349,34 +348,24 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Database = databaseAPI.NewResource(api.Services.Database, db)
 	api.GradeTransitions = adminAPI.NewGradeTransitionResource(api.Services.GradeTransition, db)
 	api.TimeTracking = timeTrackingAPI.NewResource(api.Services.WorkSession, api.Services.StaffAbsence, api.Services.Users, db)
-	// Type assertion: B11's FindInstancesWithAttendanceByStudentAndDateRange
-	// returns ScheduledInstanceRow (a repo-package type) and is therefore
-	// not declared on the InstanceStudentRepository interface. The factory
-	// hands us the interface value; the concrete type is always
-	// *schedule.InstanceStudentRepository at runtime.
-	studentDayRepo, ok := repoFactory.InstanceStudent.(*scheduleRepo.InstanceStudentRepository)
-	if !ok {
-		logger.Error("expected concrete *schedule.InstanceStudentRepository, got different type")
-	}
-	api.Timetable = timetableAPI.NewResource(
-		api.Services.CalendarPeriod,
-		api.Services.Materialization,
-		api.Services.Instance,
-		api.Services.Users,
-		repoFactory.InstanceStudent,
-		studentDayRepo,
-		repoFactory.ActivityInstance,
-		repoFactory.StudentArrivalSchedule,
-		repoFactory.StudentArrivalException,
-		repoFactory.StudentPickupSchedule,
-		repoFactory.StudentPickupException,
-		repoFactory.ActiveVisit,
-		repoFactory.Student,
-		api.Services.UserContext,
-		api.Services.Settings,
-		logger.With("handler", "timetable"),
-		db,
-	)
+	api.Timetable = timetableAPI.NewResource(timetableAPI.Dependencies{
+		CalendarPeriodService:  api.Services.CalendarPeriod,
+		MaterializationService: api.Services.Materialization,
+		InstanceService:        api.Services.Instance,
+		PersonService:          api.Services.Users,
+		InstanceStudentRepo:    repoFactory.InstanceStudent,
+		ActivityInstanceRepo:   repoFactory.ActivityInstance,
+		ArrivalScheduleRepo:    repoFactory.StudentArrivalSchedule,
+		ArrivalExceptionRepo:   repoFactory.StudentArrivalException,
+		PickupScheduleRepo:     repoFactory.StudentPickupSchedule,
+		PickupExceptionRepo:    repoFactory.StudentPickupException,
+		VisitRepo:              repoFactory.ActiveVisit,
+		StudentRepo:            repoFactory.Student,
+		UserContextService:     api.Services.UserContext,
+		SettingsService:        api.Services.Settings,
+		Logger:                 logger.With("handler", "timetable"),
+		DB:                     db,
+	})
 
 	// Initialize operator dashboard resources
 	api.Operator = operatorAPI.NewResource(operatorAPI.ResourceConfig{

--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/database"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	customMiddleware "github.com/moto-nrw/project-phoenix/middleware"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/services"
@@ -348,12 +349,31 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Database = databaseAPI.NewResource(api.Services.Database, db)
 	api.GradeTransitions = adminAPI.NewGradeTransitionResource(api.Services.GradeTransition, db)
 	api.TimeTracking = timeTrackingAPI.NewResource(api.Services.WorkSession, api.Services.StaffAbsence, api.Services.Users, db)
+	// Type assertion: B11's FindInstancesWithAttendanceByStudentAndDateRange
+	// returns ScheduledInstanceRow (a repo-package type) and is therefore
+	// not declared on the InstanceStudentRepository interface. The factory
+	// hands us the interface value; the concrete type is always
+	// *schedule.InstanceStudentRepository at runtime.
+	studentDayRepo, ok := repoFactory.InstanceStudent.(*scheduleRepo.InstanceStudentRepository)
+	if !ok {
+		logger.Error("expected concrete *schedule.InstanceStudentRepository, got different type")
+	}
 	api.Timetable = timetableAPI.NewResource(
 		api.Services.CalendarPeriod,
 		api.Services.Materialization,
 		api.Services.Instance,
 		api.Services.Users,
 		repoFactory.InstanceStudent,
+		studentDayRepo,
+		repoFactory.ActivityInstance,
+		repoFactory.StudentArrivalSchedule,
+		repoFactory.StudentArrivalException,
+		repoFactory.StudentPickupSchedule,
+		repoFactory.StudentPickupException,
+		repoFactory.ActiveVisit,
+		repoFactory.Student,
+		api.Services.UserContext,
+		api.Services.Settings,
 		logger.With("handler", "timetable"),
 		db,
 	)

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -254,45 +254,19 @@ func (rs *Resource) checkStudentFullAccess(r *http.Request, student *users.Stude
 //
 // This function MUST only be used on read paths. Write operations must use
 // checkStudentFullAccess which ignores the scope setting.
+//
+// Delegates to authorize.CanReadStudent so the same predicate is reusable
+// from other handlers (timetable, per-student day view) without duplicating
+// the scope/admin/supervisor logic.
 func (rs *Resource) checkStudentReadAccess(r *http.Request, student *users.Student) bool {
-	userPermissions := jwt.PermissionsFromCtx(r.Context())
-	if hasAdminPermissions(userPermissions) {
-		return true
-	}
-
-	// Tenant-configurable: when student_data_scope is set to all_staff, any
-	// authenticated staff member gets full read access to any student.
-	// Verify the caller is actually a staff member — other roles (guest,
-	// guardian) with users:read must NOT get unredacted access.
-	scope := configService.ResolveStringOrDefault(
+	return authorize.CanReadStudent(
 		r.Context(),
+		jwt.PermissionsFromCtx(r.Context()),
+		student,
+		rs.UserContextService,
 		rs.SettingsService,
-		configModel.KeyStudentDataScope,
-		configModel.StudentDataScopeGroupSupervisorsOnly,
 		rs.Logger,
 	)
-	if scope == configModel.StudentDataScopeAllStaff {
-		if staff, err := rs.UserContextService.GetCurrentStaff(r.Context()); err == nil && staff != nil {
-			return true
-		}
-	}
-
-	if student.GroupID == nil {
-		return false
-	}
-
-	educationGroups, err := rs.UserContextService.GetMyGroups(r.Context())
-	if err != nil {
-		return false
-	}
-
-	for _, group := range educationGroups {
-		if group.ID == *student.GroupID {
-			return true
-		}
-	}
-
-	return false
 }
 
 // isGroupSupervisorOrAdmin checks if the caller is an admin or supervises the

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -13,7 +13,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
-	scheduleRepoPkg "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/models/users"
@@ -29,17 +28,15 @@ const dateLayout = "2006-01-02"
 
 // Resource defines the timetable API resource.
 //
-// instanceService, personService, instanceStudentRepo, and logger are optional
-// at construction time: tests that only exercise /periods or /materialize can
-// pass nil and will get a 500 on the dependent routes instead of a crash.
-// Production wiring must supply all of them via NewResource.
+// Optional services may be nil in tests that only exercise a subset of routes
+// — the dependent handler will return 500 instead of panicking. Production
+// wiring must populate every field.
 type Resource struct {
 	calendarPeriodService  scheduleSvc.CalendarPeriodService
 	materializationService scheduleSvc.MaterializationService
 	instanceService        scheduleSvc.InstanceService
 	personService          userSvc.PersonService
-	instanceStudentRepo    schedule.InstanceStudentRepository         // B10 PATCH (interface-typed for unit tests with fakes)
-	studentDayRepo         *scheduleRepoPkg.InstanceStudentRepository // B11 read (concrete type; holds FindInstancesWithAttendanceByStudentAndDateRange)
+	instanceStudentRepo    schedule.InstanceStudentRepository
 	activityInstanceRepo   schedule.ActivityInstanceRepository
 	arrivalScheduleRepo    schedule.StudentArrivalScheduleRepository
 	arrivalExceptionRepo   schedule.StudentArrivalExceptionRepository
@@ -53,51 +50,50 @@ type Resource struct {
 	db                     *bun.DB
 }
 
-// NewResource creates a new timetable resource. Optional services (see the
-// Resource doc) may be nil; passing nil for the materialization or instance
-// service makes the corresponding routes return 500 instead of silently
-// misbehaving.
-//
-// The B11 student day/week endpoints require the full set of arrival/pickup/
-// instance/visit repos plus studentRepo, userContextService, settingsService.
-// If any of them is nil, the student-side routes return 500 on request.
-func NewResource(
-	calendarPeriodService scheduleSvc.CalendarPeriodService,
-	materializationService scheduleSvc.MaterializationService,
-	instanceService scheduleSvc.InstanceService,
-	personService userSvc.PersonService,
-	instanceStudentRepo schedule.InstanceStudentRepository,
-	studentDayRepo *scheduleRepoPkg.InstanceStudentRepository,
-	activityInstanceRepo schedule.ActivityInstanceRepository,
-	arrivalScheduleRepo schedule.StudentArrivalScheduleRepository,
-	arrivalExceptionRepo schedule.StudentArrivalExceptionRepository,
-	pickupScheduleRepo schedule.StudentPickupScheduleRepository,
-	pickupExceptionRepo schedule.StudentPickupExceptionRepository,
-	visitRepo active.VisitRepository,
-	studentRepo users.StudentRepository,
-	userContextService usercontextSvc.UserContextService,
-	settingsService configSvc.SettingsService,
-	logger *slog.Logger,
-	db *bun.DB,
-) *Resource {
+// Dependencies bundles everything NewResource needs. Using a struct instead
+// of a positional signature keeps tests — which frequently only populate a
+// subset — readable and lets us add future deps without churning every call
+// site.
+type Dependencies struct {
+	CalendarPeriodService  scheduleSvc.CalendarPeriodService
+	MaterializationService scheduleSvc.MaterializationService
+	InstanceService        scheduleSvc.InstanceService
+	PersonService          userSvc.PersonService
+	InstanceStudentRepo    schedule.InstanceStudentRepository
+	ActivityInstanceRepo   schedule.ActivityInstanceRepository
+	ArrivalScheduleRepo    schedule.StudentArrivalScheduleRepository
+	ArrivalExceptionRepo   schedule.StudentArrivalExceptionRepository
+	PickupScheduleRepo     schedule.StudentPickupScheduleRepository
+	PickupExceptionRepo    schedule.StudentPickupExceptionRepository
+	VisitRepo              active.VisitRepository
+	StudentRepo            users.StudentRepository
+	UserContextService     usercontextSvc.UserContextService
+	SettingsService        configSvc.SettingsService
+	Logger                 *slog.Logger
+	DB                     *bun.DB
+}
+
+// NewResource creates a new timetable resource from the given Dependencies.
+// Nil deps are tolerated at construction time; the dependent handler returns
+// 500 at request time if one of its deps is unset.
+func NewResource(deps Dependencies) *Resource {
 	return &Resource{
-		calendarPeriodService:  calendarPeriodService,
-		materializationService: materializationService,
-		instanceService:        instanceService,
-		personService:          personService,
-		instanceStudentRepo:    instanceStudentRepo,
-		studentDayRepo:         studentDayRepo,
-		activityInstanceRepo:   activityInstanceRepo,
-		arrivalScheduleRepo:    arrivalScheduleRepo,
-		arrivalExceptionRepo:   arrivalExceptionRepo,
-		pickupScheduleRepo:     pickupScheduleRepo,
-		pickupExceptionRepo:    pickupExceptionRepo,
-		visitRepo:              visitRepo,
-		studentRepo:            studentRepo,
-		userContextService:     userContextService,
-		settingsService:        settingsService,
-		logger:                 logger,
-		db:                     db,
+		calendarPeriodService:  deps.CalendarPeriodService,
+		materializationService: deps.MaterializationService,
+		instanceService:        deps.InstanceService,
+		personService:          deps.PersonService,
+		instanceStudentRepo:    deps.InstanceStudentRepo,
+		activityInstanceRepo:   deps.ActivityInstanceRepo,
+		arrivalScheduleRepo:    deps.ArrivalScheduleRepo,
+		arrivalExceptionRepo:   deps.ArrivalExceptionRepo,
+		pickupScheduleRepo:     deps.PickupScheduleRepo,
+		pickupExceptionRepo:    deps.PickupExceptionRepo,
+		visitRepo:              deps.VisitRepo,
+		studentRepo:            deps.StudentRepo,
+		userContextService:     deps.UserContextService,
+		settingsService:        deps.SettingsService,
+		logger:                 deps.Logger,
+		db:                     deps.DB,
 	}
 }
 

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -13,8 +13,13 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	scheduleRepoPkg "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	usercontextSvc "github.com/moto-nrw/project-phoenix/services/usercontext"
 	userSvc "github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
@@ -33,7 +38,17 @@ type Resource struct {
 	materializationService scheduleSvc.MaterializationService
 	instanceService        scheduleSvc.InstanceService
 	personService          userSvc.PersonService
-	instanceStudentRepo    schedule.InstanceStudentRepository // WP-B10 PATCH /instances/{id}/students/{id}
+	instanceStudentRepo    schedule.InstanceStudentRepository         // B10 PATCH (interface-typed for unit tests with fakes)
+	studentDayRepo         *scheduleRepoPkg.InstanceStudentRepository // B11 read (concrete type; holds FindInstancesWithAttendanceByStudentAndDateRange)
+	activityInstanceRepo   schedule.ActivityInstanceRepository
+	arrivalScheduleRepo    schedule.StudentArrivalScheduleRepository
+	arrivalExceptionRepo   schedule.StudentArrivalExceptionRepository
+	pickupScheduleRepo     schedule.StudentPickupScheduleRepository
+	pickupExceptionRepo    schedule.StudentPickupExceptionRepository
+	visitRepo              active.VisitRepository
+	studentRepo            users.StudentRepository
+	userContextService     usercontextSvc.UserContextService
+	settingsService        configSvc.SettingsService
 	logger                 *slog.Logger
 	db                     *bun.DB
 }
@@ -42,12 +57,26 @@ type Resource struct {
 // Resource doc) may be nil; passing nil for the materialization or instance
 // service makes the corresponding routes return 500 instead of silently
 // misbehaving.
+//
+// The B11 student day/week endpoints require the full set of arrival/pickup/
+// instance/visit repos plus studentRepo, userContextService, settingsService.
+// If any of them is nil, the student-side routes return 500 on request.
 func NewResource(
 	calendarPeriodService scheduleSvc.CalendarPeriodService,
 	materializationService scheduleSvc.MaterializationService,
 	instanceService scheduleSvc.InstanceService,
 	personService userSvc.PersonService,
 	instanceStudentRepo schedule.InstanceStudentRepository,
+	studentDayRepo *scheduleRepoPkg.InstanceStudentRepository,
+	activityInstanceRepo schedule.ActivityInstanceRepository,
+	arrivalScheduleRepo schedule.StudentArrivalScheduleRepository,
+	arrivalExceptionRepo schedule.StudentArrivalExceptionRepository,
+	pickupScheduleRepo schedule.StudentPickupScheduleRepository,
+	pickupExceptionRepo schedule.StudentPickupExceptionRepository,
+	visitRepo active.VisitRepository,
+	studentRepo users.StudentRepository,
+	userContextService usercontextSvc.UserContextService,
+	settingsService configSvc.SettingsService,
 	logger *slog.Logger,
 	db *bun.DB,
 ) *Resource {
@@ -57,6 +86,16 @@ func NewResource(
 		instanceService:        instanceService,
 		personService:          personService,
 		instanceStudentRepo:    instanceStudentRepo,
+		studentDayRepo:         studentDayRepo,
+		activityInstanceRepo:   activityInstanceRepo,
+		arrivalScheduleRepo:    arrivalScheduleRepo,
+		arrivalExceptionRepo:   arrivalExceptionRepo,
+		pickupScheduleRepo:     pickupScheduleRepo,
+		pickupExceptionRepo:    pickupExceptionRepo,
+		visitRepo:              visitRepo,
+		studentRepo:            studentRepo,
+		userContextService:     userContextService,
+		settingsService:        settingsService,
 		logger:                 logger,
 		db:                     db,
 	}
@@ -109,6 +148,16 @@ func (rs *Resource) Router() chi.Router {
 			// in a sibling route subtree.
 			r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
 				Patch("/{instance_id}/students/{student_id}", rs.patchInstanceStudent)
+		})
+
+		// WP-B11: per-student day and week read endpoints. Both gated on
+		// SchedulesRead; handler-level auth (authorize.CanReadStudent) adds
+		// the per-student check.
+		r.Route("/student/{id}", func(r chi.Router) {
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
+				Get("/day", rs.getStudentDay)
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
+				Get("/week", rs.getStudentWeek)
 		})
 	})
 

--- a/backend/api/timetable/api_test.go
+++ b/backend/api/timetable/api_test.go
@@ -153,13 +153,13 @@ func newTestPeriod() *schedule.CalendarPeriod {
 // =============================================================================
 
 func TestNewResource(t *testing.T) {
-	res := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	res := NewResource(Dependencies{})
 	assert.NotNil(t, res)
 }
 
 func TestResource_Router(t *testing.T) {
 	mock := &mockCalendarPeriodService{}
-	res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	res := NewResource(Dependencies{CalendarPeriodService: mock})
 	router := res.Router()
 	assert.NotNil(t, router)
 }
@@ -343,7 +343,7 @@ func TestListPeriods(t *testing.T) {
 		p1.UpdatedAt = time.Now()
 
 		mock := &mockCalendarPeriodService{periods: []*schedule.CalendarPeriod{p1}}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -354,7 +354,7 @@ func TestListPeriods(t *testing.T) {
 
 	t.Run("returns empty list", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{periods: []*schedule.CalendarPeriod{}}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -364,7 +364,7 @@ func TestListPeriods(t *testing.T) {
 
 	t.Run("returns 500 on service error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db error")}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -392,7 +392,7 @@ func TestGetPeriod(t *testing.T) {
 		p.UpdatedAt = time.Now()
 
 		mock := &mockCalendarPeriodService{period: p}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/42", nil)
@@ -403,7 +403,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/abc", nil)
@@ -413,7 +413,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 404 when not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/999", nil)
@@ -423,7 +423,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 500 on internal error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db connection failed")}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/42", nil)
@@ -439,7 +439,7 @@ func TestGetPeriod(t *testing.T) {
 func TestCreatePeriod(t *testing.T) {
 	t.Run("creates period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -461,7 +461,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("creates period with week cycle anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		anchor := "2025-09-01"
@@ -484,7 +484,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("defaults week cycle length to 1", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -505,7 +505,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for missing required fields", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{Name: "Only Name"}
@@ -517,7 +517,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid period_type", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -535,7 +535,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid start_date format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -553,7 +553,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid end_date format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -571,7 +571,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid week_cycle_anchor format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		badAnchor := "not-a-date"
@@ -592,7 +592,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for end_date before start_date", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -610,7 +610,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for cycle > 1 without anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -629,7 +629,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 409 for duplicate name", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: schedule.ErrCalendarPeriodNameConflict}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -650,7 +650,7 @@ func TestCreatePeriod(t *testing.T) {
 		mock := &mockCalendarPeriodService{
 			err: &scheduleSvcErr{op: "create calendar period", inner: schedule.ErrCalendarPeriodNameConflict},
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -667,7 +667,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 500 on service error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("create failed")}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -692,7 +692,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("updates period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -714,7 +714,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("updates period with anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -752,7 +752,7 @@ func TestUpdatePeriod(t *testing.T) {
 		anchoredPeriod.WeekCycleAnchor = &anchorTime
 
 		mock := &mockCalendarPeriodService{period: anchoredPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -775,7 +775,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("defaults week cycle length to 1", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -799,7 +799,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -812,7 +812,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 404 when period not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -825,7 +825,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 500 on get internal error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db connection failed")}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -838,7 +838,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid start_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -858,7 +858,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid end_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -878,7 +878,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid anchor in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -901,7 +901,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for end_date before start_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -925,7 +925,7 @@ func TestUpdatePeriod(t *testing.T) {
 			period:    existingPeriod,
 			updateErr: schedule.ErrCalendarPeriodNameConflict,
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -949,7 +949,7 @@ func TestUpdatePeriod(t *testing.T) {
 			period:    existingPeriod,
 			updateErr: errors.New("db write failed"),
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -975,7 +975,7 @@ func TestUpdatePeriod(t *testing.T) {
 func TestDeletePeriod(t *testing.T) {
 	t.Run("deletes period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: newTestPeriod()}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/42", nil)
@@ -986,7 +986,7 @@ func TestDeletePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/abc", nil)
@@ -996,7 +996,7 @@ func TestDeletePeriod(t *testing.T) {
 
 	t.Run("returns 404 when period not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/999", nil)
@@ -1009,7 +1009,7 @@ func TestDeletePeriod(t *testing.T) {
 			period:    newTestPeriod(),
 			deleteErr: errors.New("delete failed"),
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		res := NewResource(Dependencies{CalendarPeriodService: mock})
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/42", nil)

--- a/backend/api/timetable/api_test.go
+++ b/backend/api/timetable/api_test.go
@@ -153,13 +153,13 @@ func newTestPeriod() *schedule.CalendarPeriod {
 // =============================================================================
 
 func TestNewResource(t *testing.T) {
-	res := NewResource(nil, nil, nil, nil, nil, nil, nil)
+	res := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.NotNil(t, res)
 }
 
 func TestResource_Router(t *testing.T) {
 	mock := &mockCalendarPeriodService{}
-	res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+	res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := res.Router()
 	assert.NotNil(t, router)
 }
@@ -343,7 +343,7 @@ func TestListPeriods(t *testing.T) {
 		p1.UpdatedAt = time.Now()
 
 		mock := &mockCalendarPeriodService{periods: []*schedule.CalendarPeriod{p1}}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -354,7 +354,7 @@ func TestListPeriods(t *testing.T) {
 
 	t.Run("returns empty list", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{periods: []*schedule.CalendarPeriod{}}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -364,7 +364,7 @@ func TestListPeriods(t *testing.T) {
 
 	t.Run("returns 500 on service error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db error")}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.listPeriods, http.MethodGet, false)
 
 		w := executeRequest(router, http.MethodGet, "/", nil)
@@ -392,7 +392,7 @@ func TestGetPeriod(t *testing.T) {
 		p.UpdatedAt = time.Now()
 
 		mock := &mockCalendarPeriodService{period: p}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/42", nil)
@@ -403,7 +403,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/abc", nil)
@@ -413,7 +413,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 404 when not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/999", nil)
@@ -423,7 +423,7 @@ func TestGetPeriod(t *testing.T) {
 
 	t.Run("returns 500 on internal error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db connection failed")}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.getPeriod, http.MethodGet, true)
 
 		w := executeRequest(router, http.MethodGet, "/42", nil)
@@ -439,7 +439,7 @@ func TestGetPeriod(t *testing.T) {
 func TestCreatePeriod(t *testing.T) {
 	t.Run("creates period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -461,7 +461,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("creates period with week cycle anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		anchor := "2025-09-01"
@@ -484,7 +484,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("defaults week cycle length to 1", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -505,7 +505,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for missing required fields", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{Name: "Only Name"}
@@ -517,7 +517,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid period_type", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -535,7 +535,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid start_date format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -553,7 +553,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid end_date format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -571,7 +571,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid week_cycle_anchor format", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		badAnchor := "not-a-date"
@@ -592,7 +592,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for end_date before start_date", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -610,7 +610,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for cycle > 1 without anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -629,7 +629,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 409 for duplicate name", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: schedule.ErrCalendarPeriodNameConflict}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -650,7 +650,7 @@ func TestCreatePeriod(t *testing.T) {
 		mock := &mockCalendarPeriodService{
 			err: &scheduleSvcErr{op: "create calendar period", inner: schedule.ErrCalendarPeriodNameConflict},
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -667,7 +667,7 @@ func TestCreatePeriod(t *testing.T) {
 
 	t.Run("returns 500 on service error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("create failed")}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.createPeriod, http.MethodPost, false)
 
 		body := CalendarPeriodRequest{
@@ -692,7 +692,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("updates period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -714,7 +714,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("updates period with anchor", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -752,7 +752,7 @@ func TestUpdatePeriod(t *testing.T) {
 		anchoredPeriod.WeekCycleAnchor = &anchorTime
 
 		mock := &mockCalendarPeriodService{period: anchoredPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -775,7 +775,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("defaults week cycle length to 1", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -799,7 +799,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -812,7 +812,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 404 when period not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -825,7 +825,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 500 on get internal error", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: errors.New("db connection failed")}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -838,7 +838,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid start_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -858,7 +858,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid end_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -878,7 +878,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid anchor in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -901,7 +901,7 @@ func TestUpdatePeriod(t *testing.T) {
 
 	t.Run("returns 400 for end_date before start_date in update", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: existingPeriod}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -925,7 +925,7 @@ func TestUpdatePeriod(t *testing.T) {
 			period:    existingPeriod,
 			updateErr: schedule.ErrCalendarPeriodNameConflict,
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -949,7 +949,7 @@ func TestUpdatePeriod(t *testing.T) {
 			period:    existingPeriod,
 			updateErr: errors.New("db write failed"),
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		r := chi.NewRouter()
 		r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -975,7 +975,7 @@ func TestUpdatePeriod(t *testing.T) {
 func TestDeletePeriod(t *testing.T) {
 	t.Run("deletes period successfully", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{period: newTestPeriod()}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/42", nil)
@@ -986,7 +986,7 @@ func TestDeletePeriod(t *testing.T) {
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/abc", nil)
@@ -996,7 +996,7 @@ func TestDeletePeriod(t *testing.T) {
 
 	t.Run("returns 404 when period not found", func(t *testing.T) {
 		mock := &mockCalendarPeriodService{err: sql.ErrNoRows}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/999", nil)
@@ -1009,7 +1009,7 @@ func TestDeletePeriod(t *testing.T) {
 			period:    newTestPeriod(),
 			deleteErr: errors.New("delete failed"),
 		}
-		res := NewResource(mock, nil, nil, nil, nil, nil, nil)
+		res := NewResource(mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		router := setupTestRouter(res.deletePeriod, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/42", nil)

--- a/backend/api/timetable/instance_students_test.go
+++ b/backend/api/timetable/instance_students_test.go
@@ -233,7 +233,7 @@ func buildPatchSetup(t *testing.T) *patchSetup {
 	require.NoError(t, isRepo.Create(ctx, row))
 	t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "schedule.instance_students", row.ID) })
 
-	res := NewResource(nil, nil, nil, nil, isRepo, nil, db)
+	res := NewResource(nil, nil, nil, nil, isRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, db)
 
 	return &patchSetup{
 		res:        res,

--- a/backend/api/timetable/instance_students_test.go
+++ b/backend/api/timetable/instance_students_test.go
@@ -233,7 +233,7 @@ func buildPatchSetup(t *testing.T) *patchSetup {
 	require.NoError(t, isRepo.Create(ctx, row))
 	t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "schedule.instance_students", row.ID) })
 
-	res := NewResource(nil, nil, nil, nil, isRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, db)
+	res := NewResource(Dependencies{InstanceStudentRepo: isRepo, DB: db})
 
 	return &patchSetup{
 		res:        res,

--- a/backend/api/timetable/instance_students_unit_test.go
+++ b/backend/api/timetable/instance_students_unit_test.go
@@ -81,6 +81,10 @@ func (f *fakeRepo) BulkUpdateStatus(context.Context, int64, string, string) (int
 	panic("unused")
 }
 
+func (f *fakeRepo) FindInstancesWithAttendanceByStudentAndDateRange(context.Context, int64, time.Time, time.Time) ([]*schedule.ScheduledInstanceRow, error) {
+	panic("unused")
+}
+
 func (f *fakeRepo) UpdateAttendanceFromCheckin(context.Context, int64, int64, time.Time) (bool, error) {
 	panic("unused")
 }

--- a/backend/api/timetable/instance_students_unit_test.go
+++ b/backend/api/timetable/instance_students_unit_test.go
@@ -77,6 +77,10 @@ func (f *fakeRepo) FindByStudentAndDateRange(context.Context, int64, time.Time, 
 	panic("unused")
 }
 func (f *fakeRepo) DeleteByInstanceID(context.Context, int64) error { panic("unused") }
+func (f *fakeRepo) BulkUpdateStatus(context.Context, int64, string, string) (int, error) {
+	panic("unused")
+}
+
 func (f *fakeRepo) UpdateAttendanceFromCheckin(context.Context, int64, int64, time.Time) (bool, error) {
 	panic("unused")
 }

--- a/backend/api/timetable/instances_test.go
+++ b/backend/api/timetable/instances_test.go
@@ -237,7 +237,7 @@ func TestStartInstance_Success(t *testing.T) {
 	}
 	mock.startResult.Instance.ID = int64(7)
 
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/7/start", nil)
@@ -271,7 +271,7 @@ func TestStartInstance_WithWarnings(t *testing.T) {
 	}
 	mock.startResult.Instance.ID = int64(3)
 
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/3/start", nil)
@@ -285,7 +285,7 @@ func TestStartInstance_WithWarnings(t *testing.T) {
 }
 
 func TestStartInstance_InvalidID(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/not-a-number/start", nil)
@@ -294,7 +294,7 @@ func TestStartInstance_InvalidID(t *testing.T) {
 }
 
 func TestStartInstance_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/1/start", nil)
@@ -304,7 +304,7 @@ func TestStartInstance_NilService(t *testing.T) {
 
 func TestStartInstance_NotFound(t *testing.T) {
 	mock := &mockInstanceService{startErr: scheduleSvc.ErrInstanceNotFound}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/99/start", nil)
@@ -316,7 +316,7 @@ func TestStartInstance_InvalidTransition(t *testing.T) {
 	mock := &mockInstanceService{startErr: errors.New("wrap: " + scheduleSvc.ErrInvalidInstanceTransition.Error())}
 	// Use an error that errors.Is matches via wrapping.
 	mock.startErr = &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/1/start", nil)
@@ -327,7 +327,7 @@ func TestStartInstance_InvalidTransition(t *testing.T) {
 
 func TestStartInstance_InternalError(t *testing.T) {
 	mock := &mockInstanceService{startErr: errors.New("db connection lost")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/1/start", nil)
@@ -355,7 +355,7 @@ func TestCompleteInstance_Success(t *testing.T) {
 	instance.ID = int64(5)
 
 	mock := &mockInstanceService{completeRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/5/complete", nil)
@@ -376,7 +376,7 @@ func TestCompleteInstance_NoCompletedAt(t *testing.T) {
 	instance.ID = int64(5)
 
 	mock := &mockInstanceService{completeRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/5/complete", nil)
@@ -386,7 +386,7 @@ func TestCompleteInstance_NoCompletedAt(t *testing.T) {
 }
 
 func TestCompleteInstance_InvalidID(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/bad/complete", nil)
@@ -395,7 +395,7 @@ func TestCompleteInstance_InvalidID(t *testing.T) {
 }
 
 func TestCompleteInstance_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -405,7 +405,7 @@ func TestCompleteInstance_NilService(t *testing.T) {
 
 func TestCompleteInstance_NotFound(t *testing.T) {
 	mock := &mockInstanceService{completeErr: scheduleSvc.ErrInstanceNotFound}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -415,7 +415,7 @@ func TestCompleteInstance_NotFound(t *testing.T) {
 
 func TestCompleteInstance_InvalidTransition(t *testing.T) {
 	mock := &mockInstanceService{completeErr: &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -426,7 +426,7 @@ func TestCompleteInstance_InvalidTransition(t *testing.T) {
 
 func TestCompleteInstance_InternalError(t *testing.T) {
 	mock := &mockInstanceService{completeErr: errors.New("db error")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -447,7 +447,7 @@ func TestCancelInstance_Success(t *testing.T) {
 	instance.ID = int64(11)
 
 	mock := &mockInstanceService{cancelRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/11/cancel", nil)
@@ -465,7 +465,7 @@ func TestCancelInstance_NoCompletedAt(t *testing.T) {
 	instance := &scheduleModel.ActivityInstance{Status: scheduleModel.InstanceStatusCancelled}
 	instance.ID = int64(12)
 	mock := &mockInstanceService{cancelRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/12/cancel", nil)
@@ -473,7 +473,7 @@ func TestCancelInstance_NoCompletedAt(t *testing.T) {
 }
 
 func TestCancelInstance_InvalidID(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/nope/cancel", nil)
@@ -481,7 +481,7 @@ func TestCancelInstance_InvalidID(t *testing.T) {
 }
 
 func TestCancelInstance_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -490,7 +490,7 @@ func TestCancelInstance_NilService(t *testing.T) {
 
 func TestCancelInstance_NotFound(t *testing.T) {
 	mock := &mockInstanceService{cancelErr: scheduleSvc.ErrInstanceNotFound}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -499,7 +499,7 @@ func TestCancelInstance_NotFound(t *testing.T) {
 
 func TestCancelInstance_InvalidTransition(t *testing.T) {
 	mock := &mockInstanceService{cancelErr: &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -508,7 +508,7 @@ func TestCancelInstance_InvalidTransition(t *testing.T) {
 
 func TestCancelInstance_InternalError(t *testing.T) {
 	mock := &mockInstanceService{cancelErr: errors.New("db failure")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -521,13 +521,13 @@ func TestCancelInstance_InternalError(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestResolveStartedByStaffID_NilPersonService(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	staffID := rs.resolveStartedByStaffID(context.Background())
 	assert.Equal(t, int64(0), staffID)
 }
 
 func TestResolveStartedByStaffID_NoClaimsInContext(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, &instMockPersonService{}, nil, nil, nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, &instMockPersonService{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	staffID := rs.resolveStartedByStaffID(context.Background())
 	assert.Equal(t, int64(0), staffID)
 }
@@ -538,7 +538,7 @@ func TestResolveStartedByStaffID_PersonNotFound(t *testing.T) {
 			return nil, errors.New("person not found")
 		},
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -552,7 +552,7 @@ func TestResolveStartedByStaffID_PersonIsNil(t *testing.T) {
 			return nil, nil
 		},
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -569,7 +569,7 @@ func TestResolveStartedByStaffID_StaffRepoNil(t *testing.T) {
 		},
 		staffRepo: nil, // returns nil from StaffRepository()
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -591,7 +591,7 @@ func TestResolveStartedByStaffID_StaffNotFound(t *testing.T) {
 		},
 		staffRepo: staffRepo,
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -613,7 +613,7 @@ func TestResolveStartedByStaffID_StaffIsNil(t *testing.T) {
 		},
 		staffRepo: staffRepo,
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -639,7 +639,7 @@ func TestResolveStartedByStaffID_Success(t *testing.T) {
 		},
 		staffRepo: staffRepo,
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, slog.Default(), nil)
+	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -674,7 +674,7 @@ func TestStartInstance_PassesStartedByFromJWT(t *testing.T) {
 			ActiveGroupID: 1,
 		},
 	}
-	rs := NewResource(nil, nil, mock, ps, nil, slog.Default(), nil)
+	rs := NewResource(nil, nil, mock, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
 
 	r := chi.NewRouter()
 	r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -701,12 +701,12 @@ func TestStartInstance_PassesStartedByFromJWT(t *testing.T) {
 func TestResource_getLogger(t *testing.T) {
 	t.Run("returns injected logger", func(t *testing.T) {
 		custom := slog.Default()
-		rs := NewResource(nil, nil, nil, nil, nil, custom, nil)
+		rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, custom, nil)
 		assert.NotNil(t, rs.getLogger())
 	})
 
 	t.Run("falls back to slog.Default when nil", func(t *testing.T) {
-		rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
+		rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		assert.NotNil(t, rs.getLogger(), "must never return nil")
 	})
 }
@@ -722,7 +722,7 @@ func TestReplanWeekRequest_Bind_NoOp(t *testing.T) {
 }
 
 func TestReplanWeek_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)
@@ -744,7 +744,7 @@ func TestReplanWeek_NoBody_DefaultsToNextWeek(t *testing.T) {
 			},
 		},
 	}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)
@@ -771,7 +771,7 @@ func TestReplanWeek_ValidBody(t *testing.T) {
 			Materialization:  &scheduleSvc.MaterializationResult{InstancesCreated: 3},
 		},
 	}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	body := map[string]string{
@@ -796,7 +796,7 @@ func TestReplanWeek_NilMaterialization(t *testing.T) {
 			Materialization:  nil,
 		},
 	}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)
@@ -809,7 +809,7 @@ func TestReplanWeek_NilMaterialization(t *testing.T) {
 
 func TestReplanWeek_InvalidWindow(t *testing.T) {
 	mock := &mockInstanceService{}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	body := map[string]string{
@@ -823,7 +823,7 @@ func TestReplanWeek_InvalidWindow(t *testing.T) {
 
 func TestReplanWeek_InvalidJSON(t *testing.T) {
 	mock := &mockInstanceService{}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	req := httptest.NewRequest(http.MethodPost, "/instances/re-plan-week", bytes.NewReader([]byte("{not json")))
@@ -837,7 +837,7 @@ func TestReplanWeek_InvalidJSON(t *testing.T) {
 
 func TestReplanWeek_ServiceError(t *testing.T) {
 	mock := &mockInstanceService{replanErr: errors.New("db exploded")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)

--- a/backend/api/timetable/instances_test.go
+++ b/backend/api/timetable/instances_test.go
@@ -237,7 +237,7 @@ func TestStartInstance_Success(t *testing.T) {
 	}
 	mock.startResult.Instance.ID = int64(7)
 
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/7/start", nil)
@@ -271,7 +271,7 @@ func TestStartInstance_WithWarnings(t *testing.T) {
 	}
 	mock.startResult.Instance.ID = int64(3)
 
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/3/start", nil)
@@ -285,7 +285,7 @@ func TestStartInstance_WithWarnings(t *testing.T) {
 }
 
 func TestStartInstance_InvalidID(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: &mockInstanceService{}})
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/not-a-number/start", nil)
@@ -294,7 +294,7 @@ func TestStartInstance_InvalidID(t *testing.T) {
 }
 
 func TestStartInstance_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{})
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/1/start", nil)
@@ -304,7 +304,7 @@ func TestStartInstance_NilService(t *testing.T) {
 
 func TestStartInstance_NotFound(t *testing.T) {
 	mock := &mockInstanceService{startErr: scheduleSvc.ErrInstanceNotFound}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/99/start", nil)
@@ -316,7 +316,7 @@ func TestStartInstance_InvalidTransition(t *testing.T) {
 	mock := &mockInstanceService{startErr: errors.New("wrap: " + scheduleSvc.ErrInvalidInstanceTransition.Error())}
 	// Use an error that errors.Is matches via wrapping.
 	mock.startErr = &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/1/start", nil)
@@ -327,7 +327,7 @@ func TestStartInstance_InvalidTransition(t *testing.T) {
 
 func TestStartInstance_InternalError(t *testing.T) {
 	mock := &mockInstanceService{startErr: errors.New("db connection lost")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/start", rs.startInstance)
 
 	w := doPost(t, router, "/instances/1/start", nil)
@@ -355,7 +355,7 @@ func TestCompleteInstance_Success(t *testing.T) {
 	instance.ID = int64(5)
 
 	mock := &mockInstanceService{completeRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/5/complete", nil)
@@ -376,7 +376,7 @@ func TestCompleteInstance_NoCompletedAt(t *testing.T) {
 	instance.ID = int64(5)
 
 	mock := &mockInstanceService{completeRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/5/complete", nil)
@@ -386,7 +386,7 @@ func TestCompleteInstance_NoCompletedAt(t *testing.T) {
 }
 
 func TestCompleteInstance_InvalidID(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: &mockInstanceService{}})
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/bad/complete", nil)
@@ -395,7 +395,7 @@ func TestCompleteInstance_InvalidID(t *testing.T) {
 }
 
 func TestCompleteInstance_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{})
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -405,7 +405,7 @@ func TestCompleteInstance_NilService(t *testing.T) {
 
 func TestCompleteInstance_NotFound(t *testing.T) {
 	mock := &mockInstanceService{completeErr: scheduleSvc.ErrInstanceNotFound}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -415,7 +415,7 @@ func TestCompleteInstance_NotFound(t *testing.T) {
 
 func TestCompleteInstance_InvalidTransition(t *testing.T) {
 	mock := &mockInstanceService{completeErr: &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -426,7 +426,7 @@ func TestCompleteInstance_InvalidTransition(t *testing.T) {
 
 func TestCompleteInstance_InternalError(t *testing.T) {
 	mock := &mockInstanceService{completeErr: errors.New("db error")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/complete", rs.completeInstance)
 
 	w := doPost(t, router, "/instances/1/complete", nil)
@@ -447,7 +447,7 @@ func TestCancelInstance_Success(t *testing.T) {
 	instance.ID = int64(11)
 
 	mock := &mockInstanceService{cancelRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/11/cancel", nil)
@@ -465,7 +465,7 @@ func TestCancelInstance_NoCompletedAt(t *testing.T) {
 	instance := &scheduleModel.ActivityInstance{Status: scheduleModel.InstanceStatusCancelled}
 	instance.ID = int64(12)
 	mock := &mockInstanceService{cancelRes: instance}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/12/cancel", nil)
@@ -473,7 +473,7 @@ func TestCancelInstance_NoCompletedAt(t *testing.T) {
 }
 
 func TestCancelInstance_InvalidID(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: &mockInstanceService{}})
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/nope/cancel", nil)
@@ -481,7 +481,7 @@ func TestCancelInstance_InvalidID(t *testing.T) {
 }
 
 func TestCancelInstance_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{})
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -490,7 +490,7 @@ func TestCancelInstance_NilService(t *testing.T) {
 
 func TestCancelInstance_NotFound(t *testing.T) {
 	mock := &mockInstanceService{cancelErr: scheduleSvc.ErrInstanceNotFound}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -499,7 +499,7 @@ func TestCancelInstance_NotFound(t *testing.T) {
 
 func TestCancelInstance_InvalidTransition(t *testing.T) {
 	mock := &mockInstanceService{cancelErr: &wrappedErr{inner: scheduleSvc.ErrInvalidInstanceTransition}}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -508,7 +508,7 @@ func TestCancelInstance_InvalidTransition(t *testing.T) {
 
 func TestCancelInstance_InternalError(t *testing.T) {
 	mock := &mockInstanceService{cancelErr: errors.New("db failure")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/{id}/cancel", rs.cancelInstance)
 
 	w := doPost(t, router, "/instances/1/cancel", nil)
@@ -521,13 +521,13 @@ func TestCancelInstance_InternalError(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestResolveStartedByStaffID_NilPersonService(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: &mockInstanceService{}})
 	staffID := rs.resolveStartedByStaffID(context.Background())
 	assert.Equal(t, int64(0), staffID)
 }
 
 func TestResolveStartedByStaffID_NoClaimsInContext(t *testing.T) {
-	rs := NewResource(nil, nil, &mockInstanceService{}, &instMockPersonService{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: &mockInstanceService{}, PersonService: &instMockPersonService{}})
 	staffID := rs.resolveStartedByStaffID(context.Background())
 	assert.Equal(t, int64(0), staffID)
 }
@@ -538,7 +538,7 @@ func TestResolveStartedByStaffID_PersonNotFound(t *testing.T) {
 			return nil, errors.New("person not found")
 		},
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
+	rs := NewResource(Dependencies{InstanceService: &mockInstanceService{}, PersonService: ps, Logger: slog.Default()})
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -552,7 +552,7 @@ func TestResolveStartedByStaffID_PersonIsNil(t *testing.T) {
 			return nil, nil
 		},
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
+	rs := NewResource(Dependencies{InstanceService: &mockInstanceService{}, PersonService: ps, Logger: slog.Default()})
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -569,7 +569,7 @@ func TestResolveStartedByStaffID_StaffRepoNil(t *testing.T) {
 		},
 		staffRepo: nil, // returns nil from StaffRepository()
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
+	rs := NewResource(Dependencies{InstanceService: &mockInstanceService{}, PersonService: ps, Logger: slog.Default()})
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -591,7 +591,7 @@ func TestResolveStartedByStaffID_StaffNotFound(t *testing.T) {
 		},
 		staffRepo: staffRepo,
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
+	rs := NewResource(Dependencies{InstanceService: &mockInstanceService{}, PersonService: ps, Logger: slog.Default()})
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -613,7 +613,7 @@ func TestResolveStartedByStaffID_StaffIsNil(t *testing.T) {
 		},
 		staffRepo: staffRepo,
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
+	rs := NewResource(Dependencies{InstanceService: &mockInstanceService{}, PersonService: ps, Logger: slog.Default()})
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -639,7 +639,7 @@ func TestResolveStartedByStaffID_Success(t *testing.T) {
 		},
 		staffRepo: staffRepo,
 	}
-	rs := NewResource(nil, nil, &mockInstanceService{}, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
+	rs := NewResource(Dependencies{InstanceService: &mockInstanceService{}, PersonService: ps, Logger: slog.Default()})
 	claims := jwt.AppClaims{ID: 123}
 	ctx := context.WithValue(context.Background(), jwt.CtxClaims, claims)
 
@@ -674,7 +674,7 @@ func TestStartInstance_PassesStartedByFromJWT(t *testing.T) {
 			ActiveGroupID: 1,
 		},
 	}
-	rs := NewResource(nil, nil, mock, ps, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, slog.Default(), nil)
+	rs := NewResource(Dependencies{InstanceService: mock, PersonService: ps, Logger: slog.Default()})
 
 	r := chi.NewRouter()
 	r.Use(render.SetContentType(render.ContentTypeJSON))
@@ -701,12 +701,12 @@ func TestStartInstance_PassesStartedByFromJWT(t *testing.T) {
 func TestResource_getLogger(t *testing.T) {
 	t.Run("returns injected logger", func(t *testing.T) {
 		custom := slog.Default()
-		rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, custom, nil)
+		rs := NewResource(Dependencies{Logger: custom})
 		assert.NotNil(t, rs.getLogger())
 	})
 
 	t.Run("falls back to slog.Default when nil", func(t *testing.T) {
-		rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		rs := NewResource(Dependencies{})
 		assert.NotNil(t, rs.getLogger(), "must never return nil")
 	})
 }
@@ -722,7 +722,7 @@ func TestReplanWeekRequest_Bind_NoOp(t *testing.T) {
 }
 
 func TestReplanWeek_NilService(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{})
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)
@@ -744,7 +744,7 @@ func TestReplanWeek_NoBody_DefaultsToNextWeek(t *testing.T) {
 			},
 		},
 	}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)
@@ -771,7 +771,7 @@ func TestReplanWeek_ValidBody(t *testing.T) {
 			Materialization:  &scheduleSvc.MaterializationResult{InstancesCreated: 3},
 		},
 	}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	body := map[string]string{
@@ -796,7 +796,7 @@ func TestReplanWeek_NilMaterialization(t *testing.T) {
 			Materialization:  nil,
 		},
 	}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)
@@ -809,7 +809,7 @@ func TestReplanWeek_NilMaterialization(t *testing.T) {
 
 func TestReplanWeek_InvalidWindow(t *testing.T) {
 	mock := &mockInstanceService{}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	body := map[string]string{
@@ -823,7 +823,7 @@ func TestReplanWeek_InvalidWindow(t *testing.T) {
 
 func TestReplanWeek_InvalidJSON(t *testing.T) {
 	mock := &mockInstanceService{}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	req := httptest.NewRequest(http.MethodPost, "/instances/re-plan-week", bytes.NewReader([]byte("{not json")))
@@ -837,7 +837,7 @@ func TestReplanWeek_InvalidJSON(t *testing.T) {
 
 func TestReplanWeek_ServiceError(t *testing.T) {
 	mock := &mockInstanceService{replanErr: errors.New("db exploded")}
-	rs := NewResource(nil, nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{InstanceService: mock})
 	router := setupLifecycleRouter(rs, "/instances/re-plan-week", rs.replanWeek)
 
 	w := doPost(t, router, "/instances/re-plan-week", nil)

--- a/backend/api/timetable/materialize_test.go
+++ b/backend/api/timetable/materialize_test.go
@@ -142,7 +142,7 @@ func TestMaterialize_NoBody_DefaultsToNextWeek(t *testing.T) {
 			InstanceStaffCreated:    2,
 		},
 	}
-	rs := NewResource(nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{MaterializationService: mock})
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -162,7 +162,7 @@ func TestMaterialize_ValidBody_ParsesAndForwards(t *testing.T) {
 	mock := &mockMaterializer{
 		result: &scheduleSvc.MaterializationResult{InstancesCreated: 1},
 	}
-	rs := NewResource(nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{MaterializationService: mock})
 	router := setupMaterializeRouter(rs)
 
 	body, _ := json.Marshal(map[string]string{
@@ -188,7 +188,7 @@ func TestMaterialize_ValidBody_ParsesAndForwards(t *testing.T) {
 
 func TestMaterialize_InvalidWindow_Returns400(t *testing.T) {
 	mock := &mockMaterializer{}
-	rs := NewResource(nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{MaterializationService: mock})
 	router := setupMaterializeRouter(rs)
 
 	body, _ := json.Marshal(map[string]string{
@@ -205,7 +205,7 @@ func TestMaterialize_InvalidWindow_Returns400(t *testing.T) {
 }
 
 func TestMaterialize_NilService_Returns500(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{})
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -217,7 +217,7 @@ func TestMaterialize_NilService_Returns500(t *testing.T) {
 
 func TestMaterialize_ServiceError_Returns500(t *testing.T) {
 	mock := &mockMaterializer{err: errors.New("boom")}
-	rs := NewResource(nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(Dependencies{MaterializationService: mock})
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)

--- a/backend/api/timetable/materialize_test.go
+++ b/backend/api/timetable/materialize_test.go
@@ -142,7 +142,7 @@ func TestMaterialize_NoBody_DefaultsToNextWeek(t *testing.T) {
 			InstanceStaffCreated:    2,
 		},
 	}
-	rs := NewResource(nil, mock, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -162,7 +162,7 @@ func TestMaterialize_ValidBody_ParsesAndForwards(t *testing.T) {
 	mock := &mockMaterializer{
 		result: &scheduleSvc.MaterializationResult{InstancesCreated: 1},
 	}
-	rs := NewResource(nil, mock, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	body, _ := json.Marshal(map[string]string{
@@ -188,7 +188,7 @@ func TestMaterialize_ValidBody_ParsesAndForwards(t *testing.T) {
 
 func TestMaterialize_InvalidWindow_Returns400(t *testing.T) {
 	mock := &mockMaterializer{}
-	rs := NewResource(nil, mock, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	body, _ := json.Marshal(map[string]string{
@@ -205,7 +205,7 @@ func TestMaterialize_InvalidWindow_Returns400(t *testing.T) {
 }
 
 func TestMaterialize_NilService_Returns500(t *testing.T) {
-	rs := NewResource(nil, nil, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -217,7 +217,7 @@ func TestMaterialize_NilService_Returns500(t *testing.T) {
 
 func TestMaterialize_ServiceError_Returns500(t *testing.T) {
 	mock := &mockMaterializer{err: errors.New("boom")}
-	rs := NewResource(nil, mock, nil, nil, nil, nil, nil)
+	rs := NewResource(nil, mock, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	router := setupMaterializeRouter(rs)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)

--- a/backend/api/timetable/student_day.go
+++ b/backend/api/timetable/student_day.go
@@ -31,8 +31,7 @@ import (
 )
 
 // maxWeekRangeDays caps /week at 14 days inclusive. Longer spans are
-// rejected at 400 — the response assembly is O(days × instances) and the
-// frontend has no use case for a longer horizon today.
+// rejected at 400 — the frontend has no use case for a longer horizon today.
 const maxWeekRangeDays = 14
 
 // berlinDate parses a YYYY-MM-DD input anchored in Berlin timezone. The
@@ -48,6 +47,9 @@ func berlinDate(input string) (time.Time, error) {
 func isoWeekday(t time.Time) int {
 	return int((int(t.In(timezone.Berlin).Weekday())+6)%7 + 1)
 }
+
+// dateKey formats a time as YYYY-MM-DD for use as a map key.
+func dateKey(t time.Time) string { return t.Format(dateLayout) }
 
 // getStudentDay handles GET /api/timetable/student/{id}/day.
 func (rs *Resource) getStudentDay(w http.ResponseWriter, r *http.Request) {
@@ -73,17 +75,23 @@ func (rs *Resource) getStudentDay(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	day, err := rs.buildStudentDay(ctx, student.ID, date)
+	// /day is /week with from == to: one round of batch queries covers it.
+	days, err := rs.buildStudentDays(ctx, student.ID, date, date)
 	if err != nil {
 		common.RenderError(w, r, common.ErrorInternalServerWrap("build student day failed", err))
+		return
+	}
+	if len(days) != 1 {
+		common.RenderError(w, r, common.ErrorInternalServer(
+			fmt.Errorf("buildStudentDays returned %d days, expected 1", len(days))))
 		return
 	}
 
 	rs.getLogger().Info("timetable student day",
 		slog.Int64("student_id", student.ID),
-		slog.String("date", day.Date),
+		slog.String("date", days[0].Date),
 	)
-	common.Respond(w, r, http.StatusOK, day, "Student day retrieved")
+	common.Respond(w, r, http.StatusOK, days[0], "Student day retrieved")
 }
 
 // getStudentWeek handles GET /api/timetable/student/{id}/week. The date
@@ -128,14 +136,10 @@ func (rs *Resource) getStudentWeek(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	days := make([]StudentDayResponse, 0, rangeDays)
-	for d := from; !d.After(to); d = d.AddDate(0, 0, 1) {
-		dayResp, err := rs.buildStudentDay(ctx, student.ID, d)
-		if err != nil {
-			common.RenderError(w, r, common.ErrorInternalServerWrap("build student week day failed", err))
-			return
-		}
-		days = append(days, *dayResp)
+	days, err := rs.buildStudentDays(ctx, student.ID, from, to)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("build student week failed", err))
+		return
 	}
 
 	resp := StudentWeekResponse{
@@ -206,89 +210,212 @@ func (rs *Resource) resolveStudentForRead(w http.ResponseWriter, r *http.Request
 	return student, true
 }
 
-// buildStudentDay assembles the per-day response. Four reads:
-//  1. Enrolled instances + attendance rows (1 query, joined).
-//  2. All activity_instances in the tenant for the date (1 query) — needed
-//     to resolve visit.active_group_id → instance for is_unplanned entries.
-//  3. Student's visits scoped to those active_group_ids (1 query).
-//  4. Arrival/pickup schedule + exception (up to 4 queries).
-//
-// That is O(1) in the number of instances per day — no N+1.
-func (rs *Resource) buildStudentDay(ctx context.Context, studentID int64, date time.Time) (*StudentDayResponse, error) {
-	dateUTC := timezone.DateOfUTC(date)
+// weekPreload is the result of the range-wide batch queries used to assemble
+// the response for one or more days. All lookups are keyed by
+// Berlin-local YYYY-MM-DD (dateKey) except activeGroupInst which keys by
+// active_group_id (not date-specific).
+type weekPreload struct {
+	enrolledByDate       map[string][]*scheduleModel.ScheduledInstanceRow
+	instancesByDate      map[string][]*scheduleModel.ActivityInstance
+	visitsByActiveGroup  map[int64][]*activeModel.Visit
+	arrivalSchedByWeekly map[int]*scheduleModel.StudentArrivalSchedule
+	arrivalExcByDate     map[string]*scheduleModel.StudentArrivalException
+	pickupSchedByWeekly  map[int]*scheduleModel.StudentPickupSchedule
+	pickupExcByDate      map[string]*scheduleModel.StudentPickupException
+}
 
-	if rs.studentDayRepo == nil {
-		return nil, errors.New("studentDayRepo not wired")
+// preloadWeek issues one DB query per category for the full [from, to] range
+// and returns data indexed by date. Replaces the previous N+1 pattern where
+// each day re-queried the same tables.
+func (rs *Resource) preloadWeek(ctx context.Context, studentID int64, from, to time.Time) (*weekPreload, error) {
+	out := &weekPreload{
+		enrolledByDate:       map[string][]*scheduleModel.ScheduledInstanceRow{},
+		instancesByDate:      map[string][]*scheduleModel.ActivityInstance{},
+		visitsByActiveGroup:  map[int64][]*activeModel.Visit{},
+		arrivalSchedByWeekly: map[int]*scheduleModel.StudentArrivalSchedule{},
+		arrivalExcByDate:     map[string]*scheduleModel.StudentArrivalException{},
+		pickupSchedByWeekly:  map[int]*scheduleModel.StudentPickupSchedule{},
+		pickupExcByDate:      map[string]*scheduleModel.StudentPickupException{},
 	}
 
-	// 1) Enrolled instances for the student on this date.
-	enrolledRows, err := rs.studentDayRepo.FindInstancesWithAttendanceByStudentAndDateRange(
-		ctx, studentID, dateUTC, dateUTC,
+	fromUTC := timezone.DateOfUTC(from)
+	toUTC := timezone.DateOfUTC(to)
+
+	if rs.instanceStudentRepo == nil {
+		return nil, errors.New("instanceStudentRepo not wired")
+	}
+	enrolledRows, err := rs.instanceStudentRepo.FindInstancesWithAttendanceByStudentAndDateRange(
+		ctx, studentID, fromUTC, toUTC,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("load enrolled instances: %w", err)
 	}
+	for _, row := range enrolledRows {
+		k := dateKey(row.Instance.Date)
+		out.enrolledByDate[k] = append(out.enrolledByDate[k], row)
+	}
 
-	// 2) All instances in the tenant on this date — needed to map visit
-	//    active_group_ids back to an instance for is_unplanned entries.
-	allInstances, err := rs.activityInstanceRepo.FindByTenantAndDateRange(ctx, dateUTC, dateUTC)
+	if rs.activityInstanceRepo == nil {
+		return nil, errors.New("activityInstanceRepo not wired")
+	}
+	allInstances, err := rs.activityInstanceRepo.FindByTenantAndDateRange(ctx, fromUTC, toUTC)
 	if err != nil {
 		return nil, fmt.Errorf("load all tenant instances: %w", err)
 	}
 
-	// Index instances by active_group_id for the active/completed subset.
-	// Planned/cancelled never have visits bridged (per WP-B11 scope), so we
-	// skip them in the index.
-	instByActiveGroupID := make(map[int64]*scheduleModel.ActivityInstance, len(allInstances))
+	// Collect active_group_ids across the entire range for a single visits
+	// lookup. Only active/completed instances are relevant — planned/cancelled
+	// never have visits bridged (per WP-B11 scope).
 	activeGroupIDs := make([]int64, 0, len(allInstances))
+	seenAGID := make(map[int64]bool, len(allInstances))
 	for _, inst := range allInstances {
+		k := dateKey(inst.Date)
+		out.instancesByDate[k] = append(out.instancesByDate[k], inst)
 		if inst.ActiveGroupID == nil {
 			continue
 		}
-		if inst.Status != scheduleModel.InstanceStatusActive && inst.Status != scheduleModel.InstanceStatusCompleted {
+		if inst.Status != scheduleModel.InstanceStatusActive &&
+			inst.Status != scheduleModel.InstanceStatusCompleted {
 			continue
 		}
-		instByActiveGroupID[*inst.ActiveGroupID] = inst
-		activeGroupIDs = append(activeGroupIDs, *inst.ActiveGroupID)
+		if !seenAGID[*inst.ActiveGroupID] {
+			seenAGID[*inst.ActiveGroupID] = true
+			activeGroupIDs = append(activeGroupIDs, *inst.ActiveGroupID)
+		}
 	}
 
-	// 3) Student visits scoped to the active/completed instances we know
-	//    about. Empty list short-circuits with no DB call.
-	var studentVisits []*activeModel.Visit
 	if len(activeGroupIDs) > 0 && rs.visitRepo != nil {
-		studentVisits, err = rs.visitRepo.FindByStudentAndActiveGroupIDs(ctx, studentID, activeGroupIDs)
+		visits, err := rs.visitRepo.FindByStudentAndActiveGroupIDs(ctx, studentID, activeGroupIDs)
 		if err != nil {
 			return nil, fmt.Errorf("load student visits: %w", err)
 		}
+		for _, v := range visits {
+			if v == nil {
+				continue
+			}
+			out.visitsByActiveGroup[v.ActiveGroupID] = append(out.visitsByActiveGroup[v.ActiveGroupID], v)
+		}
 	}
+
+	// Arrival/pickup weekly schedules: one query each returns up to 5 rows
+	// total per student (one per weekday). Cheaper than per-weekday queries.
+	if rs.arrivalScheduleRepo != nil {
+		schedules, err := rs.arrivalScheduleRepo.FindByStudentID(ctx, studentID)
+		if err != nil {
+			return nil, fmt.Errorf("load arrival schedules: %w", err)
+		}
+		for _, s := range schedules {
+			out.arrivalSchedByWeekly[s.Weekday] = s
+		}
+	}
+	if rs.pickupScheduleRepo != nil {
+		schedules, err := rs.pickupScheduleRepo.FindByStudentID(ctx, studentID)
+		if err != nil {
+			return nil, fmt.Errorf("load pickup schedules: %w", err)
+		}
+		for _, s := range schedules {
+			out.pickupSchedByWeekly[s.Weekday] = s
+		}
+	}
+
+	// Arrival/pickup exceptions: range-scoped (avoid loading unbounded
+	// history).
+	if rs.arrivalExceptionRepo != nil {
+		excs, err := rs.arrivalExceptionRepo.FindByStudentIDAndDateRange(ctx, studentID, fromUTC, toUTC)
+		if err != nil {
+			return nil, fmt.Errorf("load arrival exceptions: %w", err)
+		}
+		for _, e := range excs {
+			out.arrivalExcByDate[dateKey(e.ExceptionDate)] = e
+		}
+	}
+	if rs.pickupExceptionRepo != nil {
+		excs, err := rs.pickupExceptionRepo.FindByStudentIDAndDateRange(ctx, studentID, fromUTC, toUTC)
+		if err != nil {
+			return nil, fmt.Errorf("load pickup exceptions: %w", err)
+		}
+		for _, e := range excs {
+			out.pickupExcByDate[dateKey(e.ExceptionDate)] = e
+		}
+	}
+
+	return out, nil
+}
+
+// buildStudentDays assembles one StudentDayResponse per day in the inclusive
+// [from, to] range. A single batch round trip per category fills weekPreload;
+// from there the per-day assembly is a pure in-memory slice.
+//
+// Query count (constant in range length): 1 enrolled + 1 all-instances +
+// 1 visits (if any active groups) + 2 schedules + 2 exceptions = max 7.
+func (rs *Resource) buildStudentDays(ctx context.Context, studentID int64, from, to time.Time) ([]StudentDayResponse, error) {
+	pre, err := rs.preloadWeek(ctx, studentID, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	dayCount := int(to.Sub(from).Hours()/24) + 1
+	days := make([]StudentDayResponse, 0, dayCount)
+	for d := from; !d.After(to); d = d.AddDate(0, 0, 1) {
+		day := buildStudentDayFromPreload(pre, studentID, d)
+		days = append(days, day)
+	}
+	return days, nil
+}
+
+// buildStudentDayFromPreload assembles a single day's response from the
+// already-preloaded data. No DB calls.
+func buildStudentDayFromPreload(pre *weekPreload, studentID int64, date time.Time) StudentDayResponse {
+	k := dateKey(date)
+
+	enrolledRows := pre.enrolledByDate[k]
+	dayInstances := pre.instancesByDate[k]
 
 	// Build the base instance list from enrolled rows.
 	enrolledInstanceIDs := make(map[int64]bool, len(enrolledRows))
-	instances := make([]InstanceDayResponse, 0, len(enrolledRows)+len(studentVisits))
+	instances := make([]InstanceDayResponse, 0, len(enrolledRows)+len(dayInstances))
 	for _, row := range enrolledRows {
 		instances = append(instances, mapEnrolledInstance(row))
 		enrolledInstanceIDs[row.Instance.ID] = true
 	}
 
-	// Append is_unplanned entries: visits whose instance is NOT in the
-	// enrolled set. Dedup by active_group_id in case of (rare) multi-visit
-	// against the same bridge.
-	seenActiveGroupID := make(map[int64]bool, len(studentVisits))
-	for _, v := range studentVisits {
-		if v == nil {
+	// Index today's active/completed instances by active_group_id so we can
+	// map visits back to their host instance.
+	instByActiveGroupID := make(map[int64]*scheduleModel.ActivityInstance, len(dayInstances))
+	for _, inst := range dayInstances {
+		if inst.ActiveGroupID == nil {
 			continue
 		}
-		inst, ok := instByActiveGroupID[v.ActiveGroupID]
-		if !ok {
+		if inst.Status != scheduleModel.InstanceStatusActive &&
+			inst.Status != scheduleModel.InstanceStatusCompleted {
 			continue
 		}
+		instByActiveGroupID[*inst.ActiveGroupID] = inst
+	}
+
+	// Append is_unplanned entries: the student has a visit on one of today's
+	// active/completed instances, but no instance_students row. active_group_id
+	// is 1:1 with activity_instance (each instance creates its own group on
+	// start), so the map lookup already scopes visits to this date.
+	for agID, inst := range instByActiveGroupID {
 		if enrolledInstanceIDs[inst.ID] {
 			continue
 		}
-		if seenActiveGroupID[v.ActiveGroupID] {
+		visits := pre.visitsByActiveGroup[agID]
+		if len(visits) == 0 {
 			continue
 		}
-		seenActiveGroupID[v.ActiveGroupID] = true
+		// Pick the first non-nil visit — dedup handled by one-entry-per-agID.
+		var v *activeModel.Visit
+		for _, candidate := range visits {
+			if candidate != nil {
+				v = candidate
+				break
+			}
+		}
+		if v == nil {
+			continue
+		}
 		instances = append(instances, mapUnplannedInstance(inst, v))
 	}
 
@@ -296,81 +423,45 @@ func (rs *Resource) buildStudentDay(ctx context.Context, studentID int64, date t
 		return instances[i].StartTime < instances[j].StartTime
 	})
 
-	// 4) Arrival / pickup slots.
-	arrival, err := rs.resolveArrivalSlot(ctx, studentID, dateUTC)
-	if err != nil {
-		return nil, fmt.Errorf("resolve arrival: %w", err)
-	}
-	pickup, err := rs.resolvePickupSlot(ctx, studentID, dateUTC)
-	if err != nil {
-		return nil, fmt.Errorf("resolve pickup: %w", err)
-	}
+	arrival := resolveArrivalSlotFromPreload(pre, date)
+	pickup := resolvePickupSlotFromPreload(pre, date)
 
-	return &StudentDayResponse{
+	return StudentDayResponse{
 		StudentID: studentID,
 		Date:      date.Format(dateLayout),
 		Weekday:   isoWeekday(date),
 		Arrival:   arrival,
 		Instances: instances,
 		Pickup:    pickup,
-	}, nil
+	}
 }
 
-// resolveArrivalSlot implements the exception-over-schedule precedence rule.
-// An arrival exception with a non-nil time wins over any weekday schedule.
-// An exception with nil time means "absent" on that date — still an
-// exception, still wins (source="exception", expected_time=null).
-func (rs *Resource) resolveArrivalSlot(ctx context.Context, studentID int64, date time.Time) (SlotResponse, error) {
-	if rs.arrivalExceptionRepo != nil {
-		exc, err := rs.arrivalExceptionRepo.FindByStudentIDAndDate(ctx, studentID, date)
-		if err != nil {
-			return SlotResponse{}, err
-		}
-		if exc != nil {
-			return mapArrivalExceptionSlot(exc), nil
+// resolveArrivalSlotFromPreload implements the exception-over-schedule rule
+// against already-loaded data. An exception on the date wins even when its
+// time is nil (absence signal).
+func resolveArrivalSlotFromPreload(pre *weekPreload, date time.Time) SlotResponse {
+	if exc, ok := pre.arrivalExcByDate[dateKey(date)]; ok && exc != nil {
+		return mapArrivalExceptionSlot(exc)
+	}
+	wd := isoWeekday(date)
+	if wd >= scheduleModel.WeekdayMonday && wd <= scheduleModel.WeekdayFriday {
+		if sched, ok := pre.arrivalSchedByWeekly[wd]; ok && sched != nil {
+			return mapArrivalScheduleSlot(sched)
 		}
 	}
-
-	if rs.arrivalScheduleRepo != nil {
-		wd := isoWeekday(date)
-		if wd >= scheduleModel.WeekdayMonday && wd <= scheduleModel.WeekdayFriday {
-			sched, err := rs.arrivalScheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, wd)
-			if err != nil {
-				return SlotResponse{}, err
-			}
-			if sched != nil {
-				return mapArrivalScheduleSlot(sched), nil
-			}
-		}
-	}
-
-	return SlotResponse{Source: SlotSourceNone}, nil
+	return SlotResponse{Source: SlotSourceNone}
 }
 
-// resolvePickupSlot mirrors resolveArrivalSlot.
-func (rs *Resource) resolvePickupSlot(ctx context.Context, studentID int64, date time.Time) (SlotResponse, error) {
-	if rs.pickupExceptionRepo != nil {
-		exc, err := rs.pickupExceptionRepo.FindByStudentIDAndDate(ctx, studentID, date)
-		if err != nil {
-			return SlotResponse{}, err
-		}
-		if exc != nil {
-			return mapPickupExceptionSlot(exc), nil
+// resolvePickupSlotFromPreload mirrors resolveArrivalSlotFromPreload.
+func resolvePickupSlotFromPreload(pre *weekPreload, date time.Time) SlotResponse {
+	if exc, ok := pre.pickupExcByDate[dateKey(date)]; ok && exc != nil {
+		return mapPickupExceptionSlot(exc)
+	}
+	wd := isoWeekday(date)
+	if wd >= scheduleModel.WeekdayMonday && wd <= scheduleModel.WeekdayFriday {
+		if sched, ok := pre.pickupSchedByWeekly[wd]; ok && sched != nil {
+			return mapPickupScheduleSlot(sched)
 		}
 	}
-
-	if rs.pickupScheduleRepo != nil {
-		wd := isoWeekday(date)
-		if wd >= scheduleModel.WeekdayMonday && wd <= scheduleModel.WeekdayFriday {
-			sched, err := rs.pickupScheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, wd)
-			if err != nil {
-				return SlotResponse{}, err
-			}
-			if sched != nil {
-				return mapPickupScheduleSlot(sched), nil
-			}
-		}
-	}
-
-	return SlotResponse{Source: SlotSourceNone}, nil
+	return SlotResponse{Source: SlotSourceNone}
 }

--- a/backend/api/timetable/student_day.go
+++ b/backend/api/timetable/student_day.go
@@ -48,6 +48,17 @@ func isoWeekday(t time.Time) int {
 	return int((int(t.In(timezone.Berlin).Weekday())+6)%7 + 1)
 }
 
+// inclusiveDayCount returns the number of Berlin-local days in the inclusive
+// [from, to] range. Anchors both ends to UTC midnight of the same Berlin date
+// via timezone.DateOfUTC so DST transitions (23h/25h days) don't skew the
+// count — a plain to.Sub(from).Hours()/24 undercounts in spring and overcounts
+// in autumn.
+func inclusiveDayCount(from, to time.Time) int {
+	fromUTC := timezone.DateOfUTC(from)
+	toUTC := timezone.DateOfUTC(to)
+	return int(toUTC.Sub(fromUTC).Hours()/24) + 1
+}
+
 // dateKey formats a time as YYYY-MM-DD for use as a map key.
 func dateKey(t time.Time) string { return t.Format(dateLayout) }
 
@@ -124,7 +135,7 @@ func (rs *Resource) getStudentWeek(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("'from' must be before or equal to 'to'")))
 		return
 	}
-	rangeDays := int(to.Sub(from).Hours()/24) + 1
+	rangeDays := inclusiveDayCount(from, to)
 	if rangeDays > maxWeekRangeDays {
 		common.RenderError(w, r, common.ErrorInvalidRequest(
 			fmt.Errorf("date range exceeds maximum of %d days", maxWeekRangeDays)))
@@ -354,7 +365,7 @@ func (rs *Resource) buildStudentDays(ctx context.Context, studentID int64, from,
 		return nil, err
 	}
 
-	dayCount := int(to.Sub(from).Hours()/24) + 1
+	dayCount := inclusiveDayCount(from, to)
 	days := make([]StudentDayResponse, 0, dayCount)
 	for d := from; !d.After(to); d = d.AddDate(0, 0, 1) {
 		day := buildStudentDayFromPreload(pre, studentID, d)

--- a/backend/api/timetable/student_day.go
+++ b/backend/api/timetable/student_day.go
@@ -24,7 +24,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
-	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
@@ -375,7 +374,3 @@ func (rs *Resource) resolvePickupSlot(ctx context.Context, studentID int64, date
 
 	return SlotResponse{Source: SlotSourceNone}, nil
 }
-
-// Compile-time hint for future readers: ScheduledInstanceRow must stay
-// exported from the repo package because mapEnrolledInstance takes it.
-var _ = (*scheduleRepo.ScheduledInstanceRow)(nil)

--- a/backend/api/timetable/student_day.go
+++ b/backend/api/timetable/student_day.go
@@ -1,0 +1,381 @@
+// Package timetable — per-student day and week read endpoints (WP-B11).
+//
+//	GET /api/timetable/student/{id}/day?date=YYYY-MM-DD
+//	GET /api/timetable/student/{id}/week?from=YYYY-MM-DD&to=YYYY-MM-DD
+//
+// Both routes return the student's planned instances for the requested
+// date(s), each enriched with the student's attendance row, plus the
+// arrival/pickup slot for that day (schedule or exception, or "none").
+// For active/completed instances the student was physically in but NOT
+// enrolled, the response adds a separate "is_unplanned" entry.
+package timetable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	usersModel "github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// maxWeekRangeDays caps /week at 14 days inclusive. Longer spans are
+// rejected at 400 — the response assembly is O(days × instances) and the
+// frontend has no use case for a longer horizon today.
+const maxWeekRangeDays = 14
+
+// berlinDate parses a YYYY-MM-DD input anchored in Berlin timezone. The
+// distinction matters for the 00:00–02:00 CET/UTC gap: a UTC-anchored parse
+// of "2026-04-22" would be midnight UTC (02:00 Berlin), and a Berlin-DateOf
+// round-trip would land on the previous day. Using ParseInLocation sidesteps
+// that entirely.
+func berlinDate(input string) (time.Time, error) {
+	return time.ParseInLocation(dateLayout, input, timezone.Berlin)
+}
+
+// isoWeekday returns 1..7 (Mon..Sun) for the Berlin-local weekday of t.
+func isoWeekday(t time.Time) int {
+	return int((int(t.In(timezone.Berlin).Weekday())+6)%7 + 1)
+}
+
+// getStudentDay handles GET /api/timetable/student/{id}/day.
+func (rs *Resource) getStudentDay(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	studentID, ok := parseStudentIDParam(w, r)
+	if !ok {
+		return
+	}
+	dateStr := r.URL.Query().Get("date")
+	if dateStr == "" {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("date is required")))
+		return
+	}
+	date, err := berlinDate(dateStr)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid date format, expected YYYY-MM-DD")))
+		return
+	}
+
+	student, ok := rs.resolveStudentForRead(w, r, studentID)
+	if !ok {
+		return
+	}
+
+	day, err := rs.buildStudentDay(ctx, student.ID, date)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("build student day failed", err))
+		return
+	}
+
+	rs.getLogger().Info("timetable student day",
+		slog.Int64("student_id", student.ID),
+		slog.String("date", day.Date),
+	)
+	common.Respond(w, r, http.StatusOK, day, "Student day retrieved")
+}
+
+// getStudentWeek handles GET /api/timetable/student/{id}/week. The date
+// range is inclusive on both ends; max 14 days.
+func (rs *Resource) getStudentWeek(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	studentID, ok := parseStudentIDParam(w, r)
+	if !ok {
+		return
+	}
+	q := r.URL.Query()
+	fromStr := q.Get("from")
+	toStr := q.Get("to")
+	if fromStr == "" || toStr == "" {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("from and to are required")))
+		return
+	}
+	from, err := berlinDate(fromStr)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid from format, expected YYYY-MM-DD")))
+		return
+	}
+	to, err := berlinDate(toStr)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid to format, expected YYYY-MM-DD")))
+		return
+	}
+	if from.After(to) {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("'from' must be before or equal to 'to'")))
+		return
+	}
+	rangeDays := int(to.Sub(from).Hours()/24) + 1
+	if rangeDays > maxWeekRangeDays {
+		common.RenderError(w, r, common.ErrorInvalidRequest(
+			fmt.Errorf("date range exceeds maximum of %d days", maxWeekRangeDays)))
+		return
+	}
+
+	student, ok := rs.resolveStudentForRead(w, r, studentID)
+	if !ok {
+		return
+	}
+
+	days := make([]StudentDayResponse, 0, rangeDays)
+	for d := from; !d.After(to); d = d.AddDate(0, 0, 1) {
+		dayResp, err := rs.buildStudentDay(ctx, student.ID, d)
+		if err != nil {
+			common.RenderError(w, r, common.ErrorInternalServerWrap("build student week day failed", err))
+			return
+		}
+		days = append(days, *dayResp)
+	}
+
+	resp := StudentWeekResponse{
+		StudentID: student.ID,
+		From:      from.Format(dateLayout),
+		To:        to.Format(dateLayout),
+		Days:      days,
+	}
+
+	rs.getLogger().Info("timetable student week",
+		slog.Int64("student_id", student.ID),
+		slog.String("from", resp.From),
+		slog.String("to", resp.To),
+		slog.Int("days", len(days)),
+	)
+	common.Respond(w, r, http.StatusOK, resp, "Student week retrieved")
+}
+
+// parseStudentIDParam extracts {id} from the path. 400 on garbage or <=0.
+func parseStudentIDParam(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid student ID")))
+		return 0, false
+	}
+	return id, true
+}
+
+// resolveStudentForRead fetches the student and enforces the read-access
+// rules. Cross-tenant ("student doesn't exist in caller's tenant") is 404;
+// same-tenant but no access is 403. The 404-vs-403 split matters: returning
+// 403 for a tenant-B student would leak the student's existence to tenant A.
+func (rs *Resource) resolveStudentForRead(w http.ResponseWriter, r *http.Request, studentID int64) (*usersModel.Student, bool) {
+	ctx := r.Context()
+
+	if rs.studentRepo == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("student repo not wired")))
+		return nil, false
+	}
+
+	student, err := rs.studentRepo.FindByID(ctx, studentID)
+	if err != nil {
+		if isNotFoundDBError(err) {
+			common.RenderError(w, r, common.ErrorNotFound(errors.New("student not found")))
+			return nil, false
+		}
+		common.RenderError(w, r, common.ErrorInternalServerWrap("load student failed", err))
+		return nil, false
+	}
+	if student == nil || student.ID == 0 {
+		common.RenderError(w, r, common.ErrorNotFound(errors.New("student not found")))
+		return nil, false
+	}
+
+	if !authorize.CanReadStudent(
+		ctx,
+		jwt.PermissionsFromCtx(ctx),
+		student,
+		rs.userContextService,
+		rs.settingsService,
+		rs.getLogger(),
+	) {
+		common.RenderError(w, r, common.ErrorForbidden(errors.New("forbidden")))
+		return nil, false
+	}
+
+	return student, true
+}
+
+// buildStudentDay assembles the per-day response. Four reads:
+//  1. Enrolled instances + attendance rows (1 query, joined).
+//  2. All activity_instances in the tenant for the date (1 query) — needed
+//     to resolve visit.active_group_id → instance for is_unplanned entries.
+//  3. Student's visits scoped to those active_group_ids (1 query).
+//  4. Arrival/pickup schedule + exception (up to 4 queries).
+//
+// That is O(1) in the number of instances per day — no N+1.
+func (rs *Resource) buildStudentDay(ctx context.Context, studentID int64, date time.Time) (*StudentDayResponse, error) {
+	dateUTC := timezone.DateOfUTC(date)
+
+	if rs.studentDayRepo == nil {
+		return nil, errors.New("studentDayRepo not wired")
+	}
+
+	// 1) Enrolled instances for the student on this date.
+	enrolledRows, err := rs.studentDayRepo.FindInstancesWithAttendanceByStudentAndDateRange(
+		ctx, studentID, dateUTC, dateUTC,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load enrolled instances: %w", err)
+	}
+
+	// 2) All instances in the tenant on this date — needed to map visit
+	//    active_group_ids back to an instance for is_unplanned entries.
+	allInstances, err := rs.activityInstanceRepo.FindByTenantAndDateRange(ctx, dateUTC, dateUTC)
+	if err != nil {
+		return nil, fmt.Errorf("load all tenant instances: %w", err)
+	}
+
+	// Index instances by active_group_id for the active/completed subset.
+	// Planned/cancelled never have visits bridged (per WP-B11 scope), so we
+	// skip them in the index.
+	instByActiveGroupID := make(map[int64]*scheduleModel.ActivityInstance, len(allInstances))
+	activeGroupIDs := make([]int64, 0, len(allInstances))
+	for _, inst := range allInstances {
+		if inst.ActiveGroupID == nil {
+			continue
+		}
+		if inst.Status != scheduleModel.InstanceStatusActive && inst.Status != scheduleModel.InstanceStatusCompleted {
+			continue
+		}
+		instByActiveGroupID[*inst.ActiveGroupID] = inst
+		activeGroupIDs = append(activeGroupIDs, *inst.ActiveGroupID)
+	}
+
+	// 3) Student visits scoped to the active/completed instances we know
+	//    about. Empty list short-circuits with no DB call.
+	var studentVisits []*activeModel.Visit
+	if len(activeGroupIDs) > 0 && rs.visitRepo != nil {
+		studentVisits, err = rs.visitRepo.FindByStudentAndActiveGroupIDs(ctx, studentID, activeGroupIDs)
+		if err != nil {
+			return nil, fmt.Errorf("load student visits: %w", err)
+		}
+	}
+
+	// Build the base instance list from enrolled rows.
+	enrolledInstanceIDs := make(map[int64]bool, len(enrolledRows))
+	instances := make([]InstanceDayResponse, 0, len(enrolledRows)+len(studentVisits))
+	for _, row := range enrolledRows {
+		instances = append(instances, mapEnrolledInstance(row))
+		enrolledInstanceIDs[row.Instance.ID] = true
+	}
+
+	// Append is_unplanned entries: visits whose instance is NOT in the
+	// enrolled set. Dedup by active_group_id in case of (rare) multi-visit
+	// against the same bridge.
+	seenActiveGroupID := make(map[int64]bool, len(studentVisits))
+	for _, v := range studentVisits {
+		if v == nil {
+			continue
+		}
+		inst, ok := instByActiveGroupID[v.ActiveGroupID]
+		if !ok {
+			continue
+		}
+		if enrolledInstanceIDs[inst.ID] {
+			continue
+		}
+		if seenActiveGroupID[v.ActiveGroupID] {
+			continue
+		}
+		seenActiveGroupID[v.ActiveGroupID] = true
+		instances = append(instances, mapUnplannedInstance(inst, v))
+	}
+
+	sort.SliceStable(instances, func(i, j int) bool {
+		return instances[i].StartTime < instances[j].StartTime
+	})
+
+	// 4) Arrival / pickup slots.
+	arrival, err := rs.resolveArrivalSlot(ctx, studentID, dateUTC)
+	if err != nil {
+		return nil, fmt.Errorf("resolve arrival: %w", err)
+	}
+	pickup, err := rs.resolvePickupSlot(ctx, studentID, dateUTC)
+	if err != nil {
+		return nil, fmt.Errorf("resolve pickup: %w", err)
+	}
+
+	return &StudentDayResponse{
+		StudentID: studentID,
+		Date:      date.Format(dateLayout),
+		Weekday:   isoWeekday(date),
+		Arrival:   arrival,
+		Instances: instances,
+		Pickup:    pickup,
+	}, nil
+}
+
+// resolveArrivalSlot implements the exception-over-schedule precedence rule.
+// An arrival exception with a non-nil time wins over any weekday schedule.
+// An exception with nil time means "absent" on that date — still an
+// exception, still wins (source="exception", expected_time=null).
+func (rs *Resource) resolveArrivalSlot(ctx context.Context, studentID int64, date time.Time) (SlotResponse, error) {
+	if rs.arrivalExceptionRepo != nil {
+		exc, err := rs.arrivalExceptionRepo.FindByStudentIDAndDate(ctx, studentID, date)
+		if err != nil {
+			return SlotResponse{}, err
+		}
+		if exc != nil {
+			return mapArrivalExceptionSlot(exc), nil
+		}
+	}
+
+	if rs.arrivalScheduleRepo != nil {
+		wd := isoWeekday(date)
+		if wd >= scheduleModel.WeekdayMonday && wd <= scheduleModel.WeekdayFriday {
+			sched, err := rs.arrivalScheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, wd)
+			if err != nil {
+				return SlotResponse{}, err
+			}
+			if sched != nil {
+				return mapArrivalScheduleSlot(sched), nil
+			}
+		}
+	}
+
+	return SlotResponse{Source: SlotSourceNone}, nil
+}
+
+// resolvePickupSlot mirrors resolveArrivalSlot.
+func (rs *Resource) resolvePickupSlot(ctx context.Context, studentID int64, date time.Time) (SlotResponse, error) {
+	if rs.pickupExceptionRepo != nil {
+		exc, err := rs.pickupExceptionRepo.FindByStudentIDAndDate(ctx, studentID, date)
+		if err != nil {
+			return SlotResponse{}, err
+		}
+		if exc != nil {
+			return mapPickupExceptionSlot(exc), nil
+		}
+	}
+
+	if rs.pickupScheduleRepo != nil {
+		wd := isoWeekday(date)
+		if wd >= scheduleModel.WeekdayMonday && wd <= scheduleModel.WeekdayFriday {
+			sched, err := rs.pickupScheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, wd)
+			if err != nil {
+				return SlotResponse{}, err
+			}
+			if sched != nil {
+				return mapPickupScheduleSlot(sched), nil
+			}
+		}
+	}
+
+	return SlotResponse{Source: SlotSourceNone}, nil
+}
+
+// Compile-time hint for future readers: ScheduledInstanceRow must stay
+// exported from the repo package because mapEnrolledInstance takes it.
+var _ = (*scheduleRepo.ScheduledInstanceRow)(nil)

--- a/backend/api/timetable/student_day_shapes.go
+++ b/backend/api/timetable/student_day_shapes.go
@@ -3,7 +3,6 @@ package timetable
 import (
 	"time"
 
-	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
@@ -79,7 +78,7 @@ type StudentWeekResponse struct {
 // wire shape. The attendance row is authoritative — status/substatus/note/
 // checked_in_at come from it directly. is_unplanned is always false here
 // (enrolled = has an instance_students row).
-func mapEnrolledInstance(row *scheduleRepo.ScheduledInstanceRow) InstanceDayResponse {
+func mapEnrolledInstance(row *scheduleModel.ScheduledInstanceRow) InstanceDayResponse {
 	att := row.Attendance
 	resp := InstanceDayResponse{
 		ID:            row.Instance.ID,

--- a/backend/api/timetable/student_day_shapes.go
+++ b/backend/api/timetable/student_day_shapes.go
@@ -1,0 +1,184 @@
+package timetable
+
+import (
+	"time"
+
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+// SlotResponse describes an arrival or pickup slot for a single day.
+//
+// Source is always one of SlotSource* below. ExpectedTime is nil when
+// source=none, or when source=exception and the exception expresses absence
+// (no time). Reason is populated only for exceptions that carry one.
+type SlotResponse struct {
+	ExpectedTime *string `json:"expected_time"`
+	Source       string  `json:"source"`
+	Reason       *string `json:"reason,omitempty"`
+}
+
+// SlotSource constants for SlotResponse.Source. Kept as strings (not a type)
+// because the wire format is a plain JSON string — no need for a typed enum.
+const (
+	SlotSourceSchedule  = "schedule"
+	SlotSourceException = "exception"
+	SlotSourceNone      = "none"
+)
+
+// AttendanceDayResponse is the per-student attendance payload on a day
+// instance. Status / substatus / note / checked_in_at come from
+// schedule.instance_students; is_unplanned is true only for active/completed
+// instances where the student had a visit but no instance_students row.
+type AttendanceDayResponse struct {
+	Status      string  `json:"status"`
+	Substatus   *string `json:"substatus"`
+	Note        *string `json:"note"`
+	CheckedInAt *string `json:"checked_in_at"`
+	IsUnplanned bool    `json:"is_unplanned"`
+}
+
+// InstanceDayResponse is one scheduled instance as it appears in a student's
+// day view. active_group_id is nil for planned/cancelled instances.
+type InstanceDayResponse struct {
+	ID            int64                 `json:"id"`
+	Title         string                `json:"title"`
+	StartTime     string                `json:"start_time"`
+	EndTime       string                `json:"end_time"`
+	RoomID        int64                 `json:"room_id"`
+	Status        string                `json:"status"`
+	ActiveGroupID *int64                `json:"active_group_id"`
+	Attendance    AttendanceDayResponse `json:"attendance"`
+}
+
+// StudentDayResponse is the body returned by GET /student/{id}/day.
+type StudentDayResponse struct {
+	StudentID int64                 `json:"student_id"`
+	Date      string                `json:"date"`
+	Weekday   int                   `json:"weekday"`
+	Arrival   SlotResponse          `json:"arrival"`
+	Instances []InstanceDayResponse `json:"instances"`
+	Pickup    SlotResponse          `json:"pickup"`
+}
+
+// StudentWeekResponse is the body returned by GET /student/{id}/week. Days
+// is always inclusive-inclusive across the requested range, one entry per
+// date (including dates with no instances).
+type StudentWeekResponse struct {
+	StudentID int64                `json:"student_id"`
+	From      string               `json:"from"`
+	To        string               `json:"to"`
+	Days      []StudentDayResponse `json:"days"`
+}
+
+// --- Mappers ---------------------------------------------------------------
+
+// mapEnrolledInstance lifts a repo-side (instance, attendance) pair into the
+// wire shape. The attendance row is authoritative — status/substatus/note/
+// checked_in_at come from it directly. is_unplanned is always false here
+// (enrolled = has an instance_students row).
+func mapEnrolledInstance(row *scheduleRepo.ScheduledInstanceRow) InstanceDayResponse {
+	att := row.Attendance
+	resp := InstanceDayResponse{
+		ID:            row.Instance.ID,
+		Title:         row.Instance.Title,
+		StartTime:     row.Instance.StartTime.Format("15:04"),
+		EndTime:       row.Instance.EndTime.Format("15:04"),
+		RoomID:        row.Instance.RoomID,
+		Status:        row.Instance.Status,
+		ActiveGroupID: row.Instance.ActiveGroupID,
+		Attendance: AttendanceDayResponse{
+			Status:      att.Status,
+			Substatus:   att.Substatus,
+			Note:        att.Note,
+			CheckedInAt: formatOptionalRFC3339(att.CheckedInAt),
+			IsUnplanned: false,
+		},
+	}
+	return resp
+}
+
+// mapUnplannedInstance builds a response entry for a visit without an
+// instance_students row. Status is synthesized as "present" (the visit
+// proves they were there), substatus/note stay nil, checked_in_at comes
+// from the visit's entry_time.
+func mapUnplannedInstance(inst *scheduleModel.ActivityInstance, visit *activeModel.Visit) InstanceDayResponse {
+	checkedIn := formatOptionalRFC3339(&visit.EntryTime)
+	return InstanceDayResponse{
+		ID:            inst.ID,
+		Title:         inst.Title,
+		StartTime:     inst.StartTime.Format("15:04"),
+		EndTime:       inst.EndTime.Format("15:04"),
+		RoomID:        inst.RoomID,
+		Status:        inst.Status,
+		ActiveGroupID: inst.ActiveGroupID,
+		Attendance: AttendanceDayResponse{
+			Status:      scheduleModel.AttendanceStatusPresent,
+			Substatus:   nil,
+			Note:        nil,
+			CheckedInAt: checkedIn,
+			IsUnplanned: true,
+		},
+	}
+}
+
+// mapArrivalScheduleSlot maps a recurring weekly schedule to the slot shape.
+func mapArrivalScheduleSlot(s *scheduleModel.StudentArrivalSchedule) SlotResponse {
+	t := s.ExpectedArrival.Format("15:04")
+	return SlotResponse{
+		ExpectedTime: &t,
+		Source:       SlotSourceSchedule,
+	}
+}
+
+// mapArrivalExceptionSlot maps a date-specific exception. A nil time means
+// absence on this date; we surface source=exception with ExpectedTime=nil.
+func mapArrivalExceptionSlot(e *scheduleModel.StudentArrivalException) SlotResponse {
+	resp := SlotResponse{Source: SlotSourceException}
+	if e.ExpectedArrival != nil {
+		t := e.ExpectedArrival.Format("15:04")
+		resp.ExpectedTime = &t
+	}
+	if e.Reason != nil && *e.Reason != "" {
+		r := *e.Reason
+		resp.Reason = &r
+	}
+	return resp
+}
+
+// mapPickupScheduleSlot mirrors mapArrivalScheduleSlot for pickup.
+func mapPickupScheduleSlot(s *scheduleModel.StudentPickupSchedule) SlotResponse {
+	t := s.PickupTime.Format("15:04")
+	return SlotResponse{
+		ExpectedTime: &t,
+		Source:       SlotSourceSchedule,
+	}
+}
+
+// mapPickupExceptionSlot mirrors mapArrivalExceptionSlot for pickup.
+func mapPickupExceptionSlot(e *scheduleModel.StudentPickupException) SlotResponse {
+	resp := SlotResponse{Source: SlotSourceException}
+	if e.PickupTime != nil {
+		t := e.PickupTime.Format("15:04")
+		resp.ExpectedTime = &t
+	}
+	if e.Reason != nil && *e.Reason != "" {
+		r := *e.Reason
+		resp.Reason = &r
+	}
+	return resp
+}
+
+// formatOptionalRFC3339 renders an optional timestamp in Berlin-local time
+// using RFC3339. Returns nil when the input is nil — the JSON field stays
+// null in that case. Berlin-local so the frontend does not need to round-
+// trip an offset conversion for display.
+func formatOptionalRFC3339(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.In(timezone.Berlin).Format(time.RFC3339)
+	return &s
+}

--- a/backend/api/timetable/student_day_test.go
+++ b/backend/api/timetable/student_day_test.go
@@ -1,0 +1,435 @@
+// Integration tests for the WP-B11 per-student day/week endpoints. Uses a
+// real DB + real repos; the test router mounts the handlers without the
+// JWT/TenantTx middleware stack, so tenant context and permissions are
+// injected directly into the request context (the same pattern used by
+// instance_students_test.go).
+package timetable
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	activeRepo "github.com/moto-nrw/project-phoenix/database/repositories/active"
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	usersRepo "github.com/moto-nrw/project-phoenix/database/repositories/users"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// studentDaySetup holds wired fixtures + resource for the B11 handler tests.
+type studentDaySetup struct {
+	res        *Resource
+	db         *bun.DB
+	ctx        context.Context
+	studentID  int64
+	staffID    int64
+	roomID     int64
+	activityID int64
+}
+
+// buildStudentDaySetup creates one student, one staff member (for
+// created_by FKs), one room, and a planned activity_instance on
+// 2026-04-22 (a Wednesday). Per-test helpers add instance_students /
+// arrival / pickup / visit rows on top.
+func buildStudentDaySetup(t *testing.T) *studentDaySetup {
+	t.Helper()
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := testpkg.TenantContext(1)
+	suffix := time.Now().UnixNano()
+
+	room := testpkg.CreateTestRoom(t, db, fmt.Sprintf("SD-Room-%d", suffix))
+	activity := testpkg.CreateTestActivityGroup(t, db, fmt.Sprintf("SD-Act-%d", suffix))
+	staff := testpkg.CreateTestStaff(t, db, "SD", fmt.Sprintf("Staff-%d", suffix))
+	student := testpkg.CreateTestStudent(t, db, "SD", fmt.Sprintf("Stu-%d", suffix), "3a")
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, db, student.ID, staff.ID, 0, activity.ID, room.ID)
+	})
+
+	// Wire the full resource with real repos for the B11 path.
+	isIface := scheduleRepo.NewInstanceStudentRepository(db)
+	studentDayConcrete := isIface.(*scheduleRepo.InstanceStudentRepository)
+
+	res := NewResource(
+		nil, nil, nil, nil, // calendar/material/instance/person services unused
+		isIface, studentDayConcrete,
+		scheduleRepo.NewActivityInstanceRepository(db),
+		scheduleRepo.NewStudentArrivalScheduleRepository(db),
+		scheduleRepo.NewStudentArrivalExceptionRepository(db),
+		scheduleRepo.NewStudentPickupScheduleRepository(db),
+		scheduleRepo.NewStudentPickupExceptionRepository(db),
+		activeRepo.NewVisitRepository(db),
+		usersRepo.NewStudentRepository(db),
+		nil, // userContextService — test path relies on admin perms
+		nil, // settingsService — CanReadStudent falls through to group-supervisor check
+		nil, // logger
+		db,
+	)
+
+	return &studentDaySetup{
+		res:        res,
+		db:         db,
+		ctx:        ctx,
+		studentID:  student.ID,
+		staffID:    staff.ID,
+		roomID:     room.ID,
+		activityID: activity.ID,
+	}
+}
+
+// adminRouter mounts /student/{id}/{day|week} without middleware, pre-baking
+// admin permissions into the request context so CanReadStudent short-circuits
+// to allow. A separate non-admin router is used for the forbidden-path tests.
+func adminRouter(parentCtx context.Context, res *Resource) chi.Router {
+	return studentRouter(parentCtx, res, []string{"admin:*"})
+}
+
+func studentRouter(parentCtx context.Context, res *Resource, perms []string) chi.Router {
+	tenantID := tenant.FromContext(parentCtx)
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := tenant.WithTenantID(req.Context(), tenantID)
+			ctx = context.WithValue(ctx, jwt.CtxPermissions, perms)
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	})
+	r.Get("/student/{id}/day", res.getStudentDay)
+	r.Get("/student/{id}/week", res.getStudentWeek)
+	return r
+}
+
+func doGet(t *testing.T, router chi.Router, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func decodeEnvelope(t *testing.T, w *httptest.ResponseRecorder, target any) {
+	t.Helper()
+	var env struct {
+		Status string          `json:"status"`
+		Data   json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env), "body=%s", w.Body.String())
+	require.Equal(t, "success", env.Status, "body=%s", w.Body.String())
+	require.NoError(t, json.Unmarshal(env.Data, target))
+}
+
+// --- /day -----------------------------------------------------------------
+
+func TestGetStudentDay_HappyPath_WithScheduleAndEnrolledInstance(t *testing.T) {
+	s := buildStudentDaySetup(t)
+
+	// Create a planned instance on Wed 2026-04-22.
+	inst := testpkg.CreateTestActivityInstance(t, s.db, time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), s.roomID, testpkg.ActivityInstanceOpts{
+		ActivityGroupID: &s.activityID,
+		StartHHMM:       "14:00",
+		EndHHMM:         "15:00",
+		Title:           "Lernzeit-3a",
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	row := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, s.studentID, schedule.AttendanceStatusExpected)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", row.ID) })
+
+	// Wednesday is weekday 3 (ISO).
+	arrival := testpkg.CreateTestArrivalSchedule(t, s.db, s.studentID, schedule.WeekdayWednesday, s.staffID, "13:00")
+	pickup := testpkg.CreateTestPickupSchedule(t, s.db, s.studentID, schedule.WeekdayWednesday, s.staffID, "16:00")
+	t.Cleanup(func() {
+		testpkg.CleanupScheduleFixturesB11(t, s.db,
+			[]int64{arrival.ID}, nil,
+			[]int64{pickup.ID}, nil,
+			nil, nil)
+	})
+
+	router := adminRouter(s.ctx, s.res)
+	w := doGet(t, router, fmt.Sprintf("/student/%d/day?date=2026-04-22", s.studentID))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var got StudentDayResponse
+	decodeEnvelope(t, w, &got)
+
+	assert.Equal(t, s.studentID, got.StudentID)
+	assert.Equal(t, "2026-04-22", got.Date)
+	assert.Equal(t, 3, got.Weekday)
+
+	// arrival: source=schedule, expected_time=13:00.
+	assert.Equal(t, SlotSourceSchedule, got.Arrival.Source)
+	require.NotNil(t, got.Arrival.ExpectedTime)
+	assert.Equal(t, "13:00", *got.Arrival.ExpectedTime)
+	assert.Nil(t, got.Arrival.Reason)
+
+	// pickup: source=schedule, expected_time=16:00.
+	assert.Equal(t, SlotSourceSchedule, got.Pickup.Source)
+	require.NotNil(t, got.Pickup.ExpectedTime)
+	assert.Equal(t, "16:00", *got.Pickup.ExpectedTime)
+
+	// instances list: one enrolled, no is_unplanned.
+	require.Len(t, got.Instances, 1)
+	i := got.Instances[0]
+	assert.Equal(t, inst.ID, i.ID)
+	assert.Equal(t, "Lernzeit-3a", i.Title)
+	assert.Equal(t, "14:00", i.StartTime)
+	assert.Equal(t, "15:00", i.EndTime)
+	assert.Equal(t, schedule.InstanceStatusPlanned, i.Status)
+	assert.False(t, i.Attendance.IsUnplanned)
+	assert.Equal(t, schedule.AttendanceStatusExpected, i.Attendance.Status)
+}
+
+func TestGetStudentDay_ExceptionOverridesSchedule(t *testing.T) {
+	s := buildStudentDaySetup(t)
+
+	arrSched := testpkg.CreateTestArrivalSchedule(t, s.db, s.studentID, schedule.WeekdayWednesday, s.staffID, "13:00")
+	arrExc := testpkg.CreateTestArrivalException(t, s.db, s.studentID,
+		time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), s.staffID, "10:30", "Wandertag")
+	t.Cleanup(func() {
+		testpkg.CleanupScheduleFixturesB11(t, s.db,
+			[]int64{arrSched.ID}, []int64{arrExc.ID}, nil, nil, nil, nil)
+	})
+
+	router := adminRouter(s.ctx, s.res)
+	w := doGet(t, router, fmt.Sprintf("/student/%d/day?date=2026-04-22", s.studentID))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got StudentDayResponse
+	decodeEnvelope(t, w, &got)
+
+	assert.Equal(t, SlotSourceException, got.Arrival.Source)
+	require.NotNil(t, got.Arrival.ExpectedTime)
+	assert.Equal(t, "10:30", *got.Arrival.ExpectedTime)
+	require.NotNil(t, got.Arrival.Reason)
+	assert.Equal(t, "Wandertag", *got.Arrival.Reason)
+}
+
+func TestGetStudentDay_PickupException_NilTimeMeansAbsence(t *testing.T) {
+	s := buildStudentDaySetup(t)
+
+	// A pickup exception with empty HHMM → PickupTime=NULL = absence for
+	// the day. Source must still be "exception", ExpectedTime must be nil.
+	exc := testpkg.CreateTestPickupException(t, s.db, s.studentID,
+		time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), s.staffID, "", "Krank")
+	t.Cleanup(func() {
+		testpkg.CleanupScheduleFixturesB11(t, s.db,
+			nil, nil, nil, []int64{exc.ID}, nil, nil)
+	})
+
+	router := adminRouter(s.ctx, s.res)
+	w := doGet(t, router, fmt.Sprintf("/student/%d/day?date=2026-04-22", s.studentID))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got StudentDayResponse
+	decodeEnvelope(t, w, &got)
+
+	assert.Equal(t, SlotSourceException, got.Pickup.Source)
+	assert.Nil(t, got.Pickup.ExpectedTime, "absence exception must surface nil time")
+	require.NotNil(t, got.Pickup.Reason)
+	assert.Equal(t, "Krank", *got.Pickup.Reason)
+}
+
+func TestGetStudentDay_NoArrivalNoPickup_SourceNone(t *testing.T) {
+	s := buildStudentDaySetup(t)
+
+	router := adminRouter(s.ctx, s.res)
+	w := doGet(t, router, fmt.Sprintf("/student/%d/day?date=2026-04-22", s.studentID))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got StudentDayResponse
+	decodeEnvelope(t, w, &got)
+
+	assert.Equal(t, SlotSourceNone, got.Arrival.Source)
+	assert.Nil(t, got.Arrival.ExpectedTime)
+	assert.Equal(t, SlotSourceNone, got.Pickup.Source)
+	assert.Nil(t, got.Pickup.ExpectedTime)
+	assert.Empty(t, got.Instances)
+}
+
+// Unplanned scenario: active.visit exists for student on an active
+// instance's bridge group, but no instance_students row.
+func TestGetStudentDay_UnplannedStudent(t *testing.T) {
+	s := buildStudentDaySetup(t)
+
+	// Active group + bridge instance.
+	ag := testpkg.CreateTestActiveGroup(t, s.db, s.activityID, s.roomID)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.groups", ag.ID) })
+
+	agID := ag.ID
+	inst := testpkg.CreateTestActivityInstance(t, s.db,
+		time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), s.roomID,
+		testpkg.ActivityInstanceOpts{
+			ActivityGroupID: &s.activityID,
+			ActiveGroupID:   &agID,
+			Status:          schedule.InstanceStatusActive,
+			StartHHMM:       "14:00",
+			EndHHMM:         "15:00",
+			Title:           "Unplanned-Session",
+		})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	// No instance_students row for our student — they're NOT on the plan.
+	// But they checked in, so a visit exists.
+	visit := testpkg.CreateTestVisit(t, s.db, s.studentID, ag.ID,
+		time.Date(2026, 4, 22, 14, 5, 0, 0, time.UTC), nil)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.visits", visit.ID) })
+
+	router := adminRouter(s.ctx, s.res)
+	w := doGet(t, router, fmt.Sprintf("/student/%d/day?date=2026-04-22", s.studentID))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var got StudentDayResponse
+	decodeEnvelope(t, w, &got)
+
+	require.Len(t, got.Instances, 1, "must surface the walk-in as an instance")
+	entry := got.Instances[0]
+	assert.Equal(t, inst.ID, entry.ID)
+	assert.True(t, entry.Attendance.IsUnplanned, "must flag is_unplanned")
+	assert.Equal(t, schedule.AttendanceStatusPresent, entry.Attendance.Status)
+	assert.Nil(t, entry.Attendance.Substatus)
+	assert.Nil(t, entry.Attendance.Note)
+	require.NotNil(t, entry.Attendance.CheckedInAt)
+	assert.Contains(t, *entry.Attendance.CheckedInAt, "2026-04-22")
+}
+
+func TestGetStudentDay_InvalidDate_Returns400(t *testing.T) {
+	s := buildStudentDaySetup(t)
+	router := adminRouter(s.ctx, s.res)
+
+	w := doGet(t, router, fmt.Sprintf("/student/%d/day?date=not-a-date", s.studentID))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid date format")
+}
+
+func TestGetStudentDay_MissingDate_Returns400(t *testing.T) {
+	s := buildStudentDaySetup(t)
+	router := adminRouter(s.ctx, s.res)
+
+	w := doGet(t, router, fmt.Sprintf("/student/%d/day", s.studentID))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "date is required")
+}
+
+func TestGetStudentDay_InvalidStudentID_Returns400(t *testing.T) {
+	s := buildStudentDaySetup(t)
+	router := adminRouter(s.ctx, s.res)
+
+	w := doGet(t, router, "/student/abc/day?date=2026-04-22")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid student ID")
+}
+
+func TestGetStudentDay_UnknownStudent_Returns404(t *testing.T) {
+	s := buildStudentDaySetup(t)
+	router := adminRouter(s.ctx, s.res)
+
+	w := doGet(t, router, "/student/999999999/day?date=2026-04-22")
+	assert.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+}
+
+// Cross-tenant must 404, not 403: returning 403 for a student in tenant B
+// would leak their existence to a caller in tenant A.
+func TestGetStudentDay_CrossTenant_Returns404(t *testing.T) {
+	s := buildStudentDaySetup(t)
+
+	// Pretend the caller is in tenant 2 — our fixture student lives in
+	// tenant 1 and must be invisible.
+	otherCtx := testpkg.TenantContext(2)
+	router := adminRouter(otherCtx, s.res)
+
+	w := doGet(t, router, fmt.Sprintf("/student/%d/day?date=2026-04-22", s.studentID))
+	assert.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+}
+
+// Same-tenant, non-admin, not a group supervisor → 403 (we already know the
+// student exists in this tenant, so hiding them would be misleading).
+func TestGetStudentDay_SameTenantNoSupervisor_Returns403(t *testing.T) {
+	s := buildStudentDaySetup(t)
+
+	// Strip admin perms; CanReadStudent falls through to the group-
+	// supervisor branch and fails because userContextService is nil.
+	router := studentRouter(s.ctx, s.res, []string{"schedules:read"})
+
+	w := doGet(t, router, fmt.Sprintf("/student/%d/day?date=2026-04-22", s.studentID))
+	assert.Equal(t, http.StatusForbidden, w.Code, "body=%s", w.Body.String())
+}
+
+// --- /week ----------------------------------------------------------------
+
+func TestGetStudentWeek_HappyPath_ReturnsEntryPerDay(t *testing.T) {
+	s := buildStudentDaySetup(t)
+	router := adminRouter(s.ctx, s.res)
+
+	w := doGet(t, router, fmt.Sprintf("/student/%d/week?from=2026-04-20&to=2026-04-24", s.studentID))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var got StudentWeekResponse
+	decodeEnvelope(t, w, &got)
+
+	assert.Equal(t, "2026-04-20", got.From)
+	assert.Equal(t, "2026-04-24", got.To)
+	require.Len(t, got.Days, 5, "must return one entry per day in the range (inclusive)")
+	for i, d := range got.Days {
+		assert.Equal(t, s.studentID, d.StudentID)
+		// Days in ascending order.
+		if i > 0 {
+			assert.True(t, d.Date > got.Days[i-1].Date, "days must be ascending")
+		}
+	}
+}
+
+func TestGetStudentWeek_RangeAtLimit_14Days_ReturnsOK(t *testing.T) {
+	s := buildStudentDaySetup(t)
+	router := adminRouter(s.ctx, s.res)
+
+	w := doGet(t, router, fmt.Sprintf("/student/%d/week?from=2026-04-01&to=2026-04-14", s.studentID))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var got StudentWeekResponse
+	decodeEnvelope(t, w, &got)
+	assert.Len(t, got.Days, 14)
+}
+
+func TestGetStudentWeek_RangeExceedsLimit_Returns400(t *testing.T) {
+	s := buildStudentDaySetup(t)
+	router := adminRouter(s.ctx, s.res)
+
+	w := doGet(t, router, fmt.Sprintf("/student/%d/week?from=2026-04-01&to=2026-04-15", s.studentID))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.True(t,
+		strings.Contains(w.Body.String(), "date range exceeds maximum of 14 days"),
+		"body=%s", w.Body.String())
+}
+
+func TestGetStudentWeek_FromAfterTo_Returns400(t *testing.T) {
+	s := buildStudentDaySetup(t)
+	router := adminRouter(s.ctx, s.res)
+
+	w := doGet(t, router, fmt.Sprintf("/student/%d/week?from=2026-04-22&to=2026-04-20", s.studentID))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "'from' must be before or equal to 'to'")
+}
+
+func TestGetStudentWeek_MissingParams_Returns400(t *testing.T) {
+	s := buildStudentDaySetup(t)
+	router := adminRouter(s.ctx, s.res)
+
+	w := doGet(t, router, fmt.Sprintf("/student/%d/week?from=2026-04-22", s.studentID))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "from and to are required")
+}

--- a/backend/api/timetable/student_day_test.go
+++ b/backend/api/timetable/student_day_test.go
@@ -462,6 +462,33 @@ func TestGetStudentWeek_RangeExceedsLimit_Returns400(t *testing.T) {
 		"body=%s", w.Body.String())
 }
 
+// Spring DST: 2026-03-29 is the Berlin spring-forward day (23h long).
+// A 15-day request spanning it must still be rejected by the cap — a naive
+// to.Sub(from).Hours()/24 would undercount by the missing hour and let it
+// through.
+func TestGetStudentWeek_SpringDST_15DayRangeStillRejected(t *testing.T) {
+	s := buildStudentDaySetup(t)
+	router := adminRouter(s.ctx, s.res)
+
+	w := doGet(t, router, fmt.Sprintf("/student/%d/week?from=2026-03-22&to=2026-04-05", s.studentID))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "date range exceeds maximum of 14 days")
+}
+
+// Spring DST: the same span minus one day (14 inclusive days crossing the
+// transition) must pass and return one entry per day.
+func TestGetStudentWeek_SpringDST_14DayRangeAtLimit_ReturnsOK(t *testing.T) {
+	s := buildStudentDaySetup(t)
+	router := adminRouter(s.ctx, s.res)
+
+	w := doGet(t, router, fmt.Sprintf("/student/%d/week?from=2026-03-23&to=2026-04-05", s.studentID))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var got StudentWeekResponse
+	decodeEnvelope(t, w, &got)
+	assert.Len(t, got.Days, 14)
+}
+
 func TestGetStudentWeek_FromAfterTo_Returns400(t *testing.T) {
 	s := buildStudentDaySetup(t)
 	router := adminRouter(s.ctx, s.res)

--- a/backend/api/timetable/student_day_test.go
+++ b/backend/api/timetable/student_day_test.go
@@ -61,24 +61,20 @@ func buildStudentDaySetup(t *testing.T) *studentDaySetup {
 	})
 
 	// Wire the full resource with real repos for the B11 path.
-	isIface := scheduleRepo.NewInstanceStudentRepository(db)
-	studentDayConcrete := isIface.(*scheduleRepo.InstanceStudentRepository)
-
-	res := NewResource(
-		nil, nil, nil, nil, // calendar/material/instance/person services unused
-		isIface, studentDayConcrete,
-		scheduleRepo.NewActivityInstanceRepository(db),
-		scheduleRepo.NewStudentArrivalScheduleRepository(db),
-		scheduleRepo.NewStudentArrivalExceptionRepository(db),
-		scheduleRepo.NewStudentPickupScheduleRepository(db),
-		scheduleRepo.NewStudentPickupExceptionRepository(db),
-		activeRepo.NewVisitRepository(db),
-		usersRepo.NewStudentRepository(db),
-		nil, // userContextService — test path relies on admin perms
-		nil, // settingsService — CanReadStudent falls through to group-supervisor check
-		nil, // logger
-		db,
-	)
+	res := NewResource(Dependencies{
+		InstanceStudentRepo:  scheduleRepo.NewInstanceStudentRepository(db),
+		ActivityInstanceRepo: scheduleRepo.NewActivityInstanceRepository(db),
+		ArrivalScheduleRepo:  scheduleRepo.NewStudentArrivalScheduleRepository(db),
+		ArrivalExceptionRepo: scheduleRepo.NewStudentArrivalExceptionRepository(db),
+		PickupScheduleRepo:   scheduleRepo.NewStudentPickupScheduleRepository(db),
+		PickupExceptionRepo:  scheduleRepo.NewStudentPickupExceptionRepository(db),
+		VisitRepo:            activeRepo.NewVisitRepository(db),
+		StudentRepo:          usersRepo.NewStudentRepository(db),
+		// UserContextService + SettingsService intentionally nil:
+		// admin-perm path short-circuits CanReadStudent; the 403 test relies on
+		// the fallthrough returning false when userCtx is nil.
+		DB: db,
+	})
 
 	return &studentDaySetup{
 		res:        res,
@@ -482,4 +478,36 @@ func TestGetStudentWeek_MissingParams_Returns400(t *testing.T) {
 	w := doGet(t, router, fmt.Sprintf("/student/%d/week?from=2026-04-22", s.studentID))
 	require.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "from and to are required")
+}
+
+// queryCounterHook counts every SELECT the handler issues during a /week
+// call. Exists purely to regression-guard the N+1 fix: /week over any valid
+// range must stay at or below the 7-query ceiling.
+type queryCounterHook struct{ n int64 }
+
+func (h *queryCounterHook) BeforeQuery(ctx context.Context, _ *bun.QueryEvent) context.Context {
+	h.n++
+	return ctx
+}
+func (h *queryCounterHook) AfterQuery(context.Context, *bun.QueryEvent) {}
+
+// TestGetStudentWeek_QueryBudget_BatchedNotNPlusOne locks in the N+1 fix:
+// a 14-day /week must fire at most 7 DB queries (enrolled + instances +
+// visits + 2 schedules + 2 exceptions). Previously this was ~98.
+func TestGetStudentWeek_QueryBudget_BatchedNotNPlusOne(t *testing.T) {
+	s := buildStudentDaySetup(t)
+
+	hook := &queryCounterHook{}
+	s.db.AddQueryHook(hook)
+
+	router := adminRouter(s.ctx, s.res)
+	w := doGet(t, router, fmt.Sprintf("/student/%d/week?from=2026-04-01&to=2026-04-14", s.studentID))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// FindByID (student resolution) + up to 7 preload queries = 8. Allow a
+	// little headroom for implicit bun/pg metadata queries; assert we're
+	// far below the pre-fix 14*7=98 regime.
+	assert.LessOrEqual(t, hook.n, int64(12),
+		"14-day /week must stay under the batched ceiling, got %d", hook.n)
+	t.Logf("14-day /week fired %d queries", hook.n)
 }

--- a/backend/api/timetable/student_day_test.go
+++ b/backend/api/timetable/student_day_test.go
@@ -261,6 +261,56 @@ func TestGetStudentDay_NoArrivalNoPickup_SourceNone(t *testing.T) {
 	assert.Empty(t, got.Instances)
 }
 
+// Regression guard: when a student is BOTH enrolled (instance_students row
+// exists) AND has a visit on the same active_group, the response must
+// contain exactly ONE entry for that instance — the enrolled one, with
+// is_unplanned=false. The dedup lives in buildStudentDay where the visit
+// loop skips ids already present in enrolledInstanceIDs; this test locks
+// that behavior in so a future rewrite can't introduce a duplicate.
+func TestGetStudentDay_EnrolledPlusVisit_NoDuplicate(t *testing.T) {
+	s := buildStudentDaySetup(t)
+
+	// Active group + bridge instance (same shape as the unplanned test).
+	ag := testpkg.CreateTestActiveGroup(t, s.db, s.activityID, s.roomID)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.groups", ag.ID) })
+
+	agID := ag.ID
+	inst := testpkg.CreateTestActivityInstance(t, s.db,
+		time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), s.roomID,
+		testpkg.ActivityInstanceOpts{
+			ActivityGroupID: &s.activityID,
+			ActiveGroupID:   &agID,
+			Status:          schedule.InstanceStatusActive,
+			StartHHMM:       "14:00",
+			EndHHMM:         "15:00",
+			Title:           "Enrolled-And-Present",
+		})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	// Both signals: enrolled row AND a visit on the same active_group.
+	row := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, s.studentID, schedule.AttendanceStatusPresent)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", row.ID) })
+
+	visit := testpkg.CreateTestVisit(t, s.db, s.studentID, ag.ID,
+		time.Date(2026, 4, 22, 14, 5, 0, 0, time.UTC), nil)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.visits", visit.ID) })
+
+	router := adminRouter(s.ctx, s.res)
+	w := doGet(t, router, fmt.Sprintf("/student/%d/day?date=2026-04-22", s.studentID))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var got StudentDayResponse
+	decodeEnvelope(t, w, &got)
+
+	require.Len(t, got.Instances, 1,
+		"enrolled student with a matching visit must appear exactly once, not duplicated")
+	entry := got.Instances[0]
+	assert.Equal(t, inst.ID, entry.ID)
+	assert.False(t, entry.Attendance.IsUnplanned,
+		"enrolled row must win over the visit-side path (is_unplanned=false)")
+	assert.Equal(t, schedule.AttendanceStatusPresent, entry.Attendance.Status)
+}
+
 // Unplanned scenario: active.visit exists for student on an active
 // instance's bridge group, but no instance_students row.
 func TestGetStudentDay_UnplannedStudent(t *testing.T) {

--- a/backend/auth/authorize/student_access.go
+++ b/backend/auth/authorize/student_access.go
@@ -1,0 +1,127 @@
+package authorize
+
+import (
+	"context"
+	"log/slog"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	"github.com/moto-nrw/project-phoenix/models/education"
+	"github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// StudentReadUserContext is the narrow subset of the user-context service that
+// CanReadStudent needs: identify the caller's staff record (if any) and list
+// the education groups they supervise. Defined here (not imported) to keep
+// this package a sibling of services/usercontext without a package cycle.
+type StudentReadUserContext interface {
+	GetCurrentStaff(ctx context.Context) (*users.Staff, error)
+	GetMyGroups(ctx context.Context) ([]*education.Group, error)
+}
+
+// StudentReadSettings is the narrow subset of the settings service CanReadStudent
+// needs: check whether a tenant override exists for the data-scope setting and
+// resolve its string value. Declared locally to avoid importing services/config,
+// which already imports this package.
+type StudentReadSettings interface {
+	HasTenantOverride(ctx context.Context, key string) (bool, error)
+	ResolveString(ctx context.Context, key string) (string, error)
+}
+
+// CanReadStudent decides whether the caller is allowed to see unredacted
+// student data (profile, location, pickup/arrival schedules, day plan).
+//
+// Order:
+//  1. Admin permissions (admin:* / *:*) → always true.
+//  2. Tenant setting gdpr.student_data_scope == "all_staff" AND caller is a
+//     verified staff member → true. Other authenticated roles (guest,
+//     guardian) with users:read must NOT pass this gate.
+//  3. Caller supervises the student's education group → true.
+//  4. Otherwise → false.
+//
+// Write operations must NOT use this function — the scope setting only
+// relaxes READ access. Use isGroupSupervisorOrAdmin / canModifyStudent for
+// writes.
+func CanReadStudent(
+	ctx context.Context,
+	userPermissions []string,
+	student *users.Student,
+	userCtx StudentReadUserContext,
+	settings StudentReadSettings,
+	logger *slog.Logger,
+) bool {
+	if student == nil {
+		return false
+	}
+	if hasAdminPermissions(userPermissions) {
+		return true
+	}
+
+	scope := resolveStudentDataScope(ctx, settings, logger)
+	if scope == configModel.StudentDataScopeAllStaff && userCtx != nil {
+		if staff, err := userCtx.GetCurrentStaff(ctx); err == nil && staff != nil {
+			return true
+		}
+	}
+
+	if student.GroupID == nil || userCtx == nil {
+		return false
+	}
+
+	educationGroups, err := userCtx.GetMyGroups(ctx)
+	if err != nil {
+		return false
+	}
+	for _, g := range educationGroups {
+		if g.ID == *student.GroupID {
+			return true
+		}
+	}
+	return false
+}
+
+// hasAdminPermissions checks for the wildcard admin scopes. Mirrors the
+// package-private helper in api/students so the extracted helper carries its
+// own authority check and does not depend on the caller pre-filtering.
+func hasAdminPermissions(permissions []string) bool {
+	for _, p := range permissions {
+		if p == "admin:*" || p == "*:*" {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveStudentDataScope returns the effective gdpr.student_data_scope for
+// the caller's tenant. Falls back to the restrictive default when there is
+// no override, the settings service is nil, or the lookup errs — the
+// permissive "all_staff" setting must only be honored when explicitly set.
+func resolveStudentDataScope(ctx context.Context, settings StudentReadSettings, logger *slog.Logger) string {
+	fallback := configModel.StudentDataScopeGroupSupervisorsOnly
+	if settings == nil {
+		return fallback
+	}
+	has, err := settings.HasTenantOverride(ctx, configModel.KeyStudentDataScope)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("settings override check failed in CanReadStudent",
+				slog.String("key", configModel.KeyStudentDataScope),
+				slog.String("error", err.Error()),
+			)
+		}
+		return fallback
+	}
+	if !has {
+		return fallback
+	}
+	val, err := settings.ResolveString(ctx, configModel.KeyStudentDataScope)
+	if err != nil || val == "" {
+		if err != nil && logger != nil {
+			logger.Warn("settings resolve failed in CanReadStudent",
+				slog.String("key", configModel.KeyStudentDataScope),
+				slog.String("error", err.Error()),
+			)
+		}
+		return fallback
+	}
+	return val
+}

--- a/backend/database/repositories/active/visits.go
+++ b/backend/database/repositories/active/visits.go
@@ -804,6 +804,43 @@ func (r *VisitRepository) GetTodayVisitNamesForStudents(ctx context.Context, stu
 	return out, nil
 }
 
+// FindByStudentAndActiveGroupIDs returns visits for the given student whose
+// active_group_id is in the provided slice. Used by the timetable /student/
+// {id}/day and /week endpoints to detect "unplanned" attendance — instances
+// where the student was actually there (has a visit) without being enrolled
+// (no instance_students row).
+//
+// Empty slice short-circuits to an empty result: bun would otherwise emit
+// `IN ('{}')` which some driver paths handle oddly. Bailing early keeps the
+// call cheap on the common "no active/completed instances" path.
+func (r *VisitRepository) FindByStudentAndActiveGroupIDs(
+	ctx context.Context, studentID int64, activeGroupIDs []int64,
+) ([]*active.Visit, error) {
+	if len(activeGroupIDs) == 0 {
+		return []*active.Visit{}, nil
+	}
+
+	var visits []*active.Visit
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&visits).
+		ModelTableExpr(tableExprActiveVisitsAsVisit).
+		Where(`"visit".student_id = ?`, studentID).
+		Where(`"visit".active_group_id IN (?)`, bun.List(activeGroupIDs)).
+		OrderExpr(`"visit".entry_time ASC`)
+
+	if where, val, ok := base.TenantWhere(ctx, "visit"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student and active group IDs",
+			Err: err,
+		}
+	}
+	return visits, nil
+}
+
 // FindActiveVisits finds all visits with no exit time (currently active)
 func (r *VisitRepository) FindActiveVisits(ctx context.Context) ([]*active.Visit, error) {
 	var visits []*active.Visit

--- a/backend/database/repositories/active/visits_time_range_test.go
+++ b/backend/database/repositories/active/visits_time_range_test.go
@@ -10,6 +10,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FindByStudentAndActiveGroupIDs returns only the student's visits whose
+// active_group_id matches one of the given IDs. Empty slice must short-circuit.
+func TestVisitRepository_FindByStudentAndActiveGroupIDs(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ActiveVisit
+	ctx := testpkg.TenantContext(1)
+	data := createVisitTestData(t, db)
+	defer cleanupVisitTestData(t, db, data)
+
+	now := time.Now()
+	v1 := testpkg.CreateTestVisit(t, db, data.Student1.ID, data.ActiveGroup.ID, now.Add(-2*time.Hour), nil)
+	v2 := testpkg.CreateTestVisit(t, db, data.Student2.ID, data.ActiveGroup.ID, now.Add(-1*time.Hour), nil)
+
+	defer func() {
+		for _, id := range []int64{v1.ID, v2.ID} {
+			testpkg.CleanupTableRecords(t, db, "active.visits", id)
+		}
+	}()
+
+	t.Run("empty id slice short-circuits", func(t *testing.T) {
+		results, err := repo.FindByStudentAndActiveGroupIDs(ctx, data.Student1.ID, nil)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("returns only matching student's visits", func(t *testing.T) {
+		results, err := repo.FindByStudentAndActiveGroupIDs(ctx, data.Student1.ID, []int64{data.ActiveGroup.ID})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, v1.ID, results[0].ID,
+			"must not include student2's visit in the same group")
+	})
+
+	t.Run("non-matching active group id returns empty", func(t *testing.T) {
+		results, err := repo.FindByStudentAndActiveGroupIDs(ctx, data.Student1.ID, []int64{data.ActiveGroup.ID + 9999})
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("different tenant context returns empty", func(t *testing.T) {
+		ctxT2 := testpkg.TenantContext(2)
+		results, err := repo.FindByStudentAndActiveGroupIDs(ctxT2, data.Student1.ID, []int64{data.ActiveGroup.ID})
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
 func TestVisitRepository_FindByStudentAndTimeRange(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/backend/database/repositories/schedule/arrival_schedule_repo.go
+++ b/backend/database/repositories/schedule/arrival_schedule_repo.go
@@ -375,6 +375,36 @@ func (r *StudentArrivalExceptionRepository) FindByStudentIDsAndDate(ctx context.
 	return exceptions, nil
 }
 
+// FindByStudentIDAndDateRange finds arrival exceptions for a student whose
+// exception_date lies in the inclusive [from, to] range.
+func (r *StudentArrivalExceptionRepository) FindByStudentIDAndDateRange(
+	ctx context.Context, studentID int64, from, to time.Time,
+) ([]*schedule.StudentArrivalException, error) {
+	fromDate := timezone.DateOfUTC(from)
+	toDate := timezone.DateOfUTC(to)
+
+	var exceptions []*schedule.StudentArrivalException
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exceptions).
+		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
+		Where(`"student_arrival_exception".student_id = ?`, studentID).
+		Where(`"student_arrival_exception".exception_date >= ?`, fromDate).
+		Where(`"student_arrival_exception".exception_date <= ?`, toDate).
+		Order("exception_date ASC")
+
+	if where, val, ok := base.TenantWhere(ctx, "student_arrival_exception"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student id and date range",
+			Err: err,
+		}
+	}
+	return exceptions, nil
+}
+
 // DeleteByStudentID deletes all arrival exceptions for a student
 func (r *StudentArrivalExceptionRepository) DeleteByStudentID(ctx context.Context, studentID int64) error {
 	query := base.GetDB(ctx, r.db).NewDelete().

--- a/backend/database/repositories/schedule/instance_student_repo.go
+++ b/backend/database/repositories/schedule/instance_student_repo.go
@@ -274,6 +274,39 @@ func (r *InstanceStudentRepository) UpdateAttendanceFields(
 	return nil
 }
 
+// BulkUpdateStatus flips every attendance row for instanceID whose current
+// status equals fromStatus to toStatus. Returns the number of rows changed.
+//
+// Used by instance Complete() to mark remaining expected students as absent.
+// The fromStatus predicate keeps the update idempotent and free of clobber:
+// rows already moved past 'expected' (present via checkin, absent via PATCH)
+// stay put.
+func (r *InstanceStudentRepository) BulkUpdateStatus(
+	ctx context.Context, instanceID int64, fromStatus, toStatus string,
+) (int, error) {
+	q := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*schedule.InstanceStudent)(nil)).
+		ModelTableExpr(modelTblInstanceStudent).
+		Set(`status = ?`, toStatus).
+		Set(`updated_at = ?`, time.Now().UTC()).
+		Where(`"instance_student".instance_id = ?`, instanceID).
+		Where(`"instance_student".status = ?`, fromStatus)
+
+	if where, val, ok := base.TenantWhere(ctx, aliasInstanceStudent); ok {
+		q = q.Where(where, val)
+	}
+
+	res, err := q.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "bulk update status",
+			Err: err,
+		}
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
 // DeleteByInstanceID removes all attendance rows for an instance.
 func (r *InstanceStudentRepository) DeleteByInstanceID(ctx context.Context, instanceID int64) error {
 	query := base.GetDB(ctx, r.db).NewDelete().

--- a/backend/database/repositories/schedule/instance_student_repo_test.go
+++ b/backend/database/repositories/schedule/instance_student_repo_test.go
@@ -520,6 +520,101 @@ func TestInstanceStudentRepository_UpdateAttendanceFields(t *testing.T) {
 	})
 }
 
+func TestInstanceStudentRepository_BulkUpdateStatus(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repo := scheduleRepo.NewInstanceStudentRepository(db)
+
+	inst, cleanupInst := createInstanceFixture(t, db, "stu-bulk", time.Date(2026, 11, 2, 0, 0, 0, 0, time.UTC))
+	defer cleanupInst()
+
+	suffix := fmt.Sprintf("Bulk-%d", time.Now().UnixNano())
+	sExpected1 := testpkg.CreateTestStudent(t, db, "Ada", suffix+"-e1", "3a")
+	sExpected2 := testpkg.CreateTestStudent(t, db, "Bea", suffix+"-e2", "3a")
+	sPresent := testpkg.CreateTestStudent(t, db, "Cem", suffix+"-p", "3a")
+	defer testpkg.CleanupActivityFixtures(t, db, sExpected1.ID, sExpected2.ID, sPresent.ID)
+
+	buildRow := func(studentID int64, status string) *scheduleModels.InstanceStudent {
+		row := &scheduleModels.InstanceStudent{
+			InstanceID: inst.ID,
+			StudentID:  studentID,
+			Status:     status,
+		}
+		row.SetTenantID(1)
+		return row
+	}
+
+	rowE1 := buildRow(sExpected1.ID, scheduleModels.AttendanceStatusExpected)
+	rowE2 := buildRow(sExpected2.ID, scheduleModels.AttendanceStatusExpected)
+	rowP := buildRow(sPresent.ID, scheduleModels.AttendanceStatusPresent)
+
+	require.NoError(t, repo.Create(ctx, rowE1))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", rowE1.ID)
+	require.NoError(t, repo.Create(ctx, rowE2))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", rowE2.ID)
+	require.NoError(t, repo.Create(ctx, rowP))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", rowP.ID)
+
+	t.Run("flips only matching expected rows", func(t *testing.T) {
+		n, err := repo.BulkUpdateStatus(ctx, inst.ID,
+			scheduleModels.AttendanceStatusExpected,
+			scheduleModels.AttendanceStatusAbsent,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 2, n)
+
+		gotE1, err := repo.FindByInstanceAndStudent(ctx, inst.ID, sExpected1.ID)
+		require.NoError(t, err)
+		require.NotNil(t, gotE1)
+		assert.Equal(t, scheduleModels.AttendanceStatusAbsent, gotE1.Status)
+
+		gotE2, err := repo.FindByInstanceAndStudent(ctx, inst.ID, sExpected2.ID)
+		require.NoError(t, err)
+		require.NotNil(t, gotE2)
+		assert.Equal(t, scheduleModels.AttendanceStatusAbsent, gotE2.Status)
+
+		gotP, err := repo.FindByInstanceAndStudent(ctx, inst.ID, sPresent.ID)
+		require.NoError(t, err)
+		require.NotNil(t, gotP)
+		assert.Equal(t, scheduleModels.AttendanceStatusPresent, gotP.Status,
+			"present row must not be touched by expected→absent bulk update")
+	})
+
+	t.Run("second call is a no-op", func(t *testing.T) {
+		n, err := repo.BulkUpdateStatus(ctx, inst.ID,
+			scheduleModels.AttendanceStatusExpected,
+			scheduleModels.AttendanceStatusAbsent,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+	})
+
+	t.Run("no-op when called with a different tenant context", func(t *testing.T) {
+		// Reset one row back to 'expected' in tenant 1 so there's a target.
+		reset := scheduleModels.AttendanceFieldPatch{}
+		expected := scheduleModels.AttendanceStatusExpected
+		reset.Status = &expected
+		require.NoError(t, repo.UpdateAttendanceFields(ctx, rowE1.ID, reset))
+
+		// Switch to a foreign tenant — bulk update must match zero rows,
+		// and the tenant 1 row must remain 'expected'.
+		ctxT2 := testpkg.TenantContext(2)
+		n, err := repo.BulkUpdateStatus(ctxT2, inst.ID,
+			scheduleModels.AttendanceStatusExpected,
+			scheduleModels.AttendanceStatusAbsent,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+
+		got, err := repo.FindByInstanceAndStudent(ctx, inst.ID, sExpected1.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, scheduleModels.AttendanceStatusExpected, got.Status)
+	})
+}
+
 func TestInstanceStudentRepository_DeleteByInstanceID(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/backend/database/repositories/schedule/pickup_schedule.go
+++ b/backend/database/repositories/schedule/pickup_schedule.go
@@ -388,6 +388,36 @@ func (r *StudentPickupExceptionRepository) FindByStudentIDsAndDate(ctx context.C
 	return exceptions, nil
 }
 
+// FindByStudentIDAndDateRange finds pickup exceptions for a student whose
+// exception_date lies in the inclusive [from, to] range.
+func (r *StudentPickupExceptionRepository) FindByStudentIDAndDateRange(
+	ctx context.Context, studentID int64, from, to time.Time,
+) ([]*schedule.StudentPickupException, error) {
+	fromDate := timezone.DateOfUTC(from)
+	toDate := timezone.DateOfUTC(to)
+
+	var exceptions []*schedule.StudentPickupException
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exceptions).
+		ModelTableExpr(`schedule.student_pickup_exceptions AS "student_pickup_exception"`).
+		Where(`"student_pickup_exception".student_id = ?`, studentID).
+		Where(`"student_pickup_exception".exception_date >= ?`, fromDate).
+		Where(`"student_pickup_exception".exception_date <= ?`, toDate).
+		Order("exception_date ASC")
+
+	if where, val, ok := base.TenantWhere(ctx, "student_pickup_exception"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student id and date range",
+			Err: err,
+		}
+	}
+	return exceptions, nil
+}
+
 // DeleteByStudentID deletes all pickup exceptions for a student
 func (r *StudentPickupExceptionRepository) DeleteByStudentID(ctx context.Context, studentID int64) error {
 	query := base.GetDB(ctx, r.db).NewDelete().

--- a/backend/database/repositories/schedule/student_day.go
+++ b/backend/database/repositories/schedule/student_day.go
@@ -9,20 +9,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 )
 
-// ScheduledInstanceRow pairs an activity instance with the caller's attendance
-// row on that instance. The timetable /student/{id}/day and /week endpoints
-// assemble their response from rows of this shape: the instance carries the
-// when/where/title, the attendance carries the student-specific status.
-//
-// Both fields are non-nil when returned by
-// FindInstancesWithAttendanceByStudentAndDateRange — the INNER JOIN guarantees
-// it. The struct lives in the repo package, not in models/schedule, because
-// it is a query-result shape, not a persistent entity.
-type ScheduledInstanceRow struct {
-	Instance   *schedule.ActivityInstance
-	Attendance *schedule.InstanceStudent
-}
-
 // scheduledInstanceScan is the flat row bun scans into; the repo then lifts
 // it into a pair of pointers. Keeping the column aliases explicit sidesteps
 // bun's cross-schema Relation limitations (same rationale as visits.go
@@ -64,18 +50,11 @@ type scheduledInstanceScan struct {
 	AiUpdatedAt       time.Time  `bun:"ai_updated_at"`
 }
 
-// FindInstancesWithAttendanceByStudentAndDateRange returns one row per
-// (instance_student, activity_instance) pair for the student in the inclusive
-// date range, sorted by date then start time. Tenant-scoped via the caller's
-// context. Single query — no N+1.
-//
-// Use this for the timetable per-student day/week aggregation. Instances
-// where the student has NO attendance row (e.g. a spontaneous instance they
-// dropped into without being enrolled) are NOT returned here — the handler
-// layer enriches those via the visits-side lookup.
+// FindInstancesWithAttendanceByStudentAndDateRange implements
+// schedule.InstanceStudentRepository.
 func (r *InstanceStudentRepository) FindInstancesWithAttendanceByStudentAndDateRange(
 	ctx context.Context, studentID int64, from, to time.Time,
-) ([]*ScheduledInstanceRow, error) {
+) ([]*schedule.ScheduledInstanceRow, error) {
 	var scans []scheduledInstanceScan
 
 	query := base.GetDB(ctx, r.db).NewSelect().
@@ -128,7 +107,7 @@ func (r *InstanceStudentRepository) FindInstancesWithAttendanceByStudentAndDateR
 		}
 	}
 
-	out := make([]*ScheduledInstanceRow, 0, len(scans))
+	out := make([]*schedule.ScheduledInstanceRow, 0, len(scans))
 	for i := range scans {
 		s := scans[i]
 		inst := &schedule.ActivityInstance{
@@ -168,7 +147,7 @@ func (r *InstanceStudentRepository) FindInstancesWithAttendanceByStudentAndDateR
 		att.UpdatedAt = s.IsUpdatedAt
 		att.SetTenantID(s.IsTenantID)
 
-		out = append(out, &ScheduledInstanceRow{Instance: inst, Attendance: att})
+		out = append(out, &schedule.ScheduledInstanceRow{Instance: inst, Attendance: att})
 	}
 	return out, nil
 }

--- a/backend/database/repositories/schedule/student_day.go
+++ b/backend/database/repositories/schedule/student_day.go
@@ -1,0 +1,174 @@
+package schedule
+
+import (
+	"context"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+// ScheduledInstanceRow pairs an activity instance with the caller's attendance
+// row on that instance. The timetable /student/{id}/day and /week endpoints
+// assemble their response from rows of this shape: the instance carries the
+// when/where/title, the attendance carries the student-specific status.
+//
+// Both fields are non-nil when returned by
+// FindInstancesWithAttendanceByStudentAndDateRange — the INNER JOIN guarantees
+// it. The struct lives in the repo package, not in models/schedule, because
+// it is a query-result shape, not a persistent entity.
+type ScheduledInstanceRow struct {
+	Instance   *schedule.ActivityInstance
+	Attendance *schedule.InstanceStudent
+}
+
+// scheduledInstanceScan is the flat row bun scans into; the repo then lifts
+// it into a pair of pointers. Keeping the column aliases explicit sidesteps
+// bun's cross-schema Relation limitations (same rationale as visits.go
+// FindByStudentAndTimeRange, where an ad-hoc struct works around the tag).
+type scheduledInstanceScan struct {
+	// instance_students columns
+	IsID          int64      `bun:"is_id"`
+	IsTenantID    int64      `bun:"is_tenant_id"`
+	IsInstanceID  int64      `bun:"is_instance_id"`
+	IsStudentID   int64      `bun:"is_student_id"`
+	IsRoomID      *int64     `bun:"is_room_id"`
+	IsStatus      string     `bun:"is_status"`
+	IsSubstatus   *string    `bun:"is_substatus"`
+	IsNote        *string    `bun:"is_note"`
+	IsCheckedInAt *time.Time `bun:"is_checked_in_at"`
+	IsCreatedAt   time.Time  `bun:"is_created_at"`
+	IsUpdatedAt   time.Time  `bun:"is_updated_at"`
+
+	// activity_instances columns
+	AiID              int64      `bun:"ai_id"`
+	AiTenantID        int64      `bun:"ai_tenant_id"`
+	AiDate            time.Time  `bun:"ai_date"`
+	AiActivityGroupID *int64     `bun:"ai_activity_group_id"`
+	AiCalendarPeriod  *int64     `bun:"ai_calendar_period_id"`
+	AiTitle           string     `bun:"ai_title"`
+	AiDescription     *string    `bun:"ai_description"`
+	AiStartTime       time.Time  `bun:"ai_start_time"`
+	AiEndTime         time.Time  `bun:"ai_end_time"`
+	AiRoomID          int64      `bun:"ai_room_id"`
+	AiStatus          string     `bun:"ai_status"`
+	AiActiveGroupID   *int64     `bun:"ai_active_group_id"`
+	AiIsSpontaneous   bool       `bun:"ai_is_spontaneous"`
+	AiNotes           *string    `bun:"ai_notes"`
+	AiCreatedBy       *int64     `bun:"ai_created_by"`
+	AiStartedBy       *int64     `bun:"ai_started_by"`
+	AiStartedAt       *time.Time `bun:"ai_started_at"`
+	AiCompletedAt     *time.Time `bun:"ai_completed_at"`
+	AiCreatedAt       time.Time  `bun:"ai_created_at"`
+	AiUpdatedAt       time.Time  `bun:"ai_updated_at"`
+}
+
+// FindInstancesWithAttendanceByStudentAndDateRange returns one row per
+// (instance_student, activity_instance) pair for the student in the inclusive
+// date range, sorted by date then start time. Tenant-scoped via the caller's
+// context. Single query — no N+1.
+//
+// Use this for the timetable per-student day/week aggregation. Instances
+// where the student has NO attendance row (e.g. a spontaneous instance they
+// dropped into without being enrolled) are NOT returned here — the handler
+// layer enriches those via the visits-side lookup.
+func (r *InstanceStudentRepository) FindInstancesWithAttendanceByStudentAndDateRange(
+	ctx context.Context, studentID int64, from, to time.Time,
+) ([]*ScheduledInstanceRow, error) {
+	var scans []scheduledInstanceScan
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`schedule.instance_students AS "instance_student"`).
+		Join(`INNER JOIN schedule.activity_instances AS "activity_instance" ON "activity_instance".id = "instance_student".instance_id`).
+		ColumnExpr(`"instance_student".id AS is_id`).
+		ColumnExpr(`"instance_student".tenant_id AS is_tenant_id`).
+		ColumnExpr(`"instance_student".instance_id AS is_instance_id`).
+		ColumnExpr(`"instance_student".student_id AS is_student_id`).
+		ColumnExpr(`"instance_student".room_id AS is_room_id`).
+		ColumnExpr(`"instance_student".status AS is_status`).
+		ColumnExpr(`"instance_student".substatus AS is_substatus`).
+		ColumnExpr(`"instance_student".note AS is_note`).
+		ColumnExpr(`"instance_student".checked_in_at AS is_checked_in_at`).
+		ColumnExpr(`"instance_student".created_at AS is_created_at`).
+		ColumnExpr(`"instance_student".updated_at AS is_updated_at`).
+		ColumnExpr(`"activity_instance".id AS ai_id`).
+		ColumnExpr(`"activity_instance".tenant_id AS ai_tenant_id`).
+		ColumnExpr(`"activity_instance".date AS ai_date`).
+		ColumnExpr(`"activity_instance".activity_group_id AS ai_activity_group_id`).
+		ColumnExpr(`"activity_instance".calendar_period_id AS ai_calendar_period_id`).
+		ColumnExpr(`"activity_instance".title AS ai_title`).
+		ColumnExpr(`"activity_instance".description AS ai_description`).
+		ColumnExpr(`"activity_instance".start_time AS ai_start_time`).
+		ColumnExpr(`"activity_instance".end_time AS ai_end_time`).
+		ColumnExpr(`"activity_instance".room_id AS ai_room_id`).
+		ColumnExpr(`"activity_instance".status AS ai_status`).
+		ColumnExpr(`"activity_instance".active_group_id AS ai_active_group_id`).
+		ColumnExpr(`"activity_instance".is_spontaneous AS ai_is_spontaneous`).
+		ColumnExpr(`"activity_instance".notes AS ai_notes`).
+		ColumnExpr(`"activity_instance".created_by AS ai_created_by`).
+		ColumnExpr(`"activity_instance".started_by AS ai_started_by`).
+		ColumnExpr(`"activity_instance".started_at AS ai_started_at`).
+		ColumnExpr(`"activity_instance".completed_at AS ai_completed_at`).
+		ColumnExpr(`"activity_instance".created_at AS ai_created_at`).
+		ColumnExpr(`"activity_instance".updated_at AS ai_updated_at`).
+		Where(`"instance_student".student_id = ?`, studentID).
+		Where(`"activity_instance".date >= ?`, from).
+		Where(`"activity_instance".date <= ?`, to).
+		OrderExpr(`"activity_instance".date ASC, "activity_instance".start_time ASC`)
+
+	if where, val, ok := base.TenantWhere(ctx, aliasInstanceStudent); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx, &scans); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find instances with attendance by student and date range",
+			Err: err,
+		}
+	}
+
+	out := make([]*ScheduledInstanceRow, 0, len(scans))
+	for i := range scans {
+		s := scans[i]
+		inst := &schedule.ActivityInstance{
+			Date:             s.AiDate,
+			ActivityGroupID:  s.AiActivityGroupID,
+			CalendarPeriodID: s.AiCalendarPeriod,
+			Title:            s.AiTitle,
+			Description:      s.AiDescription,
+			StartTime:        s.AiStartTime,
+			EndTime:          s.AiEndTime,
+			RoomID:           s.AiRoomID,
+			Status:           s.AiStatus,
+			ActiveGroupID:    s.AiActiveGroupID,
+			IsSpontaneous:    s.AiIsSpontaneous,
+			Notes:            s.AiNotes,
+			CreatedBy:        s.AiCreatedBy,
+			StartedBy:        s.AiStartedBy,
+			StartedAt:        s.AiStartedAt,
+			CompletedAt:      s.AiCompletedAt,
+		}
+		inst.ID = s.AiID
+		inst.CreatedAt = s.AiCreatedAt
+		inst.UpdatedAt = s.AiUpdatedAt
+		inst.SetTenantID(s.AiTenantID)
+
+		att := &schedule.InstanceStudent{
+			InstanceID:  s.IsInstanceID,
+			StudentID:   s.IsStudentID,
+			RoomID:      s.IsRoomID,
+			Status:      s.IsStatus,
+			Substatus:   s.IsSubstatus,
+			Note:        s.IsNote,
+			CheckedInAt: s.IsCheckedInAt,
+		}
+		att.ID = s.IsID
+		att.CreatedAt = s.IsCreatedAt
+		att.UpdatedAt = s.IsUpdatedAt
+		att.SetTenantID(s.IsTenantID)
+
+		out = append(out, &ScheduledInstanceRow{Instance: inst, Attendance: att})
+	}
+	return out, nil
+}

--- a/backend/database/repositories/schedule/student_day_test.go
+++ b/backend/database/repositories/schedule/student_day_test.go
@@ -19,7 +19,7 @@ func TestInstanceStudentRepository_FindInstancesWithAttendanceByStudentAndDateRa
 	defer func() { _ = db.Close() }()
 
 	ctx := testpkg.TenantContext(1)
-	repo := scheduleRepo.NewInstanceStudentRepository(db).(*scheduleRepo.InstanceStudentRepository)
+	repo := scheduleRepo.NewInstanceStudentRepository(db)
 
 	student := testpkg.CreateTestStudent(t, db, "Noah", fmt.Sprintf("SD-%d", time.Now().UnixNano()), "3a")
 	defer testpkg.CleanupActivityFixtures(t, db, student.ID)

--- a/backend/database/repositories/schedule/student_day_test.go
+++ b/backend/database/repositories/schedule/student_day_test.go
@@ -1,0 +1,112 @@
+package schedule_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FindInstancesWithAttendanceByStudentAndDateRange must return one row per
+// (instance, attendance) pair in the range, tenant-scoped, sorted.
+func TestInstanceStudentRepository_FindInstancesWithAttendanceByStudentAndDateRange(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repo := scheduleRepo.NewInstanceStudentRepository(db).(*scheduleRepo.InstanceStudentRepository)
+
+	student := testpkg.CreateTestStudent(t, db, "Noah", fmt.Sprintf("SD-%d", time.Now().UnixNano()), "3a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	dayA := time.Date(2026, 10, 5, 0, 0, 0, 0, time.UTC)
+	dayB := time.Date(2026, 10, 6, 0, 0, 0, 0, time.UTC)
+	dayOutside := time.Date(2026, 11, 1, 0, 0, 0, 0, time.UTC)
+
+	instA, cleanA := createInstanceFixture(t, db, "sd-A", dayA)
+	defer cleanA()
+	instB, cleanB := createInstanceFixture(t, db, "sd-B", dayB)
+	defer cleanB()
+	instOutside, cleanOut := createInstanceFixture(t, db, "sd-out", dayOutside)
+	defer cleanOut()
+
+	late := scheduleModels.AttendanceSubstatusLate
+	note := "bus verpasst"
+	checkedAt := time.Date(2026, 10, 5, 13, 5, 0, 0, time.UTC)
+
+	mkRow := func(instID int64, status string, withExtras bool) *scheduleModels.InstanceStudent {
+		row := &scheduleModels.InstanceStudent{
+			InstanceID: instID,
+			StudentID:  student.ID,
+			Status:     status,
+		}
+		if withExtras {
+			row.Substatus = &late
+			row.Note = &note
+			row.CheckedInAt = &checkedAt
+		}
+		row.SetTenantID(1)
+		return row
+	}
+
+	rowA := mkRow(instA.ID, scheduleModels.AttendanceStatusPresent, true)
+	rowB := mkRow(instB.ID, scheduleModels.AttendanceStatusExpected, false)
+	rowOut := mkRow(instOutside.ID, scheduleModels.AttendanceStatusExpected, false)
+
+	require.NoError(t, repo.Create(ctx, rowA))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", rowA.ID)
+	require.NoError(t, repo.Create(ctx, rowB))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", rowB.ID)
+	require.NoError(t, repo.Create(ctx, rowOut))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", rowOut.ID)
+
+	t.Run("returns joined rows in range, sorted", func(t *testing.T) {
+		rows, err := repo.FindInstancesWithAttendanceByStudentAndDateRange(ctx, student.ID, dayA, dayB)
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+
+		// Sorted by date ASC — dayA first.
+		assert.Equal(t, instA.ID, rows[0].Instance.ID)
+		assert.Equal(t, rowA.ID, rows[0].Attendance.ID)
+		assert.Equal(t, scheduleModels.AttendanceStatusPresent, rows[0].Attendance.Status)
+		require.NotNil(t, rows[0].Attendance.Substatus)
+		assert.Equal(t, scheduleModels.AttendanceSubstatusLate, *rows[0].Attendance.Substatus)
+		require.NotNil(t, rows[0].Attendance.Note)
+		assert.Equal(t, "bus verpasst", *rows[0].Attendance.Note)
+		require.NotNil(t, rows[0].Attendance.CheckedInAt)
+
+		assert.Equal(t, instB.ID, rows[1].Instance.ID)
+		assert.Equal(t, scheduleModels.AttendanceStatusExpected, rows[1].Attendance.Status)
+	})
+
+	t.Run("instance outside range not included", func(t *testing.T) {
+		rows, err := repo.FindInstancesWithAttendanceByStudentAndDateRange(ctx, student.ID, dayA, dayB)
+		require.NoError(t, err)
+		for _, r := range rows {
+			assert.NotEqual(t, instOutside.ID, r.Instance.ID,
+				"instance outside the requested range must not leak in")
+		}
+	})
+
+	t.Run("empty range returns empty slice", func(t *testing.T) {
+		rows, err := repo.FindInstancesWithAttendanceByStudentAndDateRange(
+			ctx, student.ID,
+			time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2027, 1, 2, 0, 0, 0, 0, time.UTC),
+		)
+		require.NoError(t, err)
+		assert.Empty(t, rows)
+	})
+
+	t.Run("different tenant context returns empty", func(t *testing.T) {
+		ctxT2 := testpkg.TenantContext(2)
+		rows, err := repo.FindInstancesWithAttendanceByStudentAndDateRange(ctxT2, student.ID, dayA, dayB)
+		require.NoError(t, err)
+		assert.Empty(t, rows, "tenant 2 must not see tenant 1 rows")
+	})
+}

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -85,6 +85,12 @@ type VisitRepository interface {
 	// student whose entry_time falls within [start, end], ordered by entry_time desc.
 	FindByStudentAndTimeRange(ctx context.Context, studentID int64, start, end time.Time) ([]*Visit, error)
 
+	// FindByStudentAndActiveGroupIDs returns visits for the student whose
+	// active_group_id is in the given list. Used by the timetable per-student
+	// day view to detect unplanned attendance in a single batch query.
+	// Returns an empty slice (no DB call) when the id list is empty.
+	FindByStudentAndActiveGroupIDs(ctx context.Context, studentID int64, activeGroupIDs []int64) ([]*Visit, error)
+
 	// EndVisit marks a visit as ended at the current time
 	EndVisit(ctx context.Context, id int64) error
 

--- a/backend/models/schedule/arrival_schedule.go
+++ b/backend/models/schedule/arrival_schedule.go
@@ -246,6 +246,12 @@ type StudentArrivalExceptionRepository interface {
 	// FindByStudentIDsAndDate finds arrival exceptions for multiple students and a specific date (bulk query)
 	FindByStudentIDsAndDate(ctx context.Context, studentIDs []int64, date time.Time) ([]*StudentArrivalException, error)
 
+	// FindByStudentIDAndDateRange finds arrival exceptions for a student whose
+	// exception_date falls within the inclusive [from, to] range, sorted by
+	// date. Used by the timetable per-student week endpoint to pre-load all
+	// exceptions in a single query.
+	FindByStudentIDAndDateRange(ctx context.Context, studentID int64, from, to time.Time) ([]*StudentArrivalException, error)
+
 	// DeleteByStudentID deletes all arrival exceptions for a student
 	DeleteByStudentID(ctx context.Context, studentID int64) error
 

--- a/backend/models/schedule/instance_student.go
+++ b/backend/models/schedule/instance_student.go
@@ -174,4 +174,14 @@ type InstanceStudentRepository interface {
 	// Callers (the PATCH handler) must validate cross-field invariants
 	// BEFORE invoking — the repo does not re-check them.
 	UpdateAttendanceFields(ctx context.Context, id int64, patch AttendanceFieldPatch) error
+
+	// BulkUpdateStatus flips every attendance row for the given instance whose
+	// current status equals fromStatus to toStatus, and returns the number of
+	// rows changed. Tenant-scoped via the caller's transaction context.
+	//
+	// Used by Complete() to mark remaining 'expected' students as 'absent'
+	// when an instance ends (WP-B10 plan §6.2). Intentionally NOT used by
+	// Cancel(): a cancelled instance never ran, so "absent" would be a
+	// semantic misclaim.
+	BulkUpdateStatus(ctx context.Context, instanceID int64, fromStatus, toStatus string) (int, error)
 }

--- a/backend/models/schedule/instance_student.go
+++ b/backend/models/schedule/instance_student.go
@@ -184,4 +184,14 @@ type InstanceStudentRepository interface {
 	// Cancel(): a cancelled instance never ran, so "absent" would be a
 	// semantic misclaim.
 	BulkUpdateStatus(ctx context.Context, instanceID int64, fromStatus, toStatus string) (int, error)
+
+	// FindInstancesWithAttendanceByStudentAndDateRange returns one row per
+	// (instance_students, activity_instance) pair for the student across the
+	// inclusive date range, sorted by date then start time. Tenant-scoped via
+	// the caller's context. Single query — no N+1.
+	//
+	// Instances the student has no attendance row for (e.g. a spontaneous
+	// instance they dropped into without being enrolled) are NOT included;
+	// the handler layer enriches those via the visits-side lookup.
+	FindInstancesWithAttendanceByStudentAndDateRange(ctx context.Context, studentID int64, from, to time.Time) ([]*ScheduledInstanceRow, error)
 }

--- a/backend/models/schedule/pickup_schedule.go
+++ b/backend/models/schedule/pickup_schedule.go
@@ -211,6 +211,12 @@ type StudentPickupExceptionRepository interface {
 	// FindByStudentIDsAndDate finds pickup exceptions for multiple students and a specific date (bulk query)
 	FindByStudentIDsAndDate(ctx context.Context, studentIDs []int64, date time.Time) ([]*StudentPickupException, error)
 
+	// FindByStudentIDAndDateRange finds pickup exceptions for a student whose
+	// exception_date falls within the inclusive [from, to] range, sorted by
+	// date. Used by the timetable per-student week endpoint to pre-load all
+	// exceptions in a single query.
+	FindByStudentIDAndDateRange(ctx context.Context, studentID int64, from, to time.Time) ([]*StudentPickupException, error)
+
 	// DeleteByStudentID deletes all pickup exceptions for a student
 	DeleteByStudentID(ctx context.Context, studentID int64) error
 

--- a/backend/models/schedule/scheduled_instance_row.go
+++ b/backend/models/schedule/scheduled_instance_row.go
@@ -1,0 +1,15 @@
+package schedule
+
+// ScheduledInstanceRow pairs an activity instance with a student's attendance
+// row on that instance. The timetable /student/{id}/day and /week endpoints
+// assemble their response from rows of this shape: the instance carries the
+// when/where/title, the attendance carries the student-specific status.
+//
+// Both fields are non-nil when returned by
+// FindInstancesWithAttendanceByStudentAndDateRange — the INNER JOIN guarantees
+// it. Lives in the models package (not the repo) so the method can be declared
+// on the InstanceStudentRepository interface without a package cycle.
+type ScheduledInstanceRow struct {
+	Instance   *ActivityInstance
+	Attendance *InstanceStudent
+}

--- a/backend/services/active/end_session_unit_test.go
+++ b/backend/services/active/end_session_unit_test.go
@@ -189,6 +189,10 @@ func (m *mockVisitRepository) FindByStudentAndTimeRange(ctx context.Context, stu
 	return nil, nil
 }
 
+func (m *mockVisitRepository) FindByStudentAndActiveGroupIDs(ctx context.Context, studentID int64, activeGroupIDs []int64) ([]*active.Visit, error) {
+	return nil, nil
+}
+
 func (m *mockVisitRepository) EndVisit(ctx context.Context, id int64) error {
 	if m.endVisitFunc != nil {
 		return m.endVisitFunc(ctx, id)

--- a/backend/services/schedule/attendance_sync_service_unit_test.go
+++ b/backend/services/schedule/attendance_sync_service_unit_test.go
@@ -139,6 +139,10 @@ func (f *fakeInstanceStudentRepo) UpdateAttendanceFields(context.Context, int64,
 	panic("unused")
 }
 
+func (f *fakeInstanceStudentRepo) BulkUpdateStatus(context.Context, int64, string, string) (int, error) {
+	panic("unused")
+}
+
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------

--- a/backend/services/schedule/attendance_sync_service_unit_test.go
+++ b/backend/services/schedule/attendance_sync_service_unit_test.go
@@ -143,6 +143,10 @@ func (f *fakeInstanceStudentRepo) BulkUpdateStatus(context.Context, int64, strin
 	panic("unused")
 }
 
+func (f *fakeInstanceStudentRepo) FindInstancesWithAttendanceByStudentAndDateRange(context.Context, int64, time.Time, time.Time) ([]*scheduleModel.ScheduledInstanceRow, error) {
+	panic("unused")
+}
+
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -241,6 +241,16 @@ func (s *instanceService) Complete(ctx context.Context, instanceID int64) (*sche
 		return nil, &ScheduleError{Op: "complete instance", Err: fmt.Errorf("active instance %d has no active_group_id", instance.ID)}
 	}
 
+	// Mark any remaining expected students as absent before ending the active
+	// group. Runs inside the caller's tenant tx — if EndActivitySession or
+	// updateLifecycleColumns fail below, the bulk update rolls back too, so
+	// the instance never leaves the tx in a half-finished state.
+	if _, err := s.deps.InstanceStudents.BulkUpdateStatus(
+		ctx, instance.ID, scheduleModel.AttendanceStatusExpected, scheduleModel.AttendanceStatusAbsent,
+	); err != nil {
+		return nil, &ScheduleError{Op: "complete instance: mark absent", Err: err}
+	}
+
 	if err := s.deps.ActiveService.EndActivitySession(ctx, *instance.ActiveGroupID); err != nil {
 		return nil, &ScheduleError{Op: "complete instance: end active.group", Err: err}
 	}

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -524,6 +524,105 @@ func instanceExists(t *testing.T, s *lifecycleSetup, id int64) bool {
 	return count > 0
 }
 
+// --- B10 follow-up: Complete marks remaining expected as absent -------------
+
+// fetchAttendance loads an instance_student row by (instance_id, student_id).
+// The tests below use it to assert status after lifecycle transitions.
+func fetchAttendance(t *testing.T, s *lifecycleSetup, instanceID, studentID int64) *scheduleModels.InstanceStudent {
+	t.Helper()
+	var row scheduleModels.InstanceStudent
+	err := s.db.NewSelect().
+		Model(&row).
+		ModelTableExpr(`schedule.instance_students AS "instance_student"`).
+		Where(`"instance_student".instance_id = ?`, instanceID).
+		Where(`"instance_student".student_id = ?`, studentID).
+		Where(`"instance_student".tenant_id = ?`, 1).
+		Scan(s.ctx)
+	require.NoError(t, err)
+	return &row
+}
+
+// Complete must flip every remaining 'expected' row to 'absent' inside the
+// same tenant tx. Present rows stay untouched.
+func TestInstance_Complete_MarksRemainingExpectedAsAbsent(t *testing.T) {
+	s := buildLifecycle(t)
+
+	ai := seedInstance(t, s, true, true) // both students expected
+	started, err := s.svc.Start(s.ctx, ai.ID, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "active.groups", started.ActiveGroupID)
+	})
+
+	// Simulate a live check-in for student1 via the monotonic mirror path.
+	repoFactory := repositories.NewFactory(s.db)
+	updated, err := repoFactory.InstanceStudent.UpdateAttendanceFromCheckin(
+		s.ctx, ai.ID, s.student1, time.Now(),
+	)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	_, err = s.svc.Complete(s.ctx, ai.ID)
+	require.NoError(t, err)
+
+	got1 := fetchAttendance(t, s, ai.ID, s.student1)
+	assert.Equal(t, scheduleModels.AttendanceStatusPresent, got1.Status,
+		"checked-in student must stay present after Complete")
+
+	got2 := fetchAttendance(t, s, ai.ID, s.student2)
+	assert.Equal(t, scheduleModels.AttendanceStatusAbsent, got2.Status,
+		"expected student must be flipped to absent at Complete")
+}
+
+// Cancel must NOT flip expected → absent. A cancelled instance never ran,
+// so "absent" would falsely imply the student failed to show up to an event
+// that happened. The cancelled status on the instance itself is the signal.
+func TestInstance_Cancel_FromPlanned_DoesNotTouchAttendance(t *testing.T) {
+	s := buildLifecycle(t)
+
+	ai := seedInstance(t, s, false, true)
+
+	cancelled, err := s.svc.Cancel(s.ctx, ai.ID)
+	require.NoError(t, err)
+	assert.Equal(t, scheduleModels.InstanceStatusCancelled, cancelled.Status)
+
+	got1 := fetchAttendance(t, s, ai.ID, s.student1)
+	assert.Equal(t, scheduleModels.AttendanceStatusExpected, got1.Status,
+		"Cancel(planned) must not flip attendance to absent")
+	got2 := fetchAttendance(t, s, ai.ID, s.student2)
+	assert.Equal(t, scheduleModels.AttendanceStatusExpected, got2.Status)
+}
+
+// Same rule for Cancel from active. Even the fire-alarm scenario: students
+// who were present when the instance was aborted keep their present status,
+// and students who hadn't arrived stay 'expected' (no event → no absence).
+func TestInstance_Cancel_FromActive_DoesNotTouchAttendance(t *testing.T) {
+	s := buildLifecycle(t)
+
+	ai := seedInstance(t, s, true, true)
+	started, err := s.svc.Start(s.ctx, ai.ID, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "active.groups", started.ActiveGroupID)
+	})
+
+	repoFactory := repositories.NewFactory(s.db)
+	_, err = repoFactory.InstanceStudent.UpdateAttendanceFromCheckin(
+		s.ctx, ai.ID, s.student1, time.Now(),
+	)
+	require.NoError(t, err)
+
+	_, err = s.svc.Cancel(s.ctx, ai.ID)
+	require.NoError(t, err)
+
+	got1 := fetchAttendance(t, s, ai.ID, s.student1)
+	assert.Equal(t, scheduleModels.AttendanceStatusPresent, got1.Status,
+		"Cancel(active) must preserve present rows — they were actually there")
+	got2 := fetchAttendance(t, s, ai.ID, s.student2)
+	assert.Equal(t, scheduleModels.AttendanceStatusExpected, got2.Status,
+		"Cancel(active) must not flip expected → absent")
+}
+
 // --- Conflict-detection pure unit (nil-safe + empty happy path) ------------
 
 func TestDetectStartConflicts_EmptyInstance_NoWarnings(t *testing.T) {

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -2488,3 +2488,250 @@ func CleanupTenantTestData(tb testing.TB, db *bun.DB, tenantIDs ...int64) {
 		}
 	}
 }
+
+// ============================================================================
+// WP-B11 fixtures: timetable student day/week
+// ============================================================================
+
+// parseTimeHHMM turns "HH:MM" into a time.Time anchored on 2000-01-01 (so
+// only the clock components matter for the TIME column). Invalid input fails
+// the test loudly.
+func parseTimeHHMM(tb testing.TB, hhmm string) time.Time {
+	tb.Helper()
+	t, err := time.Parse("15:04", hhmm)
+	require.NoError(tb, err, "invalid HH:MM literal %q", hhmm)
+	return time.Date(2000, 1, 1, t.Hour(), t.Minute(), 0, 0, time.UTC)
+}
+
+// CreateTestArrivalSchedule inserts a weekly arrival schedule for a student.
+// staffID must reference users.staff(id) — the schema's created_by FK.
+func CreateTestArrivalSchedule(tb testing.TB, db *bun.DB, studentID int64, weekday int, staffID int64, arrivalHHMM string) *schedule.StudentArrivalSchedule {
+	tb.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	row := &schedule.StudentArrivalSchedule{
+		StudentID:       studentID,
+		Weekday:         weekday,
+		ExpectedArrival: parseTimeHHMM(tb, arrivalHHMM),
+		CreatedBy:       staffID,
+	}
+	row.SetTenantID(1)
+
+	_, err := db.NewInsert().
+		Model(row).
+		ModelTableExpr(`schedule.student_arrival_schedules`).
+		Exec(ctx)
+	require.NoError(tb, err, "Failed to create test arrival schedule")
+	return row
+}
+
+// CreateTestArrivalException inserts a date-specific arrival exception.
+// Pass arrivalHHMM="" to signal absence on that date (ExpectedArrival=NULL).
+func CreateTestArrivalException(tb testing.TB, db *bun.DB, studentID int64, date time.Time, staffID int64, arrivalHHMM, reason string) *schedule.StudentArrivalException {
+	tb.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	row := &schedule.StudentArrivalException{
+		StudentID:     studentID,
+		ExceptionDate: timezone.DateOfUTC(date),
+		CreatedBy:     staffID,
+	}
+	if arrivalHHMM != "" {
+		t := parseTimeHHMM(tb, arrivalHHMM)
+		row.ExpectedArrival = &t
+	}
+	if reason != "" {
+		row.Reason = &reason
+	}
+	row.SetTenantID(1)
+
+	_, err := db.NewInsert().
+		Model(row).
+		ModelTableExpr(`schedule.student_arrival_exceptions`).
+		Exec(ctx)
+	require.NoError(tb, err, "Failed to create test arrival exception")
+	return row
+}
+
+// CreateTestPickupSchedule inserts a weekly pickup schedule for a student.
+func CreateTestPickupSchedule(tb testing.TB, db *bun.DB, studentID int64, weekday int, staffID int64, pickupHHMM string) *schedule.StudentPickupSchedule {
+	tb.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	row := &schedule.StudentPickupSchedule{
+		StudentID:  studentID,
+		Weekday:    weekday,
+		PickupTime: parseTimeHHMM(tb, pickupHHMM),
+		CreatedBy:  staffID,
+	}
+	row.SetTenantID(1)
+
+	_, err := db.NewInsert().
+		Model(row).
+		ModelTableExpr(`schedule.student_pickup_schedules`).
+		Exec(ctx)
+	require.NoError(tb, err, "Failed to create test pickup schedule")
+	return row
+}
+
+// CreateTestPickupException inserts a date-specific pickup exception.
+// Pass pickupHHMM="" for absence (PickupTime=NULL).
+func CreateTestPickupException(tb testing.TB, db *bun.DB, studentID int64, date time.Time, staffID int64, pickupHHMM, reason string) *schedule.StudentPickupException {
+	tb.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	row := &schedule.StudentPickupException{
+		StudentID:     studentID,
+		ExceptionDate: timezone.DateOfUTC(date),
+		CreatedBy:     staffID,
+	}
+	if pickupHHMM != "" {
+		t := parseTimeHHMM(tb, pickupHHMM)
+		row.PickupTime = &t
+	}
+	if reason != "" {
+		row.Reason = &reason
+	}
+	row.SetTenantID(1)
+
+	_, err := db.NewInsert().
+		Model(row).
+		ModelTableExpr(`schedule.student_pickup_exceptions`).
+		Exec(ctx)
+	require.NoError(tb, err, "Failed to create test pickup exception")
+	return row
+}
+
+// ActivityInstanceOpts lets tests tweak non-default instance fields without
+// bloating the basic helper signature.
+type ActivityInstanceOpts struct {
+	Status          string // defaults to InstanceStatusPlanned
+	ActivityGroupID *int64 // nil = spontaneous instance
+	ActiveGroupID   *int64 // set for active/completed instances
+	StartHHMM       string // defaults to "14:00"
+	EndHHMM         string // defaults to "15:00"
+	Title           string // defaults to "Test Instance"
+	IsSpontaneous   bool
+}
+
+// CreateTestActivityInstance inserts a schedule.activity_instances row.
+// Activity group / active group / status default to a planned template-backed
+// instance; override via opts for lifecycle-edge tests.
+func CreateTestActivityInstance(tb testing.TB, db *bun.DB, date time.Time, roomID int64, opts ActivityInstanceOpts) *schedule.ActivityInstance {
+	tb.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	status := opts.Status
+	if status == "" {
+		status = schedule.InstanceStatusPlanned
+	}
+	startHHMM := opts.StartHHMM
+	if startHHMM == "" {
+		startHHMM = "14:00"
+	}
+	endHHMM := opts.EndHHMM
+	if endHHMM == "" {
+		endHHMM = "15:00"
+	}
+	title := opts.Title
+	if title == "" {
+		title = fmt.Sprintf("Test Instance %d", time.Now().UnixNano())
+	}
+
+	row := &schedule.ActivityInstance{
+		Date:            timezone.DateOfUTC(date),
+		ActivityGroupID: opts.ActivityGroupID,
+		ActiveGroupID:   opts.ActiveGroupID,
+		Title:           title,
+		StartTime:       parseTimeHHMM(tb, startHHMM),
+		EndTime:         parseTimeHHMM(tb, endHHMM),
+		RoomID:          roomID,
+		Status:          status,
+		IsSpontaneous:   opts.IsSpontaneous,
+	}
+	row.SetTenantID(1)
+
+	_, err := db.NewInsert().
+		Model(row).
+		ModelTableExpr(`schedule.activity_instances`).
+		Exec(ctx)
+	require.NoError(tb, err, "Failed to create test activity instance")
+	return row
+}
+
+// CreateTestInstanceStudent inserts one instance_students row. Status defaults
+// to AttendanceStatusExpected when empty.
+func CreateTestInstanceStudent(tb testing.TB, db *bun.DB, instanceID, studentID int64, status string) *schedule.InstanceStudent {
+	tb.Helper()
+
+	if status == "" {
+		status = schedule.AttendanceStatusExpected
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	row := &schedule.InstanceStudent{
+		InstanceID: instanceID,
+		StudentID:  studentID,
+		Status:     status,
+	}
+	row.SetTenantID(1)
+
+	_, err := db.NewInsert().
+		Model(row).
+		ModelTableExpr(`schedule.instance_students`).
+		Exec(ctx)
+	require.NoError(tb, err, "Failed to create test instance student")
+	return row
+}
+
+// CleanupScheduleFixturesB11 drops arrival/pickup/instance fixtures by ID.
+// Table cleanup order matters: instance_students before activity_instances
+// (FK), arrival/pickup exceptions before their student rows. Callers can
+// pass zero IDs (skipped silently).
+func CleanupScheduleFixturesB11(
+	tb testing.TB, db *bun.DB,
+	arrivalScheduleIDs, arrivalExceptionIDs, pickupScheduleIDs, pickupExceptionIDs []int64,
+	instanceStudentIDs, activityInstanceIDs []int64,
+) {
+	tb.Helper()
+
+	nonzero := func(ids []int64) []int64 {
+		out := make([]int64, 0, len(ids))
+		for _, id := range ids {
+			if id > 0 {
+				out = append(out, id)
+			}
+		}
+		return out
+	}
+
+	byTable := []struct {
+		table string
+		ids   []int64
+	}{
+		{"schedule.instance_students", nonzero(instanceStudentIDs)},
+		{"schedule.activity_instances", nonzero(activityInstanceIDs)},
+		{"schedule.student_arrival_exceptions", nonzero(arrivalExceptionIDs)},
+		{"schedule.student_arrival_schedules", nonzero(arrivalScheduleIDs)},
+		{"schedule.student_pickup_exceptions", nonzero(pickupExceptionIDs)},
+		{"schedule.student_pickup_schedules", nonzero(pickupScheduleIDs)},
+	}
+	for _, g := range byTable {
+		if len(g.ids) == 0 {
+			continue
+		}
+		CleanupTableRecords(tb, db, g.table, g.ids...)
+	}
+}


### PR DESCRIPTION
## Summary

- **B10 follow-up fix** (commit 1): `Complete()` now flips remaining `expected` instance_students rows to `absent` inside the tenant tx. `Cancel()` stays untouched — a cancelled instance never ran, so "absent" would be a false claim. Plan §6.2.
- **WP-B11 feature** (commit 2): Two new read endpoints:
  - `GET /api/timetable/student/{id}/day?date=YYYY-MM-DD`
  - `GET /api/timetable/student/{id}/week?from=YYYY-MM-DD&to=YYYY-MM-DD` (14-day cap)
- Response bundles the student's enrolled instances with their attendance row, `is_unplanned` entries for active/completed instances they attended without enrollment, and the arrival/pickup slot for the day (exception beats schedule).
- Cross-tenant returns **404** (never leak existence). Same-tenant without supervisor access returns **403**.
- `CanReadStudent` extracted to `auth/authorize/` so the existing `/students` handler and the new `/timetable/student/{id}/*` routes share one predicate.
- **Review follow-ups** (commit 4): batched preload eliminates the /week N+1, `Dependencies` struct replaces the 17-param `NewResource` positional signature, and the `ScheduledInstanceRow` type leak out of the repo package is gone.

## Architecture notes

- `FindInstancesWithAttendanceByStudentAndDateRange` lives on the `schedule.InstanceStudentRepository` interface; `ScheduledInstanceRow` is now a DTO in `models/schedule`. The old type-assertion + silent-nil path in `api/base.go` is gone — wiring is interface-only, so a mis-wire fails at compile time instead of serving 500s at request time.
- `timetable.NewResource(Dependencies{…})` replaces the old positional signature. Test call sites only name the deps they actually use.
- **Query budget**: `/week` uses one `preloadWeek` pass that issues ≤7 DB queries regardless of range length (enrolled + tenant-instances + visits + 2 schedules + 2 exceptions). Per-day assembly is in-memory. Empirically verified at 7 queries for 14 days via `TestGetStudentWeek_QueryBudget_BatchedNotNPlusOne`. Pre-refactor this was ~98 for the same range.
- **Why the range-wide visits batch is safe**: `schedule.activity_instances` has a `UNIQUE` partial index on `active_group_id` (migration `001015036`), so each `active_group_id` maps to exactly one instance on exactly one date — visits returned in the range-wide batch cannot leak into the wrong day's `instByActiveGroupID`.
- Repo methods added for the batch path:
  - `schedule.InstanceStudentRepository.BulkUpdateStatus` — monotonic (`expected → absent` only).
  - `schedule.InstanceStudentRepository.FindInstancesWithAttendanceByStudentAndDateRange` — single JOIN query.
  - `schedule.StudentArrivalExceptionRepository.FindByStudentIDAndDateRange` and the pickup equivalent — range-bounded lookup for the /week preload.
  - `active.VisitRepository.FindByStudentAndActiveGroupIDs` — batch lookup for is_unplanned detection.
- Berlin-TZ date parsing (`time.ParseInLocation`) avoids the 00:00–02:00 UTC gap.
- `is_unplanned` surfaces only on active/completed instances with an `active_group_id` — planned/cancelled never have visits bridged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --timeout 10m` — 0 issues
- [x] `go test ./services/schedule/...` (B10 fix: Complete marks absent, Cancel preserves present + no-touch for planned/active)
- [x] `go test ./database/repositories/schedule/...` (BulkUpdateStatus + FindInstancesWithAttendance + tenant isolation)
- [x] `go test ./database/repositories/active/...` (FindByStudentAndActiveGroupIDs)
- [x] `go test ./api/timetable/...` (handler tests including happy path, exception-over-schedule, source=none, unplanned, enrolled+visit dedup, 400 cases, 404 cross-tenant, 403 no-supervisor, /week range limits, **query-budget regression guard at ≤12 for a 14-day /week, observed 7**)
- [x] `go test ./api/students/...` (CanReadStudent extraction — no behavior change)
- [x] `go test ./auth/authorize/...`
- [x] `go test ./test/ -run TestHermeticTestPatterns`

Pre-existing `TestArrivalScheduleService_*` / `TestStudentArrival*Repository_*` / `TestGetStudentArrivalSchedules` failures are unrelated — they hit the same FK violation on `development` (verified via stash + checkout).