### PR TITLE
Scope announcements to recipient baseline

### DIFF
--- a/backend/database/repositories/platform/announcement_targeting_test.go
+++ b/backend/database/repositories/platform/announcement_targeting_test.go
@@ -118,6 +118,9 @@ func TestAnnouncementTargeting_GetUnreadForUser_GlobalVisibleToAll(t *testing.T)
 
 	operator := createTestOperator(t, db, "targeting-global@example.com", "Global Test")
 	accountID := createTestAccount(t, db, "user-global@example.com")
+	orgID := createTestOrganization(t, db, "Org Global Targeting")
+	schoolID := createTestSchool(t, db, "School Global Targeting", orgID)
+	createTestAccountTenant(t, db, accountID, schoolID)
 
 	// Create a global announcement (empty targeting)
 	announcement := &platformModels.Announcement{
@@ -138,12 +141,12 @@ func TestAnnouncementTargeting_GetUnreadForUser_GlobalVisibleToAll(t *testing.T)
 	defer cleanupTargetingTestData(t, db,
 		[]int64{announcement.ID},
 		[]int64{accountID},
-		nil, nil,
+		[]int64{schoolID}, []int64{orgID},
 	)
 	defer cleanupTestOperator(t, db, operator.ID)
 
-	// Any user should see this regardless of tenant/org
-	unread, err := viewRepo.GetUnreadForUser(ctx, accountID, []string{}, 999, 999)
+	// Global announcements are visible in a valid tenant context.
+	unread, err := viewRepo.GetUnreadForUser(ctx, accountID, []string{}, schoolID, orgID)
 	require.NoError(t, err)
 	assert.Len(t, unread, 1)
 	assert.Equal(t, announcement.ID, unread[0].ID)

--- a/backend/database/repositories/platform/announcement_view_internal_test.go
+++ b/backend/database/repositories/platform/announcement_view_internal_test.go
@@ -6,17 +6,17 @@ import (
 )
 
 func TestBuildUnreadArgs_CountMatchesPlaceholders(t *testing.T) {
-	// The full query used by GetUnreadForUser and CountUnread has one ? in the
-	// JOIN clause (v.user_id = ?) plus all ?'s in unreadWhereClause. The args
+	// The full query used by GetUnreadForUser and CountUnread has all ?'s in the
+	// shared FROM clause plus all ?'s in unreadWhereClause. The args
 	// returned by buildUnreadArgs must match that total exactly.
-	joinPlaceholders := 1 // LEFT JOIN ... ON ... AND v.user_id = ?
+	fromPlaceholders := strings.Count(unreadFromClause, "?")
 	wherePlaceholders := strings.Count(unreadWhereClause, "?")
-	expectedArgs := joinPlaceholders + wherePlaceholders
+	expectedArgs := fromPlaceholders + wherePlaceholders
 
 	args := buildUnreadArgs(1, []string{"user"}, 2, 3)
 
 	if len(args) != expectedArgs {
-		t.Errorf("buildUnreadArgs returned %d args, but query has %d placeholders (JOIN: %d + WHERE: %d)",
-			len(args), expectedArgs, joinPlaceholders, wherePlaceholders)
+		t.Errorf("buildUnreadArgs returned %d args, but query has %d placeholders (FROM: %d + WHERE: %d)",
+			len(args), expectedArgs, fromPlaceholders, wherePlaceholders)
 	}
 }

--- a/backend/database/repositories/platform/announcement_view_repository.go
+++ b/backend/database/repositories/platform/announcement_view_repository.go
@@ -83,19 +83,20 @@ func (r *AnnouncementViewRepository) MarkDismissed(ctx context.Context, userID, 
 	return nil
 }
 
-// buildUnreadArgs returns the fixed-size positional args shared by the JOIN + WHERE
+// buildUnreadArgs returns the fixed-size positional args shared by the FROM + WHERE
 // in the unread announcement query.
-// Arg order: userID (JOIN), now, now, pgArray(userRoles), userID (EXISTS), tenantID (EXISTS), tenantID (targeting), orgID (targeting) — 8 args.
+// Arg order: userID (account JOIN), tenantID (membership JOIN), orgID (school JOIN),
+// now, now, pgArray(userRoles) — 6 args.
 func buildUnreadArgs(userID int64, userRoles []string, tenantID int64, orgID int64) []any {
 	now := time.Now()
 	if userRoles == nil {
 		userRoles = []string{}
 	}
-	return []any{userID, now, now, pgdialect.Array(userRoles), userID, tenantID, tenantID, orgID}
+	return []any{userID, tenantID, orgID, now, now, pgdialect.Array(userRoles)}
 }
 
 // unreadWhereClause is the shared SQL fragment used by both GetUnreadForUser
-// and CountUnread. Arg positions are fixed (always 8 — see buildUnreadArgs).
+// and CountUnread. Arg positions are fixed (always 6 — see buildUnreadArgs).
 //
 // Role matching: a user matches if their JWT role names overlap with target_roles
 // (direct match) OR if any of their assigned roles in the current session tenant
@@ -108,22 +109,41 @@ const unreadWhereClause = `
 		AND a.published_at IS NOT NULL
 		AND a.published_at <= ?
 		AND (a.expires_at IS NULL OR a.expires_at > ?)
+		AND a.published_at >= GREATEST(
+			s.created_at,
+			COALESCE(at.invited_at, at.created_at),
+			acc.created_at
+		)
 		AND v.seen_at IS NULL
 		AND (a.target_roles = '{}'
 			OR a.target_roles && ?::text[]
 			OR EXISTS (
 				SELECT 1 FROM auth.account_roles ar
 				JOIN auth.roles r ON r.id = ar.role_id
-				WHERE ar.account_id = ?
-				AND ar.tenant_id = ?
+				WHERE ar.account_id = acc.id
+				AND ar.tenant_id = at.tenant_id
 				AND r.base_role IS NOT NULL
 				AND r.base_role = ANY(a.target_roles)
 			))
 		AND (
 			(a.target_org_ids = '{}' AND a.target_tenant_ids = '{}')
-			OR (a.target_tenant_ids != '{}' AND ? = ANY(a.target_tenant_ids))
-			OR (a.target_org_ids != '{}' AND ? = ANY(a.target_org_ids))
+			OR (a.target_tenant_ids != '{}' AND at.tenant_id = ANY(a.target_tenant_ids))
+			OR (a.target_org_ids != '{}' AND s.organization_id = ANY(a.target_org_ids))
 		)`
+
+const unreadFromClause = ` FROM platform.announcements a
+		JOIN auth.accounts acc
+			ON acc.id = ?
+		JOIN auth.account_tenants at
+			ON at.account_id = acc.id
+			AND at.tenant_id = ?
+			AND at.status = 'active'
+		JOIN platform.schools s
+			ON s.id = at.tenant_id
+			AND s.organization_id = ?
+			AND s.deleted_at IS NULL
+		LEFT JOIN platform.announcement_views v
+			ON v.announcement_id = a.id AND v.user_id = acc.id`
 
 // GetUnreadForUser retrieves all unread active announcements for a user scoped to the current session tenant/org.
 // Targeting logic uses OR-union: global / org match / tenant match.
@@ -131,10 +151,8 @@ func (r *AnnouncementViewRepository) GetUnreadForUser(ctx context.Context, userI
 	var announcements []*platform.Announcement
 	args := buildUnreadArgs(userID, userRoles, tenantID, orgID)
 
-	query := `SELECT a.*
-		FROM platform.announcements a
-		LEFT JOIN platform.announcement_views v
-			ON v.announcement_id = a.id AND v.user_id = ?` +
+	query := `SELECT a.*` +
+		unreadFromClause +
 		unreadWhereClause +
 		` ORDER BY a.published_at DESC`
 
@@ -153,10 +171,8 @@ func (r *AnnouncementViewRepository) GetUnreadForUser(ctx context.Context, userI
 func (r *AnnouncementViewRepository) CountUnread(ctx context.Context, userID int64, userRoles []string, tenantID int64, orgID int64) (int, error) {
 	args := buildUnreadArgs(userID, userRoles, tenantID, orgID)
 
-	query := `SELECT COUNT(*)
-		FROM platform.announcements a
-		LEFT JOIN platform.announcement_views v
-			ON v.announcement_id = a.id AND v.user_id = ?` +
+	query := `SELECT COUNT(*)` +
+		unreadFromClause +
 		unreadWhereClause
 
 	var count int
@@ -185,12 +201,14 @@ func (r *AnnouncementViewRepository) GetStats(ctx context.Context, announcementI
 		TargetRoles     []string `bun:"target_roles,array"`
 		TargetOrgIDs    []int64  `bun:"target_org_ids,array"`
 		TargetTenantIDs []int64  `bun:"target_tenant_ids,array"`
+		PublishedAt     *time.Time
 	}
 	err := base.GetDB(ctx, r.db).NewRaw(`
 		SELECT
 			COALESCE(target_roles, '{}'::text[]) AS target_roles,
 			COALESCE(target_org_ids, '{}'::bigint[]) AS target_org_ids,
-			COALESCE(target_tenant_ids, '{}'::bigint[]) AS target_tenant_ids
+			COALESCE(target_tenant_ids, '{}'::bigint[]) AS target_tenant_ids,
+			published_at
 		FROM platform.announcements WHERE id = ?
 	`, announcementID).Scan(ctx, &targeting)
 	if err != nil {
@@ -216,6 +234,7 @@ func (r *AnnouncementViewRepository) GetStats(ctx context.Context, announcementI
 	var queryArgs []any
 
 	queryParts = append(queryParts, `SELECT COUNT(DISTINCT at.account_id) FROM auth.account_tenants at`)
+	queryParts = append(queryParts, `JOIN auth.accounts acc ON acc.id = at.account_id AND acc.active = true`)
 
 	// Always join schools to exclude accounts linked to soft-deleted tenants,
 	// even for global announcements (consistent with targeted path).
@@ -228,6 +247,11 @@ func (r *AnnouncementViewRepository) GetStats(ctx context.Context, announcementI
 	}
 
 	queryParts = append(queryParts, `WHERE at.status = 'active'`)
+
+	if targeting.PublishedAt != nil {
+		queryParts = append(queryParts, `AND ? >= GREATEST(s.created_at, COALESCE(at.invited_at, at.created_at), acc.created_at)`)
+		queryArgs = append(queryArgs, *targeting.PublishedAt)
+	}
 
 	if hasRoleFilter {
 		queryParts = append(queryParts, `AND (r.name IN (?) OR (r.base_role IS NOT NULL AND r.base_role IN (?)))`)

--- a/backend/database/repositories/platform/announcement_view_repository_test.go
+++ b/backend/database/repositories/platform/announcement_view_repository_test.go
@@ -328,6 +328,42 @@ func publishTestAnnouncement(t *testing.T, db *bun.DB, announcementID int64) {
 	require.NoError(t, err)
 }
 
+func publishTestAnnouncementAt(t *testing.T, db *bun.DB, announcementID int64, publishedAt time.Time) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.NewRaw(`UPDATE platform.announcements SET published_at = ? WHERE id = ?`, publishedAt, announcementID).Exec(ctx)
+	require.NoError(t, err)
+}
+
+func setTestAccountCreatedAt(t *testing.T, db *bun.DB, accountID int64, createdAt time.Time) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.NewRaw(`UPDATE auth.accounts SET created_at = ? WHERE id = ?`, createdAt, accountID).Exec(ctx)
+	require.NoError(t, err)
+}
+
+func setTestSchoolCreatedAt(t *testing.T, db *bun.DB, schoolID int64, createdAt time.Time) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.NewRaw(`UPDATE platform.schools SET created_at = ? WHERE id = ?`, createdAt, schoolID).Exec(ctx)
+	require.NoError(t, err)
+}
+
+func setTestAccountTenantInvitedAt(t *testing.T, db *bun.DB, accountID, tenantID int64, invitedAt time.Time) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.NewRaw(`
+		UPDATE auth.account_tenants
+		SET invited_at = ?, created_at = ?
+		WHERE account_id = ? AND tenant_id = ?
+	`, invitedAt, invitedAt, accountID, tenantID).Exec(ctx)
+	require.NoError(t, err)
+}
+
 // expireTestAnnouncement sets expires_at to the past for the given announcement.
 func expireTestAnnouncement(t *testing.T, db *bun.DB, announcementID int64) {
 	t.Helper()
@@ -799,6 +835,140 @@ func TestAnnouncementViewRepository_GetUnreadForUser(t *testing.T) {
 	})
 }
 
+func TestAnnouncementViewRepository_RecipientBaseline(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	viewRepo := platform.NewAnnouncementViewRepository(db)
+
+	operator := createTestOperator(t, db, "baseline-op@test.com", "Baseline Op")
+	defer cleanupTestOperator(t, db, operator.ID)
+
+	orgID := createTestOrganization(t, db, "baseline-org")
+	defer cleanupTestOrganization(t, db, orgID)
+
+	schoolID := createTestSchool(t, db, "baseline-school", orgID)
+	defer cleanupTestSchool(t, db, schoolID)
+
+	accountID := createTestAccount(t, db, "baseline-user@test.com")
+	defer cleanupTestAccount(t, db, accountID)
+	createTestAccountTenant(t, db, accountID, schoolID)
+	defer cleanupTestAccountTenant(t, db, accountID, schoolID)
+
+	now := time.Now().UTC()
+	setTestAccountCreatedAt(t, db, accountID, now.Add(-6*time.Hour))
+	setTestAccountTenantInvitedAt(t, db, accountID, schoolID, now.Add(-5*time.Hour))
+	setTestSchoolCreatedAt(t, db, schoolID, now.Add(-4*time.Hour))
+
+	findAnnouncement := func(announcements []*platformModels.Announcement, id int64) bool {
+		for _, announcement := range announcements {
+			if announcement.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("global announcement before tenant creation is excluded", func(t *testing.T) {
+		annoID := createTestAnnouncementWithTargeting(t, db, "baseline-old-global", operator.ID, []string{}, []int64{}, []int64{})
+		defer cleanupTestAnnouncement(t, db, annoID)
+		publishTestAnnouncementAt(t, db, annoID, now.Add(-5*time.Hour))
+
+		results, err := viewRepo.GetUnreadForUser(ctx, accountID, []string{}, schoolID, orgID)
+		require.NoError(t, err)
+		assert.False(t, findAnnouncement(results, annoID), "announcement published before school creation should be excluded")
+	})
+
+	t.Run("global announcement after recipient baseline is visible", func(t *testing.T) {
+		annoID := createTestAnnouncementWithTargeting(t, db, "baseline-new-global", operator.ID, []string{}, []int64{}, []int64{})
+		defer cleanupTestAnnouncement(t, db, annoID)
+		publishTestAnnouncementAt(t, db, annoID, now.Add(-3*time.Hour))
+
+		results, err := viewRepo.GetUnreadForUser(ctx, accountID, []string{}, schoolID, orgID)
+		require.NoError(t, err)
+		assert.True(t, findAnnouncement(results, annoID), "announcement published after recipient baseline should be visible")
+	})
+
+	t.Run("tenant-targeted announcement before baseline is excluded", func(t *testing.T) {
+		annoID := createTestAnnouncementWithTargeting(t, db, "baseline-old-tenant", operator.ID, []string{}, []int64{}, []int64{schoolID})
+		defer cleanupTestAnnouncement(t, db, annoID)
+		publishTestAnnouncementAt(t, db, annoID, now.Add(-5*time.Hour))
+
+		results, err := viewRepo.GetUnreadForUser(ctx, accountID, []string{}, schoolID, orgID)
+		require.NoError(t, err)
+		assert.False(t, findAnnouncement(results, annoID), "explicit tenant targeting should still respect the recipient baseline")
+	})
+
+	t.Run("new employee does not see announcements from before tenant invitation", func(t *testing.T) {
+		newAccountID := createTestAccount(t, db, "baseline-new-employee@test.com")
+		defer cleanupTestAccount(t, db, newAccountID)
+		createTestAccountTenant(t, db, newAccountID, schoolID)
+		defer cleanupTestAccountTenant(t, db, newAccountID, schoolID)
+		setTestAccountCreatedAt(t, db, newAccountID, now.Add(-6*time.Hour))
+		setTestAccountTenantInvitedAt(t, db, newAccountID, schoolID, now.Add(-50*time.Minute))
+
+		oldAnnoID := createTestAnnouncementWithTargeting(t, db, "baseline-before-invite", operator.ID, []string{}, []int64{}, []int64{})
+		defer cleanupTestAnnouncement(t, db, oldAnnoID)
+		publishTestAnnouncementAt(t, db, oldAnnoID, now.Add(-2*time.Hour))
+
+		newAnnoID := createTestAnnouncementWithTargeting(t, db, "baseline-after-invite", operator.ID, []string{}, []int64{}, []int64{})
+		defer cleanupTestAnnouncement(t, db, newAnnoID)
+		publishTestAnnouncementAt(t, db, newAnnoID, now.Add(-30*time.Minute))
+
+		results, err := viewRepo.GetUnreadForUser(ctx, newAccountID, []string{}, schoolID, orgID)
+		require.NoError(t, err)
+		assert.False(t, findAnnouncement(results, oldAnnoID), "announcement before membership invitation should be excluded")
+		assert.True(t, findAnnouncement(results, newAnnoID), "announcement after membership invitation should be visible")
+	})
+
+	t.Run("account creation participates in the baseline", func(t *testing.T) {
+		newAccountID := createTestAccount(t, db, "baseline-new-account@test.com")
+		defer cleanupTestAccount(t, db, newAccountID)
+		createTestAccountTenant(t, db, newAccountID, schoolID)
+		defer cleanupTestAccountTenant(t, db, newAccountID, schoolID)
+		setTestAccountCreatedAt(t, db, newAccountID, now.Add(-30*time.Minute))
+		setTestAccountTenantInvitedAt(t, db, newAccountID, schoolID, now.Add(-3*time.Hour))
+
+		oldAnnoID := createTestAnnouncementWithTargeting(t, db, "baseline-before-account", operator.ID, []string{}, []int64{}, []int64{})
+		defer cleanupTestAnnouncement(t, db, oldAnnoID)
+		publishTestAnnouncementAt(t, db, oldAnnoID, now.Add(-1*time.Hour))
+
+		newAnnoID := createTestAnnouncementWithTargeting(t, db, "baseline-after-account", operator.ID, []string{}, []int64{}, []int64{})
+		defer cleanupTestAnnouncement(t, db, newAnnoID)
+		publishTestAnnouncementAt(t, db, newAnnoID, now.Add(-20*time.Minute))
+
+		results, err := viewRepo.GetUnreadForUser(ctx, newAccountID, []string{}, schoolID, orgID)
+		require.NoError(t, err)
+		assert.False(t, findAnnouncement(results, oldAnnoID), "announcement before account creation should be excluded")
+		assert.True(t, findAnnouncement(results, newAnnoID), "announcement after account creation should be visible")
+	})
+
+	t.Run("count unread uses the same baseline", func(t *testing.T) {
+		countAccountID := createTestAccount(t, db, "baseline-count@test.com")
+		defer cleanupTestAccount(t, db, countAccountID)
+		createTestAccountTenant(t, db, countAccountID, schoolID)
+		defer cleanupTestAccountTenant(t, db, countAccountID, schoolID)
+		setTestAccountCreatedAt(t, db, countAccountID, now.Add(-6*time.Hour))
+		setTestAccountTenantInvitedAt(t, db, countAccountID, schoolID, now.Add(-50*time.Minute))
+
+		baselineCount, err := viewRepo.CountUnread(ctx, countAccountID, []string{}, schoolID, orgID)
+		require.NoError(t, err)
+
+		oldAnnoID := createTestAnnouncementWithTargeting(t, db, "baseline-count-old", operator.ID, []string{}, []int64{}, []int64{})
+		defer cleanupTestAnnouncement(t, db, oldAnnoID)
+		publishTestAnnouncementAt(t, db, oldAnnoID, now.Add(-2*time.Hour))
+
+		newAnnoID := createTestAnnouncementWithTargeting(t, db, "baseline-count-new", operator.ID, []string{}, []int64{}, []int64{})
+		defer cleanupTestAnnouncement(t, db, newAnnoID)
+		publishTestAnnouncementAt(t, db, newAnnoID, now.Add(-30*time.Minute))
+
+		count, err := viewRepo.CountUnread(ctx, countAccountID, []string{}, schoolID, orgID)
+		require.NoError(t, err)
+		assert.Equal(t, baselineCount+1, count, "count should include only the announcement after recipient baseline")
+	})
+}
+
 // --- Test: CountUnread ---
 
 func TestAnnouncementViewRepository_CountUnread(t *testing.T) {
@@ -981,14 +1151,24 @@ func TestAnnouncementViewRepository_GetStats(t *testing.T) {
 	defer cleanupTestOperator(t, db, operator.ID)
 
 	t.Run("global announcement counts all accounts", func(t *testing.T) {
+		orgID := createTestOrganization(t, db, "stats-global-org")
+		defer cleanupTestOrganization(t, db, orgID)
+
+		schoolID := createTestSchool(t, db, "stats-global-school", orgID)
+		defer cleanupTestSchool(t, db, schoolID)
+
+		acc := createTestAccount(t, db, "stats-global-acc@test.com")
+		defer cleanupTestAccount(t, db, acc)
+		createTestAccountTenant(t, db, acc, schoolID)
+		defer cleanupTestAccountTenant(t, db, acc, schoolID)
+
 		annoID := createTestAnnouncementWithTargeting(t, db, "stats-global", operator.ID, []string{}, []int64{}, []int64{})
 		defer cleanupTestAnnouncement(t, db, annoID)
 
 		stats, err := viewRepo.GetStats(ctx, annoID)
 		require.NoError(t, err)
 		assert.Equal(t, annoID, stats.AnnouncementID)
-		// TargetCount should be > 0 (counts all accounts in the system)
-		assert.Greater(t, stats.TargetCount, 0, "global announcement should target at least some accounts")
+		assert.GreaterOrEqual(t, stats.TargetCount, 1, "global announcement should target at least the test account")
 		assert.Equal(t, 0, stats.SeenCount)
 		assert.Equal(t, 0, stats.DismissedCount)
 	})
@@ -1091,6 +1271,39 @@ func TestAnnouncementViewRepository_GetStats(t *testing.T) {
 		stats, err := viewRepo.GetStats(ctx, annoID)
 		require.NoError(t, err)
 		assert.Equal(t, 1, stats.TargetCount, "should count exactly 1 account in the tenant")
+	})
+
+	t.Run("published announcement target count respects recipient baseline", func(t *testing.T) {
+		now := time.Now().UTC()
+
+		orgID := createTestOrganization(t, db, "stats-baseline-org")
+		defer cleanupTestOrganization(t, db, orgID)
+
+		schoolID := createTestSchool(t, db, "stats-baseline-school", orgID)
+		defer cleanupTestSchool(t, db, schoolID)
+		setTestSchoolCreatedAt(t, db, schoolID, now.Add(-4*time.Hour))
+
+		beforePublish := createTestAccount(t, db, "stats-baseline-before@test.com")
+		defer cleanupTestAccount(t, db, beforePublish)
+		createTestAccountTenant(t, db, beforePublish, schoolID)
+		defer cleanupTestAccountTenant(t, db, beforePublish, schoolID)
+		setTestAccountCreatedAt(t, db, beforePublish, now.Add(-3*time.Hour))
+		setTestAccountTenantInvitedAt(t, db, beforePublish, schoolID, now.Add(-3*time.Hour))
+
+		afterPublish := createTestAccount(t, db, "stats-baseline-after@test.com")
+		defer cleanupTestAccount(t, db, afterPublish)
+		createTestAccountTenant(t, db, afterPublish, schoolID)
+		defer cleanupTestAccountTenant(t, db, afterPublish, schoolID)
+		setTestAccountCreatedAt(t, db, afterPublish, now.Add(-3*time.Hour))
+		setTestAccountTenantInvitedAt(t, db, afterPublish, schoolID, now.Add(-1*time.Hour))
+
+		annoID := createTestAnnouncementWithTargeting(t, db, "stats-baseline-target", operator.ID, []string{}, []int64{}, []int64{schoolID})
+		defer cleanupTestAnnouncement(t, db, annoID)
+		publishTestAnnouncementAt(t, db, annoID, now.Add(-2*time.Hour))
+
+		stats, err := viewRepo.GetStats(ctx, annoID)
+		require.NoError(t, err)
+		assert.Equal(t, 1, stats.TargetCount, "target count should exclude accounts invited after the announcement was published")
 	})
 
 	t.Run("combined role+org filter counts intersection", func(t *testing.T) {


### PR DESCRIPTION
## What changed

This PR changes how unread platform announcements are delivered.

A user now only sees an announcement when it was published after their current recipient context existed. That context is the latest of:

- the school/tenant creation time
- the user's invitation time for that tenant
- the account creation time

This prevents new tenants and newly invited staff from getting every old announcement that was still active.

## Why

Before this change, unread delivery only checked whether an announcement was active, published, targeted to the user, and not yet seen. New tenants and new staff had no announcement view records, so old announcements looked unread even if they were published months before the tenant or user existed.

## Behavior after this change

- A tenant created in March will not see global announcements published in January.
- A staff member invited in May will not see announcements published before that invitation.
- Announcements published after the tenant/user baseline still show normally.
- Drafts are handled correctly: we compare against `published_at`, not `created_at`.
- Explicit tenant-targeted announcements also respect the baseline.
- Operator announcement stats use the same baseline for target counts.

## Product tradeoff

This can hide some old unread announcements for existing migrated users if their stored tenant or membership dates are newer than the original announcement. That is acceptable for this change. The goal is to stop historical announcement spam for new tenants and users, not to preserve every legacy unread notification.

## Validation

- `cd backend && go test ./database/repositories/platform -run 'TestAnnouncementViewRepository_(RecipientBaseline|GetUnreadForUser|CountUnread|GetStats)|TestAnnouncementTargeting_'`
- `cd backend && go test ./test/ -run TestHermeticTestPatterns -v`
- `cd backend && go test ./services/platform -run 'TestAnnouncement'`
- `cd backend && go test ./api/platform ./api/operator -run 'Test.*Announcement'`
- Reset and migrated the test DB, then ran:
  `DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable APP_ENV=test go test ./database/repositories/platform ./services/platform ./api/platform ./api/operator`
