### PR TITLE
Add attendance setup settings and NFC visibility rules

### DIFF
--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -333,6 +333,10 @@ type TenantResolveResponse struct {
 	// decide whether to render avatars on student cards. Defaults to false
 	// when the setting is missing or unresolvable.
 	StudentPhotosEnabled bool `json:"student_photos_enabled"`
+	// NFCEnabled is the tenant's resolved attendance.nfc_enabled setting.
+	// It is public tenant-shell metadata because non-admin staff also need to
+	// know whether NFC-only areas like classic activities should appear.
+	NFCEnabled bool `json:"nfc_enabled"`
 }
 
 // resolveTenant handles GET /auth/tenant/resolve?slug={slug}
@@ -380,10 +384,14 @@ func (rs *Resource) resolveTenant(w http.ResponseWriter, r *http.Request) {
 	// and parse the boolean string. Failures fall back to false so a
 	// settings outage never auto-enables the avatar UI for opt-out schools.
 	studentPhotosEnabled := false
+	nfcEnabled := false
 	if rs.SettingsService != nil {
 		val, err := rs.SettingsService.ResolveStringForTenant(r.Context(), school.ID, configModel.KeyStudentPhotosEnabled)
 		if err == nil {
 			studentPhotosEnabled = val == "true"
+		}
+		if val, err := rs.SettingsService.ResolveBoolForTenant(r.Context(), school.ID, configModel.KeyAttendanceNFCEnabled); err == nil {
+			nfcEnabled = val
 		}
 	}
 
@@ -398,6 +406,7 @@ func (rs *Resource) resolveTenant(w http.ResponseWriter, r *http.Request) {
 		Settings:             settings,
 		PresenceMode:         presenceMode,
 		StudentPhotosEnabled: studentPhotosEnabled,
+		NFCEnabled:           nfcEnabled,
 	}
 
 	common.Respond(w, r, http.StatusOK, resp, "Tenant resolved successfully")

--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -454,6 +454,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 		StudentRepo:            repoFactory.Student,
 		StaffRepo:              repoFactory.Staff,
 		RoomRepo:               repoFactory.Room,
+		ActivityCategoryRepo:   repoFactory.ActivityCategory,
 		ActivityGroupRepo:      repoFactory.ActivityGroup,
 		ActivitySupervisorRepo: repoFactory.ActivitySupervisor,
 		StudentEnrollmentRepo:  repoFactory.StudentEnrollment,

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -55,6 +55,7 @@ type Resource struct {
 	studentRepo            users.StudentRepository
 	staffRepo              users.StaffRepository
 	roomRepo               facilities.RoomRepository
+	activityCategoryRepo   activities.CategoryRepository
 	activityGroupRepo      activities.GroupRepository
 	activitySupervisorRepo activities.SupervisorPlannedRepository
 	studentEnrollmentRepo  activities.StudentEnrollmentRepository
@@ -91,6 +92,7 @@ type Dependencies struct {
 	StudentRepo            users.StudentRepository
 	StaffRepo              users.StaffRepository
 	RoomRepo               facilities.RoomRepository
+	ActivityCategoryRepo   activities.CategoryRepository
 	ActivityGroupRepo      activities.GroupRepository
 	ActivitySupervisorRepo activities.SupervisorPlannedRepository
 	StudentEnrollmentRepo  activities.StudentEnrollmentRepository
@@ -127,6 +129,7 @@ func NewResource(deps Dependencies) *Resource {
 		studentRepo:            deps.StudentRepo,
 		staffRepo:              deps.StaffRepo,
 		roomRepo:               deps.RoomRepo,
+		activityCategoryRepo:   deps.ActivityCategoryRepo,
 		activityGroupRepo:      deps.ActivityGroupRepo,
 		activitySupervisorRepo: deps.ActivitySupervisorRepo,
 		studentEnrollmentRepo:  deps.StudentEnrollmentRepo,

--- a/backend/api/timetable/operations.go
+++ b/backend/api/timetable/operations.go
@@ -2,11 +2,13 @@ package timetable
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -14,6 +16,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activityModel "github.com/moto-nrw/project-phoenix/models/activities"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
@@ -41,6 +44,10 @@ func (req *spontaneousStartRequest) Bind(_ *http.Request) error {
 	}
 	if req.RoomID <= 0 {
 		return errors.New("room_id is required")
+	}
+	req.Title = strings.TrimSpace(req.Title)
+	if req.Title == "" {
+		return errors.New("title is required")
 	}
 	return nil
 }
@@ -150,6 +157,11 @@ func (rs *Resource) operationsCreateAndStartSpontaneous(w http.ResponseWriter, r
 
 	req.StaffIDs = appendUniquePositive(req.StaffIDs, currentStaffID)
 	createdBy := currentStaffID
+	activityGroupID, err := rs.resolveSpontaneousActivityGroupID(r.Context(), req.Title, req.ActivityGroupID, createdBy)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("resolve spontaneous activity group failed", err))
+		return
+	}
 	isSpontaneous := true
 	window := serverSpontaneousActivityWindow(timezone.Now())
 	inst, err := rs.instanceService.Create(r.Context(), scheduleSvc.CreateInstanceInput{
@@ -160,7 +172,7 @@ func (rs *Resource) operationsCreateAndStartSpontaneous(w http.ResponseWriter, r
 		Description:      req.Description,
 		Notes:            req.Notes,
 		RoomID:           req.RoomID,
-		ActivityGroupID:  req.ActivityGroupID,
+		ActivityGroupID:  activityGroupID,
 		IsSpontaneous:    &isSpontaneous,
 		StaffIDs:         req.StaffIDs,
 		StudentIDs:       nil,
@@ -200,6 +212,65 @@ func bindSpontaneousStartRequest(w http.ResponseWriter, r *http.Request) (*spont
 	return req, true
 }
 
+func (rs *Resource) resolveSpontaneousActivityGroupID(ctx context.Context, title string, requestedID *int64, createdBy int64) (*int64, error) {
+	if requestedID != nil {
+		return requestedID, nil
+	}
+	if rs.activityGroupRepo == nil || rs.activityCategoryRepo == nil {
+		return nil, errors.New("activity repositories are not wired")
+	}
+	if err := rs.lockSpontaneousActivityName(ctx, title); err != nil {
+		return nil, err
+	}
+	if existing, err := rs.activityGroupRepo.FindByName(ctx, title); err == nil && existing != nil {
+		return &existing.ID, nil
+	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+
+	category, err := rs.ensureSpontaneousActivityCategory(ctx)
+	if err != nil {
+		return nil, err
+	}
+	group := &activityModel.Group{
+		Name:            title,
+		CategoryID:      category.ID,
+		MaxParticipants: 999,
+		IsOpen:          true,
+		CreatedBy:       &createdBy,
+		Type:            activityModel.GroupTypeActivity,
+		IsTemplate:      false,
+	}
+	group.SetTenantID(tenant.FromContext(ctx))
+	if err := rs.activityGroupRepo.Create(ctx, group); err != nil {
+		return nil, err
+	}
+	return &group.ID, nil
+}
+
+func (rs *Resource) ensureSpontaneousActivityCategory(ctx context.Context) (*activityModel.Category, error) {
+	const spontaneousCategoryName = "Spontan"
+	if err := rs.lockSpontaneousActivityCategory(ctx); err != nil {
+		return nil, err
+	}
+	if existing, err := rs.activityCategoryRepo.FindByName(ctx, spontaneousCategoryName); err == nil && existing != nil {
+		return existing, nil
+	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+
+	category := &activityModel.Category{
+		Name:        spontaneousCategoryName,
+		Description: "Automatisch angelegte Aktivitäten aus spontanen Web-Starts",
+		Color:       "#83CD2D",
+	}
+	category.SetTenantID(tenant.FromContext(ctx))
+	if err := rs.activityCategoryRepo.Create(ctx, category); err != nil {
+		return nil, err
+	}
+	return category, nil
+}
+
 func serverSpontaneousActivityWindow(now time.Time) spontaneousActivityWindow {
 	now = now.In(timezone.Berlin)
 	currentMinutes := now.Hour()*60 + now.Minute()
@@ -229,6 +300,40 @@ func (rs *Resource) lockSpontaneousStartRoom(ctx context.Context, roomID int64) 
 		return errors.New("tenant transaction is required")
 	}
 	key := fmt.Sprintf("timetable:spontaneous-start-room:%d:%d", tenantID, roomID)
+	_, err := (*tx).ExecContext(ctx, "SELECT pg_advisory_xact_lock(hashtextextended(?, 0))", key)
+	return err
+}
+
+func (rs *Resource) lockSpontaneousActivityName(ctx context.Context, name string) error {
+	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		return errors.New("tenant id is required")
+	}
+	tx, ok := modelBase.TxFromContext(ctx)
+	if !ok || tx == nil {
+		if rs.db == nil {
+			return nil
+		}
+		return errors.New("tenant transaction is required")
+	}
+	key := fmt.Sprintf("timetable:spontaneous-activity-name:%d:%s", tenantID, strings.ToLower(strings.TrimSpace(name)))
+	_, err := (*tx).ExecContext(ctx, "SELECT pg_advisory_xact_lock(hashtextextended(?, 0))", key)
+	return err
+}
+
+func (rs *Resource) lockSpontaneousActivityCategory(ctx context.Context) error {
+	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		return errors.New("tenant id is required")
+	}
+	tx, ok := modelBase.TxFromContext(ctx)
+	if !ok || tx == nil {
+		if rs.db == nil {
+			return nil
+		}
+		return errors.New("tenant transaction is required")
+	}
+	key := fmt.Sprintf("timetable:spontaneous-activity-category:%d", tenantID)
 	_, err := (*tx).ExecContext(ctx, "SELECT pg_advisory_xact_lock(hashtextextended(?, 0))", key)
 	return err
 }

--- a/backend/api/timetable/operations_unit_test.go
+++ b/backend/api/timetable/operations_unit_test.go
@@ -3,6 +3,7 @@ package timetable
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/testutil"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	activityModels "github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
@@ -146,6 +148,111 @@ func TestOperationsCreateAndStartSpontaneous(t *testing.T) {
 	assert.Empty(t, instanceSvc.lastCreate.StudentIDs)
 	assert.Equal(t, int64(241), service.lastInstanceID)
 	assert.Contains(t, rr.Body.String(), `"active_group_id":341`)
+}
+
+func TestOperationsCreateAndStartSpontaneousReusesActivityByName(t *testing.T) {
+	createdInstance := &schedule.ActivityInstance{Status: schedule.InstanceStatusPlanned}
+	createdInstance.ID = 242
+	startedInstance := &schedule.ActivityInstance{Status: schedule.InstanceStatusActive}
+	startedInstance.ID = 242
+	instanceSvc := &mockInstanceService{createRes: createdInstance}
+	groupRepo := &fakeOperationActivityGroupRepo{
+		findByNameResult: &activityModels.Group{Name: "Freispiel"},
+	}
+	groupRepo.findByNameResult.ID = 72
+	service := &fakeOperationsService{
+		start: &scheduleSvc.StartInstanceResult{
+			Instance:      startedInstance,
+			ActiveGroupID: 342,
+		},
+	}
+	res := NewResource(Dependencies{
+		InstanceService:      instanceSvc,
+		OperationsService:    service,
+		ActivityGroupRepo:    groupRepo,
+		ActivityCategoryRepo: &fakeOperationActivityCategoryRepo{},
+		PersonService: &instMockPersonService{
+			findByAccountIDFn: func(_ context.Context, _ int64) (*userModels.Person, error) {
+				person := &userModels.Person{}
+				person.ID = 221
+				return person, nil
+			},
+			staffRepo: &instMockStaffRepo{
+				findByPersonIDFn: func(_ context.Context, _ int64) (*userModels.Staff, error) {
+					staff := &userModels.Staff{}
+					staff.ID = 321
+					return staff, nil
+				},
+			},
+		},
+		SettingsService: &fakeOperationSettingsService{hasOverride: true, boolValue: true},
+	})
+	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
+
+	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{
+		"title":   "freispiel",
+		"room_id": int64(70),
+	})
+
+	require.Equal(t, http.StatusCreated, rr.Code)
+	require.NotNil(t, instanceSvc.lastCreate)
+	require.NotNil(t, instanceSvc.lastCreate.ActivityGroupID)
+	assert.Equal(t, int64(72), *instanceSvc.lastCreate.ActivityGroupID)
+	assert.Equal(t, "freispiel", groupRepo.lastFindByName)
+	assert.Nil(t, groupRepo.createdGroup, "existing activity should be reused, not recreated")
+}
+
+func TestOperationsCreateAndStartSpontaneousCreatesActivityForNewName(t *testing.T) {
+	createdInstance := &schedule.ActivityInstance{Status: schedule.InstanceStatusPlanned}
+	createdInstance.ID = 243
+	startedInstance := &schedule.ActivityInstance{Status: schedule.InstanceStatusActive}
+	startedInstance.ID = 243
+	instanceSvc := &mockInstanceService{createRes: createdInstance}
+	categoryRepo := &fakeOperationActivityCategoryRepo{}
+	groupRepo := &fakeOperationActivityGroupRepo{createdID: 73}
+	service := &fakeOperationsService{
+		start: &scheduleSvc.StartInstanceResult{
+			Instance:      startedInstance,
+			ActiveGroupID: 343,
+		},
+	}
+	res := NewResource(Dependencies{
+		InstanceService:      instanceSvc,
+		OperationsService:    service,
+		ActivityGroupRepo:    groupRepo,
+		ActivityCategoryRepo: categoryRepo,
+		PersonService: &instMockPersonService{
+			findByAccountIDFn: func(_ context.Context, _ int64) (*userModels.Person, error) {
+				person := &userModels.Person{}
+				person.ID = 222
+				return person, nil
+			},
+			staffRepo: &instMockStaffRepo{
+				findByPersonIDFn: func(_ context.Context, _ int64) (*userModels.Staff, error) {
+					staff := &userModels.Staff{}
+					staff.ID = 322
+					return staff, nil
+				},
+			},
+		},
+		SettingsService: &fakeOperationSettingsService{hasOverride: true, boolValue: true},
+	})
+	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
+
+	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{
+		"title":   "Neue Werkstatt",
+		"room_id": int64(70),
+	})
+
+	require.Equal(t, http.StatusCreated, rr.Code)
+	require.NotNil(t, categoryRepo.createdCategory)
+	assert.Equal(t, "Spontan", categoryRepo.createdCategory.Name)
+	require.NotNil(t, groupRepo.createdGroup)
+	assert.Equal(t, "Neue Werkstatt", groupRepo.createdGroup.Name)
+	assert.Equal(t, int64(910), groupRepo.createdGroup.CategoryID)
+	assert.Equal(t, int64(322), *groupRepo.createdGroup.CreatedBy)
+	require.NotNil(t, instanceSvc.lastCreate.ActivityGroupID)
+	assert.Equal(t, int64(73), *instanceSvc.lastCreate.ActivityGroupID)
 }
 
 func TestServerSpontaneousActivityWindowUsesBerlinServerTime(t *testing.T) {
@@ -421,6 +528,57 @@ type fakeOperationActiveGroupRepo struct {
 	activeModels.GroupRepository
 	hasRoomConflict bool
 	err             error
+}
+
+type fakeOperationActivityGroupRepo struct {
+	activityModels.GroupRepository
+	findByNameResult *activityModels.Group
+	findByNameErr    error
+	createdGroup     *activityModels.Group
+	createdID        int64
+	lastFindByName   string
+}
+
+func (r *fakeOperationActivityGroupRepo) FindByName(_ context.Context, name string) (*activityModels.Group, error) {
+	r.lastFindByName = name
+	if r.findByNameErr != nil {
+		return nil, r.findByNameErr
+	}
+	if r.findByNameResult != nil {
+		return r.findByNameResult, nil
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (r *fakeOperationActivityGroupRepo) Create(_ context.Context, group *activityModels.Group) error {
+	r.createdGroup = group
+	if r.createdID > 0 {
+		group.ID = r.createdID
+	}
+	return nil
+}
+
+type fakeOperationActivityCategoryRepo struct {
+	activityModels.CategoryRepository
+	findByNameResult *activityModels.Category
+	findByNameErr    error
+	createdCategory  *activityModels.Category
+}
+
+func (r *fakeOperationActivityCategoryRepo) FindByName(_ context.Context, _ string) (*activityModels.Category, error) {
+	if r.findByNameErr != nil {
+		return nil, r.findByNameErr
+	}
+	if r.findByNameResult != nil {
+		return r.findByNameResult, nil
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (r *fakeOperationActivityCategoryRepo) Create(_ context.Context, category *activityModels.Category) error {
+	r.createdCategory = category
+	category.ID = 910
+	return nil
 }
 
 type fakeOperationSettingsService struct {

--- a/backend/database/repositories/activities/group.go
+++ b/backend/database/repositories/activities/group.go
@@ -37,6 +37,29 @@ func NewGroupRepository(db *bun.DB) activities.GroupRepository {
 	}
 }
 
+// FindByName finds a non-archived group by name, case-insensitively.
+func (r *GroupRepository) FindByName(ctx context.Context, name string) (*activities.Group, error) {
+	group := new(activities.Group)
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(group).
+		ModelTableExpr(tableExprActivitiesGroupsAsGrp).
+		Where(`LOWER(TRIM("group".name)) = LOWER(TRIM(?))`, name).
+		Where(`"group".archived_at IS NULL`)
+
+	if where, val, ok := base.TenantWhere(ctx, "group"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find group by name",
+			Err: err,
+		}
+	}
+
+	return group, nil
+}
+
 // FindByCategory finds all groups in a specific category
 func (r *GroupRepository) FindByCategory(ctx context.Context, categoryID int64) ([]*activities.Group, error) {
 	var groups []*activities.Group

--- a/backend/models/activities/repository.go
+++ b/backend/models/activities/repository.go
@@ -22,6 +22,9 @@ type CategoryRepository interface {
 type GroupRepository interface {
 	base.Repository[*Group]
 
+	// FindByName finds a non-archived activity group by its name.
+	FindByName(ctx context.Context, name string) (*Group, error)
+
 	// FindByCategory finds all groups in a specific category
 	FindByCategory(ctx context.Context, categoryID int64) ([]*Group, error)
 

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -89,10 +89,14 @@ const (
 	KeySickClearMode                  = "operations.sick_clear_mode"
 	KeyExcusedClearMode               = "operations.excused_clear_mode"
 	KeyPresenceMode                   = "operations.presence_mode"
+	KeyAttendanceWebEnabled           = "attendance.web_enabled"
+	KeyAttendanceNFCEnabled           = "attendance.nfc_enabled"
 	KeyWebCheckinAccess               = "attendance.web_checkin_access"
 	KeyStudentActivationIntervalMin   = "operations.student_activation_interval_minutes"
 	KeyWebSpontaneousActivities       = "attendance.web_spontaneous_activities_enabled"
 	KeyStudentPhotosEnabled           = "operations.student_photos_enabled"
+	KeyGroupMode                      = "operations.group_mode"
+	KeyCareConcept                    = "operations.care_concept"
 )
 
 // PresenceMode option values for KeyPresenceMode.
@@ -105,6 +109,18 @@ const (
 const (
 	WebCheckinAccessGroupSupervisors = "group_supervisors"
 	WebCheckinAccessAllStaff         = "all_staff"
+)
+
+// GroupMode option values for KeyGroupMode.
+const (
+	GroupModeFixedGroups = "fixed_groups"
+	GroupModeOpenCare    = "open_care"
+)
+
+// CareConcept option values for KeyCareConcept.
+const (
+	CareConceptFixedSchedule = "fixed_schedule"
+	CareConceptOpenRooms     = "open_rooms"
 )
 
 // StatusFlagClearMode option values for KeySickClearMode and KeyExcusedClearMode.

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -61,8 +61,12 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"timetable.day_end_time",
 		// Presence-mode work package: tenant presence tracking model + who can check-in via web.
 		"operations.presence_mode",
+		"attendance.web_enabled",
+		"attendance.nfc_enabled",
 		"attendance.web_checkin_access",
 		"attendance.web_spontaneous_activities_enabled",
+		"operations.group_mode",
+		"operations.care_concept",
 		// Student photo feature (Datenverwaltung): per-school opt-in toggle.
 		"operations.student_photos_enabled",
 		// 2FA / MFA work package (issue #1308): mode toggle + trusted-device pair.
@@ -145,6 +149,54 @@ func TestWebSpontaneousActivitiesSetting(t *testing.T) {
 	assert.Equal(t, "operations", def.Tab)
 	assert.Equal(t, "anwesenheit", def.Category)
 	assert.Equal(t, "config:manage", def.WritePermission)
+}
+
+func TestAttendanceSetupSettings(t *testing.T) {
+	webDef := config.GetDefinition(config.KeyAttendanceWebEnabled)
+	require.NotNil(t, webDef, "attendance.web_enabled should be registered")
+	assert.Equal(t, config.FieldBoolean, webDef.Type)
+	assert.Equal(t, true, webDef.Default, "web attendance should default on")
+	assert.Equal(t, config.AccessShared, webDef.AccessPolicy)
+	assert.Equal(t, "operations", webDef.Tab)
+	assert.Equal(t, "anwesenheit", webDef.Category)
+	assert.Equal(t, "config:update", webDef.WritePermission)
+
+	nfcDef := config.GetDefinition(config.KeyAttendanceNFCEnabled)
+	require.NotNil(t, nfcDef, "attendance.nfc_enabled should be registered")
+	assert.Equal(t, config.FieldBoolean, nfcDef.Type)
+	assert.Equal(t, false, nfcDef.Default, "nfc attendance should default off")
+	assert.Equal(t, config.AccessShared, nfcDef.AccessPolicy)
+	assert.Equal(t, "operations", nfcDef.Tab)
+	assert.Equal(t, "anwesenheit", nfcDef.Category)
+	assert.Equal(t, "config:update", nfcDef.WritePermission)
+}
+
+func TestOrganizationSetupSettings(t *testing.T) {
+	groupDef := config.GetDefinition(config.KeyGroupMode)
+	require.NotNil(t, groupDef, "operations.group_mode should be registered")
+	assert.Equal(t, config.FieldSelect, groupDef.Type)
+	assert.Equal(t, config.GroupModeFixedGroups, groupDef.Default)
+	assert.Equal(t, config.AccessShared, groupDef.AccessPolicy)
+	assert.Equal(t, "operations", groupDef.Tab)
+	assert.Equal(t, "organisation", groupDef.Category)
+	assert.Equal(t, "config:update", groupDef.WritePermission)
+	require.NotNil(t, groupDef.Options)
+	groupValues := []any{groupDef.Options.Static[0].Value, groupDef.Options.Static[1].Value}
+	assert.Contains(t, groupValues, config.GroupModeFixedGroups)
+	assert.Contains(t, groupValues, config.GroupModeOpenCare)
+
+	careDef := config.GetDefinition(config.KeyCareConcept)
+	require.NotNil(t, careDef, "operations.care_concept should be registered")
+	assert.Equal(t, config.FieldSelect, careDef.Type)
+	assert.Equal(t, config.CareConceptFixedSchedule, careDef.Default)
+	assert.Equal(t, config.AccessShared, careDef.AccessPolicy)
+	assert.Equal(t, "operations", careDef.Tab)
+	assert.Equal(t, "organisation", careDef.Category)
+	assert.Equal(t, "config:update", careDef.WritePermission)
+	require.NotNil(t, careDef.Options)
+	careValues := []any{careDef.Options.Static[0].Value, careDef.Options.Static[1].Value}
+	assert.Contains(t, careValues, config.CareConceptFixedSchedule)
+	assert.Contains(t, careValues, config.CareConceptOpenRooms)
 }
 
 func TestTimetableSettings_Types(t *testing.T) {
@@ -583,6 +635,10 @@ func TestSecuritySettings(t *testing.T) {
 	assert.Equal(t, "devices", def.Tab)
 	assert.Equal(t, "pin", def.Category)
 	assert.Equal(t, "config:manage", def.WritePermission)
+	require.NotNil(t, def.DependsOn)
+	assert.Equal(t, config.KeyAttendanceNFCEnabled, def.DependsOn.Key)
+	assert.Equal(t, "eq", def.DependsOn.Condition)
+	assert.Equal(t, true, def.DependsOn.Value)
 }
 
 // TestMFASettings_TypesAndDefaults locks down the field types, registry
@@ -696,17 +752,26 @@ func TestDependsOn_GDPRGroup(t *testing.T) {
 }
 
 func TestDependsOn_PerStudentCheckoutGroup(t *testing.T) {
+	dailyCheckoutDef := config.GetDefinition("operations.student_daily_checkout_time")
+	require.NotNil(t, dailyCheckoutDef)
+	require.NotNil(t, dailyCheckoutDef.DependsOn)
+	assert.Equal(t, config.KeyAttendanceNFCEnabled, dailyCheckoutDef.DependsOn.Key)
+	assert.Equal(t, "eq", dailyCheckoutDef.DependsOn.Condition)
+	assert.Equal(t, true, dailyCheckoutDef.DependsOn.Value)
+
+	toggleDef := config.GetDefinition("operations.per_student_checkout_enabled")
+	require.NotNil(t, toggleDef)
+	require.NotNil(t, toggleDef.DependsOn)
+	assert.Equal(t, config.KeyAttendanceNFCEnabled, toggleDef.DependsOn.Key)
+	assert.Equal(t, "eq", toggleDef.DependsOn.Condition)
+	assert.Equal(t, true, toggleDef.DependsOn.Value)
+
 	deltaDef := config.GetDefinition("operations.per_student_checkout_delta_minutes")
 	require.NotNil(t, deltaDef)
 	require.NotNil(t, deltaDef.DependsOn)
 	assert.Equal(t, "operations.per_student_checkout_enabled", deltaDef.DependsOn.Key)
 	assert.Equal(t, "eq", deltaDef.DependsOn.Condition)
 	assert.Equal(t, true, deltaDef.DependsOn.Value)
-
-	// The toggle itself has no DependsOn
-	toggleDef := config.GetDefinition("operations.per_student_checkout_enabled")
-	require.NotNil(t, toggleDef)
-	assert.Nil(t, toggleDef.DependsOn)
 }
 
 func TestDependsOn_AttendanceLogGroup(t *testing.T) {
@@ -784,6 +849,10 @@ func TestDevicesSettings(t *testing.T) {
 		assert.Equal(t, "devices", def.Tab, "setting %q should be in devices tab", key)
 		assert.Equal(t, "checkout", def.Category, "setting %q should be in checkout category", key)
 		assert.Equal(t, "config:update", def.WritePermission, "setting %q should use config:update", key)
+		require.NotNil(t, def.DependsOn, "setting %q should be gated by nfc_enabled", key)
+		assert.Equal(t, config.KeyAttendanceNFCEnabled, def.DependsOn.Key)
+		assert.Equal(t, "eq", def.DependsOn.Condition)
+		assert.Equal(t, true, def.DependsOn.Value)
 	}
 
 	// Raumwechsel defaults to true (no system room required)

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -156,19 +156,19 @@ func TestAttendanceSetupSettings(t *testing.T) {
 	require.NotNil(t, webDef, "attendance.web_enabled should be registered")
 	assert.Equal(t, config.FieldBoolean, webDef.Type)
 	assert.Equal(t, true, webDef.Default, "web attendance should default on")
-	assert.Equal(t, config.AccessShared, webDef.AccessPolicy)
+	assert.Equal(t, config.AccessOperatorOnly, webDef.AccessPolicy, "web attendance is a provisioning flag, not a tenant-admin setting")
 	assert.Equal(t, "operations", webDef.Tab)
 	assert.Equal(t, "anwesenheit", webDef.Category)
-	assert.Equal(t, "config:update", webDef.WritePermission)
+	assert.Equal(t, "config:manage", webDef.WritePermission)
 
 	nfcDef := config.GetDefinition(config.KeyAttendanceNFCEnabled)
 	require.NotNil(t, nfcDef, "attendance.nfc_enabled should be registered")
 	assert.Equal(t, config.FieldBoolean, nfcDef.Type)
 	assert.Equal(t, false, nfcDef.Default, "nfc attendance should default off")
-	assert.Equal(t, config.AccessShared, nfcDef.AccessPolicy)
+	assert.Equal(t, config.AccessOperatorOnly, nfcDef.AccessPolicy, "nfc attendance is provisioned by operators after NFC setup")
 	assert.Equal(t, "operations", nfcDef.Tab)
 	assert.Equal(t, "anwesenheit", nfcDef.Category)
-	assert.Equal(t, "config:update", nfcDef.WritePermission)
+	assert.Equal(t, "config:manage", nfcDef.WritePermission)
 }
 
 func TestOrganizationSetupSettings(t *testing.T) {

--- a/backend/services/config/defaults/devices.go
+++ b/backend/services/config/defaults/devices.go
@@ -16,6 +16,11 @@ func init() {
 		Tab:             "devices",
 		Category:        "checkout",
 		SortOrder:       10,
+		DependsOn: &config.Dependency{
+			Key:       config.KeyAttendanceNFCEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
 	})
 
 	config.Register(config.Definition{
@@ -29,6 +34,11 @@ func init() {
 		Tab:             "devices",
 		Category:        "checkout",
 		SortOrder:       11,
+		DependsOn: &config.Dependency{
+			Key:       config.KeyAttendanceNFCEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
 	})
 
 	config.Register(config.Definition{
@@ -42,5 +52,10 @@ func init() {
 		Tab:             "devices",
 		Category:        "checkout",
 		SortOrder:       12,
+		DependsOn: &config.Dependency{
+			Key:       config.KeyAttendanceNFCEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
 	})
 }

--- a/backend/services/config/defaults/operations.go
+++ b/backend/services/config/defaults/operations.go
@@ -75,6 +75,11 @@ func init() {
 		Tab:             "operations",
 		Category:        "checkout",
 		SortOrder:       1,
+		DependsOn: &config.Dependency{
+			Key:       config.KeyAttendanceNFCEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
 	})
 
 	config.Register(config.Definition{
@@ -88,6 +93,11 @@ func init() {
 		Tab:             "operations",
 		Category:        "checkout",
 		SortOrder:       2,
+		DependsOn: &config.Dependency{
+			Key:       config.KeyAttendanceNFCEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
 	})
 
 	minDelta := float64(0)
@@ -258,6 +268,74 @@ func init() {
 			Static: []config.SelectOption{
 				{Label: "Detailliert (Räume & Aktivitäten)", Value: config.PresenceModeDetailed},
 				{Label: "Binär (nur An-/Abwesend)", Value: config.PresenceModeBinary},
+			},
+		},
+	})
+
+	// --- Anwesenheitserfassung (setup-level decisions) ---
+
+	config.Register(config.Definition{
+		Key:             config.KeyAttendanceWebEnabled,
+		Label:           "Anwesenheit über Web-App erfassen",
+		Description:     "Mitarbeitende können Kinder über die Web-App an- und abmelden oder in Aktivitäten eintragen.",
+		Type:            config.FieldBoolean,
+		Default:         true,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "anwesenheit",
+		SortOrder:       43,
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyAttendanceNFCEnabled,
+		Label:           "Anwesenheit über NFC-Geräte erfassen",
+		Description:     "Die OGS nutzt NFC-Armbänder oder Karten an Geräten, zum Beispiel für Räume, Schulhof oder Abmeldung.",
+		Type:            config.FieldBoolean,
+		Default:         false,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "anwesenheit",
+		SortOrder:       44,
+	})
+
+	// --- Organisationsmodell (setup-level decisions) ---
+
+	config.Register(config.Definition{
+		Key:             config.KeyGroupMode,
+		Label:           "Arbeit mit festen Gruppen",
+		Description:     "Legt fest, ob Kinder im Alltag festen OGS-Gruppen zugeordnet sind oder ob alle berechtigten Mitarbeitenden mit allen Kindern arbeiten.",
+		Type:            config.FieldSelect,
+		Default:         config.GroupModeFixedGroups,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "organisation",
+		SortOrder:       1,
+		Options: &config.SelectOptions{
+			Static: []config.SelectOption{
+				{Label: "Feste Gruppen", Value: config.GroupModeFixedGroups},
+				{Label: "Offene Betreuung ohne feste Gruppen", Value: config.GroupModeOpenCare},
+			},
+		},
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyCareConcept,
+		Label:           "Betreuungskonzept",
+		Description:     "Legt fest, ob die OGS mit einem festen Betriebsplan arbeitet oder Kinder sich frei zwischen offenen Räumen bewegen.",
+		Type:            config.FieldSelect,
+		Default:         config.CareConceptFixedSchedule,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "organisation",
+		SortOrder:       2,
+		Options: &config.SelectOptions{
+			Static: []config.SelectOption{
+				{Label: "Fester Betriebsplan", Value: config.CareConceptFixedSchedule},
+				{Label: "Offenes Raumkonzept", Value: config.CareConceptOpenRooms},
 			},
 		},
 	})

--- a/backend/services/config/defaults/operations.go
+++ b/backend/services/config/defaults/operations.go
@@ -281,10 +281,11 @@ func init() {
 		Type:            config.FieldBoolean,
 		Default:         true,
 		ReadPermission:  "config:read",
-		WritePermission: "config:update",
+		WritePermission: "config:manage",
 		Tab:             "operations",
 		Category:        "anwesenheit",
 		SortOrder:       43,
+		AccessPolicy:    config.AccessOperatorOnly,
 	})
 
 	config.Register(config.Definition{
@@ -294,10 +295,11 @@ func init() {
 		Type:            config.FieldBoolean,
 		Default:         false,
 		ReadPermission:  "config:read",
-		WritePermission: "config:update",
+		WritePermission: "config:manage",
 		Tab:             "operations",
 		Category:        "anwesenheit",
 		SortOrder:       44,
+		AccessPolicy:    config.AccessOperatorOnly,
 	})
 
 	// --- Organisationsmodell (setup-level decisions) ---

--- a/backend/services/config/defaults/security.go
+++ b/backend/services/config/defaults/security.go
@@ -19,6 +19,11 @@ func init() {
 		SortOrder:       1,
 		Validation:      &config.ValidationRules{Pattern: &pinPattern},
 		AccessPolicy:    config.AccessAdminOnly,
+		DependsOn: &config.Dependency{
+			Key:       config.KeyAttendanceNFCEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
 	})
 
 	// --- MFA / Two-Factor Authentication (issue #1308) ---

--- a/backend/services/config/schema_builder.go
+++ b/backend/services/config/schema_builder.go
@@ -44,23 +44,13 @@ func buildSchemaWithScope(
 ) (*SettingsSchema, error) {
 	defs := config.AllDefinitions()
 
-	// Resolve all values and build the resolved map
+	// Resolve all values for dependency evaluation, then filter the output
+	// separately. Tenant-visible settings can depend on operator-only
+	// provisioning flags such as attendance.nfc_enabled; hiding those parents
+	// before evaluating DependsOn would make the tenant-visible children vanish.
 	resolvedMap := make(map[string]*ResolvedSetting, len(defs))
+	outputMap := make(map[string]*ResolvedSetting, len(defs))
 	for key, def := range defs {
-		// AccessPolicy filter: hide the other audience's dedicated settings.
-		if isOperator && def.AccessPolicy == config.AccessAdminOnly {
-			continue
-		}
-		if !isOperator && def.AccessPolicy == config.AccessOperatorOnly {
-			continue
-		}
-
-		// Permission filter: only applied for tenant callers. Operators bypass
-		// the per-setting ReadPermission — AccessPolicy already gated them.
-		if !isOperator && def.ReadPermission != "" && !authorize.HasPermission(def.ReadPermission, userPermissions) {
-			continue
-		}
-
 		value, err := svc.Resolve(ctx, key)
 		if err != nil {
 			svc.logger.Warn("failed to resolve setting",
@@ -103,6 +93,9 @@ func buildSchemaWithScope(
 			Options:      def.Options,
 		}
 		resolvedMap[key] = resolved
+		if shouldIncludeInSchema(def, userPermissions, isOperator) {
+			outputMap[key] = resolved
+		}
 	}
 
 	// Evaluate DependsOn visibility. Dependencies may be nested, so resolve
@@ -117,7 +110,7 @@ func buildSchemaWithScope(
 	catItems := make(map[catKey][]*ResolvedSetting)
 	tabSet := make(map[string]bool)
 
-	for _, resolved := range resolvedMap {
+	for _, resolved := range outputMap {
 		def := config.GetDefinition(resolved.Key)
 		if def == nil {
 			continue
@@ -180,6 +173,21 @@ func buildSchemaWithScope(
 	}
 
 	return schema, nil
+}
+
+func shouldIncludeInSchema(def *config.Definition, userPermissions []string, isOperator bool) bool {
+	if isOperator && def.AccessPolicy == config.AccessAdminOnly {
+		return false
+	}
+	if !isOperator && def.AccessPolicy == config.AccessOperatorOnly {
+		return false
+	}
+
+	// Permission filter is only applied for tenant callers. Operators bypass
+	// the per-setting ReadPermission because operator access is route-gated.
+	return isOperator ||
+		def.ReadPermission == "" ||
+		authorize.HasPermission(def.ReadPermission, userPermissions)
 }
 
 // evaluateDependency checks if a setting's dependency condition is met.

--- a/backend/services/config/schema_builder.go
+++ b/backend/services/config/schema_builder.go
@@ -105,9 +105,11 @@ func buildSchemaWithScope(
 		resolvedMap[key] = resolved
 	}
 
-	// Evaluate DependsOn visibility
+	// Evaluate DependsOn visibility. Dependencies may be nested, so resolve
+	// parent visibility recursively instead of relying on map iteration order.
+	visibilityMemo := make(map[string]bool, len(resolvedMap))
 	for _, resolved := range resolvedMap {
-		resolved.Visible = evaluateDependency(resolved, resolvedMap)
+		resolved.Visible = evaluateDependency(resolved, resolvedMap, visibilityMemo, make(map[string]bool))
 	}
 
 	// Group by tab → category
@@ -181,30 +183,53 @@ func buildSchemaWithScope(
 }
 
 // evaluateDependency checks if a setting's dependency condition is met.
-func evaluateDependency(resolved *ResolvedSetting, resolvedMap map[string]*ResolvedSetting) bool {
+func evaluateDependency(resolved *ResolvedSetting, resolvedMap map[string]*ResolvedSetting, memo map[string]bool, visiting map[string]bool) bool {
+	if visible, ok := memo[resolved.Key]; ok {
+		return visible
+	}
+	if visiting[resolved.Key] {
+		slog.Warn("settings dependency cycle detected, hiding setting",
+			slog.String("key", resolved.Key),
+		)
+		memo[resolved.Key] = false
+		return false
+	}
 	if resolved.DependsOn == nil {
+		memo[resolved.Key] = true
 		return true
 	}
 
+	visiting[resolved.Key] = true
+	defer delete(visiting, resolved.Key)
+
 	parent, ok := resolvedMap[resolved.DependsOn.Key]
 	if !ok {
+		memo[resolved.Key] = false
 		return false
 	}
 
+	if !evaluateDependency(parent, resolvedMap, memo, visiting) {
+		memo[resolved.Key] = false
+		return false
+	}
+
+	visible := false
 	switch resolved.DependsOn.Condition {
 	case "eq":
-		return jsonValuesEqual(parent.Value, resolved.DependsOn.Value)
+		visible = jsonValuesEqual(parent.Value, resolved.DependsOn.Value)
 	case "neq":
-		return !jsonValuesEqual(parent.Value, resolved.DependsOn.Value)
+		visible = !jsonValuesEqual(parent.Value, resolved.DependsOn.Value)
 	case "not_empty":
-		return parent.Value != nil && parent.Value != ""
+		visible = parent.Value != nil && parent.Value != ""
 	default:
 		slog.Warn("unknown dependency condition, treating as not met",
 			slog.String("key", resolved.DependsOn.Key),
 			slog.String("condition", resolved.DependsOn.Condition),
 		)
-		return false
+		visible = false
 	}
+	memo[resolved.Key] = visible
+	return visible
 }
 
 // jsonValuesEqual compares two values by their JSON representation.

--- a/backend/services/config/settings_service_test.go
+++ b/backend/services/config/settings_service_test.go
@@ -488,6 +488,108 @@ func TestGetSchema_DependsOn_ShowsChild(t *testing.T) {
 	}
 }
 
+func TestGetSchema_DependsOn_UsesHiddenOperatorOnlyParent(t *testing.T) {
+	setupTest(t)
+
+	config.Register(config.Definition{
+		Key:             "attendance.nfc_enabled",
+		Label:           "NFC",
+		Type:            config.FieldBoolean,
+		Default:         false,
+		Tab:             "operations",
+		Category:        "attendance",
+		AccessPolicy:    config.AccessOperatorOnly,
+		ReadPermission:  "config:read",
+		WritePermission: "config:manage",
+	})
+	config.Register(config.Definition{
+		Key:             "security.ogs_device_pin",
+		Label:           "PIN",
+		Type:            config.FieldPassword,
+		Default:         "1234",
+		Tab:             "security",
+		Category:        "devices",
+		ReadPermission:  "config:read",
+		WritePermission: "config:manage",
+		DependsOn: &config.Dependency{
+			Key:       "attendance.nfc_enabled",
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+	config.Register(config.Definition{
+		Key:             "checkout.raumwechsel_enabled",
+		Label:           "Raumwechsel",
+		Type:            config.FieldBoolean,
+		Default:         true,
+		Tab:             "devices",
+		Category:        "checkout",
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		AccessPolicy:    config.AccessAdminOnly,
+		DependsOn: &config.Dependency{
+			Key:       "attendance.nfc_enabled",
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
+	tenantID := int64(42)
+	valueRepo := newMockValueRepo()
+	valueRepo.values[valueRepo.key(tenantID, "attendance.nfc_enabled")] = &config.SettingValue{
+		SettingKey: "attendance.nfc_enabled",
+		Value:      json.RawMessage(`true`),
+	}
+	valueRepo.values[valueRepo.key(tenantID, "attendance.nfc_enabled")].TenantID = tenantID
+	svc := createService(valueRepo, &mockAuditRepo{})
+
+	schema, err := svc.GetSchema(tenantCtx(tenantID), []string{"config:read"})
+	require.NoError(t, err)
+
+	visibility := schemaVisibility(schema)
+	_, parentIncluded := visibility["attendance.nfc_enabled"]
+	assert.False(t, parentIncluded, "operator-only parent must not be serialized to tenant admins")
+	assert.True(t, visibility["security.ogs_device_pin"], "shared child should use hidden parent for visibility")
+	assert.True(t, visibility["checkout.raumwechsel_enabled"], "admin-only child should use hidden parent for visibility")
+}
+
+func TestGetSchema_DependsOn_HidesChildWhenHiddenOperatorOnlyParentFalse(t *testing.T) {
+	setupTest(t)
+
+	config.Register(config.Definition{
+		Key:          "attendance.nfc_enabled",
+		Label:        "NFC",
+		Type:         config.FieldBoolean,
+		Default:      false,
+		Tab:          "operations",
+		Category:     "attendance",
+		AccessPolicy: config.AccessOperatorOnly,
+	})
+	config.Register(config.Definition{
+		Key:      "operations.student_daily_checkout_time",
+		Label:    "Checkout time",
+		Type:     config.FieldTime,
+		Default:  "",
+		Tab:      "operations",
+		Category: "checkout",
+		DependsOn: &config.Dependency{
+			Key:       "attendance.nfc_enabled",
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
+	svc := createService(newMockValueRepo(), &mockAuditRepo{})
+
+	schema, err := svc.GetSchema(tenantCtx(42), []string{})
+	require.NoError(t, err)
+
+	visibility := schemaVisibility(schema)
+	_, parentIncluded := visibility["attendance.nfc_enabled"]
+	assert.False(t, parentIncluded, "operator-only parent must not be serialized to tenant admins")
+	assert.False(t, visibility["operations.student_daily_checkout_time"], "child should hide when hidden parent is false")
+}
+
 func TestGetSchema_DependsOn_HidesGrandchildWhenParentHidden(t *testing.T) {
 	setupTest(t)
 
@@ -540,6 +642,18 @@ func TestGetSchema_DependsOn_HidesGrandchildWhenParentHidden(t *testing.T) {
 	assert.True(t, visibility["root.enabled"], "root should stay visible")
 	assert.False(t, visibility["child.enabled"], "child should hide when root is false")
 	assert.False(t, visibility["grandchild.minutes"], "grandchild should hide when its parent is hidden")
+}
+
+func schemaVisibility(schema *configSvc.SettingsSchema) map[string]bool {
+	visibility := make(map[string]bool)
+	for _, tab := range schema.Tabs {
+		for _, category := range tab.Categories {
+			for _, item := range category.Items {
+				visibility[item.Key] = item.Visible
+			}
+		}
+	}
+	return visibility
 }
 
 func TestSettingsError_Unwrap(t *testing.T) {

--- a/backend/services/config/settings_service_test.go
+++ b/backend/services/config/settings_service_test.go
@@ -488,6 +488,60 @@ func TestGetSchema_DependsOn_ShowsChild(t *testing.T) {
 	}
 }
 
+func TestGetSchema_DependsOn_HidesGrandchildWhenParentHidden(t *testing.T) {
+	setupTest(t)
+
+	config.Register(config.Definition{
+		Key:      "root.enabled",
+		Label:    "Root",
+		Type:     config.FieldBoolean,
+		Default:  false,
+		Tab:      "test",
+		Category: "deps",
+	})
+	config.Register(config.Definition{
+		Key:      "child.enabled",
+		Label:    "Child",
+		Type:     config.FieldBoolean,
+		Default:  true,
+		Tab:      "test",
+		Category: "deps",
+		DependsOn: &config.Dependency{
+			Key:       "root.enabled",
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+	config.Register(config.Definition{
+		Key:      "grandchild.minutes",
+		Label:    "Grandchild",
+		Type:     config.FieldNumber,
+		Default:  15,
+		Tab:      "test",
+		Category: "deps",
+		DependsOn: &config.Dependency{
+			Key:       "child.enabled",
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
+	svc := createService(newMockValueRepo(), &mockAuditRepo{})
+
+	schema, err := svc.GetSchema(tenantCtx(1), []string{})
+	require.NoError(t, err)
+
+	items := schema.Tabs[0].Categories[0].Items
+	visibility := make(map[string]bool, len(items))
+	for _, item := range items {
+		visibility[item.Key] = item.Visible
+	}
+
+	assert.True(t, visibility["root.enabled"], "root should stay visible")
+	assert.False(t, visibility["child.enabled"], "child should hide when root is false")
+	assert.False(t, visibility["grandchild.minutes"], "grandchild should hide when its parent is hidden")
+}
+
 func TestSettingsError_Unwrap(t *testing.T) {
 	inner := &configSvc.DefinitionNotFoundError{Key: "test"}
 	err := &configSvc.SettingsError{Op: "resolve", Err: inner}

--- a/frontend/src/app/[tenant]/(protected)/activities/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   type Timeframe,
 } from "@/lib/activity-helpers";
 import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
+import { NfcModeGuard } from "~/components/tenant/nfc-mode-guard";
 
 const logger = createLogger({ component: "ActivityDetailPage" });
 
@@ -423,16 +424,18 @@ function ActivityDetailContent() {
 
 export default function ActivityDetailPage() {
   return (
-    <BinaryModeGuard>
-      <Suspense
-        fallback={
-          <div className="flex min-h-screen items-center justify-center">
-            <p>Lädt...</p>
-          </div>
-        }
-      >
-        <ActivityDetailContent />
-      </Suspense>
-    </BinaryModeGuard>
+    <NfcModeGuard>
+      <BinaryModeGuard>
+        <Suspense
+          fallback={
+            <div className="flex min-h-screen items-center justify-center">
+              <p>Lädt...</p>
+            </div>
+          }
+        >
+          <ActivityDetailContent />
+        </Suspense>
+      </BinaryModeGuard>
+    </NfcModeGuard>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/activities/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.tsx
@@ -22,6 +22,7 @@ import { Loading } from "~/components/ui/loading";
 import { useSWRAuth } from "~/lib/swr";
 import { createLogger } from "~/lib/logger";
 import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
+import { NfcModeGuard } from "~/components/tenant/nfc-mode-guard";
 
 const logger = createLogger({ component: "ActivitiesPage" });
 
@@ -40,9 +41,11 @@ interface ActivitiesPageData {
 // page's main function — React rules forbid conditional hooks.
 export default function ActivitiesPage() {
   return (
-    <BinaryModeGuard>
-      <ActivitiesPageContent />
-    </BinaryModeGuard>
+    <NfcModeGuard>
+      <BinaryModeGuard>
+        <ActivitiesPageContent />
+      </BinaryModeGuard>
+    </NfcModeGuard>
   );
 }
 
@@ -360,7 +363,7 @@ function ActivitiesPageContent() {
                   type="button"
                   key={activity.id}
                   onClick={handleClick}
-                  className="group moto-content-surface moto-hover-elevated relative w-full cursor-pointer overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-[0_1px_2px_rgba(15,23,42,0.04),0_0_0_1px_rgba(15,23,42,0.02)] active:shadow-[0_10px_26px_rgba(15,23,42,0.1)]"
+                  className="moto-content-surface moto-hover-elevated group relative w-full cursor-pointer overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-[0_1px_2px_rgba(15,23,42,0.04),0_0_0_1px_rgba(15,23,42,0.02)] active:shadow-[0_10px_26px_rgba(15,23,42,0.1)]"
                   style={{
                     animationName: "fadeInUp",
                     animationDuration: "0.5s",

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.test.tsx
@@ -109,6 +109,11 @@ vi.mock("~/lib/swr/hooks", () => ({
   useSWRAuth: vi.fn(),
 }));
 
+vi.mock("~/components/tenant/tenant-provider", () => ({
+  useNFCEnabled: vi.fn(() => true),
+  useTenantSlugSafe: vi.fn(() => "test-tenant"),
+}));
+
 vi.mock("~/lib/dashboard-helpers", () => ({
   formatRecentActivityTime: vi.fn((timestamp: string) => {
     const date = new Date(timestamp);
@@ -124,6 +129,7 @@ vi.mock("~/lib/dashboard-helpers", () => ({
 import { useSession } from "next-auth/react";
 import { isAdmin } from "~/lib/auth-utils";
 import { useSWRAuth } from "~/lib/swr/hooks";
+import { useNFCEnabled } from "~/components/tenant/tenant-provider";
 
 // Helper to create SWR mock return values
 function mockSWR(
@@ -149,6 +155,7 @@ describe("DashboardPage", () => {
     });
     vi.mocked(isAdmin).mockReturnValue(true);
     vi.mocked(useSWRAuth).mockReturnValue(mockSWR(mockDashboardData));
+    vi.mocked(useNFCEnabled).mockReturnValue(true);
   });
 
   it("renders dashboard for admin user", async () => {
@@ -234,6 +241,25 @@ describe("DashboardPage", () => {
       expect(screen.getByText("Laufende Aktivitäten")).toBeInTheDocument();
       // "Aktive Gruppen" appears both as stat card title and info card title
       expect(screen.getAllByText("Aktive Gruppen")).toHaveLength(2);
+      expect(screen.getByText("Personal heute")).toBeInTheDocument();
+    });
+  });
+
+  it("hides activity dashboard surfaces when NFC is disabled", async () => {
+    vi.mocked(useNFCEnabled).mockReturnValue(false);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Aktive Aktivitäten")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Laufende Aktivitäten"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: /Laufende Aktivitäten/i }),
+      ).not.toBeInTheDocument();
+      expect(screen.getAllByText("Aktive Gruppen")).toHaveLength(2);
+      expect(screen.getByText("Freie Räume")).toBeInTheDocument();
       expect(screen.getByText("Personal heute")).toBeInTheDocument();
     });
   });
@@ -359,6 +385,7 @@ describe("DashboardContent rendering states", () => {
       status: "authenticated",
       update: vi.fn(),
     });
+    vi.mocked(useNFCEnabled).mockReturnValue(true);
   });
 
   it("shows empty state for recent activity when no data", async () => {
@@ -579,6 +606,7 @@ describe("StatCard component behavior", () => {
       status: "authenticated",
       update: vi.fn(),
     });
+    vi.mocked(useNFCEnabled).mockReturnValue(true);
   });
 
   it("renders stat cards as links when href is provided", async () => {
@@ -620,6 +648,7 @@ describe("InfoCard component behavior", () => {
       update: vi.fn(),
     });
     vi.mocked(useSWRAuth).mockReturnValue(mockSWR(mockDashboardData));
+    vi.mocked(useNFCEnabled).mockReturnValue(true);
   });
 
   it("renders info cards as links when href is provided", async () => {

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.test.tsx
@@ -111,6 +111,7 @@ vi.mock("~/lib/swr/hooks", () => ({
 
 vi.mock("~/components/tenant/tenant-provider", () => ({
   useNFCEnabled: vi.fn(() => true),
+  usePresenceMode: vi.fn(() => "detailed"),
   useTenantSlugSafe: vi.fn(() => "test-tenant"),
 }));
 
@@ -129,7 +130,10 @@ vi.mock("~/lib/dashboard-helpers", () => ({
 import { useSession } from "next-auth/react";
 import { isAdmin } from "~/lib/auth-utils";
 import { useSWRAuth } from "~/lib/swr/hooks";
-import { useNFCEnabled } from "~/components/tenant/tenant-provider";
+import {
+  useNFCEnabled,
+  usePresenceMode,
+} from "~/components/tenant/tenant-provider";
 
 // Helper to create SWR mock return values
 function mockSWR(
@@ -156,6 +160,7 @@ describe("DashboardPage", () => {
     vi.mocked(isAdmin).mockReturnValue(true);
     vi.mocked(useSWRAuth).mockReturnValue(mockSWR(mockDashboardData));
     vi.mocked(useNFCEnabled).mockReturnValue(true);
+    vi.mocked(usePresenceMode).mockReturnValue("detailed");
   });
 
   it("renders dashboard for admin user", async () => {
@@ -247,6 +252,26 @@ describe("DashboardPage", () => {
 
   it("hides activity dashboard surfaces when NFC is disabled", async () => {
     vi.mocked(useNFCEnabled).mockReturnValue(false);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Aktive Aktivitäten")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Laufende Aktivitäten"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: /Laufende Aktivitäten/i }),
+      ).not.toBeInTheDocument();
+      expect(screen.getAllByText("Aktive Gruppen")).toHaveLength(2);
+      expect(screen.getByText("Freie Räume")).toBeInTheDocument();
+      expect(screen.getByText("Personal heute")).toBeInTheDocument();
+    });
+  });
+
+  it("hides activity dashboard surfaces in binary presence mode", async () => {
+    vi.mocked(useNFCEnabled).mockReturnValue(true);
+    vi.mocked(usePresenceMode).mockReturnValue("binary");
 
     render(<DashboardPage />);
 
@@ -649,6 +674,7 @@ describe("InfoCard component behavior", () => {
     });
     vi.mocked(useSWRAuth).mockReturnValue(mockSWR(mockDashboardData));
     vi.mocked(useNFCEnabled).mockReturnValue(true);
+    vi.mocked(usePresenceMode).mockReturnValue("detailed");
   });
 
   it("renders info cards as links when href is provided", async () => {

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "~/lib/dashboard-helpers";
 import { useSWRAuth } from "~/lib/swr/hooks";
 import { RoleGuard } from "~/components/auth/role-guard";
+import { useNFCEnabled } from "~/components/tenant/tenant-provider";
 
 import { Loading } from "~/components/ui/loading";
 
@@ -252,6 +253,7 @@ const InfoCard: React.FC<InfoCardProps> = ({
 
 function DashboardContent() {
   const router = useTenantRouter();
+  const nfcEnabled = useNFCEnabled();
   const { data: session, status } = useSession({
     required: true,
     onUnauthenticated() {
@@ -381,14 +383,16 @@ function DashboardContent() {
           loading={isLoading}
           href="/ogs-groups"
         />
-        <StatCard
-          title="Aktive Aktivitäten"
-          value={dashboardData?.activeActivities ?? 0}
-          icon="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-          color="from-[#FF3130] to-[#e02020]"
-          loading={isLoading}
-          href="/activities"
-        />
+        {nfcEnabled ? (
+          <StatCard
+            title="Aktive Aktivitäten"
+            value={dashboardData?.activeActivities ?? 0}
+            icon="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+            color="from-[#FF3130] to-[#e02020]"
+            loading={isLoading}
+            href="/activities"
+          />
+        ) : null}
         <StatCard
           title="Freie Räume"
           value={dashboardData?.freeRooms ?? 0}
@@ -483,58 +487,59 @@ function DashboardContent() {
           })()}
         </InfoCard>
 
-        {/* Current Activities */}
-        <InfoCard
-          title="Laufende Aktivitäten"
-          icon="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-          href="/activities"
-        >
-          {(() => {
-            if (isLoading) {
+        {nfcEnabled ? (
+          <InfoCard
+            title="Laufende Aktivitäten"
+            icon="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+            href="/activities"
+          >
+            {(() => {
+              if (isLoading) {
+                return (
+                  <div className="space-y-3">
+                    {[1, 2, 3].map((i) => (
+                      <div
+                        key={i}
+                        className="h-14 animate-pulse rounded-lg bg-gray-100"
+                      ></div>
+                    ))}
+                  </div>
+                );
+              }
+              const activities = dashboardData?.currentActivities;
+              if (!activities || activities.length === 0) {
+                return (
+                  <p className="py-8 text-center text-sm text-gray-500">
+                    Keine laufenden Aktivitäten
+                  </p>
+                );
+              }
               return (
-                <div className="space-y-3">
-                  {[1, 2, 3].map((i) => (
+                <div className="space-y-2">
+                  {activities.slice(0, 5).map((activity, idx) => (
                     <div
-                      key={i}
-                      className="h-14 animate-pulse rounded-lg bg-gray-100"
-                    ></div>
+                      key={`${activity.name}-${activity.category}-${idx}`}
+                      className="flex items-center justify-between rounded-xl bg-gray-50/50 p-3 transition-colors hover:bg-gray-100/50"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-gray-900">
+                          {activity.name}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          {activity.category} • {activity.participants}/
+                          {activity.maxCapacity} Teilnehmer
+                        </p>
+                      </div>
+                      <div
+                        className={`h-2.5 w-2.5 rounded-full ${getActivityStatusColor(activity.status)} ml-2 flex-shrink-0`}
+                      ></div>
+                    </div>
                   ))}
                 </div>
               );
-            }
-            const activities = dashboardData?.currentActivities;
-            if (!activities || activities.length === 0) {
-              return (
-                <p className="py-8 text-center text-sm text-gray-500">
-                  Keine laufenden Aktivitäten
-                </p>
-              );
-            }
-            return (
-              <div className="space-y-2">
-                {activities.slice(0, 5).map((activity, idx) => (
-                  <div
-                    key={`${activity.name}-${activity.category}-${idx}`}
-                    className="flex items-center justify-between rounded-xl bg-gray-50/50 p-3 transition-colors hover:bg-gray-100/50"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium text-gray-900">
-                        {activity.name}
-                      </p>
-                      <p className="text-xs text-gray-500">
-                        {activity.category} • {activity.participants}/
-                        {activity.maxCapacity} Teilnehmer
-                      </p>
-                    </div>
-                    <div
-                      className={`h-2.5 w-2.5 rounded-full ${getActivityStatusColor(activity.status)} ml-2 flex-shrink-0`}
-                    ></div>
-                  </div>
-                ))}
-              </div>
-            );
-          })()}
-        </InfoCard>
+            })()}
+          </InfoCard>
+        ) : null}
 
         {/* Active Groups */}
         <InfoCard

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
@@ -15,7 +15,10 @@ import {
 } from "~/lib/dashboard-helpers";
 import { useSWRAuth } from "~/lib/swr/hooks";
 import { RoleGuard } from "~/components/auth/role-guard";
-import { useNFCEnabled } from "~/components/tenant/tenant-provider";
+import {
+  useNFCEnabled,
+  usePresenceMode,
+} from "~/components/tenant/tenant-provider";
 
 import { Loading } from "~/components/ui/loading";
 
@@ -254,6 +257,8 @@ const InfoCard: React.FC<InfoCardProps> = ({
 function DashboardContent() {
   const router = useTenantRouter();
   const nfcEnabled = useNFCEnabled();
+  const presenceMode = usePresenceMode();
+  const showActivitySurfaces = nfcEnabled && presenceMode !== "binary";
   const { data: session, status } = useSession({
     required: true,
     onUnauthenticated() {
@@ -383,7 +388,7 @@ function DashboardContent() {
           loading={isLoading}
           href="/ogs-groups"
         />
-        {nfcEnabled ? (
+        {showActivitySurfaces ? (
           <StatCard
             title="Aktive Aktivitäten"
             value={dashboardData?.activeActivities ?? 0}
@@ -487,7 +492,7 @@ function DashboardContent() {
           })()}
         </InfoCard>
 
-        {nfcEnabled ? (
+        {showActivitySurfaces ? (
           <InfoCard
             title="Laufende Aktivitäten"
             icon="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"

--- a/frontend/src/app/[tenant]/(protected)/database/activities/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/activities/page.tsx
@@ -26,10 +26,19 @@ import { useDeleteConfirmation } from "~/hooks/useDeleteConfirmation";
 import { useUpdateUrlParams } from "~/hooks/useUpdateUrlParams";
 import { createLogger } from "~/lib/logger";
 import { useSWRAuth, useTenantMutate } from "~/lib/swr";
+import { NfcModeGuard } from "~/components/tenant/nfc-mode-guard";
 
 const logger = createLogger({ component: "DatabaseActivitiesPage" });
 
 export default function ActivitiesPage() {
+  return (
+    <NfcModeGuard>
+      <ActivitiesPageContent />
+    </NfcModeGuard>
+  );
+}
+
+function ActivitiesPageContent() {
   const searchParams = useSearchParams();
   const updateUrlParams = useUpdateUrlParams();
 

--- a/frontend/src/app/[tenant]/(protected)/database/devices/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/devices/page.tsx
@@ -33,6 +33,7 @@ import { useDeleteConfirmation } from "~/hooks/useDeleteConfirmation";
 import { useUpdateUrlParams } from "~/hooks/useUpdateUrlParams";
 import { createLogger } from "~/lib/logger";
 import { useSWRAuth, useTenantMutate } from "~/lib/swr";
+import { NfcModeGuard } from "~/components/tenant/nfc-mode-guard";
 
 const logger = createLogger({ component: "DatabaseDevicesPage" });
 
@@ -55,6 +56,14 @@ function parseDevicesGrouping(value: string | null): DevicesGroupingMode {
 }
 
 export default function DevicesPage() {
+  return (
+    <NfcModeGuard>
+      <DevicesPageContent />
+    </NfcModeGuard>
+  );
+}
+
+function DevicesPageContent() {
   const searchParams = useSearchParams();
   const updateUrlParams = useUpdateUrlParams();
 

--- a/frontend/src/app/[tenant]/(protected)/database/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/page.tsx
@@ -12,6 +12,7 @@ import { useIsMobile } from "~/hooks/useIsMobile";
 import { LOCATION_COLORS } from "~/lib/location-helper";
 
 import { Loading } from "~/components/ui/loading";
+import { useNFCEnabled } from "~/components/tenant/tenant-provider";
 // Icon component
 const Icon: React.FC<{ path: string; className?: string }> = ({
   path,
@@ -96,9 +97,12 @@ const baseDataSections = [
   },
 ];
 
+const NFC_ONLY_SECTION_IDS = new Set(["activities", "devices"]);
+
 function DatabaseContent() {
   const { data: session, status } = useSession({ required: true });
   const isMobile = useIsMobile();
+  const nfcEnabled = useNFCEnabled();
   const [counts, setCounts] = useState<{
     students: number;
     teachers: number;
@@ -256,6 +260,10 @@ function DatabaseContent() {
       <div className="min-h-[60vh]">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {baseDataSections.map((section) => {
+            if (!nfcEnabled && NFC_ONLY_SECTION_IDS.has(section.id)) {
+              return null;
+            }
+
             // Check permissions for this section
             const permissionKey =
               `canView${section.id.charAt(0).toUpperCase() + section.id.slice(1)}` as keyof typeof permissions;
@@ -275,7 +283,7 @@ function DatabaseContent() {
               <Link
                 key={section.id}
                 href={section.href}
-                className="group moto-content-surface moto-hover-elevated relative min-h-[44px] touch-manipulation overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04),0_0_0_1px_rgba(15,23,42,0.02)] active:shadow-[0_10px_26px_rgba(15,23,42,0.1)]"
+                className="moto-content-surface moto-hover-elevated group relative min-h-[44px] touch-manipulation overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04),0_0_0_1px_rgba(15,23,42,0.02)] active:shadow-[0_10px_26px_rgba(15,23,42,0.1)]"
               >
                 <div className="pointer-events-none absolute inset-0 rounded-2xl ring-1 ring-transparent transition-[box-shadow] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] group-hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.9)]"></div>
 

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.school-checkin.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.school-checkin.test.tsx
@@ -59,6 +59,7 @@ vi.mock("~/components/tenant/tenant-provider", () => ({
   // these tests since they don't exercise the spacer path.
   useTenantSafe: vi.fn(() => null),
   usePresenceMode: vi.fn(() => "binary"),
+  useNFCEnabled: vi.fn(() => true),
   TenantProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.room-filter.test.tsx
@@ -49,6 +49,7 @@ vi.mock("~/components/tenant/tenant-provider", () => ({
   }),
   useTenantSlugSafe: () => "t",
   usePresenceMode: () => "detailed",
+  useNFCEnabled: () => true,
   TenantProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.school-checkin.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.school-checkin.test.tsx
@@ -51,6 +51,7 @@ vi.mock("~/components/tenant/tenant-provider", () => ({
   })),
   useTenantSlugSafe: vi.fn(() => "test-tenant"),
   usePresenceMode: vi.fn(() => "binary"),
+  useNFCEnabled: vi.fn(() => true),
   TenantProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 

--- a/frontend/src/app/[tenant]/(public)/reset-password/page.test.tsx
+++ b/frontend/src/app/[tenant]/(public)/reset-password/page.test.tsx
@@ -38,6 +38,7 @@ const mockUseTenant = vi.fn();
 vi.mock("~/components/tenant/tenant-provider", () => ({
   useTenantSafe: () => mockUseTenant(),
   useTenantSlugSafe: () => "demo-school",
+  useNFCEnabled: vi.fn(() => true),
 }));
 
 vi.mock("~/lib/auth-api", () => ({

--- a/frontend/src/app/[tenant]/layout.tsx
+++ b/frontend/src/app/[tenant]/layout.tsx
@@ -19,6 +19,7 @@ interface TenantResolveResponse {
   settings: TenantSettings;
   presence_mode?: string;
   student_photos_enabled?: boolean;
+  nfc_enabled?: boolean;
 }
 
 /**
@@ -51,6 +52,7 @@ async function fetchTenantInfo(slug: string): Promise<TenantInfo | null> {
       settings: data.settings ?? {},
       presenceMode: normalizePresenceMode(data.presence_mode),
       studentPhotosEnabled: data.student_photos_enabled === true,
+      nfcEnabled: data.nfc_enabled === true,
     };
   } catch {
     return null;

--- a/frontend/src/components/auth/smart-redirect.test.tsx
+++ b/frontend/src/components/auth/smart-redirect.test.tsx
@@ -44,6 +44,7 @@ vi.mock("~/lib/redirect-utils", () => ({
 vi.mock("~/components/tenant/tenant-provider", () => ({
   usePresenceMode: vi.fn(() => "detailed"),
   useTenantSlugSafe: vi.fn(() => "test-tenant"),
+  useNFCEnabled: vi.fn(() => true),
 }));
 
 import { useSession } from "next-auth/react";

--- a/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
@@ -87,7 +87,10 @@ import { useSession } from "next-auth/react";
 import { useOptionalSupervision } from "~/lib/supervision-context";
 import { isAdmin } from "~/lib/auth-utils";
 import { useShellAuth } from "~/lib/shell-auth-context";
-import { useNFCEnabled } from "~/components/tenant/tenant-provider";
+import {
+  useNFCEnabled,
+  usePresenceMode,
+} from "~/components/tenant/tenant-provider";
 
 const mockUsePathname = vi.mocked(usePathname);
 const mockUseSearchParams = vi.mocked(useSearchParams);
@@ -96,6 +99,7 @@ const mockUseSupervision = vi.mocked(useOptionalSupervision);
 const mockIsAdmin = vi.mocked(isAdmin);
 const mockUseShellAuth = vi.mocked(useShellAuth);
 const mockUseNFCEnabled = vi.mocked(useNFCEnabled);
+const mockUsePresenceMode = vi.mocked(usePresenceMode);
 
 // Helper to create mock search params - use unknown cast for test flexibility
 function createMockSearchParams(
@@ -166,6 +170,7 @@ describe("MobileBottomNav", () => {
     });
     mockIsAdmin.mockReturnValue(false);
     mockUseNFCEnabled.mockReturnValue(true);
+    mockUsePresenceMode.mockReturnValue("detailed");
   });
 
   describe("rendering", () => {
@@ -369,6 +374,20 @@ describe("MobileBottomNav", () => {
         link.getAttribute("href"),
       );
       expect(drawerHrefs).not.toContain("/activities");
+    });
+
+    it("hides the classic activities item in binary presence mode", () => {
+      mockUseNFCEnabled.mockReturnValue(true);
+      mockUsePresenceMode.mockReturnValue("binary");
+
+      render(<MobileBottomNav />);
+
+      const hrefs = screen
+        .getAllByRole("link")
+        .map((link) => link.getAttribute("href"));
+      expect(hrefs).not.toContain("/activities");
+      expect(hrefs).toContain("/ogs-groups");
+      expect(hrefs).toContain("/active-supervisions");
     });
   });
 

--- a/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
@@ -87,6 +87,7 @@ import { useSession } from "next-auth/react";
 import { useOptionalSupervision } from "~/lib/supervision-context";
 import { isAdmin } from "~/lib/auth-utils";
 import { useShellAuth } from "~/lib/shell-auth-context";
+import { useNFCEnabled } from "~/components/tenant/tenant-provider";
 
 const mockUsePathname = vi.mocked(usePathname);
 const mockUseSearchParams = vi.mocked(useSearchParams);
@@ -94,6 +95,7 @@ const mockUseSession = vi.mocked(useSession);
 const mockUseSupervision = vi.mocked(useOptionalSupervision);
 const mockIsAdmin = vi.mocked(isAdmin);
 const mockUseShellAuth = vi.mocked(useShellAuth);
+const mockUseNFCEnabled = vi.mocked(useNFCEnabled);
 
 // Helper to create mock search params - use unknown cast for test flexibility
 function createMockSearchParams(
@@ -163,6 +165,7 @@ describe("MobileBottomNav", () => {
       refresh: vi.fn(),
     });
     mockIsAdmin.mockReturnValue(false);
+    mockUseNFCEnabled.mockReturnValue(true);
   });
 
   describe("rendering", () => {
@@ -330,6 +333,42 @@ describe("MobileBottomNav", () => {
       const hrefs = links.map((link) => link.getAttribute("href"));
       expect(hrefs).toContain("/ogs-groups");
       expect(hrefs).toContain("/active-supervisions");
+    });
+  });
+
+  describe("NFC visibility", () => {
+    beforeEach(() => {
+      mockUseNFCEnabled.mockReturnValue(false);
+    });
+
+    it("hides the classic activities item from staff main navigation", () => {
+      render(<MobileBottomNav />);
+
+      const hrefs = screen
+        .getAllByRole("link")
+        .map((link) => link.getAttribute("href"));
+      expect(hrefs).not.toContain("/activities");
+      expect(hrefs).toContain("/ogs-groups");
+      expect(hrefs).toContain("/active-supervisions");
+    });
+
+    it("hides the classic activities item from the overflow drawer", () => {
+      render(<MobileBottomNav />);
+
+      const navButtons = screen.getAllByRole("button");
+      const moreButton = navButtons.find(
+        (btn) => !btn.hasAttribute("data-testid"),
+      );
+      expect(moreButton).toBeDefined();
+      fireEvent.click(moreButton!);
+
+      const drawerLinks = screen
+        .getByTestId("drawer-content")
+        .querySelectorAll("a");
+      const drawerHrefs = Array.from(drawerLinks).map((link) =>
+        link.getAttribute("href"),
+      );
+      expect(drawerHrefs).not.toContain("/activities");
     });
   });
 

--- a/frontend/src/components/dashboard/mobile-bottom-nav.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.tsx
@@ -18,6 +18,7 @@ import { useShellAuth } from "~/lib/shell-auth-context";
 import { hasRole, isCaregiver } from "~/lib/auth-utils";
 import { navigationIcons } from "~/lib/navigation-icons";
 import { operatorPath } from "~/lib/operator-url";
+import { useNFCEnabled } from "~/components/tenant/tenant-provider";
 import {
   SETTINGS_SCHEMA_SWR_KEY,
   fetchSettingsSchema,
@@ -331,6 +332,8 @@ const additionalNavItems: AdditionalNavItem[] = [
   },
 ];
 
+const NFC_ONLY_HREFS = new Set<string>(["/activities"]);
+
 interface MobileBottomNavProps {
   readonly className?: string;
 }
@@ -455,6 +458,7 @@ export function MobileBottomNav({ className = "" }: MobileBottomNavProps) {
   // Pre-compute permission flags to reduce complexity in filter
   const userIsAdmin = hasRole(session, "admin");
   const userIsCaregiver = isCaregiver(session);
+  const nfcEnabled = useNFCEnabled();
   const { data: settingsSchema } = useSWR(
     userIsAdmin && mode !== "operator" && mode !== "parent"
       ? SETTINGS_SCHEMA_SWR_KEY
@@ -474,11 +478,16 @@ export function MobileBottomNav({ className = "" }: MobileBottomNavProps) {
   const hasRoomSupervision = !isLoadingSupervision && isSupervising;
 
   // Filter additional navigation items based on permissions
+  const filteredMainItemsByMode = filteredMainItems.filter(
+    (item) => nfcEnabled || !NFC_ONLY_HREFS.has(item.href),
+  );
+
   const filteredAdditionalItems = additionalNavItems.filter((item) => {
     // Hide items marked as hideForAdmin for admin users
     if (item.hideForAdmin && userIsAdmin && !userIsCaregiver) {
       return false;
     }
+    if (!nfcEnabled && NFC_ONLY_HREFS.has(item.href)) return false;
     if (item.alwaysShow) return true;
     if (item.href === "/timetables" && !timetableEnabled) {
       return false;
@@ -496,7 +505,7 @@ export function MobileBottomNav({ className = "" }: MobileBottomNavProps) {
   // Static navigation - 4 main items + overflow drawer. Operator mode uses a
   // dedicated item list (the 4 sibling Verwaltung pages + Einstellungen) since
   // the bottom nav has only one Verwaltung slot.
-  const displayMainItems: NavItem[] = filteredMainItems;
+  const displayMainItems: NavItem[] = filteredMainItemsByMode;
   const showOverflowMenu = true;
   // Avoid duplicates between main and additional
   const mainHrefs = new Set(

--- a/frontend/src/components/dashboard/mobile-bottom-nav.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.tsx
@@ -18,7 +18,10 @@ import { useShellAuth } from "~/lib/shell-auth-context";
 import { hasRole, isCaregiver } from "~/lib/auth-utils";
 import { navigationIcons } from "~/lib/navigation-icons";
 import { operatorPath } from "~/lib/operator-url";
-import { useNFCEnabled } from "~/components/tenant/tenant-provider";
+import {
+  useNFCEnabled,
+  usePresenceMode,
+} from "~/components/tenant/tenant-provider";
 import {
   SETTINGS_SCHEMA_SWR_KEY,
   fetchSettingsSchema,
@@ -459,6 +462,8 @@ export function MobileBottomNav({ className = "" }: MobileBottomNavProps) {
   const userIsAdmin = hasRole(session, "admin");
   const userIsCaregiver = isCaregiver(session);
   const nfcEnabled = useNFCEnabled();
+  const presenceMode = usePresenceMode();
+  const showActivityNav = nfcEnabled && presenceMode !== "binary";
   const { data: settingsSchema } = useSWR(
     userIsAdmin && mode !== "operator" && mode !== "parent"
       ? SETTINGS_SCHEMA_SWR_KEY
@@ -479,7 +484,7 @@ export function MobileBottomNav({ className = "" }: MobileBottomNavProps) {
 
   // Filter additional navigation items based on permissions
   const filteredMainItemsByMode = filteredMainItems.filter(
-    (item) => nfcEnabled || !NFC_ONLY_HREFS.has(item.href),
+    (item) => showActivityNav || !NFC_ONLY_HREFS.has(item.href),
   );
 
   const filteredAdditionalItems = additionalNavItems.filter((item) => {
@@ -487,7 +492,7 @@ export function MobileBottomNav({ className = "" }: MobileBottomNavProps) {
     if (item.hideForAdmin && userIsAdmin && !userIsCaregiver) {
       return false;
     }
-    if (!nfcEnabled && NFC_ONLY_HREFS.has(item.href)) return false;
+    if (!showActivityNav && NFC_ONLY_HREFS.has(item.href)) return false;
     if (item.alwaysShow) return true;
     if (item.href === "/timetables" && !timetableEnabled) {
       return false;

--- a/frontend/src/components/dashboard/sidebar.test.tsx
+++ b/frontend/src/components/dashboard/sidebar.test.tsx
@@ -60,7 +60,10 @@ import { useSession } from "next-auth/react";
 import { useOptionalSupervision } from "~/lib/supervision-context";
 import { isAdmin } from "~/lib/auth-utils";
 import { useShellAuth } from "~/lib/shell-auth-context";
-import { usePresenceMode } from "~/components/tenant/tenant-provider";
+import {
+  useNFCEnabled,
+  usePresenceMode,
+} from "~/components/tenant/tenant-provider";
 
 const mockUsePathname = vi.mocked(usePathname);
 const mockUseSearchParams = vi.mocked(useSearchParams);
@@ -69,6 +72,7 @@ const mockUseSupervision = vi.mocked(useOptionalSupervision);
 const mockIsAdmin = vi.mocked(isAdmin);
 const mockUseShellAuth = vi.mocked(useShellAuth);
 const mockUsePresenceMode = vi.mocked(usePresenceMode);
+const mockUseNFCEnabled = vi.mocked(useNFCEnabled);
 
 // Helper to create mock search params
 function createMockSearchParams(
@@ -1521,6 +1525,35 @@ describe("Sidebar", () => {
       render(<Sidebar />);
       expect(screen.getByText("Kindersuche")).toBeInTheDocument();
       expect(screen.getByText("Mitarbeiter")).toBeInTheDocument();
+    });
+  });
+
+  describe("NFC mode", () => {
+    beforeEach(() => {
+      mockUseNFCEnabled.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+      mockUseNFCEnabled.mockReturnValue(true);
+    });
+
+    it("hides the classic Aktivitäten nav item when NFC is disabled", () => {
+      render(<Sidebar />);
+
+      expect(screen.queryByText("Aktivitäten")).not.toBeInTheDocument();
+    });
+
+    it("hides NFC-only database sub-pages when NFC is disabled", () => {
+      mockIsAdmin.mockReturnValue(true);
+      mockUseSession.mockReturnValue(createMockSession(true));
+      mockUsePathname.mockReturnValue("/database");
+
+      render(<Sidebar />);
+
+      expect(screen.getByText("Datenverwaltung")).toBeInTheDocument();
+      expect(screen.getByText("Kinder")).toBeInTheDocument();
+      expect(screen.queryByText("Geräte")).not.toBeInTheDocument();
+      expect(screen.queryByText("Aktivitäten")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/dashboard/sidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar.tsx
@@ -7,6 +7,7 @@ import useSWR from "swr";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useTenantRouter } from "~/lib/tenant-router";
 import {
+  useNFCEnabled,
   usePresenceMode,
   useTenantSlugSafe,
 } from "~/components/tenant/tenant-provider";
@@ -273,6 +274,12 @@ const DATABASE_SUB_PAGES = [
   { href: "/database/permissions", label: "Berechtigungen" },
 ];
 
+const NFC_ONLY_HREFS = new Set<string>([
+  "/activities",
+  "/database/activities",
+  "/database/devices",
+]);
+
 // Static sub-pages for Anmeldungen accordion (admin only).
 const ENROLLMENTS_SUB_PAGES = [
   { href: "/admin/enrollments", label: "Überblick" },
@@ -376,6 +383,7 @@ function SidebarContent({ className = "" }: SidebarProps) {
   const userIsCaregiver = isCaregiver(session);
   const presenceMode = usePresenceMode();
   const isBinaryMode = presenceMode === "binary";
+  const nfcEnabled = useNFCEnabled();
   const { counts: groupAttendanceCounts } = useGroupAttendanceCounts();
   const canShowGroupAttendanceCounts = pathname.startsWith("/ogs-groups");
   const { data: settingsSchema } = useSWR(
@@ -399,6 +407,14 @@ function SidebarContent({ className = "" }: SidebarProps) {
     return count ? `${count.present}/${count.total}` : undefined;
   };
 
+  const databaseSubPages = useMemo(
+    () =>
+      DATABASE_SUB_PAGES.filter(
+        (page) => nfcEnabled || !NFC_ONLY_HREFS.has(page.href),
+      ),
+    [nfcEnabled],
+  );
+
   // Nav items hidden in binary-mode tenants. Rooms and Activities are room/visit
   // concepts with no operational meaning when the tenant only tracks
   // in-school/out-of-school on active.attendance. The Aktuelle-Aufsicht
@@ -408,6 +424,7 @@ function SidebarContent({ className = "" }: SidebarProps) {
   // Filter flat navigation items based on permissions
   const filteredNavItems = NAV_ITEMS.filter((item) => {
     if (item.hideForAdmin && userIsAdmin && !userIsCaregiver) return false;
+    if (!nfcEnabled && NFC_ONLY_HREFS.has(item.href)) return false;
     if (isBinaryMode && BINARY_HIDDEN_HREFS.has(item.href)) return false;
     if (item.href === "/timetables" && !timetableEnabled) {
       return false;
@@ -646,11 +663,11 @@ function SidebarContent({ className = "" }: SidebarProps) {
   useEffect(() => {
     if (
       pathname.startsWith("/database/") &&
-      DATABASE_SUB_PAGES.some((p) => pathname === p.href)
+      databaseSubPages.some((p) => pathname === p.href)
     ) {
       localStorage.setItem("sidebar-last-database", pathname);
     }
-  }, [pathname]);
+  }, [pathname, databaseSubPages]);
 
   // Toggle accordion AND navigate to the correct URL (with last-selected sub-item).
   // Reads localStorage at click-time so the page loads with the right param immediately.
@@ -1026,12 +1043,12 @@ function SidebarContent({ className = "" }: SidebarProps) {
               onToggle={handleDatabaseToggle}
               isActive={isAccordionSectionActive(
                 "/database",
-                DATABASE_SUB_PAGES.some((p) => pathname === p.href),
+                databaseSubPages.some((p) => pathname === p.href),
               )}
               isIconActive={pathname.startsWith("/database")}
-              hasChildren={DATABASE_SUB_PAGES.length > 0}
+              hasChildren={databaseSubPages.length > 0}
             >
-              {DATABASE_SUB_PAGES.map((page) => (
+              {databaseSubPages.map((page) => (
                 <SidebarSubItem
                   key={page.href}
                   href={page.href}

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -29,6 +29,7 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("~/components/tenant/tenant-provider", () => ({
   useTenantSlugSafe: () => "demo",
+  useNFCEnabled: vi.fn(() => true),
 }));
 
 vi.mock("~/contexts/ToastContext", () => ({

--- a/frontend/src/components/rooms/room-detail-content.test.tsx
+++ b/frontend/src/components/rooms/room-detail-content.test.tsx
@@ -22,6 +22,7 @@ vi.mock("~/components/tenant/tenant-provider", () => ({
   // null tenant keeps the photo feature off in this test (matching the
   // pre-feature shape the skeleton assertions were written against).
   useTenantSafe: () => ({ tenantSlug: "test-tenant", tenant: null }),
+  useNFCEnabled: vi.fn(() => true),
 }));
 
 // The global test setup mocks `swr` to always return isLoading=true. To

--- a/frontend/src/components/tenant/binary-mode-guard.test.tsx
+++ b/frontend/src/components/tenant/binary-mode-guard.test.tsx
@@ -30,6 +30,7 @@ function makeTenant(
     settings: {},
     presenceMode,
     studentPhotosEnabled: false,
+    nfcEnabled: false,
   };
 }
 

--- a/frontend/src/components/tenant/nfc-mode-guard.test.tsx
+++ b/frontend/src/components/tenant/nfc-mode-guard.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+// Opt out of the global tenant-provider mock so the guard sees the real
+// TenantContext wired up by its wrapping TenantProvider.
+vi.unmock("~/components/tenant/tenant-provider");
+
+import { TenantProvider } from "./tenant-provider";
+import { NfcModeGuard } from "./nfc-mode-guard";
+import type { TenantInfo } from "~/lib/tenant-api";
+
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+}));
+
+function makeTenant(nfcEnabled: boolean): TenantInfo {
+  return {
+    tenantId: 1,
+    slug: "demo",
+    name: "Demo",
+    subdomain: "demo",
+    organizationId: 10,
+    organizationName: "Org",
+    settings: {},
+    presenceMode: "detailed",
+    studentPhotosEnabled: false,
+    nfcEnabled,
+  };
+}
+
+describe("NfcModeGuard", () => {
+  it("renders children when NFC is enabled", () => {
+    render(
+      <TenantProvider tenantSlug="demo" tenant={makeTenant(true)}>
+        <NfcModeGuard>
+          <div>nfc-content</div>
+        </NfcModeGuard>
+      </TenantProvider>,
+    );
+    expect(screen.getByText("nfc-content")).toBeInTheDocument();
+  });
+
+  it("triggers notFound() when NFC is disabled", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() =>
+      render(
+        <TenantProvider tenantSlug="demo" tenant={makeTenant(false)}>
+          <NfcModeGuard>
+            <div>nfc-content</div>
+          </NfcModeGuard>
+        </TenantProvider>,
+      ),
+    ).toThrow("NEXT_NOT_FOUND");
+
+    errorSpy.mockRestore();
+  });
+});

--- a/frontend/src/components/tenant/nfc-mode-guard.tsx
+++ b/frontend/src/components/tenant/nfc-mode-guard.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { notFound } from "next/navigation";
+import { useNFCEnabled } from "~/components/tenant/tenant-provider";
+
+/**
+ * NfcModeGuard — triggers Next.js 404 when the tenant does not use NFC.
+ *
+ * Use at route boundaries for classic NFC-only surfaces such as device
+ * management and the legacy activities catalog. Navigation should already
+ * hide those entries; this guards direct URL entry as well.
+ */
+export function NfcModeGuard({ children }: { children: React.ReactNode }) {
+  const nfcEnabled = useNFCEnabled();
+  if (!nfcEnabled) {
+    notFound();
+  }
+  return <>{children}</>;
+}

--- a/frontend/src/components/tenant/tenant-guard.test.tsx
+++ b/frontend/src/components/tenant/tenant-guard.test.tsx
@@ -36,6 +36,7 @@ vi.mock("next-auth/react", () => ({
 
 vi.mock("~/components/tenant/tenant-provider", () => ({
   useTenant: mockUseTenant,
+  useNFCEnabled: vi.fn(() => true),
 }));
 
 vi.mock("~/lib/tenant-api", () => ({

--- a/frontend/src/components/tenant/tenant-provider.test.tsx
+++ b/frontend/src/components/tenant/tenant-provider.test.tsx
@@ -30,6 +30,7 @@ vi.mock("~/lib/tenant-api", async (importOriginal) => {
 
 import {
   TenantProvider,
+  useNFCEnabled,
   usePresenceMode,
   useTenant,
   useTenantSafe,
@@ -50,6 +51,7 @@ const mockTenant: TenantInfo = {
   settings: {},
   presenceMode: "detailed",
   studentPhotosEnabled: false,
+  nfcEnabled: false,
 };
 
 // ============================================================================
@@ -431,5 +433,34 @@ describe("usePresenceMode", () => {
     );
     const { result } = renderHook(() => usePresenceMode(), { wrapper });
     expect(result.current).toBe("detailed");
+  });
+});
+
+describe("useNFCEnabled", () => {
+  const nfcTenant: TenantInfo = { ...mockTenant, nfcEnabled: true };
+
+  it("returns true when NFC is enabled for the tenant", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TenantProvider tenantSlug="demo" tenant={nfcTenant}>
+        {children}
+      </TenantProvider>
+    );
+    const { result } = renderHook(() => useNFCEnabled(), { wrapper });
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false outside any TenantProvider", () => {
+    const { result } = renderHook(() => useNFCEnabled());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false when tenant hasn't resolved yet", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TenantProvider tenantSlug="demo" tenant={null}>
+        {children}
+      </TenantProvider>
+    );
+    const { result } = renderHook(() => useNFCEnabled(), { wrapper });
+    expect(result.current).toBe(false);
   });
 });

--- a/frontend/src/components/tenant/tenant-provider.tsx
+++ b/frontend/src/components/tenant/tenant-provider.tsx
@@ -185,3 +185,15 @@ export function usePresenceMode(): PresenceMode {
   const ctx = useContext(TenantContext);
   return ctx?.tenant?.presenceMode ?? "detailed";
 }
+
+/**
+ * Returns whether the current tenant uses NFC attendance devices.
+ *
+ * Defaults to false when tenant metadata is unavailable. That matches the
+ * registry default and keeps NFC-only navigation hidden until the tenant
+ * explicitly opts into NFC.
+ */
+export function useNFCEnabled(): boolean {
+  const ctx = useContext(TenantContext);
+  return ctx?.tenant?.nfcEnabled === true;
+}

--- a/frontend/src/components/tenant/tenant-switcher.test.tsx
+++ b/frontend/src/components/tenant/tenant-switcher.test.tsx
@@ -42,6 +42,7 @@ vi.mock("~/lib/swr", () => ({
 
 vi.mock("~/components/tenant/tenant-provider", () => ({
   useTenantSlugSafe: mockUseTenantSlugSafe,
+  useNFCEnabled: vi.fn(() => true),
 }));
 
 vi.mock("~/env", () => ({

--- a/frontend/src/components/ui/student-presence-badge.test.tsx
+++ b/frontend/src/components/ui/student-presence-badge.test.tsx
@@ -22,6 +22,7 @@ function makeTenant(
     settings: {},
     presenceMode,
     studentPhotosEnabled: false,
+    nfcEnabled: false,
   };
 }
 

--- a/frontend/src/lib/settings-api.test.ts
+++ b/frontend/src/lib/settings-api.test.ts
@@ -327,6 +327,27 @@ describe("applyOptimisticSchemaUpdate", () => {
     expect(next.tabs[0]!.categories[0]!.items[1]!.visible).toBe(false);
   });
 
+  it("hides nested children when their direct parent is hidden", () => {
+    const schema = makeSchema([
+      makeItem("root", { type: "boolean", value: false }),
+      makeItem("child", {
+        type: "boolean",
+        value: true,
+        depends_on: { key: "root", condition: "eq", value: true },
+      }),
+      makeItem("grandchild", {
+        type: "number",
+        value: 15,
+        depends_on: { key: "child", condition: "eq", value: true },
+      }),
+    ]);
+
+    const next = applyOptimisticSchemaUpdate(schema, "root", false);
+
+    expect(next.tabs[0]!.categories[0]!.items[1]!.visible).toBe(false);
+    expect(next.tabs[0]!.categories[0]!.items[2]!.visible).toBe(false);
+  });
+
   it("supports the `neq` depends_on condition", () => {
     const schema = makeSchema([
       makeItem("parent", { type: "boolean", value: true }),

--- a/frontend/src/lib/settings-api.ts
+++ b/frontend/src/lib/settings-api.ts
@@ -73,13 +73,56 @@ export function applyOptimisticSchemaUpdate(
   value: unknown,
 ): SettingsSchema {
   const valueMap = new Map<string, unknown>();
+  const itemMap = new Map<string, ResolvedSetting>();
   for (const tab of schema.tabs) {
     for (const cat of tab.categories) {
       for (const item of cat.items) {
         valueMap.set(item.key, item.key === key ? value : item.value);
+        itemMap.set(item.key, item);
       }
     }
   }
+
+  const visibilityMemo = new Map<string, boolean>();
+  const evaluateVisibility = (
+    item: ResolvedSetting,
+    visiting = new Set<string>(),
+  ): boolean => {
+    const cached = visibilityMemo.get(item.key);
+    if (cached !== undefined) return cached;
+    if (!item.depends_on) {
+      visibilityMemo.set(item.key, true);
+      return true;
+    }
+    if (visiting.has(item.key)) {
+      visibilityMemo.set(item.key, false);
+      return false;
+    }
+    visiting.add(item.key);
+    const parent = itemMap.get(item.depends_on.key);
+    if (!parent || !evaluateVisibility(parent, visiting)) {
+      visibilityMemo.set(item.key, false);
+      visiting.delete(item.key);
+      return false;
+    }
+    const parentVal = valueMap.get(item.depends_on.key);
+    const cond = item.depends_on.condition;
+    const expected = item.depends_on.value;
+    let visible = true;
+    if (cond === "eq") {
+      visible = JSON.stringify(parentVal) === JSON.stringify(expected);
+    } else if (cond === "neq") {
+      visible = JSON.stringify(parentVal) !== JSON.stringify(expected);
+    } else if (cond === "not_empty") {
+      visible = parentVal != null && parentVal !== "";
+    } else {
+      visible = false;
+    }
+    visibilityMemo.set(item.key, visible);
+    visiting.delete(item.key);
+    return visible;
+  };
+
   return {
     ...schema,
     tabs: schema.tabs.map((tab) => ({
@@ -92,20 +135,7 @@ export function applyOptimisticSchemaUpdate(
             item.key === key
               ? { ...item, value: optimisticValue, is_default: false }
               : item;
-          if (updated.depends_on) {
-            const parentVal = valueMap.get(updated.depends_on.key);
-            const cond = updated.depends_on.condition;
-            const expected = updated.depends_on.value;
-            let visible = true;
-            if (cond === "eq")
-              visible = JSON.stringify(parentVal) === JSON.stringify(expected);
-            if (cond === "neq")
-              visible = JSON.stringify(parentVal) !== JSON.stringify(expected);
-            if (cond === "not_empty")
-              visible = parentVal != null && parentVal !== "";
-            return { ...updated, visible };
-          }
-          return updated;
+          return { ...updated, visible: evaluateVisibility(updated) };
         }),
       })),
     })),

--- a/frontend/src/lib/settings-keys.ts
+++ b/frontend/src/lib/settings-keys.ts
@@ -12,4 +12,7 @@ export const TENANT_RESOLVE_AFFECTING_KEYS: ReadonlySet<string> = new Set([
   // operator flipping it leaves reloads/new tabs on the old mode for
   // up to the layout cache TTL (300s).
   "operations.presence_mode",
+  // nfc_enabled is also served through /auth/tenant/resolve so every staff
+  // user can hide NFC-only navigation without config:read.
+  "attendance.nfc_enabled",
 ]);

--- a/frontend/src/lib/swr/hooks.test.ts
+++ b/frontend/src/lib/swr/hooks.test.ts
@@ -30,6 +30,7 @@ const { mockUseTenantSlugSafe } = vi.hoisted(() => ({
 // Mock tenant provider — default returns null (no tenant context).
 vi.mock("~/components/tenant/tenant-provider", () => ({
   useTenantSlugSafe: mockUseTenantSlugSafe,
+  useNFCEnabled: vi.fn(() => true),
 }));
 
 // Import mocked modules

--- a/frontend/src/lib/tenant-api.test.ts
+++ b/frontend/src/lib/tenant-api.test.ts
@@ -135,6 +135,7 @@ describe("tenant-api", () => {
         // — matches backend's own safe fallback.
         presenceMode: "detailed",
         studentPhotosEnabled: false,
+        nfcEnabled: false,
       });
     });
 
@@ -178,6 +179,30 @@ describe("tenant-api", () => {
       );
       const result = await resolveTenant("binary-school");
       expect(result?.presenceMode).toBe("binary");
+    });
+
+    it("passes through nfcEnabled=true when the backend advertises it", async () => {
+      const backendData = {
+        status: "success",
+        data: {
+          tenant_id: 2,
+          slug: "nfc-school",
+          name: "NFC School",
+          subdomain: "nfc",
+          organization_id: 11,
+          organization_name: "Org B",
+          settings: {},
+          nfc_enabled: true,
+        },
+      };
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify(backendData), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      const result = await resolveTenant("nfc-school");
+      expect(result?.nfcEnabled).toBe(true);
     });
 
     it("maps hidden tenants from resolve response", async () => {
@@ -306,6 +331,7 @@ describe("tenant-api", () => {
         // call resolveTenant() once the user picks a tenant.
         presenceMode: "detailed",
         studentPhotosEnabled: false,
+        nfcEnabled: false,
       });
     });
 
@@ -425,6 +451,7 @@ describe("tenant-api", () => {
         // when the new tenant's layout mounts and calls resolveTenant.
         presenceMode: "detailed",
         studentPhotosEnabled: false,
+        nfcEnabled: false,
       });
     });
 

--- a/frontend/src/lib/tenant-api.ts
+++ b/frontend/src/lib/tenant-api.ts
@@ -48,6 +48,12 @@ export interface TenantInfo {
    * carry config:read but still need to know whether to render avatars.
    */
   studentPhotosEnabled: boolean;
+  /**
+   * Whether this tenant uses NFC devices for attendance/location capture.
+   * Exposed through tenant resolve so non-admin staff can hide NFC-only
+   * navigation without needing config:read.
+   */
+  nfcEnabled: boolean;
 }
 
 interface TenantResolveResponse {
@@ -61,6 +67,7 @@ interface TenantResolveResponse {
   settings: TenantSettings;
   presence_mode?: string;
   student_photos_enabled?: boolean;
+  nfc_enabled?: boolean;
 }
 
 /**
@@ -102,6 +109,7 @@ export async function resolveTenant(slug: string): Promise<TenantInfo | null> {
       settings: data.settings ?? {},
       presenceMode: normalizePresenceMode(data.presence_mode),
       studentPhotosEnabled: data.student_photos_enabled === true,
+      nfcEnabled: data.nfc_enabled === true,
     };
   } catch {
     return null;
@@ -166,6 +174,7 @@ export async function listAllTenants(
           presenceMode: "detailed",
           // Same story for the photo flag — re-resolved on tenant landing.
           studentPhotosEnabled: false,
+          nfcEnabled: false,
         })),
         status: "ok",
       };
@@ -220,6 +229,7 @@ export async function listAvailableTenants(): Promise<TenantInfo[]> {
     // after the switch when the new tenant's layout mounts and calls resolveTenant.
     presenceMode: "detailed",
     studentPhotosEnabled: false,
+    nfcEnabled: false,
   }));
 }
 

--- a/frontend/src/lib/tenant-router.test.ts
+++ b/frontend/src/lib/tenant-router.test.ts
@@ -27,6 +27,7 @@ const {
 
 vi.mock("~/components/tenant/tenant-provider", () => ({
   useTenantSlugSafe: mockUseTenantSlugSafe,
+  useNFCEnabled: vi.fn(() => true),
 }));
 
 vi.mock("next/navigation", () => ({

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -100,6 +100,10 @@ vi.mock("~/components/tenant/tenant-provider", () => ({
   // LocationBadge / PresenceBadge render the richer detailed variant in tests
   // unless a specific test overrides the mock.
   usePresenceMode: vi.fn(() => "detailed"),
+  // Most existing page tests exercise the NFC-capable surfaces themselves
+  // (activities/devices). Default to true so those tests keep rendering the
+  // page unless they explicitly cover the NFC-off branch.
+  useNFCEnabled: vi.fn(() => true),
   TenantProvider: ({
     children,
   }: {


### PR DESCRIPTION
## Summary

This PR adds the first implementation slice for the Settings IA simplification around attendance setup. Instead of introducing a single `standard | nfc` master enum, it models the product capability as explicit Web/NFC flags with safe defaults: web is enabled by default, NFC is disabled by default and provisioned by operators when a school actually uses NFC hardware.

It also introduces the two higher-level operations settings that describe the OGS operating model:

- `operations.group_mode = fixed_groups | open_care`
- `operations.care_concept = fixed_schedule | open_rooms`

The NFC flag is now used as a central visibility input so non-NFC tenants no longer see NFC-only product surfaces such as device management, PIN configuration, kiosk checkout controls, checkout time settings, and the legacy activities catalog.

Closes #1478
Refs #1479
Refs #1480
Refs #1539

#1478 is intentionally closed by this PR, even though the final implementation does not use the originally suggested `operations.attendance_input_mode = standard | nfc` enum. The product decision changed to explicit Web/NFC capability flags because web remains the default flow, while NFC is activated during tenant setup/provisioning by operators when the school uses NFC hardware. This avoids presenting NFC as a normal tenant-admin self-service switch while still keeping the visibility rules simple and central.

Remaining issue references:

- #1479 is partially addressed by reducing NFC-related settings and navigation noise, but the full settings IA regrouping/advanced-section work is still larger.
- #1480 now has the registry-level group mode setting, but the issue also requires deeper permission/write-scope behavior and group-related UI cleanup.

## How It Works Now

### Attendance setup settings

The settings registry now contains these setup-level decisions under the operations settings area:

- `attendance.web_enabled`
  - Boolean
  - Default: `true`
  - Operator-only/provisioning setting
  - Meaning: staff can use the web app for attendance capture.
- `attendance.nfc_enabled`
  - Boolean
  - Default: `false`
  - Operator-only/provisioning setting
  - Meaning: the tenant uses NFC cards/wristbands/devices for attendance and location capture.
- `operations.group_mode`
  - Select: `fixed_groups` or `open_care`
  - Default: `fixed_groups`
  - Meaning: captures whether the OGS works with fixed groups or open care.
- `operations.care_concept`
  - Select: `fixed_schedule` or `open_rooms`
  - Default: `fixed_schedule`
  - Meaning: captures whether the OGS follows a fixed operating plan or an open room concept.

Web is the default product flow and is not disabled by enabling NFC. For NFC schools, operators enable `attendance.nfc_enabled` during setup, like the Burbach-style hardware onboarding flow. Tenant admins then see only the surfaces relevant to the capabilities provisioned for their school.

### NFC visibility rules

`attendance.nfc_enabled` is now exposed via `/auth/tenant/resolve` as `nfc_enabled`. The tenant shell maps that to `TenantInfo.nfcEnabled`, so all staff-facing navigation can react without requiring every user to have `config:read`.

When NFC is disabled:

- the classic `Aktivitäten` nav item is hidden in the desktop sidebar and mobile bottom navigation
- `Aktivitäten` and `Geräte` are hidden from the Datenverwaltung hub
- direct route access is guarded for:
  - `/activities`
  - `/activities/[id]`
  - `/database/activities`
  - `/database/devices`
- the settings registry hides NFC-only device/PIN/kiosk checkout settings through `DependsOn: attendance.nfc_enabled == true`
- checkout time settings are also hidden because they only affect device checkout behavior
- tenant resolve cache invalidation includes `attendance.nfc_enabled`, so saving that setting refreshes the layout metadata and navigation state

When NFC is enabled:

- the legacy activities catalog remains visible
- device management remains visible
- device PIN and kiosk checkout settings are available
- checkout time settings are available
- existing NFC/PyrePortal-facing flows continue to behave as before

### Settings dependencies

These settings now depend directly on `attendance.nfc_enabled == true`:

- `security.ogs_device_pin`
- `checkout.raumwechsel_enabled`
- `checkout.schulhof_enabled`
- `checkout.wc_enabled`
- `operations.student_daily_checkout_time`
- `operations.per_student_checkout_enabled`

`operations.per_student_checkout_delta_minutes` still depends on `operations.per_student_checkout_enabled == true`. The schema builder and frontend optimistic update helper now evaluate dependencies recursively, so this child is also hidden when its parent is hidden by NFC.

This centralizes the first set of visibility rules in the settings registry instead of spreading one-off UI checks through the settings page.

## Spontaneous Web Activities and Timetable Flow

The spontaneous activity UX stays intentionally simple: one input line where staff can search existing names or type a new name.

The behavior now is:

- The web UI still uses the existing search/input with `datalist` suggestions.
- If the typed name exactly matches an existing activity, the frontend sends the existing `activity_group_id` as before.
- If the frontend sends no `activity_group_id`, the backend now resolves one automatically by name.
- The backend first looks for a non-archived `activities.groups` row with the same normalized name.
- If one exists, the spontaneous timetable instance is linked to that activity.
- If none exists, the backend creates a new classic activity in the background and links the instance to it.
- New background-created activities use the auto-created category `Spontan` and `type = activity`.
- The created `schedule.activity_instances` row still has `is_spontaneous = true`, but it now also has an `activity_group_id`.

This means free spontaneous names become reusable names: after the first start, the activity exists in `activities.groups` and can be found by the same search/dropdown flow later.

The create path uses advisory locks per tenant/name and per tenant/category so concurrent starts do not create duplicate spontaneous activities or duplicate `Spontan` categories.

## PyrePortal and `/api/iot/config`

This PR does not change IoT endpoint contracts. For a web-only tenant (`attendance.nfc_enabled = false`), PyrePortal simply is not part of the operational flow. Existing PyrePortal behavior continues to apply for tenants that actually use NFC devices.

The relevant product distinction remains:

- Web-only tenant: no device/PyrePortal setup surfaces are shown.
- NFC tenant: device/PyrePortal surfaces remain available after operator provisioning.
- Detailed vs binary presence behavior remains governed by the existing `operations.presence_mode` contract.

## User Impact

For a new or non-NFC OGS, the default experience is quieter:

- Web attendance is available by default.
- NFC is disabled by default.
- NFC device setup is not shown unless NFC has been provisioned by operators.
- Staff do not see the legacy activities catalog in the main navigation unless NFC is enabled.
- Device checkout and checkout-time settings are hidden unless NFC is enabled.
- Staff can still start spontaneous activities through the web timetable flow; free names are persisted as reusable activities in the background.

For an NFC tenant, operator provisioning of the NFC flag restores the device/PIN/kiosk/checkout-time/activities surfaces without disabling the web flow.

## Implementation Notes

- Backend setting keys and option constants live in `backend/models/config/keys.go`.
- Registry defaults are added in `backend/services/config/defaults/operations.go`.
- Web/NFC capability flags are operator-only (`config:manage` + operator access policy), while group mode and care concept stay tenant-admin editable setup decisions.
- NFC-only settings dependencies are added in `backend/services/config/defaults/devices.go`, `backend/services/config/defaults/security.go`, and `backend/services/config/defaults/operations.go`.
- Tenant resolve now includes `nfc_enabled` in `backend/api/auth/api.go`.
- Frontend tenant metadata now includes `nfcEnabled` in `frontend/src/lib/tenant-api.ts` and `frontend/src/components/tenant/tenant-provider.tsx`.
- A new `NfcModeGuard` protects direct access to NFC-only pages.
- Sidebar, mobile bottom nav, and the Datenverwaltung hub filter NFC-only entries based on `useNFCEnabled()`.
- Settings dependency visibility now cascades through nested dependencies in backend schema generation and frontend optimistic updates.
- `POST /api/timetable/operations/spontaneous/start` now guarantees an `activity_group_id` by reusing or creating a classic activity by name.
- `activities.GroupRepository` now supports `FindByName` for normalized, non-archived name lookup.

## Validation

Local checks run:

- `cd backend && go test ./services/config/defaults ./models/config`
- `cd backend && go test ./services/config -run 'TestGetSchema|TestOperator|TestAccess|Test.*Schema'`
- `cd backend && go test ./services/config -run 'TestGetSchema_DependsOn_(HidesChild|ShowsChild|HidesGrandchildWhenParentHidden|NeqCondition)'`
- `cd backend && go test ./api/timetable -run 'TestOperationsCreateAndStartSpontaneous(ReusesActivityByName|CreatesActivityForNewName|$)' -v`
- `cd backend && go test ./services/schedule ./services/activities ./services/import -run '^$'`
- `cd backend && go test ./database/repositories/activities -run '^$'`
- `cd backend && go test ./models/activities`
- `cd backend && go test ./test/ -run TestHermeticTestPatterns -v`
- `cd frontend && pnpm exec vitest run src/lib/settings-api.test.ts src/lib/tenant-api.test.ts src/components/tenant/nfc-mode-guard.test.tsx src/components/tenant/tenant-provider.test.tsx src/components/dashboard/sidebar.test.tsx`
- `cd frontend && pnpm run check`
- `cd frontend && pnpm exec vitest run` (full suite)

Pre-push hooks also passed earlier on this PR:

- `git-secrets`
- `go-vet`
- `go-deadcode`
- `golangci-lint`
- `frontend-knip`
- `frontend-check`

CI on PR #1520 is green after the operator-only delta.

Not run successfully in this worktree:

- `cd backend && go test ./api/auth` currently requires a configured test database (`TEST_DB_DSN` / `.env`). The package fails before running those DB-backed tests in this fresh worktree, with the existing “Test database not configured” message.
- Broad DB-backed package runs such as `cd backend && go test ./api/timetable ./database/repositories/activities` also hit existing DB-backed tests and fail for the same missing `TEST_DB_DSN` reason. The new unit/compile checks above passed.