### PR TITLE
fix(test): close system fixture race in SetupTestDB

### DIFF
--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -459,10 +459,12 @@ func CleanupActivityFixtures(tb testing.TB, db *bun.DB, ids ...int64) {
 		// Facilities domain cleanup
 		// ========================================
 
-		// Delete from facilities.rooms
+		// Delete from facilities.rooms, but never the system default room
+		// (id=1, created by SetupTestDB). Concurrent test packages depend on it.
 		cleanupDelete(tb, db.NewDelete().
 			TableExpr("facilities.rooms").
-			Where(whereIDEquals, id),
+			Where(whereIDEquals, id).
+			Where("id != ?", 1),
 			"facilities.rooms")
 
 		// ========================================
@@ -495,16 +497,21 @@ func CleanupActivityFixtures(tb testing.TB, db *bun.DB, ids ...int64) {
 			Where(whereIDEquals, id),
 			"users.students")
 
-		// Delete from users.staff
+		// Delete from users.staff, but never the system staff fixture
+		// (id=1, created by SetupTestDB). Tests across parallel packages share it.
 		cleanupDelete(tb, db.NewDelete().
 			TableExpr(tableUsersStaff).
-			Where(whereIDEquals, id),
+			Where(whereIDEquals, id).
+			Where("id != ?", 1),
 			tableUsersStaff)
 
-		// Delete from users.persons (last, as it's referenced by students and staff)
+		// Delete from users.persons (last, as it's referenced by students and staff).
+		// Skip the system person fixture (id=1, created by SetupTestDB) for the
+		// same reason as users.staff above.
 		cleanupDelete(tb, db.NewDelete().
 			TableExpr(tableUsersPersons).
-			Where(whereIDEquals, id),
+			Where(whereIDEquals, id).
+			Where("id != ?", 1),
 			tableUsersPersons)
 
 		// ========================================

--- a/backend/test/helpers.go
+++ b/backend/test/helpers.go
@@ -148,6 +148,13 @@ For CI, set TEST_DB_DSN as an environment variable.`)
 	// always ends up at (tenant_id=1, id=1).
 	ctx := context.Background()
 	require.NoError(t, db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		// Serialize concurrent fixture setup across parallel test packages.
+		// pg_advisory_xact_lock is released automatically on commit/rollback,
+		// so other packages wait at this line instead of racing the inserts
+		// below. Constant must stay identical wherever this lock is taken.
+		if _, e := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(914735691)`); e != nil {
+			return fmt.Errorf("acquire system fixture advisory lock: %w", e)
+		}
 		if _, e := tx.ExecContext(ctx, `
 			INSERT INTO users.persons (id, tenant_id, first_name, last_name)
 			VALUES (1, 1, 'System', 'Test')


### PR DESCRIPTION
## Summary

Closes the parallel-package race that was failing `TestFetchSupervisorsBySpecialization_IncludesLegacyTeachers` on `development` (run 25068268786 on 75e2978f) with:

```
ensure system staff fixture (id=1): ERROR: insert or update on table
"staff" violates foreign key constraint "fk_staff_person_tenant"
```

The setup transaction in `backend/test/helpers.go` upserts a system person + staff at `id=1`. While that transaction is in flight, a concurrent test package can run `CleanupActivityFixtures` with `id=1` somewhere in its ID list and delete `users.persons (id=1)` between our person insert and our staff insert. `ON CONFLICT DO NOTHING` does not hold a row lock on existing rows, so the FK on `users.staff` then breaks.

Two layers, two commits:

- **Layer 1 (root cause):** `CleanupActivityFixtures` now never deletes `users.persons (id=1)`, `users.staff (id=1)`, or `facilities.rooms (id=1)`. Same pattern already used for `iot.devices.WEB-MANUAL-001`.
- **Layer 2 (defense in depth):** `SetupTestDB` takes `pg_advisory_xact_lock(914735691)` as the first statement of the system fixture transaction, so concurrent setups serialize regardless of cleanup behavior.

## Test plan
- [x] Backend builds (`go build ./...`)
- [x] `TestFetchSupervisorsBySpecialization_IncludesLegacyTeachers` passes 3/3 with `-count=3`
- [x] `./api/activities/...` and `./test/...` pass
- [x] `TestHermeticTestPatterns` passes
- [ ] CI on PR is green