### PR TITLE
Repair legacy pickup tenant IDs

### DIFF
--- a/backend/database/migrations/001015039_repair_pickup_schedule_tenant_ids.go
+++ b/backend/database/migrations/001015039_repair_pickup_schedule_tenant_ids.go
@@ -1,0 +1,241 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	repairPickupScheduleTenantIDsVersion     = "1.15.39"
+	repairPickupScheduleTenantIDsDescription = "Repair tenant IDs on existing pickup schedule data"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     repairPickupScheduleTenantIDsVersion,
+		Description: repairPickupScheduleTenantIDsDescription,
+		DependsOn:   []string{"1.15.38"},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return repairPickupScheduleTenantIDs(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return nil
+		},
+	)
+}
+
+type pickupTenantRepairSpec struct {
+	table          string
+	tableAlias     string
+	uniqueConflict string
+}
+
+var pickupTenantRepairSpecs = []pickupTenantRepairSpec{
+	{
+		table:      "schedule.student_pickup_schedules",
+		tableAlias: "pickup_schedule",
+		uniqueConflict: `
+			SELECT COUNT(*)
+			FROM schedule.student_pickup_schedules p
+			JOIN users.students s ON s.id = p.student_id
+			JOIN schedule.student_pickup_schedules existing
+				ON existing.tenant_id = s.tenant_id
+				AND existing.student_id = p.student_id
+				AND existing.weekday = p.weekday
+				AND existing.id <> p.id
+			WHERE p.tenant_id <> s.tenant_id`,
+	},
+	{
+		table:      "schedule.student_pickup_exceptions",
+		tableAlias: "pickup_exception",
+		uniqueConflict: `
+			SELECT COUNT(*)
+			FROM schedule.student_pickup_exceptions p
+			JOIN users.students s ON s.id = p.student_id
+			JOIN schedule.student_pickup_exceptions existing
+				ON existing.tenant_id = s.tenant_id
+				AND existing.student_id = p.student_id
+				AND existing.exception_date = p.exception_date
+				AND existing.id <> p.id
+			WHERE p.tenant_id <> s.tenant_id`,
+	},
+	{
+		table:          "schedule.student_pickup_notes",
+		tableAlias:     "pickup_note",
+		uniqueConflict: "",
+	},
+}
+
+var pickupCompositeFKStatements = []struct {
+	name string
+	add  string
+}{
+	{
+		name: "fk_pickup_schedules_created_by_tenant",
+		add:  `ALTER TABLE schedule.student_pickup_schedules ADD CONSTRAINT fk_pickup_schedules_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
+	},
+	{
+		name: "fk_pickup_schedules_student_tenant",
+		add:  `ALTER TABLE schedule.student_pickup_schedules ADD CONSTRAINT fk_pickup_schedules_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
+	},
+	{
+		name: "fk_pickup_exceptions_created_by_tenant",
+		add:  `ALTER TABLE schedule.student_pickup_exceptions ADD CONSTRAINT fk_pickup_exceptions_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
+	},
+	{
+		name: "fk_pickup_exceptions_student_tenant",
+		add:  `ALTER TABLE schedule.student_pickup_exceptions ADD CONSTRAINT fk_pickup_exceptions_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
+	},
+	{
+		name: "fk_pickup_notes_created_by_tenant",
+		add:  `ALTER TABLE schedule.student_pickup_notes ADD CONSTRAINT fk_pickup_notes_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
+	},
+	{
+		name: "fk_pickup_notes_student_tenant",
+		add:  `ALTER TABLE schedule.student_pickup_notes ADD CONSTRAINT fk_pickup_notes_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
+	},
+}
+
+func repairPickupScheduleTenantIDs(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.39: Repairing pickup schedule tenant IDs...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	if err := dropPickupCompositeFKsForRepair(ctx, tx); err != nil {
+		return err
+	}
+
+	for _, spec := range pickupTenantRepairSpecs {
+		if err := ensurePickupTenantRepairIsSafe(ctx, tx, spec); err != nil {
+			return err
+		}
+
+		result, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			UPDATE %s p
+			SET tenant_id = s.tenant_id
+			FROM users.students s
+			WHERE p.student_id = s.id
+				AND p.tenant_id <> s.tenant_id;
+		`, spec.table))
+		if err != nil {
+			return fmt.Errorf("repair tenant_id on %s: %w", spec.table, err)
+		}
+
+		rowsAffected, _ := result.RowsAffected()
+		fmt.Printf("Migration 1.15.39: repaired %d row(s) in %s\n", rowsAffected, spec.table)
+	}
+
+	if err := restorePickupCompositeFKsAfterRepair(ctx, tx); err != nil {
+		return err
+	}
+
+	fmt.Println("Migration 1.15.39: Pickup schedule tenant ID repair complete")
+	return tx.Commit()
+}
+
+func ensurePickupTenantRepairIsSafe(ctx context.Context, tx bun.Tx, spec pickupTenantRepairSpec) error {
+	var missingCreatedBy int64
+	err := tx.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT COUNT(*)
+		FROM %s p
+		JOIN users.students s ON s.id = p.student_id
+		LEFT JOIN users.staff st ON st.id = p.created_by
+		WHERE p.tenant_id <> s.tenant_id
+			AND st.id IS NULL;
+	`, spec.table)).Scan(&missingCreatedBy)
+	if err != nil {
+		return fmt.Errorf("check created_by existence on %s: %w", spec.table, err)
+	}
+	if missingCreatedBy > 0 {
+		return fmt.Errorf(
+			"cannot repair %s: %d row(s) reference missing created_by staff",
+			spec.table,
+			missingCreatedBy,
+		)
+	}
+
+	var badCreatedBy int64
+	err = tx.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT COUNT(*)
+		FROM %s p
+		JOIN users.students s ON s.id = p.student_id
+		JOIN users.staff st ON st.id = p.created_by
+		WHERE p.tenant_id <> s.tenant_id
+			AND st.tenant_id <> s.tenant_id;
+	`, spec.table)).Scan(&badCreatedBy)
+	if err != nil {
+		return fmt.Errorf("check created_by tenant safety on %s: %w", spec.table, err)
+	}
+	if badCreatedBy > 0 {
+		return fmt.Errorf(
+			"cannot repair %s: %d row(s) reference created_by staff from a different tenant than the owning student",
+			spec.table,
+			badCreatedBy,
+		)
+	}
+
+	if spec.uniqueConflict == "" {
+		return nil
+	}
+
+	var conflicts int64
+	if err := tx.QueryRowContext(ctx, spec.uniqueConflict).Scan(&conflicts); err != nil {
+		return fmt.Errorf("check unique conflicts on %s: %w", spec.table, err)
+	}
+	if conflicts > 0 {
+		return fmt.Errorf(
+			"cannot repair %s: %d row(s) would conflict with existing %s rows after tenant_id repair",
+			spec.table,
+			conflicts,
+			spec.tableAlias,
+		)
+	}
+
+	return nil
+}
+
+func dropPickupCompositeFKsForRepair(ctx context.Context, tx bun.Tx) error {
+	for _, fk := range pickupCompositeFKStatements {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s", pickupFKTable(fk.name), fk.name)); err != nil {
+			return fmt.Errorf("drop pickup composite FK %s: %w", fk.name, err)
+		}
+	}
+	return nil
+}
+
+func restorePickupCompositeFKsAfterRepair(ctx context.Context, tx bun.Tx) error {
+	for _, fk := range pickupCompositeFKStatements {
+		if _, err := tx.ExecContext(ctx, fk.add); err != nil {
+			return fmt.Errorf("restore pickup composite FK %s: %w", fk.name, err)
+		}
+	}
+	return nil
+}
+
+func pickupFKTable(fkName string) string {
+	switch fkName {
+	case "fk_pickup_schedules_created_by_tenant", "fk_pickup_schedules_student_tenant":
+		return "schedule.student_pickup_schedules"
+	case "fk_pickup_exceptions_created_by_tenant", "fk_pickup_exceptions_student_tenant":
+		return "schedule.student_pickup_exceptions"
+	case "fk_pickup_notes_created_by_tenant", "fk_pickup_notes_student_tenant":
+		return "schedule.student_pickup_notes"
+	default:
+		panic(fmt.Sprintf("unknown pickup FK %s", fkName))
+	}
+}

--- a/backend/database/migrations/001015039_repair_pickup_schedule_tenant_ids_test.go
+++ b/backend/database/migrations/001015039_repair_pickup_schedule_tenant_ids_test.go
@@ -1,0 +1,220 @@
+package migrations
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func TestRepairPickupScheduleTenantIDs(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	ctx := context.Background()
+	const tenantID int64 = 2
+
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+
+	dropPickupCompositeFKs(t, db)
+	t.Cleanup(func() { restorePickupCompositeFKs(t, db) })
+
+	staffID := createTenantStaff(t, db, tenantID)
+	studentID := createTenantStudent(t, db, tenantID)
+	defer cleanupPickupTenantRepairRows(t, db, staffID, studentID)
+
+	scheduleID := insertPickupScheduleWithTenant(t, db, 1, studentID, staffID)
+	exceptionID := insertPickupExceptionWithTenant(t, db, 1, studentID, staffID)
+	noteID := insertPickupNoteWithTenant(t, db, 1, studentID, staffID)
+
+	require.NoError(t, repairPickupScheduleTenantIDs(ctx, db))
+	require.NoError(t, repairPickupScheduleTenantIDs(ctx, db), "repair migration must be idempotent")
+
+	assertTenantID(t, db, "schedule.student_pickup_schedules", scheduleID, tenantID)
+	assertTenantID(t, db, "schedule.student_pickup_exceptions", exceptionID, tenantID)
+	assertTenantID(t, db, "schedule.student_pickup_notes", noteID, tenantID)
+}
+
+func TestRepairPickupScheduleTenantIDsRejectsCrossTenantCreator(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	ctx := context.Background()
+	const tenantID int64 = 2
+
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+
+	dropPickupCompositeFKs(t, db)
+	t.Cleanup(func() { restorePickupCompositeFKs(t, db) })
+
+	studentID := createTenantStudent(t, db, tenantID)
+	staff := testpkg.CreateTestStaff(t, db, "PickupRepair", "WrongTenant")
+	defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+	defer cleanupPickupTenantRepairRows(t, db, 0, studentID)
+
+	insertPickupScheduleWithTenant(t, db, 1, studentID, staff.ID)
+
+	err := repairPickupScheduleTenantIDs(ctx, db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "created_by staff from a different tenant")
+}
+
+func TestRepairPickupScheduleTenantIDsRejectsUniqueConflicts(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	ctx := context.Background()
+	const tenantID int64 = 2
+
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+
+	dropPickupCompositeFKs(t, db)
+	t.Cleanup(func() { restorePickupCompositeFKs(t, db) })
+
+	staffID := createTenantStaff(t, db, tenantID)
+	studentID := createTenantStudent(t, db, tenantID)
+	defer cleanupPickupTenantRepairRows(t, db, staffID, studentID)
+
+	insertPickupScheduleWithTenant(t, db, tenantID, studentID, staffID)
+	insertPickupScheduleWithTenant(t, db, 1, studentID, staffID)
+
+	err := repairPickupScheduleTenantIDs(ctx, db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "would conflict")
+}
+
+func dropPickupCompositeFKs(t *testing.T, db *bun.DB) {
+	t.Helper()
+
+	statements := []string{
+		`ALTER TABLE schedule.student_pickup_schedules DROP CONSTRAINT IF EXISTS fk_pickup_schedules_created_by_tenant`,
+		`ALTER TABLE schedule.student_pickup_schedules DROP CONSTRAINT IF EXISTS fk_pickup_schedules_student_tenant`,
+		`ALTER TABLE schedule.student_pickup_exceptions DROP CONSTRAINT IF EXISTS fk_pickup_exceptions_created_by_tenant`,
+		`ALTER TABLE schedule.student_pickup_exceptions DROP CONSTRAINT IF EXISTS fk_pickup_exceptions_student_tenant`,
+		`ALTER TABLE schedule.student_pickup_notes DROP CONSTRAINT IF EXISTS fk_pickup_notes_created_by_tenant`,
+		`ALTER TABLE schedule.student_pickup_notes DROP CONSTRAINT IF EXISTS fk_pickup_notes_student_tenant`,
+	}
+
+	for _, stmt := range statements {
+		_, err := db.ExecContext(context.Background(), stmt)
+		require.NoError(t, err)
+	}
+}
+
+func restorePickupCompositeFKs(t *testing.T, db *bun.DB) {
+	t.Helper()
+
+	statements := []string{
+		`ALTER TABLE schedule.student_pickup_schedules ADD CONSTRAINT fk_pickup_schedules_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
+		`ALTER TABLE schedule.student_pickup_schedules ADD CONSTRAINT fk_pickup_schedules_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
+		`ALTER TABLE schedule.student_pickup_exceptions ADD CONSTRAINT fk_pickup_exceptions_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
+		`ALTER TABLE schedule.student_pickup_exceptions ADD CONSTRAINT fk_pickup_exceptions_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
+		`ALTER TABLE schedule.student_pickup_notes ADD CONSTRAINT fk_pickup_notes_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
+		`ALTER TABLE schedule.student_pickup_notes ADD CONSTRAINT fk_pickup_notes_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
+	}
+
+	for _, stmt := range statements {
+		_, err := db.ExecContext(context.Background(), stmt)
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			require.NoError(t, err)
+		}
+	}
+}
+
+func createTenantStaff(t *testing.T, db *bun.DB, tenantID int64) int64 {
+	t.Helper()
+
+	person := testpkg.CreateTestPersonForTenant(t, db, tenantID, "PickupRepair", "Staff")
+	var staffID int64
+	err := db.QueryRowContext(context.Background(), `
+		INSERT INTO users.staff (tenant_id, person_id, created_at, updated_at)
+		VALUES (?, ?, NOW(), NOW())
+		RETURNING id
+	`, tenantID, person.ID).Scan(&staffID)
+	require.NoError(t, err)
+
+	return staffID
+}
+
+func createTenantStudent(t *testing.T, db *bun.DB, tenantID int64) int64 {
+	t.Helper()
+
+	person := testpkg.CreateTestPersonForTenant(t, db, tenantID, "PickupRepair", "Student")
+	var studentID int64
+	err := db.QueryRowContext(context.Background(), `
+		INSERT INTO users.students (tenant_id, person_id, school_class, created_at, updated_at)
+		VALUES (?, ?, '1a', NOW(), NOW())
+		RETURNING id
+	`, tenantID, person.ID).Scan(&studentID)
+	require.NoError(t, err)
+
+	return studentID
+}
+
+func insertPickupScheduleWithTenant(t *testing.T, db *bun.DB, tenantID, studentID, staffID int64) int64 {
+	t.Helper()
+
+	var id int64
+	err := db.QueryRowContext(context.Background(), `
+		INSERT INTO schedule.student_pickup_schedules
+			(tenant_id, student_id, weekday, pickup_time, created_by, created_at, updated_at)
+		VALUES (?, ?, 1, ?, ?, NOW(), NOW())
+		RETURNING id
+	`, tenantID, studentID, time.Date(2000, 1, 1, 15, 30, 0, 0, time.UTC), staffID).Scan(&id)
+	require.NoError(t, err)
+
+	return id
+}
+
+func insertPickupExceptionWithTenant(t *testing.T, db *bun.DB, tenantID, studentID, staffID int64) int64 {
+	t.Helper()
+
+	var id int64
+	err := db.QueryRowContext(context.Background(), `
+		INSERT INTO schedule.student_pickup_exceptions
+			(tenant_id, student_id, exception_date, pickup_time, reason, created_by, created_at, updated_at)
+		VALUES (?, ?, CURRENT_DATE, ?, 'Repair test', ?, NOW(), NOW())
+		RETURNING id
+	`, tenantID, studentID, time.Date(2000, 1, 1, 14, 0, 0, 0, time.UTC), staffID).Scan(&id)
+	require.NoError(t, err)
+
+	return id
+}
+
+func insertPickupNoteWithTenant(t *testing.T, db *bun.DB, tenantID, studentID, staffID int64) int64 {
+	t.Helper()
+
+	var id int64
+	err := db.QueryRowContext(context.Background(), `
+		INSERT INTO schedule.student_pickup_notes
+			(tenant_id, student_id, note_date, content, created_by, created_at, updated_at)
+		VALUES (?, ?, CURRENT_DATE, 'Repair note', ?, NOW(), NOW())
+		RETURNING id
+	`, tenantID, studentID, staffID).Scan(&id)
+	require.NoError(t, err)
+
+	return id
+}
+
+func assertTenantID(t *testing.T, db *bun.DB, table string, id, expectedTenantID int64) {
+	t.Helper()
+
+	var tenantID int64
+	err := db.QueryRowContext(context.Background(), "SELECT tenant_id FROM "+table+" WHERE id = ?", id).Scan(&tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, expectedTenantID, tenantID)
+}
+
+func cleanupPickupTenantRepairRows(t *testing.T, db *bun.DB, staffID, studentID int64) {
+	t.Helper()
+
+	_, _ = db.ExecContext(context.Background(), `DELETE FROM schedule.student_pickup_notes WHERE student_id = ?`, studentID)
+	_, _ = db.ExecContext(context.Background(), `DELETE FROM schedule.student_pickup_exceptions WHERE student_id = ?`, studentID)
+	_, _ = db.ExecContext(context.Background(), `DELETE FROM schedule.student_pickup_schedules WHERE student_id = ?`, studentID)
+	_, _ = db.ExecContext(context.Background(), `DELETE FROM users.students WHERE id = ?`, studentID)
+	if staffID > 0 {
+		_, _ = db.ExecContext(context.Background(), `DELETE FROM users.staff WHERE id = ?`, staffID)
+	}
+}

--- a/frontend/src/app/api/ogs-dashboard/route.ts
+++ b/frontend/src/app/api/ogs-dashboard/route.ts
@@ -4,7 +4,10 @@
 // and prevent sequential loading "flash" on student cards
 import type { NextRequest } from "next/server";
 import { apiGet, apiPost } from "~/lib/api-helpers";
+import { createLogger } from "~/lib/logger";
 import { createGetHandler } from "~/lib/route-wrapper";
+
+const logger = createLogger({ component: "OGSDashboardRoute" });
 
 // Backend response types
 interface BackendEducationalGroup {
@@ -167,7 +170,13 @@ export const GET = createGetHandler<OGSDashboardResponse>(
         "/api/students/pickup-times/bulk",
         token,
         { student_ids: studentIds },
-      ).catch(() => ({ data: [] as BackendPickupTime[] }));
+      ).catch((error: unknown) => {
+        logger.warn("ogs_dashboard_pickup_times_fetch_failed", {
+          student_count: studentIds.length,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return { data: [] as BackendPickupTime[] };
+      });
       pickupTimes = pickupResult.data ?? [];
     }
 


### PR DESCRIPTION
## Summary

Repairs legacy pickup schedule data whose `tenant_id` no longer matches the owning student after the tenant-scoped schedule refactor.

## What Changed

- Added migration `1.15.39` to repair `tenant_id` on `schedule.student_pickup_schedules`, `schedule.student_pickup_exceptions`, and `schedule.student_pickup_notes`.
- Temporarily drops the affected pickup composite FKs inside the migration transaction, repairs the rows, then recreates the constraints.
- Fails fast if repair would be unsafe because of missing `created_by`, cross-tenant `created_by`, or post-repair unique conflicts.
- Added migration tests for successful repair, idempotency, cross-tenant creator rejection, and unique conflict rejection.
- Logs OGS dashboard pickup bulk-fetch failures instead of swallowing them silently.

## Root Cause

Some legacy pickup records kept the old tenant assignment while their owning students belong to a different tenant. With the new composite tenant FKs, those rows are filtered out or blocked, so already-entered pickup times stop showing up.

## Validation

- `cd backend && go test ./database/migrations -run 'TestRepairPickupScheduleTenantIDs|TestNoDuplicateMigrationVersions' -count=1`
- `cd backend && go test ./database/migrations -count=1`
- `cd backend && go test ./test/ -run TestHermeticTestPatterns -count=1 -v`
- `cd frontend && pnpm run check`
- `git diff --check`
- Pre-push hook passed: `git-secrets`, `go-vet`, `frontend-knip`, `go-deadcode`, `frontend-check`, `golangci-lint`

## Notes

Existing pickup service/API tests still contain hardcoded `CreatedBy: 1` fixtures and fail against the composite `(tenant_id, created_by)` FK when run directly. That is a separate fixture hygiene issue; production code paths use the authenticated staff ID.
