### PR TITLE
Fix absence status end-of-day clear time

### DIFF
--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -73,6 +73,7 @@ const (
 	KeySessionCleanupIntervalMinutes  = "operations.session_cleanup_interval_minutes"
 	KeySessionAbandonedThresholdMin   = "operations.session_abandoned_threshold_minutes"
 	KeyAdminSupervisionOverview       = "operations.admin_supervision_overview"
+	KeyStatusFlagClearTime            = "operations.status_flag_clear_time"
 	KeySickClearMode                  = "operations.sick_clear_mode"
 	KeyExcusedClearMode               = "operations.excused_clear_mode"
 	KeyPresenceMode                   = "operations.presence_mode"

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -26,6 +26,7 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"operations.session_cleanup_interval_minutes",
 		"operations.session_abandoned_threshold_minutes",
 		"operations.admin_supervision_overview",
+		"operations.status_flag_clear_time",
 		"operations.sick_clear_mode",
 		"operations.excused_clear_mode",
 		"gdpr.data_cleanup_enabled",
@@ -67,10 +68,10 @@ func TestAllSettingsRegistered(t *testing.T) {
 		assert.NotEmpty(t, def.Category, "setting %q should have a category", key)
 	}
 
-	// 28 pre-WP-B7 settings + 7 timetable settings + 2 sick/excused clear-mode
-	// settings == 37 minimum. The `>=` is intentional so later work packages can
-	// add more settings without retrofitting this assertion.
-	assert.GreaterOrEqual(t, len(all), 37, "at least 37 settings should be registered (28 existing + 7 timetable + 2 clear-mode)")
+	// 28 pre-WP-B7 settings + 7 timetable settings + 3 status-flag settings
+	// == 38 minimum. The `>=` is intentional so later work packages can add more
+	// settings without retrofitting this assertion.
+	assert.GreaterOrEqual(t, len(all), 38, "at least 38 settings should be registered (28 existing + 7 timetable + 3 status-flag)")
 }
 
 func TestPresenceModeSetting(t *testing.T) {
@@ -232,6 +233,7 @@ func TestOperationsSettings_Types(t *testing.T) {
 		{"operations.session_cleanup_interval_minutes", config.FieldNumber},
 		{"operations.session_abandoned_threshold_minutes", config.FieldNumber},
 		{"operations.admin_supervision_overview", config.FieldBoolean},
+		{"operations.status_flag_clear_time", config.FieldTime},
 		{"operations.sick_clear_mode", config.FieldSelect},
 		{"operations.excused_clear_mode", config.FieldSelect},
 	}
@@ -465,6 +467,16 @@ func TestStudentDailyCheckoutTime_OptionalDefault(t *testing.T) {
 	assert.Equal(t, "", def.Default, "daily checkout time should default to empty (always available)")
 }
 
+func TestStatusFlagClearTime_Default(t *testing.T) {
+	def := config.GetDefinition(config.KeyStatusFlagClearTime)
+	require.NotNil(t, def)
+	assert.Equal(t, config.FieldTime, def.Type)
+	assert.Equal(t, "18:00", def.Default, "status flag clear time should have a real default so end_of_day can run")
+	assert.Equal(t, "operations", def.Tab)
+	assert.Equal(t, "abwesenheit", def.Category)
+	assert.Equal(t, "config:update", def.WritePermission)
+}
+
 func TestValidation_NumberFields(t *testing.T) {
 	// All number fields should have min/max validation
 	numberKeys := []string{
@@ -502,6 +514,7 @@ func TestDefaults_HaveReasonableValues(t *testing.T) {
 		{"operations.session_cleanup_interval_minutes", 15},
 		{"operations.session_abandoned_threshold_minutes", 60},
 		{"operations.admin_supervision_overview", false},
+		{"operations.status_flag_clear_time", "18:00"},
 		{"gdpr.data_cleanup_enabled", true},
 		{"gdpr.data_cleanup_time", "02:00"},
 		{"gdpr.data_cleanup_timeout_minutes", 30},

--- a/backend/services/config/defaults/operations.go
+++ b/backend/services/config/defaults/operations.go
@@ -200,6 +200,19 @@ func init() {
 	}
 
 	config.Register(config.Definition{
+		Key:             config.KeyStatusFlagClearTime,
+		Label:           "Abwesenheit automatisch beenden um",
+		Description:     "Uhrzeit, zu der Krankmeldungen und Entschuldigungen mit Einstellung \"Am Ende des Tages\" automatisch aufgehoben werden.",
+		Type:            config.FieldTime,
+		Default:         "18:00",
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "abwesenheit",
+		SortOrder:       29,
+	})
+
+	config.Register(config.Definition{
 		Key:             config.KeySickClearMode,
 		Label:           "Krankmeldung automatisch beenden",
 		Description:     "Legt fest, wann die Krankmeldung eines Schülers automatisch aufgehoben wird.",

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -1263,8 +1263,7 @@ func markRunToday(lastRunMap *sync.Map, tenantID int64) {
 // scheduleStatusFlagClearTask schedules a daily task to clear sick / excused
 // flags for tenants whose operations.sick_clear_mode or
 // operations.excused_clear_mode is set to "end_of_day". The task fires at the
-// tenant's configured operations.student_daily_checkout_time (the natural
-// end of the OGS day); when that setting is empty, no clear happens.
+// tenant's configured operations.status_flag_clear_time.
 func (s *Scheduler) scheduleStatusFlagClearTask() {
 	// Env var kill switch to allow ops to disable this task without code changes.
 	if os.Getenv("STATUS_FLAG_CLEAR_ENABLED") == "false" {
@@ -1285,8 +1284,8 @@ func (s *Scheduler) scheduleStatusFlagClearTask() {
 	go s.runStatusFlagClearTaskPolling(task)
 }
 
-// runStatusFlagClearTaskPolling checks every minute if any tenant's checkout
-// time matches now and clears the configured end_of_day flags.
+// runStatusFlagClearTaskPolling checks every minute if any tenant's status
+// flag clear time matches now and clears the configured end_of_day flags.
 func (s *Scheduler) runStatusFlagClearTaskPolling(task *ScheduledTask) {
 	defer s.wg.Done()
 	defer func() {
@@ -1320,7 +1319,7 @@ func (s *Scheduler) runStatusFlagClearTaskPolling(task *ScheduledTask) {
 }
 
 // checkAndRunStatusFlagClear evaluates each tenant's clear_mode settings and
-// clears flags when the configured daily checkout time matches now.
+// clears flags when the configured status flag clear time matches now.
 func (s *Scheduler) checkAndRunStatusFlagClear(task *ScheduledTask) {
 	task.mu.Lock()
 	if task.Running {
@@ -1339,7 +1338,7 @@ func (s *Scheduler) checkAndRunStatusFlagClear(task *ScheduledTask) {
 	defer cancel()
 
 	s.forEachTenantSettings(ctx, "status-flag-clear", func(tenantCtx context.Context, tenantID int64) error {
-		clearTime := s.resolveStringSetting(tenantCtx, configModel.KeyStudentDailyCheckoutTime, "", "")
+		clearTime := s.resolveStringSetting(tenantCtx, configModel.KeyStatusFlagClearTime, "", "18:00")
 		if clearTime == "" || !timeMatchesNow(clearTime) {
 			return nil
 		}

--- a/backend/services/scheduler/scheduler_status_flag_test.go
+++ b/backend/services/scheduler/scheduler_status_flag_test.go
@@ -99,8 +99,8 @@ func TestClearStatusFlag_NilDBReturnsError(t *testing.T) {
 }
 
 // fakeStatusFlagSettings scripts the scheduler's SettingsResolver for the
-// status-flag task. Keys resolve in the order the task reads them: daily
-// checkout time, sick_clear_mode, excused_clear_mode.
+// status-flag task. Keys resolve in the order the task reads them: clear time,
+// sick_clear_mode, excused_clear_mode.
 type fakeStatusFlagSettings struct {
 	overrides map[string]string
 }
@@ -124,7 +124,7 @@ func (f *fakeStatusFlagSettings) HasTenantOverride(_ context.Context, key string
 
 // TestCheckAndRunStatusFlagClear_SkipsWhenTimeDoesNotMatch — the expensive
 // UPDATE must not run when the current clock doesn't match the tenant's
-// configured daily checkout time.
+// configured status flag clear time.
 func TestCheckAndRunStatusFlagClear_SkipsWhenTimeDoesNotMatch(t *testing.T) {
 	// Set the configured time to a value that cannot equal any real minute.
 	// timeMatchesNow returns false, so the task body should short-circuit
@@ -133,7 +133,7 @@ func TestCheckAndRunStatusFlagClear_SkipsWhenTimeDoesNotMatch(t *testing.T) {
 	s := &Scheduler{
 		settings: &fakeStatusFlagSettings{
 			overrides: map[string]string{
-				"operations.student_daily_checkout_time": "99:99",
+				"operations.status_flag_clear_time": "99:99",
 			},
 		},
 	}
@@ -143,9 +143,9 @@ func TestCheckAndRunStatusFlagClear_SkipsWhenTimeDoesNotMatch(t *testing.T) {
 	assert.False(t, task.Running, "task should have reset Running flag")
 }
 
-// TestCheckAndRunStatusFlagClear_SkipsWhenClearTimeEmpty — an empty
-// student_daily_checkout_time means "no daily gate configured" and the task
-// must do nothing regardless of the mode settings.
+// TestCheckAndRunStatusFlagClear_SkipsWhenClearTimeEmpty guards the defensive
+// branch for malformed runtime config. The registered default is 18:00, so
+// real tenants should not hit this path through SettingsService.
 func TestCheckAndRunStatusFlagClear_SkipsWhenClearTimeEmpty(t *testing.T) {
 	s := &Scheduler{
 		settings: &fakeStatusFlagSettings{overrides: map[string]string{}},
@@ -156,7 +156,7 @@ func TestCheckAndRunStatusFlagClear_SkipsWhenClearTimeEmpty(t *testing.T) {
 }
 
 // TestCheckAndRunStatusFlagClear_FiresBothModesWhenTimeMatches — when the
-// clock matches student_daily_checkout_time and both modes are end_of_day,
+// clock matches status_flag_clear_time and both modes are end_of_day,
 // the task enters the clearing branch for both flags. We run without a real
 // db, which makes clearStatusFlag return an error — this is the exact path
 // we want to cover (error branch) and it also lets us verify the lastRun
@@ -173,9 +173,9 @@ func TestCheckAndRunStatusFlagClear_FiresBothModesWhenTimeMatches(t *testing.T) 
 	s := &Scheduler{
 		settings: &fakeStatusFlagSettings{
 			overrides: map[string]string{
-				"operations.student_daily_checkout_time": nowHHMM,
-				"operations.sick_clear_mode":             "end_of_day",
-				"operations.excused_clear_mode":          "end_of_day",
+				"operations.status_flag_clear_time": nowHHMM,
+				"operations.sick_clear_mode":        "end_of_day",
+				"operations.excused_clear_mode":     "end_of_day",
 			},
 		},
 	}
@@ -278,7 +278,7 @@ func reloadStudentFlags(t *testing.T, db *bun.DB, studentID int64) (sick, excuse
 // end-to-end integration test for the end_of_day path. It wires a real DB
 // and a real SchoolRepository into the scheduler, plants a student with
 // sick = true AND another with excused = true in tenant 1, configures the
-// settings resolver to return operations.student_daily_checkout_time =
+// settings resolver to return operations.status_flag_clear_time =
 // "now" with both clear modes set to end_of_day, then invokes
 // checkAndRunStatusFlagClear and asserts both flags get wiped by the
 // bulk UPDATE that the scheduler runs inside a tenant transaction. This
@@ -325,9 +325,9 @@ func TestCheckAndRunStatusFlagClear_EndToEnd_ClearsBothFlags(t *testing.T) {
 		schoolRepo: platformRepo.NewSchoolRepository(db),
 		settings: &fakeStatusFlagSettings{
 			overrides: map[string]string{
-				"operations.student_daily_checkout_time": nowHHMM,
-				"operations.sick_clear_mode":             "end_of_day",
-				"operations.excused_clear_mode":          "end_of_day",
+				"operations.status_flag_clear_time": nowHHMM,
+				"operations.sick_clear_mode":        "end_of_day",
+				"operations.excused_clear_mode":     "end_of_day",
 			},
 		},
 		logger: slog.Default(),
@@ -383,9 +383,9 @@ func TestCheckAndRunStatusFlagClear_EndToEnd_RespectsModeSetting(t *testing.T) {
 		schoolRepo: platformRepo.NewSchoolRepository(db),
 		settings: &fakeStatusFlagSettings{
 			overrides: map[string]string{
-				"operations.student_daily_checkout_time": nowHHMM,
-				"operations.sick_clear_mode":             "end_of_day",
-				"operations.excused_clear_mode":          "next_checkin",
+				"operations.status_flag_clear_time": nowHHMM,
+				"operations.sick_clear_mode":        "end_of_day",
+				"operations.excused_clear_mode":     "next_checkin",
 			},
 		},
 		logger: slog.Default(),
@@ -429,9 +429,9 @@ func TestCheckAndRunStatusFlagClear_EndToEnd_DoesNothingWhenTimeDoesNotMatch(t *
 		schoolRepo: platformRepo.NewSchoolRepository(db),
 		settings: &fakeStatusFlagSettings{
 			overrides: map[string]string{
-				"operations.student_daily_checkout_time": "25:99", // invalid, timeMatchesNow → false
-				"operations.sick_clear_mode":             "end_of_day",
-				"operations.excused_clear_mode":          "end_of_day",
+				"operations.status_flag_clear_time": "25:99", // invalid, timeMatchesNow → false
+				"operations.sick_clear_mode":        "end_of_day",
+				"operations.excused_clear_mode":     "end_of_day",
 			},
 		},
 		logger: slog.Default(),


### PR DESCRIPTION
## Summary
- add a tenant setting for the status-flag clear clock under Betrieb -> Abwesenheit
- make the existing sick/excused end-of-day scheduler use that clock instead of Tägliche Abmeldezeit
- update settings and scheduler tests for the decoupled behavior

## Root Cause
Krankmeldungen and Entschuldigungen set to "Am Ende des Tages" were tied to `operations.student_daily_checkout_time`. Schools with `Tägliche Abmeldezeit = Jederzeit` store that setting as an empty time, so the scheduler skipped the reset entirely.

## Validation
- `cd backend && go test ./services/config/defaults -count=1`
- `cd backend && go test ./services/scheduler -run 'StatusFlag|statusFlag|TestCheckAndRunStatusFlagClear|TestClearStatusFlag' -count=1`
- `cd backend && go test ./test/ -run TestHermeticTestPatterns -count=1`
- pre-push hooks: `git-secrets`, `go-vet`, `go-deadcode`, `golangci-lint`
