### PR TITLE
Add room bulk move

### DIFF
--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -595,8 +595,40 @@ func (s *service) UpdateVisit(ctx context.Context, visit *active.Visit) error {
 		return &ActiveError{Op: "UpdateVisit", Err: ErrInvalidData}
 	}
 
+	existing, err := s.visitRepo.FindByID(ctx, visit.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return &ActiveError{Op: "UpdateVisit", Err: ErrVisitNotFound}
+		}
+		return &ActiveError{Op: "UpdateVisit", Err: ErrDatabaseOperation}
+	}
+	if existing == nil {
+		return &ActiveError{Op: "UpdateVisit", Err: ErrVisitNotFound}
+	}
+
+	isActiveGroupMove := existing.ExitTime == nil && existing.ActiveGroupID != visit.ActiveGroupID
+	if isActiveGroupMove {
+		targetGroup, err := s.groupRepo.FindByID(ctx, visit.ActiveGroupID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return &ActiveError{Op: "UpdateVisit", Err: ErrActiveGroupNotFound}
+			}
+			return &ActiveError{Op: "UpdateVisit", Err: ErrDatabaseOperation}
+		}
+		if targetGroup == nil {
+			return &ActiveError{Op: "UpdateVisit", Err: ErrActiveGroupNotFound}
+		}
+		if !targetGroup.IsActive() {
+			return &ActiveError{Op: "UpdateVisit", Err: ErrActiveGroupNotFound}
+		}
+	}
+
 	if s.visitRepo.Update(ctx, visit) != nil {
 		return &ActiveError{Op: "UpdateVisit", Err: ErrDatabaseOperation}
+	}
+
+	if isActiveGroupMove {
+		s.broadcastVisitMoved(ctx, existing, visit)
 	}
 
 	return nil
@@ -735,6 +767,24 @@ func (s *service) broadcastVisitCheckout(ctx context.Context, endedVisit *active
 	// Notify all clients so dashboard counts refresh
 	_ = s.broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
 	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, studentID, activeSupervisionReasonStudentMoved)
+}
+
+// broadcastVisitMoved mirrors a room/session transfer as a checkout from the
+// source active group and a checkin into the target active group. Attendance is
+// not mutated here; the snapshot only enriches SSE payloads for clients that
+// display timetable attendance state alongside visit rows.
+func (s *service) broadcastVisitMoved(ctx context.Context, previousVisit, movedVisit *active.Visit) {
+	if s.broadcaster == nil || previousVisit == nil || movedVisit == nil {
+		return
+	}
+
+	var snapshot *AttendanceSnapshot
+	if s.attendanceSyncer != nil {
+		snapshot = s.attendanceSyncer.LoadAttendanceForVisit(ctx, movedVisit)
+	}
+
+	s.broadcastVisitCheckout(ctx, previousVisit, snapshot)
+	s.broadcastVisitCreated(ctx, movedVisit, snapshot)
 }
 
 // broadcastToEducationalGroup mirrors active-group broadcasts to the student's OGS group topic

--- a/backend/services/active/broadcast_test.go
+++ b/backend/services/active/broadcast_test.go
@@ -3,6 +3,7 @@ package active_test
 import (
 	"context"
 	"log/slog"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -24,7 +25,12 @@ type mockBroadcaster struct {
 	allCalls []realtime.Event
 }
 
-func (m *mockBroadcaster) BroadcastToGroup(_ int64, _ string, _ realtime.Event) error { return nil }
+func (m *mockBroadcaster) BroadcastToGroup(_ int64, _ string, event realtime.Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.allCalls = append(m.allCalls, event)
+	return nil
+}
 
 func (m *mockBroadcaster) BroadcastToAll(event realtime.Event) error {
 	m.mu.Lock()
@@ -55,6 +61,16 @@ func (m *mockBroadcaster) hasEventType(t realtime.EventType) bool {
 		}
 	}
 	return false
+}
+
+func (m *mockBroadcaster) eventsOfType(t realtime.EventType) []realtime.Event {
+	events := make([]realtime.Event, 0)
+	for _, e := range m.getAllCalls() {
+		if e.Type == t {
+			events = append(events, e)
+		}
+	}
+	return events
 }
 
 func setupServiceWithBroadcaster(t *testing.T) (active.Service, *mockBroadcaster) {
@@ -145,6 +161,70 @@ func TestBroadcast_EndVisitSendsDashboardCounts(t *testing.T) {
 		"expected dashboard_counts_changed after EndVisit")
 	assert.True(t, broadcaster.hasEventType(realtime.EventActiveSupervisionChanged),
 		"expected active_supervision_changed after EndVisit")
+}
+
+func TestBroadcast_UpdateVisitMoveSendsMovementEvents(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repos := repositories.NewFactory(db)
+	broadcaster := &mockBroadcaster{}
+	svc := active.NewService(active.ServiceDependencies{
+		GroupRepo:          repos.ActiveGroup,
+		VisitRepo:          repos.ActiveVisit,
+		SupervisorRepo:     repos.GroupSupervisor,
+		CombinedGroupRepo:  repos.CombinedGroup,
+		GroupMappingRepo:   repos.GroupMapping,
+		AttendanceRepo:     repos.Attendance,
+		StudentRepo:        repos.Student,
+		PersonRepo:         repos.Person,
+		TeacherRepo:        repos.Teacher,
+		StaffRepo:          repos.Staff,
+		RoomRepo:           repos.Room,
+		ActivityGroupRepo:  repos.ActivityGroup,
+		ActivityCatRepo:    repos.ActivityCategory,
+		EducationGroupRepo: repos.Group,
+		DeviceRepo:         repos.Device,
+		DB:                 db,
+		Broadcaster:        broadcaster,
+		Logger:             slog.Default(),
+	})
+
+	sourceActivity := testpkg.CreateTestActivityGroup(t, db, "broadcast-move-source")
+	targetActivity := testpkg.CreateTestActivityGroup(t, db, "broadcast-move-target")
+	sourceRoom := testpkg.CreateTestRoom(t, db, "Broadcast Move Source Room")
+	targetRoom := testpkg.CreateTestRoom(t, db, "Broadcast Move Target Room")
+	sourceGroup := testpkg.CreateTestActiveGroup(t, db, sourceActivity.ID, sourceRoom.ID)
+	targetGroup := testpkg.CreateTestActiveGroup(t, db, targetActivity.ID, targetRoom.ID)
+	student := testpkg.CreateTestStudent(t, db, "Broadcast", "Move", "4a")
+	visit := testpkg.CreateTestVisit(t, db, student.ID, sourceGroup.ID, time.Now(), nil)
+	defer testpkg.CleanupActivityFixtures(t, db,
+		sourceActivity.ID, targetActivity.ID,
+		sourceRoom.ID, targetRoom.ID,
+		sourceGroup.ID, targetGroup.ID,
+		student.ID, visit.ID,
+	)
+
+	broadcaster.mu.Lock()
+	broadcaster.allCalls = nil
+	broadcaster.mu.Unlock()
+
+	visit.ActiveGroupID = targetGroup.ID
+	err := svc.UpdateVisit(testpkg.TenantContext(1), visit)
+	require.NoError(t, err)
+
+	checkouts := broadcaster.eventsOfType(realtime.EventStudentCheckOut)
+	require.NotEmpty(t, checkouts, "expected student_checkout for source group")
+	assert.Equal(t, strconv.FormatInt(sourceGroup.ID, 10), checkouts[0].ActiveGroupID)
+
+	checkins := broadcaster.eventsOfType(realtime.EventStudentCheckIn)
+	require.NotEmpty(t, checkins, "expected student_checkin for target group")
+	assert.Equal(t, strconv.FormatInt(targetGroup.ID, 10), checkins[0].ActiveGroupID)
+
+	assert.True(t, broadcaster.hasEventType(realtime.EventDashboardCountsChanged),
+		"expected dashboard_counts_changed after visit move")
+	assert.True(t, broadcaster.hasEventType(realtime.EventActiveSupervisionChanged),
+		"expected active_supervision_changed after visit move")
 }
 
 func TestBroadcast_EndActivitySessionSendsDashboardCounts(t *testing.T) {

--- a/backend/services/active/end_session_unit_test.go
+++ b/backend/services/active/end_session_unit_test.go
@@ -142,6 +142,8 @@ func (m *mockGroupRepository) EndSessionsByIDs(ctx context.Context, ids []int64)
 // mockVisitRepository is a minimal mock implementation of active.VisitRepository
 type mockVisitRepository struct {
 	findByActiveGroupIDFunc           func(ctx context.Context, activeGroupID int64) ([]*active.Visit, error)
+	findByIDFunc                      func(ctx context.Context, id interface{}) (*active.Visit, error)
+	updateFunc                        func(ctx context.Context, entity *active.Visit) error
 	endVisitFunc                      func(ctx context.Context, id int64) error
 	getCurrentByStudentIDFunc         func(ctx context.Context, studentID int64) (*active.Visit, error)
 	getCurrentByStudentIDWithRoomFunc func(ctx context.Context, studentID int64) (*active.Visit, error)
@@ -156,10 +158,16 @@ func (m *mockVisitRepository) Create(ctx context.Context, entity *active.Visit) 
 }
 
 func (m *mockVisitRepository) FindByID(ctx context.Context, id interface{}) (*active.Visit, error) {
+	if m.findByIDFunc != nil {
+		return m.findByIDFunc(ctx, id)
+	}
 	return nil, nil
 }
 
 func (m *mockVisitRepository) Update(ctx context.Context, entity *active.Visit) error {
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, entity)
+	}
 	return nil
 }
 

