### PR TITLE
feat: add arrival schedules to student import

### DIFF
--- a/backend/api/import/api.go
+++ b/backend/api/import/api.go
@@ -206,6 +206,7 @@ func getStudentImportHeaders() []string {
 		"Erz2.Vorname (optional)", "Erz2.Nachname (optional)", "Erz2.Email (optional)", "Erz2.Telefon (optional)", "Erz2.Telefon2 (optional)", "Erz2.Mobil (optional)", "Erz2.Mobil2 (optional)", "Erz2.Dienstlich (optional)", "Erz2.Dienstlich2 (optional)", "Erz2.Verhältnis (optional)", "Erz2.Hauptansprechpartner (optional)", "Erz2.Notfall (optional)", "Erz2.Abholberechtigt (optional)",
 		"Erz2.Straße (optional)", "Erz2.Stadt (optional)", "Erz2.PLZ (optional)", "Erz2.Notizen (optional)", "Erz2.Sprache (optional)",
 		"Gesundheitsinfo (optional)", "Betreuernotizen (optional)", "Zusatzinfo (optional)", "Abholstatus (optional)", "Datenschutz", "Aufbewahrung(Tage) (optional)", "Bus (optional)", "Einschreibung von (optional)", "Einschreibung bis (optional)", "AGB akzeptiert am (optional)", "Datenverarbeitung akzeptiert am (optional)", "E-Mail-Kontakt akzeptiert am (optional)", "Foto-Einwilligung am (optional)",
+		"Ankunft.Mo (optional)", "Ankunft.Mo.Notizen (optional)", "Ankunft.Di (optional)", "Ankunft.Di.Notizen (optional)", "Ankunft.Mi (optional)", "Ankunft.Mi.Notizen (optional)", "Ankunft.Do (optional)", "Ankunft.Do.Notizen (optional)", "Ankunft.Fr (optional)", "Ankunft.Fr.Notizen (optional)",
 		"Abholung.Mo (optional)", "Abholung.Mo.Notizen (optional)", "Abholung.Di (optional)", "Abholung.Di.Notizen (optional)", "Abholung.Mi (optional)", "Abholung.Mi.Notizen (optional)", "Abholung.Do (optional)", "Abholung.Do.Notizen (optional)", "Abholung.Fr (optional)", "Abholung.Fr.Notizen (optional)",
 	}
 }
@@ -224,6 +225,8 @@ func getStudentImportExamples() [][]any {
 			testAddressMusterstr, "Köln", "50667", "", "de",
 			// Additional info
 			"", "Sehr ruhiges Kind", "", "Wird abgeholt", "Ja", 30, "Nein", "01.08.2024", "31.07.2025", "01.08.2024", "01.08.2024", "01.08.2024", "01.08.2024",
+			// Arrival schedule (Mon-Fri)
+			"08:00", "", "08:00", "", "08:00", "", "08:00", "", "08:30", "Frühbetreuung",
 			// Pickup schedule (Mon-Fri)
 			"16:00", "", "15:30", "", "16:00", "", "15:30", "", "14:00", "Frühschluss"},
 		{"Anna", "Schmidt", "2B", "Gruppe 2B", "22.03.14",
@@ -237,6 +240,8 @@ func getStudentImportExamples() [][]any {
 			"", "", "", "", "",
 			// Additional info
 			"Allergie: Nüsse", "", "Kann gut malen", "Geht alleine nach Hause", "Ja", 15, "Ja", "01.08.2024", "", "01.08.2024", "01.08.2024", "", "",
+			// Arrival schedule (partial)
+			"07:45", "", "07:45", "", "07:45", "", "", "", "", "",
 			// Pickup schedule (partial)
 			"15:00", "", "15:00", "", "15:00", "", "15:00", "", "", ""},
 	}

