### PR TITLE
test(timetable): E2E flow suite + /gaps assigned_staff_count fix

### DIFF
--- a/backend/api/timetable/gaps.go
+++ b/backend/api/timetable/gaps.go
@@ -161,11 +161,11 @@ func (rs *Resource) getGaps(w http.ResponseWriter, r *http.Request) {
 			EndTime:    inst.EndTime.Format("15:04"),
 			RoomID:     inst.RoomID,
 			Status:     inst.Status,
-			// AssignedStaffCount is always 0 here by construction: we only
-			// reach this branch when nonAbsentCounts[inst.ID] == 0. The
-			// field exists so clients can rely on a stable schema; the
-			// invariant is worth the byte.
-			AssignedStaffCount: 0,
+			// AssignedStaffCount is the total instance_staff count — present
+			// and absent combined. Matches the PR #1303 contract: an instance
+			// with two staff, both is_absent=true, reports assigned=2,absent=2
+			// so admins see "staff were planned, nobody's covering today".
+			AssignedStaffCount: len(rows),
 			AbsentStaffCount:   absentCount,
 		})
 	}

--- a/backend/api/timetable/gaps_test.go
+++ b/backend/api/timetable/gaps_test.go
@@ -164,7 +164,7 @@ func TestGaps_AllStaffAbsent_IsAGap(t *testing.T) {
 	got := decodeGaps(t, w)
 	require.Len(t, got.Gaps, 1)
 	assert.Equal(t, 2, got.Gaps[0].AbsentStaffCount)
-	assert.Equal(t, 0, got.Gaps[0].AssignedStaffCount)
+	assert.Equal(t, 2, got.Gaps[0].AssignedStaffCount)
 }
 
 func TestGaps_NonAbsentStaff_NotAGap(t *testing.T) {

--- a/backend/test/e2e/timetable/E2E_FINDINGS.md
+++ b/backend/test/e2e/timetable/E2E_FINDINGS.md
@@ -1,0 +1,138 @@
+# Timetable-Epic E2E-Sweep — Abschlussbericht
+
+Sechs End-to-End-Flows gegen die gemergten WPs B1 bis B14. Jeder Flow hermetisch, real DB + real HTTP-Stack, eigener Tenant + Cross-Tenant-Isolation in jedem Flow, Query-Budget-Messung an drei Endpoints.
+
+## Ergebnisuebersicht
+
+| Flow | Zweck | Status | Laufzeit |
+|------|-------|--------|----------|
+| A | Plan bis Report (Hauptader) | GRUEN | 0.13 s |
+| B | Cancel + Exception-Conflicts | GRUEN | 0.09 s |
+| C | Gaps + Substitute | GRUEN (nach E2E-C1-Fix) | 0.07 s |
+| D | Re-plan Merge-Strategie | GRUEN | 0.10 s |
+| E | Student Day + Unplanned Visit | GRUEN | 0.07 s |
+| F | GDPR Cleanup | GRUEN | 0.04 s |
+
+**6/6 gruen nach Fix von E2E-C1.**
+
+## Kurzfassung der Befunde
+
+| ID | Flow | Urteil | Kern |
+|----|------|--------|------|
+| **E2E-B1** | B | Plan-Ambiguity | `skipped_exception` schlaegt `skipped_existing` — Plan §6.1 ist missverstaendlich formuliert. |
+| **E2E-C1** | C | **Code-Bug (GEFIXT)** | `/gaps` gab `assigned_staff_count=0` zurueck; sollte Gesamtzahl sein. Einzeiler-Fix in `gaps.go:168`: `AssignedStaffCount: len(rows)`. Plus ein Unit-Test-Assert in `gaps_test.go:167` von `0` auf `2` angepasst (Test encodierte Bug-Verhalten). Flow C jetzt gruen. |
+| **E2E-C2** | C | Plan-Dokumentation | Query-Budget `≤ 2` galt nur fuer Handler-Queries; TenantTx-Middleware addiert 4-5 Queries. |
+| **E2E-ENV-1** | — | Existing Test-Fragility | `backend/services/schedule/arrival_service_test.go` nutzt hardcoded `CreatedBy: 1` staff-ID ohne eigenen Fixture. Die Tests sind fragil gegen DB-state, in dem staff_id=1 nicht existiert. Nicht durch diese Suite verursacht, aber erkannt. Kandidat fuer Hermetic-Bereinigung. |
+
+Dazu ein Umfeld-Befund ohne Nummerierung: `testpkg.CleanupStaffFixtures` wirft noisy `bun: Model(nil interface *interface {})` im Teardown. Cleanup funktioniert, Logs sind laut. Existing-Bug im Helper, nicht im Epic.
+
+---
+
+## Kategorien
+
+- **Code-Bug** — Produktionscode verhaelt sich anders als dokumentiert.
+- **Plan-Bug** — Plan/PR-Text beschreibt etwas, das so nie eingebaut wurde.
+- **Test-Setup-Bug** — Mein Test war kaputt, im Produktionscode nichts falsch (gefixt).
+
+---
+
+## E2E-B1 — skipped_exception vs. skipped_existing (Plan-Ambiguity)
+
+- **Flow**: B, Schritt 3 (Re-materialize mit existing Instanz + cancelled Exception)
+- **Urteil**: Plan-Ambiguity, kein Code-Bug
+- **Erwartet (Plan §6.1 / WP-B8 PR)**: Die Merge-Strategie schuetzt `planned` Instanzen: re-materialize ueber eine existing `planned` Instanz soll `skipped_existing=1` liefern.
+- **Beobachtet**: Der Service prueft `activity_exceptions` **vor** der existing-row-dedupe. Bei existing Instanz + cancelled Exception → `skipped_exception=1, skipped_existing=0`.
+- **Reproducer**: `TestFlowB_CancelAndExceptionConflicts`, Schritt 3.
+- **Bewertung**: Das Verhalten ist sinnvoll (eine gecancelte Aktivitaet soll nicht "zufaellig" per Re-Materialize gerettet werden). Der Plan-Text `§6.1` suggeriert aber eine andere Reihenfolge. Der Plan sollte klarstellen: "Exception wins over existing when candidate is evaluated."
+
+## E2E-C1 — `assigned_staff_count` ist immer 0 in Gap-Response (Code-Bug, GEFIXT)
+
+- **Flow**: C, Schritt 8 (`GET /gaps`)
+- **Urteil**: Code-Bug — **gefixt in dieser Branch**
+- **Erwartet (PR #1303 Doc-Block)**:
+  ```json
+  "gaps":[{
+    "assigned_staff_count": 2, "absent_staff_count": 2
+  }]
+  ```
+  Ein Gap mit zwei zugewiesenen Staff-Members (beide krank) soll `assigned_staff_count=2` zurueckgeben.
+- **War**: Response zeigte `assigned_staff_count=0, absent_staff_count=2`.
+- **Quelle**: `backend/api/timetable/gaps.go:168` — `AssignedStaffCount: 0,` mit missverstaendlichem Kommentar.
+- **Wurzel**: Der Kommentar missinterpretierte die Semantik. `nonAbsentCounts[inst.ID] == 0` bedeutet "null NICHT-abwesende Staff", nicht "null zugewiesene Staff". Bei zwei Supervisors, die beide krank gemeldet sind, ist `nonAbsentCount=0`, aber `assignedCount=2`.
+- **Fix**: `AssignedStaffCount: len(rows)` — die vollstaendige Liste liegt bereits im Code, einfach die Laenge nutzen.
+- **Test-Anpassung (Option B, explizit vom User autorisiert)**: `backend/api/timetable/gaps_test.go:167` war `assert.Equal(t, 0, got.Gaps[0].AssignedStaffCount)` — dieser Assert encodierte das Bug-Verhalten, nicht die Business-Rule. Geaendert zu `assert.Equal(t, 2, ...)` passend zum PR-Vertrag.
+- **Impact**: Admin-UI zeigt jetzt korrekt "2 Staff zugewiesen, 0 anwesend, 2 abwesend" statt widerspruechliches "0 zugewiesen, 2 abwesend".
+- **Reproducer**: `TestFlowC_GapsAndSubstitute`, Schritt 8 — jetzt gruen.
+
+## E2E-C2 — Query-Budget /gaps ≤ 2 ist ohne Middleware-Kontext
+
+- **Flow**: C, Schritt 3 und 8
+- **Urteil**: Plan-Dokumentations-Luecke
+- **Erwartet (PR #1303)**: `/gaps` ≤ 2 Queries (bulk query mit GROUP BY).
+- **Beobachtet**: 6 Queries (baseline, keine Gaps) bzw. 7 Queries (mit einem Gap).
+- **Wurzel**: Die Message `≤ 2` bezog sich auf die Handler-Queries (`FindByTenantAndDateRange`, `CountNonAbsentByInstanceIDs`). Die `TenantTxMiddleware` addiert 4-5 Queries pro Request (`SET LOCAL ROLE`, `SELECT set_config(...)`, etc.) zusammen mit der Transaktions-BEGIN/COMMIT. Bei einem Gap kommt zusaetzlich `FindByInstanceID` pro Gap hinzu (siehe gaps.go:145).
+- **Bewertung**: Kein Bug. Aber das PR-Target im Plan sollte prezisiert werden auf "Handler-Queries ≤ 2" oder das Budget auf die Realitaet angepasst werden (≤ 10 end-to-end).
+- **Reproducer**: `TestFlowC_GapsAndSubstitute`, Schritte 3 + 8 (Log-Output).
+
+## Umfeld-Notiz — Cleanup-Rauschen
+
+Alle Flows produzieren im Teardown `cleanup users.teachers: bun: Model(nil interface *interface {})` Log-Messages. Das kommt aus `testpkg.CleanupStaffFixtures` → `cleanupDelete` via `db.NewDelete().Model((*interface{})(nil))` — bun kann das Model-Argument nicht binden. Existing-Bug im Cleanup-Helper, nicht der E2E-Suite. Der Cleanup selbst funktioniert (die DB wird geleert), nur die Log-Zeilen sind noisy. Kein Blocker, aber ein Kandidat fuer eine separate Bereinigung.
+
+---
+
+## Was die Suite deckt und was nicht
+
+**Abgedeckt in dieser Runde:**
+- Ganzer Materialize → Start → Check-in → Complete → Report Pfad (Flow A)
+- Exception-Propagation (cancelled und modified) inkl. Arrival-Exception-Interaktion (Flow B)
+- Substitute Dry-Run-First-Atomicity bei 409-Konflikt (Flow C)
+- Active-Group-Supervisors-Rotation beim Substitute auf `active` Instanz (Flow C)
+- Gap-Detection bei komplett krankgemeldetem Staff (Flow C)
+- Re-plan-Merge-Strategie fuer alle Status-Kombinationen + Spontan-Instanz (Flow D)
+- Unplanned-Visit-Surfacing im Student-Day (Flow E)
+- GDPR-Retention-Cleanup inkl. CASCADE, Audit-Rows, Idempotenz (Flow F)
+- Tenant-Isolation an jedem Flow
+
+**Nicht abgedeckt (bewusst out of scope):**
+- A/B-Wochen-Boundary — ist durch B8-Unit-Tests + DST-Tests abgedeckt.
+- SSE-Events — separate Infra.
+- IoT-Check-in via `/api/iot/*` — PyrePortal-Track.
+- Schema-Invarianten (FKs, CHECKs) — durch B5-Tests abgedeckt.
+- Auth-Edge-Cases (abgelaufener JWT, fehlende Permissions) — Infra.
+- Retrospektive Materialisierung — out of scope §9.
+- Performance-Skalierung (z.B. 100 Templates × 1000 Schueler) — Benchmark-Territorium, nicht E2E.
+
+## Empfehlungen
+
+1. **E2E-C1 fixen** (Einzeiler in `backend/api/timetable/gaps.go:168`): `AssignedStaffCount: len(rows)` statt `0`. Sobald der Bug gefixt ist, wird Flow C automatisch gruen.
+2. **E2E-B1 im Plan praezisieren**: `docs/timetable-system-plan.md` §6.1 um einen Hinweis erweitern, dass die Exception-Checks vor der existing-row-Dedupe laufen. Das Verhalten ist sinnvoll, der Plan-Text widerspricht ihm.
+3. **E2E-C2 im Plan verorten**: die PR-Beschreibungen `≤ 2` / `≤ 22` / `≤ 12` auf Handler-Queries zu stellen und die Middleware-Overhead-Erwartung separat zu dokumentieren. Oder bei allen das End-to-End-Budget messen und realistisch angeben.
+4. **Cleanup-Helper**: separates kleines PR das `CleanupStaffFixtures` bun-Model-Problem adressiert. Kein Timetable-Blocker, macht Test-Logs aber wesentlich ruhiger.
+5. **E2E-Suite ins CI integrieren**: sobald E2E-C1 gefixt ist, passt die ganze Suite in einen `go test ./test/e2e/...` Build-Step. Dauer: insgesamt unter einer Sekunde inklusive DB-Setup.
+
+## Wie ausfuehren
+
+```bash
+# Test-DB sicherstellen
+docker compose --profile test up -d postgres-test
+
+# Alle Flows
+APP_ENV=test go test ./test/e2e/timetable/ -v
+
+# Einzelner Flow
+APP_ENV=test go test ./test/e2e/timetable/ -run TestFlowC_GapsAndSubstitute -v
+```
+
+## Dateistruktur
+
+```
+backend/test/e2e/timetable/
+├── shared_setup.go              # scenario, mountRouter, buildTemplate, helpers
+├── flow_a_happy_path_test.go    # Plan → Report
+├── flow_b_cancel_conflicts_test.go
+├── flow_c_gaps_substitute_test.go  # enthaelt den E2E-C1-Repro
+├── flow_d_replan_week_test.go
+├── flow_e_student_day_test.go
+├── flow_f_gdpr_cleanup_test.go
+└── E2E_FINDINGS.md              # dieses Dokument
+```

--- a/backend/test/e2e/timetable/flow_a_happy_path_test.go
+++ b/backend/test/e2e/timetable/flow_a_happy_path_test.go
@@ -1,0 +1,253 @@
+package e2e_timetable
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/auth/device"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	usersModel "github.com/moto-nrw/project-phoenix/models/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// TestFlowA_PlanToReport exercises the core timetable chain:
+// admin materializes templates → staff starts the instance → two students
+// check in → one student never shows → admin completes → /student/{id}/day
+// reports the right state. Tenant-isolation is verified at the end.
+func TestFlowA_PlanToReport(t *testing.T) {
+	s := newScenario(t)
+	defer s.teardown()
+
+	// --- Setup: period, room, staff, students, template --------------------
+	// Pick a Wednesday far enough ahead that the scheduler accepts the window.
+	target := nextWeekday(time.Now().UTC(), 3, 7) // Wed, ≥7 days out
+	s.createActivePeriod(fmt.Sprintf("E2E-Flow-A-%d", time.Now().UnixNano()), target)
+
+	room := testpkg.CreateTestRoom(t, s.db, "FlowA-Room")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupTableRecords(t, s.db, "facilities.rooms", room.ID)
+	})
+
+	staff1 := testpkg.CreateTestStaff(t, s.db, "Frau", "Schmidt")
+	staff2 := testpkg.CreateTestStaff(t, s.db, "Herr", "Meier")
+	student1 := testpkg.CreateTestStudent(t, s.db, "Anna", "A", "3a")
+	student2 := testpkg.CreateTestStudent(t, s.db, "Ben", "B", "3a")
+	student3 := testpkg.CreateTestStudent(t, s.db, "Cleo", "C", "3a")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupStaffFixtures(t, s.db, staff1.ID, staff2.ID)
+		testpkg.CleanupTableRecords(t, s.db, "users.students", student1.ID, student2.ID, student3.ID)
+	})
+
+	tmpl := s.buildTemplate(templateSpec{
+		name:       "Mathe-AG",
+		weekday:    3,
+		startHHMM:  "14:00",
+		endHHMM:    "15:00",
+		roomID:     room.ID,
+		staffIDs:   []int64{staff1.ID, staff2.ID},
+		studentIDs: []int64{student1.ID, student2.ID, student3.ID},
+	})
+	_ = tmpl
+
+	// --- Step 1: materialize the target week -------------------------------
+	fromS := target.Format("2006-01-02")
+	toS := fromS
+	matReq := map[string]any{"from_date": fromS, "to_date": toS}
+	rr := s.do("POST", "/materialize", matReq, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "materialize body=%s", rr.Body.String())
+
+	var matResp struct {
+		InstancesCreated        int `json:"instances_created"`
+		InstanceStudentsCreated int `json:"instance_students_created"`
+		InstanceStaffCreated    int `json:"instance_staff_created"`
+	}
+	decodeResponse(t, rr, &matResp)
+	assert.Equal(t, 1, matResp.InstancesCreated)
+	assert.Equal(t, 3, matResp.InstanceStudentsCreated)
+	assert.Equal(t, 2, matResp.InstanceStaffCreated)
+
+	// Find the created instance (for later asserts + start/complete).
+	instance := fetchOneInstance(t, s, tmpl.group.ID, target)
+	s.registerCleanup("schedule.activity_instances", instance.ID)
+	require.Equal(t, scheduleModel.InstanceStatusPlanned, instance.Status)
+
+	// --- Step 2: assert DB baseline ---------------------------------------
+	instStudents := fetchInstanceStudents(t, s, instance.ID)
+	require.Len(t, instStudents, 3)
+	for _, is := range instStudents {
+		assert.Equal(t, scheduleModel.AttendanceStatusExpected, is.Status)
+	}
+	require.Equal(t, 2, countInstanceStaff(t, s, instance.ID))
+
+	// --- Step 3: start the instance ----------------------------------------
+	rr = s.do("POST", fmt.Sprintf("/instances/%d/start", instance.ID), nil, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "start body=%s", rr.Body.String())
+
+	var startResp struct {
+		InstanceID    int64             `json:"instance_id"`
+		Status        string            `json:"status"`
+		ActiveGroupID int64             `json:"active_group_id"`
+		Warnings      []json.RawMessage `json:"warnings"`
+	}
+	decodeResponse(t, rr, &startResp)
+	assert.Equal(t, scheduleModel.InstanceStatusActive, startResp.Status)
+	require.NotZero(t, startResp.ActiveGroupID, "active_group_id must be set")
+	assert.Empty(t, startResp.Warnings, "clean start should have no warnings")
+
+	// --- Step 4: simulate two student check-ins via ActiveService ---------
+	// We're not hitting the IoT HTTP endpoint here — that's PyrePortal's path.
+	// We go directly through the active service so the attendance-sync mirror
+	// is exercised end-to-end (B10 side effect).
+	checkInStudent(t, s, student1.ID, startResp.ActiveGroupID, staff1)
+	checkInStudent(t, s, student2.ID, startResp.ActiveGroupID, staff1)
+
+	// --- Step 5: assert attendance sync flipped instance_students ----------
+	instStudents = fetchInstanceStudents(t, s, instance.ID)
+	byStudent := map[int64]*scheduleModel.InstanceStudent{}
+	for i := range instStudents {
+		byStudent[instStudents[i].StudentID] = &instStudents[i]
+	}
+	require.Contains(t, byStudent, student1.ID)
+	require.Contains(t, byStudent, student2.ID)
+	assert.Equal(t, scheduleModel.AttendanceStatusPresent, byStudent[student1.ID].Status)
+	assert.NotNil(t, byStudent[student1.ID].CheckedInAt)
+	assert.Equal(t, scheduleModel.AttendanceStatusPresent, byStudent[student2.ID].Status)
+	assert.NotNil(t, byStudent[student2.ID].CheckedInAt)
+	assert.Equal(t, scheduleModel.AttendanceStatusExpected, byStudent[student3.ID].Status,
+		"third student never checked in, should still be expected pre-complete")
+
+	// --- Step 6: complete the instance ------------------------------------
+	rr = s.do("POST", fmt.Sprintf("/instances/%d/complete", instance.ID), nil, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "complete body=%s", rr.Body.String())
+
+	var completeResp struct {
+		InstanceID  int64  `json:"instance_id"`
+		Status      string `json:"status"`
+		CompletedAt string `json:"completed_at"`
+	}
+	decodeResponse(t, rr, &completeResp)
+	assert.Equal(t, scheduleModel.InstanceStatusCompleted, completeResp.Status)
+	require.NotEmpty(t, completeResp.CompletedAt)
+
+	// --- Step 7: assert complete marked the no-show absent -----------------
+	instStudents = fetchInstanceStudents(t, s, instance.ID)
+	byStudent = map[int64]*scheduleModel.InstanceStudent{}
+	for i := range instStudents {
+		byStudent[instStudents[i].StudentID] = &instStudents[i]
+	}
+	assert.Equal(t, scheduleModel.AttendanceStatusPresent, byStudent[student1.ID].Status,
+		"student1 stays present (B10 monotonicity)")
+	assert.Equal(t, scheduleModel.AttendanceStatusPresent, byStudent[student2.ID].Status,
+		"student2 stays present")
+	assert.Equal(t, scheduleModel.AttendanceStatusAbsent, byStudent[student3.ID].Status,
+		"student3 flips expected → absent on complete (B11 fix)")
+
+	// --- Step 8: student day report for each student ----------------------
+	for _, studentID := range []int64{student1.ID, student2.ID, student3.ID} {
+		path := fmt.Sprintf("/student/%d/day?date=%s", studentID, fromS)
+		rr = s.do("GET", path, nil, primaryAdminClaims())
+		require.Equal(t, http.StatusOK, rr.Code,
+			"/student/%d/day body=%s", studentID, rr.Body.String())
+
+		var dayResp struct {
+			StudentID int64 `json:"student_id"`
+			Instances []struct {
+				ID         int64 `json:"id"`
+				Status     string
+				Attendance struct {
+					Status      string
+					IsUnplanned bool `json:"is_unplanned"`
+				}
+			}
+		}
+		decodeResponse(t, rr, &dayResp)
+		require.Len(t, dayResp.Instances, 1, "student %d day: exactly one instance", studentID)
+		entry := dayResp.Instances[0]
+		assert.Equal(t, instance.ID, entry.ID)
+		assert.Equal(t, scheduleModel.InstanceStatusCompleted, entry.Status)
+		assert.False(t, entry.Attendance.IsUnplanned)
+
+		expected := scheduleModel.AttendanceStatusPresent
+		if studentID == student3.ID {
+			expected = scheduleModel.AttendanceStatusAbsent
+		}
+		assert.Equal(t, expected, entry.Attendance.Status,
+			"student %d expected attendance=%s", studentID, expected)
+	}
+
+	// --- Step 9: tenant isolation -----------------------------------------
+	rr = s.do("GET", fmt.Sprintf("/student/%d/day?date=%s", student1.ID, fromS), nil, secondaryAdminClaims())
+	assert.Equal(t, http.StatusNotFound, rr.Code,
+		"secondary tenant must not see primary's student (got %d: %s)", rr.Code, rr.Body.String())
+}
+
+// fetchOneInstance fetches the single materialized instance for (template, date).
+func fetchOneInstance(t *testing.T, s *scenario, templateID int64, date time.Time) *scheduleModel.ActivityInstance {
+	t.Helper()
+	var inst scheduleModel.ActivityInstance
+	err := s.db.NewSelect().
+		Model(&inst).
+		ModelTableExpr(`schedule.activity_instances AS "activity_instance"`).
+		Where(`"activity_instance".activity_group_id = ?`, templateID).
+		Where(`"activity_instance".date = ?`, date.UTC().Truncate(24*time.Hour)).
+		Where(`"activity_instance".tenant_id = ?`, primaryTenantID).
+		Scan(s.tenantCtx())
+	require.NoError(t, err, "fetch instance for template %d on %s", templateID, date.Format("2006-01-02"))
+	return &inst
+}
+
+// fetchInstanceStudents loads all instance_students rows for an instance.
+func fetchInstanceStudents(t *testing.T, s *scenario, instanceID int64) []scheduleModel.InstanceStudent {
+	t.Helper()
+	var rows []scheduleModel.InstanceStudent
+	err := s.db.NewSelect().
+		Model(&rows).
+		ModelTableExpr(`schedule.instance_students AS "instance_student"`).
+		Where(`"instance_student".instance_id = ?`, instanceID).
+		Where(`"instance_student".tenant_id = ?`, primaryTenantID).
+		Scan(s.tenantCtx())
+	require.NoError(t, err, "fetch instance_students for %d", instanceID)
+	return rows
+}
+
+// countInstanceStaff returns the number of instance_staff rows.
+func countInstanceStaff(t *testing.T, s *scenario, instanceID int64) int {
+	t.Helper()
+	n, err := s.db.NewSelect().
+		Model((*scheduleModel.InstanceStaff)(nil)).
+		ModelTableExpr(`schedule.instance_staff AS "instance_staff"`).
+		Where(`"instance_staff".instance_id = ?`, instanceID).
+		Where(`"instance_staff".tenant_id = ?`, primaryTenantID).
+		Count(s.tenantCtx())
+	require.NoError(t, err, "count instance_staff for %d", instanceID)
+	return n
+}
+
+// checkInStudent creates a visit through the real active service, mirroring
+// what a PyrePortal check-in does (minus the HTTP layer). The attendance-sync
+// mirror (B10) runs as a side effect and flips instance_students.status.
+func checkInStudent(t *testing.T, s *scenario, studentID, activeGroupID int64, staff *usersModel.Staff) {
+	t.Helper()
+	// Materialize a web-manual device so we have a deviceID to attribute
+	// the visit to. Matches what the web check-in path does.
+	dev := testpkg.EnsureWebManualDevice(t, s.db)
+
+	ctx := context.WithValue(s.tenantCtx(), device.CtxDevice, dev)
+	ctx = context.WithValue(ctx, device.CtxStaff, staff)
+
+	visit := &activeModel.Visit{
+		StudentID:     studentID,
+		ActiveGroupID: activeGroupID,
+		EntryTime:     time.Now(),
+	}
+	err := s.factory.Active.CreateVisit(ctx, visit)
+	require.NoError(t, err, "CreateVisit for student %d", studentID)
+}

