### PR TITLE
Improve guide PDF pagination

### DIFF
--- a/frontend/src/components/help/guide-components.test.tsx
+++ b/frontend/src/components/help/guide-components.test.tsx
@@ -221,78 +221,52 @@ describe("GuideShell", () => {
     expect(within(article as HTMLElement).getByText("3")).toBeInTheDocument();
   });
 
-  it("starts setup chapters 2 and 4 on a new PDF page", () => {
+  it.each(["ersteinrichtung", "funktionen", "nfc"] as const)(
+    "does not force PDF page breaks before chapters for %s",
+    (activePath) => {
+      render(
+        <GuideShell
+          eyebrow="E"
+          title="T"
+          description="D"
+          chapters={makeFourChapters()}
+          activePath={activePath}
+          numbered
+        />,
+      );
+
+      for (const id of ["kap-1", "kap-2", "kap-3", "kap-4"]) {
+        expect(document.getElementById(id)).not.toHaveClass(
+          "print:[break-before:page]",
+          "print:[page-break-before:always]",
+        );
+      }
+    },
+  );
+
+  it("keeps chapter headers together with the following PDF content", () => {
     render(
       <GuideShell
         eyebrow="E"
         title="T"
         description="D"
-        chapters={makeFourChapters()}
+        chapters={makeChapters()}
         activePath="ersteinrichtung"
         numbered
       />,
     );
 
-    expect(document.getElementById("kap-1")).not.toHaveClass(
-      "print:[break-before:page]",
-    );
-    expect(document.getElementById("kap-2")).toHaveClass(
-      "print:[break-before:page]",
-      "print:[page-break-before:always]",
-    );
-    expect(document.getElementById("kap-3")).not.toHaveClass(
-      "print:[break-before:page]",
-    );
-    expect(document.getElementById("kap-4")).toHaveClass(
-      "print:[break-before:page]",
-      "print:[page-break-before:always]",
-    );
-  });
+    const chapter = document.getElementById("kap-1");
+    const chapterElement = chapter as HTMLElement;
+    const heading = within(chapterElement).getByRole("heading", {
+      name: "Erstes Kapitel",
+    });
 
-  it("starts app guide chapters 2, 3 and 4 on a new PDF page", () => {
-    render(
-      <GuideShell
-        eyebrow="E"
-        title="T"
-        description="D"
-        chapters={makeFourChapters()}
-        activePath="funktionen"
-        numbered
-      />,
+    expect(heading).toBeInTheDocument();
+    expect(chapterElement.firstElementChild).toHaveClass(
+      "print:[break-inside:avoid]",
+      "print:[break-after:avoid]",
     );
-
-    expect(document.getElementById("kap-1")).not.toHaveClass(
-      "print:[break-before:page]",
-    );
-    for (const id of ["kap-2", "kap-3", "kap-4"]) {
-      expect(document.getElementById(id)).toHaveClass(
-        "print:[break-before:page]",
-        "print:[page-break-before:always]",
-      );
-    }
-  });
-
-  it("starts every NFC chapter after the first one on a new PDF page", () => {
-    render(
-      <GuideShell
-        eyebrow="E"
-        title="T"
-        description="D"
-        chapters={makeFourChapters()}
-        activePath="nfc"
-        numbered
-      />,
-    );
-
-    expect(document.getElementById("kap-1")).not.toHaveClass(
-      "print:[break-before:page]",
-    );
-    for (const id of ["kap-2", "kap-3", "kap-4"]) {
-      expect(document.getElementById(id)).toHaveClass(
-        "print:[break-before:page]",
-        "print:[page-break-before:always]",
-      );
-    }
   });
 
   it("renders a step image with the caption as alt text, and nothing for image-less steps", () => {

--- a/frontend/src/components/help/guide-components.tsx
+++ b/frontend/src/components/help/guide-components.tsx
@@ -61,14 +61,6 @@ const coverByPath: Record<
   },
 };
 
-const setupPrintBreakBeforeChapterIndexes = new Set([1, 3]);
-const appPrintBreakBeforeChapterIndexes = new Set([1, 2, 3]);
-const nfcPrintBreakBeforeChapterIndexes = new Set(
-  Array.from({ length: 9 }, (_, index) => index + 1),
-);
-const printPageBreakBeforeClassName =
-  "print:[break-before:page] print:[page-break-before:always]";
-
 const nextLinks: Record<
   ActivePath,
   readonly {
@@ -367,14 +359,6 @@ export function GuideShell({
                 index={index}
                 startIndex={chapterStartIndex[index] ?? 0}
                 numbered={numbered}
-                breakBefore={
-                  (activePath === "ersteinrichtung" &&
-                    setupPrintBreakBeforeChapterIndexes.has(index)) ||
-                  (activePath === "funktionen" &&
-                    appPrintBreakBeforeChapterIndexes.has(index)) ||
-                  (activePath === "nfc" &&
-                    nfcPrintBreakBeforeChapterIndexes.has(index))
-                }
               />
             ))}
           </div>
@@ -521,23 +505,18 @@ function ChapterBlock({
   index,
   startIndex,
   numbered,
-  breakBefore,
 }: {
   readonly chapter: GuideChapter;
   readonly index: number;
   readonly startIndex: number;
   readonly numbered: boolean;
-  readonly breakBefore: boolean;
 }) {
   const tone = toneClasses[chapter.tone];
   const Icon = chapter.icon;
 
   return (
-    <section
-      id={chapter.id}
-      className={`scroll-mt-6 ${breakBefore ? printPageBreakBeforeClassName : ""}`}
-    >
-      <div className="mb-5 flex items-start gap-4 print:[break-inside:avoid]">
+    <section id={chapter.id} className="scroll-mt-6">
+      <div className="mb-5 flex items-start gap-4 print:[break-inside:avoid] print:[break-after:avoid]">
         <div
           className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl ${tone.soft} ${tone.text} print:border print:border-gray-300 print:bg-white print:text-gray-900`}
         >
@@ -585,9 +564,11 @@ function StepCard({
   return (
     <article
       id={item.id}
-      className={`moto-content-surface scroll-mt-24 rounded-2xl border p-5 shadow-sm sm:p-6 print:[break-inside:avoid] print:border-gray-300 print:shadow-none ${compactPrint ? "print:p-3" : "print:p-4"}`}
+      className={`moto-content-surface scroll-mt-24 rounded-2xl border p-5 shadow-sm sm:p-6 print:border-0 print:bg-transparent print:p-0 print:shadow-none ${compactPrint ? "print:[break-inside:avoid]" : ""}`}
     >
-      <div className={`flex gap-4 ${compactPrint ? "print:gap-3" : ""}`}>
+      <div
+        className={`flex gap-4 print:rounded-2xl print:border print:border-gray-300 print:bg-white print:shadow-none ${compactPrint ? "print:gap-3 print:p-3" : "print:p-4"} print:[break-inside:avoid]`}
+      >
         <span
           className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl text-sm font-bold ${toneClass.soft} ${toneClass.text} print:border print:border-gray-300 print:bg-white print:text-gray-900`}
         >
@@ -629,20 +610,15 @@ function StepCard({
           {item.callout ? (
             <Callout callout={item.callout} compactPrint={compactPrint} />
           ) : null}
-
-          {item.gallery ? (
-            <ScreenshotGallery
-              items={item.gallery}
-              compactPrint={compactPrint}
-            />
-          ) : (
-            <Screenshot
-              image={item.image}
-              caption={item.screenshot}
-              compactPrint={compactPrint}
-            />
-          )}
         </div>
+      </div>
+
+      <div className="sm:ml-14 print:ml-0">
+        {item.gallery ? (
+          <ScreenshotGallery items={item.gallery} compactPrint={compactPrint} />
+        ) : (
+          <Screenshot image={item.image} caption={item.screenshot} />
+        )}
       </div>
     </article>
   );
@@ -696,25 +672,27 @@ function Callout({
 function Screenshot({
   image,
   caption,
-  compactPrint,
 }: {
   readonly image?: string;
   readonly caption: string;
-  readonly compactPrint?: boolean;
 }) {
   // No image: render nothing. The `caption` still serves as documentation /
   // alt text in the data, but image-less steps show no placeholder box.
   if (!image) {
     return null;
   }
+  const trimRightEdge =
+    !image.includes("/nfc-") ||
+    image.includes("/nfc-geraete-pruefen") ||
+    image.includes("/nfc-einstellungen");
   return (
-    <figure className="mt-4 overflow-hidden rounded-xl border border-gray-200 shadow-sm print:border-gray-300 print:shadow-none">
+    <figure className="mt-4 overflow-hidden rounded-xl border border-gray-200 shadow-sm print:[break-inside:avoid] print:border-gray-300 print:shadow-none">
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={image}
         alt={caption}
         loading="lazy"
-        className={`block w-full print:mx-auto print:w-auto print:object-contain ${compactPrint ? "print:max-h-[205px]" : "print:max-h-[250px]"}`}
+        className={`block w-full print:max-h-none print:object-contain ${trimRightEdge ? "print:w-[102%] print:max-w-none" : "print:w-full"}`}
       />
     </figure>
   );
@@ -744,7 +722,7 @@ function ScreenshotGallery({
             src={item.image}
             alt={item.caption}
             loading="lazy"
-            className={`block w-full print:mx-auto print:w-auto print:object-contain ${compactPrint ? "print:max-h-[135px]" : "print:max-h-[160px]"}`}
+            className="block w-full print:max-h-none print:w-full print:object-contain"
           />
           <figcaption
             className={`border-t border-gray-100 px-3 py-2 text-xs leading-5 text-gray-500 print:border-gray-200 ${compactPrint ? "print:py-1.5 print:leading-4" : ""}`}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -447,6 +447,9 @@
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
   }
+  .moto-dotted-background--guide .moto-content-surface {
+    background: transparent;
+  }
 }
 
 .moto-hover-elevated {


### PR DESCRIPTION
## Summary
- split guide step rendering into separate text and media print blocks
- remove forced chapter page breaks so guides flow naturally
- keep guide text cards white while preserving the dotted page background
- render desktop screenshots full width and hide the captured right-edge artifact

## Verification
- pnpm run generate:guides
- pnpm check
- visually reviewed exported PDF page contact sheets for setup, features, and nfc

## Notes
- local pre-push initially failed because golangci-lint was not available in this shell; frontend-check, frontend-knip, go-vet, go-deadcode, and git-secrets passed before pushing with Lefthook disabled