### PR TITLE
feat(rooms): customisable per-room badge colors

### DIFF
--- a/backend/api/active/groups_handlers.go
+++ b/backend/api/active/groups_handlers.go
@@ -350,6 +350,10 @@ type visitWithStudent struct {
 	ExcusedSince  *time.Time `bun:"excused_since"`
 	CreatedAt     time.Time  `bun:"created_at"`
 	UpdatedAt     time.Time  `bun:"updated_at"`
+	VisitedRoomID int64      `bun:"visited_room_id"` // active.groups.room_id (NOT NULL); always populated via INNER JOIN
+	RoomName      string     `bun:"room_name"`       // facilities.rooms.name; required for system-room badge overrides
+	RoomColor     *string    `bun:"room_color"`      // Per-room hex color (nullable: room may have no color)
+	StammraumID   *int64     `bun:"stammraum_id"`    // education.groups.room_id (nullable: student may have no group or group no room)
 }
 
 // fetchVisitsWithDisplayData fetches visits with student display data
@@ -372,10 +376,16 @@ func (rs *Resource) fetchVisitsWithDisplayData(r *http.Request, activeGroupID in
 		ColumnExpr("s.sick_since").
 		ColumnExpr("s.excused").
 		ColumnExpr("s.excused_since").
+		ColumnExpr("ag.room_id AS visited_room_id").
+		ColumnExpr("COALESCE(vr.name, '') AS room_name").
+		ColumnExpr("vr.color AS room_color").
+		ColumnExpr("g.room_id AS stammraum_id").
 		TableExpr("active.visits AS v").
 		Join("INNER JOIN users.students AS s ON s.id = v.student_id").
 		Join("INNER JOIN users.persons AS p ON p.id = s.person_id").
 		Join("LEFT JOIN education.groups AS g ON g.id = s.group_id").
+		Join("INNER JOIN active.groups AS ag ON ag.id = v.active_group_id").
+		Join("LEFT JOIN facilities.rooms AS vr ON vr.id = ag.room_id").
 		Where("v.active_group_id = ?", activeGroupID).
 		Where("v.exit_time IS NULL").
 		OrderExpr("v.entry_time DESC").
@@ -397,6 +407,13 @@ func (rs *Resource) buildVisitDisplayResponses(results []visitWithStudent) []Vis
 		if result.Excused != nil {
 			excused = *result.Excused
 		}
+		// Resolve final badge color with reserved semantic overrides for
+		// stammraum and system rooms. Frontend uses this verbatim.
+		badgeColor := common.ResolveRoomBadgeColor(
+			result.RoomName,
+			result.RoomColor,
+			result.StammraumID != nil && result.VisitedRoomID == *result.StammraumID,
+		)
 		responses = append(responses, VisitWithDisplayDataResponse{
 			ID:            result.VisitID,
 			StudentID:     result.StudentID,
@@ -411,6 +428,7 @@ func (rs *Resource) buildVisitDisplayResponses(results []visitWithStudent) []Vis
 			SickSince:     result.SickSince,
 			Excused:       excused,
 			ExcusedSince:  result.ExcusedSince,
+			BadgeColor:    badgeColor,
 			CreatedAt:     result.CreatedAt,
 			UpdatedAt:     result.UpdatedAt,
 		})

--- a/backend/api/active/types.go
+++ b/backend/api/active/types.go
@@ -99,6 +99,7 @@ type VisitWithDisplayDataResponse struct {
 	SickSince     *time.Time `json:"sick_since,omitempty"`
 	Excused       bool       `json:"excused"`
 	ExcusedSince  *time.Time `json:"excused_since,omitempty"`
+	BadgeColor    *string    `json:"badge_color,omitempty"` // Resolved badge color: green for stammraum, otherwise the room's custom color
 	CreatedAt     time.Time  `json:"created_at"`
 	UpdatedAt     time.Time  `json:"updated_at"`
 }

--- a/backend/api/common/badge.go
+++ b/backend/api/common/badge.go
@@ -1,0 +1,32 @@
+package common
+
+import "github.com/moto-nrw/project-phoenix/constants"
+
+// BadgeStammraumGreen is the badge color reserved for students who are
+// currently in the room assigned to their education group (Stammraum).
+//
+// Cross-stack parity (must stay in lock-step):
+//   - frontend/src/lib/location-helper.ts → LOCATION_COLORS.GROUP_ROOM
+//   - TestBadgeStammraumGreenLiteral pins this Go constant
+//   - location-helper.test.ts pins the matching TS constant
+//
+// If you change the hex here, change it on the frontend in the same commit.
+const BadgeStammraumGreen = "#83CD2D"
+
+// ResolveRoomBadgeColor returns the badge color for a student's currently
+// visited room. Stammraum (own group's room) wins with reserved green.
+// System rooms (Schulhof, WC) are not part of the customisable-colour
+// feature — they return nil so the frontend keeps its existing status-based
+// rendering. All other rooms return their stored custom colour (or nil).
+func ResolveRoomBadgeColor(roomName string, roomColor *string, isStammraum bool) *string {
+	if isStammraum {
+		green := BadgeStammraumGreen
+		return &green
+	}
+
+	if constants.IsSystemRoomName(roomName) {
+		return nil
+	}
+
+	return roomColor
+}

--- a/backend/api/common/badge_test.go
+++ b/backend/api/common/badge_test.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/constants"
+)
+
+func TestResolveRoomBadgeColor(t *testing.T) {
+	t.Run("returns stammraum green when in own room", func(t *testing.T) {
+		roomColor := "#06B6D4"
+
+		resolved := ResolveRoomBadgeColor("Gruppenraum", &roomColor, true)
+
+		if resolved == nil || *resolved != BadgeStammraumGreen {
+			t.Fatalf("expected stammraum green %q, got %v", BadgeStammraumGreen, resolved)
+		}
+	})
+
+	t.Run("returns nil for system rooms (not part of customisable colour feature)", func(t *testing.T) {
+		// System rooms keep their existing frontend status-based rendering.
+		// Even if the DB has a colour stored on them, the resolver ignores it.
+		schulhofColor := "#123456"
+		if got := ResolveRoomBadgeColor(constants.SchulhofRoomName, &schulhofColor, false); got != nil {
+			t.Errorf("expected nil for Schulhof, got %v", got)
+		}
+
+		wcColor := "#654321"
+		if got := ResolveRoomBadgeColor(constants.WCRoomName, &wcColor, false); got != nil {
+			t.Errorf("expected nil for WC, got %v", got)
+		}
+	})
+
+	t.Run("falls back to room color for regular rooms", func(t *testing.T) {
+		roomColor := "#06B6D4"
+
+		resolved := ResolveRoomBadgeColor("Musikraum", &roomColor, false)
+
+		if resolved == nil || *resolved != roomColor {
+			t.Fatalf("expected room color %q, got %v", roomColor, resolved)
+		}
+	})
+}
+
+// TestBadgeStammraumGreenLiteral pins the stammraum green to the exact hex
+// shared with the frontend (LOCATION_COLORS.GROUP_ROOM). The matching TS
+// assertion lives in frontend/src/lib/location-helper.test.ts. If this test
+// fails, the two sides have drifted and badge colors will silently disagree.
+func TestBadgeStammraumGreenLiteral(t *testing.T) {
+	const expected = "#83CD2D"
+	if BadgeStammraumGreen != expected {
+		t.Fatalf("BadgeStammraumGreen drift: got %q, want %q — frontend LOCATION_COLORS.GROUP_ROOM must change in lock-step",
+			BadgeStammraumGreen, expected)
+	}
+}

--- a/backend/api/common/student_locations.go
+++ b/backend/api/common/student_locations.go
@@ -11,8 +11,10 @@ import (
 
 // StudentLocationInfo contains resolved location data including timestamps
 type StudentLocationInfo struct {
-	Location string
-	Since    *time.Time // When the student entered this location (nil if not in a room)
+	Location   string
+	Since      *time.Time // When the student entered this location (nil if not in a room)
+	BadgeColor *string    // Per-room hex color (nil when student is not in a room with a custom color)
+	RoomID     *int64     // ID of the room the student is currently in (nil when not in a room)
 }
 
 // StudentLocationSnapshot caches attendance, visit, and group data for a set of students.
@@ -171,9 +173,12 @@ func (s *StudentLocationSnapshot) ResolveStudentLocationWithTime(studentID int64
 	}
 
 	if group.Room != nil && group.Room.Name != "" {
+		roomID := group.Room.ID
 		return StudentLocationInfo{
-			Location: fmt.Sprintf("Anwesend - %s", group.Room.Name),
-			Since:    &visit.EntryTime,
+			Location:   fmt.Sprintf("Anwesend - %s", group.Room.Name),
+			Since:      &visit.EntryTime,
+			BadgeColor: ResolveRoomBadgeColor(group.Room.Name, group.Room.Color, false),
+			RoomID:     &roomID,
 		}
 	}
 

--- a/backend/api/students/response_helpers.go
+++ b/backend/api/students/response_helpers.go
@@ -134,6 +134,19 @@ func populateSnapshotPublicFields(response *StudentResponse, student *users.Stud
 	}
 }
 
