### PR TITLE
Fix active visits migration collision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,10 +80,35 @@ jobs:
             echo "✅ Release - will build and deploy to production"
           fi
 
+  validate-migrations:
+    runs-on: ubuntu-latest
+    needs: [check-environment]
+    if: needs.check-environment.outputs.should_deploy == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go with cache
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: backend/go.mod
+          cache: true
+          cache-dependency-path: backend/go.sum
+
+      - name: Validate migration registry
+        working-directory: backend
+        run: go run main.go migrate validate
+
+      - name: Check migration version collisions
+        working-directory: backend
+        run: go test ./database/migrations/ -run TestNoDuplicateMigrationVersions -v
+
   # Build and push backend image
   build-backend:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [check-environment]
+    needs: [check-environment, validate-migrations]
     if: needs.check-environment.outputs.should_deploy == 'true'
     # Cancel superseded builds on rapid pushes to the same ref. Deploy jobs
     # have their own concurrency groups, so they are NOT affected.
@@ -144,7 +169,7 @@ jobs:
   # Build and push frontend image
   build-frontend:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [check-environment]
+    needs: [check-environment, validate-migrations]
     if: needs.check-environment.outputs.should_deploy == 'true'
     # Cancel superseded builds on rapid pushes to the same ref. Deploy jobs
     # have their own concurrency groups, so they are NOT affected.
@@ -422,17 +447,18 @@ jobs:
   # Summary job for branch protection
   build-status:
     runs-on: ubuntu-latest
-    needs: [check-environment, build-backend, build-frontend]
+    needs: [check-environment, validate-migrations, build-backend, build-frontend]
     if: always() && needs.check-environment.outputs.should_deploy == 'true'
     steps:
       - name: Check build status
         run: |
-          if [[ "${{ needs.build-backend.result }}" == "success" && "${{ needs.build-frontend.result }}" == "success" ]]; then
+          if [[ "${{ needs.validate-migrations.result }}" == "success" && "${{ needs.build-backend.result }}" == "success" && "${{ needs.build-frontend.result }}" == "success" ]]; then
             echo "✅ All images built and pushed successfully"
             echo "Backend: ${{ env.BACKEND_IMAGE }}"
             echo "Frontend: ${{ env.FRONTEND_IMAGE }}"
           else
             echo "❌ Build failed"
+            echo "Migrations: ${{ needs.validate-migrations.result }}"
             echo "Backend: ${{ needs.build-backend.result }}"
             echo "Frontend: ${{ needs.build-frontend.result }}"
             exit 1

--- a/backend/api/iot/checkin/checkin_test.go
+++ b/backend/api/iot/checkin/checkin_test.go
@@ -3294,7 +3294,7 @@ func TestDeviceCheckin_DuplicateActiveVisit_AppLevelPath_Returns409WithRoomDetai
 	// instead of a generic error.
 	//
 	// The DB-race path (where visitRepo.Create itself trips the partial
-	// unique index from migration 1.15.46) is NOT exercised here — see
+	// unique index from migration 1.15.47) is NOT exercised here — see
 	// the package note on duplicateVisitActiveService above.
 	ctx := setupTestContext(t)
 	defer func() { _ = ctx.db.Close() }()

--- a/backend/api/iot/checkin/pyreportal_error_strings_test.go
+++ b/backend/api/iot/checkin/pyreportal_error_strings_test.go
@@ -68,7 +68,7 @@ var pyreportalCheckinErrorStrings = []string{
 	"activity capacity exceeded",
 
 	// Duplicate active visit (POST /checkin) — 409 Conflict path added in
-	// migration 1.15.46. PyrePortal substring-matches the code to surface
+	// migration 1.15.47. PyrePortal substring-matches the code to surface
 	// "Schüler*in ist bereits angemeldet" instead of the generic conflict
 	// fallback. The English message phrasing is the canonical
 	// active-service error from services/active/errors.go and is

--- a/backend/api/iot/checkin/workflow.go
+++ b/backend/api/iot/checkin/workflow.go
@@ -473,7 +473,7 @@ func (rs *Resource) processCheckin(ctx context.Context, w http.ResponseWriter, r
 		// previous checkout that didn't fully commit. Surface as 409 with
 		// the existing visit details so the kiosk can show "Bereits
 		// angemeldet in Raum X" instead of a generic error. The DB-level
-		// guard is migration 1.15.46's partial unique index; the
+		// guard is migration 1.15.47's partial unique index; the
 		// application-level guard is ensureStudentHasNoActiveVisit in the
 		// active service. Either path translates to ErrStudentAlreadyActive.
 		if errors.Is(err, activeSvc.ErrStudentAlreadyActive) {

--- a/backend/database/migrations/001015047_active_visits_unique_active_per_student.go
+++ b/backend/database/migrations/001015047_active_visits_unique_active_per_student.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	activeVisitsUniqueActivePerStudentVersion     = "1.15.46"
+	activeVisitsUniqueActivePerStudentVersion     = "1.15.47"
 	activeVisitsUniqueActivePerStudentDescription = "Add partial UNIQUE(tenant_id, student_id) WHERE exit_time IS NULL on active.visits to block duplicate-active-visit races"
 )
 
@@ -32,7 +32,7 @@ func init() {
 }
 
 func activeVisitsUniqueActivePerStudentUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.46: Closing duplicate active visits then adding partial unique index...")
+	fmt.Println("Migration 1.15.47: Closing duplicate active visits then adding partial unique index...")
 
 	// Pre-step: dedupe. CREATE UNIQUE INDEX would fail outright on any DB
 	// where the old race left more than one open visit per
@@ -68,7 +68,7 @@ func activeVisitsUniqueActivePerStudentUp(ctx context.Context, db *bun.DB) error
 		return fmt.Errorf("failed deduping open visits before unique index: %w", err)
 	}
 	if affected, raErr := res.RowsAffected(); raErr == nil && affected > 0 {
-		fmt.Printf("Migration 1.15.46: closed %d duplicate active visit(s) before applying unique index\n", affected)
+		fmt.Printf("Migration 1.15.47: closed %d duplicate active visit(s) before applying unique index\n", affected)
 	}
 
 	// Two concurrent checkin requests (kiosk + web, retry, race after a
@@ -90,7 +90,7 @@ func activeVisitsUniqueActivePerStudentUp(ctx context.Context, db *bun.DB) error
 }
 
 func activeVisitsUniqueActivePerStudentDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.46: dropping uniq_active_visits_open_per_student...")