--- a/backend/test/e2e/timetable/flow_b_cancel_conflicts_test.go
+++ b/backend/test/e2e/timetable/flow_b_cancel_conflicts_test.go
@@ -1,0 +1,266 @@
+package e2e_timetable
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// TestFlowB_CancelAndExceptionConflicts covers the admin "aktivitaet faellt
+// aus" workflow:
+//   - Materialize creates an instance + 3 instance_students (expected).
+//   - Admin adds a `cancelled` exception for that date. The /exception-conflicts
+//     endpoint surfaces two warnings (for students with arrival plans), and
+//     skips the student with an explicit arrival absence.
+//   - Swap in a `modified` exception with an earlier start_time; the endpoint
+//     reports `modified_instance_time_mismatch` for arriving students.
+//
+// Tenant-isolation: the neighbor tenant sees an empty conflict list.
+// Query-budget: ≤ 22 queries per B13.
+func TestFlowB_CancelAndExceptionConflicts(t *testing.T) {
+	s := newScenario(t)
+	defer s.teardown()
+
+	// --- Setup: target Monday at 13:00–14:00 -------------------------------
+	target := nextWeekday(time.Now().UTC(), 1, 7) // Mon, >=7 days out
+	fromS := target.Format("2006-01-02")
+
+	s.createActivePeriod(fmt.Sprintf("E2E-Flow-B-%d", time.Now().UnixNano()), target)
+
+	room := testpkg.CreateTestRoom(t, s.db, "FlowB-Room")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupTableRecords(t, s.db, "facilities.rooms", room.ID)
+	})
+
+	staff1 := testpkg.CreateTestStaff(t, s.db, "FlowB", "Staff1")
+	staff2 := testpkg.CreateTestStaff(t, s.db, "FlowB", "Staff2")
+	alice := testpkg.CreateTestStudent(t, s.db, "Alice", "FlowB", "3a")
+	bob := testpkg.CreateTestStudent(t, s.db, "Bob", "FlowB", "3a")
+	cleo := testpkg.CreateTestStudent(t, s.db, "Cleo", "FlowB", "3a")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupStaffFixtures(t, s.db, staff1.ID, staff2.ID)
+		testpkg.CleanupTableRecords(t, s.db, "users.students", alice.ID, bob.ID, cleo.ID)
+	})
+
+	tmpl := s.buildTemplate(templateSpec{
+		name:       "Lesen-AG",
+		weekday:    1, // Monday
+		startHHMM:  "13:00",
+		endHHMM:    "14:00",
+		roomID:     room.ID,
+		staffIDs:   []int64{staff1.ID, staff2.ID},
+		studentIDs: []int64{alice.ID, bob.ID, cleo.ID},
+	})
+
+	// Arrival schedules for Monday: alice + bob arrive 12:50. Cleo has an
+	// arrival exception saying she won't come at all (absence).
+	testpkg.CreateTestArrivalSchedule(t, s.db, alice.ID, 1, staff1.ID, "12:50")
+	testpkg.CreateTestArrivalSchedule(t, s.db, bob.ID, 1, staff1.ID, "12:50")
+	testpkg.CreateTestArrivalException(t, s.db, cleo.ID, target, staff1.ID, "", "krank")
+	// Arrival-schedules/exceptions are captured by teardown via the
+	// scenario's cleanupOrder; no explicit registerCleanup needed because
+	// rows belong to the students we delete via users.students cascade would
+	// not cover — but the teardown DELETE-by-ID loop targets exactly these
+	// tables. Explicit registration keeps things tidy.
+	s.registerArrivalFixtures(t)
+
+	// --- Step 1: materialize -----------------------------------------------
+	matReq := map[string]any{"from_date": fromS, "to_date": fromS}
+	rr := s.do("POST", "/materialize", matReq, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "materialize body=%s", rr.Body.String())
+
+	var matResp struct {
+		InstancesCreated        int `json:"instances_created"`
+		InstanceStudentsCreated int `json:"instance_students_created"`
+	}
+	decodeResponse(t, rr, &matResp)
+	require.Equal(t, 1, matResp.InstancesCreated)
+	require.Equal(t, 3, matResp.InstanceStudentsCreated)
+
+	instance := fetchOneInstance(t, s, tmpl.group.ID, target)
+	s.registerCleanup("schedule.activity_instances", instance.ID)
+
+	// --- Step 2: insert cancelled exception --------------------------------
+	cancelledExc := &scheduleModel.ActivityException{
+		ActivityGroupID: tmpl.group.ID,
+		ExceptionDate:   target.UTC().Truncate(24 * time.Hour),
+		ExceptionType:   scheduleModel.ActivityExceptionCancelled,
+		Reason:          strPtr("Heizung kaputt"),
+	}
+	cancelledExc.SetTenantID(primaryTenantID)
+	_, err := s.db.NewInsert().
+		Model(cancelledExc).
+		ModelTableExpr(`schedule.activity_exceptions`).
+		Exec(s.tenantCtx())
+	require.NoError(t, err, "insert cancelled exception")
+	s.registerCleanup("schedule.activity_exceptions", cancelledExc.ID)
+
+	// --- Step 3: re-materialize — skipped_exception, no new instance -------
+	rr = s.do("POST", "/materialize", matReq, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "rematerialize body=%s", rr.Body.String())
+
+	var matResp2 struct {
+		InstancesCreated           int `json:"instances_created"`
+		CandidatesSkippedExisting  int `json:"candidates_skipped_existing"`
+		CandidatesSkippedException int `json:"candidates_skipped_exception"`
+	}
+	decodeResponse(t, rr, &matResp2)
+	assert.Equal(t, 0, matResp2.InstancesCreated, "no new instance created")
+	// Empirical behaviour (WP-B8): the materialization service checks
+	// exceptions BEFORE existing-row dedupe, so a cancelled exception
+	// short-circuits the candidate and counts as skipped_exception even
+	// when a planned instance already exists for that date. The existing
+	// instance itself stays in place — the next steps operate on it.
+	assert.Equal(t, 1, matResp2.CandidatesSkippedException,
+		"cancelled exception skips the candidate even with an existing planned instance")
+	assert.Equal(t, 0, matResp2.CandidatesSkippedExisting)
+
+	// --- Step 4: /exception-conflicts surfaces cancelled warnings ---------
+	// Attach the query counter now so we measure a real request.
+	qc := &queryCounter{}
+	s.db.AddQueryHook(qc)
+	qc.reset()
+
+	path := fmt.Sprintf("/exception-conflicts?date=%s&date_to=%s", fromS, fromS)
+	rr = s.do("GET", path, nil, primaryAdminClaims())
+	cancelledQueryCount := qc.get()
+
+	require.Equal(t, http.StatusOK, rr.Code, "exception-conflicts body=%s", rr.Body.String())
+
+	var conflictsResp struct {
+		Conflicts []struct {
+			Kind               string
+			Date               string
+			ActivityGroupID    int64  `json:"activity_group_id"`
+			InstanceID         int64  `json:"instance_id"`
+			StudentID          int64  `json:"student_id"`
+			ExpectedArrival    string `json:"expected_arrival"`
+			ArrivalSource      string `json:"arrival_source"`
+			CancellationReason string `json:"cancellation_reason"`
+		}
+	}
+	decodeResponse(t, rr, &conflictsResp)
+
+	require.Len(t, conflictsResp.Conflicts, 2,
+		"alice + bob have arrival schedules → 2 warnings; cleo has explicit absence → suppressed")
+
+	studentsSeen := map[int64]bool{}
+	for _, c := range conflictsResp.Conflicts {
+		studentsSeen[c.StudentID] = true
+		assert.Equal(t, "cancelled_instance_with_scheduled_arrivals", c.Kind)
+		assert.Equal(t, "12:50", c.ExpectedArrival)
+		assert.Equal(t, "schedule", c.ArrivalSource)
+		assert.Equal(t, "Heizung kaputt", c.CancellationReason)
+		assert.Equal(t, instance.ID, c.InstanceID)
+	}
+	assert.True(t, studentsSeen[alice.ID], "alice must be in warnings")
+	assert.True(t, studentsSeen[bob.ID], "bob must be in warnings")
+	assert.False(t, studentsSeen[cleo.ID], "cleo (explicit absence) must NOT be in warnings")
+
+	// Query-budget — PR #1304 guarantees ≤ 22 queries regardless of fan-out.
+	// We include the TenantTxMiddleware SET LOCAL overhead in this count;
+	// the production repo budget is ≤ 22 for the handler body.
+	assert.LessOrEqual(t, cancelledQueryCount, int64(22),
+		"/exception-conflicts (cancelled) query count %d exceeds budget of 22", cancelledQueryCount)
+
+	// --- Step 5: swap in a modified exception ------------------------------
+	_, err = s.db.NewDelete().
+		Model((*scheduleModel.ActivityException)(nil)).
+		ModelTableExpr(`schedule.activity_exceptions`).
+		Where("id = ?", cancelledExc.ID).
+		Exec(s.tenantCtx())
+	require.NoError(t, err, "delete cancelled exception")
+
+	modifiedStart := parseHHMM(t, "12:30")
+	modifiedExc := &scheduleModel.ActivityException{
+		ActivityGroupID: tmpl.group.ID,
+		ExceptionDate:   target.UTC().Truncate(24 * time.Hour),
+		ExceptionType:   scheduleModel.ActivityExceptionModified,
+		StartTime:       &modifiedStart,
+		Reason:          strPtr("Fruehschluss"),
+	}
+	modifiedExc.SetTenantID(primaryTenantID)
+	_, err = s.db.NewInsert().
+		Model(modifiedExc).
+		ModelTableExpr(`schedule.activity_exceptions`).
+		Exec(s.tenantCtx())
+	require.NoError(t, err, "insert modified exception")
+	s.registerCleanup("schedule.activity_exceptions", modifiedExc.ID)
+
+	qc.reset()
+	rr = s.do("GET", path, nil, primaryAdminClaims())
+	modifiedQueryCount := qc.get()
+	require.Equal(t, http.StatusOK, rr.Code, "exception-conflicts(modified) body=%s", rr.Body.String())
+
+	var modResp struct {
+		Conflicts []struct {
+			Kind              string
+			StudentID         int64  `json:"student_id"`
+			ExpectedArrival   string `json:"expected_arrival"`
+			ArrivalSource     string `json:"arrival_source"`
+			ModifiedStartTime string `json:"modified_start_time"`
+			OriginalStartTime string `json:"original_start_time"`
+		}
+	}
+	decodeResponse(t, rr, &modResp)
+	require.Len(t, modResp.Conflicts, 2,
+		"alice + bob arrive 12:50 > modified 12:30 → 2 modified-mismatch warnings")
+
+	studentsSeen = map[int64]bool{}
+	for _, c := range modResp.Conflicts {
+		studentsSeen[c.StudentID] = true
+		assert.Equal(t, "modified_instance_time_mismatch", c.Kind)
+		assert.Equal(t, "12:50", c.ExpectedArrival)
+		assert.Equal(t, "12:30", c.ModifiedStartTime)
+		assert.Equal(t, "13:00", c.OriginalStartTime,
+			"template still schedules at 13:00 → original_start_time surfaces")
+	}
+	assert.True(t, studentsSeen[alice.ID])
+	assert.True(t, studentsSeen[bob.ID])
+	assert.False(t, studentsSeen[cleo.ID], "cleo is absent → modified mismatch suppressed too")
+
+	assert.LessOrEqual(t, modifiedQueryCount, int64(22),
+		"/exception-conflicts (modified) query count %d exceeds budget of 22", modifiedQueryCount)
+
+	// --- Step 6: tenant isolation -----------------------------------------
+	rr = s.do("GET", path, nil, secondaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "tenant2 body=%s", rr.Body.String())
+	var t2Resp struct {
+		Conflicts []struct {
+			Kind string
+		}
+	}
+	decodeResponse(t, rr, &t2Resp)
+	assert.Empty(t, t2Resp.Conflicts, "secondary tenant must see no conflicts from primary")
+}
+
+// registerArrivalFixtures adds the three arrival-schedule/exception tables
+// to the scenario cleanup plan. The helpers already cover the dedicated
+// schedule.student_arrival_* tables in cleanupOrder, but rows created via
+// testpkg.CreateTestArrivalSchedule don't go through registerCleanup — they
+// inherit tenant_id=1 and get picked up by table-level cleanup only if we
+// remember the IDs. Simpler: do a targeted DELETE at teardown.
+func (s *scenario) registerArrivalFixtures(_ *testing.T) {
+	s.extraCleanup = append(s.extraCleanup, func() {
+		ctx := s.tenantCtx()
+		_, _ = s.db.NewDelete().
+			TableExpr("schedule.student_arrival_schedules").
+			Where("tenant_id = ?", primaryTenantID).
+			Where("created_at > NOW() - INTERVAL '5 minutes'").
+			Exec(ctx)
+		_, _ = s.db.NewDelete().
+			TableExpr("schedule.student_arrival_exceptions").
+			Where("tenant_id = ?", primaryTenantID).
+			Where("created_at > NOW() - INTERVAL '5 minutes'").
+			Exec(ctx)
+	})
+}
+
+func strPtr(s string) *string { return &s }

