### PR TITLE
ci(deploy): Slack notifications for staging and production deploys

### DIFF
--- a/.github/actions/notify-deploy-slack/action.yml
+++ b/.github/actions/notify-deploy-slack/action.yml
@@ -1,0 +1,99 @@
+name: Notify Deploy Slack
+description: Send Slack notification for deploy outcomes (success, failure, cancelled) via Incoming Webhook
+
+inputs:
+  webhook_url:
+    description: "Slack Incoming Webhook URL"
+    required: true
+  job_status:
+    description: "GitHub job.status (success, failure, cancelled)"
+    required: true
+  environment:
+    description: "Target environment (staging, production)"
+    required: true
+  exit_code:
+    description: "Exit code from deploy script (0=ok, 1=pre-deploy abort, 10=rolled back, 11=rollback failed). Empty for non-deploy notifications."
+    required: false
+    default: ""
+  run_url:
+    description: "Full URL to the GitHub Actions run"
+    required: true
+  commit_url:
+    description: "Full URL to the commit"
+    required: true
+  sha:
+    description: "Commit SHA (truncated to 7 chars for display)"
+    required: true
+  actor:
+    description: "GitHub actor who triggered the workflow"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        WEBHOOK_URL: ${{ inputs.webhook_url }}
+        JOB_STATUS: ${{ inputs.job_status }}
+        ENV: ${{ inputs.environment }}
+        EXIT_CODE: ${{ inputs.exit_code }}
+        RUN_URL: ${{ inputs.run_url }}
+        COMMIT_URL: ${{ inputs.commit_url }}
+        INPUT_SHA: ${{ inputs.sha }}
+        ACTOR: ${{ inputs.actor }}
+      run: |
+        if [ -z "$WEBHOOK_URL" ]; then
+          echo "::warning::SLACK_DEPLOY_WEBHOOK secret not set, skipping Slack notification"
+          exit 0
+        fi
+
+        SHORT_SHA=$(echo "$INPUT_SHA" | cut -c1-7)
+
+        if [ "$ENV" = "production" ]; then
+          DISPLAY_ENV="Production"
+        else
+          DISPLAY_ENV="$(echo "$ENV" | sed 's/./\U&/')"
+        fi
+
+        # Map (job_status, exit_code) to (emoji, headline)
+        if [ "$JOB_STATUS" = "success" ]; then
+          EMOJI=":white_check_mark:"
+          HEADLINE="$DISPLAY_ENV deploy succeeded"
+        elif [ "$JOB_STATUS" = "cancelled" ]; then
+          EMOJI=":no_entry_sign:"
+          HEADLINE="$DISPLAY_ENV deploy cancelled"
+        elif [ "$EXIT_CODE" = "11" ]; then
+          EMOJI=":rotating_light:"
+          HEADLINE="$DISPLAY_ENV deploy + rollback FAILED — manual intervention required"
+        elif [ "$EXIT_CODE" = "10" ]; then
+          EMOJI=":warning:"
+          HEADLINE="$DISPLAY_ENV deploy failed — rolled back to previous version"
+        elif [ "$EXIT_CODE" = "1" ]; then
+          EMOJI=":warning:"
+          HEADLINE="$DISPLAY_ENV deploy aborted — no changes applied"
+        else
+          EMOJI=":x:"
+          HEADLINE="$DISPLAY_ENV deploy failed"
+        fi
+
+        TEXT="${EMOJI} *${HEADLINE}*\nCommit: <${COMMIT_URL}|\`${SHORT_SHA}\`> by ${ACTOR}\n<${RUN_URL}|View run →>"
+
+        # Best-effort: notification failures must never mask the real deploy outcome.
+        if ! PAYLOAD=$(jq -n --arg text "$TEXT" '{text: $text}' 2>&1); then
+          echo "::warning::Failed to build Slack payload (non-critical): $PAYLOAD"
+          exit 0
+        fi
+
+        if ! HTTP_RESPONSE=$(curl -sS -o /tmp/slack_response.txt -w "%{http_code}" \
+          -X POST "$WEBHOOK_URL" \
+          -H "Content-Type: application/json" \
+          -d "$PAYLOAD" 2>&1); then
+          echo "::warning::Slack notification request failed (non-critical): $HTTP_RESPONSE"
+          exit 0
+        fi
+
+        if [ "$HTTP_RESPONSE" -ge 200 ] 2>/dev/null && [ "$HTTP_RESPONSE" -lt 300 ] 2>/dev/null; then
+          echo "Slack notification sent (HTTP $HTTP_RESPONSE)"
+        else
+          echo "::warning::Slack notification rejected (HTTP $HTTP_RESPONSE, non-critical): $(cat /tmp/slack_response.txt 2>/dev/null)"
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,6 +316,19 @@ jobs:
           sha: ${{ github.sha }}
           actor: ${{ github.actor }}
 
