### PR TITLE
Persist student search filters in URL

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx
@@ -186,6 +186,7 @@ const mockStudent = {
 beforeEach(() => {
   vi.clearAllMocks();
   currentSearch = new URLSearchParams();
+  localStorage.clear();
 
   // Default: no in-flight tracking-indicators result.
   mockUseImmutableSWR.mockReturnValue({
@@ -221,7 +222,10 @@ beforeEach(() => {
   mockGetStudents.mockResolvedValue({ students: [mockStudent] });
 });
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
 
 describe("StudentSearchPage — room_id deep-link (#1323)", () => {
   it("forwards room_id from the URL into studentService.getStudents", async () => {

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -11,10 +11,13 @@ import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
 import { roomService } from "~/lib/api";
 import StudentSearchPage from "./page";
 
+const STUDENT_SEARCH_FILTER_STORAGE_KEY =
+  "student-search:last-filters:tenant-7:user-1";
+
 // Mock next-auth/react
 vi.mock("next-auth/react", () => ({
   useSession: vi.fn(() => ({
-    data: { user: { token: "test-token" } },
+    data: { user: { id: "user-1", tenantId: 7, token: "test-token" } },
     status: "authenticated",
   })),
 }));
@@ -342,12 +345,16 @@ describe("StudentSearchPage", () => {
     mockSearchParams.delete("tracking");
     mockSearchParams.delete("sort");
     mockSearchParams.delete("view");
+    localStorage.clear();
     window.history.replaceState(null, "", "/students/search");
 
     // Reset useSession mock to authenticated state
     const sessionModule = await import("next-auth/react");
     vi.mocked(sessionModule.useSession).mockReturnValue({
-      data: { user: { token: "test-token" }, expires: "2099-01-01" },
+      data: {
+        user: { id: "user-1", tenantId: 7, token: "test-token" },
+        expires: "2099-01-01",
+      },
       status: "authenticated",
       update: vi.fn(),
     } as unknown as ReturnType<typeof sessionModule.useSession>);
@@ -382,6 +389,7 @@ describe("StudentSearchPage", () => {
 
   afterEach(() => {
     cleanup();
+    localStorage.clear();
   });
 
   describe("URL Parameter Handling", () => {
@@ -506,12 +514,107 @@ describe("StudentSearchPage", () => {
       expect(url.searchParams.get("sort")).toBe("pickup");
       expect(url.searchParams.get("view")).toBe("status");
       expect(window.history.state).toEqual({ preserved: true });
+      expect(
+        JSON.parse(
+          localStorage.getItem(STUDENT_SEARCH_FILTER_STORAGE_KEY) ?? "{}",
+        ),
+      ).toEqual({
+        group_id: "2",
+        sort: "pickup",
+        status: "unterwegs",
+        view: "status",
+        year: "2",
+      });
 
       fireEvent.click(screen.getByTestId("clear-filters"));
 
       url = new URL(window.location.href);
       expect(url.searchParams.toString()).toBe("");
       expect(window.history.state).toEqual({ preserved: true });
+      expect(
+        localStorage.getItem(STUDENT_SEARCH_FILTER_STORAGE_KEY),
+      ).toBeNull();
+    });
+
+    it("restores filters from localStorage when opening without URL params", async () => {
+      localStorage.setItem(
+        STUDENT_SEARCH_FILTER_STORAGE_KEY,
+        JSON.stringify({
+          year: "2",
+          group_id: "2",
+          room_id: "101",
+          room_name: "Raum 101",
+          status: "schulhof",
+          sort: "arrival",
+          view: "room",
+        }),
+      );
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-year")).toHaveValue("2");
+        expect(screen.getByTestId("filter-group")).toHaveValue("2");
+        expect(screen.getByTestId("filter-room")).toHaveValue("101");
+        expect(screen.getByTestId("filter-attendance")).toHaveValue("schulhof");
+        expect(screen.getByTestId("filter-sort")).toHaveValue("arrival");
+        expect(screen.getByTestId("filter-groupMode")).toHaveValue("room");
+      });
+
+      const url = new URL(window.location.href);
+      expect(url.searchParams.get("year")).toBe("2");
+      expect(url.searchParams.get("group_id")).toBe("2");
+      expect(url.searchParams.get("room_id")).toBe("101");
+      expect(url.searchParams.get("room_name")).toBe("Raum 101");
+      expect(url.searchParams.get("status")).toBe("schulhof");
+    });
+
+    it("uses URL params instead of localStorage when both are present", async () => {
+      localStorage.setItem(
+        STUDENT_SEARCH_FILTER_STORAGE_KEY,
+        JSON.stringify({
+          year: "2",
+          group_id: "2",
+          status: "schulhof",
+        }),
+      );
+      mockSearchParams.set("year", "1");
+      mockSearchParams.set("group_id", "1");
+      mockSearchParams.set("status", "anwesend");
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-year")).toHaveValue("1");
+        expect(screen.getByTestId("filter-group")).toHaveValue("1");
+        expect(screen.getByTestId("filter-attendance")).toHaveValue("anwesend");
+      });
+
+      expect(
+        JSON.parse(
+          localStorage.getItem(STUDENT_SEARCH_FILTER_STORAGE_KEY) ?? "{}",
+        ),
+      ).toEqual({
+        group_id: "1",
+        status: "anwesend",
+        year: "1",
+      });
+    });
+
+    it("ignores invalid localStorage filter data", async () => {
+      localStorage.setItem(STUDENT_SEARCH_FILTER_STORAGE_KEY, "not-json");
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-year")).toHaveValue("all");
+        expect(screen.getByTestId("filter-group")).toHaveValue("");
+        expect(screen.getByTestId("filter-attendance")).toHaveValue("all");
+      });
+
+      expect(
+        localStorage.getItem(STUDENT_SEARCH_FILTER_STORAGE_KEY),
+      ).toBeNull();
     });
   });
 

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -333,8 +333,15 @@ describe("StudentSearchPage", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mockSearchParams.delete("status");
+    mockSearchParams.delete("year");
+    mockSearchParams.delete("group_id");
     mockSearchParams.delete("room_id");
     mockSearchParams.delete("room_name");
+    mockSearchParams.delete("pickup_time");
+    mockSearchParams.delete("arrival_time");
+    mockSearchParams.delete("tracking");
+    mockSearchParams.delete("sort");
+    mockSearchParams.delete("view");
     window.history.replaceState(null, "", "/students/search");
 
     // Reset useSession mock to authenticated state
@@ -440,6 +447,71 @@ describe("StudentSearchPage", () => {
         const attendanceFilter = screen.getByTestId("filter-attendance");
         expect(attendanceFilter).toHaveValue("all");
       });
+    });
+
+    it("restores non-text filters from URL params after a reload", async () => {
+      mockSearchParams.set("year", "1");
+      mockSearchParams.set("group_id", "1");
+      mockSearchParams.set("room_id", "101");
+      mockSearchParams.set("room_name", "Raum 101");
+      mockSearchParams.set("pickup_time", "15:30");
+      mockSearchParams.set("arrival_time", "08:00");
+      mockSearchParams.set("status", "anwesend");
+      mockSearchParams.set("sort", "pickup");
+      mockSearchParams.set("view", "room");
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-year")).toHaveValue("1");
+        expect(screen.getByTestId("filter-group")).toHaveValue("1");
+        expect(screen.getByTestId("filter-room")).toHaveValue("101");
+        expect(screen.getByTestId("filter-pickupTime")).toHaveValue("15:30");
+        expect(screen.getByTestId("filter-arrivalTime")).toHaveValue("08:00");
+        expect(screen.getByTestId("filter-attendance")).toHaveValue("anwesend");
+        expect(screen.getByTestId("filter-sort")).toHaveValue("pickup");
+        expect(screen.getByTestId("filter-groupMode")).toHaveValue("room");
+      });
+    });
+
+    it("syncs non-text filter changes into the URL and clear-all removes them", async () => {
+      window.history.replaceState({ preserved: true }, "", "/students/search");
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-year")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-year"), {
+        target: { value: "2" },
+      });
+      fireEvent.change(screen.getByTestId("filter-group"), {
+        target: { value: "2" },
+      });
+      fireEvent.change(screen.getByTestId("filter-attendance"), {
+        target: { value: "unterwegs" },
+      });
+      fireEvent.change(screen.getByTestId("filter-sort"), {
+        target: { value: "pickup" },
+      });
+      fireEvent.change(screen.getByTestId("filter-groupMode"), {
+        target: { value: "status" },
+      });
+
+      let url = new URL(window.location.href);
+      expect(url.searchParams.get("year")).toBe("2");
+      expect(url.searchParams.get("group_id")).toBe("2");
+      expect(url.searchParams.get("status")).toBe("unterwegs");
+      expect(url.searchParams.get("sort")).toBe("pickup");
+      expect(url.searchParams.get("view")).toBe("status");
+      expect(window.history.state).toEqual({ preserved: true });
+
+      fireEvent.click(screen.getByTestId("clear-filters"));
+
+      url = new URL(window.location.href);
+      expect(url.searchParams.toString()).toBe("");
+      expect(window.history.state).toEqual({ preserved: true });
     });
   });
 

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -616,6 +616,47 @@ describe("StudentSearchPage", () => {
         localStorage.getItem(STUDENT_SEARCH_FILTER_STORAGE_KEY),
       ).toBeNull();
     });
