### PR TITLE
Optimize CI test coverage workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,15 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     outputs:
-      # On push to main/development: always run everything (full coverage for SonarCloud)
-      # On PRs: only run what changed (path filtering saves CI minutes)
-      run-backend: ${{ github.event_name == 'push' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.ci == 'true' }}
-      run-frontend: ${{ github.event_name == 'push' || steps.filter.outputs.frontend == 'true' || steps.filter.outputs.ci == 'true' }}
+      # On PRs: only run what changed.
+      # On protected branch pushes: run both suites for full SonarCloud coverage,
+      # but still skip docs-only churn.
+      run-backend: ${{ steps.filter.outputs.backend == 'true' || steps.filter.outputs.ci == 'true' || (github.event_name == 'push' && steps.filter.outputs.frontend == 'true') }}
+      run-frontend: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.ci == 'true' || (github.event_name == 'push' && steps.filter.outputs.backend == 'true') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
@@ -40,6 +43,9 @@ jobs:
             ci:
               - '.github/**'
               - 'sonar-project.properties'
+              - 'environments/**'
+              - '.env.example'
+              - 'package.json'
 
   lint:
     permissions:
@@ -59,6 +65,8 @@ jobs:
     with:
       run-backend: ${{ needs.detect-changes.outputs.run-backend == 'true' }}
       run-frontend: ${{ needs.detect-changes.outputs.run-frontend == 'true' }}
+      is-pr: ${{ github.event_name == 'pull_request' }}
+      base_ref: ${{ github.base_ref }}
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ on:
       run-frontend:
         type: boolean
         default: true
+      is-pr:
+        type: boolean
+        default: false
+      base_ref:
+        type: string
+        default: ""
     secrets:
       SONAR_TOKEN:
         description: "SonarCloud authentication token"
@@ -73,30 +79,26 @@ jobs:
             --junitfile junit.xml \
             --rerun-fails \
             --rerun-fails-max-failures=5 \
-            --packages="./..."
+            --rerun-fails-report rerun-fails.json \
+            --packages="./..." \
+            -- \
+            -covermode=atomic \
+            -coverprofile=coverage.out
 
-      - name: Generate Go coverage
+      - name: Regenerate full Go coverage after flaky retries
         working-directory: backend
         env:
           TEST_DB_DSN: postgres://postgres:postgres@localhost:5432/phoenix_test?sslmode=disable
         run: |
-          set -euo pipefail
-          tmpdir="$(mktemp -d)"
-          trap 'rm -rf "$tmpdir"' EXIT
+          if [ ! -f rerun-fails.json ]; then
+            exit 0
+          fi
 
-          echo "mode: atomic" > coverage.out
-          go list ./... > "$tmpdir/packages.txt"
-
-          while IFS= read -r pkg; do
-            profile="$tmpdir/$(echo "$pkg" | tr '/.' '__').out"
-            if ! go test "$pkg" -coverprofile="$profile" -covermode=atomic; then
-              echo "Coverage run failed for $pkg; retrying once"
-              go test "$pkg" -coverprofile="$profile" -covermode=atomic
-            fi
-            if [ -f "$profile" ]; then
-              tail -n +2 "$profile" >> coverage.out
-            fi
-          done < "$tmpdir/packages.txt"
+          echo "Flaky tests were rerun; regenerating full coverage for SonarCloud"
+          if ! go test ./... -covermode=atomic -coverprofile=coverage.out; then
+            echo "Coverage regeneration failed; retrying once"
+            go test ./... -covermode=atomic -coverprofile=coverage.out
+          fi
 
       - name: Drop flaky retries from junit.xml
         working-directory: backend
@@ -149,6 +151,7 @@ jobs:
           PYEOF
 
       - name: Fix Go coverage paths for SonarCloud
+        if: ${{ always() && hashFiles('backend/coverage.out') != '' }}
         run: |
           # Transform Go module paths to relative paths
           # From: github.com/moto-nrw/project-phoenix/... → backend/...
@@ -182,6 +185,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
       - name: Enable corepack
         run: corepack enable
@@ -197,7 +202,15 @@ jobs:
         working-directory: frontend
         run: pnpm install --frozen-lockfile
 
-      - name: Run frontend tests with coverage
+      - name: Run changed frontend tests with coverage
+        if: ${{ inputs.is-pr && inputs.base_ref != '' }}
+        working-directory: frontend
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: pnpm vitest run --changed "origin/${BASE_REF}" --coverage
+
+      - name: Run full frontend tests with coverage
+        if: ${{ !inputs.is-pr || inputs.base_ref == '' }}
         working-directory: frontend
         run: pnpm run test:run --coverage
 
@@ -214,7 +227,7 @@ jobs:
     permissions:
       contents: read
     needs: [test-backend, test-frontend]
-    if: always()
+    if: ${{ always() && (inputs.run-backend || inputs.run-frontend) }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- optimize CI test routing so PRs run only the changed side while protected branch pushes still produce full SonarCloud coverage
- collapse backend test and coverage generation into one normal gotestsum pass
- run Vitest changed tests on frontend PRs and skip Sonar when both test suites are intentionally skipped

## Validation
- actionlint -ignore 'label "blacksmith-[^\"]+" is unknown' .github/workflows/main.yml .github/workflows/test.yml
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/main.yml .github/workflows/test.yml
- git diff --check -- .github/workflows/main.yml .github/workflows/test.yml
- local gotestsum command-shape check against ./middleware
- pnpm vitest --help confirmed --changed support
