### PR TITLE
Make timetable setting opt-out

### DIFF
--- a/backend/database/migrations/001015098_make_timetable_enabled_opt_out.go
+++ b/backend/database/migrations/001015098_make_timetable_enabled_opt_out.go
@@ -1,0 +1,60 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	makeTimetableEnabledOptOutVersion     = "1.15.98"
+	makeTimetableEnabledOptOutDescription = "Make timetable feature opt-out by removing stale false overrides."
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     makeTimetableEnabledOptOutVersion,
+		Description: makeTimetableEnabledOptOutDescription,
+		DependsOn:   []string{configSettingValuesVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Migration 1.15.98: Making timetable.enabled opt-out...")
+
+			if _, err := db.NewRaw(`
+				WITH deleted AS (
+					DELETE FROM config.setting_values
+					WHERE setting_key = 'timetable.enabled'
+						AND value = 'false'::jsonb
+					RETURNING tenant_id, setting_key, value
+				)
+				INSERT INTO config.setting_audit (
+					tenant_id,
+					setting_key,
+					old_value,
+					new_value,
+					action,
+					changed_by
+				)
+				SELECT
+					tenant_id,
+					setting_key,
+					value,
+					NULL,
+					'reset',
+					NULL
+				FROM deleted;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed resetting stale timetable.enabled=false overrides: %w", err)
+			}
+
+			return nil
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Rolling back migration 1.15.98: no-op for timetable opt-out reset...")
+			return nil
+		},
+	)
+}

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -172,12 +172,11 @@ func TestTimetableSettings_Types(t *testing.T) {
 func TestTimetableSettings_Defaults(t *testing.T) {
 	enabledDef := config.GetDefinition("timetable.enabled")
 	require.NotNil(t, enabledDef)
-	assert.Equal(t, false, enabledDef.Default, "timetable must default to false")
+	assert.Equal(t, true, enabledDef.Default, "timetable must default to true so the feature is opt-out")
 
-	// Both the materialization and auto-start flags default to FALSE so that
-	// WP-B7 is a pure no-op until the consuming services (WP-B8 / B9) ship
-	// AND a tenant explicitly opts in. Regressing either of these defaults
-	// would silently activate incomplete features for every tenant.
+	// The top-level feature is opt-out, but materialization and auto-start stay
+	// opt-in so background writes and live activity transitions do not begin
+	// unless a tenant explicitly enables those behaviours.
 	matDef := config.GetDefinition("timetable.materialization_enabled")
 	require.NotNil(t, matDef)
 	assert.Equal(t, false, matDef.Default, "materialization must default to false")

--- a/backend/services/config/defaults/timetable.go
+++ b/backend/services/config/defaults/timetable.go
@@ -8,10 +8,10 @@ import (
 // template → instance materialization pipeline, the staff-facing auto-start
 // behaviour, and the GDPR retention window for completed/cancelled instances.
 //
-// Default values follow the RFC's §5.6 recommendations. In particular,
-// `materialization_enabled` and `auto_start_planned` both default to FALSE
-// so that WP-B7 is a pure no-op until the consuming services (WP-B8 / B9)
-// are shipped and a tenant explicitly opts in via the settings UI.
+// The top-level timetable feature is opt-out, so tenants see the navigation
+// entry and related settings unless they explicitly disable it. The automated
+// behaviours remain opt-in: `materialization_enabled` and `auto_start_planned`
+// both default to FALSE.
 //
 // The weekday option values match ISO 8601 numbering (1 = Monday … 7 = Sunday)
 // so they slot directly into time.Weekday comparisons after the usual +1 shift.
@@ -29,7 +29,7 @@ func init() {
 		Label:           "Stundenplan aktivieren",
 		Description:     "Zeigt den Stundenplan in der Navigation an und schaltet die passenden Einstellungen frei.",
 		Type:            config.FieldBoolean,
-		Default:         false,
+		Default:         true,
 		ReadPermission:  "config:read",
 		WritePermission: "config:update",
 		Tab:             "operations",


### PR DESCRIPTION
## Summary
- make `timetable.enabled` default to `true` so Stundenplan is active by default
- keep materialization and auto-start opt-in
- add migration `1.15.98` to reset stale `timetable.enabled=false` overrides so existing opt-in-era customers also receive the new default

## Why
Stundenplan used to be opt-in. Flipping only the registry default would not affect tenants with a persisted `false` override, so the migration removes those stale overrides and records a reset audit entry. Tenants can still opt out afterward by disabling the setting again.

## Validation
- `cd backend && go test ./database/migrations ./services/config/... -v`
- pre-commit: git-secrets, go-imports
- pre-push: git-secrets, go-deadcode, go-vet, golangci-lint