### PR TITLE
fix(enrollment): wire default_activation_mode into approval

### DIFF
--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
 	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
@@ -226,6 +227,13 @@ type ChildOfferingRow struct {
 // the new tenant directly to the parent's existing portal account
 // instead of mailing an invite that would overwrite their password
 // on accept.
+// DecisionSettingsResolver is the narrow contract the decision service
+// needs from the platform settings service. Only the activation-mode
+// lookup is required today, so the interface stays minimal.
+type DecisionSettingsResolver interface {
+	ResolveString(ctx context.Context, key string) (string, error)
+}
+
 type DecisionServiceConfig struct {
 	RequestRepo              enrollmentModels.RequestRepository
 	RequestChildRepo         enrollmentModels.RequestChildRepository
@@ -251,8 +259,9 @@ type DecisionServiceConfig struct {
 	AccountRoleRepo          authModels.AccountRoleRepository
 	RoleRepo                 authModels.RoleRepository
 	OutboxEnqueuer           OutboxEnqueuer
-	FrontendURL              string // not used by parent-facing emails today; kept for future admin links
-	ParentsURL               string // status link in approved/waitlisted/rejected emails. Falls back to FrontendURL when empty.
+	FrontendURL              string                   // not used by parent-facing emails today; kept for future admin links
+	ParentsURL               string                   // status link in approved/waitlisted/rejected emails. Falls back to FrontendURL when empty.
+	Settings                 DecisionSettingsResolver // resolves enrollment.default_activation_mode on approval; nil-safe (defaults to scheduled)
 	Logger                   *slog.Logger
 }
 
@@ -283,6 +292,7 @@ type decisionService struct {
 	outboxEnqueuer           OutboxEnqueuer
 	frontendURL              string
 	parentsURL               string
+	settings                 DecisionSettingsResolver
 	logger                   *slog.Logger
 }
 
@@ -324,7 +334,8 @@ func NewDecisionService(cfg DecisionServiceConfig) DecisionService {
 			}
 			return strings.TrimRight(strings.TrimSpace(cfg.FrontendURL), "/")
 		}(),
-		logger: logger,
+		settings: cfg.Settings,
+		logger:   logger,
 	}
 }
 