--- a/backend/models/import/student.go
+++ b/backend/models/import/student.go
@@ -34,6 +34,9 @@ type StudentImportRow struct {
 	// Pickup schedule (weekly recurring)
 	PickupSchedules []PickupScheduleImportData `json:"pickup_schedules,omitempty"`
 
+	// Arrival schedule (weekly recurring)
+	ArrivalSchedules []ArrivalScheduleImportData `json:"arrival_schedules,omitempty"`
+
 	// Privacy consent
 	PrivacyAccepted   bool `json:"privacy_accepted"`
 	DataRetentionDays int  `json:"data_retention_days"` // 1-31, default 30
@@ -47,6 +50,13 @@ type PickupScheduleImportData struct {
 	Weekday    int    `json:"weekday"`         // 1-5 (Mon-Fri)
 	PickupTime string `json:"pickup_time"`     // HH:MM format
 	Notes      string `json:"notes,omitempty"` // Day-specific notes
+}
+
+// ArrivalScheduleImportData represents a weekly arrival schedule entry from CSV
+type ArrivalScheduleImportData struct {
+	Weekday         int    `json:"weekday"`          // 1-5 (Mon-Fri)
+	ExpectedArrival string `json:"expected_arrival"` // HH:MM format
+	Notes           string `json:"notes,omitempty"`  // Day-specific notes
 }
 
 // PhoneImportData represents a phone number from CSV import

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -715,14 +715,15 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	relationshipResolver := importService.NewRelationshipResolver(repos.Group, repos.Room)
 	studentImportConfig := importService.NewStudentImportConfig(
 		importService.StudentImportDeps{
-			PersonRepo:         repos.Person,
-			StudentRepo:        repos.Student,
-			GuardianRepo:       repos.GuardianProfile,
-			GuardianPhoneRepo:  repos.GuardianPhoneNumber,
-			RelationRepo:       repos.StudentGuardian,
-			PrivacyRepo:        repos.PrivacyConsent,
-			PickupScheduleRepo: repos.StudentPickupSchedule,
-			Resolver:           relationshipResolver,
+			PersonRepo:          repos.Person,
+			StudentRepo:         repos.Student,
+			GuardianRepo:        repos.GuardianProfile,
+			GuardianPhoneRepo:   repos.GuardianPhoneNumber,
+			RelationRepo:        repos.StudentGuardian,
+			PrivacyRepo:         repos.PrivacyConsent,
+			ArrivalScheduleRepo: repos.StudentArrivalSchedule,
+			PickupScheduleRepo:  repos.StudentPickupSchedule,
+			Resolver:            relationshipResolver,
 		},
 		db,
 	)

--- a/backend/services/import/csv_parser_test.go
+++ b/backend/services/import/csv_parser_test.go
@@ -426,6 +426,25 @@ Max,Mustermann,1A,16:00,Hort,15:30,,16:00,,15:30,,14:00,Frühschluss`
 	assert.Equal(t, "Frühschluss", rows[0].PickupSchedules[4].Notes)
 }
 
+func TestCSVParser_ParseStudents_ArrivalSchedule(t *testing.T) {
+	csvData := `Vorname,Nachname,Klasse,Ankunft.Mo,Ankunft.Mo.Notizen,Ankunft.Di,Ankunft.Di.Notizen,Ankunft.Mi,Ankunft.Mi.Notizen,Ankunft.Do,Ankunft.Do.Notizen,Ankunft.Fr,Ankunft.Fr.Notizen
+Max,Mustermann,1A,08:00,Frühdienst,08:10,,08:00,,08:15,,08:30,Später Start`
+
+	parser := NewCSVParser()
+	rows, err := parser.ParseStudents(strings.NewReader(csvData))
+
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Len(t, rows[0].ArrivalSchedules, 5)
+
+	assert.Equal(t, 1, rows[0].ArrivalSchedules[0].Weekday)
+	assert.Equal(t, "08:00", rows[0].ArrivalSchedules[0].ExpectedArrival)
+	assert.Equal(t, "Frühdienst", rows[0].ArrivalSchedules[0].Notes)
+	assert.Equal(t, 5, rows[0].ArrivalSchedules[4].Weekday)
+	assert.Equal(t, "08:30", rows[0].ArrivalSchedules[4].ExpectedArrival)
+	assert.Equal(t, "Später Start", rows[0].ArrivalSchedules[4].Notes)
+}
+
 func TestCSVParser_ParseStudents_PickupSchedulePartial(t *testing.T) {
 	csvData := `Vorname,Nachname,Klasse,Abholung.Mo,Abholung.Mo.Notizen,Abholung.Di,Abholung.Di.Notizen,Abholung.Mi,Abholung.Mi.Notizen,Abholung.Do,Abholung.Do.Notizen,Abholung.Fr,Abholung.Fr.Notizen
 Max,Mustermann,1A,16:00,,,,,,,,,`
@@ -453,8 +472,8 @@ Max,Mustermann,1A`
 }
 
 func TestCSVParser_ParseStudents_FullRowWithAllNewFields(t *testing.T) {
-	csvData := `Vorname,Nachname,Klasse,Erz1.Vorname,Erz1.Nachname,Erz1.Email,Erz1.Telefon,Erz1.Verhältnis,Erz1.Hauptansprechpartner,Erz1.Notfall,Erz1.Abholberechtigt,Erz1.Straße,Erz1.Stadt,Erz1.PLZ,Erz1.Notizen,Erz1.Sprache,Abholung.Mo,Abholung.Mo.Notizen,Abholung.Fr,Abholung.Fr.Notizen
-Max,Mustermann,1A,Maria,Müller,maria@example.com,0123-456789,Mutter,Ja,Ja,Ja,Musterstr. 1,Köln,50667,Allergien,de,16:00,Hort,14:00,Frühschluss`
+	csvData := `Vorname,Nachname,Klasse,Erz1.Vorname,Erz1.Nachname,Erz1.Email,Erz1.Telefon,Erz1.Verhältnis,Erz1.Hauptansprechpartner,Erz1.Notfall,Erz1.Abholberechtigt,Erz1.Straße,Erz1.Stadt,Erz1.PLZ,Erz1.Notizen,Erz1.Sprache,Ankunft.Mo,Ankunft.Mo.Notizen,Ankunft.Fr,Ankunft.Fr.Notizen,Abholung.Mo,Abholung.Mo.Notizen,Abholung.Fr,Abholung.Fr.Notizen
+Max,Mustermann,1A,Maria,Müller,maria@example.com,0123-456789,Mutter,Ja,Ja,Ja,Musterstr. 1,Köln,50667,Allergien,de,08:00,Frühdienst,08:30,Später Start,16:00,Hort,14:00,Frühschluss`
 
 	parser := NewCSVParser()
 	rows, err := parser.ParseStudents(strings.NewReader(csvData))
@@ -475,6 +494,14 @@ Max,Mustermann,1A,Maria,Müller,maria@example.com,0123-456789,Mutter,Ja,Ja,Ja,Mu
 	assert.Equal(t, "50667", g.AddressPostalCode)
 	assert.Equal(t, "Allergien", g.Notes)
 	assert.Equal(t, "de", g.LanguagePreference)
+
+	require.Len(t, rows[0].ArrivalSchedules, 2)
+	assert.Equal(t, 1, rows[0].ArrivalSchedules[0].Weekday)
+	assert.Equal(t, "08:00", rows[0].ArrivalSchedules[0].ExpectedArrival)
+	assert.Equal(t, "Frühdienst", rows[0].ArrivalSchedules[0].Notes)
+	assert.Equal(t, 5, rows[0].ArrivalSchedules[1].Weekday)
+	assert.Equal(t, "08:30", rows[0].ArrivalSchedules[1].ExpectedArrival)
+	assert.Equal(t, "Später Start", rows[0].ArrivalSchedules[1].Notes)
 
 	// Pickup schedules
 	require.Len(t, rows[0].PickupSchedules, 2)

--- a/backend/services/import/helpers.go
+++ b/backend/services/import/helpers.go
@@ -206,6 +206,30 @@ func MapStudentRow(mapper *ColumnMapper) (importModels.StudentImportRow, error) 
 		}
 	}
 
