### PR TITLE
feat: add guardians during student creation (#1500)

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -360,6 +360,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	})
 	api.Students = studentsAPI.NewResource(studentsAPI.ResourceConfig{
 		PersonService:          api.Services.Users,
+		GuardianService:        api.Services.Guardian,
 		StudentRepo:            repoFactory.Student,
 		EducationService:       api.Services.Education,
 		UserContextService:     api.Services.UserContext,

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -47,6 +47,7 @@ func renderError(w http.ResponseWriter, r *http.Request, errorResponse render.Re
 // Resource defines the students API resource
 type Resource struct {
 	PersonService          userService.PersonService
+	GuardianService        userService.GuardianService
 	StudentRepo            users.StudentRepository
 	EducationService       educationService.Service
 	UserContextService     userContextService.UserContextService
@@ -76,6 +77,7 @@ type Resource struct {
 // Using a config struct instead of individual parameters improves maintainability.
 type ResourceConfig struct {
 	PersonService          userService.PersonService
+	GuardianService        userService.GuardianService
 	StudentRepo            users.StudentRepository
 	EducationService       educationService.Service
 	UserContextService     userContextService.UserContextService
@@ -110,6 +112,7 @@ func NewResource(cfg ResourceConfig) *Resource {
 
 	return &Resource{
 		PersonService:          cfg.PersonService,
+		GuardianService:        cfg.GuardianService,
 		StudentRepo:            cfg.StudentRepo,
 		EducationService:       cfg.EducationService,
 		UserContextService:     cfg.UserContextService,
@@ -739,6 +742,71 @@ func createStudentFromRequest(req *StudentRequest, personID int64) *users.Studen
 	return student
 }
 
+// optionalString returns a pointer to the trimmed string, or nil when empty,
+// so optional JSON fields map cleanly onto nullable model columns.
+func optionalString(s string) *string {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+// toNewStudentGuardians maps the request guardian DTOs onto the service input
+// used by GuardianService.AddGuardiansToStudent.
+func toNewStudentGuardians(inputs []GuardianInput) []userService.NewStudentGuardian {
+	if len(inputs) == 0 {
+		return nil
+	}
+
+	out := make([]userService.NewStudentGuardian, 0, len(inputs))
+	for i := range inputs {
+		in := inputs[i]
+		out = append(out, userService.NewStudentGuardian{
+			Profile: userService.GuardianCreateRequest{
+				FirstName:              strings.TrimSpace(in.FirstName),
+				LastName:               strings.TrimSpace(in.LastName),
+				Email:                  optionalString(in.Email),
+				AddressStreet:          optionalString(in.AddressStreet),
+				AddressCity:            optionalString(in.AddressCity),
+				AddressPostalCode:      optionalString(in.AddressPostalCode),
+				PreferredContactMethod: in.PreferredContactMethod,
+				LanguagePreference:     in.LanguagePreference,
+				Notes:                  optionalString(in.Notes),
+			},
+			Relationship: userService.StudentGuardianRelationship{
+				RelationshipType:   in.RelationshipType,
+				IsPrimary:          in.IsPrimary,
+				IsEmergencyContact: in.IsEmergencyContact,
+				CanPickup:          in.CanPickup,
+				PickupNotes:        optionalString(in.PickupNotes),
+				EmergencyPriority:  in.EmergencyPriority,
+			},
+			PhoneNumbers: toPhoneRequests(in.PhoneNumbers),
+		})
+	}
+	return out
+}
+
+// toPhoneRequests maps phone DTOs onto the service phone-number requests.
+func toPhoneRequests(phones []GuardianPhoneInput) []userService.PhoneNumberCreateRequest {
+	if len(phones) == 0 {
+		return nil
+	}
+
+	out := make([]userService.PhoneNumberCreateRequest, 0, len(phones))
+	for i := range phones {
+		p := phones[i]
+		out = append(out, userService.PhoneNumberCreateRequest{
+			PhoneNumber: strings.TrimSpace(p.PhoneNumber),
+			PhoneType:   p.PhoneType,
+			Label:       optionalString(p.Label),
+			IsPrimary:   p.IsPrimary,
+		})
+	}
+	return out
+}
+
 // createStudent handles creating a new student with their person record
 func (rs *Resource) createStudent(w http.ResponseWriter, r *http.Request) {
 	// Parse request
@@ -771,8 +839,24 @@ func (rs *Resource) createStudent(w http.ResponseWriter, r *http.Request) {
 			rs.cleanupPersonAfterStudentFailure(ctx, person.ID)
 			return err
 		}
+
+		// Create any guardians supplied with the request inside the same
+		// transaction so the student and its guardians are persisted
+		// atomically — a guardian failure rolls back the whole student.
+		if len(req.Guardians) > 0 {
+			if err := rs.GuardianService.AddGuardiansToStudent(ctx, student.ID, toNewStudentGuardians(req.Guardians)); err != nil {
+				return err
+			}
+		}
 		return nil
 	}); err != nil {
+		// Bad guardian input (e.g. invalid email) is a client error: the
+		// transaction has already rolled back, so no partial data survives.
+		var validationErr *userService.ValidationError
+		if errors.As(err, &validationErr) {
+			renderError(w, r, ErrorInvalidRequest(validationErr))
+			return
+		}
 		renderError(w, r, ErrorInternalServer(err))
 		return
 	}

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -826,8 +826,21 @@ func (rs *Resource) createStudent(w http.ResponseWriter, r *http.Request) {
 	// Create person and student in tenant transaction
 	student := createStudentFromRequest(req, 0) // personID set after create
 
+	guardians := toNewStudentGuardians(req.Guardians)
+
 	tenantID := tenant.FromContext(r.Context())
 	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		// Validate guardians BEFORE writing the student. This route runs inside
+		// TenantTxMiddleware, which only rolls back on 5xx; a guardian
+		// ValidationError renders 400, so the middleware would otherwise commit
+		// an already-created student. Validating first means a 400 commits an
+		// empty transaction — no orphaned student/person rows.
+		if len(guardians) > 0 {
+			if err := rs.GuardianService.ValidateNewGuardians(ctx, guardians); err != nil {
+				return err
+			}
+		}
+
 		// Create person - validation occurs at the model layer
 		if err := rs.PersonService.Create(ctx, person); err != nil {
 			return err
@@ -843,8 +856,8 @@ func (rs *Resource) createStudent(w http.ResponseWriter, r *http.Request) {
 		// Create any guardians supplied with the request inside the same
 		// transaction so the student and its guardians are persisted
 		// atomically — a guardian failure rolls back the whole student.
-		if len(req.Guardians) > 0 {
-			if err := rs.GuardianService.AddGuardiansToStudent(ctx, student.ID, toNewStudentGuardians(req.Guardians)); err != nil {
+		if len(guardians) > 0 {
+			if err := rs.GuardianService.AddGuardiansToStudent(ctx, student.ID, guardians); err != nil {
 				return err
 			}
 		}

--- a/backend/api/students/create_student_guardians_middleware_test.go
+++ b/backend/api/students/create_student_guardians_middleware_test.go
@@ -1,0 +1,303 @@
+package students_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+// setupRouterUnderTenantTx mounts the create-student handler behind the REAL
+// TenantTxMiddleware, reproducing the production request pipeline. This matters:
+// the bare setupRouter() lets the handler's inner WithTenantTx open its own
+// outermost transaction, which rolls back cleanly on any returned error. In
+// production the route is wrapped by TenantTxMiddleware, so the inner
+// WithTenantTx merely REUSES the outer transaction and the rollback decision is
+// deferred to the middleware — which only rolls back on 5xx and COMMITS on a
+// 400. A guardian ValidationError surfaced as a 400 would therefore commit an
+// already-written student unless validation happens before the first write.
+// These tests guard exactly that pipeline behavior.
+func emailPtr(s string) *string { return &s }
+
+func setupRouterUnderTenantTx(tc *testContext, handler http.HandlerFunc) chi.Router {
+	router := chi.NewRouter()
+	router.Use(render.SetContentType(render.ContentTypeJSON))
+	router.With(tenant.TenantTxMiddleware(tc.db)).Post("/", handler)
+	return router
+}
+
+// assertNoStudentCommittedUnderTenantTx posts a create-student body that must
+// fail guardian validation through the real TenantTxMiddleware, asserts a 400
+// carrying the given German fragment, and proves the middleware did NOT commit
+// an orphaned person/student. Without the pre-write validation fix, the student
+// rows would commit despite the 400 and this assertion would fail.
+func assertNoStudentCommittedUnderTenantTx(
+	t *testing.T,
+	tc *testContext,
+	firstName, lastName string,
+	body map[string]interface{},
+	wantBodyContains string,
+) {
+	t.Helper()
+
+	router := setupRouterUnderTenantTx(tc, tc.resource.CreateStudentHandler())
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code,
+		"invalid guardian input must return 400 (not 500). Body: %s", rr.Body.String())
+	assert.Contains(t, rr.Body.String(), wantBodyContains,
+		"400 body should name the offending field, not a generic server error")
+
+	ctx := context.Background()
+	defer cleanupOrphanByName(t, tc, firstName, lastName)
+
+	personCount, err := tc.db.NewSelect().
+		Table("users.persons").
+		Where("first_name = ? AND last_name = ?", firstName, lastName).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, personCount,
+		"student/person must NOT be committed when guardian validation fails under TenantTxMiddleware")
+}
+
+// cleanupOrphanByName removes any person/student left behind by a regressed
+// rollback or a prior failed run, keyed by the unique test name.
+func cleanupOrphanByName(t *testing.T, tc *testContext, firstName, lastName string) {
+	t.Helper()
+	ctx := context.Background()
+	var personIDs []int64
+	if err := tc.db.NewSelect().
+		Table("users.persons").
+		Column("id").
+		Where("first_name = ? AND last_name = ?", firstName, lastName).
+		Scan(ctx, &personIDs); err != nil {
+		return
+	}
+	for _, pid := range personIDs {
+		if _, err := tc.db.NewDelete().Table("users.students").Where("person_id = ?", pid).Exec(ctx); err != nil {
+			t.Logf("cleanup students: %v", err)
+		}
+		if _, err := tc.db.NewDelete().Table("users.persons").Where("id = ?", pid).Exec(ctx); err != nil {
+			t.Logf("cleanup persons: %v", err)
+		}
+	}
+}
+
+// TestCreateStudent_BadGuardianDoesNotCommitUnderTenantTx is the regression test
+// for the review blocker: through the REAL TenantTxMiddleware, an invalid
+// guardian email must return 400 AND leave no orphaned student. Before the fix
+// the middleware committed the student because the 400 is not a 5xx.
+func TestCreateStudent_BadGuardianDoesNotCommitUnderTenantTx(t *testing.T) {
+	tc := setupTestContext(t)
+
+	const firstName = "MiddlewareRollback"
+	const lastName = "Orphan"
+
+	body := map[string]interface{}{
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"school_class": "1d",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":         "Invalid",
+				"last_name":          "Email",
+				"email":              "not-a-valid-email",
+				"relationship_type":  "parent",
+				"emergency_priority": 1,
+			},
+		},
+	}
+
+	assertNoStudentCommittedUnderTenantTx(t, tc, firstName, lastName, body, "Erziehungsberechtigte")
+}
+
+// TestCreateStudent_GuardianInvalidRelationshipType covers the Critical finding:
+// an unsupported relationship_type (passes the non-empty Bind check) must be a
+// 400, not a 500, and must roll back under the real middleware. Mirrors the
+// allowed set enforced by the detail-page link endpoint.
+func TestCreateStudent_GuardianInvalidRelationshipType(t *testing.T) {
+	tc := setupTestContext(t)
+
+	for _, relType := range []string{"sibling", "alien", "grandparent"} {
+		t.Run(relType, func(t *testing.T) {
+			firstName := "RelType"
+			lastName := "Reject_" + relType
+
+			body := map[string]interface{}{
+				"first_name":   firstName,
+				"last_name":    lastName,
+				"school_class": "2a",
+				"guardians": []map[string]interface{}{
+					{
+						"first_name":         "Some",
+						"last_name":          "Guardian",
+						"relationship_type":  relType,
+						"emergency_priority": 1,
+					},
+				},
+			}
+
+			assertNoStudentCommittedUnderTenantTx(t, tc, firstName, lastName, body, "Beziehungstyp")
+		})
+	}
+}
+
+// TestCreateStudent_GuardianRelationshipTypeAccepted confirms every allowed
+// relationship type still creates the student+guardian, so tightening the
+// validation didn't reject valid input. Runs through the real middleware.
+func TestCreateStudent_GuardianRelationshipTypeAccepted(t *testing.T) {
+	tc := setupTestContext(t)
+
+	for _, relType := range []string{"parent", "guardian", "relative", "other"} {
+		t.Run(relType, func(t *testing.T) {
+			router := setupRouterUnderTenantTx(tc, tc.resource.CreateStudentHandler())
+
+			body := map[string]interface{}{
+				"first_name":   "RelOk",
+				"last_name":    "Accept_" + relType,
+				"school_class": "2b",
+				"guardians": []map[string]interface{}{
+					{
+						"first_name":         "Valid",
+						"last_name":          "Guardian",
+						"relationship_type":  relType,
+						"emergency_priority": 1,
+					},
+				},
+			}
+
+			req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+			rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+			require.Equal(t, http.StatusCreated, rr.Code,
+				"relationship_type %q must be accepted. Body: %s", relType, rr.Body.String())
+
+			var resp createStudentResponse
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+			defer cleanupStudentWithGuardians(t, tc, resp.Data.ID, resp.Data.PersonID)
+		})
+	}
+}
+
+// TestCreateStudent_GuardianEmergencyPriorityBelowOne covers the Critical
+// finding: emergency_priority < 1 must be rejected with a 400 (parity with the
+// detail-page link endpoint, which rejects < 1), not silently stored as 0.
+func TestCreateStudent_GuardianEmergencyPriorityBelowOne(t *testing.T) {
+	tc := setupTestContext(t)
+
+	for _, prio := range []int{0, -1, -5} {
+		t.Run(fmt.Sprintf("priority_%d", prio), func(t *testing.T) {
+			firstName := "Prio"
+			lastName := fmt.Sprintf("Reject_%d", prio)
+
+			body := map[string]interface{}{
+				"first_name":   firstName,
+				"last_name":    lastName,
+				"school_class": "2c",
+				"guardians": []map[string]interface{}{
+					{
+						"first_name":         "Some",
+						"last_name":          "Guardian",
+						"relationship_type":  "parent",
+						"emergency_priority": prio,
+					},
+				},
+			}
+
+			assertNoStudentCommittedUnderTenantTx(t, tc, firstName, lastName, body, "Notfall-Priorität")
+		})
+	}
+}
+
+// TestCreateStudent_DuplicateGuardianEmail covers the Critical sibling case: a
+// guardian email already present in the tenant must surface as a clean 400
+// (not a 500) and must not commit an orphaned student. Profile reuse is deferred
+// to issue #1513; this test pins the interim contract.
+func TestCreateStudent_DuplicateGuardianEmail(t *testing.T) {
+	tc := setupTestContext(t)
+	ctx := context.Background()
+
+	const dupEmail = "existing.sibling.guardian@example.com"
+
+	// Seed a guardian profile that already owns the email in tenant 1.
+	existing := &users.GuardianProfile{
+		FirstName: "Existing",
+		LastName:  "Guardian",
+		Email:     emailPtr(dupEmail),
+	}
+	existing.SetTenantID(1)
+	_, err := tc.db.NewInsert().Model(existing).Exec(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if _, err := tc.db.NewDelete().
+			Table("users.guardian_profiles").
+			Where("id = ?", existing.ID).
+			Exec(ctx); err != nil {
+			t.Logf("cleanup seeded guardian: %v", err)
+		}
+	}()
+
+	const firstName = "DupEmail"
+	const lastName = "Orphan"
+
+	body := map[string]interface{}{
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"school_class": "2d",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":         "Sibling",
+				"last_name":          "Parent",
+				"email":              dupEmail,
+				"relationship_type":  "parent",
+				"emergency_priority": 1,
+			},
+		},
+	}
+
+	assertNoStudentCommittedUnderTenantTx(t, tc, firstName, lastName, body, "bereits vergeben")
+}
+
+// TestCreateStudent_DuplicateGuardianEmailWithinRequest covers two new guardians
+// sharing one email in a single request: the in-request duplicate must be
+// rejected up front rather than colliding on insert.
+func TestCreateStudent_DuplicateGuardianEmailWithinRequest(t *testing.T) {
+	tc := setupTestContext(t)
+
+	const firstName = "DupEmailInline"
+	const lastName = "Orphan"
+
+	body := map[string]interface{}{
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"school_class": "2e",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":         "First",
+				"last_name":          "Parent",
+				"email":              "same.email.twice@example.com",
+				"relationship_type":  "parent",
+				"emergency_priority": 1,
+			},
+			{
+				"first_name":         "Second",
+				"last_name":          "Parent",
+				"email":              "same.email.twice@example.com",
+				"relationship_type":  "guardian",
+				"emergency_priority": 2,
+			},
+		},
+	}
+
+	assertNoStudentCommittedUnderTenantTx(t, tc, firstName, lastName, body, "mehrfach angegeben")
+}

--- a/backend/api/students/create_student_guardians_test.go
+++ b/backend/api/students/create_student_guardians_test.go
@@ -1,0 +1,277 @@
+package students_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+)
+
+// createStudentResponse is the minimal envelope shape needed to read the IDs of
+// a freshly created student.
+type createStudentResponse struct {
+	Data struct {
+		ID       int64 `json:"id"`
+		PersonID int64 `json:"person_id"`
+	} `json:"data"`
+}
+
+// cleanupStudentWithGuardians removes a student and every guardian record linked
+// to it, in FK-safe order, so the hermetic test leaves no residue.
+func cleanupStudentWithGuardians(t *testing.T, tc *testContext, studentID, personID int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	var guardianIDs []int64
+	if err := tc.db.NewSelect().
+		Table("users.students_guardians").
+		Column("guardian_profile_id").
+		Where("student_id = ?", studentID).
+		Scan(ctx, &guardianIDs); err != nil {
+		t.Logf("failed to load guardian ids for cleanup: %v", err)
+	}
+
+	if _, err := tc.db.NewDelete().
+		Table("users.students_guardians").
+		Where("student_id = ?", studentID).
+		Exec(ctx); err != nil {
+		t.Logf("failed to delete student_guardians: %v", err)
+	}
+
+	for _, gid := range guardianIDs {
+		if _, err := tc.db.NewDelete().
+			Table("users.guardian_phone_numbers").
+			Where("guardian_profile_id = ?", gid).
+			Exec(ctx); err != nil {
+			t.Logf("failed to delete guardian phone numbers: %v", err)
+		}
+		if _, err := tc.db.NewDelete().
+			Table("users.guardian_profiles").
+			Where("id = ?", gid).
+			Exec(ctx); err != nil {
+			t.Logf("failed to delete guardian profile: %v", err)
+		}
+	}
+
+	if _, err := tc.db.NewDelete().Table("users.students").Where("id = ?", studentID).Exec(ctx); err != nil {
+		t.Logf("failed to delete student: %v", err)
+	}
+	if _, err := tc.db.NewDelete().Table("users.persons").Where("id = ?", personID).Exec(ctx); err != nil {
+		t.Logf("failed to delete person: %v", err)
+	}
+}
+
+// TestCreateStudent_WithGuardians verifies a student and its guardians (profile,
+// relationship, and phone numbers) are created together in one request.
+func TestCreateStudent_WithGuardians(t *testing.T) {
+	tc := setupTestContext(t)
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+
+	body := map[string]interface{}{
+		"first_name":   "Guarded",
+		"last_name":    "Child",
+		"school_class": "1a",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":           "Erika",
+				"last_name":            "Mustermann",
+				"email":                "erika.guardian.test@example.com",
+				"relationship_type":    "parent",
+				"is_primary":           true,
+				"can_pickup":           true,
+				"is_emergency_contact": true,
+				"emergency_priority":   1,
+				"phone_numbers": []map[string]interface{}{
+					{"phone_number": "0151 2345678", "phone_type": "mobile", "is_primary": true},
+				},
+			},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+	require.Equal(t, http.StatusCreated, rr.Code, "Expected 201 Created. Body: %s", rr.Body.String())
+
+	var resp createStudentResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.NotZero(t, resp.Data.ID, "expected a student id in the response")
+
+	defer cleanupStudentWithGuardians(t, tc, resp.Data.ID, resp.Data.PersonID)
+
+	ctx := context.Background()
+
+	relCount, err := tc.db.NewSelect().
+		Table("users.students_guardians").
+		Where("student_id = ?", resp.Data.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, relCount, "expected exactly one student-guardian relationship")
+
+	var guardianID int64
+	require.NoError(t, tc.db.NewSelect().
+		Table("users.students_guardians").
+		Column("guardian_profile_id").
+		Where("student_id = ?", resp.Data.ID).
+		Scan(ctx, &guardianID))
+
+	var canPickup, isPrimary bool
+	require.NoError(t, tc.db.NewSelect().
+		Table("users.students_guardians").
+		Column("can_pickup").
+		Where("student_id = ?", resp.Data.ID).
+		Scan(ctx, &canPickup))
+	assert.True(t, canPickup, "guardian should be marked as pickup-authorized")
+	require.NoError(t, tc.db.NewSelect().
+		Table("users.students_guardians").
+		Column("is_primary").
+		Where("student_id = ?", resp.Data.ID).
+		Scan(ctx, &isPrimary))
+	assert.True(t, isPrimary, "guardian should be marked primary")
+
+	phoneCount, err := tc.db.NewSelect().
+		Table("users.guardian_phone_numbers").
+		Where("guardian_profile_id = ?", guardianID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, phoneCount, "expected exactly one guardian phone number")
+}
+
+// TestCreateStudent_GuardianFailureRollsBackStudent verifies the whole creation
+// is atomic: an invalid guardian (bad email) aborts the transaction and leaves
+// no orphaned person/student behind.
+func TestCreateStudent_GuardianFailureRollsBackStudent(t *testing.T) {
+	tc := setupTestContext(t)
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+
+	const firstName = "Rollback"
+	const lastName = "Orphan"
+
+	body := map[string]interface{}{
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"school_class": "1b",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":         "Invalid",
+				"last_name":          "Email",
+				"email":              "not-a-valid-email",
+				"relationship_type":  "parent",
+				"emergency_priority": 1,
+			},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+	// Bad guardian input is a client error, not a server error: the handler
+	// classifies the ValidationError and returns 400 (not 500), and the
+	// surrounding transaction rolls back so no orphaned student survives.
+	assert.Equal(t, http.StatusBadRequest, rr.Code,
+		"invalid guardian email must return 400. Body: %s", rr.Body.String())
+	assert.Contains(t, rr.Body.String(), "Erziehungsberechtigte",
+		"400 body should name the offending guardian, not a generic server error")
+
+	ctx := context.Background()
+
+	// Safety net in case a prior failed run left residue or the rollback regressed.
+	defer func() {
+		var personIDs []int64
+		if err := tc.db.NewSelect().
+			Table("users.persons").
+			Column("id").
+			Where("first_name = ? AND last_name = ?", firstName, lastName).
+			Scan(ctx, &personIDs); err == nil {
+			for _, pid := range personIDs {
+				if _, err := tc.db.NewDelete().Table("users.students").Where("person_id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup students: %v", err)
+				}
+				if _, err := tc.db.NewDelete().Table("users.persons").Where("id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup persons: %v", err)
+				}
+			}
+		}
+	}()
+
+	personCount, err := tc.db.NewSelect().
+		Table("users.persons").
+		Where("first_name = ? AND last_name = ?", firstName, lastName).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, personCount, "person must not persist when guardian creation fails (transaction must roll back)")
+}
+
+// TestCreateStudent_InvalidGuardianPhoneRollsBackStudent verifies a malformed
+// guardian phone number is treated as a client error (400, not 500) and that
+// the surrounding transaction rolls back so no orphaned student survives —
+// matching the detail page, where a bad phone is a validation error.
+func TestCreateStudent_InvalidGuardianPhoneRollsBackStudent(t *testing.T) {
+	tc := setupTestContext(t)
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+
+	const firstName = "PhoneRollback"
+	const lastName = "Orphan"
+
+	body := map[string]interface{}{
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"school_class": "1c",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":         "Valid",
+				"last_name":          "Profile",
+				"email":              "valid.guardian.phone.test@example.com",
+				"relationship_type":  "parent",
+				"emergency_priority": 1,
+				"phone_numbers": []map[string]interface{}{
+					// No digits at all — fails the model's phone format check.
+					{"phone_number": "not-a-phone", "phone_type": "mobile", "is_primary": true},
+				},
+			},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code,
+		"invalid guardian phone must return 400. Body: %s", rr.Body.String())
+	assert.Contains(t, rr.Body.String(), "Telefonnummer",
+		"400 body should name the offending phone number")
+
+	ctx := context.Background()
+
+	defer func() {
+		var personIDs []int64
+		if err := tc.db.NewSelect().
+			Table("users.persons").
+			Column("id").
+			Where("first_name = ? AND last_name = ?", firstName, lastName).
+			Scan(ctx, &personIDs); err == nil {
+			for _, pid := range personIDs {
+				if _, err := tc.db.NewDelete().Table("users.students").Where("person_id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup students: %v", err)
+				}
+				if _, err := tc.db.NewDelete().Table("users.persons").Where("id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup persons: %v", err)
+				}
+			}
+		}
+	}()
+
+	personCount, err := tc.db.NewSelect().
+		Table("users.persons").
+		Where("first_name = ? AND last_name = ?", firstName, lastName).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, personCount, "person must not persist when guardian phone validation fails (transaction must roll back)")
+}

