### PR TITLE
Fix IoT daily checkout attendance FK error

### DIFF
--- a/backend/api/iot/attendance/attendance_test.go
+++ b/backend/api/iot/attendance/attendance_test.go
@@ -19,6 +19,8 @@ import (
 	attendanceAPI "github.com/moto-nrw/project-phoenix/api/iot/attendance"
 	"github.com/moto-nrw/project-phoenix/api/testutil"
 	"github.com/moto-nrw/project-phoenix/auth/device"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/services"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
@@ -592,7 +594,9 @@ func TestRouter_ReturnsValidRouter(t *testing.T) {
 // =============================================================================
 
 // TestToggleAttendance_DailyCheckoutZuhauseCheckedIn tests the daily checkout with
-// destination "zuhause" when the student IS checked in — the ToggleStudentAttendance path.
+// destination "zuhause" when the student is checked in. Real IoT daily-checkout
+// requests carry device context, but no staff context, so this guards against
+// routing through an insert path that would write checked_in_by=0.
 func TestToggleAttendance_DailyCheckoutZuhauseCheckedIn(t *testing.T) {
 	ctx := setupTestContext(t)
 	defer func() { _ = ctx.db.Close() }()
@@ -620,13 +624,12 @@ func TestToggleAttendance_DailyCheckoutZuhauseCheckedIn(t *testing.T) {
 
 	req := testutil.NewAuthenticatedRequest(t, "POST", "/toggle", body,
 		testutil.WithDeviceContext(testDevice),
-		testutil.WithStaffContext(staff),
 	)
 
 	// ACT
 	rr := testutil.ExecuteRequest(router, req)
 
-	// ASSERT: Should succeed — student checked_in + zuhause triggers ToggleStudentAttendance
+	// ASSERT: Should succeed — student checked_in + zuhause performs an explicit checkout.
 	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
 
 	// Verify response contains daily checkout action
@@ -636,6 +639,18 @@ func TestToggleAttendance_DailyCheckoutZuhauseCheckedIn(t *testing.T) {
 		assert.Equal(t, "checked_out_daily", data["action"])
 		assert.Contains(t, data["message"], "Tschüss")
 	}
+
+	var records []*activeModel.Attendance
+	err := ctx.db.NewSelect().
+		Model(&records).
+		ModelTableExpr(`active.attendance AS "attendance"`).
+		Where(`"attendance".student_id = ?`, student.ID).
+		Where(`"attendance".date = ?`, timezone.TodayUTC()).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 1, "daily checkout must close the existing row instead of inserting a new one")
+	require.NotNil(t, records[0].CheckOutTime)
+	assert.Nil(t, records[0].CheckedOutBy, "IoT daily checkout without staff context must not write a bogus staff FK")
 }
 
 // TestToggleAttendance_DailyCheckoutZuhauseAlreadyCheckedOut tests the daily checkout with

--- a/backend/api/iot/attendance/handlers.go
+++ b/backend/api/iot/attendance/handlers.go
@@ -220,19 +220,14 @@ func (rs *Resource) handleDailyCheckout(w http.ResponseWriter, r *http.Request, 
 				slog.Int64("student_id", student.ID),
 			)
 		case "checked_in":
-			deviceCtx := device.DeviceFromCtx(r.Context())
 			staffID := int64(0)
-			deviceID := int64(0)
-			if deviceCtx != nil {
-				deviceID = deviceCtx.ID
-			}
 			if staffCtx := device.StaffFromCtx(r.Context()); staffCtx != nil {
 				staffID = staffCtx.ID
 			}
 
 			// Set attendance to "checked_out" — sets check_out_time on today's record.
 			// skipAuthCheck=true because the IoT device already authenticated this request.
-			_, err := rs.ActiveService.ToggleStudentAttendance(r.Context(), student.ID, staffID, deviceID, true)
+			_, err := rs.ActiveService.CheckOutStudent(r.Context(), student.ID, staffID, true)
 			if err != nil {
 				slog.Default().ErrorContext(r.Context(), "failed to update attendance for daily checkout",
 					slog.Int64("student_id", student.ID),


### PR DESCRIPTION
## Summary

Fixes a production Sentry issue where `confirm_daily_checkout` could hit `fk_attendance_checked_in_by_tenant` after the attendance row was already closed.

## Root cause

The daily-checkout handler used `ToggleStudentAttendance` for the `zuhause` confirmation. That method re-reads state and flips based on the current row. If the row was closed before that second read, it routed into check-in and attempted to insert a fresh attendance row. Real IoT daily-checkout requests do not carry staff context, so that insert used `checked_in_by = 0` and PostgreSQL rejected it.

## Changes

- Use `CheckOutStudent` for `confirm_daily_checkout` when destination is `zuhause`.
- Keep the API response behavior unchanged for PyrePortal.
- Update the regression test to match production: device context only, no staff context, and assert the existing row is closed without inserting a second row.

## Validation

- `cd backend && go test ./api/iot/attendance ./services/active ./database/repositories/active`
- `cd backend && go test ./test/ -run TestHermeticTestPatterns -v`
- pre-push hooks: `git-secrets`, `go-vet`, `go-deadcode`, `golangci-lint`
