### PR TITLE
feat(timetable): WP-B13 exception conflict warnings endpoint

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -355,6 +355,8 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 		PersonService:          api.Services.Users,
 		InstanceStudentRepo:    repoFactory.InstanceStudent,
 		ActivityInstanceRepo:   repoFactory.ActivityInstance,
+		ActivityExceptionRepo:  repoFactory.ActivityException,
+		ActivityScheduleRepo:   repoFactory.ActivitySchedule,
 		InstanceStaffRepo:      repoFactory.InstanceStaff,
 		SupervisorRepo:         repoFactory.GroupSupervisor,
 		ArrivalScheduleRepo:    repoFactory.StudentArrivalSchedule,

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/realtime"
@@ -39,6 +40,8 @@ type Resource struct {
 	personService          userSvc.PersonService
 	instanceStudentRepo    schedule.InstanceStudentRepository
 	activityInstanceRepo   schedule.ActivityInstanceRepository
+	activityExceptionRepo  schedule.ActivityExceptionRepository
+	activityScheduleRepo   activities.ScheduleRepository
 	instanceStaffRepo      schedule.InstanceStaffRepository
 	supervisorRepo         active.GroupSupervisorRepository
 	arrivalScheduleRepo    schedule.StudentArrivalScheduleRepository
@@ -66,6 +69,8 @@ type Dependencies struct {
 	PersonService          userSvc.PersonService
 	InstanceStudentRepo    schedule.InstanceStudentRepository
 	ActivityInstanceRepo   schedule.ActivityInstanceRepository
+	ActivityExceptionRepo  schedule.ActivityExceptionRepository
+	ActivityScheduleRepo   activities.ScheduleRepository
 	InstanceStaffRepo      schedule.InstanceStaffRepository
 	SupervisorRepo         active.GroupSupervisorRepository
 	ArrivalScheduleRepo    schedule.StudentArrivalScheduleRepository
@@ -93,6 +98,8 @@ func NewResource(deps Dependencies) *Resource {
 		personService:          deps.PersonService,
 		instanceStudentRepo:    deps.InstanceStudentRepo,
 		activityInstanceRepo:   deps.ActivityInstanceRepo,
+		activityExceptionRepo:  deps.ActivityExceptionRepo,
+		activityScheduleRepo:   deps.ActivityScheduleRepo,
 		instanceStaffRepo:      deps.InstanceStaffRepo,
 		supervisorRepo:         deps.SupervisorRepo,
 		arrivalScheduleRepo:    deps.ArrivalScheduleRepo,
@@ -175,6 +182,10 @@ func (rs *Resource) Router() chi.Router {
 			Get("/gaps", rs.getGaps)
 		r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
 			Post("/substitute", rs.substitute)
+
+		// WP-B13: exception-conflict warnings (planning-only, read-only).
+		r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
+			Get("/exception-conflicts", rs.getExceptionConflicts)
 	})
 
 	return r

--- a/backend/api/timetable/dates.go
+++ b/backend/api/timetable/dates.go
@@ -1,5 +1,6 @@
 // Package timetable — shared date-parsing helpers. Used by WP-B11 (student
-// day/week) and WP-B12 (gaps, substitute) handlers.
+// day/week), WP-B12 (gaps, substitute), and WP-B13 (exception conflicts)
+// handlers.
 package timetable
 
 import (
@@ -15,4 +16,15 @@ import (
 // that entirely.
 func berlinDate(input string) (time.Time, error) {
 	return time.ParseInLocation(dateLayout, input, timezone.Berlin)
+}
+
+// inclusiveDayCount returns the number of Berlin-local days in the inclusive
+// [from, to] range. Anchors both ends to UTC midnight of the same Berlin date
+// via timezone.DateOfUTC so DST transitions (23h/25h days) don't skew the
+// count — a plain to.Sub(from).Hours()/24 undercounts in spring and overcounts
+// in autumn.
+func inclusiveDayCount(from, to time.Time) int {
+	fromUTC := timezone.DateOfUTC(from)
+	toUTC := timezone.DateOfUTC(to)
+	return int(toUTC.Sub(fromUTC).Hours()/24) + 1
 }

--- a/backend/api/timetable/exception_conflicts.go
+++ b/backend/api/timetable/exception_conflicts.go
@@ -499,7 +499,15 @@ func (rs *Resource) buildConflicts(
 	arrivalPre *arrivalPreload,
 	templatePre *templatePreload,
 ) []ConflictEntry {
-	out := make([]ConflictEntry, 0)
+	// Upper bound: every affected (instance, exception) pair contributes
+	// at most one warning per expected student. Count them up-front so the
+	// slice grows at most once for realistic workloads (cancellations often
+	// surface 20-30 students per instance).
+	maxWarnings := 0
+	for _, a := range affected {
+		maxWarnings += len(expectedByInstance[a.instance.ID])
+	}
+	out := make([]ConflictEntry, 0, maxWarnings)
 	for _, a := range affected {
 		stus, ok := expectedByInstance[a.instance.ID]
 		if !ok {
@@ -566,10 +574,10 @@ func (rs *Resource) conflictForStudent(
 		// values, but bun deserialises them with different year anchors
 		// (0000 vs 2000 depending on the column). Comparing via .After()
 		// without normalisation would be driven by the year difference, not
-		// the wall-clock. extractTimeOfDay on both sides pins both to
+		// the wall-clock. timezone.WallClock on both sides pins both to
 		// year 0001 UTC so the comparison is purely HH:MM:SS.
-		modifiedStart := extractTimeOfDay(*a.exception.StartTime)
-		arrivalNorm := extractTimeOfDay(arrivalTime)
+		modifiedStart := timezone.WallClock(*a.exception.StartTime)
+		arrivalNorm := timezone.WallClock(arrivalTime)
 
 		// Only emit when the student's arrival is strictly after the new
 		// start — equal means the student arrives exactly at the start,
@@ -599,14 +607,4 @@ func (rs *Resource) conflictForStudent(
 		slog.String("exception_type", a.exception.ExceptionType),
 	)
 	return ConflictEntry{}, false
-}
-
-// extractTimeOfDay mirrors the helper in services/schedule and the
-// activities repo. activity_exceptions.start_time is a plain TIME column,
-// but Go's time.Time still reads it with a Location — calling .Format
-// directly can therefore shift the wall-clock. Rebuild at year 0001 UTC
-// using the time's own Hour/Minute/Second so the "HH:MM" formatting is
-// stable regardless of server timezone.
-func extractTimeOfDay(t time.Time) time.Time {
-	return time.Date(1, 1, 1, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC)
 }

--- a/backend/api/timetable/exception_conflicts.go
+++ b/backend/api/timetable/exception_conflicts.go
@@ -1,0 +1,612 @@
+// Package timetable — WP-B13 exception-conflict warnings.
+//
+//	GET /api/timetable/exception-conflicts?date=YYYY-MM-DD&date_to=YYYY-MM-DD
+//
+// Surfaces two classes of planning conflicts between activity_exceptions and
+// student arrival expectations:
+//
+//   - cancelled_instance_with_scheduled_arrivals: a student is still flagged
+//     as expected on an instance whose exception cancels the occurrence.
+//   - modified_instance_time_mismatch: a modified exception pushes the
+//     start time earlier than the student's resolved arrival, meaning the
+//     student will miss the opening.
+//
+// Permission: SchedulesRead. Max range 14 days. Only today/future (same
+// Berlin-local rule as /gaps). Empty list on no-conflict → 200, never 404.
+package timetable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+// maxExceptionConflictRangeDays mirrors the /gaps and /week caps. A longer
+// horizon has no frontend consumer today and would enlarge the bulk arrival
+// lookups linearly with N dates.
+const maxExceptionConflictRangeDays = 14
+
+// Conflict kinds — stable strings surfaced to clients.
+const (
+	ConflictKindCancelledArrivals = "cancelled_instance_with_scheduled_arrivals"
+	ConflictKindModifiedMismatch  = "modified_instance_time_mismatch"
+)
+
+// ConflictEntry is a single row in the conflict response. The optional
+// string fields are populated per kind (reason only for cancelled, the
+// two start-time strings only for modified) and serialise as omitempty.
+type ConflictEntry struct {
+	Kind               string `json:"kind"`
+	Date               string `json:"date"`
+	ActivityGroupID    int64  `json:"activity_group_id"`
+	InstanceID         int64  `json:"instance_id"`
+	ActivityTitle      string `json:"activity_title"`
+	StudentID          int64  `json:"student_id"`
+	ExpectedArrival    string `json:"expected_arrival,omitempty"`
+	ArrivalSource      string `json:"arrival_source"`
+	CancellationReason string `json:"cancellation_reason,omitempty"`
+	OriginalStartTime  string `json:"original_start_time,omitempty"`
+	ModifiedStartTime  string `json:"modified_start_time,omitempty"`
+}
+
+// ConflictsResponse is the 200 body for GET /exception-conflicts.
+type ConflictsResponse struct {
+	From      string          `json:"from"`
+	To        string          `json:"to"`
+	Conflicts []ConflictEntry `json:"conflicts"`
+}
+
+// getExceptionConflicts handles GET /api/timetable/exception-conflicts.
+func (rs *Resource) getExceptionConflicts(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	from, to, ok := parseConflictRange(w, r)
+	if !ok {
+		return
+	}
+
+	if rs.activityExceptionRepo == nil ||
+		rs.activityInstanceRepo == nil ||
+		rs.instanceStudentRepo == nil ||
+		rs.arrivalExceptionRepo == nil ||
+		rs.arrivalScheduleRepo == nil ||
+		rs.activityScheduleRepo == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("timetable resource not fully wired")))
+		return
+	}
+
+	fromUTC := timezone.DateOfUTC(from)
+	toUTC := timezone.DateOfUTC(to)
+
+	exceptions, err := rs.activityExceptionRepo.FindByDateRange(ctx, fromUTC, toUTC)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("load activity exceptions failed", err))
+		return
+	}
+	if len(exceptions) == 0 {
+		respondEmptyConflicts(w, r, from, to)
+		return
+	}
+
+	instances, err := rs.activityInstanceRepo.FindByTenantAndDateRange(ctx, fromUTC, toUTC)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("load activity instances failed", err))
+		return
+	}
+
+	// Build a per-exception list of affected instances. Exceptions that do
+	// not map to any materialised instance (e.g. the exception was created
+	// before the scheduler next runs) are skipped with a debug log — not an
+	// error. This is expected because materialisation and exception creation
+	// are independent flows.
+	instancesByKey := indexInstancesByGroupDate(instances)
+	affected := make([]exceptionInstancePair, 0, len(exceptions))
+	for _, exc := range exceptions {
+		key := groupDateKey{
+			GroupID: exc.ActivityGroupID,
+			Date:    dateKey(exc.ExceptionDate),
+		}
+		matching := instancesByKey[key]
+		if len(matching) == 0 {
+			rs.getLogger().Debug("exception without matching instance, skipping",
+				slog.Int64("activity_group_id", exc.ActivityGroupID),
+				slog.String("exception_date", dateKey(exc.ExceptionDate)),
+				slog.String("exception_type", exc.ExceptionType),
+			)
+			continue
+		}
+		for _, inst := range matching {
+			affected = append(affected, exceptionInstancePair{instance: inst, exception: exc})
+		}
+	}
+	if len(affected) == 0 {
+		respondEmptyConflicts(w, r, from, to)
+		return
+	}
+
+	affectedInstanceIDs := uniqueInstanceIDs(affected)
+	expectedStudents, err := rs.instanceStudentRepo.FindExpectedByInstanceIDs(ctx, affectedInstanceIDs)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("load expected students failed", err))
+		return
+	}
+	if len(expectedStudents) == 0 {
+		respondEmptyConflicts(w, r, from, to)
+		return
+	}
+
+	expectedByInstance := make(map[int64][]*scheduleModel.InstanceStudent, len(affectedInstanceIDs))
+	for _, es := range expectedStudents {
+		expectedByInstance[es.InstanceID] = append(expectedByInstance[es.InstanceID], es)
+	}
+
+	// Collect the (student, date) tuples we still need arrival info for.
+	datesToStudents := make(map[string]map[int64]struct{})
+	for _, a := range affected {
+		stus, ok := expectedByInstance[a.instance.ID]
+		if !ok {
+			continue
+		}
+		dk := dateKey(a.exception.ExceptionDate)
+		if datesToStudents[dk] == nil {
+			datesToStudents[dk] = make(map[int64]struct{})
+		}
+		for _, s := range stus {
+			datesToStudents[dk][s.StudentID] = struct{}{}
+		}
+	}
+
+	arrivalPre, err := rs.loadArrivalPreload(ctx, affected, datesToStudents)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("load arrival preload failed", err))
+		return
+	}
+
+	templatePre, err := rs.loadTemplatePreload(ctx, affected)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("load template start-times failed", err))
+		return
+	}
+
+	conflicts := rs.buildConflicts(affected, expectedByInstance, arrivalPre, templatePre)
+
+	sort.SliceStable(conflicts, func(i, j int) bool {
+		if conflicts[i].Date != conflicts[j].Date {
+			return conflicts[i].Date < conflicts[j].Date
+		}
+		if conflicts[i].ActivityGroupID != conflicts[j].ActivityGroupID {
+			return conflicts[i].ActivityGroupID < conflicts[j].ActivityGroupID
+		}
+		return conflicts[i].StudentID < conflicts[j].StudentID
+	})
+
+	rs.getLogger().Info("exception conflicts",
+		slog.String("from", from.Format(dateLayout)),
+		slog.String("to", to.Format(dateLayout)),
+		slog.Int("exception_count", len(exceptions)),
+		slog.Int("conflict_count", len(conflicts)),
+	)
+
+	common.Respond(w, r, http.StatusOK, ConflictsResponse{
+		From:      from.Format(dateLayout),
+		To:        to.Format(dateLayout),
+		Conflicts: conflicts,
+	}, "Exception conflicts retrieved")
+}
+
+// parseConflictRange mirrors /gaps: date required, date_to optional (defaults
+// to date), range <= 14 days, date >= today in Berlin-local.
+func parseConflictRange(w http.ResponseWriter, r *http.Request) (from, to time.Time, ok bool) {
+	q := r.URL.Query()
+
+	dateStr := q.Get("date")
+	if dateStr == "" {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("date is required")))
+		return time.Time{}, time.Time{}, false
+	}
+	parsedFrom, err := berlinDate(dateStr)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid date format, expected YYYY-MM-DD")))
+		return time.Time{}, time.Time{}, false
+	}
+
+	parsedTo := parsedFrom
+	if toStr := q.Get("date_to"); toStr != "" {
+		parsedTo, err = berlinDate(toStr)
+		if err != nil {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid date_to format, expected YYYY-MM-DD")))
+			return time.Time{}, time.Time{}, false
+		}
+	}
+
+	if parsedFrom.After(parsedTo) {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("'date' must be before or equal to 'date_to'")))
+		return time.Time{}, time.Time{}, false
+	}
+	if inclusiveDayCount(parsedFrom, parsedTo) > maxExceptionConflictRangeDays {
+		common.RenderError(w, r, common.ErrorInvalidRequest(
+			fmt.Errorf("date range exceeds maximum of %d days", maxExceptionConflictRangeDays)))
+		return time.Time{}, time.Time{}, false
+	}
+
+	// "today or future" comparison in Berlin-local anchors to the same
+	// midnight the /gaps endpoint uses, so a 23:00 UTC request still
+	// considers the local-Berlin date correctly.
+	todayBerlin := timezone.DateOfUTC(time.Now())
+	fromBerlin := timezone.DateOfUTC(parsedFrom)
+	if fromBerlin.Before(todayBerlin) {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("'date' must be today or a future date")))
+		return time.Time{}, time.Time{}, false
+	}
+
+	return parsedFrom, parsedTo, true
+}
+
+func respondEmptyConflicts(w http.ResponseWriter, r *http.Request, from, to time.Time) {
+	common.Respond(w, r, http.StatusOK, ConflictsResponse{
+		From:      from.Format(dateLayout),
+		To:        to.Format(dateLayout),
+		Conflicts: []ConflictEntry{},
+	}, "Exception conflicts retrieved")
+}
+
+// -----------------------------------------------------------------------------
+// Indexing / helpers
+// -----------------------------------------------------------------------------
+
+type groupDateKey struct {
+	GroupID int64
+	Date    string
+}
+
+type exceptionInstancePair struct {
+	instance  *scheduleModel.ActivityInstance
+	exception *scheduleModel.ActivityException
+}
+
+func indexInstancesByGroupDate(instances []*scheduleModel.ActivityInstance) map[groupDateKey][]*scheduleModel.ActivityInstance {
+	out := make(map[groupDateKey][]*scheduleModel.ActivityInstance, len(instances))
+	for _, inst := range instances {
+		if inst.ActivityGroupID == nil {
+			continue // spontaneous — no template, so never tied to an exception
+		}
+		key := groupDateKey{GroupID: *inst.ActivityGroupID, Date: dateKey(inst.Date)}
+		out[key] = append(out[key], inst)
+	}
+	return out
+}
+
+func uniqueInstanceIDs(affected []exceptionInstancePair) []int64 {
+	seen := make(map[int64]struct{}, len(affected))
+	ids := make([]int64, 0, len(affected))
+	for _, a := range affected {
+		if _, ok := seen[a.instance.ID]; ok {
+			continue
+		}
+		seen[a.instance.ID] = struct{}{}
+		ids = append(ids, a.instance.ID)
+	}
+	return ids
+}
+
+// -----------------------------------------------------------------------------
+// Arrival preload
+// -----------------------------------------------------------------------------
+
+type arrivalPreload struct {
+	// byException[dateKey][studentID] — non-nil row means "arrival exception
+	// exists for this student on this date" (ExpectedArrival may still be nil
+	// inside the row — that flags an explicit absence).
+	byException map[string]map[int64]*scheduleModel.StudentArrivalException
+	// bySchedule[weekday][studentID] — weekly recurring schedule.
+	bySchedule map[int]map[int64]*scheduleModel.StudentArrivalSchedule
+}
+
+func (rs *Resource) loadArrivalPreload(
+	ctx context.Context,
+	affected []exceptionInstancePair,
+	datesToStudents map[string]map[int64]struct{},
+) (*arrivalPreload, error) {
+	pre := &arrivalPreload{
+		byException: map[string]map[int64]*scheduleModel.StudentArrivalException{},
+		bySchedule:  map[int]map[int64]*scheduleModel.StudentArrivalSchedule{},
+	}
+
+	// Arrival exceptions: one query per unique date. Range is capped at 14
+	// by parseConflictRange so this is bounded and predictable.
+	dateObjByKey := make(map[string]time.Time)
+	for _, a := range affected {
+		dateObjByKey[dateKey(a.exception.ExceptionDate)] = a.exception.ExceptionDate
+	}
+	for dk, stuMap := range datesToStudents {
+		ids := make([]int64, 0, len(stuMap))
+		for id := range stuMap {
+			ids = append(ids, id)
+		}
+		excs, err := rs.arrivalExceptionRepo.FindByStudentIDsAndDate(ctx, ids, timezone.DateOfUTC(dateObjByKey[dk]))
+		if err != nil {
+			return nil, fmt.Errorf("load arrival exceptions for %s: %w", dk, err)
+		}
+		byStu := make(map[int64]*scheduleModel.StudentArrivalException, len(excs))
+		for _, e := range excs {
+			byStu[e.StudentID] = e
+		}
+		pre.byException[dk] = byStu
+	}
+
+	// Arrival schedules: one query per unique weekday, and only for students
+	// that don't already have an exception on that date (exceptions win).
+	schedulesNeededByWd := make(map[int]map[int64]struct{})
+	for dk, stuMap := range datesToStudents {
+		wd := isoWeekday(dateObjByKey[dk])
+		if wd < scheduleModel.WeekdayMonday || wd > scheduleModel.WeekdayFriday {
+			continue
+		}
+		for stuID := range stuMap {
+			if byStu, ok := pre.byException[dk]; ok {
+				if _, hasExc := byStu[stuID]; hasExc {
+					continue
+				}
+			}
+			if schedulesNeededByWd[wd] == nil {
+				schedulesNeededByWd[wd] = make(map[int64]struct{})
+			}
+			schedulesNeededByWd[wd][stuID] = struct{}{}
+		}
+	}
+	for wd, stuMap := range schedulesNeededByWd {
+		ids := make([]int64, 0, len(stuMap))
+		for id := range stuMap {
+			ids = append(ids, id)
+		}
+		schedules, err := rs.arrivalScheduleRepo.FindByStudentIDsAndWeekday(ctx, ids, wd)
+		if err != nil {
+			return nil, fmt.Errorf("load arrival schedules for weekday %d: %w", wd, err)
+		}
+		byStu := make(map[int64]*scheduleModel.StudentArrivalSchedule, len(schedules))
+		for _, s := range schedules {
+			byStu[s.StudentID] = s
+		}
+		pre.bySchedule[wd] = byStu
+	}
+
+	return pre, nil
+}
+
+// resolveArrival returns (arrivalTime, source) for a student on a date.
+// source is one of SlotSourceException / SlotSourceSchedule / SlotSourceNone.
+// arrivalTime is time.Time{} (IsZero) when the arrival is unknown — source
+// distinguishes "none" (no rule at all) from "exception without expected_arrival"
+// (explicit absence).
+func (pre *arrivalPreload) resolveArrival(studentID int64, date time.Time) (time.Time, string) {
+	dk := dateKey(date)
+	if byStu, ok := pre.byException[dk]; ok {
+		if exc, has := byStu[studentID]; has && exc != nil {
+			if exc.ExpectedArrival != nil {
+				return *exc.ExpectedArrival, SlotSourceException
+			}
+			return time.Time{}, SlotSourceException // explicit absence
+		}
+	}
+	wd := isoWeekday(date)
+	if wd >= scheduleModel.WeekdayMonday && wd <= scheduleModel.WeekdayFriday {
+		if byStu, ok := pre.bySchedule[wd]; ok {
+			if sched, has := byStu[studentID]; has && sched != nil {
+				return sched.ExpectedArrival, SlotSourceSchedule
+			}
+		}
+	}
+	return time.Time{}, SlotSourceNone
+}
+
+// -----------------------------------------------------------------------------
+// Template start-time preload
+// -----------------------------------------------------------------------------
+
+type templatePreload struct {
+	// byKey[{group, weekday}] — all template start_times for that pair,
+	// in ascending order. A single element is the unambiguous case; multiple
+	// elements mean the template runs multiple slots on that weekday and we
+	// cannot pick the "original" without more context.
+	byKey map[groupWeekdayKey][]time.Time
+}
+
+type groupWeekdayKey struct {
+	GroupID int64
+	Weekday int
+}
+
+func (rs *Resource) loadTemplatePreload(
+	ctx context.Context,
+	affected []exceptionInstancePair,
+) (*templatePreload, error) {
+	// We only need template start-times for modified exceptions that carry
+	// a new start_time. Room-only modifies don't trigger Type 2 and
+	// cancellations don't need the "original" field at all.
+	needed := make(map[int64]struct{})
+	for _, a := range affected {
+		if a.exception.ExceptionType != scheduleModel.ActivityExceptionModified {
+			continue
+		}
+		if a.exception.StartTime == nil {
+			continue
+		}
+		needed[a.exception.ActivityGroupID] = struct{}{}
+	}
+
+	pre := &templatePreload{byKey: map[groupWeekdayKey][]time.Time{}}
+	if len(needed) == 0 {
+		return pre, nil
+	}
+
+	ids := make([]int64, 0, len(needed))
+	for id := range needed {
+		ids = append(ids, id)
+	}
+	rows, err := rs.activityScheduleRepo.FindTemplateStartTimesByGroupIDs(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("load template start times: %w", err)
+	}
+	for _, row := range rows {
+		k := groupWeekdayKey{GroupID: row.ActivityGroupID, Weekday: row.Weekday}
+		pre.byKey[k] = append(pre.byKey[k], row.StartTime)
+	}
+	return pre, nil
+}
+
+// resolveOriginalStart picks the unambiguous template start time for the
+// (group, weekday) pair. If the template defines more than one schedule on
+// that weekday (e.g. morning + afternoon slots), we cannot tell which one
+// was modified — we emit the warning anyway but surface original_start_time
+// as empty.
+func (pre *templatePreload) resolveOriginalStart(groupID int64, weekday int, logger *slog.Logger, excDate time.Time) (string, bool) {
+	starts, ok := pre.byKey[groupWeekdayKey{GroupID: groupID, Weekday: weekday}]
+	if !ok || len(starts) == 0 {
+		logger.Warn("modified exception but no template schedule for weekday",
+			slog.Int64("activity_group_id", groupID),
+			slog.Int("weekday", weekday),
+			slog.String("exception_date", dateKey(excDate)),
+		)
+		return "", false
+	}
+	if len(starts) > 1 {
+		logger.Warn("multiple template schedules for weekday, cannot disambiguate original_start_time",
+			slog.Int64("activity_group_id", groupID),
+			slog.Int("weekday", weekday),
+			slog.Int("schedule_count", len(starts)),
+			slog.String("exception_date", dateKey(excDate)),
+		)
+		return "", false
+	}
+	return starts[0].Format("15:04"), true
+}
+
+// -----------------------------------------------------------------------------
+// Build conflicts
+// -----------------------------------------------------------------------------
+
+func (rs *Resource) buildConflicts(
+	affected []exceptionInstancePair,
+	expectedByInstance map[int64][]*scheduleModel.InstanceStudent,
+	arrivalPre *arrivalPreload,
+	templatePre *templatePreload,
+) []ConflictEntry {
+	out := make([]ConflictEntry, 0)
+	for _, a := range affected {
+		stus, ok := expectedByInstance[a.instance.ID]
+		if !ok {
+			continue
+		}
+		for _, is := range stus {
+			entry, emit := rs.conflictForStudent(a, is, arrivalPre, templatePre)
+			if !emit {
+				continue
+			}
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func (rs *Resource) conflictForStudent(
+	a exceptionInstancePair,
+	is *scheduleModel.InstanceStudent,
+	arrivalPre *arrivalPreload,
+	templatePre *templatePreload,
+) (ConflictEntry, bool) {
+	arrivalTime, arrivalSource := arrivalPre.resolveArrival(is.StudentID, a.exception.ExceptionDate)
+
+	// Explicit-absence handling (Q5): if the arrival exception says the
+	// student is absent on that date (ExpectedArrival=nil → source=
+	// "exception" with zero time), both conflict kinds are noise. The child
+	// isn't coming to school — cancelling or moving the activity has no
+	// impact on them. Reconciling the instance_students.status='expected'
+	// row against the arrival-exception absence is a different concern
+	// (future B17-style reconciliation job).
+	if arrivalSource == SlotSourceException && arrivalTime.IsZero() {
+		return ConflictEntry{}, false
+	}
+
+	base := ConflictEntry{
+		Date:            dateKey(a.exception.ExceptionDate),
+		ActivityGroupID: a.exception.ActivityGroupID,
+		InstanceID:      a.instance.ID,
+		ActivityTitle:   a.instance.Title,
+		StudentID:       is.StudentID,
+		ArrivalSource:   arrivalSource,
+	}
+	if !arrivalTime.IsZero() {
+		base.ExpectedArrival = arrivalTime.Format("15:04")
+	}
+
+	switch a.exception.ExceptionType {
+	case scheduleModel.ActivityExceptionCancelled:
+		base.Kind = ConflictKindCancelledArrivals
+		if a.exception.Reason != nil && *a.exception.Reason != "" {
+			base.CancellationReason = *a.exception.Reason
+		}
+		return base, true
+
+	case scheduleModel.ActivityExceptionModified:
+		if a.exception.StartTime == nil {
+			return ConflictEntry{}, false // room-only modify — no time mismatch possible
+		}
+		if arrivalSource == SlotSourceNone {
+			return ConflictEntry{}, false // no arrival info to compare against
+		}
+		// Both the exception.start_time and the arrival columns are TIME
+		// values, but bun deserialises them with different year anchors
+		// (0000 vs 2000 depending on the column). Comparing via .After()
+		// without normalisation would be driven by the year difference, not
+		// the wall-clock. extractTimeOfDay on both sides pins both to
+		// year 0001 UTC so the comparison is purely HH:MM:SS.
+		modifiedStart := extractTimeOfDay(*a.exception.StartTime)
+		arrivalNorm := extractTimeOfDay(arrivalTime)
+
+		// Only emit when the student's arrival is strictly after the new
+		// start — equal means the student arrives exactly at the start,
+		// which is not a conflict.
+		if !arrivalNorm.After(modifiedStart) {
+			return ConflictEntry{}, false
+		}
+
+		base.Kind = ConflictKindModifiedMismatch
+		base.ModifiedStartTime = modifiedStart.Format("15:04")
+		if original, ok := templatePre.resolveOriginalStart(
+			a.exception.ActivityGroupID,
+			isoWeekday(a.exception.ExceptionDate),
+			rs.getLogger(),
+			a.exception.ExceptionDate,
+		); ok {
+			base.OriginalStartTime = original
+		}
+		return base, true
+	}
+
+	// Unknown exception type: log and skip. The model validation rejects
+	// unknown types on write, so this is defense against future additions
+	// that forget to update this switch.
+	rs.getLogger().Warn("unknown exception type, skipping",
+		slog.Int64("activity_group_id", a.exception.ActivityGroupID),
+		slog.String("exception_type", a.exception.ExceptionType),
+	)
+	return ConflictEntry{}, false
+}
+
+// extractTimeOfDay mirrors the helper in services/schedule and the
+// activities repo. activity_exceptions.start_time is a plain TIME column,
+// but Go's time.Time still reads it with a Location — calling .Format
+// directly can therefore shift the wall-clock. Rebuild at year 0001 UTC
+// using the time's own Hour/Minute/Second so the "HH:MM" formatting is
+// stable regardless of server timezone.
+func extractTimeOfDay(t time.Time) time.Time {
+	return time.Date(1, 1, 1, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC)
+}

--- a/backend/api/timetable/exception_conflicts_test.go
+++ b/backend/api/timetable/exception_conflicts_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"sort"
 	"testing"
 	"time"
 
@@ -214,7 +213,7 @@ func createTestActivitySchedule(
 
 // createTestTimeframeRow inserts a schedule.timeframes row at the given
 // Berlin-local wall-clock. Mirrors the production flow so the repo's
-// extractTimeOfDay round-trip preserves HH:MM.
+// timezone.WallClock round-trip preserves HH:MM.
 func createTestTimeframeRow(t *testing.T, db *bun.DB, startHHMM, endHHMM string) *schedule.Timeframe {
 	t.Helper()
 	start := parseBerlinHHMM(t, startHHMM)
@@ -871,33 +870,10 @@ func TestExceptionConflicts_SortOrder(t *testing.T) {
 	got := decodeConflicts(t, w)
 	require.Len(t, got.Conflicts, 4)
 
-	// Determine the expected (group, student) sort order independently.
-	expected := []struct {
-		gid int64
-		sid int64
-	}{
-		{groupA.ID, stu1.ID},
-		{groupA.ID, stu2.ID},
-		{groupB.ID, stu1.ID},
-		{groupB.ID, stu2.ID},
-	}
-	// Since groupA/groupB ordering depends on DB-assigned IDs, sort expected
-	// once so the comparison is deterministic regardless of which group was
-	// created first.
-	sort.SliceStable(expected, func(i, j int) bool {
-		if expected[i].gid != expected[j].gid {
-			return expected[i].gid < expected[j].gid
-		}
-		return expected[i].sid < expected[j].sid
-	})
-	// Pair-wise verify ordering.
-	sort.SliceStable(expected, func(i, j int) bool {
-		if expected[i].gid != expected[j].gid {
-			return expected[i].gid < expected[j].gid
-		}
-		return expected[i].sid < expected[j].sid
-	})
-
+	// Verify pairwise ordering against the documented rule: date ASC,
+	// activity_group_id ASC, student_id ASC. Because groupA/groupB IDs are
+	// DB-assigned, we check the invariant directly rather than comparing to
+	// a pre-sorted expectations slice.
 	for i := range got.Conflicts {
 		if i > 0 {
 			prev, cur := got.Conflicts[i-1], got.Conflicts[i]

--- a/backend/api/timetable/exception_conflicts_test.go
+++ b/backend/api/timetable/exception_conflicts_test.go
@@ -1,0 +1,969 @@
+// Integration tests for the WP-B13 exception-conflict endpoint. Mirrors the
+// test harness used by gaps_test.go and student_day_test.go — tenant context
+// and permissions are injected via middleware shim; JWT is skipped.
+package timetable
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	activitiesRepo "github.com/moto-nrw/project-phoenix/database/repositories/activities"
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/activities"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// -----------------------------------------------------------------------------
+// Setup harness
+// -----------------------------------------------------------------------------
+
+type conflictsSetup struct {
+	res       *Resource
+	db        *bun.DB
+	ctx       context.Context
+	roomID    int64
+	staffID   int64 // for arrival_schedule.created_by
+	cleanupFn func()
+}
+
+func buildConflictsSetup(t *testing.T) *conflictsSetup {
+	t.Helper()
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := testpkg.TenantContext(1)
+	suffix := time.Now().UnixNano()
+	room := testpkg.CreateTestRoom(t, db, fmt.Sprintf("Ec-Room-%d", suffix))
+	creator := testpkg.CreateTestStaff(t, db, "ExcCreator", fmt.Sprintf("Staff-%d", suffix))
+
+	cleanup := func() {
+		testpkg.CleanupActivityFixtures(t, db, 0, creator.ID, 0, 0, room.ID)
+	}
+
+	res := NewResource(Dependencies{
+		ActivityInstanceRepo:  scheduleRepo.NewActivityInstanceRepository(db),
+		ActivityExceptionRepo: scheduleRepo.NewActivityExceptionRepository(db),
+		ActivityScheduleRepo:  activitiesRepo.NewScheduleRepository(db),
+		InstanceStudentRepo:   scheduleRepo.NewInstanceStudentRepository(db),
+		ArrivalScheduleRepo:   scheduleRepo.NewStudentArrivalScheduleRepository(db),
+		ArrivalExceptionRepo:  scheduleRepo.NewStudentArrivalExceptionRepository(db),
+		DB:                    db,
+	})
+
+	return &conflictsSetup{
+		res:       res,
+		db:        db,
+		ctx:       ctx,
+		roomID:    room.ID,
+		staffID:   creator.ID,
+		cleanupFn: cleanup,
+	}
+}
+
+func conflictsRouter(parentCtx context.Context, res *Resource) chi.Router {
+	tenantID := tenant.FromContext(parentCtx)
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := tenant.WithTenantID(req.Context(), tenantID)
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	})
+	r.Get("/exception-conflicts", res.getExceptionConflicts)
+	return r
+}
+
+func doConflicts(t *testing.T, router chi.Router, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func decodeConflicts(t *testing.T, w *httptest.ResponseRecorder) ConflictsResponse {
+	t.Helper()
+	var env struct {
+		Status string          `json:"status"`
+		Data   json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env), "body=%s", w.Body.String())
+	require.Equal(t, "success", env.Status, "body=%s", w.Body.String())
+	var out ConflictsResponse
+	require.NoError(t, json.Unmarshal(env.Data, &out))
+	return out
+}
+
+// nextMonday returns a Berlin-local Monday >= tomorrow, as both a YYYY-MM-DD
+// string and a UTC midnight time.Time. Test fixtures that exercise weekday
+// rules need a concrete weekday, and Monday is ISO 1 — the simplest to reason
+// about. The base date is deterministic across the week so the test never
+// crosses a Saturday/Sunday boundary where arrival_schedules don't apply.
+func nextMonday() (string, time.Time) {
+	t := time.Now().AddDate(0, 0, 1)
+	for t.Weekday() != time.Monday {
+		t = t.AddDate(0, 0, 1)
+	}
+	d := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+	return d.Format("2006-01-02"), d
+}
+
+// nextTuesday mirrors nextMonday for tests that exercise a different weekday
+// relative to the materialised instance and the arrival schedule.
+func nextTuesday() (string, time.Time) {
+	t := time.Now().AddDate(0, 0, 1)
+	for t.Weekday() != time.Tuesday {
+		t = t.AddDate(0, 0, 1)
+	}
+	d := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+	return d.Format("2006-01-02"), d
+}
+
+// createTestActivityException is a local fixture — no helper exists in
+// test/fixtures.go yet and WP-B13 is the first consumer, so keeping it scoped
+// to this test file avoids churn. Mirrors the existing pattern for local
+// fixtures (see e.g. the raw timeframe insert in student_day_test.go).
+func createTestActivityException(
+	t *testing.T,
+	db *bun.DB,
+	activityGroupID int64,
+	date time.Time,
+	excType string,
+	startHHMM, endHHMM string,
+	reason string,
+) *schedule.ActivityException {
+	t.Helper()
+	row := &schedule.ActivityException{
+		ActivityGroupID: activityGroupID,
+		ExceptionDate:   timezone.DateOfUTC(date),
+		ExceptionType:   excType,
+	}
+	row.SetTenantID(1)
+	if startHHMM != "" {
+		st := parseHHMM(t, startHHMM)
+		row.StartTime = &st
+	}
+	if endHHMM != "" {
+		et := parseHHMM(t, endHHMM)
+		row.EndTime = &et
+	}
+	if reason != "" {
+		row.Reason = &reason
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.NewInsert().
+		Model(row).
+		ModelTableExpr(`schedule.activity_exceptions`).
+		Exec(ctx)
+	require.NoError(t, err, "failed to insert activity_exception fixture")
+
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "schedule.activity_exceptions", row.ID)
+	})
+	return row
+}
+
+// createTestActivitySchedule inserts an activities.schedules row. Optional
+// timeframeID lets tests either link a real timeframe (so the template
+// start-time lookup can find it) or leave it nil to exercise the skip path.
+func createTestActivitySchedule(
+	t *testing.T,
+	db *bun.DB,
+	activityGroupID int64,
+	weekday int,
+	timeframeID *int64,
+) *activities.Schedule {
+	t.Helper()
+	row := &activities.Schedule{
+		ActivityGroupID: activityGroupID,
+		Weekday:         weekday,
+		TimeframeID:     timeframeID,
+	}
+	row.SetTenantID(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.NewInsert().
+		Model(row).
+		ModelTableExpr(`activities.schedules AS "schedule"`).
+		Exec(ctx)
+	require.NoError(t, err, "failed to insert activities.schedules fixture")
+
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "activities.schedules", row.ID)
+	})
+	return row
+}
+
+// createTestTimeframeRow inserts a schedule.timeframes row at the given
+// Berlin-local wall-clock. Mirrors the production flow so the repo's
+// extractTimeOfDay round-trip preserves HH:MM.
+func createTestTimeframeRow(t *testing.T, db *bun.DB, startHHMM, endHHMM string) *schedule.Timeframe {
+	t.Helper()
+	start := parseBerlinHHMM(t, startHHMM)
+	end := parseBerlinHHMM(t, endHHMM)
+	row := &schedule.Timeframe{
+		StartTime:   start,
+		EndTime:     &end,
+		IsActive:    true,
+		Description: fmt.Sprintf("tf-%s-%s-%d", startHHMM, endHHMM, time.Now().UnixNano()),
+	}
+	row.SetTenantID(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.NewInsert().
+		Model(row).
+		ModelTableExpr(`schedule.timeframes AS "timeframe"`).
+		Exec(ctx)
+	require.NoError(t, err, "failed to insert timeframe fixture")
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "schedule.timeframes", row.ID)
+	})
+	return row
+}
+
+func parseHHMM(t *testing.T, hhmm string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse("15:04", hhmm)
+	require.NoError(t, err)
+	return time.Date(2000, 1, 1, parsed.Hour(), parsed.Minute(), 0, 0, time.UTC)
+}
+
+func parseBerlinHHMM(t *testing.T, hhmm string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse("15:04", hhmm)
+	require.NoError(t, err)
+	return time.Date(2024, 1, 1, parsed.Hour(), parsed.Minute(), 0, 0, timezone.Berlin)
+}
+
+// -----------------------------------------------------------------------------
+// Happy paths
+// -----------------------------------------------------------------------------
+
+func TestExceptionConflicts_CancelledInstance_EmitsWarningPerExpectedStudent(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, date := nextMonday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("Cancel-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	inst := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "14:00", EndHHMM: "15:00", Title: "Lernzeit-3a", ActivityGroupID: &group.ID,
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	student := testpkg.CreateTestStudent(t, s.db, "Anna", fmt.Sprintf("C-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+
+	is := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, student.ID, "")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", is.ID) })
+
+	testpkg.CreateTestArrivalSchedule(t, s.db, student.ID, schedule.WeekdayMonday, s.staffID, "13:00")
+
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionCancelled, "", "", "Feueralarm-Uebung")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	got := decodeConflicts(t, w)
+	require.Len(t, got.Conflicts, 1)
+	c := got.Conflicts[0]
+	assert.Equal(t, ConflictKindCancelledArrivals, c.Kind)
+	assert.Equal(t, dateStr, c.Date)
+	assert.Equal(t, group.ID, c.ActivityGroupID)
+	assert.Equal(t, inst.ID, c.InstanceID)
+	assert.Equal(t, "Lernzeit-3a", c.ActivityTitle)
+	assert.Equal(t, student.ID, c.StudentID)
+	assert.Equal(t, "13:00", c.ExpectedArrival)
+	assert.Equal(t, SlotSourceSchedule, c.ArrivalSource)
+	assert.Equal(t, "Feueralarm-Uebung", c.CancellationReason)
+	assert.Empty(t, c.OriginalStartTime)
+	assert.Empty(t, c.ModifiedStartTime)
+}
+
+func TestExceptionConflicts_CancelledInstance_ArrivalExceptionOverridesSchedule(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, date := nextMonday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("CancelOv-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	inst := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "14:00", EndHHMM: "15:00", ActivityGroupID: &group.ID,
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	student := testpkg.CreateTestStudent(t, s.db, "Ben", fmt.Sprintf("C-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+	is := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, student.ID, "")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", is.ID) })
+
+	testpkg.CreateTestArrivalSchedule(t, s.db, student.ID, schedule.WeekdayMonday, s.staffID, "13:00")
+	// Arrival exception for the date — 12:30, which must win over the schedule.
+	testpkg.CreateTestArrivalException(t, s.db, student.ID, date, s.staffID, "12:30", "Arzttermin vormittags")
+
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionCancelled, "", "", "Klassen-Kuchenverkauf")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	require.Len(t, got.Conflicts, 1)
+	assert.Equal(t, SlotSourceException, got.Conflicts[0].ArrivalSource)
+	assert.Equal(t, "12:30", got.Conflicts[0].ExpectedArrival)
+}
+
+func TestExceptionConflicts_CancelledInstance_NoArrivalInfo_OmitsTime(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	// Tuesday exception but the arrival schedule only covers Monday — so
+	// the student has arrival_source=none on the Tuesday.
+	dateStr, date := nextTuesday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("CancelNone-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	inst := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "14:00", EndHHMM: "15:00", ActivityGroupID: &group.ID,
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	student := testpkg.CreateTestStudent(t, s.db, "Cara", fmt.Sprintf("C-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+	is := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, student.ID, "")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", is.ID) })
+
+	// Monday schedule only — nothing for the Tuesday exception date.
+	testpkg.CreateTestArrivalSchedule(t, s.db, student.ID, schedule.WeekdayMonday, s.staffID, "13:00")
+
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionCancelled, "", "", "Ferien")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	require.Len(t, got.Conflicts, 1)
+	assert.Equal(t, SlotSourceNone, got.Conflicts[0].ArrivalSource)
+	assert.Empty(t, got.Conflicts[0].ExpectedArrival)
+}
+
+func TestExceptionConflicts_CancelledInstance_SkipsNonExpectedAttendance(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, date := nextMonday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("CancelSkip-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	inst := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "14:00", EndHHMM: "15:00", ActivityGroupID: &group.ID,
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	suffix := time.Now().UnixNano()
+	stuExpected := testpkg.CreateTestStudent(t, s.db, "Expo", fmt.Sprintf("S-%d", suffix), "3a")
+	stuPresent := testpkg.CreateTestStudent(t, s.db, "Pres", fmt.Sprintf("S-%d", suffix+1), "3a")
+	stuAbsent := testpkg.CreateTestStudent(t, s.db, "Abso", fmt.Sprintf("S-%d", suffix+2), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, stuExpected.ID, stuPresent.ID, stuAbsent.ID) })
+
+	isExp := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, stuExpected.ID, schedule.AttendanceStatusExpected)
+	isPre := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, stuPresent.ID, schedule.AttendanceStatusPresent)
+	isAbs := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, stuAbsent.ID, schedule.AttendanceStatusAbsent)
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", isExp.ID, isPre.ID, isAbs.ID)
+	})
+
+	for _, stu := range []*struct{ ID int64 }{{stuExpected.ID}, {stuPresent.ID}, {stuAbsent.ID}} {
+		testpkg.CreateTestArrivalSchedule(t, s.db, stu.ID, schedule.WeekdayMonday, s.staffID, "13:00")
+	}
+
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionCancelled, "", "", "")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	require.Len(t, got.Conflicts, 1, "only the expected student should produce a warning")
+	assert.Equal(t, stuExpected.ID, got.Conflicts[0].StudentID)
+}
+
+func TestExceptionConflicts_ModifiedEarlier_EmitsWarning(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, date := nextMonday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("ModEarly-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	tf := createTestTimeframeRow(t, s.db, "14:00", "15:00")
+	createTestActivitySchedule(t, s.db, group.ID, schedule.WeekdayMonday, &tf.ID)
+
+	// Instance materialised AFTER the exception, so inst.start_time matches
+	// the modified 13:30 (still works when instance pre-dates the exception
+	// because the handler uses the exception's start_time, not the
+	// instance's).
+	inst := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "13:30", EndHHMM: "15:00", Title: "Lernzeit-Mod", ActivityGroupID: &group.ID,
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	student := testpkg.CreateTestStudent(t, s.db, "Dana", fmt.Sprintf("M-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+	is := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, student.ID, "")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", is.ID) })
+
+	// Student arrives at 13:45 — that is AFTER the new 13:30 start: conflict.
+	testpkg.CreateTestArrivalSchedule(t, s.db, student.ID, schedule.WeekdayMonday, s.staffID, "13:45")
+
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionModified, "13:30", "15:00", "vorverlegt")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	got := decodeConflicts(t, w)
+	require.Len(t, got.Conflicts, 1)
+	c := got.Conflicts[0]
+	assert.Equal(t, ConflictKindModifiedMismatch, c.Kind)
+	assert.Equal(t, "13:45", c.ExpectedArrival)
+	assert.Equal(t, SlotSourceSchedule, c.ArrivalSource)
+	assert.Equal(t, "13:30", c.ModifiedStartTime)
+	assert.Equal(t, "14:00", c.OriginalStartTime)
+	assert.Empty(t, c.CancellationReason)
+}
+
+func TestExceptionConflicts_ModifiedLater_NoWarning(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, date := nextMonday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("ModLate-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	tf := createTestTimeframeRow(t, s.db, "14:00", "15:00")
+	createTestActivitySchedule(t, s.db, group.ID, schedule.WeekdayMonday, &tf.ID)
+
+	inst := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "14:30", EndHHMM: "15:00", ActivityGroupID: &group.ID,
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	student := testpkg.CreateTestStudent(t, s.db, "Emil", fmt.Sprintf("M-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+	is := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, student.ID, "")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", is.ID) })
+
+	testpkg.CreateTestArrivalSchedule(t, s.db, student.ID, schedule.WeekdayMonday, s.staffID, "13:45")
+
+	// Activity pushed back 14:00 → 14:30 — the 13:45 arrival still precedes.
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionModified, "14:30", "15:00", "verschoben")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	assert.Empty(t, got.Conflicts)
+}
+
+func TestExceptionConflicts_ModifiedRoomOnly_NoWarning(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, date := nextMonday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("ModRoom-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	altRoom := testpkg.CreateTestRoom(t, s.db, fmt.Sprintf("Alt-%d", time.Now().UnixNano()))
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, 0, altRoom.ID) })
+
+	inst := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "14:00", EndHHMM: "15:00", ActivityGroupID: &group.ID,
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	student := testpkg.CreateTestStudent(t, s.db, "Finn", fmt.Sprintf("M-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+	is := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, student.ID, "")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", is.ID) })
+
+	testpkg.CreateTestArrivalSchedule(t, s.db, student.ID, schedule.WeekdayMonday, s.staffID, "14:30")
+
+	// room-only modified — start_time stays NULL on the exception row.
+	roomID := altRoom.ID
+	row := &schedule.ActivityException{
+		ActivityGroupID: group.ID,
+		ExceptionDate:   timezone.DateOfUTC(date),
+		ExceptionType:   schedule.ActivityExceptionModified,
+		RoomID:          &roomID,
+	}
+	row.SetTenantID(1)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := s.db.NewInsert().
+		Model(row).
+		ModelTableExpr(`schedule.activity_exceptions`).
+		Exec(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_exceptions", row.ID) })
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	assert.Empty(t, got.Conflicts)
+}
+
+func TestExceptionConflicts_ModifiedEarlier_ArrivalSourceNone_NoWarning(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	// Tuesday: no arrival schedule for the student → source=none.
+	dateStr, date := nextTuesday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("ModNone-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	tf := createTestTimeframeRow(t, s.db, "14:00", "15:00")
+	createTestActivitySchedule(t, s.db, group.ID, schedule.WeekdayTuesday, &tf.ID)
+
+	inst := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "13:30", EndHHMM: "15:00", ActivityGroupID: &group.ID,
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	student := testpkg.CreateTestStudent(t, s.db, "Gara", fmt.Sprintf("M-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+	is := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, student.ID, "")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", is.ID) })
+
+	// No arrival data for this student on Tuesday → source=none.
+
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionModified, "13:30", "15:00", "")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	assert.Empty(t, got.Conflicts, "modified + arrival source=none must not emit")
+}
+
+func TestExceptionConflicts_ArrivalExceptionAbsence_SkipsBothKinds(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, date := nextMonday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("AbsSkip-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	tf := createTestTimeframeRow(t, s.db, "14:00", "15:00")
+	createTestActivitySchedule(t, s.db, group.ID, schedule.WeekdayMonday, &tf.ID)
+
+	// Two instances: one cancelled, one modified — both on the same day, same
+	// group is not allowed (unique per template+date), so split across two
+	// templates.
+	group2 := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("AbsSkip2-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group2.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group2.ID)
+	})
+	tf2 := createTestTimeframeRow(t, s.db, "14:00", "15:00")
+	createTestActivitySchedule(t, s.db, group2.ID, schedule.WeekdayMonday, &tf2.ID)
+
+	instCancelled := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "14:00", EndHHMM: "15:00", ActivityGroupID: &group.ID,
+	})
+	instModified := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "13:30", EndHHMM: "15:00", ActivityGroupID: &group2.ID,
+	})
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", instCancelled.ID, instModified.ID)
+	})
+
+	student := testpkg.CreateTestStudent(t, s.db, "Hera", fmt.Sprintf("Abs-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+	is1 := testpkg.CreateTestInstanceStudent(t, s.db, instCancelled.ID, student.ID, "")
+	is2 := testpkg.CreateTestInstanceStudent(t, s.db, instModified.ID, student.ID, "")
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", is1.ID, is2.ID)
+	})
+
+	testpkg.CreateTestArrivalSchedule(t, s.db, student.ID, schedule.WeekdayMonday, s.staffID, "13:00")
+	// Absence exception — expected_arrival nil, source=exception + IsZero time.
+	testpkg.CreateTestArrivalException(t, s.db, student.ID, date, s.staffID, "", "Krank")
+
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionCancelled, "", "", "Ausgefallen")
+	createTestActivityException(t, s.db, group2.ID, date, schedule.ActivityExceptionModified, "13:30", "15:00", "vorverlegt")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	assert.Empty(t, got.Conflicts,
+		"explicit absence via arrival_exception must suppress both conflict kinds")
+}
+
+func TestExceptionConflicts_ModifiedNoTemplateSchedule_EmitsWithoutOriginal(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, date := nextMonday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("ModNoTpl-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	// Intentionally no activities.schedules row — resolveOriginalStart
+	// returns empty string with a warn log.
+
+	inst := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "13:30", EndHHMM: "15:00", ActivityGroupID: &group.ID,
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	student := testpkg.CreateTestStudent(t, s.db, "Ida", fmt.Sprintf("MNT-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+	is := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, student.ID, "")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", is.ID) })
+
+	testpkg.CreateTestArrivalSchedule(t, s.db, student.ID, schedule.WeekdayMonday, s.staffID, "13:45")
+
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionModified, "13:30", "15:00", "")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	require.Len(t, got.Conflicts, 1)
+	assert.Equal(t, "13:30", got.Conflicts[0].ModifiedStartTime)
+	assert.Empty(t, got.Conflicts[0].OriginalStartTime,
+		"missing template schedule → original_start_time must be absent")
+}
+
+func TestExceptionConflicts_ModifiedAmbiguousTemplate_EmitsWithoutOriginal(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, date := nextMonday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("ModAmb-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	tfA := createTestTimeframeRow(t, s.db, "09:00", "10:00")
+	tfB := createTestTimeframeRow(t, s.db, "14:00", "15:00")
+	createTestActivitySchedule(t, s.db, group.ID, schedule.WeekdayMonday, &tfA.ID)
+	createTestActivitySchedule(t, s.db, group.ID, schedule.WeekdayMonday, &tfB.ID)
+
+	inst := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "13:30", EndHHMM: "15:00", ActivityGroupID: &group.ID,
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	student := testpkg.CreateTestStudent(t, s.db, "Jake", fmt.Sprintf("MA-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+	is := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, student.ID, "")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", is.ID) })
+
+	testpkg.CreateTestArrivalSchedule(t, s.db, student.ID, schedule.WeekdayMonday, s.staffID, "13:45")
+
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionModified, "13:30", "15:00", "")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	require.Len(t, got.Conflicts, 1)
+	assert.Equal(t, "13:30", got.Conflicts[0].ModifiedStartTime)
+	assert.Empty(t, got.Conflicts[0].OriginalStartTime,
+		"ambiguous template weekday → original_start_time must be absent")
+}
+
+// -----------------------------------------------------------------------------
+// Tenant isolation + empty responses
+// -----------------------------------------------------------------------------
+
+func TestExceptionConflicts_Empty_NoExceptions(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, _ := nextMonday()
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	assert.Equal(t, dateStr, got.From)
+	assert.Equal(t, dateStr, got.To)
+	assert.NotNil(t, got.Conflicts)
+	assert.Empty(t, got.Conflicts)
+}
+
+func TestExceptionConflicts_ExceptionWithoutInstance_SkipsSilently(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, date := nextMonday()
+
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("Orphan-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	// Exception exists but no materialised instance.
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionCancelled, "", "", "Geplant")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	got := decodeConflicts(t, w)
+	assert.Empty(t, got.Conflicts)
+}
+
+func TestExceptionConflicts_TenantIsolation(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	dateStr, date := nextMonday()
+
+	// Tenant 1 has the data.
+	group := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("Tiso-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, group.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", group.ID)
+	})
+
+	inst := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "14:00", EndHHMM: "15:00", ActivityGroupID: &group.ID,
+	})
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
+
+	student := testpkg.CreateTestStudent(t, s.db, "Kim", fmt.Sprintf("ISO-%d", time.Now().UnixNano()), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, student.ID) })
+	is := testpkg.CreateTestInstanceStudent(t, s.db, inst.ID, student.ID, "")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", is.ID) })
+
+	testpkg.CreateTestArrivalSchedule(t, s.db, student.ID, schedule.WeekdayMonday, s.staffID, "13:00")
+	createTestActivityException(t, s.db, group.ID, date, schedule.ActivityExceptionCancelled, "", "", "")
+
+	// Querying tenant 2 must see nothing.
+	tenant2Ctx := testpkg.TenantContext(2)
+	router := conflictsRouter(tenant2Ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	assert.Empty(t, got.Conflicts, "tenant 1 data must not leak to tenant 2")
+}
+
+func TestExceptionConflicts_SortOrder(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+
+	// Two groups on the same date, two students each. Deterministic sort by
+	// date ASC, activity_group_id ASC, student_id ASC.
+	dateStr, date := nextMonday()
+
+	groupA := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("SortA-%d", time.Now().UnixNano()))
+	groupB := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("SortB-%d", time.Now().UnixNano()+1))
+	t.Cleanup(func() {
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, groupA.CategoryID, 0)
+		testpkg.CleanupActivityFixtures(t, s.db, 0, 0, 0, groupB.CategoryID, 0)
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", groupA.ID, groupB.ID)
+	})
+
+	instA := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "14:00", EndHHMM: "15:00", ActivityGroupID: &groupA.ID,
+	})
+	instB := testpkg.CreateTestActivityInstance(t, s.db, date, s.roomID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "14:00", EndHHMM: "15:00", ActivityGroupID: &groupB.ID,
+	})
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", instA.ID, instB.ID)
+	})
+
+	suffix := time.Now().UnixNano()
+	stu1 := testpkg.CreateTestStudent(t, s.db, "Alpha", fmt.Sprintf("Sort-%d", suffix), "3a")
+	stu2 := testpkg.CreateTestStudent(t, s.db, "Beta", fmt.Sprintf("Sort-%d", suffix+1), "3a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, stu1.ID, stu2.ID) })
+
+	// Attach both students to both instances.
+	rows := []*schedule.InstanceStudent{
+		testpkg.CreateTestInstanceStudent(t, s.db, instA.ID, stu1.ID, ""),
+		testpkg.CreateTestInstanceStudent(t, s.db, instA.ID, stu2.ID, ""),
+		testpkg.CreateTestInstanceStudent(t, s.db, instB.ID, stu1.ID, ""),
+		testpkg.CreateTestInstanceStudent(t, s.db, instB.ID, stu2.ID, ""),
+	}
+	t.Cleanup(func() {
+		ids := make([]int64, len(rows))
+		for i, r := range rows {
+			ids[i] = r.ID
+		}
+		testpkg.CleanupTableRecords(t, s.db, "schedule.instance_students", ids...)
+	})
+
+	testpkg.CreateTestArrivalSchedule(t, s.db, stu1.ID, schedule.WeekdayMonday, s.staffID, "13:00")
+	testpkg.CreateTestArrivalSchedule(t, s.db, stu2.ID, schedule.WeekdayMonday, s.staffID, "13:00")
+
+	createTestActivityException(t, s.db, groupA.ID, date, schedule.ActivityExceptionCancelled, "", "", "")
+	createTestActivityException(t, s.db, groupB.ID, date, schedule.ActivityExceptionCancelled, "", "", "")
+
+	router := conflictsRouter(s.ctx, s.res)
+	w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", dateStr))
+	require.Equal(t, http.StatusOK, w.Code)
+	got := decodeConflicts(t, w)
+	require.Len(t, got.Conflicts, 4)
+
+	// Determine the expected (group, student) sort order independently.
+	expected := []struct {
+		gid int64
+		sid int64
+	}{
+		{groupA.ID, stu1.ID},
+		{groupA.ID, stu2.ID},
+		{groupB.ID, stu1.ID},
+		{groupB.ID, stu2.ID},
+	}
+	// Since groupA/groupB ordering depends on DB-assigned IDs, sort expected
+	// once so the comparison is deterministic regardless of which group was
+	// created first.
+	sort.SliceStable(expected, func(i, j int) bool {
+		if expected[i].gid != expected[j].gid {
+			return expected[i].gid < expected[j].gid
+		}
+		return expected[i].sid < expected[j].sid
+	})
+	// Pair-wise verify ordering.
+	sort.SliceStable(expected, func(i, j int) bool {
+		if expected[i].gid != expected[j].gid {
+			return expected[i].gid < expected[j].gid
+		}
+		return expected[i].sid < expected[j].sid
+	})
+
+	for i := range got.Conflicts {
+		if i > 0 {
+			prev, cur := got.Conflicts[i-1], got.Conflicts[i]
+			if prev.Date != cur.Date {
+				assert.Less(t, prev.Date, cur.Date, "date order broken at index %d", i)
+				continue
+			}
+			if prev.ActivityGroupID != cur.ActivityGroupID {
+				assert.Less(t, prev.ActivityGroupID, cur.ActivityGroupID, "group order broken at index %d", i)
+				continue
+			}
+			assert.Less(t, prev.StudentID, cur.StudentID, "student order broken at index %d", i)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Validation errors
+// -----------------------------------------------------------------------------
+
+func TestExceptionConflicts_ValidationErrors(t *testing.T) {
+	s := buildConflictsSetup(t)
+	defer s.cleanupFn()
+	router := conflictsRouter(s.ctx, s.res)
+
+	t.Run("date missing → 400", func(t *testing.T) {
+		w := doConflicts(t, router, "/exception-conflicts")
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("date malformed → 400", func(t *testing.T) {
+		w := doConflicts(t, router, "/exception-conflicts?date=not-a-date")
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("date_to malformed → 400", func(t *testing.T) {
+		dateStr, _ := nextMonday()
+		w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s&date_to=foo", dateStr))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("date > date_to → 400", func(t *testing.T) {
+		_, date := nextMonday()
+		after := date.AddDate(0, 0, 3)
+		w := doConflicts(t, router, fmt.Sprintf(
+			"/exception-conflicts?date=%s&date_to=%s",
+			after.Format("2006-01-02"),
+			date.Format("2006-01-02"),
+		))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("range > 14 days → 400", func(t *testing.T) {
+		_, date := nextMonday()
+		tooFar := date.AddDate(0, 0, 20)
+		w := doConflicts(t, router, fmt.Sprintf(
+			"/exception-conflicts?date=%s&date_to=%s",
+			date.Format("2006-01-02"),
+			tooFar.Format("2006-01-02"),
+		))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("date in the past → 400", func(t *testing.T) {
+		past := time.Now().AddDate(0, 0, -2).Format("2006-01-02")
+		w := doConflicts(t, router, fmt.Sprintf("/exception-conflicts?date=%s", past))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}

--- a/backend/api/timetable/instance_students_unit_test.go
+++ b/backend/api/timetable/instance_students_unit_test.go
@@ -73,6 +73,9 @@ func (f *fakeRepo) List(context.Context, *modelsBase.QueryOptions) ([]*schedule.
 func (f *fakeRepo) FindByInstanceID(context.Context, int64) ([]*schedule.InstanceStudent, error) {
 	panic("unused")
 }
+func (f *fakeRepo) FindExpectedByInstanceIDs(context.Context, []int64) ([]*schedule.InstanceStudent, error) {
+	panic("unused")
+}
 func (f *fakeRepo) FindByStudentAndDateRange(context.Context, int64, time.Time, time.Time) ([]*schedule.InstanceStudent, error) {
 	panic("unused")
 }

--- a/backend/api/timetable/student_day.go
+++ b/backend/api/timetable/student_day.go
@@ -39,17 +39,6 @@ func isoWeekday(t time.Time) int {
 	return int((int(t.In(timezone.Berlin).Weekday())+6)%7 + 1)
 }
 
-// inclusiveDayCount returns the number of Berlin-local days in the inclusive
-// [from, to] range. Anchors both ends to UTC midnight of the same Berlin date
-// via timezone.DateOfUTC so DST transitions (23h/25h days) don't skew the
-// count — a plain to.Sub(from).Hours()/24 undercounts in spring and overcounts
-// in autumn.
-func inclusiveDayCount(from, to time.Time) int {
-	fromUTC := timezone.DateOfUTC(from)
-	toUTC := timezone.DateOfUTC(to)
-	return int(toUTC.Sub(fromUTC).Hours()/24) + 1
-}
-
 // dateKey formats a time as YYYY-MM-DD for use as a map key.
 func dateKey(t time.Time) string { return t.Format(dateLayout) }
 

--- a/backend/database/repositories/activities/schedule.go
+++ b/backend/database/repositories/activities/schedule.go
@@ -7,22 +7,12 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
-
-// extractTimeOfDay mirrors the helper used by the materialization service for
-// the same column. schedule.timeframes.start_time is TIMESTAMPTZ, so a naive
-// Go-side read converts the UTC instant to the driver's local zone and the
-// wall-clock Hour/Minute the admin configured ("14:00") no longer matches
-// time.Time.Hour() on the receiving side. This rebuilds the value at
-// year 0001 UTC using the original wall-clock components so downstream
-// consumers can format/compare HH:MM consistently regardless of server tz.
-func extractTimeOfDay(t time.Time) time.Time {
-	return time.Date(1, 1, 1, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC)
-}
 
 // Table name constants (S1192 - avoid duplicate string literals)
 const (
@@ -156,7 +146,7 @@ func (r *ScheduleRepository) FindTemplateStartTimesByGroupIDs(ctx context.Contex
 		out = append(out, &activities.TemplateStartTime{
 			ActivityGroupID: gid,
 			Weekday:         wd,
-			StartTime:       extractTimeOfDay(raw),
+			StartTime:       timezone.WallClock(raw),
 		})
 	}
 	if err := rows.Err(); err != nil {

--- a/backend/database/repositories/activities/schedule.go
+++ b/backend/database/repositories/activities/schedule.go
@@ -4,6 +4,7 @@ package activities
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/models/activities"
@@ -11,6 +12,17 @@ import (
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
+
+// extractTimeOfDay mirrors the helper used by the materialization service for
+// the same column. schedule.timeframes.start_time is TIMESTAMPTZ, so a naive
+// Go-side read converts the UTC instant to the driver's local zone and the
+// wall-clock Hour/Minute the admin configured ("14:00") no longer matches
+// time.Time.Hour() on the receiving side. This rebuilds the value at
+// year 0001 UTC using the original wall-clock components so downstream
+// consumers can format/compare HH:MM consistently regardless of server tz.
+func extractTimeOfDay(t time.Time) time.Time {
+	return time.Date(1, 1, 1, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC)
+}
 
 // Table name constants (S1192 - avoid duplicate string literals)
 const (
@@ -88,6 +100,72 @@ func (r *ScheduleRepository) FindByWeekday(ctx context.Context, weekday string) 
 	}
 
 	return schedules, nil
+}
+
+// FindTemplateStartTimesByGroupIDs returns (activity_group_id, weekday,
+// timeframe.start_time) tuples for the given group IDs. Joins
+// activities.schedules to schedule.timeframes and skips rows without a
+// linked timeframe. Both tables are tenant-scoped in the WHERE clause as
+// defense-in-depth alongside RLS. Returns an empty slice on empty input.
+//
+// The caller (WP-B13 conflict-warning handler) indexes the result by
+// (ActivityGroupID, Weekday) and flags ambiguity when a template has more
+// than one schedule on the same weekday.
+func (r *ScheduleRepository) FindTemplateStartTimesByGroupIDs(ctx context.Context, groupIDs []int64) ([]*activities.TemplateStartTime, error) {
+	if len(groupIDs) == 0 {
+		return []*activities.TemplateStartTime{}, nil
+	}
+
+	// TemplateStartTime is a plain DTO and Bun's ORM layer struggles to
+	// build a valid FROM clause without a registered model, so this query
+	// uses a raw SQL statement and manual row scanning. The belt-and-
+	// suspenders tenant filter (RLS + explicit WHERE) is kept intact.
+	q := `
+		SELECT s.activity_group_id, s.weekday, t.start_time
+		FROM activities.schedules AS s
+		INNER JOIN schedule.timeframes AS t ON t.id = s.timeframe_id
+		WHERE s.activity_group_id IN (?)
+		  AND s.timeframe_id IS NOT NULL`
+	args := []any{bun.In(groupIDs)}
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		q += ` AND s.tenant_id = ? AND t.tenant_id = ?`
+		args = append(args, tenantID, tenantID)
+	}
+	q += ` ORDER BY s.activity_group_id ASC, s.weekday ASC, t.start_time ASC`
+
+	rows, err := base.GetDB(ctx, r.db).QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find template start times by group ids",
+			Err: err,
+		}
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]*activities.TemplateStartTime, 0)
+	for rows.Next() {
+		var gid int64
+		var wd int
+		var raw time.Time
+		if err := rows.Scan(&gid, &wd, &raw); err != nil {
+			return nil, &modelBase.DatabaseError{
+				Op:  "find template start times by group ids: scan",
+				Err: err,
+			}
+		}
+		out = append(out, &activities.TemplateStartTime{
+			ActivityGroupID: gid,
+			Weekday:         wd,
+			StartTime:       extractTimeOfDay(raw),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find template start times by group ids: rows",
+			Err: err,
+		}
+	}
+	return out, nil
 }
 
 // FindByTimeframeID finds all schedules for a specific timeframe

--- a/backend/database/repositories/activities/schedule.go
+++ b/backend/database/repositories/activities/schedule.go
@@ -126,7 +126,7 @@ func (r *ScheduleRepository) FindTemplateStartTimesByGroupIDs(ctx context.Contex
 		INNER JOIN schedule.timeframes AS t ON t.id = s.timeframe_id
 		WHERE s.activity_group_id IN (?)
 		  AND s.timeframe_id IS NOT NULL`
-	args := []any{bun.In(groupIDs)}
+	args := []any{bun.List(groupIDs)}
 	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
 		q += ` AND s.tenant_id = ? AND t.tenant_id = ?`
 		args = append(args, tenantID, tenantID)

--- a/backend/database/repositories/activities/schedule_repository_test.go
+++ b/backend/database/repositories/activities/schedule_repository_test.go
@@ -1,10 +1,14 @@
 package activities_test
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/activities"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -352,4 +356,166 @@ func TestScheduleRepository_Delete_NonExistent(t *testing.T) {
 		err := repo.Delete(ctx, int64(999999))
 		require.NoError(t, err)
 	})
+}
+
+// ============================================================================
+// FindTemplateStartTimesByGroupIDs (WP-B13)
+// ============================================================================
+
+// createTestTimeframe inserts a schedule.timeframes row with the given
+// wall-clock start (HH:MM → UTC date-zeroed). Returns the model with its
+// assigned ID. The tenant is 1.
+func createTestTimeframe(t *testing.T, db *bun.DB, startHour, startMin int) *scheduleModels.Timeframe {
+	t.Helper()
+	// Mirrors the production flow: admins enter wall-clock times in Berlin
+	// local zone. A TIMESTAMPTZ round-trip via Go's local TZ then preserves
+	// the HH:MM components that extractTimeOfDay inside the repo relies on.
+	start := time.Date(2024, 1, 1, startHour, startMin, 0, 0, timezone.Berlin)
+	end := start.Add(time.Hour)
+	tf := &scheduleModels.Timeframe{
+		StartTime:   start,
+		EndTime:     &end,
+		IsActive:    true,
+		Description: fmt.Sprintf("tf-%02d%02d-%d", startHour, startMin, time.Now().UnixNano()),
+	}
+	tf.SetTenantID(1)
+
+	ctx := testpkg.TenantContext(1)
+	_, err := db.NewInsert().
+		Model(tf).
+		ModelTableExpr(`schedule.timeframes AS "timeframe"`).
+		Returning("id").
+		Exec(ctx)
+	require.NoError(t, err)
+	return tf
+}
+
+func TestScheduleRepository_FindTemplateStartTimesByGroupIDs_ReturnsTimes(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ActivitySchedule
+	ctx := testpkg.TenantContext(1)
+
+	group1 := testpkg.CreateTestActivityGroup(t, db, fmt.Sprintf("B13TplA-%d", time.Now().UnixNano()))
+	group2 := testpkg.CreateTestActivityGroup(t, db, fmt.Sprintf("B13TplB-%d", time.Now().UnixNano()+1))
+	defer testpkg.CleanupActivityFixtures(t, db, 0, 0, 0, group1.CategoryID, 0)
+	defer testpkg.CleanupActivityFixtures(t, db, 0, 0, 0, group2.CategoryID, 0)
+	defer testpkg.CleanupTableRecords(t, db, "activities.groups", group1.ID)
+	defer testpkg.CleanupTableRecords(t, db, "activities.groups", group2.ID)
+
+	tf14 := createTestTimeframe(t, db, 14, 0)
+	defer testpkg.CleanupTableRecords(t, db, "schedule.timeframes", tf14.ID)
+	tf15 := createTestTimeframe(t, db, 15, 30)
+	defer testpkg.CleanupTableRecords(t, db, "schedule.timeframes", tf15.ID)
+	tf10 := createTestTimeframe(t, db, 10, 0)
+	defer testpkg.CleanupTableRecords(t, db, "schedule.timeframes", tf10.ID)
+
+	// group1 Monday 14:00, group1 Friday 15:30, group2 Monday 10:00, plus one
+	// schedule without a timeframe (must be skipped).
+	sched1 := createSchedule(t, db, group1.ID, scheduleModels.WeekdayMonday, &tf14.ID)
+	defer testpkg.CleanupTableRecords(t, db, "activities.schedules", sched1.ID)
+	sched2 := createSchedule(t, db, group1.ID, scheduleModels.WeekdayFriday, &tf15.ID)
+	defer testpkg.CleanupTableRecords(t, db, "activities.schedules", sched2.ID)
+	sched3 := createSchedule(t, db, group2.ID, scheduleModels.WeekdayMonday, &tf10.ID)
+	defer testpkg.CleanupTableRecords(t, db, "activities.schedules", sched3.ID)
+	schedNoTF := createSchedule(t, db, group1.ID, scheduleModels.WeekdayTuesday, nil)
+	defer testpkg.CleanupTableRecords(t, db, "activities.schedules", schedNoTF.ID)
+
+	rows, err := repo.FindTemplateStartTimesByGroupIDs(ctx, []int64{group1.ID, group2.ID})
+	require.NoError(t, err)
+
+	type key struct {
+		GID     int64
+		Weekday int
+	}
+	got := make(map[key][]time.Time, len(rows))
+	for _, r := range rows {
+		got[key{r.ActivityGroupID, r.Weekday}] = append(got[key{r.ActivityGroupID, r.Weekday}], r.StartTime)
+	}
+
+	require.Len(t, got[key{group1.ID, scheduleModels.WeekdayMonday}], 1)
+	assert.Equal(t, 14, got[key{group1.ID, scheduleModels.WeekdayMonday}][0].Hour())
+
+	require.Len(t, got[key{group1.ID, scheduleModels.WeekdayFriday}], 1)
+	assert.Equal(t, 15, got[key{group1.ID, scheduleModels.WeekdayFriday}][0].Hour())
+	assert.Equal(t, 30, got[key{group1.ID, scheduleModels.WeekdayFriday}][0].Minute())
+
+	require.Len(t, got[key{group2.ID, scheduleModels.WeekdayMonday}], 1)
+	assert.Equal(t, 10, got[key{group2.ID, scheduleModels.WeekdayMonday}][0].Hour())
+
+	_, hasTuesday := got[key{group1.ID, scheduleModels.WeekdayTuesday}]
+	assert.False(t, hasTuesday, "schedule without timeframe must be skipped by the JOIN")
+}
+
+func TestScheduleRepository_FindTemplateStartTimesByGroupIDs_EmptyInput(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ActivitySchedule
+	ctx := testpkg.TenantContext(1)
+
+	rows, err := repo.FindTemplateStartTimesByGroupIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestScheduleRepository_FindTemplateStartTimesByGroupIDs_AmbiguousWeekday(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ActivitySchedule
+	ctx := testpkg.TenantContext(1)
+
+	group := testpkg.CreateTestActivityGroup(t, db, fmt.Sprintf("B13Amb-%d", time.Now().UnixNano()))
+	defer testpkg.CleanupActivityFixtures(t, db, 0, 0, 0, group.CategoryID, 0)
+	defer testpkg.CleanupTableRecords(t, db, "activities.groups", group.ID)
+
+	tfMorning := createTestTimeframe(t, db, 8, 0)
+	defer testpkg.CleanupTableRecords(t, db, "schedule.timeframes", tfMorning.ID)
+	tfAfternoon := createTestTimeframe(t, db, 14, 0)
+	defer testpkg.CleanupTableRecords(t, db, "schedule.timeframes", tfAfternoon.ID)
+
+	s1 := createSchedule(t, db, group.ID, scheduleModels.WeekdayMonday, &tfMorning.ID)
+	defer testpkg.CleanupTableRecords(t, db, "activities.schedules", s1.ID)
+	s2 := createSchedule(t, db, group.ID, scheduleModels.WeekdayMonday, &tfAfternoon.ID)
+	defer testpkg.CleanupTableRecords(t, db, "activities.schedules", s2.ID)
+
+	rows, err := repo.FindTemplateStartTimesByGroupIDs(ctx, []int64{group.ID})
+	require.NoError(t, err)
+
+	mondayRows := 0
+	for _, r := range rows {
+		if r.ActivityGroupID == group.ID && r.Weekday == scheduleModels.WeekdayMonday {
+			mondayRows++
+		}
+	}
+	assert.Equal(t, 2, mondayRows, "both schedules for the same weekday must be returned — caller disambiguates")
+}
+
+func TestScheduleRepository_FindTemplateStartTimesByGroupIDs_TenantScoped(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ActivitySchedule
+
+	group := testpkg.CreateTestActivityGroup(t, db, fmt.Sprintf("B13Iso-%d", time.Now().UnixNano()))
+	defer testpkg.CleanupActivityFixtures(t, db, 0, 0, 0, group.CategoryID, 0)
+	defer testpkg.CleanupTableRecords(t, db, "activities.groups", group.ID)
+
+	tf := createTestTimeframe(t, db, 14, 0)
+	defer testpkg.CleanupTableRecords(t, db, "schedule.timeframes", tf.ID)
+
+	sched := createSchedule(t, db, group.ID, scheduleModels.WeekdayMonday, &tf.ID)
+	defer testpkg.CleanupTableRecords(t, db, "activities.schedules", sched.ID)
+
+	// Tenant 1 sees the row.
+	rows, err := repo.FindTemplateStartTimesByGroupIDs(testpkg.TenantContext(1), []int64{group.ID})
+	require.NoError(t, err)
+	assert.NotEmpty(t, rows)
+
+	// Tenant 2 must not.
+	rows2, err := repo.FindTemplateStartTimesByGroupIDs(testpkg.TenantContext(2), []int64{group.ID})
+	require.NoError(t, err)
+	assert.Empty(t, rows2, "schedules from tenant 1 must not leak to tenant 2")
 }

--- a/backend/database/repositories/schedule/instance_student_repo.go
+++ b/backend/database/repositories/schedule/instance_student_repo.go
@@ -129,6 +129,36 @@ func (r *InstanceStudentRepository) FindByInstanceID(ctx context.Context, instan
 	return rows, nil
 }
 
+// FindExpectedByInstanceIDs returns every instance_students row with
+// status='expected' for any of the given instance IDs. Tenant-scoped.
+// Empty input returns an empty slice without hitting the DB, matching the
+// sibling bulk helpers (see CountNonAbsentByInstanceIDs in instance_staff_repo).
+func (r *InstanceStudentRepository) FindExpectedByInstanceIDs(ctx context.Context, instanceIDs []int64) ([]*schedule.InstanceStudent, error) {
+	if len(instanceIDs) == 0 {
+		return []*schedule.InstanceStudent{}, nil
+	}
+	var rows []*schedule.InstanceStudent
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&rows).
+		ModelTableExpr(modelTblInstanceStudent).
+		Where(`"instance_student".instance_id IN (?)`, bun.In(instanceIDs)).
+		Where(`"instance_student".status = ?`, schedule.AttendanceStatusExpected).
+		OrderExpr(`"instance_student".instance_id ASC, "instance_student".student_id ASC`)
+
+	if where, val, ok := base.TenantWhere(ctx, aliasInstanceStudent); ok {
+		query = query.Where(where, val)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find expected by instance ids",
+			Err: err,
+		}
+	}
+	return rows, nil
+}
+
 // FindByStudentAndDateRange returns attendance rows for a student across all
 // instances whose date falls within the inclusive range.
 func (r *InstanceStudentRepository) FindByStudentAndDateRange(ctx context.Context, studentID int64, from, to time.Time) ([]*schedule.InstanceStudent, error) {

--- a/backend/database/repositories/schedule/instance_student_repo.go
+++ b/backend/database/repositories/schedule/instance_student_repo.go
@@ -141,7 +141,7 @@ func (r *InstanceStudentRepository) FindExpectedByInstanceIDs(ctx context.Contex
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&rows).
 		ModelTableExpr(modelTblInstanceStudent).
-		Where(`"instance_student".instance_id IN (?)`, bun.In(instanceIDs)).
+		Where(`"instance_student".instance_id IN (?)`, bun.List(instanceIDs)).
 		Where(`"instance_student".status = ?`, schedule.AttendanceStatusExpected).
 		OrderExpr(`"instance_student".instance_id ASC, "instance_student".student_id ASC`)
 

--- a/backend/database/repositories/schedule/instance_student_repo_test.go
+++ b/backend/database/repositories/schedule/instance_student_repo_test.go
@@ -642,3 +642,118 @@ func TestInstanceStudentRepository_DeleteByInstanceID(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, rows)
 }
+
+// ---------------------------------------------------------------------------
+// FindExpectedByInstanceIDs (WP-B13)
+// ---------------------------------------------------------------------------
+
+func TestInstanceStudentRepository_FindExpectedByInstanceIDs_FiltersStatus(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repo := scheduleRepo.NewInstanceStudentRepository(db)
+
+	inst1, cleanup1 := createInstanceFixture(t, db, "b13-a", time.Date(2026, 9, 21, 0, 0, 0, 0, time.UTC))
+	defer cleanup1()
+	inst2, cleanup2 := createInstanceFixture(t, db, "b13-b", time.Date(2026, 9, 22, 0, 0, 0, 0, time.UTC))
+	defer cleanup2()
+
+	unique := time.Now().UnixNano()
+	expectedStudent := testpkg.CreateTestStudent(t, db, "Exp", fmt.Sprintf("B13-%d", unique), "3a")
+	presentStudent := testpkg.CreateTestStudent(t, db, "Pres", fmt.Sprintf("B13-%d", unique+1), "3a")
+	absentStudent := testpkg.CreateTestStudent(t, db, "Abs", fmt.Sprintf("B13-%d", unique+2), "3a")
+	otherStudent := testpkg.CreateTestStudent(t, db, "Other", fmt.Sprintf("B13-%d", unique+3), "3a")
+	defer testpkg.CleanupActivityFixtures(t, db,
+		expectedStudent.ID, presentStudent.ID, absentStudent.ID, otherStudent.ID)
+
+	expectedRow := &scheduleModels.InstanceStudent{
+		InstanceID: inst1.ID,
+		StudentID:  expectedStudent.ID,
+		Status:     scheduleModels.AttendanceStatusExpected,
+	}
+	expectedRow.SetTenantID(1)
+	require.NoError(t, repo.Create(ctx, expectedRow))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", expectedRow.ID)
+
+	presentRow := &scheduleModels.InstanceStudent{
+		InstanceID: inst1.ID,
+		StudentID:  presentStudent.ID,
+		Status:     scheduleModels.AttendanceStatusPresent,
+	}
+	presentRow.SetTenantID(1)
+	require.NoError(t, repo.Create(ctx, presentRow))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", presentRow.ID)
+
+	absentRow := &scheduleModels.InstanceStudent{
+		InstanceID: inst1.ID,
+		StudentID:  absentStudent.ID,
+		Status:     scheduleModels.AttendanceStatusAbsent,
+	}
+	absentRow.SetTenantID(1)
+	require.NoError(t, repo.Create(ctx, absentRow))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", absentRow.ID)
+
+	otherExpected := &scheduleModels.InstanceStudent{
+		InstanceID: inst2.ID,
+		StudentID:  otherStudent.ID,
+		Status:     scheduleModels.AttendanceStatusExpected,
+	}
+	otherExpected.SetTenantID(1)
+	require.NoError(t, repo.Create(ctx, otherExpected))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", otherExpected.ID)
+
+	t.Run("returns only status=expected for given instance IDs", func(t *testing.T) {
+		rows, err := repo.FindExpectedByInstanceIDs(ctx, []int64{inst1.ID, inst2.ID})
+		require.NoError(t, err)
+		ids := make(map[int64]bool, len(rows))
+		for _, r := range rows {
+			ids[r.ID] = true
+			assert.Equal(t, scheduleModels.AttendanceStatusExpected, r.Status)
+		}
+		assert.True(t, ids[expectedRow.ID], "missed expected-status row for inst1")
+		assert.True(t, ids[otherExpected.ID], "missed expected-status row for inst2")
+		assert.False(t, ids[presentRow.ID], "should not include present-status row")
+		assert.False(t, ids[absentRow.ID], "should not include absent-status row")
+	})
+
+	t.Run("empty input returns empty slice without DB roundtrip", func(t *testing.T) {
+		rows, err := repo.FindExpectedByInstanceIDs(ctx, nil)
+		require.NoError(t, err)
+		assert.Empty(t, rows)
+	})
+
+	t.Run("unknown instance id returns empty", func(t *testing.T) {
+		rows, err := repo.FindExpectedByInstanceIDs(ctx, []int64{int64(0)})
+		require.NoError(t, err)
+		assert.Empty(t, rows)
+	})
+}
+
+func TestInstanceStudentRepository_FindExpectedByInstanceIDs_TenantScoped(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewInstanceStudentRepository(db)
+
+	inst, cleanupInst := createInstanceFixture(t, db, "b13-iso", time.Date(2026, 9, 23, 0, 0, 0, 0, time.UTC))
+	defer cleanupInst()
+
+	student := testpkg.CreateTestStudent(t, db, "Iso", fmt.Sprintf("B13-iso-%d", time.Now().UnixNano()), "3a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	row := &scheduleModels.InstanceStudent{
+		InstanceID: inst.ID,
+		StudentID:  student.ID,
+		Status:     scheduleModels.AttendanceStatusExpected,
+	}
+	row.SetTenantID(1)
+	require.NoError(t, repo.Create(testpkg.TenantContext(1), row))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", row.ID)
+
+	// Same instance ID, different tenant context → row must be invisible.
+	otherTenantCtx := testpkg.TenantContext(2)
+	rows, err := repo.FindExpectedByInstanceIDs(otherTenantCtx, []int64{inst.ID})
+	require.NoError(t, err)
+	assert.Empty(t, rows, "row from tenant 1 must not leak to tenant 2")
+}

--- a/backend/internal/timezone/timezone.go
+++ b/backend/internal/timezone/timezone.go
@@ -87,3 +87,25 @@ func EndOfDay(t time.Time) time.Time {
 		23, 59, 59, 0, Berlin,
 	)
 }
+
+// WallClock returns a new time.Time at year 0001-01-01 UTC with t's own
+// wall-clock Hour/Minute/Second/Nanosecond preserved in t's existing
+// Location.
+//
+// This is the bridge between timezone-aware timestamps coming out of bun
+// (e.g. schedule.timeframes.start_time as TIMESTAMPTZ) or TIME columns
+// whose year-anchor the driver picks arbitrarily (0000 vs 2000), and
+// downstream consumers that need to compare or format the wall-clock
+// portion regardless of the original Location or year. Dropping all of
+// date/Location preserves the value the admin saw ("08:00") rather than
+// the UTC instant ("06:00 UTC") or a year-driven .After() mismatch.
+//
+// Used by the materialization service when normalising timeframe rows for
+// insertion into activity_instances.start_time (TIME), by the activities
+// schedule repo when reading the same timeframe back for the WP-B13
+// conflict endpoint, and by the conflict handler itself when comparing
+// the exception's modified start_time against the student's resolved
+// arrival.
+func WallClock(t time.Time) time.Time {
+	return time.Date(1, 1, 1, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC)
+}

--- a/backend/models/activities/repository.go
+++ b/backend/models/activities/repository.go
@@ -56,7 +56,9 @@ type GroupRepository interface {
 //
 // Multiple rows may share the same (ActivityGroupID, Weekday) when a template
 // has several schedules on the same weekday (e.g. morning + afternoon slots).
-// The caller is responsible for disambiguating or flagging ambiguity.
+// The caller is responsible for disambiguating or flagging ambiguity. Rows
+// are returned sorted by (ActivityGroupID ASC, Weekday ASC, StartTime ASC),
+// so the earliest slot comes first when multiple exist for a given key.
 type TemplateStartTime struct {
 	ActivityGroupID int64     `bun:"activity_group_id"`
 	Weekday         int       `bun:"weekday"`

--- a/backend/models/activities/repository.go
+++ b/backend/models/activities/repository.go
@@ -49,6 +49,20 @@ type GroupRepository interface {
 	FindAllTemplates(ctx context.Context) ([]*Group, error)
 }
 
+// TemplateStartTime is a (activity_group_id, weekday) → timeframe.start_time
+// lookup row returned by ScheduleRepository.FindTemplateStartTimesByGroupIDs.
+// Used by the WP-B13 exception-conflict endpoint to resolve the "original"
+// start_time for modified exceptions.
+//
+// Multiple rows may share the same (ActivityGroupID, Weekday) when a template
+// has several schedules on the same weekday (e.g. morning + afternoon slots).
+// The caller is responsible for disambiguating or flagging ambiguity.
+type TemplateStartTime struct {
+	ActivityGroupID int64     `bun:"activity_group_id"`
+	Weekday         int       `bun:"weekday"`
+	StartTime       time.Time `bun:"start_time"`
+}
+
 // ScheduleRepository defines operations for managing activity schedules
 type ScheduleRepository interface {
 	base.Repository[*Schedule]
@@ -61,6 +75,14 @@ type ScheduleRepository interface {
 
 	// FindByTimeframeID finds all schedules for a specific timeframe
 	FindByTimeframeID(ctx context.Context, timeframeID int64) ([]*Schedule, error)
+
+	// FindTemplateStartTimesByGroupIDs returns (activity_group_id, weekday,
+	// timeframe.start_time) tuples for the given group IDs. Joins
+	// activities.schedules to schedule.timeframes and filters out rows
+	// without a linked timeframe. Both tables are tenant-scoped in the
+	// WHERE clause as defense-in-depth alongside RLS. Returns an empty
+	// slice when groupIDs is empty.
+	FindTemplateStartTimesByGroupIDs(ctx context.Context, groupIDs []int64) ([]*TemplateStartTime, error)
 }
 
 // SupervisorPlannedRepository defines operations for managing activity supervisors

--- a/backend/models/schedule/instance_student.go
+++ b/backend/models/schedule/instance_student.go
@@ -151,6 +151,14 @@ type InstanceStudentRepository interface {
 	// FindByInstanceID returns all attendance rows for an instance.
 	FindByInstanceID(ctx context.Context, instanceID int64) ([]*InstanceStudent, error)
 
+	// FindExpectedByInstanceIDs returns every instance_students row with
+	// status='expected' for any of the given instance IDs, tenant-scoped.
+	// Returns an empty slice (not nil) when instanceIDs is empty. Used by
+	// the WP-B13 exception-conflict endpoint to resolve which students are
+	// still flagged as expected on instances that have a cancellation or
+	// modification exception attached.
+	FindExpectedByInstanceIDs(ctx context.Context, instanceIDs []int64) ([]*InstanceStudent, error)
+
 	// FindByStudentAndDateRange returns attendance rows for a student across
 	// all instances whose date falls in the inclusive range. Used by the
 	// per-student day view (aggregation layer).

--- a/backend/services/schedule/attendance_sync_service_unit_test.go
+++ b/backend/services/schedule/attendance_sync_service_unit_test.go
@@ -127,6 +127,10 @@ func (f *fakeInstanceStudentRepo) FindByInstanceID(context.Context, int64) ([]*s
 	panic("unused")
 }
 
+func (f *fakeInstanceStudentRepo) FindExpectedByInstanceIDs(context.Context, []int64) ([]*scheduleModel.InstanceStudent, error) {
+	panic("unused")
+}
+
 func (f *fakeInstanceStudentRepo) FindByStudentAndDateRange(context.Context, int64, time.Time, time.Time) ([]*scheduleModel.InstanceStudent, error) {
 	panic("unused")
 }

--- a/backend/services/schedule/materialization_service.go
+++ b/backend/services/schedule/materialization_service.go
@@ -42,6 +42,7 @@ import (
 
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -757,17 +758,11 @@ func formatTimeOfDay(t time.Time) string {
 	return fmt.Sprintf("%02d:%02d:%02d", t.Hour(), t.Minute(), t.Second())
 }
 
-// extractTimeOfDay returns a new time.Time at year 0001-01-01 UTC with the
-// wall-clock hour/minute/second/nanosecond of `t` in `t`'s own location.
-//
-// This is the correct bridge between `schedule.timeframes.start_time`
-// (TIMESTAMPTZ — a timezone-aware instant) and
-// `schedule.activity_instances.start_time` (TIME — a wall-clock value):
-// we preserve what the admin saw ("08:00") rather than what the UTC instant
-// was ("06:00"). When bun writes the returned time.Time to a TIME column the
-// wall-clock hour survives the round-trip because the value is already in UTC.
+// extractTimeOfDay is a thin wrapper around timezone.WallClock preserved so
+// the local call sites read unchanged. See timezone.WallClock for the
+// full rationale on why TIMESTAMPTZ → TIME round-trips need this.
 func extractTimeOfDay(t time.Time) time.Time {
-	return time.Date(1, 1, 1, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC)
+	return timezone.WallClock(t)
 }
 
 // isUniqueViolation returns true when err (or a wrapped modelBase.DatabaseError)


### PR DESCRIPTION
## Summary

Adds `GET /api/timetable/exception-conflicts?date=YYYY-MM-DD&date_to=YYYY-MM-DD`, a read-only planning view that surfaces collisions between `schedule.activity_exceptions` and the students still flagged as `expected` on the affected instances. Permission: `SchedulesRead`. Range capped at 14 inclusive days, Berlin-local today-or-future only (same validation shape as `/gaps`).

Two conflict kinds:

- **`cancelled_instance_with_scheduled_arrivals`** — a cancellation exception exists but at least one student is still flagged as expected with a resolved arrival.
- **`modified_instance_time_mismatch`** — a modified exception pulls the activity's start time strictly earlier than the student's resolved arrival, meaning the student would miss the opening.

Arrival resolution follows the B11 rule (exception over schedule, otherwise `none`). Explicit absences (`arrival_exception.expected_arrival IS NULL`) suppress both conflict kinds: the student isn't coming, so cancelling or moving the activity isn't a conflict for them.

No migrations. No frontend consumer yet. No PyrePortal impact (endpoint lives under admin `/api/timetable`, not `/api/iot`).

## Commits

- `refactor(timetable): share inclusiveDayCount helper` — pulls the DST-safe day count into `api/timetable/dates.go` so the new handler shares one copy with `/gaps` and `/week`.
- `feat(schedule): bulk lookups for WP-B13 conflict warnings` — adds `InstanceStudentRepository.FindExpectedByInstanceIDs` (single `IN` query, status=expected only) and `activities.ScheduleRepository.FindTemplateStartTimesByGroupIDs` (JOIN `activities.schedules` × `schedule.timeframes` in one raw SQL with explicit belt-and-suspenders tenant predicates on both tables).
- `feat(timetable): WP-B13 exception conflict warnings endpoint` — handler + route + factory wiring + 15 integration tests.
- `refactor(timetable): address WP-B13 review round 1` — dedupes `extractTimeOfDay` into `timezone.WallClock`, removes a duplicated sort in the ordering test, preallocates `buildConflicts` output, clarifies the `TemplateStartTime` DTO ordering guarantee.

## Query plan (no N+1 blow-ups)

Per request, bounded by the 14-day cap:

1. `FindByDateRange(exceptions)` — 1 query
2. `FindByTenantAndDateRange(instances)` — 1 query, indexed in-memory by `(activity_group_id, date)`
3. `FindExpectedByInstanceIDs` — 1 query
4. `FindByStudentIDsAndDate(arrival exceptions)` — ≤ 14 queries (one per unique date)
5. `FindByStudentIDsAndWeekday(arrival schedules)` — ≤ 5 queries (Mon–Fri)
6. `FindTemplateStartTimesByGroupIDs` — 1 query, only when any modified exception has `start_time != NULL`

Total ≤ 22 queries regardless of exception count or student fan-out.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./api/timetable/... -run TestExceptionConflicts` (15 tests, all green)
- [x] `go test ./database/repositories/schedule/... -run TestInstanceStudentRepository_FindExpectedByInstanceIDs` (status filter + tenant isolation)
- [x] `go test ./database/repositories/activities/... -run FindTemplateStartTimesByGroupIDs` (JOIN, empty input, ambiguous weekday, tenant isolation)
- [x] `go test ./services/schedule/... -run TestApplyException -run TestExtractTimeOfDay` (wrapper preserved, existing behaviour unchanged)
- [x] `go test ./test/ -run TestHermeticTestPatterns` — all new tests hermetic, no hardcoded IDs
- [x] `golangci-lint run --timeout 10m` → 0 issues
- [x] `go run main.go gendoc --routes` confirms the new route registers with the correct auth chain (`SchedulesRead` + `TenantTxMiddleware`)
- [ ] Smoke-test happy path against a staging tenant after deploy

## Edge cases explicitly handled

- Exception without materialised instance (race between exception creation and next scheduler run) → skip with `slog.Debug`, not 500.
- Template has multiple schedules on the same weekday → warning still emits, `original_start_time` omitted, `slog.Warn` includes `activity_group_id` + `weekday` + `exception_date`.
- Template has no schedule for the weekday → same treatment.
- Room-only modified exception (`start_time == NULL`) → no time mismatch possible, skip.
- Arrival exception with `expected_arrival IS NULL` (absence) → both conflict kinds suppressed for that student.
- `arrival_source == "none"` (no weekly schedule, no exception) → cancelled emits anyway (the student is still `expected`), modified suppresses (no comparison possible).
- Strict comparison: arrival exactly equal to modified start = **no** conflict.
- Tenant isolation verified end-to-end (tenant 1 rows invisible to tenant 2).

## Out of scope (deferred)

- Parent notification email (plan §9 explicit).
- SSE events (read-only endpoint, no state change).
- `room-only changes` warning type.
- Frontend / PyrePortal integration.