### PR TITLE
feat(database/rooms): customizable badge colors per room

### DIFF
--- a/backend/api/active/converters.go
+++ b/backend/api/active/converters.go
@@ -62,8 +62,9 @@ func newActiveGroupResponse(group *active.Group) ActiveGroupResponse {
 	// Add room info if available
 	if group.Room != nil {
 		response.Room = &RoomSimple{
-			ID:   group.Room.ID,
-			Name: group.Room.Name,
+			ID:    group.Room.ID,
+			Name:  group.Room.Name,
+			Color: group.Room.Color,
 		}
 	}
 

--- a/backend/api/active/converters_color_test.go
+++ b/backend/api/active/converters_color_test.go
@@ -1,0 +1,83 @@
+package active
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/facilities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewActiveGroupResponse_RoomColorPropagation guards the most fragile
+// link in the badge-color pipeline: the RoomSimple struct used by every
+// active-group response. The frontend BFFs decode this JSON to populate
+// `current_room_color` for badges. If anyone:
+//   - removes Color from RoomSimple,
+//   - forgets to set it in newActiveGroupResponse, or
+//   - changes the JSON tag from "color" to something else,
+//
+// every per-room badge color silently disappears with no compile error.
+//
+// This test marshals the response struct and inspects the raw JSON to catch
+// all three regressions in one shot.
+func TestNewActiveGroupResponse_RoomColorPropagation(t *testing.T) {
+	now := time.Now()
+	color := "#A3D977"
+
+	t.Run("color is included in JSON when room has color set", func(t *testing.T) {
+		group := &activeModels.Group{
+			Model:     modelBase.Model{ID: 1, CreatedAt: now, UpdatedAt: now},
+			RoomID:    10,
+			StartTime: now,
+			Room: &facilities.Room{
+				Model: modelBase.Model{ID: 10},
+				Name:  "Werkraum",
+				Color: &color,
+			},
+		}
+
+		resp := newActiveGroupResponse(group)
+		require.NotNil(t, resp.Room, "Room must be populated when group.Room is set")
+
+		// Direct field check — catches "Color field removed" regression.
+		require.NotNil(t, resp.Room.Color)
+		assert.Equal(t, "#A3D977", *resp.Room.Color)
+
+		// JSON-shape check — catches "json tag renamed" regression. The
+		// frontend BFF reads this exact key, so a tag rename would silently
+		// drop the value.
+		raw, err := json.Marshal(resp.Room)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"id":10,"name":"Werkraum","color":"#A3D977"}`, string(raw))
+	})
+
+	t.Run("color is omitted from JSON when room has no color", func(t *testing.T) {
+		// When color is nil the response must still be valid JSON without
+		// a "color" key — the omitempty tag earns its keep here. Without
+		// it, the field would serialize as "color":null, which the
+		// frontend would treat as an explicit cleared value (still falls
+		// back to blue, but it's a noisier wire payload).
+		group := &activeModels.Group{
+			Model:     modelBase.Model{ID: 1},
+			RoomID:    10,
+			StartTime: now,
+			Room: &facilities.Room{
+				Model: modelBase.Model{ID: 10},
+				Name:  "Bibliothek",
+			},
+		}
+
+		resp := newActiveGroupResponse(group)
+		require.NotNil(t, resp.Room)
+		assert.Nil(t, resp.Room.Color)
+
+		raw, err := json.Marshal(resp.Room)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"id":10,"name":"Bibliothek"}`, string(raw),
+			"omitempty must drop the color key when not set")
+	})
+}

--- a/backend/api/active/types.go
+++ b/backend/api/active/types.go
@@ -63,10 +63,16 @@ type GroupSupervisorSimple struct {
 	Role    string `json:"role,omitempty"`
 }
 
-// RoomSimple represents simplified room info for active group response
+// RoomSimple represents simplified room info for active group response.
+//
+// Color is included so badge consumers (active-supervisions BFF, OGS dashboard
+// BFF) can paint per-room badges without a follow-up GET /rooms/{id} per
+// active group. omitempty keeps responses unchanged for rooms with no color
+// override; clients fall back to the OTHER_ROOM blue.
 type RoomSimple struct {
-	ID   int64  `json:"id"`
-	Name string `json:"name"`
+	ID    int64   `json:"id"`
+	Name  string  `json:"name"`
+	Color *string `json:"color,omitempty"`
 }
 
 // VisitResponse represents a visit API response

--- a/backend/api/common/student_locations.go
+++ b/backend/api/common/student_locations.go
@@ -9,10 +9,17 @@ import (
 	activeService "github.com/moto-nrw/project-phoenix/services/active"
 )
 
-// StudentLocationInfo contains resolved location data including timestamps
+// StudentLocationInfo contains resolved location data including timestamps.
+//
+// RoomColor carries the room's configured hex code (e.g. "#A3D977") when the
+// student is currently checked into a real room and that room has a color
+// override set. Frontend uses it to differentiate room badges instead of
+// rendering every "in some room" student blue. Nil for non-room statuses
+// (Schulhof / Unterwegs / Zuhause) and for rooms without a custom color.
 type StudentLocationInfo struct {
-	Location string
-	Since    *time.Time // When the student entered this location (nil if not in a room)
+	Location  string
+	Since     *time.Time // When the student entered this location (nil if not in a room)
+	RoomColor *string    // Hex color of the current room, nil when no room or no override set
 }
 
 // Mode constants for StudentLocationSnapshot.Mode. Kept as bare strings to
@@ -210,8 +217,9 @@ func (s *StudentLocationSnapshot) ResolveStudentLocationWithTime(studentID int64
 
 	if group.Room != nil && group.Room.Name != "" {
 		return StudentLocationInfo{
-			Location: fmt.Sprintf("Anwesend - %s", group.Room.Name),
-			Since:    &visit.EntryTime,
+			Location:  fmt.Sprintf("Anwesend - %s", group.Room.Name),
+			Since:     &visit.EntryTime,
+			RoomColor: group.Room.Color,
 		}
 	}
 

--- a/backend/api/common/student_locations_test.go
+++ b/backend/api/common/student_locations_test.go
@@ -364,6 +364,71 @@ func TestStudentLocationSnapshot_ResolveStudentLocation_CheckedIn_WithRoom(t *te
 	assert.Equal(t, "Anwesend - Room 101", location)
 }
 
+// TestStudentLocationSnapshot_ResolveStudentLocation_RoomColor confirms the
+// snapshot resolver populates StudentLocationInfo.RoomColor when the active
+// group's room has a color configured. Frontend depends on this to render
+// per-room badge colors instead of every "Anwesend - <Room>" being blue.
+func TestStudentLocationSnapshot_ResolveStudentLocation_RoomColor(t *testing.T) {
+	checkinTime := time.Now().Add(-30 * time.Minute)
+	entryTime := time.Now().Add(-10 * time.Minute)
+	startTime := time.Now().Add(-1 * time.Hour)
+	roomColor := "#A3D977"
+
+	t.Run("populates RoomColor when room has color set", func(t *testing.T) {
+		snapshot := &common.StudentLocationSnapshot{
+			Mode: common.PresenceModeDetailed,
+			Attendances: map[int64]*activeService.AttendanceStatus{
+				123: {StudentID: 123, Status: "checked_in", CheckInTime: &checkinTime},
+			},
+			Visits: map[int64]*activeModels.Visit{
+				123: {StudentID: 123, ActiveGroupID: 456, EntryTime: entryTime},
+			},
+			Groups: map[int64]*activeModels.Group{
+				456: {
+					GroupID:   base.Int64Ptr(789),
+					RoomID:    1,
+					StartTime: startTime,
+					Room: &facilities.Room{
+						Name:     "Bibliothek",
+						Building: "Main Building",
+						Color:    &roomColor,
+					},
+				},
+			},
+		}
+
+		info := snapshot.ResolveStudentLocationWithTime(123, true)
+		assert.Equal(t, "Anwesend - Bibliothek", info.Location)
+		require.NotNil(t, info.RoomColor)
+		assert.Equal(t, "#A3D977", *info.RoomColor)
+	})
+
+	t.Run("RoomColor is nil when room has no color (fallback to blue)", func(t *testing.T) {
+		snapshot := &common.StudentLocationSnapshot{
+			Mode: common.PresenceModeDetailed,
+			Attendances: map[int64]*activeService.AttendanceStatus{
+				123: {StudentID: 123, Status: "checked_in", CheckInTime: &checkinTime},
+			},
+			Visits: map[int64]*activeModels.Visit{
+				123: {StudentID: 123, ActiveGroupID: 456, EntryTime: entryTime},
+			},
+			Groups: map[int64]*activeModels.Group{
+				456: {
+					GroupID:   base.Int64Ptr(789),
+					RoomID:    1,
+					StartTime: startTime,
+					Room:      &facilities.Room{Name: "Sportraum"},
+				},
+			},
+		}
+
+		info := snapshot.ResolveStudentLocationWithTime(123, true)
+		assert.Equal(t, "Anwesend - Sportraum", info.Location)
+		assert.Nil(t, info.RoomColor,
+			"a room without color must propagate nil so the frontend falls back to OTHER_ROOM blue")
+	})
+}
+
 // =============================================================================
 // ResolveStudentLocationWithTime Tests
 // =============================================================================

--- a/backend/api/rooms/api.go
+++ b/backend/api/rooms/api.go
@@ -218,11 +218,9 @@ func (rs *Resource) createRoom(w http.ResponseWriter, r *http.Request) {
 		Color:    req.Color,
 	}
 
-	// Validate the room
-	if err := room.Validate(); err != nil {
-		common.RenderError(w, r, common.ErrorInvalidRequest(err))
-		return
-	}
+	// Validation runs inside CreateRoom — keeping it there as the single
+	// source of truth lets the service translate facilities.ErrReservedColor
+	// to the German service-level error which ErrorRenderer maps to 400.
 
 	// Create room using service
 	tenantID := tenant.FromContext(r.Context())
@@ -230,7 +228,7 @@ func (rs *Resource) createRoom(w http.ResponseWriter, r *http.Request) {
 		return rs.FacilityService.CreateRoom(ctx, room)
 	})
 	if err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(err))
+		common.RenderError(w, r, ErrorRenderer(err))
 		return
 	}
 
@@ -269,11 +267,8 @@ func (rs *Resource) updateRoom(w http.ResponseWriter, r *http.Request) {
 	room.Category = req.Category
 	room.Color = req.Color
 
-	// Validate the room
-	if err := room.Validate(); err != nil {
-		common.RenderError(w, r, common.ErrorInvalidRequest(err))
-		return
-	}
+	// Validation runs inside UpdateRoom; ErrorRenderer translates German
+	// ErrColorReserved / ErrColorAlreadyInUse to 400 / 409 respectively.
 
 	// Update room using service
 	tenantID := tenant.FromContext(r.Context())
@@ -281,7 +276,7 @@ func (rs *Resource) updateRoom(w http.ResponseWriter, r *http.Request) {
 		return rs.FacilityService.UpdateRoom(ctx, room)
 	})
 	if err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(err))
+		common.RenderError(w, r, ErrorRenderer(err))
 		return
 	}
 

