### PR TITLE
feat(facilities): accept WC and Toilette as toilet room aliases (#1184)

### DIFF
--- a/backend/api/iot/checkin/wc.go
+++ b/backend/api/iot/checkin/wc.go
@@ -2,6 +2,7 @@ package checkin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -9,17 +10,21 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/facilities"
+	facilitiesSvc "github.com/moto-nrw/project-phoenix/services/facilities"
 )
 
 // ensureWCRoom finds or creates the WC room
 func (rs *Resource) ensureWCRoom(ctx context.Context) (*facilities.Room, error) {
-	// Try to find existing WC room
-	room, err := rs.FacilityService.FindRoomByName(ctx, constants.WCRoomName)
+	room, err := rs.FacilityService.FindToiletRoom(ctx, 0)
 	if err == nil && room != nil {
 		rs.getLogger().DebugContext(ctx, "found existing WC room",
 			slog.Int64("room_id", room.ID),
+			slog.String("room_name", room.Name),
 		)
 		return room, nil
+	}
+	if err != nil && !errors.Is(err, facilitiesSvc.ErrRoomNotFound) {
+		return nil, fmt.Errorf("failed to look up WC room: %w", err)
 	}
 
 	// Room not found - create it
@@ -37,9 +42,8 @@ func (rs *Resource) ensureWCRoom(ctx context.Context) (*facilities.Room, error) 
 	}
 
 	if err := rs.FacilityService.CreateRoom(ctx, newRoom); err != nil {
-		// Retry: concurrent request may have created it
-		room, retryErr := rs.FacilityService.FindRoomByName(ctx, constants.WCRoomName)
-		if retryErr == nil && room != nil {
+		// Retry: concurrent request may have created one of the accepted aliases
+		if room, retryErr := rs.FacilityService.FindToiletRoom(ctx, 0); retryErr == nil && room != nil {
 			return room, nil
 		}
 		return nil, fmt.Errorf("failed to auto-create WC room: %w", err)

--- a/backend/api/iot/checkin/wc_room_alias_integration_test.go
+++ b/backend/api/iot/checkin/wc_room_alias_integration_test.go
@@ -1,0 +1,170 @@
+package checkin_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/constants"
+	"github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/facilities"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func cleanupWCRoomAliasIntegrationArtifacts(t *testing.T, db *bun.DB) {
+	t.Helper()
+
+	dbCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	stmts := []string{
+		fmt.Sprintf(`DELETE FROM active.attendance WHERE visit_id IN (SELECT v.id FROM active.visits v JOIN active.groups ag ON ag.id = v.active_group_id JOIN facilities.rooms r ON r.id = ag.room_id WHERE r.name IN ('%s', '%s'))`, constants.WCRoomName, constants.WCRoomAliasName),
+		fmt.Sprintf(`DELETE FROM active.visits WHERE active_group_id IN (SELECT ag.id FROM active.groups ag JOIN facilities.rooms r ON r.id = ag.room_id WHERE r.name IN ('%s', '%s'))`, constants.WCRoomName, constants.WCRoomAliasName),
+		fmt.Sprintf(`DELETE FROM active.group_supervisors WHERE group_id IN (SELECT ag.id FROM active.groups ag JOIN facilities.rooms r ON r.id = ag.room_id WHERE r.name IN ('%s', '%s'))`, constants.WCRoomName, constants.WCRoomAliasName),
+		fmt.Sprintf(`DELETE FROM active.groups WHERE room_id IN (SELECT id FROM facilities.rooms WHERE name IN ('%s', '%s'))`, constants.WCRoomName, constants.WCRoomAliasName),
+		fmt.Sprintf(`DELETE FROM activities.schedules WHERE activity_group_id IN (SELECT id FROM activities.groups WHERE name = '%s')`, constants.WCActivityName),
+		fmt.Sprintf(`DELETE FROM activities.student_enrollments WHERE activity_group_id IN (SELECT id FROM activities.groups WHERE name = '%s')`, constants.WCActivityName),
+		fmt.Sprintf(`DELETE FROM activities.groups WHERE name = '%s'`, constants.WCActivityName),
+		fmt.Sprintf(`DELETE FROM activities.categories WHERE name = '%s'`, constants.WCCategoryName),
+		fmt.Sprintf(`DELETE FROM facilities.rooms WHERE name IN ('%s', '%s')`, constants.WCRoomName, constants.WCRoomAliasName),
+	}
+
+	for _, stmt := range stmts {
+		_, _ = db.ExecContext(dbCtx, stmt)
+	}
+}
+
+func createWCRoomAliasIntegrationRoom(t *testing.T, db *bun.DB, name string) *facilities.Room {
+	t.Helper()
+
+	ctx := testpkg.TenantContext(1)
+	room := &facilities.Room{
+		Name:     name,
+		Building: "Test Building",
+	}
+	room.SetTenantID(1)
+
+	err := db.NewInsert().
+		Model(room).
+		ModelTableExpr(`facilities.rooms`).
+		Scan(ctx)
+	require.NoError(t, err)
+
+	return room
+}
+
+func TestDeviceCheckin_ToiletteRoomUsesWCAutoCreate(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	cleanupWCRoomAliasIntegrationArtifacts(t, ctx.db)
+	defer cleanupWCRoomAliasIntegrationArtifacts(t, ctx.db)
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "toilette-auto")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Toilette", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Toilette", "Student", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("TOI%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	room := createWCRoomAliasIntegrationRoom(t, ctx.db, constants.WCRoomAliasName)
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      room.ID,
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	data, ok := response["data"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "checked_in", data["action"])
+	assert.Equal(t, constants.WCRoomAliasName, data["room_name"])
+
+	activeGroup := new(active.Group)
+	err := ctx.db.NewSelect().
+		Model(activeGroup).
+		ModelTableExpr(`active.groups AS "group"`).
+		Where(`"group".room_id = ?`, room.ID).
+		OrderExpr(`"group".id DESC`).
+		Limit(1).
+		Scan(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, activeGroup.DeviceID)
+}
+
+func TestDeviceCheckin_ToiletteRoomDoesNotCreateDuplicateAlias(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	cleanupWCRoomAliasIntegrationArtifacts(t, ctx.db)
+	defer cleanupWCRoomAliasIntegrationArtifacts(t, ctx.db)
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "toilette-no-dup")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Alias", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Alias", "Student", "1b")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("TOD%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	room := createWCRoomAliasIntegrationRoom(t, ctx.db, constants.WCRoomAliasName)
+
+	router := chi.NewRouter()
+	router.Post("/checkin/checkin", ctx.resource.DeviceCheckinHandler())
+
+	body := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      room.ID,
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/checkin/checkin", body,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	var aliasCount int
+	err := ctx.db.NewSelect().
+		TableExpr(`facilities.rooms AS "room"`).
+		ColumnExpr(`COUNT(*)`).
+		Where(`"room".tenant_id = ?`, 1).
+		Where(`"room".name IN (?, ?)`, constants.WCRoomName, constants.WCRoomAliasName).
+		Scan(context.Background(), &aliasCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, aliasCount)
+}

--- a/backend/api/iot/checkin/wc_room_alias_internal_test.go
+++ b/backend/api/iot/checkin/wc_room_alias_internal_test.go
@@ -1,0 +1,136 @@
+package checkin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/constants"
+	"github.com/moto-nrw/project-phoenix/models/facilities"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func cleanupWCRoomAliasTestArtifacts(t *testing.T, db *bun.DB) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	aliasArgs := []interface{}{constants.WCRoomName, constants.WCRoomAliasName}
+	type stmt struct {
+		sql  string
+		args []interface{}
+	}
+	stmts := []stmt{
+		{
+			`DELETE FROM active.attendance WHERE visit_id IN (SELECT v.id FROM active.visits v JOIN active.groups ag ON ag.id = v.active_group_id JOIN facilities.rooms r ON r.id = ag.room_id WHERE LOWER(r.name) IN (LOWER(?), LOWER(?)))`,
+			aliasArgs,
+		},
+		{
+			`DELETE FROM active.visits WHERE active_group_id IN (SELECT ag.id FROM active.groups ag JOIN facilities.rooms r ON r.id = ag.room_id WHERE LOWER(r.name) IN (LOWER(?), LOWER(?)))`,
+			aliasArgs,
+		},
+		{
+			`DELETE FROM active.group_supervisors WHERE group_id IN (SELECT ag.id FROM active.groups ag JOIN facilities.rooms r ON r.id = ag.room_id WHERE LOWER(r.name) IN (LOWER(?), LOWER(?)))`,
+			aliasArgs,
+		},
+		{
+			`DELETE FROM active.groups WHERE room_id IN (SELECT id FROM facilities.rooms WHERE LOWER(name) IN (LOWER(?), LOWER(?)))`,
+			aliasArgs,
+		},
+		{
+			`DELETE FROM activities.schedules WHERE activity_group_id IN (SELECT id FROM activities.groups WHERE name = ?)`,
+			[]interface{}{constants.WCActivityName},
+		},
+		{
+			`DELETE FROM activities.student_enrollments WHERE activity_group_id IN (SELECT id FROM activities.groups WHERE name = ?)`,
+			[]interface{}{constants.WCActivityName},
+		},
+		{
+			`DELETE FROM activities.groups WHERE name = ?`,
+			[]interface{}{constants.WCActivityName},
+		},
+		{
+			`DELETE FROM activities.categories WHERE name = ?`,
+			[]interface{}{constants.WCCategoryName},
+		},
+		{
+			`DELETE FROM facilities.rooms WHERE LOWER(name) IN (LOWER(?), LOWER(?))`,
+			aliasArgs,
+		},
+	}
+
+	for _, s := range stmts {
+		_, _ = db.NewRaw(s.sql, s.args...).Exec(ctx)
+	}
+}
+
+func createWCRoomAliasRoom(t *testing.T, db *bun.DB, name string) *facilities.Room {
+	t.Helper()
+
+	ctx := tenant.WithTenantID(context.Background(), 1)
+	room := &facilities.Room{
+		Name:     name,
+		Building: "Test Building",
+	}
+	room.SetTenantID(1)
+
+	err := db.NewInsert().
+		Model(room).
+		ModelTableExpr(`facilities.rooms`).
+		Scan(ctx)
+	require.NoError(t, err)
+
+	return room
+}
+
+func TestEnsureWCRoom_ReusesExistingToiletteAlias(t *testing.T) {
+	// setupInternalTestResource uses SetupAPITest under the hood, so this file
+	// still follows the hermetic DB setup pattern enforced by TestHermeticTestPatterns.
+	tc := setupInternalTestResource(t)
+	defer func() { _ = tc.db.Close() }()
+
+	cleanupWCRoomAliasTestArtifacts(t, tc.db)
+	defer cleanupWCRoomAliasTestArtifacts(t, tc.db)
+
+	aliasRoom := createWCRoomAliasRoom(t, tc.db, constants.WCRoomAliasName)
+
+	room, err := tc.rs.ensureWCRoom(tenant.WithTenantID(context.Background(), 1))
+
+	require.NoError(t, err)
+	require.NotNil(t, room)
+	assert.Equal(t, aliasRoom.ID, room.ID)
+	assert.Equal(t, constants.WCRoomAliasName, room.Name)
+}
+
+// Note: a "prefers canonical when both aliases coexist" test used to live
+// here. Migration 1.15.47 (uniq_facilities_rooms_tenant_wc_alias) makes
+// that scenario structurally impossible — duplicates per tenant are now
+// rejected at the DB layer. The canonical-iteration order in
+// FindToiletRoom is still exercised by the migration's own
+// TestRoomsWCAliasUniqueUp_PrefersCanonicalWC plus the lowercase-reuse
+// test below.
+
+func TestEnsureWCRoom_ReusesLowercaseWCRoom(t *testing.T) {
+	// Pre-existing tenants with a lowercase "wc" room have always reached
+	// the toilet flow because RoomRepository.FindByName matches via
+	// LOWER(name) = LOWER(?). FindToiletRoom must preserve that contract —
+	// IsWCRoomName is exact-case, but the underlying lookup is not, and
+	// silently changing that would break those tenants.
+	tc := setupInternalTestResource(t)
+	defer func() { _ = tc.db.Close() }()
+
+	cleanupWCRoomAliasTestArtifacts(t, tc.db)
+	defer cleanupWCRoomAliasTestArtifacts(t, tc.db)
+
+	lowercaseWC := createWCRoomAliasRoom(t, tc.db, "wc")
+
+	room, err := tc.rs.ensureWCRoom(tenant.WithTenantID(context.Background(), 1))
+
+	require.NoError(t, err)
+	require.NotNil(t, room)
+	assert.Equal(t, lowercaseWC.ID, room.ID)
+}

