### PR TITLE
fix(test): make broken cleanup actually run + fix surfaced bugs (#1296)

### DIFF
--- a/backend/api/active/types.go
+++ b/backend/api/active/types.go
@@ -144,9 +144,9 @@ type GroupMappingResponse struct {
 
 // AnalyticsResponse represents analytics API response
 type AnalyticsResponse struct {
-	ActiveGroupsCount int `json:"active_groups_count,omitempty"`
-	TotalVisitsCount  int `json:"total_visits_count,omitempty"`
-	ActiveVisitsCount int `json:"active_visits_count,omitempty"`
+	ActiveGroupsCount int `json:"active_groups_count"`
+	TotalVisitsCount  int `json:"total_visits_count"`
+	ActiveVisitsCount int `json:"active_visits_count"`
 }
 
 // DashboardAnalyticsResponse represents dashboard analytics API response

--- a/backend/database/repositories/activities/group.go
+++ b/backend/database/repositories/activities/group.go
@@ -118,7 +118,7 @@ func (r *GroupRepository) FindAllTemplates(ctx context.Context) ([]*activities.G
 
 // FindWithEnrollmentCounts returns groups with their current enrollment counts
 func (r *GroupRepository) FindWithEnrollmentCounts(ctx context.Context) ([]*activities.Group, map[int64]int, error) {
-	var groups []*activities.Group
+	groups := make([]*activities.Group, 0)
 	groupQuery := base.GetDB(ctx, r.db).NewSelect().
 		Model(&groups).
 		ModelTableExpr(tableExprActivitiesGroupsAsGrp)
@@ -423,7 +423,7 @@ func (r *GroupRepository) Update(ctx context.Context, group *activities.Group) e
 
 // List overrides the base List method to accept the new QueryOptions type
 func (r *GroupRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*activities.Group, error) {
-	var groups []*activities.Group
+	groups := make([]*activities.Group, 0)
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&groups).
 		ModelTableExpr(tableExprActivitiesGroupsAsGrp).

--- a/backend/database/repositories/education/group_substitution.go
+++ b/backend/database/repositories/education/group_substitution.go
@@ -283,7 +283,7 @@ func applyReasonLikeFilter(filter *modelBase.Filter, value interface{}) {
 
 // ListWithOptions provides a type-safe way to list group substitutions with query options
 func (r *GroupSubstitutionRepository) ListWithOptions(ctx context.Context, options *modelBase.QueryOptions) ([]*education.GroupSubstitution, error) {
-	var substitutions []*education.GroupSubstitution
+	substitutions := make([]*education.GroupSubstitution, 0)
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&substitutions).
 		ModelTableExpr(tableExprGroupSubstitutionAsGS)

--- a/backend/database/repositories/schedule/arrival_schedule_repo.go
+++ b/backend/database/repositories/schedule/arrival_schedule_repo.go
@@ -201,7 +201,7 @@ func (r *StudentArrivalScheduleRepository) Update(ctx context.Context, s *schedu
 
 // List retrieves arrival schedules matching the provided query options
 func (r *StudentArrivalScheduleRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentArrivalSchedule, error) {
-	var schedules []*schedule.StudentArrivalSchedule
+	schedules := make([]*schedule.StudentArrivalSchedule, 0)
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&schedules).
 		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`)
@@ -482,7 +482,7 @@ func (r *StudentArrivalExceptionRepository) Update(ctx context.Context, e *sched
 
 // List retrieves arrival exceptions matching the provided query options
 func (r *StudentArrivalExceptionRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentArrivalException, error) {
-	var exceptions []*schedule.StudentArrivalException
+	exceptions := make([]*schedule.StudentArrivalException, 0)
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&exceptions).
 		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`)
@@ -705,7 +705,7 @@ func (r *StudentArrivalNoteRepository) Update(ctx context.Context, n *schedule.S
 
 // List retrieves arrival notes matching the provided query options
 func (r *StudentArrivalNoteRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentArrivalNote, error) {
-	var notes []*schedule.StudentArrivalNote
+	notes := make([]*schedule.StudentArrivalNote, 0)
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&notes).
 		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`)

--- a/backend/database/repositories/schedule/pickup_schedule.go
+++ b/backend/database/repositories/schedule/pickup_schedule.go
@@ -211,7 +211,7 @@ func (r *StudentPickupScheduleRepository) Update(ctx context.Context, s *schedul
 
 // List retrieves pickup schedules matching the provided query options
 func (r *StudentPickupScheduleRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentPickupSchedule, error) {
-	var schedules []*schedule.StudentPickupSchedule
+	schedules := make([]*schedule.StudentPickupSchedule, 0)
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&schedules).
 		ModelTableExpr(`schedule.student_pickup_schedules AS "student_pickup_schedule"`)
@@ -496,7 +496,7 @@ func (r *StudentPickupExceptionRepository) Update(ctx context.Context, e *schedu
 
 // List retrieves pickup exceptions matching the provided query options
 func (r *StudentPickupExceptionRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentPickupException, error) {
-	var exceptions []*schedule.StudentPickupException
+	exceptions := make([]*schedule.StudentPickupException, 0)
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&exceptions).
 		ModelTableExpr(`schedule.student_pickup_exceptions AS "student_pickup_exception"`)
@@ -721,7 +721,7 @@ func (r *StudentPickupNoteRepository) Update(ctx context.Context, n *schedule.St
 
 // List retrieves pickup notes matching the provided query options
 func (r *StudentPickupNoteRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentPickupNote, error) {
-	var notes []*schedule.StudentPickupNote
+	notes := make([]*schedule.StudentPickupNote, 0)
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&notes).
 		ModelTableExpr(`schedule.student_pickup_notes AS "student_pickup_note"`)

--- a/backend/services/activities/enrollment_operations.go
+++ b/backend/services/activities/enrollment_operations.go
@@ -239,7 +239,7 @@ func (s *Service) GetAvailableGroups(ctx context.Context, studentID int64) ([]*a
 	}
 
 	// Filter out already enrolled groups
-	var availableGroups []*activities.Group
+	availableGroups := make([]*activities.Group, 0)
 	for _, group := range allGroups {
 		if !enrolledMap[group.ID] {
 			availableGroups = append(availableGroups, group)

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -371,29 +371,25 @@ func CleanupActivityFixtures(tb testing.TB, db *bun.DB, ids ...int64) {
 
 		// Delete from education.group_substitution (depends on group and staff)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("education.group_substitution").
+			TableExpr("education.group_substitution").
 			Where("group_id = ? OR regular_staff_id = ? OR substitute_staff_id = ?", id, id, id),
 			"education.group_substitution")
 
 		// Delete from education.group_teacher (depends on group and teacher)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("education.group_teacher").
+			TableExpr("education.group_teacher").
 			Where("group_id = ? OR teacher_id = ?", id, id),
 			"education.group_teacher")
 
 		// Delete from users.teachers (depends on staff)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table(tableUsersTeachers).
+			TableExpr(tableUsersTeachers).
 			Where("id = ? OR staff_id = ?", id, id),
 			tableUsersTeachers)
 
 		// Delete from education.groups
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("education.groups").
+			TableExpr("education.groups").
 			Where(whereIDEquals, id),
 			"education.groups")
 
@@ -403,22 +399,19 @@ func CleanupActivityFixtures(tb testing.TB, db *bun.DB, ids ...int64) {
 
 		// Delete from active.visits by direct ID, by student_id, or by active_group_id
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table(tableActiveVisits).
+			TableExpr(tableActiveVisits).
 			Where("id = ? OR student_id = ? OR active_group_id = ?", id, id, id),
 			tableActiveVisits)
 
 		// Delete from active.visits (cascade cleanup via activities.groups reference)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table(tableActiveVisits).
+			TableExpr(tableActiveVisits).
 			Where("active_group_id IN (SELECT id FROM active.groups WHERE group_id = ?)", id),
 			"active.visits (cascade)")
 
 		// Delete from active.groups by direct ID or by reference
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("active.groups").
+			TableExpr("active.groups").
 			Where("id = ? OR group_id = ? OR device_id = ?", id, id, id),
 			"active.groups")
 
@@ -428,22 +421,19 @@ func CleanupActivityFixtures(tb testing.TB, db *bun.DB, ids ...int64) {
 
 		// Delete from activities.student_enrollments (depends on activities.groups)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("activities.student_enrollments").
+			TableExpr("activities.student_enrollments").
 			Where("activity_group_id = ?", id),
 			"activities.student_enrollments")
 
 		// Delete from activities.groups by ID or by category_id (to handle FK constraint)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("activities.groups").
+			TableExpr("activities.groups").
 			Where("id = ? OR category_id = ?", id, id),
 			"activities.groups")
 
 		// Delete from activities.categories (now safe after groups referencing them are deleted)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("activities.categories").
+			TableExpr("activities.categories").
 			Where(whereIDEquals, id),
 			"activities.categories")
 
@@ -453,8 +443,7 @@ func CleanupActivityFixtures(tb testing.TB, db *bun.DB, ids ...int64) {
 
 		// Delete from iot.devices
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("iot.devices").
+			TableExpr("iot.devices").
 			Where(whereIDEquals, id),
 			"iot.devices")
 
@@ -464,8 +453,7 @@ func CleanupActivityFixtures(tb testing.TB, db *bun.DB, ids ...int64) {
 
 		// Delete from facilities.rooms
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("facilities.rooms").
+			TableExpr("facilities.rooms").
 			Where(whereIDEquals, id),
 			"facilities.rooms")
 
@@ -475,43 +463,37 @@ func CleanupActivityFixtures(tb testing.TB, db *bun.DB, ids ...int64) {
 
 		// Delete from users.guests (depends on staff)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("users.guests").
+			TableExpr("users.guests").
 			Where("id = ? OR staff_id = ?", id, id),
 			"users.guests")
 
 		// Delete from users.profiles (depends on account)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("users.profiles").
+			TableExpr("users.profiles").
 			Where(whereIDOrAccountID, id, id),
 			"users.profiles")
 
 		// Delete from active.attendance (by student_id before deleting student)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("active.attendance").
+			TableExpr("active.attendance").
 			Where("student_id = ?", id),
 			"active.attendance")
 
 		// Delete from users.students
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("users.students").
+			TableExpr("users.students").
 			Where(whereIDEquals, id),
 			"users.students")
 
 		// Delete from users.staff
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table(tableUsersStaff).
+			TableExpr(tableUsersStaff).
 			Where(whereIDEquals, id),
 			tableUsersStaff)
 
 		// Delete from users.persons (last, as it's referenced by students and staff)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table(tableUsersPersons).
+			TableExpr(tableUsersPersons).
 			Where(whereIDEquals, id),
 			tableUsersPersons)
 
@@ -521,8 +503,7 @@ func CleanupActivityFixtures(tb testing.TB, db *bun.DB, ids ...int64) {
 
 		// Delete from active.group_supervisors
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("active.group_supervisors").
+			TableExpr("active.group_supervisors").
 			Where("id = ? OR staff_id = ? OR group_id = ?", id, id, id),
 			"active.group_supervisors")
 
@@ -537,29 +518,25 @@ func CleanupActivityFixtures(tb testing.TB, db *bun.DB, ids ...int64) {
 
 		// Delete from users.privacy_consents (by student_id)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("users.privacy_consents").
+			TableExpr("users.privacy_consents").
 			Where("id = ? OR student_id = ?", id, id),
 			"users.privacy_consents")
 
 		// Delete from users.persons_guardians (by person_id or guardian_account_id)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("users.persons_guardians").
+			TableExpr("users.persons_guardians").
 			Where("id = ? OR person_id = ? OR guardian_account_id = ?", id, id, id),
 			"users.persons_guardians")
 
 		// Delete from users.guardian_profiles
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("users.guardian_profiles").
+			TableExpr("users.guardian_profiles").
 			Where(whereIDEquals, id),
 			"users.guardian_profiles")
 
 		// Delete from users.rfid_cards (note: string ID, but try as int64)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table(tableUsersRFIDCards).
+			TableExpr(tableUsersRFIDCards).
 			Where(whereIDEquals, fmt.Sprintf("%d", id)),
 			tableUsersRFIDCards)
 	}
@@ -643,8 +620,7 @@ func CleanupRFIDCards(tb testing.TB, db *bun.DB, tagIDs ...string) {
 
 	for _, tagID := range tagIDs {
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table(tableUsersRFIDCards).
+			TableExpr(tableUsersRFIDCards).
 			Where(whereIDEquals, tagID),
 			tableUsersRFIDCards)
 	}
@@ -826,8 +802,7 @@ func CleanupPerson(tb testing.TB, db *bun.DB, personID int64) {
 	tb.Helper()
 
 	cleanupDelete(tb, db.NewDelete().
-		Model((*interface{})(nil)).
-		Table(tableUsersPersons).
+		TableExpr(tableUsersPersons).
 		Where(whereIDEquals, personID),
 		tableUsersPersons)
 }
@@ -867,23 +842,20 @@ func CleanupStaffFixtures(tb testing.TB, db *bun.DB, staffIDs ...int64) {
 
 		// Delete teacher if exists (depends on staff)
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table(tableUsersTeachers).
+			TableExpr(tableUsersTeachers).
 			Where("staff_id = ?", staffID),
 			tableUsersTeachers)
 
 		// Delete staff
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table(tableUsersStaff).
+			TableExpr(tableUsersStaff).
 			Where(whereIDEquals, staffID),
 			tableUsersStaff)
 
 		// Delete person if we found one
 		if staff.PersonID > 0 {
 			cleanupDelete(tb, db.NewDelete().
-				Model((*interface{})(nil)).
-				Table(tableUsersPersons).
+				TableExpr(tableUsersPersons).
 				Where(whereIDEquals, staff.PersonID),
 				tableUsersPersons)
 		}
@@ -940,16 +912,14 @@ func CleanupTeacherFixtures(tb testing.TB, db *bun.DB, teacherIDs ...int64) {
 
 		// Delete teacher
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table(tableUsersTeachers).
+			TableExpr(tableUsersTeachers).
 			Where(whereIDEquals, teacherID),
 			tableUsersTeachers)
 
 		// Delete staff
 		if teacher.StaffID > 0 {
 			cleanupDelete(tb, db.NewDelete().
-				Model((*interface{})(nil)).
-				Table(tableUsersStaff).
+				TableExpr(tableUsersStaff).
 				Where(whereIDEquals, teacher.StaffID),
 				tableUsersStaff)
 		}
@@ -957,8 +927,7 @@ func CleanupTeacherFixtures(tb testing.TB, db *bun.DB, teacherIDs ...int64) {
 		// Delete person
 		if staff.PersonID > 0 {
 			cleanupDelete(tb, db.NewDelete().
-				Model((*interface{})(nil)).
-				Table(tableUsersPersons).
+				TableExpr(tableUsersPersons).
 				Where(whereIDEquals, staff.PersonID),
 				tableUsersPersons)
 		}
@@ -1679,8 +1648,7 @@ func CleanupScheduleFixtures(tb testing.TB, db *bun.DB, timeframeIDs ...int64) {
 
 	for _, id := range timeframeIDs {
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("schedule.timeframes").
+			TableExpr("schedule.timeframes").
 			Where(whereIDEquals, id),
 			"schedule.timeframes")
 	}
@@ -1774,8 +1742,7 @@ func CleanupInvitationFixtures(tb testing.TB, db *bun.DB, invitationIDs ...int64
 
 	for _, id := range invitationIDs {
 		cleanupDelete(tb, db.NewDelete().
-			Model((*interface{})(nil)).
-			Table("auth.invitation_tokens").
+			TableExpr("auth.invitation_tokens").
 			Where(whereIDEquals, id),
 			"auth.invitation_tokens")
 	}

--- a/backend/test/helpers.go
+++ b/backend/test/helpers.go
@@ -130,6 +130,18 @@ For CI, set TEST_DB_DSN as an environment variable.`)
 		VALUES (1, 1, 'Default Room', 'Default')
 		ON CONFLICT (id) DO NOTHING`)
 
+	// Ensure default system staff exists (person ID 1, staff ID 1) for legacy
+	// tests that hardcode CreatedBy: 1 to satisfy created_by FK constraints on
+	// schedule/activity tables. Same convention as rooms.id=1 and schools.id=1.
+	_, _ = db.ExecContext(context.Background(), `
+		INSERT INTO users.persons (id, tenant_id, first_name, last_name)
+		VALUES (1, 1, 'System', 'Test')
+		ON CONFLICT (id) DO NOTHING`)
+	_, _ = db.ExecContext(context.Background(), `
+		INSERT INTO users.staff (id, tenant_id, person_id)
+		VALUES (1, 1, 1)
+		ON CONFLICT (id) DO NOTHING`)
+
 	// Advance the BIGSERIAL sequence past any explicitly-inserted IDs.
 	// Uses nextval (atomic, never goes backwards) instead of setval to avoid
 	// races when parallel test packages call SetupTestDB concurrently.
@@ -138,6 +150,10 @@ For CI, set TEST_DB_DSN as an environment variable.`)
 		BEGIN
 			SELECT COALESCE(MAX(id), 0) INTO max_id FROM facilities.rooms;
 			WHILE nextval('facilities.rooms_id_seq') < max_id LOOP END LOOP;
+			SELECT COALESCE(MAX(id), 0) INTO max_id FROM users.persons;
+			WHILE nextval('users.persons_id_seq') < max_id LOOP END LOOP;
+			SELECT COALESCE(MAX(id), 0) INTO max_id FROM users.staff;
+			WHILE nextval('users.staff_id_seq') < max_id LOOP END LOOP;
 		END $$`)
 
 	return db

--- a/backend/test/hermetic_verification_test.go
+++ b/backend/test/hermetic_verification_test.go
@@ -58,6 +58,22 @@ func TestHermeticTestPatterns(t *testing.T) {
 				len(violations), strings.Join(violations, "\n"))
 		}
 	})
+
+	t.Run("no_broken_cleanup_model_pattern", func(t *testing.T) {
+		violations := checkBrokenCleanupPattern(t, backendRoot)
+		if len(violations) > 0 {
+			t.Errorf("Found %d use(s) of the broken Model((*interface{})(nil)) cleanup pattern:\n\n%s\n\n"+
+				"This pattern is silently rejected by bun (interface{} is not a struct),\n"+
+				"causing every Exec() to short-circuit without running SQL — the cleanup\n"+
+				"becomes a no-op and tests rely on stale data from previous runs (#1296).\n\n"+
+				"Fix: replace with TableExpr(...) — the same pattern CleanupTableRecords uses.\n"+
+				"  // Before (no-op):\n"+
+				"  db.NewDelete().Model((*interface{})(nil)).Table(\"users.students\").Where(...)\n\n"+
+				"  // After (correct):\n"+
+				"  db.NewDelete().TableExpr(\"users.students\").Where(...)",
+				len(violations), strings.Join(violations, "\n"))
+		}
+	})
 }
 
 // findBackendRoot walks up the directory tree to find the backend root.
@@ -348,6 +364,70 @@ func checkMissingSetupTestDB(t *testing.T, root string) []string {
 		if hasDBOps && !usesSetup && !usesMocks {
 			relPath, _ := filepath.Rel(root, path)
 			violations = append(violations, "  - "+relPath)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Logf("Warning: error walking directory: %v", err)
+	}
+
+	return violations
+}
+
+// checkBrokenCleanupPattern scans the test helper package for the
+// Model((*interface{})(nil)) cleanup pattern that bun silently rejects.
+// See issue #1296 — every call site logged an error via tb.Logf but never
+// failed the test, so cleanup was a no-op for months.
+func checkBrokenCleanupPattern(t *testing.T, root string) []string {
+	t.Helper()
+
+	var violations []string
+
+	brokenPattern := regexp.MustCompile(`Model\(\(\*interface\{\}\)\(nil\)\)`)
+
+	// Only scan the test helper package — production code uses concrete types
+	// like Model((*MyStruct)(nil)) which is valid.
+	testDir := filepath.Join(root, "test")
+
+	err := filepath.Walk(testDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// Skip this file — it intentionally contains the pattern in error messages.
+		if filepath.Base(path) == "hermetic_verification_test.go" {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return nil
+		}
+		defer func() { _ = file.Close() }()
+
+		relPath, _ := filepath.Rel(root, path)
+
+		scanner := bufio.NewScanner(file)
+		lineNum := 0
+		for scanner.Scan() {
+			lineNum++
+			line := scanner.Text()
+
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+
+			if brokenPattern.MatchString(line) {
+				violations = append(violations,
+					formatViolation(relPath, lineNum, strings.TrimSpace(line)))
+			}
 		}
 
 		return nil


### PR DESCRIPTION
Closes #1296

## Summary

- **Root fix**: Replace 33 silent-no-op `Model((*interface{})(nil)).Table(...)` cleanup calls with the working `TableExpr(...)` pattern. Bun rejects `interface{}` as a non-struct, every `.Exec()` short-circuited without running SQL, and the error was logged via `tb.Logf` but never failed the test — so cleanup has been broken for months without anyone noticing.
- **Surfaced fixes**: Once cleanup actually ran, 121 latent test failures appeared. Root-caused into 3 categories:
  - Missing system-staff fixture: legacy tests hardcode `CreatedBy: 1`, which only worked because old staff rows survived the broken cleanup. `SetupTestDB` now ensures `users.persons(id=1)` and `users.staff(id=1)` exist, same convention as the existing `rooms.id=1` and `schools.id=1`.
  - 7 repository nil-vs-empty-slice bugs: `List()` / `FindWithEnrollmentCounts()` returned `nil` when the table was empty, but tests assert `NotNil` (which they should — empty slice ≠ nil in Go). Fixed by initializing with `make([]*T, 0)` in arrival/pickup/group/substitution repos and `enrollment_operations.GetAvailableGroups`.
  - API contract leak: `AnalyticsResponse` count fields had `omitempty`, so a count of 0 vanished from the JSON entirely. Clients couldn't tell "0 groups" from "field missing". Removed `omitempty` from the three count fields.
- **Guard test**: New sub-test in `TestHermeticTestPatterns` greps the `test/` package for the broken pattern and fails CI if it ever returns.

## Acceptance criteria (from #1296)

- [x] All `.Model((*interface{})(nil))` call sites replaced (33 in `fixtures.go`)
- [x] Full `go test ./...` passes on a clean `phoenix_test` DB
- [x] Full `go test ./...` passes a second time back-to-back (the actual regression this prevents)
- [x] Guard test prevents the broken pattern from returning

## Post-merge action for developers

Your local `phoenix_test` DB likely contains months of accumulated junk that the broken cleanup left behind (e.g. hundreds of leftover students with class names like `BC1`, `BOW1`). Reset it once after merging:

```bash
docker compose --profile test down postgres-test -v
docker compose --profile test up -d postgres-test
APP_ENV=test docker compose run server ./main migrate
```

Without this, tests that match by literal string (rather than ID) may fail with unique-constraint violations from old rows. New rows will continue to be cleaned up correctly.

## Notes

- Race-condition failures in parallel runs (~1–2 tests, hardcoded `tenant_id=90004` collisions between packages) still occur intermittently. CI's `gotestsum --rerun-fails` already absorbs these. Serial (`go test -p 1 ./...`) is fully green. These are pre-existing latent issues, out of scope for this PR.
- The first commit's message got truncated to a single line — the diff itself is correct (`+33 / -66`, exactly as expected).

## Test plan

- [x] `go test -p 1 ./...` passes on clean DB (Run #1 = exit 0)
- [x] `go test -p 1 ./...` passes back-to-back without DB reset (Run #2 = exit 0)
- [x] `go test ./test/ -run TestHermeticTestPatterns -v` passes all 3 sub-tests including new `no_broken_cleanup_model_pattern`
- [x] `go build ./...` and `go vet ./...` both clean