### PR TITLE
fix(ci): render Slack deploy notification mrkdwn, newlines and emoji correctly

### DIFF
--- a/.github/actions/notify-deploy-slack/action.yml
+++ b/.github/actions/notify-deploy-slack/action.yml
@@ -55,31 +55,58 @@ runs:
           DISPLAY_ENV="$(echo "$ENV" | sed 's/./\U&/')"
         fi
 
-        # Map (job_status, exit_code) to (emoji, headline)
+        # Map (job_status, exit_code) to (emoji, headline). Use Unicode emoji so
+        # rendering doesn't depend on Slack's :shortcode: → emoji conversion.
         if [ "$JOB_STATUS" = "success" ]; then
-          EMOJI=":white_check_mark:"
+          EMOJI="✅"
           HEADLINE="$DISPLAY_ENV deploy succeeded"
         elif [ "$JOB_STATUS" = "cancelled" ]; then
-          EMOJI=":no_entry_sign:"
+          EMOJI="🚫"
           HEADLINE="$DISPLAY_ENV deploy cancelled"
         elif [ "$EXIT_CODE" = "11" ]; then
-          EMOJI=":rotating_light:"
+          EMOJI="🚨"
           HEADLINE="$DISPLAY_ENV deploy + rollback FAILED — manual intervention required"
         elif [ "$EXIT_CODE" = "10" ]; then
-          EMOJI=":warning:"
+          EMOJI="⚠️"
           HEADLINE="$DISPLAY_ENV deploy failed — rolled back to previous version"
         elif [ "$EXIT_CODE" = "1" ]; then
-          EMOJI=":warning:"
+          EMOJI="⚠️"
           HEADLINE="$DISPLAY_ENV deploy aborted — no changes applied"
         else
-          EMOJI=":x:"
+          EMOJI="❌"
           HEADLINE="$DISPLAY_ENV deploy failed"
         fi
 
-        TEXT="${EMOJI} *${HEADLINE}*\nCommit: <${COMMIT_URL}|\`${SHORT_SHA}\`> by ${ACTOR}\n<${RUN_URL}|View run →>"
-
+        # Build the payload entirely inside jq so newlines and JSON escaping are
+        # handled in one pass. Block Kit guarantees mrkdwn rendering for bold
+        # text and <url|label> links, which the bare {text: ...} field does not
+        # render reliably for newer webhook apps.
         # Best-effort: notification failures must never mask the real deploy outcome.
-        if ! PAYLOAD=$(jq -n --arg text "$TEXT" '{text: $text}' 2>&1); then
+        if ! PAYLOAD=$(jq -n \
+          --arg emoji "$EMOJI" \
+          --arg headline "$HEADLINE" \
+          --arg commit_url "$COMMIT_URL" \
+          --arg sha "$SHORT_SHA" \
+          --arg actor "$ACTOR" \
+          --arg run_url "$RUN_URL" \
+          '{
+            text: "\($emoji) \($headline) — commit \($sha)",
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "\($emoji) *\($headline)*\nCommit: <\($commit_url)|`\($sha)`> by *\($actor)*"
+                }
+              },
+              {
+                type: "context",
+                elements: [
+                  { type: "mrkdwn", text: "<\($run_url)|View run →>" }
+                ]
+              }
+            ]
+          }' 2>&1); then
           echo "::warning::Failed to build Slack payload (non-critical): $PAYLOAD"
           exit 0
         fi


### PR DESCRIPTION
## Summary

The first staging deploy notification (run 25193637696) posted to `#development` as raw text:

```
:white_check_mark: *Staging deploy succeeded*\nCommit: 109748c by yungweng\nView run →
```

Three visible issues: literal `\n`, literal `*asterisks*`, literal `:shortcode:` emoji, and unclickable URLs.

## Root cause analysis

### Confirmed: newline bug

The message was built in a bash double-quoted string:

```bash
TEXT="${EMOJI} *${HEADLINE}*\nCommit: ..."
```