--- a/backend/test/e2e/timetable/flow_c_gaps_substitute_test.go
+++ b/backend/test/e2e/timetable/flow_c_gaps_substitute_test.go
@@ -1,0 +1,296 @@
+package e2e_timetable
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// TestFlowC_GapsAndSubstitute exercises the Krankmeldung scenario:
+// a staff member calls in sick on the day of two concurrent instances,
+// the admin swaps in a substitute across all affected instances, a follow-up
+// conflict attempt is rejected atomically (no partial writes), and /gaps
+// surfaces an unrelated instance with zero non-absent staff.
+func TestFlowC_GapsAndSubstitute(t *testing.T) {
+	s := newScenario(t)
+	defer s.teardown()
+
+	// Pick a Tuesday ≥ 7 days out (must be today-or-future for /gaps and /substitute).
+	target := nextWeekday(time.Now().UTC(), 2, 7)
+	fromS := target.Format("2006-01-02")
+
+	s.createActivePeriod(fmt.Sprintf("E2E-Flow-C-%d", time.Now().UnixNano()), target)
+
+	room := testpkg.CreateTestRoom(t, s.db, "FlowC-Room")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupTableRecords(t, s.db, "facilities.rooms", room.ID)
+	})
+
+	staff1 := testpkg.CreateTestStaff(t, s.db, "FlowC", "S1-Primary")
+	staff2 := testpkg.CreateTestStaff(t, s.db, "FlowC", "S2-Co")
+	staff3 := testpkg.CreateTestStaff(t, s.db, "FlowC", "S3-Sub")
+	staff4 := testpkg.CreateTestStaff(t, s.db, "FlowC", "S4-Other")
+	staff5 := testpkg.CreateTestStaff(t, s.db, "FlowC", "S5-GapOnly")
+	student := testpkg.CreateTestStudent(t, s.db, "Anna", "FlowC", "3a")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupStaffFixtures(t, s.db, staff1.ID, staff2.ID, staff3.ID, staff4.ID, staff5.ID)
+		testpkg.CleanupTableRecords(t, s.db, "users.students", student.ID)
+	})
+
+	// Two templates on the same weekday at different times.
+	tmpl1 := s.buildTemplate(templateSpec{
+		name:       "FlowC-AG1",
+		weekday:    2,
+		startHHMM:  "10:00",
+		endHHMM:    "11:00",
+		roomID:     room.ID,
+		staffIDs:   []int64{staff1.ID, staff2.ID},
+		studentIDs: []int64{student.ID},
+	})
+	tmpl2 := s.buildTemplate(templateSpec{
+		name:       "FlowC-AG2",
+		weekday:    2,
+		startHHMM:  "14:00",
+		endHHMM:    "15:00",
+		roomID:     room.ID,
+		staffIDs:   []int64{staff1.ID, staff2.ID},
+		studentIDs: []int64{student.ID},
+	})
+
+	// --- Step 1: materialize both templates --------------------------------
+	matReq := map[string]any{"from_date": fromS, "to_date": fromS}
+	rr := s.do("POST", "/materialize", matReq, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "materialize body=%s", rr.Body.String())
+	var matResp struct {
+		InstancesCreated int `json:"instances_created"`
+	}
+	decodeResponse(t, rr, &matResp)
+	require.Equal(t, 2, matResp.InstancesCreated)
+
+	inst1 := fetchOneInstance(t, s, tmpl1.group.ID, target)
+	inst2 := fetchOneInstance(t, s, tmpl2.group.ID, target)
+	s.registerCleanup("schedule.activity_instances", inst1.ID, inst2.ID)
+
+	// --- Step 2: start inst1 so we can assert active.group_supervisors rotate
+	rr = s.do("POST", fmt.Sprintf("/instances/%d/start", inst1.ID), nil, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "start body=%s", rr.Body.String())
+
+	var startResp struct {
+		ActiveGroupID int64 `json:"active_group_id"`
+		Status        string
+	}
+	decodeResponse(t, rr, &startResp)
+	require.Equal(t, scheduleModel.InstanceStatusActive, startResp.Status)
+	require.NotZero(t, startResp.ActiveGroupID)
+
+	// --- Step 3: /gaps — baseline should be empty --------------------------
+	qc := &queryCounter{}
+	s.db.AddQueryHook(qc)
+	qc.reset()
+
+	rr = s.do("GET", fmt.Sprintf("/gaps?date=%s&date_to=%s", fromS, fromS), nil, primaryAdminClaims())
+	gapsQueryCount := qc.get()
+	require.Equal(t, http.StatusOK, rr.Code, "gaps body=%s", rr.Body.String())
+
+	var gapsResp1 struct {
+		Gaps []struct {
+			InstanceID int64 `json:"instance_id"`
+		}
+	}
+	decodeResponse(t, rr, &gapsResp1)
+	assert.Empty(t, gapsResp1.Gaps, "baseline: both instances have 2 non-absent staff")
+
+	t.Logf("query-budget /gaps baseline: %d queries (PR #1303 target ≤ 2)", gapsQueryCount)
+
+	// --- Step 4: substitute S1 → S3 across both instances -----------------
+	subReq := map[string]any{
+		"absent_staff_id":     staff1.ID,
+		"substitute_staff_id": staff3.ID,
+		"date":                fromS,
+	}
+	rr = s.do("POST", "/substitute", subReq, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "substitute body=%s", rr.Body.String())
+
+	var subResp struct {
+		AbsentStaffID     int64 `json:"absent_staff_id"`
+		SubstituteStaffID int64 `json:"substitute_staff_id"`
+		AffectedInstances []struct {
+			InstanceID int64  `json:"instance_id"`
+			Action     string `json:"action"`
+		} `json:"affected_instances"`
+	}
+	decodeResponse(t, rr, &subResp)
+	require.Len(t, subResp.AffectedInstances, 2, "both instances touched")
+	for _, ai := range subResp.AffectedInstances {
+		assert.Equal(t, "substituted", ai.Action, "instance %d", ai.InstanceID)
+	}
+
+	// --- Step 5: DB-assert the staff mutations -----------------------------
+	// For each instance: the S1 row is_absent=true, a new S3 row
+	// is_substitute=true.
+	for _, instID := range []int64{inst1.ID, inst2.ID} {
+		rows := fetchInstanceStaff(t, s, instID)
+		var s1, s3 *scheduleModel.InstanceStaff
+		for i := range rows {
+			switch rows[i].StaffID {
+			case staff1.ID:
+				s1 = &rows[i]
+			case staff3.ID:
+				s3 = &rows[i]
+			}
+		}
+		require.NotNil(t, s1, "instance %d: S1 row still present", instID)
+		require.NotNil(t, s3, "instance %d: S3 substitute row inserted", instID)
+		assert.True(t, s1.IsAbsent, "S1 flipped to is_absent=true on instance %d", instID)
+		assert.False(t, s1.IsSubstitute, "S1 original row stays is_substitute=false")
+		assert.True(t, s3.IsSubstitute, "S3 new row is_substitute=true on instance %d", instID)
+		assert.False(t, s3.IsAbsent)
+	}
+
+	// For inst1 (active): active.group_supervisors was rotated.
+	supervisors := fetchGroupSupervisors(t, s, startResp.ActiveGroupID)
+	var supS1, supS3 *activeModel.GroupSupervisor
+	for i := range supervisors {
+		switch supervisors[i].StaffID {
+		case staff1.ID:
+			supS1 = &supervisors[i]
+		case staff3.ID:
+			supS3 = &supervisors[i]
+		}
+	}
+	require.NotNil(t, supS1, "original S1 supervisor row on active group")
+	assert.NotNil(t, supS1.EndDate, "S1 supervisor end_date is set after substitute")
+	require.NotNil(t, supS3, "S3 supervisor row inserted on active group")
+	assert.Nil(t, supS3.EndDate, "S3 supervisor end_date is NULL (currently serving)")
+
+	// --- Step 6: substitute conflict — different substitute for same absent.
+	// Expected: 409 substitute_conflict, NO writes (dry-run-first).
+	preconflictStaffRows := fetchInstanceStaff(t, s, inst1.ID)
+	preconflictCount := len(preconflictStaffRows)
+
+	conflictReq := map[string]any{
+		"absent_staff_id":     staff1.ID,
+		"substitute_staff_id": staff4.ID,
+		"date":                fromS,
+	}
+	rr = s.do("POST", "/substitute", conflictReq, primaryAdminClaims())
+	require.Equal(t, http.StatusConflict, rr.Code,
+		"second substitute with different sub expected 409 (got %d: %s)", rr.Code, rr.Body.String())
+
+	// DB-assert: no S4 row added anywhere (atomicity).
+	for _, instID := range []int64{inst1.ID, inst2.ID} {
+		rows := fetchInstanceStaff(t, s, instID)
+		for _, r := range rows {
+			assert.NotEqual(t, staff4.ID, r.StaffID,
+				"conflict attempt must not insert S4 row on instance %d (dry-run-first atomicity)", instID)
+		}
+	}
+	assert.Equal(t, preconflictCount, len(fetchInstanceStaff(t, s, inst1.ID)),
+		"instance_staff row count on inst1 must be unchanged after 409")
+
+	// --- Step 7: gap scenario — spontaneous instance with only absent staff.
+	// Direct fixture: planned instance with two instance_staff rows, both
+	// is_absent=true. Simulates "nobody uncovered this before /gaps was
+	// queried."
+	startFixture := parseHHMMLocal(t, "16:00")
+	endFixture := parseHHMMLocal(t, "17:00")
+	gapInstance := &scheduleModel.ActivityInstance{
+		Date:          target.UTC().Truncate(24 * time.Hour),
+		Title:         "FlowC-Gap-Instance",
+		StartTime:     startFixture,
+		EndTime:       endFixture,
+		RoomID:        room.ID,
+		Status:        scheduleModel.InstanceStatusPlanned,
+		IsSpontaneous: true,
+	}
+	gapInstance.SetTenantID(primaryTenantID)
+	_, err := s.db.NewInsert().Model(gapInstance).
+		ModelTableExpr(`schedule.activity_instances`).Exec(s.tenantCtx())
+	require.NoError(t, err, "insert gap instance")
+	s.registerCleanup("schedule.activity_instances", gapInstance.ID)
+
+	// Both staff on this instance are absent → qualifies as a gap.
+	for _, stid := range []int64{staff1.ID, staff5.ID} {
+		row := &scheduleModel.InstanceStaff{
+			InstanceID: gapInstance.ID,
+			StaffID:    stid,
+			IsAbsent:   true,
+		}
+		row.SetTenantID(primaryTenantID)
+		_, err := s.db.NewInsert().Model(row).
+			ModelTableExpr(`schedule.instance_staff`).Exec(s.tenantCtx())
+		require.NoError(t, err, "insert absent instance_staff for gap instance")
+	}
+
+	// --- Step 8: /gaps must now surface the gap instance -------------------
+	qc.reset()
+	rr = s.do("GET", fmt.Sprintf("/gaps?date=%s&date_to=%s", fromS, fromS), nil, primaryAdminClaims())
+	gapsQueryCount2 := qc.get()
+	require.Equal(t, http.StatusOK, rr.Code, "gaps(with-gap) body=%s", rr.Body.String())
+
+	var gapsResp2 struct {
+		Gaps []struct {
+			InstanceID         int64  `json:"instance_id"`
+			Title              string `json:"title"`
+			AssignedStaffCount int    `json:"assigned_staff_count"`
+			AbsentStaffCount   int    `json:"absent_staff_count"`
+			Status             string `json:"status"`
+		}
+	}
+	decodeResponse(t, rr, &gapsResp2)
+	require.Len(t, gapsResp2.Gaps, 1, "exactly one gap expected")
+	g := gapsResp2.Gaps[0]
+	assert.Equal(t, gapInstance.ID, g.InstanceID)
+	// BUG-FINDING (E2E-C1): per PR #1303 docs the response should carry
+	// `assigned_staff_count=2, absent_staff_count=2` for this input. The
+	// handler hardcodes assigned_staff_count=0 (gaps.go:168) — the comment
+	// there misreads the invariant: "nonAbsentCounts==0" means "no NON-absent
+	// staff", not "no staff at all". Tracked in E2E_FINDINGS.md.
+	assert.Equal(t, 2, g.AssignedStaffCount,
+		"assigned_staff_count must reflect total assigned staff (PR #1303 contract); got 0 — see E2E_FINDINGS.md#E2E-C1")
+	assert.Equal(t, 2, g.AbsentStaffCount, "all two are absent")
+	assert.Equal(t, scheduleModel.InstanceStatusPlanned, g.Status)
+
+	t.Logf("query-budget /gaps (with 1 gap over 3 instances): %d queries (TenantTxMiddleware overhead included; PR target ≤ 2 was handler-queries only)", gapsQueryCount2)
+
+	// --- Step 9: tenant isolation --------------------------------------------
+	// Secondary tenant attempting to substitute this tenant's staff: 404
+	// because FindByID returns no row under the tenant-2 tx.
+	rr = s.do("POST", "/substitute", subReq, secondaryAdminClaims())
+	assert.Equal(t, http.StatusNotFound, rr.Code,
+		"secondary tenant must not substitute primary's staff (got %d: %s)", rr.Code, rr.Body.String())
+}
+
+// fetchInstanceStaff returns all instance_staff rows for an instance.
+func fetchInstanceStaff(t *testing.T, s *scenario, instanceID int64) []scheduleModel.InstanceStaff {
+	t.Helper()
+	var rows []scheduleModel.InstanceStaff
+	err := s.db.NewSelect().Model(&rows).
+		ModelTableExpr(`schedule.instance_staff AS "instance_staff"`).
+		Where(`"instance_staff".instance_id = ?`, instanceID).
+		Where(`"instance_staff".tenant_id = ?`, primaryTenantID).
+		Scan(s.tenantCtx())
+	require.NoError(t, err, "fetch instance_staff for %d", instanceID)
+	return rows
+}
+
+// fetchGroupSupervisors returns all supervisor rows for an active.group.
+func fetchGroupSupervisors(t *testing.T, s *scenario, activeGroupID int64) []activeModel.GroupSupervisor {
+	t.Helper()
+	var rows []activeModel.GroupSupervisor
+	err := s.db.NewSelect().Model(&rows).
+		ModelTableExpr(`active.group_supervisors AS "group_supervisor"`).
+		Where(`"group_supervisor".group_id = ?`, activeGroupID).
+		Where(`"group_supervisor".tenant_id = ?`, primaryTenantID).
+		Scan(s.tenantCtx())
+	require.NoError(t, err, "fetch group_supervisors for %d", activeGroupID)
+	return rows
+}

