### PR TITLE
Improve timetable planning UX

### DIFF
--- a/frontend/src/components/timetable/instance-block.tsx
+++ b/frontend/src/components/timetable/instance-block.tsx
@@ -16,7 +16,10 @@
 
 import { TriangleAlert } from "lucide-react";
 
-import { getActivityLightTint } from "~/lib/timetable-helpers";
+import {
+  getActivityColor,
+  getActivityLightTint,
+} from "~/lib/timetable-helpers";
 import type { EnrichedInstance } from "~/lib/timetable-types";
 
 interface InstanceBlockProps {
@@ -109,6 +112,19 @@ export function InstanceBlock({
           >
             {instance.startTime} – {instance.endTime}
             {!isCompact && instance.roomName ? ` · ${instance.roomName}` : ""}
+          </div>
+        )}
+
+        {!isCompact && instance.isSpontaneous && !isCancelled && (
+          <div className="truncate text-[10px] font-semibold text-gray-600">
+            <span
+              className="mr-1 inline-block h-1.5 w-1.5 rounded-full align-middle"
+              style={{
+                backgroundColor: getActivityColor(instance.activityType),
+              }}
+              aria-hidden
+            />
+            Spontan
           </div>
         )}
 

--- a/frontend/src/components/timetable/instance-detail-slide-over.test.tsx
+++ b/frontend/src/components/timetable/instance-detail-slide-over.test.tsx
@@ -117,7 +117,30 @@ describe("InstanceDetailSlideOver", () => {
       expect.objectContaining({ id: "42" }),
     );
 
-    expect(onAttendancePatch).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: "Als anwesend markieren" }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Kind abmelden" })[0]!,
+    );
+    await waitFor(() =>
+      expect(onAttendancePatch).toHaveBeenCalledWith("42", "21", {
+        status: "absent",
+        substatus: "excused",
+      }),
+    );
+  });
+
+  it("marks spontaneous instances in the detail header", () => {
+    render(
+      <InstanceDetailSlideOver
+        instance={instance({ isSpontaneous: true })}
+        onClose={vi.fn()}
+        onLifecycleAction={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Spontan")).toBeInTheDocument();
   });
 
   it("handles active, cancelled and fallback student states", async () => {

--- a/frontend/src/components/timetable/instance-detail-slide-over.tsx
+++ b/frontend/src/components/timetable/instance-detail-slide-over.tsx
@@ -109,14 +109,17 @@ function StatusBadge({ status }: StatusBadgeProps) {
   );
 }
 
-function attendanceLabel(status: InstanceStudentSummary["status"]): string {
+function attendanceLabel(
+  status: InstanceStudentSummary["status"],
+  plannedContext = false,
+): string {
   switch (status) {
     case "expected":
       return "Erwartet";
     case "present":
       return "Anwesend";
     case "absent":
-      return "Fehlt";
+      return plannedContext ? "Abgemeldet" : "Fehlt";
   }
 }
 
@@ -249,6 +252,11 @@ export function InstanceDetailSlideOver({
                 <div className="flex items-center gap-2">
                   <SlideOverTitle>{instance.title}</SlideOverTitle>
                   <StatusBadge status={instance.status} />
+                  {instance.isSpontaneous && (
+                    <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[9px] font-bold tracking-wide text-gray-600 uppercase">
+                      Spontan
+                    </span>
+                  )}
                   {(() => {
                     const tb = getActivityTypeBadge(instance.activityType);
                     return tb ? (
@@ -371,11 +379,13 @@ export function InstanceDetailSlideOver({
                       studentNames={studentNames}
                       pendingStudentId={pendingStudentId}
                       onAttendancePatch={
+                        instance.status === "planned" ||
                         instance.status === "active" ||
                         instance.status === "completed"
                           ? onAttendancePatch
                           : undefined
                       }
+                      instanceStatus={instance.status}
                       handleAttendancePatch={handleAttendancePatch}
                     />
                   ))}
@@ -508,6 +518,7 @@ function StudentGroup({
   studentNames,
   pendingStudentId,
   onAttendancePatch,
+  instanceStatus,
   handleAttendancePatch,
 }: {
   status: InstanceStudentSummary["status"];
@@ -515,16 +526,18 @@ function StudentGroup({
   studentNames: Map<string, string>;
   pendingStudentId: string | null;
   onAttendancePatch?: InstanceDetailSlideOverProps["onAttendancePatch"];
+  instanceStatus: InstanceStatus;
   handleAttendancePatch: (
     studentId: string,
     body: AttendancePatchBody,
   ) => Promise<void>;
 }) {
   if (students.length === 0) return null;
+  const isPlanned = instanceStatus === "planned";
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between text-[11px] font-bold tracking-wide text-gray-400 uppercase">
-        <span>{attendanceLabel(status)}</span>
+        <span>{attendanceLabel(status, isPlanned)}</span>
         <span>{students.length}</span>
       </div>
       {students.map((student) => (
@@ -540,7 +553,7 @@ function StudentGroup({
                 `Kind #${student.studentId}`}
             </div>
             <div className="text-[11px] text-gray-500">
-              {attendanceLabel(student.status)}
+              {attendanceLabel(student.status, isPlanned)}
               {student.substatus
                 ? ` • ${attendanceSubstatusLabel(student.substatus)}`
                 : ""}
@@ -549,7 +562,7 @@ function StudentGroup({
           </div>
           {onAttendancePatch && (
             <div className="flex shrink-0 items-center gap-1">
-              {student.status !== "present" && (
+              {!isPlanned && student.status !== "present" && (
                 <IconActionButton
                   icon={<Check className="h-3.5 w-3.5" />}
                   label="Als anwesend markieren"
@@ -567,14 +580,14 @@ function StudentGroup({
               {student.status !== "absent" && (
                 <IconActionButton
                   icon={<X className="h-3.5 w-3.5" />}
-                  label="Als fehlend markieren"
+                  label={isPlanned ? "Kind abmelden" : "Als fehlend markieren"}
                   tone="red"
                   isLoading={pendingStudentId === student.studentId}
                   disabled={pendingStudentId !== null}
                   onClick={() =>
                     void handleAttendancePatch(student.studentId, {
                       status: "absent",
-                      substatus: null,
+                      substatus: isPlanned ? "excused" : null,
                     })
                   }
                 />

--- a/frontend/src/components/timetable/month-planner-grid.tsx
+++ b/frontend/src/components/timetable/month-planner-grid.tsx
@@ -118,6 +118,11 @@ export function MonthPlannerGrid({
                         <span className="min-w-0 flex-1 truncate font-medium">
                           {inst.title}
                         </span>
+                        {inst.isSpontaneous && !isCancelled && (
+                          <span className="shrink-0 rounded bg-white/70 px-1 text-[9px] font-bold tracking-wide text-gray-600 uppercase">
+                            Spontan
+                          </span>
+                        )}
                         {isActive && !isCancelled && (
                           <span
                             className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#83CD2D]"

--- a/frontend/src/components/timetable/timetable-small-components.test.tsx
+++ b/frontend/src/components/timetable/timetable-small-components.test.tsx
@@ -96,6 +96,50 @@ describe("small timetable components", () => {
     expect(screen.getByText(/1 anwesend/)).toBeInTheDocument();
   });
 
+  it("marks spontaneous instances in week and month grids", () => {
+    const spontaneous = {
+      ...instance,
+      status: "planned" as const,
+      isLive: false,
+      isSpontaneous: true,
+      conflictWarnings: [],
+    };
+    const weekDays = [
+      new Date("2026-05-04T00:00:00"),
+      new Date("2026-05-05T00:00:00"),
+      new Date("2026-05-06T00:00:00"),
+      new Date("2026-05-07T00:00:00"),
+      new Date("2026-05-08T00:00:00"),
+    ];
+
+    const { rerender } = render(
+      <WeeklyCalendarGrid
+        weekDays={weekDays}
+        instances={[spontaneous]}
+        selectedId={null}
+        onInstanceClick={vi.fn()}
+        todayISO="2026-05-04"
+        dayStartHour={9}
+        dayEndHour={17}
+        hourHeightPx={90}
+      />,
+    );
+
+    expect(screen.getByText("Spontan")).toBeInTheDocument();
+
+    rerender(
+      <MonthPlannerGrid
+        days={weekDays}
+        monthDate={new Date("2026-05-01T00:00:00")}
+        instances={[spontaneous]}
+        todayISO="2026-05-04"
+        onDayClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Spontan")).toBeInTheDocument();
+  });
+
   it("opens planning actions and confirms week replanning", async () => {
     const onMaterialize = vi.fn().mockResolvedValue(undefined);
     const onReplan = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- mark spontaneous timetable instances in week, month, and detail views
- allow planned children to be pre-marked as excused/absent from the instance detail view
- keep planned-instance attendance from showing a check-in style present action

## Validation
- cd frontend && pnpm vitest run src/components/timetable/instance-detail-slide-over.test.tsx src/components/timetable/timetable-small-components.test.tsx
- cd frontend && pnpm run check
- pre-push: frontend knip + frontend check