+// applyStammraumOverride sets the response's BadgeColor to green when the
+// student is in the room assigned to their education group. Otherwise leaves
+// the color resolved from the visited room as-is.
+func applyStammraumOverride(response *StudentResponse, info common.StudentLocationInfo, group *education.Group) {
+	if info.RoomID == nil || group == nil || group.RoomID == nil {
+		return
+	}
+	if *info.RoomID == *group.RoomID {
+		green := common.BadgeStammraumGreen
+		response.BadgeColor = &green
+	}
+}
+
 // presentOrTransit returns the appropriate location for a checked-in student
 // without a specific room assignment, based on access level.
 func presentOrTransit(hasFullAccess bool) common.StudentLocationInfo {
@@ -176,9 +189,12 @@ func resolveStudentLocationWithTime(ctx context.Context, studentID int64, hasFul
 
 	// Include room name for all authenticated staff (needed for supervised room checkout)
 	if activeGroup.Room != nil && activeGroup.Room.Name != "" {
+		roomID := activeGroup.Room.ID
 		return common.StudentLocationInfo{
-			Location: fmt.Sprintf("Anwesend - %s", activeGroup.Room.Name),
-			Since:    &currentVisit.EntryTime,
+			Location:   fmt.Sprintf("Anwesend - %s", activeGroup.Room.Name),
+			Since:      &currentVisit.EntryTime,
+			BadgeColor: common.ResolveRoomBadgeColor(activeGroup.Room.Name, activeGroup.Room.Color, false),
+			RoomID:     &roomID,
 		}
 	}
 
@@ -219,6 +235,8 @@ func newStudentResponseWithOpts(ctx context.Context, opts StudentResponseOpts, s
 		locationInfo := resolveStudentLocationWithTime(ctx, student.ID, hasFullAccess, services.ActiveService)
 		response.Location = locationInfo.Location
 		response.LocationSince = locationInfo.Since
+		response.BadgeColor = locationInfo.BadgeColor
+		applyStammraumOverride(&response, locationInfo, group)
 	}
 
 	populatePersonAndGuardianData(&response, person, student, group, hasFullAccess)
@@ -255,6 +273,8 @@ func newStudentResponseFromSnapshot(_ context.Context, student *users.Student, p
 	locationInfo := snapshot.ResolveLocationWithTime(student.ID, hasFullAccess)
 	response.Location = locationInfo.Location
 	response.LocationSince = locationInfo.Since
+	response.BadgeColor = locationInfo.BadgeColor
+	applyStammraumOverride(&response, locationInfo, group)
 
 	populatePersonAndGuardianData(&response, person, student, group, hasFullAccess)
 	populateSnapshotPublicFields(&response, student)

--- a/backend/api/students/response_helpers_test.go
+++ b/backend/api/students/response_helpers_test.go
@@ -1,0 +1,109 @@
+package students
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	educationModel "github.com/moto-nrw/project-phoenix/models/education"
+)
+
+// int64Ptr returns a pointer to the given int64.
+// (strPtr is already defined in pickup_schedule_bind_test.go for this package.)
+func int64Ptr(v int64) *int64 { return &v }
+
+func TestApplyStammraumOverride_StudentInOwnStammraum_SetsGreen(t *testing.T) {
+	resp := &StudentResponse{BadgeColor: strPtr("#06B6D4")}
+	info := common.StudentLocationInfo{
+		RoomID:     int64Ptr(5),
+		BadgeColor: strPtr("#06B6D4"),
+	}
+	group := &educationModel.Group{RoomID: int64Ptr(5)}
+
+	applyStammraumOverride(resp, info, group)
+
+	if resp.BadgeColor == nil {
+		t.Fatalf("expected BadgeColor to be set, got nil")
+	}
+	if *resp.BadgeColor != common.BadgeStammraumGreen {
+		t.Errorf("expected BadgeColor=%q (Stammraum green), got %q", common.BadgeStammraumGreen, *resp.BadgeColor)
+	}
+}
+
+func TestApplyStammraumOverride_StudentInDifferentRoom_PreservesRoomColor(t *testing.T) {
+	roomColor := "#06B6D4"
+	resp := &StudentResponse{BadgeColor: &roomColor}
+	info := common.StudentLocationInfo{
+		RoomID:     int64Ptr(7),
+		BadgeColor: &roomColor,
+	}
+	group := &educationModel.Group{RoomID: int64Ptr(5)}
+
+	applyStammraumOverride(resp, info, group)
+
+	if resp.BadgeColor == nil || *resp.BadgeColor != roomColor {
+		t.Errorf("expected BadgeColor to stay %q, got %v", roomColor, resp.BadgeColor)
+	}
+}
+
+func TestApplyStammraumOverride_NilGroup_NoOverride(t *testing.T) {
+	roomColor := "#06B6D4"
+	resp := &StudentResponse{BadgeColor: &roomColor}
+	info := common.StudentLocationInfo{
+		RoomID:     int64Ptr(5),
+		BadgeColor: &roomColor,
+	}
+
+	applyStammraumOverride(resp, info, nil)
+
+	if resp.BadgeColor == nil || *resp.BadgeColor != roomColor {
+		t.Errorf("expected BadgeColor to stay %q, got %v", roomColor, resp.BadgeColor)
+	}
+}
+
+func TestApplyStammraumOverride_GroupWithoutStammraum_NoOverride(t *testing.T) {
+	roomColor := "#06B6D4"
+	resp := &StudentResponse{BadgeColor: &roomColor}
+	info := common.StudentLocationInfo{
+		RoomID:     int64Ptr(5),
+		BadgeColor: &roomColor,
+	}
+	group := &educationModel.Group{RoomID: nil}
+
+	applyStammraumOverride(resp, info, group)
+
+	if resp.BadgeColor == nil || *resp.BadgeColor != roomColor {
+		t.Errorf("expected BadgeColor to stay %q, got %v", roomColor, resp.BadgeColor)
+	}
+}
+
+func TestApplyStammraumOverride_StudentNotInRoom_NoOverride(t *testing.T) {
+	resp := &StudentResponse{BadgeColor: nil}
+	info := common.StudentLocationInfo{RoomID: nil}
+	group := &educationModel.Group{RoomID: int64Ptr(5)}
+
+	applyStammraumOverride(resp, info, group)
+
+	if resp.BadgeColor != nil {
+		t.Errorf("expected BadgeColor to stay nil, got %q", *resp.BadgeColor)
+	}
+}
+
+func TestApplyStammraumOverride_NilBadgeColorAndStammraumMatch_StillSetsGreen(t *testing.T) {
+	// Simulates a stammraum that has no custom color set: backend sends nil
+	// from the resolver, but stammraum match still wins.
+	resp := &StudentResponse{BadgeColor: nil}
+	info := common.StudentLocationInfo{
+		RoomID:     int64Ptr(5),
+		BadgeColor: nil,
+	}
+	group := &educationModel.Group{RoomID: int64Ptr(5)}
+
+	applyStammraumOverride(resp, info, group)
+
+	if resp.BadgeColor == nil {
+		t.Fatalf("expected BadgeColor to be green, got nil")
+	}
+	if *resp.BadgeColor != common.BadgeStammraumGreen {
+		t.Errorf("expected BadgeColor=%q, got %q", common.BadgeStammraumGreen, *resp.BadgeColor)
+	}
+}

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -22,6 +22,7 @@ type StudentResponse struct {
 	SchoolClass        string     `json:"school_class"`
 	Location           string     `json:"current_location"`
 	LocationSince      *time.Time `json:"location_since,omitempty"` // When student entered current location
+	BadgeColor         *string    `json:"badge_color,omitempty"`    // Per-room hex color of the active group's room (nil when not in a room)
 	GuardianName       string     `json:"guardian_name,omitempty"`
 	GuardianContact    string     `json:"guardian_contact,omitempty"`
 	GuardianEmail      string     `json:"guardian_email,omitempty"`

--- a/backend/database/repositories/facilities/room.go
+++ b/backend/database/repositories/facilities/room.go
@@ -81,6 +81,35 @@ func (r *RoomRepository) Update(ctx context.Context, room *facilities.Room) erro
 	return base.AssertRowsAffected(result, 1, "update room")
 }
 
+// FindByIDs retrieves rooms by a list of IDs in one query and returns them keyed by ID.
+func (r *RoomRepository) FindByIDs(ctx context.Context, ids []int64) (map[int64]*facilities.Room, error) {
+	if len(ids) == 0 {
+		return map[int64]*facilities.Room{}, nil
+	}
+
+	var rooms []*facilities.Room
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&rooms).
+		ModelTableExpr(tableExprFacilitiesRoomsAsRoom).
+		Where("room.id IN (?)", bun.In(ids))
+
+	if where, val, ok := base.TenantWhere(ctx, "room"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "find by ids", Err: err}
+	}
+
+	result := make(map[int64]*facilities.Room, len(rooms))
+	for _, room := range rooms {
+		if room != nil {
+			result[room.ID] = room
+		}
+	}
+	return result, nil
+}
+
 // FindByName retrieves a room by its name
 func (r *RoomRepository) FindByName(ctx context.Context, name string) (*facilities.Room, error) {
 	room := new(facilities.Room)

--- a/backend/database/repositories/facilities/room.go
+++ b/backend/database/repositories/facilities/room.go
@@ -91,7 +91,7 @@ func (r *RoomRepository) FindByIDs(ctx context.Context, ids []int64) (map[int64]
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&rooms).
 		ModelTableExpr(tableExprFacilitiesRoomsAsRoom).
-		Where("room.id IN (?)", bun.In(ids))
+		Where("room.id IN (?)", bun.List(ids))
 
 	if where, val, ok := base.TenantWhere(ctx, "room"); ok {
 		query = query.Where(where, val)

--- a/backend/models/facilities/repository.go
+++ b/backend/models/facilities/repository.go
@@ -12,6 +12,9 @@ type RoomRepository interface {
 	// FindByID retrieves a room by its ID
 	FindByID(ctx context.Context, id interface{}) (*Room, error)
 
+	// FindByIDs retrieves rooms by a list of IDs in one query, returning a map keyed by ID.
+	FindByIDs(ctx context.Context, ids []int64) (map[int64]*Room, error)
+
 	// FindByName retrieves a room by its name
 	FindByName(ctx context.Context, name string) (*Room, error)
 

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -224,6 +224,33 @@ func (s *service) GetActiveGroupsByIDs(ctx context.Context, groupIDs []int64) (m
 		groups = make(map[int64]*active.Group)
 	}
 
+	// Bulk-load rooms so downstream callers (location resolver, badge color)
+	// can render room names and per-room colors without extra queries.
+	roomIDs := make([]int64, 0, len(groups))
+	for _, group := range groups {
+		if group != nil && group.Room == nil && group.RoomID > 0 {
+			roomIDs = append(roomIDs, group.RoomID)
+		}
+	}
+	if len(roomIDs) > 0 {
+		rooms, roomErr := s.roomRepo.FindByIDs(ctx, roomIDs)
+		if roomErr != nil {
+			s.getLogger().Warn("bulk room load failed",
+				slog.String("error", roomErr.Error()),
+				slog.Int("room_id_count", len(roomIDs)),
+			)
+		} else {
+			for _, group := range groups {
+				if group == nil || group.Room != nil || group.RoomID <= 0 {
+					continue
+				}
+				if room, ok := rooms[group.RoomID]; ok {
+					group.Room = room
+				}
+			}
+		}
+	}
+
 	return groups, nil
 }
 

--- a/backend/services/facilities/facility_service.go
+++ b/backend/services/facilities/facility_service.go
@@ -175,6 +175,16 @@ func (s *service) UpdateRoom(ctx context.Context, room *facilities.Room) error {
 		return &FacilitiesError{Op: opUpdateRoom, Err: ErrSystemRoomProtected}
 	}
 
+	// System-room edit forms intentionally omit the color field. Preserve the
+	// reserved stored color in that case, but still reject explicit changes.
+	if constants.IsSystemRoomName(existingRoom.Name) {
+		if room.Color == nil {
+			room.Color = existingRoom.Color
+		} else if !equalOptionalString(room.Color, existingRoom.Color) {
+			return &FacilitiesError{Op: opUpdateRoom, Err: ErrSystemRoomProtected}
+		}
+	}
+
 	// If name is changing, check for duplicates
 	if existingRoom.Name != room.Name {
 		existing, err := s.roomRepo.FindByName(ctx, room.Name)
@@ -222,6 +232,14 @@ func (s *service) DeleteRoom(ctx context.Context, id int64) error {
 	}
 
 	return nil
+}
+
+func equalOptionalString(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+
+	return *a == *b
 }
 
 // ListRooms retrieves all rooms with occupancy status

--- a/backend/services/facilities/facility_service_test.go
+++ b/backend/services/facilities/facility_service_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/moto-nrw/project-phoenix/constants"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/facilities"
@@ -22,7 +23,20 @@ func createRoomWithExactName(t *testing.T, db *bun.DB, name string) *facilities.
 	t.Helper()
 	ctx := testpkg.TenantContext(1)
 
-	// Clean up any pre-existing room with this exact name (from crashed tests or seed data)
+	// Clean up any pre-existing room with this exact name, including active
+	// session artifacts that would otherwise block deleting the old room row.
+	// Parameterized via $1 to keep the helper safe against names containing
+	// quotes or other SQL metacharacters.
+	for _, query := range []string{
+		`DELETE FROM active.attendance WHERE visit_id IN (SELECT v.id FROM active.visits v JOIN active.groups ag ON ag.id = v.active_group_id JOIN facilities.rooms r ON r.id = ag.room_id WHERE r.name = $1 AND r.tenant_id = 1)`,
+		`DELETE FROM active.visits WHERE active_group_id IN (SELECT ag.id FROM active.groups ag JOIN facilities.rooms r ON r.id = ag.room_id WHERE r.name = $1 AND r.tenant_id = 1)`,
+		`DELETE FROM active.group_supervisors WHERE group_id IN (SELECT ag.id FROM active.groups ag JOIN facilities.rooms r ON r.id = ag.room_id WHERE r.name = $1 AND r.tenant_id = 1)`,
+		`DELETE FROM active.groups WHERE room_id IN (SELECT id FROM facilities.rooms WHERE name = $1 AND tenant_id = 1)`,
+		`UPDATE iot.devices SET room_id = NULL WHERE room_id IN (SELECT id FROM facilities.rooms WHERE name = $1 AND tenant_id = 1)`,
+	} {
+		_, _ = db.ExecContext(ctx, query, name)
+	}
+
 	_, _ = db.NewDelete().
 		TableExpr("facilities.rooms").
 		Where("name = ? AND tenant_id = 1", name).
@@ -32,8 +46,36 @@ func createRoomWithExactName(t *testing.T, db *bun.DB, name string) *facilities.
 		Name:     name,
 		Building: "Test Building",
 	}
+	switch name {
+	case constants.SchulhofRoomName:
+		color := constants.SchulhofColor
+		room.Color = &color
+	case constants.WCRoomName:
+		color := constants.WCColor
+		room.Color = &color
+	}
+
+	existing := new(facilities.Room)
+	err := db.NewSelect().
+		Model(existing).
+		ModelTableExpr(`facilities.rooms AS "room"`).
+		Where(`"room".name = ? AND "room".tenant_id = 1`, name).
+		Scan(ctx)
+	if err == nil {
+		existing.Building = room.Building
+		existing.Color = room.Color
+		_, updateErr := db.NewUpdate().
+			Model(existing).
+			ModelTableExpr(`facilities.rooms AS "room"`).
+			Column("building", "color").
+			Where(`"room".id = ?`, existing.ID).
+			Exec(ctx)
+		require.NoError(t, updateErr, "Failed to normalize existing room %q", name)
+		return existing
+	}
+
 	room.SetTenantID(1)
-	err := db.NewInsert().
+	err = db.NewInsert().
 		Model(room).
 		ModelTableExpr(`facilities.rooms`).
 		Scan(ctx)
@@ -251,6 +293,30 @@ func TestFacilitiesService_CreateRoom(t *testing.T) {
 		require.NoError(t, err)
 		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
 	})
