### PR TITLE
feat: select existing guardian when creating/managing a student (#1513)

### DIFF
--- a/backend/api/guardians/api.go
+++ b/backend/api/guardians/api.go
@@ -65,6 +65,12 @@ func (rs *Resource) Router() chi.Router {
 		// Guardian profile CRUD operations
 		// Read operations require users:read permission
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/", rs.listGuardians)
+		// Guardian picker search (#1513): same users:read gate as the rest of the
+		// guardian reads, so anyone who can reach the student create/detail flows
+		// can link a sibling's existing guardian. Returns a minimal,
+		// enumeration-resistant projection (name, email, linked-children count) —
+		// see searchGuardiansForPicker.
+		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/search", rs.searchGuardiansForPicker)
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/{id}", rs.getGuardian)
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/without-account", rs.listGuardiansWithoutAccount)
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/invitable", rs.listInvitableGuardians)

--- a/backend/api/guardians/guardians_search_test.go
+++ b/backend/api/guardians/guardians_search_test.go
@@ -1,0 +1,362 @@
+package guardians_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+func strptr(s string) *string { return &s }
+
+// guardianSearchResponse is the envelope shape the guardian picker reads back
+// from GET /guardians/search. The projection is minimal and GDPR-safe: name,
+// email, and only a COUNT of other linked children — never child names.
+type guardianSearchResponse struct {
+	Data []struct {
+		ID                  int64   `json:"id"`
+		FirstName           string  `json:"first_name"`
+		LastName            string  `json:"last_name"`
+		Email               *string `json:"email"`
+		LinkedChildrenCount int     `json:"linked_children_count"`
+	} `json:"data"`
+}
+
+// seedSearchGuardian inserts a guardian profile in tenant 1 and registers its
+// cleanup. Names carry a caller-supplied unique token so search assertions stay
+// robust against any other data in the shared test database.
+func seedSearchGuardian(t *testing.T, tc *testContext, firstName, lastName, email string) *users.GuardianProfile {
+	t.Helper()
+	g := &users.GuardianProfile{
+		FirstName:              firstName,
+		LastName:               lastName,
+		Email:                  strptr(email),
+		PreferredContactMethod: "email",
+		LanguagePreference:     "de",
+	}
+	g.SetTenantID(1)
+	_, err := tc.db.NewInsert().Model(g).Exec(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { cleanupGuardian(t, tc.db, g.ID) })
+	return g
+}
+
+// TestListGuardians_SearchFiltersResults verifies ?search= actually filters by
+// name (case-insensitive substring) instead of returning every guardian.
+func TestListGuardians_SearchFiltersResults(t *testing.T) {
+	tc := setupTestContext(t)
+	defer func() { _ = tc.db.Close() }()
+
+	token := fmt.Sprintf("Zzmatch%d", time.Now().UnixNano())
+	match := seedSearchGuardian(t, tc, token, "Alpha", fmt.Sprintf("%s.match@example.com", token))
+	other := seedSearchGuardian(t, tc,
+		fmt.Sprintf("Zzother%d", time.Now().UnixNano()), "Beta",
+		fmt.Sprintf("other%d@example.com", time.Now().UnixNano()))
+
+	router := chi.NewRouter()
+	router.Get("/guardians/search", tc.resource.SearchGuardiansForPickerHandler())
+
+	req := testutil.NewAuthenticatedRequest(t, "GET", "/guardians/search?q="+token, nil,
+		testutil.WithClaims(testutil.DefaultTestClaims()),
+	)
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	var resp guardianSearchResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	var sawMatch, sawOther bool
+	for _, g := range resp.Data {
+		if g.ID == match.ID {
+			sawMatch = true
+		}
+		if g.ID == other.ID {
+			sawOther = true
+		}
+	}
+	assert.True(t, sawMatch, "search must return the guardian whose name contains the token")
+	assert.False(t, sawOther, "search must NOT return guardians that don't match the token")
+}
+
+// TestListGuardians_SearchMatchesFullNameWithSpace verifies a "First Last"
+// query (with a space) finds the guardian even though the first name and last
+// name live in different columns. A single full-string LIKE would match neither
+// column; the tokenized search matches each word against any column and AND-s
+// the words, so both "Andrea Bauer" and the reversed "Bauer Andrea" hit the
+// same person.
+func TestListGuardians_SearchMatchesFullNameWithSpace(t *testing.T) {
+	tc := setupTestContext(t)
+	defer func() { _ = tc.db.Close() }()
+
+	first := fmt.Sprintf("Zzfirst%d", time.Now().UnixNano())
+	last := fmt.Sprintf("Zzlast%d", time.Now().UnixNano())
+	match := seedSearchGuardian(t, tc, first, last, fmt.Sprintf("%s.full@example.com", first))
+
+	router := chi.NewRouter()
+	router.Get("/guardians/search", tc.resource.SearchGuardiansForPickerHandler())
+
+	for _, q := range []string{first + " " + last, last + " " + first} {
+		req := testutil.NewAuthenticatedRequest(t, "GET",
+			"/guardians/search?q="+url.QueryEscape(q), nil,
+			testutil.WithClaims(testutil.DefaultTestClaims()),
+		)
+		rr := testutil.ExecuteRequest(router, req)
+		testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+		var resp guardianSearchResponse
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+		var saw bool
+		for _, g := range resp.Data {
+			if g.ID == match.ID {
+				saw = true
+			}
+		}
+		assert.True(t, saw, "full-name query %q must find the guardian across first/last name columns", q)
+	}
+}
+
+// TestListGuardians_SearchWildcardsAreLiteral verifies LIKE metacharacters in
+// the query are matched literally, not as wildcards. A "%%%" query (3 chars, so
+// it clears the minimum-length guard) must NOT behave like LIKE '%%%%%' and
+// return the whole pool — otherwise a non-admin could defeat the enumeration
+// guard with raw wildcards (#1513).
+func TestListGuardians_SearchWildcardsAreLiteral(t *testing.T) {
+	tc := setupTestContext(t)
+	defer func() { _ = tc.db.Close() }()
+
+	token := fmt.Sprintf("Zzwild%d", time.Now().UnixNano())
+	seeded := seedSearchGuardian(t, tc, token, "Alpha", fmt.Sprintf("%s.wild@example.com", token))
+
+	router := chi.NewRouter()
+	router.Get("/guardians/search", tc.resource.SearchGuardiansForPickerHandler())
+
+	// "%%%" url-encoded. If wildcards were active this would match everything;
+	// treated literally it matches only a guardian whose name/email contains the
+	// literal string "%%%" (none do), so the seeded guardian must be absent.
+	req := testutil.NewAuthenticatedRequest(t, "GET", "/guardians/search?q=%25%25%25", nil,
+		testutil.WithClaims(testutil.DefaultTestClaims()),
+	)
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	var resp guardianSearchResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	for _, g := range resp.Data {
+		assert.NotEqual(t, seeded.ID, g.ID,
+			"a wildcard-only query must not match guardians via LIKE wildcards")
+	}
+}
+
+// TestListGuardians_SearchProjectionIsGDPRSafe verifies the picker projection
+// is minimal: it returns a COUNT of linked children (never their names), so a
+// staff member can't profile a family they don't supervise — address, notes,
+// language, and contact method are withheld too (#1513).
+func TestListGuardians_SearchProjectionIsGDPRSafe(t *testing.T) {
+	tc := setupTestContext(t)
+	defer func() { _ = tc.db.Close() }()
+
+	ctx := context.Background()
+	token := fmt.Sprintf("Zzlink%d", time.Now().UnixNano())
+	email := fmt.Sprintf("%s.parent@example.com", token)
+	guardian := seedSearchGuardian(t, tc, token, "Parent", email)
+
+	child := testpkg.CreateTestStudent(t, tc.db, "Lena", "Zzchild", "1a")
+	defer func() {
+		_, _ = tc.db.NewDelete().Table("users.students").Where("id = ?", child.ID).Exec(ctx)
+		_, _ = tc.db.NewDelete().Table("users.persons").Where("id = ?", child.PersonID).Exec(ctx)
+	}()
+
+	link := &users.StudentGuardian{
+		StudentID:         child.ID,
+		GuardianProfileID: guardian.ID,
+		RelationshipType:  "parent",
+		IsPrimary:         true,
+		EmergencyPriority: 1,
+	}
+	link.SetTenantID(1)
+	_, err := tc.db.NewInsert().Model(link).
+		ModelTableExpr(`users.students_guardians`).
+		Exec(ctx)
+	require.NoError(t, err)
+	// cleanupGuardian (registered by seedSearchGuardian) also removes the
+	// students_guardians link for this guardian.
+
+	router := chi.NewRouter()
+	router.Get("/guardians/search", tc.resource.SearchGuardiansForPickerHandler())
+
+	req := testutil.NewAuthenticatedRequest(t, "GET", "/guardians/search?q="+token, nil,
+		testutil.WithClaims(testutil.TeacherTestClaims(1)),
+		testutil.WithPermissions("users:read"),
+	)
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	var resp guardianSearchResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	var found bool
+	for _, g := range resp.Data {
+		if g.ID != guardian.ID {
+			continue
+		}
+		found = true
+		// Only the COUNT of linked children is exposed — never their names. This
+		// is the GDPR-relevant guarantee: the searcher learns a guardian has N
+		// other children, not who those children are.
+		assert.Equal(t, 1, g.LinkedChildrenCount, "the matched guardian must report its one linked child as a count")
+	}
+	require.True(t, found, "the seeded guardian must appear in the search results")
+}
+
+// pickerSearchRouter mounts the picker search behind its REAL route gate
+// (RequiresPermission(users:read)) + the tenant-tx middleware, exactly as
+// api.go wires it. RequiresPermission reads the permissions injected via
+// testutil.WithPermissions from context, so this exercises the actual gate
+// without needing a signed JWT.
+func pickerSearchRouter(tc *testContext) chi.Router {
+	withTx := tenant.TenantTxMiddleware(tc.db)
+	router := chi.NewRouter()
+	router.With(authorize.RequiresPermission(permissions.UsersRead), withTx).
+		Get("/guardians/search", tc.resource.SearchGuardiansForPickerHandler())
+	return router
+}
+
+// TestGuardianPickerSearch_AllowedForStaffWithUsersRead is the core of #1513:
+// the picker must be reachable by ordinary staff who manage students (the seeded
+// "user" role holds users:read), not just admins. Otherwise a group supervisor
+// can create a duplicate guardian but can't find the existing one — the exact
+// gap this feature closes. The gate matches the other guardian reads (users:read).
+func TestGuardianPickerSearch_AllowedForStaffWithUsersRead(t *testing.T) {
+	tc := setupTestContext(t)
+	defer func() { _ = tc.db.Close() }()
+
+	token := fmt.Sprintf("Zzperm%d", time.Now().UnixNano())
+	match := seedSearchGuardian(t, tc, token, "Alpha", fmt.Sprintf("%s.perm@example.com", token))
+
+	router := pickerSearchRouter(tc)
+
+	// An ordinary (non-admin) staff member holding users:read — no admin:*.
+	req := testutil.NewAuthenticatedRequest(t, "GET", "/guardians/search?q="+token, nil,
+		testutil.WithClaims(testutil.TeacherTestClaims(1)),
+		testutil.WithPermissions("users:read"),
+	)
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	var resp guardianSearchResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	var found bool
+	for _, g := range resp.Data {
+		if g.ID == match.ID {
+			found = true
+		}
+	}
+	assert.True(t, found, "a non-admin with users:read must be able to find an existing guardian")
+}
+
+// TestGuardianPickerSearch_ForbiddenWithoutUsersRead verifies the gate actually
+// bites: a caller holding neither users:read nor admin:* is rejected with 403
+// before the handler runs.
+func TestGuardianPickerSearch_ForbiddenWithoutUsersRead(t *testing.T) {
+	tc := setupTestContext(t)
+	defer func() { _ = tc.db.Close() }()
+
+	router := pickerSearchRouter(tc)
+
+	req := testutil.NewAuthenticatedRequest(t, "GET", "/guardians/search?q=anything", nil,
+		testutil.WithClaims(testutil.TeacherTestClaims(1)),
+		// Unrelated permission only — no users:read, no admin:*.
+		testutil.WithPermissions("groups:read"),
+	)
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertForbidden(t, rr)
+}
+
+// guardianSearchEnvelope decodes the pagination metadata of the picker search
+// response (the page_size the server actually applied), which the data-only
+// guardianSearchResponse ignores.
+type guardianSearchEnvelope struct {
+	Data       []json.RawMessage `json:"data"`
+	Pagination struct {
+		PageSize     int `json:"page_size"`
+		TotalRecords int `json:"total_records"`
+	} `json:"pagination"`
+}
+
+// TestGuardianPickerSearch_ShortQueryReturnsEmpty is a regression guard on the
+// enumeration defense: a query shorter than the server-side minimum
+// (minGuardianPickerQueryLength) must return an empty 200 page — never a 400 and
+// never the whole guardian pool. This keeps the picker (open to all staff with
+// users:read) from being walked one or two characters at a time, and keeps the
+// client's "type at least N characters" hint as the single source of truth (it
+// returns OK so the field doesn't flash an error while the user is still typing).
+func TestGuardianPickerSearch_ShortQueryReturnsEmpty(t *testing.T) {
+	tc := setupTestContext(t)
+	defer func() { _ = tc.db.Close() }()
+
+	// Seed a guardian whose name would match the 2-char prefix IF the guard were
+	// absent — proving the empty result is the guard firing, not just "no match".
+	token := fmt.Sprintf("Zzshort%d", time.Now().UnixNano())
+	seedSearchGuardian(t, tc, token, "Alpha", fmt.Sprintf("%s.short@example.com", token))
+
+	router := chi.NewRouter()
+	router.Get("/guardians/search", tc.resource.SearchGuardiansForPickerHandler())
+
+	// "Zz" — 2 chars, below the 3-char minimum.
+	req := testutil.NewAuthenticatedRequest(t, "GET", "/guardians/search?q=Zz", nil,
+		testutil.WithClaims(testutil.DefaultTestClaims()),
+	)
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	var resp guardianSearchEnvelope
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Data, "a sub-minimum query must return no candidates")
+	assert.Equal(t, 0, resp.Pagination.TotalRecords, "total must be zero for a sub-minimum query")
+}
+
+// TestGuardianPickerSearch_ClampsPageSize is a regression guard on the result
+// cap: common.ParsePagination imposes NO upper bound on page_size, so without the
+// handler's clamp a caller could pass ?page_size=100000 and pull most of the
+// tenant's guardian pool in one request, defeating the minimal projection. The
+// envelope must report the clamped page size (maxGuardianPickerResults = 50), not
+// the requested one.
+func TestGuardianPickerSearch_ClampsPageSize(t *testing.T) {
+	tc := setupTestContext(t)
+	defer func() { _ = tc.db.Close() }()
+
+	token := fmt.Sprintf("Zzclamp%d", time.Now().UnixNano())
+	seedSearchGuardian(t, tc, token, "Alpha", fmt.Sprintf("%s.clamp@example.com", token))
+
+	router := chi.NewRouter()
+	router.Get("/guardians/search", tc.resource.SearchGuardiansForPickerHandler())
+
+	req := testutil.NewAuthenticatedRequest(t, "GET",
+		"/guardians/search?q="+token+"&page_size=100000", nil,
+		testutil.WithClaims(testutil.DefaultTestClaims()),
+	)
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	var resp guardianSearchEnvelope
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, 50, resp.Pagination.PageSize,
+		"a request for page_size=100000 must be clamped to the 50-result ceiling")
+}

--- a/backend/api/guardians/handlers.go
+++ b/backend/api/guardians/handlers.go
@@ -57,6 +57,23 @@ type GuardianResponse struct {
 	AccountID              *int64                 `json:"account_id,omitempty"`
 }
 
