### PR TITLE
feat: add Bissendorf student search filters

### DIFF
--- a/backend/api/students/admin_filters.go
+++ b/backend/api/students/admin_filters.go
@@ -1,0 +1,80 @@
+package students
+
+import "strings"
+
+// Administrative filters (#1492): bus / photo consent / pickup rule.
+//
+// These run against the enriched StudentResponse objects (not in SQL) so they
+// share the same in-memory pipeline as the day-planning filter. Keeping them
+// here means the student list endpoint and the list export apply identical
+// semantics from a single source of truth, including the GDPR rule that
+// redacted students (HasFullAccess == false) never match an administrative
+// filter, so the filtered result can't leak which restricted children are bus
+// kids, lack photo consent, etc.
+
+// matchesAdministrativeFilters reports whether a single response satisfies all
+// active administrative filters. Empty or "all" values are treated as "off".
+func matchesAdministrativeFilters(s StudentResponse, bus, photoConsent, pickupStatus string) bool {
+	if isActiveFilterValue(bus) {
+		if !s.HasFullAccess || s.Bus != (bus == "yes") {
+			return false
+		}
+	}
+	if isActiveFilterValue(photoConsent) {
+		if !s.HasFullAccess || s.PhotoConsentGiven == nil || *s.PhotoConsentGiven != (photoConsent == "yes") {
+			return false
+		}
+	}
+	if isActiveFilterValue(pickupStatus) {
+		if !s.HasFullAccess || pickupStatusKind(s.PickupStatus) != pickupStatus {
+			return false
+		}
+	}
+	return true
+}
+
+// applyAdministrativeFilters returns the subset of responses matching the
+// active administrative filters. When none is active the input is returned
+// unchanged so callers can invoke it unconditionally.
+func applyAdministrativeFilters(responses []StudentResponse, bus, photoConsent, pickupStatus string) []StudentResponse {
+	if !isActiveFilterValue(bus) && !isActiveFilterValue(photoConsent) && !isActiveFilterValue(pickupStatus) {
+		return responses
+	}
+	filtered := make([]StudentResponse, 0, len(responses))
+	for _, response := range responses {
+		if matchesAdministrativeFilters(response, bus, photoConsent, pickupStatus) {
+			filtered = append(filtered, response)
+		}
+	}
+	return filtered
+}
+
+// pickupStatusKind normalizes the free-text pickup rule stored on a student
+// into one of the filterable buckets: "self", "pickedUp", "other" or "none".
+// Shared by the student list filter, the list export filter and their labels
+// so the categorisation can never drift between the two paths.
+func pickupStatusKind(status string) string {
+	raw := strings.TrimSpace(status)
+	if raw == "" {
+		return "none"
+	}
+	normalized := strings.ToLower(raw)
+	if strings.Contains(normalized, "alleine") ||
+		normalized == "selbst" ||
+		normalized == "self" ||
+		normalized == "alone" ||
+		normalized == "walk_home" ||
+		normalized == "geht_alleine" {
+		return "self"
+	}
+	if strings.Contains(normalized, "abgeholt") ||
+		normalized == "parent" ||
+		normalized == "parents" ||
+		normalized == "guardian" ||
+		normalized == "pickup" ||
+		normalized == "picked_up" ||
+		normalized == "wird_abgeholt" {
+		return "pickedUp"
+	}
+	return "other"
+}

--- a/backend/api/students/admin_filters_test.go
+++ b/backend/api/students/admin_filters_test.go
@@ -1,0 +1,145 @@
+package students
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPickupStatusKindBuckets(t *testing.T) {
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{"", "none"},
+		{"   ", "none"},
+		{"Geht alleine nach Hause", "self"},
+		{"self", "self"},
+		{"geht_alleine", "self"},
+		{"Wird abgeholt", "pickedUp"},
+		{"picked_up", "pickedUp"},
+		{"Taxi", "other"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			assert.Equal(t, tt.want, pickupStatusKind(tt.status))
+		})
+	}
+}
+
+func TestApplyAdministrativeFilters(t *testing.T) {
+	consentYes := true
+	consentNo := false
+	students := []StudentResponse{
+		{
+			ID:                301,
+			Bus:               true,
+			PhotoConsentGiven: &consentYes,
+			PickupStatus:      "Geht alleine nach Hause",
+			HasFullAccess:     true,
+		},
+		{
+			ID:                302,
+			Bus:               false,
+			PhotoConsentGiven: &consentNo,
+			PickupStatus:      "Wird abgeholt",
+			HasFullAccess:     true,
+		},
+		{
+			// Redacted student: never matches an administrative filter (GDPR).
+			ID:            303,
+			Bus:           true,
+			PickupStatus:  "Wird abgeholt",
+			HasFullAccess: false,
+		},
+		{
+			// Full access, no pickup rule recorded → kind "none".
+			ID:            304,
+			Bus:           false,
+			HasFullAccess: true,
+		},
+		{
+			// Redacted student that would otherwise match pickup "self":
+			// confirms GDPR redaction also gates the pickup filter.
+			ID:            305,
+			PickupStatus:  "Geht alleine nach Hause",
+			HasFullAccess: false,
+		},
+	}
+
+	tests := []struct {
+		name                        string
+		bus, photoConsent, pickupSt string
+		wantIDs                     []int64
+	}{
+		{
+			name:    "no filters returns all unchanged",
+			wantIDs: []int64{301, 302, 303, 304, 305},
+		},
+		{
+			name:    "all sentinel is treated as off",
+			bus:     "all",
+			wantIDs: []int64{301, 302, 303, 304, 305},
+		},
+		{
+			name:    "bus yes excludes redacted students",
+			bus:     "yes",
+			wantIDs: []int64{301},
+		},
+		{
+			name:         "photo_consent no",
+			photoConsent: "no",
+			wantIDs:      []int64{302},
+		},
+		{
+			name:     "pickup self excludes redacted students",
+			pickupSt: "self",
+			wantIDs:  []int64{301},
+		},
+		{
+			name:     "pickup none matches students without a recorded rule",
+			pickupSt: "none",
+			wantIDs:  []int64{304},
+		},
+		{
+			name:         "combined bus + photo_consent + pickup",
+			bus:          "no",
+			photoConsent: "no",
+			pickupSt:     "pickedUp",
+			wantIDs:      []int64{302},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyAdministrativeFilters(students, tt.bus, tt.photoConsent, tt.pickupSt)
+			gotIDs := make([]int64, 0, len(got))
+			for _, student := range got {
+				gotIDs = append(gotIDs, student.ID)
+			}
+			assert.Equal(t, tt.wantIDs, gotIDs)
+		})
+	}
+}
+
+func TestParseStudentListParamsReadsAdministrativeFilters(t *testing.T) {
+	req := httptest.NewRequest("GET", "/students?bus=yes&photo_consent=no&pickup_status=self", nil)
+	params := parseStudentListParams(req)
+
+	assert.Equal(t, "yes", params.bus)
+	assert.Equal(t, "no", params.photoConsent)
+	assert.Equal(t, "self", params.pickupStatus)
+	assert.True(t, params.hasAdministrativeFilters())
+	// Administrative filters force the in-memory pipeline so pagination/counts
+	// reflect the filtered set.
+	assert.True(t, params.hasInMemoryFilters())
+}
+
+func TestParseStudentListParamsAdministrativeFiltersDefaultOff(t *testing.T) {
+	req := httptest.NewRequest("GET", "/students?bus=all", nil)
+	params := parseStudentListParams(req)
+
+	assert.False(t, params.hasAdministrativeFilters())
+	assert.False(t, params.hasInMemoryFilters())
+}

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -411,6 +411,11 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	responses = applyDayPlanningFilter(responses, params.dayStatus)
+	// Administrative filters (#1492): bus / photo consent / pickup rule.
+	// Applied here, before in-memory pagination, so server-side counts and
+	// page boundaries reflect the filtered set (no client-side full-page
+	// fetch needed).
+	responses = applyAdministrativeFilters(responses, params.bus, params.photoConsent, params.pickupStatus)
 
 	// Apply in-memory pagination if response-derived filters were used.
 	if params.hasInMemoryFilters() {

--- a/backend/api/students/export_handlers.go
+++ b/backend/api/students/export_handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/services/listexport"
 	"github.com/moto-nrw/project-phoenix/tenant"
 )
