### PR TITLE
Stabilize teacher form error scroll test

### DIFF
--- a/frontend/src/components/teachers/teacher-form.test.tsx
+++ b/frontend/src/components/teachers/teacher-form.test.tsx
@@ -572,9 +572,11 @@ describe("TeacherForm", () => {
         ).toBeInTheDocument();
       });
 
-      expect(scrollIntoViewMock).toHaveBeenCalledWith({
-        behavior: "smooth",
-        block: "start",
+      await waitFor(() => {
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({
+          behavior: "smooth",
+          block: "start",
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary
- wait for the teacher form scroll-to-error effect before asserting `scrollIntoView`
- keep the assertion aligned with `useScrollToError`, which runs in a React effect after the error banner renders

## Root Cause
The post-merge CI failure was not caused by PR #1606's Docker/deploy change. The failing frontend test asserted `scrollIntoView` immediately after waiting for the error text to render. Rendering the error and running the `useScrollToError` effect are separate steps, so CI occasionally observed the banner before the effect had called `scrollIntoView`.

## Validation
- `pnpm test:run src/components/teachers/teacher-form.test.tsx -t "scrolls to error" --reporter=verbose`
- targeted scroll test passed 5x in a row
- `pnpm test:run src/components/teachers/teacher-form.test.tsx --reporter=dot`
- `pnpm check`
- pre-push `frontend-check`
- pre-push `frontend-knip`
