### PR TITLE
fix(frontend): clip dropdown item highlights to rounded panel corners (#1377)

### DIFF
--- a/frontend/src/app/operator/announcements/page.tsx
+++ b/frontend/src/app/operator/announcements/page.tsx
@@ -653,7 +653,7 @@ export default function OperatorAnnouncementsPage() {
                 </svg>
               </button>
               {severityDropdownOpen && (
-                <div className="absolute top-full left-0 z-[10001] mt-1 w-full rounded-xl border border-gray-200 bg-white py-1 shadow-lg">
+                <div className="absolute top-full left-0 z-[10001] mt-1 w-full overflow-hidden rounded-xl border border-gray-200 bg-white py-1 shadow-lg">
                   {Object.entries(SEVERITY_LABELS).map(([value, label]) => (
                     <button
                       key={value}
@@ -1117,7 +1117,7 @@ function AnnouncementCard({
         </button>
 
         {menuOpen && (
-          <div className="absolute top-full right-0 z-50 mt-1 w-40 rounded-xl border border-gray-100 bg-white py-1 shadow-lg">
+          <div className="absolute top-full right-0 z-50 mt-1 w-40 overflow-hidden rounded-xl border border-gray-100 bg-white py-1 shadow-lg">
             <button
               type="button"
               onClick={() => {

--- a/frontend/src/components/operator/status-dropdown.tsx
+++ b/frontend/src/components/operator/status-dropdown.tsx
@@ -109,7 +109,7 @@ export function StatusDropdown({
       ref={menuRef}
       role="listbox"
       tabIndex={-1}
-      className="fixed z-[9999] w-48 rounded-xl border border-gray-200 bg-white py-1 shadow-lg"
+      className="fixed z-[9999] w-48 overflow-hidden rounded-xl border border-gray-200 bg-white py-1 shadow-lg"
       style={{
         top: position.top,
         left: position.alignRight ? "auto" : position.left,

--- a/frontend/src/components/simple/student/ModernContactActions.tsx
+++ b/frontend/src/components/simple/student/ModernContactActions.tsx
@@ -127,7 +127,7 @@ export function ModernContactActions({
 
                 {/* Dropdown menu */}
                 {isPhoneDropdownOpen && (
-                  <div className="absolute left-0 z-50 mt-1 min-w-[200px] rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+                  <div className="absolute left-0 z-50 mt-1 min-w-[200px] overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
                     {phoneNumbers.map((phoneOption) => (
                       <button
                         key={phoneOption.number}

--- a/frontend/src/components/students/students-master-detail.tsx
+++ b/frontend/src/components/students/students-master-detail.tsx
@@ -372,7 +372,7 @@ function ClassActionsMenu({
       {open ? (
         <div
           role="menu"
-          className="absolute top-full right-0 z-50 mt-1 w-56 rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+          className="absolute top-full right-0 z-50 mt-1 w-56 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
         >
           <button
             type="button"

--- a/frontend/src/components/tenant/tenant-switcher.tsx
+++ b/frontend/src/components/tenant/tenant-switcher.tsx
@@ -140,7 +140,7 @@ export function TenantSwitcher() {
 
       {/* Dropdown menu */}
       {isOpen && (
-        <div className="absolute right-0 z-50 mt-1 w-64 rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+        <div className="absolute right-0 z-50 mt-1 w-64 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
           {[...grouped.entries()].map(([orgName, orgTenants]) => (
             <div key={orgName}>
               {grouped.size > 1 && (

--- a/frontend/src/components/ui/page-header/DesktopFilters.tsx
+++ b/frontend/src/components/ui/page-header/DesktopFilters.tsx
@@ -162,7 +162,7 @@ function DropdownFilter({
 
       {isOpen && (
         <div
-          className={`absolute top-full z-50 mt-1 w-48 rounded-xl border border-gray-200 bg-white py-1 shadow-lg ${
+          className={`absolute top-full z-50 mt-1 w-48 overflow-hidden rounded-xl border border-gray-200 bg-white py-1 shadow-lg ${
             dropdownPosition === "right" ? "right-0" : "left-0"
           }`}
         >

--- a/frontend/src/components/ui/page-header/NavigationTabs.tsx
+++ b/frontend/src/components/ui/page-header/NavigationTabs.tsx
@@ -214,7 +214,7 @@ function MobileTabDropdown({
       </button>
 
       {isOpen && (
-        <div className="absolute top-full left-0 z-50 mt-1 min-w-48 rounded-xl border border-gray-200 bg-white py-1 shadow-lg">
+        <div className="absolute top-full left-0 z-50 mt-1 min-w-48 overflow-hidden rounded-xl border border-gray-200 bg-white py-1 shadow-lg">
           {items.map((item) => {
             const isActive = item.id === activeTab;
             return (


### PR DESCRIPTION
## Summary

Fixes #1377 — selected/hover backgrounds (`bg-gray-50`) in eight dropdown panels rendered as sharp-cornered rectangles that visually bled past the panel's rounded corners.

**Root cause:** the panels used `rounded-* bg-white shadow-lg py-1` but were missing `overflow-hidden`, so child `<button>` highlights were not clipped to the panel's rounded outer shape.

**Fix:** added `overflow-hidden` to every affected panel, matching the working pattern already used in `frontend/src/components/ui/page-header/OverflowMenu.tsx`. One-class change per file, no behavioral changes.

## Affected dropdowns (8)

- `frontend/src/components/ui/page-header/DesktopFilters.tsx` — page filter dropdown (the one in the issue screenshot)
- `frontend/src/components/operator/status-dropdown.tsx` — operator status pill
- `frontend/src/components/ui/page-header/NavigationTabs.tsx` — mobile/overflow tab dropdown
- `frontend/src/components/tenant/tenant-switcher.tsx` — tenant switcher menu
- `frontend/src/components/students/students-master-detail.tsx` — class actions menu
- `frontend/src/components/simple/student/ModernContactActions.tsx` — phone-number dropdown
- `frontend/src/app/operator/announcements/page.tsx` — severity filter dropdown
- `frontend/src/app/operator/announcements/page.tsx` — announcement card menu

## Test plan

- [x] Visually verified
- [x] `pnpm run check` passes