### PR TITLE
Fix frontend Docker healthcheck

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -104,6 +104,8 @@ services:
       NEXT_PUBLIC_PARENTS_HOSTNAME: ${NEXT_PUBLIC_PARENTS_HOSTNAME}
       NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN}
       NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${NEXT_PUBLIC_SENTRY_ENVIRONMENT}
+      # Bind Next.js standalone to IPv4 so Docker healthchecks can reach it inside Alpine.
+      HOSTNAME: 0.0.0.0
     depends_on:
       - server
     volumes:
@@ -119,7 +121,7 @@ services:
       - ./frontend/postcss.config.js:/app/postcss.config.js
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/environments/production.compose.yml
+++ b/environments/production.compose.yml
@@ -85,12 +85,14 @@ services:
       API_URL: http://server:8080
       # Override PORT from shared .env (8080 is for the backend; Next.js must listen on 3000)
       PORT: 3000
+      # Bind Next.js standalone to IPv4 so Docker healthchecks can reach it inside Alpine.
+      HOSTNAME: 0.0.0.0
     logging:
       driver: journald
       options:
         tag: prod-frontend
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/environments/staging.compose.yml
+++ b/environments/staging.compose.yml
@@ -70,12 +70,14 @@ services:
       API_URL: http://server:8080
       # Override PORT from shared .env (8080 is for the backend; Next.js must listen on 3000)
       PORT: 3000
+      # Bind Next.js standalone to IPv4 so Docker healthchecks can reach it inside Alpine.
+      HOSTNAME: 0.0.0.0
     logging:
       driver: journald
       options:
         tag: staging-frontend
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- bind the frontend standalone Next.js server to IPv4 in deployed compose files
- switch frontend Docker healthchecks from `localhost` to `127.0.0.1`
- keep the local compose example aligned with staging/production

## Root Cause
PR #1603 moved the frontend image to Next.js standalone runtime. The app started, but the Docker healthcheck probed `http://localhost:3000/api/health` from inside the Alpine container. In that environment the probe failed with `Connection refused`, while the app was reachable on IPv4 loopback when bound explicitly.

This made `docker compose up -d --wait` mark `staging-frontend-1` unhealthy and triggered the automatic staging rollback.

## Validation
- Reproduced the failed healthcheck locally with `ghcr.io/moto-nrw/phoenix-frontend:4ec6518`
- Verified the fixed combination with the same image and decrypted staging env:
  - `HOSTNAME=0.0.0.0`
  - `wget -qO- http://127.0.0.1:3000/api/health` inside the container returned `200 OK`
- `docker compose -f environments/staging.compose.yml config`
- `docker compose -f environments/production.compose.yml config`
- `./scripts/env-check.sh`