--- a/backend/test/e2e/timetable/flow_d_replan_week_test.go
+++ b/backend/test/e2e/timetable/flow_d_replan_week_test.go
@@ -1,0 +1,187 @@
+package e2e_timetable
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// TestFlowD_ReplanWeekMergeStrategy covers the "Admin aendert Template
+// nachtraeglich" workflow:
+//   - 4 materialized instances plus 1 spontaneous instance on the same day.
+//   - One starts (active), one starts+completes, one gets cancelled, one
+//     stays planned. Spontaneous instance is planned + is_spontaneous=true.
+//   - POST /instances/re-plan-week deletes only planned + non-spontaneous
+//     rows and re-materializes from templates. Active/completed/cancelled/
+//     spontaneous instances survive untouched.
+func TestFlowD_ReplanWeekMergeStrategy(t *testing.T) {
+	s := newScenario(t)
+	defer s.teardown()
+
+	target := nextWeekday(time.Now().UTC(), 4, 7) // Thursday, >=7 days out
+	fromS := target.Format("2006-01-02")
+
+	s.createActivePeriod(fmt.Sprintf("E2E-Flow-D-%d", time.Now().UnixNano()), target)
+
+	room := testpkg.CreateTestRoom(t, s.db, "FlowD-Room")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupTableRecords(t, s.db, "facilities.rooms", room.ID)
+	})
+
+	staff := testpkg.CreateTestStaff(t, s.db, "FlowD", "Staff")
+	student := testpkg.CreateTestStudent(t, s.db, "Dora", "FlowD", "3a")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupStaffFixtures(t, s.db, staff.ID)
+		testpkg.CleanupTableRecords(t, s.db, "users.students", student.ID)
+	})
+
+	// Four templates at distinct times on Thursday.
+	tmpls := make([]*templateFixture, 4)
+	for i, slot := range []struct {
+		name  string
+		start string
+		end   string
+	}{
+		{"D-Active", "08:00", "09:00"},
+		{"D-Completed", "10:00", "11:00"},
+		{"D-Cancelled", "12:00", "13:00"},
+		{"D-Planned", "14:00", "15:00"},
+	} {
+		tmpls[i] = s.buildTemplate(templateSpec{
+			name:       slot.name,
+			weekday:    4,
+			startHHMM:  slot.start,
+			endHHMM:    slot.end,
+			roomID:     room.ID,
+			staffIDs:   []int64{staff.ID},
+			studentIDs: []int64{student.ID},
+		})
+	}
+
+	// --- Step 1: materialize the four templates ----------------------------
+	matReq := map[string]any{"from_date": fromS, "to_date": fromS}
+	rr := s.do("POST", "/materialize", matReq, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "materialize body=%s", rr.Body.String())
+	var matResp struct {
+		InstancesCreated int `json:"instances_created"`
+	}
+	decodeResponse(t, rr, &matResp)
+	require.Equal(t, 4, matResp.InstancesCreated)
+
+	instActive := fetchOneInstance(t, s, tmpls[0].group.ID, target)
+	instCompleted := fetchOneInstance(t, s, tmpls[1].group.ID, target)
+	instCancelled := fetchOneInstance(t, s, tmpls[2].group.ID, target)
+	instPlanned := fetchOneInstance(t, s, tmpls[3].group.ID, target)
+	s.registerCleanup("schedule.activity_instances",
+		instActive.ID, instCompleted.ID, instCancelled.ID, instPlanned.ID)
+
+	// --- Step 2: drive the three lifecycle transitions ---------------------
+	rr = s.do("POST", fmt.Sprintf("/instances/%d/start", instActive.ID), nil, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "start active body=%s", rr.Body.String())
+
+	rr = s.do("POST", fmt.Sprintf("/instances/%d/start", instCompleted.ID), nil, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "start completed body=%s", rr.Body.String())
+	rr = s.do("POST", fmt.Sprintf("/instances/%d/complete", instCompleted.ID), nil, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "complete body=%s", rr.Body.String())
+
+	rr = s.do("POST", fmt.Sprintf("/instances/%d/cancel", instCancelled.ID), nil, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "cancel body=%s", rr.Body.String())
+
+	// --- Step 3: add a spontaneous instance (planned, is_spontaneous=true) -
+	startFixture := parseHHMMLocal(t, "16:00")
+	endFixture := parseHHMMLocal(t, "17:00")
+	spont := &scheduleModel.ActivityInstance{
+		Date:          target.UTC().Truncate(24 * time.Hour),
+		Title:         "D-Spontaneous",
+		StartTime:     startFixture,
+		EndTime:       endFixture,
+		RoomID:        room.ID,
+		Status:        scheduleModel.InstanceStatusPlanned,
+		IsSpontaneous: true,
+	}
+	spont.SetTenantID(primaryTenantID)
+	_, err := s.db.NewInsert().Model(spont).
+		ModelTableExpr(`schedule.activity_instances`).Exec(s.tenantCtx())
+	require.NoError(t, err, "insert spontaneous instance")
+	s.registerCleanup("schedule.activity_instances", spont.ID)
+
+	// Capture snapshots of the 4 preserved instances for post-replan compare.
+	beforeActive := reload(t, s, instActive.ID)
+	beforeCompleted := reload(t, s, instCompleted.ID)
+	beforeCancelled := reload(t, s, instCancelled.ID)
+	beforeSpont := reload(t, s, spont.ID)
+
+	require.Equal(t, scheduleModel.InstanceStatusActive, beforeActive.Status)
+	require.Equal(t, scheduleModel.InstanceStatusCompleted, beforeCompleted.Status)
+	require.Equal(t, scheduleModel.InstanceStatusCancelled, beforeCancelled.Status)
+	require.Equal(t, scheduleModel.InstanceStatusPlanned, beforeSpont.Status)
+	require.True(t, beforeSpont.IsSpontaneous)
+
+	// --- Step 4: re-plan the week -----------------------------------------
+	rr = s.do("POST", "/instances/re-plan-week", matReq, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "re-plan body=%s", rr.Body.String())
+
+	var replanResp struct {
+		DeletedInstances int `json:"deleted_instances"`
+		InstancesCreated int `json:"instances_created"`
+	}
+	decodeResponse(t, rr, &replanResp)
+	assert.Equal(t, 1, replanResp.DeletedInstances,
+		"only the planned non-spontaneous instance should be deleted")
+	assert.Equal(t, 1, replanResp.InstancesCreated,
+		"only one template is re-materialized (the one whose instance was deleted)")
+
+	// --- Step 5: protected instances must be unchanged ---------------------
+	afterActive := reload(t, s, instActive.ID)
+	afterCompleted := reload(t, s, instCompleted.ID)
+	afterCancelled := reload(t, s, instCancelled.ID)
+	afterSpont := reload(t, s, spont.ID)
+
+	assert.Equal(t, beforeActive.Status, afterActive.Status)
+	assert.Equal(t, beforeCompleted.Status, afterCompleted.Status)
+	assert.Equal(t, beforeCancelled.Status, afterCancelled.Status)
+	assert.Equal(t, beforeSpont.Status, afterSpont.Status)
+	assert.True(t, afterSpont.IsSpontaneous, "spontaneous instance survives untouched")
+
+	// The originally-planned instance (tmpls[3]) was deleted and recreated:
+	// its ID is new even though the template is unchanged.
+	newPlanned := fetchOneInstance(t, s, tmpls[3].group.ID, target)
+	assert.NotEqual(t, instPlanned.ID, newPlanned.ID,
+		"deleted-and-recreated gets a fresh ID")
+	assert.Equal(t, scheduleModel.InstanceStatusPlanned, newPlanned.Status)
+	s.registerCleanup("schedule.activity_instances", newPlanned.ID)
+
+	// --- Step 6: tenant isolation -----------------------------------------
+	// Secondary tenant re-plans their (empty) week. No primary data sees it,
+	// so deleted_instances stays zero.
+	rr = s.do("POST", "/instances/re-plan-week", matReq, secondaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "tenant2 body=%s", rr.Body.String())
+	var t2Resp struct {
+		DeletedInstances int `json:"deleted_instances"`
+		InstancesCreated int `json:"instances_created"`
+	}
+	decodeResponse(t, rr, &t2Resp)
+	assert.Equal(t, 0, t2Resp.DeletedInstances, "secondary tenant sees no primary instances")
+	assert.Equal(t, 0, t2Resp.InstancesCreated, "secondary tenant has no templates")
+}
+
+// reload fetches an activity_instance by ID, skipping a not-found error if
+// the row has been deleted (signalled by an empty struct return).
+func reload(t *testing.T, s *scenario, id int64) scheduleModel.ActivityInstance {
+	t.Helper()
+	var inst scheduleModel.ActivityInstance
+	err := s.db.NewSelect().Model(&inst).
+		ModelTableExpr(`schedule.activity_instances AS "activity_instance"`).
+		Where(`"activity_instance".id = ?`, id).
+		Where(`"activity_instance".tenant_id = ?`, primaryTenantID).
+		Scan(s.tenantCtx())
+	require.NoError(t, err, "reload instance %d", id)
+	return inst
+}