+
+	t.Run("rejects malformed hex color", func(t *testing.T) {
+		// ARRANGE — defense-in-depth: the model regex must catch garbage so
+		// junk colors never reach the DB or leak through to LocationBadge.
+		for _, bad := range []string{"red", "#GGGGGG", "#1234", "#12345", "rgb(0,0,0)"} {
+			bad := bad
+			t.Run(bad, func(t *testing.T) {
+				color := bad
+				room := &facilities.Room{
+					Name:     "BadColor-" + time.Now().Format("20060102150405.000000"),
+					Building: "Building A",
+					Color:    &color,
+				}
+
+				// ACT
+				err := service.CreateRoom(ctx, room)
+
+				// ASSERT
+				require.Error(t, err, "expected rejection for color %q", bad)
+				assert.Contains(t, err.Error(), "color", "error should mention the offending field")
+				assert.Zero(t, room.ID, "rejected room must not be persisted")
+			})
+		}
+	})
 }
 
 // ============================================================================
@@ -355,13 +421,14 @@ func TestFacilitiesService_UpdateRoom(t *testing.T) {
 		assert.Contains(t, err.Error(), "Systemraum")
 	})
 
-	t.Run("allows updating other properties of system room", func(t *testing.T) {
+	t.Run("allows updating other properties of system room when color is omitted", func(t *testing.T) {
 		// ARRANGE — exact name required to match constants.WCRoomName
 		room := createRoomWithExactName(t, db, "WC")
 		defer cleanupRoom(t, db, room.ID)
 
 		newCapacity := 25
 		room.Capacity = &newCapacity
+		room.Color = nil
 
 		// ACT
 		err := service.UpdateRoom(ctx, room)
@@ -373,6 +440,40 @@ func TestFacilitiesService_UpdateRoom(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 25, *updated.Capacity)
 		assert.Equal(t, "WC", updated.Name)
+		require.NotNil(t, updated.Color)
+		assert.Equal(t, constants.WCColor, *updated.Color)
+	})
+
+	t.Run("blocks changing system room color", func(t *testing.T) {
+		// ARRANGE — exact name required to match constants.SchulhofRoomName
+		room := createRoomWithExactName(t, db, "Schulhof")
+		defer cleanupRoom(t, db, room.ID)
+
+		color := "#123456"
+		room.Color = &color
+
+		// ACT
+		err := service.UpdateRoom(ctx, room)
+
+		// ASSERT
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Systemraum")
+	})
+
+	t.Run("rejects malformed hex color on update", func(t *testing.T) {
+		// ARRANGE — start from a valid room, then try to overwrite with junk.
+		room := testpkg.CreateTestRoom(t, db, "UpdateBadColor-"+time.Now().Format("20060102150405.000"))
+		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+
+		bad := "not-a-hex"
+		room.Color = &bad
+
+		// ACT
+		err := service.UpdateRoom(ctx, room)
+
+		// ASSERT
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "color")
 	})
 }
 

