### PR TITLE
fix(frontend): make edit modals usable on mobile master/detail drawer

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@fontsource/geist-sans": "^5.2.5",
     "@moto-nrw/design-system": "^0.5.2",
+    "@radix-ui/react-focus-scope": "^1.1.7",
     "@radix-ui/react-tabs": "^1.1.13",
     "@sentry/nextjs": "^10.50.0",
     "@t3-oss/env-nextjs": "^0.13.11",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@moto-nrw/design-system':
         specifier: ^0.5.2
         version: 0.5.2(lucide-react@1.11.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-scope':
+        specifier: ^1.1.7
+        version: 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/frontend/src/components/dashboard/modal-context.test.tsx
+++ b/frontend/src/components/dashboard/modal-context.test.tsx
@@ -88,6 +88,53 @@ describe("useModal", () => {
       expect(result.current.closeModal).toBe(initialCloseModal);
     });
 
+    it("stays open while a stacked modal opens and closes on top", () => {
+      const { result } = renderHook(() => useModal(), {
+        wrapper: ModalProviderWrapper,
+      });
+
+      // Outer modal opens.
+      act(() => {
+        result.current.openModal();
+      });
+      expect(result.current.isModalOpen).toBe(true);
+
+      // Inner modal opens on top.
+      act(() => {
+        result.current.openModal();
+      });
+      expect(result.current.isModalOpen).toBe(true);
+
+      // Inner modal unmounts. Outer is still open, so the flag must stay true.
+      act(() => {
+        result.current.closeModal();
+      });
+      expect(result.current.isModalOpen).toBe(true);
+
+      // Outer modal unmounts last.
+      act(() => {
+        result.current.closeModal();
+      });
+      expect(result.current.isModalOpen).toBe(false);
+    });
+
+    it("clamps closeModal at zero when called too often", () => {
+      const { result } = renderHook(() => useModal(), {
+        wrapper: ModalProviderWrapper,
+      });
+
+      act(() => {
+        result.current.closeModal();
+        result.current.closeModal();
+      });
+      expect(result.current.isModalOpen).toBe(false);
+
+      act(() => {
+        result.current.openModal();
+      });
+      expect(result.current.isModalOpen).toBe(true);
+    });
+
     it("should handle multiple open/close cycles", () => {
       const { result } = renderHook(() => useModal(), {
         wrapper: ModalProviderWrapper,

--- a/frontend/src/components/dashboard/modal-context.tsx
+++ b/frontend/src/components/dashboard/modal-context.tsx
@@ -19,19 +19,24 @@ const ModalContext = createContext<ModalContextType | undefined>(undefined);
 export function ModalProvider({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  // Counter rather than boolean so that stacked modals (e.g. an edit modal
+  // opening a confirmation modal on top) only report `isModalOpen=false` once
+  // every modal has unmounted. Otherwise the inner modal's cleanup would flip
+  // the flag while the outer modal is still open, which would let the mobile
+  // master/detail drawer dismiss itself out from under it.
+  const [openCount, setOpenCount] = useState(0);
 
   const openModal = useCallback(() => {
-    setIsModalOpen(true);
+    setOpenCount((count) => count + 1);
   }, []);
 
   const closeModal = useCallback(() => {
-    setIsModalOpen(false);
+    setOpenCount((count) => (count > 0 ? count - 1 : 0));
   }, []);
 
   const contextValue = useMemo(
-    () => ({ isModalOpen, openModal, closeModal }),
-    [isModalOpen, openModal, closeModal],
+    () => ({ isModalOpen: openCount > 0, openModal, closeModal }),
+    [openCount, openModal, closeModal],
   );
 
   return (

--- a/frontend/src/components/database/master-detail-layout.test.tsx
+++ b/frontend/src/components/database/master-detail-layout.test.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
@@ -27,9 +28,53 @@ vi.mock("~/components/ui/drawer", () => ({
       {children}
     </div>
   ),
-  DrawerContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="drawer-content">{children}</div>
-  ),
+  DrawerContent: ({
+    children,
+    onInteractOutside,
+    onEscapeKeyDown,
+  }: {
+    children: React.ReactNode;
+    onInteractOutside?: (event: { preventDefault: () => void }) => void;
+    onEscapeKeyDown?: (event: { preventDefault: () => void }) => void;
+  }) => {
+    const fireOutside = () => {
+      const event = { defaultPrevented: false, preventDefault: vi.fn() };
+      onInteractOutside?.(event);
+      (
+        globalThis as unknown as {
+          __lastOutsideEvent: typeof event;
+        }
+      ).__lastOutsideEvent = event;
+    };
+    const fireEscape = () => {
+      const event = { defaultPrevented: false, preventDefault: vi.fn() };
+      onEscapeKeyDown?.(event);
+      (
+        globalThis as unknown as {
+          __lastEscapeEvent: typeof event;
+        }
+      ).__lastEscapeEvent = event;
+    };
+    return (
+      <div data-testid="drawer-content">
+        <button
+          type="button"
+          data-testid="drawer-fire-outside"
+          onClick={fireOutside}
+        >
+          outside
+        </button>
+        <button
+          type="button"
+          data-testid="drawer-fire-escape"
+          onClick={fireEscape}
+        >
+          escape
+        </button>
+        {children}
+      </div>
+    );
+  },
   DrawerHeader: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -46,7 +91,19 @@ class MockResizeObserver {
 vi.stubGlobal("ResizeObserver", MockResizeObserver);
 
 import { useIsMobile } from "~/hooks/useIsMobile";
+import { ModalProvider, useModal } from "../dashboard/modal-context";
 import { MasterDetailLayout } from "./master-detail-layout";
+
+function ModalSwitch({ open }: { open: boolean }) {
+  const { openModal, closeModal } = useModal();
+  React.useEffect(() => {
+    if (open) {
+      openModal();
+      return () => closeModal();
+    }
+  }, [open, openModal, closeModal]);
+  return null;
+}
 
 describe("MasterDetailLayout", () => {
   beforeEach(() => {
@@ -172,6 +229,74 @@ describe("MasterDetailLayout", () => {
 
       fireEvent.click(screen.getByTestId("drawer-close"));
       expect(onDeselect).toHaveBeenCalled();
+    });
+
+    it("preventsDefault on outside-interaction while a modal is open", () => {
+      const onDeselect = vi.fn();
+      render(
+        <ModalProvider>
+          <ModalSwitch open={true} />
+          <MasterDetailLayout
+            list={<div>List</div>}
+            detail={<div>Detail</div>}
+            selectedId="1"
+            onDeselect={onDeselect}
+          />
+        </ModalProvider>,
+      );
+
+      fireEvent.click(screen.getByTestId("drawer-fire-outside"));
+      const event = (
+        globalThis as unknown as {
+          __lastOutsideEvent: { preventDefault: ReturnType<typeof vi.fn> };
+        }
+      ).__lastOutsideEvent;
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("does not preventDefault on outside-interaction without an open modal", () => {
+      const onDeselect = vi.fn();
+      render(
+        <ModalProvider>
+          <ModalSwitch open={false} />
+          <MasterDetailLayout
+            list={<div>List</div>}
+            detail={<div>Detail</div>}
+            selectedId="1"
+            onDeselect={onDeselect}
+          />
+        </ModalProvider>,
+      );
+
+      fireEvent.click(screen.getByTestId("drawer-fire-outside"));
+      const event = (
+        globalThis as unknown as {
+          __lastOutsideEvent: { preventDefault: ReturnType<typeof vi.fn> };
+        }
+      ).__lastOutsideEvent;
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("preventsDefault on escape while a modal is open", () => {
+      render(
+        <ModalProvider>
+          <ModalSwitch open={true} />
+          <MasterDetailLayout
+            list={<div>List</div>}
+            detail={<div>Detail</div>}
+            selectedId="1"
+            onDeselect={vi.fn()}
+          />
+        </ModalProvider>,
+      );
+
+      fireEvent.click(screen.getByTestId("drawer-fire-escape"));
+      const event = (
+        globalThis as unknown as {
+          __lastEscapeEvent: { preventDefault: ReturnType<typeof vi.fn> };
+        }
+      ).__lastEscapeEvent;
+      expect(event.preventDefault).toHaveBeenCalled();
     });
 
     it("exposes drawer title via sr-only header", () => {

--- a/frontend/src/components/database/master-detail-layout.tsx
+++ b/frontend/src/components/database/master-detail-layout.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useIsMobile } from "~/hooks/useIsMobile";
+import { useModal } from "~/components/dashboard/modal-context";
 import { cn } from "~/lib/utils";
 import {
   Drawer,
@@ -40,6 +41,7 @@ export function MasterDetailLayout({
   unselectedBehavior = "placeholder",
 }: MasterDetailLayoutProps) {
   const isMobile = useIsMobile();
+  const { isModalOpen } = useModal();
   const containerRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState<string>("100dvh");
 
@@ -77,7 +79,21 @@ export function MasterDetailLayout({
             if (!open) onDeselect();
           }}
         >
-          <DrawerContent className="max-h-[90vh]" aria-describedby={undefined}>
+          <DrawerContent
+            className="max-h-[90vh]"
+            aria-describedby={undefined}
+            // Modals (Edit/Confirmation) portal to document.body and therefore
+            // live outside the drawer's DOM. Without these guards Vaul's
+            // DismissableLayer treats every tap inside an open modal as an
+            // outside-click and closes the drawer — which unmounts the modal
+            // before the user can interact with it. See issue #1358.
+            onInteractOutside={(event) => {
+              if (isModalOpen) event.preventDefault();
+            }}
+            onEscapeKeyDown={(event) => {
+              if (isModalOpen) event.preventDefault();
+            }}
+          >
             <DrawerHeader className="sr-only">
               <DrawerTitle>{mobileDrawerTitle}</DrawerTitle>
             </DrawerHeader>

--- a/frontend/src/components/ui/form-modal.test.tsx
+++ b/frontend/src/components/ui/form-modal.test.tsx
@@ -74,6 +74,25 @@ describe("FormModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("removes the backdrop from the tab order so FocusScope cannot land on it", async () => {
+    render(
+      <TestWrapper>
+        <FormModal isOpen={true} onClose={vi.fn()} title="Test">
+          <input data-testid="first-field" />
+        </FormModal>
+      </TestWrapper>,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(20);
+    });
+
+    const backdrop = screen.getByRole("button", {
+      name: /hintergrund.*schließen/i,
+    });
+    expect(backdrop).toHaveAttribute("tabIndex", "-1");
+  });
+
   it("should call onClose when backdrop is clicked", async () => {
     const onClose = vi.fn();
     render(

--- a/frontend/src/components/ui/form-modal.tsx
+++ b/frontend/src/components/ui/form-modal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useCallback, useState, useRef } from "react";
 import type { ReactNode } from "react";
 import { createPortal } from "react-dom";
+import { FocusScope } from "@radix-ui/react-focus-scope";
 import { useModal } from "../dashboard/modal-context";
 import { useScrollLock } from "~/hooks/useScrollLock";
 import { dialogAriaProps } from "./modal-utils";
@@ -105,101 +106,124 @@ export function FormModal({
       ? "rounded-t-2xl md:rounded-2xl"
       : "rounded-2xl";
   const modalContent = (
-    <div
-      className={`fixed inset-0 z-[9999] flex ${mobilePosition === "bottom" ? "items-end" : "items-center"} justify-center md:items-center md:p-6`}
-      style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0 }}
-    >
-      {/* Backdrop button - native button for accessibility (keyboard + click support) */}
-      <button
-        type="button"
-        onClick={handleClose}
-        aria-label="Hintergrund - Klicken zum Schließen"
-        className={`absolute inset-0 cursor-default border-none bg-transparent p-0 transition-all duration-200 ease-out ${
-          isAnimating && !isExiting ? "bg-black/40" : "bg-black/0"
-        }`}
-        style={{
-          animation:
-            isAnimating && !isExiting
-              ? "backdropEnter 200ms ease-out"
-              : undefined,
-        }}
-      />
-      {/* Dialog container */}
+    // Wrapping in FocusScope pushes a new entry onto Radix's focusScopesStack,
+    // which auto-pauses any parent FocusScope (notably Vaul's drawer focus
+    // trap). Without this, taps on inputs inside this modal are stolen back
+    // by the drawer because the modal is portaled to document.body and counts
+    // as "outside" the drawer's scope.
+    <FocusScope asChild loop trapped>
       <div
-        className={`relative w-full ${sizeClasses[size]} max-h-[90vh] md:max-h-[85vh] ${radiusClass} ${mobilePosition === "center" ? "mx-4" : ""} transform overflow-hidden border border-gray-200/50 shadow-2xl ${(() => {
-          if (isAnimating && !isExiting) return "animate-modalEnter";
-          if (isExiting) return "animate-modalExit";
-          return "translate-y-8 scale-75 -rotate-1 opacity-0";
-        })()}`}
-        {...dialogAriaProps}
+        className={`fixed inset-0 z-[9999] flex ${mobilePosition === "bottom" ? "items-end" : "items-center"} justify-center md:items-center md:p-6`}
+        // pointerEvents: 'auto' is required when this modal is rendered while
+        // a Radix/Vaul dialog (e.g. the mobile master/detail drawer) has set
+        // `document.body { pointer-events: none }`. Without this, the modal
+        // is portaled to body and inherits `none`, leaving inputs unclickable.
         style={{
-          background:
-            "linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(248,250,252,0.98) 100%)",
-          backdropFilter: "blur(20px)",
-          boxShadow:
-            "0 25px 50px -12px rgba(0, 0, 0, 0.25), 0 8px 16px -8px rgba(80, 128, 216, 0.15)",
-          animationFillMode: "both",
+          position: "fixed",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          pointerEvents: "auto",
         }}
       >
-        {/* Header with close button */}
-        <div className="flex items-center justify-between border-b border-gray-100 p-4 md:p-6">
-          {title && (
-            <h3 className="pr-4 text-lg font-semibold text-gray-900 md:text-xl">
-              {title}
-            </h3>
-          )}
-          <button
-            onClick={handleClose}
-            className="group relative flex-shrink-0 rounded-xl p-2 text-gray-400 transition-all duration-200 hover:scale-105 hover:bg-gray-100 hover:text-gray-600 active:scale-95"
-            aria-label="Modal schließen"
-          >
-            {/* Animated X icon */}
-            <svg
-              className="h-5 w-5 transition-transform duration-200 group-hover:rotate-90"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-
-            {/* Subtle hover glow */}
-            <div
-              className="absolute inset-0 rounded-xl opacity-0 transition-opacity duration-200 group-hover:opacity-100"
-              style={{
-                boxShadow: "0 0 12px rgba(80,128,216,0.3)",
-              }}
-            />
-          </button>
-        </div>
-
-        {/* Content area with custom scrollbar and reveal animation */}
+        {/* Backdrop button - dismiss-on-tap target. Excluded from the tab
+            order (tabIndex=-1) so the FocusScope auto-focus doesn't land on
+            this invisible control; ESC is the keyboard equivalent. */}
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={handleClose}
+          aria-label="Hintergrund - Klicken zum Schließen"
+          className={`absolute inset-0 cursor-default border-none bg-transparent p-0 transition-all duration-200 ease-out ${
+            isAnimating && !isExiting ? "bg-black/40" : "bg-black/0"
+          }`}
+          style={{
+            animation:
+              isAnimating && !isExiting
+                ? "backdropEnter 200ms ease-out"
+                : undefined,
+          }}
+        />
+        {/* Dialog container */}
         <div
-          data-modal-content="true"
-          className={`${footer ? "max-h-[calc(90vh-240px)] md:max-h-[calc(85vh-240px)]" : "max-h-[60vh] md:max-h-[70vh]"} scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100 overflow-y-auto`}
+          className={`relative w-full ${sizeClasses[size]} max-h-[90vh] md:max-h-[85vh] ${radiusClass} ${mobilePosition === "center" ? "mx-4" : ""} transform overflow-hidden border border-gray-200/50 shadow-2xl ${(() => {
+            if (isAnimating && !isExiting) return "animate-modalEnter";
+            if (isExiting) return "animate-modalExit";
+            return "translate-y-8 scale-75 -rotate-1 opacity-0";
+          })()}`}
+          {...dialogAriaProps}
+          style={{
+            background:
+              "linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(248,250,252,0.98) 100%)",
+            backdropFilter: "blur(20px)",
+            boxShadow:
+              "0 25px 50px -12px rgba(0, 0, 0, 0.25), 0 8px 16px -8px rgba(80, 128, 216, 0.15)",
+            animationFillMode: "both",
+          }}
         >
-          <div
-            className={`p-4 leading-relaxed text-gray-700 md:p-6 ${
-              isAnimating && !isExiting ? "animate-contentReveal" : "opacity-0"
-            }`}
-          >
-            {children}
-          </div>
-        </div>
+          {/* Header with close button */}
+          <div className="flex items-center justify-between border-b border-gray-100 p-4 md:p-6">
+            {title && (
+              <h3 className="pr-4 text-lg font-semibold text-gray-900 md:text-xl">
+                {title}
+              </h3>
+            )}
+            <button
+              onClick={handleClose}
+              className="group relative flex-shrink-0 rounded-xl p-2 text-gray-400 transition-all duration-200 hover:scale-105 hover:bg-gray-100 hover:text-gray-600 active:scale-95"
+              aria-label="Modal schließen"
+            >
+              {/* Animated X icon */}
+              <svg
+                className="h-5 w-5 transition-transform duration-200 group-hover:rotate-90"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
 
-        {/* Footer if provided - now sticky at bottom */}
-        {footer && (
-          <div className="sticky bottom-0 flex flex-wrap justify-end gap-3 border-t border-gray-100 bg-gray-50/95 p-4 backdrop-blur-sm md:p-6">
-            {footer}
+              {/* Subtle hover glow */}
+              <div
+                className="absolute inset-0 rounded-xl opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+                style={{
+                  boxShadow: "0 0 12px rgba(80,128,216,0.3)",
+                }}
+              />
+            </button>
           </div>
-        )}
+
+          {/* Content area with custom scrollbar and reveal animation */}
+          <div
+            data-modal-content="true"
+            className={`${footer ? "max-h-[calc(90vh-240px)] md:max-h-[calc(85vh-240px)]" : "max-h-[60vh] md:max-h-[70vh]"} scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100 overflow-y-auto`}
+          >
+            <div
+              className={`p-4 leading-relaxed text-gray-700 md:p-6 ${
+                isAnimating && !isExiting
+                  ? "animate-contentReveal"
+                  : "opacity-0"
+              }`}
+            >
+              {children}
+            </div>
+          </div>
+
+          {/* Footer if provided - now sticky at bottom */}
+          {footer && (
+            <div className="sticky bottom-0 flex flex-wrap justify-end gap-3 border-t border-gray-100 bg-gray-50/95 p-4 backdrop-blur-sm md:p-6">
+              {footer}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </FocusScope>
   );
 
   // Render to body to avoid any positioning issues

--- a/frontend/src/components/ui/modal.test.tsx
+++ b/frontend/src/components/ui/modal.test.tsx
@@ -141,6 +141,25 @@ describe("Modal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("removes the backdrop from the tab order so FocusScope cannot land on it", async () => {
+    render(
+      <TestWrapper>
+        <Modal isOpen={true} onClose={vi.fn()} title="Test">
+          <input data-testid="first-field" />
+        </Modal>
+      </TestWrapper>,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(20);
+    });
+
+    const backdrop = screen.getByRole("button", {
+      name: /hintergrund.*schließen/i,
+    });
+    expect(backdrop).toHaveAttribute("tabIndex", "-1");
+  });
+
   it("should call onClose when backdrop is clicked", async () => {
     const onClose = vi.fn();
     render(

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
+import { FocusScope } from "@radix-ui/react-focus-scope";
 import { useModal } from "../dashboard/modal-context";
 import { useScrollLock } from "~/hooks/useScrollLock";
 import { dialogAriaProps, getModalAnimationClass } from "./modal-utils";
@@ -89,47 +90,98 @@ export function Modal({
   if (!isOpen) return null;
 
   const modalContent = (
-    <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center"
-      style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0 }}
-    >
-      {/* Backdrop button - native button for accessibility (keyboard + click support) */}
-      <button
-        type="button"
-        onClick={handleClose}
-        aria-label="Hintergrund - Klicken zum Schließen"
-        className={`absolute inset-0 cursor-default border-none bg-transparent p-0 transition-all duration-200 ease-out ${
-          isAnimating && !isExiting ? "bg-black/40" : "bg-black/0"
-        }`}
-        style={{
-          animation:
-            isAnimating && !isExiting
-              ? "backdropEnter 200ms ease-out"
-              : undefined,
-        }}
-      />
-      {/* Dialog container */}
+    // Wrapping in FocusScope pushes a new entry onto Radix's focusScopesStack,
+    // which auto-pauses any parent FocusScope (notably Vaul's drawer focus
+    // trap). Without this, taps on inputs inside this modal are stolen back
+    // by the drawer because the modal is portaled to document.body and counts
+    // as "outside" the drawer's scope.
+    <FocusScope asChild loop trapped>
       <div
-        className={`relative mx-4 w-[calc(100%-2rem)] max-w-lg transform overflow-hidden rounded-2xl border border-gray-200/50 shadow-2xl ${getModalAnimationClass(isAnimating, isExiting)}`}
-        {...dialogAriaProps}
+        className="fixed inset-0 z-[9999] flex items-center justify-center"
+        // pointerEvents: 'auto' is required when this modal is rendered while
+        // a Radix/Vaul dialog (e.g. the mobile master/detail drawer) has set
+        // `document.body { pointer-events: none }`. Without this, the modal
+        // is portaled to body and inherits `none`, leaving inputs unclickable.
         style={{
-          background:
-            "linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(248,250,252,0.98) 100%)",
-          backdropFilter: "blur(20px)",
-          boxShadow:
-            "0 25px 50px -12px rgba(0, 0, 0, 0.25), 0 8px 16px -8px rgba(80, 128, 216, 0.15)",
-          animationFillMode: "both",
+          position: "fixed",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          pointerEvents: "auto",
         }}
       >
-        {/* Header with close button - only show border if title exists */}
-        {title ? (
-          <div className="flex items-center justify-between border-b border-gray-100 p-4 sm:p-6">
-            <h3 className="pr-4 text-lg font-semibold text-gray-900 sm:text-xl">
-              {title}
-            </h3>
+        {/* Backdrop button - dismiss-on-tap target. Excluded from the tab
+            order (tabIndex=-1) so the FocusScope auto-focus doesn't land on
+            this invisible control; ESC is the keyboard equivalent. */}
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={handleClose}
+          aria-label="Hintergrund - Klicken zum Schließen"
+          className={`absolute inset-0 cursor-default border-none bg-transparent p-0 transition-all duration-200 ease-out ${
+            isAnimating && !isExiting ? "bg-black/40" : "bg-black/0"
+          }`}
+          style={{
+            animation:
+              isAnimating && !isExiting
+                ? "backdropEnter 200ms ease-out"
+                : undefined,
+          }}
+        />
+        {/* Dialog container */}
+        <div
+          className={`relative mx-4 w-[calc(100%-2rem)] max-w-lg transform overflow-hidden rounded-2xl border border-gray-200/50 shadow-2xl ${getModalAnimationClass(isAnimating, isExiting)}`}
+          {...dialogAriaProps}
+          style={{
+            background:
+              "linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(248,250,252,0.98) 100%)",
+            backdropFilter: "blur(20px)",
+            boxShadow:
+              "0 25px 50px -12px rgba(0, 0, 0, 0.25), 0 8px 16px -8px rgba(80, 128, 216, 0.15)",
+            animationFillMode: "both",
+          }}
+        >
+          {/* Header with close button - only show border if title exists */}
+          {title ? (
+            <div className="flex items-center justify-between border-b border-gray-100 p-4 sm:p-6">
+              <h3 className="pr-4 text-lg font-semibold text-gray-900 sm:text-xl">
+                {title}
+              </h3>
+              <button
+                onClick={handleClose}
+                className="group relative flex-shrink-0 rounded-xl p-2 text-gray-400 transition-all duration-200 hover:scale-105 hover:bg-gray-100 hover:text-gray-600 active:scale-95"
+                aria-label="Modal schließen"
+              >
+                {/* Animated X icon */}
+                <svg
+                  className="h-5 w-5 transition-transform duration-200 group-hover:rotate-90"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+
+                {/* Subtle hover glow */}
+                <div
+                  className="absolute inset-0 rounded-xl opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+                  style={{
+                    boxShadow: "0 0 12px rgba(80,128,216,0.3)",
+                  }}
+                />
+              </button>
+            </div>
+          ) : (
+            /* X button positioned absolutely in top-right when no title */
             <button
               onClick={handleClose}
-              className="group relative flex-shrink-0 rounded-xl p-2 text-gray-400 transition-all duration-200 hover:scale-105 hover:bg-gray-100 hover:text-gray-600 active:scale-95"
+              className="group absolute top-4 right-4 z-10 rounded-xl p-2 text-gray-400 transition-all duration-200 hover:scale-105 hover:bg-gray-100 hover:text-gray-600 active:scale-95"
               aria-label="Modal schließen"
             >
               {/* Animated X icon */}
@@ -155,61 +207,33 @@ export function Modal({
                 }}
               />
             </button>
-          </div>
-        ) : (
-          /* X button positioned absolutely in top-right when no title */
-          <button
-            onClick={handleClose}
-            className="group absolute top-4 right-4 z-10 rounded-xl p-2 text-gray-400 transition-all duration-200 hover:scale-105 hover:bg-gray-100 hover:text-gray-600 active:scale-95"
-            aria-label="Modal schließen"
-          >
-            {/* Animated X icon */}
-            <svg
-              className="h-5 w-5 transition-transform duration-200 group-hover:rotate-90"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
+          )}
 
-            {/* Subtle hover glow */}
-            <div
-              className="absolute inset-0 rounded-xl opacity-0 transition-opacity duration-200 group-hover:opacity-100"
-              style={{
-                boxShadow: "0 0 12px rgba(80,128,216,0.3)",
-              }}
-            />
-          </button>
-        )}
-
-        {/* Content area with hidden scrollbar and reveal animation */}
-        <div
-          className="scrollbar-hidden max-h-[calc(100vh-8rem)] overflow-y-auto md:max-h-[70vh]"
-          data-modal-content="true"
-        >
+          {/* Content area with hidden scrollbar and reveal animation */}
           <div
-            className={`p-4 leading-relaxed text-gray-700 md:p-6 ${
-              isAnimating && !isExiting ? "animate-contentReveal" : "opacity-0"
-            }`}
+            className="scrollbar-hidden max-h-[calc(100vh-8rem)] overflow-y-auto md:max-h-[70vh]"
+            data-modal-content="true"
           >
-            {children}
+            <div
+              className={`p-4 leading-relaxed text-gray-700 md:p-6 ${
+                isAnimating && !isExiting
+                  ? "animate-contentReveal"
+                  : "opacity-0"
+              }`}
+            >
+              {children}
+            </div>
           </div>
-        </div>
 
-        {/* Footer if provided */}
-        {footer && (
-          <div className="flex justify-end gap-3 border-t border-gray-100 bg-gray-50/50 p-4 sm:p-6">
-            {footer}
-          </div>
-        )}
+          {/* Footer if provided */}
+          {footer && (
+            <div className="flex justify-end gap-3 border-t border-gray-100 bg-gray-50/50 p-4 sm:p-6">
+              {footer}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </FocusScope>
   );
 
   // Render to body to avoid any positioning issues


### PR DESCRIPTION
Closes #1358

## Summary

Edit-Modals waren auf Mobile in den Database-Pages nicht bedienbar — der erste Tap auf ein Form-Field hat den Detail-Drawer geschlossen und das Modal mit unmounted. Behoben werden drei sich überlagernde Ursachen.

## Root Causes

`Modal`/`FormModal` portalen an `document.body` und liegen damit außerhalb des Vaul-Drawers (Radix Dialog). Daraus folgten:

1. Vaul's `DismissableLayer` behandelte Taps im portalten Modal als Outside-Click → Drawer dismisst → Modal unmounted.
2. Radix setzt `body { pointer-events: none }`. Da `pointer-events` vererbt wird, schluckte das portale Modal alle Klicks.
3. Radix `FocusScope` zog Fokus aus jedem Input zurück in den Drawer → kein Caret, kein Tippen.

## Fixes

- `MasterDetailLayout` guardet `onInteractOutside` / `onEscapeKeyDown` auf `DrawerContent`, solange ein Modal offen ist.
- `ModalProvider` zählt offene Modals als Counter statt Boolean, damit stacked Modals (Edit + Confirmation) korrekt reporten.
- `Modal`/`FormModal` setzen `pointer-events: auto` auf der Wurzel und wrappen Inhalt in `<FocusScope trapped>`. Radix' globaler `focusScopesStack` pausiert dadurch automatisch den Drawer-Trap.
- Backdrop-Buttons bekommen `tabIndex={-1}`, damit `focusFirst()` nicht auf dem unsichtbaren „Hintergrund schließen"-Control landet (Code-Review-Befund).

Neue direkte Dependency: `@radix-ui/react-focus-scope@^1.1.7` (vorher transitiv via `vaul`).

## Test plan

- [x] Edit-Modals auf `/database/devices`, `/roles`, `/permissions`, `/personal` bedienbar (Caret, Tippen, Speichern)
- [x] Backdrop / X / ESC schließt nur das Modal, Drawer bleibt offen
- [x] Delete-Confirmation: „Abbrechen" schließt nur Modal, Drawer bleibt
- [x] Stacked Modals: innere Confirmation schließen lässt Edit + Drawer offen
- [x] Drawer-Verhalten ohne Modal unverändert (Backdrop-Tap, Swipe-Down)
- [x] Tab erreicht Backdrop nicht, FocusScope trapped korrekt
- [x] Desktop ≥ 768 px unverändert
- [x] Login Password-Reset Modal außerhalb Master-Detail bedienbar