### PR TITLE
ci: merge quality jobs and switch to Blacksmith docker cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,11 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [check-environment]
     if: needs.check-environment.outputs.should_deploy == 'true'
+    # Cancel superseded builds on rapid pushes to the same ref. Deploy jobs
+    # have their own concurrency groups, so they are NOT affected.
+    concurrency:
+      group: build-backend-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: read
       packages: write
@@ -93,8 +98,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Set up Blacksmith Docker builder
+        uses: useblacksmith/setup-docker-builder@0499d0ae6eaca32ba5f461861e214b04be4c097f # v1.8.0
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -122,7 +127,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push backend
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2.2.0
         with:
           context: ./backend
           file: ./backend/Dockerfile
@@ -130,9 +135,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          # Use separate cache scope to prevent frontend overwriting backend cache
-          cache-from: type=gha,scope=backend
-          cache-to: type=gha,mode=max,scope=backend
+          # Layer cache is mounted automatically via Blacksmith sticky disks (per repo + Dockerfile)
           provenance: false
 
       - name: Image digest
@@ -143,6 +146,11 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [check-environment]
     if: needs.check-environment.outputs.should_deploy == 'true'
+    # Cancel superseded builds on rapid pushes to the same ref. Deploy jobs
+    # have their own concurrency groups, so they are NOT affected.
+    concurrency:
+      group: build-frontend-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: read
       packages: write
@@ -151,8 +159,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Set up Blacksmith Docker builder
+        uses: useblacksmith/setup-docker-builder@0499d0ae6eaca32ba5f461861e214b04be4c097f # v1.8.0
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -207,7 +215,7 @@ jobs:
           fi
 
       - name: Build and push frontend
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2.2.0
         with:
           context: ./frontend
           file: ./frontend/Dockerfile.prod
@@ -223,9 +231,7 @@ jobs:
             NEXT_PUBLIC_TENANT_DOMAIN=${{ steps.tenant_domain.outputs.domain }}
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_SENTRY_ENVIRONMENT=${{ needs.check-environment.outputs.is_staging == 'true' && 'staging' || 'production' }}
-          # Use separate cache scope to prevent backend overwriting frontend cache
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,mode=max,scope=frontend
+          # Layer cache is mounted automatically via Blacksmith sticky disks (per repo + Dockerfile)
           provenance: false
 
       - name: Image digest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ defaults:
     shell: bash
 
 jobs:
