### PR TITLE
Archive timetable templates

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/timetables/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/timetables/page.test.tsx
@@ -17,6 +17,7 @@ const {
   mockSubstitute,
   mockPatchAttendance,
   mockDeleteCancelled,
+  mockArchiveTemplate,
 } = vi.hoisted(() => ({
   mockSearch: { value: "" },
   mockUseSession: vi.fn(),
@@ -33,6 +34,7 @@ const {
   mockSubstitute: vi.fn(),
   mockPatchAttendance: vi.fn(),
   mockDeleteCancelled: vi.fn(),
+  mockArchiveTemplate: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -82,7 +84,42 @@ vi.mock("~/lib/timetable-api", () => ({
     substitute: mockSubstitute,
     patchAttendance: mockPatchAttendance,
     deleteCancelled: mockDeleteCancelled,
+    archiveTemplate: mockArchiveTemplate,
   },
+}));
+
+vi.mock("~/components/ui/modal", () => ({
+  ConfirmationModal: ({
+    isOpen,
+    onClose,
+    onConfirm,
+    title,
+    children,
+    confirmText = "Bestätigen",
+    cancelText = "Abbrechen",
+    isConfirmLoading = false,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    title: string;
+    children: React.ReactNode;
+    confirmText?: string;
+    cancelText?: string;
+    isConfirmLoading?: boolean;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-label={title}>
+        <h2>{title}</h2>
+        <div>{children}</div>
+        <button type="button" onClick={onClose}>
+          {cancelText}
+        </button>
+        <button type="button" disabled={isConfirmLoading} onClick={onConfirm}>
+          {isConfirmLoading ? "Wird geladen..." : confirmText}
+        </button>
+      </div>
+    ) : null,
 }));
 
 vi.mock("~/lib/calendar-period-api", () => ({
@@ -318,6 +355,7 @@ vi.mock("~/components/timetable/template-list", () => ({
     onCreate,
     onEdit,
     onApply,
+    onArchive,
   }: {
     templates: Array<{ id: string; name: string }>;
     onCreate: () => void;
@@ -327,6 +365,7 @@ vi.mock("~/components/timetable/template-list", () => ({
       name: string;
       schedules: Array<{ calendarPeriodId?: string }>;
     }) => void;
+    onArchive: (template: { id: string; name: string }) => void;
   }) => (
     <div>
       <button type="button" onClick={onCreate}>
@@ -336,6 +375,9 @@ vi.mock("~/components/timetable/template-list", () => ({
         <>
           <button type="button" onClick={() => onEdit(templates[0]!)}>
             edit-template
+          </button>
+          <button type="button" onClick={() => onArchive(templates[0]!)}>
+            archive-template
           </button>
           <button
             type="button"
@@ -624,6 +666,7 @@ describe("TimetablesPage", () => {
     });
     mockPatchAttendance.mockResolvedValue({});
     mockDeleteCancelled.mockResolvedValue({});
+    mockArchiveTemplate.mockResolvedValue({});
     setupSWR();
     window.history.replaceState(null, "", "/acme/timetables");
   });
@@ -725,6 +768,22 @@ describe("TimetablesPage", () => {
     fireEvent.click(screen.getByText("apply-template"));
     await waitFor(() => expect(mockMaterialize).toHaveBeenCalled());
 
+    fireEvent.click(screen.getByText("archive-template"));
+    expect(
+      screen.getByRole("dialog", { name: "Serie archivieren?" }),
+    ).toHaveTextContent("Serie „Yoga“");
+    fireEvent.click(screen.getByRole("button", { name: "Abbrechen" }));
+    expect(mockArchiveTemplate).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("dialog", { name: "Serie archivieren?" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("archive-template"));
+    fireEvent.click(screen.getByRole("button", { name: "Archivieren" }));
+    await waitFor(() => expect(mockArchiveTemplate).toHaveBeenCalledWith("7"));
+    expect(mockToastSuccess).toHaveBeenCalledWith('Serie "Yoga" archiviert');
+    expect(mockTenantMutate).toHaveBeenCalledWith("timetable-templates-5");
+
     fireEvent.click(screen.getByText("month-view"));
     await waitFor(() => expect(screen.getByText("month-grid")).toBeVisible());
     fireEvent.click(screen.getByText("month-grid"));
@@ -742,6 +801,22 @@ describe("TimetablesPage", () => {
     fireEvent.click(screen.getByText("density"));
     fireEvent.click(screen.getByText("add-instance"));
     expect(screen.getByText("event-save")).toBeInTheDocument();
+  });
+
+  it("keeps archive confirmation open and reports errors", async () => {
+    mockSearch.value = "view=series&period=5";
+    mockArchiveTemplate.mockRejectedValueOnce(new Error("Archivierung kaputt"));
+    render(<TimetablesPage />);
+
+    fireEvent.click(screen.getByText("archive-template"));
+    fireEvent.click(screen.getByRole("button", { name: "Archivieren" }));
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith("Archivierung kaputt"),
+    );
+    expect(
+      screen.getByRole("dialog", { name: "Serie archivieren?" }),
+    ).toBeInTheDocument();
   });
 
   it("shows loading state while the session loads", () => {

--- a/frontend/src/app/[tenant]/(protected)/timetables/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/timetables/page.tsx
@@ -13,6 +13,7 @@ import { useSession } from "next-auth/react";
 
 import { CalendarPeriodModal } from "~/components/timetable/calendar-period-modal";
 import { Loading } from "~/components/ui/loading";
+import { ConfirmationModal } from "~/components/ui/modal";
 import { useToast } from "~/contexts/ToastContext";
 import type { CalendarPeriod } from "~/lib/calendar-period-helpers";
 import { ConflictWarningsBanner } from "~/components/timetable/conflict-warnings-banner";
@@ -199,6 +200,9 @@ function TimetablesContent() {
     useState<EnrichedInstance | null>(null);
   const [editingTemplate, setEditingTemplate] =
     useState<TimetableTemplate | null>(null);
+  const [archivingTemplate, setArchivingTemplate] =
+    useState<TimetableTemplate | null>(null);
+  const [archiveLoading, setArchiveLoading] = useState(false);
   const [convertingInstance, setConvertingInstance] =
     useState<EnrichedInstance | null>(null);
   const [periodModalOpen, setPeriodModalOpen] = useState(false);
@@ -1043,6 +1047,44 @@ function TimetablesContent() {
     ],
   );
 
+  const handleArchiveTemplate = useCallback(async () => {
+    if (!archivingTemplate) return;
+
+    setArchiveLoading(true);
+    try {
+      await timetableService.archiveTemplate(archivingTemplate.id);
+      toastSuccess(`Serie "${archivingTemplate.name}" archiviert`);
+      setArchivingTemplate(null);
+      if (templatePeriodID) {
+        await tenantMutate(`timetable-templates-${templatePeriodID}`);
+      }
+      await tenantMutate(swrKey);
+      await tenantMutate(gapsSWRKey);
+      await tenantMutate(exceptionConflictsSWRKey);
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Serie konnte nicht archiviert werden";
+      logger.error("template_archive_failed", {
+        template_id: archivingTemplate.id,
+        error: message,
+      });
+      toastError(message);
+    } finally {
+      setArchiveLoading(false);
+    }
+  }, [
+    archivingTemplate,
+    exceptionConflictsSWRKey,
+    gapsSWRKey,
+    swrKey,
+    templatePeriodID,
+    tenantMutate,
+    toastError,
+    toastSuccess,
+  ]);
+
   if (status === "loading") {
     return (
       <div className="p-6">
@@ -1221,6 +1263,7 @@ function TimetablesContent() {
                 setEventModalOpen(true);
               }}
               onApply={(template) => void handleApplyTemplate(template)}
+              onArchive={setArchivingTemplate}
             />
           )}
         </>
@@ -1311,6 +1354,33 @@ function TimetablesContent() {
         }}
         createDefaults={periodCreateDefaults}
       />
+
+      <ConfirmationModal
+        isOpen={archivingTemplate !== null}
+        onClose={() => {
+          if (!archiveLoading) setArchivingTemplate(null);
+        }}
+        onConfirm={() => void handleArchiveTemplate()}
+        title="Serie archivieren?"
+        confirmText="Archivieren"
+        cancelText="Abbrechen"
+        isConfirmLoading={archiveLoading}
+        confirmButtonClass="bg-slate-900 hover:bg-slate-700"
+      >
+        <p className="text-sm leading-relaxed text-slate-600">
+          Die Serie
+          {archivingTemplate ? (
+            <>
+              {" "}
+              <span className="font-semibold text-slate-900">
+                „{archivingTemplate.name}“
+              </span>
+            </>
+          ) : null}{" "}
+          verschwindet aus der Serienliste. Bereits erzeugte konkrete Termine
+          bleiben im Stundenplan erhalten.
+        </p>
+      </ConfirmationModal>
     </div>
   );
 }

--- a/frontend/src/components/timetable/template-card.tsx
+++ b/frontend/src/components/timetable/template-card.tsx
@@ -12,7 +12,7 @@
  * bar that ties the card back to the activity type.
  */
 
-import { Clock, DoorOpen, Users } from "lucide-react";
+import { Archive, Clock, DoorOpen, Users } from "lucide-react";
 
 import {
   getActivityColor,
@@ -24,6 +24,7 @@ interface TemplateCardProps {
   template: TimetableTemplate;
   onEdit: (template: TimetableTemplate) => void;
   onApply: (template: TimetableTemplate) => void;
+  onArchive: (template: TimetableTemplate) => void;
 }
 
 const WEEKDAYS = [1, 2, 3, 4, 5] as const;
@@ -53,7 +54,12 @@ function summarizeTimeRange(template: TimetableTemplate): string | null {
   return allSame ? base : `${base} +`;
 }
 
-export function TemplateCard({ template, onEdit, onApply }: TemplateCardProps) {
+export function TemplateCard({
+  template,
+  onEdit,
+  onApply,
+  onArchive,
+}: TemplateCardProps) {
   const color = getActivityColor(template.type);
   const activeWeekdays = new Set(template.schedules.map((s) => s.weekday));
   const timeRange = summarizeTimeRange(template);
@@ -120,18 +126,28 @@ export function TemplateCard({ template, onEdit, onApply }: TemplateCardProps) {
         </dl>
       </div>
 
-      <div className="flex items-center justify-between gap-2 border-t border-slate-100 px-4 py-2.5 pl-5">
-        <button
-          type="button"
-          onClick={() => onEdit(template)}
-          className="text-[12px] font-medium text-slate-600 transition-colors hover:text-slate-900"
-        >
-          Bearbeiten
-        </button>
+      <div className="flex flex-col gap-2 border-t border-slate-100 px-4 py-2.5 pl-5">
+        <div className="flex items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={() => onEdit(template)}
+            className="rounded px-1.5 py-1 text-[12px] font-medium text-slate-600 transition-colors hover:text-slate-900 focus-visible:ring-2 focus-visible:ring-slate-300 focus-visible:outline-none"
+          >
+            Bearbeiten
+          </button>
+          <button
+            type="button"
+            onClick={() => onArchive(template)}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 focus-visible:ring-2 focus-visible:ring-slate-300 focus-visible:outline-none"
+          >
+            <Archive className="h-3.5 w-3.5" aria-hidden />
+            Archivieren
+          </button>
+        </div>
         <button
           type="button"
           onClick={() => onApply(template)}
-          className="inline-flex items-center gap-1 rounded-md bg-slate-900 px-2.5 py-1.5 text-[12px] font-medium text-white transition-colors hover:bg-slate-700"
+          className="inline-flex h-8 w-full items-center justify-center rounded-md bg-slate-900 px-2.5 text-[12px] font-medium whitespace-nowrap text-white transition-colors hover:bg-slate-700 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           Termine erzeugen
         </button>

--- a/frontend/src/components/timetable/template-list.tsx
+++ b/frontend/src/components/timetable/template-list.tsx
@@ -10,6 +10,7 @@ interface TemplateListProps {
   onCreate: () => void;
   onEdit: (template: TimetableTemplate) => void;
   onApply: (template: TimetableTemplate) => void;
+  onArchive: (template: TimetableTemplate) => void;
 }
 
 export function TemplateList({
@@ -17,6 +18,7 @@ export function TemplateList({
   onCreate,
   onEdit,
   onApply,
+  onArchive,
 }: TemplateListProps) {
   if (templates.length === 0) {
     return (
@@ -52,6 +54,7 @@ export function TemplateList({
           template={template}
           onEdit={onEdit}
           onApply={onApply}
+          onArchive={onArchive}
         />
       ))}
     </div>

--- a/frontend/src/components/timetable/timetable-small-components.test.tsx
+++ b/frontend/src/components/timetable/timetable-small-components.test.tsx
@@ -127,6 +127,7 @@ describe("small timetable components", () => {
     const onCreate = vi.fn();
     const onEdit = vi.fn();
     const onApply = vi.fn();
+    const onArchive = vi.fn();
 
     const { rerender } = render(
       <TemplateList
@@ -134,6 +135,7 @@ describe("small timetable components", () => {
         onCreate={onCreate}
         onEdit={onEdit}
         onApply={onApply}
+        onArchive={onArchive}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /serientermin/i }));
@@ -145,20 +147,24 @@ describe("small timetable components", () => {
         onCreate={onCreate}
         onEdit={onEdit}
         onApply={onApply}
+        onArchive={onArchive}
       />,
     );
 
     expect(screen.getByText("Yoga")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Bearbeiten" }));
+    fireEvent.click(screen.getByRole("button", { name: "Archivieren" }));
     fireEvent.click(screen.getByRole("button", { name: "Termine erzeugen" }));
 
     expect(onEdit).toHaveBeenCalledWith(template);
+    expect(onArchive).toHaveBeenCalledWith(template);
     expect(onApply).toHaveBeenCalledWith(template);
   });
 
   it("renders a standalone template card with fallback labels", () => {
     const onEdit = vi.fn();
     const onApply = vi.fn();
+    const onArchive = vi.fn();
 
     render(
       <TemplateCard
@@ -171,6 +177,7 @@ describe("small timetable components", () => {
         }}
         onEdit={onEdit}
         onApply={onApply}
+        onArchive={onArchive}
       />,
     );
 


### PR DESCRIPTION
## Summary
- add an archive action to recurring timetable template cards in the Serien view
- show a confirmation modal before archiving and refresh timetable/template caches after success
- improve the card footer layout and focus-visible states for desktop, tablet, and mobile

## Validation
- `cd frontend && pnpm test:run src/components/timetable/timetable-small-components.test.tsx 'src/app/[tenant]/(protected)/timetables/page.test.tsx' src/lib/timetable-api.test.ts`
- `cd frontend && pnpm run check`
- pre-push: `frontend-knip`, `frontend-check`, `git-secrets`
- agent-browser smoke test with demo tenant across desktop, tablet, and iPhone 14 viewports