--- a/backend/test/e2e/timetable/flow_e_student_day_test.go
+++ b/backend/test/e2e/timetable/flow_e_student_day_test.go
@@ -1,0 +1,197 @@
+package e2e_timetable
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/auth/device"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// TestFlowE_StudentDayWithUnplannedVisit validates the student-day aggregation:
+//   - Student enrolled in instance X → attendance shows up via instance_students.
+//   - Student NOT enrolled in instance Y, but a visit exists → surfaces as
+//     `is_unplanned=true` via the active.visits join.
+//   - /student/{id}/week stays within the ≤12 query budget over 14 days.
+//   - Tenant isolation: secondary tenant → 404 on the student.
+func TestFlowE_StudentDayWithUnplannedVisit(t *testing.T) {
+	s := newScenario(t)
+	defer s.teardown()
+
+	// Pick a weekday >= 7 days out (materialize today-or-future rule).
+	target := nextWeekday(time.Now().UTC(), 5, 7) // Friday
+	fromS := target.Format("2006-01-02")
+
+	s.createActivePeriod(fmt.Sprintf("E2E-Flow-E-%d", time.Now().UnixNano()), target)
+
+	room := testpkg.CreateTestRoom(t, s.db, "FlowE-Room")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupTableRecords(t, s.db, "facilities.rooms", room.ID)
+	})
+
+	staff := testpkg.CreateTestStaff(t, s.db, "FlowE", "Staff")
+	studentA := testpkg.CreateTestStudent(t, s.db, "Alice", "FlowE", "3a")
+	studentB := testpkg.CreateTestStudent(t, s.db, "Bob", "FlowE", "3a")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupStaffFixtures(t, s.db, staff.ID)
+		testpkg.CleanupTableRecords(t, s.db, "users.students", studentA.ID, studentB.ID)
+	})
+
+	// Two templates on the target weekday. studentA is enrolled in both,
+	// studentB is enrolled only in tmplX.
+	tmplX := s.buildTemplate(templateSpec{
+		name:       "FlowE-X",
+		weekday:    5,
+		startHHMM:  "09:00",
+		endHHMM:    "10:00",
+		roomID:     room.ID,
+		staffIDs:   []int64{staff.ID},
+		studentIDs: []int64{studentA.ID, studentB.ID},
+	})
+	tmplY := s.buildTemplate(templateSpec{
+		name:       "FlowE-Y",
+		weekday:    5,
+		startHHMM:  "11:00",
+		endHHMM:    "12:00",
+		roomID:     room.ID,
+		staffIDs:   []int64{staff.ID},
+		studentIDs: []int64{studentA.ID}, // studentB NOT enrolled in Y
+	})
+	_ = tmplY
+
+	// --- Materialize + start both instances --------------------------------
+	matReq := map[string]any{"from_date": fromS, "to_date": fromS}
+	rr := s.do("POST", "/materialize", matReq, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "materialize body=%s", rr.Body.String())
+
+	instX := fetchOneInstance(t, s, tmplX.group.ID, target)
+	instY := fetchOneInstance(t, s, tmplY.group.ID, target)
+	s.registerCleanup("schedule.activity_instances", instX.ID, instY.ID)
+
+	startX := startInstance(t, s, instX.ID)
+	startY := startInstance(t, s, instY.ID)
+
+	// --- Visits: B attends X (enrolled); B also attends Y (NOT enrolled) ---
+	// studentA we don't touch — she stays `expected`.
+	dev := testpkg.EnsureWebManualDevice(t, s.db)
+	ctx := context.WithValue(s.tenantCtx(), device.CtxDevice, dev)
+	ctx = context.WithValue(ctx, device.CtxStaff, staff)
+
+	// First visit: B into X (enrolled) → flips instance_students to present.
+	v1 := &activeModel.Visit{
+		StudentID:     studentB.ID,
+		ActiveGroupID: startX.ActiveGroupID,
+		EntryTime:     time.Now(),
+	}
+	require.NoError(t, s.factory.Active.CreateVisit(ctx, v1), "visit B→X (enrolled)")
+
+	// End that visit, so B can enter the next active.group.
+	exit := time.Now().Add(time.Second)
+	v1.ExitTime = &exit
+	require.NoError(t, s.factory.Active.EndVisit(ctx, v1.ID), "end visit B→X")
+
+	// Second visit: B into Y (not enrolled) → surfaces as is_unplanned=true.
+	v2 := &activeModel.Visit{
+		StudentID:     studentB.ID,
+		ActiveGroupID: startY.ActiveGroupID,
+		EntryTime:     time.Now(),
+	}
+	require.NoError(t, s.factory.Active.CreateVisit(ctx, v2), "visit B→Y (unplanned)")
+
+	// --- /student/{B}/day → expect both instances surfaced ----------------
+	rr = s.do("GET", fmt.Sprintf("/student/%d/day?date=%s", studentB.ID, fromS), nil, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "day body=%s", rr.Body.String())
+
+	var dayResp struct {
+		Instances []struct {
+			ID         int64 `json:"id"`
+			Attendance struct {
+				Status      string
+				IsUnplanned bool `json:"is_unplanned"`
+			}
+		}
+	}
+	decodeResponse(t, rr, &dayResp)
+	require.Len(t, dayResp.Instances, 2, "B should see 2 instances on this day (enrolled X + unplanned Y)")
+
+	byID := map[int64]bool{}
+	for _, inst := range dayResp.Instances {
+		switch inst.ID {
+		case instX.ID:
+			byID[inst.ID] = true
+			assert.Equal(t, scheduleModel.AttendanceStatusPresent, inst.Attendance.Status,
+				"B on X: present via enrollment check-in")
+			assert.False(t, inst.Attendance.IsUnplanned, "X was enrolled, so not unplanned")
+		case instY.ID:
+			byID[inst.ID] = true
+			assert.Equal(t, scheduleModel.AttendanceStatusPresent, inst.Attendance.Status,
+				"B on Y: present via unplanned visit")
+			assert.True(t, inst.Attendance.IsUnplanned, "Y was NOT enrolled → unplanned")
+		}
+	}
+	assert.True(t, byID[instX.ID], "X must appear in B's day")
+	assert.True(t, byID[instY.ID], "Y must appear in B's day")
+
+	// --- Query-budget on /week over 14 days -------------------------------
+	qc := &queryCounter{}
+	s.db.AddQueryHook(qc)
+	qc.reset()
+
+	weekFrom := target.Format("2006-01-02")
+	weekTo := target.AddDate(0, 0, 13).Format("2006-01-02")
+	path := fmt.Sprintf("/student/%d/week?from=%s&to=%s", studentB.ID, weekFrom, weekTo)
+	rr = s.do("GET", path, nil, primaryAdminClaims())
+	weekQueryCount := qc.get()
+	require.Equal(t, http.StatusOK, rr.Code, "week body=%s", rr.Body.String())
+
+	var weekResp struct {
+		Days []struct {
+			Date      string
+			Instances []struct {
+				ID int64
+			}
+		}
+	}
+	decodeResponse(t, rr, &weekResp)
+	require.Len(t, weekResp.Days, 14, "14 inclusive days returned")
+
+	// PR #1300 budget: ≤ 12 handler queries. With TenantTxMiddleware overhead
+	// the end-to-end count is higher; match PR-B1 / PR-C2 convention and log
+	// instead of strict-assert, but guard against pathological fan-out
+	// (e.g. per-day loop) with a generous upper bound of 25.
+	t.Logf("query-budget /student/%d/week (14 days): %d queries (PR target ≤ 12 handler-queries only)", studentB.ID, weekQueryCount)
+	assert.LessOrEqual(t, weekQueryCount, int64(25),
+		"/week query count %d looks pathological (likely N+1 on days)", weekQueryCount)
+
+	// --- Tenant isolation -------------------------------------------------
+	rr = s.do("GET", fmt.Sprintf("/student/%d/day?date=%s", studentB.ID, fromS), nil, secondaryAdminClaims())
+	assert.Equal(t, http.StatusNotFound, rr.Code,
+		"secondary tenant must 404 on primary's student (got %d: %s)", rr.Code, rr.Body.String())
+}
+
+// startInstance calls POST /instances/{id}/start and returns the parsed body.
+func startInstance(t *testing.T, s *scenario, instanceID int64) struct {
+	InstanceID    int64  `json:"instance_id"`
+	Status        string `json:"status"`
+	ActiveGroupID int64  `json:"active_group_id"`
+} {
+	t.Helper()
+	rr := s.do("POST", fmt.Sprintf("/instances/%d/start", instanceID), nil, primaryAdminClaims())
+	require.Equal(t, http.StatusOK, rr.Code, "start instance %d body=%s", instanceID, rr.Body.String())
+	var resp struct {
+		InstanceID    int64  `json:"instance_id"`
+		Status        string `json:"status"`
+		ActiveGroupID int64  `json:"active_group_id"`
+	}
+	decodeResponse(t, rr, &resp)
+	require.NotZero(t, resp.ActiveGroupID, "instance %d: active_group_id missing", instanceID)
+	return resp
+}

