### PR TITLE
docs: help-guide-sync reminder (rule + skill + PR checklist)

### DIFF
--- a/.claude/rules/help-guide-sync.md
+++ b/.claude/rules/help-guide-sync.md
@@ -1,0 +1,109 @@
+# In-App Help Guide — Keep Docs in Sync With Features
+
+**RULE: When you add a user-facing feature flow, or substantially change a flow that is already documented, update the in-app help guide in the SAME PR.** The help guide is a living asset — it drifts the moment a screen, sidebar area, or step changes and nobody touches it.
+
+The help guide is the public, school-facing manual served under `/help`. Schools read it in the browser AND receive it as a printable PDF (generated in CI, see below). When it lies, support tickets follow.
+
+---
+
+## What the Help System Is
+
+Three guides plus a landing page, all rendered from one content file:
+
+| Guide | Page | Chapter set (in `guide-data.ts`) | Purpose |
+|-------|------|----------------------------------|---------|
+| Landing | `/help` | `guideEntryPoints` | Three entry cards linking to the guides |
+| Ersteinrichtung | `/help/setup` | `setupChapters` | Empty system → first real care day |
+| Die App im Alltag | `/help/features` | `appChapters` | Every app area explained (the feature reference) |
+| NFC & Tablets | `/help/nfc` | `nfcChapters` | Tablet/NFC manual — mostly the **initial setup** of NFC kiosks, plus daily check-in/out and troubleshooting |
+
+## File Map
+
+| File | Role |
+|------|------|
+| `frontend/src/components/help/guide-data.ts` | **The content.** All chapters, steps, callouts, screenshot captions. German text. This is what you edit. |
+| `frontend/src/components/help/guide-components.tsx` | Rendering: `GuideShell`, `HelpHeader`, `EntryPointCard` |
+| `frontend/src/components/help/guide-pdf-button.tsx` | Download button for the rendered PDF |
+| `frontend/src/components/help/help-back-button.tsx` | "Zurück" — `router.back()`, falls back to `/`. Lets kiosk/app users return after opening Hilfe. |
+| `frontend/src/app/help/{page,setup/page,features/page,nfc/page}.tsx` | The four pages; each wires one chapter set into `GuideShell` |
+| `frontend/public/help/screens/*.webp` | App screenshots, referenced by a step's `image:` field |
+| `frontend/public/help/pdfs/` | **Generated** PDFs (gitignored). Built in CI, shipped in the Docker image. |
+
+## Data Model
+
+Content is a tree: `GuideChapter` → `GuideStep`. Defined and exported from `guide-data.ts`:
+
+```ts
+interface GuideChapter {
+  id: string;
+  title: string;
+  description: string;
+  icon: LucideIcon;              // from lucide-react
+  tone: GuideTone;              // "blue" | "green" | "orange" | "red" | "purple" | "gray"
+  steps: readonly GuideStep[];
+}
+
+interface GuideStep {
+  id: string;
+  title: string;
+  summary: string;
+  steps?: readonly string[];     // ordered actions (optional — a card may be checklist-only)
+  checklist?: readonly string[]; // rendered as a checklist block
+  callout?: GuideCallout;        // { title, body, tone? } — highlighted hint
+  screenshot: string;            // caption / alt text describing the supporting image (ALWAYS set)
+  image?: string;                // path under /public, e.g. "/help/screens/feedback.webp"
+  gallery?: readonly { image; caption }[]; // captioned grid instead of one image (NFC tablet states)
+  icon?: LucideIcon;             // shown instead of a number badge on reference pages
+}
+```
+
+Notes:
+- `screenshot` is the **caption/intent** and is always present; `image` is the actual file and is optional (a step with no `image` renders no placeholder).
+- `gallery` is used by the NFC manual to show every tablet state, not just one.
+- All visible strings are **German** — the help UI is German-only.
+
+---
+
+## WHEN To Update
+
+Update the guide when the change is **visible to a school user**:
+
+- **New user-facing feature flow** → add a `GuideStep` (or a new `GuideChapter`) to the matching chapter set: setup-related → `setupChapters`, an app area → `appChapters`, NFC/tablet → `nfcChapters`.
+- **Substantial UI change to an already-documented flow** → update the affected step(s) **and re-capture the screenshot** so the image matches what the user sees. A renamed button, a moved control, a changed step order all qualify.
+- **Renamed or moved sidebar area / page** → fix the step title and, on the landing page, the relevant `guideEntryPoint`.
+- **NFC/tablet flow change** (especially first-time setup, but also daily check-in/out or troubleshooting) → update `nfcChapters`, including any `gallery` screens.
+- **A documented setting/toggle changes meaning or default** → update the step that explains it.
+
+**Do NOT** update the guide for:
+- Backend-only changes with no user-visible effect (repos, services, migrations, internal refactors)
+- Operator/parents-portal-only changes (the guide documents the **tenant/staff** app)
+- Pure styling tweaks that don't change what a step instructs
+
+When unsure: if a school admin or supervisor would *do something differently* after your change, the guide needs a line.
+
+## HOW To Update
+
+1. **Find the right chapter set** in `guide-data.ts` (`setupChapters` / `appChapters` / `nfcChapters`) and the step whose `id`/`title` matches the flow.
+2. **Edit content in German**, reusing the existing `GuideStep` shape. Keep `steps` imperative and concrete ("`Räume` öffnen, `Neuer Raum` klicken …"), mirror the tone of neighboring steps. Reuse an existing `lucide-react` icon already imported in the file before adding a new import.
+3. **Screenshots**: if the screen changed, replace the `.webp` under `frontend/public/help/screens/` (same filename to avoid touching `image:` paths) or add a new one and point `image:` at it. Always keep `screenshot:` (the caption) accurate even when there's no image.
+4. **Brand colors / reuse**: the guide is part of the frontend — follow the existing component and brand-color rules in `CLAUDE.md` and `frontend/CLAUDE.md`. Don't invent new UI; `GuideShell` already renders everything.
+5. **Don't break the PDF render.** The PDFs are produced in CI by:
+   ```bash
+   cd frontend && pnpm run generate:guides   # Playwright, playwright.guides.config.ts
+   ```
+   It renders the public `/help` pages to PDF (`public/help/pdfs/`, gitignored) and ships them in the image. Anything that breaks the `/help` build breaks the PDFs. The pages are host-agnostic, so a local render only needs placeholder hostnames.
+6. **Verify** before you call it done:
+   ```bash
+   cd frontend && pnpm run check          # zero warnings policy
+   ```
+   Optionally render the PDFs locally (`pnpm run generate:guides`) if you touched layout-affecting structure.
+
+---
+
+## Scope Boundary
+
+This rule covers the **in-app, school-facing help guide only**. It does NOT govern: developer docs (`CLAUDE.md`, `.claude/rules/*`), cross-repo docs (PyrePortal/balenaOS), or generated API route docs (`./main gendoc`). Those are separate concerns; don't bundle them here unless explicitly asked.
+
+## Paired Skill
+
+`help-guide-sync` walks through the files above when you're doing guide work. This rule is the reference; the skill is the workflow.

