### PR TITLE
feat(time-tracking): App/NFC source tracking + auditable status flips (#1368)

### DIFF
--- a/backend/api/common/errors.go
+++ b/backend/api/common/errors.go
@@ -91,6 +91,11 @@ type ErrResponse struct {
 	ErrorText string       `json:"error,omitempty"`
 	Code      string       `json:"code,omitempty"`
 	Errors    []FieldError `json:"errors,omitempty"`
+	// Details carries structured, code-specific payload that lets the frontend
+	// react to a conflict without having to refetch and pattern-match local
+	// state. Populated by helpers like ErrorConflictWithDetails. Keys are
+	// snake_case to match the rest of the API's wire format.
+	Details map[string]any `json:"details,omitempty"`
 }
 
 // Render implements the render.Renderer interface for ErrResponse
@@ -195,6 +200,21 @@ func ErrorConflictWithCode(err error, code string) render.Renderer {
 		Status:         "error",
 		ErrorText:      err.Error(),
 		Code:           code,
+	}
+}
+
+// ErrorConflictWithDetails returns a 409 Conflict carrying both a stable code
+// and a structured details payload. Use this when the frontend needs concrete
+// fields (e.g. the conflicting session_id) to drive a follow-up action — it
+// removes the dependency on whichever local state happens to be loaded.
+func ErrorConflictWithDetails(err error, code string, details map[string]any) render.Renderer {
+	return &ErrResponse{
+		Err:            err,
+		HTTPStatusCode: http.StatusConflict,
+		Status:         "error",
+		ErrorText:      err.Error(),
+		Code:           code,
+		Details:        details,
 	}
 }
 

