### PR TITLE
Fix help guide header navigation

### DIFF
--- a/frontend/src/app/help/page.tsx
+++ b/frontend/src/app/help/page.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-import { EntryPointCard } from "~/components/help/guide-components";
+import { EntryPointCard, HelpHeader } from "~/components/help/guide-components";
 import { guideEntryPoints } from "~/components/help/guide-data";
 
 export const metadata = {
@@ -12,22 +11,7 @@ export default function HelpLandingPage() {
   return (
     <main className="moto-dotted-background moto-dotted-background--fullscreen min-h-screen overflow-x-hidden">
       <div className="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col px-4 py-5 sm:px-6 lg:px-8">
-        <header className="flex items-center justify-between rounded-3xl border border-gray-200 bg-white/90 px-4 py-3 shadow-sm backdrop-blur-md">
-          <Link
-            href="/"
-            className="flex items-center gap-3 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
-          >
-            <span className="flex h-10 w-10 items-center justify-center rounded-2xl border border-gray-200 bg-white text-sm font-bold text-gray-950 shadow-sm">
-              m
-            </span>
-            <span>
-              <span className="block text-sm font-semibold text-gray-950">
-                moto
-              </span>
-              <span className="block text-xs text-gray-500">Anleitung</span>
-            </span>
-          </Link>
-        </header>
+        <HelpHeader />
 
         <section className="py-12 sm:py-16">
           <div className="max-w-2xl">

--- a/frontend/src/components/help/guide-components.test.tsx
+++ b/frontend/src/components/help/guide-components.test.tsx
@@ -117,7 +117,13 @@ describe("GuideShell", () => {
       />,
     );
 
-    expect(screen.getByText("Übersicht")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /moto\s+Anleitung/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Zur Übersicht").closest("a")).toHaveAttribute(
+      "href",
+      "/help",
+    );
     expect(screen.getAllByText("Ersteinrichtung")).toHaveLength(2);
     expect(
       screen.getAllByRole("heading", {

--- a/frontend/src/components/help/guide-components.tsx
+++ b/frontend/src/components/help/guide-components.tsx
@@ -8,6 +8,7 @@ import type {
   GuideTone,
 } from "./guide-data";
 import { GuidePdfButton } from "./guide-pdf-button";
+import { HelpBackButton, helpBackButtonClassName } from "./help-back-button";
 
 type ActivePath = "ersteinrichtung" | "funktionen" | "nfc";
 
@@ -209,6 +210,52 @@ export function EntryPointCard({
   );
 }
 
+export function HelpHeader({
+  pdf,
+}: {
+  readonly pdf?: { readonly href: string; readonly download: string };
+}) {
+  return (
+    <header className="sticky top-3 z-30 print:hidden">
+      <div className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white/92 p-3 shadow-sm backdrop-blur-md sm:relative sm:flex-row sm:items-center sm:justify-between sm:p-4">
+        <div className="flex w-full min-w-0 items-center justify-between gap-3">
+          {pdf ? (
+            <Link href="/help" className={helpBackButtonClassName}>
+              <ArrowLeft className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span className="truncate">Zur Übersicht</span>
+            </Link>
+          ) : (
+            <HelpBackButton />
+          )}
+
+          {!pdf ? (
+            <Link
+              href="/help"
+              className="flex w-fit items-center gap-2 rounded-lg px-2 py-1 transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none sm:gap-3"
+            >
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-gray-200 bg-white text-sm font-bold text-gray-950 shadow-sm">
+                m
+              </span>
+              <span className="min-w-0">
+                <span className="block text-sm font-semibold text-gray-950">
+                  moto
+                </span>
+                <span className="block text-xs text-gray-500">Anleitung</span>
+              </span>
+            </Link>
+          ) : null}
+        </div>
+
+        {pdf ? (
+          <div className="flex min-h-10 w-full items-center sm:w-fit">
+            <GuidePdfButton href={pdf.href} download={pdf.download} />
+          </div>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
 export function GuideShell({
   eyebrow,
   title,
@@ -240,23 +287,7 @@ export function GuideShell({
   return (
     <main className="moto-dotted-background moto-dotted-background--guide min-h-screen overflow-x-hidden">
       <div className="relative mx-auto w-full max-w-5xl px-4 py-4 sm:px-6 sm:py-6 lg:px-8 print:max-w-none print:px-0 print:py-0">
-        <header className="print:hidden">
-          <div className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white/90 p-3 shadow-sm backdrop-blur-md sm:flex-row sm:items-center sm:justify-between sm:p-4">
-            <Link
-              href="/help"
-              className="inline-flex w-fit items-center gap-2 rounded-lg px-2 py-1 text-sm font-semibold text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
-            >
-              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-              Übersicht
-            </Link>
-            <div className="flex w-fit flex-wrap items-center gap-2">
-              <GuidePdfButton
-                href={pdfByPath[activePath].href}
-                download={pdfByPath[activePath].download}
-              />
-            </div>
-          </div>
-        </header>
+        <HelpHeader pdf={pdfByPath[activePath]} />
 
         <GuidePrintCover
           eyebrow={eyebrow}

--- a/frontend/src/components/help/guide-pdf-button.tsx
+++ b/frontend/src/components/help/guide-pdf-button.tsx
@@ -17,7 +17,7 @@ export function GuidePdfButton({
     <a
       href={href}
       download={download}
-      className="inline-flex h-10 items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-700 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+      className="inline-flex h-10 items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold whitespace-nowrap text-gray-700 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
     >
       <Download className="h-4 w-4" aria-hidden="true" />
       PDF herunterladen

--- a/frontend/src/components/help/help-back-button.tsx
+++ b/frontend/src/components/help/help-back-button.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+const buttonClassName =
+  "inline-flex h-10 min-w-0 items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-700 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none";
+
+export function HelpBackButton() {
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (document.referrer) {
+      const referrer = new URL(document.referrer);
+      if (referrer.origin === window.location.origin) {
+        router.back();
+        return;
+      }
+    }
+
+    router.push("/");
+  };
+
+  return (
+    <button type="button" onClick={handleClick} className={buttonClassName}>
+      <ArrowLeft className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span className="truncate">Zurück zur App</span>
+    </button>
+  );
+}
+
+export { buttonClassName as helpBackButtonClassName };


### PR DESCRIPTION
## Summary

- add a reusable sticky help header for the guide overview and guide detail pages
- make the overview return button go back to the app via browser history with a tenant-root fallback
- keep guide detail pages focused with a `Zur Übersicht` link and no centered `moto Anleitung` label
- keep the PDF download button on one line

## Tests

- `pnpm vitest run src/components/help/guide-components.test.tsx src/proxy.test.ts`
- `pnpm run check`
- pre-push checks: `frontend knip`, `frontend check`, `go vet`, `go deadcode`, `golangci-lint`