### PR TITLE
Fix stale session error during tenant login

### DIFF
--- a/frontend/src/app/[tenant]/page.test.tsx
+++ b/frontend/src/app/[tenant]/page.test.tsx
@@ -152,6 +152,7 @@ function mockTenantAuthenticatedResponse(): typeof global.fetch {
 describe("HomePage (Login)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParamsGet.mockImplementation((_key: string) => null);
     vi.mocked(useSession).mockReturnValue({
       data: null,
       status: "unauthenticated",
@@ -161,11 +162,13 @@ describe("HomePage (Login)", () => {
     // Mock Element.animate globally
     Element.prototype.animate = mockAnimate;
     global.fetch = mockTenantAuthenticatedResponse();
+    window.history.pushState({}, "", "/");
   });
 
   afterEach(() => {
     vi.clearAllMocks();
     global.fetch = originalFetch;
+    window.history.pushState({}, "", "/");
   });
 
   it("renders the login form", async () => {
@@ -311,6 +314,49 @@ describe("HomePage (Login)", () => {
         refreshToken: "refresh-token",
       });
     });
+  });
+
+  it("removes stale session-expired query params before seeding the new session", async () => {
+    mockSignIn.mockResolvedValue({ error: null });
+    mockSearchParamsGet.mockImplementation((key: string) =>
+      key === "error" ? "SessionExpired" : null,
+    );
+    window.history.pushState(
+      {},
+      "",
+      "/?error=SessionExpired&callbackUrl=%2Fdashboard",
+    );
+    const replaceStateSpy = vi.spyOn(window.history, "replaceState");
+
+    render(<HomePage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("input-email")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId("input-email"), {
+        target: { value: "test@example.com" },
+      });
+      fireEvent.change(screen.getByTestId("input-password"), {
+        target: { value: "password123" },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /anmelden/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockSignIn).toHaveBeenCalledWith("credentials", {
+        redirect: false,
+        internalRefresh: "true",
+        token: "access-token",
+        refreshToken: "refresh-token",
+      });
+    });
+    expect(window.location.search).toBe("");
+    expect(replaceStateSpy).toHaveBeenCalledWith({}, "", "/");
   });
 
   it("shows error message on invalid credentials", async () => {
@@ -768,15 +814,16 @@ describe("Deliberate logout suppression", () => {
     Element.prototype.animate = mockAnimate;
     sessionStorage.clear();
     // Spy on history.replaceState to verify URL cleanup
-    Object.defineProperty(window, "history", {
-      value: { ...window.history, replaceState: replaceStateSpy },
-      writable: true,
-    });
+    vi.spyOn(window.history, "replaceState").mockImplementation(
+      replaceStateSpy,
+    );
   });
 
   afterEach(() => {
     sessionStorage.clear();
+    vi.restoreAllMocks();
     mockSearchParamsGet.mockImplementation((_key: string) => null);
+    window.history.pushState({}, "", "/");
   });
 
   it("suppresses error when deliberateLogout flag is set", async () => {
@@ -823,6 +870,11 @@ describe("Deliberate logout suppression", () => {
     sessionStorage.setItem("deliberateLogout", "1");
     mockSearchParamsGet.mockImplementation((key: string) =>
       key === "error" ? "SessionRequired" : null,
+    );
+    window.history.pushState(
+      {},
+      "",
+      "/?error=SessionRequired&callbackUrl=%2Fdashboard",
     );
 
     await act(async () => {

--- a/frontend/src/app/[tenant]/page.tsx
+++ b/frontend/src/app/[tenant]/page.tsx
@@ -32,6 +32,21 @@ import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "TenantLoginPage" });
 
+function clearSessionErrorFromUrl() {
+  const url = new URL(window.location.href);
+  const hadSessionError =
+    url.searchParams.get("error") === "SessionRequired" ||
+    url.searchParams.get("error") === "SessionExpired";
+
+  if (!hadSessionError) return;
+
+  url.searchParams.delete("error");
+  url.searchParams.delete("callbackUrl");
+
+  const nextUrl = `${url.pathname}${url.search}${url.hash}`;
+  window.history.replaceState({}, "", nextUrl);
+}
+
 interface MFAStep {
   challengeToken: string;
   maskedEmail: string;
@@ -161,11 +176,12 @@ function LoginForm() {
       }
       if (deliberate) {
         // Clean up NextAuth's error/callbackUrl params from the URL
-        window.history.replaceState({}, "", window.location.pathname);
+        clearSessionErrorFromUrl();
       } else {
         setError(
           "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an.",
         );
+        clearSessionErrorFromUrl();
       }
     }
   }, [searchParams]);
@@ -179,6 +195,7 @@ function LoginForm() {
   // backend has already authenticated the account, so we only seed the
   // session.
   const seedSessionWithTokens = async (tokens: MFATokenResponse) => {
+    clearSessionErrorFromUrl();
     const result = await signIn("credentials", {
       redirect: false,
       internalRefresh: "true",


### PR DESCRIPTION
## Summary
- Clear stale NextAuth session-error query params before seeding a freshly authenticated tenant session.
- Keep deliberate logout cleanup on the same URL-scrubbing helper and preserve unrelated query/hash state.
- Add a regression test for logging in from `/?error=SessionExpired&callbackUrl=...`.

## Root Cause
After an expired session, TenantGuard redirected to `/?error=SessionExpired`. The tenant login page showed the expired-session message but left that query string in the URL. A subsequent successful backend login could still seed the session, but `signIn(..., { redirect: false })` surfaced the stale `SessionExpired` state, producing a misleading `session_seed_failed` console error.

## Validation
- `cd frontend && pnpm exec vitest run 'src/app/[tenant]/page.test.tsx'`
- Pre-push hook: `frontend-knip`
- Pre-push hook: `frontend-check`