+	fmt.Println("Rolling back migration 1.15.47: dropping uniq_active_visits_open_per_student...")
 
 	// Cleanup of duplicate visits is intentionally NOT reversed — the closed
 	// rows were always invalid and re-opening them would corrupt active

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -511,7 +511,7 @@ func (s *service) CreateVisit(ctx context.Context, visit *active.Visit) error {
 
 // isDuplicateActiveVisitViolation returns true when err carries PostgreSQL
 // error code 23505 (unique_violation) on the partial unique index
-// uniq_active_visits_open_per_student, defined in migration 1.15.46 on
+// uniq_active_visits_open_per_student, defined in migration 1.15.47 on
 // active.visits (tenant_id, student_id) WHERE exit_time IS NULL.
 //
 // We match by constraint name (Field 'n') rather than just the error code

--- a/backend/services/active/error_helpers_test.go
+++ b/backend/services/active/error_helpers_test.go
@@ -56,7 +56,7 @@ func TestIsNotFoundError(t *testing.T) {
 // Tests for isDuplicateActiveVisitViolation helper (Issue #844).
 //
 // This is the only test that exercises the partial unique index from
-// migration 1.15.46 end-to-end: it inserts one open visit, then attempts
+// migration 1.15.47 end-to-end: it inserts one open visit, then attempts
 // a second open visit for the same (tenant_id, student_id) so PostgreSQL
 // raises 23505 on uniq_active_visits_open_per_student. The captured error
 // chain (*base.DatabaseError → bun → pgdriver.Error) is then fed into
@@ -113,7 +113,7 @@ func TestIsDuplicateActiveVisitViolation(t *testing.T) {
 		}
 		err := repo.Create(ctx, duplicate)
 
-		require.Error(t, err, "partial unique index from migration 1.15.46 must reject the second open visit")
+		require.Error(t, err, "partial unique index from migration 1.15.47 must reject the second open visit")
 		assert.Equal(t, int64(0), duplicate.ID, "rejected insert must not assign an ID")
 		assert.True(t, isDuplicateActiveVisitViolation(err),
 			"detection helper must recognise the 23505 on uniq_active_visits_open_per_student so service.CreateVisit returns ErrStudentAlreadyActive (Issue #844). got: %v", err)

--- a/backend/services/active/visit_service_test.go
+++ b/backend/services/active/visit_service_test.go
@@ -142,7 +142,7 @@ func TestActiveService_CreateVisit(t *testing.T) {
 	// Duplicate-active-visit path (Issue #844). Two paths can produce
 	// ErrStudentAlreadyActive: the application-level read-then-write check
 	// in ensureStudentHasNoActiveVisit (covers the common single-thread
-	// case) and the partial unique index from migration 1.15.46 (catches
+	// case) and the partial unique index from migration 1.15.47 (catches
 	// concurrent races that slip past the app check). Both must produce
 	// the same typed error so the IoT handler can map either to a 409.
 	t.Run("returns ErrStudentAlreadyActive when student already has open visit", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Renumber the active-visits duplicate-checkin migration from `1.15.46` to `1.15.47` so it no longer collides with `active.student_status_days`.
- Add a migration validation preflight to the Docker build/deploy workflow before image builds or deploys can start.

## Root Cause
PR #1345 merged with stale checks after `development` had already picked up `001015046_student_status_days.go` from PR #1346/#1348/#1352. The PR branch had bumped its migration from `1.15.45` to `1.15.46`, but by merge time that slot was already taken. The post-merge main workflow caught the collision, but the deploy workflow ran in parallel and only failed during staging migration.

## Validation
- `go run main.go migrate validate`
- `go test ./database/migrations/ -run TestNoDuplicateMigrationVersions -v`
- pre-push hook: `git-secrets`, `go vet`, `go deadcode`, `golangci-lint`
