### PR TITLE
Add scroll-to-error handling to student create modal

### DIFF
--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Check, Lock, Plus, Trash2 } from "lucide-react";
 import { Turnstile } from "@marsidev/react-turnstile";
 import { useTenant } from "~/components/tenant/tenant-provider";
@@ -21,6 +21,7 @@ import {
   type PublicFormSchema,
 } from "~/lib/enrollment-form-schema-api";
 import { createLogger } from "~/lib/logger";
+import { useScrollToFirstError } from "~/lib/hooks/use-scroll-to-error";
 
 const logger = createLogger({ component: "EnrollmentForm" });
 
@@ -142,32 +143,13 @@ export function EnrollmentForm({
   // (guardian_email, children_0_first_name, ...). Drives the red border +
   // inline message on the offending input; rebuilt on every submit.
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
-  // Scroll the top error banner into view on every submit attempt that
-  // leaves an error showing. The form is long (guardian + N children +
-  // offerings) with the submit button at the bottom, so an error rendered
-  // only at the top is easy to miss. Keyed on a per-attempt counter rather
-  // than the error string (the app's shared useScrollToError hook) so a
-  // repeated submit with the *same* unchanged message still scrolls back
-  // up. On a successful submit the banner isn't rendered, so the ref is
-  // null and the scroll is a no-op.
-  const errorRef = useRef<HTMLDivElement>(null);
-  const formRef = useRef<HTMLFormElement>(null);
-  const [submitAttempt, setSubmitAttempt] = useState(0);
-
-  useEffect(() => {
-    if (submitAttempt === 0) return;
-    // Scroll to the first invalid field (every marked input/select/checkbox
-    // carries aria-invalid) so the parent lands on the actual problem and its
-    // inline message, not just the top banner. Server-level errors (e.g.
-    // offering full) mark no field, so fall back to the banner.
-    const firstInvalid = formRef.current?.querySelector<HTMLElement>(
-      '[aria-invalid="true"]',
-    );
-    (firstInvalid ?? errorRef.current)?.scrollIntoView({
-      behavior: "smooth",
-      block: "center",
-    });
-  }, [submitAttempt]);
+  // Scroll to the first invalid field on every submit attempt that leaves an
+  // error showing. The form is long (guardian + N children + offerings) with
+  // the submit button at the bottom, so an error rendered above is easy to
+  // miss. `scrollToError()` is keyed on a per-attempt counter, so a repeated
+  // submit with the *same* unchanged message still scrolls back to it; on a
+  // successful submit nothing is marked invalid so it's a no-op.
+  const { formRef, errorRef, scrollToError } = useScrollToFirstError();
 
   const [guardianFirstName, setGuardianFirstName] = useState("");
   const [guardianLastName, setGuardianLastName] = useState("");
@@ -347,7 +329,7 @@ export function EnrollmentForm({
     // submit produces the same error message as the previous one. Covers
     // every synchronous validation failure below (error is set in the same
     // batch). On success no error is set, so the scroll is a no-op.
-    setSubmitAttempt((n) => n + 1);
+    scrollToError();
 
     if (previewMode) {
       setError(
@@ -622,7 +604,7 @@ export function EnrollmentForm({
       setError(message);
       // A server-side rejection resolves after the synchronous attempt bump
       // above, so bump again to scroll the late-arriving error into view.
-      setSubmitAttempt((n) => n + 1);
+      scrollToError();
     } finally {
       setSubmitting(false);
     }

--- a/frontend/src/components/students/student-create-modal.test.tsx
+++ b/frontend/src/components/students/student-create-modal.test.tsx
@@ -456,6 +456,31 @@ describe("StudentCreateModal", () => {
     });
   });
 
+  it("passes a scroll-to-error callback to the submit helper", async () => {
+    mockOnCreate.mockResolvedValue(undefined);
+
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    const form = screen.getByTestId("modal").querySelector("form");
+    await act(async () => {
+      fireEvent.submit(form!);
+    });
+
+    await waitFor(() => {
+      expect(handleStudentFormSubmit).toHaveBeenCalled();
+    });
+    // 7th arg drives scroll-to-first-error on a failed submit (shared with the
+    // parents' enrollment form via useScrollToFirstError).
+    const onError = vi.mocked(handleStudentFormSubmit).mock.calls[0]?.[6];
+    expect(onError).toBeTypeOf("function");
+  });
+
   it("updates form data when input changes", async () => {
     render(
       <StudentCreateModal

--- a/frontend/src/components/students/student-create-modal.tsx
+++ b/frontend/src/components/students/student-create-modal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Users, Plus, Search, Trash2, Clock } from "lucide-react";
 import { Modal } from "~/components/ui/modal";
+import { useScrollToFirstError } from "~/lib/hooks/use-scroll-to-error";
 import type { Student } from "@/lib/api";
 import {
   PersonalInfoSection,
@@ -177,6 +178,10 @@ export function StudentCreateModal({
   // result (the added guardian) instead of jumping past it.
   const guardianSectionRef = useRef<HTMLElement>(null);
   const pendingGuardianScrollRef = useRef(false);
+  // Scroll the form to the first invalid field on a failed submit — the modal
+  // body scrolls and the submit button sits at the bottom, so an error above
+  // is otherwise easy to miss. Same behaviour as the parents' enrollment form.
+  const { formRef, errorRef, scrollToError } = useScrollToFirstError();
 
   // Reset form when modal opens/closes
   useEffect(() => {
@@ -292,6 +297,7 @@ export function StudentCreateModal({
       onCreate,
       setSaveLoading,
       setErrors,
+      scrollToError,
     );
   };
 
@@ -325,13 +331,17 @@ export function StudentCreateModal({
     <>
       <Modal isOpen={isOpen} onClose={onClose} title="Neuer Schüler">
         <form
+          ref={formRef}
           onSubmit={handleSubmit}
           noValidate
           className="space-y-4 md:space-y-6"
         >
           {/* Submit Error */}
           {errors.submit && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-2 md:p-3">
+            <div
+              ref={errorRef}
+              className="rounded-lg border border-red-200 bg-red-50 p-2 md:p-3"
+            >
               <p className="text-xs text-red-800 md:text-sm">{errors.submit}</p>
             </div>
           )}

--- a/frontend/src/components/students/student-form-fields.tsx
+++ b/frontend/src/components/students/student-form-fields.tsx
@@ -127,6 +127,7 @@ function TextInput({
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        aria-invalid={error ? true : undefined}
         className={`block w-full rounded-lg border px-3 py-2 text-sm transition-colors ${
           error
             ? "border-red-300 bg-red-50"
@@ -403,6 +404,7 @@ export function PrivacyConsentSection({
             type="number"
             min="1"
             max="31"
+            aria-invalid={errors.data_retention_days ? true : undefined}
             value={formData.data_retention_days ?? ""}
             onChange={(e) => {
               const inputValue = e.target.value;

--- a/frontend/src/lib/hooks/use-scroll-to-error.ts
+++ b/frontend/src/lib/hooks/use-scroll-to-error.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export function useScrollToError(error: string | null | undefined) {
   const errorRef = useRef<HTMLDivElement>(null);
@@ -10,4 +10,41 @@ export function useScrollToError(error: string | null | undefined) {
   }, [error]);
 
   return errorRef;
+}
+
+/**
+ * Scroll-to-first-error for long, multi-field forms.
+ *
+ * Attach `formRef` to the <form> and `errorRef` to the top-level error banner,
+ * mark every invalid input/select/checkbox with `aria-invalid="true"`, then
+ * call `scrollToError()` after errors are set — both on client-side validation
+ * failures and on late-arriving server errors. Each call scrolls the first
+ * `[aria-invalid="true"]` field into view so the user lands on the actual
+ * problem and its inline message, falling back to the banner for server-level
+ * errors that mark no field.
+ *
+ * Unlike {@link useScrollToError} (which only scrolls a banner and is keyed on
+ * the error string), this targets the offending field and is keyed on a
+ * per-attempt counter, so a repeated submit with the same unchanged error
+ * still scrolls back to it.
+ */
+export function useScrollToFirstError() {
+  const formRef = useRef<HTMLFormElement>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    if (attempt === 0) return;
+    const firstInvalid = formRef.current?.querySelector<HTMLElement>(
+      '[aria-invalid="true"]',
+    );
+    (firstInvalid ?? errorRef.current)?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
+  }, [attempt]);
+
+  const scrollToError = useCallback(() => setAttempt((n) => n + 1), []);
+
+  return { formRef, errorRef, scrollToError };
 }

--- a/frontend/src/lib/student-form-validation.ts
+++ b/frontend/src/lib/student-form-validation.ts
@@ -102,6 +102,8 @@ export function validateStudentForm(
  * @param onSubmit - Submit handler
  * @param setLoading - Loading state setter
  * @param setErrors - Error state setter
+ * @param onError - Optional; fired after errors are set (client validation
+ *   failure or server rejection) so callers can scroll to the first error.
  */
 export async function handleStudentFormSubmit(
   e: React.FormEvent,
@@ -110,10 +112,12 @@ export async function handleStudentFormSubmit(
   onSubmit: (data: Partial<Student>) => Promise<void>,
   setLoading: (loading: boolean) => void,
   setErrors: (errors: Record<string, string>) => void,
+  onError?: () => void,
 ): Promise<void> {
   e.preventDefault();
 
   if (!validateForm()) {
+    onError?.();
     return;
   }
 
@@ -123,6 +127,7 @@ export async function handleStudentFormSubmit(
   } catch (error) {
     logger.error("error saving student", { error: String(error) });
     setErrors({ submit: toSubmitErrorMessage(error) });
+    onError?.();
   } finally {
     setLoading(false);
   }


### PR DESCRIPTION
## Summary

This PR adds scroll-to-error handling to the student create modal so failed submissions bring the first invalid field or submit error into view.

To avoid duplicating the enrollment form logic, the existing behavior is moved into a shared `useScrollToFirstError` hook and reused by both forms.

## Changes

- Adds `useScrollToFirstError` for long forms with inline validation errors.
- Wires the hook into `StudentCreateModal` and marks invalid student form fields with `aria-invalid`.
- Refactors the enrollment form to use the shared hook instead of local scroll state.
- Adds a regression test that verifies the student submit helper receives the error-scroll callback.

## Checks

- `cd frontend && pnpm run check`
- `cd frontend && pnpm test:run src/components/students/student-create-modal.test.tsx`
- Pre-push hook passed `frontend-knip` and `frontend-check`