### PR TITLE
Fix staff work status test date handling

### DIFF
--- a/backend/api/staff/staff_test.go
+++ b/backend/api/staff/staff_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/api/testutil"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	configModels "github.com/moto-nrw/project-phoenix/models/config"
@@ -326,7 +327,7 @@ func TestGetStaff_WorkStatusConsistentWithList(t *testing.T) {
 
 	tenantID := int64(testutil.DefaultTestClaims().TenantID)
 	tenantCtx := testpkg.TenantContext(tenantID)
-	today := time.Now().UTC().Truncate(24 * time.Hour)
+	today := timezone.TodayUTC()
 	session := &active.WorkSession{
 		StaffID:     staff.ID,
 		Date:        today,


### PR DESCRIPTION
## Summary
- align the staff work-status regression test with the production Berlin-calendar date helper
- prevent CI failures during the UTC/Berlin midnight window where raw UTC truncation writes yesterday while the service queries today

## Root cause
`TestGetStaff_WorkStatusConsistentWithList` inserted `active.work_sessions.date` with `time.Now().UTC().Truncate(24 * time.Hour)`, but `WorkSessionRepository.GetTodayPresenceMap` queries `timezone.TodayUTC()`. Around 22:00-23:59 UTC in summer, Berlin has already advanced to the next calendar day, so the test-created row is invisible to the production lookup.

## Verification
- `cd backend && TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable AUTH_JWT_SECRET=ci-test-secret-must-be-at-least-32-chars-long go test ./api/staff -run TestGetStaff_WorkStatusConsistentWithList -count=1 -v`
- `cd backend && TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable AUTH_JWT_SECRET=ci-test-secret-must-be-at-least-32-chars-long go test ./api/staff -count=1`
- `cd backend && TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable AUTH_JWT_SECRET=ci-test-secret-must-be-at-least-32-chars-long go test ./test/ -run TestHermeticTestPatterns -v`