### PR TITLE
fix: hide tenant switch for hidden tenants

### DIFF
--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -245,6 +245,7 @@ type TenantResolveResponse struct {
 	Subdomain        string          `json:"subdomain"`
 	OrganizationID   int64           `json:"organization_id"`
 	OrganizationName string          `json:"organization_name"`
+	Hidden           bool            `json:"hidden"`
 	Settings         json.RawMessage `json:"settings"`
 	// PresenceMode is the tenant's resolved operations.presence_mode setting
 	// ("detailed" | "binary"). Included so the frontend can render the right
@@ -319,6 +320,7 @@ func (rs *Resource) resolveTenant(w http.ResponseWriter, r *http.Request) {
 		Subdomain:            school.Subdomain,
 		OrganizationID:       school.OrganizationID,
 		OrganizationName:     orgName,
+		Hidden:               school.Hidden,
 		Settings:             settings,
 		PresenceMode:         presenceMode,
 		StudentPhotosEnabled: studentPhotosEnabled,

--- a/backend/api/auth/tenant_resolve_hidden_test.go
+++ b/backend/api/auth/tenant_resolve_hidden_test.go
@@ -1,0 +1,60 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authAPI "github.com/moto-nrw/project-phoenix/api/auth"
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	platformRepo "github.com/moto-nrw/project-phoenix/database/repositories/platform"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+func TestResolveTenant_HiddenSchoolReturnsHiddenFlag(t *testing.T) {
+	db, svc := testutil.SetupAPITest(t)
+	defer func() { _ = db.Close() }()
+
+	const tenantID int64 = 9911
+	testpkg.EnsureTestTenant(t, db, tenantID)
+
+	_, err := db.ExecContext(context.Background(),
+		`UPDATE platform.schools SET hidden = true WHERE id = ?`, tenantID)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(),
+			`UPDATE platform.schools SET hidden = false WHERE id = ?`, tenantID)
+		_, _ = db.ExecContext(context.Background(),
+			`DELETE FROM platform.schools WHERE id = ?`, tenantID)
+		_, _ = db.ExecContext(context.Background(),
+			`DELETE FROM platform.organizations WHERE id = ?`, tenantID)
+	})
+
+	schoolRepo := platformRepo.NewSchoolRepository(db)
+	resource := authAPI.NewResource(svc.Auth, svc.Invitation, schoolRepo, db)
+	resource.SettingsService = svc.Settings
+
+	router := chi.NewRouter()
+	router.Mount("/auth", resource.Router())
+
+	req := httptest.NewRequest("GET", "/auth/tenant/resolve?slug=t9911", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+
+	var resp struct {
+		Data struct {
+			Hidden bool `json:"hidden"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.True(t, resp.Data.Hidden)
+}

--- a/frontend/src/app/[tenant]/layout.tsx
+++ b/frontend/src/app/[tenant]/layout.tsx
@@ -13,6 +13,7 @@ interface TenantResolveResponse {
   subdomain: string;
   organization_id: number;
   organization_name: string;
+  hidden?: boolean;
   settings: TenantSettings;
   presence_mode?: string;
   student_photos_enabled?: boolean;
@@ -44,6 +45,7 @@ async function fetchTenantInfo(slug: string): Promise<TenantInfo | null> {
       subdomain: data.subdomain,
       organizationId: data.organization_id,
       organizationName: data.organization_name,
+      hidden: data.hidden === true,
       settings: data.settings ?? {},
       presenceMode: normalizePresenceMode(data.presence_mode),
       studentPhotosEnabled: data.student_photos_enabled === true,

--- a/frontend/src/app/[tenant]/page.test.tsx
+++ b/frontend/src/app/[tenant]/page.test.tsx
@@ -378,6 +378,10 @@ describe("Tenant selector button", () => {
       status: "unauthenticated",
       update: vi.fn(),
     });
+    vi.mocked(useTenant).mockReturnValue({
+      tenantSlug: "test-tenant",
+      tenant: null,
+    });
     Element.prototype.animate = mockAnimate;
   });
 
@@ -389,6 +393,26 @@ describe("Tenant selector button", () => {
         screen.getByRole("button", { name: /Einrichtung wechseln/i }),
       ).toBeInTheDocument();
     });
+  });
+
+  it("does not render tenant selector button for hidden tenants", async () => {
+    vi.mocked(useTenant).mockReturnValue({
+      tenantSlug: "demo-ogs",
+      tenant: {
+        name: "Demo-OGS",
+        hidden: true,
+      } as ReturnType<typeof useTenant>["tenant"],
+    });
+
+    render(<HomePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Willkommen bei moto!")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("button", { name: /Einrichtung wechseln/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("navigates to tenant domain with port when port is present", async () => {

--- a/frontend/src/app/[tenant]/page.tsx
+++ b/frontend/src/app/[tenant]/page.tsx
@@ -184,34 +184,36 @@ function LoginForm() {
     <div className="flex min-h-screen flex-col items-center justify-center p-4">
       <div className="mx-auto w-full max-w-2xl rounded-2xl bg-white/80 p-10 text-center shadow-xl backdrop-blur-md transition-all duration-300 hover:bg-white/90 hover:shadow-2xl">
         {/* Top Bar: Tenant Selector (left) + Help (right) */}
-        <div className="absolute top-4 right-4 left-4 flex items-center justify-between">
-          <button
-            type="button"
-            onClick={() => {
-              const tenantDomain = env.NEXT_PUBLIC_TENANT_DOMAIN;
-              const portSuffix = window.location.port
-                ? `:${window.location.port}`
-                : "";
-              window.location.href = `${window.location.protocol}//${tenantDomain}${portSuffix}/`;
-            }}
-            className="flex items-center gap-1.5 text-sm text-gray-500 transition-colors hover:text-gray-800"
-          >
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+        {tenant?.hidden !== true && (
+          <div className="absolute top-4 right-4 left-4 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => {
+                const tenantDomain = env.NEXT_PUBLIC_TENANT_DOMAIN;
+                const portSuffix = window.location.port
+                  ? `:${window.location.port}`
+                  : "";
+                window.location.href = `${window.location.protocol}//${tenantDomain}${portSuffix}/`;
+              }}
+              className="flex items-center gap-1.5 text-sm text-gray-500 transition-colors hover:text-gray-800"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-            Einrichtung wechseln
-          </button>
-        </div>
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 19l-7-7 7-7"
+                />
+              </svg>
+              Einrichtung wechseln
+            </button>
+          </div>
+        )}
 
         {/* Logo Section */}
         <div className="mb-8 flex justify-center">

