### PR TITLE
fix: stabilize backend flaky tests

### DIFF
--- a/backend/api/operator/settings_integration_test.go
+++ b/backend/api/operator/settings_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -444,43 +445,89 @@ func TestOperatorResetSchoolSettingValue_NonPhotoKeyDoesNotInvokeOnValueSet(t *t
 // Presence-mode switch guard (must-fix #1 from review round 2)
 // =============================================================================
 
-func presenceModeAttendanceCleanup(t *testing.T, db *bun.DB) {
+func presenceModeAttendanceCleanup(t *testing.T, db *bun.DB, tenantID int64) {
 	t.Helper()
 	_, err := db.ExecContext(context.Background(),
-		`DELETE FROM active.attendance WHERE date = ? AND tenant_id = 1`,
+		`DELETE FROM active.attendance WHERE date = ? AND tenant_id = ?`,
 		timezone.TodayUTC(),
+		tenantID,
 	)
 	require.NoError(t, err)
 }
 
-func resetPresenceMode(t *testing.T, db *bun.DB) {
+func resetPresenceMode(t *testing.T, db *bun.DB, tenantID int64) {
 	t.Helper()
 	_, err := db.ExecContext(context.Background(),
-		`DELETE FROM config.setting_values WHERE tenant_id = 1 AND setting_key = ?`,
+		`DELETE FROM config.setting_values WHERE tenant_id = ? AND setting_key = ?`,
+		tenantID,
 		configModel.KeyPresenceMode,
 	)
 	require.NoError(t, err)
+}
+
+func createPresenceModeAttendanceForTenant(
+	t *testing.T,
+	db *bun.DB,
+	tenantID int64,
+	studentID int64,
+	staffID int64,
+	deviceID int64,
+	checkInTime time.Time,
+	checkOutTime *time.Time,
+) {
+	t.Helper()
+
+	_, err := db.ExecContext(
+		context.Background(),
+		`INSERT INTO active.attendance (
+			tenant_id,
+			student_id,
+			date,
+			check_in_time,
+			check_out_time,
+			checked_in_by,
+			device_id,
+			created_at,
+			updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW())`,
+		tenantID,
+		studentID,
+		timezone.TodayUTC(),
+		checkInTime,
+		checkOutTime,
+		staffID,
+		deviceID,
+	)
+	require.NoError(t, err)
+}
+
+func presenceModePath(tenantID int64, suffix string) string {
+	return fmt.Sprintf("/schools/%d/settings/values/%s%s", tenantID, configModel.KeyPresenceMode, suffix)
 }
 
 func TestOperatorSetSchoolSettingValue_PresenceMode_BlockedByOpenAttendance(t *testing.T) {
 	ctx := setupOperatorSettingsTest(t)
 	defer func() { _ = ctx.db.Close() }()
 
-	presenceModeAttendanceCleanup(t, ctx.db)
-	resetPresenceMode(t, ctx.db)
-	defer presenceModeAttendanceCleanup(t, ctx.db)
-	defer resetPresenceMode(t, ctx.db)
+	tenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, ctx.db, tenantID)
+	presenceModeAttendanceCleanup(t, ctx.db, tenantID)
+	resetPresenceMode(t, ctx.db, tenantID)
+	defer presenceModeAttendanceCleanup(t, ctx.db, tenantID)
+	defer resetPresenceMode(t, ctx.db, tenantID)
 
-	student := testpkg.CreateTestStudent(t, ctx.db, "Guard", "Block", "9a")
-	staff := testpkg.CreateTestStaff(t, ctx.db, "Guard", "Staff")
-	device := testpkg.CreateTestDevice(t, ctx.db, "guard-device-001")
-	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID, staff.ID, device.ID)
+	student := testpkg.CreateTestStudentForTenant(t, ctx.db, tenantID, "Guard", "Block", "9a")
+	staff := testpkg.CreateTestStaffForTenant(t, ctx.db, tenantID, "Guard", "Staff")
+	device := testpkg.CreateTestDeviceForTenant(t, ctx.db, tenantID, "guard-device-001")
+	defer testpkg.CleanupActivityFixturesForTenant(t, ctx.db, tenantID, student.ID, staff.ID, device.ID)
 
 	checkInTime := time.Now().Add(-1 * time.Hour)
-	testpkg.CreateTestAttendance(t, ctx.db, student.ID, staff.ID, device.ID, checkInTime, nil)
+	createPresenceModeAttendanceForTenant(t, ctx.db, tenantID, student.ID, staff.ID, device.ID, checkInTime, nil)
+	defer presenceModeAttendanceCleanup(t, ctx.db, tenantID)
 
 	body := map[string]interface{}{"value": configModel.PresenceModeBinary}
-	req := newOperatorRequest(t, http.MethodPut, "/schools/1/settings/values/"+configModel.KeyPresenceMode, body)
+	req := newOperatorRequest(t, http.MethodPut, presenceModePath(tenantID, ""), body)
 	rr := testutil.ExecuteRequest(ctx.router, req)
 
 	assert.Equal(t, http.StatusConflict, rr.Code)
@@ -491,21 +538,24 @@ func TestOperatorSetSchoolSettingValue_PresenceMode_ForceBypassesOpenAttendance(
 	ctx := setupOperatorSettingsTest(t)
 	defer func() { _ = ctx.db.Close() }()
 
-	presenceModeAttendanceCleanup(t, ctx.db)
-	resetPresenceMode(t, ctx.db)
-	defer presenceModeAttendanceCleanup(t, ctx.db)
-	defer resetPresenceMode(t, ctx.db)
+	tenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, ctx.db, tenantID)
+	presenceModeAttendanceCleanup(t, ctx.db, tenantID)
+	resetPresenceMode(t, ctx.db, tenantID)
+	defer presenceModeAttendanceCleanup(t, ctx.db, tenantID)
+	defer resetPresenceMode(t, ctx.db, tenantID)
 
-	student := testpkg.CreateTestStudent(t, ctx.db, "Guard", "Force", "9b")
-	staff := testpkg.CreateTestStaff(t, ctx.db, "Guard", "Staff2")
-	device := testpkg.CreateTestDevice(t, ctx.db, "guard-device-002")
-	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID, staff.ID, device.ID)
+	student := testpkg.CreateTestStudentForTenant(t, ctx.db, tenantID, "Guard", "Force", "9b")
+	staff := testpkg.CreateTestStaffForTenant(t, ctx.db, tenantID, "Guard", "Staff2")
+	device := testpkg.CreateTestDeviceForTenant(t, ctx.db, tenantID, "guard-device-002")
+	defer testpkg.CleanupActivityFixturesForTenant(t, ctx.db, tenantID, student.ID, staff.ID, device.ID)
 
 	checkInTime := time.Now().Add(-1 * time.Hour)
-	testpkg.CreateTestAttendance(t, ctx.db, student.ID, staff.ID, device.ID, checkInTime, nil)
+	createPresenceModeAttendanceForTenant(t, ctx.db, tenantID, student.ID, staff.ID, device.ID, checkInTime, nil)
+	defer presenceModeAttendanceCleanup(t, ctx.db, tenantID)
 
 	body := map[string]interface{}{"value": configModel.PresenceModeBinary}
-	req := newOperatorRequest(t, http.MethodPut, "/schools/1/settings/values/"+configModel.KeyPresenceMode+"?force=true", body)
+	req := newOperatorRequest(t, http.MethodPut, presenceModePath(tenantID, "?force=true"), body)
 	rr := testutil.ExecuteRequest(ctx.router, req)
 
 	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
@@ -515,12 +565,14 @@ func TestOperatorSetSchoolSettingValue_PresenceMode_PassesWithNoOpenAttendance(t
 	ctx := setupOperatorSettingsTest(t)
 	defer func() { _ = ctx.db.Close() }()
 
-	presenceModeAttendanceCleanup(t, ctx.db)
-	resetPresenceMode(t, ctx.db)
-	defer resetPresenceMode(t, ctx.db)
+	tenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, ctx.db, tenantID)
+	presenceModeAttendanceCleanup(t, ctx.db, tenantID)
+	resetPresenceMode(t, ctx.db, tenantID)
+	defer resetPresenceMode(t, ctx.db, tenantID)
 
 	body := map[string]interface{}{"value": configModel.PresenceModeBinary}
-	req := newOperatorRequest(t, http.MethodPut, "/schools/1/settings/values/"+configModel.KeyPresenceMode, body)
+	req := newOperatorRequest(t, http.MethodPut, presenceModePath(tenantID, ""), body)
 	rr := testutil.ExecuteRequest(ctx.router, req)
 
 	testutil.AssertSuccessResponse(t, rr, http.StatusOK)

--- a/backend/database/migrations/001015039_repair_pickup_schedule_tenant_ids.go
+++ b/backend/database/migrations/001015039_repair_pickup_schedule_tenant_ids.go
@@ -2,9 +2,7 @@ package migrations
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
-	"log"
 
 	"github.com/uptrace/bun"
 )
