### PR TITLE
docs: add frontend UI kit rule so new UI defaults to the shared components

### DIFF
--- a/.claude/rules/frontend-ui-kit.md
+++ b/.claude/rules/frontend-ui-kit.md
@@ -1,0 +1,99 @@
+# Frontend UI Kit — Default to the Shared Components
+
+**RULE: All new frontend UI MUST be built from the shared kit in `frontend/src/components/ui/` (and `frontend/src/components/ui/page-header/`). Do NOT hand-roll a button, card, tab bar, modal, input, badge, table, or menu when a kit component exists. Do NOT import React components from the `@moto-nrw/design-system` package — that package is consumed for CSS tokens only.**
+
+This kit is the de-facto MOTO design system for project-phoenix — the visual language the team converged on (much of it built by Florian / `fl0r14n28`). It encodes the correct radii, brand colors, shadows, and interaction patterns. Reusing it is how every screen ends up looking the same. Hand-rolling chrome with ad-hoc `rounded-*` and generic Tailwind colors is exactly the drift this rule exists to stop.
+
+> The published `@moto-nrw/design-system` npm package ships components too, but project-phoenix is **not** on them yet — it only imports the package's CSS/tokens (`@import "@moto-nrw/design-system/tailwind"` in `globals.css`). Until the team explicitly migrates, the local `ui/` kit is the single source of truth. Don't import the package's components, and don't introduce a third component system.
+
+This rule reinforces the "Reuse Existing Components" sections in `CLAUDE.md` and `frontend/CLAUDE.md` and the reuse-before-rebuild principle.
+
+## Source of truth
+
+| Concern | Location |
+|---|---|
+| UI components | `frontend/src/components/ui/` |
+| Header / list-page kit | `frontend/src/components/ui/page-header/` |
+| Semantic brand colors | `frontend/src/lib/location-helper.ts` → `LOCATION_COLORS` (the ONLY source) |
+| Radius / spacing / shadow tokens | `@moto-nrw/design-system` via the `@theme` block `globals.css` pulls in |
+
+Imports are usually by direct file path: `import { Button } from "~/components/ui/button"`. The `ui/index.ts` barrel only re-exports a subset (`input`, `button`, `alert`, `modal`, `password-change-modal`, `form-modal`, `wizard-stepper`); importing the other components by their file path is correct and expected.
+
+## Need X → use Y (do not hand-roll)
+
+| You need… | Use | Import from |
+|---|---|---|
+| Button / CTA | `Button` — variants `primary` `secondary` `outline` `outline_danger` `danger` `success`; sizes `sm` `base` `lg` `xl` | `~/components/ui/button` |
+| Text input | `Input` | `~/components/ui/input` |
+| Inline alert / banner | `Alert` (`type`, `message`) | `~/components/ui/alert` |
+| Modal dialog | `Modal`, `ConfirmationModal` | `~/components/ui/modal` |
+| Form inside a modal | `FormModal` | `~/components/ui/form-modal` |
+| Delete confirmation | `ConfirmDeleteModal` | `~/components/ui/confirm-delete-modal` |
+| Multi-step wizard | `WizardStepper` | `~/components/ui/wizard-stepper` |
+| Tabs / segmented switcher | `Tabs`, `TabsList`, `TabsTrigger`, `TabsContent` — `variant="default"` (pill) or `"line"` (underline) | `~/components/ui/tabs` |
+| Data / list table | `DataTable`, `DataTableStatusBadge` | `~/components/ui/data-table` |
+| Info / stat card | `InfoCard`, `InfoItem` | `~/components/ui/info-card` |
+| Detail-panel fields | `DataField`, `InfoSection`, `DataGrid`, `InfoText` | `~/components/ui/detail-modal-components` |
+| Date / range picker | `DatePicker`, date-range picker | `~/components/ui/date-picker`, `~/components/ui/date-range-picker` |
+| Loading / skeleton | `Loading`, `Skeleton` | `~/components/ui/loading`, `~/components/ui/skeleton` |
+| Avatar | `Avatar` | `~/components/ui/avatar` |
+| Location / presence badge | `LocationBadge`, `PresenceBadge`, `StudentPresenceBadge` | `~/components/ui/location-badge`, etc. |
+| Back navigation | `BackButton`, `MobileBackButton` | `~/components/ui/back-button`, `~/components/ui/mobile-back-button` |
+| Overlay / side panel | `Drawer`, slide-over | `~/components/ui/drawer`, `~/components/ui/slide-over` |
+| API error message text | `getApiErrorMessage` | `~/components/ui/modal-utils` |
+| List/search page header | `PageHeaderWithSearch` | `~/components/ui/page-header` |
+| Header nav tabs (sliding indicator, mobile dropdown) | `NavigationTabs` | `~/components/ui/page-header/NavigationTabs` |
+| Kebab / overflow action menu | `OverflowMenu` | `~/components/ui/page-header/OverflowMenu` |
+| Filter toggle button | `FilterButton` | `~/components/ui/page-header/FilterButton` |
+
+If none fits, see **Kit gaps** below — extend the kit, don't inline a one-off.
+
+## Canonical values
+
+### Radius — set by the design-system `@theme`, NOT Tailwind defaults
+
+`rounded-sm`=4px · `rounded-md`=8px · `rounded-lg`=12px · `rounded-xl`=16px · `rounded-2xl`=24px · `rounded-full`=9999px
+
+- **Card / panel / floating surface wrapper** → `rounded-2xl border border-gray-200 bg-white shadow-sm`. 24px = the design system's `--card-radius`; this is the canonical card (used 13×+ across the app and in `InfoCard`). Do not invent another card shape, and never wrap content in a square `border-b`-only strip.
+- Inner controls (buttons, inputs, pills) get their radius from the kit component. Don't sprinkle bare `rounded` (= 4px Tailwind default, off the brand scale).
+
+### Colors — route every semantic color through `LOCATION_COLORS`
+
+NEVER use a generic Tailwind color class (`text-green-500`, `bg-blue-500`, …) for a brand-semantic purpose; the Tailwind hues differ from the brand. Use the kit component that already encodes the color, or the brand hex via arbitrary-value syntax (`bg-[#83CD2D]`).
+
+| Semantic | Hex | `LOCATION_COLORS` key |
+|---|---|---|
+| Brand green (primary) | `#83CD2D` | `GROUP_ROOM` |
+| Brand blue | `#5080D8` | `OTHER_ROOM` |
+| Red | `#FF3130` | `HOME` |
+| Orange | `#F78C10` | `SCHOOLYARD` |
+| Magenta | `#D946EF` | `TRANSIT` |
+| Amber | `#EAB308` | `SICK` |
+| Purple | `#7C3AED` | `EXCUSED` |
+| Gray (neutral) | `#6B7280` | `UNKNOWN` / `NOT_ARRIVAL` |
+
+Primary action button green: base `#83CD2D`, hover `#74b827`, active `#669f21`.
+
+## Kit gaps — extend the kit, don't inline a bespoke control
+
+The kit does **not** yet have a compact / ghost / icon-only button or a generic `DropdownMenu`. When you need one, ADD it to `frontend/src/components/ui/` so the next screen reuses it — do not hand-roll a one-off `<button className="…">` inline. Call out the addition in the PR description.
+
+## Gotchas
+
+- **Kit `Tabs` is Radix-based.** In tests, select a tab with `fireEvent.mouseDown(tab, { button: 0 })`, **not** `fireEvent.click` — Radix activates on mousedown/focus, so a synthetic click does nothing. Mirror `src/components/database/detail-panel.test.tsx`.
+- **`ui/Button` is page-level** (`rounded-lg px-5 py-3 shadow-md`) and defaults `type="submit"`. In a non-form context pass `type="button"`. For dense toolbar chrome it is oversized — prefer a compact variant (add one per **Kit gaps**) over reaching for raw Tailwind.
+- **`NavigationTabs` collapses to a dropdown on mobile** — use it for page-level navigation, not a compact segmented switcher. For a segmented switcher use `ui/Tabs` `variant="default"`.
+
+## Detection
+
+```bash
+# Components imported from the design-system package — should be ZERO (tokens only)
+rg -n "from ['\"]@moto-nrw/design-system['\"]" frontend/src -g '*.tsx' -g '*.ts'
+
+# Generic Tailwind brand-color utilities — prefer LOCATION_COLORS hex or a kit component
+rg -n "(text|bg|border)-(red|green|blue|orange|purple|amber|yellow|emerald)-[0-9]" frontend/src -g '*.tsx'
+```
+
+## When to deviate
+
+Only with explicit reviewer approval recorded in the PR description, citing this rule and the reason. "It was faster to inline it" is not a reason — add the missing piece to the kit instead. The whole frontend pays for every bespoke one-off.

