### PR TITLE
Fix stale auth session handling

### DIFF
--- a/backend/services/auth/auth_core_test.go
+++ b/backend/services/auth/auth_core_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	authjwt "github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
@@ -67,30 +66,6 @@ func uniqueTestCredentials(prefix string) (email, username string) {
 	email = fmt.Sprintf("%s-%s@test.local", prefix, uniqueID)
 	username = fmt.Sprintf("%s-%s", prefix, uniqueID)
 	return
-}
-
-func parseAccessTokenClaims(t *testing.T, token string) authjwt.AppClaims {
-	t.Helper()
-
-	tokenAuth, err := authjwt.NewTokenAuth()
-	require.NoError(t, err)
-
-	decoded, err := tokenAuth.JwtAuth.Decode(token)
-	require.NoError(t, err)
-
-	claims := make(map[string]any, len(decoded.Keys()))
-	for _, key := range decoded.Keys() {
-		var value any
-		err := decoded.Get(key, &value)
-		require.NoError(t, err)
-		claims[key] = value
-	}
-
-	var appClaims authjwt.AppClaims
-	err = appClaims.ParseClaims(claims)
-	require.NoError(t, err)
-
-	return appClaims
 }
 
 // =============================================================================
@@ -1099,10 +1074,10 @@ func TestAuthService_AssignRoleToAccount(t *testing.T) {
 		tokens, err := service.GetActiveTokens(ctx, int(account.ID))
 		require.NoError(t, err)
 		require.Len(t, tokens, 1)
-		assert.Equal(t, token.ID, tokens[0].ID, "existing refresh tokens should remain untouched by role assignment")
+		assert.Equal(t, token.ID, tokens[0].ID, "token deletion should roll back with the outer transaction")
 	})
 
-	t.Run("existing refresh token picks up new role on next refresh", func(t *testing.T) {
+	t.Run("existing refresh token is revoked after role assignment", func(t *testing.T) {
 		email, username := uniqueTestCredentials("assign-role-refresh")
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
@@ -1121,11 +1096,9 @@ func TestAuthService_AssignRoleToAccount(t *testing.T) {
 		require.NoError(t, err)
 
 		newAccessToken, newRefreshToken, err := service.RefreshToken(ctx, refreshToken)
-		require.NoError(t, err)
-		assert.NotEmpty(t, newRefreshToken)
-
-		claims := parseAccessTokenClaims(t, newAccessToken)
-		assert.Contains(t, claims.Roles, roleName)
+		require.Error(t, err)
+		assert.Empty(t, newAccessToken)
+		assert.Empty(t, newRefreshToken)
 	})
 }
 
@@ -1164,7 +1137,7 @@ func TestAuthService_RemoveRoleFromAccount(t *testing.T) {
 		}
 	})
 
-	t.Run("existing refresh token no longer carries removed role after refresh", func(t *testing.T) {
+	t.Run("existing refresh token is revoked after role removal", func(t *testing.T) {
 		email, username := uniqueTestCredentials("remove-role-refresh")
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
@@ -1186,11 +1159,9 @@ func TestAuthService_RemoveRoleFromAccount(t *testing.T) {
 		require.NoError(t, err)
 
 		newAccessToken, newRefreshToken, err := service.RefreshToken(ctx, refreshToken)
-		require.NoError(t, err)
-		assert.NotEmpty(t, newRefreshToken)
-
-		claims := parseAccessTokenClaims(t, newAccessToken)
-		assert.NotContains(t, claims.Roles, roleName)
+		require.Error(t, err)
+		assert.Empty(t, newAccessToken)
+		assert.Empty(t, newRefreshToken)
 	})
 }
 

--- a/backend/services/auth/role_management.go
+++ b/backend/services/auth/role_management.go
@@ -139,6 +139,10 @@ func (s *Service) AssignRoleToAccount(ctx context.Context, accountID, roleID int
 			return &AuthError{Op: "assign role to account", Err: err}
 		}
 
+		if err := s.repos.Token.DeleteByAccountID(txCtx, int64(accountID)); err != nil {
+			return &AuthError{Op: "revoke tokens after role assignment", Err: err}
+		}
+
 		return nil
 	})
 }