--- a/backend/services/active/update_visit_mock_test.go
+++ b/backend/services/active/update_visit_mock_test.go
@@ -1,0 +1,178 @@
+package active
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateVisitPreloadAndTargetLookupErrors(t *testing.T) {
+	ctx := context.Background()
+	entryTime := time.Now()
+	existingVisit := &activeModels.Visit{
+		Model:         base.Model{ID: 100},
+		StudentID:     200,
+		ActiveGroupID: 300,
+		EntryTime:     entryTime,
+	}
+	updatedVisit := &activeModels.Visit{
+		Model:         base.Model{ID: existingVisit.ID},
+		StudentID:     existingVisit.StudentID,
+		ActiveGroupID: 400,
+		EntryTime:     entryTime,
+	}
+
+	t.Run("returns visit not found when preload misses", func(t *testing.T) {
+		svc := &service{
+			visitRepo: &mockVisitRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Visit, error) {
+					return nil, sql.ErrNoRows
+				},
+			},
+		}
+
+		err := svc.UpdateVisit(ctx, updatedVisit)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVisitNotFound), "expected ErrVisitNotFound")
+	})
+
+	t.Run("returns visit not found when preload returns nil without error", func(t *testing.T) {
+		svc := &service{
+			visitRepo: &mockVisitRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Visit, error) {
+					return nil, nil
+				},
+			},
+		}
+
+		err := svc.UpdateVisit(ctx, updatedVisit)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVisitNotFound), "expected ErrVisitNotFound")
+	})
+
+	t.Run("returns active group not found when target lookup misses", func(t *testing.T) {
+		svc := &service{
+			visitRepo: &mockVisitRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Visit, error) {
+					return existingVisit, nil
+				},
+			},
+			groupRepo: &mockGroupRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+					return nil, sql.ErrNoRows
+				},
+			},
+		}
+
+		err := svc.UpdateVisit(ctx, updatedVisit)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrActiveGroupNotFound), "expected ErrActiveGroupNotFound")
+	})
+
+	t.Run("preserves database errors from target lookup", func(t *testing.T) {
+		lookupErr := errors.New("target lookup failed")
+		svc := &service{
+			visitRepo: &mockVisitRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Visit, error) {
+					return existingVisit, nil
+				},
+			},
+			groupRepo: &mockGroupRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+					return nil, lookupErr
+				},
+			},
+		}
+
+		err := svc.UpdateVisit(ctx, updatedVisit)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrDatabaseOperation), "expected ErrDatabaseOperation")
+	})
+
+	t.Run("returns active group not found when target lookup returns nil without error", func(t *testing.T) {
+		svc := &service{
+			visitRepo: &mockVisitRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Visit, error) {
+					return existingVisit, nil
+				},
+			},
+			groupRepo: &mockGroupRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+					return nil, nil
+				},
+			},
+		}
+
+		err := svc.UpdateVisit(ctx, updatedVisit)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrActiveGroupNotFound), "expected ErrActiveGroupNotFound")
+	})
+
+	t.Run("returns active group not found when target group is inactive", func(t *testing.T) {
+		endTime := entryTime.Add(time.Hour)
+		svc := &service{
+			visitRepo: &mockVisitRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Visit, error) {
+					return existingVisit, nil
+				},
+			},
+			groupRepo: &mockGroupRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+					return &activeModels.Group{
+						Model:   base.Model{ID: updatedVisit.ActiveGroupID},
+						EndTime: &endTime,
+					}, nil
+				},
+			},
+		}
+
+		err := svc.UpdateVisit(ctx, updatedVisit)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrActiveGroupNotFound), "expected ErrActiveGroupNotFound")
+	})
+
+	t.Run("updates without target lookup when active group does not change", func(t *testing.T) {
+		updateCalled := false
+		sameGroupVisit := &activeModels.Visit{
+			Model:         base.Model{ID: existingVisit.ID},
+			StudentID:     existingVisit.StudentID,
+			ActiveGroupID: existingVisit.ActiveGroupID,
+			EntryTime:     entryTime,
+		}
+		svc := &service{
+			visitRepo: &mockVisitRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Visit, error) {
+					return existingVisit, nil
+				},
+				updateFunc: func(context.Context, *activeModels.Visit) error {
+					updateCalled = true
+					return nil
+				},
+			},
+			groupRepo: &mockGroupRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+					t.Fatal("target group should not be loaded when active group is unchanged")
+					return nil, nil
+				},
+			},
+		}
+
+		err := svc.UpdateVisit(ctx, sameGroupVisit)
+
+		require.NoError(t, err)
+		assert.True(t, updateCalled, "expected visit update")
+	})
+}

