### PR TITLE
Finish timetable F3/F4 staff operations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           PHOENIX_AUTH_PASSWORD: phoenix_auth_ci
         run: go run main.go migrate
 
-      - name: Run Go tests with coverage
+      - name: Run Go tests
         working-directory: backend
         env:
           TEST_DB_DSN: postgres://postgres:postgres@localhost:5432/phoenix_test?sslmode=disable
@@ -73,10 +73,30 @@ jobs:
             --junitfile junit.xml \
             --rerun-fails \
             --rerun-fails-max-failures=5 \
-            --packages="./..." \
-            -- \
-            -coverprofile=coverage.out \
-            -covermode=atomic
+            --packages="./..."
+
+      - name: Generate Go coverage
+        working-directory: backend
+        env:
+          TEST_DB_DSN: postgres://postgres:postgres@localhost:5432/phoenix_test?sslmode=disable
+        run: |
+          set -euo pipefail
+          tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
+
+          echo "mode: atomic" > coverage.out
+          go list ./... > "$tmpdir/packages.txt"
+
+          while IFS= read -r pkg; do
+            profile="$tmpdir/$(echo "$pkg" | tr '/.' '__').out"
+            if ! go test "$pkg" -coverprofile="$profile" -covermode=atomic; then
+              echo "Coverage run failed for $pkg; retrying once"
+              go test "$pkg" -coverprofile="$profile" -covermode=atomic
+            fi
+            if [ -f "$profile" ]; then
+              tail -n +2 "$profile" >> coverage.out
+            fi
+          done < "$tmpdir/packages.txt"
 
       - name: Drop flaky retries from junit.xml
         working-directory: backend

--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -352,6 +352,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 		CalendarPeriodService:  api.Services.CalendarPeriod,
 		MaterializationService: api.Services.Materialization,
 		InstanceService:        api.Services.Instance,
+		OperationsService:      api.Services.TimetableOperations,
 		PersonService:          api.Services.Users,
 		InstanceStudentRepo:    repoFactory.InstanceStudent,
 		ActivityInstanceRepo:   repoFactory.ActivityInstance,

--- a/backend/api/students/test_helpers_test.go
+++ b/backend/api/students/test_helpers_test.go
@@ -44,6 +44,11 @@ func (b *recordingBroadcaster) BroadcastToAll(event realtime.Event) error {
 	return nil
 }
 
+func (b *recordingBroadcaster) BroadcastToTenant(_ int64, event realtime.Event) error {
+	b.events = append(b.events, event)
+	return nil
+}
+
 // setupTestContext initializes the test environment.
 func setupTestContext(t *testing.T) *testContext {
 	t.Helper()

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -38,6 +38,7 @@ type Resource struct {
 	calendarPeriodService  scheduleSvc.CalendarPeriodService
 	materializationService scheduleSvc.MaterializationService
 	instanceService        scheduleSvc.InstanceService
+	operationsService      scheduleSvc.TimetableOperationsService
 	personService          userSvc.PersonService
 	instanceStudentRepo    schedule.InstanceStudentRepository
 	activityInstanceRepo   schedule.ActivityInstanceRepository
@@ -73,6 +74,7 @@ type Dependencies struct {
 	CalendarPeriodService  scheduleSvc.CalendarPeriodService
 	MaterializationService scheduleSvc.MaterializationService
 	InstanceService        scheduleSvc.InstanceService
+	OperationsService      scheduleSvc.TimetableOperationsService
 	PersonService          userSvc.PersonService
 	InstanceStudentRepo    schedule.InstanceStudentRepository
 	ActivityInstanceRepo   schedule.ActivityInstanceRepository
@@ -108,6 +110,7 @@ func NewResource(deps Dependencies) *Resource {
 		calendarPeriodService:  deps.CalendarPeriodService,
 		materializationService: deps.MaterializationService,
 		instanceService:        deps.InstanceService,
+		operationsService:      deps.OperationsService,
 		personService:          deps.PersonService,
 		instanceStudentRepo:    deps.InstanceStudentRepo,
 		activityInstanceRepo:   deps.ActivityInstanceRepo,
@@ -220,6 +223,25 @@ func (rs *Resource) Router() chi.Router {
 		// WP-B13: exception-conflict warnings (planning-only, read-only).
 		r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
 			Get("/exception-conflicts", rs.getExceptionConflicts)
+
+		r.Route("/operations", func(r chi.Router) {
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
+				Get("/planned-now", rs.operationsPlannedNow)
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
+				Get("/instances/{id}/roster", rs.operationsRoster)
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
+				Get("/active-groups/{id}/roster", rs.operationsRosterByActiveGroup)
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
+				Post("/instances/{id}/start", rs.operationsStart)
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
+				Post("/instances/{id}/complete", rs.operationsComplete)
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
+				Post("/instances/{id}/students/{student_id}/check-in", rs.operationsCheckInStudent)
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
+				Post("/instances/{id}/students/{student_id}/check-out", rs.operationsCheckOutStudent)
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
+				Patch("/instances/{id}/students/{student_id}/attendance", rs.operationsPatchAttendance)
+		})
 
 		// Templates — admin shortcut to add a recurring activity (Mensa,
 		// Lernzeit, AGs) without leaving the planner. Bundles timeframe +

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -231,6 +231,9 @@ func (rs *Resource) Router() chi.Router {
 				Get("/instances/{id}/roster", rs.operationsRoster)
 			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
 				Get("/active-groups/{id}/roster", rs.operationsRosterByActiveGroup)
+			// Operational mutations are available to normal supervisors with
+			// SchedulesRead; the service enforces assignment/admin access via
+			// requireCanOperate before touching schedule or active state.
 			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).
 				Post("/instances/{id}/start", rs.operationsStart)
 			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).

--- a/backend/api/timetable/instance_students.go
+++ b/backend/api/timetable/instance_students.go
@@ -258,47 +258,7 @@ func decodeNullableString(raw json.RawMessage) (nullableString, error) {
 // did not clear it, OR patch sets a non-null value. Cleared substatus (with
 // SubstatusClear) is treated as nil regardless of context.
 func validateAttendancePatch(patch scheduleModel.AttendanceFieldPatch, current *scheduleModel.InstanceStudent) []fieldError {
-	var errs []fieldError
-
-	if patch.Status != nil && !scheduleModel.IsValidAttendanceStatus(*patch.Status) {
-		errs = append(errs, fieldError{Field: "status", Reason: "must be one of: expected, present, absent"})
-	}
-	if patch.Substatus != nil && !scheduleModel.IsValidAttendanceSubstatus(*patch.Substatus) {
-		errs = append(errs, fieldError{Field: "substatus", Reason: "must be one of: late, excused, sick, field_trip, other"})
-	}
-	if patch.Note != nil && len(*patch.Note) > scheduleModel.InstanceStudentNoteMaxLength {
-		errs = append(errs, fieldError{
-			Field:  "note",
-			Reason: fmt.Sprintf("must be at most %d characters", scheduleModel.InstanceStudentNoteMaxLength),
-		})
-	}
-
-	// Per-field errors must be returned alone — the cross-field rule below
-	// assumes valid status / substatus values.
-	if len(errs) > 0 {
-		return errs
-	}
-
-	finalStatus := current.Status
-	if patch.Status != nil {
-		finalStatus = *patch.Status
-	}
-
-	finalSubstatusNonNull := current.Substatus != nil
-	if patch.SubstatusClear {
-		finalSubstatusNonNull = false
-	} else if patch.Substatus != nil {
-		finalSubstatusNonNull = true
-	}
-
-	if finalSubstatusNonNull && finalStatus == scheduleModel.AttendanceStatusExpected {
-		errs = append(errs, fieldError{
-			Field:  "substatus",
-			Reason: "cannot be set when status is expected",
-		})
-	}
-
-	return errs
+	return attendancePatchFieldErrors(scheduleModel.ValidateAttendancePatch(patch, current))
 }
 
 // renderValidationErrors emits the 400 body with the full errors slice.
@@ -306,6 +266,17 @@ func validateAttendancePatch(patch scheduleModel.AttendanceFieldPatch, current *
 // frontend handler) and the per-field list in `errors`.
 func renderValidationErrors(w http.ResponseWriter, r *http.Request, errs []fieldError) {
 	common.RenderError(w, r, common.ErrorValidation("validation failed", errs))
+}
+
+func attendancePatchFieldErrors(errs []scheduleModel.AttendancePatchFieldError) []fieldError {
+	if len(errs) == 0 {
+		return nil
+	}
+	out := make([]fieldError, 0, len(errs))
+	for _, err := range errs {
+		out = append(out, fieldError{Field: err.Field, Reason: err.Reason})
+	}
+	return out
 }
 
 // AttendanceResponse is the on-wire shape of a schedule.instance_students row.

--- a/backend/api/timetable/instances_list_test.go
+++ b/backend/api/timetable/instances_list_test.go
@@ -18,6 +18,7 @@ import (
 	activitiesRepo "github.com/moto-nrw/project-phoenix/database/repositories/activities"
 	facilitiesRepo "github.com/moto-nrw/project-phoenix/database/repositories/facilities"
 	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -258,8 +259,10 @@ func TestListInstances_IncludesPlannedConflictWarnings(t *testing.T) {
 	s := buildListSetup(t)
 	defer s.cleanupFn()
 
-	from, fromDate := listFutureDate(0)
-	to, _ := listFutureDate(7)
+	fromDate := timezone.TodayUTC()
+	from := fromDate.Format("2006-01-02")
+	toDate := fromDate.AddDate(0, 0, 7)
+	to := toDate.Format("2006-01-02")
 
 	suffix := time.Now().UnixNano()
 	category := testpkg.CreateTestActivityCategory(t, s.db, fmt.Sprintf("Conflict-Category-%d", suffix))

--- a/backend/api/timetable/operations.go
+++ b/backend/api/timetable/operations.go
@@ -10,7 +10,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
-	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
 )
@@ -115,6 +114,10 @@ func (rs *Resource) operationsCheckOutStudent(w http.ResponseWriter, r *http.Req
 }
 
 func (rs *Resource) operationsPatchAttendance(w http.ResponseWriter, r *http.Request) {
+	if rs.operationsService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("timetable operations service not wired")))
+		return
+	}
 	instanceID, studentID, ok := parseOperationInstanceStudentIDs(w, r)
 	if !ok {
 		return
@@ -132,7 +135,20 @@ func (rs *Resource) operationsPatchAttendance(w http.ResponseWriter, r *http.Req
 		renderValidationErrors(w, r, []fieldError{{Field: "body", Reason: "at least one of status, substatus, note must be set"}})
 		return
 	}
-	if verrs := validateOperationAttendancePatch(patch); len(verrs) > 0 {
+	if rs.instanceStudentRepo == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("instance student repository not wired")))
+		return
+	}
+	current, err := rs.instanceStudentRepo.FindByInstanceAndStudent(r.Context(), instanceID, studentID)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+	if current == nil {
+		rs.renderOperationsError(w, r, scheduleSvc.ErrTimetableOperationNotFound)
+		return
+	}
+	if verrs := validateAttendancePatch(patch, current); len(verrs) > 0 {
 		renderValidationErrors(w, r, verrs)
 		return
 	}
@@ -182,20 +198,6 @@ func parseOperationID(w http.ResponseWriter, r *http.Request, key string) (int64
 		return 0, false
 	}
 	return id, true
-}
-
-func validateOperationAttendancePatch(patch scheduleModel.AttendanceFieldPatch) []fieldError {
-	var errs []fieldError
-	if patch.Status != nil && !scheduleModel.IsValidAttendanceStatus(*patch.Status) {
-		errs = append(errs, fieldError{Field: "status", Reason: "invalid attendance status"})
-	}
-	if patch.Substatus != nil && !scheduleModel.IsValidAttendanceSubstatus(*patch.Substatus) {
-		errs = append(errs, fieldError{Field: "substatus", Reason: "invalid attendance substatus"})
-	}
-	if patch.Note != nil && len(*patch.Note) > scheduleModel.InstanceStudentNoteMaxLength {
-		errs = append(errs, fieldError{Field: "note", Reason: "note cannot exceed 500 characters"})
-	}
-	return errs
 }
 
 type startOperationResponse struct {

--- a/backend/api/timetable/operations.go
+++ b/backend/api/timetable/operations.go
@@ -1,0 +1,227 @@
+package timetable
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+)
+
+func (rs *Resource) operationsPlannedNow(w http.ResponseWriter, r *http.Request) {
+	if rs.operationsService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("timetable operations service not wired")))
+		return
+	}
+	date := timezone.TodayUTC()
+	if raw := r.URL.Query().Get("date"); raw != "" {
+		parsed, err := time.Parse(dateLayout, raw)
+		if err != nil {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid date")))
+			return
+		}
+		date = parsed
+	}
+	claims := jwt.ClaimsFromCtx(r.Context())
+	result, err := rs.operationsService.PlannedNow(r.Context(), int64(claims.ID), claims.IsAdmin, date, timezone.Now())
+	if err != nil {
+		rs.renderOperationsError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, map[string]any{"instances": result}, "Planned timetable instances retrieved")
+}
+
+func (rs *Resource) operationsRoster(w http.ResponseWriter, r *http.Request) {
+	rs.withOperationInstance(w, r, func(instanceID int64) (any, error) {
+		claims := jwt.ClaimsFromCtx(r.Context())
+		return rs.operationsService.Roster(r.Context(), int64(claims.ID), claims.IsAdmin, instanceID)
+	}, "Timetable roster retrieved")
+}
+
+func (rs *Resource) operationsRosterByActiveGroup(w http.ResponseWriter, r *http.Request) {
+	if rs.operationsService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("timetable operations service not wired")))
+		return
+	}
+	activeGroupID, ok := parseOperationID(w, r, "id")
+	if !ok {
+		return
+	}
+	claims := jwt.ClaimsFromCtx(r.Context())
+	result, err := rs.operationsService.RosterByActiveGroup(r.Context(), int64(claims.ID), claims.IsAdmin, activeGroupID)
+	if err != nil {
+		rs.renderOperationsError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, result, "Timetable roster retrieved")
+}
+
+func (rs *Resource) operationsStart(w http.ResponseWriter, r *http.Request) {
+	rs.withOperationInstance(w, r, func(instanceID int64) (any, error) {
+		claims := jwt.ClaimsFromCtx(r.Context())
+		result, err := rs.operationsService.Start(r.Context(), int64(claims.ID), claims.IsAdmin, instanceID)
+		if err != nil {
+			return nil, err
+		}
+		return startOperationResponse{
+			InstanceID:    result.Instance.ID,
+			Status:        result.Instance.Status,
+			ActiveGroupID: result.ActiveGroupID,
+			Warnings:      result.Warnings,
+		}, nil
+	}, "Timetable instance started")
+}
+
+func (rs *Resource) operationsComplete(w http.ResponseWriter, r *http.Request) {
+	rs.withOperationInstance(w, r, func(instanceID int64) (any, error) {
+		claims := jwt.ClaimsFromCtx(r.Context())
+		return rs.operationsService.Complete(r.Context(), int64(claims.ID), claims.IsAdmin, instanceID)
+	}, "Timetable instance completed")
+}
+
+func (rs *Resource) operationsCheckInStudent(w http.ResponseWriter, r *http.Request) {
+	instanceID, studentID, ok := parseOperationInstanceStudentIDs(w, r)
+	if !ok {
+		return
+	}
+	claims := jwt.ClaimsFromCtx(r.Context())
+	result, err := rs.operationsService.CheckInStudent(r.Context(), int64(claims.ID), claims.IsAdmin, instanceID, studentID)
+	if err != nil {
+		rs.renderOperationsError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, result, "Student checked in to timetable instance")
+}
+
+func (rs *Resource) operationsCheckOutStudent(w http.ResponseWriter, r *http.Request) {
+	instanceID, studentID, ok := parseOperationInstanceStudentIDs(w, r)
+	if !ok {
+		return
+	}
+	claims := jwt.ClaimsFromCtx(r.Context())
+	result, err := rs.operationsService.CheckOutStudent(r.Context(), int64(claims.ID), claims.IsAdmin, instanceID, studentID)
+	if err != nil {
+		rs.renderOperationsError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, result, "Student checked out from timetable instance")
+}
+
+func (rs *Resource) operationsPatchAttendance(w http.ResponseWriter, r *http.Request) {
+	instanceID, studentID, ok := parseOperationInstanceStudentIDs(w, r)
+	if !ok {
+		return
+	}
+	req, ok := decodePatchBody(w, r)
+	if !ok {
+		return
+	}
+	patch, parseErrs := parseAttendancePatchRequest(req)
+	if len(parseErrs) > 0 {
+		renderValidationErrors(w, r, parseErrs)
+		return
+	}
+	if !patch.HasChanges() {
+		renderValidationErrors(w, r, []fieldError{{Field: "body", Reason: "at least one of status, substatus, note must be set"}})
+		return
+	}
+	if verrs := validateOperationAttendancePatch(patch); len(verrs) > 0 {
+		renderValidationErrors(w, r, verrs)
+		return
+	}
+	claims := jwt.ClaimsFromCtx(r.Context())
+	result, err := rs.operationsService.PatchAttendance(r.Context(), int64(claims.ID), claims.IsAdmin, instanceID, studentID, patch)
+	if err != nil {
+		rs.renderOperationsError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, result, "Timetable attendance updated")
+}
+
+func (rs *Resource) withOperationInstance(w http.ResponseWriter, r *http.Request, fn func(int64) (any, error), message string) {
+	if rs.operationsService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("timetable operations service not wired")))
+		return
+	}
+	instanceID, ok := parseOperationID(w, r, "id")
+	if !ok {
+		return
+	}
+	result, err := fn(instanceID)
+	if err != nil {
+		rs.renderOperationsError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, result, message)
+}
+
+func parseOperationInstanceStudentIDs(w http.ResponseWriter, r *http.Request) (int64, int64, bool) {
+	instanceID, ok := parseOperationID(w, r, "id")
+	if !ok {
+		return 0, 0, false
+	}
+	studentID, ok := parseOperationID(w, r, "student_id")
+	if !ok {
+		return 0, 0, false
+	}
+	return instanceID, studentID, true
+}
+
+func parseOperationID(w http.ResponseWriter, r *http.Request, key string) (int64, bool) {
+	raw := chi.URLParam(r, key)
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid id parameter")))
+		return 0, false
+	}
+	return id, true
+}
+
+func validateOperationAttendancePatch(patch scheduleModel.AttendanceFieldPatch) []fieldError {
+	var errs []fieldError
+	if patch.Status != nil && !scheduleModel.IsValidAttendanceStatus(*patch.Status) {
+		errs = append(errs, fieldError{Field: "status", Reason: "invalid attendance status"})
+	}
+	if patch.Substatus != nil && !scheduleModel.IsValidAttendanceSubstatus(*patch.Substatus) {
+		errs = append(errs, fieldError{Field: "substatus", Reason: "invalid attendance substatus"})
+	}
+	if patch.Note != nil && len(*patch.Note) > scheduleModel.InstanceStudentNoteMaxLength {
+		errs = append(errs, fieldError{Field: "note", Reason: "note cannot exceed 500 characters"})
+	}
+	return errs
+}
+
+type startOperationResponse struct {
+	InstanceID    int64                                 `json:"instance_id"`
+	Status        string                                `json:"status"`
+	ActiveGroupID int64                                 `json:"active_group_id"`
+	Warnings      []scheduleSvc.InstanceConflictWarning `json:"warnings"`
+}
+
+func (rs *Resource) renderOperationsError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, scheduleSvc.ErrTimetableOperationForbidden):
+		common.RenderError(w, r, common.ErrorForbidden(err))
+	case errors.Is(err, scheduleSvc.ErrTimetableOperationNotFound):
+		common.RenderError(w, r, common.ErrorNotFound(err))
+	case errors.Is(err, scheduleSvc.ErrTimetableOperationConflict), errors.Is(err, scheduleSvc.ErrInvalidInstanceTransition):
+		common.RenderError(w, r, common.ErrorConflict(err))
+	case errors.Is(err, scheduleSvc.ErrInstanceNotFound):
+		common.RenderError(w, r, common.ErrorNotFound(err))
+	case errors.Is(err, activeSvc.ErrStudentAlreadyActive), errors.Is(err, activeSvc.ErrRoomConflict):
+		common.RenderError(w, r, common.ErrorConflict(err))
+	case errors.Is(err, activeSvc.ErrStudentNotFound), errors.Is(err, activeSvc.ErrVisitNotFound):
+		common.RenderError(w, r, common.ErrorNotFound(err))
+	case errors.Is(err, activeSvc.ErrInvalidData):
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+	default:
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+	}
+}

--- a/backend/api/timetable/operations.go
+++ b/backend/api/timetable/operations.go
@@ -135,23 +135,6 @@ func (rs *Resource) operationsPatchAttendance(w http.ResponseWriter, r *http.Req
 		renderValidationErrors(w, r, []fieldError{{Field: "body", Reason: "at least one of status, substatus, note must be set"}})
 		return
 	}
-	if rs.instanceStudentRepo == nil {
-		common.RenderError(w, r, common.ErrorInternalServer(errors.New("instance student repository not wired")))
-		return
-	}
-	current, err := rs.instanceStudentRepo.FindByInstanceAndStudent(r.Context(), instanceID, studentID)
-	if err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(err))
-		return
-	}
-	if current == nil {
-		rs.renderOperationsError(w, r, scheduleSvc.ErrTimetableOperationNotFound)
-		return
-	}
-	if verrs := validateAttendancePatch(patch, current); len(verrs) > 0 {
-		renderValidationErrors(w, r, verrs)
-		return
-	}
 	claims := jwt.ClaimsFromCtx(r.Context())
 	result, err := rs.operationsService.PatchAttendance(r.Context(), int64(claims.ID), claims.IsAdmin, instanceID, studentID, patch)
 	if err != nil {
@@ -208,7 +191,10 @@ type startOperationResponse struct {
 }
 
 func (rs *Resource) renderOperationsError(w http.ResponseWriter, r *http.Request, err error) {
+	var validationErr *scheduleSvc.TimetableAttendanceValidationError
 	switch {
+	case errors.As(err, &validationErr):
+		renderValidationErrors(w, r, attendancePatchFieldErrors(validationErr.Fields))
 	case errors.Is(err, scheduleSvc.ErrTimetableOperationForbidden):
 		common.RenderError(w, r, common.ErrorForbidden(err))
 	case errors.Is(err, scheduleSvc.ErrTimetableOperationNotFound):

--- a/backend/api/timetable/operations_unit_test.go
+++ b/backend/api/timetable/operations_unit_test.go
@@ -145,13 +145,10 @@ func TestOperationsStudentEndpoints(t *testing.T) {
 
 func TestOperationsPatchAttendanceValidatesAndDelegates(t *testing.T) {
 	status := schedule.AttendanceStatusAbsent
-	current := &schedule.InstanceStudent{Status: schedule.AttendanceStatusExpected}
-	current.ID = 260
 	service := &fakeOperationsService{
 		patchRow: &scheduleSvc.OperationRosterRow{StudentID: 360, Status: schedule.AttendanceStatusAbsent},
 	}
-	repo := &fakeRepo{currentState: current}
-	res := NewResource(Dependencies{OperationsService: service, InstanceStudentRepo: repo})
+	res := NewResource(Dependencies{OperationsService: service})
 	router := operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
 
 	rr := executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{
@@ -181,39 +178,18 @@ func TestOperationsPatchAttendanceRejectsBadRequests(t *testing.T) {
 	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", "{bad json")
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
-	res = NewResource(Dependencies{OperationsService: &fakeOperationsService{}, InstanceStudentRepo: &fakeRepo{}})
-	router = operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
-	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{"status": "present"})
-	assert.Equal(t, http.StatusNotFound, rr.Code)
-
-	res = NewResource(Dependencies{OperationsService: &fakeOperationsService{}})
-	router = operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
-	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{"status": "present"})
-	assert.Equal(t, http.StatusInternalServerError, rr.Code)
-
-	res = NewResource(Dependencies{
-		OperationsService: &fakeOperationsService{},
-		InstanceStudentRepo: &fakeRepo{findByInstanceAndStudent: func(context.Context, int64, int64) (*schedule.InstanceStudent, error) {
-			return nil, errors.New("find failed")
-		}},
-	})
-	router = operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
-	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{"status": "present"})
-	assert.Equal(t, http.StatusInternalServerError, rr.Code)
-
-	current := &schedule.InstanceStudent{Status: schedule.AttendanceStatusExpected}
-	current.ID = 261
-	res = NewResource(Dependencies{
-		OperationsService:   &fakeOperationsService{},
-		InstanceStudentRepo: &fakeRepo{currentState: current},
-	})
+	res = NewResource(Dependencies{OperationsService: &fakeOperationsService{
+		err: &scheduleSvc.TimetableAttendanceValidationError{
+			Fields: []schedule.AttendancePatchFieldError{{Field: "substatus", Reason: "cannot be set when status is expected"}},
+		},
+	}})
 	router = operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
 	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{"substatus": "sick"})
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "substatus")
 
 	res = NewResource(Dependencies{
-		OperationsService:   &fakeOperationsService{err: scheduleSvc.ErrTimetableOperationForbidden},
-		InstanceStudentRepo: &fakeRepo{currentState: current},
+		OperationsService: &fakeOperationsService{err: scheduleSvc.ErrTimetableOperationForbidden},
 	})
 	router = operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
 	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{"status": "absent"})

--- a/backend/api/timetable/operations_unit_test.go
+++ b/backend/api/timetable/operations_unit_test.go
@@ -1,0 +1,379 @@
+package timetable
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperationsPlannedNow(t *testing.T) {
+	service := &fakeOperationsService{
+		planned: []scheduleSvc.OperationPlannedInstance{{ID: 220, Title: "Lernzeit"}},
+	}
+	res := NewResource(Dependencies{OperationsService: service})
+	router := operationRouter(http.MethodGet, "/planned-now", res.operationsPlannedNow)
+
+	rr := executeOperationRequest(router, http.MethodGet, "/planned-now?date=2026-05-10", nil)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, int64(120), service.lastAccountID)
+	assert.True(t, service.lastIsAdmin)
+	assert.Equal(t, "2026-05-10", service.lastDate.Format(dateLayout))
+	assert.Contains(t, rr.Body.String(), `"instances"`)
+}
+
+func TestOperationsPlannedNowValidationAndWiring(t *testing.T) {
+	res := NewResource(Dependencies{})
+	router := operationRouter(http.MethodGet, "/planned-now", res.operationsPlannedNow)
+	rr := executeOperationRequest(router, http.MethodGet, "/planned-now", nil)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	res = NewResource(Dependencies{OperationsService: &fakeOperationsService{}})
+	router = operationRouter(http.MethodGet, "/planned-now", res.operationsPlannedNow)
+	rr = executeOperationRequest(router, http.MethodGet, "/planned-now?date=bad", nil)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestOperationsInstanceEndpoints(t *testing.T) {
+	service := &fakeOperationsService{
+		roster: &scheduleSvc.OperationRoster{Instance: scheduleSvc.OperationRosterInstance{ID: 230}},
+		start: &scheduleSvc.StartInstanceResult{
+			Instance:      &schedule.ActivityInstance{Status: schedule.InstanceStatusActive},
+			ActiveGroupID: 330,
+		},
+		complete: &schedule.ActivityInstance{Status: schedule.InstanceStatusCompleted},
+	}
+	service.start.Instance.ID = 231
+	service.complete.ID = 232
+	res := NewResource(Dependencies{OperationsService: service})
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		fn     http.HandlerFunc
+	}{
+		{"roster", http.MethodGet, "/instances/230/roster", res.operationsRoster},
+		{"start", http.MethodPost, "/instances/231/start", res.operationsStart},
+		{"complete", http.MethodPost, "/instances/232/complete", res.operationsComplete},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := operationRouter(tc.method, "/instances/{id}/"+lastPathSegment(tc.path), tc.fn)
+
+			rr := executeOperationRequest(router, tc.method, tc.path, nil)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+		})
+	}
+	assert.Equal(t, int64(232), service.lastInstanceID)
+}
+
+func TestOperationsRosterByActiveGroup(t *testing.T) {
+	service := &fakeOperationsService{
+		roster: &scheduleSvc.OperationRoster{Instance: scheduleSvc.OperationRosterInstance{ID: 240}},
+	}
+	res := NewResource(Dependencies{OperationsService: service})
+	router := operationRouter(http.MethodGet, "/active-groups/{id}/roster", res.operationsRosterByActiveGroup)
+
+	rr := executeOperationRequest(router, http.MethodGet, "/active-groups/340/roster", nil)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, int64(340), service.lastActiveGroupID)
+
+	nilRes := NewResource(Dependencies{})
+	nilRouter := operationRouter(http.MethodGet, "/active-groups/{id}/roster", nilRes.operationsRosterByActiveGroup)
+	rr = executeOperationRequest(nilRouter, http.MethodGet, "/active-groups/340/roster", nil)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	rr = executeOperationRequest(router, http.MethodGet, "/active-groups/nope/roster", nil)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestOperationsStudentEndpoints(t *testing.T) {
+	service := &fakeOperationsService{
+		roster: &scheduleSvc.OperationRoster{Instance: scheduleSvc.OperationRosterInstance{ID: 250}},
+	}
+	res := NewResource(Dependencies{OperationsService: service})
+
+	checkInRouter := operationRouter(http.MethodPost, "/instances/{id}/students/{student_id}/check-in", res.operationsCheckInStudent)
+	rr := executeOperationRequest(checkInRouter, http.MethodPost, "/instances/250/students/350/check-in", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, int64(250), service.lastInstanceID)
+	assert.Equal(t, int64(350), service.lastStudentID)
+
+	checkOutRouter := operationRouter(http.MethodPost, "/instances/{id}/students/{student_id}/check-out", res.operationsCheckOutStudent)
+	rr = executeOperationRequest(checkOutRouter, http.MethodPost, "/instances/251/students/351/check-out", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, int64(251), service.lastInstanceID)
+	assert.Equal(t, int64(351), service.lastStudentID)
+
+	rr = executeOperationRequest(checkInRouter, http.MethodPost, "/instances/bad/students/350/check-in", nil)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	errorRouter := operationRouter(
+		http.MethodPost,
+		"/instances/{id}/students/{student_id}/check-in",
+		NewResource(Dependencies{OperationsService: &fakeOperationsService{err: scheduleSvc.ErrTimetableOperationConflict}}).operationsCheckInStudent,
+	)
+	rr = executeOperationRequest(errorRouter, http.MethodPost, "/instances/250/students/350/check-in", nil)
+	assert.Equal(t, http.StatusConflict, rr.Code)
+
+	errorRouter = operationRouter(
+		http.MethodPost,
+		"/instances/{id}/students/{student_id}/check-out",
+		NewResource(Dependencies{OperationsService: &fakeOperationsService{err: scheduleSvc.ErrTimetableOperationNotFound}}).operationsCheckOutStudent,
+	)
+	rr = executeOperationRequest(errorRouter, http.MethodPost, "/instances/250/students/350/check-out", nil)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestOperationsPatchAttendanceValidatesAndDelegates(t *testing.T) {
+	status := schedule.AttendanceStatusAbsent
+	current := &schedule.InstanceStudent{Status: schedule.AttendanceStatusExpected}
+	current.ID = 260
+	service := &fakeOperationsService{
+		patchRow: &scheduleSvc.OperationRosterRow{StudentID: 360, Status: schedule.AttendanceStatusAbsent},
+	}
+	repo := &fakeRepo{currentState: current}
+	res := NewResource(Dependencies{OperationsService: service, InstanceStudentRepo: repo})
+	router := operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
+
+	rr := executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{
+		"status": status,
+		"note":   "abgemeldet",
+	})
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, int64(260), service.lastInstanceID)
+	assert.Equal(t, int64(360), service.lastStudentID)
+	require.NotNil(t, service.lastPatch.Status)
+	assert.Equal(t, status, *service.lastPatch.Status)
+}
+
+func TestOperationsPatchAttendanceRejectsBadRequests(t *testing.T) {
+	nilService := NewResource(Dependencies{})
+	nilRouter := operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", nilService.operationsPatchAttendance)
+	rr := executeOperationRequest(nilRouter, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{"status": "present"})
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	res := NewResource(Dependencies{OperationsService: &fakeOperationsService{}})
+	router := operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
+
+	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{})
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", "{bad json")
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	res = NewResource(Dependencies{OperationsService: &fakeOperationsService{}, InstanceStudentRepo: &fakeRepo{}})
+	router = operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
+	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{"status": "present"})
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+
+	res = NewResource(Dependencies{OperationsService: &fakeOperationsService{}})
+	router = operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
+	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{"status": "present"})
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	res = NewResource(Dependencies{
+		OperationsService: &fakeOperationsService{},
+		InstanceStudentRepo: &fakeRepo{findByInstanceAndStudent: func(context.Context, int64, int64) (*schedule.InstanceStudent, error) {
+			return nil, errors.New("find failed")
+		}},
+	})
+	router = operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
+	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{"status": "present"})
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	current := &schedule.InstanceStudent{Status: schedule.AttendanceStatusExpected}
+	current.ID = 261
+	res = NewResource(Dependencies{
+		OperationsService:   &fakeOperationsService{},
+		InstanceStudentRepo: &fakeRepo{currentState: current},
+	})
+	router = operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
+	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{"substatus": "sick"})
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	res = NewResource(Dependencies{
+		OperationsService:   &fakeOperationsService{err: scheduleSvc.ErrTimetableOperationForbidden},
+		InstanceStudentRepo: &fakeRepo{currentState: current},
+	})
+	router = operationRouter(http.MethodPatch, "/instances/{id}/students/{student_id}/attendance", res.operationsPatchAttendance)
+	rr = executeOperationRequest(router, http.MethodPatch, "/instances/260/students/360/attendance", map[string]any{"status": "absent"})
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestOperationsIDParsingAndErrorMapping(t *testing.T) {
+	res := NewResource(Dependencies{OperationsService: &fakeOperationsService{err: scheduleSvc.ErrTimetableOperationForbidden}})
+	router := operationRouter(http.MethodGet, "/instances/{id}/roster", res.operationsRoster)
+	rr := executeOperationRequest(router, http.MethodGet, "/instances/abc/roster", nil)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	rr = executeOperationRequest(router, http.MethodGet, "/instances/260/roster", nil)
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+
+	errorCases := []struct {
+		err  error
+		code int
+	}{
+		{scheduleSvc.ErrTimetableOperationNotFound, http.StatusNotFound},
+		{scheduleSvc.ErrTimetableOperationConflict, http.StatusConflict},
+		{scheduleSvc.ErrInvalidInstanceTransition, http.StatusConflict},
+		{scheduleSvc.ErrInstanceNotFound, http.StatusNotFound},
+		{activeSvc.ErrStudentAlreadyActive, http.StatusConflict},
+		{activeSvc.ErrRoomConflict, http.StatusConflict},
+		{activeSvc.ErrStudentNotFound, http.StatusNotFound},
+		{activeSvc.ErrVisitNotFound, http.StatusNotFound},
+		{activeSvc.ErrInvalidData, http.StatusBadRequest},
+		{errors.New("boom"), http.StatusInternalServerError},
+	}
+
+	for _, tc := range errorCases {
+		t.Run(tc.err.Error(), func(t *testing.T) {
+			res := NewResource(Dependencies{OperationsService: &fakeOperationsService{err: tc.err}})
+			router := operationRouter(http.MethodGet, "/instances/{id}/roster", res.operationsRoster)
+
+			rr := executeOperationRequest(router, http.MethodGet, "/instances/260/roster", nil)
+
+			assert.Equal(t, tc.code, rr.Code)
+		})
+	}
+}
+
+type fakeOperationsService struct {
+	planned  []scheduleSvc.OperationPlannedInstance
+	roster   *scheduleSvc.OperationRoster
+	start    *scheduleSvc.StartInstanceResult
+	complete *schedule.ActivityInstance
+	patchRow *scheduleSvc.OperationRosterRow
+	err      error
+
+	lastAccountID     int64
+	lastIsAdmin       bool
+	lastDate          time.Time
+	lastInstanceID    int64
+	lastActiveGroupID int64
+	lastStudentID     int64
+	lastPatch         schedule.AttendanceFieldPatch
+}
+
+func (s *fakeOperationsService) PlannedNow(_ context.Context, accountID int64, isAdmin bool, date time.Time, _ time.Time) ([]scheduleSvc.OperationPlannedInstance, error) {
+	s.lastAccountID = accountID
+	s.lastIsAdmin = isAdmin
+	s.lastDate = date
+	return s.planned, s.err
+}
+
+func (s *fakeOperationsService) Start(_ context.Context, accountID int64, isAdmin bool, instanceID int64) (*scheduleSvc.StartInstanceResult, error) {
+	s.lastAccountID = accountID
+	s.lastIsAdmin = isAdmin
+	s.lastInstanceID = instanceID
+	return s.start, s.err
+}
+
+func (s *fakeOperationsService) Complete(_ context.Context, accountID int64, isAdmin bool, instanceID int64) (*schedule.ActivityInstance, error) {
+	s.lastAccountID = accountID
+	s.lastIsAdmin = isAdmin
+	s.lastInstanceID = instanceID
+	return s.complete, s.err
+}
+
+func (s *fakeOperationsService) Roster(_ context.Context, accountID int64, isAdmin bool, instanceID int64) (*scheduleSvc.OperationRoster, error) {
+	s.lastAccountID = accountID
+	s.lastIsAdmin = isAdmin
+	s.lastInstanceID = instanceID
+	return s.roster, s.err
+}
+
+func (s *fakeOperationsService) RosterByActiveGroup(_ context.Context, accountID int64, isAdmin bool, activeGroupID int64) (*scheduleSvc.OperationRoster, error) {
+	s.lastAccountID = accountID
+	s.lastIsAdmin = isAdmin
+	s.lastActiveGroupID = activeGroupID
+	return s.roster, s.err
+}
+
+func (s *fakeOperationsService) CheckInStudent(_ context.Context, accountID int64, isAdmin bool, instanceID, studentID int64) (*scheduleSvc.OperationRoster, error) {
+	s.lastAccountID = accountID
+	s.lastIsAdmin = isAdmin
+	s.lastInstanceID = instanceID
+	s.lastStudentID = studentID
+	return s.roster, s.err
+}
+
+func (s *fakeOperationsService) CheckOutStudent(_ context.Context, accountID int64, isAdmin bool, instanceID, studentID int64) (*scheduleSvc.OperationRoster, error) {
+	s.lastAccountID = accountID
+	s.lastIsAdmin = isAdmin
+	s.lastInstanceID = instanceID
+	s.lastStudentID = studentID
+	return s.roster, s.err
+}
+
+func (s *fakeOperationsService) PatchAttendance(_ context.Context, accountID int64, isAdmin bool, instanceID, studentID int64, patch schedule.AttendanceFieldPatch) (*scheduleSvc.OperationRosterRow, error) {
+	s.lastAccountID = accountID
+	s.lastIsAdmin = isAdmin
+	s.lastInstanceID = instanceID
+	s.lastStudentID = studentID
+	s.lastPatch = patch
+	return s.patchRow, s.err
+}
+
+func operationRouter(method, path string, handler http.HandlerFunc) chi.Router {
+	router := chi.NewRouter()
+	router.Use(render.SetContentType(render.ContentTypeJSON))
+	switch method {
+	case http.MethodGet:
+		router.Get(path, handler)
+	case http.MethodPost:
+		router.Post(path, handler)
+	case http.MethodPatch:
+		router.Patch(path, handler)
+	}
+	return router
+}
+
+func executeOperationRequest(router chi.Router, method, path string, body any) *httptest.ResponseRecorder {
+	var reader *bytes.Reader
+	switch v := body.(type) {
+	case nil:
+		reader = bytes.NewReader(nil)
+	case string:
+		reader = bytes.NewReader([]byte(v))
+	default:
+		raw, _ := json.Marshal(v)
+		reader = bytes.NewReader(raw)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	testutil.WithClaims(testutil.AdminTestClaims(120))(req)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	return rr
+}
+
+func lastPathSegment(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			return path[i+1:]
+		}
+	}
+	return path
+}

--- a/backend/database/migrations/001015053_complete_stale_timetable_instances.go
+++ b/backend/database/migrations/001015053_complete_stale_timetable_instances.go
@@ -1,0 +1,73 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	completeStaleTimetableInstancesVersion     = "1.15.53"
+	completeStaleTimetableInstancesDescription = "Complete timetable instances whose active session already ended"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     completeStaleTimetableInstancesVersion,
+		Description: completeStaleTimetableInstancesDescription,
+		DependsOn: []string{
+			activityInstancesCompositeFKsVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return completeStaleTimetableInstancesUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return completeStaleTimetableInstancesDown(ctx, db)
+		},
+	)
+}
+
+func completeStaleTimetableInstancesUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.53: Completing stale timetable instances linked to ended active sessions...")
+
+	_, err := db.NewRaw(`
+		WITH stale_instances AS (
+			SELECT ai.id, ag.end_time
+			FROM schedule.activity_instances AS ai
+			JOIN active.groups AS ag
+				ON ag.id = ai.active_group_id
+				AND ag.tenant_id = ai.tenant_id
+			WHERE ai.status = 'active'
+				AND ai.active_group_id IS NOT NULL
+				AND ag.end_time IS NOT NULL
+		), absent_students AS (
+			UPDATE schedule.instance_students AS student
+			SET status = 'absent',
+				updated_at = NOW()
+			FROM stale_instances
+			WHERE student.instance_id = stale_instances.id
+				AND student.status = 'expected'
+			RETURNING student.id
+		)
+		UPDATE schedule.activity_instances AS ai
+		SET status = 'completed',
+			completed_at = stale_instances.end_time,
+			updated_at = NOW()
+		FROM stale_instances
+		WHERE ai.id = stale_instances.id;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed completing stale timetable instances: %w", err)
+	}
+
+	return nil
+}
+
+func completeStaleTimetableInstancesDown(_ context.Context, _ *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.53: no-op for stale timetable completion repair")
+	return nil
+}

--- a/backend/database/repositories/schedule/timeframe_repository_test.go
+++ b/backend/database/repositories/schedule/timeframe_repository_test.go
@@ -229,7 +229,7 @@ func TestTimeframeRepository_FindByTimeRange(t *testing.T) {
 	ctx := testpkg.TenantContext(1)
 
 	t.Run("finds timeframes overlapping with range", func(t *testing.T) {
-		now := time.Now()
+		now := time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC)
 		endTime := now.Add(2 * time.Hour)
 		timeframe := &schedule.Timeframe{
 			StartTime:   now,

--- a/backend/models/schedule/instance_student.go
+++ b/backend/models/schedule/instance_student.go
@@ -3,6 +3,7 @@ package schedule
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -136,11 +137,61 @@ type AttendanceFieldPatch struct {
 	NoteClear      bool
 }
 
+// AttendancePatchFieldError describes one field-level attendance patch
+// validation failure without tying domain validation to an HTTP package.
+type AttendancePatchFieldError struct {
+	Field  string
+	Reason string
+}
+
 // HasChanges reports whether the patch carries at least one mutation. The
 // PATCH handler uses this to reject no-op bodies at 400.
 func (p AttendanceFieldPatch) HasChanges() bool {
 	return p.Status != nil || p.Substatus != nil || p.SubstatusClear ||
 		p.Note != nil || p.NoteClear
+}
+
+// ValidateAttendancePatch enforces attendance patch business rules against the
+// current row so cross-field rules can be evaluated against the final state.
+func ValidateAttendancePatch(patch AttendanceFieldPatch, current *InstanceStudent) []AttendancePatchFieldError {
+	var errs []AttendancePatchFieldError
+
+	if patch.Status != nil && !IsValidAttendanceStatus(*patch.Status) {
+		errs = append(errs, AttendancePatchFieldError{Field: "status", Reason: "must be one of: expected, present, absent"})
+	}
+	if patch.Substatus != nil && !IsValidAttendanceSubstatus(*patch.Substatus) {
+		errs = append(errs, AttendancePatchFieldError{Field: "substatus", Reason: "must be one of: late, excused, sick, field_trip, other"})
+	}
+	if patch.Note != nil && len(*patch.Note) > InstanceStudentNoteMaxLength {
+		errs = append(errs, AttendancePatchFieldError{
+			Field:  "note",
+			Reason: fmt.Sprintf("must be at most %d characters", InstanceStudentNoteMaxLength),
+		})
+	}
+	if len(errs) > 0 {
+		return errs
+	}
+
+	finalStatus := current.Status
+	if patch.Status != nil {
+		finalStatus = *patch.Status
+	}
+
+	finalSubstatusNonNull := current.Substatus != nil
+	if patch.SubstatusClear {
+		finalSubstatusNonNull = false
+	} else if patch.Substatus != nil {
+		finalSubstatusNonNull = true
+	}
+
+	if finalSubstatusNonNull && finalStatus == AttendanceStatusExpected {
+		errs = append(errs, AttendancePatchFieldError{
+			Field:  "substatus",
+			Reason: "cannot be set when status is expected",
+		})
+	}
+
+	return errs
 }
 
 // InstanceStudentRepository defines operations for managing expected/actual

--- a/backend/models/schedule/instance_student_test.go
+++ b/backend/models/schedule/instance_student_test.go
@@ -154,3 +154,110 @@ func TestAttendanceFieldPatch_HasChanges(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAttendancePatch_CrossFieldRule(t *testing.T) {
+	excused := AttendanceSubstatusExcused
+	tests := []struct {
+		name         string
+		current      *InstanceStudent
+		patch        AttendanceFieldPatch
+		wantErrField string
+		wantOK       bool
+	}{
+		{
+			name:    "expected + new substatus without status change rejects",
+			current: &InstanceStudent{Status: AttendanceStatusExpected},
+			patch: AttendanceFieldPatch{
+				Substatus: strPtr(AttendanceSubstatusLate),
+			},
+			wantErrField: "substatus",
+		},
+		{
+			name:    "expected to present with substatus is valid",
+			current: &InstanceStudent{Status: AttendanceStatusExpected},
+			patch: AttendanceFieldPatch{
+				Status:    strPtr(AttendanceStatusPresent),
+				Substatus: strPtr(AttendanceSubstatusLate),
+			},
+			wantOK: true,
+		},
+		{
+			name:    "expected to absent with substatus is valid",
+			current: &InstanceStudent{Status: AttendanceStatusExpected},
+			patch: AttendanceFieldPatch{
+				Status:    strPtr(AttendanceStatusAbsent),
+				Substatus: strPtr(AttendanceSubstatusSick),
+			},
+			wantOK: true,
+		},
+		{
+			name:    "present with substatus is valid",
+			current: &InstanceStudent{Status: AttendanceStatusPresent},
+			patch: AttendanceFieldPatch{
+				Substatus: strPtr(AttendanceSubstatusLate),
+			},
+			wantOK: true,
+		},
+		{
+			name:    "present to expected with existing substatus rejects",
+			current: &InstanceStudent{Status: AttendanceStatusPresent, Substatus: &excused},
+			patch: AttendanceFieldPatch{
+				Status: strPtr(AttendanceStatusExpected),
+			},
+			wantErrField: "substatus",
+		},
+		{
+			name:    "present to expected clearing substatus is valid",
+			current: &InstanceStudent{Status: AttendanceStatusPresent, Substatus: &excused},
+			patch: AttendanceFieldPatch{
+				Status:         strPtr(AttendanceStatusExpected),
+				SubstatusClear: true,
+			},
+			wantOK: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := ValidateAttendancePatch(tc.patch, tc.current)
+			if tc.wantOK {
+				assert.Empty(t, errs)
+				return
+			}
+			require.NotEmpty(t, errs)
+			assert.Equal(t, tc.wantErrField, errs[0].Field)
+		})
+	}
+}
+
+func TestValidateAttendancePatch_PerFieldErrors(t *testing.T) {
+	cur := &InstanceStudent{Status: AttendanceStatusPresent}
+
+	t.Run("invalid status", func(t *testing.T) {
+		errs := ValidateAttendancePatch(AttendanceFieldPatch{Status: strPtr("ghost")}, cur)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "status", errs[0].Field)
+	})
+
+	t.Run("invalid substatus", func(t *testing.T) {
+		errs := ValidateAttendancePatch(AttendanceFieldPatch{Substatus: strPtr("banana")}, cur)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "substatus", errs[0].Field)
+	})
+
+	t.Run("note too long", func(t *testing.T) {
+		tooLong := strings.Repeat("x", InstanceStudentNoteMaxLength+1)
+		errs := ValidateAttendancePatch(AttendanceFieldPatch{Note: &tooLong}, cur)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "note", errs[0].Field)
+	})
+
+	t.Run("two per-field errors returned together", func(t *testing.T) {
+		tooLong := strings.Repeat("y", InstanceStudentNoteMaxLength+1)
+		errs := ValidateAttendancePatch(AttendanceFieldPatch{
+			Status: strPtr("ghost"),
+			Note:   &tooLong,
+		}, cur)
+		require.Len(t, errs, 2)
+	})
+}

--- a/backend/realtime/broadcaster.go
+++ b/backend/realtime/broadcaster.go
@@ -10,4 +10,8 @@ type Broadcaster interface {
 	// BroadcastToAll sends an event to every connected client regardless of group subscriptions.
 	// Used for global dashboard count refreshes. Fire-and-forget.
 	BroadcastToAll(event Event) error
+
+	// BroadcastToTenant sends an event to every connected client for one tenant,
+	// regardless of group subscriptions. Used for tenant-wide refresh signals.
+	BroadcastToTenant(tenantID int64, event Event) error
 }

--- a/backend/realtime/events.go
+++ b/backend/realtime/events.go
@@ -31,6 +31,11 @@ const (
 	// Global refresh event — tells all clients to re-fetch dashboard counts
 	EventDashboardCountsChanged EventType = "dashboard_counts_changed"
 
+	// Active supervision refresh event — tenant-wide signal that the active
+	// supervision view is stale regardless of whether the cause was IoT, NFC,
+	// timetable operations, or another lifecycle action.
+	EventActiveSupervisionChanged EventType = "active_supervision_changed"
+
 	// Arrival schedule events affect derived "not arriving today" badges and
 	// bulk arrival-time lookups across student list/detail pages.
 	EventArrivalScheduleChanged EventType = "arrival_schedule_changed"
@@ -75,6 +80,9 @@ type EventData struct {
 
 	// Source tracking
 	Source *string `json:"source,omitempty"` // "rfid", "manual", "automated"
+
+	// Reason tracking for generic refresh events.
+	Reason *string `json:"reason,omitempty"`
 }
 
 // NewEvent creates a new event with current timestamp

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -32,6 +32,10 @@ type Broadcaster = realtime.Broadcaster
 const (
 	// sseErrorMessage is the standard error message for SSE broadcast failures
 	sseErrorMessage = "SSE broadcast failed"
+
+	activeSupervisionReasonActivityStarted = "activity_started"
+	activeSupervisionReasonActivityEnded   = "activity_ended"
+	activeSupervisionReasonStudentMoved    = "student_moved"
 )
 
 // RoomConflictStrategy defines how to handle room conflicts when determining room ID
@@ -723,6 +727,7 @@ func (s *service) broadcastVisitCheckout(ctx context.Context, endedVisit *active
 
 	// Notify all clients so dashboard counts refresh
 	_ = s.broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
+	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, studentID, activeSupervisionReasonStudentMoved)
 }
 
 // broadcastToEducationalGroup mirrors active-group broadcasts to the student's OGS group topic
@@ -791,6 +796,7 @@ func (s *service) broadcastStudentCheckoutEvents(ctx context.Context, sessionIDS
 	// Single global broadcast for the entire batch
 	if len(visitsToNotify) > 0 && s.broadcaster != nil {
 		_ = s.broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
+		s.broadcastActiveSupervisionChanged(ctx, sessionIDStr, "", activeSupervisionReasonStudentMoved)
 	}
 }
 
@@ -820,6 +826,7 @@ func (s *service) broadcastActivityEndEvent(ctx context.Context, sessionID int64
 
 	// Notify all clients (including zero-topic) so dashboard refreshes
 	_ = s.broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
+	s.broadcastActiveSupervisionChanged(ctx, sessionIDStr, "", activeSupervisionReasonActivityEnded)
 }
 
 // broadcastWithLogging broadcasts an event and logs any errors.

--- a/backend/services/active/attendance_sse_enrichment_test.go
+++ b/backend/services/active/attendance_sse_enrichment_test.go
@@ -58,6 +58,13 @@ func (r *recordingBroadcaster) BroadcastToAll(event realtime.Event) error {
 	return nil
 }
 
+func (r *recordingBroadcaster) BroadcastToTenant(_ int64, event realtime.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.allCalls = append(r.allCalls, event)
+	return nil
+}
+
 // firstOfType returns the first event of the given type seen across either
 // broadcast channel, or nil if none matches.
 func (r *recordingBroadcaster) firstOfType(t realtime.EventType) *realtime.Event {

--- a/backend/services/active/broadcast_test.go
+++ b/backend/services/active/broadcast_test.go
@@ -33,6 +33,13 @@ func (m *mockBroadcaster) BroadcastToAll(event realtime.Event) error {
 	return nil
 }
 
+func (m *mockBroadcaster) BroadcastToTenant(_ int64, event realtime.Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.allCalls = append(m.allCalls, event)
+	return nil
+}
+
 func (m *mockBroadcaster) getAllCalls() []realtime.Event {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -110,6 +117,8 @@ func TestBroadcast_CreateVisitSendsDashboardCounts(t *testing.T) {
 
 	assert.True(t, broadcaster.hasEventType(realtime.EventDashboardCountsChanged),
 		"expected dashboard_counts_changed after CreateVisit")
+	assert.True(t, broadcaster.hasEventType(realtime.EventActiveSupervisionChanged),
+		"expected active_supervision_changed after CreateVisit")
 }
 
 func TestBroadcast_EndVisitSendsDashboardCounts(t *testing.T) {
@@ -134,6 +143,8 @@ func TestBroadcast_EndVisitSendsDashboardCounts(t *testing.T) {
 
 	assert.True(t, broadcaster.hasEventType(realtime.EventDashboardCountsChanged),
 		"expected dashboard_counts_changed after EndVisit")
+	assert.True(t, broadcaster.hasEventType(realtime.EventActiveSupervisionChanged),
+		"expected active_supervision_changed after EndVisit")
 }
 
 func TestBroadcast_EndActivitySessionSendsDashboardCounts(t *testing.T) {
@@ -167,6 +178,8 @@ func TestBroadcast_EndActivitySessionSendsDashboardCounts(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "expected dashboard_counts_changed after EndActivitySession with active visits")
+	assert.True(t, broadcaster.hasEventType(realtime.EventActiveSupervisionChanged),
+		"expected active_supervision_changed after EndActivitySession")
 }
 
 func TestBroadcast_DailyCheckoutSendsDashboardCounts(t *testing.T) {

--- a/backend/services/active/interface.go
+++ b/backend/services/active/interface.go
@@ -325,12 +325,13 @@ type AttendanceResult struct {
 
 // DailySessionCleanupResult represents the result of ending daily sessions
 type DailySessionCleanupResult struct {
-	SessionsEnded    int       `json:"sessions_ended"`
-	VisitsEnded      int       `json:"visits_ended"`
-	SupervisorsEnded int       `json:"supervisors_ended"`
-	ExecutedAt       time.Time `json:"executed_at"`
-	Success          bool      `json:"success"`
-	Errors           []string  `json:"errors,omitempty"`
+	SessionsEnded       int       `json:"sessions_ended"`
+	VisitsEnded         int       `json:"visits_ended"`
+	SupervisorsEnded    int       `json:"supervisors_ended"`
+	EndedActiveGroupIDs []int64   `json:"-"`
+	ExecutedAt          time.Time `json:"executed_at"`
+	Success             bool      `json:"success"`
+	Errors              []string  `json:"errors,omitempty"`
 }
 
 // AttendanceCleanupResult represents the result of cleaning stale attendance records

--- a/backend/services/active/session_service.go
+++ b/backend/services/active/session_service.go
@@ -1069,6 +1069,7 @@ func (s *service) EndDailySessions(ctx context.Context) (*DailySessionCleanupRes
 		result.Success = false
 	} else {
 		result.SessionsEnded = int(sessionsEnded)
+		result.EndedActiveGroupIDs = append(result.EndedActiveGroupIDs, activeIDs...)
 	}
 
 	// 4. Bulk end supervisors

--- a/backend/services/active/session_service.go
+++ b/backend/services/active/session_service.go
@@ -122,6 +122,7 @@ func (s *service) broadcastActivityStartEvent(ctx context.Context, group *active
 
 	// Notify all clients (including zero-topic) so dashboard refreshes
 	_ = s.broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
+	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, "", activeSupervisionReasonActivityStarted)
 }
 
 // validateSupervisorIDs validates that all supervisor IDs exist as staff members

--- a/backend/services/active/sse_adapter.go
+++ b/backend/services/active/sse_adapter.go
@@ -1,0 +1,37 @@
+package active
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/moto-nrw/project-phoenix/realtime"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+// broadcastActiveSupervisionChanged sends the generic tenant-wide refresh
+// signal consumed by the active-supervisions page. Specific events still carry
+// their detailed semantics; this adapter event gives every client one stable
+// cache invalidation path regardless of the write source.
+func (s *service) broadcastActiveSupervisionChanged(ctx context.Context, activeGroupID, studentID, reason string) {
+	if s.broadcaster == nil {
+		return
+	}
+
+	data := realtime.EventData{
+		Reason: &reason,
+	}
+	if studentID != "" {
+		data.StudentID = &studentID
+	}
+
+	tenantID := tenant.FromContext(ctx)
+	event := realtime.NewEvent(realtime.EventActiveSupervisionChanged, activeGroupID, data)
+	if err := s.broadcaster.BroadcastToTenant(tenantID, event); err != nil {
+		s.getLogger().Warn("SSE active supervision broadcast failed",
+			slog.String("error", err.Error()),
+			slog.String("active_group_id", activeGroupID),
+			slog.String("reason", reason),
+			slog.Int64("tenant_id", tenantID),
+		)
+	}
+}

--- a/backend/services/active/visit_helpers.go
+++ b/backend/services/active/visit_helpers.go
@@ -296,6 +296,7 @@ func (s *service) broadcastVisitCreated(ctx context.Context, visit *active.Visit
 
 	// Notify all clients so dashboard counts refresh
 	_ = s.broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
+	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, studentID, activeSupervisionReasonStudentMoved)
 }
 
 // getStudentDisplayData fetches student name for display

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -60,6 +60,7 @@ type Factory struct {
 	Materialization          schedule.MaterializationService
 	TimetableCleanup         schedule.TimetableCleanupService
 	Instance                 schedule.InstanceService
+	TimetableOperations      schedule.TimetableOperationsService
 	Users                    users.PersonService
 	CaregiverCapability      users.CaregiverCapabilityService
 	Guardian                 users.GuardianService
@@ -388,6 +389,23 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Logger:            logger.With("service", "instance-lifecycle"),
 	})
 
+	timetableOperationsService := schedule.NewTimetableOperationsService(schedule.TimetableOperationsDependencies{
+		InstanceRepo:       repos.ActivityInstance,
+		InstanceStaffRepo:  repos.InstanceStaff,
+		InstanceStudents:   repos.InstanceStudent,
+		InstanceService:    instanceService,
+		ActiveGroupRepo:    repos.ActiveGroup,
+		ActiveService:      activeService,
+		SupervisorRepo:     repos.GroupSupervisor,
+		VisitRepo:          repos.ActiveVisit,
+		StudentRepo:        repos.Student,
+		EducationGroupRepo: repos.Group,
+		PersonService:      usersService,
+		Settings:           settingsService,
+		DB:                 db,
+		Logger:             logger.With("service", "timetable-operations"),
+	})
+
 	// Initialize arrival schedule service
 	arrivalScheduleService := schedule.NewArrivalScheduleService(
 		repos.StudentArrivalSchedule,
@@ -622,6 +640,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Materialization:          materializationService,
 		TimetableCleanup:         timetableCleanupService,
 		Instance:                 instanceService,
+		TimetableOperations:      timetableOperationsService,
 		Users:                    usersService,
 		CaregiverCapability:      caregiverCapabilityService,
 		Guardian:                 guardianService,

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -402,6 +402,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		EducationGroupRepo: repos.Group,
 		PersonService:      usersService,
 		Settings:           settingsService,
+		Broadcaster:        realtimeHub,
 		DB:                 db,
 		Logger:             logger.With("service", "timetable-operations"),
 	})

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -152,10 +152,6 @@ type instanceService struct {
 	deps InstanceServiceDependencies
 }
 
-type tenantBroadcaster interface {
-	BroadcastToTenant(tenantID int64, event realtime.Event) error
-}
-
 // NewInstanceService constructs an InstanceService. Panics if a required
 // dependency is nil — the service has no sensible degraded mode for lifecycle
 // transitions, so the factory must wire it completely at startup.
@@ -781,20 +777,50 @@ func (s *instanceService) broadcastInstanceEvent(
 			)
 		}
 	}
-	tenantScopedBroadcaster, ok := s.deps.Broadcaster.(tenantBroadcaster)
-	if !ok {
-		s.getLogger().Warn("SSE tenant broadcast unsupported",
-			slog.String("event_type", string(eventType)),
-			slog.Int64("tenant_id", tenantID),
-		)
-		return
-	}
-	if err := tenantScopedBroadcaster.BroadcastToTenant(tenantID, event); err != nil {
+	if err := s.deps.Broadcaster.BroadcastToTenant(tenantID, event); err != nil {
 		s.getLogger().Warn("SSE broadcast-to-tenant failed",
 			slog.String("event_type", string(eventType)),
 			slog.Int64("tenant_id", tenantID),
 			slog.String("error", err.Error()),
 		)
+	}
+	s.broadcastActiveSupervisionChanged(tenantID, activeGroupIDStr, instanceIDStr, eventType)
+}
+
+func (s *instanceService) broadcastActiveSupervisionChanged(
+	tenantID int64,
+	activeGroupID string,
+	instanceID string,
+	sourceEventType realtime.EventType,
+) {
+	reason := instanceRefreshReason(sourceEventType)
+	data := realtime.EventData{
+		InstanceID: &instanceID,
+		Reason:     &reason,
+	}
+	event := realtime.NewEvent(realtime.EventActiveSupervisionChanged, activeGroupID, data)
+	if err := s.deps.Broadcaster.BroadcastToTenant(tenantID, event); err != nil {
+		s.getLogger().Warn("SSE active supervision broadcast failed",
+			slog.String("event_type", string(sourceEventType)),
+			slog.String("active_group_id", activeGroupID),
+			slog.Int64("tenant_id", tenantID),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+func instanceRefreshReason(eventType realtime.EventType) string {
+	switch eventType {
+	case realtime.EventInstanceStarted:
+		return "instance_started"
+	case realtime.EventInstanceCompleted:
+		return "instance_completed"
+	case realtime.EventInstanceCancelled:
+		return "instance_cancelled"
+	case realtime.EventInstanceOverdue:
+		return "instance_overdue"
+	default:
+		return "instance_changed"
 	}
 }
 

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -232,6 +232,48 @@ func TestInstance_Start_HappyPath(t *testing.T) {
 	})
 }
 
+func TestInstance_Start_BroadcastsActiveSupervisionChanged(t *testing.T) {
+	s := buildLifecycle(t)
+	broadcaster := &recordingInstanceBroadcaster{}
+	svc := instanceServiceWithBroadcaster(s, broadcaster)
+
+	ai := seedInstance(t, s, true, true)
+
+	result, err := svc.Start(s.ctx, ai.ID, s.staffID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Instance.ActiveGroupID)
+
+	var instanceStarted, activeSupervisionChanged *realtime.Event
+	for i := range broadcaster.tenantEvents {
+		event := &broadcaster.tenantEvents[i]
+		switch event.Type {
+		case realtime.EventInstanceStarted:
+			instanceStarted = event
+		case realtime.EventActiveSupervisionChanged:
+			activeSupervisionChanged = event
+		}
+	}
+
+	require.NotNil(t, instanceStarted, "expected instance_started tenant broadcast")
+	require.NotNil(t, activeSupervisionChanged, "expected active_supervision_changed tenant broadcast")
+	assert.Equal(t, instanceStarted.ActiveGroupID, activeSupervisionChanged.ActiveGroupID)
+	require.NotNil(t, activeSupervisionChanged.Data.InstanceID)
+	assert.Equal(t, fmt.Sprintf("%d", ai.ID), *activeSupervisionChanged.Data.InstanceID)
+	require.NotNil(t, activeSupervisionChanged.Data.Reason)
+	assert.Equal(t, "instance_started", *activeSupervisionChanged.Data.Reason)
+
+	t.Cleanup(func() {
+		sups, err := s.factory.Active.FindSupervisorsByActiveGroupID(s.ctx, result.ActiveGroupID)
+		if err == nil {
+			for _, sup := range sups {
+				testpkg.CleanupTableRecords(t, s.db, "active.group_supervisors", sup.ID)
+			}
+		}
+		testpkg.CleanupTableRecords(t, s.db, "active.groups", result.ActiveGroupID)
+	})
+}
+
 func TestInstance_Start_BroadcastsGroupAndTenantTimetableEvent(t *testing.T) {
 	s := buildLifecycle(t)
 	broadcaster := &recordingInstanceBroadcaster{}
@@ -241,15 +283,23 @@ func TestInstance_Start_BroadcastsGroupAndTenantTimetableEvent(t *testing.T) {
 	result, err := svc.Start(s.ctx, ai.ID, 0)
 	require.NoError(t, err)
 	t.Cleanup(func() {
+		sups, err := s.factory.Active.FindSupervisorsByActiveGroupID(s.ctx, result.ActiveGroupID)
+		if err == nil {
+			for _, sup := range sups {
+				testpkg.CleanupTableRecords(t, s.db, "active.group_supervisors", sup.ID)
+			}
+		}
 		testpkg.CleanupTableRecords(t, s.db, "active.groups", result.ActiveGroupID)
 	})
 
 	require.Len(t, broadcaster.groupEvents, 1)
-	require.Len(t, broadcaster.tenantEvents, 1)
+	require.Len(t, broadcaster.tenantEvents, 2)
 	assert.Equal(t, tenant.FromContext(s.ctx), broadcaster.tenantID)
 	assert.Equal(t, realtime.EventInstanceStarted, broadcaster.groupEvents[0].Type)
 	assert.Equal(t, realtime.EventInstanceStarted, broadcaster.tenantEvents[0].Type)
+	assert.Equal(t, realtime.EventActiveSupervisionChanged, broadcaster.tenantEvents[1].Type)
 	assert.Equal(t, broadcaster.groupEvents[0].ActiveGroupID, broadcaster.tenantEvents[0].ActiveGroupID)
+	assert.Equal(t, broadcaster.groupEvents[0].ActiveGroupID, broadcaster.tenantEvents[1].ActiveGroupID)
 }
 
 func TestInstance_Complete_HappyPath(t *testing.T) {

--- a/backend/services/schedule/schedule_service_test.go
+++ b/backend/services/schedule/schedule_service_test.go
@@ -625,7 +625,7 @@ func TestScheduleService_FindTimeframesByTimeRange(t *testing.T) {
 
 	t.Run("finds timeframes in range", func(t *testing.T) {
 		// ARRANGE
-		startTime := time.Now().Add(1 * time.Hour)
+		startTime := time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC)
 		endTime := startTime.Add(2 * time.Hour)
 		tf := createTestTimeframe(t, db, startTime, &endTime, true)
 		defer cleanupScheduleFixtures(t, db, nil, []int64{tf.ID}, nil)

--- a/backend/services/schedule/timetable_operations_service.go
+++ b/backend/services/schedule/timetable_operations_service.go
@@ -1,0 +1,611 @@
+package schedule
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/auth/device"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	educationModel "github.com/moto-nrw/project-phoenix/models/education"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	usersModel "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+var (
+	ErrTimetableOperationForbidden = errors.New("timetable operation forbidden")
+	ErrTimetableOperationNotFound  = errors.New("timetable operation not found")
+	ErrTimetableOperationConflict  = errors.New("timetable operation conflict")
+)
+
+type OperationSettings interface {
+	ResolveBool(ctx context.Context, key string) (bool, error)
+}
+
+type OperationPersonService interface {
+	FindByAccountID(ctx context.Context, accountID int64) (*usersModel.Person, error)
+	GetByIDs(ctx context.Context, ids []int64) (map[int64]*usersModel.Person, error)
+	StaffRepository() usersModel.StaffRepository
+}
+
+type OperationActiveService interface {
+	CreateVisit(ctx context.Context, visit *activeModel.Visit) error
+	EndVisit(ctx context.Context, id int64) error
+}
+
+type TimetableOperationsService interface {
+	PlannedNow(ctx context.Context, accountID int64, isAdmin bool, date time.Time, now time.Time) ([]OperationPlannedInstance, error)
+	Start(ctx context.Context, accountID int64, isAdmin bool, instanceID int64) (*StartInstanceResult, error)
+	Complete(ctx context.Context, accountID int64, isAdmin bool, instanceID int64) (*scheduleModel.ActivityInstance, error)
+	Roster(ctx context.Context, accountID int64, isAdmin bool, instanceID int64) (*OperationRoster, error)
+	RosterByActiveGroup(ctx context.Context, accountID int64, isAdmin bool, activeGroupID int64) (*OperationRoster, error)
+	CheckInStudent(ctx context.Context, accountID int64, isAdmin bool, instanceID, studentID int64) (*OperationRoster, error)
+	CheckOutStudent(ctx context.Context, accountID int64, isAdmin bool, instanceID, studentID int64) (*OperationRoster, error)
+	PatchAttendance(ctx context.Context, accountID int64, isAdmin bool, instanceID, studentID int64, patch scheduleModel.AttendanceFieldPatch) (*OperationRosterRow, error)
+}
+
+type TimetableOperationsDependencies struct {
+	InstanceRepo       scheduleModel.ActivityInstanceRepository
+	InstanceStaffRepo  scheduleModel.InstanceStaffRepository
+	InstanceStudents   scheduleModel.InstanceStudentRepository
+	InstanceService    InstanceService
+	ActiveGroupRepo    activeModel.GroupRepository
+	ActiveService      OperationActiveService
+	SupervisorRepo     activeModel.GroupSupervisorRepository
+	VisitRepo          activeModel.VisitRepository
+	StudentRepo        usersModel.StudentRepository
+	EducationGroupRepo educationModel.GroupRepository
+	PersonService      OperationPersonService
+	Settings           OperationSettings
+	DB                 *bun.DB
+	Logger             *slog.Logger
+}
+
+type OperationPlannedInstance struct {
+	ID                    int64                     `json:"id"`
+	Title                 string                    `json:"title"`
+	Date                  string                    `json:"date"`
+	StartTime             string                    `json:"start_time"`
+	EndTime               string                    `json:"end_time"`
+	RoomID                int64                     `json:"room_id"`
+	Status                string                    `json:"status"`
+	IsOverdue             bool                      `json:"is_overdue"`
+	MinutesUntilStart     int                       `json:"minutes_until_start"`
+	ExpectedStudentsCount int                       `json:"expected_students_count"`
+	PresentStudentsCount  int                       `json:"present_students_count"`
+	AssignedStaffIDs      []int64                   `json:"assigned_staff_ids"`
+	Warnings              []InstanceConflictWarning `json:"warnings"`
+}
+
+type OperationRoster struct {
+	Instance OperationRosterInstance `json:"instance"`
+	Rows     []OperationRosterRow    `json:"rows"`
+}
+
+type OperationRosterInstance struct {
+	ID            int64   `json:"id"`
+	Title         string  `json:"title"`
+	Status        string  `json:"status"`
+	ActiveGroupID *int64  `json:"active_group_id,omitempty"`
+	RoomID        int64   `json:"room_id"`
+	RoomName      *string `json:"room_name,omitempty"`
+}
+
+type OperationRosterRow struct {
+	StudentID        int64   `json:"student_id"`
+	StudentName      string  `json:"student_name"`
+	SchoolClass      string  `json:"school_class"`
+	GroupName        string  `json:"group_name"`
+	Planned          bool    `json:"planned"`
+	IsUnplanned      bool    `json:"is_unplanned"`
+	CurrentlyPresent bool    `json:"currently_present"`
+	VisitID          *int64  `json:"visit_id,omitempty"`
+	Status           string  `json:"status"`
+	Substatus        *string `json:"substatus,omitempty"`
+	Note             *string `json:"note,omitempty"`
+	CheckedInAt      *string `json:"checked_in_at,omitempty"`
+	VisitEntryTime   *string `json:"visit_entry_time,omitempty"`
+}
+
+type timetableOperationsService struct {
+	deps TimetableOperationsDependencies
+}
+
+func NewTimetableOperationsService(deps TimetableOperationsDependencies) TimetableOperationsService {
+	if deps.InstanceRepo == nil || deps.InstanceStaffRepo == nil || deps.InstanceStudents == nil ||
+		deps.InstanceService == nil || deps.ActiveGroupRepo == nil || deps.ActiveService == nil || deps.SupervisorRepo == nil ||
+		deps.VisitRepo == nil || deps.StudentRepo == nil || deps.EducationGroupRepo == nil || deps.PersonService == nil || deps.DB == nil {
+		panic("schedule.NewTimetableOperationsService: required dependency is nil")
+	}
+	return &timetableOperationsService{deps: deps}
+}
+
+func (s *timetableOperationsService) PlannedNow(ctx context.Context, accountID int64, isAdmin bool, date time.Time, now time.Time) ([]OperationPlannedInstance, error) {
+	staffID, hasStaff, err := s.resolveStaffID(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	adminAll := s.adminOverviewEnabled(ctx, isAdmin)
+	if !hasStaff && !adminAll {
+		return nil, ErrTimetableOperationForbidden
+	}
+
+	instances, err := s.deps.InstanceRepo.FindByTenantAndDate(ctx, date)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]OperationPlannedInstance, 0)
+	for _, inst := range instances {
+		if inst.Status != scheduleModel.InstanceStatusPlanned || !plannedNowWindow(inst, now) {
+			continue
+		}
+		staffRows, err := s.deps.InstanceStaffRepo.FindByInstanceID(ctx, inst.ID)
+		if err != nil {
+			return nil, err
+		}
+		if !adminAll && !staffAssigned(staffRows, staffID) {
+			continue
+		}
+		studentRows, err := s.deps.InstanceStudents.FindByInstanceID(ctx, inst.ID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mapPlannedInstance(inst, staffRows, studentRows, now))
+	}
+	return out, nil
+}
+
+func (s *timetableOperationsService) Start(ctx context.Context, accountID int64, isAdmin bool, instanceID int64) (*StartInstanceResult, error) {
+	staffID, err := s.requireCanOperate(ctx, accountID, isAdmin, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	if staffID <= 0 {
+		return nil, ErrTimetableOperationForbidden
+	}
+	return s.deps.InstanceService.Start(ctx, instanceID, staffID)
+}
+
+func (s *timetableOperationsService) Complete(ctx context.Context, accountID int64, isAdmin bool, instanceID int64) (*scheduleModel.ActivityInstance, error) {
+	if _, err := s.requireCanOperate(ctx, accountID, isAdmin, instanceID); err != nil {
+		return nil, err
+	}
+	return s.deps.InstanceService.Complete(ctx, instanceID)
+}
+
+func (s *timetableOperationsService) Roster(ctx context.Context, accountID int64, isAdmin bool, instanceID int64) (*OperationRoster, error) {
+	if _, err := s.requireCanOperate(ctx, accountID, isAdmin, instanceID); err != nil {
+		return nil, err
+	}
+	return s.buildRoster(ctx, instanceID)
+}
+
+func (s *timetableOperationsService) RosterByActiveGroup(ctx context.Context, accountID int64, isAdmin bool, activeGroupID int64) (*OperationRoster, error) {
+	inst, err := s.deps.InstanceRepo.FindByActiveGroupID(ctx, activeGroupID)
+	if err != nil {
+		return nil, err
+	}
+	if inst == nil {
+		return nil, ErrTimetableOperationNotFound
+	}
+	return s.Roster(ctx, accountID, isAdmin, inst.ID)
+}
+
+func (s *timetableOperationsService) CheckInStudent(ctx context.Context, accountID int64, isAdmin bool, instanceID, studentID int64) (*OperationRoster, error) {
+	staffID, err := s.requireCanOperate(ctx, accountID, isAdmin, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	if staffID <= 0 {
+		return nil, ErrTimetableOperationForbidden
+	}
+	inst, err := s.loadInstance(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	if inst.Status != scheduleModel.InstanceStatusActive || inst.ActiveGroupID == nil {
+		return nil, fmt.Errorf("%w: instance is not active", ErrTimetableOperationConflict)
+	}
+	current, err := s.deps.VisitRepo.GetCurrentByStudentID(ctx, studentID)
+	if err != nil && !isNoRows(err) {
+		return nil, err
+	}
+	if current != nil {
+		if current.ActiveGroupID != *inst.ActiveGroupID {
+			return nil, fmt.Errorf("%w: student already has active visit", ErrTimetableOperationConflict)
+		}
+		if err := s.markPlannedStudentPresent(ctx, instanceID, studentID); err != nil {
+			return nil, err
+		}
+		return s.buildRoster(ctx, instanceID)
+	}
+	now := time.Now()
+	visit := &activeModel.Visit{
+		StudentID:     studentID,
+		ActiveGroupID: *inst.ActiveGroupID,
+		EntryTime:     now,
+	}
+	visit.SetTenantID(tenant.FromContext(ctx))
+	staff := &usersModel.Staff{}
+	staff.ID = staffID
+	visitCtx := context.WithValue(ctx, device.CtxStaff, staff)
+	if err := s.deps.ActiveService.CreateVisit(visitCtx, visit); err != nil {
+		return nil, err
+	}
+	if err := s.markPlannedStudentPresent(ctx, instanceID, studentID); err != nil {
+		return nil, err
+	}
+	if err := s.deps.ActiveGroupRepo.UpdateLastActivity(ctx, *inst.ActiveGroupID, now); err != nil {
+		s.logger().WarnContext(ctx, "failed to update active group activity after timetable check-in",
+			slog.Int64("active_group_id", *inst.ActiveGroupID),
+			slog.String("error", err.Error()))
+	}
+	return s.buildRoster(ctx, instanceID)
+}
+
+func (s *timetableOperationsService) markPlannedStudentPresent(ctx context.Context, instanceID, studentID int64) error {
+	row, err := s.deps.InstanceStudents.FindByInstanceAndStudent(ctx, instanceID, studentID)
+	if err != nil || row == nil {
+		return err
+	}
+	status := scheduleModel.AttendanceStatusPresent
+	return s.deps.InstanceStudents.UpdateAttendanceFields(ctx, row.ID, scheduleModel.AttendanceFieldPatch{
+		Status:         &status,
+		SubstatusClear: true,
+		NoteClear:      true,
+	})
+}
+
+func (s *timetableOperationsService) CheckOutStudent(ctx context.Context, accountID int64, isAdmin bool, instanceID, studentID int64) (*OperationRoster, error) {
+	staffID, err := s.requireCanOperate(ctx, accountID, isAdmin, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	if staffID <= 0 {
+		return nil, ErrTimetableOperationForbidden
+	}
+	inst, err := s.loadInstance(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	if inst.ActiveGroupID == nil {
+		return nil, fmt.Errorf("%w: instance has no active group", ErrTimetableOperationConflict)
+	}
+	visit, err := s.findActiveVisitForInstanceStudent(ctx, *inst.ActiveGroupID, studentID)
+	if err != nil {
+		return nil, err
+	}
+	if visit == nil {
+		return nil, ErrTimetableOperationNotFound
+	}
+	staff := &usersModel.Staff{}
+	staff.ID = staffID
+	visitCtx := context.WithValue(ctx, device.CtxStaff, staff)
+	if err := s.deps.ActiveService.EndVisit(visitCtx, visit.ID); err != nil {
+		return nil, err
+	}
+	return s.buildRoster(ctx, instanceID)
+}
+
+func (s *timetableOperationsService) PatchAttendance(ctx context.Context, accountID int64, isAdmin bool, instanceID, studentID int64, patch scheduleModel.AttendanceFieldPatch) (*OperationRosterRow, error) {
+	if _, err := s.requireCanOperate(ctx, accountID, isAdmin, instanceID); err != nil {
+		return nil, err
+	}
+	row, err := s.deps.InstanceStudents.FindByInstanceAndStudent(ctx, instanceID, studentID)
+	if err != nil {
+		return nil, err
+	}
+	if row == nil {
+		return nil, ErrTimetableOperationNotFound
+	}
+	if err := s.deps.InstanceStudents.UpdateAttendanceFields(ctx, row.ID, patch); err != nil {
+		return nil, err
+	}
+	roster, err := s.buildRoster(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range roster.Rows {
+		if roster.Rows[i].StudentID == studentID {
+			return &roster.Rows[i], nil
+		}
+	}
+	return nil, ErrTimetableOperationNotFound
+}
+
+func (s *timetableOperationsService) requireCanOperate(ctx context.Context, accountID int64, isAdmin bool, instanceID int64) (int64, error) {
+	staffID, hasStaff, err := s.resolveStaffID(ctx, accountID)
+	if err != nil {
+		return 0, err
+	}
+	if s.adminOverviewEnabled(ctx, isAdmin) {
+		return staffID, nil
+	}
+	if !hasStaff {
+		return 0, ErrTimetableOperationForbidden
+	}
+	inst, err := s.loadInstance(ctx, instanceID)
+	if err != nil {
+		return 0, err
+	}
+	staffRows, err := s.deps.InstanceStaffRepo.FindByInstanceID(ctx, instanceID)
+	if err != nil {
+		return 0, err
+	}
+	if staffAssigned(staffRows, staffID) {
+		return staffID, nil
+	}
+	if inst.ActiveGroupID != nil {
+		supervisors, err := s.deps.SupervisorRepo.FindByActiveGroupID(ctx, *inst.ActiveGroupID, true)
+		if err != nil {
+			return 0, err
+		}
+		for _, sup := range supervisors {
+			if sup.StaffID == staffID {
+				return staffID, nil
+			}
+		}
+	}
+	return 0, ErrTimetableOperationForbidden
+}
+
+func (s *timetableOperationsService) buildRoster(ctx context.Context, instanceID int64) (*OperationRoster, error) {
+	inst, err := s.loadInstance(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	plannedRows, err := s.deps.InstanceStudents.FindByInstanceID(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	var visits []*activeModel.Visit
+	if inst.ActiveGroupID != nil {
+		visits, err = s.deps.VisitRepo.FindByActiveGroupID(ctx, *inst.ActiveGroupID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	studentIDs := make([]int64, 0, len(plannedRows)+len(visits))
+	seen := map[int64]bool{}
+	for _, row := range plannedRows {
+		if !seen[row.StudentID] {
+			seen[row.StudentID] = true
+			studentIDs = append(studentIDs, row.StudentID)
+		}
+	}
+	for _, visit := range visits {
+		if !seen[visit.StudentID] {
+			seen[visit.StudentID] = true
+			studentIDs = append(studentIDs, visit.StudentID)
+		}
+	}
+	students, err := s.deps.StudentRepo.FindByIDs(ctx, studentIDs)
+	if err != nil {
+		return nil, err
+	}
+	groupIDs := make([]int64, 0, len(students))
+	personIDs := make([]int64, 0, len(students))
+	for _, st := range students {
+		personIDs = append(personIDs, st.PersonID)
+		if st.GroupID != nil {
+			groupIDs = append(groupIDs, *st.GroupID)
+		}
+	}
+	persons, err := s.deps.PersonService.GetByIDs(ctx, personIDs)
+	if err != nil {
+		return nil, err
+	}
+	groups, err := s.deps.EducationGroupRepo.FindByIDs(ctx, groupIDs)
+	if err != nil {
+		return nil, err
+	}
+	latestVisits := map[int64]*activeModel.Visit{}
+	for _, visit := range visits {
+		if current := latestVisits[visit.StudentID]; current == nil || visit.EntryTime.After(current.EntryTime) {
+			latestVisits[visit.StudentID] = visit
+		}
+	}
+	rows := make([]OperationRosterRow, 0, len(seen))
+	for _, planned := range plannedRows {
+		rows = append(rows, s.mapRosterRow(planned.StudentID, planned, latestVisits[planned.StudentID], students, persons, groups))
+	}
+	for _, visit := range latestVisits {
+		if _, planned := findPlanned(plannedRows, visit.StudentID); planned {
+			continue
+		}
+		rows = append(rows, s.mapRosterRow(visit.StudentID, nil, visit, students, persons, groups))
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].CurrentlyPresent != rows[j].CurrentlyPresent {
+			return rows[i].CurrentlyPresent && !rows[j].CurrentlyPresent
+		}
+		if rows[i].Planned != rows[j].Planned {
+			return rows[i].Planned && !rows[j].Planned
+		}
+		return rows[i].StudentName < rows[j].StudentName
+	})
+	return &OperationRoster{
+		Instance: OperationRosterInstance{
+			ID:            inst.ID,
+			Title:         inst.Title,
+			Status:        inst.Status,
+			ActiveGroupID: inst.ActiveGroupID,
+			RoomID:        inst.RoomID,
+		},
+		Rows: rows,
+	}, nil
+}
+
+func (s *timetableOperationsService) mapRosterRow(studentID int64, planned *scheduleModel.InstanceStudent, visit *activeModel.Visit, students map[int64]*usersModel.Student, persons map[int64]*usersModel.Person, groups map[int64]*educationModel.Group) OperationRosterRow {
+	row := OperationRosterRow{
+		StudentID:        studentID,
+		Planned:          planned != nil,
+		IsUnplanned:      planned == nil && visit != nil,
+		CurrentlyPresent: visit != nil && visit.ExitTime == nil,
+		Status:           scheduleModel.AttendanceStatusPresent,
+	}
+	if planned != nil {
+		row.Status = planned.Status
+		row.Substatus = planned.Substatus
+		row.Note = planned.Note
+		if planned.CheckedInAt != nil {
+			v := planned.CheckedInAt.UTC().Format(time.RFC3339)
+			row.CheckedInAt = &v
+		}
+	}
+	if visit != nil {
+		id := visit.ID
+		row.VisitID = &id
+		v := visit.EntryTime.UTC().Format(time.RFC3339)
+		row.VisitEntryTime = &v
+	}
+	if st := students[studentID]; st != nil {
+		row.SchoolClass = st.SchoolClass
+		if st.GroupID != nil {
+			if group := groups[*st.GroupID]; group != nil {
+				row.GroupName = group.Name
+			}
+		}
+		if p := persons[st.PersonID]; p != nil {
+			row.StudentName = p.GetFullName()
+		}
+	}
+	return row
+}
+
+func (s *timetableOperationsService) resolveStaffID(ctx context.Context, accountID int64) (int64, bool, error) {
+	if accountID <= 0 {
+		return 0, false, ErrTimetableOperationForbidden
+	}
+	person, err := s.deps.PersonService.FindByAccountID(ctx, accountID)
+	if err != nil || person == nil {
+		return 0, false, nil
+	}
+	staff, err := s.deps.PersonService.StaffRepository().FindByPersonID(ctx, person.ID)
+	if err != nil || staff == nil {
+		return 0, false, nil
+	}
+	return staff.ID, true, nil
+}
+
+func (s *timetableOperationsService) adminOverviewEnabled(ctx context.Context, isAdmin bool) bool {
+	if !isAdmin || s.deps.Settings == nil {
+		return false
+	}
+	enabled, err := s.deps.Settings.ResolveBool(ctx, configModel.KeyAdminSupervisionOverview)
+	if err != nil {
+		s.logger().WarnContext(ctx, "admin supervision overview setting check failed for timetable operations",
+			slog.String("error", err.Error()))
+		return false
+	}
+	return enabled
+}
+
+func (s *timetableOperationsService) loadInstance(ctx context.Context, instanceID int64) (*scheduleModel.ActivityInstance, error) {
+	inst, err := s.deps.InstanceRepo.FindByID(ctx, instanceID)
+	if err != nil {
+		if isNoRows(err) {
+			return nil, ErrTimetableOperationNotFound
+		}
+		return nil, err
+	}
+	if inst == nil {
+		return nil, ErrTimetableOperationNotFound
+	}
+	return inst, nil
+}
+
+func (s *timetableOperationsService) findActiveVisitForInstanceStudent(ctx context.Context, activeGroupID, studentID int64) (*activeModel.Visit, error) {
+	visits, err := s.deps.VisitRepo.FindByActiveGroupID(ctx, activeGroupID)
+	if err != nil {
+		return nil, err
+	}
+	for _, visit := range visits {
+		if visit.StudentID == studentID && visit.ExitTime == nil {
+			return visit, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *timetableOperationsService) logger() *slog.Logger {
+	if s.deps.Logger != nil {
+		return s.deps.Logger
+	}
+	return slog.Default()
+}
+
+func plannedNowWindow(inst *scheduleModel.ActivityInstance, now time.Time) bool {
+	start := time.Date(now.Year(), now.Month(), now.Day(), inst.StartTime.Hour(), inst.StartTime.Minute(), inst.StartTime.Second(), 0, now.Location())
+	return (start.After(now.Add(-15*time.Minute)) && start.Before(now.Add(15*time.Minute))) || start.Before(now)
+}
+
+func mapPlannedInstance(inst *scheduleModel.ActivityInstance, staffRows []*scheduleModel.InstanceStaff, studentRows []*scheduleModel.InstanceStudent, now time.Time) OperationPlannedInstance {
+	assigned := make([]int64, 0, len(staffRows))
+	for _, row := range staffRows {
+		if !row.IsAbsent {
+			assigned = append(assigned, row.StaffID)
+		}
+	}
+	expected, present := 0, 0
+	for _, row := range studentRows {
+		switch row.Status {
+		case scheduleModel.AttendanceStatusExpected:
+			expected++
+		case scheduleModel.AttendanceStatusPresent:
+			present++
+		}
+	}
+	start := time.Date(now.Year(), now.Month(), now.Day(), inst.StartTime.Hour(), inst.StartTime.Minute(), inst.StartTime.Second(), 0, now.Location())
+	return OperationPlannedInstance{
+		ID:                    inst.ID,
+		Title:                 inst.Title,
+		Date:                  inst.Date.Format("2006-01-02"),
+		StartTime:             inst.StartTime.Format("15:04"),
+		EndTime:               inst.EndTime.Format("15:04"),
+		RoomID:                inst.RoomID,
+		Status:                inst.Status,
+		IsOverdue:             start.Before(now),
+		MinutesUntilStart:     int(start.Sub(now).Minutes()),
+		ExpectedStudentsCount: expected,
+		PresentStudentsCount:  present,
+		AssignedStaffIDs:      assigned,
+		Warnings:              []InstanceConflictWarning{},
+	}
+}
+
+func staffAssigned(rows []*scheduleModel.InstanceStaff, staffID int64) bool {
+	for _, row := range rows {
+		if row.StaffID == staffID && !row.IsAbsent {
+			return true
+		}
+	}
+	return false
+}
+
+func findPlanned(rows []*scheduleModel.InstanceStudent, studentID int64) (*scheduleModel.InstanceStudent, bool) {
+	for _, row := range rows {
+		if row.StudentID == studentID {
+			return row, true
+		}
+	}
+	return nil, false
+}
+
+func isNoRows(err error) bool {
+	if errors.Is(err, sql.ErrNoRows) {
+		return true
+	}
+	type unwrapper interface{ Unwrap() error }
+	if u, ok := err.(unwrapper); ok {
+		return isNoRows(u.Unwrap())
+	}
+	return false
+}

--- a/backend/services/schedule/timetable_operations_service.go
+++ b/backend/services/schedule/timetable_operations_service.go
@@ -15,6 +15,7 @@ import (
 	educationModel "github.com/moto-nrw/project-phoenix/models/education"
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
 	usersModel "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/realtime"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
@@ -64,6 +65,7 @@ type TimetableOperationsDependencies struct {
 	EducationGroupRepo educationModel.GroupRepository
 	PersonService      OperationPersonService
 	Settings           OperationSettings
+	Broadcaster        realtime.Broadcaster
 	DB                 *bun.DB
 	Logger             *slog.Logger
 }
@@ -308,6 +310,7 @@ func (s *timetableOperationsService) PatchAttendance(ctx context.Context, accoun
 	if err := s.deps.InstanceStudents.UpdateAttendanceFields(ctx, row.ID, patch); err != nil {
 		return nil, err
 	}
+	s.broadcastAttendanceChanged(ctx, instanceID, studentID)
 	roster, err := s.buildRoster(ctx, instanceID)
 	if err != nil {
 		return nil, err
@@ -485,14 +488,55 @@ func (s *timetableOperationsService) resolveStaffID(ctx context.Context, account
 		return 0, false, ErrTimetableOperationForbidden
 	}
 	person, err := s.deps.PersonService.FindByAccountID(ctx, accountID)
-	if err != nil || person == nil {
+	if err != nil {
+		return 0, false, err
+	}
+	if person == nil {
 		return 0, false, nil
 	}
 	staff, err := s.deps.PersonService.StaffRepository().FindByPersonID(ctx, person.ID)
-	if err != nil || staff == nil {
+	if err != nil {
+		if isNoRows(err) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if staff == nil {
 		return 0, false, nil
 	}
 	return staff.ID, true, nil
+}
+
+func (s *timetableOperationsService) broadcastAttendanceChanged(ctx context.Context, instanceID, studentID int64) {
+	if s.deps.Broadcaster == nil {
+		return
+	}
+	inst, err := s.loadInstance(ctx, instanceID)
+	if err != nil {
+		s.logger().WarnContext(ctx, "failed to load instance for timetable attendance broadcast",
+			slog.Int64("instance_id", instanceID),
+			slog.String("error", err.Error()))
+		return
+	}
+	if inst.ActiveGroupID == nil {
+		return
+	}
+	activeGroupID := fmt.Sprintf("%d", *inst.ActiveGroupID)
+	instanceIDStr := fmt.Sprintf("%d", instanceID)
+	studentIDStr := fmt.Sprintf("%d", studentID)
+	reason := "timetable_attendance_updated"
+	event := realtime.NewEvent(realtime.EventActiveSupervisionChanged, activeGroupID, realtime.EventData{
+		InstanceID: &instanceIDStr,
+		StudentID:  &studentIDStr,
+		Reason:     &reason,
+	})
+	tenantID := tenant.FromContext(ctx)
+	if err := s.deps.Broadcaster.BroadcastToTenant(tenantID, event); err != nil {
+		s.logger().WarnContext(ctx, "SSE timetable attendance broadcast failed",
+			slog.Int64("tenant_id", tenantID),
+			slog.String("active_group_id", activeGroupID),
+			slog.String("error", err.Error()))
+	}
 }
 
 func (s *timetableOperationsService) adminOverviewEnabled(ctx context.Context, isAdmin bool) bool {

--- a/backend/services/schedule/timetable_operations_service.go
+++ b/backend/services/schedule/timetable_operations_service.go
@@ -16,6 +16,7 @@ import (
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
 	usersModel "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/realtime"
+	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
@@ -28,6 +29,14 @@ var (
 
 type OperationSettings interface {
 	ResolveBool(ctx context.Context, key string) (bool, error)
+}
+
+type TimetableAttendanceValidationError struct {
+	Fields []scheduleModel.AttendancePatchFieldError
+}
+
+func (e *TimetableAttendanceValidationError) Error() string {
+	return "timetable attendance validation failed"
 }
 
 type OperationPersonService interface {
@@ -307,6 +316,9 @@ func (s *timetableOperationsService) PatchAttendance(ctx context.Context, accoun
 	if row == nil {
 		return nil, ErrTimetableOperationNotFound
 	}
+	if verrs := scheduleModel.ValidateAttendancePatch(patch, row); len(verrs) > 0 {
+		return nil, &TimetableAttendanceValidationError{Fields: verrs}
+	}
 	if err := s.deps.InstanceStudents.UpdateAttendanceFields(ctx, row.ID, patch); err != nil {
 		return nil, err
 	}
@@ -489,6 +501,9 @@ func (s *timetableOperationsService) resolveStaffID(ctx context.Context, account
 	}
 	person, err := s.deps.PersonService.FindByAccountID(ctx, accountID)
 	if err != nil {
+		if errors.Is(err, usersSvc.ErrPersonNotFound) {
+			return 0, false, nil
+		}
 		return 0, false, err
 	}
 	if person == nil {
@@ -587,7 +602,7 @@ func (s *timetableOperationsService) logger() *slog.Logger {
 }
 
 func plannedNowWindow(inst *scheduleModel.ActivityInstance, now time.Time) bool {
-	start := time.Date(now.Year(), now.Month(), now.Day(), inst.StartTime.Hour(), inst.StartTime.Minute(), inst.StartTime.Second(), 0, now.Location())
+	start := instanceStartAt(inst, now.Location())
 	return (start.After(now.Add(-15*time.Minute)) && start.Before(now.Add(15*time.Minute))) || start.Before(now)
 }
 
@@ -607,7 +622,7 @@ func mapPlannedInstance(inst *scheduleModel.ActivityInstance, staffRows []*sched
 			present++
 		}
 	}
-	start := time.Date(now.Year(), now.Month(), now.Day(), inst.StartTime.Hour(), inst.StartTime.Minute(), inst.StartTime.Second(), 0, now.Location())
+	start := instanceStartAt(inst, now.Location())
 	return OperationPlannedInstance{
 		ID:                    inst.ID,
 		Title:                 inst.Title,
@@ -623,6 +638,10 @@ func mapPlannedInstance(inst *scheduleModel.ActivityInstance, staffRows []*sched
 		AssignedStaffIDs:      assigned,
 		Warnings:              []InstanceConflictWarning{},
 	}
+}
+
+func instanceStartAt(inst *scheduleModel.ActivityInstance, loc *time.Location) time.Time {
+	return time.Date(inst.Date.Year(), inst.Date.Month(), inst.Date.Day(), inst.StartTime.Hour(), inst.StartTime.Minute(), inst.StartTime.Second(), 0, loc)
 }
 
 func staffAssigned(rows []*scheduleModel.InstanceStaff, staffID int64) bool {

--- a/backend/services/schedule/timetable_operations_service_test.go
+++ b/backend/services/schedule/timetable_operations_service_test.go
@@ -12,6 +12,7 @@ import (
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
 	usersModel "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/realtime"
+	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,15 +72,71 @@ func TestTimetableOperationsPlannedNowAllowsAdminOverview(t *testing.T) {
 	assert.True(t, result[0].IsOverdue)
 }
 
+func TestTimetableOperationsPlannedNowUsesInstanceDate(t *testing.T) {
+	t.Run("does not return future-date instances as overdue today", func(t *testing.T) {
+		now := time.Date(2026, time.May, 10, 14, 0, 0, 0, time.UTC)
+		tomorrowStart := time.Date(2026, time.May, 11, 8, 0, 0, 0, time.UTC)
+		deps := newTimetableOpsDeps()
+		deps.settings.enabled = true
+		deps.instanceRepo.byDate = []*scheduleModel.ActivityInstance{
+			instanceWithTimes(334, scheduleModel.InstanceStatusPlanned, tomorrowStart, tomorrowStart.Add(time.Hour)),
+		}
+		deps.staffRepo.byInstance[334] = []*scheduleModel.InstanceStaff{{StaffID: 224}}
+
+		result, err := deps.service.PlannedNow(context.Background(), 625, true, tomorrowStart, now)
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("calculates overdue metadata from instance date", func(t *testing.T) {
+		now := time.Date(2026, time.May, 10, 23, 55, 0, 0, time.UTC)
+		tomorrowStart := time.Date(2026, time.May, 11, 0, 5, 0, 0, time.UTC)
+		inst := instanceWithTimes(335, scheduleModel.InstanceStatusPlanned, tomorrowStart, tomorrowStart.Add(time.Hour))
+
+		result := mapPlannedInstance(inst, []*scheduleModel.InstanceStaff{{StaffID: 225}}, nil, now)
+
+		assert.False(t, result.IsOverdue)
+		assert.Equal(t, 10, result.MinutesUntilStart)
+	})
+}
+
 func TestTimetableOperationsPlannedNowErrorBranches(t *testing.T) {
 	now := time.Date(2026, time.May, 10, 14, 0, 0, 0, time.UTC)
 
 	t.Run("forbids accounts without staff when admin overview is disabled", func(t *testing.T) {
 		deps := newTimetableOpsDeps()
+		deps.personService.accountErr = usersSvc.ErrPersonNotFound
 
 		result, err := deps.service.PlannedNow(context.Background(), 621, false, now, now)
 
 		require.ErrorIs(t, err, ErrTimetableOperationForbidden)
+		assert.Nil(t, result)
+	})
+
+	t.Run("admin overview allows missing person profile", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		deps.settings.enabled = true
+		deps.personService.accountErr = usersSvc.ErrPersonNotFound
+		deps.instanceRepo.byDate = []*scheduleModel.ActivityInstance{
+			instanceWithTimes(336, scheduleModel.InstanceStatusPlanned, now.Add(-time.Minute), now.Add(time.Hour)),
+		}
+		deps.staffRepo.byInstance[336] = []*scheduleModel.InstanceStaff{{StaffID: 226}}
+
+		result, err := deps.service.PlannedNow(context.Background(), 626, true, now, now)
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, int64(336), result[0].ID)
+	})
+
+	t.Run("propagates unexpected person lookup errors", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		deps.personService.accountErr = errors.New("person lookup failed")
+
+		result, err := deps.service.PlannedNow(context.Background(), 627, true, now, now)
+
+		require.EqualError(t, err, "person lookup failed")
 		assert.Nil(t, result)
 	})
 
@@ -480,6 +537,47 @@ func TestTimetableOperationsPatchAttendanceBranches(t *testing.T) {
 
 	require.ErrorIs(t, err, ErrTimetableOperationNotFound)
 	assert.Nil(t, row)
+
+	t.Run("forbidden before attendance row validation", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		instanceID := int64(423)
+		studentID := int64(565)
+		wireAssignedStaff(deps, 691, 513, 271, instanceID)
+		deps.staffRepo.byInstance[instanceID] = []*scheduleModel.InstanceStaff{{StaffID: 272}}
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, 303)
+		excused := scheduleModel.AttendanceSubstatusExcused
+		row := &scheduleModel.InstanceStudent{InstanceID: instanceID, StudentID: studentID, Status: scheduleModel.AttendanceStatusPresent, Substatus: &excused}
+		row.ID = 424
+		deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, studentID}] = row
+		expected := scheduleModel.AttendanceStatusExpected
+
+		result, err := deps.service.PatchAttendance(context.Background(), 691, false, instanceID, studentID, scheduleModel.AttendanceFieldPatch{Status: &expected})
+
+		require.ErrorIs(t, err, ErrTimetableOperationForbidden)
+		assert.Nil(t, result)
+		assert.Empty(t, deps.studentRepo.updates)
+	})
+
+	t.Run("authorized invalid patch returns field validation error", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		instanceID := int64(425)
+		studentID := int64(566)
+		wireAssignedStaff(deps, 692, 514, 273, instanceID)
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, 304)
+		row := &scheduleModel.InstanceStudent{InstanceID: instanceID, StudentID: studentID, Status: scheduleModel.AttendanceStatusExpected}
+		row.ID = 426
+		deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, studentID}] = row
+		late := scheduleModel.AttendanceSubstatusLate
+
+		result, err := deps.service.PatchAttendance(context.Background(), 692, false, instanceID, studentID, scheduleModel.AttendanceFieldPatch{Substatus: &late})
+
+		var validationErr *TimetableAttendanceValidationError
+		require.ErrorAs(t, err, &validationErr)
+		require.Len(t, validationErr.Fields, 1)
+		assert.Equal(t, "substatus", validationErr.Fields[0].Field)
+		assert.Nil(t, result)
+		assert.Empty(t, deps.studentRepo.updates)
+	})
 }
 
 func TestTimetableOperationsDependencyErrorsPropagate(t *testing.T) {
@@ -901,12 +999,16 @@ func (r *fakeOpsEducationGroupRepo) FindByIDs(_ context.Context, ids []int64) (m
 
 type fakeOpsPersonService struct {
 	accountPerson   *usersModel.Person
+	accountErr      error
 	people          map[int64]*usersModel.Person
 	staffByPersonID map[int64]*usersModel.Staff
 	staffErr        error
 }
 
 func (s *fakeOpsPersonService) FindByAccountID(_ context.Context, _ int64) (*usersModel.Person, error) {
+	if s.accountErr != nil {
+		return nil, s.accountErr
+	}
 	return s.accountPerson, nil
 }
 

--- a/backend/services/schedule/timetable_operations_service_test.go
+++ b/backend/services/schedule/timetable_operations_service_test.go
@@ -1,0 +1,974 @@
+package schedule
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	educationModel "github.com/moto-nrw/project-phoenix/models/education"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	usersModel "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/realtime"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func TestTimetableOperationsPlannedNowFiltersByAssignmentAndWindow(t *testing.T) {
+	now := time.Date(2026, time.May, 10, 14, 0, 0, 0, time.UTC)
+	assignedID := int64(210)
+	absentID := int64(211)
+	instanceID := int64(320)
+	outsideWindowID := int64(321)
+
+	deps := newTimetableOpsDeps()
+	deps.personService.accountPerson = &usersModel.Person{}
+	deps.personService.accountPerson.ID = 410
+	deps.personService.staffByPersonID[410] = &usersModel.Staff{}
+	deps.personService.staffByPersonID[410].ID = assignedID
+	deps.instanceRepo.byDate = []*scheduleModel.ActivityInstance{
+		instanceWithTimes(instanceID, scheduleModel.InstanceStatusPlanned, now.Add(10*time.Minute), now.Add(time.Hour)),
+		instanceWithTimes(outsideWindowID, scheduleModel.InstanceStatusPlanned, now.Add(20*time.Minute), now.Add(time.Hour)),
+	}
+	deps.staffRepo.byInstance[instanceID] = []*scheduleModel.InstanceStaff{
+		{StaffID: assignedID},
+		{StaffID: absentID, IsAbsent: true},
+	}
+	deps.staffRepo.byInstance[outsideWindowID] = []*scheduleModel.InstanceStaff{{StaffID: assignedID}}
+	deps.studentRepo.byInstance[instanceID] = []*scheduleModel.InstanceStudent{
+		{StudentID: 520, Status: scheduleModel.AttendanceStatusExpected},
+		{StudentID: 521, Status: scheduleModel.AttendanceStatusPresent},
+	}
+
+	result, err := deps.service.PlannedNow(context.Background(), 610, false, now, now)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, instanceID, result[0].ID)
+	assert.Equal(t, []int64{assignedID}, result[0].AssignedStaffIDs)
+	assert.Equal(t, 1, result[0].ExpectedStudentsCount)
+	assert.Equal(t, 1, result[0].PresentStudentsCount)
+	assert.False(t, result[0].IsOverdue)
+	assert.Equal(t, 10, result[0].MinutesUntilStart)
+}
+
+func TestTimetableOperationsPlannedNowAllowsAdminOverview(t *testing.T) {
+	now := time.Date(2026, time.May, 10, 14, 0, 0, 0, time.UTC)
+	deps := newTimetableOpsDeps()
+	deps.settings.enabled = true
+	deps.instanceRepo.byDate = []*scheduleModel.ActivityInstance{
+		instanceWithTimes(330, scheduleModel.InstanceStatusPlanned, now.Add(-time.Minute), now.Add(time.Hour)),
+	}
+	deps.staffRepo.byInstance[330] = []*scheduleModel.InstanceStaff{{StaffID: 220}}
+
+	result, err := deps.service.PlannedNow(context.Background(), 620, true, now, now)
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.True(t, result[0].IsOverdue)
+}
+
+func TestTimetableOperationsPlannedNowErrorBranches(t *testing.T) {
+	now := time.Date(2026, time.May, 10, 14, 0, 0, 0, time.UTC)
+
+	t.Run("forbids accounts without staff when admin overview is disabled", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+
+		result, err := deps.service.PlannedNow(context.Background(), 621, false, now, now)
+
+		require.ErrorIs(t, err, ErrTimetableOperationForbidden)
+		assert.Nil(t, result)
+	})
+
+	t.Run("propagates instance listing errors", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 622, 431, 221, 331)
+		deps.instanceRepo.findByDateErr = errors.New("date query failed")
+
+		result, err := deps.service.PlannedNow(context.Background(), 622, false, now, now)
+
+		require.EqualError(t, err, "date query failed")
+		assert.Nil(t, result)
+	})
+
+	t.Run("propagates staff lookup errors", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 623, 432, 222, 332)
+		deps.instanceRepo.byDate = []*scheduleModel.ActivityInstance{
+			instanceWithTimes(332, scheduleModel.InstanceStatusPlanned, now, now.Add(time.Hour)),
+		}
+		deps.staffRepo.err = errors.New("staff query failed")
+
+		result, err := deps.service.PlannedNow(context.Background(), 623, false, now, now)
+
+		require.EqualError(t, err, "staff query failed")
+		assert.Nil(t, result)
+	})
+
+	t.Run("propagates student lookup errors", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 624, 433, 223, 333)
+		deps.instanceRepo.byDate = []*scheduleModel.ActivityInstance{
+			instanceWithTimes(333, scheduleModel.InstanceStatusPlanned, now, now.Add(time.Hour)),
+		}
+		deps.studentRepo.err = errors.New("student query failed")
+
+		result, err := deps.service.PlannedNow(context.Background(), 624, false, now, now)
+
+		require.EqualError(t, err, "student query failed")
+		assert.Nil(t, result)
+	})
+}
+
+func TestTimetableOperationsStartRequiresAStaffIdentity(t *testing.T) {
+	deps := newTimetableOpsDeps()
+	deps.settings.enabled = true
+	deps.personService.accountPerson = &usersModel.Person{}
+	deps.personService.accountPerson.ID = 430
+
+	result, err := deps.service.Start(context.Background(), 630, true, 340)
+
+	require.ErrorIs(t, err, ErrTimetableOperationForbidden)
+	assert.Nil(t, result)
+	assert.Empty(t, deps.instanceService.started)
+}
+
+func TestTimetableOperationsStartDelegatesWhenStaffIsAssigned(t *testing.T) {
+	staffID := int64(230)
+	instanceID := int64(350)
+	deps := newTimetableOpsDeps()
+	deps.personService.accountPerson = &usersModel.Person{}
+	deps.personService.accountPerson.ID = 440
+	deps.personService.staffByPersonID[440] = &usersModel.Staff{}
+	deps.personService.staffByPersonID[440].ID = staffID
+	deps.instanceRepo.byID[instanceID] = instanceWithTimes(instanceID, scheduleModel.InstanceStatusPlanned, time.Now(), time.Now().Add(time.Hour))
+	deps.staffRepo.byInstance[instanceID] = []*scheduleModel.InstanceStaff{{StaffID: staffID}}
+
+	result, err := deps.service.Start(context.Background(), 640, false, instanceID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, instanceID, deps.instanceService.started[0].instanceID)
+	assert.Equal(t, staffID, deps.instanceService.started[0].staffID)
+}
+
+func TestTimetableOperationsRosterCombinesPlannedStudentsAndLiveDropIns(t *testing.T) {
+	instanceID := int64(360)
+	activeGroupID := int64(260)
+	groupID := int64(270)
+	visitID := int64(370)
+	deps := newTimetableOpsDeps()
+	wireAssignedStaff(deps, 650, 450, 240, instanceID)
+	deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+	deps.studentRepo.byInstance[instanceID] = []*scheduleModel.InstanceStudent{
+		{StudentID: 530, Status: scheduleModel.AttendanceStatusExpected},
+	}
+	deps.visitRepo.byActiveGroup[activeGroupID] = []*activeModel.Visit{
+		{StudentID: 531, ActiveGroupID: activeGroupID, EntryTime: time.Date(2026, time.May, 10, 14, 5, 0, 0, time.UTC)},
+	}
+	deps.visitRepo.byActiveGroup[activeGroupID][0].ID = visitID
+	deps.students.byID[530] = &usersModel.Student{PersonID: 460, SchoolClass: "3a", GroupID: &groupID}
+	deps.students.byID[531] = &usersModel.Student{PersonID: 461, SchoolClass: "4b"}
+	deps.personService.people[460] = &usersModel.Person{FirstName: "Zoe", LastName: "Zimmer"}
+	deps.personService.people[461] = &usersModel.Person{FirstName: "Anna", LastName: "Anlauf"}
+	deps.groups.byID[groupID] = &educationModel.Group{Name: "OGS Blau"}
+
+	roster, err := deps.service.Roster(context.Background(), 650, false, instanceID)
+
+	require.NoError(t, err)
+	require.Len(t, roster.Rows, 2)
+	assert.Equal(t, "Anna Anlauf", roster.Rows[0].StudentName)
+	assert.True(t, roster.Rows[0].IsUnplanned)
+	assert.True(t, roster.Rows[0].CurrentlyPresent)
+	assert.Equal(t, &visitID, roster.Rows[0].VisitID)
+	assert.Equal(t, "Zoe Zimmer", roster.Rows[1].StudentName)
+	assert.True(t, roster.Rows[1].Planned)
+	assert.Equal(t, "OGS Blau", roster.Rows[1].GroupName)
+}
+
+func TestTimetableOperationsCheckInCreatesVisitAndMarksPlannedPresent(t *testing.T) {
+	instanceID := int64(380)
+	activeGroupID := int64(280)
+	studentID := int64(540)
+	rowID := int64(390)
+	deps := newTimetableOpsDeps()
+	wireAssignedStaff(deps, 660, 470, 250, instanceID)
+	deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+	deps.studentRepo.byInstance[instanceID] = []*scheduleModel.InstanceStudent{
+		{StudentID: studentID, Status: scheduleModel.AttendanceStatusExpected},
+	}
+	deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, studentID}] = &scheduleModel.InstanceStudent{
+		InstanceID: instanceID,
+		StudentID:  studentID,
+		Status:     scheduleModel.AttendanceStatusExpected,
+	}
+	deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, studentID}].ID = rowID
+	deps.students.byID[studentID] = &usersModel.Student{PersonID: 480, SchoolClass: "2c"}
+	deps.personService.people[480] = &usersModel.Person{FirstName: "Mila", LastName: "Muster"}
+
+	roster, err := deps.service.CheckInStudent(tenant.WithTenantID(context.Background(), 720), 660, false, instanceID, studentID)
+
+	require.NoError(t, err)
+	require.Len(t, deps.activeService.created, 1)
+	assert.Equal(t, int64(720), deps.activeService.created[0].GetTenantID())
+	assert.Equal(t, activeGroupID, deps.activeService.created[0].ActiveGroupID)
+	require.Len(t, deps.studentRepo.updates, 1)
+	assert.Equal(t, rowID, deps.studentRepo.updates[0].rowID)
+	assert.Equal(t, scheduleModel.AttendanceStatusPresent, *deps.studentRepo.updates[0].patch.Status)
+	assert.True(t, deps.studentRepo.updates[0].patch.SubstatusClear)
+	assert.True(t, deps.activeGroups.lastActivity[activeGroupID].After(time.Time{}))
+	assert.Equal(t, studentID, roster.Rows[0].StudentID)
+}
+
+func TestTimetableOperationsCheckInRejectsStudentActiveElsewhere(t *testing.T) {
+	instanceID := int64(400)
+	activeGroupID := int64(290)
+	studentID := int64(550)
+	deps := newTimetableOpsDeps()
+	wireAssignedStaff(deps, 670, 490, 251, instanceID)
+	deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+	deps.visitRepo.currentByStudent[studentID] = &activeModel.Visit{StudentID: studentID, ActiveGroupID: 291, EntryTime: time.Now()}
+
+	_, err := deps.service.CheckInStudent(context.Background(), 670, false, instanceID, studentID)
+
+	require.ErrorIs(t, err, ErrTimetableOperationConflict)
+	assert.Empty(t, deps.activeService.created)
+}
+
+func TestTimetableOperationsCheckOutEndsMatchingVisit(t *testing.T) {
+	instanceID := int64(401)
+	activeGroupID := int64(292)
+	studentID := int64(551)
+	visitID := int64(402)
+	deps := newTimetableOpsDeps()
+	wireAssignedStaff(deps, 671, 491, 252, instanceID)
+	deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+	deps.visitRepo.byActiveGroup[activeGroupID] = []*activeModel.Visit{{StudentID: studentID, ActiveGroupID: activeGroupID, EntryTime: time.Now()}}
+	deps.visitRepo.byActiveGroup[activeGroupID][0].ID = visitID
+	deps.students.byID[studentID] = &usersModel.Student{PersonID: 492, SchoolClass: "1a"}
+	deps.personService.people[492] = &usersModel.Person{FirstName: "Ben", LastName: "Beispiel"}
+
+	_, err := deps.service.CheckOutStudent(context.Background(), 671, false, instanceID, studentID)
+
+	require.NoError(t, err)
+	assert.Equal(t, []int64{visitID}, deps.activeService.ended)
+}
+
+func TestTimetableOperationsPatchAttendanceUpdatesRowAndBroadcasts(t *testing.T) {
+	instanceID := int64(403)
+	activeGroupID := int64(293)
+	studentID := int64(552)
+	rowID := int64(404)
+	deps := newTimetableOpsDeps()
+	wireAssignedStaff(deps, 672, 493, 253, instanceID)
+	deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+	deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, studentID}] = &scheduleModel.InstanceStudent{
+		InstanceID: instanceID,
+		StudentID:  studentID,
+		Status:     scheduleModel.AttendanceStatusExpected,
+	}
+	deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, studentID}].ID = rowID
+	deps.studentRepo.byInstance[instanceID] = []*scheduleModel.InstanceStudent{
+		deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, studentID}],
+	}
+	deps.students.byID[studentID] = &usersModel.Student{PersonID: 494, SchoolClass: "1b"}
+	deps.personService.people[494] = &usersModel.Person{FirstName: "Lea", LastName: "Lern"}
+	status := scheduleModel.AttendanceStatusAbsent
+	note := "krank gemeldet"
+
+	row, err := deps.service.PatchAttendance(tenant.WithTenantID(context.Background(), 721), 672, false, instanceID, studentID, scheduleModel.AttendanceFieldPatch{
+		Status: &status,
+		Note:   &note,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	assert.Equal(t, studentID, row.StudentID)
+	require.Len(t, deps.studentRepo.updates, 1)
+	assert.Equal(t, rowID, deps.studentRepo.updates[0].rowID)
+	assert.Equal(t, &note, deps.studentRepo.updates[0].patch.Note)
+	require.Len(t, deps.broadcaster.events, 1)
+	assert.Equal(t, int64(721), deps.broadcaster.events[0].tenantID)
+	assert.Equal(t, realtime.EventActiveSupervisionChanged, deps.broadcaster.events[0].event.Type)
+}
+
+func TestTimetableOperationsCompleteDelegatesAfterPermissionCheck(t *testing.T) {
+	instanceID := int64(405)
+	deps := newTimetableOpsDeps()
+	wireAssignedStaff(deps, 673, 495, 254, instanceID)
+	deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, 294)
+
+	result, err := deps.service.Complete(context.Background(), 673, false, instanceID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []int64{instanceID}, deps.instanceService.completed)
+}
+
+func TestTimetableOperationsRosterByActiveGroupReturnsNotFound(t *testing.T) {
+	deps := newTimetableOpsDeps()
+
+	result, err := deps.service.RosterByActiveGroup(context.Background(), 674, false, 295)
+
+	require.ErrorIs(t, err, ErrTimetableOperationNotFound)
+	assert.Nil(t, result)
+}
+
+func TestTimetableOperationsRosterByActiveGroupSuccess(t *testing.T) {
+	instanceID := int64(416)
+	activeGroupID := int64(301)
+	deps := newTimetableOpsDeps()
+	wireAssignedStaff(deps, 684, 506, 264, instanceID)
+	deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+
+	roster, err := deps.service.RosterByActiveGroup(context.Background(), 684, false, activeGroupID)
+
+	require.NoError(t, err)
+	require.NotNil(t, roster)
+	assert.Equal(t, instanceID, roster.Instance.ID)
+}
+
+func TestTimetableOperationsPermissionBranches(t *testing.T) {
+	instanceID := int64(409)
+	activeGroupID := int64(296)
+
+	t.Run("assigned active supervisor can operate without instance staff assignment", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 675, 496, 256, instanceID)
+		deps.staffRepo.byInstance[instanceID] = nil
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+		deps.supervisors.byActiveGroup[activeGroupID] = []*activeModel.GroupSupervisor{{StaffID: 256}}
+
+		_, err := deps.service.Complete(context.Background(), 675, false, instanceID)
+
+		require.NoError(t, err)
+		assert.Equal(t, []int64{instanceID}, deps.instanceService.completed)
+	})
+
+	t.Run("unassigned staff is forbidden", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 676, 497, 257, instanceID)
+		deps.staffRepo.byInstance[instanceID] = []*scheduleModel.InstanceStaff{{StaffID: 258}}
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+
+		_, err := deps.service.Roster(context.Background(), 676, false, instanceID)
+
+		require.ErrorIs(t, err, ErrTimetableOperationForbidden)
+	})
+
+	t.Run("missing account id is forbidden before repository lookup", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+
+		_, err := deps.service.Roster(context.Background(), 0, false, instanceID)
+
+		require.ErrorIs(t, err, ErrTimetableOperationForbidden)
+	})
+
+	t.Run("missing person cannot use staff-only operations", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+
+		_, err := deps.service.Start(context.Background(), 677, false, instanceID)
+
+		require.ErrorIs(t, err, ErrTimetableOperationForbidden)
+	})
+}
+
+func TestTimetableOperationsCheckInBranches(t *testing.T) {
+	instanceID := int64(410)
+	activeGroupID := int64(297)
+	studentID := int64(557)
+
+	t.Run("rejects planned instance", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 678, 498, 259, instanceID)
+		deps.instanceRepo.byID[instanceID] = instanceWithTimes(instanceID, scheduleModel.InstanceStatusPlanned, time.Now(), time.Now().Add(time.Hour))
+
+		_, err := deps.service.CheckInStudent(context.Background(), 678, false, instanceID, studentID)
+
+		require.ErrorIs(t, err, ErrTimetableOperationConflict)
+	})
+
+	t.Run("marks planned present when active visit already belongs to same group", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 679, 499, 260, instanceID)
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+		row := &scheduleModel.InstanceStudent{InstanceID: instanceID, StudentID: studentID, Status: scheduleModel.AttendanceStatusExpected}
+		row.ID = 411
+		deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, studentID}] = row
+		deps.studentRepo.byInstance[instanceID] = []*scheduleModel.InstanceStudent{row}
+		deps.visitRepo.currentByStudent[studentID] = &activeModel.Visit{StudentID: studentID, ActiveGroupID: activeGroupID, EntryTime: time.Now()}
+		deps.visitRepo.byActiveGroup[activeGroupID] = []*activeModel.Visit{deps.visitRepo.currentByStudent[studentID]}
+		deps.students.byID[studentID] = &usersModel.Student{PersonID: 500, SchoolClass: "4a"}
+		deps.personService.people[500] = &usersModel.Person{FirstName: "Tom", LastName: "Test"}
+
+		_, err := deps.service.CheckInStudent(context.Background(), 679, false, instanceID, studentID)
+
+		require.NoError(t, err)
+		assert.Empty(t, deps.activeService.created)
+		require.Len(t, deps.studentRepo.updates, 1)
+		assert.Equal(t, int64(411), deps.studentRepo.updates[0].rowID)
+	})
+
+	t.Run("does not fail when active group last-activity update fails", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 680, 501, 261, instanceID)
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+		deps.activeGroups.updateErr = errors.New("update failed")
+		deps.students.byID[studentID] = &usersModel.Student{PersonID: 502, SchoolClass: "4a"}
+		deps.personService.people[502] = &usersModel.Person{FirstName: "Noa", LastName: "Neben"}
+
+		_, err := deps.service.CheckInStudent(context.Background(), 680, false, instanceID, studentID)
+
+		require.NoError(t, err)
+		require.Len(t, deps.activeService.created, 1)
+	})
+
+	t.Run("propagates visit creation errors", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 687, 509, 267, instanceID)
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+		deps.activeService.createErr = errors.New("create visit failed")
+
+		result, err := deps.service.CheckInStudent(context.Background(), 687, false, instanceID, studentID)
+
+		require.EqualError(t, err, "create visit failed")
+		assert.Nil(t, result)
+	})
+
+	t.Run("propagates attendance update errors after visit creation", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 688, 510, 268, instanceID)
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+		row := &scheduleModel.InstanceStudent{InstanceID: instanceID, StudentID: studentID, Status: scheduleModel.AttendanceStatusExpected}
+		row.ID = 420
+		deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, studentID}] = row
+		deps.studentRepo.updateErr = errors.New("attendance update failed")
+
+		result, err := deps.service.CheckInStudent(context.Background(), 688, false, instanceID, studentID)
+
+		require.EqualError(t, err, "attendance update failed")
+		assert.Nil(t, result)
+		require.Len(t, deps.activeService.created, 1)
+	})
+}
+
+func TestTimetableOperationsCheckOutBranches(t *testing.T) {
+	instanceID := int64(412)
+	deps := newTimetableOpsDeps()
+	wireAssignedStaff(deps, 681, 503, 262, instanceID)
+	deps.instanceRepo.byID[instanceID] = instanceWithTimes(instanceID, scheduleModel.InstanceStatusActive, time.Now(), time.Now().Add(time.Hour))
+
+	_, err := deps.service.CheckOutStudent(context.Background(), 681, false, instanceID, 558)
+
+	require.ErrorIs(t, err, ErrTimetableOperationConflict)
+
+	deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, 298)
+	_, err = deps.service.CheckOutStudent(context.Background(), 681, false, instanceID, 558)
+	require.ErrorIs(t, err, ErrTimetableOperationNotFound)
+}
+
+func TestTimetableOperationsPatchAttendanceBranches(t *testing.T) {
+	deps := newTimetableOpsDeps()
+	instanceID := int64(413)
+	wireAssignedStaff(deps, 682, 504, 263, instanceID)
+	deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, 299)
+
+	row, err := deps.service.PatchAttendance(context.Background(), 682, false, instanceID, 559, scheduleModel.AttendanceFieldPatch{})
+
+	require.ErrorIs(t, err, ErrTimetableOperationNotFound)
+	assert.Nil(t, row)
+}
+
+func TestTimetableOperationsDependencyErrorsPropagate(t *testing.T) {
+	instanceID := int64(417)
+	activeGroupID := int64(302)
+
+	t.Run("check-out propagates end visit errors", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 685, 507, 265, instanceID)
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+		visit := &activeModel.Visit{StudentID: 561, ActiveGroupID: activeGroupID, EntryTime: time.Now()}
+		visit.ID = 418
+		deps.visitRepo.byActiveGroup[activeGroupID] = []*activeModel.Visit{visit}
+		deps.activeService.endErr = errors.New("end failed")
+
+		result, err := deps.service.CheckOutStudent(context.Background(), 685, false, instanceID, 561)
+
+		require.EqualError(t, err, "end failed")
+		assert.Nil(t, result)
+	})
+
+	t.Run("patch propagates update errors", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 686, 508, 266, instanceID)
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+		row := &scheduleModel.InstanceStudent{InstanceID: instanceID, StudentID: 562, Status: scheduleModel.AttendanceStatusExpected}
+		row.ID = 419
+		deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, 562}] = row
+		deps.studentRepo.updateErr = errors.New("update failed")
+
+		result, err := deps.service.PatchAttendance(context.Background(), 686, false, instanceID, 562, scheduleModel.AttendanceFieldPatch{})
+
+		require.EqualError(t, err, "update failed")
+		assert.Nil(t, result)
+	})
+
+	t.Run("patch propagates roster rebuild errors", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 689, 511, 269, instanceID)
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+		row := &scheduleModel.InstanceStudent{InstanceID: instanceID, StudentID: 563, Status: scheduleModel.AttendanceStatusExpected}
+		row.ID = 421
+		deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, 563}] = row
+		deps.studentRepo.err = errors.New("roster failed")
+
+		result, err := deps.service.PatchAttendance(context.Background(), 689, false, instanceID, 563, scheduleModel.AttendanceFieldPatch{})
+
+		require.EqualError(t, err, "roster failed")
+		assert.Nil(t, result)
+	})
+
+	t.Run("patch returns not found when rebuilt roster omits student", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		wireAssignedStaff(deps, 690, 512, 270, instanceID)
+		deps.instanceRepo.byID[instanceID] = activeInstance(instanceID, activeGroupID)
+		row := &scheduleModel.InstanceStudent{InstanceID: instanceID, StudentID: 564, Status: scheduleModel.AttendanceStatusExpected}
+		row.ID = 422
+		deps.studentRepo.byInstanceStudent[instanceStudentKey{instanceID, 564}] = row
+
+		result, err := deps.service.PatchAttendance(context.Background(), 690, false, instanceID, 564, scheduleModel.AttendanceFieldPatch{})
+
+		require.ErrorIs(t, err, ErrTimetableOperationNotFound)
+		assert.Nil(t, result)
+	})
+
+	t.Run("load instance propagates ordinary repository errors", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		deps.instanceRepo.err = errors.New("db down")
+
+		inst, err := deps.service.(*timetableOperationsService).loadInstance(context.Background(), instanceID)
+
+		require.EqualError(t, err, "db down")
+		assert.Nil(t, inst)
+	})
+}
+
+func TestTimetableOperationsBroadcastBranches(t *testing.T) {
+	ctx := tenant.WithTenantID(context.Background(), 722)
+
+	t.Run("skips when broadcaster is nil", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		deps.service.(*timetableOperationsService).deps.Broadcaster = nil
+
+		deps.service.(*timetableOperationsService).broadcastAttendanceChanged(ctx, 414, 560)
+	})
+
+	t.Run("skips inactive instance without active group", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		deps.instanceRepo.byID[414] = instanceWithTimes(414, scheduleModel.InstanceStatusPlanned, time.Now(), time.Now().Add(time.Hour))
+
+		deps.service.(*timetableOperationsService).broadcastAttendanceChanged(ctx, 414, 560)
+
+		assert.Empty(t, deps.broadcaster.events)
+	})
+
+	t.Run("logs and continues when broadcast fails", func(t *testing.T) {
+		deps := newTimetableOpsDeps()
+		deps.broadcaster.err = errors.New("send failed")
+		deps.instanceRepo.byID[414] = activeInstance(414, 300)
+
+		deps.service.(*timetableOperationsService).broadcastAttendanceChanged(ctx, 414, 560)
+
+		require.Len(t, deps.broadcaster.events, 1)
+	})
+}
+
+func TestTimetableOperationsDependencyAndErrorBranches(t *testing.T) {
+	assert.Panics(t, func() {
+		NewTimetableOperationsService(TimetableOperationsDependencies{})
+	})
+
+	deps := newTimetableOpsDeps()
+	deps.settings.err = errors.New("settings down")
+	assert.False(t, deps.service.(*timetableOperationsService).adminOverviewEnabled(context.Background(), true))
+	assert.False(t, deps.service.(*timetableOperationsService).adminOverviewEnabled(context.Background(), false))
+
+	deps.personService.accountPerson = &usersModel.Person{}
+	deps.personService.accountPerson.ID = 505
+	deps.personService.staffErr = sql.ErrNoRows
+	staffID, hasStaff, err := deps.service.(*timetableOperationsService).resolveStaffID(context.Background(), 683)
+	require.NoError(t, err)
+	assert.Zero(t, staffID)
+	assert.False(t, hasStaff)
+
+	deps.instanceRepo.err = sql.ErrNoRows
+	inst, err := deps.service.(*timetableOperationsService).loadInstance(context.Background(), 415)
+	require.ErrorIs(t, err, ErrTimetableOperationNotFound)
+	assert.Nil(t, inst)
+}
+
+func TestTimetableOperationHelpers(t *testing.T) {
+	now := time.Date(2026, time.May, 10, 14, 0, 0, 0, time.UTC)
+	assert.True(t, plannedNowWindow(instanceWithTimes(406, scheduleModel.InstanceStatusPlanned, now.Add(-16*time.Minute), now), now))
+	assert.True(t, plannedNowWindow(instanceWithTimes(407, scheduleModel.InstanceStatusPlanned, now.Add(14*time.Minute), now), now))
+	assert.False(t, plannedNowWindow(instanceWithTimes(408, scheduleModel.InstanceStatusPlanned, now.Add(16*time.Minute), now), now))
+	assert.True(t, staffAssigned([]*scheduleModel.InstanceStaff{{StaffID: 255}}, 255))
+	assert.False(t, staffAssigned([]*scheduleModel.InstanceStaff{{StaffID: 255, IsAbsent: true}}, 255))
+	planned, ok := findPlanned([]*scheduleModel.InstanceStudent{{StudentID: 556}}, 556)
+	require.True(t, ok)
+	assert.Equal(t, int64(556), planned.StudentID)
+	assert.False(t, isNoRows(errors.New("ordinary error")))
+}
+
+func wireAssignedStaff(deps *timetableOpsTestDeps, accountID, personID, staffID, instanceID int64) {
+	deps.personService.accountPerson = &usersModel.Person{}
+	deps.personService.accountPerson.ID = personID
+	deps.personService.staffByPersonID[personID] = &usersModel.Staff{}
+	deps.personService.staffByPersonID[personID].ID = staffID
+	deps.staffRepo.byInstance[instanceID] = []*scheduleModel.InstanceStaff{{StaffID: staffID}}
+}
+
+func instanceWithTimes(id int64, status string, start, end time.Time) *scheduleModel.ActivityInstance {
+	inst := &scheduleModel.ActivityInstance{
+		Date:      time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC),
+		Title:     "Lernzeit",
+		StartTime: start,
+		EndTime:   end,
+		RoomID:    810,
+		Status:    status,
+	}
+	inst.ID = id
+	return inst
+}
+
+func activeInstance(id, activeGroupID int64) *scheduleModel.ActivityInstance {
+	inst := instanceWithTimes(id, scheduleModel.InstanceStatusActive, time.Date(2026, time.May, 10, 14, 0, 0, 0, time.UTC), time.Date(2026, time.May, 10, 15, 0, 0, 0, time.UTC))
+	inst.ID = id
+	inst.ActiveGroupID = &activeGroupID
+	return inst
+}
+
+type timetableOpsTestDeps struct {
+	service         TimetableOperationsService
+	instanceRepo    *fakeOpsInstanceRepo
+	staffRepo       *fakeOpsStaffRepo
+	studentRepo     *fakeOpsInstanceStudentRepo
+	instanceService *fakeOpsInstanceService
+	activeGroups    *fakeOpsActiveGroupRepo
+	activeService   *fakeOpsActiveService
+	supervisors     *fakeOpsSupervisorRepo
+	visitRepo       *fakeOpsVisitRepo
+	students        *fakeOpsStudentRepo
+	groups          *fakeOpsEducationGroupRepo
+	personService   *fakeOpsPersonService
+	settings        *fakeOpsSettings
+	broadcaster     *fakeOpsBroadcaster
+}
+
+func newTimetableOpsDeps() *timetableOpsTestDeps {
+	deps := &timetableOpsTestDeps{
+		instanceRepo:    &fakeOpsInstanceRepo{byID: map[int64]*scheduleModel.ActivityInstance{}},
+		staffRepo:       &fakeOpsStaffRepo{byInstance: map[int64][]*scheduleModel.InstanceStaff{}},
+		studentRepo:     &fakeOpsInstanceStudentRepo{byInstance: map[int64][]*scheduleModel.InstanceStudent{}, byInstanceStudent: map[instanceStudentKey]*scheduleModel.InstanceStudent{}},
+		instanceService: &fakeOpsInstanceService{},
+		activeGroups:    &fakeOpsActiveGroupRepo{lastActivity: map[int64]time.Time{}},
+		activeService:   &fakeOpsActiveService{},
+		supervisors:     &fakeOpsSupervisorRepo{byActiveGroup: map[int64][]*activeModel.GroupSupervisor{}},
+		visitRepo:       &fakeOpsVisitRepo{byActiveGroup: map[int64][]*activeModel.Visit{}, currentByStudent: map[int64]*activeModel.Visit{}},
+		students:        &fakeOpsStudentRepo{byID: map[int64]*usersModel.Student{}},
+		groups:          &fakeOpsEducationGroupRepo{byID: map[int64]*educationModel.Group{}},
+		personService:   &fakeOpsPersonService{people: map[int64]*usersModel.Person{}, staffByPersonID: map[int64]*usersModel.Staff{}},
+		settings:        &fakeOpsSettings{},
+		broadcaster:     &fakeOpsBroadcaster{},
+	}
+	deps.service = NewTimetableOperationsService(TimetableOperationsDependencies{
+		InstanceRepo:       deps.instanceRepo,
+		InstanceStaffRepo:  deps.staffRepo,
+		InstanceStudents:   deps.studentRepo,
+		InstanceService:    deps.instanceService,
+		ActiveGroupRepo:    deps.activeGroups,
+		ActiveService:      deps.activeService,
+		SupervisorRepo:     deps.supervisors,
+		VisitRepo:          deps.visitRepo,
+		StudentRepo:        deps.students,
+		EducationGroupRepo: deps.groups,
+		PersonService:      deps.personService,
+		Settings:           deps.settings,
+		Broadcaster:        deps.broadcaster,
+		DB:                 &bun.DB{},
+	})
+	return deps
+}
+
+type fakeOpsInstanceRepo struct {
+	scheduleModel.ActivityInstanceRepository
+	byID          map[int64]*scheduleModel.ActivityInstance
+	byDate        []*scheduleModel.ActivityInstance
+	err           error
+	findByDateErr error
+}
+
+func (r *fakeOpsInstanceRepo) FindByID(_ context.Context, id interface{}) (*scheduleModel.ActivityInstance, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.byID[id.(int64)], nil
+}
+
+func (r *fakeOpsInstanceRepo) FindByTenantAndDate(_ context.Context, _ time.Time) ([]*scheduleModel.ActivityInstance, error) {
+	if r.findByDateErr != nil {
+		return nil, r.findByDateErr
+	}
+	return r.byDate, nil
+}
+
+func (r *fakeOpsInstanceRepo) FindByActiveGroupID(_ context.Context, activeGroupID int64) (*scheduleModel.ActivityInstance, error) {
+	for _, inst := range r.byID {
+		if inst.ActiveGroupID != nil && *inst.ActiveGroupID == activeGroupID {
+			return inst, nil
+		}
+	}
+	return nil, nil
+}
+
+type fakeOpsStaffRepo struct {
+	scheduleModel.InstanceStaffRepository
+	byInstance map[int64][]*scheduleModel.InstanceStaff
+	err        error
+}
+
+func (r *fakeOpsStaffRepo) FindByInstanceID(_ context.Context, instanceID int64) ([]*scheduleModel.InstanceStaff, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.byInstance[instanceID], nil
+}
+
+type instanceStudentKey struct {
+	instanceID int64
+	studentID  int64
+}
+
+type fakeOpsInstanceStudentRepo struct {
+	scheduleModel.InstanceStudentRepository
+	byInstance        map[int64][]*scheduleModel.InstanceStudent
+	byInstanceStudent map[instanceStudentKey]*scheduleModel.InstanceStudent
+	err               error
+	updateErr         error
+	updates           []struct {
+		rowID int64
+		patch scheduleModel.AttendanceFieldPatch
+	}
+}
+
+func (r *fakeOpsInstanceStudentRepo) FindByInstanceID(_ context.Context, instanceID int64) ([]*scheduleModel.InstanceStudent, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.byInstance[instanceID], nil
+}
+
+func (r *fakeOpsInstanceStudentRepo) FindByInstanceAndStudent(_ context.Context, instanceID, studentID int64) (*scheduleModel.InstanceStudent, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.byInstanceStudent[instanceStudentKey{instanceID, studentID}], nil
+}
+
+func (r *fakeOpsInstanceStudentRepo) UpdateAttendanceFields(_ context.Context, id int64, patch scheduleModel.AttendanceFieldPatch) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	r.updates = append(r.updates, struct {
+		rowID int64
+		patch scheduleModel.AttendanceFieldPatch
+	}{rowID: id, patch: patch})
+	return nil
+}
+
+type fakeOpsInstanceService struct {
+	InstanceService
+	started   []struct{ instanceID, staffID int64 }
+	completed []int64
+}
+
+func (s *fakeOpsInstanceService) Start(_ context.Context, instanceID, startedByStaffID int64) (*StartInstanceResult, error) {
+	s.started = append(s.started, struct{ instanceID, staffID int64 }{instanceID: instanceID, staffID: startedByStaffID})
+	inst := &scheduleModel.ActivityInstance{Status: scheduleModel.InstanceStatusActive}
+	inst.ID = instanceID
+	return &StartInstanceResult{Instance: inst, ActiveGroupID: 910}, nil
+}
+
+func (s *fakeOpsInstanceService) Complete(_ context.Context, instanceID int64) (*scheduleModel.ActivityInstance, error) {
+	s.completed = append(s.completed, instanceID)
+	inst := &scheduleModel.ActivityInstance{Status: scheduleModel.InstanceStatusCompleted}
+	inst.ID = instanceID
+	return inst, nil
+}
+
+type fakeOpsActiveGroupRepo struct {
+	activeModel.GroupRepository
+	lastActivity map[int64]time.Time
+	updateErr    error
+}
+
+func (r *fakeOpsActiveGroupRepo) UpdateLastActivity(_ context.Context, id int64, lastActivity time.Time) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	r.lastActivity[id] = lastActivity
+	return nil
+}
+
+type fakeOpsActiveService struct {
+	created   []*activeModel.Visit
+	ended     []int64
+	createErr error
+	endErr    error
+}
+
+func (s *fakeOpsActiveService) CreateVisit(_ context.Context, visit *activeModel.Visit) error {
+	if s.createErr != nil {
+		return s.createErr
+	}
+	s.created = append(s.created, visit)
+	return nil
+}
+
+func (s *fakeOpsActiveService) EndVisit(_ context.Context, id int64) error {
+	if s.endErr != nil {
+		return s.endErr
+	}
+	s.ended = append(s.ended, id)
+	return nil
+}
+
+type fakeOpsSupervisorRepo struct {
+	activeModel.GroupSupervisorRepository
+	byActiveGroup map[int64][]*activeModel.GroupSupervisor
+}
+
+func (r *fakeOpsSupervisorRepo) FindByActiveGroupID(_ context.Context, activeGroupID int64, _ bool) ([]*activeModel.GroupSupervisor, error) {
+	return r.byActiveGroup[activeGroupID], nil
+}
+
+type fakeOpsVisitRepo struct {
+	activeModel.VisitRepository
+	byActiveGroup    map[int64][]*activeModel.Visit
+	currentByStudent map[int64]*activeModel.Visit
+}
+
+func (r *fakeOpsVisitRepo) FindByActiveGroupID(_ context.Context, activeGroupID int64) ([]*activeModel.Visit, error) {
+	return r.byActiveGroup[activeGroupID], nil
+}
+
+func (r *fakeOpsVisitRepo) GetCurrentByStudentID(_ context.Context, studentID int64) (*activeModel.Visit, error) {
+	return r.currentByStudent[studentID], nil
+}
+
+type fakeOpsStudentRepo struct {
+	usersModel.StudentRepository
+	byID map[int64]*usersModel.Student
+}
+
+func (r *fakeOpsStudentRepo) FindByIDs(_ context.Context, ids []int64) (map[int64]*usersModel.Student, error) {
+	out := map[int64]*usersModel.Student{}
+	for _, id := range ids {
+		if st := r.byID[id]; st != nil {
+			out[id] = st
+		}
+	}
+	return out, nil
+}
+
+type fakeOpsEducationGroupRepo struct {
+	educationModel.GroupRepository
+	byID map[int64]*educationModel.Group
+}
+
+func (r *fakeOpsEducationGroupRepo) FindByIDs(_ context.Context, ids []int64) (map[int64]*educationModel.Group, error) {
+	out := map[int64]*educationModel.Group{}
+	for _, id := range ids {
+		if group := r.byID[id]; group != nil {
+			out[id] = group
+		}
+	}
+	return out, nil
+}
+
+type fakeOpsPersonService struct {
+	accountPerson   *usersModel.Person
+	people          map[int64]*usersModel.Person
+	staffByPersonID map[int64]*usersModel.Staff
+	staffErr        error
+}
+
+func (s *fakeOpsPersonService) FindByAccountID(_ context.Context, _ int64) (*usersModel.Person, error) {
+	return s.accountPerson, nil
+}
+
+func (s *fakeOpsPersonService) GetByIDs(_ context.Context, ids []int64) (map[int64]*usersModel.Person, error) {
+	out := map[int64]*usersModel.Person{}
+	for _, id := range ids {
+		if person := s.people[id]; person != nil {
+			out[id] = person
+		}
+	}
+	return out, nil
+}
+
+func (s *fakeOpsPersonService) StaffRepository() usersModel.StaffRepository {
+	return fakeOpsStaffByPersonRepo{s: s}
+}
+
+type fakeOpsStaffByPersonRepo struct {
+	usersModel.StaffRepository
+	s *fakeOpsPersonService
+}
+
+func (r fakeOpsStaffByPersonRepo) FindByPersonID(_ context.Context, personID int64) (*usersModel.Staff, error) {
+	if r.s.staffErr != nil {
+		return nil, r.s.staffErr
+	}
+	return r.s.staffByPersonID[personID], nil
+}
+
+type fakeOpsSettings struct {
+	enabled bool
+	err     error
+}
+
+func (s *fakeOpsSettings) ResolveBool(_ context.Context, _ string) (bool, error) {
+	return s.enabled, s.err
+}
+
+type fakeOpsBroadcaster struct {
+	err    error
+	events []struct {
+		tenantID int64
+		event    realtime.Event
+	}
+}
+
+func (b *fakeOpsBroadcaster) BroadcastToTenant(tenantID int64, event realtime.Event) error {
+	b.events = append(b.events, struct {
+		tenantID int64
+		event    realtime.Event
+	}{tenantID: tenantID, event: event})
+	return b.err
+}
+
+func (b *fakeOpsBroadcaster) BroadcastToGroup(tenantID int64, _ string, event realtime.Event) error {
+	return b.BroadcastToTenant(tenantID, event)
+}
+
+func (b *fakeOpsBroadcaster) BroadcastToAll(event realtime.Event) error {
+	b.events = append(b.events, struct {
+		tenantID int64
+		event    realtime.Event
+	}{event: event})
+	return nil
+}

--- a/backend/services/scheduler/overdue_test.go
+++ b/backend/services/scheduler/overdue_test.go
@@ -169,13 +169,19 @@ func TestOverdueTick_BroadcastsOncePerInstance(t *testing.T) {
 
 	s.sched.runOverdueForTenant(s.ctx, 1, 5, s.now)
 
-	assert.Equal(t, 1, spyFilter(s.spy, ai.ID), "one broadcast for the seeded instance expected")
+	assert.Equal(t, 1, spyFilter(s.spy, ai.ID, realtime.EventInstanceOverdue), "one overdue broadcast for the seeded instance expected")
+	assert.Equal(t, 1, spyFilter(s.spy, ai.ID, realtime.EventActiveSupervisionChanged), "one active supervision refresh broadcast expected")
 
-	evt := spyFindByInstance(s.spy, ai.ID)
+	evt := spyFindByInstance(s.spy, ai.ID, realtime.EventInstanceOverdue)
 	require.NotNil(t, evt, "expected broadcast for instance id %d", ai.ID)
 	assert.Equal(t, realtime.EventInstanceOverdue, evt.Type)
 	require.NotNil(t, evt.Data.InstanceID)
 	assert.Equal(t, fmt.Sprintf("%d", ai.ID), *evt.Data.InstanceID)
+
+	refresh := spyFindByInstance(s.spy, ai.ID, realtime.EventActiveSupervisionChanged)
+	require.NotNil(t, refresh, "expected active supervision refresh for instance id %d", ai.ID)
+	require.NotNil(t, refresh.Data.Reason)
+	assert.Equal(t, "instance_overdue", *refresh.Data.Reason)
 }
 
 func TestOverdueTick_ReFireGuard(t *testing.T) {
@@ -186,7 +192,8 @@ func TestOverdueTick_ReFireGuard(t *testing.T) {
 	s.sched.runOverdueForTenant(s.ctx, 1, 5, s.now)
 	s.sched.runOverdueForTenant(s.ctx, 1, 5, s.now)
 
-	assert.Equal(t, 1, spyFilter(s.spy, ai.ID), "second tick on same instance must be suppressed")
+	assert.Equal(t, 1, spyFilter(s.spy, ai.ID, realtime.EventInstanceOverdue), "second tick on same instance must suppress overdue event")
+	assert.Equal(t, 1, spyFilter(s.spy, ai.ID, realtime.EventActiveSupervisionChanged), "second tick on same instance must suppress active supervision refresh")
 }
 
 func TestOverdueTick_ActiveInstancesNotBroadcast(t *testing.T) {
@@ -197,20 +204,21 @@ func TestOverdueTick_ActiveInstancesNotBroadcast(t *testing.T) {
 
 	s.sched.runOverdueForTenant(s.ctx, 1, 5, s.now)
 
-	assert.Equal(t, 0, spyFilter(s.spy, ai.ID), "active instances must not trigger overdue broadcast")
+	assert.Equal(t, 0, spyFilter(s.spy, ai.ID, realtime.EventInstanceOverdue), "active instances must not trigger overdue broadcast")
+	assert.Equal(t, 0, spyFilter(s.spy, ai.ID, realtime.EventActiveSupervisionChanged), "active instances must not trigger active supervision refresh")
 }
 
 // spyFilter counts broadcasts whose InstanceID matches the given id. Needed
 // because the test DB is shared across runs and may contain unrelated
 // today-dated rows from other tests; we care only about our fixture's
 // fire count, not the grand total.
-func spyFilter(b *spyBroadcaster, instanceID int64) int {
+func spyFilter(b *spyBroadcaster, instanceID int64, eventType realtime.EventType) int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	n := 0
 	needle := fmt.Sprintf("%d", instanceID)
 	for _, e := range b.all {
-		if e.Data.InstanceID != nil && *e.Data.InstanceID == needle {
+		if e.Type == eventType && e.Data.InstanceID != nil && *e.Data.InstanceID == needle {
 			n++
 		}
 	}
@@ -219,12 +227,12 @@ func spyFilter(b *spyBroadcaster, instanceID int64) int {
 
 // spyFindByInstance returns the first recorded event matching instanceID,
 // or nil if none. Companion to spyFilter for envelope-shape assertions.
-func spyFindByInstance(b *spyBroadcaster, instanceID int64) *realtime.Event {
+func spyFindByInstance(b *spyBroadcaster, instanceID int64, eventType realtime.EventType) *realtime.Event {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	needle := fmt.Sprintf("%d", instanceID)
 	for i := range b.all {
-		if b.all[i].Data.InstanceID != nil && *b.all[i].Data.InstanceID == needle {
+		if b.all[i].Type == eventType && b.all[i].Data.InstanceID != nil && *b.all[i].Data.InstanceID == needle {
 			return &b.all[i]
 		}
 	}

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -561,14 +561,72 @@ func (s *Scheduler) executeSessionEnd(task *ScheduledTask) {
 			s.getLogger().Error("session end failed", "error", err)
 			return nil
 		}
+		timetableCompleted, err := s.completeTimetableInstancesForEndedSessions(tenantCtx, result)
+		if err != nil {
+			s.getLogger().Error("session end timetable sync failed",
+				slog.String("error", err.Error()),
+			)
+			return err
+		}
 		if result.SessionsEnded > 0 {
 			s.getLogger().Info("session end completed",
 				slog.Int("sessions_ended", result.SessionsEnded),
 				slog.Int("visits_ended", result.VisitsEnded),
+				slog.Int("timetable_instances_completed", timetableCompleted),
 			)
 		}
 		return nil
 	})
+}
+
+// completeTimetableInstancesForEndedSessions closes the schedule-side rows
+// linked to active.groups that the daily session-end job just closed.
+//
+// The active service owns active.groups/visits/supervisors; timetable
+// instances live in schedule.*, so the scheduler bridges the two inside the
+// tenant transaction created by ForEachActive. If this sync fails, callers
+// return the error so the active close rolls back too instead of leaving the
+// planner in a stale "active" state.
+func (s *Scheduler) completeTimetableInstancesForEndedSessions(ctx context.Context, result *active.DailySessionCleanupResult) (int, error) {
+	if result == nil || len(result.EndedActiveGroupIDs) == 0 || s.db == nil {
+		return 0, nil
+	}
+
+	db := repoBase.GetDB(ctx, s.db)
+	now := time.Now()
+
+	if _, err := db.NewUpdate().
+		TableExpr(`schedule.instance_students AS "student"`).
+		Set("status = ?", scheduleModel.AttendanceStatusAbsent).
+		Set("updated_at = ?", now).
+		Where(`"student".status = ?`, scheduleModel.AttendanceStatusExpected).
+		Where(`"student".instance_id IN (
+			SELECT "instance".id
+			FROM schedule.activity_instances AS "instance"
+			WHERE "instance".status = ?
+				AND "instance".active_group_id IN (?)
+		)`, scheduleModel.InstanceStatusActive, bun.List(result.EndedActiveGroupIDs)).
+		Exec(ctx); err != nil {
+		return 0, fmt.Errorf("mark expected timetable students absent: %w", err)
+	}
+
+	res, err := db.NewUpdate().
+		TableExpr(`schedule.activity_instances AS "instance"`).
+		Set("status = ?", scheduleModel.InstanceStatusCompleted).
+		Set("completed_at = ?", now).
+		Set("updated_at = ?", now).
+		Where(`"instance".status = ?`, scheduleModel.InstanceStatusActive).
+		Where(`"instance".active_group_id IN (?)`, bun.List(result.EndedActiveGroupIDs)).
+		Exec(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("complete active timetable instances: %w", err)
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("complete active timetable instances rows affected: %w", err)
+	}
+	return int(rows), nil
 }
 
 // executeSessionCleanup runs session cleanup for all tenants (backward-compatible wrapper).
@@ -898,12 +956,21 @@ func (s *Scheduler) checkAndRunSessionEnd(task *ScheduledTask) {
 			)
 			return nil // don't fail other tenants
 		}
+		timetableCompleted, err := s.completeTimetableInstancesForEndedSessions(endCtx, result)
+		if err != nil {
+			s.getLogger().Error("session end timetable sync failed for tenant",
+				slog.Int64("tenant_id", tenantID),
+				slog.String("error", err.Error()),
+			)
+			return err
+		}
 
 		s.getLogger().Info("session end completed for tenant",
 			slog.Int64("tenant_id", tenantID),
 			slog.Int("sessions_ended", result.SessionsEnded),
 			slog.Int("visits_ended", result.VisitsEnded),
 			slog.Int("supervisors_ended", result.SupervisorsEnded),
+			slog.Int("timetable_instances_completed", timetableCompleted),
 		)
 
 		markRunToday(&s.lastSessionEnd, tenantID)

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -1741,10 +1741,6 @@ func (s *Scheduler) runOverdueForTenant(ctx context.Context, tenantID int64, thr
 	}
 }
 
-type tenantBroadcaster interface {
-	BroadcastToTenant(tenantID int64, event realtime.Event) error
-}
-
 // emitInstanceOverdue builds the SSE envelope and fires it tenant-wide:
 // a planned instance has no bridged active.group yet, so there is no group-
 // scoped topic to route through. Admin dashboard subscribers pick it up.
@@ -1760,16 +1756,21 @@ func (s *Scheduler) emitInstanceOverdue(ctx context.Context, tenantID int64, ins
 		InstanceStartTime: &instanceStart,
 		RoomID:            &roomIDStr,
 	})
-	tenantScopedBroadcaster, ok := s.overdueBroadcaster.(tenantBroadcaster)
-	if !ok {
-		s.getLogger().Warn("overdue tick: tenant broadcast unsupported",
+	if err := s.overdueBroadcaster.BroadcastToTenant(tenantID, event); err != nil {
+		s.getLogger().Warn("overdue tick: broadcast failed",
 			slog.Int64("tenant_id", tenantID),
 			slog.Int64("instance_id", inst.ID),
+			slog.String("error", err.Error()),
 		)
 		return
 	}
-	if err := tenantScopedBroadcaster.BroadcastToTenant(tenantID, event); err != nil {
-		s.getLogger().Warn("overdue tick: broadcast failed",
+	reason := "instance_overdue"
+	refreshEvent := realtime.NewEvent(realtime.EventActiveSupervisionChanged, "", realtime.EventData{
+		InstanceID: &instanceIDStr,
+		Reason:     &reason,
+	})
+	if err := s.overdueBroadcaster.BroadcastToTenant(tenantID, refreshEvent); err != nil {
+		s.getLogger().Warn("overdue tick: active supervision broadcast failed",
 			slog.Int64("tenant_id", tenantID),
 			slog.Int64("instance_id", inst.ID),
 			slog.String("error", err.Error()),

--- a/backend/services/scheduler/session_end_timetable_test.go
+++ b/backend/services/scheduler/session_end_timetable_test.go
@@ -1,0 +1,64 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompleteTimetableInstancesForEndedSessions(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	room := testpkg.CreateTestRoom(t, db, fmt.Sprintf("Daily Sync Room %d", time.Now().UnixNano()))
+	activity := testpkg.CreateTestActivityGroup(t, db, fmt.Sprintf("Daily Sync Activity %d", time.Now().UnixNano()))
+	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	student := testpkg.CreateTestStudent(t, db, "DailySync", "Student", "9z")
+
+	instance := testpkg.CreateTestActivityInstance(t, db, time.Now(), room.ID, testpkg.ActivityInstanceOpts{
+		Status:        scheduleModels.InstanceStatusActive,
+		ActiveGroupID: &activeGroup.ID,
+		Title:         fmt.Sprintf("Daily Sync Instance %d", time.Now().UnixNano()),
+		IsSpontaneous: true,
+	})
+	instanceStudent := testpkg.CreateTestInstanceStudent(t, db, instance.ID, student.ID, scheduleModels.AttendanceStatusExpected)
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "schedule.instance_students", instanceStudent.ID)
+		testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", instance.ID)
+		testpkg.CleanupActivityFixtures(t, db, activeGroup.ID, activity.ID, room.ID, student.ID)
+	})
+
+	s := &Scheduler{db: db, logger: slog.Default()}
+	completed, err := s.completeTimetableInstancesForEndedSessions(context.Background(), &activeSvc.DailySessionCleanupResult{
+		EndedActiveGroupIDs: []int64{activeGroup.ID},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, completed)
+
+	var reloaded scheduleModels.ActivityInstance
+	err = db.NewSelect().
+		Model(&reloaded).
+		ModelTableExpr(`schedule.activity_instances AS "activity_instance"`).
+		Where(`"activity_instance".id = ?`, instance.ID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, scheduleModels.InstanceStatusCompleted, reloaded.Status)
+	assert.NotNil(t, reloaded.CompletedAt)
+
+	var reloadedStudent scheduleModels.InstanceStudent
+	err = db.NewSelect().
+		Model(&reloadedStudent).
+		ModelTableExpr(`schedule.instance_students AS "instance_student"`).
+		Where(`"instance_student".id = ?`, instanceStudent.ID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, scheduleModels.AttendanceStatusAbsent, reloadedStudent.Status)
+}

--- a/docs/timetable-system-plan.md
+++ b/docs/timetable-system-plan.md
@@ -596,14 +596,15 @@ Two tracks: **all backend first, frontend after.** Each item is a **Work Package
 
 **Implementation cut:** F3 and F4 should ship together in one PR. F3 alone only shows planned work; F4 turns that card into the operational action that starts the planned instance and prevents duplicate unlinked live groups.
 
-- [ ] **WP-F3** — Planned items in `/active-supervisions` ("Jetzt geplant")
+- [x] **WP-F3** — Planned items in `/active-supervisions` ("Jetzt geplant") → current PR
   - Show planned instances for today in an operational window: `now - 15min` through `now + 15min`, plus overdue planned instances.
   - Cards show title, time, room, assigned staff, expected child count, conflict/gap status and a clear **Jetzt starten** action.
   - Prefer instances assigned to the current staff member; admins may see all when supervision overview is enabled.
-- [ ] **WP-F4** — Start planned instance from `/active-supervisions`
+- [x] **WP-F4** — Start planned instance from `/active-supervisions` → current PR
   - **Jetzt starten** calls `POST /api/timetable/instances/{id}/start`.
   - The resulting live `active.group` appears in the current supervision UI without requiring navigation back to the admin timetable.
   - Prevent confusing duplicate starts: when a matching planned instance exists, the staff flow should start that instance instead of creating an unlinked live group.
+  - **Bundled operational polish:** active-supervision dashboard now bridges timetable instances into the live roster flow, supports completion from the live view, avoids loading-state flashes, and handles timetable SSE invalidation for started/completed/cancelled/overdue events.
 - [ ] **WP-F5** — Instance detail/check-in list in active supervision
   - After start, show expected children from `instance_students` alongside live visits.
   - Support quick status changes: expected, present, absent, substatus/note where needed.

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
@@ -11,6 +11,10 @@ import {
 } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+const navigationMockState = vi.hoisted(() => ({
+  roomParam: null as string | null,
+}));
+
 // Mock auth-utils with hasRole that reads session roles
 vi.mock("~/lib/auth-utils", () => ({
   isAdmin: (session: { user?: { isAdmin?: boolean } } | null) =>
@@ -37,7 +41,10 @@ const mockPush = vi.fn();
 const mockRedirect = vi.fn();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
-  useSearchParams: () => ({ get: () => null }),
+  useSearchParams: () => ({
+    get: (key: string) =>
+      key === "room" ? navigationMockState.roomParam : null,
+  }),
   redirect: (url: string) => mockRedirect(url),
 }));
 
@@ -255,6 +262,7 @@ describe("MeinRaumPage (Active Supervisions)", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    navigationMockState.roomParam = null;
     global.fetch = vi.fn();
     // Default mock: loading state
     vi.mocked(useSWRAuth).mockReturnValue({
@@ -397,6 +405,203 @@ describe("MeinRaumPage (Active Supervisions)", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("student-card")).toBeInTheDocument();
+    });
+  });
+
+  it("does not flash student cards while timetable roster is still loading", async () => {
+    const dashboardData = {
+      supervisedGroups: [
+        { id: "1", name: "Raum 101", room: { id: "10", name: "Raum 101" } },
+      ],
+      unclaimedGroups: [],
+      currentStaff: { id: "1" },
+      educationalGroups: [
+        { id: "2", name: "OGS Gruppe A", room: { name: "Raum 101" } },
+      ],
+      firstRoomVisits: [
+        {
+          studentId: "100",
+          studentName: "Max Mustermann",
+          schoolClass: "1a",
+          groupName: "OGS Gruppe A",
+          activeGroupId: "1",
+          checkInTime: new Date().toISOString(),
+          isActive: true,
+        },
+      ],
+      firstRoomId: "10",
+    };
+
+    vi.mocked(useSWRAuth).mockImplementation(((key: string | null) => {
+      if (key?.startsWith("active-supervision-dashboard")) {
+        return {
+          data: dashboardData,
+          isLoading: false,
+          error: null,
+          mutate: mockMutate,
+          isValidating: false,
+        };
+      }
+
+      if (key?.startsWith("timetable-roster-active-group")) {
+        return {
+          data: undefined,
+          isLoading: true,
+          error: null,
+          mutate: mockMutate,
+          isValidating: false,
+        };
+      }
+
+      return {
+        data: null,
+        isLoading: false,
+        error: null,
+        mutate: mockMutate,
+        isValidating: false,
+      };
+    }) as never);
+
+    render(<MeinRaumPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toBeInTheDocument();
+      expect(screen.queryByTestId("student-card")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders timetable roster UI when an active roster is available", async () => {
+    const dashboardData = {
+      supervisedGroups: [
+        { id: "1", name: "Raum 101", room: { id: "10", name: "Raum 101" } },
+      ],
+      unclaimedGroups: [],
+      currentStaff: { id: "1" },
+      educationalGroups: [],
+      firstRoomVisits: [
+        {
+          studentId: "100",
+          studentName: "Max Mustermann",
+          schoolClass: "1a",
+          groupName: "OGS Gruppe A",
+          activeGroupId: "1",
+          checkInTime: new Date().toISOString(),
+          isActive: true,
+        },
+      ],
+      firstRoomId: "10",
+    };
+
+    vi.mocked(useSWRAuth).mockImplementation(((key: string | null) => {
+      if (key?.startsWith("active-supervision-dashboard")) {
+        return {
+          data: dashboardData,
+          isLoading: false,
+          error: null,
+          mutate: mockMutate,
+          isValidating: false,
+        };
+      }
+
+      if (key?.startsWith("timetable-roster-active-group")) {
+        return {
+          data: {
+            instance: { id: "99", title: "Kreativ AG" },
+            rows: [],
+          },
+          isLoading: false,
+          error: null,
+          mutate: mockMutate,
+          isValidating: false,
+        };
+      }
+
+      return {
+        data: null,
+        isLoading: false,
+        error: null,
+        mutate: mockMutate,
+        isValidating: false,
+      };
+    }) as never);
+
+    render(<MeinRaumPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Kreativ AG")).toBeInTheDocument();
+      expect(
+        screen.getByText("Laufende geplante Aktivität"),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("student-card")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not flash first-room students while a direct room URL is syncing", async () => {
+    navigationMockState.roomParam = "11";
+    const { activeService } = await import("~/lib/active-api");
+    vi.mocked(activeService.getActiveGroupVisitsWithDisplay).mockReturnValue(
+      new Promise(() => undefined) as never,
+    );
+    const dashboardData = {
+      supervisedGroups: [
+        {
+          id: "1",
+          name: "Raum 101",
+          room_id: "10",
+          room: { id: "10", name: "Raum 101" },
+        },
+        {
+          id: "2",
+          name: "Raum 102",
+          room_id: "11",
+          room: { id: "11", name: "Raum 102" },
+        },
+      ],
+      unclaimedGroups: [],
+      currentStaff: { id: "1" },
+      educationalGroups: [],
+      firstRoomVisits: [
+        {
+          studentId: "100",
+          studentName: "Max Mustermann",
+          schoolClass: "1a",
+          groupName: "OGS Gruppe A",
+          activeGroupId: "1",
+          checkInTime: new Date().toISOString(),
+          isActive: true,
+        },
+      ],
+      firstRoomId: "10",
+    };
+
+    vi.mocked(useSWRAuth).mockImplementation(((key: string | null) => {
+      if (key?.startsWith("active-supervision-dashboard")) {
+        return {
+          data: dashboardData,
+          isLoading: false,
+          error: null,
+          mutate: mockMutate,
+          isValidating: false,
+        };
+      }
+
+      return {
+        data: null,
+        isLoading: false,
+        error: null,
+        mutate: mockMutate,
+        isValidating: false,
+      };
+    }) as never);
+
+    render(<MeinRaumPage />);
+
+    await waitFor(() => {
+      expect(
+        activeService.getActiveGroupVisitsWithDisplay,
+      ).toHaveBeenCalledWith("2");
+      expect(screen.queryByTestId("student-card")).not.toBeInTheDocument();
+      expect(screen.queryByText("Max Mustermann")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
@@ -507,7 +507,73 @@ describe("MeinRaumPage (Active Supervisions)", () => {
         return {
           data: {
             instance: { id: "99", title: "Kreativ AG", activeGroupId: "1" },
-            rows: [],
+            rows: [
+              {
+                studentId: "100",
+                studentName: "Max Mustermann",
+                schoolClass: "1a",
+                groupName: "OGS Gruppe A",
+                planned: true,
+                isUnplanned: false,
+                currentlyPresent: true,
+                visitId: "visit-100",
+                status: "present",
+                substatus: null,
+                note: null,
+              },
+              {
+                studentId: "101",
+                studentName: "Erika Erwartet",
+                schoolClass: "2b",
+                groupName: "OGS Gruppe B",
+                planned: true,
+                isUnplanned: false,
+                currentlyPresent: false,
+                visitId: null,
+                status: "expected",
+                substatus: null,
+                note: null,
+              },
+              {
+                studentId: "102",
+                studentName: "Lina Krank",
+                schoolClass: "3c",
+                groupName: "OGS Gruppe C",
+                planned: true,
+                isUnplanned: false,
+                currentlyPresent: false,
+                visitId: null,
+                status: "absent",
+                substatus: "sick",
+                note: "Abgemeldet",
+              },
+              {
+                studentId: "103",
+                studentName: "Noah Gegangen",
+                schoolClass: "4d",
+                groupName: "OGS Gruppe D",
+                planned: true,
+                isUnplanned: false,
+                currentlyPresent: false,
+                visitId: "visit-103",
+                status: "present",
+                substatus: null,
+                note: null,
+              },
+              {
+                studentId: "104",
+                studentName: "Mia Spontan",
+                schoolClass: "1b",
+                groupName: "OGS Gruppe A",
+                planned: false,
+                isUnplanned: true,
+                currentlyPresent: true,
+                visitId: "visit-104",
+                status: "present",
+                substatus: null,
+                note: null,
+              },
+            ],
           },
           isLoading: false,
           error: null,
@@ -532,6 +598,20 @@ describe("MeinRaumPage (Active Supervisions)", () => {
       expect(
         screen.getByText("Laufende geplante Aktivität"),
       ).toBeInTheDocument();
+      expect(screen.getByText("Anwesend (1)")).toBeInTheDocument();
+      expect(screen.getByText("Erwartet (1)")).toBeInTheDocument();
+      expect(
+        screen.getByText("Entschuldigt / Abwesend (1)"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Nicht mehr im Raum (1)")).toBeInTheDocument();
+      expect(screen.getByText("Ungeplant (1)")).toBeInTheDocument();
+      expect(screen.getByText("Krank · Abgemeldet")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Einchecken" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getAllByRole("button", { name: "Raum verlassen" }),
+      ).toHaveLength(2);
       expect(screen.queryByTestId("student-card")).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
@@ -506,7 +506,7 @@ describe("MeinRaumPage (Active Supervisions)", () => {
       if (key?.startsWith("timetable-roster-active-group")) {
         return {
           data: {
-            instance: { id: "99", title: "Kreativ AG" },
+            instance: { id: "99", title: "Kreativ AG", activeGroupId: "1" },
             rows: [],
           },
           isLoading: false,

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -780,12 +780,24 @@ function MeinRaumPageContent() {
         throw err;
       }
     },
-    { keepPreviousData: true, revalidateOnFocus: false },
+    { keepPreviousData: false, revalidateOnFocus: false },
   );
-  const activeTimetableInstanceId = timetableRoster?.instance?.id ?? null;
+  const timetableRosterMatchesSelection =
+    timetableRoster !== undefined &&
+    timetableRoster !== null &&
+    (selectedTimetableInstanceId
+      ? timetableRoster.instance.id === selectedTimetableInstanceId
+      : !!currentRoomId &&
+        timetableRoster.instance.activeGroupId === currentRoomId);
+  const currentTimetableRoster = timetableRosterMatchesSelection
+    ? timetableRoster
+    : null;
+  const activeTimetableInstanceId =
+    currentTimetableRoster?.instance?.id ?? null;
   const isWaitingForTimetableRoster =
     timetableRosterKey !== null &&
-    timetableRoster === undefined &&
+    (timetableRoster === undefined ||
+      (timetableRoster !== null && !timetableRosterMatchesSelection)) &&
     isTimetableRosterLoading;
 
   useEffect(() => {
@@ -892,9 +904,19 @@ function MeinRaumPageContent() {
       try {
         setIsStartingInstance(instance.id);
         const result = await timetableOperationsApi.start(instance.id);
+        const startedRoom = allRooms.find(
+          (room) => room.room_id === instance.roomId,
+        );
         setSelectedTimetableInstanceId(instance.id);
         setSelectedRoomId(result.activeGroupId);
         setIsSchulhofTabSelected(false);
+        router.push(`/active-supervisions?room=${instance.roomId}`);
+        localStorage.setItem("sidebar-last-room", instance.roomId);
+        if (startedRoom?.room_name) {
+          localStorage.setItem("sidebar-last-room-name", startedRoom.room_name);
+        } else {
+          localStorage.removeItem("sidebar-last-room-name");
+        }
         await mutateDashboard();
         setRefreshKey((prev) => prev + 1);
       } catch (err) {
@@ -907,7 +929,7 @@ function MeinRaumPageContent() {
         setIsStartingInstance(null);
       }
     },
-    [mutateDashboard],
+    [allRooms, mutateDashboard, router],
   );
 
   const handleRosterAction = useCallback(
@@ -1097,6 +1119,7 @@ function MeinRaumPageContent() {
     if (!selectedRoom) return;
 
     setIsLoading(true);
+    setSelectedTimetableInstanceId(null);
     setSelectedRoomId(roomId);
     setStudents([]); // Clear current students
 
@@ -1256,24 +1279,24 @@ function MeinRaumPageContent() {
       return <ActiveSupervisionLoadingView />;
     }
 
-    if (timetableRoster) {
-      const present = timetableRoster.rows.filter(
+    if (currentTimetableRoster) {
+      const present = currentTimetableRoster.rows.filter(
         (row) => row.currentlyPresent && row.planned,
       );
-      const expected = timetableRoster.rows.filter(
+      const expected = currentTimetableRoster.rows.filter(
         (row) =>
           row.planned && !row.currentlyPresent && row.status === "expected",
       );
-      const absent = timetableRoster.rows.filter(
+      const absent = currentTimetableRoster.rows.filter(
         (row) =>
           row.planned && !row.currentlyPresent && row.status === "absent",
       );
-      const departed = timetableRoster.rows.filter(
+      const departed = currentTimetableRoster.rows.filter(
         (row) =>
           !row.currentlyPresent &&
           (row.status === "present" || (row.isUnplanned && row.visitId)),
       );
-      const unplanned = timetableRoster.rows.filter(
+      const unplanned = currentTimetableRoster.rows.filter(
         (row) => row.isUnplanned && row.currentlyPresent,
       );
       const renderRosterRow = (row: TimetableRosterRow) => (
@@ -1375,7 +1398,7 @@ function MeinRaumPageContent() {
           <div className="flex flex-col gap-3 rounded-lg border border-[#83CD2D]/40 bg-[#83CD2D]/10 p-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h2 className="text-base font-semibold text-gray-900">
-                {timetableRoster.instance.title}
+                {currentTimetableRoster.instance.title}
               </h2>
               <p className="text-sm text-gray-600">
                 Laufende geplante Aktivität
@@ -1677,6 +1700,7 @@ function MeinRaumPageContent() {
                         // Switch to Schulhof tab
                         setIsSchulhofTabSelected(true);
                         setSelectedRoomId(null);
+                        setSelectedTimetableInstanceId(null);
                         router.push("/active-supervisions?room=schulhof");
                         localStorage.setItem(
                           "sidebar-last-room",

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -579,8 +579,15 @@ function MeinRaumPageContent() {
     // Skip first-room preload when Schulhof tab is active — Schulhof uses
     // selectedRoomId=null intentionally, so !selectedRoomId would incorrectly
     // match and overwrite Schulhof students with first-room data.
+    const isUrlTargetingDifferentRoom =
+      !!roomParam &&
+      roomParam !== SCHULHOF_TAB_ID &&
+      activeRooms.some((room) => room.room_id === roomParam) &&
+      firstRoom?.room_id !== roomParam;
+
     if (
       !isSchulhofTabSelected &&
+      !isUrlTargetingDifferentRoom &&
       (!selectedRoomId || selectedRoomId === firstRoom?.id)
     ) {
       // When no room is explicitly selected yet, lock in the first room's ID
@@ -613,6 +620,7 @@ function MeinRaumPageContent() {
     updateRoomStudentCount,
     selectedRoomId,
     isSchulhofTabSelected,
+    roomParam,
   ]);
 
   // Sync selected room with URL param.
@@ -746,34 +754,39 @@ function MeinRaumPageContent() {
     : currentRoomId && !isSchulhofActive
       ? `timetable-roster-active-group-${currentRoomId}`
       : null;
-  const { data: timetableRoster, mutate: mutateRoster } =
-    useSWRAuth<TimetableRoster | null>(
-      timetableRosterKey,
-      async () => {
-        try {
-          if (selectedTimetableInstanceId) {
-            return await timetableOperationsApi.roster(
-              selectedTimetableInstanceId,
-            );
-          }
-          if (!currentRoomId) return null;
-          return await timetableOperationsApi.rosterByActiveGroup(
-            currentRoomId,
+  const {
+    data: timetableRoster,
+    isLoading: isTimetableRosterLoading,
+    mutate: mutateRoster,
+  } = useSWRAuth<TimetableRoster | null>(
+    timetableRosterKey,
+    async () => {
+      try {
+        if (selectedTimetableInstanceId) {
+          return await timetableOperationsApi.roster(
+            selectedTimetableInstanceId,
           );
-        } catch (err) {
-          if (
-            err instanceof Error &&
-            (err.message.includes("404") ||
-              err.message.toLowerCase().includes("not found"))
-          ) {
-            return null;
-          }
-          throw err;
         }
-      },
-      { keepPreviousData: true, revalidateOnFocus: false },
-    );
+        if (!currentRoomId) return null;
+        return await timetableOperationsApi.rosterByActiveGroup(currentRoomId);
+      } catch (err) {
+        if (
+          err instanceof Error &&
+          (err.message.includes("404") ||
+            err.message.toLowerCase().includes("not found"))
+        ) {
+          return null;
+        }
+        throw err;
+      }
+    },
+    { keepPreviousData: true, revalidateOnFocus: false },
+  );
   const activeTimetableInstanceId = timetableRoster?.instance?.id ?? null;
+  const isWaitingForTimetableRoster =
+    timetableRosterKey !== null &&
+    timetableRoster === undefined &&
+    isTimetableRosterLoading;
 
   useEffect(() => {
     if (!activeTimetableInstanceId || addStudentSearch.trim().length < 2) {
@@ -1132,6 +1145,11 @@ function MeinRaumPageContent() {
     (student) =>
       matchesStudentFilters(student, searchTerm, groupFilter, selectedYear),
   );
+  const isWaitingForUrlRoomSelection =
+    !!roomParam &&
+    roomParam !== SCHULHOF_TAB_ID &&
+    allRooms.some((room) => room.room_id === roomParam) &&
+    currentRoom?.room_id !== roomParam;
 
   // Prepare filter configurations for PageHeaderWithSearch
   const filterConfigs: FilterConfig[] = useMemo(() => {
@@ -1234,6 +1252,10 @@ function MeinRaumPageContent() {
 
   // Render helper for student grid content
   const renderStudentContent = () => {
+    if (isWaitingForUrlRoomSelection || isWaitingForTimetableRoster) {
+      return <ActiveSupervisionLoadingView />;
+    }
+
     if (timetableRoster) {
       const present = timetableRoster.rows.filter(
         (row) => row.currentlyPresent && row.planned,

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -38,6 +38,13 @@ import type { BulkArrivalTime } from "~/lib/student-arrival-api";
 import { useMinuteClock } from "~/lib/pickup-helpers";
 import { createLogger } from "~/lib/logger";
 import { activeService } from "~/lib/active-api";
+import { fetchStudents } from "~/lib/student-api";
+import { timetableOperationsApi } from "~/lib/timetable-operations-api";
+import type {
+  PlannedTimetableInstance,
+  TimetableRoster,
+  TimetableRosterRow,
+} from "~/lib/timetable-operations-types";
 import { isAdmin, isCaregiver } from "~/lib/auth-utils";
 import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
 import { TrackingIndicators } from "~/components/students/tracking-indicators";
@@ -136,6 +143,7 @@ interface BFFDashboardResponse {
   }>;
   firstRoomId: string | null;
   schulhofStatus: SchulhofStatusResponse | null;
+  plannedNow: PlannedTimetableInstance[];
 }
 
 const GROUP_CARD_GRADIENT = "from-blue-50/80 to-cyan-100/80";
@@ -164,6 +172,23 @@ function matchesStudentFilters(
     if (studentYear !== yearFilter) return false;
   }
   return true;
+}
+
+const ATTENDANCE_SUBSTATUS_LABELS: Record<
+  NonNullable<TimetableRosterRow["substatus"]>,
+  string
+> = {
+  late: "Verspätet",
+  excused: "Entschuldigt",
+  sick: "Krank",
+  field_trip: "Ausflug",
+  other: "Sonstiges",
+};
+
+function rosterStudentMeta(row: TimetableRosterRow): string {
+  return [row.schoolClass, row.groupName, row.isUnplanned ? "ungeplant" : ""]
+    .filter((value, index, values) => value && values.indexOf(value) === index)
+    .join(" · ");
 }
 
 /** Loading state view */
@@ -324,6 +349,16 @@ function MeinRaumPageContent() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [plannedNow, setPlannedNow] = useState<PlannedTimetableInstance[]>([]);
+  const [selectedTimetableInstanceId, setSelectedTimetableInstanceId] =
+    useState<string | null>(null);
+  const [isStartingInstance, setIsStartingInstance] = useState<string | null>(
+    null,
+  );
+  const [isCompletingInstance, setIsCompletingInstance] = useState(false);
+  const [addStudentSearch, setAddStudentSearch] = useState("");
+  const [addStudentResults, setAddStudentResults] = useState<Student[]>([]);
+  const [isAddingStudent, setIsAddingStudent] = useState(false);
 
   // OGS group rooms for color detection
   const [myGroupRooms, setMyGroupRooms] = useState<string[]>([]);
@@ -592,6 +627,7 @@ function MeinRaumPageContent() {
             ? (supervisedGroups[0]?.room_id ?? null)
             : null,
         schulhofStatus,
+        plannedNow: [],
       };
     }, []);
 
@@ -604,6 +640,7 @@ function MeinRaumPageContent() {
     data: dashboardData,
     isLoading: isDashboardLoading,
     error: dashboardError,
+    mutate: mutateDashboard,
   } = useSWRAuth<BFFDashboardResponse>(
     session?.user?.token ? `active-supervision-dashboard-${refreshKey}` : null,
     async () => {
@@ -648,6 +685,7 @@ function MeinRaumPageContent() {
     if (!dashboardData) return;
 
     const data = dashboardData;
+    setPlannedNow(data.plannedNow ?? []);
 
     // Set staff ID for UnclaimedRooms component
     if (data.currentStaff) {
@@ -972,6 +1010,66 @@ function MeinRaumPageContent() {
     }
   }, [swrVisitsData, currentRoomId, updateRoomStudentCount]);
 
+  const timetableRosterKey = selectedTimetableInstanceId
+    ? `timetable-roster-${selectedTimetableInstanceId}`
+    : currentRoomId && !isSchulhofActive
+      ? `timetable-roster-active-group-${currentRoomId}`
+      : null;
+  const { data: timetableRoster, mutate: mutateRoster } =
+    useSWRAuth<TimetableRoster | null>(
+      timetableRosterKey,
+      async () => {
+        try {
+          if (selectedTimetableInstanceId) {
+            return await timetableOperationsApi.roster(
+              selectedTimetableInstanceId,
+            );
+          }
+          if (!currentRoomId) return null;
+          return await timetableOperationsApi.rosterByActiveGroup(
+            currentRoomId,
+          );
+        } catch (err) {
+          if (
+            err instanceof Error &&
+            (err.message.includes("404") ||
+              err.message.toLowerCase().includes("not found"))
+          ) {
+            return null;
+          }
+          throw err;
+        }
+      },
+      { keepPreviousData: true, revalidateOnFocus: false },
+    );
+  const activeTimetableInstanceId = timetableRoster?.instance.id ?? null;
+
+  useEffect(() => {
+    if (!activeTimetableInstanceId || addStudentSearch.trim().length < 2) {
+      setAddStudentResults([]);
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      fetchStudents({
+        search: addStudentSearch.trim(),
+        page: 1,
+        page_size: 5,
+      })
+        .then((result) => {
+          setAddStudentResults(result.students);
+        })
+        .catch((err) => {
+          logger.warn("failed to search students for timetable roster", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+          setAddStudentResults([]);
+        });
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [activeTimetableInstanceId, addStudentSearch]);
+
   // Tracking indicators: fetch when student list changes (SSE-driven via SWR revalidation)
   const trackingStudentIds = useMemo(
     () => students.map((s) => s.id),
@@ -1044,6 +1142,121 @@ function MeinRaumPageContent() {
   const handleRoomClaimed = useCallback(() => {
     setRefreshKey((prev) => prev + 1);
   }, []);
+
+  const handleStartPlannedInstance = useCallback(
+    async (instance: PlannedTimetableInstance) => {
+      try {
+        setIsStartingInstance(instance.id);
+        const result = await timetableOperationsApi.start(instance.id);
+        setSelectedTimetableInstanceId(instance.id);
+        setSelectedRoomId(result.activeGroupId);
+        setIsSchulhofTabSelected(false);
+        await mutateDashboard();
+        setRefreshKey((prev) => prev + 1);
+      } catch (err) {
+        logger.error("failed to start planned timetable instance", {
+          instance_id: instance.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setError("Geplante Aktivität konnte nicht gestartet werden.");
+      } finally {
+        setIsStartingInstance(null);
+      }
+    },
+    [mutateDashboard],
+  );
+
+  const handleRosterAction = useCallback(
+    async (
+      action: "check-in" | "check-out" | "excused" | "absent" | "expected",
+      row: TimetableRosterRow,
+    ) => {
+      if (!activeTimetableInstanceId) return;
+      try {
+        if (action === "check-in") {
+          const roster = await timetableOperationsApi.checkIn(
+            activeTimetableInstanceId,
+            row.studentId,
+          );
+          await mutateRoster(roster, { revalidate: false });
+        } else if (action === "check-out") {
+          const roster = await timetableOperationsApi.checkOut(
+            activeTimetableInstanceId,
+            row.studentId,
+          );
+          await mutateRoster(roster, { revalidate: false });
+        } else if (action === "expected") {
+          await timetableOperationsApi.patchAttendance(
+            activeTimetableInstanceId,
+            row.studentId,
+            { status: "expected", substatus: null, note: null },
+          );
+          await mutateRoster();
+        } else {
+          await timetableOperationsApi.patchAttendance(
+            activeTimetableInstanceId,
+            row.studentId,
+            action === "excused"
+              ? { status: "absent", substatus: "excused" }
+              : { status: "absent" },
+          );
+          await mutateRoster();
+        }
+      } catch (err) {
+        logger.error("failed timetable roster action", {
+          action,
+          student_id: row.studentId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setError("Aktion im Stundenplan konnte nicht ausgeführt werden.");
+      }
+    },
+    [activeTimetableInstanceId, mutateRoster],
+  );
+
+  const handleCompleteTimetableInstance = useCallback(async () => {
+    if (!activeTimetableInstanceId) return;
+    try {
+      setIsCompletingInstance(true);
+      await timetableOperationsApi.complete(activeTimetableInstanceId);
+      setSelectedTimetableInstanceId(null);
+      await mutateDashboard();
+      setRefreshKey((prev) => prev + 1);
+    } catch (err) {
+      logger.error("failed to complete timetable instance", {
+        instance_id: activeTimetableInstanceId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setError("Aktivität konnte nicht beendet werden.");
+    } finally {
+      setIsCompletingInstance(false);
+    }
+  }, [activeTimetableInstanceId, mutateDashboard]);
+
+  const handleAddUnplannedStudent = useCallback(
+    async (studentId: string) => {
+      if (!activeTimetableInstanceId) return;
+      try {
+        setIsAddingStudent(true);
+        const roster = await timetableOperationsApi.checkIn(
+          activeTimetableInstanceId,
+          studentId,
+        );
+        setAddStudentSearch("");
+        setAddStudentResults([]);
+        await mutateRoster(roster, { revalidate: false });
+      } catch (err) {
+        logger.error("failed to add unplanned timetable student", {
+          student_id: studentId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setError("Schüler konnte nicht zur Aktivität hinzugefügt werden.");
+      } finally {
+        setIsAddingStudent(false);
+      }
+    },
+    [activeTimetableInstanceId, mutateRoster],
+  );
 
   // Handle releasing Schulhof supervision
   const handleReleaseSupervision = useCallback(async () => {
@@ -1268,7 +1481,11 @@ function MeinRaumPageContent() {
 
   // Show unclaimed rooms banner when user has no supervised groups and no Schulhof
   // If Schulhof exists, we'll show the main view with just the Schulhof tab
-  if (allRooms.length === 0 && !schulhofStatus?.exists) {
+  if (
+    allRooms.length === 0 &&
+    !schulhofStatus?.exists &&
+    plannedNow.length === 0
+  ) {
     return (
       <EmptyRoomsView
         onClaimed={handleRoomClaimed}
@@ -1286,6 +1503,203 @@ function MeinRaumPageContent() {
 
   // Render helper for student grid content
   const renderStudentContent = () => {
+    if (timetableRoster) {
+      const present = timetableRoster.rows.filter(
+        (row) => row.currentlyPresent && row.planned,
+      );
+      const expected = timetableRoster.rows.filter(
+        (row) =>
+          row.planned && !row.currentlyPresent && row.status === "expected",
+      );
+      const absent = timetableRoster.rows.filter(
+        (row) =>
+          row.planned && !row.currentlyPresent && row.status === "absent",
+      );
+      const departed = timetableRoster.rows.filter(
+        (row) =>
+          !row.currentlyPresent &&
+          (row.status === "present" || (row.isUnplanned && row.visitId)),
+      );
+      const unplanned = timetableRoster.rows.filter(
+        (row) => row.isUnplanned && row.currentlyPresent,
+      );
+      const renderRosterRow = (row: TimetableRosterRow) => (
+        <div
+          key={`${row.studentId}-${row.status}-${row.visitId ?? "planned"}`}
+          className="flex flex-col gap-3 border-b border-gray-100 px-4 py-3 last:border-b-0 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div>
+            <div className="font-medium text-gray-900">
+              {row.studentName || `Schüler ${row.studentId}`}
+            </div>
+            <div className="mt-1 text-sm text-gray-500">
+              {rosterStudentMeta(row)}
+            </div>
+            {row.substatus || row.note ? (
+              <div className="mt-1 text-sm text-[#D89A16]">
+                {[
+                  row.substatus
+                    ? ATTENDANCE_SUBSTATUS_LABELS[row.substatus]
+                    : null,
+                  row.note,
+                ]
+                  .filter(Boolean)
+                  .join(" · ")}
+              </div>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {!row.currentlyPresent && row.status === "expected" ? (
+              <button
+                type="button"
+                onClick={() => void handleRosterAction("check-in", row)}
+                className="rounded-md bg-[#83CD2D] px-3 py-2 text-sm font-medium text-white"
+              >
+                Einchecken
+              </button>
+            ) : null}
+            {!row.currentlyPresent && row.status !== "expected" ? (
+              <button
+                type="button"
+                onClick={() => void handleRosterAction("check-in", row)}
+                className="rounded-md bg-[#83CD2D] px-3 py-2 text-sm font-medium text-white"
+              >
+                Wieder einchecken
+              </button>
+            ) : null}
+            {row.currentlyPresent ? (
+              <button
+                type="button"
+                onClick={() => void handleRosterAction("check-out", row)}
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700"
+              >
+                Raum verlassen
+              </button>
+            ) : null}
+            {row.planned && row.status === "expected" ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => void handleRosterAction("excused", row)}
+                  className="rounded-md border border-[#D89A16] px-3 py-2 text-sm font-medium text-[#A66F00]"
+                >
+                  Entschuldigt
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleRosterAction("absent", row)}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700"
+                >
+                  Abwesend
+                </button>
+              </>
+            ) : null}
+            {row.planned && !row.currentlyPresent && row.status === "absent" ? (
+              <button
+                type="button"
+                onClick={() => void handleRosterAction("expected", row)}
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700"
+              >
+                Zurück auf erwartet
+              </button>
+            ) : null}
+          </div>
+        </div>
+      );
+
+      const section = (title: string, rows: TimetableRosterRow[]) =>
+        rows.length > 0 ? (
+          <section className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <div className="border-b border-gray-100 bg-gray-50 px-4 py-2 text-sm font-semibold text-gray-700">
+              {title} ({rows.length})
+            </div>
+            {rows.map(renderRosterRow)}
+          </section>
+        ) : null;
+
+      return (
+        <div className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-lg border border-[#83CD2D]/40 bg-[#83CD2D]/10 p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-base font-semibold text-gray-900">
+                {timetableRoster.instance.title}
+              </h2>
+              <p className="text-sm text-gray-600">
+                Laufende geplante Aktivität
+              </p>
+            </div>
+            <button
+              type="button"
+              disabled={isCompletingInstance}
+              onClick={() => void handleCompleteTimetableInstance()}
+              className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+            >
+              Beenden
+            </button>
+          </div>
+          <form
+            className="rounded-lg border border-gray-200 bg-white p-3"
+            onSubmit={(event) => {
+              event.preventDefault();
+              const onlyResult = addStudentResults[0];
+              if (onlyResult && addStudentResults.length === 1) {
+                void handleAddUnplannedStudent(onlyResult.id.toString());
+              }
+            }}
+          >
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <input
+                type="search"
+                value={addStudentSearch}
+                onChange={(event) => setAddStudentSearch(event.target.value)}
+                placeholder="Weiteren Schüler suchen..."
+                className="min-h-10 flex-1 rounded-md border border-gray-300 px-3 text-sm focus:border-[#83CD2D] focus:ring-2 focus:ring-[#83CD2D]/20 focus:outline-none"
+              />
+              <button
+                type="submit"
+                disabled={isAddingStudent || addStudentResults.length !== 1}
+                className="rounded-md bg-[#83CD2D] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+              >
+                Hinzufügen
+              </button>
+            </div>
+            {addStudentResults.length > 0 ? (
+              <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                {addStudentResults.map((student) => (
+                  <button
+                    key={student.id}
+                    type="button"
+                    disabled={isAddingStudent}
+                    onClick={() =>
+                      void handleAddUnplannedStudent(student.id.toString())
+                    }
+                    className="rounded-md border border-gray-200 px-3 py-2 text-left text-sm hover:border-[#83CD2D] disabled:opacity-50"
+                  >
+                    <span className="font-medium text-gray-900">
+                      {student.name ||
+                        [student.first_name, student.second_name]
+                          .filter(Boolean)
+                          .join(" ")}
+                    </span>
+                    <span className="ml-2 text-gray-500">
+                      {[student.school_class, student.group_name]
+                        .filter(Boolean)
+                        .join(" · ")}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </form>
+          {section("Anwesend", present)}
+          {section("Erwartet", expected)}
+          {section("Entschuldigt / Abwesend", absent)}
+          {section("Nicht mehr im Raum", departed)}
+          {section("Ungeplant", unplanned)}
+        </div>
+      );
+    }
+
     if (students.length === 0) {
       return (
         <div className="py-8 text-center">
@@ -1434,6 +1848,55 @@ function MeinRaumPageContent() {
         }
         currentStaffId={currentStaffId}
       />
+
+      {plannedNow.length > 0 && (
+        <section className="mb-6 rounded-lg border border-[#83CD2D]/30 bg-white p-4 shadow-sm">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-base font-semibold text-gray-900">
+              Jetzt geplant
+            </h2>
+            <span className="text-sm text-gray-500">
+              {plannedNow.length} Aktivität
+              {plannedNow.length === 1 ? "" : "en"}
+            </span>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {plannedNow.map((instance) => (
+              <article
+                key={instance.id}
+                className="rounded-lg border border-gray-200 bg-gray-50 p-4"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="font-medium text-gray-900">
+                      {instance.title}
+                    </h3>
+                    <p className="mt-1 text-sm text-gray-600">
+                      {instance.startTime}–{instance.endTime}
+                    </p>
+                  </div>
+                  {instance.isOverdue && (
+                    <span className="rounded-full bg-[#F3B63F]/20 px-2 py-1 text-xs font-medium text-[#A66F00]">
+                      Überfällig
+                    </span>
+                  )}
+                </div>
+                <div className="mt-3 text-sm text-gray-600">
+                  {instance.expectedStudentsCount} erwartet
+                </div>
+                <button
+                  type="button"
+                  disabled={isStartingInstance === instance.id}
+                  onClick={() => void handleStartPlannedInstance(instance)}
+                  className="mt-4 w-full rounded-md bg-[#83CD2D] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+                >
+                  Jetzt starten
+                </button>
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* Modern Header with PageHeaderWithSearch component */}
       {/* Count rooms EXCLUDING Schulhof (to avoid double-counting with schulhofStatus) */}

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -20,8 +20,7 @@ import { Alert } from "~/components/ui/alert";
 import { PageHeaderWithSearch } from "~/components/ui/page-header";
 import type { FilterConfig, ActiveFilter } from "~/components/ui/page-header";
 import { Loading } from "~/components/ui/loading";
-import { LocationBadge } from "@/components/ui/location-badge";
-import { ConfirmationModal } from "~/components/ui/modal";
+import { StudentPresenceBadge } from "@/components/ui/student-presence-badge";
 import { EmptyStudentResults } from "~/components/ui/empty-student-results";
 import {
   StudentCard,
@@ -57,55 +56,32 @@ import { UnclaimedRooms } from "~/components/active";
 import { SSEErrorBoundary } from "~/components/sse/SSEErrorBoundary";
 import { useSWRAuth } from "~/lib/swr";
 import { combineTimeNotes } from "~/lib/student-time-status";
+import {
+  ActiveSupervisionLoadingView,
+  EmptyRoomsView,
+  NoActiveSupervisionAccessView,
+  ReleaseSupervisionModal,
+  SchulhofNotSupervisingView,
+} from "~/components/active-supervisions/states";
+import { PlannedNowSection } from "~/components/active-supervisions/planned-now-section";
+import {
+  SCHULHOF_ROOM_NAME,
+  SCHULHOF_TAB_ID,
+  buildGroupNameToIdMap,
+  mapSupervisedGroupsToRooms,
+  mapVisitsToSupervisionStudents,
+} from "~/components/active-supervisions/view-model";
+import type {
+  ActiveSupervisionRoom,
+  ActiveSupervisionStudent,
+  MinimalActiveGroup,
+  SchulhofStatusResponse,
+} from "~/components/active-supervisions/view-model";
 
 const logger = createLogger({ component: "ActiveSupervisionsPage" });
 
-/** Minimal active group interface - compatible with both helper types */
-interface MinimalActiveGroup {
-  id: string;
-  room?: { name?: string };
-}
-
-// Schulhof room name - used for special release supervision feature
-const SCHULHOF_ROOM_NAME = "Schulhof";
-
-// Extended student interface that includes visit information
-interface StudentWithVisit extends Student {
-  activeGroupId: string;
-  checkInTime: Date;
-}
-
-// Define ActiveRoom type based on ActiveGroup with additional fields
-interface ActiveRoom {
-  id: string;
-  name: string;
-  room_name?: string;
-  room_id?: string;
-  /** Hex color of the room when set; drives the per-room badge color in LocationBadge. */
-  room_color?: string;
-  student_count?: number;
-  supervisor_name?: string;
-  students?: StudentWithVisit[];
-}
-
-// Schulhof status from BFF
-interface SchulhofStatusResponse {
-  exists: boolean;
-  roomId: string | null;
-  roomName: string;
-  activityGroupId: string | null;
-  activeGroupId: string | null;
-  isUserSupervising: boolean;
-  supervisionId: string | null;
-  supervisorCount: number;
-  studentCount: number;
-  supervisors: Array<{
-    id: string;
-    staffId: string;
-    name: string;
-    isCurrentUser: boolean;
-  }>;
-}
+type ActiveRoom = ActiveSupervisionRoom;
+type StudentWithVisit = ActiveSupervisionStudent;
 
 // BFF response type for consolidated dashboard data
 interface BFFDashboardResponse {
@@ -191,138 +167,6 @@ function rosterStudentMeta(row: TimetableRosterRow): string {
     .join(" · ");
 }
 
-/** Loading state view */
-function LoadingView() {
-  return <Loading fullPage={false} />;
-}
-
-/** No access empty state view */
-function NoAccessView() {
-  // Set breadcrumb for no access view
-  useSetBreadcrumb({
-    pageTitle: "Aktuelle Aufsicht",
-  });
-
-  return (
-    <div className="-mt-1.5 w-full">
-      <PageHeaderWithSearch title="Aktuelle Aufsicht" />
-
-      <div className="flex min-h-[60vh] items-center justify-center px-4">
-        <div className="flex max-w-md flex-col items-center gap-6 text-center">
-          <svg
-            className="h-12 w-12 text-gray-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-            />
-          </svg>
-          <div className="space-y-2">
-            <h3 className="text-lg font-medium text-gray-900">
-              Keine aktive Raum-Aufsicht
-            </h3>
-            <p className="text-gray-600">
-              Du bist aktuell in keinem Raum als Live-Aktivität registriert.
-            </p>
-            <p className="mt-4 text-sm text-gray-500">
-              Starte eine Aktivität an einem Terminal, um Live-Raumdaten
-              einzusehen.
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/** Props for EmptyRoomsView */
-interface EmptyRoomsViewProps {
-  onClaimed: () => void;
-  cachedActiveGroups: MinimalActiveGroup[];
-  currentStaffId: string | undefined;
-  searchTerm: string;
-  setSearchTerm: (term: string) => void;
-  setGroupFilter: (filter: string) => void;
-  setSelectedYear: (year: string) => void;
-  filterConfigs: FilterConfig[];
-  activeFilters: ActiveFilter[];
-}
-
-/** View when user has access but no supervised rooms */
-function EmptyRoomsView({
-  onClaimed,
-  cachedActiveGroups,
-  currentStaffId,
-  searchTerm,
-  setSearchTerm,
-  setGroupFilter,
-  setSelectedYear,
-  filterConfigs,
-  activeFilters,
-}: Readonly<EmptyRoomsViewProps>) {
-  return (
-    <div className="w-full">
-      {/* Show unclaimed rooms banner - full width */}
-      <UnclaimedRooms
-        onClaimed={onClaimed}
-        activeGroups={
-          cachedActiveGroups.length > 0 ? cachedActiveGroups : undefined
-        }
-        currentStaffId={currentStaffId}
-      />
-
-      {/* Search bar and filters - always visible */}
-      <PageHeaderWithSearch
-        title=""
-        search={{
-          value: searchTerm,
-          onChange: setSearchTerm,
-          placeholder: "Name suchen...",
-        }}
-        filters={filterConfigs}
-        activeFilters={activeFilters}
-        onClearAllFilters={() => {
-          setSearchTerm("");
-          setGroupFilter("all");
-          setSelectedYear("all");
-        }}
-      />
-
-      {/* Neutral info message */}
-      <div className="mt-8 flex min-h-[30vh] items-center justify-center">
-        <div className="flex max-w-md flex-col items-center gap-4 text-center">
-          <svg
-            className="h-12 w-12 text-gray-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-            />
-          </svg>
-          <div className="space-y-1">
-            <h3 className="text-lg font-medium text-gray-900">
-              Keine aktive Raum-Aufsicht
-            </h3>
-            <p className="text-sm text-gray-500">
-              Du beaufsichtigst aktuell keinen Raum.
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function MeinRaumPageContent() {
   const router = useTenantRouter();
   const searchParams = useSearchParams();
@@ -394,9 +238,6 @@ function MeinRaumPageContent() {
   const schulhofStatusRef = useRef<SchulhofStatusResponse | null>(null);
   schulhofStatusRef.current = schulhofStatus;
 
-  // Schulhof tab ID constant for identifying the permanent tab
-  const SCHULHOF_TAB_ID = "schulhof";
-
   // Cached active groups for UnclaimedRooms (avoids duplicate API call)
   const [cachedActiveGroups, setCachedActiveGroups] = useState<
     MinimalActiveGroup[]
@@ -456,45 +297,11 @@ function MeinRaumPageContent() {
         const visits =
           await activeService.getActiveGroupVisitsWithDisplay(roomId);
 
-        // Filter only active visits (students currently checked in)
-        const currentlyCheckedIn = visits.filter((visit) => visit.isActive);
-
-        const enriched = currentlyCheckedIn.map((visit) => {
-          // Build from visit display data only (cross-group)
-          const nameParts = visit.studentName?.split(" ") ?? ["", ""];
-          const firstName = nameParts[0] ?? "";
-          const lastName = nameParts.slice(1).join(" ") ?? "";
-          // Set location with room name for proper badge display
-          const location = roomName ? `Anwesend - ${roomName}` : "Anwesend";
-
-          // Look up group_id from group_name using the map
-          const groupId =
-            visit.groupName && groupNameToId
-              ? groupNameToId.get(visit.groupName)
-              : undefined;
-
-          return {
-            id: visit.studentId,
-            name: visit.studentName ?? "",
-            first_name: firstName,
-            second_name: lastName,
-            school_class: visit.schoolClass ?? "",
-            current_location: location,
-            current_room_color: roomColor ?? null,
-            group_name: visit.groupName,
-            group_id: groupId, // Add group_id for permission checking
-            sick: visit.sick,
-            sick_since: visit.sickSince,
-            excused: visit.excused,
-            excused_since: visit.excusedSince,
-            actual_arrival_time: visit.actualArrivalTime,
-            actual_pickup_time: visit.actualPickupTime,
-            activeGroupId: visit.activeGroupId,
-            checkInTime: visit.checkInTime,
-          } as StudentWithVisit;
+        return mapVisitsToSupervisionStudents(visits, {
+          roomName,
+          roomColor,
+          groupNameToId,
         });
-
-        return enriched;
       } catch (error) {
         // Handle 403 Forbidden gracefully - user might not have group access
         if (error instanceof Error && error.message.includes("403")) {
@@ -701,13 +508,7 @@ function MeinRaumPageContent() {
     const groupIds = data.educationalGroups.map((group) => group.id);
     setMyGroupIds(groupIds);
 
-    // Create map from group name to group ID
-    const nameToIdMap = new Map<string, string>();
-    data.educationalGroups.forEach((group) => {
-      if (group.name) {
-        nameToIdMap.set(group.name, group.id);
-      }
-    });
+    const nameToIdMap = buildGroupNameToIdMap(data.educationalGroups);
     setGroupNameToIdMap(nameToIdMap);
     groupNameToIdMapRef.current = nameToIdMap;
 
@@ -758,20 +559,7 @@ function MeinRaumPageContent() {
     // Track if supervision was gained
     hasSupervisionRef.current = data.supervisedGroups.length > 0;
 
-    // Convert supervised groups to ActiveRoom format, sorted by room name
-    const activeRooms: ActiveRoom[] = data.supervisedGroups
-      .map((group) => ({
-        id: group.id,
-        name: group.name,
-        room_name: group.room?.name,
-        room_id: group.room_id,
-        room_color: group.room?.color ?? undefined,
-        student_count: undefined,
-        supervisor_name: undefined,
-      }))
-      .sort((a, b) =>
-        (a.room_name ?? a.name).localeCompare(b.room_name ?? b.name, "de"),
-      );
+    const activeRooms = mapSupervisedGroupsToRooms(data.supervisedGroups);
 
     setAllRooms(activeRooms);
 
@@ -801,38 +589,12 @@ function MeinRaumPageContent() {
         setSelectedRoomId(firstRoom.id);
       }
       if (firstRoom && data.firstRoomVisits.length > 0) {
-        const studentsFromVisits: StudentWithVisit[] = data.firstRoomVisits.map(
-          (visit) => {
-            const nameParts = visit.studentName?.split(" ") ?? ["", ""];
-            const firstName = nameParts[0] ?? "";
-            const lastName = nameParts.slice(1).join(" ") ?? "";
-            const location = firstRoom.room_name
-              ? `Anwesend - ${firstRoom.room_name}`
-              : "Anwesend";
-
-            const groupId = visit.groupName
-              ? nameToIdMap.get(visit.groupName)
-              : undefined;
-
-            return {
-              id: visit.studentId,
-              name: visit.studentName ?? "",
-              first_name: firstName,
-              second_name: lastName,
-              school_class: visit.schoolClass ?? "",
-              current_location: location,
-              current_room_color: firstRoom.room_color ?? null,
-              group_name: visit.groupName,
-              group_id: groupId,
-              sick: visit.sick,
-              sick_since: visit.sickSince,
-              excused: visit.excused,
-              excused_since: visit.excusedSince,
-              actual_arrival_time: visit.actualArrivalTime,
-              actual_pickup_time: visit.actualPickupTime,
-              activeGroupId: visit.activeGroupId,
-              checkInTime: new Date(visit.checkInTime),
-            } as StudentWithVisit;
+        const studentsFromVisits = mapVisitsToSupervisionStudents(
+          data.firstRoomVisits,
+          {
+            roomName: firstRoom.room_name,
+            roomColor: firstRoom.room_color,
+            groupNameToId: nameToIdMap,
           },
         );
 
@@ -958,41 +720,10 @@ function MeinRaumPageContent() {
         currentRoomId!,
       );
 
-      // Filter only active visits (students currently checked in)
-      const currentlyCheckedIn = visits.filter((visit) => visit.isActive);
-
-      return currentlyCheckedIn.map((visit) => {
-        const nameParts = visit.studentName?.split(" ") ?? ["", ""];
-        const firstName = nameParts[0] ?? "";
-        const lastName = nameParts.slice(1).join(" ") ?? "";
-        const location = currentRoom?.room_name
-          ? `Anwesend - ${currentRoom.room_name}`
-          : "Anwesend";
-
-        const groupId =
-          visit.groupName && groupNameToIdMapRef.current
-            ? groupNameToIdMapRef.current.get(visit.groupName)
-            : undefined;
-
-        return {
-          id: visit.studentId,
-          name: visit.studentName ?? "",
-          first_name: firstName,
-          second_name: lastName,
-          school_class: visit.schoolClass ?? "",
-          current_location: location,
-          current_room_color: currentRoom?.room_color ?? null,
-          group_name: visit.groupName,
-          group_id: groupId,
-          sick: visit.sick,
-          sick_since: visit.sickSince,
-          excused: visit.excused,
-          excused_since: visit.excusedSince,
-          actual_arrival_time: visit.actualArrivalTime,
-          actual_pickup_time: visit.actualPickupTime,
-          activeGroupId: visit.activeGroupId,
-          checkInTime: visit.checkInTime,
-        } as StudentWithVisit;
+      return mapVisitsToSupervisionStudents(visits, {
+        roomName: currentRoom.room_name,
+        roomColor: currentRoom.room_color,
+        groupNameToId: groupNameToIdMapRef.current,
       });
     },
     {
@@ -1042,7 +773,7 @@ function MeinRaumPageContent() {
       },
       { keepPreviousData: true, revalidateOnFocus: false },
     );
-  const activeTimetableInstanceId = timetableRoster?.instance.id ?? null;
+  const activeTimetableInstanceId = timetableRoster?.instance?.id ?? null;
 
   useEffect(() => {
     if (!activeTimetableInstanceId || addStudentSearch.trim().length < 2) {
@@ -1471,12 +1202,12 @@ function MeinRaumPageContent() {
   }, [searchTerm, selectedYear, groupFilter]);
 
   if (status === "loading" || isLoading || hasAccess === null) {
-    return <LoadingView />;
+    return <ActiveSupervisionLoadingView />;
   }
 
   // Show empty state if no active supervision
   if (!hasAccess) {
-    return <NoAccessView />;
+    return <NoActiveSupervisionAccessView />;
   }
 
   // Show unclaimed rooms banner when user has no supervised groups and no Schulhof
@@ -1753,7 +1484,7 @@ function MeinRaumPageContent() {
                     )
                   }
                   locationBadge={
-                    <LocationBadge
+                    <StudentPresenceBadge
                       student={{
                         ...student,
                         not_arrival_today:
@@ -1849,54 +1580,11 @@ function MeinRaumPageContent() {
         currentStaffId={currentStaffId}
       />
 
-      {plannedNow.length > 0 && (
-        <section className="mb-6 rounded-lg border border-[#83CD2D]/30 bg-white p-4 shadow-sm">
-          <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-base font-semibold text-gray-900">
-              Jetzt geplant
-            </h2>
-            <span className="text-sm text-gray-500">
-              {plannedNow.length} Aktivität
-              {plannedNow.length === 1 ? "" : "en"}
-            </span>
-          </div>
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {plannedNow.map((instance) => (
-              <article
-                key={instance.id}
-                className="rounded-lg border border-gray-200 bg-gray-50 p-4"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <h3 className="font-medium text-gray-900">
-                      {instance.title}
-                    </h3>
-                    <p className="mt-1 text-sm text-gray-600">
-                      {instance.startTime}–{instance.endTime}
-                    </p>
-                  </div>
-                  {instance.isOverdue && (
-                    <span className="rounded-full bg-[#F3B63F]/20 px-2 py-1 text-xs font-medium text-[#A66F00]">
-                      Überfällig
-                    </span>
-                  )}
-                </div>
-                <div className="mt-3 text-sm text-gray-600">
-                  {instance.expectedStudentsCount} erwartet
-                </div>
-                <button
-                  type="button"
-                  disabled={isStartingInstance === instance.id}
-                  onClick={() => void handleStartPlannedInstance(instance)}
-                  className="mt-4 w-full rounded-md bg-[#83CD2D] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-                >
-                  Jetzt starten
-                </button>
-              </article>
-            ))}
-          </div>
-        </section>
-      )}
+      <PlannedNowSection
+        plannedNow={plannedNow}
+        isStartingInstance={isStartingInstance}
+        onStart={(instance) => void handleStartPlannedInstance(instance)}
+      />
 
       {/* Modern Header with PageHeaderWithSearch component */}
       {/* Count rooms EXCLUDING Schulhof (to avoid double-counting with schulhofStatus) */}
@@ -2090,43 +1778,12 @@ function MeinRaumPageContent() {
       })()}
 
       {/* Schulhof Release Supervision Modal */}
-      <ConfirmationModal
+      <ReleaseSupervisionModal
         isOpen={showReleaseModal}
         onClose={() => setShowReleaseModal(false)}
         onConfirm={() => handleReleaseSupervision().catch(() => undefined)}
-        title="Aufsicht abgeben"
-        confirmText="Abgeben"
-        confirmButtonClass="bg-red-600 hover:bg-red-700"
         isConfirmLoading={isReleasingSupervision}
-      >
-        <div className="space-y-4">
-          {/* Warning Box */}
-          <div className="rounded-lg border border-red-100 bg-red-50/50 p-3">
-            <div className="flex items-start gap-3">
-              <svg
-                className="mt-0.5 size-5 flex-shrink-0 text-red-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                />
-              </svg>
-              <div className="flex-1">
-                <p className="text-sm text-gray-600">
-                  Du wirst nicht mehr als Aufsicht angezeigt. Der Schulhof wird
-                  dann als &quot;ohne Aufsicht&quot; angezeigt, bis eine andere
-                  Lehrkraft die Aufsicht übernimmt.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </ConfirmationModal>
+      />
 
       {/* Mobile Error Display */}
       {error && (
@@ -2139,37 +1796,12 @@ function MeinRaumPageContent() {
       {isSchulhofActive &&
         schulhofStatus &&
         !schulhofStatus.isUserSupervising && (
-          <div className="flex flex-col items-center gap-4 py-12 text-center">
-            <svg
-              className="h-12 w-12 text-gray-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={1.5}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"
-              />
-            </svg>
-            <p className="text-lg font-medium text-gray-900">
-              Schulhof ohne Aufsicht
-            </p>
-            <p className="text-sm text-gray-500">
-              {schulhofStatus.supervisorCount > 0
-                ? `Aktuelle Aufsicht: ${schulhofStatus.supervisors.map((s) => s.name).join(", ")}`
-                : "Übernimm die Aufsicht, um Schüler zu sehen."}
-            </p>
-            <button
-              type="button"
-              onClick={() => handleToggleSchulhof().catch(() => undefined)}
-              disabled={isTogglingSchulhof}
-              className="mt-2 rounded-full bg-gray-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-50"
-            >
-              {isTogglingSchulhof ? "Wird übernommen..." : "Beaufsichtigen"}
-            </button>
-          </div>
+          <SchulhofNotSupervisingView
+            supervisorCount={schulhofStatus.supervisorCount}
+            supervisorNames={schulhofStatus.supervisors.map((s) => s.name)}
+            isToggling={isTogglingSchulhof}
+            onToggle={() => handleToggleSchulhof().catch(() => undefined)}
+          />
         )}
 
       {/* Student Grid - Mobile Optimized */}

--- a/frontend/src/app/api/active-supervision-dashboard/route.test.ts
+++ b/frontend/src/app/api/active-supervision-dashboard/route.test.ts
@@ -52,6 +52,7 @@ function createMockContext(
 }
 
 const defaultSession = mockSessionData() as ExtendedSession;
+const emptyPlannedNowResponse = { data: { instances: [] } };
 
 interface ApiResponse<T> {
   success: boolean;
@@ -97,7 +98,8 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockResolvedValueOnce({ data: unclaimedGroups }) // unclaimed groups
       .mockResolvedValueOnce({ data: staff }) // staff
       .mockResolvedValueOnce({ data: educationalGroups }) // educational groups
-      .mockResolvedValueOnce({ data: { exists: false } }); // Schulhof status
+      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
+      .mockResolvedValueOnce(emptyPlannedNowResponse); // planned now
 
     const request = createMockRequest("/api/active-supervision-dashboard");
     const response = await GET(request, createMockContext());
@@ -172,6 +174,7 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockResolvedValueOnce({ data: staff })
       .mockResolvedValueOnce({ data: educationalGroups })
       .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
+      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
       .mockResolvedValueOnce({ data: visits }); // visits for first group
 
     const request = createMockRequest("/api/active-supervision-dashboard");
@@ -213,6 +216,7 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockResolvedValueOnce({ data: null }) // staff (not found)
       .mockResolvedValueOnce({ data: [] }) // educational groups
       .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
+      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
       .mockResolvedValueOnce({ data: roomData }) // room fetch
       .mockResolvedValueOnce({ data: [] }); // visits
 
@@ -244,7 +248,8 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockRejectedValueOnce(new Error("Unclaimed groups error"))
       .mockRejectedValueOnce(new Error("Staff error"))
       .mockRejectedValueOnce(new Error("Educational groups error"))
-      .mockRejectedValueOnce(new Error("Schulhof status error"));
+      .mockRejectedValueOnce(new Error("Schulhof status error"))
+      .mockResolvedValueOnce(emptyPlannedNowResponse);
 
     const request = createMockRequest("/api/active-supervision-dashboard");
     const response = await GET(request, createMockContext());
@@ -264,15 +269,17 @@ describe("GET /api/active-supervision-dashboard", () => {
     // resolved value (not Once) so both calls see the admin session.
     mockAuth.mockResolvedValue(adminSession);
     const ownGroups = [{ id: 42, name: "Raum A", room: { id: 9, name: "A" } }];
-    // Promise.all fires the 5 parallel calls synchronously in array order
-    // (supervised, unclaimed, staff, edu, schulhof). The 6th mock is consumed
-    // asynchronously by the fallback apiGet inside the supervised catch.
+    // Promise.all fires the 6 parallel calls synchronously in array order
+    // (supervised, unclaimed, staff, edu, schulhof, plannedNow). The 7th mock
+    // is consumed asynchronously by the fallback apiGet inside the supervised
+    // catch.
     mockApiGet
       .mockRejectedValueOnce(new Error("API error (403): forbidden")) // supervised
       .mockResolvedValueOnce({ data: [] }) // unclaimed
       .mockResolvedValueOnce({ data: null }) // staff
       .mockResolvedValueOnce({ data: [] }) // educational
       .mockResolvedValueOnce({ data: { exists: false } }) // schulhof
+      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
       .mockResolvedValueOnce({ data: ownGroups }); // caregiver fallback
 
     const request = createMockRequest("/api/active-supervision-dashboard");
@@ -293,7 +300,8 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockResolvedValueOnce({ data: null }) // unclaimed
       .mockResolvedValueOnce({ data: null }) // staff
       .mockResolvedValueOnce({ data: null }) // educational groups
-      .mockResolvedValueOnce({ data: null }); // Schulhof status
+      .mockResolvedValueOnce({ data: null }) // Schulhof status
+      .mockResolvedValueOnce({ data: null }); // planned now
 
     const request = createMockRequest("/api/active-supervision-dashboard");
     const response = await GET(request, createMockContext());
@@ -324,6 +332,7 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockResolvedValueOnce({ data: { id: 5 } })
       .mockResolvedValueOnce({ data: [] })
       .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
+      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
       .mockRejectedValueOnce(new Error("403 Forbidden")); // visits fetch fails with 403
 
     const request = createMockRequest("/api/active-supervision-dashboard");
@@ -356,6 +365,7 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockResolvedValueOnce({ data: null })
       .mockResolvedValueOnce({ data: [] })
       .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
+      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
       .mockRejectedValueOnce(new Error("Room not found")) // room fetch fails
       .mockResolvedValueOnce({ data: [] }); // visits
 
@@ -392,6 +402,7 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockResolvedValueOnce({ data: staff })
       .mockResolvedValueOnce({ data: [] })
       .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
+      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
       .mockResolvedValueOnce({ data: [] }); // visits
 
     const request = createMockRequest("/api/active-supervision-dashboard");
@@ -425,6 +436,7 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockResolvedValueOnce({ data: null }) // staff
       .mockResolvedValueOnce({ data: [] }) // educational groups
       .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
+      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
       .mockResolvedValueOnce({ data: [] }); // visits
 
     const request = createMockRequest("/api/active-supervision-dashboard");
@@ -470,6 +482,7 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockResolvedValueOnce({ data: null })
       .mockResolvedValueOnce({ data: [] })
       .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
+      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
       .mockResolvedValueOnce({ data: visits });
 
     const request = createMockRequest("/api/active-supervision-dashboard");
@@ -504,6 +517,7 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockResolvedValueOnce({ data: null })
       .mockResolvedValueOnce({ data: [] })
       .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
+      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
       .mockResolvedValueOnce({ data: [] }); // visits for first (Aula)
 
     const request = createMockRequest("/api/active-supervision-dashboard");
@@ -532,7 +546,8 @@ describe("GET /api/active-supervision-dashboard", () => {
       .mockResolvedValueOnce({ data: unclaimedGroups })
       .mockResolvedValueOnce({ data: null })
       .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: { exists: false } }); // Schulhof status
+      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
+      .mockResolvedValueOnce(emptyPlannedNowResponse); // planned now
 
     const request = createMockRequest("/api/active-supervision-dashboard");
     const response = await GET(request, createMockContext());

--- a/frontend/src/app/api/active-supervision-dashboard/route.ts
+++ b/frontend/src/app/api/active-supervision-dashboard/route.ts
@@ -102,6 +102,21 @@ interface BackendSchulhofStatus {
   supervisors: BackendSchulhofSupervisor[];
 }
 
+interface BackendPlannedTimetableInstance {
+  id: number;
+  title: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+  room_id: number;
+  status: "planned" | "active" | "completed" | "cancelled";
+  is_overdue: boolean;
+  minutes_until_start: number;
+  expected_students_count: number;
+  present_students_count: number;
+  assigned_staff_ids: number[];
+}
+
 // Combined dashboard response type
 interface ActiveSupervisionDashboardResponse {
   // User's supervised active groups (with room info pre-loaded)
@@ -169,6 +184,20 @@ interface ActiveSupervisionDashboardResponse {
       isCurrentUser: boolean;
     }>;
   } | null;
+  plannedNow: Array<{
+    id: string;
+    title: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+    roomId: string;
+    status: "planned" | "active" | "completed" | "cancelled";
+    isOverdue: boolean;
+    minutesUntilStart: number;
+    expectedStudentsCount: number;
+    presentStudentsCount: number;
+    assignedStaffIds: string[];
+  }>;
 }
 
 /**
@@ -197,6 +226,7 @@ export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
       staffResult,
       groupsResult,
       schulhofResult,
+      plannedNowResult,
     ] = await Promise.all([
       // User's supervised active groups. For admin-only users, try the admin
       // overview endpoint first. If it returns 403 (setting disabled) fall
@@ -247,6 +277,12 @@ export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
         "/api/active/schulhof/status",
         token,
       ).catch(() => ({ data: null as BackendSchulhofStatus | null })),
+      apiGet<{ data: { instances: BackendPlannedTimetableInstance[] } }>(
+        "/api/timetable/operations/planned-now",
+        token,
+      ).catch(() => ({
+        data: { instances: [] as BackendPlannedTimetableInstance[] },
+      })),
     ]);
 
     // Extract data with null safety, sorted by room name for deterministic order
@@ -266,6 +302,20 @@ export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
       ? groupsResult.data
       : [];
     const schulhofData = schulhofResult.data;
+    const plannedNow = (plannedNowResult.data.instances ?? []).map((i) => ({
+      id: i.id.toString(),
+      title: i.title,
+      date: i.date,
+      startTime: i.start_time,
+      endTime: i.end_time,
+      roomId: i.room_id.toString(),
+      status: i.status,
+      isOverdue: i.is_overdue,
+      minutesUntilStart: i.minutes_until_start,
+      expectedStudentsCount: i.expected_students_count,
+      presentStudentsCount: i.present_students_count,
+      assignedStaffIds: i.assigned_staff_ids.map(String),
+    }));
 
     // Transform Schulhof status to frontend format
     const schulhofStatus = schulhofData
@@ -306,6 +356,7 @@ export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
         firstRoomVisits: [],
         firstRoomId: null,
         schulhofStatus,
+        plannedNow,
       };
     }
 
@@ -417,6 +468,7 @@ export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
       firstRoomVisits,
       firstRoomId: firstGroupId,
       schulhofStatus,
+      plannedNow,
     };
   },
 );

--- a/frontend/src/app/api/active-supervision-dashboard/route.ts
+++ b/frontend/src/app/api/active-supervision-dashboard/route.ts
@@ -302,7 +302,7 @@ export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
       ? groupsResult.data
       : [];
     const schulhofData = schulhofResult.data;
-    const plannedNow = (plannedNowResult.data.instances ?? []).map((i) => ({
+    const plannedNow = (plannedNowResult.data?.instances ?? []).map((i) => ({
       id: i.id.toString(),
       title: i.title,
       date: i.date,

--- a/frontend/src/app/api/timetable/operations/active-groups/[id]/roster/route.ts
+++ b/frontend/src/app/api/timetable/operations/active-groups/[id]/roster/route.ts
@@ -1,0 +1,14 @@
+import type { NextRequest } from "next/server";
+import { apiGet } from "~/lib/api-helpers";
+import { createGetHandler, isStringParam } from "~/lib/route-wrapper";
+
+export const GET = createGetHandler(
+  async (_request: NextRequest, token: string, params) => {
+    if (!isStringParam(params.id)) throw new Error("Invalid id parameter");
+    const response = await apiGet<{ data: unknown }>(
+      `/api/timetable/operations/active-groups/${params.id}/roster`,
+      token,
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/timetable/operations/instances/[id]/complete/route.ts
+++ b/frontend/src/app/api/timetable/operations/instances/[id]/complete/route.ts
@@ -1,0 +1,15 @@
+import type { NextRequest } from "next/server";
+import { apiPost } from "~/lib/api-helpers";
+import { createPostHandler, isStringParam } from "~/lib/route-wrapper";
+
+export const POST = createPostHandler(
+  async (_request: NextRequest, body: unknown, token: string, params) => {
+    if (!isStringParam(params.id)) throw new Error("Invalid id parameter");
+    const response = await apiPost<{ data: unknown }>(
+      `/api/timetable/operations/instances/${params.id}/complete`,
+      token,
+      body ?? {},
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/timetable/operations/instances/[id]/roster/route.ts
+++ b/frontend/src/app/api/timetable/operations/instances/[id]/roster/route.ts
@@ -1,0 +1,14 @@
+import type { NextRequest } from "next/server";
+import { apiGet } from "~/lib/api-helpers";
+import { createGetHandler, isStringParam } from "~/lib/route-wrapper";
+
+export const GET = createGetHandler(
+  async (_request: NextRequest, token: string, params) => {
+    if (!isStringParam(params.id)) throw new Error("Invalid id parameter");
+    const response = await apiGet<{ data: unknown }>(
+      `/api/timetable/operations/instances/${params.id}/roster`,
+      token,
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/timetable/operations/instances/[id]/start/route.ts
+++ b/frontend/src/app/api/timetable/operations/instances/[id]/start/route.ts
@@ -1,0 +1,15 @@
+import type { NextRequest } from "next/server";
+import { apiPost } from "~/lib/api-helpers";
+import { createPostHandler, isStringParam } from "~/lib/route-wrapper";
+
+export const POST = createPostHandler(
+  async (_request: NextRequest, body: unknown, token: string, params) => {
+    if (!isStringParam(params.id)) throw new Error("Invalid id parameter");
+    const response = await apiPost<{ data: unknown }>(
+      `/api/timetable/operations/instances/${params.id}/start`,
+      token,
+      body ?? {},
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/timetable/operations/instances/[id]/students/[studentId]/attendance/route.ts
+++ b/frontend/src/app/api/timetable/operations/instances/[id]/students/[studentId]/attendance/route.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from "next/server";
+import { apiPatch } from "~/lib/api-helpers";
+import { createPatchHandler, isStringParam } from "~/lib/route-wrapper";
+
+export const PATCH = createPatchHandler(
+  async (_request: NextRequest, body: unknown, token: string, params) => {
+    if (!isStringParam(params.id) || !isStringParam(params.studentId)) {
+      throw new Error("Invalid id parameter");
+    }
+    const response = await apiPatch<{ data: unknown }>(
+      `/api/timetable/operations/instances/${params.id}/students/${params.studentId}/attendance`,
+      token,
+      body ?? {},
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/timetable/operations/instances/[id]/students/[studentId]/check-in/route.ts
+++ b/frontend/src/app/api/timetable/operations/instances/[id]/students/[studentId]/check-in/route.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from "next/server";
+import { apiPost } from "~/lib/api-helpers";
+import { createPostHandler, isStringParam } from "~/lib/route-wrapper";
+
+export const POST = createPostHandler(
+  async (_request: NextRequest, body: unknown, token: string, params) => {
+    if (!isStringParam(params.id) || !isStringParam(params.studentId)) {
+      throw new Error("Invalid id parameter");
+    }
+    const response = await apiPost<{ data: unknown }>(
+      `/api/timetable/operations/instances/${params.id}/students/${params.studentId}/check-in`,
+      token,
+      body ?? {},
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/timetable/operations/instances/[id]/students/[studentId]/check-out/route.ts
+++ b/frontend/src/app/api/timetable/operations/instances/[id]/students/[studentId]/check-out/route.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from "next/server";
+import { apiPost } from "~/lib/api-helpers";
+import { createPostHandler, isStringParam } from "~/lib/route-wrapper";
+
+export const POST = createPostHandler(
+  async (_request: NextRequest, body: unknown, token: string, params) => {
+    if (!isStringParam(params.id) || !isStringParam(params.studentId)) {
+      throw new Error("Invalid id parameter");
+    }
+    const response = await apiPost<{ data: unknown }>(
+      `/api/timetable/operations/instances/${params.id}/students/${params.studentId}/check-out`,
+      token,
+      body ?? {},
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/timetable/operations/planned-now/route.ts
+++ b/frontend/src/app/api/timetable/operations/planned-now/route.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from "next/server";
+import { apiGet, extractParams } from "~/lib/api-helpers";
+import { createGetHandler } from "~/lib/route-wrapper";
+
+export const GET = createGetHandler(
+  async (request: NextRequest, token: string, params) => {
+    const queryParams = extractParams(request, params);
+    const queryString = new URLSearchParams(queryParams).toString();
+    const endpoint = `/api/timetable/operations/planned-now${queryString ? `?${queryString}` : ""}`;
+    const response = await apiGet<{ data: unknown }>(endpoint, token);
+    return response.data;
+  },
+);

--- a/frontend/src/components/active-supervisions/planned-now-section.test.tsx
+++ b/frontend/src/components/active-supervisions/planned-now-section.test.tsx
@@ -65,4 +65,21 @@ describe("PlannedNowSection", () => {
     );
     expect(onStart).toHaveBeenCalledWith(plannedInstance);
   });
+
+  it("renders plural labels and hides overdue badge for on-time instances", () => {
+    render(
+      <PlannedNowSection
+        plannedNow={[
+          { ...plannedInstance, id: "instance-1", isOverdue: false },
+          { ...plannedInstance, id: "instance-2", title: "AG Sport" },
+        ]}
+        isStartingInstance={null}
+        onStart={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("2 Aktivitäten")).toBeInTheDocument();
+    expect(screen.getByText("AG Sport")).toBeInTheDocument();
+    expect(screen.getAllByText("Überfällig")).toHaveLength(1);
+  });
 });

--- a/frontend/src/components/active-supervisions/planned-now-section.test.tsx
+++ b/frontend/src/components/active-supervisions/planned-now-section.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PlannedNowSection } from "./planned-now-section";
+import type { PlannedTimetableInstance } from "~/lib/timetable-operations-types";
+
+const plannedInstance: PlannedTimetableInstance = {
+  id: "instance-1",
+  date: "2026-05-10",
+  title: "Hausaufgaben",
+  roomId: "room-1",
+  startTime: "14:00",
+  endTime: "15:00",
+  status: "planned",
+  expectedStudentsCount: 8,
+  presentStudentsCount: 0,
+  minutesUntilStart: -5,
+  assignedStaffIds: [],
+  isOverdue: true,
+};
+
+describe("PlannedNowSection", () => {
+  it("renders nothing when no planned instances are due", () => {
+    const { container } = render(
+      <PlannedNowSection
+        plannedNow={[]}
+        isStartingInstance={null}
+        onStart={vi.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders planned instances and starts the selected one", () => {
+    const onStart = vi.fn();
+
+    render(
+      <PlannedNowSection
+        plannedNow={[plannedInstance]}
+        isStartingInstance="instance-1"
+        onStart={onStart}
+      />,
+    );
+
+    expect(screen.getByText("Jetzt geplant")).toBeInTheDocument();
+    expect(screen.getByText("1 Aktivität")).toBeInTheDocument();
+    expect(screen.getByText("Hausaufgaben")).toBeInTheDocument();
+    expect(screen.getByText("Überfällig")).toBeInTheDocument();
+    expect(screen.getByText("8 erwartet")).toBeInTheDocument();
+
+    const startButton = screen.getByRole("button", { name: "Jetzt starten" });
+    expect(startButton).toBeDisabled();
+
+    render(
+      <PlannedNowSection
+        plannedNow={[plannedInstance]}
+        isStartingInstance={null}
+        onStart={onStart}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Jetzt starten" })[1]!,
+    );
+    expect(onStart).toHaveBeenCalledWith(plannedInstance);
+  });
+});

--- a/frontend/src/components/active-supervisions/planned-now-section.tsx
+++ b/frontend/src/components/active-supervisions/planned-now-section.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { PlannedTimetableInstance } from "~/lib/timetable-operations-types";
+
+interface PlannedNowSectionProps {
+  readonly plannedNow: PlannedTimetableInstance[];
+  readonly isStartingInstance: string | null;
+  readonly onStart: (instance: PlannedTimetableInstance) => void;
+}
+
+export function PlannedNowSection({
+  plannedNow,
+  isStartingInstance,
+  onStart,
+}: PlannedNowSectionProps) {
+  if (plannedNow.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mb-6 rounded-lg border border-[#83CD2D]/30 bg-white p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-base font-semibold text-gray-900">Jetzt geplant</h2>
+        <span className="text-sm text-gray-500">
+          {plannedNow.length} Aktivität{plannedNow.length === 1 ? "" : "en"}
+        </span>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {plannedNow.map((instance) => (
+          <article
+            key={instance.id}
+            className="rounded-lg border border-gray-200 bg-gray-50 p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="font-medium text-gray-900">{instance.title}</h3>
+                <p className="mt-1 text-sm text-gray-600">
+                  {instance.startTime}–{instance.endTime}
+                </p>
+              </div>
+              {instance.isOverdue && (
+                <span className="rounded-full bg-[#F3B63F]/20 px-2 py-1 text-xs font-medium text-[#A66F00]">
+                  Überfällig
+                </span>
+              )}
+            </div>
+            <div className="mt-3 text-sm text-gray-600">
+              {instance.expectedStudentsCount} erwartet
+            </div>
+            <button
+              type="button"
+              disabled={isStartingInstance === instance.id}
+              onClick={() => onStart(instance)}
+              className="mt-4 w-full rounded-md bg-[#83CD2D] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+            >
+              Jetzt starten
+            </button>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/active-supervisions/states.tsx
+++ b/frontend/src/components/active-supervisions/states.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { Loading } from "~/components/ui/loading";
+import { PageHeaderWithSearch } from "~/components/ui/page-header";
+import type { ActiveFilter, FilterConfig } from "~/components/ui/page-header";
+import { ConfirmationModal } from "~/components/ui/modal";
+import { UnclaimedRooms } from "~/components/active";
+import { useSetBreadcrumb } from "~/lib/breadcrumb-context";
+
+interface MinimalActiveGroup {
+  id: string;
+  room?: { name?: string };
+}
+
+interface EmptyRoomsViewProps {
+  readonly onClaimed: () => void;
+  readonly cachedActiveGroups: MinimalActiveGroup[];
+  readonly currentStaffId: string | undefined;
+  readonly searchTerm: string;
+  readonly setSearchTerm: (term: string) => void;
+  readonly setGroupFilter: (filter: string) => void;
+  readonly setSelectedYear: (year: string) => void;
+  readonly filterConfigs: FilterConfig[];
+  readonly activeFilters: ActiveFilter[];
+}
+
+interface SchulhofNotSupervisingViewProps {
+  readonly supervisorCount: number;
+  readonly supervisorNames: string[];
+  readonly isToggling: boolean;
+  readonly onToggle: () => void;
+}
+
+interface ReleaseSupervisionModalProps {
+  readonly isOpen: boolean;
+  readonly isConfirmLoading: boolean;
+  readonly onClose: () => void;
+  readonly onConfirm: () => void;
+}
+
+export function ActiveSupervisionLoadingView() {
+  return <Loading fullPage={false} />;
+}
+
+export function NoActiveSupervisionAccessView() {
+  useSetBreadcrumb({
+    pageTitle: "Aktuelle Aufsicht",
+  });
+
+  return (
+    <div className="-mt-1.5 w-full">
+      <PageHeaderWithSearch title="Aktuelle Aufsicht" />
+
+      <div className="flex min-h-[60vh] items-center justify-center px-4">
+        <div className="flex max-w-md flex-col items-center gap-6 text-center">
+          <svg
+            className="h-12 w-12 text-gray-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+            />
+          </svg>
+          <div className="space-y-2">
+            <h3 className="text-lg font-medium text-gray-900">
+              Keine aktive Raum-Aufsicht
+            </h3>
+            <p className="text-gray-600">
+              Du bist aktuell in keinem Raum als Live-Aktivität registriert.
+            </p>
+            <p className="mt-4 text-sm text-gray-500">
+              Starte eine Aktivität an einem Terminal, um Live-Raumdaten
+              einzusehen.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function EmptyRoomsView({
+  onClaimed,
+  cachedActiveGroups,
+  currentStaffId,
+  searchTerm,
+  setSearchTerm,
+  setGroupFilter,
+  setSelectedYear,
+  filterConfigs,
+  activeFilters,
+}: EmptyRoomsViewProps) {
+  return (
+    <div className="w-full">
+      <UnclaimedRooms
+        onClaimed={onClaimed}
+        activeGroups={
+          cachedActiveGroups.length > 0 ? cachedActiveGroups : undefined
+        }
+        currentStaffId={currentStaffId}
+      />
+
+      <PageHeaderWithSearch
+        title=""
+        search={{
+          value: searchTerm,
+          onChange: setSearchTerm,
+          placeholder: "Name suchen...",
+        }}
+        filters={filterConfigs}
+        activeFilters={activeFilters}
+        onClearAllFilters={() => {
+          setSearchTerm("");
+          setGroupFilter("all");
+          setSelectedYear("all");
+        }}
+      />
+
+      <div className="mt-8 flex min-h-[30vh] items-center justify-center">
+        <div className="flex max-w-md flex-col items-center gap-4 text-center">
+          <svg
+            className="h-12 w-12 text-gray-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+            />
+          </svg>
+          <div className="space-y-1">
+            <h3 className="text-lg font-medium text-gray-900">
+              Keine aktive Raum-Aufsicht
+            </h3>
+            <p className="text-sm text-gray-500">
+              Du beaufsichtigst aktuell keinen Raum.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ReleaseSupervisionModal({
+  isOpen,
+  isConfirmLoading,
+  onClose,
+  onConfirm,
+}: ReleaseSupervisionModalProps) {
+  return (
+    <ConfirmationModal
+      isOpen={isOpen}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      title="Aufsicht abgeben"
+      confirmText="Abgeben"
+      confirmButtonClass="bg-red-600 hover:bg-red-700"
+      isConfirmLoading={isConfirmLoading}
+    >
+      <div className="space-y-4">
+        <div className="rounded-lg border border-red-100 bg-red-50/50 p-3">
+          <div className="flex items-start gap-3">
+            <svg
+              className="mt-0.5 size-5 flex-shrink-0 text-red-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            <div className="flex-1">
+              <p className="text-sm text-gray-600">
+                Du wirst nicht mehr als Aufsicht angezeigt. Der Schulhof wird
+                dann als &quot;ohne Aufsicht&quot; angezeigt, bis eine andere
+                Lehrkraft die Aufsicht übernimmt.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ConfirmationModal>
+  );
+}
+
+export function SchulhofNotSupervisingView({
+  supervisorCount,
+  supervisorNames,
+  isToggling,
+  onToggle,
+}: SchulhofNotSupervisingViewProps) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-12 text-center">
+      <svg
+        className="h-12 w-12 text-gray-400"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.5}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"
+        />
+      </svg>
+      <p className="text-lg font-medium text-gray-900">
+        Schulhof ohne Aufsicht
+      </p>
+      <p className="text-sm text-gray-500">
+        {supervisorCount > 0
+          ? `Aktuelle Aufsicht: ${supervisorNames.join(", ")}`
+          : "Übernimm die Aufsicht, um Schüler zu sehen."}
+      </p>
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={isToggling}
+        className="mt-2 rounded-full bg-gray-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-50"
+      >
+        {isToggling ? "Wird übernommen..." : "Beaufsichtigen"}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/active-supervisions/view-model.test.ts
+++ b/frontend/src/components/active-supervisions/view-model.test.ts
@@ -79,4 +79,43 @@ describe("active-supervisions view model", () => {
     });
     expect(result[0]?.checkInTime).toBeInstanceOf(Date);
   });
+
+  it("falls back cleanly when optional visit and room fields are missing", () => {
+    const checkInTime = new Date("2026-01-15T10:00:00.000Z");
+
+    const rooms = mapSupervisedGroupsToRooms([
+      {
+        id: "active-without-room",
+        name: "Freie Aufsicht",
+      },
+    ]);
+    const students = mapVisitsToSupervisionStudents(
+      [
+        {
+          studentId: "student-3",
+          activeGroupId: "active-without-room",
+          checkInTime,
+          isActive: true,
+        },
+      ],
+      {},
+    );
+
+    expect(rooms[0]).toMatchObject({
+      id: "active-without-room",
+      room_name: undefined,
+      room_color: undefined,
+    });
+    expect(students[0]).toMatchObject({
+      id: "student-3",
+      name: "",
+      first_name: "",
+      second_name: "",
+      school_class: "",
+      current_location: "Anwesend",
+      current_room_color: null,
+      group_id: undefined,
+    });
+    expect(students[0]?.checkInTime).toBe(checkInTime);
+  });
 });

--- a/frontend/src/components/active-supervisions/view-model.test.ts
+++ b/frontend/src/components/active-supervisions/view-model.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGroupNameToIdMap,
+  mapSupervisedGroupsToRooms,
+  mapVisitsToSupervisionStudents,
+} from "./view-model";
+
+describe("active-supervisions view model", () => {
+  it("maps educational group names to ids", () => {
+    const result = buildGroupNameToIdMap([
+      { id: "g2", name: "Gruppe Blau", room: { name: "Raum B" } },
+      { id: "g1", name: "Gruppe Rot", room: { name: "Raum A" } },
+    ]);
+
+    expect(result.get("Gruppe Rot")).toBe("g1");
+    expect(result.get("Gruppe Blau")).toBe("g2");
+  });
+
+  it("maps and sorts supervised groups by visible room name", () => {
+    const result = mapSupervisedGroupsToRooms([
+      {
+        id: "active-z",
+        name: "Gruppe Z",
+        room_id: "room-z",
+        room: { id: "room-z", name: "Zeichenraum", color: "#5080D8" },
+      },
+      {
+        id: "active-a",
+        name: "Gruppe A",
+        room_id: "room-a",
+        room: { id: "room-a", name: "Atelier", color: "#83CD2D" },
+      },
+    ]);
+
+    expect(result.map((room) => room.room_name)).toEqual([
+      "Atelier",
+      "Zeichenraum",
+    ]);
+    expect(result[0]?.room_color).toBe("#83CD2D");
+  });
+
+  it("maps only active visits to student card rows", () => {
+    const groupNameToId = new Map([["Gruppe Rot", "g1"]]);
+    const result = mapVisitsToSupervisionStudents(
+      [
+        {
+          studentId: "student-1",
+          studentName: "Max Mustermann",
+          schoolClass: "2a",
+          groupName: "Gruppe Rot",
+          activeGroupId: "active-1",
+          checkInTime: "2026-01-15T10:00:00.000Z",
+          isActive: true,
+        },
+        {
+          studentId: "student-2",
+          studentName: "Erika Beispiel",
+          activeGroupId: "active-1",
+          checkInTime: "2026-01-15T09:00:00.000Z",
+          isActive: false,
+        },
+      ],
+      {
+        roomName: "Atelier",
+        roomColor: "#83CD2D",
+        groupNameToId,
+      },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "student-1",
+      first_name: "Max",
+      second_name: "Mustermann",
+      group_id: "g1",
+      current_location: "Anwesend - Atelier",
+      current_room_color: "#83CD2D",
+    });
+    expect(result[0]?.checkInTime).toBeInstanceOf(Date);
+  });
+});

--- a/frontend/src/components/active-supervisions/view-model.ts
+++ b/frontend/src/components/active-supervisions/view-model.ts
@@ -1,0 +1,157 @@
+import type { Student } from "~/lib/student-helpers";
+
+export const SCHULHOF_ROOM_NAME = "Schulhof";
+export const SCHULHOF_TAB_ID = "schulhof";
+
+export interface MinimalActiveGroup {
+  id: string;
+  room?: { name?: string };
+}
+
+export interface ActiveSupervisionStudent extends Student {
+  activeGroupId: string;
+  checkInTime: Date;
+}
+
+export interface ActiveSupervisionRoom {
+  id: string;
+  name: string;
+  room_name?: string;
+  room_id?: string;
+  room_color?: string;
+  student_count?: number;
+  supervisor_name?: string;
+  students?: ActiveSupervisionStudent[];
+}
+
+export interface SchulhofStatusResponse {
+  exists: boolean;
+  roomId: string | null;
+  roomName: string;
+  activityGroupId: string | null;
+  activeGroupId: string | null;
+  isUserSupervising: boolean;
+  supervisionId: string | null;
+  supervisorCount: number;
+  studentCount: number;
+  supervisors: Array<{
+    id: string;
+    staffId: string;
+    name: string;
+    isCurrentUser: boolean;
+  }>;
+}
+
+interface VisitDisplayLike {
+  studentId: string;
+  studentName?: string;
+  schoolClass?: string;
+  groupName?: string;
+  activeGroupId: string;
+  checkInTime: string | Date;
+  actualArrivalTime?: string;
+  actualPickupTime?: string;
+  isActive: boolean;
+  sick?: boolean;
+  sickSince?: string;
+  excused?: boolean;
+  excusedSince?: string;
+}
+
+interface SupervisedGroupLike {
+  id: string;
+  name: string;
+  room_id?: string;
+  room?: { id: string; name: string; color?: string | null };
+}
+
+interface EducationalGroupLike {
+  id: string;
+  name: string;
+  room?: { name: string };
+}
+
+export function buildGroupNameToIdMap(
+  groups: readonly EducationalGroupLike[],
+): Map<string, string> {
+  const nameToIdMap = new Map<string, string>();
+  groups.forEach((group) => {
+    if (group.name) {
+      nameToIdMap.set(group.name, group.id);
+    }
+  });
+  return nameToIdMap;
+}
+
+export function mapSupervisedGroupsToRooms(
+  groups: readonly SupervisedGroupLike[],
+): ActiveSupervisionRoom[] {
+  return groups
+    .map((group) => ({
+      id: group.id,
+      name: group.name,
+      room_name: group.room?.name,
+      room_id: group.room_id,
+      room_color: group.room?.color ?? undefined,
+      student_count: undefined,
+      supervisor_name: undefined,
+    }))
+    .sort((a, b) =>
+      (a.room_name ?? a.name).localeCompare(b.room_name ?? b.name, "de"),
+    );
+}
+
+function mapVisitToSupervisionStudent(
+  visit: VisitDisplayLike,
+  options: {
+    roomName?: string;
+    roomColor?: string | null;
+    groupNameToId?: Map<string, string>;
+  },
+): ActiveSupervisionStudent {
+  const nameParts = visit.studentName?.split(" ") ?? ["", ""];
+  const firstName = nameParts[0] ?? "";
+  const lastName = nameParts.slice(1).join(" ") ?? "";
+  const location = options.roomName
+    ? `Anwesend - ${options.roomName}`
+    : "Anwesend";
+  const groupId = visit.groupName
+    ? options.groupNameToId?.get(visit.groupName)
+    : undefined;
+
+  return {
+    id: visit.studentId,
+    name: visit.studentName ?? "",
+    first_name: firstName,
+    second_name: lastName,
+    school_class: visit.schoolClass ?? "",
+    current_location: location,
+    current_room_color: options.roomColor ?? null,
+    group_name: visit.groupName,
+    group_id: groupId,
+    sick: visit.sick,
+    sick_since: visit.sickSince,
+    excused: visit.excused,
+    excused_since: visit.excusedSince,
+    actual_arrival_time: visit.actualArrivalTime,
+    actual_pickup_time: visit.actualPickupTime,
+    activeGroupId: visit.activeGroupId,
+    checkInTime:
+      visit.checkInTime instanceof Date
+        ? visit.checkInTime
+        : new Date(visit.checkInTime),
+  } as ActiveSupervisionStudent;
+}
+
+export function mapVisitsToSupervisionStudents(
+  visits: readonly VisitDisplayLike[],
+  options: {
+    roomName?: string;
+    roomColor?: string | null;
+    groupNameToId?: Map<string, string>;
+  },
+): ActiveSupervisionStudent[] {
+  return visits
+    .filter((visit) => visit.isActive)
+    .map((visit) => mapVisitToSupervisionStudent(visit, options));
+}

--- a/frontend/src/components/timetable/instance-detail-slide-over.test.tsx
+++ b/frontend/src/components/timetable/instance-detail-slide-over.test.tsx
@@ -197,4 +197,92 @@ describe("InstanceDetailSlideOver", () => {
       ),
     );
   });
+
+  it("renders completed, empty, and detailed attendance states", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <InstanceDetailSlideOver
+        instance={instance({
+          status: "completed",
+          staff: [],
+          staffCount: 0,
+          absentStaffCount: 0,
+          students: [],
+          studentIds: [],
+          expectedStudentsCount: 0,
+          presentStudentsCount: 0,
+          notes: undefined,
+          conflictWarnings: [],
+          roomName: "",
+        })}
+        onClose={onClose}
+        onLifecycleAction={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Niemand zugeordnet")).toBeInTheDocument();
+    expect(screen.getByText("Kein Personal zugeordnet.")).toBeInTheDocument();
+    expect(screen.getByText("Keine Kinder geplant.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Diese Aktivität ist bereits abgeschlossen."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Raum #3")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Schließen" }));
+    expect(onClose).toHaveBeenCalledOnce();
+
+    rerender(
+      <InstanceDetailSlideOver
+        instance={instance({
+          status: "completed",
+          students: [
+            { studentId: "31", status: "absent", substatus: "late" },
+            { studentId: "32", status: "absent", substatus: "excused" },
+            { studentId: "33", status: "absent", substatus: "field_trip" },
+            { studentId: "34", status: "absent", substatus: "other" },
+          ],
+          studentIds: ["31", "32", "33", "34"],
+        })}
+        onClose={vi.fn()}
+        onLifecycleAction={vi.fn()}
+        onAttendancePatch={vi.fn()}
+        studentNames={
+          new Map([
+            ["31", "Late Kind"],
+            ["32", "Excused Kind"],
+            ["33", "Trip Kind"],
+            ["34", "Other Kind"],
+          ])
+        }
+      />,
+    );
+
+    expect(screen.getByText(/Verspätet/)).toBeInTheDocument();
+    expect(screen.getByText(/Entschuldigt/)).toBeInTheDocument();
+    expect(screen.getByText(/Ausflug/)).toBeInTheDocument();
+    expect(screen.getByText(/Sonstiges/)).toBeInTheDocument();
+  });
+
+  it("can back out of cancelled instance deletion confirmation", () => {
+    const onDeleteCancelled = vi.fn();
+
+    render(
+      <InstanceDetailSlideOver
+        instance={instance({ status: "cancelled" })}
+        onClose={vi.fn()}
+        onLifecycleAction={vi.fn()}
+        onDeleteCancelled={onDeleteCancelled}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Löschen/ }));
+    expect(
+      screen.getByRole("button", { name: /Löschen bestätigen/ }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Löschen abbrechen/ }));
+    expect(
+      screen.queryByRole("button", { name: /Löschen bestätigen/ }),
+    ).not.toBeInTheDocument();
+    expect(onDeleteCancelled).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/timetable/instance-detail-slide-over.test.tsx
+++ b/frontend/src/components/timetable/instance-detail-slide-over.test.tsx
@@ -123,11 +123,13 @@ describe("InstanceDetailSlideOver", () => {
   it("handles active, cancelled and fallback student states", async () => {
     const onLifecycleAction = vi.fn().mockResolvedValue(undefined);
     const onDeleteCancelled = vi.fn().mockResolvedValue(undefined);
+    const onAttendancePatch = vi.fn().mockResolvedValue(undefined);
     const { rerender } = render(
       <InstanceDetailSlideOver
         instance={instance({ status: "active", isLive: true })}
         onClose={vi.fn()}
         onLifecycleAction={onLifecycleAction}
+        onAttendancePatch={onAttendancePatch}
       />,
     );
 
@@ -138,6 +140,34 @@ describe("InstanceDetailSlideOver", () => {
     fireEvent.click(screen.getByRole("button", { name: /Absagen/ }));
     await waitFor(() =>
       expect(onLifecycleAction).toHaveBeenCalledWith("cancel"),
+    );
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Als anwesend markieren" })[0]!,
+    );
+    await waitFor(() =>
+      expect(onAttendancePatch).toHaveBeenCalledWith("42", "21", {
+        status: "present",
+        substatus: null,
+      }),
+    );
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Als fehlend markieren" })[0]!,
+    );
+    await waitFor(() =>
+      expect(onAttendancePatch).toHaveBeenCalledWith("42", "21", {
+        status: "absent",
+        substatus: null,
+      }),
+    );
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Status zurücksetzen" })[0]!,
+    );
+    await waitFor(() =>
+      expect(onAttendancePatch).toHaveBeenCalledWith("42", "22", {
+        status: "expected",
+        substatus: null,
+        note: null,
+      }),
     );
 
     rerender(

--- a/frontend/src/components/timetable/instance-detail-slide-over.tsx
+++ b/frontend/src/components/timetable/instance-detail-slide-over.tsx
@@ -11,12 +11,13 @@
 import { useEffect, useMemo, useState } from "react";
 import type React from "react";
 import {
+  Check,
   CheckCircle2,
   CircleX,
   DoorOpen,
   Pencil,
   Repeat,
-  Square,
+  RotateCcw,
   StickyNote,
   Timer,
   Trash2,
@@ -27,6 +28,7 @@ import {
 } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
+import { LOCATION_COLORS } from "~/lib/location-helper";
 import {
   SlideOver,
   SlideOverClose,
@@ -86,9 +88,9 @@ interface StatusBadgeProps {
 function StatusBadge({ status }: StatusBadgeProps) {
   const palette: Record<InstanceStatus, { bg: string; text: string }> = {
     planned: { bg: "#F3F4F6", text: "#374151" },
-    active: { bg: "#83CD2D", text: "#FFFFFF" },
+    active: { bg: LOCATION_COLORS.GROUP_ROOM, text: "#FFFFFF" },
     completed: { bg: "#E5E7EB", text: "#6B7280" },
-    cancelled: { bg: "#FF3130", text: "#FFFFFF" },
+    cancelled: { bg: LOCATION_COLORS.HOME, text: "#FFFFFF" },
   };
   const { bg, text } = palette[status];
   return (
@@ -97,7 +99,7 @@ function StatusBadge({ status }: StatusBadgeProps) {
       style={{ backgroundColor: bg, color: text }}
     >
       {status === "active" && (
-        <span className="h-1.5 w-1.5 rounded-full bg-white" />
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white" />
       )}
       {getStatusLabel(status)}
     </span>
@@ -112,6 +114,23 @@ function attendanceLabel(status: InstanceStudentSummary["status"]): string {
       return "Anwesend";
     case "absent":
       return "Fehlt";
+  }
+}
+
+function attendanceSubstatusLabel(
+  substatus: NonNullable<InstanceStudentSummary["substatus"]>,
+): string {
+  switch (substatus) {
+    case "late":
+      return "Verspätet";
+    case "excused":
+      return "Entschuldigt";
+    case "sick":
+      return "Krank";
+    case "field_trip":
+      return "Ausflug";
+    case "other":
+      return "Sonstiges";
   }
 }
 
@@ -405,7 +424,7 @@ export function InstanceDetailSlideOver({
                   disabled={pendingAction !== null}
                 >
                   <span className="inline-flex items-center gap-2">
-                    <Square className="h-4 w-4" />
+                    <CheckCircle2 className="h-4 w-4" />
                     Beenden
                   </span>
                 </Button>
@@ -519,17 +538,19 @@ function StudentGroup({
             </div>
             <div className="text-[11px] text-slate-500">
               {attendanceLabel(student.status)}
-              {student.substatus ? ` • ${student.substatus}` : ""}
+              {student.substatus
+                ? ` • ${attendanceSubstatusLabel(student.substatus)}`
+                : ""}
               {student.note ? ` • ${student.note}` : ""}
             </div>
           </div>
           {onAttendancePatch && (
-            <div className="flex items-center gap-1">
+            <div className="flex shrink-0 items-center gap-1">
               {student.status !== "present" && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
+                <IconActionButton
+                  icon={<Check className="h-3.5 w-3.5" />}
+                  label="Als anwesend markieren"
+                  tone="green"
                   isLoading={pendingStudentId === student.studentId}
                   disabled={pendingStudentId !== null}
                   onClick={() =>
@@ -538,15 +559,13 @@ function StudentGroup({
                       substatus: null,
                     })
                   }
-                >
-                  Anwesend
-                </Button>
+                />
               )}
               {student.status !== "absent" && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
+                <IconActionButton
+                  icon={<X className="h-3.5 w-3.5" />}
+                  label="Als fehlend markieren"
+                  tone="red"
                   isLoading={pendingStudentId === student.studentId}
                   disabled={pendingStudentId !== null}
                   onClick={() =>
@@ -555,15 +574,13 @@ function StudentGroup({
                       substatus: null,
                     })
                   }
-                >
-                  Fehlt
-                </Button>
+                />
               )}
               {student.status !== "expected" && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
+                <IconActionButton
+                  icon={<RotateCcw className="h-3.5 w-3.5" />}
+                  label="Status zurücksetzen"
+                  tone="slate"
                   isLoading={pendingStudentId === student.studentId}
                   disabled={pendingStudentId !== null}
                   onClick={() =>
@@ -573,9 +590,7 @@ function StudentGroup({
                       note: null,
                     })
                   }
-                >
-                  Zurücksetzen
-                </Button>
+                />
               )}
             </div>
           )}
@@ -590,6 +605,51 @@ function EmptyLine({ children }: { children: React.ReactNode }) {
     <div className="rounded-md border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-xs text-slate-500">
       {children}
     </div>
+  );
+}
+
+type IconActionTone = "green" | "red" | "slate";
+
+interface IconActionButtonProps {
+  icon: React.ReactNode;
+  label: string;
+  tone: IconActionTone;
+  onClick: () => void;
+  isLoading?: boolean;
+  disabled?: boolean;
+}
+
+const ICON_ACTION_PALETTE: Record<IconActionTone, string> = {
+  green:
+    "border-[#BBF7D0] bg-white text-[#15803D] hover:border-[#86EFAC] hover:bg-[#F0FDF4]",
+  red: "border-[#FECACA] bg-white text-[#B91C1C] hover:border-[#FCA5A5] hover:bg-[#FEF2F2]",
+  slate:
+    "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50",
+};
+
+function IconActionButton({
+  icon,
+  label,
+  tone,
+  onClick,
+  isLoading,
+  disabled,
+}: IconActionButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled || isLoading}
+      title={label}
+      aria-label={label}
+      className={`inline-flex h-7 w-7 items-center justify-center rounded-full border transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${ICON_ACTION_PALETTE[tone]}`}
+    >
+      {isLoading ? (
+        <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+      ) : (
+        icon
+      )}
+    </button>
   );
 }
 
@@ -632,57 +692,94 @@ interface StatsRowProps {
 function StatsRow({ instance }: StatsRowProps) {
   const expected = instance.expectedStudentsCount;
   const present = instance.presentStudentsCount;
+  const totalStudents = expected + present;
+  const activeStaff = instance.staffCount - instance.absentStaffCount;
+
+  const studentTone: StatPillTone =
+    totalStudents === 0 ? "slate" : present > 0 ? "green" : "slate";
+  const staffTone: StatPillTone =
+    instance.staffCount === 0
+      ? "slate"
+      : instance.absentStaffCount > 0
+        ? "amber"
+        : "blue";
+
   return (
-    <div className="grid grid-cols-3 gap-2">
-      <StatBox
+    <div className="flex flex-wrap items-center gap-1.5">
+      <StatPill
+        icon={<Users className="h-3.5 w-3.5" />}
         label="Anwesend"
-        value={present > 0 ? `${present} / ${expected + present}` : "—"}
-        color="#15803D"
-        bg="#F0FDF4"
-        border="#BBF7D0"
+        value={totalStudents === 0 ? "—" : `${present} / ${totalStudents}`}
+        tone={studentTone}
       />
-      <StatBox
+      <StatPill
+        icon={<UserCheck className="h-3.5 w-3.5" />}
         label="Personal"
-        value={`${instance.staffCount - instance.absentStaffCount} / ${instance.staffCount}`}
-        color="#1E3A8A"
-        bg="#EFF6FF"
-        border="#BFDBFE"
-      />
-      <StatBox
-        label="Status"
-        value={getStatusLabel(instance.status)}
-        color={instance.status === "cancelled" ? "#7F1D1D" : "#1F2937"}
-        bg={instance.status === "cancelled" ? "#FEF2F2" : "#F8FAFC"}
-        border={instance.status === "cancelled" ? "#FECACA" : "#E2E8F0"}
+        value={
+          instance.staffCount === 0
+            ? "—"
+            : `${activeStaff} / ${instance.staffCount}`
+        }
+        tone={staffTone}
       />
     </div>
   );
 }
 
-interface StatBoxProps {
+type StatPillTone = "green" | "blue" | "amber" | "slate";
+
+interface StatPillProps {
+  icon: React.ReactNode;
   label: string;
   value: string;
-  color: string;
-  bg: string;
-  border: string;
+  tone: StatPillTone;
 }
 
-function StatBox({ label, value, color, bg, border }: StatBoxProps) {
+const STAT_PILL_PALETTE: Record<
+  StatPillTone,
+  { bg: string; border: string; accent: string; muted: string }
+> = {
+  green: {
+    bg: "#F0FDF4",
+    border: "#BBF7D0",
+    accent: "#15803D",
+    muted: "#166534CC",
+  },
+  blue: {
+    bg: "#EFF6FF",
+    border: "#BFDBFE",
+    accent: "#1E40AF",
+    muted: "#1E3A8ACC",
+  },
+  amber: {
+    bg: "#FEF3C7",
+    border: "#FDE68A",
+    accent: "#92400E",
+    muted: "#78350FCC",
+  },
+  slate: {
+    bg: "#F8FAFC",
+    border: "#E2E8F0",
+    accent: "#334155",
+    muted: "#475569CC",
+  },
+};
+
+function StatPill({ icon, label, value, tone }: StatPillProps) {
+  const { bg, border, accent, muted } = STAT_PILL_PALETTE[tone];
   return (
-    <div
-      className="rounded-md border px-3 py-2"
-      style={{ backgroundColor: bg, borderColor: border }}
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs"
+      style={{ backgroundColor: bg, borderColor: border, color: accent }}
     >
-      <div
-        className="text-[10px] font-semibold tracking-wide uppercase"
-        style={{ color }}
-      >
+      <span aria-hidden className="flex shrink-0 items-center">
+        {icon}
+      </span>
+      <span className="font-medium" style={{ color: muted }}>
         {label}
-      </div>
-      <div className="text-base font-bold" style={{ color }}>
-        {value}
-      </div>
-    </div>
+      </span>
+      <span className="font-bold tabular-nums">{value}</span>
+    </span>
   );
 }
 

--- a/frontend/src/components/timetable/period-switcher-dropdown.tsx
+++ b/frontend/src/components/timetable/period-switcher-dropdown.tsx
@@ -168,7 +168,7 @@ export function PeriodSwitcherDropdown({
       </button>
 
       {open && (
-        <div className="absolute right-0 z-30 mt-2 w-96 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-md">
+        <div className="absolute left-0 z-30 mt-2 w-[calc(100vw-3rem)] max-w-96 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-md sm:right-0 sm:left-auto sm:w-96">
           <div className="border-b border-slate-100 px-4 py-3">
             <p className="text-sm font-semibold text-slate-900">
               Planungsperiode

--- a/frontend/src/components/timetable/planning-menu.tsx
+++ b/frontend/src/components/timetable/planning-menu.tsx
@@ -93,14 +93,14 @@ export function PlanningMenu({
 
   return (
     <>
-      <div className="relative" ref={containerRef}>
+      <div className="relative w-full sm:w-auto" ref={containerRef}>
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
           disabled={disabled || isPending}
           aria-haspopup="menu"
           aria-expanded={open}
-          className={`inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${triggerClass}`}
+          className={`inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-md px-3 text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto ${triggerClass}`}
         >
           {isPending ? (
             <RefreshCw className="h-3.5 w-3.5 animate-spin" aria-hidden />
@@ -118,7 +118,7 @@ export function PlanningMenu({
           <div
             role="menu"
             aria-label="Planungsoptionen"
-            className="absolute right-0 z-30 mt-2 w-80 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-md"
+            className="absolute right-0 z-30 mt-2 w-[min(20rem,calc(100vw-2rem))] overflow-hidden rounded-lg border border-slate-200 bg-white shadow-md"
           >
             <button
               type="button"

--- a/frontend/src/components/timetable/timetable-small-components.test.tsx
+++ b/frontend/src/components/timetable/timetable-small-components.test.tsx
@@ -218,6 +218,56 @@ describe("small timetable components", () => {
     expect(onDensityChange).toHaveBeenCalledWith("comfortable");
   });
 
+  it("closes the toolbar density menu from keyboard and outside clicks", () => {
+    render(
+      <TimetableToolbar
+        view="week"
+        onViewChange={vi.fn()}
+        rangeLabel="KW 19"
+        onPrev={vi.fn()}
+        onNext={vi.fn()}
+        onToday={vi.fn()}
+        density="normal"
+        onDensityChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Weitere Optionen"));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Weitere Optionen"));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("hides irrelevant toolbar controls for series and today states", () => {
+    render(
+      <TimetableToolbar
+        view="series"
+        onViewChange={vi.fn()}
+        rangeLabel="Serien"
+        onPrev={vi.fn()}
+        onNext={vi.fn()}
+        onToday={vi.fn()}
+        isOnToday
+        navDisabled
+      />,
+    );
+
+    expect(
+      screen.queryByLabelText("Vorheriger Zeitraum"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Heute" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Weitere Optionen")).not.toBeInTheDocument();
+  });
+
   it("renders week/month/year grids and forwards date selections", () => {
     const onInstanceClick = vi.fn();
     const onDayClick = vi.fn();

--- a/frontend/src/components/timetable/timetable-toolbar.tsx
+++ b/frontend/src/components/timetable/timetable-toolbar.tsx
@@ -81,12 +81,12 @@ export function TimetableToolbar({
   const showDensity = view === "week" && density && onDensityChange;
 
   return (
-    <div className="flex flex-wrap items-center gap-3 border-b border-slate-200 bg-white px-6 py-2.5">
+    <div className="flex flex-col gap-3 border-b border-slate-200 bg-white px-4 py-3 sm:px-6 lg:flex-row lg:items-center lg:py-2.5">
       {/* Segmented view tabs */}
       <div
         role="tablist"
         aria-label="Ansicht wählen"
-        className="inline-flex items-center rounded-md bg-slate-100 p-0.5"
+        className="grid w-full grid-cols-4 rounded-md bg-slate-100 p-0.5 sm:inline-flex sm:w-auto sm:items-center lg:self-auto"
       >
         {VIEW_TABS.map((tab) => {
           const isActive = view === tab.id;
@@ -97,7 +97,7 @@ export function TimetableToolbar({
               type="button"
               aria-selected={isActive}
               onClick={() => onViewChange(tab.id)}
-              className={`rounded px-3 py-1 text-[13px] font-medium transition-colors ${
+              className={`rounded px-2 py-1.5 text-[13px] font-medium transition-colors sm:px-3 sm:py-1 ${
                 isActive
                   ? "bg-white text-slate-900 shadow-sm"
                   : "text-slate-600 hover:text-slate-900"
@@ -110,30 +110,33 @@ export function TimetableToolbar({
       </div>
 
       {showRangeNav && (
-        <>
-          <div className="h-6 w-px bg-slate-200" aria-hidden />
+        <div className="grid min-w-0 grid-cols-[2rem_minmax(0,1fr)_2rem] items-center gap-x-2 gap-y-2 sm:flex sm:gap-3">
+          <div className="hidden h-6 w-px bg-slate-200 lg:block" aria-hidden />
 
           {/* Date navigator — ghost buttons, no borders */}
-          <div className="flex items-center gap-0.5">
-            <button
-              type="button"
-              onClick={onPrev}
-              disabled={navDisabled}
-              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-40"
-              aria-label="Vorheriger Zeitraum"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
-            <button
-              type="button"
-              onClick={onNext}
-              disabled={navDisabled}
-              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-40"
-              aria-label="Nächster Zeitraum"
-            >
-              <ChevronRight className="h-4 w-4" />
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={onPrev}
+            disabled={navDisabled}
+            className="order-1 inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-40"
+            aria-label="Vorheriger Zeitraum"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+
+          <span className="order-2 min-w-0 text-center text-sm leading-tight font-semibold text-slate-900 tabular-nums sm:order-4 sm:truncate sm:text-left">
+            {rangeLabel}
+          </span>
+
+          <button
+            type="button"
+            onClick={onNext}
+            disabled={navDisabled}
+            className="order-3 inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-40 sm:order-2"
+            aria-label="Nächster Zeitraum"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
 
           {/* Today pill — only when not already on today */}
           {!isOnToday && (
@@ -141,38 +144,38 @@ export function TimetableToolbar({
               type="button"
               onClick={onToday}
               disabled={navDisabled}
-              className="inline-flex h-8 items-center rounded-md border border-slate-200 px-2.5 text-[12px] font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+              className="order-4 col-span-3 inline-flex h-8 items-center justify-self-center rounded-md border border-slate-200 px-2.5 text-[12px] font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 sm:order-3"
             >
               Heute
             </button>
           )}
-
-          <span className="text-sm font-semibold text-slate-900 tabular-nums">
-            {rangeLabel}
-          </span>
-        </>
-      )}
-
-      {/* Spacer pushes everything below to the right */}
-      <div className="flex-1" />
-
-      {onAddInstance && (
-        <div className="flex items-center gap-1.5">
-          <button
-            type="button"
-            onClick={onAddInstance}
-            className="inline-flex h-8 items-center gap-1 rounded-md bg-slate-900 px-2.5 text-[12px] font-medium text-white transition-colors hover:bg-slate-700"
-          >
-            <Plus className="h-3.5 w-3.5" />
-            Termin
-          </button>
         </div>
       )}
 
-      {planWeekAction}
+      {/* Spacer pushes everything below to the right */}
+      <div className="hidden flex-1 lg:block" />
 
-      {showDensity && (
-        <DensityMenu density={density} onDensityChange={onDensityChange} />
+      {(onAddInstance || planWeekAction || showDensity) && (
+        <div className="flex w-full items-stretch gap-2 sm:w-auto sm:items-center lg:ml-auto">
+          {planWeekAction && (
+            <div className="min-w-0 flex-1 sm:flex-none">{planWeekAction}</div>
+          )}
+
+          {onAddInstance && (
+            <button
+              type="button"
+              onClick={onAddInstance}
+              className="inline-flex h-8 items-center gap-1 rounded-md bg-slate-900 px-2.5 text-[12px] font-medium text-white transition-colors hover:bg-slate-700"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Termin
+            </button>
+          )}
+
+          {showDensity && (
+            <DensityMenu density={density} onDensityChange={onDensityChange} />
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/timetable/weekly-calendar-grid.tsx
+++ b/frontend/src/components/timetable/weekly-calendar-grid.tsx
@@ -30,8 +30,10 @@ import type { EnrichedInstance } from "~/lib/timetable-types";
 
 import { InstanceBlock } from "./instance-block";
 
-const TIME_GUTTER_WIDTH_PX = 64;
-const DAY_HEADER_HEIGHT_PX = 56;
+// Grid template columns: narrow time gutter + 7 day columns (Mo-So).
+// Mobile uses a 40px gutter so the day cells get ~48px each on iPhone SE.
+const GRID_COLS_CLASS =
+  "grid-cols-[40px_repeat(7,minmax(0,1fr))] sm:grid-cols-[64px_repeat(7,minmax(0,1fr))]";
 
 interface WeeklyCalendarGridProps {
   weekDays: Date[]; // Mo-So (7 dates)
@@ -101,11 +103,7 @@ export function WeeklyCalendarGrid({
     <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
       {/* Sticky day header */}
       <div
-        className="grid border-b border-slate-200 bg-white"
-        style={{
-          gridTemplateColumns: `${TIME_GUTTER_WIDTH_PX}px repeat(${weekDays.length}, minmax(0, 1fr))`,
-          height: `${DAY_HEADER_HEIGHT_PX}px`,
-        }}
+        className={`grid h-[52px] border-b border-slate-200 bg-white sm:h-14 ${GRID_COLS_CLASS}`}
       >
         <div aria-hidden />
         {weekDays.map((day) => {
@@ -114,21 +112,21 @@ export function WeeklyCalendarGrid({
           return (
             <div
               key={iso}
-              className="flex items-center justify-center gap-2 border-l border-slate-200 px-2 py-2"
+              className="flex min-w-0 flex-col items-center justify-center gap-0.5 border-l border-slate-200 px-1 py-1 sm:flex-row sm:gap-2 sm:px-2 sm:py-2"
             >
-              <span className="text-[11px] font-medium tracking-wide text-slate-500 uppercase">
+              <span className="text-[10px] font-medium tracking-wide text-slate-500 uppercase sm:text-[11px]">
                 {getGermanWeekdayShort(day)}
               </span>
               {isToday ? (
                 <span
-                  className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-slate-900 text-[12px] font-semibold text-white tabular-nums"
+                  className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-slate-900 text-[11px] font-semibold text-white tabular-nums sm:h-6 sm:w-6 sm:text-[12px]"
                   aria-label={formatDayHeader(day)}
                 >
                   {day.getDate()}
                 </span>
               ) : (
                 <span
-                  className="text-[14px] font-semibold text-slate-900 tabular-nums"
+                  className="text-[12px] font-semibold text-slate-900 tabular-nums sm:text-[14px]"
                   aria-label={formatDayHeader(day)}
                 >
                   {String(day.getDate()).padStart(2, "0")}
@@ -141,12 +139,7 @@ export function WeeklyCalendarGrid({
 
       {/* Scrollable body */}
       <div className="relative max-h-[720px] overflow-y-auto">
-        <div
-          className="grid"
-          style={{
-            gridTemplateColumns: `${TIME_GUTTER_WIDTH_PX}px repeat(${weekDays.length}, minmax(0, 1fr))`,
-          }}
-        >
+        <div className={`grid ${GRID_COLS_CLASS}`}>
           {/* Time gutter */}
           <div
             className="border-r border-slate-200 bg-slate-50"
@@ -155,7 +148,7 @@ export function WeeklyCalendarGrid({
             {hours.slice(0, -1).map((hour) => (
               <div
                 key={hour}
-                className="flex items-start justify-end px-2 pt-1 text-[11px] font-medium text-slate-400"
+                className="flex items-start justify-end px-1 pt-1 text-[10px] font-medium text-slate-400 sm:px-2 sm:text-[11px]"
                 style={{ height: `${hourHeightPx}px` }}
               >
                 {String(hour).padStart(2, "0")}:00
@@ -180,7 +173,7 @@ export function WeeklyCalendarGrid({
             return (
               <div
                 key={iso}
-                className={`relative border-l border-slate-200 ${isToday ? "bg-slate-50/60" : ""}`}
+                className={`relative min-w-0 border-l border-slate-200 ${isToday ? "bg-slate-50/60" : ""}`}
                 style={{ height: `${gridHeightPx}px` }}
               >
                 {/* Hour grid lines */}
@@ -245,9 +238,9 @@ export function WeeklyCalendarGrid({
                   </>
                 )}
 
-                {/* Empty-state hint */}
+                {/* Empty-state hint (hidden on mobile: column too narrow) */}
                 {dayInstances.length === 0 && (
-                  <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                  <div className="pointer-events-none absolute inset-0 hidden items-center justify-center sm:flex">
                     <span className="text-[11px] text-slate-400 italic">
                       Keine Aktivitäten
                     </span>

--- a/frontend/src/components/timetable/weekly-calendar-grid.tsx
+++ b/frontend/src/components/timetable/weekly-calendar-grid.tsx
@@ -4,8 +4,8 @@
  * WeeklyCalendarGrid — Apple-Calendar-style week view.
  *
  * Layout: a sticky day-header row above a vertically scrollable body.
- * Inside the body: a fixed time-gutter on the left and 5 day columns
- * (Mo-Fr). Each day column is a positioned container; events are placed
+ * Inside the body: a fixed time-gutter on the left and 7 day columns
+ * (Mo-So). Each day column is a positioned container; events are placed
  * absolutely via `getEventBlockPosition`. Overlapping events split a
  * column horizontally via `assignBlockLanes`.
  *
@@ -34,7 +34,7 @@ const TIME_GUTTER_WIDTH_PX = 64;
 const DAY_HEADER_HEIGHT_PX = 56;
 
 interface WeeklyCalendarGridProps {
-  weekDays: Date[]; // Mo-Fr (5 dates)
+  weekDays: Date[]; // Mo-So (7 dates)
   instances: EnrichedInstance[];
   selectedId: string | null;
   onInstanceClick: (instance: EnrichedInstance) => void;

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -298,6 +298,42 @@ describe("useGlobalSSE", () => {
       expect(mutate).toHaveBeenCalled();
     });
 
+    it("invalidates active supervision caches on active_supervision_changed event", () => {
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      onMessage?.({
+        type: "active_supervision_changed",
+        active_group_id: "456",
+        data: { reason: "instance_started" },
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+
+      const mutateCalls = vi.mocked(mutate).mock.calls;
+      const activeSupervisionCall = mutateCalls.find((call) => {
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)(
+            "tenant:active-supervision-dashboard-0",
+          ) &&
+          (matcher as (key: string) => boolean)("tenant:supervision-visits-456")
+        );
+      });
+      expect(activeSupervisionCall).toBeDefined();
+
+      const matcher = activeSupervisionCall![0] as (key: string) => boolean;
+      expect(matcher("tenant:supervision-visits-456")).toBe(true);
+      expect(matcher("tenant:room-detail-12")).toBe(true);
+      expect(matcher("tenant:tracking-supervisions-1")).toBe(true);
+      expect(matcher("tenant:tracking-indicators-search")).toBe(true);
+      expect(matcher("tenant:dashboard")).toBe(true);
+      expect(matcher("tenant:timetable-week")).toBe(false);
+    });
+
     it("invalidates dashboard caches on dashboard_counts_changed event", () => {
       renderHook(() => useGlobalSSE());
 

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -306,7 +306,7 @@ describe("useGlobalSSE", () => {
       onMessage?.({
         type: "active_supervision_changed",
         active_group_id: "456",
-        data: { reason: "instance_started" },
+        data: { reason: "instance_started", student_id: "77" },
         timestamp: new Date().toISOString(),
       });
 
@@ -339,6 +339,15 @@ describe("useGlobalSSE", () => {
       expect(matcher("tenant:tracking-indicators-search")).toBe(true);
       expect(matcher("tenant:dashboard")).toBe(true);
       expect(matcher("tenant:timetable-week")).toBe(false);
+
+      const studentDetailCall = mutateCalls.find((call) => {
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)("tenant:student-detail-77")
+        );
+      });
+      expect(studentDetailCall).toBeDefined();
     });
 
     it("invalidates dashboard caches on dashboard_counts_changed event", () => {
@@ -502,6 +511,33 @@ describe("useGlobalSSE", () => {
         );
       });
       expect(dashboardCall).toBeDefined();
+    });
+
+    it("handles mutate rejection in student_updated detail scope gracefully", async () => {
+      vi.mocked(mutate).mockRejectedValue(new Error("SWR error"));
+      const consoleSpy = vi
+        .spyOn(console, "debug")
+        .mockImplementation(() => undefined);
+
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+      onMessage?.({
+        type: "student_updated",
+        active_group_id: "",
+        data: {},
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+      await vi.runAllTimersAsync();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "swr_revalidation_failed",
+        expect.objectContaining({ scope: "student_detail" }),
+      );
+
+      consoleSpy.mockRestore();
     });
 
     it("student_checkout without active_group_id does NOT invalidate supervision-visits", () => {
@@ -717,6 +753,33 @@ describe("useGlobalSSE", () => {
       consoleSpy.mockRestore();
     });
 
+    it("handles mutate rejection in active_supervision scope gracefully", async () => {
+      vi.mocked(mutate).mockRejectedValue(new Error("SWR error"));
+      const consoleSpy = vi
+        .spyOn(console, "debug")
+        .mockImplementation(() => undefined);
+
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+      onMessage?.({
+        type: "active_supervision_changed",
+        active_group_id: "1",
+        data: {},
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+      await vi.runAllTimersAsync();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "swr_revalidation_failed",
+        expect.objectContaining({ scope: "active_supervision" }),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
     it("handles mutate rejection in supervision_visits scope gracefully", async () => {
       vi.mocked(mutate).mockRejectedValue(new Error("SWR error"));
       const consoleSpy = vi
@@ -739,6 +802,63 @@ describe("useGlobalSSE", () => {
       expect(consoleSpy).toHaveBeenCalledWith(
         "swr_revalidation_failed",
         expect.objectContaining({ scope: "supervision_visits" }),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("invalidates timetable caches on instance lifecycle events", () => {
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      onMessage?.({
+        type: "instance_started",
+        active_group_id: "",
+        data: {},
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+
+      const mutateCalls = vi.mocked(mutate).mock.calls;
+      const timetableCall = mutateCalls.find((call) => {
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)("tenant:timetable-week")
+        );
+      });
+      expect(timetableCall).toBeDefined();
+
+      const matcher = timetableCall![0] as (key: string) => boolean;
+      expect(matcher("tenant:timetable-month-2026-05")).toBe(true);
+      expect(matcher("tenant:database-calendar-periods-list")).toBe(true);
+      expect(matcher("tenant:supervision-visits-1")).toBe(false);
+    });
+
+    it("handles mutate rejection in timetable scope gracefully", async () => {
+      vi.mocked(mutate).mockRejectedValue(new Error("SWR error"));
+      const consoleSpy = vi
+        .spyOn(console, "debug")
+        .mockImplementation(() => undefined);
+
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+      onMessage?.({
+        type: "instance_completed",
+        active_group_id: "",
+        data: {},
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+      await vi.runAllTimersAsync();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "swr_revalidation_failed",
+        expect.objectContaining({ scope: "timetable" }),
       );
 
       consoleSpy.mockRestore();

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -128,6 +128,63 @@ describe("useGlobalSSE", () => {
       );
     });
 
+    it("is disabled when authenticated session has no access token", () => {
+      vi.mocked(useSession).mockReturnValueOnce({
+        status: "authenticated",
+        data: {
+          user: { tenantId: 1, roles: ["user"] },
+        } as never,
+        update: vi.fn(),
+      });
+
+      renderHook(() => useGlobalSSE());
+
+      expect(useSSE).toHaveBeenCalledWith(
+        "/api/sse/events",
+        expect.objectContaining({
+          enabled: false,
+        }),
+      );
+    });
+
+    it("is disabled for authenticated users without staff or admin roles", () => {
+      vi.mocked(useSession).mockReturnValueOnce({
+        status: "authenticated",
+        data: {
+          user: { token: "test-token", tenantId: 1, roles: ["guardian"] },
+        } as never,
+        update: vi.fn(),
+      });
+
+      renderHook(() => useGlobalSSE());
+
+      expect(useSSE).toHaveBeenCalledWith(
+        "/api/sse/events",
+        expect.objectContaining({
+          enabled: false,
+        }),
+      );
+    });
+
+    it("is disabled when authenticated session has no role list", () => {
+      vi.mocked(useSession).mockReturnValueOnce({
+        status: "authenticated",
+        data: {
+          user: { token: "test-token", tenantId: 1 },
+        } as never,
+        update: vi.fn(),
+      });
+
+      renderHook(() => useGlobalSSE());
+
+      expect(useSSE).toHaveBeenCalledWith(
+        "/api/sse/events",
+        expect.objectContaining({
+          enabled: false,
+        }),
+      );
+    });
+
     it("passes tenantId as reconnectKey to useSSE", () => {
       vi.mocked(useSession).mockReturnValueOnce({
         status: "authenticated",

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -320,13 +320,20 @@ describe("useGlobalSSE", () => {
           (matcher as (key: string) => boolean)(
             "tenant:active-supervision-dashboard-0",
           ) &&
-          (matcher as (key: string) => boolean)("tenant:supervision-visits-456")
+          (matcher as (key: string) => boolean)(
+            "tenant:supervision-visits-456",
+          ) &&
+          (matcher as (key: string) => boolean)(
+            "tenant:timetable-roster-active-group-456",
+          )
         );
       });
       expect(activeSupervisionCall).toBeDefined();
 
       const matcher = activeSupervisionCall![0] as (key: string) => boolean;
       expect(matcher("tenant:supervision-visits-456")).toBe(true);
+      expect(matcher("tenant:timetable-roster-123")).toBe(true);
+      expect(matcher("tenant:timetable-roster-active-group-456")).toBe(true);
       expect(matcher("tenant:room-detail-12")).toBe(true);
       expect(matcher("tenant:tracking-supervisions-1")).toBe(true);
       expect(matcher("tenant:tracking-indicators-search")).toBe(true);

--- a/frontend/src/lib/hooks/__tests__/use-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-sse.test.ts
@@ -221,6 +221,30 @@ describe("useSSE Hook", () => {
         { timeout: 500 },
       );
     });
+
+    it("should handle active_supervision_changed typed events", async () => {
+      const onMessage = vi.fn();
+      renderHook(() => useSSE("/api/sse/events", { onMessage }));
+
+      await waitForEventSource();
+      mockEventSource?.triggerOpen();
+
+      const testEvent: SSEEvent = {
+        type: "active_supervision_changed",
+        active_group_id: "123",
+        data: { reason: "instance_started" },
+        timestamp: new Date().toISOString(),
+      };
+
+      mockEventSource?.triggerMessage(testEvent, "active_supervision_changed");
+
+      await waitFor(
+        () => {
+          expect(onMessage).toHaveBeenCalledWith(testEvent);
+        },
+        { timeout: 500 },
+      );
+    });
   });
 
   describe("Reconnection Logic", () => {

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -229,6 +229,7 @@ export function useGlobalSSE(): SSEHookState {
           typeof key === "string" &&
           (key.includes("active-supervision-dashboard-") ||
             key.includes("supervision-visits-") ||
+            key.includes("timetable-roster-") ||
             key.includes("room-detail-") ||
             key.includes("tracking-supervisions-") ||
             key.includes("tracking-indicators-") ||

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -62,6 +62,7 @@ export function useGlobalSSE(): SSEHookState {
   const pendingGroupIds = useRef(new Set<string>());
   const pendingStudentIds = useRef(new Set<string>());
   const hasPendingActivityEvent = useRef(false);
+  const hasPendingActiveSupervisionEvent = useRef(false);
   const hasPendingDashboardEvent = useRef(false);
   const hasPendingDailyCheckoutDashboardEvent = useRef(false);
   const hasPendingArrivalScheduleEvent = useRef(false);
@@ -186,6 +187,7 @@ export function useGlobalSSE(): SSEHookState {
       pendingGroupIds.current.size > 0 ||
       pendingStudentIds.current.size > 0 ||
       hasPendingActivityEvent.current ||
+      hasPendingActiveSupervisionEvent.current ||
       hasPendingDashboardEvent.current ||
       hasPendingDailyCheckoutDashboardEvent.current ||
       hasPendingArrivalScheduleEvent.current ||
@@ -221,6 +223,24 @@ export function useGlobalSSE(): SSEHookState {
       });
     }
 
+    if (hasPendingActiveSupervisionEvent.current) {
+      mutate(
+        (key) =>
+          typeof key === "string" &&
+          (key.includes("active-supervision-dashboard-") ||
+            key.includes("supervision-visits-") ||
+            key.includes("room-detail-") ||
+            key.includes("tracking-supervisions-") ||
+            key.includes("tracking-indicators-") ||
+            key.includes("dashboard")),
+      ).catch((err) => {
+        logger.debug("swr_revalidation_failed", {
+          error: err instanceof Error ? err.message : String(err),
+          scope: "active_supervision",
+        });
+      });
+    }
+
     if (hasPendingTimetableEvent.current) {
       mutate(
         (key) =>
@@ -239,6 +259,7 @@ export function useGlobalSSE(): SSEHookState {
     pendingGroupIds.current.clear();
     pendingStudentIds.current.clear();
     hasPendingActivityEvent.current = false;
+    hasPendingActiveSupervisionEvent.current = false;
     hasPendingDashboardEvent.current = false;
     hasPendingDailyCheckoutDashboardEvent.current = false;
     hasPendingArrivalScheduleEvent.current = false;
@@ -287,6 +308,18 @@ export function useGlobalSSE(): SSEHookState {
             pendingGroupIds.current.add(event.active_group_id);
           }
           hasPendingActivityEvent.current = true;
+          scheduleFlush();
+          break;
+        }
+
+        case "active_supervision_changed": {
+          if (event.active_group_id) {
+            pendingGroupIds.current.add(event.active_group_id);
+          }
+          if (event.data.student_id) {
+            pendingStudentIds.current.add(event.data.student_id);
+          }
+          hasPendingActiveSupervisionEvent.current = true;
           scheduleFlush();
           break;
         }

--- a/frontend/src/lib/hooks/use-sse.ts
+++ b/frontend/src/lib/hooks/use-sse.ts
@@ -150,6 +150,7 @@ export function useSSE(
           "activity_start",
           "activity_end",
           "activity_update",
+          "active_supervision_changed",
           "dashboard_counts_changed",
           "arrival_schedule_changed",
           "instance_started",

--- a/frontend/src/lib/sse-types.ts
+++ b/frontend/src/lib/sse-types.ts
@@ -7,6 +7,7 @@ type SSEEventType =
   | "activity_start"
   | "activity_end"
   | "activity_update"
+  | "active_supervision_changed"
   | "dashboard_counts_changed"
   | "arrival_schedule_changed"
   // Timetable instance lifecycle events emitted by the backend (WP-B9).
@@ -42,6 +43,9 @@ interface SSEEventData {
 
   // Source tracking
   source?: "rfid" | "manual" | "automated";
+
+  // Reason tracking for generic refresh events.
+  reason?: string;
 }
 
 export interface SSEEvent {

--- a/frontend/src/lib/timetable-helpers.test.ts
+++ b/frontend/src/lib/timetable-helpers.test.ts
@@ -83,25 +83,27 @@ describe("parseTimeToMinutes", () => {
 });
 
 describe("date and range helpers", () => {
-  it("anchors week ranges to Monday through Friday", () => {
+  it("anchors week ranges to Monday through Sunday", () => {
     const { from, to } = getWeekRange(new Date("2026-05-06T12:00:00"), 0);
 
     expect(toISODate(from)).toBe("2026-05-04");
-    expect(toISODate(to)).toBe("2026-05-08");
+    expect(toISODate(to)).toBe("2026-05-10");
     expect(getWeekdays(from).map(toISODate)).toEqual([
       "2026-05-04",
       "2026-05-05",
       "2026-05-06",
       "2026-05-07",
       "2026-05-08",
+      "2026-05-09",
+      "2026-05-10",
     ]);
   });
 
-  it("treats Sunday as part of the previous school week", () => {
+  it("treats Sunday as part of the current visible week", () => {
     const { from, to } = getWeekRange(new Date("2026-05-10T12:00:00"), 0);
 
     expect(toISODate(from)).toBe("2026-05-04");
-    expect(toISODate(to)).toBe("2026-05-08");
+    expect(toISODate(to)).toBe("2026-05-10");
   });
 
   it("expands a month to full calendar weeks", () => {
@@ -137,10 +139,11 @@ describe("date and range helpers", () => {
 
   it("formats German labels", () => {
     const monday = new Date("2026-05-04T00:00:00");
-    const friday = new Date("2026-05-08T00:00:00");
+    const sunday = new Date("2026-05-10T00:00:00");
 
-    expect(formatWeekLabel(monday, friday)).toContain("KW 19");
-    expect(formatWeekLabel(monday, friday)).toContain("04.05");
+    expect(formatWeekLabel(monday, sunday)).toContain("KW 19");
+    expect(formatWeekLabel(monday, sunday)).toContain("04.05");
+    expect(formatWeekLabel(monday, sunday)).toContain("So 10.05.2026");
     expect(formatDayHeader(monday)).toBe("Mo 04.05.");
     expect(formatMonthLabel(monday)).toMatch(/Mai 2026/i);
     expect(formatYearLabel(monday)).toBe("2026");

--- a/frontend/src/lib/timetable-helpers.ts
+++ b/frontend/src/lib/timetable-helpers.ts
@@ -107,9 +107,9 @@ function getMondayOfWeek(ref: Date, weekOffset = 0): Date {
 }
 
 /**
- * Returns Monday and Friday (00:00 local) for the requested week. The
- * backend /instances endpoint accepts an inclusive range, so Friday is the
- * "to" boundary — Saturday and Sunday are not OGS days.
+ * Returns Monday and Sunday (00:00 local) for the requested week. The
+ * backend /instances endpoint accepts an inclusive range, so Sunday is the
+ * "to" boundary for the full calendar week.
  */
 export function getWeekRange(
   ref: Date,
@@ -117,7 +117,7 @@ export function getWeekRange(
 ): { from: Date; to: Date } {
   const from = getMondayOfWeek(ref, weekOffset);
   const to = new Date(from);
-  to.setDate(to.getDate() + 4); // Mo + 4 = Fr
+  to.setDate(to.getDate() + 6); // Mo + 6 = So
   return { from, to };
 }
 
@@ -206,7 +206,7 @@ export function getGermanWeekdayShort(d: Date): string {
 }
 
 /**
- * "KW 38 • Mo 22.09 – Fr 26.09.2026" — the week-navigator header.
+ * "KW 38 • Mo 22.09 – So 28.09.2026" — the week-navigator header.
  */
 export function formatWeekLabel(from: Date, to: Date): string {
   const kw = getISOWeekNumber(from);
@@ -215,7 +215,7 @@ export function formatWeekLabel(from: Date, to: Date): string {
   const toDay = String(to.getDate()).padStart(2, "0");
   const toMonth = String(to.getMonth() + 1).padStart(2, "0");
   const year = to.getFullYear();
-  return `KW ${kw} • Mo ${fromDay}.${fromMonth} – Fr ${toDay}.${toMonth}.${year}`;
+  return `KW ${kw} • Mo ${fromDay}.${fromMonth} – So ${toDay}.${toMonth}.${year}`;
 }
 
 /**
@@ -229,12 +229,12 @@ export function formatDayHeader(d: Date): string {
 }
 
 /**
- * Five Monday→Friday Date objects for the week containing `from`. Used to
+ * Seven Monday→Sunday Date objects for the week containing `from`. Used to
  * label the grid columns even on weeks with no instances.
  */
 export function getWeekdays(from: Date): Date[] {
   const days: Date[] = [];
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 7; i++) {
     const d = new Date(from);
     d.setDate(d.getDate() + i);
     days.push(d);

--- a/frontend/src/lib/timetable-operations-api.test.ts
+++ b/frontend/src/lib/timetable-operations-api.test.ts
@@ -51,6 +51,26 @@ describe("timetableOperationsApi", () => {
     expect(result[0]?.assignedStaffIds).toEqual(["330"]);
   });
 
+  it("fetches planned instances without a date query", async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: { instances: [] },
+      }),
+    );
+
+    const result = await timetableOperationsApi.plannedNow();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/timetable/operations/planned-now",
+      {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      },
+    );
+    expect(result).toEqual([]);
+  });
+
   it("posts start and maps the response", async () => {
     const mockFetch = vi.mocked(globalThis.fetch);
     mockFetch.mockResolvedValueOnce(
@@ -185,6 +205,7 @@ describe("timetableOperationsApi", () => {
       .mockResolvedValueOnce(
         jsonResponse({ error: "Nicht erlaubt" }, false, 403),
       )
+      .mockResolvedValueOnce(jsonResponse({}, false, 418))
       .mockResolvedValueOnce({
         ok: false,
         status: 500,
@@ -193,6 +214,9 @@ describe("timetableOperationsApi", () => {
 
     await expect(timetableOperationsApi.complete("136")).rejects.toThrow(
       "Nicht erlaubt",
+    );
+    await expect(timetableOperationsApi.complete("136")).rejects.toThrow(
+      "Anfrage fehlgeschlagen (HTTP 418)",
     );
     await expect(timetableOperationsApi.complete("136")).rejects.toThrow(
       "Anfrage fehlgeschlagen (HTTP 500)",

--- a/frontend/src/lib/timetable-operations-api.test.ts
+++ b/frontend/src/lib/timetable-operations-api.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { timetableOperationsApi } from "./timetable-operations-api";
+
+describe("timetableOperationsApi", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("fetches planned instances with an encoded date query", async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: {
+          instances: [
+            {
+              id: 130,
+              title: "Lernzeit",
+              date: "2026-05-10",
+              start_time: "14:00",
+              end_time: "15:00",
+              room_id: 230,
+              status: "planned",
+              is_overdue: false,
+              minutes_until_start: 10,
+              expected_students_count: 12,
+              present_students_count: 0,
+              assigned_staff_ids: [330],
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = await timetableOperationsApi.plannedNow("2026-05-10");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/timetable/operations/planned-now?date=2026-05-10",
+      {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      },
+    );
+    expect(result[0]?.id).toBe("130");
+    expect(result[0]?.assignedStaffIds).toEqual(["330"]);
+  });
+
+  it("posts start and maps the response", async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: {
+          instance_id: 131,
+          active_group_id: 231,
+          status: "active",
+        },
+      }),
+    );
+
+    const result = await timetableOperationsApi.start("131");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/timetable/operations/instances/131/start",
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      },
+    );
+    expect(result).toEqual({
+      instanceId: "131",
+      activeGroupId: "231",
+      status: "active",
+    });
+  });
+
+  it("fetches rosters by instance and active group", async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ data: rosterPayload(132) }))
+      .mockResolvedValueOnce(jsonResponse({ data: rosterPayload(133) }));
+
+    const byInstance = await timetableOperationsApi.roster("132");
+    const byGroup = await timetableOperationsApi.rosterByActiveGroup("233");
+
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/timetable/operations/instances/132/roster",
+      {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      },
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/timetable/operations/active-groups/233/roster",
+      {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      },
+    );
+    expect(byInstance.instance.id).toBe("132");
+    expect(byGroup.instance.id).toBe("133");
+  });
+
+  it("posts check-in and check-out operations", async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ data: rosterPayload(134) }))
+      .mockResolvedValueOnce(jsonResponse({ data: rosterPayload(134) }));
+
+    await timetableOperationsApi.checkIn("134", "430");
+    await timetableOperationsApi.checkOut("134", "430");
+
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/timetable/operations/instances/134/students/430/check-in",
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      },
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/timetable/operations/instances/134/students/430/check-out",
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      },
+    );
+  });
+
+  it("patches attendance and completes an instance", async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ data: { ok: true } }))
+      .mockResolvedValueOnce(jsonResponse({ data: { ok: true } }));
+
+    await timetableOperationsApi.patchAttendance("135", "431", {
+      status: "absent",
+      substatus: "sick",
+      note: "abgemeldet",
+    });
+    await timetableOperationsApi.complete("135");
+
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/timetable/operations/instances/135/students/431/attendance",
+      {
+        method: "PATCH",
+        credentials: "include",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          status: "absent",
+          substatus: "sick",
+          note: "abgemeldet",
+        }),
+      },
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/timetable/operations/instances/135/complete",
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      },
+    );
+  });
+
+  it("uses backend error messages and falls back when JSON parsing fails", async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({ error: "Nicht erlaubt" }, false, 403),
+      )
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.reject(new Error("not json")),
+      } as Response);
+
+    await expect(timetableOperationsApi.complete("136")).rejects.toThrow(
+      "Nicht erlaubt",
+    );
+    await expect(timetableOperationsApi.complete("136")).rejects.toThrow(
+      "Anfrage fehlgeschlagen (HTTP 500)",
+    );
+  });
+});
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+function rosterPayload(instanceId: number) {
+  return {
+    instance: {
+      id: instanceId,
+      title: "Lernzeit",
+      status: "active",
+      active_group_id: 240,
+      room_id: 241,
+      room_name: "Raum A",
+    },
+    rows: [
+      {
+        student_id: 440,
+        student_name: "Mila Muster",
+        school_class: "3a",
+        group_name: "OGS Blau",
+        planned: true,
+        is_unplanned: false,
+        currently_present: true,
+        visit_id: 540,
+        status: "present",
+      },
+    ],
+  };
+}

--- a/frontend/src/lib/timetable-operations-api.ts
+++ b/frontend/src/lib/timetable-operations-api.ts
@@ -1,0 +1,149 @@
+import type {
+  AttendancePatchBody,
+  BackendStartOperationResult,
+  BackendTimetableRoster,
+  PlannedTimetableInstance,
+  StartOperationResult,
+  TimetableRoster,
+} from "./timetable-operations-types";
+import {
+  mapPlannedInstance,
+  mapRoster,
+  mapStartOperation,
+} from "./timetable-operations-types";
+
+interface ApiEnvelope<T> {
+  data: T;
+}
+
+async function unwrap<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    let message = `Anfrage fehlgeschlagen (HTTP ${response.status})`;
+    try {
+      const body = (await response.json()) as { error?: string };
+      if (body.error) message = body.error;
+    } catch {
+      // Keep generic error.
+    }
+    throw new Error(message);
+  }
+  const envelope = (await response.json()) as ApiEnvelope<T>;
+  return envelope.data;
+}
+
+export const timetableOperationsApi = {
+  async plannedNow(date?: string): Promise<PlannedTimetableInstance[]> {
+    const suffix = date ? `?date=${encodeURIComponent(date)}` : "";
+    const raw = await unwrap<{
+      instances: Parameters<typeof mapPlannedInstance>[0][];
+    }>(
+      await fetch(`/api/timetable/operations/planned-now${suffix}`, {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      }),
+    );
+    return raw.instances.map(mapPlannedInstance);
+  },
+
+  async start(instanceId: string): Promise<StartOperationResult> {
+    const raw = await unwrap<BackendStartOperationResult>(
+      await fetch(`/api/timetable/operations/instances/${instanceId}/start`, {
+        method: "POST",
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      }),
+    );
+    return mapStartOperation(raw);
+  },
+
+  async roster(instanceId: string): Promise<TimetableRoster> {
+    const raw = await unwrap<BackendTimetableRoster>(
+      await fetch(`/api/timetable/operations/instances/${instanceId}/roster`, {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      }),
+    );
+    return mapRoster(raw);
+  },
+
+  async rosterByActiveGroup(activeGroupId: string): Promise<TimetableRoster> {
+    const raw = await unwrap<BackendTimetableRoster>(
+      await fetch(
+        `/api/timetable/operations/active-groups/${activeGroupId}/roster`,
+        {
+          credentials: "include",
+          headers: { Accept: "application/json" },
+        },
+      ),
+    );
+    return mapRoster(raw);
+  },
+
+  async checkIn(
+    instanceId: string,
+    studentId: string,
+  ): Promise<TimetableRoster> {
+    const raw = await unwrap<BackendTimetableRoster>(
+      await fetch(
+        `/api/timetable/operations/instances/${instanceId}/students/${studentId}/check-in`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { Accept: "application/json" },
+        },
+      ),
+    );
+    return mapRoster(raw);
+  },
+
+  async checkOut(
+    instanceId: string,
+    studentId: string,
+  ): Promise<TimetableRoster> {
+    const raw = await unwrap<BackendTimetableRoster>(
+      await fetch(
+        `/api/timetable/operations/instances/${instanceId}/students/${studentId}/check-out`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { Accept: "application/json" },
+        },
+      ),
+    );
+    return mapRoster(raw);
+  },
+
+  async patchAttendance(
+    instanceId: string,
+    studentId: string,
+    body: AttendancePatchBody,
+  ): Promise<void> {
+    await unwrap<unknown>(
+      await fetch(
+        `/api/timetable/operations/instances/${instanceId}/students/${studentId}/attendance`,
+        {
+          method: "PATCH",
+          credentials: "include",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        },
+      ),
+    );
+  },
+
+  async complete(instanceId: string): Promise<void> {
+    await unwrap<unknown>(
+      await fetch(
+        `/api/timetable/operations/instances/${instanceId}/complete`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { Accept: "application/json" },
+        },
+      ),
+    );
+  },
+};

--- a/frontend/src/lib/timetable-operations-types.test.ts
+++ b/frontend/src/lib/timetable-operations-types.test.ts
@@ -122,6 +122,64 @@ describe("timetable operation mappers", () => {
     });
   });
 
+  it("maps nullable roster instance fields", () => {
+    const raw: BackendTimetableRoster = {
+      instance: {
+        id: 123,
+        title: "Spätbetreuung",
+        status: "planned",
+        active_group_id: null,
+        room_id: 224,
+        room_name: "Raum B",
+      },
+      rows: [
+        {
+          student_id: 422,
+          student_name: "Nora Null",
+          school_class: "2c",
+          group_name: "OGS Grün",
+          planned: true,
+          is_unplanned: false,
+          currently_present: false,
+          visit_id: null,
+          status: "absent",
+          substatus: null,
+          note: null,
+          checked_in_at: null,
+          visit_entry_time: null,
+        },
+      ],
+    };
+
+    expect(mapRoster(raw)).toEqual({
+      instance: {
+        id: "123",
+        title: "Spätbetreuung",
+        status: "planned",
+        activeGroupId: null,
+        roomId: "224",
+        roomName: "Raum B",
+      },
+      rows: [
+        {
+          studentId: "422",
+          studentName: "Nora Null",
+          schoolClass: "2c",
+          groupName: "OGS Grün",
+          planned: true,
+          isUnplanned: false,
+          currentlyPresent: false,
+          visitId: null,
+          status: "absent",
+          substatus: null,
+          note: null,
+          checkedInAt: null,
+          visitEntryTime: null,
+        },
+      ],
+    });
+  });
+
   it("maps start operation ids to strings", () => {
     const raw: BackendStartOperationResult = {
       instance_id: 122,

--- a/frontend/src/lib/timetable-operations-types.test.ts
+++ b/frontend/src/lib/timetable-operations-types.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapPlannedInstance,
+  mapRoster,
+  mapStartOperation,
+  type BackendStartOperationResult,
+  type BackendTimetableRoster,
+} from "./timetable-operations-types";
+
+describe("timetable operation mappers", () => {
+  it("maps planned instances from backend snake_case into frontend camelCase", () => {
+    const result = mapPlannedInstance({
+      id: 120,
+      title: "Lernzeit",
+      date: "2026-05-10",
+      start_time: "14:00",
+      end_time: "15:00",
+      room_id: 220,
+      status: "planned",
+      is_overdue: true,
+      minutes_until_start: -5,
+      expected_students_count: 18,
+      present_students_count: 3,
+      assigned_staff_ids: [320, 321],
+    });
+
+    expect(result).toEqual({
+      id: "120",
+      title: "Lernzeit",
+      date: "2026-05-10",
+      startTime: "14:00",
+      endTime: "15:00",
+      roomId: "220",
+      status: "planned",
+      isOverdue: true,
+      minutesUntilStart: -5,
+      expectedStudentsCount: 18,
+      presentStudentsCount: 3,
+      assignedStaffIds: ["320", "321"],
+    });
+  });
+
+  it("maps roster ids and optional fields without leaking undefined", () => {
+    const raw: BackendTimetableRoster = {
+      instance: {
+        id: 121,
+        title: "AG Kunst",
+        status: "active",
+        active_group_id: 221,
+        room_id: 222,
+      },
+      rows: [
+        {
+          student_id: 420,
+          student_name: "Mila Muster",
+          school_class: "3a",
+          group_name: "OGS Blau",
+          planned: true,
+          is_unplanned: false,
+          currently_present: true,
+          visit_id: 520,
+          status: "present",
+          substatus: "late",
+          note: "kam nach",
+          checked_in_at: "2026-05-10T12:00:00Z",
+          visit_entry_time: "2026-05-10T12:01:00Z",
+        },
+        {
+          student_id: 421,
+          student_name: "Ben Beispiel",
+          school_class: "4b",
+          group_name: "",
+          planned: false,
+          is_unplanned: true,
+          currently_present: false,
+          status: "expected",
+        },
+      ],
+    };
+
+    expect(mapRoster(raw)).toEqual({
+      instance: {
+        id: "121",
+        title: "AG Kunst",
+        status: "active",
+        activeGroupId: "221",
+        roomId: "222",
+        roomName: null,
+      },
+      rows: [
+        {
+          studentId: "420",
+          studentName: "Mila Muster",
+          schoolClass: "3a",
+          groupName: "OGS Blau",
+          planned: true,
+          isUnplanned: false,
+          currentlyPresent: true,
+          visitId: "520",
+          status: "present",
+          substatus: "late",
+          note: "kam nach",
+          checkedInAt: "2026-05-10T12:00:00Z",
+          visitEntryTime: "2026-05-10T12:01:00Z",
+        },
+        {
+          studentId: "421",
+          studentName: "Ben Beispiel",
+          schoolClass: "4b",
+          groupName: "",
+          planned: false,
+          isUnplanned: true,
+          currentlyPresent: false,
+          visitId: null,
+          status: "expected",
+          substatus: null,
+          note: null,
+          checkedInAt: null,
+          visitEntryTime: null,
+        },
+      ],
+    });
+  });
+
+  it("maps start operation ids to strings", () => {
+    const raw: BackendStartOperationResult = {
+      instance_id: 122,
+      active_group_id: 223,
+      status: "active",
+    };
+
+    expect(mapStartOperation(raw)).toEqual({
+      instanceId: "122",
+      activeGroupId: "223",
+      status: "active",
+    });
+  });
+});

--- a/frontend/src/lib/timetable-operations-types.ts
+++ b/frontend/src/lib/timetable-operations-types.ts
@@ -13,7 +13,7 @@ export interface PlannedTimetableInstance {
   assignedStaffIds: string[];
 }
 
-export interface TimetableRosterInstance {
+interface TimetableRosterInstance {
   id: string;
   title: string;
   status: "planned" | "active" | "completed" | "cancelled";

--- a/frontend/src/lib/timetable-operations-types.ts
+++ b/frontend/src/lib/timetable-operations-types.ts
@@ -1,0 +1,165 @@
+export interface PlannedTimetableInstance {
+  id: string;
+  title: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  roomId: string;
+  status: "planned" | "active" | "completed" | "cancelled";
+  isOverdue: boolean;
+  minutesUntilStart: number;
+  expectedStudentsCount: number;
+  presentStudentsCount: number;
+  assignedStaffIds: string[];
+}
+
+export interface TimetableRosterInstance {
+  id: string;
+  title: string;
+  status: "planned" | "active" | "completed" | "cancelled";
+  activeGroupId: string | null;
+  roomId: string;
+  roomName?: string | null;
+}
+
+export interface TimetableRosterRow {
+  studentId: string;
+  studentName: string;
+  schoolClass: string;
+  groupName: string;
+  planned: boolean;
+  isUnplanned: boolean;
+  currentlyPresent: boolean;
+  visitId: string | null;
+  status: "expected" | "present" | "absent";
+  substatus: "late" | "excused" | "sick" | "field_trip" | "other" | null;
+  note: string | null;
+  checkedInAt: string | null;
+  visitEntryTime: string | null;
+}
+
+export interface TimetableRoster {
+  instance: TimetableRosterInstance;
+  rows: TimetableRosterRow[];
+}
+
+export interface StartOperationResult {
+  instanceId: string;
+  activeGroupId: string;
+  status: string;
+  startedAt?: string;
+}
+
+export interface AttendancePatchBody {
+  status?: "expected" | "present" | "absent";
+  substatus?: "late" | "excused" | "sick" | "field_trip" | "other" | null;
+  note?: string | null;
+}
+
+interface BackendPlannedTimetableInstance {
+  id: number;
+  title: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+  room_id: number;
+  status: PlannedTimetableInstance["status"];
+  is_overdue: boolean;
+  minutes_until_start: number;
+  expected_students_count: number;
+  present_students_count: number;
+  assigned_staff_ids: number[];
+}
+
+interface BackendRosterInstance {
+  id: number;
+  title: string;
+  status: TimetableRosterInstance["status"];
+  active_group_id?: number | null;
+  room_id: number;
+  room_name?: string | null;
+}
+
+interface BackendRosterRow {
+  student_id: number;
+  student_name: string;
+  school_class: string;
+  group_name: string;
+  planned: boolean;
+  is_unplanned: boolean;
+  currently_present: boolean;
+  visit_id?: number | null;
+  status: TimetableRosterRow["status"];
+  substatus?: TimetableRosterRow["substatus"];
+  note?: string | null;
+  checked_in_at?: string | null;
+  visit_entry_time?: string | null;
+}
+
+export interface BackendTimetableRoster {
+  instance: BackendRosterInstance;
+  rows: BackendRosterRow[];
+}
+
+export interface BackendStartOperationResult {
+  instance_id: number;
+  status: string;
+  active_group_id: number;
+}
+
+export function mapPlannedInstance(
+  raw: BackendPlannedTimetableInstance,
+): PlannedTimetableInstance {
+  return {
+    id: raw.id.toString(),
+    title: raw.title,
+    date: raw.date,
+    startTime: raw.start_time,
+    endTime: raw.end_time,
+    roomId: raw.room_id.toString(),
+    status: raw.status,
+    isOverdue: raw.is_overdue,
+    minutesUntilStart: raw.minutes_until_start,
+    expectedStudentsCount: raw.expected_students_count,
+    presentStudentsCount: raw.present_students_count,
+    assignedStaffIds: raw.assigned_staff_ids.map(String),
+  };
+}
+
+export function mapRoster(raw: BackendTimetableRoster): TimetableRoster {
+  return {
+    instance: {
+      id: raw.instance.id.toString(),
+      title: raw.instance.title,
+      status: raw.instance.status,
+      activeGroupId: raw.instance.active_group_id?.toString() ?? null,
+      roomId: raw.instance.room_id.toString(),
+      roomName: raw.instance.room_name ?? null,
+    },
+    rows: raw.rows.map((row) => ({
+      studentId: row.student_id.toString(),
+      studentName: row.student_name,
+      schoolClass: row.school_class,
+      groupName: row.group_name,
+      planned: row.planned,
+      isUnplanned: row.is_unplanned,
+      currentlyPresent: row.currently_present,
+      visitId: row.visit_id?.toString() ?? null,
+      status: row.status,
+      substatus: row.substatus ?? null,
+      note: row.note ?? null,
+      checkedInAt: row.checked_in_at ?? null,
+      visitEntryTime: row.visit_entry_time ?? null,
+    })),
+  };
+}
+
+export function mapStartOperation(
+  raw: BackendStartOperationResult,
+): StartOperationResult {
+  return {
+    instanceId: raw.instance_id.toString(),
+    activeGroupId: raw.active_group_id.toString(),
+    status: raw.status,
+  };
+}


### PR DESCRIPTION
## Summary

Finishes the timetable F3/F4 operational flow by surfacing planned timetable instances inside `/active-supervisions` and letting staff start those planned instances from the live supervision screen instead of creating duplicate unlinked active groups.

Also checks off WP-F3/WP-F4 in `docs/timetable-system-plan.md` and records the bundled operational polish that landed with this branch.

## What changed

- Added timetable operations backend endpoints and service logic for planned-now, start, complete, roster lookup, check-in, check-out, and attendance patching.
- Bridged planned timetable instances into `/active-supervisions`, including the "Jetzt geplant" section, start action, live roster state, expected/present/absent/departed/unplanned grouping, and completion from the supervision view.
- Wired timetable instance SSE events into the active-supervision refresh path so started/completed/cancelled/overdue changes invalidate the right SWR data.
- Completed stale timetable instances when their linked active session has already ended, including a repair migration for existing stale rows.
- Refactored and polished the active-supervisions page, extracted view-model/state helpers, and fixed the loading flash while a timetable roster is still resolving.
- Polished the timetable instance detail slide-over with compact stats, icon-only row actions, German substatus labels, and clearer lifecycle actions.
- Fixed timetable week/mobile ergonomics: weekend display, narrow day headers, period dropdown viewport clamping, and toolbar layout.