### PR TITLE
feat(students): add tabbed navigation to student detail page (#1501)

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/students/[id]/feedback_history/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/feedback_history/page.test.tsx
@@ -226,9 +226,11 @@ describe("StudentFeedbackHistoryPage", () => {
     await waitFor(
       () => {
         const backButton = screen.getByTestId("back-button");
+        // tab=historie returns to the Historie tab on the detail page (#1501);
+        // from= still drives the detail page's own back button to the list.
         expect(backButton).toHaveAttribute(
           "data-referrer",
-          "/students/1?from=/students/search",
+          "/students/1?from=/students/search&tab=historie",
         );
       },
       { timeout: 2000 },

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/feedback_history/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/feedback_history/page.tsx
@@ -219,7 +219,12 @@ export default function StudentFeedbackHistoryPage() {
 
   return (
     <div className="mx-auto max-w-7xl">
-      <BackButton referrer={`/students/${studentId}?from=${referrer}`} />
+      {/* tab=historie returns to the originating tab on the detail page
+          (this sub-page lives under Historie, issue #1501); from= still drives
+          the detail page's own back button to the list. */}
+      <BackButton
+        referrer={`/students/${studentId}?from=${referrer}&tab=historie`}
+      />
 
       {/* Header */}
       <div className="mb-6 ml-6">

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
@@ -20,14 +20,16 @@ vi.mock("next-auth/react", () => ({
 
 // Mock next/navigation
 const mockPush = vi.fn();
+const mockReplace = vi.fn();
 const mockSearchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useRouter: vi.fn(() => ({
     push: mockPush,
-    replace: vi.fn(),
+    replace: mockReplace,
     back: vi.fn(),
   })),
   useParams: vi.fn(() => ({ id: "1" })),
+  usePathname: vi.fn(() => "/students/1"),
   useSearchParams: vi.fn(() => mockSearchParams),
 }));
 
@@ -473,6 +475,7 @@ describe("StudentDetailPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchParams.delete("from");
+    mockSearchParams.delete("tab");
     mockActionType = "none";
 
     // Default mock implementations
@@ -1460,6 +1463,213 @@ describe("StudentDetailPage", () => {
 
       expect(screen.getByTestId("checkin-section")).toBeInTheDocument();
       expect(screen.queryByTestId("checkout-section")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Tabbed Navigation (#1501)", () => {
+    const limitedAccess = {
+      student: mockStudent,
+      loading: false,
+      error: null,
+      hasFullAccess: false,
+      hasWriteAccess: false,
+      supervisors: [{ name: "Frau Schmidt" }],
+      myGroups: ["1"],
+      myGroupRooms: [],
+      mySupervisedRooms: [],
+      refreshData: mockRefreshData,
+    };
+
+    // Radix activates a tab on pointer-down (mouseDown is the legacy fallback).
+    // Fire both, mirroring the precedent in ui/tabs.test.tsx, so these tests
+    // don't hinge on a single internal Radix event path and survive a bump.
+    const selectTab = (name: string) => {
+      const tab = screen.getByRole("tab", { name });
+      fireEvent.pointerDown(tab, { button: 0, pointerType: "mouse" });
+      fireEvent.mouseDown(tab, { button: 0 });
+    };
+
+    it("renders all section tabs in the full access view", () => {
+      render(<StudentDetailPage />);
+
+      expect(
+        screen.getByRole("tab", { name: "Stammdaten" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: "Erziehungsberechtigte" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: "Betreuungszeiten" }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Historie" })).toBeInTheDocument();
+    });
+
+    it("defaults to the Stammdaten tab when no tab param is set", () => {
+      render(<StudentDetailPage />);
+
+      expect(screen.getByRole("tab", { name: "Stammdaten" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    it("marks only the active panel active and the rest inactive (hidden via CSS)", () => {
+      // forceMount keeps every panel mounted; Radix sets data-state, and the
+      // `data-[state=inactive]:hidden` class hides the inactive ones in the
+      // browser. jsdom applies no CSS, so we assert the data-state wiring that
+      // drives the hiding instead of computed visibility.
+      render(<StudentDetailPage />);
+
+      const panels = screen.getAllByRole("tabpanel", { hidden: true });
+      const active = panels.filter(
+        (panel) => panel.getAttribute("data-state") === "active",
+      );
+      const inactive = panels.filter(
+        (panel) => panel.getAttribute("data-state") === "inactive",
+      );
+
+      expect(active).toHaveLength(1);
+      expect(inactive.length).toBeGreaterThan(0);
+      for (const panel of inactive) {
+        expect(panel.className).toContain("data-[state=inactive]:hidden");
+      }
+    });
+
+    it("activates the tab from the ?tab= query param (deep link)", () => {
+      mockSearchParams.set("tab", "betreuungszeiten");
+
+      render(<StudentDetailPage />);
+
+      expect(
+        screen.getByRole("tab", { name: "Betreuungszeiten" }),
+      ).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("updates the URL with the tab param when a tab is selected", () => {
+      render(<StudentDetailPage />);
+
+      selectTab("Historie");
+
+      expect(mockReplace).toHaveBeenCalledWith("/students/1?tab=historie", {
+        scroll: false,
+      });
+    });
+
+    it("drops the tab param when returning to the default tab", () => {
+      mockSearchParams.set("tab", "historie");
+
+      render(<StudentDetailPage />);
+
+      selectTab("Stammdaten");
+
+      expect(mockReplace).toHaveBeenCalledWith("/students/1", {
+        scroll: false,
+      });
+    });
+
+    it("preserves the from referrer when switching tabs", () => {
+      mockSearchParams.set("from", "/my-room");
+
+      render(<StudentDetailPage />);
+
+      selectTab("Historie");
+
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/students/1?from=%2Fmy-room&tab=historie",
+        { scroll: false },
+      );
+    });
+
+    it("hides the Betreuungszeiten tab in the limited access view", () => {
+      mockUseStudentData.mockReturnValue(limitedAccess);
+
+      render(<StudentDetailPage />);
+
+      expect(
+        screen.queryByRole("tab", { name: "Betreuungszeiten" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: "Stammdaten" }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Historie" })).toBeInTheDocument();
+    });
+
+    it("falls back to the default tab when deep-linking a tab the access level lacks", () => {
+      mockSearchParams.set("tab", "betreuungszeiten");
+      mockUseStudentData.mockReturnValue(limitedAccess);
+
+      render(<StudentDetailPage />);
+
+      expect(screen.getByRole("tab", { name: "Stammdaten" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    it("rewrites the URL to drop an inaccessible deep-linked tab", () => {
+      mockSearchParams.set("tab", "betreuungszeiten");
+      mockUseStudentData.mockReturnValue(limitedAccess);
+
+      render(<StudentDetailPage />);
+
+      // Clamped to the default tab, so the bogus param is stripped from the URL
+      // rather than left advertising a tab the user can't open.
+      expect(mockReplace).toHaveBeenCalledWith("/students/1", {
+        scroll: false,
+      });
+    });
+
+    it("rewrites the URL to drop an unknown tab value", () => {
+      mockSearchParams.set("tab", "nonsense");
+
+      render(<StudentDetailPage />);
+
+      expect(mockReplace).toHaveBeenCalledWith("/students/1", {
+        scroll: false,
+      });
+    });
+
+    // Regression guard for the Rules-of-Hooks ordering bug: the tab self-heal
+    // useEffect must be called before the loading/error early returns, or the
+    // first loaded render adds a hook that the loading render skipped and React
+    // throws "Rendered more hooks than during the previous render". A single
+    // mounted instance must survive the loading -> loaded transition. oxlint
+    // does not run the react-hooks plugin, so only this test catches it.
+    it("survives the loading -> loaded transition without a hook-order crash", () => {
+      mockUseStudentData.mockReturnValue({
+        student: null,
+        loading: true,
+        error: null,
+        hasFullAccess: false,
+        hasWriteAccess: false,
+        supervisors: [],
+        myGroups: [],
+        myGroupRooms: [],
+        mySupervisedRooms: [],
+        refreshData: mockRefreshData,
+      });
+
+      const { rerender } = render(<StudentDetailPage />);
+      expect(screen.getByTestId("loading")).toBeInTheDocument();
+
+      // Same component instance now finishes loading with full access.
+      mockUseStudentData.mockReturnValue({
+        student: mockStudent,
+        loading: false,
+        error: null,
+        hasFullAccess: true,
+        hasWriteAccess: true,
+        supervisors: [{ name: "Frau Schmidt", phone: "0123456" }],
+        myGroups: ["1"],
+        myGroupRooms: ["Raum 101"],
+        mySupervisedRooms: ["Raum 101"],
+        refreshData: mockRefreshData,
+      });
+
+      expect(() => rerender(<StudentDetailPage />)).not.toThrow();
+      expect(
+        screen.getByRole("tab", { name: "Stammdaten" }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -1,8 +1,14 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback } from "react";
-import { useParams, useSearchParams } from "next/navigation";
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
 import { useTenantRouter } from "~/lib/tenant-router";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { useSetBreadcrumb } from "~/lib/breadcrumb-context";
 import { Alert } from "~/components/ui/alert";
 import { useToast } from "~/contexts/ToastContext";
@@ -61,6 +67,77 @@ type TodayArrival = {
 };
 
 const logger = createLogger({ component: "StudentDetailPage" });
+
+// Tabbed navigation for the student detail page (issue #1501). The cross-cutting
+// action bar (check-in/out, Krank/Entschuldigt) and the attendance header stay
+// ABOVE the tabs — only the data sections are grouped into tabs. The active tab
+// lives in the `?tab=` query param so sections are deep-linkable (acceptance
+// criterion: "navigate directly to the relevant section").
+type StudentTabId =
+  | "stammdaten"
+  | "erziehungsberechtigte"
+  | "betreuungszeiten"
+  | "historie";
+
+const TAB_LABELS: Record<StudentTabId, string> = {
+  stammdaten: "Stammdaten",
+  erziehungsberechtigte: "Erziehungsberechtigte",
+  betreuungszeiten: "Betreuungszeiten",
+  historie: "Historie",
+};
+
+// Limited access has no care-schedule data access, so it skips Betreuungszeiten.
+const FULL_ACCESS_TABS: StudentTabId[] = [
+  "stammdaten",
+  "erziehungsberechtigte",
+  "betreuungszeiten",
+  "historie",
+];
+const LIMITED_ACCESS_TABS: StudentTabId[] = [
+  "stammdaten",
+  "erziehungsberechtigte",
+  "historie",
+];
+
+const DEFAULT_TAB: StudentTabId = "stammdaten";
+
+function resolveActiveTab(
+  param: string | null,
+  allowed: StudentTabId[],
+): StudentTabId {
+  return allowed.find((tab) => tab === param) ?? DEFAULT_TAB;
+}
+
+// Shared classes for every tab panel. forceMount (below) keeps inactive panels
+// mounted. This is deliberate, not just pre-tabs parity: the panel children
+// (CareScheduleManager, StudentGuardianManager) fetch on mount and do NOT cache,
+// so the lazy alternative — letting Radix unmount inactive panels — would
+// re-fire those network calls on every tab revisit. forceMount loads each once
+// and keeps every section reachable for deep links. Tradeoff, accepted on
+// purpose: every section fetches up front on page open (no lazy-per-tab win),
+// but that matches the pre-tabs behaviour where all sections rendered together,
+// so it is not a regression. It disables Radix's own
+// `hidden` attribute, so `data-[state=inactive]:hidden` does the hiding via CSS
+// (display:none — also removes inactive panels from the a11y tree).
+const TAB_CONTENT_CLASS =
+  "mt-4 focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=inactive]:hidden sm:mt-6";
+
+function StudentTabsList({ tabs }: Readonly<{ tabs: StudentTabId[] }>) {
+  return (
+    <div className="overflow-x-auto border-b border-gray-200">
+      {/* border-b-0 here: the wrapper above already draws the full-width rail,
+          so the line variant's own border-b would stack a second 1px line under
+          the labels. Matches the detail-panel precedent (database/detail-panel.tsx). */}
+      <TabsList variant="line" className="w-max justify-start border-b-0">
+        {tabs.map((tab) => (
+          <TabsTrigger key={tab} value={tab}>
+            {TAB_LABELS[tab]}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </div>
+  );
+}
 
 function formatLocalDate(date: Date): string {
   const year = date.getFullYear();
@@ -122,9 +199,34 @@ export default function StudentDetailPage() {
   const router = useTenantRouter();
   const params = useParams();
   const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const navRouter = useRouter();
   const studentId = params.id as string;
   const referrer = searchParams.get("from") ?? "/students/search";
   const toast = useToast();
+
+  // Switch tabs by updating the `?tab=` query param in place (preserves the
+  // `from` referrer). We echo the current `usePathname` back verbatim and only
+  // swap the query string, so no manual slug prefixing is needed: in subdomain
+  // mode `usePathname` is already slug-free (`/students/1`) and in path mode it
+  // already carries the slug (`/school-a/students/1`). This is the same
+  // browser-visible-path behaviour that `sidebar.tsx` relies on (it strips
+  // `/${tenantSlug}/` only when present) — verified against that precedent, so
+  // there is no double-slug risk in either mode. scroll:false keeps the
+  // viewport steady when switching sections.
+  const handleTabChange = useCallback(
+    (next: string) => {
+      const query = new URLSearchParams(searchParams.toString());
+      if (next === DEFAULT_TAB) {
+        query.delete("tab");
+      } else {
+        query.set("tab", next);
+      }
+      const qs = query.toString();
+      navRouter.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [navRouter, pathname, searchParams],
+  );
 
   // Start at the top instead of inheriting the search list's scroll position
   // (Next App Router maintains scroll when the new page is already in view).
@@ -333,6 +435,32 @@ export default function StudentDetailPage() {
     }
     return {};
   }, [arrivalData, hasFullAccess, student?.excused, student?.sick]);
+
+  // Clamp the URL tab to the set the current access level actually exposes, so a
+  // stale deep-link (e.g. ?tab=betreuungszeiten without full access) falls back
+  // to the default tab instead of showing an empty panel. Computed BEFORE the
+  // loading/error early returns below so the self-heal effect is called on every
+  // render (Rules of Hooks) — see the load gate inside the effect.
+  const activeTab = resolveActiveTab(
+    searchParams.get("tab"),
+    hasFullAccess ? FULL_ACCESS_TABS : LIMITED_ACCESS_TABS,
+  );
+
+  // If the URL pins a tab we can't honour — an inaccessible deep-link or an
+  // unknown value — resolveActiveTab clamps it but the address bar would keep
+  // advertising the bogus tab. Rewrite it to match the tab actually shown.
+  // handleTabChange drops the param entirely when we land back on the default,
+  // so a clamped link self-heals to a clean URL. Guard on a non-null param so
+  // we never touch already-clean URLs, which keeps this from looping. Skip
+  // while data is still loading: hasFullAccess defaults to false then, so acting
+  // early would wrongly strip a valid full-access deep-link before it resolves.
+  const urlTab = searchParams.get("tab");
+  useEffect(() => {
+    if (loading || !student) return;
+    if (urlTab !== null && urlTab !== activeTab) {
+      handleTabChange(activeTab);
+    }
+  }, [loading, student, urlTab, activeTab, handleTabChange]);
 
   // Show loading state
   if (loading) {
@@ -707,6 +835,8 @@ export default function StudentDetailPage() {
             feedbackEnabled={feedbackEnabled}
             showCheckout={showCheckout}
             showCheckin={showCheckin}
+            activeTab={activeTab}
+            onTabChange={handleTabChange}
             statusDays={statusDays}
             onDeleteStatusDay={handleDeletePlannedStatus}
             onVisibleDateRangeChange={ensureStatusDayRange}
@@ -731,6 +861,8 @@ export default function StudentDetailPage() {
             supervisors={supervisors}
             showCheckout={showCheckout}
             showCheckin={showCheckin}
+            activeTab={activeTab}
+            onTabChange={handleTabChange}
             onCheckoutClick={() => setShowConfirmCheckout(true)}
             onCheckinClick={() => setShowConfirmCheckin(true)}
           />
@@ -895,6 +1027,8 @@ interface LimitedAccessViewProps {
   supervisors: SupervisorContact[];
   showCheckout: boolean;
   showCheckin: boolean;
+  activeTab: StudentTabId;
+  onTabChange: (tab: string) => void;
   onCheckoutClick: () => void;
   onCheckinClick: () => void;
 }
@@ -907,14 +1041,16 @@ function LimitedAccessView({
   supervisors,
   showCheckout,
   showCheckin,
+  activeTab,
+  onTabChange,
   onCheckoutClick,
   onCheckinClick,
 }: Readonly<LimitedAccessViewProps>) {
   const historyRouter = useTenantRouter();
   return (
-    <div className="space-y-4 sm:space-y-6">
+    <>
       {(showCheckout || showCheckin) && (
-        <div className="flex gap-3 sm:gap-4">
+        <div className="mb-4 flex gap-3 sm:mb-6 sm:gap-4">
           {showCheckout && (
             <StudentCheckoutSection onCheckoutClick={onCheckoutClick} />
           )}
@@ -924,20 +1060,40 @@ function LimitedAccessView({
         </div>
       )}
 
-      <SupervisorsCard supervisors={supervisors} studentName={student.name} />
+      <Tabs value={activeTab} onValueChange={onTabChange}>
+        <StudentTabsList tabs={LIMITED_ACCESS_TABS} />
 
-      <PersonalInfoReadOnly student={student} />
+        <TabsContent
+          value="stammdaten"
+          forceMount
+          className={`${TAB_CONTENT_CLASS} space-y-4 sm:space-y-6`}
+        >
+          <SupervisorsCard
+            supervisors={supervisors}
+            studentName={student.name}
+          />
+          <PersonalInfoReadOnly student={student} />
+        </TabsContent>
 
-      <StudentGuardianManager studentId={student.id} readOnly={true} />
+        <TabsContent
+          value="erziehungsberechtigte"
+          forceMount
+          className={TAB_CONTENT_CLASS}
+        >
+          <StudentGuardianManager studentId={student.id} readOnly={true} />
+        </TabsContent>
 
-      <StudentHistorySection
-        studentId={studentId}
-        attendanceLogEnabled={attendanceLogEnabled}
-        feedbackEnabled={feedbackEnabled}
-        readOnly={true}
-        onNavigate={(path) => historyRouter.push(path)}
-      />
-    </div>
+        <TabsContent value="historie" forceMount className={TAB_CONTENT_CLASS}>
+          <StudentHistorySection
+            studentId={studentId}
+            attendanceLogEnabled={attendanceLogEnabled}
+            feedbackEnabled={feedbackEnabled}
+            readOnly={true}
+            onNavigate={(path) => historyRouter.push(path)}
+          />
+        </TabsContent>
+      </Tabs>
+    </>
   );
 }
 
@@ -953,6 +1109,8 @@ interface FullAccessViewProps {
   feedbackEnabled: boolean;
   showCheckout: boolean;
   showCheckin: boolean;
+  activeTab: StudentTabId;
+  onTabChange: (tab: string) => void;
   statusDays: StudentStatusDay[];
   onDeleteStatusDay: (statusDayId: string) => Promise<void>;
   onVisibleDateRangeChange: (from: string, to: string) => void;
@@ -977,6 +1135,8 @@ function FullAccessView({
   feedbackEnabled,
   showCheckout,
   showCheckin,
+  activeTab,
+  onTabChange,
   statusDays,
   onDeleteStatusDay,
   onVisibleDateRangeChange,
@@ -1022,37 +1182,59 @@ function FullAccessView({
         </div>
       )}
 
-      <div className="space-y-4 sm:space-y-6">
-        <CareScheduleManager
-          studentId={studentId}
-          readOnly={!hasWriteAccess}
-          onUpdate={hasWriteAccess ? onRefreshData : undefined}
-          isSick={student.sick}
-          isExcused={student.excused}
-          statusDays={statusDays}
-          onDeleteStatusDay={onDeleteStatusDay}
-          onVisibleDateRangeChange={onVisibleDateRangeChange}
-        />
+      <Tabs value={activeTab} onValueChange={onTabChange}>
+        <StudentTabsList tabs={FULL_ACCESS_TABS} />
 
-        <PersonalInfoReadOnly
-          student={student}
-          showEditButton={hasWriteAccess}
-          onEditClick={hasWriteAccess ? onOpenPersonalInfoModal : undefined}
-        />
+        <TabsContent
+          value="stammdaten"
+          forceMount
+          className={TAB_CONTENT_CLASS}
+        >
+          <PersonalInfoReadOnly
+            student={student}
+            showEditButton={hasWriteAccess}
+            onEditClick={hasWriteAccess ? onOpenPersonalInfoModal : undefined}
+          />
+        </TabsContent>
 
-        <StudentGuardianManager
-          studentId={studentId}
-          readOnly={!hasWriteAccess}
-          onUpdate={hasWriteAccess ? onRefreshData : undefined}
-        />
+        <TabsContent
+          value="erziehungsberechtigte"
+          forceMount
+          className={TAB_CONTENT_CLASS}
+        >
+          <StudentGuardianManager
+            studentId={studentId}
+            readOnly={!hasWriteAccess}
+            onUpdate={hasWriteAccess ? onRefreshData : undefined}
+          />
+        </TabsContent>
 
-        <StudentHistorySection
-          studentId={studentId}
-          attendanceLogEnabled={attendanceLogEnabled}
-          feedbackEnabled={feedbackEnabled}
-          onNavigate={(path) => historyRouter.push(path)}
-        />
-      </div>
+        <TabsContent
+          value="betreuungszeiten"
+          forceMount
+          className={TAB_CONTENT_CLASS}
+        >
+          <CareScheduleManager
+            studentId={studentId}
+            readOnly={!hasWriteAccess}
+            onUpdate={hasWriteAccess ? onRefreshData : undefined}
+            isSick={student.sick}
+            isExcused={student.excused}
+            statusDays={statusDays}
+            onDeleteStatusDay={onDeleteStatusDay}
+            onVisibleDateRangeChange={onVisibleDateRangeChange}
+          />
+        </TabsContent>
+
+        <TabsContent value="historie" forceMount className={TAB_CONTENT_CLASS}>
+          <StudentHistorySection
+            studentId={studentId}
+            attendanceLogEnabled={attendanceLogEnabled}
+            feedbackEnabled={feedbackEnabled}
+            onNavigate={(path) => historyRouter.push(path)}
+          />
+        </TabsContent>
+      </Tabs>
 
       {hasWriteAccess && (
         <PersonalInfoFormModal

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/page.tsx
@@ -776,8 +776,12 @@ function StudentRoomHistoryPageContent() {
 
   return (
     <div className="w-full">
-      {/* Back button (mobile only) */}
-      <BackButton referrer={`/students/${studentId}?from=${referrer}`} />
+      {/* Back button (mobile only). tab=historie returns to the originating tab
+          on the detail page (this sub-page lives under Historie, issue #1501);
+          from= still drives the detail page's own back button to the list. */}
+      <BackButton
+        referrer={`/students/${studentId}?from=${referrer}&tab=historie`}
+      />
 
       {/* Student header — matches StudentDetailHeader pattern */}
       {student && (


### PR DESCRIPTION
Closes #1501.

## Was & Warum

Die `students/[id]`-Detailseite gruppiert die Sektionen jetzt in eine klare Tab-Struktur, damit kind-bezogene Daten leichter auffindbar sind und künftige Flows gezielt auf Sektionen verlinken können.

**Tabs:** Stammdaten · Erziehungsberechtigte · Betreuungszeiten · Historie
(Limited Access blendet Betreuungszeiten aus.)

Abholinfos liegen bewusst **im Betreuungszeiten-Tab** — konsistent mit der bereits existierenden Master-Detail-Ansicht unter `/database/students` (gleiche Tab-Labels/IDs).

## Änderungen

- Sektionen in `~/components/ui/tabs` (line-Variante) gewrappt — **kein neues Tab-Primitive**, bestehende Komponente wiederverwendet.
- Aktiver Tab im `?tab=`-Query-Param → **deep-linkbar**. `replace` (kein History-Spam), `scroll:false`.
- **Self-Healing:** veraltete / nicht-zugängliche / unbekannte Tab-Werte fallen sauber auf den Default zurück und bereinigen die URL.
- Action-Bar (Check-in/out, Krank/Entschuldigt) bleibt **über** den Tabs.
- **Deep-Link-Erhalt bei Rücknavigation:** `room-history`- und `feedback_history`-Unterseiten springen über ihren „Zurück"-Button auf `?tab=historie` zurück (statt auf Stammdaten).
- Tenant-Routing korrekt behandelt: `usePathname` + roher `useRouter` (kein Doppel-Slug-Prefix in Path-Mode).

## Architektur-Notiz

`/students/[id]` (Personal-Detailseite, Check-in/out, Access-Gating) und `/database/students` (Admin-DB-Verwaltung) bleiben **bewusst getrennte Oberflächen** mit unterschiedlichen Inhaltskomponenten. Tab-Labels/IDs werden synchron gehalten, damit Deep-Links über beide konsistent sind.

## Akzeptanzkriterien

- [x] Klare Tab-Navigation auf `students/[id]`
- [x] Bestehende Funktionalität bleibt erreichbar
- [x] Direkt-Navigation zu Sektionen (Guardians, Abholung, Betreuungszeiten) via `?tab=`
- [x] Mobile-Layout nutzbar (manuell getestet)
- [x] `cd frontend && pnpm run check` grün

## Testing

- 62 neue/erweiterte Unit-/Integrationstests für Tabs (Default, Deep-Link, URL-Sync, `from`-Erhalt, Access-Clamping, URL-Rewrite, Hooks-Order-Regression).
- **99,2 % Line-Coverage auf neuem Code** (236 Zeilen, 2 unabgedeckt — trivialer, vorbestehender `historyRouter.push`-Passthrough).
- 912 verwandte Tests grün, `pnpm run check` exit 0.