--- a/backend/test/e2e/timetable/flow_f_gdpr_cleanup_test.go
+++ b/backend/test/e2e/timetable/flow_f_gdpr_cleanup_test.go
@@ -1,0 +1,271 @@
+package e2e_timetable
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	auditModel "github.com/moto-nrw/project-phoenix/models/audit"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// TestFlowF_GDPRCleanup covers the retention-based cleanup job:
+//   - Seed old instances (far past) + fresh ones + an exception row.
+//   - Set gdpr.timetable_retention_days to 30 so the cutoff falls between them.
+//   - Run the cleanup service; verify old rows + CASCADE children gone, fresh
+//     rows untouched, audit.data_deletions row per affected student.
+//   - Re-run (idempotency): zero deletions.
+func TestFlowF_GDPRCleanup(t *testing.T) {
+	s := newScenario(t)
+	defer s.teardown()
+
+	// --- Fixtures: students, room, old + fresh instances -------------------
+	room := testpkg.CreateTestRoom(t, s.db, "FlowF-Room")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupTableRecords(t, s.db, "facilities.rooms", room.ID)
+	})
+
+	studA := testpkg.CreateTestStudent(t, s.db, "Anna", "FlowF", "3a")
+	studB := testpkg.CreateTestStudent(t, s.db, "Bob", "FlowF", "3a")
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupTableRecords(t, s.db, "users.students", studA.ID, studB.ID)
+	})
+
+	// Old instance: 60 days ago. Should be deleted.
+	oldDate := time.Now().AddDate(0, 0, -60)
+	// Fresh instance: 5 days ago. Should survive.
+	freshDate := time.Now().AddDate(0, 0, -5)
+
+	// Old exception on a separate past date (template scope; no student audit).
+	oldExceptionDate := time.Now().AddDate(0, 0, -70)
+
+	oldInstance := testpkg.CreateTestActivityInstance(t, s.db, oldDate, room.ID,
+		testpkg.ActivityInstanceOpts{Title: "FlowF-Old", IsSpontaneous: true})
+	freshInstance := testpkg.CreateTestActivityInstance(t, s.db, freshDate, room.ID,
+		testpkg.ActivityInstanceOpts{Title: "FlowF-Fresh", IsSpontaneous: true})
+
+	// Old instance has two students: both get an audit row on cleanup, one
+	// of them even carries a note to confirm the sensitive field gets wiped
+	// via CASCADE.
+	_ = testpkg.CreateTestInstanceStudent(t, s.db, oldInstance.ID, studA.ID, "")
+	isB := testpkg.CreateTestInstanceStudent(t, s.db, oldInstance.ID, studB.ID, "")
+	note := "sensitive context — must be CASCADE-deleted"
+	_, err := s.db.NewUpdate().
+		Model((*scheduleModel.InstanceStudent)(nil)).
+		ModelTableExpr(`schedule.instance_students`).
+		Set("note = ?", note).
+		Where("id = ?", isB.ID).
+		Exec(s.tenantCtx())
+	require.NoError(t, err, "annotate note on instance_student")
+
+	// Fresh instance also has a student; must survive.
+	_ = testpkg.CreateTestInstanceStudent(t, s.db, freshInstance.ID, studA.ID, "")
+
+	// Cleanup registration — old instance IDs may vanish, but re-registration
+	// is idempotent from the teardown order's perspective (DELETEs skip).
+	s.registerCleanup("schedule.activity_instances", oldInstance.ID, freshInstance.ID)
+
+	// Old exception (template-scoped cleanup).
+	oldExc := &scheduleModel.ActivityException{
+		ActivityGroupID: 0, // doesn't reference a real template; tenant-scope + date drive the delete
+		ExceptionDate:   oldExceptionDate.UTC().Truncate(24 * time.Hour),
+		ExceptionType:   scheduleModel.ActivityExceptionCancelled,
+	}
+	oldExc.SetTenantID(primaryTenantID)
+	// activity_group_id is FK-constrained; point it at a throwaway template.
+	tmpl := s.buildTemplate(templateSpec{
+		name:       "FlowF-TemplatePlaceholder",
+		weekday:    1,
+		startHHMM:  "09:00",
+		endHHMM:    "10:00",
+		roomID:     room.ID,
+		staffIDs:   []int64{studAStaffProxy(t, s)}, // need at least one staff for buildTemplate
+		studentIDs: []int64{},
+	})
+	oldExc.ActivityGroupID = tmpl.group.ID
+	_, err = s.db.NewInsert().Model(oldExc).
+		ModelTableExpr(`schedule.activity_exceptions`).Exec(s.tenantCtx())
+	require.NoError(t, err, "insert old activity_exception")
+	// Exception cleanup is FK'd to template: if cleanup doesn't reach it,
+	// teardown will. Register explicitly so we don't leak.
+	s.registerCleanup("schedule.activity_exceptions", oldExc.ID)
+
+	// --- Set retention to 30 days via the settings service ----------------
+	setRetentionDays(t, s, 30)
+
+	// --- Preview first (dry-run) ------------------------------------------
+	preview := runInTenantTx(t, s, func(ctx context.Context) (any, error) {
+		return s.factory.TimetableCleanup.PreviewExpiredTimetableData(ctx)
+	}).(*scheduleSvc.TimetableCleanupPreview)
+	assert.GreaterOrEqual(t, preview.InstancesToDelete, 1,
+		"at least the old instance is previewed for delete")
+	assert.GreaterOrEqual(t, preview.ExceptionsToDelete, 1,
+		"at least the old exception is previewed for delete")
+	assert.Equal(t, 30, preview.RetentionDays)
+
+	// --- Run the actual cleanup -------------------------------------------
+	result := runInTenantTx(t, s, func(ctx context.Context) (any, error) {
+		return s.factory.TimetableCleanup.CleanupExpiredTimetableData(ctx)
+	}).(*scheduleSvc.TimetableCleanupResult)
+
+	assert.True(t, result.Success)
+	assert.Equal(t, 1, result.InstancesDeleted, "exactly one old instance deleted")
+	assert.Equal(t, 1, result.ExceptionsDeleted, "exactly one old exception deleted")
+	assert.Equal(t, 2, result.StudentsAffected, "studA + studB, both had old instance_students rows")
+
+	// --- Verify DB state --------------------------------------------------
+	assert.False(t, instanceExists(t, s, oldInstance.ID), "old instance deleted")
+	assert.True(t, instanceExists(t, s, freshInstance.ID), "fresh instance survived")
+	assert.False(t, exceptionExists(t, s, oldExc.ID), "old exception deleted")
+
+	// instance_students CASCADE delete for old instance
+	count := countInstanceStudents(t, s, oldInstance.ID)
+	assert.Equal(t, 0, count, "instance_students CASCADE-deleted with old instance")
+
+	// Audit rows: one per affected student, deletion_type='timetable_retention'.
+	auditCount := countAuditRows(t, s, studA.ID, auditModel.DeletionTypeTimetableRetention)
+	assert.Equal(t, 1, auditCount, "studA audit row")
+	auditCount = countAuditRows(t, s, studB.ID, auditModel.DeletionTypeTimetableRetention)
+	assert.Equal(t, 1, auditCount, "studB audit row")
+
+	// --- Idempotency: second run deletes nothing --------------------------
+	result2 := runInTenantTx(t, s, func(ctx context.Context) (any, error) {
+		return s.factory.TimetableCleanup.CleanupExpiredTimetableData(ctx)
+	}).(*scheduleSvc.TimetableCleanupResult)
+	assert.True(t, result2.Success)
+	assert.Equal(t, 0, result2.InstancesDeleted, "idempotent: nothing left to delete")
+	assert.Equal(t, 0, result2.ExceptionsDeleted)
+	assert.Equal(t, 0, result2.StudentsAffected, "no new audit rows")
+
+	// --- Tenant isolation: cleanup on T2 does not touch T1 data -----------
+	// Seed an old instance in T2; run cleanup there; verify T1 fresh
+	// instance is still intact.
+	t2Scope := tenant.WithTenantID(context.Background(), secondaryTenantID)
+	err = tenant.WithTenantTx(t2Scope, s.db, secondaryTenantID, func(ctx context.Context, _ bun.Tx) error {
+		_, err := s.factory.TimetableCleanup.CleanupExpiredTimetableData(ctx)
+		return err
+	})
+	require.NoError(t, err, "T2 cleanup ran cleanly")
+	assert.True(t, instanceExists(t, s, freshInstance.ID),
+		"T1 fresh instance untouched after T2 cleanup")
+
+	// cleanup: wipe audit rows we created so teardown doesn't report them
+	// from stale state.
+	_, _ = s.db.NewDelete().
+		TableExpr("audit.data_deletions").
+		Where("tenant_id = ?", primaryTenantID).
+		Where("student_id IN (?, ?)", studA.ID, studB.ID).
+		Exec(s.tenantCtx())
+}
+
+// runInTenantTx wraps fn in WithTenantTx against the primary tenant and
+// returns fn's result.
+func runInTenantTx(t *testing.T, s *scenario, fn func(ctx context.Context) (any, error)) any {
+	t.Helper()
+	var out any
+	err := tenant.WithTenantTx(context.Background(), s.db, primaryTenantID,
+		func(ctx context.Context, _ bun.Tx) error {
+			res, err := fn(ctx)
+			out = res
+			return err
+		})
+	require.NoError(t, err, "WithTenantTx fn")
+	return out
+}
+
+// setRetentionDays writes `gdpr.timetable_retention_days` for the primary
+// tenant via the settings service (admin permissions inlined for the write).
+func setRetentionDays(t *testing.T, s *scenario, days int) {
+	t.Helper()
+	perms := []string{
+		permissions.ConfigManage,
+		permissions.ConfigUpdate,
+	}
+	err := tenant.WithTenantTx(context.Background(), s.db, primaryTenantID,
+		func(ctx context.Context, _ bun.Tx) error {
+			return s.factory.Settings.SetValue(ctx, "gdpr.timetable_retention_days", days, nil, perms)
+		})
+	require.NoError(t, err, "set gdpr.timetable_retention_days=%d", days)
+	s.extraCleanup = append(s.extraCleanup, func() {
+		// Reset the override so a subsequent test sees the registry default.
+		_ = tenant.WithTenantTx(context.Background(), s.db, primaryTenantID,
+			func(ctx context.Context, _ bun.Tx) error {
+				return s.factory.Settings.ResetValue(ctx, "gdpr.timetable_retention_days", nil, perms)
+			})
+	})
+}
+
+// studAStaffProxy creates a single staff member used only to satisfy
+// buildTemplate's FK requirements for the placeholder-template exception
+// seeding.
+func studAStaffProxy(t *testing.T, s *scenario) int64 {
+	t.Helper()
+	st := testpkg.CreateTestStaff(t, s.db, "FlowF", fmt.Sprintf("Proxy-%d", time.Now().UnixNano()))
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupStaffFixtures(t, s.db, st.ID)
+	})
+	return st.ID
+}
+
+// instanceExists checks whether an activity_instance row is still in the DB.
+func instanceExists(t *testing.T, s *scenario, id int64) bool {
+	t.Helper()
+	n, err := s.db.NewSelect().
+		Model((*scheduleModel.ActivityInstance)(nil)).
+		ModelTableExpr(`schedule.activity_instances AS "activity_instance"`).
+		Where(`"activity_instance".id = ?`, id).
+		Where(`"activity_instance".tenant_id = ?`, primaryTenantID).
+		Count(s.tenantCtx())
+	require.NoError(t, err)
+	return n > 0
+}
+
+// exceptionExists checks whether an activity_exception row is still present.
+func exceptionExists(t *testing.T, s *scenario, id int64) bool {
+	t.Helper()
+	n, err := s.db.NewSelect().
+		Model((*scheduleModel.ActivityException)(nil)).
+		ModelTableExpr(`schedule.activity_exceptions AS "activity_exception"`).
+		Where(`"activity_exception".id = ?`, id).
+		Where(`"activity_exception".tenant_id = ?`, primaryTenantID).
+		Count(s.tenantCtx())
+	require.NoError(t, err)
+	return n > 0
+}
+
+// countInstanceStudents returns the number of instance_students rows left
+// for a given instance (should be 0 after CASCADE-delete).
+func countInstanceStudents(t *testing.T, s *scenario, instanceID int64) int {
+	t.Helper()
+	n, err := s.db.NewSelect().
+		Model((*scheduleModel.InstanceStudent)(nil)).
+		ModelTableExpr(`schedule.instance_students AS "instance_student"`).
+		Where(`"instance_student".instance_id = ?`, instanceID).
+		Where(`"instance_student".tenant_id = ?`, primaryTenantID).
+		Count(s.tenantCtx())
+	require.NoError(t, err)
+	return n
+}
+
+// countAuditRows counts audit.data_deletions rows for (student, deletionType).
+func countAuditRows(t *testing.T, s *scenario, studentID int64, deletionType string) int {
+	t.Helper()
+	n, err := s.db.NewSelect().
+		Model((*auditModel.DataDeletion)(nil)).
+		ModelTableExpr(`audit.data_deletions AS "data_deletion"`).
+		Where(`"data_deletion".student_id = ?`, studentID).
+		Where(`"data_deletion".deletion_type = ?`, deletionType).
+		Where(`"data_deletion".tenant_id = ?`, primaryTenantID).
+		Count(s.tenantCtx())
+	require.NoError(t, err)
+	return n
+}

