### PR TITLE
feat: configurable required enrollment fields & care offerings

### DIFF
--- a/backend/api/enrollment/care_offering_handlers.go
+++ b/backend/api/enrollment/care_offering_handlers.go
@@ -32,6 +32,7 @@ type CareOfferingResponse struct {
 	Capacity            *int      `json:"capacity,omitempty"`
 	PriceCents          *int      `json:"price_cents,omitempty"`
 	IsActive            bool      `json:"is_active"`
+	IsRequired          bool      `json:"is_required"`
 	SortOrder           int       `json:"sort_order"`
 	CreatedAt           time.Time `json:"created_at"`
 	UpdatedAt           time.Time `json:"updated_at"`
@@ -50,6 +51,7 @@ func toCareOfferingResponse(o *enrollmentModels.CareOffering) CareOfferingRespon
 		Capacity:            o.Capacity,
 		PriceCents:          o.PriceCents,
 		IsActive:            o.IsActive,
+		IsRequired:          o.IsRequired,
 		SortOrder:           o.SortOrder,
 		CreatedAt:           o.CreatedAt,
 		UpdatedAt:           o.UpdatedAt,
@@ -74,6 +76,7 @@ type CareOfferingRequest struct {
 	Capacity            *int     `json:"capacity,omitempty"`
 	PriceCents          *int     `json:"price_cents,omitempty"`
 	IsActive            bool     `json:"is_active"`
+	IsRequired          bool     `json:"is_required"`
 	SortOrder           int      `json:"sort_order"`
 }
 
@@ -99,6 +102,7 @@ func (req *CareOfferingRequest) toModel(existingID int64) *enrollmentModels.Care
 		Capacity:            req.Capacity,
 		PriceCents:          req.PriceCents,
 		IsActive:            req.IsActive,
+		IsRequired:          req.IsRequired,
 		SortOrder:           req.SortOrder,
 	}
 	o.ID = existingID

--- a/backend/api/enrollment/care_offering_handlers.go
+++ b/backend/api/enrollment/care_offering_handlers.go
@@ -297,7 +297,7 @@ func (rs *Resource) listPublicCareOfferings(w http.ResponseWriter, r *http.Reque
 		common.RenderError(w, r, common.ErrorInternalServer(errors.New("care offering service not configured")))
 		return
 	}
-	if rs.SchoolRepo == nil || rs.db == nil {
+	if rs.SchoolRepo == nil || rs.PhaseRepo == nil || rs.db == nil {
 		common.RenderError(w, r, common.ErrorInternalServer(errors.New("public endpoint not wired")))
 		return
 	}
@@ -314,8 +314,8 @@ func (rs *Resource) listPublicCareOfferings(w http.ResponseWriter, r *http.Reque
 	}
 
 	var (
-		offerings    []*enrollmentModels.CareOffering
-		careRequired bool
+		offerings     []*enrollmentModels.CareOffering
+		selectionMode = enrollmentModels.PhaseCareOfferingSelectionOptional
 	)
 	err = tenant.WithAdminTx(r.Context(), rs.db, func(adminCtx context.Context, _ bun.Tx) error {
 		school, schoolErr := rs.SchoolRepo.FindBySlug(adminCtx, slug)
@@ -327,11 +327,13 @@ func (rs *Resource) listPublicCareOfferings(w http.ResponseWriter, r *http.Reque
 			if rs.RequestService != nil && !rs.RequestService.IsEnrollmentEnabled(txCtx) {
 				return enrollmentService.ErrEnrollmentDisabled
 			}
+			phase, phaseErr := rs.PhaseRepo.FindByID(txCtx, phaseID)
+			if phaseErr != nil {
+				return errors.New("phase not found")
+			}
+			selectionMode = phase.CareOfferingSelectionMode
 			list, listErr := rs.CareOfferingService.ListActiveByPhase(txCtx, phaseID)
 			offerings = list
-			if listErr == nil && rs.RequestService != nil {
-				careRequired = rs.RequestService.IsCareOfferingsRequired(txCtx)
-			}
 			return listErr
 		})
 	})
@@ -345,8 +347,9 @@ func (rs *Resource) listPublicCareOfferings(w http.ResponseWriter, r *http.Reque
 		items = append(items, toCareOfferingResponse(o))
 	}
 	common.Respond(w, r, http.StatusOK, PublicCareOfferingsResponse{
-		Offerings:    items,
-		CareRequired: careRequired,
+		Offerings:                 items,
+		CareOfferingSelectionMode: selectionMode,
+		CareRequired:              selectionMode != enrollmentModels.PhaseCareOfferingSelectionOptional,
 	}, "Public care offerings retrieved")
 }
 
@@ -374,12 +377,14 @@ func renderPublicEnrollmentError(w http.ResponseWriter, r *http.Request, err err
 }
 
 // PublicCareOfferingsResponse wraps the public care-offering catalog with
-// the tenant's "verpflichtend" flag so the parent form can render the
-// hint and validate before submit. The flag is server-authoritative — the
-// submission service re-checks it in defense-in-depth.
+// the phase's selection mode so the parent form can render the hint and
+// validate before submit. The mode is server-authoritative - the
+// submission service re-checks it in defense-in-depth. CareRequired is
+// kept as a legacy boolean for older frontend builds.
 type PublicCareOfferingsResponse struct {
-	Offerings    []CareOfferingResponse `json:"offerings"`
-	CareRequired bool                   `json:"care_required"`
+	Offerings                 []CareOfferingResponse `json:"offerings"`
+	CareOfferingSelectionMode string                 `json:"care_offering_selection_mode"`
+	CareRequired              bool                   `json:"care_required"`
 }
 
 // We deliberately don't expose enrollmentService here — it is already
@@ -389,14 +394,15 @@ var _ = enrollmentService.ErrCareOfferingNotFound
 // PublicPhase is the parent-safe shape returned by the public phases
 // endpoint. Intentionally slim — no created_by, no audit metadata.
 type PublicPhase struct {
-	ID                       string `json:"id"`
-	Name                     string `json:"name"`
-	Kind                     string `json:"kind"`
-	ServiceStartDate         string `json:"service_start_date"`
-	ServiceEndDate           string `json:"service_end_date"`
-	EnrollmentOpenAt         string `json:"enrollment_open_at,omitempty"`
-	EnrollmentCloseAt        string `json:"enrollment_close_at,omitempty"`
-	ShowStatusReasonToParent bool   `json:"show_status_reason_to_parent"`
+	ID                        string `json:"id"`
+	Name                      string `json:"name"`
+	Kind                      string `json:"kind"`
+	ServiceStartDate          string `json:"service_start_date"`
+	ServiceEndDate            string `json:"service_end_date"`
+	EnrollmentOpenAt          string `json:"enrollment_open_at,omitempty"`
+	EnrollmentCloseAt         string `json:"enrollment_close_at,omitempty"`
+	ShowStatusReasonToParent  bool   `json:"show_status_reason_to_parent"`
+	CareOfferingSelectionMode string `json:"care_offering_selection_mode"`
 }
 
 // listPublicPhases returns the currently-open phases for the given
