### PR TITLE
fix(iot): return 409 Conflict on duplicate active visit

### DIFF
--- a/backend/api/active/active_internal_test.go
+++ b/backend/api/active/active_internal_test.go
@@ -128,11 +128,10 @@ func TestErrorRenderer_AllBadRequestErrors(t *testing.T) {
 			err:          &activeService.ActiveError{Op: "test", Err: activeService.ErrStudentAlreadyInGroup},
 			expectedText: "Student Already In Group",
 		},
-		{
-			name:         "ErrStudentAlreadyActive",
-			err:          &activeService.ActiveError{Op: "test", Err: activeService.ErrStudentAlreadyActive},
-			expectedText: "Student Already Has Active Visit",
-		},
+		// ErrStudentAlreadyActive intentionally absent — it maps to
+		// 409 Conflict (see TestErrorRenderer_StudentAlreadyActive in
+		// handlers_unit_test.go and TestErrorRenderer_StudentAlreadyActiveConflict
+		// in errors_test.go) per the Issue #844 review fix.
 		{
 			name:         "ErrStaffAlreadySupervising",
 			err:          &activeService.ActiveError{Op: "test", Err: activeService.ErrStaffAlreadySupervising},

--- a/backend/api/active/errors.go
+++ b/backend/api/active/errors.go
@@ -85,7 +85,17 @@ func ErrorRenderer(err error) render.Renderer {
 		renderer.StatusText = "Student Already In Group"
 
 	case errors.Is(err, activeSvc.ErrStudentAlreadyActive):
-		renderer.HTTPStatusCode = http.StatusBadRequest
+		// 409 Conflict — the request is well-formed but conflicts with
+		// existing state (the student already has an open visit). Issue
+		// #844 added a DB-level partial unique index on active.visits;
+		// the active service now translates the resulting 23505 error
+		// to ErrStudentAlreadyActive for ALL CreateVisit callers, not
+		// just the IoT checkin flow. Without this 409 mapping, the
+		// admin POST /active/visits route would surface concurrent
+		// duplicate-creation as 400 Bad Request, contradicting both
+		// the IoT path's 409 response and the semantic meaning of the
+		// error.
+		renderer.HTTPStatusCode = http.StatusConflict
 		renderer.StatusText = "Student Already Has Active Visit"
 
 	case errors.Is(err, activeSvc.ErrStaffAlreadySupervising):

--- a/backend/api/active/errors_test.go
+++ b/backend/api/active/errors_test.go
@@ -49,7 +49,10 @@ func TestErrorRenderer_BadRequestErrors(t *testing.T) {
 		{"ErrCombinedGroupAlreadyEnded", activeSvc.ErrCombinedGroupAlreadyEnded},
 		{"ErrGroupAlreadyInCombination", activeSvc.ErrGroupAlreadyInCombination},
 		{"ErrStudentAlreadyInGroup", activeSvc.ErrStudentAlreadyInGroup},
-		{"ErrStudentAlreadyActive", activeSvc.ErrStudentAlreadyActive},
+		// ErrStudentAlreadyActive moved out of the 400 list — see
+		// TestErrorRenderer_ConflictError. It now maps to 409 Conflict
+		// because Issue #844 routes the DB-level duplicate-active-visit
+		// translation through this renderer for non-IoT callers.
 		{"ErrStaffAlreadySupervising", activeSvc.ErrStaffAlreadySupervising},
 		{"ErrCannotDeleteActiveGroup", activeSvc.ErrCannotDeleteActiveGroup},
 		{"ErrInvalidTimeRange", activeSvc.ErrInvalidTimeRange},
@@ -73,6 +76,20 @@ func TestErrorRenderer_ConflictError(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, http.StatusConflict, resp.HTTPStatusCode)
 	assert.Equal(t, "Room Conflict", resp.StatusText)
+}
+
+// TestErrorRenderer_StudentAlreadyActiveConflict guards the Issue #844
+// review fix: ErrStudentAlreadyActive must map to 409 Conflict, not
+// 400 Bad Request. The active service's CreateVisit now translates
+// the DB unique-index violation to this sentinel for every caller —
+// including admin POST /active/visits — so a 400 here would
+// contradict the IoT path's 409 response on the same conflict.
+func TestErrorRenderer_StudentAlreadyActiveConflict(t *testing.T) {
+	renderer := active.ErrorRenderer(activeSvc.ErrStudentAlreadyActive)
+	resp, ok := renderer.(*active.ErrResponse)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusConflict, resp.HTTPStatusCode)
+	assert.Equal(t, "Student Already Has Active Visit", resp.StatusText)
 }
 
 func TestErrorRenderer_UnknownError(t *testing.T) {

--- a/backend/api/active/handlers_unit_test.go
+++ b/backend/api/active/handlers_unit_test.go
@@ -2,6 +2,7 @@ package active
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -791,12 +792,19 @@ func TestErrorRenderer_StudentAlreadyInGroup(t *testing.T) {
 }
 
 func TestErrorRenderer_StudentAlreadyActive(t *testing.T) {
+	// 409 Conflict, not 400 Bad Request: the duplicate-active-visit
+	// translation introduced for Issue #844 means this error now
+	// surfaces from the DB-level unique index on every CreateVisit
+	// caller, not just the IoT checkin flow. Mapping it to 400 would
+	// contradict both the IoT path (which already returns 409) and
+	// the HTTP semantics — a duplicate visit is a state conflict,
+	// not a malformed request.
 	err := activeSvc.ErrStudentAlreadyActive
 	renderer := ErrorRenderer(err)
 
 	errResp, ok := renderer.(*ErrResponse)
 	assert.True(t, ok)
-	assert.Equal(t, 400, errResp.HTTPStatusCode)
+	assert.Equal(t, http.StatusConflict, errResp.HTTPStatusCode)
 	assert.Equal(t, "Student Already Has Active Visit", errResp.StatusText)
 }
 

--- a/backend/api/iot/checkin/checkin_test.go
+++ b/backend/api/iot/checkin/checkin_test.go
@@ -3265,9 +3265,14 @@ func TestDevicePickupQuery_PersonNeitherStudentNorStaffReturnsNotFound(t *testin
 //   - no-ops EndVisit so the existing pre-created visit stays open and the
 //     handler's response builder finds it for the body details
 //
-// This deterministically simulates the production race scenario where the
-// application-level read-then-write check passes but the database-level
-// unique partial index rejects the insert.
+// This stub exercises the **app-level rejection path** in the IoT handler:
+// the service has already determined the student has an active visit and
+// returns ErrStudentAlreadyActive without performing an INSERT. The
+// database-level partial unique index race is NOT reached here — that
+// path lives in the active service and is covered by the
+// repository-level test on the partial unique index (see
+// backend/database/repositories/active/visits_repository_test.go) plus
+// the unit test on isDuplicateActiveVisitViolation.
 type duplicateVisitActiveService struct {
 	activeSvc.Service
 }
@@ -3280,12 +3285,17 @@ func (d *duplicateVisitActiveService) EndVisit(ctx context.Context, id int64) er
 	return nil
 }
 
-func TestDeviceCheckin_DuplicateActiveVisit_Returns409(t *testing.T) {
-	// Verifies that when CreateVisit reports ErrStudentAlreadyActive, the
-	// IoT handler returns 409 Conflict with the structured
-	// STUDENT_ALREADY_ACTIVE body (Issue #844). Includes existing visit
-	// metadata (visit_id, room_id, room_name, entry_time) so the kiosk can
-	// surface "Bereits angemeldet in <Raum>" instead of a generic error.
+func TestDeviceCheckin_DuplicateActiveVisit_AppLevelPath_Returns409WithRoomDetails(t *testing.T) {
+	// Verifies that when CreateVisit reports ErrStudentAlreadyActive via the
+	// application-level read-then-write check, the IoT handler returns 409
+	// Conflict with the structured STUDENT_ALREADY_ACTIVE body (Issue #844).
+	// Includes existing visit metadata (visit_id, room_id, room_name,
+	// entry_time) so the kiosk can surface "Bereits angemeldet in <Raum>"
+	// instead of a generic error.
+	//
+	// The DB-race path (where visitRepo.Create itself trips the partial
+	// unique index from migration 1.15.45) is NOT exercised here — see
+	// the package note on duplicateVisitActiveService above.
 	ctx := setupTestContext(t)
 	defer func() { _ = ctx.db.Close() }()
 

--- a/backend/api/iot/checkin/checkin_test.go
+++ b/backend/api/iot/checkin/checkin_test.go
@@ -3294,7 +3294,7 @@ func TestDeviceCheckin_DuplicateActiveVisit_AppLevelPath_Returns409WithRoomDetai
 	// instead of a generic error.
 	//
 	// The DB-race path (where visitRepo.Create itself trips the partial
-	// unique index from migration 1.15.45) is NOT exercised here — see
+	// unique index from migration 1.15.46) is NOT exercised here — see
 	// the package note on duplicateVisitActiveService above.
 	ctx := setupTestContext(t)
 	defer func() { _ = ctx.db.Close() }()

--- a/backend/api/iot/checkin/checkin_test.go
+++ b/backend/api/iot/checkin/checkin_test.go
@@ -24,6 +24,7 @@ import (
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/services"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
 	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
@@ -3253,4 +3254,117 @@ func TestDevicePickupQuery_PersonNeitherStudentNorStaffReturnsNotFound(t *testin
 	rr := testutil.ExecuteRequest(router, req)
 
 	testutil.AssertNotFound(t, rr)
+}
+
+// =============================================================================
+// DUPLICATE ACTIVE VISIT (409 CONFLICT) TESTS — Issue #844
+// =============================================================================
+
+// duplicateVisitActiveService wraps the real Active service and:
+//   - returns ErrStudentAlreadyActive on CreateVisit (without persisting)
+//   - no-ops EndVisit so the existing pre-created visit stays open and the
+//     handler's response builder finds it for the body details
+//
+// This deterministically simulates the production race scenario where the
+// application-level read-then-write check passes but the database-level
+// unique partial index rejects the insert.
+type duplicateVisitActiveService struct {
+	activeSvc.Service
+}
+
+func (d *duplicateVisitActiveService) CreateVisit(ctx context.Context, visit *active.Visit) error {
+	return &activeSvc.ActiveError{Op: "CreateVisit", Err: activeSvc.ErrStudentAlreadyActive}
+}
+
+func (d *duplicateVisitActiveService) EndVisit(ctx context.Context, id int64) error {
+	return nil
+}
+
+func TestDeviceCheckin_DuplicateActiveVisit_Returns409(t *testing.T) {
+	// Verifies that when CreateVisit reports ErrStudentAlreadyActive, the
+	// IoT handler returns 409 Conflict with the structured
+	// STUDENT_ALREADY_ACTIVE body (Issue #844). Includes existing visit
+	// metadata (visit_id, room_id, room_name, entry_time) so the kiosk can
+	// surface "Bereits angemeldet in <Raum>" instead of a generic error.
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "dup-409")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Dup", "ConflictStaff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Dup", "ConflictStudent", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("DUP409%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	roomA := testpkg.CreateTestRoom(t, ctx.db, "Conflict Room A")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, roomA.ID)
+	roomB := testpkg.CreateTestRoom(t, ctx.db, "Conflict Room B")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, roomB.ID)
+
+	activityA := testpkg.CreateTestActivityGroup(t, ctx.db, "Conflict Activity A")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activityA.ID)
+	activityB := testpkg.CreateTestActivityGroup(t, ctx.db, "Conflict Activity B")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activityB.ID)
+
+	activeGroupA := testpkg.CreateTestActiveGroup(t, ctx.db, activityA.ID, roomA.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activeGroupA.ID)
+	activeGroupB := testpkg.CreateTestActiveGroup(t, ctx.db, activityB.ID, roomB.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activeGroupB.ID)
+
+	// Pre-create an active visit in Room A. Once the CreateVisit-overriding
+	// wrapper kicks in (see below), EndVisit is also a no-op, so this visit
+	// stays open and the response builder loads it for the 409 body.
+	existingEntry := time.Now().Add(-5 * time.Minute)
+	existingVisit := testpkg.CreateTestVisit(t, ctx.db, student.ID, activeGroupA.ID, existingEntry, nil)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, existingVisit.ID)
+
+	// Build a Resource that injects the duplicate-visit failure path.
+	wrappedResource := checkinAPI.NewResource(
+		ctx.services.IoT,
+		ctx.services.Users,
+		&duplicateVisitActiveService{Service: ctx.services.Active},
+		ctx.services.Facilities,
+		ctx.services.Activities,
+		ctx.services.Education,
+		ctx.services.PickupSchedule,
+		nil,
+		slog.Default(),
+	)
+
+	router := testutil.NewTenantRouter(ctx.db)
+	router.Post("/checkin/checkin", wrappedResource.DeviceCheckinHandler())
+
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      roomB.ID,
+	}
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	require.Equal(t, http.StatusConflict, rr.Code, "expected 409 Conflict. Body: %s", rr.Body.String())
+
+	resp := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	assert.Equal(t, "error", resp["status"])
+	assert.Equal(t, "STUDENT_ALREADY_ACTIVE", resp["code"], "machine-readable code is the contract for PyrePortal mapping")
+	assert.Contains(t, resp["message"], "student already has an active visit",
+		"PyrePortal substring-matches this string for the German UI fallback")
+
+	details, ok := resp["details"].(map[string]interface{})
+	require.True(t, ok, "expected details object in 409 body. Body: %s", rr.Body.String())
+	assert.EqualValues(t, student.ID, details["student_id"], "student_id must surface so the kiosk can display context")
+	assert.EqualValues(t, existingVisit.ID, details["existing_visit_id"], "existing_visit_id must point to the still-open visit")
+	assert.EqualValues(t, roomA.ID, details["room_id"], "room_id must reflect the room of the existing visit, not the requested target room")
+	assert.Equal(t, roomA.Name, details["room_name"], "room_name must reflect the existing-visit's room")
 }

