### PR TITLE
fix: neutrale Abhol/Ankuftszeit für kranke/entschuldigte Kinder statt roter Überfällig-Zeit

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.test.tsx
@@ -182,12 +182,15 @@ vi.mock("~/components/students/student-card", () => ({
   StudentCard: ({
     firstName,
     lastName,
+    extraContent,
   }: {
     firstName: string;
     lastName: string;
+    extraContent?: React.ReactNode;
   }) => (
     <div data-testid="student-card">
       {firstName} {lastName}
+      {extraContent}
     </div>
   ),
   StudentInfoRow: ({ children }: { children: React.ReactNode }) => (
@@ -245,6 +248,9 @@ vi.mock("~/components/students/student-card", () => ({
       {!isAbsent && !arrivalTime && <>Ankunftszeit: —</>}
       {notes && <span>({notes})</span>}
     </div>
+  ),
+  StudentAbsenceRow: ({ label }: { label: string }) => (
+    <div data-testid="student-absence-row">Kommt heute nicht ({label})</div>
   ),
 }));
 
@@ -312,6 +318,64 @@ describe("MeinRaumPage (Active Supervisions)", () => {
     render(<MeinRaumPage />);
 
     expect(screen.getByTestId("sse-boundary")).toBeInTheDocument();
+  });
+
+  it("keeps a sick checked-in room student out of the overdue pickup row", async () => {
+    vi.mocked(useSWRAuth)
+      .mockReturnValueOnce({
+        data: {
+          supervisedGroups: [
+            {
+              id: "g1",
+              name: "OGS",
+              room_id: "r1",
+              room: { id: "r1", name: "Raum A" },
+            },
+          ],
+          unclaimedGroups: [],
+          currentStaff: { id: "staff-1" },
+          educationalGroups: [
+            { id: "eg1", name: "OGS", room: { name: "Raum A" } },
+          ],
+          firstRoomVisits: [
+            {
+              studentId: "s1",
+              studentName: "Kerstin Krank",
+              schoolClass: "1a",
+              groupName: "OGS",
+              activeGroupId: "g1",
+              checkInTime: "2026-01-15T08:05:00.000Z",
+              actualArrivalTime: "08:05",
+              actualPickupTime: undefined,
+              isActive: true,
+              sick: true,
+            },
+          ],
+          firstRoomId: "r1",
+          schulhofStatus: null,
+          plannedNow: [],
+        },
+        isLoading: false,
+        error: null,
+        mutate: mockMutate,
+        isValidating: false,
+      } as never)
+      .mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: null,
+        mutate: mockMutate,
+        isValidating: false,
+      } as never);
+
+    render(<MeinRaumPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Kommt heute nicht (krank gemeldet)"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("pickup-time-row")).not.toBeInTheDocument();
   });
 
   it("shows no access state when user has no active supervision", async () => {

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -1710,7 +1710,7 @@ function MeinRaumPageContent() {
                           sick: student.sick,
                           excused: student.excused,
                         });
-                        if (absence && !student.actual_arrival_time) {
+                        if (absence && !student.actual_pickup_time) {
                           return <StudentAbsenceRow label={absence.label} />;
                         }
                         return (

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -29,6 +29,7 @@ import {
   GroupIcon,
   PickupTimeRow,
   ArrivalTimeRow,
+  StudentAbsenceRow,
 } from "~/components/students/student-card";
 import { fetchBulkPickupTimes } from "~/lib/pickup-schedule-api";
 import type { BulkPickupTime } from "~/lib/pickup-schedule-api";
@@ -55,7 +56,7 @@ import {
 import { UnclaimedRooms } from "~/components/active";
 import { SSEErrorBoundary } from "~/components/sse/SSEErrorBoundary";
 import { useSWRAuth } from "~/lib/swr";
-import { combineTimeNotes } from "~/lib/student-time-status";
+import { combineTimeNotes, getStudentAbsence } from "~/lib/student-time-status";
 import {
   ActiveSupervisionLoadingView,
   EmptyRoomsView,
@@ -1704,38 +1705,51 @@ function MeinRaumPageContent() {
                           Gruppe: {student.group_name}
                         </StudentInfoRow>
                       )}
-                      <ArrivalTimeRow
-                        arrivalTime={studentArrival?.expectedArrival}
-                        actualTime={student.actual_arrival_time}
-                        isException={studentArrival?.isException ?? false}
-                        isAbsent={
-                          (studentArrival?.isException ?? false) &&
-                          !studentArrival?.expectedArrival
+                      {(() => {
+                        const absence = getStudentAbsence({
+                          sick: student.sick,
+                          excused: student.excused,
+                        });
+                        if (absence && !student.actual_arrival_time) {
+                          return <StudentAbsenceRow label={absence.label} />;
                         }
-                        notes={
-                          studentArrival
-                            ? combineTimeNotes(
-                                studentArrival.notes,
-                                studentArrival.dayNotes,
-                              )
-                            : undefined
-                        }
-                        now={now}
-                      />
-                      <PickupTimeRow
-                        pickupTime={studentPickup?.pickupTime}
-                        actualTime={student.actual_pickup_time}
-                        isException={studentPickup?.isException ?? false}
-                        notes={
-                          studentPickup
-                            ? combineTimeNotes(
-                                studentPickup.notes,
-                                studentPickup.dayNotes,
-                              )
-                            : undefined
-                        }
-                        now={now}
-                      />
+                        return (
+                          <>
+                            <ArrivalTimeRow
+                              arrivalTime={studentArrival?.expectedArrival}
+                              actualTime={student.actual_arrival_time}
+                              isException={studentArrival?.isException ?? false}
+                              isAbsent={
+                                (studentArrival?.isException ?? false) &&
+                                !studentArrival?.expectedArrival
+                              }
+                              notes={
+                                studentArrival
+                                  ? combineTimeNotes(
+                                      studentArrival.notes,
+                                      studentArrival.dayNotes,
+                                    )
+                                  : undefined
+                              }
+                              now={now}
+                            />
+                            <PickupTimeRow
+                              pickupTime={studentPickup?.pickupTime}
+                              actualTime={student.actual_pickup_time}
+                              isException={studentPickup?.isException ?? false}
+                              notes={
+                                studentPickup
+                                  ? combineTimeNotes(
+                                      studentPickup.notes,
+                                      studentPickup.dayNotes,
+                                    )
+                                  : undefined
+                              }
+                              now={now}
+                            />
+                          </>
+                        );
+                      })()}
                     </>
                   }
                   trackingIndicators={

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -346,6 +346,9 @@ vi.mock("~/components/students/student-card", () => ({
       {notes && <span>({notes})</span>}
     </div>
   ),
+  StudentAbsenceRow: ({ label }: { label: string }) => (
+    <div data-testid="student-absence-row">Kommt heute nicht ({label})</div>
+  ),
 }));
 
 // Mock pickup schedule API
@@ -2581,6 +2584,7 @@ describe("OGSGroupPage rendered pickup urgency", () => {
       string,
       { actualArrivalTime?: string; actualPickupTime?: string }
     >,
+    studentOverrides?: Record<string, Record<string, unknown>>,
   ) {
     vi.clearAllMocks();
     // Re-freeze time after clearAllMocks since it may reset fake timers state
@@ -2633,6 +2637,7 @@ describe("OGSGroupPage rendered pickup urgency", () => {
               current_location: "Raum 101",
               actual_arrival_time: studentActuals?.["1"]?.actualArrivalTime,
               actual_pickup_time: studentActuals?.["1"]?.actualPickupTime,
+              ...studentOverrides?.["1"],
             },
             {
               id: "2",
@@ -2642,6 +2647,7 @@ describe("OGSGroupPage rendered pickup urgency", () => {
               current_location: "Raum 101",
               actual_arrival_time: studentActuals?.["2"]?.actualArrivalTime,
               actual_pickup_time: studentActuals?.["2"]?.actualPickupTime,
+              ...studentOverrides?.["2"],
             },
             {
               id: "3",
@@ -2651,6 +2657,7 @@ describe("OGSGroupPage rendered pickup urgency", () => {
               current_location: "Zuhause",
               actual_arrival_time: studentActuals?.["3"]?.actualArrivalTime,
               actual_pickup_time: studentActuals?.["3"]?.actualPickupTime,
+              ...studentOverrides?.["3"],
             },
           ],
           roomStatus: {
@@ -2749,6 +2756,33 @@ describe("OGSGroupPage rendered pickup urgency", () => {
       .find((el) => el.dataset.pickupTime === "14:00");
     expect(row).toBeDefined();
     expect(row?.dataset.actualTime).toBe("14:07");
+  });
+
+  it("suppresses overdue pickup when an already-arrived student is later marked sick", async () => {
+    const pickupMap = new Map([
+      ["1", { pickupTime: "13:00", isException: false }],
+    ]);
+    setupWithStudentsAndPickupTimes(
+      pickupMap,
+      undefined,
+      { "1": { actualArrivalTime: "08:03" } },
+      { "1": { sick: true } },
+    );
+
+    render(<OGSGroupPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card")).toHaveLength(3);
+    });
+
+    expect(
+      screen.getByText("Kommt heute nicht (krank gemeldet)"),
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getAllByTestId("pickup-time-row")
+        .some((el) => el.dataset.pickupTime === "13:00"),
+    ).toBe(false);
   });
 
   it("renders sort filter with Alphabetisch and Nächste Abholung options", async () => {

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -2785,6 +2785,33 @@ describe("OGSGroupPage rendered pickup urgency", () => {
     ).toBe(false);
   });
 
+  it("shows the resolved pickup time, not the absence row, when a sick student is already picked up", async () => {
+    const pickupMap = new Map([
+      ["1", { pickupTime: "13:00", isException: false }],
+    ]);
+    setupWithStudentsAndPickupTimes(
+      pickupMap,
+      undefined,
+      { "1": { actualPickupTime: "13:05" } },
+      { "1": { sick: true } },
+    );
+
+    render(<OGSGroupPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card")).toHaveLength(3);
+    });
+
+    expect(
+      screen.queryByText("Kommt heute nicht (krank gemeldet)"),
+    ).not.toBeInTheDocument();
+    const row = screen
+      .getAllByTestId("pickup-time-row")
+      .find((el) => el.dataset.pickupTime === "13:00");
+    expect(row).toBeDefined();
+    expect(row?.dataset.actualTime).toBe("13:05");
+  });
+
   it("renders sort filter with Alphabetisch and Nächste Abholung options", async () => {
     setupWithStudentsAndPickupTimes(new Map());
 

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -1299,7 +1299,7 @@ function OGSGroupPageContent() {
                   }
                   extraContent={
                     <>
-                      {studentAbsence ? (
+                      {studentAbsence && !student.actual_pickup_time ? (
                         <StudentAbsenceRow label={studentAbsence.label} />
                       ) : (
                         <>

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -50,6 +50,7 @@ import {
   StudentCard,
   PickupTimeRow,
   ArrivalTimeRow,
+  StudentAbsenceRow,
 } from "~/components/students/student-card";
 import { SchoolCheckinFab } from "~/components/students/school-checkin-fab";
 import { SchoolCheckinModeMobile } from "~/components/students/school-checkin-mode-mobile";
@@ -67,6 +68,7 @@ import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
 import { TrackingIndicators } from "~/components/students/tracking-indicators";
 import {
   combineTimeNotes,
+  getStudentAbsence,
   getStudentTimeStatus,
   getTimeStatusSortRank,
 } from "~/lib/student-time-status";
@@ -98,7 +100,6 @@ interface BackendStudentFromBFF {
   current_room_color?: string | null;
   sick?: boolean;
   sick_since?: string;
-  sick_until?: string;
   excused?: boolean;
   excused_since?: string;
   location_since?: string;
@@ -912,11 +913,15 @@ function OGSGroupPageContent() {
           plannedTime: timeA,
           actualTime: a.actual_pickup_time,
           now,
+          sick: a.sick,
+          excused: a.excused,
         });
         const statusB = getStudentTimeStatus({
           plannedTime: timeB,
           actualTime: b.actual_pickup_time,
           now,
+          sick: b.sick,
+          excused: b.excused,
         });
         const rankA = getTimeStatusSortRank(statusA);
         const rankB = getTimeStatusSortRank(statusB);
@@ -950,11 +955,15 @@ function OGSGroupPageContent() {
           plannedTime: timeA,
           actualTime: a.actual_arrival_time,
           now,
+          sick: a.sick,
+          excused: a.excused,
         });
         const statusB = getStudentTimeStatus({
           plannedTime: timeB,
           actualTime: b.actual_arrival_time,
           now,
+          sick: b.sick,
+          excused: b.excused,
         });
         const rankA = getTimeStatusSortRank(statusA);
         const rankB = getTimeStatusSortRank(statusB);
@@ -1247,6 +1256,10 @@ function OGSGroupPageContent() {
               const inGroupRoom = isStudentInGroupRoom(student, currentGroup);
               const cardGradient = getCardGradient(student);
               const studentPickup = pickupTimes.get(student.id.toString());
+              const studentAbsence = getStudentAbsence({
+                sick: student.sick,
+                excused: student.excused,
+              });
 
               const checkinState = deriveCheckinState(student.current_location);
               const studentIdStr = student.id.toString();
@@ -1286,31 +1299,37 @@ function OGSGroupPageContent() {
                   }
                   extraContent={
                     <>
-                      <ArrivalTimeRow
-                        arrivalTime={student.arrival_time}
-                        actualTime={student.actual_arrival_time}
-                        isException={student.arrival_is_exception ?? false}
-                        isAbsent={
-                          (student.arrival_is_exception ?? false) &&
-                          !student.arrival_time
-                        }
-                        notes={student.arrival_notes}
-                        now={now}
-                      />
-                      <PickupTimeRow
-                        pickupTime={studentPickup?.pickupTime}
-                        actualTime={student.actual_pickup_time}
-                        isException={studentPickup?.isException ?? false}
-                        notes={
-                          studentPickup
-                            ? combineTimeNotes(
-                                studentPickup.notes,
-                                studentPickup.dayNotes,
-                              )
-                            : undefined
-                        }
-                        now={now}
-                      />
+                      {studentAbsence && !student.actual_arrival_time ? (
+                        <StudentAbsenceRow label={studentAbsence.label} />
+                      ) : (
+                        <>
+                          <ArrivalTimeRow
+                            arrivalTime={student.arrival_time}
+                            actualTime={student.actual_arrival_time}
+                            isException={student.arrival_is_exception ?? false}
+                            isAbsent={
+                              (student.arrival_is_exception ?? false) &&
+                              !student.arrival_time
+                            }
+                            notes={student.arrival_notes}
+                            now={now}
+                          />
+                          <PickupTimeRow
+                            pickupTime={studentPickup?.pickupTime}
+                            actualTime={student.actual_pickup_time}
+                            isException={studentPickup?.isException ?? false}
+                            notes={
+                              studentPickup
+                                ? combineTimeNotes(
+                                    studentPickup.notes,
+                                    studentPickup.dayNotes,
+                                  )
+                                : undefined
+                            }
+                            now={now}
+                          />
+                        </>
+                      )}
                       {/* Check-in-only avatar-clearance spacer — in navigation
                           mode this surface now opts into an in-flow bottom row
                           (hint + avatar), so the card grows naturally. The

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -1299,7 +1299,7 @@ function OGSGroupPageContent() {
                   }
                   extraContent={
                     <>
-                      {studentAbsence && !student.actual_arrival_time ? (
+                      {studentAbsence ? (
                         <StudentAbsenceRow label={studentAbsence.label} />
                       ) : (
                         <>

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -735,6 +735,40 @@ describe("StudentSearchPage", () => {
       });
     });
 
+    it("collapses a sick student's time rows into one neutral 'not coming' line (Variant B)", async () => {
+      const swrModule = await import("~/lib/swr");
+      mockUseSWRAuthWithStudents(swrModule, {
+        data: {
+          students: [
+            {
+              ...mockStudents[0]!,
+              first_name: "Kerstin",
+              current_location: "Zuhause",
+              arrival_time: "08:00",
+              pickup_time: "15:30",
+              actual_arrival_time: undefined,
+              sick: true,
+              has_full_access: true,
+            },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Kommt heute nicht (krank gemeldet)"),
+        ).toBeInTheDocument();
+      });
+      // The two time rows are replaced by the single absence line — no red
+      // "overdue" arrival/pickup for a child who isn't coming today.
+      expect(screen.queryByText(/Ankunftszeit:/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Abholzeit:/)).not.toBeInTheDocument();
+    });
+
     it("filters to show only transit students when 'unterwegs' is selected", async () => {
       mockSearchParams.set("status", "unterwegs");
 

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -769,6 +769,38 @@ describe("StudentSearchPage", () => {
       expect(screen.queryByText(/Abholzeit:/)).not.toBeInTheDocument();
     });
 
+    it("keeps a sick checked-in student out of the overdue pickup row", async () => {
+      const swrModule = await import("~/lib/swr");
+      mockUseSWRAuthWithStudents(swrModule, {
+        data: {
+          students: [
+            {
+              ...mockStudents[0]!,
+              first_name: "Kerstin",
+              current_location: "Raum 101",
+              arrival_time: "08:00",
+              pickup_time: "15:30",
+              actual_arrival_time: "08:05",
+              actual_pickup_time: undefined,
+              sick: true,
+              has_full_access: true,
+            },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Kommt heute nicht (krank gemeldet)"),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/Abholzeit:/)).not.toBeInTheDocument();
+    });
+
     it("filters to show only transit students when 'unterwegs' is selected", async () => {
       mockSearchParams.set("status", "unterwegs");
 

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -1535,7 +1535,7 @@ function SearchPageContent() {
                           sick: student.sick,
                           excused: student.excused,
                         });
-                        if (absence && !student.actual_arrival_time) {
+                        if (absence && !student.actual_pickup_time) {
                           return <StudentAbsenceRow label={absence.label} />;
                         }
                         return (

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -1265,6 +1265,24 @@ function SearchPageContent() {
 
     return [...filteredStudents].sort((a, b) => {
       if (sortMode === "pickup") {
+        const statusA = getStudentTimeStatus({
+          plannedTime: a.pickup_time,
+          actualTime: a.actual_pickup_time,
+          now,
+          sick: a.sick,
+          excused: a.excused,
+        });
+        const statusB = getStudentTimeStatus({
+          plannedTime: b.pickup_time,
+          actualTime: b.actual_pickup_time,
+          now,
+          sick: b.sick,
+          excused: b.excused,
+        });
+        const rankA = getTimeStatusSortRank(statusA);
+        const rankB = getTimeStatusSortRank(statusB);
+        if (rankA !== rankB) return rankA - rankB;
+
         const timeA = a.pickup_time;
         const timeB = b.pickup_time;
         if (timeA && !timeB) return -1;

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -39,6 +39,7 @@ import {
   StudentInfoRow,
   PickupTimeRow,
   ArrivalTimeRow,
+  StudentAbsenceRow,
 } from "~/components/students/student-card";
 import { SchoolCheckinFab } from "~/components/students/school-checkin-fab";
 import { SchoolCheckinModeMobile } from "~/components/students/school-checkin-mode-mobile";
@@ -54,6 +55,7 @@ import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
 import { TrackingIndicators } from "~/components/students/tracking-indicators";
 import { createLogger } from "~/lib/logger";
 import {
+  getStudentAbsence,
   getStudentTimeStatus,
   getTimeStatusSortRank,
 } from "~/lib/student-time-status";
@@ -1283,11 +1285,15 @@ function SearchPageContent() {
         plannedTime: a.arrival_time,
         actualTime: a.actual_arrival_time,
         now,
+        sick: a.sick,
+        excused: a.excused,
       });
       const statusB = getStudentTimeStatus({
         plannedTime: b.arrival_time,
         actualTime: b.actual_arrival_time,
         now,
+        sick: b.sick,
+        excused: b.excused,
       });
       const rankA = getTimeStatusSortRank(statusA);
       const rankB = getTimeStatusSortRank(statusB);
@@ -1523,28 +1529,40 @@ function SearchPageContent() {
                         Gruppe: {student.group_name}
                       </StudentInfoRow>
                     )}
-                    {student.has_full_access !== false && (
-                      <>
-                        <ArrivalTimeRow
-                          arrivalTime={student.arrival_time}
-                          actualTime={student.actual_arrival_time}
-                          isException={student.arrival_is_exception ?? false}
-                          isAbsent={
-                            (student.arrival_is_exception ?? false) &&
-                            !student.arrival_time
-                          }
-                          notes={student.arrival_notes}
-                          now={now}
-                        />
-                        <PickupTimeRow
-                          pickupTime={student.pickup_time ?? undefined}
-                          actualTime={student.actual_pickup_time}
-                          isException={student.pickup_is_exception ?? false}
-                          notes={student.pickup_notes}
-                          now={now}
-                        />
-                      </>
-                    )}
+                    {student.has_full_access !== false &&
+                      (() => {
+                        const absence = getStudentAbsence({
+                          sick: student.sick,
+                          excused: student.excused,
+                        });
+                        if (absence && !student.actual_arrival_time) {
+                          return <StudentAbsenceRow label={absence.label} />;
+                        }
+                        return (
+                          <>
+                            <ArrivalTimeRow
+                              arrivalTime={student.arrival_time}
+                              actualTime={student.actual_arrival_time}
+                              isException={
+                                student.arrival_is_exception ?? false
+                              }
+                              isAbsent={
+                                (student.arrival_is_exception ?? false) &&
+                                !student.arrival_time
+                              }
+                              notes={student.arrival_notes}
+                              now={now}
+                            />
+                            <PickupTimeRow
+                              pickupTime={student.pickup_time ?? undefined}
+                              actualTime={student.actual_pickup_time}
+                              isException={student.pickup_is_exception ?? false}
+                              notes={student.pickup_notes}
+                              now={now}
+                            />
+                          </>
+                        );
+                      })()}
                   </>
                 }
                 trackingIndicators={

--- a/frontend/src/app/api/ogs-dashboard/route.ts
+++ b/frontend/src/app/api/ogs-dashboard/route.ts
@@ -32,7 +32,6 @@ interface BackendStudent {
   current_room_color?: string | null;
   sick?: boolean;
   sick_since?: string;
-  sick_until?: string;
   excused?: boolean;
   excused_since?: string;
   location_since?: string;

--- a/frontend/src/components/students/student-card.test.tsx
+++ b/frontend/src/components/students/student-card.test.tsx
@@ -1,12 +1,14 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  AbsenceIcon,
   ArrivalTimeRow,
   ExceptionIcon,
   GroupIcon,
   PickupTimeIcon,
   PickupTimeRow,
   SchoolClassIcon,
+  StudentAbsenceRow,
   StudentCard,
   StudentInfoRow,
 } from "./student-card";
@@ -421,6 +423,17 @@ describe("ExceptionIcon", () => {
   });
 });
 
+describe("AbsenceIcon", () => {
+  it("renders a neutral gray clock, not an amber/orange warning", () => {
+    const { container } = render(<AbsenceIcon />);
+
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+    expect(svg?.className).toContain("text-gray-400");
+    expect(svg?.className).not.toContain("text-orange-500");
+  });
+});
+
 describe("PickupTimeRow", () => {
   const now = new Date("2025-01-15T14:00:00");
 
@@ -610,6 +623,33 @@ describe("ArrivalTimeRow", () => {
     render(<ArrivalTimeRow isException={false} isAbsent={false} now={now} />);
 
     expect(screen.getByText("Ankunftszeit: —")).toBeInTheDocument();
+  });
+});
+
+describe("StudentAbsenceRow", () => {
+  it("renders a single neutral 'not coming' line for a sick student", () => {
+    const { container } = render(<StudentAbsenceRow label="krank gemeldet" />);
+
+    expect(
+      screen.getByText("Kommt heute nicht (krank gemeldet)"),
+    ).toBeInTheDocument();
+    // Neutral gray clock — a known absence is information, not a warning. Never
+    // the amber exception triangle, never the red overdue warning.
+    expect(container.querySelector("svg.text-gray-400")).toBeInTheDocument();
+    expect(
+      container.querySelector("svg.text-orange-500"),
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector("svg.lucide-triangle-alert"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the excused label", () => {
+    render(<StudentAbsenceRow label="entschuldigt" />);
+
+    expect(
+      screen.getByText("Kommt heute nicht (entschuldigt)"),
+    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/students/student-card.tsx
+++ b/frontend/src/components/students/student-card.tsx
@@ -371,6 +371,17 @@ export function ExceptionIcon() {
 }
 
 /**
+ * Neutral marker for "not coming today" rows (sick, excused, or a schedule
+ * exception with no time). A known absence is information, not a warning — a
+ * calm gray clock matches the student detail page and avoids the alarm an
+ * amber triangle implies. Used for every absence line so the same state always
+ * reads the same, across cards and detail.
+ */
+export function AbsenceIcon() {
+  return <Clock className="h-3.5 w-3.5 text-gray-400" />;
+}
+
+/**
  * Shared pickup time display row used across OGS groups, active supervisions,
  * and student search pages. Normalizes the three rendering branches:
  *   1. Has planned or actual time → show status-aware time row
@@ -485,7 +496,7 @@ export function PickupTimeRow({
 }>) {
   if (isException && !pickupTime && !actualTime) {
     return (
-      <StudentInfoRow icon={<ExceptionIcon />}>
+      <StudentInfoRow icon={<AbsenceIcon />}>
         {notes || "Abwesend"}
       </StudentInfoRow>
     );
@@ -501,6 +512,21 @@ export function PickupTimeRow({
       now={now}
       kind="pickup"
     />
+  );
+}
+
+/**
+ * Single neutral status line shown instead of the arrival + pickup rows when a
+ * student is absent today (sick / excused). One line for the whole day — an
+ * absent child has neither a meaningful arrival nor pickup time, so repeating
+ * the reason on two rows would be noise. Mirrors the existing schedule-based
+ * "Kommt heute nicht (…)" wording so every absence reads identically.
+ */
+export function StudentAbsenceRow({ label }: Readonly<{ label: string }>) {
+  return (
+    <StudentInfoRow icon={<AbsenceIcon />}>
+      {`Kommt heute nicht (${label})`}
+    </StudentInfoRow>
   );
 }
 
@@ -527,7 +553,7 @@ export function ArrivalTimeRow({
 }>) {
   if (isAbsent) {
     return (
-      <StudentInfoRow icon={<ExceptionIcon />}>
+      <StudentInfoRow icon={<AbsenceIcon />}>
         {notes ? `Kommt heute nicht (${notes})` : "Kommt heute nicht"}
       </StudentInfoRow>
     );
@@ -535,7 +561,7 @@ export function ArrivalTimeRow({
 
   if (isException && !arrivalTime && !actualTime) {
     return (
-      <StudentInfoRow icon={<ExceptionIcon />}>
+      <StudentInfoRow icon={<AbsenceIcon />}>
         {notes ? `Kommt heute nicht (${notes})` : "Kommt heute nicht"}
       </StudentInfoRow>
     );

--- a/frontend/src/components/students/student-detail-components.test.tsx
+++ b/frontend/src/components/students/student-detail-components.test.tsx
@@ -353,6 +353,21 @@ describe("StudentDetailHeader", () => {
       expect(arrival.getByText("(Krank)")).toBeInTheDocument();
     });
 
+    it("keeps a sick checked-in student out of the overdue pickup row", () => {
+      renderHeaderWithTimes({
+        student: { ...mockStudent, sick: true },
+        todayArrivalPlannedTime: "08:00",
+        todayArrivalActualTime: "08:05",
+        todayPickupPlannedTime: "15:30",
+        todayPickupActualTime: undefined,
+      });
+
+      expect(screen.getByTestId("today-absence-row")).toHaveTextContent(
+        "Kommt heute nicht (krank gemeldet)",
+      );
+      expect(screen.queryByTestId("today-time-row-pickup")).toBeNull();
+    });
+
     it("renders the actual time even when no planned time was scheduled (walk-in)", () => {
       // Walk-in scenario: a student arrives without a planned arrival
       // configured. The row still renders the actual but suppresses the

--- a/frontend/src/components/students/student-detail-components.tsx
+++ b/frontend/src/components/students/student-detail-components.tsx
@@ -5,7 +5,10 @@ import { AlertTriangle, Check, Clock } from "lucide-react";
 import { LocationBadge } from "@/components/ui/location-badge";
 import type { ExtendedStudent } from "~/lib/hooks/use-student-data";
 import { useMinuteClock } from "~/lib/pickup-helpers";
-import { getStudentTimeStatus } from "~/lib/student-time-status";
+import {
+  getStudentAbsence,
+  getStudentTimeStatus,
+} from "~/lib/student-time-status";
 import type { SupervisorContact } from "~/lib/student-helpers";
 import { InfoCard, InfoItem } from "~/components/ui/info-card";
 import { Avatar } from "~/components/ui/avatar";
@@ -354,24 +357,52 @@ export function StudentDetailHeader({
                 <span className="truncate">{student.group_name}</span>
               </div>
             )}
-            <TodayTimeStatusInlineRow
-              kind="arrival"
-              label="Heutige Ankunft"
-              plannedTime={todayArrivalPlannedTime}
-              actualTime={todayArrivalActualTime}
-              isException={isArrivalException}
-              note={isArrivalAbsent ? undefined : todayArrivalNote}
-              isAbsent={isArrivalAbsent}
-              absentReason={todayArrivalNote}
-            />
-            <TodayTimeStatusInlineRow
-              kind="pickup"
-              label="Heutige Abholung"
-              plannedTime={todayPickupPlannedTime}
-              actualTime={todayPickupActualTime}
-              isException={isPickupException}
-              note={todayPickupNote}
-            />
+            {(() => {
+              // Variant B: a sick/excused child has neither a meaningful
+              // arrival nor pickup time today, so collapse both rows into one
+              // neutral status line — identical wording to every other surface
+              // via the shared getStudentAbsence helper. A recorded actual
+              // arrival still wins (the flag can be stale until check-in).
+              const absence = getStudentAbsence({
+                sick: student.sick,
+                excused: student.excused,
+              });
+              if (absence && !todayArrivalActualTime) {
+                return (
+                  <div
+                    data-testid="today-absence-row"
+                    className="mt-1.5 flex items-center gap-2 text-sm text-gray-600"
+                  >
+                    <ClockIcon className="h-4 w-4 text-gray-400" />
+                    <span className="font-medium text-gray-900">
+                      {`Kommt heute nicht (${absence.label})`}
+                    </span>
+                  </div>
+                );
+              }
+              return (
+                <>
+                  <TodayTimeStatusInlineRow
+                    kind="arrival"
+                    label="Heutige Ankunft"
+                    plannedTime={todayArrivalPlannedTime}
+                    actualTime={todayArrivalActualTime}
+                    isException={isArrivalException}
+                    note={isArrivalAbsent ? undefined : todayArrivalNote}
+                    isAbsent={isArrivalAbsent}
+                    absentReason={todayArrivalNote}
+                  />
+                  <TodayTimeStatusInlineRow
+                    kind="pickup"
+                    label="Heutige Abholung"
+                    plannedTime={todayPickupPlannedTime}
+                    actualTime={todayPickupActualTime}
+                    isException={isPickupException}
+                    note={todayPickupNote}
+                  />
+                </>
+              );
+            })()}
           </div>
         </div>
         <div className="mr-4 flex-shrink-0 pb-3">

--- a/frontend/src/components/students/student-detail-components.tsx
+++ b/frontend/src/components/students/student-detail-components.tsx
@@ -358,16 +358,15 @@ export function StudentDetailHeader({
               </div>
             )}
             {(() => {
-              // Variant B: a sick/excused child has neither a meaningful
-              // arrival nor pickup time today, so collapse both rows into one
-              // neutral status line — identical wording to every other surface
-              // via the shared getStudentAbsence helper. A recorded actual
-              // arrival still wins (the flag can be stale until check-in).
+              // Variant B: a sick/excused child without a completed pickup
+              // should not accrue overdue pickup urgency, even if they already
+              // checked in before the absence flag was set. Once pickup is
+              // recorded, the actual resolved times can render normally.
               const absence = getStudentAbsence({
                 sick: student.sick,
                 excused: student.excused,
               });
-              if (absence && !todayArrivalActualTime) {
+              if (absence && !todayPickupActualTime) {
                 return (
                   <div
                     data-testid="today-absence-row"

--- a/frontend/src/lib/student-time-status.test.ts
+++ b/frontend/src/lib/student-time-status.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   areStudentDayTimesResolved,
   combineTimeNotes,
+  getStudentAbsence,
   getStudentTimeStatus,
   getTimeStatusSortRank,
 } from "./student-time-status";
@@ -216,6 +217,117 @@ describe("getStudentTimeStatus edge cases", () => {
     expect(status.state).toBe("done-late");
     expect(status.diffMinutes).toBe(90);
     expect(status.detailAnnotation).toBe("+90 min");
+  });
+});
+
+describe("getStudentTimeStatus sick/excused", () => {
+  // now is well past the planned time, so without the sick/excused signal
+  // these inputs would all classify as very-overdue (red).
+  const now = new Date("2025-01-15T15:00:00");
+
+  it("neutralizes an overdue planned arrival when the student is sick", () => {
+    const status = getStudentTimeStatus({
+      plannedTime: "08:00",
+      now,
+      sick: true,
+    });
+
+    expect(status.state).toBe("absent-excused");
+    // No red overdue color — that is the whole point of the fix.
+    expect(status.textColor).toBeUndefined();
+    expect(status.iconColor).toBe(LOCATION_COLORS.UNKNOWN);
+    // A sick child is closed out for the day, not an open urgency.
+    expect(status.isResolved).toBe(true);
+    expect(status.detailAnnotation).not.toContain("Überfällig");
+  });
+
+  it("neutralizes an overdue planned pickup when the student is excused", () => {
+    const status = getStudentTimeStatus({
+      plannedTime: "13:00",
+      now,
+      excused: true,
+    });
+
+    expect(status.state).toBe("absent-excused");
+    expect(status.textColor).toBeUndefined();
+  });
+
+  it("lets a recorded actual time win over a stale sick flag (precedence)", () => {
+    // A child marked sick who nevertheless checked in (RFID) must show the
+    // real arrival, not 'absent'. actual time always wins.
+    const status = getStudentTimeStatus({
+      plannedTime: "08:00",
+      actualTime: "08:05",
+      now,
+      sick: true,
+    });
+
+    expect(status.state).toBe("done-late");
+    expect(status.displayTime).toBe("08:05");
+  });
+
+  it("ignores sick/excused when neither planned nor actual time exists", () => {
+    const status = getStudentTimeStatus({ now, sick: true });
+
+    // Nothing to neutralize — without a time there is no red to suppress.
+    expect(status.state).toBe("absent-excused");
+  });
+
+  it("ranks absent-excused out of the urgency band but above 'none'", () => {
+    const absentExcused = getStudentTimeStatus({
+      plannedTime: "08:00",
+      now,
+      sick: true,
+    });
+    const veryOverdue = getStudentTimeStatus({ plannedTime: "08:00", now });
+    const approaching = getStudentTimeStatus({ plannedTime: "15:15", now });
+    const planned = getStudentTimeStatus({ plannedTime: "16:00", now });
+    const none = getStudentTimeStatus({ now });
+
+    expect(getTimeStatusSortRank(absentExcused)).toBeGreaterThan(
+      getTimeStatusSortRank(veryOverdue),
+    );
+    expect(getTimeStatusSortRank(absentExcused)).toBeGreaterThan(
+      getTimeStatusSortRank(approaching),
+    );
+    expect(getTimeStatusSortRank(absentExcused)).toBeGreaterThan(
+      getTimeStatusSortRank(planned),
+    );
+    // Must not change the existing contract: 'none' stays last.
+    expect(getTimeStatusSortRank(none)).toBe(6);
+    expect(getTimeStatusSortRank(absentExcused)).toBeLessThan(
+      getTimeStatusSortRank(none),
+    );
+  });
+});
+
+describe("getStudentAbsence", () => {
+  it("returns null when the student is neither sick nor excused", () => {
+    expect(getStudentAbsence({})).toBeNull();
+    expect(getStudentAbsence({ sick: false, excused: false })).toBeNull();
+  });
+
+  it("labels a sick student without any date qualifier", () => {
+    // No "seit <weekday>" — a weekday abbreviation is ambiguous past 7 days
+    // and outright wrong past two weeks, so we keep a stable, date-free label.
+    const absence = getStudentAbsence({ sick: true });
+
+    expect(absence).not.toBeNull();
+    expect(absence?.reason).toBe("sick");
+    expect(absence?.label).toBe("krank gemeldet");
+  });
+
+  it("labels an excused student", () => {
+    const absence = getStudentAbsence({ excused: true });
+
+    expect(absence?.reason).toBe("excused");
+    expect(absence?.label).toBe("entschuldigt");
+  });
+
+  it("prefers sick over excused when both are set", () => {
+    const absence = getStudentAbsence({ sick: true, excused: true });
+
+    expect(absence?.reason).toBe("sick");
   });
 });
 

--- a/frontend/src/lib/student-time-status.ts
+++ b/frontend/src/lib/student-time-status.ts
@@ -56,9 +56,10 @@ interface StudentAbsenceInput {
  * The label is intentionally date-free: a "seit <weekday>" qualifier reads
  * wrong once an absence spans more than a week. We only state the status.
  *
- * Note: a recorded actual arrival/pickup always wins over this — callers must
- * check the actual time first (the sick flag can be stale until the next
- * check-in clears it).
+ * Note: resolved actual times may still win at the row level. Callers that
+ * collapse a whole day into one absence line should only do so while pickup is
+ * unresolved, otherwise an already-arrived sick/excused child can still fall
+ * through to an overdue pickup state.
  */
 export function getStudentAbsence({
   sick,

--- a/frontend/src/lib/student-time-status.ts
+++ b/frontend/src/lib/student-time-status.ts
@@ -9,7 +9,8 @@ type TimeStatusState =
   | "slightly-overdue"
   | "very-overdue"
   | "done-on-time"
-  | "done-late";
+  | "done-late"
+  | "absent-excused";
 
 type TimeStatusIcon = "clock" | "warning" | "check";
 
@@ -28,6 +29,50 @@ interface StudentTimeStatusInput {
   plannedTime?: string;
   actualTime?: string;
   now: Date;
+  /** Student is reported sick today — suppresses overdue urgency. */
+  sick?: boolean;
+  /** Student is excused today (not attending) — suppresses overdue urgency. */
+  excused?: boolean;
+}
+
+/** Why a student is not expected today. Drives the neutral "absent" rendering. */
+export interface StudentAbsence {
+  reason: "sick" | "excused";
+  /** German UI label, e.g. "krank gemeldet" or "entschuldigt". */
+  label: string;
+}
+
+interface StudentAbsenceInput {
+  sick?: boolean;
+  excused?: boolean;
+}
+
+/**
+ * Determines whether a student is absent today and why. Single source of truth
+ * for the sick/excused rule, consumed by every surface (group cards, search,
+ * active supervisions, student detail) and the sort ranking so they can never
+ * disagree. Sick takes priority over excused.
+ *
+ * The label is intentionally date-free: a "seit <weekday>" qualifier reads
+ * wrong once an absence spans more than a week. We only state the status.
+ *
+ * Note: a recorded actual arrival/pickup always wins over this — callers must
+ * check the actual time first (the sick flag can be stale until the next
+ * check-in clears it).
+ */
+export function getStudentAbsence({
+  sick,
+  excused,
+}: StudentAbsenceInput): StudentAbsence | null {
+  if (sick) {
+    return { reason: "sick", label: "krank gemeldet" };
+  }
+
+  if (excused) {
+    return { reason: "excused", label: "entschuldigt" };
+  }
+
+  return null;
 }
 
 interface TimeParts {
@@ -90,6 +135,8 @@ export function getStudentTimeStatus({
   plannedTime,
   actualTime,
   now,
+  sick,
+  excused,
 }: StudentTimeStatusInput): StudentTimeStatus {
   const displayActualTime = formatTimeDisplay(actualTime);
   const displayPlannedTime = formatTimeDisplay(plannedTime);
@@ -116,6 +163,22 @@ export function getStudentTimeStatus({
       detailAnnotation:
         diffMinutes === undefined ? undefined : formatActualDiff(diffMinutes),
       diffMinutes,
+    };
+  }
+
+  // Absence wins over the temporal (overdue) path but never over a recorded
+  // actual time above — a sick/excused child is not "overdue", they are simply
+  // not expected today. Neutral coloring, sorted out of the urgency band.
+  const absence = getStudentAbsence({ sick, excused });
+  if (absence) {
+    return {
+      state: "absent-excused",
+      displayTime: undefined,
+      icon: "clock",
+      iconColor: LOCATION_COLORS.UNKNOWN,
+      textColor: undefined,
+      isResolved: true,
+      detailAnnotation: absence.label,
     };
   }
 
@@ -214,6 +277,10 @@ export function getTimeStatusSortRank(status: StudentTimeStatus): number {
     case "done-late":
       return 4;
     case "done-on-time":
+      return 5;
+    // Out of the urgency band, alongside resolved students — but above "none"
+    // so a known-absent child still outranks one with no schedule at all.
+    case "absent-excused":
       return 5;
     case "none":
     default:


### PR DESCRIPTION
## Problem

Abhol- und Ankunftszeiten werden rot eingefärbt, sobald die geplante Zeit
überschritten ist (Status „überfällig"). Diese Logik berücksichtigte nicht, ob ein
Kind als krank oder entschuldigt markiert ist. Ein krank gemeldetes Kind mit
geplanter Abholzeit 15:00 wurde dadurch ab 15:01 als „Überfällig seit X min" in Rot
angezeigt — obwohl es heute nicht anwesend ist.

## Was sich ändert

Krank gemeldete oder entschuldigte Kinder zeigen jetzt statt der roten Zeit eine
neutrale graue Zeile:

> 🕐 Kommt heute nicht (krank gemeldet)
> 🕐 Kommt heute nicht (entschuldigt)

Die rote Überfällig-Anzeige bleibt anwesenden Kindern vorbehalten, deren Abholzeit
tatsächlich überschritten ist.

## Beispiele

| Kind | vorher | nachher |
|---|---|---|
| krank gemeldet, Abholzeit vorbei | 🔴 „Überfällig seit 15 min" | 🕐 „Kommt heute nicht (krank gemeldet)" |
| entschuldigt | 🔴 „Überfällig …" | 🕐 „Kommt heute nicht (entschuldigt)" |
| gesund, Abholzeit vorbei | 🔴 „Überfällig …" | 🔴 „Überfällig …" (unverändert) |

## Wo

Die Änderung greift überall, wo dieses Problem auftrat: OGS-Gruppen, Aktuelle
Aufsicht, Kindersuche und Kind-Detailseite. Die Logik liegt an einer zentralen
Stelle, damit Anzeige und Sortierung nie auseinanderlaufen.

## Getestet

Lokal alle Fälle durchgeklickt — graue Abwesenheits-Zeile erscheint, das Rot für
überfällige anwesende Kinder bleibt erhalten. `pnpm run check` läuft sauber,
betroffene Tests grün.

Closes #1458