--- a/.claude/rules/frontend-ui-kit.md
+++ b/.claude/rules/frontend-ui-kit.md
@@ -33,6 +33,19 @@ Prose cannot transfer taste, density, spacing judgment, or restraint. Examples c
 
 Keep this list current: if a reference is deleted or substantially rewritten, replace it with the new canonical example.
 
+## Visual references — look at the real UI
+
+Don't design from imagination. The app's real screens are captured as images you can open directly with the Read tool:
+
+- **App screenshots** → `frontend/public/help/screens/*.webp` (52 screens, maintained for the in-app help guide; treat as approximate-current). Open the relevant one before building or changing that screen. Anchors:
+  - `mitarbeiter.webp` = staff list · `mitarbeitende-anlegen.webp` = staff create
+  - `kinderdetailansicht.webp` = child detail · `kindersuche.webp` = student search/list
+  - `meine-gruppen.webp` = groups · `aktivitaeten.webp` = activities · `feedback.webp` = feedback
+  - `datenverwaltung.webp` = data admin · NFC kiosk = `nfc-*.webp`
+- **Component gallery (Storybook)** → https://moto-nrw.github.io/design-system/ (or `pnpm storybook` → :6006). Good for component anatomy and states. Caveat: it renders the `@moto-nrw/design-system` **package** components, which share the visual language but are NOT the ones we import — use it for spacing/anatomy intuition, not as import targets.
+
+Match what you see: density, neutral grays, brand-green accents used sparingly, no decorative hero cards.
+
 ## New UI is suspicious by default
 
 Writing a new component is the exception, not the default. Every new card/button/table/modal/empty-state that could have reused the kit is drift. Before building one:
