### PR TITLE
feat: weekday-specific pickup days

### DIFF
--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -736,9 +736,7 @@ func createStudentFromRequest(req *StudentRequest, personID int64) *users.Studen
 	if req.SupervisorNotes != nil {
 		student.SupervisorNotes = req.SupervisorNotes
 	}
-	if req.PickupStatus != nil {
-		student.PickupStatus = req.PickupStatus
-	}
+	reconcilePickupFields(student, req.PickupStatus, req.PickupDays)
 	if req.Bus != nil {
 		student.Bus = req.Bus
 		if !*req.Bus {
@@ -754,6 +752,33 @@ func createStudentFromRequest(req *StudentRequest, personID int64) *users.Studen
 	}
 
 	return student
+}
+
+// reconcilePickupFields keeps student.PickupDays (the authoritative per-weekday
+// map) and the legacy student.PickupStatus string in sync from a request that
+// may carry either, both, or neither. When both are present the weekday map
+// wins, since it is the granular source of truth.
+//
+// Contract for legacy (status-only) callers: pickup_status is treated as
+// authoritative. A non-"Wird abgeholt" status therefore CLEARS any existing
+// weekday map — a partial update that sends pickup_status without pickup_days
+// will wipe previously stored pickup days. This is intentional (the legacy
+// string has no per-day information to preserve), but it means new clients must
+// always send pickup_days, never pickup_status alone, to mutate the map.
+func reconcilePickupFields(student *users.Student, status *string, days *users.PickupDays) {
+	if status != nil {
+		student.PickupStatus = status
+		if *status != users.PickupStatusPickedUp {
+			student.PickupDays = users.PickupDays{}
+		} else if !student.PickupDays.HasAny() {
+			student.PickupDays = users.PickupDaysFromLegacyStatus(*status)
+		}
+	}
+	if days != nil {
+		student.PickupDays = *days
+		s := student.PickupDays.LegacyPickupStatus()
+		student.PickupStatus = &s
+	}
 }
 
 // optionalString returns a pointer to the trimmed string, or nil when empty,