@@ -73,59 +71,15 @@ var pickupTenantRepairSpecs = []pickupTenantRepairSpec{
 	},
 }
 
-var pickupCompositeFKStatements = []struct {
-	name string
-	add  string
-}{
-	{
-		name: "fk_pickup_schedules_created_by_tenant",
-		add:  `ALTER TABLE schedule.student_pickup_schedules ADD CONSTRAINT fk_pickup_schedules_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
-	},
-	{
-		name: "fk_pickup_schedules_student_tenant",
-		add:  `ALTER TABLE schedule.student_pickup_schedules ADD CONSTRAINT fk_pickup_schedules_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
-	},
-	{
-		name: "fk_pickup_exceptions_created_by_tenant",
-		add:  `ALTER TABLE schedule.student_pickup_exceptions ADD CONSTRAINT fk_pickup_exceptions_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
-	},
-	{
-		name: "fk_pickup_exceptions_student_tenant",
-		add:  `ALTER TABLE schedule.student_pickup_exceptions ADD CONSTRAINT fk_pickup_exceptions_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
-	},
-	{
-		name: "fk_pickup_notes_created_by_tenant",
-		add:  `ALTER TABLE schedule.student_pickup_notes ADD CONSTRAINT fk_pickup_notes_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
-	},
-	{
-		name: "fk_pickup_notes_student_tenant",
-		add:  `ALTER TABLE schedule.student_pickup_notes ADD CONSTRAINT fk_pickup_notes_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
-	},
-}
-
 func repairPickupScheduleTenantIDs(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Migration 1.15.39: Repairing pickup schedule tenant IDs...")
 
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() {
-		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
-			log.Printf("Error rolling back transaction: %v", err)
-		}
-	}()
-
-	if err := dropPickupCompositeFKsForRepair(ctx, tx); err != nil {
-		return err
-	}
-
 	for _, spec := range pickupTenantRepairSpecs {
-		if err := ensurePickupTenantRepairIsSafe(ctx, tx, spec); err != nil {
+		if err := ensurePickupTenantRepairIsSafe(ctx, db, spec); err != nil {
 			return err
 		}
 
-		result, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		result, err := db.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s p
 			SET tenant_id = s.tenant_id
 			FROM users.students s
@@ -140,17 +94,13 @@ func repairPickupScheduleTenantIDs(ctx context.Context, db *bun.DB) error {
 		fmt.Printf("Migration 1.15.39: repaired %d row(s) in %s\n", rowsAffected, spec.table)
 	}
 
-	if err := restorePickupCompositeFKsAfterRepair(ctx, tx); err != nil {
-		return err
-	}
-
 	fmt.Println("Migration 1.15.39: Pickup schedule tenant ID repair complete")
-	return tx.Commit()
+	return nil
 }
 
-func ensurePickupTenantRepairIsSafe(ctx context.Context, tx bun.Tx, spec pickupTenantRepairSpec) error {
+func ensurePickupTenantRepairIsSafe(ctx context.Context, db bun.IDB, spec pickupTenantRepairSpec) error {
 	var missingCreatedBy int64
-	err := tx.QueryRowContext(ctx, fmt.Sprintf(`
+	err := db.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT COUNT(*)
 		FROM %s p
 		JOIN users.students s ON s.id = p.student_id
@@ -170,7 +120,7 @@ func ensurePickupTenantRepairIsSafe(ctx context.Context, tx bun.Tx, spec pickupT
 	}
 
 	var badCreatedBy int64
-	err = tx.QueryRowContext(ctx, fmt.Sprintf(`
+	err = db.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT COUNT(*)
 		FROM %s p
 		JOIN users.students s ON s.id = p.student_id
@@ -194,7 +144,7 @@ func ensurePickupTenantRepairIsSafe(ctx context.Context, tx bun.Tx, spec pickupT
 	}
 
 	var conflicts int64
-	if err := tx.QueryRowContext(ctx, spec.uniqueConflict).Scan(&conflicts); err != nil {
+	if err := db.QueryRowContext(ctx, spec.uniqueConflict).Scan(&conflicts); err != nil {
 		return fmt.Errorf("check unique conflicts on %s: %w", spec.table, err)
 	}
 	if conflicts > 0 {
@@ -207,35 +157,4 @@ func ensurePickupTenantRepairIsSafe(ctx context.Context, tx bun.Tx, spec pickupT
 	}
 
 	return nil
-}
-
-func dropPickupCompositeFKsForRepair(ctx context.Context, tx bun.Tx) error {
-	for _, fk := range pickupCompositeFKStatements {
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s", pickupFKTable(fk.name), fk.name)); err != nil {
-			return fmt.Errorf("drop pickup composite FK %s: %w", fk.name, err)
-		}
-	}
-	return nil
-}
-
-func restorePickupCompositeFKsAfterRepair(ctx context.Context, tx bun.Tx) error {
-	for _, fk := range pickupCompositeFKStatements {
-		if _, err := tx.ExecContext(ctx, fk.add); err != nil {
-			return fmt.Errorf("restore pickup composite FK %s: %w", fk.name, err)
-		}
-	}
-	return nil
-}
-
-func pickupFKTable(fkName string) string {
-	switch fkName {
-	case "fk_pickup_schedules_created_by_tenant", "fk_pickup_schedules_student_tenant":
-		return "schedule.student_pickup_schedules"
-	case "fk_pickup_exceptions_created_by_tenant", "fk_pickup_exceptions_student_tenant":
-		return "schedule.student_pickup_exceptions"
-	case "fk_pickup_notes_created_by_tenant", "fk_pickup_notes_student_tenant":
-		return "schedule.student_pickup_notes"
-	default:
-		panic(fmt.Sprintf("unknown pickup FK %s", fkName))
-	}
 }

--- a/backend/database/migrations/001015039_repair_pickup_schedule_tenant_ids_test.go
+++ b/backend/database/migrations/001015039_repair_pickup_schedule_tenant_ids_test.go
@@ -2,7 +2,6 @@ package migrations
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -15,21 +14,18 @@ import (
 func TestRepairPickupScheduleTenantIDs(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	ctx := context.Background()
-	const tenantID int64 = 2
+	tenantID := testpkg.UniqueTestTenantID(t)
 
 	testpkg.EnsureTestTenant(t, db, tenantID)
 	defer testpkg.CleanupTenantTestData(t, db, tenantID)
-
-	dropPickupCompositeFKs(t, db)
-	t.Cleanup(func() { restorePickupCompositeFKs(t, db) })
 
 	staffID := createTenantStaff(t, db, tenantID)
 	studentID := createTenantStudent(t, db, tenantID)
 	defer cleanupPickupTenantRepairRows(t, db, staffID, studentID)
 
-	scheduleID := insertPickupScheduleWithTenant(t, db, 1, studentID, staffID)
-	exceptionID := insertPickupExceptionWithTenant(t, db, 1, studentID, staffID)
-	noteID := insertPickupNoteWithTenant(t, db, 1, studentID, staffID)
+	scheduleID := insertHistoricalPickupScheduleWithTenant(t, db, 1, studentID, staffID)
+	exceptionID := insertHistoricalPickupExceptionWithTenant(t, db, 1, studentID, staffID)
+	noteID := insertHistoricalPickupNoteWithTenant(t, db, 1, studentID, staffID)
 
 	require.NoError(t, repairPickupScheduleTenantIDs(ctx, db))
 	require.NoError(t, repairPickupScheduleTenantIDs(ctx, db), "repair migration must be idempotent")
@@ -42,20 +38,17 @@ func TestRepairPickupScheduleTenantIDs(t *testing.T) {
 func TestRepairPickupScheduleTenantIDsRejectsCrossTenantCreator(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	ctx := context.Background()
-	const tenantID int64 = 2
+	tenantID := testpkg.UniqueTestTenantID(t)
 
 	testpkg.EnsureTestTenant(t, db, tenantID)
 	defer testpkg.CleanupTenantTestData(t, db, tenantID)
-
-	dropPickupCompositeFKs(t, db)
-	t.Cleanup(func() { restorePickupCompositeFKs(t, db) })
 
 	studentID := createTenantStudent(t, db, tenantID)
 	staff := testpkg.CreateTestStaff(t, db, "PickupRepair", "WrongTenant")
 	defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
 	defer cleanupPickupTenantRepairRows(t, db, 0, studentID)
 
-	insertPickupScheduleWithTenant(t, db, 1, studentID, staff.ID)
+	insertHistoricalPickupScheduleWithTenant(t, db, 1, studentID, staff.ID)
 
 	err := repairPickupScheduleTenantIDs(ctx, db)
 	require.Error(t, err)
@@ -65,62 +58,36 @@ func TestRepairPickupScheduleTenantIDsRejectsCrossTenantCreator(t *testing.T) {
 func TestRepairPickupScheduleTenantIDsRejectsUniqueConflicts(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	ctx := context.Background()
-	const tenantID int64 = 2
+	tenantID := testpkg.UniqueTestTenantID(t)
 
 	testpkg.EnsureTestTenant(t, db, tenantID)
 	defer testpkg.CleanupTenantTestData(t, db, tenantID)
-
-	dropPickupCompositeFKs(t, db)
-	t.Cleanup(func() { restorePickupCompositeFKs(t, db) })
 
 	staffID := createTenantStaff(t, db, tenantID)
 	studentID := createTenantStudent(t, db, tenantID)
 	defer cleanupPickupTenantRepairRows(t, db, staffID, studentID)
 
 	insertPickupScheduleWithTenant(t, db, tenantID, studentID, staffID)
-	insertPickupScheduleWithTenant(t, db, 1, studentID, staffID)
+	insertHistoricalPickupScheduleWithTenant(t, db, 1, studentID, staffID)
 
 	err := repairPickupScheduleTenantIDs(ctx, db)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "would conflict")
 }
 
-func dropPickupCompositeFKs(t *testing.T, db *bun.DB) {
+func withReplicaTriggers(t *testing.T, db *bun.DB, fn func(tx bun.Tx)) {
 	t.Helper()
 
-	statements := []string{
-		`ALTER TABLE schedule.student_pickup_schedules DROP CONSTRAINT IF EXISTS fk_pickup_schedules_created_by_tenant`,
-		`ALTER TABLE schedule.student_pickup_schedules DROP CONSTRAINT IF EXISTS fk_pickup_schedules_student_tenant`,
-		`ALTER TABLE schedule.student_pickup_exceptions DROP CONSTRAINT IF EXISTS fk_pickup_exceptions_created_by_tenant`,
-		`ALTER TABLE schedule.student_pickup_exceptions DROP CONSTRAINT IF EXISTS fk_pickup_exceptions_student_tenant`,
-		`ALTER TABLE schedule.student_pickup_notes DROP CONSTRAINT IF EXISTS fk_pickup_notes_created_by_tenant`,
-		`ALTER TABLE schedule.student_pickup_notes DROP CONSTRAINT IF EXISTS fk_pickup_notes_student_tenant`,
-	}
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
 
-	for _, stmt := range statements {
-		_, err := db.ExecContext(context.Background(), stmt)
-		require.NoError(t, err)
-	}
-}
+	_, err = tx.ExecContext(ctx, `SET LOCAL session_replication_role = replica`)
+	require.NoError(t, err)
 
-func restorePickupCompositeFKs(t *testing.T, db *bun.DB) {
-	t.Helper()
-
-	statements := []string{
-		`ALTER TABLE schedule.student_pickup_schedules ADD CONSTRAINT fk_pickup_schedules_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
-		`ALTER TABLE schedule.student_pickup_schedules ADD CONSTRAINT fk_pickup_schedules_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
-		`ALTER TABLE schedule.student_pickup_exceptions ADD CONSTRAINT fk_pickup_exceptions_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
-		`ALTER TABLE schedule.student_pickup_exceptions ADD CONSTRAINT fk_pickup_exceptions_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
-		`ALTER TABLE schedule.student_pickup_notes ADD CONSTRAINT fk_pickup_notes_created_by_tenant FOREIGN KEY (tenant_id, created_by) REFERENCES users.staff(tenant_id, id)`,
-		`ALTER TABLE schedule.student_pickup_notes ADD CONSTRAINT fk_pickup_notes_student_tenant FOREIGN KEY (tenant_id, student_id) REFERENCES users.students(tenant_id, id) ON DELETE CASCADE`,
-	}
-
-	for _, stmt := range statements {
-		_, err := db.ExecContext(context.Background(), stmt)
-		if err != nil && !strings.Contains(err.Error(), "already exists") {
-			require.NoError(t, err)
-		}
-	}
+	fn(tx)
+	require.NoError(t, tx.Commit())
 }
 
 func createTenantStaff(t *testing.T, db *bun.DB, tenantID int64) int64 {
@@ -168,32 +135,53 @@ func insertPickupScheduleWithTenant(t *testing.T, db *bun.DB, tenantID, studentI
 	return id
 }
 
-func insertPickupExceptionWithTenant(t *testing.T, db *bun.DB, tenantID, studentID, staffID int64) int64 {
+func insertHistoricalPickupScheduleWithTenant(t *testing.T, db *bun.DB, tenantID, studentID, staffID int64) int64 {
 	t.Helper()
 
 	var id int64
-	err := db.QueryRowContext(context.Background(), `
-		INSERT INTO schedule.student_pickup_exceptions
-			(tenant_id, student_id, exception_date, pickup_time, reason, created_by, created_at, updated_at)
-		VALUES (?, ?, CURRENT_DATE, ?, 'Repair test', ?, NOW(), NOW())
-		RETURNING id
-	`, tenantID, studentID, time.Date(2000, 1, 1, 14, 0, 0, 0, time.UTC), staffID).Scan(&id)
-	require.NoError(t, err)
+	withReplicaTriggers(t, db, func(tx bun.Tx) {
+		err := tx.QueryRowContext(context.Background(), `
+			INSERT INTO schedule.student_pickup_schedules
+				(tenant_id, student_id, weekday, pickup_time, created_by, created_at, updated_at)
+			VALUES (?, ?, 1, ?, ?, NOW(), NOW())
+			RETURNING id
+		`, tenantID, studentID, time.Date(2000, 1, 1, 15, 30, 0, 0, time.UTC), staffID).Scan(&id)
+		require.NoError(t, err)
+	})
 
 	return id
 }
 
-func insertPickupNoteWithTenant(t *testing.T, db *bun.DB, tenantID, studentID, staffID int64) int64 {
+func insertHistoricalPickupExceptionWithTenant(t *testing.T, db *bun.DB, tenantID, studentID, staffID int64) int64 {
 	t.Helper()
 
 	var id int64
-	err := db.QueryRowContext(context.Background(), `
-		INSERT INTO schedule.student_pickup_notes
-			(tenant_id, student_id, note_date, content, created_by, created_at, updated_at)
-		VALUES (?, ?, CURRENT_DATE, 'Repair note', ?, NOW(), NOW())
-		RETURNING id
-	`, tenantID, studentID, staffID).Scan(&id)
-	require.NoError(t, err)
+	withReplicaTriggers(t, db, func(tx bun.Tx) {
+		err := tx.QueryRowContext(context.Background(), `
+			INSERT INTO schedule.student_pickup_exceptions
+				(tenant_id, student_id, exception_date, pickup_time, reason, created_by, created_at, updated_at)
+			VALUES (?, ?, CURRENT_DATE, ?, 'Repair test', ?, NOW(), NOW())
+			RETURNING id
+		`, tenantID, studentID, time.Date(2000, 1, 1, 14, 0, 0, 0, time.UTC), staffID).Scan(&id)
+		require.NoError(t, err)
+	})
+
+	return id
+}
+
+func insertHistoricalPickupNoteWithTenant(t *testing.T, db *bun.DB, tenantID, studentID, staffID int64) int64 {
+	t.Helper()
+
+	var id int64
+	withReplicaTriggers(t, db, func(tx bun.Tx) {
+		err := tx.QueryRowContext(context.Background(), `
+			INSERT INTO schedule.student_pickup_notes
+				(tenant_id, student_id, note_date, content, created_by, created_at, updated_at)
+			VALUES (?, ?, CURRENT_DATE, 'Repair note', ?, NOW(), NOW())
+			RETURNING id
+		`, tenantID, studentID, staffID).Scan(&id)
+		require.NoError(t, err)
+	})
 
 	return id
 }

--- a/backend/services/users/caregiver_capability_test.go
+++ b/backend/services/users/caregiver_capability_test.go
@@ -40,6 +40,50 @@ func setupServiceFactory(t *testing.T, db *bun.DB) *services.Factory {
 	return factory
 }
 
+func createTestTeacherWithAccountForTenant(
+	t *testing.T,
+	db *bun.DB,
+	tenantID int64,
+	firstName string,
+	lastName string,
+) (*userModels.Teacher, *authModels.Account) {
+	t.Helper()
+
+	testpkg.EnsureTestTenant(t, db, tenantID)
+
+	account := testpkg.CreateTestAccount(t, db, firstName+"."+lastName)
+	person := testpkg.CreateTestPersonForTenant(t, db, tenantID, firstName, lastName)
+	person.AccountID = &account.ID
+	_, err := db.ExecContext(
+		context.Background(),
+		`UPDATE users.persons SET account_id = ? WHERE tenant_id = ? AND id = ?`,
+		account.ID,
+		tenantID,
+		person.ID,
+	)
+	require.NoError(t, err)
+
+	staff := &userModels.Staff{PersonID: person.ID}
+	staff.SetTenantID(tenantID)
+	err = db.NewInsert().
+		Model(staff).
+		ModelTableExpr(`users.staff`).
+		Scan(context.Background())
+	require.NoError(t, err)
+	staff.Person = person
+
+	teacher := &userModels.Teacher{StaffID: staff.ID}
+	teacher.SetTenantID(tenantID)
+	err = db.NewInsert().
+		Model(teacher).
+		ModelTableExpr(`users.teachers`).
+		Scan(context.Background())
+	require.NoError(t, err)
+	teacher.Staff = staff
+
+	return teacher, account
+}
+
 func lookupSystemRoleID(t *testing.T, db *bun.DB, name string) int64 {
 	t.Helper()
 
@@ -819,91 +863,98 @@ func TestCaregiverCapability_DisableBlocksLegacyTeacherOnlyAccount(t *testing.T)
 
 func TestCaregiverDirectory_ListAndFindActiveCaregiversIncludingLegacyTeacherRole(t *testing.T) {
 	db, factory := setupCaregiverFactory(t)
-	ctx := testpkg.TenantContext(1)
+	tenantID := testpkg.UniqueTestTenantID(t)
+	ctx := testpkg.TenantContext(tenantID)
 
-	activeTeacher, activeAccount := testpkg.CreateTestTeacherWithAccount(t, db, "Active", "Caregiver")
+	activeTeacher, activeAccount := createTestTeacherWithAccountForTenant(t, db, tenantID, "Active", "Caregiver")
 	t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, db, activeAccount.ID) })
 	t.Cleanup(func() {
-		testpkg.CleanupActivityFixtures(
+		testpkg.CleanupActivityFixturesForTenant(
 			t,
 			db,
+			tenantID,
 			activeTeacher.ID,
 			activeTeacher.Staff.ID,
 			activeTeacher.Staff.Person.ID,
 		)
 	})
-	testpkg.EnsureAccountTenant(t, db, activeAccount.ID, 1)
-	assignSystemRoleToAccount(t, db, activeAccount.ID, 1, "user")
+	testpkg.EnsureAccountTenant(t, db, activeAccount.ID, tenantID)
+	assignSystemRoleToAccount(t, db, activeAccount.ID, tenantID, "user")
 
-	legacyTeacherRoleTeacher, legacyTeacherRoleAccount := testpkg.CreateTestTeacherWithAccount(t, db, "Legacy", "Teacher")
+	legacyTeacherRoleTeacher, legacyTeacherRoleAccount := createTestTeacherWithAccountForTenant(t, db, tenantID, "Legacy", "Teacher")
 	t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, db, legacyTeacherRoleAccount.ID) })
 	t.Cleanup(func() {
-		testpkg.CleanupActivityFixtures(
+		testpkg.CleanupActivityFixturesForTenant(
 			t,
 			db,
+			tenantID,
 			legacyTeacherRoleTeacher.ID,
 			legacyTeacherRoleTeacher.Staff.ID,
 			legacyTeacherRoleTeacher.Staff.Person.ID,
 		)
 	})
-	testpkg.EnsureAccountTenant(t, db, legacyTeacherRoleAccount.ID, 1)
+	testpkg.EnsureAccountTenant(t, db, legacyTeacherRoleAccount.ID, tenantID)
 	ensureSystemRoleExists(t, db, "teacher")
-	assignSystemRoleToAccount(t, db, legacyTeacherRoleAccount.ID, 1, "teacher")
+	assignSystemRoleToAccount(t, db, legacyTeacherRoleAccount.ID, tenantID, "teacher")
 
-	adminOnlyTeacher, adminOnlyAccount := testpkg.CreateTestTeacherWithAccount(t, db, "Admin", "Only")
+	adminOnlyTeacher, adminOnlyAccount := createTestTeacherWithAccountForTenant(t, db, tenantID, "Admin", "Only")
 	t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, db, adminOnlyAccount.ID) })
 	t.Cleanup(func() {
-		testpkg.CleanupActivityFixtures(
+		testpkg.CleanupActivityFixturesForTenant(
 			t,
 			db,
+			tenantID,
 			adminOnlyTeacher.ID,
 			adminOnlyTeacher.Staff.ID,
 			adminOnlyTeacher.Staff.Person.ID,
 		)
 	})
-	testpkg.EnsureAccountTenant(t, db, adminOnlyAccount.ID, 1)
-	assignSystemRoleToAccount(t, db, adminOnlyAccount.ID, 1, "admin")
+	testpkg.EnsureAccountTenant(t, db, adminOnlyAccount.ID, tenantID)
+	assignSystemRoleToAccount(t, db, adminOnlyAccount.ID, tenantID, "admin")
 
-	inactiveTeacher, inactiveAccount := testpkg.CreateTestTeacherWithAccount(t, db, "Inactive", "Caregiver")
+	inactiveTeacher, inactiveAccount := createTestTeacherWithAccountForTenant(t, db, tenantID, "Inactive", "Caregiver")
 	t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, db, inactiveAccount.ID) })
 	t.Cleanup(func() {
-		testpkg.CleanupActivityFixtures(
+		testpkg.CleanupActivityFixturesForTenant(
 			t,
 			db,
+			tenantID,
 			inactiveTeacher.ID,
 			inactiveTeacher.Staff.ID,
 			inactiveTeacher.Staff.Person.ID,
 		)
 	})
-	testpkg.EnsureAccountTenant(t, db, inactiveAccount.ID, 1)
-	assignSystemRoleToAccount(t, db, inactiveAccount.ID, 1, "user")
+	testpkg.EnsureAccountTenant(t, db, inactiveAccount.ID, tenantID)
+	assignSystemRoleToAccount(t, db, inactiveAccount.ID, tenantID, "user")
 
 	_, err := db.ExecContext(context.Background(), `UPDATE auth.accounts SET active = false WHERE id = ?`, inactiveAccount.ID)
 	require.NoError(t, err)
 
-	inactiveMembershipTeacher, inactiveMembershipAccount := testpkg.CreateTestTeacherWithAccount(
+	inactiveMembershipTeacher, inactiveMembershipAccount := createTestTeacherWithAccountForTenant(
 		t,
 		db,
+		tenantID,
 		"Former",
 		"Member",
 	)
 	t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, db, inactiveMembershipAccount.ID) })
 	t.Cleanup(func() {
-		testpkg.CleanupActivityFixtures(
+		testpkg.CleanupActivityFixturesForTenant(
 			t,
 			db,
+			tenantID,
 			inactiveMembershipTeacher.ID,
 			inactiveMembershipTeacher.Staff.ID,
 			inactiveMembershipTeacher.Staff.Person.ID,
 		)
 	})
-	testpkg.EnsureAccountTenant(t, db, inactiveMembershipAccount.ID, 1)
-	assignSystemRoleToAccount(t, db, inactiveMembershipAccount.ID, 1, "user")
+	testpkg.EnsureAccountTenant(t, db, inactiveMembershipAccount.ID, tenantID)
+	assignSystemRoleToAccount(t, db, inactiveMembershipAccount.ID, tenantID, "user")
 	setAccountTenantStatus(
 		t,
 		db,
 		inactiveMembershipAccount.ID,
-		1,
+		tenantID,
 		authModels.AccountTenantStatusInactive,
 	)
 
@@ -942,22 +993,23 @@ func TestCaregiverDirectory_ListAndFindActiveCaregiversIncludingLegacyTeacherRol
 
 func TestCaregiverDirectory_ExcludesTenantScopedUserRole(t *testing.T) {
 	db, factory := setupCaregiverFactory(t)
-	ctx := testpkg.TenantContext(1)
+	tenantID := testpkg.UniqueTestTenantID(t)
+	ctx := testpkg.TenantContext(tenantID)
 
-	teacher, account := testpkg.CreateTestTeacherWithAccount(t, db, "Tenant", "UserRole")
+	teacher, account := createTestTeacherWithAccountForTenant(t, db, tenantID, "Tenant", "UserRole")
 	t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, db, account.ID) })
 	t.Cleanup(func() {
-		testpkg.CleanupActivityFixtures(
+		testpkg.CleanupActivityFixturesForTenant(
 			t,
 			db,
+			tenantID,
 			teacher.ID,
 			teacher.Staff.ID,
 			teacher.Staff.Person.ID,
 		)
 	})
-	testpkg.EnsureAccountTenant(t, db, account.ID, 1)
+	testpkg.EnsureAccountTenant(t, db, account.ID, tenantID)
 
-	tenantID := teacher.GetTenantID()
 	customUserRole := &authModels.Role{
 		Name:        "user",
 		Description: "Tenant-scoped custom user role",


### PR DESCRIPTION
## Summary
- isolate presence-mode operator tests and caregiver directory tests with unique tenants
- remove lock-heavy FK drop/restore from pickup tenant repair migration
- update migration tests to create historical bad rows without global schema mutation

## Validation
- go test ./api/operator -run 'TestOperatorSetSchoolSettingValue_PresenceMode' -count=10\n- go test ./services/users -run 'TestCaregiverDirectory' -count=10\n- go test ./database/migrations -run 'TestRepairPickupScheduleTenantIDs' -count=10\n- go test ./test/ -run TestHermeticTestPatterns -v\n- go test ./...\n- pre-push: git-secrets, go-vet, golangci-lint, go-deadcode\n