### PR TITLE
fix(api/common): guard error helpers against nil input (#423)

### DIFF
--- a/backend/api/common/errors.go
+++ b/backend/api/common/errors.go
@@ -99,14 +99,30 @@ func (e *ErrResponse) Render(_ http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-// ErrorInvalidRequest returns a 400 Bad Request error response
-func ErrorInvalidRequest(err error) render.Renderer {
+// newErrResponse builds an ErrResponse, tolerating a nil err by falling back to
+// the standard HTTP status text. A nil err here means a caller violated the
+// helper contract — we log a warning so the bug surfaces instead of being
+// masked by a panic or a silent "unknown error" string.
+func newErrResponse(status int, err error) *ErrResponse {
+	text := http.StatusText(status)
+	if err != nil {
+		text = err.Error()
+	} else {
+		slog.Default().Warn("error helper called with nil error",
+			slog.Int("status", status),
+		)
+	}
 	return &ErrResponse{
 		Err:            err,
-		HTTPStatusCode: http.StatusBadRequest,
+		HTTPStatusCode: status,
 		Status:         "error",
-		ErrorText:      err.Error(),
+		ErrorText:      text,
 	}
+}
+
+// ErrorInvalidRequest returns a 400 Bad Request error response
+func ErrorInvalidRequest(err error) render.Renderer {
+	return newErrResponse(http.StatusBadRequest, err)
 }
 
 // ErrorValidation returns a 400 Bad Request with a summary message and a
@@ -126,42 +142,22 @@ func ErrorValidation(summary string, fields []FieldError) render.Renderer {
 
 // ErrorUnauthorized returns a 401 Unauthorized error response
 func ErrorUnauthorized(err error) render.Renderer {
-	return &ErrResponse{
-		Err:            err,
-		HTTPStatusCode: http.StatusUnauthorized,
-		Status:         "error",
-		ErrorText:      err.Error(),
-	}
+	return newErrResponse(http.StatusUnauthorized, err)
 }
 
 // ErrorForbidden returns a 403 Forbidden error response
 func ErrorForbidden(err error) render.Renderer {
-	return &ErrResponse{
-		Err:            err,
-		HTTPStatusCode: http.StatusForbidden,
-		Status:         "error",
-		ErrorText:      err.Error(),
-	}
+	return newErrResponse(http.StatusForbidden, err)
 }
 
 // ErrorNotFound returns a 404 Not Found error response
 func ErrorNotFound(err error) render.Renderer {
-	return &ErrResponse{
-		Err:            err,
-		HTTPStatusCode: http.StatusNotFound,
-		Status:         "error",
-		ErrorText:      err.Error(),
-	}
+	return newErrResponse(http.StatusNotFound, err)
 }
 
 // ErrorInternalServer returns a 500 Internal Server Error response
 func ErrorInternalServer(err error) render.Renderer {
-	return &ErrResponse{
-		Err:            err,
-		HTTPStatusCode: http.StatusInternalServerError,
-		Status:         "error",
-		ErrorText:      err.Error(),
-	}
+	return newErrResponse(http.StatusInternalServerError, err)
 }
 
 // ErrorInternalServerWrap returns a 500 response with a stable client-facing message
@@ -179,23 +175,14 @@ func ErrorInternalServerWrap(clientMsg string, cause error) render.Renderer {
 
 // ErrorConflict returns a 409 Conflict error response
 func ErrorConflict(err error) render.Renderer {
-	return &ErrResponse{
-		Err:            err,
-		HTTPStatusCode: http.StatusConflict,
-		Status:         "error",
-		ErrorText:      err.Error(),
-	}
+	return newErrResponse(http.StatusConflict, err)
 }
 
 // ErrorConflictWithCode returns a 409 Conflict with a stable error code for frontend disambiguation.
 func ErrorConflictWithCode(err error, code string) render.Renderer {
-	return &ErrResponse{
-		Err:            err,
-		HTTPStatusCode: http.StatusConflict,
-		Status:         "error",
-		ErrorText:      err.Error(),
-		Code:           code,
-	}
+	resp := newErrResponse(http.StatusConflict, err)
+	resp.Code = code
+	return resp
 }
 
 // ErrorConflictMessage returns a 409 Conflict with a user-facing message string.
@@ -211,12 +198,7 @@ func ErrorConflictMessage(message string) render.Renderer {
 
 // ErrorTooManyRequests returns a 429 Too Many Requests error response
 func ErrorTooManyRequests(err error) render.Renderer {
-	return &ErrResponse{
-		Err:            err,
-		HTTPStatusCode: http.StatusTooManyRequests,
-		Status:         "error",
-		ErrorText:      err.Error(),
-	}
+	return newErrResponse(http.StatusTooManyRequests, err)
 }
 
 // IsConstraintViolation checks if an error is a PostgreSQL constraint violation
@@ -243,10 +225,5 @@ func IsConstraintViolation(err error) bool {
 
 // ErrorGone returns a 410 Gone error response
 func ErrorGone(err error) render.Renderer {
-	return &ErrResponse{
-		Err:            err,
-		HTTPStatusCode: http.StatusGone,
-		Status:         "error",
-		ErrorText:      err.Error(),
-	}
+	return newErrResponse(http.StatusGone, err)
 }

--- a/backend/api/common/errors_test.go
+++ b/backend/api/common/errors_test.go
@@ -616,3 +616,118 @@ func TestRenderError_NonErrResponseRenderer(t *testing.T) {
 	common.RenderError(w, r, renderer)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
+
+// =============================================================================
+// Regression: Nil-Error Inputs (Issue #423)
+// =============================================================================
+//
+// Prior behavior: each helper called err.Error() unconditionally, so passing
+// nil panicked with a nil-pointer dereference. The fix routes every helper
+// through a shared constructor that falls back to http.StatusText(status)
+// when err is nil. These tests pin that behavior so a future refactor can't
+// reintroduce the panic.
+
+func TestErrorHelpers_NilErrorDoesNotPanic(t *testing.T) {
+	// Each entry: helper name -> (invocation, expected HTTP status).
+	// Every helper that takes a single `error` parameter must accept nil
+	// without panicking and return the corresponding HTTP status with a
+	// non-empty ErrorText fallback.
+	cases := []struct {
+		name           string
+		renderer       render.Renderer
+		expectedStatus int
+	}{
+		{"ErrorInvalidRequest", common.ErrorInvalidRequest(nil), http.StatusBadRequest},
+		{"ErrorUnauthorized", common.ErrorUnauthorized(nil), http.StatusUnauthorized},
+		{"ErrorForbidden", common.ErrorForbidden(nil), http.StatusForbidden},
+		{"ErrorNotFound", common.ErrorNotFound(nil), http.StatusNotFound},
+		{"ErrorInternalServer", common.ErrorInternalServer(nil), http.StatusInternalServerError},
+		{"ErrorConflict", common.ErrorConflict(nil), http.StatusConflict},
+		{"ErrorTooManyRequests", common.ErrorTooManyRequests(nil), http.StatusTooManyRequests},
+		{"ErrorGone", common.ErrorGone(nil), http.StatusGone},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotNil(t, tc.renderer, "helper returned nil renderer")
+
+			errResp, ok := tc.renderer.(*common.ErrResponse)
+			require.True(t, ok, "helper must return *ErrResponse")
+			assert.Equal(t, tc.expectedStatus, errResp.HTTPStatusCode)
+			assert.Equal(t, "error", errResp.Status)
+			assert.Nil(t, errResp.Err, "Err must remain nil when caller passed nil")
+			// Fallback text must be non-empty so the client gets a meaningful body.
+			assert.NotEmpty(t, errResp.ErrorText, "ErrorText must fall back, not be empty")
+			// And it must match the standard HTTP status text for the code.
+			assert.Equal(t, http.StatusText(tc.expectedStatus), errResp.ErrorText)
+
+			// End-to-end: rendering must succeed and the response body must
+			// contain the fallback text.
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/test", nil)
+			require.NoError(t, render.Render(w, r, tc.renderer))
+			assert.Equal(t, tc.expectedStatus, w.Code)
+
+			var body map[string]interface{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			assert.Equal(t, "error", body["status"])
+			assert.Equal(t, http.StatusText(tc.expectedStatus), body["error"])
+		})
+	}
+}
+
+func TestErrorConflictWithCode_NilError(t *testing.T) {
+	// ErrorConflictWithCode takes (err, code). nil err must still produce
+	// a valid response, and the provided code must be preserved.
+	renderer := common.ErrorConflictWithCode(nil, "ACCOUNT_ALREADY_HAS_TENANT_ACCESS")
+	require.NotNil(t, renderer)
+
+	errResp, ok := renderer.(*common.ErrResponse)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusConflict, errResp.HTTPStatusCode)
+	assert.Equal(t, "error", errResp.Status)
+	assert.Nil(t, errResp.Err)
+	assert.Equal(t, http.StatusText(http.StatusConflict), errResp.ErrorText)
+	assert.Equal(t, "ACCOUNT_ALREADY_HAS_TENANT_ACCESS", errResp.Code,
+		"code must be preserved even when err is nil")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/test", nil)
+	require.NoError(t, render.Render(w, r, renderer))
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "ACCOUNT_ALREADY_HAS_TENANT_ACCESS", body["code"])
+}
+
+func TestErrorHelpers_NonNilErrorPreservesMessage(t *testing.T) {
+	// Sibling check to the nil-error suite: when a real error is passed,
+	// ErrorText must reflect err.Error() — not the http.StatusText fallback.
+	// Guards against a future "always use StatusText" regression.
+	customErr := errors.New("custom failure message")
+
+	cases := []struct {
+		name     string
+		renderer render.Renderer
+	}{
+		{"ErrorInvalidRequest", common.ErrorInvalidRequest(customErr)},
+		{"ErrorUnauthorized", common.ErrorUnauthorized(customErr)},
+		{"ErrorForbidden", common.ErrorForbidden(customErr)},
+		{"ErrorNotFound", common.ErrorNotFound(customErr)},
+		{"ErrorInternalServer", common.ErrorInternalServer(customErr)},
+		{"ErrorConflict", common.ErrorConflict(customErr)},
+		{"ErrorTooManyRequests", common.ErrorTooManyRequests(customErr)},
+		{"ErrorGone", common.ErrorGone(customErr)},
+		{"ErrorConflictWithCode", common.ErrorConflictWithCode(customErr, "SOME_CODE")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errResp, ok := tc.renderer.(*common.ErrResponse)
+			require.True(t, ok)
+			assert.Same(t, customErr, errResp.Err, "Err pointer must be preserved")
+			assert.Equal(t, "custom failure message", errResp.ErrorText)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Route all 8 single-error helpers (`ErrorInvalidRequest`, `ErrorUnauthorized`, `ErrorForbidden`, `ErrorNotFound`, `ErrorInternalServer`, `ErrorConflict`, `ErrorTooManyRequests`, `ErrorGone`) plus `ErrorConflictWithCode` through a shared `newErrResponse(status, err)` constructor. When `err == nil`, it falls back to `http.StatusText(status)` and emits a `slog.Warn` so the caller bug surfaces instead of panicking with a nil-pointer dereference.
- `Err` stays `nil` on the response struct, so `RenderError`'s existing `errResp.Err != nil` guard keeps Sentry from capturing nil errors.
- Non-nil behaviour is bit-equivalent to before — pinned by a new regression test so a future "always use StatusText" refactor can't silently swallow real error messages.

Closes #423.

## Test plan
- [x] `go test -count=1 ./api/common/...` — all tests pass (incl. 3 new regression tests covering every helper for nil and non-nil inputs).
- [x] `go build ./...` clean.
- [x] `golangci-lint run ./api/common/...` — 0 issues.
- [x] `go test ./test/ -run TestHermeticTestPatterns` passes.
- [x] Full backend suite run against test DB — only pre-existing failures surface (`tenant_resolve_photos`, `TestRepairPickupScheduleTenantIDs`), verified via `git stash` baseline. Untouched by this PR.
- [x] Repo-wide grep confirms no production caller passes `nil` to any of these helpers today — the new `slog.Warn` branch is a defensive net, not a hot path.