@@ -438,12 +444,13 @@ func (rs *Resource) listPublicPhases(w http.ResponseWriter, r *http.Request) {
 	out := make([]PublicPhase, 0, len(phases))
 	for _, p := range phases {
 		entry := PublicPhase{
-			ID:                       strconv.FormatInt(p.ID, 10),
-			Name:                     p.Name,
-			Kind:                     p.Kind,
-			ServiceStartDate:         p.ServiceStartDate.Format("2006-01-02"),
-			ServiceEndDate:           p.ServiceEndDate.Format("2006-01-02"),
-			ShowStatusReasonToParent: p.ShowStatusReasonToParent,
+			ID:                        strconv.FormatInt(p.ID, 10),
+			Name:                      p.Name,
+			Kind:                      p.Kind,
+			ServiceStartDate:          p.ServiceStartDate.Format("2006-01-02"),
+			ServiceEndDate:            p.ServiceEndDate.Format("2006-01-02"),
+			ShowStatusReasonToParent:  p.ShowStatusReasonToParent,
+			CareOfferingSelectionMode: p.CareOfferingSelectionMode,
 		}
 		if p.EnrollmentOpenAt != nil {
 			entry.EnrollmentOpenAt = p.EnrollmentOpenAt.Format(time.RFC3339)

--- a/backend/api/enrollment/phase_handlers.go
+++ b/backend/api/enrollment/phase_handlers.go
@@ -20,17 +20,18 @@ import (
 // are formatted YYYY-MM-DD; timestamps RFC3339. The frontend reverses
 // the formatting when binding the edit form.
 type PhaseResponse struct {
-	ID                       string  `json:"id"`
-	Name                     string  `json:"name"`
-	Kind                     string  `json:"kind"`
-	ServiceStartDate         string  `json:"service_start_date"`
-	ServiceEndDate           string  `json:"service_end_date"`
-	EnrollmentOpenAt         *string `json:"enrollment_open_at,omitempty"`
-	EnrollmentCloseAt        *string `json:"enrollment_close_at,omitempty"`
-	FormSchemaID             *string `json:"form_schema_id,omitempty"`
-	ShowStatusReasonToParent bool    `json:"show_status_reason_to_parent"`
-	CareOverflowMode         string  `json:"care_overflow_mode"`
-	IsActive                 bool    `json:"is_active"`
+	ID                        string  `json:"id"`
+	Name                      string  `json:"name"`
+	Kind                      string  `json:"kind"`
+	ServiceStartDate          string  `json:"service_start_date"`
+	ServiceEndDate            string  `json:"service_end_date"`
+	EnrollmentOpenAt          *string `json:"enrollment_open_at,omitempty"`
+	EnrollmentCloseAt         *string `json:"enrollment_close_at,omitempty"`
+	FormSchemaID              *string `json:"form_schema_id,omitempty"`
+	ShowStatusReasonToParent  bool    `json:"show_status_reason_to_parent"`
+	CareOverflowMode          string  `json:"care_overflow_mode"`
+	CareOfferingSelectionMode string  `json:"care_offering_selection_mode"`
+	IsActive                  bool    `json:"is_active"`
 	// Rollover columns (migration 1.15.61) — emitted so the admin UI
 	// can distinguish rollover phases from fresh ones and surface the
 	// review-queue link only for rolled-forward phases.
@@ -45,16 +46,17 @@ type PhaseResponse struct {
 
 func toPhaseResponse(p *enrollmentModels.Phase) PhaseResponse {
 	resp := PhaseResponse{
-		ID:                       strconv.FormatInt(p.ID, 10),
-		Name:                     p.Name,
-		Kind:                     p.Kind,
-		ServiceStartDate:         p.ServiceStartDate.Format("2006-01-02"),
-		ServiceEndDate:           p.ServiceEndDate.Format("2006-01-02"),
-		ShowStatusReasonToParent: p.ShowStatusReasonToParent,
-		CareOverflowMode:         p.CareOverflowMode,
-		IsActive:                 p.IsActive,
-		CreatedAt:                p.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:                p.UpdatedAt.Format(time.RFC3339),
+		ID:                        strconv.FormatInt(p.ID, 10),
+		Name:                      p.Name,
+		Kind:                      p.Kind,
+		ServiceStartDate:          p.ServiceStartDate.Format("2006-01-02"),
+		ServiceEndDate:            p.ServiceEndDate.Format("2006-01-02"),
+		ShowStatusReasonToParent:  p.ShowStatusReasonToParent,
+		CareOverflowMode:          p.CareOverflowMode,
+		CareOfferingSelectionMode: p.CareOfferingSelectionMode,
+		IsActive:                  p.IsActive,
+		CreatedAt:                 p.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:                 p.UpdatedAt.Format(time.RFC3339),
 	}
 	if p.EnrollmentOpenAt != nil {
 		s := p.EnrollmentOpenAt.Format(time.RFC3339)
@@ -91,16 +93,17 @@ func toPhaseResponse(p *enrollmentModels.Phase) PhaseResponse {
 // row, or omitted/empty for "no custom fields" (the parent form
 // renders core fields only).
 type PhaseRequest struct {
-	Name                     string  `json:"name"`
-	Kind                     string  `json:"kind"`
-	ServiceStartDate         string  `json:"service_start_date"`
-	ServiceEndDate           string  `json:"service_end_date"`
-	EnrollmentOpenAt         *string `json:"enrollment_open_at,omitempty"`
-	EnrollmentCloseAt        *string `json:"enrollment_close_at,omitempty"`
-	FormSchemaID             *string `json:"form_schema_id,omitempty"`
-	ShowStatusReasonToParent bool    `json:"show_status_reason_to_parent"`
-	CareOverflowMode         string  `json:"care_overflow_mode"`
-	IsActive                 bool    `json:"is_active"`
+	Name                      string  `json:"name"`
+	Kind                      string  `json:"kind"`
+	ServiceStartDate          string  `json:"service_start_date"`
+	ServiceEndDate            string  `json:"service_end_date"`
+	EnrollmentOpenAt          *string `json:"enrollment_open_at,omitempty"`
+	EnrollmentCloseAt         *string `json:"enrollment_close_at,omitempty"`
+	FormSchemaID              *string `json:"form_schema_id,omitempty"`
+	ShowStatusReasonToParent  bool    `json:"show_status_reason_to_parent"`
+	CareOverflowMode          string  `json:"care_overflow_mode"`
+	CareOfferingSelectionMode string  `json:"care_offering_selection_mode"`
+	IsActive                  bool    `json:"is_active"`
 }
 
 func (req *PhaseRequest) Bind(_ *http.Request) error { return nil }
@@ -119,13 +122,14 @@ func (req *PhaseRequest) toModel(existingID int64) (*enrollmentModels.Phase, err
 	}
 
 	p := &enrollmentModels.Phase{
-		Name:                     req.Name,
-		Kind:                     req.Kind,
-		ServiceStartDate:         startDate,
-		ServiceEndDate:           endDate,
-		ShowStatusReasonToParent: req.ShowStatusReasonToParent,
-		CareOverflowMode:         req.CareOverflowMode,
-		IsActive:                 req.IsActive,
+		Name:                      req.Name,
+		Kind:                      req.Kind,
+		ServiceStartDate:          startDate,
+		ServiceEndDate:            endDate,
+		ShowStatusReasonToParent:  req.ShowStatusReasonToParent,
+		CareOverflowMode:          req.CareOverflowMode,
+		CareOfferingSelectionMode: req.CareOfferingSelectionMode,
+		IsActive:                  req.IsActive,
 	}
 	if req.EnrollmentOpenAt != nil && *req.EnrollmentOpenAt != "" {
 		t, parseErr := time.Parse(time.RFC3339, *req.EnrollmentOpenAt)

--- a/backend/api/enrollment/response_shapers_test.go
+++ b/backend/api/enrollment/response_shapers_test.go
@@ -111,21 +111,22 @@ func TestToPhaseResponse_StringifiesIDsAndFormatsDates(t *testing.T) {
 			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
 			UpdatedAt: time.Date(2026, 4, 2, 12, 0, 0, 0, time.UTC),
 		},
-		Name:                     "Schuljahr 2026/27",
-		Kind:                     enrollmentModels.PhaseKindSchoolYear,
-		ServiceStartDate:         time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
-		ServiceEndDate:           time.Date(2027, 7, 31, 0, 0, 0, 0, time.UTC),
-		EnrollmentOpenAt:         &openAt,
-		EnrollmentCloseAt:        &closeAt,
-		FormSchemaID:             &schemaID,
-		ShowStatusReasonToParent: true,
-		CareOverflowMode:         enrollmentModels.PhaseCareOverflowWaitlist,
-		IsActive:                 true,
-		RolloverSourcePhaseID:    &srcPhase,
-		RolloverMode:             &mode,
-		RolloverAutoApprove:      true,
-		RolloverDeadline:         &deadline,
-		RolloverBumpsGrade:       true,
+		Name:                      "Schuljahr 2026/27",
+		Kind:                      enrollmentModels.PhaseKindSchoolYear,
+		ServiceStartDate:          time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		ServiceEndDate:            time.Date(2027, 7, 31, 0, 0, 0, 0, time.UTC),
+		EnrollmentOpenAt:          &openAt,
+		EnrollmentCloseAt:         &closeAt,
+		FormSchemaID:              &schemaID,
+		ShowStatusReasonToParent:  true,
+		CareOverflowMode:          enrollmentModels.PhaseCareOverflowWaitlist,
+		CareOfferingSelectionMode: enrollmentModels.PhaseCareOfferingSelectionAtLeastOne,
+		IsActive:                  true,
+		RolloverSourcePhaseID:     &srcPhase,
+		RolloverMode:              &mode,
+		RolloverAutoApprove:       true,
+		RolloverDeadline:          &deadline,
+		RolloverBumpsGrade:        true,
 	}
 	out := toPhaseResponse(p)
 	assert.Equal(t, "1234", out.ID, "int64 ID stringified per CLAUDE rule 4")
@@ -148,6 +149,7 @@ func TestToPhaseResponse_StringifiesIDsAndFormatsDates(t *testing.T) {
 	assert.True(t, out.RolloverBumpsGrade)
 	assert.True(t, out.ShowStatusReasonToParent)
 	assert.Equal(t, enrollmentModels.PhaseCareOverflowWaitlist, out.CareOverflowMode)
+	assert.Equal(t, enrollmentModels.PhaseCareOfferingSelectionAtLeastOne, out.CareOfferingSelectionMode)
 	assert.Equal(t, "2026-04-01T12:00:00Z", out.CreatedAt)
 	assert.Equal(t, "2026-04-02T12:00:00Z", out.UpdatedAt)
 }

--- a/backend/api/enrollment/schema_handlers.go
+++ b/backend/api/enrollment/schema_handlers.go
@@ -22,25 +22,41 @@ import (
 // FormSchemaResponse is the wire shape returned to admin UIs. The id is
 // stringified so the frontend can keep its int64-as-string convention.
 type FormSchemaResponse struct {
-	ID        string                       `json:"id"`
-	Name      string                       `json:"name"`
-	Version   int                          `json:"version"`
-	IsActive  bool                         `json:"is_active"`
-	Fields    []enrollmentModels.FormField `json:"fields"`
-	CreatedBy string                       `json:"created_by"`
-	CreatedAt time.Time                    `json:"created_at"`
+	ID               string                            `json:"id"`
+	Name             string                            `json:"name"`
+	Version          int                               `json:"version"`
+	IsActive         bool                              `json:"is_active"`
+	Fields           []enrollmentModels.FormField      `json:"fields"`
+	CoreRequirements enrollmentModels.CoreRequirements `json:"core_requirements"`
+	CreatedBy        string                            `json:"created_by"`
+	CreatedAt        time.Time                         `json:"created_at"`
 }
 
 func toFormSchemaResponse(s *enrollmentModels.FormSchema) FormSchemaResponse {
 	return FormSchemaResponse{
-		ID:        strconv.FormatInt(s.ID, 10),
-		Name:      s.Name,
-		Version:   s.Version,
-		IsActive:  s.IsActive,
-		Fields:    s.Fields,
-		CreatedBy: strconv.FormatInt(s.CreatedBy, 10),
-		CreatedAt: s.CreatedAt,
+		ID:               strconv.FormatInt(s.ID, 10),
+		Name:             s.Name,
+		Version:          s.Version,
+		IsActive:         s.IsActive,
+		Fields:           s.Fields,
+		CoreRequirements: coreRequirementsValue(s.CoreRequirements),
+		CreatedBy:        strconv.FormatInt(s.CreatedBy, 10),
+		CreatedAt:        s.CreatedAt,
 	}
+}
+
+func coreRequirementsValue(value enrollmentModels.CoreRequirements) enrollmentModels.CoreRequirements {
+	if value == nil {
+		return enrollmentModels.CoreRequirements{}
+	}
+	return value
+}
+
+func coreRequirementsOrEmpty(value *enrollmentModels.CoreRequirements) enrollmentModels.CoreRequirements {
+	if value == nil {
+		return enrollmentModels.CoreRequirements{}
+	}
+	return *value
 }
 
 // PublishSchemaRequest is the wire shape POST /schema accepts. When
@@ -48,8 +64,9 @@ func toFormSchemaResponse(s *enrollmentModels.FormSchema) FormSchemaResponse {
 // when empty it falls back to PublishVersion (legacy single-schema
 // flow that writes the row under the default name).
 type PublishSchemaRequest struct {
-	Name   string                       `json:"name"`
-	Fields []enrollmentModels.FormField `json:"fields"`
+	Name             string                             `json:"name"`
+	Fields           []enrollmentModels.FormField       `json:"fields"`
+	CoreRequirements *enrollmentModels.CoreRequirements `json:"core_requirements,omitempty"`
 }
 
 // Bind satisfies render.Binder. Field-level validation runs in the
@@ -65,7 +82,8 @@ func (req *PublishSchemaRequest) Bind(_ *http.Request) error {
 // Only the fields are mutable — name is inherited from the source
 // schema so all versions of a logical schema share the same name.
 type UpdateSchemaRequest struct {
-	Fields []enrollmentModels.FormField `json:"fields"`
+	Fields           []enrollmentModels.FormField       `json:"fields"`
+	CoreRequirements *enrollmentModels.CoreRequirements `json:"core_requirements,omitempty"`
 }
 
 func (req *UpdateSchemaRequest) Bind(_ *http.Request) error {
@@ -81,9 +99,10 @@ func (req *UpdateSchemaRequest) Bind(_ *http.Request) error {
 // form. The fields array carries everything the dynamic renderer
 // consumes (label, type, options, validation).
 type PublicFormSchemaResponse struct {
-	ID      string                       `json:"id"`
-	Version int                          `json:"version"`
-	Fields  []enrollmentModels.FormField `json:"fields"`
+	ID               string                            `json:"id"`
+	Version          int                               `json:"version"`
+	Fields           []enrollmentModels.FormField      `json:"fields"`
+	CoreRequirements enrollmentModels.CoreRequirements `json:"core_requirements"`
 }
 
 // listPublicActiveSchema returns the form schema for a (tenant, phase)
@@ -145,9 +164,10 @@ func (rs *Resource) listPublicActiveSchema(w http.ResponseWriter, r *http.Reques
 	}
 
 	out := PublicFormSchemaResponse{
-		ID:      strconv.FormatInt(schema.ID, 10),
-		Version: schema.Version,
-		Fields:  schema.Fields,
+		ID:               strconv.FormatInt(schema.ID, 10),
+		Version:          schema.Version,
+		Fields:           schema.Fields,
+		CoreRequirements: coreRequirementsValue(schema.CoreRequirements),
 	}
 	common.Respond(w, r, http.StatusOK, out, "Public active form schema retrieved")
 }
@@ -302,8 +322,14 @@ func (rs *Resource) publishSchema(w http.ResponseWriter, r *http.Request) {
 
 	var schema *enrollmentModels.FormSchema
 	err := rs.runInTenantTx(r, func(ctx context.Context) error {
+		updateExisting := func(id int64) (*enrollmentModels.FormSchema, error) {
+			if req.CoreRequirements == nil {
+				return rs.FormSchemaService.UpdateSchema(ctx, id, req.Fields, int64(claims.ID))
+			}
+			return rs.FormSchemaService.UpdateSchema(ctx, id, req.Fields, int64(claims.ID), *req.CoreRequirements)
+		}
 		if req.Name != "" {
-			s, innerErr := rs.FormSchemaService.CreateSchema(ctx, req.Name, req.Fields, int64(claims.ID))
+			s, innerErr := rs.FormSchemaService.CreateSchema(ctx, req.Name, req.Fields, int64(claims.ID), coreRequirementsOrEmpty(req.CoreRequirements))
 			schema = s
 			return innerErr
 		}
@@ -315,19 +341,19 @@ func (rs *Resource) publishSchema(w http.ResponseWriter, r *http.Request) {
 			}
 			for _, version := range versions {
 				if version.Name == "Standardformular" {
-					s, updateErr := rs.FormSchemaService.UpdateSchema(ctx, version.ID, req.Fields, int64(claims.ID))
+					s, updateErr := updateExisting(version.ID)
 					schema = s
 					return updateErr
 				}
 			}
-			s, createErr := rs.FormSchemaService.CreateSchema(ctx, "Standardformular", req.Fields, int64(claims.ID))
+			s, createErr := rs.FormSchemaService.CreateSchema(ctx, "Standardformular", req.Fields, int64(claims.ID), coreRequirementsOrEmpty(req.CoreRequirements))
 			schema = s
 			return createErr
 		}
 		if innerErr != nil {
 			return innerErr
 		}
-		s, innerErr := rs.FormSchemaService.UpdateSchema(ctx, active.ID, req.Fields, int64(claims.ID))
+		s, innerErr := updateExisting(active.ID)
 		schema = s
 		return innerErr
 	})
@@ -375,7 +401,15 @@ func (rs *Resource) updateSchema(w http.ResponseWriter, r *http.Request) {
 
 	var schema *enrollmentModels.FormSchema
 	txErr := rs.runInTenantTx(r, func(ctx context.Context) error {
-		s, innerErr := rs.FormSchemaService.UpdateSchema(ctx, id, req.Fields, int64(claims.ID))
+		var (
+			s        *enrollmentModels.FormSchema
+			innerErr error
+		)
+		if req.CoreRequirements == nil {
+			s, innerErr = rs.FormSchemaService.UpdateSchema(ctx, id, req.Fields, int64(claims.ID))
+		} else {
+			s, innerErr = rs.FormSchemaService.UpdateSchema(ctx, id, req.Fields, int64(claims.ID), *req.CoreRequirements)
+		}
 		schema = s
 		return innerErr
 	})

--- a/backend/api/enrollment/schema_handlers_test.go
+++ b/backend/api/enrollment/schema_handlers_test.go
@@ -33,11 +33,15 @@ type mockFormSchemaService struct {
 	createName       string
 	createFields     []enrollmentModels.FormField
 	createCreatedBy  int64
+	createCore       enrollmentModels.CoreRequirements
+	createCoreSet    bool
 	createResult     *enrollmentModels.FormSchema
 	createErr        error
 	updateID         int64
 	updateFields     []enrollmentModels.FormField
 	updateUpdatedBy  int64
+	updateCore       enrollmentModels.CoreRequirements
+	updateCoreSet    bool
 	updateResult     *enrollmentModels.FormSchema
 	updateErr        error
 	deleteID         int64
@@ -61,23 +65,31 @@ func (m *mockFormSchemaService) GetByID(_ context.Context, id int64) (*enrollmen
 func (m *mockFormSchemaService) ListVersions(_ context.Context) ([]*enrollmentModels.FormSchema, error) {
 	return m.listResult, m.listErr
 }
-func (m *mockFormSchemaService) CreateSchema(_ context.Context, name string, fields []enrollmentModels.FormField, createdBy int64) (*enrollmentModels.FormSchema, error) {
+func (m *mockFormSchemaService) CreateSchema(_ context.Context, name string, fields []enrollmentModels.FormField, createdBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
 	m.createName = name
 	m.createFields = fields
 	m.createCreatedBy = createdBy
+	if len(coreRequirements) > 0 {
+		m.createCore = coreRequirements[0]
+		m.createCoreSet = true
+	}
 	return m.createResult, m.createErr
 }
-func (m *mockFormSchemaService) UpdateSchema(_ context.Context, id int64, fields []enrollmentModels.FormField, updatedBy int64) (*enrollmentModels.FormSchema, error) {
+func (m *mockFormSchemaService) UpdateSchema(_ context.Context, id int64, fields []enrollmentModels.FormField, updatedBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
 	m.updateID = id
 	m.updateFields = fields
 	m.updateUpdatedBy = updatedBy
+	if len(coreRequirements) > 0 {
+		m.updateCore = coreRequirements[0]
+		m.updateCoreSet = true
+	}
 	return m.updateResult, m.updateErr
 }
 func (m *mockFormSchemaService) DeleteSchema(_ context.Context, id int64) error {
 	m.deleteID = id
 	return m.deleteErr
 }
-func (m *mockFormSchemaService) PublishVersion(_ context.Context, fields []enrollmentModels.FormField, createdBy int64) (*enrollmentModels.FormSchema, error) {
+func (m *mockFormSchemaService) PublishVersion(_ context.Context, fields []enrollmentModels.FormField, createdBy int64, _ ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
 	m.publishVFields = fields
 	m.publishVCreated = createdBy
 	return m.publishVResult, m.publishVErr
@@ -309,6 +321,8 @@ func TestPublishSchemaHandler_NoNameWithActiveSchemaUpdatesIt(t *testing.T) {
 	require.Equal(t, http.StatusCreated, w.Code)
 	assert.Equal(t, int64(9999), mock.updateID,
 		"no name + active schema exists → UpdateSchema on active.id")
+	assert.False(t, mock.updateCoreSet,
+		"omitted core_requirements must preserve the source schema's existing core requirements")
 }
 
 func TestPublishSchemaHandler_ValidationErrorReturns400(t *testing.T) {
@@ -357,6 +371,20 @@ func TestUpdateSchemaHandler_HappyPath(t *testing.T) {
 	assert.Equal(t, int64(1234), mock.updateID)
 	assert.Equal(t, int64(4321), mock.updateUpdatedBy)
 	assert.Len(t, mock.updateFields, 1)
+}
+
+func TestUpdateSchemaHandler_ForwardsCoreRequirementsWhenPresent(t *testing.T) {
+	mock := &mockFormSchemaService{updateResult: makeFormSchema(1234, "Klassenanmeldung", 2)}
+	router := buildSchemaRouter(mock)
+	w := executeSchemaJSON(t, router, http.MethodPut, "/enrollment/schema/1234",
+		map[string]any{
+			"fields":            []map[string]any{{"key": "x", "label": "X", "type": "text", "sort_order": 0}},
+			"core_requirements": map[string]bool{"guardian_phone": true},
+		})
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.True(t, mock.updateCoreSet,
+		"present core_requirements, even when sparse, must be forwarded so admins can change the matrix")
+	assert.True(t, mock.updateCore.Required(enrollmentModels.CoreRequirementGuardianPhone))
 }
 
 func TestUpdateSchemaHandler_ServiceErrorReturns400(t *testing.T) {

--- a/backend/api/enrollment/submission_handlers.go
+++ b/backend/api/enrollment/submission_handlers.go
@@ -211,10 +211,11 @@ func buildServiceRequest(wireReq *SubmitEnrollmentRequest, tenantID int64, remot
 // in sync with SUBMISSION_ERROR_MESSAGES in
 // frontend/src/lib/enrollment-submission-api.ts.
 const (
-	ErrCodeEnrollmentCareOfferingMissing = "enrollment.care_offering_missing"
-	ErrCodeEnrollmentCareOfferingFull    = "enrollment.care_offering_full"
-	ErrCodeEnrollmentInvalidPhone        = "enrollment.invalid_phone"
-	ErrCodeEnrollmentInvalidEmail        = "enrollment.invalid_email"
+	ErrCodeEnrollmentCareOfferingMissing         = "enrollment.care_offering_missing"
+	ErrCodeEnrollmentRequiredCareOfferingMissing = "enrollment.required_care_offering_missing"
+	ErrCodeEnrollmentCareOfferingFull            = "enrollment.care_offering_full"
+	ErrCodeEnrollmentInvalidPhone                = "enrollment.invalid_phone"
+	ErrCodeEnrollmentInvalidEmail                = "enrollment.invalid_email"
 )
 
 // mapSubmitError translates service-layer sentinel errors into HTTP
@@ -226,6 +227,8 @@ func mapSubmitError(w http.ResponseWriter, r *http.Request, err error) {
 		common.RenderError(w, r, common.ErrorForbidden(err))
 	case errors.Is(err, enrollmentService.ErrCareOfferingMissing):
 		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, ErrCodeEnrollmentCareOfferingMissing))
+	case errors.Is(err, enrollmentService.ErrRequiredCareOfferingMissing):
+		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, ErrCodeEnrollmentRequiredCareOfferingMissing))
 	case errors.Is(err, enrollmentService.ErrInvalidGuardianPhone):
 		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, ErrCodeEnrollmentInvalidPhone))
 	// Must precede the generic ErrInvalidSubmission case below: the email

--- a/backend/api/enrollment/submission_handlers.go
+++ b/backend/api/enrollment/submission_handlers.go
@@ -212,6 +212,7 @@ func buildServiceRequest(wireReq *SubmitEnrollmentRequest, tenantID int64, remot
 // frontend/src/lib/enrollment-submission-api.ts.
 const (
 	ErrCodeEnrollmentCareOfferingMissing         = "enrollment.care_offering_missing"
+	ErrCodeEnrollmentCareOfferingExactlyOne      = "enrollment.care_offering_exactly_one"
 	ErrCodeEnrollmentRequiredCareOfferingMissing = "enrollment.required_care_offering_missing"
 	ErrCodeEnrollmentCareOfferingFull            = "enrollment.care_offering_full"
 	ErrCodeEnrollmentInvalidPhone                = "enrollment.invalid_phone"
@@ -227,6 +228,8 @@ func mapSubmitError(w http.ResponseWriter, r *http.Request, err error) {
 		common.RenderError(w, r, common.ErrorForbidden(err))
 	case errors.Is(err, enrollmentService.ErrCareOfferingMissing):
 		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, ErrCodeEnrollmentCareOfferingMissing))
+	case errors.Is(err, enrollmentService.ErrCareOfferingExactlyOneRequired):
+		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, ErrCodeEnrollmentCareOfferingExactlyOne))
 	case errors.Is(err, enrollmentService.ErrRequiredCareOfferingMissing):
 		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, ErrCodeEnrollmentRequiredCareOfferingMissing))
 	case errors.Is(err, enrollmentService.ErrInvalidGuardianPhone):

--- a/backend/database/migrations/001015079_form_schemas_core_requirements.go
+++ b/backend/database/migrations/001015079_form_schemas_core_requirements.go
@@ -1,0 +1,46 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	formSchemasCoreRequirementsVersion     = "1.15.79"
+	formSchemasCoreRequirementsDescription = "Add core_requirements JSONB to enrollment.form_schemas so each form template can mark supported built-in enrollment fields such as guardian phone as required."
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     formSchemasCoreRequirementsVersion,
+		Description: formSchemasCoreRequirementsDescription,
+		DependsOn: []string{
+			formSchemasAddNameVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Migration 1.15.79: Adding core_requirements to enrollment.form_schemas...")
+			if _, err := db.NewRaw(`
+				ALTER TABLE enrollment.form_schemas
+				ADD COLUMN IF NOT EXISTS core_requirements JSONB NOT NULL DEFAULT '{}'::jsonb;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed adding core_requirements column: %w", err)
+			}
+			return nil
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Rolling back migration 1.15.79...")
+			if _, err := db.NewRaw(`
+				ALTER TABLE enrollment.form_schemas
+				DROP COLUMN IF EXISTS core_requirements;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed dropping core_requirements column: %w", err)
+			}
+			return nil
+		},
+	)
+}

--- a/backend/database/migrations/001015080_care_offerings_is_required.go
+++ b/backend/database/migrations/001015080_care_offerings_is_required.go
@@ -1,0 +1,46 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	careOfferingsIsRequiredVersion     = "1.15.80"
+	careOfferingsIsRequiredDescription = "Add is_required flag to enrollment.care_offerings so a school can mark a specific care offering as mandatory for every child in the phase."
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     careOfferingsIsRequiredVersion,
+		Description: careOfferingsIsRequiredDescription,
+		DependsOn: []string{
+			createCareOfferingsVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Migration 1.15.80: Adding is_required to enrollment.care_offerings...")
+			if _, err := db.NewRaw(`
+				ALTER TABLE enrollment.care_offerings
+				ADD COLUMN IF NOT EXISTS is_required BOOLEAN NOT NULL DEFAULT FALSE;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed adding is_required column: %w", err)
+			}
+			return nil
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Rolling back migration 1.15.80...")
+			if _, err := db.NewRaw(`
+				ALTER TABLE enrollment.care_offerings
+				DROP COLUMN IF EXISTS is_required;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed dropping is_required column: %w", err)
+			}
+			return nil
+		},
+	)
+}

--- a/backend/database/migrations/001015095_form_schemas_core_requirements.go
+++ b/backend/database/migrations/001015095_form_schemas_core_requirements.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	formSchemasCoreRequirementsVersion     = "1.15.79"
+	formSchemasCoreRequirementsVersion     = "1.15.95"
 	formSchemasCoreRequirementsDescription = "Add core_requirements JSONB to enrollment.form_schemas so each form template can mark supported built-in enrollment fields such as guardian phone as required."
 )
 
@@ -23,7 +23,7 @@ func init() {
 
 	Migrations.MustRegister(
 		func(ctx context.Context, db *bun.DB) error {
-			fmt.Println("Migration 1.15.79: Adding core_requirements to enrollment.form_schemas...")
+			fmt.Println("Migration 1.15.95: Adding core_requirements to enrollment.form_schemas...")
 			if _, err := db.NewRaw(`
 				ALTER TABLE enrollment.form_schemas
 				ADD COLUMN IF NOT EXISTS core_requirements JSONB NOT NULL DEFAULT '{}'::jsonb;
@@ -33,7 +33,7 @@ func init() {
 			return nil
 		},
 		func(ctx context.Context, db *bun.DB) error {
-			fmt.Println("Rolling back migration 1.15.79...")
+			fmt.Println("Rolling back migration 1.15.95...")
 			if _, err := db.NewRaw(`
 				ALTER TABLE enrollment.form_schemas
 				DROP COLUMN IF EXISTS core_requirements;

--- a/backend/database/migrations/001015096_care_offerings_is_required.go
+++ b/backend/database/migrations/001015096_care_offerings_is_required.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	careOfferingsIsRequiredVersion     = "1.15.80"
+	careOfferingsIsRequiredVersion     = "1.15.96"
 	careOfferingsIsRequiredDescription = "Add is_required flag to enrollment.care_offerings so a school can mark a specific care offering as mandatory for every child in the phase."
 )
 
@@ -23,7 +23,7 @@ func init() {
 
 	Migrations.MustRegister(
 		func(ctx context.Context, db *bun.DB) error {
-			fmt.Println("Migration 1.15.80: Adding is_required to enrollment.care_offerings...")
+			fmt.Println("Migration 1.15.96: Adding is_required to enrollment.care_offerings...")
 			if _, err := db.NewRaw(`
 				ALTER TABLE enrollment.care_offerings
 				ADD COLUMN IF NOT EXISTS is_required BOOLEAN NOT NULL DEFAULT FALSE;
@@ -33,7 +33,7 @@ func init() {
 			return nil
 		},
 		func(ctx context.Context, db *bun.DB) error {
-			fmt.Println("Rolling back migration 1.15.80...")
+			fmt.Println("Rolling back migration 1.15.96...")
 			if _, err := db.NewRaw(`
 				ALTER TABLE enrollment.care_offerings
 				DROP COLUMN IF EXISTS is_required;

--- a/backend/database/migrations/001015097_phase_care_offering_selection_mode.go
+++ b/backend/database/migrations/001015097_phase_care_offering_selection_mode.go
@@ -1,0 +1,72 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	phaseCareOfferingSelectionModeVersion     = "1.15.97"
+	phaseCareOfferingSelectionModeDescription = "Add per-phase care offering selection mode for optional, at-least-one, or exactly-one parent choices."
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     phaseCareOfferingSelectionModeVersion,
+		Description: phaseCareOfferingSelectionModeDescription,
+		DependsOn:   []string{createEnrollmentPhasesVersion, configSettingValuesVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Migration 1.15.97: Adding care_offering_selection_mode to enrollment.phases...")
+			if _, err := db.NewRaw(`
+				ALTER TABLE enrollment.phases
+				ADD COLUMN IF NOT EXISTS care_offering_selection_mode TEXT NOT NULL DEFAULT 'optional';
+
+				ALTER TABLE enrollment.phases
+				DROP CONSTRAINT IF EXISTS chk_enrollment_phases_care_offering_selection_mode;
+
+				ALTER TABLE enrollment.phases
+				ADD CONSTRAINT chk_enrollment_phases_care_offering_selection_mode
+				CHECK (care_offering_selection_mode IN ('optional', 'at_least_one', 'exactly_one'));
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed adding care_offering_selection_mode: %w", err)
+			}
+
+			if _, err := db.NewRaw(`
+				UPDATE enrollment.phases AS p
+				SET care_offering_selection_mode = 'at_least_one'
+				FROM config.setting_values AS sv
+				WHERE sv.tenant_id = p.tenant_id
+					AND sv.setting_key = 'enrollment.care_offerings_required'
+					AND sv.value = 'true'::jsonb;
+
+				DELETE FROM config.setting_values
+				WHERE setting_key = 'enrollment.care_offerings_required';
+
+				DELETE FROM config.setting_audit
+				WHERE setting_key = 'enrollment.care_offerings_required';
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed backfilling care_offering_selection_mode: %w", err)
+			}
+
+			return nil
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Rolling back migration 1.15.97...")
+			if _, err := db.NewRaw(`
+				ALTER TABLE enrollment.phases
+				DROP CONSTRAINT IF EXISTS chk_enrollment_phases_care_offering_selection_mode;
+
+				ALTER TABLE enrollment.phases
+				DROP COLUMN IF EXISTS care_offering_selection_mode;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed dropping care_offering_selection_mode: %w", err)
+			}
+			return nil
+		},
+	)
+}

--- a/backend/database/repositories/enrollment/form_schema_repository.go
+++ b/backend/database/repositories/enrollment/form_schema_repository.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/models/enrollment"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
 
@@ -44,11 +45,14 @@ func (r *FormSchemaRepository) Create(ctx context.Context, schema *enrollment.Fo
 // FindByID retrieves a schema by primary key.
 func (r *FormSchemaRepository) FindByID(ctx context.Context, id int64) (*enrollment.FormSchema, error) {
 	schema := new(enrollment.FormSchema)
-	err := base.GetDB(ctx, r.db).NewSelect().
+	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(schema).
 		ModelTableExpr(formSchemaTableExpr).
-		Where(`"form_schema".id = ?`, id).
-		Scan(ctx)
+		Where(`"form_schema".id = ?`, id)
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where(`"form_schema".tenant_id = ?`, tenantID)
+	}
+	err := query.Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("form schema %d not found", id)
@@ -64,11 +68,14 @@ func (r *FormSchemaRepository) FindByID(ctx context.Context, id int64) (*enrollm
 // layer translates that to its own ErrNoActiveSchema sentinel.
 func (r *FormSchemaRepository) FindActive(ctx context.Context) (*enrollment.FormSchema, error) {
 	schema := new(enrollment.FormSchema)
-	err := base.GetDB(ctx, r.db).NewSelect().
+	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(schema).
 		ModelTableExpr(formSchemaTableExpr).
-		Where(`"form_schema".is_active = true`).
-		Scan(ctx)
+		Where(`"form_schema".is_active = true`)
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where(`"form_schema".tenant_id = ?`, tenantID)
+	}
+	err := query.Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("no active form schema for tenant: %w", err)
@@ -82,11 +89,14 @@ func (r *FormSchemaRepository) FindActive(ctx context.Context) (*enrollment.Form
 // ordered newest-version-first.
 func (r *FormSchemaRepository) ListByTenant(ctx context.Context) ([]*enrollment.FormSchema, error) {
 	var schemas []*enrollment.FormSchema
-	err := base.GetDB(ctx, r.db).NewSelect().
+	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&schemas).
 		ModelTableExpr(formSchemaTableExpr).
-		OrderExpr(`"form_schema".version DESC`).
-		Scan(ctx)
+		OrderExpr(`"form_schema".version DESC`)
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where(`"form_schema".tenant_id = ?`, tenantID)
+	}
+	err := query.Scan(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list form schemas: %w", err)
 	}
@@ -98,10 +108,13 @@ func (r *FormSchemaRepository) ListByTenant(ctx context.Context) ([]*enrollment.
 // single-schema publish path. New code should prefer NextVersionForName.
 func (r *FormSchemaRepository) NextVersion(ctx context.Context) (int, error) {
 	var maxVersion int
-	err := base.GetDB(ctx, r.db).NewSelect().
+	query := base.GetDB(ctx, r.db).NewSelect().
 		ColumnExpr(`COALESCE(MAX(version), 0)`).
-		TableExpr(`enrollment.form_schemas`).
-		Scan(ctx, &maxVersion)
+		TableExpr(`enrollment.form_schemas`)
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+	err := query.Scan(ctx, &maxVersion)
 	if err != nil {
 		return 0, fmt.Errorf("failed to read max version: %w", err)
 	}
@@ -113,11 +126,14 @@ func (r *FormSchemaRepository) NextVersion(ctx context.Context) (int, error) {
 // with that name — i.e. first version of a freshly created schema.
 func (r *FormSchemaRepository) NextVersionForName(ctx context.Context, name string) (int, error) {
 	var maxVersion int
-	err := base.GetDB(ctx, r.db).NewSelect().
+	query := base.GetDB(ctx, r.db).NewSelect().
 		ColumnExpr(`COALESCE(MAX(version), 0)`).
 		TableExpr(`enrollment.form_schemas`).
-		Where(`name = ?`, name).
-		Scan(ctx, &maxVersion)
+		Where(`name = ?`, name)
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+	err := query.Scan(ctx, &maxVersion)
 	if err != nil {
 		return 0, fmt.Errorf("failed to read max version for name %q: %w", name, err)
 	}
@@ -130,12 +146,15 @@ func (r *FormSchemaRepository) NextVersionForName(ctx context.Context, name stri
 // the at-most-one-active invariant; running this first prevents a unique
 // violation when the new version is inserted with is_active=true.
 func (r *FormSchemaRepository) DeactivatePrevious(ctx context.Context) error {
-	_, err := base.GetDB(ctx, r.db).NewUpdate().
+	query := base.GetDB(ctx, r.db).NewUpdate().
 		Model((*enrollment.FormSchema)(nil)).
 		ModelTableExpr(formSchemaTableExpr).
 		Set("is_active = false").
-		Where(`"form_schema".is_active = true`).
-		Exec(ctx)
+		Where(`"form_schema".is_active = true`)
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where(`"form_schema".tenant_id = ?`, tenantID)
+	}
+	_, err := query.Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to deactivate previous schemas: %w", err)
 	}
@@ -144,12 +163,15 @@ func (r *FormSchemaRepository) DeactivatePrevious(ctx context.Context) error {
 
 // UpdateActiveFlag toggles is_active on a single schema row.
 func (r *FormSchemaRepository) UpdateActiveFlag(ctx context.Context, id int64, isActive bool) error {
-	res, err := base.GetDB(ctx, r.db).NewUpdate().
+	query := base.GetDB(ctx, r.db).NewUpdate().
 		Model((*enrollment.FormSchema)(nil)).
 		ModelTableExpr(formSchemaTableExpr).
 		Set("is_active = ?", isActive).
-		Where(`"form_schema".id = ?`, id).
-		Exec(ctx)
+		Where(`"form_schema".id = ?`, id)
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where(`"form_schema".tenant_id = ?`, tenantID)
+	}
+	res, err := query.Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to update is_active: %w", err)
 	}
@@ -163,11 +185,14 @@ func (r *FormSchemaRepository) UpdateActiveFlag(ctx context.Context, id int64, i
 // DeleteByName removes every version of a logical schema. Callers must
 // check phase and request references first.
 func (r *FormSchemaRepository) DeleteByName(ctx context.Context, name string) error {
-	res, err := base.GetDB(ctx, r.db).NewDelete().
+	query := base.GetDB(ctx, r.db).NewDelete().
 		Model((*enrollment.FormSchema)(nil)).
 		ModelTableExpr(formSchemaTableExpr).
-		Where(`"form_schema".name = ?`, name).
-		Exec(ctx)
+		Where(`"form_schema".name = ?`, name)
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where(`"form_schema".tenant_id = ?`, tenantID)
+	}
+	res, err := query.Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to delete form schema %q: %w", name, err)
 	}

--- a/backend/database/repositories/enrollment/form_schema_repository_test.go
+++ b/backend/database/repositories/enrollment/form_schema_repository_test.go
@@ -33,7 +33,7 @@ func setupSchemaRepoTest(t *testing.T) (*bun.DB, enrollmentModels.FormSchemaRepo
 	t.Helper()
 	db := testpkg.SetupTestDB(t)
 	t.Cleanup(func() { _ = db.Close() })
-	var tenantID int64 = 1
+	tenantID := testpkg.UniqueTestTenantID(t)
 	testpkg.EnsureTestTenant(t, db, tenantID)
 
 	account := testpkg.CreateTestAccount(t, db, "schemarepo")

--- a/backend/database/repositories/enrollment/phase_repository.go
+++ b/backend/database/repositories/enrollment/phase_repository.go
@@ -190,7 +190,7 @@ func (r *PhaseRepository) RepointFormSchema(ctx context.Context, fromIDs []int64
 		ModelTableExpr(phaseTableExpr).
 		Set("form_schema_id = ?", toID).
 		Set("updated_at = NOW()").
-		Where(`"phase".form_schema_id IN (?)`, bun.In(fromIDs)).
+		Where(`"phase".form_schema_id IN (?)`, bun.List(fromIDs)).
 		Exec(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to repoint phases to schema %d: %w", toID, err)

--- a/backend/database/repositories/enrollment/phase_repository.go
+++ b/backend/database/repositories/enrollment/phase_repository.go
@@ -174,6 +174,31 @@ func (r *PhaseRepository) ExistsByFormSchemaID(ctx context.Context, schemaID int
 	return count > 0, nil
 }
 
+// RepointFormSchema advances every phase currently bound to one of
+// fromIDs so it points at toID instead. Used when a schema is edited:
+// publishing a new version mints a new schema id, and live phases must
+// follow it so the admin's change reaches the public form without a
+// manual re-bind. Already-submitted requests keep their own pinned
+// schema_id (copied at submit time), so history is unaffected. Returns
+// the number of phases updated. Tenant-scoped via the request's RLS tx.
+func (r *PhaseRepository) RepointFormSchema(ctx context.Context, fromIDs []int64, toID int64) (int64, error) {
+	if len(fromIDs) == 0 {
+		return 0, nil
+	}
+	res, err := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*enrollment.Phase)(nil)).
+		ModelTableExpr(phaseTableExpr).
+		Set("form_schema_id = ?", toID).
+		Set("updated_at = NOW()").
+		Where(`"phase".form_schema_id IN (?)`, bun.In(fromIDs)).
+		Exec(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to repoint phases to schema %d: %w", toID, err)
+	}
+	rows, _ := res.RowsAffected()
+	return rows, nil
+}
+
 // ExistsByRolloverSourcePhaseID is the rollover-uniqueness check.
 // Returns true if any phase already references the given phase as its
 // rollover_source_phase_id — i.e., the source has been rolled forward

--- a/backend/database/repositories/enrollment/phase_repository.go
+++ b/backend/database/repositories/enrollment/phase_repository.go
@@ -78,6 +78,7 @@ func (r *PhaseRepository) Update(ctx context.Context, phase *enrollment.Phase) e
 		Set("form_schema_id = ?", phase.FormSchemaID).
 		Set("show_status_reason_to_parent = ?", phase.ShowStatusReasonToParent).
 		Set("care_overflow_mode = ?", phase.CareOverflowMode).
+		Set("care_offering_selection_mode = ?", phase.CareOfferingSelectionMode).
 		Set("is_active = ?", phase.IsActive).
 		Set("updated_at = NOW()").
 		Where(`"phase".id = ?`, phase.ID).

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -108,13 +108,13 @@ const (
 )
 
 // Parent-enrollment settings. Tenant-wide behavioural toggles only -
-// per-phase overrides (open window, form schema, overflow mode, status-
-// reason visibility) live on enrollment.phases columns.
+// per-phase overrides (open window, form schema, care offering selection,
+// overflow mode, status-reason visibility) live on enrollment.phases
+// columns.
 const (
 	KeyEnrollmentEnabled                     = "enrollment.enabled"
 	KeyEnrollmentCollectGradeLevel           = "enrollment.collect_grade_level"
 	KeyEnrollmentCareOfferingsEnabled        = "enrollment.care_offerings_enabled"
-	KeyEnrollmentCareOfferingsRequired       = "enrollment.care_offerings_required"
 	KeyEnrollmentDefaultActivationMode       = "enrollment.default_activation_mode"
 	KeyEnrollmentNotificationEmails          = "enrollment.notification_emails"
 	KeyEnrollmentAutoInviteGuardianOnApprove = "enrollment.auto_invite_guardian_on_approval"

--- a/backend/models/enrollment/care_offering.go
+++ b/backend/models/enrollment/care_offering.go
@@ -47,6 +47,7 @@ type CareOffering struct {
 	Capacity            *int     `bun:"capacity" json:"capacity,omitempty"`
 	PriceCents          *int     `bun:"price_cents" json:"price_cents,omitempty"`
 	IsActive            bool     `bun:"is_active,notnull" json:"is_active"`
+	IsRequired          bool     `bun:"is_required,notnull,default:false" json:"is_required"`
 	SortOrder           int      `bun:"sort_order,notnull,default:0" json:"sort_order"`
 }
 
@@ -83,6 +84,13 @@ func (c *CareOffering) Validate() error {
 	}
 	if c.PriceCents != nil && *c.PriceCents < 0 {
 		return errors.New("price_cents must be non-negative")
+	}
+	// A required offering must be available to every child, so it cannot
+	// carry a hard capacity limit - otherwise a full offering would block
+	// every new enrollment in the phase. The admin editor prevents the
+	// combination; this is the backstop.
+	if c.IsRequired && c.Capacity != nil {
+		return errors.New("a required care offering must not have a capacity limit")
 	}
 	return nil
 }

--- a/backend/models/enrollment/care_offering_validate_test.go
+++ b/backend/models/enrollment/care_offering_validate_test.go
@@ -133,6 +133,33 @@ func TestCareOffering_Validate_AcceptsZeroPrice(t *testing.T) {
 	assert.NoError(t, c.Validate())
 }
 
+func TestCareOffering_Validate_AcceptsRequiredWithoutCapacity(t *testing.T) {
+	c := validCareOffering()
+	c.IsRequired = true
+	c.Capacity = nil
+	assert.NoError(t, c.Validate())
+}
+
+func TestCareOffering_Validate_RejectsRequiredWithCapacity(t *testing.T) {
+	// A required offering must be available to every child, so a hard
+	// capacity limit (which could fill up and block enrollments) is illegal.
+	c := validCareOffering()
+	c.IsRequired = true
+	cap := 20
+	c.Capacity = &cap
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "capacity")
+}
+
+func TestCareOffering_Validate_AcceptsCapacityWhenNotRequired(t *testing.T) {
+	c := validCareOffering()
+	c.IsRequired = false
+	cap := 20
+	c.Capacity = &cap
+	assert.NoError(t, c.Validate())
+}
+
 func TestCareOffering_HasUnlimitedCapacity_NilIsUnlimited(t *testing.T) {
 	c := validCareOffering()
 	c.Capacity = nil

--- a/backend/models/enrollment/form_schema.go
+++ b/backend/models/enrollment/form_schema.go
@@ -1,12 +1,8 @@
 // Package enrollment holds domain entities for the parent-enrollment
 // feature. The schema is split across several tables - form_schemas
 // (versioned form definitions), requests (parent submissions),
-// request_children (per-child decisions), and (PR 6) care_offerings +
+// request_children (per-child decisions), and care_offerings +
 // request_child_offerings.
-//
-// PR 5 ships form_schemas, requests, request_children, plus the
-// platform.email_outbox table which lives outside this package because
-// it's shared across features.
 package enrollment
 
 import (
@@ -94,6 +90,36 @@ type FormField struct {
 	SortOrder   int                  `json:"sort_order"`
 	AppliesToCh bool                 `json:"applies_to_child,omitempty"` // false (default) = guardian-level field; true = per-child field
 	Target      string               `json:"target,omitempty"`           // "" = free custom field; otherwise one of ReservedTargets
+}
+
+const CoreRequirementGuardianPhone = "guardian_phone"
+
+var validCoreRequirements = map[string]bool{
+	CoreRequirementGuardianPhone: true,
+}
+
+// CoreRequirements stores per-template required-state for core fields
+// that are rendered from dedicated request/request_child columns rather
+// than from FormSchema.Fields. A missing or false value means optional.
+type CoreRequirements map[string]bool
+
+// Validate rejects unknown core requirement keys so typos in the admin API
+// do not silently create requirements the public form cannot enforce.
+func (c CoreRequirements) Validate() error {
+	for key := range c {
+		if !validCoreRequirements[key] {
+			return fmt.Errorf("unknown core requirement %q", key)
+		}
+	}
+	return nil
+}
+
+// Required reports whether the given core field must be answered.
+func (c CoreRequirements) Required(key string) bool {
+	if c == nil {
+		return false
+	}
+	return c[key]
 }
 
 // ReservedTargets maps each known target to the FormFieldType it requires
@@ -347,11 +373,12 @@ func (c *ContactEntry) Validate() error {
 type FormSchema struct {
 	base.Model `bun:"schema:enrollment,table:form_schemas"`
 	base.TenantModel
-	Name      string      `bun:"name,notnull,default:''" json:"name"`
-	Version   int         `bun:"version,notnull" json:"version"`
-	Fields    []FormField `bun:"fields,type:jsonb,notnull,default:'[]'" json:"fields"`
-	IsActive  bool        `bun:"is_active,notnull,default:false" json:"is_active"`
-	CreatedBy int64       `bun:"created_by,notnull" json:"created_by"`
+	Name             string           `bun:"name,notnull,default:''" json:"name"`
+	Version          int              `bun:"version,notnull" json:"version"`
+	Fields           []FormField      `bun:"fields,type:jsonb,notnull,default:'[]'" json:"fields"`
+	CoreRequirements CoreRequirements `bun:"core_requirements,type:jsonb,notnull,default:'{}'" json:"core_requirements"`
+	IsActive         bool             `bun:"is_active,notnull,default:false" json:"is_active"`
+	CreatedBy        int64            `bun:"created_by,notnull" json:"created_by"`
 }
 
 // TableName returns the schema-qualified table name.
@@ -369,6 +396,12 @@ func (s *FormSchema) Validate() error {
 	}
 	if s.CreatedBy <= 0 {
 		return errors.New("form schema created_by is required")
+	}
+	if s.CoreRequirements == nil {
+		s.CoreRequirements = CoreRequirements{}
+	}
+	if err := s.CoreRequirements.Validate(); err != nil {
+		return err
 	}
 	seenKeys := make(map[string]bool, len(s.Fields))
 	for i := range s.Fields {
@@ -396,12 +429,12 @@ type FormSchemaRepository interface {
 	DeleteByName(ctx context.Context, name string) error
 }
 
-// SubmissionData is the shape submitted by parents. PR 7 will validate
-// this against the schema's fields. Defined here so PR 5's schema-service
-// validation helper can stay strongly typed.
+// SubmissionData is the reduced shape used by the legacy schema-service
+// validation helper. The full public submit flow validates the request model
+// directly.
 type SubmissionData struct {
 	GuardianFields map[string]any `json:"guardian_fields"`
-	ChildFields    map[string]any `json:"child_fields"` // keyed by child index → field map; PR 7 fills in
+	ChildFields    map[string]any `json:"child_fields"` // keyed by child index -> field map
 }
 
 // _ keeps `time` imported even when the model doesn't reference time.Time

--- a/backend/models/enrollment/form_schema_validate_test.go
+++ b/backend/models/enrollment/form_schema_validate_test.go
@@ -72,6 +72,14 @@ func TestFormSchema_Validate_EmptyFieldsOK(t *testing.T) {
 	assert.NoError(t, s.Validate())
 }
 
+func TestFormSchema_Validate_RejectsUnknownCoreRequirement(t *testing.T) {
+	s := validSchema()
+	s.CoreRequirements = CoreRequirements{"guardian_fax": true}
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown core requirement")
+}
+
 func TestFormSchema_Validate_RejectsDuplicateKey(t *testing.T) {
 	s := validSchema()
 	s.Fields = []FormField{

--- a/backend/models/enrollment/phase.go
+++ b/backend/models/enrollment/phase.go
@@ -45,6 +45,24 @@ var validPhaseCareOverflowModes = map[string]bool{
 	PhaseCareOverflowAllow:    true,
 }
 
+// PhaseCareOfferingSelectionMode values match
+// enrollment.phases.care_offering_selection_mode.
+//
+// The mode answers "how many care offerings must a parent choose per
+// child?". It is deliberately separate from CareOffering.IsRequired,
+// which means "this exact offering is always included".
+const (
+	PhaseCareOfferingSelectionOptional   = "optional"
+	PhaseCareOfferingSelectionAtLeastOne = "at_least_one"
+	PhaseCareOfferingSelectionExactlyOne = "exactly_one"
+)
+
+var validPhaseCareOfferingSelectionModes = map[string]bool{
+	PhaseCareOfferingSelectionOptional:   true,
+	PhaseCareOfferingSelectionAtLeastOne: true,
+	PhaseCareOfferingSelectionExactlyOne: true,
+}
+
 // PhaseRolloverMode values match enrollment.phases.rollover_mode.
 // A phase created by RolloverService gets one of these; phases created
 // from scratch leave rollover_mode NULL.
@@ -87,9 +105,10 @@ type Phase struct {
 	// as IsActive=true (DB default wins). Same gotcha we hit on
 	// care_offering's bool fields in PR 6 - see the migration's DEFAULT
 	// for the implicit init value.
-	ShowStatusReasonToParent bool   `bun:"show_status_reason_to_parent,notnull" json:"show_status_reason_to_parent"`
-	CareOverflowMode         string `bun:"care_overflow_mode,notnull" json:"care_overflow_mode"`
-	IsActive                 bool   `bun:"is_active,notnull" json:"is_active"`
+	ShowStatusReasonToParent  bool   `bun:"show_status_reason_to_parent,notnull" json:"show_status_reason_to_parent"`
+	CareOverflowMode          string `bun:"care_overflow_mode,notnull" json:"care_overflow_mode"`
+	CareOfferingSelectionMode string `bun:"care_offering_selection_mode,notnull" json:"care_offering_selection_mode"`
+	IsActive                  bool   `bun:"is_active,notnull" json:"is_active"`
 
 	// Rollover columns (migration 1.15.61). All NULL/false on phases
 	// created from scratch; populated only by RolloverService.
@@ -157,6 +176,12 @@ func (p *Phase) Validate() error {
 	}
 	if !validPhaseCareOverflowModes[p.CareOverflowMode] {
 		return fmt.Errorf("care_overflow_mode must be waitlist/reject/allow, got %q", p.CareOverflowMode)
+	}
+	if p.CareOfferingSelectionMode == "" {
+		p.CareOfferingSelectionMode = PhaseCareOfferingSelectionOptional
+	}
+	if !validPhaseCareOfferingSelectionModes[p.CareOfferingSelectionMode] {
+		return fmt.Errorf("care_offering_selection_mode must be optional/at_least_one/exactly_one, got %q", p.CareOfferingSelectionMode)
 	}
 	if p.RolloverMode != nil && !validPhaseRolloverModes[*p.RolloverMode] {
 		return fmt.Errorf("rollover_mode must be opt_in/opt_out, got %q", *p.RolloverMode)

--- a/backend/models/enrollment/phase.go
+++ b/backend/models/enrollment/phase.go
@@ -209,6 +209,12 @@ type PhaseRepository interface {
 	// phases owning the schema must be repointed first.
 	ExistsByFormSchemaID(ctx context.Context, schemaID int64) (bool, error)
 
+	// RepointFormSchema advances every phase bound to one of fromIDs to
+	// point at toID instead. Called after a schema edit publishes a new
+	// version so live phases follow the change automatically. Returns the
+	// number of phases updated.
+	RepointFormSchema(ctx context.Context, fromIDs []int64, toID int64) (int64, error)
+
 	// ExistsByRolloverSourcePhaseID reports whether any phase already
 	// names the given phase as its rollover source. Used by the
 	// rollover service to refuse creating a second follow-up from the

--- a/backend/models/enrollment/request.go
+++ b/backend/models/enrollment/request.go
@@ -39,6 +39,30 @@ func (r *Request) TableName() string {
 	return "enrollment.requests"
 }
 
+// Consent-flag keys stored in Request.ConsentFlags. These are the
+// canonical string keys shared across the submit validation, the
+// decision service (which stamps the matching student consent
+// timestamps), and the public form.
+//
+// KEEP IN SYNC with the consent_flags object built in
+// frontend/src/components/enrollment/enrollment-form.tsx.
+const (
+	ConsentKeyAGB            = "agb"
+	ConsentKeyDataProcessing = "data_processing"
+	ConsentKeyEmailContact   = "email_contact"
+	ConsentKeyPhoto          = "photo"
+)
+
+// RequiredConsentKeys lists the consents a parent must accept for any
+// submission to be valid. Photo consent is intentionally excluded - it
+// is optional. Enforced server-side in the submit flow as
+// defense-in-depth on top of the public form's client-side validation.
+var RequiredConsentKeys = []string{
+	ConsentKeyAGB,
+	ConsentKeyDataProcessing,
+	ConsentKeyEmailContact,
+}
+
 // RequestStatus values - derived, not stored. Documented here as the
 // canonical source for the derivation logic the request service applies.
 const (

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -70,13 +70,12 @@ func TestAllSettingsRegistered(t *testing.T) {
 		// Parent-enrollment PR 3: guardian invitation token expiry.
 		"invitations.guardian_token_expiry_hours",
 		// Parent-enrollment registry plumbing. open_window_*,
-		// show_status_reason_to_parent, and care_overflow_mode moved
-		// to per-phase columns on enrollment.phases - they're no
-		// longer tenant-wide settings.
+		// show_status_reason_to_parent, care_overflow_mode, and
+		// care_offerings_required moved to per-phase columns on
+		// enrollment.phases - they're no longer tenant-wide settings.
 		"enrollment.enabled",
 		"enrollment.collect_grade_level",
 		"enrollment.care_offerings_enabled",
-		"enrollment.care_offerings_required",
 		"enrollment.default_activation_mode",
 		"enrollment.notification_emails",
 		"enrollment.auto_invite_guardian_on_approval",
@@ -323,7 +322,6 @@ func TestEnrollmentSettings_AllRegistered_OnEnrollmentTab(t *testing.T) {
 		config.KeyEnrollmentEnabled,
 		config.KeyEnrollmentCollectGradeLevel,
 		config.KeyEnrollmentCareOfferingsEnabled,
-		config.KeyEnrollmentCareOfferingsRequired,
 		config.KeyEnrollmentDefaultActivationMode,
 		config.KeyEnrollmentNotificationEmails,
 		config.KeyEnrollmentAutoInviteGuardianOnApprove,
@@ -389,12 +387,6 @@ func TestEnrollmentSettings_DependencyOnEnabled(t *testing.T) {
 		assert.Equal(t, "eq", def.DependsOn.Condition)
 		assert.Equal(t, true, def.DependsOn.Value)
 	}
-
-	// Care-offerings-required hangs off care_offerings_enabled (nested gate),
-	// not the master toggle.
-	careRequired := config.GetDefinition(config.KeyEnrollmentCareOfferingsRequired)
-	require.NotNil(t, careRequired.DependsOn)
-	assert.Equal(t, config.KeyEnrollmentCareOfferingsEnabled, careRequired.DependsOn.Key)
 }
 
 // TestEnrollmentSelectOptions_AreCanonical guards the static option lists

--- a/backend/services/config/defaults/enrollment.go
+++ b/backend/services/config/defaults/enrollment.go
@@ -95,12 +95,6 @@ func registerEnrollmentCareOfferings() {
 		Condition: "eq",
 		Value:     true,
 	}
-	dependsOnCareEnabled := &config.Dependency{
-		Key:       config.KeyEnrollmentCareOfferingsEnabled,
-		Condition: "eq",
-		Value:     true,
-	}
-
 	config.Register(config.Definition{
 		Key:             config.KeyEnrollmentCareOfferingsEnabled,
 		Label:           "Betreuungsangebote anbieten",
@@ -115,19 +109,9 @@ func registerEnrollmentCareOfferings() {
 		DependsOn:       dependsOnEnabled,
 	})
 
-	config.Register(config.Definition{
-		Key:             config.KeyEnrollmentCareOfferingsRequired,
-		Label:           "Betreuungsauswahl verpflichtend",
-		Description:     "Eltern müssen mindestens ein Betreuungsangebot auswählen, bevor sie die Anmeldung absenden können.",
-		Type:            config.FieldBoolean,
-		Default:         false,
-		ReadPermission:  "config:read",
-		WritePermission: "config:update",
-		Tab:             "enrollment",
-		Category:        "betreuungsangebote",
-		SortOrder:       31,
-		DependsOn:       dependsOnCareEnabled,
-	})
+	// enrollment.care_offerings_required moved to per-phase
+	// care_offering_selection_mode. Migration 1.15.97 backfills existing
+	// phases from the old setting and then removes stored overrides.
 }
 
 func registerEnrollmentNotifications() {

--- a/backend/services/enrollment/care_offering_service_test.go
+++ b/backend/services/enrollment/care_offering_service_test.go
@@ -30,7 +30,7 @@ func setupCareTest(t *testing.T) (*bun.DB, enrollmentService.CareOfferingService
 	})
 
 	phase := &enrollmentModels.Phase{
-		Name:             "phase-" + t.Name(),
+		Name:             uniqueSchemaName("phase-" + t.Name()),
 		Kind:             enrollmentModels.PhaseKindSchoolYear,
 		ServiceStartDate: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
 		ServiceEndDate:   time.Date(2027, 7, 31, 0, 0, 0, 0, time.UTC),
@@ -176,7 +176,7 @@ func TestCareOfferingService_Clone_RepointsToTargetPhase(t *testing.T) {
 	// Build a second phase as the clone target.
 	repoFactory := repositories.NewFactory(db)
 	target := &enrollmentModels.Phase{
-		Name:             "phase-clone-target-" + t.Name(),
+		Name:             uniqueSchemaName("phase-clone-target-" + t.Name()),
 		Kind:             enrollmentModels.PhaseKindSchoolYear,
 		ServiceStartDate: time.Date(2027, 9, 1, 0, 0, 0, 0, time.UTC),
 		ServiceEndDate:   time.Date(2028, 7, 31, 0, 0, 0, 0, time.UTC),

--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -1147,7 +1147,7 @@ func (s *decisionService) applyTargetedFields(
 	// enrollment.requests if a more precise audit is ever needed.
 	if request.ConsentFlags != nil {
 		now := time.Now()
-		if photo, ok := request.ConsentFlags["photo"].(bool); ok && photo {
+		if photo, ok := request.ConsentFlags[enrollmentModels.ConsentKeyPhoto].(bool); ok && photo {
 			student.PhotoConsentGivenAt = &now
 			if reviewedBy > 0 {
 				rb := reviewedBy
@@ -1155,15 +1155,15 @@ func (s *decisionService) applyTargetedFields(
 			}
 			studentDirty = true
 		}
-		if agb, ok := request.ConsentFlags["agb"].(bool); ok && agb {
+		if agb, ok := request.ConsentFlags[enrollmentModels.ConsentKeyAGB].(bool); ok && agb {
 			student.AGBAcceptedAt = &now
 			studentDirty = true
 		}
-		if dp, ok := request.ConsentFlags["data_processing"].(bool); ok && dp {
+		if dp, ok := request.ConsentFlags[enrollmentModels.ConsentKeyDataProcessing].(bool); ok && dp {
 			student.DataProcessingAcceptedAt = &now
 			studentDirty = true
 		}
-		if email, ok := request.ConsentFlags["email_contact"].(bool); ok && email {
+		if email, ok := request.ConsentFlags[enrollmentModels.ConsentKeyEmailContact].(bool); ok && email {
 			student.EmailContactAcceptedAt = &now
 			studentDirty = true
 		}

--- a/backend/services/enrollment/form_schema_service.go
+++ b/backend/services/enrollment/form_schema_service.go
@@ -258,6 +258,16 @@ func (s *formSchemaService) createOrVersion(ctx context.Context, name string, fi
 		return nil, fmt.Errorf("create schema: %w", err)
 	}
 
+	// Advance any phase still bound to a prior version of this schema name
+	// onto the freshly published version, so admin edits (new required
+	// fields, core requirements, ...) reach the public form without a
+	// manual re-bind. A brand-new name has no prior versions, so this is a
+	// no-op for CreateSchema. Failing here rolls back the publish rather
+	// than silently leaving the edit invisible.
+	if err := s.repointPhasesToVersion(ctx, schema); err != nil {
+		return nil, err
+	}
+
 	s.logger.Info("form schema published",
 		slog.String("name", schema.Name),
 		slog.Int("version", schema.Version),
@@ -266,6 +276,39 @@ func (s *formSchemaService) createOrVersion(ctx context.Context, name string, fi
 		slog.Int("field_count", len(fields)))
 
 	return schema, nil
+}
+
+// repointPhasesToVersion moves every phase bound to an older version of
+// newSchema's name onto newSchema.ID. No-op when the phase repo isn't
+// wired (some unit setups) or when no sibling versions exist.
+func (s *formSchemaService) repointPhasesToVersion(ctx context.Context, newSchema *enrollmentModels.FormSchema) error {
+	if s.phaseRepo == nil {
+		return nil
+	}
+	versions, err := s.repo.ListByTenant(ctx)
+	if err != nil {
+		return fmt.Errorf("list schema versions for repoint: %w", err)
+	}
+	oldIDs := make([]int64, 0, len(versions))
+	for _, v := range versions {
+		if v.Name == newSchema.Name && v.ID != newSchema.ID {
+			oldIDs = append(oldIDs, v.ID)
+		}
+	}
+	if len(oldIDs) == 0 {
+		return nil
+	}
+	updated, err := s.phaseRepo.RepointFormSchema(ctx, oldIDs, newSchema.ID)
+	if err != nil {
+		return fmt.Errorf("repoint phases to schema %d: %w", newSchema.ID, err)
+	}
+	if updated > 0 {
+		s.logger.Info("repointed phases to new schema version",
+			slog.String("name", newSchema.Name),
+			slog.Int64("new_schema_id", newSchema.ID),
+			slog.Int64("phases_updated", updated))
+	}
+	return nil
 }
 
 func firstCoreRequirements(values []enrollmentModels.CoreRequirements) enrollmentModels.CoreRequirements {

--- a/backend/services/enrollment/form_schema_service.go
+++ b/backend/services/enrollment/form_schema_service.go
@@ -45,7 +45,7 @@ type FormSchemaService interface {
 	//
 	// Deprecated: prefer CreateSchema (new schema) or UpdateSchema
 	// (new version of an existing schema). PublishVersion is kept for
-	// backward compatibility with the original single-schema flow —
+	// backward compatibility with the original single-schema flow.
 	// it now writes the row with name="Standardformular" and does NOT
 	// deactivate other names' rows, only siblings of the same name.
 	PublishVersion(ctx context.Context, fields []enrollmentModels.FormField, createdBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error)
@@ -53,7 +53,7 @@ type FormSchemaService interface {
 	// CreateSchema creates a new logical schema (version 1) under the
 	// given name. Use this when the admin clicks "Neues Formular" on
 	// the schema list page. Names are unique per tenant by convention
-	// but not by DB constraint — the service rejects an attempt to
+	// but not by DB constraint. The service rejects an attempt to
 	// create a new schema with a name that already exists; callers
 	// must use UpdateSchema to add another version to an existing
 	// schema instead.
@@ -61,9 +61,10 @@ type FormSchemaService interface {
 
 	// UpdateSchema publishes a new version of an existing schema,
 	// looked up by id. The new row inherits the source row's name,
-	// uses max(version)+1 for that name, and is marked active. Older
-	// versions stay around so previously-submitted requests keep
-	// their schema reference intact.
+	// uses max(version)+1 for that name, and is marked active. Phases
+	// using an older version of the same logical schema are repointed
+	// to the new row, while previously-submitted requests keep their
+	// schema reference intact.
 	UpdateSchema(ctx context.Context, id int64, fields []enrollmentModels.FormField, updatedBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error)
 
 	// DeleteSchema removes every version of the logical schema selected
@@ -142,7 +143,7 @@ func (s *formSchemaService) CreateSchema(ctx context.Context, name string, field
 	if name == "" {
 		return nil, fmt.Errorf("schema name is required")
 	}
-	// Refuse to overload an existing name — the admin should use
+	// Refuse to overload an existing name. The admin should use
 	// UpdateSchema to add a new version instead. The
 	// "next version > 1" check is the lightweight uniqueness signal.
 	existing, err := s.repo.NextVersionForName(ctx, name)
@@ -224,9 +225,9 @@ func (s *formSchemaService) DeleteSchema(ctx context.Context, id int64) error {
 }
 
 // createOrVersion is the shared internal: pick max(version)+1 for the
-// name, insert a new active row. Sibling rows with the same name stay
-// in place — admins can revert to an older version by binding the
-// phase to that row's id.
+// name and insert a new active row. Sibling rows with the same name
+// stay in place for historical submissions, but phases using any prior
+// sibling version are advanced to the newly published row.
 func (s *formSchemaService) createOrVersion(ctx context.Context, name string, fields []enrollmentModels.FormField, createdBy int64, coreRequirements enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
 	if createdBy <= 0 {
 		return nil, fmt.Errorf("createdBy is required")

--- a/backend/services/enrollment/form_schema_service.go
+++ b/backend/services/enrollment/form_schema_service.go
@@ -1,6 +1,5 @@
-// Package enrollment holds the parent-enrollment service layer. PR 5
-// ships the form schema service; PR 6 will add care offerings; PR 7 the
-// public submission service; PR 8 the per-child decision service.
+// Package enrollment holds the parent-enrollment service layer: form schemas,
+// care offerings, public submissions, and per-child decisions.
 package enrollment
 
 import (
@@ -13,8 +12,8 @@ import (
 )
 
 // ErrNoActiveSchema is returned by GetActive when no active form schema
-// exists for the tenant. Callers (e.g., the public form renderer in
-// PR 7) should treat this as "feature not configured yet".
+// exists for the tenant. Callers should treat this as "feature not configured
+// yet".
 var ErrNoActiveSchema = errors.New("no active form schema for tenant")
 
 var (
@@ -23,11 +22,9 @@ var (
 	ErrFormSchemaHasRequests = errors.New("form schema has enrollment requests")
 )
 
-// FormSchemaService manages form-schema versioning. The two key
-// operations are GetActive (consumed by PR 7's public form renderer
-// + admin editor pre-fill) and PublishVersion (called by the admin
-// editor on save - creates a new version and atomically marks it
-// active, deactivating the previous one).
+// FormSchemaService manages form-schema versioning. GetActive feeds the public
+// form renderer and admin pre-fill; PublishVersion creates a new active version
+// for the default schema.
 type FormSchemaService interface {
 	// GetActive returns the currently-active form schema for the
 	// tenant in context, or ErrNoActiveSchema if none exists.
@@ -51,7 +48,7 @@ type FormSchemaService interface {
 	// backward compatibility with the original single-schema flow —
 	// it now writes the row with name="Standardformular" and does NOT
 	// deactivate other names' rows, only siblings of the same name.
-	PublishVersion(ctx context.Context, fields []enrollmentModels.FormField, createdBy int64) (*enrollmentModels.FormSchema, error)
+	PublishVersion(ctx context.Context, fields []enrollmentModels.FormField, createdBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error)
 
 	// CreateSchema creates a new logical schema (version 1) under the
 	// given name. Use this when the admin clicks "Neues Formular" on
@@ -60,23 +57,23 @@ type FormSchemaService interface {
 	// create a new schema with a name that already exists; callers
 	// must use UpdateSchema to add another version to an existing
 	// schema instead.
-	CreateSchema(ctx context.Context, name string, fields []enrollmentModels.FormField, createdBy int64) (*enrollmentModels.FormSchema, error)
+	CreateSchema(ctx context.Context, name string, fields []enrollmentModels.FormField, createdBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error)
 
 	// UpdateSchema publishes a new version of an existing schema,
 	// looked up by id. The new row inherits the source row's name,
 	// uses max(version)+1 for that name, and is marked active. Older
 	// versions stay around so previously-submitted requests keep
 	// their schema reference intact.
-	UpdateSchema(ctx context.Context, id int64, fields []enrollmentModels.FormField, updatedBy int64) (*enrollmentModels.FormSchema, error)
+	UpdateSchema(ctx context.Context, id int64, fields []enrollmentModels.FormField, updatedBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error)
 
 	// DeleteSchema removes every version of the logical schema selected
 	// by id. It refuses deletion when any version is used by a phase or
 	// historical request.
 	DeleteSchema(ctx context.Context, id int64) error
 
-	// ValidateSubmission checks a parent's submission payload against
-	// a pinned schema version. PR 7's submit handler calls this. PR 5
-	// ships the helper; PR 7 wires it.
+	// ValidateSubmission checks guardian-level custom data against a pinned
+	// schema version. The parent submit flow performs the full request/child
+	// validation before creating enrollment rows.
 	ValidateSubmission(ctx context.Context, schemaID int64, data enrollmentModels.SubmissionData) error
 }
 
@@ -137,11 +134,11 @@ func (s *formSchemaService) ListVersions(ctx context.Context) ([]*enrollmentMode
 // schema.
 const defaultSchemaName = "Standardformular"
 
-func (s *formSchemaService) PublishVersion(ctx context.Context, fields []enrollmentModels.FormField, createdBy int64) (*enrollmentModels.FormSchema, error) {
-	return s.createOrVersion(ctx, defaultSchemaName, fields, createdBy)
+func (s *formSchemaService) PublishVersion(ctx context.Context, fields []enrollmentModels.FormField, createdBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
+	return s.createOrVersion(ctx, defaultSchemaName, fields, createdBy, firstCoreRequirements(coreRequirements))
 }
 
-func (s *formSchemaService) CreateSchema(ctx context.Context, name string, fields []enrollmentModels.FormField, createdBy int64) (*enrollmentModels.FormSchema, error) {
+func (s *formSchemaService) CreateSchema(ctx context.Context, name string, fields []enrollmentModels.FormField, createdBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
 	if name == "" {
 		return nil, fmt.Errorf("schema name is required")
 	}
@@ -155,10 +152,10 @@ func (s *formSchemaService) CreateSchema(ctx context.Context, name string, field
 	if existing > 1 {
 		return nil, fmt.Errorf("schema with name %q already exists; use UpdateSchema to add a new version", name)
 	}
-	return s.createOrVersion(ctx, name, fields, createdBy)
+	return s.createOrVersion(ctx, name, fields, createdBy, firstCoreRequirements(coreRequirements))
 }
 
-func (s *formSchemaService) UpdateSchema(ctx context.Context, id int64, fields []enrollmentModels.FormField, updatedBy int64) (*enrollmentModels.FormSchema, error) {
+func (s *formSchemaService) UpdateSchema(ctx context.Context, id int64, fields []enrollmentModels.FormField, updatedBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
 	if id <= 0 {
 		return nil, fmt.Errorf("schema id must be positive")
 	}
@@ -166,7 +163,11 @@ func (s *formSchemaService) UpdateSchema(ctx context.Context, id int64, fields [
 	if err != nil {
 		return nil, fmt.Errorf("load source schema: %w", err)
 	}
-	return s.createOrVersion(ctx, source.Name, fields, updatedBy)
+	nextCoreRequirements := source.CoreRequirements
+	if len(coreRequirements) > 0 {
+		nextCoreRequirements = firstCoreRequirements(coreRequirements)
+	}
+	return s.createOrVersion(ctx, source.Name, fields, updatedBy, nextCoreRequirements)
 }
 
 func (s *formSchemaService) DeleteSchema(ctx context.Context, id int64) error {
@@ -226,7 +227,7 @@ func (s *formSchemaService) DeleteSchema(ctx context.Context, id int64) error {
 // name, insert a new active row. Sibling rows with the same name stay
 // in place — admins can revert to an older version by binding the
 // phase to that row's id.
-func (s *formSchemaService) createOrVersion(ctx context.Context, name string, fields []enrollmentModels.FormField, createdBy int64) (*enrollmentModels.FormSchema, error) {
+func (s *formSchemaService) createOrVersion(ctx context.Context, name string, fields []enrollmentModels.FormField, createdBy int64, coreRequirements enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
 	if createdBy <= 0 {
 		return nil, fmt.Errorf("createdBy is required")
 	}
@@ -235,7 +236,7 @@ func (s *formSchemaService) createOrVersion(ctx context.Context, name string, fi
 	}
 
 	// Validate fields up front so we don't write a half-correct row.
-	tmp := &enrollmentModels.FormSchema{Name: name, Version: 1, CreatedBy: createdBy, Fields: fields}
+	tmp := &enrollmentModels.FormSchema{Name: name, Version: 1, CreatedBy: createdBy, Fields: fields, CoreRequirements: coreRequirements}
 	if err := tmp.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid schema: %w", err)
 	}
@@ -246,11 +247,12 @@ func (s *formSchemaService) createOrVersion(ctx context.Context, name string, fi
 	}
 
 	schema := &enrollmentModels.FormSchema{
-		Name:      name,
-		Version:   nextVersion,
-		Fields:    fields,
-		IsActive:  true,
-		CreatedBy: createdBy,
+		Name:             name,
+		Version:          nextVersion,
+		Fields:           fields,
+		CoreRequirements: tmp.CoreRequirements,
+		IsActive:         true,
+		CreatedBy:        createdBy,
 	}
 	if err := s.repo.Create(ctx, schema); err != nil {
 		return nil, fmt.Errorf("create schema: %w", err)
@@ -266,10 +268,17 @@ func (s *formSchemaService) createOrVersion(ctx context.Context, name string, fi
 	return schema, nil
 }
 
-// ValidateSubmission resolves the schema by ID and runs the per-field
-// validators against the supplied data. PR 5 ships a basic "every
-// required field has a value" check; PR 7 will extend with type
-// coercion and pattern enforcement.
+func firstCoreRequirements(values []enrollmentModels.CoreRequirements) enrollmentModels.CoreRequirements {
+	if len(values) == 0 || values[0] == nil {
+		return enrollmentModels.CoreRequirements{}
+	}
+	return values[0]
+}
+
+// ValidateSubmission resolves the schema by ID and runs the legacy
+// guardian-level required-field check against the supplied data. Full public
+// submission validation, including child fields and structured field types,
+// lives in request_service.go.
 func (s *formSchemaService) ValidateSubmission(ctx context.Context, schemaID int64, data enrollmentModels.SubmissionData) error {
 	schema, err := s.repo.FindByID(ctx, schemaID)
 	if err != nil {
@@ -285,10 +294,9 @@ func (s *formSchemaService) ValidateSubmission(ctx context.Context, schemaID int
 		var value any
 		var present bool
 		if field.AppliesToCh {
-			// Per-child fields validated by PR 7 (when child slot
-			// indexing is wired); PR 5 only checks guardian-level
-			// required fields. Skip until then to avoid false
-			// positives during admin form preview.
+			// Per-child fields are validated in the parent submit flow where
+			// child rows are available. This helper only receives
+			// guardian-level data.
 			continue
 		}
 		value, present = data.GuardianFields[field.Key]

--- a/backend/services/enrollment/form_schema_service_extra_test.go
+++ b/backend/services/enrollment/form_schema_service_extra_test.go
@@ -279,9 +279,9 @@ func TestFormSchemaService_ValidateSubmission_PresentValueOK(t *testing.T) {
 }
 
 func TestFormSchemaService_ValidateSubmission_SkipsPerChildFields(t *testing.T) {
-	// PR 5 only validates guardian-level required fields. Per-child
-	// required fields are deferred to PR 7's submit handler — verify
-	// the service does not flag them as missing here.
+	// This helper only receives guardian-level custom data. Per-child
+	// required fields are validated by RequestService.Submit, so this
+	// legacy check must not flag them as missing here.
 	_, svc, creatorID, _ := setupFullSchemaTest(t)
 	ctx := testpkg.TenantContext(1)
 

--- a/backend/services/enrollment/form_schema_service_extra_test.go
+++ b/backend/services/enrollment/form_schema_service_extra_test.go
@@ -162,6 +162,62 @@ func TestFormSchemaService_UpdateSchema_InheritsNameBumpsVersion(t *testing.T) {
 		"previous version stays active under multi-schema semantics")
 }
 
+func TestFormSchemaService_UpdateSchema_RepointsPhasesButKeepsRequestSchemaPin(t *testing.T) {
+	_, svc, creatorID, repoFactory := setupFullSchemaTest(t)
+	ctx := testpkg.TenantContext(1)
+
+	name := uniqueSchemaName("RepointTest")
+	v1, err := svc.CreateSchema(ctx, name, []enrollmentModels.FormField{
+		{Key: "field_a", Label: "Feld A", Type: enrollmentModels.FormFieldText, SortOrder: 0},
+	}, creatorID)
+	require.NoError(t, err)
+
+	phaseName := uniqueSchemaName("form-schema-extra-repoint")
+	phase := &enrollmentModels.Phase{
+		Name:              phaseName,
+		Kind:              enrollmentModels.PhaseKindSchoolYear,
+		ServiceStartDate:  time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		ServiceEndDate:    time.Date(2027, 7, 31, 0, 0, 0, 0, time.UTC),
+		FormSchemaID:      &v1.ID,
+		IsActive:          true,
+		CareOverflowMode:  enrollmentModels.PhaseCareOverflowWaitlist,
+		EnrollmentOpenAt:  nil,
+		EnrollmentCloseAt: nil,
+	}
+	require.NoError(t, repoFactory.Phase.Create(ctx, phase))
+
+	request := &enrollmentModels.Request{
+		SchemaID:          &v1.ID,
+		PhaseID:           phase.ID,
+		GuardianFirstName: "Form",
+		GuardianLastName:  "Schema",
+		GuardianEmail:     "form-schema-extra-repoint@test",
+		ConsentFlags:      map[string]any{},
+		CustomData:        map[string]any{},
+		StatusToken:       "form-schema-extra-repoint-" + time.Now().Format("150405.000000"),
+		SubmittedAt:       time.Now().UTC(),
+	}
+	require.NoError(t, repoFactory.Request.Create(ctx, request))
+
+	v2, err := svc.UpdateSchema(ctx, v1.ID, []enrollmentModels.FormField{
+		{Key: "field_a", Label: "Feld A (v2)", Type: enrollmentModels.FormFieldText, SortOrder: 0, Required: true},
+	}, creatorID)
+	require.NoError(t, err)
+	require.NotEqual(t, v1.ID, v2.ID)
+
+	gotPhase, err := repoFactory.Phase.FindByID(ctx, phase.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotPhase.FormSchemaID)
+	assert.Equal(t, v2.ID, *gotPhase.FormSchemaID,
+		"phase must follow the newly published version of the same logical schema")
+
+	gotRequest, err := repoFactory.Request.FindByID(ctx, request.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotRequest.SchemaID)
+	assert.Equal(t, v1.ID, *gotRequest.SchemaID,
+		"already-submitted requests must keep their original schema_id pin")
+}
+
 func TestFormSchemaService_UpdateSchema_RejectsCoreFieldKey(t *testing.T) {
 	_, svc, creatorID, _ := setupFullSchemaTest(t)
 	ctx := testpkg.TenantContext(1)

--- a/backend/services/enrollment/form_schema_service_test.go
+++ b/backend/services/enrollment/form_schema_service_test.go
@@ -15,10 +15,11 @@ import (
 	"github.com/uptrace/bun"
 )
 
-func setupSchemaTest(t *testing.T) (*bun.DB, enrollmentService.FormSchemaService, int64) {
+func setupSchemaTest(t *testing.T) (*bun.DB, enrollmentService.FormSchemaService, int64, int64) {
 	t.Helper()
 	db := testpkg.SetupTestDB(t)
-	testpkg.EnsureTestTenant(t, db, 1)
+	tenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantID)
 	repoFactory := repositories.NewFactory(db)
 	svc := enrollmentService.NewFormSchemaService(enrollmentService.FormSchemaServiceConfig{
 		Repo:   repoFactory.FormSchema,
@@ -40,12 +41,12 @@ func setupSchemaTest(t *testing.T) (*bun.DB, enrollmentService.FormSchemaService
 		_ = db.Close()
 	})
 
-	return db, svc, account.ID
+	return db, svc, account.ID, tenantID
 }
 
 func TestFormSchemaService_PublishVersion_CreatesActive(t *testing.T) {
-	_, svc, creatorID := setupSchemaTest(t)
-	ctx := testpkg.TenantContext(1)
+	_, svc, creatorID, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
 
 	fields := []enrollmentModels.FormField{
 		{Key: "allergies", Label: "Allergien", Type: enrollmentModels.FormFieldTextarea, SortOrder: 0},
@@ -69,8 +70,8 @@ func TestFormSchemaService_PublishVersion_KeepsAllVersionsActive(t *testing.T) {
 	// stay valid until the row is hard-deleted. The (tenant_id, name,
 	// version) unique index from migration 1.15.74 lets multiple
 	// versions coexist with is_active=true.
-	_, svc, creatorID := setupSchemaTest(t)
-	ctx := testpkg.TenantContext(1)
+	_, svc, creatorID, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
 
 	v1, err := svc.PublishVersion(ctx, []enrollmentModels.FormField{
 		{Key: "allergies", Label: "Allergien", Type: enrollmentModels.FormFieldText, SortOrder: 0},
@@ -93,8 +94,8 @@ func TestFormSchemaService_PublishVersion_KeepsAllVersionsActive(t *testing.T) {
 }
 
 func TestFormSchemaService_GetActive_NoRowsErrSentinel(t *testing.T) {
-	_, svc, _ := setupSchemaTest(t)
-	ctx := testpkg.TenantContext(1)
+	_, svc, _, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
 
 	_, err := svc.GetActive(ctx)
 	require.Error(t, err)
@@ -103,8 +104,8 @@ func TestFormSchemaService_GetActive_NoRowsErrSentinel(t *testing.T) {
 }
 
 func TestFormSchemaService_PublishVersion_RejectsCoreFieldKey(t *testing.T) {
-	_, svc, creatorID := setupSchemaTest(t)
-	ctx := testpkg.TenantContext(1)
+	_, svc, creatorID, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
 
 	_, err := svc.PublishVersion(ctx, []enrollmentModels.FormField{
 		{Key: "guardian_email", Label: "Email", Type: enrollmentModels.FormFieldText, SortOrder: 0},
@@ -113,8 +114,8 @@ func TestFormSchemaService_PublishVersion_RejectsCoreFieldKey(t *testing.T) {
 }
 
 func TestFormSchemaService_PublishVersion_RejectsDuplicateKey(t *testing.T) {
-	_, svc, creatorID := setupSchemaTest(t)
-	ctx := testpkg.TenantContext(1)
+	_, svc, creatorID, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
 
 	_, err := svc.PublishVersion(ctx, []enrollmentModels.FormField{
 		{Key: "allergies", Label: "Allergien", Type: enrollmentModels.FormFieldText, SortOrder: 0},
@@ -124,8 +125,8 @@ func TestFormSchemaService_PublishVersion_RejectsDuplicateKey(t *testing.T) {
 }
 
 func TestFormSchemaService_ListVersions_ReturnsNewestFirst(t *testing.T) {
-	_, svc, creatorID := setupSchemaTest(t)
-	ctx := testpkg.TenantContext(1)
+	_, svc, creatorID, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
 
 	for i := 0; i < 3; i++ {
 		_, err := svc.PublishVersion(ctx, []enrollmentModels.FormField{

--- a/backend/services/enrollment/request_helpers_test.go
+++ b/backend/services/enrollment/request_helpers_test.go
@@ -106,9 +106,9 @@ func TestValidateOfferingSelections_EmptyChildrenIsOK(t *testing.T) {
 }
 
 func TestValidateOfferingSelections_ChildWithNoPicksIsOK(t *testing.T) {
-	// The "care_offerings_required" gate is enforced separately. This
+	// Phase-level care offering selection is enforced separately. This
 	// helper only checks that everything the parent DID pick is in the
-	// open catalog — a child with no picks is silently fine here.
+	// open catalog, a child with no picks is silently fine here.
 	assert.NoError(t, validateOfferingSelections([]SubmitChild{{}}, map[int64]*enrollmentModels.CareOffering{}))
 }
 

--- a/backend/services/enrollment/request_helpers_test.go
+++ b/backend/services/enrollment/request_helpers_test.go
@@ -111,3 +111,56 @@ func TestValidateOfferingSelections_ChildWithNoPicksIsOK(t *testing.T) {
 	// open catalog — a child with no picks is silently fine here.
 	assert.NoError(t, validateOfferingSelections([]SubmitChild{{}}, map[int64]*enrollmentModels.CareOffering{}))
 }
+
+// ---- validateRequiredOfferings ------------------------------------------
+
+func TestValidateRequiredOfferings_NoRequiredIsOK(t *testing.T) {
+	open := map[int64]*enrollmentModels.CareOffering{
+		1: {Name: "A", IsRequired: false},
+		2: {Name: "B", IsRequired: false},
+	}
+	children := []SubmitChild{{OfferingIDs: nil}}
+	assert.NoError(t, validateRequiredOfferings(children, open))
+}
+
+func TestValidateRequiredOfferings_AcceptsWhenRequiredSelected(t *testing.T) {
+	open := map[int64]*enrollmentModels.CareOffering{
+		1: {Name: "Mittagessen", IsRequired: true},
+		2: {Name: "AG", IsRequired: false},
+	}
+	children := []SubmitChild{
+		{OfferingIDs: []int64{1}},
+		{OfferingIDs: []int64{2, 1}},
+	}
+	assert.NoError(t, validateRequiredOfferings(children, open))
+}
+
+func TestValidateRequiredOfferings_RejectsWhenRequiredMissing(t *testing.T) {
+	open := map[int64]*enrollmentModels.CareOffering{
+		1: {Name: "Mittagessen", IsRequired: true},
+	}
+	children := []SubmitChild{
+		{OfferingIDs: []int64{}}, // required offering 1 not selected
+	}
+	err := validateRequiredOfferings(children, open)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRequiredCareOfferingMissing),
+		"a missing required offering must surface ErrRequiredCareOfferingMissing")
+}
+
+func TestValidateRequiredOfferings_RejectsWhenOnlySomeChildrenComply(t *testing.T) {
+	open := map[int64]*enrollmentModels.CareOffering{
+		1: {Name: "Mittagessen", IsRequired: true},
+	}
+	children := []SubmitChild{
+		{OfferingIDs: []int64{1}}, // ok
+		{OfferingIDs: []int64{}},  // missing
+	}
+	err := validateRequiredOfferings(children, open)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRequiredCareOfferingMissing))
+}
+
+func TestValidateRequiredOfferings_EmptyCatalogIsOK(t *testing.T) {
+	assert.NoError(t, validateRequiredOfferings([]SubmitChild{{}}, map[int64]*enrollmentModels.CareOffering{}))
+}

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -34,10 +34,16 @@ var (
 	// enrollment.care_offerings_required is true but a child in the
 	// submission has no offering selected. Mapped to 400 with a stable
 	// code so the parent form can highlight the right child.
-	ErrCareOfferingMissing  = errors.New("care offering selection is required for every child")
-	ErrRateLimited          = errors.New("too many submission attempts; please retry later")
-	ErrRequestNotFound      = errors.New("enrollment request not found")
-	ErrInvalidGuardianPhone = errors.New("guardian phone number has an invalid format")
+	ErrCareOfferingMissing = errors.New("care offering selection is required for every child")
+	// ErrRequiredCareOfferingMissing is returned when a care offering
+	// flagged is_required is not selected for one of the children. Unlike
+	// ErrCareOfferingMissing (the tenant-wide "at least one" gate), this
+	// targets a specific mandatory offering. Mapped to 400 with a stable
+	// code so the parent form can highlight the right child.
+	ErrRequiredCareOfferingMissing = errors.New("a required care offering was not selected for every child")
+	ErrRateLimited                 = errors.New("too many submission attempts; please retry later")
+	ErrRequestNotFound             = errors.New("enrollment request not found")
+	ErrInvalidGuardianPhone        = errors.New("guardian phone number has an invalid format")
 	// ErrInvalidGuardianEmail wraps ErrInvalidSubmission so callers that match
 	// the broad category keep working, while the HTTP layer maps the specific
 	// case to a stable code (enrollment.invalid_email) for per-field marking.
@@ -300,6 +306,9 @@ func (s *requestService) Submit(ctx context.Context, req SubmitRequest) (*Submit
 		openByID[o.ID] = o
 	}
 	if err := validateOfferingSelections(req.Children, openByID); err != nil {
+		return nil, err
+	}
+	if err := validateRequiredOfferings(req.Children, openByID); err != nil {
 		return nil, err
 	}
 
@@ -620,6 +629,35 @@ func validateOfferingSelections(children []SubmitChild, openByID map[int64]*enro
 		for _, offeringID := range child.OfferingIDs {
 			if _, ok := openByID[offeringID]; !ok {
 				return ErrCareOfferingClosed
+			}
+		}
+	}
+	return nil
+}
+
+// validateRequiredOfferings enforces that every offering flagged
+// is_required in the phase's open catalog is selected by every child.
+// The day-level requirement for parent_choice offerings is already
+// enforced at insert time by resolveSelectedDays, so this only checks
+// presence in child.OfferingIDs.
+func validateRequiredOfferings(children []SubmitChild, openByID map[int64]*enrollmentModels.CareOffering) error {
+	requiredIDs := make([]int64, 0)
+	for id, offering := range openByID {
+		if offering.IsRequired {
+			requiredIDs = append(requiredIDs, id)
+		}
+	}
+	if len(requiredIDs) == 0 {
+		return nil
+	}
+	for i, child := range children {
+		selected := make(map[int64]bool, len(child.OfferingIDs))
+		for _, id := range child.OfferingIDs {
+			selected[id] = true
+		}
+		for _, requiredID := range requiredIDs {
+			if !selected[requiredID] {
+				return fmt.Errorf("%w: child %d offering %d", ErrRequiredCareOfferingMissing, i, requiredID)
 			}
 		}
 	}

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -47,6 +47,8 @@ var (
 	ErrDuplicateEnrollment  = errors.New("an active enrollment already exists for this parent and child in this phase")
 )
 
+var requiredConsentKeys = []string{"agb", "data_processing", "email_contact"}
+
 // Rate-limit thresholds. Hardcoded for now - if individual schools
 // need different limits we can promote these to settings, but the
 // defaults need to work for "small school with families of 3 kids
@@ -320,6 +322,11 @@ func (s *requestService) Submit(ctx context.Context, req SubmitRequest) (*Submit
 	if err != nil {
 		return nil, fmt.Errorf("submit: load schema: %w", err)
 	}
+	if schema != nil {
+		if err := validateSubmissionAgainstSchema(req, schema); err != nil {
+			return nil, err
+		}
+	}
 
 	statusToken, err := newStatusToken()
 	if err != nil {
@@ -485,6 +492,12 @@ func (s *requestService) validateSubmission(ctx context.Context, req SubmitReque
 			return ErrInvalidGuardianPhone
 		}
 	}
+	for _, key := range requiredConsentKeys {
+		accepted, ok := req.ConsentFlags[key].(bool)
+		if !ok || !accepted {
+			return fmt.Errorf("%w: consent %s is required", ErrInvalidSubmission, key)
+		}
+	}
 	if len(req.Children) == 0 {
 		return fmt.Errorf("%w: at least one child is required", ErrInvalidSubmission)
 	}
@@ -508,6 +521,96 @@ func (s *requestService) validateSubmission(ctx context.Context, req SubmitReque
 		}
 	}
 	return nil
+}
+
+func validateSubmissionAgainstSchema(req SubmitRequest, schema *enrollmentModels.FormSchema) error {
+	if schema.CoreRequirements.Required(enrollmentModels.CoreRequirementGuardianPhone) {
+		if req.GuardianPhone == nil || strings.TrimSpace(*req.GuardianPhone) == "" {
+			return fmt.Errorf("%w: guardian phone is required", ErrInvalidSubmission)
+		}
+	}
+	for _, field := range schema.Fields {
+		if !field.Required {
+			continue
+		}
+		if field.AppliesToCh {
+			for i, child := range req.Children {
+				if !customValueSatisfiesRequired(field, child.CustomData[field.Key]) {
+					return fmt.Errorf("%w: child %d field %s is required", ErrInvalidSubmission, i, field.Key)
+				}
+			}
+			continue
+		}
+		if !customValueSatisfiesRequired(field, req.CustomData[field.Key]) {
+			return fmt.Errorf("%w: field %s is required", ErrInvalidSubmission, field.Key)
+		}
+	}
+	return nil
+}
+
+func customValueSatisfiesRequired(field enrollmentModels.FormField, value any) bool {
+	switch field.Type {
+	case enrollmentModels.FormFieldBoolean:
+		_, ok := value.(bool)
+		return ok
+	case enrollmentModels.FormFieldPhoneList:
+		var entries []enrollmentModels.PhoneEntry
+		if err := decodeStructured(value, &entries); err != nil || len(entries) == 0 {
+			return false
+		}
+		for i := range entries {
+			if err := entries[i].Validate(); err != nil {
+				return false
+			}
+		}
+		return true
+	case enrollmentModels.FormFieldContactList:
+		var entries []enrollmentModels.ContactEntry
+		if err := decodeStructured(value, &entries); err != nil || len(entries) == 0 {
+			return false
+		}
+		for i := range entries {
+			if err := entries[i].Validate(); err != nil {
+				return false
+			}
+		}
+		return true
+	case enrollmentModels.FormFieldWeekdaySchedule:
+		return scheduleHasAnyTime(value)
+	case enrollmentModels.FormFieldNumber:
+		switch v := value.(type) {
+		case float64:
+			return true
+		case int:
+			return true
+		case string:
+			return strings.TrimSpace(v) != ""
+		default:
+			return false
+		}
+	default:
+		return stringValue(value) != ""
+	}
+}
+
+func scheduleHasAnyTime(value any) bool {
+	raw, ok := value.(map[string]any)
+	if !ok {
+		if typed, ok := value.(map[string]string); ok {
+			for _, v := range typed {
+				if strings.TrimSpace(v) != "" {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	for _, v := range raw {
+		if str, ok := v.(string); ok && strings.TrimSpace(str) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // validateOfferingSelections cross-checks every offering id against the

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -53,8 +53,6 @@ var (
 	ErrDuplicateEnrollment  = errors.New("an active enrollment already exists for this parent and child in this phase")
 )
 
-var requiredConsentKeys = []string{"agb", "data_processing", "email_contact"}
-
 // Rate-limit thresholds. Hardcoded for now - if individual schools
 // need different limits we can promote these to settings, but the
 // defaults need to work for "small school with families of 3 kids
@@ -501,7 +499,7 @@ func (s *requestService) validateSubmission(ctx context.Context, req SubmitReque
 			return ErrInvalidGuardianPhone
 		}
 	}
-	for _, key := range requiredConsentKeys {
+	for _, key := range enrollmentModels.RequiredConsentKeys {
 		accepted, ok := req.ConsentFlags[key].(bool)
 		if !ok || !accepted {
 			return fmt.Errorf("%w: consent %s is required", ErrInvalidSubmission, key)

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -30,14 +30,18 @@ var (
 	ErrInvalidSubmission      = errors.New("invalid submission")
 	ErrCareOfferingClosed     = errors.New("one or more selected care offerings are not currently accepting applications")
 	ErrCareOfferingFull       = errors.New("one or more selected care offerings are at capacity")
-	// ErrCareOfferingMissing is returned when the tenant setting
-	// enrollment.care_offerings_required is true but a child in the
-	// submission has no offering selected. Mapped to 400 with a stable
-	// code so the parent form can highlight the right child.
+	// ErrCareOfferingMissing is returned when a phase requires at least
+	// one care offering per child but a child has no offering selected.
+	// Mapped to 400 with a stable code so the parent form can highlight
+	// the right child.
 	ErrCareOfferingMissing = errors.New("care offering selection is required for every child")
+	// ErrCareOfferingExactlyOneRequired is returned when a phase requires
+	// exactly one care offering per child but a child selected none or
+	// more than one.
+	ErrCareOfferingExactlyOneRequired = errors.New("exactly one care offering must be selected for every child")
 	// ErrRequiredCareOfferingMissing is returned when a care offering
 	// flagged is_required is not selected for one of the children. Unlike
-	// ErrCareOfferingMissing (the tenant-wide "at least one" gate), this
+	// ErrCareOfferingMissing (the phase-wide "at least one" gate), this
 	// targets a specific mandatory offering. Mapped to 400 with a stable
 	// code so the parent form can highlight the right child.
 	ErrRequiredCareOfferingMissing = errors.New("a required care offering was not selected for every child")
@@ -159,13 +163,6 @@ type RequestService interface {
 	// already be inside a tenant-tx so the settings repo can read the
 	// per-tenant override.
 	IsEnrollmentEnabled(ctx context.Context) bool
-
-	// IsCareOfferingsRequired reports whether the tenant setting
-	// enrollment.care_offerings_required is on. Surfaced through the
-	// public care-offerings endpoint so the parent form can render the
-	// "verpflichtend" hint and validate client-side. Defense-in-depth:
-	// Submit re-checks the setting server-side.
-	IsCareOfferingsRequired(ctx context.Context) bool
 }
 
 // RequestSettingsResolver is the narrow contract the service needs from
@@ -307,6 +304,9 @@ func (s *requestService) Submit(ctx context.Context, req SubmitRequest) (*Submit
 		return nil, err
 	}
 	if err := validateRequiredOfferings(req.Children, openByID); err != nil {
+		return nil, err
+	}
+	if err := validateCareOfferingSelectionMode(req.Children, openByID, phase.CareOfferingSelectionMode); err != nil {
 		return nil, err
 	}
 
@@ -509,7 +509,6 @@ func (s *requestService) validateSubmission(ctx context.Context, req SubmitReque
 		return fmt.Errorf("%w: at least one child is required", ErrInvalidSubmission)
 	}
 	gradeMax := s.resolveGradeMax(ctx)
-	careRequired := s.IsCareOfferingsRequired(ctx)
 	for i, child := range req.Children {
 		if strings.TrimSpace(child.FirstName) == "" || strings.TrimSpace(child.LastName) == "" {
 			return fmt.Errorf("%w: child %d missing name", ErrInvalidSubmission, i)
@@ -522,9 +521,6 @@ func (s *requestService) validateSubmission(ctx context.Context, req SubmitReque
 		}
 		if *child.TargetGradeLevel < 1 || int(*child.TargetGradeLevel) > gradeMax {
 			return fmt.Errorf("%w: child %d grade out of range 1..%d", ErrInvalidSubmission, i, gradeMax)
-		}
-		if careRequired && len(child.OfferingIDs) == 0 {
-			return fmt.Errorf("%w: child %d", ErrCareOfferingMissing, i)
 		}
 	}
 	return nil
@@ -676,6 +672,56 @@ func validateRequiredOfferings(children []SubmitChild, openByID map[int64]*enrol
 		for _, requiredID := range requiredIDs {
 			if !selected[requiredID] {
 				return fmt.Errorf("%w: child %d offering %d", ErrRequiredCareOfferingMissing, i, requiredID)
+			}
+		}
+	}
+	return nil
+}
+
+// validateCareOfferingSelectionMode enforces the phase's selection mode
+// over the *choosable* (non-required) offerings only. Required offerings
+// are always-on and orthogonal to the mode: they are forced by
+// validateRequiredOfferings and must not count toward "at least one" /
+// "exactly one". Counting them would make exactly_one impossible whenever
+// the phase also carries a required base offering (e.g. a mandatory care
+// package plus a choose-one-time-slot rule): the contradiction this
+// function is designed to avoid.
+func validateCareOfferingSelectionMode(children []SubmitChild, openByID map[int64]*enrollmentModels.CareOffering, mode string) error {
+	if mode == "" || mode == enrollmentModels.PhaseCareOfferingSelectionOptional {
+		return nil
+	}
+	if mode != enrollmentModels.PhaseCareOfferingSelectionAtLeastOne &&
+		mode != enrollmentModels.PhaseCareOfferingSelectionExactlyOne {
+		return fmt.Errorf("%w: invalid care offering selection mode %q", ErrInvalidSubmission, mode)
+	}
+
+	for i, child := range children {
+		selected := make(map[int64]bool, len(child.OfferingIDs))
+		for _, id := range child.OfferingIDs {
+			selected[id] = true
+		}
+		for _, dayPick := range child.OfferingDays {
+			if !selected[dayPick.OfferingID] {
+				return fmt.Errorf("%w: child %d offering %d has days but is not selected", ErrInvalidSubmission, i, dayPick.OfferingID)
+			}
+		}
+		// Count only the choosable (non-required) selected offerings. An
+		// offering absent from openByID is rejected earlier by
+		// validateOfferingSelections, so treat unknown ids as choosable.
+		choosableCount := 0
+		for _, id := range child.OfferingIDs {
+			if o, ok := openByID[id]; !ok || !o.IsRequired {
+				choosableCount++
+			}
+		}
+		switch mode {
+		case enrollmentModels.PhaseCareOfferingSelectionAtLeastOne:
+			if choosableCount == 0 {
+				return fmt.Errorf("%w: child %d", ErrCareOfferingMissing, i)
+			}
+		case enrollmentModels.PhaseCareOfferingSelectionExactlyOne:
+			if choosableCount != 1 {
+				return fmt.Errorf("%w: child %d", ErrCareOfferingExactlyOneRequired, i)
 			}
 		}
 	}
@@ -1035,29 +1081,8 @@ func (s *requestService) isEnrollmentEnabled(ctx context.Context) bool {
 	return false
 }
 
-// IsCareOfferingsRequired is the public counterpart consumed by the
-// care-offerings endpoint. Tenant override → registry default; no env
-// var fallback (the setting was registered from day one).
-func (s *requestService) IsCareOfferingsRequired(ctx context.Context) bool {
-	if s.settings == nil {
-		return false
-	}
-	if has, err := s.settings.HasTenantOverride(ctx, configModel.KeyEnrollmentCareOfferingsRequired); err == nil && has {
-		v, err := s.settings.ResolveBool(ctx, configModel.KeyEnrollmentCareOfferingsRequired)
-		if err == nil {
-			return v
-		}
-	}
-	// Registry default is false (see services/config/defaults/enrollment.go).
-	// Read it through Resolve so a future registry change flows through
-	// without a code touch here.
-	v, err := s.settings.ResolveBool(ctx, configModel.KeyEnrollmentCareOfferingsRequired)
-	if err != nil {
-		return false
-	}
-	return v
-}
-
+// resolveGradeMax reads the tenant setting and falls back to the current
+// registry default when unset or unreadable.
 func (s *requestService) resolveGradeMax(ctx context.Context) int {
 	if s.settings == nil {
 		return 4

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -537,20 +537,30 @@ func validateSubmissionAgainstSchema(req SubmitRequest, schema *enrollmentModels
 		}
 	}
 	for _, field := range schema.Fields {
-		if !field.Required {
-			continue
+		if err := validateRequiredCustomField(field, req); err != nil {
+			return err
 		}
-		if field.AppliesToCh {
-			for i, child := range req.Children {
-				if !customValueSatisfiesRequired(field, child.CustomData[field.Key]) {
-					return fmt.Errorf("%w: child %d field %s is required", ErrInvalidSubmission, i, field.Key)
-				}
+	}
+	return nil
+}
+
+// validateRequiredCustomField enforces a single schema field's required
+// constraint against the submission. Per-child fields are checked for every
+// child; request-level fields once. No-op for optional fields.
+func validateRequiredCustomField(field enrollmentModels.FormField, req SubmitRequest) error {
+	if !field.Required {
+		return nil
+	}
+	if field.AppliesToCh {
+		for i, child := range req.Children {
+			if !customValueSatisfiesRequired(field, child.CustomData[field.Key]) {
+				return fmt.Errorf("%w: child %d field %s is required", ErrInvalidSubmission, i, field.Key)
 			}
-			continue
 		}
-		if !customValueSatisfiesRequired(field, req.CustomData[field.Key]) {
-			return fmt.Errorf("%w: field %s is required", ErrInvalidSubmission, field.Key)
-		}
+		return nil
+	}
+	if !customValueSatisfiesRequired(field, req.CustomData[field.Key]) {
+		return fmt.Errorf("%w: field %s is required", ErrInvalidSubmission, field.Key)
 	}
 	return nil
 }
@@ -561,42 +571,52 @@ func customValueSatisfiesRequired(field enrollmentModels.FormField, value any) b
 		_, ok := value.(bool)
 		return ok
 	case enrollmentModels.FormFieldPhoneList:
-		var entries []enrollmentModels.PhoneEntry
-		if err := decodeStructured(value, &entries); err != nil || len(entries) == 0 {
-			return false
-		}
-		for i := range entries {
-			if err := entries[i].Validate(); err != nil {
-				return false
-			}
-		}
-		return true
+		return phoneListSatisfiesRequired(value)
 	case enrollmentModels.FormFieldContactList:
-		var entries []enrollmentModels.ContactEntry
-		if err := decodeStructured(value, &entries); err != nil || len(entries) == 0 {
-			return false
-		}
-		for i := range entries {
-			if err := entries[i].Validate(); err != nil {
-				return false
-			}
-		}
-		return true
+		return contactListSatisfiesRequired(value)
 	case enrollmentModels.FormFieldWeekdaySchedule:
 		return scheduleHasAnyTime(value)
 	case enrollmentModels.FormFieldNumber:
-		switch v := value.(type) {
-		case float64:
-			return true
-		case int:
-			return true
-		case string:
-			return strings.TrimSpace(v) != ""
-		default:
-			return false
-		}
+		return numberValueSatisfiesRequired(value)
 	default:
 		return stringValue(value) != ""
+	}
+}
+
+func phoneListSatisfiesRequired(value any) bool {
+	var entries []enrollmentModels.PhoneEntry
+	if err := decodeStructured(value, &entries); err != nil || len(entries) == 0 {
+		return false
+	}
+	for i := range entries {
+		if err := entries[i].Validate(); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func contactListSatisfiesRequired(value any) bool {
+	var entries []enrollmentModels.ContactEntry
+	if err := decodeStructured(value, &entries); err != nil || len(entries) == 0 {
+		return false
+	}
+	for i := range entries {
+		if err := entries[i].Validate(); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func numberValueSatisfiesRequired(value any) bool {
+	switch v := value.(type) {
+	case float64, int:
+		return true
+	case string:
+		return strings.TrimSpace(v) != ""
+	default:
+		return false
 	}
 }
 

--- a/backend/services/enrollment/request_service_test.go
+++ b/backend/services/enrollment/request_service_test.go
@@ -169,6 +169,7 @@ func setupRequestTest(t *testing.T) (*requestTestEnv, func()) {
 		ServiceStartDate: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
 		ServiceEndDate:   time.Date(2027, 7, 31, 0, 0, 0, 0, time.UTC),
 		IsActive:         true,
+		FormSchemaID:     &schema.ID,
 		CareOverflowMode: enrollmentModels.PhaseCareOverflowWaitlist,
 	}
 	phase.SetTenantID(1)
@@ -226,6 +227,12 @@ func validSubmission(phaseID int64) enrollmentService.SubmitRequest {
 		GuardianFirstName: "Anna",
 		GuardianLastName:  "Beispiel",
 		GuardianEmail:     "anna@example.com",
+		ConsentFlags: map[string]any{
+			"agb":             true,
+			"data_processing": true,
+			"email_contact":   true,
+			"photo":           false,
+		},
 		Children: []enrollmentService.SubmitChild{
 			{
 				FirstName:        "Lina",
@@ -323,6 +330,24 @@ func TestRequestService_Submit_RejectsInvalidGuardianPhone(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, enrollmentService.ErrInvalidGuardianPhone),
 		"invalid guardian phone must return ErrInvalidGuardianPhone; got %v", err)
+}
+
+func TestRequestService_Submit_RejectsMissingRequiredGuardianPhone(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	_, err := env.db.ExecContext(ctx, `
+		UPDATE enrollment.form_schemas
+		SET core_requirements = '{"guardian_phone": true}'::jsonb
+		WHERE id = ?
+	`, env.schemaID)
+	require.NoError(t, err)
+
+	_, err = env.svc.Submit(ctx, validSubmission(env.phaseID))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, enrollmentService.ErrInvalidSubmission),
+		"missing required guardian phone must return ErrInvalidSubmission; got %v", err)
 }
 
 // Regression: submit used to accept guardian emails that net/mail.ParseAddress

--- a/backend/services/enrollment/request_service_test.go
+++ b/backend/services/enrollment/request_service_test.go
@@ -429,6 +429,144 @@ func TestRequestService_Submit_RejectsInactiveOffering(t *testing.T) {
 		"inactive offering selection must return ErrCareOfferingClosed, got %v", err)
 }
 
+func TestRequestService_Submit_EnforcesPhaseCareOfferingSelectionMode(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+	repoFactory := repositories.NewFactory(env.db)
+
+	env.phase.CareOfferingSelectionMode = enrollmentModels.PhaseCareOfferingSelectionAtLeastOne
+	require.NoError(t, repoFactory.Phase.Update(ctx, env.phase))
+
+	_, err := env.svc.Submit(ctx, validSubmission(env.phaseID))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, enrollmentService.ErrCareOfferingMissing),
+		"at_least_one mode must reject children without an offering; got %v", err)
+}
+
+func TestRequestService_Submit_EnforcesExactlyOneCareOffering(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+	repoFactory := repositories.NewFactory(env.db)
+
+	env.phase.CareOfferingSelectionMode = enrollmentModels.PhaseCareOfferingSelectionExactlyOne
+	require.NoError(t, repoFactory.Phase.Update(ctx, env.phase))
+
+	first := setupCareOfferingForCapacity(t, env, 0)
+	second := setupCareOfferingForCapacity(t, env, 0)
+	req := validSubmission(env.phaseID)
+	req.Children[0].OfferingIDs = []int64{first.ID, second.ID}
+
+	_, err := env.svc.Submit(ctx, req)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, enrollmentService.ErrCareOfferingExactlyOneRequired),
+		"exactly_one mode must reject multiple selected offerings; got %v", err)
+}
+
+// TestRequestService_Submit_ExactlyOneCountsOnlyChoosableOfferings verifies
+// that a required (always-on) offering is orthogonal to the selection mode:
+// it must NOT count toward "exactly one". A mandatory base offering plus
+// exactly one choosable offering submits successfully, while the lone
+// required offering (zero choosable) and required-plus-two-choosable are
+// both rejected. This guards the contradiction where a required base
+// offering would otherwise make exactly_one unsatisfiable.
+func TestRequestService_Submit_ExactlyOneCountsOnlyChoosableOfferings(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+	repoFactory := repositories.NewFactory(env.db)
+
+	env.phase.CareOfferingSelectionMode = enrollmentModels.PhaseCareOfferingSelectionExactlyOne
+	require.NoError(t, repoFactory.Phase.Update(ctx, env.phase))
+
+	// Mandatory base offering: always-on, no capacity limit.
+	required := &enrollmentModels.CareOffering{
+		PhaseID:        env.phaseID,
+		Name:           "Mandatory base care",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"mon", "tue", "wed", "thu", "fri"},
+		IsActive:       true,
+		IsRequired:     true,
+	}
+	required.SetTenantID(1)
+	require.NoError(t, repoFactory.CareOffering.Create(ctx, required))
+
+	// Two choosable time-slot offerings the parent picks exactly one of.
+	slotA := setupCareOfferingForCapacity(t, env, 5)
+	slotB := setupCareOfferingForCapacity(t, env, 5)
+
+	// required + exactly one choosable → valid.
+	ok := validSubmission(env.phaseID)
+	ok.GuardianEmail = "valid@example.com"
+	ok.Children[0].OfferingIDs = []int64{required.ID, slotA.ID}
+	_, err := env.svc.Submit(ctx, ok)
+	require.NoError(t, err,
+		"required base offering plus exactly one choosable must submit; got %v", err)
+
+	// required + two choosable → rejected (choosable count is 2).
+	tooMany := validSubmission(env.phaseID)
+	tooMany.GuardianEmail = "toomany@example.com"
+	tooMany.Children[0].OfferingIDs = []int64{required.ID, slotA.ID, slotB.ID}
+	_, err = env.svc.Submit(ctx, tooMany)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, enrollmentService.ErrCareOfferingExactlyOneRequired),
+		"two choosable offerings must be rejected under exactly_one; got %v", err)
+
+	// required only, zero choosable → rejected (choosable count is 0).
+	none := validSubmission(env.phaseID)
+	none.GuardianEmail = "none@example.com"
+	none.Children[0].OfferingIDs = []int64{required.ID}
+	_, err = env.svc.Submit(ctx, none)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, enrollmentService.ErrCareOfferingExactlyOneRequired),
+		"a lone required offering does not satisfy exactly_one; got %v", err)
+}
+
+// TestRequestService_Submit_AtLeastOneCountsOnlyChoosableOfferings is the
+// at_least_one counterpart: a required base offering does not satisfy "at
+// least one" on its own; the parent must additionally pick a choosable
+// offering.
+func TestRequestService_Submit_AtLeastOneCountsOnlyChoosableOfferings(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+	repoFactory := repositories.NewFactory(env.db)
+
+	env.phase.CareOfferingSelectionMode = enrollmentModels.PhaseCareOfferingSelectionAtLeastOne
+	require.NoError(t, repoFactory.Phase.Update(ctx, env.phase))
+
+	required := &enrollmentModels.CareOffering{
+		PhaseID:        env.phaseID,
+		Name:           "Mandatory base care",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"mon", "tue", "wed", "thu", "fri"},
+		IsActive:       true,
+		IsRequired:     true,
+	}
+	required.SetTenantID(1)
+	require.NoError(t, repoFactory.CareOffering.Create(ctx, required))
+
+	choosable := setupCareOfferingForCapacity(t, env, 5)
+
+	// required only → rejected (zero choosable selected).
+	none := validSubmission(env.phaseID)
+	none.GuardianEmail = "none@example.com"
+	none.Children[0].OfferingIDs = []int64{required.ID}
+	_, err := env.svc.Submit(ctx, none)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, enrollmentService.ErrCareOfferingMissing),
+		"a lone required offering does not satisfy at_least_one; got %v", err)
+
+	// required + one choosable → valid.
+	ok := validSubmission(env.phaseID)
+	ok.GuardianEmail = "valid@example.com"
+	ok.Children[0].OfferingIDs = []int64{required.ID, choosable.ID}
+	_, err = env.svc.Submit(ctx, ok)
+	require.NoError(t, err,
+		"required base offering plus one choosable must submit under at_least_one; got %v", err)
+}
+
 // --- GetByStatusToken ---
 
 func TestRequestService_GetByStatusToken_RoundTrip(t *testing.T) {
@@ -748,19 +886,20 @@ func TestRequestService_Submit_RateLimitTenantIsolation(t *testing.T) {
 	// platform.schools to satisfy the FK; EnsureTestTenant is idempotent.
 	testpkg.EnsureTestTenant(t, env.db, 2)
 	repoFactory := repositories.NewFactory(env.db)
-	state, err := repoFactory.SubmissionRateLimit.IncrementAttempts(
-		ctx, 2, enrollmentModels.SubmissionRateLimitKeyTypeEmail, "anna@example.com", 24*time.Hour,
-	)
-	require.NoError(t, err)
-	assert.Equal(t, 1, state.Attempts,
-		"a different tenant's bucket must start fresh, got %d", state.Attempts)
-	// Cleanup the bucket row we just inserted for tenant 2.
+	tenantTwoEmail := "anna+" + strconv.FormatInt(time.Now().UnixNano(), 10) + "@example.com"
 	t.Cleanup(func() {
 		_, _ = env.db.NewDelete().
 			TableExpr("enrollment.submission_rate_limits").
 			Where("tenant_id = ?", 2).
+			Where("key_value = ?", tenantTwoEmail).
 			Exec(context.Background())
 	})
+	state, err := repoFactory.SubmissionRateLimit.IncrementAttempts(
+		ctx, 2, enrollmentModels.SubmissionRateLimitKeyTypeEmail, tenantTwoEmail, 24*time.Hour,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, state.Attempts,
+		"a different tenant's bucket must start fresh, got %d", state.Attempts)
 }
 
 // --- Capacity overflow ---

--- a/backend/services/enrollment/rollover_autoapprove_integration_test.go
+++ b/backend/services/enrollment/rollover_autoapprove_integration_test.go
@@ -93,6 +93,12 @@ func seedApprovedChildWithStudent(
 		GuardianFirstName: guardianFirst,
 		GuardianLastName:  guardianLast,
 		GuardianEmail:     guardianEmail,
+		ConsentFlags: map[string]any{
+			"agb":             true,
+			"data_processing": true,
+			"email_contact":   true,
+			"photo":           false,
+		},
 		Children: []enrollmentService.SubmitChild{
 			{
 				FirstName:        childFirst,

--- a/backend/services/enrollment/rollover_service.go
+++ b/backend/services/enrollment/rollover_service.go
@@ -334,21 +334,22 @@ func (s *rolloverService) runCreate(ctx context.Context, tenantID int64, req Cre
 	mode := req.RolloverMode
 	deadline := req.RolloverDeadline
 	newPhase := &enrollmentModels.Phase{
-		Name:                     req.Name,
-		Kind:                     req.Kind,
-		ServiceStartDate:         req.ServiceStartDate,
-		ServiceEndDate:           req.ServiceEndDate,
-		EnrollmentOpenAt:         req.EnrollmentOpenAt,
-		EnrollmentCloseAt:        req.EnrollmentCloseAt,
-		FormSchemaID:             formSchemaID,
-		ShowStatusReasonToParent: source.ShowStatusReasonToParent,
-		CareOverflowMode:         source.CareOverflowMode,
-		IsActive:                 true,
-		RolloverSourcePhaseID:    &source.ID,
-		RolloverMode:             &mode,
-		RolloverAutoApprove:      req.RolloverAutoApprove,
-		RolloverDeadline:         &deadline,
-		RolloverBumpsGrade:       req.RolloverBumpsGrade,
+		Name:                      req.Name,
+		Kind:                      req.Kind,
+		ServiceStartDate:          req.ServiceStartDate,
+		ServiceEndDate:            req.ServiceEndDate,
+		EnrollmentOpenAt:          req.EnrollmentOpenAt,
+		EnrollmentCloseAt:         req.EnrollmentCloseAt,
+		FormSchemaID:              formSchemaID,
+		ShowStatusReasonToParent:  source.ShowStatusReasonToParent,
+		CareOverflowMode:          source.CareOverflowMode,
+		CareOfferingSelectionMode: source.CareOfferingSelectionMode,
+		IsActive:                  true,
+		RolloverSourcePhaseID:     &source.ID,
+		RolloverMode:              &mode,
+		RolloverAutoApprove:       req.RolloverAutoApprove,
+		RolloverDeadline:          &deadline,
+		RolloverBumpsGrade:        req.RolloverBumpsGrade,
 	}
 	newPhase.SetTenantID(tenantID)
 	if err := newPhase.Validate(); err != nil {

--- a/backend/services/enrollment/rollover_service_test.go
+++ b/backend/services/enrollment/rollover_service_test.go
@@ -169,6 +169,7 @@ func seedApprovedChild(t *testing.T, env *rolloverTestEnv, phaseID int64, guardi
 		GuardianFirstName: guardianFirst,
 		GuardianLastName:  guardianLast,
 		GuardianEmail:     guardianEmail,
+		ConsentFlags:      rolloverConsentFlags(),
 		Children: []enrollmentService.SubmitChild{
 			{
 				FirstName:        childFirst,
@@ -191,6 +192,15 @@ func seedApprovedChild(t *testing.T, env *rolloverTestEnv, phaseID int64, guardi
 	updated, err := env.repos.RequestChild.FindByID(ctx, child.ID)
 	require.NoError(t, err)
 	return updated
+}
+
+func rolloverConsentFlags() map[string]any {
+	return map[string]any{
+		"agb":             true,
+		"data_processing": true,
+		"email_contact":   true,
+		"photo":           false,
+	}
 }
 
 // validRolloverRequest is a request-body builder. Caller passes mode +
@@ -309,6 +319,7 @@ func TestRolloverService_CreatePhaseFromSource_NoGradeLevelGoesToReview(t *testi
 		GuardianFirstName: "Anna",
 		GuardianLastName:  "Beispiel",
 		GuardianEmail:     "anna@example.com",
+		ConsentFlags:      rolloverConsentFlags(),
 		Children: []enrollmentService.SubmitChild{
 			{
 				FirstName:        "Lina",
@@ -372,6 +383,7 @@ func TestRolloverService_CreatePhaseFromSource_SkipsNonApproved(t *testing.T) {
 		GuardianFirstName: "Beata",
 		GuardianLastName:  "Withdrawn",
 		GuardianEmail:     "withdrawn@example.com",
+		ConsentFlags:      rolloverConsentFlags(),
 		Children: []enrollmentService.SubmitChild{
 			{FirstName: "Max", LastName: "Withdrawn", DateOfBirth: time.Date(2018, 4, 15, 0, 0, 0, 0, time.UTC), TargetGradeLevel: &one},
 		},

--- a/frontend/src/app/api/enrollment/schema/[id]/route.ts
+++ b/frontend/src/app/api/enrollment/schema/[id]/route.ts
@@ -86,9 +86,9 @@ export async function PUT(
         // makes the admin's guardian-phone-required toggle stick.
         body: JSON.stringify({
           fields: body.fields ?? [],
-          ...(body.core_requirements !== undefined
-            ? { core_requirements: body.core_requirements }
-            : {}),
+          ...(body.core_requirements === undefined
+            ? {}
+            : { core_requirements: body.core_requirements }),
         }),
       },
     );

--- a/frontend/src/app/api/enrollment/schema/[id]/route.ts
+++ b/frontend/src/app/api/enrollment/schema/[id]/route.ts
@@ -69,7 +69,10 @@ export async function PUT(
     return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
   }
   try {
-    const body = (await request.json()) as { fields?: unknown };
+    const body = (await request.json()) as {
+      fields?: unknown;
+      core_requirements?: unknown;
+    };
     const response = await fetch(
       `${getServerApiUrl()}/api/enrollment/schema/${id}`,
       {
@@ -78,7 +81,15 @@ export async function PUT(
           "Content-Type": "application/json",
           Authorization: authHeader,
         },
-        body: JSON.stringify({ fields: body.fields ?? [] }),
+        // Forward core_requirements only when present so the backend's
+        // "absent = preserve existing" semantics still hold; sending it
+        // makes the admin's guardian-phone-required toggle stick.
+        body: JSON.stringify({
+          fields: body.fields ?? [],
+          ...(body.core_requirements !== undefined
+            ? { core_requirements: body.core_requirements }
+            : {}),
+        }),
       },
     );
     const payload = await response.json().catch(() => ({}));

--- a/frontend/src/app/api/enrollment/schema/route.ts
+++ b/frontend/src/app/api/enrollment/schema/route.ts
@@ -58,9 +58,9 @@ export async function POST(request: NextRequest) {
         // Forward core_requirements so per-template required-state for
         // built-in fields (e.g. guardian_phone) is persisted. Omitting it
         // here silently dropped the admin toggle.
-        ...(body.core_requirements !== undefined
-          ? { core_requirements: body.core_requirements }
-          : {}),
+        ...(body.core_requirements === undefined
+          ? {}
+          : { core_requirements: body.core_requirements }),
       }),
     });
     const payload = await response.json().catch(() => ({}));

--- a/frontend/src/app/api/enrollment/schema/route.ts
+++ b/frontend/src/app/api/enrollment/schema/route.ts
@@ -41,7 +41,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
   }
   try {
-    const body = (await request.json()) as { name?: unknown; fields?: unknown };
+    const body = (await request.json()) as {
+      name?: unknown;
+      fields?: unknown;
+      core_requirements?: unknown;
+    };
     const response = await fetch(`${getServerApiUrl()}/api/enrollment/schema`, {
       method: "POST",
       headers: {
@@ -51,6 +55,12 @@ export async function POST(request: NextRequest) {
       body: JSON.stringify({
         name: typeof body.name === "string" ? body.name : "",
         fields: body.fields ?? [],
+        // Forward core_requirements so per-template required-state for
+        // built-in fields (e.g. guardian_phone) is persisted. Omitting it
+        // here silently dropped the admin toggle.
+        ...(body.core_requirements !== undefined
+          ? { core_requirements: body.core_requirements }
+          : {}),
       }),
     });
     const payload = await response.json().catch(() => ({}));

--- a/frontend/src/components/enrollment/admin-enrollments-list.test.tsx
+++ b/frontend/src/components/enrollment/admin-enrollments-list.test.tsx
@@ -49,6 +49,7 @@ function phase(overrides: Partial<Phase> = {}): Phase {
     form_schema_id: null,
     show_status_reason_to_parent: false,
     care_overflow_mode: "waitlist",
+    care_offering_selection_mode: "optional",
     is_active: true,
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",

--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -66,6 +66,7 @@ function blankInput(phaseId: number): CareOfferingInput {
     capacity: null,
     price_cents: null,
     is_active: true,
+    is_required: false,
     sort_order: 0,
   };
 }
@@ -85,6 +86,7 @@ function offeringToInput(offering: CareOffering): CareOfferingInput {
     capacity: offering.capacity ?? null,
     price_cents: offering.price_cents ?? null,
     is_active: offering.is_active,
+    is_required: offering.is_required,
     sort_order: offering.sort_order,
   };
 }
@@ -288,13 +290,16 @@ export function CareOfferingsEditor() {
         header: "Details",
         render: (offering) => (
           <div className="flex flex-wrap gap-1.5">
+            {offering.is_required ? <FeaturePill label="Pflicht" /> : null}
             {offering.includes_lunch ? (
               <FeaturePill label="Mittagessen" />
             ) : null}
             {offering.includes_holiday_care ? (
               <FeaturePill label="Ferienbetreuung" />
             ) : null}
-            {!offering.includes_lunch && !offering.includes_holiday_care ? (
+            {!offering.is_required &&
+            !offering.includes_lunch &&
+            !offering.includes_holiday_care ? (
               <span className="text-sm text-gray-400">Keine Extras</span>
             ) : null}
           </div>
@@ -921,16 +926,24 @@ function CareOfferingForm({
             type="number"
             name="capacity"
             min={0}
-            value={draft.capacity ?? ""}
+            value={draft.is_required ? "" : (draft.capacity ?? "")}
+            disabled={draft.is_required}
             onChange={(event) =>
               update({
                 capacity:
                   event.target.value === "" ? null : Number(event.target.value),
               })
             }
-            placeholder="Unbegrenzt"
-            className="mt-1 h-10 w-full rounded-lg border border-gray-200 px-3 text-sm shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+            placeholder={
+              draft.is_required ? "Unbegrenzt (Pflicht)" : "Unbegrenzt"
+            }
+            className="mt-1 h-10 w-full rounded-lg border border-gray-200 px-3 text-sm shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400"
           />
+          {draft.is_required && (
+            <span className="mt-1 block text-xs text-gray-500">
+              Pflichtangebote haben keine Platzbegrenzung.
+            </span>
+          )}
         </label>
         <label className="block">
           <span className="text-xs font-medium text-gray-700">
@@ -990,6 +1003,18 @@ function CareOfferingForm({
             onChange={(checked) => update({ is_active: checked })}
             label="Aktiv"
             hint="Nur aktive Angebote sind auswählbar"
+          />
+          <CareOfferingCheckbox
+            checked={draft.is_required}
+            onChange={(checked) =>
+              update(
+                checked
+                  ? { is_required: true, capacity: null }
+                  : { is_required: false },
+              )
+            }
+            label="Pflicht"
+            hint="Jedes Kind muss dieses Angebot wählen (ohne Platzbegrenzung)"
           />
         </div>
       </fieldset>

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -122,6 +122,7 @@ function phase(overrides: Partial<Phase> = {}): Phase {
     form_schema_id: "schema-1",
     show_status_reason_to_parent: false,
     care_overflow_mode: "waitlist",
+    care_offering_selection_mode: "optional",
     is_active: true,
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -407,6 +407,7 @@ describe("EnrollmentFormEditor", () => {
             ],
           }),
         ]),
+        {},
       );
     });
 
@@ -430,6 +431,7 @@ describe("EnrollmentFormEditor", () => {
       expect(mocks.updateSchema).toHaveBeenCalledWith(
         "schema-1",
         expect.arrayContaining([expect.objectContaining({ type: "textarea" })]),
+        {},
       );
     });
 

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -166,6 +166,7 @@ function offering(overrides: Partial<CareOffering> = {}): CareOffering {
     capacity: 20,
     price_cents: 12500,
     is_active: true,
+    is_required: false,
     sort_order: 0,
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",
@@ -262,6 +263,45 @@ describe("CareOfferingsEditor", () => {
     await waitFor(() => {
       expect(mocks.listCareOfferings.mock.calls.length).toBeGreaterThanOrEqual(
         2,
+      );
+    });
+  });
+
+  it("locks and clears capacity when an offering is marked required", async () => {
+    mocks.listPhases.mockResolvedValue([phase()]);
+    mocks.listCareOfferings.mockResolvedValue([offering()]);
+    mocks.createCareOffering.mockResolvedValue(
+      offering({
+        id: "req",
+        name: "Mittagessen",
+        is_required: true,
+        capacity: null,
+      }),
+    );
+
+    render(<CareOfferingsEditor />);
+    expect(await screen.findByText("Regelbetreuung")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Neues Betreuungsangebot" }),
+    );
+    fireEvent.change(inputByName("name"), {
+      target: { value: "Mittagessen" },
+    });
+    fireEvent.change(inputByName("capacity"), { target: { value: "30" } });
+
+    // Marking the offering as required clears any capacity and locks the field.
+    fireEvent.click(screen.getByText("Pflicht"));
+    expect(inputByName("capacity")).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Erstellen" }));
+    await waitFor(() => {
+      expect(mocks.createCareOffering).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Mittagessen",
+          is_required: true,
+          capacity: null,
+        }),
       );
     });
   });

--- a/frontend/src/components/enrollment/enrollment-form-editor.tsx
+++ b/frontend/src/components/enrollment/enrollment-form-editor.tsx
@@ -30,6 +30,7 @@ import {
 } from "lucide-react";
 import { useToast } from "~/contexts/ToastContext";
 import { ConfirmationModal } from "~/components/ui/modal";
+import { BooleanField } from "~/components/settings/fields/boolean-field";
 import {
   blankField,
   createSchema,
@@ -42,6 +43,8 @@ import {
   type FormFieldTarget,
   type FormFieldType,
   type FormSchema,
+  type CoreRequirementKey,
+  type CoreRequirements,
 } from "~/lib/enrollment-form-schema-api";
 import { listPhases, type Phase } from "~/lib/enrollment-phase-api";
 import { createLogger } from "~/lib/logger";
@@ -124,7 +127,10 @@ interface CoreField {
   readonly label: string;
   readonly type: FormFieldType;
   readonly required: boolean;
-  readonly appliesToChild: boolean;
+  readonly group: "guardian" | "child";
+  readonly requirementKey?: CoreRequirementKey;
+  readonly requirementLabel?: string;
+  readonly requirementHint?: string;
 }
 
 const CORE_FIELDS: ReadonlyArray<CoreField> = [
@@ -133,56 +139,59 @@ const CORE_FIELDS: ReadonlyArray<CoreField> = [
     label: "Vorname (Elternteil)",
     type: "text",
     required: true,
-    appliesToChild: false,
+    group: "guardian",
   },
   {
     key: "guardian_last_name",
     label: "Nachname (Elternteil)",
     type: "text",
     required: true,
-    appliesToChild: false,
+    group: "guardian",
   },
   {
     key: "guardian_email",
     label: "E-Mail (Elternteil)",
     type: "text",
     required: true,
-    appliesToChild: false,
+    group: "guardian",
   },
   {
     key: "guardian_phone",
     label: "Telefonnummer (Elternteil)",
     type: "text",
     required: false,
-    appliesToChild: false,
+    group: "guardian",
+    requirementKey: "guardian_phone",
+    requirementLabel: "Telefonnummer verpflichtend",
+    requirementHint: "Eltern müssen eine gültige Telefonnummer angeben.",
   },
   {
     key: "first_name",
     label: "Vorname (Kind)",
     type: "text",
     required: true,
-    appliesToChild: true,
+    group: "child",
   },
   {
     key: "last_name",
     label: "Nachname (Kind)",
     type: "text",
     required: true,
-    appliesToChild: true,
+    group: "child",
   },
   {
     key: "date_of_birth",
     label: "Geburtsdatum (Kind)",
     type: "date",
     required: true,
-    appliesToChild: true,
+    group: "child",
   },
   {
     key: "target_grade_level",
     label: "Klassenstufe (Kind)",
     type: "number",
     required: true,
-    appliesToChild: true,
+    group: "child",
   },
 ];
 
@@ -193,6 +202,9 @@ export function EnrollmentFormEditor() {
   const [selectedKey, setSelectedKey] = useState<string>(NEW_SCHEMA_VALUE);
   const [name, setName] = useState("");
   const [fields, setFields] = useState<FormField[]>([]);
+  const [coreRequirements, setCoreRequirements] = useState<CoreRequirements>(
+    {},
+  );
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -236,6 +248,7 @@ export function EnrollmentFormEditor() {
     setSelectedKey(schema.id);
     setName(schema.name);
     setFields(schema.fields);
+    setCoreRequirements(schema.core_requirements ?? {});
     setError(null);
     setMode(nextMode);
   };
@@ -275,6 +288,7 @@ export function EnrollmentFormEditor() {
     setSelectedKey(NEW_SCHEMA_VALUE);
     setName("");
     setFields([]);
+    setCoreRequirements({});
     setError(null);
     setMode("builder");
   };
@@ -288,6 +302,13 @@ export function EnrollmentFormEditor() {
     setFields((prev) =>
       prev.map((f, i) => (i === index ? { ...f, ...patch } : f)),
     );
+  };
+
+  const updateCoreRequirement = (
+    key: CoreRequirementKey,
+    required: boolean,
+  ) => {
+    setCoreRequirements((prev) => ({ ...prev, [key]: required }));
   };
 
   const addField = () => {
@@ -330,11 +351,22 @@ export function EnrollmentFormEditor() {
     [currentSchema?.fields],
   );
   const currentFieldSignature = useMemo(() => JSON.stringify(fields), [fields]);
+  const savedCoreRequirementSignature = useMemo(
+    () => coreRequirementsSignature(currentSchema?.core_requirements ?? {}),
+    [currentSchema?.core_requirements],
+  );
+  const currentCoreRequirementSignature = useMemo(
+    () => coreRequirementsSignature(coreRequirements),
+    [coreRequirements],
+  );
   const hasUnsavedChanges =
     mode === "builder" &&
     (isCreating
-      ? name.trim() !== "" || fields.length > 0
-      : currentFieldSignature !== savedFieldSignature);
+      ? name.trim() !== "" ||
+        fields.length > 0 ||
+        currentCoreRequirementSignature !== "{}"
+      : currentFieldSignature !== savedFieldSignature ||
+        savedCoreRequirementSignature !== currentCoreRequirementSignature);
   const saveBlockedMessage = getSchemaDraftValidationMessage({
     fields,
     isCreating,
@@ -361,9 +393,17 @@ export function EnrollmentFormEditor() {
       const fieldsForSave = prepareFieldsForSave(fields);
       let result: FormSchema;
       if (isCreating) {
-        result = await createSchema(name.trim(), fieldsForSave);
+        result = await createSchema(
+          name.trim(),
+          fieldsForSave,
+          coreRequirements,
+        );
       } else {
-        result = await updateSchema(selectedKey, fieldsForSave);
+        result = await updateSchema(
+          selectedKey,
+          fieldsForSave,
+          coreRequirements,
+        );
       }
       const refreshed = await loadAll();
       const stillThere = refreshed.find((s) => s.id === result.id);
@@ -534,7 +574,11 @@ export function EnrollmentFormEditor() {
               fields={fields}
             />
 
-            <CoreFieldsSection />
+            <CoreFieldsSection
+              coreRequirements={coreRequirements}
+              onRequirementChange={updateCoreRequirement}
+              disabled={saving}
+            />
 
             <section className="space-y-4">
               <div className="flex flex-col gap-3 border-t border-gray-100 pt-5 sm:flex-row sm:items-end sm:justify-between">
@@ -620,6 +664,7 @@ export function EnrollmentFormEditor() {
           <aside className="moto-dotted-background moto-dotted-background--split border-t border-gray-100 p-5 sm:p-6 lg:border-t-0 lg:border-l">
             <FormPreview
               fields={fields}
+              coreRequirements={coreRequirements}
               templateName={name}
               isActive={currentSchema?.is_active ?? false}
               isSaved={currentSchema !== null}
@@ -688,7 +733,8 @@ function EnrollmentFormsOverview({
                 </h2>
                 <p className="mt-2 max-w-3xl text-sm leading-6 text-gray-600">
                   Das Basisformular ist immer vorhanden. Eigene Vorlagen nutzt
-                  du nur, wenn eine Anmeldephase zusätzliche Fragen braucht.
+                  du, wenn eine Anmeldephase abweichende Pflichtangaben oder
+                  Zusatzfragen braucht.
                 </p>
               </div>
               <button
@@ -715,7 +761,8 @@ function EnrollmentFormsOverview({
                   </h3>
                   <p className="mt-1 text-sm text-gray-600">
                     Jede Anmeldephase nutzt entweder das Basisformular oder eine
-                    eigene Vorlage mit Zusatzfragen.
+                    eigene Vorlage mit angepassten Pflichtangaben und
+                    Zusatzfragen.
                   </p>
                 </div>
               </div>
@@ -797,7 +844,7 @@ function BaseTemplateOverviewRow() {
         <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
           <UsageLine title="Standard" status="base" />
           <span>Systemformular</span>
-          <span>Keine Zusatzfragen</span>
+          <span>Keine Anpassungen</span>
         </div>
       </div>
       <div className="flex justify-start gap-2 md:justify-end">
@@ -848,7 +895,7 @@ function TemplateOverviewRow({
           </h4>
         </div>
         <p className="mt-1 text-xs leading-5 text-gray-500">
-          Eigene Vorlage für zusätzliche Fragen.
+          Eigene Vorlage für Pflichtangaben und Zusatzfragen.
         </p>
         <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
           <UsageLine title={usageTitle} status={usageStatus} />
@@ -1107,7 +1154,7 @@ function OverviewGuide({
           />
           <GuideStep
             icon={<ListPlus className="h-4 w-4" aria-hidden="true" />}
-            title="Zusatzfragen nur bei Bedarf"
+            title="Vorlage nur bei Bedarf"
             done={templateCount > 0}
           />
           <GuideStep
@@ -1171,7 +1218,8 @@ function FormTemplateDetail({
                   </h2>
                   <p className="mt-2 max-w-3xl text-sm leading-6 text-gray-600">
                     Prüfe die Formularvorschau und ordne diese Vorlage einer
-                    Anmeldephase zu, wenn Eltern die Zusatzfragen sehen sollen.
+                    Anmeldephase zu, wenn Eltern die angepassten Pflichtangaben
+                    oder Zusatzfragen sehen sollen.
                   </p>
                 </div>
                 <button
@@ -1198,7 +1246,7 @@ function FormTemplateDetail({
                 <FormMetric
                   icon={<Check className="h-4 w-4" aria-hidden="true" />}
                   value={requiredCount.toString()}
-                  label="Pflichtfragen"
+                  label="Pflicht-Zusatzfragen"
                 />
                 <FormMetric
                   icon={<FileText className="h-4 w-4" aria-hidden="true" />}
@@ -1209,6 +1257,7 @@ function FormTemplateDetail({
 
               <FormPreview
                 fields={schema.fields}
+                coreRequirements={schema.core_requirements ?? {}}
                 templateName={schema.name}
                 isActive={schema.is_active}
                 isSaved
@@ -1476,12 +1525,12 @@ function FormBuilderIntro() {
         Formular-Konfigurator
       </p>
       <h2 className="mt-1 text-xl font-semibold text-gray-900">
-        Zusatzfragen bearbeiten
+        Formularvorlage bearbeiten
       </h2>
       <p className="mt-2 max-w-3xl text-sm leading-6 text-gray-600">
-        Ergänze hier nur Fragen, die über das Basisformular hinausgehen. Die
-        Auswahl der Vorlage passiert in der Übersicht, dieser Bereich ist nur
-        zum Bearbeiten da.
+        Lege fest, welche optionalen Basisfelder verpflichtend sind, und ergänze
+        bei Bedarf Zusatzfragen. Die Vorlage wird später in einer Anmeldephase
+        ausgewählt.
       </p>
     </header>
   );
@@ -1547,7 +1596,7 @@ function BuilderTemplateSummary({
           </h2>
           <p className="mt-1 max-w-2xl text-sm text-gray-600">
             {isCreating
-              ? "Gib der Vorlage einen eindeutigen Namen. Danach kannst du Zusatzfragen anlegen."
+              ? "Gib der Vorlage einen eindeutigen Namen. Danach kannst du Pflichtangaben und Zusatzfragen festlegen."
               : "Beim Speichern bleiben bestehende Anmeldungen nachvollziehbar."}
           </p>
         </div>
@@ -1572,7 +1621,7 @@ function BuilderTemplateSummary({
               {fields.length} Zusatzfragen
             </span>
             <span className="rounded-full bg-gray-100 px-2.5 py-1 font-medium text-gray-700">
-              {requiredCount} Pflichtfragen
+              {requiredCount} Pflicht-Zusatzfragen
             </span>
             <span className="rounded-full bg-gray-100 px-2.5 py-1 font-medium text-gray-700">
               {childFieldCount} pro Kind
@@ -1592,27 +1641,54 @@ function BuilderTemplateSummary({
   );
 }
 
-function CoreFieldsSection() {
-  const guardian = CORE_FIELDS.filter((f) => !f.appliesToChild);
-  const child = CORE_FIELDS.filter((f) => f.appliesToChild);
+function CoreFieldsSection({
+  coreRequirements,
+  onRequirementChange,
+  disabled,
+}: Readonly<{
+  coreRequirements: CoreRequirements;
+  onRequirementChange: (key: CoreRequirementKey, required: boolean) => void;
+  disabled: boolean;
+}>) {
+  const guardian = CORE_FIELDS.filter((f) => f.group === "guardian");
+  const child = CORE_FIELDS.filter((f) => f.group === "child");
+  const groups = [
+    { title: "Eltern", fields: guardian },
+    { title: "Kind", fields: child },
+  ] satisfies ReadonlyArray<{ title: string; fields: CoreField[] }>;
+
   return (
-    <section className="rounded-2xl border border-gray-200 bg-gray-50/70 p-4">
-      <div className="flex items-start gap-3">
-        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white text-gray-500 shadow-sm">
-          <Lock className="h-4 w-4" aria-hidden="true" />
-        </span>
+    <section className="moto-content-surface rounded-2xl border p-5 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h2 className="text-sm font-semibold text-gray-900">Basisformular</h2>
-          <p className="mt-0.5 text-xs leading-5 text-gray-600">
-            Diese Angaben sind immer Teil der Online-Anmeldung und werden hier
-            nur als Orientierung angezeigt.
+          <p className="text-xs font-semibold tracking-wide text-[#5080D8] uppercase">
+            Basisformular
+          </p>
+          <h2 className="mt-1 text-base font-semibold text-gray-900">
+            Pflichtstatus der Basisfelder
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-gray-600">
+            Fest gesetzte Felder bleiben immer Pflicht. Optionale Basisfelder
+            kannst du hier verpflichtend machen.
           </p>
         </div>
+        <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600">
+          <Lock className="h-3.5 w-3.5" aria-hidden="true" />
+          Basisfelder
+        </span>
       </div>
 
-      <div className="mt-4 grid gap-4 md:grid-cols-2">
-        <CoreFieldGroup title="Eltern" fields={guardian} />
-        <CoreFieldGroup title="Kind" fields={child} />
+      <div className="mt-4 overflow-hidden rounded-xl border border-gray-200">
+        {groups.map((group) => (
+          <CoreFieldGroup
+            key={group.title}
+            title={group.title}
+            fields={group.fields}
+            coreRequirements={coreRequirements}
+            onRequirementChange={onRequirementChange}
+            disabled={disabled}
+          />
+        ))}
       </div>
     </section>
   );
@@ -1621,28 +1697,92 @@ function CoreFieldsSection() {
 function CoreFieldGroup({
   title,
   fields,
-}: Readonly<{ title: string; fields: CoreField[] }>) {
+  coreRequirements,
+  onRequirementChange,
+  disabled,
+}: Readonly<{
+  title: string;
+  fields: CoreField[];
+  coreRequirements: CoreRequirements;
+  onRequirementChange: (key: CoreRequirementKey, required: boolean) => void;
+  disabled: boolean;
+}>) {
   return (
-    <div>
-      <h3 className="text-xs font-semibold text-gray-700">{title}</h3>
-      <ul className="mt-2 space-y-1.5">
+    <div className="border-b border-gray-100 last:border-b-0">
+      <div className="bg-gray-50/80 px-4 py-2">
+        <h3 className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
+          {title}
+        </h3>
+      </div>
+      <ul className="divide-y divide-gray-100">
         {fields.map((field) => (
-          <CoreFieldRow key={field.key} field={field} />
+          <CoreFieldRow
+            key={field.key}
+            field={field}
+            required={Boolean(
+              field.requirementKey
+                ? coreRequirements[field.requirementKey]
+                : field.required,
+            )}
+            onRequirementChange={onRequirementChange}
+            disabled={disabled}
+          />
         ))}
       </ul>
     </div>
   );
 }
 
-function CoreFieldRow({ field }: { readonly field: CoreField }) {
+function CoreFieldRow({
+  field,
+  required,
+  onRequirementChange,
+  disabled,
+}: {
+  readonly field: CoreField;
+  readonly required: boolean;
+  readonly onRequirementChange: (
+    key: CoreRequirementKey,
+    required: boolean,
+  ) => void;
+  readonly disabled: boolean;
+}) {
   return (
-    <li className="moto-content-surface flex items-center gap-2 rounded-lg border px-3 py-2 text-xs shadow-sm">
-      <span className="flex-1 font-medium text-gray-900">{field.label}</span>
-      <span className="text-gray-500">{fieldTypeLabels[field.type]}</span>
-      {field.required && (
-        <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600">
-          Pflicht
-        </span>
+    <li className="grid gap-3 bg-white px-4 py-3 sm:grid-cols-[minmax(0,1fr)_220px] sm:items-center">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-sm font-medium text-gray-900">{field.label}</p>
+          <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
+            {fieldTypeLabels[field.type]}
+          </span>
+        </div>
+        <p className="mt-0.5 text-xs leading-5 text-gray-500">
+          {field.requirementKey
+            ? (field.requirementHint ?? "Kann verpflichtend gemacht werden.")
+            : "Immer erforderlich und deshalb nicht änderbar."}
+        </p>
+      </div>
+      {field.requirementKey ? (
+        <div className="flex items-center justify-between gap-3 sm:justify-end">
+          <span className="text-xs font-medium text-gray-600">
+            {required ? "Pflicht" : "Optional"}
+          </span>
+          <BooleanField
+            value={required}
+            onChange={(checked) =>
+              onRequirementChange(field.requirementKey!, checked)
+            }
+            disabled={disabled}
+            ariaLabel={field.requirementLabel ?? `${field.label} Pflichtfeld`}
+          />
+        </div>
+      ) : (
+        <div className="flex justify-start sm:justify-end">
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600">
+            <Lock className="h-3.5 w-3.5" aria-hidden="true" />
+            Immer Pflicht
+          </span>
+        </div>
       )}
     </li>
   );
@@ -1667,16 +1807,16 @@ function TargetSuggestions({
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h3 className="text-sm font-semibold text-gray-900">
-            Feste Vorschläge
+            Stammdaten-Vorschläge
           </h3>
           <p className="mt-1 max-w-2xl text-xs leading-5 text-gray-600">
             Diese Fragen sind mit vorhandenen Stammdaten verbunden. Du kannst
-            sie hinzufügen oder entfernen, der Inhalt ist fest vorgegeben.
+            sie hinzufügen oder entfernen; Label und Typ sind fest vorgegeben.
           </p>
         </div>
         <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm">
           <Lock className="h-3.5 w-3.5" aria-hidden="true" />
-          Gesperrt
+          Stammdaten
         </span>
       </div>
 
@@ -1842,8 +1982,8 @@ function FieldEditorRow({
                 Wird bei bestätigter Anmeldung in die Stammdaten übernommen.
               </p>
               <p className="mt-0.5">
-                Dieser Vorschlag ist fest vorgegeben. Entferne ihn, wenn diese
-                Angabe nicht abgefragt werden soll.
+                Label und Typ sind fest vorgegeben. Entferne den Vorschlag, wenn
+                diese Angabe nicht abgefragt werden soll.
               </p>
             </div>
           ) : (
@@ -1947,8 +2087,8 @@ function FieldEditorRow({
               checked={Boolean(field.required)}
               onChange={(checked) => onChange({ required: checked })}
               label="Pflichtfrage"
-              hint="Eltern müssen diese Frage beantworten."
-              disabled={disabled || isTargetField}
+              hint={getRequiredHint(field)}
+              disabled={disabled}
             />
             <FormChoice
               checked={Boolean(field.applies_to_child)}
@@ -2010,6 +2150,7 @@ function FormChoice({
 
 function FormPreview({
   fields,
+  coreRequirements,
   templateName,
   isActive,
   isSaved,
@@ -2019,6 +2160,7 @@ function FormPreview({
   sticky = true,
 }: Readonly<{
   fields: FormField[];
+  coreRequirements: CoreRequirements;
   templateName: string;
   isActive: boolean;
   isSaved: boolean;
@@ -2032,6 +2174,12 @@ function FormPreview({
     isActive,
     isSaved,
   });
+  const guardianFields = [
+    "Vorname *",
+    "Nachname *",
+    "E-Mail *",
+    coreRequirements.guardian_phone ? "Telefonnummer *" : "Telefonnummer",
+  ];
 
   return (
     <div className={sticky ? "sticky top-6 space-y-4" : "space-y-4"}>
@@ -2130,13 +2278,15 @@ function FormPreview({
         </div>
 
         <div className="space-y-5 p-4">
-          <PreviewSection
-            title="Elternteil"
-            fields={["Vorname", "Nachname", "E-Mail", "Telefonnummer"]}
-          />
+          <PreviewSection title="Elternteil" fields={guardianFields} />
           <PreviewSection
             title="Kind"
-            fields={["Vorname", "Nachname", "Geburtsdatum", "Klassenstufe"]}
+            fields={[
+              "Vorname *",
+              "Nachname *",
+              "Geburtsdatum *",
+              "Klassenstufe *",
+            ]}
           />
           <PreviewSection
             title="Betreuungsangebot"
@@ -2159,7 +2309,8 @@ function FormPreview({
                   Keine Zusatzfragen
                 </p>
                 <p className="mt-1 text-xs leading-5 text-gray-500">
-                  Eltern sehen nur das Basisformular.
+                  Eltern sehen nur das Basisformular mit den gewählten
+                  Pflichtangaben.
                 </p>
               </div>
             ) : (
@@ -2358,13 +2509,14 @@ function normalizeFieldKey(value: string): string {
 function createTargetField(
   target: Exclude<FormFieldTarget, "">,
   sortOrder: number,
+  existing?: FormField,
 ): FormField {
   const spec = RESERVED_TARGETS[target];
   return {
     key: target.replace(/\./g, "_"),
     label: spec.label,
     type: spec.type,
-    required: false,
+    required: Boolean(existing?.required),
     help_text: "",
     options: getTargetOptions(target),
     sort_order: sortOrder,
@@ -2386,7 +2538,7 @@ function getTargetOptions(
 function prepareFieldsForSave(fields: FormField[]): FormField[] {
   return fields.map((field, index) => {
     if (field.target) {
-      return createTargetField(field.target, index);
+      return createTargetField(field.target, index, field);
     }
     return {
       ...field,
@@ -2396,6 +2548,30 @@ function prepareFieldsForSave(fields: FormField[]): FormField[] {
       sort_order: index,
     };
   });
+}
+
+function coreRequirementsSignature(value: CoreRequirements): string {
+  const enabled = Object.entries(value)
+    .filter(([, required]) => required)
+    .map(([key]) => key)
+    .sort();
+  return JSON.stringify(Object.fromEntries(enabled.map((key) => [key, true])));
+}
+
+function getRequiredHint(field: FormField): string {
+  if (field.type === "boolean") {
+    return "Eltern müssen Ja oder Nein auswählen.";
+  }
+  if (field.type === "weekday_schedule") {
+    return "Eltern müssen mindestens eine Uhrzeit angeben.";
+  }
+  if (field.type === "contact_list") {
+    return "Eltern müssen mindestens einen vollständigen Kontakt angeben.";
+  }
+  if (field.type === "phone_list") {
+    return "Eltern müssen mindestens eine Telefonnummer angeben.";
+  }
+  return "Eltern müssen diese Frage beantworten.";
 }
 
 function getSchemaDraftValidationMessage({

--- a/frontend/src/components/enrollment/enrollment-form-editor.tsx
+++ b/frontend/src/components/enrollment/enrollment-form-editor.tsx
@@ -2554,7 +2554,7 @@ function coreRequirementsSignature(value: CoreRequirements): string {
   const enabled = Object.entries(value)
     .filter(([, required]) => required)
     .map(([key]) => key)
-    .sort();
+    .sort((a, b) => a.localeCompare(b));
   return JSON.stringify(Object.fromEntries(enabled.map((key) => [key, true])));
 }
 

--- a/frontend/src/components/enrollment/enrollment-form.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.test.tsx
@@ -359,6 +359,43 @@ describe("EnrollmentForm", () => {
     expect(mockSubmitEnrollment).not.toHaveBeenCalled();
   });
 
+  it("enforces configurable core required fields", async () => {
+    mockFetchPublicActiveSchema.mockResolvedValueOnce({
+      ...schema(),
+      core_requirements: {
+        guardian_phone: true,
+      },
+    });
+    mockFetchPublicCareOfferings.mockResolvedValueOnce({
+      offerings: [],
+      careRequired: false,
+    });
+    renderForm();
+    await waitForLoaded();
+    fillRequiredFields();
+
+    fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
+
+    expect(
+      await screen.findAllByText("Bitte Telefonnummer angeben."),
+    ).not.toHaveLength(0);
+    expect(mockSubmitEnrollment).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByRole("textbox", { name: /Telefon/ }), {
+      target: { value: "+49 221 1234567" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
+
+    await waitFor(() => {
+      expect(mockSubmitEnrollment).toHaveBeenCalledTimes(1);
+    });
+    const [, payload] = mockSubmitEnrollment.mock.calls[0] as [
+      string,
+      SubmitEnrollmentPayload,
+    ];
+    expect(payload.consent_flags?.photo).toBe(false);
+  });
+
   it("adds and removes children without submitting in preview mode", async () => {
     renderForm({ previewMode: true, previewSchema: schema() });
     await waitForLoaded();

--- a/frontend/src/components/enrollment/enrollment-form.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.test.tsx
@@ -4,11 +4,13 @@ import "@testing-library/jest-dom/vitest";
 
 const {
   mockFetchPublicActiveSchema,
+  mockFetchPublicCaptchaConfig,
   mockFetchPublicCareOfferings,
   mockFetchMyEnrollmentProfile,
   mockSubmitEnrollment,
 } = vi.hoisted(() => ({
   mockFetchPublicActiveSchema: vi.fn(),
+  mockFetchPublicCaptchaConfig: vi.fn(),
   mockFetchPublicCareOfferings: vi.fn(),
   mockFetchMyEnrollmentProfile: vi.fn(),
   mockSubmitEnrollment: vi.fn(),
@@ -19,6 +21,7 @@ vi.mock("~/lib/enrollment-form-schema-api", async (importOriginal) => {
   return {
     ...actual,
     fetchPublicActiveSchema: mockFetchPublicActiveSchema,
+    fetchPublicCaptchaConfig: mockFetchPublicCaptchaConfig,
   };
 });
 
@@ -195,12 +198,18 @@ function fillRequiredFields() {
 describe("EnrollmentForm", () => {
   beforeEach(() => {
     mockFetchPublicActiveSchema.mockReset();
+    mockFetchPublicCaptchaConfig.mockReset();
     mockFetchPublicCareOfferings.mockReset();
     mockFetchMyEnrollmentProfile.mockReset();
     mockSubmitEnrollment.mockReset();
     mockFetchPublicActiveSchema.mockResolvedValue(schema());
+    mockFetchPublicCaptchaConfig.mockResolvedValue({
+      enabled: false,
+      site_key: "",
+    });
     mockFetchPublicCareOfferings.mockResolvedValue({
       offerings: offerings(),
+      careOfferingSelectionMode: "at_least_one",
       careRequired: true,
     });
     mockFetchMyEnrollmentProfile.mockResolvedValue(null);
@@ -361,6 +370,31 @@ describe("EnrollmentForm", () => {
     expect(mockSubmitEnrollment).not.toHaveBeenCalled();
   });
 
+  it("treats exactly-one care selection as a single-choice group", async () => {
+    mockFetchPublicCareOfferings.mockResolvedValueOnce({
+      offerings: offerings(),
+      careOfferingSelectionMode: "exactly_one",
+      careRequired: true,
+    });
+    renderForm();
+    await waitForLoaded();
+
+    const flexible = screen.getByRole("checkbox", {
+      name: /Flexible Betreuung/,
+    }) as HTMLInputElement;
+    const fixed = screen.getByRole("checkbox", {
+      name: /Fixe Betreuung/,
+    }) as HTMLInputElement;
+
+    fireEvent.click(fixed);
+    expect(fixed).toBeChecked();
+    expect(flexible).not.toBeChecked();
+
+    fireEvent.click(flexible);
+    expect(flexible).toBeChecked();
+    expect(fixed).not.toBeChecked();
+  });
+
   it("enforces configurable core required fields", async () => {
     mockFetchPublicActiveSchema.mockResolvedValueOnce({
       ...schema(),
@@ -370,6 +404,7 @@ describe("EnrollmentForm", () => {
     });
     mockFetchPublicCareOfferings.mockResolvedValueOnce({
       offerings: [],
+      careOfferingSelectionMode: "optional",
       careRequired: false,
     });
     renderForm();
@@ -457,6 +492,7 @@ describe("EnrollmentForm", () => {
           capacity: null,
         },
       ],
+      careOfferingSelectionMode: "optional",
       careRequired: false,
     });
     renderForm({ submitter, skipCaptcha: true });
@@ -478,5 +514,81 @@ describe("EnrollmentForm", () => {
     });
     const payload = submitter.mock.calls[0]?.[0] as SubmitEnrollmentPayload;
     expect(payload.children[0]?.offering_ids).toEqual([20]);
+  });
+
+  it("counts only choosable offerings for exactly_one when a required offering is present", async () => {
+    mockFetchPublicCareOfferings.mockResolvedValueOnce({
+      offerings: [
+        {
+          id: "20",
+          phase_id: "5",
+          name: "Mittagessen",
+          description: null,
+          days_of_week_mode: "fixed",
+          available_days: ["mon", "tue", "wed", "thu", "fri"],
+          includes_holiday_care: false,
+          includes_lunch: true,
+          is_active: true,
+          is_required: true,
+          capacity: null,
+        },
+        {
+          id: "12",
+          phase_id: "5",
+          name: "Fixe Betreuung",
+          description: null,
+          days_of_week_mode: "fixed",
+          available_days: ["tue", "thu"],
+          includes_holiday_care: false,
+          includes_lunch: false,
+          is_active: true,
+          is_required: false,
+          capacity: 20,
+        },
+      ],
+      careOfferingSelectionMode: "exactly_one",
+      careRequired: true,
+    });
+    renderForm();
+    await waitForLoaded();
+
+    // The required offering renders in its own locked "Pflichtangebote" block,
+    // checked and disabled - it is not the parent's pick.
+    expect(screen.getByText("Pflichtangebote")).toBeInTheDocument();
+    const required = screen.getByRole("checkbox", {
+      name: /Mittagessen/,
+    }) as HTMLInputElement;
+    expect(required).toBeChecked();
+    expect(required).toBeDisabled();
+
+    fillRequiredFields();
+
+    // Submitting with ONLY the required offering must be rejected: exactly_one
+    // counts the choosable offerings, and none is chosen yet. The required
+    // offering must not satisfy the limit on its own.
+    fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
+    expect(
+      await screen.findByText(
+        "Bitte wähle für jedes Kind genau ein Betreuungsangebot aus.",
+      ),
+    ).toBeInTheDocument();
+    expect(mockSubmitEnrollment).not.toHaveBeenCalled();
+
+    // Picking exactly one choosable offering satisfies the mode; the required
+    // offering rides along without counting toward the limit.
+    fireEvent.click(screen.getByRole("checkbox", { name: /Fixe Betreuung/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
+
+    await waitFor(() => {
+      expect(mockSubmitEnrollment).toHaveBeenCalledTimes(1);
+    });
+    const [, payload] = mockSubmitEnrollment.mock.calls[0] as [
+      string,
+      SubmitEnrollmentPayload,
+    ];
+    expect(payload.children[0]?.offering_ids).toHaveLength(2);
+    expect(payload.children[0]?.offering_ids).toEqual(
+      expect.arrayContaining([20, 12]),
+    );
   });
 });

--- a/frontend/src/components/enrollment/enrollment-form.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.test.tsx
@@ -109,6 +109,7 @@ function offerings(): PublicCareOffering[] {
       includes_holiday_care: true,
       includes_lunch: true,
       is_active: true,
+      is_required: false,
       capacity: null,
     },
     {
@@ -121,6 +122,7 @@ function offerings(): PublicCareOffering[] {
       includes_holiday_care: false,
       includes_lunch: false,
       is_active: true,
+      is_required: false,
       capacity: 20,
     },
   ];
@@ -435,5 +437,46 @@ describe("EnrollmentForm", () => {
     expect(payload.captcha_token).toBeUndefined();
     expect(payload.children[0]?.offering_ids).toEqual([12]);
     expect(onSubmitted).toHaveBeenCalledWith("/parents/status/1");
+  });
+
+  it("pre-selects and locks a mandatory offering and submits it for every child", async () => {
+    const submitter = vi.fn().mockResolvedValue({ status_url: "/status/req" });
+    mockFetchPublicCareOfferings.mockResolvedValue({
+      offerings: [
+        {
+          id: "20",
+          phase_id: "5",
+          name: "Mittagessen",
+          description: null,
+          days_of_week_mode: "fixed",
+          available_days: ["mon", "tue", "wed", "thu", "fri"],
+          includes_holiday_care: false,
+          includes_lunch: true,
+          is_active: true,
+          is_required: true,
+          capacity: null,
+        },
+      ],
+      careRequired: false,
+    });
+    renderForm({ submitter, skipCaptcha: true });
+    await waitForLoaded();
+
+    // The mandatory offering is checked and cannot be toggled off.
+    const checkbox = screen.getByRole("checkbox", {
+      name: /Mittagessen/,
+    }) as HTMLInputElement;
+    expect(checkbox).toBeChecked();
+    expect(checkbox).toBeDisabled();
+    expect(screen.getByText("Pflicht")).toBeInTheDocument();
+
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
+
+    await waitFor(() => {
+      expect(submitter).toHaveBeenCalledTimes(1);
+    });
+    const payload = submitter.mock.calls[0]?.[0] as SubmitEnrollmentPayload;
+    expect(payload.children[0]?.offering_ids).toEqual([20]);
   });
 });

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Check, Plus, Trash2 } from "lucide-react";
 import { Turnstile } from "@marsidev/react-turnstile";
 import { useTenant } from "~/components/tenant/tenant-provider";
@@ -117,6 +117,12 @@ export function EnrollmentForm({
   const [schema, setSchema] = useState<PublicFormSchema | null>(null);
   const [offerings, setOfferings] = useState<PublicCareOffering[]>([]);
   const [careRequired, setCareRequired] = useState(false);
+  // Offerings the school flagged as mandatory. These are pre-selected and
+  // locked in the UI so every child carries them.
+  const requiredOfferingIDs = useMemo(
+    () => offerings.filter((o) => o.is_required).map((o) => o.id),
+    [offerings],
+  );
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -204,6 +210,20 @@ export function EnrollmentForm({
         setSchema(schemaResult);
         setOfferings(offeringsResult.offerings);
         setCareRequired(offeringsResult.careRequired);
+        // Seed mandatory offerings into the children that already exist
+        // (the initial blank slot is created before offerings load).
+        const requiredIDs = offeringsResult.offerings
+          .filter((o) => o.is_required)
+          .map((o) => o.id);
+        if (requiredIDs.length > 0) {
+          setChildren((prev) =>
+            prev.map((c) => {
+              const nextIDs = new Set(c.offering_ids);
+              requiredIDs.forEach((id) => nextIDs.add(id));
+              return { ...c, offering_ids: nextIDs };
+            }),
+          );
+        }
         setCaptchaConfig(captchaResult);
         // Prefill guardian fields from the profile when present. We
         // only fill empty fields so an admin testing the form on a
@@ -244,6 +264,8 @@ export function EnrollmentForm({
   };
 
   const toggleOffering = (childIndex: number, offeringID: string) => {
+    // Mandatory offerings are locked - they can never be unselected.
+    if (requiredOfferingIDs.includes(offeringID)) return;
     setChildren((prev) =>
       prev.map((c, i) => {
         if (i !== childIndex) return c;
@@ -283,7 +305,8 @@ export function EnrollmentForm({
     );
   };
 
-  const addChild = () => setChildren((prev) => [...prev, blankChild()]);
+  const addChild = () =>
+    setChildren((prev) => [...prev, blankChild(requiredOfferingIDs)]);
   const removeChild = (index: number) =>
     setChildren((prev) => prev.filter((_, i) => i !== index));
 
@@ -628,7 +651,7 @@ export function EnrollmentForm({
             existing={profile.children}
             usedIDs={usedExistingChildIDs}
             onAdopt={(child) => {
-              const newSlot: ChildDraft = blankChild();
+              const newSlot: ChildDraft = blankChild(requiredOfferingIDs);
               newSlot.first_name = child.first_name;
               newSlot.last_name = child.last_name;
               newSlot.target_grade_level =
@@ -733,11 +756,14 @@ export function EnrollmentForm({
                   }`}
                 >
                   {offerings.map((o) => {
-                    const checked = child.offering_ids.has(o.id);
+                    const required = o.is_required;
+                    const checked = child.offering_ids.has(o.id) || required;
                     return (
                       <label
                         key={o.id}
-                        className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 text-sm transition-colors ${
+                        className={`flex items-start gap-3 rounded-lg border p-3 text-sm transition-colors ${
+                          required ? "cursor-default" : "cursor-pointer"
+                        } ${
                           checked
                             ? "border-[#83CD2D]/40 bg-[#83CD2D]/10"
                             : "border-gray-200 bg-white hover:border-gray-300"
@@ -748,6 +774,7 @@ export function EnrollmentForm({
                             name={`children_${i}_offering_${o.id}`}
                             type="checkbox"
                             checked={checked}
+                            disabled={required}
                             onChange={() => {
                               toggleOffering(i, o.id);
                               if (childOfferingErrors[i]) {
@@ -758,7 +785,9 @@ export function EnrollmentForm({
                                 });
                               }
                             }}
-                            className="absolute inset-0 cursor-pointer opacity-0"
+                            className={`absolute inset-0 opacity-0 ${
+                              required ? "cursor-default" : "cursor-pointer"
+                            }`}
                           />
                           {checked && (
                             <span className="flex h-5 w-5 items-center justify-center rounded-md bg-[#83CD2D] text-white">
@@ -767,8 +796,15 @@ export function EnrollmentForm({
                           )}
                         </span>
                         <div className="min-w-0">
-                          <div className="font-medium break-words text-gray-900">
-                            {o.name}
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="font-medium break-words text-gray-900">
+                              {o.name}
+                            </span>
+                            {required && (
+                              <span className="rounded-full bg-[#83CD2D]/15 px-2 py-0.5 text-xs font-medium text-[#4a7a15]">
+                                Pflicht
+                              </span>
+                            )}
                           </div>
                           {o.description && (
                             <div className="text-xs break-words text-gray-600">
@@ -940,13 +976,15 @@ export function EnrollmentForm({
   );
 }
 
-function blankChild(): ChildDraft {
+function blankChild(requiredOfferingIDs: readonly string[] = []): ChildDraft {
   return {
     first_name: "",
     last_name: "",
     date_of_birth: "",
     target_grade_level: "",
-    offering_ids: new Set(),
+    // Required offerings are pre-selected and locked; seed them so a new
+    // child slot starts compliant.
+    offering_ids: new Set(requiredOfferingIDs),
     offering_days: {},
     custom: {},
   };

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -161,7 +161,7 @@ export function EnrollmentForm({
   const [agbConsent, setAgbConsent] = useState(false);
   const [dataConsent, setDataConsent] = useState(false);
   const [emailConsent, setEmailConsent] = useState(false);
-  const [photoConsent, setPhotoConsent] = useState(false);
+  const [photoConsent, setPhotoConsent] = useState<boolean | null>(null);
   const [children, setChildren] = useState<ChildDraft[]>([blankChild()]);
   // Request-level custom fields (applies_to_child=false). Stored
   // separately from per-child custom data because their values are
@@ -329,8 +329,19 @@ export function EnrollmentForm({
     // parent fixes their own typo instead of producing a request that can
     // never be approved (the backend enforces the same rule).
     const trimmedPhone = guardianPhone.trim();
-    if (trimmedPhone && !GUARDIAN_PHONE_PATTERN.test(trimmedPhone)) {
+    const guardianPhoneRequired =
+      schema?.core_requirements?.guardian_phone === true;
+    if (guardianPhoneRequired && !trimmedPhone) {
+      newFieldErrors.guardian_phone = "Bitte Telefonnummer angeben.";
+    } else if (trimmedPhone && !GUARDIAN_PHONE_PATTERN.test(trimmedPhone)) {
       newFieldErrors.guardian_phone = "Bitte gültige Telefonnummer angeben.";
+    }
+    for (const field of schema?.fields.filter((f) => !f.applies_to_child) ??
+      []) {
+      if (!field.required) continue;
+      if (customValueMissing(field, customData[field.key])) {
+        newFieldErrors[`custom_${field.key}`] = requiredMessageForField(field);
+      }
     }
     for (const [i, c] of children.entries()) {
       if (!c.first_name.trim()) {
@@ -346,6 +357,14 @@ export function EnrollmentForm({
       if (!c.target_grade_level) {
         newFieldErrors[`children_${i}_target_grade_level`] =
           "Bitte Klassenstufe angeben.";
+      }
+      for (const field of schema?.fields.filter((f) => f.applies_to_child) ??
+        []) {
+        if (!field.required) continue;
+        if (customValueMissing(field, c.custom[field.key])) {
+          newFieldErrors[`children_${i}_custom_${field.key}`] =
+            requiredMessageForField(field);
+        }
       }
     }
     // Required consents are collected into the same pass so a missing one is
@@ -453,7 +472,7 @@ export function EnrollmentForm({
           agb: agbConsent,
           data_processing: dataConsent,
           email_contact: emailConsent,
-          photo: photoConsent,
+          photo: photoConsent === true,
         },
         custom_data: customData,
         children: payloadChildren,
@@ -551,13 +570,14 @@ export function EnrollmentForm({
             error={fieldErrors.guardian_email}
           />
           <Input
-            label="Telefon"
+            label={`Telefon${schema?.core_requirements?.guardian_phone ? " *" : ""}`}
             name="guardian_phone"
             type="tel"
             autoComplete="tel"
             inputMode="tel"
             value={guardianPhone}
             onChange={setGuardianPhone}
+            required={schema?.core_requirements?.guardian_phone === true}
             error={fieldErrors.guardian_phone}
           />
         </div>
@@ -580,6 +600,7 @@ export function EnrollmentForm({
                 onChange={(v) =>
                   setCustomData((prev) => ({ ...prev, [f.key]: v }))
                 }
+                error={fieldErrors[`custom_${f.key}`]}
               />
             ))}
         </section>
@@ -820,6 +841,7 @@ export function EnrollmentForm({
                   onChange={(v) =>
                     updateChild(i, { custom: { ...child.custom, [f.key]: v } })
                   }
+                  error={fieldErrors[`children_${i}_custom_${f.key}`]}
                 />
               ))}
           </div>
@@ -859,8 +881,8 @@ export function EnrollmentForm({
         <Consent
           name="consent_photo"
           label="Mein Kind darf bei Schulveranstaltungen fotografiert werden (optional)."
-          checked={photoConsent}
-          onChange={setPhotoConsent}
+          checked={photoConsent === true}
+          onChange={(checked) => setPhotoConsent(checked)}
         />
       </section>
 
@@ -1092,13 +1114,79 @@ function Consent({
   );
 }
 
+function customValueMissing(
+  field: PublicFormSchema["fields"][number],
+  value: unknown,
+): boolean {
+  if (field.type === "boolean") {
+    return typeof value !== "boolean";
+  }
+  if (field.type === "phone_list") {
+    if (!Array.isArray(value) || value.length === 0) return true;
+    return value.some((row) => {
+      if (!row || typeof row !== "object") return true;
+      const phoneNumber = (row as Partial<PhoneEntry>).phone_number;
+      return typeof phoneNumber !== "string" || phoneNumber.trim() === "";
+    });
+  }
+  if (field.type === "contact_list") {
+    if (!Array.isArray(value) || value.length === 0) return true;
+    return value.some((row) => {
+      if (!row || typeof row !== "object") return true;
+      const contact = row as ContactEntryValue;
+      const hasName =
+        typeof contact.first_name === "string" &&
+        contact.first_name.trim() !== "" &&
+        typeof contact.last_name === "string" &&
+        contact.last_name.trim() !== "";
+      const hasEmail = (contact.email ?? "").trim() !== "";
+      const hasPhone =
+        Array.isArray(contact.phone_numbers) &&
+        contact.phone_numbers.some((phone) => phone.phone_number.trim() !== "");
+      return !hasName || (!hasEmail && !hasPhone);
+    });
+  }
+  if (field.type === "weekday_schedule") {
+    const schedule = asScheduleObject(value);
+    return !Object.values(schedule).some((time) => time.trim() !== "");
+  }
+  return typeof value !== "string" || value.trim() === "";
+}
+
+function requiredMessageForField(
+  field: PublicFormSchema["fields"][number],
+): string {
+  if (field.type === "boolean") {
+    return "Bitte Ja oder Nein auswählen.";
+  }
+  if (field.type === "phone_list") {
+    return "Bitte mindestens eine Telefonnummer angeben.";
+  }
+  if (field.type === "contact_list") {
+    return "Bitte mindestens einen vollständigen Kontakt mit E-Mail oder Telefonnummer angeben.";
+  }
+  if (field.type === "weekday_schedule") {
+    return "Bitte mindestens eine Uhrzeit angeben.";
+  }
+  if (field.type === "select") {
+    return "Bitte eine Option auswählen.";
+  }
+  return "Bitte dieses Pflichtfeld ausfüllen.";
+}
+
 interface CustomFieldInputProps {
   readonly field: PublicFormSchema["fields"][number];
   readonly value: unknown;
   readonly onChange: (v: unknown) => void;
+  readonly error?: string;
 }
 
-function CustomFieldInput({ field, value, onChange }: CustomFieldInputProps) {
+function CustomFieldInput({
+  field,
+  value,
+  onChange,
+  error,
+}: CustomFieldInputProps) {
   const labelEl = (
     <span className="block text-sm font-semibold text-gray-700">
       {field.label}
@@ -1110,7 +1198,7 @@ function CustomFieldInput({ field, value, onChange }: CustomFieldInputProps) {
   if (field.type === "boolean") {
     const selectedValue = value === true ? "yes" : value === false ? "no" : "";
     return (
-      <fieldset>
+      <fieldset aria-invalid={error ? "true" : undefined}>
         {labelEl}
         <div className="mt-2 grid grid-cols-2 gap-2">
           {[
@@ -1137,6 +1225,7 @@ function CustomFieldInput({ field, value, onChange }: CustomFieldInputProps) {
             </label>
           ))}
         </div>
+        {error && <p className="mt-1 text-xs text-[#FF3130]">{error}</p>}
       </fieldset>
     );
   }
@@ -1149,9 +1238,11 @@ function CustomFieldInput({ field, value, onChange }: CustomFieldInputProps) {
           onChange={(e) => onChange(e.target.value)}
           rows={3}
           name={field.key}
-          className="moto-content-surface mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+          className={`moto-content-surface mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none ${error ? "border-[#FF3130]" : ""}`}
           aria-required={field.required}
+          aria-invalid={error ? "true" : undefined}
         />
+        {error && <p className="mt-1 text-xs text-[#FF3130]">{error}</p>}
       </label>
     );
   }
@@ -1164,7 +1255,8 @@ function CustomFieldInput({ field, value, onChange }: CustomFieldInputProps) {
           value={valueStr}
           onChange={(e) => onChange(e.target.value)}
           aria-required={field.required}
-          className="moto-select moto-content-surface mt-1 h-10 w-full rounded-lg border px-3 text-sm shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+          aria-invalid={error ? "true" : undefined}
+          className={`moto-select moto-content-surface mt-1 h-10 w-full rounded-lg border px-3 text-sm shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none ${error ? "border-[#FF3130]" : ""}`}
         >
           <option value="">Bitte wählen</option>
           {(field.options ?? []).map((o) => (
@@ -1173,19 +1265,39 @@ function CustomFieldInput({ field, value, onChange }: CustomFieldInputProps) {
             </option>
           ))}
         </select>
+        {error && <p className="mt-1 text-xs text-[#FF3130]">{error}</p>}
       </label>
     );
   }
   if (field.type === "phone_list") {
-    return <PhoneListInput field={field} value={value} onChange={onChange} />;
+    return (
+      <PhoneListInput
+        field={field}
+        value={value}
+        onChange={onChange}
+        error={error}
+      />
+    );
   }
   if (field.type === "weekday_schedule") {
     return (
-      <WeekdayScheduleInput field={field} value={value} onChange={onChange} />
+      <WeekdayScheduleInput
+        field={field}
+        value={value}
+        onChange={onChange}
+        error={error}
+      />
     );
   }
   if (field.type === "contact_list") {
-    return <ContactListInput field={field} value={value} onChange={onChange} />;
+    return (
+      <ContactListInput
+        field={field}
+        value={value}
+        onChange={onChange}
+        error={error}
+      />
+    );
   }
 
   const inputType =
@@ -1203,8 +1315,10 @@ function CustomFieldInput({ field, value, onChange }: CustomFieldInputProps) {
         value={valueStr}
         onChange={(e) => onChange(e.target.value)}
         aria-required={field.required}
-        className="moto-content-surface mt-1 h-10 w-full rounded-lg border px-3 text-sm shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+        aria-invalid={error ? "true" : undefined}
+        className={`moto-content-surface mt-1 h-10 w-full rounded-lg border px-3 text-sm shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none ${error ? "border-[#FF3130]" : ""}`}
       />
+      {error && <p className="mt-1 text-xs text-[#FF3130]">{error}</p>}
     </label>
   );
 }
@@ -1239,13 +1353,21 @@ function asPhoneArray(v: unknown): PhoneEntry[] {
   });
 }
 
-function PhoneListInput({ field, value, onChange }: CustomFieldInputProps) {
+function PhoneListInput({
+  field,
+  value,
+  onChange,
+  error,
+}: CustomFieldInputProps) {
   const phones = asPhoneArray(value);
   const update = (next: PhoneEntry[]) => onChange(next);
   const setRow = (idx: number, patch: Partial<PhoneEntry>) =>
     update(phones.map((p, i) => (i === idx ? { ...p, ...patch } : p)));
   return (
-    <fieldset className="rounded-2xl border border-gray-200 bg-gray-50/70 p-4">
+    <fieldset
+      className={`rounded-2xl border bg-gray-50/70 p-4 ${error ? "border-[#FF3130]" : "border-gray-200"}`}
+      aria-invalid={error ? "true" : undefined}
+    >
       <legend className="px-1 text-sm font-semibold text-gray-900">
         {field.label}
         {field.required && <span className="text-[#FF3130]"> *</span>}
@@ -1328,6 +1450,7 @@ function PhoneListInput({ field, value, onChange }: CustomFieldInputProps) {
         <Plus className="h-4 w-4" aria-hidden="true" />
         Telefonnummer hinzufügen
       </button>
+      {error && <p className="mt-2 text-xs text-[#FF3130]">{error}</p>}
     </fieldset>
   );
 }
@@ -1354,10 +1477,14 @@ function WeekdayScheduleInput({
   field,
   value,
   onChange,
+  error,
 }: CustomFieldInputProps) {
   const sched = asScheduleObject(value);
   return (
-    <fieldset className="rounded-lg border border-gray-200 p-3">
+    <fieldset
+      className={`rounded-lg border p-3 ${error ? "border-[#FF3130]" : "border-gray-200"}`}
+      aria-invalid={error ? "true" : undefined}
+    >
       <legend className="px-1 text-xs font-medium text-gray-700">
         {field.label}
         {field.required && <span className="text-[#FF3130]"> *</span>}
@@ -1378,6 +1505,7 @@ function WeekdayScheduleInput({
           </label>
         ))}
       </div>
+      {error && <p className="mt-2 text-xs text-[#FF3130]">{error}</p>}
     </fieldset>
   );
 }
@@ -1413,13 +1541,21 @@ function blankContact(): ContactEntryValue {
   };
 }
 
-function ContactListInput({ field, value, onChange }: CustomFieldInputProps) {
+function ContactListInput({
+  field,
+  value,
+  onChange,
+  error,
+}: CustomFieldInputProps) {
   const contacts = asContactArray(value);
   const update = (next: ContactEntryValue[]) => onChange(next);
   const setRow = (idx: number, patch: Partial<ContactEntryValue>) =>
     update(contacts.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
   return (
-    <fieldset className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+    <fieldset
+      className={`rounded-2xl border bg-white p-4 shadow-sm ${error ? "border-[#FF3130]" : "border-gray-200"}`}
+      aria-invalid={error ? "true" : undefined}
+    >
       <legend className="px-1 text-sm font-semibold text-gray-900">
         {field.label}
         {field.required && <span className="text-[#FF3130]"> *</span>}
@@ -1537,6 +1673,7 @@ function ContactListInput({ field, value, onChange }: CustomFieldInputProps) {
         <Plus className="h-4 w-4" aria-hidden="true" />
         Kontakt hinzufügen
       </button>
+      {error && <p className="mt-2 text-xs text-[#FF3130]">{error}</p>}
     </fieldset>
   );
 }

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Check, Plus, Trash2 } from "lucide-react";
+import { Check, Lock, Plus, Trash2 } from "lucide-react";
 import { Turnstile } from "@marsidev/react-turnstile";
 import { useTenant } from "~/components/tenant/tenant-provider";
 import {
@@ -10,6 +10,7 @@ import {
   submitEnrollment,
   type MeProfileChild,
   type MeProfileResponse,
+  type CareOfferingSelectionMode,
   type PublicCareOffering,
   type SubmitChildPayload,
 } from "~/lib/enrollment-submission-api";
@@ -30,7 +31,7 @@ const logger = createLogger({ component: "EnrollmentForm" });
 const GUARDIAN_PHONE_PATTERN = /^(\+[0-9]{1,3}\s?)?[0-9\s-]{7,15}$/;
 
 // Mirror of the backend canonical email format
-// (backend/models/users/email_validation.go) — the single rule enforced both
+// (backend/models/users/email_validation.go), the single rule enforced both
 // at enrollment submit AND at student creation on approval. Kept in sync so a
 // value the form accepts can never be rejected later at approval.
 const GUARDIAN_EMAIL_PATTERN = /^[A-Za-z0-9._%-]+@[A-Za-z0-9.-]+[.][A-Za-z]+$/;
@@ -44,7 +45,7 @@ interface ChildDraft {
   /**
    * Per-offering day picks for offerings whose days_of_week_mode is
    * "parent_choice". Keyed by offering id (same shape as in offering_ids).
-   * Absent when the offering uses fixed days — the form submits no days
+   * Absent when the offering uses fixed days. The form submits no days
    * entry for it. For parent_choice offerings the form REQUIRES at
    * least one day before allowing submit.
    */
@@ -116,7 +117,8 @@ export function EnrollmentForm({
   const { tenantSlug } = useTenant();
   const [schema, setSchema] = useState<PublicFormSchema | null>(null);
   const [offerings, setOfferings] = useState<PublicCareOffering[]>([]);
-  const [careRequired, setCareRequired] = useState(false);
+  const [careOfferingSelectionMode, setCareOfferingSelectionMode] =
+    useState<CareOfferingSelectionMode>("optional");
   // Offerings the school flagged as mandatory. These are pre-selected and
   // locked in the UI so every child carries them.
   const requiredOfferingIDs = useMemo(
@@ -156,7 +158,7 @@ export function EnrollmentForm({
     if (submitAttempt === 0) return;
     // Scroll to the first invalid field (every marked input/select/checkbox
     // carries aria-invalid) so the parent lands on the actual problem and its
-    // inline message — not just the top banner. Server-level errors (e.g.
+    // inline message, not just the top banner. Server-level errors (e.g.
     // offering full) mark no field, so fall back to the banner.
     const firstInvalid = formRef.current?.querySelector<HTMLElement>(
       '[aria-invalid="true"]',
@@ -204,7 +206,11 @@ export function EnrollmentForm({
                 : Promise.resolve(null),
             phaseID
               ? fetchPublicCareOfferings(tenantSlug, phaseID)
-              : Promise.resolve({ offerings: [], careRequired: false }),
+              : Promise.resolve({
+                  offerings: [],
+                  careOfferingSelectionMode: "optional" as const,
+                  careRequired: false,
+                }),
             profileLoader().catch(() => null),
             // Skip the captcha config when the caller already authenticated
             // the parent (parent-portal embedded form). Saves a round-trip
@@ -216,7 +222,7 @@ export function EnrollmentForm({
         if (cancelled) return;
         setSchema(schemaResult);
         setOfferings(offeringsResult.offerings);
-        setCareRequired(offeringsResult.careRequired);
+        setCareOfferingSelectionMode(offeringsResult.careOfferingSelectionMode);
         // Seed mandatory offerings into the children that already exist
         // (the initial blank slot is created before offerings load).
         const requiredIDs = offeringsResult.offerings
@@ -265,7 +271,9 @@ export function EnrollmentForm({
   };
 
   const toggleOffering = (childIndex: number, offeringID: string) => {
-    // Mandatory offerings are locked - they can never be unselected.
+    // Mandatory offerings are locked - they can never be unselected. The
+    // selection mode only governs the choosable (non-required) offerings,
+    // so required ones never block toggling a choosable one.
     if (requiredOfferingIDs.includes(offeringID)) return;
     setChildren((prev) =>
       prev.map((c, i) => {
@@ -276,6 +284,15 @@ export function EnrollmentForm({
           nextIDs.delete(offeringID);
           delete nextDays[offeringID];
         } else {
+          if (careOfferingSelectionMode === "exactly_one") {
+            for (const existingID of nextIDs) {
+              if (!requiredOfferingIDs.includes(existingID)) {
+                delete nextDays[existingID];
+              }
+            }
+            nextIDs.clear();
+            requiredOfferingIDs.forEach((id) => nextIDs.add(id));
+          }
           nextIDs.add(offeringID);
         }
         return { ...c, offering_ids: nextIDs, offering_days: nextDays };
@@ -285,7 +302,7 @@ export function EnrollmentForm({
 
   // toggleOfferingDay flips one day in an offering's selected-day set.
   // Only meaningful when the offering's days_of_week_mode is "parent_choice"
-  // — callers pre-check that.
+  // Callers pre-check that.
   const toggleOfferingDay = (
     childIndex: number,
     offeringID: string,
@@ -421,14 +438,31 @@ export function EnrollmentForm({
     // only collects errors; the payload is assembled afterwards once
     // everything is valid.
     const missingCareIndexes: number[] = [];
+    const exactOneCareIndexes: number[] = [];
     // Selected parent_choice offerings with no day picked, keyed
     // `${childIndex}_${offeringId}` so each offending row gets a red border +
     // inline message and the scroll-to-error effect can target it.
     const dayErrors: Record<string, boolean> = {};
     let firstDayErrorMessage: string | null = null;
+    // The selection mode only constrains the choosable (non-required)
+    // offerings. Required offerings are always-on and must not count toward
+    // "at least one" / "exactly one"; otherwise a required base offering
+    // would make exactly_one unsatisfiable.
     for (const [i, c] of children.entries()) {
-      if (careRequired && c.offering_ids.size === 0) {
+      const choosableSelectedCount = [...c.offering_ids].filter(
+        (id) => !requiredOfferingIDs.includes(id),
+      ).length;
+      if (
+        careOfferingSelectionMode === "at_least_one" &&
+        choosableSelectedCount === 0
+      ) {
         missingCareIndexes.push(i);
+      }
+      if (
+        careOfferingSelectionMode === "exactly_one" &&
+        choosableSelectedCount !== 1
+      ) {
+        exactOneCareIndexes.push(i);
       }
       for (const id of c.offering_ids) {
         const offering = offerings.find((o) => o.id === id);
@@ -447,20 +481,27 @@ export function EnrollmentForm({
 
     const fieldErrorKeys = Object.keys(newFieldErrors);
     const dayErrorCount = Object.keys(dayErrors).length;
-    const hasOfferingIssue = missingCareIndexes.length > 0 || dayErrorCount > 0;
+    const hasOfferingIssue =
+      missingCareIndexes.length > 0 ||
+      exactOneCareIndexes.length > 0 ||
+      dayErrorCount > 0;
     if (fieldErrorKeys.length > 0 || hasOfferingIssue) {
       setFieldErrors(newFieldErrors);
-      if (missingCareIndexes.length > 0) {
+      const invalidCareIndexes = [
+        ...missingCareIndexes,
+        ...exactOneCareIndexes,
+      ];
+      if (invalidCareIndexes.length > 0) {
         setChildOfferingErrors(
-          Object.fromEntries(missingCareIndexes.map((i) => [i, true])),
+          Object.fromEntries(invalidCareIndexes.map((i) => [i, true])),
         );
       }
       setOfferingDayErrors(dayErrors);
       // Banner text:
-      //  - exactly one missing field        → its own specific message
-      //  - only consents missing            → the consent summary
-      //  - only care-offering issues        → the matching offering message
-      //  - anything else / mixed            → a generic summary
+      //  - exactly one missing field: its own specific message
+      //  - only consents missing: the consent summary
+      //  - only care-offering issues: the matching offering message
+      //  - anything else / mixed: a generic summary
       // Every offending input is red-marked regardless, and the scroll
       // effect lands on the first one.
       const onlyConsents =
@@ -477,6 +518,11 @@ export function EnrollmentForm({
           "Bitte wähle für jedes Kind mindestens ein Betreuungsangebot aus.";
       } else if (
         fieldErrorKeys.length === 0 &&
+        exactOneCareIndexes.length > 0
+      ) {
+        banner = "Bitte wähle für jedes Kind genau ein Betreuungsangebot aus.";
+      } else if (
+        fieldErrorKeys.length === 0 &&
         dayErrorCount > 0 &&
         firstDayErrorMessage
       ) {
@@ -486,7 +532,7 @@ export function EnrollmentForm({
       return;
     }
 
-    // All required input is valid — assemble the wire payload. Day
+    // All required input is valid, assemble the wire payload. Day
     // selections for parent_choice offerings are guaranteed present by the
     // validation above, so this only builds data (no further checks).
     const payloadChildren: SubmitChildPayload[] = children.map((c) => {
@@ -546,13 +592,27 @@ export function EnrollmentForm({
       const message = err instanceof Error ? err.message : "Unbekannter Fehler";
       const code = (err as { code?: string } | undefined)?.code;
       logger.error("enrollment_submit_failed", { error: message, code });
-      if (code === "enrollment.care_offering_missing") {
-        // Backend re-checked the setting (defense-in-depth). Mark every
-        // child without an offering. The server doesn't tell us which
-        // one, so we highlight all that are empty.
+      if (
+        code === "enrollment.care_offering_missing" ||
+        code === "enrollment.care_offering_exactly_one"
+      ) {
+        // Backend re-checked the phase mode (defense-in-depth). Mark
+        // every child that violates the current mode. The server
+        // doesn't tell us which one, so we derive it locally.
         const empties = children.reduce<Record<number, boolean>>(
           (acc, c, i) => {
-            if (c.offering_ids.size === 0) acc[i] = true;
+            if (
+              code === "enrollment.care_offering_missing" &&
+              c.offering_ids.size === 0
+            ) {
+              acc[i] = true;
+            }
+            if (
+              code === "enrollment.care_offering_exactly_one" &&
+              c.offering_ids.size !== 1
+            ) {
+              acc[i] = true;
+            }
             return acc;
           },
           {},
@@ -772,53 +832,82 @@ export function EnrollmentForm({
             </div>
 
             {offerings.length > 0 && (
-              <div>
-                <div className="mb-2">
-                  <p className="text-sm font-semibold text-gray-700">
-                    Betreuungsangebote
-                    {careRequired && (
-                      <span className="ml-1 text-[#FF3130]">*</span>
-                    )}
-                  </p>
-                  <p className="mt-1 text-xs leading-5 text-gray-500">
-                    Wählen Sie die Angebote aus, die für dieses Kind gewünscht
-                    sind. Die OGS prüft freie Plätze nach dem Absenden.
-                  </p>
-                </div>
-                <div
-                  aria-invalid={childOfferingErrors[i] ? true : undefined}
-                  className={`space-y-2 ${
-                    childOfferingErrors[i]
-                      ? "rounded-md border border-[#FF3130] bg-[#FF3130]/5 p-2"
-                      : ""
-                  }`}
-                >
-                  {offerings.map((o) => {
-                    const required = o.is_required;
-                    const checked = child.offering_ids.has(o.id) || required;
-                    const dayError = offeringDayErrors[`${i}_${o.id}`] ?? false;
-                    let stateClass =
-                      "border-gray-200 bg-white hover:border-gray-300";
-                    if (dayError) {
-                      stateClass = "border-[#FF3130] bg-[#FF3130]/5";
-                    } else if (checked) {
-                      stateClass = "border-[#83CD2D]/40 bg-[#83CD2D]/10";
-                    }
-                    return (
-                      <label
-                        key={o.id}
-                        aria-invalid={dayError ? true : undefined}
-                        className={`flex items-start gap-3 rounded-lg border p-3 text-sm transition-colors ${
-                          required ? "cursor-default" : "cursor-pointer"
-                        } ${stateClass}`}
-                      >
-                        <span className="relative mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white">
-                          <input
-                            name={`children_${i}_offering_${o.id}`}
-                            type="checkbox"
-                            checked={checked}
-                            disabled={required}
-                            onChange={() => {
+              <div className="space-y-4">
+                {/* Required offerings are part of the enrollment regardless of
+                    the parent's choice. They are presented as an "always
+                    included" block - locked, no checkbox-style selection - so
+                    they never read as "something I picked". The selection mode
+                    and its "choose at least one" requirement live entirely in
+                    the choosable block below. */}
+                {offerings.some((o) => o.is_required) && (
+                  <div>
+                    <p className="text-sm font-semibold text-gray-700">
+                      Pflichtangebote
+                    </p>
+                    <p className="mt-1 text-xs leading-5 text-gray-500">
+                      Diese Angebote sind fester Bestandteil der Anmeldung.
+                    </p>
+                    <div className="mt-2 space-y-2">
+                      {offerings
+                        .filter((o) => o.is_required)
+                        .map((o) => (
+                          <OfferingCard
+                            key={o.id}
+                            offering={o}
+                            childIndex={i}
+                            checked
+                            selectedDays={child.offering_days[o.id]}
+                            dayError={
+                              offeringDayErrors[`${i}_${o.id}`] ?? false
+                            }
+                            onToggle={() => toggleOffering(i, o.id)}
+                            onToggleDay={(day) =>
+                              toggleOfferingDay(i, o.id, day)
+                            }
+                          />
+                        ))}
+                    </div>
+                  </div>
+                )}
+                {offerings.some((o) => !o.is_required) && (
+                  <div>
+                    <p className="text-sm font-semibold text-gray-700">
+                      {offerings.some((o) => o.is_required)
+                        ? "Zusätzlich wählen"
+                        : "Betreuungsangebote"}
+                      {careOfferingSelectionMode !== "optional" && (
+                        <span className="ml-1 text-[#FF3130]">*</span>
+                      )}
+                    </p>
+                    <p className="mt-1 text-xs leading-5 text-gray-500">
+                      {careOfferingSelectionMode === "exactly_one"
+                        ? "Wählen Sie genau ein Angebot aus, das für dieses Kind gewünscht ist."
+                        : careOfferingSelectionMode === "at_least_one"
+                          ? "Wählen Sie mindestens ein Angebot aus, das für dieses Kind gewünscht ist."
+                          : "Wählen Sie die Angebote aus, die für dieses Kind gewünscht sind."}{" "}
+                      Die OGS prüft freie Plätze nach dem Absenden.
+                    </p>
+                    <div
+                      aria-invalid={childOfferingErrors[i] ? true : undefined}
+                      className={`mt-2 space-y-2 ${
+                        childOfferingErrors[i]
+                          ? "rounded-md border border-[#FF3130] bg-[#FF3130]/5 p-2"
+                          : ""
+                      }`}
+                    >
+                      {offerings
+                        .filter((o) => !o.is_required)
+                        .map((o) => (
+                          <OfferingCard
+                            key={o.id}
+                            offering={o}
+                            childIndex={i}
+                            checked={child.offering_ids.has(o.id)}
+                            selectedDays={child.offering_days[o.id]}
+                            dayError={
+                              offeringDayErrors[`${i}_${o.id}`] ?? false
+                            }
+                            onToggle={() => {
                               toggleOffering(i, o.id);
                               if (childOfferingErrors[i]) {
                                 setChildOfferingErrors((prev) => {
@@ -828,89 +917,20 @@ export function EnrollmentForm({
                                 });
                               }
                             }}
-                            className={`absolute inset-0 opacity-0 ${
-                              required ? "cursor-default" : "cursor-pointer"
-                            }`}
+                            onToggleDay={(day) =>
+                              toggleOfferingDay(i, o.id, day)
+                            }
                           />
-                          {checked && (
-                            <span className="flex h-5 w-5 items-center justify-center rounded-md bg-[#83CD2D] text-white">
-                              <Check className="h-3.5 w-3.5" />
-                            </span>
-                          )}
-                        </span>
-                        <div className="min-w-0">
-                          <div className="flex flex-wrap items-center gap-2">
-                            <span className="font-medium break-words text-gray-900">
-                              {o.name}
-                            </span>
-                            {required && (
-                              <span className="rounded-full bg-[#83CD2D]/15 px-2 py-0.5 text-xs font-medium text-[#4a7a15]">
-                                Pflicht
-                              </span>
-                            )}
-                          </div>
-                          {o.description && (
-                            <div className="text-xs break-words text-gray-600">
-                              {o.description}
-                            </div>
-                          )}
-                          <div className="mt-1 text-xs text-gray-500">
-                            {o.days_of_week_mode === "parent_choice"
-                              ? "Wählbare Tage: "
-                              : "Tage: "}
-                            {o.available_days
-                              .map((d) => DAY_LABELS[d] ?? d)
-                              .join(", ")}
-                            {o.includes_holiday_care &&
-                              " · inkl. Ferienbetreuung"}
-                            {o.includes_lunch && " · inkl. Mittagessen"}
-                          </div>
-                          {checked &&
-                            o.days_of_week_mode === "parent_choice" && (
-                              <div className="mt-2 flex flex-wrap gap-1.5">
-                                {o.available_days.map((day) => {
-                                  const picked =
-                                    child.offering_days[o.id]?.has(day) ??
-                                    false;
-                                  return (
-                                    <button
-                                      key={day}
-                                      type="button"
-                                      onClick={(e) => {
-                                        // The card's outer <label> would
-                                        // otherwise treat this as a click on
-                                        // the offering checkbox itself.
-                                        e.preventDefault();
-                                        e.stopPropagation();
-                                        toggleOfferingDay(i, o.id, day);
-                                      }}
-                                      className={`rounded-md border px-2 py-0.5 text-xs font-medium transition-colors ${
-                                        picked
-                                          ? "border-[#83CD2D] bg-[#83CD2D] text-white"
-                                          : "border-gray-300 bg-white text-gray-700 hover:border-gray-400"
-                                      }`}
-                                      aria-pressed={picked}
-                                    >
-                                      {DAY_LABELS[day] ?? day}
-                                    </button>
-                                  );
-                                })}
-                              </div>
-                            )}
-                          {dayError && (
-                            <p className="mt-1 text-xs text-[#FF3130]">
-                              Bitte mindestens einen Tag auswählen.
-                            </p>
-                          )}
-                        </div>
-                      </label>
-                    );
-                  })}
-                </div>
-                {childOfferingErrors[i] && (
-                  <p className="mt-1 text-xs text-[#FF3130]">
-                    Bitte mindestens ein Betreuungsangebot auswählen.
-                  </p>
+                        ))}
+                    </div>
+                    {childOfferingErrors[i] && (
+                      <p className="mt-1 text-xs text-[#FF3130]">
+                        {careOfferingSelectionMode === "exactly_one"
+                          ? "Bitte wählen Sie genau ein Angebot aus."
+                          : "Bitte wählen Sie mindestens ein Angebot aus."}
+                      </p>
+                    )}
+                  </div>
                 )}
               </div>
             )}
@@ -975,7 +995,7 @@ export function EnrollmentForm({
         - the caller didn't skip captcha (parent JWT path skips), and
         - the tenant has configured enrollment.captcha_site_key.
         When require_captcha=true but no site_key is set, we still
-        render a warning to the parent and disable submit — failing
+        render a warning to the parent and disable submit; failing
         closed is safer than letting bots through silently.
         The hidden input ships the token along with the form post.
       */}
@@ -1050,6 +1070,130 @@ function seedRequiredOfferings(
     requiredIDs.forEach((id) => nextIDs.add(id));
     return { ...c, offering_ids: nextIDs };
   });
+}
+
+// OfferingCard renders one care-offering row. Required offerings show as a
+// locked "always included" card (gray, lock indicator) so they never read as
+// a parent's pick; choosable offerings keep the interactive green-check
+// checkbox. The day picker stays available for parent_choice offerings in
+// both cases.
+function OfferingCard({
+  offering,
+  childIndex,
+  checked,
+  selectedDays,
+  dayError,
+  onToggle,
+  onToggleDay,
+}: {
+  readonly offering: PublicCareOffering;
+  readonly childIndex: number;
+  readonly checked: boolean;
+  readonly selectedDays: Set<string> | undefined;
+  readonly dayError: boolean;
+  readonly onToggle: () => void;
+  readonly onToggleDay: (day: string) => void;
+}) {
+  const required = offering.is_required;
+  const effectiveChecked = required || checked;
+  let stateClass = "border-gray-200 bg-white hover:border-gray-300";
+  if (dayError) {
+    stateClass = "border-[#FF3130] bg-[#FF3130]/5";
+  } else if (required) {
+    stateClass = "border-gray-200 bg-gray-50";
+  } else if (checked) {
+    stateClass = "border-[#83CD2D]/40 bg-[#83CD2D]/10";
+  }
+  return (
+    <label
+      aria-invalid={dayError ? true : undefined}
+      className={`flex items-start gap-3 rounded-lg border p-3 text-sm transition-colors ${
+        required ? "cursor-default" : "cursor-pointer"
+      } ${stateClass}`}
+    >
+      <span className="relative mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white">
+        <input
+          name={`children_${childIndex}_offering_${offering.id}`}
+          type="checkbox"
+          checked={effectiveChecked}
+          disabled={required}
+          onChange={onToggle}
+          className={`absolute inset-0 opacity-0 ${
+            required ? "cursor-default" : "cursor-pointer"
+          }`}
+        />
+        {required ? (
+          <span className="flex h-5 w-5 items-center justify-center rounded-md bg-gray-400 text-white">
+            <Lock className="h-3 w-3" />
+          </span>
+        ) : (
+          checked && (
+            <span className="flex h-5 w-5 items-center justify-center rounded-md bg-[#83CD2D] text-white">
+              <Check className="h-3.5 w-3.5" />
+            </span>
+          )
+        )}
+      </span>
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium break-words text-gray-900">
+            {offering.name}
+          </span>
+          {required && (
+            <span className="rounded-full bg-gray-200 px-2 py-0.5 text-xs font-medium text-gray-600">
+              Pflicht
+            </span>
+          )}
+        </div>
+        {offering.description && (
+          <div className="text-xs break-words text-gray-600">
+            {offering.description}
+          </div>
+        )}
+        <div className="mt-1 text-xs text-gray-500">
+          {offering.days_of_week_mode === "parent_choice"
+            ? "Wählbare Tage: "
+            : "Tage: "}
+          {offering.available_days.map((d) => DAY_LABELS[d] ?? d).join(", ")}
+          {offering.includes_holiday_care && " · inkl. Ferienbetreuung"}
+          {offering.includes_lunch && " · inkl. Mittagessen"}
+        </div>
+        {effectiveChecked && offering.days_of_week_mode === "parent_choice" && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {offering.available_days.map((day) => {
+              const picked = selectedDays?.has(day) ?? false;
+              return (
+                <button
+                  key={day}
+                  type="button"
+                  onClick={(e) => {
+                    // The card's outer <label> would otherwise treat this as a
+                    // click on the offering checkbox itself.
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onToggleDay(day);
+                  }}
+                  className={`rounded-md border px-2 py-0.5 text-xs font-medium transition-colors ${
+                    picked
+                      ? "border-[#83CD2D] bg-[#83CD2D] text-white"
+                      : "border-gray-300 bg-white text-gray-700 hover:border-gray-400"
+                  }`}
+                  aria-pressed={picked}
+                >
+                  {DAY_LABELS[day] ?? day}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        {dayError && (
+          <p className="mt-1 text-xs text-[#FF3130]">
+            Bitte mindestens einen Tag auswählen.
+          </p>
+        )}
+      </div>
+    </label>
+  );
 }
 
 function Input({

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -223,13 +223,7 @@ export function EnrollmentForm({
           .filter((o) => o.is_required)
           .map((o) => o.id);
         if (requiredIDs.length > 0) {
-          setChildren((prev) =>
-            prev.map((c) => {
-              const nextIDs = new Set(c.offering_ids);
-              requiredIDs.forEach((id) => nextIDs.add(id));
-              return { ...c, offering_ids: nextIDs };
-            }),
-          );
+          setChildren((prev) => seedRequiredOfferings(prev, requiredIDs));
         }
         setCaptchaConfig(captchaResult);
         // Prefill guardian fields from the profile when present. We
@@ -438,7 +432,7 @@ export function EnrollmentForm({
       }
       for (const id of c.offering_ids) {
         const offering = offerings.find((o) => o.id === id);
-        if (!offering || offering.days_of_week_mode !== "parent_choice") {
+        if (offering?.days_of_week_mode !== "parent_choice") {
           continue;
         }
         const picked = c.offering_days[id];
@@ -502,7 +496,7 @@ export function EnrollmentForm({
       }> = [];
       for (const id of c.offering_ids) {
         const offering = offerings.find((o) => o.id === id);
-        if (!offering || offering.days_of_week_mode !== "parent_choice") {
+        if (offering?.days_of_week_mode !== "parent_choice") {
           continue;
         }
         const picked = c.offering_days[id];
@@ -803,19 +797,20 @@ export function EnrollmentForm({
                     const required = o.is_required;
                     const checked = child.offering_ids.has(o.id) || required;
                     const dayError = offeringDayErrors[`${i}_${o.id}`] ?? false;
+                    let stateClass =
+                      "border-gray-200 bg-white hover:border-gray-300";
+                    if (dayError) {
+                      stateClass = "border-[#FF3130] bg-[#FF3130]/5";
+                    } else if (checked) {
+                      stateClass = "border-[#83CD2D]/40 bg-[#83CD2D]/10";
+                    }
                     return (
                       <label
                         key={o.id}
                         aria-invalid={dayError ? true : undefined}
                         className={`flex items-start gap-3 rounded-lg border p-3 text-sm transition-colors ${
                           required ? "cursor-default" : "cursor-pointer"
-                        } ${
-                          dayError
-                            ? "border-[#FF3130] bg-[#FF3130]/5"
-                            : checked
-                              ? "border-[#83CD2D]/40 bg-[#83CD2D]/10"
-                              : "border-gray-200 bg-white hover:border-gray-300"
-                        }`}
+                        } ${stateClass}`}
                       >
                         <span className="relative mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white">
                           <input
@@ -1043,6 +1038,20 @@ function blankChild(requiredOfferingIDs: readonly string[] = []): ChildDraft {
   };
 }
 
+// seedRequiredOfferings adds every mandatory offering id to each existing
+// child slot, leaving the rest of the draft untouched. Used after offerings
+// load to back-fill the initial blank child created before the fetch resolved.
+function seedRequiredOfferings(
+  children: ChildDraft[],
+  requiredIDs: readonly string[],
+): ChildDraft[] {
+  return children.map((c) => {
+    const nextIDs = new Set(c.offering_ids);
+    requiredIDs.forEach((id) => nextIDs.add(id));
+    return { ...c, offering_ids: nextIDs };
+  });
+}
+
 function Input({
   label,
   name,
@@ -1213,35 +1222,43 @@ function customValueMissing(
     return typeof value !== "boolean";
   }
   if (field.type === "phone_list") {
-    if (!Array.isArray(value) || value.length === 0) return true;
-    return value.some((row) => {
-      if (!row || typeof row !== "object") return true;
-      const phoneNumber = (row as Partial<PhoneEntry>).phone_number;
-      return typeof phoneNumber !== "string" || phoneNumber.trim() === "";
-    });
+    return phoneListValueMissing(value);
   }
   if (field.type === "contact_list") {
-    if (!Array.isArray(value) || value.length === 0) return true;
-    return value.some((row) => {
-      if (!row || typeof row !== "object") return true;
-      const contact = row as ContactEntryValue;
-      const hasName =
-        typeof contact.first_name === "string" &&
-        contact.first_name.trim() !== "" &&
-        typeof contact.last_name === "string" &&
-        contact.last_name.trim() !== "";
-      const hasEmail = (contact.email ?? "").trim() !== "";
-      const hasPhone =
-        Array.isArray(contact.phone_numbers) &&
-        contact.phone_numbers.some((phone) => phone.phone_number.trim() !== "");
-      return !hasName || (!hasEmail && !hasPhone);
-    });
+    return contactListValueMissing(value);
   }
   if (field.type === "weekday_schedule") {
     const schedule = asScheduleObject(value);
     return !Object.values(schedule).some((time) => time.trim() !== "");
   }
   return typeof value !== "string" || value.trim() === "";
+}
+
+function phoneListValueMissing(value: unknown): boolean {
+  if (!Array.isArray(value) || value.length === 0) return true;
+  return value.some((row) => {
+    if (!row || typeof row !== "object") return true;
+    const phoneNumber = (row as Partial<PhoneEntry>).phone_number;
+    return typeof phoneNumber !== "string" || phoneNumber.trim() === "";
+  });
+}
+
+function contactListValueMissing(value: unknown): boolean {
+  if (!Array.isArray(value) || value.length === 0) return true;
+  return value.some((row) => {
+    if (!row || typeof row !== "object") return true;
+    const contact = row as ContactEntryValue;
+    const hasName =
+      typeof contact.first_name === "string" &&
+      contact.first_name.trim() !== "" &&
+      typeof contact.last_name === "string" &&
+      contact.last_name.trim() !== "";
+    const hasEmail = (contact.email ?? "").trim() !== "";
+    const hasPhone =
+      Array.isArray(contact.phone_numbers) &&
+      contact.phone_numbers.some((phone) => phone.phone_number.trim() !== "");
+    return !hasName || (!hasEmail && !hasPhone);
+  });
 }
 
 function requiredMessageForField(

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -129,6 +129,13 @@ export function EnrollmentForm({
   const [childOfferingErrors, setChildOfferingErrors] = useState<
     Record<number, boolean>
   >({});
+  // Per parent_choice offering that is selected but has no day picked.
+  // Keyed by `${childIndex}_${offeringId}` so the offending offering row
+  // (not the whole group) gets the red border + inline message, and the
+  // scroll-to-error effect can land on it via aria-invalid.
+  const [offeringDayErrors, setOfferingDayErrors] = useState<
+    Record<string, boolean>
+  >({});
   // Per-field validation errors, keyed by each input's `name`
   // (guardian_email, children_0_first_name, ...). Drives the red border +
   // inline message on the offending input; rebuilt on every submit.
@@ -303,6 +310,15 @@ export function EnrollmentForm({
         };
       }),
     );
+    // Clear the "no day picked" error for this offering as soon as the
+    // parent picks one, so the red border + message disappear live.
+    setOfferingDayErrors((prev) => {
+      const key = `${childIndex}_${offeringID}`;
+      if (!prev[key]) return prev;
+      const nextErrors = { ...prev };
+      delete nextErrors[key];
+      return nextErrors;
+    });
   };
 
   const addChild = () =>
@@ -314,6 +330,7 @@ export function EnrollmentForm({
     e.preventDefault();
     setError(null);
     setChildOfferingErrors({});
+    setOfferingDayErrors({});
     setFieldErrors({});
     // Bump per attempt so the scroll-to-error effect re-runs even when this
     // submit produces the same error message as the previous one. Covers
@@ -404,65 +421,100 @@ export function EnrollmentForm({
       newFieldErrors.consent_email_contact =
         "Bitte dem E-Mail-Kontakt zustimmen.";
     }
-    const errorKeys = Object.keys(newFieldErrors);
-    if (errorKeys.length > 0) {
+    // Offering validation runs in the SAME pass as the field checks above
+    // so a missing care-offering day and a missing core field (e.g. phone)
+    // are flagged together on a single submit, not one-at-a-time. This pass
+    // only collects errors; the payload is assembled afterwards once
+    // everything is valid.
+    const missingCareIndexes: number[] = [];
+    // Selected parent_choice offerings with no day picked, keyed
+    // `${childIndex}_${offeringId}` so each offending row gets a red border +
+    // inline message and the scroll-to-error effect can target it.
+    const dayErrors: Record<string, boolean> = {};
+    let firstDayErrorMessage: string | null = null;
+    for (const [i, c] of children.entries()) {
+      if (careRequired && c.offering_ids.size === 0) {
+        missingCareIndexes.push(i);
+      }
+      for (const id of c.offering_ids) {
+        const offering = offerings.find((o) => o.id === id);
+        if (!offering || offering.days_of_week_mode !== "parent_choice") {
+          continue;
+        }
+        const picked = c.offering_days[id];
+        if (!picked || picked.size === 0) {
+          dayErrors[`${i}_${id}`] = true;
+          if (!firstDayErrorMessage) {
+            firstDayErrorMessage = `Kind ${i + 1}: Beim Angebot „${offering.name}" muss mindestens ein Tag ausgewählt werden.`;
+          }
+        }
+      }
+    }
+
+    const fieldErrorKeys = Object.keys(newFieldErrors);
+    const dayErrorCount = Object.keys(dayErrors).length;
+    const hasOfferingIssue = missingCareIndexes.length > 0 || dayErrorCount > 0;
+    if (fieldErrorKeys.length > 0 || hasOfferingIssue) {
       setFieldErrors(newFieldErrors);
+      if (missingCareIndexes.length > 0) {
+        setChildOfferingErrors(
+          Object.fromEntries(missingCareIndexes.map((i) => [i, true])),
+        );
+      }
+      setOfferingDayErrors(dayErrors);
       // Banner text:
-      //  - exactly one missing field/consent → its own specific message
-      //  - several, but all of them consents → the consent summary
-      //  - anything else / mixed             → a generic summary
-      // (the per-field red marking always shows which inputs are affected).
-      const onlyConsents = errorKeys.every((key) => key.startsWith("consent_"));
-      const [firstMessage] = Object.values(newFieldErrors);
+      //  - exactly one missing field        → its own specific message
+      //  - only consents missing            → the consent summary
+      //  - only care-offering issues        → the matching offering message
+      //  - anything else / mixed            → a generic summary
+      // Every offending input is red-marked regardless, and the scroll
+      // effect lands on the first one.
+      const onlyConsents =
+        !hasOfferingIssue &&
+        fieldErrorKeys.length > 0 &&
+        fieldErrorKeys.every((key) => key.startsWith("consent_"));
       let banner = "Bitte korrigiere die rot markierten Felder.";
-      if (errorKeys.length === 1 && firstMessage) {
-        banner = firstMessage;
+      if (fieldErrorKeys.length === 1 && !hasOfferingIssue) {
+        banner = Object.values(newFieldErrors)[0] ?? banner;
       } else if (onlyConsents) {
         banner = "Bitte bestätige alle erforderlichen Zustimmungen.";
+      } else if (fieldErrorKeys.length === 0 && missingCareIndexes.length > 0) {
+        banner =
+          "Bitte wähle für jedes Kind mindestens ein Betreuungsangebot aus.";
+      } else if (
+        fieldErrorKeys.length === 0 &&
+        dayErrorCount > 0 &&
+        firstDayErrorMessage
+      ) {
+        banner = firstDayErrorMessage;
       }
       setError(banner);
       return;
     }
 
-    const payloadChildren: SubmitChildPayload[] = [];
-    const missingCareIndexes: number[] = [];
-    for (const [i, c] of children.entries()) {
-      // Core fields are already guaranteed present by the field-collection
-      // pass above; this loop only builds the payload + validates offerings.
-      if (careRequired && c.offering_ids.size === 0) {
-        missingCareIndexes.push(i);
-      }
-
-      // Build the optional offering_days payload: one entry per
-      // parent_choice offering the parent picked. Fixed offerings get
-      // no entry (backend treats absence as "use the admin-fixed
-      // days"). Reject submit when a parent_choice offering is picked
-      // but has no day selected — the message names the offending row.
+    // All required input is valid — assemble the wire payload. Day
+    // selections for parent_choice offerings are guaranteed present by the
+    // validation above, so this only builds data (no further checks).
+    const payloadChildren: SubmitChildPayload[] = children.map((c) => {
       const offeringDaysPayload: Array<{
         offering_id: number;
         selected_days: string[];
       }> = [];
       for (const id of c.offering_ids) {
         const offering = offerings.find((o) => o.id === id);
-        if (!offering) continue;
-        if (offering.days_of_week_mode !== "parent_choice") continue;
-        const picked = c.offering_days[id];
-        if (!picked || picked.size === 0) {
-          setError(
-            `Kind ${i + 1}: Beim Angebot „${offering.name}" muss mindestens ein Tag ausgewählt werden.`,
-          );
-          return;
+        if (!offering || offering.days_of_week_mode !== "parent_choice") {
+          continue;
         }
+        const picked = c.offering_days[id];
+        if (!picked || picked.size === 0) continue;
         offeringDaysPayload.push({
           offering_id: Number(id),
-          // Preserve the admin-defined order from available_days so
-          // the wire payload doesn't fluctuate with the parent's click
-          // order; deterministic ordering helps idempotency / dedup.
+          // Preserve the admin-defined order from available_days so the wire
+          // payload doesn't fluctuate with the parent's click order.
           selected_days: offering.available_days.filter((d) => picked.has(d)),
         });
       }
-
-      payloadChildren.push({
+      return {
         first_name: c.first_name.trim(),
         last_name: c.last_name.trim(),
         date_of_birth: c.date_of_birth,
@@ -471,17 +523,8 @@ export function EnrollmentForm({
         offering_ids: Array.from(c.offering_ids).map((id) => Number(id)),
         offering_days:
           offeringDaysPayload.length > 0 ? offeringDaysPayload : undefined,
-      });
-    }
-    if (missingCareIndexes.length > 0) {
-      setChildOfferingErrors(
-        Object.fromEntries(missingCareIndexes.map((i) => [i, true])),
-      );
-      setError(
-        "Bitte wähle für jedes Kind mindestens ein Betreuungsangebot aus.",
-      );
-      return;
-    }
+      };
+    });
 
     setSubmitting(true);
     try {
@@ -749,6 +792,7 @@ export function EnrollmentForm({
                   </p>
                 </div>
                 <div
+                  aria-invalid={childOfferingErrors[i] ? true : undefined}
                   className={`space-y-2 ${
                     childOfferingErrors[i]
                       ? "rounded-md border border-[#FF3130] bg-[#FF3130]/5 p-2"
@@ -758,15 +802,19 @@ export function EnrollmentForm({
                   {offerings.map((o) => {
                     const required = o.is_required;
                     const checked = child.offering_ids.has(o.id) || required;
+                    const dayError = offeringDayErrors[`${i}_${o.id}`] ?? false;
                     return (
                       <label
                         key={o.id}
+                        aria-invalid={dayError ? true : undefined}
                         className={`flex items-start gap-3 rounded-lg border p-3 text-sm transition-colors ${
                           required ? "cursor-default" : "cursor-pointer"
                         } ${
-                          checked
-                            ? "border-[#83CD2D]/40 bg-[#83CD2D]/10"
-                            : "border-gray-200 bg-white hover:border-gray-300"
+                          dayError
+                            ? "border-[#FF3130] bg-[#FF3130]/5"
+                            : checked
+                              ? "border-[#83CD2D]/40 bg-[#83CD2D]/10"
+                              : "border-gray-200 bg-white hover:border-gray-300"
                         }`}
                       >
                         <span className="relative mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white">
@@ -854,6 +902,11 @@ export function EnrollmentForm({
                                 })}
                               </div>
                             )}
+                          {dayError && (
+                            <p className="mt-1 text-xs text-[#FF3130]">
+                              Bitte mindestens einen Tag auswählen.
+                            </p>
+                          )}
                         </div>
                       </label>
                     );

--- a/frontend/src/components/enrollment/phases-editor.tsx
+++ b/frontend/src/components/enrollment/phases-editor.tsx
@@ -23,6 +23,7 @@ import {
   type PhaseInput,
   type PhaseKind,
   type PhaseCareOverflowMode,
+  type PhaseCareOfferingSelectionMode,
   type RolloverResult,
   createPhase,
   deletePhase,
@@ -58,6 +59,12 @@ const OVERFLOW_LABELS: Record<PhaseCareOverflowMode, string> = {
   allow: "Ohne Hinweis akzeptieren",
 };
 
+const CARE_SELECTION_LABELS: Record<PhaseCareOfferingSelectionMode, string> = {
+  optional: "Optional",
+  at_least_one: "Mindestens ein Angebot",
+  exactly_one: "Genau ein Angebot",
+};
+
 // Schema-source mode.
 // "base" sets form_schema_id = null. "reuse" picks an existing schema row.
 type SchemaSource = "base" | "reuse";
@@ -78,6 +85,7 @@ function blankInput(): PhaseInput {
     form_schema_id: null,
     show_status_reason_to_parent: false,
     care_overflow_mode: "waitlist",
+    care_offering_selection_mode: "optional",
     is_active: true,
   };
 }
@@ -93,6 +101,7 @@ function phaseToInput(p: Phase): PhaseInput {
     form_schema_id: p.form_schema_id ?? null,
     show_status_reason_to_parent: p.show_status_reason_to_parent,
     care_overflow_mode: p.care_overflow_mode,
+    care_offering_selection_mode: p.care_offering_selection_mode ?? "optional",
     is_active: p.is_active,
   };
 }
@@ -1155,6 +1164,34 @@ function PhaseForm(props: PhaseFormProps) {
       </fieldset>
 
       <div className="grid gap-4 sm:grid-cols-2">
+        <label className="block">
+          <span className="text-xs font-medium text-gray-700">
+            Betreuungsauswahl
+          </span>
+          <select
+            name="care_offering_selection_mode"
+            value={draft.care_offering_selection_mode}
+            onChange={(e) =>
+              update({
+                care_offering_selection_mode: e.target
+                  .value as PhaseCareOfferingSelectionMode,
+              })
+            }
+            className="moto-select moto-content-surface mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+          >
+            <option value="optional">{CARE_SELECTION_LABELS.optional}</option>
+            <option value="at_least_one">
+              {CARE_SELECTION_LABELS.at_least_one}
+            </option>
+            <option value="exactly_one">
+              {CARE_SELECTION_LABELS.exactly_one}
+            </option>
+          </select>
+          <span className="mt-1 block text-xs text-gray-500">
+            Pflichtangebote bleiben davon getrennt und sind immer vorausgewählt.
+          </span>
+        </label>
+
         <label className="block">
           <span className="text-xs font-medium text-gray-700">
             Verhalten bei voller Betreuung

--- a/frontend/src/components/enrollment/rollover-form.test.tsx
+++ b/frontend/src/components/enrollment/rollover-form.test.tsx
@@ -37,6 +37,7 @@ function makeSourcePhase(overrides: Partial<Phase> = {}): Phase {
     form_schema_id: "7",
     show_status_reason_to_parent: false,
     care_overflow_mode: "waitlist",
+    care_offering_selection_mode: "optional",
     is_active: true,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",

--- a/frontend/src/components/settings/fields/boolean-field.tsx
+++ b/frontend/src/components/settings/fields/boolean-field.tsx
@@ -4,18 +4,21 @@ interface BooleanFieldProps {
   readonly value: boolean;
   readonly onChange: (value: boolean) => void;
   readonly disabled?: boolean;
+  readonly ariaLabel?: string;
 }
 
 export function BooleanField({
   value,
   onChange,
   disabled = false,
+  ariaLabel,
 }: BooleanFieldProps) {
   return (
     <button
       type="button"
       role="switch"
       aria-checked={value}
+      aria-label={ariaLabel}
       onClick={() => onChange(!value)}
       disabled={disabled}
       className={`relative inline-flex h-7 w-12 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 ${

--- a/frontend/src/lib/care-offering-api.test.ts
+++ b/frontend/src/lib/care-offering-api.test.ts
@@ -44,6 +44,7 @@ function mkOffering(id: string): CareOffering {
     includes_holiday_care: false,
     includes_lunch: false,
     is_active: true,
+    is_required: false,
     sort_order: 0,
     created_at: "2026-04-01T12:00:00Z",
     updated_at: "2026-04-01T12:00:00Z",
@@ -58,6 +59,7 @@ const validInput: CareOfferingInput = {
   includes_holiday_care: false,
   includes_lunch: false,
   is_active: true,
+  is_required: false,
   sort_order: 0,
 };
 

--- a/frontend/src/lib/care-offering-api.ts
+++ b/frontend/src/lib/care-offering-api.ts
@@ -17,6 +17,7 @@ export interface CareOffering {
   capacity?: number | null;
   price_cents?: number | null;
   is_active: boolean;
+  is_required: boolean;
   sort_order: number;
   created_at: string;
   updated_at: string;
@@ -34,6 +35,7 @@ export interface CareOfferingInput {
   capacity?: number | null;
   price_cents?: number | null;
   is_active: boolean;
+  is_required: boolean;
   sort_order: number;
 }
 

--- a/frontend/src/lib/enrollment-form-schema-api.ts
+++ b/frontend/src/lib/enrollment-form-schema-api.ts
@@ -216,7 +216,7 @@ export function latestSchemasByName(schemas: FormSchema[]): FormSchema[] {
 
 /**
  * Public variant of fetchActiveSchema for the parent enrollment form.
- * Slug-gated, no JWT — backend resolves the tenant from the URL param
+ * Slug-gated, no JWT. Backend resolves the tenant from the URL param
  * and returns only the active schema's fields. Returns null when no
  * schema has been published yet (404), letting the form fall back to
  * core fields only without erroring out.
@@ -232,7 +232,7 @@ export interface PublicFormSchema {
  * Public Cloudflare Turnstile config for a tenant. enabled mirrors the
  * server-side enrollment.require_captcha setting; site_key is the
  * public Turnstile site key (safe to render in the widget). When
- * site_key is empty the widget is hidden and submit falls through —
+ * site_key is empty the widget is hidden and submit falls through;
  * the backend's IsEnabled check still gates verification.
  */
 export interface PublicCaptchaConfig {
@@ -284,7 +284,7 @@ export async function fetchPublicActiveSchema(
 
 /**
  * Creates a new named schema (version 1). Backend rejects when a
- * schema with the same name already exists — use updateSchema in
+ * schema with the same name already exists. Use updateSchema in
  * that case.
  */
 export async function createSchema(
@@ -315,8 +315,9 @@ export async function createSchema(
 /**
  * Publishes a new version of an existing named schema. The new row
  * inherits the source schema's name and uses max(version)+1 for that
- * name. Older versions stay in place — already-bound phases keep
- * their pinned schema_id.
+ * name. Older versions stay in place for historical submissions, and
+ * phases using an older version of this template are moved to the new
+ * schema_id.
  */
 export async function updateSchema(
   id: string,

--- a/frontend/src/lib/enrollment-form-schema-api.ts
+++ b/frontend/src/lib/enrollment-form-schema-api.ts
@@ -120,12 +120,17 @@ export interface FormField {
   target?: FormFieldTarget;
 }
 
+export type CoreRequirementKey = "guardian_phone";
+
+export type CoreRequirements = Partial<Record<CoreRequirementKey, boolean>>;
+
 export interface FormSchema {
   id: string;
   name: string;
   version: number;
   is_active: boolean;
   fields: FormField[];
+  core_requirements?: CoreRequirements;
   created_by: string;
   created_at: string;
 }
@@ -220,6 +225,7 @@ export interface PublicFormSchema {
   id: string;
   version: number;
   fields: FormField[];
+  core_requirements?: CoreRequirements;
 }
 
 /**
@@ -284,11 +290,12 @@ export async function fetchPublicActiveSchema(
 export async function createSchema(
   name: string,
   fields: FormField[],
+  coreRequirements: CoreRequirements = {},
 ): Promise<FormSchema> {
   const response = await fetch(SCHEMA_PATH, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name, fields }),
+    body: JSON.stringify({ name, fields, core_requirements: coreRequirements }),
   });
   if (!response.ok) {
     const payload = (await response
@@ -314,11 +321,16 @@ export async function createSchema(
 export async function updateSchema(
   id: string,
   fields: FormField[],
+  coreRequirements?: CoreRequirements,
 ): Promise<FormSchema> {
+  const body =
+    coreRequirements === undefined
+      ? { fields }
+      : { fields, core_requirements: coreRequirements };
   const response = await fetch(`${SCHEMA_PATH}/${encodeURIComponent(id)}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ fields }),
+    body: JSON.stringify(body),
   });
   if (!response.ok) {
     const payload = (await response

--- a/frontend/src/lib/enrollment-phase-api.test.ts
+++ b/frontend/src/lib/enrollment-phase-api.test.ts
@@ -50,6 +50,7 @@ function mkPhase(id: string, name: string): Phase {
     form_schema_id: "7",
     show_status_reason_to_parent: false,
     care_overflow_mode: "waitlist",
+    care_offering_selection_mode: "optional",
     is_active: true,
     created_at: "2026-04-01T12:00:00Z",
     updated_at: "2026-04-01T12:00:00Z",
@@ -63,6 +64,7 @@ const validInput: PhaseInput = {
   service_end_date: "2027-07-31",
   show_status_reason_to_parent: false,
   care_overflow_mode: "waitlist",
+  care_offering_selection_mode: "optional",
   is_active: true,
 };
 

--- a/frontend/src/lib/enrollment-phase-api.ts
+++ b/frontend/src/lib/enrollment-phase-api.ts
@@ -4,6 +4,10 @@ const logger = createLogger({ component: "EnrollmentPhaseAPI" });
 
 export type PhaseKind = "school_year" | "holiday" | "custom";
 export type PhaseCareOverflowMode = "waitlist" | "reject" | "allow";
+export type PhaseCareOfferingSelectionMode =
+  | "optional"
+  | "at_least_one"
+  | "exactly_one";
 
 export interface Phase {
   id: string;
@@ -16,6 +20,7 @@ export interface Phase {
   form_schema_id?: string | null;
   show_status_reason_to_parent: boolean;
   care_overflow_mode: PhaseCareOverflowMode;
+  care_offering_selection_mode: PhaseCareOfferingSelectionMode;
   is_active: boolean;
   // Rollover columns — populated only on phases created by the
   // "verlängern" flow. NULL/false on fresh phases.
@@ -38,6 +43,7 @@ export interface PhaseInput {
   form_schema_id?: string | null;
   show_status_reason_to_parent: boolean;
   care_overflow_mode: PhaseCareOverflowMode;
+  care_offering_selection_mode: PhaseCareOfferingSelectionMode;
   is_active: boolean;
 }
 

--- a/frontend/src/lib/enrollment-submission-api.test.ts
+++ b/frontend/src/lib/enrollment-submission-api.test.ts
@@ -47,6 +47,7 @@ describe("enrollment-submission-api", () => {
               is_active: true,
             },
           ],
+          care_offering_selection_mode: "at_least_one",
           care_required: true,
         },
       }),
@@ -55,6 +56,7 @@ describe("enrollment-submission-api", () => {
     await expect(
       fetchPublicCareOfferings("test tenant", "phase/5"),
     ).resolves.toMatchObject({
+      careOfferingSelectionMode: "at_least_one",
       careRequired: true,
       offerings: [{ id: "11", name: "Flexible Betreuung" }],
     });
@@ -71,6 +73,7 @@ describe("enrollment-submission-api", () => {
 
     await expect(fetchPublicCareOfferings("tenant", "5")).resolves.toEqual({
       offerings: [],
+      careOfferingSelectionMode: "optional",
       careRequired: false,
     });
   });
@@ -103,6 +106,7 @@ describe("enrollment-submission-api", () => {
             service_start_date: "2026-08-01",
             service_end_date: "2027-07-31",
             show_status_reason_to_parent: true,
+            care_offering_selection_mode: "at_least_one",
           },
         ],
       }),

--- a/frontend/src/lib/enrollment-submission-api.ts
+++ b/frontend/src/lib/enrollment-submission-api.ts
@@ -14,6 +14,7 @@ export interface PublicCareOffering {
   capacity?: number | null;
   price_cents?: number | null;
   is_active: boolean;
+  is_required: boolean;
 }
 
 interface SubmitOfferingDays {
@@ -79,6 +80,8 @@ async function readJSON<T>(response: Response): Promise<T> {
 const SUBMISSION_ERROR_MESSAGES: Record<string, string> = {
   "enrollment.care_offering_missing":
     "Bitte wähle für jedes Kind mindestens ein Betreuungsangebot aus.",
+  "enrollment.required_care_offering_missing":
+    "Für jedes Kind muss ein verpflichtendes Betreuungsangebot ausgewählt sein.",
   "enrollment.care_offering_full":
     "Eines der ausgewählten Betreuungsangebote ist bereits voll und kann derzeit keine weiteren Anmeldungen aufnehmen. Bitte wähle ein anderes Angebot oder wende dich an die Schule.",
   "enrollment.disabled":

--- a/frontend/src/lib/enrollment-submission-api.ts
+++ b/frontend/src/lib/enrollment-submission-api.ts
@@ -2,6 +2,11 @@ import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "EnrollmentSubmissionAPI" });
 
+export type CareOfferingSelectionMode =
+  | "optional"
+  | "at_least_one"
+  | "exactly_one";
+
 export interface PublicCareOffering {
   id: string;
   phase_id?: string | null;
@@ -80,6 +85,8 @@ async function readJSON<T>(response: Response): Promise<T> {
 const SUBMISSION_ERROR_MESSAGES: Record<string, string> = {
   "enrollment.care_offering_missing":
     "Bitte wähle für jedes Kind mindestens ein Betreuungsangebot aus.",
+  "enrollment.care_offering_exactly_one":
+    "Bitte wähle für jedes Kind genau ein Betreuungsangebot aus.",
   "enrollment.required_care_offering_missing":
     "Für jedes Kind muss ein verpflichtendes Betreuungsangebot ausgewählt sein.",
   "enrollment.care_offering_full":
@@ -120,14 +127,15 @@ async function readError(response: Response, fallback: string): Promise<Error> {
 
 export interface PublicCareOfferingsResult {
   offerings: PublicCareOffering[];
+  careOfferingSelectionMode: CareOfferingSelectionMode;
   careRequired: boolean;
 }
 
 /**
  * Fetches the public care-offering catalog for a given tenant slug
- * and phase. Returns the offerings plus the tenant's
- * "care_offerings_required" flag so the form can render the hint and
- * validate before submit. The backend re-checks the flag on submit.
+ * and phase. Returns the offerings plus the phase-level selection mode
+ * so the form can render the hint and validate before submit. The
+ * backend re-checks the mode on submit.
  */
 export async function fetchPublicCareOfferings(
   tenantSlug: string,
@@ -147,11 +155,16 @@ export async function fetchPublicCareOfferings(
   }
   const payload = await readJSON<{
     offerings?: PublicCareOffering[];
+    care_offering_selection_mode?: CareOfferingSelectionMode;
     care_required?: boolean;
   }>(response);
+  const mode =
+    payload?.care_offering_selection_mode ??
+    (payload?.care_required === true ? "at_least_one" : "optional");
   return {
     offerings: Array.isArray(payload?.offerings) ? payload.offerings : [],
-    careRequired: payload?.care_required === true,
+    careOfferingSelectionMode: mode,
+    careRequired: mode !== "optional",
   };
 }
 
@@ -164,6 +177,7 @@ export interface PublicPhase {
   enrollment_open_at?: string;
   enrollment_close_at?: string;
   show_status_reason_to_parent: boolean;
+  care_offering_selection_mode: CareOfferingSelectionMode;
 }
 
 /**


### PR DESCRIPTION
## What this does

Lets a school mark previously-optional enrollment fields as **required**, per form template / phase — without touching the fields that are always required or the consent block.

Three independent "required" mechanisms:

1. **Built-in base fields** — a per-template `core_requirements` map. Currently only the guardian phone number is configurable (the only optional base field); name/email/child fields stay always-required.
2. **Custom & Stammdaten questions** — the existing per-field `required` flag is now enforced server-side, and the toggle is enabled for Stammdaten/target questions too (was previously locked off).
3. **Care offerings** — a per-offering `is_required` flag makes an offering mandatory for every child.

**Explicitly out of scope (unchanged):** the consent block. AGB / Datenschutz / E-Mail-Kontakt stay always-required; photo stays always-optional.

## How it works

- **Storage:** `form_schemas.core_requirements` (JSONB) + `care_offerings.is_required` (bool). Two additive migrations (1.15.79 / 1.15.80), both defaulting to "optional" so existing data is unaffected.
- **Enforcement is layered (client + server):**
  - Public form pre-validates and blocks submit with inline per-field errors.
  - Backend re-validates in `RequestService.Submit` (`validateSubmissionAgainstSchema` for core + custom fields, `validateRequiredOfferings` for offerings, plus the consent gate) — defense-in-depth, so a stale/bypassed client can't get through.
- **Required care offerings** are pre-selected and locked in the public form (and seeded into every child slot, incl. newly added/adopted children). A required offering may not carry a capacity limit (validated in the model + the editor clears/locks the field) so it can never fill up and block enrollment.
- **Required + `parent_choice` offering:** the parent must still pick at least one day; enforced at insert time by `resolveSelectedDays`.

## Important to note

- **Schema edits now propagate to live phases.** Editing a template publishes a new version (new id) and `RepointFormSchema` advances every bound phase onto it, so the change reaches the public form without a manual re-bind. Already-submitted requests keep their pinned `schema_id`, so history is unaffected.
- The `is_active` flag on form schemas is intentionally **not** load-bearing for named templates — phases pin by id (see migration 1.15.74). Multiple active versions per name is expected.
- Consent keys are centralized (`models/enrollment`) and **must stay in sync** with the `consent_flags` object in `enrollment-form.tsx`.

## Testing

Backend (build/vet/hermetic/migration-validate + enrollment suite) and frontend (check/prettier/enrollment + settings tests) all green. Verified live in demo-school end-to-end: toggle persistence, public-form rendering + submit-blocking (incl. structured fields), schema-edit propagation, locked required offering, and a full successful submit writing a correct request.