@@ -80,6 +93,7 @@ If none fits, see **Kit gaps** below — extend the kit, don't inline a one-off.
 
 - **Card / panel / floating surface wrapper** → `rounded-2xl border border-gray-200 bg-white shadow-sm`. 24px = the design system's `--card-radius`; this is the canonical card (used 13×+ across the app and in `InfoCard`). Do not invent another card shape, and never wrap content in a square `border-b`-only strip.
 - Inner controls (buttons, inputs, pills) get their radius from the kit component. Don't sprinkle bare `rounded` (= 4px Tailwind default, off the brand scale).
+- Component radius tokens: button & input = `--radius-md` (8px), card = `--radius-2xl` (24px), badge/pill = `--radius-full`.
 
 ### Colors — route every semantic color through `LOCATION_COLORS`
 
@@ -97,6 +111,20 @@ NEVER use a generic Tailwind color class (`text-green-500`, `bg-blue-500`, …) 
 | Gray (neutral) | `#6B7280` | `UNKNOWN` / `NOT_ARRIVAL` |
 
 Primary action button green: base `#83CD2D`, hover `#74b827`, active `#669f21`.
+
+**Do NOT use the package color palette.** The `@moto-nrw/design-system` `@theme` ships a `steel` / `sage` / `warm` palette and `--color-brand-primary` (= sage `#7ba05b`). That is **not** the app's green. The app's brand green is `#83CD2D` (`LOCATION_COLORS.GROUP_ROOM` / the logo). Use `LOCATION_COLORS` for brand semantics and Tailwind `gray-*` for neutrals; never `bg-sage-*`, `bg-steel-*`, or `--color-brand-primary`, or you introduce a third, wrong green.
+
+### Spacing & padding
+
+Standard 4px scale — Tailwind `p-*` / `gap-*` / `m-*` map 1:1: `1`=4 · `2`=8 · `3`=12 · `4`=16 · `5`=20 · `6`=24 · `8`=32 · `10`=40 · `12`=48 · `16`=64 px. Canonical component padding (from the design-system component tokens):
+
+- Card → `p-6` (24px); `p-4` compact, `p-10` large
+- Button → `px-5 py-2` (md); `px-3 py-1` (sm)
+- Input → `px-4 py-3`
+
+### Shadows
+
+`shadow-sm` (cards / surfaces — the app default) · `shadow-md` (hover / raised) · `shadow-lg` / `shadow-xl` (overlays / modals). The canonical card uses `shadow-sm`.
 
 ## Kit gaps — extend the kit, don't inline a bespoke control
 

