### PR TITLE
Add caregiver option to school admin invites

### DIFF
--- a/backend/api/operator/provisioning.go
+++ b/backend/api/operator/provisioning.go
@@ -129,28 +129,30 @@ func (req *updateSchoolRequest) Bind(_ *http.Request) error {
 }
 
 type inviteSchoolAdminRequest struct {
-	Email     string `json:"email"`
-	FirstName string `json:"first_name,omitempty"`
-	LastName  string `json:"last_name,omitempty"`
-	Position  string `json:"position,omitempty"`
+	Email            string `json:"email"`
+	FirstName        string `json:"first_name,omitempty"`
+	LastName         string `json:"last_name,omitempty"`
+	Position         string `json:"position,omitempty"`
+	CaregiverEnabled bool   `json:"caregiver_enabled,omitempty"`
 }
 
 type operatorInvitationResponse struct {
-	ID              int64      `json:"id"`
-	Email           string     `json:"email"`
-	RoleID          int64      `json:"role_id"`
-	RoleName        string     `json:"role_name,omitempty"`
-	Token           *string    `json:"token,omitempty"`
-	ExpiresAt       time.Time  `json:"expires_at"`
-	FirstName       *string    `json:"first_name,omitempty"`
-	LastName        *string    `json:"last_name,omitempty"`
-	Position        *string    `json:"position,omitempty"`
-	CreatedBy       int64      `json:"created_by"`
-	Creator         string     `json:"creator,omitempty"`
-	DeliveryStatus  string     `json:"delivery_status"`
-	EmailSentAt     *time.Time `json:"email_sent_at,omitempty"`
-	EmailError      *string    `json:"email_error,omitempty"`
-	EmailRetryCount int        `json:"email_retry_count"`
+	ID               int64      `json:"id"`
+	Email            string     `json:"email"`
+	RoleID           int64      `json:"role_id"`
+	RoleName         string     `json:"role_name,omitempty"`
+	Token            *string    `json:"token,omitempty"`
+	ExpiresAt        time.Time  `json:"expires_at"`
+	FirstName        *string    `json:"first_name,omitempty"`
+	LastName         *string    `json:"last_name,omitempty"`
+	Position         *string    `json:"position,omitempty"`
+	CaregiverEnabled bool       `json:"caregiver_enabled"`
+	CreatedBy        int64      `json:"created_by"`
+	Creator          string     `json:"creator,omitempty"`
+	DeliveryStatus   string     `json:"delivery_status"`
+	EmailSentAt      *time.Time `json:"email_sent_at,omitempty"`
+	EmailError       *string    `json:"email_error,omitempty"`
+	EmailRetryCount  int        `json:"email_retry_count"`
 }
 
 func (req *inviteSchoolAdminRequest) Bind(_ *http.Request) error {
@@ -389,7 +391,10 @@ func (rs *ProvisioningResource) InviteSchoolAdmin(w http.ResponseWriter, r *http
 		return
 	}
 	operatorID := int64(jwt.ClaimsFromCtx(r.Context()).ID)
-	invitationReq := authSvc.InvitationRequest{Email: req.Email}
+	invitationReq := authSvc.InvitationRequest{
+		Email:            req.Email,
+		CaregiverEnabled: req.CaregiverEnabled,
+	}
 	if req.FirstName != "" {
 		first := req.FirstName
 		invitationReq.FirstName = &first
@@ -408,18 +413,19 @@ func (rs *ProvisioningResource) InviteSchoolAdmin(w http.ResponseWriter, r *http
 		return
 	}
 	resp := operatorInvitationResponse{
-		ID:              invitation.ID,
-		Email:           invitation.Email,
-		RoleID:          invitation.RoleID,
-		ExpiresAt:       invitation.ExpiresAt,
-		FirstName:       invitation.FirstName,
-		LastName:        invitation.LastName,
-		Position:        invitation.Position,
-		CreatedBy:       operatorInvitationCreatedByValue(invitation.CreatedBy),
-		DeliveryStatus:  operatorInvitationDeliveryStatus(invitation.EmailSentAt, invitation.EmailError),
-		EmailSentAt:     invitation.EmailSentAt,
-		EmailError:      invitation.EmailError,
-		EmailRetryCount: invitation.EmailRetryCount,
+		ID:               invitation.ID,
+		Email:            invitation.Email,
+		RoleID:           invitation.RoleID,
+		ExpiresAt:        invitation.ExpiresAt,
+		FirstName:        invitation.FirstName,
+		LastName:         invitation.LastName,
+		Position:         invitation.Position,
+		CaregiverEnabled: invitation.CaregiverEnabled,
+		CreatedBy:        operatorInvitationCreatedByValue(invitation.CreatedBy),
+		DeliveryStatus:   operatorInvitationDeliveryStatus(invitation.EmailSentAt, invitation.EmailError),
+		EmailSentAt:      invitation.EmailSentAt,
+		EmailError:       invitation.EmailError,
+		EmailRetryCount:  invitation.EmailRetryCount,
 	}
 	if invitation.Role != nil {
 		resp.RoleName = invitation.Role.Name

--- a/backend/api/operator/provisioning_internal_test.go
+++ b/backend/api/operator/provisioning_internal_test.go
@@ -415,25 +415,27 @@ func TestProvisioningResource_InviteSchoolAdmin(t *testing.T) {
 			require.NotNil(t, req.LastName)
 			require.NotNil(t, req.Position)
 			assert.Equal(t, "principal@example.com", req.Email)
+			assert.True(t, req.CaregiverEnabled)
 			return &authModels.InvitationToken{
-				Model:      modelBase.Model{ID: 5},
-				Email:      req.Email,
-				RoleID:     9,
-				Token:      token,
-				ExpiresAt:  expiresAt,
-				FirstName:  &first,
-				LastName:   &last,
-				Position:   &position,
-				CreatedBy:  nil,
-				Role:       &authModels.Role{Name: roleName},
-				Creator:    &authModels.Account{Email: creatorEmail},
-				EmailError: nil,
+				Model:            modelBase.Model{ID: 5},
+				Email:            req.Email,
+				RoleID:           9,
+				Token:            token,
+				ExpiresAt:        expiresAt,
+				FirstName:        &first,
+				LastName:         &last,
+				Position:         &position,
+				CaregiverEnabled: req.CaregiverEnabled,
+				CreatedBy:        nil,
+				Role:             &authModels.Role{Name: roleName},
+				Creator:          &authModels.Account{Email: creatorEmail},
+				EmailError:       nil,
 			}, nil
 		},
 	})
 
 	viper.Set("app_env", "development")
-	req := httptest.NewRequest(http.MethodPost, "/operator/schools/12/invite-admin", bytes.NewBufferString(`{"email":" PRINCIPAL@example.com ","first_name":" Ada ","last_name":" Lovelace ","position":" Principal "}`))
+	req := httptest.NewRequest(http.MethodPost, "/operator/schools/12/invite-admin", bytes.NewBufferString(`{"email":" PRINCIPAL@example.com ","first_name":" Ada ","last_name":" Lovelace ","position":" Principal ","caregiver_enabled":true}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(seedTokenHeader, "true")
 	req.RemoteAddr = "203.0.113.5:9999"
@@ -451,6 +453,7 @@ func TestProvisioningResource_InviteSchoolAdmin(t *testing.T) {
 	assert.Equal(t, float64(0), data["created_by"])
 	assert.Equal(t, roleName, data["role_name"])
 	assert.Equal(t, creatorEmail, data["creator"])
+	assert.Equal(t, true, data["caregiver_enabled"])
 }
 
 func TestProvisioningResource_InviteSchoolAdmin_InvalidSchoolID(t *testing.T) {
@@ -864,10 +867,11 @@ func TestCreateSchoolRequest_Bind_TrimAndLowercaseEmail(t *testing.T) {
 
 func TestInviteSchoolAdminRequest_Bind_TrimAndLowercaseEmail(t *testing.T) {
 	req := &inviteSchoolAdminRequest{
-		Email:     "  ADMIN@EXAMPLE.COM  ",
-		FirstName: "  Ada  ",
-		LastName:  "  Lovelace  ",
-		Position:  "  Principal  ",
+		Email:            "  ADMIN@EXAMPLE.COM  ",
+		FirstName:        "  Ada  ",
+		LastName:         "  Lovelace  ",
+		Position:         "  Principal  ",
+		CaregiverEnabled: true,
 	}
 	err := req.Bind(nil)
 	require.NoError(t, err)
@@ -875,6 +879,7 @@ func TestInviteSchoolAdminRequest_Bind_TrimAndLowercaseEmail(t *testing.T) {
 	assert.Equal(t, "Ada", req.FirstName)
 	assert.Equal(t, "Lovelace", req.LastName)
 	assert.Equal(t, "Principal", req.Position)
+	assert.True(t, req.CaregiverEnabled)
 }
 
 func TestCreateDeviceRequest_Bind_TrimWhitespace(t *testing.T) {

--- a/backend/database/migrations/001015100_invitation_tokens_caregiver_enabled.go
+++ b/backend/database/migrations/001015100_invitation_tokens_caregiver_enabled.go
@@ -1,0 +1,44 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	invitationTokensCaregiverEnabledVersion     = "1.15.100"
+	invitationTokensCaregiverEnabledDescription = "Add caregiver_enabled flag to auth.invitation_tokens for operator admin invitations with caregiver capability"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     invitationTokensCaregiverEnabledVersion,
+		Description: invitationTokensCaregiverEnabledDescription,
+		DependsOn:   []string{AddPositionToInvitationTokensVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Migration 1.15.100: Adding caregiver_enabled to auth.invitation_tokens...")
+			if _, err := db.NewRaw(`
+				ALTER TABLE auth.invitation_tokens
+					ADD COLUMN IF NOT EXISTS caregiver_enabled boolean NOT NULL DEFAULT false;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed adding caregiver_enabled to auth.invitation_tokens: %w", err)
+			}
+			return nil
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Rolling back migration 1.15.100: Removing caregiver_enabled from auth.invitation_tokens...")
+			if _, err := db.NewRaw(`
+				ALTER TABLE auth.invitation_tokens
+					DROP COLUMN IF EXISTS caregiver_enabled;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed dropping caregiver_enabled from auth.invitation_tokens: %w", err)
+			}
+			return nil
+		},
+	)
+}

--- a/backend/models/auth/invitation_token.go
+++ b/backend/models/auth/invitation_token.go
@@ -14,18 +14,19 @@ type InvitationToken struct {
 	base.Model `bun:"schema:auth,table:invitation_tokens"`
 	base.TenantModel
 
-	Email           string     `bun:"email,notnull" json:"email"`
-	Token           string     `bun:"token,notnull" json:"token"`
-	RoleID          int64      `bun:"role_id,notnull" json:"role_id"`
-	CreatedBy       *int64     `bun:"created_by,nullzero" json:"created_by,omitempty"`
-	ExpiresAt       time.Time  `bun:"expires_at,notnull" json:"expires_at"`
-	UsedAt          *time.Time `bun:"used_at,nullzero" json:"used_at,omitempty"`
-	FirstName       *string    `bun:"first_name,nullzero" json:"first_name,omitempty"`
-	LastName        *string    `bun:"last_name,nullzero" json:"last_name,omitempty"`
-	Position        *string    `bun:"position,nullzero" json:"position,omitempty"`
-	EmailSentAt     *time.Time `bun:"email_sent_at,nullzero" json:"email_sent_at,omitempty"`
-	EmailError      *string    `bun:"email_error,nullzero" json:"email_error,omitempty"`
-	EmailRetryCount int        `bun:"email_retry_count,notnull,default:0" json:"email_retry_count"`
+	Email            string     `bun:"email,notnull" json:"email"`
+	Token            string     `bun:"token,notnull" json:"token"`
+	RoleID           int64      `bun:"role_id,notnull" json:"role_id"`
+	CreatedBy        *int64     `bun:"created_by,nullzero" json:"created_by,omitempty"`
+	ExpiresAt        time.Time  `bun:"expires_at,notnull" json:"expires_at"`
+	UsedAt           *time.Time `bun:"used_at,nullzero" json:"used_at,omitempty"`
+	FirstName        *string    `bun:"first_name,nullzero" json:"first_name,omitempty"`
+	LastName         *string    `bun:"last_name,nullzero" json:"last_name,omitempty"`
+	Position         *string    `bun:"position,nullzero" json:"position,omitempty"`
+	CaregiverEnabled bool       `bun:"caregiver_enabled,notnull,default:false" json:"caregiver_enabled"`
+	EmailSentAt      *time.Time `bun:"email_sent_at,nullzero" json:"email_sent_at,omitempty"`
+	EmailError       *string    `bun:"email_error,nullzero" json:"email_error,omitempty"`
+	EmailRetryCount  int        `bun:"email_retry_count,notnull,default:0" json:"email_retry_count"`
 
 	// Relations
 	Role    *Role    `bun:"rel:belongs-to,join:role_id=id" json:"role,omitempty"`

--- a/backend/services/auth/invitation_interface.go
+++ b/backend/services/auth/invitation_interface.go
@@ -10,14 +10,15 @@ import (
 
 // InvitationRequest describes the data required to create a new invitation.
 type InvitationRequest struct {
-	Email      string
-	RoleID     int64
-	TenantID   int64
-	FirstName  *string
-	LastName   *string
-	Position   *string
-	CreatedBy  int64
-	SchoolName string // Display name of the tenant (shown in invitation email)
+	Email            string
+	RoleID           int64
+	TenantID         int64
+	FirstName        *string
+	LastName         *string
+	Position         *string
+	CaregiverEnabled bool
+	CreatedBy        int64
+	SchoolName       string // Display name of the tenant (shown in invitation email)
 }
 
 // UserRegistrationData captures the information supplied when accepting an invitation.
@@ -30,12 +31,13 @@ type UserRegistrationData struct {
 
 // InvitationValidationResult represents the public-safe view of an invitation.
 type InvitationValidationResult struct {
-	Email     string    `json:"email"`
-	RoleName  string    `json:"role_name"`
-	FirstName *string   `json:"first_name,omitempty"`
-	LastName  *string   `json:"last_name,omitempty"`
-	Position  *string   `json:"position,omitempty"`
-	ExpiresAt time.Time `json:"expires_at"`
+	Email            string    `json:"email"`
+	RoleName         string    `json:"role_name"`
+	FirstName        *string   `json:"first_name,omitempty"`
+	LastName         *string   `json:"last_name,omitempty"`
+	Position         *string   `json:"position,omitempty"`
+	CaregiverEnabled bool      `json:"caregiver_enabled"`
+	ExpiresAt        time.Time `json:"expires_at"`
 }
 
 // InvitationService defines the operations for managing invitation workflows.

--- a/backend/services/auth/invitation_service.go
+++ b/backend/services/auth/invitation_service.go
@@ -244,10 +244,11 @@ func (s *invitationService) invalidatePreviousInvitations(ctx context.Context, e
 // buildInvitationToken constructs the invitation token with optional fields.
 func (s *invitationService) buildInvitationToken(email string, req InvitationRequest) *authModels.InvitationToken {
 	invitation := &authModels.InvitationToken{
-		Email:     email,
-		Token:     uuid.Must(uuid.NewV4()).String(),
-		RoleID:    req.RoleID,
-		ExpiresAt: time.Now().Add(s.invitationExpiry),
+		Email:            email,
+		Token:            uuid.Must(uuid.NewV4()).String(),
+		RoleID:           req.RoleID,
+		ExpiresAt:        time.Now().Add(s.invitationExpiry),
+		CaregiverEnabled: req.CaregiverEnabled,
 	}
 	if req.CreatedBy > 0 {
 		invitation.CreatedBy = nullableCreatedBy(req.CreatedBy)
@@ -312,12 +313,13 @@ func (s *invitationService) ValidateInvitation(ctx context.Context, token string
 		}
 
 		result = &InvitationValidationResult{
-			Email:     invitation.Email,
-			RoleName:  roleName,
-			FirstName: invitation.FirstName,
-			LastName:  invitation.LastName,
-			Position:  invitation.Position,
-			ExpiresAt: invitation.ExpiresAt,
+			Email:            invitation.Email,
+			RoleName:         roleName,
+			FirstName:        invitation.FirstName,
+			LastName:         invitation.LastName,
+			Position:         invitation.Position,
+			CaregiverEnabled: invitation.CaregiverEnabled,
+			ExpiresAt:        invitation.ExpiresAt,
 		}
 		return nil
 	})
@@ -475,6 +477,10 @@ func (s *invitationService) createAccountWithRole(
 		return nil, err
 	}
 
+	if err := s.assignCaregiverRoleIfRequested(ctx, account.ID, invitation); err != nil {
+		return nil, err
+	}
+
 	if err := s.createAccountTenant(ctx, account.ID, invitation.TenantID); err != nil {
 		return nil, err
 	}
@@ -625,6 +631,33 @@ func (s *invitationService) createAccountTenant(ctx context.Context, accountID, 
 	return nil
 }
 
+func (s *invitationService) assignCaregiverRoleIfRequested(ctx context.Context, accountID int64, invitation *authModels.InvitationToken) error {
+	if !invitation.CaregiverEnabled {
+		return nil
+	}
+
+	role, err := s.roleRepo.FindByID(ctx, invitation.RoleID)
+	if err != nil {
+		return &AuthError{Op: "assign caregiver role", Err: err}
+	}
+	if role == nil {
+		return &AuthError{Op: "assign caregiver role", Err: fmt.Errorf("role not found")}
+	}
+	if shouldCreateTeacherForRole(role.Name) {
+		return nil
+	}
+
+	userRole, err := s.roleRepo.FindByName(ctx, "user")
+	if err != nil {
+		return &AuthError{Op: "assign caregiver role", Err: err}
+	}
+	if userRole == nil {
+		return &AuthError{Op: "assign caregiver role", Err: fmt.Errorf("user role not found")}
+	}
+
+	return s.assignRole(ctx, accountID, userRole.ID, invitation.TenantID)
+}
+
 // createStaffAndTeacherIfSystemRole creates staff and teacher records for system roles.
 func (s *invitationService) createStaffAndTeacherIfSystemRole(
 	ctx context.Context,
@@ -642,7 +675,7 @@ func (s *invitationService) createStaffAndTeacherIfSystemRole(
 		return &AuthError{Op: "create staff", Err: err}
 	}
 
-	if !shouldCreateTeacherForRole(role.Name) {
+	if !shouldCreateTeacherForRole(role.Name) && !invitation.CaregiverEnabled {
 		return nil
 	}
 

--- a/backend/services/auth/invitation_service.go
+++ b/backend/services/auth/invitation_service.go
@@ -647,7 +647,7 @@ func (s *invitationService) assignCaregiverRoleIfRequested(ctx context.Context, 
 		return nil
 	}
 
-	userRole, err := s.roleRepo.FindByName(ctx, "user")
+	userRole, err := s.resolveSystemRoleByName(ctx, authModels.BaseRoleUser)
 	if err != nil {
 		return &AuthError{Op: "assign caregiver role", Err: err}
 	}
@@ -656,6 +656,25 @@ func (s *invitationService) assignCaregiverRoleIfRequested(ctx context.Context, 
 	}
 
 	return s.assignRole(ctx, accountID, userRole.ID, invitation.TenantID)
+}
+
+func (s *invitationService) resolveSystemRoleByName(ctx context.Context, name string) (*authModels.Role, error) {
+	roles, err := s.roleRepo.List(ctx, map[string]interface{}{
+		"name":      strings.TrimSpace(strings.ToLower(name)),
+		"is_system": true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, role := range roles {
+		if role == nil {
+			continue
+		}
+		if role.TenantID == nil && role.IsSystem && strings.EqualFold(role.Name, name) {
+			return role, nil
+		}
+	}
+	return nil, nil
 }
 
 // createStaffAndTeacherIfSystemRole creates staff and teacher records for system roles.

--- a/backend/services/auth/invitation_service_test.go
+++ b/backend/services/auth/invitation_service_test.go
@@ -528,9 +528,11 @@ func TestAcceptInvitation_AdminCaregiverEnabledCreatesUserRoleAndTeacherProfile(
 
 	invitations := newStubInvitationTokenRepository()
 	accounts := newStubAccountRepository()
+	tenantID := int64(42)
 	roles := newStubRoleRepository(
 		&authModel.Role{Model: baseModel.Model{ID: 21}, Name: "admin", IsSystem: true},
 		&authModel.Role{Model: baseModel.Model{ID: 22}, Name: "user", IsSystem: true},
+		&authModel.Role{Model: baseModel.Model{ID: 23}, TenantID: &tenantID, Name: "user", IsSystem: false},
 	)
 	accountRoles := newStubAccountRoleRepository()
 	persons := newStubPersonRepository()
@@ -563,7 +565,7 @@ func TestAcceptInvitation_AdminCaregiverEnabledCreatesUserRoleAndTeacherProfile(
 		Position:         &position,
 		CaregiverEnabled: true,
 	}
-	token.SetTenantID(42)
+	token.SetTenantID(tenantID)
 	require.NoError(t, invitations.Create(context.Background(), token))
 
 	expectAdminTx(mock)
@@ -581,17 +583,18 @@ func TestAcceptInvitation_AdminCaregiverEnabledCreatesUserRoleAndTeacherProfile(
 	require.Len(t, assignments, 2)
 	require.Equal(t, int64(21), assignments[0].RoleID)
 	require.Equal(t, int64(22), assignments[1].RoleID)
-	require.Equal(t, int64(42), assignments[0].TenantID)
-	require.Equal(t, int64(42), assignments[1].TenantID)
+	require.NotEqual(t, int64(23), assignments[1].RoleID, "caregiver capability must use the global system user role, not a tenant-owned role with the same name")
+	require.Equal(t, tenantID, assignments[0].TenantID)
+	require.Equal(t, tenantID, assignments[1].TenantID)
 
 	createdStaff := staff.All()
 	require.Len(t, createdStaff, 1)
-	require.Equal(t, int64(42), createdStaff[0].TenantID)
+	require.Equal(t, tenantID, createdStaff[0].TenantID)
 
 	createdTeachers := teachers.All()
 	require.Len(t, createdTeachers, 1)
 	require.Equal(t, createdStaff[0].ID, createdTeachers[0].StaffID)
-	require.Equal(t, int64(42), createdTeachers[0].TenantID)
+	require.Equal(t, tenantID, createdTeachers[0].TenantID)
 	require.Equal(t, position, createdTeachers[0].Role)
 }
 

--- a/backend/services/auth/invitation_service_test.go
+++ b/backend/services/auth/invitation_service_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/moto-nrw/project-phoenix/email"
 	authModel "github.com/moto-nrw/project-phoenix/models/auth"
 	baseModel "github.com/moto-nrw/project-phoenix/models/base"
+	userModel "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
 // testStrongCredential is a valid credential for unit tests that meets strength requirements.
@@ -811,4 +813,725 @@ func TestAcceptInvitationReactivatesInactiveAccount(t *testing.T) {
 	require.NoError(t, findErr)
 	require.True(t, stored.Active, "stored account must reflect activation")
 	require.NotEqual(t, existingHash, *stored.PasswordHash)
+}
+
+func TestCreateInvitationRejectsInvalidRequests(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     InvitationRequest
+		wantErr error
+	}{
+		{
+			name:    "empty email",
+			req:     InvitationRequest{Email: " ", RoleID: 1},
+			wantErr: fmt.Errorf("email is required"),
+		},
+		{
+			name:    "invalid email",
+			req:     InvitationRequest{Email: "not-an-email", RoleID: 1},
+			wantErr: fmt.Errorf("invalid email address"),
+		},
+		{
+			name:    "missing role id",
+			req:     InvitationRequest{Email: "person@example.com"},
+			wantErr: fmt.Errorf("role id is required"),
+		},
+		{
+			name:    "negative created by",
+			req:     InvitationRequest{Email: "person@example.com", RoleID: 1, CreatedBy: -10},
+			wantErr: fmt.Errorf("created_by is invalid"),
+		},
+		{
+			name:    "negative tenant id",
+			req:     InvitationRequest{Email: "person@example.com", RoleID: 1, TenantID: -10},
+			wantErr: fmt.Errorf("tenant id is invalid"),
+		},
+		{
+			name:    "unknown role",
+			req:     InvitationRequest{Email: "person@example.com", RoleID: 404},
+			wantErr: fmt.Errorf("role not found"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, _, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+			t.Cleanup(cleanup)
+
+			_, err := service.CreateInvitation(context.Background(), tt.req)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr.Error())
+		})
+	}
+}
+
+func TestCreateInvitationRejectsExistingAccountWithoutTargetTenant(t *testing.T) {
+	service, _, accounts, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+	t.Cleanup(cleanup)
+
+	accounts.storeAccount(&authModel.Account{
+		Model:  baseModel.Model{ID: 101},
+		Email:  "existing@example.com",
+		Active: true,
+	})
+
+	_, err := service.CreateInvitation(context.Background(), InvitationRequest{
+		Email:  "existing@example.com",
+		RoleID: 1,
+	})
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrEmailAlreadyExists), "expected ErrEmailAlreadyExists, got %v", err)
+}
+
+func TestCreateInvitationRejectsExistingTenantAccess(t *testing.T) {
+	invitations := newStubInvitationTokenRepository()
+	accounts := newStubAccountRepository(&authModel.Account{
+		Model:  baseModel.Model{ID: 102},
+		Email:  "existing@example.com",
+		Active: true,
+	})
+	accountTenants := newStubAccountTenantRepository()
+	require.NoError(t, accountTenants.Create(context.Background(), &authModel.AccountTenant{
+		AccountID: 102,
+		TenantID:  77,
+		Status:    authModel.AccountTenantStatusActive,
+	}))
+	service := NewInvitationService(InvitationServiceConfig{
+		InvitationRepo:    invitations,
+		AccountRepo:       accounts,
+		AccountTenantRepo: accountTenants,
+		RoleRepo:          newStubRoleRepository(&authModel.Role{Model: baseModel.Model{ID: 1}, Name: "Admin"}),
+		AccountRoleRepo:   newStubAccountRoleRepository(),
+		PersonRepo:        newStubPersonRepository(),
+		StaffRepo:         newStubStaffRepository(),
+		TeacherRepo:       newStubTeacherRepository(),
+		SchoolRepo:        &stubSchoolRepository{},
+		FrontendURL:       "http://localhost:3000",
+		DefaultFrom:       newDefaultFromEmail(),
+		InvitationExpiry:  48 * time.Hour,
+	})
+
+	_, err := service.CreateInvitation(context.Background(), InvitationRequest{
+		Email:    "existing@example.com",
+		RoleID:   1,
+		TenantID: 77,
+	})
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrAccountAlreadyHasTenantAccess),
+		"expected ErrAccountAlreadyHasTenantAccess, got %v", err)
+}
+
+func TestAcceptInvitationUsesInvitationNameFallback(t *testing.T) {
+	service, invitations, _, _, _, persons, _, mock, cleanup := newInvitationTestEnv(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	token := &authModel.InvitationToken{
+		Email:     "fallback@example.com",
+		Token:     "fallback-name-token",
+		RoleID:    2,
+		FirstName: strPtr("Invite"),
+		LastName:  strPtr("Name"),
+		ExpiresAt: time.Now().Add(10 * time.Hour),
+	}
+	token.SetTenantID(5)
+	require.NoError(t, invitations.Create(ctx, token))
+
+	expectAdminTx(mock)
+	account, err := service.AcceptInvitation(ctx, token.Token, UserRegistrationData{
+		Password:        testStrongCredential,
+		ConfirmPassword: testStrongCredential,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	require.Len(t, persons.people, 1)
+	for _, person := range persons.people {
+		require.Equal(t, "Invite", person.FirstName)
+		require.Equal(t, "Name", person.LastName)
+	}
+}
+
+func TestAcceptInvitationRejectsPasswordMismatchAndMissingNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    UserRegistrationData
+		wantErr error
+	}{
+		{
+			name: "password mismatch",
+			data: UserRegistrationData{
+				FirstName:       "Jane",
+				LastName:        "Doe",
+				Password:        testStrongCredential,
+				ConfirmPassword: testStrongCredential + "x",
+			},
+			wantErr: ErrPasswordMismatch,
+		},
+		{
+			name: "missing names",
+			data: UserRegistrationData{
+				Password:        testStrongCredential,
+				ConfirmPassword: testStrongCredential,
+			},
+			wantErr: ErrInvitationNameRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, invitations, _, _, _, _, _, mock, cleanup := newInvitationTestEnv(t)
+			t.Cleanup(cleanup)
+
+			token := &authModel.InvitationToken{
+				Email:     tt.name + "@example.com",
+				Token:     tt.name + "-token",
+				RoleID:    2,
+				ExpiresAt: time.Now().Add(10 * time.Hour),
+			}
+			require.NoError(t, invitations.Create(context.Background(), token))
+
+			expectAdminTxRollback(mock)
+			_, err := service.AcceptInvitation(context.Background(), token.Token, tt.data)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, tt.wantErr), "expected %v, got %v", tt.wantErr, err)
+			require.False(t, token.IsUsed())
+		})
+	}
+}
+
+func TestInvitationManagementErrorAndEdgePaths(t *testing.T) {
+	t.Run("list wraps repository error", func(t *testing.T) {
+		service, invitations, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		svc := service.(*invitationService)
+		svc.invitationRepo = &failingInvitationTokenRepository{stubInvitationTokenRepository: invitations, listErr: errors.New("list failed")}
+
+		_, err := svc.ListPendingInvitations(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "list failed")
+	})
+
+	t.Run("cleanup deletes expired invitations", func(t *testing.T) {
+		service, invitations, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		require.NoError(t, invitations.Create(context.Background(), &authModel.InvitationToken{
+			Email:     "expired@example.com",
+			Token:     "cleanup-expired",
+			RoleID:    1,
+			ExpiresAt: time.Now().Add(-time.Hour),
+		}))
+
+		count, err := service.CleanupExpiredInvitations(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("cleanup wraps repository error", func(t *testing.T) {
+		service, invitations, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		svc := service.(*invitationService)
+		svc.invitationRepo = &failingInvitationTokenRepository{stubInvitationTokenRepository: invitations, deleteExpiredErr: errors.New("delete failed")}
+
+		_, err := svc.CleanupExpiredInvitations(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "delete failed")
+	})
+
+	t.Run("invalidate tenant wraps repository error", func(t *testing.T) {
+		service, invitations, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		svc := service.(*invitationService)
+		svc.invitationRepo = &failingInvitationTokenRepository{stubInvitationTokenRepository: invitations, invalidateTenantErr: errors.New("invalidate failed")}
+
+		_, err := svc.InvalidatePendingInvitationsByTenantID(context.Background(), 42)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalidate failed")
+	})
+}
+
+func TestResendInvitationErrorPaths(t *testing.T) {
+	t.Run("not found", func(t *testing.T) {
+		service, _, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+
+		err := service.ResendInvitation(context.Background(), 404, 99)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrInvitationNotFound), "expected ErrInvitationNotFound, got %v", err)
+	})
+
+	t.Run("used", func(t *testing.T) {
+		service, invitations, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		now := time.Now()
+		token := &authModel.InvitationToken{
+			Email:     "used-resend@example.com",
+			Token:     "used-resend-token",
+			RoleID:    1,
+			ExpiresAt: time.Now().Add(time.Hour),
+			UsedAt:    &now,
+		}
+		require.NoError(t, invitations.Create(context.Background(), token))
+
+		err := service.ResendInvitation(context.Background(), token.ID, 99)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrInvitationUsed), "expected ErrInvitationUsed, got %v", err)
+	})
+
+	t.Run("role lookup error", func(t *testing.T) {
+		service, invitations, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		token := &authModel.InvitationToken{
+			Email:     "missing-role@example.com",
+			Token:     "missing-role-token",
+			RoleID:    404,
+			ExpiresAt: time.Now().Add(time.Hour),
+		}
+		require.NoError(t, invitations.Create(context.Background(), token))
+
+		err := service.ResendInvitation(context.Background(), token.ID, 99)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "role not found")
+	})
+
+	t.Run("update error", func(t *testing.T) {
+		service, invitations, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		token := &authModel.InvitationToken{
+			Email:     "update-error@example.com",
+			Token:     "update-error-token",
+			RoleID:    1,
+			ExpiresAt: time.Now().Add(time.Hour),
+		}
+		require.NoError(t, invitations.Create(context.Background(), token))
+		svc := service.(*invitationService)
+		svc.invitationRepo = &failingInvitationTokenRepository{stubInvitationTokenRepository: invitations, updateErr: errors.New("update failed")}
+
+		err := svc.ResendInvitation(context.Background(), token.ID, 99)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "update failed")
+	})
+}
+
+func TestRevokeInvitationErrorPaths(t *testing.T) {
+	t.Run("not found", func(t *testing.T) {
+		service, _, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+
+		err := service.RevokeInvitation(context.Background(), 404, 99)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrInvitationNotFound), "expected ErrInvitationNotFound, got %v", err)
+	})
+
+	t.Run("used", func(t *testing.T) {
+		service, invitations, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		now := time.Now()
+		token := &authModel.InvitationToken{
+			Email:     "used-revoke@example.com",
+			Token:     "used-revoke-token",
+			RoleID:    1,
+			ExpiresAt: time.Now().Add(time.Hour),
+			UsedAt:    &now,
+		}
+		require.NoError(t, invitations.Create(context.Background(), token))
+
+		err := service.RevokeInvitation(context.Background(), token.ID, 99)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrInvitationUsed), "expected ErrInvitationUsed, got %v", err)
+	})
+
+	t.Run("mark used error", func(t *testing.T) {
+		service, invitations, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		token := &authModel.InvitationToken{
+			Email:     "mark-error@example.com",
+			Token:     "mark-error-token",
+			RoleID:    1,
+			ExpiresAt: time.Now().Add(time.Hour),
+		}
+		require.NoError(t, invitations.Create(context.Background(), token))
+		svc := service.(*invitationService)
+		svc.invitationRepo = &failingInvitationTokenRepository{stubInvitationTokenRepository: invitations, markErr: errors.New("mark failed")}
+
+		err := svc.RevokeInvitation(context.Background(), token.ID, 99)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "mark failed")
+	})
+}
+
+func TestInvitationHelpersCoverFallbacks(t *testing.T) {
+	service, _, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+	t.Cleanup(cleanup)
+	svc := service.(*invitationService)
+
+	require.Equal(t, "", svc.lookupSchoolName(context.Background(), 0))
+	require.Equal(t, "", svc.lookupSchoolName(context.Background(), 55))
+	require.Equal(t, "", sanitizeEmailError(nil))
+	require.Equal(t, "smtp down", sanitizeEmailError(errors.New(" smtp down ")))
+
+	dbErr := &baseModel.DatabaseError{Err: sql.ErrNoRows}
+	require.True(t, isNotFoundError(dbErr))
+	require.False(t, isNotFoundError(errors.New("other")))
+
+	invitation := svc.buildInvitationToken("name@example.com", InvitationRequest{
+		Email:     "name@example.com",
+		RoleID:    1,
+		FirstName: strPtr(" Ada "),
+		LastName:  strPtr(" Lovelace "),
+		Position:  strPtr(" Leitung "),
+	})
+	require.Equal(t, "Ada", *invitation.FirstName)
+	require.Equal(t, "Lovelace", *invitation.LastName)
+	require.Equal(t, "Leitung", *invitation.Position)
+
+	var tx bun.Tx
+	ctxWithTx := baseModel.ContextWithTx(context.Background(), &tx)
+	called := false
+	require.NoError(t, svc.withAdminTx(ctxWithTx, func(context.Context) error {
+		called = true
+		return nil
+	}))
+	require.True(t, called)
+
+	tenantCtx := tenant.WithTenantID(context.Background(), 123)
+	require.Same(t, tenantCtx, scopedInvitationTenantContext(tenantCtx, 123))
+
+	svc.dispatcher = nil
+	svc.sendInvitationEmail(&authModel.InvitationToken{
+		Model: baseModel.Model{ID: 99},
+		Email: "skip-email@example.com",
+		Token: "skip-email-token",
+	}, "admin", "")
+}
+
+func TestInvitationLookupErrorBranches(t *testing.T) {
+	service, _, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+	t.Cleanup(cleanup)
+	svc := service.(*invitationService)
+
+	_, err := svc.fetchValidInvitation(context.Background(), " ")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvitationNotFound), "expected ErrInvitationNotFound, got %v", err)
+
+	_, err = svc.fetchValidInvitation(context.Background(), "missing-token")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvitationNotFound), "expected ErrInvitationNotFound, got %v", err)
+
+	svc.roleRepo = &failingRoleRepository{
+		stubRoleRepository: newStubRoleRepository(),
+		findErr:            errors.New("role lookup failed"),
+	}
+	_, err = svc.lookupRoleName(context.Background(), 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "role lookup failed")
+
+	err = svc.assignCaregiverRoleIfRequested(context.Background(), 1, &authModel.InvitationToken{
+		RoleID:           1,
+		CaregiverEnabled: true,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "role lookup failed")
+
+	svc.roleRepo = &failingRoleRepository{
+		stubRoleRepository: newStubRoleRepository(&authModel.Role{
+			Model: baseModel.Model{ID: 2},
+			Name:  "admin",
+		}),
+		listErr: errors.New("role list failed"),
+	}
+	err = svc.assignCaregiverRoleIfRequested(context.Background(), 1, &authModel.InvitationToken{
+		RoleID:           2,
+		CaregiverEnabled: true,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "role list failed")
+}
+
+func TestEnsureInvitationTargetAllowedWrapsTenantLookupError(t *testing.T) {
+	service, _, accounts, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+	t.Cleanup(cleanup)
+	accounts.storeAccount(&authModel.Account{
+		Model:  baseModel.Model{ID: 201},
+		Email:  "tenant-error@example.com",
+		Active: true,
+	})
+	svc := service.(*invitationService)
+	svc.accountTenantRepo = &failingAccountTenantRepository{
+		stubAccountTenantRepository: newStubAccountTenantRepository(),
+		existsErr:                   errors.New("tenant lookup failed"),
+	}
+
+	err := svc.ensureInvitationTargetAllowed(context.Background(), "tenant-error@example.com", InvitationRequest{
+		TenantID: 88,
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tenant lookup failed")
+}
+
+func TestCreateOrUpdateAccountErrorPaths(t *testing.T) {
+	t.Run("create account error", func(t *testing.T) {
+		service, _, accounts, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		accounts.failCreate = true
+		svc := service.(*invitationService)
+
+		_, err := svc.createOrUpdateAccount(context.Background(), "create-error@example.com", "hash", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "account create failed")
+	})
+
+	t.Run("update password error", func(t *testing.T) {
+		service, _, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		svc := service.(*invitationService)
+
+		_, err := svc.createOrUpdateAccount(context.Background(), "missing@example.com", "hash", &authModel.Account{
+			Model:  baseModel.Model{ID: 202},
+			Email:  "missing@example.com",
+			Active: true,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "update account password")
+	})
+
+	t.Run("reactivate error", func(t *testing.T) {
+		service, _, accounts, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+		t.Cleanup(cleanup)
+		svc := service.(*invitationService)
+
+		_, err := svc.createOrUpdateAccount(context.Background(), "inactive@example.com", "hash", &authModel.Account{
+			Model:  baseModel.Model{ID: 203},
+			Email:  "inactive@example.com",
+			Active: false,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "update account password")
+
+		accounts.storeAccount(&authModel.Account{
+			Model:  baseModel.Model{ID: 204},
+			Email:  "inactive@example.com",
+			Active: false,
+		})
+		svc.accountRepo = &failingSetActiveAccountRepository{stubAccountRepository: accounts}
+		_, err = svc.createOrUpdateAccount(context.Background(), "inactive@example.com", "hash", &authModel.Account{
+			Model:  baseModel.Model{ID: 204},
+			Email:  "inactive@example.com",
+			Active: false,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reactivate account on invitation")
+	})
+}
+
+func TestCreateAccountWithRoleStopsOnPartialFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*invitationService, *authModel.InvitationToken)
+		wantErr string
+	}{
+		{
+			name: "account tenant mapping error",
+			mutate: func(svc *invitationService, _ *authModel.InvitationToken) {
+				svc.accountTenantRepo = &failingAccountTenantRepository{
+					stubAccountTenantRepository: newStubAccountTenantRepository(),
+					createErr:                   errors.New("mapping failed"),
+				}
+			},
+			wantErr: "mapping failed",
+		},
+		{
+			name: "role assignment error",
+			mutate: func(svc *invitationService, _ *authModel.InvitationToken) {
+				svc.accountRoleRepo = failingAccountRoleRepository{}
+			},
+			wantErr: "role assignment failed",
+		},
+		{
+			name: "caregiver role error",
+			mutate: func(_ *invitationService, invitation *authModel.InvitationToken) {
+				invitation.RoleID = 1
+				invitation.CaregiverEnabled = true
+			},
+			wantErr: "user role not found",
+		},
+		{
+			name: "staff creation error",
+			mutate: func(svc *invitationService, invitation *authModel.InvitationToken) {
+				invitation.RoleID = 10
+				svc.roleRepo = newStubRoleRepository(&authModel.Role{
+					Model:    baseModel.Model{ID: 10},
+					Name:     "admin",
+					IsSystem: true,
+				})
+				svc.staffRepo = failingStaffRepository{stubStaffRepository: newStubStaffRepository()}
+			},
+			wantErr: "staff failed",
+		},
+		{
+			name: "teacher creation error",
+			mutate: func(svc *invitationService, invitation *authModel.InvitationToken) {
+				invitation.RoleID = 11
+				svc.roleRepo = newStubRoleRepository(&authModel.Role{
+					Model:    baseModel.Model{ID: 11},
+					Name:     "user",
+					IsSystem: true,
+				})
+				svc.teacherRepo = failingTeacherRepository{stubTeacherRepository: newStubTeacherRepository()}
+			},
+			wantErr: "teacher failed",
+		},
+		{
+			name: "mark invitation used error",
+			mutate: func(svc *invitationService, _ *authModel.InvitationToken) {
+				svc.invitationRepo = &failingInvitationTokenRepository{
+					stubInvitationTokenRepository: newStubInvitationTokenRepository(),
+					markErr:                       errors.New("mark failed"),
+				}
+			},
+			wantErr: "mark failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, _, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
+			t.Cleanup(cleanup)
+			svc := service.(*invitationService)
+			invitation := &authModel.InvitationToken{
+				Model:  baseModel.Model{ID: 301},
+				Email:  tt.name + "@example.com",
+				Token:  tt.name + "-token",
+				RoleID: 1,
+			}
+			invitation.SetTenantID(55)
+			tt.mutate(svc, invitation)
+
+			_, err := svc.createAccountWithRole(context.Background(), invitation, "hash", "First", "Last", nil)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+type failingInvitationTokenRepository struct {
+	*stubInvitationTokenRepository
+
+	listErr             error
+	deleteExpiredErr    error
+	invalidateTenantErr error
+	updateErr           error
+	markErr             error
+}
+
+func (r *failingInvitationTokenRepository) List(ctx context.Context, filters map[string]interface{}) ([]*authModel.InvitationToken, error) {
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	return r.stubInvitationTokenRepository.List(ctx, filters)
+}
+
+func (r *failingInvitationTokenRepository) DeleteExpired(ctx context.Context, now time.Time) (int, error) {
+	if r.deleteExpiredErr != nil {
+		return 0, r.deleteExpiredErr
+	}
+	return r.stubInvitationTokenRepository.DeleteExpired(ctx, now)
+}
+
+func (r *failingInvitationTokenRepository) InvalidateByTenantID(ctx context.Context, tenantID int64) (int, error) {
+	if r.invalidateTenantErr != nil {
+		return 0, r.invalidateTenantErr
+	}
+	return r.stubInvitationTokenRepository.InvalidateByTenantID(ctx, tenantID)
+}
+
+func (r *failingInvitationTokenRepository) Update(ctx context.Context, token *authModel.InvitationToken) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	return r.stubInvitationTokenRepository.Update(ctx, token)
+}
+
+func (r *failingInvitationTokenRepository) MarkAsUsed(ctx context.Context, id int64) error {
+	if r.markErr != nil {
+		return r.markErr
+	}
+	return r.stubInvitationTokenRepository.MarkAsUsed(ctx, id)
+}
+
+type failingAccountTenantRepository struct {
+	*stubAccountTenantRepository
+
+	createErr error
+	existsErr error
+}
+
+func (r *failingAccountTenantRepository) Create(ctx context.Context, accountTenant *authModel.AccountTenant) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	return r.stubAccountTenantRepository.Create(ctx, accountTenant)
+}
+
+func (r *failingAccountTenantRepository) ExistsByAccountAndTenant(ctx context.Context, accountID, tenantID int64) (bool, error) {
+	if r.existsErr != nil {
+		return false, r.existsErr
+	}
+	return r.stubAccountTenantRepository.ExistsByAccountAndTenant(ctx, accountID, tenantID)
+}
+
+type failingSetActiveAccountRepository struct {
+	*stubAccountRepository
+}
+
+func (r *failingSetActiveAccountRepository) SetActive(context.Context, int64, bool) error {
+	return errors.New("set active failed")
+}
+
+type failingAccountRoleRepository struct {
+	noopAccountRoleRepository
+}
+
+func (failingAccountRoleRepository) Create(context.Context, *authModel.AccountRole) error {
+	return errors.New("role assignment failed")
+}
+
+type failingStaffRepository struct {
+	*stubStaffRepository
+}
+
+func (failingStaffRepository) Create(context.Context, *userModel.Staff) error {
+	return errors.New("staff failed")
+}
+
+type failingTeacherRepository struct {
+	*stubTeacherRepository
+}
+
+func (failingTeacherRepository) Create(context.Context, *userModel.Teacher) error {
+	return errors.New("teacher failed")
+}
+
+type failingRoleRepository struct {
+	*stubRoleRepository
+
+	findErr error
+	listErr error
+}
+
+func (r *failingRoleRepository) FindByID(ctx context.Context, id interface{}) (*authModel.Role, error) {
+	if r.findErr != nil {
+		return nil, r.findErr
+	}
+	return r.stubRoleRepository.FindByID(ctx, id)
+}
+
+func (r *failingRoleRepository) List(ctx context.Context, filters map[string]interface{}) ([]*authModel.Role, error) {
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	return r.stubRoleRepository.List(ctx, filters)
 }

--- a/backend/services/auth/invitation_service_test.go
+++ b/backend/services/auth/invitation_service_test.go
@@ -515,6 +515,86 @@ func TestShouldCreateTeacherForRole(t *testing.T) {
 	require.False(t, shouldCreateTeacherForRole("admin"))
 }
 
+func TestAcceptInvitation_AdminCaregiverEnabledCreatesUserRoleAndTeacherProfile(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	bunDB := bun.NewDB(sqlDB, pgdialect.New())
+	t.Cleanup(func() {
+		mock.ExpectClose()
+		require.NoError(t, bunDB.Close())
+		require.NoError(t, sqlDB.Close())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	invitations := newStubInvitationTokenRepository()
+	accounts := newStubAccountRepository()
+	roles := newStubRoleRepository(
+		&authModel.Role{Model: baseModel.Model{ID: 21}, Name: "admin", IsSystem: true},
+		&authModel.Role{Model: baseModel.Model{ID: 22}, Name: "user", IsSystem: true},
+	)
+	accountRoles := newStubAccountRoleRepository()
+	persons := newStubPersonRepository()
+	staff := newStubStaffRepository()
+	teachers := newStubTeacherRepository()
+
+	service := NewInvitationService(InvitationServiceConfig{
+		InvitationRepo:    invitations,
+		AccountRepo:       accounts,
+		AccountTenantRepo: newStubAccountTenantRepository(),
+		RoleRepo:          roles,
+		AccountRoleRepo:   accountRoles,
+		PersonRepo:        persons,
+		StaffRepo:         staff,
+		TeacherRepo:       teachers,
+		SchoolRepo:        &stubSchoolRepository{},
+		FrontendURL:       "http://localhost:3000",
+		DefaultFrom:       newDefaultFromEmail(),
+		InvitationExpiry:  48 * time.Hour,
+		DB:                bunDB,
+	})
+
+	position := "OGS-Büro"
+	token := &authModel.InvitationToken{
+		Email:            "admin-caregiver@example.com",
+		Token:            "admin-caregiver-token",
+		RoleID:           21,
+		CreatedBy:        nullableCreatedBy(31),
+		ExpiresAt:        time.Now().Add(10 * time.Hour),
+		Position:         &position,
+		CaregiverEnabled: true,
+	}
+	token.SetTenantID(42)
+	require.NoError(t, invitations.Create(context.Background(), token))
+
+	expectAdminTx(mock)
+	account, err := service.AcceptInvitation(context.Background(), token.Token, UserRegistrationData{
+		FirstName:       "Ada",
+		LastName:        "Lovelace",
+		Password:        testStrongCredential,
+		ConfirmPassword: testStrongCredential,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, account)
+
+	assignments := accountRoles.Assignments()
+	require.Len(t, assignments, 2)
+	require.Equal(t, int64(21), assignments[0].RoleID)
+	require.Equal(t, int64(22), assignments[1].RoleID)
+	require.Equal(t, int64(42), assignments[0].TenantID)
+	require.Equal(t, int64(42), assignments[1].TenantID)
+
+	createdStaff := staff.All()
+	require.Len(t, createdStaff, 1)
+	require.Equal(t, int64(42), createdStaff[0].TenantID)
+
+	createdTeachers := teachers.All()
+	require.Len(t, createdTeachers, 1)
+	require.Equal(t, createdStaff[0].ID, createdTeachers[0].StaffID)
+	require.Equal(t, int64(42), createdTeachers[0].TenantID)
+	require.Equal(t, position, createdTeachers[0].Role)
+}
+
 func TestAcceptInvitationSecondAttemptFails(t *testing.T) {
 	service, invitations, _, _, _, _, _, mock, cleanup := newInvitationTestEnv(t)
 	t.Cleanup(cleanup)

--- a/backend/services/auth/test_helpers_test.go
+++ b/backend/services/auth/test_helpers_test.go
@@ -807,6 +807,15 @@ func (r *stubRoleRepository) FindByID(_ context.Context, id interface{}) (*authM
 	return nil, sql.ErrNoRows
 }
 
+func (r *stubRoleRepository) FindByName(_ context.Context, name string) (*authModel.Role, error) {
+	for _, role := range r.roles {
+		if strings.EqualFold(role.Name, name) {
+			return role, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
 // noopAccountRoleRepository provides default panic implementations.
 type noopAccountRoleRepository struct{}
 
@@ -1217,6 +1226,16 @@ func (r *stubStaffRepository) Create(_ context.Context, staff *userModel.Staff) 
 	return nil
 }
 
+func (r *stubStaffRepository) All() []*userModel.Staff {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*userModel.Staff, 0, len(r.staff))
+	for _, staff := range r.staff {
+		out = append(out, staff)
+	}
+	return out
+}
+
 func (r *stubStaffRepository) FindByID(context.Context, interface{}) (*userModel.Staff, error) {
 	panic("FindByID not implemented")
 }
@@ -1283,6 +1302,16 @@ func (r *stubTeacherRepository) Create(_ context.Context, teacher *userModel.Tea
 	}
 	r.teachers[teacher.ID] = teacher
 	return nil
+}
+
+func (r *stubTeacherRepository) All() []*userModel.Teacher {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*userModel.Teacher, 0, len(r.teachers))
+	for _, teacher := range r.teachers {
+		out = append(out, teacher)
+	}
+	return out
 }
 
 func (r *stubTeacherRepository) FindByID(context.Context, interface{}) (*userModel.Teacher, error) {

--- a/backend/services/auth/test_helpers_test.go
+++ b/backend/services/auth/test_helpers_test.go
@@ -816,6 +816,20 @@ func (r *stubRoleRepository) FindByName(_ context.Context, name string) (*authMo
 	return nil, sql.ErrNoRows
 }
 
+func (r *stubRoleRepository) List(_ context.Context, filters map[string]interface{}) ([]*authModel.Role, error) {
+	var roles []*authModel.Role
+	for _, role := range r.roles {
+		if name, ok := filters["name"].(string); ok && !strings.EqualFold(role.Name, name) {
+			continue
+		}
+		if isSystem, ok := filters["is_system"].(bool); ok && role.IsSystem != isSystem {
+			continue
+		}
+		roles = append(roles, role)
+	}
+	return roles, nil
+}
+
 // noopAccountRoleRepository provides default panic implementations.
 type noopAccountRoleRepository struct{}
 

--- a/backend/services/platform/operator_provisioning_service_test.go
+++ b/backend/services/platform/operator_provisioning_service_test.go
@@ -303,11 +303,15 @@ func (m *mockInvitationService) WithTx(tx bun.Tx) interface{} { return m }
 func (m *mockInvitationService) CreateInvitation(_ context.Context, req authSvc.InvitationRequest) (*authModels.InvitationToken, error) {
 	m.req = req
 	return &authModels.InvitationToken{
-		Model:     base.Model{ID: 10},
-		Email:     req.Email,
-		RoleID:    req.RoleID,
-		CreatedBy: nil,
-		ExpiresAt: time.Now().Add(24 * time.Hour),
+		Model:            base.Model{ID: 10},
+		Email:            req.Email,
+		RoleID:           req.RoleID,
+		CreatedBy:        nil,
+		ExpiresAt:        time.Now().Add(24 * time.Hour),
+		FirstName:        req.FirstName,
+		LastName:         req.LastName,
+		Position:         req.Position,
+		CaregiverEnabled: req.CaregiverEnabled,
 	}, nil
 }
 func (m *mockInvitationService) ValidateInvitation(context.Context, string) (*authSvc.InvitationValidationResult, error) {
@@ -811,11 +815,13 @@ func TestOperatorProvisioningService_InviteSchoolAdmin_DoesNotRequireAuthCreator
 	})
 
 	invitation, err := service.InviteSchoolAdmin(context.Background(), 9, 11, net.IPv4(127, 0, 0, 1), authSvc.InvitationRequest{
-		Email: "principal@example.com",
+		Email:            "principal@example.com",
+		CaregiverEnabled: true,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, invitation)
 	require.Equal(t, int64(0), invitations.req.CreatedBy)
+	require.True(t, invitations.req.CaregiverEnabled)
 }
 
 func TestOperatorProvisioningService_CreateSchool_OrganizationNotFound(t *testing.T) {

--- a/frontend/src/app/operator/provisioning/invite-admin-modal.test.tsx
+++ b/frontend/src/app/operator/provisioning/invite-admin-modal.test.tsx
@@ -1,0 +1,222 @@
+import type { ReactNode } from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockInviteSchoolAdmin, mockLoggerError } = vi.hoisted(() => ({
+  mockInviteSchoolAdmin: vi.fn(),
+  mockLoggerError: vi.fn(),
+}));
+
+vi.mock("~/components/ui/modal", () => ({
+  Modal: ({
+    isOpen,
+    title,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    title: string;
+    children: ReactNode;
+    footer?: ReactNode;
+  }) =>
+    isOpen ? (
+      <div data-testid="modal">
+        <h2>{title}</h2>
+        {children}
+        <div>{footer}</div>
+      </div>
+    ) : null,
+}));
+
+vi.mock("~/lib/operator/provisioning-api", () => ({
+  operatorProvisioningService: {
+    inviteSchoolAdmin: mockInviteSchoolAdmin,
+  },
+}));
+
+vi.mock("~/lib/hooks/use-scroll-to-error", () => ({
+  useScrollToError: () => vi.fn(),
+}));
+
+vi.mock("~/lib/logger", () => ({
+  createLogger: () => ({
+    error: mockLoggerError,
+  }),
+}));
+
+import { InviteAdminModal } from "./invite-admin-modal";
+
+const invitationResult = {
+  id: "55",
+  email: "admin@example.com",
+  roleId: "21",
+  roleName: "admin",
+  expiresAt: "2026-06-06T12:00:00Z",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  position: null,
+  caregiverEnabled: false,
+  createdBy: "31",
+  creator: "operator@example.com",
+  deliveryStatus: "sent",
+  emailSentAt: "2026-06-05T12:00:00Z",
+  emailError: null,
+  emailRetryCount: 0,
+};
+
+function renderModal(
+  props: Partial<Parameters<typeof InviteAdminModal>[0]> = {},
+) {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    schoolId: "10",
+    schoolName: "Test Schule",
+    ...props,
+  };
+  return {
+    ...render(<InviteAdminModal {...defaultProps} />),
+    ...defaultProps,
+  };
+}
+
+function fillInviteForm() {
+  fireEvent.change(screen.getByLabelText(/E-Mail/), {
+    target: { value: "admin@example.com" },
+  });
+  fireEvent.change(screen.getByLabelText(/Vorname/), {
+    target: { value: "Ada" },
+  });
+  fireEvent.change(screen.getByLabelText(/Nachname/), {
+    target: { value: "Lovelace" },
+  });
+}
+
+describe("InviteAdminModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInviteSchoolAdmin.mockResolvedValue(invitationResult);
+  });
+
+  it("does not render when closed", () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+  });
+
+  it("renders caregiver toggle unchecked and hides position by default", () => {
+    renderModal();
+
+    expect(
+      screen.getByText("Admin einladen — Test Schule"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Auch als Betreuer einsetzen"),
+    ).not.toBeChecked();
+    expect(screen.queryByLabelText("Position")).not.toBeInTheDocument();
+  });
+
+  it("shows position only when caregiver capability is enabled", () => {
+    renderModal();
+
+    fireEvent.click(screen.getByLabelText("Auch als Betreuer einsetzen"));
+
+    expect(screen.getByLabelText("Position")).toBeInTheDocument();
+    expect(screen.getByText("Pädagogische Fachkraft")).toBeInTheDocument();
+    expect(screen.getByText("OGS-Büro")).toBeInTheDocument();
+    expect(screen.getByText("Extern")).toBeInTheDocument();
+  });
+
+  it("submits a plain admin invitation without caregiver fields", async () => {
+    renderModal();
+
+    fillInviteForm();
+    fireEvent.click(screen.getByText("Einladung senden"));
+
+    await waitFor(() => {
+      expect(mockInviteSchoolAdmin).toHaveBeenCalledWith("10", {
+        email: "admin@example.com",
+        first_name: "Ada",
+        last_name: "Lovelace",
+      });
+    });
+  });
+
+  it("submits caregiver capability and position when enabled", async () => {
+    mockInviteSchoolAdmin.mockResolvedValue({
+      ...invitationResult,
+      caregiverEnabled: true,
+      position: "OGS-Büro",
+    });
+    renderModal();
+
+    fillInviteForm();
+    fireEvent.click(screen.getByLabelText("Auch als Betreuer einsetzen"));
+    fireEvent.change(screen.getByLabelText("Position"), {
+      target: { value: "OGS-Büro" },
+    });
+    fireEvent.click(screen.getByText("Einladung senden"));
+
+    await waitFor(() => {
+      expect(mockInviteSchoolAdmin).toHaveBeenCalledWith("10", {
+        email: "admin@example.com",
+        first_name: "Ada",
+        last_name: "Lovelace",
+        caregiver_enabled: true,
+        position: "OGS-Büro",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Verwaltung + Betreuung")).toBeInTheDocument();
+    });
+  });
+
+  it("resets caregiver fields when reopened", () => {
+    const { rerender, onClose } = renderModal();
+
+    fireEvent.click(screen.getByLabelText("Auch als Betreuer einsetzen"));
+    fireEvent.change(screen.getByLabelText("Position"), {
+      target: { value: "Extern" },
+    });
+
+    rerender(
+      <InviteAdminModal
+        isOpen={false}
+        onClose={onClose}
+        schoolId="10"
+        schoolName="Test Schule"
+      />,
+    );
+    rerender(
+      <InviteAdminModal
+        isOpen={true}
+        onClose={onClose}
+        schoolId="10"
+        schoolName="Test Schule"
+      />,
+    );
+
+    expect(
+      screen.getByLabelText("Auch als Betreuer einsetzen"),
+    ).not.toBeChecked();
+    expect(screen.queryByLabelText("Position")).not.toBeInTheDocument();
+  });
+
+  it("shows API errors and logs them", async () => {
+    mockInviteSchoolAdmin.mockRejectedValue(
+      new Error("E-Mail bereits vergeben"),
+    );
+    renderModal();
+
+    fillInviteForm();
+    fireEvent.click(screen.getByText("Einladung senden"));
+
+    await waitFor(() => {
+      expect(screen.getByText("E-Mail bereits vergeben")).toBeInTheDocument();
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        "admin_invite_failed",
+        expect.objectContaining({ error: "E-Mail bereits vergeben" }),
+      );
+    });
+  });
+});

--- a/frontend/src/app/operator/provisioning/invite-admin-modal.tsx
+++ b/frontend/src/app/operator/provisioning/invite-admin-modal.tsx
@@ -8,6 +8,7 @@ import {
   FormField,
   FormError,
   DeliveryStatusBadge,
+  SelectWithChevron,
 } from "./provisioning-shared";
 
 const logger = createLogger({ component: "InviteAdminModal" });
@@ -26,11 +27,15 @@ export function InviteAdminModal({
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteFirstName, setInviteFirstName] = useState("");
   const [inviteLastName, setInviteLastName] = useState("");
+  const [position, setPosition] = useState("");
+  const [caregiverEnabled, setCaregiverEnabled] = useState(false);
   const [inviteSaving, setInviteSaving] = useState(false);
   const [inviteError, setInviteError] = useState("");
   const errorRef = useScrollToError(inviteError);
 
   const [inviteResult, setInviteResult] = useState<Invitation | null>(null);
+  const inputClasses =
+    "w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none";
 
   // Reset form when opening
   useEffect(() => {
@@ -38,6 +43,8 @@ export function InviteAdminModal({
       setInviteEmail("");
       setInviteFirstName("");
       setInviteLastName("");
+      setPosition("");
+      setCaregiverEnabled(false);
       setInviteError("");
       setInviteResult(null);
     }
@@ -56,6 +63,8 @@ export function InviteAdminModal({
             email: inviteEmail.trim(),
             ...(inviteFirstName && { first_name: inviteFirstName.trim() }),
             ...(inviteLastName && { last_name: inviteLastName.trim() }),
+            ...(caregiverEnabled && { caregiver_enabled: true }),
+            ...(caregiverEnabled && position && { position: position.trim() }),
           },
         );
         setInviteResult(result);
@@ -70,7 +79,14 @@ export function InviteAdminModal({
         setInviteSaving(false);
       }
     },
-    [schoolId, inviteEmail, inviteFirstName, inviteLastName],
+    [
+      schoolId,
+      inviteEmail,
+      inviteFirstName,
+      inviteLastName,
+      caregiverEnabled,
+      position,
+    ],
   );
 
   const handleClose = useCallback(() => {
@@ -141,6 +157,12 @@ export function InviteAdminModal({
               <span className="font-medium">Status:</span>{" "}
               <DeliveryStatusBadge status={inviteResult.deliveryStatus} />
             </p>
+            {inviteResult.caregiverEnabled && (
+              <p>
+                <span className="font-medium">Einsatz:</span> Verwaltung +
+                Betreuung
+              </p>
+            )}
             {inviteResult.emailError && (
               <p className="text-red-600">
                 <span className="font-medium">Fehler:</span>{" "}
@@ -163,7 +185,7 @@ export function InviteAdminModal({
               value={inviteEmail}
               onChange={(e) => setInviteEmail(e.target.value)}
               maxLength={255}
-              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              className={inputClasses}
               required
             />
           </FormField>
@@ -176,7 +198,7 @@ export function InviteAdminModal({
                 value={inviteFirstName}
                 onChange={(e) => setInviteFirstName(e.target.value)}
                 maxLength={255}
-                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                className={inputClasses}
               />
             </FormField>
             <FormField label="Nachname" htmlFor="invite-last-name">
@@ -187,10 +209,47 @@ export function InviteAdminModal({
                 value={inviteLastName}
                 onChange={(e) => setInviteLastName(e.target.value)}
                 maxLength={255}
-                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                className={inputClasses}
               />
             </FormField>
           </div>
+          <div className="flex items-start gap-3 rounded-lg border border-gray-200 px-4 py-3">
+            <input
+              id="invite-admin-caregiver-enabled"
+              type="checkbox"
+              checked={caregiverEnabled}
+              onChange={(e) => setCaregiverEnabled(e.target.checked)}
+              className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <div className="space-y-1">
+              <label
+                htmlFor="invite-admin-caregiver-enabled"
+                className="text-sm font-medium text-gray-900"
+              >
+                Auch als Betreuer einsetzen
+              </label>
+              <p className="text-sm text-gray-600">
+                Vergibt zusätzlich die Betreuer-Rolle und legt das nötige
+                Staff-/Teacher-Profil an.
+              </p>
+            </div>
+          </div>
+          {caregiverEnabled && (
+            <FormField label="Position" htmlFor="invite-admin-position">
+              <SelectWithChevron
+                id="invite-admin-position"
+                value={position}
+                onChange={(e) => setPosition(e.target.value)}
+              >
+                <option value="">Position auswählen...</option>
+                <option value="Pädagogische Fachkraft">
+                  Pädagogische Fachkraft
+                </option>
+                <option value="OGS-Büro">OGS-Büro</option>
+                <option value="Extern">Extern</option>
+              </SelectWithChevron>
+            </FormField>
+          )}
           {inviteError && <FormError ref={errorRef} message={inviteError} />}
         </form>
       )}

--- a/frontend/src/lib/operator/provisioning-api.test.ts
+++ b/frontend/src/lib/operator/provisioning-api.test.ts
@@ -475,6 +475,7 @@ describe("OperatorProvisioningService", () => {
         email: "admin@example.com",
         first_name: "Ada",
         last_name: "Lovelace",
+        caregiver_enabled: true,
       });
 
       expect(mockOperatorFetch).toHaveBeenCalledWith(
@@ -485,6 +486,7 @@ describe("OperatorProvisioningService", () => {
             email: "admin@example.com",
             first_name: "Ada",
             last_name: "Lovelace",
+            caregiver_enabled: true,
           },
         },
       );
@@ -508,6 +510,7 @@ describe("OperatorProvisioningService", () => {
         firstName: "Ada",
         lastName: "Lovelace",
         position: null,
+        caregiverEnabled: false,
         createdBy: "0",
         creator: "",
         deliveryStatus: "pending",

--- a/frontend/src/lib/operator/provisioning-helpers.test.ts
+++ b/frontend/src/lib/operator/provisioning-helpers.test.ts
@@ -302,6 +302,7 @@ describe("mapInvitation", () => {
       first_name: "Max",
       last_name: "Mustermann",
       position: "Schulleiter",
+      caregiver_enabled: true,
       created_by: 3,
       creator: "operator@test.de",
       delivery_status: "sent",
@@ -319,6 +320,7 @@ describe("mapInvitation", () => {
     expect(result.firstName).toBe("Max");
     expect(result.lastName).toBe("Mustermann");
     expect(result.position).toBe("Schulleiter");
+    expect(result.caregiverEnabled).toBe(true);
     expect(result.createdBy).toBe("3");
     expect(result.deliveryStatus).toBe("sent");
     expect(result.emailSentAt).toBe("2025-01-01T00:00:00Z");
@@ -341,6 +343,7 @@ describe("mapInvitation", () => {
     expect(result.firstName).toBeNull();
     expect(result.lastName).toBeNull();
     expect(result.position).toBeNull();
+    expect(result.caregiverEnabled).toBe(false);
     expect(result.roleName).toBe("");
     expect(result.creator).toBe("");
     expect(result.emailSentAt).toBeNull();

--- a/frontend/src/lib/operator/provisioning-helpers.ts
+++ b/frontend/src/lib/operator/provisioning-helpers.ts
@@ -201,6 +201,7 @@ export interface BackendInvitation {
   first_name?: string | null;
   last_name?: string | null;
   position?: string | null;
+  caregiver_enabled?: boolean;
   created_by: number;
   creator?: string;
   delivery_status: string;
@@ -249,6 +250,7 @@ export interface Invitation {
   firstName: string | null;
   lastName: string | null;
   position: string | null;
+  caregiverEnabled: boolean;
   createdBy: string;
   creator: string;
   deliveryStatus: string;
@@ -351,6 +353,7 @@ export interface InviteAdminRequest {
   first_name?: string;
   last_name?: string;
   position?: string;
+  caregiver_enabled?: boolean;
 }
 
 export interface CreateAccountRequest {
@@ -411,6 +414,7 @@ export function mapInvitation(data: BackendInvitation): Invitation {
     firstName: data.first_name ?? null,
     lastName: data.last_name ?? null,
     position: data.position ?? null,
+    caregiverEnabled: data.caregiver_enabled ?? false,
     createdBy: data.created_by.toString(),
     creator: data.creator ?? "",
     deliveryStatus: data.delivery_status,


### PR DESCRIPTION
## Summary
- add an optional caregiver-capability flag to operator-created school admin invitations
- persist the flag on invitation tokens and apply it during invitation acceptance by assigning the caregiver role and creating Staff/Teacher profile data
- add the matching Operator dashboard checkbox and position selector using the existing provisioning modal style

## Validation
- cd backend && go test ./services/auth ./services/platform ./api/operator ./database/migrations
- cd backend && go test ./test/ -run TestHermeticTestPatterns -v
- cd frontend && pnpm vitest run src/app/operator/provisioning/invite-admin-modal.test.tsx src/lib/operator/provisioning-helpers.test.ts src/lib/operator/provisioning-api.test.ts
- cd frontend && pnpm run check
- pre-push hook: git-secrets, go-vet, frontend-knip, go-deadcode, frontend-check, golangci-lint