--- a/backend/api/iot/checkin/pyreportal_error_strings_test.go
+++ b/backend/api/iot/checkin/pyreportal_error_strings_test.go
@@ -67,6 +67,17 @@ var pyreportalCheckinErrorStrings = []string{
 	"ACTIVITY_CAPACITY_EXCEEDED",
 	"activity capacity exceeded",
 
+	// Duplicate active visit (POST /checkin) — 409 Conflict path added in
+	// migration 1.15.45. PyrePortal substring-matches the code to surface
+	// "Schüler*in ist bereits angemeldet" instead of the generic conflict
+	// fallback. The English message phrasing is the canonical
+	// active-service error from services/active/errors.go and is
+	// surfaced both as the response Message and as the typed Error()
+	// string so existing PyrePortal builds without the new code mapping
+	// still display a sensible message.
+	"STUDENT_ALREADY_ACTIVE",
+	"student already has an active visit",
+
 	// RFID lookup (POST /checkin, POST /pickup-query)
 	"RFID tag not found",
 	"RFID tag not assigned",

--- a/backend/api/iot/checkin/pyreportal_error_strings_test.go
+++ b/backend/api/iot/checkin/pyreportal_error_strings_test.go
@@ -68,7 +68,7 @@ var pyreportalCheckinErrorStrings = []string{
 	"activity capacity exceeded",
 
 	// Duplicate active visit (POST /checkin) — 409 Conflict path added in
-	// migration 1.15.45. PyrePortal substring-matches the code to surface
+	// migration 1.15.46. PyrePortal substring-matches the code to surface
 	// "Schüler*in ist bereits angemeldet" instead of the generic conflict
 	// fallback. The English message phrasing is the canonical
 	// active-service error from services/active/errors.go and is

--- a/backend/api/iot/checkin/workflow.go
+++ b/backend/api/iot/checkin/workflow.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/facilities"
 	"github.com/moto-nrw/project-phoenix/models/iot"
 	"github.com/moto-nrw/project-phoenix/models/users"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
 )
 
@@ -314,6 +315,32 @@ func (rs *Resource) loadCurrentVisitWithRoom(ctx context.Context, studentID int6
 	return currentVisit
 }
 
+// buildStudentAlreadyActiveResponse builds the 409 Conflict response body
+// for a duplicate-checkin attempt. It best-effort-loads the existing visit
+// so the kiosk can show "Bereits angemeldet in Raum X". The lookup is
+// deliberately tolerant: if it fails (race window between INSERT failure
+// and the response build, or the visit was just closed by another path),
+// we return the response with only StudentID set rather than upgrading the
+// 409 to a 500. The kiosk degrades to a generic "already checked in"
+// message in that case, which is still strictly better than the old 500.
+func (rs *Resource) buildStudentAlreadyActiveResponse(ctx context.Context, studentID int64) render.Renderer {
+	existing := rs.loadCurrentVisitWithRoom(ctx, studentID)
+	if existing == nil {
+		return iotCommon.ErrorStudentAlreadyActive(studentID, 0, time.Time{}, nil, "")
+	}
+
+	var roomID *int64
+	var roomName string
+	if existing.ActiveGroup != nil {
+		rid := existing.ActiveGroup.RoomID
+		roomID = &rid
+		if existing.ActiveGroup.Room != nil {
+			roomName = existing.ActiveGroup.Room.Name
+		}
+	}
+	return iotCommon.ErrorStudentAlreadyActive(studentID, existing.ID, existing.EntryTime, roomID, roomName)
+}
+
 // processCheckout handles the checkout logic for a student with an active visit
 // Returns: visitID, previousRoomName, error
 func (rs *Resource) processCheckout(ctx context.Context, w http.ResponseWriter, r *http.Request, student *users.Student, person *users.Person, currentVisit *active.Visit) (*int64, string, error) {
@@ -441,6 +468,21 @@ func (rs *Resource) processCheckin(ctx context.Context, w http.ResponseWriter, r
 		slog.Int64("active_group_id", selection.Group.ID),
 	)
 	if err := rs.ActiveService.CreateVisit(ctx, newVisit); err != nil {
+		// Duplicate active visit — race between two concurrent scans, or a
+		// previous checkout that didn't fully commit. Surface as 409 with
+		// the existing visit details so the kiosk can show "Bereits
+		// angemeldet in Raum X" instead of a generic error. The DB-level
+		// guard is migration 1.15.45's partial unique index; the
+		// application-level guard is ensureStudentHasNoActiveVisit in the
+		// active service. Either path translates to ErrStudentAlreadyActive.
+		if errors.Is(err, activeSvc.ErrStudentAlreadyActive) {
+			rs.getLogger().InfoContext(ctx, "duplicate active visit rejected",
+				slog.Int64("student_id", student.ID),
+				slog.String("error", err.Error()),
+			)
+			iotCommon.RenderError(w, r, rs.buildStudentAlreadyActiveResponse(ctx, student.ID))
+			return nil, nil, err
+		}
 		rs.getLogger().ErrorContext(ctx, "failed to create visit",
 			slog.Int64("student_id", student.ID),
 			slog.String("error", err.Error()),

--- a/backend/api/iot/checkin/workflow.go
+++ b/backend/api/iot/checkin/workflow.go
@@ -473,7 +473,7 @@ func (rs *Resource) processCheckin(ctx context.Context, w http.ResponseWriter, r
 		// previous checkout that didn't fully commit. Surface as 409 with
 		// the existing visit details so the kiosk can show "Bereits
 		// angemeldet in Raum X" instead of a generic error. The DB-level
-		// guard is migration 1.15.45's partial unique index; the
+		// guard is migration 1.15.46's partial unique index; the
 		// application-level guard is ensureStudentHasNoActiveVisit in the
 		// active service. Either path translates to ErrStudentAlreadyActive.
 		if errors.Is(err, activeSvc.ErrStudentAlreadyActive) {

--- a/backend/api/iot/checkin/workflow.go
+++ b/backend/api/iot/checkin/workflow.go
@@ -326,7 +326,7 @@ func (rs *Resource) loadCurrentVisitWithRoom(ctx context.Context, studentID int6
 func (rs *Resource) buildStudentAlreadyActiveResponse(ctx context.Context, studentID int64) render.Renderer {
 	existing := rs.loadCurrentVisitWithRoom(ctx, studentID)
 	if existing == nil {
-		return iotCommon.ErrorStudentAlreadyActive(studentID, 0, time.Time{}, nil, "")
+		return iotCommon.ErrorStudentAlreadyActive(studentID, 0, nil, nil, "")
 	}
 
 	var roomID *int64
@@ -338,7 +338,8 @@ func (rs *Resource) buildStudentAlreadyActiveResponse(ctx context.Context, stude
 			roomName = existing.ActiveGroup.Room.Name
 		}
 	}
-	return iotCommon.ErrorStudentAlreadyActive(studentID, existing.ID, existing.EntryTime, roomID, roomName)
+	entryTime := existing.EntryTime
+	return iotCommon.ErrorStudentAlreadyActive(studentID, existing.ID, &entryTime, roomID, roomName)
 }
 
 // processCheckout handles the checkout logic for a student with an active visit

--- a/backend/api/iot/common/errors.go
+++ b/backend/api/iot/common/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
@@ -117,6 +118,64 @@ func ErrorActivityCapacityExceeded(activityID int64, activityName string, curren
 			ActivityName:     activityName,
 			CurrentOccupancy: currentOccupancy,
 			MaxCapacity:      maxCapacity,
+		},
+	}
+}
+
+// StudentAlreadyActiveError carries the existing-visit context that the
+// kiosk surfaces to the user when a duplicate-checkin is rejected.
+//
+// All fields except StudentID are optional: ExistingVisitID is omitted when
+// the lookup couldn't load the prior visit (race window between the
+// failing INSERT and the response build), RoomID/RoomName are omitted when
+// the prior visit's active group has no associated room.
+type StudentAlreadyActiveError struct {
+	StudentID       int64     `json:"student_id"`
+	ExistingVisitID int64     `json:"existing_visit_id,omitempty"`
+	EntryTime       time.Time `json:"entry_time,omitempty"`
+	RoomID          *int64    `json:"room_id,omitempty"`
+	RoomName        string    `json:"room_name,omitempty"`
+}
+
+// Error implements the error interface for StudentAlreadyActiveError.
+// The substring "student already has an active visit" is the canonical
+// active-service phrasing (see services/active/errors.go) and is what
+// PyrePortal substring-matches on for the German UI translation.
+func (e *StudentAlreadyActiveError) Error() string {
+	return "student already has an active visit"
+}
+
+// StudentAlreadyActiveErrorResponse is the structured 409 body returned
+// when a duplicate-active-visit attempt is rejected. The shape mirrors
+// CapacityErrorResponse so PyrePortal can parse all checkin-conflict
+// responses through a single decoder.
+type StudentAlreadyActiveErrorResponse struct {
+	Status  string                     `json:"status"`
+	Message string                     `json:"message"`
+	Code    string                     `json:"code"`
+	Details *StudentAlreadyActiveError `json:"details"`
+}
+
+// Render implements render.Renderer
+func (e *StudentAlreadyActiveErrorResponse) Render(_ http.ResponseWriter, r *http.Request) error {
+	render.Status(r, http.StatusConflict)
+	return nil
+}
+
+// ErrorStudentAlreadyActive returns a 409 Conflict response with details
+// about the existing visit. existingVisitID, entryTime, roomID and
+// roomName may all be zero-valued — only studentID is required.
+func ErrorStudentAlreadyActive(studentID, existingVisitID int64, entryTime time.Time, roomID *int64, roomName string) render.Renderer {
+	return &StudentAlreadyActiveErrorResponse{
+		Status:  "error",
+		Message: "student already has an active visit",
+		Code:    "STUDENT_ALREADY_ACTIVE",
+		Details: &StudentAlreadyActiveError{
+			StudentID:       studentID,
+			ExistingVisitID: existingVisitID,
+			EntryTime:       entryTime,
+			RoomID:          roomID,
+			RoomName:        roomName,
 		},
 	}
 }

--- a/backend/api/iot/common/errors.go
+++ b/backend/api/iot/common/errors.go
@@ -129,12 +129,18 @@ func ErrorActivityCapacityExceeded(activityID int64, activityName string, curren
 // the lookup couldn't load the prior visit (race window between the
 // failing INSERT and the response build), RoomID/RoomName are omitted when
 // the prior visit's active group has no associated room.
+//
+// EntryTime is *time.Time rather than time.Time because encoding/json's
+// `omitempty` tag does not skip zero-valued struct fields — a value-typed
+// time.Time would marshal to "0001-01-01T00:00:00Z" in the degraded path,
+// breaking the optional-field contract and feeding clients a bogus
+// timestamp. A nil pointer is omitted correctly.
 type StudentAlreadyActiveError struct {
-	StudentID       int64     `json:"student_id"`
-	ExistingVisitID int64     `json:"existing_visit_id,omitempty"`
-	EntryTime       time.Time `json:"entry_time,omitempty"`
-	RoomID          *int64    `json:"room_id,omitempty"`
-	RoomName        string    `json:"room_name,omitempty"`
+	StudentID       int64      `json:"student_id"`
+	ExistingVisitID int64      `json:"existing_visit_id,omitempty"`
+	EntryTime       *time.Time `json:"entry_time,omitempty"`
+	RoomID          *int64     `json:"room_id,omitempty"`
+	RoomName        string     `json:"room_name,omitempty"`
 }
 
 // Error implements the error interface for StudentAlreadyActiveError.
@@ -164,8 +170,11 @@ func (e *StudentAlreadyActiveErrorResponse) Render(_ http.ResponseWriter, r *htt
 
 // ErrorStudentAlreadyActive returns a 409 Conflict response with details
 // about the existing visit. existingVisitID, entryTime, roomID and
-// roomName may all be zero-valued — only studentID is required.
-func ErrorStudentAlreadyActive(studentID, existingVisitID int64, entryTime time.Time, roomID *int64, roomName string) render.Renderer {
+// roomName may all be zero-valued — only studentID is required. Pass
+// entryTime as nil (not &time.Time{}) when the visit lookup couldn't
+// resolve the entry timestamp; the field is dropped from the JSON body
+// rather than serialized as the Go zero value.
+func ErrorStudentAlreadyActive(studentID, existingVisitID int64, entryTime *time.Time, roomID *int64, roomName string) render.Renderer {
 	return &StudentAlreadyActiveErrorResponse{
 		Status:  "error",
 		Message: "student already has an active visit",

--- a/backend/api/iot/common/errors_test.go
+++ b/backend/api/iot/common/errors_test.go
@@ -1,16 +1,19 @@
 package common_test
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	iotCommon "github.com/moto-nrw/project-phoenix/api/iot/common"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 	feedbackSvc "github.com/moto-nrw/project-phoenix/services/feedback"
 	iotSvc "github.com/moto-nrw/project-phoenix/services/iot"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test Error Variables
@@ -265,4 +268,70 @@ func TestActivityCapacityErrorResponse_Render(t *testing.T) {
 
 	err := resp.Render(w, r)
 	assert.NoError(t, err)
+}
+
+// TestErrorStudentAlreadyActive_DegradedPathOmitsOptionalFields verifies
+// the contract documented on StudentAlreadyActiveError: when the
+// duplicate-visit lookup fails (race window between the failing INSERT
+// and the response build), the 409 body must contain ONLY student_id —
+// every other field carries the JSON `omitempty` semantics so kiosks
+// don't render a bogus zero-valued timestamp ("0001-01-01T00:00:00Z")
+// or a phantom existing_visit_id of 0.
+//
+// Issue #844 review feedback: the original implementation used
+// EntryTime time.Time, which encoding/json does NOT skip for the zero
+// value (omitempty only applies to nil pointers, empty strings/slices,
+// 0 numbers, and false booleans — NOT struct zero values). Switching
+// to *time.Time fixes the contract.
+func TestErrorStudentAlreadyActive_DegradedPathOmitsOptionalFields(t *testing.T) {
+	renderer := iotCommon.ErrorStudentAlreadyActive(int64(42), 0, nil, nil, "")
+	resp, ok := renderer.(*iotCommon.StudentAlreadyActiveErrorResponse)
+	require.True(t, ok)
+	require.NotNil(t, resp.Details)
+
+	body, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &decoded))
+
+	assert.Equal(t, "STUDENT_ALREADY_ACTIVE", decoded["code"])
+	details, ok := decoded["details"].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.EqualValues(t, 42, details["student_id"], "student_id is the only required field")
+
+	// All other fields must be omitted when not provided. A regression here
+	// re-introduces the bogus "0001-01-01T00:00:00Z" / 0-valued IDs that
+	// the cross-repo contract with PyrePortal explicitly forbids.
+	assert.NotContains(t, details, "existing_visit_id", "must be omitted when 0")
+	assert.NotContains(t, details, "entry_time", "must be omitted when nil — see *time.Time choice on the struct")
+	assert.NotContains(t, details, "room_id", "must be omitted when nil")
+	assert.NotContains(t, details, "room_name", "must be omitted when empty")
+}
+
+// TestErrorStudentAlreadyActive_FullPathPreservesAllFields verifies
+// that when the existing-visit lookup succeeds, every detail field is
+// serialized so the kiosk can render "Bereits angemeldet in <Raum>".
+func TestErrorStudentAlreadyActive_FullPathPreservesAllFields(t *testing.T) {
+	entryTime := time.Date(2026, 4, 29, 14, 16, 30, 0, time.UTC)
+	roomID := int64(7)
+	renderer := iotCommon.ErrorStudentAlreadyActive(int64(42), int64(101), &entryTime, &roomID, "Klassenzimmer 2")
+	resp, ok := renderer.(*iotCommon.StudentAlreadyActiveErrorResponse)
+	require.True(t, ok)
+
+	body, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &decoded))
+
+	details, ok := decoded["details"].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.EqualValues(t, 42, details["student_id"])
+	assert.EqualValues(t, 101, details["existing_visit_id"])
+	assert.Equal(t, "2026-04-29T14:16:30Z", details["entry_time"])
+	assert.EqualValues(t, 7, details["room_id"])
+	assert.Equal(t, "Klassenzimmer 2", details["room_name"])
 }

--- a/backend/database/migrations/001015045_active_visits_unique_active_per_student.go
+++ b/backend/database/migrations/001015045_active_visits_unique_active_per_student.go
@@ -1,0 +1,103 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	activeVisitsUniqueActivePerStudentVersion     = "1.15.45"
+	activeVisitsUniqueActivePerStudentDescription = "Add partial UNIQUE(tenant_id, student_id) WHERE exit_time IS NULL on active.visits to block duplicate-active-visit races"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     activeVisitsUniqueActivePerStudentVersion,
+		Description: activeVisitsUniqueActivePerStudentDescription,
+		DependsOn: []string{
+			ActiveVisitsVersion, // 1.4.2 — active.visits
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return activeVisitsUniqueActivePerStudentUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return activeVisitsUniqueActivePerStudentDown(ctx, db)
+		},
+	)
+}
+
+func activeVisitsUniqueActivePerStudentUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.45: Closing duplicate active visits then adding partial unique index...")
+
+	// Pre-step: dedupe. CREATE UNIQUE INDEX would fail outright on any DB
+	// where the old race left more than one open visit per
+	// (tenant_id, student_id) — the very condition this migration exists to
+	// make impossible. Pick the row with the latest entry_time as the
+	// survivor; close every older duplicate by setting
+	// exit_time = entry_time + 1 second so the close timestamp follows the
+	// open one but doesn't claim a supervised checkout.
+	//
+	// This mirrors the cleanup pattern from 1.15.42
+	// (uniq_attendance_open_per_student_day): cleanup + index in one tx so
+	// the migration framework rolls everything back together if the index
+	// build fails.
+	res, err := db.NewRaw(`
+		WITH ranked AS (
+			SELECT id,
+			       ROW_NUMBER() OVER (
+			           PARTITION BY tenant_id, student_id
+			           ORDER BY entry_time DESC, id DESC
+			       ) AS rn,
+			       entry_time
+			FROM active.visits
+			WHERE exit_time IS NULL
+		)
+		UPDATE active.visits v
+		SET exit_time = ranked.entry_time + INTERVAL '1 second',
+		    updated_at = NOW()
+		FROM ranked
+		WHERE v.id = ranked.id
+		  AND ranked.rn > 1;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed deduping open visits before unique index: %w", err)
+	}
+	if affected, raErr := res.RowsAffected(); raErr == nil && affected > 0 {
+		fmt.Printf("Migration 1.15.45: closed %d duplicate active visit(s) before applying unique index\n", affected)
+	}
+
+	// Two concurrent checkin requests (kiosk + web, retry, race after a
+	// silent checkout failure) used to both pass the read-then-write
+	// idempotency check in services/active.ensureStudentHasNoActiveVisit
+	// and INSERT duplicate active visits. The partial unique index closes
+	// the race at the database layer; the repository maps the resulting
+	// 23505 to ErrStudentAlreadyActive so the IoT handler returns 409
+	// regardless of which path detected the conflict first.
+	if _, err := db.NewRaw(`
+		CREATE UNIQUE INDEX IF NOT EXISTS uniq_active_visits_open_per_student
+		ON active.visits (tenant_id, student_id)
+		WHERE exit_time IS NULL;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed creating uniq_active_visits_open_per_student: %w", err)
+	}
+
+	return nil
+}
+
+func activeVisitsUniqueActivePerStudentDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.45: dropping uniq_active_visits_open_per_student...")
+
+	// Cleanup of duplicate visits is intentionally NOT reversed — the closed
+	// rows were always invalid and re-opening them would corrupt active
+	// state. Only the index drops on rollback.
+	if _, err := db.NewRaw(`DROP INDEX IF EXISTS active.uniq_active_visits_open_per_student;`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed dropping uniq_active_visits_open_per_student: %w", err)
+	}
+
+	return nil
+}

--- a/backend/database/migrations/001015046_active_visits_unique_active_per_student.go
+++ b/backend/database/migrations/001015046_active_visits_unique_active_per_student.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	activeVisitsUniqueActivePerStudentVersion     = "1.15.45"
+	activeVisitsUniqueActivePerStudentVersion     = "1.15.46"
 	activeVisitsUniqueActivePerStudentDescription = "Add partial UNIQUE(tenant_id, student_id) WHERE exit_time IS NULL on active.visits to block duplicate-active-visit races"
 )
 