--- a/.claude/rules/frontend-ui-kit.md
+++ b/.claude/rules/frontend-ui-kit.md
@@ -19,6 +19,30 @@ This rule reinforces the "Reuse Existing Components" sections in `CLAUDE.md` and
 
 Imports are usually by direct file path: `import { Button } from "~/components/ui/button"`. The `ui/index.ts` barrel only re-exports a subset (`input`, `button`, `alert`, `modal`, `password-change-modal`, `form-modal`, `wizard-stepper`); importing the other components by their file path is correct and expected.
 
+## Study these first — canonical reference screens
+
+Prose cannot transfer taste, density, spacing judgment, or restraint. Examples can. **Before building or changing any UI, open the relevant file(s) below and match their structure, density, spacing, color use, component choice, and restraint.** These are the bar for "looks like the rest of the app."
+
+| Pattern | File | Why it's canonical |
+|---|---|---|
+| List / index page | `frontend/src/app/[tenant]/(protected)/staff/page.tsx` | `PageHeaderWithSearch` + filter chips + `DataTable`; compact and operational |
+| Detail page | `frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx` | `ui/Tabs` + `detail-modal-components` field layout |
+| Dense dashboard | `frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx` | KPI/Saldo cards, charts, tables, modals — how a complex operational screen stays dense, not decorative (big file; study sections, don't read top-to-bottom) |
+| Card primitive | `frontend/src/components/ui/info-card.tsx` | the canonical card surface |
+| Table primitive | `frontend/src/components/ui/data-table.tsx` | the canonical table |
+
+Keep this list current: if a reference is deleted or substantially rewritten, replace it with the new canonical example.
+
+## New UI is suspicious by default
+
+Writing a new component is the exception, not the default. Every new card/button/table/modal/empty-state that could have reused the kit is drift. Before building one:
+
+1. Search `ui/` and the canonical screens above for an existing fit.
+2. If something fits, reuse it (extend via props/className, don't fork).
+3. If nothing fits, STOP and state in the PR description **why** reuse doesn't fit and **what you added to the kit** instead of inlining a one-off.
+
+An unexplained bespoke component is a review failure, not a style preference.
+
 ## Need X → use Y (do not hand-roll)
 
 | You need… | Use | Import from |
@@ -93,6 +117,22 @@ rg -n "from ['\"]@moto-nrw/design-system['\"]" frontend/src -g '*.tsx' -g '*.ts'
 # Generic Tailwind brand-color utilities — prefer LOCATION_COLORS hex or a kit component
 rg -n "(text|bg|border)-(red|green|blue|orange|purple|amber|yellow|emerald)-[0-9]" frontend/src -g '*.tsx'
 ```
+
+## Mandatory visual check — do not skip
+
+Code can be correct and the UI still feel wrong (spacing, density, decoration). For any change a school user would see, **run the app locally and look at the actual screen before calling the work done** — do not rely on the diff or on tests passing. Use the project's browser-verification setup (the `verify` / agent-browser flow against `{slug}.localhost:3000`), screenshot the changed screen, and compare it side by side with the nearest canonical screen above. If it doesn't sit naturally next to that screen, it isn't done.
+
+## Design-review checklist
+
+Apply before marking any UI work complete (and reviewers: before approving):
+
+- [ ] Reuses kit components; any new component is justified in the PR description
+- [ ] Colors come from `LOCATION_COLORS` / kit components — no generic Tailwind hues
+- [ ] Radius, spacing, and density match the canonical screens (card = `rounded-2xl border border-gray-200 bg-white shadow-sm`)
+- [ ] No marketing-style hero / decorative cards — it reads as an operational school tool
+- [ ] Works on mobile
+- [ ] Dense enough for daily operational use (not airy / landing-page)
+- [ ] Visually verified: ran the app, screenshotted the changed screen, compared against a canonical screen
 
 ## When to deviate
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -147,6 +147,8 @@ Each portal is its own NextAuth instance. Cookies are host-only on operator + pa
 
 **ABSOLUTE RULE: Before creating ANY new UI element, color, or component, search the existing codebase first.** Do not reinvent what already exists. Duplication is a bug.
 
+**The shared UI kit is the source of truth.** Build from `src/components/ui/` (and `ui/page-header/`); never hand-roll a button/card/tab/modal/input/menu, and never import components from the `@moto-nrw/design-system` package (CSS tokens only). For the full component map, canonical radii (card = `rounded-2xl border border-gray-200 bg-white shadow-sm`), brand colors, and gotchas, see **`.claude/rules/frontend-ui-kit.md`**.
+
 ### Brand Colors — NEVER Use Generic Tailwind Colors
 
 MOTO has specific brand hex codes. Using generic Tailwind colors (like `text-green-500`, `bg-blue-500`) instead of the correct brand hex is **wrong** and will be rejected in review. Tailwind defaults are different hues than the MOTO brand.


### PR DESCRIPTION
## What

Adds `.claude/rules/frontend-ui-kit.md` — a binding convention so **new frontend UI defaults to the shared kit** (`src/components/ui/` + `ui/page-header/`) instead of bespoke markup. This is the rule that motivated the toolbar cleanup in #1586.

The rule states:
- The local `ui/` kit is the single source of truth. Never hand-roll a button/card/tab/modal/input/menu when a kit component exists.
- Never import React components from `@moto-nrw/design-system` — that package is consumed for **CSS tokens only** (not yet adopted as components).
- A concrete **"need X → use Y"** component map with import paths and key props.
- Canonical values: radius scale (`rounded-2xl` = 24px = the design system's `--card-radius`), the canonical card class `rounded-2xl border border-gray-200 bg-white shadow-sm`, and brand colors routed through `LOCATION_COLORS`.
- Known **kit gaps** (no compact/ghost/icon button, no generic dropdown) with the instruction to extend the kit rather than inline a one-off.
- Gotchas: Radix `Tabs` tests use `mouseDown` not `click`; `ui/Button` is page-level + defaults `type="submit"`; `NavigationTabs` is for page nav, not a segmented switcher.

Also adds a pointer from `frontend/CLAUDE.md` so the existing "Reuse Existing Components" section links to the full rule.

## Why

Most frontend work here is agent-assisted, and agents load `CLAUDE.md` + `.claude/rules/*` into context every session. Codifying the kit as a rule is the highest-leverage way to make every future session default to the established look (radius, colors, components) instead of re-deriving it.

## Notes

Docs only — no code or behavior changes. A CI lint guard (ban design-system component imports + flag generic color classes) is a sensible follow-up but intentionally out of scope here.