### PR TITLE
Harden agent hook reminders

### DIFF
--- a/.claude/hooks/skill-reminder.sh
+++ b/.claude/hooks/skill-reminder.sh
@@ -8,14 +8,41 @@ set -euo pipefail
 project_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 
 skills=()
+skill_roots=(
+    "$project_root/.claude/skills"
+    "$project_root/.agents/skills"
+    "$HOME/.codex/skills"
+    "$HOME/.claude/skills"
+    "$HOME/.agents/skills"
+    "$HOME/repos/dotfiles/claude/.claude/skills"
+)
 
-# Scan project-local skills (.claude/skills/*/SKILL.md)
-if [[ -d "$project_root/.claude/skills" ]]; then
-    while IFS= read -r skill_path; do
-        skill_name=$(basename "$(dirname "$skill_path")")
-        skills+=("$skill_name")
-    done < <(find "$project_root/.claude/skills" -name "SKILL.md" -type f 2>/dev/null | sort)
+if [[ -n "${CODEX_SKILLS_PATH:-}" ]]; then
+    IFS=':' read -r -a extra_skill_roots <<< "$CODEX_SKILLS_PATH"
+    skill_roots+=("${extra_skill_roots[@]}")
 fi
+
+if [[ -n "${CLAUDE_SKILLS_PATH:-}" ]]; then
+    IFS=':' read -r -a extra_skill_roots <<< "$CLAUDE_SKILLS_PATH"
+    skill_roots+=("${extra_skill_roots[@]}")
+fi
+
+if [[ -n "${AGENT_SKILLS_PATH:-}" ]]; then
+    IFS=':' read -r -a extra_skill_roots <<< "$AGENT_SKILLS_PATH"
+    skill_roots+=("${extra_skill_roots[@]}")
+fi
+
+# Scan project-local and user-global skills.
+while IFS= read -r skill_path; do
+    skill_name=$(basename "$(dirname "$skill_path")")
+    skills+=("$skill_name")
+done < <(
+    for skill_root in "${skill_roots[@]}"; do
+        if [[ -d "$skill_root" ]]; then
+            find "$skill_root" -name "SKILL.md" -type f 2>/dev/null
+        fi
+    done | sort -u
+)
 
 # Scan project-local commands (.claude/commands/*.md)
 if [[ -d "$project_root/.claude/commands" ]]; then
@@ -30,19 +57,22 @@ fi
 
 # Build vertical list
 skill_list=""
-for skill in "${skills[@]}"; do
+while IFS= read -r skill; do
+    if [[ -z "$skill" ]]; then
+        continue
+    fi
     skill_list="${skill_list}
 - ${skill}"
-done
+done < <(printf '%s\n' "${skills[@]}" | sort -u)
 
-# Output compact JSON reminder
-cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "UserPromptSubmit",
-    "additionalContext": "<skill-reminder>USE SKILLS ACTIVELY! Available:${skill_list}
+# Output compact JSON reminder. Use jq so embedded newlines are escaped.
+additional_context="<skill-reminder>USE SKILLS ACTIVELY! Available:${skill_list}
 
 Invoke via Skill tool before acting.</skill-reminder>"
+
+jq -n --arg context "$additional_context" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $context
   }
-}
-EOF
+}'

--- a/.claude/hooks/subagent-reminder.sh
+++ b/.claude/hooks/subagent-reminder.sh
@@ -31,14 +31,14 @@ for agent in "${agents[@]}"; do
 - ${agent}"
 done
 
-# Output compact JSON reminder
-cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "UserPromptSubmit",
-    "additionalContext": "<subagent-reminder>Project subagents (use Task tool with subagent_type):${agent_list}
+# Output compact JSON reminder. Use jq so embedded newlines are escaped.
+additional_context="<subagent-reminder>Project subagents (use Task tool with subagent_type):${agent_list}
 
 Invoke via Task tool when relevant.</subagent-reminder>"
+
+jq -n --arg context "$additional_context" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $context
   }