--- a/backend/services/import/relationship_resolver_test.go
+++ b/backend/services/import/relationship_resolver_test.go
@@ -410,6 +410,9 @@ func (m *mockRoomRepo) Create(_ context.Context, _ *facilities.Room) error { ret
 func (m *mockRoomRepo) FindByID(_ context.Context, _ interface{}) (*facilities.Room, error) {
 	return nil, nil
 }
+func (m *mockRoomRepo) FindByIDs(_ context.Context, _ []int64) (map[int64]*facilities.Room, error) {
+	return map[int64]*facilities.Room{}, nil
+}
 func (m *mockRoomRepo) FindByName(_ context.Context, _ string) (*facilities.Room, error) {
 	return nil, nil
 }

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -128,6 +128,7 @@ interface BFFDashboardResponse {
     sickSince?: string;
     excused?: boolean;
     excusedSince?: string;
+    badgeColor?: string | null;
   }>;
   firstRoomId: string | null;
   schulhofStatus: SchulhofStatusResponse | null;
@@ -445,6 +446,7 @@ function MeinRaumPageContent() {
             sick_since: visit.sickSince,
             excused: visit.excused,
             excused_since: visit.excusedSince,
+            badge_color: visit.badgeColor ?? null,
             activeGroupId: visit.activeGroupId,
             checkInTime: visit.checkInTime,
           } as StudentWithVisit;
@@ -779,6 +781,7 @@ function MeinRaumPageContent() {
               sick_since: visit.sickSince,
               excused: visit.excused,
               excused_since: visit.excusedSince,
+              badge_color: visit.badgeColor ?? null,
               activeGroupId: visit.activeGroupId,
               checkInTime: new Date(visit.checkInTime),
             } as StudentWithVisit;
@@ -936,6 +939,7 @@ function MeinRaumPageContent() {
           sick_since: visit.sickSince,
           excused: visit.excused,
           excused_since: visit.excusedSince,
+          badge_color: visit.badgeColor ?? null,
           activeGroupId: visit.activeGroupId,
           checkInTime: visit.checkInTime,
         } as StudentWithVisit;

--- a/frontend/src/app/[tenant]/(protected)/database/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/rooms/page.tsx
@@ -16,6 +16,7 @@ import { getDbOperationMessage } from "@/lib/use-notification";
 import { createCrudService } from "@/lib/database/service-factory";
 import { roomsConfig } from "@/lib/database/configs/rooms.config";
 import { formatFloor, type Room } from "@/lib/room-helpers";
+import { getRoomGradient } from "~/lib/location-helper";
 import {
   RoomCreateModal,
   RoomDetailModal,
@@ -401,7 +402,10 @@ export default function RoomsPage() {
 
                 <div className="relative flex items-center gap-4 p-5">
                   <div className="flex-shrink-0">
-                    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-indigo-600 font-semibold text-white shadow-md transition-transform duration-150 md:group-hover:scale-105">
+                    <div
+                      className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br font-semibold text-white shadow-md transition-transform duration-150 md:group-hover:scale-105"
+                      style={{ backgroundImage: getRoomGradient(room.color) }}
+                    >
                       {initial}
                     </div>
                   </div>

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -89,6 +89,7 @@ interface BackendStudentFromBFF {
   excused?: boolean;
   excused_since?: string;
   location_since?: string;
+  badge_color?: string | null;
   group_id?: number;
   group_name?: string;
   arrival_time?: string;
@@ -310,6 +311,7 @@ function OGSGroupPageContent() {
         excused: s.excused ?? false,
         excused_since: s.excused_since,
         location_since: s.location_since,
+        badge_color: s.badge_color ?? null,
         group_id: s.group_id?.toString(),
         group_name: s.group_name,
         arrival_time: s.arrival_time,

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/components/StudentHeader.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/components/StudentHeader.tsx
@@ -8,6 +8,7 @@ interface StudentBadgeData {
   location_since?: string;
   group_id?: string;
   group_name?: string;
+  badge_color?: string | null;
 }
 
 interface StudentHeaderProps {

--- a/frontend/src/app/api/active-supervision-dashboard/route.ts
+++ b/frontend/src/app/api/active-supervision-dashboard/route.ts
@@ -74,6 +74,7 @@ interface BackendVisitDisplay {
   sick_since?: string;
   excused?: boolean;
   excused_since?: string;
+  badge_color?: string | null;
   is_active: boolean;
 }
 
@@ -140,6 +141,7 @@ interface ActiveSupervisionDashboardResponse {
     sickSince?: string;
     excused?: boolean;
     excusedSince?: string;
+    badgeColor?: string | null;
   }>;
 
   // ID of first room (for state initialization)
@@ -382,6 +384,7 @@ export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
             sickSince: v.sick_since,
             excused: v.excused,
             excusedSince: v.excused_since,
+            badgeColor: v.badge_color ?? null,
           }));
       } catch {
         firstRoomVisits = [];

--- a/frontend/src/components/rooms/index.ts
+++ b/frontend/src/components/rooms/index.ts
@@ -1,4 +1,3 @@
 export { RoomCreateModal } from "./room-create-modal";
 export { RoomEditModal } from "./room-edit-modal";
 export { RoomDetailModal } from "./room-detail-modal";
-export { RoomColorPicker } from "./room-color-picker";

--- a/frontend/src/components/rooms/index.ts
+++ b/frontend/src/components/rooms/index.ts
@@ -1,3 +1,4 @@
 export { RoomCreateModal } from "./room-create-modal";
 export { RoomEditModal } from "./room-edit-modal";
 export { RoomDetailModal } from "./room-detail-modal";
+export { RoomColorPicker } from "./room-color-picker";

--- a/frontend/src/components/rooms/room-color-picker.test.tsx
+++ b/frontend/src/components/rooms/room-color-picker.test.tsx
@@ -73,7 +73,7 @@ describe("RoomColorPicker", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it("shows 'außerhalb der Palette' hint for non-palette values", () => {
+  it("treats a non-palette legacy value as 'Keine Farbe' (cleared swatch selected)", () => {
     render(
       <RoomColorPicker
         value="#4F46E5"
@@ -81,25 +81,30 @@ describe("RoomColorPicker", () => {
         label="Badge-Farbe"
       />,
     );
-    expect(screen.getByText(/außerhalb der Palette/i)).toBeDefined();
-    expect(screen.getByText(/#4F46E5/i)).toBeDefined();
+    expect(screen.getByLabelText("Keine Farbe")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    // No palette swatch should be marked as selected
+    for (const color of ROOM_COLOR_PALETTE) {
+      expect(screen.getByLabelText(`Farbe ${color}`)).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    }
   });
 
-  it("does not show the hint when value is in the palette", () => {
-    render(
-      <RoomColorPicker
-        value={ROOM_COLOR_PALETTE[0]}
-        onChange={() => {}}
-        label="Badge-Farbe"
-      />,
-    );
-    expect(screen.queryByText(/außerhalb der Palette/i)).toBeNull();
-  });
-
-  it("does not show the hint when value is null/empty", () => {
-    render(
-      <RoomColorPicker value={null} onChange={() => {}} label="Badge-Farbe" />,
-    );
-    expect(screen.queryByText(/außerhalb der Palette/i)).toBeNull();
+  it("never shows an 'außerhalb der Palette' hint, regardless of value", () => {
+    for (const value of [null, "#4F46E5", ROOM_COLOR_PALETTE[0]] as const) {
+      const { unmount } = render(
+        <RoomColorPicker
+          value={value}
+          onChange={() => {}}
+          label="Badge-Farbe"
+        />,
+      );
+      expect(screen.queryByText(/außerhalb der Palette/i)).toBeNull();
+      unmount();
+    }
   });
 });

--- a/frontend/src/components/rooms/room-color-picker.test.tsx
+++ b/frontend/src/components/rooms/room-color-picker.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { RoomColorPicker } from "./room-color-picker";
+import { ROOM_COLOR_PALETTE } from "~/lib/location-helper";
+
+describe("RoomColorPicker", () => {
+  it("renders the 'Keine Farbe' option plus all palette swatches", () => {
+    render(
+      <RoomColorPicker value={null} onChange={() => {}} label="Badge-Farbe" />,
+    );
+    // 1 "Keine Farbe" + N palette buttons
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(ROOM_COLOR_PALETTE.length + 1);
+    expect(screen.getByLabelText("Keine Farbe")).toBeDefined();
+    for (const color of ROOM_COLOR_PALETTE) {
+      expect(screen.getByLabelText(`Farbe ${color}`)).toBeDefined();
+    }
+  });
+
+  it("marks 'Keine Farbe' as pressed when value is null", () => {
+    render(
+      <RoomColorPicker value={null} onChange={() => {}} label="Badge-Farbe" />,
+    );
+    expect(screen.getByLabelText("Keine Farbe")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("marks the matching swatch as pressed when value is in the palette", () => {
+    const palette = ROOM_COLOR_PALETTE[0]!;
+    render(
+      <RoomColorPicker
+        value={palette}
+        onChange={() => {}}
+        label="Badge-Farbe"
+      />,
+    );
+    expect(screen.getByLabelText(`Farbe ${palette}`)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("calls onChange with null when 'Keine Farbe' is clicked", () => {
+    const onChange = vi.fn();
+    render(
+      <RoomColorPicker
+        value={ROOM_COLOR_PALETTE[0]}
+        onChange={onChange}
+        label="Badge-Farbe"
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Keine Farbe"));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("calls onChange with the picked color when a swatch is clicked", () => {
+    const onChange = vi.fn();
+    const palette = ROOM_COLOR_PALETTE[2]!;
+    render(
+      <RoomColorPicker value={null} onChange={onChange} label="Badge-Farbe" />,
+    );
+    fireEvent.click(screen.getByLabelText(`Farbe ${palette}`));
+    expect(onChange).toHaveBeenCalledWith(palette);
+  });
+
+  it("does NOT auto-call onChange on mount (no auto-pick)", () => {
+    const onChange = vi.fn();
+    render(
+      <RoomColorPicker value={null} onChange={onChange} label="Badge-Farbe" />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("shows 'außerhalb der Palette' hint for non-palette values", () => {
+    render(
+      <RoomColorPicker
+        value="#4F46E5"
+        onChange={() => {}}
+        label="Badge-Farbe"
+      />,
+    );
+    expect(screen.getByText(/außerhalb der Palette/i)).toBeDefined();
+    expect(screen.getByText(/#4F46E5/i)).toBeDefined();
+  });
+
+  it("does not show the hint when value is in the palette", () => {
+    render(
+      <RoomColorPicker
+        value={ROOM_COLOR_PALETTE[0]}
+        onChange={() => {}}
+        label="Badge-Farbe"
+      />,
+    );
+    expect(screen.queryByText(/außerhalb der Palette/i)).toBeNull();
+  });
+
+  it("does not show the hint when value is null/empty", () => {
+    render(
+      <RoomColorPicker value={null} onChange={() => {}} label="Badge-Farbe" />,
+    );
+    expect(screen.queryByText(/außerhalb der Palette/i)).toBeNull();
+  });
+});

--- a/frontend/src/components/rooms/room-color-picker.tsx
+++ b/frontend/src/components/rooms/room-color-picker.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { ROOM_COLOR_PALETTE } from "~/lib/location-helper";
+
+interface RoomColorPickerProps {
+  readonly value: unknown;
+  readonly onChange: (value: unknown) => void;
+  readonly label: string;
+  readonly required?: boolean;
+}
+
+/**
+ * Dumb controlled color picker for rooms. Renders a "Keine Farbe" option plus
+ * the curated palette. Callers (e.g. RoomCreateModal) are responsible for
+ * pre-filling a sensible default. Edit-mode rooms with an existing
+ * non-palette color show a hint instead of being silently overwritten.
+ */
+export function RoomColorPicker({
+  value,
+  onChange,
+  label,
+  required,
+}: RoomColorPickerProps) {
+  const selected = typeof value === "string" ? value.toLowerCase() : "";
+  const isCleared = !selected;
+  const isInPalette = ROOM_COLOR_PALETTE.some(
+    (c) => c.toLowerCase() === selected,
+  );
+  const hasNonPaletteValue = !isCleared && !isInPalette;
+
+  return (
+    <div>
+      <label className="mb-1.5 block text-xs font-medium text-gray-700">
+        {label}
+        {required && <span className="ml-1 text-red-500">*</span>}
+      </label>
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          aria-label="Keine Farbe"
+          aria-pressed={isCleared}
+          title="Keine Farbe (Standardblau)"
+          className={`relative flex h-8 w-8 items-center justify-center rounded-full border-2 bg-white transition-transform duration-150 hover:scale-110 ${
+            isCleared
+              ? "border-gray-900 ring-2 ring-gray-900/20"
+              : "border-gray-300 shadow-sm"
+          }`}
+        >
+          <span className="absolute h-[2px] w-5 rotate-45 bg-gray-400" />
+        </button>
+        {ROOM_COLOR_PALETTE.map((color) => {
+          const isSelected = selected === color.toLowerCase();
+          return (
+            <button
+              key={color}
+              type="button"
+              onClick={() => onChange(color)}
+              aria-label={`Farbe ${color}`}
+              aria-pressed={isSelected}
+              className={`h-8 w-8 rounded-full border-2 transition-transform duration-150 hover:scale-110 ${
+                isSelected
+                  ? "border-gray-900 ring-2 ring-gray-900/20"
+                  : "border-white shadow-sm"
+              }`}
+              style={{ backgroundColor: color }}
+            />
+          );
+        })}
+      </div>
+      {hasNonPaletteValue && (
+        <p className="mt-2 text-xs text-gray-500">
+          Aktuell: <span className="font-mono uppercase">{selected}</span>{" "}
+          (außerhalb der Palette — wähle eine Farbe oben aus, um sie zu
+          ersetzen)
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/rooms/room-color-picker.tsx
+++ b/frontend/src/components/rooms/room-color-picker.tsx
@@ -12,8 +12,9 @@ interface RoomColorPickerProps {
 /**
  * Dumb controlled color picker for rooms. Renders a "Keine Farbe" option plus
  * the curated palette. Callers (e.g. RoomCreateModal) are responsible for
- * pre-filling a sensible default. Edit-mode rooms with an existing
- * non-palette color show a hint instead of being silently overwritten.
+ * pre-filling a sensible default. A stored value that isn't in the palette
+ * (e.g. legacy `#4F46E5`) is treated as the "no color picked" state — the
+ * cleared swatch lights up as selected, with no separate warning hint.
  */
 export function RoomColorPicker({
   value,
@@ -22,11 +23,11 @@ export function RoomColorPicker({
   required,
 }: RoomColorPickerProps) {
   const selected = typeof value === "string" ? value.toLowerCase() : "";
-  const isCleared = !selected;
   const isInPalette = ROOM_COLOR_PALETTE.some(
     (c) => c.toLowerCase() === selected,
   );
-  const hasNonPaletteValue = !isCleared && !isInPalette;
+  // Anything not in the palette (null, "", legacy hex) is treated as cleared.
+  const treatAsCleared = !isInPalette;
 
   return (
     <div>
@@ -39,10 +40,10 @@ export function RoomColorPicker({
           type="button"
           onClick={() => onChange(null)}
           aria-label="Keine Farbe"
-          aria-pressed={isCleared}
+          aria-pressed={treatAsCleared}
           title="Keine Farbe (Standardblau)"
           className={`relative flex h-8 w-8 items-center justify-center rounded-full border-2 bg-white transition-transform duration-150 hover:scale-110 ${
-            isCleared
+            treatAsCleared
               ? "border-gray-900 ring-2 ring-gray-900/20"
               : "border-gray-300 shadow-sm"
           }`}
@@ -68,13 +69,6 @@ export function RoomColorPicker({
           );
         })}
       </div>
-      {hasNonPaletteValue && (
-        <p className="mt-2 text-xs text-gray-500">
-          Aktuell: <span className="font-mono uppercase">{selected}</span>{" "}
-          (außerhalb der Palette — wähle eine Farbe oben aus, um sie zu
-          ersetzen)
-        </p>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/rooms/room-create-modal.test.tsx
+++ b/frontend/src/components/rooms/room-create-modal.test.tsx
@@ -6,6 +6,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { RoomCreateModal } from "./room-create-modal";
 
+const mockPickRoomColor = vi.fn();
+const mockUseSWR = vi.fn();
+const mockFetchRooms = vi.fn();
+
 // Mock Modal component
 vi.mock("~/components/ui/modal", () => ({
   Modal: ({
@@ -34,12 +38,15 @@ vi.mock("~/components/ui/database/database-form", () => ({
     onSubmit,
     onCancel,
     submitLabel,
+    initialData,
   }: {
     onSubmit: (data: unknown) => Promise<void>;
     onCancel: () => void;
     submitLabel: string;
+    initialData: Record<string, unknown>;
   }) => (
     <div data-testid="database-form">
+      <span data-testid="initial-data">{JSON.stringify(initialData)}</span>
       <button onClick={() => onSubmit({ name: "Test Room" })}>
         {submitLabel}
       </button>
@@ -80,12 +87,30 @@ vi.mock("@/lib/database/types", () => ({
   configToFormSection: (section: unknown) => section,
 }));
 
+vi.mock("~/lib/location-helper", () => ({
+  pickRoomColor: (...args: unknown[]) => mockPickRoomColor(...args),
+}));
+
+vi.mock("swr", () => ({
+  default: (...args: unknown[]) => mockUseSWR(...args),
+}));
+
+vi.mock("~/lib/rooms-api", () => ({
+  fetchRooms: (...args: unknown[]) => mockFetchRooms(...args),
+}));
+
 describe("RoomCreateModal", () => {
   const mockOnClose = vi.fn();
   const mockOnCreate = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPickRoomColor.mockReset();
+    mockPickRoomColor
+      .mockReturnValueOnce("#111111")
+      .mockReturnValueOnce("#222222");
+    mockUseSWR.mockReturnValue({ data: [], isLoading: false });
+    mockFetchRooms.mockResolvedValue([]);
   });
 
   it("renders nothing when modal is closed", () => {
@@ -144,5 +169,87 @@ describe("RoomCreateModal", () => {
       expect(screen.getByTestId("database-form")).toBeInTheDocument();
       expect(screen.getByText("Erstellen")).toBeInTheDocument();
     });
+  });
+
+  it("waits for rooms before choosing the initial default color on cold open", async () => {
+    let swrState:
+      | { data: Array<{ color: string }>; isLoading: false }
+      | { data: undefined; isLoading: true } = {
+      data: undefined,
+      isLoading: true,
+    };
+
+    mockUseSWR.mockImplementation(() => swrState);
+
+    const { rerender } = render(
+      <RoomCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    expect(
+      screen.getByText("Formular wird vorbereitet..."),
+    ).toBeInTheDocument();
+    expect(mockPickRoomColor).not.toHaveBeenCalled();
+
+    swrState = { data: [{ color: "#34D399" }], isLoading: false };
+    rerender(
+      <RoomCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("database-form")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("initial-data")).toHaveTextContent("#111111");
+    expect(mockPickRoomColor).toHaveBeenCalledWith(["#34D399"]);
+  });
+
+  it("keeps initial data stable after rooms revalidate", async () => {
+    let swrState = {
+      data: [{ color: "#34D399" }],
+      isLoading: false,
+    };
+
+    mockUseSWR.mockImplementation(() => swrState);
+
+    const { rerender } = render(
+      <RoomCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("database-form")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("initial-data")).toHaveTextContent("#111111");
+
+    swrState = {
+      data: [{ color: "#34D399" }, { color: "#14B8A6" }],
+      isLoading: false,
+    };
+    rerender(
+      <RoomCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("database-form")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("initial-data")).toHaveTextContent("#111111");
+    expect(screen.getByTestId("initial-data")).not.toHaveTextContent("#222222");
   });
 });

--- a/frontend/src/components/rooms/room-create-modal.tsx
+++ b/frontend/src/components/rooms/room-create-modal.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import useSWR from "swr";
 import { Modal } from "~/components/ui/modal";
 import { DatabaseForm } from "~/components/ui/database/database-form";
+import { useTenantSlugSafe } from "~/components/tenant/tenant-provider";
 import type { Room } from "@/lib/room-helpers";
 import { roomsConfig } from "@/lib/database/configs/rooms.config";
 import { configToFormSection } from "@/lib/database/types";
+import { pickRoomColor } from "~/lib/location-helper";
+import { fetchRooms } from "~/lib/rooms-api";
 
 interface RoomCreateModalProps {
   readonly isOpen: boolean;
@@ -13,12 +18,58 @@ interface RoomCreateModalProps {
   readonly loading?: boolean;
 }
 
+function buildInitialRoomData(usedColors: readonly string[]): Partial<Room> {
+  return {
+    ...roomsConfig.form.defaultValues,
+    color: pickRoomColor(usedColors),
+  };
+}
+
 export function RoomCreateModal({
   isOpen,
   onClose,
   onCreate,
   loading = false,
 }: RoomCreateModalProps) {
+  const [initialData, setInitialData] = useState<Partial<Room> | null>(null);
+  const tenantSlug = useTenantSlugSafe();
+
+  // Fetch existing rooms once so the soft-prefer-unique default knows which
+  // palette colors are already in use. `fetchRooms` already swallows errors
+  // into `[]` and logs internally — failure here only degrades the color
+  // pick to "any palette color", which is acceptable.
+  // Cache key is tenant-prefixed to prevent cross-tenant cache bleed when
+  // switching tenants in the same browser session.
+  const { data: rooms, isLoading: roomsLoading } = useSWR(
+    isOpen ? `${tenantSlug ?? "no-tenant"}:rooms-list-for-color-default` : null,
+    () => fetchRooms(),
+    { revalidateOnFocus: false },
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      setInitialData(null);
+      return;
+    }
+
+    if (initialData) {
+      return;
+    }
+
+    // On a cold open, wait for the first rooms result before choosing a
+    // default so we can actually prefer an unused palette color.
+    if (roomsLoading && rooms === undefined) {
+      return;
+    }
+
+    // Seed once per open cycle. After that, keep the object stable so
+    // DatabaseForm does not reset user-entered values during revalidation.
+    const usedColors = (rooms ?? [])
+      .map((r) => r.color ?? "")
+      .filter((c) => c !== "");
+    setInitialData(buildInitialRoomData(usedColors));
+  }, [initialData, isOpen, rooms, roomsLoading]);
+
   return (
     <Modal
       isOpen={isOpen}
@@ -32,11 +83,18 @@ export function RoomCreateModal({
             <p className="text-gray-600">Daten werden geladen...</p>
           </div>
         </div>
+      ) : !initialData ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="flex flex-col items-center gap-4">
+            <div className="h-12 w-12 animate-spin rounded-full border-2 border-gray-200 border-t-indigo-500" />
+            <p className="text-gray-600">Formular wird vorbereitet...</p>
+          </div>
+        </div>
       ) : (
         <DatabaseForm
           theme={roomsConfig.theme}
           sections={roomsConfig.form.sections.map(configToFormSection)}
-          initialData={roomsConfig.form.defaultValues}
+          initialData={initialData}
           onSubmit={onCreate}
           onCancel={onClose}
           isLoading={loading}

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -10,6 +10,7 @@ import {
   DetailIcons,
 } from "~/components/ui/detail-modal-components";
 import { formatFloor, isSystemRoom, type Room } from "@/lib/room-helpers";
+import { getRoomGradient } from "~/lib/location-helper";
 
 interface RoomDetailModalProps {
   readonly isOpen: boolean;
@@ -49,7 +50,10 @@ export function RoomDetailModal({
       <div className="space-y-4 md:space-y-6">
         {/* Header */}
         <div className="flex items-center gap-3 border-b border-gray-100 pb-3 md:gap-4 md:pb-4">
-          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-indigo-600 text-xl font-semibold text-white shadow-md md:h-16 md:w-16">
+          <div
+            className="flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br text-xl font-semibold text-white shadow-md md:h-16 md:w-16"
+            style={{ backgroundImage: getRoomGradient(room.color) }}
+          >
             {initial}
           </div>
           <div className="min-w-0">
@@ -87,6 +91,21 @@ export function RoomDetailModal({
               </DataField>
               <DataField label="Status">
                 {room.isOccupied ? "Belegt" : "Frei"}
+              </DataField>
+              <DataField label="Badge-Farbe">
+                {room.color ? (
+                  <span className="inline-flex items-center gap-2">
+                    <span
+                      className="inline-block h-4 w-4 rounded-full border border-white shadow-sm"
+                      style={{ backgroundColor: room.color }}
+                    />
+                    <span className="font-mono text-xs uppercase">
+                      {room.color}
+                    </span>
+                  </span>
+                ) : (
+                  <span className="text-gray-500">Keine</span>
+                )}
               </DataField>
               {room.activityName && (
                 <DataField label="Aktivität" fullWidth>

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -92,21 +92,23 @@ export function RoomDetailModal({
               <DataField label="Status">
                 {room.isOccupied ? "Belegt" : "Frei"}
               </DataField>
-              <DataField label="Badge-Farbe">
-                {room.color ? (
-                  <span className="inline-flex items-center gap-2">
-                    <span
-                      className="inline-block h-4 w-4 rounded-full border border-white shadow-sm"
-                      style={{ backgroundColor: room.color }}
-                    />
-                    <span className="font-mono text-xs uppercase">
-                      {room.color}
+              {!isSystemRoom(room) && (
+                <DataField label="Badge-Farbe">
+                  {room.color ? (
+                    <span className="inline-flex items-center gap-2">
+                      <span
+                        className="inline-block h-4 w-4 rounded-full border border-white shadow-sm"
+                        style={{ backgroundColor: room.color }}
+                      />
+                      <span className="font-mono text-xs uppercase">
+                        {room.color}
+                      </span>
                     </span>
-                  </span>
-                ) : (
-                  <span className="text-gray-500">Keine</span>
-                )}
-              </DataField>
+                  ) : (
+                    <span className="text-gray-500">Keine</span>
+                  )}
+                </DataField>
+              )}
               {room.activityName && (
                 <DataField label="Aktivität" fullWidth>
                   {room.activityName}

--- a/frontend/src/components/rooms/room-edit-modal.test.tsx
+++ b/frontend/src/components/rooms/room-edit-modal.test.tsx
@@ -44,14 +44,16 @@ vi.mock("~/components/ui/database/database-form", () => ({
       fields: Array<{ name: string; disabled?: boolean; helperText?: string }>;
     }>;
   }) => {
-    const nameField = sections
-      ?.flatMap((s) => s.fields)
-      .find((f) => f.name === "name");
+    const fields = sections?.flatMap((s) => s.fields);
+    const nameField = fields.find((f) => f.name === "name");
+    const colorField = fields.find((f) => f.name === "color");
+
     return (
       <div data-testid="database-form">
         {nameField?.disabled && (
           <span data-testid="name-disabled">{nameField.helperText}</span>
         )}
+        {colorField && <span data-testid="color-field-present">Farbfeld</span>}
         <button onClick={() => onSubmit({ name: "Updated Room" })}>
           {submitLabel}
         </button>
@@ -91,6 +93,11 @@ vi.mock("@/lib/database/configs/rooms.config", () => ({
                 { value: "Themenraum", label: "Themenraum" },
                 { value: "Sport", label: "Sport" },
               ],
+            },
+            {
+              name: "color",
+              label: "Badge-Farbe",
+              type: "custom",
             },
           ],
         },
@@ -191,6 +198,7 @@ describe("RoomEditModal", () => {
     await waitFor(() => {
       expect(screen.getByTestId("database-form")).toBeInTheDocument();
       expect(screen.getByText("Speichern")).toBeInTheDocument();
+      expect(screen.getByTestId("color-field-present")).toBeInTheDocument();
     });
   });
 
@@ -248,6 +256,9 @@ describe("RoomEditModal", () => {
       const nameDisabled = screen.getByTestId("name-disabled");
       expect(nameDisabled).toBeInTheDocument();
       expect(nameDisabled).toHaveTextContent("Systemraum:");
+      expect(
+        screen.queryByTestId("color-field-present"),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -268,10 +279,13 @@ describe("RoomEditModal", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("name-disabled")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("color-field-present"),
+      ).not.toBeInTheDocument();
     });
   });
 
-  it("does not disable name field for regular room", async () => {
+  it("keeps color field for regular rooms", async () => {
     render(
       <RoomEditModal
         isOpen={true}
@@ -284,6 +298,7 @@ describe("RoomEditModal", () => {
     await waitFor(() => {
       expect(screen.getByTestId("database-form")).toBeInTheDocument();
       expect(screen.queryByTestId("name-disabled")).not.toBeInTheDocument();
+      expect(screen.getByTestId("color-field-present")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/rooms/room-edit-modal.tsx
+++ b/frontend/src/components/rooms/room-edit-modal.tsx
@@ -33,7 +33,7 @@ export function RoomEditModal({
   const isSystem = isSystemRoom(room);
 
   // Dynamically add legacy category if room has one not in standard list
-  // and disable name field for system rooms
+  // and apply system-room protections.
   const sections = useMemo(() => {
     let baseSections = roomsConfig.form.sections.map(configToFormSection);
 
@@ -57,19 +57,22 @@ export function RoomEditModal({
       }));
     }
 
-    // Disable name field for system rooms (Schulhof, WC)
+    // System rooms keep their reserved location semantics, so they cannot be
+    // renamed and their badge color cannot be customized.
     if (isSystem) {
       baseSections = baseSections.map((section) => ({
         ...section,
-        fields: section.fields.map((field) =>
-          field.name === "name"
-            ? {
-                ...field,
-                disabled: true,
-                helperText: "Systemraum: Name kann nicht geändert werden",
-              }
-            : field,
-        ),
+        fields: section.fields
+          .filter((field) => field.name !== "color")
+          .map((field) =>
+            field.name === "name"
+              ? {
+                  ...field,
+                  disabled: true,
+                  helperText: "Systemraum: Name kann nicht geändert werden",
+                }
+              : field,
+          ),
       }));
     }
 

--- a/frontend/src/components/students/student-detail-components.tsx
+++ b/frontend/src/components/students/student-detail-components.tsx
@@ -311,6 +311,7 @@ export function StudentDetailHeader({
     excused: student.excused,
     excused_since: student.excused_since,
     has_full_access: student.has_full_access,
+    badge_color: student.badge_color,
     not_arrival_today: isArrivalAbsent ?? false,
     not_arrival_reason: todayArrivalNote ?? null,
   };

--- a/frontend/src/components/ui/location-badge.tsx
+++ b/frontend/src/components/ui/location-badge.tsx
@@ -171,11 +171,13 @@ export function LocationBadge({
     );
     if (hasDetailedAccess) {
       // Own students - user can see full room details
-      // Green: OGS group room, Blue: other room, Orange: Schulhof, etc.
+      // Green: OGS group room, individual color: other rooms with custom hex,
+      // Blue: other rooms without custom color, Orange: Schulhof, etc.
       color = getLocationColor(
         student.current_location,
         isGroupRoom,
         groupRooms,
+        student.badge_color,
       );
     } else {
       // Foreign students - user sees limited info (only status, no room)
@@ -185,7 +187,12 @@ export function LocationBadge({
     }
   } else {
     // roomName mode - use full location for color
-    color = getLocationColor(student.current_location, isGroupRoom, groupRooms);
+    color = getLocationColor(
+      student.current_location,
+      isGroupRoom,
+      groupRooms,
+      student.badge_color,
+    );
   }
 
   // Override for sick/excused/notArrival students at home: replace the base label

--- a/frontend/src/lib/active-helpers.ts
+++ b/frontend/src/lib/active-helpers.ts
@@ -53,6 +53,8 @@ export interface BackendVisit {
   sick_since?: string;
   excused?: boolean;
   excused_since?: string;
+  /** Resolved badge color: green when in own stammraum, room's custom color otherwise, null when no color is set */
+  badge_color?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -143,6 +145,8 @@ export interface Visit {
   sickSince?: string;
   excused?: boolean;
   excusedSince?: string;
+  /** Resolved badge color (green for stammraum, room color else, null for fallback) */
+  badgeColor?: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -237,6 +241,7 @@ export function mapVisitResponse(backendVisit: BackendVisit): Visit {
     sickSince: backendVisit.sick_since,
     excused: backendVisit.excused,
     excusedSince: backendVisit.excused_since,
+    badgeColor: backendVisit.badge_color ?? null,
     createdAt: new Date(backendVisit.created_at),
     updatedAt: new Date(backendVisit.updated_at),
   };

--- a/frontend/src/lib/database/configs/rooms.config.test.tsx
+++ b/frontend/src/lib/database/configs/rooms.config.test.tsx
@@ -40,11 +40,14 @@ describe("roomsConfig", () => {
     expect(fieldNames).toContain("floor");
   });
 
-  it("has default color value", () => {
-    expect(roomsConfig.form.defaultValues?.color).toBe("#4F46E5");
+  it("does not force a static default color (Create-Modal computes via pickRoomColor)", () => {
+    // The legacy "#4F46E5" indigo default was removed when the customisable
+    // room-color feature shipped. The default is now computed per-instance by
+    // RoomCreateModal using `pickRoomColor` against existing rooms.
+    expect(roomsConfig.form.defaultValues?.color).toBeUndefined();
   });
 
-  it("transforms data before submit", () => {
+  it("transforms data before submit (no longer forces a fallback color)", () => {
     const data = {
       name: "  Room 101  ",
       floor: "2",
@@ -54,7 +57,16 @@ describe("roomsConfig", () => {
     const transformed = roomsConfig.form.transformBeforeSubmit?.(data);
     expect(transformed?.name).toBe("Room 101");
     expect(transformed?.floor).toBe(2);
-    expect(transformed?.color).toBe("#4F46E5");
+    // Color is not coerced — RoomColorPicker manages its own value
+    // (palette pick or null for "Keine Farbe").
+    expect(transformed?.color).toBeUndefined();
+  });
+
+  it("includes a custom color picker field", () => {
+    const fields = roomsConfig.form.sections[0]?.fields ?? [];
+    const colorField = fields.find((f) => f.name === "color");
+    expect(colorField).toBeDefined();
+    expect(colorField?.type).toBe("custom");
   });
 
   it("validates floor field", () => {

--- a/frontend/src/lib/database/configs/rooms.config.tsx
+++ b/frontend/src/lib/database/configs/rooms.config.tsx
@@ -2,6 +2,7 @@
 
 import { defineEntityConfig } from "../types";
 import { databaseThemes } from "@/components/ui/database/themes";
+import { RoomColorPicker } from "@/components/rooms/room-color-picker";
 import { mapRoomResponse, prepareRoomForBackend } from "@/lib/room-helpers";
 import type { Room, BackendRoom } from "@/lib/room-helpers";
 
@@ -64,19 +65,18 @@ export const roomsConfig = defineEntityConfig<Room>({
               return null;
             },
           },
+          {
+            name: "color",
+            label: "Badge-Farbe",
+            type: "custom",
+            colSpan: 2,
+            component: RoomColorPicker,
+          },
         ],
       },
     ],
 
-    defaultValues: {
-      color: "#4F46E5", // Default color (matches original implementation)
-    },
-
     transformBeforeSubmit: (data) => {
-      // Match original implementation:
-      // - Trim name (String(form.name).trim())
-      // - Convert floor to number (Number(form.floor))
-      // - Ensure color has default (form.color ?? "#4F46E5")
       return {
         ...data,
         name: typeof data.name === "string" ? data.name.trim() : data.name,
@@ -84,7 +84,6 @@ export const roomsConfig = defineEntityConfig<Room>({
           typeof data.floor === "string"
             ? Number.parseInt(data.floor, 10)
             : data.floor,
-        color: data.color ?? "#4F46E5", // Ensure color is always set
       };
     },
   },

--- a/frontend/src/lib/hooks/use-student-data.ts
+++ b/frontend/src/lib/hooks/use-student-data.ts
@@ -79,6 +79,7 @@ function mapStudentResponse(
     location_since: hasAccess
       ? (mappedStudent.location_since ?? undefined)
       : undefined,
+    badge_color: mappedStudent.badge_color ?? null,
     bus: mappedStudent.bus ?? false,
     current_room: undefined,
     birthday: mappedStudent.birthday ?? undefined,

--- a/frontend/src/lib/location-helper.test.ts
+++ b/frontend/src/lib/location-helper.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   LOCATION_STATUSES,
   LOCATION_COLORS,
+  ROOM_COLOR_PALETTE,
   parseLocation,
   normalizeLocation,
   getLocationColor,
@@ -12,6 +13,7 @@ import {
   isHomeLocation,
   isSchoolyardLocation,
   isTransitLocation,
+  pickRoomColor,
   type StudentLocationContext,
 } from "./location-helper";
 
@@ -44,6 +46,15 @@ describe("LOCATION_COLORS", () => {
     expect(LOCATION_COLORS.TRANSIT).toBe("#D946EF");
     expect(LOCATION_COLORS.UNKNOWN).toBe("#6B7280");
     expect(LOCATION_COLORS.SICK).toBe("#EAB308");
+  });
+
+  // Cross-stack parity: GROUP_ROOM is also hardcoded in
+  // backend/api/common/badge.go as `BadgeStammraumGreen`. The Go-side pin
+  // lives in `TestBadgeStammraumGreenLiteral`. If you change either side,
+  // update the other in the same commit or stammraum badges will desync
+  // between API responses and frontend rendering.
+  it("pins GROUP_ROOM to the value the backend resolves stammraum to", () => {
+    expect(LOCATION_COLORS.GROUP_ROOM).toBe("#83CD2D");
   });
 
   it("has SICK color (amber) for medical indication", () => {
@@ -312,5 +323,122 @@ describe("StudentLocationContext with sick fields", () => {
     };
     expect(student.sick).toBeUndefined();
     expect(student.sick_since).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// ROOM COLOR PALETTE + PICKER LOGIC
+// =============================================================================
+
+describe("ROOM_COLOR_PALETTE", () => {
+  it("contains the 9 curated palette colors", () => {
+    expect(ROOM_COLOR_PALETTE).toHaveLength(9);
+  });
+
+  it("does not include reserved status / brand colors", () => {
+    const reserved = [
+      LOCATION_COLORS.GROUP_ROOM,
+      LOCATION_COLORS.OTHER_ROOM,
+      LOCATION_COLORS.HOME,
+      LOCATION_COLORS.SCHOOLYARD,
+      LOCATION_COLORS.TRANSIT,
+      LOCATION_COLORS.SICK,
+      LOCATION_COLORS.EXCUSED,
+    ].map((c) => c.toLowerCase());
+    for (const palette of ROOM_COLOR_PALETTE) {
+      expect(reserved).not.toContain(palette.toLowerCase());
+    }
+  });
+});
+
+describe("pickRoomColor", () => {
+  it("returns a palette color when nothing is used", () => {
+    const picked = pickRoomColor([]);
+    expect(ROOM_COLOR_PALETTE).toContain(picked);
+  });
+
+  it("prefers an unused palette color when some are used", () => {
+    const used = ROOM_COLOR_PALETTE.slice(0, 3);
+    const picked = pickRoomColor(used);
+    expect(ROOM_COLOR_PALETTE).toContain(picked);
+    expect(used).not.toContain(picked);
+  });
+
+  it("falls back to allowing duplicates when palette is exhausted", () => {
+    const picked = pickRoomColor(ROOM_COLOR_PALETTE);
+    expect(ROOM_COLOR_PALETTE).toContain(picked);
+  });
+
+  it("compares case-insensitively when filtering used colors", () => {
+    const used = ROOM_COLOR_PALETTE.slice(0, 8).map((c) => c.toLowerCase());
+    const picked = pickRoomColor(used);
+    // Only one palette color should be left as truly "unused"
+    expect(picked.toLowerCase()).toBe(ROOM_COLOR_PALETTE[8]!.toLowerCase());
+  });
+});
+
+// =============================================================================
+// getLocationColor with roomColor parameter (per-room custom colors)
+// =============================================================================
+
+describe("getLocationColor with roomColor", () => {
+  it("returns the room's custom color for non-group rooms", () => {
+    const color = getLocationColor(
+      "Anwesend - Mathe-Raum",
+      false,
+      [],
+      "#06B6D4",
+    );
+    expect(color).toBe("#06B6D4");
+  });
+
+  it("falls back to OTHER_ROOM blue when roomColor is not provided", () => {
+    const color = getLocationColor("Anwesend - Mathe-Raum", false, []);
+    expect(color).toBe(LOCATION_COLORS.OTHER_ROOM);
+  });
+
+  it("falls back to OTHER_ROOM blue when roomColor is empty string", () => {
+    const color = getLocationColor("Anwesend - Mathe-Raum", false, [], "");
+    expect(color).toBe(LOCATION_COLORS.OTHER_ROOM);
+  });
+
+  it("falls back to OTHER_ROOM blue when roomColor is null", () => {
+    const color = getLocationColor("Anwesend - Mathe-Raum", false, [], null);
+    expect(color).toBe(LOCATION_COLORS.OTHER_ROOM);
+  });
+
+  it("Stammraum-Grün via groupRooms wins over roomColor", () => {
+    const color = getLocationColor(
+      "Anwesend - Mathe-Raum",
+      false,
+      ["Mathe-Raum"],
+      "#06B6D4",
+    );
+    expect(color).toBe(LOCATION_COLORS.GROUP_ROOM);
+  });
+
+  it("Stammraum-Grün via isGroupRoom flag wins over roomColor", () => {
+    const color = getLocationColor(
+      "Anwesend - Mathe-Raum",
+      true,
+      undefined,
+      "#06B6D4",
+    );
+    expect(color).toBe(LOCATION_COLORS.GROUP_ROOM);
+  });
+
+  it("status colors win over roomColor (Schulhof stays orange)", () => {
+    const color = getLocationColor("Schulhof", false, [], "#06B6D4");
+    expect(color).toBe(LOCATION_COLORS.SCHOOLYARD);
+  });
+
+  it("returns roomColor when room is not in groupRooms list", () => {
+    const color = getLocationColor(
+      "Anwesend - Bastelraum",
+      false,
+      ["Mathe-Raum"],
+      "#DB2777",
+    );
+    expect(color).toBe("#DB2777");
   });
 });

--- a/frontend/src/lib/location-helper.ts
+++ b/frontend/src/lib/location-helper.ts
@@ -28,6 +28,8 @@ export interface StudentLocationContext {
   /** Today has an arrival-schedule exception with null expected time — student is not coming */
   not_arrival_today?: boolean;
   not_arrival_reason?: string | null;
+  /** Per-room custom color from the backend (resolved against the active group's room) */
+  badge_color?: string | null;
 }
 
 export const LOCATION_STATUSES = {
@@ -52,6 +54,69 @@ export const LOCATION_COLORS = {
   EXCUSED: "#7C3AED", // Purple - excused absence (kind is not attending today)
   NOT_ARRIVAL: "#6B7280", // Gray - planned absence via arrival-schedule exception
 } as const;
+
+/**
+ * Curated palette for per-room color customization. Picks are chosen from
+ * hue zones that do NOT appear in the status badges (no Rot/Orange/Amber/
+ * Lime-Grün/Medium-Blau/Violett/Magenta — those are reserved for HOME,
+ * SCHOOLYARD, SICK, GROUP_ROOM, OTHER_ROOM, EXCUSED, TRANSIT). Within the
+ * remaining safe range we use multiple recognizable shades per family
+ * (Mint/Türkis/Cyan and Hellblau/Dunkelblau and Pink/Rosa) so neighboring
+ * picks differ in lightness AND hue, not just one or the other.
+ */
+export const ROOM_COLOR_PALETTE: readonly string[] = [
+  "#34D399", // Mint        (emerald-400)  ~158° (light, NOT lime)
+  "#14B8A6", // Türkis      (teal-500)     ~173°
+  "#06B6D4", // Cyan        (cyan-500)     ~189°
+  "#38BDF8", // Hellblau    (sky-400)      ~199° (light)
+  "#1D4ED8", // Dunkelblau  (blue-700)     ~224° (deep, NOT OTHER_ROOM)
+  "#6366F1", // Indigo      (indigo-500)   ~239°
+  "#A855F7", // Lila        (purple-500)   ~271°
+  "#EC4899", // Pink        (pink-500)     ~333° (vivid)
+  "#F43F5E", // Rosa        (rose-500)     ~350° (red-leaning, NOT HOME)
+] as const;
+
+/**
+ * Picks a color from the palette using a soft-prefer-unique strategy:
+ * if any palette colors are unused by existing rooms, pick from those first;
+ * otherwise allow duplicates by picking from the full palette.
+ */
+export function pickRoomColor(usedColors: readonly string[]): string {
+  const usedSet = new Set(usedColors.map((c) => c.toLowerCase()));
+  const unused = ROOM_COLOR_PALETTE.filter(
+    (c) => !usedSet.has(c.toLowerCase()),
+  );
+  const pool = unused.length > 0 ? unused : ROOM_COLOR_PALETTE;
+  return pool[Math.floor(Math.random() * pool.length)] as string;
+}
+
+/**
+ * Matches `#RGB` or `#RRGGBB` (case-insensitive).
+ *
+ * Cross-stack parity: this MUST match the regex in
+ * `backend/models/facilities/room.go` (`Room.Validate()`), which is the
+ * authoritative gate enforced by `CreateRoom` / `UpdateRoom`. The frontend
+ * pattern is defensive (catches legacy/bad data before it hits CSS); the
+ * backend pattern is the one that prevents persistence.
+ */
+const HEX_COLOR_PATTERN = /^#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/;
+
+/** Returns true if `value` is a syntactically valid hex color string. */
+export function isValidRoomColor(value: unknown): value is string {
+  return typeof value === "string" && HEX_COLOR_PATTERN.test(value.trim());
+}
+
+/**
+ * Builds the avatar gradient used by room cards/avatars. Falls back to the
+ * OTHER_ROOM brand blue when no valid color is supplied so callers don't
+ * each invent their own fallback.
+ */
+export function getRoomGradient(color?: string | null): string {
+  const base = isValidRoomColor(color)
+    ? color.trim()
+    : LOCATION_COLORS.OTHER_ROOM;
+  return `linear-gradient(to bottom right, ${base}, color-mix(in srgb, ${base} 85%, black))`;
+}
 
 const LOCATION_SEPARATOR = "-";
 const UNKNOWN_STATUS = LOCATION_STATUSES.UNKNOWN;
@@ -155,11 +220,17 @@ function isStudentInGroupRoom(
 
 /**
  * Determines the color for a student who is present with a room assignment.
+ *
+ * Stammraum (own group's room) is hard-reserved as GROUP_ROOM green and
+ * always wins over `roomColor`. Otherwise, when the backend supplies the
+ * room's customized color via `roomColor`, that color is used; without it
+ * we fall back to OTHER_ROOM blue.
  */
 function getColorForPresentWithRoom(
   room: string,
   isGroupRoom?: boolean,
   groupRooms?: string[],
+  roomColor?: string | null,
 ): string {
   // Check if room is one of the user's OGS group rooms
   if (
@@ -175,7 +246,13 @@ function getColorForPresentWithRoom(
     return LOCATION_COLORS.GROUP_ROOM; // Green - in their group's room
   }
 
-  // Student in any other room
+  // Student is in another room — prefer the room's individual color when
+  // it's a syntactically valid hex (defense-in-depth against legacy/bad data).
+  if (isValidRoomColor(roomColor)) {
+    return roomColor.trim();
+  }
+
+  // Fallback when the room has no (valid) color set
   return LOCATION_COLORS.OTHER_ROOM; // Blue - in external/supervised room
 }
 
@@ -184,13 +261,15 @@ function getColorForPresentWithRoom(
  *
  * Color rules:
  * - GREEN: Student in their OGS group's room OR "Anwesend" without room details
- * - BLUE: Student in any other room (external room or supervised room)
+ * - Per-room color: Student in any other room with a custom color set
+ * - BLUE: Student in any other room without a custom color
  * - RED/ORANGE/MAGENTA: Status-based (Home, Schoolyard, Transit)
  */
 export function getLocationColor(
   location?: string | null,
   isGroupRoom?: boolean,
   groupRooms?: string[],
+  roomColor?: string | null,
 ): string {
   const parsed = parseLocation(location);
   const status = parsed.status;
@@ -204,7 +283,12 @@ export function getLocationColor(
   // Handle "Anwesend" status
   if (status === LOCATION_STATUSES.PRESENT) {
     if (parsed.room) {
-      return getColorForPresentWithRoom(parsed.room, isGroupRoom, groupRooms);
+      return getColorForPresentWithRoom(
+        parsed.room,
+        isGroupRoom,
+        groupRooms,
+        roomColor,
+      );
     }
     // "Anwesend" without room details (GDPR-reduced) - show green (present in building)
     return LOCATION_COLORS.GROUP_ROOM;

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -50,6 +50,8 @@ export interface BackendStudent {
   school_class: string;
   current_location?: string | null;
   location_since?: string | null; // When student entered current location (ISO timestamp)
+  /** Per-room custom color resolved by the backend from the active group's room (hex, no leading "#" stripped) */
+  badge_color?: string | null;
   bus?: boolean;
   sick?: boolean;
   sick_since?: string;
@@ -146,6 +148,8 @@ export interface Student {
   current_location: string;
   // When student entered current location (only for hasFullAccess users)
   location_since?: string;
+  // Per-room custom color (resolved by backend from active group's room)
+  badge_color?: string | null;
   // Transportation method (separate from attendance)
   takes_bus?: boolean;
   bus?: boolean; // Administrative permission flag (Buskind), not attendance status
@@ -212,6 +216,7 @@ export function mapStudentResponse(
     // New attendance-based system
     current_location,
     location_since: backendStudent.location_since ?? undefined,
+    badge_color: backendStudent.badge_color ?? null,
     takes_bus: undefined,
     bus: backendStudent.bus ?? false, // Administrative permission flag (Buskind)
     sick: backendStudent.sick ?? false, // Sickness status


### PR DESCRIPTION
## Summary
- Rooms can now hold an optional hex color (`facilities.rooms.color`) used as the student's location-badge color.
- The backend resolves the badge per visit: **stammraum (own group's room) → reserved green `#83CD2D`**, **system rooms (Schulhof, WC) → `nil`** (frontend keeps existing status-based rendering), **otherwise → the room's stored color or `nil`**.
- Frontend ships a 9-color palette picker (`ROOM_COLOR_PALETTE`) with a "Keine Farbe" option. `RoomCreateModal` seeds the form with an unused palette color via `pickRoomColor`. Edit modal strips the color field for system rooms.

## Cross-stack parity
`BadgeStammraumGreen` (`backend/api/common/badge.go`) and `LOCATION_COLORS.GROUP_ROOM` (`frontend/src/lib/location-helper.ts`) must stay equal. Both are pinned by tests (`TestBadgeStammraumGreenLiteral` + `it("pins GROUP_ROOM ...")`). Hex-validation regex is duplicated frontend-side as defense-in-depth; backend `Room.Validate()` is the gate.

## Notable backend changes
- `RoomRepository.FindByIDs` (tenant-scoped bulk load).
- `GetActiveGroupsByIDs` now hydrates `group.Room` for all groups via a single bulk query — additive cost for callers that don't need rooms.
- `UpdateRoom` preserves the existing color for system rooms when the form omits it, and rejects explicit changes.

## Test plan
- [ ] `cd backend && go test ./...`
- [ ] `cd backend && go test ./test/ -run TestHermeticTestPatterns -v`
- [ ] `cd frontend && pnpm run check`
- [ ] Pick a non-stammraum color → student badge renders that color in the supervision dashboard, OGS-Gruppen view, and student detail header.
- [ ] Open the rooms list (database/rooms) → room avatar gradient reflects the saved color.
- [ ] Move student into their own group's room → badge stays green regardless of stored color.
- [ ] Edit Schulhof/WC → no Badge-Farbe field; reserved color preserved on save.
- [ ] Open a legacy room with stored `#4F46E5` → picker shows "Keine Farbe" selected, no warning hint.
- [ ] Switch tenants in the same browser → Create-Modal's unused-color suggestion is per tenant (no cache bleed).

---
Closes #1324