### PR TITLE
fix(students): start detail and history pages at top instead of inheriting list scroll

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/students/[id]/feedback_history/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/feedback_history/page.tsx
@@ -7,6 +7,7 @@ import { Alert } from "~/components/ui/alert";
 import { useSession } from "next-auth/react";
 import { getStartDateForTimeRange } from "~/lib/date-helpers";
 import { useStudentHistoryBreadcrumb } from "~/lib/breadcrumb-context";
+import { useScrollToTop } from "~/lib/hooks/use-scroll-to-top";
 import { BackButton } from "~/components/ui/back-button";
 import { Loading } from "~/components/ui/loading";
 import { createLogger } from "~/lib/logger";
@@ -68,6 +69,9 @@ export default function StudentFeedbackHistoryPage() {
   const [showDetails, setShowDetails] = useState(false);
 
   useStudentHistoryBreadcrumb({ studentName: student?.name, referrer });
+
+  // Start at the top instead of inheriting the previous page's scroll position
+  useScrollToTop(studentId);
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   useStudentData,
   type ExtendedStudent,
 } from "~/lib/hooks/use-student-data";
+import { useScrollToTop } from "~/lib/hooks/use-scroll-to-top";
 import { useSWRAuth } from "~/lib/swr";
 import type { SupervisorContact } from "~/lib/student-helpers";
 import {
@@ -65,6 +66,10 @@ export default function StudentDetailPage() {
   const studentId = params.id as string;
   const referrer = searchParams.get("from") ?? "/students/search";
   const toast = useToast();
+
+  // Start at the top instead of inheriting the search list's scroll position
+  // (Next App Router maintains scroll when the new page is already in view).
+  useScrollToTop(studentId);
 
   // Use custom hook for data fetching
   const {

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/page.tsx
@@ -16,6 +16,7 @@ import { BackButton } from "~/components/ui/back-button";
 import { Alert } from "~/components/ui/alert";
 import { Loading } from "~/components/ui/loading";
 import { useStudentHistoryBreadcrumb } from "~/lib/breadcrumb-context";
+import { useScrollToTop } from "~/lib/hooks/use-scroll-to-top";
 import { createLogger } from "~/lib/logger";
 import {
   type AttendanceHistory,
@@ -663,10 +664,8 @@ function StudentRoomHistoryPageContent() {
 
   useStudentHistoryBreadcrumb({ studentName: student?.name, referrer });
 
-  // Scroll to top on mount — prevents inheriting scroll position from previous page
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
+  // Start at the top instead of inheriting the previous page's scroll position
+  useScrollToTop(studentId);
 
   const fetchStudent = useCallback(async (): Promise<Student | null> => {
     try {

--- a/frontend/src/lib/hooks/use-scroll-to-top.test.ts
+++ b/frontend/src/lib/hooks/use-scroll-to-top.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { useScrollToTop } from "./use-scroll-to-top";
+
+describe("useScrollToTop", () => {
+  let originalScrollTo: typeof window.scrollTo;
+  let scrollTo: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalScrollTo = window.scrollTo;
+    scrollTo = vi.fn();
+    window.scrollTo = scrollTo as unknown as typeof window.scrollTo;
+  });
+
+  afterEach(() => {
+    window.scrollTo = originalScrollTo;
+  });
+
+  it("scrolls to the top on mount", () => {
+    renderHook(() => useScrollToTop("student-1"));
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it("scrolls again when the key changes (e.g. switching students in place)", () => {
+    const { rerender } = renderHook(({ k }) => useScrollToTop(k), {
+      initialProps: { k: "student-1" },
+    });
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+
+    rerender({ k: "student-2" });
+    expect(scrollTo).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not scroll again on re-render when the key is unchanged", () => {
+    const { rerender } = renderHook(({ k }) => useScrollToTop(k), {
+      initialProps: { k: "student-1" },
+    });
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+
+    // Re-render with the same key — the keyed effect must not re-fire, so a
+    // normal re-render (state update, parent re-render) never yanks the user
+    // back to the top mid-scroll.
+    rerender({ k: "student-1" });
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("still scrolls to the top on mount when no key is provided", () => {
+    renderHook(() => useScrollToTop());
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+});

--- a/frontend/src/lib/hooks/use-scroll-to-top.ts
+++ b/frontend/src/lib/hooks/use-scroll-to-top.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Scrolls the window to the top on mount, and again whenever `key` changes.
+ *
+ * Why this is needed: Next.js App Router intentionally *maintains* the scroll
+ * position on navigation when the new Page is already visible in the viewport
+ * (see the `<Link>` scroll docs). Navigating from a scrolled-down list (e.g.
+ * `/students/search`) to a long detail page in the same layout therefore lands
+ * the user mid-page instead of at the top. Running `window.scrollTo(0, 0)` in
+ * an effect overrides Next's handler (our effect runs after it) without
+ * touching the global navigation, so back/forward scroll restoration on other
+ * routes stays intact.
+ *
+ * Pass the route's identifying value (e.g. a student id) as `key` so the reset
+ * also fires when navigating between two instances of the same route segment —
+ * in that case the component does NOT remount, so a bare mount effect (`[]`)
+ * would not fire.
+ *
+ * SSR-safe: the effect only runs in the browser.
+ */
+export function useScrollToTop(key?: unknown): void {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [key]);
+}


### PR DESCRIPTION
## Problem

Closes #1461.

Next.js App Router keeps the current scroll position on navigation when the new page is already visible in the viewport. Scrolling down the student search list and clicking a child therefore opened the detail page mid-scroll, with the name/photo/status header off-screen. The same happened opening the **room-history** and **feedback-history** sub-pages from a scrolled detail page.

## Fix

- New reusable `useScrollToTop(key)` hook (`lib/hooks/use-scroll-to-top.ts`): `window.scrollTo(0, 0)` in an effect keyed on a stable id. Keyed (not bare `[]`) so it also fires when switching between students in place (no remount) — but **not** on unrelated re-renders.
- Applied to `students/[id]` (detail), `room-history`, and `feedback_history`. Replaces room-history's inline `useEffect` workaround.
- Unit test covers: mount fire, key-change re-fire, same-key no-op, no-key mount.

## Why it's safe for back/forward

The hook is keyed on the student id and Next's router cache preserves the page instance, so browser **back** still restores the previous scroll position (verified live: returning to a detail page restored to its prior offset, not 0). A layout/`template`-level handler keyed on `pathname` would *not* be safe — it would re-fire on back-navigation and clobber restoration.

## Verification

Driven live in the browser (demo-school, real client-side navigation):
- Search list scrolled to y=3000 → click child → detail page at **y=0**, header visible.
- Detail scrolled → room-history (client-side) → **y=0**.
- Detail scrolled → feedback-history (client-side) → **y=0**.
- Back-navigation into a detail page **restores** the prior scroll (no regression).

`pnpm run check` green (0 warnings / 0 errors); new hook test + existing room-history scroll test pass.

## Out of scope

Operator and parents portals have structurally similar full-page detail views reached from scrollable lists; left out of this PR by decision. Most tenant detail views use modals/slide-overs and aren't affected.