### PR TITLE
Improve student search filters

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/database/rooms/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/rooms/page.test.tsx
@@ -4,6 +4,11 @@ import { useState, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import RoomsPage from "./page";
 
+const mockTenantMutate = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const mockRefreshRoomConsumers = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve()),
+);
+
 vi.mock("next-auth/react", () => ({
   useSession: vi.fn(() => ({
     data: { user: { id: "1", token: "test-token" }, expires: "2099-01-01" },
@@ -33,10 +38,10 @@ vi.mock("next/navigation", () => ({
 vi.mock("~/lib/swr", () => ({
   useSWRAuth: vi.fn(),
   mutate: vi.fn(),
-  useTenantMutate: vi.fn(() => vi.fn()),
+  useTenantMutate: vi.fn(() => mockTenantMutate),
   // Added with Issue #1324 — page invalidates badge consumer caches after a
-  // room save. Pure setup mock; no test asserts the matcher contents.
-  useTenantMutateMatching: vi.fn(() => vi.fn()),
+  // room save. Tests only assert that the returned refresher is called.
+  useTenantMutateMatching: vi.fn(() => mockRefreshRoomConsumers),
 }));
 
 const mockGetOne = vi.fn();
@@ -240,6 +245,7 @@ vi.mock("~/components/ui/modal", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { ROOM_LIST_CACHE_KEYS } from "~/lib/swr/room-derived-caches";
 
 const mockRooms = [
   {
@@ -397,6 +403,11 @@ describe("RoomsPage", () => {
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalled();
     });
+    await waitFor(() => {
+      for (const key of ROOM_LIST_CACHE_KEYS) {
+        expect(mockTenantMutate).toHaveBeenCalledWith(key);
+      }
+    });
   });
 
   it("re-throws create errors so the form can render them inline (Issue #1356)", async () => {
@@ -509,6 +520,12 @@ describe("RoomsPage", () => {
         expect.objectContaining({ name: "Updated Room" }),
       );
     });
+    await waitFor(() => {
+      for (const key of ROOM_LIST_CACHE_KEYS) {
+        expect(mockTenantMutate).toHaveBeenCalledWith(key);
+      }
+      expect(mockRefreshRoomConsumers).toHaveBeenCalled();
+    });
   });
 
   it("calls delete service after confirming deletion from the detail panel", async () => {
@@ -534,6 +551,11 @@ describe("RoomsPage", () => {
       expect(mockReplace).toHaveBeenCalledWith("/tenant/database/rooms", {
         scroll: false,
       });
+    });
+    await waitFor(() => {
+      for (const key of ROOM_LIST_CACHE_KEYS) {
+        expect(mockTenantMutate).toHaveBeenCalledWith(key);
+      }
     });
   });
 

--- a/frontend/src/app/[tenant]/(protected)/database/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/rooms/page.tsx
@@ -32,7 +32,11 @@ import {
   useTenantMutate,
   useTenantMutateMatching,
 } from "~/lib/swr";
-import { ROOM_DERIVED_CACHE_KEY_FRAGMENTS } from "~/lib/swr/room-derived-caches";
+import {
+  DATABASE_ROOMS_LIST_CACHE_KEY,
+  ROOM_DERIVED_CACHE_KEY_FRAGMENTS,
+  ROOM_LIST_CACHE_KEYS,
+} from "~/lib/swr/room-derived-caches";
 
 const logger = createLogger({ component: "DatabaseRoomsPage" });
 
@@ -90,12 +94,16 @@ export default function RoomsPage() {
   const refreshRoomConsumers = useTenantMutateMatching(
     ROOM_DERIVED_CACHE_KEY_FRAGMENTS,
   );
+  const refreshRoomLists = useCallback(
+    () => Promise.all(ROOM_LIST_CACHE_KEYS.map((key) => tenantMutate(key))),
+    [tenantMutate],
+  );
 
   const {
     data: roomsData,
     isLoading: loading,
     error: roomsError,
-  } = useSWRAuth("database-rooms-list", async () => {
+  } = useSWRAuth(DATABASE_ROOMS_LIST_CACHE_KEY, async () => {
     const data = await service.getList({ page: 1, pageSize: 500 });
     return Array.isArray(data.data) ? data.data : [];
   });
@@ -238,7 +246,7 @@ export default function RoomsPage() {
           ),
         );
         setShowCreateModal(false);
-        await tenantMutate("database-rooms-list");
+        await refreshRoomLists();
       } catch (createError) {
         logger.error("failed to create room", {
           error:
@@ -249,7 +257,7 @@ export default function RoomsPage() {
         throw createError;
       }
     },
-    [service, tenantMutate, toastSuccess],
+    [service, refreshRoomLists, toastSuccess],
   );
 
   const handleUpdateRoom = useCallback(
@@ -268,7 +276,7 @@ export default function RoomsPage() {
           ),
         );
         await Promise.all([
-          tenantMutate("database-rooms-list"),
+          refreshRoomLists(),
           // Refetch every consumer that holds room-stamped data so badges
           // pick up the new color without a manual reload.
           refreshRoomConsumers(),
@@ -284,7 +292,13 @@ export default function RoomsPage() {
         throw updateError;
       }
     },
-    [selectedRoom, service, tenantMutate, refreshRoomConsumers, toastSuccess],
+    [
+      selectedRoom,
+      service,
+      refreshRoomLists,
+      refreshRoomConsumers,
+      toastSuccess,
+    ],
   );
 
   const handleDeleteRoom = useCallback(async () => {
@@ -302,14 +316,14 @@ export default function RoomsPage() {
       ),
     );
     handleSelectRoom(null);
-    await tenantMutate("database-rooms-list");
+    await refreshRoomLists();
   }, [
     selectedRoom,
     service,
     toastError,
     toastSuccess,
     handleSelectRoom,
-    tenantMutate,
+    refreshRoomLists,
   ]);
 
   const canShowDetail =

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx
@@ -138,6 +138,9 @@ vi.mock("~/lib/api", () => ({
   groupService: {
     getGroups: vi.fn(() => Promise.resolve([])),
   },
+  roomService: {
+    getRooms: vi.fn(() => Promise.resolve([])),
+  },
 }));
 
 vi.mock("~/lib/swr", () => ({

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx
@@ -198,10 +198,17 @@ beforeEach(() => {
   // sees the call — useSWRAuth's real impl runs the fetcher synchronously
   // for the test path; we mimic that here.
   mockUseSWRAuth.mockImplementation(
-    (_key: string | null, fetcher?: () => Promise<unknown>) => {
+    (key: string | null, fetcher?: () => Promise<unknown>) => {
       if (fetcher) {
         // Fire-and-forget — we only assert on mockGetStudents call shape.
         void fetcher().catch(() => undefined);
+      }
+      if (key === "search-rooms-list") {
+        return {
+          data: [],
+          isLoading: false,
+          error: null,
+        };
       }
       return {
         data: { students: [mockStudent] },

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.school-checkin.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.school-checkin.test.tsx
@@ -261,11 +261,21 @@ describe("StudentSearchPage — school check-in wiring", () => {
       isLoading: false,
       error: null,
     } as never);
-    vi.mocked(useSWRAuth).mockReturnValue({
-      data: { students: mockStudents },
-      isLoading: false,
-      error: null,
-    } as never);
+    vi.mocked(useSWRAuth).mockImplementation((key) => {
+      if (key === "search-rooms-list") {
+        return {
+          data: [],
+          isLoading: false,
+          error: null,
+        } as never;
+      }
+
+      return {
+        data: { students: mockStudents },
+        isLoading: false,
+        error: null,
+      } as never;
+    });
   });
 
   afterEach(() => {

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -301,6 +301,34 @@ vi.mock("~/lib/usercontext-api", () => ({
   },
 }));
 
+function mockUseSWRAuthWithStudents(
+  swrModule: typeof import("~/lib/swr"),
+  response: ReturnType<typeof swrModule.useSWRAuth>,
+) {
+  vi.mocked(swrModule.useSWRAuth).mockImplementation((key) => {
+    if (key === "search-rooms-list") {
+      return {
+        data: [
+          { id: "101", name: "Raum 101", isOccupied: true },
+          { id: "102", name: "Raum 102", isOccupied: false },
+        ],
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>;
+    }
+
+    if (typeof key === "string" && key.startsWith("tracking-indicators-")) {
+      return {
+        data: undefined,
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>;
+    }
+
+    return response;
+  });
+}
+
 describe("StudentSearchPage", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -320,11 +348,12 @@ describe("StudentSearchPage", () => {
     // Reset SWR mock data for each test
     const swrModule = await import("~/lib/swr");
     vi.mocked(swrModule.useImmutableSWR).mockImplementation((key) => {
-      if (key === "search-rooms-list") {
+      if (key === "search-groups-list") {
         return {
           data: [
-            { id: "101", name: "Raum 101", isOccupied: true },
-            { id: "102", name: "Raum 102", isOccupied: false },
+            { id: "1", name: "Gruppe A" },
+            { id: "2", name: "Gruppe B" },
+            { id: "3", name: "Gruppe C" },
           ],
           isLoading: false,
           error: null,
@@ -332,16 +361,12 @@ describe("StudentSearchPage", () => {
       }
 
       return {
-        data: [
-          { id: "1", name: "Gruppe A" },
-          { id: "2", name: "Gruppe B" },
-          { id: "3", name: "Gruppe C" },
-        ],
+        data: [],
         isLoading: false,
         error: null,
       } as ReturnType<typeof swrModule.useImmutableSWR>;
     });
-    vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+    mockUseSWRAuthWithStudents(swrModule, {
       data: { students: mockStudents },
       isLoading: false,
       error: null,
@@ -490,7 +515,7 @@ describe("StudentSearchPage", () => {
 
     it("filters to show only sick students when 'krank' is selected", async () => {
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: {
           students: [
             { ...mockStudents[0]!, sick: true },
@@ -579,7 +604,7 @@ describe("StudentSearchPage", () => {
 
     it("shows loading state while fetching students", async () => {
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: undefined,
         isLoading: true,
         // IMPORTANT: Use undefined, not null. The page checks `error !== undefined`
@@ -599,7 +624,7 @@ describe("StudentSearchPage", () => {
   describe("Error Handling", () => {
     it("renders 403 permission denied error message", async () => {
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: undefined,
         isLoading: false,
         error: new Error("403 Forbidden"),
@@ -616,7 +641,7 @@ describe("StudentSearchPage", () => {
 
     it("renders 401 session expired error message", async () => {
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: undefined,
         isLoading: false,
         error: new Error("401 Unauthorized"),
@@ -632,7 +657,7 @@ describe("StudentSearchPage", () => {
 
     it("renders generic error for other API errors", async () => {
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: undefined,
         isLoading: false,
         error: new Error("Network Error"),
@@ -653,7 +678,7 @@ describe("StudentSearchPage", () => {
     it("shows empty state when no students match filters", async () => {
       // Mock SWR to return empty students
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: { students: [] },
         isLoading: false,
         error: null,
@@ -752,7 +777,7 @@ describe("StudentSearchPage", () => {
         },
       );
 
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: { students: mockStudents },
         isLoading: false,
         error: null,
@@ -805,7 +830,7 @@ describe("StudentSearchPage", () => {
         },
       );
 
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: { students: mockStudents },
         isLoading: false,
         error: null,
@@ -851,6 +876,14 @@ describe("StudentSearchPage", () => {
       } as ReturnType<typeof swrModule.useImmutableSWR>);
 
       vi.mocked(swrModule.useSWRAuth).mockImplementation((key, fetcher) => {
+        if (key === "search-rooms-list") {
+          return {
+            data: [],
+            isLoading: false,
+            error: null,
+          } as ReturnType<typeof swrModule.useSWRAuth>;
+        }
+
         // Capture the students fetcher when the key contains "search-students"
         // Note: key is null until groupsLoaded state becomes true after useEffect runs
         if (
@@ -890,7 +923,7 @@ describe("StudentSearchPage", () => {
     // Fix P3 regression test: Error heading now uses errorType instead of substring matching
     it("renders 'Keine Berechtigung' heading for 403 errors (P3 fix)", async () => {
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: undefined,
         isLoading: false,
         error: new Error("403 Forbidden"),
@@ -913,7 +946,7 @@ describe("StudentSearchPage", () => {
 
     it("renders 'Fehler' heading for 401 session errors", async () => {
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: undefined,
         isLoading: false,
         error: new Error("401 Unauthorized"),
@@ -933,7 +966,7 @@ describe("StudentSearchPage", () => {
 
     it("renders generic error heading for non-403/401 errors", async () => {
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: undefined,
         isLoading: false,
         error: new Error("500 Internal Server Error"),
@@ -990,7 +1023,7 @@ describe("StudentSearchPage", () => {
 
       // SWR won't fetch when unauthenticated
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: undefined,
         isLoading: false,
         error: undefined,
@@ -1012,7 +1045,7 @@ describe("StudentSearchPage", () => {
 
       // SWR won't fetch during auth loading
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: undefined,
         isLoading: false,
         error: undefined,
@@ -1067,7 +1100,7 @@ describe("StudentSearchPage", () => {
 
       // Groups haven't loaded yet, so studentsCacheKey is null
       // SWR returns undefined data (not yet fetched)
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: undefined, // No data yet - first fetch hasn't completed
         isLoading: true, // SWR is loading students
         error: undefined,
@@ -1102,7 +1135,7 @@ describe("StudentSearchPage", () => {
       } as ReturnType<typeof swrModule.useImmutableSWR>);
 
       // Students fetch completed with empty results (hasFetchedOnce = true)
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: { students: [] }, // Empty results from completed fetch
         isLoading: false,
         error: undefined,
@@ -1235,7 +1268,7 @@ describe("StudentSearchPage", () => {
       ];
 
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: { students: studentsWithRedacted },
         isLoading: false,
         error: null,
@@ -1325,7 +1358,7 @@ describe("StudentSearchPage", () => {
       ];
 
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: { students: studentsNoPickup },
         isLoading: false,
         error: null,
@@ -1392,7 +1425,7 @@ describe("StudentSearchPage", () => {
       ];
 
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: { students: studentsWithArrivalGaps },
         isLoading: false,
         error: null,
@@ -1452,7 +1485,7 @@ describe("StudentSearchPage", () => {
         { ...mockStudents[0]!, id: "9", first_name: "SickChild", sick: true },
       ];
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: { students: studentsByStatus },
         isLoading: false,
         error: null,
@@ -1507,7 +1540,7 @@ describe("StudentSearchPage", () => {
         },
       ];
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: { students: groupedFixture },
         isLoading: false,
         error: null,
@@ -1587,6 +1620,14 @@ describe("StudentSearchPage", () => {
         error: null,
       } as ReturnType<typeof swrModule.useSWRAuth>;
       vi.mocked(swrModule.useSWRAuth).mockImplementation((key: unknown) => {
+        if (key === "search-rooms-list") {
+          return {
+            data: [],
+            isLoading: false,
+            error: null,
+          } as ReturnType<typeof swrModule.useSWRAuth>;
+        }
+
         if (typeof key === "string" && key.startsWith("tracking-indicators-")) {
           return trackingResult;
         }
@@ -1847,24 +1888,22 @@ describe("StudentSearchPage", () => {
 
     it("requests a large first page for the room filter options", async () => {
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useImmutableSWR).mockImplementation(
-        (key, fetcher) => {
-          if (key === "search-rooms-list") {
-            void (fetcher as () => Promise<unknown>)();
-            return {
-              data: [],
-              isLoading: false,
-              error: null,
-            } as ReturnType<typeof swrModule.useImmutableSWR>;
-          }
-
+      vi.mocked(swrModule.useSWRAuth).mockImplementation((key, fetcher) => {
+        if (key === "search-rooms-list") {
+          void (fetcher as () => Promise<unknown>)();
           return {
             data: [],
             isLoading: false,
             error: null,
-          } as ReturnType<typeof swrModule.useImmutableSWR>;
-        },
-      );
+          } as ReturnType<typeof swrModule.useSWRAuth>;
+        }
+
+        return {
+          data: { students: mockStudents },
+          isLoading: false,
+          error: null,
+        } as ReturnType<typeof swrModule.useSWRAuth>;
+      });
 
       render(<StudentSearchPage />);
 
@@ -1930,7 +1969,7 @@ describe("StudentSearchPage", () => {
 
     it("does not group status-only locations as rooms", async () => {
       const swrModule = await import("~/lib/swr");
-      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+      mockUseSWRAuthWithStudents(swrModule, {
         data: {
           students: [
             {

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
+import { roomService } from "~/lib/api";
 import StudentSearchPage from "./page";
 
 // Mock next-auth/react
@@ -304,6 +305,9 @@ describe("StudentSearchPage", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mockSearchParams.delete("status");
+    mockSearchParams.delete("room_id");
+    mockSearchParams.delete("room_name");
+    window.history.replaceState(null, "", "/students/search");
 
     // Reset useSession mock to authenticated state
     const sessionModule = await import("next-auth/react");
@@ -1612,6 +1616,135 @@ describe("StudentSearchPage", () => {
       expect(
         screen.getByRole("option", { name: "Raum 101" }),
       ).toBeInTheDocument();
+    });
+
+    it("requests a large first page for the room filter options", async () => {
+      const swrModule = await import("~/lib/swr");
+      vi.mocked(swrModule.useImmutableSWR).mockImplementation(
+        (key, fetcher) => {
+          if (key === "search-rooms-list") {
+            void (fetcher as () => Promise<unknown>)();
+            return {
+              data: [],
+              isLoading: false,
+              error: null,
+            } as ReturnType<typeof swrModule.useImmutableSWR>;
+          }
+
+          return {
+            data: [],
+            isLoading: false,
+            error: null,
+          } as ReturnType<typeof swrModule.useImmutableSWR>;
+        },
+      );
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(roomService.getRooms).toHaveBeenCalledWith({
+          page: 1,
+          pageSize: 1000,
+        });
+      });
+    });
+
+    it("syncs room selection changes into the URL", async () => {
+      mockSearchParams.set("room_id", "42");
+      mockSearchParams.set("room_name", "Alter Raum");
+      window.history.replaceState(
+        { preserved: true },
+        "",
+        "/students/search?room_id=42&room_name=Alter+Raum&status=anwesend",
+      );
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-room")).toHaveValue("42");
+      });
+
+      fireEvent.change(screen.getByTestId("filter-room"), {
+        target: { value: "101" },
+      });
+
+      const url = new URL(window.location.href);
+      expect(url.searchParams.get("room_id")).toBe("101");
+      expect(url.searchParams.get("room_name")).toBe("Raum 101");
+      expect(url.searchParams.get("status")).toBe("anwesend");
+      expect(window.history.state).toEqual({ preserved: true });
+    });
+
+    it("removes only room params when clearing the room filter", async () => {
+      mockSearchParams.set("room_id", "42");
+      mockSearchParams.set("room_name", "Alter Raum");
+      window.history.replaceState(
+        { preserved: true },
+        "",
+        "/students/search?room_id=42&room_name=Alter+Raum&status=anwesend",
+      );
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-room")).toHaveValue("42");
+      });
+
+      fireEvent.change(screen.getByTestId("filter-room"), {
+        target: { value: "" },
+      });
+
+      const url = new URL(window.location.href);
+      expect(url.searchParams.has("room_id")).toBe(false);
+      expect(url.searchParams.has("room_name")).toBe(false);
+      expect(url.searchParams.get("status")).toBe("anwesend");
+      expect(window.history.state).toEqual({ preserved: true });
+    });
+
+    it("does not group status-only locations as rooms", async () => {
+      const swrModule = await import("~/lib/swr");
+      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+        data: {
+          students: [
+            {
+              id: "5",
+              first_name: "Nina",
+              second_name: "Status",
+              school_class: "1a",
+              current_location: "Anwesend",
+              has_full_access: true,
+            },
+            {
+              id: "6",
+              first_name: "Rita",
+              second_name: "Redacted",
+              school_class: "1a",
+              current_location: "Anwesend",
+              has_full_access: false,
+            },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Nina")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-groupMode"), {
+        target: { value: "room" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Kein Raum")).toBeInTheDocument();
+        expect(screen.getByText("Nicht einsehbar")).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByRole("heading", { name: "Anwesend" }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -229,6 +229,7 @@ const mockStudents = [
     school_class: "1a",
     group_name: "Gruppe A",
     current_location: "Raum 101",
+    arrival_time: "08:00",
     pickup_time: "15:30",
     has_full_access: true,
   },
@@ -239,6 +240,7 @@ const mockStudents = [
     school_class: "2b",
     group_name: "Gruppe B",
     current_location: "Zuhause",
+    arrival_time: "08:30",
     has_full_access: true,
   },
   {
@@ -248,6 +250,7 @@ const mockStudents = [
     school_class: "1a",
     group_name: "Gruppe A",
     current_location: "Unterwegs",
+    arrival_time: "08:15",
     pickup_time: "16:00",
     has_full_access: true,
   },
@@ -258,6 +261,7 @@ const mockStudents = [
     school_class: "3c",
     group_name: "Gruppe C",
     current_location: "Schulhof",
+    arrival_time: "09:00",
     has_full_access: true,
   },
 ];
@@ -276,6 +280,14 @@ vi.mock("~/lib/api", () => ({
         { id: "1", name: "Gruppe A" },
         { id: "2", name: "Gruppe B" },
         { id: "3", name: "Gruppe C" },
+      ]),
+    ),
+  },
+  roomService: {
+    getRooms: vi.fn(() =>
+      Promise.resolve([
+        { id: "101", name: "Raum 101", isOccupied: true },
+        { id: "102", name: "Raum 102", isOccupied: false },
       ]),
     ),
   },
@@ -303,15 +315,28 @@ describe("StudentSearchPage", () => {
 
     // Reset SWR mock data for each test
     const swrModule = await import("~/lib/swr");
-    vi.mocked(swrModule.useImmutableSWR).mockReturnValue({
-      data: [
-        { id: "1", name: "Gruppe A" },
-        { id: "2", name: "Gruppe B" },
-        { id: "3", name: "Gruppe C" },
-      ],
-      isLoading: false,
-      error: null,
-    } as ReturnType<typeof swrModule.useImmutableSWR>);
+    vi.mocked(swrModule.useImmutableSWR).mockImplementation((key) => {
+      if (key === "search-rooms-list") {
+        return {
+          data: [
+            { id: "101", name: "Raum 101", isOccupied: true },
+            { id: "102", name: "Raum 102", isOccupied: false },
+          ],
+          isLoading: false,
+          error: null,
+        } as ReturnType<typeof swrModule.useImmutableSWR>;
+      }
+
+      return {
+        data: [
+          { id: "1", name: "Gruppe A" },
+          { id: "2", name: "Gruppe B" },
+          { id: "3", name: "Gruppe C" },
+        ],
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useImmutableSWR>;
+    });
     vi.mocked(swrModule.useSWRAuth).mockReturnValue({
       data: { students: mockStudents },
       isLoading: false,
@@ -461,6 +486,21 @@ describe("StudentSearchPage", () => {
   });
 
   describe("Year Filtering", () => {
+    it("renders the school year filter as a stage dropdown", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-year")).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole("option", { name: "Alle Stufen" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: "Stufe 1" }),
+      ).toBeInTheDocument();
+    });
+
     it("filters students by school year when year filter changes", async () => {
       render(<StudentSearchPage />);
 
@@ -1512,6 +1552,66 @@ describe("StudentSearchPage", () => {
       expect(screen.getByText("Anna")).toBeInTheDocument();
       expect(screen.getByText("Tom")).toBeInTheDocument();
       expect(screen.getByText("Lisa")).toBeInTheDocument();
+    });
+
+    it("offers pickup sorting as a dedicated sort mode", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => expect(screen.getByText("Max")).toBeInTheDocument());
+
+      fireEvent.change(screen.getByTestId("filter-sort"), {
+        target: { value: "pickup" },
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId("filter-sort")).toHaveValue("pickup"),
+      );
+      expect(screen.getByText("Max")).toBeInTheDocument();
+      expect(screen.getByText("Tom")).toBeInTheDocument();
+    });
+
+    it("filters by a specific arrival time", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => expect(screen.getByText("Max")).toBeInTheDocument());
+
+      fireEvent.change(screen.getByTestId("filter-arrivalTime"), {
+        target: { value: "08:15" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Tom")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Max")).not.toBeInTheDocument();
+      expect(screen.queryByText("Anna")).not.toBeInTheDocument();
+      expect(screen.queryByText("Lisa")).not.toBeInTheDocument();
+    });
+
+    it("groups the result list when a grouping mode is selected", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => expect(screen.getByText("Max")).toBeInTheDocument());
+
+      fireEvent.change(screen.getByTestId("filter-groupMode"), {
+        target: { value: "status" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId("student-group")).toHaveLength(4);
+      });
+      expect(screen.getAllByText("Anwesend").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Abwesend").length).toBeGreaterThan(0);
+    });
+
+    it("shows the room filter even without a room deep-link", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-room")).toBeInTheDocument();
+      });
+      expect(
+        screen.getByRole("option", { name: "Raum 101" }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -487,6 +487,38 @@ describe("StudentSearchPage", () => {
         expect(screen.queryByText("Tom")).not.toBeInTheDocument();
       });
     });
+
+    it("filters to show only sick students when 'krank' is selected", async () => {
+      const swrModule = await import("~/lib/swr");
+      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+        data: {
+          students: [
+            { ...mockStudents[0]!, sick: true },
+            { ...mockStudents[1]!, sick: false },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Max")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-attendance"), {
+        target: { value: "krank" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Max")).toBeInTheDocument();
+        expect(screen.queryByText("Anna")).not.toBeInTheDocument();
+        expect(
+          screen.getByTestId("active-filter-attendance"),
+        ).toHaveTextContent("Krank");
+      });
+    });
   });
 
   describe("Year Filtering", () => {
@@ -1307,6 +1339,201 @@ describe("StudentSearchPage", () => {
 
       // Should show "Abholzeit: —" fallback for students with full access but no pickup time
       expect(screen.getByText("Abholzeit: —")).toBeInTheDocument();
+    });
+  });
+
+  describe("Arrival Time Filtering", () => {
+    it("filters students by specific arrival time", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Max")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-arrivalTime"), {
+        target: { value: "08:15" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Tom")).toBeInTheDocument();
+        expect(screen.queryByText("Max")).not.toBeInTheDocument();
+        expect(screen.queryByText("Anna")).not.toBeInTheDocument();
+        expect(screen.queryByText("Lisa")).not.toBeInTheDocument();
+      });
+    });
+
+    it("filters students with no arrival time while excluding redacted and exception-only rows", async () => {
+      const studentsWithArrivalGaps = [
+        {
+          id: "30",
+          first_name: "NoArrival",
+          second_name: "Student",
+          school_class: "1a",
+          current_location: "Raum 101",
+          has_full_access: true,
+        },
+        {
+          id: "31",
+          first_name: "Exception",
+          second_name: "Student",
+          school_class: "1a",
+          current_location: "Raum 101",
+          arrival_is_exception: true,
+          has_full_access: true,
+        },
+        {
+          id: "32",
+          first_name: "RedactedArrival",
+          second_name: "Student",
+          school_class: "1a",
+          current_location: "Raum 101",
+          has_full_access: false,
+        },
+      ];
+
+      const swrModule = await import("~/lib/swr");
+      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+        data: { students: studentsWithArrivalGaps },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("NoArrival")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-arrivalTime"), {
+        target: { value: "none" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("NoArrival")).toBeInTheDocument();
+        expect(screen.queryByText("Exception")).not.toBeInTheDocument();
+        expect(screen.queryByText("RedactedArrival")).not.toBeInTheDocument();
+        expect(
+          screen.getByTestId("active-filter-arrivalTime"),
+        ).toHaveTextContent("Keine Ankunftszeit");
+      });
+    });
+  });
+
+  describe("Sorting and Grouping", () => {
+    it("sorts students by pickup time before students without pickup times", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Max")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-sort"), {
+        target: { value: "pickup" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("active-filter-sort")).toHaveTextContent(
+          "Nächste Abholung",
+        );
+      });
+
+      const renderedNames = screen
+        .getAllByText(/^(Max|Tom|Lisa|Anna)$/)
+        .map((node) => node.textContent);
+      expect(renderedNames).toEqual(["Max", "Tom", "Lisa", "Anna"]);
+    });
+
+    it("groups students by status in operational order", async () => {
+      const studentsByStatus = [
+        { ...mockStudents[1]!, first_name: "HomeChild" },
+        { ...mockStudents[3]!, first_name: "YardChild" },
+        { ...mockStudents[2]!, first_name: "TransitChild" },
+        { ...mockStudents[0]!, first_name: "PresentChild" },
+        { ...mockStudents[0]!, id: "9", first_name: "SickChild", sick: true },
+      ];
+      const swrModule = await import("~/lib/swr");
+      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+        data: { students: studentsByStatus },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("PresentChild")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-groupMode"), {
+        target: { value: "status" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("active-filter-groupMode")).toHaveTextContent(
+          "Ansicht: Nach Status",
+        );
+      });
+
+      expect(
+        screen.getAllByRole("heading", { level: 2 }).map((h) => h.textContent),
+      ).toEqual(["Anwesend", "Unterwegs", "Schulhof", "Krank", "Abwesend"]);
+    });
+
+    it("groups redacted and missing room/time values under explicit fallback labels", async () => {
+      const groupedFixture = [
+        {
+          id: "40",
+          first_name: "Hidden",
+          second_name: "Student",
+          school_class: "1a",
+          current_location: "Raum 101",
+          has_full_access: false,
+        },
+        {
+          id: "41",
+          first_name: "Home",
+          second_name: "Student",
+          school_class: "1a",
+          current_location: "Zuhause",
+          has_full_access: true,
+        },
+        {
+          id: "42",
+          first_name: "Room",
+          second_name: "Student",
+          school_class: "1a",
+          current_location: "Gruppe A - Atelier",
+          has_full_access: true,
+        },
+      ];
+      const swrModule = await import("~/lib/swr");
+      vi.mocked(swrModule.useSWRAuth).mockReturnValue({
+        data: { students: groupedFixture },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Hidden")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-groupMode"), {
+        target: { value: "room" },
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Atelier" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("heading", { name: "Kein Raum" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("heading", { name: "Nicht einsehbar" }),
+        ).toBeInTheDocument();
+      });
     });
   });
 

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -323,7 +323,9 @@ function SearchPageContent() {
     },
   );
 
-  const { data: rooms = [] } = useImmutableSWR<Room[]>(
+  // Room names/options are mutable from the rooms admin page, so this must
+  // revalidate stale cache entries when the search page remounts.
+  const { data: rooms = [] } = useSWRAuth<Room[]>(
     SEARCH_ROOMS_LIST_CACHE_KEY,
     async () => {
       try {

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -21,6 +21,7 @@ import { useUserContext } from "~/lib/hooks/use-user-context";
 import { Loading } from "~/components/ui/loading";
 import { StudentPresenceBadge } from "@/components/ui/student-presence-badge";
 import {
+  LOCATION_STATUSES,
   isHomeLocation,
   isPresentLocation,
   isSchoolyardLocation,
@@ -131,6 +132,8 @@ function statusLabelForStudent(student: Student): string {
 }
 
 function roomLabelForStudent(student: Student): string {
+  if (student.has_full_access === false) return "Nicht einsehbar";
+
   const location = student.current_location?.trim();
   if (!location || isHomeLocation(location)) return "Kein Raum";
   if (isTransitLocation(location)) return "Unterwegs";
@@ -139,6 +142,9 @@ function roomLabelForStudent(student: Student): string {
   if (separatorIndex >= 0) {
     const room = location.slice(separatorIndex + 1).trim();
     return room || "Kein Raum";
+  }
+  if (Object.values(LOCATION_STATUSES).some((status) => status === location)) {
+    return "Kein Raum";
   }
   return location;
 }
@@ -320,7 +326,7 @@ function SearchPageContent() {
     "search-rooms-list",
     async () => {
       try {
-        return await roomService.getRooms();
+        return await roomService.getRooms({ page: 1, pageSize: 1000 });
       } catch {
         logger.warn("could not load rooms for filter");
         return [];
@@ -362,21 +368,28 @@ function SearchPageContent() {
     },
   );
 
-  // Clearing the room filter resets state AND strips room_id/room_name from
-  // the URL so a refresh doesn't silently re-hydrate a filter the user has
-  // just removed. window.history.replaceState avoids a Next.js navigation,
-  // which would discard SWR data and flash the loading skeleton. Merge into
-  // the existing state object instead of replacing it — App Router stashes
-  // routing metadata (scroll restoration, RSC cache keys) on
-  // window.history.state, and clobbering it with `{}` can degrade browser
+  // Keep room state and room_id/room_name query params in sync without a
+  // Next.js navigation, which would discard SWR data and flash the loading
+  // skeleton. Merge into the existing state object instead of replacing it —
+  // App Router stashes routing metadata (scroll restoration, RSC cache keys)
+  // on window.history.state, and clobbering it with `{}` can degrade browser
   // back/forward into a hard reload for this entry.
-  const clearRoomFilter = useCallback(() => {
-    setSelectedRoomId("");
-    setSelectedRoomName("");
+  const updateRoomFilter = useCallback((roomId: string, roomName: string) => {
+    setSelectedRoomId(roomId);
+    setSelectedRoomName(roomName);
     if (typeof window !== "undefined") {
       const url = new URL(window.location.href);
-      url.searchParams.delete("room_id");
-      url.searchParams.delete("room_name");
+      if (roomId) {
+        url.searchParams.set("room_id", roomId);
+        if (roomName) {
+          url.searchParams.set("room_name", roomName);
+        } else {
+          url.searchParams.delete("room_name");
+        }
+      } else {
+        url.searchParams.delete("room_id");
+        url.searchParams.delete("room_name");
+      }
       window.history.replaceState(
         window.history.state ?? null,
         "",
@@ -384,6 +397,10 @@ function SearchPageContent() {
       );
     }
   }, []);
+
+  const clearRoomFilter = useCallback(() => {
+    updateRoomFilter("", "");
+  }, [updateRoomFilter]);
 
   const students = studentsData?.students ?? [];
 
@@ -492,8 +509,10 @@ function SearchPageContent() {
             return;
           }
           const room = rooms.find((r) => r.id === v);
-          setSelectedRoomId(v);
-          setSelectedRoomName(room?.name ?? "");
+          updateRoomFilter(
+            v,
+            room?.name ?? (v === selectedRoomId ? selectedRoomName : ""),
+          );
         },
         options: [
           { value: "", label: "Alle Räume" },
@@ -619,6 +638,7 @@ function SearchPageContent() {
       selectedRoomName,
       orderedRoomOptions,
       clearRoomFilter,
+      updateRoomFilter,
       sortMode,
       groupMode,
     ],

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -48,6 +48,7 @@ import {
 } from "~/lib/hooks/use-school-checkin-mode";
 import { usePresenceMode } from "~/components/tenant/tenant-provider";
 import { useSWRAuth, useImmutableSWR } from "~/lib/swr";
+import { SEARCH_ROOMS_LIST_CACHE_KEY } from "~/lib/swr/room-derived-caches";
 import { activeService } from "~/lib/active-api";
 import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
 import { TrackingIndicators } from "~/components/students/tracking-indicators";
@@ -323,7 +324,7 @@ function SearchPageContent() {
   );
 
   const { data: rooms = [] } = useImmutableSWR<Room[]>(
-    "search-rooms-list",
+    SEARCH_ROOMS_LIST_CACHE_KEY,
     async () => {
       try {
         return await roomService.getRooms({ page: 1, pageSize: 1000 });

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState, useEffect, useRef, Suspense, useMemo } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  Suspense,
+  useMemo,
+  useCallback,
+} from "react";
 // SSE is handled globally by TenantAuthWrapper - real-time updates work automatically
 import { useSession } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
@@ -8,8 +15,8 @@ import { useTenantRouter } from "~/lib/tenant-router";
 import { Alert } from "~/components/ui/alert";
 import { PageHeaderWithSearch } from "~/components/ui/page-header";
 import type { FilterConfig, ActiveFilter } from "~/components/ui/page-header";
-import { studentService, groupService } from "~/lib/api";
-import type { Student, Group } from "~/lib/api";
+import { studentService, groupService, roomService } from "~/lib/api";
+import type { Student, Group, Room } from "~/lib/api";
 import { useUserContext } from "~/lib/hooks/use-user-context";
 import { Loading } from "~/components/ui/loading";
 import { StudentPresenceBadge } from "@/components/ui/student-presence-badge";
@@ -56,6 +63,162 @@ import {
 } from "./tracking-filter";
 
 const logger = createLogger({ component: "StudentSearchPage" });
+const EMPTY_STRING_ARRAY: string[] = [];
+
+type StatusFilter =
+  | "all"
+  | "anwesend"
+  | "abwesend"
+  | "unterwegs"
+  | "schulhof"
+  | "krank";
+type SortMode = "name" | "arrival" | "pickup";
+type GroupMode = "none" | "status" | "room" | "arrival" | "pickup";
+
+const STATUS_FILTER_OPTIONS: Array<{ value: StatusFilter; label: string }> = [
+  { value: "all", label: "Alle" },
+  { value: "anwesend", label: "Anwesend" },
+  { value: "abwesend", label: "Abwesend" },
+  { value: "krank", label: "Krank" },
+  { value: "unterwegs", label: "Unterwegs" },
+  { value: "schulhof", label: "Schulhof" },
+];
+
+const SORT_OPTIONS: Array<{ value: SortMode; label: string }> = [
+  { value: "name", label: "Name A-Z" },
+  { value: "arrival", label: "Nächste Ankunft" },
+  { value: "pickup", label: "Nächste Abholung" },
+];
+
+const GROUP_OPTIONS: Array<{ value: GroupMode; label: string }> = [
+  { value: "none", label: "Liste" },
+  { value: "status", label: "Nach Status" },
+  { value: "room", label: "Nach Raum" },
+  { value: "arrival", label: "Nach Ankunftszeit" },
+  { value: "pickup", label: "Nach Abholzeit" },
+];
+
+const SCHOOL_YEAR_DROPDOWN_OPTIONS = SCHOOL_YEAR_FILTER_OPTIONS.map(
+  (option) => ({
+    value: option.value,
+    label: option.value === "all" ? "Alle Stufen" : `Stufe ${option.label}`,
+  }),
+);
+
+const STATUS_GROUP_ORDER = new Map([
+  ["Anwesend", 0],
+  ["Unterwegs", 1],
+  ["Schulhof", 2],
+  ["Krank", 3],
+  ["Abwesend", 4],
+]);
+
+function compareByName(a: Student, b: Student) {
+  const lastCmp = (a.second_name ?? "").localeCompare(
+    b.second_name ?? "",
+    "de",
+  );
+  if (lastCmp !== 0) return lastCmp;
+  return (a.first_name ?? "").localeCompare(b.first_name ?? "", "de");
+}
+
+function statusLabelForStudent(student: Student): string {
+  if (student.sick) return "Krank";
+  if (isSchoolyardLocation(student.current_location)) return "Schulhof";
+  if (isTransitLocation(student.current_location)) return "Unterwegs";
+  if (isHomeLocation(student.current_location)) return "Abwesend";
+  return "Anwesend";
+}
+
+function roomLabelForStudent(student: Student): string {
+  const location = student.current_location?.trim();
+  if (!location || isHomeLocation(location)) return "Kein Raum";
+  if (isTransitLocation(location)) return "Unterwegs";
+  if (isSchoolyardLocation(location)) return "Schulhof";
+  const separatorIndex = location.indexOf("-");
+  if (separatorIndex >= 0) {
+    const room = location.slice(separatorIndex + 1).trim();
+    return room || "Kein Raum";
+  }
+  return location;
+}
+
+function pickupLabelForStudent(student: Student): string {
+  if (student.has_full_access === false) return "Nicht einsehbar";
+  return student.pickup_time ? `${student.pickup_time} Uhr` : "Keine Abholzeit";
+}
+
+function arrivalLabelForStudent(student: Student): string {
+  if (student.has_full_access === false) return "Nicht einsehbar";
+  return student.arrival_time
+    ? `${student.arrival_time} Uhr`
+    : "Keine Ankunftszeit";
+}
+
+function groupStudents(students: Student[], groupMode: GroupMode) {
+  if (groupMode === "none") return [];
+
+  const groups = new Map<string, Student[]>();
+  for (const student of students) {
+    const key =
+      groupMode === "status"
+        ? statusLabelForStudent(student)
+        : groupMode === "room"
+          ? roomLabelForStudent(student)
+          : groupMode === "arrival"
+            ? arrivalLabelForStudent(student)
+            : pickupLabelForStudent(student);
+    const bucket = groups.get(key);
+    if (bucket) {
+      bucket.push(student);
+    } else {
+      groups.set(key, [student]);
+    }
+  }
+
+  return Array.from(groups.entries())
+    .map(([label, items]) => ({
+      label,
+      items,
+    }))
+    .sort((a, b) => {
+      if (groupMode === "status") {
+        return (
+          (STATUS_GROUP_ORDER.get(a.label) ?? 99) -
+          (STATUS_GROUP_ORDER.get(b.label) ?? 99)
+        );
+      }
+      if (groupMode === "pickup" || groupMode === "arrival") {
+        const rank = (label: string) =>
+          label === "Keine Abholzeit" || label === "Keine Ankunftszeit"
+            ? "99"
+            : label === "Nicht einsehbar"
+              ? "zz"
+              : label;
+        return rank(a.label).localeCompare(rank(b.label), "de");
+      }
+      return a.label.localeCompare(b.label, "de");
+    });
+}
+
+function orderedRooms(
+  rooms: Room[],
+  groupRoomNames: string[],
+  supervisedRoomNames: string[],
+) {
+  const priorityNames = new Set(
+    [...groupRoomNames, ...supervisedRoomNames].map((name) =>
+      name.trim().toLowerCase(),
+    ),
+  );
+
+  return [...rooms].sort((a, b) => {
+    const aPriority = priorityNames.has(a.name.trim().toLowerCase());
+    const bPriority = priorityNames.has(b.name.trim().toLowerCase());
+    if (aPriority !== bPriority) return aPriority ? -1 : 1;
+    return a.name.localeCompare(b.name, "de");
+  });
+}
 
 function SearchPageContent() {
   const router = useTenantRouter();
@@ -71,16 +234,11 @@ function SearchPageContent() {
 
   // Read initial filter from URL params (supports deep-linking from dashboard)
   const initialStatus = searchParams.get("status") ?? "all";
-  const validStatuses = [
-    "all",
-    "anwesend",
-    "abwesend",
-    "unterwegs",
-    "schulhof",
-    "krank",
-  ];
-  const initialAttendanceFilter = validStatuses.includes(initialStatus)
-    ? initialStatus
+  const validStatuses = STATUS_FILTER_OPTIONS.map((option) => option.value);
+  const initialAttendanceFilter = validStatuses.includes(
+    initialStatus as StatusFilter,
+  )
+    ? (initialStatus as StatusFilter)
     : "all";
 
   // Room filter — populated when the user lands here from the room detail
@@ -94,12 +252,14 @@ function SearchPageContent() {
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(""); // Debounced version for SWR key
   const [selectedGroup, setSelectedGroup] = useState("");
   const [selectedYear, setSelectedYear] = useState("all");
-  const [attendanceFilter, setAttendanceFilter] = useState(
+  const [attendanceFilter, setAttendanceFilter] = useState<StatusFilter>(
     initialAttendanceFilter,
   );
   const [pickupTimeFilter, setPickupTimeFilter] = useState("all");
+  const [arrivalTimeFilter, setArrivalTimeFilter] = useState("all");
   const [trackingFilter, setTrackingFilter] = useState<TrackingFilter>("all");
-  const [sortMode, setSortMode] = useState<"default" | "arrival">("default");
+  const [sortMode, setSortMode] = useState<SortMode>("name");
+  const [groupMode, setGroupMode] = useState<GroupMode>("none");
   const [selectedRoomId, setSelectedRoomId] = useState(initialRoomId);
   const [selectedRoomName, setSelectedRoomName] = useState(initialRoomName);
 
@@ -109,9 +269,11 @@ function SearchPageContent() {
   // OGS group tracking via shared BFF endpoint with SWR caching
   // This eliminates 2 separate API calls with 2 auth() calls each
   const { userContext } = useUserContext();
-  const myGroups = userContext?.educationalGroupIds ?? [];
-  const myGroupRooms = userContext?.educationalGroupRoomNames ?? [];
-  const mySupervisedRooms = userContext?.supervisedRoomNames ?? [];
+  const myGroups = userContext?.educationalGroupIds ?? EMPTY_STRING_ARRAY;
+  const myGroupRooms =
+    userContext?.educationalGroupRoomNames ?? EMPTY_STRING_ARRAY;
+  const mySupervisedRooms =
+    userContext?.supervisedRoomNames ?? EMPTY_STRING_ARRAY;
 
   // Page-level school check-in/out mode. When active, clicking a card toggles
   // the student's attendance instead of navigating to the detail page.
@@ -149,6 +311,18 @@ function SearchPageContent() {
       } catch {
         // User might not have groups:read permission - continue with empty list
         logger.warn("could not load groups for filter");
+        return [];
+      }
+    },
+  );
+
+  const { data: rooms = [] } = useImmutableSWR<Room[]>(
+    "search-rooms-list",
+    async () => {
+      try {
+        return await roomService.getRooms();
+      } catch {
+        logger.warn("could not load rooms for filter");
         return [];
       }
     },
@@ -196,7 +370,7 @@ function SearchPageContent() {
   // routing metadata (scroll restoration, RSC cache keys) on
   // window.history.state, and clobbering it with `{}` can degrade browser
   // back/forward into a hard reload for this entry.
-  const clearRoomFilter = () => {
+  const clearRoomFilter = useCallback(() => {
     setSelectedRoomId("");
     setSelectedRoomName("");
     if (typeof window !== "undefined") {
@@ -209,7 +383,7 @@ function SearchPageContent() {
         url.toString(),
       );
     }
-  };
+  }, []);
 
   const students = studentsData?.students ?? [];
 
@@ -280,15 +454,20 @@ function SearchPageContent() {
   // which triggers SWR refetch for search-students-* keys automatically.
 
   // Prepare filter configurations for PageHeaderWithSearch
+  const orderedRoomOptions = useMemo(
+    () => orderedRooms(rooms, myGroupRooms, mySupervisedRooms),
+    [rooms, myGroupRooms, mySupervisedRooms],
+  );
+
   const filterConfigs: FilterConfig[] = useMemo(
     () => [
       {
         id: "year",
-        label: "Klassenstufe",
-        type: "buttons",
+        label: "Stufe",
+        type: "dropdown",
         value: selectedYear,
         onChange: (value) => setSelectedYear(value as string),
-        options: [...SCHOOL_YEAR_FILTER_OPTIONS],
+        options: SCHOOL_YEAR_DROPDOWN_OPTIONS,
       },
       {
         id: "group",
@@ -302,29 +481,35 @@ function SearchPageContent() {
         ],
       },
       {
-        id: "sort",
-        label: "Sortierung",
-        type: "buttons",
-        value: sortMode,
-        onChange: (value) => setSortMode(value as "default" | "arrival"),
-        options: [
-          { value: "default", label: "Alphabetisch" },
-          { value: "arrival", label: "Nächste Ankunft" },
-        ],
-      },
-      {
-        id: "attendance",
-        label: "Anwesenheit",
+        id: "room",
+        label: "Raum",
         type: "dropdown",
-        value: attendanceFilter,
-        onChange: (value) => setAttendanceFilter(value as string),
+        value: selectedRoomId,
+        onChange: (value: string | string[]) => {
+          const v = Array.isArray(value) ? value[0] : value;
+          if (!v) {
+            clearRoomFilter();
+            return;
+          }
+          const room = rooms.find((r) => r.id === v);
+          setSelectedRoomId(v);
+          setSelectedRoomName(room?.name ?? "");
+        },
         options: [
-          { value: "all", label: "Alle Status" },
-          { value: "anwesend", label: "Anwesend" },
-          { value: "abwesend", label: "Zuhause" },
-          { value: "unterwegs", label: "Unterwegs" },
-          { value: "schulhof", label: "Schulhof" },
-          { value: "krank", label: "Krank" },
+          { value: "", label: "Alle Räume" },
+          ...orderedRoomOptions.map((room) => ({
+            value: room.id,
+            label: room.name,
+          })),
+          ...(selectedRoomId &&
+          !orderedRoomOptions.some((room) => room.id === selectedRoomId)
+            ? [
+                {
+                  value: selectedRoomId,
+                  label: selectedRoomName || `Raum #${selectedRoomId}`,
+                },
+              ]
+            : []),
         ],
       },
       {
@@ -347,34 +532,57 @@ function SearchPageContent() {
           { value: "none", label: "Keine Abholzeit" },
         ],
       },
-      // Room (#1323): only surfaces when a deep-link from a room detail
-      // page set ?room_id=…. Following the established pattern of this
-      // page (every active filter must be clearable through the filter
-      // sheet, since activeFilterDisplay="count" hides chips), the room
-      // appears here with two options — its own value plus "Alle Räume"
-      // to clear. Same UX a user would use to clear a Dashboard "Krank"
-      // deep-link via the Anwesenheit dropdown.
-      ...(selectedRoomId
-        ? [
-            {
-              id: "room",
-              label: "Raum",
-              type: "dropdown" as const,
-              value: selectedRoomId,
-              onChange: (value: string | string[]) => {
-                const v = Array.isArray(value) ? value[0] : value;
-                if (!v) clearRoomFilter();
-              },
-              options: [
-                {
-                  value: selectedRoomId,
-                  label: selectedRoomName || `Raum #${selectedRoomId}`,
-                },
-                { value: "", label: "Alle Räume" },
-              ],
-            },
-          ]
-        : []),
+      {
+        id: "arrivalTime",
+        label: "Ankunftszeit",
+        type: "dropdown",
+        value: arrivalTimeFilter,
+        onChange: (value) => setArrivalTimeFilter(value as string),
+        options: [
+          { value: "all", label: "Alle Ankunftszeiten" },
+          ...Array.from(
+            new Set(
+              (studentsData?.students ?? [])
+                .map((s) => s.arrival_time)
+                .filter((t): t is string => !!t),
+            ),
+          )
+            .sort((a, b) => a.localeCompare(b))
+            .map((time) => ({ value: time, label: `${time} Uhr` })),
+          { value: "none", label: "Keine Ankunftszeit" },
+        ],
+      },
+      {
+        id: "attendance",
+        label: "Status",
+        type: "dropdown",
+        value: attendanceFilter,
+        onChange: (value) => setAttendanceFilter(value as StatusFilter),
+        options: [
+          { value: "all", label: "Alle Status" },
+          { value: "anwesend", label: "Anwesend" },
+          { value: "abwesend", label: "Abwesend" },
+          { value: "krank", label: "Krank" },
+          { value: "unterwegs", label: "Unterwegs" },
+          { value: "schulhof", label: "Schulhof" },
+        ],
+      },
+      {
+        id: "sort",
+        label: "Sortierung",
+        type: "dropdown",
+        value: sortMode,
+        onChange: (value) => setSortMode(value as SortMode),
+        options: SORT_OPTIONS,
+      },
+      {
+        id: "groupMode",
+        label: "Ansicht",
+        type: "dropdown",
+        value: groupMode,
+        onChange: (value) => setGroupMode(value as GroupMode),
+        options: GROUP_OPTIONS,
+      },
       ...(trackingLabels && trackingLabels.length > 0
         ? [
             {
@@ -399,15 +607,20 @@ function SearchPageContent() {
     [
       selectedYear,
       selectedGroup,
-      attendanceFilter,
       pickupTimeFilter,
+      arrivalTimeFilter,
+      attendanceFilter,
       trackingFilter,
       trackingLabels,
       groups,
+      rooms,
       studentsData,
-      sortMode,
       selectedRoomId,
       selectedRoomName,
+      orderedRoomOptions,
+      clearRoomFilter,
+      sortMode,
+      groupMode,
     ],
   );
 
@@ -455,9 +668,9 @@ function SearchPageContent() {
     }
 
     if (attendanceFilter !== "all") {
-      const statusLabels: Record<string, string> = {
+      const statusLabels: Record<Exclude<StatusFilter, "all">, string> = {
         anwesend: "Anwesend",
-        abwesend: "Zuhause",
+        abwesend: "Abwesend",
         unterwegs: "Unterwegs",
         schulhof: "Schulhof",
         krank: "Krank",
@@ -480,6 +693,17 @@ function SearchPageContent() {
       });
     }
 
+    if (arrivalTimeFilter !== "all") {
+      filters.push({
+        id: "arrivalTime",
+        label:
+          arrivalTimeFilter === "none"
+            ? "Keine Ankunftszeit"
+            : `Ankunftszeit ${arrivalTimeFilter} Uhr`,
+        onRemove: () => setArrivalTimeFilter("all"),
+      });
+    }
+
     if (trackingLabels) {
       const chipLabel = trackingFilterChipLabel(trackingFilter, trackingLabels);
       if (chipLabel !== null) {
@@ -491,6 +715,27 @@ function SearchPageContent() {
       }
     }
 
+    if (sortMode !== "name") {
+      filters.push({
+        id: "sort",
+        label:
+          SORT_OPTIONS.find((option) => option.value === sortMode)?.label ??
+          "Sortierung",
+        onRemove: () => setSortMode("name"),
+      });
+    }
+
+    if (groupMode !== "none") {
+      filters.push({
+        id: "groupMode",
+        label: `Ansicht: ${
+          GROUP_OPTIONS.find((option) => option.value === groupMode)?.label ??
+          "Ansicht"
+        }`,
+        onRemove: () => setGroupMode("none"),
+      });
+    }
+
     return filters;
   }, [
     searchTerm,
@@ -498,11 +743,15 @@ function SearchPageContent() {
     selectedGroup,
     attendanceFilter,
     pickupTimeFilter,
+    arrivalTimeFilter,
     trackingFilter,
     trackingLabels,
     groups,
     selectedRoomId,
     selectedRoomName,
+    sortMode,
+    groupMode,
+    clearRoomFilter,
   ]);
 
   // Apply additional client-side filtering for attendance statuses and year
@@ -566,6 +815,15 @@ function SearchPageContent() {
       }
     }
 
+    if (arrivalTimeFilter !== "all") {
+      if (student.has_full_access === false) return false;
+      if (arrivalTimeFilter === "none") {
+        if (student.arrival_time || student.arrival_is_exception) return false;
+      } else if (student.arrival_time !== arrivalTimeFilter) {
+        return false;
+      }
+    }
+
     if (!matchesTrackingFilter(student, trackingFilter, trackingData)) {
       return false;
     }
@@ -573,51 +831,54 @@ function SearchPageContent() {
     return true;
   });
 
-  // Apply sort mode (default = backend order; arrival = by arrival urgency + time)
+  // Apply sort mode (name = stable A-Z; arrival/pickup = daily operational order)
   const sortedStudents = useMemo(() => {
-    if (sortMode !== "arrival") return filteredStudents;
-
-    const compareByName = (a: Student, b: Student) => {
-      const lastCmp = (a.second_name ?? "").localeCompare(
-        b.second_name ?? "",
-        "de",
-      );
-      if (lastCmp !== 0) return lastCmp;
-      return (a.first_name ?? "").localeCompare(b.first_name ?? "", "de");
-    };
+    if (sortMode === "name") return [...filteredStudents].sort(compareByName);
 
     return [...filteredStudents].sort((a, b) => {
+      if (sortMode === "pickup") {
+        const timeA = a.pickup_time;
+        const timeB = b.pickup_time;
+        if (timeA && !timeB) return -1;
+        if (!timeA && timeB) return 1;
+        if (timeA && timeB) {
+          const timeCmp = timeA.localeCompare(timeB);
+          if (timeCmp !== 0) return timeCmp;
+        }
+        return compareByName(a, b);
+      }
+
       const aHome = isHomeLocation(a.current_location);
       const bHome = isHomeLocation(b.current_location);
-
       if (!aHome && bHome) return 1;
       if (aHome && !bHome) return -1;
 
-      const timeA = a.arrival_time;
-      const timeB = b.arrival_time;
       const statusA = getStudentTimeStatus({
-        plannedTime: timeA,
+        plannedTime: a.arrival_time,
         actualTime: a.actual_arrival_time,
         now,
       });
       const statusB = getStudentTimeStatus({
-        plannedTime: timeB,
+        plannedTime: b.arrival_time,
         actualTime: b.actual_arrival_time,
         now,
       });
       const rankA = getTimeStatusSortRank(statusA);
       const rankB = getTimeStatusSortRank(statusB);
-
       if (rankA !== rankB) return rankA - rankB;
 
-      if (timeA && timeB) {
-        const timeCmp = timeA.localeCompare(timeB);
+      if (a.arrival_time && b.arrival_time) {
+        const timeCmp = a.arrival_time.localeCompare(b.arrival_time);
         if (timeCmp !== 0) return timeCmp;
       }
-
       return compareByName(a, b);
     });
   }, [filteredStudents, sortMode, now]);
+
+  const groupedStudents = useMemo(
+    () => groupStudents(sortedStudents, groupMode),
+    [sortedStudents, groupMode],
+  );
 
   // Fix P2: Show loading during initialization (prevents empty state flash)
   // Note: With required: true, unauthenticated users are auto-redirected to login
@@ -634,7 +895,7 @@ function SearchPageContent() {
           header on desktop via primaryAction. */}
       <div className="-mx-1 px-1 pb-2 sm:mx-0 sm:px-0">
         <PageHeaderWithSearch
-          title="Suche"
+          title="Kindersuche"
           badge={{
             icon: (
               <svg
@@ -669,7 +930,6 @@ function SearchPageContent() {
           // (1280px). Matches Stripe / Airbnb / Slack pattern for
           // filter-heavy pages.
           desktopFiltersFrom="xl"
-          activeFilterDisplay="count"
           search={{
             value: searchTerm,
             onChange: setSearchTerm,
@@ -683,7 +943,10 @@ function SearchPageContent() {
             setSelectedYear("all");
             setAttendanceFilter("all");
             setPickupTimeFilter("all");
+            setArrivalTimeFilter("all");
             setTrackingFilter("all");
+            setSortMode("name");
+            setGroupMode("none");
             clearRoomFilter();
           }}
         />
@@ -804,101 +1067,114 @@ function SearchPageContent() {
             if (statusFilter) qs.set("status", statusFilter);
             return encodeURIComponent(`/students/search?${qs.toString()}`);
           })();
-          return (
-            <div>
-              <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
-                {sortedStudents.map((student) => {
-                  const checkinState = deriveCheckinState(
-                    student.current_location,
-                  );
-                  const studentIdStr = student.id.toString();
-                  return (
-                    <StudentCard
-                      key={student.id}
-                      studentId={student.id}
-                      firstName={student.first_name}
-                      lastName={student.second_name}
-                      onClick={() =>
-                        router.push(
-                          `/students/${student.id}?from=${buildFromParam}`,
-                        )
-                      }
-                      checkinMode={isBinaryMode && schoolCheckin.isActive}
-                      checkinState={checkinState}
-                      isCheckinPending={schoolCheckin.pendingIds.has(
-                        studentIdStr,
-                      )}
-                      onCheckinClick={() =>
-                        void schoolCheckin.toggle(studentIdStr, checkinState)
-                      }
-                      locationBadge={
-                        <StudentPresenceBadge
-                          student={{
-                            ...student,
-                            not_arrival_today:
-                              (student.arrival_is_exception ?? false) &&
-                              !student.arrival_time,
-                            not_arrival_reason: student.arrival_notes ?? null,
-                          }}
-                          displayMode="contextAware"
-                          userGroups={myGroups}
-                          groupRooms={myGroupRooms}
-                          supervisedRooms={mySupervisedRooms}
-                          variant="modern"
-                          size="md"
+          const renderStudentCard = (student: Student) => {
+            const checkinState = deriveCheckinState(student.current_location);
+            const studentIdStr = student.id.toString();
+            return (
+              <StudentCard
+                key={student.id}
+                studentId={student.id}
+                firstName={student.first_name}
+                lastName={student.second_name}
+                onClick={() =>
+                  router.push(`/students/${student.id}?from=${buildFromParam}`)
+                }
+                checkinMode={isBinaryMode && schoolCheckin.isActive}
+                checkinState={checkinState}
+                isCheckinPending={schoolCheckin.pendingIds.has(studentIdStr)}
+                onCheckinClick={() =>
+                  void schoolCheckin.toggle(studentIdStr, checkinState)
+                }
+                locationBadge={
+                  <StudentPresenceBadge
+                    student={{
+                      ...student,
+                      not_arrival_today:
+                        (student.arrival_is_exception ?? false) &&
+                        !student.arrival_time,
+                      not_arrival_reason: student.arrival_notes ?? null,
+                    }}
+                    displayMode="contextAware"
+                    userGroups={myGroups}
+                    groupRooms={myGroupRooms}
+                    supervisedRooms={mySupervisedRooms}
+                    variant="modern"
+                    size="md"
+                  />
+                }
+                extraContent={
+                  <>
+                    <StudentInfoRow icon={<SchoolClassIcon />}>
+                      {student.school_class}
+                    </StudentInfoRow>
+                    {student.group_name && (
+                      <StudentInfoRow icon={<GroupIcon />}>
+                        Gruppe: {student.group_name}
+                      </StudentInfoRow>
+                    )}
+                    {student.has_full_access !== false && (
+                      <>
+                        <ArrivalTimeRow
+                          arrivalTime={student.arrival_time}
+                          actualTime={student.actual_arrival_time}
+                          isException={student.arrival_is_exception ?? false}
+                          isAbsent={
+                            (student.arrival_is_exception ?? false) &&
+                            !student.arrival_time
+                          }
+                          notes={student.arrival_notes}
+                          now={now}
                         />
-                      }
-                      extraContent={
-                        <>
-                          <StudentInfoRow icon={<SchoolClassIcon />}>
-                            {student.school_class}
-                          </StudentInfoRow>
-                          {student.group_name && (
-                            <StudentInfoRow icon={<GroupIcon />}>
-                              Gruppe: {student.group_name}
-                            </StudentInfoRow>
-                          )}
-                          {student.has_full_access !== false && (
-                            <>
-                              <ArrivalTimeRow
-                                arrivalTime={student.arrival_time}
-                                actualTime={student.actual_arrival_time}
-                                isException={
-                                  student.arrival_is_exception ?? false
-                                }
-                                isAbsent={
-                                  (student.arrival_is_exception ?? false) &&
-                                  !student.arrival_time
-                                }
-                                notes={student.arrival_notes}
-                                now={now}
-                              />
-                              <PickupTimeRow
-                                pickupTime={student.pickup_time ?? undefined}
-                                actualTime={student.actual_pickup_time}
-                                isException={
-                                  student.pickup_is_exception ?? false
-                                }
-                                notes={student.pickup_notes}
-                                now={now}
-                              />
-                            </>
-                          )}
-                        </>
-                      }
-                      trackingIndicators={
-                        trackingData?.labels?.length &&
-                        student.has_full_access !== false ? (
-                          <TrackingIndicators
-                            labels={trackingData.labels}
-                            results={trackingData.results[student.id] ?? []}
-                          />
-                        ) : undefined
-                      }
+                        <PickupTimeRow
+                          pickupTime={student.pickup_time ?? undefined}
+                          actualTime={student.actual_pickup_time}
+                          isException={student.pickup_is_exception ?? false}
+                          notes={student.pickup_notes}
+                          now={now}
+                        />
+                      </>
+                    )}
+                  </>
+                }
+                trackingIndicators={
+                  trackingData?.labels?.length &&
+                  student.has_full_access !== false ? (
+                    <TrackingIndicators
+                      labels={trackingData.labels}
+                      results={trackingData.results[student.id] ?? []}
                     />
-                  );
-                })}
+                  ) : undefined
+                }
+              />
+            );
+          };
+
+          if (groupMode !== "none") {
+            return (
+              <div className="space-y-6">
+                {groupedStudents.map((group) => (
+                  <section key={group.label} data-testid="student-group">
+                    <div className="mb-3 flex items-center gap-3">
+                      <h2 className="text-sm font-semibold text-gray-900">
+                        {group.label}
+                      </h2>
+                      <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+                        {group.items.length}
+                      </span>
+                      <div className="h-px min-w-8 flex-1 bg-gray-200" />
+                    </div>
+                    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
+                      {group.items.map(renderStudentCard)}
+                    </div>
+                  </section>
+                ))}
               </div>
+            );
+          }
+
+          return (
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
+              {sortedStudents.map(renderStudentCard)}
             </div>
           );
         })()}

--- a/frontend/src/components/ui/page-header/DesktopFilters.tsx
+++ b/frontend/src/components/ui/page-header/DesktopFilters.tsx
@@ -13,7 +13,7 @@ export function DesktopFilters({
   className = "",
 }: Readonly<DesktopFiltersProps>) {
   return (
-    <div className={`flex gap-2 ${className}`}>
+    <div className={`flex flex-wrap gap-2 ${className}`}>
       {filters.map((filter) => (
         <FilterControl key={filter.id} filter={filter} />
       ))}

--- a/frontend/src/components/ui/page-header/MobileFilterPanel.test.tsx
+++ b/frontend/src/components/ui/page-header/MobileFilterPanel.test.tsx
@@ -185,7 +185,7 @@ describe("MobileFilterPanel", () => {
       },
     ];
 
-    it("renders dropdown options as list", () => {
+    it("renders single-select dropdown options inside a select", () => {
       render(
         <MobileFilterPanel
           isOpen={true}
@@ -194,12 +194,19 @@ describe("MobileFilterPanel", () => {
         />,
       );
 
-      expect(screen.getByText("Alle Räume")).toBeInTheDocument();
-      expect(screen.getByText("Raum 101")).toBeInTheDocument();
-      expect(screen.getByText("Raum 102")).toBeInTheDocument();
+      expect(screen.getByTestId("filter-room")).toHaveValue("all");
+      expect(
+        screen.getByRole("option", { name: "Alle Räume" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: "Raum 101 (5)" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: "Raum 102 (3)" }),
+      ).toBeInTheDocument();
     });
 
-    it("shows count when provided", () => {
+    it("includes counts in single-select option labels", () => {
       render(
         <MobileFilterPanel
           isOpen={true}
@@ -208,8 +215,12 @@ describe("MobileFilterPanel", () => {
         />,
       );
 
-      expect(screen.getByText("(5)")).toBeInTheDocument();
-      expect(screen.getByText("(3)")).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: "Raum 101 (5)" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: "Raum 102 (3)" }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/ui/page-header/MobileFilterPanel.test.tsx
+++ b/frontend/src/components/ui/page-header/MobileFilterPanel.test.tsx
@@ -121,6 +121,28 @@ describe("MobileFilterPanel", () => {
 
       expect(mockOnChange).toHaveBeenCalledWith(["active", "inactive"]);
     });
+
+    it("removes a selected multi-select button when clicked again", () => {
+      const multiSelectFilters: FilterConfig[] = [
+        {
+          ...sampleFilters[0]!,
+          value: ["active", "inactive"],
+          multiSelect: true,
+        },
+      ];
+
+      render(
+        <MobileFilterPanel
+          isOpen={true}
+          onClose={mockOnClose}
+          filters={multiSelectFilters}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Aktiv"));
+
+      expect(mockOnChange).toHaveBeenCalledWith(["inactive"]);
+    });
   });
 
   describe("Grid type filters", () => {
@@ -166,6 +188,42 @@ describe("MobileFilterPanel", () => {
 
       expect(screen.getByText("Gruppe")).toBeInTheDocument();
       expect(screen.getByText("Raum")).toBeInTheDocument();
+    });
+
+    it("handles single-select grid option clicks", () => {
+      render(
+        <MobileFilterPanel
+          isOpen={true}
+          onClose={mockOnClose}
+          filters={gridFilters}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Raum"));
+
+      expect(mockOnChange).toHaveBeenCalledWith("room");
+    });
+
+    it("handles multi-select grid option clicks", () => {
+      const multiGridFilters: FilterConfig[] = [
+        {
+          ...gridFilters[0]!,
+          value: ["group"],
+          multiSelect: true,
+        },
+      ];
+
+      render(
+        <MobileFilterPanel
+          isOpen={true}
+          onClose={mockOnClose}
+          filters={multiGridFilters}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Raum"));
+
+      expect(mockOnChange).toHaveBeenCalledWith(["group", "room"]);
     });
   });
 
@@ -221,6 +279,132 @@ describe("MobileFilterPanel", () => {
       expect(
         screen.getByRole("option", { name: "Raum 102 (3)" }),
       ).toBeInTheDocument();
+    });
+
+    it("calls onChange when the single-select dropdown changes", () => {
+      render(
+        <MobileFilterPanel
+          isOpen={true}
+          onClose={mockOnClose}
+          filters={dropdownFilters}
+        />,
+      );
+
+      fireEvent.change(screen.getByTestId("filter-room"), {
+        target: { value: "101" },
+      });
+
+      expect(mockOnChange).toHaveBeenCalledWith("101");
+    });
+
+    it("renders multi-select dropdowns as compact buttons with counts", () => {
+      const multiDropdownFilters: FilterConfig[] = [
+        {
+          ...dropdownFilters[0]!,
+          value: ["101"],
+          multiSelect: true,
+        },
+      ];
+
+      render(
+        <MobileFilterPanel
+          isOpen={true}
+          onClose={mockOnClose}
+          filters={multiDropdownFilters}
+        />,
+      );
+
+      expect(screen.queryByTestId("filter-room")).not.toBeInTheDocument();
+      expect(screen.getByText("Raum 101")).toHaveClass(
+        "bg-gray-900",
+        "text-white",
+      );
+      expect(screen.getByText("(5)")).toHaveClass("text-gray-300");
+      expect(screen.getByText("(3)")).toHaveClass("text-gray-500");
+    });
+
+    it("toggles multi-select dropdown options", () => {
+      const multiDropdownFilters: FilterConfig[] = [
+        {
+          ...dropdownFilters[0]!,
+          value: ["101"],
+          multiSelect: true,
+        },
+      ];
+
+      render(
+        <MobileFilterPanel
+          isOpen={true}
+          onClose={mockOnClose}
+          filters={multiDropdownFilters}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Raum 102"));
+
+      expect(mockOnChange).toHaveBeenCalledWith(["101", "102"]);
+    });
+  });
+
+  describe("Panel dismissal", () => {
+    it("closes when Escape is pressed", () => {
+      render(
+        <MobileFilterPanel
+          isOpen={true}
+          onClose={mockOnClose}
+          filters={sampleFilters}
+        />,
+      );
+
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores non-Escape key presses", () => {
+      render(
+        <MobileFilterPanel
+          isOpen={true}
+          onClose={mockOnClose}
+          filters={sampleFilters}
+        />,
+      );
+
+      fireEvent.keyDown(document, { key: "Enter" });
+
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    it("closes when the backdrop is clicked", () => {
+      render(
+        <MobileFilterPanel
+          isOpen={true}
+          onClose={mockOnClose}
+          filters={sampleFilters}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Filter schließen" }));
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders nothing for unsupported filter types", () => {
+      const unknownFilter = {
+        ...sampleFilters[0]!,
+        type: "unknown",
+      } as unknown as FilterConfig;
+
+      render(
+        <MobileFilterPanel
+          isOpen={true}
+          onClose={mockOnClose}
+          filters={[unknownFilter]}
+        />,
+      );
+
+      expect(screen.getByText("Status")).toBeInTheDocument();
+      expect(screen.queryByText("Alle")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/ui/page-header/MobileFilterPanel.tsx
+++ b/frontend/src/components/ui/page-header/MobileFilterPanel.tsx
@@ -123,36 +123,56 @@ export function MobileFilterPanel({
 
       case "dropdown":
         return (
-          <div className="space-y-1">
-            {filter.options.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() =>
-                  isMulti
-                    ? handleMultiSelectClick(
+          <div>
+            {isMulti ? (
+              <div className="flex flex-wrap gap-1.5">
+                {filter.options.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() =>
+                      handleMultiSelectClick(
                         filter,
                         option.value,
                         selectedValues,
                       )
-                    : handleSingleSelectClick(filter, option.value)
-                }
-                className={`w-full rounded-lg px-3 py-2 text-left text-sm font-medium transition-all ${
-                  selectedValues.includes(option.value)
-                    ? "bg-gray-900 text-white"
-                    : "bg-gray-50 text-gray-600 hover:bg-gray-100"
-                } `}
-              >
-                {option.label}
-                {option.count !== undefined && (
-                  <span
-                    className={`ml-2 text-xs ${selectedValues.includes(option.value) ? "text-gray-300" : "text-gray-500"}`}
+                    }
+                    className={`rounded-lg px-3 py-2 text-sm font-medium transition-all ${
+                      selectedValues.includes(option.value)
+                        ? "bg-gray-900 text-white"
+                        : "bg-gray-50 text-gray-600 hover:bg-gray-100"
+                    } `}
                   >
-                    ({option.count})
-                  </span>
-                )}
-              </button>
-            ))}
+                    {option.label}
+                    {option.count !== undefined && (
+                      <span
+                        className={`ml-2 text-xs ${selectedValues.includes(option.value) ? "text-gray-300" : "text-gray-500"}`}
+                      >
+                        ({option.count})
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <select
+                id={`mobile-filter-${filter.id}`}
+                data-testid={`filter-${filter.id}`}
+                value={filter.value as string}
+                onChange={(event) =>
+                  handleSingleSelectClick(filter, event.target.value)
+                }
+                className="h-10 w-full rounded-lg border border-gray-200 bg-gray-50 px-3 text-sm font-medium text-gray-900"
+              >
+                {filter.options.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.count !== undefined
+                      ? `${option.label} (${option.count})`
+                      : option.label}
+                  </option>
+                ))}
+              </select>
+            )}
           </div>
         );
 
@@ -188,7 +208,10 @@ export function MobileFilterPanel({
         <div className="space-y-4">
           {filters.map((filter) => (
             <div key={filter.id}>
-              <label className="mb-1.5 block text-xs font-medium text-gray-600">
+              <label
+                htmlFor={`mobile-filter-${filter.id}`}
+                className="mb-1.5 block text-sm font-semibold text-gray-800"
+              >
                 {filter.label}
               </label>
               {renderFilterOptions(filter)}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -368,6 +368,8 @@ describe("api.ts helper functions", () => {
           category: "classroom",
           occupied: true,
           search: "test",
+          page: 1,
+          pageSize: 1000,
         });
 
         const callUrl = vi.mocked(fetchWithRetry).mock.calls[0]?.[0];
@@ -376,6 +378,8 @@ describe("api.ts helper functions", () => {
         expect(callUrl).toContain("category=classroom");
         expect(callUrl).toContain("occupied=true");
         expect(callUrl).toContain("search=test");
+        expect(callUrl).toContain("page=1");
+        expect(callUrl).toContain("page_size=1000");
       } finally {
         restore();
       }
@@ -1843,6 +1847,8 @@ describe("api.ts helper functions", () => {
           category: "lab",
           occupied: false,
           search: "chemistry",
+          page: 1,
+          pageSize: 1000,
         });
 
         const url = vi.mocked(fetchWithRetry).mock.calls[0]?.[0] ?? "";
@@ -1851,6 +1857,8 @@ describe("api.ts helper functions", () => {
         expect(url).toContain("category=lab");
         expect(url).toContain("occupied=false");
         expect(url).toContain("search=chemistry");
+        expect(url).toContain("page=1");
+        expect(url).toContain("page_size=1000");
       } finally {
         restore();
       }

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -403,6 +403,56 @@ describe("api.ts helper functions", () => {
         restore();
       }
     });
+
+    it("unwraps paginated room responses before mapping", async () => {
+      const wrappedRooms = {
+        data: [
+          { id: 101, name: "Raum 101", capacity: 20 },
+          { id: 102, name: "Raum 102", capacity: 18 },
+        ],
+        pagination: {
+          current_page: 1,
+          page_size: 1000,
+          total_pages: 1,
+          total_records: 2,
+        },
+      };
+      const { fetchWithRetry } = await import("./api-helpers");
+      vi.mocked(fetchWithRetry).mockResolvedValue({
+        data: wrappedRooms,
+        response: new Response(),
+      });
+
+      const { roomService } = await import("./api");
+      const { mapRoomsResponse } = await import("./room-helpers");
+
+      const restore = setupBrowserEnv();
+      try {
+        await roomService.getRooms({ page: 1, pageSize: 1000 });
+        expect(mapRoomsResponse).toHaveBeenCalledWith(wrappedRooms.data);
+      } finally {
+        restore();
+      }
+    });
+
+    it("treats wrapped room responses with non-array data as invalid", async () => {
+      const { fetchWithRetry } = await import("./api-helpers");
+      vi.mocked(fetchWithRetry).mockResolvedValue({
+        data: { data: { id: 101, name: "Not a list" } },
+        response: new Response(),
+      });
+
+      const { roomService } = await import("./api");
+      const { mapRoomsResponse } = await import("./room-helpers");
+
+      const restore = setupBrowserEnv();
+      try {
+        await roomService.getRooms();
+        expect(mapRoomsResponse).toHaveBeenCalledWith([]);
+      } finally {
+        restore();
+      }
+    });
   });
 
   describe("roomService.getRoom", () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -278,6 +278,8 @@ function buildRoomQueryParams(filters?: {
   category?: string;
   occupied?: boolean;
   search?: string;
+  page?: number;
+  pageSize?: number;
 }): URLSearchParams {
   const params = new URLSearchParams();
   if (filters?.search) params.append("search", filters.search);
@@ -287,6 +289,10 @@ function buildRoomQueryParams(filters?: {
   if (filters?.category) params.append("category", filters.category);
   if (filters?.occupied !== undefined)
     params.append("occupied", filters.occupied.toString());
+  if (filters?.page !== undefined)
+    params.append("page", filters.page.toString());
+  if (filters?.pageSize !== undefined)
+    params.append("page_size", filters.pageSize.toString());
   return params;
 }
 
@@ -1881,6 +1887,8 @@ export const roomService = {
     category?: string;
     occupied?: boolean;
     search?: string;
+    page?: number;
+    pageSize?: number;
   }): Promise<Room[]> => {
     const params = buildRoomQueryParams(filters);
     const queryString = params.toString();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -295,6 +295,15 @@ function buildRoomQueryParams(filters?: {
  * Returns empty array for invalid formats with warning.
  */
 function parseRoomsResponse(responseData: unknown): BackendRoom[] {
+  if (
+    responseData &&
+    typeof responseData === "object" &&
+    "data" in responseData &&
+    Array.isArray((responseData as { data?: unknown }).data)
+  ) {
+    return (responseData as { data: BackendRoom[] }).data;
+  }
+
   if (!responseData || !Array.isArray(responseData)) {
     logger.warn("invalid response format for rooms", {
       response_type: typeof responseData,

--- a/frontend/src/lib/swr/room-derived-caches.ts
+++ b/frontend/src/lib/swr/room-derived-caches.ts
@@ -22,9 +22,8 @@
  *   - any future room-attribute that finds its way into a student/visit row
  *
  * **What does NOT belong**: caches that fetch Room data directly
- * (`/api/rooms` lists). Those have their own invalidation path
- * (`tenantMutate("database-rooms-list")`). This list is for *consumers* of
- * room data, not the room data itself.
+ * (`/api/rooms` lists). Those belong in `ROOM_LIST_CACHE_KEYS` below. This
+ * list is for *consumers* of room data, not the room data itself.
  *
  * If you add a new SWR key that fits the criteria above, add its substring
  * here AND add a unit test verifying the badge updates after a room save.
@@ -54,4 +53,19 @@ export const ROOM_DERIVED_CACHE_KEY_FRAGMENTS: readonly string[] = [
   "ogs-dashboard",
   "ogs-students-",
   "search-students-",
+] as const;
+
+export const DATABASE_ROOMS_LIST_CACHE_KEY = "database-rooms-list";
+export const SEARCH_ROOMS_LIST_CACHE_KEY = "search-rooms-list";
+
+/**
+ * Exact SWR keys for pages that fetch `/api/rooms` directly.
+ *
+ * Any room create, rename, update, or delete must invalidate all of these.
+ * Otherwise a user who opened one page before changing a room on another page
+ * keeps stale room names/options until a hard reload.
+ */
+export const ROOM_LIST_CACHE_KEYS: readonly string[] = [
+  DATABASE_ROOMS_LIST_CACHE_KEY,
+  SEARCH_ROOMS_LIST_CACHE_KEY,
 ] as const;


### PR DESCRIPTION
## Summary
- Rework student search filters into a compact, clearer filter model with stage, group, room, arrival time, pickup time, status, sort, and grouped views.
- Make mobile filter dropdowns compact native selects instead of long option lists.
- Fix room response parsing so the room filter is populated from wrapped `/api/rooms` responses.

## Validation
- cd frontend && pnpm run check
- cd frontend && pnpm vitest run src/components/ui/page-header/MobileFilterPanel.test.tsx src/components/ui/page-header/PageHeaderWithSearch.test.tsx 'src/app/[tenant]/(protected)/students/search/page.test.tsx' 'src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx' src/lib/api.test.ts
- pre-push: frontend-knip, frontend-check
