### PR TITLE
fix: correct logo aspect ratio and remove glow effect

### DIFF
--- a/frontend/src/components/dashboard/header/brand-link.tsx
+++ b/frontend/src/components/dashboard/header/brand-link.tsx
@@ -20,17 +20,15 @@ export function BrandLink({
 }: BrandLinkProps) {
   return (
     <Link href={href} className="group flex items-center space-x-3">
-      <div className="relative transition-transform duration-200 group-hover:scale-110">
+      <div className="transition-transform duration-200 group-hover:scale-110">
         <Image
           src="/images/moto_transparent.png"
           alt="moto"
-          width={40}
-          height={40}
-          className="h-9 w-9"
+          width={907}
+          height={646}
+          className="h-9 w-auto"
           priority
         />
-        {/* Subtle glow effect */}
-        <div className="absolute inset-0 -z-10 h-9 w-9 rounded-full bg-gradient-to-br from-[#5080d8]/20 to-[#83cd2d]/20 blur-sm" />
       </div>
 
       <div className="flex items-center space-x-3">

--- a/frontend/src/components/dashboard/page-header.tsx
+++ b/frontend/src/components/dashboard/page-header.tsx
@@ -25,8 +25,8 @@ export function PageHeader({
             <Image
               src="/images/moto_transparent.png"
               alt="Logo"
-              width={40}
-              height={40}
+              width={907}
+              height={646}
               className="h-10 w-auto"
             />
           </div>


### PR DESCRIPTION
Das hier ist ein Vorschlag von mir — mir ist aufgefallen, dass das Logo gequetscht aussah, und ich finde es ohne den Gradient-Glow insgesamt cleaner. Wenn ihr das anders seht, können wir gern drüber reden.

### Was & Warum

Das Logo (`moto_transparent.png`, real **907 × 646 px**) war im Dashboard-Header und in den Page-Headern mit `40 × 40` deklariert und wurde dadurch in ein Quadrat gequetscht. Jetzt werden die echten Dimensionen mit `h-* w-auto` verwendet, sodass es im korrekten Seitenverhältnis rendert. Den Gradient-Glow hinter dem Logo habe ich gleich mitentfernt, weil der Header für mich so schlichter und sauberer wirkt.

### Änderungen

- `brand-link.tsx`: Dimensionen `40×40 → 907×646`, `h-9 w-9 → h-9 w-auto`, Glow-`div` + `relative`-Wrapper entfernt
- `page-header.tsx`: Dimensionen `40×40 → 907×646` (CSS `h-10 w-auto` war schon korrekt)

### Tests

- `pnpm run check` (oxlint + tsc) ✅
- `page-header.test.tsx` → 9/9 ✅
- Reines UI-Update, keine Logik- oder API-Änderung



<img width="1785" height="1999" alt="demo-school localhost_3000_students_search_year=2" src="https://github.com/user-attachments/assets/d4fdacda-9ae7-426e-b530-1ef2d233bca1" />
<img width="1785" height="1999" alt="demo-school localhost_3001_dashboard" src="https://github.com/user-attachments/assets/7335369c-58ef-4667-96f2-f524a733d1fc" />