--- a/backend/services/active/visit_service_test.go
+++ b/backend/services/active/visit_service_test.go
@@ -231,6 +231,26 @@ func TestActiveService_UpdateVisit(t *testing.T) {
 		// ASSERT
 		require.Error(t, err)
 	})
+
+	t.Run("preserves database errors while preloading visit", func(t *testing.T) {
+		// ARRANGE
+		failingDB := testpkg.SetupTestDB(t)
+		serviceWithClosedDB := setupActiveService(t, failingDB)
+		require.NoError(t, failingDB.Close())
+		visit := &activeModels.Visit{
+			StudentID:     99999998,
+			ActiveGroupID: 99999997,
+			EntryTime:     time.Now(),
+		}
+		visit.ID = 99999999
+
+		// ACT
+		err := serviceWithClosedDB.UpdateVisit(ctx, visit)
+
+		// ASSERT
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, active.ErrDatabaseOperation), "expected ErrDatabaseOperation")
+	})
 }
 
 // =============================================================================

--- a/frontend/src/components/rooms/students-in-room-section.test.tsx
+++ b/frontend/src/components/rooms/students-in-room-section.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { StudentsInRoomSection } from "./students-in-room-section";
 
@@ -6,22 +6,48 @@ import { StudentsInRoomSection } from "./students-in-room-section";
 // Mocks
 // ----------------------------------------------------------------------------
 
-const mockPush = vi.fn();
+const {
+  mockPush,
+  mockUseSearchParams,
+  mockUseSWRAuth,
+  mockUseTenantMutateMatching,
+  mockGetStudentCurrentVisit,
+  mockUpdateVisit,
+  mockGetActiveGroups,
+} = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockUseSearchParams: vi.fn(() => ({
+    get: vi.fn(() => null),
+    toString: vi.fn(() => "room=42"),
+  })),
+  mockUseSWRAuth: vi.fn(),
+  mockUseTenantMutateMatching: vi.fn(),
+  mockGetStudentCurrentVisit: vi.fn(),
+  mockUpdateVisit: vi.fn(),
+  mockGetActiveGroups: vi.fn(),
+}));
+
 vi.mock("~/lib/tenant-router", () => ({
   useTenantRouter: () => ({ push: mockPush }),
 }));
 
-const mockUseSearchParams = vi.fn(() => ({
-  get: vi.fn(() => null),
-  toString: vi.fn(() => "room=42"),
-}));
 vi.mock("next/navigation", () => ({
   useSearchParams: () => mockUseSearchParams(),
 }));
 
-const mockUseSWRAuth = vi.fn();
 vi.mock("~/lib/swr", () => ({
   useSWRAuth: (...args: unknown[]) => mockUseSWRAuth(...args),
+  useTenantMutateMatching: (...args: unknown[]) =>
+    mockUseTenantMutateMatching(...args),
+}));
+
+vi.mock("~/lib/active-service", () => ({
+  activeService: {
+    getActiveGroups: (...args: unknown[]) => mockGetActiveGroups(...args),
+    getStudentCurrentVisit: (...args: unknown[]) =>
+      mockGetStudentCurrentVisit(...args),
+    updateVisit: (...args: unknown[]) => mockUpdateVisit(...args),
+  },
 }));
 
 // Light mocks for visual primitives — we want to assert behaviors (text,
@@ -97,6 +123,17 @@ interface MockStudent {
   group_name?: string;
 }
 
