### PR TITLE
Show live group attendance counts

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/layout.tsx
+++ b/frontend/src/app/[tenant]/(protected)/layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BreadcrumbProvider } from "~/lib/breadcrumb-context";
+import { GroupAttendanceCountProvider } from "~/lib/group-attendance-count-context";
 import { TeacherShellProvider } from "~/lib/shell-auth-context";
 import { AppShell } from "~/components/dashboard/app-shell";
 import { AnnouncementModal } from "~/components/platform/announcement-modal";
@@ -13,7 +14,9 @@ export default function ProtectedLayout({
   return (
     <TeacherShellProvider>
       <BreadcrumbProvider>
-        <AppShell>{children}</AppShell>
+        <GroupAttendanceCountProvider>
+          <AppShell>{children}</AppShell>
+        </GroupAttendanceCountProvider>
         <AnnouncementModal />
       </BreadcrumbProvider>
     </TeacherShellProvider>

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.test.ts
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
+  countCheckedInStudents,
+  formatGroupLabelWithAttendance,
+  isStudentCheckedIn,
   isStudentInGroupRoom,
   matchesSearchFilter,
   matchesAttendanceFilter,
@@ -89,6 +92,49 @@ describe("isStudentInGroupRoom", () => {
     const student = makeStudent({ current_location: "Anwesend - Raum 2" });
     const group = makeGroup({ room_name: "Raum 1", room_id: undefined });
     expect(isStudentInGroupRoom(student, group)).toBe(false);
+  });
+});
+
+describe("attendance count helpers", () => {
+  it("counts present, transit, and schoolyard students as checked in", () => {
+    const students = [
+      makeStudent({ current_location: "Anwesend - Raum 1" }),
+      makeStudent({ current_location: "Unterwegs" }),
+      makeStudent({ current_location: "Schulhof" }),
+      makeStudent({ current_location: "Zuhause" }),
+      makeStudent({ current_location: "Unbekannt" }),
+      makeStudent({ current_location: undefined }),
+    ];
+
+    expect(countCheckedInStudents(students)).toBe(3);
+  });
+
+  it("does not count home, unknown, or empty locations as checked in", () => {
+    expect(
+      isStudentCheckedIn(makeStudent({ current_location: "Zuhause" })),
+    ).toBe(false);
+    expect(
+      isStudentCheckedIn(makeStudent({ current_location: "Unbekannt" })),
+    ).toBe(false);
+    expect(
+      isStudentCheckedIn(makeStudent({ current_location: undefined })),
+    ).toBe(false);
+  });
+
+  it("formats group labels with checked-in and total counts", () => {
+    const group = makeGroup({
+      name: "Eulen",
+      present_count: 12,
+      student_count: 18,
+    });
+
+    expect(formatGroupLabelWithAttendance(group)).toBe("Eulen 12/18");
+  });
+
+  it("keeps the plain group label before counts are loaded", () => {
+    expect(formatGroupLabelWithAttendance(makeGroup({ name: "Eulen" }))).toBe(
+      "Eulen",
+    );
   });
 });
 

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.ts
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/ogs-group-helpers.ts
@@ -1,5 +1,6 @@
 import type { Student } from "~/lib/api";
 import {
+  isPresentLocation,
   isHomeLocation,
   isSchoolyardLocation,
   isTransitLocation,
@@ -13,9 +14,38 @@ export interface OGSGroup {
   room_name?: string;
   room_id?: string;
   student_count?: number;
+  present_count?: number;
   supervisor_name?: string;
   students?: Student[];
   viaSubstitution?: boolean;
+}
+
+type StudentLocationLike = {
+  readonly current_location?: string | null;
+};
+
+export function isStudentCheckedIn(student: StudentLocationLike): boolean {
+  return (
+    isPresentLocation(student.current_location) ||
+    isSchoolyardLocation(student.current_location) ||
+    isTransitLocation(student.current_location)
+  );
+}
+
+export function countCheckedInStudents(
+  students: readonly StudentLocationLike[],
+): number {
+  return students.filter(isStudentCheckedIn).length;
+}
+
+export function formatGroupAttendanceCount(group?: OGSGroup | null): string {
+  if (!group || group.student_count === undefined) return "";
+  return `${group.present_count ?? 0}/${group.student_count}`;
+}
+
+export function formatGroupLabelWithAttendance(group: OGSGroup): string {
+  const attendanceCount = formatGroupAttendanceCount(group);
+  return attendanceCount ? `${group.name} ${attendanceCount}` : group.name;
 }
 
 export function isStudentInGroupRoom(

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.school-checkin.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.school-checkin.test.tsx
@@ -295,6 +295,16 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 vi.mock("./ogs-group-helpers", () => ({
+  countCheckedInStudents: (students: Array<{ current_location?: string }>) =>
+    students.filter((student) => student.current_location !== "Zuhause").length,
+  formatGroupLabelWithAttendance: (group: {
+    name: string;
+    present_count?: number;
+    student_count?: number;
+  }) =>
+    group.student_count === undefined
+      ? group.name
+      : `${group.name} ${group.present_count ?? 0}/${group.student_count}`,
   isStudentInGroupRoom: () => true,
   matchesSearchFilter: () => true,
   matchesAttendanceFilter: () => true,

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -187,6 +187,9 @@ vi.mock("~/lib/location-helper", () => ({
     GROUP_ROOM: "#83CD2D",
   },
   LOCATION_STATUSES: { PRESENT: "Anwesend" },
+  isPresentLocation: vi.fn((location?: string | null) =>
+    (location ?? "").startsWith("Anwesend"),
+  ),
   isHomeLocation: vi.fn(() => false),
   isSchoolyardLocation: vi.fn(() => false),
   isTransitLocation: vi.fn(() => false),

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -26,6 +26,8 @@ import {
   parseLocation,
 } from "~/lib/location-helper";
 import {
+  countCheckedInStudents,
+  formatGroupLabelWithAttendance,
   isStudentInGroupRoom,
   matchesSearchFilter,
   matchesAttendanceFilter,
@@ -39,6 +41,7 @@ import type { StaffWithRole, GroupTransfer } from "~/lib/group-transfer-api";
 import { useToast } from "~/contexts/ToastContext";
 import { useSWRAuth } from "~/lib/swr";
 import { useUserContext } from "~/lib/hooks/use-user-context";
+import { useGroupAttendanceCounts } from "~/lib/group-attendance-count-context";
 
 import { Loading } from "~/components/ui/loading";
 import { StudentPresenceBadge } from "@/components/ui/student-presence-badge";
@@ -146,6 +149,36 @@ interface OGSDashboardBFFResponse {
   firstGroupId: string | null;
 }
 
+function mapStudentForOgsPage(
+  student: Student | BackendStudentFromBFF,
+): Student {
+  if ("last_name" in student) {
+    return {
+      id: student.id.toString(),
+      name: `${student.first_name} ${student.last_name}`.trim(),
+      first_name: student.first_name,
+      second_name: student.last_name,
+      school_class: student.school_class ?? "",
+      current_location: student.current_location ?? "",
+      current_room_color: student.current_room_color ?? null,
+      sick: student.sick ?? false,
+      sick_since: student.sick_since,
+      excused: student.excused ?? false,
+      excused_since: student.excused_since,
+      location_since: student.location_since,
+      group_id: student.group_id?.toString(),
+      group_name: student.group_name,
+      arrival_time: student.arrival_time,
+      arrival_is_exception: student.arrival_is_exception,
+      arrival_notes: student.arrival_notes,
+      actual_arrival_time: student.actual_arrival_time,
+      actual_pickup_time: student.actual_pickup_time,
+    };
+  }
+
+  return student;
+}
+
 function OGSGroupPageContent() {
   const router = useTenantRouter();
   const searchParams = useSearchParams();
@@ -158,6 +191,7 @@ function OGSGroupPageContent() {
 
   const { success: showSuccessToast } = useToast();
   const { userContext } = useUserContext();
+  const { setGroupAttendanceCount } = useGroupAttendanceCounts();
 
   // Only binary-mode tenants expose the web check-in toggle; in detailed
   // mode the kiosk owns check-in/out and a parallel web button would
@@ -297,6 +331,11 @@ function OGSGroupPageContent() {
     // Update student count on the first sorted group (BFF pre-loads data for it)
     if (ogsGroups[0]) {
       ogsGroups[0].student_count = studentsData.length;
+      ogsGroups[0].present_count = countCheckedInStudents(studentsData);
+      setGroupAttendanceCount(ogsGroups[0].id, {
+        present: ogsGroups[0].present_count,
+        total: ogsGroups[0].student_count,
+      });
     }
 
     setAllGroups(ogsGroups);
@@ -322,27 +361,7 @@ function OGSGroupPageContent() {
       }
 
       // Map backend students to frontend format (last_name → second_name)
-      const mappedStudents: Student[] = studentsData.map((s) => ({
-        id: s.id.toString(),
-        name: `${s.first_name} ${s.last_name}`.trim(),
-        first_name: s.first_name,
-        second_name: s.last_name, // Backend uses last_name
-        school_class: s.school_class ?? "",
-        current_location: s.current_location ?? "",
-        current_room_color: s.current_room_color ?? null,
-        sick: s.sick ?? false,
-        sick_since: s.sick_since,
-        excused: s.excused ?? false,
-        excused_since: s.excused_since,
-        location_since: s.location_since,
-        group_id: s.group_id?.toString(),
-        group_name: s.group_name,
-        arrival_time: s.arrival_time,
-        arrival_is_exception: s.arrival_is_exception,
-        arrival_notes: s.arrival_notes,
-        actual_arrival_time: s.actual_arrival_time,
-        actual_pickup_time: s.actual_pickup_time,
-      }));
+      const mappedStudents = studentsData.map(mapStudentForOgsPage);
       setStudents(mappedStudents);
 
       // Set pickup times from BFF response (prevents loading flash)
@@ -387,7 +406,7 @@ function OGSGroupPageContent() {
     setActiveTransfers(transfers);
     setError(null);
     setIsLoading(false);
-  }, [dashboardData, selectedGroupId]);
+  }, [dashboardData, selectedGroupId, setGroupAttendanceCount]);
 
   // Sync selected group with URL param.
   // The sidebar navigates with the correct ?group= param at click-time,
@@ -466,6 +485,7 @@ function OGSGroupPageContent() {
   // Only fetches when hasAccess is confirmed and we have a group ID.
   // Includes room status and pickup times to prevent "loading flash" on student cards.
   const { data: swrStudentsData } = useSWRAuth<{
+    groupId: string;
     students: Student[];
     roomStatus?: Record<
       string,
@@ -542,6 +562,7 @@ function OGSGroupPageContent() {
       }
 
       return {
+        groupId: currentGroupId!,
         students,
         roomStatus: roomStatusResponse ?? undefined,
         pickupTimes: pickupTimesMap,
@@ -557,8 +578,31 @@ function OGSGroupPageContent() {
   // Sync SWR student data with local state
   // Also syncs room status and pickup times to keep UI in sync and prevent loading flash
   useEffect(() => {
+    if (swrStudentsData?.groupId !== currentGroupId) {
+      return;
+    }
+
     if (swrStudentsData?.students) {
-      setStudents(swrStudentsData.students);
+      const mappedStudents = swrStudentsData.students.map(mapStudentForOgsPage);
+      setStudents(mappedStudents);
+      if (currentGroupId) {
+        const presentCount = countCheckedInStudents(mappedStudents);
+        setGroupAttendanceCount(currentGroupId, {
+          present: presentCount,
+          total: mappedStudents.length,
+        });
+        setAllGroups((prev) =>
+          prev.map((group) =>
+            group.id === currentGroupId
+              ? {
+                  ...group,
+                  student_count: mappedStudents.length,
+                  present_count: presentCount,
+                }
+              : group,
+          ),
+        );
+      }
     }
     if (swrStudentsData?.roomStatus) {
       setRoomStatus(swrStudentsData.roomStatus);
@@ -568,7 +612,7 @@ function OGSGroupPageContent() {
     if (swrStudentsData?.pickupTimes instanceof Map) {
       setPickupTimes(swrStudentsData.pickupTimes);
     }
-  }, [swrStudentsData]);
+  }, [swrStudentsData, currentGroupId, setGroupAttendanceCount]);
 
   // Ref to track current group without triggering unnecessary re-renders
   const currentGroupRef = useRef<OGSGroup | null>(null);
@@ -775,14 +819,23 @@ function OGSGroupPageContent() {
         token: session?.user?.token,
       });
       const studentsData = studentsResponse.students || [];
+      const presentCount = countCheckedInStudents(studentsData);
 
       setStudents(studentsData);
+      setGroupAttendanceCount(groupId, {
+        present: presentCount,
+        total: studentsData.length,
+      });
 
       // Update group with actual student count
       setAllGroups((prev) =>
         prev.map((group) =>
           group.id === groupId
-            ? { ...group, student_count: studentsData.length }
+            ? {
+                ...group,
+                student_count: studentsData.length,
+                present_count: presentCount,
+              }
             : group,
         ),
       );
@@ -1275,7 +1328,9 @@ function OGSGroupPageContent() {
           <PageHeaderWithSearch
             title={
               isMobile && allGroups.length === 1
-                ? (currentGroup?.name ?? "Meine Gruppe")
+                ? currentGroup
+                  ? formatGroupLabelWithAttendance(currentGroup)
+                  : "Meine Gruppe"
                 : "" // No title when multiple groups (tabs show group names) or on desktop
             }
             actionButton={renderSubstitutionBadge("desktop")}
@@ -1298,8 +1353,7 @@ function OGSGroupPageContent() {
                 ? {
                     items: allGroups.map((group) => ({
                       id: group.id,
-                      label: group.name,
-                      count: group.student_count,
+                      label: formatGroupLabelWithAttendance(group),
                     })),
                     activeTab: currentGroup?.id ?? "",
                     onTabChange: (tabId) => {

--- a/frontend/src/components/dashboard/sidebar-sub-item.tsx
+++ b/frontend/src/components/dashboard/sidebar-sub-item.tsx
@@ -6,7 +6,7 @@ interface SidebarSubItemProps {
   readonly href: string;
   readonly label: string;
   readonly isActive: boolean;
-  readonly count?: number;
+  readonly count?: number | string;
 }
 
 export function SidebarSubItem({

--- a/frontend/src/components/dashboard/sidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar.tsx
@@ -17,6 +17,7 @@ import { operatorPath } from "~/lib/operator-url";
 import { useSidebarAccordion } from "~/lib/hooks/use-sidebar-accordion";
 import { useSuggestionsUnread } from "~/lib/hooks/use-suggestions-unread";
 import { useOperatorSuggestionsUnread } from "~/lib/hooks/use-operator-suggestions-unread";
+import { useGroupAttendanceCounts } from "~/lib/group-attendance-count-context";
 import { SidebarAccordionSection } from "~/components/dashboard/sidebar-accordion-section";
 import { SidebarSubItem } from "~/components/dashboard/sidebar-sub-item";
 import { navigationIcons } from "~/lib/navigation-icons";
@@ -326,6 +327,14 @@ function SidebarContent({ className = "" }: SidebarProps) {
   const userIsCaregiver = isCaregiver(session);
   const presenceMode = usePresenceMode();
   const isBinaryMode = presenceMode === "binary";
+  const { counts: groupAttendanceCounts } = useGroupAttendanceCounts();
+  const canShowGroupAttendanceCounts = pathname.startsWith("/ogs-groups");
+
+  const formatGroupAttendanceCount = (groupId: string | number) => {
+    if (!canShowGroupAttendanceCounts) return undefined;
+    const count = groupAttendanceCounts[groupId.toString()];
+    return count ? `${count.present}/${count.total}` : undefined;
+  };
 
   // Nav items hidden in binary-mode tenants. Rooms and Activities are room/visit
   // concepts with no operational meaning when the tenant only tracks
@@ -727,7 +736,16 @@ function SidebarContent({ className = "" }: SidebarProps) {
           {showStaffAccordions && (
             <SidebarAccordionSection
               icon="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-              label={groups.length > 1 ? "Meine Gruppen" : "Meine Gruppe"}
+              label={
+                groups.length > 1
+                  ? "Meine Gruppen"
+                  : [
+                      "Meine Gruppe",
+                      formatGroupAttendanceCount(groups[0]?.id ?? ""),
+                    ]
+                      .filter(Boolean)
+                      .join(" ")
+              }
               activeColor="text-[#83CD2D]"
               isExpanded={expanded === "groups"}
               onToggle={handleGroupsToggle}
@@ -749,6 +767,7 @@ function SidebarContent({ className = "" }: SidebarProps) {
                   key={group.id}
                   href={`/ogs-groups?group=${group.id}`}
                   label={group.name}
+                  count={formatGroupAttendanceCount(group.id)}
                   isActive={isGroupSubItemActive(
                     childGroupId,
                     group.id.toString(),

--- a/frontend/src/lib/group-attendance-count-context.tsx
+++ b/frontend/src/lib/group-attendance-count-context.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+interface GroupAttendanceCount {
+  readonly present: number;
+  readonly total: number;
+}
+
+interface GroupAttendanceCountContextValue {
+  readonly counts: Readonly<Record<string, GroupAttendanceCount>>;
+  readonly setGroupAttendanceCount: (
+    groupId: string,
+    count: GroupAttendanceCount,
+  ) => void;
+}
+
+const GroupAttendanceCountContext =
+  createContext<GroupAttendanceCountContextValue | null>(null);
+
+const EMPTY_GROUP_ATTENDANCE_COUNTS: GroupAttendanceCountContextValue = {
+  counts: {},
+  setGroupAttendanceCount: () => {},
+};
+
+export function GroupAttendanceCountProvider({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const [counts, setCounts] = useState<Record<string, GroupAttendanceCount>>(
+    {},
+  );
+
+  const setGroupAttendanceCount = useCallback(
+    (groupId: string, count: GroupAttendanceCount) => {
+      setCounts((prev) => {
+        const existing = prev[groupId];
+        if (
+          existing &&
+          existing.present === count.present &&
+          existing.total === count.total
+        ) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          [groupId]: count,
+        };
+      });
+    },
+    [],
+  );
+
+  const value = useMemo(
+    () => ({ counts, setGroupAttendanceCount }),
+    [counts, setGroupAttendanceCount],
+  );
+
+  return (
+    <GroupAttendanceCountContext.Provider value={value}>
+      {children}
+    </GroupAttendanceCountContext.Provider>
+  );
+}
+
+export function useGroupAttendanceCounts() {
+  const context = useContext(GroupAttendanceCountContext);
+  return context ?? EMPTY_GROUP_ATTENDANCE_COUNTS;
+}


### PR DESCRIPTION
## Summary
- show checked-in/total attendance counts beside OGS group labels
- surface counts in the desktop sidebar while keeping the mobile group labels updated
- share the already-derived OGS page counts with the persistent shell instead of adding a sidebar fetch

## Validation
- pnpm --dir frontend run check
- pnpm --dir frontend exec vitest run src/app/'[tenant]'/'(protected)'/ogs-groups/ogs-group-helpers.test.ts src/app/'[tenant]'/'(protected)'/ogs-groups/page.test.tsx src/components/dashboard/sidebar.test.tsx src/components/dashboard/sidebar-sub-item.test.tsx --reporter=dot
- pre-push: git-secrets, frontend-knip, frontend-check

## Notes
Counts are live for groups whose student list has been loaded by the OGS page. The currently open group updates through the existing SSE/SWR invalidation path.