### PR TITLE
docs: clarify activity guide for non-NFC schools

### DIFF
--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -221,9 +221,9 @@ export const setupChapters: readonly GuideChapter[] = [
         id: "aktivitaeten-anlegen",
         title: "Aktivitäten anlegen",
         summary:
-          "Wiederkehrende Angebote vorbereiten. Dieser Schritt ist vor allem für Einrichtungen relevant, die mit NFC oder Tablets arbeiten.",
+          "Wiederkehrende Angebote vorbereiten. Dieser Schritt ist nur für Einrichtungen relevant, die mit NFC oder Tablets arbeiten.",
         steps: [
-          "`Datenverwaltung` öffnen und `Aktivitäten` wählen.",
+          "Falls Ihre Einrichtung mit NFC oder Tablets arbeitet: `Datenverwaltung` öffnen und `Aktivitäten` wählen.",
           "Neue Aktivität anlegen.",
           "`Name` kurz und verständlich eintragen.",
           "`Kategorie` wählen.",
@@ -231,9 +231,9 @@ export const setupChapters: readonly GuideChapter[] = [
           "Speichern.",
         ],
         callout: {
-          title: "Optional ohne NFC",
-          body: "Wenn Ihre Einrichtung nicht mit NFC oder Tablets arbeitet, können Sie diesen Schritt für die Ersteinrichtung zunächst überspringen und Aktivitäten später ergänzen.",
-          tone: "gray",
+          title: "Nur bei NFC-/Tablet-Nutzung sichtbar",
+          body: "Wenn Ihre Einrichtung kein NFC oder keine Tablets nutzt, wird der Bereich `Aktivitäten` in der Datenverwaltung nicht angezeigt. In diesem Fall können Angebote je nach Freischaltung später im Alltag über `Aktuelle Aufsicht` oder den `Stundenplan` entstehen (siehe `Die App im Alltag` -> `Aktuelle Aufsicht` und `Stundenplan`).",
+          tone: "blue",
         },
         screenshot:
           "Aktivitätsformular mit Name, Kategorie und maximale Teilnehmer.",
@@ -442,7 +442,7 @@ export const appChapters: readonly GuideChapter[] = [
         title: "Aktivitäten",
         icon: Activity,
         summary:
-          "Liste aller Aktivitäten mit Suche und Filter; hier legst du neue Angebote an.",
+          "Liste aller Aktivitäten mit Suche und Filter; hier legst du neue Angebote an. Dieser Bereich ist nur bei Einrichtungen mit NFC-/Tablet-Nutzung sichtbar.",
         steps: [
           "`Aktivitäten` öffnen.",
           "Nach Name suchen oder nach `Kategorie` und `Meine Aktivitäten` filtern.",
@@ -563,10 +563,11 @@ export const appChapters: readonly GuideChapter[] = [
         title: "Datenverwaltung",
         icon: Database,
         summary:
-          "Der Admin-Bereich für alle Stammdaten: Kinder, Personal, Räume, Aktivitäten, Gruppen, Rollen, Geräte und Berechtigungen.",
+          "Der Admin-Bereich für alle Stammdaten: Kinder, Personal, Räume, Gruppen, Rollen und Berechtigungen. `Aktivitäten` und `Geräte` werden zusätzlich angezeigt, wenn Ihre Einrichtung mit NFC oder Tablets arbeitet.",
         steps: [
           "`Datenverwaltung` öffnen.",
-          "Den gewünschten Bereich wählen: `Kinder`, `Personal`, `Räume`, `Aktivitäten`, `Gruppen`, `Rollen`, `Geräte` oder `Berechtigungen`.",
+          "Den gewünschten Bereich wählen: `Kinder`, `Personal`, `Räume`, `Gruppen`, `Rollen` oder `Berechtigungen`.",
+          "Wenn NFC oder Tablets genutzt werden, zusätzlich `Aktivitäten` und `Geräte` öffnen.",
           "Einträge anlegen, bearbeiten oder prüfen.",
         ],
         screenshot: "Datenverwaltung mit allen Bereichen und Eintragszahlen.",


### PR DESCRIPTION
**Ziel**
Klarstellung der Hilfe-Anleitung rund um  für Schulen ohne NFC-/Tablet-Nutzung.

**Was wurde geändert**
- In  den Abschnitt  präzisiert:
  - nur für Schulen mit NFC/Tablets relevant
  - Hinweis ergänzt, dass der Bereich ohne NFC nicht in der Datenverwaltung sichtbar ist
  - Verweis auf  ->  und 
- In  den Abschnitt  ergänzt:
  - Bereich ist nur bei NFC-/Tablet-Nutzung sichtbar
- Im Abschnitt  klargestellt:
  -  und  sind keine immer sichtbaren Standardbereiche, sondern abhängig von NFC-/Tablet-Nutzung

**Warum**
Die bisherige Anleitung hat den Eindruck erweckt, dass  in jeder Schule unter  verfügbar sind. Für Schulen ohne NFC führt das zu Verwirrung, weil der Bereich dort bewusst ausgeblendet ist.

**Verifikation**
-  pre-push checks erfolgreich
-  erfolgreich
-  erfolgreich