@@ -730,6 +741,34 @@ func (s *decisionService) Decide(ctx context.Context, input DecideInput) (*Decid
 //
 // Returns a PendingGuardianInvite when the guardian needs an invitation
 // (no existing portal account) so the handler can fire it post-commit.
+// resolveActivationMode reads enrollment.default_activation_mode for the
+// tenant in context. The setting was registered from the start with a
+// registry default of "scheduled", so a plain ResolveString (tenant
+// override → registry default) is correct — there is no env-var fallback.
+//
+// Any resolve error or empty/unknown value falls back to the safe
+// "scheduled" default rather than failing the approval: an unconfigured
+// or momentarily-unreadable setting must never block a school from
+// approving a child.
+func (s *decisionService) resolveActivationMode(ctx context.Context) string {
+	if s.settings == nil {
+		return configModel.EnrollmentActivationModeScheduled
+	}
+	mode, err := s.settings.ResolveString(ctx, configModel.KeyEnrollmentDefaultActivationMode)
+	if err != nil {
+		s.logger.Warn("decision: resolve activation mode failed, defaulting to scheduled",
+			slog.String("key", configModel.KeyEnrollmentDefaultActivationMode),
+			slog.String("error", err.Error()),
+		)
+		return configModel.EnrollmentActivationModeScheduled
+	}
+	if mode == configModel.EnrollmentActivationModeImmediate {
+		return configModel.EnrollmentActivationModeImmediate
+	}
+	// Empty (unconfigured) or any unknown value normalizes to scheduled.
+	return configModel.EnrollmentActivationModeScheduled
+}
+
 func (s *decisionService) applyApproval(
 	ctx context.Context,
 	request *enrollmentModels.Request,
@@ -812,19 +851,34 @@ func (s *decisionService) applyApproval(
 		return nil, fmt.Errorf("decision: create person: %w", err)
 	}
 
-	// 3. Student row pinned to the phase's service window. Status
-	// 'pending' lets the activate-students scheduler flip to 'active'
-	// when ServiceStartDate arrives.
+	// 3. Student row pinned to the phase's service window. The
+	// enrollment.default_activation_mode setting decides the initial
+	// status:
+	//   - "scheduled" (default): status 'pending' lets the
+	//     activate-students scheduler flip to 'active' once enrolled_from
+	//     (ServiceStartDate) arrives.
+	//   - "immediate": status 'active' right away, so the child appears
+	//     in lists/attendance/check-in immediately.
+	//
+	// enrolled_from stays the phase's ServiceStartDate in BOTH modes — it
+	// is the official, consistent start date (not the arbitrary approval
+	// day) and is no longer read once a student is active; only
+	// enrolled_until drives later deactivation.
 	schoolClass := s.gradeToClass(child.TargetGradeLevel)
 	enrolledFrom := phase.ServiceStartDate
 	enrolledUntil := phase.ServiceEndDate
 	guardianEmail := request.GuardianEmail
 	guardianPhone := request.GuardianPhone
 
+	studentStatus := users.StudentStatusPending
+	if s.resolveActivationMode(ctx) == configModel.EnrollmentActivationModeImmediate {
+		studentStatus = users.StudentStatusActive
+	}
+
 	student := &users.Student{
 		PersonID:      person.ID,
 		SchoolClass:   schoolClass,
-		Status:        users.StudentStatusPending,
+		Status:        studentStatus,
 		EnrolledFrom:  &enrolledFrom,
 		EnrolledUntil: &enrolledUntil,
 		GuardianEmail: &guardianEmail,

--- a/backend/services/enrollment/decision_service_test.go
+++ b/backend/services/enrollment/decision_service_test.go
@@ -1,6 +1,7 @@
 package enrollment_test
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"testing"
@@ -11,7 +12,9 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
+	usersModels "github.com/moto-nrw/project-phoenix/models/users"
 	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
@@ -34,7 +37,30 @@ type decisionTestEnv struct {
 	decision enrollmentService.DecisionService
 }
 
+// stubActivationSettings is a fake DecisionSettingsResolver returning a
+// fixed enrollment.default_activation_mode, so the immediate/scheduled
+// approval paths can be exercised without writing config.setting_values
+// rows. Any other key resolves to "" (registry-default behaviour).
+type stubActivationSettings struct {
+	mode string
+}
+
+func (s stubActivationSettings) ResolveString(_ context.Context, key string) (string, error) {
+	if key == configModel.KeyEnrollmentDefaultActivationMode {
+		return s.mode, nil
+	}
+	return "", nil
+}
+
 func setupDecisionTest(t *testing.T) (*decisionTestEnv, func()) {
+	// nil Settings exercises the safe default (scheduled).
+	return setupDecisionTestWithSettings(t, nil)
+}
+
+func setupDecisionTestWithSettings(
+	t *testing.T,
+	settings enrollmentService.DecisionSettingsResolver,
+) (*decisionTestEnv, func()) {
 	t.Helper()
 	env, cleanup := setupRolloverTest(t)
 
@@ -64,6 +90,7 @@ func setupDecisionTest(t *testing.T) (*decisionTestEnv, func()) {
 		OutboxEnqueuer:           env.outbox,
 		FrontendURL:              "http://localhost:3000",
 		ParentsURL:               "http://parents.localhost:3000",
+		Settings:                 settings,
 		Logger:                   slog.Default(),
 	})
 	return &decisionTestEnv{rolloverTestEnv: env, decision: decision}, cleanup
@@ -365,6 +392,71 @@ func TestDecisionService_Decide_ApprovedCreatesDownstreamRecords(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, student)
 	assert.NotEmpty(t, student.SchoolClass, "school class must be derived from target_grade_level")
+}
+
+// ---- Decide: activation mode (enrollment.default_activation_mode) -------
+
+// Default / "scheduled": an approved child becomes a PENDING student
+// pinned to the phase's service-start date, so the activate-students
+// scheduler flips it to active when that date arrives. Uses the nil-
+// Settings setup, which must behave identically to an explicit
+// "scheduled" override (the safe default).
+func TestDecisionService_Decide_ApprovedScheduledKeepsStudentPending(t *testing.T) {
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	reqID, childID := submitOneChild(t, env, "activation-scheduled@example.com", "Sched", "Uled")
+	outcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
+		RequestID:  reqID,
+		ChildID:    childID,
+		Status:     enrollmentService.DecisionApproved,
+		ReviewedBy: env.creatorID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Child.CreatedStudentID)
+
+	student, err := env.repos.Student.FindByID(ctx, *outcome.Child.CreatedStudentID)
+	require.NoError(t, err)
+	assert.Equal(t, usersModels.StudentStatusPending, student.Status,
+		"scheduled mode must create the student as pending")
+	require.NotNil(t, student.EnrolledFrom)
+	assert.Equal(t,
+		env.sourcePhase.ServiceStartDate.Format("2006-01-02"),
+		student.EnrolledFrom.Format("2006-01-02"),
+		"enrolled_from must be pinned to the phase service-start date")
+}
+
+// "immediate": an approved child becomes an ACTIVE student right away so
+// it appears in lists/attendance/check-in immediately. enrolled_from is
+// still pinned to the phase's service-start date (the mode changes only
+// the status, never the dates).
+func TestDecisionService_Decide_ApprovedImmediateActivatesStudent(t *testing.T) {
+	env, cleanup := setupDecisionTestWithSettings(t, stubActivationSettings{
+		mode: configModel.EnrollmentActivationModeImmediate,
+	})
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	reqID, childID := submitOneChild(t, env, "activation-immediate@example.com", "Immo", "Diate")
+	outcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
+		RequestID:  reqID,
+		ChildID:    childID,
+		Status:     enrollmentService.DecisionApproved,
+		ReviewedBy: env.creatorID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Child.CreatedStudentID)
+
+	student, err := env.repos.Student.FindByID(ctx, *outcome.Child.CreatedStudentID)
+	require.NoError(t, err)
+	assert.Equal(t, usersModels.StudentStatusActive, student.Status,
+		"immediate mode must activate the student on approval")
+	require.NotNil(t, student.EnrolledFrom)
+	assert.Equal(t,
+		env.sourcePhase.ServiceStartDate.Format("2006-01-02"),
+		student.EnrolledFrom.Format("2006-01-02"),
+		"enrolled_from must stay the phase service-start date even in immediate mode")
 }
 
 func TestDecisionService_Decide_ApprovedStampsConsentTimestamps(t *testing.T) {

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -925,6 +925,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		OutboxEnqueuer:           platform.NewEnrollmentOutboxAdapter(emailOutboxService),
 		FrontendURL:              frontendURL,
 		ParentsURL:               parentsURL,
+		Settings:                 settingsService,
 		Logger:                   logger.With("service", "enrollment-decision"),
 	})
 