--- a/backend/api/time-tracking/api.go
+++ b/backend/api/time-tracking/api.go
@@ -166,7 +166,7 @@ func (rs *Resource) checkIn(w http.ResponseWriter, r *http.Request) {
 	var session *activeModels.WorkSession
 	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
 		var txErr error
-		session, txErr = rs.WorkSessionService.CheckIn(ctx, staffID, req.Status)
+		session, txErr = rs.WorkSessionService.CheckIn(ctx, staffID, req.Status, activeModels.WorkSessionSourceApp)
 		return txErr
 	}); err != nil {
 		common.RenderError(w, r, classifyServiceError(err))

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -133,7 +133,7 @@ func (m *mockPersonService) GetAllStudentsWithGroups(_ context.Context) ([]users
 // --- Mock WorkSessionService ---
 
 type mockWorkSessionService struct {
-	checkInFn            func(ctx context.Context, staffID int64, status string) (*activeModels.WorkSession, error)
+	checkInFn            func(ctx context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error)
 	checkOutFn           func(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
 	startBreakFn         func(ctx context.Context, staffID int64, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
 	endBreakFn           func(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
@@ -147,9 +147,9 @@ type mockWorkSessionService struct {
 	autoEndExpiredBreaks func(ctx context.Context) (int, error)
 }
 
-func (m *mockWorkSessionService) CheckIn(ctx context.Context, staffID int64, status string) (*activeModels.WorkSession, error) {
+func (m *mockWorkSessionService) CheckIn(ctx context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error) {
 	if m.checkInFn != nil {
-		return m.checkInFn(ctx, staffID, status)
+		return m.checkInFn(ctx, staffID, status, source)
 	}
 	return &activeModels.WorkSession{}, nil
 }
@@ -208,7 +208,7 @@ func (m *mockWorkSessionService) GetTodayPresenceMap(ctx context.Context) (map[i
 	return map[int64]string{}, nil
 }
 func (m *mockWorkSessionService) CleanupOpenSessions(_ context.Context) (int, error) { return 0, nil }
-func (m *mockWorkSessionService) EnsureCheckedIn(_ context.Context, _ int64) (*activeModels.WorkSession, error) {
+func (m *mockWorkSessionService) EnsureCheckedIn(_ context.Context, _ int64, _ string) (*activeModels.WorkSession, error) {
 	return nil, nil
 }
 func (m *mockWorkSessionService) ExportSessions(ctx context.Context, staffID int64, from, to time.Time, format string) ([]byte, string, error) {
@@ -426,10 +426,11 @@ func TestCheckIn_Success(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	wsSvc := &mockWorkSessionService{
-		checkInFn: func(_ context.Context, staffID int64, status string) (*activeModels.WorkSession, error) {
+		checkInFn: func(_ context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error) {
 			assert.Equal(t, int64(100), staffID)
 			assert.Equal(t, "present", status)
-			ws := &activeModels.WorkSession{Status: "present"}
+			assert.Equal(t, activeModels.WorkSessionSourceApp, source)
+			ws := &activeModels.WorkSession{Status: "present", Source: source}
 			ws.ID = 1
 			return ws, nil
 		},
@@ -485,7 +486,7 @@ func TestCheckIn_ServiceConflict(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	wsSvc := &mockWorkSessionService{
-		checkInFn: func(_ context.Context, _ int64, _ string) (*activeModels.WorkSession, error) {
+		checkInFn: func(_ context.Context, _ int64, _, _ string) (*activeModels.WorkSession, error) {
 			return nil, errors.New("already checked in")
 		},
 	}

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -803,6 +803,35 @@ func TestUpdateSession_Forbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+// TestUpdateSession_NotesRequiredOnStatusChange locks in the HTTP-boundary
+// contract for the service error introduced in Issue #1368: a status flip
+// without a reason in `notes` is a client validation failure and must
+// surface as HTTP 400, not 500. Without a matching case in
+// classifyServiceError the error would fall through to ErrorInternalServer
+// and leak the raw message — this test guards the classifier wiring.
+func TestUpdateSession_NotesRequiredOnStatusChange(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	wsSvc := &mockWorkSessionService{
+		updateSessionFn: func(_ context.Context, _ int64, _ int64, _ activeSvc.SessionUpdateRequest) (*activeModels.WorkSession, error) {
+			return nil, errors.New("notes required when changing status")
+		},
+	}
+	rs := testResource(wsSvc, &mockStaffAbsenceService{}, defaultPersonSvc(), db)
+
+	body := bytes.NewBufferString(`{"status":"home_office"}`)
+	r := httptest.NewRequest(http.MethodPut, "/42", body)
+	r.Header.Set("Content-Type", "application/json")
+	r = withClaims(r, validClaims())
+	r = withChiParam(r, "id", "42")
+	w := httptest.NewRecorder()
+
+	rs.updateSession(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"missing reason on status change must classify as 400, not 500")
+}
+
 // --- startBreak handler ---
 
 func TestStartBreak_Success(t *testing.T) {

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -534,14 +534,25 @@ func TestCheckIn_ReopenStatusConflict(t *testing.T) {
 	require.Equal(t, http.StatusConflict, w.Code)
 
 	var resp struct {
-		Status string `json:"status"`
-		Code   string `json:"code"`
-		Error  string `json:"error"`
+		Status  string         `json:"status"`
+		Code    string         `json:"code"`
+		Error   string         `json:"error"`
+		Details map[string]any `json:"details"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, "error", resp.Status)
 	assert.Equal(t, "reopen_status_conflict", resp.Code,
 		"frontend branches on this code via REOPEN_STATUS_CONFLICT_CODE")
+
+	// Details payload drives the reopen-with-status-change modal directly.
+	// Without it the frontend would have to look up the session in local
+	// history — which fails when the user is viewing a past week and today's
+	// session isn't in the fetched range.
+	require.NotNil(t, resp.Details, "details must carry the conflicting session id and statuses")
+	assert.Equal(t, "42", resp.Details["session_id"],
+		"session_id is an int64; serialize as string so the frontend can use it as-is")
+	assert.Equal(t, activeModels.WorkSessionStatusPresent, resp.Details["existing_status"])
+	assert.Equal(t, activeModels.WorkSessionStatusHomeOffice, resp.Details["requested_status"])
 }
 
 // --- checkOut handler ---

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -502,6 +502,48 @@ func TestCheckIn_ServiceConflict(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, w.Code)
 }
 
+// TestCheckIn_ReopenStatusConflict locks in the HTTP-boundary contract for
+// Issue #1368: when the service returns *ReopenStatusConflictError, the
+// handler must respond 409 with a stable {"code":"reopen_status_conflict"}
+// body so the frontend can branch into the "change status with reason" flow
+// without parsing message strings. The errors.As wiring in
+// classifyServiceError is what would silently break if someone wrapped the
+// error or moved the type — service-level tests alone don't catch that.
+func TestCheckIn_ReopenStatusConflict(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	wsSvc := &mockWorkSessionService{
+		checkInFn: func(_ context.Context, _ int64, _, _ string) (*activeModels.WorkSession, error) {
+			return nil, &activeSvc.ReopenStatusConflictError{
+				SessionID:       42,
+				ExistingStatus:  activeModels.WorkSessionStatusPresent,
+				RequestedStatus: activeModels.WorkSessionStatusHomeOffice,
+			}
+		},
+	}
+	rs := testResource(wsSvc, &mockStaffAbsenceService{}, defaultPersonSvc(), db)
+
+	body := bytes.NewBufferString(`{"status":"home_office"}`)
+	r := httptest.NewRequest(http.MethodPost, "/check-in", body)
+	r.Header.Set("Content-Type", "application/json")
+	r = withClaims(r, validClaims())
+	w := httptest.NewRecorder()
+
+	rs.checkIn(w, r)
+	require.Equal(t, http.StatusConflict, w.Code)
+
+	var resp struct {
+		Status string `json:"status"`
+		Code   string `json:"code"`
+		Error  string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "error", resp.Status)
+	assert.Equal(t, "reopen_status_conflict", resp.Code,
+		"frontend branches on this code via REOPEN_STATUS_CONFLICT_CODE")
+}
+
 // --- checkOut handler ---
 
 func TestCheckOut_Success(t *testing.T) {

--- a/backend/api/time-tracking/errors.go
+++ b/backend/api/time-tracking/errors.go
@@ -2,6 +2,7 @@ package timetracking
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 
 	"github.com/go-chi/render"
@@ -14,9 +15,18 @@ func classifyServiceError(err error) render.Renderer {
 	// Typed reopen-status-conflict: surfaced as 409 with a stable code so the
 	// frontend can branch into the "change status with reason" flow instead
 	// of showing a generic conflict toast (Issue #1368).
+	//
+	// We also serialize the conflict's identifying fields into details so the
+	// frontend can drive the follow-up modal directly from the response —
+	// without scanning local history (which may not even cover today's date
+	// when the user is viewing a past week).
 	var reopenConflict *activeSvc.ReopenStatusConflictError
 	if errors.As(err, &reopenConflict) {
-		return common.ErrorConflictWithCode(err, "reopen_status_conflict")
+		return common.ErrorConflictWithDetails(err, "reopen_status_conflict", map[string]any{
+			"session_id":       strconv.FormatInt(reopenConflict.SessionID, 10),
+			"existing_status":  reopenConflict.ExistingStatus,
+			"requested_status": reopenConflict.RequestedStatus,
+		})
 	}
 
 	msg := err.Error()

--- a/backend/api/time-tracking/errors.go
+++ b/backend/api/time-tracking/errors.go
@@ -38,6 +38,8 @@ func classifyServiceError(err error) render.Renderer {
 		return common.ErrorForbidden(err)
 
 	case strings.HasPrefix(msg, "status must be"),
+		strings.HasPrefix(msg, "source must be"),
+		msg == "notes required when changing status",
 		msg == "break minutes cannot be negative",
 		msg == "break duration cannot be negative",
 		strings.HasPrefix(msg, "planned_duration_minutes must be"),

--- a/backend/api/time-tracking/errors.go
+++ b/backend/api/time-tracking/errors.go
@@ -1,14 +1,24 @@
 package timetracking
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 )
 
 // classifyServiceError maps known business errors to appropriate HTTP status codes
 func classifyServiceError(err error) render.Renderer {
+	// Typed reopen-status-conflict: surfaced as 409 with a stable code so the
+	// frontend can branch into the "change status with reason" flow instead
+	// of showing a generic conflict toast (Issue #1368).
+	var reopenConflict *activeSvc.ReopenStatusConflictError
+	if errors.As(err, &reopenConflict) {
+		return common.ErrorConflictWithCode(err, "reopen_status_conflict")
+	}
+
 	msg := err.Error()
 
 	switch {

--- a/backend/database/migrations/001015049_work_sessions_source.go
+++ b/backend/database/migrations/001015049_work_sessions_source.go
@@ -17,9 +17,8 @@ func init() {
 		Version:     workSessionsSourceVersion,
 		Description: workSessionsSourceDescription,
 		DependsOn: []string{
-			workSessionsVersion,     // 1.10.1 — active.work_sessions
-			GroupSupervisorsVersion, // 1.4.3 — active.group_supervisors (heuristic backfill reads it)
-			addTenantIDVersion,      // 1.14.2 — tenant_id columns on both tables (heuristic scopes by tenant)
+			workSessionsVersion, // 1.10.1 — active.work_sessions
+			addTenantIDVersion,  // 1.14.2 — tenant_id columns
 		},
 	})
 
@@ -38,61 +37,19 @@ func init() {
 // the App and Web flow) or 'nfc' (auto-stamp triggered by a kiosk scan
 // flowing through services/active session_service.assignSupervisorNonCritical).
 //
-// Historical rows pre-date the column. They were created by one of two paths:
+// Pre-existing rows are labelled 'unknown' — the channel was never recorded
+// for them and we do not guess. The export renders 'unknown' as "—" so the
+// audit trail stays honest about what is and isn't known. Going forward,
+// WorkSessionService.CheckIn rejects 'unknown' as a write value, so only
+// 'app' and 'nfc' ever land on new rows.
 //
-//  1. App / Web check-in handler -> WorkSessionService.CheckIn — no
-//     active.group_supervisors row written in the same transaction.
-//  2. IoT kiosk activity start -> assignSupervisorNonCritical, which (a)
-//     inserts a group_supervisors row and then (b) calls EnsureCheckedIn,
-//     which calls CheckIn milliseconds later for the SAME staff member.
-//
-// The heuristic below labels a row 'nfc' when an active.group_supervisors
-// row exists for the same staff in the same tenant with created_at in the
-// 2-second window immediately preceding the work_session.check_in_time.
-// This catches path (2) reliably because the two inserts happen in the
-// same function call, but does not false-positive path (1) because the
-// App handler creates no supervisor row. The window is intentionally
-// asymmetric (gs.created_at <= ws.check_in_time) — supervisor row is
-// always written first.
-//
-// Caveats (acceptable for a one-shot backfill of pre-existing rows):
-//
-//   - Other call sites also create active.group_supervisors rows (e.g.
-//     the activity-supervisor management flow elsewhere in
-//     services/active/session_service.go). If one of those happens to
-//     land within 2s of an App check-in for the same staff in the same
-//     tenant, this heuristic would mislabel an App row as 'nfc'.
-//     Operationally unlikely — those flows are admin-triggered and not
-//     co-scheduled with App check-ins — but not zero.
-//
-//   - Timestamp sources differ: group_supervisors.created_at is set by
-//     the Postgres clock (DEFAULT current_timestamp); work_sessions.check_in_time
-//     is set by Go's time.Now() in WorkSessionService.CheckIn. The
-//     2-second window absorbs typical app-server-to-DB clock skew, but
-//     if the app server clock drifts more than ~2s ahead of the DB at
-//     the time the original rows were written, NFC pairs miss the
-//     window and fall through to 'app'. Sanity-check `SELECT now()` vs
-//     the app server clock before running this in prod.
-//
-//   - Supervisor rows have shorter lifetimes than work_sessions:
-//     active.group_supervisors rows are deleted when the activity ends
-//     (no soft-delete column). Any historical NFC stamp whose paired
-//     supervisor row is already gone at migration time falls through to
-//     'app'. Acceptable for a one-shot best-effort backfill — labels are
-//     advisory for pre-existing rows, and forward writes set source
-//     explicitly.
-//
-// Any rows the heuristic does not match — and all future inserts that do
-// not specify source — fall back to 'app', matching the DB DEFAULT below.
-// The DEFAULT is correct going forward because new code paths must pass
-// source explicitly (validated in WorkSessionService.CheckIn); the
-// DEFAULT only catches the in-flight transaction window between this
-// migration running and the new server binary booting.
+// The DB DEFAULT is 'app' as a safety net for the brief window between this
+// migration completing and the new server (which always passes source
+// explicitly) being live. The CHECK constraint is the safety net for any
+// future code path that bypasses the service.
 func workSessionsSourceUp(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Migration 1.15.49: Adding source column to active.work_sessions...")
 
-	// Step 1: add column nullable so the heuristic UPDATE can run before
-	// the NOT NULL + DEFAULT lock-in.
 	if _, err := db.NewRaw(`
 		ALTER TABLE active.work_sessions
 		ADD COLUMN IF NOT EXISTS source VARCHAR(10);
@@ -100,46 +57,17 @@ func workSessionsSourceUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("failed adding source column: %w", err)
 	}
 
-	// Step 2: best-effort NFC backfill for historical rows. Tenant-scoped
-	// to avoid cross-tenant matches even though staff_id is global-unique
-	// today — defence in depth.
-	nfcRes, err := db.NewRaw(`
-		UPDATE active.work_sessions ws
-		SET source = 'nfc'
-		WHERE source IS NULL
-		  AND EXISTS (
-		    SELECT 1
-		      FROM active.group_supervisors gs
-		     WHERE gs.staff_id  = ws.staff_id
-		       AND gs.tenant_id = ws.tenant_id
-		       AND ws.check_in_time
-		           BETWEEN gs.created_at
-		               AND gs.created_at + INTERVAL '2 seconds'
-		  );
-	`).Exec(ctx)
-	if err != nil {
-		return fmt.Errorf("failed backfilling source='nfc': %w", err)
-	}
-	nfcAffected, _ := nfcRes.RowsAffected()
-	fmt.Printf("Migration 1.15.49: labelled %d historical row(s) as 'nfc' via group_supervisors timing heuristic\n", nfcAffected)
-
-	// Step 3: everything else is App-originated. Includes legacy rows
-	// from the App flow and any odd cases the heuristic missed.
-	appRes, err := db.NewRaw(`
+	res, err := db.NewRaw(`
 		UPDATE active.work_sessions
-		   SET source = 'app'
+		   SET source = 'unknown'
 		 WHERE source IS NULL;
 	`).Exec(ctx)
 	if err != nil {
-		return fmt.Errorf("failed backfilling source='app': %w", err)
+		return fmt.Errorf("failed backfilling source='unknown': %w", err)
 	}
-	appAffected, _ := appRes.RowsAffected()
-	fmt.Printf("Migration 1.15.49: labelled %d historical row(s) as 'app'\n", appAffected)
+	affected, _ := res.RowsAffected()
+	fmt.Printf("Migration 1.15.49: labelled %d historical row(s) as 'unknown'\n", affected)
 
-	// Step 4: lock the column down. DEFAULT 'app' is for the brief window
-	// between this migration completing and the new server (which always
-	// passes source explicitly) being live; CHECK is the safety net for
-	// any future code path that bypasses WorkSessionService.CheckIn.
 	if _, err := db.NewRaw(`
 		ALTER TABLE active.work_sessions
 		  ALTER COLUMN source SET NOT NULL,
@@ -148,12 +76,9 @@ func workSessionsSourceUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("failed locking source column: %w", err)
 	}
 
-	// Adding the CHECK constraint as a separate statement because
-	// ALTER COLUMN ... ADD CONSTRAINT can't be combined with the NOT NULL
-	// flip on every Postgres version we support.
 	if _, err := db.NewRaw(`
 		ALTER TABLE active.work_sessions
-		ADD CONSTRAINT chk_work_sessions_source CHECK (source IN ('app','nfc'));
+		ADD CONSTRAINT chk_work_sessions_source CHECK (source IN ('app','nfc','unknown'));
 	`).Exec(ctx); err != nil {
 		return fmt.Errorf("failed adding source CHECK constraint: %w", err)
 	}
@@ -164,8 +89,8 @@ func workSessionsSourceUp(ctx context.Context, db *bun.DB) error {
 func workSessionsSourceDown(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Rolling back migration 1.15.49: Dropping source column from active.work_sessions...")
 
-	// Drop the constraint first so the down is idempotent even if a
-	// partial up left the constraint behind without the column rename.
+	// Drop the constraint first so the down is idempotent even if a partial
+	// up left the constraint behind without the column.
 	if _, err := db.NewRaw(`
 		ALTER TABLE active.work_sessions
 		DROP CONSTRAINT IF EXISTS chk_work_sessions_source;

--- a/backend/database/migrations/001015049_work_sessions_source.go
+++ b/backend/database/migrations/001015049_work_sessions_source.go
@@ -1,0 +1,63 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	workSessionsSourceVersion     = "1.15.49"
+	workSessionsSourceDescription = "Add source column to active.work_sessions to distinguish App vs NFC vs auto-created stamps (Issue #1368)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     workSessionsSourceVersion,
+		Description: workSessionsSourceDescription,
+		DependsOn:   []string{workSessionsVersion}, // 1.10.1 — work_sessions table
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return workSessionsSourceUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return workSessionsSourceDown(ctx, db)
+		},
+	)
+}
+
+// workSessionsSourceUp adds a `source` column that records which channel
+// produced a work session: 'app' (POST /api/time-tracking/check-in, used
+// by the App and Web flow) or 'nfc' (auto-stamp triggered by a kiosk scan
+// flowing through services/active session_service.assignSupervisorNonCritical).
+// The default is 'app' because the App path is the only direct check-in
+// path users invoke today; existing rows are backfilled with 'app' for the
+// same reason.
+func workSessionsSourceUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.49: Adding source column to active.work_sessions...")
+
+	if _, err := db.NewRaw(`
+		ALTER TABLE active.work_sessions
+		ADD COLUMN IF NOT EXISTS source VARCHAR(10) NOT NULL DEFAULT 'app'
+		CONSTRAINT chk_work_sessions_source CHECK (source IN ('app','nfc'));
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed adding source column: %w", err)
+	}
+
+	return nil
+}
+
+func workSessionsSourceDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.49: Dropping source column from active.work_sessions...")
+
+	if _, err := db.NewRaw(`
+		ALTER TABLE active.work_sessions DROP COLUMN IF EXISTS source;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed dropping source column: %w", err)
+	}
+
+	return nil
+}

--- a/backend/database/migrations/001015049_work_sessions_source.go
+++ b/backend/database/migrations/001015049_work_sessions_source.go
@@ -74,6 +74,14 @@ func init() {
 //     window and fall through to 'app'. Sanity-check `SELECT now()` vs
 //     the app server clock before running this in prod.
 //
+//   - Supervisor rows have shorter lifetimes than work_sessions:
+//     active.group_supervisors rows are deleted when the activity ends
+//     (no soft-delete column). Any historical NFC stamp whose paired
+//     supervisor row is already gone at migration time falls through to
+//     'app'. Acceptable for a one-shot best-effort backfill — labels are
+//     advisory for pre-existing rows, and forward writes set source
+//     explicitly.
+//
 // Any rows the heuristic does not match — and all future inserts that do
 // not specify source — fall back to 'app', matching the DB DEFAULT below.
 // The DEFAULT is correct going forward because new code paths must pass

--- a/backend/database/migrations/001015049_work_sessions_source.go
+++ b/backend/database/migrations/001015049_work_sessions_source.go
@@ -9,14 +9,18 @@ import (
 
 const (
 	workSessionsSourceVersion     = "1.15.49"
-	workSessionsSourceDescription = "Add source column to active.work_sessions to distinguish App vs NFC vs auto-created stamps (Issue #1368)"
+	workSessionsSourceDescription = "Add source column to active.work_sessions to distinguish App vs NFC stamps (Issue #1368)"
 )
 
 func init() {
 	MigrationRegistry.Register(&Migration{
 		Version:     workSessionsSourceVersion,
 		Description: workSessionsSourceDescription,
-		DependsOn:   []string{workSessionsVersion}, // 1.10.1 — work_sessions table
+		DependsOn: []string{
+			workSessionsVersion,     // 1.10.1 — active.work_sessions
+			GroupSupervisorsVersion, // 1.4.3 — active.group_supervisors (heuristic backfill reads it)
+			addTenantIDVersion,      // 1.14.2 — tenant_id columns on both tables (heuristic scopes by tenant)
+		},
 	})
 
 	Migrations.MustRegister(
@@ -30,21 +34,120 @@ func init() {
 }
 
 // workSessionsSourceUp adds a `source` column that records which channel
-// produced a work session: 'app' (POST /api/time-tracking/check-in, used
-// by the App and Web flow) or 'nfc' (auto-stamp triggered by a kiosk scan
+// produced a work session: 'app' (POST /api/time-tracking/check-in, used by
+// the App and Web flow) or 'nfc' (auto-stamp triggered by a kiosk scan
 // flowing through services/active session_service.assignSupervisorNonCritical).
-// The default is 'app' because the App path is the only direct check-in
-// path users invoke today; existing rows are backfilled with 'app' for the
-// same reason.
+//
+// Historical rows pre-date the column. They were created by one of two paths:
+//
+//  1. App / Web check-in handler -> WorkSessionService.CheckIn — no
+//     active.group_supervisors row written in the same transaction.
+//  2. IoT kiosk activity start -> assignSupervisorNonCritical, which (a)
+//     inserts a group_supervisors row and then (b) calls EnsureCheckedIn,
+//     which calls CheckIn milliseconds later for the SAME staff member.
+//
+// The heuristic below labels a row 'nfc' when an active.group_supervisors
+// row exists for the same staff in the same tenant with created_at in the
+// 2-second window immediately preceding the work_session.check_in_time.
+// This catches path (2) reliably because the two inserts happen in the
+// same function call, but does not false-positive path (1) because the
+// App handler creates no supervisor row. The window is intentionally
+// asymmetric (gs.created_at <= ws.check_in_time) — supervisor row is
+// always written first.
+//
+// Caveats (acceptable for a one-shot backfill of pre-existing rows):
+//
+//   - Other call sites also create active.group_supervisors rows (e.g.
+//     the activity-supervisor management flow elsewhere in
+//     services/active/session_service.go). If one of those happens to
+//     land within 2s of an App check-in for the same staff in the same
+//     tenant, this heuristic would mislabel an App row as 'nfc'.
+//     Operationally unlikely — those flows are admin-triggered and not
+//     co-scheduled with App check-ins — but not zero.
+//
+//   - Timestamp sources differ: group_supervisors.created_at is set by
+//     the Postgres clock (DEFAULT current_timestamp); work_sessions.check_in_time
+//     is set by Go's time.Now() in WorkSessionService.CheckIn. The
+//     2-second window absorbs typical app-server-to-DB clock skew, but
+//     if the app server clock drifts more than ~2s ahead of the DB at
+//     the time the original rows were written, NFC pairs miss the
+//     window and fall through to 'app'. Sanity-check `SELECT now()` vs
+//     the app server clock before running this in prod.
+//
+// Any rows the heuristic does not match — and all future inserts that do
+// not specify source — fall back to 'app', matching the DB DEFAULT below.
+// The DEFAULT is correct going forward because new code paths must pass
+// source explicitly (validated in WorkSessionService.CheckIn); the
+// DEFAULT only catches the in-flight transaction window between this
+// migration running and the new server binary booting.
 func workSessionsSourceUp(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Migration 1.15.49: Adding source column to active.work_sessions...")
 
+	// Step 1: add column nullable so the heuristic UPDATE can run before
+	// the NOT NULL + DEFAULT lock-in.
 	if _, err := db.NewRaw(`
 		ALTER TABLE active.work_sessions
-		ADD COLUMN IF NOT EXISTS source VARCHAR(10) NOT NULL DEFAULT 'app'
-		CONSTRAINT chk_work_sessions_source CHECK (source IN ('app','nfc'));
+		ADD COLUMN IF NOT EXISTS source VARCHAR(10);
 	`).Exec(ctx); err != nil {
 		return fmt.Errorf("failed adding source column: %w", err)
+	}
+
+	// Step 2: best-effort NFC backfill for historical rows. Tenant-scoped
+	// to avoid cross-tenant matches even though staff_id is global-unique
+	// today — defence in depth.
+	nfcRes, err := db.NewRaw(`
+		UPDATE active.work_sessions ws
+		SET source = 'nfc'
+		WHERE source IS NULL
+		  AND EXISTS (
+		    SELECT 1
+		      FROM active.group_supervisors gs
+		     WHERE gs.staff_id  = ws.staff_id
+		       AND gs.tenant_id = ws.tenant_id
+		       AND ws.check_in_time
+		           BETWEEN gs.created_at
+		               AND gs.created_at + INTERVAL '2 seconds'
+		  );
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed backfilling source='nfc': %w", err)
+	}
+	nfcAffected, _ := nfcRes.RowsAffected()
+	fmt.Printf("Migration 1.15.49: labelled %d historical row(s) as 'nfc' via group_supervisors timing heuristic\n", nfcAffected)
+
+	// Step 3: everything else is App-originated. Includes legacy rows
+	// from the App flow and any odd cases the heuristic missed.
+	appRes, err := db.NewRaw(`
+		UPDATE active.work_sessions
+		   SET source = 'app'
+		 WHERE source IS NULL;
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed backfilling source='app': %w", err)
+	}
+	appAffected, _ := appRes.RowsAffected()
+	fmt.Printf("Migration 1.15.49: labelled %d historical row(s) as 'app'\n", appAffected)
+
+	// Step 4: lock the column down. DEFAULT 'app' is for the brief window
+	// between this migration completing and the new server (which always
+	// passes source explicitly) being live; CHECK is the safety net for
+	// any future code path that bypasses WorkSessionService.CheckIn.
+	if _, err := db.NewRaw(`
+		ALTER TABLE active.work_sessions
+		  ALTER COLUMN source SET NOT NULL,
+		  ALTER COLUMN source SET DEFAULT 'app';
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed locking source column: %w", err)
+	}
+
+	// Adding the CHECK constraint as a separate statement because
+	// ALTER COLUMN ... ADD CONSTRAINT can't be combined with the NOT NULL
+	// flip on every Postgres version we support.
+	if _, err := db.NewRaw(`
+		ALTER TABLE active.work_sessions
+		ADD CONSTRAINT chk_work_sessions_source CHECK (source IN ('app','nfc'));
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed adding source CHECK constraint: %w", err)
 	}
 
 	return nil
@@ -52,6 +155,15 @@ func workSessionsSourceUp(ctx context.Context, db *bun.DB) error {
 
 func workSessionsSourceDown(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Rolling back migration 1.15.49: Dropping source column from active.work_sessions...")
+
+	// Drop the constraint first so the down is idempotent even if a
+	// partial up left the constraint behind without the column rename.
+	if _, err := db.NewRaw(`
+		ALTER TABLE active.work_sessions
+		DROP CONSTRAINT IF EXISTS chk_work_sessions_source;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed dropping source CHECK constraint: %w", err)
+	}
 
 	if _, err := db.NewRaw(`
 		ALTER TABLE active.work_sessions DROP COLUMN IF EXISTS source;

--- a/backend/database/migrations/001015049_work_sessions_source_test.go
+++ b/backend/database/migrations/001015049_work_sessions_source_test.go
@@ -273,3 +273,79 @@ func TestWorkSessionsSourceUp_ConstraintRejectsBadValue(t *testing.T) {
 	assert.Contains(t, err.Error(), "chk_work_sessions_source",
 		"error must name the constraint so the cause is obvious in logs")
 }
+
+// TestWorkSessionsSourceDown_DropsColumnAndConstraint exercises the rollback
+// path directly. Other tests in this file only invoke workSessionsSourceDown
+// indirectly via the dropWorkSessionsSourceColumn cleanup, so a regression
+// in Down (e.g. typo in the DROP COLUMN statement, missing IF EXISTS, wrong
+// constraint name) would otherwise go undetected until a real rollback was
+// attempted in production.
+//
+// We deliberately do not call dropWorkSessionsSourceColumn here — that helper
+// drops the column via raw SQL bypassing Down, which is exactly the code we
+// want to test. Instead we run Down on the schema as it stands after
+// SetupTestDB (column + constraint present), assert both are gone, then
+// re-run Up so sibling tests see the expected schema. A t.Cleanup also
+// re-runs Up as a belt-and-braces net in case the test fails mid-flight.
+func TestWorkSessionsSourceDown_DropsColumnAndConstraint(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	// Defers run LIFO: restore the column FIRST, then close the connection.
+	// Using t.Cleanup here is wrong because Cleanup runs AFTER the test
+	// function's deferred db.Close, which would leave the restore call
+	// hitting a dead pool and the shared Postgres schema in a column-less
+	// state for every sibling test that follows.
+	defer func() { _ = db.Close() }()
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := workSessionsSourceUp(ctx, db); err != nil {
+			t.Logf("restoring active.work_sessions.source after TestDown: %v", err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Self-heal the schema before testing. A previous test crashing between
+	// Down and Up — or a previous run of this very test failing to restore —
+	// would leave the column missing, and workSessionsSourceUp's ADD
+	// CONSTRAINT step is not idempotent (no IF NOT EXISTS). Run Down first
+	// (best-effort, uses IF EXISTS) then Up so we always start the assertion
+	// chain from a known fully-migrated state.
+	if err := workSessionsSourceDown(ctx, db); err != nil {
+		t.Logf("pre-test Down (best-effort): %v", err)
+	}
+	require.NoError(t, workSessionsSourceUp(ctx, db),
+		"pre-test Up must succeed to establish the known starting state")
+
+	var preColCount int
+	require.NoError(t, db.NewRaw(`
+		SELECT COUNT(*) FROM information_schema.columns
+		WHERE table_schema = 'active' AND table_name = 'work_sessions' AND column_name = 'source';
+	`).Scan(ctx, &preColCount))
+	require.Equal(t, 1, preColCount, "pre-condition: source column must exist before Down")
+
+	require.NoError(t, workSessionsSourceDown(ctx, db),
+		"Down on a fully-migrated schema must succeed")
+
+	var postColCount int
+	require.NoError(t, db.NewRaw(`
+		SELECT COUNT(*) FROM information_schema.columns
+		WHERE table_schema = 'active' AND table_name = 'work_sessions' AND column_name = 'source';
+	`).Scan(ctx, &postColCount))
+	assert.Equal(t, 0, postColCount, "Down must drop the source column")
+
+	var postConstraintCount int
+	require.NoError(t, db.NewRaw(`
+		SELECT COUNT(*) FROM information_schema.table_constraints
+		WHERE table_schema = 'active' AND table_name = 'work_sessions'
+		  AND constraint_name = 'chk_work_sessions_source';
+	`).Scan(ctx, &postConstraintCount))
+	assert.Equal(t, 0, postConstraintCount, "Down must drop the CHECK constraint")
+
+	// Idempotency: Down on a schema that already lacks the column must not
+	// error — the DROP statements use IF EXISTS specifically to support
+	// re-running the rollback after a partial up.
+	require.NoError(t, workSessionsSourceDown(ctx, db),
+		"Down must be idempotent (second call on missing column must succeed)")
+}

--- a/backend/database/migrations/001015049_work_sessions_source_test.go
+++ b/backend/database/migrations/001015049_work_sessions_source_test.go
@@ -15,10 +15,29 @@ import (
 // dropWorkSessionsSourceColumn rolls back the schema portion of migration
 // 1.15.49 so a test can re-run the up against a controlled pre-migration
 // state. SetupTestDB has already run every migration including 1.15.49, so
-// the column exists at the start of every test in this file; the deferred
-// cleanup branch puts it back via workSessionsSourceUp.
+// the column exists at the start of every test in this file.
+//
+// SetupTestDB hands out a process-shared *bun.DB, so a panic or a require
+// failure between the drop and the subsequent workSessionsSourceUp would
+// leave sibling tests running against a column-less schema. We register a
+// t.Cleanup that restores the schema regardless of how the test exits:
+// down() drops the constraint + column (no-ops if already gone), then
+// up() re-adds both. This handles every failure mode — succeeded, failed
+// after drop, failed before drop — without relying on workSessionsSourceUp
+// being self-idempotent (its ADD CONSTRAINT step is not).
 func dropWorkSessionsSourceColumn(t *testing.T, db *bun.DB) {
 	t.Helper()
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		if err := workSessionsSourceDown(cleanupCtx, db); err != nil {
+			t.Logf("rollback before schema restore failed: %v", err)
+			return
+		}
+		if err := workSessionsSourceUp(cleanupCtx, db); err != nil {
+			t.Logf("restoring active.work_sessions.source after test: %v", err)
+		}
+	})
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_, err := db.ExecContext(ctx, `
@@ -239,7 +258,6 @@ func TestWorkSessionsSourceUp_ConstraintRejectsBadValue(t *testing.T) {
 	defer cleanupWorkSessionsSourceTest(t, db, tenantID)
 
 	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Constraint", "Test")
-	wsTime := time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC)
 
 	// Re-running up() on the existing schema is idempotent (column already
 	// exists with IF NOT EXISTS), so we don't need to drop/re-add to assert
@@ -254,6 +272,4 @@ func TestWorkSessionsSourceUp_ConstraintRejectsBadValue(t *testing.T) {
 	require.Error(t, err, "CHECK constraint must reject unknown source values")
 	assert.Contains(t, err.Error(), "chk_work_sessions_source",
 		"error must name the constraint so the cause is obvious in logs")
-
-	_ = wsTime
 }

--- a/backend/database/migrations/001015049_work_sessions_source_test.go
+++ b/backend/database/migrations/001015049_work_sessions_source_test.go
@@ -48,10 +48,10 @@ func dropWorkSessionsSourceColumn(t *testing.T, db *bun.DB) {
 	require.NoError(t, err, "drop work_sessions.source column")
 }
 
-// insertWorkSession stages a work_sessions row with a specific check_in_time
-// so the heuristic in workSessionsSourceUp can be exercised deterministically.
-// created_by/updated_by point at the staff member themselves, matching what
-// WorkSessionService.CheckIn writes in production.
+// insertWorkSession stages a work_sessions row to verify that the migration's
+// backfill labels pre-existing rows as 'unknown'. created_by/updated_by point
+// at the staff member themselves, matching what WorkSessionService.CheckIn
+// writes in production.
 func insertWorkSession(t *testing.T, db *bun.DB, tenantID, staffID int64, checkInTime time.Time) int64 {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -64,38 +64,6 @@ func insertWorkSession(t *testing.T, db *bun.DB, tenantID, staffID int64, checkI
 		RETURNING id;
 	`, tenantID, staffID, checkInTime, checkInTime, staffID, staffID).Scan(ctx, &id)
 	require.NoError(t, err, "insert work_session")
-	return id
-}
-
-// insertGroupSupervisor stages a supervisor row whose created_at sits at a
-// caller-chosen timestamp so the migration's ±2-second window can be
-// triggered or missed deterministically. The associated active.groups row
-// is created on the fly because group_supervisors.group_id is FK-enforced;
-// active.groups.room_id is NOT NULL so a throwaway room is created too.
-func insertGroupSupervisor(t *testing.T, db *bun.DB, tenantID, staffID int64, createdAt time.Time) int64 {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	room := testpkg.CreateTestRoomForTenant(t, db, tenantID,
-		fmt.Sprintf("ws-source-test-room-%d", time.Now().UnixNano()))
-
-	var groupID int64
-	err := db.NewRaw(`
-		INSERT INTO active.groups (tenant_id, room_id, start_time, last_activity, timeout_minutes)
-		VALUES (?, ?, ?, ?, 30)
-		RETURNING id;
-	`, tenantID, room.ID, createdAt, createdAt).Scan(ctx, &groupID)
-	require.NoError(t, err, "insert active.group for supervisor")
-
-	var id int64
-	err = db.NewRaw(`
-		INSERT INTO active.group_supervisors
-		    (tenant_id, staff_id, group_id, role, start_date, created_at, updated_at)
-		VALUES (?, ?, ?, 'Supervisor', ?::date, ?, ?)
-		RETURNING id;
-	`, tenantID, staffID, groupID, createdAt, createdAt, createdAt).Scan(ctx, &id)
-	require.NoError(t, err, "insert group_supervisor")
 	return id
 }
 
@@ -113,25 +81,17 @@ func cleanupWorkSessionsSourceTest(t *testing.T, db *bun.DB, tenantID int64) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	stmts := []string{
-		`DELETE FROM active.work_sessions WHERE tenant_id = ?`,
-		`DELETE FROM active.group_supervisors WHERE tenant_id = ?`,
-		`DELETE FROM active.groups WHERE tenant_id = ?`,
-		`DELETE FROM facilities.rooms WHERE tenant_id = ?`,
-	}
-	for _, stmt := range stmts {
-		if _, err := db.ExecContext(ctx, stmt, tenantID); err != nil {
-			t.Logf("work_sessions source migration cleanup: %v", err)
-		}
+	if _, err := db.ExecContext(ctx,
+		`DELETE FROM active.work_sessions WHERE tenant_id = ?`, tenantID); err != nil {
+		t.Logf("work_sessions source migration cleanup: %v", err)
 	}
 }
 
-// TestWorkSessionsSourceUp_HeuristicLabelsNFC verifies the core behaviour:
-// a work_session whose check_in_time sits inside the (gs.created_at, +2s]
-// window for the same staff/tenant must be labelled 'nfc'. This is the
-// production signal for the IoT supervisor flow — supervisor row written
-// first, work_session a few ms later.
-func TestWorkSessionsSourceUp_HeuristicLabelsNFC(t *testing.T) {
+// TestWorkSessionsSourceUp_LabelsLegacyRowsUnknown verifies the backfill:
+// a row that exists before the migration runs (no source value) must end up
+// labelled 'unknown'. This is the entire backfill contract — no heuristic,
+// no guessing, just an honest sentinel for pre-existing data.
+func TestWorkSessionsSourceUp_LabelsLegacyRowsUnknown(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
 
@@ -140,28 +100,22 @@ func TestWorkSessionsSourceUp_HeuristicLabelsNFC(t *testing.T) {
 	defer testpkg.CleanupTenantTestData(t, db, tenantID)
 	defer cleanupWorkSessionsSourceTest(t, db, tenantID)
 
-	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "NFC", "Stamper")
-
-	// Production timing: supervisorRepo.Create runs at T, then CheckIn writes
-	// work_sessions.check_in_time at T + ~few ms. We seed +500ms to be safely
-	// inside the 2-second window.
-	gsTime := time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC)
-	wsTime := gsTime.Add(500 * time.Millisecond)
-	insertGroupSupervisor(t, db, tenantID, staff.ID, gsTime)
-	wsID := insertWorkSession(t, db, tenantID, staff.ID, wsTime)
+	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Legacy", "Stamper")
 
 	dropWorkSessionsSourceColumn(t, db)
+	wsID := insertWorkSession(t, db, tenantID, staff.ID,
+		time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC))
 	require.NoError(t, workSessionsSourceUp(context.Background(), db))
 
-	assert.Equal(t, "nfc", workSessionSource(t, db, wsID),
-		"work_session created milliseconds after a group_supervisor row must be labelled 'nfc'")
+	assert.Equal(t, "unknown", workSessionSource(t, db, wsID),
+		"row that pre-dates the migration must be labelled 'unknown'")
 }
 
-// TestWorkSessionsSourceUp_HeuristicLabelsApp verifies that work_sessions
-// without a nearby supervisor row are labelled 'app' — the App / Web check-in
-// flow does not write group_supervisors, so this is the dominant historical
-// case.
-func TestWorkSessionsSourceUp_HeuristicLabelsApp(t *testing.T) {
+// TestWorkSessionsSourceUp_ConstraintAcceptsAllowedValues verifies that the
+// CHECK constraint admits exactly the three documented values. New writes
+// must still be able to land 'app' and 'nfc' from WorkSessionService.CheckIn,
+// and the 'unknown' sentinel must remain valid because legacy rows carry it.
+func TestWorkSessionsSourceUp_ConstraintAcceptsAllowedValues(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
 
@@ -170,78 +124,19 @@ func TestWorkSessionsSourceUp_HeuristicLabelsApp(t *testing.T) {
 	defer testpkg.CleanupTenantTestData(t, db, tenantID)
 	defer cleanupWorkSessionsSourceTest(t, db, tenantID)
 
-	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "App", "Stamper")
-	wsID := insertWorkSession(t, db, tenantID, staff.ID,
-		time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC))
+	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Constraint", "Test")
 
-	dropWorkSessionsSourceColumn(t, db)
-	require.NoError(t, workSessionsSourceUp(context.Background(), db))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
-	assert.Equal(t, "app", workSessionSource(t, db, wsID),
-		"work_session without any group_supervisor row must be labelled 'app'")
-}
-
-// TestWorkSessionsSourceUp_AppCheckinBeforeLaterSupervisorStaysApp protects
-// against the false-positive scenario where a staff member checks in via the
-// App and then a few seconds later starts an NFC activity. Because the
-// window is asymmetric (gs.created_at <= ws.check_in_time only), the App row
-// must stay 'app'.
-func TestWorkSessionsSourceUp_AppCheckinBeforeLaterSupervisorStaysApp(t *testing.T) {
-	db := testpkg.SetupTestDB(t)
-	defer func() { _ = db.Close() }()
-
-	const tenantID int64 = 9203
-	testpkg.EnsureTestTenant(t, db, tenantID)
-	defer testpkg.CleanupTenantTestData(t, db, tenantID)
-	defer cleanupWorkSessionsSourceTest(t, db, tenantID)
-
-	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "App", "First")
-
-	// App check-in at T; NFC activity start 3 seconds later. EnsureCheckedIn
-	// in prod would no-op (already checked in), but the supervisor row still
-	// gets written. The asymmetric window must not match.
-	wsTime := time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC)
-	wsID := insertWorkSession(t, db, tenantID, staff.ID, wsTime)
-	insertGroupSupervisor(t, db, tenantID, staff.ID, wsTime.Add(3*time.Second))
-
-	dropWorkSessionsSourceColumn(t, db)
-	require.NoError(t, workSessionsSourceUp(context.Background(), db))
-
-	assert.Equal(t, "app", workSessionSource(t, db, wsID),
-		"supervisor row written AFTER the work_session must not cause an 'nfc' relabel")
-}
-
-// TestWorkSessionsSourceUp_TenantIsolation guards against cross-tenant
-// matches. Two tenants happen to share the same staff_id (impossible today
-// but defended in the heuristic via gs.tenant_id = ws.tenant_id) — the
-// supervisor row from tenant A must not relabel the work_session in tenant B.
-func TestWorkSessionsSourceUp_TenantIsolation(t *testing.T) {
-	db := testpkg.SetupTestDB(t)
-	defer func() { _ = db.Close() }()
-
-	const tenantA int64 = 9204
-	const tenantB int64 = 9205
-	testpkg.EnsureTestTenant(t, db, tenantA)
-	testpkg.EnsureTestTenant(t, db, tenantB)
-	defer testpkg.CleanupTenantTestData(t, db, tenantA, tenantB)
-	defer cleanupWorkSessionsSourceTest(t, db, tenantA)
-	defer cleanupWorkSessionsSourceTest(t, db, tenantB)
-
-	// Different staff in each tenant, but choose timestamps that would match
-	// the heuristic if tenant_id were not part of the join.
-	staffA := testpkg.CreateTestStaffForTenant(t, db, tenantA, "Cross", "TenantA")
-	staffB := testpkg.CreateTestStaffForTenant(t, db, tenantB, "Cross", "TenantB")
-
-	moment := time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC)
-	// Supervisor row in tenant A, work_session in tenant B at the same moment.
-	insertGroupSupervisor(t, db, tenantA, staffA.ID, moment)
-	wsB := insertWorkSession(t, db, tenantB, staffB.ID, moment.Add(500*time.Millisecond))
-
-	dropWorkSessionsSourceColumn(t, db)
-	require.NoError(t, workSessionsSourceUp(context.Background(), db))
-
-	assert.Equal(t, "app", workSessionSource(t, db, wsB),
-		"supervisor row in another tenant must not leak across the heuristic join")
+	for i, src := range []string{"app", "nfc", "unknown"} {
+		_, err := db.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO active.work_sessions
+			    (tenant_id, staff_id, date, status, source, check_in_time, created_by, updated_by)
+			VALUES (%d, %d, '2026-03-%02d', 'present', '%s', '2026-03-%02d 08:00:00+00', %d, %d);
+		`, tenantID, staff.ID, i+10, src, i+10, staff.ID, staff.ID))
+		assert.NoError(t, err, "CHECK constraint must accept source=%q", src)
+	}
 }
 
 // TestWorkSessionsSourceUp_ConstraintRejectsBadValue verifies the CHECK
@@ -252,12 +147,12 @@ func TestWorkSessionsSourceUp_ConstraintRejectsBadValue(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
 
-	const tenantID int64 = 9206
+	const tenantID int64 = 9203
 	testpkg.EnsureTestTenant(t, db, tenantID)
 	defer testpkg.CleanupTenantTestData(t, db, tenantID)
 	defer cleanupWorkSessionsSourceTest(t, db, tenantID)
 
-	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Constraint", "Test")
+	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Constraint", "Reject")
 
 	// Re-running up() on the existing schema is idempotent (column already
 	// exists with IF NOT EXISTS), so we don't need to drop/re-add to assert

--- a/backend/database/migrations/001015049_work_sessions_source_test.go
+++ b/backend/database/migrations/001015049_work_sessions_source_test.go
@@ -1,0 +1,259 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// dropWorkSessionsSourceColumn rolls back the schema portion of migration
+// 1.15.49 so a test can re-run the up against a controlled pre-migration
+// state. SetupTestDB has already run every migration including 1.15.49, so
+// the column exists at the start of every test in this file; the deferred
+// cleanup branch puts it back via workSessionsSourceUp.
+func dropWorkSessionsSourceColumn(t *testing.T, db *bun.DB) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.ExecContext(ctx, `
+		ALTER TABLE active.work_sessions
+		DROP CONSTRAINT IF EXISTS chk_work_sessions_source;
+		ALTER TABLE active.work_sessions DROP COLUMN IF EXISTS source;
+	`)
+	require.NoError(t, err, "drop work_sessions.source column")
+}
+
+// insertWorkSession stages a work_sessions row with a specific check_in_time
+// so the heuristic in workSessionsSourceUp can be exercised deterministically.
+// created_by/updated_by point at the staff member themselves, matching what
+// WorkSessionService.CheckIn writes in production.
+func insertWorkSession(t *testing.T, db *bun.DB, tenantID, staffID int64, checkInTime time.Time) int64 {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var id int64
+	err := db.NewRaw(`
+		INSERT INTO active.work_sessions
+		    (tenant_id, staff_id, date, status, check_in_time, created_by, updated_by)
+		VALUES (?, ?, ?::date, 'present', ?, ?, ?)
+		RETURNING id;
+	`, tenantID, staffID, checkInTime, checkInTime, staffID, staffID).Scan(ctx, &id)
+	require.NoError(t, err, "insert work_session")
+	return id
+}
+
+// insertGroupSupervisor stages a supervisor row whose created_at sits at a
+// caller-chosen timestamp so the migration's ±2-second window can be
+// triggered or missed deterministically. The associated active.groups row
+// is created on the fly because group_supervisors.group_id is FK-enforced;
+// active.groups.room_id is NOT NULL so a throwaway room is created too.
+func insertGroupSupervisor(t *testing.T, db *bun.DB, tenantID, staffID int64, createdAt time.Time) int64 {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	room := testpkg.CreateTestRoomForTenant(t, db, tenantID,
+		fmt.Sprintf("ws-source-test-room-%d", time.Now().UnixNano()))
+
+	var groupID int64
+	err := db.NewRaw(`
+		INSERT INTO active.groups (tenant_id, room_id, start_time, last_activity, timeout_minutes)
+		VALUES (?, ?, ?, ?, 30)
+		RETURNING id;
+	`, tenantID, room.ID, createdAt, createdAt).Scan(ctx, &groupID)
+	require.NoError(t, err, "insert active.group for supervisor")
+
+	var id int64
+	err = db.NewRaw(`
+		INSERT INTO active.group_supervisors
+		    (tenant_id, staff_id, group_id, role, start_date, created_at, updated_at)
+		VALUES (?, ?, ?, 'Supervisor', ?::date, ?, ?)
+		RETURNING id;
+	`, tenantID, staffID, groupID, createdAt, createdAt, createdAt).Scan(ctx, &id)
+	require.NoError(t, err, "insert group_supervisor")
+	return id
+}
+
+func workSessionSource(t *testing.T, db *bun.DB, id int64) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var source string
+	err := db.NewRaw(`SELECT source FROM active.work_sessions WHERE id = ?;`, id).Scan(ctx, &source)
+	require.NoError(t, err, "read work_session.source for id=%d", id)
+	return source
+}
+
+func cleanupWorkSessionsSourceTest(t *testing.T, db *bun.DB, tenantID int64) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	stmts := []string{
+		`DELETE FROM active.work_sessions WHERE tenant_id = ?`,
+		`DELETE FROM active.group_supervisors WHERE tenant_id = ?`,
+		`DELETE FROM active.groups WHERE tenant_id = ?`,
+		`DELETE FROM facilities.rooms WHERE tenant_id = ?`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.ExecContext(ctx, stmt, tenantID); err != nil {
+			t.Logf("work_sessions source migration cleanup: %v", err)
+		}
+	}
+}
+
+// TestWorkSessionsSourceUp_HeuristicLabelsNFC verifies the core behaviour:
+// a work_session whose check_in_time sits inside the (gs.created_at, +2s]
+// window for the same staff/tenant must be labelled 'nfc'. This is the
+// production signal for the IoT supervisor flow — supervisor row written
+// first, work_session a few ms later.
+func TestWorkSessionsSourceUp_HeuristicLabelsNFC(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantID int64 = 9201
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+	defer cleanupWorkSessionsSourceTest(t, db, tenantID)
+
+	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "NFC", "Stamper")
+
+	// Production timing: supervisorRepo.Create runs at T, then CheckIn writes
+	// work_sessions.check_in_time at T + ~few ms. We seed +500ms to be safely
+	// inside the 2-second window.
+	gsTime := time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC)
+	wsTime := gsTime.Add(500 * time.Millisecond)
+	insertGroupSupervisor(t, db, tenantID, staff.ID, gsTime)
+	wsID := insertWorkSession(t, db, tenantID, staff.ID, wsTime)
+
+	dropWorkSessionsSourceColumn(t, db)
+	require.NoError(t, workSessionsSourceUp(context.Background(), db))
+
+	assert.Equal(t, "nfc", workSessionSource(t, db, wsID),
+		"work_session created milliseconds after a group_supervisor row must be labelled 'nfc'")
+}
+
+// TestWorkSessionsSourceUp_HeuristicLabelsApp verifies that work_sessions
+// without a nearby supervisor row are labelled 'app' — the App / Web check-in
+// flow does not write group_supervisors, so this is the dominant historical
+// case.
+func TestWorkSessionsSourceUp_HeuristicLabelsApp(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantID int64 = 9202
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+	defer cleanupWorkSessionsSourceTest(t, db, tenantID)
+
+	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "App", "Stamper")
+	wsID := insertWorkSession(t, db, tenantID, staff.ID,
+		time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC))
+
+	dropWorkSessionsSourceColumn(t, db)
+	require.NoError(t, workSessionsSourceUp(context.Background(), db))
+
+	assert.Equal(t, "app", workSessionSource(t, db, wsID),
+		"work_session without any group_supervisor row must be labelled 'app'")
+}
+
+// TestWorkSessionsSourceUp_AppCheckinBeforeLaterSupervisorStaysApp protects
+// against the false-positive scenario where a staff member checks in via the
+// App and then a few seconds later starts an NFC activity. Because the
+// window is asymmetric (gs.created_at <= ws.check_in_time only), the App row
+// must stay 'app'.
+func TestWorkSessionsSourceUp_AppCheckinBeforeLaterSupervisorStaysApp(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantID int64 = 9203
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+	defer cleanupWorkSessionsSourceTest(t, db, tenantID)
+
+	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "App", "First")
+
+	// App check-in at T; NFC activity start 3 seconds later. EnsureCheckedIn
+	// in prod would no-op (already checked in), but the supervisor row still
+	// gets written. The asymmetric window must not match.
+	wsTime := time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC)
+	wsID := insertWorkSession(t, db, tenantID, staff.ID, wsTime)
+	insertGroupSupervisor(t, db, tenantID, staff.ID, wsTime.Add(3*time.Second))
+
+	dropWorkSessionsSourceColumn(t, db)
+	require.NoError(t, workSessionsSourceUp(context.Background(), db))
+
+	assert.Equal(t, "app", workSessionSource(t, db, wsID),
+		"supervisor row written AFTER the work_session must not cause an 'nfc' relabel")
+}
+
+// TestWorkSessionsSourceUp_TenantIsolation guards against cross-tenant
+// matches. Two tenants happen to share the same staff_id (impossible today
+// but defended in the heuristic via gs.tenant_id = ws.tenant_id) — the
+// supervisor row from tenant A must not relabel the work_session in tenant B.
+func TestWorkSessionsSourceUp_TenantIsolation(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantA int64 = 9204
+	const tenantB int64 = 9205
+	testpkg.EnsureTestTenant(t, db, tenantA)
+	testpkg.EnsureTestTenant(t, db, tenantB)
+	defer testpkg.CleanupTenantTestData(t, db, tenantA, tenantB)
+	defer cleanupWorkSessionsSourceTest(t, db, tenantA)
+	defer cleanupWorkSessionsSourceTest(t, db, tenantB)
+
+	// Different staff in each tenant, but choose timestamps that would match
+	// the heuristic if tenant_id were not part of the join.
+	staffA := testpkg.CreateTestStaffForTenant(t, db, tenantA, "Cross", "TenantA")
+	staffB := testpkg.CreateTestStaffForTenant(t, db, tenantB, "Cross", "TenantB")
+
+	moment := time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC)
+	// Supervisor row in tenant A, work_session in tenant B at the same moment.
+	insertGroupSupervisor(t, db, tenantA, staffA.ID, moment)
+	wsB := insertWorkSession(t, db, tenantB, staffB.ID, moment.Add(500*time.Millisecond))
+
+	dropWorkSessionsSourceColumn(t, db)
+	require.NoError(t, workSessionsSourceUp(context.Background(), db))
+
+	assert.Equal(t, "app", workSessionSource(t, db, wsB),
+		"supervisor row in another tenant must not leak across the heuristic join")
+}
+
+// TestWorkSessionsSourceUp_ConstraintRejectsBadValue verifies the CHECK
+// constraint is in place after up() runs, so any future code path that
+// bypasses WorkSessionService.CheckIn cannot smuggle a bogus channel into
+// the table.
+func TestWorkSessionsSourceUp_ConstraintRejectsBadValue(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantID int64 = 9206
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+	defer cleanupWorkSessionsSourceTest(t, db, tenantID)
+
+	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Constraint", "Test")
+	wsTime := time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC)
+
+	// Re-running up() on the existing schema is idempotent (column already
+	// exists with IF NOT EXISTS), so we don't need to drop/re-add to assert
+	// the constraint is live.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO active.work_sessions
+		    (tenant_id, staff_id, date, status, source, check_in_time, created_by, updated_by)
+		VALUES (%d, %d, '2026-03-04', 'present', 'bogus', '2026-03-04 08:00:00+00', %d, %d);
+	`, tenantID, staff.ID, staff.ID, staff.ID))
+	require.Error(t, err, "CHECK constraint must reject unknown source values")
+	assert.Contains(t, err.Error(), "chk_work_sessions_source",
+		"error must name the constraint so the cause is obvious in logs")
+
+	_ = wsTime
+}

--- a/backend/database/migrations/001015054_work_sessions_source.go
+++ b/backend/database/migrations/001015054_work_sessions_source.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	workSessionsSourceVersion     = "1.15.49"
+	workSessionsSourceVersion     = "1.15.54"
 	workSessionsSourceDescription = "Add source column to active.work_sessions to distinguish App vs NFC stamps (Issue #1368)"
 )
 
@@ -48,7 +48,7 @@ func init() {
 // explicitly) being live. The CHECK constraint is the safety net for any
 // future code path that bypasses the service.
 func workSessionsSourceUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.49: Adding source column to active.work_sessions...")
+	fmt.Println("Migration 1.15.54: Adding source column to active.work_sessions...")
 
 	if _, err := db.NewRaw(`
 		ALTER TABLE active.work_sessions
@@ -66,7 +66,7 @@ func workSessionsSourceUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("failed backfilling source='unknown': %w", err)
 	}
 	affected, _ := res.RowsAffected()
-	fmt.Printf("Migration 1.15.49: labelled %d historical row(s) as 'unknown'\n", affected)
+	fmt.Printf("Migration 1.15.54: labelled %d historical row(s) as 'unknown'\n", affected)
 
 	if _, err := db.NewRaw(`
 		ALTER TABLE active.work_sessions
@@ -87,7 +87,7 @@ func workSessionsSourceUp(ctx context.Context, db *bun.DB) error {
 }
 
 func workSessionsSourceDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.49: Dropping source column from active.work_sessions...")
+	fmt.Println("Rolling back migration 1.15.54: Dropping source column from active.work_sessions...")
 
 	// Drop the constraint first so the down is idempotent even if a partial
 	// up left the constraint behind without the column.

--- a/backend/database/migrations/001015054_work_sessions_source_test.go
+++ b/backend/database/migrations/001015054_work_sessions_source_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 // dropWorkSessionsSourceColumn rolls back the schema portion of migration
-// 1.15.49 so a test can re-run the up against a controlled pre-migration
-// state. SetupTestDB has already run every migration including 1.15.49, so
+// 1.15.54 so a test can re-run the up against a controlled pre-migration
+// state. SetupTestDB has already run every migration including 1.15.54, so
 // the column exists at the start of every test in this file.
 //
 // SetupTestDB hands out a process-shared *bun.DB, so a panic or a require

--- a/backend/database/migrations/001015054_work_sessions_source_test.go
+++ b/backend/database/migrations/001015054_work_sessions_source_test.go
@@ -17,17 +17,34 @@ import (
 // state. SetupTestDB has already run every migration including 1.15.54, so
 // the column exists at the start of every test in this file.
 //
-// SetupTestDB hands out a process-shared *bun.DB, so a panic or a require
-// failure between the drop and the subsequent workSessionsSourceUp would
-// leave sibling tests running against a column-less schema. We register a
-// t.Cleanup that restores the schema regardless of how the test exits:
-// down() drops the constraint + column (no-ops if already gone), then
-// up() re-adds both. This handles every failure mode — succeeded, failed
-// after drop, failed before drop — without relying on workSessionsSourceUp
-// being self-idempotent (its ADD CONSTRAINT step is not).
-func dropWorkSessionsSourceColumn(t *testing.T, db *bun.DB) {
+// The schema is shared across every test in the package (Postgres database
+// scoped per process), so a panic or a require failure between the drop and
+// the subsequent workSessionsSourceUp would leave sibling tests running
+// against a column-less schema. To handle that we return a restore closure
+// that down()s any leftover constraint/column and then up()s the migration
+// — this works regardless of how the test exits (success, fail after drop,
+// fail before drop) without relying on workSessionsSourceUp being
+// self-idempotent (its ADD CONSTRAINT step is not).
+//
+// IMPORTANT: callers MUST register the returned closure with `defer` BEFORE
+// any `defer db.Close()`, so LIFO order runs the restore against an open
+// pool. Registering via t.Cleanup is wrong here because t.Cleanup fires
+// AFTER the test function's deferred db.Close(), which would route the
+// restore through a closed pool ("sql: database is closed") and leave the
+// shared schema column-less for every subsequent test. See
+// TestWorkSessionsSourceDown_DropsColumnAndConstraint for the same pattern.
+func dropWorkSessionsSourceColumn(t *testing.T, db *bun.DB) func() {
 	t.Helper()
-	t.Cleanup(func() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.ExecContext(ctx, `
+		ALTER TABLE active.work_sessions
+		DROP CONSTRAINT IF EXISTS chk_work_sessions_source;
+		ALTER TABLE active.work_sessions DROP COLUMN IF EXISTS source;
+	`)
+	require.NoError(t, err, "drop work_sessions.source column")
+
+	return func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cleanupCancel()
 		if err := workSessionsSourceDown(cleanupCtx, db); err != nil {
@@ -37,15 +54,7 @@ func dropWorkSessionsSourceColumn(t *testing.T, db *bun.DB) {
 		if err := workSessionsSourceUp(cleanupCtx, db); err != nil {
 			t.Logf("restoring active.work_sessions.source after test: %v", err)
 		}
-	})
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	_, err := db.ExecContext(ctx, `
-		ALTER TABLE active.work_sessions
-		DROP CONSTRAINT IF EXISTS chk_work_sessions_source;
-		ALTER TABLE active.work_sessions DROP COLUMN IF EXISTS source;
-	`)
-	require.NoError(t, err, "drop work_sessions.source column")
+	}
 }
 
 // insertWorkSession stages a work_sessions row to verify that the migration's
@@ -102,7 +111,12 @@ func TestWorkSessionsSourceUp_LabelsLegacyRowsUnknown(t *testing.T) {
 
 	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Legacy", "Stamper")
 
-	dropWorkSessionsSourceColumn(t, db)
+	// Register restore via defer so LIFO runs it before the test function's
+	// db.Close (line 104). t.Cleanup is wrong here — it fires AFTER deferred
+	// calls return, by which point the pool is closed.
+	restoreSchema := dropWorkSessionsSourceColumn(t, db)
+	defer restoreSchema()
+
 	wsID := insertWorkSession(t, db, tenantID, staff.ID,
 		time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC))
 	require.NoError(t, workSessionsSourceUp(context.Background(), db))

--- a/backend/models/active/work_session.go
+++ b/backend/models/active/work_session.go
@@ -19,7 +19,7 @@ const (
 
 // WorkSessionSource records which channel produced the row (Issue #1368).
 // New writes are restricted to App/NFC by WorkSessionService.CheckIn;
-// 'unknown' exists only for rows that pre-date migration 1.15.49 and is
+// 'unknown' exists only for rows that pre-date migration 1.15.54 and is
 // rejected as a write value but accepted as a read value so legacy rows
 // survive partial-update flows (break edits, notes patches). The DB CHECK
 // constraint chk_work_sessions_source enforces the same set on disk.

--- a/backend/models/active/work_session.go
+++ b/backend/models/active/work_session.go
@@ -17,12 +17,32 @@ const (
 	WorkSessionStatusHomeOffice = "home_office"
 )
 
+// WorkSessionSource records which channel produced the row. Used by the
+// export to label "Vor Ort (NFC)" vs "Vor Ort (App)" vs "Homeoffice (App)"
+// without inferring from status alone (Issue #1368).
+//
+// Validation lives in two layers on purpose:
+//   - WorkSessionService.CheckIn rejects unknown values at the service
+//     boundary, so bad input never reaches the DB.
+//   - The Postgres CHECK constraint chk_work_sessions_source is the safety
+//     net for any code path that would bypass the service.
+//
+// Validate() on this entity intentionally does not re-check Source — partial
+// update flows (e.g. break management, notes patches) load existing rows
+// that may have been written before this column existed. Re-validating here
+// would reject those rows on otherwise-unrelated mutations.
+const (
+	WorkSessionSourceApp = "app" // POST /api/time-tracking/check-in (App / Web)
+	WorkSessionSourceNFC = "nfc" // Auto-stamp from a kiosk-driven scan
+)
+
 type WorkSession struct {
 	base.Model `bun:"schema:active,table:work_sessions"`
 	base.TenantModel
 	StaffID        int64      `bun:"staff_id,notnull" json:"staff_id"`
 	Date           time.Time  `bun:"date,notnull,type:date" json:"date"`
 	Status         string     `bun:"status,notnull,default:'present'" json:"status"`
+	Source         string     `bun:"source,notnull,default:'app'" json:"source"`
 	CheckInTime    time.Time  `bun:"check_in_time,notnull" json:"check_in_time"`
 	CheckOutTime   *time.Time `bun:"check_out_time" json:"check_out_time,omitempty"`
 	BreakMinutes   int        `bun:"break_minutes,notnull,default:0" json:"break_minutes"`
@@ -64,6 +84,8 @@ func (ws *WorkSession) Validate() error {
 	if ws.Status != WorkSessionStatusPresent && ws.Status != WorkSessionStatusHomeOffice {
 		return errors.New("status must be 'present' or 'home_office'")
 	}
+	// Source is intentionally not validated here — see the const block above
+	// for why: partial-update flows load pre-Source rows.
 	if ws.CheckOutTime != nil && ws.CheckInTime.After(*ws.CheckOutTime) {
 		return errors.New("check-in time must be before check-out time")
 	}

--- a/backend/models/active/work_session.go
+++ b/backend/models/active/work_session.go
@@ -27,10 +27,14 @@ const (
 //   - The Postgres CHECK constraint chk_work_sessions_source is the safety
 //     net for any code path that would bypass the service.
 //
-// Validate() on this entity intentionally does not re-check Source — partial
-// update flows (e.g. break management, notes patches) load existing rows
-// that may have been written before this column existed. Re-validating here
-// would reject those rows on otherwise-unrelated mutations.
+// Validate() on this entity intentionally does not re-check Source. Both
+// write paths in the service (CheckIn, reopenSession) set Source before
+// calling Validate(), and migration 1.15.49 guarantees every row has a
+// non-empty Source on disk — so the field is structurally always present.
+// We still skip Validate() for it because partial-update flows (break
+// management, notes patches) round-trip the loaded row, and a stricter
+// invariant here would risk rejecting otherwise-valid mutations if the
+// allowed value set ever expands.
 const (
 	WorkSessionSourceApp = "app" // POST /api/time-tracking/check-in (App / Web)
 	WorkSessionSourceNFC = "nfc" // Auto-stamp from a kiosk-driven scan
@@ -85,7 +89,8 @@ func (ws *WorkSession) Validate() error {
 		return errors.New("status must be 'present' or 'home_office'")
 	}
 	// Source is intentionally not validated here — see the const block above
-	// for why: partial-update flows load pre-Source rows.
+	// for the rationale (skipping keeps partial-update flows resilient if
+	// the allowed value set ever expands).
 	if ws.CheckOutTime != nil && ws.CheckInTime.After(*ws.CheckOutTime) {
 		return errors.New("check-in time must be before check-out time")
 	}

--- a/backend/models/active/work_session.go
+++ b/backend/models/active/work_session.go
@@ -17,27 +17,16 @@ const (
 	WorkSessionStatusHomeOffice = "home_office"
 )
 
-// WorkSessionSource records which channel produced the row. Used by the
-// export to label "Vor Ort (NFC)" vs "Vor Ort (App)" vs "Homeoffice (App)"
-// without inferring from status alone (Issue #1368).
-//
-// Validation lives in two layers on purpose:
-//   - WorkSessionService.CheckIn rejects unknown values at the service
-//     boundary, so bad input never reaches the DB.
-//   - The Postgres CHECK constraint chk_work_sessions_source is the safety
-//     net for any code path that would bypass the service.
-//
-// Validate() on this entity intentionally does not re-check Source. Both
-// write paths in the service (CheckIn, reopenSession) set Source before
-// calling Validate(), and migration 1.15.49 guarantees every row has a
-// non-empty Source on disk — so the field is structurally always present.
-// We still skip Validate() for it because partial-update flows (break
-// management, notes patches) round-trip the loaded row, and a stricter
-// invariant here would risk rejecting otherwise-valid mutations if the
-// allowed value set ever expands.
+// WorkSessionSource records which channel produced the row (Issue #1368).
+// New writes are restricted to App/NFC by WorkSessionService.CheckIn;
+// 'unknown' exists only for rows that pre-date migration 1.15.49 and is
+// rejected as a write value but accepted as a read value so legacy rows
+// survive partial-update flows (break edits, notes patches). The DB CHECK
+// constraint chk_work_sessions_source enforces the same set on disk.
 const (
-	WorkSessionSourceApp = "app" // POST /api/time-tracking/check-in (App / Web)
-	WorkSessionSourceNFC = "nfc" // Auto-stamp from a kiosk-driven scan
+	WorkSessionSourceApp     = "app"     // POST /api/time-tracking/check-in (App / Web)
+	WorkSessionSourceNFC     = "nfc"     // Auto-stamp from a kiosk-driven scan
+	WorkSessionSourceUnknown = "unknown" // Pre-migration legacy rows; never written by new code
 )
 
 type WorkSession struct {
@@ -88,9 +77,9 @@ func (ws *WorkSession) Validate() error {
 	if ws.Status != WorkSessionStatusPresent && ws.Status != WorkSessionStatusHomeOffice {
 		return errors.New("status must be 'present' or 'home_office'")
 	}
-	// Source is intentionally not validated here — see the const block above
-	// for the rationale (skipping keeps partial-update flows resilient if
-	// the allowed value set ever expands).
+	// Source is intentionally not re-validated here — write paths gate it at
+	// the service boundary, and legacy 'unknown' rows must round-trip cleanly
+	// through partial-update flows (break edits, notes patches).
 	if ws.CheckOutTime != nil && ws.CheckInTime.After(*ws.CheckOutTime) {
 		return errors.New("check-in time must be before check-out time")
 	}

--- a/backend/services/active/session_service.go
+++ b/backend/services/active/session_service.go
@@ -82,11 +82,24 @@ func (s *service) assignSupervisorNonCritical(ctx context.Context, groupID, staf
 	// NFC auto-check-in: ensure staff member has a work session for today.
 	// This path runs from the IoT supervisor flow (kiosk-driven activity
 	// start), so the channel is recorded as 'nfc' in the audit trail.
+	//
+	// EnsureCheckedIn returns (nil, nil) when the staff member has already
+	// checked out for the day — by design, we do not auto-reopen. That
+	// leaves an asymmetric audit trail (supervisor row recorded, no
+	// matching NFC stamp), so log it at INFO so a dispute can be traced
+	// later.
 	if s.workSessionService != nil {
-		if _, err := s.workSessionService.EnsureCheckedIn(ctx, staffID, active.WorkSessionSourceNFC); err != nil {
+		session, err := s.workSessionService.EnsureCheckedIn(ctx, staffID, active.WorkSessionSourceNFC)
+		switch {
+		case err != nil:
 			s.getLogger().WarnContext(ctx, "NFC auto-check-in failed",
 				slog.Int64("staff_id", staffID),
 				slog.String("error", err.Error()),
+			)
+		case session == nil:
+			s.getLogger().InfoContext(ctx, "NFC auto-check-in skipped: staff already checked out today",
+				slog.Int64("staff_id", staffID),
+				slog.Int64("group_id", groupID),
 			)
 		}
 	}

--- a/backend/services/active/session_service.go
+++ b/backend/services/active/session_service.go
@@ -250,6 +250,12 @@ func (s *service) createSessionWithMultipleSupervisors(ctx context.Context, acti
 
 // assignMultipleSupervisorsNonCritical assigns multiple supervisors but doesn't fail if assignment fails.
 // Each supervisor is inserted independently so one bad row doesn't prevent the other valid assignments.
+//
+// Mirrors the single-supervisor variant's NFC auto-check-in (assignSupervisorNonCritical):
+// the kiosk-driven IoT activity start dispatches through this path, so each
+// supervisor must get a work_session stamped with source='nfc' for the audit
+// trail to distinguish kiosk scans from app check-ins. Without the loop here,
+// /api/iot/* started sessions silently miss the NFC stamp (Issue #1368).
 func (s *service) assignMultipleSupervisorsNonCritical(ctx context.Context, groupID int64, supervisorIDs []int64, startDate time.Time) {
 	// Deduplicate supervisor IDs
 	uniqueSupervisors := make(map[int64]bool)
@@ -276,6 +282,28 @@ func (s *service) assignMultipleSupervisorsNonCritical(ctx context.Context, grou
 				slog.Int64("group_id", groupID),
 				slog.String("error", err.Error()),
 			)
+		}
+
+		// NFC auto-check-in (kiosk-driven multi-supervisor flow). Same
+		// asymmetric-audit caveat as the single-supervisor path: if the
+		// staff member already checked out today, EnsureCheckedIn returns
+		// (nil, nil) and we log it so a dispute over the supervisor row
+		// without a matching NFC stamp can be traced later.
+		if s.workSessionService != nil {
+			session, err := s.workSessionService.EnsureCheckedIn(ctx, staffID, active.WorkSessionSourceNFC)
+			switch {
+			case err != nil:
+				s.getLogger().WarnContext(ctx, "NFC auto-check-in failed",
+					slog.Int64("staff_id", staffID),
+					slog.Int64("group_id", groupID),
+					slog.String("error", err.Error()),
+				)
+			case session == nil:
+				s.getLogger().InfoContext(ctx, "NFC auto-check-in skipped: staff already checked out today",
+					slog.Int64("staff_id", staffID),
+					slog.Int64("group_id", groupID),
+				)
+			}
 		}
 	}
 }

--- a/backend/services/active/session_service.go
+++ b/backend/services/active/session_service.go
@@ -79,9 +79,11 @@ func (s *service) assignSupervisorNonCritical(ctx context.Context, groupID, staf
 		)
 	}
 
-	// NFC auto-check-in: ensure staff member has a work session for today
+	// NFC auto-check-in: ensure staff member has a work session for today.
+	// This path runs from the IoT supervisor flow (kiosk-driven activity
+	// start), so the channel is recorded as 'nfc' in the audit trail.
 	if s.workSessionService != nil {
-		if _, err := s.workSessionService.EnsureCheckedIn(ctx, staffID); err != nil {
+		if _, err := s.workSessionService.EnsureCheckedIn(ctx, staffID, active.WorkSessionSourceNFC); err != nil {
 			s.getLogger().WarnContext(ctx, "NFC auto-check-in failed",
 				slog.Int64("staff_id", staffID),
 				slog.String("error", err.Error()),

--- a/backend/services/active/work_session_export_test.go
+++ b/backend/services/active/work_session_export_test.go
@@ -347,14 +347,14 @@ func TestWSSessionToRow_Complete(t *testing.T) {
 	row := svc.sessionToRow(sr)
 
 	require.Len(t, row, 8)
-	assert.Equal(t, "15.01.2024", row[0])  // Datum
-	assert.Equal(t, "Montag", row[1])      // Wochentag
-	assert.Equal(t, "08:30", row[2])       // Start
-	assert.Equal(t, "17:15", row[3])       // Ende
-	assert.Equal(t, "45", row[4])          // Pause
-	assert.Equal(t, "8h 00min", row[5])    // Netto
-	assert.Equal(t, "In der OGS", row[6])  // Ort
-	assert.Equal(t, "Regular day", row[7]) // Bemerkungen
+	assert.Equal(t, "15.01.2024", row[0])    // Datum
+	assert.Equal(t, "Montag", row[1])        // Wochentag
+	assert.Equal(t, "08:30", row[2])         // Start
+	assert.Equal(t, "17:15", row[3])         // Ende
+	assert.Equal(t, "45", row[4])            // Pause
+	assert.Equal(t, "8h 00min", row[5])      // Netto
+	assert.Equal(t, "Vor Ort (App)", row[6]) // Quelle (Issue #1368)
+	assert.Equal(t, "Regular day", row[7])   // Bemerkungen
 }
 
 func TestWSSessionToRow_NoCheckOut(t *testing.T) {
@@ -398,7 +398,57 @@ func TestWSSessionToRow_HomeOffice(t *testing.T) {
 
 	row := svc.sessionToRow(sr)
 
-	assert.Equal(t, "Homeoffice", row[6]) // Ort
+	assert.Equal(t, "Homeoffice (App)", row[6]) // Quelle (Issue #1368)
+}
+
+func TestWSSessionToRow_Quelle_AutoCheckedOut(t *testing.T) {
+	// Issue #1368: Auto-Checkout wins over the chosen status because it tells
+	// the OGS-Leitung the session was closed by the scheduler, not the staff.
+	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
+
+	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	checkIn := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
+	checkOut := time.Date(2024, 1, 15, 23, 59, 0, 0, time.UTC)
+
+	sr := &SessionResponse{
+		WorkSession: &activeModels.WorkSession{
+			Model:          base.Model{ID: 1},
+			Date:           date,
+			CheckInTime:    checkIn,
+			CheckOutTime:   &checkOut,
+			Status:         activeModels.WorkSessionStatusPresent,
+			AutoCheckedOut: true,
+		},
+		NetMinutes: 0,
+		EditCount:  0,
+	}
+
+	row := svc.sessionToRow(sr)
+	assert.Equal(t, "Auto-Checkout", row[6])
+}
+
+func TestWSSessionToRow_Quelle_ManuelCorrected(t *testing.T) {
+	// Issue #1368: a manual correction is the strongest signal — it overrides
+	// both Auto-Checkout and the underlying status. EditCount > 0 wins.
+	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
+
+	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	checkIn := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
+
+	sr := &SessionResponse{
+		WorkSession: &activeModels.WorkSession{
+			Model:          base.Model{ID: 1},
+			Date:           date,
+			CheckInTime:    checkIn,
+			Status:         activeModels.WorkSessionStatusHomeOffice,
+			AutoCheckedOut: true,
+		},
+		NetMinutes: 0,
+		EditCount:  2,
+	}
+
+	row := svc.sessionToRow(sr)
+	assert.Equal(t, "Manuell korrigiert", row[6])
 }
 
 func TestWSSessionToRow_NetMinutesFormatting(t *testing.T) {
@@ -501,7 +551,7 @@ func TestWSExportCSV_Headers(t *testing.T) {
 	assert.Equal(t, "Ende", header[3])
 	assert.Equal(t, "Pause (Min)", header[4])
 	assert.Equal(t, "Netto (Std)", header[5])
-	assert.Equal(t, "Ort", header[6])
+	assert.Equal(t, "Quelle", header[6]) // Issue #1368: was "Ort"
 	assert.Equal(t, "Bemerkungen", header[7])
 }
 
@@ -576,6 +626,8 @@ func TestWSExportXLSX_WithData(t *testing.T) {
 // ============================================================================
 
 func TestWSUpdateSession_StatusChange(t *testing.T) {
+	// Issue #1368: status changes require a non-empty reason in notes — the
+	// happy path now sends notes alongside the new status.
 	svc, sessionRepo, _, auditRepo, _ := wsCreateTestService()
 	staffID := int64(100)
 	sessionID := int64(100)
@@ -596,17 +648,109 @@ func TestWSUpdateSession_StatusChange(t *testing.T) {
 	}
 
 	auditRepo.createBatchFunc = func(_ context.Context, edits []*auditModels.WorkSessionEdit) error {
-		assert.Len(t, edits, 1)
-		assert.Equal(t, auditModels.FieldStatus, edits[0].FieldName)
+		// Both status and notes change → two audit entries, both annotated
+		// with the same reason via uc.notes.
+		assert.Len(t, edits, 2)
+		fields := []string{edits[0].FieldName, edits[1].FieldName}
+		assert.Contains(t, fields, auditModels.FieldStatus)
+		assert.Contains(t, fields, auditModels.FieldNotes)
 		return nil
 	}
 
 	newStatus := activeModels.WorkSessionStatusHomeOffice
+	reason := "Mittags ins Homeoffice gewechselt"
 	updates := SessionUpdateRequest{
 		Status: &newStatus,
+		Notes:  &reason,
 	}
 
 	session, err := svc.UpdateSession(context.Background(), staffID, sessionID, updates)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+}
+
+func TestWSUpdateSession_StatusChangeRequiresNotes(t *testing.T) {
+	// Issue #1368: a status change without a reason must be rejected so the
+	// audit trail can never silently lose the "why" of a Vor Ort ↔ Homeoffice
+	// switch. Empty/whitespace-only notes count as missing.
+	svc, sessionRepo, _, auditRepo, _ := wsCreateTestService()
+	staffID := int64(100)
+	sessionID := int64(100)
+
+	sessionRepo.findByIDFunc = func(_ context.Context, _ any) (*activeModels.WorkSession, error) {
+		return &activeModels.WorkSession{
+			Model:       base.Model{ID: sessionID},
+			StaffID:     staffID,
+			CheckInTime: time.Now().Add(-8 * time.Hour),
+			Status:      activeModels.WorkSessionStatusPresent,
+			Date:        time.Now().Truncate(24 * time.Hour),
+			CreatedBy:   staffID,
+		}, nil
+	}
+	sessionRepo.updateFunc = func(_ context.Context, _ *activeModels.WorkSession) error {
+		t.Fatal("repo.Update must not be called when status change is rejected")
+		return nil
+	}
+	auditRepo.createBatchFunc = func(_ context.Context, _ []*auditModels.WorkSessionEdit) error {
+		t.Fatal("audit.CreateBatch must not be called when status change is rejected")
+		return nil
+	}
+
+	newStatus := activeModels.WorkSessionStatusHomeOffice
+	emptyNotes := ""
+	whitespaceNotes := "   "
+	cases := []struct {
+		name  string
+		notes *string
+	}{
+		{name: "nil notes", notes: nil},
+		{name: "empty notes", notes: &emptyNotes},
+		{name: "whitespace-only notes", notes: &whitespaceNotes},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			updates := SessionUpdateRequest{
+				Status: &newStatus,
+				Notes:  tc.notes,
+			}
+			session, err := svc.UpdateSession(context.Background(), staffID, sessionID, updates)
+			require.Error(t, err)
+			assert.Nil(t, session)
+			assert.Contains(t, err.Error(), "notes required")
+		})
+	}
+}
+
+func TestWSUpdateSession_NotesOnlyDoesNotRequireReason(t *testing.T) {
+	// Issue #1368: the gate is specifically for status changes — editing only
+	// notes (e.g., adding a comment) must still work without a reason field.
+	svc, sessionRepo, _, auditRepo, _ := wsCreateTestService()
+	staffID := int64(100)
+	sessionID := int64(100)
+
+	sessionRepo.findByIDFunc = func(_ context.Context, _ any) (*activeModels.WorkSession, error) {
+		return &activeModels.WorkSession{
+			Model:       base.Model{ID: sessionID},
+			StaffID:     staffID,
+			CheckInTime: time.Now().Add(-8 * time.Hour),
+			Status:      activeModels.WorkSessionStatusHomeOffice,
+			Date:        time.Now().Truncate(24 * time.Hour),
+			CreatedBy:   staffID,
+			Notes:       "old",
+		}, nil
+	}
+	sessionRepo.updateFunc = func(_ context.Context, _ *activeModels.WorkSession) error {
+		return nil
+	}
+	auditRepo.createBatchFunc = func(_ context.Context, _ []*auditModels.WorkSessionEdit) error {
+		return nil
+	}
+
+	newNotes := "added comment"
+	session, err := svc.UpdateSession(context.Background(), staffID, sessionID, SessionUpdateRequest{
+		Notes: &newNotes,
+	})
 	require.NoError(t, err)
 	require.NotNil(t, session)
 }

--- a/backend/services/active/work_session_export_test.go
+++ b/backend/services/active/work_session_export_test.go
@@ -385,6 +385,32 @@ func TestWSSessionToRow_NFC(t *testing.T) {
 	assert.Equal(t, "NFC", row[7])
 }
 
+// TestWSSessionToRow_LegacyUnknownSource verifies that pre-migration rows
+// (source = 'unknown') render Quelle as "—" rather than guessing App or NFC.
+// Issue #1368: the audit trail must distinguish "we know it was App" from
+// "we never recorded the channel".
+func TestWSSessionToRow_LegacyUnknownSource(t *testing.T) {
+	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
+
+	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	checkIn := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
+
+	sr := &SessionResponse{
+		WorkSession: &activeModels.WorkSession{
+			Model:       base.Model{ID: 1},
+			Date:        date,
+			CheckInTime: checkIn,
+			Status:      activeModels.WorkSessionStatusPresent,
+			Source:      activeModels.WorkSessionSourceUnknown,
+		},
+		NetMinutes: 0,
+	}
+
+	row := svc.sessionToRow(sr)
+	assert.Equal(t, "Vor Ort", row[6])
+	assert.Equal(t, "—", row[7], "legacy 'unknown' source must render as em-dash, not guessed App/NFC")
+}
+
 func TestWSSessionToRow_NoCheckOut(t *testing.T) {
 	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
 

--- a/backend/services/active/work_session_export_test.go
+++ b/backend/services/active/work_session_export_test.go
@@ -339,6 +339,7 @@ func TestWSSessionToRow_Complete(t *testing.T) {
 			CheckOutTime: &checkOut,
 			BreakMinutes: 45,
 			Status:       activeModels.WorkSessionStatusPresent,
+			Source:       activeModels.WorkSessionSourceApp,
 			Notes:        "Regular day",
 		},
 		NetMinutes: 480, // 8h 0min
@@ -355,6 +356,30 @@ func TestWSSessionToRow_Complete(t *testing.T) {
 	assert.Equal(t, "8h 00min", row[5])      // Netto
 	assert.Equal(t, "Vor Ort (App)", row[6]) // Quelle (Issue #1368)
 	assert.Equal(t, "Regular day", row[7])   // Bemerkungen
+}
+
+func TestWSSessionToRow_NFC(t *testing.T) {
+	// Issue #1368: an NFC-stamped session must be distinguishable from an
+	// App-stamped one in the export. Both have status=present, so the label
+	// has to read source.
+	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
+
+	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	checkIn := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
+
+	sr := &SessionResponse{
+		WorkSession: &activeModels.WorkSession{
+			Model:       base.Model{ID: 1},
+			Date:        date,
+			CheckInTime: checkIn,
+			Status:      activeModels.WorkSessionStatusPresent,
+			Source:      activeModels.WorkSessionSourceNFC,
+		},
+		NetMinutes: 0,
+	}
+
+	row := svc.sessionToRow(sr)
+	assert.Equal(t, "Vor Ort (NFC)", row[6])
 }
 
 func TestWSSessionToRow_NoCheckOut(t *testing.T) {
@@ -392,6 +417,7 @@ func TestWSSessionToRow_HomeOffice(t *testing.T) {
 			Date:        date,
 			CheckInTime: checkIn,
 			Status:      activeModels.WorkSessionStatusHomeOffice,
+			Source:      activeModels.WorkSessionSourceApp,
 		},
 		NetMinutes: 0,
 	}
@@ -1278,7 +1304,7 @@ func TestWSCheckIn_CreateError(t *testing.T) {
 		return errors.New("create error")
 	}
 
-	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent)
+	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "failed to create work session")

--- a/backend/services/active/work_session_export_test.go
+++ b/backend/services/active/work_session_export_test.go
@@ -347,21 +347,23 @@ func TestWSSessionToRow_Complete(t *testing.T) {
 
 	row := svc.sessionToRow(sr)
 
-	require.Len(t, row, 8)
-	assert.Equal(t, "15.01.2024", row[0])    // Datum
-	assert.Equal(t, "Montag", row[1])        // Wochentag
-	assert.Equal(t, "08:30", row[2])         // Start
-	assert.Equal(t, "17:15", row[3])         // Ende
-	assert.Equal(t, "45", row[4])            // Pause
-	assert.Equal(t, "8h 00min", row[5])      // Netto
-	assert.Equal(t, "Vor Ort (App)", row[6]) // Quelle (Issue #1368)
-	assert.Equal(t, "Regular day", row[7])   // Bemerkungen
+	require.Len(t, row, 9)
+	assert.Equal(t, "15.01.2024", row[0])  // Datum
+	assert.Equal(t, "Montag", row[1])      // Wochentag
+	assert.Equal(t, "08:30", row[2])       // Start
+	assert.Equal(t, "17:15", row[3])       // Ende
+	assert.Equal(t, "45", row[4])          // Pause
+	assert.Equal(t, "8h 00min", row[5])    // Netto
+	assert.Equal(t, "Vor Ort", row[6])     // Status (Issue #1368)
+	assert.Equal(t, "App", row[7])         // Quelle (Issue #1368)
+	assert.Equal(t, "Regular day", row[8]) // Bemerkungen
 }
 
 func TestWSSessionToRow_NFC(t *testing.T) {
 	// Issue #1368: an NFC-stamped session must be distinguishable from an
-	// App-stamped one in the export. Both have status=present, so the label
-	// has to read source.
+	// App-stamped one in the export. Status and Quelle are now in separate
+	// columns (Status row[6], Quelle row[7]) so the channel survives even
+	// when system events overlay the Quelle cell.
 	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
 
 	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
@@ -379,7 +381,8 @@ func TestWSSessionToRow_NFC(t *testing.T) {
 	}
 
 	row := svc.sessionToRow(sr)
-	assert.Equal(t, "Vor Ort (NFC)", row[6])
+	assert.Equal(t, "Vor Ort", row[6])
+	assert.Equal(t, "NFC", row[7])
 }
 
 func TestWSSessionToRow_NoCheckOut(t *testing.T) {
@@ -424,12 +427,15 @@ func TestWSSessionToRow_HomeOffice(t *testing.T) {
 
 	row := svc.sessionToRow(sr)
 
-	assert.Equal(t, "Homeoffice (App)", row[6]) // Quelle (Issue #1368)
+	assert.Equal(t, "Homeoffice", row[6]) // Status (Issue #1368)
+	assert.Equal(t, "App", row[7])        // Quelle (Issue #1368)
 }
 
 func TestWSSessionToRow_Quelle_AutoCheckedOut(t *testing.T) {
-	// Issue #1368: Auto-Checkout wins over the chosen status because it tells
-	// the OGS-Leitung the session was closed by the scheduler, not the staff.
+	// Issue #1368: Auto-Checkout overlays the Quelle cell so the
+	// OGS-Leitung sees the session was closed by the scheduler. Status
+	// remains the underlying work mode — Vor Ort is preserved here even
+	// though Quelle is "Auto-Checkout".
 	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
 
 	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
@@ -450,12 +456,14 @@ func TestWSSessionToRow_Quelle_AutoCheckedOut(t *testing.T) {
 	}
 
 	row := svc.sessionToRow(sr)
-	assert.Equal(t, "Auto-Checkout", row[6])
+	assert.Equal(t, "Vor Ort", row[6], "Status survives Auto-Checkout overlay")
+	assert.Equal(t, "Auto-Checkout", row[7])
 }
 
 func TestWSSessionToRow_Quelle_ManuelCorrected(t *testing.T) {
-	// Issue #1368: a manual correction is the strongest signal — it overrides
-	// both Auto-Checkout and the underlying status. EditCount > 0 wins.
+	// Issue #1368: a manual correction overlays Quelle, but Status still
+	// shows the underlying work mode (Homeoffice) — so the OGS-Leitung can
+	// see both the corrected-state signal AND what the staff actually did.
 	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
 
 	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
@@ -474,7 +482,8 @@ func TestWSSessionToRow_Quelle_ManuelCorrected(t *testing.T) {
 	}
 
 	row := svc.sessionToRow(sr)
-	assert.Equal(t, "Manuell korrigiert", row[6])
+	assert.Equal(t, "Homeoffice", row[6], "Status survives Manuell-korrigiert overlay")
+	assert.Equal(t, "Manuell korrigiert", row[7])
 }
 
 func TestWSSessionToRow_NetMinutesFormatting(t *testing.T) {
@@ -571,14 +580,16 @@ func TestWSExportCSV_Headers(t *testing.T) {
 	require.Len(t, records, 1) // Only header
 
 	header := records[0]
+	require.Len(t, header, 9) // Issue #1368: split "Ort" into Status + Quelle
 	assert.Equal(t, "Datum", header[0])
 	assert.Equal(t, "Wochentag", header[1])
 	assert.Equal(t, "Start", header[2])
 	assert.Equal(t, "Ende", header[3])
 	assert.Equal(t, "Pause (Min)", header[4])
 	assert.Equal(t, "Netto (Std)", header[5])
-	assert.Equal(t, "Quelle", header[6]) // Issue #1368: was "Ort"
-	assert.Equal(t, "Bemerkungen", header[7])
+	assert.Equal(t, "Status", header[6]) // Issue #1368: was part of "Ort"
+	assert.Equal(t, "Quelle", header[7]) // Issue #1368: split out
+	assert.Equal(t, "Bemerkungen", header[8])
 }
 
 func TestWSExportCSV_UTF8BOM(t *testing.T) {

--- a/backend/services/active/work_session_export_test.go
+++ b/backend/services/active/work_session_export_test.go
@@ -238,8 +238,13 @@ func TestWSBuildExportRows_AbsencesOnly(t *testing.T) {
 
 	require.Len(t, rows, 3) // 3 days: Jan 2, 3, 4
 	assert.Equal(t, dateStart, rows[0].Date)
-	assert.Contains(t, rows[0].Row[6], "Krank")
-	assert.Contains(t, rows[0].Row[7], "Flu")
+	// Header is 9 cells after the Status/Quelle split — pin the length so a
+	// future regression that drops a cell (and silently shifts Note into the
+	// Quelle column) fails here instead of on the user's CSV.
+	require.Len(t, rows[0].Row, 9, "absence rows must match the 9-column export header")
+	assert.Contains(t, rows[0].Row[6], "Krank")                     // Status
+	assert.Equal(t, "", rows[0].Row[7], "absences carry no Quelle") // Quelle
+	assert.Contains(t, rows[0].Row[8], "Flu")                       // Bemerkungen
 }
 
 func TestWSBuildExportRows_Mixed(t *testing.T) {

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -1011,7 +1011,7 @@ func (s *workSessionService) sessionToRow(sr *SessionResponse) []string {
 }
 
 // quelleLabel renders the export "Quelle" cell from the persisted source.
-// 'unknown' marks rows that pre-date migration 1.15.49 — no channel was ever
+// 'unknown' marks rows that pre-date migration 1.15.54 — no channel was ever
 // recorded, so we render "—" rather than guess. Anything else falls through
 // to App, matching the DB column default for in-flight rows that may exist
 // briefly between migration and new-server boot.

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -56,7 +56,12 @@ type SessionResponse struct {
 
 // WorkSessionService defines operations for staff time tracking
 type WorkSessionService interface {
-	CheckIn(ctx context.Context, staffID int64, status string) (*activeModels.WorkSession, error)
+	// CheckIn opens or reopens today's session for staffID. `source` records
+	// the channel that triggered the check-in (app/nfc/auto) so the export
+	// can label "Vor Ort (App)" vs "Vor Ort (NFC)" without inferring it from
+	// status alone (Issue #1368). Reopening overwrites the source to reflect
+	// the channel of the latest action.
+	CheckIn(ctx context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error)
 	CheckOut(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
 	StartBreak(ctx context.Context, staffID int64, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
 	EndBreak(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
@@ -67,7 +72,13 @@ type WorkSessionService interface {
 	GetSessionEdits(ctx context.Context, staffID, sessionID int64) ([]*auditModels.WorkSessionEdit, error)
 	GetTodayPresenceMap(ctx context.Context) (map[int64]string, error)
 	CleanupOpenSessions(ctx context.Context) (int, error)
-	EnsureCheckedIn(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
+	// EnsureCheckedIn opens today's session if the staff member has no active
+	// row. The caller passes `source` (`app`/`nfc`) to record which channel
+	// triggered the auto-stamp; this avoids hard-coding the channel inside
+	// the service so future callers (web action triggers, schedulers) cannot
+	// be silently mislabelled as NFC. Returns nil if the staff member is
+	// already checked out today (no re-open).
+	EnsureCheckedIn(ctx context.Context, staffID int64, source string) (*activeModels.WorkSession, error)
 	ExportSessions(ctx context.Context, staffID int64, from, to time.Time, format string) ([]byte, string, error)
 	AutoEndExpiredBreaks(ctx context.Context) (int, error)
 }
@@ -98,9 +109,12 @@ func NewWorkSessionService(repo activeModels.WorkSessionRepository, breakRepo ac
 // CheckIn creates a new work session for the staff member.
 // Status must be explicitly chosen — empty values are rejected so the caller
 // (HTTP handler or internal worker) cannot accidentally fall back to "present".
-func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status string) (*activeModels.WorkSession, error) {
+func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error) {
 	if status != activeModels.WorkSessionStatusPresent && status != activeModels.WorkSessionStatusHomeOffice {
 		return nil, fmt.Errorf("status must be 'present' or 'home_office'")
+	}
+	if source != activeModels.WorkSessionSourceApp && source != activeModels.WorkSessionSourceNFC {
+		return nil, fmt.Errorf("source must be 'app' or 'nfc'")
 	}
 
 	// Get today's date as UTC midnight for PostgreSQL DATE column
@@ -117,7 +131,7 @@ func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status 
 			return nil, fmt.Errorf("already checked in")
 		}
 		// Re-open the checked-out session (accidental checkout recovery)
-		return s.reopenSession(ctx, existingSession, staffID, status)
+		return s.reopenSession(ctx, existingSession, staffID, status, source)
 	}
 
 	// Create new session
@@ -126,6 +140,7 @@ func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status 
 		StaffID:      staffID,
 		Date:         today,
 		Status:       status,
+		Source:       source,
 		CheckInTime:  now,
 		CheckOutTime: nil,
 		BreakMinutes: 0,
@@ -145,10 +160,11 @@ func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status 
 }
 
 // reopenSession clears checkout on an existing session so the staff member can continue working
-func (s *workSessionService) reopenSession(ctx context.Context, session *activeModels.WorkSession, staffID int64, status string) (*activeModels.WorkSession, error) {
+func (s *workSessionService) reopenSession(ctx context.Context, session *activeModels.WorkSession, staffID int64, status, source string) (*activeModels.WorkSession, error) {
 	session.CheckOutTime = nil
 	session.AutoCheckedOut = false
 	session.Status = status
+	session.Source = source
 	session.UpdatedBy = &staffID
 
 	if err := session.Validate(); err != nil {
@@ -704,8 +720,9 @@ func (s *workSessionService) CleanupOpenSessions(ctx context.Context) (int, erro
 	return count, nil
 }
 
-// EnsureCheckedIn ensures a staff member is checked in, creating a session if needed
-func (s *workSessionService) EnsureCheckedIn(ctx context.Context, staffID int64) (*activeModels.WorkSession, error) {
+// EnsureCheckedIn ensures a staff member is checked in, creating a session if needed.
+// `source` is forwarded to CheckIn so the channel is recorded faithfully.
+func (s *workSessionService) EnsureCheckedIn(ctx context.Context, staffID int64, source string) (*activeModels.WorkSession, error) {
 	// Check if already checked in
 	currentSession, err := s.repo.GetCurrentByStaffID(ctx, staffID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -728,8 +745,8 @@ func (s *workSessionService) EnsureCheckedIn(ctx context.Context, staffID int64)
 		return nil, nil
 	}
 
-	// No session today, create one
-	return s.CheckIn(ctx, staffID, activeModels.WorkSessionStatusPresent)
+	// No session today, create one with the channel the caller passed in.
+	return s.CheckIn(ctx, staffID, activeModels.WorkSessionStatusPresent, source)
 }
 
 // German weekday names for export
@@ -926,14 +943,11 @@ func (s *workSessionService) sessionToRow(sr *SessionResponse) []string {
 	m := netMins % 60
 	netto := fmt.Sprintf("%dh %02dmin", h, m)
 
-	// Quelle (source) collapses location and origin into one column.
+	// Quelle (source) collapses channel and status into one column.
 	// Priority: any manual edit wins over auto-checkout, which wins over the
-	// session's chosen status — because corrections are the most useful signal
-	// for the OGS-Leitung when reading the export.
-	quelle := "Vor Ort (App)"
-	if sess.Status == activeModels.WorkSessionStatusHomeOffice {
-		quelle = "Homeoffice (App)"
-	}
+	// session's recorded source+status — because corrections are the most
+	// useful signal for the OGS-Leitung when reading the export.
+	quelle := quelleLabel(sess.Source, sess.Status)
 	if sess.AutoCheckedOut {
 		quelle = "Auto-Checkout"
 	}
@@ -942,6 +956,20 @@ func (s *workSessionService) sessionToRow(sr *SessionResponse) []string {
 	}
 
 	return []string{datum, wochentag, start, ende, pauseMin, netto, quelle, sess.Notes}
+}
+
+// quelleLabel renders the export "Quelle" cell from the persisted source +
+// status. NFC is the only non-default channel; anything else (including the
+// zero value on legacy rows) renders as App, matching the DB column default.
+func quelleLabel(source, status string) string {
+	channel := "App"
+	if source == activeModels.WorkSessionSourceNFC {
+		channel = "NFC"
+	}
+	if status == activeModels.WorkSessionStatusHomeOffice {
+		return fmt.Sprintf("Homeoffice (%s)", channel)
+	}
+	return fmt.Sprintf("Vor Ort (%s)", channel)
 }
 
 // AutoEndExpiredBreaks ends all breaks whose planned_end_time has passed

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -54,16 +54,38 @@ type SessionResponse struct {
 	EditCount        int                              `json:"edit_count"`
 }
 
+// ReopenStatusConflictError is returned by CheckIn when the staff member
+// already has a checked-out session for today and the requested status
+// differs from the existing one. Reopening would silently change the status
+// without an audit edit; the caller (App UI) must instead reopen with the
+// existing status and then go through UpdateSession (which requires a
+// notes reason and emits a FieldStatus edit).
+//
+// The frontend disambiguates this from other 409s via the typed code
+// "reopen_status_conflict" produced by api/time-tracking/errors.go.
+type ReopenStatusConflictError struct {
+	SessionID       int64
+	ExistingStatus  string
+	RequestedStatus string
+}
+
+func (e *ReopenStatusConflictError) Error() string {
+	return "reopen status conflict"
+}
+
 // WorkSessionService defines operations for staff time tracking
 type WorkSessionService interface {
 	// CheckIn opens or reopens today's session for staffID. `source` records
 	// the channel that triggered the check-in (app/nfc) so the export can
 	// label "Vor Ort (App)" vs "Vor Ort (NFC)" without inferring it from
-	// status alone (Issue #1368). On reopen the originating Source is
-	// preserved — the channel that first recorded the session is the
-	// audit-relevant fact, and there is no FieldSource audit edit yet to
-	// capture a change. `status`, by contrast, IS overwritten because Vor
-	// Ort ↔ Homeoffice can legitimately change mid-day.
+	// status alone (Issue #1368).
+	//
+	// Reopen rules: the originating Source AND Status are both preserved.
+	// The channel is an audit-relevant fact with no audit edit to capture
+	// a change; status changes carry audit weight and must go through
+	// UpdateSession (which gates on a notes reason). If `status` differs
+	// from the existing session's status, CheckIn returns
+	// *ReopenStatusConflictError instead of silently overwriting.
 	CheckIn(ctx context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error)
 	CheckOut(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
 	StartBreak(ctx context.Context, staffID int64, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
@@ -133,10 +155,20 @@ func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status,
 		if existingSession.IsActive() {
 			return nil, fmt.Errorf("already checked in")
 		}
+		// A status mismatch on reopen would silently rewrite an audit-relevant
+		// field with no FieldStatus edit emitted. Force the caller to reopen
+		// with the existing status, then change it via UpdateSession (which
+		// gates on a notes reason and produces the audit edit).
+		if existingSession.Status != status {
+			return nil, &ReopenStatusConflictError{
+				SessionID:       existingSession.ID,
+				ExistingStatus:  existingSession.Status,
+				RequestedStatus: status,
+			}
+		}
 		// Re-open the checked-out session (accidental checkout recovery).
-		// `source` is intentionally not forwarded — the original channel
-		// stays as the audit-relevant fact (see reopenSession).
-		return s.reopenSession(ctx, existingSession, staffID, status)
+		// Source and Status are both preserved (see reopenSession comment).
+		return s.reopenSession(ctx, existingSession, staffID)
 	}
 
 	// Create new session
@@ -165,13 +197,16 @@ func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status,
 }
 
 // reopenSession clears checkout on an existing session so the staff member
-// can continue working. Source is intentionally preserved: the originating
-// channel is an audit-relevant fact, and overwriting it on reopen would
-// silently drop that signal (there is no FieldSource audit edit yet).
-func (s *workSessionService) reopenSession(ctx context.Context, session *activeModels.WorkSession, staffID int64, status string) (*activeModels.WorkSession, error) {
+// can continue working. Both Source and Status are intentionally preserved:
+// the originating channel and the previously-chosen work mode are
+// audit-relevant facts, and overwriting either on reopen would silently
+// drop the signal with no audit edit. CheckIn rejects the call with
+// ReopenStatusConflictError before this point if the requested status
+// differs from the existing one — the caller is expected to follow up
+// with UpdateSession (which gates on a notes reason).
+func (s *workSessionService) reopenSession(ctx context.Context, session *activeModels.WorkSession, staffID int64) (*activeModels.WorkSession, error) {
 	session.CheckOutTime = nil
 	session.AutoCheckedOut = false
-	session.Status = status
 	session.UpdatedBy = &staffID
 
 	if err := session.Validate(); err != nil {

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -895,7 +895,7 @@ func (s *workSessionService) exportCSV(rows []exportRow) ([]byte, error) {
 	w.Comma = ';'
 
 	// Header
-	if err := w.Write([]string{"Datum", "Wochentag", "Start", "Ende", "Pause (Min)", "Netto (Std)", "Quelle", "Bemerkungen"}); err != nil {
+	if err := w.Write([]string{"Datum", "Wochentag", "Start", "Ende", "Pause (Min)", "Netto (Std)", "Status", "Quelle", "Bemerkungen"}); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
 	}
 
@@ -928,7 +928,7 @@ func (s *workSessionService) exportXLSX(rows []exportRow) ([]byte, error) {
 		_ = f.DeleteSheet("Sheet1")
 	}
 
-	headers := []string{"Datum", "Wochentag", "Start", "Ende", "Pause (Min)", "Netto (Std)", "Quelle", "Bemerkungen"}
+	headers := []string{"Datum", "Wochentag", "Start", "Ende", "Pause (Min)", "Netto (Std)", "Status", "Quelle", "Bemerkungen"}
 
 	// Header style
 	headerStyle, _ := f.NewStyle(&excelize.Style{
@@ -985,11 +985,21 @@ func (s *workSessionService) sessionToRow(sr *SessionResponse) []string {
 	m := netMins % 60
 	netto := fmt.Sprintf("%dh %02dmin", h, m)
 
-	// Quelle (source) collapses channel and status into one column.
-	// Priority: any manual edit wins over auto-checkout, which wins over the
-	// session's recorded source+status — because corrections are the most
-	// useful signal for the OGS-Leitung when reading the export.
-	quelle := quelleLabel(sess.Source, sess.Status)
+	// Status carries the underlying work mode and is never overwritten by
+	// system events — the OGS-Leitung must always be able to see whether
+	// the row was Vor Ort or Homeoffice, even if the session was later
+	// auto-closed or manually corrected.
+	status := "Vor Ort"
+	if sess.Status == activeModels.WorkSessionStatusHomeOffice {
+		status = "Homeoffice"
+	}
+
+	// Quelle records the originating channel, with system-event overlays:
+	// a manual correction is the most informative signal and wins; an
+	// auto-checkout still tells the reader the session was closed by the
+	// scheduler rather than the staff member; otherwise the persisted
+	// source (App / NFC) is shown verbatim.
+	quelle := quelleLabel(sess.Source)
 	if sess.AutoCheckedOut {
 		quelle = "Auto-Checkout"
 	}
@@ -997,21 +1007,18 @@ func (s *workSessionService) sessionToRow(sr *SessionResponse) []string {
 		quelle = "Manuell korrigiert"
 	}
 
-	return []string{datum, wochentag, start, ende, pauseMin, netto, quelle, sess.Notes}
+	return []string{datum, wochentag, start, ende, pauseMin, netto, status, quelle, sess.Notes}
 }
 
-// quelleLabel renders the export "Quelle" cell from the persisted source +
-// status. NFC is the only non-default channel; anything else (including the
-// zero value on legacy rows) renders as App, matching the DB column default.
-func quelleLabel(source, status string) string {
-	channel := "App"
+// quelleLabel renders the export "Quelle" cell from the persisted source.
+// NFC is the only non-default channel; anything else (including the zero
+// value on legacy rows the migration heuristic missed) renders as App,
+// matching the DB column default.
+func quelleLabel(source string) string {
 	if source == activeModels.WorkSessionSourceNFC {
-		channel = "NFC"
+		return "NFC"
 	}
-	if status == activeModels.WorkSessionStatusHomeOffice {
-		return fmt.Sprintf("Homeoffice (%s)", channel)
-	}
-	return fmt.Sprintf("Vor Ort (%s)", channel)
+	return "App"
 }
 
 // AutoEndExpiredBreaks ends all breaks whose planned_end_time has passed

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -57,10 +57,13 @@ type SessionResponse struct {
 // WorkSessionService defines operations for staff time tracking
 type WorkSessionService interface {
 	// CheckIn opens or reopens today's session for staffID. `source` records
-	// the channel that triggered the check-in (app/nfc/auto) so the export
-	// can label "Vor Ort (App)" vs "Vor Ort (NFC)" without inferring it from
-	// status alone (Issue #1368). Reopening overwrites the source to reflect
-	// the channel of the latest action.
+	// the channel that triggered the check-in (app/nfc) so the export can
+	// label "Vor Ort (App)" vs "Vor Ort (NFC)" without inferring it from
+	// status alone (Issue #1368). On reopen the originating Source is
+	// preserved — the channel that first recorded the session is the
+	// audit-relevant fact, and there is no FieldSource audit edit yet to
+	// capture a change. `status`, by contrast, IS overwritten because Vor
+	// Ort ↔ Homeoffice can legitimately change mid-day.
 	CheckIn(ctx context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error)
 	CheckOut(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
 	StartBreak(ctx context.Context, staffID int64, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
@@ -130,8 +133,10 @@ func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status,
 		if existingSession.IsActive() {
 			return nil, fmt.Errorf("already checked in")
 		}
-		// Re-open the checked-out session (accidental checkout recovery)
-		return s.reopenSession(ctx, existingSession, staffID, status, source)
+		// Re-open the checked-out session (accidental checkout recovery).
+		// `source` is intentionally not forwarded — the original channel
+		// stays as the audit-relevant fact (see reopenSession).
+		return s.reopenSession(ctx, existingSession, staffID, status)
 	}
 
 	// Create new session
@@ -159,12 +164,14 @@ func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status,
 	return session, nil
 }
 
-// reopenSession clears checkout on an existing session so the staff member can continue working
-func (s *workSessionService) reopenSession(ctx context.Context, session *activeModels.WorkSession, staffID int64, status, source string) (*activeModels.WorkSession, error) {
+// reopenSession clears checkout on an existing session so the staff member
+// can continue working. Source is intentionally preserved: the originating
+// channel is an audit-relevant fact, and overwriting it on reopen would
+// silently drop that signal (there is no FieldSource audit edit yet).
+func (s *workSessionService) reopenSession(ctx context.Context, session *activeModels.WorkSession, staffID int64, status string) (*activeModels.WorkSession, error) {
 	session.CheckOutTime = nil
 	session.AutoCheckedOut = false
 	session.Status = status
-	session.Source = source
 	session.UpdatedBy = &staffID
 
 	if err := session.Validate(); err != nil {

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -1011,14 +1011,19 @@ func (s *workSessionService) sessionToRow(sr *SessionResponse) []string {
 }
 
 // quelleLabel renders the export "Quelle" cell from the persisted source.
-// NFC is the only non-default channel; anything else (including the zero
-// value on legacy rows the migration heuristic missed) renders as App,
-// matching the DB column default.
+// 'unknown' marks rows that pre-date migration 1.15.49 — no channel was ever
+// recorded, so we render "—" rather than guess. Anything else falls through
+// to App, matching the DB column default for in-flight rows that may exist
+// briefly between migration and new-server boot.
 func quelleLabel(source string) string {
-	if source == activeModels.WorkSessionSourceNFC {
+	switch source {
+	case activeModels.WorkSessionSourceNFC:
 		return "NFC"
+	case activeModels.WorkSessionSourceUnknown:
+		return "—"
+	default:
+		return "App"
 	}
-	return "App"
 }
 
 // AutoEndExpiredBreaks ends all breaks whose planned_end_time has passed

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
@@ -94,14 +95,10 @@ func NewWorkSessionService(repo activeModels.WorkSessionRepository, breakRepo ac
 	return &workSessionService{repo: repo, breakRepo: breakRepo, auditRepo: auditRepo, absenceRepo: absenceRepo, supervisorRepo: supervisorRepo, logger: logger}
 }
 
-// CheckIn creates a new work session for the staff member
+// CheckIn creates a new work session for the staff member.
+// Status must be explicitly chosen — empty values are rejected so the caller
+// (HTTP handler or internal worker) cannot accidentally fall back to "present".
 func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status string) (*activeModels.WorkSession, error) {
-	// Default status to present if empty
-	if status == "" {
-		status = activeModels.WorkSessionStatusPresent
-	}
-
-	// Validate status
 	if status != activeModels.WorkSessionStatusPresent && status != activeModels.WorkSessionStatusHomeOffice {
 		return nil, fmt.Errorf("status must be 'present' or 'home_office'")
 	}
@@ -413,6 +410,15 @@ func (s *workSessionService) UpdateSession(ctx context.Context, staffID int64, s
 
 	if session.StaffID != staffID {
 		return nil, fmt.Errorf("can only update own sessions")
+	}
+
+	// A status change (Vor Ort ↔ Homeoffice) carries audit weight and must be
+	// justified — otherwise the audit trail loses meaning. Requires the caller
+	// to send the reason in `notes` on the same request.
+	if updates.Status != nil && *updates.Status != session.Status {
+		if updates.Notes == nil || strings.TrimSpace(*updates.Notes) == "" {
+			return nil, fmt.Errorf("notes required when changing status")
+		}
 	}
 
 	uc := &sessionUpdateContext{
@@ -830,7 +836,7 @@ func (s *workSessionService) exportCSV(rows []exportRow) ([]byte, error) {
 	w.Comma = ';'
 
 	// Header
-	if err := w.Write([]string{"Datum", "Wochentag", "Start", "Ende", "Pause (Min)", "Netto (Std)", "Ort", "Bemerkungen"}); err != nil {
+	if err := w.Write([]string{"Datum", "Wochentag", "Start", "Ende", "Pause (Min)", "Netto (Std)", "Quelle", "Bemerkungen"}); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
 	}
 
@@ -863,7 +869,7 @@ func (s *workSessionService) exportXLSX(rows []exportRow) ([]byte, error) {
 		_ = f.DeleteSheet("Sheet1")
 	}
 
-	headers := []string{"Datum", "Wochentag", "Start", "Ende", "Pause (Min)", "Netto (Std)", "Ort", "Bemerkungen"}
+	headers := []string{"Datum", "Wochentag", "Start", "Ende", "Pause (Min)", "Netto (Std)", "Quelle", "Bemerkungen"}
 
 	// Header style
 	headerStyle, _ := f.NewStyle(&excelize.Style{
@@ -920,12 +926,22 @@ func (s *workSessionService) sessionToRow(sr *SessionResponse) []string {
 	m := netMins % 60
 	netto := fmt.Sprintf("%dh %02dmin", h, m)
 
-	ort := "In der OGS"
+	// Quelle (source) collapses location and origin into one column.
+	// Priority: any manual edit wins over auto-checkout, which wins over the
+	// session's chosen status — because corrections are the most useful signal
+	// for the OGS-Leitung when reading the export.
+	quelle := "Vor Ort (App)"
 	if sess.Status == activeModels.WorkSessionStatusHomeOffice {
-		ort = "Homeoffice"
+		quelle = "Homeoffice (App)"
+	}
+	if sess.AutoCheckedOut {
+		quelle = "Auto-Checkout"
+	}
+	if sr.EditCount > 0 {
+		quelle = "Manuell korrigiert"
 	}
 
-	return []string{datum, wochentag, start, ende, pauseMin, netto, ort, sess.Notes}
+	return []string{datum, wochentag, start, ende, pauseMin, netto, quelle, sess.Notes}
 }
 
 // AutoEndExpiredBreaks ends all breaks whose planned_end_time has passed

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -869,9 +869,15 @@ func (s *workSessionService) buildExportRows(sessions []*SessionResponse, absenc
 		for !d.After(absence.DateEnd) {
 			datum := d.Format("02.01.2006")
 			wochentag := germanWeekdays[d.Weekday()]
+			// Column layout must match the export header (9 cells):
+			// Datum, Wochentag, Start, Ende, Pause, Netto, Status, Quelle, Bemerkungen.
+			// Absences have no Quelle (the staff member did not stamp at all),
+			// so that cell stays empty rather than borrowing the "—" sentinel
+			// already used by quelleLabel for legacy work_sessions of unknown
+			// channel — those are two different facts and must read distinctly.
 			rows = append(rows, exportRow{
 				Date: d,
-				Row:  []string{datum, wochentag, "--", "--", "--", "--", label, absence.Note},
+				Row:  []string{datum, wochentag, "--", "--", "--", "--", label, "", absence.Note},
 			})
 			d = d.AddDate(0, 0, 1)
 		}

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -647,7 +647,7 @@ func TestWSCheckIn_InvalidStatus(t *testing.T) {
 // TestWSCheckIn_InvalidSource guards the second validation step in CheckIn:
 // a bogus channel must be rejected at the service boundary before any DB
 // write, so the only values that ever reach active.work_sessions.source are
-// 'app' or 'nfc' (matching the CHECK constraint in migration 1.15.49).
+// 'app' or 'nfc' (matching the CHECK constraint in migration 1.15.54).
 // The error string is also part of the HTTP-boundary contract — the
 // classifier in api/time-tracking/errors.go keys on the "source must be"
 // prefix to produce 400 instead of 500.
@@ -663,7 +663,7 @@ func TestWSCheckIn_InvalidSource(t *testing.T) {
 }
 
 // TestWSCheckIn_RejectsUnknownSource locks in the write/read asymmetry on
-// the 'unknown' sentinel: legacy rows on disk may carry it (migration 1.15.49
+// the 'unknown' sentinel: legacy rows on disk may carry it (migration 1.15.54
 // backfills NULL → 'unknown'), but the service must never produce a new row
 // with source='unknown'. Without this gate, a careless caller could erase
 // the audit signal "this stamp's channel was actually never recorded" by

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -644,6 +644,95 @@ func TestWSCheckIn_InvalidStatus(t *testing.T) {
 	assert.Contains(t, err.Error(), "status must be")
 }
 
+// TestWSReopenThenUpdateSession_EmitsFieldStatusEdit exercises the realistic
+// frontend sequence end-to-end: a checked-out 'present' session is reopened
+// at the existing status (no conflict), then the requested status flip is
+// routed through UpdateSession with a notes reason. The combined behaviour
+// the audit trail relies on is:
+//
+//  1. The reopen does not create an audit edit (it preserves Status).
+//  2. The follow-up UpdateSession produces a FieldStatus edit whose old/new
+//     values match the chosen flip and whose Reason carries the user's text.
+//
+// This complements the unit tests that cover each step in isolation
+// (TestWSCheckIn_ReopenPreservesOriginalSourceAndStatus and
+// TestWSUpdateSession_StatusChange) by locking in the cross-call behaviour.
+func TestWSReopenThenUpdateSession_EmitsFieldStatusEdit(t *testing.T) {
+	svc, sessionRepo, _, auditRepo, _ := wsCreateTestService()
+	ctx := context.Background()
+	staffID := int64(100)
+	sessionID := int64(7)
+	checkOut := time.Now().Add(-1 * time.Hour)
+
+	current := &activeModels.WorkSession{
+		Model:          base.Model{ID: sessionID},
+		StaffID:        staffID,
+		CheckInTime:    time.Now().Add(-4 * time.Hour),
+		CheckOutTime:   &checkOut,
+		AutoCheckedOut: true,
+		Status:         activeModels.WorkSessionStatusPresent,
+		Source:         activeModels.WorkSessionSourceApp,
+		Date:           time.Now().Truncate(24 * time.Hour),
+		CreatedBy:      staffID,
+	}
+
+	sessionRepo.getByStaffAndDateFunc = func(_ context.Context, _ int64, _ time.Time) (*activeModels.WorkSession, error) {
+		return current, nil
+	}
+	sessionRepo.findByIDFunc = func(_ context.Context, _ any) (*activeModels.WorkSession, error) {
+		return current, nil
+	}
+	sessionRepo.updateFunc = func(_ context.Context, entity *activeModels.WorkSession) error {
+		current = entity
+		return nil
+	}
+
+	var auditCalls int
+	var capturedEdits []*auditModels.WorkSessionEdit
+	auditRepo.createBatchFunc = func(_ context.Context, edits []*auditModels.WorkSessionEdit) error {
+		auditCalls++
+		capturedEdits = append(capturedEdits, edits...)
+		return nil
+	}
+
+	// Step 1: reopen at existing status — no audit edit.
+	reopened, err := svc.CheckIn(ctx, staffID,
+		activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
+	require.NoError(t, err)
+	require.NotNil(t, reopened)
+	require.Nil(t, reopened.CheckOutTime, "reopen must clear CheckOutTime")
+	assert.Equal(t, 0, auditCalls, "reopen alone must not emit audit edits")
+
+	// Step 2: route the actual status flip through UpdateSession with reason.
+	newStatus := activeModels.WorkSessionStatusHomeOffice
+	reason := "Mittags ins Homeoffice gewechselt"
+	updated, err := svc.UpdateSession(ctx, staffID, sessionID, SessionUpdateRequest{
+		Status: &newStatus,
+		Notes:  &reason,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	require.GreaterOrEqual(t, auditCalls, 1, "UpdateSession must emit an audit batch")
+	var statusEdit *auditModels.WorkSessionEdit
+	for _, e := range capturedEdits {
+		if e.FieldName == auditModels.FieldStatus {
+			statusEdit = e
+			break
+		}
+	}
+	require.NotNil(t, statusEdit, "audit batch must contain a FieldStatus edit")
+	require.NotNil(t, statusEdit.OldValue)
+	require.NotNil(t, statusEdit.NewValue)
+	assert.Equal(t, activeModels.WorkSessionStatusPresent, *statusEdit.OldValue,
+		"FieldStatus old value reflects the pre-update status")
+	assert.Equal(t, activeModels.WorkSessionStatusHomeOffice, *statusEdit.NewValue,
+		"FieldStatus new value reflects the requested flip")
+	require.NotNil(t, statusEdit.Notes,
+		"FieldStatus edit must carry the user-supplied reason in Notes")
+	assert.Equal(t, reason, *statusEdit.Notes)
+}
+
 func TestWSCheckIn_RepoError(t *testing.T) {
 	svc, sessionRepo, _, _, _ := wsCreateTestService()
 

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -490,22 +490,21 @@ func TestWSCheckIn_Success(t *testing.T) {
 	assert.Nil(t, session.CheckOutTime)
 }
 
-func TestWSCheckIn_DefaultStatus(t *testing.T) {
+func TestWSCheckIn_RejectsEmptyStatus(t *testing.T) {
+	// Issue #1368: staff must explicitly choose Vor Ort vs Homeoffice; the
+	// service no longer silently defaults an empty status to "present".
 	svc, sessionRepo, _, _, _ := wsCreateTestService()
 	ctx := context.Background()
 
-	sessionRepo.getByStaffAndDateFunc = func(_ context.Context, _ int64, _ time.Time) (*activeModels.WorkSession, error) {
-		return nil, sql.ErrNoRows
-	}
-	sessionRepo.createFunc = func(_ context.Context, entity *activeModels.WorkSession) error {
-		assert.Equal(t, activeModels.WorkSessionStatusPresent, entity.Status)
-		entity.ID = 10
+	sessionRepo.createFunc = func(_ context.Context, _ *activeModels.WorkSession) error {
+		t.Fatal("createFunc should not be called when status is empty")
 		return nil
 	}
 
 	session, err := svc.CheckIn(ctx, 100, "")
-	require.NoError(t, err)
-	assert.Equal(t, activeModels.WorkSessionStatusPresent, session.Status)
+	require.Error(t, err)
+	assert.Nil(t, session)
+	assert.Contains(t, err.Error(), "status must be")
 }
 
 func TestWSCheckIn_AlreadyCheckedIn(t *testing.T) {

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -482,11 +482,12 @@ func TestWSCheckIn_Success(t *testing.T) {
 		return nil
 	}
 
-	session, err := svc.CheckIn(ctx, staffID, activeModels.WorkSessionStatusPresent)
+	session, err := svc.CheckIn(ctx, staffID, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
 	require.NoError(t, err)
 	require.NotNil(t, session)
 	assert.Equal(t, staffID, session.StaffID)
 	assert.Equal(t, activeModels.WorkSessionStatusPresent, session.Status)
+	assert.Equal(t, activeModels.WorkSessionSourceApp, session.Source)
 	assert.Nil(t, session.CheckOutTime)
 }
 
@@ -501,7 +502,7 @@ func TestWSCheckIn_RejectsEmptyStatus(t *testing.T) {
 		return nil
 	}
 
-	session, err := svc.CheckIn(ctx, 100, "")
+	session, err := svc.CheckIn(ctx, 100, "", activeModels.WorkSessionSourceApp)
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "status must be")
@@ -518,7 +519,7 @@ func TestWSCheckIn_AlreadyCheckedIn(t *testing.T) {
 		}, nil
 	}
 
-	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent)
+	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "already checked in")
@@ -547,7 +548,7 @@ func TestWSCheckIn_ReopenCheckedOutSession(t *testing.T) {
 		return nil
 	}
 
-	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent)
+	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
 	require.NoError(t, err)
 	require.NotNil(t, session)
 	assert.Nil(t, session.CheckOutTime)
@@ -556,7 +557,7 @@ func TestWSCheckIn_ReopenCheckedOutSession(t *testing.T) {
 func TestWSCheckIn_InvalidStatus(t *testing.T) {
 	svc, _, _, _, _ := wsCreateTestService()
 
-	session, err := svc.CheckIn(context.Background(), 100, "invalid_status")
+	session, err := svc.CheckIn(context.Background(), 100, "invalid_status", activeModels.WorkSessionSourceApp)
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "status must be")
@@ -569,7 +570,7 @@ func TestWSCheckIn_RepoError(t *testing.T) {
 		return nil, errors.New("database error")
 	}
 
-	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent)
+	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "failed to check existing session")
@@ -1107,7 +1108,7 @@ func TestWSEnsureCheckedIn_AlreadyActive(t *testing.T) {
 		}, nil
 	}
 
-	session, err := svc.EnsureCheckedIn(context.Background(), staffID)
+	session, err := svc.EnsureCheckedIn(context.Background(), staffID, activeModels.WorkSessionSourceNFC)
 	require.NoError(t, err)
 	require.NotNil(t, session)
 	assert.Equal(t, staffID, session.StaffID)
@@ -1130,7 +1131,7 @@ func TestWSEnsureCheckedIn_AlreadyCheckedOutToday(t *testing.T) {
 		}, nil
 	}
 
-	session, err := svc.EnsureCheckedIn(context.Background(), staffID)
+	session, err := svc.EnsureCheckedIn(context.Background(), staffID, activeModels.WorkSessionSourceNFC)
 	require.NoError(t, err)
 	assert.Nil(t, session) // Should return nil when already checked out today
 }
@@ -1154,14 +1155,44 @@ func TestWSEnsureCheckedIn_CreatesNew(t *testing.T) {
 		return nil, sql.ErrNoRows
 	}
 
+	var capturedSource string
 	sessionRepo.createFunc = func(_ context.Context, entity *activeModels.WorkSession) error {
 		entity.ID = 10
+		capturedSource = entity.Source
 		return nil
 	}
 
-	session, err := svc.EnsureCheckedIn(context.Background(), staffID)
+	session, err := svc.EnsureCheckedIn(context.Background(), staffID, activeModels.WorkSessionSourceNFC)
 	require.NoError(t, err)
 	require.NotNil(t, session)
+	assert.Equal(t, activeModels.WorkSessionSourceNFC, capturedSource,
+		"EnsureCheckedIn must forward the caller-supplied source to CheckIn")
+}
+
+// TestWSEnsureCheckedIn_ForwardsAppSource verifies that EnsureCheckedIn does
+// not hard-code 'nfc' — non-NFC callers (web triggers, future schedulers)
+// must be able to record their channel faithfully.
+func TestWSEnsureCheckedIn_ForwardsAppSource(t *testing.T) {
+	svc, sessionRepo, _, _, _ := wsCreateTestService()
+	staffID := int64(100)
+
+	sessionRepo.getCurrentByStaffIDFunc = func(_ context.Context, _ int64) (*activeModels.WorkSession, error) {
+		return nil, sql.ErrNoRows
+	}
+	sessionRepo.getByStaffAndDateFunc = func(_ context.Context, _ int64, _ time.Time) (*activeModels.WorkSession, error) {
+		return nil, sql.ErrNoRows
+	}
+
+	var capturedSource string
+	sessionRepo.createFunc = func(_ context.Context, entity *activeModels.WorkSession) error {
+		entity.ID = 11
+		capturedSource = entity.Source
+		return nil
+	}
+
+	_, err := svc.EnsureCheckedIn(context.Background(), staffID, activeModels.WorkSessionSourceApp)
+	require.NoError(t, err)
+	assert.Equal(t, activeModels.WorkSessionSourceApp, capturedSource)
 }
 
 // ============================================================================

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -644,6 +644,37 @@ func TestWSCheckIn_InvalidStatus(t *testing.T) {
 	assert.Contains(t, err.Error(), "status must be")
 }
 
+// TestWSCheckIn_InvalidSource guards the second validation step in CheckIn:
+// a bogus channel must be rejected at the service boundary before any DB
+// write, so the only values that ever reach active.work_sessions.source are
+// 'app' or 'nfc' (matching the CHECK constraint in migration 1.15.49).
+// The error string is also part of the HTTP-boundary contract — the
+// classifier in api/time-tracking/errors.go keys on the "source must be"
+// prefix to produce 400 instead of 500.
+func TestWSCheckIn_InvalidSource(t *testing.T) {
+	svc, _, _, _, _ := wsCreateTestService()
+
+	session, err := svc.CheckIn(context.Background(), 100,
+		activeModels.WorkSessionStatusPresent, "bogus")
+	require.Error(t, err)
+	assert.Nil(t, session)
+	assert.Contains(t, err.Error(), "source must be",
+		"classifyServiceError matches this prefix to map the error to HTTP 400")
+}
+
+// TestReopenStatusConflictError_Error covers the typed error's stringification.
+// Production callers use errors.As to branch on the type, which does not
+// invoke Error(), but the message still appears in slog warnings/info logs
+// when the error bubbles up — locking the string keeps log greps stable.
+func TestReopenStatusConflictError_Error(t *testing.T) {
+	err := &ReopenStatusConflictError{
+		SessionID:       7,
+		ExistingStatus:  activeModels.WorkSessionStatusPresent,
+		RequestedStatus: activeModels.WorkSessionStatusHomeOffice,
+	}
+	assert.Equal(t, "reopen status conflict", err.Error())
+}
+
 // TestWSReopenThenUpdateSession_EmitsFieldStatusEdit exercises the realistic
 // frontend sequence end-to-end: a checked-out 'present' session is reopened
 // at the existing status (no conflict), then the requested status flip is

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -554,6 +554,50 @@ func TestWSCheckIn_ReopenCheckedOutSession(t *testing.T) {
 	assert.Nil(t, session.CheckOutTime)
 }
 
+// TestWSCheckIn_ReopenPreservesOriginalSource locks in the audit-trail
+// behaviour for Issue #1368: an NFC-originated session that the staff
+// member reopens via the App must remain source='nfc'. Overwriting would
+// silently drop the originating channel, which is an audit-relevant fact
+// with no corresponding FieldSource audit edit to capture the change.
+// Status, by contrast, IS overwritten because Vor Ort ↔ Homeoffice can
+// legitimately change mid-day.
+func TestWSCheckIn_ReopenPreservesOriginalSource(t *testing.T) {
+	svc, sessionRepo, _, _, _ := wsCreateTestService()
+	checkOut := time.Now().Add(-1 * time.Hour)
+
+	sessionRepo.getByStaffAndDateFunc = func(_ context.Context, _ int64, _ time.Time) (*activeModels.WorkSession, error) {
+		return &activeModels.WorkSession{
+			Model:          base.Model{ID: 1},
+			StaffID:        100,
+			CheckInTime:    time.Now().Add(-4 * time.Hour),
+			CheckOutTime:   &checkOut,
+			AutoCheckedOut: true,
+			Status:         activeModels.WorkSessionStatusPresent,
+			Source:         activeModels.WorkSessionSourceNFC,
+			Date:           time.Now().Truncate(24 * time.Hour),
+			CreatedBy:      100,
+		}, nil
+	}
+
+	var capturedSource, capturedStatus string
+	sessionRepo.updateFunc = func(_ context.Context, entity *activeModels.WorkSession) error {
+		capturedSource = entity.Source
+		capturedStatus = entity.Status
+		return nil
+	}
+
+	// Reopen via App with a different status — the new status takes effect,
+	// the original NFC source must survive.
+	session, err := svc.CheckIn(context.Background(), 100,
+		activeModels.WorkSessionStatusHomeOffice, activeModels.WorkSessionSourceApp)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.Equal(t, activeModels.WorkSessionSourceNFC, capturedSource,
+		"reopen must preserve the originating Source")
+	assert.Equal(t, activeModels.WorkSessionStatusHomeOffice, capturedStatus,
+		"reopen must apply the new Status")
+}
+
 func TestWSCheckIn_InvalidStatus(t *testing.T) {
 	svc, _, _, _, _ := wsCreateTestService()
 

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -554,14 +554,13 @@ func TestWSCheckIn_ReopenCheckedOutSession(t *testing.T) {
 	assert.Nil(t, session.CheckOutTime)
 }
 
-// TestWSCheckIn_ReopenPreservesOriginalSource locks in the audit-trail
-// behaviour for Issue #1368: an NFC-originated session that the staff
-// member reopens via the App must remain source='nfc'. Overwriting would
-// silently drop the originating channel, which is an audit-relevant fact
-// with no corresponding FieldSource audit edit to capture the change.
-// Status, by contrast, IS overwritten because Vor Ort ↔ Homeoffice can
-// legitimately change mid-day.
-func TestWSCheckIn_ReopenPreservesOriginalSource(t *testing.T) {
+// TestWSCheckIn_ReopenPreservesOriginalSourceAndStatus locks in the
+// audit-trail behaviour for Issue #1368: when the staff member reopens an
+// NFC-originated session via the App with the SAME status, both Source and
+// Status are preserved. Reopen never overwrites either field — Source has
+// no audit-edit channel, and Status changes must go through UpdateSession
+// (which gates on a notes reason).
+func TestWSCheckIn_ReopenPreservesOriginalSourceAndStatus(t *testing.T) {
 	svc, sessionRepo, _, _, _ := wsCreateTestService()
 	checkOut := time.Now().Add(-1 * time.Hour)
 
@@ -586,16 +585,54 @@ func TestWSCheckIn_ReopenPreservesOriginalSource(t *testing.T) {
 		return nil
 	}
 
-	// Reopen via App with a different status — the new status takes effect,
-	// the original NFC source must survive.
+	// Reopen via App with the SAME status — both Source and Status survive.
 	session, err := svc.CheckIn(context.Background(), 100,
-		activeModels.WorkSessionStatusHomeOffice, activeModels.WorkSessionSourceApp)
+		activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
 	require.NoError(t, err)
 	require.NotNil(t, session)
 	assert.Equal(t, activeModels.WorkSessionSourceNFC, capturedSource,
 		"reopen must preserve the originating Source")
-	assert.Equal(t, activeModels.WorkSessionStatusHomeOffice, capturedStatus,
-		"reopen must apply the new Status")
+	assert.Equal(t, activeModels.WorkSessionStatusPresent, capturedStatus,
+		"reopen must preserve the originating Status")
+}
+
+// TestWSCheckIn_ReopenStatusMismatchReturnsTypedConflict guards the audit
+// trail: a reopen that would silently flip Vor Ort ↔ Homeoffice is rejected
+// before the DB write. The frontend uses the typed code to branch into the
+// "change status with reason" flow (UpdateSession with notes).
+func TestWSCheckIn_ReopenStatusMismatchReturnsTypedConflict(t *testing.T) {
+	svc, sessionRepo, _, _, _ := wsCreateTestService()
+	checkOut := time.Now().Add(-1 * time.Hour)
+
+	existing := &activeModels.WorkSession{
+		Model:          base.Model{ID: 42},
+		StaffID:        100,
+		CheckInTime:    time.Now().Add(-4 * time.Hour),
+		CheckOutTime:   &checkOut,
+		AutoCheckedOut: true,
+		Status:         activeModels.WorkSessionStatusPresent,
+		Source:         activeModels.WorkSessionSourceNFC,
+		Date:           time.Now().Truncate(24 * time.Hour),
+		CreatedBy:      100,
+	}
+	sessionRepo.getByStaffAndDateFunc = func(_ context.Context, _ int64, _ time.Time) (*activeModels.WorkSession, error) {
+		return existing, nil
+	}
+	sessionRepo.updateFunc = func(_ context.Context, _ *activeModels.WorkSession) error {
+		t.Fatal("repo.Update must not be called on a status-mismatch reopen")
+		return nil
+	}
+
+	session, err := svc.CheckIn(context.Background(), 100,
+		activeModels.WorkSessionStatusHomeOffice, activeModels.WorkSessionSourceApp)
+	require.Error(t, err)
+	assert.Nil(t, session)
+
+	var conflict *ReopenStatusConflictError
+	require.ErrorAs(t, err, &conflict, "must surface as the typed conflict")
+	assert.Equal(t, int64(42), conflict.SessionID)
+	assert.Equal(t, activeModels.WorkSessionStatusPresent, conflict.ExistingStatus)
+	assert.Equal(t, activeModels.WorkSessionStatusHomeOffice, conflict.RequestedStatus)
 }
 
 func TestWSCheckIn_InvalidStatus(t *testing.T) {

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -662,6 +662,23 @@ func TestWSCheckIn_InvalidSource(t *testing.T) {
 		"classifyServiceError matches this prefix to map the error to HTTP 400")
 }
 
+// TestWSCheckIn_RejectsUnknownSource locks in the write/read asymmetry on
+// the 'unknown' sentinel: legacy rows on disk may carry it (migration 1.15.49
+// backfills NULL → 'unknown'), but the service must never produce a new row
+// with source='unknown'. Without this gate, a careless caller could erase
+// the audit signal "this stamp's channel was actually never recorded" by
+// re-writing a fresh row with the same sentinel.
+func TestWSCheckIn_RejectsUnknownSource(t *testing.T) {
+	svc, _, _, _, _ := wsCreateTestService()
+
+	session, err := svc.CheckIn(context.Background(), 100,
+		activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceUnknown)
+	require.Error(t, err)
+	assert.Nil(t, session)
+	assert.Contains(t, err.Error(), "source must be",
+		"'unknown' is a read-only sentinel for legacy rows and must not be writable")
+}
+
 // TestReopenStatusConflictError_Error covers the typed error's stringification.
 // Production callers use errors.As to branch on the type, which does not
 // invoke Error(), but the message still appears in slog warnings/info logs
@@ -692,7 +709,7 @@ func TestWSReopenThenUpdateSession_EmitsFieldStatusEdit(t *testing.T) {
 	svc, sessionRepo, _, auditRepo, _ := wsCreateTestService()
 	ctx := context.Background()
 	staffID := int64(100)
-	sessionID := int64(7)
+	sessionID := int64(701)
 	checkOut := time.Now().Add(-1 * time.Hour)
 
 	current := &activeModels.WorkSession{

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -531,6 +531,18 @@ func CleanupActivityFixturesForTenant(tb testing.TB, db *bun.DB, tenantID int64,
 			Where("tenant_id = ?", tenantID),
 			"users.students")
 
+		// Delete from active.work_sessions referencing this staff. The IoT
+		// supervisor flow auto-creates a work_session via EnsureCheckedIn
+		// when StartActivitySession runs in tests; the FK to users.staff has
+		// no ON DELETE CASCADE, so the row must be cleared first.
+		// active.work_session_breaks and audit.work_session_edits cascade
+		// via session_id ON DELETE CASCADE.
+		cleanupDelete(tb, db.NewDelete().
+			TableExpr("active.work_sessions").
+			Where("staff_id = ? OR created_by = ? OR updated_by = ?", id, id, id).
+			Where("tenant_id = ?", tenantID),
+			"active.work_sessions")
+
 		// Delete from users.staff, but never the system staff fixture
 		// (id=1, created by SetupTestDB). Tests across parallel packages share it.
 		cleanupDelete(tb, db.NewDelete().

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -932,16 +932,40 @@ describe("TimeTrackingPage", () => {
   // route the change through CheckIn(existingStatus) + UpdateSession.
 
   describe("reopen-with-status-change", () => {
-    function makeReopenConflictError(): Error & {
+    // makeReopenConflictError builds the typed 409 the backend returns from
+    // CheckIn when the requested status differs from today's existing
+    // (checked-out) session's status. The structured `details` payload comes
+    // straight from ErrorConflictWithDetails on the backend (see
+    // api/time-tracking/errors.go) and is what drives the modal — the
+    // frontend no longer reads today's session out of historyData, because
+    // history is fetched per-week and won't include today when the user is
+    // viewing a past week.
+    function makeReopenConflictError(
+      overrides?: Partial<{
+        sessionId: string;
+        existingStatus: string;
+        requestedStatus: string;
+        omitDetails: boolean;
+      }>,
+    ): Error & {
       code?: string;
       status?: number;
+      details?: Record<string, unknown>;
     } {
       const err = new Error("reopen status conflict") as Error & {
         code?: string;
         status?: number;
+        details?: Record<string, unknown>;
       };
       err.code = "reopen_status_conflict";
       err.status = 409;
+      if (!overrides?.omitDetails) {
+        err.details = {
+          session_id: overrides?.sessionId ?? mockHistorySession.id,
+          existing_status: overrides?.existingStatus ?? "present",
+          requested_status: overrides?.requestedStatus ?? "home_office",
+        };
+      }
       return err;
     }
 
@@ -1157,14 +1181,15 @@ describe("TimeTrackingPage", () => {
       expect(screen.getByText("Status für heute ändern")).toBeInTheDocument();
     });
 
-    it("reopen conflict before history loads: warns and shows toast instead of modal", async () => {
-      // SWR-race branch: the backend rejects with REOPEN_STATUS_CONFLICT_CODE
-      // but history hasn't loaded today's checked-out session yet, so the UI
-      // has no session id to drive the reason modal. Must surface a
-      // user-visible toast — not swallow the conflict behind a generic error.
+    it("reopen conflict without details payload: warns and shows toast instead of modal", async () => {
+      // Defensive branch: the typed code arrives but the structured details
+      // payload is missing (older server, middleware stripping fields, schema
+      // drift). Without session_id + existing_status we cannot drive the
+      // reason modal, so the UI must surface a user-visible toast — not
+      // swallow the conflict behind a generic error.
       setupDefaultMocks({ history: [] });
       vi.mocked(timeTrackingService.checkIn).mockRejectedValueOnce(
-        makeReopenConflictError(),
+        makeReopenConflictError({ omitDetails: true }),
       );
       const errorToast = vi.fn();
       vi.mocked(useToast).mockReturnValue({
@@ -1202,7 +1227,10 @@ describe("TimeTrackingPage", () => {
       };
       setupDefaultMocks({ history: [homeOfficeHistory] });
       vi.mocked(timeTrackingService.checkIn).mockRejectedValueOnce(
-        makeReopenConflictError(),
+        makeReopenConflictError({
+          existingStatus: "home_office",
+          requestedStatus: "present",
+        }),
       );
 
       render(<TimeTrackingPage />);

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -33,6 +33,7 @@ vi.mock("~/contexts/ToastContext", () => ({
 }));
 
 vi.mock("~/lib/time-tracking-api", () => ({
+  REOPEN_STATUS_CONFLICT_CODE: "reopen_status_conflict",
   timeTrackingService: {
     checkIn: vi.fn(),
     checkOut: vi.fn(),
@@ -916,6 +917,148 @@ describe("TimeTrackingPage", () => {
         const krankTexts = screen.getAllByText(/Krank/);
         expect(krankTexts.length).toBeGreaterThanOrEqual(1);
       });
+    });
+  });
+
+  // ── Reopen-with-status-change (Issue #1368) ─────────────────────────────
+  //
+  // Backend rejects a CheckIn that would silently flip Vor Ort ↔ Homeoffice
+  // on a checked-out session for today. The page must catch the typed error
+  // (code: "reopen_status_conflict"), prompt for an audit reason, then
+  // route the change through CheckIn(existingStatus) + UpdateSession.
+
+  describe("reopen-with-status-change", () => {
+    function makeReopenConflictError(): Error & {
+      code?: string;
+      status?: number;
+    } {
+      const err = new Error("reopen status conflict") as Error & {
+        code?: string;
+        status?: number;
+      };
+      err.code = "reopen_status_conflict";
+      err.status = 409;
+      return err;
+    }
+
+    it("opens the status-change modal on reopen_status_conflict", async () => {
+      // Today: existing checked-out 'present' session in history.
+      setupDefaultMocks({ history: [mockHistorySession] });
+      vi.mocked(timeTrackingService.checkIn).mockRejectedValueOnce(
+        makeReopenConflictError(),
+      );
+      render(<TimeTrackingPage />);
+
+      // User picks Homeoffice — different from the existing 'present'.
+      fireEvent.click(screen.getByText("Homeoffice"));
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Einstempeln"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Status für heute ändern")).toBeInTheDocument();
+      });
+
+      // Confirm button is disabled until the user enters a reason.
+      const confirmBtn = screen.getByText("Auf Homeoffice ändern");
+      expect(confirmBtn).toBeDisabled();
+    });
+
+    it("confirm calls checkIn(existingStatus) then updateSession with reason", async () => {
+      setupDefaultMocks({ history: [mockHistorySession] });
+      // First CheckIn (Homeoffice) → conflict. Second CheckIn (the reopen
+      // with the existing 'present' status) → succeeds.
+      vi.mocked(timeTrackingService.checkIn)
+        .mockRejectedValueOnce(makeReopenConflictError())
+        .mockResolvedValueOnce(mockActiveSession);
+      vi.mocked(timeTrackingService.updateSession).mockResolvedValue({
+        ...mockActiveSession,
+        status: "home_office",
+      });
+      render(<TimeTrackingPage />);
+
+      fireEvent.click(screen.getByText("Homeoffice"));
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Einstempeln"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Status für heute ändern")).toBeInTheDocument();
+      });
+
+      // Enter the audit reason.
+      const textarea = screen.getByLabelText("Grund");
+      fireEvent.change(textarea, {
+        target: { value: "Mittags ins Homeoffice gewechselt" },
+      });
+
+      const confirmBtn = screen.getByText("Auf Homeoffice ändern");
+      expect(confirmBtn).not.toBeDisabled();
+
+      await act(async () => {
+        fireEvent.click(confirmBtn);
+      });
+
+      await waitFor(() => {
+        // Reopen at the EXISTING status, not the requested one.
+        expect(timeTrackingService.checkIn).toHaveBeenLastCalledWith("present");
+        // Status change carries the reason as notes.
+        expect(timeTrackingService.updateSession).toHaveBeenCalledWith(
+          mockHistorySession.id,
+          { status: "home_office", notes: "Mittags ins Homeoffice gewechselt" },
+        );
+      });
+    });
+
+    it("cancel closes the modal without calling checkIn or updateSession again", async () => {
+      setupDefaultMocks({ history: [mockHistorySession] });
+      vi.mocked(timeTrackingService.checkIn).mockRejectedValueOnce(
+        makeReopenConflictError(),
+      );
+      render(<TimeTrackingPage />);
+
+      fireEvent.click(screen.getByText("Homeoffice"));
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Einstempeln"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Status für heute ändern")).toBeInTheDocument();
+      });
+
+      // CheckIn was called once (the failed initial call). Reset history so
+      // the assertion below can prove no further calls happen on cancel.
+      vi.mocked(timeTrackingService.checkIn).mockClear();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Abbrechen"));
+      });
+
+      expect(timeTrackingService.checkIn).not.toHaveBeenCalled();
+      expect(timeTrackingService.updateSession).not.toHaveBeenCalled();
+    });
+
+    it("same-status reopen does not surface the modal", async () => {
+      // Existing 'present' session, user picks Vor Ort again — a normal
+      // recovery reopen. CheckIn succeeds; no conflict, no modal.
+      setupDefaultMocks({ history: [mockHistorySession] });
+      vi.mocked(timeTrackingService.checkIn).mockResolvedValueOnce(
+        mockActiveSession,
+      );
+      render(<TimeTrackingPage />);
+
+      selectPresentMode();
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Einstempeln"));
+      });
+
+      await waitFor(() => {
+        expect(timeTrackingService.checkIn).toHaveBeenCalledWith("present");
+      });
+      expect(
+        screen.queryByText("Status für heute ändern"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -1156,6 +1156,74 @@ describe("TimeTrackingPage", () => {
       expect(timeTrackingService.updateSession).not.toHaveBeenCalled();
       expect(screen.getByText("Status für heute ändern")).toBeInTheDocument();
     });
+
+    it("reopen conflict before history loads: warns and shows toast instead of modal", async () => {
+      // SWR-race branch: the backend rejects with REOPEN_STATUS_CONFLICT_CODE
+      // but history hasn't loaded today's checked-out session yet, so the UI
+      // has no session id to drive the reason modal. Must surface a
+      // user-visible toast — not swallow the conflict behind a generic error.
+      setupDefaultMocks({ history: [] });
+      vi.mocked(timeTrackingService.checkIn).mockRejectedValueOnce(
+        makeReopenConflictError(),
+      );
+      const errorToast = vi.fn();
+      vi.mocked(useToast).mockReturnValue({
+        success: vi.fn(),
+        error: errorToast,
+        info: vi.fn(),
+        warning: vi.fn(),
+        remove: vi.fn(),
+      });
+
+      render(<TimeTrackingPage />);
+
+      fireEvent.click(screen.getByText("Homeoffice"));
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Einstempeln"));
+      });
+
+      await waitFor(() => {
+        expect(errorToast).toHaveBeenCalledTimes(1);
+      });
+      const msg = errorToast.mock.calls[0]?.[0] as string;
+      expect(msg).toMatch(/bereits eine Sitzung/);
+      expect(
+        screen.queryByText("Status für heute ändern"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("home_office → present: modal text and confirm button reflect the inverse direction", async () => {
+      // Inverse of the other tests: today's existing session is home_office,
+      // user picks Vor Ort. Exercises the false branches of the
+      // existingStatus / requestedStatus ternaries in the modal copy.
+      const homeOfficeHistory: WorkSessionHistory = {
+        ...mockHistorySession,
+        status: "home_office",
+      };
+      setupDefaultMocks({ history: [homeOfficeHistory] });
+      vi.mocked(timeTrackingService.checkIn).mockRejectedValueOnce(
+        makeReopenConflictError(),
+      );
+
+      render(<TimeTrackingPage />);
+
+      selectPresentMode();
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Einstempeln"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Status für heute ändern")).toBeInTheDocument();
+      });
+
+      // Confirm button label flips when target is "present".
+      expect(screen.getByText("Auf Vor Ort ändern")).toBeInTheDocument();
+      // Modal copy names the existing Homeoffice session and the requested
+      // Vor Ort target.
+      const body = screen.getByTestId("modal-body");
+      expect(body.textContent).toMatch(/Homeoffice-Sitzung/);
+      expect(body.textContent).toMatch(/Vor Ort/);
+    });
   });
 
   // ── Edit Modal ──────────────────────────────────────────────────────────

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -381,10 +381,24 @@ describe("TimeTrackingPage", () => {
       expect(screen.getByText("Abwesend")).toBeInTheDocument();
     });
 
-    it("shows Einstempeln label by default", () => {
+    it("shows 'Bitte Status wählen' label before any mode is selected", () => {
+      // Issue #1368: no pre-selection — staff must explicitly pick Vor Ort,
+      // Homeoffice, or Abwesend. Until then the action label nudges the user.
       setupDefaultMocks();
       render(<TimeTrackingPage />);
-      expect(screen.getByText("Einstempeln")).toBeInTheDocument();
+      expect(screen.getByText("Bitte Status wählen")).toBeInTheDocument();
+      expect(screen.queryByText("Einstempeln")).not.toBeInTheDocument();
+    });
+
+    it("disables the Einstempeln button until a mode is chosen", () => {
+      // Issue #1368: the action button stays disabled with no mode selected,
+      // so a stray click cannot trigger an unintended check-in.
+      setupDefaultMocks();
+      render(<TimeTrackingPage />);
+      const btn = screen.getByLabelText("Einstempeln");
+      expect(btn).toBeDisabled();
+      fireEvent.click(screen.getByText("In der OGS"));
+      expect(btn).not.toBeDisabled();
     });
 
     it("shows Abwesenheit melden label when absent mode selected", () => {
@@ -406,6 +420,11 @@ describe("TimeTrackingPage", () => {
         mockActiveSession,
       );
       render(<TimeTrackingPage />);
+
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -449,6 +468,11 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
+
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
       });
@@ -474,6 +498,11 @@ describe("TimeTrackingPage", () => {
         new Error("already checked in"),
       );
       render(<TimeTrackingPage />);
+
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -812,6 +841,11 @@ describe("TimeTrackingPage", () => {
       setupDefaultMocks({ absences: [mockAbsence] });
       render(<TimeTrackingPage />);
 
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
+
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
       });
@@ -825,6 +859,11 @@ describe("TimeTrackingPage", () => {
     it("cancels check-in when Abbrechen clicked in confirmation", async () => {
       setupDefaultMocks({ absences: [mockAbsence] });
       render(<TimeTrackingPage />);
+
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -850,6 +889,11 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
+
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
       });
@@ -870,6 +914,11 @@ describe("TimeTrackingPage", () => {
     it("shows absence type in confirmation modal", async () => {
       setupDefaultMocks({ absences: [mockAbsence] });
       render(<TimeTrackingPage />);
+
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -998,6 +1047,11 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
+
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
       });
@@ -1108,6 +1162,11 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
+
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
       });
@@ -1129,6 +1188,11 @@ describe("TimeTrackingPage", () => {
       setupDefaultMocks();
       vi.mocked(timeTrackingService.checkIn).mockRejectedValue("string error");
       render(<TimeTrackingPage />);
+
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -3086,6 +3150,11 @@ describe("TimeTrackingPage", () => {
       setupDefaultMocks({ absences: [vacAbsence] });
       render(<TimeTrackingPage />);
 
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
+
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
       });
@@ -3571,6 +3640,11 @@ describe("TimeTrackingPage", () => {
       });
       render(<TimeTrackingPage />);
 
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
+
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
       });
@@ -3600,6 +3674,11 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
+
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
       });
@@ -3618,6 +3697,11 @@ describe("TimeTrackingPage", () => {
         history: [todayEditedHistory],
       });
       render(<TimeTrackingPage />);
+
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -3647,6 +3731,11 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
+      // Issue #1368: pick a status before the check-in button is enabled. The
+      // page no longer pre-selects "present" — silently defaulting an audit-
+      // relevant choice would defeat the feature.
+      fireEvent.click(screen.getByText("In der OGS"));
+
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
       });
@@ -3671,6 +3760,9 @@ describe("TimeTrackingPage", () => {
         absences: [mockAbsence],
       });
       render(<TimeTrackingPage />);
+
+      // Issue #1368: pick a status before the check-in button is enabled.
+      fireEvent.click(screen.getByText("In der OGS"));
 
       // Step 1: Click check-in → manual edit warning appears first
       await act(async () => {

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -1060,6 +1060,98 @@ describe("TimeTrackingPage", () => {
         screen.queryByText("Status für heute ändern"),
       ).not.toBeInTheDocument();
     });
+
+    it("partial-state failure: reopen succeeds but updateSession fails — modal closes with explicit toast", async () => {
+      // Issue #1368: the two-step confirm flow can leave the session
+      // reopened at the OLD status if UpdateSession fails. The UI must:
+      //   (a) refresh data so the now-active session is visible,
+      //   (b) close the modal (don't trap the user in the reason prompt),
+      //   (c) surface a toast that names the partial state and points at
+      //       "Sitzung bearbeiten" as the recovery path.
+      setupDefaultMocks({ history: [mockHistorySession] });
+      // Step 1: initial CheckIn(home_office) → typed conflict.
+      // Step 2: CheckIn(present) (the reopen at existing status) → succeeds.
+      // Step 3: UpdateSession → fails. This is the partial-state branch.
+      vi.mocked(timeTrackingService.checkIn)
+        .mockRejectedValueOnce(makeReopenConflictError())
+        .mockResolvedValueOnce(mockActiveSession);
+      vi.mocked(timeTrackingService.updateSession).mockRejectedValue(
+        new Error("network down"),
+      );
+      const errorToast = vi.fn();
+      vi.mocked(useToast).mockReturnValue({
+        success: vi.fn(),
+        error: errorToast,
+        info: vi.fn(),
+        warning: vi.fn(),
+        remove: vi.fn(),
+      });
+
+      render(<TimeTrackingPage />);
+
+      fireEvent.click(screen.getByText("Homeoffice"));
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Einstempeln"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Status für heute ändern")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText("Grund"), {
+        target: { value: "Mittags ins Homeoffice gewechselt" },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Auf Homeoffice ändern"));
+      });
+
+      // Modal closed so the user can see the now-active session and act.
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Status für heute ändern"),
+        ).not.toBeInTheDocument();
+      });
+
+      // Toast names the partial state and points at the recovery path.
+      expect(errorToast).toHaveBeenCalledTimes(1);
+      const toastMsg = errorToast.mock.calls[0]?.[0] as string;
+      expect(toastMsg).toMatch(/wiedereröffnet/);
+      expect(toastMsg).toMatch(/Sitzung bearbeiten/);
+    });
+
+    it("reopen itself fails: modal stays open so the user can retry", async () => {
+      // Distinct from the partial-state branch above. If the reopen call
+      // never succeeded, no state changed on the server; the modal must
+      // stay open so the user can retry without re-entering the reason.
+      setupDefaultMocks({ history: [mockHistorySession] });
+      vi.mocked(timeTrackingService.checkIn)
+        .mockRejectedValueOnce(makeReopenConflictError())
+        .mockRejectedValueOnce(new Error("network down"));
+
+      render(<TimeTrackingPage />);
+
+      fireEvent.click(screen.getByText("Homeoffice"));
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Einstempeln"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Status für heute ändern")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText("Grund"), {
+        target: { value: "Mittags ins Homeoffice gewechselt" },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Auf Homeoffice ändern"));
+      });
+
+      // Reopen failed → no UpdateSession attempt and modal stays open.
+      expect(timeTrackingService.updateSession).not.toHaveBeenCalled();
+      expect(screen.getByText("Status für heute ändern")).toBeInTheDocument();
+    });
   });
 
   // ── Edit Modal ──────────────────────────────────────────────────────────

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -272,7 +272,11 @@ const mockMutate = vi.fn();
 // Tests that exercise the check-in flow call this helper to make the
 // requirement explicit and keep prologue noise out of the assertions.
 function selectPresentMode() {
-  fireEvent.click(screen.getByText("In der OGS"));
+  // Use role+name to disambiguate from "In der OGS" text that also appears
+  // in status badges, edit-modal options, and history rows when today's
+  // session has Status = 'present'. getByText would throw
+  // getMultipleElementsFoundError in those setups.
+  fireEvent.click(screen.getByRole("button", { name: "In der OGS" }));
 }
 
 function setupDefaultMocks(overrides?: {

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -266,6 +266,14 @@ const mockVacationAbsence: StaffAbsence = {
 
 const mockMutate = vi.fn();
 
+// Issue #1368: the page no longer pre-selects a work mode — staff must pick
+// Vor Ort, Homeoffice, or Abwesend before "Einstempeln" becomes enabled.
+// Tests that exercise the check-in flow call this helper to make the
+// requirement explicit and keep prologue noise out of the assertions.
+function selectPresentMode() {
+  fireEvent.click(screen.getByText("In der OGS"));
+}
+
 function setupDefaultMocks(overrides?: {
   currentSession?: WorkSession | null;
   history?: WorkSessionHistory[];
@@ -397,7 +405,7 @@ describe("TimeTrackingPage", () => {
       render(<TimeTrackingPage />);
       const btn = screen.getByLabelText("Einstempeln");
       expect(btn).toBeDisabled();
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode();
       expect(btn).not.toBeDisabled();
     });
 
@@ -421,10 +429,7 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -468,10 +473,7 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -499,10 +501,7 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -841,10 +840,7 @@ describe("TimeTrackingPage", () => {
       setupDefaultMocks({ absences: [mockAbsence] });
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -860,10 +856,7 @@ describe("TimeTrackingPage", () => {
       setupDefaultMocks({ absences: [mockAbsence] });
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -889,10 +882,7 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -915,10 +905,7 @@ describe("TimeTrackingPage", () => {
       setupDefaultMocks({ absences: [mockAbsence] });
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -1047,10 +1034,7 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -1162,10 +1146,7 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -1189,10 +1170,7 @@ describe("TimeTrackingPage", () => {
       vi.mocked(timeTrackingService.checkIn).mockRejectedValue("string error");
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -3150,10 +3128,7 @@ describe("TimeTrackingPage", () => {
       setupDefaultMocks({ absences: [vacAbsence] });
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -3640,10 +3615,7 @@ describe("TimeTrackingPage", () => {
       });
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -3674,10 +3646,7 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -3698,10 +3667,7 @@ describe("TimeTrackingPage", () => {
       });
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -3731,10 +3697,7 @@ describe("TimeTrackingPage", () => {
       );
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled. The
-      // page no longer pre-selects "present" — silently defaulting an audit-
-      // relevant choice would defeat the feature.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Einstempeln"));
@@ -3761,8 +3724,7 @@ describe("TimeTrackingPage", () => {
       });
       render(<TimeTrackingPage />);
 
-      // Issue #1368: pick a status before the check-in button is enabled.
-      fireEvent.click(screen.getByText("In der OGS"));
+      selectPresentMode(); // Issue #1368: no pre-selection — must pick first.
 
       // Step 1: Click check-in → manual edit warning appears first
       await act(async () => {

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -3612,6 +3612,17 @@ function TimeTrackingContent() {
   // the status change through UpdateSession with the user's reason. Two
   // round-trips, but each one carries a distinct audit meaning: reopen =
   // resume work, update = change of work mode.
+  //
+  // Partial-state handling: if the reopen succeeds but UpdateSession fails,
+  // the session is now active again at the OLD status with no audit edit.
+  // That is a consistent state — old status, no edit — but the user's
+  // intent (status flip) wasn't applied. We refresh the data so the UI
+  // reflects reality, close the modal so the now-active session is visible,
+  // and surface a specific toast pointing the user at the "edit session"
+  // path for retrying just the status change. We deliberately do NOT
+  // attempt to roll back the reopen via checkOut, because that would
+  // introduce a second failure point and leave the audit trail with two
+  // unrelated state changes for one user action.
   const confirmReopenStatusChange = useCallback(async () => {
     const pending = pendingReopenStatusChange;
     if (!pending) return;
@@ -3619,8 +3630,10 @@ function TimeTrackingContent() {
     if (!reason) return;
 
     setReopenStatusChangeSubmitting(true);
+    let reopenSucceeded = false;
     try {
       await timeTrackingService.checkIn(pending.existingStatus);
+      reopenSucceeded = true;
       await timeTrackingService.updateSession(pending.sessionId, {
         status: pending.requestedStatus,
         notes: reason,
@@ -3632,8 +3645,22 @@ function TimeTrackingContent() {
     } catch (err) {
       logger.error("reopen_status_change_failed", {
         error: err instanceof Error ? err.message : String(err),
+        reopen_succeeded: reopenSucceeded,
+        session_id: pending.sessionId,
       });
-      toast.error(friendlyError(err, "Fehler beim Statuswechsel"));
+      if (reopenSucceeded) {
+        // Refresh so the UI shows the now-active session at the old status,
+        // then close the modal so the user can act on it via the edit flow.
+        await Promise.all([mutateCurrentSession(), mutateHistory()]);
+        toast.error(
+          "Sitzung wurde wiedereröffnet, aber der Statuswechsel ist fehlgeschlagen. Bitte den Status über „Sitzung bearbeiten“ ändern.",
+        );
+        setPendingReopenStatusChange(null);
+        setReopenStatusChangeReason("");
+      } else {
+        // Reopen itself failed — modal stays open so the user can retry.
+        toast.error(friendlyError(err, "Fehler beim Statuswechsel"));
+      }
     } finally {
       setReopenStatusChangeSubmitting(false);
     }

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -25,7 +25,11 @@ import {
 import { Modal } from "~/components/ui/modal";
 import { useToast } from "~/contexts/ToastContext";
 import { useSWRAuth } from "~/lib/swr";
-import { timeTrackingService } from "~/lib/time-tracking-api";
+import {
+  REOPEN_STATUS_CONFLICT_CODE,
+  timeTrackingService,
+} from "~/lib/time-tracking-api";
+import type { ApiError } from "~/lib/auth-api";
 import {
   type AbsenceType,
   type StaffAbsence,
@@ -3424,6 +3428,24 @@ function TimeTrackingContent() {
   const [pendingManualEditCheckIn, setPendingManualEditCheckIn] =
     useState<SessionStatus | null>(null);
 
+  // Reopen-with-status-change confirmation. Set when the backend rejects a
+  // CheckIn with REOPEN_STATUS_CONFLICT_CODE because the requested status
+  // differs from today's existing (checked-out) session. The follow-up
+  // modal collects the audit reason and routes the change through
+  // UpdateSession instead of silently flipping status on reopen.
+  const [pendingReopenStatusChange, setPendingReopenStatusChange] = useState<{
+    sessionId: string;
+    existingStatus: SessionStatus;
+    requestedStatus: SessionStatus;
+  } | null>(null);
+  const [reopenStatusChangeReason, setReopenStatusChangeReason] = useState("");
+  const [reopenStatusChangeSubmitting, setReopenStatusChangeSubmitting] =
+    useState(false);
+  const handleClosePendingReopenStatusChange = useCallback(() => {
+    setPendingReopenStatusChange(null);
+    setReopenStatusChangeReason("");
+  }, []);
+
   // Calculate date range for data fetching
   // - Chart shows trailing 10 workdays ending at reference date
   // - WeekView shows calendar week containing reference date
@@ -3530,6 +3552,20 @@ function TimeTrackingContent() {
     [currentSession, historyData, todayISO],
   );
 
+  // Today's checked-out session (if any) — used to drive the
+  // reopen-with-status-change confirmation when the backend rejects a
+  // CheckIn with REOPEN_STATUS_CONFLICT_CODE.
+  const todayCheckedOutSession = useMemo(
+    () =>
+      (historyData ?? []).find(
+        (s) =>
+          s.date === todayISO &&
+          s.checkOutTime &&
+          (s.status === "present" || s.status === "home_office"),
+      ),
+    [historyData, todayISO],
+  );
+
   const executeCheckIn = useCallback(
     async (status: SessionStatus) => {
       try {
@@ -3537,14 +3573,68 @@ function TimeTrackingContent() {
         await Promise.all([mutateCurrentSession(), mutateHistory()]);
         toast.success("Erfolgreich eingestempelt");
       } catch (err) {
+        const apiErr = err as ApiError;
+        if (
+          apiErr.code === REOPEN_STATUS_CONFLICT_CODE &&
+          todayCheckedOutSession
+        ) {
+          // Audit-trail gate: silent status change on reopen is forbidden.
+          // Surface the prompt; the user supplies a reason and we route
+          // the change through UpdateSession (which emits a FieldStatus
+          // edit). See work_session_service.go ReopenStatusConflictError.
+          setReopenStatusChangeReason("");
+          setPendingReopenStatusChange({
+            sessionId: todayCheckedOutSession.id,
+            existingStatus: todayCheckedOutSession.status as SessionStatus,
+            requestedStatus: status,
+          });
+          return;
+        }
         logger.error("check_in_failed", {
           error: err instanceof Error ? err.message : String(err),
         });
         toast.error(friendlyError(err, "Fehler beim Einstempeln"));
       }
     },
-    [mutateCurrentSession, mutateHistory, toast],
+    [mutateCurrentSession, mutateHistory, toast, todayCheckedOutSession],
   );
+
+  // Confirm path: reopen the session at its existing status, then route
+  // the status change through UpdateSession with the user's reason. Two
+  // round-trips, but each one carries a distinct audit meaning: reopen =
+  // resume work, update = change of work mode.
+  const confirmReopenStatusChange = useCallback(async () => {
+    const pending = pendingReopenStatusChange;
+    if (!pending) return;
+    const reason = reopenStatusChangeReason.trim();
+    if (!reason) return;
+
+    setReopenStatusChangeSubmitting(true);
+    try {
+      await timeTrackingService.checkIn(pending.existingStatus);
+      await timeTrackingService.updateSession(pending.sessionId, {
+        status: pending.requestedStatus,
+        notes: reason,
+      });
+      await Promise.all([mutateCurrentSession(), mutateHistory()]);
+      toast.success("Status geändert");
+      setPendingReopenStatusChange(null);
+      setReopenStatusChangeReason("");
+    } catch (err) {
+      logger.error("reopen_status_change_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      toast.error(friendlyError(err, "Fehler beim Statuswechsel"));
+    } finally {
+      setReopenStatusChangeSubmitting(false);
+    }
+  }, [
+    pendingReopenStatusChange,
+    reopenStatusChangeReason,
+    mutateCurrentSession,
+    mutateHistory,
+    toast,
+  ]);
 
   const handleCheckIn = useCallback(
     async (status: SessionStatus) => {
@@ -3930,6 +4020,72 @@ function TimeTrackingContent() {
               : ""}
             . Trotzdem einstempeln?
           </p>
+        </div>
+      </Modal>
+
+      {/* Reopen-with-status-change: collect a reason and route through
+          UpdateSession so the audit trail gets a FieldStatus edit. */}
+      <Modal
+        isOpen={pendingReopenStatusChange !== null}
+        onClose={handleClosePendingReopenStatusChange}
+        title="Status für heute ändern"
+        footer={
+          <div className="flex w-full gap-3">
+            <button
+              onClick={handleClosePendingReopenStatusChange}
+              disabled={reopenStatusChangeSubmitting}
+              className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-all duration-200 hover:border-gray-400 hover:bg-gray-50 disabled:opacity-50"
+            >
+              Abbrechen
+            </button>
+            <button
+              onClick={confirmReopenStatusChange}
+              disabled={
+                reopenStatusChangeSubmitting ||
+                reopenStatusChangeReason.trim() === ""
+              }
+              className="flex-1 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-all duration-200 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {pendingReopenStatusChange?.requestedStatus === "home_office"
+                ? "Auf Homeoffice ändern"
+                : "Auf Vor Ort ändern"}
+            </button>
+          </div>
+        }
+      >
+        <div className="py-2">
+          <p className="text-sm text-gray-600">
+            Du hast heute bereits eine{" "}
+            <span className="font-medium text-gray-900">
+              {pendingReopenStatusChange?.existingStatus === "home_office"
+                ? "Homeoffice"
+                : "Vor-Ort"}
+              -Sitzung
+            </span>
+            . Möchtest du sie als{" "}
+            <span className="font-medium text-gray-900">
+              {pendingReopenStatusChange?.requestedStatus === "home_office"
+                ? "Homeoffice"
+                : "Vor Ort"}
+            </span>{" "}
+            fortsetzen? Bitte gib einen kurzen Grund an — er erscheint im
+            Audit-Trail.
+          </p>
+          <label
+            htmlFor="reopen-status-change-reason"
+            className="mt-4 block text-xs font-medium text-gray-700"
+          >
+            Grund
+          </label>
+          <textarea
+            id="reopen-status-change-reason"
+            value={reopenStatusChangeReason}
+            onChange={(e) => setReopenStatusChangeReason(e.target.value)}
+            disabled={reopenStatusChangeSubmitting}
+            placeholder="z. B. Mittags ins Homeoffice gewechselt"
+            rows={3}
+            className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-gray-500 focus:ring-1 focus:ring-gray-500 focus:outline-none disabled:opacity-50"
+          />
         </div>
       </Modal>
     </div>

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -235,33 +235,46 @@ function getSessionStatusBadge(
     return { className: "bg-amber-100 text-amber-700", label: "Pause" };
   }
   if (status === "home_office") {
-    return { className: "bg-sky-100 text-sky-700", label: "Homeoffice" };
+    return {
+      className: "bg-[#5080D8]/10 text-[#5080D8]",
+      label: "Homeoffice",
+    };
   }
   return { className: "bg-[#83CD2D]/10 text-[#70b525]", label: "In der OGS" };
 }
 
-// Returns className for mode toggle button
+// Returns className for mode toggle button. `currentMode` is null before the
+// staff member has actively chosen Vor Ort / Homeoffice / Abwesend (Issue #1368
+// — no pre-selection). All buttons render inactive in that case.
 function getModeToggleClassName(
   buttonMode: WorkMode,
-  currentMode: WorkMode,
+  currentMode: WorkMode | null,
 ): string {
   const base =
     "rounded-full px-3 py-1.5 text-xs font-medium transition-all sm:px-4";
   const inactive = "bg-gray-100 text-gray-500 hover:bg-gray-200";
   if (buttonMode !== currentMode) return `${base} ${inactive}`;
+  // Brand colors from LOCATION_COLORS (lib/location-helper.ts):
+  //   present     → GROUP_ROOM #83CD2D (green)
+  //   home_office → OTHER_ROOM #5080D8 (blue)
+  //   absent      → HOME       #FF3130 (red)
   if (buttonMode === "present")
     return `${base} bg-[#83CD2D]/10 text-[#70b525] ring-1 ring-[#83CD2D]/40`;
   if (buttonMode === "home_office")
-    return `${base} bg-sky-100 text-sky-700 ring-1 ring-sky-300`;
-  return `${base} bg-red-100 text-red-700 ring-1 ring-red-300`;
+    return `${base} bg-[#5080D8]/10 text-[#5080D8] ring-1 ring-[#5080D8]/40`;
+  return `${base} bg-[#FF3130]/10 text-[#FF3130] ring-1 ring-[#FF3130]/40`;
 }
 
-// Returns className for check-in button based on mode
-function getCheckInButtonClassName(mode: WorkMode): string {
+// Returns className for check-in button. When `mode` is null the button is
+// rendered in a muted style and disabled — the staff member must pick a status
+// first (Issue #1368: keine Vorauswahl).
+function getCheckInButtonClassName(mode: WorkMode | null): string {
   const base =
-    "flex h-16 w-16 items-center justify-center rounded-full border-2 transition-all active:scale-95 disabled:opacity-50";
+    "flex h-16 w-16 items-center justify-center rounded-full border-2 transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50";
+  if (mode === null)
+    return `${base} border-[#6B7280]/40 text-[#6B7280]/60 cursor-not-allowed`;
   if (mode === "home_office")
-    return `${base} border-sky-500 text-sky-500 hover:bg-sky-50`;
+    return `${base} border-[#5080D8] text-[#5080D8] hover:bg-[#5080D8]/5`;
   return `${base} border-[#83CD2D] text-[#83CD2D] hover:bg-[#83CD2D]/5`;
 }
 
@@ -431,7 +444,10 @@ function ClockInCard({
   readonly weeklyMinutes: number;
   readonly onAddAbsence: () => void;
 }) {
-  const [mode, setMode] = useState<WorkMode>("present");
+  // Null until the staff member explicitly picks Vor Ort / Homeoffice / Abwesend.
+  // No pre-selection per Issue #1368 — silent defaults are unacceptable for an
+  // audit-relevant choice.
+  const [mode, setMode] = useState<WorkMode | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
   const [tick, setTick] = useState(0); // forces re-render for live times
   const [breakMenuOpen, setBreakMenuOpen] = useState(false);
@@ -539,7 +555,10 @@ function ClockInCard({
       : null;
 
   const handleCheckIn = async () => {
-    if (mode === "absent") return;
+    // mode === null: user has not yet chosen — the button is disabled in the
+    // UI, but guard here too in case of stray double-clicks.
+    // mode === "absent": that path opens the absence modal, not check-in.
+    if (mode === null || mode === "absent") return;
     setActionLoading(true);
     try {
       await onCheckIn(mode);
@@ -644,7 +663,7 @@ function ClockInCard({
             ) : (
               <button
                 onClick={handleCheckIn}
-                disabled={actionLoading}
+                disabled={actionLoading || mode === null}
                 className={getCheckInButtonClassName(mode)}
                 aria-label="Einstempeln"
               >
@@ -663,7 +682,11 @@ function ClockInCard({
             )}
 
             <span className="text-xs text-gray-400 sm:text-sm">
-              {mode === "absent" ? "Abwesenheit melden" : "Einstempeln"}
+              {mode === null
+                ? "Bitte Status wählen"
+                : mode === "absent"
+                  ? "Abwesenheit melden"
+                  : "Einstempeln"}
             </span>
           </div>
         )}

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -3574,20 +3574,29 @@ function TimeTrackingContent() {
         toast.success("Erfolgreich eingestempelt");
       } catch (err) {
         const apiErr = err as ApiError;
-        if (
-          apiErr.code === REOPEN_STATUS_CONFLICT_CODE &&
-          todayCheckedOutSession
-        ) {
-          // Audit-trail gate: silent status change on reopen is forbidden.
-          // Surface the prompt; the user supplies a reason and we route
-          // the change through UpdateSession (which emits a FieldStatus
-          // edit). See work_session_service.go ReopenStatusConflictError.
-          setReopenStatusChangeReason("");
-          setPendingReopenStatusChange({
-            sessionId: todayCheckedOutSession.id,
-            existingStatus: todayCheckedOutSession.status as SessionStatus,
-            requestedStatus: status,
+        if (apiErr.code === REOPEN_STATUS_CONFLICT_CODE) {
+          if (todayCheckedOutSession) {
+            // Audit-trail gate: silent status change on reopen is forbidden.
+            // Surface the prompt; the user supplies a reason and we route
+            // the change through UpdateSession (which emits a FieldStatus
+            // edit). See work_session_service.go ReopenStatusConflictError.
+            setReopenStatusChangeReason("");
+            setPendingReopenStatusChange({
+              sessionId: todayCheckedOutSession.id,
+              existingStatus: todayCheckedOutSession.status as SessionStatus,
+              requestedStatus: status,
+            });
+            return;
+          }
+          // SWR hasn't loaded today's history yet — we can't open the
+          // reason modal without the session id. Tell the user explicitly
+          // rather than swallowing the conflict behind a generic error.
+          logger.warn("reopen_conflict_missing_history", {
+            requested_status: status,
           });
+          toast.error(
+            "Heute liegt bereits eine Sitzung vor. Bitte kurz warten und erneut versuchen.",
+          );
           return;
         }
         logger.error("check_in_failed", {

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -3552,20 +3552,6 @@ function TimeTrackingContent() {
     [currentSession, historyData, todayISO],
   );
 
-  // Today's checked-out session (if any) — used to drive the
-  // reopen-with-status-change confirmation when the backend rejects a
-  // CheckIn with REOPEN_STATUS_CONFLICT_CODE.
-  const todayCheckedOutSession = useMemo(
-    () =>
-      (historyData ?? []).find(
-        (s) =>
-          s.date === todayISO &&
-          s.checkOutTime &&
-          (s.status === "present" || s.status === "home_office"),
-      ),
-    [historyData, todayISO],
-  );
-
   const executeCheckIn = useCallback(
     async (status: SessionStatus) => {
       try {
@@ -3575,24 +3561,46 @@ function TimeTrackingContent() {
       } catch (err) {
         const apiErr = err as ApiError;
         if (apiErr.code === REOPEN_STATUS_CONFLICT_CODE) {
-          if (todayCheckedOutSession) {
-            // Audit-trail gate: silent status change on reopen is forbidden.
-            // Surface the prompt; the user supplies a reason and we route
-            // the change through UpdateSession (which emits a FieldStatus
-            // edit). See work_session_service.go ReopenStatusConflictError.
+          // Audit-trail gate: silent status change on reopen is forbidden.
+          // Surface the prompt; the user supplies a reason and we route
+          // the change through UpdateSession (which emits a FieldStatus
+          // edit). See work_session_service.go ReopenStatusConflictError.
+          //
+          // The conflict's identifying fields come from the API response so
+          // this works regardless of which week the user is viewing — the
+          // historyData fetch is offset-based and won't contain today's
+          // session when weekOffset < 0.
+          const details = apiErr.details;
+          const sessionId =
+            typeof details?.session_id === "string"
+              ? details.session_id
+              : undefined;
+          const existingStatus =
+            typeof details?.existing_status === "string"
+              ? (details.existing_status as SessionStatus)
+              : undefined;
+          const requestedStatus =
+            typeof details?.requested_status === "string"
+              ? (details.requested_status as SessionStatus)
+              : status;
+
+          if (sessionId && existingStatus) {
             setReopenStatusChangeReason("");
             setPendingReopenStatusChange({
-              sessionId: todayCheckedOutSession.id,
-              existingStatus: todayCheckedOutSession.status as SessionStatus,
-              requestedStatus: status,
+              sessionId,
+              existingStatus,
+              requestedStatus,
             });
             return;
           }
-          // SWR hasn't loaded today's history yet — we can't open the
-          // reason modal without the session id. Tell the user explicitly
-          // rather than swallowing the conflict behind a generic error.
-          logger.warn("reopen_conflict_missing_history", {
+          // Backend returned the conflict code without the details payload —
+          // older server, schema drift, or middleware stripping fields. Log
+          // loudly so this regression is visible in Grafana and fall back to
+          // a user-facing error instead of opening an unfilled modal.
+          logger.warn("reopen_conflict_missing_details", {
             requested_status: status,
+            has_session_id: Boolean(sessionId),
+            has_existing_status: Boolean(existingStatus),
           });
           toast.error(
             "Heute liegt bereits eine Sitzung vor. Bitte kurz warten und erneut versuchen.",
@@ -3605,7 +3613,7 @@ function TimeTrackingContent() {
         toast.error(friendlyError(err, "Fehler beim Einstempeln"));
       }
     },
-    [mutateCurrentSession, mutateHistory, toast, todayCheckedOutSession],
+    [mutateCurrentSession, mutateHistory, toast],
   );
 
   // Confirm path: reopen the session at its existing status, then route

--- a/frontend/src/lib/api-helpers.test.ts
+++ b/frontend/src/lib/api-helpers.test.ts
@@ -167,6 +167,58 @@ describe("handleApiError", () => {
     expect(body.error).toBe("email already exists");
     expect(body.code).toBeUndefined();
   });
+
+  // Regression for Issue #1368: the proxy must forward the backend's
+  // structured `details` payload alongside `error` and `code`. Dropping
+  // details here breaks the reopen-with-status-change modal because the
+  // UI can no longer learn which session is conflicting from the response —
+  // it falls back to history-data lookup, which is empty on past weeks.
+  it("forwards backend details payload (e.g. reopen_status_conflict)", async () => {
+    const backendJson = JSON.stringify({
+      status: "error",
+      error: "reopen status conflict",
+      code: "reopen_status_conflict",
+      details: {
+        session_id: "42",
+        existing_status: "present",
+        requested_status: "home_office",
+      },
+    });
+    const error = new Error(`API error (409): ${backendJson}`);
+
+    const response = handleApiError(error);
+    const body = (await response.json()) as {
+      error: string;
+      code?: string;
+      details?: Record<string, unknown>;
+    };
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("reopen_status_conflict");
+    expect(body.details).toEqual({
+      session_id: "42",
+      existing_status: "present",
+      requested_status: "home_office",
+    });
+  });
+
+  it("omits details field when backend JSON has no details", async () => {
+    const backendJson = JSON.stringify({
+      status: "error",
+      error: "generic 409",
+      code: "generic_conflict",
+    });
+    const error = new Error(`API error (409): ${backendJson}`);
+
+    const response = handleApiError(error);
+    const body = (await response.json()) as {
+      error: string;
+      code?: string;
+      details?: Record<string, unknown>;
+    };
+
+    expect(body.details).toBeUndefined();
+  });
 });
 
 describe("handleDomainApiError", () => {

--- a/frontend/src/lib/api-helpers.ts
+++ b/frontend/src/lib/api-helpers.ts
@@ -28,6 +28,10 @@ export interface ApiErrorResponse {
   error: string;
   status?: number;
   code?: string;
+  // Structured payload mirrored from the backend's ErrResponse.details.
+  // Forwarded through the proxy so codes like reopen_status_conflict can
+  // carry identifying fields (session_id, existing_status, …) to the UI.
+  details?: Record<string, unknown>;
 }
 
 /**
@@ -247,7 +251,10 @@ export function handleApiError(error: unknown): NextResponse<ApiErrorResponse> {
         });
       }
 
-      // Try to extract structured fields from embedded backend JSON response
+      // Try to extract structured fields from embedded backend JSON response.
+      // Mirror the wire shape: error, code, AND details — the proxy must not
+      // silently drop details, or codes like reopen_status_conflict that carry
+      // identifying fields lose them between backend and browser (Issue #1368).
       const response: ApiErrorResponse = { error: error.message };
       const jsonStart = error.message.indexOf("{");
       if (jsonStart !== -1) {
@@ -256,12 +263,16 @@ export function handleApiError(error: unknown): NextResponse<ApiErrorResponse> {
             error?: string;
             message?: string;
             code?: string;
+            details?: Record<string, unknown>;
           };
           if (parsed.error ?? parsed.message) {
             response.error = (parsed.error ?? parsed.message) as string;
           }
           if (parsed.code) {
             response.code = parsed.code;
+          }
+          if (parsed.details) {
+            response.details = parsed.details;
           }
         } catch {
           // Not valid JSON, keep original error message

--- a/frontend/src/lib/auth-api.test.ts
+++ b/frontend/src/lib/auth-api.test.ts
@@ -789,5 +789,48 @@ describe("auth-api", () => {
         expect(apiErr.status).toBe(409);
       }
     });
+
+    // The structured `details` payload was added so the reopen-status-change
+    // modal can be driven from the response instead of looking the session up
+    // in local history (which is offset-fetched and may not include today).
+    // If buildApiError ever stops surfacing details, the modal will silently
+    // fall back to the generic toast for any user viewing a past week.
+    it("propagates structured details from the JSON body to ApiError.details", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        headers: new Headers({
+          "Content-Type": "application/json",
+        }),
+        json: () =>
+          Promise.resolve({
+            error: "reopen status conflict",
+            code: "reopen_status_conflict",
+            details: {
+              session_id: "42",
+              existing_status: "present",
+              requested_status: "home_office",
+            },
+          }),
+      });
+
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        await requestPasswordReset("test@example.com");
+        throw new Error("expected requestPasswordReset to reject");
+      } catch (err) {
+        const apiErr = err as {
+          code?: string;
+          details?: Record<string, unknown>;
+        };
+        expect(apiErr.code).toBe("reopen_status_conflict");
+        expect(apiErr.details).toEqual({
+          session_id: "42",
+          existing_status: "present",
+          requested_status: "home_office",
+        });
+      }
+    });
   });
 });

--- a/frontend/src/lib/auth-api.test.ts
+++ b/frontend/src/lib/auth-api.test.ts
@@ -757,5 +757,37 @@ describe("auth-api", () => {
         "Fehler beim Senden der Passwort-Zurücksetzen-E-Mail",
       );
     });
+
+    // Locks in the typed-code propagation added in Issue #1368: backend
+    // returns `code: "reopen_status_conflict"` so the frontend can branch
+    // into the change-status-with-reason flow rather than showing a
+    // generic 409 toast. If `buildApiError` ever drops this assignment
+    // the App reopen path will degrade silently — an unrecoverable
+    // status flip from the user's perspective.
+    it("propagates the typed code from the JSON body to ApiError.code", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        headers: new Headers({
+          "Content-Type": "application/json",
+        }),
+        json: () =>
+          Promise.resolve({
+            error: "reopen status conflict",
+            code: "reopen_status_conflict",
+          }),
+      });
+
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        await requestPasswordReset("test@example.com");
+        throw new Error("expected requestPasswordReset to reject");
+      } catch (err) {
+        const apiErr = err as { code?: string; status?: number };
+        expect(apiErr.code).toBe("reopen_status_conflict");
+        expect(apiErr.status).toBe(409);
+      }
+    });
   });
 });

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -160,6 +160,11 @@ export type ApiError = Error & {
   status?: number;
   retryAfterSeconds?: number;
   code?: string;
+  // Structured payload mirrored from the backend's ErrResponse.details.
+  // Populated for codes that carry follow-up data (e.g. reopen_status_conflict
+  // returns the conflicting session id and the existing/requested statuses so
+  // the UI doesn't have to look them up in local state).
+  details?: Record<string, unknown>;
 };
 
 function parseRetryAfter(value: string | null): number | null {
@@ -187,6 +192,7 @@ export async function buildApiError(
 ): Promise<ApiError> {
   let message = fallbackMessage;
   let code: string | undefined;
+  let details: Record<string, unknown> | undefined;
 
   try {
     const contentType = response.headers.get("Content-Type") ?? "";
@@ -195,9 +201,11 @@ export async function buildApiError(
         error?: string;
         message?: string;
         code?: string;
+        details?: Record<string, unknown>;
       };
       message = body?.error ?? body?.message ?? fallbackMessage;
       code = body?.code;
+      details = body?.details;
     } else {
       const text = (await response.text()).trim();
       if (text) {
@@ -214,6 +222,9 @@ export async function buildApiError(
   apiError.status = response.status;
   if (code) {
     apiError.code = code;
+  }
+  if (details) {
+    apiError.details = details;
   }
 
   const retryAfter = parseRetryAfter(response.headers.get("Retry-After"));

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -181,11 +181,12 @@ function parseRetryAfter(value: string | null): number | null {
   return null;
 }
 
-async function buildApiError(
+export async function buildApiError(
   response: Response,
   fallbackMessage: string,
 ): Promise<ApiError> {
   let message = fallbackMessage;
+  let code: string | undefined;
 
   try {
     const contentType = response.headers.get("Content-Type") ?? "";
@@ -193,8 +194,10 @@ async function buildApiError(
       const body = (await response.json()) as {
         error?: string;
         message?: string;
+        code?: string;
       };
       message = body?.error ?? body?.message ?? fallbackMessage;
+      code = body?.code;
     } else {
       const text = (await response.text()).trim();
       if (text) {
@@ -209,6 +212,9 @@ async function buildApiError(
 
   const apiError = new Error(message) as ApiError;
   apiError.status = response.status;
+  if (code) {
+    apiError.code = code;
+  }
 
   const retryAfter = parseRetryAfter(response.headers.get("Retry-After"));
   if (retryAfter !== null) {

--- a/frontend/src/lib/time-tracking-api.test.ts
+++ b/frontend/src/lib/time-tracking-api.test.ts
@@ -19,7 +19,9 @@ function mockFetchResponse(data: unknown, ok = true, status = 200) {
   return vi.fn().mockResolvedValue({
     ok,
     status,
+    headers: new Headers({ "Content-Type": "application/json" }),
     json: vi.fn().mockResolvedValue(data),
+    text: vi.fn().mockResolvedValue(JSON.stringify(data)),
   });
 }
 

--- a/frontend/src/lib/time-tracking-api.ts
+++ b/frontend/src/lib/time-tracking-api.ts
@@ -1,6 +1,7 @@
 // Time tracking API service for check-in/out and history management
 
 import { getSession } from "next-auth/react";
+import type { ApiError } from "./auth-api";
 import type {
   StaffAbsence,
   WorkSession,
@@ -31,7 +32,16 @@ interface ApiResponse<T> {
 interface ErrorResponse {
   error?: string;
   message?: string;
+  code?: string;
 }
+
+/**
+ * Stable error code surfaced by the backend when a CheckIn would silently
+ * change the status of an existing checked-out session. The page handles
+ * this by prompting for a reason and routing the change through
+ * UpdateSession (Issue #1368).
+ */
+export const REOPEN_STATUS_CONFLICT_CODE = "reopen_status_conflict";
 
 /**
  * Update session request body
@@ -102,8 +112,7 @@ class TimeTrackingService {
     });
 
     if (!response.ok) {
-      const error = (await response.json()) as ErrorResponse;
-      throw new Error(error.error ?? error.message ?? errorMessage);
+      throw await this.toApiError(response, errorMessage);
     }
 
     return (await response.json()) as ApiResponse<T>;
@@ -121,9 +130,33 @@ class TimeTrackingService {
     });
 
     if (!response.ok) {
-      const error = (await response.json()) as ErrorResponse;
-      throw new Error(error.error ?? error.message ?? errorMessage);
+      throw await this.toApiError(response, errorMessage);
     }
+  }
+
+  /**
+   * Build an ApiError from a non-OK response, preserving the backend's
+   * `code` field so callers (e.g., the time-tracking page) can branch on
+   * typed errors without parsing strings.
+   */
+  private async toApiError(
+    response: Response,
+    fallbackMessage: string,
+  ): Promise<ApiError> {
+    let body: ErrorResponse = {};
+    try {
+      body = (await response.json()) as ErrorResponse;
+    } catch {
+      // non-JSON body — fall through with empty body
+    }
+    const apiError = new Error(
+      body.error ?? body.message ?? fallbackMessage,
+    ) as ApiError;
+    apiError.status = response.status;
+    if (body.code) {
+      apiError.code = body.code;
+    }
+    return apiError;
   }
 
   async checkIn(status: "present" | "home_office"): Promise<WorkSession> {

--- a/frontend/src/lib/time-tracking-api.ts
+++ b/frontend/src/lib/time-tracking-api.ts
@@ -1,7 +1,7 @@
 // Time tracking API service for check-in/out and history management
 
 import { getSession } from "next-auth/react";
-import type { ApiError } from "./auth-api";
+import { buildApiError } from "./auth-api";
 import type {
   StaffAbsence,
   WorkSession,
@@ -24,15 +24,6 @@ interface ApiResponse<T> {
   success: boolean;
   message: string;
   data: T;
-}
-
-/**
- * Error response structure
- */
-interface ErrorResponse {
-  error?: string;
-  message?: string;
-  code?: string;
 }
 
 /**
@@ -112,7 +103,7 @@ class TimeTrackingService {
     });
 
     if (!response.ok) {
-      throw await this.toApiError(response, errorMessage);
+      throw await buildApiError(response, errorMessage);
     }
 
     return (await response.json()) as ApiResponse<T>;
@@ -130,33 +121,8 @@ class TimeTrackingService {
     });
 
     if (!response.ok) {
-      throw await this.toApiError(response, errorMessage);
+      throw await buildApiError(response, errorMessage);
     }
-  }
-
-  /**
-   * Build an ApiError from a non-OK response, preserving the backend's
-   * `code` field so callers (e.g., the time-tracking page) can branch on
-   * typed errors without parsing strings.
-   */
-  private async toApiError(
-    response: Response,
-    fallbackMessage: string,
-  ): Promise<ApiError> {
-    let body: ErrorResponse = {};
-    try {
-      body = (await response.json()) as ErrorResponse;
-    } catch {
-      // non-JSON body — fall through with empty body
-    }
-    const apiError = new Error(
-      body.error ?? body.message ?? fallbackMessage,
-    ) as ApiError;
-    apiError.status = response.status;
-    if (body.code) {
-      apiError.code = body.code;
-    }
-    return apiError;
   }
 
   async checkIn(status: "present" | "home_office"): Promise<WorkSession> {


### PR DESCRIPTION
## Summary

Closes #1368. Makes App-based time-tracking auditable so OGS-Leitung can tell on-site (NFC kiosk) from App self-claim in the export, and so every Vor Ort ↔ Homeoffice flip is tied to a written reason.

## How it works

- **Check-in:** keine Vorauswahl, Button bleibt disabled bis der Mitarbeiter einen Status wählt (Vor Ort, Homeoffice oder Abwesend; bei „Abwesend" öffnet sich der Abwesenheits-Dialog statt einzustempeln).
- **Source tracking:** jede `work_session` trägt eine `source`-Spalte (`app` | `nfc`). App-Stempel landen als `app`, NFC-Scans aus dem PyrePortal-Kiosk-Flow (`assignSupervisorNonCritical`) landen als `nfc`.
- **Status-Wechsel auf reopener Sitzung:** Backend liefert `409 reopen_status_conflict`; die App promptet für einen Grund und schreibt ihn als Audit-Edit auf das Status-Feld via `UpdateSession`. Ohne Grund wird die Änderung abgelehnt. Source **und** Status der bestehenden Sitzung bleiben beim reinen Reopen erhalten.
- **Export:** zwei Spalten — **Status** (`Vor Ort` / `Homeoffice`, spiegelt nur den gewählten Arbeitsmodus und wird von System-Ereignissen nie überschrieben) und **Quelle** (`App` / `NFC` / `—`, mit Overlay `Auto-Checkout` bei Scheduler-Schließung bzw. `Manuell korrigiert` bei vorhandenen Audit-Edits). Last-write-wins: `Manuell korrigiert` schlägt `Auto-Checkout` schlägt App/NFC/—. Der Original-Kanal bleibt in der DB-Spalte `source` erhalten, wird im Export aber von den Overlays verdeckt.

### Quelle-Spalte: Präzedenz

| Bedingung | Quelle-Zelle |
|---|---|
| `EditCount > 0` | **Manuell korrigiert** |
| `AutoCheckedOut = true` und kein Edit | **Auto-Checkout** |
| `source = 'nfc'`, kein Edit, kein Auto-Checkout | **NFC** |
| `source = 'unknown'` (Legacy, pre-Migration), kein Edit, kein Auto-Checkout | **—** |
| sonst (`source = 'app'`) | **App** |

## Changes

- Neue `source`-Spalte auf `active.work_sessions` mit `CHECK`-Constraint, Migration `001015049` (Version `1.15.49`). Legacy-Rows werden auf `unknown` gebackfilled und im Export als `—` gerendert; neue Rows können nur `app` oder `nfc` sein.
- `CheckIn` und `EnsureCheckedIn` nehmen explizit eine `source` (`app` | `nfc`) und lehnen `unknown` als Schreibwert ab. `reopenSession` erhält Source und Status der bestehenden Sitzung — eine Status-Differenz beim Reopen wird mit `*ReopenStatusConflictError` abgelehnt und muss über `UpdateSession` mit Grund laufen.
- Status-Change-Validation-Errors (`status must be …`, `source must be …`, `notes required when changing status`) liefern jetzt 400 statt 500.
- Typed `ReopenStatusConflictError` + exportiertes `buildApiError`, damit neue Error-Codes (`reopen_status_conflict`) im Frontend disambiguiert werden können.

## Test plan

- [ ] `cd backend && go test ./...`
- [ ] `cd frontend && pnpm run check`
- [ ] Manuell: App-Check-in beide Modi → Quelle = `App`
- [ ] Manuell: NFC-Scan via PyrePortal → Quelle = `NFC`
- [ ] Manuell: Status-Flip auf reopener Sitzung → Grund-Prompt, Audit-Edit auf Status-Feld
- [ ] Manuell: Status-Flip ohne Grund → wird abgelehnt
- [ ] Manuell: Auto-Checkout durch Scheduler → Quelle = `Auto-Checkout` (überdeckt App/NFC)
- [ ] Manuell: Bearbeitete Sitzung → Quelle = `Manuell korrigiert` (überdeckt Auto-Checkout)