--- a/frontend/src/app/operator/provisioning/edit-school-modal.test.tsx
+++ b/frontend/src/app/operator/provisioning/edit-school-modal.test.tsx
@@ -2,10 +2,12 @@ import type { ReactNode } from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockUpdateSchool, mockLoggerError } = vi.hoisted(() => ({
-  mockUpdateSchool: vi.fn(),
-  mockLoggerError: vi.fn(),
-}));
+const { mockUpdateSchool, mockRevalidateTenantCache, mockLoggerError } =
+  vi.hoisted(() => ({
+    mockUpdateSchool: vi.fn(),
+    mockRevalidateTenantCache: vi.fn(),
+    mockLoggerError: vi.fn(),
+  }));
 
 vi.mock("~/components/ui/modal", () => ({
   Modal: ({
@@ -32,6 +34,8 @@ vi.mock("~/lib/operator/provisioning-api", () => ({
   operatorProvisioningService: {
     updateSchool: (...args: unknown[]) => mockUpdateSchool(...args),
   },
+  revalidateTenantCache: (...args: unknown[]) =>
+    mockRevalidateTenantCache(...args),
 }));
 
 vi.mock("~/lib/operator/provisioning-helpers", async (importOriginal) => {
@@ -160,6 +164,7 @@ describe("EditSchoolModal", () => {
 
   it("sends hidden=true when saving with visibility toggled off", async () => {
     mockUpdateSchool.mockResolvedValue(mockSchool);
+    mockRevalidateTenantCache.mockResolvedValue(undefined);
 
     render(
       <EditSchoolModal
@@ -188,6 +193,10 @@ describe("EditSchoolModal", () => {
         }),
       );
     });
+    expect(mockRevalidateTenantCache).toHaveBeenCalledWith([
+      "test-school",
+      "test-school",
+    ]);
   });
 
   it("sends hidden=false when school is visible", async () => {

--- a/frontend/src/app/operator/provisioning/edit-school-modal.tsx
+++ b/frontend/src/app/operator/provisioning/edit-school-modal.tsx
@@ -102,8 +102,7 @@ export function EditSchoolModal({
           active: school.active,
           hidden: schoolHidden,
         });
-        // Purge ISR cache for old subdomain so it stops serving stale pages
-        if (oldSubdomain !== newSubdomain) {
+        if (oldSubdomain !== newSubdomain || school.hidden !== schoolHidden) {
           await revalidateTenantCache([oldSubdomain, newSubdomain]);
         }
         onClose();

--- a/frontend/src/lib/tenant-api.test.ts
+++ b/frontend/src/lib/tenant-api.test.ts
@@ -105,6 +105,7 @@ describe("tenant-api", () => {
           subdomain: "demo",
           organization_id: 10,
           organization_name: "Org A",
+          hidden: false,
           settings: { primaryColor: "#ff0000" },
         },
       };
@@ -128,6 +129,7 @@ describe("tenant-api", () => {
         subdomain: "demo",
         organizationId: 10,
         organizationName: "Org A",
+        hidden: false,
         settings: { primaryColor: "#ff0000" },
         // Missing presence_mode on a backend response defaults to "detailed"
         // — matches backend's own safe fallback.
@@ -176,6 +178,32 @@ describe("tenant-api", () => {
       );
       const result = await resolveTenant("binary-school");
       expect(result?.presenceMode).toBe("binary");
+    });
+
+    it("maps hidden tenants from resolve response", async () => {
+      const backendData = {
+        status: "success",
+        data: {
+          tenant_id: 3,
+          slug: "demo-ogs",
+          name: "Demo-OGS",
+          subdomain: "demo-ogs",
+          organization_id: 12,
+          organization_name: "Org C",
+          hidden: true,
+          settings: {},
+        },
+      };
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify(backendData), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await resolveTenant("demo-ogs");
+
+      expect(result?.hidden).toBe(true);
     });
 
     it("defaults unknown presence_mode values to detailed", async () => {
@@ -272,6 +300,7 @@ describe("tenant-api", () => {
         subdomain: "school-a",
         organizationId: 0,
         organizationName: "Org Alpha",
+        hidden: false,
         settings: {},
         // List endpoints don't carry per-tenant presence mode; consumers
         // call resolveTenant() once the user picks a tenant.

--- a/frontend/src/lib/tenant-api.ts
+++ b/frontend/src/lib/tenant-api.ts
@@ -38,6 +38,7 @@ export interface TenantInfo {
   subdomain: string;
   organizationId: number;
   organizationName: string;
+  hidden?: boolean;
   settings: TenantSettings;
   presenceMode: PresenceMode;
   /**
@@ -56,6 +57,7 @@ interface TenantResolveResponse {
   subdomain: string;
   organization_id: number;
   organization_name: string;
+  hidden?: boolean;
   settings: TenantSettings;
   presence_mode?: string;
   student_photos_enabled?: boolean;
@@ -96,6 +98,7 @@ export async function resolveTenant(slug: string): Promise<TenantInfo | null> {
       subdomain: data.subdomain,
       organizationId: data.organization_id,
       organizationName: data.organization_name,
+      hidden: data.hidden === true,
       settings: data.settings ?? {},
       presenceMode: normalizePresenceMode(data.presence_mode),
       studentPhotosEnabled: data.student_photos_enabled === true,
@@ -156,6 +159,7 @@ export async function listAllTenants(
           subdomain: t.subdomain,
           organizationId: 0,
           organizationName: t.organization_name,
+          hidden: false,
           settings: {},
           // list endpoints don't carry per-tenant presence mode; consumers
           // that need it call resolveTenant() on the selected slug.


### PR DESCRIPTION
## Summary

- Adds the school hidden flag to tenant resolve responses and frontend tenant metadata
- Hides the tenant login "Einrichtung wechseln" action when the current tenant is hidden
- Covers hidden tenant resolve and login rendering with regression tests

## Tests

- cd frontend && pnpm exec vitest run 'src/app/[tenant]/page.test.tsx' src/lib/tenant-api.test.ts\n- cd frontend && pnpm run check\n- cd backend && go test ./api/auth -run TestResolveTenant -count=1\n- cd backend && go test ./test/ -run TestHermeticTestPatterns -v\n\n## Notes\n\nHidden tenants remain directly reachable by subdomain, but the login page no longer links users back to the root tenant selector where those tenants are intentionally excluded.