--- a/backend/api/students/create_student_guardians_test.go
+++ b/backend/api/students/create_student_guardians_test.go
@@ -275,3 +275,290 @@ func TestCreateStudent_InvalidGuardianPhoneRollsBackStudent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, personCount, "person must not persist when guardian phone validation fails (transaction must roll back)")
 }
+
+// assertGuardianBadRequestNoOrphan posts a create-student body that must fail
+// guardian validation, asserts a 400 carrying the given German fragment, and
+// verifies the transaction rolled back so no person/student survives. It also
+// cleans up any residue from a regressed rollback or a prior failed run.
+func assertGuardianBadRequestNoOrphan(
+	t *testing.T,
+	tc *testContext,
+	firstName, lastName string,
+	body map[string]interface{},
+	wantBodyContains string,
+) {
+	t.Helper()
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code,
+		"invalid guardian input must return 400. Body: %s", rr.Body.String())
+	assert.Contains(t, rr.Body.String(), wantBodyContains,
+		"400 body should name the offending field, not a generic server error")
+
+	ctx := context.Background()
+	defer func() {
+		var personIDs []int64
+		if err := tc.db.NewSelect().
+			Table("users.persons").
+			Column("id").
+			Where("first_name = ? AND last_name = ?", firstName, lastName).
+			Scan(ctx, &personIDs); err == nil {
+			for _, pid := range personIDs {
+				if _, err := tc.db.NewDelete().Table("users.students").Where("person_id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup students: %v", err)
+				}
+				if _, err := tc.db.NewDelete().Table("users.persons").Where("id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup persons: %v", err)
+				}
+			}
+		}
+	}()
+
+	personCount, err := tc.db.NewSelect().
+		Table("users.persons").
+		Where("first_name = ? AND last_name = ?", firstName, lastName).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, personCount, "person must not persist when guardian validation fails (transaction must roll back)")
+}
+
+// TestCreateStudent_MultipleGuardians verifies the batch path: several guardians
+// in one request are each created and linked to the same student atomically.
+func TestCreateStudent_MultipleGuardians(t *testing.T) {
+	tc := setupTestContext(t)
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+
+	body := map[string]interface{}{
+		"first_name":   "Multi",
+		"last_name":    "Guardians",
+		"school_class": "2a",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":         "Mother",
+				"last_name":          "One",
+				"email":              "mother.multi.test@example.com",
+				"relationship_type":  "parent",
+				"is_primary":         true,
+				"emergency_priority": 1,
+				"phone_numbers": []map[string]interface{}{
+					{"phone_number": "0151 1111111", "phone_type": "mobile", "is_primary": true},
+				},
+			},
+			{
+				"first_name":         "Father",
+				"last_name":          "Two",
+				"email":              "father.multi.test@example.com",
+				"relationship_type":  "guardian",
+				"can_pickup":         true,
+				"emergency_priority": 2,
+				"phone_numbers": []map[string]interface{}{
+					// Unknown phone type — must be coerced to "mobile", not
+					// rejected (matches AddPhoneNumber's own coercion).
+					{"phone_number": "0151 2222222", "phone_type": "fax-machine", "is_primary": true},
+				},
+			},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+	require.Equal(t, http.StatusCreated, rr.Code, "Expected 201 Created. Body: %s", rr.Body.String())
+
+	var resp createStudentResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.NotZero(t, resp.Data.ID)
+
+	defer cleanupStudentWithGuardians(t, tc, resp.Data.ID, resp.Data.PersonID)
+
+	ctx := context.Background()
+	relCount, err := tc.db.NewSelect().
+		Table("users.students_guardians").
+		Where("student_id = ?", resp.Data.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, relCount, "both guardians must be linked to the student")
+
+	// The unknown phone type was coerced to "mobile" and persisted.
+	var phoneType string
+	require.NoError(t, tc.db.NewSelect().
+		ColumnExpr("phone_type").
+		Table("users.guardian_phone_numbers").
+		Where("phone_number = ?", "0151 2222222").
+		Scan(ctx, &phoneType))
+	assert.Equal(t, "mobile", phoneType, "unknown phone type must be coerced to mobile")
+}
+
+// TestCreateStudent_GuardianOptionalFieldsPersisted verifies the optional
+// profile/relationship fields (address, notes, contact method, pickup notes,
+// emergency flags) are mapped through and persisted, not silently dropped.
+func TestCreateStudent_GuardianOptionalFieldsPersisted(t *testing.T) {
+	tc := setupTestContext(t)
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+
+	body := map[string]interface{}{
+		"first_name":   "Optional",
+		"last_name":    "Fields",
+		"school_class": "2b",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":               "Detailed",
+				"last_name":                "Guardian",
+				"email":                    "detailed.guardian.test@example.com",
+				"address_street":           "Musterstraße 1",
+				"address_city":             "Musterstadt",
+				"address_postal_code":      "12345",
+				"preferred_contact_method": "email",
+				"notes":                    "Bevorzugt nachmittags erreichbar",
+				"relationship_type":        "relative",
+				"is_emergency_contact":     true,
+				"pickup_notes":             "Nur mit Ausweis",
+				"emergency_priority":       3,
+			},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+
+	require.Equal(t, http.StatusCreated, rr.Code, "Expected 201 Created. Body: %s", rr.Body.String())
+
+	var resp createStudentResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.NotZero(t, resp.Data.ID)
+
+	defer cleanupStudentWithGuardians(t, tc, resp.Data.ID, resp.Data.PersonID)
+
+	ctx := context.Background()
+
+	var profile struct {
+		AddressStreet          string `bun:"address_street"`
+		AddressCity            string `bun:"address_city"`
+		AddressPostalCode      string `bun:"address_postal_code"`
+		PreferredContactMethod string `bun:"preferred_contact_method"`
+		Notes                  string `bun:"notes"`
+	}
+	require.NoError(t, tc.db.NewSelect().
+		ColumnExpr("gp.address_street, gp.address_city, gp.address_postal_code, gp.preferred_contact_method, gp.notes").
+		TableExpr("users.guardian_profiles AS gp").
+		Join("JOIN users.students_guardians AS sg ON sg.guardian_profile_id = gp.id").
+		Where("sg.student_id = ?", resp.Data.ID).
+		Scan(ctx, &profile))
+	assert.Equal(t, "Musterstraße 1", profile.AddressStreet)
+	assert.Equal(t, "Musterstadt", profile.AddressCity)
+	assert.Equal(t, "12345", profile.AddressPostalCode)
+	assert.Equal(t, "email", profile.PreferredContactMethod)
+	assert.Equal(t, "Bevorzugt nachmittags erreichbar", profile.Notes)
+
+	var rel struct {
+		RelationshipType   string `bun:"relationship_type"`
+		IsEmergencyContact bool   `bun:"is_emergency_contact"`
+		EmergencyPriority  int    `bun:"emergency_priority"`
+		PickupNotes        string `bun:"pickup_notes"`
+	}
+	require.NoError(t, tc.db.NewSelect().
+		ColumnExpr("relationship_type, is_emergency_contact, emergency_priority, pickup_notes").
+		Table("users.students_guardians").
+		Where("student_id = ?", resp.Data.ID).
+		Scan(ctx, &rel))
+	assert.Equal(t, "relative", rel.RelationshipType)
+	assert.True(t, rel.IsEmergencyContact)
+	assert.Equal(t, 3, rel.EmergencyPriority)
+	assert.Equal(t, "Nur mit Ausweis", rel.PickupNotes)
+}
+
+// TestCreateStudent_GuardianMissingRelationshipType verifies Bind rejects a
+// guardian without a relationship_type (the one field required to link) with a
+// 400 before any row is written.
+func TestCreateStudent_GuardianMissingRelationshipType(t *testing.T) {
+	tc := setupTestContext(t)
+
+	assertGuardianBadRequestNoOrphan(t, tc, "NoRelType", "Guardian", map[string]interface{}{
+		"first_name":   "NoRelType",
+		"last_name":    "Guardian",
+		"school_class": "2c",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name": "Missing",
+				"last_name":  "Relationship",
+				"email":      "missing.rel.test@example.com",
+				// relationship_type omitted
+			},
+		},
+	}, "relationship_type")
+}
+
+// TestCreateStudent_GuardianInvalidContactMethod verifies an unknown preferred
+// contact method is a classified client error (400) and rolls back the student.
+func TestCreateStudent_GuardianInvalidContactMethod(t *testing.T) {
+	tc := setupTestContext(t)
+
+	assertGuardianBadRequestNoOrphan(t, tc, "BadContact", "Method", map[string]interface{}{
+		"first_name":   "BadContact",
+		"last_name":    "Method",
+		"school_class": "2d",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":               "Invalid",
+				"last_name":                "Contact",
+				"email":                    "valid.contact.test@example.com",
+				"preferred_contact_method": "carrier-pigeon",
+				"relationship_type":        "parent",
+				"emergency_priority":       1,
+			},
+		},
+	}, "Kontaktmethode")
+}
+
+// TestCreateStudent_GuardianPhoneMissingNumber verifies an empty phone number is
+// a classified client error (400) and rolls back the student.
+func TestCreateStudent_GuardianPhoneMissingNumber(t *testing.T) {
+	tc := setupTestContext(t)
+
+	assertGuardianBadRequestNoOrphan(t, tc, "EmptyPhone", "Guardian", map[string]interface{}{
+		"first_name":   "EmptyPhone",
+		"last_name":    "Guardian",
+		"school_class": "2e",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":         "Empty",
+				"last_name":          "Phone",
+				"email":              "empty.phone.test@example.com",
+				"relationship_type":  "parent",
+				"emergency_priority": 1,
+				"phone_numbers": []map[string]interface{}{
+					{"phone_number": "   ", "phone_type": "mobile", "is_primary": true},
+				},
+			},
+		},
+	}, "Telefonnummer ist erforderlich")
+}
+
+// TestCreateStudent_GuardianPhoneTooFewDigits verifies a phone number with fewer
+// than three digits is a classified client error (400) and rolls back.
+func TestCreateStudent_GuardianPhoneTooFewDigits(t *testing.T) {
+	tc := setupTestContext(t)
+
+	assertGuardianBadRequestNoOrphan(t, tc, "ShortPhone", "Guardian", map[string]interface{}{
+		"first_name":   "ShortPhone",
+		"last_name":    "Guardian",
+		"school_class": "2f",
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":         "Short",
+				"last_name":          "Phone",
+				"email":              "short.phone.test@example.com",
+				"relationship_type":  "parent",
+				"emergency_priority": 1,
+				"phone_numbers": []map[string]interface{}{
+					{"phone_number": "12", "phone_type": "mobile", "is_primary": true},
+				},
+			},
+		},
+	}, "Ziffern")
+}

