### PR TITLE
feat: align timetable UI with the design system and add mobile week view

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/timetables/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/timetables/page.tsx
@@ -1106,7 +1106,7 @@ function TimetablesContent() {
   return (
     <div className="flex flex-col gap-4 p-6">
       <header className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl font-bold text-slate-900">Stundenplan</h1>
+        <h1 className="text-2xl font-bold text-gray-900">Stundenplan</h1>
         <div className="flex flex-wrap items-center gap-2">
           <PeriodSwitcherDropdown
             periods={calendarPeriods}
@@ -1160,7 +1160,7 @@ function TimetablesContent() {
 
       {view === "month" &&
         (isInstanceDataLoading ? (
-          <div className="rounded-xl border border-slate-200 bg-white p-8">
+          <div className="moto-content-surface rounded-2xl border p-8">
             <Loading />
           </div>
         ) : (
@@ -1175,7 +1175,7 @@ function TimetablesContent() {
 
       {view === "year" &&
         (isInstanceDataLoading ? (
-          <div className="rounded-xl border border-slate-200 bg-white p-8">
+          <div className="moto-content-surface rounded-2xl border p-8">
             <Loading />
           </div>
         ) : (
@@ -1191,7 +1191,7 @@ function TimetablesContent() {
       {view === "week" && (
         <>
           {isInstanceDataLoading ? (
-            <div className="rounded-xl border border-slate-200 bg-white p-8">
+            <div className="rounded-xl border border-gray-200 bg-white p-8">
               <Loading />
             </div>
           ) : (
@@ -1365,14 +1365,13 @@ function TimetablesContent() {
         confirmText="Archivieren"
         cancelText="Abbrechen"
         isConfirmLoading={archiveLoading}
-        confirmButtonClass="bg-slate-900 hover:bg-slate-700"
       >
-        <p className="text-sm leading-relaxed text-slate-600">
+        <p className="text-sm leading-relaxed text-gray-600">
           Die Serie
           {archivingTemplate ? (
             <>
               {" "}
-              <span className="font-semibold text-slate-900">
+              <span className="font-semibold text-gray-900">
                 „{archivingTemplate.name}“
               </span>
             </>

--- a/frontend/src/components/timetable/calendar-period-modal.tsx
+++ b/frontend/src/components/timetable/calendar-period-modal.tsx
@@ -14,7 +14,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
-import { Modal } from "~/components/ui/modal";
+import { FormModal } from "~/components/ui/form-modal";
 import { useToast } from "~/contexts/ToastContext";
 import { calendarPeriodService } from "~/lib/calendar-period-api";
 import {
@@ -199,9 +199,10 @@ export function CalendarPeriodModal({
   };
 
   return (
-    <Modal
+    <FormModal
       isOpen={isOpen}
       onClose={onClose}
+      size="md"
       title={isEdit ? "Kalenderperiode bearbeiten" : "Kalenderperiode anlegen"}
       footer={
         <div className="flex w-full items-center justify-between gap-2">
@@ -232,7 +233,7 @@ export function CalendarPeriodModal({
             {deleteConfirm && !deleting && (
               <button
                 type="button"
-                className="text-xs font-semibold text-slate-500 hover:text-slate-700"
+                className="text-xs font-semibold text-gray-500 hover:text-gray-700"
                 onClick={() => setDeleteConfirm(false)}
               >
                 Löschen abbrechen
@@ -284,7 +285,7 @@ export function CalendarPeriodModal({
             id="period_type"
             value={form.periodType}
             onChange={(e) => update("periodType", e.target.value as PeriodType)}
-            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8] focus:outline-none"
+            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:ring-1 focus:ring-gray-200 focus:outline-none"
           >
             {PERIOD_TYPES.map((t) => (
               <option key={t} value={t}>
@@ -341,17 +342,15 @@ export function CalendarPeriodModal({
           </Field>
         </div>
 
-        <label className="flex cursor-pointer items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm">
+        <label className="flex cursor-pointer items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm">
           <input
             type="checkbox"
             checked={form.isActive}
             onChange={(e) => update("isActive", e.target.checked)}
             className="h-4 w-4"
           />
-          <span className="font-semibold text-slate-700">
-            Periode ist aktiv
-          </span>
-          <span className="text-xs text-slate-500">
+          <span className="font-semibold text-gray-700">Periode ist aktiv</span>
+          <span className="text-xs text-gray-500">
             Nur aktive Perioden erzeugen Serientermine
           </span>
         </label>
@@ -359,13 +358,13 @@ export function CalendarPeriodModal({
         {validationError && (
           <div
             role="alert"
-            className="rounded-md border border-[#FECACA] bg-[#FEF2F2] px-3 py-2 text-xs font-semibold text-[#7F1D1D]"
+            className="rounded-md border border-[#FF3130]/20 bg-[#FF3130]/10 px-3 py-2 text-xs font-semibold text-[#CC2626]"
           >
             {validationError}
           </div>
         )}
       </form>
-    </Modal>
+    </FormModal>
   );
 }
 
@@ -379,7 +378,7 @@ interface FieldProps {
 function Field({ label, htmlFor, required = false, children }: FieldProps) {
   return (
     <label htmlFor={htmlFor} className="flex flex-col gap-1">
-      <span className="text-xs font-semibold text-slate-700">
+      <span className="text-xs font-semibold text-gray-700">
         {label}
         {required && <span className="ml-0.5 text-[#FF3130]">*</span>}
       </span>

--- a/frontend/src/components/timetable/conflict-warnings-banner.tsx
+++ b/frontend/src/components/timetable/conflict-warnings-banner.tsx
@@ -26,13 +26,13 @@ export function ConflictWarningsBanner({
   return (
     <div
       role="status"
-      className="flex items-center gap-2.5 rounded-lg border border-slate-200 bg-white px-3 py-2"
+      className="flex items-center gap-2.5 rounded-lg border border-gray-200 bg-white px-3 py-2"
     >
-      <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-50">
-        <TriangleAlert className="h-3.5 w-3.5 text-amber-600" aria-hidden />
+      <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#EAB308]/10">
+        <TriangleAlert className="h-3.5 w-3.5 text-[#EAB308]" aria-hidden />
       </span>
-      <p className="min-w-0 flex-1 text-[12px] text-slate-600">
-        <span className="font-semibold text-slate-900">
+      <p className="min-w-0 flex-1 text-xs text-gray-600">
+        <span className="font-semibold text-gray-900">
           {conflictCount} {conflictCount === 1 ? "Konflikt" : "Konflikte"}
         </span>{" "}
         diese Woche · doppelt belegte Räume, Personal oder Kinder. Klicke einen

--- a/frontend/src/components/timetable/instance-block.tsx
+++ b/frontend/src/components/timetable/instance-block.tsx
@@ -7,7 +7,7 @@
  * - 3px left color-bar tied to activity type via `getActivityColor`
  * - flat surface with single hairline border, no default shadow
  * - status indicator as a 6px dot, not a noisy pill
- * - text hierarchy: title 12px semibold, time/room 10px slate-500
+ * - text hierarchy: title 12px semibold, time/room 10px gray-500
  *
  * Brand colours come exclusively from the helpers in `timetable-helpers.ts`.
  * Cancelled instances render with a dashed red border + line-through, matching
@@ -56,19 +56,19 @@ export function InstanceBlock({
     : getActivityLightTint(instance.activityType);
 
   const ringClass = isSelected
-    ? "ring-2 ring-offset-1 ring-slate-900"
-    : "ring-0 hover:ring-1 hover:ring-slate-300";
+    ? "ring-2 ring-offset-1 ring-gray-900"
+    : "ring-0 hover:ring-1 hover:ring-gray-300";
 
   const borderClass = isCancelled
     ? "border border-dashed border-[#FF3130]"
-    : "border border-slate-200/60";
+    : "border border-gray-200/60";
 
   return (
     <button
       type="button"
       onClick={onClick}
       aria-pressed={isSelected}
-      className={`group absolute ${ringClass} ${borderClass} cursor-pointer overflow-hidden rounded-md text-left transition-all`}
+      className={`group absolute ${ringClass} ${borderClass} cursor-pointer overflow-hidden rounded-md text-left transition-all focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none`}
       style={{
         top: `${top}px`,
         height: `${Math.max(height, 18)}px`,
@@ -81,9 +81,9 @@ export function InstanceBlock({
       <div className="flex h-full flex-col gap-0.5">
         <div className="flex items-start justify-between gap-1">
           <span
-            className={`min-w-0 truncate font-semibold text-slate-900 ${
-              isCancelled ? "text-slate-400 line-through" : ""
-            } ${isTiny ? "text-[11px]" : "text-[12px]"}`}
+            className={`min-w-0 truncate font-semibold text-gray-900 ${
+              isCancelled ? "text-gray-400 line-through" : ""
+            } ${isTiny ? "text-[11px]" : "text-xs"}`}
           >
             {isActive && !isCancelled && (
               <span
@@ -95,7 +95,7 @@ export function InstanceBlock({
           </span>
           {hasConflict && (
             <TriangleAlert
-              className="h-3 w-3 shrink-0 text-[#A16207]"
+              className="h-3 w-3 shrink-0 text-[#EAB308]"
               aria-label={`${instance.conflictWarnings.length} Konflikte`}
             />
           )}
@@ -104,7 +104,7 @@ export function InstanceBlock({
         {!isTiny && (
           <div
             className={`truncate text-[10px] tabular-nums ${
-              isCancelled ? "text-slate-400 line-through" : "text-slate-500"
+              isCancelled ? "text-gray-400 line-through" : "text-gray-500"
             }`}
           >
             {instance.startTime} – {instance.endTime}
@@ -113,7 +113,7 @@ export function InstanceBlock({
         )}
 
         {!isCompact && !isCancelled && (
-          <div className="truncate text-[10px] text-slate-500">
+          <div className="truncate text-[10px] text-gray-500">
             {instance.staffCount} P ·{" "}
             {instance.expectedStudentsCount + instance.presentStudentsCount} K
             {isActive &&

--- a/frontend/src/components/timetable/instance-detail-slide-over.tsx
+++ b/frontend/src/components/timetable/instance-detail-slide-over.tsx
@@ -140,11 +140,11 @@ function attendanceSubstatusLabel(
 function attendanceTone(status: InstanceStudentSummary["status"]): string {
   switch (status) {
     case "present":
-      return "border-[#BBF7D0] bg-[#F0FDF4] text-[#15803D]";
+      return "border-[#83CD2D]/20 bg-[#83CD2D]/10 text-[#6BA023]";
     case "absent":
-      return "border-[#FECACA] bg-[#FEF2F2] text-[#B91C1C]";
+      return "border-[#FF3130]/20 bg-[#FF3130]/10 text-[#CC2626]";
     case "expected":
-      return "border-slate-200 bg-slate-50 text-slate-600";
+      return "border-gray-200 bg-gray-50 text-gray-600";
   }
 }
 
@@ -269,7 +269,7 @@ export function InstanceDetailSlideOver({
               <SlideOverClose asChild>
                 <button
                   type="button"
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 text-slate-500 hover:bg-slate-100"
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-gray-200 text-gray-500 hover:bg-gray-100"
                   aria-label="Schließen"
                 >
                   <X className="h-4 w-4" />
@@ -280,8 +280,8 @@ export function InstanceDetailSlideOver({
 
           <div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
             {instance.conflictWarnings.length > 0 && (
-              <div className="rounded-md border border-[#FECACA] bg-[#FEF2F2] p-3">
-                <div className="flex items-center gap-2 text-xs font-bold text-[#7F1D1D]">
+              <div className="rounded-md border border-[#FF3130]/20 bg-[#FF3130]/10 p-3">
+                <div className="flex items-center gap-2 text-xs font-bold text-[#CC2626]">
                   <TriangleAlert className="h-4 w-4" />
                   {instance.conflictWarnings.length} Konflikt(e)
                 </div>
@@ -450,14 +450,14 @@ export function InstanceDetailSlideOver({
                 </Button>
               )}
               {instance.status === "completed" && (
-                <span className="inline-flex items-center gap-2 text-xs text-slate-500">
+                <span className="inline-flex items-center gap-2 text-xs text-gray-500">
                   <CheckCircle2 className="h-4 w-4" />
                   Diese Aktivität ist bereits abgeschlossen.
                 </span>
               )}
               {instance.status === "cancelled" && (
                 <>
-                  <span className="inline-flex items-center gap-2 text-xs text-slate-500">
+                  <span className="inline-flex items-center gap-2 text-xs text-gray-500">
                     <CircleX className="h-4 w-4" />
                     Diese Aktivität wurde abgesagt.
                   </span>
@@ -480,7 +480,7 @@ export function InstanceDetailSlideOver({
                   {deleteConfirm && !pendingDelete && (
                     <button
                       type="button"
-                      className="text-xs font-semibold text-slate-500 hover:text-slate-700"
+                      className="text-xs font-semibold text-gray-500 hover:text-gray-700"
                       onClick={() => setDeleteConfirm(false)}
                     >
                       Löschen abbrechen
@@ -490,7 +490,7 @@ export function InstanceDetailSlideOver({
               )}
             </div>
             {editDeferred && (
-              <div className="flex items-center justify-end gap-2 text-xs text-slate-400">
+              <div className="flex items-center justify-end gap-2 text-xs text-gray-400">
                 <Pencil className="h-3.5 w-3.5" />
                 <span>Bearbeiten kommt im nächsten Update</span>
               </div>
@@ -523,7 +523,7 @@ function StudentGroup({
   if (students.length === 0) return null;
   return (
     <div className="space-y-1.5">
-      <div className="flex items-center justify-between text-[11px] font-bold tracking-wide text-slate-400 uppercase">
+      <div className="flex items-center justify-between text-[11px] font-bold tracking-wide text-gray-400 uppercase">
         <span>{attendanceLabel(status)}</span>
         <span>{students.length}</span>
       </div>
@@ -535,11 +535,11 @@ function StudentGroup({
           )}`}
         >
           <div className="min-w-0">
-            <div className="truncate text-sm font-semibold text-slate-900">
+            <div className="truncate text-sm font-semibold text-gray-900">
               {studentNames.get(student.studentId) ??
                 `Kind #${student.studentId}`}
             </div>
-            <div className="text-[11px] text-slate-500">
+            <div className="text-[11px] text-gray-500">
               {attendanceLabel(student.status)}
               {student.substatus
                 ? ` • ${attendanceSubstatusLabel(student.substatus)}`
@@ -605,7 +605,7 @@ function StudentGroup({
 
 function EmptyLine({ children }: { children: React.ReactNode }) {
   return (
-    <div className="rounded-md border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-xs text-slate-500">
+    <div className="rounded-md border border-dashed border-gray-300 bg-gray-50 px-3 py-2 text-xs text-gray-500">
       {children}
     </div>
   );
@@ -624,10 +624,10 @@ interface IconActionButtonProps {
 
 const ICON_ACTION_PALETTE: Record<IconActionTone, string> = {
   green:
-    "border-[#BBF7D0] bg-white text-[#15803D] hover:border-[#86EFAC] hover:bg-[#F0FDF4]",
-  red: "border-[#FECACA] bg-white text-[#B91C1C] hover:border-[#FCA5A5] hover:bg-[#FEF2F2]",
+    "border-[#83CD2D]/20 bg-white text-[#6BA023] hover:border-[#83CD2D]/40 hover:bg-[#83CD2D]/10",
+  red: "border-[#FF3130]/20 bg-white text-[#CC2626] hover:border-[#FF3130]/40 hover:bg-[#FF3130]/10",
   slate:
-    "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50",
+    "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50",
 };
 
 function IconActionButton({
@@ -670,15 +670,15 @@ function PersonLine({
     <div
       className={`rounded-md border px-3 py-2 ${
         danger
-          ? "border-[#FECACA] bg-[#FEF2F2]"
-          : "border-slate-200 bg-slate-50"
+          ? "border-[#FF3130]/20 bg-[#FF3130]/10"
+          : "border-gray-200 bg-gray-50"
       }`}
     >
-      <div className="text-sm font-semibold text-slate-900">{name}</div>
+      <div className="text-sm font-semibold text-gray-900">{name}</div>
       {labels.length > 0 && (
         <div
           className={`mt-0.5 text-[11px] ${
-            danger ? "text-[#B91C1C]" : "text-slate-500"
+            danger ? "text-[#CC2626]" : "text-gray-500"
           }`}
         >
           {labels.join(" • ")}
@@ -742,29 +742,32 @@ const STAT_PILL_PALETTE: Record<
   StatPillTone,
   { bg: string; border: string; accent: string; muted: string }
 > = {
+  // Brand-aligned pill tints: green=GROUP_ROOM #83CD2D, blue=OTHER_ROOM
+  // #5080D8, amber=SICK #EAB308, slate=neutral gray. Solid hex (not /10
+  // classes) because these feed inline styles.
   green: {
-    bg: "#F0FDF4",
-    border: "#BBF7D0",
-    accent: "#15803D",
-    muted: "#166534CC",
+    bg: "#F1F9E6",
+    border: "#D7EDB8",
+    accent: "#5A8E1F",
+    muted: "#4A7A15CC",
   },
   blue: {
-    bg: "#EFF6FF",
-    border: "#BFDBFE",
-    accent: "#1E40AF",
-    muted: "#1E3A8ACC",
+    bg: "#EDF3FC",
+    border: "#C9DBF6",
+    accent: "#3F66C0",
+    muted: "#2F4F9ECC",
   },
   amber: {
-    bg: "#FEF3C7",
-    border: "#FDE68A",
-    accent: "#92400E",
-    muted: "#78350FCC",
+    bg: "#FBF3D6",
+    border: "#F2E2A0",
+    accent: "#8A6D00",
+    muted: "#6E5700CC",
   },
   slate: {
-    bg: "#F8FAFC",
-    border: "#E2E8F0",
-    accent: "#334155",
-    muted: "#475569CC",
+    bg: "#F9FAFB",
+    border: "#E5E7EB",
+    accent: "#374151",
+    muted: "#4B5563CC",
   },
 };
 
@@ -794,7 +797,7 @@ interface SectionProps {
 function Section({ title, children }: SectionProps) {
   return (
     <div className="space-y-2">
-      <h4 className="text-[10px] font-bold tracking-wider text-slate-400 uppercase">
+      <h4 className="text-[10px] font-bold tracking-wider text-gray-400 uppercase">
         {title}
       </h4>
       <div className="space-y-1.5">{children}</div>
@@ -811,12 +814,12 @@ interface RowProps {
 function Row({ icon, label, children }: RowProps) {
   return (
     <div className="flex items-start gap-3 text-sm">
-      <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-slate-400">
+      <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-gray-400">
         {icon}
       </span>
       <div className="flex min-w-0 flex-1 flex-col">
-        <span className="text-[11px] font-medium text-slate-500">{label}</span>
-        <span className="text-sm text-slate-900">{children}</span>
+        <span className="text-[11px] font-medium text-gray-500">{label}</span>
+        <span className="text-sm text-gray-900">{children}</span>
       </div>
     </div>
   );

--- a/frontend/src/components/timetable/month-planner-grid.tsx
+++ b/frontend/src/components/timetable/month-planner-grid.tsx
@@ -30,12 +30,12 @@ export function MonthPlannerGrid({
   const currentMonth = monthDate.getMonth();
 
   return (
-    <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
-      <div className="grid grid-cols-7 border-b border-slate-200">
+    <div className="moto-content-surface overflow-hidden rounded-2xl border">
+      <div className="grid grid-cols-7 border-b border-gray-200">
         {days.slice(0, 7).map((day) => (
           <div
             key={getGermanWeekdayShort(day)}
-            className="px-3 py-2 text-center text-[11px] font-medium tracking-wide text-slate-500 uppercase"
+            className="px-3 py-2 text-center text-[11px] font-medium tracking-wide text-gray-500 uppercase"
           >
             {getGermanWeekdayShort(day)}
           </div>
@@ -61,27 +61,27 @@ export function MonthPlannerGrid({
               key={iso}
               type="button"
               onClick={() => onDayClick(iso)}
-              className={`min-h-[112px] border-r border-b border-slate-100 p-2 text-left transition-colors hover:bg-slate-50 ${
-                outsideMonth ? "bg-slate-50/40 text-slate-400" : "bg-white"
+              className={`min-h-[112px] border-r border-b border-gray-100 p-2 text-left transition-colors hover:bg-gray-50 ${
+                outsideMonth ? "bg-gray-50/40 text-gray-400" : "bg-white"
               }`}
             >
               <div className="flex items-center justify-between gap-2">
                 {isToday ? (
-                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-slate-900 text-[12px] font-semibold text-white tabular-nums">
+                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-gray-900 text-xs font-semibold text-white tabular-nums">
                     {day.getDate()}
                   </span>
                 ) : (
-                  <span className="text-[13px] font-semibold tabular-nums">
+                  <span className="text-sm font-semibold tabular-nums">
                     {day.getDate()}
                   </span>
                 )}
                 {conflicts > 0 && (
-                  <AlertTriangle className="h-3.5 w-3.5 text-amber-600" />
+                  <AlertTriangle className="h-3.5 w-3.5 text-[#EAB308]" />
                 )}
               </div>
 
               {dayInstances.length === 0 ? (
-                <div className="mt-5 flex items-center gap-1 text-[11px] text-slate-400">
+                <div className="mt-5 flex items-center gap-1 text-[11px] text-gray-400">
                   <CalendarDays className="h-3 w-3" />
                   Leer
                 </div>
@@ -97,8 +97,8 @@ export function MonthPlannerGrid({
                         key={inst.id}
                         className={`flex min-w-0 items-center gap-1.5 rounded-md border px-1.5 py-1 text-[11px] ${
                           isCancelled
-                            ? "border-dashed border-[#FF3130] bg-slate-50 text-slate-400 line-through"
-                            : "border-slate-200/60 text-slate-700"
+                            ? "border-dashed border-[#FF3130] bg-gray-50 text-gray-400 line-through"
+                            : "border-gray-200/60 text-gray-700"
                         }`}
                         style={{
                           backgroundColor: isCancelled
@@ -126,7 +126,7 @@ export function MonthPlannerGrid({
                         )}
                         {hasConflict && (
                           <AlertTriangle
-                            className="h-3 w-3 shrink-0 text-[#A16207]"
+                            className="h-3 w-3 shrink-0 text-[#EAB308]"
                             aria-label={`${inst.conflictWarnings.length} Konflikte`}
                           />
                         )}
@@ -134,7 +134,7 @@ export function MonthPlannerGrid({
                     );
                   })}
                   {moreCount > 0 && (
-                    <div className="text-[10px] font-medium text-slate-500">
+                    <div className="text-[10px] font-medium text-gray-500">
                       + {moreCount} weitere
                     </div>
                   )}

--- a/frontend/src/components/timetable/period-switcher-dropdown.test.tsx
+++ b/frontend/src/components/timetable/period-switcher-dropdown.test.tsx
@@ -101,7 +101,7 @@ describe("PeriodSwitcherDropdown", () => {
     expect(onCreate).toHaveBeenCalledOnce();
   });
 
-  it("uses selected period in series view and hides loading state", () => {
+  it("uses selected period in series view and shows a loading skeleton", () => {
     const { container } = render(
       <PeriodSwitcherDropdown
         periods={basePeriods}
@@ -115,7 +115,9 @@ describe("PeriodSwitcherDropdown", () => {
       />,
     );
 
-    expect(container).toBeEmptyDOMElement();
+    // Loading now renders a skeleton placeholder (sized like the trigger
+    // pill) instead of nothing, so the header keeps its place.
+    expect(container.querySelector(".animate-pulse")).not.toBeNull();
 
     render(
       <PeriodSwitcherDropdown

--- a/frontend/src/components/timetable/period-switcher-dropdown.tsx
+++ b/frontend/src/components/timetable/period-switcher-dropdown.tsx
@@ -17,7 +17,11 @@
  * 3. A "Neue Periode anlegen" footer.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { Check, ChevronDown, Plus } from "lucide-react";
+
+import { Skeleton } from "~/components/ui/skeleton";
+import { useClickOutside } from "~/lib/hooks/use-click-outside";
 
 import {
   type CalendarPeriod,
@@ -115,23 +119,14 @@ export function PeriodSwitcherDropdown({
     ].filter((g) => g.periods.length > 0);
   }, [periods]);
 
-  // Click-outside to close.
-  useEffect(() => {
-    if (!open) return;
-    function onDocClick(event: MouseEvent) {
-      if (
-        containerRef.current &&
-        event.target instanceof Node &&
-        !containerRef.current.contains(event.target)
-      ) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", onDocClick);
-    return () => document.removeEventListener("mousedown", onDocClick);
-  }, [open]);
+  // Click-outside / Escape to close.
+  useClickOutside(containerRef, () => setOpen(false), open);
 
-  if (isLoading) return null;
+  // While loading, render a skeleton sized like the trigger pill so the
+  // header keeps its place instead of popping in when periods resolve.
+  if (isLoading) {
+    return <Skeleton className="h-8 w-44 rounded-md" />;
+  }
 
   // Empty state — no periods exist at all.
   if (periods.length === 0) {
@@ -139,7 +134,7 @@ export function PeriodSwitcherDropdown({
       <button
         type="button"
         onClick={onCreate}
-        className="inline-flex h-8 items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-3 text-[12px] font-medium text-amber-900 transition-colors hover:bg-amber-100"
+        className="inline-flex h-8 items-center gap-1.5 rounded-md bg-gray-900 px-3 text-xs font-medium text-white transition-colors hover:bg-gray-700 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
         title="Ohne aktive Kalenderperiode kann der Plan nicht materialisiert werden."
       >
         Periode anlegen
@@ -154,7 +149,7 @@ export function PeriodSwitcherDropdown({
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         aria-haspopup="dialog"
-        className="inline-flex h-8 max-w-[240px] items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 text-[12px] font-medium text-slate-700 transition-colors hover:bg-slate-50"
+        className="inline-flex h-8 max-w-[240px] items-center gap-1.5 rounded-md border border-gray-200 bg-white px-2.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
         title="Planungsperiode wechseln"
       >
         <span
@@ -162,18 +157,16 @@ export function PeriodSwitcherDropdown({
           aria-hidden
         />
         <span className="truncate">{triggerLabel}</span>
-        <span aria-hidden className="text-slate-400">
-          ▾
-        </span>
+        <ChevronDown className="h-3.5 w-3.5 text-gray-400" aria-hidden />
       </button>
 
       {open && (
-        <div className="absolute left-0 z-30 mt-2 w-[calc(100vw-3rem)] max-w-96 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-md sm:right-0 sm:left-auto sm:w-96">
-          <div className="border-b border-slate-100 px-4 py-3">
-            <p className="text-sm font-semibold text-slate-900">
+        <div className="absolute left-0 z-30 mt-2 w-[calc(100vw-3rem)] max-w-96 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg sm:right-0 sm:left-auto sm:w-96">
+          <div className="border-b border-gray-100 px-4 py-3">
+            <p className="text-sm font-semibold text-gray-900">
               Planungsperiode
             </p>
-            <p className="text-[11px] text-slate-500">
+            <p className="text-[11px] text-gray-500">
               Wähle eine Periode oder erstelle eine neue.
             </p>
           </div>
@@ -186,8 +179,8 @@ export function PeriodSwitcherDropdown({
           )}
 
           {showContextAssignments && view !== "month" && (
-            <div className="border-b border-slate-100 bg-slate-50/60 px-4 py-2.5">
-              <p className="mb-1 text-[10px] font-semibold tracking-wider text-slate-500 uppercase">
+            <div className="border-b border-gray-100 bg-gray-50/60 px-4 py-2.5">
+              <p className="mb-1 text-[10px] font-semibold tracking-wider text-gray-500 uppercase">
                 {contextLabel}
               </p>
               <div className="space-y-0.5">
@@ -198,12 +191,12 @@ export function PeriodSwitcherDropdown({
                       key={a.date}
                       className="flex items-center justify-between gap-3 text-[11px]"
                     >
-                      <span className="font-medium text-slate-500">
+                      <span className="font-medium text-gray-500">
                         {getGermanWeekdayShort(day)}
                       </span>
-                      <span className="min-w-0 flex-1 truncate text-right text-slate-700">
+                      <span className="min-w-0 flex-1 truncate text-right text-gray-700">
                         {a.period?.name ?? (
-                          <span className="text-amber-700">
+                          <span className="text-[#EAB308]">
                             Keine aktive Periode
                           </span>
                         )}
@@ -219,7 +212,7 @@ export function PeriodSwitcherDropdown({
           <div className="max-h-72 overflow-y-auto py-1">
             {grouped.map((group) => (
               <div key={group.label} className="py-1">
-                <p className="px-4 py-1 text-[10px] font-semibold tracking-wider text-slate-400 uppercase">
+                <p className="px-4 py-1 text-[10px] font-semibold tracking-wider text-gray-400 uppercase">
                   {group.label}
                 </p>
                 {group.periods.map((p) => {
@@ -235,21 +228,22 @@ export function PeriodSwitcherDropdown({
                           setOpen(false);
                           onSelect(p);
                         }}
-                        className={`group min-w-0 flex-1 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-slate-100 ${
-                          isAssigned ? "bg-slate-100" : ""
+                        className={`group min-w-0 flex-1 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-100 ${
+                          isAssigned ? "bg-gray-100" : ""
                         }`}
                       >
                         <div className="flex items-center justify-between gap-2">
-                          <span className="truncate text-[12px] font-medium text-slate-900">
+                          <span className="truncate text-xs font-medium text-gray-900">
                             {p.name}
                           </span>
                           {isAssigned && (
-                            <span className="shrink-0 text-[10px] font-semibold text-slate-900">
-                              ✓
-                            </span>
+                            <Check
+                              className="h-3.5 w-3.5 shrink-0 text-gray-900"
+                              aria-hidden
+                            />
                           )}
                         </div>
-                        <p className="text-[10px] text-slate-500 tabular-nums">
+                        <p className="text-[10px] text-gray-500 tabular-nums">
                           {formatPeriodRange(p)}
                         </p>
                       </button>
@@ -259,7 +253,7 @@ export function PeriodSwitcherDropdown({
                           setOpen(false);
                           onEdit(p);
                         }}
-                        className="rounded-md px-2 py-1 text-[10px] font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900"
+                        className="rounded-md px-2 py-1 text-[10px] font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
                         aria-label={`${p.name} bearbeiten`}
                       >
                         Bearbeiten
@@ -278,10 +272,9 @@ export function PeriodSwitcherDropdown({
               setOpen(false);
               onCreate();
             }}
-            className="flex w-full items-center gap-1.5 border-t border-slate-100 px-4 py-2.5 text-left text-[12px] font-medium text-slate-700 transition-colors hover:bg-slate-50"
+            className="flex w-full items-center gap-1.5 border-t border-gray-100 px-4 py-2.5 text-left text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
           >
-            <span className="text-base leading-none">+</span> Neue Periode
-            anlegen
+            <Plus className="h-4 w-4" aria-hidden /> Neue Periode anlegen
           </button>
         </div>
       )}
@@ -299,13 +292,13 @@ function MonthPeriodSummary({
   if (assignedPeriods.length === 1 && !hasMissingDays) {
     const period = assignedPeriods[0]!;
     return (
-      <div className="border-b border-slate-100 bg-slate-50/60 px-4 py-2.5">
-        <p className="mb-1 text-[10px] font-semibold tracking-wider text-slate-500 uppercase">
+      <div className="border-b border-gray-100 bg-gray-50/60 px-4 py-2.5">
+        <p className="mb-1 text-[10px] font-semibold tracking-wider text-gray-500 uppercase">
           Dieser Monat
         </p>
-        <p className="text-[12px] text-slate-700">
+        <p className="text-xs text-gray-700">
           Liegt komplett in{" "}
-          <span className="font-semibold text-slate-900">{period.name}</span>.
+          <span className="font-semibold text-gray-900">{period.name}</span>.
         </p>
       </div>
     );
@@ -313,11 +306,11 @@ function MonthPeriodSummary({
 
   if (assignedPeriods.length === 0) {
     return (
-      <div className="border-b border-slate-100 bg-slate-50/60 px-4 py-2.5">
-        <p className="mb-1 text-[10px] font-semibold tracking-wider text-slate-500 uppercase">
+      <div className="border-b border-gray-100 bg-gray-50/60 px-4 py-2.5">
+        <p className="mb-1 text-[10px] font-semibold tracking-wider text-gray-500 uppercase">
           Dieser Monat
         </p>
-        <p className="text-[12px] text-amber-700">
+        <p className="text-xs text-[#EAB308]">
           Für diesen Monat ist keine aktive Periode hinterlegt.
         </p>
       </div>
@@ -325,25 +318,23 @@ function MonthPeriodSummary({
   }
 
   return (
-    <div className="border-b border-slate-100 bg-slate-50/60 px-4 py-2.5">
-      <p className="mb-1 text-[10px] font-semibold tracking-wider text-slate-500 uppercase">
+    <div className="border-b border-gray-100 bg-gray-50/60 px-4 py-2.5">
+      <p className="mb-1 text-[10px] font-semibold tracking-wider text-gray-500 uppercase">
         Dieser Monat
       </p>
-      <p className="mb-1.5 text-[12px] text-slate-700">
-        Umfasst mehrere Perioden.
-      </p>
+      <p className="mb-1.5 text-xs text-gray-700">Umfasst mehrere Perioden.</p>
       <div className="space-y-0.5">
         {assignedPeriods.map((period) => (
           <p
             key={period.id}
-            className="truncate text-[11px] text-slate-600 tabular-nums"
+            className="truncate text-[11px] text-gray-600 tabular-nums"
           >
-            <span className="font-medium text-slate-800">{period.name}</span>{" "}
-            <span className="text-slate-400">{formatPeriodRange(period)}</span>
+            <span className="font-medium text-gray-800">{period.name}</span>{" "}
+            <span className="text-gray-400">{formatPeriodRange(period)}</span>
           </p>
         ))}
         {hasMissingDays && (
-          <p className="text-[11px] text-amber-700">
+          <p className="text-[11px] text-[#EAB308]">
             Einige Tage haben keine aktive Periode.
           </p>
         )}

--- a/frontend/src/components/timetable/plan-quality-panel.tsx
+++ b/frontend/src/components/timetable/plan-quality-panel.tsx
@@ -112,10 +112,10 @@ export function PlanQualityPanel({
   };
 
   return (
-    <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+    <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
       <div>
-        <h2 className="text-sm font-bold text-slate-900">Planstatus</h2>
-        <p className="mt-0.5 text-xs text-slate-500">
+        <h2 className="text-sm font-bold text-gray-900">Planstatus</h2>
+        <p className="mt-0.5 text-xs text-gray-500">
           {hasError
             ? "Planstatus konnte nicht vollständig geprüft werden."
             : loading
@@ -154,7 +154,7 @@ export function PlanQualityPanel({
       </div>
 
       {hasError && (
-        <div className="mt-4 rounded-md border border-[#FDE68A] bg-[#FFFBEB] p-3 text-xs text-[#713F12]">
+        <div className="mt-4 rounded-md border border-[#EAB308]/20 bg-[#EAB308]/10 p-3 text-xs text-[#EAB308]">
           <div className="flex items-center gap-2 font-bold">
             <TriangleAlert className="h-4 w-4" />
             Prüfung unvollständig
@@ -169,8 +169,8 @@ export function PlanQualityPanel({
       {(gaps.length > 0 || conflicts.length > 0) && (
         <div className="mt-4 grid gap-3 lg:grid-cols-2">
           {gaps.length > 0 && (
-            <div className="rounded-md border border-[#FECACA] bg-[#FEF2F2] p-3">
-              <div className="flex items-center gap-2 text-xs font-bold text-[#7F1D1D]">
+            <div className="rounded-md border border-[#FF3130]/20 bg-[#FF3130]/10 p-3">
+              <div className="flex items-center gap-2 text-xs font-bold text-[#CC2626]">
                 <UserPlus className="h-4 w-4" />
                 Personal-Lücken
               </div>
@@ -190,11 +190,11 @@ export function PlanQualityPanel({
                       <button
                         type="button"
                         onClick={() => onSelectInstance(gap.instanceId)}
-                        className="text-left font-bold text-slate-900 hover:text-[#5080D8]"
+                        className="text-left font-bold text-gray-900 hover:text-gray-900"
                       >
                         {dateLabel(gap.date)} • {gap.startTime} {gap.title}
                       </button>
-                      <div className="mt-1 text-slate-500">
+                      <div className="mt-1 text-gray-500">
                         {gap.assignedStaffCount === 0
                           ? "Kein Personal zugeordnet."
                           : `${gap.absentStaffCount} von ${gap.assignedStaffCount} zugeordneten Personen abwesend.`}
@@ -232,7 +232,7 @@ export function PlanQualityPanel({
                                   [gap.instanceId]: e.target.value,
                                 }))
                               }
-                              className="min-w-48 rounded-md border border-slate-300 bg-white px-2 py-1 text-xs"
+                              className="min-w-48 rounded-md border border-gray-300 bg-white px-2 py-1 text-xs"
                             >
                               {absentRows.map((item) => (
                                 <option key={item.staffId} value={item.staffId}>
@@ -250,7 +250,7 @@ export function PlanQualityPanel({
                                 [gap.instanceId]: e.target.value,
                               }))
                             }
-                            className="min-w-48 rounded-md border border-slate-300 bg-white px-2 py-1 text-xs"
+                            className="min-w-48 rounded-md border border-gray-300 bg-white px-2 py-1 text-xs"
                           >
                             <option value="">Ersatz auswählen …</option>
                             {availableStaff.map((item) => (
@@ -279,8 +279,8 @@ export function PlanQualityPanel({
           )}
 
           {conflicts.length > 0 && (
-            <div className="rounded-md border border-[#FDE68A] bg-[#FFFBEB] p-3">
-              <div className="flex items-center gap-2 text-xs font-bold text-[#713F12]">
+            <div className="rounded-md border border-[#EAB308]/20 bg-[#EAB308]/10 p-3">
+              <div className="flex items-center gap-2 text-xs font-bold text-[#EAB308]">
                 <TriangleAlert className="h-4 w-4" />
                 Ausnahmen prüfen
               </div>
@@ -292,16 +292,16 @@ export function PlanQualityPanel({
                     onClick={() => onSelectInstance(conflict.instanceId)}
                     className="block w-full rounded-md bg-white p-2 text-left text-xs shadow-sm hover:bg-[#FFF7ED]"
                   >
-                    <div className="font-bold text-slate-900">
+                    <div className="font-bold text-gray-900">
                       {dateLabel(conflict.date)} • {conflict.activityTitle}
                     </div>
-                    <div className="mt-0.5 text-slate-600">
+                    <div className="mt-0.5 text-gray-600">
                       {conflictText(conflict)}
                     </div>
                   </button>
                 ))}
                 {conflicts.length > 6 && (
-                  <div className="text-xs font-semibold text-[#713F12]">
+                  <div className="text-xs font-semibold text-[#EAB308]">
                     + {conflicts.length - 6} weitere Konflikte
                   </div>
                 )}
@@ -326,10 +326,10 @@ function Metric({
   tone: "neutral" | "success" | "warning" | "danger";
 }) {
   const palette = {
-    neutral: "border-slate-200 bg-slate-50 text-slate-700",
-    success: "border-[#BBF7D0] bg-[#F0FDF4] text-[#15803D]",
-    warning: "border-[#FDE68A] bg-[#FFFBEB] text-[#A16207]",
-    danger: "border-[#FECACA] bg-[#FEF2F2] text-[#B91C1C]",
+    neutral: "border-gray-200 bg-gray-50 text-gray-700",
+    success: "border-[#83CD2D]/20 bg-[#83CD2D]/10 text-[#6BA023]",
+    warning: "border-[#EAB308]/20 bg-[#EAB308]/10 text-[#EAB308]",
+    danger: "border-[#FF3130]/20 bg-[#FF3130]/10 text-[#CC2626]",
   };
   return (
     <div className={`rounded-md border px-3 py-2 ${palette[tone]}`}>

--- a/frontend/src/components/timetable/planning-menu.tsx
+++ b/frontend/src/components/timetable/planning-menu.tsx
@@ -20,15 +20,17 @@
  * modal dialog (`ReplanConfirmDialog`).
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { CalendarPlus, ChevronDown, RefreshCw } from "lucide-react";
+
+import { useClickOutside } from "~/lib/hooks/use-click-outside";
 
 interface PlanningMenuProps {
   onMaterialize: () => Promise<void>;
   onReplan: () => Promise<void>;
   weekLabel: string;
   disabled?: boolean;
-  /** When true, renders the trigger as a primary slate-900 solid button. */
+  /** When true, renders the trigger as a primary gray-900 solid button. */
   emphasis?: "primary" | "secondary" | "accent";
   label?: string;
 }
@@ -47,27 +49,7 @@ export function PlanningMenu({
   const [replanning, setReplanning] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    function onDocClick(event: MouseEvent) {
-      if (
-        containerRef.current &&
-        event.target instanceof Node &&
-        !containerRef.current.contains(event.target)
-      ) {
-        setOpen(false);
-      }
-    }
-    function onKey(event: KeyboardEvent) {
-      if (event.key === "Escape") setOpen(false);
-    }
-    document.addEventListener("mousedown", onDocClick);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDocClick);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
+  useClickOutside(containerRef, () => setOpen(false), open);
 
   const handleMaterialize = () => {
     setOpen(false);
@@ -86,10 +68,10 @@ export function PlanningMenu({
   const isPending = materializing || replanning;
   const triggerClass =
     emphasis === "primary"
-      ? "bg-slate-900 text-white hover:bg-slate-700"
+      ? "bg-gray-900 text-white hover:bg-gray-700"
       : emphasis === "accent"
-        ? "bg-[#83CD2D] text-slate-950 hover:bg-[#74b827]"
-        : "border border-slate-200 bg-white text-slate-700 hover:bg-slate-50";
+        ? "bg-[#83CD2D] text-gray-950 hover:bg-[#74b827]"
+        : "border border-gray-200 bg-white text-gray-700 hover:bg-gray-50";
 
   return (
     <>
@@ -100,7 +82,7 @@ export function PlanningMenu({
           disabled={disabled || isPending}
           aria-haspopup="menu"
           aria-expanded={open}
-          className={`inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-md px-3 text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto ${triggerClass}`}
+          className={`inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-md px-3 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto ${triggerClass}`}
         >
           {isPending ? (
             <RefreshCw className="h-3.5 w-3.5 animate-spin" aria-hidden />
@@ -118,29 +100,29 @@ export function PlanningMenu({
           <div
             role="menu"
             aria-label="Planungsoptionen"
-            className="absolute right-0 z-30 mt-2 w-[min(20rem,calc(100vw-2rem))] overflow-hidden rounded-lg border border-slate-200 bg-white shadow-md"
+            className="absolute right-0 z-30 mt-2 w-[min(20rem,calc(100vw-2rem))] overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg"
           >
             <button
               type="button"
               role="menuitem"
               onClick={handleMaterialize}
-              className="flex w-full items-start gap-3 px-3 py-3 text-left transition-colors hover:bg-slate-50"
+              className="flex w-full items-start gap-3 px-3 py-3 text-left transition-colors hover:bg-gray-50"
             >
-              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-slate-100">
-                <CalendarPlus className="h-4 w-4 text-slate-700" aria-hidden />
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-gray-100">
+                <CalendarPlus className="h-4 w-4 text-gray-700" aria-hidden />
               </div>
               <div className="min-w-0 flex-1">
-                <div className="text-[13px] font-semibold text-slate-900">
+                <div className="text-sm font-semibold text-gray-900">
                   Lücken füllen
                 </div>
-                <p className="mt-0.5 text-[11px] leading-relaxed text-slate-500">
+                <p className="mt-0.5 text-[11px] leading-relaxed text-gray-500">
                   Legt fehlende Termine aus den Serien an. Bestehende Termine
                   werden nicht geändert.
                 </p>
               </div>
             </button>
 
-            <div className="h-px bg-slate-100" />
+            <div className="h-px bg-gray-100" />
 
             <button
               type="button"
@@ -149,16 +131,16 @@ export function PlanningMenu({
                 setOpen(false);
                 setShowReplanDialog(true);
               }}
-              className="flex w-full items-start gap-3 px-3 py-3 text-left transition-colors hover:bg-slate-50"
+              className="flex w-full items-start gap-3 px-3 py-3 text-left transition-colors hover:bg-gray-50"
             >
-              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-amber-50">
-                <RefreshCw className="h-4 w-4 text-amber-600" aria-hidden />
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[#EAB308]/10">
+                <RefreshCw className="h-4 w-4 text-[#EAB308]" aria-hidden />
               </div>
               <div className="min-w-0 flex-1">
-                <div className="text-[13px] font-semibold text-slate-900">
+                <div className="text-sm font-semibold text-gray-900">
                   Woche neu berechnen
                 </div>
-                <p className="mt-0.5 text-[11px] leading-relaxed text-slate-500">
+                <p className="mt-0.5 text-[11px] leading-relaxed text-gray-500">
                   Löscht noch nicht gestartete Serientermine dieser Woche und
                   erstellt sie neu aus den Serien. Laufende, abgesagte und
                   manuell angelegte Termine bleiben erhalten.
@@ -202,31 +184,31 @@ function ReplanConfirmDialog({
       <button
         type="button"
         aria-label="Schließen"
-        className="absolute inset-0 bg-slate-900/40 transition-opacity"
+        className="absolute inset-0 bg-gray-900/40 transition-opacity"
         onClick={replanning ? undefined : onCancel}
         disabled={replanning}
       />
-      <div className="relative w-full max-w-md overflow-hidden rounded-lg border border-slate-200 bg-white shadow-md">
+      <div className="relative w-full max-w-md overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-xl">
         <div className="px-5 py-4">
           <h3
             id="replan-dialog-title"
-            className="text-base font-semibold text-slate-900"
+            className="text-base font-semibold text-gray-900"
           >
             Woche neu berechnen?
           </h3>
-          <p className="mt-1.5 text-sm text-slate-600">
+          <p className="mt-1.5 text-sm text-gray-600">
             Noch nicht gestartete Serientermine in{" "}
-            <span className="font-semibold text-slate-900">{weekLabel}</span>{" "}
+            <span className="font-semibold text-gray-900">{weekLabel}</span>{" "}
             werden gelöscht und anhand der aktuellen Serien neu erstellt.
             Laufende, abgesagte und manuell angelegte Termine bleiben erhalten.
           </p>
         </div>
-        <div className="flex items-center justify-end gap-2 border-t border-slate-100 bg-slate-50/50 px-5 py-3">
+        <div className="flex items-center justify-end gap-2 border-t border-gray-100 bg-gray-50/50 px-5 py-3">
           <button
             type="button"
             onClick={onCancel}
             disabled={replanning}
-            className="inline-flex h-8 items-center rounded-md px-3 text-[12px] font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex h-8 items-center rounded-md px-3 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50"
           >
             Abbrechen
           </button>
@@ -234,7 +216,7 @@ function ReplanConfirmDialog({
             type="button"
             onClick={onConfirm}
             disabled={replanning}
-            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-slate-900 px-3 text-[12px] font-medium text-white transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-gray-900 px-3 text-xs font-medium text-white transition-colors hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {replanning && (
               <RefreshCw className="h-3.5 w-3.5 animate-spin" aria-hidden />

--- a/frontend/src/components/timetable/template-card.tsx
+++ b/frontend/src/components/timetable/template-card.tsx
@@ -65,7 +65,7 @@ export function TemplateCard({
   const timeRange = summarizeTimeRange(template);
 
   return (
-    <article className="group relative flex flex-col overflow-hidden rounded-lg border border-slate-200 bg-white transition-shadow hover:shadow-sm">
+    <article className="group moto-content-surface relative flex flex-col overflow-hidden rounded-2xl border transition-shadow hover:shadow-sm">
       <div
         className="absolute top-0 left-0 h-full w-1"
         style={{ backgroundColor: color }}
@@ -75,10 +75,10 @@ export function TemplateCard({
       <div className="flex flex-col gap-3 p-4 pl-5">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
-            <h3 className="truncate text-sm font-semibold text-slate-900">
+            <h3 className="truncate text-sm font-semibold text-gray-900">
               {template.name}
             </h3>
-            <p className="mt-0.5 text-[11px] font-medium tracking-wide text-slate-500 uppercase">
+            <p className="mt-0.5 text-[11px] font-medium tracking-wide text-gray-500 uppercase">
               {TYPE_LABELS[template.type]}
               {template.categoryName ? ` · ${template.categoryName}` : ""}
             </p>
@@ -93,8 +93,8 @@ export function TemplateCard({
                 key={wd}
                 className={`flex h-6 w-7 items-center justify-center rounded text-[10px] font-semibold ${
                   active
-                    ? "bg-slate-900 text-white"
-                    : "bg-slate-100 text-slate-400"
+                    ? "bg-gray-900 text-white"
+                    : "bg-gray-100 text-gray-400"
                 }`}
               >
                 {weekdayShort(wd)}
@@ -103,19 +103,19 @@ export function TemplateCard({
           })}
         </div>
 
-        <dl className="space-y-1.5 text-[12px] text-slate-600">
+        <dl className="space-y-1.5 text-xs text-gray-600">
           <div className="flex items-center gap-2">
-            <Clock className="h-3.5 w-3.5 text-slate-400" aria-hidden />
+            <Clock className="h-3.5 w-3.5 text-gray-400" aria-hidden />
             <span className="tabular-nums">
               {timeRange ?? "Keine Zeiten hinterlegt"}
             </span>
           </div>
           <div className="flex items-center gap-2">
-            <DoorOpen className="h-3.5 w-3.5 text-slate-400" aria-hidden />
+            <DoorOpen className="h-3.5 w-3.5 text-gray-400" aria-hidden />
             <span className="truncate">{template.roomName ?? "Kein Raum"}</span>
           </div>
           <div className="flex items-center gap-2">
-            <Users className="h-3.5 w-3.5 text-slate-400" aria-hidden />
+            <Users className="h-3.5 w-3.5 text-gray-400" aria-hidden />
             <span>
               {template.enrollmentCount}{" "}
               {template.enrollmentCount === 1 ? "Kind" : "Kinder"}
@@ -126,19 +126,19 @@ export function TemplateCard({
         </dl>
       </div>
 
-      <div className="flex flex-col gap-2 border-t border-slate-100 px-4 py-2.5 pl-5">
+      <div className="flex flex-col gap-2 border-t border-gray-100 px-4 py-2.5 pl-5">
         <div className="flex items-center justify-between gap-2">
           <button
             type="button"
             onClick={() => onEdit(template)}
-            className="rounded px-1.5 py-1 text-[12px] font-medium text-slate-600 transition-colors hover:text-slate-900 focus-visible:ring-2 focus-visible:ring-slate-300 focus-visible:outline-none"
+            className="rounded px-1.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:text-gray-900 focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:outline-none"
           >
             Bearbeiten
           </button>
           <button
             type="button"
             onClick={() => onArchive(template)}
-            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 focus-visible:ring-2 focus-visible:ring-slate-300 focus-visible:outline-none"
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:outline-none"
           >
             <Archive className="h-3.5 w-3.5" aria-hidden />
             Archivieren
@@ -147,7 +147,7 @@ export function TemplateCard({
         <button
           type="button"
           onClick={() => onApply(template)}
-          className="inline-flex h-8 w-full items-center justify-center rounded-md bg-slate-900 px-2.5 text-[12px] font-medium whitespace-nowrap text-white transition-colors hover:bg-slate-700 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:outline-none"
+          className="inline-flex h-8 w-full items-center justify-center rounded-md bg-gray-900 px-2.5 text-xs font-medium whitespace-nowrap text-white transition-colors hover:bg-gray-700 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           Termine erzeugen
         </button>

--- a/frontend/src/components/timetable/template-list.tsx
+++ b/frontend/src/components/timetable/template-list.tsx
@@ -22,15 +22,15 @@ export function TemplateList({
 }: TemplateListProps) {
   if (templates.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-slate-200 bg-slate-50/40 px-6 py-16 text-center">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-100">
-          <CalendarDays className="h-6 w-6 text-slate-400" aria-hidden />
+      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-200 bg-gray-50/40 px-6 py-16 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+          <CalendarDays className="h-6 w-6 text-gray-400" aria-hidden />
         </div>
         <div className="flex flex-col gap-1">
-          <h3 className="text-base font-semibold text-slate-900">
+          <h3 className="text-base font-semibold text-gray-900">
             Keine Serien für diese Periode
           </h3>
-          <p className="max-w-sm text-sm text-slate-500">
+          <p className="max-w-sm text-sm text-gray-500">
             Serien sind wiederkehrende Termine, die automatisch im Kalender
             erscheinen.
           </p>
@@ -38,7 +38,7 @@ export function TemplateList({
         <button
           type="button"
           onClick={onCreate}
-          className="mt-2 inline-flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1.5 text-[13px] font-medium text-white transition-colors hover:bg-slate-700"
+          className="mt-2 inline-flex items-center gap-1 rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-gray-700"
         >
           + Serientermin anlegen
         </button>

--- a/frontend/src/components/timetable/timetable-event-modal.tsx
+++ b/frontend/src/components/timetable/timetable-event-modal.tsx
@@ -563,7 +563,7 @@ export function TimetableEventModal({
             <SlideOverClose asChild>
               <button
                 type="button"
-                className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 text-slate-500 transition-colors hover:bg-slate-100"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-gray-200 text-gray-500 transition-colors hover:bg-gray-100"
                 aria-label="Schließen"
               >
                 <X className="h-4 w-4" aria-hidden />
@@ -579,7 +579,7 @@ export function TimetableEventModal({
         >
           <div className="flex flex-col gap-5">
             {initialInstance && initialInstance.status !== "planned" && (
-              <div className="rounded-md border border-[#FECACA] bg-[#FEF2F2] px-3 py-2 text-xs font-semibold text-[#7F1D1D]">
+              <div className="rounded-md border border-[#FF3130]/20 bg-[#FF3130]/10 px-3 py-2 text-xs font-semibold text-[#CC2626]">
                 Nur geplante Termine können bearbeitet werden.
               </div>
             )}
@@ -640,7 +640,7 @@ export function TimetableEventModal({
                 onChange={(event) => update("roomId", event.target.value)}
                 disabled={loadingRefs}
                 required
-                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8] focus:outline-none disabled:bg-gray-100"
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:ring-1 focus:ring-gray-200 focus:outline-none disabled:bg-gray-100"
               >
                 <option value="">
                   {loadingRefs ? "Lade Räume ..." : "Raum auswählen ..."}
@@ -656,10 +656,10 @@ export function TimetableEventModal({
             </Field>
 
             <div className="flex flex-col gap-1">
-              <span className="text-xs font-semibold text-slate-700">
+              <span className="text-xs font-semibold text-gray-700">
                 Wiederholen
               </span>
-              <div className="inline-flex w-fit rounded-md bg-slate-100 p-0.5">
+              <div className="inline-flex w-fit rounded-md bg-gray-100 p-0.5">
                 {REPEAT_OPTIONS.map((option) => {
                   const isActive = form.repeat === option.value;
                   const disabled = isEditingSeries && option.value === "none";
@@ -681,10 +681,10 @@ export function TimetableEventModal({
                           );
                         }
                       }}
-                      className={`rounded px-3 py-1.5 text-[13px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                      className={`rounded px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
                         isActive
-                          ? "bg-white text-slate-900 shadow-sm"
-                          : "text-slate-600 hover:text-slate-900"
+                          ? "bg-white text-gray-900 shadow-sm"
+                          : "text-gray-600 hover:text-gray-900"
                       }`}
                     >
                       {option.label}
@@ -697,7 +697,7 @@ export function TimetableEventModal({
             {isSeriesFlow && (
               <>
                 <div className="flex flex-col gap-1">
-                  <span className="text-xs font-semibold text-slate-700">
+                  <span className="text-xs font-semibold text-gray-700">
                     Typ <span className="ml-0.5 text-[#FF3130]">*</span>
                   </span>
                   <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
@@ -712,7 +712,7 @@ export function TimetableEventModal({
                           className={`flex flex-col items-start gap-0.5 rounded-md border px-3 py-2 text-left transition-colors ${
                             isActive
                               ? "border-2 bg-white"
-                              : "border border-slate-200 bg-slate-50 hover:bg-white"
+                              : "border border-gray-200 bg-gray-50 hover:bg-white"
                           }`}
                           style={isActive ? { borderColor: color } : undefined}
                         >
@@ -722,7 +722,7 @@ export function TimetableEventModal({
                           >
                             {option.label}
                           </span>
-                          <span className="text-[10px] text-slate-500">
+                          <span className="text-[10px] text-gray-500">
                             {option.hint}
                           </span>
                         </button>
@@ -732,7 +732,7 @@ export function TimetableEventModal({
                 </div>
 
                 <div className="flex flex-col gap-1">
-                  <span className="text-xs font-semibold text-slate-700">
+                  <span className="text-xs font-semibold text-gray-700">
                     Wochentage <span className="ml-0.5 text-[#FF3130]">*</span>
                   </span>
                   <div className="flex flex-wrap gap-1.5">
@@ -745,8 +745,8 @@ export function TimetableEventModal({
                           onClick={() => toggleWeekday(iso)}
                           className={`min-w-[44px] rounded-md border px-3 py-1.5 text-sm font-semibold transition-colors ${
                             isActive
-                              ? "border-[#5080D8] bg-[#5080D8] text-white"
-                              : "border-slate-300 bg-white text-slate-600 hover:bg-slate-50"
+                              ? "border-gray-900 bg-gray-900 text-white"
+                              : "border-gray-300 bg-white text-gray-600 hover:bg-gray-50"
                           }`}
                           aria-pressed={isActive}
                         >
@@ -767,7 +767,7 @@ export function TimetableEventModal({
                       }
                       required
                       disabled={loadingRefs}
-                      className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8] focus:outline-none disabled:bg-gray-100"
+                      className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:ring-1 focus:ring-gray-200 focus:outline-none disabled:bg-gray-100"
                     >
                       <option value="">
                         {loadingRefs
@@ -794,7 +794,7 @@ export function TimetableEventModal({
                           update("calendarPeriodId", event.target.value)
                         }
                         required
-                        className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8] focus:outline-none"
+                        className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:ring-1 focus:ring-gray-200 focus:outline-none"
                       >
                         <option value="">Periode auswählen ...</option>
                         {calendarPeriods.map((period) => (
@@ -806,13 +806,13 @@ export function TimetableEventModal({
                     </Field>
                   ) : (
                     <div className="flex flex-col justify-end gap-1">
-                      <span className="text-xs font-semibold text-slate-700">
+                      <span className="text-xs font-semibold text-gray-700">
                         Planungsperiode
                       </span>
-                      <div className="flex h-10 items-center rounded-lg border border-slate-200 bg-slate-50 px-3 text-sm text-slate-600">
+                      <div className="flex h-10 items-center rounded-lg border border-gray-200 bg-gray-50 px-3 text-sm text-gray-600">
                         <span className="truncate">
                           Gilt in{" "}
-                          <span className="font-semibold text-slate-800">
+                          <span className="font-semibold text-gray-800">
                             {calendarPeriods.find(
                               (p) => p.id === form.calendarPeriodId,
                             )?.name ?? "der aktuellen Planungsperiode"}
@@ -854,7 +854,7 @@ export function TimetableEventModal({
                   onChange={(event) =>
                     update("primaryStaffId", event.target.value)
                   }
-                  className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8] focus:outline-none"
+                  className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:ring-1 focus:ring-gray-200 focus:outline-none"
                 >
                   <option value="">Keine Auswahl</option>
                   {staff
@@ -875,7 +875,7 @@ export function TimetableEventModal({
                   value={form.notes}
                   onChange={(event) => update("notes", event.target.value)}
                   rows={3}
-                  className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8] focus:outline-none"
+                  className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:ring-1 focus:ring-gray-200 focus:outline-none"
                 />
               </Field>
             )}
@@ -883,7 +883,7 @@ export function TimetableEventModal({
             {isSeriesFlow && calendarPeriods.length === 0 && (
               <div
                 role="alert"
-                className="rounded-md border border-[#FECACA] bg-[#FEF2F2] px-3 py-2 text-xs font-semibold text-[#7F1D1D]"
+                className="rounded-md border border-[#FF3130]/20 bg-[#FF3130]/10 px-3 py-2 text-xs font-semibold text-[#CC2626]"
               >
                 Für diese Woche gibt es keine aktive Planungsperiode. Lege
                 zuerst eine Periode im Kopfbereich an.
@@ -893,7 +893,7 @@ export function TimetableEventModal({
             {validationError && (
               <div
                 role="alert"
-                className="rounded-md border border-[#FECACA] bg-[#FEF2F2] px-3 py-2 text-xs font-semibold text-[#7F1D1D]"
+                className="rounded-md border border-[#FF3130]/20 bg-[#FF3130]/10 px-3 py-2 text-xs font-semibold text-[#CC2626]"
               >
                 {validationError}
               </div>
@@ -941,7 +941,7 @@ function Field({
 }) {
   return (
     <label htmlFor={htmlFor} className="flex flex-col gap-1">
-      <span className="text-xs font-semibold text-slate-700">
+      <span className="text-xs font-semibold text-gray-700">
         {label}
         {required && <span className="ml-0.5 text-[#FF3130]">*</span>}
       </span>
@@ -1038,10 +1038,10 @@ function MultiSelectField({
   };
 
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-slate-200 bg-slate-50 p-3">
+    <div className="flex flex-col gap-2 rounded-lg border border-gray-200 bg-gray-50 p-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <span className="text-xs font-semibold text-slate-700">{label}</span>
-        <span className="text-[11px] text-slate-500">
+        <span className="text-xs font-semibold text-gray-700">{label}</span>
+        <span className="text-[11px] text-gray-500">
           {value.length} ausgewählt
         </span>
       </div>
@@ -1050,7 +1050,7 @@ function MultiSelectField({
         <label className="relative">
           <span className="sr-only">{label} suchen</span>
           <Search
-            className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400"
+            className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400"
             aria-hidden
           />
           <input
@@ -1058,14 +1058,14 @@ function MultiSelectField({
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder={`${label} suchen ...`}
-            className="h-9 w-full rounded-md border border-slate-200 bg-white pr-3 pl-9 text-sm focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8] focus:outline-none"
+            className="h-9 w-full rounded-md border border-gray-200 bg-white pr-3 pl-9 text-sm focus:border-gray-400 focus:ring-1 focus:ring-gray-200 focus:outline-none"
           />
         </label>
         {metadata === "student" && classOptions.length > 0 && (
           <select
             value={classFilter}
             onChange={(event) => setClassFilter(event.target.value)}
-            className="h-9 rounded-md border border-slate-200 bg-white px-2 text-sm text-slate-700 focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8] focus:outline-none"
+            className="h-9 rounded-md border border-gray-200 bg-white px-2 text-sm text-gray-700 focus:border-gray-400 focus:ring-1 focus:ring-gray-200 focus:outline-none"
             aria-label="Nach Klasse filtern"
           >
             <option value="all">Alle Klassen</option>
@@ -1080,7 +1080,7 @@ function MultiSelectField({
           <select
             value={groupFilter}
             onChange={(event) => setGroupFilter(event.target.value)}
-            className="h-9 rounded-md border border-slate-200 bg-white px-2 text-sm text-slate-700 focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8] focus:outline-none"
+            className="h-9 rounded-md border border-gray-200 bg-white px-2 text-sm text-gray-700 focus:border-gray-400 focus:ring-1 focus:ring-gray-200 focus:outline-none"
             aria-label="Nach Gruppe filtern"
           >
             <option value="all">Alle Gruppen</option>
@@ -1098,7 +1098,7 @@ function MultiSelectField({
           type="button"
           onClick={allVisibleSelected ? clearVisible : selectVisible}
           disabled={visibleIds.length === 0}
-          className="rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-700 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {allVisibleSelected ? "Sichtbare abwählen" : "Sichtbare auswählen"}
         </button>
@@ -1106,7 +1106,7 @@ function MultiSelectField({
           <button
             type="button"
             onClick={() => onChange([])}
-            className="rounded-md px-2.5 py-1.5 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800"
+            className="rounded-md px-2.5 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-800"
           >
             Auswahl leeren
           </button>
@@ -1119,20 +1119,20 @@ function MultiSelectField({
               setClassFilter("all");
               setGroupFilter("all");
             }}
-            className="rounded-md px-2.5 py-1.5 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800"
+            className="rounded-md px-2.5 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-800"
           >
             Filter zurücksetzen
           </button>
         )}
       </div>
 
-      <div className="max-h-72 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2">
+      <div className="max-h-72 overflow-y-auto rounded-lg border border-gray-200 bg-white p-2">
         {options.length === 0 ? (
-          <div className="px-2 py-3 text-xs text-slate-500">
+          <div className="px-2 py-3 text-xs text-gray-500">
             Keine Einträge gefunden
           </div>
         ) : filteredOptions.length === 0 ? (
-          <div className="px-2 py-3 text-xs text-slate-500">
+          <div className="px-2 py-3 text-xs text-gray-500">
             Keine passenden Einträge gefunden
           </div>
         ) : (
@@ -1140,18 +1140,18 @@ function MultiSelectField({
             {filteredOptions.map((option) => (
               <label
                 key={option.id}
-                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
               >
                 <input
                   type="checkbox"
                   checked={selected.has(option.id)}
                   onChange={() => toggle(option.id)}
-                  className="h-4 w-4 rounded border-slate-300 text-[#5080D8] focus:ring-[#5080D8]"
+                  className="h-4 w-4 rounded border-gray-300 text-gray-900 focus:ring-gray-200"
                 />
                 <span className="min-w-0 flex-1">
                   <span className="block truncate">{option.name}</span>
                   {(option.schoolClass || option.groupName) && (
-                    <span className="block truncate text-[11px] text-slate-400">
+                    <span className="block truncate text-[11px] text-gray-400">
                       {[option.schoolClass, option.groupName]
                         .filter(Boolean)
                         .join(" · ")}

--- a/frontend/src/components/timetable/timetable-toolbar.tsx
+++ b/frontend/src/components/timetable/timetable-toolbar.tsx
@@ -10,9 +10,17 @@
  * to fit on one line at desktop widths.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { ReactNode } from "react";
-import { ChevronLeft, ChevronRight, MoreVertical, Plus } from "lucide-react";
+import {
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  MoreVertical,
+  Plus,
+} from "lucide-react";
+
+import { useClickOutside } from "~/lib/hooks/use-click-outside";
 
 export type TimetableView = "week" | "month" | "year" | "series";
 
@@ -81,12 +89,12 @@ export function TimetableToolbar({
   const showDensity = view === "week" && density && onDensityChange;
 
   return (
-    <div className="flex flex-col gap-3 border-b border-slate-200 bg-white px-4 py-3 sm:px-6 lg:flex-row lg:items-center lg:py-2.5">
+    <div className="flex flex-col gap-3 border-b border-gray-200 bg-white px-4 py-3 sm:px-6 lg:flex-row lg:items-center lg:py-2.5">
       {/* Segmented view tabs */}
       <div
         role="tablist"
         aria-label="Ansicht wählen"
-        className="grid w-full grid-cols-4 rounded-md bg-slate-100 p-0.5 sm:inline-flex sm:w-auto sm:items-center lg:self-auto"
+        className="grid w-full grid-cols-4 rounded-md bg-gray-100 p-0.5 sm:inline-flex sm:w-auto sm:items-center lg:self-auto"
       >
         {VIEW_TABS.map((tab) => {
           const isActive = view === tab.id;
@@ -97,10 +105,10 @@ export function TimetableToolbar({
               type="button"
               aria-selected={isActive}
               onClick={() => onViewChange(tab.id)}
-              className={`rounded px-2 py-1.5 text-[13px] font-medium transition-colors sm:px-3 sm:py-1 ${
+              className={`rounded px-2 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none sm:px-3 sm:py-1 ${
                 isActive
-                  ? "bg-white text-slate-900 shadow-sm"
-                  : "text-slate-600 hover:text-slate-900"
+                  ? "bg-white text-gray-900 shadow-sm"
+                  : "text-gray-600 hover:text-gray-900"
               }`}
             >
               {tab.label}
@@ -111,20 +119,20 @@ export function TimetableToolbar({
 
       {showRangeNav && (
         <div className="grid min-w-0 grid-cols-[2rem_minmax(0,1fr)_2rem] items-center gap-x-2 gap-y-2 sm:flex sm:gap-3">
-          <div className="hidden h-6 w-px bg-slate-200 lg:block" aria-hidden />
+          <div className="hidden h-6 w-px bg-gray-200 lg:block" aria-hidden />
 
           {/* Date navigator — ghost buttons, no borders */}
           <button
             type="button"
             onClick={onPrev}
             disabled={navDisabled}
-            className="order-1 inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-40"
+            className="order-1 inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40"
             aria-label="Vorheriger Zeitraum"
           >
             <ChevronLeft className="h-4 w-4" />
           </button>
 
-          <span className="order-2 min-w-0 text-center text-sm leading-tight font-semibold text-slate-900 tabular-nums sm:order-4 sm:truncate sm:text-left">
+          <span className="order-2 min-w-0 text-center text-sm leading-tight font-semibold text-gray-900 tabular-nums sm:order-4 sm:truncate sm:text-left">
             {rangeLabel}
           </span>
 
@@ -132,7 +140,7 @@ export function TimetableToolbar({
             type="button"
             onClick={onNext}
             disabled={navDisabled}
-            className="order-3 inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-40 sm:order-2"
+            className="order-3 inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40 sm:order-2"
             aria-label="Nächster Zeitraum"
           >
             <ChevronRight className="h-4 w-4" />
@@ -144,7 +152,7 @@ export function TimetableToolbar({
               type="button"
               onClick={onToday}
               disabled={navDisabled}
-              className="order-4 col-span-3 inline-flex h-8 items-center justify-self-center rounded-md border border-slate-200 px-2.5 text-[12px] font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 sm:order-3"
+              className="order-4 col-span-3 inline-flex h-8 items-center justify-self-center rounded-md border border-gray-200 px-2.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 sm:order-3"
             >
               Heute
             </button>
@@ -165,7 +173,7 @@ export function TimetableToolbar({
             <button
               type="button"
               onClick={onAddInstance}
-              className="inline-flex h-8 items-center gap-1 rounded-md bg-slate-900 px-2.5 text-[12px] font-medium text-white transition-colors hover:bg-slate-700"
+              className="inline-flex h-8 items-center gap-1 rounded-md bg-gray-900 px-2.5 text-xs font-medium text-white transition-colors hover:bg-gray-700"
             >
               <Plus className="h-3.5 w-3.5" />
               Termin
@@ -191,27 +199,7 @@ function DensityMenu({
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    function onDocClick(event: MouseEvent) {
-      if (
-        containerRef.current &&
-        event.target instanceof Node &&
-        !containerRef.current.contains(event.target)
-      ) {
-        setOpen(false);
-      }
-    }
-    function onKey(event: KeyboardEvent) {
-      if (event.key === "Escape") setOpen(false);
-    }
-    document.addEventListener("mousedown", onDocClick);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDocClick);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
+  useClickOutside(containerRef, () => setOpen(false), open);
 
   return (
     <div className="relative" ref={containerRef}>
@@ -221,7 +209,7 @@ function DensityMenu({
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label="Weitere Optionen"
-        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
       >
         <MoreVertical className="h-4 w-4" />
       </button>
@@ -229,10 +217,10 @@ function DensityMenu({
       {open && (
         <div
           role="menu"
-          className="absolute right-0 z-30 mt-2 w-56 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-md"
+          className="absolute right-0 z-30 mt-2 w-56 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg"
         >
-          <div className="border-b border-slate-100 px-3 py-2">
-            <p className="text-[10px] font-semibold tracking-wider text-slate-500 uppercase">
+          <div className="border-b border-gray-100 px-3 py-2">
+            <p className="text-[10px] font-semibold tracking-wider text-gray-500 uppercase">
               Zeilenhöhe
             </p>
           </div>
@@ -248,15 +236,13 @@ function DensityMenu({
                   onDensityChange(opt.value);
                   setOpen(false);
                 }}
-                className={`flex w-full items-center justify-between px-3 py-2 text-[12px] font-medium transition-colors hover:bg-slate-50 ${
-                  isActive ? "text-slate-900" : "text-slate-600"
+                className={`flex w-full items-center justify-between px-3 py-2 text-xs font-medium transition-colors hover:bg-gray-50 ${
+                  isActive ? "text-gray-900" : "text-gray-600"
                 }`}
               >
                 <span>{opt.label}</span>
                 {isActive && (
-                  <span className="text-[12px] text-slate-900" aria-hidden>
-                    ✓
-                  </span>
+                  <Check className="h-4 w-4 text-gray-900" aria-hidden />
                 )}
               </button>
             );

--- a/frontend/src/components/timetable/weekly-calendar-grid.tsx
+++ b/frontend/src/components/timetable/weekly-calendar-grid.tsx
@@ -30,10 +30,10 @@ import type { EnrichedInstance } from "~/lib/timetable-types";
 
 import { InstanceBlock } from "./instance-block";
 
-// Grid template columns: narrow time gutter + 7 day columns (Mo-So).
-// Mobile uses a 40px gutter so the day cells get ~48px each on iPhone SE.
+// Grid template columns: narrow time gutter + day columns. Mobile shows a
+// single day column (gutter + 1fr) via the day strip; sm+ shows all seven.
 const GRID_COLS_CLASS =
-  "grid-cols-[40px_repeat(7,minmax(0,1fr))] sm:grid-cols-[64px_repeat(7,minmax(0,1fr))]";
+  "grid-cols-[40px_minmax(0,1fr)] sm:grid-cols-[64px_repeat(7,minmax(0,1fr))]";
 
 interface WeeklyCalendarGridProps {
   weekDays: Date[]; // Mo-So (7 dates)
@@ -99,11 +99,61 @@ export function WeeklyCalendarGrid({
   }, []);
   void nowTick;
 
+  // Mobile (< sm) shows one day at a time, picked via the day strip. Default
+  // to today when it falls in the visible week, otherwise Monday.
+  const todayIndex = weekDays.findIndex((day) => toISODate(day) === todayISO);
+  const [selectedDayIndex, setSelectedDayIndex] = useState(
+    todayIndex >= 0 ? todayIndex : 0,
+  );
+  const safeSelectedIndex = Math.min(
+    Math.max(selectedDayIndex, 0),
+    weekDays.length - 1,
+  );
+
   return (
-    <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
-      {/* Sticky day header */}
+    <div className="moto-content-surface overflow-hidden rounded-2xl border">
+      {/* Mobile day strip — tap a day to switch (single-day view < sm) */}
+      <div className="flex gap-1 border-b border-gray-200 bg-white p-2 sm:hidden">
+        {weekDays.map((day, index) => {
+          const iso = toISODate(day);
+          const isToday = iso === todayISO;
+          const isSelected = index === safeSelectedIndex;
+          return (
+            <button
+              key={iso}
+              type="button"
+              onClick={() => setSelectedDayIndex(index)}
+              aria-pressed={isSelected}
+              className={`flex min-w-0 flex-1 flex-col items-center gap-0.5 rounded-lg px-1 py-1.5 transition-colors focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none ${
+                isSelected
+                  ? "bg-gray-900 text-white"
+                  : "text-gray-600 hover:bg-gray-100"
+              }`}
+            >
+              <span
+                className={`text-[10px] font-medium tracking-wide uppercase ${
+                  isSelected ? "text-white/80" : "text-gray-500"
+                }`}
+              >
+                {getGermanWeekdayShort(day)}
+              </span>
+              <span className="text-sm font-semibold tabular-nums">
+                {String(day.getDate()).padStart(2, "0")}
+              </span>
+              {isToday && !isSelected && (
+                <span
+                  className="h-1 w-1 rounded-full bg-[#FF3130]"
+                  aria-hidden
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Sticky day header (desktop — mobile uses the day strip above) */}
       <div
-        className={`grid h-[52px] border-b border-slate-200 bg-white sm:h-14 ${GRID_COLS_CLASS}`}
+        className={`hidden h-[52px] border-b border-gray-200 bg-white sm:grid sm:h-14 ${GRID_COLS_CLASS}`}
       >
         <div aria-hidden />
         {weekDays.map((day) => {
@@ -112,21 +162,21 @@ export function WeeklyCalendarGrid({
           return (
             <div
               key={iso}
-              className="flex min-w-0 flex-col items-center justify-center gap-0.5 border-l border-slate-200 px-1 py-1 sm:flex-row sm:gap-2 sm:px-2 sm:py-2"
+              className="flex min-w-0 flex-col items-center justify-center gap-0.5 border-l border-gray-200 px-1 py-1 sm:flex-row sm:gap-2 sm:px-2 sm:py-2"
             >
-              <span className="text-[10px] font-medium tracking-wide text-slate-500 uppercase sm:text-[11px]">
+              <span className="text-[10px] font-medium tracking-wide text-gray-500 uppercase sm:text-[11px]">
                 {getGermanWeekdayShort(day)}
               </span>
               {isToday ? (
                 <span
-                  className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-slate-900 text-[11px] font-semibold text-white tabular-nums sm:h-6 sm:w-6 sm:text-[12px]"
+                  className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-gray-900 text-[11px] font-semibold text-white tabular-nums sm:h-6 sm:w-6 sm:text-xs"
                   aria-label={formatDayHeader(day)}
                 >
                   {day.getDate()}
                 </span>
               ) : (
                 <span
-                  className="text-[12px] font-semibold text-slate-900 tabular-nums sm:text-[14px]"
+                  className="text-xs font-semibold text-gray-900 tabular-nums sm:text-sm"
                   aria-label={formatDayHeader(day)}
                 >
                   {String(day.getDate()).padStart(2, "0")}
@@ -142,13 +192,13 @@ export function WeeklyCalendarGrid({
         <div className={`grid ${GRID_COLS_CLASS}`}>
           {/* Time gutter */}
           <div
-            className="border-r border-slate-200 bg-slate-50"
+            className="border-r border-gray-200 bg-gray-50"
             style={{ height: `${gridHeightPx}px` }}
           >
             {hours.slice(0, -1).map((hour) => (
               <div
                 key={hour}
-                className="flex items-start justify-end px-1 pt-1 text-[10px] font-medium text-slate-400 sm:px-2 sm:text-[11px]"
+                className="flex items-start justify-end px-1 pt-1 text-[10px] font-medium text-gray-400 sm:px-2 sm:text-[11px]"
                 style={{ height: `${hourHeightPx}px` }}
               >
                 {String(hour).padStart(2, "0")}:00
@@ -157,7 +207,7 @@ export function WeeklyCalendarGrid({
           </div>
 
           {/* Day columns */}
-          {weekDays.map((day) => {
+          {weekDays.map((day, dayIndex) => {
             const iso = toISODate(day);
             const isToday = iso === todayISO;
             const dayInstances = grouped.get(iso) ?? [];
@@ -173,7 +223,7 @@ export function WeeklyCalendarGrid({
             return (
               <div
                 key={iso}
-                className={`relative min-w-0 border-l border-slate-200 ${isToday ? "bg-slate-50/60" : ""}`}
+                className={`relative min-w-0 border-l border-gray-200 ${isToday ? "bg-gray-50/60" : ""} ${dayIndex === safeSelectedIndex ? "" : "hidden sm:block"}`}
                 style={{ height: `${gridHeightPx}px` }}
               >
                 {/* Hour grid lines */}
@@ -182,7 +232,7 @@ export function WeeklyCalendarGrid({
                   return (
                     <div
                       key={hour}
-                      className="pointer-events-none absolute right-0 left-0 border-t border-slate-100"
+                      className="pointer-events-none absolute right-0 left-0 border-t border-gray-100"
                       style={{ top: `${top}px` }}
                     />
                   );
@@ -195,7 +245,7 @@ export function WeeklyCalendarGrid({
                   return (
                     <div
                       key={`half-${hour}`}
-                      className="pointer-events-none absolute right-0 left-0 border-t border-slate-50"
+                      className="pointer-events-none absolute right-0 left-0 border-t border-gray-50"
                       style={{ top: `${top}px` }}
                     />
                   );
@@ -238,10 +288,11 @@ export function WeeklyCalendarGrid({
                   </>
                 )}
 
-                {/* Empty-state hint (hidden on mobile: column too narrow) */}
-                {dayInstances.length === 0 && (
+                {/* Per-column hint — only on a genuinely empty day, not when
+                    the whole-week empty overlay is showing. */}
+                {dayInstances.length === 0 && !emptyState && (
                   <div className="pointer-events-none absolute inset-0 hidden items-center justify-center sm:flex">
-                    <span className="text-[11px] text-slate-400 italic">
+                    <span className="text-[11px] text-gray-400 italic">
                       Keine Aktivitäten
                     </span>
                   </div>
@@ -253,11 +304,11 @@ export function WeeklyCalendarGrid({
 
         {emptyState && (
           <div className="pointer-events-none absolute inset-x-0 top-1/2 z-20 flex -translate-y-1/2 justify-center px-4">
-            <div className="max-w-sm rounded-lg border border-slate-200 bg-white/95 px-4 py-3 text-center shadow-sm backdrop-blur">
-              <h3 className="text-sm font-semibold text-slate-900">
+            <div className="max-w-sm rounded-2xl border border-gray-200 bg-white/95 px-4 py-3 text-center shadow-sm backdrop-blur">
+              <h3 className="text-sm font-semibold text-gray-900">
                 {emptyState.title}
               </h3>
-              <p className="mt-1 text-xs leading-relaxed text-slate-500">
+              <p className="mt-1 text-xs leading-relaxed text-gray-500">
                 {emptyState.description}
               </p>
             </div>

--- a/frontend/src/components/timetable/year-planner-grid.tsx
+++ b/frontend/src/components/timetable/year-planner-grid.tsx
@@ -47,35 +47,35 @@ export function YearPlannerGrid({
         return (
           <section
             key={`${month.getFullYear()}-${month.getMonth()}`}
-            className="overflow-hidden rounded-lg border border-slate-200 bg-white"
+            className="moto-content-surface overflow-hidden rounded-2xl border"
           >
             <button
               type="button"
               onClick={() => onMonthClick(month)}
-              className="flex w-full items-center justify-between gap-3 border-b border-slate-200 px-3 py-2 text-left transition-colors hover:bg-slate-50"
+              className="flex w-full items-center justify-between gap-3 border-b border-gray-200 px-3 py-2 text-left transition-colors hover:bg-gray-50"
             >
               <div>
-                <h2 className="text-sm font-semibold text-slate-900">
+                <h2 className="text-sm font-semibold text-gray-900">
                   {month.toLocaleDateString("de-DE", { month: "long" })}
                 </h2>
-                <p className="text-[11px] text-slate-500">
+                <p className="text-[11px] text-gray-500">
                   {monthInstances.length} Termin
                   {monthInstances.length === 1 ? "" : "e"}
                 </p>
               </div>
               {conflictCount > 0 && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-[#FCEFD9] px-2 py-1 text-[10px] font-semibold text-[#F78C10]">
+                <span className="inline-flex items-center gap-1 rounded-full bg-[#EAB308]/10 px-2 py-1 text-[10px] font-semibold text-[#EAB308]">
                   <AlertTriangle className="h-3 w-3" aria-hidden />
                   {conflictCount}
                 </span>
               )}
             </button>
 
-            <div className="grid grid-cols-7 border-b border-slate-100 px-2 pt-2">
+            <div className="grid grid-cols-7 border-b border-gray-100 px-2 pt-2">
               {monthDays.slice(0, 7).map((day) => (
                 <div
                   key={getGermanWeekdayShort(day)}
-                  className="pb-1 text-center text-[10px] font-medium text-slate-400"
+                  className="pb-1 text-center text-[10px] font-medium text-gray-400"
                 >
                   {getGermanWeekdayShort(day)}
                 </div>
@@ -97,15 +97,15 @@ export function YearPlannerGrid({
                     key={iso}
                     type="button"
                     onClick={() => onDayClick(iso)}
-                    className={`relative flex aspect-square min-h-8 items-center justify-center rounded text-[11px] font-medium tabular-nums transition-colors hover:bg-slate-100 ${
-                      outsideMonth ? "text-slate-300" : "text-slate-700"
-                    } ${dayInstances.length > 0 ? "bg-slate-50" : ""}`}
+                    className={`relative flex aspect-square min-h-8 items-center justify-center rounded text-[11px] font-medium tabular-nums transition-colors hover:bg-gray-100 ${
+                      outsideMonth ? "text-gray-300" : "text-gray-700"
+                    } ${dayInstances.length > 0 ? "bg-gray-50" : ""}`}
                     aria-label={`${iso}: ${dayInstances.length} Termine`}
                   >
                     <span
                       className={
                         isToday
-                          ? "flex h-5 w-5 items-center justify-center rounded-full bg-slate-900 text-white"
+                          ? "flex h-5 w-5 items-center justify-center rounded-full bg-gray-900 text-white"
                           : ""
                       }
                     >
@@ -114,7 +114,7 @@ export function YearPlannerGrid({
                     {dayInstances.length > 0 && (
                       <span
                         className={`absolute bottom-1 h-1.5 w-1.5 rounded-full ${
-                          hasConflicts ? "bg-[#F78C10]" : "bg-[#83CD2D]"
+                          hasConflicts ? "bg-[#EAB308]" : "bg-[#83CD2D]"
                         }`}
                         aria-hidden
                       />
@@ -125,7 +125,7 @@ export function YearPlannerGrid({
             </div>
 
             {monthInstances.length === 0 && (
-              <div className="flex items-center gap-1 border-t border-slate-100 px-3 py-2 text-[11px] text-slate-400">
+              <div className="flex items-center gap-1 border-t border-gray-100 px-3 py-2 text-[11px] text-gray-400">
                 <CalendarDays className="h-3 w-3" aria-hidden />
                 Leer
               </div>

--- a/frontend/src/lib/hooks/use-click-outside.test.ts
+++ b/frontend/src/lib/hooks/use-click-outside.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { useClickOutside } from "./use-click-outside";
+
+function mountContainer() {
+  const container = document.createElement("div");
+  const child = document.createElement("button");
+  container.appendChild(child);
+  document.body.appendChild(container);
+  return { container, child };
+}
+
+describe("useClickOutside", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("calls onDismiss on a mousedown outside the container", () => {
+    const { container } = mountContainer();
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    const onDismiss = vi.fn();
+
+    renderHook(() => useClickOutside({ current: container }, onDismiss, true));
+
+    outside.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onDismiss on a mousedown inside the container", () => {
+    const { container, child } = mountContainer();
+    const onDismiss = vi.fn();
+
+    renderHook(() => useClickOutside({ current: container }, onDismiss, true));
+
+    child.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("calls onDismiss when Escape is pressed", () => {
+    const { container } = mountContainer();
+    const onDismiss = vi.fn();
+
+    renderHook(() => useClickOutside({ current: container }, onDismiss, true));
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not attach listeners when disabled", () => {
+    const { container } = mountContainer();
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    const onDismiss = vi.fn();
+
+    renderHook(() => useClickOutside({ current: container }, onDismiss, false));
+
+    outside.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/hooks/use-click-outside.ts
+++ b/frontend/src/lib/hooks/use-click-outside.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from "react";
+import type { RefObject } from "react";
+
+/**
+ * Calls `onDismiss` when a pointer press lands outside `ref`, or when the
+ * Escape key is pressed. Centralises the click-outside + Escape handling that
+ * the timetable's three header dropdowns (density menu, period switcher,
+ * planning menu) each used to hand-roll in their own `useEffect`.
+ *
+ * Pass the element that wraps BOTH the trigger and the popover as `ref` so
+ * clicking the trigger to close does not register as an outside press.
+ *
+ * @param ref       Container element ref (trigger + popover).
+ * @param onDismiss Called on an outside press or Escape.
+ * @param enabled   Gate the listeners — pass the open state so the handlers
+ *                  only run while the menu is open. Defaults to `true`.
+ *
+ * SSR-safe: the effect only runs in the browser.
+ */
+export function useClickOutside<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  onDismiss: () => void,
+  enabled = true,
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handlePointer = (event: MouseEvent | TouchEvent) => {
+      const el = ref.current;
+      if (el && event.target instanceof Node && !el.contains(event.target)) {
+        onDismiss();
+      }
+    };
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onDismiss();
+    };
+
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("touchstart", handlePointer);
+    document.addEventListener("keydown", handleKey);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("touchstart", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [ref, onDismiss, enabled]);
+}


### PR DESCRIPTION
## Summary

UI polish for the Stundenplan (timetable) feature, bringing it in line with the project's brand design language (Florian's newest components), plus a mobile-friendly weekly view.

Refs #1522 — this PR does **not** close the issue.

## What changed

**Colors**
- Unified the four divergent conflict/warning palettes onto the single brand amber `#EAB308`
- Error/success/warning banners now use the brand pattern (`#FF3130`/`#CC2626` red, `#83CD2D` green, `#EAB308` amber)
- Generic blue `#5080D8` used as a form focus/selection/checkbox state in the event modal → neutral gray (activity category colors are semantic and stay)
- `slate-*` → `gray-*` swept across the feature for brand consistency

**Structure & reuse**
- Calendar-period modal: legacy `Modal` → shared `FormModal` primitive (mobile bottom-sheet)
- New shared `useClickOutside` hook (+ test), adopted by the density, period-switcher and planning dropdowns (replaces three hand-rolled click-outside effects)
- Raw glyphs → lucide icons (`Check`, `ChevronDown`, `Plus`)

**Polish**
- `moto-content-surface` + `rounded-2xl` on grid/loading cards
- Type scale instead of bespoke pixel sizes; `focus-visible` rings; de-duplicated week-view empty state; skeleton while the period switcher loads

**Mobile**
- The weekly view now shows a tappable day strip with one full-width day on small screens instead of seven cramped columns; desktop keeps all seven columns

## Notes
- One existing test (`period-switcher-dropdown.test.tsx`) encoded "hide the switcher while loading"; it was updated to reflect the new skeleton behavior.

## Verification
- `pnpm run check`: clean (0 warnings, 0 type errors)
- 36/36 timetable + page + hook tests pass
- Browser-verified on desktop and mobile across all views, modals and dropdowns