-}
-EOF
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -156,11 +156,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/format-go.sh\""
+            "command": "bash -c 'root=\"${CLAUDE_PROJECT_DIR:-}\"; if [[ -z \"$root\" ]]; then root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; fi; bash \"$root/.claude/hooks/format-go.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/format-typescript.sh\""
+            "command": "bash -c 'root=\"${CLAUDE_PROJECT_DIR:-}\"; if [[ -z \"$root\" ]]; then root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; fi; bash \"$root/.claude/hooks/format-typescript.sh\"'"
           }
         ]
       }
@@ -171,7 +171,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-commit-message.sh\""
+            "command": "bash -c 'root=\"${CLAUDE_PROJECT_DIR:-}\"; if [[ -z \"$root\" ]]; then root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; fi; bash \"$root/.claude/hooks/check-commit-message.sh\"'"
           }
         ]
       }
@@ -182,7 +182,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-env-files.sh\""
+            "command": "bash -c 'root=\"${CLAUDE_PROJECT_DIR:-}\"; if [[ -z \"$root\" ]]; then root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; fi; bash \"$root/.claude/hooks/check-env-files.sh\"'"
           }
         ]
       }
@@ -192,7 +192,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null) && bash \"$root/.claude/hooks/skill-reminder.sh\"'"
+            "command": "bash -c 'root=\"${CLAUDE_PROJECT_DIR:-}\"; if [[ -z \"$root\" ]]; then root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; fi; bash \"$root/.claude/hooks/skill-reminder.sh\"'"
           }
         ]
       },
@@ -200,7 +200,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null) && bash \"$root/.claude/hooks/subagent-reminder.sh\"'"
+            "command": "bash -c 'root=\"${CLAUDE_PROJECT_DIR:-}\"; if [[ -z \"$root\" ]]; then root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; fi; bash \"$root/.claude/hooks/subagent-reminder.sh\"'"
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/check-commit-message.sh\""
+            "command": "bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; bash \"$root/.codex/hooks/check-commit-message.sh\"'"
           }
         ]
       }
@@ -17,11 +17,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/format-go.sh\""
+            "command": "bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; bash \"$root/.codex/hooks/format-go.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/format-typescript.sh\""
+            "command": "bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; bash \"$root/.codex/hooks/format-typescript.sh\"'"
           }
         ]
       }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/check-env-files.sh\""
+            "command": "bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; bash \"$root/.codex/hooks/check-env-files.sh\"'"
           }
         ]
       }
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/skill-reminder.sh\""
+            "command": "bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; bash \"$root/.codex/hooks/skill-reminder.sh\"'"
           }
         ]
       },
@@ -50,7 +50,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/subagent-reminder.sh\""
+            "command": "bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; bash \"$root/.codex/hooks/subagent-reminder.sh\"'"
           }
         ]
       }

--- a/.codex/hooks/skill-reminder.sh
+++ b/.codex/hooks/skill-reminder.sh
@@ -8,14 +8,41 @@ set -euo pipefail
 project_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 
 skills=()
+skill_roots=(
+    "$project_root/.claude/skills"
+    "$project_root/.agents/skills"
+    "$HOME/.codex/skills"
+    "$HOME/.claude/skills"
+    "$HOME/.agents/skills"
+    "$HOME/repos/dotfiles/claude/.claude/skills"
+)
 
-# Scan project-local skills (.claude/skills/*/SKILL.md)
-if [[ -d "$project_root/.claude/skills" ]]; then
-    while IFS= read -r skill_path; do
-        skill_name=$(basename "$(dirname "$skill_path")")
-        skills+=("$skill_name")
-    done < <(find "$project_root/.claude/skills" -name "SKILL.md" -type f 2>/dev/null | sort)
+if [[ -n "${CODEX_SKILLS_PATH:-}" ]]; then
+    IFS=':' read -r -a extra_skill_roots <<< "$CODEX_SKILLS_PATH"
+    skill_roots+=("${extra_skill_roots[@]}")
 fi
