### PR TITLE
chore: remove invalid mcp__* permission allow rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -103,7 +103,6 @@
       "Bash(brew:*)",
       "Bash(jq:*)",
       "Bash(wget:*)",
-      "mcp__*",
       "WebFetch(domain:docs.anthropic.com)",
       "WebSearch",
       "WebFetch"


### PR DESCRIPTION
## What

Removes the dead `"mcp__*"` entry from `permissions.allow` in `.claude/settings.json`.

## Why

`/doctor` flagged it as an invalid permission rule. Claude Code only permits a glob in the **tool** position after a concrete `mcp__<server>__` prefix (e.g. `mcp__linear-server__*`). A bare `mcp__*` that also wildcards the server name is rejected, so the rule was being **silently skipped** — it had no effect.

## Impact

None on behavior. The rule was already inert, so MCP tool calls were (and remain) governed by normal permission prompting. This just clears the `/doctor` warning for everyone on the team.