### PR TITLE
fix: improve rooms drawer UX

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
@@ -80,10 +80,12 @@ vi.mock("~/components/ui/page-header", () => ({
   PageHeaderWithSearch: ({
     search,
     filters,
+    activeFilters,
     onClearAllFilters,
   }: {
     search: { value: string; onChange: (v: string) => void };
     filters?: Array<{ onChange: (v: string | string[]) => void }>;
+    activeFilters?: Array<{ id: string; label: string; onRemove: () => void }>;
     onClearAllFilters: () => void;
   }) => (
     <div data-testid="page-header">
@@ -107,6 +109,15 @@ vi.mock("~/components/ui/page-header", () => ({
       <button data-testid="clear-filters" onClick={onClearAllFilters}>
         Clear
       </button>
+      {activeFilters?.map((filter) => (
+        <button
+          key={filter.id}
+          data-testid={`remove-filter-${filter.id}`}
+          onClick={filter.onRemove}
+        >
+          {filter.label}
+        </button>
+      ))}
     </div>
   ),
 }));
@@ -232,7 +243,7 @@ describe("RoomsPage", () => {
     // that useTenantRouter wraps.
     expect(mockPush).toHaveBeenCalledWith("/test-tenant/rooms?room=1");
     // updateUrlParams (which uses replace internally) must NOT be called
-    // for opening — only for closing.
+    // for opening, only for closing.
     expect(mockUpdateUrlParams).not.toHaveBeenCalledWith({ room: "1" });
   });
 
@@ -256,7 +267,7 @@ describe("RoomsPage", () => {
 
     // After open-then-close, history must collapse to a single /rooms
     // entry. Replace would leave [/rooms, /rooms] and Back would appear
-    // to do nothing — the close path has to pop the modal entry.
+    // to do nothing, the close path has to pop the modal entry.
     expect(mockBack).toHaveBeenCalledTimes(1);
     expect(mockUpdateUrlParams).not.toHaveBeenCalledWith({ room: null });
   });
@@ -266,7 +277,7 @@ describe("RoomsPage", () => {
     // window.history.state, not in component state. Otherwise drilling
     // into a child and pressing browser Back would remount /rooms with
     // a fresh ref, and the close path would silently fall back to
-    // replace — leaving the duplicate-/rooms history bug intact.
+    // replace, leaving the duplicate-/rooms history bug intact.
     vi.mocked(useSWRAuth).mockReturnValue({
       data: mockRooms,
       isLoading: false,
@@ -462,7 +473,7 @@ describe("RoomsPage", () => {
     render(<RoomsPage />);
 
     // The data-loading state is now a content-shaped skeleton grid in
-    // place of the generic <Loading> spinner — the page header still
+    // place of the generic <Loading> spinner, the page header still
     // renders, only the card grid is replaced with skeleton cards
     // (review feedback #1323). Same business assertion ("a loading
     // state is announced while data is fetched"), new selector
@@ -498,6 +509,47 @@ describe("RoomsPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Raum 101")).toBeInTheDocument();
       expect(screen.queryByText("Freier Raum")).not.toBeInTheDocument();
+    });
+  });
+
+  it("removes active search, building, and status filters from the header chips", async () => {
+    vi.mocked(useSWRAuth).mockReturnValue({
+      data: mockRooms,
+      isLoading: false,
+      error: null,
+    } as never);
+
+    render(<RoomsPage />);
+
+    fireEvent.change(screen.getByTestId("search-input"), {
+      target: { value: "Raum" },
+    });
+    fireEvent.click(screen.getByTestId("filter-building"));
+    fireEvent.click(screen.getByTestId("filter-occupied"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("remove-filter-search")).toBeInTheDocument();
+      expect(screen.getByTestId("remove-filter-building")).toBeInTheDocument();
+      expect(screen.getByTestId("remove-filter-occupied")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("remove-filter-search"));
+    await waitFor(() => {
+      expect(screen.getByTestId("search-input")).toHaveValue("");
+    });
+
+    fireEvent.click(screen.getByTestId("remove-filter-building"));
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("remove-filter-building"),
+      ).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("remove-filter-occupied"));
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("remove-filter-occupied"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
@@ -358,20 +358,57 @@ describe("RoomsPage", () => {
     });
   });
 
-  it("shows transit fake room when rooms data is empty", () => {
-    vi.mocked(useSWRAuth).mockReturnValue({
-      data: [],
-      isLoading: false,
-      error: null,
-    } as never);
+  it("shows the transit assignment entry as a separate work list", () => {
+    vi.mocked(useSWRAuth).mockImplementation((key: unknown) => {
+      if (key === "dashboard-analytics") {
+        return {
+          data: { studentsInTransit: 2 },
+          isLoading: false,
+          error: null,
+        } as never;
+      }
+
+      return {
+        data: [],
+        isLoading: false,
+        error: null,
+      } as never;
+    });
 
     render(<RoomsPage />);
 
     expect(
       screen.getByRole("heading", { name: "Unterwegs" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Kinder ohne Raum")).toBeInTheDocument();
+    expect(screen.getByText("Arbeitsliste")).toBeInTheDocument();
+    expect(screen.getByText(/Kinder ohne Raumzuweisung/)).toBeInTheDocument();
     expect(screen.queryByText("Keine Räume gefunden")).not.toBeInTheDocument();
+  });
+
+  it("opens the transit assignment drawer from the work list", () => {
+    vi.mocked(useSWRAuth).mockImplementation((key: unknown) => {
+      if (key === "dashboard-analytics") {
+        return {
+          data: { studentsInTransit: 2 },
+          isLoading: false,
+          error: null,
+        } as never;
+      }
+
+      return {
+        data: mockRooms,
+        isLoading: false,
+        error: null,
+      } as never;
+    });
+
+    render(<RoomsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Unterwegs/i }));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      "/test-tenant/rooms?room=__transit__",
+    );
   });
 
   it("displays occupied room with group name", () => {

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
@@ -384,6 +384,31 @@ describe("RoomsPage", () => {
     expect(screen.queryByText("Keine Räume gefunden")).not.toBeInTheDocument();
   });
 
+  it("hides the transit assignment entry when no children are unterwegs", () => {
+    vi.mocked(useSWRAuth).mockImplementation((key: unknown) => {
+      if (key === "dashboard-analytics") {
+        return {
+          data: { studentsInTransit: 0 },
+          isLoading: false,
+          error: null,
+        } as never;
+      }
+
+      return {
+        data: [],
+        isLoading: false,
+        error: null,
+      } as never;
+    });
+
+    render(<RoomsPage />);
+
+    expect(
+      screen.queryByRole("heading", { name: "Unterwegs" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Keine Räume gefunden")).toBeInTheDocument();
+  });
+
   it("opens the transit assignment drawer from the work list", () => {
     vi.mocked(useSWRAuth).mockImplementation((key: unknown) => {
       if (key === "dashboard-analytics") {

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
@@ -380,7 +380,6 @@ describe("RoomsPage", () => {
     expect(
       screen.getByRole("heading", { name: "Unterwegs" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Arbeitsliste")).toBeInTheDocument();
     expect(screen.getByText(/Kinder ohne Raumzuweisung/)).toBeInTheDocument();
     expect(screen.queryByText("Keine Räume gefunden")).not.toBeInTheDocument();
   });

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -21,7 +21,7 @@ import {
 } from "~/lib/room-helpers";
 import type { BackendRoom } from "~/lib/room-helpers";
 import { useSWRAuth } from "~/lib/swr";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, Footprints } from "lucide-react";
 
 import { Loading } from "~/components/ui/loading";
 import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
@@ -121,20 +121,15 @@ function TransitAssignmentCard({
           style={{ backgroundColor: `${LOCATION_COLORS.TRANSIT}14` }}
           aria-hidden="true"
         >
-          <span
-            className="h-2.5 w-2.5 rounded-full"
-            style={{ backgroundColor: LOCATION_COLORS.TRANSIT }}
+          <Footprints
+            className="h-5 w-5"
+            style={{ color: LOCATION_COLORS.TRANSIT }}
           />
         </span>
         <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <h2 className="text-base font-semibold text-gray-900 sm:text-lg">
-              Unterwegs
-            </h2>
-            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
-              Arbeitsliste
-            </span>
-          </div>
+          <h2 className="text-base font-semibold text-gray-900 sm:text-lg">
+            Unterwegs
+          </h2>
           <p className="mt-0.5 text-sm text-gray-500">
             <span className="font-medium text-gray-900">{count}</span>{" "}
             {count === 1 ? "Kind" : "Kinder"} ohne Raumzuweisung

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -251,6 +251,17 @@ function RoomsPageContent() {
   // Track whether the click handler just pushed an entry. Used by the
   // effect below to stamp a marker into the resulting history entry.
   const justPushedRef = useRef(false);
+  const roomCardRefs = useRef(new Map<string, HTMLButtonElement>());
+  const pendingFocusRoomIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const roomIdToFocus = pendingFocusRoomIdRef.current;
+    if (selectedRoomId || !roomIdToFocus) return;
+    pendingFocusRoomIdRef.current = null;
+    window.requestAnimationFrame(() => {
+      roomCardRefs.current.get(roomIdToFocus)?.focus();
+    });
+  }, [selectedRoomId]);
 
   // Open the detail modal by pushing ?room={id} as a NEW history entry
   // (not replace), so the browser Back button closes the overlay
@@ -295,6 +306,7 @@ function RoomsPageContent() {
   // got here from the student page's in-app back which pushed a fresh
   // untagged entry).
   const handleCloseDetail = useCallback(() => {
+    pendingFocusRoomIdRef.current = selectedRoomId;
     const state = typeof window !== "undefined" ? window.history.state : null;
     const wasPushedByUs =
       state &&
@@ -306,7 +318,7 @@ function RoomsPageContent() {
     } else {
       updateUrlParams({ room: null });
     }
-  }, [router, updateUrlParams]);
+  }, [router, selectedRoomId, updateUrlParams]);
 
   // Get unique values for filters
   const uniqueBuildings = useMemo(() => {
@@ -480,7 +492,19 @@ function RoomsPageContent() {
               <button
                 type="button"
                 key={room.id}
+                ref={(node) => {
+                  if (node) {
+                    roomCardRefs.current.set(room.id, node);
+                  } else {
+                    roomCardRefs.current.delete(room.id);
+                  }
+                }}
                 onClick={handleClick}
+                aria-haspopup="dialog"
+                aria-expanded={selectedRoomId === room.id}
+                aria-controls={
+                  selectedRoomId === room.id ? "room-detail-panel" : undefined
+                }
                 className="group relative w-full cursor-pointer overflow-hidden rounded-3xl bg-white/90 text-left shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md transition-all duration-150 focus:ring-2 focus:ring-blue-500/50 focus:outline-none active:scale-[0.98] md:hover:-translate-y-0.5 md:hover:bg-white md:hover:shadow-[0_12px_40px_rgb(0,0,0,0.18)]"
               >
                 <div className="relative p-6 pb-5">

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -109,7 +109,7 @@ function RoomsPageContent() {
 
   // Filters are local React state for snappy UI, but their initial
   // value comes from the URL so they SURVIVE a remount when the user
-  // drills /rooms → /students/X → browser back. The student page's
+  // drills through /students/X and returns with browser back. The student page's
   // BackButton pushes back to /rooms with the params we tucked into
   // ?from= (see students-in-room-section.tsx), so on remount the URL
   // re-hydrates the React state.
@@ -138,7 +138,7 @@ function RoomsPageContent() {
   // Mirror local filter state into the URL so the current history entry
   // always reflects the user's view. Without this, typing a filter while
   // the URL is bare /rooms means closing a just-opened room modal pops
-  // back to a URL that never carried those filters — they would survive
+  // back to a URL that never carried those filters. They would survive
   // in React state for now, but a refresh, share, or future remount
   // would silently drop them. router.replace keeps the entry count
   // unchanged, so handleSelectRoom's push and handleCloseDetail's
@@ -275,7 +275,7 @@ function RoomsPageContent() {
 
   // After router.push commits, mark the now-current history entry as
   // "we pushed this". Stored in window.history.state so it survives
-  // page remounts — i.e. when the user drills /rooms → /students/X and
+  // page remounts, for example when the user drills through /students/X and
   // returns via browser back, the marker is still there even though
   // the React component was unmounted in between.
   useEffect(() => {
@@ -437,7 +437,7 @@ function RoomsPageContent() {
         </div>
       )}
 
-      {/* Room Cards Grid — skeleton mirrors the populated grid's column
+      {/* Room Cards Grid, skeleton mirrors the populated grid's column
           breakpoints and per-card shape (rounded-3xl, min-h-[180px],
           header row + meta line + status pill, middle content rows,
           footer hint) so the grid area doesn't visibly resize when real
@@ -481,68 +481,105 @@ function RoomsPageContent() {
                 type="button"
                 key={room.id}
                 onClick={handleClick}
-                className="group relative w-full cursor-pointer overflow-hidden rounded-3xl border border-gray-100/50 bg-white/90 text-left shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md transition-all duration-150 active:scale-[0.98] md:hover:-translate-y-0.5 md:hover:border-[#5080D8]/30 md:hover:shadow-[0_12px_40px_rgb(0,0,0,0.18)]"
+                className="group relative w-full cursor-pointer overflow-hidden rounded-3xl bg-white/90 text-left shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md transition-all duration-150 focus:ring-2 focus:ring-blue-500/50 focus:outline-none active:scale-[0.98] md:hover:-translate-y-0.5 md:hover:bg-white md:hover:shadow-[0_12px_40px_rgb(0,0,0,0.18)]"
               >
-                <div className="absolute inset-0 rounded-3xl bg-[#5080D8] opacity-[0.03]"></div>
-                <div className="absolute inset-px rounded-3xl bg-gradient-to-br from-white/80 to-white/20"></div>
-                <div className="absolute inset-0 rounded-3xl ring-1 ring-white/20 transition-all duration-300 md:group-hover:ring-[#5080D8]/40"></div>
+                <div className="relative p-6 pb-5">
+                  <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-50/80 to-cyan-100/80 opacity-[0.03]" />
+                  <div className="pointer-events-none absolute inset-px bg-gradient-to-br from-white/80 to-white/20" />
+                  <div className="pointer-events-none absolute inset-0 ring-1 ring-white/20 transition-all duration-150 md:group-hover:ring-blue-200/60" />
 
-                <div className="relative flex min-h-[180px] flex-col p-6">
-                  <div className="mb-3 flex items-start justify-between">
-                    <div className="min-w-0 flex-1">
-                      <h3 className="overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap text-gray-800 transition-colors duration-300 md:group-hover:text-[#5080D8]">
-                        {room.name}
-                      </h3>
-                      {(room.building !== undefined ||
-                        room.floor !== undefined) && (
-                        <p className="mt-0.5 text-sm text-gray-500">
-                          {room.building &&
-                            room.floor !== undefined &&
-                            `${room.building} · ${formatFloor(room.floor)}`}
-                          {room.building &&
-                            room.floor === undefined &&
-                            room.building}
-                          {!room.building &&
-                            room.floor !== undefined &&
-                            formatFloor(room.floor)}
-                        </p>
-                      )}
+                  <div className="relative flex min-h-[156px] flex-col">
+                    <div className="mb-3 flex items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <h3 className="overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap text-gray-800 transition-colors duration-150 md:group-hover:text-blue-600">
+                            {room.name}
+                          </h3>
+                          <svg
+                            className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors duration-150 md:group-hover:text-blue-500"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M9 5l7 7-7 7"
+                            />
+                          </svg>
+                        </div>
+                        {(room.building !== undefined ||
+                          room.floor !== undefined) && (
+                          <p className="mt-0.5 overflow-hidden text-sm text-ellipsis whitespace-nowrap text-gray-500 transition-colors duration-150 md:group-hover:text-blue-500">
+                            {room.building &&
+                              room.floor !== undefined &&
+                              `${room.building} · ${formatFloor(room.floor)}`}
+                            {room.building &&
+                              room.floor === undefined &&
+                              room.building}
+                            {!room.building &&
+                              room.floor !== undefined &&
+                              formatFloor(room.floor)}
+                          </p>
+                        )}
+                      </div>
+
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-bold ${
+                          room.isOccupied
+                            ? "bg-[#FF3130]/15 text-[#FF3130]"
+                            : "bg-[#83CD2D]/15 text-[#4a7a15]"
+                        }`}
+                      >
+                        <span
+                          className={`mr-1.5 h-1.5 w-1.5 rounded-full ${
+                            room.isOccupied
+                              ? "animate-pulse bg-[#FF3130]"
+                              : "bg-[#83CD2D]"
+                          }`}
+                        ></span>
+                        {room.isOccupied ? "Belegt" : "Frei"}
+                      </span>
                     </div>
 
-                    <span
-                      className={`ml-3 inline-flex items-center rounded-full px-2.5 py-1 text-xs font-bold ${
-                        room.isOccupied
-                          ? "bg-[#FF3130]/15 text-[#FF3130]"
-                          : "bg-[#83CD2D]/15 text-[#4a7a15]"
-                      }`}
-                    >
-                      <span
-                        className={`mr-1.5 h-1.5 w-1.5 rounded-full ${
-                          room.isOccupied
-                            ? "animate-pulse bg-[#FF3130]"
-                            : "bg-[#83CD2D]"
-                        }`}
-                      ></span>
-                      {room.isOccupied ? "Belegt" : "Frei"}
-                    </span>
-                  </div>
-
-                  {/* Middle section: Room details (grows to fill space) */}
-                  <div className="flex-1 space-y-2">
-                    {/* When occupied: Activity + Student count + Supervisor */}
-                    {room.isOccupied && room.groupName && (
-                      <div className="text-sm text-gray-700">
-                        <span className="font-medium">Aktuelle Aktivität:</span>{" "}
-                        {room.groupName}
-                      </div>
-                    )}
-                    {room.isOccupied &&
-                      ((room.studentCount !== undefined &&
-                        room.studentCount > 0) ||
-                        room.supervisorName) && (
-                        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-600">
-                          {room.studentCount !== undefined &&
-                            room.studentCount > 0 && (
+                    {/* Middle section: Room details (grows to fill space) */}
+                    <div className="flex-1 space-y-2">
+                      {/* When occupied: Activity + Student count + Supervisor */}
+                      {room.isOccupied && room.groupName && (
+                        <div className="text-sm text-gray-700">
+                          <span className="font-medium">
+                            Aktuelle Aktivität:
+                          </span>{" "}
+                          {room.groupName}
+                        </div>
+                      )}
+                      {room.isOccupied &&
+                        ((room.studentCount !== undefined &&
+                          room.studentCount > 0) ||
+                          room.supervisorName) && (
+                          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-600">
+                            {room.studentCount !== undefined &&
+                              room.studentCount > 0 && (
+                                <span className="flex items-center gap-1">
+                                  <svg
+                                    className="h-4 w-4"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                  >
+                                    <path
+                                      strokeLinecap="round"
+                                      strokeLinejoin="round"
+                                      strokeWidth={2}
+                                      d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                                    />
+                                  </svg>
+                                  {room.studentCount}{" "}
+                                  {room.studentCount === 1 ? "Kind" : "Kinder"}
+                                </span>
+                              )}
+                            {room.supervisorName && (
                               <span className="flex items-center gap-1">
                                 <svg
                                   className="h-4 w-4"
@@ -554,58 +591,37 @@ function RoomsPageContent() {
                                     strokeLinecap="round"
                                     strokeLinejoin="round"
                                     strokeWidth={2}
-                                    d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                                    d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2"
                                   />
                                 </svg>
-                                {room.studentCount}{" "}
-                                {room.studentCount === 1 ? "Kind" : "Kinder"}
+                                {room.supervisorName}
                               </span>
                             )}
-                          {room.supervisorName && (
-                            <span className="flex items-center gap-1">
-                              <svg
-                                className="h-4 w-4"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth={2}
-                                  d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2"
-                                />
-                              </svg>
-                              {room.supervisorName}
-                            </span>
-                          )}
-                        </div>
-                      )}
-
-                    {/* When free: Placeholder text */}
-                    {!room.isOccupied && (
-                      <>
-                        <div className="text-sm text-gray-600">
-                          Für Aktivitäten buchbar
-                        </div>
-                        {room.capacity !== undefined && room.capacity > 0 && (
-                          <div className="text-sm text-gray-600">
-                            Kapazität: {room.capacity} Plätze
                           </div>
                         )}
-                      </>
-                    )}
+
+                      {/* When free: Placeholder text */}
+                      {!room.isOccupied && (
+                        <>
+                          <div className="text-sm text-gray-600">
+                            Für Aktivitäten buchbar
+                          </div>
+                          {room.capacity !== undefined && room.capacity > 0 && (
+                            <div className="text-sm text-gray-600">
+                              Kapazität: {room.capacity} Plätze
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </div>
+
+                    <p className="mt-2 text-xs text-gray-400 transition-colors duration-150 md:group-hover:text-blue-400">
+                      Tippen für mehr Infos
+                    </p>
+
+                    <div className="absolute right-3 bottom-3 h-3 w-3 rounded-full bg-white/30"></div>
                   </div>
-
-                  <p className="mt-2 text-xs text-gray-400 transition-colors duration-300 md:group-hover:text-[#5080D8]">
-                    Tippen für mehr Infos
-                  </p>
-
-                  <div className="absolute top-4 left-4 h-4 w-4 animate-ping rounded-full bg-white/20"></div>
-                  <div className="absolute right-4 bottom-4 h-2.5 w-2.5 rounded-full bg-white/30"></div>
                 </div>
-
-                <div className="absolute inset-0 rounded-3xl bg-gradient-to-r from-transparent via-[#5080D8]/15 to-transparent opacity-0 transition-opacity duration-300 md:group-hover:opacity-100"></div>
               </button>
             );
           })}
@@ -618,7 +634,7 @@ function RoomsPageContent() {
 }
 
 // Main component with Suspense wrapper + binary-mode 404 guard.
-// Binary-mode tenants don't track room occupancy — the concepts this page
+// Binary-mode tenants don't track room occupancy, so the concepts this page
 // surfaces don't apply. Guard triggers Next.js notFound() for direct URL entry.
 export default function RoomsPage() {
   return (

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -470,8 +470,11 @@ function RoomsPageContent() {
   }, [searchTerm, buildingFilter, occupiedFilter]);
 
   const transitCount = dashboardData?.studentsInTransit ?? 0;
+  const normalizedSearchTerm = searchTerm.trim().toLowerCase();
   const showTransitAssignment =
-    transitCount > 0 || "unterwegs".includes(searchTerm.toLowerCase());
+    transitCount > 0 ||
+    (normalizedSearchTerm.length > 0 &&
+      "unterwegs".includes(normalizedSearchTerm));
 
   // Auth-loading: nothing to render until NextAuth resolves the session
   // (the `useSession({ required: true })` callback redirects on

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "~/lib/room-helpers";
 import type { BackendRoom } from "~/lib/room-helpers";
 import { useSWRAuth } from "~/lib/swr";
+import { ArrowRight } from "lucide-react";
 
 import { Loading } from "~/components/ui/loading";
 import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
@@ -93,6 +94,58 @@ function RoomsGridSkeleton() {
         <RoomCardSkeleton key={i} />
       ))}
     </output>
+  );
+}
+
+function TransitAssignmentCard({
+  count,
+  onOpen,
+  buttonRef,
+}: {
+  readonly count: number;
+  readonly onOpen: () => void;
+  readonly buttonRef: (node: HTMLButtonElement | null) => void;
+}) {
+  return (
+    <button
+      type="button"
+      ref={buttonRef}
+      onClick={onOpen}
+      aria-haspopup="dialog"
+      aria-controls="room-detail-panel"
+      className="group mb-5 flex w-full items-center justify-between gap-4 rounded-2xl border border-gray-100 bg-white/90 p-4 text-left shadow-[0_8px_30px_rgb(0,0,0,0.10)] backdrop-blur-md transition-all duration-150 hover:-translate-y-0.5 hover:border-gray-200 hover:bg-white hover:shadow-[0_12px_40px_rgb(0,0,0,0.14)] focus:ring-2 focus:ring-gray-300 focus:outline-none active:scale-[0.99] sm:p-5"
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <span
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
+          style={{ backgroundColor: `${LOCATION_COLORS.TRANSIT}14` }}
+          aria-hidden="true"
+        >
+          <span
+            className="h-2.5 w-2.5 rounded-full"
+            style={{ backgroundColor: LOCATION_COLORS.TRANSIT }}
+          />
+        </span>
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <h2 className="text-base font-semibold text-gray-900 sm:text-lg">
+              Unterwegs
+            </h2>
+            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+              Arbeitsliste
+            </span>
+          </div>
+          <p className="mt-0.5 text-sm text-gray-500">
+            <span className="font-medium text-gray-900">{count}</span>{" "}
+            {count === 1 ? "Kind" : "Kinder"} ohne Raumzuweisung
+          </p>
+        </div>
+      </div>
+      <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors group-hover:border-gray-300 group-hover:bg-gray-50">
+        Zuweisen
+        <ArrowRight className="h-4 w-4 text-gray-500" aria-hidden="true" />
+      </span>
+    </button>
   );
 }
 
@@ -421,9 +474,9 @@ function RoomsPageContent() {
     return filters;
   }, [searchTerm, buildingFilter, occupiedFilter]);
 
-  const showTransitRoom =
-    !searchTerm || "unterwegs".includes(searchTerm.toLowerCase());
   const transitCount = dashboardData?.studentsInTransit ?? 0;
+  const showTransitAssignment =
+    transitCount > 0 || "unterwegs".includes(searchTerm.toLowerCase());
 
   // Auth-loading: nothing to render until NextAuth resolves the session
   // (the `useSession({ required: true })` callback redirects on
@@ -485,234 +538,220 @@ function RoomsPageContent() {
           jumped open when rooms loaded. */}
       {loading ? (
         <RoomsGridSkeleton />
-      ) : filteredRooms.length === 0 && !showTransitRoom ? (
-        <div className="py-12 text-center">
-          <div className="flex flex-col items-center gap-4">
-            <svg
-              className="h-12 w-12 text-gray-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-              />
-            </svg>
-            <div>
-              <h3 className="text-lg font-medium text-gray-900">
-                Keine Räume gefunden
-              </h3>
-              <p className="text-gray-600">
-                Versuchen Sie Ihre Suchkriterien anzupassen.
-              </p>
-            </div>
-          </div>
-        </div>
       ) : (
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-          {showTransitRoom && (
-            <button
-              type="button"
-              onClick={handleSelectTransitRoom}
-              className="group relative w-full cursor-pointer overflow-hidden rounded-3xl border border-gray-100/50 bg-white/90 text-left shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md transition-all duration-150 active:scale-[0.98] md:hover:-translate-y-0.5 md:hover:border-[#D946EF]/30 md:hover:shadow-[0_12px_40px_rgb(0,0,0,0.18)]"
-            >
-              <div
-                className="absolute inset-0 rounded-3xl opacity-[0.04]"
-                style={{ backgroundColor: LOCATION_COLORS.TRANSIT }}
-              ></div>
-              <div className="absolute inset-px rounded-3xl bg-gradient-to-br from-white/80 to-white/20"></div>
-              <div className="absolute inset-0 rounded-3xl ring-1 ring-white/20 transition-all duration-300 md:group-hover:ring-[#D946EF]/30"></div>
+        <>
+          {showTransitAssignment ? (
+            <TransitAssignmentCard
+              count={transitCount}
+              onOpen={handleSelectTransitRoom}
+              buttonRef={(node) => {
+                if (node) {
+                  roomCardRefs.current.set(TRANSIT_ROOM_ID, node);
+                } else {
+                  roomCardRefs.current.delete(TRANSIT_ROOM_ID);
+                }
+              }}
+            />
+          ) : null}
 
-              <div className="relative flex min-h-[180px] flex-col p-6">
-                <div className="mb-3 min-w-0">
-                  <h3 className="overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap text-gray-800 transition-colors duration-300 md:group-hover:text-[#D946EF]">
-                    Unterwegs
+          {filteredRooms.length === 0 && !showTransitAssignment ? (
+            <div className="py-12 text-center">
+              <div className="flex flex-col items-center gap-4">
+                <svg
+                  className="h-12 w-12 text-gray-400"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+                  />
+                </svg>
+                <div>
+                  <h3 className="text-lg font-medium text-gray-900">
+                    Keine Räume gefunden
                   </h3>
-                  <p className="mt-0.5 text-sm text-gray-500">
-                    Kinder ohne Raum
+                  <p className="text-gray-600">
+                    Versuchen Sie Ihre Suchkriterien anzupassen.
                   </p>
                 </div>
-
-                <div className="flex-1 text-sm text-gray-700">
-                  <span className="font-medium">{transitCount}</span>{" "}
-                  {transitCount === 1 ? "Kind" : "Kinder"} aktuell unterwegs
-                </div>
-
-                <p className="mt-2 text-xs text-gray-400 transition-colors duration-300 md:group-hover:text-[#D946EF]">
-                  Tippen zum Zuweisen
-                </p>
               </div>
+            </div>
+          ) : null}
 
-              <div className="absolute inset-0 rounded-3xl bg-gradient-to-r from-transparent via-[#D946EF]/10 to-transparent opacity-0 transition-opacity duration-300 md:group-hover:opacity-100"></div>
-            </button>
-          )}
-          {filteredRooms.map((room) => {
-            const handleClick = () => handleSelectRoom(room);
-            return (
-              <button
-                type="button"
-                key={room.id}
-                ref={(node) => {
-                  if (node) {
-                    roomCardRefs.current.set(room.id, node);
-                  } else {
-                    roomCardRefs.current.delete(room.id);
-                  }
-                }}
-                onClick={handleClick}
-                aria-haspopup="dialog"
-                aria-expanded={selectedRoomId === room.id}
-                aria-controls={
-                  selectedRoomId === room.id ? "room-detail-panel" : undefined
-                }
-                className="group relative w-full cursor-pointer overflow-hidden rounded-3xl bg-white/90 text-left shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md transition-all duration-150 focus:ring-2 focus:ring-blue-500/50 focus:outline-none active:scale-[0.98] md:hover:-translate-y-0.5 md:hover:bg-white md:hover:shadow-[0_12px_40px_rgb(0,0,0,0.18)]"
-              >
-                <div className="relative p-6 pb-5">
-                  <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-50/80 to-cyan-100/80 opacity-[0.03]" />
-                  <div className="pointer-events-none absolute inset-px bg-gradient-to-br from-white/80 to-white/20" />
-                  <div className="pointer-events-none absolute inset-0 ring-1 ring-white/20 transition-all duration-150 md:group-hover:ring-blue-200/60" />
+          {filteredRooms.length > 0 ? (
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+              {filteredRooms.map((room) => {
+                const handleClick = () => handleSelectRoom(room);
+                return (
+                  <button
+                    type="button"
+                    key={room.id}
+                    ref={(node) => {
+                      if (node) {
+                        roomCardRefs.current.set(room.id, node);
+                      } else {
+                        roomCardRefs.current.delete(room.id);
+                      }
+                    }}
+                    onClick={handleClick}
+                    aria-haspopup="dialog"
+                    aria-expanded={selectedRoomId === room.id}
+                    aria-controls={
+                      selectedRoomId === room.id
+                        ? "room-detail-panel"
+                        : undefined
+                    }
+                    className="group relative w-full cursor-pointer overflow-hidden rounded-3xl bg-white/90 text-left shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-md transition-all duration-150 focus:ring-2 focus:ring-blue-500/50 focus:outline-none active:scale-[0.98] md:hover:-translate-y-0.5 md:hover:bg-white md:hover:shadow-[0_12px_40px_rgb(0,0,0,0.18)]"
+                  >
+                    <div className="relative p-6 pb-5">
+                      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-50/80 to-cyan-100/80 opacity-[0.03]" />
+                      <div className="pointer-events-none absolute inset-px bg-gradient-to-br from-white/80 to-white/20" />
+                      <div className="pointer-events-none absolute inset-0 ring-1 ring-white/20 transition-all duration-150 md:group-hover:ring-blue-200/60" />
 
-                  <div className="relative flex min-h-[156px] flex-col">
-                    <div className="mb-3 flex items-start justify-between gap-3">
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-2">
-                          <h3 className="overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap text-gray-800 transition-colors duration-150 md:group-hover:text-blue-600">
-                            {room.name}
-                          </h3>
-                          <svg
-                            className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors duration-150 md:group-hover:text-blue-500"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M9 5l7 7-7 7"
-                            />
-                          </svg>
-                        </div>
-                        {(room.building !== undefined ||
-                          room.floor !== undefined) && (
-                          <p className="mt-0.5 overflow-hidden text-sm text-ellipsis whitespace-nowrap text-gray-500 transition-colors duration-150 md:group-hover:text-blue-500">
-                            {room.building &&
-                              room.floor !== undefined &&
-                              `${room.building} · ${formatFloor(room.floor)}`}
-                            {room.building &&
-                              room.floor === undefined &&
-                              room.building}
-                            {!room.building &&
-                              room.floor !== undefined &&
-                              formatFloor(room.floor)}
-                          </p>
-                        )}
-                      </div>
-
-                      <span
-                        className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-bold ${
-                          room.isOccupied
-                            ? "bg-[#FF3130]/15 text-[#FF3130]"
-                            : "bg-[#83CD2D]/15 text-[#4a7a15]"
-                        }`}
-                      >
-                        <span
-                          className={`mr-1.5 h-1.5 w-1.5 rounded-full ${
-                            room.isOccupied
-                              ? "animate-pulse bg-[#FF3130]"
-                              : "bg-[#83CD2D]"
-                          }`}
-                        ></span>
-                        {room.isOccupied ? "Belegt" : "Frei"}
-                      </span>
-                    </div>
-
-                    {/* Middle section: Room details (grows to fill space) */}
-                    <div className="flex-1 space-y-2">
-                      {/* When occupied: Activity + Student count + Supervisor */}
-                      {room.isOccupied && room.groupName && (
-                        <div className="text-sm text-gray-700">
-                          <span className="font-medium">
-                            Aktuelle Aktivität:
-                          </span>{" "}
-                          {room.groupName}
-                        </div>
-                      )}
-                      {room.isOccupied &&
-                        ((room.studentCount !== undefined &&
-                          room.studentCount > 0) ||
-                          room.supervisorName) && (
-                          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-600">
-                            {room.studentCount !== undefined &&
-                              room.studentCount > 0 && (
-                                <span className="flex items-center gap-1">
-                                  <svg
-                                    className="h-4 w-4"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                  >
-                                    <path
-                                      strokeLinecap="round"
-                                      strokeLinejoin="round"
-                                      strokeWidth={2}
-                                      d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                                    />
-                                  </svg>
-                                  {room.studentCount}{" "}
-                                  {room.studentCount === 1 ? "Kind" : "Kinder"}
-                                </span>
-                              )}
-                            {room.supervisorName && (
-                              <span className="flex items-center gap-1">
-                                <svg
-                                  className="h-4 w-4"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2"
-                                  />
-                                </svg>
-                                {room.supervisorName}
-                              </span>
+                      <div className="relative flex min-h-[156px] flex-col">
+                        <div className="mb-3 flex items-start justify-between gap-3">
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2">
+                              <h3 className="overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap text-gray-800 transition-colors duration-150 md:group-hover:text-blue-600">
+                                {room.name}
+                              </h3>
+                              <svg
+                                className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors duration-150 md:group-hover:text-blue-500"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M9 5l7 7-7 7"
+                                />
+                              </svg>
+                            </div>
+                            {(room.building !== undefined ||
+                              room.floor !== undefined) && (
+                              <p className="mt-0.5 overflow-hidden text-sm text-ellipsis whitespace-nowrap text-gray-500 transition-colors duration-150 md:group-hover:text-blue-500">
+                                {room.building &&
+                                  room.floor !== undefined &&
+                                  `${room.building} · ${formatFloor(room.floor)}`}
+                                {room.building &&
+                                  room.floor === undefined &&
+                                  room.building}
+                                {!room.building &&
+                                  room.floor !== undefined &&
+                                  formatFloor(room.floor)}
+                              </p>
                             )}
                           </div>
-                        )}
 
-                      {/* When free: Placeholder text */}
-                      {!room.isOccupied && (
-                        <>
-                          <div className="text-sm text-gray-600">
-                            Für Aktivitäten buchbar
-                          </div>
-                          {room.capacity !== undefined && room.capacity > 0 && (
-                            <div className="text-sm text-gray-600">
-                              Kapazität: {room.capacity} Plätze
+                          <span
+                            className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-bold ${
+                              room.isOccupied
+                                ? "bg-[#FF3130]/15 text-[#FF3130]"
+                                : "bg-[#83CD2D]/15 text-[#4a7a15]"
+                            }`}
+                          >
+                            <span
+                              className={`mr-1.5 h-1.5 w-1.5 rounded-full ${
+                                room.isOccupied
+                                  ? "animate-pulse bg-[#FF3130]"
+                                  : "bg-[#83CD2D]"
+                              }`}
+                            ></span>
+                            {room.isOccupied ? "Belegt" : "Frei"}
+                          </span>
+                        </div>
+
+                        <div className="flex-1 space-y-2">
+                          {room.isOccupied && room.groupName && (
+                            <div className="text-sm text-gray-700">
+                              <span className="font-medium">
+                                Aktuelle Aktivität:
+                              </span>{" "}
+                              {room.groupName}
                             </div>
                           )}
-                        </>
-                      )}
+                          {room.isOccupied &&
+                            ((room.studentCount !== undefined &&
+                              room.studentCount > 0) ||
+                              room.supervisorName) && (
+                              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-600">
+                                {room.studentCount !== undefined &&
+                                  room.studentCount > 0 && (
+                                    <span className="flex items-center gap-1">
+                                      <svg
+                                        className="h-4 w-4"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                        stroke="currentColor"
+                                      >
+                                        <path
+                                          strokeLinecap="round"
+                                          strokeLinejoin="round"
+                                          strokeWidth={2}
+                                          d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                                        />
+                                      </svg>
+                                      {room.studentCount}{" "}
+                                      {room.studentCount === 1
+                                        ? "Kind"
+                                        : "Kinder"}
+                                    </span>
+                                  )}
+                                {room.supervisorName && (
+                                  <span className="flex items-center gap-1">
+                                    <svg
+                                      className="h-4 w-4"
+                                      fill="none"
+                                      viewBox="0 0 24 24"
+                                      stroke="currentColor"
+                                    >
+                                      <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2"
+                                      />
+                                    </svg>
+                                    {room.supervisorName}
+                                  </span>
+                                )}
+                              </div>
+                            )}
+
+                          {!room.isOccupied && (
+                            <>
+                              <div className="text-sm text-gray-600">
+                                Für Aktivitäten buchbar
+                              </div>
+                              {room.capacity !== undefined &&
+                                room.capacity > 0 && (
+                                  <div className="text-sm text-gray-600">
+                                    Kapazität: {room.capacity} Plätze
+                                  </div>
+                                )}
+                            </>
+                          )}
+                        </div>
+
+                        <p className="mt-2 text-xs text-gray-400 transition-colors duration-150 md:group-hover:text-blue-400">
+                          Tippen für mehr Infos
+                        </p>
+
+                        <div className="absolute right-3 bottom-3 h-3 w-3 rounded-full bg-white/30"></div>
+                      </div>
                     </div>
-
-                    <p className="mt-2 text-xs text-gray-400 transition-colors duration-150 md:group-hover:text-blue-400">
-                      Tippen für mehr Infos
-                    </p>
-
-                    <div className="absolute right-3 bottom-3 h-3 w-3 rounded-full bg-white/30"></div>
-                  </div>
-                </div>
-              </button>
-            );
-          })}
-        </div>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+        </>
       )}
 
       <RoomDetailModal roomId={selectedRoomId} onClose={handleCloseDetail} />

--- a/frontend/src/components/rooms/room-detail-content.test.tsx
+++ b/frontend/src/components/rooms/room-detail-content.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { RoomDetailContent, RoomDetailLoader } from "./room-detail-content";
 
 // ----------------------------------------------------------------------------
-// Mocks — keep dependencies cheap so we exercise this file's own logic
+// Mocks: keep dependencies cheap so we exercise this file's own logic
 // (useRoomDetail fetcher branches, mapping helpers, render conditionals,
 // loader states) rather than session/SSE plumbing.
 // ----------------------------------------------------------------------------
@@ -40,7 +40,7 @@ vi.mock("~/lib/swr", async () => {
       const [loading, setLoading] = React.useState(true);
 
       // Hold the fetcher in a ref so the effect can depend only on `key`
-      // without lint complaints — the fetcher closure is recreated on
+      // without lint complaints. The fetcher closure is recreated on
       // every render of useRoomDetail, so re-running the effect on each
       // identity change would loop. This mirrors the dedup behavior the
       // real SWR provides via its own cache.
@@ -80,7 +80,7 @@ vi.mock("~/lib/swr", async () => {
 // Loading widget is no longer used by RoomDetailLoader (replaced with a
 // content-shaped RoomDetailSkeleton in #1323 review). The test below now
 // targets the skeleton's data-testid + role="status" instead of the old
-// "loading" testid — same business assertion (a loading state IS shown
+// "loading" testid. Same business assertion (a loading state IS shown
 // while SWR fetches), new selector that matches the new shape.
 
 vi.mock("~/components/ui/info-card", () => ({
@@ -171,7 +171,7 @@ const notOk = (): FetchResponse => ({
 });
 
 // ----------------------------------------------------------------------------
-// useRoomDetail — exercised through the RoomDetailLoader render path.
+// useRoomDetail, exercised through the RoomDetailLoader render path.
 // ----------------------------------------------------------------------------
 
 describe("useRoomDetail (via RoomDetailLoader)", () => {
@@ -265,7 +265,7 @@ describe("useRoomDetail (via RoomDetailLoader)", () => {
     expect(screen.getByText("Lesen")).toBeInTheDocument();
   });
 
-  it("collapses to empty history when the wrapper carries data:null (#1374 regression guard)", async () => {
+  it("hides history when the wrapper carries data:null (#1374 regression guard)", async () => {
     mockFetch
       .mockResolvedValueOnce(
         okJson({ id: 3003, name: "Kleiner Raum", is_occupied: false }),
@@ -287,9 +287,7 @@ describe("useRoomDetail (via RoomDetailLoader)", () => {
     await waitFor(() =>
       expect(screen.getAllByText("Kleiner Raum")[0]).toBeInTheDocument(),
     );
-    expect(
-      screen.getByText("Keine Belegungshistorie verfügbar."),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("Belegungshistorie")).not.toBeInTheDocument();
   });
 
   it("treats a non-OK history response as empty (does not throw)", async () => {
@@ -308,9 +306,7 @@ describe("useRoomDetail (via RoomDetailLoader)", () => {
     await waitFor(() =>
       expect(screen.getAllByText("Sporthalle")[0]).toBeInTheDocument(),
     );
-    expect(
-      screen.getByText("Keine Belegungshistorie verfügbar."),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("Belegungshistorie")).not.toBeInTheDocument();
   });
 
   it("renders the error placeholder when the room fetch fails", async () => {
@@ -349,7 +345,7 @@ describe("useRoomDetail (via RoomDetailLoader)", () => {
 });
 
 // ----------------------------------------------------------------------------
-// RoomDetailContent — render-state branches the loader-path tests don't reach.
+// RoomDetailContent, render-state branches the loader-path tests don't reach.
 // ----------------------------------------------------------------------------
 
 const baseRoom = {
@@ -366,7 +362,7 @@ describe("RoomDetailContent", () => {
       </Wrapper>,
     );
     // "Frei" renders in the StatusBadge AND in the Rauminformationen
-    // Status row — both must be present to give staff the same signal
+    // Status row, both must be present to give staff the same signal
     // wherever they look.
     expect(screen.getAllByText(/Frei/).length).toBeGreaterThanOrEqual(2);
     expect(screen.queryByText("Aktuelle Aktivität")).not.toBeInTheDocument();
@@ -420,8 +416,8 @@ describe("RoomDetailContent", () => {
 
   it("hides the supervisor and student-count rows when those fields are missing", () => {
     // Defensive: if the backend doesn't report a supervisor/count yet
-    // (e.g. group is in transition), the detail block must collapse —
-    // empty rows would look like "Aktuelle Aufsicht: —" placeholders
+    // (e.g. group is in transition), the detail block must collapse.
+    // Empty rows would look like "Aktuelle Aufsicht: -" placeholders
     // which is worse UX than just not showing them.
     render(
       <Wrapper>
@@ -437,7 +433,7 @@ describe("RoomDetailContent", () => {
   });
 
   it("renders Gebäude / Etage / Kategorie rows but NOT a separate Raumname row", () => {
-    // Raumname intentionally omitted from the detail block — review
+    // Raumname intentionally omitted from the detail block. Review
     // feedback (#1323): the room name is already the h1 above the
     // detail card, so a "Raumname: …" row was pure redundancy. The
     // remaining static fields must still all render.
@@ -464,7 +460,7 @@ describe("RoomDetailContent", () => {
 
   it("does not render the legacy building · floor · category subline under the header", () => {
     // The "Hauptgebäude · Etage 2" subline that used to sit under the
-    // h1 was removed (#1323) — those values now live exclusively in
+    // h1 was removed (#1323). Those values now live exclusively in
     // the IconDetailRow list, so showing them twice was clutter.
     render(
       <Wrapper>
@@ -503,15 +499,13 @@ describe("RoomDetailContent", () => {
     expect(screen.getAllByText("Etage 3")[0]).toBeInTheDocument();
   });
 
-  it("renders the empty-history placeholder when there are no entries", () => {
+  it("hides the history section when there are no entries", () => {
     render(
       <Wrapper>
         <RoomDetailContent room={{ ...baseRoom }} history={[]} />
       </Wrapper>,
     );
-    expect(
-      screen.getByText("Keine Belegungshistorie verfügbar."),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("Belegungshistorie")).not.toBeInTheDocument();
   });
 
   it("groups entry+exit pairs into a single activity card with the formatted duration", () => {

--- a/frontend/src/components/rooms/room-detail-content.test.tsx
+++ b/frontend/src/components/rooms/room-detail-content.test.tsx
@@ -563,6 +563,60 @@ describe("RoomDetailContent", () => {
     );
     expect(screen.getByText("Laufend")).toBeInTheDocument();
   });
+
+  it("focuses the room title when rendered as drawer content", async () => {
+    render(
+      <Wrapper>
+        <RoomDetailContent
+          room={{ ...baseRoom }}
+          history={[]}
+          headerAction={<button type="button">Schließen</button>}
+        />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Testraum" })).toHaveFocus();
+    });
+  });
+
+  it("sorts history days newest first and entries within a day by start time", () => {
+    render(
+      <Wrapper>
+        <RoomDetailContent
+          room={{ ...baseRoom }}
+          history={[
+            {
+              id: "a",
+              timestamp: "2026-04-29T09:30:00Z",
+              entry_type: "entry",
+              groupName: "A",
+              activityName: "Früher",
+            },
+            {
+              id: "b",
+              timestamp: "2026-04-30T08:00:00Z",
+              entry_type: "entry",
+              groupName: "B",
+              activityName: "Neuer Tag",
+            },
+            {
+              id: "c",
+              timestamp: "2026-04-29T08:00:00Z",
+              entry_type: "entry",
+              groupName: "C",
+              activityName: "Noch früher",
+            },
+          ]}
+        />
+      </Wrapper>,
+    );
+
+    const activityNames = screen
+      .getAllByRole("heading", { level: 4 })
+      .map((heading) => heading.textContent);
+    expect(activityNames).toEqual(["Neuer Tag", "Noch früher", "Früher"]);
+  });
 });
 
 // ----------------------------------------------------------------------------

--- a/frontend/src/components/rooms/room-detail-content.tsx
+++ b/frontend/src/components/rooms/room-detail-content.tsx
@@ -11,6 +11,7 @@
 
 "use client";
 
+import { useEffect, useRef } from "react";
 import { useSession } from "next-auth/react";
 import {
   Building2,
@@ -371,39 +372,56 @@ function IconDetailRow({
 interface RoomDetailContentProps {
   readonly room: Room;
   readonly history: readonly RoomHistoryEntry[];
-  // Optional slot rendered in the header row next to the StatusBadge.
-  // Used by the slide-over to drop its X close button alongside the
-  // room name and badge so they share one clean line. The master-detail
-  // database page leaves it undefined , its container owns close
-  // affordances elsewhere.
   readonly headerAction?: React.ReactNode;
+  readonly onSelectionActiveChange?: (active: boolean) => void;
 }
 
 export function RoomDetailContent({
   room,
   history,
   headerAction,
+  onSelectionActiveChange,
 }: RoomDetailContentProps) {
   const activities = groupHistoryByActivity([...history]);
   const groupedActivities = groupByDate(activities);
+  const hasHistory = groupedActivities.length > 0;
+  const isModalContext = Boolean(headerAction);
+  const titleRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    if (!isModalContext) return;
+    titleRef.current?.focus({ preventScroll: true });
+  }, [isModalContext, room.id]);
 
   return (
     <div>
-      {/* Room Header , name, status badge, and (in the slide-over) the
-          X close button on a single line (#1323 review).
-          Layout choices:
-            • Badge sits tight to the heading (no flex-1 on h1) so the
-              status reads as part of the title, not a far-right tag.
-            • X gets ml-auto, so it always anchors to the far right.
-            • leading-tight on h1 collapses the bold heading's line-box
-              so it visually centers with the smaller badge + icon
-              button instead of floating above them. */}
-      <div className="mb-6 flex items-center gap-2">
-        <h1 className="min-w-0 truncate text-2xl leading-tight font-bold text-gray-900 md:text-3xl">
-          {room.name}
-        </h1>
-        <div className="flex-shrink-0">
-          <StatusBadge isOccupied={room.isOccupied} />
+      <div
+        className={`mb-5 flex items-center gap-2 ${
+          headerAction
+            ? "sticky top-0 z-20 -mx-5 -mt-5 border-b border-gray-200/70 bg-gray-50/95 px-5 pt-5 pb-4 backdrop-blur supports-[backdrop-filter]:bg-gray-50/85 sm:-mx-6 sm:px-6"
+            : ""
+        }`}
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <h1
+              ref={titleRef}
+              tabIndex={isModalContext ? -1 : undefined}
+              className="min-w-0 truncate text-2xl leading-tight font-bold text-gray-900 md:text-3xl"
+            >
+              {room.name}
+            </h1>
+            <div className="flex-shrink-0">
+              <StatusBadge isOccupied={room.isOccupied} />
+            </div>
+          </div>
+          {headerAction && (room.building || room.floor !== undefined) ? (
+            <p className="mt-1 truncate text-xs font-medium text-gray-500">
+              {room.building && room.floor !== undefined
+                ? `${room.building} · ${formatFloor(room.floor)}`
+                : (room.building ?? formatFloor(room.floor ?? 0))}
+            </p>
+          ) : null}
         </div>
         {headerAction && (
           <div className="ml-auto flex-shrink-0">{headerAction}</div>
@@ -485,19 +503,17 @@ export function RoomDetailContent({
           </div>
         </div>
 
-        <StudentsInRoomSection roomId={room.id} roomName={room.name} />
+        <StudentsInRoomSection
+          roomId={room.id}
+          roomName={room.name}
+          onSelectionActiveChange={onSelectionActiveChange}
+        />
 
-        {/* Quiet section header to match the Rauminformationen block
-            above (#1323). */}
-        <div className={DETAIL_CARD_CLASS}>
-          <h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">
-            Belegungshistorie
-          </h2>
-          {groupedActivities.length === 0 ? (
-            <div className="py-8 text-center text-gray-500">
-              Keine Belegungshistorie verfügbar.
-            </div>
-          ) : (
+        {hasHistory ? (
+          <div className={DETAIL_CARD_CLASS}>
+            <h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">
+              Belegungshistorie
+            </h2>
             <div className="space-y-6">
               {groupedActivities.map((dateGroup) => (
                 <div key={dateGroup.date}>
@@ -577,8 +593,8 @@ export function RoomDetailContent({
                 </div>
               ))}
             </div>
-          )}
-        </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -704,6 +720,7 @@ interface RoomDetailLoaderProps {
   readonly roomId: string;
   readonly emptyAction?: React.ReactNode;
   readonly headerAction?: React.ReactNode;
+  readonly onSelectionActiveChange?: (active: boolean) => void;
 }
 
 /**
@@ -717,6 +734,7 @@ export function RoomDetailLoader({
   roomId,
   emptyAction,
   headerAction,
+  onSelectionActiveChange,
 }: RoomDetailLoaderProps) {
   const { room, history, loading, error } = useRoomDetail(roomId);
 
@@ -740,6 +758,7 @@ export function RoomDetailLoader({
       room={room}
       history={history}
       headerAction={headerAction}
+      onSelectionActiveChange={onSelectionActiveChange}
     />
   );
 }

--- a/frontend/src/components/rooms/room-detail-content.tsx
+++ b/frontend/src/components/rooms/room-detail-content.tsx
@@ -396,10 +396,10 @@ export function RoomDetailContent({
   return (
     <div>
       <div
-        className={`mb-5 flex items-center gap-2 ${
+        className={`flex items-center gap-2 ${
           headerAction
-            ? "sticky top-0 z-20 -mx-5 -mt-5 border-b border-gray-200/70 bg-gray-50/95 px-5 pt-5 pb-4 backdrop-blur supports-[backdrop-filter]:bg-gray-50/85 sm:-mx-6 sm:px-6"
-            : ""
+            ? "sticky top-0 z-20 border-b border-gray-200/70 bg-gray-50/95 px-5 pt-5 pb-4 backdrop-blur supports-[backdrop-filter]:bg-gray-50/85 sm:px-6"
+            : "mb-5"
         }`}
       >
         <div className="min-w-0 flex-1">
@@ -428,7 +428,11 @@ export function RoomDetailContent({
         )}
       </div>
 
-      <div className="space-y-4 sm:space-y-6">
+      <div
+        className={`space-y-4 sm:space-y-6 ${
+          headerAction ? "px-5 pt-5 sm:px-6" : ""
+        }`}
+      >
         {/* Compact icon-row block , every field that used to live in the
             old "Rauminformationen" InfoItem stack is here, but each row
             is anchored by a brand-tinted icon so the eye can scan

--- a/frontend/src/components/rooms/room-detail-content.tsx
+++ b/frontend/src/components/rooms/room-detail-content.tsx
@@ -234,13 +234,18 @@ function groupByDate(activities: Activity[]): DateGroup[] {
   const groups: Record<string, Activity[]> = {};
 
   activities.forEach((activity) => {
-    const date = new Date(activity.entryTimestamp).toLocaleDateString("de-DE");
+    const timestamp = new Date(activity.entryTimestamp);
+    const date = [
+      timestamp.getFullYear(),
+      String(timestamp.getMonth() + 1).padStart(2, "0"),
+      String(timestamp.getDate()).padStart(2, "0"),
+    ].join("-");
     groups[date] ??= [];
     groups[date].push(activity);
   });
 
   return Object.keys(groups)
-    .sort((a, b) => new Date(b).getTime() - new Date(a).getTime())
+    .sort((a, b) => b.localeCompare(a))
     .map((date) => ({
       date,
       entries: (groups[date] ?? []).sort(

--- a/frontend/src/components/rooms/room-detail-content.tsx
+++ b/frontend/src/components/rooms/room-detail-content.tsx
@@ -1,6 +1,6 @@
 // components/rooms/room-detail-content.tsx
 //
-// Body of the room detail view — used by both the full subpage
+// Body of the room detail view , used by both the full subpage
 // (/rooms/[id]/page.tsx, kept for deep links) and the responsive modal
 // rendered from /rooms (#1374).
 //
@@ -34,6 +34,8 @@ import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled"
 import { StudentsInRoomSection } from "./students-in-room-section";
 
 const logger = createLogger({ component: "RoomDetailContent" });
+const DETAIL_CARD_CLASS =
+  "rounded-3xl border border-gray-100/50 bg-white/90 p-5 shadow-[0_8px_30px_rgb(0,0,0,0.12)] sm:p-6";
 
 interface Room {
   id: string;
@@ -260,7 +262,7 @@ function useRoomDetail(roomId: string): UseRoomDetailResult {
   const token = session?.user?.token;
 
   // SWR-cached so the global SSE handler can invalidate the header on
-  // checkin/checkout/activity events — see use-global-sse.ts. The cache
+  // checkin/checkout/activity events , see use-global-sse.ts. The cache
   // key shape is "room-detail-{id}" (the slug-prefix is added by
   // useSWRAuth); SSE matches via key.includes("room-detail-").
   const { data, error, isLoading } = useSWRAuth<{
@@ -333,8 +335,8 @@ function useRoomDetail(roomId: string): UseRoomDetailResult {
 }
 
 // Icon-row layout for the room-detail card (#1323 review).
-// Each row: a brand-tinted icon on the left, then a stacked
-// label (small, muted) + value (regular, bold) — same shape as the
+// Each row: a muted icon on the left, then a stacked
+// label (small, muted) + value (regular, bold), same shape as the
 // reference screenshot's DETAILS section. Keeps every field the old
 // InfoItem layout had, just denser and with a clearer visual anchor
 // per row so staff can scan vertically by icon.
@@ -353,7 +355,7 @@ function IconDetailRow({
     // tried to align the icon with the small label, which left it
     // visually too high relative to the bold value below.
     <div className="flex items-center gap-3 py-1">
-      <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-[#5080D8]/10 text-[#5080D8]">
+      <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-gray-100 text-gray-500">
         {icon}
       </div>
       <div className="min-w-0 flex-1">
@@ -372,7 +374,7 @@ interface RoomDetailContentProps {
   // Optional slot rendered in the header row next to the StatusBadge.
   // Used by the slide-over to drop its X close button alongside the
   // room name and badge so they share one clean line. The master-detail
-  // database page leaves it undefined — its container owns close
+  // database page leaves it undefined , its container owns close
   // affordances elsewhere.
   readonly headerAction?: React.ReactNode;
 }
@@ -387,7 +389,7 @@ export function RoomDetailContent({
 
   return (
     <div>
-      {/* Room Header — name, status badge, and (in the slide-over) the
+      {/* Room Header , name, status badge, and (in the slide-over) the
           X close button on a single line (#1323 review).
           Layout choices:
             • Badge sits tight to the heading (no flex-1 on h1) so the
@@ -409,7 +411,7 @@ export function RoomDetailContent({
       </div>
 
       <div className="space-y-4 sm:space-y-6">
-        {/* Compact icon-row block — every field that used to live in the
+        {/* Compact icon-row block , every field that used to live in the
             old "Rauminformationen" InfoItem stack is here, but each row
             is anchored by a brand-tinted icon so the eye can scan
             vertically without re-reading labels. Review feedback
@@ -418,16 +420,16 @@ export function RoomDetailContent({
         {/* Quiet section header (option A from #1323 review): small
             uppercase label instead of the bold h2 + tinted icon box.
             Inverts the previous size hierarchy where the heading
-            outweighed the data underneath — now the heading is a quiet
+            outweighed the data underneath , now the heading is a quiet
             anchor and the IconDetailRow values carry the visual weight.
             Card outline / padding stay so the section is still
             visually grouped. */}
-        <div className="rounded-2xl border border-gray-100 bg-white/50 p-4 backdrop-blur-sm sm:p-6">
+        <div className={DETAIL_CARD_CLASS}>
           <h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">
             Rauminformationen
           </h2>
           <div className="space-y-1">
-            {/* Raumname intentionally omitted — already in the h1
+            {/* Raumname intentionally omitted , already in the h1
                 header above; review feedback (#1323): redundant. */}
             {room.building && (
               <IconDetailRow
@@ -487,7 +489,7 @@ export function RoomDetailContent({
 
         {/* Quiet section header to match the Rauminformationen block
             above (#1323). */}
-        <div className="rounded-2xl border border-gray-100 bg-white/50 p-4 backdrop-blur-sm sm:p-6">
+        <div className={DETAIL_CARD_CLASS}>
           <h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">
             Belegungshistorie
           </h2>
@@ -520,7 +522,7 @@ export function RoomDetailContent({
                       return (
                         <div
                           key={activity.id}
-                          className="rounded-lg border border-gray-100 bg-white p-4 transition-shadow hover:shadow-md"
+                          className="rounded-2xl border border-gray-100 bg-white p-4 transition-shadow hover:shadow-md"
                         >
                           <div
                             className="-mx-4 -mt-4 mb-3 h-1 rounded-full"
@@ -563,7 +565,7 @@ export function RoomDetailContent({
                                 Ende: {formatTime(activity.exitTimestamp)}
                               </span>
                             ) : (
-                              <span className="font-medium text-[#5080D8]">
+                              <span className="font-medium text-gray-700">
                                 Laufend
                               </span>
                             )}
@@ -585,7 +587,7 @@ export function RoomDetailContent({
 // Content-shaped skeleton for the loading state. Mirrors the three card
 // shells of the loaded layout (Rauminformationen / Kinder im Raum /
 // Belegungshistorie) so the slide-over body doesn't visibly resize when
-// real data arrives — review feedback #1323. Pulse-animated placeholders
+// real data arrives , review feedback #1323. Pulse-animated placeholders
 // for header text, badge, icon-rows, and child rows. Keeps role="status"
 // + aria-label so the previous business assertion ("loading state is
 // announced to AT") is preserved.
@@ -598,7 +600,7 @@ function SkeletonCardShell({
   children,
 }: Readonly<{ heading: string; children: React.ReactNode }>) {
   return (
-    <div className="rounded-2xl border border-gray-100 bg-white/50 p-4 backdrop-blur-sm sm:p-6">
+    <div className={DETAIL_CARD_CLASS}>
       <h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">
         {heading}
       </h2>
@@ -624,7 +626,7 @@ function SkeletonStudentRow({ withAvatar }: { withAvatar: boolean }) {
   // Mirrors CompactStudentCard: full-width pill with name + meta line.
   // When the per-tenant photo feature is on, also reserve the avatar
   // slot (sm = 32px) so the populated row's content origin lines up
-  // with the skeleton — avoids a horizontal jump when data arrives.
+  // with the skeleton , avoids a horizontal jump when data arrives.
   return (
     <div className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3">
       {withAvatar ? (
@@ -650,7 +652,7 @@ function RoomDetailSkeleton() {
       data-testid="room-detail-skeleton"
       className="block"
     >
-      {/* Header row — name + status pill, same line as the loaded view. */}
+      {/* Header row , name + status pill, same line as the loaded view. */}
       <div className="mb-6 flex items-center gap-2">
         <SkeletonLine className="h-7 w-48 md:h-8 md:w-64" />
         <SkeletonLine className="h-6 w-16 rounded-full" />

--- a/frontend/src/components/rooms/room-detail-modal.test.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { RoomDetailModal } from "./room-detail-modal";
 
 // ----------------------------------------------------------------------------
-// Mocks — every dependency below is stubbed so the test only exercises this
+// Mocks: every dependency below is stubbed so the test only exercises this
 // component's branching (mobile/desktop direction, roomId null, nested-modal
 // guards), not the heavy room-detail body or session/auth machinery.
 // ----------------------------------------------------------------------------
@@ -29,13 +29,22 @@ vi.mock("./room-detail-content", () => ({
   RoomDetailLoader: ({
     roomId,
     headerAction,
+    onSelectionActiveChange,
   }: {
     roomId: string;
     headerAction?: React.ReactNode;
+    onSelectionActiveChange?: (active: boolean) => void;
   }) => (
     <div data-testid="room-detail-loader">
       loader for {roomId}
       {headerAction}
+      <button
+        type="button"
+        onClick={() => onSelectionActiveChange?.(true)}
+        data-testid="activate-selection"
+      >
+        activate selection
+      </button>
     </div>
   ),
 }));
@@ -51,6 +60,7 @@ type DrawerProps = {
   children: React.ReactNode;
 };
 type DrawerContentProps = {
+  id?: string;
   className?: string;
   onInteractOutside?: (event: { preventDefault: () => void }) => void;
   onEscapeKeyDown?: (event: { preventDefault: () => void }) => void;
@@ -58,6 +68,58 @@ type DrawerContentProps = {
 };
 const drawerProps = vi.fn<(props: DrawerProps) => void>();
 const drawerContentProps = vi.fn<(props: DrawerContentProps) => void>();
+
+type SlideOverProps = {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  shouldScaleBackground?: boolean;
+  children: React.ReactNode;
+};
+type SlideOverContentProps = DrawerContentProps & {
+  widthClass?: string;
+};
+const slideOverProps = vi.fn<(props: SlideOverProps) => void>();
+const slideOverContentProps = vi.fn<(props: SlideOverContentProps) => void>();
+
+vi.mock("~/components/ui/slide-over", () => ({
+  SlideOver: (props: SlideOverProps) => {
+    slideOverProps(props);
+    return props.open ? (
+      <div data-testid="slide-over-shell" data-direction="right">
+        {props.children}
+      </div>
+    ) : null;
+  },
+  SlideOverContent: (props: SlideOverContentProps) => {
+    slideOverContentProps(props);
+    return <div data-testid="slide-over-content">{props.children}</div>;
+  },
+  SlideOverHeader: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="slide-over-header">{children}</div>
+  ),
+  SlideOverTitle: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="slide-over-title">{children}</div>
+  ),
+  SlideOverClose: ({
+    children,
+    className,
+    "aria-label": ariaLabel,
+  }: {
+    children?: React.ReactNode;
+    className?: string;
+    "aria-label"?: string;
+  }) => (
+    <button
+      type="button"
+      data-testid="slide-over-close"
+      aria-label={ariaLabel}
+      className={className}
+    >
+      {children}
+    </button>
+  ),
+}));
+
 vi.mock("~/components/ui/drawer", () => ({
   Drawer: (props: DrawerProps) => {
     drawerProps(props);
@@ -77,7 +139,7 @@ vi.mock("~/components/ui/drawer", () => ({
   DrawerTitle: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="drawer-title">{children}</div>
   ),
-  // Vaul's Close primitive — modal renders an X button via this on
+  // Vaul's Close primitive. Modal renders an X button via this on
   // desktop. Mock it as a plain button so the close-button test below
   // can assert presence and click without portals/dialogs.
   DrawerClose: ({
@@ -114,6 +176,8 @@ describe("RoomDetailModal", () => {
     });
     drawerProps.mockReset();
     drawerContentProps.mockReset();
+    slideOverProps.mockReset();
+    slideOverContentProps.mockReset();
   });
 
   describe("desktop branch (right-side slide-over)", () => {
@@ -121,53 +185,48 @@ describe("RoomDetailModal", () => {
       mockUseIsMobile.mockReturnValue(false);
     });
 
-    it("renders the Drawer with direction=right and the loader body when a roomId is provided", () => {
+    it("renders the SlideOver with the loader body when a roomId is provided", () => {
       const onClose = vi.fn();
       render(<RoomDetailModal roomId="42" onClose={onClose} />);
 
-      const shell = screen.getByTestId("drawer-shell");
+      const shell = screen.getByTestId("slide-over-shell");
       expect(shell).toBeInTheDocument();
       expect(shell.getAttribute("data-direction")).toBe("right");
-      // Title is sr-only but must still be present for accessibility.
-      expect(screen.getByTestId("drawer-title").textContent).toBe(
+      expect(screen.getByTestId("slide-over-title").textContent).toBe(
         "Raumdetails",
       );
-      expect(screen.getByTestId("room-detail-loader").textContent).toBe(
+      expect(screen.getByTestId("room-detail-loader").textContent).toContain(
         "loader for 42",
       );
     });
 
-    it("disables shouldScaleBackground on the right-side panel (only applies to bottom sheet)", () => {
+    it("does not opt into background scaling on the right-side panel", () => {
       render(<RoomDetailModal roomId="42" onClose={vi.fn()} />);
-      const lastCall = drawerProps.mock.calls.at(-1);
-      expect(lastCall?.[0].shouldScaleBackground).toBe(false);
+      const lastCall = slideOverProps.mock.calls.at(-1);
+      expect(lastCall?.[0].shouldScaleBackground).toBeUndefined();
     });
 
     it("renders no shell when roomId is null (closed deep-link state)", () => {
       render(<RoomDetailModal roomId={null} onClose={vi.fn()} />);
-      expect(screen.queryByTestId("drawer-shell")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("slide-over-shell")).not.toBeInTheDocument();
       expect(
         screen.queryByTestId("room-detail-loader"),
       ).not.toBeInTheDocument();
-      const lastCall = drawerProps.mock.calls.at(-1);
+      const lastCall = slideOverProps.mock.calls.at(-1);
       expect(lastCall?.[0].open).toBe(false);
     });
 
     it("forwards onClose via onOpenChange(false)", () => {
       const onClose = vi.fn();
       render(<RoomDetailModal roomId="42" onClose={onClose} />);
-      const lastCall = drawerProps.mock.calls.at(-1);
+      const lastCall = slideOverProps.mock.calls.at(-1);
       lastCall![0].onOpenChange(false);
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
     it("renders an explicit X close button with an aria-label on desktop", () => {
-      // Reviewer asked for an X — Esc + outside-click alone aren't
-      // discoverable on desktop, especially for keyboard-aware users.
-      // The button is a Vaul DrawerClose so vaul handles dismissal
-      // automatically (no extra onClick wiring needed).
       render(<RoomDetailModal roomId="42" onClose={vi.fn()} />);
-      const close = screen.getByTestId("drawer-close");
+      const close = screen.getByTestId("slide-over-close");
       expect(close).toBeInTheDocument();
       expect(close.getAttribute("aria-label")).toBe("Raumdetails schließen");
     });
@@ -185,7 +244,7 @@ describe("RoomDetailModal", () => {
       const shell = screen.getByTestId("drawer-shell");
       expect(shell).toBeInTheDocument();
       expect(shell.getAttribute("data-direction")).toBe("bottom");
-      expect(screen.getByTestId("room-detail-loader").textContent).toBe(
+      expect(screen.getByTestId("room-detail-loader").textContent).toContain(
         "loader for 7",
       );
       expect(screen.getByTestId("drawer-title").textContent).toBe(
@@ -193,9 +252,12 @@ describe("RoomDetailModal", () => {
       );
     });
 
-    it("hides the X close button on mobile (drag handle / swipe carries the affordance)", () => {
+    it("renders an explicit X close button on mobile too", () => {
       render(<RoomDetailModal roomId="42" onClose={vi.fn()} />);
-      expect(screen.queryByTestId("drawer-close")).not.toBeInTheDocument();
+      expect(screen.getByTestId("drawer-close")).toHaveAttribute(
+        "aria-label",
+        "Raumdetails schließen",
+      );
     });
 
     it("keeps shouldScaleBackground on the bottom sheet (iOS-style scale animation)", () => {
@@ -248,7 +310,9 @@ describe("RoomDetailModal", () => {
 
         render(<RoomDetailModal roomId="42" onClose={vi.fn()} />);
 
-        const lastContentCall = drawerContentProps.mock.calls.at(-1);
+        const lastContentCall = isMobile
+          ? drawerContentProps.mock.calls.at(-1)
+          : slideOverContentProps.mock.calls.at(-1);
         expect(lastContentCall).toBeDefined();
 
         const outsideEvent = { preventDefault: vi.fn() };
@@ -270,7 +334,7 @@ describe("RoomDetailModal", () => {
 
       render(<RoomDetailModal roomId="42" onClose={vi.fn()} />);
 
-      const lastContentCall = drawerContentProps.mock.calls.at(-1);
+      const lastContentCall = slideOverContentProps.mock.calls.at(-1);
       const outsideEvent = { preventDefault: vi.fn() };
       lastContentCall![0].onInteractOutside!(outsideEvent);
       expect(outsideEvent.preventDefault).not.toHaveBeenCalled();
@@ -278,6 +342,20 @@ describe("RoomDetailModal", () => {
       const escapeEvent = { preventDefault: vi.fn() };
       lastContentCall![0].onEscapeKeyDown!(escapeEvent);
       expect(escapeEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("swallows outside-click and Escape while child selection is active", () => {
+      render(<RoomDetailModal roomId="42" onClose={vi.fn()} />);
+      fireEvent.click(screen.getByTestId("activate-selection"));
+
+      const lastContentCall = slideOverContentProps.mock.calls.at(-1);
+      const outsideEvent = { preventDefault: vi.fn() };
+      lastContentCall![0].onInteractOutside!(outsideEvent);
+      expect(outsideEvent.preventDefault).toHaveBeenCalledTimes(1);
+
+      const escapeEvent = { preventDefault: vi.fn() };
+      lastContentCall![0].onEscapeKeyDown!(escapeEvent);
+      expect(escapeEvent.preventDefault).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/src/components/rooms/room-detail-modal.test.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.test.tsx
@@ -49,6 +49,12 @@ vi.mock("./room-detail-content", () => ({
   ),
 }));
 
+vi.mock("./transit-students-section", () => ({
+  TransitStudentsSection: () => (
+    <div data-testid="transit-students-section">transit students</div>
+  ),
+}));
+
 // Capture every prop passed to the Drawer primitives so we can drive
 // onOpenChange / onInteractOutside / onEscapeKeyDown without rendering
 // the real vaul implementation (which needs portals and document setup).
@@ -230,6 +236,17 @@ describe("RoomDetailModal", () => {
       expect(close).toBeInTheDocument();
       expect(close.getAttribute("aria-label")).toBe("Raumdetails schließen");
     });
+
+    it("renders transit content on desktop without fetching room details", () => {
+      render(<RoomDetailModal roomId="__transit__" onClose={vi.fn()} />);
+
+      expect(screen.getByRole("heading", { name: "Unterwegs" }))
+        .toBeInTheDocument();
+      expect(screen.getByTestId("transit-students-section"))
+        .toBeInTheDocument();
+      expect(screen.queryByTestId("room-detail-loader"))
+        .not.toBeInTheDocument();
+    });
   });
 
   describe("mobile branch (bottom drawer)", () => {
@@ -258,6 +275,17 @@ describe("RoomDetailModal", () => {
         "aria-label",
         "Raumdetails schließen",
       );
+    });
+
+    it("renders transit content on mobile without fetching room details", () => {
+      render(<RoomDetailModal roomId="__transit__" onClose={vi.fn()} />);
+
+      expect(screen.getByRole("heading", { name: "Unterwegs" }))
+        .toBeInTheDocument();
+      expect(screen.getByTestId("transit-students-section"))
+        .toBeInTheDocument();
+      expect(screen.queryByTestId("room-detail-loader"))
+        .not.toBeInTheDocument();
     });
 
     it("keeps shouldScaleBackground on the bottom sheet (iOS-style scale animation)", () => {

--- a/frontend/src/components/rooms/room-detail-modal.test.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.test.tsx
@@ -50,8 +50,21 @@ vi.mock("./room-detail-content", () => ({
 }));
 
 vi.mock("./transit-students-section", () => ({
-  TransitStudentsSection: () => (
-    <div data-testid="transit-students-section">transit students</div>
+  TransitStudentsSection: ({
+    onSelectionActiveChange,
+  }: {
+    onSelectionActiveChange?: (active: boolean) => void;
+  }) => (
+    <div data-testid="transit-students-section">
+      transit students
+      <button
+        type="button"
+        onClick={() => onSelectionActiveChange?.(true)}
+        data-testid="activate-transit-selection"
+      >
+        activate transit selection
+      </button>
+    </div>
   ),
 }));
 
@@ -375,6 +388,20 @@ describe("RoomDetailModal", () => {
     it("swallows outside-click and Escape while child selection is active", () => {
       render(<RoomDetailModal roomId="42" onClose={vi.fn()} />);
       fireEvent.click(screen.getByTestId("activate-selection"));
+
+      const lastContentCall = slideOverContentProps.mock.calls.at(-1);
+      const outsideEvent = { preventDefault: vi.fn() };
+      lastContentCall![0].onInteractOutside!(outsideEvent);
+      expect(outsideEvent.preventDefault).toHaveBeenCalledTimes(1);
+
+      const escapeEvent = { preventDefault: vi.fn() };
+      lastContentCall![0].onEscapeKeyDown!(escapeEvent);
+      expect(escapeEvent.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows outside-click and Escape while transit selection is active", () => {
+      render(<RoomDetailModal roomId="__transit__" onClose={vi.fn()} />);
+      fireEvent.click(screen.getByTestId("activate-transit-selection"));
 
       const lastContentCall = slideOverContentProps.mock.calls.at(-1);
       const outsideEvent = { preventDefault: vi.fn() };

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -42,8 +42,10 @@ interface RoomDetailModalProps {
 
 function TransitDetailContent({
   headerAction,
+  onSelectionActiveChange,
 }: {
   readonly headerAction: React.ReactNode;
+  readonly onSelectionActiveChange?: (active: boolean) => void;
 }) {
   return (
     <div>
@@ -62,7 +64,9 @@ function TransitDetailContent({
         <div className="ml-auto flex-shrink-0">{headerAction}</div>
       </div>
       <div className="px-5 pt-5 sm:px-6">
-        <TransitStudentsSection />
+        <TransitStudentsSection
+          onSelectionActiveChange={onSelectionActiveChange}
+        />
       </div>
     </div>
   );
@@ -121,6 +125,7 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
           >
             {roomId === TRANSIT_ROOM_ID ? (
               <TransitDetailContent
+                onSelectionActiveChange={setHasActiveSelection}
                 headerAction={
                   <SlideOverClose
                     aria-label="Raumdetails schließen"
@@ -182,6 +187,7 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
           <div className="min-h-[60vh]">
             {roomId === TRANSIT_ROOM_ID ? (
               <TransitDetailContent
+                onSelectionActiveChange={setHasActiveSelection}
                 headerAction={
                   <DrawerClose
                     aria-label="Raumdetails schließen"

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -14,6 +14,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { X } from "lucide-react";
 import { useIsMobile } from "~/hooks/useIsMobile";
+import { useScrollLock } from "~/hooks/useScrollLock";
 import {
   Drawer,
   DrawerClose,
@@ -41,6 +42,8 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
   const { isModalOpen } = useModal();
   const open = roomId !== null;
   const [hasActiveSelection, setHasActiveSelection] = useState(false);
+
+  useScrollLock(open);
 
   useEffect(() => {
     setHasActiveSelection(false);
@@ -81,7 +84,10 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
           <SlideOverHeader className="sr-only">
             <SlideOverTitle>Raumdetails</SlideOverTitle>
           </SlideOverHeader>
-          <div className="min-h-0 flex-1 overflow-auto pb-6">
+          <div
+            data-modal-content="true"
+            className="scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent min-h-0 flex-1 overflow-auto pb-6"
+          >
             {roomId ? (
               <RoomDetailLoader
                 roomId={roomId}
@@ -124,7 +130,10 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
         <DrawerHeader className="sr-only">
           <DrawerTitle>Raumdetails</DrawerTitle>
         </DrawerHeader>
-        <div className="min-h-0 flex-1 overflow-auto pb-6">
+        <div
+          data-modal-content="true"
+          className="scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent min-h-0 flex-1 overflow-auto pb-6"
+        >
           {/* min-h-[60vh] keeps the mobile bottom sheet from collapsing
               when the loader / error fallback returns a tiny payload.
               No-op on desktop , the side panel is already h-full. */}

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -2,7 +2,7 @@
 //
 // Responsive wrapper that opens the room-detail view from /rooms without
 // navigating away from the card grid (#1374). Right-side slide-over on
-// desktop, vaul Drawer (bottom) on mobile — keeps the rooms grid
+// desktop, vaul Drawer (bottom) on mobile , keeps the rooms grid
 // visible behind the panel so the user retains context while drilling
 // into a room (review feedback, #1323).
 //
@@ -20,6 +20,13 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "~/components/ui/drawer";
+import {
+  SlideOver,
+  SlideOverClose,
+  SlideOverContent,
+  SlideOverHeader,
+  SlideOverTitle,
+} from "~/components/ui/slide-over";
 import { useModal } from "~/components/dashboard/modal-context";
 import { RoomDetailLoader } from "./room-detail-content";
 
@@ -36,7 +43,7 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
   // Nested Modals (e.g. a future edit/confirm dialog) portal to
   // document.body, so Vaul's outside-click / escape handlers would
   // otherwise dismiss the drawer when the user interacts with the
-  // modal. Block the dismiss while a child modal is open — same guard
+  // modal. Block the dismiss while a child modal is open , same guard
   // MasterDetailLayout uses.
   const guardOutside = (event: Event) => {
     if (isModalOpen) event.preventDefault();
@@ -45,6 +52,44 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
     if (isModalOpen) event.preventDefault();
   };
 
+  if (!isMobile) {
+    return (
+      <SlideOver
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) onClose();
+        }}
+      >
+        <SlideOverContent
+          widthClass="sm:w-[520px]"
+          className="bg-gray-50"
+          aria-describedby={undefined}
+          onInteractOutside={guardOutside}
+          onEscapeKeyDown={guardEscape}
+        >
+          <SlideOverHeader className="sr-only">
+            <SlideOverTitle>Raumdetails</SlideOverTitle>
+          </SlideOverHeader>
+          <div className="min-h-0 flex-1 overflow-auto px-5 pt-5 pb-6">
+            {roomId ? (
+              <RoomDetailLoader
+                roomId={roomId}
+                headerAction={
+                  <SlideOverClose
+                    aria-label="Raumdetails schließen"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:ring-2 focus:ring-gray-300 focus:outline-none"
+                  >
+                    <X className="h-5 w-5" aria-hidden="true" />
+                  </SlideOverClose>
+                }
+              />
+            ) : null}
+          </div>
+        </SlideOverContent>
+      </SlideOver>
+    );
+  }
+
   return (
     <Drawer
       open={open}
@@ -52,7 +97,7 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
         if (!next) onClose();
       }}
       direction={isMobile ? "bottom" : "right"}
-      // shouldScaleBackground only makes sense for the bottom sheet —
+      // shouldScaleBackground only makes sense for the bottom sheet ,
       // on a right-side panel the background scaling looks broken
       // because the page slides on the wrong axis.
       shouldScaleBackground={isMobile}
@@ -69,22 +114,22 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
         <div className="min-h-0 flex-1 overflow-auto px-4 pt-4 pb-6 sm:px-6 sm:pt-6">
           {/* min-h-[60vh] keeps the mobile bottom sheet from collapsing
               when the loader / error fallback returns a tiny payload.
-              No-op on desktop — the side panel is already h-full. */}
+              No-op on desktop , the side panel is already h-full. */}
           <div className="min-h-[60vh]">
             {roomId ? (
               <RoomDetailLoader
                 roomId={roomId}
-                // Inline X close button — flows into the room header row
+                // Inline X close button , flows into the room header row
                 // alongside the room name + status badge so the slide-over
                 // header is one balanced line. Desktop only: the bottom
                 // sheet dismisses via its drag handle. The button itself is
-                // a Vaul DrawerClose, so vaul handles dismissal — no manual
+                // a Vaul DrawerClose, so vaul handles dismissal , no manual
                 // onClick wiring needed.
                 headerAction={
                   !isMobile ? (
                     <DrawerClose
                       aria-label="Raumdetails schließen"
-                      className="inline-flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:ring-2 focus:ring-[#5080D8]/40 focus:outline-none"
+                      className="inline-flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:ring-2 focus:ring-gray-300 focus:outline-none"
                     >
                       <X className="h-5 w-5" aria-hidden="true" />
                     </DrawerClose>

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -81,7 +81,7 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
           <SlideOverHeader className="sr-only">
             <SlideOverTitle>Raumdetails</SlideOverTitle>
           </SlideOverHeader>
-          <div className="min-h-0 flex-1 overflow-auto px-5 pt-5 pb-6">
+          <div className="min-h-0 flex-1 overflow-auto pb-6">
             {roomId ? (
               <RoomDetailLoader
                 roomId={roomId}
@@ -124,7 +124,7 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
         <DrawerHeader className="sr-only">
           <DrawerTitle>Raumdetails</DrawerTitle>
         </DrawerHeader>
-        <div className="min-h-0 flex-1 overflow-auto px-4 pt-4 pb-6 sm:px-6 sm:pt-6">
+        <div className="min-h-0 flex-1 overflow-auto pb-6">
           {/* min-h-[60vh] keeps the mobile bottom sheet from collapsing
               when the loader / error fallback returns a tiny payload.
               No-op on desktop , the side panel is already h-full. */}

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -40,6 +40,39 @@ interface RoomDetailModalProps {
   readonly onClose: () => void;
 }
 
+function TransitDetailContent({
+  headerAction,
+}: {
+  readonly headerAction: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="sticky top-0 z-20 flex items-center gap-3 border-b border-gray-200/70 bg-gray-50/95 px-5 pt-5 pb-4 backdrop-blur supports-[backdrop-filter]:bg-gray-50/85 sm:px-6">
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <h1
+              tabIndex={-1}
+              className="min-w-0 truncate text-2xl leading-tight font-bold text-gray-900 md:text-3xl"
+            >
+              Unterwegs
+            </h1>
+            <span className="shrink-0 rounded-full bg-gray-100 px-2.5 py-1 text-xs font-semibold text-gray-600">
+              Arbeitsliste
+            </span>
+          </div>
+          <p className="mt-1 truncate text-xs font-medium text-gray-500">
+            Kinder ohne Raumzuweisung
+          </p>
+        </div>
+        <div className="ml-auto flex-shrink-0">{headerAction}</div>
+      </div>
+      <div className="px-5 pt-5 sm:px-6">
+        <TransitStudentsSection />
+      </div>
+    </div>
+  );
+}
+
 export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
   const isMobile = useIsMobile();
   const { isModalOpen } = useModal();
@@ -91,7 +124,18 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
             data-modal-content="true"
             className="scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent min-h-0 flex-1 overflow-auto pb-6"
           >
-            {roomId ? (
+            {roomId === TRANSIT_ROOM_ID ? (
+              <TransitDetailContent
+                headerAction={
+                  <SlideOverClose
+                    aria-label="Raumdetails schließen"
+                    className={closeButtonClass}
+                  >
+                    <X className="h-5 w-5" aria-hidden="true" />
+                  </SlideOverClose>
+                }
+              />
+            ) : roomId ? (
               <RoomDetailLoader
                 roomId={roomId}
                 headerAction={
@@ -142,7 +186,16 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
               No-op on desktop , the side panel is already h-full. */}
           <div className="min-h-[60vh]">
             {roomId === TRANSIT_ROOM_ID ? (
-              <TransitStudentsSection />
+              <TransitDetailContent
+                headerAction={
+                  <DrawerClose
+                    aria-label="Raumdetails schließen"
+                    className={closeButtonClass}
+                  >
+                    <X className="h-5 w-5" aria-hidden="true" />
+                  </DrawerClose>
+                }
+              />
             ) : roomId ? (
               <RoomDetailLoader
                 roomId={roomId}

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -49,17 +49,12 @@ function TransitDetailContent({
     <div>
       <div className="sticky top-0 z-20 flex items-center gap-3 border-b border-gray-200/70 bg-gray-50/95 px-5 pt-5 pb-4 backdrop-blur supports-[backdrop-filter]:bg-gray-50/85 sm:px-6">
         <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 items-center gap-2">
-            <h1
-              tabIndex={-1}
-              className="min-w-0 truncate text-2xl leading-tight font-bold text-gray-900 md:text-3xl"
-            >
-              Unterwegs
-            </h1>
-            <span className="shrink-0 rounded-full bg-gray-100 px-2.5 py-1 text-xs font-semibold text-gray-600">
-              Arbeitsliste
-            </span>
-          </div>
+          <h1
+            tabIndex={-1}
+            className="min-w-0 truncate text-2xl leading-tight font-bold text-gray-900 md:text-3xl"
+          >
+            Unterwegs
+          </h1>
           <p className="mt-1 truncate text-xs font-medium text-gray-500">
             Kinder ohne Raumzuweisung
           </p>

--- a/frontend/src/components/rooms/room-detail-modal.tsx
+++ b/frontend/src/components/rooms/room-detail-modal.tsx
@@ -11,6 +11,7 @@
 
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import { X } from "lucide-react";
 import { useIsMobile } from "~/hooks/useIsMobile";
 import {
@@ -39,18 +40,27 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
   const isMobile = useIsMobile();
   const { isModalOpen } = useModal();
   const open = roomId !== null;
+  const [hasActiveSelection, setHasActiveSelection] = useState(false);
 
-  // Nested Modals (e.g. a future edit/confirm dialog) portal to
-  // document.body, so Vaul's outside-click / escape handlers would
-  // otherwise dismiss the drawer when the user interacts with the
-  // modal. Block the dismiss while a child modal is open , same guard
-  // MasterDetailLayout uses.
-  const guardOutside = (event: Event) => {
-    if (isModalOpen) event.preventDefault();
-  };
-  const guardEscape = (event: KeyboardEvent) => {
-    if (isModalOpen) event.preventDefault();
-  };
+  useEffect(() => {
+    setHasActiveSelection(false);
+  }, [roomId]);
+
+  const shouldBlockDismiss = isModalOpen || hasActiveSelection;
+  const guardOutside = useCallback(
+    (event: Event) => {
+      if (shouldBlockDismiss) event.preventDefault();
+    },
+    [shouldBlockDismiss],
+  );
+  const guardEscape = useCallback(
+    (event: KeyboardEvent) => {
+      if (shouldBlockDismiss) event.preventDefault();
+    },
+    [shouldBlockDismiss],
+  );
+  const closeButtonClass =
+    "inline-flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300";
 
   if (!isMobile) {
     return (
@@ -61,8 +71,9 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
         }}
       >
         <SlideOverContent
+          id="room-detail-panel"
           widthClass="sm:w-[520px]"
-          className="bg-gray-50"
+          className="overscroll-contain bg-gray-50"
           aria-describedby={undefined}
           onInteractOutside={guardOutside}
           onEscapeKeyDown={guardEscape}
@@ -77,11 +88,12 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
                 headerAction={
                   <SlideOverClose
                     aria-label="Raumdetails schließen"
-                    className="inline-flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:ring-2 focus:ring-gray-300 focus:outline-none"
+                    className={closeButtonClass}
                   >
                     <X className="h-5 w-5" aria-hidden="true" />
                   </SlideOverClose>
                 }
+                onSelectionActiveChange={setHasActiveSelection}
               />
             ) : null}
           </div>
@@ -103,7 +115,8 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
       shouldScaleBackground={isMobile}
     >
       <DrawerContent
-        className={isMobile ? "max-h-[90vh]" : undefined}
+        id="room-detail-panel"
+        className={isMobile ? "max-h-[90vh] overscroll-contain" : undefined}
         aria-describedby={undefined}
         onInteractOutside={guardOutside}
         onEscapeKeyDown={guardEscape}
@@ -119,22 +132,15 @@ export function RoomDetailModal({ roomId, onClose }: RoomDetailModalProps) {
             {roomId ? (
               <RoomDetailLoader
                 roomId={roomId}
-                // Inline X close button , flows into the room header row
-                // alongside the room name + status badge so the slide-over
-                // header is one balanced line. Desktop only: the bottom
-                // sheet dismisses via its drag handle. The button itself is
-                // a Vaul DrawerClose, so vaul handles dismissal , no manual
-                // onClick wiring needed.
                 headerAction={
-                  !isMobile ? (
-                    <DrawerClose
-                      aria-label="Raumdetails schließen"
-                      className="inline-flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:ring-2 focus:ring-gray-300 focus:outline-none"
-                    >
-                      <X className="h-5 w-5" aria-hidden="true" />
-                    </DrawerClose>
-                  ) : undefined
+                  <DrawerClose
+                    aria-label="Raumdetails schließen"
+                    className={closeButtonClass}
+                  >
+                    <X className="h-5 w-5" aria-hidden="true" />
+                  </DrawerClose>
                 }
+                onSelectionActiveChange={setHasActiveSelection}
               />
             ) : null}
           </div>

--- a/frontend/src/components/rooms/students-in-room-section.test.tsx
+++ b/frontend/src/components/rooms/students-in-room-section.test.tsx
@@ -71,10 +71,14 @@ vi.mock("~/components/ui/button", () => ({
     children,
     isLoading: _isLoading,
     loadingText: _loadingText,
+    variant: _variant,
+    size: _size,
     ...rest
   }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
     isLoading?: boolean;
     loadingText?: string;
+    variant?: string;
+    size?: string;
   }) => (
     <button onClick={onClick} {...rest}>
       {children}
@@ -192,6 +196,11 @@ beforeEach(() => {
   mockUpdateVisit.mockReset();
   mockGetActiveGroups.mockReset();
   mockToastSuccess.mockReset();
+  mockUseSearchParams.mockReset();
+  mockUseSearchParams.mockReturnValue({
+    get: vi.fn(() => null),
+    toString: vi.fn(() => "room=42"),
+  });
   mockUseTenantMutateMatching.mockReturnValue(vi.fn());
   setSWR({ data: { students: [] } });
   setBulkData();
@@ -509,6 +518,27 @@ describe("StudentsInRoomSection", () => {
       ).toBeChecked();
     });
 
+    it("reports active selection state to the drawer wrapper", async () => {
+      const onSelectionActiveChange = vi.fn();
+      setSWR({ data: { students: [makeStudent({ id: "7" })] } });
+
+      render(
+        <StudentsInRoomSection
+          roomId="42"
+          roomName="OGS-Raum 1"
+          onSelectionActiveChange={onSelectionActiveChange}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("checkbox", { name: /Anna Müller auswählen/ }),
+      );
+
+      await waitFor(() => {
+        expect(onSelectionActiveChange).toHaveBeenLastCalledWith(true);
+      });
+    });
+
     it("excludes the current room from the target room list", () => {
       setSWR({ data: { students: [makeStudent({ id: "7" })] } });
       setBulkData({
@@ -562,7 +592,7 @@ describe("StudentsInRoomSection", () => {
       // must carry the complete current query string, including any
       // grid filters (search, building, status), so the user lands
       // back on their narrowed view, not a reset grid.
-      mockUseSearchParams.mockReturnValueOnce({
+      mockUseSearchParams.mockReturnValue({
         get: vi.fn(() => null),
         toString: vi.fn(
           () => "search=foo&building=Main&status=occupied&room=42",
@@ -587,7 +617,7 @@ describe("StudentsInRoomSection", () => {
     });
 
     it("falls back to /rooms?room={id} when no query string is present", () => {
-      mockUseSearchParams.mockReturnValueOnce({
+      mockUseSearchParams.mockReturnValue({
         get: vi.fn(() => null),
         toString: vi.fn(() => ""),
       });

--- a/frontend/src/components/rooms/students-in-room-section.test.tsx
+++ b/frontend/src/components/rooms/students-in-room-section.test.tsx
@@ -14,6 +14,7 @@ const {
   mockGetStudentCurrentVisit,
   mockUpdateVisit,
   mockGetActiveGroups,
+  mockToastSuccess,
 } = vi.hoisted(() => ({
   mockPush: vi.fn(),
   mockUseSearchParams: vi.fn(() => ({
@@ -25,6 +26,7 @@ const {
   mockGetStudentCurrentVisit: vi.fn(),
   mockUpdateVisit: vi.fn(),
   mockGetActiveGroups: vi.fn(),
+  mockToastSuccess: vi.fn(),
 }));
 
 vi.mock("~/lib/tenant-router", () => ({
@@ -50,19 +52,30 @@ vi.mock("~/lib/active-service", () => ({
   },
 }));
 
-// Light mocks for visual primitives — we want to assert behaviors (text,
+vi.mock("~/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: mockToastSuccess,
+  }),
+}));
+
+// Light mocks for visual primitives, we want to assert behaviors (text,
 // button visibility, click handlers), not the exact rendering of every UI
 // atom imported transitively. The "Kinder im Raum" section now renders
 // its own <section aria-label> wrapper instead of going through InfoCard
-// (#1323 review — quiet section headers across the slide-over), so no
+// (#1323 review, quiet section headers across the slide-over), so no
 // info-card mock is needed.
 
 vi.mock("~/components/ui/button", () => ({
   Button: ({
     onClick,
     children,
+    isLoading: _isLoading,
+    loadingText: _loadingText,
     ...rest
-  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    isLoading?: boolean;
+    loadingText?: string;
+  }) => (
     <button onClick={onClick} {...rest}>
       {children}
     </button>
@@ -77,7 +90,7 @@ vi.mock("~/components/ui/alert", () => ({
 
 // Loading widget is no longer used here (replaced with a content-shaped
 // StudentRowSkeleton in #1323 review). Tests below assert the skeleton's
-// data-testid + role="status" instead of the old "loading" testid — same
+// data-testid + role="status" instead of the old "loading" testid, same
 // business assertion (a loading state IS shown while SWR fetches), new
 // selector that matches the new skeleton shape.
 
@@ -88,26 +101,22 @@ vi.mock("~/components/students/compact-student-card", () => ({
     lastName,
     schoolClass,
     groupName,
-    onClick,
   }: {
     studentId: string;
     firstName?: string;
     lastName?: string;
     schoolClass?: string;
     groupName?: string;
-    onClick?: () => void;
   }) => (
-    <button
-      type="button"
+    <div
       data-testid={`compact-student-card-${studentId}`}
       data-school-class={schoolClass}
       data-group-name={groupName}
-      onClick={onClick}
     >
       <span>
         {firstName} {lastName}
       </span>
-    </button>
+    </div>
   ),
 }));
 
@@ -182,6 +191,7 @@ beforeEach(() => {
   mockGetStudentCurrentVisit.mockReset();
   mockUpdateVisit.mockReset();
   mockGetActiveGroups.mockReset();
+  mockToastSuccess.mockReset();
   mockUseTenantMutateMatching.mockReturnValue(vi.fn());
   setSWR({ data: { students: [] } });
   setBulkData();
@@ -241,9 +251,7 @@ describe("StudentsInRoomSection", () => {
 
       const alert = screen.getByRole("alert");
       expect(alert).toHaveTextContent(/Liste der Kinder/);
-      // Error path must not also render the empty-state placeholder —
-      // those two states are mutually exclusive and showing both would
-      // confuse the user about whether a retry would help.
+      // Error and empty states must stay mutually exclusive.
       expect(
         screen.queryByText(/Aktuell keine Kinder/),
       ).not.toBeInTheDocument();
@@ -257,9 +265,7 @@ describe("StudentsInRoomSection", () => {
       expect(
         screen.getByText(/Aktuell keine Kinder im Raum/),
       ).toBeInTheDocument();
-      // "In Kindersuche öffnen" must NOT render when the list is empty —
-      // otherwise the deep-link would land on an empty filtered Kindersuche
-      // with no obvious affordance for the user to recover.
+      // Do not deep-link to an empty filtered Kindersuche.
       expect(
         screen.queryByRole("button", { name: /Kindersuche/ }),
       ).not.toBeInTheDocument();
@@ -286,11 +292,7 @@ describe("StudentsInRoomSection", () => {
     });
 
     it("forwards school_class and group_name to the compact card", () => {
-      // The minimal card shows just identity (name + class + group). The
-      // section must pass those fields through unmodified — earlier
-      // versions used StudentCard with extraContent and arrival/pickup
-      // rows; that complexity is gone, but the identifiers must remain
-      // visible so staff can recognise the child.
+      // The minimal card still needs class and group identifiers.
       setSWR({
         data: {
           students: [
@@ -383,7 +385,7 @@ describe("StudentsInRoomSection", () => {
     it("renders an overflow status when total_records exceeds rendered count", () => {
       // Hard-coded pageSize=200 caps the response. When a room ever
       // exceeds it, the section must surface the gap and point at the
-      // Kindersuche escape hatch — otherwise staff can't see or open
+      // Kindersuche escape hatch, otherwise staff can't see or open
       // the missing children (#1374).
       setSWR({
         data: {
@@ -473,7 +475,7 @@ describe("StudentsInRoomSection", () => {
         expect.objectContaining({ activeGroupId: "900", studentId: "8" }),
       );
       expect(refreshCaches).toHaveBeenCalledTimes(1);
-      expect(screen.getByRole("status")).toHaveTextContent(
+      expect(mockToastSuccess).toHaveBeenCalledWith(
         "2 Kinder nach Raum 6 bewegt.",
       );
     });
@@ -492,6 +494,19 @@ describe("StudentsInRoomSection", () => {
       expect(
         screen.getByRole("button", { name: "In Raum setzen" }),
       ).toBeDisabled();
+    });
+
+    it("selects a child when clicking the row content without opening the profile", () => {
+      setSWR({ data: { students: [makeStudent({ id: "7" })] } });
+
+      render(<StudentsInRoomSection roomId="42" roomName="OGS-Raum 1" />);
+
+      fireEvent.click(screen.getByTestId("compact-student-card-7"));
+
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole("checkbox", { name: /Anna Müller auswählen/ }),
+      ).toBeChecked();
     });
 
     it("excludes the current room from the target room list", () => {
@@ -544,8 +559,8 @@ describe("StudentsInRoomSection", () => {
     it("encodes the full URL as from= in the slide-over context (preserves filters)", () => {
       // The section now only renders inside the slide-over (legacy
       // /rooms/{id} subpage is a server-side redirect). The from= URL
-      // must carry the COMPLETE current query string — including any
-      // grid filters (search, building, status) — so the user lands
+      // must carry the complete current query string, including any
+      // grid filters (search, building, status), so the user lands
       // back on their narrowed view, not a reset grid.
       mockUseSearchParams.mockReturnValueOnce({
         get: vi.fn(() => null),
@@ -557,7 +572,9 @@ describe("StudentsInRoomSection", () => {
 
       render(<StudentsInRoomSection roomId="42" roomName="OGS-Raum 1" />);
 
-      fireEvent.click(screen.getByTestId("compact-student-card-7"));
+      fireEvent.click(
+        screen.getByRole("button", { name: /Anna Müller Profil öffnen/ }),
+      );
 
       // ? inside from= must be URL-encoded; & inside likewise. Without
       // encoding the outer query parser splits at the inner '?' and
@@ -578,7 +595,9 @@ describe("StudentsInRoomSection", () => {
 
       render(<StudentsInRoomSection roomId="42" roomName="OGS-Raum 1" />);
 
-      fireEvent.click(screen.getByTestId("compact-student-card-7"));
+      fireEvent.click(
+        screen.getByRole("button", { name: /Anna Müller Profil öffnen/ }),
+      );
 
       expect(mockPush).toHaveBeenCalledWith(
         `/students/7?from=${encodeURIComponent("/rooms?room=42")}`,
@@ -601,7 +620,7 @@ describe("StudentsInRoomSection", () => {
       expect(mockPush).toHaveBeenCalledTimes(1);
       const target = mockPush.mock.calls[0]?.[0] as string;
       expect(target).toMatch(/^\/students\/search\?/);
-      // room_name must be URL-encoded — the seed value "OGS-Raum 1" contains
+      // room_name must be URL-encoded. The seed value "OGS-Raum 1" contains
       // a space and a hyphen and would break a naive concatenation.
       expect(target).toContain("room_id=42");
       expect(target).toContain("room_name=OGS-Raum+1");

--- a/frontend/src/components/rooms/students-in-room-section.test.tsx
+++ b/frontend/src/components/rooms/students-in-room-section.test.tsx
@@ -505,6 +505,94 @@ describe("StudentsInRoomSection", () => {
       ).toBeDisabled();
     });
 
+    it("treats a child already in the target room as a successful no-op", async () => {
+      const refreshCaches = vi.fn().mockResolvedValue(undefined);
+      mockUseTenantMutateMatching.mockReturnValue(refreshCaches);
+      setSWR({ data: { students: [makeStudent({ id: "7" })] } });
+      mockGetStudentCurrentVisit.mockResolvedValue({
+        id: "visit-7",
+        studentId: "7",
+        activeGroupId: "900",
+        checkInTime: new Date("2026-05-14T08:00:00.000Z"),
+        isActive: true,
+        createdAt: new Date("2026-05-14T08:00:00.000Z"),
+        updatedAt: new Date("2026-05-14T08:00:00.000Z"),
+      });
+
+      render(<StudentsInRoomSection roomId="42" roomName="OGS-Raum 1" />);
+
+      fireEvent.click(
+        screen.getByRole("checkbox", { name: /Anna Müller auswählen/ }),
+      );
+      fireEvent.change(screen.getByLabelText("Zielraum"), {
+        target: { value: "900" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "In Raum setzen" }));
+
+      await waitFor(() => {
+        expect(mockGetStudentCurrentVisit).toHaveBeenCalledWith("7");
+      });
+      expect(mockUpdateVisit).not.toHaveBeenCalled();
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "1 Kind nach Raum 6 bewegt.",
+      );
+      expect(refreshCaches).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports a partial failure when a selected child has no active visit", async () => {
+      const refreshCaches = vi.fn().mockResolvedValue(undefined);
+      mockUseTenantMutateMatching.mockReturnValue(refreshCaches);
+      setSWR({
+        data: {
+          students: [
+            makeStudent({ id: "7", first_name: "Anna" }),
+            makeStudent({ id: "8", first_name: "Ben", second_name: "Schulz" }),
+          ],
+        },
+      });
+      mockGetStudentCurrentVisit.mockImplementation((studentId: string) => {
+        if (studentId === "7") {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve({
+          id: "visit-8",
+          studentId: "8",
+          activeGroupId: "current-group",
+          checkInTime: new Date("2026-05-14T08:00:00.000Z"),
+          isActive: true,
+          createdAt: new Date("2026-05-14T08:00:00.000Z"),
+          updatedAt: new Date("2026-05-14T08:00:00.000Z"),
+        });
+      });
+      mockUpdateVisit.mockResolvedValue({});
+
+      render(<StudentsInRoomSection roomId="42" roomName="OGS-Raum 1" />);
+
+      fireEvent.click(
+        screen.getByRole("checkbox", { name: /Anna Müller auswählen/ }),
+      );
+      fireEvent.click(
+        screen.getByRole("checkbox", { name: /Ben Schulz auswählen/ }),
+      );
+      fireEvent.change(screen.getByLabelText("Zielraum"), {
+        target: { value: "900" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "In Raum setzen" }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(
+          "1 von 2 Kindern konnten nicht bewegt werden.",
+        );
+      });
+      expect(mockUpdateVisit).toHaveBeenCalledTimes(1);
+      expect(mockUpdateVisit).toHaveBeenCalledWith(
+        "visit-8",
+        expect.objectContaining({ activeGroupId: "900", studentId: "8" }),
+      );
+      expect(mockToastSuccess).not.toHaveBeenCalled();
+      expect(refreshCaches).toHaveBeenCalledTimes(1);
+    });
+
     it("selects a child when clicking the row content without opening the profile", () => {
       setSWR({ data: { students: [makeStudent({ id: "7" })] } });
 

--- a/frontend/src/components/rooms/students-in-room-section.tsx
+++ b/frontend/src/components/rooms/students-in-room-section.tsx
@@ -14,7 +14,7 @@
 
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Check, ExternalLink } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useTenantRouter } from "~/lib/tenant-router";
@@ -41,11 +41,13 @@ const DETAIL_CARD_CLASS =
 interface StudentsInRoomSectionProps {
   readonly roomId: string;
   readonly roomName: string;
+  readonly onSelectionActiveChange?: (active: boolean) => void;
 }
 
 export function StudentsInRoomSection({
   roomId,
   roomName,
+  onSelectionActiveChange,
 }: StudentsInRoomSectionProps) {
   const router = useTenantRouter();
   const { success: toastSuccess } = useToast();
@@ -128,6 +130,16 @@ export function StudentsInRoomSection({
   // have no affordance to open the missing children.
   const isTruncated = totalCount > students.length;
   const hiddenCount = Math.max(0, totalCount - students.length);
+
+  useEffect(() => {
+    setSelectedStudentIds(new Set());
+    setTargetActiveGroupId("");
+    setBulkMoveState({ type: "idle" });
+  }, [roomId]);
+
+  useEffect(() => {
+    onSelectionActiveChange?.(selectedVisibleCount > 0);
+  }, [onSelectionActiveChange, selectedVisibleCount]);
 
   const openInSearch = () => {
     const qs = new URLSearchParams({
@@ -237,16 +249,18 @@ export function StudentsInRoomSection({
           Kinder im Raum
         </h2>
         {totalCount > 0 && (
-          <button
+          <Button
             type="button"
+            variant="outline"
+            size="sm"
             onClick={openInSearch}
             aria-label="In Kindersuche öffnen"
             title="In Kindersuche öffnen"
-            className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full bg-white px-2.5 text-xs font-medium text-gray-600 ring-1 ring-gray-200 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300"
+            className="h-8 shrink-0 gap-1.5 rounded-full px-2.5 py-0 text-xs font-medium shadow-none"
           >
             Kindersuche
             <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
-          </button>
+          </Button>
         )}
       </div>
       <p className="text-sm text-gray-600">
@@ -367,9 +381,16 @@ function BulkMoveToolbar({
   const canMove =
     selectedCount > 0 && targetActiveGroupId.length > 0 && !isMoving;
   const allSelected = selectedCount === totalCount;
+  const hasSelection = selectedCount > 0;
 
   return (
-    <div className="mb-4 rounded-2xl bg-gray-50/80 p-3">
+    <div
+      className={`mb-4 rounded-2xl border p-3 transition-shadow ${
+        hasSelection
+          ? "sticky bottom-3 z-20 border-gray-200 bg-white/95 shadow-[0_12px_40px_rgb(0,0,0,0.12)] backdrop-blur"
+          : "border-transparent bg-gray-50/80 shadow-none"
+      }`}
+    >
       <div className="flex items-start justify-between gap-3">
         <p className="min-w-0 text-sm font-semibold text-gray-900">
           <span className="block truncate">
@@ -381,13 +402,15 @@ function BulkMoveToolbar({
             Zielraum wählen und gemeinsam verschieben
           </span>
         </p>
-        <button
+        <Button
           type="button"
+          variant="outline"
+          size="sm"
           onClick={allSelected ? onClearSelection : onSelectAll}
-          className="shrink-0 rounded-full bg-white px-3 py-1.5 text-xs font-medium text-gray-700 ring-1 ring-gray-200 transition-colors hover:bg-gray-50 hover:text-gray-900"
+          className="h-8 shrink-0 rounded-full px-3 py-0 text-xs shadow-none"
         >
           {allSelected ? "Aufheben" : "Alle auswählen"}
-        </button>
+        </Button>
       </div>
 
       <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
@@ -595,16 +618,18 @@ function SelectableStudentRow({
           chrome="plain"
         />
       </button>
-      <button
+      <Button
         type="button"
+        variant="outline"
+        size="sm"
         onClick={onOpen}
         aria-label={`${fullName} Profil öffnen`}
         title="Profil öffnen"
-        className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full bg-white px-2.5 text-xs font-medium text-gray-600 ring-1 ring-gray-200 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300"
+        className="h-8 shrink-0 gap-1.5 rounded-full px-2.5 py-0 text-xs font-medium shadow-none"
       >
         Profil
         <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
-      </button>
+      </Button>
     </div>
   );
 }

--- a/frontend/src/components/rooms/students-in-room-section.tsx
+++ b/frontend/src/components/rooms/students-in-room-section.tsx
@@ -4,7 +4,7 @@
 //
 // Uses the same `/api/students?room_id=` data path as Kindersuche, but
 // renders a compact name + class + group row per child (CompactStudentCard)
-// because the side panel doesn't have room — and doesn't need — the full
+// because the side panel doesn't have room, and doesn't need, the full
 // StudentCard. Every row shown is a real, currently checked-in student;
 // the total count is the server's authoritative pagination count.
 //
@@ -15,6 +15,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { Check, ExternalLink } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useTenantRouter } from "~/lib/tenant-router";
 import { useSWRAuth, useTenantMutateMatching } from "~/lib/swr";
@@ -22,6 +23,7 @@ import { ROOM_LIST_CACHE_KEYS } from "~/lib/swr/room-derived-caches";
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { DatabaseSelect } from "~/components/ui/database/database-select";
+import { useToast } from "~/contexts/ToastContext";
 import { roomService, studentService } from "~/lib/api";
 import type { Student } from "~/lib/api";
 import { activeService } from "~/lib/active-service";
@@ -33,6 +35,8 @@ import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "StudentsInRoomSection" });
 const EMPTY_STUDENTS: Student[] = [];
+const DETAIL_CARD_CLASS =
+  "rounded-3xl border border-gray-100/50 bg-white/90 p-5 shadow-[0_8px_30px_rgb(0,0,0,0.12)] sm:p-6";
 
 interface StudentsInRoomSectionProps {
   readonly roomId: string;
@@ -44,6 +48,7 @@ export function StudentsInRoomSection({
   roomName,
 }: StudentsInRoomSectionProps) {
   const router = useTenantRouter();
+  const { success: toastSuccess } = useToast();
   const refreshRoomConsumers = useTenantMutateMatching([
     "room-students-",
     "room-detail-",
@@ -58,7 +63,6 @@ export function StudentsInRoomSection({
   const [bulkMoveState, setBulkMoveState] = useState<
     | { type: "idle" }
     | { type: "loading" }
-    | { type: "success"; movedCount: number; roomName: string }
     | { type: "error"; message: string }
   >({ type: "idle" });
   const sectionSearchParams = useSearchParams();
@@ -74,7 +78,7 @@ export function StudentsInRoomSection({
   // pageSize must comfortably exceed any realistic room occupancy (combined
   // groups in Sporthalle/Aula/Mensa cap well below 100 in normal usage) so
   // every present child shows up. Backend default is only 50, which would
-  // silently truncate larger rooms — see PR #1374 review.
+  // silently truncate larger rooms, see PR #1374 review.
   const { data, error, isLoading } = useSWRAuth<{
     students: Student[];
     pagination?: { total_records: number };
@@ -212,11 +216,10 @@ export function StudentsInRoomSection({
 
     setSelectedStudentIds(new Set());
     setTargetActiveGroupId("");
-    setBulkMoveState({
-      type: "success",
-      movedCount: studentIds.length,
-      roomName: target.roomName,
-    });
+    setBulkMoveState({ type: "idle" });
+    toastSuccess(
+      `${studentIds.length} ${studentIds.length === 1 ? "Kind" : "Kinder"} nach ${target.roomName} bewegt.`,
+    );
     await refreshRoomConsumers();
   };
 
@@ -227,41 +230,29 @@ export function StudentsInRoomSection({
     // / a11y tooling expect from the previous InfoCard wrapper.
     <section
       aria-label="Kinder im Raum"
-      className="rounded-2xl border border-gray-100 bg-white/50 p-4 backdrop-blur-sm sm:p-6"
+      className={DETAIL_CARD_CLASS}
     >
-      <h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">
-        Kinder im Raum
-      </h2>
-      {/* items-end so the Kindersuche button bottom-aligns with the
-          count text bottom. The shared `<Button>` component has fixed
-          py-3, which would make the row too tall and push the count
-          text down — so this row uses an inline outline-styled button
-          with py-1, matching the count text's line height. The button
-          stays the same visual style as the elsewhere-used Button
-          outline variant, just sized to fit a one-line row.
-          Review feedback (#1323). */}
-      <div className="flex flex-wrap items-end justify-between gap-3">
-        <p className="text-sm text-gray-600">
-          <span className="font-medium text-gray-900">{totalCount}</span>{" "}
-          {totalCount === 1 ? "Kind" : "Kinder"} aktuell anwesend
-        </p>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h2 className="text-xs font-semibold tracking-wider text-gray-500 uppercase">
+          Kinder im Raum
+        </h2>
         {totalCount > 0 && (
-          // Tinted brand-blue ghost button. Uses LOCATION_COLORS.OTHER_ROOM
-          // (#5080D8) — same hue the IconDetailRow icons in
-          // Rauminformationen above are tinted with, so the slide-over
-          // has one accent color across all its sections instead of the
-          // gray-outline button visually getting lost. CLAUDE.md §0 —
-          // brand colors via arbitrary value syntax, never generic
-          // tailwind blues.
           <button
             type="button"
             onClick={openInSearch}
-            className="inline-flex items-center rounded-lg bg-[#5080D8]/10 px-3 py-1 text-sm font-medium text-[#5080D8] transition-colors hover:bg-[#5080D8]/20 focus:ring-2 focus:ring-[#5080D8]/40 focus:outline-none"
+            aria-label="In Kindersuche öffnen"
+            title="In Kindersuche öffnen"
+            className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full bg-white px-2.5 text-xs font-medium text-gray-600 ring-1 ring-gray-200 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300"
           >
-            In Kindersuche öffnen
+            Kindersuche
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
           </button>
         )}
       </div>
+      <p className="text-sm text-gray-600">
+        <span className="font-medium text-gray-900">{totalCount}</span>{" "}
+        {totalCount === 1 ? "Kind" : "Kinder"} aktuell anwesend
+      </p>
 
       {isTruncated && (
         <div
@@ -270,7 +261,7 @@ export function StudentsInRoomSection({
         >
           Es werden {students.length} von {totalCount} Kindern angezeigt.{" "}
           {hiddenCount} weitere {hiddenCount === 1 ? "Kind ist" : "Kinder sind"}{" "}
-          aktuell nicht in dieser Übersicht — bitte in der Kindersuche öffnen,
+          aktuell nicht in dieser Übersicht, bitte in der Kindersuche öffnen,
           um alle zu sehen.
         </div>
       )}
@@ -354,7 +345,6 @@ interface BulkMoveToolbarProps {
   readonly state:
     | { type: "idle" }
     | { type: "loading" }
-    | { type: "success"; movedCount: number; roomName: string }
     | { type: "error"; message: string };
   readonly onSelectAll: () => void;
   readonly onClearSelection: () => void;
@@ -379,8 +369,8 @@ function BulkMoveToolbar({
   const allSelected = selectedCount === totalCount;
 
   return (
-    <div className="mb-4 rounded-xl border border-gray-200 bg-gray-50/70 p-3">
-      <div className="flex items-center justify-between gap-3">
+    <div className="mb-4 rounded-2xl bg-gray-50/80 p-3">
+      <div className="flex items-start justify-between gap-3">
         <p className="min-w-0 text-sm font-semibold text-gray-900">
           <span className="block truncate">
             {selectedCount > 0
@@ -391,15 +381,13 @@ function BulkMoveToolbar({
             Zielraum wählen und gemeinsam verschieben
           </span>
         </p>
-        <Button
+        <button
           type="button"
-          variant="outline"
-          size="sm"
           onClick={allSelected ? onClearSelection : onSelectAll}
-          className="shrink-0 px-3 py-2 text-sm shadow-none"
+          className="shrink-0 rounded-full bg-white px-3 py-1.5 text-xs font-medium text-gray-700 ring-1 ring-gray-200 transition-colors hover:bg-gray-50 hover:text-gray-900"
         >
-          {allSelected ? "Aufheben" : "Alle"}
-        </Button>
+          {allSelected ? "Aufheben" : "Alle auswählen"}
+        </button>
       </div>
 
       <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
@@ -419,29 +407,23 @@ function BulkMoveToolbar({
             value: option.activeGroupId,
             label: option.roomName,
           }))}
-          focusRingColor="focus:ring-[#5080D8]"
+          focusRingColor="focus:ring-gray-300"
           className="bg-white text-sm md:text-sm"
         />
         <Button
           type="button"
-          variant="success"
+          variant="primary"
           size="sm"
           isLoading={isMoving}
           loadingText="Bewege..."
           onClick={onMoveSelected}
           disabled={!canMove}
-          className="min-h-10 w-full bg-[#83CD2D] px-4 py-2.5 text-sm shadow-sm hover:bg-[#74b827] active:bg-[#669f21] disabled:bg-gray-200 disabled:text-gray-500 sm:w-auto"
+          className="h-9 w-full px-3 py-2 text-xs shadow-sm sm:w-auto"
         >
           In Raum setzen
         </Button>
       </div>
 
-      {state.type === "success" ? (
-        <p role="status" className="mt-2 text-sm text-[#4a7a15]">
-          {state.movedCount} {state.movedCount === 1 ? "Kind" : "Kinder"} nach{" "}
-          {state.roomName} bewegt.
-        </p>
-      ) : null}
       {state.type === "error" ? (
         <p role="alert" className="mt-2 text-sm text-[#FF3130]">
           {state.message}
@@ -575,20 +557,34 @@ function SelectableStudentRow({
 
   return (
     <div
-      className={`flex items-center gap-3 rounded-xl border px-3 py-3 transition-colors ${
+      className={`flex items-center gap-2 rounded-2xl border px-3 py-2.5 transition-colors ${
         isSelected
-          ? "border-[#5080D8]/40 bg-[#5080D8]/10"
-          : "border-gray-200 bg-white hover:border-gray-300 hover:bg-gray-50"
+          ? "border-gray-300 bg-gray-50"
+          : "border-gray-100 bg-white hover:border-gray-200 hover:bg-gray-50"
       }`}
     >
-      <input
-        type="checkbox"
-        checked={isSelected}
+      <button
+        type="button"
+        role="checkbox"
+        aria-checked={isSelected}
         aria-label={`${fullName} auswählen`}
-        onChange={onToggleSelection}
-        className="h-5 w-5 shrink-0 rounded border-gray-300 text-[#5080D8] accent-[#5080D8] focus:ring-2 focus:ring-[#5080D8]/40 focus:outline-none"
-      />
-      <div className="min-w-0 flex-1">
+        onClick={onToggleSelection}
+        className="flex min-w-0 flex-1 items-center gap-3 rounded-xl text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300"
+      >
+        <span
+          className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-md border shadow-sm transition-all ${
+            isSelected
+              ? "border-gray-900 bg-gray-900"
+              : "border-gray-300 bg-white"
+          }`}
+          aria-hidden="true"
+        >
+          <Check
+            className={`h-3.5 w-3.5 text-white transition-opacity ${
+              isSelected ? "opacity-100" : "opacity-0"
+            }`}
+          />
+        </span>
         <CompactStudentCard
           studentId={student.id}
           firstName={student.first_name}
@@ -596,10 +592,19 @@ function SelectableStudentRow({
           schoolClass={student.school_class}
           groupName={student.group_name ?? undefined}
           photoUrl={student.photo_url ?? null}
-          onClick={onOpen}
           chrome="plain"
         />
-      </div>
+      </button>
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={`${fullName} Profil öffnen`}
+        title="Profil öffnen"
+        className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full bg-white px-2.5 text-xs font-medium text-gray-600 ring-1 ring-gray-200 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300"
+      >
+        Profil
+        <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
     </div>
   );
 }

--- a/frontend/src/components/rooms/transit-students-section.test.tsx
+++ b/frontend/src/components/rooms/transit-students-section.test.tsx
@@ -10,6 +10,23 @@ import {
 } from "~/lib/swr";
 import { TransitStudentsSection } from "./transit-students-section";
 
+const { mockPush, mockSearchParamsToString } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockSearchParamsToString: vi.fn(() => "room=__transit__"),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({
+    toString: mockSearchParamsToString,
+  }),
+}));
+
+vi.mock("~/lib/tenant-router", () => ({
+  useTenantRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
 vi.mock("~/lib/swr", () => ({
   useSWRAuth: vi.fn(),
   useTenantMutate: vi.fn(),
@@ -126,6 +143,7 @@ function mockTransitData({
 describe("TransitStudentsSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParamsToString.mockReturnValue("room=__transit__");
     mutateStudents.mockResolvedValue(undefined);
     mutateKey.mockResolvedValue(undefined);
     mutateMatching.mockResolvedValue(undefined);
@@ -175,6 +193,34 @@ describe("TransitStudentsSection", () => {
     expect(mutateStudents).toHaveBeenCalledTimes(1);
     expect(mutateKey).toHaveBeenCalledWith("rooms-list");
     expect(mutateMatching).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens a transit child profile from the dedicated profile button", () => {
+    render(<TransitStudentsSection />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Mila Sommer Profil öffnen" }),
+    );
+
+    expect(mockPush).toHaveBeenCalledWith(
+      `/students/11?from=${encodeURIComponent("/rooms?room=__transit__")}`,
+    );
+  });
+
+  it("reports active selection state to the drawer wrapper", async () => {
+    const onSelectionActiveChange = vi.fn();
+
+    render(
+      <TransitStudentsSection
+        onSelectionActiveChange={onSelectionActiveChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Mila Sommer auswählen"));
+
+    await waitFor(() => {
+      expect(onSelectionActiveChange).toHaveBeenLastCalledWith(true);
+    });
   });
 
   it("shows empty and error states", () => {

--- a/frontend/src/components/rooms/transit-students-section.test.tsx
+++ b/frontend/src/components/rooms/transit-students-section.test.tsx
@@ -29,6 +29,13 @@ vi.mock("~/lib/api", () => ({
   },
 }));
 
+const mockToastSuccess = vi.fn();
+vi.mock("~/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: mockToastSuccess,
+  }),
+}));
+
 const mockStudents: Student[] = [
   {
     id: "11",
@@ -122,6 +129,7 @@ describe("TransitStudentsSection", () => {
     mutateStudents.mockResolvedValue(undefined);
     mutateKey.mockResolvedValue(undefined);
     mutateMatching.mockResolvedValue(undefined);
+    mockToastSuccess.mockReset();
     vi.mocked(useTenantMutate).mockReturnValue(mutateKey as never);
     vi.mocked(useTenantMutateMatching).mockReturnValue(mutateMatching as never);
     vi.mocked(activeService.assignTransitStudents).mockResolvedValue({
@@ -152,10 +160,10 @@ describe("TransitStudentsSection", () => {
     render(<TransitStudentsSection />);
 
     fireEvent.click(screen.getByLabelText("Mila Sommer auswählen"));
-    fireEvent.change(screen.getByRole("combobox"), {
+    fireEvent.change(screen.getByLabelText("Zielraum"), {
       target: { value: "101" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "1 Kind zuweisen" }));
+    fireEvent.click(screen.getByRole("button", { name: "In Raum setzen" }));
 
     await waitFor(() => {
       expect(activeService.assignTransitStudents).toHaveBeenCalledWith(
@@ -163,9 +171,7 @@ describe("TransitStudentsSection", () => {
         "101",
       );
     });
-    await waitFor(() => {
-      expect(screen.getByText("1 Kind zugewiesen.")).toBeInTheDocument();
-    });
+    expect(mockToastSuccess).toHaveBeenCalledWith("1 Kind zugewiesen.");
     expect(mutateStudents).toHaveBeenCalledTimes(1);
     expect(mutateKey).toHaveBeenCalledWith("rooms-list");
     expect(mutateMatching).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/rooms/transit-students-section.tsx
+++ b/frontend/src/components/rooms/transit-students-section.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { Check } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Check, ExternalLink } from "lucide-react";
+import { useSearchParams } from "next/navigation";
 import {
   useSWRAuth,
   useTenantMutate,
@@ -16,9 +17,11 @@ import type { ActiveGroup } from "~/lib/active-helpers";
 import { studentService } from "~/lib/api";
 import type { Student } from "~/lib/api";
 import { CompactStudentCard } from "~/components/students/compact-student-card";
+import { useTenantRouter } from "~/lib/tenant-router";
 
 const DETAIL_CARD_CLASS =
   "rounded-3xl border border-gray-100/50 bg-white/90 p-5 shadow-[0_8px_30px_rgb(0,0,0,0.12)] sm:p-6";
+const EMPTY_STUDENTS: Student[] = [];
 
 function buildSessionLabel(group: ActiveGroup): string {
   const roomName = group.room?.name ?? `Raum ${group.roomId}`;
@@ -26,7 +29,15 @@ function buildSessionLabel(group: ActiveGroup): string {
   return activityName ? `${roomName} · ${activityName}` : roomName;
 }
 
-export function TransitStudentsSection() {
+interface TransitStudentsSectionProps {
+  readonly onSelectionActiveChange?: (active: boolean) => void;
+}
+
+export function TransitStudentsSection({
+  onSelectionActiveChange,
+}: TransitStudentsSectionProps) {
+  const router = useTenantRouter();
+  const sectionSearchParams = useSearchParams();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
   const [targetGroupId, setTargetGroupId] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -70,9 +81,25 @@ export function TransitStudentsSection() {
     [activeGroups],
   );
 
-  const students = studentsData?.students ?? [];
+  const students = studentsData?.students ?? EMPTY_STUDENTS;
+  const visibleStudentIds = useMemo(
+    () => new Set(students.map((student) => String(student.id))),
+    [students],
+  );
+  const selectedVisibleCount = [...selectedIds].filter((studentId) =>
+    visibleStudentIds.has(studentId),
+  ).length;
   const totalCount = studentsData?.pagination?.total_records ?? students.length;
-  const allSelected = students.length > 0 && selectedIds.size === students.length;
+  const allSelected =
+    students.length > 0 && selectedVisibleCount === students.length;
+  const fromReferrer = (() => {
+    const qs = sectionSearchParams?.toString() ?? "";
+    return qs ? `/rooms?${qs}` : "/rooms?room=__transit__";
+  })();
+
+  useEffect(() => {
+    onSelectionActiveChange?.(selectedVisibleCount > 0);
+  }, [onSelectionActiveChange, selectedVisibleCount]);
 
   const toggleSelected = (studentId: string) => {
     setSelectedIds((current) => {
@@ -95,12 +122,15 @@ export function TransitStudentsSection() {
   };
 
   const assignSelected = async () => {
-    if (!targetGroupId || selectedIds.size === 0) return;
+    const studentIds = [...selectedIds].filter((studentId) =>
+      visibleStudentIds.has(studentId),
+    );
+    if (!targetGroupId || studentIds.length === 0) return;
     setSubmitting(true);
     setSubmitError(null);
     try {
       const result = await activeService.assignTransitStudents(
-        Array.from(selectedIds),
+        studentIds,
         targetGroupId,
       );
       setSelectedIds(new Set());
@@ -155,7 +185,7 @@ export function TransitStudentsSection() {
 
       <div
         className={`mt-4 mb-4 rounded-2xl border p-3 transition-shadow ${
-          selectedIds.size > 0
+          selectedVisibleCount > 0
             ? "sticky bottom-3 z-20 border-gray-200 bg-white/95 shadow-[0_12px_40px_rgb(0,0,0,0.12)] backdrop-blur"
             : "border-transparent bg-gray-50/80 shadow-none"
         }`}
@@ -163,8 +193,8 @@ export function TransitStudentsSection() {
         <div className="flex items-start justify-between gap-3">
           <p className="min-w-0 text-sm font-semibold text-gray-900">
             <span className="block truncate">
-              {selectedIds.size > 0
-                ? `${selectedIds.size} von ${students.length} ausgewählt`
+              {selectedVisibleCount > 0
+                ? `${selectedVisibleCount} von ${students.length} ausgewählt`
                 : "Kinder auswählen"}
             </span>
             <span className="block text-xs font-medium text-gray-500">
@@ -216,7 +246,7 @@ export function TransitStudentsSection() {
             isLoading={submitting}
             loadingText="Weise zu..."
             onClick={() => void assignSelected()}
-            disabled={!targetGroupId || selectedIds.size === 0 || submitting}
+            disabled={!targetGroupId || selectedVisibleCount === 0 || submitting}
             className="h-9 w-full px-3 py-2 text-xs shadow-sm sm:w-auto"
           >
             In Raum setzen
@@ -237,6 +267,9 @@ export function TransitStudentsSection() {
           students.map((student) => {
             const studentId = student.id.toString();
             const checked = selectedIds.has(studentId);
+            const fullName =
+              `${student.first_name ?? ""} ${student.second_name ?? ""}`.trim() ||
+              "Kind";
             return (
               <div
                 key={student.id}
@@ -250,7 +283,7 @@ export function TransitStudentsSection() {
                   type="button"
                   role="checkbox"
                   aria-checked={checked}
-                  aria-label={`${student.first_name} ${student.second_name} auswählen`}
+                  aria-label={`${fullName} auswählen`}
                   onClick={() => toggleSelected(studentId)}
                   className="flex min-w-0 flex-1 items-center gap-3 rounded-xl text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300"
                 >
@@ -278,6 +311,24 @@ export function TransitStudentsSection() {
                     chrome="plain"
                   />
                 </button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    router.push(
+                      `/students/${student.id}?from=${encodeURIComponent(
+                        fromReferrer,
+                      )}`,
+                    )
+                  }
+                  aria-label={`${fullName} Profil öffnen`}
+                  title="Profil öffnen"
+                  className="h-8 shrink-0 gap-1.5 rounded-full px-2.5 py-0 text-xs font-medium shadow-none"
+                >
+                  Profil
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
               </div>
             );
           })

--- a/frontend/src/components/rooms/transit-students-section.tsx
+++ b/frontend/src/components/rooms/transit-students-section.tsx
@@ -1,16 +1,24 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { Check } from "lucide-react";
 import {
   useSWRAuth,
   useTenantMutate,
   useTenantMutateMatching,
 } from "~/lib/swr";
 import { Alert } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
+import { DatabaseSelect } from "~/components/ui/database/database-select";
+import { useToast } from "~/contexts/ToastContext";
 import { activeService } from "~/lib/active-service";
 import type { ActiveGroup } from "~/lib/active-helpers";
 import { studentService } from "~/lib/api";
 import type { Student } from "~/lib/api";
+import { CompactStudentCard } from "~/components/students/compact-student-card";
+
+const DETAIL_CARD_CLASS =
+  "rounded-3xl border border-gray-100/50 bg-white/90 p-5 shadow-[0_8px_30px_rgb(0,0,0,0.12)] sm:p-6";
 
 function buildSessionLabel(group: ActiveGroup): string {
   const roomName = group.room?.name ?? `Raum ${group.roomId}`;
@@ -22,8 +30,8 @@ export function TransitStudentsSection() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
   const [targetGroupId, setTargetGroupId] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [message, setMessage] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const { success: toastSuccess } = useToast();
   const mutateKey = useTenantMutate();
   const mutateMatching = useTenantMutateMatching([
     "room-students-",
@@ -64,6 +72,7 @@ export function TransitStudentsSection() {
 
   const students = studentsData?.students ?? [];
   const totalCount = studentsData?.pagination?.total_records ?? students.length;
+  const allSelected = students.length > 0 && selectedIds.size === students.length;
 
   const toggleSelected = (studentId: string) => {
     setSelectedIds((current) => {
@@ -72,14 +81,22 @@ export function TransitStudentsSection() {
       else next.add(studentId);
       return next;
     });
-    setMessage(null);
+    setSubmitError(null);
+  };
+
+  const selectAllVisible = () => {
+    setSelectedIds(new Set(students.map((student) => student.id.toString())));
+    setSubmitError(null);
+  };
+
+  const clearSelection = () => {
+    setSelectedIds(new Set());
     setSubmitError(null);
   };
 
   const assignSelected = async () => {
     if (!targetGroupId || selectedIds.size === 0) return;
     setSubmitting(true);
-    setMessage(null);
     setSubmitError(null);
     try {
       const result = await activeService.assignTransitStudents(
@@ -91,7 +108,7 @@ export function TransitStudentsSection() {
       await mutateKey("rooms-list");
       await mutateMatching();
       const skipped = result.skipped.length;
-      setMessage(
+      toastSuccess(
         skipped > 0
           ? `${result.assigned.length} zugewiesen, ${skipped} übersprungen.`
           : `${result.assigned.length} ${
@@ -110,7 +127,7 @@ export function TransitStudentsSection() {
   return (
     <section
       aria-label="Kinder unterwegs"
-      className="rounded-2xl border border-gray-100 bg-white/50 p-4 backdrop-blur-sm sm:p-6"
+      className={DETAIL_CARD_CLASS}
     >
       <h2 className="mb-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">
         Kinder unterwegs
@@ -135,44 +152,76 @@ export function TransitStudentsSection() {
           <Alert type="error" message={submitError} />
         </div>
       ) : null}
-      {message ? (
-        <div className="mt-4 rounded-lg border border-[#83CD2D]/30 bg-[#83CD2D]/10 p-3 text-sm text-[#4a7a15]">
-          {message}
-        </div>
-      ) : null}
 
-      <div className="mt-4 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
-        <select
-          value={targetGroupId}
-          onChange={(event) => setTargetGroupId(event.target.value)}
-          disabled={groupsLoading || targetOptions.length === 0}
-          className="min-h-10 rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-900 focus:border-[#5080D8] focus:ring-2 focus:ring-[#5080D8]/20 focus:outline-none disabled:bg-gray-50 disabled:text-gray-400"
-        >
-          <option value="">
-            {groupsLoading
-              ? "Aktive Räume werden geladen..."
-              : targetOptions.length === 0
-                ? "Keine aktiven Räume"
-                : "Zielraum wählen"}
-          </option>
-          {targetOptions.map((group) => (
-            <option key={group.id} value={group.id}>
-              {buildSessionLabel(group)}
-            </option>
-          ))}
-        </select>
-        <button
-          type="button"
-          onClick={() => void assignSelected()}
-          disabled={!targetGroupId || selectedIds.size === 0 || submitting}
-          className="inline-flex min-h-10 items-center justify-center rounded-lg bg-[#5080D8] px-4 text-sm font-medium text-white transition-colors hover:bg-[#4070c8] disabled:cursor-not-allowed disabled:bg-gray-300"
-        >
-          {submitting
-            ? "Zuweisen..."
-            : `${selectedIds.size} ${
-                selectedIds.size === 1 ? "Kind" : "Kinder"
-              } zuweisen`}
-        </button>
+      <div
+        className={`mt-4 mb-4 rounded-2xl border p-3 transition-shadow ${
+          selectedIds.size > 0
+            ? "sticky bottom-3 z-20 border-gray-200 bg-white/95 shadow-[0_12px_40px_rgb(0,0,0,0.12)] backdrop-blur"
+            : "border-transparent bg-gray-50/80 shadow-none"
+        }`}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <p className="min-w-0 text-sm font-semibold text-gray-900">
+            <span className="block truncate">
+              {selectedIds.size > 0
+                ? `${selectedIds.size} von ${students.length} ausgewählt`
+                : "Kinder auswählen"}
+            </span>
+            <span className="block text-xs font-medium text-gray-500">
+              Zielraum wählen und gemeinsam zuweisen
+            </span>
+          </p>
+          {students.length > 0 ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={allSelected ? clearSelection : selectAllVisible}
+              className="h-8 shrink-0 rounded-full px-3 py-0 text-xs shadow-none"
+            >
+              {allSelected ? "Aufheben" : "Alle auswählen"}
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+          <DatabaseSelect
+            id="transit-target-room"
+            name="transit-target-room"
+            label="Zielraum"
+            value={targetGroupId}
+            onChange={(value) => {
+              setTargetGroupId(value);
+              setSubmitError(null);
+            }}
+            disabled={groupsLoading || targetOptions.length === 0 || submitting}
+            placeholder={
+              groupsLoading
+                ? "Aktive Räume werden geladen..."
+                : targetOptions.length === 0
+                  ? "Keine aktiven Räume"
+                  : "Zielraum wählen"
+            }
+            options={targetOptions.map((group) => ({
+              value: group.id,
+              label: buildSessionLabel(group),
+            }))}
+            focusRingColor="focus:ring-gray-300"
+            className="bg-white text-sm md:text-sm"
+          />
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            isLoading={submitting}
+            loadingText="Weise zu..."
+            onClick={() => void assignSelected()}
+            disabled={!targetGroupId || selectedIds.size === 0 || submitting}
+            className="h-9 w-full px-3 py-2 text-xs shadow-sm sm:w-auto"
+          >
+            In Raum setzen
+          </Button>
+        </div>
       </div>
 
       <div className="mt-4 flex flex-col gap-2">
@@ -189,28 +238,47 @@ export function TransitStudentsSection() {
             const studentId = student.id.toString();
             const checked = selectedIds.has(studentId);
             return (
-              <label
+              <div
                 key={student.id}
-                aria-label={`${student.first_name} ${student.second_name} auswählen`}
-                className="flex cursor-pointer items-center gap-3 rounded-xl border border-gray-200 bg-white px-3 py-2 transition-colors hover:bg-gray-50"
+                className={`flex items-center gap-2 rounded-2xl border px-3 py-2.5 transition-colors ${
+                  checked
+                    ? "border-gray-300 bg-gray-50"
+                    : "border-gray-100 bg-white hover:border-gray-200 hover:bg-gray-50"
+                }`}
               >
-                <input
-                  type="checkbox"
-                  checked={checked}
-                  onChange={() => toggleSelected(studentId)}
-                  className="h-4 w-4 rounded border-gray-300 text-[#5080D8] focus:ring-[#5080D8]"
-                />
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-base font-semibold text-gray-900">
-                    {student.first_name} {student.second_name}
-                  </p>
-                  <p className="mt-0.5 truncate text-sm text-gray-500">
-                    {[student.school_class, student.group_name]
-                      .filter(Boolean)
-                      .join(" · ")}
-                  </p>
-                </div>
-              </label>
+                <button
+                  type="button"
+                  role="checkbox"
+                  aria-checked={checked}
+                  aria-label={`${student.first_name} ${student.second_name} auswählen`}
+                  onClick={() => toggleSelected(studentId)}
+                  className="flex min-w-0 flex-1 items-center gap-3 rounded-xl text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300"
+                >
+                  <span
+                    className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-md border shadow-sm transition-all ${
+                      checked
+                        ? "border-gray-900 bg-gray-900"
+                        : "border-gray-300 bg-white"
+                    }`}
+                    aria-hidden="true"
+                  >
+                    <Check
+                      className={`h-3.5 w-3.5 text-white transition-opacity ${
+                        checked ? "opacity-100" : "opacity-0"
+                      }`}
+                    />
+                  </span>
+                  <CompactStudentCard
+                    studentId={student.id}
+                    firstName={student.first_name}
+                    lastName={student.second_name}
+                    schoolClass={student.school_class}
+                    groupName={student.group_name ?? undefined}
+                    photoUrl={student.photo_url ?? null}
+                    chrome="plain"
+                  />
+                </button>
+              </div>
             );
           })
         )}

--- a/frontend/src/components/students/compact-student-card.test.tsx
+++ b/frontend/src/components/students/compact-student-card.test.tsx
@@ -63,7 +63,7 @@ describe("CompactStudentCard", () => {
       <CompactStudentCard studentId="42" firstName="Anna" lastName="Müller" />,
     );
 
-    // Only the name <p> should render — no second <p> for meta.
+    // Only the name <p> should render, no second <p> for meta.
     expect(container.querySelectorAll("p")).toHaveLength(1);
   });
 
@@ -89,8 +89,22 @@ describe("CompactStudentCard", () => {
       <CompactStudentCard studentId={42} firstName="Anna" lastName="Müller" />,
     );
 
+    expect(screen.getByTestId("compact-student-card-42")).toBeInTheDocument();
+  });
+
+  it("uses a button only when an onClick handler is provided", () => {
+    const onClick = vi.fn();
+    render(
+      <CompactStudentCard
+        studentId={42}
+        firstName="Anna"
+        lastName="Müller"
+        onClick={onClick}
+      />,
+    );
+
     const button = screen.getByRole("button", {
-      name: "Anna Müller – Profil öffnen",
+      name: "Anna Müller - Profil öffnen",
     });
     expect(button).toHaveAttribute("data-testid", "compact-student-card-42");
     expect(button).toHaveAttribute("type", "button");

--- a/frontend/src/components/students/compact-student-card.tsx
+++ b/frontend/src/components/students/compact-student-card.tsx
@@ -1,7 +1,7 @@
 // components/students/compact-student-card.tsx
 //
 // Lightweight, single-line student row for the room-detail slide-over
-// (#1323 review). The full StudentCard is too heavy for a side panel —
+// (#1323 review). The full StudentCard is too heavy for a side panel,
 // staff already know the kids are present (that's the whole point of
 // "Kinder im Raum"), so the location badge and arrival/pickup rows are
 // noise here. Just the identifiers staff need to recognise the child:
@@ -23,7 +23,7 @@ interface CompactStudentCardProps {
   readonly schoolClass?: string;
   readonly groupName?: string;
   /**
-   * Photo URL — gated server-side by operations.student_photos_enabled +
+   * Photo URL, gated server-side by operations.student_photos_enabled +
    * parental consent. When falsy the Avatar falls back to brand initials,
    * so callers can pass `student.photo_url` unconditionally.
    */
@@ -47,7 +47,7 @@ export function CompactStudentCard({
   // Per-tenant feature flag. When off, the avatar slot is suppressed so
   // opt-out schools see the original pre-feature shape (name + meta only).
   const { enabled: photosEnabled } = useStudentPhotosEnabled();
-  // No "Gruppe X" prefix — group names are already self-evidently
+  // No "Gruppe X" prefix, group names are already self-evidently
   // group names ("Bärengruppe", "Sternengruppe", …), so prefixing with
   // "Gruppe" reads as a stutter ("Gruppe Bärengruppe").
   const meta = [schoolClass, groupName].filter(Boolean).join(" · ");
@@ -56,28 +56,44 @@ export function CompactStudentCard({
   const chromeClass =
     chrome === "card"
       ? "border border-gray-200 bg-white px-4 py-3 hover:border-gray-300 hover:bg-gray-50"
-      : "border border-transparent bg-transparent px-0 py-0 hover:bg-transparent";
+      : "bg-transparent px-0 py-0 hover:bg-transparent";
+  const content = (
+    <>
+      {photosEnabled ? (
+        <Avatar imageUrl={photoUrl ?? null} name={fullName} size="sm" />
+      ) : null}
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold text-gray-900">
+          {firstName} {lastName}
+        </p>
+        {meta && (
+          <p className="mt-0.5 truncate text-xs text-gray-500">{meta}</p>
+        )}
+      </div>
+    </>
+  );
+
+  if (!onClick) {
+    return (
+      <div
+        data-testid={`compact-student-card-${studentId}`}
+        className={`flex w-full items-center gap-3 rounded-xl text-left ${chromeClass} ${className}`}
+      >
+        {content}
+      </div>
+    );
+  }
 
   return (
     <button
       key={studentId}
       type="button"
       onClick={onClick}
-      aria-label={`${firstName} ${lastName} – Profil öffnen`}
+      aria-label={`${firstName} ${lastName} - Profil öffnen`}
       data-testid={`compact-student-card-${studentId}`}
-      className={`group flex w-full items-center gap-3 rounded-xl text-left transition-colors duration-150 focus:ring-2 focus:ring-[#5080D8]/40 focus:outline-none ${chromeClass} ${className}`}
+      className={`group flex w-full items-center gap-3 rounded-xl text-left transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 ${chromeClass} ${className}`}
     >
-      {photosEnabled ? (
-        <Avatar imageUrl={photoUrl ?? null} name={fullName} size="sm" />
-      ) : null}
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-base font-semibold text-gray-900">
-          {firstName} {lastName}
-        </p>
-        {meta && (
-          <p className="mt-0.5 truncate text-sm text-gray-500">{meta}</p>
-        )}
-      </div>
+      {content}
     </button>
   );
 }

--- a/frontend/src/components/ui/database/database-select.tsx
+++ b/frontend/src/components/ui/database/database-select.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { ChevronDown } from "lucide-react";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "DatabaseSelect" });
@@ -106,7 +107,7 @@ export function DatabaseSelect({
 
   // Base input classes matching StudentForm styling
   const baseClasses = `
-    w-full rounded-lg border border-gray-300 px-3 py-2 md:px-4 
+    w-full appearance-none rounded-lg border border-gray-300 px-3 py-2 pr-10 md:px-4 md:pr-10
     text-sm md:text-base transition-all duration-200 focus:ring-2 ${focusRingColor} focus:outline-none
     ${isLoading ? "opacity-50 cursor-wait" : ""}
     ${disabled ? "bg-gray-50 cursor-not-allowed" : ""}
@@ -126,40 +127,43 @@ export function DatabaseSelect({
         </label>
       )}
 
-      <select
-        id={id ?? name}
-        name={name}
-        value={value}
-        onChange={handleChange}
-        disabled={disabled || isLoading}
-        required={required}
-        className={baseClasses}
-      >
-        {/* Empty option */}
-        {includeEmpty && (
-          <option value="">
-            {isLoading ? "Lädt..." : (emptyOptionLabel ?? placeholder)}
-          </option>
-        )}
+      <div className="relative">
+        <select
+          id={id ?? name}
+          name={name}
+          value={value}
+          onChange={handleChange}
+          disabled={disabled || isLoading}
+          required={required}
+          className={baseClasses}
+        >
+          {includeEmpty && (
+            <option value="">
+              {isLoading ? "Lädt..." : (emptyOptionLabel ?? placeholder)}
+            </option>
+          )}
 
-        {/* Render options */}
-        {options.map((option) => (
-          <option
-            key={option.value}
-            value={option.value}
-            disabled={option.disabled}
-          >
-            {option.label}
-          </option>
-        ))}
+          {options.map((option) => (
+            <option
+              key={option.value}
+              value={option.value}
+              disabled={option.disabled}
+            >
+              {option.label}
+            </option>
+          ))}
 
-        {/* Show message if no options available */}
-        {!isLoading && options.length === 0 && !includeEmpty && (
-          <option value="" disabled>
-            Keine Optionen verfügbar
-          </option>
-        )}
-      </select>
+          {!isLoading && options.length === 0 && !includeEmpty && (
+            <option value="" disabled>
+              Keine Optionen verfügbar
+            </option>
+          )}
+        </select>
+        <ChevronDown
+          aria-hidden="true"
+          className="pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 text-gray-400"
+        />
+      </div>
 
       {/* Helper text or error message */}
       {displayError && (

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -132,6 +132,7 @@
 /* Custom scrollbar styles for modals */
 .scrollbar-thin {
   scrollbar-width: thin;
+  scrollbar-color: rgb(209 213 219) transparent;
 }
 
 .scrollbar-thumb-gray-300::-webkit-scrollbar-thumb {
@@ -143,17 +144,23 @@
   background-color: rgb(243 244 246);
 }
 
+.scrollbar-track-transparent::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
 .scrollbar-thin::-webkit-scrollbar {
-  width: 6px;
+  width: 8px;
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb {
   background-color: rgb(209 213 219);
-  border-radius: 0.375rem;
+  border: 2px solid transparent;
+  border-radius: 9999px;
+  background-clip: padding-box;
 }
 
 .scrollbar-thin::-webkit-scrollbar-track {
-  background-color: rgb(243 244 246);
+  background-color: transparent;
 }
 
 /* Sophisticated Modal Animations - Following UI/UX Best Practices */
@@ -354,22 +361,26 @@ html {
   }
 }
 
-/* Optional: Customize scrollbar appearance for better aesthetics */
+/* App scrollbar */
 ::-webkit-scrollbar {
-  width: 10px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #c5c5c5;
-  border-radius: 5px;
+  background: #d1d5db;
+  border: 2px solid transparent;
+  border-radius: 9999px;
+  background-clip: padding-box;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #a8a8a8;
+  background: #9ca3af;
+  background-clip: padding-box;
 }
 
 /* Progress bar animation for save notification */
@@ -436,4 +447,3 @@ html {
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
-


### PR DESCRIPTION
## Summary

- Refines the room card hover treatment to match the existing child card interaction pattern more closely.
- Reworks the room detail drawer toward the cleaner shadcn-style surface used elsewhere in the app.
- Updates the children-in-room controls: neutral profile action, custom checkbox, compact bulk move controls, reusable toast success feedback, and cleaner target-room select styling.
- Prevents row clicks from opening child detail pages accidentally. Staff now select children from the row and open profiles through the explicit profile action.

## Tests

- `docker compose -f /Users/flo/Developer/moto/project-phoenix/docker-compose.yml --project-directory /Users/flo/Developer/moto/project-phoenix-rooms-drawer-ux exec -T frontend pnpm exec vitest run src/components/rooms/students-in-room-section.test.tsx src/components/students/compact-student-card.test.tsx src/components/rooms/room-detail-content.test.tsx src/components/ui/database/database-select.test.tsx`
- `docker compose -f /Users/flo/Developer/moto/project-phoenix/docker-compose.yml --project-directory /Users/flo/Developer/moto/project-phoenix-rooms-drawer-ux exec -T frontend pnpm run check`

## Notes

Local host pre-commit and pre-push frontend hooks tried to run against missing host `frontend/node_modules` and failed outside Docker. The equivalent frontend checks were run successfully inside the active Docker frontend container.

Follow-up for the currently inconsistent room occupancy history contract is tracked in #1425.
