### PR TITLE
Fix frontend rate-limit forwarding

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"log/slog"
 	"net/http"
 	"os"
@@ -11,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
+	jwxjwt "github.com/lestrrat-go/jwx/v3/jwt"
 	slogchi "github.com/samber/slog-chi"
 	"github.com/spf13/viper"
 	"github.com/uptrace/bun"
@@ -42,6 +45,7 @@ import (
 	operatorAPI "github.com/moto-nrw/project-phoenix/api/operator"
 	platformAPI "github.com/moto-nrw/project-phoenix/api/platform"
 
+	projectJWT "github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/database"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	customMiddleware "github.com/moto-nrw/project-phoenix/middleware"
@@ -246,10 +250,41 @@ func setupRateLimiting(router chi.Router, securityLogger *customMiddleware.Secur
 	generalBurst := parsePositiveInt("RATE_LIMIT_BURST", 10)
 
 	generalRateLimiter := customMiddleware.NewRateLimiter(generalLimit, generalBurst)
+	if tokenAuth, err := projectJWT.NewTokenAuth(); err == nil {
+		generalRateLimiter.SetKeyFunc(tokenAwareRateLimitKey(tokenAuth))
+	}
 	if securityLogger != nil {
 		generalRateLimiter.SetLogger(securityLogger)
 	}
 	router.Use(generalRateLimiter.Middleware())
+}
+
+func tokenAwareRateLimitKey(tokenAuth *projectJWT.TokenAuth) func(*http.Request) string {
+	return func(r *http.Request) string {
+		tokenString := extractBearerToken(r.Header.Get("Authorization"))
+		if tokenString == "" || tokenAuth == nil || tokenAuth.JwtAuth == nil {
+			return ""
+		}
+
+		token, err := tokenAuth.JwtAuth.Decode(tokenString)
+		if err != nil {
+			return ""
+		}
+		if err := jwxjwt.Validate(token); err != nil {
+			return ""
+		}
+
+		sum := sha256.Sum256([]byte(tokenString))
+		return "token:" + hex.EncodeToString(sum[:])
+	}
+}
+
+func extractBearerToken(authHeader string) string {
+	const bearerPrefix = "Bearer "
+	if len(authHeader) <= len(bearerPrefix) || !strings.HasPrefix(authHeader, bearerPrefix) {
+		return ""
+	}
+	return strings.TrimSpace(authHeader[len(bearerPrefix):])
 }
 
 // parsePositiveInt parses a positive integer from environment variable with a default value

--- a/backend/api/base_utility_test.go
+++ b/backend/api/base_utility_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -260,6 +262,90 @@ func TestRegisterRoutesWithRateLimiting_MountsOperatorInvitationRoutes(t *testin
 	api.Router.ServeHTTP(rr, req)
 
 	assert.NotEqual(t, http.StatusNotFound, rr.Code)
+}
+
+func TestTokenAwareRateLimitKey_ValidTokenUsesHashedToken(t *testing.T) {
+	viper.Set("auth_jwt_expiry", 15*time.Minute)
+	viper.Set("auth_jwt_refresh_expiry", 24*time.Hour)
+
+	tokenAuth, err := jwt.NewTokenAuthWithSecret("rate-limit-test-secret-32-chars!!")
+	require.NoError(t, err)
+
+	token, err := tokenAuth.CreateJWT(jwt.AppClaims{
+		ID:          42,
+		Sub:         "user@example.com",
+		Roles:       []string{"user"},
+		Permissions: []string{"read"},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/students", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	sum := sha256.Sum256([]byte(token))
+	expected := "token:" + hex.EncodeToString(sum[:])
+
+	assert.Equal(t, expected, tokenAwareRateLimitKey(tokenAuth)(req))
+	assert.NotContains(t, tokenAwareRateLimitKey(tokenAuth)(req), token)
+}
+
+func TestTokenAwareRateLimitKey_InvalidTokenFallsBack(t *testing.T) {
+	tokenAuth, err := jwt.NewTokenAuthWithSecret("rate-limit-test-secret-32-chars!!")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/students", nil)
+	req.Header.Set("Authorization", "Bearer not-a-real-token")
+
+	assert.Empty(t, tokenAwareRateLimitKey(tokenAuth)(req))
+}
+
+func TestTokenAwareRateLimitKey_ExpiredTokenFallsBack(t *testing.T) {
+	tokenAuth, err := jwt.NewTokenAuthWithSecret("rate-limit-test-secret-32-chars!!")
+	require.NoError(t, err)
+
+	_, token, err := tokenAuth.JwtAuth.Encode(map[string]any{
+		"exp": time.Now().Add(-1 * time.Hour).Unix(),
+		"iat": time.Now().Add(-2 * time.Hour).Unix(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/students", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	assert.Empty(t, tokenAwareRateLimitKey(tokenAuth)(req))
+}
+
+func TestTokenAwareRateLimitKey_DifferentValidTokensHaveDifferentKeys(t *testing.T) {
+	viper.Set("auth_jwt_expiry", 15*time.Minute)
+	viper.Set("auth_jwt_refresh_expiry", 24*time.Hour)
+
+	tokenAuth, err := jwt.NewTokenAuthWithSecret("rate-limit-test-secret-32-chars!!")
+	require.NoError(t, err)
+
+	tokenA, err := tokenAuth.CreateJWT(jwt.AppClaims{
+		ID:          42,
+		Sub:         "user-a@example.com",
+		Roles:       []string{"user"},
+		Permissions: []string{"read"},
+	})
+	require.NoError(t, err)
+	tokenB, err := tokenAuth.CreateJWT(jwt.AppClaims{
+		ID:          43,
+		Sub:         "user-b@example.com",
+		Roles:       []string{"user"},
+		Permissions: []string{"read"},
+	})
+	require.NoError(t, err)
+
+	reqA := httptest.NewRequest(http.MethodGet, "/api/students", nil)
+	reqA.RemoteAddr = "192.168.1.1:12345"
+	reqA.Header.Set("Authorization", "Bearer "+tokenA)
+	reqB := httptest.NewRequest(http.MethodGet, "/api/students", nil)
+	reqB.RemoteAddr = "192.168.1.1:12345"
+	reqB.Header.Set("Authorization", "Bearer "+tokenB)
+
+	keyFunc := tokenAwareRateLimitKey(tokenAuth)
+	assert.NotEqual(t, keyFunc(reqA), keyFunc(reqB))
 }
 
 // TestOnValueSetCallback_WCEnabled tests that the OnValueSet callback

--- a/backend/middleware/ratelimit.go
+++ b/backend/middleware/ratelimit.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// RateLimiter manages rate limiting by IP address
+// RateLimiter manages rate limiting by request key.
 type RateLimiter struct {
 	visitors map[string]*visitor
 	mu       sync.RWMutex
@@ -19,9 +19,10 @@ type RateLimiter struct {
 	b        int        // burst size
 	ttl      time.Duration
 	logger   *SecurityLogger // optional security logger
+	keyFunc  func(*http.Request) string
 }
 
-// visitor tracks rate limiting for a single IP
+// visitor tracks rate limiting for a single request key.
 type visitor struct {
 	limiter  *rate.Limiter
 	lastSeen time.Time
@@ -50,15 +51,36 @@ func (rl *RateLimiter) SetLogger(logger *SecurityLogger) {
 	rl.logger = logger
 }
 
-// getVisitor returns the rate limiter for the given IP
-func (rl *RateLimiter) getVisitor(ip string) *rate.Limiter {
+// SetKeyFunc sets the request key function for the rate limiter.
+// If keyFunc returns an empty key, the limiter falls back to the client IP.
+func (rl *RateLimiter) SetKeyFunc(keyFunc func(*http.Request) string) {
+	rl.keyFunc = keyFunc
+}
+
+func defaultRateLimitKey(r *http.Request) string {
+	return "ip:" + GetClientIP(r)
+}
+
+func (rl *RateLimiter) requestKey(r *http.Request) string {
+	if rl.keyFunc == nil {
+		return defaultRateLimitKey(r)
+	}
+	key := rl.keyFunc(r)
+	if key == "" {
+		return defaultRateLimitKey(r)
+	}
+	return key
+}
+
+// getVisitor returns the rate limiter for the given request key.
+func (rl *RateLimiter) getVisitor(key string) *rate.Limiter {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	v, exists := rl.visitors[ip]
+	v, exists := rl.visitors[key]
 	if !exists {
 		limiter := rate.NewLimiter(rl.r, rl.b)
-		rl.visitors[ip] = &visitor{limiter: limiter, lastSeen: time.Now()}
+		rl.visitors[key] = &visitor{limiter: limiter, lastSeen: time.Now()}
 		return limiter
 	}
 
@@ -86,8 +108,7 @@ func (rl *RateLimiter) cleanupVisitors() {
 func (rl *RateLimiter) Middleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ip := GetClientIP(r)
-			limiter := rl.getVisitor(ip)
+			limiter := rl.getVisitor(rl.requestKey(r))
 
 			if !limiter.Allow() {
 				w.Header().Set("X-RateLimit-Limit", fmt.Sprintf("%d", int(rl.r*60)))

--- a/backend/middleware/ratelimit_test.go
+++ b/backend/middleware/ratelimit_test.go
@@ -56,6 +56,18 @@ func TestRateLimiter_SetLogger(t *testing.T) {
 	assert.NotNil(t, rl.logger)
 }
 
+func TestRateLimiter_SetKeyFunc(t *testing.T) {
+	rl := NewRateLimiter(60, 10)
+	rl.SetKeyFunc(func(r *http.Request) string {
+		return "custom:" + r.Header.Get("X-Rate-Limit-Key")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Rate-Limit-Key", "abc")
+
+	assert.Equal(t, "custom:abc", rl.requestKey(req))
+}
+
 // =============================================================================
 // GetClientIP Tests
 // =============================================================================
@@ -237,6 +249,67 @@ func TestRateLimiter_Middleware_PerIPRateLimiting(t *testing.T) {
 	rr4 := httptest.NewRecorder()
 	r.ServeHTTP(rr4, req4)
 	assert.Equal(t, http.StatusTooManyRequests, rr4.Code)
+}
+
+func TestRateLimiter_Middleware_CustomKeySeparatesSameIP(t *testing.T) {
+	rl := NewRateLimiter(1, 1)
+	rl.SetKeyFunc(func(r *http.Request) string {
+		return "token:" + r.Header.Get("Authorization")
+	})
+
+	r := chi.NewRouter()
+	r.Use(rl.Middleware())
+	r.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req1.RemoteAddr = "192.168.1.1:12345"
+	req1.Header.Set("Authorization", "token-a")
+	rr1 := httptest.NewRecorder()
+	r.ServeHTTP(rr1, req1)
+	assert.Equal(t, http.StatusOK, rr1.Code)
+
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req2.RemoteAddr = "192.168.1.1:12345"
+	req2.Header.Set("Authorization", "token-b")
+	rr2 := httptest.NewRecorder()
+	r.ServeHTTP(rr2, req2)
+	assert.Equal(t, http.StatusOK, rr2.Code)
+
+	req3 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req3.RemoteAddr = "192.168.1.1:12345"
+	req3.Header.Set("Authorization", "token-a")
+	rr3 := httptest.NewRecorder()
+	r.ServeHTTP(rr3, req3)
+	assert.Equal(t, http.StatusTooManyRequests, rr3.Code)
+}
+
+func TestRateLimiter_Middleware_EmptyCustomKeyFallsBackToIP(t *testing.T) {
+	rl := NewRateLimiter(1, 1)
+	rl.SetKeyFunc(func(r *http.Request) string {
+		return ""
+	})
+
+	r := chi.NewRouter()
+	r.Use(rl.Middleware())
+	r.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req1.RemoteAddr = "192.168.1.1:12345"
+	req1.Header.Set("Authorization", "token-a")
+	rr1 := httptest.NewRecorder()
+	r.ServeHTTP(rr1, req1)
+	assert.Equal(t, http.StatusOK, rr1.Code)
+
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req2.RemoteAddr = "192.168.1.1:12345"
+	req2.Header.Set("Authorization", "token-b")
+	rr2 := httptest.NewRecorder()
+	r.ServeHTTP(rr2, req2)
+	assert.Equal(t, http.StatusTooManyRequests, rr2.Code)
 }
 
 // =============================================================================

--- a/frontend/src/app/api/rooms/route.test.ts
+++ b/frontend/src/app/api/rooms/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Session } from "next-auth";
 import { NextRequest } from "next/server";
 import { GET, POST } from "./route";
+import { suppressConsole } from "~/test/helpers/console";
 
 // ============================================================================
 // Types
@@ -92,6 +93,8 @@ async function parseJsonResponse<T>(response: Response): Promise<T> {
 // ============================================================================
 
 describe("GET /api/rooms", () => {
+  const consoleSpies = suppressConsole("warn");
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue(defaultSession);
@@ -189,6 +192,21 @@ describe("GET /api/rooms", () => {
       };
     }>(response);
     expect(json.data).toEqual([]);
+  });
+
+  it("logs rate-limited fetch failures as warnings", async () => {
+    mockApiGet.mockRejectedValueOnce(
+      new Error("API error (429): Rate limit exceeded"),
+    );
+
+    const request = createMockRequest("/api/rooms");
+    const response = await GET(request, createMockContext());
+
+    expect(response.status).toBe(200);
+    expect(consoleSpies.warn).toHaveBeenCalledWith("rooms fetch failed", {
+      error: "API error (429): Rate limit exceeded",
+      rate_limited: true,
+    });
   });
 });
 

--- a/frontend/src/app/api/rooms/route.ts
+++ b/frontend/src/app/api/rooms/route.ts
@@ -106,9 +106,19 @@ export const GET = createGetHandler(
         },
       };
     } catch (error) {
-      logger.error("rooms fetch failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const logContext = {
+        error: errorMessage,
+        ...(errorMessage.includes("API error (429)") && {
+          rate_limited: true,
+        }),
+      };
+      if (logContext.rate_limited) {
+        logger.warn("rooms fetch failed", logContext);
+      } else {
+        logger.error("rooms fetch failed", logContext);
+      }
       // Return empty response with pagination
       return {
         data: [],

--- a/frontend/src/app/api/students/route.test.ts
+++ b/frontend/src/app/api/students/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Session } from "next-auth";
 import { NextRequest } from "next/server";
 import { GET, POST } from "./route";
+import { suppressConsole } from "~/test/helpers/console";
 
 // ============================================================================
 // Types
@@ -37,7 +38,9 @@ vi.mock("~/lib/api-helpers", () => ({
       ? 401
       : message.includes("(404)")
         ? 404
-        : 500;
+        : message.includes("(429)")
+          ? 429
+          : 500;
     return new Response(JSON.stringify({ error: message }), { status });
   }),
 }));
@@ -123,6 +126,8 @@ async function parseJsonResponse<T>(response: Response): Promise<T> {
 // ============================================================================
 
 describe("GET /api/students", () => {
+  const consoleSpies = suppressConsole("warn");
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue(defaultSession);
@@ -239,6 +244,21 @@ describe("GET /api/students", () => {
       "test-token",
     );
     expect(response.status).toBe(200);
+  });
+
+  it("logs rate-limited fetch failures as warnings", async () => {
+    mockApiGet.mockRejectedValueOnce(
+      new Error("API error (429): Rate limit exceeded"),
+    );
+
+    const request = createMockRequest("/api/students");
+    const response = await GET(request, createMockContext());
+
+    expect(response.status).toBe(429);
+    expect(consoleSpies.warn).toHaveBeenCalledWith("students fetch failed", {
+      error: "API error (429): Rate limit exceeded",
+      rate_limited: true,
+    });
   });
 });
 

--- a/frontend/src/app/api/students/route.ts
+++ b/frontend/src/app/api/students/route.ts
@@ -155,9 +155,19 @@ export const GET = createGetHandler(
         },
       };
     } catch (error) {
-      logger.error("students fetch failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const logContext = {
+        error: errorMessage,
+        ...(errorMessage.includes("API error (429)") && {
+          rate_limited: true,
+        }),
+      };
+      if (logContext.rate_limited) {
+        logger.warn("students fetch failed", logContext);
+      } else {
+        logger.error("students fetch failed", logContext);
+      }
       throw error; // Re-throw to let the error handler deal with it
     }
   },

--- a/frontend/src/lib/api-helpers.test.ts
+++ b/frontend/src/lib/api-helpers.test.ts
@@ -18,6 +18,18 @@ import {
 } from "./api-helpers";
 import { suppressConsole } from "~/test/helpers/console";
 
+const { mockNextHeaders } = vi.hoisted(() => ({
+  mockNextHeaders: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: mockNextHeaders,
+}));
+
+vi.mock("~/lib/server-api-url", () => ({
+  getServerApiUrl: () => "http://backend.test",
+}));
+
 // Helper to create mock NextRequest
 function createMockNextRequest(
   url: string,
@@ -117,6 +129,19 @@ describe("handleApiError", () => {
 
     expect(consoleSpies.warn).toHaveBeenCalled();
     // consoleError not called for 4xx
+  });
+
+  it("logs rate-limit responses with rate_limited context", () => {
+    const error = new Error("API error (429): Rate limit exceeded");
+
+    handleApiError(error);
+
+    expect(consoleSpies.warn).toHaveBeenCalledWith("api route rate limited", {
+      status: 429,
+      error: "API error (429): Rate limit exceeded",
+      rate_limited: true,
+    });
+    expect(consoleSpies.error).not.toHaveBeenCalled();
   });
 
   it("returns 500 for unknown error format", async () => {
@@ -648,6 +673,27 @@ describe("fetchWithRetry", () => {
     ).rejects.toThrow("API error: 400");
   });
 
+  it("logs 429 responses as rate-limit warnings", async () => {
+    mockFetchRetry.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      text: () => Promise.resolve("Rate limit exceeded"),
+    } as Response);
+
+    await expect(
+      fetchWithRetry("http://api.test/endpoint", "test-token"),
+    ).rejects.toThrow("API error: 429");
+
+    expect(consoleSpies.warn).toHaveBeenCalledWith("api rate limited", {
+      url: "http://api.test/endpoint",
+      method: "GET",
+      status: 429,
+      error_text: "Rate limit exceeded",
+      rate_limited: true,
+    });
+    expect(consoleSpies.error).not.toHaveBeenCalled();
+  });
+
   it("throws error for 5xx server errors", async () => {
     mockFetchRetry.mockResolvedValueOnce({
       ok: false,
@@ -813,6 +859,133 @@ describe("apiGet (client-side)", () => {
 
     await expect(apiGet("/test", "token")).rejects.toThrow(
       'API error (404): {"message":"Not Found"}',
+    );
+  });
+});
+
+describe("apiGet (server-side)", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalFetch: typeof fetch;
+  let mockFetch: MockedFetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalWindow = globalThis.window;
+    originalFetch = globalThis.fetch;
+    mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+    Object.defineProperty(globalThis, "window", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(globalThis, "window", {
+      value: originalWindow,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("forwards incoming client IP and user agent headers to the backend", async () => {
+    mockNextHeaders.mockResolvedValueOnce(
+      new Headers({
+        "x-forwarded-for": "203.0.113.10, 172.20.0.4",
+        "user-agent": "Mozilla/5.0 Test Browser",
+      }),
+    );
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ result: "ok" }),
+    } as Response);
+
+    const result = await apiGet<{ result: string }>("/api/test", "token");
+
+    expect(result).toEqual({ result: "ok" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://backend.test/api/test",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+          "X-Forwarded-For": "203.0.113.10",
+          "X-Real-IP": "203.0.113.10",
+          "User-Agent": "Mozilla/5.0 Test Browser",
+        }) as HeadersInit,
+      }),
+    );
+  });
+
+  it("falls back to X-Real-IP when X-Forwarded-For is absent", async () => {
+    mockNextHeaders.mockResolvedValueOnce(
+      new Headers({
+        "x-real-ip": "198.51.100.25",
+      }),
+    );
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ result: "ok" }),
+    } as Response);
+
+    await apiGet<{ result: string }>("/api/test", "token");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://backend.test/api/test",
+      expect.objectContaining({
+        headers: {
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+          "X-Forwarded-For": "198.51.100.25",
+          "X-Real-IP": "198.51.100.25",
+        },
+      }),
+    );
+  });
+
+  it("omits forward headers when no client IP or user agent is available", async () => {
+    mockNextHeaders.mockResolvedValueOnce(new Headers());
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ result: "ok" }),
+    } as Response);
+
+    await apiGet<{ result: string }>("/api/test", "token");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://backend.test/api/test",
+      expect.objectContaining({
+        headers: {
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+  });
+
+  it("still calls the backend when request headers are unavailable", async () => {
+    mockNextHeaders.mockRejectedValueOnce(new Error("outside request scope"));
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ result: "ok" }),
+    } as Response);
+
+    await apiGet<{ result: string }>("/api/test", "token");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://backend.test/api/test",
+      expect.objectContaining({
+        headers: {
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+        },
+      }),
     );
   });
 });

