### PR TITLE
fix(operator): gelöschte Träger/Schulen aus globalen Listen und Dropdowns entfernen

### DIFF
--- a/backend/database/repositories/auth/account_tenant.go
+++ b/backend/database/repositories/auth/account_tenant.go
@@ -178,6 +178,11 @@ func (r *AccountTenantRepository) ListAllAccounts(ctx context.Context) ([]auth.O
 }
 
 // queryOrgAccounts builds the shared org-level accounts query with an optional WHERE clause.
+//
+// Accounts whose tenant school is soft-deleted are filtered out unconditionally.
+// Schools are only soft-deletable when their organization is still active, and
+// an organization can only be soft-deleted once all its schools are in the
+// Papierkorb, so filtering on school.deleted_at also covers the org-deleted case.
 func (r *AccountTenantRepository) queryOrgAccounts(ctx context.Context, db bun.IDB, whereClause string, arg interface{}) ([]auth.OrgAccountInfo, error) {
 	var accounts []auth.OrgAccountInfo
 	q := db.NewSelect().
@@ -202,7 +207,8 @@ func (r *AccountTenantRepository) queryOrgAccounts(ctx context.Context, db bun.I
 		Join(`LEFT JOIN auth.roles AS "r" ON "r".id = "ar".role_id`).
 		Join(`LEFT JOIN users.persons AS "p" ON "p".account_id = "at".account_id AND "p".tenant_id = "at".tenant_id`).
 		Join(`LEFT JOIN users.staff AS "s" ON "s".person_id = "p".id AND "s".tenant_id = "at".tenant_id`).
-		Join(`LEFT JOIN users.teachers AS "t" ON "t".staff_id = "s".id AND "t".tenant_id = "at".tenant_id`)
+		Join(`LEFT JOIN users.teachers AS "t" ON "t".staff_id = "s".id AND "t".tenant_id = "at".tenant_id`).
+		Where(`"sch".deleted_at IS NULL`)
 	if whereClause != "" {
 		q = q.Where(whereClause, arg)
 	}
@@ -233,7 +239,8 @@ func (r *AccountTenantRepository) queryOrgInvitations(ctx context.Context, db bu
 		ColumnExpr(`false AS is_active_caregiver`).
 		TableExpr(`auth.invitation_tokens AS "inv"`).
 		Join(`INNER JOIN platform.schools AS "sch" ON "sch".id = "inv".tenant_id`).
-		Join(`LEFT JOIN auth.roles AS "r" ON "r".id = "inv".role_id`)
+		Join(`LEFT JOIN auth.roles AS "r" ON "r".id = "inv".role_id`).
+		Where(`"sch".deleted_at IS NULL`)
 	if whereClause != "" {
 		q = q.Where(whereClause, arg)
 	}

--- a/backend/database/repositories/auth/account_tenant_repository_test.go
+++ b/backend/database/repositories/auth/account_tenant_repository_test.go
@@ -234,3 +234,76 @@ func TestAccountTenantRepository_ListAllAccounts(t *testing.T) {
 	}
 	assert.True(t, found, "expected to find test account in all accounts")
 }
+
+// containsAccount reports whether the result list includes an entry for the given email.
+func containsAccount(accounts []authModels.OrgAccountInfo, email string) bool {
+	for _, a := range accounts {
+		if a.Email == email {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAccountTenantRepository_ListAllAccounts_ExcludesDeletedSchool verifies that
+// the global org-accounts listing hides accounts whose tenant school is in the
+// Papierkorb (soft-deleted), and re-includes them after restore.
+func TestAccountTenantRepository_ListAllAccounts_ExcludesDeletedSchool(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	ctx := context.Background()
+
+	tenantID := int64(90011)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+
+	account := testpkg.CreateTestAccount(t, db, "list-all-deleted")
+	testpkg.MapAccountToTenant(t, db, account.ID, tenantID)
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM auth.account_tenants WHERE account_id = ?`, account.ID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM auth.accounts WHERE id = ?`, account.ID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.schools WHERE id = ?`, tenantID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.organizations WHERE id = ?`, tenantID)
+		_ = db.Close()
+	})
+
+	repo := authRepo.NewAccountTenantRepository(db)
+
+	// Baseline: account is visible while school is active.
+	accounts, err := repo.ListAllAccounts(ctx)
+	require.NoError(t, err)
+	require.True(t, containsAccount(accounts, account.Email),
+		"baseline: account should be visible while school is active")
+
+	// Soft-delete the school directly to keep the test isolated from
+	// SoftDeleteSchool's side effects (token revocation, invitation invalidation).
+	_, err = db.ExecContext(ctx,
+		`UPDATE platform.schools SET deleted_at = NOW() WHERE id = ?`, tenantID)
+	require.NoError(t, err)
+
+	// After soft-delete: account must disappear from global listing.
+	accounts, err = repo.ListAllAccounts(ctx)
+	require.NoError(t, err)
+	require.False(t, containsAccount(accounts, account.Email),
+		"account whose school is soft-deleted must not appear in ListAllAccounts")
+
+	// Also hidden when filtered by the parent organization.
+	orgAccounts, err := repo.ListAccountsByOrganizationID(ctx, tenantID)
+	require.NoError(t, err)
+	require.False(t, containsAccount(orgAccounts, account.Email),
+		"account whose school is soft-deleted must not appear in ListAccountsByOrganizationID")
+
+	// Restore: account reappears in both listings.
+	_, err = db.ExecContext(ctx,
+		`UPDATE platform.schools SET deleted_at = NULL WHERE id = ?`, tenantID)
+	require.NoError(t, err)
+
+	accounts, err = repo.ListAllAccounts(ctx)
+	require.NoError(t, err)
+	assert.True(t, containsAccount(accounts, account.Email),
+		"restore: account should be visible again in ListAllAccounts")
+
+	orgAccounts, err = repo.ListAccountsByOrganizationID(ctx, tenantID)
+	require.NoError(t, err)
+	assert.True(t, containsAccount(orgAccounts, account.Email),
+		"restore: account should be visible again in ListAccountsByOrganizationID")
+}

--- a/backend/services/platform/operator_provisioning_integration_test.go
+++ b/backend/services/platform/operator_provisioning_integration_test.go
@@ -437,3 +437,152 @@ func TestIntegration_SoftDeletePerson_StudentSuccess(t *testing.T) {
 	assert.Equal(t, "Gelöscht", dbPerson.FirstName)
 	assert.NotNil(t, dbPerson.DeletedAt)
 }
+
+// =============================================================================
+// Global Operator Listings: deleted-school Papierkorb hiding
+// =============================================================================
+
+// TestIntegration_ListAllDevices_HidesDeletedSchoolDevices verifies that the
+// global operator devices listing excludes devices whose tenant school is
+// soft-deleted, and re-includes them after restore. Companion to
+// TestAccountTenantRepository_ListAllAccounts_ExcludesDeletedSchool — both
+// guard the user-visible contract "everything tied to a deleted school must
+// disappear from the UI; the school itself stays restorable via Papierkorb."
+func TestIntegration_ListAllDevices_HidesDeletedSchoolDevices(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := buildProvisioningService(t, db)
+	ctx := context.Background()
+
+	tenantID := int64(90021)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+
+	device := testpkg.CreateTestDeviceForTenant(t, db, tenantID, "trash-test")
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM iot.devices WHERE id = ?`, device.ID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.schools WHERE id = ?`, tenantID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.organizations WHERE id = ?`, tenantID)
+	})
+
+	containsDevice := func(devices []platformSvc.OperatorDeviceInfo) bool {
+		for _, d := range devices {
+			if d.ID == device.ID {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Baseline: device visible while school is active.
+	devices, err := service.ListAllDevices(ctx)
+	require.NoError(t, err)
+	require.True(t, containsDevice(devices),
+		"baseline: device should be visible while school is active")
+
+	// Soft-delete the school directly (avoids SoftDeleteSchool's token/invitation
+	// side effects which are orthogonal to the read-filter behavior under test).
+	_, err = db.ExecContext(ctx,
+		`UPDATE platform.schools SET deleted_at = NOW() WHERE id = ?`, tenantID)
+	require.NoError(t, err)
+
+	// After soft-delete: device must disappear from the global listing.
+	devices, err = service.ListAllDevices(ctx)
+	require.NoError(t, err)
+	require.False(t, containsDevice(devices),
+		"device whose school is soft-deleted must not appear in ListAllDevices")
+
+	// Also hidden when filtered by the parent organization (org filter goes through
+	// the same query path; no separate IsDeleted pre-check protects ListOrganizationDevices).
+	devices, err = service.ListOrganizationDevices(ctx, tenantID)
+	require.NoError(t, err)
+	require.False(t, containsDevice(devices),
+		"device whose school is soft-deleted must not appear in ListOrganizationDevices")
+
+	// Restore: device reappears.
+	_, err = db.ExecContext(ctx,
+		`UPDATE platform.schools SET deleted_at = NULL WHERE id = ?`, tenantID)
+	require.NoError(t, err)
+
+	devices, err = service.ListAllDevices(ctx)
+	require.NoError(t, err)
+	assert.True(t, containsDevice(devices),
+		"restore: device should be visible again in ListAllDevices")
+}
+
+// TestIntegration_ListAllDevices_HidesDeletedOrgDevices verifies the
+// second layer of the SQL filter: devices belonging to a soft-deleted
+// organization (whose schools may technically still have deleted_at IS NULL
+// in a corrupt-state scenario) also disappear. Defensive — under normal
+// flow an org can only be deleted after all its schools are in the Papierkorb.
+func TestIntegration_ListAllDevices_HidesDeletedOrgDevices(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := buildProvisioningService(t, db)
+	ctx := context.Background()
+
+	tenantID := int64(90022)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+
+	device := testpkg.CreateTestDeviceForTenant(t, db, tenantID, "org-trash")
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM iot.devices WHERE id = ?`, device.ID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.schools WHERE id = ?`, tenantID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.organizations WHERE id = ?`, tenantID)
+	})
+
+	containsDevice := func(devices []platformSvc.OperatorDeviceInfo) bool {
+		for _, d := range devices {
+			if d.ID == device.ID {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Mark only the org as deleted (school stays active to isolate the org filter).
+	_, err := db.ExecContext(ctx,
+		`UPDATE platform.organizations SET deleted_at = NOW() WHERE id = ?`, tenantID)
+	require.NoError(t, err)
+
+	devices, err := service.ListAllDevices(ctx)
+	require.NoError(t, err)
+	assert.False(t, containsDevice(devices),
+		"device whose organization is soft-deleted must not appear in ListAllDevices")
+}
+
+// TestIntegration_ListOrganizationDevices_RejectsDeletedOrg verifies the
+// explicit IsDeleted pre-check on ListOrganizationDevices: targeting a
+// soft-deleted org must return OrganizationDeletedError, mirroring the
+// behavior of ListSchoolDevices for soft-deleted schools.
+func TestIntegration_ListOrganizationDevices_RejectsDeletedOrg(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := buildProvisioningService(t, db)
+	ctx := context.Background()
+
+	tenantID := int64(90023)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.schools WHERE id = ?`, tenantID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.organizations WHERE id = ?`, tenantID)
+	})
+
+	// Soft-delete the org (EnsureTestTenant created school+org sharing tenantID
+	// as their primary key, see testpkg.EnsureTestTenant).
+	_, err := db.ExecContext(ctx,
+		`UPDATE platform.organizations SET deleted_at = NOW() WHERE id = ?`, tenantID)
+	require.NoError(t, err)
+
+	_, err = service.ListOrganizationDevices(ctx, tenantID)
+	require.Error(t, err)
+	var deletedErr *platformSvc.OrganizationDeletedError
+	require.ErrorAs(t, err, &deletedErr,
+		"ListOrganizationDevices on a soft-deleted org must return OrganizationDeletedError")
+	assert.Equal(t, tenantID, deletedErr.OrganizationID)
+}