@@ -28,15 +29,18 @@ type studentExportRequest struct {
 }
 
 type studentExportFilters struct {
-	Search      string `json:"search"`
-	GroupID     string `json:"group_id"`
-	RoomID      string `json:"room_id"`
-	Year        string `json:"year"`
-	Status      string `json:"status"`
-	DayStatus   string `json:"day_status"`
-	PickupTime  string `json:"pickup_time"`
-	ArrivalTime string `json:"arrival_time"`
-	Sort        string `json:"sort"`
+	Search       string `json:"search"`
+	GroupID      string `json:"group_id"`
+	RoomID       string `json:"room_id"`
+	Year         string `json:"year"`
+	Status       string `json:"status"`
+	Bus          string `json:"bus"`
+	PhotoConsent string `json:"photo_consent"`
+	PickupStatus string `json:"pickup_status"`
+	DayStatus    string `json:"day_status"`
+	PickupTime   string `json:"pickup_time"`
+	ArrivalTime  string `json:"arrival_time"`
+	Sort         string `json:"sort"`
 }
 
 type weeklySchedule struct {
@@ -72,6 +76,9 @@ func (rs *Resource) exportStudents(w http.ResponseWriter, r *http.Request) {
 
 	accessCtx := rs.determineStudentAccess(r)
 	responses := rs.buildStudentResponses(r.Context(), students, params, accessCtx, dataSnapshot, false)
+	if exportNeedsPhotoConsentFilter(req.Filters) {
+		populateExportPhotoConsentFilterData(responses, students)
+	}
 	for i := range responses {
 		if responses[i].HasFullAccess {
 			applyActualTimesFromSnapshot(&responses[i], dataSnapshot)
@@ -160,6 +167,27 @@ func exportRequestToListParams(req studentExportRequest) *studentListParams {
 	return params
 }
 
+func exportNeedsPhotoConsentFilter(filters studentExportFilters) bool {
+	return filters.PhotoConsent != "" && filters.PhotoConsent != "all"
+}
+
+func populateExportPhotoConsentFilterData(responses []StudentResponse, students []*users.Student) {
+	consentByStudentID := make(map[int64]bool, len(students))
+	for _, student := range students {
+		if student == nil {
+			continue
+		}
+		consentByStudentID[student.ID] = student.PhotoConsentGivenAt != nil
+	}
+	for i := range responses {
+		consentGiven, ok := consentByStudentID[responses[i].ID]
+		if !ok {
+			continue
+		}
+		responses[i].PhotoConsentGiven = &consentGiven
+	}
+}
+
 func applyExportFilters(students []StudentResponse, filters studentExportFilters) []StudentResponse {
 	filtered := make([]StudentResponse, 0, len(students))
 	for _, student := range students {
@@ -167,6 +195,9 @@ func applyExportFilters(students []StudentResponse, filters studentExportFilters
 			continue
 		}
 		if filters.Status != "" && filters.Status != "all" && exportStatus(student) != filters.Status {
+			continue
+		}
+		if !matchesAdministrativeFilters(student, filters.Bus, filters.PhotoConsent, filters.PickupStatus) {
 			continue
 		}
 		if filters.DayStatus != "" && filters.DayStatus != DayPlanningStatusAll && student.DayPlanningStatus != filters.DayStatus {
@@ -375,10 +406,40 @@ func exportFilterLabels(filters studentExportFilters) []string {
 	if filters.Status != "" && filters.Status != "all" {
 		labels = append(labels, "Momentaufnahme: "+filters.Status)
 	}
+	if filters.Bus != "" && filters.Bus != "all" {
+		if filters.Bus == "yes" {
+			labels = append(labels, "Buskind")
+		} else {
+			labels = append(labels, "Kein Buskind")
+		}
+	}
+	if filters.PhotoConsent != "" && filters.PhotoConsent != "all" {
+		if filters.PhotoConsent == "yes" {
+			labels = append(labels, "Fotoerlaubnis liegt vor")
+		} else {
+			labels = append(labels, "Keine Fotoerlaubnis")
+		}
+	}
+	if filters.PickupStatus != "" && filters.PickupStatus != "all" {
+		labels = append(labels, "Abholregelung: "+exportPickupStatusLabel(filters.PickupStatus))
+	}
 	if filters.DayStatus != "" && filters.DayStatus != DayPlanningStatusAll {
 		labels = append(labels, "Tagesplanung: "+dayStatusExportLabel(filters.DayStatus))
 	}
 	return labels
+}
+
+func exportPickupStatusLabel(status string) string {
+	switch status {
+	case "self":
+		return "Geht alleine nach Hause"
+	case "pickedUp":
+		return "Wird abgeholt"
+	case "none":
+		return "Keine Abholregelung"
+	default:
+		return "Sonstige"
+	}
 }
 
 func dayStatusExportLabel(status string) string {

--- a/backend/api/students/export_handlers_test.go
+++ b/backend/api/students/export_handlers_test.go
@@ -2,9 +2,13 @@ package students
 
 import (
 	"testing"
+	"time"
 
+	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExportRequestToListParamsPreservesRoomFilter(t *testing.T) {
@@ -22,6 +26,217 @@ func TestExportRequestToListParamsPreservesRoomFilter(t *testing.T) {
 	assert.Equal(t, studentExportPageSize, params.pageSize)
 	assert.True(t, params.includePickupTimes)
 	assert.True(t, params.includeArrivalTimes)
+}
+
+func TestApplyExportFiltersAdministrativeFilters(t *testing.T) {
+	consentYes := true
+	consentNo := false
+	students := []StudentResponse{
+		{
+			ID:                101,
+			SchoolClass:       "Klasse 1a",
+			Bus:               true,
+			PhotoConsentGiven: &consentYes,
+			PickupStatus:      "Geht alleine nach Hause",
+			HasFullAccess:     true,
+		},
+		{
+			ID:                102,
+			SchoolClass:       "Klasse 2a",
+			Bus:               false,
+			PhotoConsentGiven: &consentNo,
+			PickupStatus:      "Wird abgeholt",
+			HasFullAccess:     true,
+		},
+		{
+			ID:            103,
+			SchoolClass:   "Klasse 3a",
+			Bus:           true,
+			PickupStatus:  "Wird abgeholt",
+			HasFullAccess: false,
+		},
+	}
+
+	tests := []struct {
+		name    string
+		filters studentExportFilters
+		wantIDs []int64
+	}{
+		{
+			name:    "bus yes excludes redacted students",
+			filters: studentExportFilters{Bus: "yes"},
+			wantIDs: []int64{101},
+		},
+		{
+			name:    "photo consent no",
+			filters: studentExportFilters{PhotoConsent: "no"},
+			wantIDs: []int64{102},
+		},
+		{
+			name:    "pickup self",
+			filters: studentExportFilters{PickupStatus: "self"},
+			wantIDs: []int64{101},
+		},
+		{
+			name:    "combined filters",
+			filters: studentExportFilters{Bus: "no", PhotoConsent: "no", PickupStatus: "pickedUp"},
+			wantIDs: []int64{102},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyExportFilters(students, tt.filters)
+			gotIDs := make([]int64, 0, len(got))
+			for _, student := range got {
+				gotIDs = append(gotIDs, student.ID)
+			}
+			assert.Equal(t, tt.wantIDs, gotIDs)
+		})
+	}
+}
+
+func TestPopulateExportPhotoConsentFilterDataSupportsFeatureOffResponses(t *testing.T) {
+	now := time.Now()
+	responses := []StudentResponse{
+		{ID: 101, HasFullAccess: true},
+		{ID: 102, HasFullAccess: true},
+	}
+	students := []*users.Student{
+		{Model: base.Model{ID: 101}, PhotoConsentGivenAt: &now},
+		{Model: base.Model{ID: 102}},
+	}
+
+	populateExportPhotoConsentFilterData(responses, students)
+
+	require.NotNil(t, responses[0].PhotoConsentGiven)
+	assert.True(t, *responses[0].PhotoConsentGiven)
+	require.NotNil(t, responses[1].PhotoConsentGiven)
+	assert.False(t, *responses[1].PhotoConsentGiven)
+
+	yes := applyExportFilters(responses, studentExportFilters{PhotoConsent: "yes"})
+	require.Len(t, yes, 1)
+	assert.Equal(t, int64(101), yes[0].ID)
+
+	no := applyExportFilters(responses, studentExportFilters{PhotoConsent: "no"})
+	require.Len(t, no, 1)
+	assert.Equal(t, int64(102), no[0].ID)
+}
+
+func TestApplyExportFiltersCombinedWithDayStatus(t *testing.T) {
+	consentYes := true
+	consentNo := false
+	// 201/204 come today; 202/203 are planned absent (krank/entschuldigt → not_coming_today).
+	students := []StudentResponse{
+		{
+			ID:                201,
+			Bus:               true,
+			PhotoConsentGiven: &consentYes,
+			PickupStatus:      "Geht alleine nach Hause",
+			DayPlanningStatus: DayPlanningStatusComesToday,
+			HasFullAccess:     true,
+		},
+		{
+			ID:                202,
+			Bus:               false,
+			PhotoConsentGiven: &consentNo,
+			PickupStatus:      "Wird abgeholt",
+			DayPlanningStatus: DayPlanningStatusNotComingToday,
+			HasFullAccess:     true,
+		},
+		{
+			ID:                203,
+			Bus:               true,
+			PhotoConsentGiven: &consentYes,
+			PickupStatus:      "Wird abgeholt",
+			DayPlanningStatus: DayPlanningStatusNotComingToday,
+			HasFullAccess:     true,
+		},
+		{
+			ID:                204,
+			Bus:               true,
+			PhotoConsentGiven: &consentYes,
+			PickupStatus:      "Geht alleine nach Hause",
+			DayPlanningStatus: DayPlanningStatusComesToday,
+			HasFullAccess:     true,
+		},
+	}
+
+	tests := []struct {
+		name    string
+		filters studentExportFilters
+		wantIDs []int64
+	}{
+		{
+			name:    "day_status comes_today only",
+			filters: studentExportFilters{DayStatus: DayPlanningStatusComesToday},
+			wantIDs: []int64{201, 204},
+		},
+		{
+			name:    "day_status not_coming_today keeps planned krank/entschuldigt",
+			filters: studentExportFilters{DayStatus: DayPlanningStatusNotComingToday},
+			wantIDs: []int64{202, 203},
+		},
+		{
+			name:    "day_status comes_today AND bus yes",
+			filters: studentExportFilters{DayStatus: DayPlanningStatusComesToday, Bus: "yes"},
+			wantIDs: []int64{201, 204},
+		},
+		{
+			name:    "day_status not_coming_today AND photo_consent yes",
+			filters: studentExportFilters{DayStatus: DayPlanningStatusNotComingToday, PhotoConsent: "yes"},
+			wantIDs: []int64{203},
+		},
+		{
+			name:    "day_status comes_today AND pickup_status self",
+			filters: studentExportFilters{DayStatus: DayPlanningStatusComesToday, PickupStatus: "self"},
+			wantIDs: []int64{201, 204},
+		},
+		{
+			name:    "day_status all keeps every student",
+			filters: studentExportFilters{DayStatus: DayPlanningStatusAll},
+			wantIDs: []int64{201, 202, 203, 204},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyExportFilters(students, tt.filters)
+			gotIDs := make([]int64, 0, len(got))
+			for _, student := range got {
+				gotIDs = append(gotIDs, student.ID)
+			}
+			assert.Equal(t, tt.wantIDs, gotIDs)
+		})
+	}
+}
+
+func TestExportRequestToListParamsParsesDayStatus(t *testing.T) {
+	params := exportRequestToListParams(studentExportRequest{
+		Filters: studentExportFilters{DayStatus: "not_coming_today"},
+	})
+	assert.Equal(t, "not_coming_today", params.dayStatus)
+
+	// Administrative filters are applied client-side, so they must NOT leak
+	// into the backend list query params.
+	adminOnly := exportRequestToListParams(studentExportRequest{
+		Filters: studentExportFilters{Bus: "yes", PhotoConsent: "no", PickupStatus: "self"},
+	})
+	assert.Equal(t, DayPlanningStatusAll, adminOnly.dayStatus)
+}
+
+func TestExportFilterLabelsCombinesDayStatusAndAdministrative(t *testing.T) {
+	labels := exportFilterLabels(studentExportFilters{
+		Bus:          "yes",
+		PhotoConsent: "no",
+		PickupStatus: "self",
+		DayStatus:    DayPlanningStatusNotComingToday,
+	})
+
+	assert.Contains(t, labels, "Buskind")
+	assert.Contains(t, labels, "Keine Fotoerlaubnis")
+	assert.Contains(t, labels, "Abholregelung: Geht alleine nach Hause")
+	assert.Contains(t, labels, "Tagesplanung: Kommt heute nicht")
 }
 
 func TestWeeklyCellUsesExplicitLabels(t *testing.T) {

--- a/backend/api/students/list_helpers.go
+++ b/backend/api/students/list_helpers.go
@@ -25,6 +25,13 @@ type studentListParams struct {
 	includePickupTimes  bool
 	includeArrivalTimes bool
 	dayStatus           string
+	// Administrative filters (#1492). Resolved against the enriched response
+	// objects in the same in-memory pass as dayStatus so pagination and counts
+	// stay correct. bus/photoConsent are "yes"/"no"; pickupStatus is one of the
+	// pickupStatusKind buckets ("self"/"pickedUp"/"none"). Empty or "all" = off.
+	bus          string
+	photoConsent string
+	pickupStatus string
 	// studentIDs is an optional pre-filter populated by upstream resolution
 	// (e.g., room_id → active visits) before the SQL list query runs. When
 	// set, buildBaseFilter adds `student.id IN (...)` so the standard
@@ -70,6 +77,12 @@ func parseStudentListParams(r *http.Request) *studentListParams {
 	params.includeArrivalTimes = r.URL.Query().Get("include_arrival_times") == "true"
 	params.dayStatus = parseDayStatusParam(r.URL.Query().Get("day_status"))
 
+	// Administrative filters (#1492). Applied in-memory against the enriched
+	// responses, mirroring the student list export filter semantics.
+	params.bus = r.URL.Query().Get("bus")
+	params.photoConsent = r.URL.Query().Get("photo_consent")
+	params.pickupStatus = r.URL.Query().Get("pickup_status")
+
 	// Parse pagination
 	params.page, params.pageSize = common.ParsePagination(r)
 
@@ -82,7 +95,22 @@ func (p *studentListParams) hasPersonFilters() bool {
 }
 
 func (p *studentListParams) hasInMemoryFilters() bool {
-	return p.hasPersonFilters() || p.dayStatus != "" && p.dayStatus != DayPlanningStatusAll
+	return p.hasPersonFilters() ||
+		p.dayStatus != "" && p.dayStatus != DayPlanningStatusAll ||
+		p.hasAdministrativeFilters()
+}
+
+// hasAdministrativeFilters reports whether any of the #1492 administrative
+// filters (bus / photo consent / pickup rule) is active.
+func (p *studentListParams) hasAdministrativeFilters() bool {
+	return isActiveFilterValue(p.bus) ||
+		isActiveFilterValue(p.photoConsent) ||
+		isActiveFilterValue(p.pickupStatus)
+}
+
+// isActiveFilterValue treats both empty and the neutral "all" sentinel as "off".
+func isActiveFilterValue(value string) bool {
+	return value != "" && value != "all"
 }
 
 func parseDayStatusParam(value string) string {

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx
@@ -43,6 +43,10 @@ vi.mock("~/lib/tenant-router", () => ({
 
 vi.mock("~/components/tenant/tenant-provider", () => ({
   useTenant: () => ({ tenantSlug: "t", tenant: null }),
+  useTenantSafe: () => ({
+    tenantSlug: "t",
+    tenant: { studentPhotosEnabled: true },
+  }),
   useTenantSlugSafe: () => "t",
   usePresenceMode: () => "detailed",
   TenantProvider: ({ children }: { children: React.ReactNode }) => children,

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.school-checkin.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.school-checkin.test.tsx
@@ -45,6 +45,10 @@ vi.mock("~/lib/hooks/use-school-checkin-mode", () => ({
 // (src/test/setup.ts defaults to "detailed") so the button renders.
 vi.mock("~/components/tenant/tenant-provider", () => ({
   useTenant: vi.fn(() => ({ tenantSlug: "test-tenant", tenant: null })),
+  useTenantSafe: vi.fn(() => ({
+    tenantSlug: "test-tenant",
+    tenant: { studentPhotosEnabled: true },
+  })),
   useTenantSlugSafe: vi.fn(() => "test-tenant"),
   usePresenceMode: vi.fn(() => "binary"),
   TenantProvider: ({ children }: { children: React.ReactNode }) => children,

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -62,6 +62,7 @@ vi.mock("~/components/ui/page-header", () => ({
     activeFilters,
     onClearAllFilters,
     search,
+    overflowMenu,
   }: {
     filters: Array<{
       id: string;
@@ -72,6 +73,7 @@ vi.mock("~/components/ui/page-header", () => ({
     activeFilters: Array<{ id: string; label: string }>;
     onClearAllFilters: () => void;
     search: { value: string; onChange: (v: string) => void };
+    overflowMenu?: Array<{ label: string; onClick: () => void }>;
   }) => (
     <div data-testid="page-header">
       <input
@@ -119,11 +121,35 @@ vi.mock("~/components/ui/page-header", () => ({
       <button data-testid="clear-filters" onClick={onClearAllFilters}>
         Clear
       </button>
+      {(overflowMenu ?? []).map((item) => (
+        <button
+          key={item.label}
+          data-testid={`overflow-${item.label}`}
+          onClick={item.onClick}
+        >
+          {item.label}
+        </button>
+      ))}
     </div>
   ),
 }));
 
-// Mock StudentPresenceBadge — wrapper the page now renders instead of
+// Mock the export modal so a test can capture the filters prop it receives
+// and confirm no active filter is dropped on the way to the export payload.
+vi.mock("~/components/students/student-export-modal", () => ({
+  StudentExportModal: ({
+    isOpen,
+    filters,
+  }: {
+    isOpen: boolean;
+    filters: Record<string, string>;
+  }) =>
+    isOpen ? (
+      <div data-testid="export-modal" data-filters={JSON.stringify(filters)} />
+    ) : null,
+}));
+
+// Mock StudentPresenceBadge: wrapper the page now renders instead of
 // the bare LocationBadge, so binary-mode tenants can hide detailed labels.
 vi.mock("@/components/ui/student-presence-badge", () => ({
   StudentPresenceBadge: ({
@@ -140,7 +166,7 @@ vi.mock("@/components/ui/location-badge", () => ({
   ),
 }));
 
-// Mock location helpers — LOCATION_COLORS is consumed by student-card.tsx
+// Mock location helpers: LOCATION_COLORS is consumed by student-card.tsx
 // (check-in mode tint), so the mock must expose the brand palette even if
 // individual tests don't assert on colors.
 vi.mock("~/lib/location-helper", () => ({
@@ -174,7 +200,7 @@ vi.mock("~/lib/location-helper", () => ({
 }));
 
 // Mock school-checkin FAB + hook so existing search tests aren't
-// responsible for the new floating mode trigger —
+// responsible for the new floating mode trigger;
 // page.school-checkin.test.tsx covers it dedicatedly.
 vi.mock("~/components/students/school-checkin-fab", () => ({
   SchoolCheckinFab: () => <div data-testid="school-checkin-fab" />,
@@ -235,6 +261,10 @@ const mockStudents = [
     current_location: "Raum 101",
     arrival_time: "08:00",
     pickup_time: "15:30",
+    pickup_status: "Geht alleine nach Hause",
+    bus: true,
+    photo_consent_given: true,
+    photo_consent_given_at: "2026-01-01T10:00:00Z",
     has_full_access: true,
   },
   {
@@ -245,6 +275,9 @@ const mockStudents = [
     group_name: "Gruppe B",
     current_location: "Zuhause",
     arrival_time: "08:30",
+    pickup_status: "Wird abgeholt",
+    bus: false,
+    photo_consent_given: false,
     has_full_access: true,
   },
   {
@@ -256,6 +289,9 @@ const mockStudents = [
     current_location: "Unterwegs",
     arrival_time: "08:15",
     pickup_time: "16:00",
+    pickup_status: "Geht alleine nach Hause",
+    bus: true,
+    photo_consent_given: false,
     has_full_access: true,
   },
   {
@@ -266,6 +302,10 @@ const mockStudents = [
     group_name: "Gruppe C",
     current_location: "Schulhof",
     arrival_time: "09:00",
+    pickup_status: "Wird abgeholt",
+    bus: false,
+    photo_consent_given: true,
+    photo_consent_given_at: "2026-01-02T10:00:00Z",
     has_full_access: true,
   },
 ];
@@ -332,6 +372,45 @@ function mockUseSWRAuthWithStudents(
   });
 }
 
+// Mocks useSWRAuth so the students SWR fetcher is captured (not auto-run) and
+// returns it. Lets a test execute the fetcher itself and assert which filters
+// the page forwards to studentService.getStudents, the real backend contract
+// for the #1492 administrative filters.
+function captureStudentsFetcher(swrModule: typeof import("~/lib/swr")) {
+  const captured: { current: (() => Promise<unknown>) | null } = {
+    current: null,
+  };
+  vi.mocked(swrModule.useSWRAuth).mockImplementation((key, fetcher) => {
+    if (
+      typeof key === "string" &&
+      key.startsWith("search-students-") &&
+      fetcher
+    ) {
+      captured.current = fetcher as () => Promise<unknown>;
+    }
+    if (typeof key === "string" && key.startsWith("tracking-indicators-")) {
+      return {
+        data: undefined,
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>;
+    }
+    if (key === "search-rooms-list") {
+      return {
+        data: [],
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>;
+    }
+    return {
+      data: { students: mockStudents },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof swrModule.useSWRAuth>;
+  });
+  return captured;
+}
+
 describe("StudentSearchPage", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -340,6 +419,9 @@ describe("StudentSearchPage", () => {
     mockSearchParams.delete("group_id");
     mockSearchParams.delete("room_id");
     mockSearchParams.delete("room_name");
+    mockSearchParams.delete("bus");
+    mockSearchParams.delete("photo_consent");
+    mockSearchParams.delete("pickup_status");
     mockSearchParams.delete("pickup_time");
     mockSearchParams.delete("arrival_time");
     mockSearchParams.delete("day_status");
@@ -359,6 +441,12 @@ describe("StudentSearchPage", () => {
       status: "authenticated",
       update: vi.fn(),
     } as unknown as ReturnType<typeof sessionModule.useSession>);
+
+    const tenantProvider = await import("~/components/tenant/tenant-provider");
+    vi.mocked(tenantProvider.useTenantSafe).mockReturnValue({
+      tenantSlug: "test-tenant",
+      tenant: { studentPhotosEnabled: true },
+    } as unknown as ReturnType<typeof tenantProvider.useTenantSafe>);
 
     // Reset SWR mock data for each test
     const swrModule = await import("~/lib/swr");
@@ -486,11 +574,14 @@ describe("StudentSearchPage", () => {
       mockSearchParams.set("group_id", "1");
       mockSearchParams.set("room_id", "101");
       mockSearchParams.set("room_name", "Raum 101");
+      mockSearchParams.set("bus", "yes");
+      mockSearchParams.set("photo_consent", "no");
+      mockSearchParams.set("pickup_status", "pickedUp");
       mockSearchParams.set("pickup_time", "15:30");
       mockSearchParams.set("arrival_time", "08:00");
       mockSearchParams.set("status", "anwesend");
       mockSearchParams.set("sort", "pickup");
-      mockSearchParams.set("view", "room");
+      mockSearchParams.set("view", "pickup-status");
 
       render(<StudentSearchPage />);
 
@@ -498,11 +589,18 @@ describe("StudentSearchPage", () => {
         expect(screen.getByTestId("filter-year")).toHaveValue("1");
         expect(screen.getByTestId("filter-group")).toHaveValue("1");
         expect(screen.getByTestId("filter-room")).toHaveValue("101");
+        expect(screen.getByTestId("filter-bus")).toHaveValue("yes");
+        expect(screen.getByTestId("filter-photoConsent")).toHaveValue("no");
+        expect(screen.getByTestId("filter-pickupStatus")).toHaveValue(
+          "pickedUp",
+        );
         expect(screen.getByTestId("filter-pickupTime")).toHaveValue("15:30");
         expect(screen.getByTestId("filter-arrivalTime")).toHaveValue("08:00");
         expect(screen.getByTestId("filter-attendance")).toHaveValue("anwesend");
         expect(screen.getByTestId("filter-sort")).toHaveValue("pickup");
-        expect(screen.getByTestId("filter-groupMode")).toHaveValue("room");
+        expect(screen.getByTestId("filter-groupMode")).toHaveValue(
+          "pickup-status",
+        );
       });
     });
 
@@ -524,29 +622,44 @@ describe("StudentSearchPage", () => {
       fireEvent.change(screen.getByTestId("filter-attendance"), {
         target: { value: "unterwegs" },
       });
+      fireEvent.change(screen.getByTestId("filter-bus"), {
+        target: { value: "yes" },
+      });
+      fireEvent.change(screen.getByTestId("filter-photoConsent"), {
+        target: { value: "no" },
+      });
+      fireEvent.change(screen.getByTestId("filter-pickupStatus"), {
+        target: { value: "self" },
+      });
       fireEvent.change(screen.getByTestId("filter-sort"), {
         target: { value: "pickup" },
       });
       fireEvent.change(screen.getByTestId("filter-groupMode"), {
-        target: { value: "status" },
+        target: { value: "pickup-status" },
       });
 
       let url = new URL(window.location.href);
       expect(url.searchParams.get("year")).toBe("2");
       expect(url.searchParams.get("group_id")).toBe("2");
       expect(url.searchParams.get("status")).toBe("unterwegs");
+      expect(url.searchParams.get("bus")).toBe("yes");
+      expect(url.searchParams.get("photo_consent")).toBe("no");
+      expect(url.searchParams.get("pickup_status")).toBe("self");
       expect(url.searchParams.get("sort")).toBe("pickup");
-      expect(url.searchParams.get("view")).toBe("status");
+      expect(url.searchParams.get("view")).toBe("pickup-status");
       expect(window.history.state).toEqual({ preserved: true });
       expect(
         JSON.parse(
           localStorage.getItem(STUDENT_SEARCH_FILTER_STORAGE_KEY) ?? "{}",
         ),
       ).toEqual({
+        bus: "yes",
         group_id: "2",
+        photo_consent: "no",
+        pickup_status: "self",
         sort: "pickup",
         status: "unterwegs",
-        view: "status",
+        view: "pickup-status",
         year: "2",
       });
 
@@ -560,6 +673,66 @@ describe("StudentSearchPage", () => {
       ).toBeNull();
     });
 
+    it("keeps day_status and administrative filters together across URL, localStorage and export", async () => {
+      window.history.replaceState({ preserved: true }, "", "/students/search");
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-dayStatus")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-dayStatus"), {
+        target: { value: "comes_today" },
+      });
+      fireEvent.change(screen.getByTestId("filter-bus"), {
+        target: { value: "yes" },
+      });
+      fireEvent.change(screen.getByTestId("filter-photoConsent"), {
+        target: { value: "no" },
+      });
+      fireEvent.change(screen.getByTestId("filter-pickupStatus"), {
+        target: { value: "self" },
+      });
+
+      // Day-planning filter and the administrative filters must all survive in
+      // the URL, not just one group or the other.
+      const url = new URL(window.location.href);
+      expect(url.searchParams.get("day_status")).toBe("comes_today");
+      expect(url.searchParams.get("bus")).toBe("yes");
+      expect(url.searchParams.get("photo_consent")).toBe("no");
+      expect(url.searchParams.get("pickup_status")).toBe("self");
+
+      // ...and in localStorage.
+      expect(
+        JSON.parse(
+          localStorage.getItem(STUDENT_SEARCH_FILTER_STORAGE_KEY) ?? "{}",
+        ),
+      ).toMatchObject({
+        day_status: "comes_today",
+        bus: "yes",
+        photo_consent: "no",
+        pickup_status: "self",
+      });
+
+      // ...and in the payload handed to the export modal.
+      fireEvent.click(screen.getByTestId("overflow-Exportieren"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("export-modal")).toBeInTheDocument();
+      });
+
+      const exportFilters = JSON.parse(
+        screen.getByTestId("export-modal").getAttribute("data-filters") ?? "{}",
+      ) as Record<string, string>;
+      expect(exportFilters).toMatchObject({
+        day_status: "comes_today",
+        bus: "yes",
+        photo_consent: "no",
+        pickup_status: "self",
+      });
+    });
+
     it("restores filters from localStorage when opening without URL params", async () => {
       localStorage.setItem(
         STUDENT_SEARCH_FILTER_STORAGE_KEY,
@@ -568,9 +741,12 @@ describe("StudentSearchPage", () => {
           group_id: "2",
           room_id: "101",
           room_name: "Raum 101",
+          bus: "no",
+          photo_consent: "yes",
+          pickup_status: "none",
           status: "schulhof",
           sort: "arrival",
-          view: "room",
+          view: "pickup-status",
         }),
       );
 
@@ -580,9 +756,14 @@ describe("StudentSearchPage", () => {
         expect(screen.getByTestId("filter-year")).toHaveValue("2");
         expect(screen.getByTestId("filter-group")).toHaveValue("2");
         expect(screen.getByTestId("filter-room")).toHaveValue("101");
+        expect(screen.getByTestId("filter-bus")).toHaveValue("no");
+        expect(screen.getByTestId("filter-photoConsent")).toHaveValue("yes");
+        expect(screen.getByTestId("filter-pickupStatus")).toHaveValue("none");
         expect(screen.getByTestId("filter-attendance")).toHaveValue("schulhof");
         expect(screen.getByTestId("filter-sort")).toHaveValue("arrival");
-        expect(screen.getByTestId("filter-groupMode")).toHaveValue("room");
+        expect(screen.getByTestId("filter-groupMode")).toHaveValue(
+          "pickup-status",
+        );
       });
 
       const url = new URL(window.location.href);
@@ -590,6 +771,9 @@ describe("StudentSearchPage", () => {
       expect(url.searchParams.get("group_id")).toBe("2");
       expect(url.searchParams.get("room_id")).toBe("101");
       expect(url.searchParams.get("room_name")).toBe("Raum 101");
+      expect(url.searchParams.get("bus")).toBe("no");
+      expect(url.searchParams.get("photo_consent")).toBe("yes");
+      expect(url.searchParams.get("pickup_status")).toBe("none");
       expect(url.searchParams.get("status")).toBe("schulhof");
     });
 
@@ -776,7 +960,7 @@ describe("StudentSearchPage", () => {
           screen.getByText("Kommt heute nicht (krank gemeldet)"),
         ).toBeInTheDocument();
       });
-      // The two time rows are replaced by the single absence line — no red
+      // The two time rows are replaced by the single absence line, no red
       // "overdue" arrival/pickup for a child who isn't coming today.
       expect(screen.queryByText(/Ankunftszeit:/)).not.toBeInTheDocument();
       expect(screen.queryByText(/Abholzeit:/)).not.toBeInTheDocument();
@@ -1566,6 +1750,323 @@ describe("StudentSearchPage", () => {
     });
   });
 
+  describe("Administrative Student Filters", () => {
+    it("separates student caches when the photo feature flag changes", async () => {
+      const swrModule = await import("~/lib/swr");
+      const tenantProvider =
+        await import("~/components/tenant/tenant-provider");
+      const studentKeys: string[] = [];
+
+      vi.mocked(swrModule.useSWRAuth).mockImplementation((key) => {
+        if (key === "search-rooms-list") {
+          return {
+            data: [],
+            isLoading: false,
+            error: null,
+          } as ReturnType<typeof swrModule.useSWRAuth>;
+        }
+
+        if (typeof key === "string" && key.startsWith("search-students-")) {
+          studentKeys.push(key);
+        }
+
+        return {
+          data: { students: mockStudents },
+          isLoading: false,
+          error: null,
+        } as ReturnType<typeof swrModule.useSWRAuth>;
+      });
+
+      vi.mocked(tenantProvider.useTenantSafe).mockReturnValue({
+        tenantSlug: "test-tenant",
+        tenant: { studentPhotosEnabled: false },
+      } as unknown as ReturnType<typeof tenantProvider.useTenantSafe>);
+
+      const { rerender } = render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(studentKeys.some((key) => key.includes("photos-disabled"))).toBe(
+          true,
+        );
+      });
+
+      vi.mocked(tenantProvider.useTenantSafe).mockReturnValue({
+        tenantSlug: "test-tenant",
+        tenant: { studentPhotosEnabled: true },
+      } as unknown as ReturnType<typeof tenantProvider.useTenantSafe>);
+
+      rerender(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(studentKeys.some((key) => key.includes("photos-enabled"))).toBe(
+          true,
+        );
+      });
+    });
+
+    it("keys tracking indicators by the fetched student ids", async () => {
+      mockSearchParams.set("bus", "yes");
+
+      const swrModule = await import("~/lib/swr");
+      const trackingKeys: string[] = [];
+      const completeStudents = [
+        { ...mockStudents[0]!, id: "first-page-student" },
+        { ...mockStudents[2]!, id: "later-page-student" },
+      ];
+
+      vi.mocked(swrModule.useSWRAuth).mockImplementation((key) => {
+        if (key === "search-rooms-list") {
+          return {
+            data: [],
+            isLoading: false,
+            error: null,
+          } as ReturnType<typeof swrModule.useSWRAuth>;
+        }
+
+        if (typeof key === "string" && key.startsWith("tracking-indicators-")) {
+          trackingKeys.push(key);
+          return {
+            data: undefined,
+            isLoading: false,
+            error: null,
+          } as ReturnType<typeof swrModule.useSWRAuth>;
+        }
+
+        return {
+          data: { students: completeStudents },
+          isLoading: false,
+          error: null,
+        } as ReturnType<typeof swrModule.useSWRAuth>;
+      });
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(trackingKeys).toContain(
+          "tracking-indicators-first-page-student,later-page-student",
+        );
+      });
+    });
+
+    it("includes pickup status filters in the students SWR cache key", async () => {
+      const swrModule = await import("~/lib/swr");
+      const studentKeys: string[] = [];
+
+      vi.mocked(swrModule.useSWRAuth).mockImplementation((key) => {
+        if (key === "search-rooms-list") {
+          return {
+            data: [],
+            isLoading: false,
+            error: null,
+          } as ReturnType<typeof swrModule.useSWRAuth>;
+        }
+
+        if (typeof key === "string" && key.startsWith("search-students-")) {
+          studentKeys.push(key);
+        }
+
+        return {
+          data: { students: mockStudents },
+          isLoading: false,
+          error: null,
+        } as ReturnType<typeof swrModule.useSWRAuth>;
+      });
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-pickupStatus")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-pickupStatus"), {
+        target: { value: "self" },
+      });
+
+      await waitFor(() => {
+        // pickup_status is the last segment of the students cache key, so a
+        // change to it must produce a key ending in the new value (forces SWR
+        // to refetch the now server-filtered page).
+        expect(studentKeys.some((key) => key.endsWith("-self"))).toBe(true);
+      });
+    });
+
+    it("delegates Buskind filtering to a single backend request (#1492)", async () => {
+      // Previously the page fetched every page client-side and filtered locally.
+      // The backend now filters + paginates server-side, so the fetcher makes a
+      // single getStudents call carrying bus and must NOT loop over pages.
+      mockSearchParams.set("bus", "yes");
+
+      const studentService = await import("~/lib/api");
+      const mockGetStudents = vi.fn().mockResolvedValue({
+        students: [{ ...mockStudents[0]!, id: "101", first_name: "OnlyPage" }],
+        pagination: {
+          current_page: 1,
+          page_size: 50,
+          total_pages: 1,
+          total_records: 1,
+        },
+      });
+      vi.mocked(studentService.studentService.getStudents).mockImplementation(
+        mockGetStudents,
+      );
+
+      let capturedStudentsFetcher: (() => Promise<unknown>) | null = null;
+      const swrModule = await import("~/lib/swr");
+      vi.mocked(swrModule.useSWRAuth).mockImplementation((key, fetcher) => {
+        if (key === "search-rooms-list") {
+          return {
+            data: [],
+            isLoading: false,
+            error: null,
+          } as ReturnType<typeof swrModule.useSWRAuth>;
+        }
+
+        if (
+          typeof key === "string" &&
+          key.includes("search-students") &&
+          fetcher
+        ) {
+          capturedStudentsFetcher = fetcher as () => Promise<unknown>;
+        }
+
+        return {
+          data: { students: [] },
+          isLoading: false,
+          error: null,
+        } as ReturnType<typeof swrModule.useSWRAuth>;
+      });
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(capturedStudentsFetcher).not.toBeNull();
+      });
+
+      await (capturedStudentsFetcher as unknown as () => Promise<unknown>)();
+
+      // Exactly one backend call, carrying bus, and no page-2 follow-up.
+      expect(mockGetStudents).toHaveBeenCalledTimes(1);
+      expect(mockGetStudents).toHaveBeenCalledWith(
+        expect.objectContaining({ bus: "yes" }),
+      );
+      expect(mockGetStudents).not.toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 }),
+      );
+    });
+
+    it("uses consistent default labels for administrative filters", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-bus")).toBeInTheDocument();
+      });
+
+      expect(
+        (screen.getByTestId("filter-bus") as HTMLSelectElement)
+          .selectedOptions[0]?.textContent,
+      ).toBe("Buskind: Beliebig");
+      expect(
+        (screen.getByTestId("filter-photoConsent") as HTMLSelectElement)
+          .selectedOptions[0]?.textContent,
+      ).toBe("Fotoerlaubnis: Beliebig");
+      expect(
+        (screen.getByTestId("filter-pickupStatus") as HTMLSelectElement)
+          .selectedOptions[0]?.textContent,
+      ).toBe("Abholregelung: Beliebig");
+    });
+
+    it("forwards the Buskind filter to the backend (#1492)", async () => {
+      // Buskind is now a server-side filter, so the page must hand it to
+      // getStudents rather than re-filter the fetched page client-side. The
+      // actual exclusion (incl. GDPR redaction) is covered by the backend
+      // applyAdministrativeFilters tests.
+      mockSearchParams.set("bus", "yes");
+      const { studentService } = await import("~/lib/api");
+      const swrModule = await import("~/lib/swr");
+      const fetcher = captureStudentsFetcher(swrModule);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => expect(fetcher.current).not.toBeNull());
+      await fetcher.current!();
+
+      expect(studentService.getStudents).toHaveBeenCalledWith(
+        expect.objectContaining({ bus: "yes" }),
+      );
+      expect(screen.getByTestId("active-filter-bus")).toHaveTextContent(
+        "Buskind",
+      );
+    });
+
+    it("forwards the photo consent filter to the backend (#1492)", async () => {
+      mockSearchParams.set("photo_consent", "no");
+      const { studentService } = await import("~/lib/api");
+      const swrModule = await import("~/lib/swr");
+      const fetcher = captureStudentsFetcher(swrModule);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => expect(fetcher.current).not.toBeNull());
+      await fetcher.current!();
+
+      expect(studentService.getStudents).toHaveBeenCalledWith(
+        expect.objectContaining({ photoConsent: "no" }),
+      );
+    });
+
+    it("hides the photo consent filter when the tenant photo feature is disabled", async () => {
+      const tenantProvider =
+        await import("~/components/tenant/tenant-provider");
+      vi.mocked(tenantProvider.useTenantSafe).mockReturnValue({
+        tenantSlug: "test-tenant",
+        tenant: { studentPhotosEnabled: false },
+      } as unknown as ReturnType<typeof tenantProvider.useTenantSafe>);
+      mockSearchParams.set("photo_consent", "no");
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("filter-photoConsent"),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId("active-filter-photoConsent"),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText("Max")).toBeInTheDocument();
+        expect(screen.getByText("Lisa")).toBeInTheDocument();
+      });
+    });
+
+    it("hides the photo consent filter when the API omits consent state", async () => {
+      const redactedConsentStudents = mockStudents.map((student) => {
+        const copy: Partial<(typeof mockStudents)[number]> = { ...student };
+        delete copy.photo_consent_given;
+        delete copy.photo_consent_given_at;
+        return copy;
+      });
+
+      const swrModule = await import("~/lib/swr");
+      mockUseSWRAuthWithStudents(swrModule, {
+        data: { students: redactedConsentStudents },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof swrModule.useSWRAuth>);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("filter-photoConsent"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    // GDPR exclusion of redacted students from administrative filters is now
+    // enforced server-side (api/students applyAdministrativeFilters) and
+    // covered by its backend tests, so it no longer has a client-side
+    // equivalent here.
+  });
+
   describe("Pickup Time Filtering", () => {
     it("filters students by specific pickup time", async () => {
       render(<StudentSearchPage />);
@@ -1574,7 +2075,7 @@ describe("StudentSearchPage", () => {
         expect(screen.getByText("Max")).toBeInTheDocument();
       });
 
-      // Filter by 15:30 — only Max has this pickup time
+      // Filter by 15:30, only Max has this pickup time
       const pickupFilter = screen.getByTestId("filter-pickupTime");
       fireEvent.change(pickupFilter, { target: { value: "15:30" } });
 
@@ -1593,7 +2094,7 @@ describe("StudentSearchPage", () => {
         expect(screen.getByText("Max")).toBeInTheDocument();
       });
 
-      // Filter by "none" — Anna and Lisa have no pickup_time
+      // Filter by "none": Anna and Lisa have no pickup_time
       const pickupFilter = screen.getByTestId("filter-pickupTime");
       fireEvent.change(pickupFilter, { target: { value: "none" } });
 
@@ -1645,13 +2146,13 @@ describe("StudentSearchPage", () => {
         expect(screen.getByText("Redacted")).toBeInTheDocument();
       });
 
-      // Apply "none" pickup time filter — redacted student should be excluded (GDPR)
+      // Apply "none" pickup time filter: redacted student should be excluded (GDPR)
       const pickupFilter = screen.getByTestId("filter-pickupTime");
       fireEvent.change(pickupFilter, { target: { value: "none" } });
 
       await waitFor(() => {
         expect(screen.getByText("Visible")).toBeInTheDocument();
-        // Redacted student must NOT appear — has_full_access=false means we
+        // Redacted student must NOT appear: has_full_access=false means we
         // can't know their pickup status, so they're excluded from filtering
         expect(screen.queryByText("Redacted")).not.toBeInTheDocument();
       });
@@ -1674,7 +2175,7 @@ describe("StudentSearchPage", () => {
         ).toHaveTextContent("Keine Abholzeit");
       });
 
-      // Switch to specific time — verify chip label and clear-all
+      // Switch to specific time: verify chip label and clear-all
       fireEvent.change(pickupFilter, { target: { value: "15:30" } });
       await waitFor(() => {
         expect(
@@ -1734,7 +2235,7 @@ describe("StudentSearchPage", () => {
         expect(screen.getByText("NoPickup")).toBeInTheDocument();
       });
 
-      // Should show "Abholzeit: —" fallback for students with full access but no pickup time
+      // Should show the "Abholzeit:" em-dash fallback for students with full access but no pickup time
       expect(screen.getByText("Abholzeit: —")).toBeInTheDocument();
     });
   });
@@ -1838,6 +2339,69 @@ describe("StudentSearchPage", () => {
         .getAllByText(/^(Max|Tom|Lisa|Anna)$/)
         .map((node) => node.textContent);
       expect(renderedNames).toEqual(["Max", "Tom", "Lisa", "Anna"]);
+    });
+
+    it("forwards the pickup status filter to the backend (#1492)", async () => {
+      mockSearchParams.set("pickup_status", "self");
+      const { studentService } = await import("~/lib/api");
+      const swrModule = await import("~/lib/swr");
+      const fetcher = captureStudentsFetcher(swrModule);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => expect(fetcher.current).not.toBeNull());
+      await fetcher.current!();
+
+      expect(studentService.getStudents).toHaveBeenCalledWith(
+        expect.objectContaining({ pickupStatus: "self" }),
+      );
+      expect(
+        screen.getByTestId("active-filter-pickupStatus"),
+      ).toHaveTextContent("Geht alleine nach Hause");
+    });
+
+    it("forwards the 'no pickup rule' filter to the backend (#1492)", async () => {
+      mockSearchParams.set("pickup_status", "none");
+      const { studentService } = await import("~/lib/api");
+      const swrModule = await import("~/lib/swr");
+      const fetcher = captureStudentsFetcher(swrModule);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => expect(fetcher.current).not.toBeNull());
+      await fetcher.current!();
+
+      expect(studentService.getStudents).toHaveBeenCalledWith(
+        expect.objectContaining({ pickupStatus: "none" }),
+      );
+      expect(
+        screen.getByTestId("active-filter-pickupStatus"),
+      ).toHaveTextContent("Keine Abholregelung");
+    });
+
+    // GDPR exclusion of redacted students from the pickup-status filter is
+    // enforced and tested server-side now (see backend applyAdministrativeFilters).
+
+    it("groups students by permanent pickup status", async () => {
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Max")).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId("filter-groupMode"), {
+        target: { value: "pickup-status" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("active-filter-groupMode")).toHaveTextContent(
+          "Ansicht: Nach Abholregelung",
+        );
+      });
+
+      expect(
+        screen.getAllByRole("heading", { level: 2 }).map((h) => h.textContent),
+      ).toEqual(["Geht alleine nach Hause", "Wird abgeholt"]);
     });
 
     it("groups students by status in operational order", async () => {
@@ -2175,7 +2739,7 @@ describe("StudentSearchPage", () => {
       await waitFor(() => {
         // Felix missing HA → shown.
         expect(screen.getByText("Felix")).toBeInTheDocument();
-        // Redacted kid hidden — no tracking data AND has_full_access false.
+        // Redacted kid hidden: no tracking data AND has_full_access false.
         expect(screen.queryByText("Redacted")).not.toBeInTheDocument();
       });
     });
@@ -2187,7 +2751,7 @@ describe("StudentSearchPage", () => {
 
       await waitFor(() => expect(screen.getByText("Max")).toBeInTheDocument());
 
-      // Flip to arrival sort mode — component should re-render without error.
+      // Flip to arrival sort mode: component should re-render without error.
       fireEvent.change(screen.getByTestId("filter-sort"), {
         target: { value: "arrival" },
       });

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -50,6 +50,7 @@ import {
   useSchoolCheckinMode,
 } from "~/lib/hooks/use-school-checkin-mode";
 import { usePresenceMode } from "~/components/tenant/tenant-provider";
+import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled";
 import { useSWRAuth, useImmutableSWR } from "~/lib/swr";
 import { SEARCH_ROOMS_LIST_CACHE_KEY } from "~/lib/swr/room-derived-caches";
 import { activeService } from "~/lib/active-api";
@@ -84,9 +85,18 @@ type StatusFilter =
   | "schulhof"
   | "krank"
   | "entschuldigt";
+type BooleanFilter = "all" | "yes" | "no";
+type PickupStatusKind = "self" | "pickedUp" | "other" | "none" | "redacted";
+type PickupStatusFilter = "all" | "self" | "pickedUp" | "none";
 type DayStatusFilter = "all" | "comes_today" | "not_coming_today";
 type SortMode = "name" | "arrival" | "pickup";
-type GroupMode = "none" | "status" | "room" | "arrival" | "pickup";
+type GroupMode =
+  | "none"
+  | "status"
+  | "room"
+  | "arrival"
+  | "pickup"
+  | "pickup-status";
 
 const STATUS_FILTER_OPTIONS: Array<{ value: StatusFilter; label: string }> = [
   { value: "all", label: "Alle" },
@@ -119,6 +129,7 @@ const GROUP_OPTIONS: Array<{ value: GroupMode; label: string }> = [
   { value: "room", label: "Nach Raum" },
   { value: "arrival", label: "Nach Ankunftszeit" },
   { value: "pickup", label: "Nach Abholzeit" },
+  { value: "pickup-status", label: "Nach Abholregelung" },
 ];
 
 const FILTER_QUERY_PARAMS = [
@@ -126,6 +137,9 @@ const FILTER_QUERY_PARAMS = [
   "group_id",
   "room_id",
   "room_name",
+  "bus",
+  "photo_consent",
+  "pickup_status",
   "pickup_time",
   "arrival_time",
   "day_status",
@@ -140,6 +154,7 @@ type PersistedSearchFilters = Partial<Record<FilterQueryParam, string>>;
 type SearchParamReader = Pick<URLSearchParams, "get" | "has">;
 
 const STUDENT_SEARCH_FILTER_STORAGE_PREFIX = "student-search:last-filters";
+const FULL_STUDENT_SEARCH_PAGE_SIZE = 1000;
 
 const SCHOOL_YEAR_DROPDOWN_OPTIONS = SCHOOL_YEAR_FILTER_OPTIONS.map(
   (option) => ({
@@ -156,6 +171,39 @@ const STATUS_GROUP_ORDER = new Map([
   ["Entschuldigt", 4],
   ["Abwesend", 5],
 ]);
+
+const BOOLEAN_FILTER_VALUES: readonly BooleanFilter[] = ["all", "yes", "no"];
+const PICKUP_STATUS_FILTER_VALUES: readonly PickupStatusFilter[] = [
+  "all",
+  "self",
+  "pickedUp",
+  "none",
+];
+
+const BUS_FILTER_OPTIONS: Array<{ value: BooleanFilter; label: string }> = [
+  { value: "all", label: "Buskind: Beliebig" },
+  { value: "yes", label: "Buskind" },
+  { value: "no", label: "Kein Buskind" },
+];
+
+const PHOTO_CONSENT_FILTER_OPTIONS: Array<{
+  value: BooleanFilter;
+  label: string;
+}> = [
+  { value: "all", label: "Fotoerlaubnis: Beliebig" },
+  { value: "yes", label: "Fotoerlaubnis liegt vor" },
+  { value: "no", label: "Keine Fotoerlaubnis" },
+];
+
+const PICKUP_STATUS_FILTER_OPTIONS: Array<{
+  value: PickupStatusFilter;
+  label: string;
+}> = [
+  { value: "all", label: "Abholregelung: Beliebig" },
+  { value: "self", label: "Geht alleine nach Hause" },
+  { value: "pickedUp", label: "Wird abgeholt" },
+  { value: "none", label: "Keine Abholregelung" },
+];
 
 const STATUS_FILTER_LABELS: Record<
   Exclude<StatusFilter, "all" | "anwesend">,
@@ -222,6 +270,26 @@ function normalizeStoredFilters(
     group_id: params.get("group_id") ?? "",
     room_id: params.get("room_id") ?? "",
     room_name: params.get("room_id") ? (params.get("room_name") ?? "") : "",
+    bus:
+      validQueryValue(params.get("bus"), BOOLEAN_FILTER_VALUES, "all") === "all"
+        ? ""
+        : (params.get("bus") ?? ""),
+    photo_consent:
+      validQueryValue(
+        params.get("photo_consent"),
+        BOOLEAN_FILTER_VALUES,
+        "all",
+      ) === "all"
+        ? ""
+        : (params.get("photo_consent") ?? ""),
+    pickup_status:
+      validQueryValue(
+        params.get("pickup_status"),
+        PICKUP_STATUS_FILTER_VALUES,
+        "all",
+      ) === "all"
+        ? ""
+        : (params.get("pickup_status") ?? ""),
     pickup_time: params.get("pickup_time") ?? "",
     arrival_time: params.get("arrival_time") ?? "",
     day_status:
@@ -380,6 +448,47 @@ function pickupLabelForStudent(student: Student): string {
   return student.pickup_time ? `${student.pickup_time} Uhr` : "Keine Abholzeit";
 }
 
+function pickupStatusKind(student: Student): PickupStatusKind {
+  if (student.has_full_access === false) return "redacted";
+
+  const raw = student.pickup_status?.trim();
+  if (!raw) return "none";
+
+  const normalized = raw.toLowerCase();
+  if (
+    normalized.includes("alleine") ||
+    normalized === "selbst" ||
+    normalized === "self" ||
+    normalized === "alone" ||
+    normalized === "walk_home" ||
+    normalized === "geht_alleine"
+  ) {
+    return "self";
+  }
+  if (
+    normalized.includes("abgeholt") ||
+    normalized === "parent" ||
+    normalized === "parents" ||
+    normalized === "guardian" ||
+    normalized === "pickup" ||
+    normalized === "picked_up" ||
+    normalized === "wird_abgeholt"
+  ) {
+    return "pickedUp";
+  }
+
+  return "other";
+}
+
+function pickupStatusLabelForStudent(student: Student): string {
+  const kind = pickupStatusKind(student);
+  if (kind === "redacted") return "Nicht einsehbar";
+  if (kind === "self") return "Geht alleine nach Hause";
+  if (kind === "pickedUp") return "Wird abgeholt";
+  if (kind === "none") return "Keine Abholregelung";
+  return student.pickup_status?.trim() || "Keine Abholregelung";
+}
+
 function arrivalLabelForStudent(student: Student): string {
   if (student.has_full_access === false) return "Nicht einsehbar";
   return student.arrival_time
@@ -399,7 +508,9 @@ function groupStudents(students: Student[], groupMode: GroupMode) {
           ? roomLabelForStudent(student)
           : groupMode === "arrival"
             ? arrivalLabelForStudent(student)
-            : pickupLabelForStudent(student);
+            : groupMode === "pickup"
+              ? pickupLabelForStudent(student)
+              : pickupStatusLabelForStudent(student);
     const bucket = groups.get(key);
     if (bucket) {
       bucket.push(student);
@@ -429,8 +540,52 @@ function groupStudents(students: Student[], groupMode: GroupMode) {
               : label;
         return rank(a.label).localeCompare(rank(b.label), "de");
       }
+      if (groupMode === "pickup-status") {
+        const rank = (label: string) =>
+          label === "Geht alleine nach Hause"
+            ? 0
+            : label === "Wird abgeholt"
+              ? 1
+              : label === "Nicht einsehbar"
+                ? 99
+                : label === "Keine Abholregelung"
+                  ? 98
+                  : 2;
+        const rankCmp = rank(a.label) - rank(b.label);
+        if (rankCmp !== 0) return rankCmp;
+      }
       return a.label.localeCompare(b.label, "de");
     });
+}
+
+function compareByPickupTime(a: Student, b: Student, now: Date) {
+  const statusA = getStudentTimeStatus({
+    plannedTime: a.pickup_time,
+    actualTime: a.actual_pickup_time,
+    now,
+    sick: a.sick,
+    excused: a.excused,
+  });
+  const statusB = getStudentTimeStatus({
+    plannedTime: b.pickup_time,
+    actualTime: b.actual_pickup_time,
+    now,
+    sick: b.sick,
+    excused: b.excused,
+  });
+  const rankA = getTimeStatusSortRank(statusA);
+  const rankB = getTimeStatusSortRank(statusB);
+  if (rankA !== rankB) return rankA - rankB;
+
+  const timeA = a.pickup_time;
+  const timeB = b.pickup_time;
+  if (timeA && !timeB) return -1;
+  if (!timeA && timeB) return 1;
+  if (timeA && timeB) {
+    const timeCmp = timeA.localeCompare(timeB);
+    if (timeCmp !== 0) return timeCmp;
+  }
+  return compareByName(a, b);
 }
 
 function orderedRooms(
@@ -530,6 +685,28 @@ function SearchPageContent() {
   const [attendanceFilter, setAttendanceFilter] = useState<StatusFilter>(
     initialAttendanceFilter,
   );
+  const [busFilter, setBusFilter] = useState<BooleanFilter>(
+    validQueryValue(
+      initialFilterParams.get("bus"),
+      BOOLEAN_FILTER_VALUES,
+      "all",
+    ),
+  );
+  const [photoConsentFilter, setPhotoConsentFilter] = useState<BooleanFilter>(
+    validQueryValue(
+      initialFilterParams.get("photo_consent"),
+      BOOLEAN_FILTER_VALUES,
+      "all",
+    ),
+  );
+  const [pickupStatusFilter, setPickupStatusFilter] =
+    useState<PickupStatusFilter>(
+      validQueryValue(
+        initialFilterParams.get("pickup_status"),
+        PICKUP_STATUS_FILTER_VALUES,
+        "all",
+      ),
+    );
   const [dayStatusFilter, setDayStatusFilter] = useState<DayStatusFilter>(
     initialDayStatusFilter,
   );
@@ -592,6 +769,23 @@ function SearchPageContent() {
       );
       setPickupTimeFilter(params.get("pickup_time") ?? "all");
       setArrivalTimeFilter(params.get("arrival_time") ?? "all");
+      setBusFilter(
+        validQueryValue(params.get("bus"), BOOLEAN_FILTER_VALUES, "all"),
+      );
+      setPhotoConsentFilter(
+        validQueryValue(
+          params.get("photo_consent"),
+          BOOLEAN_FILTER_VALUES,
+          "all",
+        ),
+      );
+      setPickupStatusFilter(
+        validQueryValue(
+          params.get("pickup_status"),
+          PICKUP_STATUS_FILTER_VALUES,
+          "all",
+        ),
+      );
       setDayStatusFilter(
         validQueryValue(
           params.get("day_status"),
@@ -669,6 +863,10 @@ function SearchPageContent() {
   const presenceMode = usePresenceMode();
   const isBinaryMode = presenceMode === "binary";
   const schoolCheckin = useSchoolCheckinMode();
+  const {
+    enabled: studentPhotosEnabled,
+    isLoading: studentPhotosSettingLoading,
+  } = useStudentPhotosEnabled();
 
   // Debounce search term for SWR key (prevents excessive API calls while typing)
   useEffect(() => {
@@ -717,7 +915,22 @@ function SearchPageContent() {
 
   // Generate SWR cache key for students (changes when filters change → SWR auto-cancels old requests)
   // Note: User context is only for badge styling, not for fetching students
-  const studentsCacheKey = `search-students-${debouncedSearchTerm}-${selectedGroup}-${selectedRoomId}-${dayStatusFilter}`;
+  const photoConsentFeatureAvailable = studentPhotosSettingLoading
+    ? true
+    : studentPhotosEnabled;
+  const photoConsentFeatureState = studentPhotosSettingLoading
+    ? "photos-loading"
+    : studentPhotosEnabled
+      ? "photos-enabled"
+      : "photos-disabled";
+  const requestedPhotoConsentFilter = photoConsentFeatureAvailable
+    ? photoConsentFilter
+    : "all";
+  // bus / photo_consent / pickup_status are now real backend filters (#1492),
+  // applied server-side in the same in-memory pass as day_status, so the
+  // backend returns correctly-filtered and correctly-counted pages. The cache
+  // key just has to vary with every filter value so SWR refetches on change.
+  const studentsCacheKey = `search-students-${debouncedSearchTerm}-${selectedGroup}-${selectedRoomId}-${dayStatusFilter}-${photoConsentFeatureState}-${busFilter}-${requestedPhotoConsentFilter}-${pickupStatusFilter}`;
 
   // Fetch students with SWR (automatic deduplication, cancellation, and revalidation)
   const {
@@ -727,11 +940,21 @@ function SearchPageContent() {
   } = useSWRAuth<{ students: Student[] }>(
     studentsCacheKey,
     async () => {
-      return await studentService.getStudents({
+      const filters = {
         search: debouncedSearchTerm,
         groupId: selectedGroup,
         roomId: selectedRoomId || undefined,
         dayStatus: dayStatusFilter === "all" ? undefined : dayStatusFilter,
+        // Administrative filters (#1492) are now applied server-side, so the
+        // backend returns the correctly-filtered, correctly-counted page set
+        // directly, no client-side full-page fetch + filter required.
+        bus: busFilter === "all" ? undefined : busFilter,
+        photoConsent:
+          requestedPhotoConsentFilter === "all"
+            ? undefined
+            : requestedPhotoConsentFilter,
+        pickupStatus:
+          pickupStatusFilter === "all" ? undefined : pickupStatusFilter,
         // When filtering by room, this page is the "see all" target the
         // room-detail modal links to (#1374). The modal itself caps at
         // 200 cards and shows a truncation notice; this page must show
@@ -739,10 +962,12 @@ function SearchPageContent() {
         // 1000 covers any realistic combined-group / assembly-room
         // session well above what backend ParsePagination would return
         // by default (50). General search keeps the default.
-        pageSize: selectedRoomId ? 1000 : undefined,
+        pageSize: selectedRoomId ? FULL_STUDENT_SEARCH_PAGE_SIZE : undefined,
         includePickupTimes: true,
         includeArrivalTimes: true,
-      });
+      };
+
+      return await studentService.getStudents(filters);
     },
     {
       // Keep previous data while fetching (prevents loading flash)
@@ -792,6 +1017,30 @@ function SearchPageContent() {
     (value: StatusFilter) => {
       setAttendanceFilter(value);
       updateUrlParams({ status: value === "all" ? "" : value });
+    },
+    [updateUrlParams],
+  );
+
+  const updateBusFilter = useCallback(
+    (value: BooleanFilter) => {
+      setBusFilter(value);
+      updateUrlParams({ bus: value === "all" ? "" : value });
+    },
+    [updateUrlParams],
+  );
+
+  const updatePhotoConsentFilter = useCallback(
+    (value: BooleanFilter) => {
+      setPhotoConsentFilter(value);
+      updateUrlParams({ photo_consent: value === "all" ? "" : value });
+    },
+    [updateUrlParams],
+  );
+
+  const updatePickupStatusFilter = useCallback(
+    (value: PickupStatusFilter) => {
+      setPickupStatusFilter(value);
+      updateUrlParams({ pickup_status: value === "all" ? "" : value });
     },
     [updateUrlParams],
   );
@@ -849,6 +1098,9 @@ function SearchPageContent() {
     setSelectedGroup("");
     setSelectedYear("all");
     setAttendanceFilter("all");
+    setBusFilter("all");
+    setPhotoConsentFilter("all");
+    setPickupStatusFilter("all");
     setPickupTimeFilter("all");
     setArrivalTimeFilter("all");
     setDayStatusFilter("all");
@@ -864,15 +1116,38 @@ function SearchPageContent() {
   }, [storageKey, updateUrlParams]);
 
   const students = studentsData?.students ?? [];
+  const photoConsentDataAvailable =
+    photoConsentFeatureAvailable &&
+    (students.length === 0 ||
+      students.some(
+        (student) =>
+          student.has_full_access !== false &&
+          student.photo_consent_given !== undefined,
+      ));
+  const canUsePhotoConsentFilter =
+    studentPhotosSettingLoading || photoConsentDataAvailable;
+  const effectivePhotoConsentFilter = canUsePhotoConsentFilter
+    ? photoConsentFilter
+    : "all";
+
+  useEffect(() => {
+    if (!canUsePhotoConsentFilter && photoConsentFilter !== "all") {
+      updatePhotoConsentFilter("all");
+    }
+  }, [canUsePhotoConsentFilter, photoConsentFilter, updatePhotoConsentFilter]);
 
   // Tracking indicators for student cards
   const trackingStudentIds = useMemo(
     () => (studentsData?.students ?? []).map((s) => s.id),
     [studentsData],
   );
+  const trackingStudentIdsKey = useMemo(
+    () => trackingStudentIds.join(","),
+    [trackingStudentIds],
+  );
   const { data: trackingData } = useSWRAuth<TrackingIndicatorsResponse>(
     trackingStudentIds.length > 0
-      ? `tracking-indicators-${debouncedSearchTerm}-${selectedGroup}-${selectedRoomId}-${dayStatusFilter}`
+      ? `tracking-indicators-${trackingStudentIdsKey}`
       : null,
     async () => activeService.getTrackingIndicators(trackingStudentIds),
     { keepPreviousData: true, revalidateOnFocus: false },
@@ -1057,6 +1332,36 @@ function SearchPageContent() {
         ],
       },
       {
+        id: "bus",
+        label: "Buskind",
+        type: "dropdown",
+        value: busFilter,
+        onChange: (value) => updateBusFilter(value as BooleanFilter),
+        options: BUS_FILTER_OPTIONS,
+      },
+      ...(canUsePhotoConsentFilter
+        ? [
+            {
+              id: "photoConsent",
+              label: "Fotoerlaubnis",
+              type: "dropdown" as const,
+              value: photoConsentFilter,
+              onChange: (value: string | string[]) =>
+                updatePhotoConsentFilter(value as BooleanFilter),
+              options: PHOTO_CONSENT_FILTER_OPTIONS,
+            },
+          ]
+        : []),
+      {
+        id: "pickupStatus",
+        label: "Abholregelung",
+        type: "dropdown",
+        value: pickupStatusFilter,
+        onChange: (value) =>
+          updatePickupStatusFilter(value as PickupStatusFilter),
+        options: PICKUP_STATUS_FILTER_OPTIONS,
+      },
+      {
         id: "sort",
         label: "Sortierung",
         type: "dropdown",
@@ -1099,6 +1404,10 @@ function SearchPageContent() {
       pickupTimeFilter,
       arrivalTimeFilter,
       attendanceFilter,
+      busFilter,
+      photoConsentFilter,
+      pickupStatusFilter,
+      canUsePhotoConsentFilter,
       dayStatusFilter,
       trackingFilter,
       trackingLabels,
@@ -1115,6 +1424,9 @@ function SearchPageContent() {
       updateSelectedYear,
       updateSelectedGroup,
       updateAttendanceFilter,
+      updateBusFilter,
+      updatePhotoConsentFilter,
+      updatePickupStatusFilter,
       updatePickupTimeFilter,
       updateArrivalTimeFilter,
       updateDayStatusFilter,
@@ -1180,6 +1492,36 @@ function SearchPageContent() {
         id: "attendance",
         label: statusLabels[attendanceFilter] ?? attendanceFilter,
         onRemove: () => updateAttendanceFilter("all"),
+      });
+    }
+
+    if (busFilter !== "all") {
+      filters.push({
+        id: "bus",
+        label: busFilter === "yes" ? "Buskind" : "Kein Buskind",
+        onRemove: () => updateBusFilter("all"),
+      });
+    }
+
+    if (effectivePhotoConsentFilter !== "all") {
+      filters.push({
+        id: "photoConsent",
+        label:
+          effectivePhotoConsentFilter === "yes"
+            ? "Fotoerlaubnis liegt vor"
+            : "Keine Fotoerlaubnis",
+        onRemove: () => updatePhotoConsentFilter("all"),
+      });
+    }
+
+    if (pickupStatusFilter !== "all") {
+      filters.push({
+        id: "pickupStatus",
+        label:
+          PICKUP_STATUS_FILTER_OPTIONS.find(
+            (option) => option.value === pickupStatusFilter,
+          )?.label ?? "Abholregelung",
+        onRemove: () => updatePickupStatusFilter("all"),
       });
     }
 
@@ -1254,6 +1596,9 @@ function SearchPageContent() {
     selectedYear,
     selectedGroup,
     attendanceFilter,
+    busFilter,
+    effectivePhotoConsentFilter,
+    pickupStatusFilter,
     dayStatusFilter,
     pickupTimeFilter,
     arrivalTimeFilter,
@@ -1268,6 +1613,9 @@ function SearchPageContent() {
     updateSelectedYear,
     updateSelectedGroup,
     updateAttendanceFilter,
+    updateBusFilter,
+    updatePhotoConsentFilter,
+    updatePickupStatusFilter,
     updateDayStatusFilter,
     updatePickupTimeFilter,
     updateArrivalTimeFilter,
@@ -1282,6 +1630,9 @@ function SearchPageContent() {
       group_id: selectedGroup,
       year: selectedYear,
       status: attendanceFilter,
+      bus: busFilter,
+      photo_consent: effectivePhotoConsentFilter,
+      pickup_status: pickupStatusFilter,
       day_status: dayStatusFilter,
       pickup_time: pickupTimeFilter,
       arrival_time: arrivalTimeFilter,
@@ -1293,6 +1644,9 @@ function SearchPageContent() {
       selectedGroup,
       selectedYear,
       attendanceFilter,
+      busFilter,
+      effectivePhotoConsentFilter,
+      pickupStatusFilter,
       dayStatusFilter,
       pickupTimeFilter,
       arrivalTimeFilter,
@@ -1338,6 +1692,10 @@ function SearchPageContent() {
       }
     }
 
+    // bus / photo_consent / pickup_status (#1492) are filtered server-side now
+    // (see api/students applyAdministrativeFilters), so the page no longer
+    // re-filters them here. The fetched page is already the filtered set.
+
     // Apply pickup time filter. For redacted students, missing pickup_time
     // due to has_full_access=false is not the same as "no schedule")
     if (pickupTimeFilter !== "all") {
@@ -1371,33 +1729,7 @@ function SearchPageContent() {
 
     return [...filteredStudents].sort((a, b) => {
       if (sortMode === "pickup") {
-        const statusA = getStudentTimeStatus({
-          plannedTime: a.pickup_time,
-          actualTime: a.actual_pickup_time,
-          now,
-          sick: a.sick,
-          excused: a.excused,
-        });
-        const statusB = getStudentTimeStatus({
-          plannedTime: b.pickup_time,
-          actualTime: b.actual_pickup_time,
-          now,
-          sick: b.sick,
-          excused: b.excused,
-        });
-        const rankA = getTimeStatusSortRank(statusA);
-        const rankB = getTimeStatusSortRank(statusB);
-        if (rankA !== rankB) return rankA - rankB;
-
-        const timeA = a.pickup_time;
-        const timeB = b.pickup_time;
-        if (timeA && !timeB) return -1;
-        if (!timeA && timeB) return 1;
-        if (timeA && timeB) {
-          const timeCmp = timeA.localeCompare(timeB);
-          if (timeCmp !== 0) return timeCmp;
-        }
-        return compareByName(a, b);
+        return compareByPickupTime(a, b, now);
       }
 
       const aHome = isHomeLocation(a.current_location);
@@ -1605,6 +1937,11 @@ function SearchPageContent() {
             if (selectedGroup) qs.set("group_id", selectedGroup);
             if (selectedYear !== "all") qs.set("year", selectedYear);
             if (attendanceFilter !== "all") qs.set("status", attendanceFilter);
+            if (busFilter !== "all") qs.set("bus", busFilter);
+            if (effectivePhotoConsentFilter !== "all")
+              qs.set("photo_consent", effectivePhotoConsentFilter);
+            if (pickupStatusFilter !== "all")
+              qs.set("pickup_status", pickupStatusFilter);
             if (dayStatusFilter !== "all")
               qs.set("day_status", dayStatusFilter);
             if (pickupTimeFilter !== "all")

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -943,6 +943,58 @@ describe("api.ts helper functions", () => {
         restore();
       }
     });
+
+    it("appends the administrative filters (bus, photo consent, pickup rule)", async () => {
+      const { fetchWithRetry } = await import("./api-helpers");
+      vi.mocked(fetchWithRetry).mockResolvedValue({
+        data: [],
+        response: new Response(),
+      });
+
+      const { studentService } = await import("./api");
+
+      const restore = setupBrowserEnv();
+      try {
+        await studentService.getStudents({
+          bus: "yes",
+          photoConsent: "no",
+          pickupStatus: "pickedUp",
+          token: "test-token",
+        });
+
+        const callUrl = vi.mocked(fetchWithRetry).mock.calls[0]?.[0];
+        expect(callUrl).toContain("bus=yes");
+        expect(callUrl).toContain("photo_consent=no");
+        expect(callUrl).toContain("pickup_status=pickedUp");
+      } finally {
+        restore();
+      }
+    });
+
+    it("omits the administrative filters when they are not set", async () => {
+      const { fetchWithRetry } = await import("./api-helpers");
+      vi.mocked(fetchWithRetry).mockResolvedValue({
+        data: [],
+        response: new Response(),
+      });
+
+      const { studentService } = await import("./api");
+
+      const restore = setupBrowserEnv();
+      try {
+        await studentService.getStudents({
+          search: "Test",
+          token: "test-token",
+        });
+
+        const callUrl = vi.mocked(fetchWithRetry).mock.calls[0]?.[0];
+        expect(callUrl).not.toContain("bus=");
+        expect(callUrl).not.toContain("photo_consent=");
+        expect(callUrl).not.toContain("pickup_status=");
+      } finally {
+        restore();
+      }
+    });
   });
 
   describe("studentService.getStudent", () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -185,6 +185,9 @@ function buildStudentQueryParams(filters?: {
   roomId?: string;
   locationState?: "transit";
   dayStatus?: "comes_today" | "not_coming_today";
+  bus?: "yes" | "no";
+  photoConsent?: "yes" | "no";
+  pickupStatus?: "self" | "pickedUp" | "none";
   page?: number;
   pageSize?: number;
   includePickupTimes?: boolean;
@@ -202,6 +205,13 @@ function buildStudentQueryParams(filters?: {
   if (filters?.locationState)
     params.append("location_state", filters.locationState);
   if (filters?.dayStatus) params.append("day_status", filters.dayStatus);
+  // Administrative filters (#1492). The backend applies these in-memory in the
+  // same pass as day_status, so pagination and counts stay correct server-side.
+  if (filters?.bus) params.append("bus", filters.bus);
+  if (filters?.photoConsent)
+    params.append("photo_consent", filters.photoConsent);
+  if (filters?.pickupStatus)
+    params.append("pickup_status", filters.pickupStatus);
   if (filters?.page) params.append("page", filters.page.toString());
   if (filters?.pageSize)
     params.append("page_size", filters.pageSize.toString());
@@ -783,6 +793,9 @@ export const studentService = {
     roomId?: string;
     locationState?: "transit";
     dayStatus?: "comes_today" | "not_coming_today";
+    bus?: "yes" | "no";
+    photoConsent?: "yes" | "no";
+    pickupStatus?: "self" | "pickedUp" | "none";
     page?: number;
     pageSize?: number;
     includePickupTimes?: boolean;

--- a/frontend/src/lib/student-export-api.ts
+++ b/frontend/src/lib/student-export-api.ts
@@ -26,8 +26,12 @@ export type StudentExportColumn =
 export interface StudentExportFilters {
   search?: string;
   group_id?: string;
+  room_id?: string;
   year?: string;
   status?: string;
+  bus?: string;
+  photo_consent?: string;
+  pickup_status?: string;
   day_status?: string;
   pickup_time?: string;
   arrival_time?: string;


### PR DESCRIPTION
## Summary
Adds the administrative student filters requested by Bissendorf to the student search page. Staff can now narrow the list by Buskind, Fotoerlaubnis, and Abholregelung, and can also group students by pickup rule.

## What changed
- Adds dropdown filters for Buskind, Fotoerlaubnis, and Abholregelung in the student search filters.
- Uses "Beliebig" for the neutral/all state of the three new administrative filters.
- Persists the new filters in URL params and local storage together with the existing search filters.
- Fetches complete student result pages before applying these client-side administrative filters, so matching students are not missed because of backend pagination.
- Hides the photo consent filter when student photos are disabled or the API does not expose consent data.
- Adds grouping by Abholregelung for operational review.
- Extends the existing student export filter payload/server filtering with Buskind, Fotoerlaubnis, and Abholregelung so exports match these new active filters.

## Context
Bissendorf asked for these filters so staff can quickly find children by bus status, photo consent, and pickup rule without manually scanning the full student list.

## Verification
- `cd frontend && pnpm run check`
- `cd frontend && pnpm vitest run --changed "origin/development" --coverage`
- `cd backend && go test ./api/students -run 'TestApplyExportFiltersAdministrativeFilters|TestExportRequestToListParamsPreservesRoomFilter|TestWeeklyCellUsesExplicitLabels'`
- Pre-push hooks: git-secrets, go-vet, frontend-knip, golangci-lint, go-deadcode, frontend-check

## Notes for review
This is intentionally opened as a draft PR.