### PR TITLE
test: fix midnight-window flake in class trip dashboard analytics test

### DIFF
--- a/backend/services/active/analytics_service_test.go
+++ b/backend/services/active/analytics_service_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
@@ -82,7 +83,10 @@ func TestGetDashboardAnalytics(t *testing.T) {
 			`,
 				classTripStudent.GetTenantID(),
 				studentID,
-				now,
+				// The DATE column must hold the Berlin calendar date; the driver
+				// binds raw time.Time values as UTC, which is one day behind
+				// Berlin between 00:00 and 02:00 local time.
+				timezone.DateOfUTC(now),
 				activeModels.StudentStatusDayClassTrip,
 				now,
 				activeModels.StudentStatusSourcePlanned,


### PR DESCRIPTION
## Problem

`TestGetDashboardAnalytics/counts_class_trip_students_as_excused_without_counting_sick_overlaps` (added in #1602) fails deterministically between 00:00 and 02:00 Berlin time. This broke the development push CI and the release PR #1604 tonight (runs at 22:06 UTC = 00:06 Berlin).

## Root cause

The subtest inserts `active.student_status_days` rows via raw SQL and passes `time.Now()` as the `DATE` value. The pg driver binds `time.Time` params as UTC, so the row lands on the UTC calendar date. `GetDashboardAnalytics` queries class trips for Berlin's current date (`timezone.Today()`). Between midnight and 02:00 Berlin (CEST) the two dates differ by one day, the class trip rows don't match, and the excused count comes up 1 instead of 2.

The sibling subtest ("scopes class trip count to tenant context") never failed because it goes through `StudentStatusDayRepository.UpsertReported`, which already normalizes `entry.Date = timezone.DateOfUTC(entry.Date)`.

## Fix

Normalize the fixture date with `timezone.DateOfUTC(now)` in the raw insert, matching the repository behavior. Production code is untouched; it was correct.

## Verification

Reproduced the failure locally at 00:12 Berlin time on unmodified development, then confirmed the fixed test passes at 00:16 (still inside the failure window). Full `services/active` package and `TestHermeticTestPatterns` pass.