--- a/backend/services/platform/operator_provisioning_service.go
+++ b/backend/services/platform/operator_provisioning_service.go
@@ -706,14 +706,21 @@ INNER JOIN platform.organizations AS "o" ON "o".id = "s".organization_id
 
 // queryDevices runs the shared device query with an optional WHERE clause.
 // All callers pass static WHERE strings with parameterized args — no user input is concatenated.
+//
+// Devices belonging to a soft-deleted school or organization are filtered out
+// unconditionally so global listings (operator dashboard) never surface entries
+// for tenants that are in the Papierkorb. Detail endpoints (ListSchoolDevices,
+// ListOrganizationDevices) still reject deleted targets via their explicit
+// IsDeleted pre-check before reaching this query; the SQL filter is the
+// safety net for the global ListAllDevices path.
 func (s *operatorProvisioningService) queryDevices(adminCtx context.Context, whereClause string, args ...interface{}) ([]OperatorDeviceInfo, error) {
 	var db bun.IDB = s.txHandler.DB
 	if tx, ok := modelBase.TxFromContext(adminCtx); ok && tx != nil {
 		db = tx
 	}
-	q := operatorDeviceQuery
+	q := operatorDeviceQuery + ` WHERE "s".deleted_at IS NULL AND "o".deleted_at IS NULL`
 	if whereClause != "" {
-		q += " WHERE " + whereClause
+		q += " AND " + whereClause
 	}
 	q += ` ORDER BY "o".name, "s".name, "d".device_id`
 
@@ -769,6 +776,9 @@ func (s *operatorProvisioningService) ListOrganizationDevices(ctx context.Contex
 		}
 		if org == nil {
 			return &OrganizationNotFoundError{OrganizationID: organizationID}
+		}
+		if org.IsDeleted() {
+			return &OrganizationDeletedError{OrganizationID: organizationID}
 		}
 		var queryErr error
 		result, queryErr = s.queryDevices(adminCtx, `"o".id = ?`, organizationID)

--- a/frontend/src/app/operator/devices/page.tsx
+++ b/frontend/src/app/operator/devices/page.tsx
@@ -32,7 +32,7 @@ function OperatorDevicesPageContent() {
 
   const {
     isAuthenticated,
-    schools,
+    activeSchools,
     activeOrganizations,
     filterOrgId,
     selectedSchool,
@@ -271,7 +271,7 @@ function OperatorDevicesPageContent() {
       <CreateDeviceModal
         isOpen={createDeviceOpen}
         onClose={() => setCreateDeviceOpen(false)}
-        schools={schools}
+        schools={activeSchools}
         onCreated={() => {
           void refreshDevices();
         }}

--- a/frontend/src/app/operator/provisioning/use-org-school-filter.test.ts
+++ b/frontend/src/app/operator/provisioning/use-org-school-filter.test.ts
@@ -2,7 +2,7 @@
  * Tests for useOrgSchoolFilter — guards the Papierkorb-hiding contract that
  * lives in the activeSchools / filteredSchools memos. Issue #1435.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { Organization, School } from "~/lib/operator/provisioning-helpers";
 
@@ -11,8 +11,9 @@ vi.mock("next-auth/react", () => ({
   useSession: () => mockUseSession(),
 }));
 
+const mockReplace = vi.fn();
 const mockUseRouter = vi.fn(() => ({
-  replace: vi.fn(),
+  replace: mockReplace,
   push: vi.fn(),
 }));
 const mockUseSearchParams = vi.fn(() => new URLSearchParams());
@@ -34,6 +35,11 @@ vi.mock("~/lib/operator/provisioning-api", () => ({
     listOrganizations: vi.fn(),
     listSchools: vi.fn(),
   },
+}));
+
+vi.mock("~/lib/operator-url", () => ({
+  operatorPath: (path: string) =>
+    path.startsWith("/operator") ? path : `/operator${path}`,
 }));
 
 import { useOrgSchoolFilter } from "./use-org-school-filter";
@@ -77,6 +83,11 @@ function setupData(orgs: Organization[], schools: School[]): void {
 }
 
 describe("useOrgSchoolFilter — Papierkorb filtering (issue #1435)", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
+  });
+
   it("activeSchools excludes soft-deleted schools", () => {
     setupData(
       [org("1")],
@@ -127,5 +138,61 @@ describe("useOrgSchoolFilter — Papierkorb filtering (issue #1435)", () => {
 
     expect(result.current.activeSchools).toEqual([]);
     expect(result.current.filteredSchools).toEqual([]);
+  });
+
+  it("selectedSchool is null when urlSchoolId points at a soft-deleted school", () => {
+    mockUseSearchParams.mockReturnValueOnce(new URLSearchParams("schoolId=11"));
+    setupData(
+      [org("1")],
+      [school("10", "1"), school("11", "1", "2025-06-01T00:00:00Z")],
+    );
+
+    const { result } = renderHook(() => useOrgSchoolFilter("/devices"));
+
+    expect(result.current.selectedSchool).toBeNull();
+  });
+
+  it("self-heals URL: clears schoolId param when the school is soft-deleted", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("schoolId=11"));
+    setupData(
+      [org("1")],
+      [school("10", "1"), school("11", "1", "2025-06-01T00:00:00Z")],
+    );
+
+    renderHook(() => useOrgSchoolFilter("/devices"));
+
+    expect(mockReplace).toHaveBeenCalledWith("/operator/devices");
+  });
+
+  it("self-heals URL: clears schoolId param when the school no longer exists", () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams("orgId=1&schoolId=99"),
+    );
+    setupData([org("1")], [school("10", "1")]);
+
+    renderHook(() => useOrgSchoolFilter("/devices"));
+
+    expect(mockReplace).toHaveBeenCalledWith("/operator/devices?orgId=1");
+  });
+
+  it("does NOT self-heal while schools is still loading (SWR undefined)", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("schoolId=11"));
+    mockSWRData.mockImplementation((key: string | null) => {
+      if (key === "operator-organizations") return [org("1")];
+      return undefined;
+    });
+
+    renderHook(() => useOrgSchoolFilter("/devices"));
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("does NOT self-heal when the urlSchoolId points at an active school", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("schoolId=10"));
+    setupData([org("1")], [school("10", "1")]);
+
+    renderHook(() => useOrgSchoolFilter("/devices"));
+
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/operator/provisioning/use-org-school-filter.test.ts
+++ b/frontend/src/app/operator/provisioning/use-org-school-filter.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for useOrgSchoolFilter — guards the Papierkorb-hiding contract that
+ * lives in the activeSchools / filteredSchools memos. Issue #1435.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { Organization, School } from "~/lib/operator/provisioning-helpers";
+
+const mockUseSession = vi.fn(() => ({ status: "authenticated" }));
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+}));
+
+const mockUseRouter = vi.fn(() => ({
+  replace: vi.fn(),
+  push: vi.fn(),
+}));
+const mockUseSearchParams = vi.fn(() => new URLSearchParams());
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockUseRouter(),
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+const mockSWRData = vi.fn();
+vi.mock("swr", () => ({
+  default: (key: string | null) => {
+    const data = mockSWRData(key);
+    return { data, error: undefined, isLoading: false, mutate: vi.fn() };
+  },
+}));
+
+vi.mock("~/lib/operator/provisioning-api", () => ({
+  operatorProvisioningService: {
+    listOrganizations: vi.fn(),
+    listSchools: vi.fn(),
+  },
+}));
+
+import { useOrgSchoolFilter } from "./use-org-school-filter";
+
+const org = (id: string, deletedAt: string | null = null): Organization =>
+  ({
+    id,
+    name: `Org ${id}`,
+    slug: `org-${id}`,
+    active: true,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    deletedAt,
+  }) as unknown as Organization;
+
+const school = (
+  id: string,
+  organizationId: string,
+  deletedAt: string | null = null,
+): School =>
+  ({
+    id,
+    organizationId,
+    name: `School ${id}`,
+    slug: `school-${id}`,
+    subdomain: `school-${id}`,
+    active: true,
+    hidden: false,
+    deletedAt,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    organization: org(organizationId),
+  }) as unknown as School;
+
+function setupData(orgs: Organization[], schools: School[]): void {
+  mockSWRData.mockImplementation((key: string | null) => {
+    if (key === "operator-organizations") return orgs;
+    if (key === "operator-schools") return schools;
+    return undefined;
+  });
+}
+
+describe("useOrgSchoolFilter — Papierkorb filtering (issue #1435)", () => {
+  it("activeSchools excludes soft-deleted schools", () => {
+    setupData(
+      [org("1")],
+      [
+        school("10", "1"),
+        school("11", "1", "2025-06-01T00:00:00Z"),
+        school("12", "1"),
+      ],
+    );
+
+    const { result } = renderHook(() => useOrgSchoolFilter("/devices"));
+
+    expect(result.current.activeSchools.map((s) => s.id)).toEqual(["10", "12"]);
+    expect(result.current.schools).toHaveLength(3);
+  });
+
+  it("filteredSchools without orgId returns activeSchools (no deleted)", () => {
+    setupData(
+      [org("1")],
+      [school("10", "1"), school("11", "1", "2025-06-01T00:00:00Z")],
+    );
+
+    const { result } = renderHook(() => useOrgSchoolFilter("/devices"));
+
+    expect(result.current.filteredSchools.map((s) => s.id)).toEqual(["10"]);
+  });
+
+  it("filteredSchools with orgId still excludes deleted schools", () => {
+    mockUseSearchParams.mockReturnValueOnce(new URLSearchParams("orgId=1"));
+    setupData(
+      [org("1"), org("2")],
+      [
+        school("10", "1"),
+        school("11", "1", "2025-06-01T00:00:00Z"),
+        school("20", "2"),
+      ],
+    );
+
+    const { result } = renderHook(() => useOrgSchoolFilter("/devices"));
+
+    expect(result.current.filteredSchools.map((s) => s.id)).toEqual(["10"]);
+  });
+
+  it("activeSchools is empty when schools is undefined (SWR not loaded yet)", () => {
+    mockSWRData.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useOrgSchoolFilter("/devices"));
+
+    expect(result.current.activeSchools).toEqual([]);
+    expect(result.current.filteredSchools).toEqual([]);
+  });
+});