@@ -32,7 +32,7 @@ func init() {
 }
 
 func activeVisitsUniqueActivePerStudentUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.45: Closing duplicate active visits then adding partial unique index...")
+	fmt.Println("Migration 1.15.46: Closing duplicate active visits then adding partial unique index...")
 
 	// Pre-step: dedupe. CREATE UNIQUE INDEX would fail outright on any DB
 	// where the old race left more than one open visit per
@@ -68,7 +68,7 @@ func activeVisitsUniqueActivePerStudentUp(ctx context.Context, db *bun.DB) error
 		return fmt.Errorf("failed deduping open visits before unique index: %w", err)
 	}
 	if affected, raErr := res.RowsAffected(); raErr == nil && affected > 0 {
-		fmt.Printf("Migration 1.15.45: closed %d duplicate active visit(s) before applying unique index\n", affected)
+		fmt.Printf("Migration 1.15.46: closed %d duplicate active visit(s) before applying unique index\n", affected)
 	}
 
 	// Two concurrent checkin requests (kiosk + web, retry, race after a
@@ -90,7 +90,7 @@ func activeVisitsUniqueActivePerStudentUp(ctx context.Context, db *bun.DB) error
 }
 
 func activeVisitsUniqueActivePerStudentDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.45: dropping uniq_active_visits_open_per_student...")
