### PR TITLE
feat: relocate student avatar and unify fallback colour

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -1269,7 +1269,6 @@ function OGSGroupPageContent() {
                   onCheckinClick={() =>
                     void schoolCheckin.toggle(studentIdStr, checkinState)
                   }
-                  useInlineHintAvatarRow={photosEnabled}
                   locationBadge={
                     <StudentPresenceBadge
                       student={{

--- a/frontend/src/components/dashboard/header/profile-dropdown.tsx
+++ b/frontend/src/components/dashboard/header/profile-dropdown.tsx
@@ -17,7 +17,9 @@ interface UserAvatarProps {
 }
 
 function UserAvatar({ avatarUrl, userName, size = "sm" }: UserAvatarProps) {
-  return <Avatar imageUrl={avatarUrl} name={userName} size={size} />;
+  return (
+    <Avatar imageUrl={avatarUrl} name={userName} size={size} variant="staff" />
+  );
 }
 
 /**

--- a/frontend/src/components/dashboard/header/profile-dropdown.tsx
+++ b/frontend/src/components/dashboard/header/profile-dropdown.tsx
@@ -17,9 +17,7 @@ interface UserAvatarProps {
 }
 
 function UserAvatar({ avatarUrl, userName, size = "sm" }: UserAvatarProps) {
-  return (
-    <Avatar imageUrl={avatarUrl} name={userName} size={size} variant="staff" />
-  );
+  return <Avatar imageUrl={avatarUrl} name={userName} size={size} />;
 }
 
 /**

--- a/frontend/src/components/students/student-card.test.tsx
+++ b/frontend/src/components/students/student-card.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ArrivalTimeRow,
   ExceptionIcon,
@@ -10,6 +10,26 @@ import {
   StudentCard,
   StudentInfoRow,
 } from "./student-card";
+
+// Default the photos feature flag to off so the original test suite (which
+// pre-dates the avatar overlay) keeps its existing assertions. Individual
+// tests below flip the mock to `true` to exercise the avatar branch.
+const photosEnabledMock = vi.fn(() => ({
+  enabled: false,
+  isLoading: false,
+}));
+
+vi.mock("~/lib/hooks/use-student-photos-enabled", () => ({
+  useStudentPhotosEnabled: () => photosEnabledMock(),
+}));
+
+beforeEach(() => {
+  photosEnabledMock.mockReturnValue({ enabled: false, isLoading: false });
+});
+
+afterEach(() => {
+  photosEnabledMock.mockReset();
+});
 
 describe("StudentCard", () => {
   const defaultProps = {
@@ -247,6 +267,91 @@ describe("StudentCard", () => {
     // Disabled button must NOT fire onCheckinClick.
     fireEvent.click(btn);
     expect(onCheckinClick).not.toHaveBeenCalled();
+  });
+
+  // ── Avatar overlay (per-tenant student-photos feature) ────────────────
+  // Covers the photosEnabled branch and the photoUrl / fallback-initials
+  // permutations on the Avatar embedded in the card header.
+
+  it("does NOT render the avatar when the photos feature is disabled", () => {
+    photosEnabledMock.mockReturnValue({ enabled: false, isLoading: false });
+    render(<StudentCard {...defaultProps} photoUrl="https://x/y.jpg" />);
+    // aria-label on Avatar is the trimmed full name; absence proves the
+    // overlay was skipped despite a photoUrl being passed in.
+    expect(screen.queryByLabelText("Max Mustermann")).toBeNull();
+  });
+
+  it("renders the avatar with the student photo when the feature is enabled", () => {
+    photosEnabledMock.mockReturnValue({ enabled: true, isLoading: false });
+    render(
+      <StudentCard {...defaultProps} photoUrl="https://example.com/max.jpg" />,
+    );
+    const avatar = screen.getByLabelText("Max Mustermann");
+    expect(avatar).toBeInTheDocument();
+    // Image element is rendered by next/image inside the avatar — the alt
+    // text mirrors the trimmed name, which is what screen readers announce.
+    expect(screen.getByAltText("Max Mustermann")).toBeInTheDocument();
+  });
+
+  it("falls back to initials when photoUrl is omitted", () => {
+    photosEnabledMock.mockReturnValue({ enabled: true, isLoading: false });
+    render(<StudentCard {...defaultProps} photoUrl={null} />);
+    const avatar = screen.getByLabelText("Max Mustermann");
+    expect(avatar.textContent).toBe("MM");
+  });
+
+  it("falls back to '?' initials when both names are missing", () => {
+    // Hits the `firstName ?? "" + lastName ?? ""`.trim() || "?"` branch.
+    photosEnabledMock.mockReturnValue({ enabled: true, isLoading: false });
+    render(
+      <StudentCard
+        {...defaultProps}
+        firstName={undefined}
+        lastName={undefined}
+      />,
+    );
+    const avatar = screen.getByLabelText("?");
+    expect(avatar.textContent).toBe("?");
+  });
+
+  it("renders the 'anmelden' (+) action icon on the tap-strip for absent students", () => {
+    // Covers tapStrip.action === "anmelden" branch in the SVG path switch.
+    const { container } = render(
+      <StudentCard
+        {...defaultProps}
+        checkinMode
+        checkinState="abwesend"
+        onCheckinClick={vi.fn()}
+      />,
+    );
+    const strip = container.querySelector("[data-checkin-tap-strip='true']");
+    expect(strip).not.toBeNull();
+    // The "anmelden" icon path is the plus sign (vertical + horizontal line).
+    expect(strip?.querySelector('path[d="M12 4v16m8-8H4"]')).not.toBeNull();
+  });
+
+  it("renders the 'abmelden' (−) action icon on the tap-strip for present students", () => {
+    // Covers tapStrip.action === "abmelden" branch in the SVG path switch.
+    const { container } = render(
+      <StudentCard
+        {...defaultProps}
+        checkinMode
+        checkinState="anwesend"
+        onCheckinClick={vi.fn()}
+      />,
+    );
+    const strip = container.querySelector("[data-checkin-tap-strip='true']");
+    // The "abmelden" icon path is the single horizontal line (minus sign).
+    expect(strip?.querySelector('path[d="M20 12H4"]')).not.toBeNull();
+  });
+
+  it("does not set the data-checkin-* attributes when checkinMode is off", () => {
+    // Covers the `checkinMode || undefined` and `checkinMode ? ... : undefined`
+    // false branches on the data attributes.
+    render(<StudentCard {...defaultProps} />);
+    const btn = screen.getByRole("button");
+    expect(btn).not.toHaveAttribute("data-checkin-mode");
+    expect(btn).not.toHaveAttribute("data-checkin-state");
   });
 
   it("hides the navigation arrow + 'mehr Infos' hint when checkinMode is true", () => {

--- a/frontend/src/components/students/student-card.tsx
+++ b/frontend/src/components/students/student-card.tsx
@@ -37,12 +37,6 @@ interface StudentCardProps {
   /** Optional tracking indicators (right-aligned, below location badge) */
   readonly trackingIndicators?: ReactNode;
   /**
-   * Opt-in compact-surface layout: render the navigation hint and avatar in a
-   * shared in-flow bottom row so the card grows subtly instead of letting the
-   * avatar overlap a dense indicator stack.
-   */
-  readonly useInlineHintAvatarRow?: boolean;
-  /**
    * When true, the card is rendered in school check-in/out mode: the bottom
    * hint area becomes a coloured tap-strip whose copy + colour follow
    * checkinState, click fires onCheckinClick instead of onClick, and a
@@ -114,7 +108,6 @@ export function StudentCard({
   locationBadge,
   extraContent,
   trackingIndicators,
-  useInlineHintAvatarRow = false,
   checkinMode = false,
   checkinState = "unknown",
   isCheckinPending = false,
@@ -179,40 +172,49 @@ export function StudentCard({
         {/* Card body content sits above the decorative layers */}
         <div className="relative">
           {/* Header with student name */}
-          <div
-            className={`flex items-start justify-between gap-3 ${
-              !checkinMode && photosEnabled && useInlineHintAvatarRow
-                ? "mb-1"
-                : "mb-3"
-            }`}
-          >
+          <div className="mb-3 flex items-start justify-between gap-3">
             {/* Student Name */}
             <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <h3 className="overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap text-gray-800 transition-colors duration-150 md:group-hover:text-blue-600">
-                  {firstName}
-                </h3>
-                {/* Arrow hint only points to navigation; in check-in mode the
-                  bottom strip carries the action signal instead. */}
-                {!checkinMode && (
-                  <svg
-                    className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors duration-150 md:group-hover:text-blue-500"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 5l7 7-7 7"
-                    />
-                  </svg>
+              {/* Avatar moved to top-left, inline with first/last name so only
+                  the name gets pushed aside. extraContent below stays full
+                  width. */}
+              <div className="flex items-start gap-3">
+                {photosEnabled && (
+                  <Avatar
+                    imageUrl={photoUrl ?? null}
+                    name={`${firstName ?? ""} ${lastName ?? ""}`.trim() || "?"}
+                    size="md"
+                    className="flex-shrink-0"
+                  />
                 )}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <h3 className="overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap text-gray-800 transition-colors duration-150 md:group-hover:text-blue-600">
+                      {firstName}
+                    </h3>
+                    {/* Arrow hint only points to navigation; in check-in mode the
+                      bottom strip carries the action signal instead. */}
+                    {!checkinMode && (
+                      <svg
+                        className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors duration-150 md:group-hover:text-blue-500"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M9 5l7 7-7 7"
+                        />
+                      </svg>
+                    )}
+                  </div>
+                  <p className="overflow-hidden text-base font-semibold text-ellipsis whitespace-nowrap text-gray-700 transition-colors duration-150 md:group-hover:text-blue-500">
+                    {lastName}
+                  </p>
+                </div>
               </div>
-              <p className="overflow-hidden text-base font-semibold text-ellipsis whitespace-nowrap text-gray-700 transition-colors duration-150 md:group-hover:text-blue-500">
-                {lastName}
-              </p>
               {/* Extra content slot (school class, group name, etc.) */}
               {extraContent}
             </div>
@@ -228,54 +230,17 @@ export function StudentCard({
             )}
           </div>
 
-          {/* Bottom hint in navigation mode only. Compact surfaces can opt
-              into an in-flow row with the avatar so the card grows just
-              enough to clear a tall indicator stack without affecting other
-              StudentCard consumers. */}
-          {!checkinMode &&
-            (photosEnabled && useInlineHintAvatarRow ? (
-              <div className="flex items-center gap-3">
-                <p className="text-xs text-gray-400 transition-colors duration-150 md:group-hover:text-blue-400">
-                  Tippen für mehr Infos
-                </p>
-                <Avatar
-                  imageUrl={photoUrl ?? null}
-                  name={`${firstName ?? ""} ${lastName ?? ""}`.trim() || "?"}
-                  size="md"
-                  className="ml-auto flex-shrink-0"
-                />
-              </div>
-            ) : (
-              <p
-                className={`text-xs text-gray-400 transition-colors duration-150 md:group-hover:text-blue-400 ${photosEnabled ? "pr-14" : ""}`}
-              >
-                Tippen für mehr Infos
-              </p>
-            ))}
-
-          {/* Decorative pings — kept in both modes, they belong to the card's
-              visual identity, not to the navigation affordance. The bottom-
-              right ping is suppressed when the avatar overlay takes its
-              place so they don't visually overlap. */}
-          <div className="absolute top-3 left-3 h-5 w-5 animate-ping rounded-full bg-white/20" />
-          {!photosEnabled && (
-            <div className="absolute right-3 bottom-3 h-3 w-3 rounded-full bg-white/30" />
+          {/* Bottom hint in navigation mode only. */}
+          {!checkinMode && (
+            <p className="text-xs text-gray-400 transition-colors duration-150 md:group-hover:text-blue-400">
+              Tippen für mehr Infos
+            </p>
           )}
 
-          {/* Avatar overlay — sits at the same bottom-right corner the
-              decorative ping used to occupy. Pinned absolutely so it never
-              shifts the card layout, pointer-events-none so the whole card
-              stays a single click target. Size md (44px) keeps it discreet
-              in dense grids while still readable as a face/initials. */}
-          {photosEnabled && !(!checkinMode && useInlineHintAvatarRow) ? (
-            <div className="pointer-events-none absolute right-0 bottom-3">
-              <Avatar
-                imageUrl={photoUrl ?? null}
-                name={`${firstName ?? ""} ${lastName ?? ""}`.trim() || "?"}
-                size="md"
-              />
-            </div>
-          ) : null}
+          {/* Decorative bottom-right ping — static, no pulse animation.
+              The previous top-left animate-ping was removed because it
+              visually pulsed through the avatar now sitting in that corner. */}
+          <div className="absolute right-3 bottom-3 h-3 w-3 rounded-full bg-white/30" />
         </div>
       </div>
 

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -7,25 +7,16 @@ import { useEffect, useState } from "react";
 import { getInitials } from "~/lib/format-utils";
 
 type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl";
-type AvatarVariant = "student" | "staff";
 
 interface AvatarProps {
   readonly imageUrl?: string | null;
   readonly name: string;
   readonly size?: AvatarSize;
   readonly className?: string;
-  /**
-   * Colour tone of the initials-fallback background. `student` (default) uses
-   * the brand green (LOCATION_COLORS.GROUP_ROOM); `staff` uses a neutral grey
-   * so children and staff are visually distinguishable at a glance.
-   */
-  readonly variant?: AvatarVariant;
 }
 
-const VARIANT_BG: Record<AvatarVariant, string> = {
-  student: "#83CD2D", // LOCATION_COLORS.GROUP_ROOM — brand green for kids
-  staff: "#6B7280", // LOCATION_COLORS.UNKNOWN — neutral grey for staff
-};
+// Single brand-green fallback background for every avatar (LOCATION_COLORS.GROUP_ROOM).
+const FALLBACK_BG = "#83CD2D";
 
 const SIZE_CLASSES: Record<AvatarSize, string> = {
   xs: "w-6 h-6 text-[10px]",
@@ -48,7 +39,6 @@ export function Avatar({
   name,
   size = "sm",
   className,
-  variant = "student",
 }: AvatarProps) {
   const initials = getInitials(name);
   const sizeClass = SIZE_CLASSES[size];
@@ -70,7 +60,7 @@ export function Avatar({
     <div
       className={`relative ${sizeClass} ${ringClass} flex flex-shrink-0 items-center justify-center overflow-hidden rounded-full font-semibold text-white ${className ?? ""}`}
       style={{
-        background: showImage ? "transparent" : VARIANT_BG[variant],
+        background: showImage ? "transparent" : FALLBACK_BG,
       }}
       aria-label={name}
     >

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -7,13 +7,25 @@ import { useEffect, useState } from "react";
 import { getInitials } from "~/lib/format-utils";
 
 type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl";
+type AvatarVariant = "student" | "staff";
 
 interface AvatarProps {
   readonly imageUrl?: string | null;
   readonly name: string;
   readonly size?: AvatarSize;
   readonly className?: string;
+  /**
+   * Colour tone of the initials-fallback background. `student` (default) uses
+   * the brand green (LOCATION_COLORS.GROUP_ROOM); `staff` uses a neutral grey
+   * so children and staff are visually distinguishable at a glance.
+   */
+  readonly variant?: AvatarVariant;
 }
+
+const VARIANT_BG: Record<AvatarVariant, string> = {
+  student: "#83CD2D", // LOCATION_COLORS.GROUP_ROOM — brand green for kids
+  staff: "#6B7280", // LOCATION_COLORS.UNKNOWN — neutral grey for staff
+};
 
 const SIZE_CLASSES: Record<AvatarSize, string> = {
   xs: "w-6 h-6 text-[10px]",
@@ -36,6 +48,7 @@ export function Avatar({
   name,
   size = "sm",
   className,
+  variant = "student",
 }: AvatarProps) {
   const initials = getInitials(name);
   const sizeClass = SIZE_CLASSES[size];
@@ -57,9 +70,7 @@ export function Avatar({
     <div
       className={`relative ${sizeClass} ${ringClass} flex flex-shrink-0 items-center justify-center overflow-hidden rounded-full font-semibold text-white ${className ?? ""}`}
       style={{
-        background: showImage
-          ? "transparent"
-          : "linear-gradient(135deg, #5080d8, #83cd2d)",
+        background: showImage ? "transparent" : VARIANT_BG[variant],
       }}
       aria-label={name}
     >


### PR DESCRIPTION
## Summary
- `StudentCard` avatar moves from an absolutely-positioned bottom-right overlay to the top-left of the card header, inline with the name. The `useInlineHintAvatarRow` compact-surface workaround (and its OGS-groups call site) is dropped — the new layout works in every surface.
- Avatar initials-fallback background switches from the blue→green gradient (`#5080d8 → #83cd2d`) to a solid brand green (`#83CD2D`, `LOCATION_COLORS.GROUP_ROOM`) for both students and staff.
- Removed the top-left `animate-ping` (it pulsed through the new avatar position) and the pulse animation on the bottom-right deco ping; dropped the `pr-14` reserve that existed only for the old overlay.
- Backfilled `student-card` tests covering the photos-enabled / fallback-initials branches and the anmelden/abmelden tap-strip icons (new-code coverage ~31% → ~97%).

## Why
The bottom-right overlay collided with the "Tippen für mehr Infos" hint row and the tracking-indicator stack in dense lists — hence the `useInlineHintAvatarRow` branch. Moving the avatar into the header flow resolves it structurally instead of with a special case. The gradient fallback was a holdover that didn't match any brand colour; the solid brand green aligns with `LOCATION_COLORS`.

## Test plan
- [x] Student list with `photosEnabled = true`: avatar top-left, no overlap, ellipsis on long names — confirmed locally
- [x] Profile dropdown without photo: brand-green initials background — confirmed locally
- [ ] Student list without photos: green initials background
- [ ] Check-in flow: no stray arrow/hint
- [ ] `pnpm run check` green (passed in pre-push hook)