### PR TITLE
fix(students): forward current_room_color to detail-page badge (#1381)

### DIFF
--- a/frontend/src/components/students/student-detail-components.test.tsx
+++ b/frontend/src/components/students/student-detail-components.test.tsx
@@ -156,6 +156,69 @@ describe("StudentDetailHeader", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Per-room color forwarding (Issue #1381) — the header builds a `badgeStudent`
+  // object from the incoming student before passing it to LocationBadge. A
+  // prior whitelist version of that object dropped `current_room_color`, which
+  // left the detail-page badge stuck on the default Anwesend blue while
+  // /students/search rendered the configured hex correctly. This regression
+  // test fails if anyone reintroduces the whitelist (or any other field
+  // filtering between `student` and the badge).
+  // ---------------------------------------------------------------------------
+  describe("LocationBadge field forwarding (Issue #1381)", () => {
+    afterEach(() => cleanup());
+
+    it("forwards current_room_color to the LocationBadge", () => {
+      const studentInRoom: ExtendedStudent = {
+        ...mockStudent,
+        // contextAware mode only paints the per-room hex when the viewer has
+        // detailed access. has_full_access bypasses the OGS-group check and
+        // keeps the test independent of myGroups wiring.
+        has_full_access: true,
+        current_location: "Anwesend - Bibliothek",
+        current_room_color: "#A3D977",
+      };
+
+      render(
+        <StudentDetailHeader
+          student={studentInRoom}
+          myGroups={[]}
+          myGroupRooms={[]}
+          mySupervisedRooms={[]}
+        />,
+      );
+
+      // The badge renders the room name as its label; closest("span") grabs
+      // the styled wrapper that carries backgroundColor inline.
+      const badgeContainer = screen.getByText("Bibliothek").closest("span");
+      expect(badgeContainer).toHaveStyle({ backgroundColor: "#A3D977" });
+    });
+
+    it("falls back to the default room color when current_room_color is null", () => {
+      const studentInRoom: ExtendedStudent = {
+        ...mockStudent,
+        has_full_access: true,
+        current_location: "Anwesend - Bibliothek",
+        current_room_color: null,
+      };
+
+      render(
+        <StudentDetailHeader
+          student={studentInRoom}
+          myGroups={[]}
+          myGroupRooms={[]}
+          mySupervisedRooms={[]}
+        />,
+      );
+
+      const badgeContainer = screen.getByText("Bibliothek").closest("span");
+      // OTHER_ROOM blue is the documented fallback (see location-badge tests
+      // for Issue #1324). Asserting on a non-default color guards against
+      // accidentally passing the per-room override through as `undefined`.
+      expect(badgeContainer).not.toHaveStyle({ backgroundColor: "#A3D977" });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // TodayTimeStatusInlineRow — covers planned/actual rendering, absent flow,
   // exception dot, and the "(geplant: …)" parenthetical.
   //

--- a/frontend/src/components/students/student-detail-components.tsx
+++ b/frontend/src/components/students/student-detail-components.tsx
@@ -308,16 +308,11 @@ export function StudentDetailHeader({
   isArrivalAbsent,
   todayArrivalNote,
 }: Readonly<StudentHeaderProps>) {
+  // Spread the student so any field LocationBadge consumes (current_room_color,
+  // future room-derived attributes, etc.) propagates without maintaining a
+  // parallel whitelist here. Only the not_arrival_* fields are computed locally.
   const badgeStudent = {
-    current_location: student.current_location,
-    location_since: student.location_since,
-    group_id: student.group_id,
-    group_name: student.group_name,
-    sick: student.sick,
-    sick_since: student.sick_since,
-    excused: student.excused,
-    excused_since: student.excused_since,
-    has_full_access: student.has_full_access,
+    ...student,
     not_arrival_today: isArrivalAbsent ?? false,
     not_arrival_reason: todayArrivalNote ?? null,
   };

--- a/frontend/src/lib/hooks/use-student-data.ts
+++ b/frontend/src/lib/hooks/use-student-data.ts
@@ -67,28 +67,25 @@ function mapStudentResponse(
     group_supervisors?: SupervisorContact[];
   };
 
+  // Spread upstream-mapped student so future Student fields propagate without
+  // touching this whitelist. Explicit lines below either coerce nullish to a
+  // default (first_name/group_id/...) or apply access-control gating.
   return {
-    id: mappedStudent.id,
+    ...mappedStudent,
     first_name: mappedStudent.first_name ?? "",
     second_name: mappedStudent.second_name ?? "",
-    name: mappedStudent.name,
-    school_class: mappedStudent.school_class,
     group_id: mappedStudent.group_id ?? "",
     group_name: mappedStudent.group_name ?? "",
-    current_location: mappedStudent.current_location,
+    bus: mappedStudent.bus ?? false,
+    buskind: mappedStudent.bus ?? false,
+    current_room: undefined,
     location_since: hasAccess
       ? (mappedStudent.location_since ?? undefined)
       : undefined,
-    bus: mappedStudent.bus ?? false,
-    current_room: undefined,
-    birthday: mappedStudent.birthday ?? undefined,
-    buskind: mappedStudent.bus ?? false,
     extra_info: hasAccess ? (mappedStudent.extra_info ?? undefined) : undefined,
     supervisor_notes: hasAccess
       ? (mappedStudent.supervisor_notes ?? undefined)
       : undefined,
-    health_info: mappedStudent.health_info ?? undefined,
-    pickup_status: mappedStudent.pickup_status ?? undefined,
     sick: hasAccess ? (mappedStudent.sick ?? false) : false,
     sick_since: hasAccess ? (mappedStudent.sick_since ?? undefined) : undefined,
     excused: hasAccess ? (mappedStudent.excused ?? false) : false,


### PR DESCRIPTION
Closes #1381

## Summary

Detail-Page Raum-Badge zeigte Default-Blau statt Per-Room-Hex. Zwei Whitelists zwischen BFF und LocationBadge haben `current_room_color` verschluckt — beide durch Spread ersetzt.

- `use-student-data.ts` → `mapStudentResponse` spreadet jetzt `mappedStudent`
- `student-detail-components.tsx` → `StudentDetailHeader` spreadet `student` in `badgeStudent`
- Regression-Tests für Hex-Forwarding + Null-Fallback

## Test plan

- [x] `pnpm run check` grün
- [x] Tests grün (308/308 in betroffenen Files)
- [x] Manual: Schüler mit Raum-Hex → Detail-Page zeigt konfigurierten Hex

Labels: `bug`, `priority: medium`