+	// Parse arrival schedule (Mon-Fri) with per-day notes
+	arrivalDayColumns := []struct {
+		key      string
+		notesKey string
+		weekday  int
+	}{
+		{"ankunft.mo", "ankunft.mo.notizen", 1},
+		{"ankunft.di", "ankunft.di.notizen", 2},
+		{"ankunft.mi", "ankunft.mi.notizen", 3},
+		{"ankunft.do", "ankunft.do.notizen", 4},
+		{"ankunft.fr", "ankunft.fr.notizen", 5},
+	}
+	for _, d := range arrivalDayColumns {
+		timeStr := mapper.GetCol(d.key)
+		notes := mapper.GetCol(d.notesKey)
+		if timeStr != "" {
+			row.ArrivalSchedules = append(row.ArrivalSchedules, importModels.ArrivalScheduleImportData{
+				Weekday:         d.weekday,
+				ExpectedArrival: timeStr,
+				Notes:           notes,
+			})
+		}
+	}
+
 	return row, nil
 }
 

--- a/backend/services/import/helpers_test.go
+++ b/backend/services/import/helpers_test.go
@@ -666,6 +666,82 @@ func TestMapStudentRow_PickupSchedules(t *testing.T) {
 	})
 }
 
+func TestMapStudentRow_ArrivalSchedules(t *testing.T) {
+	t.Run("maps all five weekdays", func(t *testing.T) {
+		mapping := map[string]int{
+			"vorname":            0,
+			"nachname":           1,
+			"ankunft.mo":         2,
+			"ankunft.mo.notizen": 3,
+			"ankunft.di":         4,
+			"ankunft.di.notizen": 5,
+			"ankunft.mi":         6,
+			"ankunft.mi.notizen": 7,
+			"ankunft.do":         8,
+			"ankunft.do.notizen": 9,
+			"ankunft.fr":         10,
+			"ankunft.fr.notizen": 11,
+		}
+		values := []string{
+			"Max", "Mustermann",
+			"08:00", "Frühdienst",
+			"08:10", "",
+			"08:00", "",
+			"08:15", "",
+			"08:30", "Später Start",
+		}
+		mapper := NewColumnMapper(mapping, values)
+
+		row, err := MapStudentRow(mapper)
+
+		require.NoError(t, err)
+		require.Len(t, row.ArrivalSchedules, 5)
+
+		assert.Equal(t, 1, row.ArrivalSchedules[0].Weekday)
+		assert.Equal(t, "08:00", row.ArrivalSchedules[0].ExpectedArrival)
+		assert.Equal(t, "Frühdienst", row.ArrivalSchedules[0].Notes)
+		assert.Equal(t, 5, row.ArrivalSchedules[4].Weekday)
+		assert.Equal(t, "08:30", row.ArrivalSchedules[4].ExpectedArrival)
+		assert.Equal(t, "Später Start", row.ArrivalSchedules[4].Notes)
+	})
+
+	t.Run("skips empty days", func(t *testing.T) {
+		mapping := map[string]int{
+			"vorname":    0,
+			"nachname":   1,
+			"ankunft.mo": 2,
+			"ankunft.di": 3,
+			"ankunft.mi": 4,
+		}
+		values := []string{
+			"Max", "Mustermann",
+			"08:00", "", "08:15",
+		}
+		mapper := NewColumnMapper(mapping, values)
+
+		row, err := MapStudentRow(mapper)
+
+		require.NoError(t, err)
+		require.Len(t, row.ArrivalSchedules, 2)
+		assert.Equal(t, 1, row.ArrivalSchedules[0].Weekday)
+		assert.Equal(t, 3, row.ArrivalSchedules[1].Weekday)
+	})
+
+	t.Run("no arrival columns returns empty", func(t *testing.T) {
+		mapping := map[string]int{
+			"vorname":  0,
+			"nachname": 1,
+		}
+		values := []string{"Max", "Mustermann"}
+		mapper := NewColumnMapper(mapping, values)
+
+		row, err := MapStudentRow(mapper)
+
+		require.NoError(t, err)
+		assert.Empty(t, row.ArrivalSchedules)
+	})
+}
+
 // TestMapStudentRow_GuardianProfileFieldsEmpty tests that empty guardian profile fields are mapped as empty strings
 func TestMapStudentRow_GuardianProfileFieldsEmpty(t *testing.T) {
 	mapping := map[string]int{

--- a/backend/services/import/student_import_config.go
+++ b/backend/services/import/student_import_config.go
@@ -81,42 +81,45 @@ func MapRelationshipType(germanType string) string {
 
 // StudentImportConfig implements ImportConfig for student imports
 type StudentImportConfig struct {
-	personRepo         users.PersonRepository
-	studentRepo        users.StudentRepository
-	guardianRepo       users.GuardianProfileRepository
-	guardianPhoneRepo  users.GuardianPhoneNumberRepository
-	relationRepo       users.StudentGuardianRepository
-	privacyRepo        users.PrivacyConsentRepository
-	pickupScheduleRepo scheduleModels.StudentPickupScheduleRepository
-	resolver           *RelationshipResolver
-	txHandler          *base.TxHandler
+	personRepo          users.PersonRepository
+	studentRepo         users.StudentRepository
+	guardianRepo        users.GuardianProfileRepository
+	guardianPhoneRepo   users.GuardianPhoneNumberRepository
+	relationRepo        users.StudentGuardianRepository
+	privacyRepo         users.PrivacyConsentRepository
+	arrivalScheduleRepo scheduleModels.StudentArrivalScheduleRepository
+	pickupScheduleRepo  scheduleModels.StudentPickupScheduleRepository
+	resolver            *RelationshipResolver
+	txHandler           *base.TxHandler
 }
 
 // StudentImportDeps contains dependencies for StudentImportConfig
 type StudentImportDeps struct {
-	PersonRepo         users.PersonRepository
-	StudentRepo        users.StudentRepository
-	GuardianRepo       users.GuardianProfileRepository
-	GuardianPhoneRepo  users.GuardianPhoneNumberRepository
-	RelationRepo       users.StudentGuardianRepository
-	PrivacyRepo        users.PrivacyConsentRepository
-	PickupScheduleRepo scheduleModels.StudentPickupScheduleRepository
-	Resolver           *RelationshipResolver
+	PersonRepo          users.PersonRepository
+	StudentRepo         users.StudentRepository
+	GuardianRepo        users.GuardianProfileRepository
+	GuardianPhoneRepo   users.GuardianPhoneNumberRepository
+	RelationRepo        users.StudentGuardianRepository
+	PrivacyRepo         users.PrivacyConsentRepository
+	ArrivalScheduleRepo scheduleModels.StudentArrivalScheduleRepository
+	PickupScheduleRepo  scheduleModels.StudentPickupScheduleRepository
+	Resolver            *RelationshipResolver
 }
 
 // NewStudentImportConfig creates a new student import configuration
 // Note: RFID cards are not supported in CSV import and must be assigned separately
 func NewStudentImportConfig(deps StudentImportDeps, db *bun.DB) *StudentImportConfig {
 	return &StudentImportConfig{
-		personRepo:         deps.PersonRepo,
-		studentRepo:        deps.StudentRepo,
-		guardianRepo:       deps.GuardianRepo,
-		guardianPhoneRepo:  deps.GuardianPhoneRepo,
-		relationRepo:       deps.RelationRepo,
-		privacyRepo:        deps.PrivacyRepo,
-		pickupScheduleRepo: deps.PickupScheduleRepo,
-		resolver:           deps.Resolver,
-		txHandler:          base.NewTxHandler(db),
+		personRepo:          deps.PersonRepo,
+		studentRepo:         deps.StudentRepo,
+		guardianRepo:        deps.GuardianRepo,
+		guardianPhoneRepo:   deps.GuardianPhoneRepo,
+		relationRepo:        deps.RelationRepo,
+		privacyRepo:         deps.PrivacyRepo,
+		arrivalScheduleRepo: deps.ArrivalScheduleRepo,
+		pickupScheduleRepo:  deps.PickupScheduleRepo,
+		resolver:            deps.Resolver,
+		txHandler:           base.NewTxHandler(db),
 	}
 }
 
@@ -196,7 +199,8 @@ func (c *StudentImportConfig) Validate(ctx context.Context, row *importModels.St
 
 	}
 
-	// 5b. OPTIONAL: Pickup schedule validation
+	// 5b. OPTIONAL: Arrival and pickup schedule validation
+	errors = append(errors, validateArrivalSchedules(row.ArrivalSchedules)...)
 	errors = append(errors, validatePickupSchedules(row.PickupSchedules)...)
 
 	// 6. Birthday validation (if provided)
@@ -330,6 +334,30 @@ func validateConsentDates(row *importModels.StudentImportRow) []importModels.Val
 	validate(&row.EmailContactAcceptedAt, "email_contact_accepted_at", "E-Mail-Kontakt akzeptiert am")
 	validate(&row.PhotoConsentGivenAt, "photo_consent_given_at", "Foto-Einwilligung am")
 
+	return errors
+}
+
+// validateArrivalSchedules validates all arrival schedule entries
+func validateArrivalSchedules(schedules []importModels.ArrivalScheduleImportData) []importModels.ValidationError {
+	var errors []importModels.ValidationError
+	for _, sched := range schedules {
+		if sched.Weekday < 1 || sched.Weekday > 5 {
+			errors = append(errors, importModels.ValidationError{
+				Field:    "arrival_schedule",
+				Message:  fmt.Sprintf("Ungültiger Wochentag %d. Erlaubt: 1 (Mo) bis 5 (Fr)", sched.Weekday),
+				Code:     "invalid_weekday",
+				Severity: importModels.ErrorSeverityError,
+			})
+		}
+		if !isValidTimeFormat(sched.ExpectedArrival) {
+			errors = append(errors, importModels.ValidationError{
+				Field:    "arrival_schedule",
+				Message:  fmt.Sprintf("Ungültiges Zeitformat '%s'. Bitte HH:MM verwenden (z.B. 08:00)", sched.ExpectedArrival),
+				Code:     "invalid_time_format",
+				Severity: importModels.ErrorSeverityError,
+			})
+		}
+	}
 	return errors
 }
 
@@ -520,7 +548,7 @@ func (c *StudentImportConfig) Create(ctx context.Context, row importModels.Stude
 	return c.createAllEntities(ctx, row)
 }
 
-// createAllEntities creates person, student, guardians, privacy consent, and pickup schedules.
+// createAllEntities creates person, student, guardians, privacy consent, and weekly schedules.
 func (c *StudentImportConfig) createAllEntities(ctx context.Context, row importModels.StudentImportRow) (int64, error) {
 	person, err := c.createPersonFromRow(ctx, row)
 	if err != nil {
@@ -537,6 +565,10 @@ func (c *StudentImportConfig) createAllEntities(ctx context.Context, row importM
 	}
 
 	if err := c.createPrivacyConsentIfNeeded(ctx, student.ID, row); err != nil {
+		return 0, err
+	}
+
+	if err := c.createArrivalSchedules(ctx, student.ID, row.ArrivalSchedules); err != nil {
 		return 0, err
 	}
 
@@ -962,6 +994,36 @@ func guardianLanguagePreference(val string) string {
 		return "de"
 	}
 	return strings.ToLower(strings.TrimSpace(val))
+}
+
+// createArrivalSchedules creates weekly arrival schedule records for a student
+func (c *StudentImportConfig) createArrivalSchedules(ctx context.Context, studentID int64, schedules []importModels.ArrivalScheduleImportData) error {
+	if len(schedules) == 0 || c.arrivalScheduleRepo == nil {
+		return nil
+	}
+
+	for i, sched := range schedules {
+		parsed, err := time.Parse("15:04", sched.ExpectedArrival)
+		if err != nil {
+			return fmt.Errorf("arrival schedule %d: invalid time '%s': %w", i+1, sched.ExpectedArrival, err)
+		}
+		arrivalTime := time.Date(2024, 1, 1, parsed.Hour(), parsed.Minute(), 0, 0, time.UTC)
+
+		record := &scheduleModels.StudentArrivalSchedule{
+			StudentID:       studentID,
+			Weekday:         sched.Weekday,
+			ExpectedArrival: arrivalTime,
+			Notes:           stringPtr(sched.Notes),
+			CreatedBy:       ImporterIDFromContext(ctx),
+		}
+		record.SetTenantID(tenant.FromContext(ctx))
+
+		if err := c.arrivalScheduleRepo.Create(ctx, record); err != nil {
+			return fmt.Errorf("create arrival schedule (weekday %d): %w", sched.Weekday, err)
+		}
+	}
+
+	return nil
 }
 
 // createPickupSchedules creates weekly pickup schedule records for a student

--- a/backend/services/import/student_import_config_test.go
+++ b/backend/services/import/student_import_config_test.go
@@ -766,6 +766,76 @@ func TestStudentImportConfig_Validate_PickupSchedule(t *testing.T) {
 	}
 }
 
+func TestStudentImportConfig_Validate_ArrivalSchedule(t *testing.T) {
+	config := &StudentImportConfig{
+		resolver: &RelationshipResolver{
+			groupCache: make(map[string]*education.Group),
+		},
+	}
+
+	tests := []struct {
+		name      string
+		schedules []importModels.ArrivalScheduleImportData
+		wantCodes []string
+	}{
+		{
+			name: "valid schedule",
+			schedules: []importModels.ArrivalScheduleImportData{
+				{Weekday: 1, ExpectedArrival: "08:00"},
+				{Weekday: 5, ExpectedArrival: "08:30"},
+			},
+			wantCodes: nil,
+		},
+		{
+			name: "invalid weekday",
+			schedules: []importModels.ArrivalScheduleImportData{
+				{Weekday: 6, ExpectedArrival: "08:00"},
+			},
+			wantCodes: []string{"invalid_weekday"},
+		},
+		{
+			name: "invalid time format",
+			schedules: []importModels.ArrivalScheduleImportData{
+				{Weekday: 1, ExpectedArrival: "morgens"},
+			},
+			wantCodes: []string{"invalid_time_format"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			row := importModels.StudentImportRow{
+				FirstName:         "Max",
+				LastName:          "Mustermann",
+				SchoolClass:       "1A",
+				ArrivalSchedules:  tt.schedules,
+				DataRetentionDays: 30,
+			}
+
+			errors := config.Validate(context.Background(), &row)
+
+			for _, expectedCode := range tt.wantCodes {
+				found := false
+				for _, err := range errors {
+					if err.Code == expectedCode {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Expected error code '%s' not found", expectedCode)
+			}
+
+			if tt.wantCodes == nil {
+				for _, err := range errors {
+					if err.Field == "arrival_schedule" {
+						t.Errorf("Unexpected arrival schedule error: %s", err.Message)
+					}
+				}
+			}
+		})
+	}
+}
+
 // ============================================================================
 // isValidTimeFormat Tests
 // ============================================================================
@@ -964,6 +1034,31 @@ func TestStudentImportConfig_Validate_PickupScheduleErrorMessages(t *testing.T) 
 // ============================================================================
 // createPickupSchedules nil-repo safety
 // ============================================================================
+
+func TestStudentImportConfig_CreateArrivalSchedules_NilRepo(t *testing.T) {
+	config := &StudentImportConfig{
+		arrivalScheduleRepo: nil,
+	}
+
+	schedules := []importModels.ArrivalScheduleImportData{
+		{Weekday: 1, ExpectedArrival: "08:00"},
+	}
+
+	err := config.createArrivalSchedules(context.Background(), 123, schedules)
+	assert.NoError(t, err, "should not error when arrivalScheduleRepo is nil")
+}
+
+func TestStudentImportConfig_CreateArrivalSchedules_EmptySchedules(t *testing.T) {
+	config := &StudentImportConfig{
+		arrivalScheduleRepo: nil,
+	}
+
+	err := config.createArrivalSchedules(context.Background(), 123, nil)
+	assert.NoError(t, err)
+
+	err = config.createArrivalSchedules(context.Background(), 123, []importModels.ArrivalScheduleImportData{})
+	assert.NoError(t, err)
+}
 
 func TestStudentImportConfig_CreatePickupSchedules_NilRepo(t *testing.T) {
 	config := &StudentImportConfig{

--- a/backend/services/import/xlsx_parser_test.go
+++ b/backend/services/import/xlsx_parser_test.go
@@ -385,6 +385,42 @@ func TestXLSXParser_ParseStudents_GuardianProfileFields(t *testing.T) {
 // Pickup Schedule Tests
 // ============================================================================
 
+func TestXLSXParser_ParseStudents_ArrivalSchedule(t *testing.T) {
+	t.Run("parses all five weekdays with notes", func(t *testing.T) {
+		headers := []string{
+			"Vorname", "Nachname", "Klasse",
+			"Ankunft.Mo", "Ankunft.Mo.Notizen",
+			"Ankunft.Di", "Ankunft.Di.Notizen",
+			"Ankunft.Mi", "Ankunft.Mi.Notizen",
+			"Ankunft.Do", "Ankunft.Do.Notizen",
+			"Ankunft.Fr", "Ankunft.Fr.Notizen",
+		}
+		rows := [][]string{
+			{"Max", "Mustermann", "1A",
+				"08:00", "Frühdienst",
+				"08:10", "",
+				"08:00", "",
+				"08:15", "",
+				"08:30", "Später Start"},
+		}
+		buf := createTestXLSX(t, headers, rows)
+
+		parser := NewXLSXParser()
+		students, err := parser.ParseStudents(buf)
+
+		require.NoError(t, err)
+		require.Len(t, students, 1)
+		require.Len(t, students[0].ArrivalSchedules, 5)
+
+		assert.Equal(t, 1, students[0].ArrivalSchedules[0].Weekday)
+		assert.Equal(t, "08:00", students[0].ArrivalSchedules[0].ExpectedArrival)
+		assert.Equal(t, "Frühdienst", students[0].ArrivalSchedules[0].Notes)
+		assert.Equal(t, 5, students[0].ArrivalSchedules[4].Weekday)
+		assert.Equal(t, "08:30", students[0].ArrivalSchedules[4].ExpectedArrival)
+		assert.Equal(t, "Später Start", students[0].ArrivalSchedules[4].Notes)
+	})
+}
+
 func TestXLSXParser_ParseStudents_PickupSchedule(t *testing.T) {
 	t.Run("parses all five weekdays with notes", func(t *testing.T) {
 		headers := []string{
@@ -475,6 +511,8 @@ func TestXLSXParser_ParseStudents_FullRowAllNewFields(t *testing.T) {
 		"Erz1.Verhältnis", "Erz1.Hauptansprechpartner", "Erz1.Notfall", "Erz1.Abholberechtigt",
 		"Erz1.Straße", "Erz1.Stadt", "Erz1.PLZ",
 		"Erz1.Notizen", "Erz1.Sprache",
+		"Ankunft.Mo", "Ankunft.Mo.Notizen",
+		"Ankunft.Fr", "Ankunft.Fr.Notizen",
 		"Abholung.Mo", "Abholung.Mo.Notizen",
 		"Abholung.Fr", "Abholung.Fr.Notizen",
 	}
@@ -484,6 +522,8 @@ func TestXLSXParser_ParseStudents_FullRowAllNewFields(t *testing.T) {
 			"Mutter", "Ja", "Ja", "Ja",
 			"Musterstr. 1", "Köln", "50667",
 			"Allergien", "de",
+			"08:00", "Frühdienst",
+			"08:30", "Später Start",
 			"16:00", "Hort",
 			"14:00", "Frühschluss"},
 	}
@@ -505,6 +545,14 @@ func TestXLSXParser_ParseStudents_FullRowAllNewFields(t *testing.T) {
 	assert.Equal(t, "50667", g.AddressPostalCode)
 	assert.Equal(t, "Allergien", g.Notes)
 	assert.Equal(t, "de", g.LanguagePreference)
+
+	require.Len(t, students[0].ArrivalSchedules, 2)
+	assert.Equal(t, 1, students[0].ArrivalSchedules[0].Weekday)
+	assert.Equal(t, "08:00", students[0].ArrivalSchedules[0].ExpectedArrival)
+	assert.Equal(t, "Frühdienst", students[0].ArrivalSchedules[0].Notes)
+	assert.Equal(t, 5, students[0].ArrivalSchedules[1].Weekday)
+	assert.Equal(t, "08:30", students[0].ArrivalSchedules[1].ExpectedArrival)
+	assert.Equal(t, "Später Start", students[0].ArrivalSchedules[1].Notes)
 
 	// Pickup
 	require.Len(t, students[0].PickupSchedules, 2)


### PR DESCRIPTION
## Summary
- extend the student CSV/XLSX import templates with  to  plus notes
- parse, validate, and persist weekly arrival schedules during student import
- add tests for mapper, CSV parser, XLSX parser, and import validation

## Testing
- cd backend && go test ./services/import
- cd backend && go test ./api/import
- cd backend && go test ./test/ -run TestHermeticTestPatterns -v
- cd frontend && pnpm run check