--- a/backend/api/students/test_helpers_test.go
+++ b/backend/api/students/test_helpers_test.go
@@ -73,6 +73,7 @@ func setupTestContext(t *testing.T) *testContext {
 
 	resource := studentsAPI.NewResource(studentsAPI.ResourceConfig{
 		PersonService:          svc.Users,
+		GuardianService:        svc.Guardian,
 		StudentRepo:            repoFactory.Student,
 		EducationService:       svc.Education,
 		UserContextService:     svc.UserContext,

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -147,6 +147,45 @@ type StudentRequest struct {
 	SupervisorNotes *string `json:"supervisor_notes,omitempty"` // Notes from supervisors
 	PickupStatus    *string `json:"pickup_status,omitempty"`    // How the child gets home
 	Bus             *bool   `json:"bus,omitempty"`              // Administrative permission flag (Buskind)
+
+	// Guardians created together with the student in one atomic transaction
+	// (guardian_profiles system). Optional and independent of the legacy
+	// scalar guardian_* fields above.
+	Guardians []GuardianInput `json:"guardians,omitempty"`
+}
+
+// GuardianPhoneInput is one phone number for a guardian created alongside a student.
+type GuardianPhoneInput struct {
+	PhoneNumber string `json:"phone_number"`
+	PhoneType   string `json:"phone_type,omitempty"` // mobile, home, work, other
+	Label       string `json:"label,omitempty"`
+	IsPrimary   bool   `json:"is_primary,omitempty"`
+}
+
+// GuardianInput is one guardian (profile + relationship + phone numbers) to be
+// created together with a new student. Mirrors the fields managed on the
+// student detail page's guardian form.
+type GuardianInput struct {
+	// Profile
+	FirstName              string `json:"first_name"`
+	LastName               string `json:"last_name"`
+	Email                  string `json:"email,omitempty"`
+	AddressStreet          string `json:"address_street,omitempty"`
+	AddressCity            string `json:"address_city,omitempty"`
+	AddressPostalCode      string `json:"address_postal_code,omitempty"`
+	PreferredContactMethod string `json:"preferred_contact_method,omitempty"`
+	LanguagePreference     string `json:"language_preference,omitempty"`
+	Notes                  string `json:"notes,omitempty"`
+
+	// Relationship to the student
+	RelationshipType   string `json:"relationship_type"` // parent, guardian, relative, other
+	IsPrimary          bool   `json:"is_primary,omitempty"`
+	IsEmergencyContact bool   `json:"is_emergency_contact,omitempty"`
+	CanPickup          bool   `json:"can_pickup,omitempty"`
+	PickupNotes        string `json:"pickup_notes,omitempty"`
+	EmergencyPriority  int    `json:"emergency_priority,omitempty"`
+
+	PhoneNumbers []GuardianPhoneInput `json:"phone_numbers,omitempty"`
 }
 
 // UpdateStudentRequest represents a student update request
@@ -237,6 +276,16 @@ func (req *StudentRequest) Bind(_ *http.Request) error {
 
 	// Guardian fields are now optional (legacy fields - use guardian_profiles system instead)
 	// No validation required for guardian fields
+
+	// Validate guardians created alongside the student. Email/phone format and
+	// other field-level rules are enforced at the model layer on insert (which
+	// rolls back the whole transaction on failure); here we only guard the
+	// relationship type, which has no default and is required to link.
+	for i := range req.Guardians {
+		if strings.TrimSpace(req.Guardians[i].RelationshipType) == "" {
+			return errors.New("guardian relationship_type is required")
+		}
+	}
 
 	return nil
 }

--- a/backend/models/users/person_guardian.go
+++ b/backend/models/users/person_guardian.go
@@ -21,6 +21,24 @@ const (
 	RelationshipOther    RelationshipType = "other"
 )
 
+// validRelationshipTypes is the single source of truth for the allowed guardian
+// relationship types. PersonGuardian.Validate, StudentGuardian.Validate, and the
+// student-create guardian path (services/users) all resolve the allowed set
+// through here so the three request paths cannot drift apart.
+var validRelationshipTypes = map[RelationshipType]bool{
+	RelationshipParent:   true,
+	RelationshipGuardian: true,
+	RelationshipRelative: true,
+	RelationshipOther:    true,
+}
+
+// IsValidRelationshipType reports whether s names an allowed guardian
+// relationship type. Input is trimmed and lowercased before the lookup, matching
+// the normalization the model Validate() methods apply.
+func IsValidRelationshipType(s string) bool {
+	return validRelationshipTypes[RelationshipType(strings.ToLower(strings.TrimSpace(s)))]
+}
+
 const personGuardianTableName = "users.persons_guardians"
 
 // PersonGuardian represents the relationship between a person and their guardian
@@ -74,15 +92,8 @@ func (pg *PersonGuardian) Validate() error {
 	// Convert relationship type to lowercase for consistency
 	pg.RelationshipType = RelationshipType(strings.ToLower(string(pg.RelationshipType)))
 
-	// Validate against known types
-	validTypes := map[RelationshipType]bool{
-		RelationshipParent:   true,
-		RelationshipGuardian: true,
-		RelationshipRelative: true,
-		RelationshipOther:    true,
-	}
-
-	if !validTypes[pg.RelationshipType] {
+	// Validate against the shared allowed set (single source of truth)
+	if !validRelationshipTypes[pg.RelationshipType] {
 		return errors.New("invalid relationship type")
 	}
 

--- a/backend/models/users/student_guardian.go
+++ b/backend/models/users/student_guardian.go
@@ -61,15 +61,8 @@ func (sg *StudentGuardian) Validate() error {
 	// Convert relationship type to lowercase for consistency
 	sg.RelationshipType = strings.ToLower(sg.RelationshipType)
 
-	// Validate against known types
-	validTypes := map[string]bool{
-		"parent":   true,
-		"guardian": true,
-		"relative": true,
-		"other":    true,
-	}
-
-	if !validTypes[sg.RelationshipType] {
+	// Validate against the shared allowed set (single source of truth)
+	if !IsValidRelationshipType(sg.RelationshipType) {
 		return errors.New("invalid relationship type")
 	}
 

--- a/backend/services/users/guardian_interface.go
+++ b/backend/services/users/guardian_interface.go
@@ -160,10 +160,20 @@ type GuardianService interface {
 	// LinkGuardianToStudent creates a relationship between guardian and student
 	LinkGuardianToStudent(ctx context.Context, req StudentGuardianCreateRequest) (*users.StudentGuardian, error)
 
+	// ValidateNewGuardians checks guardian input (profile, relationship type,
+	// emergency priority, phone numbers, and duplicate email) WITHOUT writing
+	// anything. Callers that persist a student and its guardians in one
+	// transaction MUST call this before the first write so a ValidationError
+	// rolls back an empty transaction instead of committing an orphaned
+	// student (TenantTxMiddleware only rolls back on 5xx). Returns a
+	// *ValidationError for bad client input.
+	ValidateNewGuardians(ctx context.Context, guardians []NewStudentGuardian) error
+
 	// AddGuardiansToStudent creates each guardian profile, links it to the
 	// student, and adds its phone numbers. Designed to run inside an ambient
 	// tenant transaction so the whole set is atomic with student creation;
-	// any failure aborts the surrounding transaction.
+	// any failure aborts the surrounding transaction. Re-runs
+	// ValidateNewGuardians internally as defense-in-depth.
 	AddGuardiansToStudent(ctx context.Context, studentID int64, guardians []NewStudentGuardian) error
 
 	// GetStudentGuardianRelationship retrieves a student-guardian relationship by ID

--- a/backend/services/users/guardian_interface.go
+++ b/backend/services/users/guardian_interface.go
@@ -83,6 +83,27 @@ type PhoneNumberUpdateRequest struct {
 	Priority    *int
 }
 
+// StudentGuardianRelationship holds the relationship flags for linking a
+// guardian to a student, without the student/guardian IDs which are set
+// internally by AddGuardiansToStudent.
+type StudentGuardianRelationship struct {
+	RelationshipType   string // parent, guardian, relative, other
+	IsPrimary          bool
+	IsEmergencyContact bool
+	CanPickup          bool
+	PickupNotes        *string
+	EmergencyPriority  int
+}
+
+// NewStudentGuardian bundles a guardian profile, its relationship to a
+// student, and its phone numbers so a guardian can be created and linked
+// atomically alongside a new student.
+type NewStudentGuardian struct {
+	Profile      GuardianCreateRequest
+	Relationship StudentGuardianRelationship
+	PhoneNumbers []PhoneNumberCreateRequest
+}
+
 // GuardianWithStudents represents a guardian with their associated students
 type GuardianWithStudents struct {
 	Profile  *users.GuardianProfile
@@ -138,6 +159,12 @@ type GuardianService interface {
 
 	// LinkGuardianToStudent creates a relationship between guardian and student
 	LinkGuardianToStudent(ctx context.Context, req StudentGuardianCreateRequest) (*users.StudentGuardian, error)
+
+	// AddGuardiansToStudent creates each guardian profile, links it to the
+	// student, and adds its phone numbers. Designed to run inside an ambient
+	// tenant transaction so the whole set is atomic with student creation;
+	// any failure aborts the surrounding transaction.
+	AddGuardiansToStudent(ctx context.Context, studentID int64, guardians []NewStudentGuardian) error
 
 	// GetStudentGuardianRelationship retrieves a student-guardian relationship by ID
 	GetStudentGuardianRelationship(ctx context.Context, relationshipID int64) (*users.StudentGuardian, error)

--- a/backend/services/users/guardian_service.go
+++ b/backend/services/users/guardian_service.go
@@ -706,18 +706,18 @@ func germanGuardianValidationMessage(err error) string {
 	}
 }
 
-// AddGuardiansToStudent creates each guardian profile, links it to the student,
-// and adds its phone numbers. It reuses CreateGuardian, LinkGuardianToStudent,
-// and AddPhoneNumber, all of which join the ambient tenant transaction via the
-// context, so a failure on any guardian aborts the surrounding transaction and
-// leaves no partial student/guardian data behind.
-func (s *guardianService) AddGuardiansToStudent(ctx context.Context, studentID int64, guardians []NewStudentGuardian) error {
-	// Validate every guardian's input up front, before any row is written, so
-	// bad client input surfaces as a classified ValidationError (mapped to HTTP
-	// 400 by the handler) instead of a generic 500. We reuse the profile and
-	// phone-number model Validate() — the same checks the repository runs on
-	// insert — to avoid duplicating the email/contact-method/phone rules.
+// ValidateNewGuardians validates guardian input without persisting anything.
+// See the interface doc comment for why callers must run this before the first
+// write. Every failure is returned as a *ValidationError (HTTP 400) carrying a
+// user-facing German message.
+func (s *guardianService) ValidateNewGuardians(ctx context.Context, guardians []NewStudentGuardian) error {
+	// Track emails seen within this single request so two new guardians sharing
+	// one email are rejected up front rather than colliding on insert.
+	seenEmails := make(map[string]struct{}, len(guardians))
+
 	for i := range guardians {
+		// Profile rules (email format, contact method) via the shared model
+		// Validate() — the same checks the repository runs on insert.
 		probe := &users.GuardianProfile{
 			FirstName:              guardians[i].Profile.FirstName,
 			LastName:               guardians[i].Profile.LastName,
@@ -727,6 +727,40 @@ func (s *guardianService) AddGuardiansToStudent(ctx context.Context, studentID i
 		if err := probe.Validate(); err != nil {
 			//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
 			return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: %s", i+1, germanGuardianValidationMessage(err))}
+		}
+
+		// Relationship type must be one of the allowed values. Without this,
+		// an unsupported value passes Bind, then fails at insert as a plain
+		// error (HTTP 500). users.IsValidRelationshipType is the single source
+		// of truth shared with StudentGuardian.Validate() and the detail-page
+		// link path, so the allowed set cannot drift across request paths.
+		if !users.IsValidRelationshipType(guardians[i].Relationship.RelationshipType) {
+			//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
+			return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: ungültiger Beziehungstyp", i+1)}
+		}
+
+		// Emergency priority must be >= 1, matching the detail-page link
+		// endpoint (StudentGuardianLinkRequest.Bind rejects < 1).
+		if guardians[i].Relationship.EmergencyPriority < 1 {
+			//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
+			return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: Notfall-Priorität muss mindestens 1 sein", i+1)}
+		}
+
+		// Duplicate email: a sibling sharing a guardian email hits the
+		// UNIQUE(tenant_id, email) index on insert and would otherwise surface
+		// as a 500 and roll the whole student back. Detect it as bad input.
+		// (Reusing the existing guardian profile is deferred to #1513.)
+		if probe.Email != nil && *probe.Email != "" {
+			email := *probe.Email // already trimmed + lowercased by probe.Validate()
+			if _, dup := seenEmails[email]; dup {
+				//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
+				return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: E-Mail-Adresse %q ist mehrfach angegeben", i+1, email)}
+			}
+			if existing, err := s.guardianProfileRepo.FindByEmail(ctx, email); err == nil && existing != nil {
+				//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
+				return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: E-Mail-Adresse %q ist bereits vergeben", i+1, email)}
+			}
+			seenEmails[email] = struct{}{}
 		}
 
 		// Validate phone numbers the same way AddPhoneNumber does on insert.
@@ -751,6 +785,23 @@ func (s *guardianService) AddGuardiansToStudent(ctx context.Context, studentID i
 		}
 	}
 
+	return nil
+}
+
+// AddGuardiansToStudent creates each guardian profile, links it to the student,
+// and adds its phone numbers. It reuses CreateGuardian, LinkGuardianToStudent,
+// and AddPhoneNumber, all of which join the ambient tenant transaction via the
+// context, so a failure on any guardian aborts the surrounding transaction and
+// leaves no partial student/guardian data behind.
+func (s *guardianService) AddGuardiansToStudent(ctx context.Context, studentID int64, guardians []NewStudentGuardian) error {
+	// Defense-in-depth: re-validate before any write so this method is safe
+	// even if a caller forgets the pre-write ValidateNewGuardians call. Bad
+	// client input surfaces as a classified ValidationError (HTTP 400) instead
+	// of a generic 500.
+	if err := s.ValidateNewGuardians(ctx, guardians); err != nil {
+		return err
+	}
+
 	for i := range guardians {
 		g := guardians[i]
 
@@ -759,11 +810,9 @@ func (s *guardianService) AddGuardiansToStudent(ctx context.Context, studentID i
 			return fmt.Errorf("failed to create guardian at index %d: %w", i, err)
 		}
 
-		// EmergencyPriority is passed through verbatim, exactly like the
-		// detail-page link path (LinkGuardianToStudent). No floor here: the
-		// guardian form always sends >= 1, so the create flow stores the same
-		// value the detail page would. Centralizing any default belongs on the
-		// link path, not duplicated here.
+		// RelationshipType and EmergencyPriority were already checked by
+		// ValidateNewGuardians (>= 1, allowed type) — parity with the
+		// detail-page link path (LinkGuardianToStudent).
 		if _, err := s.LinkGuardianToStudent(ctx, StudentGuardianCreateRequest{
 			StudentID:          studentID,
 			GuardianProfileID:  profile.ID,

--- a/backend/services/users/guardian_service.go
+++ b/backend/services/users/guardian_service.go
@@ -684,6 +684,109 @@ func (s *guardianService) LinkGuardianToStudent(ctx context.Context, req Student
 	return relationship, nil
 }
 
+// germanGuardianValidationMessage translates the English validation messages
+// emitted by GuardianProfile.Validate() / GuardianPhoneNumber.Validate() into
+// German for the user-facing 400 response. The model methods are shared with
+// other call sites and must stay language-neutral, so the translation lives
+// here. Unknown messages fall back to the original text rather than masking it.
+func germanGuardianValidationMessage(err error) string {
+	switch err.Error() {
+	case "invalid email format":
+		return "ungültiges E-Mail-Format"
+	case "invalid preferred contact method":
+		return "ungültige bevorzugte Kontaktmethode"
+	case "phone number is required":
+		return "Telefonnummer ist erforderlich"
+	case "invalid phone number format":
+		return "ungültiges Telefonnummer-Format"
+	case "phone number must contain at least 3 digits":
+		return "Telefonnummer muss mindestens 3 Ziffern enthalten"
+	default:
+		return err.Error()
+	}
+}
+
+// AddGuardiansToStudent creates each guardian profile, links it to the student,
+// and adds its phone numbers. It reuses CreateGuardian, LinkGuardianToStudent,
+// and AddPhoneNumber, all of which join the ambient tenant transaction via the
+// context, so a failure on any guardian aborts the surrounding transaction and
+// leaves no partial student/guardian data behind.
+func (s *guardianService) AddGuardiansToStudent(ctx context.Context, studentID int64, guardians []NewStudentGuardian) error {
+	// Validate every guardian's input up front, before any row is written, so
+	// bad client input surfaces as a classified ValidationError (mapped to HTTP
+	// 400 by the handler) instead of a generic 500. We reuse the profile and
+	// phone-number model Validate() — the same checks the repository runs on
+	// insert — to avoid duplicating the email/contact-method/phone rules.
+	for i := range guardians {
+		probe := &users.GuardianProfile{
+			FirstName:              guardians[i].Profile.FirstName,
+			LastName:               guardians[i].Profile.LastName,
+			Email:                  guardians[i].Profile.Email,
+			PreferredContactMethod: guardians[i].Profile.PreferredContactMethod,
+		}
+		if err := probe.Validate(); err != nil {
+			//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
+			return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: %s", i+1, germanGuardianValidationMessage(err))}
+		}
+
+		// Validate phone numbers the same way AddPhoneNumber does on insert.
+		// GuardianProfileID is set to a placeholder (1) only to pass the model's
+		// "ID required" guard — the real ID is assigned after CreateGuardian. The
+		// phone type is coerced to mobile for unknown values exactly like
+		// AddPhoneNumber, so the probe never rejects a type the real path accepts.
+		for j := range guardians[i].PhoneNumbers {
+			phoneType := users.PhoneType(guardians[i].PhoneNumbers[j].PhoneType)
+			if !users.ValidPhoneTypes[phoneType] {
+				phoneType = users.PhoneTypeMobile
+			}
+			phoneProbe := &users.GuardianPhoneNumber{
+				GuardianProfileID: 1,
+				PhoneNumber:       guardians[i].PhoneNumbers[j].PhoneNumber,
+				PhoneType:         phoneType,
+			}
+			if err := phoneProbe.Validate(); err != nil {
+				//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
+				return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d, Telefonnummer %d: %s", i+1, j+1, germanGuardianValidationMessage(err))}
+			}
+		}
+	}
+
+	for i := range guardians {
+		g := guardians[i]
+
+		profile, err := s.CreateGuardian(ctx, g.Profile)
+		if err != nil {
+			return fmt.Errorf("failed to create guardian at index %d: %w", i, err)
+		}
+
+		// EmergencyPriority is passed through verbatim, exactly like the
+		// detail-page link path (LinkGuardianToStudent). No floor here: the
+		// guardian form always sends >= 1, so the create flow stores the same
+		// value the detail page would. Centralizing any default belongs on the
+		// link path, not duplicated here.
+		if _, err := s.LinkGuardianToStudent(ctx, StudentGuardianCreateRequest{
+			StudentID:          studentID,
+			GuardianProfileID:  profile.ID,
+			RelationshipType:   g.Relationship.RelationshipType,
+			IsPrimary:          g.Relationship.IsPrimary,
+			IsEmergencyContact: g.Relationship.IsEmergencyContact,
+			CanPickup:          g.Relationship.CanPickup,
+			PickupNotes:        g.Relationship.PickupNotes,
+			EmergencyPriority:  g.Relationship.EmergencyPriority,
+		}); err != nil {
+			return fmt.Errorf("failed to link guardian at index %d: %w", i, err)
+		}
+
+		for j := range g.PhoneNumbers {
+			if _, err := s.AddPhoneNumber(ctx, profile.ID, g.PhoneNumbers[j]); err != nil {
+				return fmt.Errorf("failed to add phone number %d for guardian at index %d: %w", j, i, err)
+			}
+		}
+	}
+
+	return nil
+}
+
 // GetStudentGuardianRelationship retrieves a student-guardian relationship by ID
 func (s *guardianService) GetStudentGuardianRelationship(ctx context.Context, relationshipID int64) (*users.StudentGuardian, error) {
 	relationship, err := s.studentGuardianRepo.FindByID(ctx, relationshipID)

--- a/backend/services/users/guardian_validation_message_test.go
+++ b/backend/services/users/guardian_validation_message_test.go
@@ -1,0 +1,57 @@
+package users
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGermanGuardianValidationMessage verifies every English model-validation
+// message used by the student-create guardian flow is translated to German for
+// the user-facing 400 response, and that unknown messages fall through verbatim
+// rather than being masked.
+func TestGermanGuardianValidationMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       error
+		expected string
+	}{
+		{
+			name:     "invalid email",
+			in:       errors.New("invalid email format"),
+			expected: "ungültiges E-Mail-Format",
+		},
+		{
+			name:     "invalid contact method",
+			in:       errors.New("invalid preferred contact method"),
+			expected: "ungültige bevorzugte Kontaktmethode",
+		},
+		{
+			name:     "phone required",
+			in:       errors.New("phone number is required"),
+			expected: "Telefonnummer ist erforderlich",
+		},
+		{
+			name:     "invalid phone format",
+			in:       errors.New("invalid phone number format"),
+			expected: "ungültiges Telefonnummer-Format",
+		},
+		{
+			name:     "phone too few digits",
+			in:       errors.New("phone number must contain at least 3 digits"),
+			expected: "Telefonnummer muss mindestens 3 Ziffern enthalten",
+		},
+		{
+			name:     "unknown message falls through verbatim",
+			in:       errors.New("some unexpected validation failure"),
+			expected: "some unexpected validation failure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, germanGuardianValidationMessage(tt.in))
+		})
+	}
+}

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
@@ -217,6 +217,7 @@ vi.mock("@/components/students/student-create-modal", () => ({
     onCreate: (data: {
       first_name: string;
       second_name: string;
+      guardians?: Array<Record<string, unknown>>;
     }) => Promise<void>;
   }) =>
     isOpen ? (
@@ -228,6 +229,18 @@ vi.mock("@/components/students/student-create-modal", () => ({
           }
         >
           Submit
+        </button>
+        <button
+          data-testid="submit-create-with-guardians"
+          onClick={() =>
+            void onCreate({
+              first_name: "New",
+              second_name: "Student",
+              guardians: [{ first_name: "Erika", relationship_type: "parent" }],
+            })
+          }
+        >
+          Submit with guardians
         </button>
         <button data-testid="close-create-modal" onClick={onClose}>
           Close
@@ -625,6 +638,34 @@ describe("StudentsPage", () => {
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalled();
     });
+  });
+
+  it("forwards guardians to the create service when present", async () => {
+    mockCreate.mockResolvedValueOnce({
+      id: "4",
+      first_name: "New",
+      second_name: "Student",
+    });
+
+    render(<StudentsPage />);
+
+    const createButton = screen.getAllByLabelText("Schüler erstellen")[0]!;
+    fireEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("student-create-modal")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("submit-create-with-guardians"));
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalled();
+    });
+    // The guardians must survive transformBeforeSubmit and reach service.create.
+    const payload = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(payload.guardians).toEqual([
+      { first_name: "Erika", relationship_type: "parent" },
+    ]);
   });
 
   it("calls update service when the detail panel saves Stammdaten", async () => {

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -28,6 +28,7 @@ import { createCrudService } from "@/lib/database/service-factory";
 import { studentsConfig } from "@/lib/database/configs/students.config";
 import { useDeleteConfirmation } from "~/hooks/useDeleteConfirmation";
 import type { Student } from "@/lib/api";
+import type { StudentGuardianPayload } from "@/lib/guardian-helpers";
 import { useSWRAuth, useTenantMutate } from "~/lib/swr";
 import { createLogger } from "~/lib/logger";
 
@@ -222,11 +223,22 @@ export default function StudentsPage() {
   }, [searchTerm, groupFilter, allGroups]);
 
   const handleCreateStudent = useCallback(
-    async (studentData: Partial<Student>) => {
-      if (studentsConfig.form.transformBeforeSubmit) {
-        studentData = studentsConfig.form.transformBeforeSubmit(studentData);
+    async (
+      studentData: Partial<Student> & { guardians?: StudentGuardianPayload[] },
+    ) => {
+      // Run the config transform, then re-attach guardians from the original
+      // input. transformBeforeSubmit is typed Partial<Student> and drops the
+      // extra guardians field from the static type; re-attaching here makes the
+      // contract explicit so a future transform change can't silently strip the
+      // guardians (see issue #1500 atomic create flow).
+      let payload: Partial<Student> & { guardians?: StudentGuardianPayload[] } =
+        studentsConfig.form.transformBeforeSubmit
+          ? studentsConfig.form.transformBeforeSubmit(studentData)
+          : studentData;
+      if (studentData.guardians && studentData.guardians.length > 0) {
+        payload = { ...payload, guardians: studentData.guardians };
       }
-      const newStudent = await service.create(studentData);
+      const newStudent = await service.create(payload);
       const displayName = studentsConfig.list.item.title(newStudent);
       toastSuccess(
         getDbOperationMessage(

--- a/frontend/src/app/api/students/route.ts
+++ b/frontend/src/app/api/students/route.ts
@@ -20,6 +20,7 @@ import {
   buildStudentResponse,
   handleStudentCreationError,
 } from "~/lib/student-request-helpers";
+import type { StudentGuardianPayload } from "~/lib/guardian-helpers";
 
 /**
  * Type definition for student response from backend
@@ -187,6 +188,7 @@ export const POST = createPostHandler<
     guardian_phone?: string;
     privacy_consent_accepted?: boolean;
     data_retention_days?: number;
+    guardians?: StudentGuardianPayload[];
   }
 >(
   async (
@@ -196,6 +198,7 @@ export const POST = createPostHandler<
       guardian_phone?: string;
       privacy_consent_accepted?: boolean;
       data_retention_days?: number;
+      guardians?: StudentGuardianPayload[];
     },
     token: string,
   ) => {

--- a/frontend/src/components/students/student-create-modal.test.tsx
+++ b/frontend/src/components/students/student-create-modal.test.tsx
@@ -11,6 +11,7 @@ import {
 } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { StudentCreateModal } from "./student-create-modal";
+import { handleStudentFormSubmit } from "~/lib/student-form-validation";
 
 // Mock Modal component
 vi.mock("~/components/ui/modal", () => ({
@@ -522,5 +523,85 @@ describe("StudentCreateModal", () => {
 
     expect(screen.queryByText(/Erika Muster/)).not.toBeInTheDocument();
     expect(screen.getByText("Optional")).toBeInTheDocument();
+  });
+
+  it("forwards collected guardians (snake_case mapped) to onCreate on submit", async () => {
+    mockOnCreate.mockResolvedValue(undefined);
+
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Erziehungsberechtigte hinzufügen"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("MockSubmitGuardian"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Erika Muster/)).toBeInTheDocument();
+    });
+
+    const form = screen.getByTestId("modal").querySelector("form");
+    await act(async () => {
+      fireEvent.submit(form!);
+    });
+
+    await waitFor(() => {
+      expect(handleStudentFormSubmit).toHaveBeenCalled();
+    });
+
+    // handleSubmit must hand the form payload (arg index 1) a snake_case-mapped
+    // guardians array, nested exactly as the create endpoint expects.
+    const submitted = vi.mocked(handleStudentFormSubmit).mock
+      .calls[0]?.[1] as Record<string, unknown>;
+    expect(submitted).toMatchObject({
+      guardians: [
+        {
+          first_name: "Erika",
+          last_name: "Muster",
+          email: "erika@example.com",
+          language_preference: "de",
+          relationship_type: "parent",
+          is_primary: true,
+          is_emergency_contact: false,
+          can_pickup: true,
+          emergency_priority: 1,
+          phone_numbers: [
+            {
+              phone_number: "0151 2345678",
+              phone_type: "mobile",
+              is_primary: true,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("does not attach a guardians field when none were added", async () => {
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    const form = screen.getByTestId("modal").querySelector("form");
+    await act(async () => {
+      fireEvent.submit(form!);
+    });
+
+    await waitFor(() => {
+      expect(handleStudentFormSubmit).toHaveBeenCalled();
+    });
+    const submitted = vi.mocked(handleStudentFormSubmit).mock
+      .calls[0]?.[1] as Record<string, unknown>;
+    expect(submitted).not.toHaveProperty("guardians");
   });
 });

--- a/frontend/src/components/students/student-create-modal.test.tsx
+++ b/frontend/src/components/students/student-create-modal.test.tsx
@@ -111,6 +111,56 @@ vi.mock("./student-common-form-sections", () => ({
   ),
 }));
 
+// Mock the reused GuardianFormModal: when open, expose a button that calls
+// onSubmit with one canned guardian entry (the same shape the real modal emits).
+// This lets us exercise StudentCreateModal's collection/summary logic without
+// driving the full guardian form.
+vi.mock("~/components/guardians/guardian-form-modal", () => ({
+  default: ({
+    isOpen,
+    onSubmit,
+  }: {
+    isOpen: boolean;
+    onSubmit: (entries: unknown[]) => Promise<void>;
+  }) =>
+    isOpen ? (
+      <div data-testid="guardian-form-modal">
+        <button
+          type="button"
+          onClick={() =>
+            void onSubmit([
+              {
+                id: "g1",
+                guardianData: {
+                  firstName: "Erika",
+                  lastName: "Muster",
+                  email: "erika@example.com",
+                  languagePreference: "de",
+                },
+                relationshipData: {
+                  relationshipType: "parent",
+                  isPrimary: true,
+                  isEmergencyContact: false,
+                  canPickup: true,
+                  emergencyPriority: 1,
+                },
+                phoneNumbers: [
+                  {
+                    phoneNumber: "0151 2345678",
+                    phoneType: "mobile",
+                    isPrimary: true,
+                  },
+                ],
+              },
+            ])
+          }
+        >
+          MockSubmitGuardian
+        </button>
+      </div>
+    ) : null,
+}));
+
 // Mock validation utilities
 vi.mock("~/lib/student-form-validation", () => ({
   validateStudentForm: vi.fn(() => ({})),
@@ -399,5 +449,78 @@ describe("StudentCreateModal", () => {
     await waitFor(() => {
       expect(screen.getByTestId("personal-info-section")).toBeInTheDocument();
     });
+  });
+
+  it("opens the reused guardian form when the add button is clicked", async () => {
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Erziehungsberechtigte hinzufügen"));
+    });
+
+    expect(screen.getByTestId("guardian-form-modal")).toBeInTheDocument();
+  });
+
+  it("adds a submitted guardian to the summary list", async () => {
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Erziehungsberechtigte hinzufügen"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("MockSubmitGuardian"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Erika Muster/)).toBeInTheDocument();
+    });
+    // Relationship label and pickup flag are rendered from the payload.
+    expect(screen.getByText("Elternteil")).toBeInTheDocument();
+    expect(screen.getByText(/Abholberechtigt/)).toBeInTheDocument();
+    expect(screen.getByText("1 hinzugefügt")).toBeInTheDocument();
+    // Sub-modal closes after collecting.
+    expect(screen.queryByTestId("guardian-form-modal")).not.toBeInTheDocument();
+  });
+
+  it("removes a guardian from the summary list", async () => {
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Erziehungsberechtigte hinzufügen"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("MockSubmitGuardian"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Erika Muster/)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByLabelText("Erziehungsberechtigte/n entfernen"),
+      );
+    });
+
+    expect(screen.queryByText(/Erika Muster/)).not.toBeInTheDocument();
+    expect(screen.getByText("Optional")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/students/student-create-modal.tsx
+++ b/frontend/src/components/students/student-create-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { Users, Plus, Trash2 } from "lucide-react";
 import { Modal } from "~/components/ui/modal";
 import type { Student } from "@/lib/api";
 import {
@@ -13,11 +14,77 @@ import {
   validateStudentForm,
   handleStudentFormSubmit,
 } from "~/lib/student-form-validation";
+import GuardianFormModal, {
+  type RelationshipFormData,
+} from "~/components/guardians/guardian-form-modal";
+import {
+  RELATIONSHIP_TYPES,
+  type GuardianFormData,
+  type PhoneType,
+  type StudentGuardianPayload,
+} from "@/lib/guardian-helpers";
+
+// Shape returned by GuardianFormModal's onSubmit for each entry.
+type GuardianSubmitEntry = {
+  id: string;
+  guardianData: GuardianFormData;
+  relationshipData: RelationshipFormData;
+  phoneNumbers: Array<{
+    id?: string;
+    phoneNumber: string;
+    phoneType: PhoneType;
+    label?: string;
+    isPrimary: boolean;
+  }>;
+};
+
+// Maps GuardianFormModal entries onto the snake_case payload the create-student
+// endpoint expects, so the same component used on the detail page feeds the
+// atomic create flow without rebuilding any guardian fields.
+function toGuardianPayloads(
+  entries: GuardianSubmitEntry[],
+): StudentGuardianPayload[] {
+  return entries.map((entry) => ({
+    first_name: entry.guardianData.firstName,
+    last_name: entry.guardianData.lastName,
+    email: entry.guardianData.email,
+    address_street: entry.guardianData.addressStreet,
+    address_city: entry.guardianData.addressCity,
+    address_postal_code: entry.guardianData.addressPostalCode,
+    // preferred_contact_method and pickup_notes are part of the shared guardian
+    // types but GuardianFormModal's create mode does not expose inputs for them
+    // yet, so they arrive undefined today. Mapped through deliberately so they
+    // flow automatically once the form adds those fields (the backend applies
+    // its own contact-method default when omitted).
+    preferred_contact_method: entry.guardianData.preferredContactMethod,
+    language_preference: entry.guardianData.languagePreference,
+    notes: entry.guardianData.notes,
+    relationship_type: entry.relationshipData.relationshipType,
+    is_primary: entry.relationshipData.isPrimary,
+    is_emergency_contact: entry.relationshipData.isEmergencyContact,
+    can_pickup: entry.relationshipData.canPickup,
+    pickup_notes: entry.relationshipData.pickupNotes,
+    emergency_priority: entry.relationshipData.emergencyPriority,
+    phone_numbers: entry.phoneNumbers.map((phone) => ({
+      phone_number: phone.phoneNumber,
+      phone_type: phone.phoneType,
+      label: phone.label,
+      is_primary: phone.isPrimary,
+    })),
+  }));
+}
+
+// Human-readable relationship label for the summary list.
+function relationshipLabel(value: string): string {
+  return RELATIONSHIP_TYPES.find((t) => t.value === value)?.label ?? value;
+}
 
 interface StudentCreateModalProps {
   readonly isOpen: boolean;
   readonly onClose: () => void;
-  readonly onCreate: (data: Partial<Student>) => Promise<void>;
+  readonly onCreate: (
+    data: Partial<Student> & { guardians?: StudentGuardianPayload[] },
+  ) => Promise<void>;
   readonly groups?: Array<{ readonly value: string; readonly label: string }>;
 }
 
@@ -45,6 +112,8 @@ export function StudentCreateModal({
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [saveLoading, setSaveLoading] = useState(false);
+  const [guardians, setGuardians] = useState<StudentGuardianPayload[]>([]);
+  const [guardianModalOpen, setGuardianModalOpen] = useState(false);
 
   // Reset form when modal opens/closes
   useEffect(() => {
@@ -64,8 +133,22 @@ export function StudentCreateModal({
         pickup_status: "",
       });
       setErrors({});
+      setGuardians([]);
+      setGuardianModalOpen(false);
     }
   }, [isOpen]);
+
+  // Collect guardians from the reused GuardianFormModal into local state. The
+  // guardians are persisted together with the student in one request — no API
+  // calls happen here.
+  const handleGuardianSubmit = async (entries: GuardianSubmitEntry[]) => {
+    setGuardians((prev) => [...prev, ...toGuardianPayloads(entries)]);
+    setGuardianModalOpen(false);
+  };
+
+  const removeGuardian = (index: number) => {
+    setGuardians((prev) => prev.filter((_, i) => i !== index));
+  };
 
   const validateForm = (): boolean => {
     const newErrors = validateStudentForm(formData, {
@@ -78,9 +161,11 @@ export function StudentCreateModal({
   };
 
   const handleSubmit = (e: React.FormEvent) => {
+    const payload: Partial<Student> & { guardians?: StudentGuardianPayload[] } =
+      guardians.length > 0 ? { ...formData, guardians } : formData;
     return handleStudentFormSubmit(
       e,
-      formData,
+      payload,
       validateForm,
       onCreate,
       setSaveLoading,
@@ -104,122 +189,173 @@ export function StudentCreateModal({
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Neuer Schüler">
-      <form
-        onSubmit={handleSubmit}
-        noValidate
-        className="space-y-4 md:space-y-6"
-      >
-        {/* Submit Error */}
-        {errors.submit && (
-          <div className="rounded-lg border border-red-200 bg-red-50 p-2 md:p-3">
-            <p className="text-xs text-red-800 md:text-sm">{errors.submit}</p>
-          </div>
-        )}
-
-        {/* Personal Information */}
-        <PersonalInfoSection
-          formData={formData}
-          onChange={handleChange}
-          errors={errors}
-          groups={groups}
-        />
-
-        {/* Guardian Information - Note about managing after creation */}
-        <div className="rounded-xl border border-purple-100 bg-purple-50/50 p-3 md:p-4">
-          <div className="flex items-start gap-3">
-            <div className="flex-shrink-0">
-              <svg
-                className="h-5 w-5 text-purple-600"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                />
-              </svg>
+    <>
+      <Modal isOpen={isOpen} onClose={onClose} title="Neuer Schüler">
+        <form
+          onSubmit={handleSubmit}
+          noValidate
+          className="space-y-4 md:space-y-6"
+        >
+          {/* Submit Error */}
+          {errors.submit && (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-2 md:p-3">
+              <p className="text-xs text-red-800 md:text-sm">{errors.submit}</p>
             </div>
-            <div className="flex-1">
-              <h3 className="mb-1 text-xs font-semibold text-gray-900 md:text-sm">
+          )}
+
+          {/* Personal Information */}
+          <PersonalInfoSection
+            formData={formData}
+            onChange={handleChange}
+            errors={errors}
+            groups={groups}
+          />
+
+          {/* Guardian Information — add directly during creation. Styling
+              matches the other modal sections (border-gray-100 + blue tint,
+              blue heading icon) and reuses the guardian modal's own dashed
+              add-button and red remove patterns. */}
+          <div className="rounded-xl border border-gray-100 bg-blue-50/30 p-3 md:p-4">
+            <div className="mb-3 flex items-center justify-between md:mb-4">
+              <h3 className="flex items-center gap-2 text-xs font-semibold text-gray-900 md:text-sm">
+                <Users className="h-3.5 w-3.5 text-blue-600 md:h-4 md:w-4" />
                 Erziehungsberechtigte
               </h3>
-              <p className="text-xs text-gray-600">
-                Erziehungsberechtigte können nach der Erstellung des Schülers
-                auf der Schülerdetailseite hinzugefügt und verwaltet werden.
-                Dort stehen umfangreiche Optionen zur Verfügung (Kontaktdaten,
-                Adressen, Abholberechtigungen, Notfallkontakte).
-              </p>
-            </div>
-          </div>
-        </div>
-
-        {/* Common Form Sections */}
-        <StudentCommonFormSections
-          formData={formData}
-          errors={errors}
-          onChange={handleChange}
-        />
-
-        {/* Bus Status */}
-        <BusStatusSection
-          value={formData.bus}
-          onChange={(v) => handleChange("bus", v)}
-        />
-
-        {/* Pickup Status */}
-        <PickupStatusSection
-          value={formData.pickup_status}
-          onChange={(v) => handleChange("pickup_status", v)}
-        />
-
-        {/* Action Buttons */}
-        <div className="sticky bottom-0 -mx-4 mt-4 -mb-4 flex gap-2 border-t border-gray-100 bg-white/95 px-4 py-3 backdrop-blur-sm md:-mx-6 md:mt-6 md:-mb-6 md:gap-3 md:px-6 md:py-4">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={saveLoading}
-            className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-xs font-medium text-gray-700 transition-all duration-200 hover:border-gray-400 hover:bg-gray-50 hover:shadow-md active:scale-100 disabled:cursor-not-allowed disabled:opacity-50 md:px-4 md:text-sm md:hover:scale-105"
-          >
-            Abbrechen
-          </button>
-          <button
-            type="submit"
-            disabled={saveLoading}
-            className="flex-1 rounded-lg bg-gray-900 px-3 py-2 text-xs font-medium text-white transition-all duration-200 hover:bg-gray-700 hover:shadow-lg active:scale-100 disabled:cursor-not-allowed disabled:opacity-50 md:px-4 md:text-sm md:hover:scale-105"
-          >
-            {saveLoading ? (
-              <span className="flex items-center justify-center gap-2">
-                <svg
-                  className="h-4 w-4 animate-spin text-white"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  ></circle>
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  ></path>
-                </svg>
-                Wird erstellt...
+              <span className="text-xs text-gray-500">
+                {guardians.length > 0
+                  ? `${guardians.length} hinzugefügt`
+                  : "Optional"}
               </span>
-            ) : (
-              "Erstellen"
+            </div>
+
+            {guardians.length > 0 && (
+              <ul className="mb-3 space-y-2">
+                {guardians.map((guardian, index) => {
+                  const flags = [
+                    guardian.can_pickup ? "Abholberechtigt" : null,
+                    guardian.is_emergency_contact ? "Notfallkontakt" : null,
+                    guardian.is_primary ? "Primär" : null,
+                  ].filter(Boolean);
+                  return (
+                    <li
+                      key={`${guardian.first_name}-${guardian.last_name}-${index}`}
+                      className="flex items-start justify-between gap-2 rounded-lg border border-gray-100 bg-white p-2 md:p-3"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-xs font-medium text-gray-900 md:text-sm">
+                          {`${guardian.first_name} ${guardian.last_name}`.trim() ||
+                            "Erziehungsberechtigte/r"}
+                          <span className="ml-2 font-normal text-gray-500">
+                            {relationshipLabel(guardian.relationship_type)}
+                          </span>
+                        </p>
+                        {flags.length > 0 && (
+                          <p className="mt-0.5 truncate text-xs text-gray-500">
+                            {flags.join(" · ")}
+                          </p>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => removeGuardian(index)}
+                        disabled={saveLoading}
+                        aria-label="Erziehungsberechtigte/n entfernen"
+                        className="flex flex-shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-xs text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
             )}
-          </button>
-        </div>
-      </form>
-    </Modal>
+
+            <button
+              type="button"
+              onClick={() => setGuardianModalOpen(true)}
+              disabled={saveLoading}
+              className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 py-2 text-xs font-medium text-gray-600 transition-all duration-200 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+            >
+              <Plus className="h-4 w-4" />
+              Erziehungsberechtigte hinzufügen
+            </button>
+          </div>
+
+          {/* Common Form Sections */}
+          <StudentCommonFormSections
+            formData={formData}
+            errors={errors}
+            onChange={handleChange}
+          />
+
+          {/* Bus Status */}
+          <BusStatusSection
+            value={formData.bus}
+            onChange={(v) => handleChange("bus", v)}
+          />
+
+          {/* Pickup Status */}
+          <PickupStatusSection
+            value={formData.pickup_status}
+            onChange={(v) => handleChange("pickup_status", v)}
+          />
+
+          {/* Action Buttons */}
+          <div className="sticky bottom-0 -mx-4 mt-4 -mb-4 flex gap-2 border-t border-gray-100 bg-white/95 px-4 py-3 backdrop-blur-sm md:-mx-6 md:mt-6 md:-mb-6 md:gap-3 md:px-6 md:py-4">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={saveLoading}
+              className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-xs font-medium text-gray-700 transition-all duration-200 hover:border-gray-400 hover:bg-gray-50 hover:shadow-md active:scale-100 disabled:cursor-not-allowed disabled:opacity-50 md:px-4 md:text-sm md:hover:scale-105"
+            >
+              Abbrechen
+            </button>
+            <button
+              type="submit"
+              disabled={saveLoading}
+              className="flex-1 rounded-lg bg-gray-900 px-3 py-2 text-xs font-medium text-white transition-all duration-200 hover:bg-gray-700 hover:shadow-lg active:scale-100 disabled:cursor-not-allowed disabled:opacity-50 md:px-4 md:text-sm md:hover:scale-105"
+            >
+              {saveLoading ? (
+                <span className="flex items-center justify-center gap-2">
+                  <svg
+                    className="h-4 w-4 animate-spin text-white"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    ></circle>
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    ></path>
+                  </svg>
+                  Wird erstellt...
+                </span>
+              ) : (
+                "Erstellen"
+              )}
+            </button>
+          </div>
+        </form>
+      </Modal>
+
+      {/* Reuse the existing guardian form: collect guardians without firing
+          API calls — they are persisted atomically with the student. */}
+      {guardianModalOpen && (
+        <GuardianFormModal
+          isOpen={guardianModalOpen}
+          mode="create"
+          onClose={() => setGuardianModalOpen(false)}
+          onSubmit={handleGuardianSubmit}
+        />
+      )}
+    </>
   );
 }

--- a/frontend/src/lib/database/service-factory.ts
+++ b/frontend/src/lib/database/service-factory.ts
@@ -181,7 +181,13 @@ export function createCrudService<T>(config: EntityConfig<T>): CrudService<T> {
       // Try to extract a clean error message from the nested JSON response.
       // The error chain is: backend → route handler → this fetch, each wrapping the previous.
       const userMessage = extractErrorMessage(errorText, response.status);
-      throw new Error(userMessage);
+      // Carry the HTTP status on the thrown error so callers can distinguish a
+      // client-side validation error (4xx, message is user-facing) from a
+      // network/server error (5xx, message is technical noise). Additive: the
+      // message and `instanceof Error` are unchanged for existing consumers.
+      const apiError = new Error(userMessage) as Error & { status?: number };
+      apiError.status = response.status;
+      throw apiError;
     }
 
     // Handle empty responses (204 No Content, or empty body from DELETE)

--- a/frontend/src/lib/guardian-helpers.ts
+++ b/frontend/src/lib/guardian-helpers.ts
@@ -103,6 +103,34 @@ export interface GuardianFormData {
   notes?: string;
 }
 
+// Snake-case guardian payload sent together with a new student to
+// POST /api/students (backend `GuardianInput`). Used when creating a child and
+// its guardians in one atomic request, mirroring the guardian fields managed on
+// the student detail page.
+export interface StudentGuardianPayload {
+  first_name: string;
+  last_name: string;
+  email?: string;
+  address_street?: string;
+  address_city?: string;
+  address_postal_code?: string;
+  preferred_contact_method?: string;
+  language_preference?: string;
+  notes?: string;
+  relationship_type: string;
+  is_primary: boolean;
+  is_emergency_contact: boolean;
+  can_pickup: boolean;
+  pickup_notes?: string;
+  emergency_priority: number;
+  phone_numbers: Array<{
+    phone_number: string;
+    phone_type: PhoneType;
+    label?: string;
+    is_primary: boolean;
+  }>;
+}
+
 // Backend Guardian Create Request
 // preferred_contact_method and language_preference are optional — the backend
 // applies its own defaults ("phone" and "de") when omitted.

--- a/frontend/src/lib/student-form-validation.test.ts
+++ b/frontend/src/lib/student-form-validation.test.ts
@@ -286,6 +286,55 @@ describe("handleStudentFormSubmit", () => {
     });
   });
 
+  it("surfaces a 4xx backend validation message to the user", async () => {
+    // Atomic student+guardian create (#1500): a duplicate guardian email comes
+    // back as an HTTP 400 with a user-facing German message. The status is
+    // attached by the CRUD service's fetch layer. The user must see the real
+    // reason, since a retry won't fix it.
+    mockValidateForm.mockReturnValue(true);
+    const error = new Error(
+      'Erziehungsberechtigte/r 1: E-Mail-Adresse "a@b.de" ist bereits vergeben',
+    ) as Error & { status?: number };
+    error.status = 400;
+    mockOnSubmit.mockRejectedValue(error);
+
+    await handleStudentFormSubmit(
+      mockEvent as unknown as React.FormEvent,
+      {},
+      mockValidateForm,
+      mockOnSubmit,
+      mockSetLoading,
+      mockSetErrors,
+    );
+
+    expect(mockSetErrors).toHaveBeenCalledWith({
+      submit:
+        'Erziehungsberechtigte/r 1: E-Mail-Adresse "a@b.de" ist bereits vergeben',
+    });
+  });
+
+  it("keeps a 5xx server error generic (no technical leak)", async () => {
+    mockValidateForm.mockReturnValue(true);
+    const error = new Error("API error: 500 - boom") as Error & {
+      status?: number;
+    };
+    error.status = 500;
+    mockOnSubmit.mockRejectedValue(error);
+
+    await handleStudentFormSubmit(
+      mockEvent as unknown as React.FormEvent,
+      {},
+      mockValidateForm,
+      mockOnSubmit,
+      mockSetLoading,
+      mockSetErrors,
+    );
+
+    expect(mockSetErrors).toHaveBeenCalledWith({
+      submit: "Fehler beim Speichern. Bitte versuchen Sie es erneut.",
+    });
+  });
+
   it("always sets loading to false in finally block", async () => {
     mockValidateForm.mockReturnValue(true);
     mockOnSubmit.mockRejectedValue(new Error("Test error"));

--- a/frontend/src/lib/student-form-validation.ts
+++ b/frontend/src/lib/student-form-validation.ts
@@ -8,6 +8,39 @@ import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "StudentFormValidation" });
 
+const GENERIC_SUBMIT_ERROR =
+  "Fehler beim Speichern. Bitte versuchen Sie es erneut.";
+
+/**
+ * Picks the message to show in the form's submit-error box.
+ *
+ * Backend validation failures (HTTP 4xx) carry a user-facing German message —
+ * e.g. a guardian's email already exists or an invalid relationship type from
+ * the atomic student+guardian create flow (#1500). Those must reach the user,
+ * because a retry won't fix them. Network/server errors (5xx) and untyped
+ * errors stay generic: surfacing "Network error" or "API error: 500" is noise.
+ *
+ * The HTTP status is attached by the CRUD service's fetch layer
+ * (`createCrudService`); an error without a numeric `status` is treated as
+ * technical and gets the generic message.
+ */
+function toSubmitErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const status = (error as { status?: number }).status;
+    const message = error.message.trim();
+    if (
+      typeof status === "number" &&
+      status >= 400 &&
+      status < 500 &&
+      message !== "" &&
+      !message.startsWith("API error")
+    ) {
+      return message;
+    }
+  }
+  return GENERIC_SUBMIT_ERROR;
+}
+
 /**
  * Validates data retention days field
  * @param retentionDays - The retention days value to validate
@@ -89,9 +122,7 @@ export async function handleStudentFormSubmit(
     await onSubmit(formData);
   } catch (error) {
     logger.error("error saving student", { error: String(error) });
-    setErrors({
-      submit: "Fehler beim Speichern. Bitte versuchen Sie es erneut.",
-    });
+    setErrors({ submit: toSubmitErrorMessage(error) });
   } finally {
     setLoading(false);
   }

--- a/frontend/src/lib/student-request-helpers.test.ts
+++ b/frontend/src/lib/student-request-helpers.test.ts
@@ -241,6 +241,61 @@ describe("buildBackendStudentRequest", () => {
     });
   });
 
+  it("passes guardians through for atomic creation", () => {
+    const validated = {
+      firstName: "Max",
+      lastName: "Mustermann",
+      schoolClass: "1a",
+    };
+    const guardians = [
+      {
+        first_name: "Erika",
+        last_name: "Muster",
+        relationship_type: "parent",
+        is_primary: true,
+        is_emergency_contact: false,
+        can_pickup: true,
+        emergency_priority: 1,
+        phone_numbers: [
+          {
+            phone_number: "0151 2345678",
+            phone_type: "mobile" as const,
+            is_primary: true,
+          },
+        ],
+      },
+    ];
+    const body = {
+      first_name: "Max",
+      second_name: "Mustermann",
+      school_class: "1a",
+      guardians,
+    };
+    const guardianContact = { email: undefined, phone: undefined };
+
+    const result = buildBackendStudentRequest(validated, body, guardianContact);
+
+    expect(result.guardians).toEqual(guardians);
+  });
+
+  it("omits guardians when none are provided", () => {
+    const validated = {
+      firstName: "Max",
+      lastName: "Mustermann",
+      schoolClass: "1a",
+    };
+    const body = {
+      first_name: "Max",
+      second_name: "Mustermann",
+      school_class: "1a",
+    };
+    const guardianContact = { email: undefined, phone: undefined };
+
+    const result = buildBackendStudentRequest(validated, body, guardianContact);
+
+    expect(result.guardians).toBeUndefined();
+  });
+
   it("includes tag_id when provided", () => {
     const validated = {
       firstName: "Max",

--- a/frontend/src/lib/student-request-helpers.ts
+++ b/frontend/src/lib/student-request-helpers.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Student } from "~/lib/student-helpers";
+import type { StudentGuardianPayload } from "~/lib/guardian-helpers";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "StudentRequestHelpers" });
@@ -31,6 +32,8 @@ interface BackendStudentRequest {
   guardian_contact?: string;
   guardian_email?: string;
   guardian_phone?: string;
+  // Guardians created atomically with the student (guardian_profiles system).
+  guardians?: StudentGuardianPayload[];
 }
 
 /**
@@ -134,6 +137,7 @@ export function buildBackendStudentRequest(
   body: Partial<Student> & {
     guardian_email?: string;
     guardian_phone?: string;
+    guardians?: StudentGuardianPayload[];
   },
   guardianContact: GuardianContact,
 ): BackendStudentRequest {
@@ -171,6 +175,11 @@ export function buildBackendStudentRequest(
   if (guardianContact.phone || backendData.guardian_phone) {
     request.guardian_phone =
       guardianContact.phone ?? backendData.guardian_phone;
+  }
+
+  // Pass through guardians (guardian_profiles system) for atomic creation.
+  if (body.guardians && body.guardians.length > 0) {
+    request.guardians = body.guardians;
   }
 
   return request;


### PR DESCRIPTION
## Summary

Adds the ability to create **guardians (Erziehungsberechtigte) directly while creating a child** in `Datenverwaltung > Kinder`, instead of the old two-step workflow (save child → open detail page → add guardians). Child and guardians are persisted **atomically in one request**.

Implements the **feature part** of #1500.

## What it does

- The student creation modal now has an **Erziehungsberechtigte** section. Staff/admins can add one or more guardians (profile + relationship + phone numbers) before saving the child.
- The form **reuses the existing `GuardianFormModal`** (`mode="create"`) — the same component used on the child detail page — so guardian fields match the detail-page management by construction (no rebuild, no field drift).
- On submit, child + all guardians are created **in a single tenant transaction**. Any guardian failure rolls the whole thing back, so there are never orphaned child records.

## How it works

**Backend**
- New `GuardianService.AddGuardiansToStudent(ctx, studentID, guardians)` — creates each guardian profile, links it to the student, and adds phone numbers, reusing `CreateGuardian` / `LinkGuardianToStudent` / `AddPhoneNumber` (all join the ambient tenant tx, so tenant scoping + linking behavior are unchanged).
- The `createStudent` handler runs guardian creation inside the existing `WithTenantTx`. Bad guardian input is classified as a `ValidationError` → **HTTP 400 with a German message** (not a generic 500); everything else rolls back atomically.
- Request DTO gains an optional `guardians[]` field; `Bind` requires `relationship_type` (the field needed to link). Email / contact-method / phone-format rules are enforced via the shared model `Validate()` at the service boundary.

**Frontend**
- `StudentCreateModal`: collects guardians into local state, renders a summary list (name, relationship label, pickup/emergency/primary flags) with add/remove, and ships them in the create payload — **no per-guardian API calls**, all persisted with the child.
- `toGuardianPayloads` maps the camelCase form entries to the snake_case backend contract.
- `buildBackendStudentRequest` / students page pass `guardians[]` through to `service.create`.

## Acceptance criteria (#1500)

- [x] A child can be manually created with guardian information in one flow
- [x] Validation errors for child **and** guardian fields are shown clearly before save (child: client-side `validateStudentForm`; guardian: backend `ValidationError` → 400 German message surfaced in the modal error box)
- [x] Existing child detail guardian editing remains functional (detail path untouched — same service methods reused)
- [x] `cd frontend && pnpm run check` passes (oxlint + tsc clean)
- [x] Relevant backend tests added (API behavior changed)

## Partially solved / known limitation

- **Sibling / duplicate guardian (same email):** if a guardian's email already exists in the tenant (e.g. the same parent for a second child), `CreateGuardian` hits the `UNIQUE(tenant_id, email)` constraint → the request currently returns **500 and rolls back the child**. The detail page has the same underlying behavior, but the atomic create flow makes the consequence more visible (child not created).
  - **Deferred to a follow-up issue** (reuse-existing-guardian-by-email, mirroring `resolveGuardianProfile` in the enrollment decision service). Not an acceptance criterion of #1500.

## Explicitly out of scope

- **Onboarding/Anleitung update.** The issue notes the manual guide should stop telling users to "save first, add guardians later." That documentation change is **not** part of this PR and belongs in the separate Anleitung task.
- **Any change to the child detail guardian flow** — left fully intact.

## Testing

- **Backend** (`api/students`, `services/users`): happy path, multi-guardian batch, optional-field mapping (address/notes/pickup/emergency), missing `relationship_type` → 400, invalid contact method / empty phone / <3 digits → 400 + rollback, unknown phone type coerced to mobile, and a unit test covering all `germanGuardianValidationMessage` branches. Hermetic; `TestHermeticTestPatterns` passes.
- **Frontend**: submit forwards snake_case-mapped guardians (and omits the field when none added), `buildBackendStudentRequest` passthrough, students-page re-attach through `transformBeforeSubmit`.
- **New-code coverage:** backend **93.1%**, frontend **91.9%** (both ≥ 85% target). Remaining gaps are defensive error-wraps and pre-existing reindented UI wiring.

## Risk / cross-repo

- No IoT/`/api/iot/*` endpoints, auth headers, or error contracts changed → **no PyrePortal impact**.
- Tenant scoping and guardian linking unchanged (same service methods, same `tenant_id` wiring).