Bash double quotes do **not** interpret `\n` as a newline. The variable contained two literal characters (`\` + `n`). When `jq --arg text "$TEXT"` JSON-encoded it, the literal backslash got escaped to `\\`, so the wire format became `"\\n"`. JSON-decoded by Slack, that's the two characters `\n` again — rendered verbatim.

Verified empirically:

```text
$ TEXT="foo\nbar"; printf '%s' "$TEXT" | od -c
0000000   f   o   o   \   n   b   a   r           # two chars, not a newline

$ jq -n --arg t 'foo\nbar' '{text: $t}'
{ "text": "foo\\nbar" }                            # backslash escaped

$ jq -n '{text: "foo\nbar"}'
{ "text": "foo\nbar" }                             # real JSON newline escape
```

This is the dominant bug and the fix is unambiguous: build the payload entirely inside `jq -n` so `\n` lives inside a jq string literal (where it IS a newline) and JSON encoding happens in one pass.

### Less certain: why mrkdwn / emoji didn't render

The PR previously claimed "Slack apps created via the new flow render the bare `{text: ...}` field as plain text". That claim is **not backed by Slack's documentation** — Slack's docs say mrkdwn is the default for `chat.postMessage`'s `text` field, but for incoming webhooks the rendering behavior of the bare `text` field is **undocumented**.

Plausible alternatives:
1. The embedded literal `\n` may have caused Slack's mrkdwn parser to fall through to plain-text rendering for the whole message
2. Slack returned **HTTP 200** (verified in the workflow log: `Slack notification sent (HTTP 200)`), so this was not a validation error — purely a rendering behavior question
3. Possible copy-paste artifacts in what was reported (no screenshot to compare against the actual rendered message)

So the mrkdwn portion of the fix is **defensive**, not a proven fix for a known bug. We move to Block Kit because:

- Slack docs explicitly recommend Block Kit for formatted content
- Block Kit's `type: "mrkdwn"` text objects guarantee mrkdwn rendering deterministically
- Once newlines are real newlines, the `text` field might already render correctly — we won't know until we test

## Fix

- Build the entire payload inside a single `jq -n` call so newlines and JSON escaping happen in one pass
- Emit Block Kit blocks (one `section` + one `context`) with explicit `type: "mrkdwn"` text objects so mrkdwn rendering is deterministic
- Swap `:shortcode:` emoji for Unicode characters (`✅`, `⚠️`, `🚨`, `🚫`, `❌`) so they render outside mrkdwn contexts and in mobile push previews
- Keep the `text` field as a plain-text fallback for notifications and clients without Block Kit support

Local jq dry-run produces:

```json
{
  "text": "✅ Staging deploy succeeded — commit abc1234",
  "blocks": [
    {
      "type": "section",
      "text": {
        "type": "mrkdwn",
        "text": "✅ *Staging deploy succeeded*\nCommit: <https://.../commit/abc1234|`abc1234`> by *yungweng*"
      }
    },
    {
      "type": "context",
      "elements": [
        { "type": "mrkdwn", "text": "<https://.../actions/runs/123|View run →>" }
      ]
    }
  ]
}
```

The `\n` in the `mrkdwn` text is now a JSON-encoded newline (single backslash + n in the JSON wire format), which Slack decodes to a real line break.

## Test plan

- [ ] Merge to `development` → triggers `deploy-staging`
- [ ] **Screenshot** the rendered Slack message (not copy-paste — Slack copy-paste can drop formatting)
- [ ] Confirm in the screenshot: ✅ rendered as emoji, *Staging deploy succeeded* in bold, `109748c` is a clickable code-styled link, "View run →" is a smaller context-block link, no literal `\n` visible
- [ ] Workflow log shows `Slack notification sent (HTTP 200)` (Slack returns 400 if Block Kit is malformed)
- [ ] If anything still renders wrong, capture the exact JSON that was sent (we may need to log the payload at debug level temporarily)
- [ ] After staging green: trigger production via the next release PR and verify the production message renders identically