+	fmt.Println("Rolling back migration 1.15.46: dropping uniq_active_visits_open_per_student...")
 
 	// Cleanup of duplicate visits is intentionally NOT reversed — the closed
 	// rows were always invalid and re-opening them would corrupt active

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -508,7 +508,7 @@ func (s *service) CreateVisit(ctx context.Context, visit *active.Visit) error {
 
 // isDuplicateActiveVisitViolation returns true when err carries PostgreSQL
 // error code 23505 (unique_violation) on the partial unique index
-// uniq_active_visits_open_per_student, defined in migration 1.15.45 on
+// uniq_active_visits_open_per_student, defined in migration 1.15.46 on
 // active.visits (tenant_id, student_id) WHERE exit_time IS NULL.
 //
 // We match by constraint name (Field 'n') rather than just the error code

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/driver/pgdriver"
 )
 
 // Broadcaster interface (re-exported from realtime for convenience)
@@ -476,7 +477,15 @@ func (s *service) CreateVisit(ctx context.Context, visit *active.Visit) error {
 
 	// Create the visit record
 	visit.SetTenantID(tenant.FromContext(ctx))
-	if s.visitRepo.Create(ctx, visit) != nil {
+	if err := s.visitRepo.Create(ctx, visit); err != nil {
+		// The partial unique index uniq_active_visits_open_per_student is the
+		// race-safety net behind ensureStudentHasNoActiveVisit above. When
+		// two concurrent requests both pass the read-then-write check, the
+		// loser hits 23505 here. Translate to ErrStudentAlreadyActive so the
+		// IoT handler maps it to 409 Conflict instead of 500.
+		if isDuplicateActiveVisitViolation(err) {
+			return &ActiveError{Op: "CreateVisit", Err: ErrStudentAlreadyActive}
+		}
 		return &ActiveError{Op: "CreateVisit", Err: ErrDatabaseOperation}
 	}
 
@@ -495,6 +504,30 @@ func (s *service) CreateVisit(ctx context.Context, visit *active.Visit) error {
 	s.broadcastVisitCreated(ctx, visit, snapshot)
 
 	return nil
+}
+
+// isDuplicateActiveVisitViolation returns true when err carries PostgreSQL
+// error code 23505 (unique_violation) on the partial unique index
+// uniq_active_visits_open_per_student, defined in migration 1.15.45 on
+// active.visits (tenant_id, student_id) WHERE exit_time IS NULL.
+//
+// We match by constraint name (Field 'n') rather than just the error code
+// so a future unrelated unique index on active.visits doesn't accidentally
+// translate into ErrStudentAlreadyActive.
+func isDuplicateActiveVisitViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var dbErr *base.DatabaseError
+	if errors.As(err, &dbErr) {
+		err = dbErr.Err
+	}
+	var pgErr pgdriver.Error
+	if errors.As(err, &pgErr) {
+		return pgErr.Field('C') == "23505" &&
+			pgErr.Field('n') == "uniq_active_visits_open_per_student"
+	}
+	return false
 }
 
 // isNotFoundError checks if an error is due to "not found" (sql.ErrNoRows) vs. other database errors

--- a/backend/services/active/error_helpers_test.go
+++ b/backend/services/active/error_helpers_test.go
@@ -4,9 +4,14 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/base"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Tests for isNotFoundError helper
@@ -45,5 +50,72 @@ func TestIsNotFoundError(t *testing.T) {
 		wrappedErr := errors.Join(errors.New("context"), dbErr)
 		// Note: errors.As will find the DatabaseError in the chain
 		assert.True(t, isNotFoundError(wrappedErr))
+	})
+}
+
+// Tests for isDuplicateActiveVisitViolation helper (Issue #844).
+//
+// This is the only test that exercises the partial unique index from
+// migration 1.15.45 end-to-end: it inserts one open visit, then attempts
+// a second open visit for the same (tenant_id, student_id) so PostgreSQL
+// raises 23505 on uniq_active_visits_open_per_student. The captured error
+// chain (*base.DatabaseError → bun → pgdriver.Error) is then fed into
+// isDuplicateActiveVisitViolation to verify both:
+//
+//  1. The migration's index actually rejects the duplicate at the DB layer.
+//  2. The detection function correctly identifies that error so
+//     service.CreateVisit translates it to ErrStudentAlreadyActive (and
+//     thus the IoT handler returns 409, not 500).
+//
+// Without this test, the unique-index → 23505 → ErrStudentAlreadyActive
+// path has zero coverage: the existing TestActiveService_CreateVisit
+// "returns ErrStudentAlreadyActive when student already has open visit"
+// short-circuits inside the app-level ensureStudentHasNoActiveVisit
+// check and never reaches visitRepo.Create.
+func TestIsDuplicateActiveVisitViolation(t *testing.T) {
+	t.Run("returns false for nil error", func(t *testing.T) {
+		assert.False(t, isDuplicateActiveVisitViolation(nil))
+	})
+
+	t.Run("returns false for unrelated error", func(t *testing.T) {
+		assert.False(t, isDuplicateActiveVisitViolation(errors.New("connection refused")))
+	})
+
+	t.Run("returns false for DatabaseError without pgdriver error", func(t *testing.T) {
+		err := &base.DatabaseError{Op: "create", Err: errors.New("not a pg error")}
+		assert.False(t, isDuplicateActiveVisitViolation(err))
+	})
+
+	t.Run("returns true for real 23505 violation on uniq_active_visits_open_per_student", func(t *testing.T) {
+		db := testpkg.SetupTestDB(t)
+		defer func() { _ = db.Close() }()
+
+		ctx := testpkg.TenantContext(1)
+		repo := repositories.NewFactory(db).ActiveVisit
+
+		// Hermetic fixtures.
+		student := testpkg.CreateTestStudent(t, db, "DupViol", "Student", "1a")
+		activity := testpkg.CreateTestActivityGroup(t, db, "DupViolActivity")
+		room := testpkg.CreateTestRoom(t, db, "DupViolRoom")
+		activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID, activity.ID, room.ID, activeGroup.ID)
+
+		// First insert: succeeds and stays open (exit_time IS NULL).
+		first := testpkg.CreateTestVisit(t, db, student.ID, activeGroup.ID, time.Now().Add(-1*time.Minute), nil)
+		defer testpkg.CleanupTableRecords(t, db, "active.visits", first.ID)
+
+		// Second insert: same (tenant_id=1, student_id, exit_time IS NULL)
+		// — must be rejected by uniq_active_visits_open_per_student.
+		duplicate := &activeModels.Visit{
+			StudentID:     student.ID,
+			ActiveGroupID: activeGroup.ID,
+			EntryTime:     time.Now(),
+		}
+		err := repo.Create(ctx, duplicate)
+
+		require.Error(t, err, "partial unique index from migration 1.15.45 must reject the second open visit")
+		assert.Equal(t, int64(0), duplicate.ID, "rejected insert must not assign an ID")
+		assert.True(t, isDuplicateActiveVisitViolation(err),
+			"detection helper must recognise the 23505 on uniq_active_visits_open_per_student so service.CreateVisit returns ErrStudentAlreadyActive (Issue #844). got: %v", err)
 	})
 }