--- a/frontend/src/app/operator/provisioning/use-org-school-filter.ts
+++ b/frontend/src/app/operator/provisioning/use-org-school-filter.ts
@@ -18,6 +18,7 @@ export function useOrgSchoolFilter(routePath: string): {
   readonly organizations: Organization[] | undefined;
   readonly schools: School[] | undefined;
   readonly activeOrganizations: Organization[];
+  readonly activeSchools: School[];
   readonly filterOrgId: string;
   readonly urlSchoolId: string;
   readonly selectedSchool: School | null;
@@ -58,16 +59,20 @@ export function useOrgSchoolFilter(routePath: string): {
     [organizations],
   );
 
+  const activeSchools = useMemo(
+    () => schools?.filter((s) => s.deletedAt == null) ?? [],
+    [schools],
+  );
+
   const selectedSchool = useMemo<School | null>(() => {
     if (!urlSchoolId) return null;
     return schools?.find((s) => s.id === urlSchoolId) ?? null;
   }, [urlSchoolId, schools]);
 
   const filteredSchools = useMemo(() => {
-    if (!schools) return [];
-    if (!filterOrgId) return schools;
-    return schools.filter((s) => s.organizationId === filterOrgId);
-  }, [schools, filterOrgId]);
+    if (!filterOrgId) return activeSchools;
+    return activeSchools.filter((s) => s.organizationId === filterOrgId);
+  }, [activeSchools, filterOrgId]);
 
   const updateQuery = useCallback(
     (next: { orgId?: string; schoolId?: string }) => {
@@ -109,6 +114,7 @@ export function useOrgSchoolFilter(routePath: string): {
     organizations,
     schools,
     activeOrganizations,
+    activeSchools,
     filterOrgId,
     urlSchoolId,
     selectedSchool,

--- a/frontend/src/app/operator/provisioning/use-org-school-filter.ts
+++ b/frontend/src/app/operator/provisioning/use-org-school-filter.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 // eslint-disable-next-line no-restricted-imports -- operator pages are not tenant-scoped
 import useSWR from "swr";
@@ -66,8 +66,8 @@ export function useOrgSchoolFilter(routePath: string): {
 
   const selectedSchool = useMemo<School | null>(() => {
     if (!urlSchoolId) return null;
-    return schools?.find((s) => s.id === urlSchoolId) ?? null;
-  }, [urlSchoolId, schools]);
+    return activeSchools.find((s) => s.id === urlSchoolId) ?? null;
+  }, [urlSchoolId, activeSchools]);
 
   const filteredSchools = useMemo(() => {
     if (!filterOrgId) return activeSchools;
@@ -90,6 +90,18 @@ export function useOrgSchoolFilter(routePath: string): {
     },
     [router, searchParams, routePath],
   );
+
+  // Self-heal stale deep links: if the URL points at a school that no longer
+  // exists or has been soft-deleted, drop the schoolId param once schools
+  // have loaded. Couples to `schools` (not `activeSchools`) so we don't fire
+  // during the SWR loading window when both are still undefined/empty.
+  useEffect(() => {
+    if (!urlSchoolId || schools === undefined) return;
+    const stillActive = activeSchools.some((s) => s.id === urlSchoolId);
+    if (!stillActive) {
+      updateQuery({ schoolId: "" });
+    }
+  }, [urlSchoolId, schools, activeSchools, updateQuery]);
 
   const handleOrgFilterChange = useCallback(
     (orgId: string) => {

--- a/frontend/src/lib/active-service.ts
+++ b/frontend/src/lib/active-service.ts
@@ -51,7 +51,7 @@ interface TransitAssignSkipped {
   reason: string;
 }
 
-export interface TransitAssignResult {
+interface TransitAssignResult {
   assigned: number[];
   skipped: TransitAssignSkipped[];
   active_group_id: number;


### PR DESCRIPTION
## Zusammenfassung
- Operator-Dashboard zeigt gelöschte Träger/Schulen nicht mehr ungefiltert: weder ihre Geräte, Konten und offenen Einladungen in den globalen Tabellen, noch die Schulen selbst in den Filter- und „Neues Gerät anlegen"-Dropdowns.
- Backend filtert in `queryDevices`, `queryOrgAccounts` und `queryOrgInvitations` auf `platform.schools.deleted_at` (für Geräte zusätzlich auf `platform.organizations.deleted_at`).
- `ListOrganizationDevices` bekommt den `org.IsDeleted()`-Pre-Check analog zu `ListSchoolDevices` und liefert jetzt `OrganizationDeletedError` statt einer stillen leeren Liste.
- Frontend-Hook `useOrgSchoolFilter` exponiert ein neues `activeSchools` und speist daraus `filteredSchools`. `CreateDeviceModal` auf der Geräte-Seite nutzt ebenfalls `activeSchools`. Konten- und Personen-Seite ziehen die Filter-Liste transitiv über `filteredSchools` mit.

Closes #1435

## Hintergrund
Bei Ogata Demo (Production) tauchten Geräte, Konten und offene Einladungen einer bereits gelöschten Schule weiterhin in den globalen Operator-Tabellen auf, und die Schule selbst war in den Schul-Dropdowns wählbar. Bestehende Detail-Pfade (`ListSchoolDevices`) hatten schon einen `IsDeleted`-Guard, die globalen Listen jedoch nicht.

## Tests
- Backend: 3 neue Integration-Tests (gelöschte Schule, gelöschte Org, Org-Detail mit Papierkorb-Org) plus 1 Repo-Test inkl. Restore-Roundtrip.
- Frontend: 4 neue Vitest-Cases für `useOrgSchoolFilter`.
- Coverage auf neuem Code: Backend 6/6, Frontend-Hook 7/7 — über dem 85%-Gate.

## Test plan
- [x] `docker compose build server && docker compose up -d server`, Operator-Login
- [x] `/operator/devices`: gelöschte Schule weder in Tabelle noch im Filter-Dropdown; „Neues Gerät anlegen" → Schul-Dropdown papierkorb-frei
- [x] `/operator/accounts`: Accounts und offene Einladungen der gelöschten Schule fehlen; Filter-Dropdown papierkorb-frei
- [x] `/operator/persons`: Filter-Dropdown papierkorb-frei

## Hinweis zum Knip-Commit
Enthält einen mitgenommenen Cherry-Pick (`4bb84376 chore(frontend): drop unused export on TransitAssignResult`), weil der Lefthook-`frontend-knip` sonst auf dem aktuellen `development`-Stand jeden Push blockiert. Derselbe Fix existiert parallel auf `feat/1308-2fa-email` und `feat/room-history-aggregated` — wer zuerst gemerged wird, gewinnt; die anderen droppen ihn beim Rebase.