### PR TITLE
feat: add arrival/pickup times to student create modal (#1502)

### DIFF
--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -829,6 +829,28 @@ func (rs *Resource) createStudent(w http.ResponseWriter, r *http.Request) {
 
 	guardians := toNewStudentGuardians(req.Guardians)
 
+	// Resolve the acting staff once — weekly schedules are stamped with
+	// CreatedBy. Only required when schedules are supplied so plain student
+	// creation (no schedules) is unaffected.
+	//
+	// Creating a student is governed by users:create, but attached weekly
+	// schedules are writes to the same Betreuungszeiten records edited by the
+	// standalone PUT endpoints. Keep that schedule write contract aligned:
+	// callers need users:update and must resolve to a staff record so schedule
+	// rows always carry a valid author.
+	var staffID int64
+	if len(req.ArrivalSchedules) > 0 || len(req.PickupSchedules) > 0 {
+		if !authorize.HasPermission(permissions.UsersUpdate, jwt.PermissionsFromCtx(r.Context())) {
+			renderError(w, r, ErrorForbidden(errors.New("users:update permission required to create student schedules")))
+			return
+		}
+		staffID, err = rs.getStaffIDFromJWT(r)
+		if err != nil {
+			renderError(w, r, ErrorForbidden(err))
+			return
+		}
+	}
+
 	tenantID := tenant.FromContext(r.Context())
 	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
 		// Validate guardians BEFORE writing the student. This route runs inside
@@ -859,6 +881,23 @@ func (rs *Resource) createStudent(w http.ResponseWriter, r *http.Request) {
 		// atomically — a guardian failure rolls back the whole student.
 		if len(guardians) > 0 {
 			if err := rs.GuardianService.AddGuardiansToStudent(ctx, student.ID, guardians); err != nil {
+				return err
+			}
+		}
+
+		// Persist weekly arrival/pickup schedules in the same transaction so the
+		// student and its recurring care times are created atomically (mirrors
+		// the guardian handling above). The schedule tables FK to the student,
+		// which now exists within this transaction.
+		if len(req.ArrivalSchedules) > 0 {
+			arrivals := toArrivalScheduleModels(req.ArrivalSchedules, student.ID, staffID)
+			if err := rs.ArrivalScheduleService.UpsertBulkStudentArrivalSchedules(ctx, student.ID, arrivals); err != nil {
+				return err
+			}
+		}
+		if len(req.PickupSchedules) > 0 {
+			pickups := toPickupScheduleModels(req.PickupSchedules, student.ID, staffID)
+			if err := rs.PickupScheduleService.UpsertBulkStudentPickupSchedules(ctx, student.ID, pickups); err != nil {
 				return err
 			}
 		}

--- a/backend/api/students/arrival_schedule_handlers.go
+++ b/backend/api/students/arrival_schedule_handlers.go
@@ -110,8 +110,16 @@ func (r *ArrivalNoteRequest) Bind(_ *http.Request) error {
 
 // Bind implements render.Binder for BulkArrivalScheduleRequest
 func (r *BulkArrivalScheduleRequest) Bind(_ *http.Request) error {
+	return validateArrivalScheduleItems(r.Schedules)
+}
+
+// validateArrivalScheduleItems validates weekday range, uniqueness, time format
+// and notes length for a set of weekly arrival schedule items. Shared by the
+// bulk-update endpoint and the atomic create-student flow so both paths enforce
+// the same rules.
+func validateArrivalScheduleItems(items []ArrivalScheduleRequestItem) error {
 	seenWeekdays := make(map[int]bool)
-	for i, s := range r.Schedules {
+	for i, s := range items {
 		if s.Weekday < schedule.WeekdayMonday || s.Weekday > schedule.WeekdayFriday {
 			return fmt.Errorf("schedule %d: weekday must be between 1 (Monday) and 5 (Friday)", i)
 		}
@@ -130,6 +138,29 @@ func (r *BulkArrivalScheduleRequest) Bind(_ *http.Request) error {
 		}
 	}
 	return nil
+}
+
+// toArrivalScheduleModels maps request items onto schedule models stamped with
+// the student and acting staff. Shared by the bulk-update endpoint and the
+// create-student flow.
+//
+// Callers MUST run validateArrivalScheduleItems first (both current callers do,
+// via their Bind): the parse error below is intentionally discarded because the
+// time format is already guaranteed valid at that point. Mapping unvalidated
+// items here would silently persist a zero time.
+func toArrivalScheduleModels(items []ArrivalScheduleRequestItem, studentID, staffID int64) []*schedule.StudentArrivalSchedule {
+	schedules := make([]*schedule.StudentArrivalSchedule, 0, len(items))
+	for _, s := range items {
+		arrivalTime, _ := parseTimeOnly(s.ExpectedArrival)
+		schedules = append(schedules, &schedule.StudentArrivalSchedule{
+			StudentID:       studentID,
+			Weekday:         s.Weekday,
+			ExpectedArrival: arrivalTime,
+			Notes:           s.Notes,
+			CreatedBy:       staffID,
+		})
+	}
+	return schedules
 }
 
 // Bind implements render.Binder for ArrivalExceptionRequest
@@ -358,17 +389,7 @@ func (rs *Resource) updateStudentArrivalSchedules(w http.ResponseWriter, r *http
 		return
 	}
 
-	schedules := make([]*schedule.StudentArrivalSchedule, 0, len(req.Schedules))
-	for _, s := range req.Schedules {
-		arrivalTime, _ := parseTimeOnly(s.ExpectedArrival)
-		schedules = append(schedules, &schedule.StudentArrivalSchedule{
-			StudentID:       student.ID,
-			Weekday:         s.Weekday,
-			ExpectedArrival: arrivalTime,
-			Notes:           s.Notes,
-			CreatedBy:       staffID,
-		})
-	}
+	schedules := toArrivalScheduleModels(req.Schedules, student.ID, staffID)
 
 	tenantID := tenant.FromContext(r.Context())
 	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {

--- a/backend/api/students/create_student_schedules_test.go
+++ b/backend/api/students/create_student_schedules_test.go
@@ -1,0 +1,399 @@
+package students_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// TestCreateStudent_WithSchedules verifies a student and its weekly arrival and
+// pickup schedules are created together in one atomic request (issue #1502),
+// mirroring the existing atomic guardian-creation path.
+func TestCreateStudent_WithSchedules(t *testing.T) {
+	tc := setupTestContext(t)
+
+	// The schedule path stamps CreatedBy from the JWT, so the acting account
+	// must resolve to a staff record (account → person → staff).
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "Schedule", "Creator")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+
+	body := map[string]interface{}{
+		"first_name":   "Scheduled",
+		"last_name":    "Child",
+		"school_class": "1a",
+		"arrival_schedules": []map[string]interface{}{
+			{"weekday": 1, "expected_arrival": "07:30", "notes": "Kommt mit Bus"},
+			{"weekday": 3, "expected_arrival": "08:00"},
+		},
+		"pickup_schedules": []map[string]interface{}{
+			{"weekday": 1, "pickup_time": "15:00"},
+			{"weekday": 3, "pickup_time": "16:30", "notes": "Oma holt ab"},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"admin:*"})
+
+	require.Equal(t, http.StatusCreated, rr.Code, "Expected 201 Created. Body: %s", rr.Body.String())
+
+	var resp createStudentResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.NotZero(t, resp.Data.ID, "expected a student id in the response")
+
+	// Schedules FK to the student with ON DELETE CASCADE, so deleting the
+	// student (via the shared guardian cleanup) also removes them.
+	defer cleanupStudentWithGuardians(t, tc, resp.Data.ID, resp.Data.PersonID)
+
+	ctx := context.Background()
+
+	arrivalCount, err := tc.db.NewSelect().
+		Model((*scheduleModel.StudentArrivalSchedule)(nil)).
+		ModelTableExpr("schedule.student_arrival_schedules").
+		Where("student_id = ?", resp.Data.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, arrivalCount, "expected two weekly arrival schedules")
+
+	pickupCount, err := tc.db.NewSelect().
+		Model((*scheduleModel.StudentPickupSchedule)(nil)).
+		ModelTableExpr("schedule.student_pickup_schedules").
+		Where("student_id = ?", resp.Data.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, pickupCount, "expected two weekly pickup schedules")
+
+	// Spot-check the persisted values: the time and notes mapped through, not
+	// silently dropped.
+	var arrival struct {
+		ExpectedArrival string  `bun:"expected_arrival"`
+		Notes           *string `bun:"notes"`
+	}
+	require.NoError(t, tc.db.NewSelect().
+		ColumnExpr("expected_arrival, notes").
+		TableExpr("schedule.student_arrival_schedules").
+		Where("student_id = ? AND weekday = ?", resp.Data.ID, 1).
+		Scan(ctx, &arrival))
+	assert.Contains(t, arrival.ExpectedArrival, "07:30", "Monday arrival time should persist")
+	require.NotNil(t, arrival.Notes)
+	assert.Equal(t, "Kommt mit Bus", *arrival.Notes)
+}
+
+// TestCreateStudent_InvalidScheduleTimeRejected verifies a malformed schedule
+// time is a client error (400) caught at Bind — before any row is written — so
+// no orphaned person/student survives.
+func TestCreateStudent_InvalidScheduleTimeRejected(t *testing.T) {
+	tc := setupTestContext(t)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "BadTimeSchedule", "Creator")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+
+	const firstName = "BadTime"
+	const lastName = "Schedule"
+
+	body := map[string]interface{}{
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"school_class": "1b",
+		"arrival_schedules": []map[string]interface{}{
+			{"weekday": 1, "expected_arrival": "invalid"},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"admin:*"})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code,
+		"invalid arrival time must return 400. Body: %s", rr.Body.String())
+
+	ctx := context.Background()
+
+	// Safety net in case a regressed validation let a row through.
+	defer func() {
+		var personIDs []int64
+		if err := tc.db.NewSelect().
+			Table("users.persons").
+			Column("id").
+			Where("first_name = ? AND last_name = ?", firstName, lastName).
+			Scan(ctx, &personIDs); err == nil {
+			for _, pid := range personIDs {
+				if _, err := tc.db.NewDelete().Table("users.students").Where("person_id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup students: %v", err)
+				}
+				if _, err := tc.db.NewDelete().Table("users.persons").Where("id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup persons: %v", err)
+				}
+			}
+		}
+	}()
+
+	personCount, err := tc.db.NewSelect().
+		Table("users.persons").
+		Where("first_name = ? AND last_name = ?", firstName, lastName).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, personCount, "person must not persist when schedule validation fails (Bind rejects before any write)")
+}
+
+// TestCreateStudent_WithSchedulesRequiresUsersUpdate pins the permission split:
+// users:create is enough for creating the student itself, but attached weekly
+// care schedules are Betreuungszeiten writes and must require the same
+// users:update permission as the standalone update endpoints.
+func TestCreateStudent_WithSchedulesRequiresUsersUpdate(t *testing.T) {
+	tc := setupTestContext(t)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "ScheduleCreateOnly", "Creator")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+
+	const firstName = "CreateOnly"
+	const lastName = "ScheduleDenied"
+
+	body := map[string]interface{}{
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"school_class": "1c",
+		"arrival_schedules": []map[string]interface{}{
+			{"weekday": 1, "expected_arrival": "07:30"},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"users:create"})
+
+	assert.Equal(t, http.StatusForbidden, rr.Code,
+		"create-only users must not create Betreuungszeiten. Body: %s", rr.Body.String())
+
+	ctx := context.Background()
+	personCount, err := tc.db.NewSelect().
+		Table("users.persons").
+		Where("first_name = ? AND last_name = ?", firstName, lastName).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, personCount, "student/person must not persist when schedule permission is missing")
+}
+
+// TestCreateStudent_GuardianFailureRollsBackSchedules verifies the combined
+// student+guardian+schedule create is one atomic unit: when the request carries
+// valid weekly schedules but an invalid guardian, the whole transaction rolls
+// back and NO schedule rows leak (mirrors the #1500 guardian-rollback test).
+//
+// Note on coverage: the schedule write is the terminal step of the create
+// transaction, every schedule field is validated at Bind, and CreatedBy is
+// guaranteed > 0 by getStaffIDFromJWT — so the schedule insert itself cannot be
+// made to fail from a black-box handler test without mocking the service. This
+// test therefore exercises the realistic atomic-failure path (a bad guardian)
+// and locks the contract that schedules never survive a rolled-back create. The
+// happy-path persistence of schedules inside the same transaction is covered by
+// TestCreateStudent_WithSchedules above.
+func TestCreateStudent_GuardianFailureRollsBackSchedules(t *testing.T) {
+	tc := setupTestContext(t)
+
+	// The schedule path resolves the acting staff from the JWT, so the account
+	// must map to a staff record (account → person → staff).
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "ScheduleRollback", "Creator")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+
+	const firstName = "ScheduleAtomic"
+	const lastName = "Orphan"
+
+	body := map[string]interface{}{
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"school_class": "1d",
+		// Valid schedules — these must not survive the rollback triggered below.
+		"arrival_schedules": []map[string]interface{}{
+			{"weekday": 1, "expected_arrival": "07:45"},
+		},
+		"pickup_schedules": []map[string]interface{}{
+			{"weekday": 1, "pickup_time": "15:30"},
+		},
+		// Invalid guardian (bad email) aborts the transaction.
+		"guardians": []map[string]interface{}{
+			{
+				"first_name":         "Invalid",
+				"last_name":          "Email",
+				"email":              "not-a-valid-email",
+				"relationship_type":  "parent",
+				"emergency_priority": 1,
+			},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"admin:*"})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code,
+		"invalid guardian email must return 400 even with schedules attached. Body: %s", rr.Body.String())
+
+	ctx := context.Background()
+
+	// Safety net in case the rollback regressed and left residue behind.
+	defer func() {
+		var personIDs []int64
+		if err := tc.db.NewSelect().
+			Table("users.persons").
+			Column("id").
+			Where("first_name = ? AND last_name = ?", firstName, lastName).
+			Scan(ctx, &personIDs); err == nil {
+			for _, pid := range personIDs {
+				if _, err := tc.db.NewDelete().Table("users.students").Where("person_id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup students: %v", err)
+				}
+				if _, err := tc.db.NewDelete().Table("users.persons").Where("id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup persons: %v", err)
+				}
+			}
+		}
+	}()
+
+	personCount, err := tc.db.NewSelect().
+		Table("users.persons").
+		Where("first_name = ? AND last_name = ?", firstName, lastName).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, personCount, "person must not persist when the guardian fails (transaction must roll back)")
+
+	// Schedules FK to the student; assert none leaked by joining back to the
+	// would-be person name. Catches any regression where schedules are written
+	// outside the create transaction.
+	studentSubquery := tc.db.NewSelect().
+		Table("users.students").
+		Column("id").
+		Where("person_id IN (SELECT id FROM users.persons WHERE first_name = ? AND last_name = ?)", firstName, lastName)
+
+	arrivalCount, err := tc.db.NewSelect().
+		Model((*scheduleModel.StudentArrivalSchedule)(nil)).
+		ModelTableExpr("schedule.student_arrival_schedules").
+		Where("student_id IN (?)", studentSubquery).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, arrivalCount, "arrival schedules must not survive a rolled-back create")
+
+	pickupCount, err := tc.db.NewSelect().
+		Model((*scheduleModel.StudentPickupSchedule)(nil)).
+		ModelTableExpr("schedule.student_pickup_schedules").
+		Where("student_id IN (?)", studentSubquery).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, pickupCount, "pickup schedules must not survive a rolled-back create")
+}
+
+// TestCreateStudent_InvalidPickupTimeRejected is the pickup counterpart to
+// TestCreateStudent_InvalidScheduleTimeRejected: a malformed pickup time must be
+// caught at Bind (400) before any row is written. The arrival list is empty here
+// so this exercises the pickup validation branch specifically — the same
+// validatePickupScheduleItems rules the bulk-update endpoint enforces.
+func TestCreateStudent_InvalidPickupTimeRejected(t *testing.T) {
+	tc := setupTestContext(t)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "BadPickupSchedule", "Creator")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID)
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+
+	const firstName = "BadPickup"
+	const lastName = "Schedule"
+
+	body := map[string]interface{}{
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"school_class": "1e",
+		"pickup_schedules": []map[string]interface{}{
+			{"weekday": 2, "pickup_time": "25:99"},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"admin:*"})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code,
+		"invalid pickup time must return 400. Body: %s", rr.Body.String())
+
+	ctx := context.Background()
+
+	// Safety net in case a regressed validation let a row through.
+	defer func() {
+		var personIDs []int64
+		if err := tc.db.NewSelect().
+			Table("users.persons").
+			Column("id").
+			Where("first_name = ? AND last_name = ?", firstName, lastName).
+			Scan(ctx, &personIDs); err == nil {
+			for _, pid := range personIDs {
+				if _, err := tc.db.NewDelete().Table("users.students").Where("person_id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup students: %v", err)
+				}
+				if _, err := tc.db.NewDelete().Table("users.persons").Where("id = ?", pid).Exec(ctx); err != nil {
+					t.Logf("cleanup persons: %v", err)
+				}
+			}
+		}
+	}()
+
+	personCount, err := tc.db.NewSelect().
+		Table("users.persons").
+		Where("first_name = ? AND last_name = ?", firstName, lastName).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, personCount, "person must not persist when pickup validation fails (Bind rejects before any write)")
+}
+
+// TestCreateStudent_SchedulesNonStaffAccountForbidden pins the staff-resolution
+// contract: schedule rows are stamped with CreatedBy, so the acting JWT account
+// must resolve to a staff record. An account that has users:update but maps to a
+// non-staff person (e.g. a guardian-only or bare person account) must be refused
+// with 403 — and no student/person may be created. Covers the getStaffIDFromJWT
+// failure branch of the atomic create path.
+func TestCreateStudent_SchedulesNonStaffAccountForbidden(t *testing.T) {
+	tc := setupTestContext(t)
+
+	// Person + account WITHOUT a staff record — getStaffIDFromJWT must fail.
+	actingPerson, account := testpkg.CreateTestPersonWithAccount(t, tc.db, "NonStaff", "Scheduler")
+	defer testpkg.CleanupPerson(t, tc.db, actingPerson.ID)
+	defer testpkg.CleanupAccount(t, tc.db, account.ID)
+
+	router := setupRouter(tc.resource.CreateStudentHandler(), "")
+
+	const firstName = "NonStaffCreated"
+	const lastName = "Child"
+
+	body := map[string]interface{}{
+		"first_name":   firstName,
+		"last_name":    lastName,
+		"school_class": "1f",
+		"arrival_schedules": []map[string]interface{}{
+			{"weekday": 1, "expected_arrival": "07:30"},
+		},
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/", body)
+	// users:update passes the permission gate so the staff-resolution branch is
+	// the thing under test, not the permission check.
+	rr := executeWithAuth(router, req, testutil.AdminTestClaims(int(account.ID)), []string{"users:create", "users:update"})
+
+	assert.Equal(t, http.StatusForbidden, rr.Code,
+		"non-staff account must not create Betreuungszeiten. Body: %s", rr.Body.String())
+
+	ctx := context.Background()
+	personCount, err := tc.db.NewSelect().
+		Table("users.persons").
+		Where("first_name = ? AND last_name = ?", firstName, lastName).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, personCount, "student/person must not persist when staff resolution fails")
+}

