### PR TITLE
fix(enrollment): render custom field help texts in the enrollment form

### DIFF
--- a/frontend/src/components/enrollment/enrollment-form.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.test.tsx
@@ -255,6 +255,28 @@ describe("EnrollmentForm", () => {
     expect(mockSubmitEnrollment).not.toHaveBeenCalled();
   });
 
+  it("renders custom field help texts so parents see the admin's guidance", async () => {
+    // Regression guard: help_text was stored, served, and shown in the form
+    // editor, but never rendered in the actual enrollment form (CustomFieldInput
+    // and the structured field renderers dropped it). Cover both render paths:
+    // a simple field via labelEl (textarea) and a structured one
+    // (weekday_schedule), which render help_text independently.
+    const withHelp = schema();
+    withHelp.fields[0]!.help_text = "Bitte gewünschte Abholung beschreiben.";
+    withHelp.fields[3]!.help_text = "Pro Tag die Uhrzeit eintragen.";
+    mockFetchPublicActiveSchema.mockResolvedValue(withHelp);
+
+    renderForm();
+    await waitForLoaded();
+
+    expect(
+      screen.getByText("Bitte gewünschte Abholung beschreiben."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Pro Tag die Uhrzeit eintragen."),
+    ).toBeInTheDocument();
+  });
+
   it("fails closed when the legal texts cannot be loaded", async () => {
     // A real load failure (settings/DB/JSON error) must reject the whole
     // form load so the parent never submits legally relevant consent

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -1855,10 +1855,17 @@ function CustomFieldInput({
   error,
 }: CustomFieldInputProps) {
   const labelEl = (
-    <span className="block text-sm font-semibold text-gray-700">
-      {field.label}
-      {field.required && <span className="text-[#FF3130]"> *</span>}
-    </span>
+    <>
+      <span className="block text-sm font-semibold text-gray-700">
+        {field.label}
+        {field.required && <span className="text-[#FF3130]"> *</span>}
+      </span>
+      {field.help_text && (
+        <span className="mt-1 block text-xs leading-5 text-gray-500">
+          {field.help_text}
+        </span>
+      )}
+    </>
   );
   const valueStr = typeof value === "string" ? value : "";
 
@@ -2039,6 +2046,11 @@ function PhoneListInput({
         {field.label}
         {field.required && <span className="text-[#FF3130]"> *</span>}
       </legend>
+      {field.help_text && (
+        <p className="mt-1 text-xs leading-5 text-gray-500">
+          {field.help_text}
+        </p>
+      )}
       {phones.length === 0 && (
         <p className="mt-2 text-sm text-gray-500">
           Noch keine Nummer eingetragen.
@@ -2156,6 +2168,11 @@ function WeekdayScheduleInput({
         {field.label}
         {field.required && <span className="text-[#FF3130]"> *</span>}
       </legend>
+      {field.help_text && (
+        <p className="mt-1 text-xs leading-5 text-gray-500">
+          {field.help_text}
+        </p>
+      )}
       <p className="text-xs text-gray-500">
         Leere Felder bedeuten: an diesem Tag keine Angabe.
       </p>
@@ -2227,6 +2244,11 @@ function ContactListInput({
         {field.label}
         {field.required && <span className="text-[#FF3130]"> *</span>}
       </legend>
+      {field.help_text && (
+        <p className="mt-1 text-xs leading-5 text-gray-500">
+          {field.help_text}
+        </p>
+      )}
       {contacts.length === 0 && (
         <p className="mt-2 text-sm text-gray-500">
           Noch kein zusätzlicher Kontakt eingetragen.


### PR DESCRIPTION
## Problem

Customer feedback (Franziska): die für Eltern hinterlegten Texte bei den **Zusatzfragen** erscheinen in der Testversion des Anmeldeformulars nicht.

Root cause: `help_text` ist im Datenmodell vorhanden, wird von der API ausgeliefert und **im Formular-Editor** angezeigt (`enrollment-form-editor.tsx:2891`) — aber das **echte Formular** (`CustomFieldInput` + die strukturierten Renderer) hat das Feld nie gerendert. Live-Formular, Testversion/Vorschau (`/enroll/preview`) und der Parents-Portal-Pfad teilen dieselbe Komponente, also fehlte der Text überall.

Reine Render-Auslassung — Daten/API/Typ waren korrekt.

## Fix

`field.help_text` wird an **vier** Render-Stellen unter dem Label ausgegeben (rein additiv, hinter `{field.help_text && …}`):

| Stelle | deckt ab |
|---|---|
| `labelEl` (CustomFieldInput) | boolean, textarea, select, text, number, date |
| `PhoneListInput` | phone_list |
| `WeekdayScheduleInput` | weekday_schedule (Abholregelung/Buskind) |
| `ContactListInput` | contact_list |

Styling (`text-xs leading-5 text-gray-500`) 1:1 aus der bestehenden Editor-Vorschau übernommen — bewusst konsistent mit dem Umfeld, keine neue Farbe erfunden.

## Tests

- Neuer Regressionstest in `enrollment-form.test.tsx` deckt beide Render-Pfad-Familien ab (`labelEl` via textarea + strukturierter Renderer via `weekday_schedule`). Geteilte Fixture nicht mutiert (Mock-Override).
- `vitest` → 12/12 grün · `pnpm run check` (oxlint + tsc) → sauber.

## Bewusst nicht im Scope

- `aria-describedby`-Verknüpfung des Hilfetexts mit dem Input (a11y) — vorbestehende Lücke, kein Regress; eigener, breiterer Change.