### PR TITLE
Fix/enrollment followups

### DIFF
--- a/backend/database/migrations/001015076_submission_rate_limits_add_updated_at.go
+++ b/backend/database/migrations/001015076_submission_rate_limits_add_updated_at.go
@@ -1,0 +1,46 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	submissionRateLimitsAddUpdatedAtVersion     = "1.15.76"
+	submissionRateLimitsAddUpdatedAtDescription = "Add updated_at column to enrollment.submission_rate_limits for existing databases created before the rate-limit table included base.Model timestamps"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     submissionRateLimitsAddUpdatedAtVersion,
+		Description: submissionRateLimitsAddUpdatedAtDescription,
+		DependsOn: []string{
+			createEnrollmentRateLimitsVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Migration 1.15.76: Adding updated_at to enrollment.submission_rate_limits...")
+			if _, err := db.NewRaw(`
+				ALTER TABLE enrollment.submission_rate_limits
+				ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed adding updated_at to enrollment.submission_rate_limits: %w", err)
+			}
+			return nil
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Rolling back migration 1.15.76...")
+			if _, err := db.NewRaw(`
+				ALTER TABLE enrollment.submission_rate_limits
+				DROP COLUMN IF EXISTS updated_at;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed dropping updated_at from enrollment.submission_rate_limits: %w", err)
+			}
+			return nil
+		},
+	)
+}

--- a/backend/database/migrations/001015077_submission_rate_limits_backfill_rls.go
+++ b/backend/database/migrations/001015077_submission_rate_limits_backfill_rls.go
@@ -1,0 +1,67 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	submissionRateLimitsBackfillRLSVersion     = "1.15.77"
+	submissionRateLimitsBackfillRLSDescription = "Backfill RLS policy on enrollment.submission_rate_limits for databases that ran the pre-amendment 1.15.66 (which created the table without RLS). Idempotent: no-op on databases that already have the policy from the amended 1.15.66."
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     submissionRateLimitsBackfillRLSVersion,
+		Description: submissionRateLimitsBackfillRLSDescription,
+		DependsOn: []string{
+			submissionRateLimitsAddUpdatedAtVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Migration 1.15.77: Backfilling RLS policy on enrollment.submission_rate_limits...")
+
+			// ENABLE / FORCE ROW LEVEL SECURITY are idempotent: re-running
+			// them on a table that already has RLS active is a no-op.
+			// DROP POLICY IF EXISTS + CREATE POLICY guarantees the policy
+			// matches the canonical definition even if a partial / stale
+			// version is sitting on the table.
+			//
+			// Background: migration 1.15.66 originally created
+			// enrollment.submission_rate_limits without RLS. The
+			// amendment to 1.15.66 added RLS in-place, but the bun
+			// migration registry skips migrations whose version is
+			// already in bun_migrations, so any DB that ran the
+			// pre-amendment 1.15.66 never got the policy. This
+			// migration closes that drift between fresh and pre-existing
+			// databases.
+			if _, err := db.NewRaw(`
+				ALTER TABLE enrollment.submission_rate_limits ENABLE ROW LEVEL SECURITY;
+				ALTER TABLE enrollment.submission_rate_limits FORCE ROW LEVEL SECURITY;
+				DROP POLICY IF EXISTS tenant_isolation_submission_rate_limits ON enrollment.submission_rate_limits;
+				CREATE POLICY tenant_isolation_submission_rate_limits ON enrollment.submission_rate_limits
+					FOR ALL
+					USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+					WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed backfilling RLS on enrollment.submission_rate_limits: %w", err)
+			}
+			return nil
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Rolling back migration 1.15.77: dropping tenant_isolation_submission_rate_limits policy...")
+			// Best-effort rollback: drop the policy but leave RLS enabled
+			// (other migrations may rely on the FORCE flag).
+			if _, err := db.NewRaw(`
+				DROP POLICY IF EXISTS tenant_isolation_submission_rate_limits ON enrollment.submission_rate_limits;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed dropping tenant_isolation_submission_rate_limits policy: %w", err)
+			}
+			return nil
+		},
+	)
+}

--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
@@ -1273,6 +1274,7 @@ func (s *decisionService) dispatchWeekdaySchedule(ctx context.Context, raw any, 
 		if err != nil {
 			return fmt.Errorf("parse %s time %q: %w", day, hhmm, err)
 		}
+		t = timezone.WallClock(t)
 		if isPickup {
 			row := &scheduleModels.StudentPickupSchedule{
 				StudentID:  studentID,

--- a/frontend/src/components/enrollment/enrollment-form-editor.tsx
+++ b/frontend/src/components/enrollment/enrollment-form-editor.tsx
@@ -60,6 +60,21 @@ const fieldTypeLabels: Record<FormFieldType, string> = {
   contact_list: "Kontaktliste",
 };
 
+const freeFieldTypes = [
+  "boolean",
+  "number",
+  "text",
+  "textarea",
+  "date",
+  "select",
+] satisfies FormFieldType[];
+
+const structuredFieldTypes = new Set<FormFieldType>([
+  "phone_list",
+  "weekday_schedule",
+  "contact_list",
+]);
+
 // Labels for the answer storage picker. Admins can still rename the
 // displayed question; the target decides whether the answer is copied
 // into student data, schedule data, or contacts at approval time.
@@ -1850,7 +1865,7 @@ function FieldEditorRow({
               </span>
               <input
                 type="text"
-                value={displayLabel}
+                value={isTargetField ? displayLabel : field.label}
                 onChange={(event) => {
                   const nextLabel = event.target.value;
                   const currentAutoKey = normalizeFieldKey(field.label);
@@ -1885,9 +1900,12 @@ function FieldEditorRow({
                 disabled={disabled || isTargetField}
                 className="moto-select moto-content-surface mt-1 h-10 w-full rounded-lg border px-3 text-sm shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none disabled:bg-gray-100 disabled:text-gray-600"
               >
-                {Object.entries(fieldTypeLabels).map(([value, label]) => (
+                {(isTargetField
+                  ? (Object.keys(fieldTypeLabels) as FormFieldType[])
+                  : freeFieldTypes
+                ).map((value) => (
                   <option key={value} value={value}>
-                    {label}
+                    {fieldTypeLabels[value]}
                   </option>
                 ))}
               </select>
@@ -2408,6 +2426,10 @@ function getSchemaDraftValidationMessage({
       return `Bitte ändere Frage ${questionNumber}. Zwei Zusatzfragen haben denselben oder einen zu ähnlichen Fragetext.`;
     }
     seenKeys.add(key);
+
+    if (!field.target && structuredFieldTypes.has(field.type)) {
+      return `Bitte wähle für Frage ${questionNumber} einen einfachen Typ. Telefonlisten, Wochenzeiten und Kontaktlisten sind nur als feste Vorschläge verfügbar.`;
+    }
 
     if (field.type === "select" && (field.options ?? []).length === 0) {
       return `Bitte ergänze für Frage ${questionNumber} mindestens eine Auswahloption.`;


### PR DESCRIPTION
Bugs gefunden beim Testen und gefixt 1. Zusatzfelder hat falsche Feldtypen erlaubt 2. enrollment rate limit hatte kein update spalte in der db 3. wenn man Abholzeiten im Formular eingegeben hat, kam es im Backend zu einem Fehler