+
+if [[ -n "${CLAUDE_SKILLS_PATH:-}" ]]; then
+    IFS=':' read -r -a extra_skill_roots <<< "$CLAUDE_SKILLS_PATH"
+    skill_roots+=("${extra_skill_roots[@]}")
+fi
+
+if [[ -n "${AGENT_SKILLS_PATH:-}" ]]; then
+    IFS=':' read -r -a extra_skill_roots <<< "$AGENT_SKILLS_PATH"
+    skill_roots+=("${extra_skill_roots[@]}")
+fi
+
+# Scan project-local and user-global skills.
+while IFS= read -r skill_path; do
+    skill_name=$(basename "$(dirname "$skill_path")")
+    skills+=("$skill_name")
+done < <(
+    for skill_root in "${skill_roots[@]}"; do
+        if [[ -d "$skill_root" ]]; then
+            find "$skill_root" -name "SKILL.md" -type f 2>/dev/null
+        fi
+    done | sort -u
+)
 
 # Scan project-local commands (.claude/commands/*.md)
 if [[ -d "$project_root/.claude/commands" ]]; then
@@ -30,19 +57,22 @@ fi
 
 # Build vertical list
 skill_list=""
-for skill in "${skills[@]}"; do
+while IFS= read -r skill; do
+    if [[ -z "$skill" ]]; then
+        continue
+    fi
     skill_list="${skill_list}
 - ${skill}"
-done
+done < <(printf '%s\n' "${skills[@]}" | sort -u)
 
-# Output compact JSON reminder
-cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "UserPromptSubmit",
-    "additionalContext": "<skill-reminder>USE SKILLS ACTIVELY! Available:${skill_list}
+# Output compact JSON reminder. Use jq so embedded newlines are escaped.
+additional_context="<skill-reminder>USE SKILLS ACTIVELY! Available:${skill_list}
 
 Invoke via Skill tool before acting.</skill-reminder>"
+
+jq -n --arg context "$additional_context" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $context
   }
-}
-EOF
+}'

--- a/.codex/hooks/subagent-reminder.sh
+++ b/.codex/hooks/subagent-reminder.sh
@@ -31,14 +31,14 @@ for agent in "${agents[@]}"; do
 - ${agent}"
 done
 
-# Output compact JSON reminder
-cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "UserPromptSubmit",
-    "additionalContext": "<subagent-reminder>Project subagents (use Task tool with subagent_type):${agent_list}
+# Output compact JSON reminder. Use jq so embedded newlines are escaped.
+additional_context="<subagent-reminder>Project subagents (use Task tool with subagent_type):${agent_list}
 
 Invoke via Task tool when relevant.</subagent-reminder>"
+
+jq -n --arg context "$additional_context" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $context
   }
-}
-EOF
+}'


### PR DESCRIPTION
## Summary

- harden Codex and Claude hook commands so missing repo roots skip cleanly instead of executing `/.codex/...` or `/.claude/...`
- emit UserPromptSubmit reminder payloads with `jq` so multiline context is valid JSON
- include shared dotfiles skills in reminder discovery, while keeping project and user skill roots plus env-var extension points

## Root Cause

The hook commands assumed `git rev-parse --show-toplevel` or `CLAUDE_PROJECT_DIR` would always resolve. When the hook runner started without that context, paths collapsed to root-level hook paths and exited `127`. After that was fixed, reminder scripts still hand-built JSON with raw newlines inside string values, which Codex rejected as invalid UserPromptSubmit JSON.

## Validation

- `jq empty .codex/hooks.json .claude/settings.json`
- Codex and Claude configured hooks emit valid JSON or empty output
- Codex SessionStart hook returns `0` inside and outside the repo
- skill reminder output includes `canvas-animation`, `find-docs`, `vercel-react-best-practices`, and `web-design-guidelines`
- lefthook pre-commit: passed `git-secrets`; other checks skipped as no matching staged files
- lefthook pre-push: passed `git-secrets`; other checks skipped as no matching push files
