### PR TITLE
fix flaky operator login loading test

### DIFF
--- a/frontend/src/app/operator/login/page.test.tsx
+++ b/frontend/src/app/operator/login/page.test.tsx
@@ -135,8 +135,12 @@ describe("OperatorLoginPage", () => {
   });
 
   it("shows loading state during authentication", async () => {
+    let resolveSignIn: (value: { error: null }) => void = () => undefined;
     mockSignIn.mockImplementation(
-      () => new Promise((resolve) => setTimeout(resolve, 100)),
+      () =>
+        new Promise((resolve) => {
+          resolveSignIn = resolve;
+        }),
     );
 
     render(<OperatorLoginPage />);
@@ -146,6 +150,14 @@ describe("OperatorLoginPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Anmeldung läuft...")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      resolveSignIn({ error: null });
+    });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/operator/suggestions");
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the operator login loading-state test so it owns the full async sign-in lifecycle instead of leaving a timer-backed promise pending after the test ends.

## Root Cause

The test used `setTimeout` inside the mocked `signIn` promise and only asserted the loading state. The test could finish before the promise resolved, then React would run `setIsLoading(false)` during jsdom teardown and Vitest would report `ReferenceError: window is not defined` as an unhandled rejection.

## Changes

- Replace the timer-backed mock with a manually controlled promise.
- Resolve the pending sign-in inside `act()`.
- Assert the final redirect so the test waits for the component to settle.

## Validation

- `cd frontend && pnpm run test:run src/app/operator/login/page.test.tsx`
- `cd frontend && pnpm run check`
- pre-push: `frontend-knip`
- pre-push: `frontend-check`