### PR TITLE
Improve Sentry diagnostics for materialization failures

### DIFF
--- a/backend/api/timetable/materialize.go
+++ b/backend/api/timetable/materialize.go
@@ -2,12 +2,14 @@ package timetable
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
 // materializeRequest is the optional body shape for the manual endpoint.
@@ -77,6 +79,12 @@ func (rs *Resource) materialize(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 		return
 	}
+
+	rs.getLogger().Info("manual materialization requested",
+		slog.Int64("tenant_id", tenant.FromContext(r.Context())),
+		slog.String("from", from.Format(dateLayout)),
+		slog.String("to", to.Format(dateLayout)),
+	)
 
 	result, err := rs.materializationService.MaterializeForTenant(
 		r.Context(), from, to, scheduleSvc.MaterializationSourceManual,

--- a/backend/database/query_hook.go
+++ b/backend/database/query_hook.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/driver/pgdriver"
 )
 
 const slowQueryThreshold = 5 * time.Millisecond
@@ -26,7 +27,7 @@ func (h *QueryHook) BeforeQuery(ctx context.Context, _ *bun.QueryEvent) context.
 	return ctx
 }
 
-func (h *QueryHook) AfterQuery(_ context.Context, event *bun.QueryEvent) {
+func (h *QueryHook) AfterQuery(ctx context.Context, event *bun.QueryEvent) {
 	dur := time.Since(event.StartTime)
 	query := event.Query
 	if len(query) > 200 {
@@ -41,19 +42,28 @@ func (h *QueryHook) AfterQuery(_ context.Context, event *bun.QueryEvent) {
 
 	if event.Err != nil {
 		if errors.Is(event.Err, sql.ErrNoRows) {
-			h.logger.LogAttrs(context.Background(), slog.LevelDebug, "query no rows", attrs...)
+			h.logger.LogAttrs(ctx, slog.LevelDebug, "query no rows", attrs...)
 			return
 		}
 		attrs = append(attrs, slog.String("error", event.Err.Error()))
-		h.logger.LogAttrs(context.Background(), slog.LevelError, "query error", attrs...)
+		var pgErr pgdriver.Error
+		if errors.As(event.Err, &pgErr) {
+			if code := pgErr.Field('C'); code != "" {
+				attrs = append(attrs, slog.String("sqlstate", code))
+			}
+			if constraint := pgErr.Field('n'); constraint != "" {
+				attrs = append(attrs, slog.String("constraint", constraint))
+			}
+		}
+		h.logger.LogAttrs(ctx, slog.LevelError, "query error", attrs...)
 		return
 	}
 
 	if dur >= slowQueryThreshold {
 		attrs = append(attrs, slog.Bool("slow_query", true))
-		h.logger.LogAttrs(context.Background(), slog.LevelWarn, "slow query", attrs...)
+		h.logger.LogAttrs(ctx, slog.LevelWarn, "slow query", attrs...)
 		return
 	}
 
-	h.logger.LogAttrs(context.Background(), slog.LevelDebug, "query", attrs...)
+	h.logger.LogAttrs(ctx, slog.LevelDebug, "query", attrs...)
 }

--- a/backend/database/query_hook_test.go
+++ b/backend/database/query_hook_test.go
@@ -6,11 +6,14 @@ import (
 	"database/sql"
 	"errors"
 	"log/slog"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/driver/pgdriver"
 )
 
 func newTestQueryHook(t *testing.T) (*QueryHook, *bytes.Buffer) {
@@ -66,6 +69,24 @@ func TestQueryHookAfterQuery_LogsNonNoRowsErrorsAtError(t *testing.T) {
 	}
 }
 
+func TestQueryHookAfterQuery_LogsPostgresErrorMetadata(t *testing.T) {
+	hook, buf := newTestQueryHook(t)
+
+	hook.AfterQuery(context.Background(), &bun.QueryEvent{
+		Query:     `INSERT INTO schedule.activity_instances (...) VALUES (...)`,
+		StartTime: time.Now(),
+		Err:       newPgErrorWithConstraint("23505", "idx_activity_instances_template_unique"),
+	})
+
+	output := buf.String()
+	if !strings.Contains(output, `"sqlstate":"23505"`) {
+		t.Fatalf("expected sqlstate in log, got %q", output)
+	}
+	if !strings.Contains(output, `"constraint":"idx_activity_instances_template_unique"`) {
+		t.Fatalf("expected constraint in log, got %q", output)
+	}
+}
+
 func TestQueryHookAfterQuery_LogsSlowQueriesAtWarn(t *testing.T) {
 	hook, buf := newTestQueryHook(t)
 
@@ -84,4 +105,13 @@ func TestQueryHookAfterQuery_LogsSlowQueriesAtWarn(t *testing.T) {
 	if !strings.Contains(output, `"slow_query":true`) {
 		t.Fatalf("expected slow_query marker, got %q", output)
 	}
+}
+
+func newPgErrorWithConstraint(code, constraintName string) error {
+	pgErr := pgdriver.Error{}
+	v := reflect.ValueOf(&pgErr).Elem()
+	mField := v.FieldByName("m")
+	ptr := unsafe.Pointer(mField.UnsafeAddr()) //nolint:gosec
+	*(*map[byte]string)(ptr) = map[byte]string{'C': code, 'n': constraintName}
+	return pgErr
 }

--- a/backend/services/schedule/materialization_service.go
+++ b/backend/services/schedule/materialization_service.go
@@ -423,7 +423,21 @@ func (s *materializationService) materializeTemplate(
 
 			inserted, err := s.instanceRepo.CreateTemplateBackedIfAbsent(ctx, instance)
 			if err != nil {
-				return &ScheduleError{Op: "materialize template: create instance", Err: err}
+				return &ScheduleError{
+					Op: "materialize template: create instance",
+					Err: fmt.Errorf(
+						"tenant_id=%d template_id=%d schedule_id=%d date=%s period_id=%d room_id=%d start_time=%s end_time=%s: %w",
+						tenant.FromContext(ctx),
+						tmpl.ID,
+						sch.ID,
+						date.Format("2006-01-02"),
+						period.ID,
+						effective.RoomID,
+						formatTimeOfDay(effective.StartTime),
+						formatTimeOfDay(effective.EndTime),
+						err,
+					),
+				}
 			}
 			if !inserted {
 				result.CandidatesRaced++

--- a/backend/services/schedule/materialization_service_test.go
+++ b/backend/services/schedule/materialization_service_test.go
@@ -578,6 +578,14 @@ func TestMaterializeForTenant_TemplateInsertErrorBubbles(t *testing.T) {
 	require.Error(t, err)
 	require.NotNil(t, result)
 	assert.Contains(t, err.Error(), "materialize template: create instance")
+	assert.Contains(t, err.Error(), "tenant_id=300")
+	assert.Contains(t, err.Error(), "template_id=500")
+	assert.Contains(t, err.Error(), "schedule_id=800")
+	assert.Contains(t, err.Error(), "date=2026-04-20")
+	assert.Contains(t, err.Error(), "period_id=400")
+	assert.Contains(t, err.Error(), "room_id=700")
+	assert.Contains(t, err.Error(), "start_time=14:00:00")
+	assert.Contains(t, err.Error(), "end_time=15:00:00")
 	assert.Zero(t, result.InstancesCreated)
 	assert.Zero(t, result.CandidatesRaced)
 }
@@ -598,6 +606,7 @@ func newMaterializationBranchService(instanceRepo materializationFakeInstanceRep
 			Model:         modelBase.Model{ID: templateID},
 		}}},
 		materializationFakeScheduleRepo{schedules: []*activities.Schedule{{
+			Model:           modelBase.Model{ID: 800},
 			ActivityGroupID: templateID,
 			Weekday:         activities.WeekdayMonday,
 			TimeframeID:     &timeframeID,

--- a/frontend/src/sentry.shared.test.ts
+++ b/frontend/src/sentry.shared.test.ts
@@ -25,6 +25,8 @@ describe("scrubEvent", () => {
 
     const result = scrubEvent(event);
 
+    expect(result).not.toBeNull();
+    if (result === null) throw new Error("expected event to be kept");
     expect(result.request?.headers).toStrictEqual({
       "Content-Type": "application/json",
     });
@@ -39,6 +41,8 @@ describe("scrubEvent", () => {
 
     const result = scrubEvent(event);
 
+    expect(result).not.toBeNull();
+    if (result === null) throw new Error("expected event to be kept");
     expect(result.request?.cookies).toStrictEqual({});
   });
 
@@ -54,6 +58,8 @@ describe("scrubEvent", () => {
 
     const result = scrubEvent(event);
 
+    expect(result).not.toBeNull();
+    if (result === null) throw new Error("expected event to be kept");
     expect(result.user).toStrictEqual({ id: "42" });
   });
 
@@ -62,6 +68,8 @@ describe("scrubEvent", () => {
 
     const result = scrubEvent(event);
 
+    expect(result).not.toBeNull();
+    if (result === null) throw new Error("expected event to be kept");
     expect(result.event_id).toBe("test-id");
   });
 
@@ -72,11 +80,75 @@ describe("scrubEvent", () => {
 
     const result = scrubEvent(event);
 
+    expect(result).not.toBeNull();
+    if (result === null) throw new Error("expected event to be kept");
     expect(result.request?.url).toBe("https://example.com");
   });
 
   it("returns the same event reference (mutates in place)", () => {
     const event = makeEvent({ user: { id: "1", email: "a@b.com" } });
+
+    const result = scrubEvent(event);
+
+    expect(result).toBe(event);
+  });
+
+  it("drops the known Next.js RSC router state parse noise", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "The router state header was sent but could not be parsed.",
+          },
+        ],
+      },
+      contexts: {
+        nextjs: {
+          request_path: "/dashboard?_rsc=tww4p",
+        },
+      },
+      request: {
+        url: "https://altenberge.moto-app.de/dashboard",
+      },
+    });
+
+    const result = scrubEvent(event);
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps router state parse errors without an RSC marker", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "The router state header was sent but could not be parsed.",
+          },
+        ],
+      },
+      request: {
+        url: "https://altenberge.moto-app.de/dashboard",
+      },
+    });
+
+    const result = scrubEvent(event);
+
+    expect(result).toBe(event);
+  });
+
+  it("keeps unrelated RSC errors", () => {
+    const event = makeEvent({
+      exception: {
+        values: [{ type: "Error", value: "database unavailable" }],
+      },
+      contexts: {
+        nextjs: {
+          request_path: "/dashboard?_rsc=tww4p",
+        },
+      },
+    });
 
     const result = scrubEvent(event);
 

--- a/frontend/src/sentry.shared.ts
+++ b/frontend/src/sentry.shared.ts
@@ -1,10 +1,17 @@
 import type { ErrorEvent } from "@sentry/nextjs";
 
+const routerStateParseMessage =
+  "The router state header was sent but could not be parsed.";
+
 /**
  * Shared Sentry beforeSend handler for GDPR-compliant event scrubbing.
  * Used by client, server, and edge configs to keep scrubbing rules in sync.
  */
-export function scrubEvent(event: ErrorEvent): ErrorEvent {
+export function scrubEvent(event: ErrorEvent): ErrorEvent | null {
+  if (isKnownRscRouterStateParseError(event)) {
+    return null;
+  }
+
   // Strip auth headers and cookies
   if (event.request?.headers) {
     delete event.request.headers["Authorization"];
@@ -24,4 +31,47 @@ export function scrubEvent(event: ErrorEvent): ErrorEvent {
   }
 
   return event;
+}
+
+function isKnownRscRouterStateParseError(event: ErrorEvent): boolean {
+  if (!eventHasMessage(event, routerStateParseMessage)) {
+    return false;
+  }
+
+  const requestPath = getNestedString(event.contexts, "nextjs", "request_path");
+  if (requestPath?.includes("_rsc=")) {
+    return true;
+  }
+
+  return event.request?.url?.includes("_rsc=") ?? false;
+}
+
+function eventHasMessage(event: ErrorEvent, message: string): boolean {
+  if (event.message === message) {
+    return true;
+  }
+
+  return (
+    event.exception?.values?.some((value) => value.value === message) ?? false
+  );
+}
+
+function getNestedString(
+  source: unknown,
+  firstKey: string,
+  secondKey: string,
+): string | undefined {
+  if (!isRecord(source)) {
+    return undefined;
+  }
+  const nested = source[firstKey];
+  if (!isRecord(nested)) {
+    return undefined;
+  }
+  const value = nested[secondKey];
+  return typeof value === "string" ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }


### PR DESCRIPTION
## Summary

- filter the known Next.js `_rsc` router-state parse noise from Sentry without hiding non-RSC errors
- add tenant/window logging for manual timetable materialization requests
- enrich materialization instance-create failures with tenant, template, schedule, date, period, room, and time-slot context
- include PostgreSQL SQLSTATE and constraint metadata in Bun query error logs

## Why

Sentry showed two noisy Next.js App Router `_rsc` router-state parse issues and one backend materialization failure that only surfaced the secondary `SQLSTATE=25P02` transaction-aborted symptom. This change keeps the known frontend framework noise out of alerts and makes future backend materialization failures point to the failing slot and original database metadata.

## Validation

- `cd frontend && pnpm run check`
- `cd frontend && pnpm test:run src/sentry.shared.test.ts`
- `cd backend && go test ./database -run 'TestQueryHookAfterQuery'`\n- `cd backend && go test ./services/schedule -run 'TestMaterializeForTenant_(TemplateInsertErrorBubbles|DuplicateInsertRaceDoesNotCopyChildren)'`\n- `cd backend && go test ./test/ -run TestHermeticTestPatterns -v`\n- pre-push: git-secrets, frontend knip, go vet, frontend check, go deadcode, golangci-lint\n\n## Notes\n\nA broader local backend package run was blocked by local test DB schema drift (`users.staff.employment_type` and `audit.data_deletions.staff_id` missing), unrelated to this change.