--- a/backend/test/e2e/timetable/shared_setup.go
+++ b/backend/test/e2e/timetable/shared_setup.go
@@ -1,0 +1,476 @@
+// Package e2e_timetable exercises the timetable epic as end-to-end HTTP flows.
+//
+// Each flow test spins up the real service factory against the test DB and
+// drives real HTTP requests through the production timetable router, minting
+// actual JWTs with admin permissions. Tenant isolation is verified in-flow
+// by issuing a second tenant's token and asserting 404.
+//
+// Fixtures follow the existing testpkg pattern; `tenant_id=1` is the primary
+// tenant (matching the whitelisted value in the hermetic linter) and
+// `tenant_id=2` is the isolated neighbor.
+package e2e_timetable
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	timetableAPI "github.com/moto-nrw/project-phoenix/api/timetable"
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/services"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// primaryTenantID matches the whitelisted tenant used by testpkg fixtures.
+const primaryTenantID int64 = 1
+
+// secondaryTenantID is created per test run for cross-tenant isolation checks.
+const secondaryTenantID int64 = 2
+
+// scenario bundles the common infrastructure a single flow needs.
+type scenario struct {
+	t         *testing.T
+	db        *bun.DB
+	factory   *services.Factory
+	repos     *repositories.Factory
+	router    chi.Router
+	tokenAuth *jwt.TokenAuth
+
+	cleanupOrder []string
+	cleanupIDs   map[string][]int64
+	extraCleanup []func()
+}
+
+// newScenario returns a ready-to-use scenario with real DB + service factory
+// + fully mounted timetable router + JWT signer.
+func newScenario(t *testing.T) *scenario {
+	t.Helper()
+
+	db, factory := testutil.SetupAPITest(t)
+	testpkg.EnsureTestTenant(t, db, secondaryTenantID)
+
+	// SetupAPITest sets the viper defaults we need; NewTokenAuth reads them.
+	ta, err := jwt.NewTokenAuth()
+	require.NoError(t, err, "init JWT token auth")
+
+	repos := repositories.NewFactory(db)
+
+	s := &scenario{
+		t:         t,
+		db:        db,
+		factory:   factory,
+		repos:     repos,
+		tokenAuth: ta,
+		cleanupOrder: []string{
+			"schedule.instance_students",
+			"schedule.instance_staff",
+			"schedule.activity_instances",
+			"schedule.activity_exceptions",
+			"schedule.student_arrival_exceptions",
+			"schedule.student_arrival_schedules",
+			"schedule.student_pickup_exceptions",
+			"schedule.student_pickup_schedules",
+			"activities.student_enrollments",
+			"activities.supervisors",
+			"activities.schedules",
+			"audit.data_deletions",
+			"active.visits",
+			"active.group_supervisors",
+			"active.groups",
+			"activities.groups",
+			"activities.categories",
+			"schedule.timeframes",
+			"schedule.calendar_periods",
+		},
+		cleanupIDs: make(map[string][]int64),
+	}
+	s.router = s.mountRouter()
+	return s
+}
+
+// registerCleanup tracks IDs to delete at teardown.
+func (s *scenario) registerCleanup(table string, ids ...int64) {
+	s.cleanupIDs[table] = append(s.cleanupIDs[table], ids...)
+}
+
+// teardown deletes all registered fixtures in FK-safe order.
+func (s *scenario) teardown() {
+	s.t.Helper()
+	for _, tbl := range s.cleanupOrder {
+		if ids := s.cleanupIDs[tbl]; len(ids) > 0 {
+			testpkg.CleanupTableRecords(s.t, s.db, tbl, ids...)
+		}
+	}
+	for _, fn := range s.extraCleanup {
+		fn()
+	}
+}
+
+// tenantCtx returns a context bound to the primary tenant.
+func (s *scenario) tenantCtx() context.Context {
+	return tenant.WithTenantID(context.Background(), primaryTenantID)
+}
+
+// mountRouter builds the full timetable Resource with real services and
+// returns its router (with JWT + tenant middleware intact).
+func (s *scenario) mountRouter() chi.Router {
+	deps := timetableAPI.Dependencies{
+		CalendarPeriodService:  s.factory.CalendarPeriod,
+		MaterializationService: s.factory.Materialization,
+		InstanceService:        s.factory.Instance,
+		PersonService:          s.factory.Users,
+		InstanceStudentRepo:    s.repos.InstanceStudent,
+		ActivityInstanceRepo:   s.repos.ActivityInstance,
+		ActivityExceptionRepo:  s.repos.ActivityException,
+		ActivityScheduleRepo:   s.repos.ActivitySchedule,
+		InstanceStaffRepo:      s.repos.InstanceStaff,
+		SupervisorRepo:         s.repos.GroupSupervisor,
+		ArrivalScheduleRepo:    s.repos.StudentArrivalSchedule,
+		ArrivalExceptionRepo:   s.repos.StudentArrivalException,
+		PickupScheduleRepo:     s.repos.StudentPickupSchedule,
+		PickupExceptionRepo:    s.repos.StudentPickupException,
+		VisitRepo:              s.repos.ActiveVisit,
+		StudentRepo:            s.repos.Student,
+		StaffRepo:              s.repos.Staff,
+		UserContextService:     s.factory.UserContext,
+		SettingsService:        s.factory.Settings,
+		Broadcaster:            s.factory.RealtimeHub,
+		Logger:                 slog.Default(),
+		DB:                     s.db,
+	}
+
+	resource := timetableAPI.NewResource(deps)
+	return resource.Router()
+}
+
+// do executes an HTTP request against the timetable router.
+// method, path: e.g. ("POST", "/materialize"). body: nil or a JSON-marshalable struct.
+// claims: which tenant/permissions to authenticate as.
+func (s *scenario) do(method, path string, body any, claims jwt.AppClaims) *httptest.ResponseRecorder {
+	s.t.Helper()
+
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(s.t, err, "marshal request body")
+		reader = bytes.NewBuffer(b)
+	}
+
+	token, err := s.tokenAuth.CreateJWT(claims)
+	require.NoError(s.t, err, "mint JWT")
+
+	req := httptest.NewRequest(method, path, reader)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rr := httptest.NewRecorder()
+	s.router.ServeHTTP(rr, req)
+	return rr
+}
+
+// decodeResponse parses {"status":"...","data":...} into a target struct's
+// Data field. Uses the common envelope exposed by api/common.Respond.
+func decodeResponse(t *testing.T, rr *httptest.ResponseRecorder, target any) {
+	t.Helper()
+	var env struct {
+		Status  string          `json:"status"`
+		Data    json.RawMessage `json:"data"`
+		Message string          `json:"message"`
+		Error   string          `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &env),
+		"unmarshal envelope: %s", rr.Body.String())
+	if target != nil && len(env.Data) > 0 {
+		require.NoError(t, json.Unmarshal(env.Data, target),
+			"unmarshal data payload: %s", string(env.Data))
+	}
+}
+
+// adminClaimsForTenant builds admin JWT claims pinned to the given tenant,
+// with the full permission set the timetable routes care about.
+func adminClaimsForTenant(accountID, tenantID int64) jwt.AppClaims {
+	c := testutil.AdminTestClaims(int(accountID))
+	c.Permissions = []string{
+		permissions.SchedulesRead,
+		permissions.SchedulesCreate,
+		permissions.SchedulesUpdate,
+		permissions.SchedulesDelete,
+		permissions.SchedulesManage,
+		permissions.ConfigRead,
+		permissions.ConfigUpdate,
+		permissions.ConfigManage,
+		permissions.UsersRead,
+		"admin:*",
+	}
+	c.IsAdmin = true
+	c.TenantID = tenantID
+	return c
+}
+
+// primaryAdminClaims returns claims for the primary tenant admin.
+func primaryAdminClaims() jwt.AppClaims {
+	return adminClaimsForTenant(1, primaryTenantID)
+}
+
+// secondaryAdminClaims returns claims for an admin on the isolated tenant.
+func secondaryAdminClaims() jwt.AppClaims {
+	return adminClaimsForTenant(2, secondaryTenantID)
+}
+
+// parseHHMM parses "HH:MM" into a time.Time anchored on 2000-01-01.
+func parseHHMM(t *testing.T, hhmm string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse("15:04", hhmm)
+	require.NoError(t, err, "invalid HH:MM literal %q", hhmm)
+	return time.Date(2000, 1, 1, parsed.Hour(), parsed.Minute(), 0, 0, time.UTC)
+}
+
+// createActivePeriod creates an active calendar period spanning 1 year before
+// and 1 year after `anchor`.
+func (s *scenario) createActivePeriod(name string, anchor time.Time) *scheduleModels.CalendarPeriod {
+	s.t.Helper()
+	period := &scheduleModels.CalendarPeriod{
+		Name:            name,
+		PeriodType:      scheduleModels.PeriodTypeSchoolYear,
+		StartDate:       time.Date(anchor.Year()-1, 8, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:         time.Date(anchor.Year()+1, 7, 31, 0, 0, 0, 0, time.UTC),
+		WeekCycleLength: 1,
+		IsActive:        true,
+	}
+	require.NoError(s.t, s.factory.CalendarPeriod.CreatePeriod(s.tenantCtx(), period))
+	s.registerCleanup("schedule.calendar_periods", period.ID)
+	return period
+}
+
+// createTimeframeWithTimes inserts a timeframe with explicit HH:MM times.
+// The start_time / end_time columns are TIMESTAMPTZ; the service layer reads
+// them back through timezone.WallClock(), which extracts .Hour() from the
+// time.Time as loaded by the driver. Store the values anchored to local
+// (Berlin) time so the wall clock hours match what we intended — using UTC
+// would cross a DST/CET offset and shift the hour by +1 or +2 on read.
+func (s *scenario) createTimeframeWithTimes(description, startHHMM, endHHMM string) *scheduleModels.Timeframe {
+	s.t.Helper()
+	start := parseHHMMLocal(s.t, startHHMM)
+	end := parseHHMMLocal(s.t, endHHMM)
+
+	tf := &scheduleModels.Timeframe{
+		StartTime:   start,
+		EndTime:     &end,
+		IsActive:    true,
+		Description: description,
+	}
+	tf.SetTenantID(primaryTenantID)
+
+	_, err := s.db.NewInsert().
+		Model(tf).
+		ModelTableExpr(`schedule.timeframes`).
+		Exec(s.tenantCtx())
+	require.NoError(s.t, err, "insert timeframe")
+	s.registerCleanup("schedule.timeframes", tf.ID)
+	return tf
+}
+
+// parseHHMMLocal builds a time.Time at today's date with the given wall-clock
+// time in the machine's local timezone (Berlin on the dev box). Use this for
+// TIMESTAMPTZ columns where the wall-clock hour must round-trip through the
+// driver unchanged.
+func parseHHMMLocal(t *testing.T, hhmm string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse("15:04", hhmm)
+	require.NoError(t, err, "invalid HH:MM literal %q", hhmm)
+	now := time.Now()
+	return time.Date(now.Year(), now.Month(), now.Day(), parsed.Hour(), parsed.Minute(), 0, 0, now.Location())
+}
+
+// templateSpec describes a weekly template to materialize later.
+type templateSpec struct {
+	name       string
+	weekday    int
+	startHHMM  string
+	endHHMM    string
+	roomID     int64
+	staffIDs   []int64
+	studentIDs []int64
+	periodID   *int64
+	validFrom  time.Time
+	validUntil *time.Time
+}
+
+// templateFixture is the full bundle of rows behind one activity template.
+type templateFixture struct {
+	group        *activitiesModels.Group
+	schedule     *activitiesModels.Schedule
+	timeframe    *scheduleModels.Timeframe
+	enrollments  []int64
+	supervisors  []int64
+	roomID       int64
+	staffIDs     []int64
+	studentIDs   []int64
+	validFromUTC time.Time
+}
+
+// buildTemplate inserts a full template bundle so materialize() will pick it up.
+func (s *scenario) buildTemplate(spec templateSpec) *templateFixture {
+	s.t.Helper()
+	ctx := s.tenantCtx()
+
+	category := testpkg.CreateTestActivityCategory(s.t, s.db, spec.name)
+	s.registerCleanup("activities.categories", category.ID)
+
+	creator := testpkg.CreateTestStaff(s.t, s.db, "Creator", spec.name)
+	s.extraCleanup = append(s.extraCleanup, func() {
+		testpkg.CleanupStaffFixtures(s.t, s.db, creator.ID)
+	})
+
+	group := &activitiesModels.Group{
+		Name:            spec.name,
+		MaxParticipants: 20,
+		IsOpen:          true,
+		CategoryID:      category.ID,
+		CreatedBy:       &creator.ID,
+		PlannedRoomID:   &spec.roomID,
+		IsTemplate:      true,
+	}
+	group.SetTenantID(primaryTenantID)
+	_, err := s.db.NewInsert().
+		Model(group).
+		ModelTableExpr(`activities.groups AS "group"`).
+		Exec(ctx)
+	require.NoError(s.t, err, "insert activity group")
+	s.registerCleanup("activities.groups", group.ID)
+
+	timeframe := s.createTimeframeWithTimes(spec.name+"-tf", spec.startHHMM, spec.endHHMM)
+
+	sched := &activitiesModels.Schedule{
+		Weekday:          spec.weekday,
+		TimeframeID:      &timeframe.ID,
+		ActivityGroupID:  group.ID,
+		WeekPattern:      0,
+		CalendarPeriodID: spec.periodID,
+	}
+	sched.SetTenantID(primaryTenantID)
+	_, err = s.db.NewInsert().
+		Model(sched).
+		ModelTableExpr(`activities.schedules`).
+		Exec(ctx)
+	require.NoError(s.t, err, "insert schedule")
+	s.registerCleanup("activities.schedules", sched.ID)
+
+	validFrom := spec.validFrom
+	if validFrom.IsZero() {
+		validFrom = time.Now().AddDate(0, -1, 0)
+	}
+
+	var enrollmentIDs []int64
+	for _, sid := range spec.studentIDs {
+		enroll := &activitiesModels.StudentEnrollment{
+			StudentID:       sid,
+			ActivityGroupID: group.ID,
+			ValidFrom:       validFrom,
+			ValidUntil:      spec.validUntil,
+		}
+		enroll.SetTenantID(primaryTenantID)
+		_, err := s.db.NewInsert().
+			Model(enroll).
+			ModelTableExpr(`activities.student_enrollments`).
+			Exec(ctx)
+		require.NoError(s.t, err, "insert enrollment")
+		enrollmentIDs = append(enrollmentIDs, enroll.ID)
+	}
+	s.registerCleanup("activities.student_enrollments", enrollmentIDs...)
+
+	var supervisorIDs []int64
+	for i, stid := range spec.staffIDs {
+		sup := &activitiesModels.SupervisorPlanned{
+			StaffID:    stid,
+			GroupID:    group.ID,
+			IsPrimary:  i == 0,
+			ValidFrom:  validFrom,
+			ValidUntil: spec.validUntil,
+		}
+		sup.SetTenantID(primaryTenantID)
+		_, err := s.db.NewInsert().
+			Model(sup).
+			ModelTableExpr(`activities.supervisors`).
+			Exec(ctx)
+		require.NoError(s.t, err, "insert supervisor")
+		supervisorIDs = append(supervisorIDs, sup.ID)
+	}
+	s.registerCleanup("activities.supervisors", supervisorIDs...)
+
+	return &templateFixture{
+		group:        group,
+		schedule:     sched,
+		timeframe:    timeframe,
+		enrollments:  enrollmentIDs,
+		supervisors:  supervisorIDs,
+		roomID:       spec.roomID,
+		staffIDs:     spec.staffIDs,
+		studentIDs:   spec.studentIDs,
+		validFromUTC: validFrom,
+	}
+}
+
+// queryCounter is a bun.QueryHook that counts queries between reset and read.
+type queryCounter struct {
+	count atomic.Int64
+}
+
+func (q *queryCounter) BeforeQuery(ctx context.Context, _ *bun.QueryEvent) context.Context {
+	return ctx
+}
+func (q *queryCounter) AfterQuery(_ context.Context, _ *bun.QueryEvent) {
+	q.count.Add(1)
+}
+func (q *queryCounter) reset()     { q.count.Store(0) }
+func (q *queryCounter) get() int64 { return q.count.Load() }
+
+// nextWeekday returns the next occurrence of the given ISO weekday (1=Mon...7=Sun)
+// at least `minDaysAhead` days from `from`.
+func nextWeekday(from time.Time, isoWeekday, minDaysAhead int) time.Time {
+	d := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, time.UTC).
+		AddDate(0, 0, minDaysAhead)
+	for {
+		w := int(d.Weekday())
+		if w == 0 {
+			w = 7
+		}
+		if w == isoWeekday {
+			return d
+		}
+		d = d.AddDate(0, 0, 1)
+	}
+}
+
+// ensureJWTSecret makes sure viper has a JWT secret set before NewTokenAuth
+// is called. testutil.SetupAPITest does this via viper.SetDefault, but if
+// the viper store has an empty "auth_jwt_secret" from a parent config file,
+// the default is overridden to empty.
+func init() {
+	if viper.GetString("auth_jwt_secret") == "" {
+		viper.Set("auth_jwt_secret", "e2e-test-secret-abcdefghijklmnopqrstuvwxyz")
+	}
+	if viper.GetDuration("auth_jwt_expiry") == 0 {
+		viper.Set("auth_jwt_expiry", 15*time.Minute)
+	}
+	if viper.GetDuration("auth_jwt_refresh_expiry") == 0 {
+		viper.Set("auth_jwt_refresh_expiry", time.Hour)
+	}
+}

--- a/backend/test/e2e/timetable/shared_setup.go
+++ b/backend/test/e2e/timetable/shared_setup.go
@@ -31,6 +31,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/services"
@@ -288,15 +289,17 @@ func (s *scenario) createTimeframeWithTimes(description, startHHMM, endHHMM stri
 }
 
 // parseHHMMLocal builds a time.Time at today's date with the given wall-clock
-// time in the machine's local timezone (Berlin on the dev box). Use this for
-// TIMESTAMPTZ columns where the wall-clock hour must round-trip through the
-// driver unchanged.
+// time pinned to Europe/Berlin. We cannot use `time.Local` here because the
+// CI runner's Local is UTC while the dev box's Local is Europe/Berlin — the
+// TIMESTAMPTZ column round-trips the value through Postgres's session TZ
+// (Europe/Berlin), so inserting in UTC yields a +2h shift on read. Pinning
+// the input to Europe/Berlin keeps the wall-clock stable across both envs.
 func parseHHMMLocal(t *testing.T, hhmm string) time.Time {
 	t.Helper()
 	parsed, err := time.Parse("15:04", hhmm)
 	require.NoError(t, err, "invalid HH:MM literal %q", hhmm)
-	now := time.Now()
-	return time.Date(now.Year(), now.Month(), now.Day(), parsed.Hour(), parsed.Minute(), 0, 0, now.Location())
+	now := time.Now().In(timezone.Berlin)
+	return time.Date(now.Year(), now.Month(), now.Day(), parsed.Hour(), parsed.Minute(), 0, 0, timezone.Berlin)
 }
 
 // templateSpec describes a weekly template to materialize later.

--- a/backend/test/hermetic_verification_test.go
+++ b/backend/test/hermetic_verification_test.go
@@ -261,6 +261,7 @@ func checkMissingSetupTestDB(t *testing.T, root string) []string {
 		"SetupAPITest",
 		"setupAPITest",
 		"setupTestContext", // Indirect setup via shared helper (calls SetupAPITest)
+		"newScenario",      // E2E timetable flows — shared_setup.go wraps SetupAPITest
 	}
 
 	// Patterns indicating mock-based testing (legitimate alternative)


### PR DESCRIPTION
## Summary

- New E2E flow suite under `backend/test/e2e/timetable/` covering the six cross-WP chains of the timetable epic (WP-B1 through WP-B14). Runs under 1s against the test DB.
- Fix for **E2E-C1** — `GET /api/timetable/gaps` was hardcoding `assigned_staff_count=0`; now reports `len(rows)` so admins see the correct total-assigned vs. absent breakdown.
- Findings report at `backend/test/e2e/timetable/E2E_FINDINGS.md` documents everything the sweep surfaced (including two plan-ambiguity notes that don't need code changes).

## What the suite verifies

| Flow | Scenario |
|------|----------|
| A | Admin plans → scheduler materializes → staff starts → 2 students check in → `Complete` flips the no-show to `absent` → `/student/{id}/day` reports truth |
| B | `cancelled` + `modified` exceptions; `/exception-conflicts` surfaces warnings only for students with resolved arrivals (explicit absence suppresses) |
| C | `/substitute` swaps S1→S3 across both instances, including `active.group_supervisors` rotation on an active instance; second `/substitute` with different sub → **409 with zero partial writes** (dry-run-first atomicity) |
| D | `/re-plan-week` deletes only `planned` non-spontaneous rows; active/completed/cancelled/spontaneous all survive unchanged |
| E | Student enrolled in X → `is_unplanned=false`; same student with a visit in Y but no enrollment → `is_unplanned=true` via `active.visits` join |
| F | Retention cleanup CASCADEs, writes one `audit.data_deletions` row per affected student, second run is a no-op |

Every flow runs a tenant-isolation check at the end (primary-tenant fixtures, secondary-tenant claims → 404 or empty response as appropriate).

## The fix

`backend/api/timetable/gaps.go:168` used to set `AssignedStaffCount: 0` with a comment claiming the value was "always 0 here by construction". The comment misread the invariant: the branch runs when `nonAbsentCounts[inst.ID] == 0`, which means "no NON-absent staff", not "no staff". PR #1303 documents the expected shape (`assigned=2, absent=2` when two staff are both sick) so admins can distinguish "staff was planned, nobody's covering" from "nobody was ever assigned". Fixed with `AssignedStaffCount: len(rows)`.

The existing unit test `TestGaps_AllStaffAbsent_IsAGap` asserted the buggy shape. Its one assert is updated to match the documented contract. `TestGaps_OneGapPlannedNoStaff` continues to expect `0` because no staff rows exist for that case.

## Findings surfaced but not fixed here

- **E2E-B1** — Plan §6.1 suggests `skipped_existing` wins over `skipped_exception` on re-materialize; observed behaviour is the opposite (exception short-circuits the candidate). The current behaviour is sensible; the plan text is the thing to update.
- **E2E-C2** — Query-budget numbers `≤ 2` / `≤ 22` / `≤ 12` from the PR descriptions apply to handler-queries only. `TenantTxMiddleware` adds 4-5 queries per request. E2E measurements are logged; strict gates use a generous upper bound.
- **E2E-ENV-1** — `backend/services/schedule/arrival_service_test.go` hardcodes `CreatedBy: 1` without its own staff fixture; fragile against DB states where staff_id=1 is absent. Pre-existing, worth a follow-up PR.

## Test plan

- [ ] `APP_ENV=test go test ./test/e2e/timetable/ -v` — all six flows green
- [ ] `APP_ENV=test go test ./api/timetable/... -count=1` — including the amended gaps unit test
- [ ] `APP_ENV=test go test ./test/ -run TestHermeticTestPatterns` — newScenario pattern recognised
- [ ] Inspect `E2E_FINDINGS.md` for the full record