### PR TITLE
fix(students): support full-name search on database page

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
@@ -409,6 +409,18 @@ describe("StudentsPage", () => {
     });
   });
 
+  it("filters students by full name across first and last name", async () => {
+    render(<StudentsPage />);
+
+    const searchInput = screen.getByTestId("search-input");
+    fireEvent.change(searchInput, { target: { value: "Max Mu" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Max Mustermann")).toBeInTheDocument();
+      expect(screen.queryByText("Anna Schmidt")).not.toBeInTheDocument();
+    });
+  });
+
   it("filters students by guardian name (name_lg)", async () => {
     render(<StudentsPage />);
 

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
@@ -421,6 +421,30 @@ describe("StudentsPage", () => {
     });
   });
 
+  it("filters students by last name", async () => {
+    render(<StudentsPage />);
+
+    const searchInput = screen.getByTestId("search-input");
+    fireEvent.change(searchInput, { target: { value: "Muster" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Max Mustermann")).toBeInTheDocument();
+      expect(screen.queryByText("Anna Schmidt")).not.toBeInTheDocument();
+    });
+  });
+
+  it("filters students by reversed full name", async () => {
+    render(<StudentsPage />);
+
+    const searchInput = screen.getByTestId("search-input");
+    fireEvent.change(searchInput, { target: { value: "Mustermann Max" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Max Mustermann")).toBeInTheDocument();
+      expect(screen.queryByText("Anna Schmidt")).not.toBeInTheDocument();
+    });
+  });
+
   it("filters students by guardian name (name_lg)", async () => {
     render(<StudentsPage />);
 
@@ -444,6 +468,18 @@ describe("StudentsPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Max Mustermann")).toBeInTheDocument();
       // Anna is in 2b, so should be filtered out
+      expect(screen.queryByText("Anna Schmidt")).not.toBeInTheDocument();
+    });
+  });
+
+  it("filters students by group name", async () => {
+    render(<StudentsPage />);
+
+    const searchInput = screen.getByTestId("search-input");
+    fireEvent.change(searchInput, { target: { value: "Gruppe A" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Max Mustermann")).toBeInTheDocument();
       expect(screen.queryByText("Anna Schmidt")).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
@@ -280,6 +280,19 @@ const mockStudents = [
     group_name: "Gruppe B",
     name_lg: null,
   },
+  // Sparse fixture: all string fields except name_lg are nullish so the
+  // optional-chaining branches in the search filter (`student.first_name?.…`,
+  // `student.second_name?.…`, `student.school_class?.…`, `student.group_name?.…`)
+  // exercise their falsy paths when a search runs.
+  {
+    id: "3",
+    first_name: null,
+    second_name: null,
+    school_class: null,
+    group_id: null,
+    group_name: null,
+    name_lg: "Erika Beispiel",
+  },
 ];
 
 describe("StudentsPage", () => {
@@ -455,6 +468,22 @@ describe("StudentsPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Max Mustermann")).toBeInTheDocument();
       // Anna has null name_lg, so should be filtered out
+      expect(screen.queryByText("Anna Schmidt")).not.toBeInTheDocument();
+    });
+  });
+
+  it("matches a student whose name and class fields are nullish", async () => {
+    render(<StudentsPage />);
+
+    // Student id "3" has first_name/second_name/school_class/group_name all null;
+    // searching by guardian name still matches and exercises every `?.` falsy
+    // branch in the search filter.
+    const searchInput = screen.getByTestId("search-input");
+    fireEvent.change(searchInput, { target: { value: "Erika" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Erika Beispiel/)).toBeInTheDocument();
+      expect(screen.queryByText("Max Mustermann")).not.toBeInTheDocument();
       expect(screen.queryByText("Anna Schmidt")).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -143,15 +143,27 @@ export default function StudentsPage() {
 
     if (searchTerm) {
       const searchLower = searchTerm.trim().toLowerCase();
-      filtered = filtered.filter(
-        (student) =>
+      filtered = filtered.filter((student) => {
+        const fullName = [student.first_name, student.second_name]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        const lastNameFirst = [student.second_name, student.first_name]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+
+        return (
           (student.first_name?.toLowerCase().includes(searchLower) ?? false) ||
           (student.second_name?.toLowerCase().includes(searchLower) ?? false) ||
+          fullName.includes(searchLower) ||
+          lastNameFirst.includes(searchLower) ||
           (student.school_class?.toLowerCase().includes(searchLower) ??
             false) ||
           (student.group_name?.toLowerCase().includes(searchLower) ?? false) ||
-          (student.name_lg?.toLowerCase().includes(searchLower) ?? false),
-      );
+          (student.name_lg?.toLowerCase().includes(searchLower) ?? false)
+        );
+      });
     }
 
     if (groupFilter !== "all") {


### PR DESCRIPTION
Closes #1387

## Summary

Fixes the student search on `Datenbank > Schüler` so searches spanning first and last name work again.

Previously the filter only checked `first_name` and `second_name` separately, so inputs like `Max Mu` or `Max Mustermann` returned no results. The filter now also matches combined name variants and adds a regression test for that case.

## Validation

- `pnpm --dir ./frontend test:run 'src/app/[tenant]/(protected)/database/students/page.test.tsx'`
- `pnpm --dir ./frontend check`
