### PR TITLE
Add excused status KPI to dashboard

### DIFF
--- a/backend/api/active/analytics_handlers.go
+++ b/backend/api/active/analytics_handlers.go
@@ -25,6 +25,7 @@ func (rs *Resource) getDashboardAnalytics(w http.ResponseWriter, r *http.Request
 		StudentsOnPlayground: analytics.StudentsOnPlayground,
 		StudentsInRooms:      analytics.StudentsInRooms,
 		StudentsSick:         analytics.StudentsSick,
+		StudentsExcused:      analytics.StudentsExcused,
 		ActiveActivities:     analytics.ActiveActivities,
 		FreeRooms:            analytics.FreeRooms,
 		TotalRooms:           analytics.TotalRooms,

--- a/backend/api/active/types.go
+++ b/backend/api/active/types.go
@@ -163,6 +163,7 @@ type DashboardAnalyticsResponse struct {
 	StudentsOnPlayground int `json:"students_on_playground"`
 	StudentsInRooms      int `json:"students_in_rooms"` // Students in indoor rooms (excluding playground)
 	StudentsSick         int `json:"students_sick"`     // Students currently flagged as sick
+	StudentsExcused      int `json:"students_excused"`  // Students currently flagged as excused
 
 	// Activities & Rooms
 	ActiveActivities    int     `json:"active_activities"`

--- a/backend/services/active/active_group_service_test.go
+++ b/backend/services/active/active_group_service_test.go
@@ -696,6 +696,30 @@ func TestActiveService_GetDashboardAnalytics(t *testing.T) {
 		assert.GreaterOrEqual(t, result.ActiveActivities, 0)
 		assert.NotZero(t, result.LastUpdated)
 	})
+
+	t.Run("counts excused students", func(t *testing.T) {
+		// ARRANGE
+		before, err := service.GetDashboardAnalytics(ctx)
+		require.NoError(t, err)
+
+		student := testpkg.CreateTestStudent(t, db, "Excused", "Dashboard", "ED1")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		excused := true
+		_, err = db.NewUpdate().
+			Model(student).
+			Set("excused = ?", excused).
+			Where("id = ?", student.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		// ACT
+		after, err := service.GetDashboardAnalytics(ctx)
+
+		// ASSERT
+		require.NoError(t, err)
+		assert.Equal(t, before.StudentsExcused+1, after.StudentsExcused)
+	})
 }
 
 // =============================================================================

--- a/backend/services/active/analytics_service.go
+++ b/backend/services/active/analytics_service.go
@@ -37,6 +37,12 @@ func (s *service) GetDashboardAnalytics(ctx context.Context) (*DashboardAnalytic
 		analytics.StudentsSick = sickCount
 	}
 
+	excusedOpts := modelBase.NewQueryOptions()
+	excusedOpts.Filter.Equal("excused", true)
+	if excusedCount, err := s.studentRepo.CountWithOptions(ctx, excusedOpts); err == nil {
+		analytics.StudentsExcused = excusedCount
+	}
+
 	// Phase 3: Build room lookup maps
 	roomData := s.buildRoomLookupMaps(baseData.allRooms)
 

--- a/backend/services/active/interface.go
+++ b/backend/services/active/interface.go
@@ -168,6 +168,7 @@ type DashboardAnalytics struct {
 	StudentsOnPlayground int
 	StudentsInRooms      int // Students in indoor rooms (excluding playground)
 	StudentsSick         int // Students currently flagged as sick
+	StudentsExcused      int // Students currently flagged as excused
 
 	// Activities & Rooms
 	ActiveActivities    int

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.test.tsx
@@ -69,6 +69,8 @@ const mockDashboardData = {
   studentsInRooms: 120,
   studentsInTransit: 20,
   studentsOnPlayground: 10,
+  studentsSick: 4,
+  studentsExcused: 3,
   activeOGSGroups: 8,
   activeActivities: 5,
   freeRooms: 12,
@@ -191,6 +193,8 @@ describe("DashboardPage", () => {
       expect(screen.getByText("150")).toBeInTheDocument(); // studentsPresent
       expect(screen.getByText("120")).toBeInTheDocument(); // studentsInRooms
       expect(screen.getByText("20")).toBeInTheDocument(); // studentsInTransit
+      expect(screen.getByText("4")).toBeInTheDocument(); // studentsSick
+      expect(screen.getByText("3")).toBeInTheDocument(); // studentsExcused
       // 10 appears multiple times (studentsOnPlayground and supervisorsToday)
       expect(screen.getAllByText("10")).toHaveLength(2);
     });
@@ -204,6 +208,8 @@ describe("DashboardPage", () => {
       expect(screen.getByText("In Räumen")).toBeInTheDocument();
       expect(screen.getByText("Unterwegs")).toBeInTheDocument();
       expect(screen.getByText("Schulhof")).toBeInTheDocument();
+      expect(screen.getByText("Krank")).toBeInTheDocument();
+      expect(screen.getByText("Entschuldigt")).toBeInTheDocument();
       // "Aktive Gruppen" appears both as stat card title and info card title
       expect(screen.getAllByText("Aktive Gruppen")).toHaveLength(2);
       expect(screen.getByText("Aktive Aktivitäten")).toBeInTheDocument();

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
@@ -67,6 +67,10 @@ const COLOR_THEMES: Record<string, ColorTheme> = {
     overlay: "from-amber-50/80 to-yellow-100/80",
     ring: "ring-amber-200/60",
   },
+  "[#7C3AED]": {
+    overlay: "from-purple-50/80 to-violet-100/80",
+    ring: "ring-purple-200/60",
+  },
   "orange-500": {
     overlay: "from-orange-50/80 to-orange-100/80",
     ring: "ring-orange-200/60",
@@ -319,8 +323,8 @@ function DashboardContent() {
         </div>
       )}
 
-      {/* Main Stats Grid (3x3) */}
-      <div className="mb-6 grid grid-cols-2 gap-3 md:mb-8 md:grid-cols-3 md:gap-4">
+      {/* Main Stats Grid */}
+      <div className="mb-6 grid grid-cols-2 gap-3 md:mb-8 md:grid-cols-3 md:gap-4 xl:grid-cols-5">
         <StatCard
           title="Kinder anwesend"
           value={dashboardData?.studentsPresent ?? 0}
@@ -360,6 +364,14 @@ function DashboardContent() {
           color="from-[#EAB308] to-[#CA9908]"
           loading={isLoading}
           href="/students/search?status=krank"
+        />
+        <StatCard
+          title="Entschuldigt"
+          value={dashboardData?.studentsExcused ?? 0}
+          icon="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+          color="from-[#7C3AED] to-[#5B21B6]"
+          loading={isLoading}
+          href="/students/search?status=entschuldigt"
         />
         <StatCard
           title="Aktive Gruppen"

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -446,6 +446,17 @@ describe("StudentSearchPage", () => {
       });
     });
 
+    it("reads 'entschuldigt' status from URL params", async () => {
+      mockSearchParams.set("status", "entschuldigt");
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        const attendanceFilter = screen.getByTestId("filter-attendance");
+        expect(attendanceFilter).toHaveValue("entschuldigt");
+      });
+    });
+
     it("falls back to 'all' for invalid status param", async () => {
       mockSearchParams.set("status", "invalid_status");
 
@@ -701,6 +712,29 @@ describe("StudentSearchPage", () => {
       });
     });
 
+    it("does not show excused-at-home students when 'abwesend' is selected", async () => {
+      const swrModule = await import("~/lib/swr");
+      mockUseSWRAuthWithStudents(swrModule, {
+        data: {
+          students: [
+            { ...mockStudents[0]!, current_location: "Zuhause", excused: true },
+            { ...mockStudents[1]!, current_location: "Zuhause" },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      mockSearchParams.set("status", "abwesend");
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Anna")).toBeInTheDocument();
+        expect(screen.queryByText("Max")).not.toBeInTheDocument();
+      });
+    });
+
     it("filters to show only transit students when 'unterwegs' is selected", async () => {
       mockSearchParams.set("status", "unterwegs");
 
@@ -758,6 +792,38 @@ describe("StudentSearchPage", () => {
         expect(
           screen.getByTestId("active-filter-attendance"),
         ).toHaveTextContent("Krank");
+      });
+    });
+
+    it("filters to show only excused students when 'entschuldigt' is selected", async () => {
+      const swrModule = await import("~/lib/swr");
+      mockUseSWRAuthWithStudents(swrModule, {
+        data: {
+          students: [
+            { ...mockStudents[0]!, excused: true },
+            { ...mockStudents[1]!, excused: false },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Max")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-attendance"), {
+        target: { value: "entschuldigt" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Max")).toBeInTheDocument();
+        expect(screen.queryByText("Anna")).not.toBeInTheDocument();
+        expect(
+          screen.getByTestId("active-filter-attendance"),
+        ).toHaveTextContent("Entschuldigt");
       });
     });
   });
@@ -1699,6 +1765,12 @@ describe("StudentSearchPage", () => {
         { ...mockStudents[2]!, first_name: "TransitChild" },
         { ...mockStudents[0]!, first_name: "PresentChild" },
         { ...mockStudents[0]!, id: "9", first_name: "SickChild", sick: true },
+        {
+          ...mockStudents[1]!,
+          id: "10",
+          first_name: "ExcusedChild",
+          excused: true,
+        },
       ];
       const swrModule = await import("~/lib/swr");
       mockUseSWRAuthWithStudents(swrModule, {
@@ -1725,7 +1797,14 @@ describe("StudentSearchPage", () => {
 
       expect(
         screen.getAllByRole("heading", { level: 2 }).map((h) => h.textContent),
-      ).toEqual(["Anwesend", "Unterwegs", "Schulhof", "Krank", "Abwesend"]);
+      ).toEqual([
+        "Anwesend",
+        "Unterwegs",
+        "Schulhof",
+        "Krank",
+        "Entschuldigt",
+        "Abwesend",
+      ]);
     });
 
     it("groups redacted and missing room/time values under explicit fallback labels", async () => {

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -74,7 +74,8 @@ type StatusFilter =
   | "abwesend"
   | "unterwegs"
   | "schulhof"
-  | "krank";
+  | "krank"
+  | "entschuldigt";
 type SortMode = "name" | "arrival" | "pickup";
 type GroupMode = "none" | "status" | "room" | "arrival" | "pickup";
 
@@ -83,6 +84,7 @@ const STATUS_FILTER_OPTIONS: Array<{ value: StatusFilter; label: string }> = [
   { value: "anwesend", label: "Anwesend" },
   { value: "abwesend", label: "Abwesend" },
   { value: "krank", label: "Krank" },
+  { value: "entschuldigt", label: "Entschuldigt" },
   { value: "unterwegs", label: "Unterwegs" },
   { value: "schulhof", label: "Schulhof" },
 ];
@@ -132,8 +134,20 @@ const STATUS_GROUP_ORDER = new Map([
   ["Unterwegs", 1],
   ["Schulhof", 2],
   ["Krank", 3],
-  ["Abwesend", 4],
+  ["Entschuldigt", 4],
+  ["Abwesend", 5],
 ]);
+
+const STATUS_FILTER_LABELS: Record<
+  Exclude<StatusFilter, "all" | "anwesend">,
+  string
+> = {
+  abwesend: "Abwesend",
+  unterwegs: "Unterwegs",
+  schulhof: "Schulhof",
+  krank: "Krank",
+  entschuldigt: "Entschuldigt",
+};
 
 function validQueryValue<T extends string>(
   value: string | null,
@@ -309,6 +323,7 @@ function compareByName(a: Student, b: Student) {
 
 function statusLabelForStudent(student: Student): string {
   if (student.sick) return "Krank";
+  if (student.excused) return "Entschuldigt";
   if (isSchoolyardLocation(student.current_location)) return "Schulhof";
   if (isTransitLocation(student.current_location)) return "Unterwegs";
   if (isHomeLocation(student.current_location)) return "Abwesend";
@@ -975,6 +990,7 @@ function SearchPageContent() {
           { value: "anwesend", label: "Anwesend" },
           { value: "abwesend", label: "Abwesend" },
           { value: "krank", label: "Krank" },
+          { value: "entschuldigt", label: "Entschuldigt" },
           { value: "unterwegs", label: "Unterwegs" },
           { value: "schulhof", label: "Schulhof" },
         ],
@@ -1095,6 +1111,7 @@ function SearchPageContent() {
         unterwegs: "Unterwegs",
         schulhof: "Schulhof",
         krank: "Krank",
+        entschuldigt: "Entschuldigt",
       };
       filters.push({
         id: "attendance",
@@ -1197,30 +1214,10 @@ function SearchPageContent() {
       }
 
       if (
-        attendanceFilter === "abwesend" &&
-        !isHomeLocation(student.current_location)
+        attendanceFilter !== "anwesend" &&
+        statusLabelForStudent(student) !==
+          STATUS_FILTER_LABELS[attendanceFilter]
       ) {
-        return false;
-      }
-
-      // Filter for "Unterwegs" status specifically
-      if (
-        attendanceFilter === "unterwegs" &&
-        !isTransitLocation(student.current_location)
-      ) {
-        return false;
-      }
-
-      // Filter for "Schulhof" status specifically
-      if (
-        attendanceFilter === "schulhof" &&
-        !isSchoolyardLocation(student.current_location)
-      ) {
-        return false;
-      }
-
-      // Filter for "Krank" status specifically — independent of location
-      if (attendanceFilter === "krank" && !student.sick) {
         return false;
       }
     }

--- a/frontend/src/lib/dashboard-helpers.test.ts
+++ b/frontend/src/lib/dashboard-helpers.test.ts
@@ -17,6 +17,7 @@ describe("dashboard-helpers", () => {
         students_on_playground: 30,
         students_in_rooms: 75,
         students_sick: 4,
+        students_excused: 3,
         active_activities: 8,
         free_rooms: 5,
         total_rooms: 20,
@@ -83,6 +84,8 @@ describe("dashboard-helpers", () => {
       expect(result.studentsInTransit).toBe(15);
       expect(result.studentsOnPlayground).toBe(30);
       expect(result.studentsInRooms).toBe(75);
+      expect(result.studentsSick).toBe(4);
+      expect(result.studentsExcused).toBe(3);
       expect(result.activeActivities).toBe(8);
       expect(result.freeRooms).toBe(5);
       expect(result.totalRooms).toBe(20);
@@ -130,6 +133,7 @@ describe("dashboard-helpers", () => {
         students_on_playground: 0,
         students_in_rooms: 0,
         students_sick: 0,
+        students_excused: 0,
         active_activities: 0,
         free_rooms: 0,
         total_rooms: 0,

--- a/frontend/src/lib/dashboard-helpers.ts
+++ b/frontend/src/lib/dashboard-helpers.ts
@@ -6,6 +6,7 @@ export interface DashboardAnalytics {
   studentsOnPlayground: number;
   studentsInRooms: number; // Students in indoor rooms (excluding playground)
   studentsSick: number; // Students currently flagged as sick
+  studentsExcused: number; // Students currently flagged as excused
 
   // Activities & Rooms
   activeActivities: number;
@@ -64,6 +65,7 @@ export interface DashboardAnalyticsResponse {
   students_on_playground: number;
   students_in_rooms: number; // Students in indoor rooms (excluding playground)
   students_sick: number;
+  students_excused: number;
   active_activities: number;
   free_rooms: number;
   total_rooms: number;
@@ -107,6 +109,7 @@ export function mapDashboardAnalyticsResponse(
     studentsOnPlayground: data.students_on_playground,
     studentsInRooms: data.students_in_rooms,
     studentsSick: data.students_sick ?? 0,
+    studentsExcused: data.students_excused ?? 0,
     activeActivities: data.active_activities,
     freeRooms: data.free_rooms,
     totalRooms: data.total_rooms,


### PR DESCRIPTION
## Summary
- add `students_excused` to dashboard analytics and map it through the frontend dashboard API model
- show an `Entschuldigt` KPI tile on `/dashboard` linking to `/students/search?status=entschuldigt`
- add the `Entschuldigt` student-search status filter and align status filtering with the displayed status precedence

## Why
Maren C. requested that the Home-Seite (`/dashboard`) show the `Entschuldigt` status the same way the existing `Krank` status is shown.

## Notes
The search filter now uses the same status precedence as the displayed row/group label, so excused-at-home students appear under `Entschuldigt`, not `Abwesend`.

## Validation
- `cd backend && go test ./services/active ./api/active`
- `cd backend && go test ./test/ -run TestHermeticTestPatterns -v`
- `cd frontend && pnpm exec vitest run src/lib/dashboard-helpers.test.ts 'src/app/[tenant]/(protected)/dashboard/page.test.tsx' 'src/app/[tenant]/(protected)/students/search/page.test.tsx'`
- `cd frontend && pnpm exec vitest run 'src/app/[tenant]/(protected)/students/search/page.test.tsx'`
- `cd frontend && pnpm run check`
- pre-push hook: `git-secrets`, `go-vet`, `frontend-knip`, `go-deadcode`, `frontend-check`, `golangci-lint`
