### PR TITLE
Apply enrollment activation mode setting

### DIFF
--- a/backend/database/repositories/enrollment/request_child_repository.go
+++ b/backend/database/repositories/enrollment/request_child_repository.go
@@ -138,6 +138,28 @@ func (r *RequestChildRepository) LinkCreatedStudent(ctx context.Context, request
 	return nil
 }
 
+// UpdateActivationPlan records the approval-time lifecycle decision on
+// the child row. Submission rows start with the schema default; approval is
+// the first point where the tenant setting and phase dates are authoritative.
+func (r *RequestChildRepository) UpdateActivationPlan(ctx context.Context, requestChildID int64, mode string, activateOn *time.Time) error {
+	res, err := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*enrollment.RequestChild)(nil)).
+		ModelTableExpr(requestChildTableExpr).
+		Set("activation_mode = ?", mode).
+		Set("activate_on = ?", activateOn).
+		Set("updated_at = ?", time.Now()).
+		Where(`"request_child".id = ?`, requestChildID).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to update request child activation plan: %w", err)
+	}
+	rows, _ := res.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("request child %d not found", requestChildID)
+	}
+	return nil
+}
+
 // CountCreatedStudentsByPhaseID returns the number of distinct students
 // that were created from the phase's enrollment requests (children with
 // a non-null created_student_id). Powers the phase-delete confirmation

--- a/backend/database/repositories/enrollment/request_child_repository_test.go
+++ b/backend/database/repositories/enrollment/request_child_repository_test.go
@@ -306,6 +306,61 @@ func TestRequestChildRepository_LinkCreatedStudent_MissingChildErrors(t *testing
 	assert.Contains(t, err.Error(), "not found")
 }
 