+
+    it("continues with default filters when localStorage access is blocked", async () => {
+      const originalLocalStorage = window.localStorage;
+      const getItemSpy = vi.fn(() => {
+        throw new DOMException("Blocked", "SecurityError");
+      });
+      const removeItemSpy = vi.fn(() => {
+        throw new DOMException("Blocked", "SecurityError");
+      });
+      Object.defineProperty(window, "localStorage", {
+        configurable: true,
+        value: {
+          clear: vi.fn(),
+          getItem: getItemSpy,
+          key: vi.fn(),
+          removeItem: removeItemSpy,
+          setItem: vi.fn(() => {
+            throw new DOMException("Blocked", "SecurityError");
+          }),
+          length: 0,
+        },
+      });
+
+      try {
+        render(<StudentSearchPage />);
+
+        await waitFor(() => {
+          expect(screen.getByTestId("filter-year")).toHaveValue("all");
+          expect(screen.getByTestId("filter-group")).toHaveValue("");
+          expect(screen.getByTestId("filter-attendance")).toHaveValue("all");
+        });
+
+        expect(getItemSpy).toHaveBeenCalled();
+        expect(removeItemSpy).toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(window, "localStorage", {
+          configurable: true,
+          value: originalLocalStorage,
+        });
+      }
+    });
   });
 
   describe("Client-Side Filtering", () => {

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -227,6 +227,14 @@ function compactStoredFilters(filters: PersistedSearchFilters) {
   ) as PersistedSearchFilters;
 }
 
+function safelyRemoveStoredFilters(storageKey: string) {
+  try {
+    window.localStorage.removeItem(storageKey);
+  } catch {
+    // Storage can be fully blocked by browser/privacy settings.
+  }
+}
+
 function readStoredFilters(storageKey: string | null) {
   if (!storageKey || typeof window === "undefined") return null;
 
@@ -235,14 +243,14 @@ function readStoredFilters(storageKey: string | null) {
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      window.localStorage.removeItem(storageKey);
+      safelyRemoveStoredFilters(storageKey);
       return null;
     }
     return compactStoredFilters(
       normalizeStoredFilters(parsed as PersistedSearchFilters),
     );
   } catch {
-    window.localStorage.removeItem(storageKey);
+    safelyRemoveStoredFilters(storageKey);
     return null;
   }
 }