--- a/backend/api/students/pickup_schedule_handlers.go
+++ b/backend/api/students/pickup_schedule_handlers.go
@@ -132,8 +132,15 @@ func (r *PickupScheduleRequest) Bind(_ *http.Request) error {
 
 // Bind implements render.Binder
 func (r *BulkPickupScheduleRequest) Bind(_ *http.Request) error {
+	return validatePickupScheduleItems(r.Schedules)
+}
+
+// validatePickupScheduleItems validates weekday range, uniqueness, time format
+// and notes length for a set of weekly pickup schedule items. Shared by the
+// bulk-update endpoint and the atomic create-student flow.
+func validatePickupScheduleItems(items []PickupScheduleRequest) error {
 	seenWeekdays := make(map[int]bool)
-	for i, s := range r.Schedules {
+	for i, s := range items {
 		if s.Weekday < schedule.WeekdayMonday || s.Weekday > schedule.WeekdayFriday {
 			return fmt.Errorf("schedule %d: weekday must be between 1 (Monday) and 5 (Friday)", i)
 		}
@@ -152,6 +159,29 @@ func (r *BulkPickupScheduleRequest) Bind(_ *http.Request) error {
 		}
 	}
 	return nil
+}
+
+// toPickupScheduleModels maps request items onto schedule models stamped with
+// the student and acting staff. Shared by the bulk-update endpoint and the
+// create-student flow.
+//
+// Callers MUST run validatePickupScheduleItems first (both current callers do,
+// via their Bind): the parse error below is intentionally discarded because the
+// time format is already guaranteed valid at that point. Mapping unvalidated
+// items here would silently persist a zero time.
+func toPickupScheduleModels(items []PickupScheduleRequest, studentID, staffID int64) []*schedule.StudentPickupSchedule {
+	schedules := make([]*schedule.StudentPickupSchedule, 0, len(items))
+	for _, s := range items {
+		pickupTime, _ := parseTimeOnly(s.PickupTime)
+		schedules = append(schedules, &schedule.StudentPickupSchedule{
+			StudentID:  studentID,
+			Weekday:    s.Weekday,
+			PickupTime: pickupTime,
+			Notes:      s.Notes,
+			CreatedBy:  staffID,
+		})
+	}
+	return schedules
 }
 
 // Bind implements render.Binder
@@ -377,17 +407,7 @@ func (rs *Resource) updateStudentPickupSchedules(w http.ResponseWriter, r *http.
 	}
 
 	// Convert requests to schedule models
-	schedules := make([]*schedule.StudentPickupSchedule, 0, len(req.Schedules))
-	for _, s := range req.Schedules {
-		pickupTime, _ := parseTimeOnly(s.PickupTime)
-		schedules = append(schedules, &schedule.StudentPickupSchedule{
-			StudentID:  student.ID,
-			Weekday:    s.Weekday,
-			PickupTime: pickupTime,
-			Notes:      s.Notes,
-			CreatedBy:  staffID,
-		})
-	}
+	schedules := toPickupScheduleModels(req.Schedules, student.ID, staffID)
 
 	tenantID := tenant.FromContext(r.Context())
 	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -152,6 +152,13 @@ type StudentRequest struct {
 	// (guardian_profiles system). Optional and independent of the legacy
 	// scalar guardian_* fields above.
 	Guardians []GuardianInput `json:"guardians,omitempty"`
+
+	// Weekly recurring arrival/pickup schedules persisted together with the
+	// student in the same atomic transaction. Reuse the bulk-update item DTOs
+	// so the time format and validation match the post-creation editing
+	// endpoints (PUT /students/{id}/{arrival,pickup}-schedules).
+	ArrivalSchedules []ArrivalScheduleRequestItem `json:"arrival_schedules,omitempty"`
+	PickupSchedules  []PickupScheduleRequest      `json:"pickup_schedules,omitempty"`
 }
 
 // GuardianPhoneInput is one phone number for a guardian created alongside a student.
@@ -292,6 +299,15 @@ func (req *StudentRequest) Bind(_ *http.Request) error {
 		if strings.TrimSpace(req.Guardians[i].RelationshipType) == "" {
 			return errors.New("guardian relationship_type is required")
 		}
+	}
+
+	// Validate weekly schedules with the same rules as the bulk-update
+	// endpoints so the atomic create path cannot persist invalid times.
+	if err := validateArrivalScheduleItems(req.ArrivalSchedules); err != nil {
+		return err
+	}
+	if err := validatePickupScheduleItems(req.PickupSchedules); err != nil {
+		return err
 	}
 
 	return nil

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -17,7 +17,10 @@ import type {
 import { useIsMobile } from "~/hooks/useIsMobile";
 import { useUpdateUrlParams } from "~/hooks/useUpdateUrlParams";
 import { useToast } from "~/contexts/ToastContext";
-import { StudentCreateModal } from "@/components/students/student-create-modal";
+import {
+  StudentCreateModal,
+  type CreateStudentSchedules,
+} from "@/components/students/student-create-modal";
 import {
   StudentsMasterDetail,
   type GroupingMode,
@@ -224,19 +227,40 @@ export default function StudentsPage() {
 
   const handleCreateStudent = useCallback(
     async (
-      studentData: Partial<Student> & { guardians?: StudentGuardianPayload[] },
+      studentData: Partial<Student> & {
+        guardians?: StudentGuardianPayload[];
+      } & CreateStudentSchedules,
     ) => {
-      // Run the config transform, then re-attach guardians from the original
-      // input. transformBeforeSubmit is typed Partial<Student> and drops the
-      // extra guardians field from the static type; re-attaching here makes the
-      // contract explicit so a future transform change can't silently strip the
-      // guardians (see issue #1500 atomic create flow).
-      let payload: Partial<Student> & { guardians?: StudentGuardianPayload[] } =
-        studentsConfig.form.transformBeforeSubmit
-          ? studentsConfig.form.transformBeforeSubmit(studentData)
-          : studentData;
+      // Run the config transform, then re-attach guardians and weekly schedules
+      // from the original input. transformBeforeSubmit is typed Partial<Student>
+      // and drops these extra fields from the static type; re-attaching here
+      // makes the contract explicit so a future transform change can't silently
+      // strip them (see issue #1500 atomic create flow, #1502 schedules).
+      let payload: Partial<Student> & {
+        guardians?: StudentGuardianPayload[];
+      } & CreateStudentSchedules = studentsConfig.form.transformBeforeSubmit
+        ? studentsConfig.form.transformBeforeSubmit(studentData)
+        : studentData;
       if (studentData.guardians && studentData.guardians.length > 0) {
         payload = { ...payload, guardians: studentData.guardians };
+      }
+      if (
+        studentData.arrival_schedules &&
+        studentData.arrival_schedules.length > 0
+      ) {
+        payload = {
+          ...payload,
+          arrival_schedules: studentData.arrival_schedules,
+        };
+      }
+      if (
+        studentData.pickup_schedules &&
+        studentData.pickup_schedules.length > 0
+      ) {
+        payload = {
+          ...payload,
+          pickup_schedules: studentData.pickup_schedules,
+        };
       }
       const newStudent = await service.create(payload);
       const displayName = studentsConfig.list.item.title(newStudent);

--- a/frontend/src/app/api/students/route.ts
+++ b/frontend/src/app/api/students/route.ts
@@ -21,6 +21,8 @@ import {
   handleStudentCreationError,
 } from "~/lib/student-request-helpers";
 import type { StudentGuardianPayload } from "~/lib/guardian-helpers";
+import type { ArrivalScheduleFormEntry } from "~/lib/arrival-schedule-helpers";
+import type { BackendPickupScheduleRequest } from "~/lib/pickup-schedule-helpers";
 
 /**
  * Type definition for student response from backend
@@ -189,6 +191,8 @@ export const POST = createPostHandler<
     privacy_consent_accepted?: boolean;
     data_retention_days?: number;
     guardians?: StudentGuardianPayload[];
+    arrival_schedules?: ArrivalScheduleFormEntry[];
+    pickup_schedules?: BackendPickupScheduleRequest[];
   }
 >(
   async (
@@ -199,6 +203,8 @@ export const POST = createPostHandler<
       privacy_consent_accepted?: boolean;
       data_retention_days?: number;
       guardians?: StudentGuardianPayload[];
+      arrival_schedules?: ArrivalScheduleFormEntry[];
+      pickup_schedules?: BackendPickupScheduleRequest[];
     },
     token: string,
   ) => {

--- a/frontend/src/components/students/care-weekly-plan-modal.test.tsx
+++ b/frontend/src/components/students/care-weekly-plan-modal.test.tsx
@@ -101,6 +101,35 @@ describe("CareWeeklyPlanModal", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("uses the overridden successMessage when provided", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+
+    render(
+      <CareWeeklyPlanModal
+        isOpen
+        onClose={onClose}
+        initialArrivalSchedules={initialArrivalSchedules}
+        initialPickupSchedules={initialPickupSchedules}
+        onSubmit={onSubmit}
+        successMessage="Betreuungszeiten übernommen"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Wochenplan speichern" }),
+    );
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Betreuungszeiten übernommen");
+    });
+    // The default wording must not appear when overridden.
+    expect(toastSuccess).not.toHaveBeenCalledWith(
+      "Wochenplan wurde gespeichert",
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
   it("shows validation errors for invalid times", async () => {
     render(
       <CareWeeklyPlanModal

--- a/frontend/src/components/students/care-weekly-plan-modal.tsx
+++ b/frontend/src/components/students/care-weekly-plan-modal.tsx
@@ -22,6 +22,10 @@ interface CareWeeklyPlanModalProps {
     arrivalSchedules: ArrivalScheduleFormEntry[];
     pickupData: BulkPickupScheduleFormData;
   }) => Promise<void>;
+  // Success toast shown after onSubmit resolves. Defaults to the post-creation
+  // "saved" wording; the create-student flow overrides it because the plan is
+  // only staged locally there, not yet persisted.
+  readonly successMessage?: string;
 }
 
 interface CareWeeklyPlanRow {
@@ -40,6 +44,7 @@ export function CareWeeklyPlanModal({
   initialArrivalSchedules,
   initialPickupSchedules,
   onSubmit,
+  successMessage = "Wochenplan wurde gespeichert",
 }: CareWeeklyPlanModalProps) {
   const toast = useToast();
   const [rows, setRows] = useState<CareWeeklyPlanRow[]>([]);
@@ -158,7 +163,7 @@ export function CareWeeklyPlanModal({
     setIsSubmitting(true);
     try {
       await onSubmit({ arrivalSchedules, pickupData });
-      toast.success("Wochenplan wurde gespeichert");
+      toast.success(successMessage);
       onClose();
     } catch (err) {
       const message =

--- a/frontend/src/components/students/student-create-modal.test.tsx
+++ b/frontend/src/components/students/student-create-modal.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
   fireEvent,
   act,
+  within,
 } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { StudentCreateModal } from "./student-create-modal";
@@ -157,6 +158,56 @@ vi.mock("~/components/guardians/guardian-form-modal", () => ({
           }
         >
           MockSubmitGuardian
+        </button>
+      </div>
+    ) : null,
+}));
+
+// Mock the reused CareWeeklyPlanModal the same way as the guardian modal: when
+// open, expose a button that calls onSubmit with one canned arrival + pickup
+// entry (the shapes the real modal emits). This exercises StudentCreateModal's
+// staging/summary/payload logic without driving the full weekly-plan editor.
+vi.mock("./care-weekly-plan-modal", () => ({
+  CareWeeklyPlanModal: ({
+    isOpen,
+    onClose,
+    onSubmit,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onSubmit: (data: {
+      arrivalSchedules: Array<{
+        weekday: number;
+        expected_arrival: string;
+        notes: string | null;
+      }>;
+      pickupData: {
+        schedules: Array<{
+          weekday: number;
+          pickupTime: string;
+          notes?: string;
+        }>;
+      };
+    }) => Promise<void>;
+  }) =>
+    isOpen ? (
+      <div data-testid="care-weekly-plan-modal">
+        <button
+          type="button"
+          onClick={() =>
+            // Mirror the real modal: after onSubmit resolves it closes itself.
+            void onSubmit({
+              arrivalSchedules: [
+                { weekday: 1, expected_arrival: "07:30", notes: "Bus" },
+                { weekday: 3, expected_arrival: "08:00", notes: null },
+              ],
+              pickupData: {
+                schedules: [{ weekday: 1, pickupTime: "15:00", notes: "Oma" }],
+              },
+            }).then(() => onClose())
+          }
+        >
+          MockSubmitCarePlan
         </button>
       </div>
     ) : null,
@@ -565,7 +616,11 @@ describe("StudentCreateModal", () => {
     });
 
     expect(screen.queryByText(/Erika Muster/)).not.toBeInTheDocument();
-    expect(screen.getByText("Optional")).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByRole("region", { name: "Erziehungsberechtigte" }),
+      ).getByText("Optional"),
+    ).toBeInTheDocument();
   });
 
   it("forwards collected guardians (snake_case mapped) to onCreate on submit", async () => {
@@ -646,6 +701,151 @@ describe("StudentCreateModal", () => {
     const submitted = vi.mocked(handleStudentFormSubmit).mock
       .calls[0]?.[1] as Record<string, unknown>;
     expect(submitted).not.toHaveProperty("guardians");
+  });
+
+  it("opens the reused weekly care-plan editor when the add button is clicked", async () => {
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Wochenplan hinzufügen"));
+    });
+
+    expect(screen.getByTestId("care-weekly-plan-modal")).toBeInTheDocument();
+  });
+
+  it("stages a submitted care plan and shows the weekday summary", async () => {
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Wochenplan hinzufügen"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("MockSubmitCarePlan"));
+    });
+
+    // Summary lists the covered weekdays (Mo from arrival+pickup, Mi from
+    // arrival) and the per-type counts, and the add button flips to "edit".
+    await waitFor(() => {
+      expect(screen.getByText("Mo · Mi")).toBeInTheDocument();
+    });
+    expect(screen.getByText("2× Ankunft · 1× Abholung")).toBeInTheDocument();
+    expect(screen.getByText("2 Tage")).toBeInTheDocument();
+    expect(screen.getByText("Wochenplan bearbeiten")).toBeInTheDocument();
+    // Sub-modal closes after collecting.
+    expect(
+      screen.queryByTestId("care-weekly-plan-modal"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("removes the staged care plan via the remove button", async () => {
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Wochenplan hinzufügen"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("MockSubmitCarePlan"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Mo · Mi")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Betreuungszeiten entfernen"));
+    });
+
+    expect(screen.queryByText("Mo · Mi")).not.toBeInTheDocument();
+    // Section reverts to the "Optional" empty state + "add" wording.
+    expect(
+      within(
+        screen.getByRole("region", { name: "Betreuungszeiten" }),
+      ).getByText("Optional"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Wochenplan hinzufügen")).toBeInTheDocument();
+  });
+
+  it("forwards staged schedules (snake_case mapped) to the submit payload", async () => {
+    mockOnCreate.mockResolvedValue(undefined);
+
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Wochenplan hinzufügen"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("MockSubmitCarePlan"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Mo · Mi")).toBeInTheDocument();
+    });
+
+    const form = screen.getByTestId("modal").querySelector("form");
+    await act(async () => {
+      fireEvent.submit(form!);
+    });
+
+    await waitFor(() => {
+      expect(handleStudentFormSubmit).toHaveBeenCalled();
+    });
+
+    // Arrival entries travel backend-shaped already; pickup entries are mapped
+    // from the care-plan form (pickupTime → pickup_time) before submit.
+    const submitted = vi.mocked(handleStudentFormSubmit).mock
+      .calls[0]?.[1] as Record<string, unknown>;
+    expect(submitted).toMatchObject({
+      arrival_schedules: [
+        { weekday: 1, expected_arrival: "07:30", notes: "Bus" },
+        { weekday: 3, expected_arrival: "08:00", notes: null },
+      ],
+      pickup_schedules: [{ weekday: 1, pickup_time: "15:00", notes: "Oma" }],
+    });
+  });
+
+  it("does not attach schedule fields when no care plan was staged", async () => {
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    const form = screen.getByTestId("modal").querySelector("form");
+    await act(async () => {
+      fireEvent.submit(form!);
+    });
+
+    await waitFor(() => {
+      expect(handleStudentFormSubmit).toHaveBeenCalled();
+    });
+    const submitted = vi.mocked(handleStudentFormSubmit).mock
+      .calls[0]?.[1] as Record<string, unknown>;
+    expect(submitted).not.toHaveProperty("arrival_schedules");
+    expect(submitted).not.toHaveProperty("pickup_schedules");
   });
 
   it("opens the existing-guardian picker when the search button is clicked", async () => {

--- a/frontend/src/components/students/student-create-modal.tsx
+++ b/frontend/src/components/students/student-create-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { Users, Plus, Search, Trash2 } from "lucide-react";
+import { Users, Plus, Search, Trash2, Clock } from "lucide-react";
 import { Modal } from "~/components/ui/modal";
 import type { Student } from "@/lib/api";
 import {
@@ -25,6 +25,16 @@ import {
   type PhoneType,
   type StudentGuardianPayload,
 } from "@/lib/guardian-helpers";
+import { CareWeeklyPlanModal } from "./care-weekly-plan-modal";
+import {
+  WEEKDAYS,
+  type ArrivalScheduleFormEntry,
+} from "~/lib/arrival-schedule-helpers";
+import {
+  mapBulkPickupScheduleFormToBackend,
+  type BackendPickupScheduleRequest,
+  type PickupScheduleFormData,
+} from "~/lib/pickup-schedule-helpers";
 
 // Shape returned by GuardianFormModal's onSubmit for each entry.
 type GuardianSubmitEntry = {
@@ -104,11 +114,22 @@ function relationshipLabel(value: string): string {
   return RELATIONSHIP_TYPES.find((t) => t.value === value)?.label ?? value;
 }
 
+// Weekly schedules travel to the backend in snake_case alongside the student so
+// they are persisted in the same atomic create transaction. Arrival entries are
+// already backend-shaped (ArrivalScheduleFormEntry); pickup entries are mapped
+// from the care-plan form via mapBulkPickupScheduleFormToBackend.
+export type CreateStudentSchedules = {
+  arrival_schedules?: ArrivalScheduleFormEntry[];
+  pickup_schedules?: BackendPickupScheduleRequest[];
+};
+
 interface StudentCreateModalProps {
   readonly isOpen: boolean;
   readonly onClose: () => void;
   readonly onCreate: (
-    data: Partial<Student> & { guardians?: StudentGuardianPayload[] },
+    data: Partial<Student> & {
+      guardians?: StudentGuardianPayload[];
+    } & CreateStudentSchedules,
   ) => Promise<void>;
   readonly groups?: Array<{ readonly value: string; readonly label: string }>;
 }
@@ -139,12 +160,22 @@ export function StudentCreateModal({
   const [saveLoading, setSaveLoading] = useState(false);
   const [guardians, setGuardians] = useState<StudentGuardianPayload[]>([]);
   const [guardianModalOpen, setGuardianModalOpen] = useState(false);
+  // Weekly care plan staged in the create modal (no API calls here — persisted
+  // atomically with the student on submit). Arrival entries are backend-shaped;
+  // pickup entries stay in the care-plan form shape until submit.
+  const [arrivalSchedules, setArrivalSchedules] = useState<
+    ArrivalScheduleFormEntry[]
+  >([]);
+  const [pickupSchedules, setPickupSchedules] = useState<
+    PickupScheduleFormData[]
+  >([]);
+  const [carePlanModalOpen, setCarePlanModalOpen] = useState(false);
   const [guardianPickerOpen, setGuardianPickerOpen] = useState(false);
   // The inline picker panel is tall; collapsing it (on add or cancel) shrinks
   // the modal so the kept scroll position lands further down the form. Re-anchor
   // to the guardian section so the user stays where they acted and sees the
   // result (the added guardian) instead of jumping past it.
-  const guardianSectionRef = useRef<HTMLDivElement>(null);
+  const guardianSectionRef = useRef<HTMLElement>(null);
   const pendingGuardianScrollRef = useRef(false);
 
   // Reset form when modal opens/closes
@@ -167,6 +198,9 @@ export function StudentCreateModal({
       setErrors({});
       setGuardians([]);
       setGuardianModalOpen(false);
+      setArrivalSchedules([]);
+      setPickupSchedules([]);
+      setCarePlanModalOpen(false);
       setGuardianPickerOpen(false);
       pendingGuardianScrollRef.current = false;
     }
@@ -237,8 +271,20 @@ export function StudentCreateModal({
   };
 
   const handleSubmit = (e: React.FormEvent) => {
-    const payload: Partial<Student> & { guardians?: StudentGuardianPayload[] } =
-      guardians.length > 0 ? { ...formData, guardians } : formData;
+    const payload: Partial<Student> & {
+      guardians?: StudentGuardianPayload[];
+    } & CreateStudentSchedules = { ...formData };
+    if (guardians.length > 0) {
+      payload.guardians = guardians;
+    }
+    if (arrivalSchedules.length > 0) {
+      payload.arrival_schedules = arrivalSchedules;
+    }
+    if (pickupSchedules.length > 0) {
+      payload.pickup_schedules = mapBulkPickupScheduleFormToBackend({
+        schedules: pickupSchedules,
+      }).schedules;
+    }
     return handleStudentFormSubmit(
       e,
       payload,
@@ -263,6 +309,17 @@ export function StudentCreateModal({
       });
     }
   };
+
+  // Weekdays covered by either an arrival or a pickup time, for the summary.
+  const scheduledWeekdays = Array.from(
+    new Set([
+      ...arrivalSchedules.map((s) => s.weekday),
+      ...pickupSchedules.map((s) => s.weekday),
+    ]),
+  ).sort((a, b) => a - b);
+  const hasCarePlan = scheduledWeekdays.length > 0;
+  const weekdayShort = (value: number) =>
+    WEEKDAYS.find((d) => d.value === value)?.shortLabel ?? String(value);
 
   return (
     <>
@@ -291,8 +348,9 @@ export function StudentCreateModal({
               matches the other modal sections (border-gray-100 + blue tint,
               blue heading icon) and reuses the guardian modal's own dashed
               add-button and red remove patterns. */}
-          <div
+          <section
             ref={guardianSectionRef}
+            aria-label="Erziehungsberechtigte"
             className="scroll-mt-4 rounded-xl border border-gray-100 bg-blue-50/30 p-3 md:p-4"
           >
             <div className="mb-3 flex items-center justify-between md:mb-4">
@@ -380,7 +438,60 @@ export function StudentCreateModal({
                 </button>
               </div>
             )}
-          </div>
+          </section>
+
+          {/* Betreuungszeiten — weekly arrival/pickup times staged here and
+              persisted atomically with the student, mirroring the guardian
+              section above. Reuses the existing CareWeeklyPlanModal editor. */}
+          <section
+            aria-label="Betreuungszeiten"
+            className="rounded-xl border border-gray-100 bg-blue-50/30 p-3 md:p-4"
+          >
+            <div className="mb-3 flex items-center justify-between md:mb-4">
+              <h3 className="flex items-center gap-2 text-xs font-semibold text-gray-900 md:text-sm">
+                <Clock className="h-3.5 w-3.5 text-blue-600 md:h-4 md:w-4" />
+                Betreuungszeiten
+              </h3>
+              <span className="text-xs text-gray-500">
+                {hasCarePlan ? `${scheduledWeekdays.length} Tage` : "Optional"}
+              </span>
+            </div>
+
+            {hasCarePlan && (
+              <div className="mb-3 flex items-start justify-between gap-2 rounded-lg border border-gray-100 bg-white p-2 md:p-3">
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-medium text-gray-900 md:text-sm">
+                    {scheduledWeekdays.map(weekdayShort).join(" · ")}
+                  </p>
+                  <p className="mt-0.5 truncate text-xs text-gray-500">
+                    {`${arrivalSchedules.length}× Ankunft · ${pickupSchedules.length}× Abholung`}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setArrivalSchedules([]);
+                    setPickupSchedules([]);
+                  }}
+                  disabled={saveLoading}
+                  aria-label="Betreuungszeiten entfernen"
+                  className="flex flex-shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-xs text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={() => setCarePlanModalOpen(true)}
+              disabled={saveLoading}
+              className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 py-2 text-xs font-medium text-gray-600 transition-all duration-200 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+            >
+              <Plus className="h-4 w-4" />
+              {hasCarePlan ? "Wochenplan bearbeiten" : "Wochenplan hinzufügen"}
+            </button>
+          </section>
 
           {/* Common Form Sections */}
           <StudentCommonFormSections
@@ -455,6 +566,24 @@ export function StudentCreateModal({
           mode="create"
           onClose={() => setGuardianModalOpen(false)}
           onSubmit={handleGuardianSubmit}
+        />
+      )}
+
+      {/* Reuse the existing weekly care-plan editor. onSubmit only stages the
+          plan locally (no API calls) — it is persisted atomically with the
+          student on create. successMessage overrides the default "saved"
+          wording since nothing is persisted yet here. */}
+      {carePlanModalOpen && (
+        <CareWeeklyPlanModal
+          isOpen={carePlanModalOpen}
+          onClose={() => setCarePlanModalOpen(false)}
+          initialArrivalSchedules={arrivalSchedules}
+          initialPickupSchedules={pickupSchedules}
+          successMessage="Betreuungszeiten übernommen"
+          onSubmit={async ({ arrivalSchedules: nextArrival, pickupData }) => {
+            setArrivalSchedules(nextArrival);
+            setPickupSchedules(pickupData.schedules);
+          }}
         />
       )}
     </>

--- a/frontend/src/lib/student-request-helpers.test.ts
+++ b/frontend/src/lib/student-request-helpers.test.ts
@@ -296,6 +296,55 @@ describe("buildBackendStudentRequest", () => {
     expect(result.guardians).toBeUndefined();
   });
 
+  it("passes weekly arrival and pickup schedules through for atomic creation", () => {
+    const validated = {
+      firstName: "Max",
+      lastName: "Mustermann",
+      schoolClass: "1a",
+    };
+    const arrival_schedules = [
+      { weekday: 1, expected_arrival: "07:30", notes: "Bus" },
+      { weekday: 3, expected_arrival: "08:00", notes: null },
+    ];
+    const pickup_schedules = [
+      { weekday: 1, pickup_time: "15:00", notes: undefined },
+    ];
+    const body = {
+      first_name: "Max",
+      second_name: "Mustermann",
+      school_class: "1a",
+      arrival_schedules,
+      pickup_schedules,
+    };
+    const guardianContact = { email: undefined, phone: undefined };
+
+    const result = buildBackendStudentRequest(validated, body, guardianContact);
+
+    expect(result.arrival_schedules).toEqual(arrival_schedules);
+    expect(result.pickup_schedules).toEqual(pickup_schedules);
+  });
+
+  it("omits schedules when none are provided or arrays are empty", () => {
+    const validated = {
+      firstName: "Max",
+      lastName: "Mustermann",
+      schoolClass: "1a",
+    };
+    const body = {
+      first_name: "Max",
+      second_name: "Mustermann",
+      school_class: "1a",
+      arrival_schedules: [],
+      pickup_schedules: [],
+    };
+    const guardianContact = { email: undefined, phone: undefined };
+
+    const result = buildBackendStudentRequest(validated, body, guardianContact);
+
+    expect(result.arrival_schedules).toBeUndefined();
+    expect(result.pickup_schedules).toBeUndefined();
+  });
+
   it("includes tag_id when provided", () => {
     const validated = {
       firstName: "Max",
@@ -694,6 +743,70 @@ describe("handleStudentCreationError", () => {
       "permission denied when creating student",
       { error: String(error) },
     );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("throws schedule permission error when Betreuungszeiten creation lacks users:update", () => {
+    const error = new Error(
+      'API error: 403 {"error":"users:update permission required to create student schedules"}',
+    );
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    expect(() => handleStudentCreationError(error)).toThrow(
+      "Permission denied: You need the 'users:update' permission to create student Betreuungszeiten.",
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "permission denied when creating student",
+      { error: String(error) },
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("preserves 403 status for mapped schedule permission errors", () => {
+    const error = new Error(
+      'API error (403): {"error":"users:update permission required to create student schedules"}',
+    );
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    try {
+      handleStudentCreationError(error);
+      throw new Error("Expected handleStudentCreationError to throw");
+    } catch (caught) {
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toContain("API error (403):");
+      expect((caught as { status?: number }).status).toBe(403);
+      expect((caught as Error).message).toContain(
+        "Permission denied: You need the 'users:update' permission to create student Betreuungszeiten.",
+      );
+    }
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("preserves 403 status for mapped student create permission errors", () => {
+    const error = new Error("API error (403): Forbidden");
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    try {
+      handleStudentCreationError(error);
+      throw new Error("Expected handleStudentCreationError to throw");
+    } catch (caught) {
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toContain("API error (403):");
+      expect((caught as { status?: number }).status).toBe(403);
+      expect((caught as Error).message).toContain(
+        "Permission denied: You need the 'users:create' permission to create students.",
+      );
+    }
 
     consoleErrorSpy.mockRestore();
   });

--- a/frontend/src/lib/student-request-helpers.ts
+++ b/frontend/src/lib/student-request-helpers.ts
@@ -5,11 +5,18 @@
 
 import type { Student } from "~/lib/student-helpers";
 import type { StudentGuardianPayload } from "~/lib/guardian-helpers";
+import type { ArrivalScheduleFormEntry } from "~/lib/arrival-schedule-helpers";
+import type { BackendPickupScheduleRequest } from "~/lib/pickup-schedule-helpers";
+import { ApiResponseError } from "~/lib/api-helpers";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "StudentRequestHelpers" });
 import { prepareStudentForBackend } from "~/lib/student-helpers";
 import { LOCATION_STATUSES } from "~/lib/location-helper";
+
+function createPermissionError(message: string): ApiResponseError {
+  return new ApiResponseError(403, JSON.stringify({ error: message }));
+}
 
 /**
  * Backend student request structure
@@ -34,6 +41,11 @@ interface BackendStudentRequest {
   guardian_phone?: string;
   // Guardians created atomically with the student (guardian_profiles system).
   guardians?: StudentGuardianPayload[];
+  // Weekly recurring schedules created atomically with the student. Arrival
+  // entries are already backend-shaped; pickup entries are snake_case via
+  // BackendPickupScheduleRequest.
+  arrival_schedules?: ArrivalScheduleFormEntry[];
+  pickup_schedules?: BackendPickupScheduleRequest[];
 }
 
 /**
@@ -138,6 +150,8 @@ export function buildBackendStudentRequest(
     guardian_email?: string;
     guardian_phone?: string;
     guardians?: StudentGuardianPayload[];
+    arrival_schedules?: ArrivalScheduleFormEntry[];
+    pickup_schedules?: BackendPickupScheduleRequest[];
   },
   guardianContact: GuardianContact,
 ): BackendStudentRequest {
@@ -180,6 +194,14 @@ export function buildBackendStudentRequest(
   // Pass through guardians (guardian_profiles system) for atomic creation.
   if (body.guardians && body.guardians.length > 0) {
     request.guardians = body.guardians;
+  }
+
+  // Pass through weekly schedules for atomic creation.
+  if (body.arrival_schedules && body.arrival_schedules.length > 0) {
+    request.arrival_schedules = body.arrival_schedules;
+  }
+  if (body.pickup_schedules && body.pickup_schedules.length > 0) {
+    request.pickup_schedules = body.pickup_schedules;
   }
 
   return request;
@@ -295,7 +317,16 @@ export function handleStudentCreationError(error: unknown): never {
     logger.error("permission denied when creating student", {
       error: String(error),
     });
-    throw new Error(
+    if (
+      error.message.includes(
+        "users:update permission required to create student schedules",
+      )
+    ) {
+      throw createPermissionError(
+        "Permission denied: You need the 'users:update' permission to create student Betreuungszeiten.",
+      );
+    }
+    throw createPermissionError(
       "Permission denied: You need the 'users:create' permission to create students.",
     );
   }


### PR DESCRIPTION
## Summary

Closes #1502.

Admins can now set a child's weekly **Betreuungszeiten** (recurring arrival and pickup times) directly in the "Neuer Schüler" create modal, instead of having to create the student first and then edit the schedules separately. The schedule is staged in the modal and persisted **atomically** with the student on submit.

## Backend

- `StudentRequest` accepts optional `arrival_schedules` / `pickup_schedules`, reusing the bulk-update item DTOs so the time format and validation rules are identical to the existing `PUT /students/{id}/{arrival,pickup}-schedules` endpoints.
- Schedules are written inside the **same transaction** as the student and guardians. A guardian validation failure rolls back the schedules too (extends the #1500 atomic-create flow).
- Schedule writes require the `users:update` permission and a resolvable staff record, because schedule rows are stamped with `CreatedBy`. This matches the contract of the standalone schedule endpoints. **Plain student creation (no schedules) is unchanged** — it still only needs `users:create`.
- Extracted shared `validate{Arrival,Pickup}ScheduleItems` and `to{Arrival,Pickup}ScheduleModels` helpers so the bulk-update path and the create path enforce one set of rules (no duplicated mapping/validation).

## Frontend

- `StudentCreateModal` gains a **Betreuungszeiten** section that mirrors the guardian section's UI (dashed add button, summary card, red remove). It reuses the existing `CareWeeklyPlanModal` as a sub-modal — no new editor.
- The plan is staged in local state; nothing is persisted until the student is created. `CareWeeklyPlanModal` got an optional `successMessage` prop so the create flow shows "übernommen" (staged) rather than "gespeichert" (saved).
- Schedules flow through `buildBackendStudentRequest`; the `users:update` permission error is mapped to a clear German message.

## Tests

- **Backend** (`create_student_schedules_test.go`): atomic create with schedules, invalid arrival/pickup time rejection, `users:update` requirement, non-staff-account forbidden, and guardian-failure-rolls-back-schedules.
- **Frontend**: open/stage/remove the care plan in the create modal, snake_case payload mapping, no schedule fields when none staged, the `successMessage` override, request-helper passthrough, and the permission-error mapping.

## Notes

- New per-tenant runtime config? No — this is data, not settings.
- No new env vars, no IoT/PyrePortal contract changes.

## Test plan

- [ ] `cd backend && go test ./api/students/...`
- [ ] `cd frontend && pnpm run check`
- [ ] Manual: create a student with a weekly plan → verify times appear under the student's Betreuungszeiten; create one without → unaffected.