--- a/.claude/skills/help-guide-sync/SKILL.md
+++ b/.claude/skills/help-guide-sync/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: help-guide-sync
+description: Use when adding or substantially changing a user-facing feature flow that the in-app help guide documents, or when editing the help guide content, screenshots, or PDF export. Triggers on guide-data.ts, /help pages, Hilfe, Anleitung, guide chapters, GuideStep/GuideChapter, or "update the docs/guide".
+metadata:
+  author: moto-nrw
+  version: "1.0.0"
+---
+
+# In-App Help Guide Sync
+
+Keeps the school-facing help guide (`/help`) in sync with the app. The full reference is in `.claude/rules/help-guide-sync.md` — this skill points you at the right files and the update flow.
+
+## When to Use
+
+- You added a **new user-facing feature flow** (a school user does something new)
+- You **substantially changed** a flow that is already documented (renamed/moved controls, changed step order, new screen)
+- You're editing the help content, a screenshot, or the PDF export directly
+- A documented setting/toggle changed its meaning or default
+
+Skip for backend-only changes, operator/parents-portal-only changes, and pure styling tweaks. See the rule for the full WHEN/WHEN-NOT list.
+
+## Files to Read First
+
+```
+frontend/src/components/help/guide-data.ts          # THE CONTENT — chapters, steps, captions (edit this)
+frontend/src/components/help/guide-components.tsx    # GuideShell rendering (rarely edited)
+frontend/src/app/help/{,setup,features,nfc}/page.tsx # which page wires which chapter set
+frontend/public/help/screens/                        # screenshots referenced by step `image:`
+```
+
+## Which Chapter Set?
+
+All three live in `guide-data.ts`:
+
+| Change is about… | Edit |
+|------------------|------|
+| First-time setup (empty system → first care day) | `setupChapters` (`/help/setup`) |
+| An app area / everyday feature | `appChapters` (`/help/features`) |
+| NFC tablet / kiosk (setup, check-in/out, troubleshooting) | `nfcChapters` (`/help/nfc`) |
+| Landing-page entry cards | `guideEntryPoints` (`/help`) |
+
+## Process
+
+1. **Locate** the chapter set and the `GuideStep` whose `id`/`title` matches the flow.
+2. **Edit in German**, reusing the existing `GuideStep` shape (`title`, `summary`, `steps`, `checklist`, `callout`, `screenshot`, `image`, `gallery`, `icon`). Match the tone of neighboring steps; reuse an already-imported `lucide-react` icon before adding one.
+3. **Screenshot**: if the screen changed, replace the `.webp` in `frontend/public/help/screens/` (keep the filename) or add a new file and point `image:` at it. Keep the `screenshot:` caption accurate even with no image.
+4. **Don't break the PDF render** — the public `/help` build feeds the CI PDF export:
+   ```bash
+   cd frontend && pnpm run generate:guides   # Playwright → public/help/pdfs/ (gitignored)
+   ```
+5. **Verify**:
+   ```bash
+   cd frontend && pnpm run check
+   ```
+
+## Common Mistakes
+
+| Mistake | Consequence |
+|---------|-------------|
+| Ship a UI change, skip `guide-data.ts` | Guide + PDF lie to schools → support tickets |
+| Change a screen but reuse the old screenshot | Image no longer matches the instructions |
+| Write guide text in English | Help UI is German-only; sticks out immediately |
+| Add a new component/color for the guide | `GuideShell` already renders everything; follow brand-color/reuse rules |
+| Break the `/help` build | CI PDF generation (`generate:guides`) fails |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,6 +45,7 @@
 - [ ] I have performed a self-review of my code
 - [ ] I have commented my code, especially in hard-to-understand areas
 - [ ] I have updated the documentation as needed