+// GuardianPickerResponse is the MINIMAL, GDPR-safe projection returned by the
+// guardian picker search (GET /guardians/search). Unlike the admin guardian list
+// (full profiles) the projection here is deliberately the smallest thing that
+// still lets someone recognise a contact they already know — and nothing they
+// could use to profile a family they have no relationship to (#1513):
+//   - Only a COUNT of other linked children is returned, never their names —
+//     a guardian's other children belong to other families the searcher may
+//     not supervise. Full child names stay on the guardian detail view.
+//     Address, notes, language, contact method, account_id are all omitted.
+type GuardianPickerResponse struct {
+	ID                  int64   `json:"id"`
+	FirstName           string  `json:"first_name"`
+	LastName            string  `json:"last_name"`
+	Email               *string `json:"email,omitempty"`
+	LinkedChildrenCount int     `json:"linked_children_count"`
+}
+
 // GuardianCreateRequest represents a request to create a new guardian
 // Note: Phone numbers should be added separately via POST /guardians/{id}/phone-numbers
 type GuardianCreateRequest struct {
@@ -357,23 +374,21 @@ func (rs *Resource) canModifyGuardian(ctx context.Context, guardianID int64) (bo
 	return false, fmt.Errorf("you can only modify guardians for students in groups you supervise")
 }
 
-// listGuardians handles listing all guardians with pagination
+// listGuardians handles listing all guardians with pagination. This is the
+// admin (users:read) full-profile list. The picker search lives in its own
+// handler (searchGuardiansForPicker) with a lower gate + minimal projection.
 func (rs *Resource) listGuardians(w http.ResponseWriter, r *http.Request) {
-	// Create query options
-	queryOptions := base.NewQueryOptions()
-
-	// Add pagination
 	page, pageSize := common.ParsePagination(r)
+
+	queryOptions := base.NewQueryOptions()
 	queryOptions.WithPagination(page, pageSize)
 
-	// Get guardians
 	guardians, err := rs.GuardianService.ListGuardians(r.Context(), queryOptions)
 	if err != nil {
 		common.RenderError(w, r, common.ErrorInternalServer(err))
 		return
 	}
 
-	// Convert to response format
 	responses := make([]*GuardianResponse, 0, len(guardians))
 	for _, guardian := range guardians {
 		responses = append(responses, newGuardianResponse(guardian))
@@ -381,6 +396,71 @@ func (rs *Resource) listGuardians(w http.ResponseWriter, r *http.Request) {
 
 	// For now, return without total count (would need separate count query)
 	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: page, PageSize: pageSize, Total: len(responses)}, "Guardians retrieved successfully")
+}
+
+// minGuardianPickerQueryLength is the server-side floor for picker searches. It
+// mirrors the client minimum so a non-admin can't enumerate the guardian pool
+// one character at a time. It is a fixed data-protection guardrail, not a
+// per-school business rule, so it lives here rather than in the settings system.
+const minGuardianPickerQueryLength = 3
+
+// maxGuardianPickerResults caps how many matches a single picker search can
+// return. common.ParsePagination enforces NO upper bound on page_size, so
+// without this clamp a caller could pass ?q=ann&page_size=100000 and pull most
+// of the tenant's guardian pool (name + email + linked-children count) in one
+// request — defeating the minimal, enumeration-resistant projection. The picker
+// is a type-to-narrow lookup; a staff member never needs more than a screenful
+// of candidates, so 50 is the hard ceiling regardless of the requested
+// page_size. There is no OFFSET: the endpoint deliberately returns only this
+// first capped slice, not real pages.
+const maxGuardianPickerResults = 50
+
+// searchGuardiansForPicker backs the existing-guardian picker (#1513). It shares
+// the users:read gate with the other guardian reads, so anyone who can reach the
+// student create/detail flows can link a sibling's already-existing guardian
+// instead of creating a duplicate. The projection is deliberately minimal and
+// enumeration-resistant — name, email, and only a COUNT of other linked children
+// (see GuardianPickerResponse). A query shorter than minGuardianPickerQueryLength
+// returns an empty page rather than 400, so the client's "type at least N
+// characters" hint stays the single source of truth.
+func (rs *Resource) searchGuardiansForPicker(w http.ResponseWriter, r *http.Request) {
+	page, pageSize := common.ParsePagination(r)
+	search := strings.TrimSpace(r.URL.Query().Get("q"))
+
+	if len([]rune(search)) < minGuardianPickerQueryLength {
+		common.RespondPaginated(w, r, http.StatusOK, []*GuardianPickerResponse{}, common.PaginationParams{Page: page, PageSize: pageSize, Total: 0}, "Guardians retrieved successfully")
+		return
+	}
+
+	// Clamp the caller-supplied page_size to a hard ceiling — ParsePagination
+	// itself imposes no maximum.
+	limit := pageSize
+	if limit > maxGuardianPickerResults {
+		limit = maxGuardianPickerResults
+	}
+
+	matches, err := rs.GuardianService.SearchGuardiansForPicker(r.Context(), search, limit)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	responses := make([]*GuardianPickerResponse, 0, len(matches))
+	for _, m := range matches {
+		responses = append(responses, &GuardianPickerResponse{
+			ID:                  m.Profile.ID,
+			FirstName:           m.Profile.FirstName,
+			LastName:            m.Profile.LastName,
+			Email:               m.Profile.Email,
+			LinkedChildrenCount: len(m.Children),
+		})
+	}
+
+	// Report the clamped limit as the page size so the envelope reflects what
+	// was actually applied, not the (possibly larger) requested page_size. The
+	// endpoint returns a single capped slice with no OFFSET — there are no
+	// further pages to fetch — so Total is the size of this slice.
+	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: page, PageSize: limit, Total: len(responses)}, "Guardians retrieved successfully")
 }
 
 // getGuardian handles getting a guardian by ID
@@ -454,6 +534,16 @@ func (rs *Resource) createGuardian(w http.ResponseWriter, r *http.Request) {
 		guardian, txErr = rs.GuardianService.CreateGuardian(ctx, createReq)
 		return txErr
 	}); err != nil {
+		// A duplicate email (or other bad input) comes back as a ValidationError
+		// carrying a user-facing German message — render it as a 400 so the
+		// frontend surfaces "bereits vergeben – über die Suche auswählen"
+		// instead of the generic 500 catch-all. The tenant tx already rolled
+		// back, so no partial guardian survives.
+		var validationErr *guardianSvc.ValidationError
+		if errors.As(err, &validationErr) {
+			common.RenderError(w, r, common.ErrorInvalidRequest(validationErr))
+			return
+		}
 		common.RenderError(w, r, common.ErrorInternalServer(err))
 		return
 	}
@@ -1010,6 +1100,11 @@ func (rs *Resource) acceptGuardianInvitation(w http.ResponseWriter, r *http.Requ
 
 // ListGuardiansHandler returns the list guardians handler
 func (rs *Resource) ListGuardiansHandler() http.HandlerFunc { return rs.listGuardians }
+
+// SearchGuardiansForPickerHandler returns the guardian picker search handler.
+func (rs *Resource) SearchGuardiansForPickerHandler() http.HandlerFunc {
+	return rs.searchGuardiansForPicker
+}
 
 // GetGuardianHandler returns the get guardian handler
 func (rs *Resource) GetGuardianHandler() http.HandlerFunc { return rs.getGuardian }

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -782,7 +782,8 @@ func toNewStudentGuardians(inputs []GuardianInput) []userService.NewStudentGuard
 				PickupNotes:        optionalString(in.PickupNotes),
 				EmergencyPriority:  in.EmergencyPriority,
 			},
-			PhoneNumbers: toPhoneRequests(in.PhoneNumbers),
+			PhoneNumbers:      toPhoneRequests(in.PhoneNumbers),
+			ExistingProfileID: in.GuardianProfileID,
 		})
 	}
 	return out