--- a/frontend/src/lib/api-helpers.ts
+++ b/frontend/src/lib/api-helpers.ts
@@ -48,6 +48,27 @@ interface ServerFetchOptions {
   returnVoidOn204?: boolean;
 }
 
+async function getIncomingForwardHeaders(): Promise<Record<string, string>> {
+  try {
+    const { headers } = await import("next/headers");
+    const incomingHeaders = await headers();
+    const forwardedFor = incomingHeaders.get("x-forwarded-for");
+    const realIp = incomingHeaders.get("x-real-ip");
+    const userAgent = incomingHeaders.get("user-agent");
+    const ip = forwardedFor?.split(",")[0]?.trim() ?? realIp;
+
+    return {
+      ...(ip && {
+        "X-Forwarded-For": ip,
+        "X-Real-IP": ip,
+      }),
+      ...(userAgent && { "User-Agent": userAgent }),
+    };
+  } catch {
+    return {};
+  }
+}
+
 /**
  * Check if the current session is authenticated
  * @returns NextResponse with error if not authenticated, null if authenticated
@@ -74,6 +95,7 @@ async function serverFetchWithRetry<T>(
 ): Promise<T> {
   const { getServerApiUrl } = await import("~/lib/server-api-url");
   const url = `${getServerApiUrl()}${endpoint}`;
+  const forwardHeaders = await getIncomingForwardHeaders();
 
   const executeRequest = async (bearer: string) =>
     fetch(url, {
@@ -81,6 +103,7 @@ async function serverFetchWithRetry<T>(
       headers: {
         Authorization: `Bearer ${bearer}`,
         "Content-Type": "application/json",
+        ...forwardHeaders,
       },
       body: options.body ? JSON.stringify(options.body) : undefined,
       cache: "no-store", // Prevent Next.js from caching API responses
@@ -264,6 +287,12 @@ export function handleApiError(error: unknown): NextResponse<ApiErrorResponse> {
         logger.error("api route error", {
           status,
           error: error.message,
+        });
+      } else if (status === 429) {
+        logger.warn("api route rate limited", {
+          status,
+          error: error.message,
+          rate_limited: true,
         });
       } else {
         logger.warn("api route error", {
@@ -548,12 +577,18 @@ export async function fetchWithRetry<T>(
       return { response: null, data: null };
     }
     // All other errors (4xx bugs, 5xx server errors) should throw
-    logger.error("api error", {
+    const logContext = {
       url,
       method,
       status: response.status,
       error_text: errorText.substring(0, 200),
-    });
+      ...(response.status === 429 && { rate_limited: true }),
+    };
+    if (response.status === 429) {
+      logger.warn("api rate limited", logContext);
+    } else {
+      logger.error("api error", logContext);
+    }
     throw new Error(`API error: ${response.status}`);
   }
 

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -214,6 +214,35 @@ describe("api.ts helper functions", () => {
         restore();
       }
     });
+
+    it("logs 429 failures as rate-limit warnings", async () => {
+      const consoleWarn = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const { fetchWithRetry } = await import("./api-helpers");
+      vi.mocked(fetchWithRetry).mockRejectedValueOnce(
+        new Error("API error: 429"),
+      );
+
+      const { studentService } = await import("./api");
+
+      const restore = setupBrowserEnv();
+      try {
+        await expect(
+          studentService.getStudents({ token: "test-token" }),
+        ).rejects.toThrow("Error fetching students: API error: 429");
+
+        expect(consoleWarn).toHaveBeenCalledWith("api operation rate limited", {
+          context: "Error fetching students",
+          error: "API error: 429",
+          status: 429,
+          rate_limited: true,
+        });
+      } finally {
+        consoleWarn.mockRestore();
+        restore();
+      }
+    });
   });
 
   describe("studentService.createStudent", () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,6 +59,7 @@ const logger = createLogger({ component: "ApiClient" });
 function handleApiError(error: unknown, context: string): Error {
   // Extract error details
   const errorMessage = error instanceof Error ? error.message : String(error);
+  const statusMatch = /API error[:\s(]+(\d{3})/.exec(errorMessage);
   const status =
     error &&
     typeof error === "object" &&
@@ -67,13 +68,21 @@ function handleApiError(error: unknown, context: string): Error {
     typeof error.response === "object" &&
     "status" in error.response
       ? (error.response.status as number)
-      : undefined;
+      : statusMatch?.[1]
+        ? Number.parseInt(statusMatch[1], 10)
+        : undefined;
 
-  logger.error("api operation failed", {
+  const logContext = {
     context,
     error: errorMessage,
     status,
-  });
+    ...(status === 429 && { rate_limited: true }),
+  };
+  if (status === 429) {
+    logger.warn("api operation rate limited", logContext);
+  } else {
+    logger.error("api operation failed", logContext);
+  }
 
   return new Error(`${context}: ${errorMessage}`);
 }

--- a/frontend/src/lib/swr/config.test.ts
+++ b/frontend/src/lib/swr/config.test.ts
@@ -57,6 +57,26 @@ describe("swrConfig.onError", () => {
       error: "[object Object]",
     });
   });
+
+  it("logs 429 errors as rate-limit warnings", () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    swrConfig.onError?.(
+      new Error("Error fetching students: API error: 429"),
+      "tenant-slug:ogs-students-3",
+      stubConfig,
+    );
+
+    expect(consoleWarn).toHaveBeenCalledWith("swr_fetch_rate_limited", {
+      key: "tenant-slug:ogs-students-3",
+      error: "Error fetching students: API error: 429",
+      rate_limited: true,
+    });
+    expect(consoleError).not.toHaveBeenCalled();
+  });
 });
 
 describe("swrConfig defaults", () => {

--- a/frontend/src/lib/swr/config.ts
+++ b/frontend/src/lib/swr/config.ts
@@ -19,10 +19,20 @@ const logger = createLogger({ component: "useSWRAuth" });
  * failures by domain (e.g., "tenant-slug:database-devices-list").
  */
 function logSWRError(error: unknown, key: string): void {
-  logger.error("swr_fetch_failed", {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  const isRateLimited = errorMessage.includes("API error: 429");
+  const logContext = {
     key,
-    error: error instanceof Error ? error.message : String(error),
-  });
+    error: errorMessage,
+    ...(isRateLimited && { rate_limited: true }),
+  };
+
+  if (isRateLimited) {
+    logger.warn("swr_fetch_rate_limited", logContext);
+    return;
+  }
+
+  logger.error("swr_fetch_failed", logContext);
 }
 
 /**


### PR DESCRIPTION
## Summary
- forward the original client IP and user agent from Next.js server-side API calls to the Go backend
- classify 429 responses as rate-limit warnings instead of generic errors in API, SWR, students, and rooms logs
- make the backend's general rate limiter use a verified Bearer JWT hash for authenticated requests, falling back to IP for missing, invalid, or expired tokens

## Root Cause
The backend rate limiter already honors `X-Real-IP` and `X-Forwarded-For`, but the normal tenant API proxy path only sent auth and content-type headers. In production the backend therefore saw many app requests as the frontend Docker container IP (`172.20.0.4`) with `node` as user agent, so unrelated users shared one rate-limit bucket.

The backend still had one more NAT-sensitive edge: its global limiter was mounted before JWT auth, so even correctly forwarded school IPs could group many authenticated users behind the same public network. The limiter now keeps IP-based protection for unauthenticated traffic and uses a hashed, validated Bearer token as the bucket key for normal authenticated API calls.

## Validation
- `pnpm --dir frontend exec tsc --noEmit --pretty false`
- `pnpm --dir frontend exec vitest run src/lib/api-helpers.test.ts src/lib/swr/config.test.ts src/lib/api.test.ts src/app/api/students/route.test.ts src/app/api/rooms/route.test.ts`
- `pnpm --dir frontend run check`
- `pnpm --dir frontend build`
- `go test ./middleware ./api` from `backend/`
- pre-push: `pnpm --dir frontend knip`
- pre-push: `pnpm --dir frontend run check`
- pre-push: `go vet`, `golangci-lint`, `go-deadcode`

## Notes
- `go test ./...` from `backend/` was also attempted. It currently fails in `api/students` at `TestListStudents_LocationStateTransit_EmptyReturnsEmpty` because the local test database contains leftover transit fixture rows; the focused backend packages touched by this PR pass.