+- [ ] If this PR changes a user-facing flow, I updated the in-app help guide (`guide-data.ts`) and any changed screenshot — or it doesn't apply (backend-only, operator/parents-portal-only, or pure-styling change)
 - [ ] All tests are passing
 - [ ] My changes generate no new warnings or errors
 - [ ] I have checked for and resolved any merge conflicts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,6 +424,14 @@ Per-school configuration via a registry-driven system. Schools configure setting
 
 **For architecture, step-by-step guides, and field type reference, see `.claude/rules/settings-system.md`.**
 
+## In-App Help Guide
+
+The school-facing manual lives under `/help` (three guides: Ersteinrichtung, Die App im Alltag, NFC & Tablets). Schools read it in the browser and receive it as a printable PDF generated in CI. All content is one file: `frontend/src/components/help/guide-data.ts` (`GuideChapter → GuideStep`, German). It is a living asset — it drifts the moment a screen or step changes and nobody touches it.
+
+**RULE: When you add a user-facing feature flow, or substantially change a flow that the guide already documents, update `guide-data.ts` (and any changed screenshot) in the SAME PR.** This does not apply to backend-only, operator/parents-portal-only, or pure-styling changes. When unsure: if a school user would *do something differently* after your change, the guide needs a line.
+
+**For the file map, the data model, the exact when/how, and the PDF-render caveat, see `.claude/rules/help-guide-sync.md`** (paired skill: `help-guide-sync`).
+
 ---
 
 @CLAUDE.local.md


### PR DESCRIPTION
## Description

Makes "keep the school-facing help guide in sync with the app" an enforced, repeatable reminder instead of tribal knowledge. Follows up on the Slack thread (Flo/Yannick): the in-app help guide under `/help` — the manual schools read in the browser and receive as a CI-generated PDF — is a living asset that silently drifts the moment a screen or step changes and nobody touches it.

This wires the reminder into the same **CLAUDE.md rule + `.claude/rules` reference + paired skill** triad already used for `settings-system` and `env-docker-sync`, and adds a conditional PR-template checkbox so the reminder also fires for human reviewers — not just the agent.

**Scope is deliberately the in-app help guide only** (the tenant/staff `/help` manual), per Yannick's clarification that "doku" = the Schul-Hilfe. It does **not** cover backend-only, operator/parents-portal-only, or pure-styling changes — that exception list is written once in the rule and mirrored verbatim into the PR checkbox so the two cannot drift.

## Type of Change

- [x] Documentation update
- [x] Configuration change

## What's included

| File | Change |
|------|--------|
| `CLAUDE.md` | New **In-App Help Guide** section: the rule statement + pointer to the full reference and paired skill |
| `.claude/rules/help-guide-sync.md` | Full reference — file map, `GuideChapter → GuideStep` data model, exact WHEN/WHEN-NOT, and the PDF-render caveat |
| `.claude/skills/help-guide-sync/SKILL.md` | Workflow skill — auto-triggers on guide work (`guide-data.ts`, `/help`, "Hilfe/Anleitung"), points at the right files and the update flow |
| `.github/PULL_REQUEST_TEMPLATE.md` | One conditional checklist line, mirroring the rule's exception list so backend/operator/styling PRs can tick it honestly |

## Reminder coverage

The same expectation now surfaces on four channels:

1. **CLAUDE.md** — loaded every session (the `RULE:` line is always in context)
2. **`.claude/rules/help-guide-sync.md`** — auto-injected reference alongside the other project rules
3. **`help-guide-sync` skill** — surfaced to the agent on guide-related work
4. **PR template** — a checkbox every human reviewer sees on every PR

## Verification

- All paths referenced by the rule/skill verified to exist (`guide-data.ts`, `guide-components.tsx`, `playwright.guides.config.ts`, the `generate:guides` npm script, `public/help/screens/*.webp`).
- No app code touched → `pnpm run check` unaffected; `git-secrets` pre-commit passed.

## Note for reviewers

The exception wording (`backend-only, operator/parents-portal-only, or pure-styling change`) now lives in three places: `CLAUDE.md`, the rule file, and the PR template. There is no automation keeping them aligned — if the exceptions change, update all three.

## Related

- Follow-up to the help-guide work Flo is shipping; coordinate so this and his branch don't both touch `PULL_REQUEST_TEMPLATE.md`.