+func TestRequestChildRepository_UpdateActivationPlan_StampsImmediate(t *testing.T) {
+	db, repo, tenantID, _, requestID := setupRequestChildRepoTest(t)
+
+	child := makeChild(requestID, "Immo", "Diate")
+	require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		return repo.Create(ctx, child)
+	}))
+
+	require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		return repo.UpdateActivationPlan(ctx, child.ID, enrollmentModels.ChildActivationImmediate, nil)
+	}))
+
+	var got *enrollmentModels.RequestChild
+	require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		var findErr error
+		got, findErr = repo.FindByID(ctx, child.ID)
+		return findErr
+	}))
+	assert.Equal(t, enrollmentModels.ChildActivationImmediate, got.ActivationMode)
+	assert.Nil(t, got.ActivateOn)
+}
+
+func TestRequestChildRepository_UpdateActivationPlan_StampsScheduledDate(t *testing.T) {
+	db, repo, tenantID, _, requestID := setupRequestChildRepoTest(t)
+
+	child := makeChild(requestID, "Sched", "Uled")
+	require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		return repo.Create(ctx, child)
+	}))
+
+	activateOn := time.Date(2027, 9, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		return repo.UpdateActivationPlan(ctx, child.ID, enrollmentModels.ChildActivationScheduled, &activateOn)
+	}))
+
+	var got *enrollmentModels.RequestChild
+	require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		var findErr error
+		got, findErr = repo.FindByID(ctx, child.ID)
+		return findErr
+	}))
+	assert.Equal(t, enrollmentModels.ChildActivationScheduled, got.ActivationMode)
+	require.NotNil(t, got.ActivateOn)
+	assert.Equal(t, activateOn.Format("2006-01-02"), got.ActivateOn.Format("2006-01-02"))
+}
+
+func TestRequestChildRepository_UpdateActivationPlan_MissingChildErrors(t *testing.T) {
+	db, repo, tenantID, _, _ := setupRequestChildRepoTest(t)
+	err := runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		return repo.UpdateActivationPlan(ctx, 9_999_999, enrollmentModels.ChildActivationImmediate, nil)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
 // --- ListByPhaseAndStatuses --------------------------------------------
 
 func TestRequestChildRepository_ListByPhaseAndStatuses_Filters(t *testing.T) {

--- a/backend/models/enrollment/request_child.go
+++ b/backend/models/enrollment/request_child.go
@@ -129,6 +129,7 @@ type RequestChildRepository interface {
 
 	UpdateStatus(ctx context.Context, id int64, newStatus string, reason *string, reviewedBy int64) error
 	LinkCreatedStudent(ctx context.Context, requestChildID, studentID int64) error
+	UpdateActivationPlan(ctx context.Context, requestChildID int64, mode string, activateOn *time.Time) error
 
 	// ListByPhaseAndStatuses returns every child row in the given
 	// phase whose status is in the provided set, sorted by request

--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -769,6 +769,40 @@ func (s *decisionService) resolveActivationMode(ctx context.Context) string {
 	return configModel.EnrollmentActivationModeScheduled
 }
 
+type approvalActivationPlan struct {
+	Mode          string
+	ActivateOn    *time.Time
+	StudentStatus users.StudentStatus
+}
+
+func (s *decisionService) approvalActivationPlan(ctx context.Context, phase *enrollmentModels.Phase) approvalActivationPlan {
+	mode := s.resolveActivationMode(ctx)
+	if mode == configModel.EnrollmentActivationModeImmediate {
+		return approvalActivationPlan{
+			Mode:          enrollmentModels.ChildActivationImmediate,
+			StudentStatus: users.StudentStatusActive,
+		}
+	}
+
+	activateOn := phase.ServiceStartDate
+	status := users.StudentStatusPending
+	if !timezone.DateOfUTC(activateOn).After(timezone.TodayUTC()) {
+		status = users.StudentStatusActive
+	}
+	return approvalActivationPlan{
+		Mode:          enrollmentModels.ChildActivationScheduled,
+		ActivateOn:    &activateOn,
+		StudentStatus: status,
+	}
+}
+
+func (s *decisionService) stampActivationPlan(ctx context.Context, requestChildID int64, plan approvalActivationPlan) error {
+	if err := s.requestChildRepo.UpdateActivationPlan(ctx, requestChildID, plan.Mode, plan.ActivateOn); err != nil {
+		return fmt.Errorf("decision: stamp activation plan: %w", err)
+	}
+	return nil
+}
+
 func (s *decisionService) applyApproval(
 	ctx context.Context,
 	request *enrollmentModels.Request,
@@ -869,16 +903,12 @@ func (s *decisionService) applyApproval(
 	enrolledUntil := phase.ServiceEndDate
 	guardianEmail := request.GuardianEmail
 	guardianPhone := request.GuardianPhone
-
-	studentStatus := users.StudentStatusPending
-	if s.resolveActivationMode(ctx) == configModel.EnrollmentActivationModeImmediate {
-		studentStatus = users.StudentStatusActive
-	}
+	activationPlan := s.approvalActivationPlan(ctx, phase)
 
 	student := &users.Student{
 		PersonID:      person.ID,
 		SchoolClass:   schoolClass,
-		Status:        studentStatus,
+		Status:        activationPlan.StudentStatus,
 		EnrolledFrom:  &enrolledFrom,
 		EnrolledUntil: &enrolledUntil,
 		GuardianEmail: &guardianEmail,
@@ -929,6 +959,10 @@ func (s *decisionService) applyApproval(
 	// in activities.student_enrollments. Offerings without an activity
 	// group (pure schedule-only offerings) are skipped.
 	if err := s.materializeEnrollments(ctx, child.ID, student.ID, phase); err != nil {
+		return nil, err
+	}
+
+	if err := s.stampActivationPlan(ctx, child.ID, activationPlan); err != nil {
 		return nil, err
 	}
 
@@ -997,20 +1031,30 @@ func (s *decisionService) applyApprovalRollover(
 		return nil, fmt.Errorf("decision: rollover load existing student %d: %w", studentID, err)
 	}
 
-	// Update school_class / enrollment window. Status is left at
-	// whatever the scheduler had it on — typically 'active'. The
-	// activate-students scheduler keeps the lifecycle in sync.
+	activationPlan := s.approvalActivationPlan(ctx, phase)
+
+	// Update school_class / enrollment window. Already-active children
+	// stay active even for a future rollover phase, so current attendance
+	// workflows are not interrupted. Inactive/pending children follow the
+	// approval-time activation plan.
 	existing.SchoolClass = s.gradeToClass(child.TargetGradeLevel)
 	enrolledFrom := phase.ServiceStartDate
 	enrolledUntil := phase.ServiceEndDate
 	existing.EnrolledFrom = &enrolledFrom
 	existing.EnrolledUntil = &enrolledUntil
+	if existing.Status != users.StudentStatusActive {
+		existing.Status = activationPlan.StudentStatus
+	}
 	if err := s.studentRepo.Update(ctx, existing); err != nil {
 		return nil, fmt.Errorf("decision: rollover update student: %w", err)
 	}
 
 	// Materialize the new year's care offerings under this student.
 	if err := s.materializeEnrollments(ctx, child.ID, studentID, phase); err != nil {
+		return nil, err
+	}
+
+	if err := s.stampActivationPlan(ctx, child.ID, activationPlan); err != nil {
 		return nil, err
 	}
 

--- a/backend/services/enrollment/decision_service_test.go
+++ b/backend/services/enrollment/decision_service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
@@ -127,6 +128,16 @@ func submitOneChild(t *testing.T, env *decisionTestEnv, guardianEmail, childFirs
 	require.NoError(t, err)
 	require.Len(t, res.Children, 1)
 	return res.Request.ID, res.Children[0].ID
+}
+
+func setSourcePhaseServiceStartDate(t *testing.T, env *decisionTestEnv, serviceStartDate time.Time) {
+	t.Helper()
+	ctx := testpkg.TenantContext(1)
+	env.sourcePhase.ServiceStartDate = serviceStartDate
+	if !env.sourcePhase.ServiceEndDate.After(serviceStartDate) {
+		env.sourcePhase.ServiceEndDate = serviceStartDate.AddDate(0, 10, 0)
+	}
+	require.NoError(t, env.repos.Phase.Update(ctx, env.sourcePhase))
 }
 
 // ---- Get ----------------------------------------------------------------
@@ -425,6 +436,15 @@ func TestDecisionService_Decide_ApprovedScheduledKeepsStudentPending(t *testing.
 		env.sourcePhase.ServiceStartDate.Format("2006-01-02"),
 		student.EnrolledFrom.Format("2006-01-02"),
 		"enrolled_from must be pinned to the phase service-start date")
+
+	child, err := env.repos.RequestChild.FindByID(ctx, childID)
+	require.NoError(t, err)
+	assert.Equal(t, enrollmentModels.ChildActivationScheduled, child.ActivationMode)
+	require.NotNil(t, child.ActivateOn)
+	assert.Equal(t,
+		env.sourcePhase.ServiceStartDate.Format("2006-01-02"),
+		child.ActivateOn.Format("2006-01-02"),
+		"scheduled approval must stamp the planned activation date")
 }
 
 // "immediate": an approved child becomes an ACTIVE student right away so
@@ -457,6 +477,69 @@ func TestDecisionService_Decide_ApprovedImmediateActivatesStudent(t *testing.T) 
 		env.sourcePhase.ServiceStartDate.Format("2006-01-02"),
 		student.EnrolledFrom.Format("2006-01-02"),
 		"enrolled_from must stay the phase service-start date even in immediate mode")
+
+	child, err := env.repos.RequestChild.FindByID(ctx, childID)
+	require.NoError(t, err)
+	assert.Equal(t, enrollmentModels.ChildActivationImmediate, child.ActivationMode)
+	assert.Nil(t, child.ActivateOn)
+}
+
+func TestDecisionService_Decide_ApprovedScheduledPastStartActivatesStudent(t *testing.T) {
+	env, cleanup := setupDecisionTestWithSettings(t, stubActivationSettings{
+		mode: configModel.EnrollmentActivationModeScheduled,
+	})
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	reqID, childID := submitOneChild(t, env, "activation-scheduled-past@example.com", "Past", "Start")
+	startDate := timezone.TodayUTC().AddDate(0, 0, -1)
+	setSourcePhaseServiceStartDate(t, env, startDate)
+
+	outcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
+		RequestID:  reqID,
+		ChildID:    childID,
+		Status:     enrollmentService.DecisionApproved,
+		ReviewedBy: env.creatorID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Child.CreatedStudentID)
+
+	student, err := env.repos.Student.FindByID(ctx, *outcome.Child.CreatedStudentID)
+	require.NoError(t, err)
+	assert.Equal(t, usersModels.StudentStatusActive, student.Status,
+		"scheduled mode must activate immediately when service_start_date is today or already past")
+
+	child, err := env.repos.RequestChild.FindByID(ctx, childID)
+	require.NoError(t, err)
+	assert.Equal(t, enrollmentModels.ChildActivationScheduled, child.ActivationMode)
+	require.NotNil(t, child.ActivateOn)
+	assert.Equal(t, startDate.Format("2006-01-02"), child.ActivateOn.Format("2006-01-02"))
+}
+
+func TestDecisionService_Decide_ApprovedUnknownActivationModeFallsBackToScheduled(t *testing.T) {
+	env, cleanup := setupDecisionTestWithSettings(t, stubActivationSettings{mode: "bogus"})
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	reqID, childID := submitOneChild(t, env, "activation-unknown@example.com", "Safe", "Default")
+	outcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
+		RequestID:  reqID,
+		ChildID:    childID,
+		Status:     enrollmentService.DecisionApproved,
+		ReviewedBy: env.creatorID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Child.CreatedStudentID)
+
+	student, err := env.repos.Student.FindByID(ctx, *outcome.Child.CreatedStudentID)
+	require.NoError(t, err)
+	assert.Equal(t, usersModels.StudentStatusPending, student.Status,
+		"unknown setting values must not activate students")
+
+	child, err := env.repos.RequestChild.FindByID(ctx, childID)
+	require.NoError(t, err)
+	assert.Equal(t, enrollmentModels.ChildActivationScheduled, child.ActivationMode)
+	require.NotNil(t, child.ActivateOn)
 }
 
 func TestDecisionService_Decide_ApprovedStampsConsentTimestamps(t *testing.T) {

--- a/backend/services/enrollment/rollover_autoapprove_integration_test.go
+++ b/backend/services/enrollment/rollover_autoapprove_integration_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
 	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
@@ -28,6 +30,13 @@ import (
 // rather than inserting a second one.
 
 func setupAutoApproveIntegrationEnv(t *testing.T) (*rolloverTestEnv, func()) {
+	return setupAutoApproveIntegrationEnvWithSettings(t, nil)
+}
+
+func setupAutoApproveIntegrationEnvWithSettings(
+	t *testing.T,
+	settings enrollmentService.DecisionSettingsResolver,
+) (*rolloverTestEnv, func()) {
 	t.Helper()
 	env, cleanup := setupRolloverTest(t)
 
@@ -54,6 +63,7 @@ func setupAutoApproveIntegrationEnv(t *testing.T) (*rolloverTestEnv, func()) {
 		OutboxEnqueuer:           env.outbox,
 		FrontendURL:              "http://localhost:3000",
 		ParentsURL:               "http://parents.localhost:3000",
+		Settings:                 settings,
 		Logger:                   slog.Default(),
 	})
 
@@ -236,6 +246,8 @@ func TestRolloverService_AutoApprove_EndToEndUpdatesExistingStudent(t *testing.T
 	// memory copy.
 	refreshed, err := env.repos.Student.FindByID(ctx, existing.ID)
 	require.NoError(t, err)
+	assert.Equal(t, usersModels.StudentStatusActive, refreshed.Status,
+		"already-active rollover students must stay active even for a future phase")
 	assert.Equal(t, classForGrade(2), refreshed.SchoolClass,
 		"grade was bumped 1 → 2; school_class must follow")
 	require.NotNil(t, refreshed.EnrolledFrom)
@@ -243,6 +255,135 @@ func TestRolloverService_AutoApprove_EndToEndUpdatesExistingStudent(t *testing.T
 		"enrolled_from must follow the new phase's service window")
 	require.NotNil(t, refreshed.EnrolledUntil)
 	assert.Equal(t, result.Phase.ServiceEndDate, *refreshed.EnrolledUntil)
+	assert.Equal(t, enrollmentModels.ChildActivationScheduled, approved[0].ActivationMode)
+	require.NotNil(t, approved[0].ActivateOn)
+	assert.Equal(t, result.Phase.ServiceStartDate.Format("2006-01-02"), approved[0].ActivateOn.Format("2006-01-02"))
+}
+
+func TestRolloverService_AutoApprove_InactiveExistingStudentImmediateBecomesActive(t *testing.T) {
+	env, cleanup := setupAutoApproveIntegrationEnvWithSettings(t, stubActivationSettings{
+		mode: configModel.EnrollmentActivationModeImmediate,
+	})
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	_, existing := seedApprovedChildWithStudent(
+		t, env,
+		"Anna", "Inactive", "inactive-immediate@example.com",
+		"Lina", "Inactive",
+		int16(1),
+	)
+	existing.Status = usersModels.StudentStatusInactive
+	require.NoError(t, env.repos.Student.Update(ctx, existing))
+
+	req := validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true)
+	req.RolloverAutoApprove = true
+	req.RolloverDeadline = time.Now().Add(-1 * time.Hour)
+	req.Name = "inactive-immediate-target"
+	result, err := env.rolloverSvc.CreatePhaseFromSource(ctx, req)
+	require.NoError(t, err)
+
+	summary, err := env.rolloverSvc.RunDeadlineWorker(ctx, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.AutoRenewedToApproved)
+	assert.Equal(t, 0, summary.AutoApproveErrors)
+
+	approved, err := env.repos.RequestChild.ListByPhaseAndStatuses(
+		ctx, result.Phase.ID,
+		[]string{enrollmentModels.ChildStatusApproved},
+	)
+	require.NoError(t, err)
+	require.Len(t, approved, 1)
+	assert.Equal(t, enrollmentModels.ChildActivationImmediate, approved[0].ActivationMode)
+	assert.Nil(t, approved[0].ActivateOn)
+
+	refreshed, err := env.repos.Student.FindByID(ctx, existing.ID)
+	require.NoError(t, err)
+	assert.Equal(t, usersModels.StudentStatusActive, refreshed.Status)
+}
+
+func TestRolloverService_AutoApprove_InactiveExistingStudentFutureScheduledBecomesPending(t *testing.T) {
+	env, cleanup := setupAutoApproveIntegrationEnv(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	_, existing := seedApprovedChildWithStudent(
+		t, env,
+		"Anna", "Inactive", "inactive-scheduled@example.com",
+		"Lina", "Inactive",
+		int16(1),
+	)
+	existing.Status = usersModels.StudentStatusInactive
+	require.NoError(t, env.repos.Student.Update(ctx, existing))
+
+	req := validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true)
+	req.RolloverAutoApprove = true
+	req.RolloverDeadline = time.Now().Add(-1 * time.Hour)
+	req.Name = "inactive-scheduled-target"
+	result, err := env.rolloverSvc.CreatePhaseFromSource(ctx, req)
+	require.NoError(t, err)
+
+	summary, err := env.rolloverSvc.RunDeadlineWorker(ctx, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.AutoRenewedToApproved)
+	assert.Equal(t, 0, summary.AutoApproveErrors)
+
+	refreshed, err := env.repos.Student.FindByID(ctx, existing.ID)
+	require.NoError(t, err)
+	assert.Equal(t, usersModels.StudentStatusPending, refreshed.Status)
+
+	approved, err := env.repos.RequestChild.ListByPhaseAndStatuses(
+		ctx, result.Phase.ID,
+		[]string{enrollmentModels.ChildStatusApproved},
+	)
+	require.NoError(t, err)
+	require.Len(t, approved, 1)
+	assert.Equal(t, enrollmentModels.ChildActivationScheduled, approved[0].ActivationMode)
+	require.NotNil(t, approved[0].ActivateOn)
+	assert.Equal(t, result.Phase.ServiceStartDate.Format("2006-01-02"), approved[0].ActivateOn.Format("2006-01-02"))
+}
+
+func TestRolloverService_AutoApprove_InactiveExistingStudentPastScheduledBecomesActive(t *testing.T) {
+	env, cleanup := setupAutoApproveIntegrationEnv(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	_, existing := seedApprovedChildWithStudent(
+		t, env,
+		"Anna", "Inactive", "inactive-scheduled-past@example.com",
+		"Lina", "Inactive",
+		int16(1),
+	)
+	existing.Status = usersModels.StudentStatusInactive
+	require.NoError(t, env.repos.Student.Update(ctx, existing))
+
+	req := validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true)
+	req.RolloverAutoApprove = true
+	req.RolloverDeadline = time.Now().Add(-1 * time.Hour)
+	req.ServiceStartDate = timezone.TodayUTC().AddDate(0, 0, -1)
+	req.ServiceEndDate = req.ServiceStartDate.AddDate(0, 10, 0)
+	req.Name = "inactive-scheduled-past-target"
+	result, err := env.rolloverSvc.CreatePhaseFromSource(ctx, req)
+	require.NoError(t, err)
+
+	summary, err := env.rolloverSvc.RunDeadlineWorker(ctx, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.AutoRenewedToApproved)
+	assert.Equal(t, 0, summary.AutoApproveErrors)
+
+	refreshed, err := env.repos.Student.FindByID(ctx, existing.ID)
+	require.NoError(t, err)
+	assert.Equal(t, usersModels.StudentStatusActive, refreshed.Status)
+
+	approved, err := env.repos.RequestChild.ListByPhaseAndStatuses(
+		ctx, result.Phase.ID,
+		[]string{enrollmentModels.ChildStatusApproved},
+	)
+	require.NoError(t, err)
+	require.Len(t, approved, 1)
+	assert.Equal(t, enrollmentModels.ChildActivationScheduled, approved[0].ActivationMode)
+	require.NotNil(t, approved[0].ActivateOn)
+	assert.Equal(t, result.Phase.ServiceStartDate.Format("2006-01-02"), approved[0].ActivateOn.Format("2006-01-02"))
 }
 
 func TestRolloverService_AutoApprove_DoesNotDuplicateStudents(t *testing.T) {


### PR DESCRIPTION
## Summary
- apply `enrollment.default_activation_mode` during enrollment approval
- stamp approved `request_children` rows with the chosen activation plan
- handle rollover approvals for inactive students while keeping already-active rollover students active

## Behavior TL;DR
The setting is not retroactive. It is read at the moment an admin approves an enrollment child.

If the setting is **“Zum Anmeldedatum”**:
- Approving a child creates/updates the student as `pending` if the phase `service_start_date` is in the future.
- The child becomes `active` automatically later via the existing scheduler when `enrolled_from <= today`.
- If the phase start date is today or already in the past, approval creates/updates the student as `active` immediately.
- The request child is stamped as `activation_mode = scheduled` and `activate_on = phase.service_start_date`.

If the setting is then switched to **“Ab sofort”**:
- New approvals from that point onward create/update students as `active` immediately.
- The request child is stamped as `activation_mode = immediate` and `activate_on = NULL`.
- Existing already-approved students are not changed by flipping the setting.

If the setting is switched back to **“Zum Anmeldedatum”**:
- New approvals from that point onward go back to scheduled behavior.
- Existing students that were activated while “Ab sofort” was selected stay active.
- Existing pending students from earlier scheduled approvals stay pending until the scheduler activates them.

For rollover approvals:
- Already active students stay active, even if the new phase starts in the future.
- Inactive/pending existing students follow the current setting at approval time:
  - “Ab sofort” → active.
  - “Zum Anmeldedatum” + future start → pending.
  - “Zum Anmeldedatum” + today/past start → active.

Mental model: the setting controls future approval decisions, not historical records.

## Why
The setting was visible in school settings, but approval logic still created scheduled/pending records in important paths. Admins choosing “Sofort aktiv” expected approved students to become active immediately.

Closes #1578

## Validation
- `cd backend && go test ./... -run '^$'`
- `cd backend && go test ./test/ -run TestHermeticTestPatterns -v`
- `git diff --check`
- pre-push: `git-secrets`, `go-vet`, `go-deadcode`, `golangci-lint`

Focused integration tests were added but could not be executed locally because this checkout has no `.env` / `TEST_DB_DSN` and no active `docker-compose.yml`.
