### PR TITLE
Gate spontaneous activities by care concept

### DIFF
--- a/backend/api/timetable/operations.go
+++ b/backend/api/timetable/operations.go
@@ -383,6 +383,16 @@ func (rs *Resource) webSpontaneousActivitiesEnabled(r *http.Request) bool {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	careConcept := configSvc.ResolveStringOrDefault(
+		r.Context(),
+		rs.settingsService,
+		configModel.KeyCareConcept,
+		configModel.CareConceptOpenRooms,
+		logger,
+	)
+	if careConcept != configModel.CareConceptOpenRooms {
+		return false
+	}
 	return configSvc.ResolveBoolOrDefault(
 		r.Context(),
 		rs.settingsService,

--- a/backend/api/timetable/operations_unit_test.go
+++ b/backend/api/timetable/operations_unit_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/api/testutil"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	activityModels "github.com/moto-nrw/project-phoenix/models/activities"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
@@ -356,6 +357,31 @@ func TestOperationsCreateAndStartSpontaneousRequiresSetting(t *testing.T) {
 	assert.Nil(t, instanceSvc.lastCreate, "disabled web spontaneous activities must not create instances")
 }
 
+func TestOperationsCreateAndStartSpontaneousRejectsFixedScheduleCareConcept(t *testing.T) {
+	instanceSvc := &mockInstanceService{}
+	res := NewResource(Dependencies{
+		InstanceService:   instanceSvc,
+		OperationsService: &fakeOperationsService{},
+		SettingsService: &fakeOperationSettingsService{
+			hasOverride: true,
+			boolValue:   true,
+			stringValue: configModel.CareConceptFixedSchedule,
+		},
+	})
+	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
+
+	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{
+		"date":       "2026-05-11",
+		"start_time": "14:00",
+		"end_time":   "15:00",
+		"title":      "Freispiel",
+		"room_id":    7,
+	})
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Nil(t, instanceSvc.lastCreate, "fixed schedule must not create spontaneous instances")
+}
+
 func TestOperationsCapabilities(t *testing.T) {
 	res := NewResource(Dependencies{
 		SettingsService: &fakeOperationSettingsService{
@@ -384,6 +410,22 @@ func TestOperationsCapabilitiesDefaultsToEnabled(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), `"web_spontaneous_activities_enabled":true`)
+}
+
+func TestOperationsCapabilitiesDisabledForFixedScheduleCareConcept(t *testing.T) {
+	res := NewResource(Dependencies{
+		SettingsService: &fakeOperationSettingsService{
+			hasOverride: true,
+			boolValue:   true,
+			stringValue: configModel.CareConceptFixedSchedule,
+		},
+	})
+	router := operationRouter(http.MethodGet, "/capabilities", res.operationsCapabilities)
+
+	rr := executeOperationRequest(router, http.MethodGet, "/capabilities", nil)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"web_spontaneous_activities_enabled":false`)
 }
 
 func TestOperationsRosterByActiveGroup(t *testing.T) {
@@ -614,6 +656,7 @@ type fakeOperationSettingsService struct {
 	configSvc.SettingsService
 	hasOverride bool
 	boolValue   bool
+	stringValue string
 	err         error
 }
 
@@ -629,6 +672,13 @@ func (s *fakeOperationSettingsService) ResolveBool(_ context.Context, _ string) 
 		return false, s.err
 	}
 	return s.boolValue, nil
+}
+
+func (s *fakeOperationSettingsService) ResolveString(_ context.Context, _ string) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.stringValue, nil
 }
 
 func (r *fakeOperationActiveGroupRepo) CheckRoomConflict(_ context.Context, _ int64, _ int64) (bool, *activeModels.Group, error) {

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -149,6 +149,10 @@ func TestWebSpontaneousActivitiesSetting(t *testing.T) {
 	assert.Equal(t, "operations", def.Tab)
 	assert.Equal(t, "anwesenheit", def.Category)
 	assert.Equal(t, "config:manage", def.WritePermission)
+	require.NotNil(t, def.DependsOn)
+	assert.Equal(t, config.KeyCareConcept, def.DependsOn.Key)
+	assert.Equal(t, "eq", def.DependsOn.Condition)
+	assert.Equal(t, config.CareConceptOpenRooms, def.DependsOn.Value)
 }
 
 func TestAttendanceSetupSettings(t *testing.T) {
@@ -188,7 +192,7 @@ func TestOrganizationSetupSettings(t *testing.T) {
 	careDef := config.GetDefinition(config.KeyCareConcept)
 	require.NotNil(t, careDef, "operations.care_concept should be registered")
 	assert.Equal(t, config.FieldSelect, careDef.Type)
-	assert.Equal(t, config.CareConceptFixedSchedule, careDef.Default)
+	assert.Equal(t, config.CareConceptOpenRooms, careDef.Default)
 	assert.Equal(t, config.AccessShared, careDef.AccessPolicy)
 	assert.Equal(t, "operations", careDef.Tab)
 	assert.Equal(t, "organisation", careDef.Category)

--- a/backend/services/config/defaults/operations.go
+++ b/backend/services/config/defaults/operations.go
@@ -328,7 +328,7 @@ func init() {
 		Label:           "Betreuungskonzept",
 		Description:     "Legt fest, ob die OGS mit einem festen Betriebsplan arbeitet oder Kinder sich frei zwischen offenen Räumen bewegen.",
 		Type:            config.FieldSelect,
-		Default:         config.CareConceptFixedSchedule,
+		Default:         config.CareConceptOpenRooms,
 		ReadPermission:  "config:read",
 		WritePermission: "config:update",
 		Tab:             "operations",
@@ -397,6 +397,11 @@ func init() {
 		Tab:             "operations",
 		Category:        "anwesenheit",
 		SortOrder:       42,
+		DependsOn: &config.Dependency{
+			Key:       config.KeyCareConcept,
+			Condition: "eq",
+			Value:     config.CareConceptOpenRooms,
+		},
 	})
 
 	// --- Kinderfotos (Datenverwaltung-Erweiterung) ---


### PR DESCRIPTION
## Summary

This PR wires `operations.care_concept` into the spontaneous activity flow. `open_rooms` is now the default care concept and keeps the existing spontaneous activity UX available; `fixed_schedule` disables operational spontaneous starts.

The `attendance.web_spontaneous_activities_enabled` setting is still the per-tenant opt-out, but it is now only visible/effective when `operations.care_concept = open_rooms`.

## Behavior

- `operations.care_concept` defaults to `open_rooms`.
- `/api/timetable/operations/capabilities` returns `web_spontaneous_activities_enabled = true` only when:
  - `operations.care_concept = open_rooms`
  - `attendance.web_spontaneous_activities_enabled = true`
- `POST /api/timetable/operations/spontaneous/start` uses the same gate and returns 403 in `fixed_schedule` before creating instances or activity groups.
- The admin timetable instance creation path is unchanged, so planned single appointments remain possible.

## Issue Context

Refs #1523. This implements the care-concept spontaneous-activity slice from that follow-up, but does not close it because #1523 also tracks broader Settings IA and group-mode rollout work.

Context from the original setup-settings work: #1520, #1479, #1480.

Related NFC/dashboard context remains separate: #1478, #1539.

## Validation

- `cd backend && go test ./services/config/defaults -run 'TestWebSpontaneousActivitiesSetting|TestOrganizationSetupSettings|TestDefaultValues' -v`
- `cd backend && go test ./api/timetable -run 'TestOperations(CreateAndStartSpontaneous|Capabilities)' -v`
- `cd backend && go test ./services/config/...`
- `cd backend && go test ./test/ -run TestHermeticTestPatterns -v`
- `cd frontend && pnpm exec vitest run src/lib/settings-api.test.ts`
- pre-push: `git-secrets`, `go-vet`, `golangci-lint`, `go-deadcode`