### PR TITLE
fix: redirect binary caregivers to student search

### DIFF
--- a/frontend/src/components/auth/smart-redirect.test.tsx
+++ b/frontend/src/components/auth/smart-redirect.test.tsx
@@ -41,13 +41,20 @@ vi.mock("~/lib/redirect-utils", () => ({
   })),
 }));
 
+vi.mock("~/components/tenant/tenant-provider", () => ({
+  usePresenceMode: vi.fn(() => "detailed"),
+  useTenantSlugSafe: vi.fn(() => "test-tenant"),
+}));
+
 import { useSession } from "next-auth/react";
 import { useSupervision } from "~/lib/supervision-context";
 import { useSmartRedirectPath } from "~/lib/redirect-utils";
+import { usePresenceMode } from "~/components/tenant/tenant-provider";
 
 describe("SmartRedirect", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(usePresenceMode).mockReturnValue("detailed");
   });
 
   it("renders nothing (returns null)", () => {
@@ -158,6 +165,19 @@ describe("SmartRedirect", () => {
         hasGroups: true,
         isSupervising: true,
       }),
+      "detailed",
+    );
+  });
+
+  it("passes binary presence mode to useSmartRedirectPath", () => {
+    vi.mocked(usePresenceMode).mockReturnValue("binary");
+
+    render(<SmartRedirect />);
+
+    expect(useSmartRedirectPath).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "binary",
     );
   });
 });

--- a/frontend/src/components/auth/smart-redirect.tsx
+++ b/frontend/src/components/auth/smart-redirect.tsx
@@ -5,6 +5,7 @@ import { useSession } from "next-auth/react";
 import { useTenantRouter } from "~/lib/tenant-router";
 import { useSupervision } from "~/lib/supervision-context";
 import { useSmartRedirectPath } from "~/lib/redirect-utils";
+import { usePresenceMode } from "~/components/tenant/tenant-provider";
 
 interface SmartRedirectProps {
   readonly onRedirect?: (path: string) => void;
@@ -17,15 +18,20 @@ interface SmartRedirectProps {
 export function SmartRedirect({ onRedirect }: SmartRedirectProps) {
   const router = useTenantRouter();
   const { data: session, status } = useSession();
+  const presenceMode = usePresenceMode();
   const { hasGroups, isLoadingGroups, isSupervising, isLoadingSupervision } =
     useSupervision();
 
-  const { redirectPath, isReady } = useSmartRedirectPath(session, {
-    hasGroups,
-    isLoadingGroups,
-    isSupervising,
-    isLoadingSupervision,
-  });
+  const { redirectPath, isReady } = useSmartRedirectPath(
+    session,
+    {
+      hasGroups,
+      isLoadingGroups,
+      isSupervising,
+      isLoadingSupervision,
+    },
+    presenceMode,
+  );
 
   useEffect(() => {
     // Only redirect if user is authenticated and supervision data is ready

--- a/frontend/src/lib/redirect-utils.test.ts
+++ b/frontend/src/lib/redirect-utils.test.ts
@@ -96,6 +96,32 @@ describe("redirect-utils", () => {
       expect(result).toBe("/active-supervisions");
     });
 
+    it("should return /students/search for binary-mode caregivers", () => {
+      const session = createSession(["user"]);
+      const supervisionState: SupervisionState = {
+        hasGroups: false,
+        isLoadingGroups: false,
+        isSupervising: true,
+        isLoadingSupervision: false,
+      };
+
+      const result = getSmartRedirectPath(session, supervisionState, "binary");
+      expect(result).toBe("/students/search");
+    });
+
+    it("should return /students/search for binary-mode caregivers with groups", () => {
+      const session = createSession(["user"]);
+      const supervisionState: SupervisionState = {
+        hasGroups: true,
+        isLoadingGroups: false,
+        isSupervising: false,
+        isLoadingSupervision: false,
+      };
+
+      const result = getSmartRedirectPath(session, supervisionState, "binary");
+      expect(result).toBe("/students/search");
+    });
+
     it("should return /ogs-groups as default for regular users", () => {
       const session = createSession(["user"]);
       const supervisionState: SupervisionState = {
@@ -301,6 +327,21 @@ describe("redirect-utils", () => {
 
       expect(result.isReady).toBe(true);
       expect(result.redirectPath).toBe("/active-supervisions");
+    });
+
+    it("should return students search for binary-mode caregiver when ready", () => {
+      const session = createSession(["user"]);
+      const supervisionState: SupervisionState = {
+        hasGroups: false,
+        isLoadingGroups: false,
+        isSupervising: true,
+        isLoadingSupervision: false,
+      };
+
+      const result = useSmartRedirectPath(session, supervisionState, "binary");
+
+      expect(result.isReady).toBe(true);
+      expect(result.redirectPath).toBe("/students/search");
     });
 
     it("should return caregiver path for teacher-only accounts when ready", () => {

--- a/frontend/src/lib/redirect-utils.ts
+++ b/frontend/src/lib/redirect-utils.ts
@@ -4,6 +4,7 @@
 
 import type { Session } from "next-auth";
 import { hasRole, isCaregiver } from "~/lib/auth-utils";
+import type { PresenceMode } from "~/lib/tenant-api";
 
 export interface SupervisionState {
   hasGroups: boolean;
@@ -15,19 +16,25 @@ export interface SupervisionState {
 /**
  * Determines the best redirect path for a user based on their permissions and supervision state
  * Priority order:
- * 1. Caregivers with groups → /ogs-groups
- * 2. Caregivers actively supervising → /active-supervisions
- * 3. Other caregivers → /ogs-groups
- * 4. Admin-only users → /dashboard
+ * 1. Binary-mode caregivers: /students/search
+ * 2. Caregivers with groups: /ogs-groups
+ * 3. Caregivers actively supervising: /active-supervisions
+ * 4. Other caregivers: /ogs-groups
+ * 5. Admin-only users: /dashboard
  */
 export function getSmartRedirectPath(
   session: Session | null,
   supervisionState: SupervisionState,
+  presenceMode: PresenceMode = "detailed",
 ): string {
   const canUseCaregiverFlows = isCaregiver(session);
   const canUseAdminFlows = hasRole(session, "admin");
 
   if (canUseCaregiverFlows) {
+    if (presenceMode === "binary") {
+      return "/students/search";
+    }
+
     // If still loading supervision state, use ogs-groups as caregiver fallback
     if (
       supervisionState.isLoadingGroups ||
@@ -61,10 +68,15 @@ export function getSmartRedirectPath(
 export function useSmartRedirectPath(
   session: Session | null,
   supervisionState: SupervisionState,
+  presenceMode: PresenceMode = "detailed",
 ): { redirectPath: string; isReady: boolean } {
   const isReady =
     !supervisionState.isLoadingGroups && !supervisionState.isLoadingSupervision;
-  const redirectPath = getSmartRedirectPath(session, supervisionState);
+  const redirectPath = getSmartRedirectPath(
+    session,
+    supervisionState,
+    presenceMode,
+  );
 
   return {
     redirectPath,


### PR DESCRIPTION
## Summary
- route caregivers in binary presence mode to `/students/search` after login
- pass tenant presence mode into SmartRedirect path selection
- add regression coverage for binary-mode caregiver redirects

## Verification
- `pnpm exec vitest run src/lib/redirect-utils.test.ts src/components/auth/smart-redirect.test.tsx --config vitest.config.ts`
- `pnpm run check`
- pre-push hooks: frontend knip, frontend check, go vet, go deadcode, golangci-lint