### PR TITLE
Add transit room assignment

### DIFF
--- a/backend/api/active/api.go
+++ b/backend/api/active/api.go
@@ -119,6 +119,9 @@ func (rs *Resource) Router() chi.Router {
 
 			// Immediate check-in for students (from home)
 			r.With(authorize.RequiresPermission(permissions.VisitsUpdate), withTx).Post("/student/{studentId}/checkin", rs.checkinStudent)
+
+			// Bulk assign checked-in students without a room visit to an active room session.
+			r.With(authorize.RequiresPermission(permissions.VisitsUpdate), withTx).Post("/transit/assign", rs.assignTransitStudents)
 		})
 
 		// Supervisors

--- a/backend/api/active/supervision_overview_internal_test.go
+++ b/backend/api/active/supervision_overview_internal_test.go
@@ -149,6 +149,12 @@ func (s *stubActiveService) GetStudentCurrentVisitWithRoom(_ context.Context, _ 
 func (s *stubActiveService) GetStudentsCurrentVisits(_ context.Context, _ []int64) (map[int64]*activeModel.Visit, error) {
 	return nil, nil
 }
+func (s *stubActiveService) ListStudentsInTransit(_ context.Context) ([]int64, error) {
+	return nil, nil
+}
+func (s *stubActiveService) AssignTransitStudentsToActiveGroup(_ context.Context, _ []int64, _ int64) (*activeSvc.TransitAssignResult, error) {
+	return nil, nil
+}
 func (s *stubActiveService) CountActiveVisitsByRoomID(_ context.Context, _ int64) (int, error) {
 	return 0, nil
 }

--- a/backend/api/active/tracking_handlers_test.go
+++ b/backend/api/active/tracking_handlers_test.go
@@ -171,6 +171,12 @@ func (m *trackingMockActiveService) CountActiveVisitsByActiveGroupID(ctx context
 func (m *trackingMockActiveService) ListStudentsPresentInRoom(ctx context.Context, roomID int64) ([]int64, error) {
 	return nil, nil
 }
+func (m *trackingMockActiveService) ListStudentsInTransit(ctx context.Context) ([]int64, error) {
+	return nil, nil
+}
+func (m *trackingMockActiveService) AssignTransitStudentsToActiveGroup(ctx context.Context, studentIDs []int64, activeGroupID int64) (*activeSvc.TransitAssignResult, error) {
+	return nil, nil
+}
 func (m *trackingMockActiveService) GetGroupSupervisor(ctx context.Context, id int64) (*activeModel.GroupSupervisor, error) {
 	return nil, nil
 }

--- a/backend/api/active/tracking_handlers_test.go
+++ b/backend/api/active/tracking_handlers_test.go
@@ -75,7 +75,8 @@ func (m *trackingMockSettingsService) ClearLoginImageURL(ctx context.Context, te
 // --- Mock ActiveService (stub all methods, only GetTrackingIndicators functional) ---
 
 type trackingMockActiveService struct {
-	getTrackingIndicatorsFunc func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error)
+	getTrackingIndicatorsFunc              func(ctx context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error)
+	assignTransitStudentsToActiveGroupFunc func(ctx context.Context, studentIDs []int64, activeGroupID int64) (*activeSvc.TransitAssignResult, error)
 }
 
 // The only method used by the tracking handler:
@@ -175,6 +176,9 @@ func (m *trackingMockActiveService) ListStudentsInTransit(ctx context.Context) (
 	return nil, nil
 }
 func (m *trackingMockActiveService) AssignTransitStudentsToActiveGroup(ctx context.Context, studentIDs []int64, activeGroupID int64) (*activeSvc.TransitAssignResult, error) {
+	if m.assignTransitStudentsToActiveGroupFunc != nil {
+		return m.assignTransitStudentsToActiveGroupFunc(ctx, studentIDs, activeGroupID)
+	}
 	return nil, nil
 }
 func (m *trackingMockActiveService) GetGroupSupervisor(ctx context.Context, id int64) (*activeModel.GroupSupervisor, error) {

--- a/backend/api/active/transit_handlers.go
+++ b/backend/api/active/transit_handlers.go
@@ -1,0 +1,34 @@
+package active
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+)
+
+type assignTransitStudentsRequest struct {
+	StudentIDs    []int64 `json:"student_ids"`
+	ActiveGroupID int64   `json:"active_group_id"`
+}
+
+func (rs *Resource) assignTransitStudents(w http.ResponseWriter, r *http.Request) {
+	var req assignTransitStudentsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		common.RenderError(w, r, ErrorInvalidRequest(errors.New("invalid request body")))
+		return
+	}
+	if len(req.StudentIDs) == 0 || req.ActiveGroupID <= 0 {
+		common.RenderError(w, r, ErrorInvalidRequest(errors.New("student_ids and active_group_id are required")))
+		return
+	}
+
+	result, err := rs.ActiveService.AssignTransitStudentsToActiveGroup(r.Context(), req.StudentIDs, req.ActiveGroupID)
+	if err != nil {
+		common.RenderError(w, r, ErrorRenderer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, result, "Transit students assigned successfully")
+}

--- a/backend/api/active/transit_handlers_test.go
+++ b/backend/api/active/transit_handlers_test.go
@@ -1,0 +1,102 @@
+package active
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssignTransitStudents(t *testing.T) {
+	t.Run("assigns selected students", func(t *testing.T) {
+		var capturedStudentIDs []int64
+		var capturedActiveGroupID int64
+		rs := &Resource{
+			ActiveService: &trackingMockActiveService{
+				assignTransitStudentsToActiveGroupFunc: func(_ context.Context, studentIDs []int64, activeGroupID int64) (*activeSvc.TransitAssignResult, error) {
+					capturedStudentIDs = studentIDs
+					capturedActiveGroupID = activeGroupID
+					return &activeSvc.TransitAssignResult{
+						Assigned:      []int64{42, 84},
+						Skipped:       []activeSvc.TransitAssignSkipped{},
+						ActiveGroupID: activeGroupID,
+						RoomID:        77,
+					}, nil
+				},
+			},
+		}
+
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/api/active/visits/transit/assign",
+			bytes.NewBufferString(`{"student_ids":[42,84],"active_group_id":99}`),
+		)
+		w := httptest.NewRecorder()
+
+		rs.assignTransitStudents(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, []int64{42, 84}, capturedStudentIDs)
+		assert.Equal(t, int64(99), capturedActiveGroupID)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, "Transit students assigned successfully", body["message"])
+	})
+
+	t.Run("rejects malformed json", func(t *testing.T) {
+		rs := &Resource{ActiveService: &trackingMockActiveService{}}
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/api/active/visits/transit/assign",
+			bytes.NewBufferString(`{"student_ids":[42]`),
+		)
+		w := httptest.NewRecorder()
+
+		rs.assignTransitStudents(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("rejects missing required fields", func(t *testing.T) {
+		rs := &Resource{ActiveService: &trackingMockActiveService{}}
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/api/active/visits/transit/assign",
+			bytes.NewBufferString(`{"student_ids":[],"active_group_id":99}`),
+		)
+		w := httptest.NewRecorder()
+
+		rs.assignTransitStudents(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("renders service errors", func(t *testing.T) {
+		rs := &Resource{
+			ActiveService: &trackingMockActiveService{
+				assignTransitStudentsToActiveGroupFunc: func(_ context.Context, _ []int64, _ int64) (*activeSvc.TransitAssignResult, error) {
+					return nil, &activeSvc.ActiveError{
+						Op:  "AssignTransitStudentsToActiveGroup",
+						Err: activeSvc.ErrActiveGroupAlreadyEnded,
+					}
+				},
+			},
+		}
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/api/active/visits/transit/assign",
+			bytes.NewBufferString(`{"student_ids":[42],"active_group_id":99}`),
+		)
+		w := httptest.NewRecorder()
+
+		rs.assignTransitStudents(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}

--- a/backend/api/sse/resolve_supervisions_internal_test.go
+++ b/backend/api/sse/resolve_supervisions_internal_test.go
@@ -172,6 +172,12 @@ func (m *mockActiveSvcForSSE) CountActiveVisitsByActiveGroupID(_ context.Context
 func (m *mockActiveSvcForSSE) ListStudentsPresentInRoom(_ context.Context, _ int64) ([]int64, error) {
 	return nil, nil
 }
+func (m *mockActiveSvcForSSE) ListStudentsInTransit(_ context.Context) ([]int64, error) {
+	return nil, nil
+}
+func (m *mockActiveSvcForSSE) AssignTransitStudentsToActiveGroup(_ context.Context, _ []int64, _ int64) (*activeSvc.TransitAssignResult, error) {
+	return nil, nil
+}
 func (m *mockActiveSvcForSSE) GetGroupSupervisor(_ context.Context, _ int64) (*activeModel.GroupSupervisor, error) {
 	return nil, nil
 }

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -346,6 +346,10 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 	// Fetch students based on parameters
 	students, totalCount, err := rs.fetchStudentsForList(r, params)
 	if err != nil {
+		if errors.Is(err, ErrInvalidRequest) {
+			renderError(w, r, ErrorInvalidRequest(err))
+			return
+		}
 		renderError(w, r, ErrorInternalServer(err))
 		return
 	}
@@ -404,6 +408,32 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 func (rs *Resource) fetchStudentsForList(r *http.Request, params *studentListParams) ([]*users.Student, int, error) {
 	ctx := r.Context()
 
+	if params.locationState != "" {
+		if params.locationState != "transit" {
+			return nil, 0, ErrInvalidRequest
+		}
+		if params.roomID > 0 {
+			return nil, 0, ErrInvalidRequest
+		}
+		ids, err := rs.ActiveService.ListStudentsInTransit(ctx)
+		if err != nil {
+			return nil, 0, err
+		}
+		if len(ids) == 0 {
+			return []*users.Student{}, 0, nil
+		}
+		if params.groupID > 0 {
+			ids, err = rs.filterStudentIDsByGroup(ctx, ids, params.groupID)
+			if err != nil {
+				return nil, 0, err
+			}
+			if len(ids) == 0 {
+				return []*users.Student{}, 0, nil
+			}
+		}
+		params.studentIDs = ids
+	}
+
 	// room_id pre-filter (#1323) — resolve students currently checked-in to
 	// any active group in the room, then push the IDs through the standard
 	// query path so school_class / guardian_name / pagination still apply.
@@ -422,17 +452,9 @@ func (rs *Resource) fetchStudentsForList(r *http.Request, params *studentListPar
 		// active-group chip in the search UI. group_id lives on the Student
 		// row, so a single bulk lookup is enough.
 		if params.groupID > 0 {
-			studentMap, err := rs.StudentRepo.FindByIDs(ctx, ids)
+			filtered, err := rs.filterStudentIDsByGroup(ctx, ids, params.groupID)
 			if err != nil {
 				return nil, 0, err
-			}
-			filtered := make([]int64, 0, len(studentMap))
-			for _, sid := range ids {
-				s, ok := studentMap[sid]
-				if !ok || s.GroupID == nil || *s.GroupID != params.groupID {
-					continue
-				}
-				filtered = append(filtered, sid)
 			}
 			if len(filtered) == 0 {
 				return []*users.Student{}, 0, nil
@@ -444,7 +466,7 @@ func (rs *Resource) fetchStudentsForList(r *http.Request, params *studentListPar
 		// intentionally NOT cleared here even though buildBaseFilter ignores it
 		// — the room∩group intersection has already been computed via FindByIDs
 		// above, so re-applying group_id downstream would be redundant.
-	} else if params.groupID > 0 {
+	} else if params.groupID > 0 && params.locationState == "" {
 		// group-only branch keeps existing behavior
 		students, err := rs.StudentRepo.FindByGroupIDs(ctx, []int64{params.groupID})
 		if err != nil {
@@ -470,6 +492,22 @@ func (rs *Resource) fetchStudentsForList(r *http.Request, params *studentListPar
 	}
 
 	return students, totalCount, nil
+}
+
+func (rs *Resource) filterStudentIDsByGroup(ctx context.Context, studentIDs []int64, groupID int64) ([]int64, error) {
+	studentMap, err := rs.StudentRepo.FindByIDs(ctx, studentIDs)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]int64, 0, len(studentMap))
+	for _, sid := range studentIDs {
+		student, ok := studentMap[sid]
+		if !ok || student.GroupID == nil || *student.GroupID != groupID {
+			continue
+		}
+		filtered = append(filtered, sid)
+	}
+	return filtered, nil
 }
 
 // buildStudentResponses builds filtered student responses

--- a/backend/api/students/list_helpers.go
+++ b/backend/api/students/list_helpers.go
@@ -16,6 +16,7 @@ type studentListParams struct {
 	firstName           string
 	lastName            string
 	location            string
+	locationState       string
 	groupID             int64
 	roomID              int64
 	search              string
@@ -37,12 +38,13 @@ type studentAccessContext = common.StudentAccessContext
 // parseStudentListParams extracts query parameters from the request
 func parseStudentListParams(r *http.Request) *studentListParams {
 	params := &studentListParams{
-		schoolClass:  r.URL.Query().Get("school_class"),
-		guardianName: r.URL.Query().Get("guardian_name"),
-		firstName:    r.URL.Query().Get("first_name"),
-		lastName:     r.URL.Query().Get("last_name"),
-		location:     r.URL.Query().Get("location"),
-		search:       r.URL.Query().Get("search"),
+		schoolClass:   r.URL.Query().Get("school_class"),
+		guardianName:  r.URL.Query().Get("guardian_name"),
+		firstName:     r.URL.Query().Get("first_name"),
+		lastName:      r.URL.Query().Get("last_name"),
+		location:      r.URL.Query().Get("location"),
+		locationState: r.URL.Query().Get("location_state"),
+		search:        r.URL.Query().Get("search"),
 	}
 
 	// Parse group ID if provided

--- a/backend/api/students/students_room_filter_test.go
+++ b/backend/api/students/students_room_filter_test.go
@@ -1,6 +1,7 @@
 package students_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -149,4 +150,117 @@ func TestListStudents_RoomFilter_EmptyRoomReturnsEmpty(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
 	assert.Empty(t, resp.Data, "empty-room filter must short-circuit to []")
+}
+
+func TestListStudents_LocationStateTransit_ReturnsCheckedInStudentsWithoutActiveVisit(t *testing.T) {
+	tc := setupTestContext(t)
+
+	staff := testpkg.CreateTestStaff(t, tc.db, "TransitFilter", "Staff")
+	device := testpkg.CreateTestDevice(t, tc.db, "transit-filter-device")
+	room := testpkg.CreateTestRoom(t, tc.db, "TransitFilterRoom")
+	activity := testpkg.CreateTestActivityGroup(t, tc.db, "TransitFilterActivity")
+	activeGroup := testpkg.CreateTestActiveGroup(t, tc.db, activity.ID, room.ID)
+
+	transitStudent := testpkg.CreateTestStudent(t, tc.db, "Transit", "Student", "TFS1")
+	inRoomStudent := testpkg.CreateTestStudent(t, tc.db, "InRoom", "Student", "TFS2")
+	absentStudent := testpkg.CreateTestStudent(t, tc.db, "Absent", "Student", "TFS3")
+
+	now := time.Now().UTC()
+	transitAttendance := testpkg.CreateTestAttendance(t, tc.db, transitStudent.ID, staff.ID, device.ID, now.Add(-20*time.Minute), nil)
+	inRoomAttendance := testpkg.CreateTestAttendance(t, tc.db, inRoomStudent.ID, staff.ID, device.ID, now.Add(-15*time.Minute), nil)
+	visit := testpkg.CreateTestVisit(t, tc.db, inRoomStudent.ID, activeGroup.ID, now.Add(-10*time.Minute), nil)
+
+	defer testpkg.CleanupActivityFixtures(
+		t, tc.db,
+		visit.ID, activeGroup.ID, transitStudent.ID, inRoomStudent.ID, absentStudent.ID,
+		activity.ID, room.ID, staff.ID, device.ID,
+	)
+	defer testpkg.CleanupTableRecords(t, tc.db, "active.attendance", transitAttendance.ID, inRoomAttendance.ID)
+
+	router := setupRouter(tc.resource.ListStudentsHandler(), "")
+	req := testutil.NewRequest("GET", "/?location_state=transit", nil)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+
+	var resp struct {
+		Data []struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	ids := make(map[int64]struct{}, len(resp.Data))
+	for _, s := range resp.Data {
+		ids[s.ID] = struct{}{}
+	}
+
+	_, hasTransit := ids[transitStudent.ID]
+	_, hasInRoom := ids[inRoomStudent.ID]
+	_, hasAbsent := ids[absentStudent.ID]
+
+	assert.True(t, hasTransit, "checked-in student without active visit must appear")
+	assert.False(t, hasInRoom, "student with active room visit must NOT appear")
+	assert.False(t, hasAbsent, "student without open attendance must NOT appear")
+}
+
+func TestListStudents_LocationStateTransitWithGroupID_IntersectsFilters(t *testing.T) {
+	tc := setupTestContext(t)
+	ctx := context.Background()
+
+	staff := testpkg.CreateTestStaff(t, tc.db, "TransitGroupFilter", "Staff")
+	device := testpkg.CreateTestDevice(t, tc.db, "transit-group-filter-device")
+	targetGroup := testpkg.CreateTestEducationGroup(t, tc.db, "TransitGroupFilterTarget")
+	otherGroup := testpkg.CreateTestEducationGroup(t, tc.db, "TransitGroupFilterOther")
+
+	matchingTransitStudent := testpkg.CreateTestStudent(t, tc.db, "MatchingTransit", "Student", "TGFS1")
+	otherGroupTransitStudent := testpkg.CreateTestStudent(t, tc.db, "OtherGroupTransit", "Student", "TGFS2")
+	matchingAbsentStudent := testpkg.CreateTestStudent(t, tc.db, "MatchingAbsent", "Student", "TGFS3")
+
+	_, err := tc.db.NewUpdate().
+		TableExpr(`users.students`).
+		Set("group_id = ?", targetGroup.ID).
+		Where("id = ?", matchingTransitStudent.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+	_, err = tc.db.NewUpdate().
+		TableExpr(`users.students`).
+		Set("group_id = ?", otherGroup.ID).
+		Where("id = ?", otherGroupTransitStudent.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+	_, err = tc.db.NewUpdate().
+		TableExpr(`users.students`).
+		Set("group_id = ?", targetGroup.ID).
+		Where("id = ?", matchingAbsentStudent.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	matchingAttendance := testpkg.CreateTestAttendance(t, tc.db, matchingTransitStudent.ID, staff.ID, device.ID, now.Add(-20*time.Minute), nil)
+	otherGroupAttendance := testpkg.CreateTestAttendance(t, tc.db, otherGroupTransitStudent.ID, staff.ID, device.ID, now.Add(-20*time.Minute), nil)
+
+	defer testpkg.CleanupActivityFixtures(
+		t, tc.db,
+		matchingTransitStudent.ID, otherGroupTransitStudent.ID, matchingAbsentStudent.ID,
+		staff.ID, device.ID,
+	)
+	defer testpkg.CleanupTableRecords(t, tc.db, "active.attendance", matchingAttendance.ID, otherGroupAttendance.ID)
+	defer testpkg.CleanupTableRecords(t, tc.db, "education.groups", targetGroup.ID, otherGroup.ID)
+
+	router := setupRouter(tc.resource.ListStudentsHandler(), "")
+	req := testutil.NewRequest("GET", fmt.Sprintf("/?location_state=transit&group_id=%d", targetGroup.ID), nil)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+
+	var resp struct {
+		Data []struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	require.Len(t, resp.Data, 1)
+	assert.Equal(t, matchingTransitStudent.ID, resp.Data[0].ID)
 }

--- a/backend/api/students/students_room_filter_test.go
+++ b/backend/api/students/students_room_filter_test.go
@@ -264,3 +264,87 @@ func TestListStudents_LocationStateTransitWithGroupID_IntersectsFilters(t *testi
 	require.Len(t, resp.Data, 1)
 	assert.Equal(t, matchingTransitStudent.ID, resp.Data[0].ID)
 }
+
+func TestListStudents_LocationStateTransit_InvalidFilters(t *testing.T) {
+	tc := setupTestContext(t)
+	router := setupRouter(tc.resource.ListStudentsHandler(), "")
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "unknown location state",
+			path: "/?location_state=room",
+		},
+		{
+			name: "transit cannot be combined with room",
+			path: "/?location_state=transit&room_id=42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := testutil.NewRequest("GET", tt.path, nil)
+			rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code, "Body: %s", rr.Body.String())
+		})
+	}
+}
+
+func TestListStudents_LocationStateTransit_EmptyReturnsEmpty(t *testing.T) {
+	tc := setupTestContext(t)
+
+	bystander := testpkg.CreateTestStudent(t, tc.db, "TransitEmpty", "Bystander", "TEB1")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, bystander.ID)
+
+	router := setupRouter(tc.resource.ListStudentsHandler(), "")
+	req := testutil.NewRequest("GET", "/?location_state=transit", nil)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+
+	var resp struct {
+		Data []json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data)
+}
+
+func TestListStudents_LocationStateTransitWithGroupID_NoIntersectionReturnsEmpty(t *testing.T) {
+	tc := setupTestContext(t)
+	ctx := context.Background()
+
+	staff := testpkg.CreateTestStaff(t, tc.db, "TransitNoMatch", "Staff")
+	device := testpkg.CreateTestDevice(t, tc.db, "transit-no-match-device")
+	studentGroup := testpkg.CreateTestEducationGroup(t, tc.db, "TransitNoMatchStudentGroup")
+	filterGroup := testpkg.CreateTestEducationGroup(t, tc.db, "TransitNoMatchFilterGroup")
+	transitStudent := testpkg.CreateTestStudent(t, tc.db, "TransitNoMatch", "Student", "TNMS1")
+
+	_, err := tc.db.NewUpdate().
+		TableExpr(`users.students`).
+		Set("group_id = ?", studentGroup.ID).
+		Where("id = ?", transitStudent.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	attendance := testpkg.CreateTestAttendance(t, tc.db, transitStudent.ID, staff.ID, device.ID, now.Add(-20*time.Minute), nil)
+
+	defer testpkg.CleanupActivityFixtures(t, tc.db, transitStudent.ID, staff.ID, device.ID)
+	defer testpkg.CleanupTableRecords(t, tc.db, "active.attendance", attendance.ID)
+	defer testpkg.CleanupTableRecords(t, tc.db, "education.groups", studentGroup.ID, filterGroup.ID)
+
+	router := setupRouter(tc.resource.ListStudentsHandler(), "")
+	req := testutil.NewRequest("GET", fmt.Sprintf("/?location_state=transit&group_id=%d", filterGroup.ID), nil)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+
+	var resp struct {
+		Data []json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data)
+}

--- a/backend/database/repositories/active/attendance_repository.go
+++ b/backend/database/repositories/active/attendance_repository.go
@@ -357,6 +357,33 @@ func (r *AttendanceRepository) FindForDate(ctx context.Context, date time.Time) 
 	return attendance, nil
 }
 
+// ListOpenStudentIDsForDate returns unique student IDs with open attendance
+// rows on the given date.
+func (r *AttendanceRepository) ListOpenStudentIDsForDate(ctx context.Context, date time.Time) ([]int64, error) {
+	dateOnly := timezone.DateOfUTC(date)
+	var ids []int64
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`active.attendance AS "attendance"`).
+		ColumnExpr(`DISTINCT "attendance".student_id`).
+		Where(`"attendance".date = ?`, dateOnly).
+		Where(`"attendance".check_out_time IS NULL`).
+		OrderExpr(`"attendance".student_id ASC`)
+
+	if where, val, ok := base.TenantWhere(ctx, "attendance"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx, &ids); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list open student IDs for date",
+			Err: err,
+		}
+	}
+
+	return ids, nil
+}
+
 // CountByStaffID counts attendance records where the staff member checked in or checked out students.
 func (r *AttendanceRepository) CountByStaffID(ctx context.Context, staffID int64) (int, error) {
 	query := base.GetDB(ctx, r.db).NewSelect().

--- a/backend/database/repositories/active/attendance_repository_test.go
+++ b/backend/database/repositories/active/attendance_repository_test.go
@@ -164,6 +164,28 @@ func TestAttendanceRepository_Create(t *testing.T) {
 	})
 }
 
+func TestAttendanceRepository_ListOpenStudentIDsForDate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).Attendance
+	ctx := testpkg.TenantContext(1)
+	data := createAttendanceTestData(t, db)
+	defer cleanupAttendanceTestData(t, db, data)
+
+	now := time.Now()
+	openAttendance := testpkg.CreateTestAttendance(t, db, data.Student1.ID, data.Staff1.ID, data.Device1.ID, now.Add(-30*time.Minute), nil)
+	checkOutTime := now.Add(-5 * time.Minute)
+	closedAttendance := testpkg.CreateTestAttendance(t, db, data.Student2.ID, data.Staff1.ID, data.Device1.ID, now.Add(-30*time.Minute), &checkOutTime)
+	defer testpkg.CleanupTableRecords(t, db, "active.attendance", openAttendance.ID, closedAttendance.ID)
+
+	ids, err := repo.ListOpenStudentIDsForDate(ctx, now)
+
+	require.NoError(t, err)
+	assert.Contains(t, ids, data.Student1.ID)
+	assert.NotContains(t, ids, data.Student2.ID)
+}
+
 // TestAttendanceRepository_FindByStudentAndDate tests querying attendance records by student and date
 func TestAttendanceRepository_FindByStudentAndDate(t *testing.T) {
 	db := testpkg.SetupTestDB(t)

--- a/backend/models/active/attendance.go
+++ b/backend/models/active/attendance.go
@@ -127,6 +127,10 @@ type AttendanceRepository interface {
 	// FindForDate finds all attendance records for a specific date
 	FindForDate(ctx context.Context, date time.Time) ([]*Attendance, error)
 
+	// ListOpenStudentIDsForDate returns unique student IDs with an open
+	// attendance row for the given date.
+	ListOpenStudentIDsForDate(ctx context.Context, date time.Time) ([]int64, error)
+
 	// CountByStaffID counts attendance records where the staff member checked in or checked out students
 	CountByStaffID(ctx context.Context, staffID int64) (int, error)
 }

--- a/backend/services/active/interface.go
+++ b/backend/services/active/interface.go
@@ -40,6 +40,8 @@ type Service interface {
 	CountActiveVisitsByRoomID(ctx context.Context, roomID int64) (int, error)
 	CountActiveVisitsByActiveGroupID(ctx context.Context, activeGroupID int64) (int, error)
 	ListStudentsPresentInRoom(ctx context.Context, roomID int64) ([]int64, error)
+	ListStudentsInTransit(ctx context.Context) ([]int64, error)
+	AssignTransitStudentsToActiveGroup(ctx context.Context, studentIDs []int64, activeGroupID int64) (*TransitAssignResult, error)
 
 	// Group Supervisor operations
 	GetGroupSupervisor(ctx context.Context, id int64) (*active.GroupSupervisor, error)
@@ -140,6 +142,22 @@ type Service interface {
 	// Injects the tenant-scoped settings resolver (optional).
 	// Called by the factory after the settings service is constructed.
 	SetSettingsService(resolver SettingsResolver)
+}
+
+// TransitAssignSkipped describes a student that was not assigned during a
+// transit bulk operation.
+type TransitAssignSkipped struct {
+	StudentID int64  `json:"student_id"`
+	Reason    string `json:"reason"`
+}
+
+// TransitAssignResult is returned when transit students are assigned to an
+// active room session.
+type TransitAssignResult struct {
+	Assigned      []int64                `json:"assigned"`
+	Skipped       []TransitAssignSkipped `json:"skipped"`
+	ActiveGroupID int64                  `json:"active_group_id"`
+	RoomID        int64                  `json:"room_id"`
 }
 
 // DashboardAnalytics represents aggregated analytics for dashboard

--- a/backend/services/active/transit_service.go
+++ b/backend/services/active/transit_service.go
@@ -1,0 +1,127 @@
+package active
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/active"
+)
+
+const (
+	TransitSkipNotInTransit = "not_in_transit"
+	TransitSkipCreateFailed = "create_failed"
+)
+
+// ListStudentsInTransit returns students who are checked in today but do not
+// currently have an open room visit.
+func (s *service) ListStudentsInTransit(ctx context.Context) ([]int64, error) {
+	openAttendanceIDs, err := s.attendanceRepo.ListOpenStudentIDsForDate(ctx, time.Now())
+	if err != nil {
+		return nil, &ActiveError{Op: "ListStudentsInTransit", Err: ErrDatabaseOperation}
+	}
+	if len(openAttendanceIDs) == 0 {
+		return []int64{}, nil
+	}
+
+	currentVisits, err := s.visitRepo.GetCurrentByStudentIDs(ctx, openAttendanceIDs)
+	if err != nil {
+		return nil, &ActiveError{Op: "ListStudentsInTransit", Err: ErrDatabaseOperation}
+	}
+
+	ids := make([]int64, 0, len(openAttendanceIDs))
+	for _, studentID := range openAttendanceIDs {
+		if _, hasVisit := currentVisits[studentID]; hasVisit {
+			continue
+		}
+		ids = append(ids, studentID)
+	}
+
+	return ids, nil
+}
+
+// AssignTransitStudentsToActiveGroup assigns checked-in students without an
+// active room visit to an existing active group/session.
+func (s *service) AssignTransitStudentsToActiveGroup(ctx context.Context, studentIDs []int64, activeGroupID int64) (*TransitAssignResult, error) {
+	if activeGroupID <= 0 || len(studentIDs) == 0 {
+		return nil, &ActiveError{Op: "AssignTransitStudentsToActiveGroup", Err: ErrInvalidData}
+	}
+
+	targetGroup, err := s.GetActiveGroup(ctx, activeGroupID)
+	if err != nil {
+		return nil, err
+	}
+	if targetGroup == nil || !targetGroup.IsActive() {
+		return nil, &ActiveError{Op: "AssignTransitStudentsToActiveGroup", Err: ErrActiveGroupAlreadyEnded}
+	}
+
+	uniqueIDs := uniquePositiveInt64s(studentIDs)
+	if len(uniqueIDs) == 0 {
+		return nil, &ActiveError{Op: "AssignTransitStudentsToActiveGroup", Err: ErrInvalidData}
+	}
+
+	openAttendance, err := s.attendanceRepo.GetTodayByStudentIDs(ctx, uniqueIDs)
+	if err != nil {
+		return nil, &ActiveError{Op: "AssignTransitStudentsToActiveGroup", Err: ErrDatabaseOperation}
+	}
+	currentVisits, err := s.visitRepo.GetCurrentByStudentIDs(ctx, uniqueIDs)
+	if err != nil {
+		return nil, &ActiveError{Op: "AssignTransitStudentsToActiveGroup", Err: ErrDatabaseOperation}
+	}
+
+	result := &TransitAssignResult{
+		Assigned:      []int64{},
+		Skipped:       []TransitAssignSkipped{},
+		ActiveGroupID: targetGroup.ID,
+		RoomID:        targetGroup.RoomID,
+	}
+
+	for _, studentID := range uniqueIDs {
+		attendance, hasAttendance := openAttendance[studentID]
+		_, hasVisit := currentVisits[studentID]
+		if !hasAttendance || attendance == nil || attendance.CheckOutTime != nil || hasVisit {
+			result.Skipped = append(result.Skipped, TransitAssignSkipped{StudentID: studentID, Reason: TransitSkipNotInTransit})
+			continue
+		}
+
+		visit := &active.Visit{
+			StudentID:     studentID,
+			ActiveGroupID: targetGroup.ID,
+			EntryTime:     time.Now(),
+		}
+		if err := s.CreateVisit(ctx, visit); err != nil {
+			if errors.Is(err, ErrStudentAlreadyActive) {
+				result.Skipped = append(result.Skipped, TransitAssignSkipped{StudentID: studentID, Reason: TransitSkipNotInTransit})
+				continue
+			}
+			result.Skipped = append(result.Skipped, TransitAssignSkipped{StudentID: studentID, Reason: TransitSkipCreateFailed})
+			continue
+		}
+
+		result.Assigned = append(result.Assigned, studentID)
+	}
+
+	if len(result.Assigned) > 0 {
+		if err := s.UpdateSessionActivity(ctx, targetGroup.ID); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+func uniquePositiveInt64s(ids []int64) []int64 {
+	seen := make(map[int64]struct{}, len(ids))
+	unique := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if id <= 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	return unique
+}

--- a/backend/services/active/transit_service_test.go
+++ b/backend/services/active/transit_service_test.go
@@ -1,0 +1,121 @@
+package active_test
+
+import (
+	"testing"
+	"time"
+
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActiveService_ListStudentsInTransit(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := testpkg.TenantContext(1)
+	now := time.Now()
+
+	activity := testpkg.CreateTestActivityGroup(t, db, "transit-list")
+	room := testpkg.CreateTestRoom(t, db, "Transit List Room")
+	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	staff := testpkg.CreateTestStaff(t, db, "Transit", "List")
+	device := testpkg.CreateTestDevice(t, db, "transit-list-device")
+	transitStudent := testpkg.CreateTestStudent(t, db, "Transit", "Listed", "TLS1")
+	inRoomStudent := testpkg.CreateTestStudent(t, db, "In", "Room", "TLS2")
+	checkedOutStudent := testpkg.CreateTestStudent(t, db, "Checked", "Out", "TLS3")
+
+	transitAttendance := testpkg.CreateTestAttendance(t, db, transitStudent.ID, staff.ID, device.ID, now.Add(-20*time.Minute), nil)
+	inRoomAttendance := testpkg.CreateTestAttendance(t, db, inRoomStudent.ID, staff.ID, device.ID, now.Add(-20*time.Minute), nil)
+	checkOutTime := now.Add(-5 * time.Minute)
+	checkedOutAttendance := testpkg.CreateTestAttendance(t, db, checkedOutStudent.ID, staff.ID, device.ID, now.Add(-20*time.Minute), &checkOutTime)
+	visit := testpkg.CreateTestVisit(t, db, inRoomStudent.ID, activeGroup.ID, now.Add(-15*time.Minute), nil)
+
+	defer testpkg.CleanupActivityFixtures(
+		t, db,
+		activity.ID, room.ID, activeGroup.ID, staff.ID, device.ID,
+		transitStudent.ID, inRoomStudent.ID, checkedOutStudent.ID, visit.ID,
+	)
+	defer testpkg.CleanupTableRecords(t, db, "active.attendance", transitAttendance.ID, inRoomAttendance.ID, checkedOutAttendance.ID)
+
+	ids, err := service.ListStudentsInTransit(ctx)
+
+	require.NoError(t, err)
+	assert.Contains(t, ids, transitStudent.ID)
+	assert.NotContains(t, ids, inRoomStudent.ID)
+	assert.NotContains(t, ids, checkedOutStudent.ID)
+}
+
+func TestActiveService_AssignTransitStudentsToActiveGroup(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := testpkg.TenantContext(1)
+	now := time.Now()
+
+	sourceActivity := testpkg.CreateTestActivityGroup(t, db, "transit-assign-source")
+	targetActivity := testpkg.CreateTestActivityGroup(t, db, "transit-assign-target")
+	sourceRoom := testpkg.CreateTestRoom(t, db, "Transit Source Room")
+	targetRoom := testpkg.CreateTestRoom(t, db, "Transit Target Room")
+	sourceGroup := testpkg.CreateTestActiveGroup(t, db, sourceActivity.ID, sourceRoom.ID)
+	targetGroup := testpkg.CreateTestActiveGroup(t, db, targetActivity.ID, targetRoom.ID)
+	staff := testpkg.CreateTestStaff(t, db, "Transit", "Assign")
+	device := testpkg.CreateTestDevice(t, db, "transit-assign-device")
+	transitStudent := testpkg.CreateTestStudent(t, db, "Transit", "Assignable", "TAS1")
+	inRoomStudent := testpkg.CreateTestStudent(t, db, "Already", "Roomed", "TAS2")
+
+	transitAttendance := testpkg.CreateTestAttendance(t, db, transitStudent.ID, staff.ID, device.ID, now.Add(-20*time.Minute), nil)
+	inRoomAttendance := testpkg.CreateTestAttendance(t, db, inRoomStudent.ID, staff.ID, device.ID, now.Add(-20*time.Minute), nil)
+	existingVisit := testpkg.CreateTestVisit(t, db, inRoomStudent.ID, sourceGroup.ID, now.Add(-15*time.Minute), nil)
+
+	defer testpkg.CleanupActivityFixtures(
+		t, db,
+		sourceActivity.ID, targetActivity.ID, sourceRoom.ID, targetRoom.ID,
+		sourceGroup.ID, targetGroup.ID, staff.ID, device.ID,
+		transitStudent.ID, inRoomStudent.ID, existingVisit.ID,
+	)
+	defer testpkg.CleanupTableRecords(t, db, "active.attendance", transitAttendance.ID, inRoomAttendance.ID)
+
+	result, err := service.AssignTransitStudentsToActiveGroup(ctx, []int64{transitStudent.ID, inRoomStudent.ID, transitStudent.ID}, targetGroup.ID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, targetGroup.ID, result.ActiveGroupID)
+	assert.Equal(t, targetRoom.ID, result.RoomID)
+	assert.Equal(t, []int64{transitStudent.ID}, result.Assigned)
+	require.Len(t, result.Skipped, 1)
+	assert.Equal(t, activeSvc.TransitSkipNotInTransit, result.Skipped[0].Reason)
+	assert.Equal(t, inRoomStudent.ID, result.Skipped[0].StudentID)
+
+	currentVisit, err := service.GetStudentCurrentVisit(ctx, transitStudent.ID)
+	require.NoError(t, err)
+	require.NotNil(t, currentVisit)
+	assert.Equal(t, targetGroup.ID, currentVisit.ActiveGroupID)
+}
+
+func TestActiveService_AssignTransitStudentsToActiveGroup_EndedTargetFails(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	activity := testpkg.CreateTestActivityGroup(t, db, "transit-ended-target")
+	room := testpkg.CreateTestRoom(t, db, "Transit Ended Target Room")
+	targetGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	student := testpkg.CreateTestStudent(t, db, "Transit", "Blocked", "TES1")
+	endTime := time.Now()
+	targetGroup.EndTime = &endTime
+	require.NoError(t, service.UpdateActiveGroup(ctx, targetGroup))
+
+	defer testpkg.CleanupActivityFixtures(t, db, activity.ID, room.ID, targetGroup.ID, student.ID)
+
+	result, err := service.AssignTransitStudentsToActiveGroup(ctx, []int64{student.ID}, targetGroup.ID)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, activeSvc.ErrActiveGroupAlreadyEnded)
+}

--- a/backend/services/active/transit_service_test.go
+++ b/backend/services/active/transit_service_test.go
@@ -48,6 +48,19 @@ func TestActiveService_ListStudentsInTransit(t *testing.T) {
 	assert.NotContains(t, ids, checkedOutStudent.ID)
 }
 
+func TestActiveService_ListStudentsInTransit_NoOpenAttendance(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	ids, err := service.ListStudentsInTransit(ctx)
+
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
 func TestActiveService_AssignTransitStudentsToActiveGroup(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
@@ -94,6 +107,29 @@ func TestActiveService_AssignTransitStudentsToActiveGroup(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, currentVisit)
 	assert.Equal(t, targetGroup.ID, currentVisit.ActiveGroupID)
+}
+
+func TestActiveService_AssignTransitStudentsToActiveGroup_InvalidInput(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	result, err := service.AssignTransitStudentsToActiveGroup(ctx, nil, 42)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, activeSvc.ErrInvalidData)
+
+	activity := testpkg.CreateTestActivityGroup(t, db, "transit-invalid-input")
+	room := testpkg.CreateTestRoom(t, db, "Transit Invalid Input Room")
+	targetGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, db, activity.ID, room.ID, targetGroup.ID)
+
+	result, err = service.AssignTransitStudentsToActiveGroup(ctx, []int64{-42}, targetGroup.ID)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, activeSvc.ErrInvalidData)
 }
 
 func TestActiveService_AssignTransitStudentsToActiveGroup_EndedTargetFails(t *testing.T) {

--- a/backend/services/scheduler/scheduler_test.go
+++ b/backend/services/scheduler/scheduler_test.go
@@ -1147,6 +1147,12 @@ func (m *mockActiveService) CountActiveVisitsByActiveGroupID(_ context.Context, 
 func (m *mockActiveService) ListStudentsPresentInRoom(_ context.Context, _ int64) ([]int64, error) {
 	return nil, nil
 }
+func (m *mockActiveService) ListStudentsInTransit(_ context.Context) ([]int64, error) {
+	return nil, nil
+}
+func (m *mockActiveService) AssignTransitStudentsToActiveGroup(_ context.Context, _ []int64, _ int64) (*activeService.TransitAssignResult, error) {
+	return nil, nil
+}
 func (m *mockActiveService) GetDashboardAnalytics(_ context.Context) (*activeService.DashboardAnalytics, error) {
 	return nil, nil
 }

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
@@ -347,7 +347,7 @@ describe("RoomsPage", () => {
     });
   });
 
-  it("shows empty state when rooms data is empty", () => {
+  it("shows transit fake room when rooms data is empty", () => {
     vi.mocked(useSWRAuth).mockReturnValue({
       data: [],
       isLoading: false,
@@ -356,7 +356,11 @@ describe("RoomsPage", () => {
 
     render(<RoomsPage />);
 
-    expect(screen.getByText("Keine Räume gefunden")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Unterwegs" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Kinder ohne Raum")).toBeInTheDocument();
+    expect(screen.queryByText("Keine Räume gefunden")).not.toBeInTheDocument();
   });
 
   it("displays occupied room with group name", () => {

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -25,6 +25,10 @@ import { useSWRAuth } from "~/lib/swr";
 import { Loading } from "~/components/ui/loading";
 import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
 import { RoomDetailModal } from "~/components/rooms";
+import { TRANSIT_ROOM_ID } from "~/components/rooms/room-detail-modal";
+import { fetchDashboardAnalyticsClient } from "~/lib/dashboard-api";
+import type { DashboardAnalytics } from "~/lib/dashboard-helpers";
+import { LOCATION_COLORS } from "~/lib/location-helper";
 
 // Room interface - entspricht der BackendRoom-Struktur aus den API-Dateien
 interface Room {
@@ -209,6 +213,12 @@ function RoomsPageContent() {
     },
   );
 
+  const { data: dashboardData } = useSWRAuth<DashboardAnalytics>(
+    "dashboard-analytics",
+    fetchDashboardAnalyticsClient,
+    { refreshInterval: 5 * 60 * 1000 },
+  );
+
   const error = roomsError
     ? "Fehler beim Laden der Raumdaten. Bitte versuchen Sie es später erneut."
     : null;
@@ -386,6 +396,10 @@ function RoomsPageContent() {
     return filters;
   }, [searchTerm, buildingFilter, occupiedFilter]);
 
+  const showTransitCard =
+    !searchTerm || "unterwegs".includes(searchTerm.toLowerCase());
+  const transitCount = dashboardData?.studentsInTransit ?? 0;
+
   // Auth-loading: nothing to render until NextAuth resolves the session
   // (the `useSession({ required: true })` callback redirects on
   // unauthenticated). Keep the existing loader for this branch.
@@ -435,6 +449,64 @@ function RoomsPageContent() {
         <div className="mb-4 rounded-lg border border-[#FF3130]/30 bg-[#FF3130]/10 p-4 text-[#FF3130]">
           {error}
         </div>
+      )}
+
+      {showTransitCard && (
+        <section className="mb-6">
+          <h2 className="mb-3 px-1 text-xs font-semibold tracking-wider text-gray-500 uppercase">
+            Sonderbereiche
+          </h2>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+            <button
+              type="button"
+              onClick={() => {
+                const next = new URLSearchParams(searchParams.toString());
+                if (searchTerm) next.set("search", searchTerm);
+                else next.delete("search");
+                if (buildingFilter !== "all")
+                  next.set("building", buildingFilter);
+                else next.delete("building");
+                if (occupiedFilter !== "all")
+                  next.set("status", occupiedFilter);
+                else next.delete("status");
+                next.set("room", TRANSIT_ROOM_ID);
+                justPushedRef.current = true;
+                router.push(`/rooms?${next.toString()}`);
+              }}
+              className="group relative w-full cursor-pointer overflow-hidden rounded-3xl border border-gray-100/50 bg-white/90 text-left shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md transition-all duration-150 active:scale-[0.98] md:hover:-translate-y-0.5 md:hover:border-[#D946EF]/30 md:hover:shadow-[0_12px_40px_rgb(0,0,0,0.18)]"
+            >
+              <div
+                className="absolute inset-0 rounded-3xl opacity-[0.06]"
+                style={{ backgroundColor: LOCATION_COLORS.TRANSIT }}
+              ></div>
+              <div className="absolute inset-px rounded-3xl bg-gradient-to-br from-white/80 to-white/20"></div>
+              <div className="absolute inset-0 rounded-3xl ring-1 ring-white/20 transition-all duration-300 md:group-hover:ring-[#D946EF]/40"></div>
+              <div className="relative flex min-h-[180px] flex-col p-6">
+                <div className="mb-3 flex items-start justify-between">
+                  <div className="min-w-0 flex-1">
+                    <h3 className="overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap text-gray-800 transition-colors duration-300 md:group-hover:text-[#D946EF]">
+                      Unterwegs
+                    </h3>
+                    <p className="mt-0.5 text-sm text-gray-500">
+                      Kinder ohne Raum
+                    </p>
+                  </div>
+                  <span className="ml-3 inline-flex items-center rounded-full bg-[#D946EF]/15 px-2.5 py-1 text-xs font-bold text-[#D946EF]">
+                    Sonderbereich
+                  </span>
+                </div>
+                <div className="flex-1 text-sm text-gray-700">
+                  <span className="font-medium">{transitCount}</span>{" "}
+                  {transitCount === 1 ? "Kind" : "Kinder"} aktuell unterwegs
+                </div>
+                <p className="mt-2 text-xs text-gray-400 transition-colors duration-300 md:group-hover:text-[#D946EF]">
+                  Tippen zum Zuweisen
+                </p>
+              </div>
+              <div className="absolute inset-0 rounded-3xl bg-gradient-to-r from-transparent via-[#D946EF]/15 to-transparent opacity-0 transition-opacity duration-300 md:group-hover:opacity-100"></div>
+            </button>
+          </div>
+        </section>
       )}
 
       {/* Room Cards Grid — skeleton mirrors the populated grid's column

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -25,6 +25,10 @@ import { useSWRAuth } from "~/lib/swr";
 import { Loading } from "~/components/ui/loading";
 import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
 import { RoomDetailModal } from "~/components/rooms";
+import { TRANSIT_ROOM_ID } from "~/components/rooms/room-detail-modal";
+import { fetchDashboardAnalyticsClient } from "~/lib/dashboard-api";
+import type { DashboardAnalytics } from "~/lib/dashboard-helpers";
+import { LOCATION_COLORS } from "~/lib/location-helper";
 
 // Room interface - entspricht der BackendRoom-Struktur aus den API-Dateien
 interface Room {
@@ -209,6 +213,12 @@ function RoomsPageContent() {
     },
   );
 
+  const { data: dashboardData } = useSWRAuth<DashboardAnalytics>(
+    "dashboard-analytics",
+    fetchDashboardAnalyticsClient,
+    { refreshInterval: 5 * 60 * 1000 },
+  );
+
   const error = roomsError
     ? "Fehler beim Laden der Raumdaten. Bitte versuchen Sie es später erneut."
     : null;
@@ -272,6 +282,19 @@ function RoomsPageContent() {
     },
     [router, searchParams, searchTerm, buildingFilter, occupiedFilter],
   );
+
+  const handleSelectTransitRoom = useCallback(() => {
+    const next = new URLSearchParams(searchParams.toString());
+    if (searchTerm) next.set("search", searchTerm);
+    else next.delete("search");
+    if (buildingFilter !== "all") next.set("building", buildingFilter);
+    else next.delete("building");
+    if (occupiedFilter !== "all") next.set("status", occupiedFilter);
+    else next.delete("status");
+    next.set("room", TRANSIT_ROOM_ID);
+    justPushedRef.current = true;
+    router.push(`/rooms?${next.toString()}`);
+  }, [router, searchParams, searchTerm, buildingFilter, occupiedFilter]);
 
   // After router.push commits, mark the now-current history entry as
   // "we pushed this". Stored in window.history.state so it survives
@@ -386,6 +409,10 @@ function RoomsPageContent() {
     return filters;
   }, [searchTerm, buildingFilter, occupiedFilter]);
 
+  const showTransitRoom =
+    !searchTerm || "unterwegs".includes(searchTerm.toLowerCase());
+  const transitCount = dashboardData?.studentsInTransit ?? 0;
+
   // Auth-loading: nothing to render until NextAuth resolves the session
   // (the `useSession({ required: true })` callback redirects on
   // unauthenticated). Keep the existing loader for this branch.
@@ -446,7 +473,7 @@ function RoomsPageContent() {
           jumped open when rooms loaded. */}
       {loading ? (
         <RoomsGridSkeleton />
-      ) : filteredRooms.length === 0 ? (
+      ) : filteredRooms.length === 0 && !showTransitRoom ? (
         <div className="py-12 text-center">
           <div className="flex flex-col items-center gap-4">
             <svg
@@ -474,6 +501,42 @@ function RoomsPageContent() {
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          {showTransitRoom && (
+            <button
+              type="button"
+              onClick={handleSelectTransitRoom}
+              className="group relative w-full cursor-pointer overflow-hidden rounded-3xl border border-gray-100/50 bg-white/90 text-left shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md transition-all duration-150 active:scale-[0.98] md:hover:-translate-y-0.5 md:hover:border-[#D946EF]/30 md:hover:shadow-[0_12px_40px_rgb(0,0,0,0.18)]"
+            >
+              <div
+                className="absolute inset-0 rounded-3xl opacity-[0.04]"
+                style={{ backgroundColor: LOCATION_COLORS.TRANSIT }}
+              ></div>
+              <div className="absolute inset-px rounded-3xl bg-gradient-to-br from-white/80 to-white/20"></div>
+              <div className="absolute inset-0 rounded-3xl ring-1 ring-white/20 transition-all duration-300 md:group-hover:ring-[#D946EF]/30"></div>
+
+              <div className="relative flex min-h-[180px] flex-col p-6">
+                <div className="mb-3 min-w-0">
+                  <h3 className="overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap text-gray-800 transition-colors duration-300 md:group-hover:text-[#D946EF]">
+                    Unterwegs
+                  </h3>
+                  <p className="mt-0.5 text-sm text-gray-500">
+                    Kinder ohne Raum
+                  </p>
+                </div>
+
+                <div className="flex-1 text-sm text-gray-700">
+                  <span className="font-medium">{transitCount}</span>{" "}
+                  {transitCount === 1 ? "Kind" : "Kinder"} aktuell unterwegs
+                </div>
+
+                <p className="mt-2 text-xs text-gray-400 transition-colors duration-300 md:group-hover:text-[#D946EF]">
+                  Tippen zum Zuweisen
+                </p>
+              </div>
+
+              <div className="absolute inset-0 rounded-3xl bg-gradient-to-r from-transparent via-[#D946EF]/10 to-transparent opacity-0 transition-opacity duration-300 md:group-hover:opacity-100"></div>
+            </button>
+          )}
           {filteredRooms.map((room) => {
             const handleClick = () => handleSelectRoom(room);
             return (

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -25,10 +25,6 @@ import { useSWRAuth } from "~/lib/swr";
 import { Loading } from "~/components/ui/loading";
 import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
 import { RoomDetailModal } from "~/components/rooms";
-import { TRANSIT_ROOM_ID } from "~/components/rooms/room-detail-modal";
-import { fetchDashboardAnalyticsClient } from "~/lib/dashboard-api";
-import type { DashboardAnalytics } from "~/lib/dashboard-helpers";
-import { LOCATION_COLORS } from "~/lib/location-helper";
 
 // Room interface - entspricht der BackendRoom-Struktur aus den API-Dateien
 interface Room {
@@ -213,12 +209,6 @@ function RoomsPageContent() {
     },
   );
 
-  const { data: dashboardData } = useSWRAuth<DashboardAnalytics>(
-    "dashboard-analytics",
-    fetchDashboardAnalyticsClient,
-    { refreshInterval: 5 * 60 * 1000 },
-  );
-
   const error = roomsError
     ? "Fehler beim Laden der Raumdaten. Bitte versuchen Sie es später erneut."
     : null;
@@ -396,10 +386,6 @@ function RoomsPageContent() {
     return filters;
   }, [searchTerm, buildingFilter, occupiedFilter]);
 
-  const showTransitCard =
-    !searchTerm || "unterwegs".includes(searchTerm.toLowerCase());
-  const transitCount = dashboardData?.studentsInTransit ?? 0;
-
   // Auth-loading: nothing to render until NextAuth resolves the session
   // (the `useSession({ required: true })` callback redirects on
   // unauthenticated). Keep the existing loader for this branch.
@@ -449,64 +435,6 @@ function RoomsPageContent() {
         <div className="mb-4 rounded-lg border border-[#FF3130]/30 bg-[#FF3130]/10 p-4 text-[#FF3130]">
           {error}
         </div>
-      )}
-
-      {showTransitCard && (
-        <section className="mb-6">
-          <h2 className="mb-3 px-1 text-xs font-semibold tracking-wider text-gray-500 uppercase">
-            Sonderbereiche
-          </h2>
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-            <button
-              type="button"
-              onClick={() => {
-                const next = new URLSearchParams(searchParams.toString());
-                if (searchTerm) next.set("search", searchTerm);
-                else next.delete("search");
-                if (buildingFilter !== "all")
-                  next.set("building", buildingFilter);
-                else next.delete("building");
-                if (occupiedFilter !== "all")
-                  next.set("status", occupiedFilter);
-                else next.delete("status");
-                next.set("room", TRANSIT_ROOM_ID);
-                justPushedRef.current = true;
-                router.push(`/rooms?${next.toString()}`);
-              }}
-              className="group relative w-full cursor-pointer overflow-hidden rounded-3xl border border-gray-100/50 bg-white/90 text-left shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md transition-all duration-150 active:scale-[0.98] md:hover:-translate-y-0.5 md:hover:border-[#D946EF]/30 md:hover:shadow-[0_12px_40px_rgb(0,0,0,0.18)]"
-            >
-              <div
-                className="absolute inset-0 rounded-3xl opacity-[0.06]"
-                style={{ backgroundColor: LOCATION_COLORS.TRANSIT }}
-              ></div>
-              <div className="absolute inset-px rounded-3xl bg-gradient-to-br from-white/80 to-white/20"></div>
-              <div className="absolute inset-0 rounded-3xl ring-1 ring-white/20 transition-all duration-300 md:group-hover:ring-[#D946EF]/40"></div>
-              <div className="relative flex min-h-[180px] flex-col p-6">
-                <div className="mb-3 flex items-start justify-between">
-                  <div className="min-w-0 flex-1">
-                    <h3 className="overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap text-gray-800 transition-colors duration-300 md:group-hover:text-[#D946EF]">
-                      Unterwegs
-                    </h3>
-                    <p className="mt-0.5 text-sm text-gray-500">
-                      Kinder ohne Raum
-                    </p>
-                  </div>
-                  <span className="ml-3 inline-flex items-center rounded-full bg-[#D946EF]/15 px-2.5 py-1 text-xs font-bold text-[#D946EF]">
-                    Sonderbereich
-                  </span>
-                </div>
-                <div className="flex-1 text-sm text-gray-700">
-                  <span className="font-medium">{transitCount}</span>{" "}
-                  {transitCount === 1 ? "Kind" : "Kinder"} aktuell unterwegs
-                </div>
-                <p className="mt-2 text-xs text-gray-400 transition-colors duration-300 md:group-hover:text-[#D946EF]">
-                  Tippen zum Zuweisen
-                </p>
-              </div>
-              <div className="absolute inset-0 rounded-3xl bg-gradient-to-r from-transparent via-[#D946EF]/15 to-transparent opacity-0 transition-opacity duration-300 md:group-hover:opacity-100"></div>
-            </button>
-          </div>
-        </section>
       )}
 
       {/* Room Cards Grid — skeleton mirrors the populated grid's column

--- a/frontend/src/app/api/active/visits/transit/assign/route.test.ts
+++ b/frontend/src/app/api/active/visits/transit/assign/route.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockAuth, mockApiPost } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockApiPost: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+  auth: mockAuth,
+  uncachedAuth: mockAuth,
+}));
+
+vi.mock("../server/auth", () => ({
+  auth: mockAuth,
+  uncachedAuth: mockAuth,
+}));
+
+vi.mock("~/lib/api-helpers", () => ({
+  apiPost: mockApiPost,
+  handleApiError: vi.fn((error: unknown) => {
+    const message =
+      error instanceof Error ? error.message : "Internal Server Error";
+    return new Response(JSON.stringify({ error: message }), { status: 500 });
+  }),
+}));
+
+import { POST } from "./route";
+
+describe("POST /api/active/visits/transit/assign", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ user: { token: "access-token" } });
+  });
+
+  it("forwards assignments to the backend and unwraps data", async () => {
+    mockApiPost.mockResolvedValue({
+      data: {
+        assigned: [42],
+        skipped: [],
+        active_group_id: 99,
+        room_id: 77,
+      },
+    });
+    const body = { student_ids: [42], active_group_id: 99 };
+    const request = new NextRequest(
+      "http://localhost:3000/api/active/visits/transit/assign",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+
+    const response = await POST(request, { params: Promise.resolve({}) });
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/active/visits/transit/assign",
+      "access-token",
+      body,
+    );
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      data: {
+        assigned: [42],
+        skipped: [],
+        active_group_id: 99,
+        room_id: 77,
+      },
+      message: "Success",
+    });
+  });
+});

--- a/frontend/src/app/api/active/visits/transit/assign/route.ts
+++ b/frontend/src/app/api/active/visits/transit/assign/route.ts
@@ -1,0 +1,18 @@
+import { apiPost } from "~/lib/api-helpers";
+import { createPostHandler } from "~/lib/route-wrapper";
+
+interface AssignTransitBody {
+  student_ids: number[];
+  active_group_id: number;
+}
+
+export const POST = createPostHandler<unknown, AssignTransitBody>(
+  async (_request, body, token) => {
+    const response = await apiPost<{ data: unknown }>(
+      "/api/active/visits/transit/assign",
+      token,
+      body,
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -22,6 +22,9 @@ import {
 } from "~/components/ui/drawer";
 import { useModal } from "~/components/dashboard/modal-context";
 import { RoomDetailLoader } from "./room-detail-content";
+import { TransitStudentsSection } from "./transit-students-section";
+
+export const TRANSIT_ROOM_ID = "__transit__";
 
 interface RoomDetailModalProps {
   readonly roomId: string | null;
@@ -71,7 +74,9 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
               when the loader / error fallback returns a tiny payload.
               No-op on desktop — the side panel is already h-full. */}
           <div className="min-h-[60vh]">
-            {roomId ? (
+            {roomId === TRANSIT_ROOM_ID ? (
+              <TransitStudentsSection />
+            ) : roomId ? (
               <RoomDetailLoader
                 roomId={roomId}
                 // Inline X close button — flows into the room header row

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -24,7 +24,7 @@ import { useModal } from "~/components/dashboard/modal-context";
 import { RoomDetailLoader } from "./room-detail-content";
 import { TransitStudentsSection } from "./transit-students-section";
 
-const TRANSIT_ROOM_ID = "__transit__";
+export const TRANSIT_ROOM_ID = "__transit__";
 
 interface RoomDetailModalProps {
   readonly roomId: string | null;

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -24,7 +24,7 @@ import { useModal } from "~/components/dashboard/modal-context";
 import { RoomDetailLoader } from "./room-detail-content";
 import { TransitStudentsSection } from "./transit-students-section";
 
-export const TRANSIT_ROOM_ID = "__transit__";
+const TRANSIT_ROOM_ID = "__transit__";
 
 interface RoomDetailModalProps {
   readonly roomId: string | null;

--- a/frontend/src/components/rooms/transit-students-section.test.tsx
+++ b/frontend/src/components/rooms/transit-students-section.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { activeService } from "~/lib/active-service";
+import type { ActiveGroup } from "~/lib/active-helpers";
+import type { Student } from "~/lib/api";
+import {
+  useSWRAuth,
+  useTenantMutate,
+  useTenantMutateMatching,
+} from "~/lib/swr";
+import { TransitStudentsSection } from "./transit-students-section";
+
+vi.mock("~/lib/swr", () => ({
+  useSWRAuth: vi.fn(),
+  useTenantMutate: vi.fn(),
+  useTenantMutateMatching: vi.fn(),
+}));
+
+vi.mock("~/lib/active-service", () => ({
+  activeService: {
+    getActiveGroups: vi.fn(),
+    assignTransitStudents: vi.fn(),
+  },
+}));
+
+vi.mock("~/lib/api", () => ({
+  studentService: {
+    getStudents: vi.fn(),
+  },
+}));
+
+const mockStudents: Student[] = [
+  {
+    id: "11",
+    name: "Mila Sommer",
+    first_name: "Mila",
+    second_name: "Sommer",
+    school_class: "2a",
+    group_name: "Gruppe A",
+    current_location: "transit",
+  },
+  {
+    id: "12",
+    name: "Noah Winter",
+    first_name: "Noah",
+    second_name: "Winter",
+    school_class: "3b",
+    group_name: "Gruppe B",
+    current_location: "transit",
+  },
+];
+
+const mockGroups: ActiveGroup[] = [
+  {
+    id: "101",
+    groupId: "201",
+    roomId: "301",
+    startTime: new Date("2026-05-14T08:00:00.000Z"),
+    isActive: true,
+    room: { id: 301, name: "Aula" },
+    actualGroup: { id: 201, name: "Gruppe A" },
+    createdAt: new Date("2026-05-14T08:00:00.000Z"),
+    updatedAt: new Date("2026-05-14T08:00:00.000Z"),
+  },
+  {
+    id: "102",
+    groupId: "202",
+    roomId: "302",
+    startTime: new Date("2026-05-14T08:00:00.000Z"),
+    isActive: false,
+    room: { id: 302, name: "Musikraum" },
+    actualGroup: { id: 202, name: "Gruppe B" },
+    createdAt: new Date("2026-05-14T08:00:00.000Z"),
+    updatedAt: new Date("2026-05-14T08:00:00.000Z"),
+  },
+];
+
+const mutateStudents = vi.fn();
+const mutateKey = vi.fn();
+const mutateMatching = vi.fn();
+
+function mockTransitData({
+  students = mockStudents,
+  activeGroups = mockGroups,
+  studentsError = null,
+  groupsError = null,
+  studentsLoading = false,
+  groupsLoading = false,
+}: {
+  students?: Student[];
+  activeGroups?: ActiveGroup[];
+  studentsError?: Error | null;
+  groupsError?: Error | null;
+  studentsLoading?: boolean;
+  groupsLoading?: boolean;
+} = {}) {
+  vi.mocked(useSWRAuth).mockImplementation((key: unknown) => {
+    if (key === "transit-students") {
+      return {
+        data: { students, pagination: { total_records: students.length } },
+        error: studentsError,
+        isLoading: studentsLoading,
+        mutate: mutateStudents,
+      } as never;
+    }
+
+    if (key === "active-groups-for-transit") {
+      return {
+        data: activeGroups,
+        error: groupsError,
+        isLoading: groupsLoading,
+      } as never;
+    }
+
+    throw new Error(`Unexpected SWR key: ${String(key)}`);
+  });
+}
+
+describe("TransitStudentsSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateStudents.mockResolvedValue(undefined);
+    mutateKey.mockResolvedValue(undefined);
+    mutateMatching.mockResolvedValue(undefined);
+    vi.mocked(useTenantMutate).mockReturnValue(mutateKey as never);
+    vi.mocked(useTenantMutateMatching).mockReturnValue(mutateMatching as never);
+    vi.mocked(activeService.assignTransitStudents).mockResolvedValue({
+      assigned: [11],
+      skipped: [],
+      active_group_id: 101,
+      room_id: 301,
+    });
+    mockTransitData();
+  });
+
+  it("renders transit students and active target rooms", () => {
+    render(<TransitStudentsSection />);
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Kinder ohne Raum")).toBeInTheDocument();
+    expect(screen.getByText("Mila Sommer")).toBeInTheDocument();
+    expect(screen.getByText("Noah Winter")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Aula · Gruppe A" })).toHaveValue(
+      "101",
+    );
+    expect(
+      screen.queryByRole("option", { name: "Musikraum · Gruppe B" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("assigns selected transit students to the selected active room", async () => {
+    render(<TransitStudentsSection />);
+
+    fireEvent.click(screen.getByLabelText("Mila Sommer auswählen"));
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "101" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "1 Kind zuweisen" }));
+
+    await waitFor(() => {
+      expect(activeService.assignTransitStudents).toHaveBeenCalledWith(
+        ["11"],
+        "101",
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText("1 Kind zugewiesen.")).toBeInTheDocument();
+    });
+    expect(mutateStudents).toHaveBeenCalledTimes(1);
+    expect(mutateKey).toHaveBeenCalledWith("rooms-list");
+    expect(mutateMatching).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows empty and error states", () => {
+    mockTransitData({
+      students: [],
+      activeGroups: [],
+      studentsError: new Error("failed"),
+    });
+
+    render(<TransitStudentsSection />);
+
+    expect(
+      screen.getByText("Die Unterwegs-Daten konnten nicht geladen werden."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Aktuell keine Kinder unterwegs."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeDisabled();
+    expect(screen.getByRole("option", { name: "Keine aktiven Räume" }));
+  });
+});

--- a/frontend/src/components/rooms/transit-students-section.test.tsx
+++ b/frontend/src/components/rooms/transit-students-section.test.tsx
@@ -187,6 +187,8 @@ describe("TransitStudentsSection", () => {
       screen.getByText("Aktuell keine Kinder unterwegs."),
     ).toBeInTheDocument();
     expect(screen.getByRole("combobox")).toBeDisabled();
-    expect(screen.getByRole("option", { name: "Keine aktiven Räume" }));
+    expect(
+      screen.getByRole("option", { name: "Keine aktiven Räume" }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/rooms/transit-students-section.tsx
+++ b/frontend/src/components/rooms/transit-students-section.tsx
@@ -11,7 +11,6 @@ import { activeService } from "~/lib/active-service";
 import type { ActiveGroup } from "~/lib/active-helpers";
 import { studentService } from "~/lib/api";
 import type { Student } from "~/lib/api";
-import { LOCATION_COLORS } from "~/lib/location-helper";
 
 function buildSessionLabel(group: ActiveGroup): string {
   const roomName = group.room?.name ?? `Raum ${group.roomId}`;
@@ -121,15 +120,6 @@ export function TransitStudentsSection() {
           <span className="font-medium text-gray-900">{totalCount}</span>{" "}
           {totalCount === 1 ? "Kind" : "Kinder"} ohne Raum
         </p>
-        <span
-          className="rounded-full px-2.5 py-1 text-xs font-medium"
-          style={{
-            backgroundColor: `${LOCATION_COLORS.TRANSIT}1A`,
-            color: LOCATION_COLORS.TRANSIT,
-          }}
-        >
-          Sonderbereich
-        </span>
       </div>
 
       {studentsError || groupsError ? (

--- a/frontend/src/components/rooms/transit-students-section.tsx
+++ b/frontend/src/components/rooms/transit-students-section.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  useSWRAuth,
+  useTenantMutate,
+  useTenantMutateMatching,
+} from "~/lib/swr";
+import { Alert } from "~/components/ui/alert";
+import { activeService } from "~/lib/active-service";
+import type { ActiveGroup } from "~/lib/active-helpers";
+import { studentService } from "~/lib/api";
+import type { Student } from "~/lib/api";
+import { LOCATION_COLORS } from "~/lib/location-helper";
+
+function buildSessionLabel(group: ActiveGroup): string {
+  const roomName = group.room?.name ?? `Raum ${group.roomId}`;
+  const activityName = group.actualGroup?.name;
+  return activityName ? `${roomName} · ${activityName}` : roomName;
+}
+
+export function TransitStudentsSection() {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const [targetGroupId, setTargetGroupId] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const mutateKey = useTenantMutate();
+  const mutateMatching = useTenantMutateMatching([
+    "room-students-",
+    "room-detail-",
+    "rooms-list",
+    "dashboard",
+  ]);
+
+  const {
+    data: studentsData,
+    error: studentsError,
+    isLoading: studentsLoading,
+    mutate: mutateStudents,
+  } = useSWRAuth<{
+    students: Student[];
+    pagination?: { total_records: number };
+  }>("transit-students", () =>
+    studentService.getStudents({ locationState: "transit", pageSize: 200 }),
+  );
+
+  const {
+    data: activeGroups = [],
+    error: groupsError,
+    isLoading: groupsLoading,
+  } = useSWRAuth<ActiveGroup[]>("active-groups-for-transit", () =>
+    activeService.getActiveGroups({ active: true }),
+  );
+
+  const targetOptions = useMemo(
+    () =>
+      [...activeGroups]
+        .filter((group) => group.isActive)
+        .sort((a, b) =>
+          buildSessionLabel(a).localeCompare(buildSessionLabel(b), "de"),
+        ),
+    [activeGroups],
+  );
+
+  const students = studentsData?.students ?? [];
+  const totalCount = studentsData?.pagination?.total_records ?? students.length;
+
+  const toggleSelected = (studentId: string) => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(studentId)) next.delete(studentId);
+      else next.add(studentId);
+      return next;
+    });
+    setMessage(null);
+    setSubmitError(null);
+  };
+
+  const assignSelected = async () => {
+    if (!targetGroupId || selectedIds.size === 0) return;
+    setSubmitting(true);
+    setMessage(null);
+    setSubmitError(null);
+    try {
+      const result = await activeService.assignTransitStudents(
+        Array.from(selectedIds),
+        targetGroupId,
+      );
+      setSelectedIds(new Set());
+      await mutateStudents();
+      await mutateKey("rooms-list");
+      await mutateMatching();
+      const skipped = result.skipped.length;
+      setMessage(
+        skipped > 0
+          ? `${result.assigned.length} zugewiesen, ${skipped} übersprungen.`
+          : `${result.assigned.length} ${
+              result.assigned.length === 1 ? "Kind" : "Kinder"
+            } zugewiesen.`,
+      );
+    } catch {
+      setSubmitError(
+        "Die ausgewählten Kinder konnten nicht zugewiesen werden.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section
+      aria-label="Kinder unterwegs"
+      className="rounded-2xl border border-gray-100 bg-white/50 p-4 backdrop-blur-sm sm:p-6"
+    >
+      <h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">
+        Kinder unterwegs
+      </h2>
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <p className="text-sm text-gray-600">
+          <span className="font-medium text-gray-900">{totalCount}</span>{" "}
+          {totalCount === 1 ? "Kind" : "Kinder"} ohne Raum
+        </p>
+        <span
+          className="rounded-full px-2.5 py-1 text-xs font-medium"
+          style={{
+            backgroundColor: `${LOCATION_COLORS.TRANSIT}1A`,
+            color: LOCATION_COLORS.TRANSIT,
+          }}
+        >
+          Sonderbereich
+        </span>
+      </div>
+
+      {studentsError || groupsError ? (
+        <div className="mt-4">
+          <Alert
+            type="error"
+            message="Die Unterwegs-Daten konnten nicht geladen werden."
+          />
+        </div>
+      ) : null}
+      {submitError ? (
+        <div className="mt-4">
+          <Alert type="error" message={submitError} />
+        </div>
+      ) : null}
+      {message ? (
+        <div className="mt-4 rounded-lg border border-[#83CD2D]/30 bg-[#83CD2D]/10 p-3 text-sm text-[#4a7a15]">
+          {message}
+        </div>
+      ) : null}
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
+        <select
+          value={targetGroupId}
+          onChange={(event) => setTargetGroupId(event.target.value)}
+          disabled={groupsLoading || targetOptions.length === 0}
+          className="min-h-10 rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-900 focus:border-[#5080D8] focus:ring-2 focus:ring-[#5080D8]/20 focus:outline-none disabled:bg-gray-50 disabled:text-gray-400"
+        >
+          <option value="">
+            {groupsLoading
+              ? "Aktive Räume werden geladen..."
+              : targetOptions.length === 0
+                ? "Keine aktiven Räume"
+                : "Zielraum wählen"}
+          </option>
+          {targetOptions.map((group) => (
+            <option key={group.id} value={group.id}>
+              {buildSessionLabel(group)}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void assignSelected()}
+          disabled={!targetGroupId || selectedIds.size === 0 || submitting}
+          className="inline-flex min-h-10 items-center justify-center rounded-lg bg-[#5080D8] px-4 text-sm font-medium text-white transition-colors hover:bg-[#4070c8] disabled:cursor-not-allowed disabled:bg-gray-300"
+        >
+          {submitting
+            ? "Zuweisen..."
+            : `${selectedIds.size} ${
+                selectedIds.size === 1 ? "Kind" : "Kinder"
+              } zuweisen`}
+        </button>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-2">
+        {studentsLoading && students.length === 0 ? (
+          <div className="rounded-xl border border-gray-200 bg-white px-4 py-6 text-center text-sm text-gray-500">
+            Kinder werden geladen...
+          </div>
+        ) : students.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-gray-200 bg-white px-4 py-6 text-center text-sm text-gray-500">
+            Aktuell keine Kinder unterwegs.
+          </div>
+        ) : (
+          students.map((student) => {
+            const studentId = student.id.toString();
+            const checked = selectedIds.has(studentId);
+            return (
+              <label
+                key={student.id}
+                aria-label={`${student.first_name} ${student.second_name} auswählen`}
+                className="flex cursor-pointer items-center gap-3 rounded-xl border border-gray-200 bg-white px-3 py-2 transition-colors hover:bg-gray-50"
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => toggleSelected(studentId)}
+                  className="h-4 w-4 rounded border-gray-300 text-[#5080D8] focus:ring-[#5080D8]"
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-base font-semibold text-gray-900">
+                    {student.first_name} {student.second_name}
+                  </p>
+                  <p className="mt-0.5 truncate text-sm text-gray-500">
+                    {[student.school_class, student.group_name]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </p>
+                </div>
+              </label>
+            );
+          })
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/lib/active-service.test.ts
+++ b/frontend/src/lib/active-service.test.ts
@@ -538,6 +538,36 @@ describe("active-service", () => {
         );
         expect(result.id).toBe("100");
       });
+
+      it("assigns transit students to an active group", async () => {
+        const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                assigned: [50],
+                skipped: [],
+                active_group_id: 1,
+                room_id: 5,
+              },
+            }),
+        } as Response);
+
+        const result = await activeService.assignTransitStudents(["50"], "1");
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/active/visits/transit/assign",
+          expect.objectContaining({
+            method: "POST",
+            body: JSON.stringify({
+              student_ids: [50],
+              active_group_id: 1,
+            }),
+          }),
+        );
+        expect(result.assigned).toEqual([50]);
+      });
     });
 
     describe("updateVisit", () => {

--- a/frontend/src/lib/active-service.ts
+++ b/frontend/src/lib/active-service.ts
@@ -46,6 +46,18 @@ interface ApiResponse<T> {
   status?: string;
 }
 
+interface TransitAssignSkipped {
+  student_id: number;
+  reason: string;
+}
+
+export interface TransitAssignResult {
+  assigned: number[];
+  skipped: TransitAssignSkipped[];
+  active_group_id: number;
+  room_id: number;
+}
+
 interface BackendResponseEnvelope<T> {
   data: T;
   message?: string;
@@ -1017,6 +1029,22 @@ export const activeService = {
       `/active/visits/student/${studentId}/checkout`,
       {},
       "Checkout student",
+    );
+  },
+
+  assignTransitStudents: async (
+    studentIds: string[],
+    activeGroupId: string,
+  ): Promise<TransitAssignResult> => {
+    return coreFetch<TransitAssignResult>(
+      "POST",
+      "/api/active/visits/transit/assign",
+      "/active/visits/transit/assign",
+      "Assign transit students",
+      {
+        student_ids: studentIds.map((id) => Number.parseInt(id, 10)),
+        active_group_id: Number.parseInt(activeGroupId, 10),
+      },
     );
   },
 

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -89,6 +89,7 @@ describe("api.ts helper functions", () => {
           search: "test",
           inHouse: true,
           groupId: "123",
+          locationState: "transit",
           page: 2,
           pageSize: 25,
           token: "test-token",
@@ -99,6 +100,7 @@ describe("api.ts helper functions", () => {
         expect(callUrl).toContain("search=test");
         expect(callUrl).toContain("in_house=true");
         expect(callUrl).toContain("group_id=123");
+        expect(callUrl).toContain("location_state=transit");
         expect(callUrl).toContain("page=2");
         expect(callUrl).toContain("page_size=25");
       } finally {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -174,6 +174,7 @@ function buildStudentQueryParams(filters?: {
   inHouse?: boolean;
   groupId?: string;
   roomId?: string;
+  locationState?: "transit";
   page?: number;
   pageSize?: number;
   includePickupTimes?: boolean;
@@ -188,6 +189,8 @@ function buildStudentQueryParams(filters?: {
   // active group taking place in this room (#1323). Backend joins via
   // active.visits → active.groups; see api/students/list_helpers.go.
   if (filters?.roomId) params.append("room_id", filters.roomId);
+  if (filters?.locationState)
+    params.append("location_state", filters.locationState);
   if (filters?.page) params.append("page", filters.page.toString());
   if (filters?.pageSize)
     params.append("page_size", filters.pageSize.toString());
@@ -767,6 +770,7 @@ export const studentService = {
     inHouse?: boolean;
     groupId?: string;
     roomId?: string;
+    locationState?: "transit";
     page?: number;
     pageSize?: number;
     includePickupTimes?: boolean;


### PR DESCRIPTION
## Summary
- add a virtual Unterwegs room on the Rooms page for checked-in students without an active room visit
- add backend transit listing and bulk assignment endpoints using active attendance/visits
- add frontend selection and room assignment flow for transit students
- cover transit filtering, group intersections, and assignment behavior with tests

## Validation
- cd frontend && pnpm run check
- cd backend && go test ./api/active -count=1
- cd backend && go test ./api/students -run 'TestListStudents_(RoomFilter|LocationStateTransit|LocationStateTransitWithGroupID)' -count=1\n- cd backend && go test ./services/active -run 'TestActiveService_(ListStudentsInTransit|AssignTransitStudentsToActiveGroup)' -count=1\n- cd backend && go test ./test/ -run TestHermeticTestPatterns -v\n- agent-browser smoke test across desktop, mobile, and tablet viewports\n- pre-push: git-secrets, go-vet, golangci-lint, frontend-knip, go-deadcode, frontend-check\n