@@ -146,8 +150,21 @@ func (s *Service) AssignRoleToAccount(ctx context.Context, accountID, roleID int
 // RemoveRoleFromAccount removes a role from an account
 func (s *Service) RemoveRoleFromAccount(ctx context.Context, accountID, roleID int) error {
 	return s.runInTx(ctx, func(txCtx context.Context) error {
+		existingRole, err := s.repos.AccountRole.FindByAccountAndRole(txCtx, int64(accountID), int64(roleID))
+		if err != nil && !strings.Contains(err.Error(), "no rows") {
+			return &AuthError{Op: "check role assignment", Err: err}
+		}
+
+		if existingRole == nil {
+			return nil
+		}
+
 		if err := s.repos.AccountRole.DeleteByAccountAndRole(txCtx, int64(accountID), int64(roleID)); err != nil {
 			return &AuthError{Op: "remove role from account", Err: err}
+		}
+
+		if err := s.repos.Token.DeleteByAccountID(txCtx, int64(accountID)); err != nil {
+			return &AuthError{Op: "revoke tokens after role removal", Err: err}
 		}
 
 		return nil

--- a/backend/services/auth/role_management_internal_test.go
+++ b/backend/services/auth/role_management_internal_test.go
@@ -434,13 +434,14 @@ func TestRoleManagement_ListAndGetAccountRoles_ErrorPaths(t *testing.T) {
 	})
 }
 
-func TestRoleManagement_AssignAndRemoveRole_DoNotRevokeTokens(t *testing.T) {
+func TestRoleManagement_AssignAndRemoveRole_RevokeTokens(t *testing.T) {
 	ctx := tenant.WithTenantID(context.Background(), 9)
 	account := &authModel.Account{Model: base.Model{ID: 12}}
 	role := &authModel.Role{Model: base.Model{ID: 34}}
 
-	t.Run("AssignRoleToAccount succeeds without token cleanup", func(t *testing.T) {
+	t.Run("AssignRoleToAccount revokes account tokens after creating assignment", func(t *testing.T) {
 		var createdAssignment *authModel.AccountRole
+		var revokedAccountID int64
 		svc := newRoleManagementService(
 			roleManagementRoleRepo{
 				findByIDFn: func(_ context.Context, id interface{}) (*authModel.Role, error) {
@@ -466,7 +467,7 @@ func TestRoleManagement_AssignAndRemoveRole_DoNotRevokeTokens(t *testing.T) {
 			roleManagementRolePermissionRepo{},
 			roleManagementTokenRepo{
 				deleteByAccountIDFn: func(_ context.Context, accountID int64) error {
-					t.Fatalf("unexpected token cleanup for account %d", accountID)
+					revokedAccountID = accountID
 					return nil
 				},
 			},
@@ -476,14 +477,21 @@ func TestRoleManagement_AssignAndRemoveRole_DoNotRevokeTokens(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, createdAssignment)
 		assert.Equal(t, int64(9), createdAssignment.TenantID)
+		assert.Equal(t, int64(12), revokedAccountID)
 	})
 
 	t.Run("RemoveRoleFromAccount returns delete failure without token cleanup", func(t *testing.T) {
+		tokenCleanupCalled := false
 		expectedErr := errors.New("assignment delete failed")
 		svc := newRoleManagementService(
 			roleManagementRoleRepo{},
 			roleManagementAccountRepo{},
 			roleManagementAccountRoleRepo{
+				findByAccountAndRoleFn: func(_ context.Context, accountID, roleID int64) (*authModel.AccountRole, error) {
+					assert.Equal(t, int64(12), accountID)
+					assert.Equal(t, int64(34), roleID)
+					return &authModel.AccountRole{AccountID: accountID, RoleID: roleID}, nil
+				},
 				deleteByAccountAndRoleFn: func(_ context.Context, accountID, roleID int64) error {
 					assert.Equal(t, int64(12), accountID)
 					assert.Equal(t, int64(34), roleID)
@@ -493,7 +501,7 @@ func TestRoleManagement_AssignAndRemoveRole_DoNotRevokeTokens(t *testing.T) {
 			roleManagementRolePermissionRepo{},
 			roleManagementTokenRepo{
 				deleteByAccountIDFn: func(_ context.Context, accountID int64) error {
-					t.Fatalf("unexpected token cleanup for account %d", accountID)
+					tokenCleanupCalled = true
 					return nil
 				},
 			},
@@ -502,17 +510,30 @@ func TestRoleManagement_AssignAndRemoveRole_DoNotRevokeTokens(t *testing.T) {
 		err := svc.RemoveRoleFromAccount(context.Background(), 12, 34)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, expectedErr)
+		assert.False(t, tokenCleanupCalled)
 	})
 
-	t.Run("RemoveRoleFromAccount succeeds without token cleanup", func(t *testing.T) {
+	t.Run("RemoveRoleFromAccount no-op does not revoke account tokens", func(t *testing.T) {
+		tokenCleanupCalled := false
+		deleteCalled := false
 		svc := newRoleManagementService(
 			roleManagementRoleRepo{},
 			roleManagementAccountRepo{},
-			roleManagementAccountRoleRepo{},
+			roleManagementAccountRoleRepo{
+				findByAccountAndRoleFn: func(_ context.Context, accountID, roleID int64) (*authModel.AccountRole, error) {
+					assert.Equal(t, int64(12), accountID)
+					assert.Equal(t, int64(34), roleID)
+					return nil, sql.ErrNoRows
+				},
+				deleteByAccountAndRoleFn: func(context.Context, int64, int64) error {
+					deleteCalled = true
+					return nil
+				},
+			},
 			roleManagementRolePermissionRepo{},
 			roleManagementTokenRepo{
-				deleteByAccountIDFn: func(_ context.Context, accountID int64) error {
-					t.Fatalf("unexpected token cleanup for account %d", accountID)
+				deleteByAccountIDFn: func(context.Context, int64) error {
+					tokenCleanupCalled = true
 					return nil
 				},
 			},
@@ -520,5 +541,33 @@ func TestRoleManagement_AssignAndRemoveRole_DoNotRevokeTokens(t *testing.T) {
 
 		err := svc.RemoveRoleFromAccount(context.Background(), 12, 34)
 		require.NoError(t, err)
+		assert.False(t, deleteCalled)
+		assert.False(t, tokenCleanupCalled)
+	})
+
+	t.Run("RemoveRoleFromAccount revokes account tokens after deleting assignment", func(t *testing.T) {
+		var revokedAccountID int64
+		svc := newRoleManagementService(
+			roleManagementRoleRepo{},
+			roleManagementAccountRepo{},
+			roleManagementAccountRoleRepo{
+				findByAccountAndRoleFn: func(_ context.Context, accountID, roleID int64) (*authModel.AccountRole, error) {
+					assert.Equal(t, int64(12), accountID)
+					assert.Equal(t, int64(34), roleID)
+					return &authModel.AccountRole{AccountID: accountID, RoleID: roleID}, nil
+				},
+			},
+			roleManagementRolePermissionRepo{},
+			roleManagementTokenRepo{
+				deleteByAccountIDFn: func(_ context.Context, accountID int64) error {
+					revokedAccountID = accountID
+					return nil
+				},
+			},
+		)
+
+		err := svc.RemoveRoleFromAccount(context.Background(), 12, 34)
+		require.NoError(t, err)
+		assert.Equal(t, int64(12), revokedAccountID)
 	})
 }

--- a/frontend/src/components/tenant/tenant-guard.test.tsx
+++ b/frontend/src/components/tenant/tenant-guard.test.tsx
@@ -124,7 +124,7 @@ describe("TenantGuard", () => {
 
   it("renders children when session tenant matches URL tenant", () => {
     mockUseSession.mockReturnValue({
-      data: { user: { tenantId: 1 } },
+      data: { user: { tenantId: 1, token: "access-token" } },
       status: "authenticated",
       update: vi.fn(),
     });
@@ -166,7 +166,7 @@ describe("TenantGuard", () => {
 
   it("shows switching state when mismatch detected", () => {
     mockUseSession.mockReturnValue({
-      data: { user: { tenantId: 1 } },
+      data: { user: { tenantId: 1, token: "access-token" } },
       status: "authenticated",
       update: vi.fn(),
     });
@@ -190,7 +190,7 @@ describe("TenantGuard", () => {
   it("calls performTenantSwitch + update on mismatch", async () => {
     const mockUpdate = vi.fn().mockResolvedValue(undefined);
     mockUseSession.mockReturnValue({
-      data: { user: { tenantId: 1 } },
+      data: { user: { tenantId: 1, token: "access-token" } },
       status: "authenticated",
       update: mockUpdate,
     });
@@ -222,7 +222,7 @@ describe("TenantGuard", () => {
 
   it("signs out when switchTenant reports access denied", async () => {
     mockUseSession.mockReturnValue({
-      data: { user: { tenantId: 1 } },
+      data: { user: { tenantId: 1, token: "access-token" } },
       status: "authenticated",
       update: vi.fn(),
     });
@@ -251,7 +251,13 @@ describe("TenantGuard", () => {
 
   it("signs out operator session on tenant subdomain and blocks render", async () => {
     mockUseSession.mockReturnValue({
-      data: { user: { tenantId: undefined, scope: "platform" } },
+      data: {
+        user: {
+          tenantId: undefined,
+          scope: "platform",
+          token: "operator-token",
+        },
+      },
       status: "authenticated",
       update: vi.fn(),
     });
@@ -286,7 +292,13 @@ describe("TenantGuard", () => {
 
   it("redirects to tenant login even when signOut fails", async () => {
     mockUseSession.mockReturnValue({
-      data: { user: { tenantId: undefined, scope: "platform" } },
+      data: {
+        user: {
+          tenantId: undefined,
+          scope: "platform",
+          token: "operator-token",
+        },
+      },
       status: "authenticated",
       update: vi.fn(),
     });
@@ -313,7 +325,13 @@ describe("TenantGuard", () => {
 
   it("redirects to tenant login even when cache clear fails", async () => {
     mockUseSession.mockReturnValue({
-      data: { user: { tenantId: undefined, scope: "platform" } },
+      data: {
+        user: {
+          tenantId: undefined,
+          scope: "platform",
+          token: "operator-token",
+        },
+      },
       status: "authenticated",
       update: vi.fn(),
     });
@@ -340,7 +358,13 @@ describe("TenantGuard", () => {
 
   it("skips check when session tenantId is undefined and scope is not platform", () => {
     mockUseSession.mockReturnValue({
-      data: { user: { tenantId: undefined, scope: undefined } },
+      data: {
+        user: {
+          tenantId: undefined,
+          scope: undefined,
+          token: "access-token",
+        },
+      },
       status: "authenticated",
       update: vi.fn(),
     });
@@ -362,7 +386,7 @@ describe("TenantGuard", () => {
 
   it("does not sign out on transient switch failures", async () => {
     mockUseSession.mockReturnValue({
-      data: { user: { tenantId: 1 } },
+      data: { user: { tenantId: 1, token: "access-token" } },
       status: "authenticated",
       update: vi.fn(),
     });
@@ -391,7 +415,7 @@ describe("TenantGuard", () => {
 
   it("retries after a remount instead of persisting a failed slug marker", async () => {
     mockUseSession.mockReturnValue({
-      data: { user: { tenantId: 1 } },
+      data: { user: { tenantId: 1, token: "access-token" } },
       status: "authenticated",
       update: vi.fn(),
     });
@@ -437,7 +461,7 @@ describe("TenantGuard", () => {
 
   it("renders children when tenant context is null", () => {
     mockUseSession.mockReturnValue({
-      data: { user: { tenantId: 1 } },
+      data: { user: { tenantId: 1, token: "access-token" } },
       status: "authenticated",
       update: vi.fn(),
     });
@@ -455,5 +479,77 @@ describe("TenantGuard", () => {
     // tenant is null — guard skips check, renders children
     expect(screen.getByText("Protected Content")).toBeInTheDocument();
     expect(mockPerformTenantSwitch).not.toHaveBeenCalled();
+  });
+
+  it("signs out invalid authenticated session with no token", async () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          tenantId: 1,
+          token: "",
+          roles: [],
+        },
+      },
+      status: "authenticated",
+      update: vi.fn(),
+    });
+    mockUseTenant.mockReturnValue({
+      tenantSlug: "school-a",
+      tenant: tenantA,
+    });
+
+    render(
+      <TenantGuard>
+        <div>Protected Content</div>
+      </TenantGuard>,
+    );
+
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+    expect(screen.getByText("Sitzung wird erneuert...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledWith({ redirect: false });
+    });
+    expect(mockMutate).toHaveBeenCalled();
+    expect(mockClearSessionCache).toHaveBeenCalled();
+    expect(window.location.assign).toHaveBeenCalledWith(
+      "/?error=SessionExpired",
+    );
+    expect(mockPerformTenantSwitch).not.toHaveBeenCalled();
+  });
+
+  it("signs out authenticated session with refresh error", async () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          tenantId: 1,
+          token: "access-token",
+          roles: [],
+        },
+        error: "RefreshTokenError",
+      },
+      status: "authenticated",
+      update: vi.fn(),
+    });
+    mockUseTenant.mockReturnValue({
+      tenantSlug: "school-a",
+      tenant: tenantA,
+    });
+
+    render(
+      <TenantGuard>
+        <div>Protected Content</div>
+      </TenantGuard>,
+    );
+
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+    expect(screen.getByText("Sitzung wird erneuert...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledWith({ redirect: false });
+    });
+    expect(window.location.assign).toHaveBeenCalledWith(
+      "/?error=SessionExpired",
+    );
   });
 });

--- a/frontend/src/components/tenant/tenant-guard.tsx
+++ b/frontend/src/components/tenant/tenant-guard.tsx
@@ -31,15 +31,57 @@ export function TenantGuard({ children }: { children: React.ReactNode }) {
   const { tenant } = useTenant();
   const switchAttempted = useRef(false);
   const [signingOutOperator, setSigningOutOperator] = useState(false);
+  const [signingOutExpiredSession, setSigningOutExpiredSession] =
+    useState(false);
 
   const sessionTenantId = session?.user?.tenantId;
   const sessionScope = session?.user?.scope;
+  const sessionToken = session?.user?.token;
+  const sessionError = session?.error;
   const urlTenantId = tenant?.tenantId;
   const urlSlug = tenant?.slug;
+
+  // Auth.js can still report "authenticated" after the JWT callback has
+  // stripped token/roles because refresh failed. Do not render tenant UI in
+  // that limbo state; it makes real admins look like caregivers and produces
+  // confusing forbidden screens.
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    if (sessionToken && !sessionError) return;
+
+    logger.warn("tenant_session_invalid", {
+      token_present: !!sessionToken,
+      error: sessionError,
+    });
+
+    setSigningOutExpiredSession(true);
+
+    void (async () => {
+      try {
+        await mutate(() => true, undefined, { revalidate: false });
+        clearSessionCache();
+      } catch (err) {
+        logger.warn("invalid_session_cache_clear_failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      try {
+        await signOut({ redirect: false });
+      } catch (err) {
+        logger.warn("invalid_session_signout_failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        window.location.assign("/?error=SessionExpired");
+      }
+    })();
+  }, [status, sessionToken, sessionError]);
 
   // Operator session on tenant subdomain — sign out immediately
   useEffect(() => {
     if (status !== "authenticated" || !tenant) return;
+    if (!sessionToken || sessionError) return;
     if (sessionScope !== "platform") return;
 
     logger.warn("operator_session_on_tenant", {
@@ -69,11 +111,12 @@ export function TenantGuard({ children }: { children: React.ReactNode }) {
         window.location.assign("/");
       }
     })();
-  }, [status, tenant, sessionScope, urlSlug]);
+  }, [status, tenant, sessionScope, urlSlug, sessionToken, sessionError]);
 
   useEffect(() => {
     // Only check when authenticated and tenant context is resolved
     if (status !== "authenticated" || !tenant) return;
+    if (!sessionToken || sessionError) return;
 
     // Operator sessions are handled by the effect above
     if (sessionScope === "platform") return;
@@ -127,6 +170,8 @@ export function TenantGuard({ children }: { children: React.ReactNode }) {
     urlTenantId,
     urlSlug,
     update,
+    sessionToken,
+    sessionError,
   ]);
 
   // While session is loading, render children transparently.
@@ -143,6 +188,17 @@ export function TenantGuard({ children }: { children: React.ReactNode }) {
   const isOperatorOnTenant =
     signingOutOperator ||
     (status === "authenticated" && sessionScope === "platform" && !!tenant);
+
+  if (
+    signingOutExpiredSession ||
+    (status === "authenticated" && (!sessionToken || sessionError))
+  ) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <div className="text-sm text-gray-500">Sitzung wird erneuert...</div>
+      </div>
+    );
+  }
 
   if (isOperatorOnTenant) {
     return (


### PR DESCRIPTION
## Summary

Fixes the stale/invalid tenant session path that could make a valid school admin appear as a caregiver with missing navigation and forbidden admin pages.

## Root Cause

NextAuth can still report `authenticated` after refresh failure while the session callback has stripped the access token and roles. The tenant UI then rendered with `roles: []`, so real admins looked like caregivers and hit `Kein Zugriff` on admin routes.

Separately, role assignment/removal did not invalidate existing refresh tokens, allowing stale role claims after real role changes.

## Changes

- Block authenticated tenant sessions that have no access token or a refresh error, clear caches, sign out, and redirect to login instead of rendering the protected app in a broken state.
- Revoke account refresh tokens after successful role assignment.
- Revoke account refresh tokens after role removal only when an assignment actually existed, avoiding forced logout on stale or duplicate remove requests.
- Update backend and frontend tests for invalid-session handling, rollback behavior, token invalidation, and no-op role removal.

## Validation

- `go test ./services/auth -count=1`
- `go test ./test/ -run TestHermeticTestPatterns -v`
- `pnpm test src/components/tenant/tenant-guard.test.tsx`
- `pnpm run check`
- Pre-push hook: `git-secrets`, `go-vet`, `golangci-lint`, `frontend-knip`, `go-deadcode`, `frontend-check`