+interface MockActiveGroup {
+  id: string;
+  roomId: string;
+  isActive: boolean;
+}
+
+interface MockRoom {
+  id: string;
+  name: string;
+}
+
 const makeStudent = (overrides: Partial<MockStudent> = {}): MockStudent => ({
   id: "1",
   first_name: "Anna",
@@ -106,24 +143,72 @@ const makeStudent = (overrides: Partial<MockStudent> = {}): MockStudent => ({
   ...overrides,
 });
 
-const setSWR = (state: {
+let roomStudentsState: {
   data?: {
     students: MockStudent[];
     pagination?: { total_records: number };
   };
   error?: unknown;
   isLoading?: boolean;
-}) => {
-  mockUseSWRAuth.mockReturnValue({
-    data: state.data,
-    error: state.error ?? null,
-    isLoading: state.isLoading ?? false,
-  });
+};
+let activeGroupsState: { data: MockActiveGroup[] };
+let roomsState: { data: MockRoom[] };
+
+const setSWR = (state: typeof roomStudentsState) => {
+  roomStudentsState = state;
+};
+
+const setBulkData = ({
+  activeGroups = [
+    { id: "900", roomId: "9000", isActive: true },
+    { id: "901", roomId: "9001", isActive: true },
+  ],
+  rooms = [
+    { id: "9000", name: "Raum 6" },
+    { id: "9001", name: "Atelier" },
+  ],
+}: {
+  activeGroups?: MockActiveGroup[];
+  rooms?: MockRoom[];
+} = {}) => {
+  activeGroupsState = { data: activeGroups };
+  roomsState = { data: rooms };
 };
 
 beforeEach(() => {
   mockPush.mockReset();
   mockUseSWRAuth.mockReset();
+  mockUseTenantMutateMatching.mockReset();
+  mockGetStudentCurrentVisit.mockReset();
+  mockUpdateVisit.mockReset();
+  mockGetActiveGroups.mockReset();
+  mockUseTenantMutateMatching.mockReturnValue(vi.fn());
+  setSWR({ data: { students: [] } });
+  setBulkData();
+  mockUseSWRAuth.mockImplementation((key: string) => {
+    if (key.startsWith("room-students-")) {
+      return {
+        data: roomStudentsState.data,
+        error: roomStudentsState.error ?? null,
+        isLoading: roomStudentsState.isLoading ?? false,
+      };
+    }
+    if (key === "room-bulk-active-groups") {
+      return {
+        data: activeGroupsState.data,
+        error: null,
+        isLoading: false,
+      };
+    }
+    if (key === "room-bulk-rooms") {
+      return {
+        data: roomsState.data,
+        error: null,
+        isLoading: false,
+      };
+    }
+    return { data: undefined, error: null, isLoading: false };
+  });
 });
 
 // ----------------------------------------------------------------------------
@@ -330,6 +415,128 @@ describe("StudentsInRoomSection", () => {
       render(<StudentsInRoomSection roomId="42" roomName="OGS-Raum 1" />);
 
       expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("bulk room move", () => {
+    it("selects multiple children and moves their current visits to the selected room", async () => {
+      const refreshCaches = vi.fn().mockResolvedValue(undefined);
+      mockUseTenantMutateMatching.mockReturnValue(refreshCaches);
+      setSWR({
+        data: {
+          students: [
+            makeStudent({ id: "7", first_name: "Anna" }),
+            makeStudent({ id: "8", first_name: "Ben", second_name: "Schulz" }),
+          ],
+        },
+      });
+      mockGetStudentCurrentVisit.mockImplementation((studentId: string) =>
+        Promise.resolve({
+          id: `visit-${studentId}`,
+          studentId,
+          activeGroupId: "current-group",
+          checkInTime: new Date("2026-05-14T08:00:00.000Z"),
+          isActive: true,
+          createdAt: new Date("2026-05-14T08:00:00.000Z"),
+          updatedAt: new Date("2026-05-14T08:00:00.000Z"),
+        }),
+      );
+      mockUpdateVisit.mockResolvedValue({});
+
+      render(<StudentsInRoomSection roomId="42" roomName="OGS-Raum 1" />);
+
+      expect(mockUseTenantMutateMatching).toHaveBeenCalledWith(
+        expect.arrayContaining(["rooms-list"]),
+      );
+      fireEvent.click(
+        screen.getByRole("checkbox", { name: /Anna Müller auswählen/ }),
+      );
+      fireEvent.click(
+        screen.getByRole("checkbox", { name: /Ben Schulz auswählen/ }),
+      );
+      fireEvent.change(screen.getByLabelText("Zielraum"), {
+        target: { value: "900" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "In Raum setzen" }));
+
+      await waitFor(() => {
+        expect(mockUpdateVisit).toHaveBeenCalledTimes(2);
+      });
+      expect(mockGetStudentCurrentVisit).toHaveBeenCalledWith("7");
+      expect(mockGetStudentCurrentVisit).toHaveBeenCalledWith("8");
+      expect(mockUpdateVisit).toHaveBeenCalledWith(
+        "visit-7",
+        expect.objectContaining({ activeGroupId: "900", studentId: "7" }),
+      );
+      expect(mockUpdateVisit).toHaveBeenCalledWith(
+        "visit-8",
+        expect.objectContaining({ activeGroupId: "900", studentId: "8" }),
+      );
+      expect(refreshCaches).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "2 Kinder nach Raum 6 bewegt.",
+      );
+    });
+
+    it("keeps the move action disabled when no target room is selected", () => {
+      setSWR({ data: { students: [makeStudent({ id: "7" })] } });
+
+      render(<StudentsInRoomSection roomId="42" roomName="OGS-Raum 1" />);
+
+      fireEvent.click(
+        screen.getByRole("checkbox", { name: /Anna Müller auswählen/ }),
+      );
+
+      expect(mockGetStudentCurrentVisit).not.toHaveBeenCalled();
+      expect(mockUpdateVisit).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole("button", { name: "In Raum setzen" }),
+      ).toBeDisabled();
+    });
+
+    it("excludes the current room from the target room list", () => {
+      setSWR({ data: { students: [makeStudent({ id: "7" })] } });
+      setBulkData({
+        activeGroups: [
+          { id: "current", roomId: "42", isActive: true },
+          { id: "target", roomId: "9000", isActive: true },
+        ],
+        rooms: [
+          { id: "42", name: "OGS-Raum 1" },
+          { id: "9000", name: "Raum 6" },
+        ],
+      });
+
+      render(<StudentsInRoomSection roomId="42" roomName="OGS-Raum 1" />);
+
+      expect(screen.queryByRole("option", { name: "OGS-Raum 1" })).toBeNull();
+      expect(
+        screen.getByRole("option", { name: "Raum 6" }),
+      ).toBeInTheDocument();
+    });
+
+    it("excludes rooms with multiple active sessions from the target room list", () => {
+      setSWR({ data: { students: [makeStudent({ id: "7" })] } });
+      setBulkData({
+        activeGroups: [
+          { id: "first", roomId: "9000", isActive: true },
+          { id: "second", roomId: "9000", isActive: true },
+          { id: "single", roomId: "9001", isActive: true },
+        ],
+        rooms: [
+          { id: "9000", name: "Raum mit Konflikt" },
+          { id: "9001", name: "Raum 6" },
+        ],
+      });
+
+      render(<StudentsInRoomSection roomId="42" roomName="OGS-Raum 1" />);
+
+      expect(
+        screen.queryByRole("option", { name: "Raum mit Konflikt" }),
+      ).toBeNull();
+      expect(
+        screen.getByRole("option", { name: "Raum 6" }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/rooms/students-in-room-section.tsx
+++ b/frontend/src/components/rooms/students-in-room-section.tsx
@@ -14,17 +14,25 @@
 
 "use client";
 
+import { useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useTenantRouter } from "~/lib/tenant-router";
-import { useSWRAuth } from "~/lib/swr";
+import { useSWRAuth, useTenantMutateMatching } from "~/lib/swr";
+import { ROOM_LIST_CACHE_KEYS } from "~/lib/swr/room-derived-caches";
 import { Alert } from "~/components/ui/alert";
-import { studentService } from "~/lib/api";
+import { Button } from "~/components/ui/button";
+import { DatabaseSelect } from "~/components/ui/database/database-select";
+import { roomService, studentService } from "~/lib/api";
 import type { Student } from "~/lib/api";
+import { activeService } from "~/lib/active-service";
+import type { ActiveGroup } from "~/lib/active-helpers";
+import type { Room } from "~/lib/room-helpers";
 import { CompactStudentCard } from "~/components/students/compact-student-card";
 import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "StudentsInRoomSection" });
+const EMPTY_STUDENTS: Student[] = [];
 
 interface StudentsInRoomSectionProps {
   readonly roomId: string;
@@ -36,6 +44,23 @@ export function StudentsInRoomSection({
   roomName,
 }: StudentsInRoomSectionProps) {
   const router = useTenantRouter();
+  const refreshRoomConsumers = useTenantMutateMatching([
+    "room-students-",
+    "room-detail-",
+    ...ROOM_LIST_CACHE_KEYS,
+    "search-students-",
+    "database-students-list",
+  ]);
+  const [selectedStudentIds, setSelectedStudentIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [targetActiveGroupId, setTargetActiveGroupId] = useState("");
+  const [bulkMoveState, setBulkMoveState] = useState<
+    | { type: "idle" }
+    | { type: "loading" }
+    | { type: "success"; movedCount: number; roomName: string }
+    | { type: "error"; message: string }
+  >({ type: "idle" });
   const sectionSearchParams = useSearchParams();
   // Drilling into a child must return to the same /rooms grid state the
   // user came from. Preserve the full query string (room=… AND any
@@ -59,6 +84,13 @@ export function StudentsInRoomSection({
       pageSize: 200,
     }),
   );
+  const { data: activeGroups = [] } = useSWRAuth<ActiveGroup[]>(
+    "room-bulk-active-groups",
+    () => activeService.getActiveGroups({ active: true }),
+  );
+  const { data: rooms = [] } = useSWRAuth<Room[]>("room-bulk-rooms", () =>
+    roomService.getRooms(),
+  );
 
   if (error) {
     logger.warn("students_in_room_load_failed", {
@@ -67,7 +99,21 @@ export function StudentsInRoomSection({
     });
   }
 
-  const students = data?.students ?? [];
+  const students = data?.students ?? EMPTY_STUDENTS;
+  const visibleStudentIds = useMemo(
+    () => new Set(students.map((student) => String(student.id))),
+    [students],
+  );
+  const selectedVisibleCount = [...selectedStudentIds].filter((studentId) =>
+    visibleStudentIds.has(studentId),
+  ).length;
+  const targetOptions = useMemo(
+    () => buildTargetRoomOptions(activeGroups, rooms, roomId),
+    [activeGroups, rooms, roomId],
+  );
+  const selectedTarget = targetOptions.find(
+    (option) => option.activeGroupId === targetActiveGroupId,
+  );
   // Prefer the server's authoritative count so the badge stays honest even
   // if pagination ever truncates the response. Fall back to length only
   // when pagination metadata is missing.
@@ -85,6 +131,93 @@ export function StudentsInRoomSection({
       room_name: roomName,
     }).toString();
     router.push(`/students/search?${qs}`);
+  };
+
+  const clearSelection = () => {
+    setSelectedStudentIds(new Set());
+    setBulkMoveState({ type: "idle" });
+  };
+
+  const toggleStudentSelection = (studentId: string) => {
+    setSelectedStudentIds((current) => {
+      const next = new Set(current);
+      if (next.has(studentId)) {
+        next.delete(studentId);
+      } else {
+        next.add(studentId);
+      }
+      return next;
+    });
+    setBulkMoveState({ type: "idle" });
+  };
+
+  const selectAllVisible = () => {
+    setSelectedStudentIds(
+      new Set(students.map((student) => String(student.id))),
+    );
+    setBulkMoveState({ type: "idle" });
+  };
+
+  const moveSelectedStudents = async () => {
+    const target = selectedTarget;
+    if (!target) {
+      setBulkMoveState({
+        type: "error",
+        message: "Bitte wähle zuerst einen Zielraum aus.",
+      });
+      return;
+    }
+
+    const studentIds = [...selectedStudentIds].filter((studentId) =>
+      visibleStudentIds.has(studentId),
+    );
+    if (studentIds.length === 0) {
+      setBulkMoveState({
+        type: "error",
+        message: "Bitte wähle mindestens ein Kind aus.",
+      });
+      return;
+    }
+
+    setBulkMoveState({ type: "loading" });
+    const results = await Promise.allSettled(
+      studentIds.map(async (studentId) => {
+        const visit = await activeService.getStudentCurrentVisit(studentId);
+        if (!visit) {
+          throw new Error(`Kind ${studentId} hat keinen aktiven Besuch.`);
+        }
+        if (visit.activeGroupId === target.activeGroupId) {
+          return;
+        }
+        await activeService.updateVisit(visit.id, {
+          ...visit,
+          activeGroupId: target.activeGroupId,
+        });
+      }),
+    );
+    const failures = results.filter((result) => result.status === "rejected");
+    if (failures.length > 0) {
+      logger.warn("room_bulk_move_partial_failure", {
+        selected_count: studentIds.length,
+        failed_count: failures.length,
+        target_active_group_id: target.activeGroupId,
+      });
+      setBulkMoveState({
+        type: "error",
+        message: `${failures.length} von ${studentIds.length} Kindern konnten nicht bewegt werden.`,
+      });
+      await refreshRoomConsumers();
+      return;
+    }
+
+    setSelectedStudentIds(new Set());
+    setTargetActiveGroupId("");
+    setBulkMoveState({
+      type: "success",
+      movedCount: studentIds.length,
+      roomName: target.roomName,
+    });
+    await refreshRoomConsumers();
   };
 
   return (
@@ -146,15 +279,175 @@ export function StudentsInRoomSection({
           the first student card. Without it the button bottom edge sits
           flush with the first card border. Review feedback (#1323). */}
       <div className="mt-4">
+        {students.length > 0 ? (
+          <BulkMoveToolbar
+            selectedCount={selectedVisibleCount}
+            totalCount={students.length}
+            targetActiveGroupId={targetActiveGroupId}
+            targetOptions={targetOptions}
+            state={bulkMoveState}
+            onSelectAll={selectAllVisible}
+            onClearSelection={clearSelection}
+            onTargetChange={(value) => {
+              setTargetActiveGroupId(value);
+              setBulkMoveState({ type: "idle" });
+            }}
+            onMoveSelected={moveSelectedStudents}
+          />
+        ) : null}
         <StudentsInRoomBody
           fromReferrer={fromReferrer}
           loading={isLoading}
           hasError={!!error}
           students={students}
+          selectedStudentIds={selectedStudentIds}
+          onToggleStudentSelection={toggleStudentSelection}
           router={router}
         />
       </div>
     </section>
+  );
+}
+
+interface TargetRoomOption {
+  readonly activeGroupId: string;
+  readonly roomId: string;
+  readonly roomName: string;
+}
+
+function buildTargetRoomOptions(
+  activeGroups: readonly ActiveGroup[],
+  rooms: readonly Room[],
+  currentRoomId: string,
+): TargetRoomOption[] {
+  const roomsById = new Map(rooms.map((room) => [room.id, room]));
+  const groupsByRoomId = new Map<string, ActiveGroup[]>();
+
+  activeGroups.forEach((group) => {
+    if (!group.isActive || group.roomId === currentRoomId) return;
+    const groupsInRoom = groupsByRoomId.get(group.roomId) ?? [];
+    groupsInRoom.push(group);
+    groupsByRoomId.set(group.roomId, groupsInRoom);
+  });
+
+  return [...groupsByRoomId.entries()]
+    .flatMap(([targetRoomId, groups]) => {
+      const activeGroup = groups.length === 1 ? groups[0] : undefined;
+      if (!activeGroup) return [];
+      const room = roomsById.get(targetRoomId);
+      return [
+        {
+          activeGroupId: activeGroup.id,
+          roomId: targetRoomId,
+          roomName: room?.name ?? `Raum ${targetRoomId}`,
+        },
+      ];
+    })
+    .sort((a, b) => a.roomName.localeCompare(b.roomName, "de"));
+}
+
+interface BulkMoveToolbarProps {
+  readonly selectedCount: number;
+  readonly totalCount: number;
+  readonly targetActiveGroupId: string;
+  readonly targetOptions: readonly TargetRoomOption[];
+  readonly state:
+    | { type: "idle" }
+    | { type: "loading" }
+    | { type: "success"; movedCount: number; roomName: string }
+    | { type: "error"; message: string };
+  readonly onSelectAll: () => void;
+  readonly onClearSelection: () => void;
+  readonly onTargetChange: (value: string) => void;
+  readonly onMoveSelected: () => void;
+}
+
+function BulkMoveToolbar({
+  selectedCount,
+  totalCount,
+  targetActiveGroupId,
+  targetOptions,
+  state,
+  onSelectAll,
+  onClearSelection,
+  onTargetChange,
+  onMoveSelected,
+}: BulkMoveToolbarProps) {
+  const isMoving = state.type === "loading";
+  const canMove =
+    selectedCount > 0 && targetActiveGroupId.length > 0 && !isMoving;
+  const allSelected = selectedCount === totalCount;
+
+  return (
+    <div className="mb-4 rounded-xl border border-gray-200 bg-gray-50/70 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="min-w-0 text-sm font-semibold text-gray-900">
+          <span className="block truncate">
+            {selectedCount > 0
+              ? `${selectedCount} von ${totalCount} ausgewählt`
+              : "Kinder auswählen"}
+          </span>
+          <span className="block text-xs font-medium text-gray-500">
+            Zielraum wählen und gemeinsam verschieben
+          </span>
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={allSelected ? onClearSelection : onSelectAll}
+          className="shrink-0 px-3 py-2 text-sm shadow-none"
+        >
+          {allSelected ? "Aufheben" : "Alle"}
+        </Button>
+      </div>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+        <DatabaseSelect
+          id="room-bulk-target"
+          name="room-bulk-target"
+          label="Zielraum"
+          value={targetActiveGroupId}
+          onChange={onTargetChange}
+          disabled={targetOptions.length === 0 || isMoving}
+          placeholder={
+            targetOptions.length === 0
+              ? "Kein aktiver Zielraum verfügbar"
+              : "Zielraum wählen"
+          }
+          options={targetOptions.map((option) => ({
+            value: option.activeGroupId,
+            label: option.roomName,
+          }))}
+          focusRingColor="focus:ring-[#5080D8]"
+          className="bg-white text-sm md:text-sm"
+        />
+        <Button
+          type="button"
+          variant="success"
+          size="sm"
+          isLoading={isMoving}
+          loadingText="Bewege..."
+          onClick={onMoveSelected}
+          disabled={!canMove}
+          className="min-h-10 w-full bg-[#83CD2D] px-4 py-2.5 text-sm shadow-sm hover:bg-[#74b827] active:bg-[#669f21] disabled:bg-gray-200 disabled:text-gray-500 sm:w-auto"
+        >
+          In Raum setzen
+        </Button>
+      </div>
+
+      {state.type === "success" ? (
+        <p role="status" className="mt-2 text-sm text-[#4a7a15]">
+          {state.movedCount} {state.movedCount === 1 ? "Kind" : "Kinder"} nach{" "}
+          {state.roomName} bewegt.
+        </p>
+      ) : null}
+      {state.type === "error" ? (
+        <p role="alert" className="mt-2 text-sm text-[#FF3130]">
+          {state.message}
+        </p>
+      ) : null}
+    </div>
   );
 }
 
@@ -163,6 +456,8 @@ interface StudentsInRoomBodyProps {
   readonly loading: boolean;
   readonly hasError: boolean;
   readonly students: readonly Student[];
+  readonly selectedStudentIds: ReadonlySet<string>;
+  readonly onToggleStudentSelection: (studentId: string) => void;
   readonly router: ReturnType<typeof useTenantRouter>;
 }
 
@@ -193,6 +488,8 @@ function StudentsInRoomBody({
   loading,
   hasError,
   students,
+  selectedStudentIds,
+  onToggleStudentSelection,
   router,
 }: StudentsInRoomBodyProps) {
   const { enabled: photosEnabled } = useStudentPhotosEnabled();
@@ -246,21 +543,63 @@ function StudentsInRoomBody({
     // below useful tap-target size on touch.
     <div className="flex flex-col gap-2">
       {students.map((student) => (
-        <CompactStudentCard
+        <SelectableStudentRow
           key={student.id}
-          studentId={student.id}
-          firstName={student.first_name}
-          lastName={student.second_name}
-          schoolClass={student.school_class}
-          groupName={student.group_name ?? undefined}
-          photoUrl={student.photo_url ?? null}
-          onClick={() =>
+          student={student}
+          isSelected={selectedStudentIds.has(String(student.id))}
+          onToggleSelection={() => onToggleStudentSelection(String(student.id))}
+          onOpen={() =>
             router.push(
               `/students/${student.id}?from=${encodeURIComponent(fromReferrer)}`,
             )
           }
         />
       ))}
+    </div>
+  );
+}
+
+function SelectableStudentRow({
+  student,
+  isSelected,
+  onToggleSelection,
+  onOpen,
+}: {
+  readonly student: Student;
+  readonly isSelected: boolean;
+  readonly onToggleSelection: () => void;
+  readonly onOpen: () => void;
+}) {
+  const fullName =
+    `${student.first_name ?? ""} ${student.second_name ?? ""}`.trim() || "Kind";
+
+  return (
+    <div
+      className={`flex items-center gap-3 rounded-xl border px-3 py-3 transition-colors ${
+        isSelected
+          ? "border-[#5080D8]/40 bg-[#5080D8]/10"
+          : "border-gray-200 bg-white hover:border-gray-300 hover:bg-gray-50"
+      }`}
+    >
+      <input
+        type="checkbox"
+        checked={isSelected}
+        aria-label={`${fullName} auswählen`}
+        onChange={onToggleSelection}
+        className="h-5 w-5 shrink-0 rounded border-gray-300 text-[#5080D8] accent-[#5080D8] focus:ring-2 focus:ring-[#5080D8]/40 focus:outline-none"
+      />
+      <div className="min-w-0 flex-1">
+        <CompactStudentCard
+          studentId={student.id}
+          firstName={student.first_name}
+          lastName={student.second_name}
+          schoolClass={student.school_class}
+          groupName={student.group_name ?? undefined}
+          photoUrl={student.photo_url ?? null}
+          onClick={onOpen}
+          chrome="plain"
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/students/compact-student-card.tsx
+++ b/frontend/src/components/students/compact-student-card.tsx
@@ -29,6 +29,8 @@ interface CompactStudentCardProps {
    */
   readonly photoUrl?: string | null;
   readonly onClick?: () => void;
+  readonly chrome?: "card" | "plain";
+  readonly className?: string;
 }
 
 export function CompactStudentCard({
@@ -39,6 +41,8 @@ export function CompactStudentCard({
   groupName,
   photoUrl,
   onClick,
+  chrome = "card",
+  className = "",
 }: CompactStudentCardProps) {
   // Per-tenant feature flag. When off, the avatar slot is suppressed so
   // opt-out schools see the original pre-feature shape (name + meta only).
@@ -49,6 +53,11 @@ export function CompactStudentCard({
   const meta = [schoolClass, groupName].filter(Boolean).join(" · ");
   const fullName = `${firstName ?? ""} ${lastName ?? ""}`.trim() || "?";
 
+  const chromeClass =
+    chrome === "card"
+      ? "border border-gray-200 bg-white px-4 py-3 hover:border-gray-300 hover:bg-gray-50"
+      : "border border-transparent bg-transparent px-0 py-0 hover:bg-transparent";
+
   return (
     <button
       key={studentId}
@@ -56,7 +65,7 @@ export function CompactStudentCard({
       onClick={onClick}
       aria-label={`${firstName} ${lastName} – Profil öffnen`}
       data-testid={`compact-student-card-${studentId}`}
-      className="group flex w-full items-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 text-left transition-colors duration-150 hover:border-gray-300 hover:bg-gray-50 focus:ring-2 focus:ring-[#5080D8]/40 focus:outline-none"
+      className={`group flex w-full items-center gap-3 rounded-xl text-left transition-colors duration-150 focus:ring-2 focus:ring-[#5080D8]/40 focus:outline-none ${chromeClass} ${className}`}
     >
       {photosEnabled ? (
         <Avatar imageUrl={photoUrl ?? null} name={fullName} size="sm" />

--- a/frontend/src/lib/active-service.test.ts
+++ b/frontend/src/lib/active-service.test.ts
@@ -464,11 +464,50 @@ describe("active-service", () => {
         expect(result?.isActive).toBe(true);
       });
 
+      it("unwraps backend response envelopes returned by the Next proxy", async () => {
+        const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                status: "success",
+                data: { ...sampleBackendVisit, active_group_id: 77 },
+                message: "Student current visit retrieved successfully",
+              },
+            }),
+        } as Response);
+
+        const result = await activeService.getStudentCurrentVisit("50");
+
+        expect(result).not.toBeNull();
+        expect(result?.activeGroupId).toBe("77");
+      });
+
       it("returns null when no current visit", async () => {
         const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
         mockFetch.mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve({ data: null }),
+        } as Response);
+
+        const result = await activeService.getStudentCurrentVisit("50");
+
+        expect(result).toBeNull();
+      });
+
+      it("returns null for enveloped backend no-current responses", async () => {
+        const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                status: "success",
+                data: null,
+                message: "No active visit found",
+              },
+            }),
         } as Response);
 
         const result = await activeService.getStudentCurrentVisit("50");
@@ -498,6 +537,35 @@ describe("active-service", () => {
           }),
         );
         expect(result.id).toBe("100");
+      });
+    });
+
+    describe("updateVisit", () => {
+      it("unwraps backend response envelopes before mapping the updated visit", async () => {
+        const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                status: "success",
+                data: { ...sampleBackendVisit, active_group_id: 77 },
+                message: "Visit updated successfully",
+              },
+            }),
+        } as Response);
+
+        const result = await activeService.updateVisit("100", {
+          studentId: "50",
+          activeGroupId: "77",
+          checkInTime: new Date("2024-01-15T08:30:00Z"),
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/active/visits/100",
+          expect.objectContaining({ method: "PUT" }),
+        );
+        expect(result.activeGroupId).toBe("77");
       });
     });
 

--- a/frontend/src/lib/active-service.ts
+++ b/frontend/src/lib/active-service.ts
@@ -46,6 +46,13 @@ interface ApiResponse<T> {
   status?: string;
 }
 
+interface BackendResponseEnvelope<T> {
+  data: T;
+  message?: string;
+  status?: string;
+  success?: boolean;
+}
+
 // Helper to extract array from potentially paginated response
 function extractArrayFromResponse<T>(response: unknown): T[] {
   if (!response || typeof response !== "object") {
@@ -68,6 +75,35 @@ function extractArrayFromResponse<T>(response: unknown): T[] {
   }
 
   return [];
+}
+
+function unwrapBackendEnvelope<T>(payload: T | BackendResponseEnvelope<T>): T {
+  if (!payload || typeof payload !== "object") {
+    return payload as T;
+  }
+
+  const obj = payload as Record<string, unknown>;
+  if (
+    "data" in obj &&
+    ("status" in obj || "message" in obj || "success" in obj)
+  ) {
+    return obj.data as T;
+  }
+
+  return payload as T;
+}
+
+function mapVisitPayload(
+  payload: BackendVisit | BackendResponseEnvelope<BackendVisit>,
+): Visit {
+  return mapVisitResponse(unwrapBackendEnvelope(payload));
+}
+
+function mapNullableVisitPayload(
+  payload: BackendVisit | BackendResponseEnvelope<BackendVisit | null>,
+): Visit | null {
+  const visit = unwrapBackendEnvelope(payload);
+  return visit ? mapVisitResponse(visit) : null;
 }
 
 // ============================================================================
@@ -504,10 +540,13 @@ export const activeService = {
   },
 
   getVisit: async (id: string): Promise<Visit> => {
-    return proxyGet<BackendVisit, Visit>(
+    return proxyGet<
+      BackendVisit | BackendResponseEnvelope<BackendVisit>,
+      Visit
+    >(
       `/api/active/visits/${id}`,
       `/active/visits/${id}`,
-      mapVisitResponse,
+      mapVisitPayload,
       "Get visit",
     );
   },
@@ -522,10 +561,13 @@ export const activeService = {
   },
 
   getStudentCurrentVisit: async (studentId: string): Promise<Visit | null> => {
-    return proxyGetNullable<BackendVisit, Visit>(
+    return proxyGetNullable<
+      BackendVisit | BackendResponseEnvelope<BackendVisit | null>,
+      Visit | null
+    >(
       `/api/active/visits/student/${studentId}/current`,
       `/active/visits/student/${studentId}/current`,
-      mapVisitResponse,
+      mapNullableVisitPayload,
       "Get student current visit",
     );
   },
@@ -541,22 +583,28 @@ export const activeService = {
 
   createVisit: async (visit: CreateVisitInput): Promise<Visit> => {
     const backendData = prepareVisitForBackend(visit);
-    return proxyPost<BackendVisit, Visit>(
+    return proxyPost<
+      BackendVisit | BackendResponseEnvelope<BackendVisit>,
+      Visit
+    >(
       "/api/active/visits",
       "/active/visits",
       backendData,
-      mapVisitResponse,
+      mapVisitPayload,
       "Create visit",
     );
   },
 
   updateVisit: async (id: string, visit: Partial<Visit>): Promise<Visit> => {
     const backendData = prepareVisitForBackend(visit);
-    return proxyPut<BackendVisit, Visit>(
+    return proxyPut<
+      BackendVisit | BackendResponseEnvelope<BackendVisit>,
+      Visit
+    >(
       `/api/active/visits/${id}`,
       `/active/visits/${id}`,
       backendData,
-      mapVisitResponse,
+      mapVisitPayload,
       "Update visit",
     );
   },
@@ -570,10 +618,13 @@ export const activeService = {
   },
 
   endVisit: async (id: string): Promise<Visit> => {
-    return proxyPostNoBody<BackendVisit, Visit>(
+    return proxyPostNoBody<
+      BackendVisit | BackendResponseEnvelope<BackendVisit>,
+      Visit
+    >(
       `/api/active/visits/${id}/end`,
       `/active/visits/${id}/end`,
-      mapVisitResponse,
+      mapVisitPayload,
       "End visit",
     );
   },

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -461,6 +461,7 @@ describe("useGlobalSSE", () => {
       // Matcher must work with tenant-prefixed keys (useSWRAuth adds tenant slug prefix)
       const matcher = ogsStudentCall![0] as (key: string) => boolean;
       expect(matcher("my-tenant:ogs-students-5")).toBe(true);
+      expect(matcher("my-tenant:rooms-list")).toBe(true);
       expect(matcher("my-tenant:tracking-supervisions-1-42,43")).toBe(true);
       expect(matcher("my-tenant:tracking-indicators-search-group1")).toBe(true);
     });

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -26,6 +26,7 @@ import { useCallback, useRef } from "react";
 import { mutate } from "swr";
 import { useSession } from "next-auth/react";
 import { useSSE } from "~/lib/hooks/use-sse";
+import { ROOM_LIST_CACHE_KEYS } from "~/lib/swr/room-derived-caches";
 import type { SSEEvent, SSEHookState } from "~/lib/sse-types";
 import { createLogger } from "~/lib/logger";
 
@@ -127,7 +128,11 @@ export function useGlobalSSE(): SSEHookState {
             // groupName, studentCount, isOccupied. Without this, the
             // "Aktuell anwesend: X" InfoItem stays stale while the
             // section above it refreshes (#1374).
-            key.includes("room-detail-")),
+            key.includes("room-detail-") ||
+            // Room overview cards on /rooms use their own direct rooms
+            // list cache. A room move changes studentCount there even
+            // though the Room entity itself did not change.
+            ROOM_LIST_CACHE_KEYS.some((cacheKey) => key.includes(cacheKey))),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),

--- a/frontend/src/lib/swr/room-derived-caches.ts
+++ b/frontend/src/lib/swr/room-derived-caches.ts
@@ -57,6 +57,7 @@ export const ROOM_DERIVED_CACHE_KEY_FRAGMENTS: readonly string[] = [
 
 export const DATABASE_ROOMS_LIST_CACHE_KEY = "database-rooms-list";
 export const SEARCH_ROOMS_LIST_CACHE_KEY = "search-rooms-list";
+const ROOMS_PAGE_LIST_CACHE_KEY = "rooms-list";
 
 /**
  * Exact SWR keys for pages that fetch `/api/rooms` directly.
@@ -67,5 +68,6 @@ export const SEARCH_ROOMS_LIST_CACHE_KEY = "search-rooms-list";
  */
 export const ROOM_LIST_CACHE_KEYS: readonly string[] = [
   DATABASE_ROOMS_LIST_CACHE_KEY,
+  ROOMS_PAGE_LIST_CACHE_KEY,
   SEARCH_ROOMS_LIST_CACHE_KEY,
 ] as const;


### PR DESCRIPTION
## Summary
- add bulk room moves from the Rooms detail panel
- update active visit movement to emit the same live events as normal check-in/check-out flows
- clean up the bulk selection UI with existing Button, DatabaseSelect, and CompactStudentCard patterns

## Details
Staff can now select multiple children in a room, choose a target room, and move all selected active visits into that target room. Target rooms are only offered when they have exactly one active session, so the UI does not silently pick an arbitrary activity.

The frontend now unwraps proxied active visit response envelopes correctly, refreshes room list/detail/search caches after a move, and global SSE invalidates the rooms overview when movement events arrive.

## Validation
- `cd frontend && pnpm run check`
- `cd frontend && pnpm test -- use-global-sse.test.ts students-in-room-section.test.tsx active-service.test.ts`
- `cd frontend && pnpm test -- students-in-room-section.test.tsx`
- `cd backend && go test ./services/active -run 'TestBroadcast_UpdateVisitMoveSendsMovementEvents|TestActiveService_UpdateVisit'`
- browser tested on desktop `1440x1000` and mobile `390x844` at `/rooms?room=2`
- pre-push: git-secrets, go-vet, golangci-lint, frontend-knip, go-deadcode, frontend-check