--- a/backend/api/students/create_student_select_existing_test.go
+++ b/backend/api/students/create_student_select_existing_test.go
@@ -1,0 +1,255 @@
+package students_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// seedExistingGuardian inserts a guardian profile in tenant 1 and returns it,
+// registering its cleanup. Used by the select-existing (#1513) tests to stand in
+// for a sibling's already-existing guardian.
+func seedExistingGuardian(t *testing.T, tc *testContext, firstName, lastName, email string) *users.GuardianProfile {
+	t.Helper()
+	ctx := context.Background()
+
+	g := &users.GuardianProfile{
+		FirstName:              firstName,
+		LastName:               lastName,
+		Email:                  emailPtr(email),
+		PreferredContactMethod: "email",
+		LanguagePreference:     "de",
+	}
+	g.SetTenantID(1)
+	_, err := tc.db.NewInsert().Model(g).Exec(ctx)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if _, err := tc.db.NewDelete().
+			Table("users.guardian_profiles").
+			Where("id = ?", g.ID).
+			Exec(ctx); err != nil {
+			t.Logf("cleanup seeded guardian: %v", err)
+		}
+	})
+	return g
+}
+
+// TestCreateStudent_SelectExistingGuardian verifies the sibling case: a student
+// created with guardian_profile_id links the EXISTING profile (no new profile,
+// no mutation, no phone writes) and applies only the relationship flags.
+func TestCreateStudent_SelectExistingGuardian(t *testing.T) {
+	tc := setupTestContext(t)
+	ctx := context.Background()
+
+	existing := seedExistingGuardian(t, tc, "Sibling", "Parent", "sibling.parent.existing@example.com")
+
+	router := setupRouterUnderTenantTx(tc, tc.resource.CreateStudentHandler())
+
+	body := map[string]interface{}{
+		"first_name":   "Second",
+		"last_name":    "Child",
+		"school_class": "3a",
+		"guardians": []map[string]interface{}{
+			{
+				"guardian_profile_id":  existing.ID,
+				"relationship_type":    "parent",
+				"is_primary":           true,
+				"can_pickup":           true,
+				"is_emergency_contact": true,
+				"emergency_priority":   1,
+			},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+	require.Equal(t, http.StatusCreated, rr.Code, "Expected 201 Created. Body: %s", rr.Body.String())
+
+	var resp createStudentResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.NotZero(t, resp.Data.ID)
+	defer cleanupStudentWithGuardians(t, tc, resp.Data.ID, resp.Data.PersonID)
+
+	// Exactly one link, pointing at the EXISTING profile.
+	var linkedID int64
+	require.NoError(t, tc.db.NewSelect().
+		Table("users.students_guardians").
+		Column("guardian_profile_id").
+		Where("student_id = ?", resp.Data.ID).
+		Scan(ctx, &linkedID))
+	assert.Equal(t, existing.ID, linkedID, "link must target the existing profile, not a new one")
+
+	relCount, err := tc.db.NewSelect().
+		Table("users.students_guardians").
+		Where("student_id = ?", resp.Data.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, relCount, "exactly one student-guardian relationship")
+
+	// No duplicate profile was created for the same email.
+	profileCount, err := tc.db.NewSelect().
+		Table("users.guardian_profiles").
+		Where("email = ?", "sibling.parent.existing@example.com").
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, profileCount, "the existing profile must not be duplicated")
+
+	// The existing profile's own data is untouched.
+	var reloaded struct {
+		FirstName string  `bun:"first_name"`
+		LastName  string  `bun:"last_name"`
+		Email     *string `bun:"email"`
+	}
+	require.NoError(t, tc.db.NewSelect().
+		ColumnExpr("first_name, last_name, email").
+		Table("users.guardian_profiles").
+		Where("id = ?", existing.ID).
+		Scan(ctx, &reloaded))
+	assert.Equal(t, "Sibling", reloaded.FirstName, "existing first name must not be mutated")
+	assert.Equal(t, "Parent", reloaded.LastName, "existing last name must not be mutated")
+	require.NotNil(t, reloaded.Email)
+	assert.Equal(t, "sibling.parent.existing@example.com", *reloaded.Email, "existing email must not be mutated")
+
+	// No phone numbers were written against the existing profile.
+	phoneCount, err := tc.db.NewSelect().
+		Table("users.guardian_phone_numbers").
+		Where("guardian_profile_id = ?", existing.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, phoneCount, "linking an existing guardian must not write phone numbers")
+
+	// The relationship flags from the form were applied to the new link.
+	var rel struct {
+		RelationshipType string `bun:"relationship_type"`
+		IsPrimary        bool   `bun:"is_primary"`
+		CanPickup        bool   `bun:"can_pickup"`
+	}
+	require.NoError(t, tc.db.NewSelect().
+		ColumnExpr("relationship_type, is_primary, can_pickup").
+		Table("users.students_guardians").
+		Where("student_id = ?", resp.Data.ID).
+		Scan(ctx, &rel))
+	assert.Equal(t, "parent", rel.RelationshipType)
+	assert.True(t, rel.IsPrimary)
+	assert.True(t, rel.CanPickup)
+}
+
+// TestCreateStudent_SelectExistingGuardian_DuplicateSkipped verifies the same
+// existing guardian selected twice in one request yields a single link (the
+// duplicate is skipped silently), never a UNIQUE-constraint 500.
+func TestCreateStudent_SelectExistingGuardian_DuplicateSkipped(t *testing.T) {
+	tc := setupTestContext(t)
+	ctx := context.Background()
+
+	existing := seedExistingGuardian(t, tc, "Dup", "Selection", "dup.selection.existing@example.com")
+
+	router := setupRouterUnderTenantTx(tc, tc.resource.CreateStudentHandler())
+
+	body := map[string]interface{}{
+		"first_name":   "DupSelect",
+		"last_name":    "Child",
+		"school_class": "3b",
+		"guardians": []map[string]interface{}{
+			{"guardian_profile_id": existing.ID, "relationship_type": "parent", "emergency_priority": 1},
+			{"guardian_profile_id": existing.ID, "relationship_type": "guardian", "emergency_priority": 2},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+	require.Equal(t, http.StatusCreated, rr.Code, "Expected 201 Created. Body: %s", rr.Body.String())
+
+	var resp createStudentResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.NotZero(t, resp.Data.ID)
+	defer cleanupStudentWithGuardians(t, tc, resp.Data.ID, resp.Data.PersonID)
+
+	relCount, err := tc.db.NewSelect().
+		Table("users.students_guardians").
+		Where("student_id = ?", resp.Data.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, relCount, "the duplicate existing selection must be skipped, leaving exactly one link")
+}
+
+// TestCreateStudent_MixedNewAndExistingGuardian verifies one request can both
+// link an existing guardian and create a brand-new one in the same atomic write.
+func TestCreateStudent_MixedNewAndExistingGuardian(t *testing.T) {
+	tc := setupTestContext(t)
+	ctx := context.Background()
+
+	existing := seedExistingGuardian(t, tc, "Mixed", "Existing", "mixed.existing@example.com")
+
+	router := setupRouterUnderTenantTx(tc, tc.resource.CreateStudentHandler())
+
+	body := map[string]interface{}{
+		"first_name":   "Mixed",
+		"last_name":    "Child",
+		"school_class": "3c",
+		"guardians": []map[string]interface{}{
+			{"guardian_profile_id": existing.ID, "relationship_type": "parent", "is_primary": true, "emergency_priority": 1},
+			{
+				"first_name":         "Brand",
+				"last_name":          "New",
+				"email":              "brand.new.mixed@example.com",
+				"relationship_type":  "guardian",
+				"emergency_priority": 2,
+			},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+	require.Equal(t, http.StatusCreated, rr.Code, "Expected 201 Created. Body: %s", rr.Body.String())
+
+	var resp createStudentResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.NotZero(t, resp.Data.ID)
+	defer cleanupStudentWithGuardians(t, tc, resp.Data.ID, resp.Data.PersonID)
+
+	relCount, err := tc.db.NewSelect().
+		Table("users.students_guardians").
+		Where("student_id = ?", resp.Data.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, relCount, "both the existing link and the new guardian must be linked")
+
+	// The existing profile is linked alongside a freshly created one.
+	var existingLinks int
+	existingLinks, err = tc.db.NewSelect().
+		Table("users.students_guardians").
+		Where("student_id = ?", resp.Data.ID).
+		Where("guardian_profile_id = ?", existing.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, existingLinks, "the existing profile must be linked exactly once")
+}
+
+// TestCreateStudent_SelectExistingGuardian_NotFound verifies a guardian_profile_id
+// that does not exist (or belongs to another tenant — RLS makes it invisible) is
+// a clean 400, not a 500, and commits no orphaned student.
+func TestCreateStudent_SelectExistingGuardian_NotFound(t *testing.T) {
+	tc := setupTestContext(t)
+
+	const firstName = "GhostRef"
+	const lastName = "Orphan"
+
+	body := map[string]interface{}{
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"school_class": "3d",
+		"guardians": []map[string]interface{}{
+			{"guardian_profile_id": int64(999999999), "relationship_type": "parent", "emergency_priority": 1},
+		},
+	}
+
+	assertNoStudentCommittedUnderTenantTx(t, tc, firstName, lastName, body, "nicht gefunden")
+}

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -166,6 +166,13 @@ type GuardianPhoneInput struct {
 // created together with a new student. Mirrors the fields managed on the
 // student detail page's guardian form.
 type GuardianInput struct {
+	// GuardianProfileID, when set, links an EXISTING guardian profile to the
+	// new student instead of creating a new one (sibling case, issue #1513).
+	// When present the profile fields below (name, email, address, phone
+	// numbers) are ignored and the existing profile is never mutated — only the
+	// relationship flags apply to the new link.
+	GuardianProfileID *int64 `json:"guardian_profile_id,omitempty"`
+
 	// Profile
 	FirstName              string `json:"first_name"`
 	LastName               string `json:"last_name"`

--- a/backend/database/repositories/users/guardian_profile.go
+++ b/backend/database/repositories/users/guardian_profile.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -176,6 +177,83 @@ func (r *GuardianProfileRepository) ListWithOptions(ctx context.Context, options
 	err := query.Scan(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list guardian profiles: %w", err)
+	}
+
+	return profiles, nil
+}
+
+// escapeLikePattern escapes the LIKE metacharacters (\, %, _) in user-supplied
+// search text so they match literally instead of acting as wildcards. Without
+// this a caller could pass "%" or "___" to defeat the picker's minimum-query-
+// length guard and match the whole guardian pool (the picker is open to all
+// staff, not just admins — see searchGuardiansForPicker). The query pairs this
+// with an explicit ESCAPE '\' clause. Backslash is escaped first so the escapes
+// added for % and _ are not themselves re-escaped.
+func escapeLikePattern(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "%", `\%`)
+	s = strings.ReplaceAll(s, "_", `\_`)
+	return s
+}
+
+// maxSearchTokens bounds how many whitespace-separated terms a single picker
+// search expands into, so a pathological query ("a b c d e …") can't build an
+// unbounded WHERE clause. A real name search never needs more than a handful.
+const maxSearchTokens = 10
+
+// SearchByText retrieves guardian profiles matching the search text
+// (case-insensitive substring across first name, last name, and email). Tenant
+// isolation is enforced by RLS on the ambient tenant transaction (the endpoint
+// runs under TenantTxMiddleware), mirroring the other read methods on this
+// repository. Results are capped by limit so the guardian picker payload stays
+// small.
+//
+// The search text is split into whitespace-separated tokens; EACH token must
+// match at least one column, and ALL tokens must match (AND). This is what makes
+// a full-name query like "Andrea Bauer" work even though "Andrea" lives in
+// first_name and "Bauer" in last_name — a single full-string LIKE would match
+// neither column and return nothing. Token order is irrelevant, so "Bauer
+// Andrea" matches the same person.
+//
+// LIKE metacharacters in each token are escaped (see escapeLikePattern) so they
+// match literally — the picker's enumeration guard relies on a real minimum
+// query length, which raw "%"/"_" input would otherwise bypass.
+func (r *GuardianProfileRepository) SearchByText(ctx context.Context, searchText string, limit int) ([]*users.GuardianProfile, error) {
+	// strings.Fields splits on any run of whitespace and drops empties, so a
+	// query that is only spaces yields no tokens → empty result.
+	tokens := strings.Fields(strings.ToLower(searchText))
+	if len(tokens) == 0 {
+		return []*users.GuardianProfile{}, nil
+	}
+	if len(tokens) > maxSearchTokens {
+		tokens = tokens[:maxSearchTokens]
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+
+	var profiles []*users.GuardianProfile
+
+	query := repoBase.GetDB(ctx, r.db).NewSelect().
+		Model(&profiles).
+		ModelTableExpr(`users.guardian_profiles AS "guardian_profile"`)
+
+	// One AND-ed WHERE group per token; within a group the token may match any of
+	// the three columns. The explicit parentheses keep each token's OR set
+	// isolated so the groups combine as (t1col OR …) AND (t2col OR …).
+	for _, tok := range tokens {
+		pattern := "%" + escapeLikePattern(tok) + "%"
+		query = query.Where(
+			`(LOWER("guardian_profile".first_name) LIKE ? ESCAPE '\' OR LOWER("guardian_profile".last_name) LIKE ? ESCAPE '\' OR LOWER("guardian_profile".email) LIKE ? ESCAPE '\')`,
+			pattern, pattern, pattern,
+		)
+	}
+
+	if err := query.
+		Order(`last_name ASC`, `first_name ASC`).
+		Limit(limit).
+		Scan(ctx); err != nil {
+		return nil, fmt.Errorf("failed to search guardian profiles: %w", err)
 	}
 
 	return profiles, nil

--- a/backend/database/repositories/users/guardian_profile_repository_test.go
+++ b/backend/database/repositories/users/guardian_profile_repository_test.go
@@ -1,6 +1,7 @@
 package users_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
 )
 
 // ============================================================================
@@ -400,5 +402,104 @@ func TestGuardianProfileRepository_GetStudentCount(t *testing.T) {
 		count, err := repo.GetStudentCount(ctx, profile.ID)
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
+	})
+}
+
+// seedNamedGuardian inserts a guardian with a caller-controlled first name (so
+// search assertions can key off a unique token) and registers cleanup.
+func seedNamedGuardian(t *testing.T, db *bun.DB, ctx context.Context, repo users.GuardianProfileRepository, firstName, lastName string) *users.GuardianProfile {
+	t.Helper()
+	email := fmt.Sprintf("%s-%d@search.local", firstName, time.Now().UnixNano())
+	profile := &users.GuardianProfile{
+		FirstName:              firstName,
+		LastName:               lastName,
+		Email:                  &email,
+		PreferredContactMethod: "email",
+		LanguagePreference:     "de",
+	}
+	require.NoError(t, repo.Create(ctx, profile))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "users.guardian_profiles", profile.ID) })
+	return profile
+}
+
+// TestGuardianProfileRepository_SearchByText unit-tests the picker search at the
+// repository layer (it was previously only exercised through the HTTP handler).
+// It pins the substring/case-insensitive contract and the input guards that back
+// the picker's enumeration defense.
+func TestGuardianProfileRepository_SearchByText(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).GuardianProfile
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("matches a first-name substring case-insensitively and excludes non-matches", func(t *testing.T) {
+		token := fmt.Sprintf("Zzsearch%d", time.Now().UnixNano())
+		match := seedNamedGuardian(t, db, ctx, repo, token, "Alpha")
+		other := seedNamedGuardian(t, db, ctx, repo, fmt.Sprintf("Zzother%d", time.Now().UnixNano()), "Beta")
+
+		// Lower-cased query must still match (SearchByText lower-cases both sides).
+		results, err := repo.SearchByText(ctx, token, 50)
+		require.NoError(t, err)
+
+		var sawMatch, sawOther bool
+		for _, g := range results {
+			if g.ID == match.ID {
+				sawMatch = true
+			}
+			if g.ID == other.ID {
+				sawOther = true
+			}
+		}
+		assert.True(t, sawMatch, "search must return the guardian whose name contains the token")
+		assert.False(t, sawOther, "search must exclude guardians that don't match the token")
+	})
+
+	t.Run("whitespace-only query returns an empty result without error", func(t *testing.T) {
+		results, err := repo.SearchByText(ctx, "   ", 50)
+		require.NoError(t, err)
+		assert.Empty(t, results, "a query with no real tokens must not match anything")
+	})
+
+	t.Run("a non-positive limit falls back to a default and still returns matches", func(t *testing.T) {
+		token := fmt.Sprintf("Zzlimit%d", time.Now().UnixNano())
+		match := seedNamedGuardian(t, db, ctx, repo, token, "Gamma")
+
+		// limit <= 0 must not mean "return nothing"; it falls back to the method's
+		// internal default rather than passing LIMIT 0 to the query.
+		results, err := repo.SearchByText(ctx, token, 0)
+		require.NoError(t, err)
+
+		var found bool
+		for _, g := range results {
+			if g.ID == match.ID {
+				found = true
+			}
+		}
+		assert.True(t, found, "limit<=0 must fall back to a default, not suppress all results")
+	})
+
+	t.Run("tolerates a pathological many-token query", func(t *testing.T) {
+		// Far more tokens than maxSearchTokens. The repo caps the token count so
+		// the WHERE clause can't grow unbounded; the call must still succeed and,
+		// since every token is the same matching string, still find the guardian.
+		token := fmt.Sprintf("Zzmany%d", time.Now().UnixNano())
+		match := seedNamedGuardian(t, db, ctx, repo, token, "Delta")
+
+		manyTokens := token
+		for i := 0; i < 14; i++ {
+			manyTokens += " " + token
+		}
+
+		results, err := repo.SearchByText(ctx, manyTokens, 50)
+		require.NoError(t, err, "a many-token query must be handled gracefully, never error")
+
+		var found bool
+		for _, g := range results {
+			if g.ID == match.ID {
+				found = true
+			}
+		}
+		assert.True(t, found, "repeated matching tokens must still find the guardian")
 	})
 }

--- a/backend/database/repositories/users/student_guardian.go
+++ b/backend/database/repositories/users/student_guardian.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
 
@@ -26,6 +27,61 @@ func NewStudentGuardianRepository(db *bun.DB) users.StudentGuardianRepository {
 		Repository: repo,
 		db:         db,
 	}
+}
+
+// LinkIfNotExists inserts the student↔guardian relationship, treating a
+// duplicate link (same tenant_id + student_id + guardian_profile_id) as a no-op
+// via ON CONFLICT DO NOTHING. It returns true when a new row was inserted and
+// false when the link already existed.
+//
+// Why ON CONFLICT rather than a read-then-insert check: re-linking the same
+// guardian must never raise a unique violation, and in PostgreSQL a violation
+// raised inside the request's tenant transaction would ALSO abort that
+// transaction — breaking the atomic student-create path. DO NOTHING avoids both:
+// it is race-safe (two concurrent links can't both succeed-then-500) and it
+// leaves the transaction usable. The conflict target matches the
+// UNIQUE(tenant_id, student_id, guardian_profile_id) index
+// (idx_students_guardians_tenant, migration 001014003) — NOT the legacy
+// (student_id, guardian_profile_id) constraint, which that migration dropped.
+//
+// On conflict the existing row is left UNTOUCHED: relationship flags change only
+// through the dedicated update path, never via a silent re-link upsert. Mirrors
+// base.Create's validate + tenant-autoset + ModelTableExpr insert, adding only
+// the conflict clause.
+func (r *StudentGuardianRepository) LinkIfNotExists(ctx context.Context, rel *users.StudentGuardian) (bool, error) {
+	if rel == nil {
+		return false, fmt.Errorf("student guardian cannot be nil")
+	}
+	if err := rel.Validate(); err != nil {
+		return false, err
+	}
+	if rel.GetTenantID() == 0 {
+		if tid := tenant.FromContext(ctx); tid != 0 {
+			rel.SetTenantID(tid)
+		}
+	}
+
+	res, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(rel).
+		ModelTableExpr(`users.students_guardians`).
+		On(`CONFLICT (tenant_id, student_id, guardian_profile_id) DO NOTHING`).
+		Exec(ctx)
+	if err != nil {
+		return false, &modelBase.DatabaseError{
+			Op:  "link guardian if not exists",
+			Err: err,
+		}
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, &modelBase.DatabaseError{
+			Op:  "link guardian if not exists (rows affected)",
+			Err: err,
+		}
+	}
+
+	return affected > 0, nil
 }
 
 // FindByStudentID retrieves relationships by student ID
@@ -72,6 +128,51 @@ func (r *StudentGuardianRepository) FindByGuardianProfileID(ctx context.Context,
 	}
 
 	return relationships, nil
+}
+
+// ListLinkedChildrenForGuardians returns every child linked to any of the given
+// guardian profiles in ONE join query (students_guardians → students → persons),
+// projecting only id + name. This is what lets the guardian picker enrich its
+// matches with linked children without a per-guardian N+1 (#1513). Tenant
+// isolation is enforced purely by RLS on the ambient tenant transaction — the
+// query carries no explicit tenant predicate, and the incoming guardian profile
+// ids are themselves already RLS-scoped (they come from SearchByText under the
+// same tenant tx). Soft-deleted persons are excluded; students carry no
+// soft-delete column.
+func (r *StudentGuardianRepository) ListLinkedChildrenForGuardians(ctx context.Context, guardianProfileIDs []int64) ([]*users.GuardianLinkedChild, error) {
+	if len(guardianProfileIDs) == 0 {
+		return []*users.GuardianLinkedChild{}, nil
+	}
+
+	// Raw SQL: this three-table join (link → student → person) projecting a flat
+	// custom row doesn't fit bun's model-relation inference cleanly, and the
+	// repo conventions bless raw SQL for joins the generic shape can't express.
+	// Tenant isolation is enforced by RLS on the ambient tenant transaction,
+	// exactly like SearchByText on the guardian-profile repo.
+	const query = `
+		SELECT sg.guardian_profile_id AS guardian_profile_id,
+		       s.id                   AS student_id,
+		       p.first_name           AS first_name,
+		       p.last_name            AS last_name
+		FROM users.students_guardians AS sg
+		JOIN users.students AS s ON s.id = sg.student_id
+		JOIN users.persons  AS p ON p.id = s.person_id
+		WHERE sg.guardian_profile_id IN (?)
+		  AND p.deleted_at IS NULL
+		ORDER BY p.last_name ASC, p.first_name ASC`
+
+	// bun.List expands the slice to a comma-separated list ("1, 2, 3") with no
+	// surrounding parens, so it slots straight into the "IN (?)" placeholder
+	// above. (bun.Tuple would wrap in its own parens → "IN ((1, 2, 3))".)
+	var rows []*users.GuardianLinkedChild
+	if err := base.GetDB(ctx, r.db).NewRaw(query, bun.List(guardianProfileIDs)).Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list linked children for guardians",
+			Err: err,
+		}
+	}
+
+	return rows, nil
 }
 
 // FindPrimaryByStudentID retrieves the primary guardian for a student

--- a/backend/database/repositories/users/student_guardian_test.go
+++ b/backend/database/repositories/users/student_guardian_test.go
@@ -609,3 +609,114 @@ func TestStudentGuardianRepository_List_WithFilters(t *testing.T) {
 		assert.True(t, r.IsPrimary)
 	}
 }
+
+// TestStudentGuardianRepository_LinkIfNotExists unit-tests the idempotent link
+// used by the select-existing-guardian path (#1513) directly at the repo layer.
+// It pins three contracts the service relies on: a fresh link inserts and
+// reports true, a duplicate link is a silent no-op reporting false (never a
+// unique-violation that would abort the surrounding tenant tx), and tenant_id is
+// auto-populated from context when the caller leaves it unset.
+func TestStudentGuardianRepository_LinkIfNotExists(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).StudentGuardian
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("inserts a new link and reports it as inserted", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Link", "Student", "1a")
+		guardian := testpkg.CreateTestGuardianProfile(t, db, "linkfresh")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID, guardian.ID)
+
+		rel := &users.StudentGuardian{
+			StudentID:         student.ID,
+			GuardianProfileID: guardian.ID,
+			RelationshipType:  "parent",
+			CanPickup:         true,
+			EmergencyPriority: 1,
+		}
+		rel.SetTenantID(1)
+
+		inserted, err := repo.LinkIfNotExists(ctx, rel)
+		defer cleanupStudentGuardians(t, db, rel.ID)
+		require.NoError(t, err)
+		assert.True(t, inserted, "a brand-new link must report inserted=true")
+	})
+
+	t.Run("treats a duplicate link as a no-op reporting not-inserted", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Dup", "Student", "1b")
+		guardian := testpkg.CreateTestGuardianProfile(t, db, "linkdup")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID, guardian.ID)
+
+		first := &users.StudentGuardian{
+			StudentID:         student.ID,
+			GuardianProfileID: guardian.ID,
+			RelationshipType:  "parent",
+			EmergencyPriority: 1,
+		}
+		first.SetTenantID(1)
+		inserted, err := repo.LinkIfNotExists(ctx, first)
+		require.NoError(t, err)
+		require.True(t, inserted)
+		defer cleanupStudentGuardians(t, db, first.ID)
+
+		// Same (tenant, student, guardian) again — must NOT raise a unique
+		// violation and must report that nothing new was inserted.
+		dup := &users.StudentGuardian{
+			StudentID:         student.ID,
+			GuardianProfileID: guardian.ID,
+			RelationshipType:  "guardian",
+			EmergencyPriority: 2,
+		}
+		dup.SetTenantID(1)
+		inserted, err = repo.LinkIfNotExists(ctx, dup)
+		require.NoError(t, err, "a duplicate link must not error")
+		assert.False(t, inserted, "a duplicate link must report inserted=false")
+
+		// Exactly one row survives for this (student, guardian) pair.
+		count, err := repo.List(ctx, map[string]interface{}{"student_id": student.ID})
+		require.NoError(t, err)
+		var matched int
+		for _, l := range count {
+			if l.GuardianProfileID == guardian.ID {
+				matched++
+			}
+		}
+		assert.Equal(t, 1, matched, "the duplicate must not create a second row")
+	})
+
+	t.Run("auto-populates tenant_id from context when unset", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "Auto", "Student", "1c")
+		guardian := testpkg.CreateTestGuardianProfile(t, db, "linkauto")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID, guardian.ID)
+
+		// TenantID deliberately left at zero — the repo must fill it from ctx.
+		rel := &users.StudentGuardian{
+			StudentID:         student.ID,
+			GuardianProfileID: guardian.ID,
+			RelationshipType:  "parent",
+			EmergencyPriority: 1,
+		}
+		inserted, err := repo.LinkIfNotExists(ctx, rel)
+		defer cleanupStudentGuardians(t, db, rel.ID)
+		require.NoError(t, err)
+		require.True(t, inserted)
+		assert.Equal(t, int64(1), rel.GetTenantID(), "tenant_id must be auto-set from context")
+	})
+}
+
+// TestStudentGuardianRepository_ListLinkedChildrenForGuardians_EmptyInput pins
+// the early-return contract the picker batch relies on: an empty id slice yields
+// an empty result with no query (and no error), so SearchGuardiansForPicker can
+// call it unconditionally.
+func TestStudentGuardianRepository_ListLinkedChildrenForGuardians_EmptyInput(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).StudentGuardian
+	ctx := testpkg.TenantContext(1)
+
+	rows, err := repo.ListLinkedChildrenForGuardians(ctx, []int64{})
+	require.NoError(t, err)
+	assert.Empty(t, rows, "an empty guardian-id slice must return no rows")
+}