--- a/backend/services/active/error_helpers_test.go
+++ b/backend/services/active/error_helpers_test.go
@@ -56,7 +56,7 @@ func TestIsNotFoundError(t *testing.T) {
 // Tests for isDuplicateActiveVisitViolation helper (Issue #844).
 //
 // This is the only test that exercises the partial unique index from
-// migration 1.15.45 end-to-end: it inserts one open visit, then attempts
+// migration 1.15.46 end-to-end: it inserts one open visit, then attempts
 // a second open visit for the same (tenant_id, student_id) so PostgreSQL
 // raises 23505 on uniq_active_visits_open_per_student. The captured error
 // chain (*base.DatabaseError → bun → pgdriver.Error) is then fed into
@@ -113,7 +113,7 @@ func TestIsDuplicateActiveVisitViolation(t *testing.T) {
 		}
 		err := repo.Create(ctx, duplicate)
 
-		require.Error(t, err, "partial unique index from migration 1.15.45 must reject the second open visit")
+		require.Error(t, err, "partial unique index from migration 1.15.46 must reject the second open visit")
 		assert.Equal(t, int64(0), duplicate.ID, "rejected insert must not assign an ID")
 		assert.True(t, isDuplicateActiveVisitViolation(err),
 			"detection helper must recognise the 23505 on uniq_active_visits_open_per_student so service.CreateVisit returns ErrStudentAlreadyActive (Issue #844). got: %v", err)

--- a/backend/services/active/visit_service_test.go
+++ b/backend/services/active/visit_service_test.go
@@ -138,6 +138,42 @@ func TestActiveService_CreateVisit(t *testing.T) {
 		// ASSERT
 		require.Error(t, err)
 	})