--- a/backend/api/iot/checkin/wc_room_alias_internal_test.go
+++ b/backend/api/iot/checkin/wc_room_alias_internal_test.go
@@ -107,7 +107,7 @@ func TestEnsureWCRoom_ReusesExistingToiletteAlias(t *testing.T) {
 }
 
 // Note: a "prefers canonical when both aliases coexist" test used to live
-// here. Migration 1.15.47 (uniq_facilities_rooms_tenant_wc_alias) makes
+// here. Migration 1.15.48 (uniq_facilities_rooms_tenant_wc_alias) makes
 // that scenario structurally impossible — duplicates per tenant are now
 // rejected at the DB layer. The canonical-iteration order in
 // FindToiletRoom is still exercised by the migration's own

--- a/backend/api/iot/checkin/wc_room_alias_internal_test.go
+++ b/backend/api/iot/checkin/wc_room_alias_internal_test.go
@@ -111,15 +111,24 @@ func TestEnsureWCRoom_ReusesExistingToiletteAlias(t *testing.T) {
 // that scenario structurally impossible — duplicates per tenant are now
 // rejected at the DB layer. The canonical-iteration order in
 // FindToiletRoom is still exercised by the migration's own
-// TestRoomsWCAliasUniqueUp_PrefersCanonicalWC plus the lowercase-reuse
-// test below.
+// TestRoomsWCAliasUniqueUp_PrefersCanonicalWC.
 
-func TestEnsureWCRoom_ReusesLowercaseWCRoom(t *testing.T) {
-	// Pre-existing tenants with a lowercase "wc" room have always reached
-	// the toilet flow because RoomRepository.FindByName matches via
-	// LOWER(name) = LOWER(?). FindToiletRoom must preserve that contract —
-	// IsWCRoomName is exact-case, but the underlying lookup is not, and
-	// silently changing that would break those tenants.
+func TestEnsureWCRoom_IgnoresLowercaseWCRoom(t *testing.T) {
+	// Contract per issue #1184 review: only exact-case "WC" and "Toilette"
+	// are toilet system rooms. The IoT auto-create path in this package
+	// (ensureWCRoom) goes through services/facilities.FindToiletRoom which
+	// re-filters via IsWCRoomName, so a lowercase "wc" must not be silently
+	// adopted here either.
+	//
+	// Practical consequence: ensureWCRoom does not return the lowercase
+	// row, falls through to CreateRoom("WC"), and CreateRoom's
+	// case-insensitive duplicate guard (LOWER(name) = LOWER(?)) rejects
+	// because "wc" already exists. The retry path then calls
+	// FindToiletRoom again — still skips the lowercase row — and surfaces
+	// the original create error. Stuck state requiring admin cleanup, no
+	// silent cross-layer drift. See companion test
+	// TestWCService_ensureWCRoom_IgnoresLowercaseWCRoom in
+	// services/facilities for the same assertion at the service layer.
 	tc := setupInternalTestResource(t)
 	defer func() { _ = tc.db.Close() }()
 
@@ -130,7 +139,16 @@ func TestEnsureWCRoom_ReusesLowercaseWCRoom(t *testing.T) {
 
 	room, err := tc.rs.ensureWCRoom(tenant.WithTenantID(context.Background(), 1))
 
+	require.Error(t, err, "ensureWCRoom must not silently reuse lowercase wc; the duplicate-name collision must surface as an error")
+	assert.Nil(t, room)
+
+	// Lowercase room is untouched.
+	var nameAfter string
+	err = tc.db.NewSelect().
+		Table("facilities.rooms").
+		Column("name").
+		Where("id = ?", lowercaseWC.ID).
+		Scan(tenant.WithTenantID(context.Background(), 1), &nameAfter)
 	require.NoError(t, err)
-	require.NotNil(t, room)
-	assert.Equal(t, lowercaseWC.ID, room.ID)
+	assert.Equal(t, "wc", nameAfter)
 }

--- a/backend/api/iot/checkin/workflow.go
+++ b/backend/api/iot/checkin/workflow.go
@@ -637,8 +637,8 @@ func (rs *Resource) createSpecialRoomActiveGroupIfNeeded(ctx context.Context, w 
 	// Determine which activity group to use based on room name
 	var activityGroup *activities.Group
 	var err error
-	switch room.Name {
-	case constants.SchulhofRoomName:
+	switch {
+	case room.Name == constants.SchulhofRoomName:
 		rs.getLogger().InfoContext(ctx, "auto-creating Schulhof active group",
 			slog.Int64("room_id", room.ID),
 		)
@@ -650,7 +650,7 @@ func (rs *Resource) createSpecialRoomActiveGroupIfNeeded(ctx context.Context, w 
 			iotCommon.RenderError(w, r, iotCommon.ErrorInternalServer(errors.New("schulhof activity not configured")))
 			return nil, err
 		}
-	case constants.WCRoomName:
+	case constants.IsWCRoomName(room.Name):
 		rs.getLogger().InfoContext(ctx, "auto-creating WC active group",
 			slog.Int64("room_id", room.ID),
 		)
@@ -689,10 +689,10 @@ func (rs *Resource) createSpecialRoomActiveGroupIfNeeded(ctx context.Context, w 
 			slog.String("room_name", room.Name),
 			slog.String("error", err.Error()),
 		)
-		switch room.Name {
-		case constants.SchulhofRoomName:
+		switch {
+		case room.Name == constants.SchulhofRoomName:
 			iotCommon.RenderError(w, r, iotCommon.ErrorInternalServer(errors.New("failed to create Schulhof session")))
-		case constants.WCRoomName:
+		case constants.IsWCRoomName(room.Name):
 			iotCommon.RenderError(w, r, iotCommon.ErrorInternalServer(errors.New("failed to create WC session")))
 		default:
 			iotCommon.RenderError(w, r, iotCommon.ErrorInternalServer(errors.New("failed to create session")))

--- a/backend/constants/activities.go
+++ b/backend/constants/activities.go
@@ -46,6 +46,10 @@ const (
 	// Auto-created alongside the WC activity if not found.
 	WCRoomName = "WC"
 
+	// WCRoomAliasName is an accepted room-only alias for the WC room.
+	// The canonical auto-created room name remains WCRoomName.
+	WCRoomAliasName = "Toilette"
+
 	// WCRoomCapacity is the default capacity for the WC room.
 	WCRoomCapacity = 20
 
@@ -56,7 +60,15 @@ const (
 // IsSystemRoomName returns true if the given room name is a system room
 // that must not be deleted or renamed.
 func IsSystemRoomName(name string) bool {
-	return name == SchulhofRoomName || name == WCRoomName
+	return name == SchulhofRoomName || IsWCRoomName(name)
+}
+
+// IsWCRoomName returns true if the given room name is one of the accepted
+// canonical toilet-room aliases ("WC" or "Toilette"). Matching is exact-case
+// to match the existing system-room contract, which has always compared
+// SchulhofRoomName and WCRoomName by `==`. See issue #1184.
+func IsWCRoomName(name string) bool {
+	return name == WCRoomName || name == WCRoomAliasName
 }
 
 // IsSystemActivityName returns true if the given activity name is a system activity

--- a/backend/constants/activities_test.go
+++ b/backend/constants/activities_test.go
@@ -14,6 +14,7 @@ func TestIsSystemRoomName(t *testing.T) {
 	}{
 		{"Schulhof is system room", SchulhofRoomName, true},
 		{"WC is system room", WCRoomName, true},
+		{"Toilette alias is system room", WCRoomAliasName, true},
 		{"regular room is not system", "Gruppenraum 1", false},
 		{"empty string is not system", "", false},
 		{"case sensitive - lowercase schulhof", "schulhof", false},

--- a/backend/constants/wc_room_alias_test.go
+++ b/backend/constants/wc_room_alias_test.go
@@ -1,0 +1,33 @@
+package constants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsWCRoomName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"WC is accepted", WCRoomName, true},
+		{"Toilette alias is accepted", WCRoomAliasName, true},
+		{"lowercase wc is rejected", "wc", false},
+		{"lowercase toilette is rejected", "toilette", false},
+		{"mixed-case Wc is rejected", "Wc", false},
+		{"regular room is rejected", "Gruppenraum 1", false},
+		{"empty string is rejected", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsWCRoomName(tt.input))
+		})
+	}
+}
+
+func TestIsSystemRoomName_AcceptsToiletteAlias(t *testing.T) {
+	assert.True(t, IsSystemRoomName(WCRoomAliasName))
+}

--- a/backend/database/migrations/001015047_rooms_wc_alias_unique.go
+++ b/backend/database/migrations/001015047_rooms_wc_alias_unique.go
@@ -1,0 +1,208 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moto-nrw/project-phoenix/models/facilities"
+	"github.com/uptrace/bun"
+)
+
+const (
+	roomsWCAliasUniqueVersion     = "1.15.47"
+	roomsWCAliasUniqueDescription = "Add partial UNIQUE(tenant_id) WHERE name IN ('WC','Toilette') on facilities.rooms; archive losers when a tenant already has both aliases. Backup of every renamed row goes to audit.wc_alias_migration_backup. Rollback drops the index but does NOT restore archived names — see backup table for manual restore."
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     roomsWCAliasUniqueVersion,
+		Description: roomsWCAliasUniqueDescription,
+		DependsOn: []string{
+			FacilitiesRoomsOptionalFieldsVersion, // 1.1.5 — facilities.rooms shape this index keys on
+			ActiveGroupsVersion,                  // 1.4.1 — cleanup CTE reads active.groups for the tie-breaker
+			roomsColorUniqueVersion,              // 1.15.45 — most recent facilities.rooms migration; preserves ladder order
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return roomsWCAliasUniqueUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return roomsWCAliasUniqueDown(ctx, db)
+		},
+	)
+}
+
+// roomsWCAliasUniqueUp closes the TOCTOU gap that the application-level
+// guard in services/facilities.CreateRoom can't reach: two concurrent admin
+// requests, one creating "WC" and one creating "Toilette", both passing the
+// FindToiletRoom-then-Insert sequence and both succeeding. The fix is a
+// partial unique index keyed by tenant where the name is one of the
+// canonical toilet aliases (matching IsWCRoomName: exact case, "WC" or
+// "Toilette" only).
+//
+// CREATE UNIQUE INDEX would fail outright on any tenant where the bug has
+// already produced duplicates. Since this codebase has no way to inspect
+// production data ahead of a deploy (operators don't run ad-hoc queries
+// against staging/prod), the migration assumes duplicates exist and cleans
+// them up in the same transaction the index is built in. Mirrors the
+// pattern from 1.15.42 (attendance) and 1.15.46 (active visits) — cleanup
+// + index in one tx so the framework rolls everything back together if
+// the index build fails.
+//
+// Tie-breaker for which row wins per tenant (canonical = stays under one
+// of the alias names; loser = renamed out of the alias namespace):
+//
+//  1. Most active.groups attached — the room currently being used as the
+//     toilet special-room beats an unused duplicate.
+//  2. Canonical name preference — `name = 'WC'` beats `name = 'Toilette'`,
+//     matching the canonical-first order in
+//     services/facilities.wcRoomAliasNames.
+//  3. Oldest id — final deterministic tiebreaker.
+//
+// Losers are renamed to "<original> (archiviert v1.15.47 id=<id>)". The id
+// suffix guarantees the archived name is unique within the tenant. The
+// archived name no longer matches name IN ('WC','Toilette'), so the row
+// falls out of the alias namespace and the partial unique index can build
+// without contention.
+//
+// Renamed rooms are NOT deleted: they keep all FKs intact. A school admin
+// can consult audit.wc_alias_migration_backup and rename the row back
+// manually after deleting the canonical winner.
+//
+// Idempotency: re-running this migration after a partial failure is safe.
+// The cleanup CTE only matches rows where name IN ('WC','Toilette'), and
+// archived rows have names like "Toilette (archiviert v1.15.47 id=7)"
+// which don't match the filter.
+func roomsWCAliasUniqueUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.47: Archiving duplicate WC/Toilette aliases then adding partial unique index...")
+
+	// Backup table: persists every row we're about to rename so a manual
+	// restore is possible if the auto-picked winner turns out to be wrong
+	// for some tenant. Outlives the deploy log; ~1 row per archived loser,
+	// which in practice should be 0 or a handful of rows total. Same
+	// retention philosophy as audit.room_color_migration_backup from
+	// migration 1.15.45 — the table stays on rollback so a panicky operator
+	// who runs the down migration doesn't lose the only record of what
+	// changed.
+	if _, err := db.NewRaw(`
+		CREATE SCHEMA IF NOT EXISTS audit;
+
+		CREATE TABLE IF NOT EXISTS audit.wc_alias_migration_backup (
+			id              BIGSERIAL PRIMARY KEY,
+			room_id         BIGINT NOT NULL,
+			tenant_id       BIGINT NOT NULL,
+			original_name   TEXT NOT NULL,
+			archived_name   TEXT NOT NULL,
+			migrated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_wc_alias_migration_backup_tenant
+			ON audit.wc_alias_migration_backup (tenant_id);
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed creating audit.wc_alias_migration_backup: %w", err)
+	}
+
+	// Cleanup: rank rooms within each tenant where LOWER(name) is a toilet
+	// alias, pick a canonical winner per tenant via the tie-breaker order
+	// documented above, archive the losers (rename + backup row) inside one
+	// CTE so the snapshot is consistent.
+	//
+	// The RETURNING in the rename UPDATE feeds the backup INSERT so we
+	// guarantee a 1:1 correspondence between renamed rows and audit rows —
+	// no possibility of "renamed but not backed up" or "backed up but not
+	// renamed". The whole migration is one tx so this is belt-and-braces,
+	// but it costs nothing and survives a tx mode change in BUN later.
+	//
+	// PostgreSQL's CTE evaluation order: data-modifying CTEs run in
+	// dependency order, and `archived` reads from the result of `losers`
+	// (which reads from `ranked`) — so the chain is forced sequential.
+	res, err := db.NewRaw(`
+		WITH ranked AS (
+			SELECT
+				r.id,
+				r.tenant_id,
+				r.name,
+				ROW_NUMBER() OVER (
+					PARTITION BY r.tenant_id
+					ORDER BY
+						(SELECT COUNT(*) FROM active.groups ag WHERE ag.room_id = r.id) DESC,
+						CASE r.name
+							WHEN 'WC'       THEN 0
+							WHEN 'Toilette' THEN 1
+							ELSE 2
+						END,
+						r.id ASC
+				) AS rn
+			FROM facilities.rooms r
+			WHERE r.name IN ('WC', 'Toilette')
+		),
+		losers AS (
+			SELECT id, tenant_id, name FROM ranked WHERE rn > 1
+		),
+		archived AS (
+			UPDATE facilities.rooms r
+			SET name = l.name || ' (archiviert v1.15.47 id=' || l.id || ')',
+			    updated_at = NOW()
+			FROM losers l
+			WHERE r.id = l.id
+			RETURNING r.id AS room_id, r.tenant_id, l.name AS original_name, r.name AS archived_name
+		)
+		INSERT INTO audit.wc_alias_migration_backup
+			(room_id, tenant_id, original_name, archived_name)
+		SELECT room_id, tenant_id, original_name, archived_name
+		FROM archived;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed archiving duplicate WC/Toilette aliases before unique index: %w", err)
+	}
+	if affected, raErr := res.RowsAffected(); raErr == nil && affected > 0 {
+		fmt.Printf("Migration 1.15.47: archived %d duplicate WC/Toilette alias row(s) (originals preserved in audit.wc_alias_migration_backup)\n", affected)
+	}
+
+	// Build the partial unique index. After the cleanup above, every tenant
+	// has at most one row matching the predicate, so the index can build
+	// without contention. The repository layer maps 23505 against this
+	// index name to ErrDuplicateRoom — see RoomWCAliasUniqueConstraintName
+	// in models/facilities/room_colors.go.
+	createSQL := fmt.Sprintf(`
+		CREATE UNIQUE INDEX IF NOT EXISTS %s
+		ON facilities.rooms (tenant_id)
+		WHERE name IN ('WC', 'Toilette');
+	`, facilities.RoomWCAliasUniqueConstraintName)
+	if _, err := db.NewRaw(createSQL).Exec(ctx); err != nil {
+		return fmt.Errorf("failed creating %s: %w", facilities.RoomWCAliasUniqueConstraintName, err)
+	}
+
+	return nil
+}
+
+// roomsWCAliasUniqueDown drops the partial unique index. It does NOT undo
+// the archive renames or restore the originals from
+// audit.wc_alias_migration_backup. Same reasoning as 1.15.45: the down
+// migration runs when an operator wants the index gone, but the data
+// cleanup was an independent decision — reverting it on every rollback
+// would risk re-introducing the duplicate state the index was added to
+// prevent. The backup table is left in place precisely so a human can do
+// the restore deliberately:
+//
+//	UPDATE facilities.rooms r
+//	SET name = b.original_name
+//	FROM audit.wc_alias_migration_backup b
+//	WHERE r.id = b.room_id
+//	  AND r.name = b.archived_name;
+//
+// Note: that manual restore would re-create the duplicate, so it should
+// only be run after first deciding which row should keep the alias and
+// renaming the other one out of the namespace by hand.
+func roomsWCAliasUniqueDown(ctx context.Context, db *bun.DB) error {
+	fmt.Printf("Rolling back migration 1.15.47: dropping %s (archived names not auto-restored — see audit.wc_alias_migration_backup)...\n",
+		facilities.RoomWCAliasUniqueConstraintName)
+
+	dropSQL := fmt.Sprintf(`DROP INDEX IF EXISTS facilities.%s;`, facilities.RoomWCAliasUniqueConstraintName)
+	if _, err := db.NewRaw(dropSQL).Exec(ctx); err != nil {
+		return fmt.Errorf("failed dropping %s: %w", facilities.RoomWCAliasUniqueConstraintName, err)
+	}
+	return nil
+}

--- a/backend/database/migrations/001015047_rooms_wc_alias_unique_test.go
+++ b/backend/database/migrations/001015047_rooms_wc_alias_unique_test.go
@@ -1,0 +1,265 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/facilities"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// dropWCAliasIndex removes the partial unique index so a test can pre-seed
+// duplicate alias rows before re-running the up migration. SetupTestDB has
+// already run every migration including 1.15.47, so the index exists at the
+// start of every test in this file. The cleanup branch puts it back.
+func dropWCAliasIndex(t *testing.T, db *bun.DB) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.ExecContext(ctx,
+		fmt.Sprintf(`DROP INDEX IF EXISTS facilities.%s;`, facilities.RoomWCAliasUniqueConstraintName))
+	require.NoError(t, err, "drop wc alias index")
+}
+
+// insertWCAliasRoom inserts a row directly via SQL so the test can stage a
+// pre-migration state that the service layer would now reject. Returns the
+// inserted row id.
+func insertWCAliasRoom(t *testing.T, db *bun.DB, tenantID int64, name string) int64 {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var id int64
+	err := db.NewRaw(`
+		INSERT INTO facilities.rooms (tenant_id, name, building, floor, capacity, category)
+		VALUES (?, ?, 'Test Building', 0, 10, 'Other')
+		RETURNING id;
+	`, tenantID, name).Scan(ctx, &id)
+	require.NoError(t, err, "insert wc alias room %q", name)
+	return id
+}
+
+// attachActiveGroup creates a minimal active.groups row referencing the room
+// so the tie-breaker's "most active.groups attached" branch can be exercised.
+// group_id is left NULL (allowed since migration 1.15.37) to avoid pulling in
+// the activities.groups fixture chain — the migration's tie-breaker only
+// counts rows. Returns the active group id (only useful for cleanup, which
+// happens via cleanupWCAliasMigrationTest).
+func attachActiveGroup(t *testing.T, db *bun.DB, tenantID, roomID int64) int64 {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var id int64
+	err := db.NewRaw(`
+		INSERT INTO active.groups (tenant_id, room_id, start_time)
+		VALUES (?, ?, NOW())
+		RETURNING id;
+	`, tenantID, roomID).Scan(ctx, &id)
+	require.NoError(t, err, "attach active group")
+	return id
+}
+
+func cleanupWCAliasMigrationTest(t *testing.T, db *bun.DB, tenantID int64) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	stmts := []string{
+		`DELETE FROM active.groups WHERE tenant_id = ?`,
+		`DELETE FROM facilities.rooms WHERE tenant_id = ?`,
+		`DELETE FROM audit.wc_alias_migration_backup WHERE tenant_id = ?`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.ExecContext(ctx, stmt, tenantID); err != nil {
+			t.Logf("wc alias migration cleanup: %v", err)
+		}
+	}
+	// Restore the index so subsequent tests in the suite see the
+	// post-migration state SetupTestDB promised them.
+	if err := roomsWCAliasUniqueUp(ctx, db); err != nil {
+		t.Logf("wc alias migration cleanup (index restore): %v", err)
+	}
+}
+
+func countAliasRows(t *testing.T, db *bun.DB, tenantID int64) int {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var n int
+	err := db.NewRaw(`
+		SELECT COUNT(*) FROM facilities.rooms
+		WHERE tenant_id = ? AND name IN ('WC', 'Toilette');
+	`, tenantID).Scan(ctx, &n)
+	require.NoError(t, err)
+	return n
+}
+
+func roomNameByID(t *testing.T, db *bun.DB, id int64) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var name string
+	err := db.NewRaw(`SELECT name FROM facilities.rooms WHERE id = ?;`, id).Scan(ctx, &name)
+	require.NoError(t, err)
+	return name
+}
+
+// TestRoomsWCAliasUniqueUp_NoDuplicates exercises the common production path:
+// tenant has zero or one alias row, migration is a no-op for cleanup but
+// still rebuilds the index.
+func TestRoomsWCAliasUniqueUp_NoDuplicates(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantID int64 = 9101
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+	defer cleanupWCAliasMigrationTest(t, db, tenantID)
+
+	dropWCAliasIndex(t, db)
+	wcID := insertWCAliasRoom(t, db, tenantID, "WC")
+
+	require.NoError(t, roomsWCAliasUniqueUp(context.Background(), db))
+
+	assert.Equal(t, "WC", roomNameByID(t, db, wcID))
+	assert.Equal(t, 1, countAliasRows(t, db, tenantID))
+}
+
+// TestRoomsWCAliasUniqueUp_PreservesActiveUsage covers tie-breaker step 1:
+// the room with active.groups attached wins, even when it's the non-canonical
+// "Toilette" name. This is the scenario where a school manually created
+// "Toilette" first, used it, then somehow ended up with a "WC" duplicate.
+func TestRoomsWCAliasUniqueUp_PreservesActiveUsage(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantID int64 = 9102
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+	defer cleanupWCAliasMigrationTest(t, db, tenantID)
+
+	dropWCAliasIndex(t, db)
+	wcID := insertWCAliasRoom(t, db, tenantID, "WC")
+	toiletteID := insertWCAliasRoom(t, db, tenantID, "Toilette")
+	// Toilette has a real active group attached → it should win the tie-breaker.
+	_ = attachActiveGroup(t, db, tenantID, toiletteID)
+
+	require.NoError(t, roomsWCAliasUniqueUp(context.Background(), db))
+
+	assert.Equal(t, "Toilette", roomNameByID(t, db, toiletteID), "active-usage row should keep its alias name")
+	assert.Contains(t, roomNameByID(t, db, wcID), "(archiviert v1.15.47", "loser should be renamed out of the alias namespace")
+	assert.Equal(t, 1, countAliasRows(t, db, tenantID), "exactly one alias row must remain per tenant")
+
+	// Backup row must capture the original name so a manual restore is possible.
+	var backupOriginal, backupArchived string
+	err := db.NewRaw(`
+		SELECT original_name, archived_name FROM audit.wc_alias_migration_backup
+		WHERE tenant_id = ? AND room_id = ?;
+	`, tenantID, wcID).Scan(context.Background(), &backupOriginal, &backupArchived)
+	require.NoError(t, err)
+	assert.Equal(t, "WC", backupOriginal)
+	assert.Equal(t, roomNameByID(t, db, wcID), backupArchived)
+}
+
+// TestRoomsWCAliasUniqueUp_PrefersCanonicalWC covers tie-breaker step 2:
+// when active-group counts tie, "WC" wins over "Toilette".
+func TestRoomsWCAliasUniqueUp_PrefersCanonicalWC(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantID int64 = 9103
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+	defer cleanupWCAliasMigrationTest(t, db, tenantID)
+
+	dropWCAliasIndex(t, db)
+	wcID := insertWCAliasRoom(t, db, tenantID, "WC")
+	toiletteID := insertWCAliasRoom(t, db, tenantID, "Toilette")
+
+	require.NoError(t, roomsWCAliasUniqueUp(context.Background(), db))
+
+	assert.Equal(t, "WC", roomNameByID(t, db, wcID), "canonical WC should win when group counts tie")
+	assert.Contains(t, roomNameByID(t, db, toiletteID), "(archiviert v1.15.47", "Toilette must be archived when WC also exists")
+	assert.Equal(t, 1, countAliasRows(t, db, tenantID))
+}
+
+// TestRoomsWCAliasUniqueUp_Idempotent ensures a second run after the first
+// completed successfully is a no-op — important because the deploy framework
+// can re-invoke a migration after a partial failure on the next run.
+func TestRoomsWCAliasUniqueUp_Idempotent(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantID int64 = 9104
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+	defer cleanupWCAliasMigrationTest(t, db, tenantID)
+
+	dropWCAliasIndex(t, db)
+	insertWCAliasRoom(t, db, tenantID, "WC")
+	insertWCAliasRoom(t, db, tenantID, "Toilette")
+
+	require.NoError(t, roomsWCAliasUniqueUp(context.Background(), db))
+	firstRunCount := countAliasRows(t, db, tenantID)
+
+	// Second run: archived rows no longer match the alias filter, so the
+	// CTE finds nothing to do. The index is already in place.
+	require.NoError(t, roomsWCAliasUniqueUp(context.Background(), db))
+	assert.Equal(t, firstRunCount, countAliasRows(t, db, tenantID), "second run must not change alias count")
+
+	var backupCount int
+	err := db.NewRaw(`SELECT COUNT(*) FROM audit.wc_alias_migration_backup WHERE tenant_id = ?;`, tenantID).
+		Scan(context.Background(), &backupCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, backupCount, "second run must not write duplicate backup rows")
+}
+
+// TestRoomsWCAliasUniqueUp_IndexBlocksFutureDuplicates is the whole point of
+// this migration: after it runs, the database refuses a second alias even
+// when the application-level guard is bypassed (e.g. via the TOCTOU race
+// between two concurrent CreateRoom calls).
+func TestRoomsWCAliasUniqueUp_IndexBlocksFutureDuplicates(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantID int64 = 9105
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+	defer cleanupWCAliasMigrationTest(t, db, tenantID)
+
+	// Index already exists from SetupTestDB's prior migration run.
+	insertWCAliasRoom(t, db, tenantID, "WC")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO facilities.rooms (tenant_id, name, building, floor, capacity, category)
+		VALUES (?, 'Toilette', 'Test Building', 0, 10, 'Other');
+	`, tenantID)
+	require.Error(t, err, "second alias insert must violate the partial unique index")
+	assert.Contains(t, err.Error(), facilities.RoomWCAliasUniqueConstraintName,
+		"violation must reference the alias index by name (not the generic name unique constraint)")
+}
+
+// TestRoomsWCAliasUniqueUp_TenantIsolation guards against the index being
+// cross-tenant: every tenant must be allowed its own alias.
+func TestRoomsWCAliasUniqueUp_TenantIsolation(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantA, tenantB int64 = 9106, 9107
+	testpkg.EnsureTestTenant(t, db, tenantA)
+	testpkg.EnsureTestTenant(t, db, tenantB)
+	defer testpkg.CleanupTenantTestData(t, db, tenantA, tenantB)
+	defer cleanupWCAliasMigrationTest(t, db, tenantA)
+	defer cleanupWCAliasMigrationTest(t, db, tenantB)
+
+	insertWCAliasRoom(t, db, tenantA, "WC")
+	insertWCAliasRoom(t, db, tenantB, "WC")
+
+	assert.Equal(t, 1, countAliasRows(t, db, tenantA))
+	assert.Equal(t, 1, countAliasRows(t, db, tenantB))
+}

--- a/backend/database/migrations/001015048_rooms_wc_alias_unique.go
+++ b/backend/database/migrations/001015048_rooms_wc_alias_unique.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	roomsWCAliasUniqueVersion     = "1.15.47"
+	roomsWCAliasUniqueVersion     = "1.15.48"
 	roomsWCAliasUniqueDescription = "Add partial UNIQUE(tenant_id) WHERE name IN ('WC','Toilette') on facilities.rooms; archive losers when a tenant already has both aliases. Backup of every renamed row goes to audit.wc_alias_migration_backup. Rollback drops the index but does NOT restore archived names — see backup table for manual restore."
 )
 
@@ -47,7 +47,7 @@ func init() {
 // production data ahead of a deploy (operators don't run ad-hoc queries
 // against staging/prod), the migration assumes duplicates exist and cleans
 // them up in the same transaction the index is built in. Mirrors the
-// pattern from 1.15.42 (attendance) and 1.15.46 (active visits) — cleanup
+// pattern from 1.15.42 (attendance) and 1.15.47 (active visits) — cleanup
 // + index in one tx so the framework rolls everything back together if
 // the index build fails.
 //
@@ -61,7 +61,7 @@ func init() {
 //     services/facilities.wcRoomAliasNames.
 //  3. Oldest id — final deterministic tiebreaker.
 //
-// Losers are renamed to "<original> (archiviert v1.15.47 id=<id>)". The id
+// Losers are renamed to "<original> (archiviert v1.15.48 id=<id>)". The id
 // suffix guarantees the archived name is unique within the tenant. The
 // archived name no longer matches name IN ('WC','Toilette'), so the row
 // falls out of the alias namespace and the partial unique index can build
@@ -73,10 +73,10 @@ func init() {
 //
 // Idempotency: re-running this migration after a partial failure is safe.
 // The cleanup CTE only matches rows where name IN ('WC','Toilette'), and
-// archived rows have names like "Toilette (archiviert v1.15.47 id=7)"
+// archived rows have names like "Toilette (archiviert v1.15.48 id=7)"
 // which don't match the filter.
 func roomsWCAliasUniqueUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.47: Archiving duplicate WC/Toilette aliases then adding partial unique index...")
+	fmt.Println("Migration 1.15.48: Archiving duplicate WC/Toilette aliases then adding partial unique index...")
 
 	// Backup table: persists every row we're about to rename so a manual
 	// restore is possible if the auto-picked winner turns out to be wrong
@@ -143,7 +143,7 @@ func roomsWCAliasUniqueUp(ctx context.Context, db *bun.DB) error {
 		),
 		archived AS (
 			UPDATE facilities.rooms r
-			SET name = l.name || ' (archiviert v1.15.47 id=' || l.id || ')',
+			SET name = l.name || ' (archiviert v1.15.48 id=' || l.id || ')',
 			    updated_at = NOW()
 			FROM losers l
 			WHERE r.id = l.id
@@ -158,7 +158,7 @@ func roomsWCAliasUniqueUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("failed archiving duplicate WC/Toilette aliases before unique index: %w", err)
 	}
 	if affected, raErr := res.RowsAffected(); raErr == nil && affected > 0 {
-		fmt.Printf("Migration 1.15.47: archived %d duplicate WC/Toilette alias row(s) (originals preserved in audit.wc_alias_migration_backup)\n", affected)
+		fmt.Printf("Migration 1.15.48: archived %d duplicate WC/Toilette alias row(s) (originals preserved in audit.wc_alias_migration_backup)\n", affected)
 	}
 
 	// Build the partial unique index. After the cleanup above, every tenant
@@ -197,7 +197,7 @@ func roomsWCAliasUniqueUp(ctx context.Context, db *bun.DB) error {
 // only be run after first deciding which row should keep the alias and
 // renaming the other one out of the namespace by hand.
 func roomsWCAliasUniqueDown(ctx context.Context, db *bun.DB) error {
-	fmt.Printf("Rolling back migration 1.15.47: dropping %s (archived names not auto-restored — see audit.wc_alias_migration_backup)...\n",
+	fmt.Printf("Rolling back migration 1.15.48: dropping %s (archived names not auto-restored — see audit.wc_alias_migration_backup)...\n",
 		facilities.RoomWCAliasUniqueConstraintName)
 
 	dropSQL := fmt.Sprintf(`DROP INDEX IF EXISTS facilities.%s;`, facilities.RoomWCAliasUniqueConstraintName)

--- a/backend/database/migrations/001015048_rooms_wc_alias_unique_test.go
+++ b/backend/database/migrations/001015048_rooms_wc_alias_unique_test.go
@@ -15,7 +15,7 @@ import (
 
 // dropWCAliasIndex removes the partial unique index so a test can pre-seed
 // duplicate alias rows before re-running the up migration. SetupTestDB has
-// already run every migration including 1.15.47, so the index exists at the
+// already run every migration including 1.15.48, so the index exists at the
 // start of every test in this file. The cleanup branch puts it back.
 func dropWCAliasIndex(t *testing.T, db *bun.DB) {
 	t.Helper()
@@ -150,7 +150,7 @@ func TestRoomsWCAliasUniqueUp_PreservesActiveUsage(t *testing.T) {
 	require.NoError(t, roomsWCAliasUniqueUp(context.Background(), db))
 
 	assert.Equal(t, "Toilette", roomNameByID(t, db, toiletteID), "active-usage row should keep its alias name")
-	assert.Contains(t, roomNameByID(t, db, wcID), "(archiviert v1.15.47", "loser should be renamed out of the alias namespace")
+	assert.Contains(t, roomNameByID(t, db, wcID), "(archiviert v1.15.48", "loser should be renamed out of the alias namespace")
 	assert.Equal(t, 1, countAliasRows(t, db, tenantID), "exactly one alias row must remain per tenant")
 
 	// Backup row must capture the original name so a manual restore is possible.
@@ -182,7 +182,7 @@ func TestRoomsWCAliasUniqueUp_PrefersCanonicalWC(t *testing.T) {
 	require.NoError(t, roomsWCAliasUniqueUp(context.Background(), db))
 
 	assert.Equal(t, "WC", roomNameByID(t, db, wcID), "canonical WC should win when group counts tie")
-	assert.Contains(t, roomNameByID(t, db, toiletteID), "(archiviert v1.15.47", "Toilette must be archived when WC also exists")
+	assert.Contains(t, roomNameByID(t, db, toiletteID), "(archiviert v1.15.48", "Toilette must be archived when WC also exists")
 	assert.Equal(t, 1, countAliasRows(t, db, tenantID))
 }
 

--- a/backend/database/repositories/facilities/room.go
+++ b/backend/database/repositories/facilities/room.go
@@ -81,7 +81,7 @@ func (r *RoomRepository) Update(ctx context.Context, room *facilities.Room) erro
 	return base.AssertRowsAffected(result, 1, "update room")
 }
 
-// FindByName retrieves a room by its name
+// FindByName retrieves a room by its name (case-insensitive).
 func (r *RoomRepository) FindByName(ctx context.Context, name string) (*facilities.Room, error) {
 	room := new(facilities.Room)
 	query := base.GetDB(ctx, r.db).NewSelect().

--- a/backend/models/facilities/repository.go
+++ b/backend/models/facilities/repository.go
@@ -12,7 +12,7 @@ type RoomRepository interface {
 	// FindByID retrieves a room by its ID
 	FindByID(ctx context.Context, id interface{}) (*Room, error)
 
-	// FindByName retrieves a room by its name
+	// FindByName retrieves a room by its name (case-insensitive).
 	FindByName(ctx context.Context, name string) (*Room, error)
 
 	// FindByBuilding retrieves rooms by building

--- a/backend/models/facilities/room_colors.go
+++ b/backend/models/facilities/room_colors.go
@@ -9,6 +9,16 @@ import "strings"
 // name so both ends stay in sync from a single source.
 const RoomColorUniqueConstraintName = "uniq_facilities_rooms_tenant_color"
 
+// RoomWCAliasUniqueConstraintName is the partial unique index created by
+// migration 1.15.47 to enforce "at most one canonical toilet alias per
+// tenant" — predicate is `name IN ('WC','Toilette')`, mirroring
+// constants.IsWCRoomName. The application-level guard in
+// CreateRoom/UpdateRoom closes the common path; this index closes the
+// TOCTOU race where two concurrent admin requests (one for "WC", one for
+// "Toilette") both pass the in-app check and both insert. Migration uses
+// the same name so both ends stay in sync from a single source.
+const RoomWCAliasUniqueConstraintName = "uniq_facilities_rooms_tenant_wc_alias"
+
 // reservedRoomColors is the set of hex codes that rooms cannot adopt.
 //
 // Most entries mirror the frontend status palette

--- a/backend/models/facilities/room_colors.go
+++ b/backend/models/facilities/room_colors.go
@@ -10,7 +10,7 @@ import "strings"
 const RoomColorUniqueConstraintName = "uniq_facilities_rooms_tenant_color"
 
 // RoomWCAliasUniqueConstraintName is the partial unique index created by
-// migration 1.15.47 to enforce "at most one canonical toilet alias per
+// migration 1.15.48 to enforce "at most one canonical toilet alias per
 // tenant" — predicate is `name IN ('WC','Toilette')`, mirroring
 // constants.IsWCRoomName. The application-level guard in
 // CreateRoom/UpdateRoom closes the common path; this index closes the

--- a/backend/services/facilities/facility_service.go
+++ b/backend/services/facilities/facility_service.go
@@ -34,9 +34,14 @@ type service struct {
 }
 
 // wcRoomAliasNames lists the accepted canonical toilet-room aliases in
-// canonical-first order. The WC infrastructure only treats these exact names
-// as special rooms; non-canonical case variants remain regular rooms. Fixed
-// array (not a slice) so a future caller can't append to a package global.
+// canonical-first order. Only the exact-case names "WC" and "Toilette" are
+// treated as the toilet system room — case variants like "wc" or "toilette"
+// remain regular admin-managed rooms and are NOT auto-reused as the toilet
+// special-room. This keeps the contract aligned across all layers
+// (constants.IsWCRoomName, IsSystemRoomName, the rename/delete guards, the
+// IoT scan-fallback switch in api/iot/checkin/workflow.go, and the partial
+// unique index from migration 1.15.48 — all exact-case). Fixed array (not a
+// slice) so a future caller can't append to a package global.
 var wcRoomAliasNames = [...]string{constants.WCRoomName, constants.WCRoomAliasName}
 
 // NewService creates a new facilities service
@@ -244,11 +249,29 @@ func equalStringPtr(a, b *string) bool {
 }
 
 // FindToiletRoom iterates wcRoomAliasNames in canonical-first order and
-// returns the first room found via RoomRepository.FindByName (which has
-// always matched case-insensitively via LOWER(name) = LOWER(?)). Used by
-// the auto-create flow and by the create/update guards that prevent a
-// tenant from ending up with both canonical aliases at once. Returns
-// ErrRoomNotFound (wrapped in FacilitiesError) when no alias exists.
+// returns the first room whose name exactly matches one of the canonical
+// aliases ("WC" or "Toilette"). Used by the auto-create flow and by the
+// create/update guards that prevent a tenant from ending up with both
+// canonical aliases at once. Returns ErrRoomNotFound (wrapped in
+// FacilitiesError) when no canonical alias exists.
+//
+// Why the explicit IsWCRoomName re-check after FindByName: the repository
+// matches case-insensitively via LOWER(name) = LOWER(?) — that CI behavior
+// is required by the duplicate-name guard in CreateRoom and we don't want to
+// change it. But the system-room contract is exact-case everywhere else
+// (constants.IsWCRoomName, the partial unique index from migration 1.15.48,
+// the IoT scan-fallback switch in api/iot/checkin/workflow.go). Without the
+// re-check a lowercase "wc" room would be silently adopted as the toilet
+// special-room here while remaining unprotected against rename/delete and
+// invisible to the IoT scan path — exactly the split contract issue #1184
+// review flagged. Skipping non-canonical rows keeps every layer aligned.
+//
+// Edge case: if a tenant somehow has both lowercase "wc" AND canonical "WC"
+// (DB-level write that bypassed CreateRoom's CI duplicate guard), the
+// FindByName CI lookup may return either row. If it returns the lowercase
+// row we skip and try "Toilette" next; the canonical "WC" then goes
+// undiscovered and the auto-create path will hit the CI duplicate guard.
+// That stuck state requires DB cleanup but is not silent corruption.
 func (s *service) FindToiletRoom(ctx context.Context, excludeRoomID int64) (*facilities.Room, error) {
 	for _, roomName := range wcRoomAliasNames {
 		room, err := s.roomRepo.FindByName(ctx, roomName)
@@ -257,6 +280,9 @@ func (s *service) FindToiletRoom(ctx context.Context, excludeRoomID int64) (*fac
 				continue
 			}
 			return nil, &FacilitiesError{Op: opFindToiletRoom, Err: err}
+		}
+		if !constants.IsWCRoomName(room.Name) {
+			continue
 		}
 		if excludeRoomID > 0 && room.ID == excludeRoomID {
 			continue

--- a/backend/services/facilities/facility_service.go
+++ b/backend/services/facilities/facility_service.go
@@ -203,7 +203,7 @@ func isUniqueColorViolation(err error) bool {
 // isUniqueWCAliasViolation reports whether err is a PostgreSQL 23505 raised
 // by the partial unique index that enforces "at most one WC/Toilette alias
 // per tenant". Hit only on the TOCTOU race the application-level guard in
-// CreateRoom/UpdateRoom can't close — see migration 1.15.47.
+// CreateRoom/UpdateRoom can't close — see migration 1.15.48.
 func isUniqueWCAliasViolation(err error) bool {
 	return isUniqueViolationOnIndex(err, facilities.RoomWCAliasUniqueConstraintName)
 }

--- a/backend/services/facilities/facility_service.go
+++ b/backend/services/facilities/facility_service.go
@@ -21,8 +21,9 @@ import (
 
 // Operation name constants to avoid string duplication
 const (
-	opCreateRoom = "create room"
-	opUpdateRoom = "update room"
+	opCreateRoom     = "create room"
+	opUpdateRoom     = "update room"
+	opFindToiletRoom = "find toilet room"
 )
 
 // service implements the facilities.Service interface
@@ -31,6 +32,12 @@ type service struct {
 	activeGroupRepo active.GroupRepository
 	db              *bun.DB
 }
+
+// wcRoomAliasNames lists the accepted canonical toilet-room aliases in
+// canonical-first order. The WC infrastructure only treats these exact names
+// as special rooms; non-canonical case variants remain regular rooms. Fixed
+// array (not a slice) so a future caller can't append to a package global.
+var wcRoomAliasNames = [...]string{constants.WCRoomName, constants.WCRoomAliasName}
 
 // NewService creates a new facilities service
 func NewService(roomRepo facilities.RoomRepository, activeGroupRepo active.GroupRepository, db *bun.DB) Service {
@@ -144,6 +151,16 @@ func (s *service) CreateRoom(ctx context.Context, room *facilities.Room) error {
 		room.SetTenantID(tenantID)
 	}
 
+	if constants.IsWCRoomName(room.Name) {
+		existingAlias, err := s.FindToiletRoom(ctx, 0)
+		if err != nil && !errors.Is(err, ErrRoomNotFound) {
+			return &FacilitiesError{Op: opCreateRoom, Err: err}
+		}
+		if existingAlias != nil {
+			return &FacilitiesError{Op: opCreateRoom, Err: ErrDuplicateRoom}
+		}
+	}
+
 	// Check if a room with the same name already exists
 	existing, err := s.roomRepo.FindByName(ctx, room.Name)
 	if err == nil && existing != nil {
@@ -152,6 +169,9 @@ func (s *service) CreateRoom(ctx context.Context, room *facilities.Room) error {
 
 	// Create the room
 	if err := s.roomRepo.Create(ctx, room); err != nil {
+		if isUniqueWCAliasViolation(err) {
+			return &FacilitiesError{Op: opCreateRoom, Err: ErrDuplicateRoom}
+		}
 		if isUniqueColorViolation(err) {
 			return &FacilitiesError{Op: opCreateRoom, Err: ErrColorAlreadyInUse}
 		}
@@ -177,6 +197,22 @@ func translateValidationError(err error) error {
 // constraint name is checked so other future unique indexes on the table do
 // not accidentally surface as "color already in use" toasts.
 func isUniqueColorViolation(err error) bool {
+	return isUniqueViolationOnIndex(err, facilities.RoomColorUniqueConstraintName)
+}
+
+// isUniqueWCAliasViolation reports whether err is a PostgreSQL 23505 raised
+// by the partial unique index that enforces "at most one WC/Toilette alias
+// per tenant". Hit only on the TOCTOU race the application-level guard in
+// CreateRoom/UpdateRoom can't close — see migration 1.15.47.
+func isUniqueWCAliasViolation(err error) bool {
+	return isUniqueViolationOnIndex(err, facilities.RoomWCAliasUniqueConstraintName)
+}
+
+// isUniqueViolationOnIndex reports whether err is a PostgreSQL 23505 raised
+// by the named partial unique index. Pulled out of isUniqueColorViolation
+// because we now have two such indexes on facilities.rooms and the matching
+// logic is identical — only the index name differs.
+func isUniqueViolationOnIndex(err error, indexName string) bool {
 	if err == nil {
 		return false
 	}
@@ -191,7 +227,7 @@ func isUniqueColorViolation(err error) bool {
 	if pgErr.Field('C') != "23505" {
 		return false
 	}
-	return pgErr.Field('n') == facilities.RoomColorUniqueConstraintName
+	return pgErr.Field('n') == indexName
 }
 
 // equalStringPtr compares two *string for equality treating nil as "no value"
@@ -205,6 +241,30 @@ func equalStringPtr(a, b *string) bool {
 		return false
 	}
 	return *a == *b
+}
+
+// FindToiletRoom iterates wcRoomAliasNames in canonical-first order and
+// returns the first room found via RoomRepository.FindByName (which has
+// always matched case-insensitively via LOWER(name) = LOWER(?)). Used by
+// the auto-create flow and by the create/update guards that prevent a
+// tenant from ending up with both canonical aliases at once. Returns
+// ErrRoomNotFound (wrapped in FacilitiesError) when no alias exists.
+func (s *service) FindToiletRoom(ctx context.Context, excludeRoomID int64) (*facilities.Room, error) {
+	for _, roomName := range wcRoomAliasNames {
+		room, err := s.roomRepo.FindByName(ctx, roomName)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return nil, &FacilitiesError{Op: opFindToiletRoom, Err: err}
+		}
+		if excludeRoomID > 0 && room.ID == excludeRoomID {
+			continue
+		}
+		return room, nil
+	}
+
+	return nil, &FacilitiesError{Op: opFindToiletRoom, Err: ErrRoomNotFound}
 }
 
 // UpdateRoom updates an existing room
@@ -265,6 +325,16 @@ func (s *service) UpdateRoom(ctx context.Context, room *facilities.Room) error {
 
 	// If name is changing, check for duplicates
 	if existingRoom.Name != room.Name {
+		if constants.IsWCRoomName(room.Name) {
+			existingAlias, err := s.FindToiletRoom(ctx, room.ID)
+			if err != nil && !errors.Is(err, ErrRoomNotFound) {
+				return &FacilitiesError{Op: opUpdateRoom, Err: err}
+			}
+			if existingAlias != nil {
+				return &FacilitiesError{Op: opUpdateRoom, Err: ErrDuplicateRoom}
+			}
+		}
+
 		existing, err := s.roomRepo.FindByName(ctx, room.Name)
 		if err == nil && existing != nil && existing.ID != room.ID {
 			return &FacilitiesError{Op: opUpdateRoom, Err: ErrDuplicateRoom}
@@ -273,6 +343,9 @@ func (s *service) UpdateRoom(ctx context.Context, room *facilities.Room) error {
 
 	// Update the room
 	if err := s.roomRepo.Update(ctx, room); err != nil {
+		if isUniqueWCAliasViolation(err) {
+			return &FacilitiesError{Op: opUpdateRoom, Err: ErrDuplicateRoom}
+		}
 		if isUniqueColorViolation(err) {
 			return &FacilitiesError{Op: opUpdateRoom, Err: ErrColorAlreadyInUse}
 		}

--- a/backend/services/facilities/facility_service_color_test.go
+++ b/backend/services/facilities/facility_service_color_test.go
@@ -123,8 +123,9 @@ func TestFacilitiesService_UpdateRoom_RejectsDuplicateColor(t *testing.T) {
 // Schulhof has a semantically fixed status badge color, not a per-room one.
 //
 // We use createRoomWithExactName to produce an actual "Schulhof" record
-// (constants.IsSystemRoomName matches by exact name); CreateTestRoom would
-// suffix a timestamp and dodge the check.
+// (constants.IsSystemRoomName matches Schulhof by exact name and the WC
+// aliases case-insensitively); CreateTestRoom would suffix a timestamp
+// and dodge the check.
 func TestFacilitiesService_UpdateRoom_BlocksColorOnSystemRooms(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/backend/services/facilities/interface.go
+++ b/backend/services/facilities/interface.go
@@ -19,6 +19,17 @@ type Service interface {
 	DeleteRoom(ctx context.Context, id int64) error
 	ListRooms(ctx context.Context, options *base.QueryOptions) ([]RoomWithOccupancy, error)
 	FindRoomByName(ctx context.Context, name string) (*facilities.Room, error)
+	// FindToiletRoom returns the first existing toilet special room whose
+	// name matches a canonical alias (WC, then Toilette) case-insensitively,
+	// preferring earlier entries. Returns ErrRoomNotFound (wrapped in
+	// FacilitiesError) when no alias exists.
+	//
+	// excludeRoomID > 0 skips the row with that ID and continues searching
+	// the remaining aliases — used by update-time alias-collision checks
+	// where the row currently being updated must not count as its own
+	// duplicate. It does NOT short-circuit the loop, so a tenant with both
+	// aliases will still surface the non-excluded one.
+	FindToiletRoom(ctx context.Context, excludeRoomID int64) (*facilities.Room, error)
 	FindRoomsByBuilding(ctx context.Context, building string) ([]*facilities.Room, error)
 	FindRoomsByCategory(ctx context.Context, category string) ([]*facilities.Room, error)
 	FindRoomsByFloor(ctx context.Context, building string, floor int) ([]*facilities.Room, error)

--- a/backend/services/facilities/system_room_toilet_alias_test.go
+++ b/backend/services/facilities/system_room_toilet_alias_test.go
@@ -1,0 +1,120 @@
+package facilities_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/constants"
+	"github.com/moto-nrw/project-phoenix/models/facilities"
+	facilitiesSvc "github.com/moto-nrw/project-phoenix/services/facilities"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFacilitiesService_ToiletteAliasSystemProtection(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupFacilitiesService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("blocks renaming system room Toilette", func(t *testing.T) {
+		room := createRoomWithExactName(t, db, constants.WCRoomAliasName)
+		defer cleanupRoom(t, db, room.ID)
+
+		room.Name = "Ruheraum"
+		err := service.UpdateRoom(ctx, room)
+
+		require.Error(t, err)
+		require.True(t, errors.Is(err, facilitiesSvc.ErrSystemRoomProtected))
+	})
+
+	t.Run("blocks deletion of system room Toilette", func(t *testing.T) {
+		room := createRoomWithExactName(t, db, constants.WCRoomAliasName)
+		defer cleanupRoom(t, db, room.ID)
+
+		err := service.DeleteRoom(ctx, room.ID)
+
+		require.Error(t, err)
+		require.True(t, errors.Is(err, facilitiesSvc.ErrSystemRoomProtected))
+	})
+
+	t.Run("blocks color change on system room Toilette", func(t *testing.T) {
+		room := createRoomWithExactName(t, db, constants.WCRoomAliasName)
+		defer cleanupRoom(t, db, room.ID)
+
+		newColor := "#A3D977"
+		room.Color = &newColor
+		err := service.UpdateRoom(ctx, room)
+
+		require.Error(t, err)
+		require.True(t, errors.Is(err, facilitiesSvc.ErrSystemRoomProtected))
+	})
+}
+
+func TestFacilitiesService_CreateRoom_RejectsWCRoomAliasDuplicates(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupFacilitiesService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("rejects Toilette when WC already exists", func(t *testing.T) {
+		room := createRoomWithExactName(t, db, constants.WCRoomName)
+		defer cleanupRoom(t, db, room.ID)
+
+		aliasRoom := &facilities.Room{Name: constants.WCRoomAliasName, Building: "Test Building"}
+		err := service.CreateRoom(ctx, aliasRoom)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, facilitiesSvc.ErrDuplicateRoom))
+	})
+
+	t.Run("rejects WC when Toilette already exists", func(t *testing.T) {
+		room := createRoomWithExactName(t, db, constants.WCRoomAliasName)
+		defer cleanupRoom(t, db, room.ID)
+
+		aliasRoom := &facilities.Room{Name: constants.WCRoomName, Building: "Test Building"}
+		err := service.CreateRoom(ctx, aliasRoom)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, facilitiesSvc.ErrDuplicateRoom))
+	})
+}
+
+func TestFacilitiesService_UpdateRoom_RejectsWCRoomAliasDuplicates(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupFacilitiesService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("rejects renaming to Toilette when WC already exists", func(t *testing.T) {
+		wcRoom := createRoomWithExactName(t, db, constants.WCRoomName)
+		defer cleanupRoom(t, db, wcRoom.ID)
+
+		room := testpkg.CreateTestRoom(t, db, "AliasTarget")
+		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+
+		room.Name = constants.WCRoomAliasName
+		err := service.UpdateRoom(ctx, room)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, facilitiesSvc.ErrDuplicateRoom))
+	})
+
+	t.Run("rejects renaming to WC when Toilette already exists", func(t *testing.T) {
+		aliasRoom := createRoomWithExactName(t, db, constants.WCRoomAliasName)
+		defer cleanupRoom(t, db, aliasRoom.ID)
+
+		room := testpkg.CreateTestRoom(t, db, "CanonicalTarget")
+		defer testpkg.CleanupActivityFixtures(t, db, room.ID)
+
+		room.Name = constants.WCRoomName
+		err := service.UpdateRoom(ctx, room)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, facilitiesSvc.ErrDuplicateRoom))
+	})
+}

--- a/backend/services/facilities/wc_room_alias_internal_test.go
+++ b/backend/services/facilities/wc_room_alias_internal_test.go
@@ -2,6 +2,7 @@ package facilities
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -99,13 +100,23 @@ func TestWCService_ensureWCRoom_ReusesExistingToiletteAlias(t *testing.T) {
 // that scenario structurally impossible — duplicates per tenant are now
 // rejected at the DB layer. The canonical-iteration order in
 // FindToiletRoom is still exercised by the migration's own
-// TestRoomsWCAliasUniqueUp_PrefersCanonicalWC plus the lowercase-reuse
-// test below.
+// TestRoomsWCAliasUniqueUp_PrefersCanonicalWC.
 
-func TestWCService_ensureWCRoom_ReusesLowercaseWCRoom(t *testing.T) {
-	// Pre-existing tenants with a lowercase "wc" room have always reached
-	// the toilet flow because RoomRepository.FindByName matches via
-	// LOWER(name) = LOWER(?). FindToiletRoom must preserve that contract.
+func TestWCService_ensureWCRoom_IgnoresLowercaseWCRoom(t *testing.T) {
+	// Contract per issue #1184 review: only the exact-case names "WC" and
+	// "Toilette" are toilet system rooms. A lowercase "wc" must NOT be
+	// silently adopted by FindToiletRoom — otherwise it would be used as
+	// the WC special-room while remaining unprotected against rename/delete
+	// (constants.IsSystemRoomName is exact-case) and invisible to the IoT
+	// scan-fallback switch in api/iot/checkin/workflow.go (also exact-case).
+	//
+	// Practical consequence for tenants with a pre-existing lowercase room:
+	// FindToiletRoom skips it and ensureWCRoom proceeds to create canonical
+	// "WC", which then fails the case-insensitive duplicate guard in
+	// CreateRoom (LOWER(name) = LOWER(?)). The result is a stuck state
+	// surfaced as an error — the admin must rename the lowercase room
+	// before the IoT WC button works. That's acceptable: no silent data
+	// adoption, no invisible cross-layer drift.
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
 
@@ -117,7 +128,39 @@ func TestWCService_ensureWCRoom_ReusesLowercaseWCRoom(t *testing.T) {
 
 	room, err := service.ensureWCRoom(testpkg.TenantContext(1))
 
+	require.Error(t, err, "ensureWCRoom must not silently reuse lowercase wc and must surface the duplicate-name collision when auto-creating canonical WC")
+	assert.Nil(t, room)
+
+	// Lowercase room is untouched: its name stays "wc" and it remains a
+	// regular admin-managed room (deletable/renamable via the rooms admin).
+	var nameAfter string
+	err = db.NewSelect().
+		Table("facilities.rooms").
+		Column("name").
+		Where("id = ?", lowercaseWC.ID).
+		Scan(testpkg.TenantContext(1), &nameAfter)
 	require.NoError(t, err)
-	require.NotNil(t, room)
-	assert.Equal(t, lowercaseWC.ID, room.ID)
+	assert.Equal(t, "wc", nameAfter)
+}
+
+// TestFindToiletRoom_SkipsLowercaseWCRoom asserts the contract directly at
+// the FindToiletRoom layer: case-variants are skipped, ErrRoomNotFound is
+// returned. Companion to the ensureWCRoom test above — that one asserts the
+// downstream side-effect, this one asserts the lookup primitive.
+func TestFindToiletRoom_SkipsLowercaseWCRoom(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	cleanupWCRoomAliasArtifactsInternal(t, db)
+	defer cleanupWCRoomAliasArtifactsInternal(t, db)
+
+	service := setupWCServiceInternal(t, db)
+	_ = createWCRoomAliasRoomInternal(t, db, "wc")
+	_ = createWCRoomAliasRoomInternal(t, db, "toilette")
+
+	room, err := service.facilityService.FindToiletRoom(testpkg.TenantContext(1), 0)
+
+	require.Error(t, err)
+	assert.Nil(t, room)
+	assert.True(t, errors.Is(err, ErrRoomNotFound))
 }

--- a/backend/services/facilities/wc_room_alias_internal_test.go
+++ b/backend/services/facilities/wc_room_alias_internal_test.go
@@ -95,7 +95,7 @@ func TestWCService_ensureWCRoom_ReusesExistingToiletteAlias(t *testing.T) {
 }
 
 // Note: a "prefers canonical when both aliases coexist" test used to live
-// here. Migration 1.15.47 (uniq_facilities_rooms_tenant_wc_alias) makes
+// here. Migration 1.15.48 (uniq_facilities_rooms_tenant_wc_alias) makes
 // that scenario structurally impossible — duplicates per tenant are now
 // rejected at the DB layer. The canonical-iteration order in
 // FindToiletRoom is still exercised by the migration's own

--- a/backend/services/facilities/wc_room_alias_internal_test.go
+++ b/backend/services/facilities/wc_room_alias_internal_test.go
@@ -1,0 +1,123 @@
+package facilities
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/constants"
+	"github.com/moto-nrw/project-phoenix/models/facilities"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func cleanupWCRoomAliasArtifactsInternal(t *testing.T, db *bun.DB) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	type stmt struct {
+		sql  string
+		args []interface{}
+	}
+	stmts := []stmt{
+		{
+			`DELETE FROM active.groups WHERE room_id IN (SELECT id FROM facilities.rooms WHERE LOWER(name) IN (LOWER(?), LOWER(?)))`,
+			[]interface{}{constants.WCRoomName, constants.WCRoomAliasName},
+		},
+		{
+			`DELETE FROM activities.schedules WHERE activity_group_id IN (SELECT id FROM activities.groups WHERE name = ?)`,
+			[]interface{}{constants.WCActivityName},
+		},
+		{
+			`DELETE FROM activities.student_enrollments WHERE activity_group_id IN (SELECT id FROM activities.groups WHERE name = ?)`,
+			[]interface{}{constants.WCActivityName},
+		},
+		{
+			`DELETE FROM activities.groups WHERE name = ?`,
+			[]interface{}{constants.WCActivityName},
+		},
+		{
+			`DELETE FROM activities.categories WHERE name = ?`,
+			[]interface{}{constants.WCCategoryName},
+		},
+		{
+			`DELETE FROM facilities.rooms WHERE LOWER(name) IN (LOWER(?), LOWER(?))`,
+			[]interface{}{constants.WCRoomName, constants.WCRoomAliasName},
+		},
+	}
+
+	for _, s := range stmts {
+		if _, err := db.NewRaw(s.sql, s.args...).Exec(ctx); err != nil {
+			t.Logf("wc alias cleanup: %v (stmt: %s)", err, s.sql)
+		}
+	}
+}
+
+func createWCRoomAliasRoomInternal(t *testing.T, db *bun.DB, name string) *facilities.Room {
+	t.Helper()
+
+	ctx := testpkg.TenantContext(1)
+	room := &facilities.Room{
+		Name:     name,
+		Building: "Test Building",
+	}
+	room.SetTenantID(1)
+
+	err := db.NewInsert().
+		Model(room).
+		ModelTableExpr(`facilities.rooms`).
+		Scan(ctx)
+	require.NoError(t, err)
+
+	return room
+}
+
+func TestWCService_ensureWCRoom_ReusesExistingToiletteAlias(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	cleanupWCRoomAliasArtifactsInternal(t, db)
+	defer cleanupWCRoomAliasArtifactsInternal(t, db)
+
+	service := setupWCServiceInternal(t, db)
+	aliasRoom := createWCRoomAliasRoomInternal(t, db, constants.WCRoomAliasName)
+
+	room, err := service.ensureWCRoom(testpkg.TenantContext(1))
+
+	require.NoError(t, err)
+	require.NotNil(t, room)
+	assert.Equal(t, aliasRoom.ID, room.ID)
+	assert.Equal(t, constants.WCRoomAliasName, room.Name)
+}
+
+// Note: a "prefers canonical when both aliases coexist" test used to live
+// here. Migration 1.15.47 (uniq_facilities_rooms_tenant_wc_alias) makes
+// that scenario structurally impossible — duplicates per tenant are now
+// rejected at the DB layer. The canonical-iteration order in
+// FindToiletRoom is still exercised by the migration's own
+// TestRoomsWCAliasUniqueUp_PrefersCanonicalWC plus the lowercase-reuse
+// test below.
+
+func TestWCService_ensureWCRoom_ReusesLowercaseWCRoom(t *testing.T) {
+	// Pre-existing tenants with a lowercase "wc" room have always reached
+	// the toilet flow because RoomRepository.FindByName matches via
+	// LOWER(name) = LOWER(?). FindToiletRoom must preserve that contract.
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	cleanupWCRoomAliasArtifactsInternal(t, db)
+	defer cleanupWCRoomAliasArtifactsInternal(t, db)
+
+	service := setupWCServiceInternal(t, db)
+	lowercaseWC := createWCRoomAliasRoomInternal(t, db, "wc")
+
+	room, err := service.ensureWCRoom(testpkg.TenantContext(1))
+
+	require.NoError(t, err)
+	require.NotNil(t, room)
+	assert.Equal(t, lowercaseWC.ID, room.ID)
+}

--- a/backend/services/facilities/wc_service.go
+++ b/backend/services/facilities/wc_service.go
@@ -132,12 +132,12 @@ func (s *wcService) findWCActivity(ctx context.Context) (*activityModels.Group, 
 
 // ensureWCRoom finds or creates the WC room.
 func (s *wcService) ensureWCRoom(ctx context.Context) (*facilities.Room, error) {
-	// Try to find existing WC room
-	room, err := s.facilityService.FindRoomByName(ctx, constants.WCRoomName)
+	room, err := s.facilityService.FindToiletRoom(ctx, 0)
 	if err == nil && room != nil {
 		s.getLogger().Info("found existing WC room",
 			slog.String("component", "wc"),
-			slog.Int64("room_id", room.ID))
+			slog.Int64("room_id", room.ID),
+			slog.String("room_name", room.Name))
 		return room, nil
 	}
 	if err != nil && !errors.Is(err, ErrRoomNotFound) {
@@ -160,9 +160,8 @@ func (s *wcService) ensureWCRoom(ctx context.Context) (*facilities.Room, error) 
 	}
 
 	if err := s.facilityService.CreateRoom(ctx, newRoom); err != nil {
-		// Retry: concurrent request may have created it
-		room, retryErr := s.facilityService.FindRoomByName(ctx, constants.WCRoomName)
-		if retryErr == nil && room != nil {
+		// Retry: concurrent request may have created one of the accepted aliases
+		if room, retryErr := s.facilityService.FindToiletRoom(ctx, 0); retryErr == nil && room != nil {
 			return room, nil
 		}
 		return nil, fmt.Errorf("failed to create WC room: %w", err)

--- a/frontend/src/lib/room-helpers.test.ts
+++ b/frontend/src/lib/room-helpers.test.ts
@@ -571,8 +571,13 @@ describe("isSystemRoom", () => {
     expect(isSystemRoom(room)).toBe(true);
   });
 
+  it("returns true for Toilette", () => {
+    const room: Room = { id: "3", name: "Toilette", isOccupied: false };
+    expect(isSystemRoom(room)).toBe(true);
+  });
+
   it("returns false for regular room", () => {
-    const room: Room = { id: "3", name: "Gruppenraum 1", isOccupied: false };
+    const room: Room = { id: "4", name: "Gruppenraum 1", isOccupied: false };
     expect(isSystemRoom(room)).toBe(false);
   });
 

--- a/frontend/src/lib/room-helpers.ts
+++ b/frontend/src/lib/room-helpers.ts
@@ -45,10 +45,13 @@ export interface Room {
 }
 
 // System room names that cannot be deleted or renamed.
-// Must stay in sync with backend constants/activities.go.
-const SYSTEM_ROOM_NAMES = ["Schulhof", "WC"] as const;
+// Must stay in sync with backend constants/activities.go
+// (SchulhofRoomName, WCRoomName, WCRoomAliasName) and PyrePortal
+// src/services/api.ts (WC_ROOM_ALIASES). Matching is exact-case to mirror
+// the backend's `name == SchulhofRoomName || IsWCRoomName(name)` check.
+const SYSTEM_ROOM_NAMES = ["Schulhof", "WC", "Toilette"] as const;
 
-/** Returns true if the room is a system room (Schulhof, WC). */
+/** Returns true if the room is a system room (Schulhof, WC, Toilette). */
 export function isSystemRoom(room: Room | null | undefined): boolean {
   if (!room) return false;
   return SYSTEM_ROOM_NAMES.includes(


### PR DESCRIPTION
Companion PR: https://github.com/moto-nrw/PyrePortal/pull/336
Closes #1184

## Summary

- `IsWCRoomName(name)` accepts both `WC` (canonical, auto-created) and `Toilette` (manually-created alias). `IsSystemRoomName` delegates to it, so rename/delete/color protection automatically covers `Toilette` rooms — no separate guard needed.
- New `Service.FindToiletRoom(ctx, excludeRoomID)` resolves the toilet special-room by iterating canonical-first (`WC` then `Toilette`). Used by the auto-create flow in `api/iot/checkin/wc.go` and `services/facilities/wc_service.go` so an existing alias is reused instead of producing duplicates.
- **Exact-case contract across all layers** (per #1184 review): only the names `"WC"` and `"Toilette"` count as toilet system rooms. `FindToiletRoom` re-filters the result of the case-insensitive `RoomRepository.FindByName` with `IsWCRoomName` so non-canonical case variants (e.g. lowercase `wc`) are skipped. This aligns `FindToiletRoom` with `IsWCRoomName`, `IsSystemRoomName`, the rename/delete guards, the IoT scan-fallback in `api/iot/checkin/workflow.go`, and the partial unique index from migration 1.15.48 — all exact-case.
- `CreateRoom` and `UpdateRoom` reject creating/renaming to a second alias when one already exists for the tenant, with a DB-level partial unique index `WHERE name IN ('WC','Toilette')` (migration 1.15.48) closing the TOCTOU race the app guard can't reach.
- Migration 1.15.48 also archives pre-existing duplicates per tenant — picks a canonical winner (most active groups, then `WC` over `Toilette`, then oldest id), renames losers to `<name> (archiviert v1.15.48 id=<id>)`, and writes originals to `audit.wc_alias_migration_backup` for manual restore.
- Frontend `SYSTEM_ROOM_NAMES` in `room-helpers.ts` adds `Toilette` so the rooms admin UI treats it as a protected system room (sync note links the three-way invariant: backend constants, frontend helper, PyrePortal `WC_ROOM_ALIASES`).
- Activity / category logic untouched — only room-name detection broadens, the WC activity name remains `WCActivityName`.

## Behavior matrix

| Tenant state | Before | After |
|---|---|---|
| Has room `WC` | Toilet flow works | Toilet flow works (unchanged) |
| Has room `Toilette` (manually created) | Auto-create makes a duplicate `WC` room | Existing `Toilette` is reused |
| Has neither | Auto-creates one canonical `WC` | Same |
| Has both (legacy / accidental) | N/A | Migration 1.15.48 picks one and archives the loser |
| Admin tries to create `Toilette` while `WC` exists | Allowed (duplicate) | Rejected with `ErrDuplicateRoom` (app guard + DB index) |
| Has only lowercase `wc` (no canonical) | Toilet flow worked (silent adoption) | **Toilet flow returns an error until admin renames the room to `WC`** |

## Behavioral regression to flag

Tenants that have *only* a lowercase `wc` room (no canonical `WC` or `Toilette`) lose the kiosk toilet flow until an admin renames the room. This is the cost of picking the exact-case contract from yungweng's review — the previous "silent adoption" was the bug, because the adopted room was unprotected against rename/delete and invisible to other layers. Stuck state surfaces as a clear error, not silent corruption. Worth a heads-up for staging operators on rollout.

## Out of scope

- The case-insensitive lookup in `RoomRepository.FindByName` (`LOWER(name) = LOWER(?)`) is pre-existing and intentionally preserved — `CreateRoom`'s duplicate-name guard relies on it. `FindToiletRoom` enforces exact-case at the call site via `IsWCRoomName` re-check rather than tightening `FindByName` itself.
- Pre-existing failures in `TestRepairPickupScheduleTenantIDs*` (migration 1.15.39 tests) are unrelated to this branch.

## Test plan

- [ ] `cd backend && go test ./constants/... ./services/facilities/... ./api/iot/checkin/... ./database/migrations/... -run "WC|Toilet|System"` — all alias tests green (includes new `TestFindToiletRoom_SkipsLowercaseWCRoom`, `TestEnsureWCRoom_IgnoresLowercaseWCRoom`, `TestWCService_ensureWCRoom_IgnoresLowercaseWCRoom`)
- [ ] `cd backend && go test ./test/ -run TestHermeticTestPatterns -v` — hermetic check green
- [ ] `cd backend && ./main migrate validate` — dependency graph valid
- [ ] `cd frontend && pnpm run check` — no warnings
- [ ] On a staging tenant that *only* has a `WC` room: kiosk Toilette flow still works, auto-create still produces `WC`
- [ ] On a staging tenant that *only* has a `Toilette` room: kiosk Toilette flow works, no duplicate `WC` is created on first scan
- [ ] On a staging tenant with neither: kiosk Toilette flow auto-creates `WC` (canonical)
- [ ] On a staging tenant with *only* a lowercase `wc` room: kiosk Toilette flow surfaces an error (admin must rename to `WC` to unblock)
- [ ] Admin UI: deleting/renaming/recoloring a `Toilette` room is blocked with the existing system-room message
- [ ] Admin UI: creating a second toilet alias while one exists returns `ErrDuplicateRoom`
- [ ] Run the migration on a staging snapshot containing pre-existing duplicates — losers archived, `audit.wc_alias_migration_backup` populated, partial unique index built

## Cross-repo coordination

Phoenix is backwards-compatible with the old kiosk (no behavior change for tenants currently on `WC`), so this can land first. The companion PyrePortal PR adds the kiosk-side alias detection so `Toilette`-named rooms light up the toilet button.