--- a/backend/models/users/repository.go
+++ b/backend/models/users/repository.go
@@ -385,6 +385,21 @@ type StudentGuardianRepository interface {
 	// FindByGuardianProfileID retrieves relationships by guardian profile ID
 	FindByGuardianProfileID(ctx context.Context, guardianProfileID int64) ([]*StudentGuardian, error)
 
+	// LinkIfNotExists inserts the student↔guardian relationship, treating a
+	// duplicate (same tenant_id + student_id + guardian_profile_id) as a no-op
+	// via ON CONFLICT DO NOTHING. Returns true when a new row was inserted, false
+	// when the link already existed. Race-safe and transaction-safe — a duplicate
+	// never raises a unique violation (which would abort the surrounding tenant
+	// tx). On conflict the existing row is left untouched.
+	LinkIfNotExists(ctx context.Context, rel *StudentGuardian) (bool, error)
+
+	// ListLinkedChildrenForGuardians returns, in a single query, the children
+	// linked to any of the given guardian profiles (id + name only). Backs the
+	// guardian picker search so it never falls into a per-guardian N+1. Tenant
+	// isolation is enforced by RLS on the ambient tenant transaction (the query
+	// carries no explicit tenant predicate).
+	ListLinkedChildrenForGuardians(ctx context.Context, guardianProfileIDs []int64) ([]*GuardianLinkedChild, error)
+
 	// FindPrimaryByStudentID retrieves the primary guardian for a student
 	FindPrimaryByStudentID(ctx context.Context, studentID int64) (*StudentGuardian, error)
 
@@ -489,6 +504,11 @@ type GuardianProfileRepository interface {
 
 	// ListWithOptions retrieves guardian profiles with pagination and filters
 	ListWithOptions(ctx context.Context, options *base.QueryOptions) ([]*GuardianProfile, error)
+
+	// SearchByText retrieves guardian profiles whose first name, last name, or
+	// email matches the search text (case-insensitive substring). Tenant-scoped
+	// via RLS; results are capped by limit to keep the picker payload small.
+	SearchByText(ctx context.Context, searchText string, limit int) ([]*GuardianProfile, error)
 
 	// Count returns the total number of guardian profiles
 	Count(ctx context.Context) (int, error)

--- a/backend/models/users/student_guardian.go
+++ b/backend/models/users/student_guardian.go
@@ -9,6 +9,17 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// GuardianLinkedChild is a minimal projection of a child currently linked to a
+// guardian, used by the guardian picker search to show which children a guardian
+// belongs to (sibling case, #1513). It is NOT a persisted entity — it is scanned
+// from a join across students_guardians → students → persons.
+type GuardianLinkedChild struct {
+	GuardianProfileID int64  `bun:"guardian_profile_id"`
+	StudentID         int64  `bun:"student_id"`
+	FirstName         string `bun:"first_name"`
+	LastName          string `bun:"last_name"`
+}
+
 // StudentGuardian represents the relationship between a student and their guardian
 type StudentGuardian struct {
 	base.Model `bun:"schema:users,table:students_guardians"`

--- a/backend/services/users/guardian_interface.go
+++ b/backend/services/users/guardian_interface.go
@@ -102,12 +102,29 @@ type NewStudentGuardian struct {
 	Profile      GuardianCreateRequest
 	Relationship StudentGuardianRelationship
 	PhoneNumbers []PhoneNumberCreateRequest
+
+	// ExistingProfileID, when non-nil, links an already-existing guardian
+	// profile to the student instead of creating a new one (sibling case,
+	// issue #1513). In that case Profile and PhoneNumbers are ignored and the
+	// existing profile is never mutated — only the Relationship flags apply to
+	// the new link.
+	ExistingProfileID *int64
 }
 
 // GuardianWithStudents represents a guardian with their associated students
 type GuardianWithStudents struct {
 	Profile  *users.GuardianProfile
 	Students []*StudentWithRelationship
+}
+
+// GuardianPickerMatch is one result from the guardian picker search: a guardian
+// profile plus the children currently linked to it. Backs GET /guardians/search
+// (sibling case, #1513). The handler projects only id/name/email + a COUNT of
+// children onto the wire — address, notes, language, and contact method never
+// leave the server, and child names are never exposed (only the count).
+type GuardianPickerMatch struct {
+	Profile  *users.GuardianProfile
+	Children []*users.GuardianLinkedChild
 }
 
 // StudentWithRelationship represents a student with guardian relationship details
@@ -187,6 +204,12 @@ type GuardianService interface {
 
 	// ListGuardians retrieves guardians with pagination and filters
 	ListGuardians(ctx context.Context, options *base.QueryOptions) ([]*users.GuardianProfile, error)
+
+	// SearchGuardiansForPicker retrieves guardians whose name or email matches
+	// the search text (case-insensitive), each enriched with its linked children
+	// in a single batch query (no N+1). Backs the guardian picker used to link an
+	// existing guardian to a student (sibling case). Tenant-scoped via RLS.
+	SearchGuardiansForPicker(ctx context.Context, searchText string, limit int) ([]*GuardianPickerMatch, error)
 
 	// GetGuardiansWithoutAccount retrieves guardians who don't have portal accounts
 	GetGuardiansWithoutAccount(ctx context.Context) ([]*users.GuardianProfile, error)

--- a/backend/services/users/guardian_service.go
+++ b/backend/services/users/guardian_service.go
@@ -126,6 +126,22 @@ func (s *guardianService) CreateGuardian(ctx context.Context, req GuardianCreate
 	}
 
 	profile.SetTenantID(tenant.FromContext(ctx))
+
+	// Reject a duplicate email up front. The tenant-scoped UNIQUE(tenant_id,
+	// email) index forbids two guardians sharing an email, so without this
+	// pre-check the INSERT fails with a raw 23505 that surfaces to the user as a
+	// generic 500. Detect it as bad input instead and steer the caller to the
+	// existing-guardian picker (#1513) — the same German message and 400
+	// semantics as the batch student-create path (ValidateNewGuardians).
+	// FindByEmail matches case-insensitively (LOWER(email)), so it is at least
+	// as strict as the index and never lets a colliding email slip through.
+	if profile.Email != nil && strings.TrimSpace(*profile.Email) != "" {
+		if existing, err := s.guardianProfileRepo.FindByEmail(ctx, strings.TrimSpace(*profile.Email)); err == nil && existing != nil {
+			//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
+			return nil, &ValidationError{Err: fmt.Errorf("E-Mail-Adresse %q ist bereits vergeben – bitte die vorhandene Person über die Suche auswählen", strings.TrimSpace(*profile.Email))}
+		}
+	}
+
 	if err := s.guardianProfileRepo.Create(ctx, profile); err != nil {
 		return nil, fmt.Errorf("failed to create guardian profile: %w", err)
 	}
@@ -664,7 +680,7 @@ func (s *guardianService) LinkGuardianToStudent(ctx context.Context, req Student
 		return nil, fmt.Errorf("student not found: %w", err)
 	}
 
-	// Create relationship
+	// Build the new relationship.
 	relationship := &users.StudentGuardian{
 		StudentID:          req.StudentID,
 		GuardianProfileID:  req.GuardianProfileID,
@@ -677,11 +693,38 @@ func (s *guardianService) LinkGuardianToStudent(ctx context.Context, req Student
 	}
 	relationship.SetTenantID(tenant.FromContext(ctx))
 
-	if err := s.studentGuardianRepo.Create(ctx, relationship); err != nil {
+	// Idempotent on an existing link: re-linking a guardian already attached to
+	// this student is a pure NO-OP, never an error. LinkIfNotExists inserts via
+	// ON CONFLICT DO NOTHING, so a duplicate — whether sequential, concurrent, or
+	// retried — neither raises a 500 nor aborts the surrounding tenant
+	// transaction (a raw duplicate INSERT would do both in PostgreSQL). This is
+	// the same "re-selecting is not an error" semantics as the batch create path
+	// in AddGuardiansToStudent.
+	inserted, err := s.studentGuardianRepo.LinkIfNotExists(ctx, relationship)
+	if err != nil {
 		return nil, fmt.Errorf("failed to create relationship: %w", err)
 	}
+	if inserted {
+		return relationship, nil
+	}
 
-	return relationship, nil
+	// The link already existed. Return it UNCHANGED — linking is a create, not an
+	// edit. Changing an existing relationship's flags goes through the dedicated
+	// update path (UpdateStudentGuardianRelationship, the detail page's "edit"
+	// action). Never upserting the flags on a re-link keeps safety-relevant fields
+	// (who can pick up the child, who the emergency contact is) mutable only via
+	// that explicit endpoint, with no silent overwrite from a stray re-link.
+	existingLinks, err := s.studentGuardianRepo.FindByStudentID(ctx, req.StudentID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load existing guardian link: %w", err)
+	}
+	for _, link := range existingLinks {
+		if link.GuardianProfileID == req.GuardianProfileID {
+			return link, nil
+		}
+	}
+
+	return nil, fmt.Errorf("guardian link reported as existing but not found for student %d", req.StudentID)
 }
 
 // germanGuardianValidationMessage translates the English validation messages
@@ -716,6 +759,28 @@ func (s *guardianService) ValidateNewGuardians(ctx context.Context, guardians []
 	seenEmails := make(map[string]struct{}, len(guardians))
 
 	for i := range guardians {
+		// Select-existing path (#1513): the entry links an already-existing
+		// profile instead of creating one. There is no profile/email/phone
+		// input to validate — only that the profile exists (FindByID is
+		// tenant-scoped via RLS, so a cross-tenant or stale id surfaces as a
+		// clean 400, not a 500) and that the relationship fields are valid,
+		// matching the new-guardian path below and the detail-page link route.
+		if id := guardians[i].ExistingProfileID; id != nil {
+			if _, err := s.guardianProfileRepo.FindByID(ctx, *id); err != nil {
+				//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
+				return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: ausgewählte Person nicht gefunden", i+1)}
+			}
+			if !users.IsValidRelationshipType(guardians[i].Relationship.RelationshipType) {
+				//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
+				return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: ungültiger Beziehungstyp", i+1)}
+			}
+			if guardians[i].Relationship.EmergencyPriority < 1 {
+				//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
+				return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: Notfall-Priorität muss mindestens 1 sein", i+1)}
+			}
+			continue
+		}
+
 		// Profile rules (email format, contact method) via the shared model
 		// Validate() — the same checks the repository runs on insert.
 		probe := &users.GuardianProfile{
@@ -758,7 +823,7 @@ func (s *guardianService) ValidateNewGuardians(ctx context.Context, guardians []
 			}
 			if existing, err := s.guardianProfileRepo.FindByEmail(ctx, email); err == nil && existing != nil {
 				//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
-				return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: E-Mail-Adresse %q ist bereits vergeben", i+1, email)}
+				return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: E-Mail-Adresse %q ist bereits vergeben – bitte die vorhandene Person über die Suche auswählen", i+1, email)}
 			}
 			seenEmails[email] = struct{}{}
 		}
@@ -802,12 +867,30 @@ func (s *guardianService) AddGuardiansToStudent(ctx context.Context, studentID i
 		return err
 	}
 
+	// Track profile ids already linked to this student within this request so a
+	// guardian selected (or typed) twice doesn't collide on the
+	// UNIQUE(student_id, guardian_profile_id) index. Re-selecting the same
+	// person is not an error — the duplicate link is skipped silently (#1513).
+	linked := make(map[int64]struct{}, len(guardians))
+
 	for i := range guardians {
 		g := guardians[i]
 
-		profile, err := s.CreateGuardian(ctx, g.Profile)
-		if err != nil {
-			return fmt.Errorf("failed to create guardian at index %d: %w", i, err)
+		var profileID int64
+		if g.ExistingProfileID != nil {
+			// Select-existing path: link the existing profile as-is. Never
+			// create it and never touch its phone numbers — the existing
+			// profile's own data stays untouched.
+			profileID = *g.ExistingProfileID
+			if _, dup := linked[profileID]; dup {
+				continue
+			}
+		} else {
+			profile, err := s.CreateGuardian(ctx, g.Profile)
+			if err != nil {
+				return fmt.Errorf("failed to create guardian at index %d: %w", i, err)
+			}
+			profileID = profile.ID
 		}
 
 		// RelationshipType and EmergencyPriority were already checked by
@@ -815,7 +898,7 @@ func (s *guardianService) AddGuardiansToStudent(ctx context.Context, studentID i
 		// detail-page link path (LinkGuardianToStudent).
 		if _, err := s.LinkGuardianToStudent(ctx, StudentGuardianCreateRequest{
 			StudentID:          studentID,
-			GuardianProfileID:  profile.ID,
+			GuardianProfileID:  profileID,
 			RelationshipType:   g.Relationship.RelationshipType,
 			IsPrimary:          g.Relationship.IsPrimary,
 			IsEmergencyContact: g.Relationship.IsEmergencyContact,
@@ -825,10 +908,15 @@ func (s *guardianService) AddGuardiansToStudent(ctx context.Context, studentID i
 		}); err != nil {
 			return fmt.Errorf("failed to link guardian at index %d: %w", i, err)
 		}
+		linked[profileID] = struct{}{}
 
-		for j := range g.PhoneNumbers {
-			if _, err := s.AddPhoneNumber(ctx, profile.ID, g.PhoneNumbers[j]); err != nil {
-				return fmt.Errorf("failed to add phone number %d for guardian at index %d: %w", j, i, err)
+		// Phone numbers only apply to newly created profiles. An existing
+		// profile keeps its own phone numbers untouched.
+		if g.ExistingProfileID == nil {
+			for j := range g.PhoneNumbers {
+				if _, err := s.AddPhoneNumber(ctx, profileID, g.PhoneNumbers[j]); err != nil {
+					return fmt.Errorf("failed to add phone number %d for guardian at index %d: %w", j, i, err)
+				}
 			}
 		}
 	}
@@ -908,6 +996,45 @@ func (s *guardianService) ListGuardians(ctx context.Context, options *base.Query
 	}
 
 	return profiles, nil
+}
+
+// SearchGuardiansForPicker retrieves guardians matching the search text and
+// enriches each with its linked children. It backs the guardian picker (link an
+// existing guardian to a student). Tenant isolation is enforced by RLS on the
+// ambient tenant transaction. Phone numbers are intentionally not loaded — the
+// picker identifies people by name, email, and linked children.
+//
+// The linked children are fetched in ONE batch query for all matched guardians
+// and grouped in memory, so the picker never falls into a per-guardian N+1.
+func (s *guardianService) SearchGuardiansForPicker(ctx context.Context, searchText string, limit int) ([]*GuardianPickerMatch, error) {
+	profiles, err := s.guardianProfileRepo.SearchByText(ctx, searchText, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(profiles) == 0 {
+		return []*GuardianPickerMatch{}, nil
+	}
+
+	ids := make([]int64, len(profiles))
+	for i, p := range profiles {
+		ids[i] = p.ID
+	}
+
+	children, err := s.studentGuardianRepo.ListLinkedChildrenForGuardians(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	byGuardian := make(map[int64][]*users.GuardianLinkedChild, len(profiles))
+	for _, c := range children {
+		byGuardian[c.GuardianProfileID] = append(byGuardian[c.GuardianProfileID], c)
+	}
+
+	matches := make([]*GuardianPickerMatch, len(profiles))
+	for i, p := range profiles {
+		matches[i] = &GuardianPickerMatch{Profile: p, Children: byGuardian[p.ID]}
+	}
+	return matches, nil
 }
 
 // GetGuardiansWithoutAccount retrieves guardians who don't have portal accounts

--- a/backend/services/users/guardian_service_test.go
+++ b/backend/services/users/guardian_service_test.go
@@ -119,6 +119,47 @@ func TestGuardianService_CreateGuardian(t *testing.T) {
 	})
 }
 
+// TestGuardianService_CreateGuardian_DuplicateEmail verifies that creating a
+// second guardian with an email already in use returns a *ValidationError
+// (rendered as a 400 with a German "use the search" message) instead of letting
+// the tenant-scoped UNIQUE(tenant_id, email) index fail the INSERT with a raw
+// 23505 that would surface as a generic 500 (#1513).
+func TestGuardianService_CreateGuardian_DuplicateEmail(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupGuardianService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	email := fmt.Sprintf("dup-guardian-%d@example.com", time.Now().UnixNano())
+	req := users.GuardianCreateRequest{
+		FirstName:              "First",
+		LastName:               "Guardian",
+		Email:                  &email,
+		PreferredContactMethod: "email",
+		LanguagePreference:     "de",
+	}
+
+	// First create succeeds.
+	first, err := service.CreateGuardian(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	defer testpkg.CleanupActivityFixtures(t, db, first.ID)
+
+	// Second create with the SAME email (different name) must be rejected as a
+	// validation error, not a DB/operational failure — and nothing is inserted.
+	dupReq := req
+	dupReq.FirstName = "Second"
+	second, err := service.CreateGuardian(ctx, dupReq)
+
+	require.Error(t, err)
+	assert.Nil(t, second)
+	var validationErr *users.ValidationError
+	require.ErrorAs(t, err, &validationErr, "duplicate email must be a ValidationError → 400, not a 500")
+	assert.Contains(t, err.Error(), "bereits vergeben")
+	assert.Contains(t, err.Error(), "Suche")
+}
+
 // =============================================================================
 // GetGuardianByID Tests
 // =============================================================================
@@ -314,6 +355,98 @@ func TestGuardianService_LinkGuardianToStudent(t *testing.T) {
 		assert.Equal(t, guardian.ID, result.GuardianProfileID)
 		assert.Equal(t, "parent", result.RelationshipType)
 		assert.True(t, result.IsPrimary)
+	})
+
+	t.Run("is idempotent when the guardian is already linked", func(t *testing.T) {
+		// ARRANGE — link a guardian once.
+		guardian := testpkg.CreateTestGuardianProfile(t, db, "relink")
+		student := testpkg.CreateTestStudent(t, db, "Relink", "Student", "1c")
+		defer testpkg.CleanupActivityFixtures(t, db, guardian.ID, student.ID)
+
+		req := users.StudentGuardianCreateRequest{
+			StudentID:         student.ID,
+			GuardianProfileID: guardian.ID,
+			RelationshipType:  "parent",
+			EmergencyPriority: 1,
+		}
+		first, err := service.LinkGuardianToStudent(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, first)
+
+		// ACT — link the SAME guardian to the SAME student again.
+		second, err := service.LinkGuardianToStudent(ctx, req)
+
+		// ASSERT — no UNIQUE-constraint error; the existing relationship is
+		// returned, and only one link exists.
+		require.NoError(t, err, "re-linking an already-linked guardian must not error")
+		require.NotNil(t, second)
+		assert.Equal(t, first.ID, second.ID, "re-link must return the existing relationship, not create a new one")
+
+		links, err := service.GetStudentGuardians(ctx, student.ID)
+		require.NoError(t, err)
+		var count int
+		for _, l := range links {
+			if l.Profile != nil && l.Profile.ID == guardian.ID {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "exactly one link must exist after re-linking")
+	})
+
+	t.Run("re-linking is a no-op and never overwrites the existing relationship flags", func(t *testing.T) {
+		// Linking is a CREATE, not an edit: a re-link must return the existing
+		// row untouched. Changing flags goes through the dedicated update path
+		// (UpdateStudentGuardianRelationship). This guards against a stray or
+		// retried link request silently flipping pickup/emergency-contact flags.
+		// ARRANGE — link a guardian with a minimal relationship.
+		guardian := testpkg.CreateTestGuardianProfile(t, db, "upsert")
+		student := testpkg.CreateTestStudent(t, db, "Upsert", "Student", "1d")
+		defer testpkg.CleanupActivityFixtures(t, db, guardian.ID, student.ID)
+
+		first, err := service.LinkGuardianToStudent(ctx, users.StudentGuardianCreateRequest{
+			StudentID:         student.ID,
+			GuardianProfileID: guardian.ID,
+			RelationshipType:  "parent",
+			IsPrimary:         false,
+			CanPickup:         false,
+			EmergencyPriority: 1,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, first)
+
+		// ACT — re-link the SAME guardian with DIFFERENT relationship flags.
+		second, err := service.LinkGuardianToStudent(ctx, users.StudentGuardianCreateRequest{
+			StudentID:          student.ID,
+			GuardianProfileID:  guardian.ID,
+			RelationshipType:   "guardian",
+			IsPrimary:          true,
+			IsEmergencyContact: true,
+			CanPickup:          true,
+			EmergencyPriority:  2,
+		})
+
+		// ASSERT — same single row, and the flags STILL reflect the ORIGINAL
+		// link, not the re-link request (the changed flags were ignored).
+		require.NoError(t, err, "re-linking must not error")
+		require.NotNil(t, second)
+		assert.Equal(t, first.ID, second.ID, "re-link must return the existing row, not create a new one")
+
+		links, err := service.GetStudentGuardians(ctx, student.ID)
+		require.NoError(t, err)
+		var matched int
+		for _, l := range links {
+			if l.Profile == nil || l.Profile.ID != guardian.ID {
+				continue
+			}
+			matched++
+			require.NotNil(t, l.Relationship)
+			assert.Equal(t, "parent", l.Relationship.RelationshipType, "relationship type must be unchanged by a re-link")
+			assert.False(t, l.Relationship.IsPrimary, "is_primary must be unchanged by a re-link")
+			assert.False(t, l.Relationship.IsEmergencyContact, "is_emergency_contact must be unchanged by a re-link")
+			assert.False(t, l.Relationship.CanPickup, "can_pickup must be unchanged by a re-link")
+			assert.Equal(t, 1, l.Relationship.EmergencyPriority, "emergency_priority must be unchanged by a re-link")
+		}
+		assert.Equal(t, 1, matched, "exactly one link must exist after re-linking")
 	})
 
 	t.Run("returns error when guardian not found", func(t *testing.T) {

--- a/frontend/src/app/api/guardians/search/route.ts
+++ b/frontend/src/app/api/guardians/search/route.ts
@@ -1,0 +1,25 @@
+import { createGetHandler } from "@/lib/route-wrapper";
+import { apiGet } from "@/lib/api-helpers";
+
+// GET /api/guardians/search - guardian picker search (#1513).
+//
+// Shares the users:read gate with the admin guardian list (GET /api/guardians),
+// so any staff member who manages students can link a sibling's existing
+// guardian. Unlike that full-profile list, the backend returns a minimal,
+// enumeration-resistant projection: name, email, and only a COUNT of other
+// linked children (never their names) — address, notes, language, contact
+// method, and account are all withheld server-side.
+export const GET = createGetHandler(async (request, token, _params) => {
+  const searchParams = request.nextUrl.searchParams;
+  const queryString = searchParams.toString();
+
+  const endpoint = queryString
+    ? `/api/guardians/search?${queryString}`
+    : "/api/guardians/search";
+
+  const response = await apiGet(endpoint, token);
+  // Return the bare data array (mirrors the /api/guardians list route); the
+  // route wrapper re-wraps it into the client's { data, status } envelope.
+  // @ts-expect-error - API helper returns unknown type
+  return response.data;
+});

--- a/frontend/src/components/guardians/guardian-form-modal.tsx
+++ b/frontend/src/components/guardians/guardian-form-modal.tsx
@@ -10,10 +10,13 @@ import type {
   PhoneType,
 } from "@/lib/guardian-helpers";
 import {
-  RELATIONSHIP_TYPES,
   PHONE_TYPE_LABELS,
   LANGUAGE_PREFERENCES,
 } from "@/lib/guardian-helpers";
+import {
+  RelationshipTypeSelect,
+  RelationshipPermissionsFields,
+} from "~/components/guardians/guardian-relationship-fields";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "GuardianForm" });
@@ -598,50 +601,14 @@ export default function GuardianFormModal({
                   />
                 </div>
 
-                <div>
-                  <label
-                    htmlFor={`guardian-relationship-type-${entry.id}`}
-                    className="mb-1 block text-xs font-medium text-gray-700"
-                  >
-                    Beziehung zum Kind
-                  </label>
-                  <div className="relative">
-                    <select
-                      id={`guardian-relationship-type-${entry.id}`}
-                      value={entry.relationshipType}
-                      onChange={(e) =>
-                        updateEntry(
-                          entry.id,
-                          "relationshipType",
-                          e.target.value,
-                        )
-                      }
-                      className="block w-full appearance-none rounded-lg border border-gray-200 bg-white px-3 py-2 pr-10 text-sm transition-colors focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8]"
-                      disabled={isLoading}
-                    >
-                      {RELATIONSHIP_TYPES.map((type) => (
-                        <option key={type.value} value={type.value}>
-                          {type.label}
-                        </option>
-                      ))}
-                    </select>
-                    <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-500">
-                      <svg
-                        className="h-4 w-4"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M19 9l-7 7-7-7"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
+                <RelationshipTypeSelect
+                  id={`guardian-relationship-type-${entry.id}`}
+                  value={entry.relationshipType}
+                  onChange={(value) =>
+                    updateEntry(entry.id, "relationshipType", value)
+                  }
+                  disabled={isLoading}
+                />
               </div>
             </div>
 
@@ -999,91 +966,14 @@ export default function GuardianFormModal({
               </div>
             </div>
 
-            {/* Relationship Flags */}
-            <div className="rounded-xl border border-gray-100 bg-blue-50/30 p-3 md:p-4">
-              <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold text-gray-900 md:mb-4 md:text-sm">
-                <svg
-                  className="h-3.5 w-3.5 text-blue-600 md:h-4 md:w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
-                  />
-                </svg>
-                Berechtigungen
-              </h3>
-              <div className="space-y-2">
-                <label className="flex cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 transition-colors hover:bg-white/50">
-                  <input
-                    type="checkbox"
-                    checked={entry.isPrimary}
-                    onChange={(e) =>
-                      updateEntry(entry.id, "isPrimary", e.target.checked)
-                    }
-                    className="h-4 w-4 rounded border-gray-300 text-purple-600 focus:ring-purple-600"
-                    disabled={isLoading}
-                  />
-                  <span className="text-sm text-gray-700">
-                    Hauptansprechpartner
-                  </span>
-                </label>
-                <label className="flex cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 transition-colors hover:bg-white/50">
-                  <input
-                    type="checkbox"
-                    checked={entry.canPickup}
-                    onChange={(e) =>
-                      updateEntry(entry.id, "canPickup", e.target.checked)
-                    }
-                    className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-600"
-                    disabled={isLoading}
-                  />
-                  <span className="text-sm text-gray-700">Abholberechtigt</span>
-                </label>
-              </div>
-            </div>
-
-            {/* Emergency Contact */}
-            <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-2">
-              <label className="group flex cursor-pointer items-center gap-3">
-                <input
-                  type="checkbox"
-                  checked={entry.isEmergencyContact}
-                  onChange={(e) =>
-                    updateEntry(
-                      entry.id,
-                      "isEmergencyContact",
-                      e.target.checked,
-                    )
-                  }
-                  className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-600"
-                  disabled={isLoading}
-                  aria-label="Als Notfallkontakt markieren"
-                />
-                <div className="flex items-center gap-2">
-                  <svg
-                    className="h-5 w-5 text-red-600"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                    />
-                  </svg>
-                  <span className="text-sm font-medium text-red-900">
-                    Notfallkontakt
-                  </span>
-                </div>
-              </label>
-            </div>
+            {/* Relationship Flags + Emergency Contact (shared with picker) */}
+            <RelationshipPermissionsFields
+              isPrimary={entry.isPrimary}
+              canPickup={entry.canPickup}
+              isEmergencyContact={entry.isEmergencyContact}
+              onChange={(field, value) => updateEntry(entry.id, field, value)}
+              disabled={isLoading}
+            />
 
             {/* Divider between entries */}
             {index < entries.length - 1 && (

--- a/frontend/src/components/guardians/guardian-picker-panel.test.tsx
+++ b/frontend/src/components/guardians/guardian-picker-panel.test.tsx
@@ -1,0 +1,224 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import GuardianPickerPanel from "./guardian-picker-panel";
+import type { Guardian } from "@/lib/guardian-helpers";
+
+const mockSearchGuardians = vi.fn();
+
+// The panel imports both the search function and the result-limit constant from
+// guardian-api; the mock must supply both. Keep the limit equal to the real
+// value (50) so the truncation-hint assertions exercise the real threshold.
+vi.mock("@/lib/guardian-api", () => ({
+  searchGuardians: (query: string) => mockSearchGuardians(query),
+  GUARDIAN_PICKER_RESULT_LIMIT: 50,
+}));
+
+function makeGuardian(i: number): Guardian {
+  return {
+    id: String(i),
+    firstName: `First${i}`,
+    lastName: `Last${i}`,
+    email: `g${i}@example.com`,
+    phoneNumbers: [],
+    preferredContactMethod: "",
+    languagePreference: "",
+    hasAccount: false,
+  };
+}
+
+describe("GuardianPickerPanel truncation hint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the narrow-your-search hint when results hit the cap", async () => {
+    // Exactly the cap (50) → more may exist, so the hint must appear.
+    mockSearchGuardians.mockResolvedValue(
+      Array.from({ length: 50 }, (_, i) => makeGuardian(i)),
+    );
+
+    render(<GuardianPickerPanel onSelect={vi.fn()} onCancel={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Name oder E-Mail suchen…"), {
+      target: { value: "mueller" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Viele Treffer – bitte den Namen weiter eingrenzen."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not show the hint when results are below the cap", async () => {
+    mockSearchGuardians.mockResolvedValue(
+      Array.from({ length: 3 }, (_, i) => makeGuardian(i)),
+    );
+
+    render(<GuardianPickerPanel onSelect={vi.fn()} onCancel={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Name oder E-Mail suchen…"), {
+      target: { value: "schmidt" },
+    });
+
+    // Wait for the results to render, then assert the hint is absent.
+    await waitFor(() => {
+      expect(screen.getByText("First0 Last0")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("Viele Treffer – bitte den Namen weiter eingrenzen."),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("GuardianPickerPanel select-and-confirm flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Search for one guardian, wait for it to render, and click it — leaving the
+  // panel on the relationship step. Shared by the flow tests below.
+  async function searchAndPick(guardian: Guardian) {
+    mockSearchGuardians.mockResolvedValue([guardian]);
+    fireEvent.change(screen.getByPlaceholderText("Name oder E-Mail suchen…"), {
+      target: { value: "schmidt" },
+    });
+    const fullName = `${guardian.firstName} ${guardian.lastName}`;
+    await waitFor(() => {
+      expect(screen.getByText(fullName)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText(fullName));
+  }
+
+  it("confirms with the chosen guardian and the default relationship", async () => {
+    const onSelect = vi.fn();
+    const guardian = makeGuardian(7);
+    render(<GuardianPickerPanel onSelect={onSelect} onCancel={vi.fn()} />);
+
+    await searchAndPick(guardian);
+
+    // The relationship step is now shown; confirm without changing anything.
+    fireEvent.click(screen.getByText("Hinzufügen"));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(guardian, {
+      relationshipType: "parent",
+      isPrimary: false,
+      isEmergencyContact: false,
+      canPickup: true,
+      emergencyPriority: 1,
+    });
+  });
+
+  it("carries a toggled permission flag through to onSelect", async () => {
+    const onSelect = vi.fn();
+    const guardian = makeGuardian(8);
+    render(<GuardianPickerPanel onSelect={onSelect} onCancel={vi.fn()} />);
+
+    await searchAndPick(guardian);
+
+    // Flip "Hauptansprechpartner" (isPrimary) before confirming.
+    fireEvent.click(screen.getByLabelText("Hauptansprechpartner"));
+    fireEvent.click(screen.getByText("Hinzufügen"));
+
+    expect(onSelect).toHaveBeenCalledWith(
+      guardian,
+      expect.objectContaining({ isPrimary: true, canPickup: true }),
+    );
+  });
+
+  it("returns to the result list via 'Andere wählen' without confirming", async () => {
+    const onSelect = vi.fn();
+    const guardian = makeGuardian(9);
+    render(<GuardianPickerPanel onSelect={onSelect} onCancel={vi.fn()} />);
+
+    await searchAndPick(guardian);
+    expect(screen.getByText("Hinzufügen")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Andere wählen"));
+
+    // Back on the search step: the input reappears and nothing was selected.
+    expect(
+      screen.getByPlaceholderText("Name oder E-Mail suchen…"),
+    ).toBeInTheDocument();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("greys out and disables an already-added guardian", async () => {
+    const guardian = makeGuardian(3);
+    mockSearchGuardians.mockResolvedValue([guardian]);
+
+    render(
+      <GuardianPickerPanel
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+        excludeProfileIds={[guardian.id]}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Name oder E-Mail suchen…"), {
+      target: { value: "schmidt" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("(bereits hinzugefügt)")).toBeInTheDocument();
+    });
+    // The result button for an excluded guardian must be non-interactive.
+    const row = screen.getByText("First3 Last3").closest("button");
+    expect(row).toBeDisabled();
+  });
+
+  it("shows the linked-children count for disambiguation", async () => {
+    const guardian = { ...makeGuardian(4), linkedChildrenCount: 2 };
+    mockSearchGuardians.mockResolvedValue([guardian]);
+
+    render(<GuardianPickerPanel onSelect={vi.fn()} onCancel={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText("Name oder E-Mail suchen…"), {
+      target: { value: "schmidt" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Erziehungsberechtigte/r von 2 weiteren Kindern"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows a German error message when the search fails", async () => {
+    mockSearchGuardians.mockRejectedValue(new Error("backend exploded"));
+
+    render(<GuardianPickerPanel onSelect={vi.fn()} onCancel={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText("Name oder E-Mail suchen…"), {
+      target: { value: "schmidt" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Suche fehlgeschlagen. Bitte erneut versuchen."),
+      ).toBeInTheDocument();
+    });
+    // The raw backend message must never reach the user.
+    expect(screen.queryByText("backend exploded")).not.toBeInTheDocument();
+  });
+
+  it("shows the minimum-length hint and does not search for short queries", async () => {
+    render(<GuardianPickerPanel onSelect={vi.fn()} onCancel={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Name oder E-Mail suchen…"), {
+      target: { value: "ab" },
+    });
+
+    expect(
+      screen.getByText("Mindestens 3 Zeichen eingeben."),
+    ).toBeInTheDocument();
+    expect(mockSearchGuardians).not.toHaveBeenCalled();
+  });
+
+  it("calls onCancel when the close button is clicked", () => {
+    const onCancel = vi.fn();
+    render(<GuardianPickerPanel onSelect={vi.fn()} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByLabelText("Suche schließen"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/guardians/guardian-picker-panel.tsx
+++ b/frontend/src/components/guardians/guardian-picker-panel.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Search, Users, ArrowLeft, Check, X } from "lucide-react";
+import {
+  searchGuardians,
+  GUARDIAN_PICKER_RESULT_LIMIT,
+} from "@/lib/guardian-api";
+import { getGuardianFullName, type Guardian } from "@/lib/guardian-helpers";
+import {
+  RelationshipTypeSelect,
+  RelationshipPermissionsFields,
+  type RelationshipFlag,
+} from "~/components/guardians/guardian-relationship-fields";
+import type { RelationshipFormData } from "~/components/guardians/guardian-form-modal";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "GuardianPickerPanel" });
+
+// Minimum characters before a search fires, and debounce delay. The minimum is
+// also enforced server-side: it keeps the picker (open to all staff) from being
+// used to enumerate the guardian pool one letter at a time (#1513).
+const MIN_QUERY_LENGTH = 3;
+const SEARCH_DEBOUNCE_MS = 300;
+
+// Neutral, name-free label for how many other children a guardian is linked to.
+// The picker never shows those children's names (they may belong to families the
+// staff member doesn't supervise) — only the count, for disambiguation.
+function linkedChildrenLabel(count: number): string {
+  return count === 1
+    ? "Erziehungsberechtigte/r von 1 weiteren Kind"
+    : `Erziehungsberechtigte/r von ${count} weiteren Kindern`;
+}
+
+interface GuardianPickerPanelProps {
+  // Called once the staff member has chosen an existing guardian and set the
+  // relationship flags for THIS child. The picker never mutates the profile.
+  readonly onSelect: (
+    guardian: Guardian,
+    relationship: RelationshipFormData,
+  ) => void;
+  // Collapses the panel without selecting anyone.
+  readonly onCancel: () => void;
+  // Guardian profile ids already added to / linked with this child. Shown
+  // greyed-out so the same person can't be added twice.
+  readonly excludeProfileIds?: readonly string[];
+}
+
+// Stable empty default so the prop keeps referential equality across renders.
+const EMPTY_PROFILE_IDS: readonly string[] = [];
+
+// Relationship defaults mirror createEmptyEntry() in the guardian form so the
+// "new" and "existing" paths start from the same place.
+const DEFAULT_RELATIONSHIP: RelationshipFormData = {
+  relationshipType: "parent",
+  isPrimary: false,
+  isEmergencyContact: false,
+  canPickup: true,
+  emergencyPriority: 1,
+};
+
+// GuardianPickerPanel is the INLINE (non-modal) counterpart to "Neu anlegen".
+// Linking an existing guardian is just a lookup, so it expands in place inside
+// the host form/card instead of stacking a second modal — which also makes the
+// two paths visually distinct. The host mounts it only while active, so every
+// open starts from a fresh state.
+export default function GuardianPickerPanel({
+  onSelect,
+  onCancel,
+  excludeProfileIds = EMPTY_PROFILE_IDS,
+}: GuardianPickerPanelProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Guardian[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Guardian | null>(null);
+  const [relationship, setRelationship] =
+    useState<RelationshipFormData>(DEFAULT_RELATIONSHIP);
+
+  // Debounced search. Skips firing while a guardian is already selected (the
+  // relationship step) or while the query is too short.
+  useEffect(() => {
+    if (selected) return;
+
+    const trimmed = query.trim();
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      setResults([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    let cancelled = false;
+    const handle = setTimeout(() => {
+      searchGuardians(trimmed)
+        .then((found) => {
+          if (!cancelled) {
+            setResults(found);
+            setError(null);
+          }
+        })
+        .catch((err: unknown) => {
+          if (!cancelled) {
+            // Log the technical detail, but never surface a raw (English)
+            // backend/JS message to the user — show a German message instead.
+            logger.error("guardian_search_failed", {
+              error: err instanceof Error ? err.message : String(err),
+            });
+            setResults([]);
+            setError("Suche fehlgeschlagen. Bitte erneut versuchen.");
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [query, selected]);
+
+  const updateRelationship = (field: RelationshipFlag, value: boolean) => {
+    setRelationship((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleConfirm = () => {
+    if (!selected) return;
+    onSelect(selected, relationship);
+  };
+
+  const excluded = new Set(excludeProfileIds);
+
+  return (
+    <div
+      data-testid="guardian-picker-panel"
+      className="space-y-3 rounded-xl border border-[#5080D8]/40 bg-blue-50/40 p-3 md:p-4"
+    >
+      {/* Panel header */}
+      <div className="flex items-center justify-between">
+        <h4 className="flex items-center gap-2 text-xs font-semibold text-gray-900 md:text-sm">
+          <Search className="h-3.5 w-3.5 text-blue-600 md:h-4 md:w-4" />
+          Vorhandene/n suchen
+        </h4>
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Suche schließen"
+          className="rounded-lg p-1 text-gray-400 transition-colors hover:bg-white/60 hover:text-gray-600"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {selected ? (
+        <div className="space-y-3">
+          {/* Chosen person (read-only) */}
+          <div className="rounded-lg border border-gray-200 bg-white p-3">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold text-gray-900">
+                  {getGuardianFullName(selected)}
+                </p>
+                {selected.email && (
+                  <p className="truncate text-xs text-gray-500">
+                    {selected.email}
+                  </p>
+                )}
+                {selected.linkedChildrenCount !== undefined &&
+                  selected.linkedChildrenCount > 0 && (
+                    <p className="mt-0.5 truncate text-xs text-gray-500">
+                      {linkedChildrenLabel(selected.linkedChildrenCount)}
+                    </p>
+                  )}
+              </div>
+              <button
+                type="button"
+                onClick={() => setSelected(null)}
+                className="flex flex-shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-white/60"
+              >
+                <ArrowLeft className="h-3.5 w-3.5" />
+                Andere wählen
+              </button>
+            </div>
+          </div>
+
+          {/* Relationship for THIS child only (shared with the guardian form) */}
+          <RelationshipTypeSelect
+            id="picker-relationship-type"
+            value={relationship.relationshipType}
+            onChange={(value) =>
+              setRelationship((prev) => ({ ...prev, relationshipType: value }))
+            }
+          />
+          <RelationshipPermissionsFields
+            isPrimary={relationship.isPrimary}
+            canPickup={relationship.canPickup}
+            isEmergencyContact={relationship.isEmergencyContact}
+            onChange={updateRelationship}
+          />
+
+          <button
+            type="button"
+            onClick={handleConfirm}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-gray-900 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-gray-700 md:text-sm"
+          >
+            <Check className="h-4 w-4" />
+            Hinzufügen
+          </button>
+        </div>
+      ) : (
+        <>
+          {/* Search input */}
+          <div className="relative">
+            <Search className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+              placeholder="Name oder E-Mail suchen…"
+              className="block w-full rounded-lg border border-gray-200 bg-white py-2 pr-3 pl-9 text-sm transition-colors focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8]"
+            />
+          </div>
+
+          {error && (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-2 md:p-3">
+              <p className="text-xs text-red-800 md:text-sm">{error}</p>
+            </div>
+          )}
+
+          {/* Results */}
+          <div className="max-h-72 space-y-2 overflow-y-auto">
+            {loading && (
+              <p className="px-1 py-4 text-center text-xs text-gray-500">
+                Suche läuft…
+              </p>
+            )}
+
+            {!loading &&
+              query.trim().length >= MIN_QUERY_LENGTH &&
+              results.length === 0 &&
+              !error && (
+                <p className="px-1 py-4 text-center text-xs text-gray-500">
+                  Keine Erziehungsberechtigten gefunden.
+                </p>
+              )}
+
+            {!loading && query.trim().length < MIN_QUERY_LENGTH && (
+              <p className="px-1 py-4 text-center text-xs text-gray-400">
+                Mindestens {MIN_QUERY_LENGTH} Zeichen eingeben.
+              </p>
+            )}
+
+            {!loading && results.length >= GUARDIAN_PICKER_RESULT_LIMIT && (
+              <p className="px-1 pt-1 text-center text-xs text-gray-400">
+                Viele Treffer – bitte den Namen weiter eingrenzen.
+              </p>
+            )}
+
+            {results.map((guardian) => {
+              const isExcluded = excluded.has(guardian.id);
+              return (
+                <button
+                  key={guardian.id}
+                  type="button"
+                  disabled={isExcluded}
+                  onClick={() => setSelected(guardian)}
+                  className={`flex w-full items-start gap-2 rounded-lg border p-2 text-left transition-colors md:p-3 ${
+                    isExcluded
+                      ? "cursor-not-allowed border-gray-100 bg-gray-50 opacity-60"
+                      : "border-gray-100 bg-white hover:border-[#5080D8] hover:bg-blue-50/40"
+                  }`}
+                >
+                  <Users className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-600" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-xs font-medium text-gray-900 md:text-sm">
+                      {getGuardianFullName(guardian)}
+                      {isExcluded && (
+                        <span className="ml-2 font-normal text-gray-500">
+                          (bereits hinzugefügt)
+                        </span>
+                      )}
+                    </p>
+                    {guardian.email && (
+                      <p className="truncate text-xs text-gray-500">
+                        {guardian.email}
+                      </p>
+                    )}
+                    {guardian.linkedChildrenCount !== undefined &&
+                      guardian.linkedChildrenCount > 0 && (
+                        <p className="truncate text-xs text-gray-400">
+                          {linkedChildrenLabel(guardian.linkedChildrenCount)}
+                        </p>
+                      )}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/guardians/guardian-relationship-fields.tsx
+++ b/frontend/src/components/guardians/guardian-relationship-fields.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { RELATIONSHIP_TYPES } from "@/lib/guardian-helpers";
+
+// Shared relationship UI used by BOTH the multi-guardian form (create/edit) and
+// the existing-guardian picker (#1513). Extracting these blocks keeps the two
+// paths from drifting on relationship-type options, permission labels, or the
+// emergency-contact styling. The markup is byte-for-byte the original
+// GuardianFormModal markup, so the form renders identically after the swap.
+
+interface RelationshipTypeSelectProps {
+  readonly id: string;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly disabled?: boolean;
+}
+
+// RelationshipTypeSelect renders the "Beziehung zum Kind" dropdown.
+export function RelationshipTypeSelect({
+  id,
+  value,
+  onChange,
+  disabled = false,
+}: RelationshipTypeSelectProps) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1 block text-xs font-medium text-gray-700"
+      >
+        Beziehung zum Kind
+      </label>
+      <div className="relative">
+        <select
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="block w-full appearance-none rounded-lg border border-gray-200 bg-white px-3 py-2 pr-10 text-sm transition-colors focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8]"
+          disabled={disabled}
+        >
+          {RELATIONSHIP_TYPES.map((type) => (
+            <option key={type.value} value={type.value}>
+              {type.label}
+            </option>
+          ))}
+        </select>
+        <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-500">
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export type RelationshipFlag = "isPrimary" | "canPickup" | "isEmergencyContact";
+
+interface RelationshipPermissionsFieldsProps {
+  readonly isPrimary: boolean;
+  readonly canPickup: boolean;
+  readonly isEmergencyContact: boolean;
+  readonly onChange: (field: RelationshipFlag, value: boolean) => void;
+  readonly disabled?: boolean;
+}
+
+// RelationshipPermissionsFields renders the "Berechtigungen" block
+// (Hauptansprechpartner, Abholberechtigt) plus the "Notfallkontakt" block.
+export function RelationshipPermissionsFields({
+  isPrimary,
+  canPickup,
+  isEmergencyContact,
+  onChange,
+  disabled = false,
+}: RelationshipPermissionsFieldsProps) {
+  return (
+    <>
+      {/* Relationship Flags */}
+      <div className="rounded-xl border border-gray-100 bg-blue-50/30 p-3 md:p-4">
+        <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold text-gray-900 md:mb-4 md:text-sm">
+          <svg
+            className="h-3.5 w-3.5 text-blue-600 md:h-4 md:w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+            />
+          </svg>
+          Berechtigungen
+        </h3>
+        <div className="space-y-2">
+          <label className="flex cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 transition-colors hover:bg-white/50">
+            <input
+              type="checkbox"
+              checked={isPrimary}
+              onChange={(e) => onChange("isPrimary", e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-purple-600 focus:ring-purple-600"
+              disabled={disabled}
+            />
+            <span className="text-sm text-gray-700">Hauptansprechpartner</span>
+          </label>
+          <label className="flex cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 transition-colors hover:bg-white/50">
+            <input
+              type="checkbox"
+              checked={canPickup}
+              onChange={(e) => onChange("canPickup", e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-600"
+              disabled={disabled}
+            />
+            <span className="text-sm text-gray-700">Abholberechtigt</span>
+          </label>
+        </div>
+      </div>
+
+      {/* Emergency Contact */}
+      <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-2">
+        <label className="group flex cursor-pointer items-center gap-3">
+          <input
+            type="checkbox"
+            checked={isEmergencyContact}
+            onChange={(e) => onChange("isEmergencyContact", e.target.checked)}
+            className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-600"
+            disabled={disabled}
+            aria-label="Als Notfallkontakt markieren"
+          />
+          <div className="flex items-center gap-2">
+            <svg
+              className="h-5 w-5 text-red-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            <span className="text-sm font-medium text-red-900">
+              Notfallkontakt
+            </span>
+          </div>
+        </label>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/guardians/student-guardian-manager.test.tsx
+++ b/frontend/src/components/guardians/student-guardian-manager.test.tsx
@@ -137,6 +137,55 @@ vi.mock("./guardian-form-modal", () => ({
     ) : null,
 }));
 
+// Mock the inline existing-guardian picker panel. It's mounted only while the
+// picker is open, so it renders here whenever present and exposes one button
+// that fires onSelect with a canned EXISTING guardian + relationship (the shape
+// the real panel emits). This exercises the manager's link-existing wiring
+// without driving the real search UI. A second button exercises onCancel.
+vi.mock("./guardian-picker-panel", () => ({
+  default: ({
+    onSelect,
+    onCancel,
+  }: {
+    onSelect: (guardian: unknown, relationship: unknown) => void;
+    onCancel: () => void;
+    excludeProfileIds?: readonly string[];
+  }) => (
+    <div data-testid="guardian-picker-panel">
+      <button
+        type="button"
+        data-testid="picker-select"
+        onClick={() =>
+          onSelect(
+            {
+              id: "777",
+              firstName: "Hans",
+              lastName: "Schmidt",
+              email: "hans@example.com",
+              phoneNumbers: [],
+              preferredContactMethod: "",
+              languagePreference: "",
+              hasAccount: false,
+            },
+            {
+              relationshipType: "parent",
+              isPrimary: false,
+              isEmergencyContact: false,
+              canPickup: true,
+              emergencyPriority: 1,
+            },
+          )
+        }
+      >
+        MockPickExisting
+      </button>
+      <button type="button" data-testid="picker-cancel" onClick={onCancel}>
+        MockCancelPicker
+      </button>
+    </div>
+  ),
+}));
+
 vi.mock("./guardian-delete-modal", () => ({
   GuardianDeleteModal: ({
     isOpen,
@@ -618,6 +667,122 @@ describe("StudentGuardianManager", () => {
           screen.queryByTestId("guardian-form-modal"),
         ).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe("Select Existing Guardian Flow", () => {
+    it("opens the picker when the search button is clicked", async () => {
+      render(<StudentGuardianManager studentId="student-123" />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByTitle("Vorhandene/n Erziehungsberechtigte/n suchen"),
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(
+        screen.getByTitle("Vorhandene/n Erziehungsberechtigte/n suchen"),
+      );
+
+      expect(screen.getByTestId("guardian-picker-panel")).toBeInTheDocument();
+    });
+
+    it("links the picked existing guardian and shows a success toast", async () => {
+      mockLinkGuardianToStudent.mockResolvedValue(undefined);
+
+      render(<StudentGuardianManager studentId="student-123" />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByTitle("Vorhandene/n Erziehungsberechtigte/n suchen"),
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(
+        screen.getByTitle("Vorhandene/n Erziehungsberechtigte/n suchen"),
+      );
+      fireEvent.click(screen.getByTestId("picker-select"));
+
+      // The existing-guardian path links (never creates) with the profile id +
+      // the relationship flags chosen for THIS child.
+      await waitFor(() => {
+        expect(mockLinkGuardianToStudent).toHaveBeenCalledWith("student-123", {
+          guardianProfileId: "777",
+          relationshipType: "parent",
+          isPrimary: false,
+          isEmergencyContact: false,
+          canPickup: true,
+          emergencyPriority: 1,
+        });
+      });
+      // Never creates a profile or writes phone numbers on the existing path.
+      expect(mockCreateGuardian).not.toHaveBeenCalled();
+      expect(mockAddGuardianPhoneNumber).not.toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(mockToastSuccess).toHaveBeenCalledWith(
+          "Hans Schmidt wurde erfolgreich hinzugefügt",
+        );
+      });
+      // Picker closes after a selection.
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("guardian-picker-panel"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows a German error toast when linking the existing guardian fails", async () => {
+      mockLinkGuardianToStudent.mockRejectedValue(
+        new Error("guardian already linked"),
+      );
+
+      render(<StudentGuardianManager studentId="student-123" />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByTitle("Vorhandene/n Erziehungsberechtigte/n suchen"),
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(
+        screen.getByTitle("Vorhandene/n Erziehungsberechtigte/n suchen"),
+      );
+      fireEvent.click(screen.getByTestId("picker-select"));
+
+      await waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith(
+          "Fehler beim Verknüpfen der/des Erziehungsberechtigten",
+        );
+      });
+      // A raw backend message must never reach the user.
+      expect(mockToastError).not.toHaveBeenCalledWith(
+        "guardian already linked",
+      );
+    });
+
+    it("closes the picker without linking when cancelled", async () => {
+      render(<StudentGuardianManager studentId="student-123" />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByTitle("Vorhandene/n Erziehungsberechtigte/n suchen"),
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(
+        screen.getByTitle("Vorhandene/n Erziehungsberechtigte/n suchen"),
+      );
+      expect(screen.getByTestId("guardian-picker-panel")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("picker-cancel"));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("guardian-picker-panel"),
+        ).not.toBeInTheDocument();
+      });
+      expect(mockLinkGuardianToStudent).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/components/guardians/student-guardian-manager.tsx
+++ b/frontend/src/components/guardians/student-guardian-manager.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus, Search } from "lucide-react";
 import GuardianList from "./guardian-list";
 import GuardianFormModal from "./guardian-form-modal";
+import GuardianPickerPanel from "./guardian-picker-panel";
 import { GuardianDeleteModal } from "./guardian-delete-modal";
 import type {
+  Guardian,
   GuardianWithRelationship,
   GuardianFormData,
   PhoneType,
@@ -45,6 +47,7 @@ export default function StudentGuardianManager({
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [editingGuardian, setEditingGuardian] = useState<
     GuardianWithRelationship | undefined
   >();
@@ -53,7 +56,7 @@ export default function StudentGuardianManager({
     GuardianWithRelationship | undefined
   >();
   const [isDeleting, setIsDeleting] = useState(false);
-  const { success: toastSuccess } = useToast();
+  const { success: toastSuccess, error: toastError } = useToast();
 
   // Load guardians
   const loadGuardians = useCallback(async () => {
@@ -160,6 +163,34 @@ export default function StudentGuardianManager({
             : `${successCount} Erziehungsberechtigte erfolgreich hinzugefügt`,
         );
       }
+    }
+  };
+
+  // Link an existing guardian chosen from the picker (sibling case). Unlike the
+  // create path this never creates a profile — it only links the chosen one with
+  // the relationship flags set for THIS child.
+  const handleSelectExistingGuardian = async (
+    guardian: Guardian,
+    relationship: RelationshipFormData,
+  ) => {
+    try {
+      await linkGuardianToStudent(studentId, {
+        guardianProfileId: guardian.id,
+        ...relationship,
+      });
+      await loadGuardians();
+      onUpdate?.();
+      toastSuccess(
+        `${getGuardianFullName(guardian)} wurde erfolgreich hinzugefügt`,
+      );
+    } catch (err) {
+      // Log the technical detail; show the user a German message only (the
+      // link API throws raw, often English, backend strings).
+      logger.error("guardian_link_existing_failed", {
+        error: err instanceof Error ? err.message : String(err),
+        student_id: studentId,
+      });
+      toastError("Fehler beim Verknüpfen der/des Erziehungsberechtigten");
     }
   };
 
@@ -421,17 +452,42 @@ export default function StudentGuardianManager({
             </span>
           )}
           {!readOnly && (
-            <button
-              onClick={handleOpenCreateModal}
-              className="inline-flex items-center gap-1 rounded-lg bg-gray-900 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-gray-700"
-              title="Erziehungsberechtigte/n hinzufügen"
-            >
-              <Plus className="h-4 w-4" />
-              <span className="hidden sm:inline">Hinzufügen</span>
-            </button>
+            <>
+              <button
+                onClick={() => setIsPickerOpen(true)}
+                className="inline-flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                title="Vorhandene/n Erziehungsberechtigte/n suchen"
+              >
+                <Search className="h-4 w-4" />
+                <span className="hidden sm:inline">Vorhandene/n suchen</span>
+              </button>
+              <button
+                onClick={handleOpenCreateModal}
+                className="inline-flex items-center gap-1 rounded-lg bg-gray-900 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-gray-700"
+                title="Erziehungsberechtigte/n hinzufügen"
+              >
+                <Plus className="h-4 w-4" />
+                <span className="hidden sm:inline">Hinzufügen</span>
+              </button>
+            </>
           )}
         </div>
       </div>
+
+      {/* Existing-guardian picker (sibling case) — inline, not a modal, since a
+          search is a light lookup. "Hinzufügen" opens the heavy form modal. */}
+      {isPickerOpen && (
+        <div className="mb-3">
+          <GuardianPickerPanel
+            onSelect={(guardian, relationship) => {
+              setIsPickerOpen(false);
+              void handleSelectExistingGuardian(guardian, relationship);
+            }}
+            onCancel={() => setIsPickerOpen(false)}
+            excludeProfileIds={guardians.map((g) => g.id)}
+          />
+        </div>
+      )}
 
       {/* Guardian List */}
       <div className="space-y-3">

--- a/frontend/src/components/students/student-create-modal.test.tsx
+++ b/frontend/src/components/students/student-create-modal.test.tsx
@@ -162,6 +162,49 @@ vi.mock("~/components/guardians/guardian-form-modal", () => ({
     ) : null,
 }));
 
+// Mock the inline existing-guardian picker panel: it's mounted only while
+// active, so it always renders here and exposes a button that calls onSelect
+// with one canned EXISTING guardian + relationship (the shape the real panel
+// emits). Lets us exercise StudentCreateModal's link-existing collection without
+// driving the real search UI.
+vi.mock("~/components/guardians/guardian-picker-panel", () => ({
+  default: ({
+    onSelect,
+  }: {
+    onSelect: (guardian: unknown, relationship: unknown) => void;
+    onCancel: () => void;
+  }) => (
+    <div data-testid="guardian-picker-panel">
+      <button
+        type="button"
+        onClick={() =>
+          onSelect(
+            {
+              id: "777",
+              firstName: "Hans",
+              lastName: "Schmidt",
+              email: "hans@example.com",
+              phoneNumbers: [],
+              preferredContactMethod: "email",
+              languagePreference: "de",
+              hasAccount: false,
+            },
+            {
+              relationshipType: "parent",
+              isPrimary: false,
+              isEmergencyContact: false,
+              canPickup: true,
+              emergencyPriority: 1,
+            },
+          )
+        }
+      >
+        MockPickExisting
+      </button>
+    </div>
+  ),
+}));
+
 // Mock validation utilities
 vi.mock("~/lib/student-form-validation", () => ({
   validateStudentForm: vi.fn(() => ({})),
@@ -462,7 +505,7 @@ describe("StudentCreateModal", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByText("Erziehungsberechtigte hinzufügen"));
+      fireEvent.click(screen.getByText("Neu anlegen"));
     });
 
     expect(screen.getByTestId("guardian-form-modal")).toBeInTheDocument();
@@ -478,7 +521,7 @@ describe("StudentCreateModal", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByText("Erziehungsberechtigte hinzufügen"));
+      fireEvent.click(screen.getByText("Neu anlegen"));
     });
     await act(async () => {
       fireEvent.click(screen.getByText("MockSubmitGuardian"));
@@ -505,7 +548,7 @@ describe("StudentCreateModal", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByText("Erziehungsberechtigte hinzufügen"));
+      fireEvent.click(screen.getByText("Neu anlegen"));
     });
     await act(async () => {
       fireEvent.click(screen.getByText("MockSubmitGuardian"));
@@ -537,7 +580,7 @@ describe("StudentCreateModal", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByText("Erziehungsberechtigte hinzufügen"));
+      fireEvent.click(screen.getByText("Neu anlegen"));
     });
     await act(async () => {
       fireEvent.click(screen.getByText("MockSubmitGuardian"));
@@ -603,5 +646,93 @@ describe("StudentCreateModal", () => {
     const submitted = vi.mocked(handleStudentFormSubmit).mock
       .calls[0]?.[1] as Record<string, unknown>;
     expect(submitted).not.toHaveProperty("guardians");
+  });
+
+  it("opens the existing-guardian picker when the search button is clicked", async () => {
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Vorhandene/n suchen"));
+    });
+
+    expect(screen.getByTestId("guardian-picker-panel")).toBeInTheDocument();
+  });
+
+  it("adds a picked existing guardian to the summary list", async () => {
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Vorhandene/n suchen"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("MockPickExisting"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Hans Schmidt/)).toBeInTheDocument();
+    });
+    expect(screen.getByText("1 hinzugefügt")).toBeInTheDocument();
+    // Picker closes after a selection.
+    expect(
+      screen.queryByTestId("guardian-picker-panel"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("forwards a picked existing guardian with guardian_profile_id to onCreate", async () => {
+    mockOnCreate.mockResolvedValue(undefined);
+
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Vorhandene/n suchen"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("MockPickExisting"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Hans Schmidt/)).toBeInTheDocument();
+    });
+
+    const form = screen.getByTestId("modal").querySelector("form");
+    await act(async () => {
+      fireEvent.submit(form!);
+    });
+
+    await waitFor(() => {
+      expect(handleStudentFormSubmit).toHaveBeenCalled();
+    });
+
+    // The existing selection must carry guardian_profile_id (link, not create)
+    // and the relationship flags, with no phone numbers.
+    const submitted = vi.mocked(handleStudentFormSubmit).mock
+      .calls[0]?.[1] as Record<string, unknown>;
+    expect(submitted).toMatchObject({
+      guardians: [
+        {
+          guardian_profile_id: 777,
+          relationship_type: "parent",
+          can_pickup: true,
+          phone_numbers: [],
+        },
+      ],
+    });
   });
 });

--- a/frontend/src/components/students/student-create-modal.tsx
+++ b/frontend/src/components/students/student-create-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Users, Plus, Trash2 } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { Users, Plus, Search, Trash2 } from "lucide-react";
 import { Modal } from "~/components/ui/modal";
 import type { Student } from "@/lib/api";
 import {
@@ -17,8 +17,10 @@ import {
 import GuardianFormModal, {
   type RelationshipFormData,
 } from "~/components/guardians/guardian-form-modal";
+import GuardianPickerPanel from "~/components/guardians/guardian-picker-panel";
 import {
   RELATIONSHIP_TYPES,
+  type Guardian,
   type GuardianFormData,
   type PhoneType,
   type StudentGuardianPayload,
@@ -74,6 +76,29 @@ function toGuardianPayloads(
   }));
 }
 
+// Maps a guardian chosen from the picker (an EXISTING profile) plus the
+// relationship flags onto the create-student payload. guardian_profile_id tells
+// the backend to link the existing profile instead of creating a new one; the
+// name rides along only for the summary list and is ignored server-side. The
+// email is deliberately NOT carried — the backend ignores profile fields for an
+// existing link anyway, so there's no reason to round-trip it.
+function toExistingGuardianPayload(
+  guardian: Guardian,
+  relationship: RelationshipFormData,
+): StudentGuardianPayload {
+  return {
+    guardian_profile_id: Number(guardian.id),
+    first_name: guardian.firstName,
+    last_name: guardian.lastName,
+    relationship_type: relationship.relationshipType,
+    is_primary: relationship.isPrimary,
+    is_emergency_contact: relationship.isEmergencyContact,
+    can_pickup: relationship.canPickup,
+    emergency_priority: relationship.emergencyPriority,
+    phone_numbers: [],
+  };
+}
+
 // Human-readable relationship label for the summary list.
 function relationshipLabel(value: string): string {
   return RELATIONSHIP_TYPES.find((t) => t.value === value)?.label ?? value;
@@ -114,6 +139,13 @@ export function StudentCreateModal({
   const [saveLoading, setSaveLoading] = useState(false);
   const [guardians, setGuardians] = useState<StudentGuardianPayload[]>([]);
   const [guardianModalOpen, setGuardianModalOpen] = useState(false);
+  const [guardianPickerOpen, setGuardianPickerOpen] = useState(false);
+  // The inline picker panel is tall; collapsing it (on add or cancel) shrinks
+  // the modal so the kept scroll position lands further down the form. Re-anchor
+  // to the guardian section so the user stays where they acted and sees the
+  // result (the added guardian) instead of jumping past it.
+  const guardianSectionRef = useRef<HTMLDivElement>(null);
+  const pendingGuardianScrollRef = useRef(false);
 
   // Reset form when modal opens/closes
   useEffect(() => {
@@ -135,8 +167,22 @@ export function StudentCreateModal({
       setErrors({});
       setGuardians([]);
       setGuardianModalOpen(false);
+      setGuardianPickerOpen(false);
+      pendingGuardianScrollRef.current = false;
     }
   }, [isOpen]);
+
+  // After the inline picker collapses (add or cancel), re-anchor to the guardian
+  // section so the shrinking modal doesn't leave the user scrolled past it.
+  useEffect(() => {
+    if (pendingGuardianScrollRef.current) {
+      pendingGuardianScrollRef.current = false;
+      guardianSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      });
+    }
+  }, [guardians, guardianPickerOpen]);
 
   // Collect guardians from the reused GuardianFormModal into local state. The
   // guardians are persisted together with the student in one request — no API
@@ -146,9 +192,39 @@ export function StudentCreateModal({
     setGuardianModalOpen(false);
   };
 
+  // Link an existing guardian chosen from the picker. Dedup defensively: if the
+  // same profile is already in the list, skip it (the picker also greys out
+  // already-added profiles, so this only guards a race).
+  const handleGuardianPick = (
+    guardian: Guardian,
+    relationship: RelationshipFormData,
+  ) => {
+    const profileId = Number(guardian.id);
+    setGuardians((prev) =>
+      prev.some((g) => g.guardian_profile_id === profileId)
+        ? prev
+        : [...prev, toExistingGuardianPayload(guardian, relationship)],
+    );
+    pendingGuardianScrollRef.current = true;
+    setGuardianPickerOpen(false);
+  };
+
+  // Collapse the inline picker without selecting; re-anchor like the add path.
+  const handlePickerCancel = () => {
+    pendingGuardianScrollRef.current = true;
+    setGuardianPickerOpen(false);
+  };
+
   const removeGuardian = (index: number) => {
     setGuardians((prev) => prev.filter((_, i) => i !== index));
   };
+
+  // Profile ids already added — passed to the picker so it greys out
+  // guardians that are already on this child.
+  const addedProfileIds = guardians
+    .map((g) => g.guardian_profile_id)
+    .filter((id): id is number => id !== undefined)
+    .map((id) => id.toString());
 
   const validateForm = (): boolean => {
     const newErrors = validateStudentForm(formData, {
@@ -215,7 +291,10 @@ export function StudentCreateModal({
               matches the other modal sections (border-gray-100 + blue tint,
               blue heading icon) and reuses the guardian modal's own dashed
               add-button and red remove patterns. */}
-          <div className="rounded-xl border border-gray-100 bg-blue-50/30 p-3 md:p-4">
+          <div
+            ref={guardianSectionRef}
+            className="scroll-mt-4 rounded-xl border border-gray-100 bg-blue-50/30 p-3 md:p-4"
+          >
             <div className="mb-3 flex items-center justify-between md:mb-4">
               <h3 className="flex items-center gap-2 text-xs font-semibold text-gray-900 md:text-sm">
                 <Users className="h-3.5 w-3.5 text-blue-600 md:h-4 md:w-4" />
@@ -270,15 +349,37 @@ export function StudentCreateModal({
               </ul>
             )}
 
-            <button
-              type="button"
-              onClick={() => setGuardianModalOpen(true)}
-              disabled={saveLoading}
-              className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 py-2 text-xs font-medium text-gray-600 transition-all duration-200 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
-            >
-              <Plus className="h-4 w-4" />
-              Erziehungsberechtigte hinzufügen
-            </button>
+            {guardianPickerOpen ? (
+              // Existing-guardian path is inline (not a second modal): a search
+              // is a light lookup, so it expands here in place. "Neu anlegen"
+              // stays a full modal because the new-guardian form is heavy.
+              <GuardianPickerPanel
+                onSelect={handleGuardianPick}
+                onCancel={handlePickerCancel}
+                excludeProfileIds={addedProfileIds}
+              />
+            ) : (
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <button
+                  type="button"
+                  onClick={() => setGuardianModalOpen(true)}
+                  disabled={saveLoading}
+                  className="flex flex-1 items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 py-2 text-xs font-medium text-gray-600 transition-all duration-200 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                >
+                  <Plus className="h-4 w-4" />
+                  Neu anlegen
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setGuardianPickerOpen(true)}
+                  disabled={saveLoading}
+                  className="flex flex-1 items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 py-2 text-xs font-medium text-gray-600 transition-all duration-200 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                >
+                  <Search className="h-4 w-4" />
+                  Vorhandene/n suchen
+                </button>
+              </div>
+            )}
           </div>
 
           {/* Common Form Sections */}

--- a/frontend/src/lib/guardian-api.test.ts
+++ b/frontend/src/lib/guardian-api.test.ts
@@ -49,6 +49,16 @@ describe("translateApiError", () => {
     ).toBe("Diese E-Mail-Adresse wird bereits verwendet");
   });
 
+  it("surfaces the 'use the search' guidance for a duplicate email on create (#1513)", () => {
+    expect(
+      translateApiError(
+        'E-Mail-Adresse "peter.berger@email.de" ist bereits vergeben – bitte die vorhandene Person über die Suche auswählen',
+      ),
+    ).toBe(
+      "Diese E-Mail-Adresse ist bereits vergeben. Bitte die vorhandene Person über die Suche auswählen.",
+    );
+  });
+
   it("translates 'guardian not found' to German", () => {
     expect(translateApiError("guardian not found")).toBe(
       "Erziehungsberechtigte/r nicht gefunden",
@@ -168,8 +178,8 @@ describe("errorTranslations", () => {
     }
   });
 
-  it("has exactly 11 error translations", () => {
-    expect(Object.keys(errorTranslations).length).toBe(11);
+  it("has exactly 12 error translations", () => {
+    expect(Object.keys(errorTranslations).length).toBe(12);
   });
 });
 
@@ -872,7 +882,9 @@ describe("guardian-api functions", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]!.firstName).toBe("John");
-      expect(global.fetch).toHaveBeenCalledWith("/api/guardians?search=john");
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/guardians/search?q=john&page_size=50",
+      );
     });
 
     it("encodes search query properly", async () => {
@@ -888,7 +900,7 @@ describe("guardian-api functions", () => {
       await searchGuardians("john doe & sons");
 
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/guardians?search=john%20doe%20%26%20sons",
+        "/api/guardians/search?q=john%20doe%20%26%20sons&page_size=50",
       );
     });
 

--- a/frontend/src/lib/guardian-api.ts
+++ b/frontend/src/lib/guardian-api.ts
@@ -8,6 +8,7 @@ import type {
   GuardianFormData,
   StudentGuardianLinkRequest,
   BackendGuardianProfile,
+  BackendGuardianPickerResponse,
   BackendGuardianWithRelationship,
   PhoneNumber,
   PhoneNumberCreateRequest,
@@ -16,6 +17,7 @@ import type {
 } from "./guardian-helpers";
 import {
   mapGuardianResponse,
+  mapGuardianPickerResponse,
   mapGuardianWithRelationshipResponse,
   mapGuardianFormDataToBackend,
   mapStudentGuardianLinkToBackend,
@@ -67,6 +69,12 @@ function isErrorResponse(value: unknown): value is ErrorResponse {
 export const errorTranslations: Record<string, string> = {
   "invalid email format": "Ungültiges E-Mail-Format",
   "bereits registriert": "Diese E-Mail-Adresse wird bereits verwendet",
+  // Duplicate-email on guardian create (#1513): the backend already sends a
+  // German message, but translateApiError replaces any unrecognised string with
+  // the generic catch-all — so this pattern is required for the helpful
+  // "use the search" guidance to reach the user.
+  "bereits vergeben":
+    "Diese E-Mail-Adresse ist bereits vergeben. Bitte die vorhandene Person über die Suche auswählen.",
   "guardian not found": "Erziehungsberechtigte/r nicht gefunden",
   "student not found": "Schüler/in nicht gefunden",
   "relationship already exists": "Diese Verknüpfung existiert bereits",
@@ -515,12 +523,20 @@ export async function removeGuardianFromStudent(
   }
 }
 
+// Hard ceiling on guardian picker results, requested explicitly so the picker
+// doesn't silently ride on whatever the backend's default page size happens to
+// be. The backend clamps to the same value (maxGuardianPickerResults); keep the
+// two in sync. The picker uses it to detect "the list was capped" — when a
+// search returns exactly this many rows, more may exist and the user should
+// narrow their query rather than assume the person isn't there (#1513).
+export const GUARDIAN_PICKER_RESULT_LIMIT = 50;
+
 /**
  * Search for existing guardians (for linking)
  */
 export async function searchGuardians(query: string): Promise<Guardian[]> {
   const response = await fetch(
-    `/api/guardians?search=${encodeURIComponent(query)}`,
+    `/api/guardians/search?q=${encodeURIComponent(query)}&page_size=${GUARDIAN_PICKER_RESULT_LIMIT}`,
   );
 
   if (!response.ok) {
@@ -539,13 +555,13 @@ export async function searchGuardians(query: string): Promise<Guardian[]> {
   }
 
   const result =
-    (await response.json()) as PaginatedResponse<BackendGuardianProfile>;
+    (await response.json()) as PaginatedResponse<BackendGuardianPickerResponse>;
 
   if (result.status === "error") {
     throw new Error(result.error ?? "Failed to search guardians");
   }
 
-  return (result.data ?? []).map(mapGuardianResponse);
+  return (result.data ?? []).map(mapGuardianPickerResponse);
 }
 
 // =============================================================================

--- a/frontend/src/lib/guardian-helpers.ts
+++ b/frontend/src/lib/guardian-helpers.ts
@@ -44,6 +44,11 @@ export interface Guardian {
   notes?: string;
   hasAccount: boolean;
   accountId?: string;
+  // Populated only by the guardian picker search (GET /guardians/search). The
+  // picker is open to all staff, so it never carries the linked children's
+  // names — only how many other children the guardian is linked to, for
+  // disambiguation (#1513 GDPR minimization).
+  linkedChildrenCount?: number;
 }
 
 // Backend Guardian Profile Response
@@ -61,6 +66,21 @@ export interface BackendGuardianProfile {
   notes?: string;
   has_account: boolean;
   account_id?: number;
+}
+
+// Backend Guardian Picker Response (GET /guardians/search). This is the
+// deliberately minimal, enumeration-resistant projection the picker endpoint
+// emits — NOT a full profile. Address, notes, language, contact method,
+// account, and phone numbers are all withheld server-side; and only a COUNT of
+// other linked children is exposed, never their names (#1513 GDPR
+// minimization). Kept separate from BackendGuardianProfile so callers can't
+// accidentally read fields the picker never sends.
+export interface BackendGuardianPickerResponse {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email?: string;
+  linked_children_count: number;
 }
 
 // Student-Guardian Relationship
@@ -108,6 +128,11 @@ export interface GuardianFormData {
 // its guardians in one atomic request, mirroring the guardian fields managed on
 // the student detail page.
 export interface StudentGuardianPayload {
+  // When set, links an EXISTING guardian profile to the new student instead of
+  // creating one (sibling case, #1513). The profile fields below are then
+  // carried only for local display in the create modal's summary list — the
+  // backend ignores them and never mutates the existing profile.
+  guardian_profile_id?: number;
   first_name: string;
   last_name: string;
   email?: string;
@@ -197,6 +222,29 @@ export function mapGuardianResponse(data: BackendGuardianProfile): Guardian {
     notes: data.notes,
     hasAccount: data.has_account,
     accountId: data.account_id?.toString(),
+  };
+}
+
+// Maps the minimal guardian picker projection (GET /guardians/search) onto the
+// Guardian shape used by the picker UI. The picker withholds most profile fields
+// server-side, so the absent ones are filled with safe, explicit defaults rather
+// than left undefined: phoneNumbers is empty (the picker never loads them) and
+// hasAccount is false. Only id, name, email, and the linked-children COUNT carry
+// real data. Use this — never mapGuardianResponse — for picker results, so
+// nothing downstream trusts a field the picker never sent.
+export function mapGuardianPickerResponse(
+  data: BackendGuardianPickerResponse,
+): Guardian {
+  return {
+    id: data.id.toString(),
+    firstName: data.first_name,
+    lastName: data.last_name,
+    email: data.email,
+    phoneNumbers: [],
+    preferredContactMethod: "",
+    languagePreference: "",
+    hasAccount: false,
+    linkedChildrenCount: data.linked_children_count,
   };
 }
 


### PR DESCRIPTION
## Why

A second child of the same parent forced staff to **re-type the guardian from scratch**, producing duplicate guardian profiles — duplicated contact data, split pickup/emergency permissions, and a messy data set for GDPR exports. This adds an **existing-guardian picker** to both the student-create flow and the student-detail guardian manager, so a sibling's guardian is *linked*, never duplicated.

## What changed

**Backend**
- New `GET /guardians/search` — a deliberately minimal, enumeration-resistant projection (name, email, and only a **count** of other linked children — never their names, addresses, notes, language, or account). Gated on `users:read`, same as the existing guardian list.
- `guardian_profile_id` accepted on the atomic student-create guardian input: when present the existing profile is linked as-is (never created, never mutated, no phone writes) — only the relationship flags apply to the new link.
- `LinkIfNotExists` repo method (idempotent `ON CONFLICT DO NOTHING` on `(tenant_id, student_id, guardian_profile_id)`): re-linking is a silent no-op, never a unique-violation that would abort the tenant transaction. Existing relationship flags are **never** overwritten by a re-link — flag changes stay on the dedicated update path.
- `CreateGuardian` now rejects a duplicate email as a `400` ValidationError ("…bereits vergeben – bitte die vorhandene Person über die Suche auswählen") instead of a raw `500`, steering the user to the picker.
- Linked-children enrichment batched in one query — no per-guardian N+1.

**Frontend**
- New inline `GuardianPickerPanel` (search → pick → set relationship → confirm). Inline rather than a second modal because a lookup is light; "Neu anlegen" still opens the full form.
- Shared `guardian-relationship-fields` extraction so the create form and the picker can't drift on relationship/permission UI.
- Wired into `student-create-modal` (collects into the atomic payload) and `student-guardian-manager` (links immediately).
- Client guardrails mirroring the server: 3-char minimum, 300 ms debounce, result-cap hint, greys out already-added guardians.

## Security / GDPR notes
- The picker exposes **strictly less** than the existing `users:read` `GET /guardians` list (which already returns full profiles), so it does not widen the data surface — it narrows it.
- Enumeration defenses: server-enforced 3-char minimum, LIKE-metacharacter escaping with explicit `ESCAPE '\'`, a hard 50-result cap (since `ParsePagination` has no upper bound), and a token-count cap to keep the WHERE clause bounded.
- Tenant isolation is RLS-enforced on the ambient tenant transaction throughout.

## Tests
- **Backend** (hermetic, DB-backed): picker permission gate (allowed for `users:read`, 403 without), GDPR projection (count not names), full-name token search, literal-wildcard search, short-query→empty, page_size clamp, repo-level `SearchByText` contract, `LinkIfNotExists` idempotency + tenant auto-set, select-existing create / duplicate-skip / mixed new+existing / not-found→400, and duplicate-email→ValidationError.
- **Frontend**: full picker select→confirm flow, flag pass-through, exclude/greying, error path, min-length guard, plus manager/modal link-existing wiring.
- Coverage on new code ~87% backend / ~98% picker component; remaining uncovered is defensive-only (nil guards, DB-error wrapping).
- `cd frontend && pnpm run check` clean; affected backend suites + hermetic check green.

## Reviewer call-out (one open item)
`CreateGuardian`'s new duplicate-email message ("…über die Suche auswählen") is also inherited by `CreateGuardianWithInvitation`, where there's no picker. Not a regression (that path failed before too, just with a 500), but if we want context-appropriate wording there it's a small follow-up.

## Cross-repo / migrations
None. No new env vars, no schema migrations (reuses the existing `idx_students_guardians_tenant` unique index), no IoT/PyrePortal contract changes.