+
+	// Duplicate-active-visit path (Issue #844). Two paths can produce
+	// ErrStudentAlreadyActive: the application-level read-then-write check
+	// in ensureStudentHasNoActiveVisit (covers the common single-thread
+	// case) and the partial unique index from migration 1.15.45 (catches
+	// concurrent races that slip past the app check). Both must produce
+	// the same typed error so the IoT handler can map either to a 409.
+	t.Run("returns ErrStudentAlreadyActive when student already has open visit", func(t *testing.T) {
+		// ARRANGE
+		activity := testpkg.CreateTestActivityGroup(t, db, "dup-visit")
+		room := testpkg.CreateTestRoom(t, db, "Dup Visit Room")
+		activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+		student := testpkg.CreateTestStudent(t, db, "Duplicate", "Visit", "1a")
+		staff := testpkg.CreateTestStaff(t, db, "Dup", "Staff")
+		iotDevice := testpkg.CreateTestDevice(t, db, "dup-visit-device")
+		existing := testpkg.CreateTestVisit(t, db, student.ID, activeGroup.ID, time.Now().Add(-5*time.Minute), nil)
+		defer testpkg.CleanupActivityFixtures(t, db, activity.ID, room.ID, activeGroup.ID, student.ID, staff.ID, iotDevice.ID, existing.ID)
+
+		staffCtx := context.WithValue(ctx, device.CtxStaff, staff)
+		deviceCtx := context.WithValue(staffCtx, device.CtxDevice, iotDevice)
+
+		duplicate := &activeModels.Visit{
+			StudentID:     student.ID,
+			ActiveGroupID: activeGroup.ID,
+			EntryTime:     time.Now(),
+		}
+
+		// ACT
+		err := service.CreateVisit(deviceCtx, duplicate)
+
+		// ASSERT
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, active.ErrStudentAlreadyActive),
+			"expected ErrStudentAlreadyActive, got %v", err)
+		assert.Equal(t, int64(0), duplicate.ID, "duplicate visit must not be persisted")
+	})
 }
 
 // =============================================================================

