### PR TITLE
Add student day planning filters

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -347,6 +347,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 		ArrivalScheduleService: api.Services.ArrivalSchedule,
 		PickupScheduleRepo:     repoFactory.StudentPickupSchedule,
 		ArrivalScheduleRepo:    repoFactory.StudentArrivalSchedule,
+		InstanceStudentRepo:    repoFactory.InstanceStudent,
 		SchoolRepo:             repoFactory.School,
 		SettingsService:        api.Services.Settings,
 		AttendanceRepo:         repoFactory.Attendance,

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -57,6 +57,7 @@ type Resource struct {
 	ArrivalScheduleService scheduleService.ArrivalScheduleService
 	PickupScheduleRepo     scheduleModel.StudentPickupScheduleRepository
 	ArrivalScheduleRepo    scheduleModel.StudentArrivalScheduleRepository
+	InstanceStudentRepo    scheduleModel.InstanceStudentRepository
 	SchoolRepo             platform.SchoolRepository
 	SettingsService        configService.SettingsService
 	AttendanceRepo         active.AttendanceRepository
@@ -67,6 +68,7 @@ type Resource struct {
 	StudentPhotos          userService.StudentPhotoService
 	ListExportService      listexport.Service
 	Logger                 *slog.Logger
+	Now                    func() time.Time
 	db                     *bun.DB
 }
 
@@ -84,6 +86,7 @@ type ResourceConfig struct {
 	ArrivalScheduleService scheduleService.ArrivalScheduleService
 	PickupScheduleRepo     scheduleModel.StudentPickupScheduleRepository
 	ArrivalScheduleRepo    scheduleModel.StudentArrivalScheduleRepository
+	InstanceStudentRepo    scheduleModel.InstanceStudentRepository
 	SchoolRepo             platform.SchoolRepository
 	SettingsService        configService.SettingsService
 	AttendanceRepo         active.AttendanceRepository
@@ -94,11 +97,17 @@ type ResourceConfig struct {
 	StudentPhotos          userService.StudentPhotoService
 	ListExportService      listexport.Service
 	Logger                 *slog.Logger
+	Now                    func() time.Time
 	DB                     *bun.DB
 }
 
 // NewResource creates a new students resource from the provided configuration.
 func NewResource(cfg ResourceConfig) *Resource {
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+
 	return &Resource{
 		PersonService:          cfg.PersonService,
 		StudentRepo:            cfg.StudentRepo,
@@ -111,6 +120,7 @@ func NewResource(cfg ResourceConfig) *Resource {
 		ArrivalScheduleService: cfg.ArrivalScheduleService,
 		PickupScheduleRepo:     cfg.PickupScheduleRepo,
 		ArrivalScheduleRepo:    cfg.ArrivalScheduleRepo,
+		InstanceStudentRepo:    cfg.InstanceStudentRepo,
 		SchoolRepo:             cfg.SchoolRepo,
 		SettingsService:        cfg.SettingsService,
 		AttendanceRepo:         cfg.AttendanceRepo,
@@ -121,6 +131,7 @@ func NewResource(cfg ResourceConfig) *Resource {
 		StudentPhotos:          cfg.StudentPhotos,
 		ListExportService:      cfg.ListExportService,
 		Logger:                 cfg.Logger,
+		Now:                    now,
 		db:                     cfg.DB,
 	}
 }
@@ -389,8 +400,16 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 	// Build and filter responses
 	responses := rs.buildStudentResponses(r.Context(), students, params, accessCtx, dataSnapshot, photosEnabled)
 
-	// Apply in-memory pagination if person-based filters were used
-	if params.hasPersonFilters() {
+	now := rs.Now()
+	if err := rs.enrichWithDayPlanning(r.Context(), responses, now, attendanceMapFromSnapshot(dataSnapshot)); err != nil {
+		slog.Default().Error("failed to enrich student day planning", slog.String("error", err.Error()))
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
+	responses = applyDayPlanningFilter(responses, params.dayStatus)
+
+	// Apply in-memory pagination if response-derived filters were used.
+	if params.hasInMemoryFilters() {
 		responses, totalCount = applyInMemoryPagination(responses, params.page, params.pageSize)
 	}
 
@@ -406,10 +425,10 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 	if params.includePickupTimes || params.includeArrivalTimes {
 		fullAccessIDs := collectFullAccessStudentIDs(responses)
 		if params.includePickupTimes {
-			rs.enrichWithPickupTimes(r.Context(), responses, fullAccessIDs, time.Now())
+			rs.enrichWithPickupTimes(r.Context(), responses, fullAccessIDs, now)
 		}
 		if params.includeArrivalTimes {
-			rs.enrichWithArrivalTimes(r.Context(), responses, fullAccessIDs, time.Now())
+			rs.enrichWithArrivalTimes(r.Context(), responses, fullAccessIDs, now)
 		}
 	}
 
@@ -618,6 +637,15 @@ func (rs *Resource) getStudent(w http.ResponseWriter, r *http.Request) {
 		} else {
 			applyActualTimesFromAttendance(&response.StudentResponse, attendanceStatus)
 		}
+
+		single := []StudentResponse{response.StudentResponse}
+		if err := rs.enrichWithDayPlanning(r.Context(), single, rs.Now(), map[int64]*activeService.AttendanceStatus{
+			student.ID: attendanceStatus,
+		}); err != nil {
+			renderError(w, r, ErrorInternalServer(err))
+			return
+		}
+		response.StudentResponse = single[0]
 	}
 
 	// Add supervisor contacts for users without full access

--- a/backend/api/students/day_planning.go
+++ b/backend/api/students/day_planning.go
@@ -1,0 +1,145 @@
+package students
+
+import (
+	"context"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeService "github.com/moto-nrw/project-phoenix/services/active"
+	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
+)
+
+const (
+	DayPlanningStatusAll              = "all"
+	DayPlanningStatusComesToday       = "comes_today"
+	DayPlanningStatusNotComingToday   = "not_coming_today"
+	dayPlanningReasonSick             = "sick"
+	dayPlanningReasonExcused          = "excused"
+	dayPlanningReasonArrivalException = "arrival_exception"
+	dayPlanningReasonPickupException  = "pickup_exception"
+	dayPlanningReasonArrivalSchedule  = "arrival_schedule"
+	dayPlanningReasonPickupSchedule   = "pickup_schedule"
+	dayPlanningReasonTimetable        = "timetable"
+	dayPlanningReasonUnplanned        = "unplanned_attendance"
+	dayPlanningReasonNoPlan           = "no_plan"
+)
+
+func (rs *Resource) enrichWithDayPlanning(ctx context.Context, responses []StudentResponse, now time.Time, attendances map[int64]*activeService.AttendanceStatus) error {
+	fullAccessIDs := collectFullAccessStudentIDs(responses)
+	if len(fullAccessIDs) == 0 {
+		return nil
+	}
+
+	arrivals := map[int64]*scheduleService.EffectiveArrivalTime{}
+	if rs.ArrivalScheduleService != nil {
+		var err error
+		arrivals, err = rs.ArrivalScheduleService.GetBulkEffectiveArrivalTimesForDate(ctx, fullAccessIDs, now)
+		if err != nil {
+			return err
+		}
+	}
+
+	pickups := map[int64]*scheduleService.EffectivePickupTime{}
+	if rs.PickupScheduleService != nil {
+		var err error
+		pickups, err = rs.PickupScheduleService.GetBulkEffectivePickupTimesForDate(ctx, fullAccessIDs, now)
+		if err != nil {
+			return err
+		}
+	}
+
+	timetableIDs := map[int64]struct{}{}
+	if rs.InstanceStudentRepo != nil {
+		plannedIDs, err := rs.InstanceStudentRepo.FindPlannedStudentIDsByDate(ctx, fullAccessIDs, timezone.DateOfUTC(now))
+		if err != nil {
+			return err
+		}
+		for _, id := range plannedIDs {
+			timetableIDs[id] = struct{}{}
+		}
+	}
+
+	for i := range responses {
+		if !responses[i].HasFullAccess {
+			continue
+		}
+		status, reason, label := resolveDayPlanning(responses[i], arrivals[responses[i].ID], pickups[responses[i].ID], attendances[responses[i].ID], timetableIDs)
+		responses[i].DayPlanningStatus = status
+		responses[i].DayPlanningReason = reason
+		responses[i].DayPlanningLabel = label
+	}
+
+	return nil
+}
+
+func resolveDayPlanning(
+	student StudentResponse,
+	arrival *scheduleService.EffectiveArrivalTime,
+	pickup *scheduleService.EffectivePickupTime,
+	attendance *activeService.AttendanceStatus,
+	timetableIDs map[int64]struct{},
+) (string, string, string) {
+	if arrival != nil && arrival.ArrivalTime != nil {
+		if arrival.IsException {
+			return DayPlanningStatusComesToday, dayPlanningReasonArrivalException, "geplante Ankunft heute"
+		}
+		return DayPlanningStatusComesToday, dayPlanningReasonArrivalSchedule, "Ankunftsplan heute"
+	}
+	if pickup != nil && pickup.PickupTime != nil {
+		if pickup.IsException {
+			return DayPlanningStatusComesToday, dayPlanningReasonPickupException, "geplante Abholung heute"
+		}
+		return DayPlanningStatusComesToday, dayPlanningReasonPickupSchedule, "Abholplan heute"
+	}
+	if _, ok := timetableIDs[student.ID]; ok {
+		return DayPlanningStatusComesToday, dayPlanningReasonTimetable, "Stundenplan heute"
+	}
+	if hasActualAttendanceToday(attendance) {
+		return DayPlanningStatusComesToday, dayPlanningReasonUnplanned, "ungeplant anwesend"
+	}
+	if student.Sick {
+		return DayPlanningStatusNotComingToday, dayPlanningReasonSick, "krank gemeldet"
+	}
+	if student.Excused {
+		return DayPlanningStatusNotComingToday, dayPlanningReasonExcused, "entschuldigt"
+	}
+	if arrival != nil && arrival.IsException && arrival.ArrivalTime == nil {
+		return DayPlanningStatusNotComingToday, dayPlanningReasonArrivalException, dayPlanningExceptionLabel(arrival.Notes)
+	}
+	if pickup != nil && pickup.IsException && pickup.PickupTime == nil {
+		return DayPlanningStatusNotComingToday, dayPlanningReasonPickupException, dayPlanningExceptionLabel(pickup.Notes)
+	}
+	return DayPlanningStatusNotComingToday, dayPlanningReasonNoPlan, "kein Plan für heute"
+}
+
+func hasActualAttendanceToday(attendance *activeService.AttendanceStatus) bool {
+	return attendance != nil && attendance.CheckInTime != nil && attendance.Status != "not_checked_in"
+}
+
+func attendanceMapFromSnapshot(snapshot *common.StudentDataSnapshot) map[int64]*activeService.AttendanceStatus {
+	if snapshot == nil || snapshot.LocationSnapshot == nil || snapshot.LocationSnapshot.Attendances == nil {
+		return map[int64]*activeService.AttendanceStatus{}
+	}
+	return snapshot.LocationSnapshot.Attendances
+}
+
+func dayPlanningExceptionLabel(notes string) string {
+	if notes != "" {
+		return notes
+	}
+	return "Tagesausnahme"
+}
+
+func applyDayPlanningFilter(responses []StudentResponse, dayStatus string) []StudentResponse {
+	if dayStatus == "" || dayStatus == DayPlanningStatusAll {
+		return responses
+	}
+	filtered := make([]StudentResponse, 0, len(responses))
+	for _, response := range responses {
+		if response.DayPlanningStatus == dayStatus {
+			filtered = append(filtered, response)
+		}
+	}
+	return filtered
+}

--- a/backend/api/students/export_handlers.go
+++ b/backend/api/students/export_handlers.go
@@ -33,6 +33,7 @@ type studentExportFilters struct {
 	RoomID      string `json:"room_id"`
 	Year        string `json:"year"`
 	Status      string `json:"status"`
+	DayStatus   string `json:"day_status"`
 	PickupTime  string `json:"pickup_time"`
 	ArrivalTime string `json:"arrival_time"`
 	Sort        string `json:"sort"`
@@ -78,7 +79,11 @@ func (rs *Resource) exportStudents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fullAccessIDs := collectFullAccessStudentIDs(responses)
-	today := time.Now()
+	today := rs.Now()
+	if err := rs.enrichWithDayPlanning(r.Context(), responses, today, attendanceMapFromSnapshot(dataSnapshot)); err != nil {
+		renderError(w, r, ErrorInternalServer(err))
+		return
+	}
 	rs.enrichWithPickupTimes(r.Context(), responses, fullAccessIDs, today)
 	rs.enrichWithArrivalTimes(r.Context(), responses, fullAccessIDs, today)
 
@@ -139,6 +144,7 @@ func exportRequestToListParams(req studentExportRequest) *studentListParams {
 		pageSize:            studentExportPageSize,
 		includePickupTimes:  true,
 		includeArrivalTimes: true,
+		dayStatus:           parseDayStatusParam(req.Filters.DayStatus),
 	}
 	if req.Filters.GroupID != "" {
 		if groupID, err := strconv.ParseInt(req.Filters.GroupID, 10, 64); err == nil {
@@ -160,6 +166,9 @@ func applyExportFilters(students []StudentResponse, filters studentExportFilters
 			continue
 		}
 		if filters.Status != "" && filters.Status != "all" && exportStatus(student) != filters.Status {
+			continue
+		}
+		if filters.DayStatus != "" && filters.DayStatus != DayPlanningStatusAll && student.DayPlanningStatus != filters.DayStatus {
 			continue
 		}
 		if filters.PickupTime != "" && filters.PickupTime != "all" {
@@ -365,7 +374,21 @@ func exportFilterLabels(filters studentExportFilters) []string {
 	if filters.Status != "" && filters.Status != "all" {
 		labels = append(labels, "Momentaufnahme: "+filters.Status)
 	}
+	if filters.DayStatus != "" && filters.DayStatus != DayPlanningStatusAll {
+		labels = append(labels, "Tagesplanung: "+dayStatusExportLabel(filters.DayStatus))
+	}
 	return labels
+}
+
+func dayStatusExportLabel(status string) string {
+	switch status {
+	case DayPlanningStatusComesToday:
+		return "Kommt heute"
+	case DayPlanningStatusNotComingToday:
+		return "Kommt heute nicht"
+	default:
+		return status
+	}
 }
 
 func schoolYear(schoolClass string) string {

--- a/backend/api/students/list_helpers.go
+++ b/backend/api/students/list_helpers.go
@@ -24,6 +24,7 @@ type studentListParams struct {
 	pageSize            int
 	includePickupTimes  bool
 	includeArrivalTimes bool
+	dayStatus           string
 	// studentIDs is an optional pre-filter populated by upstream resolution
 	// (e.g., room_id → active visits) before the SQL list query runs. When
 	// set, buildBaseFilter adds `student.id IN (...)` so the standard
@@ -67,6 +68,7 @@ func parseStudentListParams(r *http.Request) *studentListParams {
 	// Parse optional includes
 	params.includePickupTimes = r.URL.Query().Get("include_pickup_times") == "true"
 	params.includeArrivalTimes = r.URL.Query().Get("include_arrival_times") == "true"
+	params.dayStatus = parseDayStatusParam(r.URL.Query().Get("day_status"))
 
 	// Parse pagination
 	params.page, params.pageSize = common.ParsePagination(r)
@@ -77,6 +79,19 @@ func parseStudentListParams(r *http.Request) *studentListParams {
 // hasPersonFilters returns true if any person-based filters are active
 func (p *studentListParams) hasPersonFilters() bool {
 	return p.search != "" || p.firstName != "" || p.lastName != "" || p.location != ""
+}
+
+func (p *studentListParams) hasInMemoryFilters() bool {
+	return p.hasPersonFilters() || p.dayStatus != "" && p.dayStatus != DayPlanningStatusAll
+}
+
+func parseDayStatusParam(value string) string {
+	switch value {
+	case DayPlanningStatusComesToday, DayPlanningStatusNotComingToday:
+		return value
+	default:
+		return DayPlanningStatusAll
+	}
 }
 
 // buildBaseFilter creates the shared filter for school_class and guardian_name
@@ -104,7 +119,7 @@ func (p *studentListParams) buildQueryOptions() *base.QueryOptions {
 	queryOptions.Filter = p.buildBaseFilter()
 
 	// Add pagination only if no person-based filters
-	if !p.hasPersonFilters() {
+	if !p.hasInMemoryFilters() {
 		queryOptions.WithPagination(p.page, p.pageSize)
 	}
 

--- a/backend/api/students/students_test.go
+++ b/backend/api/students/students_test.go
@@ -16,8 +16,28 @@ import (
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	usersModel "github.com/moto-nrw/project-phoenix/models/users"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
+
+type studentDayPlanningTestResponse struct {
+	ID                int64  `json:"id"`
+	DayPlanningStatus string `json:"day_planning_status"`
+	DayPlanningReason string `json:"day_planning_reason"`
+}
+
+func decodeStudentsByID(t *testing.T, body []byte) map[int64]studentDayPlanningTestResponse {
+	t.Helper()
+	var resp struct {
+		Data []studentDayPlanningTestResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(body, &resp))
+	byID := make(map[int64]studentDayPlanningTestResponse, len(resp.Data))
+	for _, student := range resp.Data {
+		byID[student.ID] = student
+	}
+	return byID
+}
 
 // =============================================================================
 // List Students with Pickup Times Tests
@@ -226,6 +246,101 @@ func TestListStudents_WithArrivalTimes(t *testing.T) {
 			_, hasArrivalTime := student["arrival_time"]
 			assert.False(t, hasArrivalTime, "arrival_time should not be present when include_arrival_times is not set")
 		}
+	})
+}
+
+func TestListStudents_DayPlanningStatus(t *testing.T) {
+	tc := setupTestContext(t)
+	fixedNow := time.Date(2026, time.June, 1, 10, 0, 0, 0, time.UTC)
+	tc.resource.Now = func() time.Time { return fixedNow }
+
+	schoolClass := fmt.Sprintf("DP-%d", time.Now().UnixNano())
+	planned := testpkg.CreateTestStudent(t, tc.db, "DayPlan", "Pickup", schoolClass)
+	notPlanned := testpkg.CreateTestStudent(t, tc.db, "DayPlan", "NoPlan", schoolClass)
+	walkIn := testpkg.CreateTestStudent(t, tc.db, "DayPlan", "WalkIn", schoolClass)
+	sick := testpkg.CreateTestStudent(t, tc.db, "DayPlan", "Sick", schoolClass)
+	exceptionAbsent := testpkg.CreateTestStudent(t, tc.db, "DayPlan", "Exception", schoolClass)
+	staff := testpkg.CreateTestStaff(t, tc.db, "DayPlan", "Creator")
+	device := testpkg.CreateTestDevice(t, tc.db, "day-planning-device")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, planned.ID, notPlanned.ID, walkIn.ID, sick.ID, exceptionAbsent.ID, staff.ID, device.ID)
+
+	today := timezone.DateOfUTC(fixedNow)
+	pickupSchedule := testpkg.CreateTestPickupSchedule(t, tc.db, planned.ID, scheduleModel.WeekdayMonday, staff.ID, "15:30")
+	testpkg.CreateTestAttendance(t, tc.db, walkIn.ID, staff.ID, device.ID, time.Now().Add(-30*time.Minute), nil)
+
+	trueValue := true
+	_, err := tc.db.NewUpdate().
+		Model((*usersModel.Student)(nil)).
+		ModelTableExpr("users.students").
+		Set("sick = ?", trueValue).
+		Where("id = ?", sick.ID).
+		Exec(context.Background())
+	require.NoError(t, err)
+	arrivalException := testpkg.CreateTestArrivalException(t, tc.db, exceptionAbsent.ID, today, staff.ID, "", "Arzttermin")
+	defer testpkg.CleanupScheduleFixturesB11(
+		t,
+		tc.db,
+		nil,
+		[]int64{arrivalException.ID},
+		[]int64{pickupSchedule.ID},
+		nil,
+		nil,
+		nil,
+	)
+
+	router := setupRouter(tc.resource.ListStudentsHandler(), "")
+
+	t.Run("returns_computed_day_planning_fields", func(t *testing.T) {
+		req := testutil.NewRequest("GET", fmt.Sprintf("/?school_class=%s&page_size=50", schoolClass), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+		require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+		byID := decodeStudentsByID(t, rr.Body.Bytes())
+		assert.Equal(t, students.DayPlanningStatusComesToday, byID[planned.ID].DayPlanningStatus)
+		assert.Equal(t, "pickup_schedule", byID[planned.ID].DayPlanningReason)
+		assert.Equal(t, students.DayPlanningStatusNotComingToday, byID[notPlanned.ID].DayPlanningStatus)
+		assert.Equal(t, "no_plan", byID[notPlanned.ID].DayPlanningReason)
+		assert.Equal(t, students.DayPlanningStatusComesToday, byID[walkIn.ID].DayPlanningStatus)
+		assert.Equal(t, "unplanned_attendance", byID[walkIn.ID].DayPlanningReason)
+		assert.Equal(t, students.DayPlanningStatusNotComingToday, byID[sick.ID].DayPlanningStatus)
+		assert.Equal(t, "sick", byID[sick.ID].DayPlanningReason)
+		assert.Equal(t, students.DayPlanningStatusNotComingToday, byID[exceptionAbsent.ID].DayPlanningStatus)
+		assert.Equal(t, "arrival_exception", byID[exceptionAbsent.ID].DayPlanningReason)
+	})
+
+	t.Run("filters_comes_today_before_pagination", func(t *testing.T) {
+		req := testutil.NewRequest("GET", fmt.Sprintf("/?school_class=%s&day_status=comes_today&page_size=1", schoolClass), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+		require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+		byID := decodeStudentsByID(t, rr.Body.Bytes())
+		require.Len(t, byID, 1)
+		_, ok := byID[planned.ID]
+		assert.True(t, ok, "only planned student should survive comes_today filter")
+	})
+
+	t.Run("filters_actual_walk_in_as_comes_today_before_pagination", func(t *testing.T) {
+		req := testutil.NewRequest("GET", fmt.Sprintf("/?school_class=%s&day_status=comes_today&page_size=2", schoolClass), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+		require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+		byID := decodeStudentsByID(t, rr.Body.Bytes())
+		require.Len(t, byID, 2)
+		assert.Contains(t, byID, planned.ID)
+		assert.Contains(t, byID, walkIn.ID)
+	})
+
+	t.Run("filters_not_coming_today", func(t *testing.T) {
+		req := testutil.NewRequest("GET", fmt.Sprintf("/?school_class=%s&day_status=not_coming_today&page_size=50", schoolClass), nil)
+		rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+		require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+		byID := decodeStudentsByID(t, rr.Body.Bytes())
+		assert.NotContains(t, byID, planned.ID)
+		assert.NotContains(t, byID, walkIn.ID)
+		assert.Contains(t, byID, notPlanned.ID)
+		assert.Contains(t, byID, sick.ID)
+		assert.Contains(t, byID, exceptionAbsent.ID)
 	})
 }
 

--- a/backend/api/students/test_helpers_test.go
+++ b/backend/api/students/test_helpers_test.go
@@ -81,6 +81,7 @@ func setupTestContext(t *testing.T) *testContext {
 		PrivacyConsentRepo:     repoFactory.PrivacyConsent,
 		PickupScheduleService:  svc.PickupSchedule,
 		ArrivalScheduleService: svc.ArrivalSchedule,
+		InstanceStudentRepo:    repoFactory.InstanceStudent,
 		SchoolRepo:             repoFactory.School,
 		SettingsService:        svc.Settings,
 		AttendanceRepo:         repoFactory.Attendance,

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -46,6 +46,9 @@ type StudentResponse struct {
 	SickSince          *time.Time `json:"sick_since,omitempty"`
 	Excused            bool       `json:"excused"`
 	ExcusedSince       *time.Time `json:"excused_since,omitempty"`
+	DayPlanningStatus  string     `json:"day_planning_status,omitempty"`
+	DayPlanningReason  string     `json:"day_planning_reason,omitempty"`
+	DayPlanningLabel   string     `json:"day_planning_label,omitempty"`
 
 	// Photo (gated by operations.student_photos_enabled). PhotoURL is empty
 	// when no photo is set OR when the feature is off — the frontend's Avatar

--- a/backend/api/timetable/instance_students_unit_test.go
+++ b/backend/api/timetable/instance_students_unit_test.go
@@ -79,6 +79,9 @@ func (f *fakeRepo) FindExpectedByInstanceIDs(context.Context, []int64) ([]*sched
 func (f *fakeRepo) FindByStudentAndDateRange(context.Context, int64, time.Time, time.Time) ([]*schedule.InstanceStudent, error) {
 	panic("unused")
 }
+func (f *fakeRepo) FindPlannedStudentIDsByDate(context.Context, []int64, time.Time) ([]int64, error) {
+	panic("unused")
+}
 func (f *fakeRepo) DeleteByInstanceID(context.Context, int64) error { panic("unused") }
 func (f *fakeRepo) BulkUpdateStatus(context.Context, int64, string, string) (int, error) {
 	panic("unused")

--- a/backend/database/repositories/schedule/student_day.go
+++ b/backend/database/repositories/schedule/student_day.go
@@ -7,6 +7,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/uptrace/bun"
 )
 
 // scheduledInstanceScan is the flat row bun scans into; the repo then lifts
@@ -150,4 +151,34 @@ func (r *InstanceStudentRepository) FindInstancesWithAttendanceByStudentAndDateR
 		out = append(out, &schedule.ScheduledInstanceRow{Instance: inst, Attendance: att})
 	}
 	return out, nil
+}
+
+func (r *InstanceStudentRepository) FindPlannedStudentIDsByDate(ctx context.Context, studentIDs []int64, date time.Time) ([]int64, error) {
+	if len(studentIDs) == 0 {
+		return []int64{}, nil
+	}
+
+	var ids []int64
+	dateOnly := dateParam(date)
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`schedule.instance_students AS "instance_student"`).
+		Join(`INNER JOIN schedule.activity_instances AS "activity_instance" ON "activity_instance".id = "instance_student".instance_id AND "activity_instance".tenant_id = "instance_student".tenant_id`).
+		ColumnExpr(`DISTINCT "instance_student".student_id`).
+		Where(`"instance_student".student_id IN (?)`, bun.List(studentIDs)).
+		Where(`"activity_instance".date = ?::date`, dateOnly).
+		Where(`"activity_instance".status <> ?`, schedule.InstanceStatusCancelled).
+		OrderExpr(`"instance_student".student_id ASC`)
+
+	if where, val, ok := base.TenantWhere(ctx, aliasInstanceStudent); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx, &ids); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find planned student ids by date",
+			Err: err,
+		}
+	}
+
+	return ids, nil
 }

--- a/backend/models/schedule/instance_student.go
+++ b/backend/models/schedule/instance_student.go
@@ -253,4 +253,9 @@ type InstanceStudentRepository interface {
 	// instance they dropped into without being enrolled) are NOT included;
 	// the handler layer enriches those via the visits-side lookup.
 	FindInstancesWithAttendanceByStudentAndDateRange(ctx context.Context, studentID int64, from, to time.Time) ([]*ScheduledInstanceRow, error)
+
+	// FindPlannedStudentIDsByDate returns unique student IDs that have a
+	// non-cancelled materialized timetable row on the given date. Used by
+	// student search's "kommt heute" heuristic as an additive planning signal.
+	FindPlannedStudentIDsByDate(ctx context.Context, studentIDs []int64, date time.Time) ([]int64, error)
 }

--- a/backend/services/schedule/attendance_sync_service_unit_test.go
+++ b/backend/services/schedule/attendance_sync_service_unit_test.go
@@ -139,6 +139,10 @@ func (f *fakeInstanceStudentRepo) FindByStudentAndDateRange(context.Context, int
 	panic("unused")
 }
 
+func (f *fakeInstanceStudentRepo) FindPlannedStudentIDsByDate(context.Context, []int64, time.Time) ([]int64, error) {
+	panic("unused")
+}
+
 func (f *fakeInstanceStudentRepo) DeleteByInstanceID(context.Context, int64) error {
 	panic("unused")
 }

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -58,6 +58,10 @@ import { SSEErrorBoundary } from "~/components/sse/SSEErrorBoundary";
 import { useSWRAuth } from "~/lib/swr";
 import { combineTimeNotes, getStudentAbsence } from "~/lib/student-time-status";
 import {
+  getDayPlanningNotComingLabel,
+  getStudentPresenceBadgePlanning,
+} from "~/lib/day-planning-helper";
+import {
   ActiveSupervisionLoadingView,
   EmptyRoomsView,
   NoActiveSupervisionAccessView,
@@ -1679,13 +1683,19 @@ function MeinRaumPageContent() {
                   }
                   locationBadge={
                     <StudentPresenceBadge
-                      student={{
-                        ...student,
-                        not_arrival_today:
-                          (studentArrival?.isException ?? false) &&
-                          !studentArrival?.expectedArrival,
-                        not_arrival_reason: studentArrival?.notes ?? null,
-                      }}
+                      student={(() => {
+                        const badgePlanning = getStudentPresenceBadgePlanning({
+                          ...student,
+                          arrival_is_exception: studentArrival?.isException,
+                          arrival_time: studentArrival?.expectedArrival,
+                          arrival_notes: studentArrival?.notes,
+                        });
+                        return {
+                          ...student,
+                          not_arrival_today: badgePlanning.notArrivalToday,
+                          not_arrival_reason: badgePlanning.notArrivalReason,
+                        };
+                      })()}
                       displayMode="contextAware"
                       userGroups={myGroupIds}
                       groupRooms={myGroupRooms}
@@ -1712,6 +1722,18 @@ function MeinRaumPageContent() {
                         });
                         if (absence && !student.actual_pickup_time) {
                           return <StudentAbsenceRow label={absence.label} />;
+                        }
+                        const dayPlanningNotComingLabel =
+                          getDayPlanningNotComingLabel(student);
+                        if (
+                          dayPlanningNotComingLabel &&
+                          !student.actual_pickup_time
+                        ) {
+                          return (
+                            <StudentAbsenceRow
+                              label={dayPlanningNotComingLabel}
+                            />
+                          );
                         }
                         return (
                           <>

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -245,11 +245,17 @@ vi.mock("@/components/ui/student-presence-badge", () => ({
   StudentPresenceBadge: ({
     student,
   }: {
-    student?: { current_room_color?: string | null };
+    student?: {
+      current_room_color?: string | null;
+      not_arrival_today?: boolean;
+      not_arrival_reason?: string | null;
+    };
   }) => (
     <div
       data-testid="location-badge"
       data-room-color={student?.current_room_color ?? ""}
+      data-not-arrival={String(student?.not_arrival_today ?? false)}
+      data-not-arrival-reason={student?.not_arrival_reason ?? ""}
     >
       Presence
     </div>
@@ -2783,6 +2789,32 @@ describe("OGSGroupPage rendered pickup urgency", () => {
         .getAllByTestId("pickup-time-row")
         .some((el) => el.dataset.pickupTime === "13:00"),
     ).toBe(false);
+  });
+
+  it("uses day planning status for OGS group card absence and badge state", async () => {
+    setupWithStudentsAndPickupTimes(new Map(), undefined, undefined, {
+      "1": {
+        current_location: "Zuhause",
+        day_planning_status: "not_coming_today",
+        day_planning_label: "kein Plan für heute",
+      },
+    });
+
+    render(<OGSGroupPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("student-card")).toHaveLength(3);
+    });
+
+    expect(
+      screen.getByText("Kommt heute nicht (kein Plan für heute)"),
+    ).toBeInTheDocument();
+    const firstBadge = screen.getAllByTestId("location-badge")[0];
+    expect(firstBadge).toHaveAttribute("data-not-arrival", "true");
+    expect(firstBadge).toHaveAttribute(
+      "data-not-arrival-reason",
+      "kein Plan für heute",
+    );
   });
 
   it("shows the resolved pickup time, not the absence row, when a sick student is already picked up", async () => {

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -72,6 +72,10 @@ import {
   getStudentTimeStatus,
   getTimeStatusSortRank,
 } from "~/lib/student-time-status";
+import {
+  getDayPlanningNotComingLabel,
+  getStudentPresenceBadgePlanning,
+} from "~/lib/day-planning-helper";
 
 import { createLogger } from "~/lib/logger";
 
@@ -108,6 +112,9 @@ interface BackendStudentFromBFF {
   arrival_time?: string;
   arrival_is_exception?: boolean;
   arrival_notes?: string;
+  day_planning_status?: "comes_today" | "not_coming_today";
+  day_planning_reason?: string;
+  day_planning_label?: string;
   actual_arrival_time?: string;
   actual_pickup_time?: string;
   // Authenticated photo URL (already rewritten by the backend response
@@ -176,6 +183,9 @@ function mapStudentForOgsPage(
       arrival_time: student.arrival_time,
       arrival_is_exception: student.arrival_is_exception,
       arrival_notes: student.arrival_notes,
+      day_planning_status: student.day_planning_status,
+      day_planning_reason: student.day_planning_reason,
+      day_planning_label: student.day_planning_label,
       actual_arrival_time: student.actual_arrival_time,
       actual_pickup_time: student.actual_pickup_time,
       // Photo URL is forwarded as-is. Backend has already rewritten it
@@ -837,6 +847,7 @@ function OGSGroupPageContent() {
       // Pass token to skip redundant getSession() call (~600ms savings)
       const studentsResponse = await studentService.getStudents({
         groupId: selectedGroup.id,
+        includeArrivalTimes: true,
         token: session?.user?.token,
       });
       const studentsData = studentsResponse.students || [];
@@ -1284,13 +1295,15 @@ function OGSGroupPageContent() {
                   }
                   locationBadge={
                     <StudentPresenceBadge
-                      student={{
-                        ...student,
-                        not_arrival_today:
-                          (student.arrival_is_exception ?? false) &&
-                          !student.arrival_time,
-                        not_arrival_reason: student.arrival_notes ?? null,
-                      }}
+                      student={(() => {
+                        const badgePlanning =
+                          getStudentPresenceBadgePlanning(student);
+                        return {
+                          ...student,
+                          not_arrival_today: badgePlanning.notArrivalToday,
+                          not_arrival_reason: badgePlanning.notArrivalReason,
+                        };
+                      })()}
                       displayMode="roomName"
                       isGroupRoom={inGroupRoom}
                       variant="modern"
@@ -1302,33 +1315,53 @@ function OGSGroupPageContent() {
                       {studentAbsence && !student.actual_pickup_time ? (
                         <StudentAbsenceRow label={studentAbsence.label} />
                       ) : (
-                        <>
-                          <ArrivalTimeRow
-                            arrivalTime={student.arrival_time}
-                            actualTime={student.actual_arrival_time}
-                            isException={student.arrival_is_exception ?? false}
-                            isAbsent={
-                              (student.arrival_is_exception ?? false) &&
-                              !student.arrival_time
-                            }
-                            notes={student.arrival_notes}
-                            now={now}
-                          />
-                          <PickupTimeRow
-                            pickupTime={studentPickup?.pickupTime}
-                            actualTime={student.actual_pickup_time}
-                            isException={studentPickup?.isException ?? false}
-                            notes={
-                              studentPickup
-                                ? combineTimeNotes(
-                                    studentPickup.notes,
-                                    studentPickup.dayNotes,
-                                  )
-                                : undefined
-                            }
-                            now={now}
-                          />
-                        </>
+                        (() => {
+                          const dayPlanningNotComingLabel =
+                            getDayPlanningNotComingLabel(student);
+                          if (
+                            dayPlanningNotComingLabel &&
+                            !student.actual_pickup_time
+                          ) {
+                            return (
+                              <StudentAbsenceRow
+                                label={dayPlanningNotComingLabel}
+                              />
+                            );
+                          }
+                          return (
+                            <>
+                              <ArrivalTimeRow
+                                arrivalTime={student.arrival_time}
+                                actualTime={student.actual_arrival_time}
+                                isException={
+                                  student.arrival_is_exception ?? false
+                                }
+                                isAbsent={
+                                  (student.arrival_is_exception ?? false) &&
+                                  !student.arrival_time
+                                }
+                                notes={student.arrival_notes}
+                                now={now}
+                              />
+                              <PickupTimeRow
+                                pickupTime={studentPickup?.pickupTime}
+                                actualTime={student.actual_pickup_time}
+                                isException={
+                                  studentPickup?.isException ?? false
+                                }
+                                notes={
+                                  studentPickup
+                                    ? combineTimeNotes(
+                                        studentPickup.notes,
+                                        studentPickup.dayNotes,
+                                      )
+                                    : undefined
+                                }
+                                now={now}
+                              />
+                            </>
+                          );
+                        })()
                       )}
                       {/* Check-in-only avatar-clearance spacer — in navigation
                           mode this surface now opts into an in-flow bottom row

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -342,6 +342,7 @@ describe("StudentSearchPage", () => {
     mockSearchParams.delete("room_name");
     mockSearchParams.delete("pickup_time");
     mockSearchParams.delete("arrival_time");
+    mockSearchParams.delete("day_status");
     mockSearchParams.delete("tracking");
     mockSearchParams.delete("sort");
     mockSearchParams.delete("view");
@@ -399,6 +400,18 @@ describe("StudentSearchPage", () => {
       await waitFor(() => {
         const attendanceFilter = screen.getByTestId("filter-attendance");
         expect(attendanceFilter).toHaveValue("all");
+      });
+    });
+
+    it("reads day_status from URL params", async () => {
+      mockSearchParams.set("day_status", "comes_today");
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("filter-dayStatus")).toHaveValue(
+          "comes_today",
+        );
       });
     });
 
@@ -1206,6 +1219,7 @@ describe("StudentSearchPage", () => {
     });
 
     it("executes the students SWR fetcher", async () => {
+      mockSearchParams.set("day_status", "not_coming_today");
       const studentService = await import("~/lib/api");
       const mockGetStudents = vi.fn().mockResolvedValue({
         students: [{ id: "1", first_name: "Test", second_name: "Student" }],
@@ -1263,7 +1277,9 @@ describe("StudentSearchPage", () => {
       expect(result).toEqual({
         students: [{ id: "1", first_name: "Test", second_name: "Student" }],
       });
-      expect(mockGetStudents).toHaveBeenCalled();
+      expect(mockGetStudents).toHaveBeenCalledWith(
+        expect.objectContaining({ dayStatus: "not_coming_today" }),
+      );
     });
   });
 

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -62,6 +62,10 @@ import {
   getTimeStatusSortRank,
 } from "~/lib/student-time-status";
 import {
+  getDayPlanningNotComingLabel,
+  getStudentPresenceBadgePlanning,
+} from "~/lib/day-planning-helper";
+import {
   matchesTrackingFilter,
   parseTrackingFilter,
   resolveTrackingFilterAfterLabelChange,
@@ -80,6 +84,7 @@ type StatusFilter =
   | "schulhof"
   | "krank"
   | "entschuldigt";
+type DayStatusFilter = "all" | "comes_today" | "not_coming_today";
 type SortMode = "name" | "arrival" | "pickup";
 type GroupMode = "none" | "status" | "room" | "arrival" | "pickup";
 
@@ -91,6 +96,15 @@ const STATUS_FILTER_OPTIONS: Array<{ value: StatusFilter; label: string }> = [
   { value: "entschuldigt", label: "Entschuldigt" },
   { value: "unterwegs", label: "Unterwegs" },
   { value: "schulhof", label: "Schulhof" },
+];
+
+const DAY_STATUS_FILTER_OPTIONS: Array<{
+  value: DayStatusFilter;
+  label: string;
+}> = [
+  { value: "all", label: "Alle Kinder" },
+  { value: "comes_today", label: "Kommt heute" },
+  { value: "not_coming_today", label: "Kommt heute nicht" },
 ];
 
 const SORT_OPTIONS: Array<{ value: SortMode; label: string }> = [
@@ -114,6 +128,7 @@ const FILTER_QUERY_PARAMS = [
   "room_name",
   "pickup_time",
   "arrival_time",
+  "day_status",
   "status",
   "tracking",
   "sort",
@@ -209,6 +224,14 @@ function normalizeStoredFilters(
     room_name: params.get("room_id") ? (params.get("room_name") ?? "") : "",
     pickup_time: params.get("pickup_time") ?? "",
     arrival_time: params.get("arrival_time") ?? "",
+    day_status:
+      validQueryValue(
+        params.get("day_status"),
+        DAY_STATUS_FILTER_OPTIONS.map((option) => option.value),
+        "all",
+      ) === "all"
+        ? ""
+        : (params.get("day_status") ?? ""),
     status:
       validQueryValue(
         params.get("status"),
@@ -465,6 +488,11 @@ function SearchPageContent() {
     STATUS_FILTER_OPTIONS.map((option) => option.value),
     "all",
   );
+  const initialDayStatusFilter = validQueryValue(
+    initialFilterParams.get("day_status"),
+    DAY_STATUS_FILTER_OPTIONS.map((option) => option.value),
+    "all",
+  );
   const initialYear = validQueryValue(
     initialFilterParams.get("year"),
     SCHOOL_YEAR_DROPDOWN_OPTIONS.map((option) => option.value),
@@ -501,6 +529,9 @@ function SearchPageContent() {
   const [selectedYear, setSelectedYear] = useState<string>(initialYear);
   const [attendanceFilter, setAttendanceFilter] = useState<StatusFilter>(
     initialAttendanceFilter,
+  );
+  const [dayStatusFilter, setDayStatusFilter] = useState<DayStatusFilter>(
+    initialDayStatusFilter,
   );
   const [pickupTimeFilter, setPickupTimeFilter] = useState(
     initialFilterParams.get("pickup_time") ?? "all",
@@ -561,6 +592,13 @@ function SearchPageContent() {
       );
       setPickupTimeFilter(params.get("pickup_time") ?? "all");
       setArrivalTimeFilter(params.get("arrival_time") ?? "all");
+      setDayStatusFilter(
+        validQueryValue(
+          params.get("day_status"),
+          DAY_STATUS_FILTER_OPTIONS.map((option) => option.value),
+          "all",
+        ),
+      );
 
       const trackingParam = params.get("tracking") ?? "all";
       setTrackingFilter(
@@ -679,7 +717,7 @@ function SearchPageContent() {
 
   // Generate SWR cache key for students (changes when filters change → SWR auto-cancels old requests)
   // Note: User context is only for badge styling, not for fetching students
-  const studentsCacheKey = `search-students-${debouncedSearchTerm}-${selectedGroup}-${selectedRoomId}`;
+  const studentsCacheKey = `search-students-${debouncedSearchTerm}-${selectedGroup}-${selectedRoomId}-${dayStatusFilter}`;
 
   // Fetch students with SWR (automatic deduplication, cancellation, and revalidation)
   const {
@@ -693,6 +731,7 @@ function SearchPageContent() {
         search: debouncedSearchTerm,
         groupId: selectedGroup,
         roomId: selectedRoomId || undefined,
+        dayStatus: dayStatusFilter === "all" ? undefined : dayStatusFilter,
         // When filtering by room, this page is the "see all" target the
         // room-detail modal links to (#1374). The modal itself caps at
         // 200 cards and shows a truncation notice; this page must show
@@ -773,6 +812,14 @@ function SearchPageContent() {
     [updateUrlParams],
   );
 
+  const updateDayStatusFilter = useCallback(
+    (value: DayStatusFilter) => {
+      setDayStatusFilter(value);
+      updateUrlParams({ day_status: value === "all" ? "" : value });
+    },
+    [updateUrlParams],
+  );
+
   const updateTrackingFilter = useCallback(
     (value: TrackingFilter) => {
       setTrackingFilter(value);
@@ -804,6 +851,7 @@ function SearchPageContent() {
     setAttendanceFilter("all");
     setPickupTimeFilter("all");
     setArrivalTimeFilter("all");
+    setDayStatusFilter("all");
     setTrackingFilter("all");
     setSortMode("name");
     setGroupMode("none");
@@ -824,7 +872,7 @@ function SearchPageContent() {
   );
   const { data: trackingData } = useSWRAuth<TrackingIndicatorsResponse>(
     trackingStudentIds.length > 0
-      ? `tracking-indicators-${debouncedSearchTerm}-${selectedGroup}-${selectedRoomId}`
+      ? `tracking-indicators-${debouncedSearchTerm}-${selectedGroup}-${selectedRoomId}-${dayStatusFilter}`
       : null,
     async () => activeService.getTrackingIndicators(trackingStudentIds),
     { keepPreviousData: true, revalidateOnFocus: false },
@@ -985,6 +1033,14 @@ function SearchPageContent() {
         ],
       },
       {
+        id: "dayStatus",
+        label: "Tagesplanung",
+        type: "dropdown",
+        value: dayStatusFilter,
+        onChange: (value) => updateDayStatusFilter(value as DayStatusFilter),
+        options: DAY_STATUS_FILTER_OPTIONS,
+      },
+      {
         id: "attendance",
         label: "Status",
         type: "dropdown",
@@ -1043,6 +1099,7 @@ function SearchPageContent() {
       pickupTimeFilter,
       arrivalTimeFilter,
       attendanceFilter,
+      dayStatusFilter,
       trackingFilter,
       trackingLabels,
       groups,
@@ -1060,6 +1117,7 @@ function SearchPageContent() {
       updateAttendanceFilter,
       updatePickupTimeFilter,
       updateArrivalTimeFilter,
+      updateDayStatusFilter,
       updateTrackingFilter,
       updateSortMode,
       updateGroupMode,
@@ -1125,6 +1183,17 @@ function SearchPageContent() {
       });
     }
 
+    if (dayStatusFilter !== "all") {
+      filters.push({
+        id: "dayStatus",
+        label:
+          DAY_STATUS_FILTER_OPTIONS.find(
+            (option) => option.value === dayStatusFilter,
+          )?.label ?? dayStatusFilter,
+        onRemove: () => updateDayStatusFilter("all"),
+      });
+    }
+
     if (pickupTimeFilter !== "all") {
       filters.push({
         id: "pickupTime",
@@ -1185,6 +1254,7 @@ function SearchPageContent() {
     selectedYear,
     selectedGroup,
     attendanceFilter,
+    dayStatusFilter,
     pickupTimeFilter,
     arrivalTimeFilter,
     trackingFilter,
@@ -1198,6 +1268,7 @@ function SearchPageContent() {
     updateSelectedYear,
     updateSelectedGroup,
     updateAttendanceFilter,
+    updateDayStatusFilter,
     updatePickupTimeFilter,
     updateArrivalTimeFilter,
     updateTrackingFilter,
@@ -1211,6 +1282,7 @@ function SearchPageContent() {
       group_id: selectedGroup,
       year: selectedYear,
       status: attendanceFilter,
+      day_status: dayStatusFilter,
       pickup_time: pickupTimeFilter,
       arrival_time: arrivalTimeFilter,
       room_id: selectedRoomId,
@@ -1221,6 +1293,7 @@ function SearchPageContent() {
       selectedGroup,
       selectedYear,
       attendanceFilter,
+      dayStatusFilter,
       pickupTimeFilter,
       arrivalTimeFilter,
       selectedRoomId,
@@ -1248,6 +1321,13 @@ function SearchPageContent() {
       ) {
         return false;
       }
+    }
+
+    if (
+      dayStatusFilter !== "all" &&
+      student.day_planning_status !== dayStatusFilter
+    ) {
+      return false;
     }
 
     // Apply year filter - extract year from school_class (e.g., "Klasse 3a" → year 3)
@@ -1525,6 +1605,8 @@ function SearchPageContent() {
             if (selectedGroup) qs.set("group_id", selectedGroup);
             if (selectedYear !== "all") qs.set("year", selectedYear);
             if (attendanceFilter !== "all") qs.set("status", attendanceFilter);
+            if (dayStatusFilter !== "all")
+              qs.set("day_status", dayStatusFilter);
             if (pickupTimeFilter !== "all")
               qs.set("pickup_time", pickupTimeFilter);
             if (arrivalTimeFilter !== "all")
@@ -1556,13 +1638,15 @@ function SearchPageContent() {
                 }
                 locationBadge={
                   <StudentPresenceBadge
-                    student={{
-                      ...student,
-                      not_arrival_today:
-                        (student.arrival_is_exception ?? false) &&
-                        !student.arrival_time,
-                      not_arrival_reason: student.arrival_notes ?? null,
-                    }}
+                    student={(() => {
+                      const badgePlanning =
+                        getStudentPresenceBadgePlanning(student);
+                      return {
+                        ...student,
+                        not_arrival_today: badgePlanning.notArrivalToday,
+                        not_arrival_reason: badgePlanning.notArrivalReason,
+                      };
+                    })()}
                     displayMode="contextAware"
                     userGroups={myGroups}
                     groupRooms={myGroupRooms}
@@ -1589,6 +1673,18 @@ function SearchPageContent() {
                         });
                         if (absence && !student.actual_pickup_time) {
                           return <StudentAbsenceRow label={absence.label} />;
+                        }
+                        const dayPlanningNotComingLabel =
+                          getDayPlanningNotComingLabel(student);
+                        if (
+                          dayPlanningNotComingLabel &&
+                          !student.actual_pickup_time
+                        ) {
+                          return (
+                            <StudentAbsenceRow
+                              label={dayPlanningNotComingLabel}
+                            />
+                          );
                         }
                         return (
                           <>

--- a/frontend/src/app/api/ogs-dashboard/route.ts
+++ b/frontend/src/app/api/ogs-dashboard/route.ts
@@ -38,6 +38,9 @@ interface BackendStudent {
   arrival_time?: string;
   arrival_is_exception?: boolean;
   arrival_notes?: string;
+  day_planning_status?: "comes_today" | "not_coming_today";
+  day_planning_reason?: string;
+  day_planning_label?: string;
   actual_arrival_time?: string;
   actual_pickup_time?: string;
 }

--- a/frontend/src/app/api/students/route.ts
+++ b/frontend/src/app/api/students/route.ts
@@ -42,6 +42,9 @@ interface StudentResponseFromBackend {
   guardian_email?: string;
   guardian_phone?: string;
   group_id?: number;
+  day_planning_status?: "comes_today" | "not_coming_today";
+  day_planning_reason?: string;
+  day_planning_label?: string;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/components/students/student-detail-components.test.tsx
+++ b/frontend/src/components/students/student-detail-components.test.tsx
@@ -368,6 +368,25 @@ describe("StudentDetailHeader", () => {
       expect(screen.queryByTestId("today-time-row-pickup")).toBeNull();
     });
 
+    it("uses day planning status for the detail header absence row", () => {
+      renderHeaderWithTimes({
+        student: {
+          ...mockStudent,
+          current_location: "Zuhause",
+          day_planning_status: "not_coming_today",
+          day_planning_label: "kein Plan für heute",
+        },
+        todayArrivalPlannedTime: undefined,
+        todayPickupPlannedTime: undefined,
+      });
+
+      expect(screen.getByTestId("today-absence-row")).toHaveTextContent(
+        "Kommt heute nicht (kein Plan für heute)",
+      );
+      expect(screen.queryByTestId("today-time-row-arrival")).toBeNull();
+      expect(screen.queryByTestId("today-time-row-pickup")).toBeNull();
+    });
+
     it("renders the actual time even when no planned time was scheduled (walk-in)", () => {
       // Walk-in scenario: a student arrives without a planned arrival
       // configured. The row still renders the actual but suppresses the

--- a/frontend/src/components/students/student-detail-components.tsx
+++ b/frontend/src/components/students/student-detail-components.tsx
@@ -9,6 +9,10 @@ import {
   getStudentAbsence,
   getStudentTimeStatus,
 } from "~/lib/student-time-status";
+import {
+  getDayPlanningNotComingLabel,
+  getStudentPresenceBadgePlanning,
+} from "~/lib/day-planning-helper";
 import type { SupervisorContact } from "~/lib/student-helpers";
 import { InfoCard, InfoItem } from "~/components/ui/info-card";
 import { Avatar } from "~/components/ui/avatar";
@@ -316,10 +320,18 @@ export function StudentDetailHeader({
   // Spread the student so any field LocationBadge consumes (current_room_color,
   // future room-derived attributes, etc.) propagates without maintaining a
   // parallel whitelist here. Only the not_arrival_* fields are computed locally.
+  const badgePlanning = getStudentPresenceBadgePlanning({
+    ...student,
+    arrival_is_exception: isArrivalException,
+    arrival_time: todayArrivalPlannedTime,
+    arrival_notes: todayArrivalNote,
+  });
   const badgeStudent = {
     ...student,
-    not_arrival_today: isArrivalAbsent ?? false,
-    not_arrival_reason: todayArrivalNote ?? null,
+    not_arrival_today:
+      badgePlanning.notArrivalToday || (isArrivalAbsent ?? false),
+    not_arrival_reason:
+      badgePlanning.notArrivalReason ?? todayArrivalNote ?? null,
   };
 
   const fullName =
@@ -366,7 +378,11 @@ export function StudentDetailHeader({
                 sick: student.sick,
                 excused: student.excused,
               });
-              if (absence && !todayPickupActualTime) {
+              const dayPlanningNotComingLabel =
+                getDayPlanningNotComingLabel(student);
+              const notComingLabel =
+                absence?.label ?? dayPlanningNotComingLabel;
+              if (notComingLabel && !todayPickupActualTime) {
                 return (
                   <div
                     data-testid="today-absence-row"
@@ -374,7 +390,7 @@ export function StudentDetailHeader({
                   >
                     <ClockIcon className="h-4 w-4 text-gray-400" />
                     <span className="font-medium text-gray-900">
-                      {`Kommt heute nicht (${absence.label})`}
+                      {`Kommt heute nicht (${notComingLabel})`}
                     </span>
                   </div>
                 );

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -90,6 +90,7 @@ describe("api.ts helper functions", () => {
           inHouse: true,
           groupId: "123",
           locationState: "transit",
+          dayStatus: "comes_today",
           page: 2,
           pageSize: 25,
           token: "test-token",
@@ -101,6 +102,7 @@ describe("api.ts helper functions", () => {
         expect(callUrl).toContain("in_house=true");
         expect(callUrl).toContain("group_id=123");
         expect(callUrl).toContain("location_state=transit");
+        expect(callUrl).toContain("day_status=comes_today");
         expect(callUrl).toContain("page=2");
         expect(callUrl).toContain("page_size=25");
       } finally {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -184,6 +184,7 @@ function buildStudentQueryParams(filters?: {
   groupId?: string;
   roomId?: string;
   locationState?: "transit";
+  dayStatus?: "comes_today" | "not_coming_today";
   page?: number;
   pageSize?: number;
   includePickupTimes?: boolean;
@@ -200,6 +201,7 @@ function buildStudentQueryParams(filters?: {
   if (filters?.roomId) params.append("room_id", filters.roomId);
   if (filters?.locationState)
     params.append("location_state", filters.locationState);
+  if (filters?.dayStatus) params.append("day_status", filters.dayStatus);
   if (filters?.page) params.append("page", filters.page.toString());
   if (filters?.pageSize)
     params.append("page_size", filters.pageSize.toString());
@@ -780,6 +782,7 @@ export const studentService = {
     groupId?: string;
     roomId?: string;
     locationState?: "transit";
+    dayStatus?: "comes_today" | "not_coming_today";
     page?: number;
     pageSize?: number;
     includePickupTimes?: boolean;

--- a/frontend/src/lib/day-planning-helper.ts
+++ b/frontend/src/lib/day-planning-helper.ts
@@ -1,0 +1,47 @@
+type DayPlanningStatus = "comes_today" | "not_coming_today";
+
+export interface DayPlanningStudent {
+  day_planning_status?: DayPlanningStatus;
+  day_planning_label?: string;
+  arrival_is_exception?: boolean;
+  arrival_time?: string;
+  arrival_notes?: string;
+  actual_arrival_time?: string;
+  current_location?: string | null;
+}
+
+export function getDayPlanningNotComingLabel(
+  student: Pick<
+    DayPlanningStudent,
+    | "day_planning_status"
+    | "day_planning_label"
+    | "actual_arrival_time"
+    | "current_location"
+  >,
+): string | null {
+  if (hasActualAttendance(student)) return null;
+  if (student.day_planning_status !== "not_coming_today") return null;
+  return student.day_planning_label ?? "kein Plan für heute";
+}
+
+export function getStudentPresenceBadgePlanning(student: DayPlanningStudent): {
+  notArrivalToday: boolean;
+  notArrivalReason: string | null;
+} {
+  const dayPlanningLabel = getDayPlanningNotComingLabel(student);
+  const arrivalExceptionAbsent =
+    (student.arrival_is_exception ?? false) && !student.arrival_time;
+
+  return {
+    notArrivalToday: dayPlanningLabel !== null || arrivalExceptionAbsent,
+    notArrivalReason: dayPlanningLabel ?? student.arrival_notes ?? null,
+  };
+}
+
+function hasActualAttendance(
+  student: Pick<DayPlanningStudent, "actual_arrival_time" | "current_location">,
+): boolean {
+  if (student.actual_arrival_time) return true;
+  const location = student.current_location?.trim().toLowerCase();
+  return !!location && location !== "zuhause" && location !== "abwesend";
+}

--- a/frontend/src/lib/student-export-api.ts
+++ b/frontend/src/lib/student-export-api.ts
@@ -28,6 +28,7 @@ export interface StudentExportFilters {
   group_id?: string;
   year?: string;
   status?: string;
+  day_status?: string;
   pickup_time?: string;
   arrival_time?: string;
   sort?: string;

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -57,6 +57,9 @@ export interface BackendStudent {
   sick_since?: string;
   excused?: boolean;
   excused_since?: string;
+  day_planning_status?: "comes_today" | "not_coming_today";
+  day_planning_reason?: string;
+  day_planning_label?: string;
   guardian_name?: string; // Optional: Legacy field, use guardian_profiles instead
   guardian_contact?: string; // Optional: Legacy field, use guardian_profiles instead
   guardian_email?: string;
@@ -174,6 +177,9 @@ export interface Student {
   // Excused status (kind is not attending the OGS today, only visible to supervisors/admins)
   excused?: boolean;
   excused_since?: string;
+  day_planning_status?: "comes_today" | "not_coming_today";
+  day_planning_reason?: string;
+  day_planning_label?: string;
   name_lg?: string;
   contact_lg?: string;
   guardian_email?: string;
@@ -251,6 +257,9 @@ export function mapStudentResponse(
     sick_since: backendStudent.sick_since,
     excused: backendStudent.excused ?? false, // Excused from attending today
     excused_since: backendStudent.excused_since,
+    day_planning_status: backendStudent.day_planning_status,
+    day_planning_reason: backendStudent.day_planning_reason,
+    day_planning_label: backendStudent.day_planning_label,
     name_lg: backendStudent.guardian_name ?? undefined,
     contact_lg: backendStudent.guardian_contact ?? undefined,
     guardian_email: backendStudent.guardian_email,


### PR DESCRIPTION
## Summary

Adds the Go-Live heuristic for Issue #1448 so the student search, exports, detail header, OGS groups, and active supervision cards can distinguish `Kommt heute` from `Kommt heute nicht` without introducing a new weekly care-plan schema.

Closes #1448

## How It Works

The backend computes three derived student fields for full-access callers:

- `day_planning_status`: `comes_today` or `not_coming_today`
- `day_planning_reason`: machine-readable source such as `pickup_schedule`, `arrival_exception`, `timetable`, `unplanned_attendance`, `sick`, `excused`, or `no_plan`
- `day_planning_label`: German UI label such as `Abholplan heute`, `ungeplant anwesend`, `krank gemeldet`, or `kein Plan für heute`

`abwesend` stays separate from day planning. Day planning answers whether the child is expected or operationally relevant today. Attendance answers whether the child is currently there, checked out, sick, excused, etc.

## Decision Matrix

| Situation | Backend status | Reason | Main UI result | Notes |
|---|---|---|---|---|
| Arrival schedule for today has a time | `comes_today` | `arrival_schedule` | Shows as `Kommt heute` / planned | Existing arrival schedule is enough. |
| Arrival exception for today has a time | `comes_today` | `arrival_exception` | Shows as `Kommt heute` / planned | One-day override beats missing weekly time. |
| Pickup schedule for today has a time | `comes_today` | `pickup_schedule` | Shows as `Kommt heute` / planned | This covers children with pickup plan but no arrival plan. |
| Pickup exception for today has a time | `comes_today` | `pickup_exception` | Shows as `Kommt heute` / planned | One-day pickup override counts as today plan. |
| Child is on a timetable/activity instance today | `comes_today` | `timetable` | Shows as `Kommt heute` / planned | An `absent` status on one activity does not mean whole-day not coming. |
| No plan, but child has checked in / is currently present today | `comes_today` | `unplanned_attendance` | Treated like present/expected in prominent UI, with less prominent `ungeplant anwesend` info | This preserves the fact that the child was not planned while avoiding a wrong `Kommt heute nicht` badge. |
| Sick today | `not_coming_today` | `sick` | Shows `Kommt heute nicht` with sick label | Sick is a whole-day non-coming signal. |
| Excused today | `not_coming_today` | `excused` | Shows `Kommt heute nicht` with excused label | Excused is a whole-day non-coming signal. |
| Explicit arrival exception says no arrival time today | `not_coming_today` | `no_arrival` | Shows `Kommt heute nicht` | Explicit no-time exception means not planned to arrive. |
| Explicit pickup exception says no pickup time today | `not_coming_today` | `no_pickup` | Shows `Kommt heute nicht` | Explicit no-time exception means not planned for pickup. |
| No arrival, pickup, timetable, exception, or attendance today | `not_coming_today` | `no_plan` | Shows `Kommt heute nicht`, label `kein Plan für heute` | This is the default no-plan case. |

## UI Impact

- Kindersuche gets a `Tagesplanung` filter with `Alle Kinder`, `Kommt heute`, and `Kommt heute nicht`.
- The default remains `Alle Kinder`, so admins can still see the full list.
- Student cards, the detail header, OGS groups, and active supervision cards reuse the same day-planning badge mapping instead of each surface deriving its own `Kommt heute nicht` state.
- The frontend does not render the prominent `Kommt heute nicht` state when actual arrival/current location shows the child is already there.
- OGS groups forward the new `day_planning_*` fields through their local mapper and BFF type so the initial dashboard load and group switching behave consistently.
- Student exports accept and display the same day-planning filter.

## Validation

- `cd frontend && pnpm test -- src/lib/api.test.ts 'src/app/[tenant]/(protected)/students/search/page.test.tsx' --runInBand`
- `cd frontend && pnpm test -- src/components/students/student-detail-components.test.tsx 'src/app/[tenant]/(protected)/ogs-groups/page.test.tsx' --runInBand`
- `cd frontend && pnpm exec tsc --noEmit`
- `cd frontend && pnpm run check`
- `cd backend && go test ./api/students -run 'TestListStudents_DayPlanningStatus|TestListStudents_WithArrivalTimes|TestListStudents_WithPickupTimes'`
- `cd backend && go test ./api/timetable ./api/students`
- `cd backend && go test ./test/ -run TestHermeticTestPatterns -v`
- Pre-push hook: `git-secrets`, `go-vet`, `frontend-knip`, `go-deadcode`, `golangci-lint`, `frontend-check`
