### PR TITLE
fix: portal mobile filter panel so it clears the bottom nav

### DIFF
--- a/frontend/src/components/ui/page-header/MobileFilterPanel.test.tsx
+++ b/frontend/src/components/ui/page-header/MobileFilterPanel.test.tsx
@@ -165,7 +165,7 @@ describe("MobileFilterPanel", () => {
     ];
 
     it("renders grid options in 2 columns", () => {
-      const { container } = render(
+      render(
         <MobileFilterPanel
           isOpen={true}
           onClose={mockOnClose}
@@ -173,7 +173,9 @@ describe("MobileFilterPanel", () => {
         />,
       );
 
-      const gridContainer = container.querySelector(".grid-cols-2");
+      // Panel is portaled to document.body, so query the document rather than
+      // the local render container.
+      const gridContainer = document.querySelector(".grid-cols-2");
       expect(gridContainer).toBeInTheDocument();
     });
 

--- a/frontend/src/components/ui/page-header/MobileFilterPanel.tsx
+++ b/frontend/src/components/ui/page-header/MobileFilterPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { createPortal } from "react-dom";
 import {
   normalizeFilterValues,
   type MobileFilterPanelProps,
@@ -181,7 +182,7 @@ export function MobileFilterPanel({
     }
   };
 
-  return (
+  const panel = (
     <>
       {/* Click-outside backdrop. Transparent so the page content stays
           visible behind it — Stripe / Linear pattern. The panel itself
@@ -203,7 +204,7 @@ export function MobileFilterPanel({
         role="dialog"
         aria-modal="true"
         aria-label="Filter"
-        className="fixed inset-x-3 bottom-3 z-50 max-h-[85vh] overflow-y-auto rounded-2xl border border-gray-200 bg-white p-4 shadow-xl md:inset-x-auto md:top-[6rem] md:right-4 md:bottom-auto md:max-h-[80vh] md:w-96"
+        className="fixed inset-x-3 bottom-24 z-50 max-h-[80vh] overflow-y-auto overscroll-contain rounded-2xl border border-gray-200 bg-white p-4 shadow-xl md:inset-x-auto md:top-[6rem] md:right-4 md:bottom-auto md:max-h-[80vh] md:w-96"
       >
         <div className="space-y-4">
           {filters.map((filter) => (
@@ -247,4 +248,14 @@ export function MobileFilterPanel({
       </div>
     </>
   );
+
+  // Portal to <body> so the panel escapes the page's `relative z-10` content
+  // stacking context (app-shell.tsx). Without this, the mobile bottom nav
+  // (fixed z-30 at the root) paints over the panel's z-50 and blocks the
+  // "Anwenden" button — z-index can't cross out of a nested stacking context.
+  if (typeof document !== "undefined") {
+    return createPortal(panel, document.body);
+  }
+
+  return panel;
 }


### PR DESCRIPTION
## What

The mobile filter panel was being painted over by the bottom navigation, which blocked the "Anwenden" button.

Root cause: the panel renders inside the page content's `relative z-10` stacking context (`app-shell.tsx`), while the bottom nav is a `fixed z-30` element at the shell root. A `z-index` inside a nested stacking context can't paint above an element outside it — so the panel's `z-50` lost to the nav's `z-30`.

## Fix

- Portal the panel to `document.body` so it escapes the `z-10` context and its `z-50` competes at the root level (guarded with `typeof document` for SSR).
- Re-anchor the mobile sheet (`bottom-3` → `bottom-24`) so it sits above the bottom nav, tighten max height (`85vh` → `80vh`), and add `overscroll-contain` to stop scroll-chaining to the body.

## Notes

- Side effect (intended): the click-outside backdrop now also covers the header, so tapping the header while the panel is open dismisses it — standard popover behavior.
- Tests: existing suite updated to query the portaled DOM; 25/25 pass. `pnpm run check` clean.

## Testing

Verified on a mobile viewport — panel clears the nav and "Anwenden" is tappable.