--- a/backend/services/active/visit_service_test.go
+++ b/backend/services/active/visit_service_test.go
@@ -142,7 +142,7 @@ func TestActiveService_CreateVisit(t *testing.T) {
 	// Duplicate-active-visit path (Issue #844). Two paths can produce
 	// ErrStudentAlreadyActive: the application-level read-then-write check
 	// in ensureStudentHasNoActiveVisit (covers the common single-thread
-	// case) and the partial unique index from migration 1.15.45 (catches
+	// case) and the partial unique index from migration 1.15.46 (catches
 	// concurrent races that slip past the app check). Both must produce
 	// the same typed error so the IoT handler can map either to a 409.
 	t.Run("returns ErrStudentAlreadyActive when student already has open visit", func(t *testing.T) {

--- a/backend/test/hermetic_verification_test.go
+++ b/backend/test/hermetic_verification_test.go
@@ -166,6 +166,7 @@ func checkHardcodedIDs(t *testing.T, root string) []string {
 		"invitations_test.go",                                    // Uses mocks for handler tests
 		"error_helpers_test.go",                                  // Internal unit tests for helper functions (no DB)
 		"api/iot/api_test.go",                                    // Uses mock SchoolRepo for unit testing handler
+		"api/iot/common/errors_test.go",                          // Pure JSON-marshal regression tests for error renderers; int64 literals are throwaway IDs, not DB rows
 		"api/iot/config_test.go",                                 // Uses mock settings service for unit testing config endpoint
 		"enrich_pickup_times_test.go",                            // Uses mock PickupScheduleService for unit testing enrichment
 		"api/timetable/api_test.go",                              // Uses mock CalendarPeriodService for unit testing handlers


### PR DESCRIPTION
Closes #844. Companion kiosk PR: moto-nrw/PyrePortal#332.

## Problem
`POST /api/iot/checkin` returned HTTP 500 when a student already had an open
`active.visits` row (production log, student_id 231). 500 signals a server
error, so PyrePortal showed a generic failure and risked retry storms; the
condition is in fact a state conflict and should be a 409.

## What changes

### IoT checkin path (`api/iot/checkin`)
- Map `services/active.ErrStudentAlreadyActive` to **HTTP 409** with a
  structured body so the kiosk can render "Bereits angemeldet in <Raum>":
  ```json
  {
    "error": "student already has an active visit",
    "code": "STUDENT_ALREADY_ACTIVE",
    "details": {
      "student_id": 231,
      "existing_visit_id": 9123,
      "entry_time": "2026-02-05T13:14:22Z",
      "room_id": 12,
      "room_name": "Lernraum 2"
    }
  }
  ```
- `entry_time` is `*time.Time` so the degraded path (existing-visit lookup
  fails) drops the field instead of marshalling `0001-01-01T00:00:00Z`.

### Admin visits route (`api/active`)
- `ErrStudentAlreadyActive` was previously classified as 400 by
  `api/active.ErrorRenderer`. With the DB-level translation introduced
  below, every `CreateVisit` caller can now hit it, so the admin route
  would have surfaced the same state conflict as 400 while the IoT path
  returned 409. Both endpoints now agree on **409**.

### DB-level race close (migration 1.15.46)
- Adds partial unique index `uniq_active_visits_open_per_student` on
  `active.visits (tenant_id, student_id) WHERE exit_time IS NULL` so two
  concurrent checkins can't both pass the application-level idempotency
  check and double-insert.
- `services/active.CreateVisit` translates the resulting `pgerrcode 23505`
  on that constraint to `ErrStudentAlreadyActive`, so the read-then-write
  race and the steady-state duplicate hit the same 409 response.
- Migration also dedupes any existing duplicates (keeps the most recent
  open row per student) before the index is created, so it's safe to apply
  on environments that already drifted.

## Tests
- `TestDeviceCheckin_DuplicateActiveVisit_AppLevelPath_Returns409WithRoomDetails`
  — handler-level 409 + structured body for the application path.
- `TestErrorStudentAlreadyActive_*` — JSON shape on the full path and the
  degraded path (only `student_id` survives when the existing-visit lookup
  failed).
- `TestIsDuplicateActiveVisitViolation` — inserts an open visit, attempts a
  second open insert, and asserts the real
  `*base.DatabaseError → bun → pgdriver.Error` chain is recognised by the
  detection helper. Exercises the migration's index end-to-end.
- `TestErrorRenderer_StudentAlreadyActiveConflict` — guards the admin-route
  409 mapping so a future reshuffle can't silently regress it back to 400.

## Notes
- Migration version was bumped 1.15.45 → 1.15.46 because development picked
  up an unrelated `rooms_color_unique` migration on the same slot mid-flight
  (`MigrationRegistry` keys on the version string and silently overwrites
  on collision).
- Cross-repo contract: PyrePortal must match on `code: STUDENT_ALREADY_ACTIVE`
  and read `details.room_name` / `details.student_id` — see companion PR.