### PR TITLE
Fix materialization duplicate transaction abort

### DIFF
--- a/backend/database/repositories/schedule/activity_instance_repo.go
+++ b/backend/database/repositories/schedule/activity_instance_repo.go
@@ -49,6 +49,49 @@ func (r *ActivityInstanceRepository) Create(ctx context.Context, i *schedule.Act
 	return r.Repository.Create(ctx, i)
 }
 
+// CreateTemplateBackedIfAbsent inserts a template-backed activity instance,
+// absorbing the duplicate-template-slot race at the database layer. Catching a
+// 23505 after a plain INSERT would leave the surrounding PostgreSQL
+// transaction aborted, so materialization must use ON CONFLICT DO NOTHING.
+func (r *ActivityInstanceRepository) CreateTemplateBackedIfAbsent(ctx context.Context, i *schedule.ActivityInstance) (bool, error) {
+	if i == nil {
+		return false, errActivityInstanceNil
+	}
+	if i.ActivityGroupID == nil {
+		return false, fmt.Errorf("activity_group_id is required for template-backed insert")
+	}
+	if err := i.Validate(); err != nil {
+		return false, err
+	}
+
+	if i.GetTenantID() == 0 {
+		if tid := tenant.FromContext(ctx); tid != 0 {
+			i.SetTenantID(tid)
+		}
+	}
+
+	res, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(i).
+		ModelTableExpr(tableActivityInstances).
+		On("CONFLICT (tenant_id, date, activity_group_id, start_time) WHERE activity_group_id IS NOT NULL DO NOTHING").
+		Exec(ctx)
+	if err != nil {
+		return false, &modelBase.DatabaseError{
+			Op:  "create template-backed if absent",
+			Err: err,
+		}
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, &modelBase.DatabaseError{
+			Op:  "create template-backed if absent rows affected",
+			Err: err,
+		}
+	}
+	return affected > 0, nil
+}
+
 // Update writes the given activity instance back to the database.
 func (r *ActivityInstanceRepository) Update(ctx context.Context, i *schedule.ActivityInstance) error {
 	if i == nil {

--- a/backend/database/repositories/schedule/activity_instance_repo_test.go
+++ b/backend/database/repositories/schedule/activity_instance_repo_test.go
@@ -1,12 +1,14 @@
 package schedule_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -152,6 +154,95 @@ func TestActivityInstanceRepository_Create(t *testing.T) {
 		b := buildInstance(1, fx.roomID, &fx.activityID, date, start, end, "Lernzeit B")
 		err := repo.Create(ctx, b)
 		require.Error(t, err, "partial UNIQUE must block same (tenant,date,group,start)")
+	})
+}
+
+func TestActivityInstanceRepository_CreateTemplateBackedIfAbsent_DuplicateDoesNotAbortTransaction(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repo := scheduleRepo.NewActivityInstanceRepository(db)
+	fx := newActivityInstanceFixtures(t, db, "create-if-absent")
+	defer fx.cleanup()
+
+	date := time.Date(2026, 9, 21, 0, 0, 0, 0, time.UTC)
+	start := time.Date(2024, 1, 1, 14, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 1, 15, 0, 0, 0, time.UTC)
+	var createdIDs []int64
+
+	err := tenant.WithTenantTx(ctx, db, 1, func(ctx context.Context, _ bun.Tx) error {
+		first := buildInstance(0, fx.roomID, &fx.activityID, date, start, end, "Lernzeit A")
+		inserted, err := repo.CreateTemplateBackedIfAbsent(ctx, first)
+		require.NoError(t, err)
+		require.True(t, inserted)
+		require.Greater(t, first.ID, int64(0), "inserted instance must keep its generated ID for materialization children")
+
+		duplicate := buildInstance(0, fx.roomID, &fx.activityID, date, start, end, "Lernzeit B")
+		inserted, err = repo.CreateTemplateBackedIfAbsent(ctx, duplicate)
+		require.NoError(t, err)
+		require.False(t, inserted)
+
+		rows, err := repo.FindByActivityGroupAndDate(ctx, fx.activityID, date)
+		require.NoError(t, err, "duplicate DO NOTHING must leave the transaction usable")
+		require.Len(t, rows, 1)
+		createdIDs = append(createdIDs, rows[0].ID)
+		return nil
+	})
+	require.NoError(t, err)
+	defer testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", createdIDs...)
+}
+
+func TestActivityInstanceRepository_CreateTemplateBackedIfAbsent_ValidationBranches(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repo := scheduleRepo.NewActivityInstanceRepository(db)
+	fx := newActivityInstanceFixtures(t, db, "create-if-absent-invalid")
+	defer fx.cleanup()
+
+	date := time.Date(2026, 9, 22, 0, 0, 0, 0, time.UTC)
+	start := time.Date(2024, 1, 1, 14, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 1, 15, 0, 0, 0, time.UTC)
+
+	t.Run("rejects nil", func(t *testing.T) {
+		inserted, err := repo.CreateTemplateBackedIfAbsent(ctx, nil)
+		require.Error(t, err)
+		assert.False(t, inserted)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+
+	t.Run("rejects spontaneous row", func(t *testing.T) {
+		inst := buildInstance(1, fx.roomID, nil, date, start, end, "Spontan")
+
+		inserted, err := repo.CreateTemplateBackedIfAbsent(ctx, inst)
+		require.Error(t, err)
+		assert.False(t, inserted)
+		assert.Contains(t, err.Error(), "activity_group_id is required")
+	})
+
+	t.Run("rejects model validation failure", func(t *testing.T) {
+		inst := buildInstance(
+			1, fx.roomID, &fx.activityID, date,
+			start, time.Date(2024, 1, 1, 13, 0, 0, 0, time.UTC),
+			"Broken",
+		)
+
+		inserted, err := repo.CreateTemplateBackedIfAbsent(ctx, inst)
+		require.Error(t, err)
+		assert.False(t, inserted)
+		assert.Contains(t, err.Error(), "end_time must be after start_time")
+	})
+
+	t.Run("wraps database insert failure", func(t *testing.T) {
+		missingRoomID := int64(987654321)
+		inst := buildInstance(1, missingRoomID, &fx.activityID, date, start, end, "Missing Room")
+
+		inserted, err := repo.CreateTemplateBackedIfAbsent(ctx, inst)
+		require.Error(t, err)
+		assert.False(t, inserted)
+		assert.Contains(t, err.Error(), "create template-backed if absent")
 	})
 }
 

--- a/backend/models/schedule/activity_instance.go
+++ b/backend/models/schedule/activity_instance.go
@@ -134,6 +134,10 @@ func (i *ActivityInstance) IsLive() bool {
 type ActivityInstanceRepository interface {
 	base.Repository[*ActivityInstance]
 
+	// CreateTemplateBackedIfAbsent inserts a template-backed instance and
+	// returns inserted=false when the unique template slot already exists.
+	CreateTemplateBackedIfAbsent(ctx context.Context, instance *ActivityInstance) (inserted bool, err error)
+
 	// FindByTenantAndDate returns all instances for the current tenant on the given date.
 	FindByTenantAndDate(ctx context.Context, date time.Time) ([]*ActivityInstance, error)
 

--- a/backend/services/schedule/attendance_sync_service_unit_test.go
+++ b/backend/services/schedule/attendance_sync_service_unit_test.go
@@ -53,6 +53,10 @@ func (f *fakeInstanceRepo) Create(context.Context, *scheduleModel.ActivityInstan
 	panic("unused")
 }
 
+func (f *fakeInstanceRepo) CreateTemplateBackedIfAbsent(context.Context, *scheduleModel.ActivityInstance) (bool, error) {
+	panic("unused")
+}
+
 func (f *fakeInstanceRepo) FindByID(context.Context, interface{}) (*scheduleModel.ActivityInstance, error) {
 	panic("unused")
 }

--- a/backend/services/schedule/materialization_service.go
+++ b/backend/services/schedule/materialization_service.go
@@ -28,8 +28,8 @@
 //     aborts the tenant's run; the scheduler will retry on the next matching
 //     weekday.
 //
-//   - UniqueViolation on Create is absorbed (race with a concurrent run) and
-//     counted as raced, not fatal.
+//   - Duplicate template-slot races are absorbed via INSERT ... ON CONFLICT DO
+//     NOTHING and counted as raced, not fatal.
 package schedule
 
 import (
@@ -40,14 +40,11 @@ import (
 	"sort"
 	"time"
 
-	modelBase "github.com/moto-nrw/project-phoenix/models/base"
-
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
-	"github.com/uptrace/bun/driver/pgdriver"
 )
 
 // MaxMaterializationWindowDays caps how many civil days a single call may
@@ -424,20 +421,21 @@ func (s *materializationService) materializeTemplate(
 				IsSpontaneous:    false,
 			}
 
-			if err := s.instanceRepo.Create(ctx, instance); err != nil {
-				if isUniqueViolation(err) {
-					result.CandidatesRaced++
-					s.getLogger().Warn("materialization race: instance already present",
-						slog.Int64("template_id", tmpl.ID),
-						slog.String("date", date.Format("2006-01-02")),
-						slog.String("start_time", effective.StartTime.Format("15:04:05")),
-					)
-					// Mark it in the index so a second schedule row on the same
-					// (date, start_time) doesn't race again.
-					existingIdx[key] = struct{}{}
-					continue
-				}
+			inserted, err := s.instanceRepo.CreateTemplateBackedIfAbsent(ctx, instance)
+			if err != nil {
 				return &ScheduleError{Op: "materialize template: create instance", Err: err}
+			}
+			if !inserted {
+				result.CandidatesRaced++
+				s.getLogger().Warn("materialization race: instance already present",
+					slog.Int64("template_id", tmpl.ID),
+					slog.String("date", date.Format("2006-01-02")),
+					slog.String("start_time", effective.StartTime.Format("15:04:05")),
+				)
+				// Mark it in the index so a second schedule row on the same
+				// (date, start_time) doesn't race again.
+				existingIdx[key] = struct{}{}
+				continue
 			}
 			existingIdx[key] = struct{}{}
 			result.InstancesCreated++
@@ -818,22 +816,4 @@ func formatTimeOfDay(t time.Time) string {
 // full rationale on why TIMESTAMPTZ → TIME round-trips need this.
 func extractTimeOfDay(t time.Time) time.Time {
 	return timezone.WallClock(t)
-}
-
-// isUniqueViolation returns true when err (or a wrapped modelBase.DatabaseError)
-// carries PostgreSQL error code 23505. Mirrors services/platform/db_helpers.go
-// without cross-package-importing it (keeps the dependency graph acyclic).
-func isUniqueViolation(err error) bool {
-	if err == nil {
-		return false
-	}
-	var dbErr *modelBase.DatabaseError
-	if errors.As(err, &dbErr) {
-		err = dbErr.Err
-	}
-	var pgErr pgdriver.Error
-	if errors.As(err, &pgErr) {
-		return pgErr.IntegrityViolation() && pgErr.Field('C') == "23505"
-	}
-	return false
 }

--- a/backend/services/schedule/materialization_service_test.go
+++ b/backend/services/schedule/materialization_service_test.go
@@ -1,13 +1,16 @@
 package schedule
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/models/activities"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -421,20 +424,208 @@ func TestIsoWeekday(t *testing.T) {
 	assert.Equal(t, 7, isoWeekday(mon.AddDate(0, 0, 6)))
 }
 
-// -----------------------------------------------------------------------------
-// TestIsUniqueViolation — asserts the race-branch classifier matches real
-// PostgreSQL 23505 errors (wrapped or unwrapped) and rejects everything else.
-// Exercised as a unit test because simulating a real concurrent-insert race
-// end-to-end would require contrived synchronisation the real scheduler never
-// depends on.
-// -----------------------------------------------------------------------------
+type materializationFakeGroupRepo struct {
+	activities.GroupRepository
+	templates []*activities.Group
+}
 
-func TestIsUniqueViolation(t *testing.T) {
-	modelBase := errors.New("unrelated error")
-	assert.False(t, isUniqueViolation(nil))
-	assert.False(t, isUniqueViolation(modelBase))
-	assert.False(t, isUniqueViolation(errors.New("not a unique violation")))
-	// pgdriver.Error is unexported in many of its constructors, so we
-	// assert the nil + generic paths here and rely on the isUniqueViolation
-	// in services/platform (same helper) which has pg-driver coverage.
+func (r materializationFakeGroupRepo) FindAllTemplates(context.Context) ([]*activities.Group, error) {
+	return r.templates, nil
+}
+
+type materializationFakeScheduleRepo struct {
+	activities.ScheduleRepository
+	schedules []*activities.Schedule
+}
+
+func (r materializationFakeScheduleRepo) FindByGroupID(context.Context, int64) ([]*activities.Schedule, error) {
+	return r.schedules, nil
+}
+
+type materializationFakeEnrollmentRepo struct {
+	activities.StudentEnrollmentRepository
+}
+
+func (r materializationFakeEnrollmentRepo) FindByGroupID(context.Context, int64) ([]*activities.StudentEnrollment, error) {
+	return nil, nil
+}
+
+type materializationFakeSupervisorRepo struct {
+	activities.SupervisorPlannedRepository
+}
+
+func (r materializationFakeSupervisorRepo) FindByGroupID(context.Context, int64) ([]*activities.SupervisorPlanned, error) {
+	return nil, nil
+}
+
+type materializationFakePeriodRepo struct {
+	schedule.CalendarPeriodRepository
+	periods []*schedule.CalendarPeriod
+}
+
+func (r materializationFakePeriodRepo) FindActiveByTenantID(context.Context) ([]*schedule.CalendarPeriod, error) {
+	return r.periods, nil
+}
+
+type materializationFakeInstanceRepo struct {
+	schedule.ActivityInstanceRepository
+	inserted bool
+	err      error
+}
+
+func (r materializationFakeInstanceRepo) FindByTenantAndDateRange(context.Context, time.Time, time.Time) ([]*schedule.ActivityInstance, error) {
+	return nil, nil
+}
+
+func (r materializationFakeInstanceRepo) CreateTemplateBackedIfAbsent(context.Context, *schedule.ActivityInstance) (bool, error) {
+	return r.inserted, r.err
+}
+
+type materializationFakeStaffRepo struct {
+	schedule.InstanceStaffRepository
+}
+
+func (r materializationFakeStaffRepo) Create(context.Context, *schedule.InstanceStaff) error {
+	panic("staff copy must not run when instance insert loses the race")
+}
+
+type materializationFakeStudentRepo struct {
+	schedule.InstanceStudentRepository
+}
+
+func (r materializationFakeStudentRepo) Create(context.Context, *schedule.InstanceStudent) error {
+	panic("student copy must not run when instance insert loses the race")
+}
+
+type materializationFakeExceptionRepo struct {
+	schedule.ActivityExceptionRepository
+}
+
+func (r materializationFakeExceptionRepo) FindByDateRange(context.Context, time.Time, time.Time) ([]*schedule.ActivityException, error) {
+	return nil, nil
+}
+
+type materializationFakeTimeframeRepo struct {
+	schedule.TimeframeRepository
+	timeframes []*schedule.Timeframe
+}
+
+func (r materializationFakeTimeframeRepo) List(context.Context, *modelBase.QueryOptions) ([]*schedule.Timeframe, error) {
+	return r.timeframes, nil
+}
+
+type materializationAllowCalendarService struct{}
+
+func (materializationAllowCalendarService) GetAllPeriods(context.Context) ([]*schedule.CalendarPeriod, error) {
+	panic("unused")
+}
+
+func (materializationAllowCalendarService) GetActivePeriods(context.Context) ([]*schedule.CalendarPeriod, error) {
+	panic("unused")
+}
+
+func (materializationAllowCalendarService) GetPeriodByID(context.Context, int64) (*schedule.CalendarPeriod, error) {
+	panic("unused")
+}
+
+func (materializationAllowCalendarService) CreatePeriod(context.Context, *schedule.CalendarPeriod) error {
+	panic("unused")
+}
+
+func (materializationAllowCalendarService) UpdatePeriod(context.Context, *schedule.CalendarPeriod) error {
+	panic("unused")
+}
+
+func (materializationAllowCalendarService) DeletePeriod(context.Context, int64) error {
+	panic("unused")
+}
+
+func (materializationAllowCalendarService) ShouldMaterialize(int, time.Time, *schedule.CalendarPeriod) bool {
+	return true
+}
+
+func TestMaterializeForTenant_DuplicateInsertRaceDoesNotCopyChildren(t *testing.T) {
+	svc, date := newMaterializationBranchService(materializationFakeInstanceRepo{inserted: false})
+
+	result, err := svc.MaterializeForTenant(
+		tenant.WithTenantID(context.Background(), 300),
+		date,
+		date,
+		MaterializationSourceManual,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Zero(t, result.InstancesCreated)
+	assert.Equal(t, 1, result.CandidatesRaced)
+	assert.Zero(t, result.InstanceStudentsCreated)
+	assert.Zero(t, result.InstanceStaffCreated)
+}
+
+func TestMaterializeForTenant_TemplateInsertErrorBubbles(t *testing.T) {
+	svc, date := newMaterializationBranchService(materializationFakeInstanceRepo{
+		inserted: false,
+		err:      errors.New("database unavailable"),
+	})
+
+	result, err := svc.MaterializeForTenant(
+		tenant.WithTenantID(context.Background(), 300),
+		date,
+		date,
+		MaterializationSourceManual,
+	)
+
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, err.Error(), "materialize template: create instance")
+	assert.Zero(t, result.InstancesCreated)
+	assert.Zero(t, result.CandidatesRaced)
+}
+
+func newMaterializationBranchService(instanceRepo materializationFakeInstanceRepo) (MaterializationService, time.Time) {
+	date := time.Date(2026, time.April, 20, 0, 0, 0, 0, time.UTC)
+	start := time.Date(2024, time.January, 1, 14, 0, 0, 0, time.UTC)
+	end := time.Date(2024, time.January, 1, 15, 0, 0, 0, time.UTC)
+	roomID := int64(700)
+	templateID := int64(500)
+	timeframeID := int64(600)
+
+	svc := NewMaterializationService(
+		materializationFakeGroupRepo{templates: []*activities.Group{{
+			Name:          "Lernzeit",
+			PlannedRoomID: &roomID,
+			IsTemplate:    true,
+			Model:         modelBase.Model{ID: templateID},
+		}}},
+		materializationFakeScheduleRepo{schedules: []*activities.Schedule{{
+			ActivityGroupID: templateID,
+			Weekday:         activities.WeekdayMonday,
+			TimeframeID:     &timeframeID,
+		}}},
+		materializationFakeEnrollmentRepo{},
+		materializationFakeSupervisorRepo{},
+		materializationFakePeriodRepo{periods: []*schedule.CalendarPeriod{{
+			Name:            "Schuljahr",
+			PeriodType:      schedule.PeriodTypeSchoolYear,
+			StartDate:       date.AddDate(0, -1, 0),
+			EndDate:         date.AddDate(0, 1, 0),
+			WeekCycleLength: 1,
+			IsActive:        true,
+			Model:           modelBase.Model{ID: 400},
+		}}},
+		instanceRepo,
+		materializationFakeStaffRepo{},
+		materializationFakeStudentRepo{},
+		materializationFakeExceptionRepo{},
+		materializationFakeTimeframeRepo{timeframes: []*schedule.Timeframe{{
+			StartTime: start,
+			EndTime:   &end,
+			Model:     modelBase.Model{ID: timeframeID},
+		}}},
+		materializationAllowCalendarService{},
+		nil,
+		slog.Default(),
+	)
+
+	return svc, date
 }

--- a/backend/services/scheduler/setters_test.go
+++ b/backend/services/scheduler/setters_test.go
@@ -154,6 +154,9 @@ type fakeInstanceRepo struct {
 func (f *fakeInstanceRepo) Create(_ context.Context, _ *scheduleModel.ActivityInstance) error {
 	return nil
 }
+func (f *fakeInstanceRepo) CreateTemplateBackedIfAbsent(_ context.Context, _ *scheduleModel.ActivityInstance) (bool, error) {
+	return false, nil
+}
 func (f *fakeInstanceRepo) FindByID(_ context.Context, _ any) (*scheduleModel.ActivityInstance, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary
- Fix timetable materialization duplicate-template races without aborting the surrounding PostgreSQL transaction.
- Add an idempotent template-backed activity instance insert path using `ON CONFLICT DO NOTHING`.
- Keep duplicate materialization races counted as `CandidatesRaced` while allowing the transaction to continue cleanly.

## Root Cause
The materializer caught unique-constraint errors from plain `INSERT` statements and continued inside the same transaction. In PostgreSQL, a failed statement marks the transaction aborted, so the next query failed with `SQLSTATE=25P02` (`current transaction is aborted`).

## Validation
- `go test ./services/schedule ./database/repositories/schedule ./services/scheduler -count=1`
- `go test ./test/ -run TestHermeticTestPatterns -v -count=1`
- Pre-push hooks passed: `git-secrets`, `go-vet`, `go-deadcode`, `golangci-lint`

## Note
A full `go test ./...` was attempted locally but the test DB appears stale/unrelated to this change: many packages fail because `auth.accounts.mfa_attempts` is missing, with additional unrelated fixture failures.