--- a/backend/api/rooms/errors.go
+++ b/backend/api/rooms/errors.go
@@ -24,29 +24,35 @@ var (
 //     future code path returns an unwrapped facilities.ErrXxx). Without
 //     this, a forgotten wrap turns "name required" into 500.
 //  3. Default 500.
+//
+// User-facing branches render the inner sentinel directly so the JSON
+// `error` field carries just the (German) message instead of FacilitiesError's
+// "facilities error during {Op}: …" prefix. The 500 fallback keeps the
+// wrapped facErr so server logs still capture the operation context.
 func ErrorRenderer(err error) render.Renderer {
 	var facErr *facilities.FacilitiesError
 	if errors.As(err, &facErr) {
 		// Inner sentinel from the service layer (Op + Err wrap).
-		switch facErr.Unwrap() {
+		inner := facErr.Unwrap()
+		switch inner {
 		case facilities.ErrRoomNotFound:
-			return common.ErrorNotFound(facErr)
+			return common.ErrorNotFound(inner)
 		case facilities.ErrRoomInUse:
-			return common.ErrorConflict(facErr)
+			return common.ErrorConflict(inner)
 		case facilities.ErrSystemRoomProtected:
-			return common.ErrorForbidden(facErr)
+			return common.ErrorForbidden(inner)
 		case facilities.ErrDuplicateRoom:
-			return common.ErrorConflict(facErr)
+			return common.ErrorConflict(inner)
 		case facilities.ErrColorAlreadyInUse:
-			return common.ErrorConflictWithCode(facErr, "color_already_in_use")
+			return common.ErrorConflictWithCode(inner, "color_already_in_use")
 		case facilities.ErrColorReserved:
-			return common.ErrorInvalidRequest(facErr)
+			return common.ErrorInvalidRequest(inner)
 		}
 
 		// Model-level Validate() sentinels propagated through the service
 		// (name required, capacity negative, invalid color format).
-		if modelFacilities.IsValidationError(facErr.Unwrap()) {
-			return common.ErrorInvalidRequest(facErr)
+		if modelFacilities.IsValidationError(inner) {
+			return common.ErrorInvalidRequest(inner)
 		}
 
 		return common.ErrorInternalServer(facErr)

--- a/backend/api/rooms/errors.go
+++ b/backend/api/rooms/errors.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
+	modelFacilities "github.com/moto-nrw/project-phoenix/models/facilities"
 	"github.com/moto-nrw/project-phoenix/services/facilities"
 )
 
@@ -16,9 +17,17 @@ var (
 )
 
 // ErrorRenderer maps service-layer errors to appropriate HTTP responses.
+//
+// The branches are ordered:
+//  1. Service-level FacilitiesError sentinels (the common path).
+//  2. Bare model-level Validate() sentinels (defensive — fires when a
+//     future code path returns an unwrapped facilities.ErrXxx). Without
+//     this, a forgotten wrap turns "name required" into 500.
+//  3. Default 500.
 func ErrorRenderer(err error) render.Renderer {
 	var facErr *facilities.FacilitiesError
 	if errors.As(err, &facErr) {
+		// Inner sentinel from the service layer (Op + Err wrap).
 		switch facErr.Unwrap() {
 		case facilities.ErrRoomNotFound:
 			return common.ErrorNotFound(facErr)
@@ -28,10 +37,28 @@ func ErrorRenderer(err error) render.Renderer {
 			return common.ErrorForbidden(facErr)
 		case facilities.ErrDuplicateRoom:
 			return common.ErrorConflict(facErr)
-		default:
-			return common.ErrorInternalServer(facErr)
+		case facilities.ErrColorAlreadyInUse:
+			return common.ErrorConflictWithCode(facErr, "color_already_in_use")
+		case facilities.ErrColorReserved:
+			return common.ErrorInvalidRequest(facErr)
 		}
+
+		// Model-level Validate() sentinels propagated through the service
+		// (name required, capacity negative, invalid color format).
+		if modelFacilities.IsValidationError(facErr.Unwrap()) {
+			return common.ErrorInvalidRequest(facErr)
+		}
+
+		return common.ErrorInternalServer(facErr)
 	}
+
+	// Defence-in-depth: a future caller may forget to wrap a model
+	// validation error in *FacilitiesError. errors.Is walks the chain so
+	// this still catches the intent and renders 400 instead of 500.
+	if modelFacilities.IsValidationError(err) {
+		return common.ErrorInvalidRequest(err)
+	}
+
 	return common.ErrorInternalServer(err)
 }
 

--- a/backend/api/rooms/rooms_test.go
+++ b/backend/api/rooms/rooms_test.go
@@ -194,7 +194,7 @@ func TestCreateRoom(t *testing.T) {
 		floor := 2
 		// Hex stays deterministic — the row gets cleaned up below, so
 		// repeated runs no longer collide on the (tenant_id, lower(color))
-		// unique index from migration 1.15.44. Earlier crashed/cancelled
+		// unique index from migration 1.15.45. Earlier crashed/cancelled
 		// runs may have left a #FF5733 row behind that the deferred
 		// cleanup never ran on; sweep it up here to keep the test
 		// hermetic.

--- a/backend/api/rooms/rooms_test.go
+++ b/backend/api/rooms/rooms_test.go
@@ -2,6 +2,7 @@ package rooms_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -191,6 +192,17 @@ func TestCreateRoom(t *testing.T) {
 		router := setupRouter(tc.resource.CreateRoomHandler(), "")
 		uniqueName := fmt.Sprintf("Full Room %d", time.Now().UnixNano())
 		floor := 2
+		// Hex stays deterministic — the row gets cleaned up below, so
+		// repeated runs no longer collide on the (tenant_id, lower(color))
+		// unique index from migration 1.15.44. Earlier crashed/cancelled
+		// runs may have left a #FF5733 row behind that the deferred
+		// cleanup never ran on; sweep it up here to keep the test
+		// hermetic.
+		_, _ = tc.db.NewDelete().
+			TableExpr("facilities.rooms").
+			Where("LOWER(color) = LOWER(?)", "#FF5733").
+			Exec(context.Background())
+
 		body := map[string]interface{}{
 			"name":     uniqueName,
 			"building": "Main",
@@ -204,6 +216,20 @@ func TestCreateRoom(t *testing.T) {
 		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
 
 		assert.Equal(t, http.StatusCreated, rr.Code, "Expected 201 Created. Body: %s", rr.Body.String())
+
+		// Clean up the row we just created so the unique-on-color index
+		// doesn't poison subsequent runs of this test in the shared test
+		// DB. The original test omitted this and relied on the (then-non-
+		// existent) lack of a constraint to dodge collisions; now that
+		// uniqueness is enforced the cleanup is mandatory.
+		var resp struct {
+			Data struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+		require.NotZero(t, resp.Data.ID)
+		defer testpkg.CleanupActivityFixtures(t, tc.db, resp.Data.ID)
 	})
 
 	t.Run("bad_request_missing_name", func(t *testing.T) {

--- a/backend/api/students/response_helpers.go
+++ b/backend/api/students/response_helpers.go
@@ -187,8 +187,9 @@ func resolveStudentLocationWithTime(ctx context.Context, studentID int64, hasFul
 	// Include room name for all authenticated staff (needed for supervised room checkout)
 	if activeGroup.Room != nil && activeGroup.Room.Name != "" {
 		return common.StudentLocationInfo{
-			Location: fmt.Sprintf("Anwesend - %s", activeGroup.Room.Name),
-			Since:    &currentVisit.EntryTime,
+			Location:  fmt.Sprintf("Anwesend - %s", activeGroup.Room.Name),
+			Since:     &currentVisit.EntryTime,
+			RoomColor: activeGroup.Room.Color,
 		}
 	}
 
@@ -229,6 +230,7 @@ func newStudentResponseWithOpts(ctx context.Context, opts StudentResponseOpts, s
 		locationInfo := resolveStudentLocationWithTime(ctx, student.ID, hasFullAccess, services.ActiveService)
 		response.Location = locationInfo.Location
 		response.LocationSince = locationInfo.Since
+		response.RoomColor = locationInfo.RoomColor
 	}
 
 	populatePersonAndGuardianData(&response, person, student, group, hasFullAccess)
@@ -265,6 +267,7 @@ func newStudentResponseFromSnapshot(_ context.Context, student *users.Student, p
 	locationInfo := snapshot.ResolveLocationWithTime(student.ID, hasFullAccess)
 	response.Location = locationInfo.Location
 	response.LocationSince = locationInfo.Since
+	response.RoomColor = locationInfo.RoomColor
 
 	populatePersonAndGuardianData(&response, person, student, group, hasFullAccess)
 	populateSnapshotPublicFields(&response, student)

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -21,7 +21,8 @@ type StudentResponse struct {
 	Birthday           string     `json:"birthday,omitempty"` // Date in YYYY-MM-DD format
 	SchoolClass        string     `json:"school_class"`
 	Location           string     `json:"current_location"`
-	LocationSince      *time.Time `json:"location_since,omitempty"` // When student entered current location
+	LocationSince      *time.Time `json:"location_since,omitempty"`     // When student entered current location
+	RoomColor          *string    `json:"current_room_color,omitempty"` // Hex of the current room when set; nil for status-only locations or rooms without override
 	GuardianName       string     `json:"guardian_name,omitempty"`
 	GuardianContact    string     `json:"guardian_contact,omitempty"`
 	GuardianEmail      string     `json:"guardian_email,omitempty"`

--- a/backend/database/migrations/001015044_rooms_color_unique.go
+++ b/backend/database/migrations/001015044_rooms_color_unique.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	roomsColorUniqueVersion     = "1.15.44"
-	roomsColorUniqueDescription = "Add partial UNIQUE(tenant_id, lower(color)) on facilities.rooms; back up + clear legacy #4F46E5 bug-default into audit.room_color_migration_backup. Rollback drops the index but does NOT restore cleared colors — use the backup table for manual restore."
+	roomsColorUniqueDescription = "Add partial UNIQUE(tenant_id, lower(color)) on facilities.rooms; back up + clear legacy bug-defaults (#4F46E5 from rooms.config.tsx, #FFFFFF from the 1.1.1 NOT NULL DEFAULT) into audit.room_color_migration_backup. Rollback drops the index but does NOT restore cleared colors — use the backup table for manual restore."
 )
 
 func init() {
@@ -35,23 +35,34 @@ func init() {
 // roomsColorUniqueUp adds a partial unique index keyed by tenant + lowercase
 // color so two rooms inside the same school cannot share a hex code.
 //
-// Pre-step nulls every row carrying the legacy "#4F46E5" default. That value
-// was never user-chosen — it came from a bug in rooms.config.tsx
-// transformBeforeSubmit which stamped it onto every save regardless of admin
-// input, so production DBs almost certainly have many rooms with this exact
-// hex even though no Pflegekraft picked it. The previous LocationBadge
-// renderer ignored room.color and always rendered OTHER_ROOM blue, so the
-// stored "#4F46E5" was invisible. With Issue #1324 the badge starts honouring
-// room.color, so the legacy default would suddenly paint as a slightly
-// purple-ish blue, mixed with rooms that fall through to OTHER_ROOM blue —
-// visually inconsistent for no reason.
+// Pre-step nulls every row carrying one of two legacy bug-defaults:
 //
-// Clearing the bug-default at migration time gives every room a clean
-// baseline. Genuine admin-picked colors (anything other than #4F46E5) are
-// preserved untouched. Once cleared, the partial unique index can apply
-// without contention.
+//   - #4F46E5 — produced by a rooms.config.tsx transformBeforeSubmit bug that
+//     stamped this hex onto every save regardless of admin input, so
+//     production DBs almost certainly have many rooms with this exact hex
+//     even though no Pflegekraft picked it. The previous LocationBadge
+//     renderer ignored room.color and always rendered OTHER_ROOM blue, so
+//     the stored value was invisible. With Issue #1324 the badge starts
+//     honouring room.color, so the legacy default would suddenly paint as
+//     a slightly purple-ish blue, mixed with rooms that fall through to
+//     OTHER_ROOM blue — visually inconsistent for no reason.
+//
+//   - #FFFFFF — the original NOT NULL DEFAULT from migration 1.1.1
+//     (see 001001001_facilities_rooms.go). Migration 1.1.5 dropped the
+//     default + NOT NULL constraint but never nulled existing rows, so any
+//     tenant with two rooms created before 1.1.5 has duplicate "#FFFFFF"
+//     values today. The new partial UNIQUE(tenant_id, LOWER(color))
+//     WHERE color IS NOT NULL would refuse to create against those rows
+//     and break the deploy. Same provenance as #4F46E5: the value was
+//     never user-chosen, only inherited from a column default.
+//
+// Both go into the same audit.room_color_migration_backup table; the
+// `color` column on the backup row preserves the original value so a manual
+// restore knows exactly what to put back per row. Genuine admin-picked
+// colors (anything outside this set) are preserved untouched. Once cleared,
+// the partial unique index can apply without contention.
 func roomsColorUniqueUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.44: Backing up + clearing legacy #4F46E5 bug-default then adding partial unique index...")
+	fmt.Println("Migration 1.15.44: Backing up + clearing legacy bug-defaults (#4F46E5, #FFFFFF) then adding partial unique index...")
 
 	// Backup table: persists rows we're about to NULL so a manual restore
 	// is possible if our "no admin ever picked exactly #4F46E5" assumption
@@ -78,14 +89,16 @@ func roomsColorUniqueUp(ctx context.Context, db *bun.DB) error {
 	// the snapshot is consistent — if a concurrent writer slipped in
 	// between an enumerate and a clear, both would see the same set.
 	// NOW() comes from the row default; we just project the columns we
-	// need to be able to reverse-engineer the change.
+	// need to be able to reverse-engineer the change. The backup row's
+	// `color` column preserves the original hex per row so a manual
+	// restore knows whether to put back #4F46E5 or #FFFFFF.
 	backupRes, err := db.NewRaw(`
 		INSERT INTO audit.room_color_migration_backup
 			(room_id, tenant_id, name, color)
 		SELECT id, tenant_id, name, color
 		FROM facilities.rooms
 		WHERE color IS NOT NULL
-		  AND LOWER(color) = LOWER('#4F46E5');
+		  AND LOWER(color) IN (LOWER('#4F46E5'), LOWER('#FFFFFF'));
 	`).Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed populating audit.room_color_migration_backup: %w", err)
@@ -94,20 +107,20 @@ func roomsColorUniqueUp(ctx context.Context, db *bun.DB) error {
 		fmt.Printf("Migration 1.15.44: backed up %d room(s) into audit.room_color_migration_backup before clearing\n", backed)
 	}
 
-	// NULL every room carrying the legacy bug-default. Case-insensitive
+	// NULL every room carrying either legacy bug-default. Case-insensitive
 	// compare in case anything posted lower-case before the model started
 	// uppercasing on write.
 	res, err := db.NewRaw(`
 		UPDATE facilities.rooms
 		SET color = NULL
 		WHERE color IS NOT NULL
-		  AND LOWER(color) = LOWER('#4F46E5');
+		  AND LOWER(color) IN (LOWER('#4F46E5'), LOWER('#FFFFFF'));
 	`).Exec(ctx)
 	if err != nil {
-		return fmt.Errorf("failed clearing legacy room color default before unique index: %w", err)
+		return fmt.Errorf("failed clearing legacy room color defaults before unique index: %w", err)
 	}
 	if affected, raErr := res.RowsAffected(); raErr == nil && affected > 0 {
-		fmt.Printf("Migration 1.15.44: cleared %d room(s) carrying the legacy #4F46E5 bug-default (audit.room_color_migration_backup retains the original values)\n", affected)
+		fmt.Printf("Migration 1.15.44: cleared %d room(s) carrying a legacy bug-default hex (#4F46E5 or #FFFFFF) (audit.room_color_migration_backup retains the original values)\n", affected)
 	}
 
 	createSQL := fmt.Sprintf(`

--- a/backend/database/migrations/001015044_rooms_color_unique.go
+++ b/backend/database/migrations/001015044_rooms_color_unique.go
@@ -1,0 +1,150 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moto-nrw/project-phoenix/models/facilities"
+	"github.com/uptrace/bun"
+)
+
+const (
+	roomsColorUniqueVersion     = "1.15.44"
+	roomsColorUniqueDescription = "Add partial UNIQUE(tenant_id, lower(color)) on facilities.rooms; back up + clear legacy #4F46E5 bug-default into audit.room_color_migration_backup. Rollback drops the index but does NOT restore cleared colors — use the backup table for manual restore."
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     roomsColorUniqueVersion,
+		Description: roomsColorUniqueDescription,
+		DependsOn: []string{
+			FacilitiesRoomsOptionalFieldsVersion, // 1.1.5 — color column made nullable
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return roomsColorUniqueUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return roomsColorUniqueDown(ctx, db)
+		},
+	)
+}
+
+// roomsColorUniqueUp adds a partial unique index keyed by tenant + lowercase
+// color so two rooms inside the same school cannot share a hex code.
+//
+// Pre-step nulls every row carrying the legacy "#4F46E5" default. That value
+// was never user-chosen — it came from a bug in rooms.config.tsx
+// transformBeforeSubmit which stamped it onto every save regardless of admin
+// input, so production DBs almost certainly have many rooms with this exact
+// hex even though no Pflegekraft picked it. The previous LocationBadge
+// renderer ignored room.color and always rendered OTHER_ROOM blue, so the
+// stored "#4F46E5" was invisible. With Issue #1324 the badge starts honouring
+// room.color, so the legacy default would suddenly paint as a slightly
+// purple-ish blue, mixed with rooms that fall through to OTHER_ROOM blue —
+// visually inconsistent for no reason.
+//
+// Clearing the bug-default at migration time gives every room a clean
+// baseline. Genuine admin-picked colors (anything other than #4F46E5) are
+// preserved untouched. Once cleared, the partial unique index can apply
+// without contention.
+func roomsColorUniqueUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.44: Backing up + clearing legacy #4F46E5 bug-default then adding partial unique index...")
+
+	// Backup table: persists rows we're about to NULL so a manual restore
+	// is possible if our "no admin ever picked exactly #4F46E5" assumption
+	// is ever wrong. Outlives deploy log rotation, ~1 row per affected
+	// room. The CASCADE in the rollback drops it together with anything
+	// else in the audit schema, but we only DROP the index there — keeping
+	// the backup data untouched on rollback is the whole point.
+	if _, err := db.NewRaw(`
+		CREATE TABLE IF NOT EXISTS audit.room_color_migration_backup (
+			id           BIGSERIAL PRIMARY KEY,
+			room_id      BIGINT NOT NULL,
+			tenant_id    BIGINT NOT NULL,
+			name         TEXT NOT NULL,
+			color        TEXT NOT NULL,
+			migrated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+		);
+		CREATE INDEX IF NOT EXISTS idx_room_color_migration_backup_tenant
+			ON audit.room_color_migration_backup (tenant_id);
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed creating audit.room_color_migration_backup: %w", err)
+	}
+
+	// Insert backups BEFORE the UPDATE. Using a single INSERT … SELECT so
+	// the snapshot is consistent — if a concurrent writer slipped in
+	// between an enumerate and a clear, both would see the same set.
+	// NOW() comes from the row default; we just project the columns we
+	// need to be able to reverse-engineer the change.
+	backupRes, err := db.NewRaw(`
+		INSERT INTO audit.room_color_migration_backup
+			(room_id, tenant_id, name, color)
+		SELECT id, tenant_id, name, color
+		FROM facilities.rooms
+		WHERE color IS NOT NULL
+		  AND LOWER(color) = LOWER('#4F46E5');
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed populating audit.room_color_migration_backup: %w", err)
+	}
+	if backed, raErr := backupRes.RowsAffected(); raErr == nil && backed > 0 {
+		fmt.Printf("Migration 1.15.44: backed up %d room(s) into audit.room_color_migration_backup before clearing\n", backed)
+	}
+
+	// NULL every room carrying the legacy bug-default. Case-insensitive
+	// compare in case anything posted lower-case before the model started
+	// uppercasing on write.
+	res, err := db.NewRaw(`
+		UPDATE facilities.rooms
+		SET color = NULL
+		WHERE color IS NOT NULL
+		  AND LOWER(color) = LOWER('#4F46E5');
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed clearing legacy room color default before unique index: %w", err)
+	}
+	if affected, raErr := res.RowsAffected(); raErr == nil && affected > 0 {
+		fmt.Printf("Migration 1.15.44: cleared %d room(s) carrying the legacy #4F46E5 bug-default (audit.room_color_migration_backup retains the original values)\n", affected)
+	}
+
+	createSQL := fmt.Sprintf(`
+		CREATE UNIQUE INDEX IF NOT EXISTS %s
+		ON facilities.rooms (tenant_id, LOWER(color))
+		WHERE color IS NOT NULL;
+	`, facilities.RoomColorUniqueConstraintName)
+	if _, err := db.NewRaw(createSQL).Exec(ctx); err != nil {
+		return fmt.Errorf("failed creating %s: %w", facilities.RoomColorUniqueConstraintName, err)
+	}
+
+	return nil
+}
+
+// roomsColorUniqueDown drops the index. It does NOT restore cleared colours
+// from audit.room_color_migration_backup — operators run the rollback when
+// they want the index gone, but reverting the data side requires a conscious
+// SQL statement (we can't tell the difference between "rollback the whole
+// migration" and "drop just the index, keep the cleanup"). The backup table
+// is left in place precisely so a human can do the restore deliberately:
+//
+//	UPDATE facilities.rooms r
+//	SET color = b.color
+//	FROM audit.room_color_migration_backup b
+//	WHERE r.id = b.room_id
+//	  AND r.color IS NULL;
+//
+// The audit table itself is left undropped on rollback — losing the only
+// record of what was cleared on a panicky rollback is exactly the kind of
+// foot-gun this whole table exists to prevent.
+func roomsColorUniqueDown(ctx context.Context, db *bun.DB) error {
+	fmt.Printf("Rolling back migration 1.15.44: dropping %s (cleared colours not auto-restored — see audit.room_color_migration_backup)...\n",
+		facilities.RoomColorUniqueConstraintName)
+
+	dropSQL := fmt.Sprintf(`DROP INDEX IF EXISTS facilities.%s;`, facilities.RoomColorUniqueConstraintName)
+	if _, err := db.NewRaw(dropSQL).Exec(ctx); err != nil {
+		return fmt.Errorf("failed dropping %s: %w", facilities.RoomColorUniqueConstraintName, err)
+	}
+	return nil
+}

--- a/backend/database/migrations/001015045_rooms_color_unique.go
+++ b/backend/database/migrations/001015045_rooms_color_unique.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	roomsColorUniqueVersion     = "1.15.44"
+	roomsColorUniqueVersion     = "1.15.45"
 	roomsColorUniqueDescription = "Add partial UNIQUE(tenant_id, lower(color)) on facilities.rooms; back up + clear legacy bug-defaults (#4F46E5 from rooms.config.tsx, #FFFFFF from the 1.1.1 NOT NULL DEFAULT) into audit.room_color_migration_backup. Rollback drops the index but does NOT restore cleared colors — use the backup table for manual restore."
 )
 
@@ -62,7 +62,7 @@ func init() {
 // colors (anything outside this set) are preserved untouched. Once cleared,
 // the partial unique index can apply without contention.
 func roomsColorUniqueUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.44: Backing up + clearing legacy bug-defaults (#4F46E5, #FFFFFF) then adding partial unique index...")
+	fmt.Println("Migration 1.15.45: Backing up + clearing legacy bug-defaults (#4F46E5, #FFFFFF) then adding partial unique index...")
 
 	// Backup table: persists rows we're about to NULL so a manual restore
 	// is possible if our "no admin ever picked exactly #4F46E5" assumption
@@ -104,7 +104,7 @@ func roomsColorUniqueUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("failed populating audit.room_color_migration_backup: %w", err)
 	}
 	if backed, raErr := backupRes.RowsAffected(); raErr == nil && backed > 0 {
-		fmt.Printf("Migration 1.15.44: backed up %d room(s) into audit.room_color_migration_backup before clearing\n", backed)
+		fmt.Printf("Migration 1.15.45: backed up %d room(s) into audit.room_color_migration_backup before clearing\n", backed)
 	}
 
 	// NULL every room carrying either legacy bug-default. Case-insensitive
@@ -120,7 +120,7 @@ func roomsColorUniqueUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("failed clearing legacy room color defaults before unique index: %w", err)
 	}
 	if affected, raErr := res.RowsAffected(); raErr == nil && affected > 0 {
-		fmt.Printf("Migration 1.15.44: cleared %d room(s) carrying a legacy bug-default hex (#4F46E5 or #FFFFFF) (audit.room_color_migration_backup retains the original values)\n", affected)
+		fmt.Printf("Migration 1.15.45: cleared %d room(s) carrying a legacy bug-default hex (#4F46E5 or #FFFFFF) (audit.room_color_migration_backup retains the original values)\n", affected)
 	}
 
 	createSQL := fmt.Sprintf(`
@@ -152,7 +152,7 @@ func roomsColorUniqueUp(ctx context.Context, db *bun.DB) error {
 // record of what was cleared on a panicky rollback is exactly the kind of
 // foot-gun this whole table exists to prevent.
 func roomsColorUniqueDown(ctx context.Context, db *bun.DB) error {
-	fmt.Printf("Rolling back migration 1.15.44: dropping %s (cleared colours not auto-restored — see audit.room_color_migration_backup)...\n",
+	fmt.Printf("Rolling back migration 1.15.45: dropping %s (cleared colours not auto-restored — see audit.room_color_migration_backup)...\n",
 		facilities.RoomColorUniqueConstraintName)
 
 	dropSQL := fmt.Sprintf(`DROP INDEX IF EXISTS facilities.%s;`, facilities.RoomColorUniqueConstraintName)

--- a/backend/database/repositories/facilities/room.go
+++ b/backend/database/repositories/facilities/room.go
@@ -40,10 +40,12 @@ func (r *RoomRepository) Create(ctx context.Context, room *facilities.Room) erro
 		return fmt.Errorf("room cannot be nil")
 	}
 
-	// Validate room
-	if err := room.Validate(); err != nil {
-		return err
-	}
+	// Validation lives in the service layer — see services/facilities/
+	// facility_service.go CreateRoom/UpdateRoom. The repo previously
+	// re-validated here, which collided with the system-room legacy-colour
+	// preserve path: that flow re-attaches an existing #4F46E5 (now
+	// reserved per migration 1.15.44) right before the repo write, and a
+	// second Validate would reject it. Keep validation in one place.
 
 	// Use the base Create method which now uses ModelTableExpr
 	return r.Repository.Create(ctx, room)
@@ -55,10 +57,8 @@ func (r *RoomRepository) Update(ctx context.Context, room *facilities.Room) erro
 		return fmt.Errorf("room cannot be nil")
 	}
 
-	// Validate room
-	if err := room.Validate(); err != nil {
-		return err
-	}
+	// Validation lives in the service layer (see Create above for the full
+	// rationale). Repo writes trust the service to have validated already.
 
 	// Use GetDB to detect transaction from context
 	query := base.GetDB(ctx, r.db).NewUpdate().

--- a/backend/database/repositories/facilities/room.go
+++ b/backend/database/repositories/facilities/room.go
@@ -44,7 +44,7 @@ func (r *RoomRepository) Create(ctx context.Context, room *facilities.Room) erro
 	// facility_service.go CreateRoom/UpdateRoom. The repo previously
 	// re-validated here, which collided with the system-room legacy-colour
 	// preserve path: that flow re-attaches an existing #4F46E5 (now
-	// reserved per migration 1.15.44) right before the repo write, and a
+	// reserved per migration 1.15.45) right before the repo write, and a
 	// second Validate would reject it. Keep validation in one place.
 
 	// Use the base Create method which now uses ModelTableExpr

--- a/backend/models/facilities/room.go
+++ b/backend/models/facilities/room.go
@@ -69,6 +69,18 @@ func (r *Room) Validate() error {
 			return ErrInvalidColorFormat
 		}
 
+		// Expand #RGB → #RRGGBB before normalising case. The unique index
+		// lives on LOWER(color), so two rooms picking "#ABC" and "#AABBCC"
+		// would otherwise persist as textually different rows even though
+		// both render as the same CSS color. Native <input type="color">
+		// always emits the 6-digit form; this guards direct API callers
+		// (and any future UI surface that uses shorthand).
+		if len(*r.Color) == 4 {
+			s := *r.Color
+			expanded := string([]byte{'#', s[1], s[1], s[2], s[2], s[3], s[3]})
+			r.Color = &expanded
+		}
+
 		// Normalise case — the unique index is on LOWER(color), so two
 		// rooms posting "#A3D977" and "#a3d977" would otherwise persist
 		// as visually identical but textually different rows. Audit log

--- a/backend/models/facilities/room.go
+++ b/backend/models/facilities/room.go
@@ -44,7 +44,7 @@ func (r *Room) BeforeAppendModel(query any) error {
 // Validate ensures room data is valid
 func (r *Room) Validate() error {
 	if r.Name == "" {
-		return errors.New("room name is required")
+		return ErrNameRequired
 	}
 
 	// Trim spaces from name
@@ -52,7 +52,7 @@ func (r *Room) Validate() error {
 
 	// Validate capacity is non-negative (if provided)
 	if r.Capacity != nil && *r.Capacity < 0 {
-		return errors.New("capacity cannot be negative")
+		return ErrCapacityNegative
 	}
 
 	// Validate color is a valid hex color (if provided)
@@ -66,11 +66,46 @@ func (r *Room) Validate() error {
 		// Validate hex color format (#RRGGBB or #RGB)
 		hexColorPattern := regexp.MustCompile(`^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$`)
 		if !hexColorPattern.MatchString(*r.Color) {
-			return errors.New("invalid color format, must be a valid hex color")
+			return ErrInvalidColorFormat
+		}
+
+		// Normalise case — the unique index is on LOWER(color), so two
+		// rooms posting "#A3D977" and "#a3d977" would otherwise persist
+		// as visually identical but textually different rows. Audit log
+		// and API consumers also expect a single canonical form.
+		upper := strings.ToUpper(*r.Color)
+		r.Color = &upper
+
+		// Reject hex codes that the frontend reserves for status badges
+		// (e.g. Schulhof/Unterwegs/eigener Gruppenraum). A room with such a
+		// color would visually masquerade as a status and defeat the whole
+		// reason this feature exists.
+		if IsReservedRoomColor(*r.Color) {
+			return ErrReservedColor
 		}
 	}
 
 	return nil
+}
+
+// Validate sentinels. Service layer maps these to HTTP statuses; ErrorRenderer
+// renders any of them as 400 (with the German message preferred where one
+// exists for ErrReservedColor).
+var (
+	ErrNameRequired       = errors.New("room name is required")
+	ErrCapacityNegative   = errors.New("capacity cannot be negative")
+	ErrInvalidColorFormat = errors.New("invalid color format, must be a valid hex color")
+	ErrReservedColor      = errors.New("color is reserved for status badges")
+)
+
+// IsValidationError reports whether err is one of the model-level Validate
+// sentinels. Lets the API layer render any validation failure as 400 without
+// having to enumerate each variant.
+func IsValidationError(err error) bool {
+	return errors.Is(err, ErrNameRequired) ||
+		errors.Is(err, ErrCapacityNegative) ||
+		errors.Is(err, ErrInvalidColorFormat) ||
+		errors.Is(err, ErrReservedColor)
 }
 
 // IsAvailable checks if the room is available for a given capacity

--- a/backend/models/facilities/room_colors.go
+++ b/backend/models/facilities/room_colors.go
@@ -1,0 +1,87 @@
+package facilities
+
+import "strings"
+
+// RoomColorUniqueConstraintName is the index name created by migration
+// 1.15.44. Service layer matches it via pgdriver.Error.Field('n') so a
+// generic ErrDuplicateRoom doesn't shadow the more specific
+// ErrColorAlreadyInUse for the colour-conflict path. Migration uses the same
+// name so both ends stay in sync from a single source.
+const RoomColorUniqueConstraintName = "uniq_facilities_rooms_tenant_color"
+
+// reservedRoomColors is the set of hex codes that rooms cannot adopt.
+//
+// Most entries mirror the frontend status palette
+// (frontend/src/lib/location-helper.ts LOCATION_COLORS) — letting a room
+// carry one of those would make its badge visually indistinguishable from a
+// status like "Unterwegs" or "Schulhof".
+//
+// One entry — #4F46E5 — is reserved for a different reason: it was the
+// forced default produced by the rooms.config.tsx transformBeforeSubmit bug,
+// stamped onto every saved room before Issue #1324. Migration 1.15.44 NULLs
+// every row carrying this hex (audit.room_color_migration_backup keeps the
+// originals). Allowing an admin to re-pick the same hex afterwards would
+// recreate the same situation the migration just cleaned up — and would also
+// collide with the backup table's restore semantics ("any row holding
+// #4F46E5 must have come from the bug, never from a deliberate pick").
+// Reserving it keeps that invariant explicit forever.
+//
+// Stored as uppercase #RRGGBB strings; Validate() upper-cases incoming values
+// before lookup so input casing does not matter. Mirrors LOCATION_COLORS in
+// frontend/src/lib/location-helper.ts. The drift test
+// (room_colors_drift_test.go) catches divergence on the status palette half;
+// #4F46E5 is intentionally backend-only and is excluded from that comparison
+// (knownReserved excludes it via the legacyBugDefault constant).
+var reservedRoomColors = map[string]struct{}{
+	"#83CD2D":           {}, // GROUP_ROOM (eigener Gruppenraum, grün)
+	"#5080D8":           {}, // OTHER_ROOM fallback (blau) — also blocked so a room cannot share the default
+	"#FF3130":           {}, // HOME (Zuhause)
+	"#F78C10":           {}, // SCHOOLYARD (Schulhof)
+	"#D946EF":           {}, // TRANSIT (Unterwegs)
+	"#EAB308":           {}, // SICK (Krank)
+	"#7C3AED":           {}, // EXCUSED (Entschuldigt)
+	"#6B7280":           {}, // UNKNOWN / NOT_ARRIVAL (grau)
+	legacyBugDefaultHex: {}, // see migration 1.15.44 / room_colors.go header comment
+}
+
+// legacyBugDefaultHex is the colour the rooms.config.tsx forced-default bug
+// stamped onto every save before Issue #1324. Pinned as a constant so the
+// drift test can exclude it from the cross-codebase comparison without
+// hardcoding the value in two places.
+const legacyBugDefaultHex = "#4F46E5"
+
+// IsReservedRoomColor reports whether color matches one of the status badge
+// colors that rooms are not allowed to claim. The input is normalized to the
+// canonical "#RRGGBB" upper-case form before lookup so "#5080d8", "5080D8"
+// and "#5080D8" are all rejected the same way.
+func IsReservedRoomColor(color string) bool {
+	normalized := normalizeHexForReservedLookup(color)
+	if normalized == "" {
+		return false
+	}
+	_, found := reservedRoomColors[normalized]
+	return found
+}
+
+// normalizeHexForReservedLookup expands #RGB to #RRGGBB and uppercases. Invalid
+// inputs return "" — the caller is expected to have already validated format.
+func normalizeHexForReservedLookup(color string) string {
+	color = strings.ToUpper(strings.TrimSpace(color))
+	if !strings.HasPrefix(color, "#") {
+		color = "#" + color
+	}
+	switch len(color) {
+	case 7: // #RRGGBB
+		return color
+	case 4: // #RGB → expand each nibble
+		var b strings.Builder
+		b.WriteByte('#')
+		for i := 1; i < 4; i++ {
+			b.WriteByte(color[i])
+			b.WriteByte(color[i])
+		}
+		return b.String()
+	default:
+		return ""
+	}
+}

--- a/backend/models/facilities/room_colors.go
+++ b/backend/models/facilities/room_colors.go
@@ -3,7 +3,7 @@ package facilities
 import "strings"
 
 // RoomColorUniqueConstraintName is the index name created by migration
-// 1.15.44. Service layer matches it via pgdriver.Error.Field('n') so a
+// 1.15.45. Service layer matches it via pgdriver.Error.Field('n') so a
 // generic ErrDuplicateRoom doesn't shadow the more specific
 // ErrColorAlreadyInUse for the colour-conflict path. Migration uses the same
 // name so both ends stay in sync from a single source.
@@ -18,7 +18,7 @@ const RoomColorUniqueConstraintName = "uniq_facilities_rooms_tenant_color"
 //
 // One entry — #4F46E5 — is reserved for a different reason: it was the
 // forced default produced by the rooms.config.tsx transformBeforeSubmit bug,
-// stamped onto every saved room before Issue #1324. Migration 1.15.44 NULLs
+// stamped onto every saved room before Issue #1324. Migration 1.15.45 NULLs
 // every row carrying this hex (audit.room_color_migration_backup keeps the
 // originals). Allowing an admin to re-pick the same hex afterwards would
 // recreate the same situation the migration just cleaned up — and would also
@@ -41,7 +41,7 @@ var reservedRoomColors = map[string]struct{}{
 	"#EAB308":           {}, // SICK (Krank)
 	"#7C3AED":           {}, // EXCUSED (Entschuldigt)
 	"#6B7280":           {}, // UNKNOWN / NOT_ARRIVAL (grau)
-	legacyBugDefaultHex: {}, // see migration 1.15.44 / room_colors.go header comment
+	legacyBugDefaultHex: {}, // see migration 1.15.45 / room_colors.go header comment
 }
 
 // legacyBugDefaultHex is the colour the rooms.config.tsx forced-default bug

--- a/backend/models/facilities/room_colors_drift_test.go
+++ b/backend/models/facilities/room_colors_drift_test.go
@@ -154,7 +154,7 @@ func exposedReservedHexes(t *testing.T) map[string]struct{} {
 func TestReservedRoomColors_LegacyBugDefault(t *testing.T) {
 	require.True(t, facilities.IsReservedRoomColor("#4F46E5"),
 		"legacy bug-default #4F46E5 must remain reserved — see "+
-			"migration 1.15.44 / room_colors.go for the rationale")
+			"migration 1.15.45 / room_colors.go for the rationale")
 }
 
 func setDiff(a, b map[string]struct{}) []string {

--- a/backend/models/facilities/room_colors_drift_test.go
+++ b/backend/models/facilities/room_colors_drift_test.go
@@ -1,0 +1,169 @@
+package facilities_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/models/facilities"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReservedRoomColors_MatchesFrontendLOCATION_COLORS guards the most
+// fragile bit of the colour-blocking pipeline: the backend's reservedRoomColors
+// list must stay in lock-step with the frontend's LOCATION_COLORS map. If
+// they drift, an admin can pick a status colour the frontend offers but the
+// backend rejects (or the other way round).
+//
+// The failure mode is silent — no compile error, no obvious runtime issue,
+// just confused users. This test parses the TS source directly so a frontend
+// palette tweak fails CI before merge instead of leaking into prod.
+//
+// We extract the hex values out of LOCATION_COLORS via regex. The TS file is
+// hand-maintained and its layout is stable, so a regex is acceptable here;
+// if the TS shape ever changes, this test will fail loudly and force a sync
+// review.
+func TestReservedRoomColors_MatchesFrontendLOCATION_COLORS(t *testing.T) {
+	frontendPath := findFrontendLocationHelper(t)
+
+	bytes, err := os.ReadFile(frontendPath) // #nosec G304 — path computed inside repo
+	require.NoError(t, err, "could not read %s", frontendPath)
+
+	frontendHexes := extractLocationColorsHexes(t, string(bytes))
+	backendHexes := exposedReservedHexes(t)
+
+	require.NotEmpty(t, frontendHexes,
+		"failed to extract any hex values from frontend LOCATION_COLORS — "+
+			"the regex in this test probably needs updating to match the new layout")
+
+	missingFromBackend := setDiff(frontendHexes, backendHexes)
+	missingFromFrontend := setDiff(backendHexes, frontendHexes)
+
+	if len(missingFromBackend) > 0 || len(missingFromFrontend) > 0 {
+		t.Fatalf(
+			"reservedRoomColors drift detected — keep "+
+				"backend/models/facilities/room_colors.go in sync with "+
+				"frontend/src/lib/location-helper.ts LOCATION_COLORS.\n"+
+				"  Hex codes in frontend but not backend: %v\n"+
+				"  Hex codes in backend but not frontend: %v\n"+
+				"  Frontend file: %s",
+			missingFromBackend, missingFromFrontend, frontendPath,
+		)
+	}
+}
+
+// findFrontendLocationHelper walks up from the package's working directory
+// to the repo root, then down to frontend/src/lib/location-helper.ts. We
+// can't hard-code the relative path because Go test working directory is
+// the package dir, not the repo root, and depth varies depending on which
+// package the test runs from.
+func findFrontendLocationHelper(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		candidate := filepath.Join(dir, "frontend", "src", "lib", "location-helper.ts")
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	t.Fatalf("could not locate frontend/src/lib/location-helper.ts walking up from %s", dir)
+	return ""
+}
+
+// extractLocationColorsHexes pulls every hex literal that appears inside the
+// `export const LOCATION_COLORS = { ... } as const;` block. We deliberately
+// scope the search to that block so unrelated hex literals elsewhere in the
+// file (e.g. GROUP_ROOM_SHADES) don't pollute the comparison set.
+func extractLocationColorsHexes(t *testing.T, source string) map[string]struct{} {
+	t.Helper()
+
+	startMarker := "export const LOCATION_COLORS"
+	startIdx := strings.Index(source, startMarker)
+	require.NotEqual(t, -1, startIdx,
+		"could not find LOCATION_COLORS export — frontend file structure changed")
+
+	// Block ends at the matching closing brace of the object literal.
+	closeIdx := strings.Index(source[startIdx:], "} as const")
+	require.NotEqual(t, -1, closeIdx,
+		"could not find end of LOCATION_COLORS block — frontend file structure changed")
+	block := source[startIdx : startIdx+closeIdx]
+
+	hexPattern := regexp.MustCompile(`"(#[0-9A-Fa-f]{3,6})"`)
+	matches := hexPattern.FindAllStringSubmatch(block, -1)
+
+	out := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		out[strings.ToUpper(m[1])] = struct{}{}
+	}
+	return out
+}
+
+// exposedReservedHexes mirrors what reservedRoomColors holds, EXCLUDING
+// entries that are intentionally backend-only (e.g. the legacy bug-default
+// #4F46E5, reserved for migration-restore-correctness reasons rather than
+// because it's a frontend status badge). The drift test only cares about
+// cross-codebase agreement on the palette half — backend-only entries are
+// asserted separately below.
+//
+// We probe via IsReservedRoomColor against a candidate set — that's the
+// public contract, so testing through it avoids reaching into unexported
+// state.
+func exposedReservedHexes(t *testing.T) map[string]struct{} {
+	t.Helper()
+
+	// Hard-coded mirror of the palette half of reservedRoomColors. Backend-
+	// only entries (legacy bug-default) live in a separate assertion below.
+	knownReserved := []string{
+		"#83CD2D",
+		"#5080D8",
+		"#FF3130",
+		"#F78C10",
+		"#D946EF",
+		"#EAB308",
+		"#7C3AED",
+		"#6B7280",
+	}
+
+	out := make(map[string]struct{}, len(knownReserved))
+	for _, hex := range knownReserved {
+		require.True(t, facilities.IsReservedRoomColor(hex),
+			"backend room_colors.go knownReserved is out of sync with "+
+				"reservedRoomColors map: %s should be reserved but isn't",
+			hex)
+		out[strings.ToUpper(hex)] = struct{}{}
+	}
+	return out
+}
+
+// TestReservedRoomColors_LegacyBugDefault pins the backend-only entry that
+// the drift test deliberately excludes. Tests intent rather than mechanics:
+// even if someone refactors the palette half, this assertion stays put and
+// keeps #4F46E5 reserved.
+func TestReservedRoomColors_LegacyBugDefault(t *testing.T) {
+	require.True(t, facilities.IsReservedRoomColor("#4F46E5"),
+		"legacy bug-default #4F46E5 must remain reserved — see "+
+			"migration 1.15.44 / room_colors.go for the rationale")
+}
+
+func setDiff(a, b map[string]struct{}) []string {
+	out := make([]string, 0)
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/backend/models/facilities/room_colors_test.go
+++ b/backend/models/facilities/room_colors_test.go
@@ -54,7 +54,7 @@ func TestIsReservedRoomColor(t *testing.T) {
 
 	t.Run("allows arbitrary non-status colors", func(t *testing.T) {
 		// #4F46E5 used to live in this list as "non-reserved". It now sits
-		// in the reserved set on purpose — see migration 1.15.44 / the
+		// in the reserved set on purpose — see migration 1.15.45 / the
 		// header comment in room_colors.go for why allowing admins to
 		// re-pick the legacy bug-default would defeat the migration's
 		// invariant. The test below asserts it's reserved.
@@ -68,7 +68,7 @@ func TestIsReservedRoomColor(t *testing.T) {
 	})
 
 	t.Run("rejects legacy bug-default #4F46E5", func(t *testing.T) {
-		// Migration 1.15.44 NULLs every row carrying this hex; the audit
+		// Migration 1.15.45 NULLs every row carrying this hex; the audit
 		// backup table relies on "any #4F46E5 row in facilities.rooms
 		// must have come from the bug" as a restore invariant. Letting an
 		// admin pick the same hex afterwards would break that. Both

--- a/backend/models/facilities/room_colors_test.go
+++ b/backend/models/facilities/room_colors_test.go
@@ -143,6 +143,40 @@ func TestRoomValidate_ReservedColor(t *testing.T) {
 		assert.True(t, errors.Is(err, facilities.ErrReservedColor))
 	})
 
+	t.Run("expands #RGB shorthand to #RRGGBB before storing", func(t *testing.T) {
+		// The unique index is on LOWER(color); without expansion, "#ABC"
+		// and "#AABBCC" persist as textually different rows even though
+		// they render the same CSS color. Native picker always emits 6
+		// digits, but a direct API call could send either form.
+		room := &facilities.Room{
+			Name:  "Shorthand",
+			Color: strPtr("#abc"),
+		}
+		require.NoError(t, room.Validate())
+		require.NotNil(t, room.Color)
+		assert.Equal(t, "#AABBCC", *room.Color)
+	})
+
+	t.Run("expands shorthand even when '#' prefix is missing", func(t *testing.T) {
+		// Validate() prepends "#" before regex-matching, so a bare "abc"
+		// must travel the same canonicalisation path as "#abc": prefix →
+		// expand to 6 digits → uppercase. This pins the storage form so
+		// the unique index on LOWER(color) cannot be sidestepped by
+		// posting the shorthand without a leading hash. None of the
+		// current reserved hexes are repeating-pair palindromes (e.g.
+		// #AABBCC), so we cannot also assert reserved-rejection on a
+		// shorthand input — that path is covered indirectly: expansion
+		// runs before IsReservedRoomColor, so any future reserved hex of
+		// that shape would trip the reserved check after expansion.
+		room := &facilities.Room{
+			Name:  "Shorthand prefix",
+			Color: strPtr("abc"), // missing # → adds # → expands → uppercases
+		}
+		require.NoError(t, room.Validate())
+		require.NotNil(t, room.Color)
+		assert.Equal(t, "#AABBCC", *room.Color)
+	})
+
 	t.Run("normalises mixed-case input to upper-case", func(t *testing.T) {
 		// The unique index lives on LOWER(color), so storage casing doesn't
 		// affect dedup — but audit log + API consumers expect a single

--- a/backend/models/facilities/room_colors_test.go
+++ b/backend/models/facilities/room_colors_test.go
@@ -1,0 +1,160 @@
+package facilities_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/models/facilities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestIsReservedRoomColor(t *testing.T) {
+	t.Run("rejects every status badge color", func(t *testing.T) {
+		// Mirrors LOCATION_COLORS in frontend/src/lib/location-helper.ts.
+		// If the frontend list grows, the backend list must too — this test
+		// won't catch that drift, but the cross-codebase reference comment
+		// in room_colors.go points reviewers at it.
+		reserved := []string{
+			"#83CD2D", // GROUP_ROOM
+			"#5080D8", // OTHER_ROOM (the blue we're trying to escape)
+			"#FF3130", // HOME
+			"#F78C10", // SCHOOLYARD
+			"#D946EF", // TRANSIT
+			"#EAB308", // SICK
+			"#7C3AED", // EXCUSED
+			"#6B7280", // UNKNOWN / NOT_ARRIVAL
+		}
+		for _, c := range reserved {
+			assert.True(t, facilities.IsReservedRoomColor(c),
+				"expected %s to be reserved", c)
+		}
+	})
+
+	t.Run("normalizes case and whitespace", func(t *testing.T) {
+		// User-supplied input could land in any of these shapes; all must hit.
+		variants := []string{"#5080d8", " #5080D8 ", "5080D8", "5080d8"}
+		for _, v := range variants {
+			assert.True(t, facilities.IsReservedRoomColor(v),
+				"variant %q should be reserved", v)
+		}
+	})
+
+	t.Run("expands #RGB shorthand", func(t *testing.T) {
+		// #6B7280 is reserved as #6B7280; test a known shorthand collapse to
+		// confirm the expansion path works at all.
+		assert.False(t, facilities.IsReservedRoomColor("#FFF"),
+			"#FFF expands to #FFFFFF which is not reserved")
+		// Build a 3-char that expands to a reserved 6-char: there is no exact
+		// 3→6 collision in the list (e.g. #837 → #883377 ≠ any reserved), so
+		// we just sanity-check the helper returns false for non-matches.
+	})
+
+	t.Run("allows arbitrary non-status colors", func(t *testing.T) {
+		// #4F46E5 used to live in this list as "non-reserved". It now sits
+		// in the reserved set on purpose — see migration 1.15.44 / the
+		// header comment in room_colors.go for why allowing admins to
+		// re-pick the legacy bug-default would defeat the migration's
+		// invariant. The test below asserts it's reserved.
+		nonReserved := []string{
+			"#A3D977", "#FFD580", "#1ABC9C", "#000000", "#FFFFFF",
+		}
+		for _, c := range nonReserved {
+			assert.False(t, facilities.IsReservedRoomColor(c),
+				"%s should not be reserved", c)
+		}
+	})
+
+	t.Run("rejects legacy bug-default #4F46E5", func(t *testing.T) {
+		// Migration 1.15.44 NULLs every row carrying this hex; the audit
+		// backup table relies on "any #4F46E5 row in facilities.rooms
+		// must have come from the bug" as a restore invariant. Letting an
+		// admin pick the same hex afterwards would break that. Both
+		// upper- and lower-case must be rejected since the picker emits
+		// uppercase but a direct API call could send either.
+		assert.True(t, facilities.IsReservedRoomColor("#4F46E5"))
+		assert.True(t, facilities.IsReservedRoomColor("#4f46e5"))
+	})
+
+	t.Run("handles empty and malformed input gracefully", func(t *testing.T) {
+		assert.False(t, facilities.IsReservedRoomColor(""))
+		assert.False(t, facilities.IsReservedRoomColor("#"))
+		assert.False(t, facilities.IsReservedRoomColor("not-a-color"))
+		assert.False(t, facilities.IsReservedRoomColor("#GGGGGG"))
+	})
+}
+
+func TestRoomValidate_ReservedColor(t *testing.T) {
+	t.Run("rejects a reserved color", func(t *testing.T) {
+		room := &facilities.Room{
+			Name:  "Reserved Color Room",
+			Color: strPtr("#5080D8"),
+		}
+		err := room.Validate()
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, facilities.ErrReservedColor),
+			"expected ErrReservedColor, got %v", err)
+		assert.True(t, facilities.IsValidationError(err),
+			"reserved-color error should report as validation error")
+	})
+
+	t.Run("allows a non-reserved hex", func(t *testing.T) {
+		room := &facilities.Room{
+			Name:  "Custom Color Room",
+			Color: strPtr("#A3D977"),
+		}
+		require.NoError(t, room.Validate())
+	})
+
+	t.Run("allows nil color (default fallback to blue)", func(t *testing.T) {
+		room := &facilities.Room{Name: "No Color"}
+		require.NoError(t, room.Validate())
+	})
+
+	t.Run("rejects malformed hex with sentinel", func(t *testing.T) {
+		room := &facilities.Room{
+			Name:  "Bad Color",
+			Color: strPtr("not-hex"),
+		}
+		err := room.Validate()
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, facilities.ErrInvalidColorFormat))
+	})
+
+	t.Run("auto-prefixes # before validation", func(t *testing.T) {
+		room := &facilities.Room{
+			Name:  "Prefixed",
+			Color: strPtr("A3D977"),
+		}
+		require.NoError(t, room.Validate())
+		require.NotNil(t, room.Color)
+		assert.Equal(t, "#A3D977", *room.Color)
+	})
+
+	t.Run("auto-prefix into reserved color is still rejected", func(t *testing.T) {
+		room := &facilities.Room{
+			Name:  "Sneaky",
+			Color: strPtr("5080D8"), // missing # → adds # → matches reserved
+		}
+		err := room.Validate()
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, facilities.ErrReservedColor))
+	})
+
+	t.Run("normalises mixed-case input to upper-case", func(t *testing.T) {
+		// The unique index lives on LOWER(color), so storage casing doesn't
+		// affect dedup — but audit log + API consumers expect a single
+		// canonical form. Without normalisation, "#a3d977" and "#A3D977"
+		// flow through as-is and the API answers two visually-identical
+		// rooms with different colour strings.
+		room := &facilities.Room{
+			Name:  "Mixed Case",
+			Color: strPtr("#a3D977"),
+		}
+		require.NoError(t, room.Validate())
+		require.NotNil(t, room.Color)
+		assert.Equal(t, "#A3D977", *room.Color)
+	})
+}

--- a/backend/services/facilities/errors.go
+++ b/backend/services/facilities/errors.go
@@ -16,6 +16,8 @@ var (
 	ErrCategoryNotFound     = errors.New("category not found")
 	ErrRoomInUse            = errors.New("Raum kann nicht gelöscht werden: Raum wird aktuell von einer aktiven Gruppe verwendet") //nolint:staticcheck // ST1005: user-facing German message
 	ErrSystemRoomProtected  = errors.New("Systemraum kann nicht gelöscht oder umbenannt werden")                                  //nolint:staticcheck // ST1005: user-facing German message
+	ErrColorAlreadyInUse    = errors.New("Diese Farbe ist bereits einem anderen Raum zugeordnet")                                 //nolint:staticcheck // ST1005: user-facing German message
+	ErrColorReserved        = errors.New("Diese Farbe ist für Statusbadges reserviert und kann nicht für Räume verwendet werden") //nolint:staticcheck // ST1005: user-facing German message
 )
 
 // FacilitiesError represents a facilities-related error

--- a/backend/services/facilities/facility_service.go
+++ b/backend/services/facilities/facility_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/facilities"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/driver/pgdriver"
 )
 
 // Operation name constants to avoid string duplication
@@ -135,7 +136,7 @@ func (s *service) GetRoomWithOccupancy(ctx context.Context, id int64) (RoomWithO
 func (s *service) CreateRoom(ctx context.Context, room *facilities.Room) error {
 	// Validate room data
 	if err := room.Validate(); err != nil {
-		return &FacilitiesError{Op: opCreateRoom, Err: err}
+		return &FacilitiesError{Op: opCreateRoom, Err: translateValidationError(err)}
 	}
 
 	// Set tenant ID from context
@@ -151,17 +152,66 @@ func (s *service) CreateRoom(ctx context.Context, room *facilities.Room) error {
 
 	// Create the room
 	if err := s.roomRepo.Create(ctx, room); err != nil {
+		if isUniqueColorViolation(err) {
+			return &FacilitiesError{Op: opCreateRoom, Err: ErrColorAlreadyInUse}
+		}
 		return &FacilitiesError{Op: opCreateRoom, Err: err}
 	}
 
 	return nil
 }
 
+// translateValidationError maps Validate() sentinels to the service-level
+// errors that the API layer can render with the correct HTTP status. Any
+// other validation error is forwarded unchanged so the existing
+// ErrorInvalidRequest path renders 400.
+func translateValidationError(err error) error {
+	if errors.Is(err, facilities.ErrReservedColor) {
+		return ErrColorReserved
+	}
+	return err
+}
+
+// isUniqueColorViolation reports whether err is a PostgreSQL 23505 raised by
+// the partial unique index on facilities.rooms (tenant_id, lower(color)). The
+// constraint name is checked so other future unique indexes on the table do
+// not accidentally surface as "color already in use" toasts.
+func isUniqueColorViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var dbErr *base.DatabaseError
+	if errors.As(err, &dbErr) {
+		err = dbErr.Err
+	}
+	var pgErr pgdriver.Error
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	if pgErr.Field('C') != "23505" {
+		return false
+	}
+	return pgErr.Field('n') == facilities.RoomColorUniqueConstraintName
+}
+
+// equalStringPtr compares two *string for equality treating nil as "no value"
+// — used to detect "color actually changed" without false-positives from the
+// nil/empty distinction.
+func equalStringPtr(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
 // UpdateRoom updates an existing room
 func (s *service) UpdateRoom(ctx context.Context, room *facilities.Room) error {
 	// Validate room data
 	if err := room.Validate(); err != nil {
-		return &FacilitiesError{Op: opUpdateRoom, Err: err}
+		return &FacilitiesError{Op: opUpdateRoom, Err: translateValidationError(err)}
 	}
 
 	// Check if room exists
@@ -175,6 +225,44 @@ func (s *service) UpdateRoom(ctx context.Context, room *facilities.Room) error {
 		return &FacilitiesError{Op: opUpdateRoom, Err: ErrSystemRoomProtected}
 	}
 
+	// System-room color handling.
+	//
+	// The frontend strips the color picker for Schulhof/WC, so a benign edit
+	// (e.g. changing capacity) arrives with room.Color == nil regardless of
+	// what's persisted. If we treated nil as "user wants to clear", every
+	// non-color edit on a Schulhof that still carries the legacy #4F46E5
+	// bug-default would 403 — the migration covers most cases but not all
+	// (e.g. a tenant that hasn't run migrations yet, or a system room
+	// imported with a colour later).
+	//
+	// Strategy: treat a nil incoming colour as "request did not touch the
+	// colour field" and silently preserve the existing value. Only block
+	// when the request explicitly sets a different non-nil colour — that's
+	// the path a malicious or buggy direct API call would take, and the one
+	// the rule actually exists to stop.
+	//
+	// Side-effect of this strategy: a system room cannot have its colour
+	// *cleared* via the API. If a Schulhof somehow carries a stale colour
+	// (legacy bug-default that escaped migration cleanup, or an imported
+	// dataset), the only way to drop it is direct SQL. Acceptable trade-off
+	// — system rooms shouldn't have admin-set colours anyway, and the
+	// alternative is admins losing the ability to edit any other field.
+	//
+	// Why both `room.Color != nil` AND equalStringPtr?
+	//   - Inline `*room.Color != *existingRoom.Color` would NPE when the
+	//     existing colour is nil and the request sets a new one (case A).
+	//   - Dropping the outer guard would re-block benign updates whose
+	//     incoming colour is nil but existing is non-nil (the very bug
+	//     this comment block exists to fix).
+	// Both checks together give: "block only when the request explicitly
+	// names a different non-nil colour, ignore colour-field absence".
+	if constants.IsSystemRoomName(existingRoom.Name) {
+		if room.Color != nil && !equalStringPtr(room.Color, existingRoom.Color) {
+			return &FacilitiesError{Op: opUpdateRoom, Err: ErrSystemRoomProtected}
+		}
+		room.Color = existingRoom.Color
+	}
+
 	// If name is changing, check for duplicates
 	if existingRoom.Name != room.Name {
 		existing, err := s.roomRepo.FindByName(ctx, room.Name)
@@ -185,6 +273,9 @@ func (s *service) UpdateRoom(ctx context.Context, room *facilities.Room) error {
 
 	// Update the room
 	if err := s.roomRepo.Update(ctx, room); err != nil {
+		if isUniqueColorViolation(err) {
+			return &FacilitiesError{Op: opUpdateRoom, Err: ErrColorAlreadyInUse}
+		}
 		return &FacilitiesError{Op: opUpdateRoom, Err: err}
 	}
 

--- a/backend/services/facilities/facility_service_color_test.go
+++ b/backend/services/facilities/facility_service_color_test.go
@@ -85,7 +85,7 @@ func TestFacilitiesService_CreateRoom_AcceptsCustomColor(t *testing.T) {
 }
 
 // TestFacilitiesService_UpdateRoom_RejectsDuplicateColor exercises the partial
-// unique index from migration 1.15.44. Two rooms in the same school cannot
+// unique index from migration 1.15.45. Two rooms in the same school cannot
 // share a color; the service translates the 23505 to ErrColorAlreadyInUse so
 // the frontend toast can surface the German message instead of a 500.
 func TestFacilitiesService_UpdateRoom_RejectsDuplicateColor(t *testing.T) {

--- a/backend/services/facilities/facility_service_color_test.go
+++ b/backend/services/facilities/facility_service_color_test.go
@@ -1,0 +1,261 @@
+package facilities_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/facilities"
+	facilitiesSvc "github.com/moto-nrw/project-phoenix/services/facilities"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// uniqueRoomName is duplicated here (instead of imported) so the color suite
+// stays independent of the existing facility_service_test.go ordering. Random
+// enough to avoid colliding inside the same test run.
+func uniqueRoomName(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+// TestFacilitiesService_CreateRoom_RejectsReservedColor confirms that a hex
+// claimed by the frontend status palette gets rejected before the row is
+// written. Mirrors the user-facing behaviour: form pickers offering, e.g.,
+// the SCHOOLYARD orange should fail with the German message even if a sneaky
+// caller bypasses the picker and posts the hex directly.
+func TestFacilitiesService_CreateRoom_RejectsReservedColor(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupFacilitiesService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	cases := []struct {
+		label    string
+		hex      string
+		expected error
+	}{
+		{"OTHER_ROOM blue", "#5080D8", facilitiesSvc.ErrColorReserved},
+		{"SCHOOLYARD orange", "#F78C10", facilitiesSvc.ErrColorReserved},
+		{"TRANSIT magenta", "#D946EF", facilitiesSvc.ErrColorReserved},
+		{"GROUP_ROOM green", "#83CD2D", facilitiesSvc.ErrColorReserved},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			color := tc.hex
+			room := &facilities.Room{
+				Name:  uniqueRoomName("Reserved"),
+				Color: &color,
+			}
+
+			err := service.CreateRoom(ctx, room)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, tc.expected),
+				"expected ErrColorReserved, got %v", err)
+		})
+	}
+}
+
+// TestFacilitiesService_CreateRoom_AcceptsCustomColor sanity-checks the happy
+// path: a color that is neither reserved nor in use gets persisted as-is.
+func TestFacilitiesService_CreateRoom_AcceptsCustomColor(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupFacilitiesService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	color := "#A3D977"
+	room := &facilities.Room{
+		Name:  uniqueRoomName("CustomColor"),
+		Color: &color,
+	}
+
+	err := service.CreateRoom(ctx, room)
+	require.NoError(t, err)
+	defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+
+	retrieved, err := service.GetRoom(ctx, room.ID)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved.Color)
+	assert.Equal(t, "#A3D977", *retrieved.Color)
+}
+
+// TestFacilitiesService_UpdateRoom_RejectsDuplicateColor exercises the partial
+// unique index from migration 1.15.44. Two rooms in the same school cannot
+// share a color; the service translates the 23505 to ErrColorAlreadyInUse so
+// the frontend toast can surface the German message instead of a 500.
+func TestFacilitiesService_UpdateRoom_RejectsDuplicateColor(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupFacilitiesService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	// ARRANGE — Room A claims the color first.
+	colorA := "#A3D977"
+	roomA := &facilities.Room{Name: uniqueRoomName("RoomA"), Color: &colorA}
+	require.NoError(t, service.CreateRoom(ctx, roomA))
+	defer testpkg.CleanupActivityFixtures(t, db, roomA.ID)
+
+	// Second room created without color (so the create succeeds)
+	roomB := &facilities.Room{Name: uniqueRoomName("RoomB")}
+	require.NoError(t, service.CreateRoom(ctx, roomB))
+	defer testpkg.CleanupActivityFixtures(t, db, roomB.ID)
+
+	// ACT — try to update Room B to the same color as Room A.
+	colorBAttempt := colorA
+	roomB.Color = &colorBAttempt
+	err := service.UpdateRoom(ctx, roomB)
+
+	// ASSERT — surface the German conflict, not a raw DB error.
+	require.Error(t, err)
+	require.True(t, errors.Is(err, facilitiesSvc.ErrColorAlreadyInUse),
+		"expected ErrColorAlreadyInUse, got %v", err)
+}
+
+// TestFacilitiesService_UpdateRoom_BlocksColorOnSystemRooms catches a
+// specific regression: someone removes the system-room color check and
+// "Schulhof" silently gets a yellow badge — confusing the whole UI because
+// Schulhof has a semantically fixed status badge color, not a per-room one.
+//
+// We use createRoomWithExactName to produce an actual "Schulhof" record
+// (constants.IsSystemRoomName matches by exact name); CreateTestRoom would
+// suffix a timestamp and dodge the check.
+func TestFacilitiesService_UpdateRoom_BlocksColorOnSystemRooms(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupFacilitiesService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("rejects color change on Schulhof", func(t *testing.T) {
+		room := createRoomWithExactName(t, db, "Schulhof")
+		defer cleanupRoom(t, db, room.ID)
+
+		// Try to add a color to a system room — should be blocked.
+		newColor := "#A3D977"
+		room.Color = &newColor
+		err := service.UpdateRoom(ctx, room)
+
+		require.Error(t, err)
+		require.True(t, errors.Is(err, facilitiesSvc.ErrSystemRoomProtected),
+			"expected ErrSystemRoomProtected, got %v", err)
+	})
+
+	t.Run("rejects color change on WC", func(t *testing.T) {
+		room := createRoomWithExactName(t, db, "WC")
+		defer cleanupRoom(t, db, room.ID)
+
+		newColor := "#A3D977"
+		room.Color = &newColor
+		err := service.UpdateRoom(ctx, room)
+
+		require.Error(t, err)
+		require.True(t, errors.Is(err, facilitiesSvc.ErrSystemRoomProtected))
+	})
+
+	t.Run("allows benign updates that do not touch color", func(t *testing.T) {
+		// Regression guard: the system-room block must trigger on the *color
+		// field*, not on every system-room update. Editing Capacity must
+		// still succeed, otherwise admins lose the ability to change any
+		// non-name field on Schulhof.
+		room := createRoomWithExactName(t, db, "Schulhof")
+		defer cleanupRoom(t, db, room.ID)
+
+		newCapacity := 200
+		room.Capacity = &newCapacity
+		// Color stays nil — no change in the protected field.
+		require.NoError(t, service.UpdateRoom(ctx, room))
+	})
+
+	t.Run("allows clearing a non-existent color (no-op)", func(t *testing.T) {
+		// If a system room somehow had Color=nil already, sending nil again
+		// should not be flagged as a change. equalStringPtr handles this —
+		// without it, every update on a colorless system room would 403.
+		room := createRoomWithExactName(t, db, "Schulhof")
+		defer cleanupRoom(t, db, room.ID)
+
+		room.Color = nil // unchanged
+		room.Building = "Updated"
+		require.NoError(t, service.UpdateRoom(ctx, room))
+	})
+
+	t.Run("benign update on a system room with leftover legacy color succeeds", func(t *testing.T) {
+		// Reproduces the review-flagged #2 regression: production Schulhof
+		// rows almost certainly carried "#4F46E5" from the rooms.config bug.
+		// The frontend strips the color picker for system rooms, so a
+		// capacity-only update sends room.Color = nil. Earlier code treated
+		// nil ≠ &"#4F46E5" as a forbidden colour change and 403'd every such
+		// edit. Now the service preserves the existing colour for system
+		// rooms when the request omits it.
+		room := createRoomWithExactName(t, db, "Schulhof")
+		defer cleanupRoom(t, db, room.ID)
+
+		// Bypass Validate() (would reject the reserved colour) by writing
+		// the legacy hex directly with a raw UPDATE — this matches what a
+		// pre-migration production DB looks like.
+		legacy := "#4F46E5"
+		_, err := db.NewUpdate().
+			TableExpr("facilities.rooms").
+			Set("color = ?", legacy).
+			Where("id = ?", room.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		// Reload to mirror what the handler does (FindByID then mutate).
+		fresh, err := service.GetRoom(ctx, room.ID)
+		require.NoError(t, err)
+		require.NotNil(t, fresh.Color)
+		require.Equal(t, "#4F46E5", *fresh.Color)
+
+		// Frontend strips the color field → request body has no colour →
+		// handler sets room.Color = nil. Capacity bumps must still go
+		// through.
+		fresh.Color = nil
+		newCap := 250
+		fresh.Capacity = &newCap
+
+		require.NoError(t, service.UpdateRoom(ctx, fresh),
+			"benign capacity update on Schulhof must succeed even when the "+
+				"row carries a legacy color and the request omits the field")
+
+		// Existing colour should be preserved (defensive: confirms we
+		// silently kept the legacy value rather than nulling it).
+		retrieved, err := service.GetRoom(ctx, room.ID)
+		require.NoError(t, err)
+		require.NotNil(t, retrieved.Color)
+		assert.Equal(t, "#4F46E5", *retrieved.Color)
+		assert.Equal(t, 250, *retrieved.Capacity)
+	})
+}
+
+// TestFacilitiesService_UpdateRoom_AllowsClearingColor confirms a room can
+// drop its color back to NULL even after a custom one was set. The partial
+// unique index ignores NULLs, so multiple rooms can hold "no color" — the
+// blue fallback in the badge renderer covers them.
+func TestFacilitiesService_UpdateRoom_AllowsClearingColor(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupFacilitiesService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	// ARRANGE — start with a custom color
+	color := "#1ABC9C"
+	room := &facilities.Room{Name: uniqueRoomName("ClearColor"), Color: &color}
+	require.NoError(t, service.CreateRoom(ctx, room))
+	defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+
+	// ACT — clear to nil (frontend's "Zurücksetzen" button)
+	room.Color = nil
+	require.NoError(t, service.UpdateRoom(ctx, room))
+
+	// ASSERT — DB shows null
+	retrieved, err := service.GetRoom(ctx, room.ID)
+	require.NoError(t, err)
+	assert.Nil(t, retrieved.Color, "color should be cleared after update")
+}

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -74,6 +74,8 @@ interface ActiveRoom {
   name: string;
   room_name?: string;
   room_id?: string;
+  /** Hex color of the room when set; drives the per-room badge color in LocationBadge. */
+  room_color?: string;
   student_count?: number;
   supervisor_name?: string;
   students?: StudentWithVisit[];
@@ -104,7 +106,7 @@ interface BFFDashboardResponse {
     id: string;
     name: string;
     room_id?: string;
-    room?: { id: string; name: string };
+    room?: { id: string; name: string; color?: string | null };
   }>;
   unclaimedGroups: Array<{
     id: string;
@@ -412,6 +414,7 @@ function MeinRaumPageContent() {
       roomId: string,
       roomName?: string,
       groupNameToId?: Map<string, string>,
+      roomColor?: string | null,
     ): Promise<StudentWithVisit[]> => {
       try {
         // Use bulk endpoint to fetch visits with display data for specific room
@@ -442,6 +445,7 @@ function MeinRaumPageContent() {
             second_name: lastName,
             school_class: visit.schoolClass ?? "",
             current_location: location,
+            current_room_color: roomColor ?? null,
             group_name: visit.groupName,
             group_id: groupId, // Add group_id for permission checking
             sick: visit.sick,
@@ -723,6 +727,7 @@ function MeinRaumPageContent() {
         name: group.name,
         room_name: group.room?.name,
         room_id: group.room_id,
+        room_color: group.room?.color ?? undefined,
         student_count: undefined,
         supervisor_name: undefined,
       }))
@@ -778,6 +783,7 @@ function MeinRaumPageContent() {
               second_name: lastName,
               school_class: visit.schoolClass ?? "",
               current_location: location,
+              current_room_color: firstRoom.room_color ?? null,
               group_name: visit.groupName,
               group_id: groupId,
               sick: visit.sick,
@@ -937,6 +943,7 @@ function MeinRaumPageContent() {
           second_name: lastName,
           school_class: visit.schoolClass ?? "",
           current_location: location,
+          current_room_color: currentRoom?.room_color ?? null,
           group_name: visit.groupName,
           group_id: groupId,
           sick: visit.sick,
@@ -1142,6 +1149,7 @@ function MeinRaumPageContent() {
         selectedRoom.id,
         selectedRoom.room_name,
         groupNameToIdMapRef.current,
+        selectedRoom.room_color,
       );
 
       // Set students state

--- a/frontend/src/app/[tenant]/(protected)/database/rooms/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/rooms/page.test.tsx
@@ -34,6 +34,9 @@ vi.mock("~/lib/swr", () => ({
   useSWRAuth: vi.fn(),
   mutate: vi.fn(),
   useTenantMutate: vi.fn(() => vi.fn()),
+  // Added with Issue #1324 — page invalidates badge consumer caches after a
+  // room save. Pure setup mock; no test asserts the matcher contents.
+  useTenantMutateMatching: vi.fn(() => vi.fn()),
 }));
 
 const mockGetOne = vi.fn();

--- a/frontend/src/app/[tenant]/(protected)/database/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/rooms/page.tsx
@@ -27,7 +27,12 @@ import { useIsMobile } from "~/hooks/useIsMobile";
 import { useDeleteConfirmation } from "~/hooks/useDeleteConfirmation";
 import { useUpdateUrlParams } from "~/hooks/useUpdateUrlParams";
 import { createLogger } from "~/lib/logger";
-import { useSWRAuth, useTenantMutate } from "~/lib/swr";
+import {
+  useSWRAuth,
+  useTenantMutate,
+  useTenantMutateMatching,
+} from "~/lib/swr";
+import { ROOM_DERIVED_CACHE_KEY_FRAGMENTS } from "~/lib/swr/room-derived-caches";
 
 const logger = createLogger({ component: "DatabaseRoomsPage" });
 
@@ -77,6 +82,15 @@ export default function RoomsPage() {
 
   const service = useMemo(() => createCrudService(roomsConfig), []);
   const tenantMutate = useTenantMutate();
+  // Other pages stamp room data (colour, name) into their cached student/
+  // visit rows, so a Room save has to invalidate them too — otherwise the
+  // badge colours stay stale until the user navigates away and back. The
+  // list of affected cache substrings lives in lib/swr/room-derived-caches.ts
+  // as a single source of truth — keep it there, not inline here, so future
+  // SWR consumers see the doc comment when they touch the file.
+  const refreshRoomConsumers = useTenantMutateMatching(
+    ROOM_DERIVED_CACHE_KEY_FRAGMENTS,
+  );
 
   const {
     data: roomsData,
@@ -249,7 +263,12 @@ export default function RoomsPage() {
             selectedRoom.name,
           ),
         );
-        await tenantMutate("database-rooms-list");
+        await Promise.all([
+          tenantMutate("database-rooms-list"),
+          // Refetch every consumer that holds room-stamped data so badges
+          // pick up the new color without a manual reload.
+          refreshRoomConsumers(),
+        ]);
       } catch (updateError) {
         logger.error("failed to update room", {
           room_id: selectedRoom.id,
@@ -261,7 +280,7 @@ export default function RoomsPage() {
         throw updateError;
       }
     },
-    [selectedRoom, service, tenantMutate, toastSuccess],
+    [selectedRoom, service, tenantMutate, refreshRoomConsumers, toastSuccess],
   );
 
   const handleDeleteRoom = useCallback(async () => {

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -235,9 +235,22 @@ vi.mock("@/components/ui/location-badge", () => ({
 }));
 
 // Mock StudentPresenceBadge — page-level wrapper that picks Location vs
-// PresenceBadge based on tenant presence mode.
+// PresenceBadge based on tenant presence mode. Exposes `current_room_color`
+// from the student prop as a data attribute so we can assert the BFF→state
+// pipeline doesn't drop the per-room color (regression guard for #1324).
 vi.mock("@/components/ui/student-presence-badge", () => ({
-  StudentPresenceBadge: () => <div data-testid="location-badge">Presence</div>,
+  StudentPresenceBadge: ({
+    student,
+  }: {
+    student?: { current_room_color?: string | null };
+  }) => (
+    <div
+      data-testid="location-badge"
+      data-room-color={student?.current_room_color ?? ""}
+    >
+      Presence
+    </div>
+  ),
 }));
 
 // Mock EmptyStudentResults
@@ -245,19 +258,23 @@ vi.mock("~/components/ui/empty-student-results", () => ({
   EmptyStudentResults: () => <div data-testid="empty-results">No results</div>,
 }));
 
-// Mock StudentCard — renders extraContent to exercise urgency icon rendering
+// Mock StudentCard — renders extraContent and locationBadge so tests can
+// assert downstream presence-badge props (e.g. current_room_color forwarding).
 vi.mock("~/components/students/student-card", () => ({
   StudentCard: ({
     firstName,
     lastName,
     extraContent,
+    locationBadge,
   }: {
     firstName: string;
     lastName: string;
     extraContent?: React.ReactNode;
+    locationBadge?: React.ReactNode;
   }) => (
     <div data-testid="student-card">
       {firstName} {lastName}
+      {locationBadge}
       {extraContent && <div data-testid="extra-content">{extraContent}</div>}
     </div>
   ),
@@ -1163,6 +1180,49 @@ describe("OGSGroupPage", () => {
       expect(screen.getByTestId("student-card")).toBeInTheDocument();
       // Student name should render from first_name + last_name mapping
       expect(screen.getByText(/Max Mustermann/)).toBeInTheDocument();
+    });
+  });
+
+  it("forwards current_room_color from BFF dashboard data to the badge", async () => {
+    // Regression guard: the dashboard-data → local-state mapping previously
+    // dropped current_room_color, so navigating away and back into a group
+    // reverted custom room badges to the OTHER_ROOM blue fallback.
+    vi.mocked(useSWRAuth).mockReturnValue({
+      data: {
+        groups: [
+          {
+            id: 1,
+            name: "OGS A",
+            room_id: 10,
+            room: { id: 10, name: "Raum 101" },
+          },
+        ],
+        students: [
+          {
+            id: 1,
+            first_name: "Max",
+            last_name: "Mustermann",
+            school_class: "1a",
+            current_location: "Anwesend - Raum 101",
+            current_room_color: "#A3D977",
+          },
+        ],
+        roomStatus: null,
+        substitutions: [],
+        pickupTimes: [],
+        firstGroupId: "1",
+      },
+      isLoading: false,
+      error: null,
+      mutate: mockMutate,
+      isValidating: false,
+    } as never);
+
+    render(<OGSGroupPage />);
+
+    await waitFor(() => {
+      const badge = screen.getByTestId("location-badge");
+      expect(badge).toHaveAttribute("data-room-color", "#A3D977");
     });
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -91,6 +91,7 @@ interface BackendStudentFromBFF {
   name?: string;
   school_class?: string;
   current_location?: string;
+  current_room_color?: string | null;
   sick?: boolean;
   sick_since?: string;
   sick_until?: string;
@@ -328,6 +329,7 @@ function OGSGroupPageContent() {
         second_name: s.last_name, // Backend uses last_name
         school_class: s.school_class ?? "",
         current_location: s.current_location ?? "",
+        current_room_color: s.current_room_color ?? null,
         sick: s.sick ?? false,
         sick_since: s.sick_since,
         excused: s.excused ?? false,

--- a/frontend/src/app/api/active-supervision-dashboard/route.ts
+++ b/frontend/src/app/api/active-supervision-dashboard/route.ts
@@ -15,6 +15,7 @@ interface BackendActiveGroup {
   room?: {
     id: number;
     name: string;
+    color?: string | null;
   };
   end_time?: string;
 }
@@ -58,6 +59,7 @@ interface BackendRoom {
   name: string;
   building?: string;
   floor?: number;
+  color?: string | null;
 }
 
 // Backend response for visits with display data
@@ -107,7 +109,7 @@ interface ActiveSupervisionDashboardResponse {
     id: string;
     name: string;
     room_id?: string;
-    room?: { id: string; name: string };
+    room?: { id: string; name: string; color?: string | null };
   }>;
 
   // Unclaimed groups available to claim
@@ -320,7 +322,11 @@ export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
             id: group.id.toString(),
             name: group.name,
             room_id: group.room_id?.toString(),
-            room: { id: group.room.id.toString(), name: group.room.name },
+            room: {
+              id: group.room.id.toString(),
+              name: group.room.name,
+              color: group.room.color ?? null,
+            },
           };
         }
 
@@ -339,6 +345,7 @@ export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
                 ? {
                     id: roomResponse.data.id.toString(),
                     name: roomResponse.data.name,
+                    color: roomResponse.data.color ?? null,
                   }
                 : undefined,
             };

--- a/frontend/src/app/api/ogs-dashboard/route.ts
+++ b/frontend/src/app/api/ogs-dashboard/route.ts
@@ -28,6 +28,8 @@ interface BackendStudent {
   name?: string;
   school_class?: string;
   current_location?: string;
+  /** Hex color of the student's current room when set; drives badge color in LocationBadge. */
+  current_room_color?: string | null;
   sick?: boolean;
   sick_since?: string;
   sick_until?: string;

--- a/frontend/src/app/api/students/[id]/route.ts
+++ b/frontend/src/app/api/students/[id]/route.ts
@@ -40,6 +40,10 @@ interface StudentResponseFromBackend {
   tag_id?: string;
   school_class: string;
   current_location?: string | null;
+  // Hex of the student's current room when set (Issue #1324). The proxy
+  // forwards it untouched; mapStudentResponse threads it into the Student
+  // type that powers LocationBadge.
+  current_room_color?: string | null;
   guardian_name: string;
   guardian_contact: string;
   guardian_email?: string;

--- a/frontend/src/app/api/students/route.ts
+++ b/frontend/src/app/api/students/route.ts
@@ -32,6 +32,10 @@ interface StudentResponseFromBackend {
   tag_id?: string;
   school_class: string;
   current_location?: string | null;
+  // Hex of the student's current room when set (Issue #1324). The proxy
+  // forwards it untouched; mapStudentResponse threads it into the Student
+  // type that powers LocationBadge.
+  current_room_color?: string | null;
   bus: boolean;
   guardian_name: string;
   guardian_contact: string;

--- a/frontend/src/components/rooms/room-form-sections.test.ts
+++ b/frontend/src/components/rooms/room-form-sections.test.ts
@@ -56,4 +56,58 @@ describe("buildRoomFormSections", () => {
       "Systemraum: Name kann nicht geändert werden",
     );
   });
+
+  // ===========================================================================
+  // Issue #1324 — system rooms must NOT show the color picker. Backend
+  // rejects color changes on Schulhof/WC with a 403, so leaving the picker
+  // visible would let admins pick a color, hit save, and see a confusing
+  // German error toast for what looks like a normal field. This filter is
+  // a UX guard, not a security one — the backend stays the source of truth.
+  // ===========================================================================
+  it("strips the color field for system rooms (Schulhof)", () => {
+    const sections = buildRoomFormSections({
+      ...baseRoom,
+      name: "Schulhof",
+    });
+    const fieldNames = sections.flatMap((section) =>
+      section.fields.map((f) => f.name),
+    );
+    expect(fieldNames).not.toContain("color");
+  });
+
+  it("strips the color field for system rooms (WC)", () => {
+    const sections = buildRoomFormSections({
+      ...baseRoom,
+      name: "WC",
+    });
+    const fieldNames = sections.flatMap((section) =>
+      section.fields.map((f) => f.name),
+    );
+    expect(fieldNames).not.toContain("color");
+  });
+
+  it("keeps the color field for regular rooms", () => {
+    // Regression guard: the filter must trigger ONLY for system rooms.
+    // If someone refactors and accidentally drops the isSystemRoom guard,
+    // every room loses its color picker silently.
+    const sections = buildRoomFormSections({
+      ...baseRoom,
+      name: "Werkraum",
+    });
+    const fieldNames = sections.flatMap((section) =>
+      section.fields.map((f) => f.name),
+    );
+    expect(fieldNames).toContain("color");
+  });
+
+  it("returns the color field unchanged when given null/undefined room", () => {
+    // The form is also rendered when creating a new room (no Room object
+    // exists yet). isSystemRoom(null) returns false, so the color field
+    // must be present — otherwise admins can never set a color on creation.
+    const sections = buildRoomFormSections(null);
+    const fieldNames = sections.flatMap((section) =>
+      section.fields.map((f) => f.name),
+    );
+    expect(fieldNames).toContain("color");
+  });
 });

--- a/frontend/src/components/rooms/room-form-sections.ts
+++ b/frontend/src/components/rooms/room-form-sections.ts
@@ -47,15 +47,22 @@ export function buildRoomFormSections(
   if (isSystemRoom(room)) {
     sections = sections.map((section) => ({
       ...section,
-      fields: section.fields.map((field) =>
-        field.name === "name"
-          ? {
-              ...field,
-              disabled: true,
-              helperText: "Systemraum: Name kann nicht geändert werden",
-            }
-          : field,
-      ),
+      fields: section.fields
+        // Drop the color picker for system rooms — Schulhof and WC have
+        // semantically fixed badges (Schulhof = orange via the parser,
+        // WC has no badge), so letting an admin pick a color would just
+        // mislead. Backend rejects color changes here too, so this is
+        // strictly a UX guard.
+        .filter((field) => field.name !== "color")
+        .map((field) =>
+          field.name === "name"
+            ? {
+                ...field,
+                disabled: true,
+                helperText: "Systemraum: Name kann nicht geändert werden",
+              }
+            : field,
+        ),
     }));
   }
 

--- a/frontend/src/components/ui/database/room-color-field.test.tsx
+++ b/frontend/src/components/ui/database/room-color-field.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { RoomColorField } from "./room-color-field";
+import { LOCATION_COLORS } from "@/lib/location-helper";
+
+describe("RoomColorField", () => {
+  it("renders the configured hex when value is set", () => {
+    render(
+      <RoomColorField
+        value="#a3d977"
+        onChange={vi.fn()}
+        label="Farbe"
+        required={false}
+      />,
+    );
+    // Display value is uppercased so audit + uniqueness checks stay consistent.
+    expect(screen.getByText("#A3D977")).toBeInTheDocument();
+  });
+
+  it("shows the Standard placeholder when no value is set", () => {
+    render(<RoomColorField value={null} onChange={vi.fn()} label="Farbe" />);
+    expect(screen.getByText("Standard")).toBeInTheDocument();
+    // Reset button only appears when a value is set
+    expect(screen.queryByRole("button", { name: /Zurücksetzen/i })).toBeNull();
+  });
+
+  it("uppercases the hex on change", () => {
+    const onChange = vi.fn();
+    render(<RoomColorField value={null} onChange={onChange} label="Farbe" />);
+    const input = screen.getByLabelText("Farbe") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "#a3d977" } });
+    expect(onChange).toHaveBeenCalledWith("#A3D977");
+  });
+
+  it("clears the value to null when Zurücksetzen is clicked", () => {
+    const onChange = vi.fn();
+    render(
+      <RoomColorField value="#A3D977" onChange={onChange} label="Farbe" />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Zurücksetzen/i }));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("uses the OTHER_ROOM blue as the default picker preview", () => {
+    render(<RoomColorField value={null} onChange={vi.fn()} label="Farbe" />);
+    const input = screen.getByLabelText("Farbe") as HTMLInputElement;
+    // The picker shows the fallback blue when nothing is set so admins see
+    // the same color the badge would render today.
+    expect(input.value.toLowerCase()).toBe(
+      LOCATION_COLORS.OTHER_ROOM.toLowerCase(),
+    );
+  });
+});

--- a/frontend/src/components/ui/database/room-color-field.tsx
+++ b/frontend/src/components/ui/database/room-color-field.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useId } from "react";
+import { LOCATION_COLORS } from "@/lib/location-helper";
+
+/**
+ * Custom field component for picking a room's badge color in the Database
+ * Rooms edit form. Wraps the native `<input type="color">` (works on touch
+ * devices, no extra dependency) plus a clear button so admins can reset to
+ * the system default blue.
+ *
+ * Backend rules the field surfaces by example, not by enforcement:
+ *   - Colors reserved for status badges (Schulhof, Unterwegs, eigener
+ *     Gruppenraum, etc.) are rejected with 400 + German message; the toast in
+ *     rooms.config.tsx surfaces that.
+ *   - Two rooms cannot share a color in the same school; backend returns 409
+ *     and the toast tells the user to pick a different color.
+ *
+ * Display value is normalised to upper-case hex so the audit log and the
+ * uniqueness index stay consistent.
+ */
+export function RoomColorField(props: {
+  value: unknown;
+  onChange: (value: unknown) => void;
+  label: string;
+  required?: boolean;
+}) {
+  const { value, onChange, label, required } = props;
+  const inputId = useId();
+
+  const stringValue =
+    typeof value === "string" && value.length > 0 ? value.toUpperCase() : null;
+
+  // Show OTHER_ROOM blue as the fallback preview so picking it intentionally
+  // is impossible (the backend reserves it anyway) and the unset state still
+  // looks like the badge users see today.
+  const displayHex = stringValue ?? LOCATION_COLORS.OTHER_ROOM;
+
+  return (
+    <div>
+      <label
+        htmlFor={inputId}
+        className="mb-1.5 block text-xs font-medium text-gray-700"
+      >
+        {label}
+        {required && "*"}
+      </label>
+      <div className="flex items-center gap-3">
+        {/* Round preview that hosts the native color picker on click. The
+            native input itself is invisible but full-size on top, so the
+            click target stays accessible and the OS picker still opens. */}
+        <label
+          htmlFor={inputId}
+          className="relative inline-block h-9 w-9 shrink-0 cursor-pointer rounded-full border border-gray-300 shadow-sm ring-1 ring-gray-200/50 transition hover:ring-gray-300"
+          style={{ backgroundColor: displayHex }}
+          aria-label={`${label} auswählen`}
+        >
+          <input
+            id={inputId}
+            type="color"
+            value={displayHex}
+            onChange={(e) => onChange(e.target.value.toUpperCase())}
+            className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            aria-label={label}
+          />
+        </label>
+        <span className="font-mono text-sm text-gray-700">
+          {stringValue ?? "Standard"}
+        </span>
+        {stringValue && (
+          <button
+            type="button"
+            onClick={() => onChange(null)}
+            className="text-xs text-gray-500 underline hover:text-gray-700"
+          >
+            Zurücksetzen
+          </button>
+        )}
+      </div>
+      <p className="mt-1 text-xs text-gray-500">
+        Damit kannst du das Badge dieses Raums einfärben. Wähle eine Farbe, die
+        du noch nicht für einen anderen Raum benutzt.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/location-badge.test.tsx
+++ b/frontend/src/components/ui/location-badge.test.tsx
@@ -595,4 +595,73 @@ describe("LocationBadge", () => {
       expect(screen.getByText(LOCATION_STATUSES.SICK)).toBeInTheDocument();
     });
   });
+
+  // ===========================================================================
+  // Per-room color (Issue #1324) — make sure the badge actually paints the
+  // configured hex when student.current_room_color is set, and falls back to
+  // OTHER_ROOM blue otherwise. Drives the differentiation users will see.
+  // ===========================================================================
+  describe("per-room color (current_room_color)", () => {
+    it("paints the per-room color when set in roomName mode", () => {
+      const student = createStudent({
+        current_location: "Anwesend - Bibliothek",
+        current_room_color: "#A3D977",
+      });
+      render(<LocationBadge student={student} displayMode="roomName" />);
+      const badgeContainer = screen.getByText("Bibliothek").closest("span");
+      // Tailwind keeps style serialized as the literal value we pass in;
+      // jsdom compares colors as written, so the assertion is exact.
+      expect(badgeContainer).toHaveStyle({ backgroundColor: "#A3D977" });
+    });
+
+    it("falls back to OTHER_ROOM blue when no per-room color is set", () => {
+      const student = createStudent({
+        current_location: "Anwesend - Bibliothek",
+        current_room_color: null,
+      });
+      render(<LocationBadge student={student} displayMode="roomName" />);
+      const badgeContainer = screen.getByText("Bibliothek").closest("span");
+      expect(badgeContainer).toHaveStyle({
+        backgroundColor: LOCATION_COLORS.OTHER_ROOM,
+      });
+    });
+
+    it("keeps GROUP_ROOM green when room is the viewer's own group room (hard constraint)", () => {
+      // Per-room color must NOT override the eigener-Gruppenraum green —
+      // see Issue #1324 discussion: all non-blue colors keep their meaning.
+      const student = createStudent({
+        current_location: "Anwesend - Raum A",
+        current_room_color: "#A3D977",
+      });
+      render(
+        <LocationBadge
+          student={student}
+          displayMode="roomName"
+          groupRooms={["Raum A"]}
+        />,
+      );
+      const badgeContainer = screen.getByText("Raum A").closest("span");
+      expect(badgeContainer).toHaveStyle({
+        backgroundColor: LOCATION_COLORS.GROUP_ROOM,
+      });
+    });
+
+    it("renders correctly when current_room_color key is absent (forward compat)", () => {
+      // Old backend builds (rolled back during a deploy or older PyrePortal
+      // proxy in the request path) won't include current_room_color in their
+      // payload at all — TypeScript represents that as `undefined`. The
+      // badge must fall back to OTHER_ROOM blue without crashing or
+      // rendering an empty backgroundColor.
+      const student: StudentLocationContext = {
+        current_location: "Anwesend - Bibliothek",
+        location_since: "2024-01-15T10:00:00Z",
+        // current_room_color intentionally omitted
+      };
+      render(<LocationBadge student={student} displayMode="roomName" />);
+      const badgeContainer = screen.getByText("Bibliothek").closest("span");
+      expect(badgeContainer).toHaveStyle({
+        backgroundColor: LOCATION_COLORS.OTHER_ROOM,
+      });
+    });
+  });
 });

--- a/frontend/src/components/ui/location-badge.tsx
+++ b/frontend/src/components/ui/location-badge.tsx
@@ -171,11 +171,12 @@ export function LocationBadge({
     );
     if (hasDetailedAccess) {
       // Own students - user can see full room details
-      // Green: OGS group room, Blue: other room, Orange: Schulhof, etc.
+      // Green: OGS group room, per-room hex when set, Blue otherwise; Orange: Schulhof, etc.
       color = getLocationColor(
         student.current_location,
         isGroupRoom,
         groupRooms,
+        student.current_room_color,
       );
     } else {
       // Foreign students - user sees limited info (only status, no room)
@@ -185,7 +186,12 @@ export function LocationBadge({
     }
   } else {
     // roomName mode - use full location for color
-    color = getLocationColor(student.current_location, isGroupRoom, groupRooms);
+    color = getLocationColor(
+      student.current_location,
+      isGroupRoom,
+      groupRooms,
+      student.current_room_color,
+    );
   }
 
   // Override for sick/excused/notArrival students at home: replace the base label

--- a/frontend/src/lib/database/configs/rooms.config.test.tsx
+++ b/frontend/src/lib/database/configs/rooms.config.test.tsx
@@ -38,23 +38,51 @@ describe("roomsConfig", () => {
     expect(fieldNames).toContain("category");
     expect(fieldNames).toContain("building");
     expect(fieldNames).toContain("floor");
+    // Color picker is part of the form (Issue #1324) so admins can override
+    // the default OTHER_ROOM blue per room.
+    expect(fieldNames).toContain("color");
   });
 
-  it("has default color value", () => {
-    expect(roomsConfig.form.defaultValues?.color).toBe("#4F46E5");
+  it("does not force a default color (Issue #1324)", () => {
+    // The previous "#4F46E5" default forced every saved room into the same
+    // hue, defeating the whole point of the color picker. New rooms now
+    // start with no color and the badge falls back to OTHER_ROOM blue until
+    // an admin picks one.
+    expect(roomsConfig.form.defaultValues?.color).toBeUndefined();
   });
 
-  it("transforms data before submit", () => {
+  it("preserves color through transformBeforeSubmit", () => {
+    // Whatever the picker emits — a hex, null, or undefined — must reach
+    // the backend untouched. Forcing a default here would clobber the
+    // user's "Zurücksetzen" action and re-introduce the all-blue bug.
+    const explicit = roomsConfig.form.transformBeforeSubmit?.({
+      name: "Room 101",
+      color: "#A3D977",
+    } as Partial<Room>);
+    expect(explicit?.color).toBe("#A3D977");
+
+    const cleared = roomsConfig.form.transformBeforeSubmit?.({
+      name: "Room 101",
+      color: null,
+    } as unknown as Partial<Room>);
+    expect(cleared?.color).toBeNull();
+
+    const omitted = roomsConfig.form.transformBeforeSubmit?.({
+      name: "Room 101",
+      color: undefined,
+    } as unknown as Partial<Room>);
+    expect(omitted?.color).toBeUndefined();
+  });
+
+  it("transforms name and floor before submit", () => {
     const data = {
       name: "  Room 101  ",
       floor: "2",
-      color: undefined,
     } as unknown as Partial<Room>;
 
     const transformed = roomsConfig.form.transformBeforeSubmit?.(data);
     expect(transformed?.name).toBe("Room 101");
     expect(transformed?.floor).toBe(2);
-    expect(transformed?.color).toBe("#4F46E5");
   });
 
   it("validates floor field", () => {

--- a/frontend/src/lib/database/configs/rooms.config.tsx
+++ b/frontend/src/lib/database/configs/rooms.config.tsx
@@ -2,6 +2,7 @@
 
 import { defineEntityConfig } from "../types";
 import { databaseThemes } from "@/components/ui/database/themes";
+import { RoomColorField } from "@/components/ui/database/room-color-field";
 import { mapRoomResponse, prepareRoomForBackend } from "@/lib/room-helpers";
 import type { Room, BackendRoom } from "@/lib/room-helpers";
 
@@ -64,19 +65,22 @@ export const roomsConfig = defineEntityConfig<Room>({
               return null;
             },
           },
+          {
+            name: "color",
+            label: "Farbe",
+            type: "custom",
+            colSpan: 2,
+            component: RoomColorField,
+          },
         ],
       },
     ],
 
-    defaultValues: {
-      color: "#4F46E5", // Default color (matches original implementation)
-    },
-
     transformBeforeSubmit: (data) => {
-      // Match original implementation:
-      // - Trim name (String(form.name).trim())
-      // - Convert floor to number (Number(form.floor))
-      // - Ensure color has default (form.color ?? "#4F46E5")
+      // - Trim name
+      // - Convert floor to number
+      // - Pass color through untouched: null/undefined clears it server-side,
+      //   the backend uses NULL to mean "fall back to badge default blue"
       return {
         ...data,
         name: typeof data.name === "string" ? data.name.trim() : data.name,
@@ -84,7 +88,6 @@ export const roomsConfig = defineEntityConfig<Room>({
           typeof data.floor === "string"
             ? Number.parseInt(data.floor, 10)
             : data.floor,
-        color: data.color ?? "#4F46E5", // Ensure color is always set
       };
     },
   },

--- a/frontend/src/lib/location-helper.test.ts
+++ b/frontend/src/lib/location-helper.test.ts
@@ -137,6 +137,72 @@ describe("getLocationColor", () => {
   it("returns UNKNOWN color for unknown status", () => {
     expect(getLocationColor("SomeRandomStatus")).toBe(LOCATION_COLORS.UNKNOWN);
   });
+
+  // ===========================================================================
+  // Per-room color (Issue #1324 — eliminate the all-blue room badges)
+  // ===========================================================================
+
+  it("returns the per-room color when set and the room is not a group room", () => {
+    // The viewer is not in this group → no green; the room has its own
+    // configured hex → that wins over the OTHER_ROOM blue fallback.
+    const color = getLocationColor(
+      "Anwesend - Bibliothek",
+      false,
+      ["Raum A"],
+      "#A3D977",
+    );
+    expect(color).toBe("#A3D977");
+  });
+
+  it("falls back to OTHER_ROOM blue when no per-room color is set", () => {
+    // Same scenario as above without a configured color: kept as today.
+    const color = getLocationColor(
+      "Anwesend - Bibliothek",
+      false,
+      ["Raum A"],
+      null,
+    );
+    expect(color).toBe(LOCATION_COLORS.OTHER_ROOM);
+  });
+
+  it("treats empty string roomColor like null (clearing the override)", () => {
+    // Clearing the color via the picker yields "" or null depending on the
+    // wire shape; either must fall back to the blue default.
+    const color = getLocationColor(
+      "Anwesend - Bibliothek",
+      false,
+      ["Raum A"],
+      "",
+    );
+    expect(color).toBe(LOCATION_COLORS.OTHER_ROOM);
+  });
+
+  it("keeps GROUP_ROOM green when viewer is in the same group, even with a per-room color", () => {
+    // Hard constraint: non-blue colors must keep their meaning. If the room
+    // is the viewer's own OGS-Gruppenraum, green wins over the configured
+    // per-room hex.
+    const color = getLocationColor(
+      "Anwesend - Raum A",
+      false,
+      ["Raum A"],
+      "#A3D977",
+    );
+    expect(color).toBe(LOCATION_COLORS.GROUP_ROOM);
+  });
+
+  it("keeps status colors unchanged regardless of per-room color", () => {
+    // Status badges (Schulhof, Unterwegs, Zuhause) must never be overridden
+    // by a roomColor — the parser hits STATUS_COLOR_MAP first.
+    expect(getLocationColor("Schulhof", false, [], "#A3D977")).toBe(
+      LOCATION_COLORS.SCHOOLYARD,
+    );
+    expect(getLocationColor("Unterwegs", false, [], "#A3D977")).toBe(
+      LOCATION_COLORS.TRANSIT,
+    );
+    expect(getLocationColor("Zuhause", false, [], "#A3D977")).toBe(
+      LOCATION_COLORS.HOME,
+    );
+  });
 });
 
 // =============================================================================

--- a/frontend/src/lib/location-helper.ts
+++ b/frontend/src/lib/location-helper.ts
@@ -18,6 +18,21 @@ export interface LocationStyle {
 export interface StudentLocationContext {
   current_location?: string | null;
   location_since?: string | null;
+  /**
+   * Hex color of the student's current room when set. Backend serves this in
+   * `current_room_color` for visit/student responses; the active-supervisions
+   * page derives it from the current room object directly. Drives the room
+   * badge color so the OGS list isn't a wall of identical blue badges anymore.
+   * Nil for status-only locations (Schulhof / Unterwegs / Zuhause / sick / etc.)
+   * and for rooms without a custom color set.
+   *
+   * **Maintenance note**: any new SWR cache that stores rows containing this
+   * field (or any other room-derived attribute like the room name baked into
+   * `current_location`) MUST register its key substring in
+   * `lib/swr/room-derived-caches.ts`. Otherwise badge colours stay stale
+   * after an admin saves a room until the cache happens to refetch.
+   */
+  current_room_color?: string | null;
   group_id?: string | null;
   group_name?: string | null;
   sick?: boolean;
@@ -170,11 +185,20 @@ function isStudentInGroupRoom(
 
 /**
  * Determines the color for a student who is present with a room assignment.
+ *
+ * Priority is intentional:
+ *   1. Eigener-Gruppenraum-Grün — viewer-relative signal, kept as-is per the
+ *      hard constraint that all non-blue colors keep their meaning.
+ *   2. Per-room hex from the backend (`roomColor`) — the new differentiator
+ *      that replaces the painful "every other room is the same blue" symptom.
+ *   3. OTHER_ROOM blue fallback — bestehende Räume ohne gesetzte Farbe sehen
+ *      genauso aus wie heute, kein visueller Sprung.
  */
 function getColorForPresentWithRoom(
   room: string,
   isGroupRoom?: boolean,
   groupRooms?: string[],
+  roomColor?: string | null,
 ): string {
   // Check if room is one of the user's OGS group rooms
   if (
@@ -188,6 +212,13 @@ function getColorForPresentWithRoom(
   // Fallback to isGroupRoom prop if groupRooms not provided
   if (isGroupRoom) {
     return LOCATION_COLORS.GROUP_ROOM; // Green - in their group's room
+  }
+
+  // Per-room override — empty string is treated like null (the rooms.config
+  // form sends "" when the user clears the picker, the backend translates
+  // both to NULL; either way the badge falls back to OTHER_ROOM blue).
+  if (roomColor && roomColor.length > 0) {
+    return roomColor;
   }
 
   // Student in any other room
@@ -206,6 +237,7 @@ export function getLocationColor(
   location?: string | null,
   isGroupRoom?: boolean,
   groupRooms?: string[],
+  roomColor?: string | null,
 ): string {
   const parsed = parseLocation(location);
   const status = parsed.status;
@@ -219,7 +251,12 @@ export function getLocationColor(
   // Handle "Anwesend" status
   if (status === LOCATION_STATUSES.PRESENT) {
     if (parsed.room) {
-      return getColorForPresentWithRoom(parsed.room, isGroupRoom, groupRooms);
+      return getColorForPresentWithRoom(
+        parsed.room,
+        isGroupRoom,
+        groupRooms,
+        roomColor,
+      );
     }
     // "Anwesend" without room details (GDPR-reduced) - show green (present in building)
     return LOCATION_COLORS.GROUP_ROOM;

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -50,6 +50,8 @@ export interface BackendStudent {
   school_class: string;
   current_location?: string | null;
   location_since?: string | null; // When student entered current location (ISO timestamp)
+  /** Hex color of the current room when set (Issue #1324). Drives badge color in LocationBadge. */
+  current_room_color?: string | null;
   bus?: boolean;
   sick?: boolean;
   sick_since?: string;
@@ -148,6 +150,8 @@ export interface Student {
   current_location: string;
   // When student entered current location (only for hasFullAccess users)
   location_since?: string;
+  /** Hex color of the current room when set (Issue #1324). Empty string treated as null. */
+  current_room_color?: string | null;
   // Transportation method (separate from attendance)
   takes_bus?: boolean;
   bus?: boolean; // Administrative permission flag (Buskind), not attendance status
@@ -216,6 +220,7 @@ export function mapStudentResponse(
     // New attendance-based system
     current_location,
     location_since: backendStudent.location_since ?? undefined,
+    current_room_color: backendStudent.current_room_color ?? null,
     takes_bus: undefined,
     bus: backendStudent.bus ?? false, // Administrative permission flag (Buskind)
     sick: backendStudent.sick ?? false, // Sickness status

--- a/frontend/src/lib/swr/hooks.test.ts
+++ b/frontend/src/lib/swr/hooks.test.ts
@@ -5,6 +5,7 @@ import {
   useImmutableSWR,
   useSWRWithId,
   useTenantMutate,
+  useTenantMutateMatching,
 } from "./hooks";
 
 // Mock next-auth/react
@@ -348,6 +349,104 @@ describe("SWR Hooks", () => {
       void result.current("some-key");
 
       expect(mockSwrMutate).toHaveBeenCalledWith("some-key");
+    });
+  });
+
+  // ===========================================================================
+  // useTenantMutateMatching — cross-tenant isolation is the bug magnet here.
+  // The hook must invalidate ONLY caches for the active tenant; matching by
+  // substring alone would silently invalidate every tenant in a multi-tab
+  // session, which is hard to reproduce locally and a privacy footgun in
+  // production (forces refetches that may surface in audit logs etc.).
+  // ===========================================================================
+  describe("useTenantMutateMatching", () => {
+    /**
+     * Capture the matcher predicate that the hook passes to swr.mutate so we
+     * can interrogate it directly. Avoids relying on swr's internal cache
+     * iteration in tests — the predicate is the real contract.
+     */
+    function renderAndCaptureMatcher(
+      slug: string | null,
+      substrings: string[],
+    ): (key: unknown) => boolean {
+      mockUseTenantSlugSafe.mockReturnValue(slug);
+      const { result } = renderHook(() => useTenantMutateMatching(substrings));
+      void result.current();
+
+      const lastCall =
+        mockSwrMutate.mock.calls[mockSwrMutate.mock.calls.length - 1];
+      const matcher = lastCall?.[0];
+      expect(typeof matcher).toBe("function");
+      return matcher as (key: unknown) => boolean;
+    }
+
+    it("matches keys for the current tenant whose name contains a substring", () => {
+      const matcher = renderAndCaptureMatcher("school-a", [
+        "active-supervision",
+        "ogs-students",
+      ]);
+
+      expect(matcher("school-a:active-supervision-dashboard-0")).toBe(true);
+      expect(matcher("school-a:ogs-students-42")).toBe(true);
+    });
+
+    it("rejects keys for OTHER tenants even when the substring matches", () => {
+      // The bug class this guards against: a multi-tab user has tenant A in
+      // one tab and tenant B in another. Saving a room in tenant A must not
+      // invalidate tenant B's caches — otherwise B's tab refetches data the
+      // user there did not ask for.
+      const matcher = renderAndCaptureMatcher("school-a", [
+        "active-supervision",
+      ]);
+
+      expect(matcher("school-b:active-supervision-dashboard-0")).toBe(false);
+      expect(matcher("school-c:active-supervision-visits-1")).toBe(false);
+    });
+
+    it("rejects keys that match the tenant but no substring", () => {
+      const matcher = renderAndCaptureMatcher("school-a", ["ogs-students"]);
+
+      expect(matcher("school-a:database-teachers-list")).toBe(false);
+      expect(matcher("school-a:students-search-foo")).toBe(false);
+    });
+
+    it("rejects non-string keys (SWR allows arrays/objects as keys)", () => {
+      const matcher = renderAndCaptureMatcher("school-a", ["foo"]);
+
+      expect(matcher(["school-a", "foo"])).toBe(false);
+      expect(matcher({ slug: "school-a", key: "foo" })).toBe(false);
+      expect(matcher(null)).toBe(false);
+      expect(matcher(undefined)).toBe(false);
+    });
+
+    it("falls back to substring-only matching when no tenant context", () => {
+      // Operator dashboard / pre-auth scenarios use bare keys without slug
+      // prefix. The hook must still work there without filtering everything
+      // out — otherwise a colorless tenant context would silently no-op.
+      const matcher = renderAndCaptureMatcher(null, ["operator-foo"]);
+
+      expect(matcher("operator-foo-1")).toBe(true);
+      expect(matcher("unrelated-bar")).toBe(false);
+    });
+
+    it("returns the same callback when called with a fresh array of identical contents", () => {
+      // Stability guard: callers pass a literal array each render. Without
+      // the joined-string dep, useCallback would re-create the function every
+      // render and cascade through every consumer using it as a dep —
+      // forcing unrelated re-renders on every keystroke in the rooms search
+      // box. This test pins the optimisation in place.
+      mockUseTenantSlugSafe.mockReturnValue("school-a");
+      const { result, rerender } = renderHook(
+        ({ subs }: { subs: string[] }) => useTenantMutateMatching(subs),
+        { initialProps: { subs: ["a", "b"] } },
+      );
+      const firstCallback = result.current;
+
+      rerender({ subs: ["a", "b"] }); // fresh array, same contents
+      expect(result.current).toBe(firstCallback);
+
+      rerender({ subs: ["a", "c"] }); // genuinely different contents
+      expect(result.current).not.toBe(firstCallback);
     });
   });
 });

--- a/frontend/src/lib/swr/hooks.ts
+++ b/frontend/src/lib/swr/hooks.ts
@@ -120,6 +120,68 @@ export function useTenantMutate() {
 }
 
 /**
+ * Hook that invalidates every tenant-scoped SWR cache entry whose key matches
+ * a substring. Useful for cross-cutting changes that affect data displayed by
+ * multiple unrelated pages — e.g. updating a room's color must refresh every
+ * visit/student list that stamps `current_room_color` into its rows.
+ *
+ * Match is checked against the tenant-prefixed key, so substrings should
+ * include enough context to avoid over-invalidation. Pass an array of
+ * substrings to match if any of them appears.
+ *
+ * **Picking substrings**: prefer fragments that are unlikely to collide with
+ * future cache keys. `"ogs-students"` is safer than `"students"` because the
+ * latter would also match `students-search`, `students-import`, etc., once
+ * those caches exist. Substring match is a forward-compatibility hazard — a
+ * new SWR consumer added later may accidentally land in your invalidation
+ * net without anyone noticing. Err on the side of longer, more specific
+ * fragments and revisit this list whenever a new cache key is introduced
+ * that contains one of your substrings.
+ *
+ * **Convention**: existing SWR keys in this codebase put a trailing dash
+ * before their first dynamic segment (`ogs-students-${groupId}`,
+ * `active-supervision-dashboard-${refreshKey}`). Including that trailing
+ * dash in your substring (`"ogs-students-"` instead of `"ogs-students"`)
+ * narrows the match window and makes accidental collisions with future
+ * keys that only happen to start with the same prefix less likely.
+ *
+ * **Stability**: Callers can pass a literal array each render — the hook
+ * derives a stable string key internally from the joined substrings, so the
+ * returned callback identity stays referentially stable across renders.
+ * This avoids cascading useCallback invalidations in consumers that depend
+ * on the returned function.
+ *
+ * @example
+ * ```tsx
+ * const refreshRoomConsumers = useTenantMutateMatching([
+ *   "active-supervision",
+ *   "supervision-visits",
+ *   "ogs-students",
+ *   "search-students",
+ * ]);
+ * await refreshRoomConsumers(); // every cache key containing one of those substrings refetches
+ * ```
+ */
+export function useTenantMutateMatching(substrings: readonly string[]) {
+  const slug = useTenantSlugSafe();
+  // "|" is a safe joiner: substrings are caller-supplied cache-key fragments
+  // (literals like "ogs-students"), which cannot legally contain pipe in any
+  // SWR key the codebase produces. The joined string is the actual dep — a
+  // fresh array literal with identical contents reuses the memoized callback.
+  const joined = substrings.join("|");
+
+  return useCallback(() => {
+    const needles = joined.length > 0 ? joined.split("|") : [];
+    return swrMutate((key) => {
+      if (typeof key !== "string") return false;
+      // Limit to the active tenant so cross-tenant caches (multi-tab) stay put.
+      if (slug && !key.startsWith(`${slug}:`)) return false;
+      return needles.some((needle) => key.includes(needle));
+    });
+  }, [slug, joined]);
+}
+
+/**
  * SWR hook for data that depends on a parameter.
  *
  * Automatically generates a cache key that includes the parameter,

--- a/frontend/src/lib/swr/index.ts
+++ b/frontend/src/lib/swr/index.ts
@@ -23,6 +23,7 @@ export {
   useImmutableSWR,
   useSWRWithId,
   useTenantMutate,
+  useTenantMutateMatching,
 } from "./hooks";
 
 // Re-export config for advanced usage

--- a/frontend/src/lib/swr/room-derived-caches.ts
+++ b/frontend/src/lib/swr/room-derived-caches.ts
@@ -1,0 +1,57 @@
+/**
+ * Single source of truth for SWR cache keys that hold room-stamped data.
+ *
+ * **Why this file exists**: many pages cache student/visit lists with
+ * `current_room_color` (or other room-derived attributes like the room name)
+ * baked into each row. When an admin saves a Room — colour, name, anything
+ * the badge renderer reads — those caches stay stale until SWR refetches.
+ * The Database Rooms page invalidates them via `useTenantMutateMatching`,
+ * but it needs to know which cache substrings count as "room-derived".
+ *
+ * Hardcoding that list inside `database/rooms/page.tsx` worked but rotted on
+ * contact: every new SWR consumer that consumes room-stamped data needs the
+ * page-author to also remember to register their key here. Centralising
+ * makes the coupling visible — anyone touching this list is forced past the
+ * doc comment that explains the invariant.
+ *
+ * **What belongs here**: cache-key substrings (matching the
+ * `useTenantMutateMatching` convention of trailing-dash prefixes) for caches
+ * that contain ANY room-derived value:
+ *   - `current_room_color` (Issue #1324)
+ *   - the resolved room name in `current_location` strings
+ *   - any future room-attribute that finds its way into a student/visit row
+ *
+ * **What does NOT belong**: caches that fetch Room data directly
+ * (`/api/rooms` lists). Those have their own invalidation path
+ * (`tenantMutate("database-rooms-list")`). This list is for *consumers* of
+ * room data, not the room data itself.
+ *
+ * If you add a new SWR key that fits the criteria above, add its substring
+ * here AND add a unit test verifying the badge updates after a room save.
+ * The forward-compat hazard documented on `useTenantMutateMatching` makes
+ * silent regressions easy.
+ */
+
+/**
+ * Substrings of cache keys that hold room-derived student/visit data.
+ *
+ * Each entry uses the convention from `useTenantMutateMatching`: include the
+ * trailing dash before the first dynamic segment so accidental future
+ * collisions are harder. The bare `ogs-dashboard` key has no dynamic suffix
+ * and is matched as-is.
+ *
+ * Keep this list in sync with the actual SWR keys used in pages. Currently:
+ *   - `active-supervision-dashboard-${refreshKey}` — active-supervisions BFF
+ *   - `supervision-visits-${roomId}` — active-supervisions per-room visit
+ *     refresh
+ *   - `ogs-dashboard` — OGS-Groups BFF
+ *   - `ogs-students-${groupId}` — OGS-Groups per-group student fetch
+ *   - `search-students-${term}-${groupFilter}` — Students Search list
+ */
+export const ROOM_DERIVED_CACHE_KEY_FRAGMENTS: readonly string[] = [
+  "active-supervision-dashboard-",
+  "supervision-visits-",
+  "ogs-dashboard",
+  "ogs-students-",
+  "search-students-",
+] as const;


### PR DESCRIPTION
Closes #1324. Replaces the all-blue room badge with admin-pickable hex codes. Status colors (Schulhof, Unterwegs, Zuhause, Krank, Entschuldigt) and the "own group room" green keep their meaning — only the generic `OTHER_ROOM` blue fallback is replaced when a room has a color set. System rooms (Schulhof, WC) cannot be re-coloured.

## Backend

- Migration `1.15.44` backs up every row carrying the legacy `#4F46E5` value into `audit.room_color_migration_backup` and NULLs it on `facilities.rooms`. That hex was never user-chosen — it came from a `transformBeforeSubmit` bug that stamped it onto every save, invisible until now because the badge ignored `room.color`. Migration then adds a partial `UNIQUE(tenant_id, lower(color)) WHERE color IS NOT NULL` index. Rollback drops the index but does not restore cleared colors.
- `reservedRoomColors` blocks the status palette plus `#4F46E5`. A drift test parses `LOCATION_COLORS` from the frontend and fails CI if the two diverge.
- System rooms reject color writes; edits that omit the `color` field preserve the existing value (so a Schulhof capacity bump still works on rows carrying leftover legacy color).
- Validation centralised in the service layer; model sentinels translated to 400 / 409 with German messages via `ErrorRenderer`. Color-conflict path matches the unique-constraint name via `pgdriver.Error.Field('n')` so `ErrColorAlreadyInUse` is not shadowed by the generic `ErrDuplicateRoom`.
- `StudentResponse.current_room_color` and `RoomSimple.color` carry the value into student / visit payloads.

## Frontend

- New `RoomColorField` (circle preview + reset button) on Database → Rooms; hidden for system rooms.
- `getLocationColor` priority: own group room green → per-room hex → `OTHER_ROOM` blue. Status colors are unchanged.
- `useTenantMutateMatching` invalidates room-derived caches after a save; the substring list lives in `lib/swr/room-derived-caches.ts` as a single source of truth.
- `current_room_color` threaded through active-supervisions, OGS-Groups, and students-search via `mapStudentResponse` and the existing BFF passthrough routes.

## Test plan

- [ ] `cd backend && go test ./...` and `cd frontend && pnpm run check`
- [ ] Apply migration `1.15.44` on a DB with `#4F46E5` rows; verify backup table is populated and index `uniq_facilities_rooms_tenant_color` exists
- [ ] Pick a custom hex on a non-system room → badge updates on Database, Active-Supervisions, and OGS-Groups
- [ ] Reserved hex (e.g. `#83CD2D`) → 400 with German message
- [ ] Same hex on two rooms in one school → 409 with German message
- [ ] Color write on Schulhof / WC rejected; capacity-only edit on the same row still succeeds