### PR TITLE
Align room occupancy history child count label

### DIFF
--- a/frontend/src/components/rooms/room-detail-content.test.tsx
+++ b/frontend/src/components/rooms/room-detail-content.test.tsx
@@ -556,7 +556,7 @@ describe("RoomDetailContent", () => {
     // duration_minutes from the session takes precedence over calculateDuration().
     expect(screen.getByText("45m")).toBeInTheDocument();
     expect(screen.getByText(/Frau A/)).toBeInTheDocument();
-    expect(screen.getByText(/Teilnehmer: 12/)).toBeInTheDocument();
+    expect(screen.getByText(/Kinder: 12/)).toBeInTheDocument();
     expect(screen.queryByText("Laufend")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/rooms/room-detail-content.tsx
+++ b/frontend/src/components/rooms/room-detail-content.tsx
@@ -543,7 +543,7 @@ export function RoomDetailContent({
                             {session.supervisorName && (
                               <div>Aufsicht: {session.supervisorName}</div>
                             )}
-                            <div>Teilnehmer: {session.studentCount}</div>
+                            <div>Kinder: {session.studentCount}</div>
                           </div>
 
                           <div className="mt-3 flex justify-between border-t border-gray-100 pt-3 text-xs text-gray-500">


### PR DESCRIPTION
## Summary

- Align the room occupancy history card wording with the agreed room-level contract: the aggregate count is shown as `Kinder`, not generic participants.
- Keep the existing aggregated room-history implementation intact: no child names, no child IDs, and one row per room session.

## Context

The underlying implementation for room occupancy history is already present from the #1425 follow-up: `/api/rooms/{id}/history` returns aggregated sessions with activity/session label, supervisor names, duration, and distinct child count. This PR tightens the visible label so it matches the product wording for #645.

Closes #645
Refs #1425

## Validation

- `cd backend && go test ./api/rooms ./services/facilities ./database/repositories/active -count=1`
- `cd frontend && pnpm exec vitest run src/components/rooms/room-detail-content.test.tsx 'src/app/api/rooms/[id]/history/route.test.ts'`
- `cd frontend && pnpm run check`
- pre-push: git-secrets, frontend-knip, frontend-check
