### PR TITLE
Fix frontend standalone Docker runtime

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -119,7 +119,7 @@ services:
       - ./frontend/postcss.config.js:/app/postcss.config.js
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/environments/production.compose.yml
+++ b/environments/production.compose.yml
@@ -90,7 +90,7 @@ services:
       options:
         tag: prod-frontend
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/environments/staging.compose.yml
+++ b/environments/staging.compose.yml
@@ -75,7 +75,7 @@ services:
       options:
         tag: staging-frontend
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -59,14 +59,10 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Copy only production dependencies
-COPY --from=deps /app/node_modules ./node_modules
-
 # Copy built application
-COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \
@@ -75,4 +71,4 @@ USER nextjs
 
 EXPOSE 3000
 
-CMD ["pnpm", "start"]
+CMD ["node", "server.js"]

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -58,9 +58,9 @@ ENV NEXT_TELEMETRY_DISABLED=1
 
 WORKDIR /app
 
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=builder --chown=root:nodejs --chmod=0555 /app/.next/standalone ./
+COPY --from=builder --chown=root:nodejs --chmod=0555 /app/.next/static ./.next/static
+COPY --from=builder --chown=root:nodejs --chmod=0555 /app/public ./public
 
 USER nextjs
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,16 +1,20 @@
-FROM node:24-alpine
+FROM node:24-alpine AS base
 
 RUN apk add --no-cache tzdata && \
     corepack enable && corepack prepare pnpm@10 --activate
 ENV TZ=Europe/Berlin
+ENV NEXT_TELEMETRY_DISABLED=1
 
 WORKDIR /app
 
-# Install dependencies
+FROM base AS deps
+
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
-# Copy source files
+FROM base AS builder
+
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 # Accept build args
@@ -42,17 +46,25 @@ RUN pnpm run validate:build-env
 # Build the app. Runtime secrets are validated when the container starts.
 RUN SKIP_ENV_VALIDATION=true pnpm run build
 
-# Set production environment
+FROM node:24-alpine AS runner
+
+RUN apk add --no-cache tzdata && \
+    addgroup -g 1001 -S nodejs && \
+    adduser -S nextjs -u 1001 -G nodejs
+
+ENV TZ=Europe/Berlin
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Create non-root user for security
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nextjs -u 1001 -G nodejs && \
-    chown -R nextjs:nodejs /app
+WORKDIR /app
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
 USER nextjs
 
 EXPOSE 3000
 
-# Run production server
-CMD ["pnpm", "start"]
+# Run the production server without invoking pnpm/corepack at runtime.
+CMD ["node", "server.js"]

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -6,7 +6,9 @@ import "./src/env.js";
 import { withSentryConfig } from "@sentry/nextjs";
 
 /** @type {import("next").NextConfig} */
-const config = {};
+const config = {
+  output: "standalone",
+};
 
 export default withSentryConfig(config, {
   silent: true,

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -43,6 +43,21 @@ restore_uploads_volume() {
   return 0
 }
 
+wait_for_postgres_ready() {
+  local attempts="${1:-60}"
+  local delay_seconds="${2:-1}"
+
+  for _ in $(seq 1 "$attempts"); do
+    if docker compose exec -T postgres pg_isready -U postgres -d template1 >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "$delay_seconds"
+  done
+
+  echo "CRITICAL: PostgreSQL did not become ready for restore"
+  return 1
+}
+
 BACKUP_FILE="$1"
 
 if [ -z "$BACKUP_FILE" ]; then
@@ -56,6 +71,10 @@ if [ ! -f "$BACKUP_FILE" ]; then
 fi
 
 echo "Restoring database from: $(basename "$BACKUP_FILE")"
+
+if ! wait_for_postgres_ready; then
+  exit 1
+fi
 
 # ── Restore cluster globals (roles, passwords) if available ──
 # Naming conventions:
@@ -89,6 +108,9 @@ if [ -n "$GLOBALS_FILE" ] && [ -f "$GLOBALS_FILE" ]; then
   echo "Restoring cluster globals from: $(basename "$GLOBALS_FILE")"
   docker compose exec -T postgres psql -U postgres -d template1 < "$GLOBALS_FILE" 2>/dev/null || true
   echo "Cluster globals restored (roles, passwords)"
+  if ! wait_for_postgres_ready; then
+    exit 1
+  fi
 else
   echo "WARNING: No globals file found — roles must already exist on this cluster"
 fi
@@ -96,6 +118,9 @@ fi
 # ── Drop and recreate database from clean template ──
 docker compose exec -T postgres psql -U postgres -d template1 -c "DROP DATABASE IF EXISTS postgres WITH (FORCE);" 2>/dev/null || true
 docker compose exec -T postgres psql -U postgres -d template1 -c "CREATE DATABASE postgres OWNER postgres TEMPLATE template0;"
+if ! wait_for_postgres_ready; then
+  exit 1
+fi
 
 # ── Restore with strict error handling ──
 RESTORE_LOG=$(mktemp)


### PR DESCRIPTION
## Summary
- switch the frontend production image to Next.js standalone output and `node server.js` at runtime
- copy only `.next/standalone`, `.next/static`, and `public` into the production runtime image
- move frontend Docker healthchecks to `/api/health` and make DB restore wait for Postgres readiness around drop/create

## Why
The staging outage was triggered by the frontend container starting through `pnpm start`, which invoked Corepack at runtime and tried to create/download cache state under `/home/nextjs/.cache/node/corepack/v1`. That failed with `ENOSPC`, making the frontend unhealthy and causing deploy rollback pressure.

Running the standalone Next.js server directly removes pnpm/Corepack from the production startup path and keeps the runtime image smaller and faster to assemble.

## Validation
- `docker build -f frontend/Dockerfile.prod -t phoenix-frontend-standalone-smoke ... frontend`
- runtime smoke: `Cmd=["node","server.js"] WorkingDir=/app`
- runtime smoke: process list shows `next-server`, not pnpm/Corepack
- runtime smoke: `curl http://localhost:3998/api/health` returned `200 OK`
- runtime smoke: `curl -I http://localhost:3998/` returned `200 OK`
- `docker build -f frontend/Dockerfile --target production -t phoenix-frontend-devdocker-smoke frontend`

## Notes
- Existing Sentry build warning about `onRouterTransitionStart` still appears; this PR does not change that behavior.