+      - name: Notify Slack
+        if: always()
+        uses: ./.github/actions/notify-deploy-slack
+        with:
+          webhook_url: ${{ secrets.SLACK_DEPLOY_WEBHOOK }}
+          job_status: ${{ job.status }}
+          environment: staging
+          exit_code: ${{ steps.deploy.outputs.deploy_exit }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          commit_url: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          sha: ${{ github.sha }}
+          actor: ${{ github.actor }}
+
   # Deploy to production with automatic rollback on failure
   # Exit codes from deploy-remote.sh: 0=success, 1=pre-deploy abort, 10=rollback ok, 11=rollback failed
   deploy-production:
@@ -388,6 +401,19 @@ jobs:
           environment: production
           resend_api_key: ${{ secrets.RESEND_API_KEY }}
           notify_emails: ${{ vars.DEPLOY_NOTIFY_EMAILS }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          commit_url: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          sha: ${{ github.sha }}
+          actor: ${{ github.actor }}
+
+      - name: Notify Slack
+        if: always()
+        uses: ./.github/actions/notify-deploy-slack
+        with:
+          webhook_url: ${{ secrets.SLACK_DEPLOY_WEBHOOK }}
+          job_status: ${{ job.status }}
+          environment: production
+          exit_code: ${{ steps.deploy.outputs.deploy_exit }}
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           commit_url: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
           sha: ${{ github.sha }}


### PR DESCRIPTION
## Summary

- Adds composite action `.github/actions/notify-deploy-slack/` that posts deploy outcomes (success / failure / cancelled / rollback) to a Slack Incoming Webhook
- Wires it into `deploy-staging` and `deploy-production` jobs with `if: always()` so **every** deploy is notified, not only failures
- Notification is best-effort: missing secret or Slack API error is logged as a warning and never masks the real deploy outcome
- Replaces the (currently silent) Blacksmith monitor approach, which never triggered because deploy jobs run on `ubuntu-latest`, not on Blacksmith runners

## Notification matrix

| Job status | Exit code | Slack headline |
|------------|-----------|---------------|
| success | 0 | ✅ Production deploy succeeded |
| cancelled | — | 🚫 Production deploy cancelled |
| failure | 1 | ⚠️ Production deploy aborted — no changes applied |
| failure | 10 | ⚠️ Production deploy failed — rolled back to previous version |
| failure | 11 | 🚨 Production deploy + rollback FAILED — manual intervention required |
| failure | other | ❌ Production deploy failed |

## Required setup before merge

1. Create a Slack Incoming Webhook (App in Ganztagshelden workspace, channel `#development`)
2. Add the webhook URL as GitHub repository secret `SLACK_DEPLOY_WEBHOOK`

If the secret is missing, the step exits with a warning, the deploy still completes normally.

## Test plan

- [x] Add `SLACK_DEPLOY_WEBHOOK` secret in GitHub repo settings before merge
- [ ] Merge to `development` → triggers `deploy-staging`, expect a ✅ message in `#development`
- [ ] Verify message contains commit SHA link, actor, and run URL
- [ ] Optional: temporarily break a staging deploy step to verify failure path renders correctly
- [ ] After staging green: merge release PR `development → main` and verify production deploy posts to `#development`
- [ ] Decommission the `deploy-production failures or successes` Blacksmith monitor once Slack notifications are confirmed working