### PR DESCRIPTION
The enrollment.default_activation_mode setting was registered in the settings UI (immediate|scheduled) but never consumed — every approved student was hardcoded to 'pending', so the 'Sofort aktiv' option had no effect. This was unfinished plumbing from the settings PR, not a regression: decision_service never read the setting in any prior version.

Resolve the setting in the approval path and branch the new student's
status: 'immediate' -> active on approval, 'scheduled' (default) ->
pending until the phase service-start date (scheduler activates it). enrolled_from stays pinned to the phase service-start date in both modes — the mode changes only the status, never the dates. nil/error/unknown resolves to the safe 'scheduled' default so an unreadable setting never blocks an approval.

Rollover is intentionally left unchanged: returning students are already active and the mode governs only newly approved children.

Tests cover both modes (active vs pending + enrolled_from unchanged).

# Pull Request

## Description
<!-- Explain the changes you've made and why they're needed -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Configuration change
- [ ] Security improvement
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition/modification
- [ ] CI/CD improvement

## Related Issues
<!-- List any related issues using the following syntax:
- Fixes #123
- Addresses #456
- Related to #789
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Testing documentation updated

## Security Checklist
<!-- This section is mandatory for all PRs -->
- [ ] I have followed the [security guidelines](../docs/security.md)
- [ ] No sensitive information is committed (secrets, credentials, certificates)
- [ ] Environment variables are properly managed with templates
- [ ] Code does not contain hardcoded secrets
- [ ] No potential security vulnerabilities introduced

## Screenshots or Examples
<!-- Add screenshots or code examples if applicable -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have updated the documentation as needed
- [ ] If this PR changes a user-facing flow, I updated the in-app help guide (`guide-data.ts`) and any changed screenshot — or it doesn't apply (backend-only, operator/parents-portal-only, or pure-styling change)
- [ ] All tests are passing
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and resolved any merge conflicts

## Additional Notes
<!-- Add any other context about the PR here -->