### PR TITLE
fix(enrollment): render weekday_boolean values on admin detail

### DIFF
--- a/frontend/src/components/enrollment/admin-enrollment-detail.test.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-detail.test.tsx
@@ -45,6 +45,61 @@ describe("formatCustomValue", () => {
     expect(formatCustomValue(value, field("weekday_boolean"))).toBeNull();
   });
 
+  // The reserved student.pickup_status target treats an empty map as a real
+  // answer ("Geht alleine nach Hause"), not a missing field. The admin must be
+  // able to tell "goes alone every day" apart from an absent field, so the row
+  // is rendered with an explicit label instead of being dropped.
+  it("renders 'Geht alleine nach Hause' for an all-false pickup_status", () => {
+    const value = {
+      mon: false,
+      tue: false,
+      wed: false,
+      thu: false,
+      fri: false,
+    };
+    expect(
+      formatCustomValue(
+        value,
+        field("weekday_boolean", { target: "student.pickup_status" }),
+      ),
+    ).toBe("Geht alleine nach Hause");
+  });
+
+  it("renders 'Geht alleine nach Hause' for an explicit empty pickup_status map", () => {
+    expect(
+      formatCustomValue(
+        {},
+        field("weekday_boolean", { target: "student.pickup_status" }),
+      ),
+    ).toBe("Geht alleine nach Hause");
+  });
+
+  it("still renders selected days for pickup_status when days are chosen", () => {
+    const value = { mon: true, fri: true };
+    expect(
+      formatCustomValue(
+        value,
+        field("weekday_boolean", { target: "student.pickup_status" }),
+      ),
+    ).toBe("Mo, Fr");
+  });
+
+  // Buskind is also weekday_boolean but has no special empty-map meaning: no
+  // bus days means the child simply is not a bus kid, so the row drops out.
+  it("returns null for an all-false non-pickup weekday_boolean (Buskind)", () => {
+    const value = { mon: false, tue: false };
+    expect(
+      formatCustomValue(
+        value,
+        field("weekday_boolean", {
+          key: "student.bus",
+          target: "student.bus",
+          label: "Buskind",
+        }),
+      ),
+    ).toBeNull();
+  });
+
   it("still renders weekday_schedule time values per day", () => {
     const value = { mon: "07:30", wed: "08:00" };
     const { container } = render(

--- a/frontend/src/components/enrollment/admin-enrollment-detail.test.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-detail.test.tsx
@@ -1,0 +1,60 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { type AdminRequestSchemaField } from "~/lib/enrollment-admin-api";
+import { formatCustomValue } from "./admin-enrollment-detail";
+
+function field(
+  type: string,
+  overrides: Partial<AdminRequestSchemaField> = {},
+): AdminRequestSchemaField {
+  return {
+    key: "student.pickup_status",
+    label: "Abholregelung",
+    type,
+    applies_to_child: true,
+    ...overrides,
+  };
+}
+
+describe("formatCustomValue", () => {
+  // Regression: weekday_boolean values ({mon: true, tue: false}) used to be
+  // filtered out entirely (the object branch only kept non-empty strings), so
+  // Abholregelung and Buskind vanished from the admin review page. They must
+  // now render the selected days, like the backend export (formatWeekdayBoolean).
+  it("renders selected days for a weekday_boolean value", () => {
+    const value = {
+      mon: true,
+      tue: false,
+      wed: true,
+      thu: false,
+      fri: true,
+    };
+    expect(formatCustomValue(value, field("weekday_boolean"))).toBe(
+      "Mo, Mi, Fr",
+    );
+  });
+
+  it("renders weekday_boolean even when no field metadata is passed", () => {
+    const value = { mon: true, tue: true };
+    expect(formatCustomValue(value)).toBe("Mo, Di");
+  });
+
+  it("returns null when no weekday_boolean day is selected", () => {
+    const value = { mon: false, tue: false, wed: false };
+    expect(formatCustomValue(value, field("weekday_boolean"))).toBeNull();
+  });
+
+  it("still renders weekday_schedule time values per day", () => {
+    const value = { mon: "07:30", wed: "08:00" };
+    const { container } = render(
+      <>{formatCustomValue(value, field("weekday_schedule"))}</>,
+    );
+    expect(container.textContent).toContain("Mo:");
+    expect(container.textContent).toContain("07:30");
+    expect(container.textContent).toContain("Mi:");
+    expect(container.textContent).toContain("08:00");
+    // Days without a time must not appear.
+    expect(container.textContent).not.toContain("Di:");
+  });
+});

--- a/frontend/src/components/enrollment/admin-enrollment-detail.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-detail.tsx
@@ -817,17 +817,33 @@ function formatStringValue(
 
 function formatWeekdayObject(
   o: Record<string, unknown>,
+  field?: AdminRequestSchemaField,
 ): React.ReactNode | null {
   // weekday_boolean (Abholregelung, Buskind): values are per-day booleans
   // ({mon: true, tue: false}). List only the selected days as "Mo, Mi, Fr",
   // mirroring the backend export renderer (formatWeekdayBoolean in
-  // export_format.go). Detected by value type so it works without `field`.
-  if (WEEKDAYS.some(([key]) => typeof o[key] === "boolean")) {
+  // export_format.go). Detected by value type so it works without `field`;
+  // the field metadata also flags it, which covers an explicit empty {} map
+  // that carries no boolean values to sniff.
+  const isWeekdayBoolean =
+    field?.type === "weekday_boolean" ||
+    WEEKDAYS.some(([key]) => typeof o[key] === "boolean");
+  if (isWeekdayBoolean) {
     const days = WEEKDAYS.filter(([key]) => o[key] === true).map(
       ([, label]) => label,
     );
-    if (days.length === 0) return null;
-    return days.join(", ");
+    if (days.length > 0) return days.join(", ");
+    // No days selected. For the reserved student.pickup_status target an
+    // empty map is itself a valid submitted answer ("Geht alleine nach
+    // Hause", see PickupDays.LegacyPickupStatus in the backend). Render that
+    // label so the admin can tell an explicit "goes alone every day" answer
+    // apart from an absent field — dropping the row would conflate the two.
+    // Other weekday_boolean targets (e.g. Buskind) keep dropping the empty
+    // row: no bus days means the child is simply not a bus kid.
+    if (field?.target === "student.pickup_status") {
+      return "Geht alleine nach Hause";
+    }
+    return null;
   }
 
   // weekday_schedule: values are per-day time strings ({mon: "07:30"}).
@@ -872,7 +888,7 @@ export function formatCustomValue(
     );
   }
   if (typeof v === "object") {
-    return formatWeekdayObject(v as Record<string, unknown>);
+    return formatWeekdayObject(v as Record<string, unknown>, field);
   }
   return String(v);
 }

--- a/frontend/src/components/enrollment/admin-enrollment-detail.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-detail.tsx
@@ -794,7 +794,7 @@ function ChildExtraFields({
   );
 }
 
-function formatCustomValue(
+export function formatCustomValue(
   v: unknown,
   field?: AdminRequestSchemaField,
 ): React.ReactNode | null {
@@ -832,6 +832,19 @@ function formatCustomValue(
       ["thu", "Do"],
       ["fri", "Fr"],
     ] as const;
+
+    // weekday_boolean (Abholregelung, Buskind): values are per-day booleans
+    // ({mon: true, tue: false}). List only the selected days as "Mo, Mi, Fr",
+    // mirroring the backend export renderer (formatWeekdayBoolean in
+    // export_format.go). Detected by value type so it works without `field`.
+    if (weekdays.some(([key]) => typeof o[key] === "boolean")) {
+      const days = weekdays
+        .filter(([key]) => o[key] === true)
+        .map(([, label]) => label);
+      if (days.length === 0) return null;
+      return days.join(", ");
+    }
+
     const cells = weekdays
       .map(([key, label]) => ({ label, value: o[key] }))
       .filter(

--- a/frontend/src/components/enrollment/admin-enrollment-detail.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-detail.tsx
@@ -794,21 +794,69 @@ function ChildExtraFields({
   );
 }
 
+const WEEKDAYS = [
+  ["mon", "Mo"],
+  ["tue", "Di"],
+  ["wed", "Mi"],
+  ["thu", "Do"],
+  ["fri", "Fr"],
+] as const;
+
+function formatStringValue(
+  v: string,
+  field?: AdminRequestSchemaField,
+): React.ReactNode | null {
+  const trimmed = v.trim();
+  if (trimmed === "") return null;
+  if (field?.type === "select" && field.options) {
+    const opt = field.options.find((o) => o.value === trimmed);
+    if (opt) return opt.label;
+  }
+  return trimmed;
+}
+
+function formatWeekdayObject(
+  o: Record<string, unknown>,
+): React.ReactNode | null {
+  // weekday_boolean (Abholregelung, Buskind): values are per-day booleans
+  // ({mon: true, tue: false}). List only the selected days as "Mo, Mi, Fr",
+  // mirroring the backend export renderer (formatWeekdayBoolean in
+  // export_format.go). Detected by value type so it works without `field`.
+  if (WEEKDAYS.some(([key]) => typeof o[key] === "boolean")) {
+    const days = WEEKDAYS.filter(([key]) => o[key] === true).map(
+      ([, label]) => label,
+    );
+    if (days.length === 0) return null;
+    return days.join(", ");
+  }
+
+  // weekday_schedule: values are per-day time strings ({mon: "07:30"}).
+  const cells = WEEKDAYS.map(([key, label]) => ({
+    label,
+    value: o[key],
+  })).filter(
+    (c) => typeof c.value === "string" && (c.value as string).trim() !== "",
+  );
+  if (cells.length === 0) return null;
+  return (
+    <span>
+      {cells.map((c) => (
+        <span key={c.label} className="mr-3 inline-block">
+          <span className="text-gray-500">{c.label}:</span>{" "}
+          <span className="font-medium">{c.value as string}</span>
+        </span>
+      ))}
+    </span>
+  );
+}
+
 export function formatCustomValue(
   v: unknown,
   field?: AdminRequestSchemaField,
 ): React.ReactNode | null {
   if (v === null || v === undefined) return null;
   if (typeof v === "boolean") return v ? "Ja" : "Nein";
-  if (typeof v === "string") {
-    const trimmed = v.trim();
-    if (trimmed === "") return null;
-    if (field?.type === "select" && field.options) {
-      const opt = field.options.find((o) => o.value === trimmed);
-      if (opt) return opt.label;
-    }
-    return trimmed;
-  }
+  if (typeof v === "string") return formatStringValue(v, field);
   if (typeof v === "number") return String(v);
 
   if (Array.isArray(v)) {
@@ -824,43 +872,7 @@ export function formatCustomValue(
     );
   }
   if (typeof v === "object") {
-    const o = v as Record<string, unknown>;
-    const weekdays = [
-      ["mon", "Mo"],
-      ["tue", "Di"],
-      ["wed", "Mi"],
-      ["thu", "Do"],
-      ["fri", "Fr"],
-    ] as const;
-
-    // weekday_boolean (Abholregelung, Buskind): values are per-day booleans
-    // ({mon: true, tue: false}). List only the selected days as "Mo, Mi, Fr",
-    // mirroring the backend export renderer (formatWeekdayBoolean in
-    // export_format.go). Detected by value type so it works without `field`.
-    if (weekdays.some(([key]) => typeof o[key] === "boolean")) {
-      const days = weekdays
-        .filter(([key]) => o[key] === true)
-        .map(([, label]) => label);
-      if (days.length === 0) return null;
-      return days.join(", ");
-    }
-
-    const cells = weekdays
-      .map(([key, label]) => ({ label, value: o[key] }))
-      .filter(
-        (c) => typeof c.value === "string" && (c.value as string).trim() !== "",
-      );
-    if (cells.length === 0) return null;
-    return (
-      <span>
-        {cells.map((c) => (
-          <span key={c.label} className="mr-3 inline-block">
-            <span className="text-gray-500">{c.label}:</span>{" "}
-            <span className="font-medium">{c.value as string}</span>
-          </span>
-        ))}
-      </span>
-    );
+    return formatWeekdayObject(v as Record<string, unknown>);
   }
   return String(v);
 }


### PR DESCRIPTION
## What

`formatCustomValue` in the admin enrollment detail page now renders `weekday_boolean` answers (Abholregelung, Buskind) as a comma-joined day list (`"Mo, Mi, Fr"`).

## Why

The object branch only kept non-empty **string** values, so per-day boolean maps (`{mon: true, tue: false}`) fell through to an empty cell list and rendered as `null` — the field silently vanished from the admin review page.

## How

- Add a `weekday_boolean` branch that lists the selected days, mirroring the backend export renderer (`formatWeekdayBoolean` in `export_format.go` — same Mo–Fr order, same German labels, same `, ` join).
- Detect by value type (`typeof === "boolean"`) rather than `field.type`, so it works even when field metadata is absent and can't collide with the `weekday_schedule` (string) branch.
- An empty / all-false map renders nothing — intended: for `pickup_status` an empty map is the valid "Geht allein nach Hause" state, consistent with the backend export.

## Tests

New `admin-enrollment-detail.test.tsx`: selected days, no-metadata path, all-false → null, and a guard that `weekday_schedule` time values still render.

`pnpm run check` passes (pre-push hooks green).


Closes #1599