@@ -1090,9 +1115,7 @@ func applyOptionalStudentFields(req *UpdateStudentRequest, student *users.Studen
 	if req.SupervisorNotes != nil {
 		student.SupervisorNotes = req.SupervisorNotes
 	}
-	if req.PickupStatus != nil {
-		student.PickupStatus = req.PickupStatus
-	}
+	reconcilePickupFields(student, req.PickupStatus, req.PickupDays)
 	if req.Bus != nil {
 		student.Bus = req.Bus
 		if !*req.Bus {

--- a/backend/api/students/response_helpers.go
+++ b/backend/api/students/response_helpers.go
@@ -76,6 +76,7 @@ func populatePublicStudentFields(response *StudentResponse, student *users.Stude
 		response.Bus = *student.Bus
 	}
 	response.BusDays = student.BusDays.Normalize()
+	response.PickupDays = student.PickupDays.Normalize()
 	if student.PickupStatus != nil {
 		response.PickupStatus = *student.PickupStatus
 	}
@@ -211,6 +212,7 @@ func populateSnapshotPublicFields(response *StudentResponse, student *users.Stud
 		response.Bus = *student.Bus
 	}
 	response.BusDays = student.BusDays.Normalize()
+	response.PickupDays = student.PickupDays.Normalize()
 	if student.PickupStatus != nil {
 		response.PickupStatus = *student.PickupStatus
 	}

--- a/backend/api/students/types.go
+++ b/backend/api/students/types.go
@@ -17,43 +17,44 @@ const (
 
 // StudentResponse represents a student response
 type StudentResponse struct {
-	ID                 int64         `json:"id"`
-	PersonID           int64         `json:"person_id"`
-	FirstName          string        `json:"first_name"`
-	LastName           string        `json:"last_name"`
-	TagID              string        `json:"tag_id,omitempty"`
-	Birthday           string        `json:"birthday,omitempty"` // Date in YYYY-MM-DD format
-	SchoolClass        string        `json:"school_class"`
-	Location           string        `json:"current_location"`
-	LocationSince      *time.Time    `json:"location_since,omitempty"`     // When student entered current location
-	RoomColor          *string       `json:"current_room_color,omitempty"` // Hex of the current room when set; nil for status-only locations or rooms without override
-	GuardianName       string        `json:"guardian_name,omitempty"`
-	GuardianContact    string        `json:"guardian_contact,omitempty"`
-	GuardianEmail      string        `json:"guardian_email,omitempty"`
-	GuardianPhone      string        `json:"guardian_phone,omitempty"`
-	GroupID            int64         `json:"group_id,omitempty"`
-	GroupName          string        `json:"group_name,omitempty"`
-	ExtraInfo          string        `json:"extra_info,omitempty"`
-	HealthInfo         string        `json:"health_info,omitempty"`
-	SupervisorNotes    string        `json:"supervisor_notes,omitempty"`
-	PickupStatus       string        `json:"pickup_status,omitempty"`
-	PickupTime         *string       `json:"pickup_time,omitempty"`          // Today's effective pickup time (HH:MM)
-	PickupIsException  bool          `json:"pickup_is_exception,omitempty"`  // True if today's pickup time is an exception
-	PickupNotes        string        `json:"pickup_notes,omitempty"`         // Exception reason or schedule notes
-	ArrivalTime        *string       `json:"arrival_time,omitempty"`         // Today's effective arrival time (HH:MM)
-	ArrivalIsException bool          `json:"arrival_is_exception,omitempty"` // True if today's arrival time is an exception
-	ArrivalNotes       string        `json:"arrival_notes,omitempty"`        // Exception reason or schedule notes
-	ActualArrivalTime  *string       `json:"actual_arrival_time,omitempty"`  // Today's actual arrival time from attendance (HH:MM)
-	ActualPickupTime   *string       `json:"actual_pickup_time,omitempty"`   // Today's actual pickup time from attendance (HH:MM)
-	Bus                bool          `json:"bus"`
-	BusDays            users.BusDays `json:"bus_days,omitempty"`
-	Sick               bool          `json:"sick"`
-	SickSince          *time.Time    `json:"sick_since,omitempty"`
-	Excused            bool          `json:"excused"`
-	ExcusedSince       *time.Time    `json:"excused_since,omitempty"`
-	DayPlanningStatus  string        `json:"day_planning_status,omitempty"`
-	DayPlanningReason  string        `json:"day_planning_reason,omitempty"`
-	DayPlanningLabel   string        `json:"day_planning_label,omitempty"`
+	ID                 int64            `json:"id"`
+	PersonID           int64            `json:"person_id"`
+	FirstName          string           `json:"first_name"`
+	LastName           string           `json:"last_name"`
+	TagID              string           `json:"tag_id,omitempty"`
+	Birthday           string           `json:"birthday,omitempty"` // Date in YYYY-MM-DD format
+	SchoolClass        string           `json:"school_class"`
+	Location           string           `json:"current_location"`
+	LocationSince      *time.Time       `json:"location_since,omitempty"`     // When student entered current location
+	RoomColor          *string          `json:"current_room_color,omitempty"` // Hex of the current room when set; nil for status-only locations or rooms without override
+	GuardianName       string           `json:"guardian_name,omitempty"`
+	GuardianContact    string           `json:"guardian_contact,omitempty"`
+	GuardianEmail      string           `json:"guardian_email,omitempty"`
+	GuardianPhone      string           `json:"guardian_phone,omitempty"`
+	GroupID            int64            `json:"group_id,omitempty"`
+	GroupName          string           `json:"group_name,omitempty"`
+	ExtraInfo          string           `json:"extra_info,omitempty"`
+	HealthInfo         string           `json:"health_info,omitempty"`
+	SupervisorNotes    string           `json:"supervisor_notes,omitempty"`
+	PickupStatus       string           `json:"pickup_status,omitempty"`
+	PickupDays         users.PickupDays `json:"pickup_days,omitempty"`          // Weekdays on which the child is picked up
+	PickupTime         *string          `json:"pickup_time,omitempty"`          // Today's effective pickup time (HH:MM)
+	PickupIsException  bool             `json:"pickup_is_exception,omitempty"`  // True if today's pickup time is an exception
+	PickupNotes        string           `json:"pickup_notes,omitempty"`         // Exception reason or schedule notes
+	ArrivalTime        *string          `json:"arrival_time,omitempty"`         // Today's effective arrival time (HH:MM)
+	ArrivalIsException bool             `json:"arrival_is_exception,omitempty"` // True if today's arrival time is an exception
+	ArrivalNotes       string           `json:"arrival_notes,omitempty"`        // Exception reason or schedule notes
+	ActualArrivalTime  *string          `json:"actual_arrival_time,omitempty"`  // Today's actual arrival time from attendance (HH:MM)
+	ActualPickupTime   *string          `json:"actual_pickup_time,omitempty"`   // Today's actual pickup time from attendance (HH:MM)
+	Bus                bool             `json:"bus"`
+	BusDays            users.BusDays    `json:"bus_days,omitempty"`
+	Sick               bool             `json:"sick"`
+	SickSince          *time.Time       `json:"sick_since,omitempty"`
+	Excused            bool             `json:"excused"`
+	ExcusedSince       *time.Time       `json:"excused_since,omitempty"`
+	DayPlanningStatus  string           `json:"day_planning_status,omitempty"`
+	DayPlanningReason  string           `json:"day_planning_reason,omitempty"`
+	DayPlanningLabel   string           `json:"day_planning_label,omitempty"`
 
 	// Photo (gated by operations.student_photos_enabled). PhotoURL is empty
 	// when no photo is set OR when the feature is off — the frontend's Avatar
@@ -146,13 +147,14 @@ type StudentRequest struct {
 	GuardianPhone   string `json:"guardian_phone,omitempty"`
 
 	// Optional fields
-	GroupID         *int64         `json:"group_id,omitempty"`
-	ExtraInfo       *string        `json:"extra_info,omitempty"`       // Extra information visible to supervisors
-	HealthInfo      *string        `json:"health_info,omitempty"`      // Static health and medical information
-	SupervisorNotes *string        `json:"supervisor_notes,omitempty"` // Notes from supervisors
-	PickupStatus    *string        `json:"pickup_status,omitempty"`    // How the child gets home
-	Bus             *bool          `json:"bus,omitempty"`              // Administrative permission flag (Buskind)
-	BusDays         *users.BusDays `json:"bus_days,omitempty"`         // Weekdays on which the child is a Buskind
+	GroupID         *int64            `json:"group_id,omitempty"`
+	ExtraInfo       *string           `json:"extra_info,omitempty"`       // Extra information visible to supervisors
+	HealthInfo      *string           `json:"health_info,omitempty"`      // Static health and medical information
+	SupervisorNotes *string           `json:"supervisor_notes,omitempty"` // Notes from supervisors
+	PickupStatus    *string           `json:"pickup_status,omitempty"`    // How the child gets home
+	PickupDays      *users.PickupDays `json:"pickup_days,omitempty"`      // Weekdays on which the child is picked up
+	Bus             *bool             `json:"bus,omitempty"`              // Administrative permission flag (Buskind)
+	BusDays         *users.BusDays    `json:"bus_days,omitempty"`         // Weekdays on which the child is a Buskind
 
 	// Guardians created together with the student in one atomic transaction
 	// (guardian_profiles system). Optional and independent of the legacy
@@ -217,21 +219,22 @@ type UpdateStudentRequest struct {
 	TagID     *string `json:"tag_id,omitempty"`
 
 	// Student-specific details (optional for update)
-	SchoolClass     *string        `json:"school_class,omitempty"`
-	GuardianName    *string        `json:"guardian_name,omitempty"`
-	GuardianContact *string        `json:"guardian_contact,omitempty"`
-	GuardianEmail   *string        `json:"guardian_email,omitempty"`
-	GuardianPhone   *string        `json:"guardian_phone,omitempty"`
-	GroupID         *int64         `json:"group_id,omitempty"`
-	HealthInfo      *string        `json:"health_info,omitempty"`      // Static health and medical information
-	SupervisorNotes *string        `json:"supervisor_notes,omitempty"` // Notes from supervisors
-	ExtraInfo       *string        `json:"extra_info,omitempty"`       // Extra information visible to supervisors
-	PickupStatus    *string        `json:"pickup_status,omitempty"`    // How the child gets home
-	Bus             *bool          `json:"bus,omitempty"`              // Administrative permission flag (Buskind)
-	BusDays         *users.BusDays `json:"bus_days,omitempty"`         // Weekdays on which the child is a Buskind
-	Sick            *bool          `json:"sick,omitempty"`             // true = currently sick
-	SickReason      *string        `json:"sick_reason,omitempty"`      // optional free-text reason stamped on today's sick day
-	Excused         *bool          `json:"excused,omitempty"`          // true = currently excused (not attending today)
+	SchoolClass     *string           `json:"school_class,omitempty"`
+	GuardianName    *string           `json:"guardian_name,omitempty"`
+	GuardianContact *string           `json:"guardian_contact,omitempty"`
+	GuardianEmail   *string           `json:"guardian_email,omitempty"`
+	GuardianPhone   *string           `json:"guardian_phone,omitempty"`
+	GroupID         *int64            `json:"group_id,omitempty"`
+	HealthInfo      *string           `json:"health_info,omitempty"`      // Static health and medical information
+	SupervisorNotes *string           `json:"supervisor_notes,omitempty"` // Notes from supervisors
+	ExtraInfo       *string           `json:"extra_info,omitempty"`       // Extra information visible to supervisors
+	PickupStatus    *string           `json:"pickup_status,omitempty"`    // How the child gets home
+	PickupDays      *users.PickupDays `json:"pickup_days,omitempty"`      // Weekdays on which the child is picked up
+	Bus             *bool             `json:"bus,omitempty"`              // Administrative permission flag (Buskind)
+	BusDays         *users.BusDays    `json:"bus_days,omitempty"`         // Weekdays on which the child is a Buskind
+	Sick            *bool             `json:"sick,omitempty"`             // true = currently sick
+	SickReason      *string           `json:"sick_reason,omitempty"`      // optional free-text reason stamped on today's sick day
+	Excused         *bool             `json:"excused,omitempty"`          // true = currently excused (not attending today)
 
 	// PhotoConsentGiven: documented parental photo-consent flag. The handler
 	// records who set it and when (photo_consent_given_at/_by columns) on a
@@ -324,6 +327,13 @@ func (req *StudentRequest) Bind(_ *http.Request) error {
 		normalized := req.BusDays.Normalize()
 		req.BusDays = &normalized
 	}
+	if req.PickupDays != nil {
+		if err := req.PickupDays.Validate(); err != nil {
+			return err
+		}
+		normalized := req.PickupDays.Normalize()
+		req.PickupDays = &normalized
+	}
 
 	return nil
 }
@@ -346,6 +356,13 @@ func (req *UpdateStudentRequest) Bind(_ *http.Request) error {
 		}
 		normalized := req.BusDays.Normalize()
 		req.BusDays = &normalized
+	}
+	if req.PickupDays != nil {
+		if err := req.PickupDays.Validate(); err != nil {
+			return err
+		}
+		normalized := req.PickupDays.Normalize()
+		req.PickupDays = &normalized
 	}
 	// Guardian fields are deprecated - allow empty strings for clearing
 	// Empty strings will be converted to nil in the update handler

--- a/backend/database/migrations/001015116_students_pickup_days.go
+++ b/backend/database/migrations/001015116_students_pickup_days.go
@@ -1,0 +1,101 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	studentsPickupDaysVersion     = "1.15.116"
+	studentsPickupDaysDescription = "Add weekday-specific pickup days to users.students"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     studentsPickupDaysVersion,
+		Description: studentsPickupDaysDescription,
+		DependsOn: []string{
+			addPickupStatusToStudentsVersion,
+			studentsBusDaysVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return studentsPickupDaysUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return studentsPickupDaysDown(ctx, db)
+		},
+	)
+}
+
+func studentsPickupDaysUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.116: Adding pickup_days to users.students...")
+
+	if _, err := db.NewRaw(`
+		ALTER TABLE users.students
+			ADD COLUMN IF NOT EXISTS pickup_days JSONB NOT NULL DEFAULT '{}'::jsonb;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed adding pickup_days to users.students: %w", err)
+	}
+
+	// Backfill from the legacy single status: "Wird abgeholt" implies all five
+	// weekdays. "Geht alleine nach Hause" and unset stay empty. Only pickup_days
+	// is written here — pickup_status is left untouched so existing displays
+	// stay stable until a child is next edited.
+	if _, err := db.NewRaw(`
+		UPDATE users.students
+		SET pickup_days = CASE
+			WHEN pickup_status = 'Wird abgeholt' THEN '{"mon":true,"tue":true,"wed":true,"thu":true,"fri":true}'::jsonb
+			ELSE '{}'::jsonb
+		END
+		WHERE pickup_days = '{}'::jsonb;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed backfilling users.students.pickup_days: %w", err)
+	}
+
+	if _, err := db.NewRaw(`
+		CREATE OR REPLACE FUNCTION users.is_valid_pickup_days(value JSONB)
+		RETURNS BOOLEAN
+		LANGUAGE sql
+		IMMUTABLE
+		AS $$
+			SELECT jsonb_typeof(value) = 'object'
+				AND NOT EXISTS (
+					SELECT 1
+					FROM jsonb_each(value) AS elem(key, value)
+					WHERE elem.key NOT IN ('mon', 'tue', 'wed', 'thu', 'fri')
+						OR jsonb_typeof(elem.value) <> 'boolean'
+				)
+		$$;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed creating users.students pickup_days validation function: %w", err)
+	}
+
+	if _, err := db.NewRaw(`
+		ALTER TABLE users.students
+			DROP CONSTRAINT IF EXISTS check_students_pickup_days,
+			ADD CONSTRAINT check_students_pickup_days CHECK (users.is_valid_pickup_days(pickup_days));
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed adding users.students.pickup_days check constraint: %w", err)
+	}
+
+	return nil
+}
+
+func studentsPickupDaysDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.116: Removing pickup_days from users.students...")
+
+	if _, err := db.NewRaw(`
+		ALTER TABLE users.students
+			DROP CONSTRAINT IF EXISTS check_students_pickup_days,
+			DROP COLUMN IF EXISTS pickup_days;
+		DROP FUNCTION IF EXISTS users.is_valid_pickup_days(JSONB);
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed removing users.students.pickup_days: %w", err)
+	}
+	return nil
+}

--- a/backend/database/migrations/001015117_form_schemas_pickup_weekday_boolean.go
+++ b/backend/database/migrations/001015117_form_schemas_pickup_weekday_boolean.go
@@ -1,0 +1,67 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	formSchemasPickupWeekdayBooleanVersion     = "1.15.117"
+	formSchemasPickupWeekdayBooleanDescription = "Convert existing pickup_status form fields from select to weekday_boolean"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     formSchemasPickupWeekdayBooleanVersion,
+		Description: formSchemasPickupWeekdayBooleanDescription,
+		DependsOn: []string{
+			createEnrollmentFormSchemasVersion,
+			studentsPickupDaysVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return formSchemasPickupWeekdayBooleanUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			// Down is intentionally a no-op: we cannot reconstruct the
+			// admin's original select options, and the weekday_boolean shape
+			// is forward-compatible. Rolling back the column migration
+			// (1.15.116) does not require reverting persisted form schemas.
+			return nil
+		},
+	)
+}
+
+// formSchemasPickupWeekdayBooleanUp rewrites every persisted form field whose
+// target is student.pickup_status so its type becomes weekday_boolean and any
+// leftover select `options` are dropped. ReservedTargets now declares
+// pickup_status as weekday_boolean, and FormField.Validate() rejects a
+// targeted field whose stored type no longer matches the reserved type — so
+// without this rewrite, any school that already added the "Abholregelung"
+// field to its enrollment form would fail validation on the next load/save.
+func formSchemasPickupWeekdayBooleanUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.117: Converting pickup_status form fields to weekday_boolean...")
+
+	if _, err := db.NewRaw(`
+		UPDATE enrollment.form_schemas
+		SET fields = (
+			SELECT jsonb_agg(
+				CASE
+					WHEN elem->>'target' = 'student.pickup_status'
+					THEN (elem - 'options') || '{"type":"weekday_boolean"}'::jsonb
+					ELSE elem
+				END
+			)
+			FROM jsonb_array_elements(fields) AS elem
+		)
+		WHERE fields @> '[{"target":"student.pickup_status"}]'::jsonb;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed converting pickup_status form fields: %w", err)
+	}
+
+	return nil
+}

--- a/backend/database/repositories/users/student.go
+++ b/backend/database/repositories/users/student.go
@@ -336,9 +336,11 @@ func (r *StudentRepository) persistBusDays(ctx context.Context, student *users.S
 	return base.AssertRowsAffected(result, 1, "update student bus days")
 }
 
-// persistPickupDays writes the per-weekday pickup map and keeps the legacy
-// pickup_status string in sync on subsequent reads (HasAny → "Wird abgeholt",
-// else "Geht alleine nach Hause"). Mirrors persistBusDays.
+// persistPickupDays writes the per-weekday pickup map AND the derived legacy
+// pickup_status string in the same update, so the repository is the single
+// source of truth: any caller that mutates PickupDays directly (not just the
+// HTTP reconcile helpers) can never leave pickup_status stale. HasAny →
+// "Wird abgeholt", else "Geht alleine nach Hause". Mirrors persistBusDays.
 func (r *StudentRepository) persistPickupDays(ctx context.Context, student *users.Student) error {
 	if student.PickupDays == nil {
 		if student.PickupStatus == nil {
@@ -347,9 +349,11 @@ func (r *StudentRepository) persistPickupDays(ctx context.Context, student *user
 		student.PickupDays = users.PickupDaysFromLegacyStatus(*student.PickupStatus)
 	}
 	normalized := student.PickupDays.Normalize()
+	legacyStatus := normalized.LegacyPickupStatus()
 	query := base.GetDB(ctx, r.db).NewUpdate().
 		TableExpr(`users.students AS "student"`).
 		Set(`pickup_days = ?`, normalized).
+		Set(`pickup_status = ?`, legacyStatus).
 		Where(`"student".id = ?`, student.ID)
 
 	if where, val, ok := base.TenantWhere(ctx, "student"); ok {
@@ -369,6 +373,7 @@ func (r *StudentRepository) persistPickupDays(ctx context.Context, student *user
 		}
 	}
 	student.PickupDays = normalized
+	student.PickupStatus = &legacyStatus
 	return base.AssertRowsAffected(result, 1, "update student pickup days")
 }
 

--- a/backend/database/repositories/users/student.go
+++ b/backend/database/repositories/users/student.go
@@ -276,7 +276,10 @@ func (r *StudentRepository) Create(ctx context.Context, student *users.Student) 
 	if err := r.Repository.Create(ctx, student); err != nil {
 		return err
 	}
-	return r.persistBusDays(ctx, student)
+	if err := r.persistBusDays(ctx, student); err != nil {
+		return err
+	}
+	return r.persistPickupDays(ctx, student)
 }
 
 // Update overrides the base Update method to handle validation
@@ -293,7 +296,10 @@ func (r *StudentRepository) Update(ctx context.Context, student *users.Student) 
 	if err := r.Repository.Update(ctx, student); err != nil {
 		return err
 	}
-	return r.persistBusDays(ctx, student)
+	if err := r.persistBusDays(ctx, student); err != nil {
+		return err
+	}
+	return r.persistPickupDays(ctx, student)
 }
 
 func (r *StudentRepository) persistBusDays(ctx context.Context, student *users.Student) error {
@@ -318,7 +324,7 @@ func (r *StudentRepository) persistBusDays(ctx context.Context, student *users.S
 		// Migration tests exercise historical schemas with the current model.
 		// Before 1.15.112 the column legitimately does not exist; let the
 		// legacy bus flag continue to cover those test/database states.
-		if isUndefinedBusDaysColumn(err) {
+		if isUndefinedColumnError(err) {
 			return nil
 		}
 		return &modelBase.DatabaseError{
@@ -330,7 +336,43 @@ func (r *StudentRepository) persistBusDays(ctx context.Context, student *users.S
 	return base.AssertRowsAffected(result, 1, "update student bus days")
 }
 
-func isUndefinedBusDaysColumn(err error) bool {
+// persistPickupDays writes the per-weekday pickup map and keeps the legacy
+// pickup_status string in sync on subsequent reads (HasAny → "Wird abgeholt",
+// else "Geht alleine nach Hause"). Mirrors persistBusDays.
+func (r *StudentRepository) persistPickupDays(ctx context.Context, student *users.Student) error {
+	if student.PickupDays == nil {
+		if student.PickupStatus == nil {
+			return nil
+		}
+		student.PickupDays = users.PickupDaysFromLegacyStatus(*student.PickupStatus)
+	}
+	normalized := student.PickupDays.Normalize()
+	query := base.GetDB(ctx, r.db).NewUpdate().
+		TableExpr(`users.students AS "student"`).
+		Set(`pickup_days = ?`, normalized).
+		Where(`"student".id = ?`, student.ID)
+
+	if where, val, ok := base.TenantWhere(ctx, "student"); ok {
+		query = query.Where(where, val)
+	}
+
+	result, err := query.Exec(ctx)
+	if err != nil {
+		// Before 1.15.116 the column legitimately does not exist; let the
+		// legacy pickup_status field continue to cover those test states.
+		if isUndefinedColumnError(err) {
+			return nil
+		}
+		return &modelBase.DatabaseError{
+			Op:  "update student pickup days",
+			Err: err,
+		}
+	}
+	student.PickupDays = normalized
+	return base.AssertRowsAffected(result, 1, "update student pickup days")
+}
+
+func isUndefinedColumnError(err error) bool {
 	var pgErr pgdriver.Error
 	return errors.As(err, &pgErr) && pgErr.Field('C') == "42703"
 }
@@ -697,12 +739,27 @@ func (r *StudentRepository) hydrateBusDaysForStudents(ctx context.Context, stude
 		return nil
 	}
 
-	type busDaysRow struct {
-		ID      int64         `bun:"id"`
-		BusDays users.BusDays `bun:"bus_days"`
+	// pickup_days (1.15.116) lands one migration after bus_days (1.15.112),
+	// so there is a schema window where bus_days exists but pickup_days does
+	// not. Detect the column independently and only select it when present —
+	// otherwise a missing pickup_days would fail the whole query and drop the
+	// bus_days hydration along with it.
+	hasPickupDays, err := r.hasStudentColumn(ctx, "pickup_days")
+	if err != nil {
+		return err
 	}
-	var rows []busDaysRow
-	sql := `SELECT "student".id, "student".bus_days FROM users.students AS "student" WHERE "student".id IN (?)`
+
+	type weekdayDaysRow struct {
+		ID         int64            `bun:"id"`
+		BusDays    users.BusDays    `bun:"bus_days"`
+		PickupDays users.PickupDays `bun:"pickup_days"`
+	}
+	var rows []weekdayDaysRow
+	pickupCol := `, NULL::jsonb AS pickup_days`
+	if hasPickupDays {
+		pickupCol = `, "student".pickup_days`
+	}
+	sql := `SELECT "student".id, "student".bus_days` + pickupCol + ` FROM users.students AS "student" WHERE "student".id IN (?)`
 	args := []any{bun.List(ids)}
 	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
 		sql += ` AND "student".tenant_id = ?`
@@ -711,13 +768,13 @@ func (r *StudentRepository) hydrateBusDaysForStudents(ctx context.Context, stude
 
 	if err := base.GetDB(ctx, r.db).NewRaw(sql, args...).Scan(ctx, &rows); err != nil {
 		// Migration tests exercise historical schemas with the current model.
-		// Before 1.15.112 the column legitimately does not exist; callers can
-		// still rely on the legacy bus flag in those schema states.
+		// Before 1.15.112 the bus_days column legitimately does not exist;
+		// callers can still rely on the legacy bus flag in those schema states.
 		if strings.Contains(err.Error(), "bus_days") {
 			return nil
 		}
 		return &modelBase.DatabaseError{
-			Op:  "hydrate student bus days",
+			Op:  "hydrate student weekday days",
 			Err: err,
 		}
 	}
@@ -725,6 +782,7 @@ func (r *StudentRepository) hydrateBusDaysForStudents(ctx context.Context, stude
 	for _, row := range rows {
 		if student := byID[row.ID]; student != nil {
 			student.BusDays = row.BusDays.Normalize()
+			student.PickupDays = row.PickupDays.Normalize()
 		}
 	}
 	return nil
@@ -844,7 +902,7 @@ func (r *StudentRepository) FindByIDForUpdate(ctx context.Context, id int64) (*u
 }
 
 func (r *StudentRepository) hydrateBusDaysIfPresent(ctx context.Context, students []*users.Student) error {
-	hasBusDays, err := r.hasBusDaysColumn(ctx)
+	hasBusDays, err := r.hasStudentColumn(ctx, "bus_days")
 	if err != nil {
 		return err
 	}
@@ -854,7 +912,7 @@ func (r *StudentRepository) hydrateBusDaysIfPresent(ctx context.Context, student
 	return r.hydrateBusDaysForStudents(ctx, students)
 }
 
-func (r *StudentRepository) hasBusDaysColumn(ctx context.Context) (bool, error) {
+func (r *StudentRepository) hasStudentColumn(ctx context.Context, column string) (bool, error) {
 	var exists bool
 	err := base.GetDB(ctx, r.db).NewRaw(`
 		SELECT EXISTS (
@@ -862,12 +920,12 @@ func (r *StudentRepository) hasBusDaysColumn(ctx context.Context) (bool, error) 
 			FROM information_schema.columns
 			WHERE table_schema = 'users'
 			  AND table_name = 'students'
-			  AND column_name = 'bus_days'
+			  AND column_name = ?
 		)
-	`).Scan(ctx, &exists)
+	`, column).Scan(ctx, &exists)
 	if err != nil {
 		return false, &modelBase.DatabaseError{
-			Op:  "check students bus_days column",
+			Op:  "check students column",
 			Err: err,
 		}
 	}

--- a/backend/database/repositories/users/student_internal_test.go
+++ b/backend/database/repositories/users/student_internal_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/uptrace/bun/driver/pgdriver"
 )
 
-func TestIsUndefinedBusDaysColumn(t *testing.T) {
-	assert.True(t, isUndefinedBusDaysColumn(testPgError("42703")))
-	assert.False(t, isUndefinedBusDaysColumn(testPgError("23514")))
-	assert.False(t, isUndefinedBusDaysColumn(errors.New("check_students_bus_days mentions bus_days")))
+func TestIsUndefinedColumnError(t *testing.T) {
+	assert.True(t, isUndefinedColumnError(testPgError("42703")))
+	assert.False(t, isUndefinedColumnError(testPgError("23514")))
+	assert.False(t, isUndefinedColumnError(errors.New("check_students_bus_days mentions bus_days")))
 }
 
 func testPgError(code string) error {

--- a/backend/database/repositories/users/student_pickup_days_test.go
+++ b/backend/database/repositories/users/student_pickup_days_test.go
@@ -1,0 +1,150 @@
+package users_test
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func requireStudentsPickupDaysColumn(t *testing.T, db *bun.DB) {
+	t.Helper()
+	var exists bool
+	err := db.NewRaw(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = 'users'
+			  AND table_name = 'students'
+			  AND column_name = 'pickup_days'
+		)
+	`).Scan(testpkg.TenantContext(1), &exists)
+	require.NoError(t, err)
+	if !exists {
+		t.Skip("users.students.pickup_days column is not present in this test database")
+	}
+}
+
+// TestStudentRepository_PickupDaysRoundtrip exercises persistPickupDays (on both
+// Create and Update) and the hydration path that reads the per-weekday map back,
+// plus the legacy pickup_status → pickup_days seeding that keeps old callers and
+// the importer working. Mirrors the bus_days roundtrip coverage.
+func TestStudentRepository_PickupDaysRoundtrip(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).Student
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("persists and hydrates an explicit weekday map", func(t *testing.T) {
+		requireStudentsPickupDaysColumn(t, db)
+
+		person := testpkg.CreateTestPerson(t, db, "Pickup", "Map")
+		defer testpkg.CleanupActivityFixtures(t, db, person.ID)
+
+		student := &users.Student{
+			PersonID:    person.ID,
+			SchoolClass: "1a",
+			PickupDays: users.PickupDays{
+				users.PickupDayMonday:    true,
+				users.PickupDayWednesday: true,
+			},
+		}
+
+		require.NoError(t, repo.Create(ctx, student))
+
+		found, err := repo.FindByID(ctx, student.ID)
+		require.NoError(t, err)
+		assert.True(t, found.PickupDays[users.PickupDayMonday])
+		assert.True(t, found.PickupDays[users.PickupDayWednesday])
+		assert.False(t, found.PickupDays[users.PickupDayTuesday])
+		assert.True(t, found.PickupDays.HasAny())
+
+		cleanupStudentRecords(t, db, student.ID)
+	})
+
+	t.Run("seeds all weekdays from legacy pickup_status picked up", func(t *testing.T) {
+		requireStudentsPickupDaysColumn(t, db)
+
+		person := testpkg.CreateTestPerson(t, db, "Pickup", "LegacyPickedUp")
+		defer testpkg.CleanupActivityFixtures(t, db, person.ID)
+
+		status := users.PickupStatusPickedUp
+		student := &users.Student{
+			PersonID:     person.ID,
+			SchoolClass:  "2a",
+			PickupStatus: &status,
+		}
+
+		require.NoError(t, repo.Create(ctx, student))
+
+		found, err := repo.FindByID(ctx, student.ID)
+		require.NoError(t, err)
+		for _, day := range users.PickupDayOrder {
+			assert.True(t, found.PickupDays[day], "legacy picked-up should enable %s", day)
+		}
+
+		cleanupStudentRecords(t, db, student.ID)
+	})
+
+	t.Run("seeds empty map from legacy goes-alone status", func(t *testing.T) {
+		requireStudentsPickupDaysColumn(t, db)
+
+		person := testpkg.CreateTestPerson(t, db, "Pickup", "LegacyAlone")
+		defer testpkg.CleanupActivityFixtures(t, db, person.ID)
+
+		status := users.PickupStatusGoesAlone
+		student := &users.Student{
+			PersonID:     person.ID,
+			SchoolClass:  "2b",
+			PickupStatus: &status,
+		}
+
+		require.NoError(t, repo.Create(ctx, student))
+
+		found, err := repo.FindByID(ctx, student.ID)
+		require.NoError(t, err)
+		assert.False(t, found.PickupDays.HasAny())
+		assert.Empty(t, found.PickupDays.Normalize())
+
+		cleanupStudentRecords(t, db, student.ID)
+	})
+
+	t.Run("updates the weekday map on an existing student", func(t *testing.T) {
+		requireStudentsPickupDaysColumn(t, db)
+
+		student := testpkg.CreateTestStudent(t, db, "Pickup", "Update", "3a")
+		defer cleanupStudentRecords(t, db, student.ID)
+
+		student.PickupDays = users.PickupDays{users.PickupDayFriday: true}
+		require.NoError(t, repo.Update(ctx, student))
+
+		found, err := repo.FindByID(ctx, student.ID)
+		require.NoError(t, err)
+		assert.True(t, found.PickupDays[users.PickupDayFriday])
+		assert.False(t, found.PickupDays[users.PickupDayMonday])
+		assert.Equal(t, 1, len(found.PickupDays.Normalize()))
+
+		cleanupStudentRecords(t, db, student.ID)
+	})
+
+	t.Run("rejects an invalid weekday before persistence", func(t *testing.T) {
+		person := testpkg.CreateTestPerson(t, db, "Pickup", "Invalid")
+		defer testpkg.CleanupActivityFixtures(t, db, person.ID)
+
+		student := &users.Student{
+			PersonID:    person.ID,
+			SchoolClass: "1a",
+			PickupDays:  users.PickupDays{"sat": true},
+		}
+
+		err := repo.Create(ctx, student)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `weekday "sat"`)
+		assert.Zero(t, student.ID)
+	})
+}

--- a/backend/database/repositories/users/student_pickup_days_test.go
+++ b/backend/database/repositories/users/student_pickup_days_test.go
@@ -132,6 +132,50 @@ func TestStudentRepository_PickupDaysRoundtrip(t *testing.T) {
 		cleanupStudentRecords(t, db, student.ID)
 	})
 
+	// A direct PickupDays write must keep the legacy pickup_status column in
+	// sync even when the caller never sets PickupStatus — the repository is the
+	// single source of truth, so filters/exports reading the legacy string can
+	// never disagree with the weekday map. Covers the three distinct states.
+	t.Run("syncs legacy pickup_status from a direct weekday write", func(t *testing.T) {
+		requireStudentsPickupDaysColumn(t, db)
+
+		t.Run("selected days derive picked-up", func(t *testing.T) {
+			student := testpkg.CreateTestStudent(t, db, "Pickup", "SyncPicked", "4a")
+			defer cleanupStudentRecords(t, db, student.ID)
+
+			// Set only the map, leave PickupStatus nil (the stale-write case).
+			student.PickupStatus = nil
+			student.PickupDays = users.PickupDays{users.PickupDayFriday: true}
+			require.NoError(t, repo.Update(ctx, student))
+
+			found, err := repo.FindByID(ctx, student.ID)
+			require.NoError(t, err)
+			require.NotNil(t, found.PickupStatus)
+			assert.Equal(t, users.PickupStatusPickedUp, *found.PickupStatus)
+		})
+
+		t.Run("explicit empty map derives goes-alone", func(t *testing.T) {
+			student := testpkg.CreateTestStudent(t, db, "Pickup", "SyncAlone", "4b")
+			defer cleanupStudentRecords(t, db, student.ID)
+
+			// Seed a picked-up student, then clear the map to the empty answer.
+			picked := users.PickupStatusPickedUp
+			student.PickupStatus = &picked
+			student.PickupDays = users.PickupDays{users.PickupDayMonday: true}
+			require.NoError(t, repo.Update(ctx, student))
+
+			student.PickupStatus = nil
+			student.PickupDays = users.PickupDays{}
+			require.NoError(t, repo.Update(ctx, student))
+
+			found, err := repo.FindByID(ctx, student.ID)
+			require.NoError(t, err)
+			require.NotNil(t, found.PickupStatus)
+			assert.Equal(t, users.PickupStatusGoesAlone, *found.PickupStatus)
+			assert.False(t, found.PickupDays.HasAny())
+		})
+	})
+
 	t.Run("rejects an invalid weekday before persistence", func(t *testing.T) {
 		person := testpkg.CreateTestPerson(t, db, "Pickup", "Invalid")
 		defer testpkg.CleanupActivityFixtures(t, db, person.ID)

--- a/backend/models/enrollment/form_field_target_test.go
+++ b/backend/models/enrollment/form_field_target_test.go
@@ -90,17 +90,16 @@ func TestFormField_Validate_StructuredTypeWithMatchingTargetOK(t *testing.T) {
 }
 
 func TestFormField_Validate_SelectTargetSeedsAreCheckedToo(t *testing.T) {
-	// pickup_status is target=select; the editor seeds canonical options
-	// but the model must still enforce that select fields ship options.
+	// pickup_status is no longer a select target (it is now weekday_boolean);
+	// a free-form admin select must still ship options and validate.
 	f := &FormField{
-		Key:       "pickup_status",
-		Label:     "Abholregelung",
+		Key:       "lunch_choice",
+		Label:     "Mittagessen",
 		Type:      FormFieldSelect,
 		SortOrder: 0,
-		Target:    TargetStudentPickupStatus,
 		Options: []FormFieldOption{
-			{Label: "Geht alleine nach Hause", Value: "alone"},
-			{Label: "Wird abgeholt", Value: "picked_up"},
+			{Label: "Vegetarisch", Value: "veggie"},
+			{Label: "Mit Fleisch", Value: "meat"},
 		},
 	}
 	assert.NoError(t, f.Validate())
@@ -108,15 +107,45 @@ func TestFormField_Validate_SelectTargetSeedsAreCheckedToo(t *testing.T) {
 
 func TestFormField_Validate_SelectWithoutOptionsRejected(t *testing.T) {
 	f := &FormField{
+		Key:       "lunch_choice",
+		Label:     "Mittagessen",
+		Type:      FormFieldSelect,
+		SortOrder: 0,
+	}
+	err := f.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "select")
+}
+
+func TestFormField_Validate_PickupStatusMustBeWeekdayBoolean(t *testing.T) {
+	// Locks in the post-migration contract: pickup_status is a
+	// weekday_boolean reserved target. A weekday_boolean field wired to it
+	// must validate...
+	ok := &FormField{
+		Key:       "pickup_status",
+		Label:     "Abholregelung",
+		Type:      FormFieldWeekdayBoolean,
+		SortOrder: 0,
+		Target:    TargetStudentPickupStatus,
+	}
+	assert.NoError(t, ok.Validate())
+
+	// ...and the legacy select shape (the exact thing migration 1.15.117
+	// rewrites) must now be rejected, so a stale schema can't slip through.
+	legacy := &FormField{
 		Key:       "pickup_status",
 		Label:     "Abholregelung",
 		Type:      FormFieldSelect,
 		SortOrder: 0,
 		Target:    TargetStudentPickupStatus,
+		Options: []FormFieldOption{
+			{Label: "Wird abgeholt", Value: "picked_up"},
+		},
 	}
-	err := f.Validate()
+	err := legacy.Validate()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "select")
+	assert.Contains(t, err.Error(), "target")
+	assert.Contains(t, err.Error(), "type")
 }
 
 func TestIsStructuredFieldType_RecognisesAllStructuredTypes(t *testing.T) {

--- a/backend/models/enrollment/form_schema.go
+++ b/backend/models/enrollment/form_schema.go
@@ -273,7 +273,7 @@ var ReservedTargets = map[string]ReservedTarget{
 	TargetStudentHealthInfo:   {Type: FormFieldTextarea, AppliesToChild: true, Label: "Gesundheitsinformationen"},
 	TargetStudentExtraInfo:    {Type: FormFieldTextarea, AppliesToChild: true, Label: "Hinweise an die Betreuung"},
 	TargetStudentBus:          {Type: FormFieldWeekdayBoolean, AppliesToChild: true, Label: "Buskind"},
-	TargetStudentPickupStatus: {Type: FormFieldSelect, AppliesToChild: true, Label: "Abholregelung"},
+	TargetStudentPickupStatus: {Type: FormFieldWeekdayBoolean, AppliesToChild: true, Label: "Abholregelung"},
 	TargetSchedulePickup:      {Type: FormFieldWeekdaySchedule, AppliesToChild: true, Label: "Abholzeiten"},
 	TargetScheduleArrival:     {Type: FormFieldWeekdaySchedule, AppliesToChild: true, Label: "Ankunftszeiten"},
 	TargetStudentContacts:     {Type: FormFieldContactList, AppliesToChild: true, Label: "Weitere Kontakte / Abholberechtigte / Notfallkontakte"},

--- a/backend/models/users/pickup_days.go
+++ b/backend/models/users/pickup_days.go
@@ -1,0 +1,96 @@
+package users
+
+import "fmt"
+
+const (
+	PickupDayMonday    = "mon"
+	PickupDayTuesday   = "tue"
+	PickupDayWednesday = "wed"
+	PickupDayThursday  = "thu"
+	PickupDayFriday    = "fri"
+)
+
+var PickupDayOrder = []string{
+	PickupDayMonday,
+	PickupDayTuesday,
+	PickupDayWednesday,
+	PickupDayThursday,
+	PickupDayFriday,
+}
+
+var validPickupDays = map[string]bool{
+	PickupDayMonday:    true,
+	PickupDayTuesday:   true,
+	PickupDayWednesday: true,
+	PickupDayThursday:  true,
+	PickupDayFriday:    true,
+}
+
+// Legacy pickup_status string values. The per-weekday model supersedes the
+// single global status, but the string is kept (derived) for backward
+// compatibility with consumers that still read student.pickup_status.
+const (
+	PickupStatusPickedUp  = "Wird abgeholt"
+	PickupStatusGoesAlone = "Geht alleine nach Hause"
+)
+
+// PickupDays stores the recurring weekdays on which a child is picked up
+// ("wird abgeholt"). A weekday not present (or false) means the child goes
+// home alone that day. Mirrors BusDays so the create/edit surfaces and the
+// public enrollment form can treat both the same way.
+type PickupDays map[string]bool
+
+func (p PickupDays) Validate() error {
+	for day := range p {
+		if !validPickupDays[day] {
+			return fmt.Errorf("pickup_days weekday %q must be one of mon/tue/wed/thu/fri", day)
+		}
+	}
+	return nil
+}
+
+func (p PickupDays) HasAny() bool {
+	for _, day := range PickupDayOrder {
+		if p[day] {
+			return true
+		}
+	}
+	return false
+}
+
+func (p PickupDays) Normalize() PickupDays {
+	out := PickupDays{}
+	for _, day := range PickupDayOrder {
+		if p[day] {
+			out[day] = true
+		}
+	}
+	return out
+}
+
+// PickupDaysFromLegacyStatus seeds the per-weekday map from the legacy
+// pickup_status string. "Wird abgeholt" implies all five weekdays; any other
+// value (including "Geht alleine nach Hause" and the empty/unset string)
+// implies no pickup days.
+func PickupDaysFromLegacyStatus(status string) PickupDays {
+	if status != PickupStatusPickedUp {
+		return PickupDays{}
+	}
+	return PickupDays{
+		PickupDayMonday:    true,
+		PickupDayTuesday:   true,
+		PickupDayWednesday: true,
+		PickupDayThursday:  true,
+		PickupDayFriday:    true,
+	}
+}
+
+// LegacyPickupStatus derives the legacy pickup_status string from the
+// per-weekday map: any selected day means "Wird abgeholt"; otherwise the
+// child goes home alone.
+func (p PickupDays) LegacyPickupStatus() string {
+	if p.HasAny() {
+		return PickupStatusPickedUp
+	}
+	return PickupStatusGoesAlone
+}

--- a/backend/models/users/pickup_days_test.go
+++ b/backend/models/users/pickup_days_test.go
@@ -1,0 +1,131 @@
+package users
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPickupDaysValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		days    PickupDays
+		wantErr string
+	}{
+		{
+			name: "accepts empty days",
+			days: PickupDays{},
+		},
+		{
+			name: "accepts weekdays",
+			days: PickupDays{
+				PickupDayMonday:    true,
+				PickupDayWednesday: false,
+				PickupDayFriday:    true,
+			},
+		},
+		{
+			name: "rejects unknown day",
+			days: PickupDays{
+				"sat": true,
+			},
+			wantErr: `weekday "sat"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.days.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("PickupDays.Validate() unexpected error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("PickupDays.Validate() expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("PickupDays.Validate() error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPickupDaysHasAny(t *testing.T) {
+	tests := []struct {
+		name string
+		days PickupDays
+		want bool
+	}{
+		{name: "empty days", days: PickupDays{}, want: false},
+		{name: "all false weekdays", days: PickupDays{PickupDayMonday: false, PickupDayFriday: false}, want: false},
+		{name: "known true weekday", days: PickupDays{PickupDayTuesday: true}, want: true},
+		{name: "unknown true day is ignored", days: PickupDays{"sat": true}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.days.HasAny(); got != tt.want {
+				t.Fatalf("PickupDays.HasAny() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPickupDaysNormalize(t *testing.T) {
+	days := PickupDays{
+		PickupDayMonday:    true,
+		PickupDayTuesday:   false,
+		PickupDayWednesday: true,
+		"sat":              true,
+	}
+
+	got := days.Normalize()
+	want := PickupDays{
+		PickupDayMonday:    true,
+		PickupDayWednesday: true,
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("PickupDays.Normalize() length = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for day, wantEnabled := range want {
+		if got[day] != wantEnabled {
+			t.Fatalf("PickupDays.Normalize()[%q] = %v, want %v", day, got[day], wantEnabled)
+		}
+	}
+	if got["sat"] {
+		t.Fatal("PickupDays.Normalize() kept unknown day sat")
+	}
+}
+
+func TestPickupDaysFromLegacyStatus(t *testing.T) {
+	alone := PickupDaysFromLegacyStatus(PickupStatusGoesAlone)
+	if alone.HasAny() {
+		t.Fatalf("PickupDaysFromLegacyStatus(%q) = %#v, want no enabled days", PickupStatusGoesAlone, alone)
+	}
+
+	unset := PickupDaysFromLegacyStatus("")
+	if unset.HasAny() {
+		t.Fatalf("PickupDaysFromLegacyStatus(\"\") = %#v, want no enabled days", unset)
+	}
+
+	pickedUp := PickupDaysFromLegacyStatus(PickupStatusPickedUp)
+	for _, day := range PickupDayOrder {
+		if !pickedUp[day] {
+			t.Fatalf("PickupDaysFromLegacyStatus(%q)[%q] = false, want true", PickupStatusPickedUp, day)
+		}
+	}
+	if len(pickedUp) != len(PickupDayOrder) {
+		t.Fatalf("PickupDaysFromLegacyStatus(%q) length = %d, want %d", PickupStatusPickedUp, len(pickedUp), len(PickupDayOrder))
+	}
+}
+
+func TestPickupDaysLegacyPickupStatus(t *testing.T) {
+	if got := (PickupDays{}).LegacyPickupStatus(); got != PickupStatusGoesAlone {
+		t.Fatalf("empty PickupDays.LegacyPickupStatus() = %q, want %q", got, PickupStatusGoesAlone)
+	}
+	if got := (PickupDays{PickupDayMonday: true}).LegacyPickupStatus(); got != PickupStatusPickedUp {
+		t.Fatalf("non-empty PickupDays.LegacyPickupStatus() = %q, want %q", got, PickupStatusPickedUp)
+	}
+}

--- a/backend/models/users/student.go
+++ b/backend/models/users/student.go
@@ -39,12 +39,13 @@ type Student struct {
 	SupervisorNotes *string       `bun:"supervisor_notes" json:"supervisor_notes,omitempty"`
 	HealthInfo      *string       `bun:"health_info" json:"health_info,omitempty"`
 	PickupStatus    *string       `bun:"pickup_status" json:"pickup_status,omitempty"`
-	Bus             *bool         `bun:"bus" json:"bus,omitempty"`                               // Administrative permission flag (Buskind)
-	BusDays         BusDays       `bun:"bus_days,type:jsonb,scanonly" json:"bus_days,omitempty"` // Weekdays on which the child is a Buskind
-	Sick            *bool         `bun:"sick" json:"sick,omitempty"`                             // true = currently sick
-	SickSince       *time.Time    `bun:"sick_since" json:"sick_since,omitempty"`                 // When sickness was reported
-	Excused         *bool         `bun:"excused" json:"excused,omitempty"`                       // true = currently excused (not attending today)
-	ExcusedSince    *time.Time    `bun:"excused_since" json:"excused_since,omitempty"`           // When excused status was reported
+	PickupDays      PickupDays    `bun:"pickup_days,type:jsonb,scanonly" json:"pickup_days,omitempty"` // Weekdays on which the child is picked up ("wird abgeholt")
+	Bus             *bool         `bun:"bus" json:"bus,omitempty"`                                     // Administrative permission flag (Buskind)
+	BusDays         BusDays       `bun:"bus_days,type:jsonb,scanonly" json:"bus_days,omitempty"`       // Weekdays on which the child is a Buskind
+	Sick            *bool         `bun:"sick" json:"sick,omitempty"`                                   // true = currently sick
+	SickSince       *time.Time    `bun:"sick_since" json:"sick_since,omitempty"`                       // When sickness was reported
+	Excused         *bool         `bun:"excused" json:"excused,omitempty"`                             // true = currently excused (not attending today)
+	ExcusedSince    *time.Time    `bun:"excused_since" json:"excused_since,omitempty"`                 // When excused status was reported
 	Status          StudentStatus `bun:"status,notnull,default:'active'" json:"status"`
 	EnrolledFrom    *time.Time    `bun:"enrolled_from,type:date" json:"enrolled_from,omitempty"`
 	EnrolledUntil   *time.Time    `bun:"enrolled_until,type:date" json:"enrolled_until,omitempty"`
@@ -116,6 +117,10 @@ func (s *Student) Validate() error {
 	}
 
 	if err := s.BusDays.Validate(); err != nil {
+		return err
+	}
+
+	if err := s.PickupDays.Validate(); err != nil {
 		return err
 	}
 

--- a/backend/services/enrollment/decision_helpers_test.go
+++ b/backend/services/enrollment/decision_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
+	"github.com/moto-nrw/project-phoenix/models/users"
 )
 
 // Pure-helper tests for the small functions the decision service
@@ -94,6 +95,45 @@ func TestDecodeBusDays_RejectsUnknownWeekday(t *testing.T) {
 	_, err := decodeBusDays(map[string]any{"sat": true})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sat")
+}
+
+func TestDecodePickupDays_NormalizesWeekdayMap(t *testing.T) {
+	out, err := decodePickupDays(map[string]any{"mon": true, "wed": false, "fri": true})
+	require.NoError(t, err)
+	assert.True(t, out["mon"])
+	assert.True(t, out["fri"])
+	assert.False(t, out["wed"])
+	assert.True(t, out.HasAny())
+}
+
+func TestDecodePickupDays_AcceptsLegacySelectValues(t *testing.T) {
+	// Pending pre-migration submissions stored the frontend select option
+	// *value*, not the German label. "picked_up" must map to all weekdays.
+	pickedUp, err := decodePickupDays("picked_up")
+	require.NoError(t, err)
+	for _, day := range users.PickupDayOrder {
+		assert.True(t, pickedUp[day], "picked_up should imply %s", day)
+	}
+
+	alone, err := decodePickupDays("alone")
+	require.NoError(t, err)
+	assert.False(t, alone.HasAny(), "alone should imply no pickup days")
+}
+
+func TestDecodePickupDays_AcceptsGermanLabels(t *testing.T) {
+	pickedUp, err := decodePickupDays(users.PickupStatusPickedUp)
+	require.NoError(t, err)
+	assert.True(t, pickedUp.HasAny())
+
+	alone, err := decodePickupDays(users.PickupStatusGoesAlone)
+	require.NoError(t, err)
+	assert.False(t, alone.HasAny())
+}
+
+func TestDecodePickupDays_RejectsUnknownWeekday(t *testing.T) {
+	_, err := decodePickupDays(map[string]any{"sun": true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sun")
 }
 
 func TestDecodeStructured_DecodesContactList(t *testing.T) {

--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -1585,8 +1585,12 @@ func (s *decisionService) applyTargetedFields(
 				studentDirty = true
 			}
 		case enrollmentModels.TargetStudentPickupStatus:
-			if str := stringValue(raw); str != "" {
-				student.PickupStatus = &str
+			if days, err := decodePickupDays(raw); err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", field.Target, err))
+			} else {
+				status := days.LegacyPickupStatus()
+				student.PickupDays = days
+				student.PickupStatus = &status
 				studentDirty = true
 			}
 		case enrollmentModels.TargetSchedulePickup:
@@ -1689,6 +1693,44 @@ func decodeBusDays(raw any) (users.BusDays, error) {
 		}
 	}
 	return out, nil
+}
+
+// decodePickupDays accepts either a legacy pickup answer (string) or the
+// weekday_boolean map the reserved pickup_status target now uses. Pending
+// submissions created before the migration carry a string; new submissions
+// carry the map.
+func decodePickupDays(raw any) (users.PickupDays, error) {
+	if str, ok := raw.(string); ok {
+		return pickupDaysFromLegacyPickupAnswer(str), nil
+	}
+	var days enrollmentModels.WeekdayBoolean
+	if err := decodeStructured(raw, &days); err != nil {
+		return nil, fmt.Errorf("decode weekday_boolean: %w", err)
+	}
+	if err := days.Validate(); err != nil {
+		return nil, err
+	}
+	out := users.PickupDays{}
+	for _, day := range users.PickupDayOrder {
+		if days[day] {
+			out[day] = true
+		}
+	}
+	return out, nil
+}
+
+// pickupDaysFromLegacyPickupAnswer maps a pending pre-migration submission's
+// pickup_status answer to the per-weekday model. Such submissions stored the
+// frontend select option *value* ("picked_up" / "alone"), not the German
+// label — so map "picked_up" to "all five weekdays" explicitly. A stored
+// German label ("Wird abgeholt") is handled by the model helper for safety.
+// Anything else — "alone", "Geht alleine nach Hause", the empty string — means
+// no pickup days ("Geht alleine nach Hause").
+func pickupDaysFromLegacyPickupAnswer(answer string) users.PickupDays {
+	if strings.TrimSpace(answer) == "picked_up" {
+		return users.PickupDaysFromLegacyStatus(users.PickupStatusPickedUp)
+	}
+	return users.PickupDaysFromLegacyStatus(answer)
 }
 
 // readFieldValue pulls the submission value for a field. Guardian-level

--- a/backend/services/enrollment/form_visibility.go
+++ b/backend/services/enrollment/form_visibility.go
@@ -242,6 +242,14 @@ func customValueSatisfiesRequired(field enrollmentModels.FormField, value any) b
 	case enrollmentModels.FormFieldWeekdaySchedule:
 		return scheduleHasAnyTime(value)
 	case enrollmentModels.FormFieldWeekdayBoolean:
+		// For the pickup target an empty map is the valid "Geht alleine nach
+		// Hause" answer — the parent consciously selected no pickup days — so a
+		// required Abholregelung is satisfied as long as the value is a
+		// well-formed weekday map. Every other weekday_boolean field (e.g.
+		// Buskind) still needs at least one selected day to count as answered.
+		if field.Target == enrollmentModels.TargetStudentPickupStatus {
+			return weekdayBooleanWellFormed(value)
+		}
 		return weekdayBooleanHasAnySelected(value)
 	case enrollmentModels.FormFieldNumber:
 		return numberValueSatisfiesRequired(value)
@@ -259,6 +267,18 @@ func weekdayBooleanHasAnySelected(value any) bool {
 		return false
 	}
 	return days.HasAny()
+}
+
+// weekdayBooleanWellFormed reports whether the value decodes to a valid
+// weekday map, without requiring any day to be selected. Used for the pickup
+// target, where an empty map ("Geht alleine nach Hause") is a legitimate
+// answer — a nil/absent value decodes to an empty map and is accepted too.
+func weekdayBooleanWellFormed(value any) bool {
+	var days enrollmentModels.WeekdayBoolean
+	if err := decodeStructured(value, &days); err != nil {
+		return false
+	}
+	return days.Validate() == nil
 }
 
 func phoneListSatisfiesRequired(value any) bool {

--- a/backend/services/enrollment/form_visibility.go
+++ b/backend/services/enrollment/form_visibility.go
@@ -194,7 +194,7 @@ func (s *requestService) validateRequiredCustomFields(
 		if !fieldVisible(f, guardianCtx) {
 			continue
 		}
-		if !customValueSatisfiesRequired(*f, req.CustomData[f.Key]) {
+		if !customAnswerSatisfiesRequired(*f, req.CustomData) {
 			return fmt.Errorf("%w: field %q is required", ErrInvalidSubmission, f.Key)
 		}
 	}
@@ -216,12 +216,28 @@ func (s *requestService) validateRequiredCustomFields(
 			if !fieldVisible(f, childCtx) {
 				continue
 			}
-			if !customValueSatisfiesRequired(*f, child.CustomData[f.Key]) {
+			if !customAnswerSatisfiesRequired(*f, child.CustomData) {
 				return fmt.Errorf("%w: child %d field %q is required", ErrInvalidSubmission, idx, f.Key)
 			}
 		}
 	}
 	return nil
+}
+
+// customAnswerSatisfiesRequired reports whether a required field is answered,
+// pulling the value out of the answer map so it can distinguish a *missing*
+// key from a present-but-empty value. This matters only for the pickup target:
+// an explicit empty weekday map is the valid "Geht alleine nach Hause" answer,
+// but a field the parent never touched (no key in custom_data) is unanswered
+// and must fail a required check. Every other field type derives "missing"
+// from the value shape alone, so the value lookup is sufficient for them.
+func customAnswerSatisfiesRequired(field enrollmentModels.FormField, answers map[string]any) bool {
+	value, present := answers[field.Key]
+	if field.Type == enrollmentModels.FormFieldWeekdayBoolean &&
+		field.Target == enrollmentModels.TargetStudentPickupStatus && !present {
+		return false
+	}
+	return customValueSatisfiesRequired(field, value)
 }
 
 // customValueSatisfiesRequired reports whether a required field's answer is

--- a/backend/services/enrollment/form_visibility_test.go
+++ b/backend/services/enrollment/form_visibility_test.go
@@ -52,6 +52,22 @@ func TestCustomValueSatisfiesRequired(t *testing.T) {
 	assert.False(t, customValueSatisfiesRequired(sched, map[string]any{"mon": "", "tue": ""}), "all-blank schedule rejected")
 	assert.True(t, customValueSatisfiesRequired(sched, map[string]any{"mon": "08:00"}), "a filled day accepted")
 	assert.False(t, customValueSatisfiesRequired(sched, nil), "nil schedule rejected")
+
+	// weekday_boolean (Buskind): needs at least one selected day.
+	busDays := enrollmentModels.FormField{Type: enrollmentModels.FormFieldWeekdayBoolean, Target: enrollmentModels.TargetStudentBus}
+	assert.False(t, customValueSatisfiesRequired(busDays, nil), "nil bus days rejected")
+	assert.False(t, customValueSatisfiesRequired(busDays, map[string]any{}), "empty bus days rejected")
+	assert.False(t, customValueSatisfiesRequired(busDays, map[string]any{"mon": false}), "all-false bus days rejected")
+	assert.True(t, customValueSatisfiesRequired(busDays, map[string]any{"mon": true}), "a selected bus day accepted")
+
+	// weekday_boolean (Abholregelung): an empty map is the valid "Geht
+	// alleine nach Hause" answer, so a required pickup field is satisfied
+	// even with no day selected. A malformed value is still rejected.
+	pickupDays := enrollmentModels.FormField{Type: enrollmentModels.FormFieldWeekdayBoolean, Target: enrollmentModels.TargetStudentPickupStatus}
+	assert.True(t, customValueSatisfiesRequired(pickupDays, nil), "nil pickup days accepted (goes alone)")
+	assert.True(t, customValueSatisfiesRequired(pickupDays, map[string]any{}), "empty pickup days accepted (goes alone)")
+	assert.True(t, customValueSatisfiesRequired(pickupDays, map[string]any{"mon": true}), "selected pickup day accepted")
+	assert.False(t, customValueSatisfiesRequired(pickupDays, map[string]any{"sat": true}), "invalid weekday rejected")
 }
 
 // ---- fieldVisible --------------------------------------------------------

--- a/backend/services/enrollment/form_visibility_test.go
+++ b/backend/services/enrollment/form_visibility_test.go
@@ -70,6 +70,50 @@ func TestCustomValueSatisfiesRequired(t *testing.T) {
 	assert.False(t, customValueSatisfiesRequired(pickupDays, map[string]any{"sat": true}), "invalid weekday rejected")
 }
 
+// customAnswerSatisfiesRequired adds presence-awareness on top of the value
+// shape check: for a required pickup field an explicit empty map is the valid
+// "Geht alleine nach Hause" answer, but a missing key (parent never touched the
+// picker) must fail. Covers the three distinct states the change hinges on.
+func TestCustomAnswerSatisfiesRequired_PickupPresence(t *testing.T) {
+	pickup := enrollmentModels.FormField{
+		Key:    "pickup",
+		Type:   enrollmentModels.FormFieldWeekdayBoolean,
+		Target: enrollmentModels.TargetStudentPickupStatus,
+	}
+
+	// 1) Missing key — unanswered required pickup is rejected.
+	assert.False(t, customAnswerSatisfiesRequired(pickup, map[string]any{}),
+		"missing pickup answer must fail required")
+	assert.False(t, customAnswerSatisfiesRequired(pickup, map[string]any{"other": true}),
+		"unrelated keys do not satisfy a missing pickup answer")
+
+	// 2) Explicit empty map — the valid "goes home alone" answer is accepted.
+	assert.True(t, customAnswerSatisfiesRequired(pickup, map[string]any{"pickup": map[string]any{}}),
+		"explicit empty pickup map is a valid answer")
+
+	// 3) One or more selected weekdays — accepted.
+	assert.True(t, customAnswerSatisfiesRequired(pickup, map[string]any{"pickup": map[string]any{"mon": true}}),
+		"selected pickup day is a valid answer")
+
+	// A malformed value is still rejected even when present.
+	assert.False(t, customAnswerSatisfiesRequired(pickup, map[string]any{"pickup": map[string]any{"sat": true}}),
+		"invalid weekday rejected")
+
+	// Non-pickup weekday_boolean (Buskind) still requires a selected day even
+	// when present, and a missing key fails as before.
+	bus := enrollmentModels.FormField{
+		Key:    "bus",
+		Type:   enrollmentModels.FormFieldWeekdayBoolean,
+		Target: enrollmentModels.TargetStudentBus,
+	}
+	assert.False(t, customAnswerSatisfiesRequired(bus, map[string]any{}),
+		"missing bus answer fails required")
+	assert.False(t, customAnswerSatisfiesRequired(bus, map[string]any{"bus": map[string]any{}}),
+		"empty bus map fails required (needs a selected day)")
+	assert.True(t, customAnswerSatisfiesRequired(bus, map[string]any{"bus": map[string]any{"mon": true}}),
+		"selected bus day accepted")
+}
+
 // ---- fieldVisible --------------------------------------------------------
 
 func TestFieldVisible_NoCondition(t *testing.T) {

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -511,6 +511,7 @@ export default function StudentDetailPage() {
       supervisor_notes: editedStudent.supervisor_notes,
       extra_info: editedStudent.extra_info,
       pickup_status: editedStudent.pickup_status,
+      pickup_days: editedStudent.pickup_days,
     });
 
     refreshData();

--- a/frontend/src/components/enrollment/enrollment-form-editor.tsx
+++ b/frontend/src/components/enrollment/enrollment-form-editor.tsx
@@ -133,7 +133,7 @@ const targetSuggestionDescriptions: Record<
     "Für wichtige Hinweise, die im Alltag der Betreuung sichtbar sein sollen.",
   "student.bus": "Für die Information, ob ein Kind mit dem Bus fährt.",
   "student.pickup_status":
-    "Für die grundsätzliche Regelung, ob ein Kind abgeholt wird oder alleine geht.",
+    "Für die Wochentage, an denen ein Kind abgeholt wird. Nicht gewählte Tage bedeuten, dass es alleine nach Hause geht.",
   "schedule.pickup": "Für regelmäßige Abholzeiten je Wochentag.",
   "schedule.arrival": "Für regelmäßige Ankunftszeiten je Wochentag.",
   "student.contacts":
@@ -3042,13 +3042,12 @@ function createTargetField(
 }
 
 function getTargetOptions(
-  target: Exclude<FormFieldTarget, "">,
+  _target: Exclude<FormFieldTarget, "">,
 ): FormField["options"] {
-  if (target !== "student.pickup_status") return [];
-  return [
-    { label: "Geht alleine nach Hause", value: "alone" },
-    { label: "Wird abgeholt", value: "picked_up" },
-  ];
+  // No reserved target uses static select options anymore. Abholregelung is
+  // a weekday_boolean (the parent picks the pickup weekdays, just like the
+  // Buskind field); structured types carry no options.
+  return [];
 }
 
 function prepareFieldsForSave(fields: FormField[]): FormField[] {

--- a/frontend/src/components/enrollment/enrollment-form.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.test.tsx
@@ -689,6 +689,35 @@ describe("EnrollmentForm", () => {
     });
   });
 
+  it("shows pickup-specific helper text for the Abholregelung weekday field", async () => {
+    const withPickup = schema();
+    withPickup.fields = [
+      ...withPickup.fields,
+      {
+        key: "pickup_status",
+        label: "Abholregelung",
+        type: "weekday_boolean",
+        target: "student.pickup_status",
+        required: false,
+        applies_to_child: true,
+        sort_order: 7,
+      },
+    ];
+    mockFetchPublicActiveSchema.mockResolvedValueOnce(withPickup);
+    renderForm();
+    await waitForLoaded();
+
+    // The pickup field gets the pickup copy, not the bus copy — guards the
+    // regression where the shared weekday_boolean input hardcoded bus text.
+    expect(
+      screen.getByText(/an denen das Kind abgeholt wird/),
+    ).toBeInTheDocument();
+    // The Buskind field still shows its own bus copy.
+    expect(
+      screen.getByText(/an denen das Kind mit dem Bus fährt/),
+    ).toBeInTheDocument();
+  });
+
   it("requires at least one selected weekday for required weekday boolean fields", async () => {
     const requiredBusDays = schema();
     requiredBusDays.fields = requiredBusDays.fields.map((field) =>

--- a/frontend/src/components/enrollment/enrollment-form.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
 const {
@@ -741,6 +747,55 @@ describe("EnrollmentForm", () => {
     expect(mockSubmitEnrollment).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Mo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
+
+    await waitFor(() => {
+      expect(mockSubmitEnrollment).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("required pickup rejects an untouched picker but accepts an explicit empty selection", async () => {
+    const withRequiredPickup = schema();
+    withRequiredPickup.fields = [
+      ...withRequiredPickup.fields,
+      {
+        key: "pickup_status",
+        label: "Abholregelung",
+        type: "weekday_boolean",
+        target: "student.pickup_status",
+        required: true,
+        applies_to_child: true,
+        sort_order: 7,
+      },
+    ];
+    mockFetchPublicActiveSchema.mockResolvedValueOnce(withRequiredPickup);
+    mockFetchPublicCareOfferings.mockResolvedValueOnce({
+      offerings: [],
+      careOfferingSelectionMode: "optional",
+      careRequired: false,
+    });
+    renderForm();
+    await waitForLoaded();
+    fillRequiredFields();
+
+    // Untouched required pickup is "missing" — submission is blocked and the
+    // pickup-specific confirm message (not the bus "pick a day" message) shows.
+    fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
+    expect(
+      await screen.findAllByText(
+        "Bitte die Abholregelung bestätigen (Tage auswählen oder leer lassen).",
+      ),
+    ).not.toHaveLength(0);
+    expect(mockSubmitEnrollment).not.toHaveBeenCalled();
+
+    // Touch the pickup picker and clear it again → an explicit empty map. That
+    // is the valid "geht alleine nach Hause" answer, so submission proceeds.
+    const pickupGroup = screen.getByRole("group", { name: /Abholregelung/ });
+    const pickupMonday = within(pickupGroup).getByRole("checkbox", {
+      name: "Mo",
+    });
+    fireEvent.click(pickupMonday); // select
+    fireEvent.click(pickupMonday); // deselect → touched, empty
     fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
 
     await waitFor(() => {

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -1829,10 +1829,14 @@ function customValueMissing(
     return !Object.values(schedule).some((time) => time.trim() !== "");
   }
   if (field.type === "weekday_boolean") {
-    // Pickup: an empty selection is the valid "Geht alleine nach Hause"
-    // answer, so a required Abholregelung is never "missing". Other
+    // Pickup: an explicit (touched) selection — even an empty one — is the
+    // valid "Geht alleine nach Hause" answer. Only a never-touched field
+    // (no value object was ever produced) counts as missing, so a required
+    // Abholregelung forces the parent to engage with it once. Other
     // weekday_boolean fields (e.g. Buskind) still need at least one day.
-    if (field.target === "student.pickup_status") return false;
+    if (field.target === "student.pickup_status") {
+      return value === undefined || value === null || typeof value !== "object";
+    }
     const days = asWeekdayBooleanObject(value);
     return !Object.values(days).some(Boolean);
   }
@@ -1882,6 +1886,12 @@ function requiredMessageForField(
     return "Bitte mindestens eine Uhrzeit angeben.";
   }
   if (field.type === "weekday_boolean") {
+    // Pickup accepts an empty selection ("geht alleine nach Hause"), so the
+    // required check only asks the parent to confirm the field — not to pick a
+    // day. Every other weekday_boolean (Buskind) genuinely needs a day.
+    if (field.target === "student.pickup_status") {
+      return "Bitte die Abholregelung bestätigen (Tage auswählen oder leer lassen).";
+    }
     return "Bitte mindestens einen Wochentag auswählen.";
   }
   if (field.type === "select") {

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -1829,6 +1829,10 @@ function customValueMissing(
     return !Object.values(schedule).some((time) => time.trim() !== "");
   }
   if (field.type === "weekday_boolean") {
+    // Pickup: an empty selection is the valid "Geht alleine nach Hause"
+    // answer, so a required Abholregelung is never "missing". Other
+    // weekday_boolean fields (e.g. Buskind) still need at least one day.
+    if (field.target === "student.pickup_status") return false;
     const days = asWeekdayBooleanObject(value);
     return !Object.values(days).some(Boolean);
   }
@@ -2281,7 +2285,9 @@ function WeekdayBooleanInput({
         </p>
       )}
       <p className="text-xs text-gray-500">
-        Wähle die Tage aus, an denen das Kind mit dem Bus fährt.
+        {field.target === "student.pickup_status"
+          ? "Wähle die Tage aus, an denen das Kind abgeholt wird. An nicht gewählten Tagen geht es alleine nach Hause."
+          : "Wähle die Tage aus, an denen das Kind mit dem Bus fährt."}
       </p>
       <div className="mt-2 grid gap-2 sm:grid-cols-5">
         {WEEKDAYS.map((w) => {

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -694,7 +694,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Das Anmeldeformular bestimmt, welche Angaben Eltern machen. Das `Basisformular` ist immer vorhanden; eigene Vorlagen ergänzen nur zusätzliche Fragen.",
         steps: [
           "`Anmeldeformulare` öffnen. Das `Basisformular` fragt Elternteil, Kind, Klassenstufe und das gewünschte Betreuungsangebot ab.",
-          "Nur bei zusätzlichem Bedarf über `Neue Vorlage` eine eigene Formularvorlage mit Zusatzfragen anlegen. Bei `Buskind` wählen Eltern die passenden Wochentage aus.",
+          "Nur bei zusätzlichem Bedarf über `Neue Vorlage` eine eigene Formularvorlage mit Zusatzfragen anlegen. Bei `Buskind` und `Abholregelung` wählen Eltern die passenden Wochentage aus.",
           "Mit `Vorschau` prüfen, wie das Formular für Eltern aussieht.",
           "Die Vorlage wirkt erst, wenn du sie in einer `Anmeldephase` als Formular auswählst.",
         ],

--- a/frontend/src/components/students/personal-info-form-modal.test.tsx
+++ b/frontend/src/components/students/personal-info-form-modal.test.tsx
@@ -334,18 +334,25 @@ describe("PersonalInfoFormModal", () => {
       expect(select.value).toBe("true");
     });
 
-    it("displays pickup status select with correct value", () => {
+    it("displays the selected pickup weekdays", () => {
       render(
         <PersonalInfoFormModal
           isOpen={true}
           onClose={mockOnClose}
-          student={createMockStudent({ pickup_status: "Wird abgeholt" })}
+          student={createMockStudent({
+            pickup_status: "Wird abgeholt",
+            pickup_days: { mon: true, wed: true },
+          })}
           onSave={mockOnSave}
         />,
       );
 
-      const select = screen.getByLabelText<HTMLSelectElement>("Abholstatus");
-      expect(select.value).toBe("Wird abgeholt");
+      expect(
+        screen.getByRole("checkbox", { name: "Montag wird abgeholt" }),
+      ).toBeChecked();
+      expect(
+        screen.getByRole("checkbox", { name: "Mittwoch wird abgeholt" }),
+      ).toBeChecked();
     });
 
     it("changes buskind when selected", () => {

--- a/frontend/src/components/students/personal-info-form-modal.tsx
+++ b/frontend/src/components/students/personal-info-form-modal.tsx
@@ -5,6 +5,8 @@ import { FormModal } from "~/components/ui/form-modal";
 import { useToast } from "~/contexts/ToastContext";
 import type { ExtendedStudent } from "~/lib/hooks/use-student-data";
 import { ChevronDownIcon } from "./student-detail-components";
+import { PickupStatusSection } from "./student-form-fields";
+import { normalizePickupDays, pickupDaysHaveAny } from "~/lib/student-helpers";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "PersonalInfoFormModal" });
@@ -123,19 +125,18 @@ export function PersonalInfoFormModal({
             { value: "true", label: "Ja" },
           ]}
         />
-        <SelectInput
-          id="modal-student-pickup-status"
-          label="Abholstatus"
-          value={editedStudent.pickup_status ?? ""}
-          onChange={(value) => updateField("pickup_status", value || undefined)}
-          options={[
-            { value: "", label: "Nicht gesetzt" },
-            {
-              value: "Geht alleine nach Hause",
-              label: "Geht alleine nach Hause",
-            },
-            { value: "Wird abgeholt", label: "Wird abgeholt" },
-          ]}
+        <PickupStatusSection
+          days={editedStudent.pickup_days}
+          onChange={(value) => {
+            const normalized = normalizePickupDays(value);
+            setEditedStudent((prev) => ({
+              ...prev,
+              pickup_days: normalized,
+              pickup_status: pickupDaysHaveAny(normalized)
+                ? "Wird abgeholt"
+                : "Geht alleine nach Hause",
+            }));
+          }}
         />
         <TextAreaInput
           id="modal-student-health-info"

--- a/frontend/src/components/students/student-create-modal.test.tsx
+++ b/frontend/src/components/students/student-create-modal.test.tsx
@@ -728,6 +728,32 @@ describe("StudentCreateModal", () => {
     expect(submitted).not.toHaveProperty("guardians");
   });
 
+  it("submits an explicit empty pickup_days map (goes-home-alone) for an untouched create", async () => {
+    render(
+      <StudentCreateModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onCreate={mockOnCreate}
+      />,
+    );
+
+    const form = screen.getByTestId("modal").querySelector("form");
+    await act(async () => {
+      fireEvent.submit(form!);
+    });
+
+    await waitFor(() => {
+      expect(handleStudentFormSubmit).toHaveBeenCalled();
+    });
+    const submitted = vi.mocked(handleStudentFormSubmit).mock
+      .calls[0]?.[1] as Record<string, unknown>;
+    // The new UI semantics say "no selected days = goes home alone", and that
+    // must be sent as an explicit empty map (not omitted) so the stored
+    // pickup_days/pickup_status pair is correct without anyone editing later.
+    expect(submitted.pickup_days).toEqual({});
+    expect(submitted.pickup_status).toBe("Geht alleine nach Hause");
+  });
+
   it("opens the reused weekly care-plan editor when the add button is clicked", async () => {
     render(
       <StudentCreateModal

--- a/frontend/src/components/students/student-create-modal.tsx
+++ b/frontend/src/components/students/student-create-modal.tsx
@@ -19,6 +19,8 @@ import {
   busDaysHaveAny,
   normalizeBusDays,
   type BusDays,
+  pickupDaysHaveAny,
+  normalizePickupDays,
 } from "~/lib/student-helpers";
 import GuardianFormModal, {
   type RelationshipFormData,
@@ -531,8 +533,17 @@ export function StudentCreateModal({
 
           {/* Pickup Status */}
           <PickupStatusSection
-            value={formData.pickup_status}
-            onChange={(v) => handleChange("pickup_status", v)}
+            days={formData.pickup_days}
+            onChange={(value) => {
+              const normalized = normalizePickupDays(value);
+              setFormData((prev) => ({
+                ...prev,
+                pickup_days: normalized,
+                pickup_status: pickupDaysHaveAny(normalized)
+                  ? "Wird abgeholt"
+                  : "Geht alleine nach Hause",
+              }));
+            }}
           />
 
           {/* Action Buttons */}

--- a/frontend/src/components/students/student-create-modal.tsx
+++ b/frontend/src/components/students/student-create-modal.tsx
@@ -162,7 +162,12 @@ export function StudentCreateModal({
     privacy_consent_accepted: false,
     data_retention_days: 30,
     bus: false,
-    pickup_status: "",
+    // Explicit empty pickup map = "Geht alleine nach Hause". Sending it (not
+    // omitting it) keeps the create contract identical to the edit flow and
+    // makes the stored pickup_days/pickup_status pair correct even when the
+    // pickup section is never touched.
+    pickup_days: {},
+    pickup_status: "Geht alleine nach Hause",
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [saveLoading, setSaveLoading] = useState(false);
@@ -205,7 +210,8 @@ export function StudentCreateModal({
         privacy_consent_accepted: false,
         data_retention_days: 30,
         bus: false,
-        pickup_status: "",
+        pickup_days: {},
+        pickup_status: "Geht alleine nach Hause",
       });
       setErrors({});
       setGuardians([]);

--- a/frontend/src/components/students/student-detail-components.test.tsx
+++ b/frontend/src/components/students/student-detail-components.test.tsx
@@ -646,9 +646,19 @@ describe("PersonalInfoReadOnly", () => {
     expect(screen.getByText("Nein")).toBeInTheDocument();
   });
 
-  it("renders pickup status", () => {
-    render(<PersonalInfoReadOnly student={mockStudent} />);
-    expect(screen.getByText("selbst")).toBeInTheDocument();
+  it("renders the pickup weekdays when the child is picked up", () => {
+    const pickedUp = {
+      ...mockStudent,
+      pickup_days: { mon: true, wed: true },
+    };
+    render(<PersonalInfoReadOnly student={pickedUp} />);
+    expect(screen.getByText("Wird abgeholt: Mo, Mi")).toBeInTheDocument();
+  });
+
+  it("renders 'Geht alleine nach Hause' when no pickup days are set", () => {
+    const goesAlone = { ...mockStudent, pickup_days: {} };
+    render(<PersonalInfoReadOnly student={goesAlone} />);
+    expect(screen.getByText("Geht alleine nach Hause")).toBeInTheDocument();
   });
 
   it("renders health info when present", () => {

--- a/frontend/src/components/students/student-detail-components.tsx
+++ b/frontend/src/components/students/student-detail-components.tsx
@@ -14,6 +14,7 @@ import {
   getStudentPresenceBadgePlanning,
 } from "~/lib/day-planning-helper";
 import type { SupervisorContact } from "~/lib/student-helpers";
+import { formatPickupDays, pickupDaysHaveAny } from "~/lib/student-helpers";
 import { InfoCard, InfoItem } from "~/components/ui/info-card";
 import { Avatar } from "~/components/ui/avatar";
 import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled";
@@ -694,8 +695,12 @@ export function PersonalInfoReadOnly({
         <InfoItem label="Geburtsdatum" value={birthdayDisplay} />
         <InfoItem label="Buskind" value={student.buskind ? "Ja" : "Nein"} />
         <InfoItem
-          label="Abholstatus"
-          value={student.pickup_status ?? "Nicht gesetzt"}
+          label="Abholregelung"
+          value={
+            pickupDaysHaveAny(student.pickup_days)
+              ? `Wird abgeholt: ${formatPickupDays(student.pickup_days)}`
+              : "Geht alleine nach Hause"
+          }
         />
         {student.health_info && (
           <InfoItem

--- a/frontend/src/components/students/student-edit-modal.tsx
+++ b/frontend/src/components/students/student-edit-modal.tsx
@@ -17,6 +17,8 @@ import {
   busDaysHaveAny,
   normalizeBusDays,
   type BusDays,
+  pickupDaysHaveAny,
+  normalizePickupDays,
 } from "~/lib/student-helpers";
 
 interface StudentEditModalProps {
@@ -58,6 +60,7 @@ export function StudentEditModal({
         data_retention_days: student.data_retention_days ?? 30,
         bus: student.bus ?? false,
         bus_days: normalizeBusDays(student.bus_days),
+        pickup_days: normalizePickupDays(student.pickup_days),
         pickup_status: student.pickup_status ?? "",
       });
       setErrors({});
@@ -198,8 +201,17 @@ export function StudentEditModal({
 
           {/* Pickup Status */}
           <PickupStatusSection
-            value={formData.pickup_status}
-            onChange={(v) => handleChange("pickup_status", v)}
+            days={formData.pickup_days}
+            onChange={(value) => {
+              const normalized = normalizePickupDays(value);
+              setFormData((prev) => ({
+                ...prev,
+                pickup_days: normalized,
+                pickup_status: pickupDaysHaveAny(normalized)
+                  ? "Wird abgeholt"
+                  : "Geht alleine nach Hause",
+              }));
+            }}
           />
 
           {/* Bus Status */}

--- a/frontend/src/components/students/student-form-fields.test.tsx
+++ b/frontend/src/components/students/student-form-fields.test.tsx
@@ -295,30 +295,44 @@ describe("EnrollmentConsentsSection", () => {
 });
 
 describe("PickupStatusSection", () => {
-  it("renders pickup status select", () => {
+  it("renders selected pickup weekdays", () => {
     const onChange = vi.fn();
-    render(<PickupStatusSection value="Wird abgeholt" onChange={onChange} />);
+    render(
+      <PickupStatusSection
+        days={{ mon: true, wed: true }}
+        onChange={onChange}
+      />,
+    );
 
-    expect(screen.getByDisplayValue("Wird abgeholt")).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "Montag wird abgeholt" }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Mittwoch wird abgeholt" }),
+    ).toBeChecked();
   });
 
-  it("calls onChange when selection changes", () => {
+  it("calls onChange with weekday map when toggled", () => {
     const onChange = vi.fn();
-    render(<PickupStatusSection value="" onChange={onChange} />);
+    render(<PickupStatusSection days={{}} onChange={onChange} />);
 
-    const select = screen.getByRole("combobox");
-    fireEvent.change(select, { target: { value: "Geht alleine nach Hause" } });
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Montag wird abgeholt",
+    });
+    fireEvent.click(checkbox);
 
-    expect(onChange).toHaveBeenCalledWith("Geht alleine nach Hause");
+    expect(onChange).toHaveBeenCalledWith({ mon: true });
   });
 
-  it("handles null value for empty selection", () => {
+  it("unchecking a selected day removes it from the map", () => {
     const onChange = vi.fn();
-    render(<PickupStatusSection value="Wird abgeholt" onChange={onChange} />);
+    render(<PickupStatusSection days={{ mon: true }} onChange={onChange} />);
 
-    const select = screen.getByRole("combobox");
-    fireEvent.change(select, { target: { value: "" } });
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Montag wird abgeholt",
+    });
+    fireEvent.click(checkbox);
 
-    expect(onChange).toHaveBeenCalledWith(null);
+    expect(onChange).toHaveBeenCalledWith({ mon: false });
   });
 });

--- a/frontend/src/components/students/student-form-fields.tsx
+++ b/frontend/src/components/students/student-form-fields.tsx
@@ -13,6 +13,11 @@ import {
   formatBusDays,
   normalizeBusDays,
   type BusDays,
+  PICKUP_WEEKDAYS,
+  pickupDaysHaveAny,
+  formatPickupDays,
+  normalizePickupDays,
+  type PickupDays,
 } from "~/lib/student-helpers";
 
 interface SelectOption {
@@ -604,45 +609,20 @@ export function EnrollmentConsentsSection({
 }
 
 export function PickupStatusSection({
-  value,
+  days,
   onChange,
 }: Readonly<{
-  value: string | undefined | null;
-  onChange: (value: string | null) => void;
+  days?: PickupDays | null;
+  onChange: (value: PickupDays) => void;
 }>) {
+  const normalized = normalizePickupDays(days);
+  const anySelected = pickupDaysHaveAny(normalized);
   return (
     <div className="rounded-xl border border-gray-100 bg-blue-50/30 p-3 md:p-4">
-      <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold text-gray-900 md:mb-4 md:text-sm">
-        <svg
-          className="h-3.5 w-3.5 text-green-600 md:h-4 md:w-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-          />
-        </svg>
-        Abholstatus
-      </h3>
-      <div className="relative">
-        <select
-          value={value ?? ""}
-          onChange={(e) => onChange(e.target.value || null)}
-          className="moto-content-surface block w-full appearance-none rounded-lg border px-3 py-2 pr-10 text-sm transition-colors focus:border-[#5080D8] focus:ring-1 focus:ring-[#5080D8]"
-        >
-          <option value="">Nicht gesetzt</option>
-          <option value="Geht alleine nach Hause">
-            Geht alleine nach Hause
-          </option>
-          <option value="Wird abgeholt">Wird abgeholt</option>
-        </select>
-        <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-500">
+      <div className="mb-3 flex items-start justify-between gap-3 md:mb-4">
+        <h3 className="flex min-w-0 items-center gap-2 text-xs font-semibold text-gray-900 md:text-sm">
           <svg
-            className="h-4 w-4"
+            className="h-3.5 w-3.5 shrink-0 text-[#83CD2D] md:h-4 md:w-4"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -651,11 +631,53 @@ export function PickupStatusSection({
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth={2}
-              d="M19 9l-7 7-7-7"
+              d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
             />
           </svg>
-        </div>
+          Abholregelung
+        </h3>
+        {anySelected && (
+          <span className="shrink-0 rounded-full bg-[#DCF5C1] px-2.5 py-1 text-xs font-medium text-[#4a7a15]">
+            {formatPickupDays(normalized)}
+          </span>
+        )}
       </div>
+      <p className="mb-3 text-xs text-gray-500">
+        {anySelected
+          ? "Tage auswählen, an denen das Kind abgeholt wird."
+          : "Keine Abhol-Tage ausgewählt. Das Kind geht alleine nach Hause."}
+      </p>
+      <div className="grid grid-cols-5 gap-2">
+        {PICKUP_WEEKDAYS.map((day) => {
+          const checked = Boolean(normalized[day.key]);
+          return (
+            <label
+              key={day.key}
+              className={`flex h-9 cursor-pointer items-center justify-center rounded-lg border px-2 text-xs font-semibold transition-colors ${
+                checked
+                  ? "border-[#83CD2D] bg-[#DCF5C1] text-[#4a7a15]"
+                  : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50"
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={(event) =>
+                  onChange({ ...normalized, [day.key]: event.target.checked })
+                }
+                className="sr-only"
+                aria-label={`${day.label} wird abgeholt`}
+              />
+              {day.label.slice(0, 2)}
+            </label>
+          );
+        })}
+      </div>
+      <p className="mt-2 text-xs text-gray-500">
+        {anySelected
+          ? "An nicht ausgewählten Tagen geht das Kind alleine nach Hause."
+          : "Ohne ausgewählten Tag geht das Kind an allen Tagen alleine nach Hause."}
+      </p>
     </div>
   );
 }

--- a/frontend/src/components/students/student-stammdaten-tab.tsx
+++ b/frontend/src/components/students/student-stammdaten-tab.tsx
@@ -23,6 +23,9 @@ import {
   busDaysHaveAny,
   normalizeBusDays,
   type BusDays,
+  pickupDaysHaveAny,
+  normalizePickupDays,
+  type PickupDays,
 } from "~/lib/student-helpers";
 import type { Student } from "~/lib/api";
 
@@ -63,6 +66,21 @@ function busDaysEqual(a?: BusDays | null, b?: BusDays | null): boolean {
   );
 }
 
+function pickupDaysEqual(
+  a?: PickupDays | null,
+  b?: PickupDays | null,
+): boolean {
+  const left = normalizePickupDays(a);
+  const right = normalizePickupDays(b);
+  return (
+    Boolean(left.mon) === Boolean(right.mon) &&
+    Boolean(left.tue) === Boolean(right.tue) &&
+    Boolean(left.wed) === Boolean(right.wed) &&
+    Boolean(left.thu) === Boolean(right.thu) &&
+    Boolean(left.fri) === Boolean(right.fri)
+  );
+}
+
 function buildDraft(
   student: Student,
   photosEnabled: boolean,
@@ -83,6 +101,7 @@ function buildDraft(
       consent?.dataRetentionDays ?? student.data_retention_days ?? 30,
     bus: student.bus ?? false,
     bus_days: normalizeBusDays(student.bus_days),
+    pickup_days: normalizePickupDays(student.pickup_days),
     pickup_status: student.pickup_status ?? "",
   };
   // Only mirror consent state into the form when the photo feature is
@@ -263,6 +282,12 @@ export function StudentStammdatenTab({
     return keys.some((key) => {
       if (key === "bus_days") {
         return !busDaysEqual(originalDraft.bus_days, formData.bus_days);
+      }
+      if (key === "pickup_days") {
+        return !pickupDaysEqual(
+          originalDraft.pickup_days,
+          formData.pickup_days,
+        );
       }
       return originalDraft[key] !== formData[key];
     });
@@ -477,8 +502,17 @@ export function StudentStammdatenTab({
       />
 
       <PickupStatusSection
-        value={formData.pickup_status}
-        onChange={(value) => handleChange("pickup_status", value)}
+        days={formData.pickup_days}
+        onChange={(value) => {
+          const normalized = normalizePickupDays(value);
+          setFormData((prev) => ({
+            ...prev,
+            pickup_days: normalized,
+            pickup_status: pickupDaysHaveAny(normalized)
+              ? "Wird abgeholt"
+              : "Geht alleine nach Hause",
+          }));
+        }}
       />
 
       <BusStatusSection

--- a/frontend/src/lib/enrollment-form-schema-api.test.ts
+++ b/frontend/src/lib/enrollment-form-schema-api.test.ts
@@ -61,7 +61,9 @@ describe("RESERVED_TARGETS", () => {
   it("declares the right field type per target", () => {
     expect(RESERVED_TARGETS["student.health_info"].type).toBe("textarea");
     expect(RESERVED_TARGETS["student.bus"].type).toBe("weekday_boolean");
-    expect(RESERVED_TARGETS["student.pickup_status"].type).toBe("select");
+    expect(RESERVED_TARGETS["student.pickup_status"].type).toBe(
+      "weekday_boolean",
+    );
     expect(RESERVED_TARGETS["schedule.pickup"].type).toBe("weekday_schedule");
     expect(RESERVED_TARGETS["student.contacts"].type).toBe("contact_list");
   });

--- a/frontend/src/lib/enrollment-form-schema-api.ts
+++ b/frontend/src/lib/enrollment-form-schema-api.ts
@@ -96,7 +96,7 @@ export const RESERVED_TARGETS: Record<
     label: "Buskind",
   },
   "student.pickup_status": {
-    type: "select",
+    type: "weekday_boolean",
     appliesToChild: true,
     label: "Abholregelung",
   },

--- a/frontend/src/lib/student-helpers.test.ts
+++ b/frontend/src/lib/student-helpers.test.ts
@@ -10,6 +10,9 @@ import {
   formatBusDays,
   getSchoolYear,
   normalizeBusDays,
+  pickupDaysHaveAny,
+  formatPickupDays,
+  normalizePickupDays,
   SCHOOL_YEAR_FILTER_OPTIONS,
   mapStudentResponse,
   mapStudentsResponse,
@@ -101,6 +104,39 @@ describe("bus day helpers", () => {
     );
     expect(formatBusDays({ tue: false })).toBe("Keine Bus-Tage");
     expect(formatBusDays(null)).toBe("Keine Bus-Tage");
+  });
+});
+
+describe("pickup day helpers", () => {
+  it("normalizes only enabled known weekdays", () => {
+    const result = normalizePickupDays({
+      mon: true,
+      tue: false,
+      wed: true,
+      sat: true,
+    } as Parameters<typeof normalizePickupDays>[0] & { sat: boolean });
+
+    expect(result).toEqual({ mon: true, wed: true });
+  });
+
+  it("normalizes null and undefined to an empty object", () => {
+    expect(normalizePickupDays(null)).toEqual({});
+    expect(normalizePickupDays(undefined)).toEqual({});
+  });
+
+  it("detects any enabled known weekday", () => {
+    expect(pickupDaysHaveAny({ fri: true })).toBe(true);
+    expect(pickupDaysHaveAny({ mon: false, thu: false })).toBe(false);
+    expect(pickupDaysHaveAny(null)).toBe(false);
+    expect(pickupDaysHaveAny(undefined)).toBe(false);
+  });
+
+  it("formats selected weekdays or the empty label", () => {
+    expect(formatPickupDays({ mon: true, wed: true, fri: true })).toBe(
+      "Mo, Mi, Fr",
+    );
+    expect(formatPickupDays({ tue: false })).toBe("Keine Abhol-Tage");
+    expect(formatPickupDays(null)).toBe("Keine Abhol-Tage");
   });
 });
 
@@ -409,6 +445,21 @@ describe("prepareStudentForBackend", () => {
     });
 
     expect(result.id).toBeUndefined();
+  });
+
+  it("normalizes pickup_days when present", () => {
+    const result = prepareStudentForBackend({
+      id: "1",
+      pickup_days: { mon: true, tue: false, wed: true },
+    });
+
+    expect(result.pickup_days).toEqual({ mon: true, wed: true });
+  });
+
+  it("omits pickup_days when undefined so partial updates do not wipe the map", () => {
+    const result = prepareStudentForBackend({ id: "1" });
+
+    expect(result.pickup_days).toBeUndefined();
   });
 });
 

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -53,6 +53,42 @@ export function formatBusDays(value?: BusDays | null): string {
   return labels.length > 0 ? labels.join(", ") : "Keine Bus-Tage";
 }
 
+// Pickup days mirror bus days: per-weekday "wird abgeholt" flags. A day not
+// selected means the child goes home alone that day. Reuses the same weekday
+// keys as BusDays.
+export type PickupDayKey = BusDayKey;
+export type PickupDays = Partial<Record<PickupDayKey, boolean>>;
+
+export const PICKUP_WEEKDAYS: ReadonlyArray<{
+  key: PickupDayKey;
+  label: string;
+}> = [
+  { key: "mon", label: "Montag" },
+  { key: "tue", label: "Dienstag" },
+  { key: "wed", label: "Mittwoch" },
+  { key: "thu", label: "Donnerstag" },
+  { key: "fri", label: "Freitag" },
+] as const;
+
+export function normalizePickupDays(value?: PickupDays | null): PickupDays {
+  const out: PickupDays = {};
+  for (const day of PICKUP_WEEKDAYS) {
+    if (value?.[day.key]) out[day.key] = true;
+  }
+  return out;
+}
+
+export function pickupDaysHaveAny(value?: PickupDays | null): boolean {
+  return PICKUP_WEEKDAYS.some((day) => Boolean(value?.[day.key]));
+}
+
+export function formatPickupDays(value?: PickupDays | null): string {
+  const labels = PICKUP_WEEKDAYS.filter((day) => Boolean(value?.[day.key])).map(
+    (day) => day.label.slice(0, 2),
+  );
+  return labels.length > 0 ? labels.join(", ") : "Keine Abhol-Tage";
+}
+
 /**
  * Extract the school year (Klassenstufe) from a school_class string.
  * E.g. "Klasse 3a" → "3", "2b" → "2", "unknown" → null
@@ -84,6 +120,7 @@ export interface BackendStudent {
   current_room_color?: string | null;
   bus?: boolean;
   bus_days?: BusDays;
+  pickup_days?: PickupDays;
   sick?: boolean;
   sick_since?: string;
   excused?: boolean;
@@ -203,6 +240,7 @@ export interface Student {
   takes_bus?: boolean;
   bus?: boolean; // Administrative permission flag (Buskind), not attendance status
   bus_days?: BusDays;
+  pickup_days?: PickupDays;
   // Sickness status (only visible to supervisors/admins)
   sick?: boolean;
   sick_since?: string;
@@ -286,6 +324,7 @@ export function mapStudentResponse(
     takes_bus: undefined,
     bus: backendStudent.bus ?? false, // Administrative permission flag (Buskind)
     bus_days: normalizeBusDays(backendStudent.bus_days),
+    pickup_days: normalizePickupDays(backendStudent.pickup_days),
     sick: backendStudent.sick ?? false, // Sickness status
     sick_since: backendStudent.sick_since,
     excused: backendStudent.excused ?? false, // Excused from attending today
@@ -391,6 +430,10 @@ export function prepareStudentForBackend(
       student.bus_days !== undefined
         ? normalizeBusDays(student.bus_days)
         : undefined,
+    pickup_days:
+      student.pickup_days !== undefined
+        ? normalizePickupDays(student.pickup_days)
+        : undefined,
     // REMOVED: guardian_name and guardian_contact - deprecated fields
     // Use guardian_profiles system instead
     group_id: student.group_id
@@ -436,6 +479,7 @@ export interface UpdateStudentRequest {
   pickup_status?: string;
   bus?: boolean;
   bus_days?: BusDays;
+  pickup_days?: PickupDays;
   sick?: boolean;
   /** Optional free-text reason stamped on today's sick day when marking sick. */
   sick_reason?: string;
@@ -466,6 +510,7 @@ export interface BackendUpdateRequest {
   pickup_status?: string;
   bus?: boolean;
   bus_days?: BusDays;
+  pickup_days?: PickupDays;
   sick?: boolean;
   sick_reason?: string;
   excused?: boolean;
@@ -519,6 +564,7 @@ const DIRECT_FIELD_MAPPINGS: FieldMapping[] = [
   { source: "pickup_status", target: "pickup_status" },
   { source: "bus", target: "bus" },
   { source: "bus_days", target: "bus_days" },
+  { source: "pickup_days", target: "pickup_days" },
   { source: "sick", target: "sick" },
   { source: "sick_reason", target: "sick_reason" },
   { source: "excused", target: "excused" },

--- a/frontend/src/lib/student-request-helpers.ts
+++ b/frontend/src/lib/student-request-helpers.ts
@@ -3,7 +3,7 @@
  * Extracted to reduce cognitive complexity in route handlers
  */
 
-import type { BusDays, Student } from "~/lib/student-helpers";
+import type { BusDays, PickupDays, Student } from "~/lib/student-helpers";
 import type { StudentGuardianPayload } from "~/lib/guardian-helpers";
 import type { ArrivalScheduleFormEntry } from "~/lib/arrival-schedule-helpers";
 import type { BackendPickupScheduleRequest } from "~/lib/pickup-schedule-helpers";
@@ -31,6 +31,7 @@ interface BackendStudentRequest {
   group_id?: number;
   bus?: boolean;
   bus_days?: BusDays;
+  pickup_days?: PickupDays;
   extra_info?: string;
   birthday?: string;
   health_info?: string;
@@ -170,6 +171,7 @@ export function buildBackendStudentRequest(
     group_id: backendData.group_id,
     bus: backendData.bus,
     bus_days: backendData.bus_days,
+    pickup_days: backendData.pickup_days,
     extra_info: backendData.extra_info,
     birthday: backendData.birthday,
     health_info: backendData.health_info,


### PR DESCRIPTION
## Was

Bisher hatte ein Kind eine einzige `Abholregelung` als Auswahl (`Geht alleine nach Hause` / `Wird abgeholt`). Diese PR ersetzt den globalen Status durch eine **Wochentag-genaue Abholregelung** (`PickupDays`, Mo bis Fr), analog zum bestehenden `Buskind`-Feature. Nicht gewählte Tage bedeuten, dass das Kind an diesem Tag alleine nach Hause geht.

Der alte `pickup_status`-String bleibt erhalten und wird automatisch abgeleitet (mindestens ein Tag gewählt, dann `Wird abgeholt`, sonst `Geht alleine nach Hause`), damit bestehende Consumer nicht brechen.

## Warum

Schulen brauchen pro Wochentag unterschiedliche Abholregelungen (Kind wird Mo/Mi abgeholt, geht Di/Do/Fr alleine). Der bisherige Einzelstatus konnte das nicht abbilden.

## Änderungen

**Backend**
- Neues Model `users.PickupDays` (`map[string]bool`, mon..fri) mit `Validate`/`HasAny`/`Normalize` und Legacy-Konvertierung in beide Richtungen.
- Migration `1.15.116`: Spalte `users.students.pickup_days` (JSONB), Backfill aus `pickup_status` (`Wird abgeholt` wird zu allen fünf Tagen), plus `CHECK`-Constraint via `users.is_valid_pickup_days`.
- Migration `1.15.117`: konvertiert vorhandene Anmeldeformular-Felder mit Target `student.pickup_status` von `select` zu `weekday_boolean` (sonst würde `FormField.Validate()` nach der Reserved-Target-Änderung fehlschlagen). Down ist bewusst ein No-op.
- Reserved Target `student.pickup_status` ist jetzt `weekday_boolean` statt `select`.
- `reconcilePickupFields` hält Map und Legacy-String synchron; der Decode-Pfad der Anmeldung akzeptiert sowohl die neue Map als auch alte Select-Werte aus noch offenen Submissions.
- Repository persistiert und hydratisiert `pickup_days` (Muster von `bus_days` übernommen).

**Frontend**
- `PickupStatusSection` ist jetzt ein 5-Tage-Toggle-Grid statt eines Selects, in Anlegen-, Bearbeiten-, Stammdaten- und Personal-Info-Modal.
- Anmeldeformular rendert `Abholregelung` als `weekday_boolean` mit pickup-spezifischem Hilfetext. Leere Auswahl ist eine gültige Antwort (`Geht alleine nach Hause`), eine erforderliche Abholregelung gilt damit immer als beantwortet.
- Helper (`normalizePickupDays`, `pickupDaysHaveAny`, `formatPickupDays`) und Read-only-Anzeige.
- Hilfe-Guide (`guide-data.ts`) aktualisiert.

## Verhalten / Hinweise

- `pickup_status` allein (ohne `pickup_days`) in einem Partial-Update setzt die Wochentag-Map zurück. Das ist dokumentiert und gewollt (der Legacy-String trägt keine Tagesinfo). Neue Clients senden immer beide Felder.

## Tests

- Backend: Model-, Repository-Roundtrip-, Decode- und Form-Visibility-Tests.
- Frontend: Helper-, Komponenten- und Anmeldeformular-Tests.
- `go build ./...`, `tsc --noEmit`, `knip` und alle betroffenen Test-Suites grün.

## Migration

`docker compose run server ./main migrate` führt `1.15.116` und `1.15.117` aus. Backfill ist idempotent (nur leere `pickup_days` werden gesetzt).

## Offene Punkte (nicht blockierend)

- `hydrateBusDaysForStudents` macht jetzt eine zusätzliche `information_schema`-Abfrage pro Aufruf. Kandidat fürs Cachen am Repository.
- Drei Test-Mocks von `PickupStatusSection` nutzen noch den alten `value`-Vertrag (Tests grün, aber inhaltlich veraltet).