-  backend-format:
+  backend-quality:
     if: ${{ inputs.run-backend }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
@@ -28,6 +28,12 @@ jobs:
           go-version-file: backend/go.mod
           cache: true
           cache-dependency-path: backend/go.sum
+
+      - name: Install Go quality tools
+        run: |
+          go install golang.org/x/tools/cmd/deadcode@latest
+          go install github.com/google/go-licenses@latest
+
       - name: Check Go formatting
         working-directory: backend
         run: |
@@ -45,21 +51,14 @@ jobs:
             echo "All Go files are properly formatted"
           fi
 
-  backend-deadcode:
-    if: ${{ inputs.run-backend }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Setup Go with cache
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: backend/go.mod
-          cache: true
-          cache-dependency-path: backend/go.sum
-      - name: Install deadcode
-        run: go install golang.org/x/tools/cmd/deadcode@latest
+      - name: Validate migration dependencies
+        working-directory: backend
+        run: go run main.go migrate validate
+
+      - name: Check for migration version collisions
+        working-directory: backend
+        run: go test ./database/migrations/ -run TestNoDuplicateMigrationVersions -v
+
       - name: Run dead code detection
         working-directory: backend
         run: |
@@ -124,6 +123,25 @@ jobs:
             echo "No dead code detected"
           fi
 
+      - name: Check Go dependency licenses
+        working-directory: backend
+        run: |
+          echo "🔍 Checking Go dependency licenses..."
+
+          # Disallowed licenses for a source-available project (copyleft / network-copyleft)
+          DISALLOWED="AGPL-3.0,GPL-3.0,LGPL-3.0,SSPL-1.0,EUPL-1.2"
+
+          # go-licenses check exits non-zero if disallowed licenses are found
+          go-licenses check ./... --disallowed_types=restricted,reciprocal 2>&1 || {
+            echo ""
+            echo "❌ Disallowed licenses found in Go dependencies."
+            echo "Source-available project cannot use restricted or reciprocal licenses."
+            echo "Review the output above and replace the offending dependency."
+            exit 1
+          }
+
+          echo "All Go dependency licenses are compatible"
+
   backend-lint:
     if: ${{ inputs.run-backend }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -144,102 +162,9 @@ jobs:
           args: --timeout 10m
           working-directory: backend
 
-  backend-migration-validate:
-    if: ${{ inputs.run-backend }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Setup Go with cache
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: backend/go.mod
-          cache: true
-          cache-dependency-path: backend/go.sum
-      - name: Validate migration dependencies
-        working-directory: backend
-        run: go run main.go migrate validate
-      - name: Check for migration version collisions
-        working-directory: backend
-        run: go test ./database/migrations/ -run TestNoDuplicateMigrationVersions -v
-
-  backend-licenses:
-    if: ${{ inputs.run-backend }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Setup Go with cache
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: backend/go.mod
-          cache: true
-          cache-dependency-path: backend/go.sum
-      - name: Install go-licenses
-        run: go install github.com/google/go-licenses@latest
-      - name: Check Go dependency licenses
-        working-directory: backend
-        run: |
-          echo "🔍 Checking Go dependency licenses..."
-
-          # Disallowed licenses for a source-available project (copyleft / network-copyleft)
-          DISALLOWED="AGPL-3.0,GPL-3.0,LGPL-3.0,SSPL-1.0,EUPL-1.2"
-
-          # go-licenses check exits non-zero if disallowed licenses are found
-          go-licenses check ./... --disallowed_types=restricted,reciprocal 2>&1 || {
-            echo ""
-            echo "❌ Disallowed licenses found in Go dependencies."
-            echo "Source-available project cannot use restricted or reciprocal licenses."
-            echo "Review the output above and replace the offending dependency."
-            exit 1
-          }
-
-          echo "All Go dependency licenses are compatible"
-
-  frontend-licenses:
+  frontend-quality:
     if: ${{ inputs.run-frontend }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: "24"
-          cache: "pnpm"
-          cache-dependency-path: "frontend/pnpm-lock.yaml"
-
-      - name: Install dependencies
-        working-directory: frontend
-        run: pnpm install --frozen-lockfile
-
-      - name: Check npm dependency licenses
-        working-directory: frontend
-        run: |
-          echo "🔍 Checking npm dependency licenses..."
-
-          npx license-checker --production --failOn \
-            "AGPL-1.0-only;AGPL-1.0-or-later;AGPL-3.0-only;AGPL-3.0-or-later;GPL-2.0-only;GPL-2.0-or-later;GPL-3.0-only;GPL-3.0-or-later;LGPL-2.0-only;LGPL-2.0-or-later;LGPL-2.1-only;LGPL-2.1-or-later;LGPL-3.0-only;LGPL-3.0-or-later;SSPL-1.0;EUPL-1.2" \
-            --summary || {
-            echo ""
-            echo "❌ Disallowed licenses found in npm dependencies."
-            echo "Source-available project cannot use restricted or reciprocal licenses."
-            echo "Review the output above and replace the offending dependency."
-            exit 1
-          }
-
-          echo "All npm dependency licenses are compatible"
-
-  frontend-lint:
-    if: ${{ inputs.run-frontend }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
     env:
@@ -266,63 +191,30 @@ jobs:
         working-directory: frontend
         run: pnpm run lint --max-warnings 0
 
-  frontend-typecheck:
-    if: ${{ inputs.run-frontend }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      contents: read
-    env:
-      NEXT_PUBLIC_API_URL: "http://localhost:8080" # Default API URL for linting
-      SKIP_ENV_VALIDATION: "true" # Skip validation during linting
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: "24"
-          cache: "pnpm"
-          cache-dependency-path: "frontend/pnpm-lock.yaml"
-
-      - name: Install dependencies
-        working-directory: frontend
-        run: pnpm install --frozen-lockfile
-
       - name: Run typecheck
         working-directory: frontend
         run: pnpm run typecheck
 
-  frontend-knip:
-    if: ${{ inputs.run-frontend }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    permissions:
-      contents: read
-    env:
-      NEXT_PUBLIC_API_URL: "http://localhost:8080" # Default API URL for linting
-      SKIP_ENV_VALIDATION: "true" # Skip validation during linting
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: "24"
-          cache: "pnpm"
-          cache-dependency-path: "frontend/pnpm-lock.yaml"
-
-      - name: Install dependencies
-        working-directory: frontend
-        run: pnpm install --frozen-lockfile
-
       - name: Check for unused code
         working-directory: frontend
         run: pnpm knip
+
+      - name: Check npm dependency licenses
+        working-directory: frontend
+        run: |
+          echo "🔍 Checking npm dependency licenses..."
+
+          npx license-checker --production --failOn \
+            "AGPL-1.0-only;AGPL-1.0-or-later;AGPL-3.0-only;AGPL-3.0-or-later;GPL-2.0-only;GPL-2.0-or-later;GPL-3.0-only;GPL-3.0-or-later;LGPL-2.0-only;LGPL-2.0-or-later;LGPL-2.1-only;LGPL-2.1-or-later;LGPL-3.0-only;LGPL-3.0-or-later;SSPL-1.0;EUPL-1.2" \
+            --summary || {
+            echo ""
+            echo "❌ Disallowed licenses found in npm dependencies."
+            echo "Source-available project cannot use restricted or reciprocal licenses."
+            echo "Review the output above and replace the offending dependency."
+            exit 1
+          }
+
+          echo "All npm dependency licenses are compatible"
 
   frontend-build:
     if: ${{ inputs.run-frontend }}


### PR DESCRIPTION
## Summary

Consolidates redundant CI jobs and moves Docker layer caching off the GitHub-hosted cache. Three logical changes in one PR.

### `lint.yml` — fewer jobs, fewer redundant installs
- **`backend-quality`** replaces `backend-format` + `backend-deadcode` + `backend-migration-validate` + `backend-licenses`. Eliminates 3 redundant Go module hydrations. Stays on `blacksmith-2vcpu`.
- **`frontend-quality`** replaces `frontend-lint` + `frontend-typecheck` + `frontend-knip` + `frontend-licenses`. Eliminates 3 redundant `pnpm install` cycles. Runs on `blacksmith-4vcpu` (typecheck still needs it).
- `backend-lint` (golangci-lint) and `frontend-build` kept separate.

### `build.yml` — Blacksmith-native Docker cache
- `docker/setup-buildx-action` → `useblacksmith/setup-docker-builder@v1.8.0`
- `docker/build-push-action@v7.1.0` → `useblacksmith/build-push-action@v2.2.0`
- `cache-from: type=gha` / `cache-to: type=gha` lines removed; layer cache mounts automatically via Blacksmith sticky disks.

### `build.yml` — concurrency on builds
- Job-level `concurrency: cancel-in-progress: true` on `build-backend` and `build-frontend`. Rapid pushes to the same ref now skip superseded builds.
- Deploy jobs are unchanged: `deploy-staging` and `deploy-production` keep their own concurrency groups with `cancel-in-progress: false`, so a deploy already in flight cannot be cancelled by a later push.

## Trade-offs to be aware of

- **Wall clock vs. runner-minutes:** the lint merges save runner-minutes (cost), not wall-clock. Frontend wall-clock may be ~15-30s slower per PR because lint/typecheck/knip/licenses now run sequentially instead of in parallel.
- **First Docker build after merge will be cold** (no Blacksmith sticky disk warmed up yet). Subsequent builds use the new cache.
- **Sticky disk billing:** ~\$0.50/GB/month per Dockerfile cache. Estimate ~\$2-3/mo ongoing.
- **`build-status` semantics on cancellation:** when a build is cancelled by the new concurrency rule, `build-status` reports "Build failed" with `Backend: cancelled`. Pre-existing logic, but the case is now reachable. Optional follow-up cleanup.

## Test plan

- [ ] Verify branch protection rules on `main` and `development` no longer pin to old check names (e.g., `frontend-lint`, `backend-format`). Required checks may need to be updated to `backend-quality` / `frontend-quality`.
- [ ] First push to this PR: confirm `backend-quality` and `frontend-quality` run end-to-end with the same exit semantics as before.
- [ ] Confirm `useblacksmith/build-push-action@v2.2.0` accepts `build-args`, `provenance: false`, and `platforms: linux/amd64` as drop-in replacements (Blacksmith docs imply yes; not yet exercised against this repo's Dockerfiles).
- [ ] After merge to `development`, observe staging deploy: first build should be cold, subsequent should be fast.
- [ ] On a second push to this branch, observe that the older build run is cancelled (concurrency working) and the deploy job (if reached) is not.