@@ -256,7 +264,7 @@ function writeStoredFilters(
   const compacted = compactStoredFilters(normalizeStoredFilters(filters));
   try {
     if (Object.keys(compacted).length === 0) {
-      window.localStorage.removeItem(storageKey);
+      safelyRemoveStoredFilters(storageKey);
       return;
     }
     window.localStorage.setItem(storageKey, JSON.stringify(compacted));
@@ -268,12 +276,7 @@ function writeStoredFilters(
 
 function removeStoredFilters(storageKey: string | null) {
   if (!storageKey || typeof window === "undefined") return;
-
-  try {
-    window.localStorage.removeItem(storageKey);
-  } catch {
-    // See writeStoredFilters: storage is a convenience layer, not required.
-  }
+  safelyRemoveStoredFilters(storageKey);
 }
 
 function buildSearchFilterStorageKey(

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -114,6 +114,12 @@ const FILTER_QUERY_PARAMS = [
   "view",
 ] as const;
 
+type FilterQueryParam = (typeof FILTER_QUERY_PARAMS)[number];
+type PersistedSearchFilters = Partial<Record<FilterQueryParam, string>>;
+type SearchParamReader = Pick<URLSearchParams, "get" | "has">;
+
+const STUDENT_SEARCH_FILTER_STORAGE_PREFIX = "student-search:last-filters";
+
 const SCHOOL_YEAR_DROPDOWN_OPTIONS = SCHOOL_YEAR_FILTER_OPTIONS.map(
   (option) => ({
     value: option.value,
@@ -135,6 +141,158 @@ function validQueryValue<T extends string>(
   fallback: T,
 ): T {
   return value && validValues.includes(value as T) ? (value as T) : fallback;
+}
+
+function searchParamsHavePersistedFilters(searchParams: SearchParamReader) {
+  return FILTER_QUERY_PARAMS.some((key) => searchParams.has(key));
+}
+
+function persistedFiltersToSearchParams(filters: PersistedSearchFilters) {
+  const params = new URLSearchParams();
+  for (const key of FILTER_QUERY_PARAMS) {
+    const value = filters[key];
+    if (value) params.set(key, value);
+  }
+  return params;
+}
+
+function filtersFromSearchParams(
+  searchParams: SearchParamReader,
+): PersistedSearchFilters {
+  const filters: PersistedSearchFilters = {};
+  for (const key of FILTER_QUERY_PARAMS) {
+    const value = searchParams.get(key);
+    if (value) filters[key] = value;
+  }
+  return filters;
+}
+
+function normalizeStoredFilters(
+  filters: PersistedSearchFilters,
+): PersistedSearchFilters {
+  const params = persistedFiltersToSearchParams(filters);
+  const trackingParam = params.get("tracking");
+  const trackingFilter =
+    trackingParam && parseTrackingFilter(trackingParam).kind !== "invalid"
+      ? trackingParam
+      : "";
+
+  return {
+    year:
+      validQueryValue(
+        params.get("year"),
+        SCHOOL_YEAR_DROPDOWN_OPTIONS.map((option) => option.value),
+        "all",
+      ) === "all"
+        ? ""
+        : (params.get("year") ?? ""),
+    group_id: params.get("group_id") ?? "",
+    room_id: params.get("room_id") ?? "",
+    room_name: params.get("room_id") ? (params.get("room_name") ?? "") : "",
+    pickup_time: params.get("pickup_time") ?? "",
+    arrival_time: params.get("arrival_time") ?? "",
+    status:
+      validQueryValue(
+        params.get("status"),
+        STATUS_FILTER_OPTIONS.map((option) => option.value),
+        "all",
+      ) === "all"
+        ? ""
+        : (params.get("status") ?? ""),
+    tracking: trackingFilter,
+    sort:
+      validQueryValue(
+        params.get("sort"),
+        SORT_OPTIONS.map((option) => option.value),
+        "name",
+      ) === "name"
+        ? ""
+        : (params.get("sort") ?? ""),
+    view:
+      validQueryValue(
+        params.get("view"),
+        GROUP_OPTIONS.map((option) => option.value),
+        "none",
+      ) === "none"
+        ? ""
+        : (params.get("view") ?? ""),
+  };
+}
+
+function compactStoredFilters(filters: PersistedSearchFilters) {
+  return Object.fromEntries(
+    Object.entries(filters).filter(
+      (entry): entry is [FilterQueryParam, string] => Boolean(entry[1]),
+    ),
+  ) as PersistedSearchFilters;
+}
+
+function readStoredFilters(storageKey: string | null) {
+  if (!storageKey || typeof window === "undefined") return null;
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      window.localStorage.removeItem(storageKey);
+      return null;
+    }
+    return compactStoredFilters(
+      normalizeStoredFilters(parsed as PersistedSearchFilters),
+    );
+  } catch {
+    window.localStorage.removeItem(storageKey);
+    return null;
+  }
+}
+
+function writeStoredFilters(
+  storageKey: string | null,
+  filters: PersistedSearchFilters,
+) {
+  if (!storageKey || typeof window === "undefined") return;
+
+  const compacted = compactStoredFilters(normalizeStoredFilters(filters));
+  try {
+    if (Object.keys(compacted).length === 0) {
+      window.localStorage.removeItem(storageKey);
+      return;
+    }
+    window.localStorage.setItem(storageKey, JSON.stringify(compacted));
+  } catch {
+    // localStorage can fail in private mode or when quota is exceeded. URL
+    // persistence still works, so ignore storage failures.
+  }
+}
+
+function removeStoredFilters(storageKey: string | null) {
+  if (!storageKey || typeof window === "undefined") return;
+
+  try {
+    window.localStorage.removeItem(storageKey);
+  } catch {
+    // See writeStoredFilters: storage is a convenience layer, not required.
+  }
+}
+
+function buildSearchFilterStorageKey(
+  user:
+    | {
+        id?: string | null;
+        email?: string | null;
+        tenantId?: number | null;
+      }
+    | undefined,
+) {
+  if (typeof window === "undefined") return null;
+
+  const tenantKey =
+    user?.tenantId !== undefined && user.tenantId !== null
+      ? `tenant-${user.tenantId}`
+      : `host-${window.location.host}`;
+  const accountKey = user?.id ?? user?.email ?? "anonymous";
+  return `${STUDENT_SEARCH_FILTER_STORAGE_PREFIX}:${tenantKey}:${accountKey}`;
 }
 
 function compareByName(a: Student, b: Student) {
@@ -260,31 +418,48 @@ function SearchPageContent() {
   });
   const searchParams = useSearchParams();
   const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const storageKey = useMemo(
+    () => buildSearchFilterStorageKey(session?.user),
+    [session?.user],
+  );
+  const hasUrlFilterParams = searchParamsHavePersistedFilters(searchParams);
+  const storedInitialFilters = useMemo(
+    () => (hasUrlFilterParams ? null : readStoredFilters(storageKey)),
+    [hasUrlFilterParams, storageKey],
+  );
+  const initialFilterParams = useMemo(
+    () =>
+      storedInitialFilters
+        ? persistedFiltersToSearchParams(storedInitialFilters)
+        : searchParams,
+    [searchParams, storedInitialFilters],
+  );
 
   // Read initial filters from URL params so refreshes, revisits via browser
-  // history, and copied links restore the same operational view.
+  // history, and copied links restore the same operational view. When no URL
+  // filters are present, fall back to the last browser-local PWA view.
   const initialAttendanceFilter = validQueryValue(
-    searchParams.get("status"),
+    initialFilterParams.get("status"),
     STATUS_FILTER_OPTIONS.map((option) => option.value),
     "all",
   );
   const initialYear = validQueryValue(
-    searchParams.get("year"),
+    initialFilterParams.get("year"),
     SCHOOL_YEAR_DROPDOWN_OPTIONS.map((option) => option.value),
     "all",
   );
-  const initialTrackingParam = searchParams.get("tracking") ?? "all";
+  const initialTrackingParam = initialFilterParams.get("tracking") ?? "all";
   const initialTrackingFilter =
     parseTrackingFilter(initialTrackingParam).kind === "invalid"
       ? "all"
       : (initialTrackingParam as TrackingFilter);
   const initialSortMode = validQueryValue(
-    searchParams.get("sort"),
+    initialFilterParams.get("sort"),
     SORT_OPTIONS.map((option) => option.value),
     "name",
   );
   const initialGroupMode = validQueryValue(
-    searchParams.get("view"),
+    initialFilterParams.get("view"),
     GROUP_OPTIONS.map((option) => option.value),
     "none",
   );
@@ -292,24 +467,24 @@ function SearchPageContent() {
   // Room filter — populated when the user lands here from the room detail
   // page's "In Kindersuche öffnen" link (#1323). room_name is purely a
   // display affordance for the chip; the backend filter only uses room_id.
-  const initialRoomId = searchParams.get("room_id") ?? "";
-  const initialRoomName = searchParams.get("room_name") ?? "";
+  const initialRoomId = initialFilterParams.get("room_id") ?? "";
+  const initialRoomName = initialFilterParams.get("room_name") ?? "";
 
   // Search and filter state
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(""); // Debounced version for SWR key
   const [selectedGroup, setSelectedGroup] = useState(
-    searchParams.get("group_id") ?? "",
+    initialFilterParams.get("group_id") ?? "",
   );
   const [selectedYear, setSelectedYear] = useState<string>(initialYear);
   const [attendanceFilter, setAttendanceFilter] = useState<StatusFilter>(
     initialAttendanceFilter,
   );
   const [pickupTimeFilter, setPickupTimeFilter] = useState(
-    searchParams.get("pickup_time") ?? "all",
+    initialFilterParams.get("pickup_time") ?? "all",
   );
   const [arrivalTimeFilter, setArrivalTimeFilter] = useState(
-    searchParams.get("arrival_time") ?? "all",
+    initialFilterParams.get("arrival_time") ?? "all",
   );
   const [trackingFilter, setTrackingFilter] = useState<TrackingFilter>(
     initialTrackingFilter,
@@ -335,9 +510,82 @@ function SearchPageContent() {
         "",
         url.toString(),
       );
+      writeStoredFilters(storageKey, filtersFromSearchParams(url.searchParams));
+    },
+    [storageKey],
+  );
+
+  const applyPersistedFilters = useCallback(
+    (filters: PersistedSearchFilters) => {
+      const params = persistedFiltersToSearchParams(
+        compactStoredFilters(normalizeStoredFilters(filters)),
+      );
+
+      setSelectedGroup(params.get("group_id") ?? "");
+      setSelectedYear(
+        validQueryValue(
+          params.get("year"),
+          SCHOOL_YEAR_DROPDOWN_OPTIONS.map((option) => option.value),
+          "all",
+        ),
+      );
+      setAttendanceFilter(
+        validQueryValue(
+          params.get("status"),
+          STATUS_FILTER_OPTIONS.map((option) => option.value),
+          "all",
+        ),
+      );
+      setPickupTimeFilter(params.get("pickup_time") ?? "all");
+      setArrivalTimeFilter(params.get("arrival_time") ?? "all");
+
+      const trackingParam = params.get("tracking") ?? "all";
+      setTrackingFilter(
+        parseTrackingFilter(trackingParam).kind === "invalid"
+          ? "all"
+          : (trackingParam as TrackingFilter),
+      );
+
+      setSortMode(
+        validQueryValue(
+          params.get("sort"),
+          SORT_OPTIONS.map((option) => option.value),
+          "name",
+        ),
+      );
+      setGroupMode(
+        validQueryValue(
+          params.get("view"),
+          GROUP_OPTIONS.map((option) => option.value),
+          "none",
+        ),
+      );
+      setSelectedRoomId(params.get("room_id") ?? "");
+      setSelectedRoomName(params.get("room_name") ?? "");
     },
     [],
   );
+
+  useEffect(() => {
+    if (!storageKey) return;
+
+    if (hasUrlFilterParams) {
+      writeStoredFilters(storageKey, filtersFromSearchParams(searchParams));
+      return;
+    }
+
+    const storedFilters = readStoredFilters(storageKey);
+    if (!storedFilters || Object.keys(storedFilters).length === 0) return;
+
+    applyPersistedFilters(storedFilters);
+    updateUrlParams(storedFilters);
+  }, [
+    applyPersistedFilters,
+    hasUrlFilterParams,
+    searchParams,
+    storageKey,
+    updateUrlParams,
+  ]);
 
   // Current time for pickup urgency calculation (updates every minute)
   const now = useMinuteClock();
@@ -541,7 +789,8 @@ function SearchPageContent() {
     updateUrlParams(
       Object.fromEntries(FILTER_QUERY_PARAMS.map((key) => [key, ""])),
     );
-  }, [updateUrlParams]);
+    removeStoredFilters(storageKey);
+  }, [storageKey, updateUrlParams]);
 
   const students = studentsData?.students ?? [];
 

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -59,6 +59,7 @@ import {
 } from "~/lib/student-time-status";
 import {
   matchesTrackingFilter,
+  parseTrackingFilter,
   resolveTrackingFilterAfterLabelChange,
   trackingFilterChipLabel,
   type TrackingFilter,
@@ -100,6 +101,19 @@ const GROUP_OPTIONS: Array<{ value: GroupMode; label: string }> = [
   { value: "pickup", label: "Nach Abholzeit" },
 ];
 
+const FILTER_QUERY_PARAMS = [
+  "year",
+  "group_id",
+  "room_id",
+  "room_name",
+  "pickup_time",
+  "arrival_time",
+  "status",
+  "tracking",
+  "sort",
+  "view",
+] as const;
+
 const SCHOOL_YEAR_DROPDOWN_OPTIONS = SCHOOL_YEAR_FILTER_OPTIONS.map(
   (option) => ({
     value: option.value,
@@ -114,6 +128,14 @@ const STATUS_GROUP_ORDER = new Map([
   ["Krank", 3],
   ["Abwesend", 4],
 ]);
+
+function validQueryValue<T extends string>(
+  value: string | null,
+  validValues: readonly T[],
+  fallback: T,
+): T {
+  return value && validValues.includes(value as T) ? (value as T) : fallback;
+}
 
 function compareByName(a: Student, b: Student) {
   const lastCmp = (a.second_name ?? "").localeCompare(
@@ -239,14 +261,33 @@ function SearchPageContent() {
   const searchParams = useSearchParams();
   const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Read initial filter from URL params (supports deep-linking from dashboard)
-  const initialStatus = searchParams.get("status") ?? "all";
-  const validStatuses = STATUS_FILTER_OPTIONS.map((option) => option.value);
-  const initialAttendanceFilter = validStatuses.includes(
-    initialStatus as StatusFilter,
-  )
-    ? (initialStatus as StatusFilter)
-    : "all";
+  // Read initial filters from URL params so refreshes, revisits via browser
+  // history, and copied links restore the same operational view.
+  const initialAttendanceFilter = validQueryValue(
+    searchParams.get("status"),
+    STATUS_FILTER_OPTIONS.map((option) => option.value),
+    "all",
+  );
+  const initialYear = validQueryValue(
+    searchParams.get("year"),
+    SCHOOL_YEAR_DROPDOWN_OPTIONS.map((option) => option.value),
+    "all",
+  );
+  const initialTrackingParam = searchParams.get("tracking") ?? "all";
+  const initialTrackingFilter =
+    parseTrackingFilter(initialTrackingParam).kind === "invalid"
+      ? "all"
+      : (initialTrackingParam as TrackingFilter);
+  const initialSortMode = validQueryValue(
+    searchParams.get("sort"),
+    SORT_OPTIONS.map((option) => option.value),
+    "name",
+  );
+  const initialGroupMode = validQueryValue(
+    searchParams.get("view"),
+    GROUP_OPTIONS.map((option) => option.value),
+    "none",
+  );
 
   // Room filter — populated when the user lands here from the room detail
   // page's "In Kindersuche öffnen" link (#1323). room_name is purely a
@@ -257,18 +298,46 @@ function SearchPageContent() {
   // Search and filter state
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(""); // Debounced version for SWR key
-  const [selectedGroup, setSelectedGroup] = useState("");
-  const [selectedYear, setSelectedYear] = useState("all");
+  const [selectedGroup, setSelectedGroup] = useState(
+    searchParams.get("group_id") ?? "",
+  );
+  const [selectedYear, setSelectedYear] = useState<string>(initialYear);
   const [attendanceFilter, setAttendanceFilter] = useState<StatusFilter>(
     initialAttendanceFilter,
   );
-  const [pickupTimeFilter, setPickupTimeFilter] = useState("all");
-  const [arrivalTimeFilter, setArrivalTimeFilter] = useState("all");
-  const [trackingFilter, setTrackingFilter] = useState<TrackingFilter>("all");
-  const [sortMode, setSortMode] = useState<SortMode>("name");
-  const [groupMode, setGroupMode] = useState<GroupMode>("none");
+  const [pickupTimeFilter, setPickupTimeFilter] = useState(
+    searchParams.get("pickup_time") ?? "all",
+  );
+  const [arrivalTimeFilter, setArrivalTimeFilter] = useState(
+    searchParams.get("arrival_time") ?? "all",
+  );
+  const [trackingFilter, setTrackingFilter] = useState<TrackingFilter>(
+    initialTrackingFilter,
+  );
+  const [sortMode, setSortMode] = useState<SortMode>(initialSortMode);
+  const [groupMode, setGroupMode] = useState<GroupMode>(initialGroupMode);
   const [selectedRoomId, setSelectedRoomId] = useState(initialRoomId);
   const [selectedRoomName, setSelectedRoomName] = useState(initialRoomName);
+
+  const updateUrlParams = useCallback(
+    (patch: Partial<Record<(typeof FILTER_QUERY_PARAMS)[number], string>>) => {
+      if (typeof window === "undefined") return;
+      const url = new URL(window.location.href);
+      for (const [key, value] of Object.entries(patch)) {
+        if (value === undefined || value === "") {
+          url.searchParams.delete(key);
+        } else {
+          url.searchParams.set(key, value);
+        }
+      }
+      window.history.replaceState(
+        window.history.state ?? null,
+        "",
+        url.toString(),
+      );
+    },
+    [],
+  );
 
   // Current time for pickup urgency calculation (updates every minute)
   const now = useMinuteClock();
@@ -377,33 +446,102 @@ function SearchPageContent() {
   // App Router stashes routing metadata (scroll restoration, RSC cache keys)
   // on window.history.state, and clobbering it with `{}` can degrade browser
   // back/forward into a hard reload for this entry.
-  const updateRoomFilter = useCallback((roomId: string, roomName: string) => {
-    setSelectedRoomId(roomId);
-    setSelectedRoomName(roomName);
-    if (typeof window !== "undefined") {
-      const url = new URL(window.location.href);
-      if (roomId) {
-        url.searchParams.set("room_id", roomId);
-        if (roomName) {
-          url.searchParams.set("room_name", roomName);
-        } else {
-          url.searchParams.delete("room_name");
-        }
-      } else {
-        url.searchParams.delete("room_id");
-        url.searchParams.delete("room_name");
-      }
-      window.history.replaceState(
-        window.history.state ?? null,
-        "",
-        url.toString(),
-      );
-    }
-  }, []);
+  const updateRoomFilter = useCallback(
+    (roomId: string, roomName: string) => {
+      setSelectedRoomId(roomId);
+      setSelectedRoomName(roomName);
+      updateUrlParams({
+        room_id: roomId,
+        room_name: roomId ? roomName : "",
+      });
+    },
+    [updateUrlParams],
+  );
 
   const clearRoomFilter = useCallback(() => {
     updateRoomFilter("", "");
   }, [updateRoomFilter]);
+
+  const updateSelectedYear = useCallback(
+    (value: string) => {
+      setSelectedYear(value);
+      updateUrlParams({ year: value === "all" ? "" : value });
+    },
+    [updateUrlParams],
+  );
+
+  const updateSelectedGroup = useCallback(
+    (value: string) => {
+      setSelectedGroup(value);
+      updateUrlParams({ group_id: value });
+    },
+    [updateUrlParams],
+  );
+
+  const updateAttendanceFilter = useCallback(
+    (value: StatusFilter) => {
+      setAttendanceFilter(value);
+      updateUrlParams({ status: value === "all" ? "" : value });
+    },
+    [updateUrlParams],
+  );
+
+  const updatePickupTimeFilter = useCallback(
+    (value: string) => {
+      setPickupTimeFilter(value);
+      updateUrlParams({ pickup_time: value === "all" ? "" : value });
+    },
+    [updateUrlParams],
+  );
+
+  const updateArrivalTimeFilter = useCallback(
+    (value: string) => {
+      setArrivalTimeFilter(value);
+      updateUrlParams({ arrival_time: value === "all" ? "" : value });
+    },
+    [updateUrlParams],
+  );
+
+  const updateTrackingFilter = useCallback(
+    (value: TrackingFilter) => {
+      setTrackingFilter(value);
+      updateUrlParams({ tracking: value === "all" ? "" : value });
+    },
+    [updateUrlParams],
+  );
+
+  const updateSortMode = useCallback(
+    (value: SortMode) => {
+      setSortMode(value);
+      updateUrlParams({ sort: value === "name" ? "" : value });
+    },
+    [updateUrlParams],
+  );
+
+  const updateGroupMode = useCallback(
+    (value: GroupMode) => {
+      setGroupMode(value);
+      updateUrlParams({ view: value === "none" ? "" : value });
+    },
+    [updateUrlParams],
+  );
+
+  const clearAllFilters = useCallback(() => {
+    setSearchTerm("");
+    setSelectedGroup("");
+    setSelectedYear("all");
+    setAttendanceFilter("all");
+    setPickupTimeFilter("all");
+    setArrivalTimeFilter("all");
+    setTrackingFilter("all");
+    setSortMode("name");
+    setGroupMode("none");
+    setSelectedRoomId("");
+    setSelectedRoomName("");
+    updateUrlParams(
+      Object.fromEntries(FILTER_QUERY_PARAMS.map((key) => [key, ""])),
+    );
+  }, [updateUrlParams]);
 
   const students = studentsData?.students ?? [];
 
@@ -429,8 +567,8 @@ function SearchPageContent() {
       trackingFilter,
       trackingData,
     );
-    if (next !== trackingFilter) setTrackingFilter(next);
-  }, [trackingData, trackingFilter]);
+    if (next !== trackingFilter) updateTrackingFilter(next);
+  }, [trackingData, trackingFilter, updateTrackingFilter]);
 
   // Error type for proper heading display (Fix P3: substring matching on transformed string)
   type ErrorType = "permission" | "session" | "generic" | null;
@@ -486,7 +624,7 @@ function SearchPageContent() {
         label: "Stufe",
         type: "dropdown",
         value: selectedYear,
-        onChange: (value) => setSelectedYear(value as string),
+        onChange: (value) => updateSelectedYear(value as string),
         options: SCHOOL_YEAR_DROPDOWN_OPTIONS,
       },
       {
@@ -494,7 +632,7 @@ function SearchPageContent() {
         label: "Gruppe",
         type: "dropdown",
         value: selectedGroup,
-        onChange: (value) => setSelectedGroup(value as string),
+        onChange: (value) => updateSelectedGroup(value as string),
         options: [
           { value: "", label: "Alle Gruppen" },
           ...groups.map((group) => ({ value: group.id, label: group.name })),
@@ -539,7 +677,7 @@ function SearchPageContent() {
         label: "Abholzeit",
         type: "dropdown",
         value: pickupTimeFilter,
-        onChange: (value) => setPickupTimeFilter(value as string),
+        onChange: (value) => updatePickupTimeFilter(value as string),
         options: [
           { value: "all", label: "Alle Abholzeiten" },
           ...Array.from(
@@ -559,7 +697,7 @@ function SearchPageContent() {
         label: "Ankunftszeit",
         type: "dropdown",
         value: arrivalTimeFilter,
-        onChange: (value) => setArrivalTimeFilter(value as string),
+        onChange: (value) => updateArrivalTimeFilter(value as string),
         options: [
           { value: "all", label: "Alle Ankunftszeiten" },
           ...Array.from(
@@ -579,7 +717,7 @@ function SearchPageContent() {
         label: "Status",
         type: "dropdown",
         value: attendanceFilter,
-        onChange: (value) => setAttendanceFilter(value as StatusFilter),
+        onChange: (value) => updateAttendanceFilter(value as StatusFilter),
         options: [
           { value: "all", label: "Alle Status" },
           { value: "anwesend", label: "Anwesend" },
@@ -594,7 +732,7 @@ function SearchPageContent() {
         label: "Sortierung",
         type: "dropdown",
         value: sortMode,
-        onChange: (value) => setSortMode(value as SortMode),
+        onChange: (value) => updateSortMode(value as SortMode),
         options: SORT_OPTIONS,
       },
       {
@@ -602,7 +740,7 @@ function SearchPageContent() {
         label: "Ansicht",
         type: "dropdown",
         value: groupMode,
-        onChange: (value) => setGroupMode(value as GroupMode),
+        onChange: (value) => updateGroupMode(value as GroupMode),
         options: GROUP_OPTIONS,
       },
       ...(trackingLabels && trackingLabels.length > 0
@@ -613,7 +751,7 @@ function SearchPageContent() {
               type: "dropdown" as const,
               value: trackingFilter,
               onChange: (value: string | string[]) =>
-                setTrackingFilter(value as TrackingFilter),
+                updateTrackingFilter(value as TrackingFilter),
               options: [
                 { value: "all", label: "Alle Aktivitäten heute" },
                 ...trackingLabels.map((lbl, idx) => ({
@@ -644,6 +782,14 @@ function SearchPageContent() {
       updateRoomFilter,
       sortMode,
       groupMode,
+      updateSelectedYear,
+      updateSelectedGroup,
+      updateAttendanceFilter,
+      updatePickupTimeFilter,
+      updateArrivalTimeFilter,
+      updateTrackingFilter,
+      updateSortMode,
+      updateGroupMode,
     ],
   );
 
@@ -663,7 +809,7 @@ function SearchPageContent() {
       filters.push({
         id: "year",
         label: `Jahr ${selectedYear}`,
-        onRemove: () => setSelectedYear("all"),
+        onRemove: () => updateSelectedYear("all"),
       });
     }
 
@@ -673,7 +819,7 @@ function SearchPageContent() {
       filters.push({
         id: "group",
         label: groupName,
-        onRemove: () => setSelectedGroup(""),
+        onRemove: () => updateSelectedGroup(""),
       });
     }
 
@@ -701,7 +847,7 @@ function SearchPageContent() {
       filters.push({
         id: "attendance",
         label: statusLabels[attendanceFilter] ?? attendanceFilter,
-        onRemove: () => setAttendanceFilter("all"),
+        onRemove: () => updateAttendanceFilter("all"),
       });
     }
 
@@ -712,7 +858,7 @@ function SearchPageContent() {
           pickupTimeFilter === "none"
             ? "Keine Abholzeit"
             : `Abholzeit ${pickupTimeFilter} Uhr`,
-        onRemove: () => setPickupTimeFilter("all"),
+        onRemove: () => updatePickupTimeFilter("all"),
       });
     }
 
@@ -723,7 +869,7 @@ function SearchPageContent() {
           arrivalTimeFilter === "none"
             ? "Keine Ankunftszeit"
             : `Ankunftszeit ${arrivalTimeFilter} Uhr`,
-        onRemove: () => setArrivalTimeFilter("all"),
+        onRemove: () => updateArrivalTimeFilter("all"),
       });
     }
 
@@ -733,7 +879,7 @@ function SearchPageContent() {
         filters.push({
           id: "tracking",
           label: chipLabel,
-          onRemove: () => setTrackingFilter("all"),
+          onRemove: () => updateTrackingFilter("all"),
         });
       }
     }
@@ -744,7 +890,7 @@ function SearchPageContent() {
         label:
           SORT_OPTIONS.find((option) => option.value === sortMode)?.label ??
           "Sortierung",
-        onRemove: () => setSortMode("name"),
+        onRemove: () => updateSortMode("name"),
       });
     }
 
@@ -755,7 +901,7 @@ function SearchPageContent() {
           GROUP_OPTIONS.find((option) => option.value === groupMode)?.label ??
           "Ansicht"
         }`,
-        onRemove: () => setGroupMode("none"),
+        onRemove: () => updateGroupMode("none"),
       });
     }
 
@@ -775,6 +921,14 @@ function SearchPageContent() {
     sortMode,
     groupMode,
     clearRoomFilter,
+    updateSelectedYear,
+    updateSelectedGroup,
+    updateAttendanceFilter,
+    updatePickupTimeFilter,
+    updateArrivalTimeFilter,
+    updateTrackingFilter,
+    updateSortMode,
+    updateGroupMode,
   ]);
 
   // Apply additional client-side filtering for attendance statuses and year
@@ -960,18 +1114,7 @@ function SearchPageContent() {
           }}
           filters={filterConfigs}
           activeFilters={activeFilters}
-          onClearAllFilters={() => {
-            setSearchTerm("");
-            setSelectedGroup("");
-            setSelectedYear("all");
-            setAttendanceFilter("all");
-            setPickupTimeFilter("all");
-            setArrivalTimeFilter("all");
-            setTrackingFilter("all");
-            setSortMode("name");
-            setGroupMode("none");
-            clearRoomFilter();
-          }}
+          onClearAllFilters={clearAllFilters}
         />
       </div>
 
@@ -1063,31 +1206,26 @@ function SearchPageContent() {
               </div>
             );
           }
-          // Preserve the active room filter in the back-link so stepping
-          // from a room → child → back returns to the same filtered list
-          // (#1323). Plain `/students/search` would drop room_id/room_name.
-          // Encoding is only needed when a query string is appended; the
-          // bare path stays unencoded so existing call sites/tests keep
-          // matching the established `from=/students/search` shape.
-          //
-          // Also forward `?status=` (attendanceFilter) — it is the only
-          // URL-rehydrating refinement on this page beyond the room
-          // filter, and the dashboard deep-links here with it. Without
-          // forwarding it, drilling into a child after narrowing by
-          // status silently broadens the result set on back. The other
-          // local refinements (search term, group, year, pickup,
-          // tracking, sort) are not URL-rehydrated on this page, so
-          // forwarding them would not survive the remount anyway.
+          // Preserve the URL-rehydrating filters in the back-link so stepping
+          // from the search page → child → back returns to the same operational
+          // view. Free-text search intentionally remains transient.
           const buildFromParam = (() => {
-            const statusFilter =
-              attendanceFilter !== "all" ? attendanceFilter : "";
-            if (!selectedRoomId && !statusFilter) return "/students/search";
             const qs = new URLSearchParams();
             if (selectedRoomId) {
               qs.set("room_id", selectedRoomId);
               if (selectedRoomName) qs.set("room_name", selectedRoomName);
             }
-            if (statusFilter) qs.set("status", statusFilter);
+            if (selectedGroup) qs.set("group_id", selectedGroup);
+            if (selectedYear !== "all") qs.set("year", selectedYear);
+            if (attendanceFilter !== "all") qs.set("status", attendanceFilter);
+            if (pickupTimeFilter !== "all")
+              qs.set("pickup_time", pickupTimeFilter);
+            if (arrivalTimeFilter !== "all")
+              qs.set("arrival_time", arrivalTimeFilter);
+            if (trackingFilter !== "all") qs.set("tracking", trackingFilter);
+            if (sortMode !== "name") qs.set("sort", sortMode);
+            if (groupMode !== "none") qs.set("view", groupMode);
+            if (qs.size === 0) return "/students/search";
             return encodeURIComponent(`/students/search?${qs.toString()}`);
           })();
           const renderStudentCard = (student: Student) => {

--- a/frontend/src/components/ui/page-header/ActiveFilterChips.test.tsx
+++ b/frontend/src/components/ui/page-header/ActiveFilterChips.test.tsx
@@ -56,7 +56,7 @@ describe("ActiveFilterChips", () => {
     expect(screen.getByText("Alle löschen")).toBeInTheDocument();
   });
 
-  it("does not render clear all button when only one filter", () => {
+  it("renders clear all button when only one filter and onClearAll provided", () => {
     render(
       <ActiveFilterChips
         filters={[defaultFilters[0]!]}
@@ -64,7 +64,7 @@ describe("ActiveFilterChips", () => {
       />,
     );
 
-    expect(screen.queryByText("Alle löschen")).not.toBeInTheDocument();
+    expect(screen.getByText("Alle löschen")).toBeInTheDocument();
   });
 
   it("does not render clear all button when onClearAll not provided", () => {

--- a/frontend/src/components/ui/page-header/ActiveFilterChips.tsx
+++ b/frontend/src/components/ui/page-header/ActiveFilterChips.tsx
@@ -44,7 +44,7 @@ export function ActiveFilterChips({
         ))}
       </div>
 
-      {onClearAll && filters.length > 1 && (
+      {onClearAll && (
         <button
           type="button"
           onClick={onClearAll}

--- a/frontend/src/lib/settings-broadcast.test.ts
+++ b/frontend/src/lib/settings-broadcast.test.ts
@@ -10,25 +10,59 @@ import {
   subscribeSettingsChanged,
 } from "./settings-broadcast";
 
+type BroadcastHandler = ((event: MessageEvent) => void) | null;
+
+class FakeBroadcastChannel {
+  private static channels = new Map<string, Set<FakeBroadcastChannel>>();
+
+  onmessage: BroadcastHandler = null;
+
+  constructor(private readonly name: string) {
+    const channels = FakeBroadcastChannel.channels.get(name) ?? new Set();
+    channels.add(this);
+    FakeBroadcastChannel.channels.set(name, channels);
+  }
+
+  postMessage(data: unknown) {
+    const channels = FakeBroadcastChannel.channels.get(this.name) ?? new Set();
+    for (const channel of channels) {
+      if (channel !== this) {
+        channel.onmessage?.({ data } as MessageEvent);
+      }
+    }
+  }
+
+  close() {
+    FakeBroadcastChannel.channels.get(this.name)?.delete(this);
+  }
+
+  static reset() {
+    FakeBroadcastChannel.channels.clear();
+  }
+}
+
 describe("settings-broadcast", () => {
+  const originalBroadcastChannel = globalThis.BroadcastChannel;
+
   beforeEach(() => {
     vi.restoreAllMocks();
+    FakeBroadcastChannel.reset();
+    globalThis.BroadcastChannel =
+      FakeBroadcastChannel as unknown as typeof BroadcastChannel;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    FakeBroadcastChannel.reset();
+    globalThis.BroadcastChannel = originalBroadcastChannel;
   });
 
-  it("subscribeSettingsChanged invokes the handler when notify fires", async () => {
-    // happy-doom polyfills BroadcastChannel; messages are async, so wait a
-    // microtask after notify before asserting.
+  it("subscribeSettingsChanged invokes the handler when notify fires", () => {
     const handler = vi.fn();
     const unsubscribe = subscribeSettingsChanged(handler);
 
     notifySettingsChanged();
 
-    // Yield to the BroadcastChannel delivery microtask.
-    await new Promise((r) => setTimeout(r, 0));
     expect(handler).toHaveBeenCalledTimes(1);
 
     unsubscribe();
@@ -62,18 +96,16 @@ describe("settings-broadcast", () => {
     }
   });
 
-  it("unsubscribe stops the handler from firing on later notifies", async () => {
+  it("unsubscribe stops the handler from firing on later notifies", () => {
     const handler = vi.fn();
     const unsubscribe = subscribeSettingsChanged(handler);
 
     notifySettingsChanged();
-    await new Promise((r) => setTimeout(r, 0));
     expect(handler).toHaveBeenCalledTimes(1);
 
     unsubscribe();
 
     notifySettingsChanged();
-    await new Promise((r) => setTimeout(r, 0));
     // Still 1 — closed channel does not deliver.
     expect(handler).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary
- Persist Kindersuche non-text filters in URL query params so refreshes, copied links, and browser history restore the same view.
- Keep free-text student search transient to avoid putting student names into browser history.
- Make the existing active-filter reset action visible even when only one filter is active.

## Why
The new Kindersuche filter system previously reset most filters on refresh or revisit. URL-backed filters solve the common daily workflow without introducing saved views or per-user preference management.

## Validation
- `cd frontend && pnpm run check`
- `cd frontend && pnpm exec vitest run 'src/app/[tenant]/(protected)/students/search/page.test.tsx' 'src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx' 'src/components/ui/page-header/ActiveFilterChips.test.tsx'`
- Browser-tested locally via `agent-browser`: filter changes updated the URL, reload restored state, student detail back-links preserved filters, and `Alle löschen` cleared filters and query params.
