### PR TITLE
refactor: move service-layer query construction into the repository layer

### DIFF
--- a/backend/api/iot/data/available_teachers_internal_test.go
+++ b/backend/api/iot/data/available_teachers_internal_test.go
@@ -184,3 +184,12 @@ func TestGetAvailableTeachers_UsesTeacherRoster(t *testing.T) {
 
 var _ userModels.TeacherRepository = teacherRepositoryStub{}
 var _ usersSvc.PersonService = personServiceWithTeacherRepo{}
+
+// Stubs for the issue #585 refactor interface additions — unused here.
+func (s teacherRepositoryStub) ListActiveCaregivers(context.Context) ([]*userModels.ActiveCaregiver, error) {
+	return nil, nil
+}
+
+func (s teacherRepositoryStub) FindActiveCaregiverByAccountID(context.Context, int64) (*userModels.ActiveCaregiver, error) {
+	return nil, nil
+}

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -97,6 +97,7 @@ func NewServer(logger *slog.Logger) (*Server, error) {
 		// active.groups via repositories (issue #585 layering).
 		if api.repos != nil {
 			srv.scheduler.SetTimetableBridgeRepos(api.repos.InstanceStudent, api.repos.ActivityInstance)
+			srv.scheduler.SetStudentStatusDayRepo(api.repos.StudentStatusDay)
 		}
 		// Parent-enrollment PR 2: activate-students tick.
 		if api.repos != nil && api.repos.Student != nil {

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -93,6 +93,11 @@ func NewServer(logger *slog.Logger) (*Server, error) {
 		if api.repos != nil && api.Services.RealtimeHub != nil {
 			srv.scheduler.SetInstanceOverdueDeps(api.repos.ActivityInstance, api.Services.RealtimeHub)
 		}
+		// Daily session-end bridge: closes schedule-side rows for ended
+		// active.groups via repositories (issue #585 layering).
+		if api.repos != nil {
+			srv.scheduler.SetTimetableBridgeRepos(api.repos.InstanceStudent, api.repos.ActivityInstance)
+		}
 		// Parent-enrollment PR 2: activate-students tick.
 		if api.repos != nil && api.repos.Student != nil {
 			srv.scheduler.SetStudentLifecycleRepo(api.repos.Student)

--- a/backend/api/students/status_day_internal_test.go
+++ b/backend/api/students/status_day_internal_test.go
@@ -596,3 +596,12 @@ func executeStatusDayHandler(router chi.Router, req *http.Request, claims jwt.Ap
 	router.ServeHTTP(rr, req)
 	return rr
 }
+
+// Stubs for the issue #585 refactor interface additions — unused here.
+func (r *fakeStatusDayRepo) ArchiveAndClearStatusFlag(context.Context, string, string, string, time.Time, time.Time, string) (int64, error) {
+	return 0, nil
+}
+
+func (r *fakeStatusDayRepo) CountActiveClassTripStudents(context.Context, time.Time) (int, error) {
+	return 0, nil
+}

--- a/backend/api/timetable/instance_students_unit_test.go
+++ b/backend/api/timetable/instance_students_unit_test.go
@@ -588,3 +588,13 @@ func TestDecodePatchBody_Direct(t *testing.T) {
 		assert.False(t, ok)
 	})
 }
+
+// Stubs for the issue #585 cleanup refactor interface additions — unused by
+// these tests.
+func (f *fakeRepo) MarkExpectedAbsentByActiveGroupIDs(context.Context, []int64, time.Time) error {
+	panic("unused")
+}
+
+func (f *fakeRepo) ListStudentInstanceRefsBefore(context.Context, time.Time) ([]schedule.StudentInstanceRef, error) {
+	panic("unused")
+}

--- a/backend/api/timetable/templates_test.go
+++ b/backend/api/timetable/templates_test.go
@@ -81,7 +81,7 @@ func buildTemplateSetup(t *testing.T, mat scheduleSvc.MaterializationService) *t
 		StudentEnrollmentRepo:  activitiesRepo.NewStudentEnrollmentRepository(db),
 		ActivitySupervisorRepo: activitiesRepo.NewSupervisorPlannedRepository(db),
 		TimeframeRepo:          scheduleRepo.NewTimeframeRepository(db),
-		CalendarPeriodService:  scheduleSvc.NewCalendarPeriodService(scheduleRepo.NewCalendarPeriodRepository(db), db, nil),
+		CalendarPeriodService:  scheduleSvc.NewCalendarPeriodService(scheduleRepo.NewCalendarPeriodRepository(db), nil),
 		RoomRepo:               facilitiesRepo.NewRoomRepository(db),
 		MaterializationService: mat,
 		DB:                     db,

--- a/backend/auth/authorize/policies/student_visits_test.go
+++ b/backend/auth/authorize/policies/student_visits_test.go
@@ -34,7 +34,6 @@ func setupPolicyServices(t *testing.T, db *bun.DB) (education.Service, users.Per
 		repos.Teacher,
 		repos.Staff,
 		repos.Student,
-		db,
 	)
 
 	// Create users service

--- a/backend/cmd/cleanup_helpers.go
+++ b/backend/cmd/cleanup_helpers.go
@@ -95,6 +95,7 @@ func newCleanupContextWithCleanupService() (*cleanupContext, error) {
 	consentService := users.NewPrivacyConsentService(nil, slog.Default())
 	ctx.CleanupService = active.NewCleanupService(
 		ctx.RepoFactory.ActiveVisit,
+		ctx.RepoFactory.Attendance,
 		ctx.RepoFactory.PrivacyConsent,
 		ctx.RepoFactory.DataDeletion,
 		consentService,
@@ -114,7 +115,9 @@ func newCleanupContextWithTimetableCleanup() (*cleanupContext, error) {
 		return nil, err
 	}
 	ctx.TimetableCleanupService = schedule.NewTimetableCleanupService(
-		ctx.DB,
+		ctx.RepoFactory.ActivityInstance,
+		ctx.RepoFactory.ActivityException,
+		ctx.RepoFactory.InstanceStudent,
 		auditRepo.NewDataDeletionRepository(ctx.DB),
 		ctx.ServiceFactory.Settings,
 		slog.Default().With("service", "timetable-cleanup-cli"),
@@ -132,7 +135,8 @@ func newCleanupContextWithTimeTrackingCleanup() (*cleanupContext, error) {
 		return nil, err
 	}
 	ctx.TimeTrackingCleanupService = active.NewTimeTrackingCleanupService(
-		ctx.DB,
+		ctx.RepoFactory.WorkSession,
+		ctx.RepoFactory.StaffAbsence,
 		auditRepo.NewDataDeletionRepository(ctx.DB),
 		ctx.ServiceFactory.Settings,
 		slog.Default().With("service", "time-tracking-cleanup-cli"),

--- a/backend/cmd/cleanup_test.go
+++ b/backend/cmd/cleanup_test.go
@@ -28,6 +28,7 @@ func setupTestCleanupContext(t *testing.T) *cleanupContext {
 	repoFactory := repositories.NewFactory(db)
 	cleanupSvc := active.NewCleanupService(
 		repoFactory.ActiveVisit,
+		repoFactory.Attendance,
 		repoFactory.PrivacyConsent,
 		repoFactory.DataDeletion,
 		users.NewPrivacyConsentService(nil, slog.Default()),
@@ -48,6 +49,7 @@ func setupTestCleanupContextWithServices(t *testing.T) *cleanupContext {
 	require.NoError(t, err, "Failed to create service factory")
 	cleanupSvc := active.NewCleanupService(
 		repoFactory.ActiveVisit,
+		repoFactory.Attendance,
 		repoFactory.PrivacyConsent,
 		repoFactory.DataDeletion,
 		users.NewPrivacyConsentService(nil, slog.Default()),

--- a/backend/database/repositories/active/attendance_repository.go
+++ b/backend/database/repositories/active/attendance_repository.go
@@ -404,3 +404,29 @@ func (r *AttendanceRepository) CountByStaffID(ctx context.Context, staffID int64
 
 	return count, nil
 }
+
+// FindStaleOpen returns attendance rows dated before the given day that still
+// lack a check-out time. Feeds the nightly stale-attendance cleanup and its
+// preview (services/active/cleanup_service.go).
+func (r *AttendanceRepository) FindStaleOpen(ctx context.Context, before time.Time) ([]*active.Attendance, error) {
+	var records []*active.Attendance
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&records).
+		ModelTableExpr(`active.attendance AS "attendance"`).
+		Where(`"attendance".date < ?`, before).
+		Where(`"attendance".check_out_time IS NULL`)
+
+	if where, val, ok := base.TenantWhere(ctx, "attendance"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find stale open attendance",
+			Err: err,
+		}
+	}
+
+	return records, nil
+}

--- a/backend/database/repositories/active/group_supervisor.go
+++ b/backend/database/repositories/active/group_supervisor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/uptrace/bun"
 )
 
@@ -491,4 +492,29 @@ func (r *GroupSupervisorRepository) GetStaffIDsWithSupervisionToday(ctx context.
 	}
 
 	return staffIDs, nil
+}
+
+// ListActiveSupervisionBlockers returns the staff member's still-open group
+// supervisions as caregiver-capability blocker rows. Custom raw-SQL method
+// (backend-conventions Rule 2): cross-schema join into the users blocker
+// read model with text-cast dates for the UI.
+func (r *GroupSupervisorRepository) ListActiveSupervisionBlockers(ctx context.Context, staffID, tenantID int64) ([]userModels.BlockerSupervision, error) {
+	var results []userModels.BlockerSupervision
+	err := base.GetDB(ctx, r.db).NewRaw(`
+		SELECT gs.id, COALESCE(g.name, 'Unbekannte Gruppe') AS group_name,
+		       gs.start_date::text AS start_date
+		FROM active.group_supervisors AS gs
+		LEFT JOIN education.groups AS g ON g.id = gs.group_id AND g.tenant_id = gs.tenant_id
+		WHERE gs.tenant_id = ?
+		  AND gs.staff_id = ?
+		  AND (gs.end_date IS NULL OR gs.end_date > NOW())
+		ORDER BY gs.start_date DESC
+	`, tenantID, staffID).Scan(ctx, &results)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list active supervision blockers",
+			Err: err,
+		}
+	}
+	return results, nil
 }

--- a/backend/database/repositories/active/student_status_day.go
+++ b/backend/database/repositories/active/student_status_day.go
@@ -230,3 +230,88 @@ func (r *StudentStatusDayRepository) findByStudentAndDateRange(ctx context.Conte
 	}
 	return entries, nil
 }
+
+// ArchiveAndClearStatusFlag archives the given legacy student status flag
+// into active.student_status_days for the given date (upsert) and then
+// clears the flag + its timestamp on users.students for every flagged
+// student. Returns the number of students cleared.
+//
+// Custom raw-SQL method (backend-conventions Rule 2/11 exception): the
+// INSERT...SELECT upsert spans users.students → active.student_status_days
+// and is not expressible through the generic shape. Column names are
+// interpolated but MUST be trusted constants from the scheduler's fixed
+// flag set ("sick"/"sick_since", "excused"/"excused_since") — never user
+// input. Tenant scoping comes from the caller's per-tenant RLS transaction.
+func (r *StudentStatusDayRepository) ArchiveAndClearStatusFlag(
+	ctx context.Context,
+	flagColumn, sinceColumn, status string,
+	date, reportedFallback time.Time,
+	source string,
+) (int64, error) {
+	db := base.GetDB(ctx, r.db)
+
+	upsertQuery := fmt.Sprintf(`
+		INSERT INTO active.student_status_days
+			(tenant_id, student_id, date, status, reported_at, cleared_at, source)
+		SELECT tenant_id, id, ?, ?, COALESCE(%s, ?), ?, ?
+		FROM users.students
+		WHERE %s = TRUE
+		ON CONFLICT (tenant_id, student_id, date, status) DO UPDATE
+		SET reported_at = EXCLUDED.reported_at,
+		    cleared_at = EXCLUDED.cleared_at,
+		    source = EXCLUDED.source;
+	`, sinceColumn, flagColumn)
+	if _, err := db.NewRaw(upsertQuery, date, status, reportedFallback, reportedFallback, source).Exec(ctx); err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "archive status flag",
+			Err: err,
+		}
+	}
+
+	clearQuery := fmt.Sprintf(
+		`UPDATE users.students SET %s = FALSE, %s = NULL WHERE %s = TRUE`,
+		flagColumn, sinceColumn, flagColumn,
+	)
+	res, err := db.NewRaw(clearQuery).Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "clear status flag",
+			Err: err,
+		}
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "clear status flag rows affected",
+			Err: err,
+		}
+	}
+	return affected, nil
+}
+
+// CountActiveClassTripStudents counts distinct students with an uncleared
+// class-trip status entry for the date, excluding students currently flagged
+// sick or excused. Custom method (backend-conventions Rule 2): join on
+// users.students with COALESCE flag predicates for the dashboard analytics.
+func (r *StudentStatusDayRepository) CountActiveClassTripStudents(ctx context.Context, date time.Time) (int, error) {
+	var count int
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`active.student_status_days AS "student_status_day"`).
+		Join(`JOIN users.students AS "student" ON "student".id = "student_status_day".student_id AND "student".tenant_id = "student_status_day".tenant_id`).
+		Where(`"student_status_day".date = ?`, date).
+		Where(`"student_status_day".status = ?`, active.StudentStatusDayClassTrip).
+		Where(`"student_status_day".cleared_at IS NULL`).
+		Where(`COALESCE("student".sick, FALSE) = FALSE`).
+		Where(`COALESCE("student".excused, FALSE) = FALSE`).
+		ColumnExpr(`COUNT(DISTINCT "student_status_day".student_id)`)
+	if where, val, ok := base.TenantWhere(ctx, "student_status_day"); ok {
+		query = query.Where(where, val)
+	}
+	if err := query.Scan(ctx, &count); err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "count active class trip students",
+			Err: err,
+		}
+	}
+	return count, nil
+}

--- a/backend/database/repositories/active/visits.go
+++ b/backend/database/repositories/active/visits.go
@@ -891,3 +891,52 @@ func (r *VisitRepository) FindActiveVisits(ctx context.Context) ([]*active.Visit
 
 	return visits, nil
 }
+
+// GetCurrentRoomNamesForStudents returns the room name of each student's
+// current open visit (visit without exit_time in a still-running active
+// group), newest visit first per student. Students without an open visit are
+// absent from the map. Custom method (backend-conventions Rule 2):
+// DISTINCT ON projection joining active.groups and facilities.rooms for the
+// emergency list. Tenant scoping via defense-in-depth predicate on top of
+// the caller's RLS transaction.
+func (r *VisitRepository) GetCurrentRoomNamesForStudents(ctx context.Context, studentIDs []int64) (map[int64]string, error) {
+	if len(studentIDs) == 0 {
+		return map[int64]string{}, nil
+	}
+
+	type currentLocationRow struct {
+		StudentID int64          `bun:"student_id"`
+		RoomName  sql.NullString `bun:"room_name"`
+	}
+
+	var rows []currentLocationRow
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`active.visits AS "visit"`).
+		ColumnExpr(`DISTINCT ON ("visit".student_id) "visit".student_id`).
+		ColumnExpr(`"room".name AS "room_name"`).
+		Join(`JOIN active.groups AS "group" ON "group".id = "visit".active_group_id AND "group".end_time IS NULL`).
+		Join(`JOIN facilities.rooms AS "room" ON "room".id = "group".room_id`).
+		Where(`"visit".student_id IN (?)`, bun.List(studentIDs)).
+		Where(`"visit".exit_time IS NULL`).
+		OrderExpr(`"visit".student_id ASC`).
+		OrderExpr(`"visit".entry_time DESC`)
+
+	if where, val, ok := base.TenantWhere(ctx, "visit"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "get current room names for students",
+			Err: err,
+		}
+	}
+
+	locations := make(map[int64]string, len(rows))
+	for _, row := range rows {
+		if row.RoomName.Valid {
+			locations[row.StudentID] = row.RoomName.String
+		}
+	}
+	return locations, nil
+}

--- a/backend/database/repositories/activities/supervisor_planned.go
+++ b/backend/database/repositories/activities/supervisor_planned.go
@@ -361,3 +361,27 @@ func (r *SupervisorPlannedRepository) List(ctx context.Context, options *modelBa
 
 	return supervisors, nil
 }
+
+// ListPlannedSupervisionBlockers returns the staff member's planned activity
+// supervisions as caregiver-capability blocker rows. Custom raw-SQL method
+// (backend-conventions Rule 2): join into the users blocker read model.
+func (r *SupervisorPlannedRepository) ListPlannedSupervisionBlockers(ctx context.Context, staffID, tenantID int64) ([]users.BlockerActivity, error) {
+	var results []users.BlockerActivity
+	err := base.GetDB(ctx, r.db).NewRaw(`
+		SELECT s.id, s.group_id AS activity_id,
+		       COALESCE(ag.name, 'Unbekannte Aktivität') AS activity_name,
+		       COALESCE(s.is_primary, false) AS is_primary
+		FROM activities.supervisors AS s
+		LEFT JOIN activities.groups AS ag ON ag.id = s.group_id AND ag.tenant_id = s.tenant_id
+		WHERE s.tenant_id = ?
+		  AND s.staff_id = ?
+		ORDER BY ag.name ASC
+	`, tenantID, staffID).Scan(ctx, &results)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list planned supervision blockers",
+			Err: err,
+		}
+	}
+	return results, nil
+}

--- a/backend/database/repositories/auth/accounts.go
+++ b/backend/database/repositories/auth/accounts.go
@@ -652,3 +652,24 @@ func (r *AccountRepository) Update(ctx context.Context, account *auth.Account) e
 
 	return nil
 }
+
+// AnonymizeForDeletion overwrites the account's email with the given
+// anonymized placeholder and clears the username. Custom method
+// (backend-conventions Rule 2): GDPR person-deletion step that pairs two
+// column writes into one statement; used by operator SoftDeletePerson.
+func (r *AccountRepository) AnonymizeForDeletion(ctx context.Context, accountID int64, anonymizedEmail string) error {
+	_, err := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*auth.Account)(nil)).
+		ModelTableExpr(accountTableAlias).
+		Set(`email = ?`, anonymizedEmail).
+		Set(`username = NULL`).
+		Where(`"account".id = ?`, accountID).
+		Exec(ctx)
+	if err != nil {
+		return &modelBase.DatabaseError{
+			Op:  "anonymize account for deletion",
+			Err: err,
+		}
+	}
+	return nil
+}

--- a/backend/database/repositories/base/base.go
+++ b/backend/database/repositories/base/base.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 	"unicode"
 
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
@@ -158,15 +159,7 @@ func (r *Repository[T]) Update(ctx context.Context, entity T) error {
 
 // Delete removes an entity from the database
 func (r *Repository[T]) Delete(ctx context.Context, id any) error {
-	// Create a new instance of entity type
-	entityType := reflect.TypeFor[T]()
-
-	// If it's a pointer type, get the element type
-	if entityType.Kind() == reflect.Pointer {
-		entityType = entityType.Elem()
-	}
-
-	entityVal := reflect.New(entityType).Interface()
+	entityVal := r.newEntityValue()
 
 	// Use ModelTableExpr to specify the schema-qualified table name with proper alias
 	// Convert EntityName from CamelCase to snake_case for consistent alias
@@ -231,15 +224,7 @@ func (r *Repository[T]) List(ctx context.Context, filters map[string]any) ([]T, 
 
 // Count returns the number of entities matching the filters
 func (r *Repository[T]) Count(ctx context.Context, filters map[string]any) (int, error) {
-	// Create a new instance of entity type
-	entityType := reflect.TypeFor[T]()
-
-	// If it's a pointer type, get the element type
-	if entityType.Kind() == reflect.Pointer {
-		entityType = entityType.Elem()
-	}
-
-	entityVal := reflect.New(entityType).Interface()
+	entityVal := r.newEntityValue()
 
 	// Use ModelTableExpr to specify the schema-qualified table name with proper alias
 	// Get the entity name in lowercase to use as alias
@@ -273,6 +258,170 @@ func (r *Repository[T]) Count(ctx context.Context, filters map[string]any) (int,
 	}
 
 	return count, nil
+}
+
+// CountWithOptions returns the number of entities matching the query options.
+// Unlike Count, it supports the full Filter operator set (LessThan, IsNull,
+// In, ...). Sorting and pagination are ignored — they cannot change a count.
+func (r *Repository[T]) CountWithOptions(ctx context.Context, options *modelBase.QueryOptions) (int, error) {
+	entityVal := r.newEntityValue()
+
+	entityName := toSnakeCase(strings.TrimPrefix(r.EntityName, "*"))
+	tableExpr := fmt.Sprintf(`%s AS "%s"`, r.TableName, entityName)
+
+	query := GetDB(ctx, r.DB).NewSelect().
+		Model(entityVal).
+		ModelTableExpr(tableExpr).
+		Column(entityName + ".id")
+
+	query = r.applyTenantFilter(ctx, query, entityName)
+
+	if options != nil && options.Filter != nil {
+		options.Filter.WithTableAlias(entityName)
+		query = options.Filter.ApplyToQuery(query)
+	}
+
+	count, err := query.Count(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "count with options",
+			Err: err,
+		}
+	}
+
+	return count, nil
+}
+
+// OldestBefore returns the minimum value of dateColumn among matching rows,
+// optionally restricted to rows where dateColumn < cutoff (pass nil for the
+// absolute minimum). Returns nil when no rows match. Intended for
+// retention/cleanup statistics (oldest expired record, preview output).
+// dateColumn must be a compile-time constant column name, never user input.
+func (r *Repository[T]) OldestBefore(ctx context.Context, dateColumn string, cutoff *time.Time) (*time.Time, error) {
+	entityVal := r.newEntityValue()
+
+	entityName := toSnakeCase(strings.TrimPrefix(r.EntityName, "*"))
+	tableExpr := fmt.Sprintf(`%s AS "%s"`, r.TableName, entityName)
+
+	query := GetDB(ctx, r.DB).NewSelect().
+		Model(entityVal).
+		ModelTableExpr(tableExpr).
+		ColumnExpr("MIN(?)", bun.Ident(dateColumn))
+
+	query = r.applyTenantFilter(ctx, query, entityName)
+
+	if cutoff != nil {
+		query = query.Where("? < ?", bun.Ident(dateColumn), *cutoff)
+	}
+
+	var oldest *time.Time
+	if err := query.Scan(ctx, &oldest); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "oldest before",
+			Err: err,
+		}
+	}
+
+	return oldest, nil
+}
+
+// DeleteOlderThan deletes all matching rows whose dateColumn is strictly
+// before cutoff and returns the number of rows deleted. Intended for
+// retention/cleanup jobs (GDPR data expiry, stale-record pruning).
+// dateColumn must be a compile-time constant column name, never user input.
+func (r *Repository[T]) DeleteOlderThan(ctx context.Context, dateColumn string, cutoff time.Time) (int64, error) {
+	entityVal := r.newEntityValue()
+
+	entityName := toSnakeCase(strings.TrimPrefix(r.EntityName, "*"))
+	tableExpr := fmt.Sprintf(`%s AS "%s"`, r.TableName, entityName)
+
+	query := GetDB(ctx, r.DB).NewDelete().
+		Model(entityVal).
+		ModelTableExpr(tableExpr).
+		Where("? < ?", bun.Ident(dateColumn), cutoff)
+
+	if r.TenantScoped {
+		if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+			query = query.Where(fmt.Sprintf(`"%s".tenant_id = ?`, entityName), tenantID)
+		}
+	}
+
+	result, err := query.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "delete older than",
+			Err: err,
+		}
+	}
+
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "delete older than",
+			Err: err,
+		}
+	}
+
+	return deleted, nil
+}
+
+// UpdateColumns updates only the named columns of entity (matched by primary
+// key) and returns the number of rows affected, so callers own the 0-rows
+// decision. Unlike Update, it does not run entity validation: callers update
+// a partial projection, so whole-entity invariants may not hold on the
+// in-memory value. Include "updated_at" in columns (and set it on the entity)
+// when the touch timestamp should move.
+// Column names must be compile-time constants, never user input.
+func (r *Repository[T]) UpdateColumns(ctx context.Context, entity T, columns ...string) (int64, error) {
+	if reflect.ValueOf(entity).IsZero() {
+		return 0, fmt.Errorf("%s cannot be nil or zero value", r.EntityName)
+	}
+	if len(columns) == 0 {
+		return 0, fmt.Errorf("update columns %s: at least one column required", r.EntityName)
+	}
+
+	entityName := toSnakeCase(strings.TrimPrefix(r.EntityName, "*"))
+	tableExpr := fmt.Sprintf(`%s AS "%s"`, r.TableName, entityName)
+
+	query := GetDB(ctx, r.DB).NewUpdate().
+		Model(entity).
+		ModelTableExpr(tableExpr).
+		Column(columns...).
+		WherePK()
+
+	if r.TenantScoped {
+		if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+			query = query.Where(fmt.Sprintf(`"%s".tenant_id = ?`, entityName), tenantID)
+		}
+	}
+
+	result, err := query.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "update columns",
+			Err: err,
+		}
+	}
+
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "update columns",
+			Err: err,
+		}
+	}
+
+	return updated, nil
+}
+
+// newEntityValue creates a new zero-value instance of the entity type for use
+// as a bun model target (table metadata only, never scanned into).
+func (r *Repository[T]) newEntityValue() any {
+	entityType := reflect.TypeFor[T]()
+	if entityType.Kind() == reflect.Pointer {
+		entityType = entityType.Elem()
+	}
+	return reflect.New(entityType).Interface()
 }
 
 // Transaction executes a function within a database transaction

--- a/backend/database/repositories/base/base_test.go
+++ b/backend/database/repositories/base/base_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	configModels "github.com/moto-nrw/project-phoenix/models/config"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
@@ -377,4 +378,237 @@ func TestRepository_Transaction_Rollback(t *testing.T) {
 		Count(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
+}
+
+// ============================================================================
+// Generic query helpers (issue #585 services→repository refactor):
+// CountWithOptions, OldestBefore, DeleteOlderThan, UpdateColumns.
+//
+// Aggregate tests (count/min/delete) run under their own tenant via
+// UniqueTestTenantID + TenantScoped=true, so rows that other tests create in
+// the shared config.setting_values table cannot affect the assertions.
+// ============================================================================
+
+// newTenantScopedRepo builds a base repository with the tenant_id
+// defense-in-depth filter enabled, matching how domain repositories
+// (students, groups, ...) construct their embedded generic.
+func newTenantScopedRepo(db *bun.DB) *base.Repository[*configModels.SettingValue] {
+	repo := base.NewRepository[*configModels.SettingValue](db, baseTestTable, baseTestEntityName)
+	repo.TenantScoped = true
+	return repo
+}
+
+// createSettingValueForTenant inserts a row for the given tenant and returns it.
+func createSettingValueForTenant(t *testing.T, db *bun.DB, tenantID int64, key, value string) *configModels.SettingValue {
+	t.Helper()
+	sv := &configModels.SettingValue{
+		SettingKey: key,
+		Value:      jsonValue(value),
+	}
+	sv.SetTenantID(tenantID)
+	_, err := db.NewInsert().Model(sv).ModelTableExpr(baseTestTable).Exec(testpkg.TenantContext(tenantID))
+	require.NoError(t, err)
+	return sv
+}
+
+// setSettingValueCreatedAt overwrites created_at so date-window tests have
+// deterministic timestamps (the column default is current_timestamp).
+func setSettingValueCreatedAt(t *testing.T, db *bun.DB, id int64, createdAt time.Time) {
+	t.Helper()
+	_, err := db.NewUpdate().
+		TableExpr(baseTestTable).
+		Set("created_at = ?", createdAt).
+		Where("id = ?", id).
+		Exec(testpkg.TenantContext(1))
+	require.NoError(t, err)
+}
+
+// cleanupTenantSettingValues removes every row the test created for a tenant.
+func cleanupTenantSettingValues(t *testing.T, db *bun.DB, tenantID int64) {
+	t.Helper()
+	_, _ = db.NewDelete().
+		TableExpr(baseTestTable).
+		Where("tenant_id = ?", tenantID).
+		Exec(testpkg.TenantContext(tenantID))
+}
+
+func TestRepository_CountWithOptions(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	tenantID := testpkg.UniqueTestTenantID(t)
+	otherTenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	testpkg.EnsureTestTenant(t, db, otherTenantID)
+	defer cleanupTenantSettingValues(t, db, tenantID)
+	defer cleanupTenantSettingValues(t, db, otherTenantID)
+
+	repo := newTenantScopedRepo(db)
+	ctx := testpkg.TenantContext(tenantID)
+
+	prefix := uniqueKey("count_options")
+	first := createSettingValueForTenant(t, db, tenantID, prefix+"_a", "v1")
+	createSettingValueForTenant(t, db, tenantID, prefix+"_b", "v2")
+	createSettingValueForTenant(t, db, tenantID, prefix+"_c", "v3")
+	// Same key prefix under another tenant — must not be counted.
+	createSettingValueForTenant(t, db, otherTenantID, prefix+"_other", "v4")
+
+	t.Run("nil options counts all tenant rows", func(t *testing.T) {
+		count, err := repo.CountWithOptions(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 3, count)
+	})
+
+	t.Run("like filter", func(t *testing.T) {
+		options := modelBase.NewQueryOptions()
+		options.Filter = modelBase.NewFilter().Like("setting_key", prefix+"%")
+		count, err := repo.CountWithOptions(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, 3, count)
+	})
+
+	t.Run("equal filter", func(t *testing.T) {
+		options := modelBase.NewQueryOptions()
+		options.Filter = modelBase.NewFilter().Equal("setting_key", first.SettingKey)
+		count, err := repo.CountWithOptions(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+}
+
+func TestRepository_OldestBefore(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	tenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer cleanupTenantSettingValues(t, db, tenantID)
+
+	repo := newTenantScopedRepo(db)
+	ctx := testpkg.TenantContext(tenantID)
+
+	older := time.Date(2020, 1, 15, 10, 0, 0, 0, time.UTC)
+	newer := time.Date(2021, 3, 10, 12, 0, 0, 0, time.UTC)
+
+	prefix := uniqueKey("oldest_before")
+	first := createSettingValueForTenant(t, db, tenantID, prefix+"_old", "v1")
+	second := createSettingValueForTenant(t, db, tenantID, prefix+"_new", "v2")
+	setSettingValueCreatedAt(t, db, first.ID, older)
+	setSettingValueCreatedAt(t, db, second.ID, newer)
+
+	t.Run("nil cutoff returns absolute minimum", func(t *testing.T) {
+		oldest, err := repo.OldestBefore(ctx, "created_at", nil)
+		require.NoError(t, err)
+		require.NotNil(t, oldest)
+		assert.WithinDuration(t, older, *oldest, time.Second)
+	})
+
+	t.Run("cutoff between rows returns only the older one", func(t *testing.T) {
+		cutoff := time.Date(2020, 6, 1, 0, 0, 0, 0, time.UTC)
+		oldest, err := repo.OldestBefore(ctx, "created_at", &cutoff)
+		require.NoError(t, err)
+		require.NotNil(t, oldest)
+		assert.WithinDuration(t, older, *oldest, time.Second)
+	})
+
+	t.Run("cutoff before all rows returns nil", func(t *testing.T) {
+		cutoff := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+		oldest, err := repo.OldestBefore(ctx, "created_at", &cutoff)
+		require.NoError(t, err)
+		assert.Nil(t, oldest)
+	})
+}
+
+func TestRepository_DeleteOlderThan(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	tenantID := testpkg.UniqueTestTenantID(t)
+	otherTenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	testpkg.EnsureTestTenant(t, db, otherTenantID)
+	defer cleanupTenantSettingValues(t, db, tenantID)
+	defer cleanupTenantSettingValues(t, db, otherTenantID)
+
+	repo := newTenantScopedRepo(db)
+	ctx := testpkg.TenantContext(tenantID)
+
+	older := time.Date(2020, 1, 15, 10, 0, 0, 0, time.UTC)
+	newer := time.Date(2021, 3, 10, 12, 0, 0, 0, time.UTC)
+
+	prefix := uniqueKey("delete_older")
+	expired := createSettingValueForTenant(t, db, tenantID, prefix+"_expired", "v1")
+	kept := createSettingValueForTenant(t, db, tenantID, prefix+"_kept", "v2")
+	foreign := createSettingValueForTenant(t, db, otherTenantID, prefix+"_foreign", "v3")
+	setSettingValueCreatedAt(t, db, expired.ID, older)
+	setSettingValueCreatedAt(t, db, kept.ID, newer)
+	setSettingValueCreatedAt(t, db, foreign.ID, older)
+
+	cutoff := time.Date(2020, 12, 31, 0, 0, 0, 0, time.UTC)
+	deleted, err := repo.DeleteOlderThan(ctx, "created_at", cutoff)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, deleted)
+
+	// The newer row survives.
+	remaining, err := repo.CountWithOptions(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, remaining)
+
+	// The other tenant's expired row is untouched despite matching the cutoff.
+	foreignCount, err := repo.CountWithOptions(testpkg.TenantContext(otherTenantID), nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, foreignCount)
+}
+
+func TestRepository_UpdateColumns(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := base.NewRepository[*configModels.SettingValue](db, baseTestTable, baseTestEntityName)
+	ctx := testpkg.TenantContext(1)
+
+	sv := newSettingValue(uniqueKey("update_columns"), "original", nil)
+	_, err := db.NewInsert().Model(sv).ModelTableExpr(baseTestTable).Exec(ctx)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = db.NewDelete().TableExpr(baseTestTable).Where("id = ?", sv.ID).Exec(ctx)
+	}()
+
+	t.Run("updates only the named columns", func(t *testing.T) {
+		originalKey := sv.SettingKey
+		sv.Value = jsonValue("changed")
+		sv.SettingKey = originalKey + "_mutated_in_memory"
+
+		updated, err := repo.UpdateColumns(ctx, sv, "value")
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, updated)
+
+		found, err := repo.FindByID(ctx, sv.ID)
+		require.NoError(t, err)
+		assert.JSONEq(t, `"changed"`, string(found.Value))
+		assert.Equal(t, originalKey, found.SettingKey, "setting_key must not be written when only value is named")
+
+		sv.SettingKey = originalKey
+	})
+
+	t.Run("returns zero rows for missing entity without error", func(t *testing.T) {
+		ghost := newSettingValue(uniqueKey("update_columns_ghost"), "ghost", nil)
+		ghost.ID = 999999999
+		updated, err := repo.UpdateColumns(ctx, ghost, "value")
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), updated)
+	})
+
+	t.Run("rejects empty column list", func(t *testing.T) {
+		_, err := repo.UpdateColumns(ctx, sv)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least one column required")
+	})
+
+	t.Run("rejects nil entity", func(t *testing.T) {
+		var nilSV *configModels.SettingValue
+		_, err := repo.UpdateColumns(ctx, nilSV, "value")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil or zero value")
+	})
 }

--- a/backend/database/repositories/education/group.go
+++ b/backend/database/repositories/education/group.go
@@ -301,33 +301,3 @@ func (r *GroupRepository) ListWithOptions(ctx context.Context, options *modelBas
 
 	return groups, nil
 }
-
-// CountWithOptions counts groups matching the query options (without pagination)
-func (r *GroupRepository) CountWithOptions(ctx context.Context, options *modelBase.QueryOptions) (int, error) {
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model((*education.Group)(nil)).
-		ModelTableExpr(`education.groups AS "group"`).
-		Column("group.id")
-
-	if where, val, ok := base.TenantWhere(ctx, "group"); ok {
-		query = query.Where(where, val)
-	}
-
-	// Apply only filters (not pagination) for counting
-	if options != nil {
-		if options.Filter != nil {
-			options.Filter.WithTableAlias("group")
-			query = options.Filter.ApplyToQuery(query)
-		}
-	}
-
-	count, err := query.Count(ctx)
-	if err != nil {
-		return 0, &modelBase.DatabaseError{
-			Op:  "count with options",
-			Err: err,
-		}
-	}
-
-	return count, nil
-}

--- a/backend/database/repositories/education/group_substitution.go
+++ b/backend/database/repositories/education/group_substitution.go
@@ -601,3 +601,30 @@ func (r *GroupSubstitutionRepository) FindActiveByGroupWithRelations(ctx context
 
 	return r.ListWithRelations(ctx, options)
 }
+
+// ListActiveSubstitutionBlockers returns the staff member's current or
+// upcoming substitutions (as substitute or regular) as caregiver-capability
+// blocker rows. Custom raw-SQL method (backend-conventions Rule 2):
+// role CASE projection into the users blocker read model.
+func (r *GroupSubstitutionRepository) ListActiveSubstitutionBlockers(ctx context.Context, staffID, tenantID int64) ([]users.BlockerSubstitution, error) {
+	var results []users.BlockerSubstitution
+	err := base.GetDB(ctx, r.db).NewRaw(`
+		SELECT gs.id, COALESCE(g.name, 'Unbekannte Gruppe') AS group_name,
+		       CASE WHEN gs.substitute_staff_id = ? THEN 'substitute' ELSE 'regular' END AS role,
+		       gs.start_date::text AS start_date,
+		       gs.end_date::text AS end_date
+		FROM education.group_substitution AS gs
+		LEFT JOIN education.groups AS g ON g.id = gs.group_id AND g.tenant_id = gs.tenant_id
+		WHERE gs.tenant_id = ?
+		  AND (gs.substitute_staff_id = ? OR gs.regular_staff_id = ?)
+		  AND gs.end_date >= CURRENT_DATE
+		ORDER BY gs.start_date DESC
+	`, staffID, tenantID, staffID, staffID).Scan(ctx, &results)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list active substitution blockers",
+			Err: err,
+		}
+	}
+	return results, nil
+}

--- a/backend/database/repositories/education/group_teacher.go
+++ b/backend/database/repositories/education/group_teacher.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/education"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/uptrace/bun"
 )
 
@@ -173,4 +174,37 @@ func (r *GroupTeacherRepository) ListWithOptions(ctx context.Context, options *m
 	}
 
 	return groupTeachers, nil
+}
+
+// ListGroupTeacherBlockers returns the teacher's group assignments as
+// caregiver-capability blocker rows, including the full teacher set per
+// group (for sole-teacher detection). Custom raw-SQL method
+// (backend-conventions Rule 2): correlated ARRAY_AGG subquery into the
+// users blocker read model.
+func (r *GroupTeacherRepository) ListGroupTeacherBlockers(ctx context.Context, teacherID, tenantID int64) ([]userModels.BlockerGroup, error) {
+	var results []userModels.BlockerGroup
+	err := base.GetDB(ctx, r.db).NewRaw(`
+		SELECT gt.id,
+		       gt.group_id,
+		       COALESCE(g.name, 'Unbekannte Gruppe') AS group_name,
+		       gt.teacher_id,
+		       COALESCE((
+		           SELECT ARRAY_AGG(gt_all.teacher_id ORDER BY gt_all.id)
+		           FROM education.group_teacher AS gt_all
+		           WHERE gt_all.tenant_id = gt.tenant_id
+		             AND gt_all.group_id = gt.group_id
+		       ), '{}'::bigint[]) AS teacher_ids
+		FROM education.group_teacher AS gt
+		LEFT JOIN education.groups AS g ON g.id = gt.group_id AND g.tenant_id = gt.tenant_id
+		WHERE gt.tenant_id = ?
+		  AND gt.teacher_id = ?
+		ORDER BY g.name ASC
+	`, tenantID, teacherID).Scan(ctx, &results)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list group teacher blockers",
+			Err: err,
+		}
+	}
+	return results, nil
 }

--- a/backend/database/repositories/enrollment/request_repository.go
+++ b/backend/database/repositories/enrollment/request_repository.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/models/enrollment"
@@ -221,4 +222,42 @@ func (r *RequestRepository) FindByStatusToken(ctx context.Context, token string)
 		return nil, fmt.Errorf("failed to find enrollment request by token: %w", err)
 	}
 	return req, nil
+}
+
+// UpdateGuardianData writes the guardian-editable fields of the request
+// (names, phone, consent flags, custom answers) and bumps updated_at.
+// Custom method (backend-conventions Rule 2): fixed multi-column projection
+// for the parent-portal edit flow.
+func (r *RequestRepository) UpdateGuardianData(ctx context.Context, req *enrollment.Request) error {
+	_, err := base.GetDB(ctx, r.db).NewUpdate().
+		Model(req).
+		ModelTableExpr(requestTableExpr).
+		Set("guardian_first_name = ?", req.GuardianFirstName).
+		Set("guardian_last_name = ?", req.GuardianLastName).
+		Set("guardian_phone = ?", req.GuardianPhone).
+		Set("consent_flags = ?", req.ConsentFlags).
+		Set("custom_data = ?", req.CustomData).
+		Set("updated_at = NOW()").
+		Where(`"request".id = ?`, req.ID).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to update guardian data: %w", err)
+	}
+	return nil
+}
+
+// MarkWithdrawn stamps withdrawn_at on the request and bumps updated_at.
+// Used by the parent-portal withdraw flow once every child is withdrawn.
+func (r *RequestRepository) MarkWithdrawn(ctx context.Context, requestID int64, withdrawnAt time.Time) error {
+	_, err := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*enrollment.Request)(nil)).
+		ModelTableExpr(requestTableExpr).
+		Set("withdrawn_at = ?", withdrawnAt).
+		Set("updated_at = NOW()").
+		Where(`"request".id = ?`, requestID).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to mark request withdrawn: %w", err)
+	}
+	return nil
 }

--- a/backend/database/repositories/facilities/room.go
+++ b/backend/database/repositories/facilities/room.go
@@ -330,3 +330,93 @@ func (r *RoomRepository) SearchByText(ctx context.Context, searchText string) ([
 
 	return rooms, nil
 }
+
+// occupancyColumns adds the shared occupancy projection used by
+// FindWithOccupancy and ListWithOccupancy. Aggregates across ALL active
+// groups in the room (not a single arbitrary one) so the list and detail
+// surfaces stay consistent for multi-group rooms (#1374).
+func occupancyColumns(q *bun.SelectQuery) *bun.SelectQuery {
+	return q.
+		ColumnExpr("r.id, r.name, r.building, r.floor, r.capacity, r.category, r.color, r.created_at, r.updated_at").
+		ColumnExpr(`EXISTS (
+			SELECT 1 FROM active.groups ag
+			WHERE ag.room_id = r.id AND ag.end_time IS NULL
+		) AS is_occupied`).
+		ColumnExpr(`(
+			SELECT string_agg(DISTINCT act_group.name, ', ' ORDER BY act_group.name)
+			FROM active.groups ag
+			INNER JOIN activities.groups act_group ON act_group.id = ag.group_id
+			WHERE ag.room_id = r.id AND ag.end_time IS NULL
+		) AS group_name`).
+		ColumnExpr(`(
+			SELECT string_agg(DISTINCT cat.name, ', ' ORDER BY cat.name)
+			FROM active.groups ag
+			INNER JOIN activities.groups act_group ON act_group.id = ag.group_id
+			INNER JOIN activities.categories cat ON cat.id = act_group.category_id
+			WHERE ag.room_id = r.id AND ag.end_time IS NULL
+		) AS category_name`).
+		ColumnExpr(`COALESCE((
+			SELECT COUNT(DISTINCT v.student_id)
+			FROM active.visits v
+			INNER JOIN active.groups ag ON ag.id = v.active_group_id
+			WHERE ag.room_id = r.id AND ag.end_time IS NULL AND v.exit_time IS NULL
+		), 0)::int AS student_count`).
+		ColumnExpr(`(
+			SELECT string_agg(DISTINCT CONCAT(p.first_name, ' ', p.last_name), ', ')
+			FROM active.group_supervisors gs
+			INNER JOIN active.groups ag ON ag.id = gs.group_id
+			INNER JOIN users.staff st ON st.id = gs.staff_id
+			INNER JOIN users.persons p ON p.id = st.person_id
+			WHERE ag.room_id = r.id AND ag.end_time IS NULL AND gs.end_date IS NULL
+		) AS supervisor_names`)
+}
+
+// FindWithOccupancy returns the room row plus its live occupancy aggregate.
+// Custom method (backend-conventions Rule 2): correlated subqueries over
+// active.groups / visits / supervisors that the generic shape cannot
+// express. The not-found case surfaces as a wrapped sql.ErrNoRows.
+func (r *RoomRepository) FindWithOccupancy(ctx context.Context, id int64) (*facilities.RoomOccupancyRow, error) {
+	var result facilities.RoomOccupancyRow
+	query := occupancyColumns(base.GetDB(ctx, r.db).NewSelect().
+		TableExpr("facilities.rooms AS r")).
+		Where("r.id = ?", id)
+
+	if where, val, ok := base.TenantWhere(ctx, "r"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx, &result); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find room with occupancy",
+			Err: err,
+		}
+	}
+	return &result, nil
+}
+
+// ListWithOccupancy returns every room (optionally filtered) plus its live
+// occupancy aggregate, ordered by name. Same projection as
+// FindWithOccupancy so the list and detail surfaces cannot drift.
+func (r *RoomRepository) ListWithOccupancy(ctx context.Context, options *modelBase.QueryOptions) ([]facilities.RoomOccupancyRow, error) {
+	query := occupancyColumns(base.GetDB(ctx, r.db).NewSelect().
+		TableExpr("facilities.rooms AS r")).
+		OrderExpr("r.name ASC")
+
+	if where, val, ok := base.TenantWhere(ctx, "r"); ok {
+		query = query.Where(where, val)
+	}
+
+	if options != nil && options.Filter != nil {
+		options.Filter.WithTableAlias("r")
+		query = options.Filter.ApplyToQuery(query)
+	}
+
+	var results []facilities.RoomOccupancyRow
+	if err := query.Scan(ctx, &results); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list rooms with occupancy",
+			Err: err,
+		}
+	}
+	return results, nil
+}

--- a/backend/database/repositories/platform/operator_summaries_repository.go
+++ b/backend/database/repositories/platform/operator_summaries_repository.go
@@ -300,3 +300,61 @@ func (r *OperatorSummariesRepository) PersonsByOrganization(ctx context.Context,
 	}
 	return result, nil
 }
+
+const operatorDeviceQuery = `
+SELECT
+	"d".id,
+	"d".device_id,
+	"d".device_type,
+	"d".name,
+	"d".status,
+	"d".api_key,
+	"d".last_seen,
+	"d".created_at,
+	"d".updated_at,
+	"s".id AS school_id,
+	"s".name AS school_name,
+	"o".id AS organization_id,
+	"o".name AS organization_name
+FROM iot.devices AS "d"
+INNER JOIN platform.schools AS "s" ON "s".id = "d".tenant_id
+INNER JOIN platform.organizations AS "o" ON "o".id = "s".organization_id
+`
+
+// ListDeviceRows runs the shared operator device listing with an optional
+// filter (by device row, school, or organization). Custom raw-SQL method
+// (backend-conventions Rule 2): cross-schema join for the operator
+// dashboard, deliberately cross-tenant inside the caller's admin
+// transaction.
+//
+// Devices belonging to a soft-deleted school or organization are filtered
+// out unconditionally so global listings (operator dashboard) never surface
+// entries for tenants that are in the Papierkorb. Detail endpoints
+// (ListSchoolDevices, ListOrganizationDevices) still reject deleted targets
+// via their explicit IsDeleted pre-check before reaching this query; the
+// SQL filter is the safety net for the global ListAllDevices path.
+func (r *OperatorSummariesRepository) ListDeviceRows(ctx context.Context, filter platform.OperatorDeviceFilter) ([]platform.OperatorDeviceRow, error) {
+	q := operatorDeviceQuery + ` WHERE "s".deleted_at IS NULL AND "o".deleted_at IS NULL`
+	var args []interface{}
+	switch {
+	case filter.DeviceRowID != nil:
+		q += ` AND "d".id = ?`
+		args = append(args, *filter.DeviceRowID)
+	case filter.SchoolID != nil:
+		q += ` AND "d".tenant_id = ?`
+		args = append(args, *filter.SchoolID)
+	case filter.OrganizationID != nil:
+		q += ` AND "o".id = ?`
+		args = append(args, *filter.OrganizationID)
+	}
+	q += ` ORDER BY "o".name, "s".name, "d".device_id`
+
+	var result []platform.OperatorDeviceRow
+	if err := base.GetDB(ctx, r.db).NewRaw(q, args...).Scan(ctx, &result); err != nil {
+		return nil, err
+	}
+	if result == nil {
+		result = []platform.OperatorDeviceRow{}
+	}
+	return result, nil
+}

--- a/backend/database/repositories/schedule/activity_instance_repo.go
+++ b/backend/database/repositories/schedule/activity_instance_repo.go
@@ -279,3 +279,43 @@ func (r *ActivityInstanceRepository) FindByActiveGroupID(ctx context.Context, ac
 	}
 	return &instance, nil
 }
+
+// CompleteActiveByActiveGroupIDs marks every still-active instance bridged to
+// one of the given active.groups as completed and returns the number of rows
+// changed. Custom method (backend-conventions Rule 2): lifecycle bulk update
+// keyed on the active-group bridge, paired with MarkCompleted's
+// column-restricted shape. Used by the scheduler's daily session-end bridge.
+func (r *ActivityInstanceRepository) CompleteActiveByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64, completedAt time.Time) (int64, error) {
+	if len(activeGroupIDs) == 0 {
+		return 0, nil
+	}
+
+	q := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*schedule.ActivityInstance)(nil)).
+		ModelTableExpr(modelTblActivityInstance).
+		Set(`status = ?`, schedule.InstanceStatusCompleted).
+		Set(`completed_at = ?`, completedAt).
+		Set(`updated_at = ?`, completedAt).
+		Where(`"activity_instance".status = ?`, schedule.InstanceStatusActive).
+		Where(`"activity_instance".active_group_id IN (?)`, bun.List(activeGroupIDs))
+
+	if where, val, ok := base.TenantWhere(ctx, aliasActivityInstance); ok {
+		q = q.Where(where, val)
+	}
+
+	res, err := q.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "complete active instances by active group ids",
+			Err: err,
+		}
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "complete active instances by active group ids",
+			Err: err,
+		}
+	}
+	return rows, nil
+}

--- a/backend/database/repositories/schedule/activity_instance_repo.go
+++ b/backend/database/repositories/schedule/activity_instance_repo.go
@@ -319,3 +319,33 @@ func (r *ActivityInstanceRepository) CompleteActiveByActiveGroupIDs(ctx context.
 	}
 	return rows, nil
 }
+
+// DeletePlannedNonSpontaneousInWindow removes every still-planned,
+// template-backed instance whose date falls in the inclusive [from, to]
+// window and returns the number of rows deleted. CASCADE removes the
+// instance_staff / instance_students children (declared at DDL level).
+// Custom method (backend-conventions Rule 2): multi-predicate lifecycle
+// delete for the ReplanWeek admin action.
+func (r *ActivityInstanceRepository) DeletePlannedNonSpontaneousInWindow(ctx context.Context, from, to time.Time) (int64, error) {
+	q := base.GetDB(ctx, r.db).NewDelete().
+		Model((*schedule.ActivityInstance)(nil)).
+		ModelTableExpr(modelTblActivityInstance).
+		Where(`"activity_instance".date >= ?`, from).
+		Where(`"activity_instance".date <= ?`, to).
+		Where(`"activity_instance".status = ?`, schedule.InstanceStatusPlanned).
+		Where(`"activity_instance".is_spontaneous = ?`, false)
+
+	if where, val, ok := base.TenantWhere(ctx, aliasActivityInstance); ok {
+		q = q.Where(where, val)
+	}
+
+	res, err := q.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "delete planned non-spontaneous in window",
+			Err: err,
+		}
+	}
+	deleted, _ := res.RowsAffected() // nil-driver-safe: fall through with 0
+	return deleted, nil
+}

--- a/backend/database/repositories/schedule/instance_student_repo.go
+++ b/backend/database/repositories/schedule/instance_student_repo.go
@@ -357,3 +357,69 @@ func (r *InstanceStudentRepository) DeleteByInstanceID(ctx context.Context, inst
 	}
 	return nil
 }
+
+// MarkExpectedAbsentByActiveGroupIDs flips status 'expected' → 'absent' for
+// students on still-active instances bridged to the given active.groups.
+// Custom method (backend-conventions Rule 2): the subquery join on
+// activity_instances is not expressible through the generic filter shape.
+// Used by the scheduler's daily session-end bridge.
+func (r *InstanceStudentRepository) MarkExpectedAbsentByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64, updatedAt time.Time) error {
+	if len(activeGroupIDs) == 0 {
+		return nil
+	}
+
+	q := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*schedule.InstanceStudent)(nil)).
+		ModelTableExpr(modelTblInstanceStudent).
+		Set(`status = ?`, schedule.AttendanceStatusAbsent).
+		Set(`updated_at = ?`, updatedAt).
+		Where(`"instance_student".status = ?`, schedule.AttendanceStatusExpected).
+		Where(`"instance_student".instance_id IN (
+			SELECT "instance".id
+			FROM schedule.activity_instances AS "instance"
+			WHERE "instance".status = ?
+				AND "instance".active_group_id IN (?)
+		)`, schedule.InstanceStatusActive, bun.List(activeGroupIDs))
+
+	if where, val, ok := base.TenantWhere(ctx, aliasInstanceStudent); ok {
+		q = q.Where(where, val)
+	}
+
+	if _, err := q.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{
+			Op:  "mark expected absent by active group ids",
+			Err: err,
+		}
+	}
+	return nil
+}
+
+// ListStudentInstanceRefsBefore returns (student_id, instance_id) pairs for
+// attendance rows whose instance date is before the cutoff, ordered by
+// student then instance. Custom projection (backend-conventions Rule 2): the
+// join on activity_instances for the date predicate is not expressible
+// through the generic filter shape. Feeds the per-student audit rows of the
+// timetable retention cleanup.
+func (r *InstanceStudentRepository) ListStudentInstanceRefsBefore(ctx context.Context, cutoff time.Time) ([]schedule.StudentInstanceRef, error) {
+	var rows []schedule.StudentInstanceRef
+
+	q := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`schedule.instance_students AS i_s`).
+		ColumnExpr(`i_s.student_id AS student_id`).
+		ColumnExpr(`i_s.instance_id AS instance_id`).
+		Join(`JOIN schedule.activity_instances AS i ON i.id = i_s.instance_id`).
+		Where(`i.date < ?`, cutoff).
+		Order("i_s.student_id", "i_s.instance_id")
+
+	if where, val, ok := base.TenantWhere(ctx, "i"); ok {
+		q = q.Where(where, val)
+	}
+
+	if err := q.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list student instance refs before",
+			Err: err,
+		}
+	}
+	return rows, nil
+}

--- a/backend/database/repositories/users/person.go
+++ b/backend/database/repositories/users/person.go
@@ -492,3 +492,31 @@ func applyNullableFieldFilter(filter *modelBase.Filter, column string, value int
 		}
 	}
 }
+
+// AnonymizeAndSoftDelete overwrites the person's PII with placeholder values
+// and stamps deleted_at. Custom method (backend-conventions Rule 2): GDPR
+// person-deletion step combining anonymization and soft delete in one
+// statement; used by operator SoftDeletePerson. Cross-tenant by design when
+// the context carries no tenant (operator admin transactions).
+func (r *PersonRepository) AnonymizeAndSoftDelete(ctx context.Context, personID int64) error {
+	query := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*users.Person)(nil)).
+		ModelTableExpr(`users.persons AS "person"`).
+		Set(`first_name = ?`, "Gelöscht").
+		Set(`last_name = ?`, "Benutzer").
+		Set(`birthday = NULL`).
+		Set(`deleted_at = NOW()`).
+		Where(`"person".id = ?`, personID)
+
+	if where, val, ok := base.TenantWhere(ctx, "person"); ok {
+		query = query.Where(where, val)
+	}
+
+	if _, err := query.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{
+			Op:  "anonymize and soft delete person",
+			Err: err,
+		}
+	}
+	return nil
+}

--- a/backend/database/repositories/users/student.go
+++ b/backend/database/repositories/users/student.go
@@ -448,40 +448,6 @@ func (r *StudentRepository) ListWithOptions(ctx context.Context, options *modelB
 	return students, nil
 }
 
-// CountWithOptions counts students matching the query options
-func (r *StudentRepository) CountWithOptions(ctx context.Context, options *modelBase.QueryOptions) (int, error) {
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model((*users.Student)(nil)).
-		ModelTableExpr(tableExprUsersStudentsAsStudent).
-		Column("student.id")
-
-	if where, val, ok := base.TenantWhere(ctx, "student"); ok {
-		query = query.Where(where, val)
-	}
-
-	// Apply query options with table alias
-	if options != nil {
-		if options.Filter != nil {
-			options.Filter.WithTableAlias("student")
-			query = options.Filter.ApplyToQuery(query)
-		}
-		// Apply sorting if needed (but not pagination for counting)
-		if options.Sorting != nil {
-			query = options.Sorting.ApplyToQuery(query)
-		}
-	}
-
-	count, err := query.Count(ctx)
-	if err != nil {
-		return 0, &modelBase.DatabaseError{
-			Op:  "count with options",
-			Err: err,
-		}
-	}
-
-	return count, nil
-}
-
 // CountByGroupIDs counts students per group for multiple groups in a single query
 func (r *StudentRepository) CountByGroupIDs(ctx context.Context, groupIDs []int64) (map[int64]int, error) {
 	if len(groupIDs) == 0 {

--- a/backend/database/repositories/users/student_guardian.go
+++ b/backend/database/repositories/users/student_guardian.go
@@ -506,3 +506,46 @@ func (r *StudentGuardianRepository) FindWithStudentAndPerson(ctx context.Context
 
 	return relationship, nil
 }
+
+// ListEmergencyContactRows returns one row per (guardian, phone number) for
+// the given students, ordered so that emergency contacts, primary guardians,
+// and primary/priority phone numbers come first. The caller aggregates the
+// rows into display strings. Custom method (backend-conventions Rule 2):
+// three-table join with NULLS LAST ordering for the emergency list.
+func (r *StudentGuardianRepository) ListEmergencyContactRows(ctx context.Context, studentIDs []int64) ([]users.GuardianEmergencyContactRow, error) {
+	if len(studentIDs) == 0 {
+		return nil, nil
+	}
+
+	var rows []users.GuardianEmergencyContactRow
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`users.students_guardians AS "student_guardian"`).
+		ColumnExpr(`"student_guardian".student_id`).
+		ColumnExpr(`"guardian".first_name`).
+		ColumnExpr(`"guardian".last_name`).
+		ColumnExpr(`"phone".phone_number`).
+		Join(`JOIN users.guardian_profiles AS "guardian" ON "guardian".id = "student_guardian".guardian_profile_id`).
+		Join(`LEFT JOIN users.guardian_phone_numbers AS "phone" ON "phone".guardian_profile_id = "guardian".id`).
+		Where(`"student_guardian".student_id IN (?)`, bun.List(studentIDs)).
+		OrderExpr(`"student_guardian".is_emergency_contact DESC`).
+		OrderExpr(`"student_guardian".is_primary DESC`).
+		OrderExpr(`"student_guardian".emergency_priority ASC`).
+		OrderExpr(`"phone".is_primary DESC NULLS LAST`).
+		OrderExpr(`"phone".priority ASC NULLS LAST`).
+		OrderExpr(`"student_guardian".student_id ASC`).
+		OrderExpr(`"guardian".id ASC`)
+
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where(`"student_guardian".tenant_id = ?`, tenantID)
+		query = query.Where(`"guardian".tenant_id = ?`, tenantID)
+		query = query.Where(`("phone".tenant_id = ? OR "phone".tenant_id IS NULL)`, tenantID)
+	}
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list emergency contact rows",
+			Err: err,
+		}
+	}
+	return rows, nil
+}

--- a/backend/database/repositories/users/teacher.go
+++ b/backend/database/repositories/users/teacher.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
 
@@ -455,4 +457,83 @@ func (r *TeacherRepository) FindWithStaffAndPersonByIDs(ctx context.Context, ids
 	}
 
 	return teachers, nil
+}
+
+// activeCaregiverQuery builds the canonical operational caregiver lookup:
+// teachers joined through staff/person/account to active tenant mappings and
+// the system "user"/"teacher" roles. Shared by ListActiveCaregivers and
+// FindActiveCaregiverByAccountID. Custom query (backend-conventions Rule 2):
+// seven-table join projecting into the ActiveCaregiver read model.
+func (r *TeacherRepository) activeCaregiverQuery(ctx context.Context) *bun.SelectQuery {
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model((*users.ActiveCaregiver)(nil)).
+		ModelTableExpr(`users.teachers AS "teacher"`).
+		ColumnExpr(`"account".id AS account_id`).
+		ColumnExpr(`"person".id AS person_id`).
+		ColumnExpr(`"staff".id AS staff_id`).
+		ColumnExpr(`"teacher".id AS teacher_id`).
+		ColumnExpr(`"person".first_name`).
+		ColumnExpr(`"person".last_name`).
+		ColumnExpr(`"account".email`).
+		ColumnExpr(`"staff".created_at`).
+		ColumnExpr(`"staff".updated_at`).
+		Join(`INNER JOIN users.staff AS "staff" ON "staff".id = "teacher".staff_id`).
+		Join(`INNER JOIN users.persons AS "person" ON "person".id = "staff".person_id`).
+		Join(`INNER JOIN auth.accounts AS "account" ON "account".id = "person".account_id`).
+		Join(`INNER JOIN auth.account_tenants AS "at" ON "at".account_id = "account".id AND "at".tenant_id = "teacher".tenant_id`).
+		Join(`INNER JOIN auth.account_roles AS "ar" ON "ar".account_id = "account".id AND "ar".tenant_id = "teacher".tenant_id`).
+		Join(`INNER JOIN auth.roles AS "role" ON "role".id = "ar".role_id`).
+		Where(`"account".active = TRUE`).
+		Where(`"at".status = ?`, authModels.AccountTenantStatusActive).
+		Where(`"role".is_system = TRUE`).
+		Where(`"role".tenant_id IS NULL`).
+		Where(`LOWER("role".name) IN (?, ?)`, "user", "teacher").
+		Distinct()
+
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.
+			Where(`"at".tenant_id = ?`, tenantID).
+			Where(`"teacher".tenant_id = ?`, tenantID).
+			Where(`"staff".tenant_id = ?`, tenantID).
+			Where(`"person".tenant_id = ?`, tenantID).
+			Where(`"ar".tenant_id = ?`, tenantID)
+	}
+
+	return query
+}
+
+// ListActiveCaregivers returns every active caregiver for the tenant in
+// context, ordered by name then staff id.
+func (r *TeacherRepository) ListActiveCaregivers(ctx context.Context) ([]*users.ActiveCaregiver, error) {
+	var caregivers []*users.ActiveCaregiver
+	query := r.activeCaregiverQuery(ctx).
+		OrderExpr(`"person".first_name ASC, "person".last_name ASC, "staff".id ASC`)
+
+	if err := query.Scan(ctx, &caregivers); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list active caregivers",
+			Err: err,
+		}
+	}
+	return caregivers, nil
+}
+
+// FindActiveCaregiverByAccountID returns the active caregiver bound to the
+// account, or nil when the account is not an active caregiver.
+func (r *TeacherRepository) FindActiveCaregiverByAccountID(ctx context.Context, accountID int64) (*users.ActiveCaregiver, error) {
+	var caregivers []*users.ActiveCaregiver
+	query := r.activeCaregiverQuery(ctx).
+		Where(`"account".id = ?`, accountID).
+		Limit(1)
+
+	if err := query.Scan(ctx, &caregivers); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find active caregiver by account ID",
+			Err: err,
+		}
+	}
+	if len(caregivers) == 0 {
+		return nil, nil
+	}
+	return caregivers[0], nil
 }

--- a/backend/models/active/attendance.go
+++ b/backend/models/active/attendance.go
@@ -131,6 +131,16 @@ type AttendanceRepository interface {
 	// attendance row for the given date.
 	ListOpenStudentIDsForDate(ctx context.Context, date time.Time) ([]int64, error)
 
+	// FindStaleOpen returns attendance rows dated before the given day that
+	// still lack a check-out time. Feeds the nightly stale-attendance
+	// cleanup and its preview.
+	FindStaleOpen(ctx context.Context, before time.Time) ([]*Attendance, error)
+
+	// UpdateColumns is the generic partial-update helper promoted from the
+	// embedded base repository: updates only the named columns by primary
+	// key and returns the number of rows affected.
+	UpdateColumns(ctx context.Context, attendance *Attendance, columns ...string) (int64, error)
+
 	// CountByStaffID counts attendance records where the staff member checked in or checked out students
 	CountByStaffID(ctx context.Context, staffID int64) (int, error)
 }

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -5,11 +5,16 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/users"
 )
 
 // GroupRepository defines operations for managing active groups
 type GroupRepository interface {
 	base.Repository[*Group]
+
+	// CountWithOptions is the generic filtered count promoted from the
+	// embedded base repository.
+	CountWithOptions(ctx context.Context, options *base.QueryOptions) (int, error)
 
 	// FindActiveByRoomID finds all active groups in a specific room
 	FindActiveByRoomID(ctx context.Context, roomID int64) ([]*Group, error)
@@ -100,6 +105,10 @@ type VisitRepository interface {
 	// FindActiveByStudentID finds all active visits for a specific student
 	FindActiveByStudentID(ctx context.Context, studentID int64) ([]*Visit, error)
 
+	// GetCurrentRoomNamesForStudents returns the room name of each student's
+	// current open visit; students without one are absent from the map.
+	GetCurrentRoomNamesForStudents(ctx context.Context, studentIDs []int64) (map[int64]string, error)
+
 	// FindByActiveGroupID finds all visits for a specific active group
 	FindByActiveGroupID(ctx context.Context, activeGroupID int64) ([]*Visit, error)
 
@@ -175,6 +184,10 @@ type VisitRepository interface {
 // GroupSupervisorRepository defines operations for managing active group supervisors
 type GroupSupervisorRepository interface {
 	base.Repository[*GroupSupervisor]
+
+	// ListActiveSupervisionBlockers returns still-open supervisions as
+	// caregiver-capability blocker rows.
+	ListActiveSupervisionBlockers(ctx context.Context, staffID, tenantID int64) ([]users.BlockerSupervision, error)
 
 	// FindActiveByStaffID finds all active supervisions for a specific staff member
 	FindActiveByStaffID(ctx context.Context, staffID int64) ([]*GroupSupervisor, error)

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -280,6 +280,12 @@ type WorkSessionRepository interface {
 
 	// UpdateBreakMinutes sets the break_minutes cache field on a session
 	UpdateBreakMinutes(ctx context.Context, id int64, breakMinutes int) error
+
+	// Generic query helpers promoted from the embedded base repository.
+	// Used by the time-tracking retention cleanup.
+	CountWithOptions(ctx context.Context, options *base.QueryOptions) (int, error)
+	OldestBefore(ctx context.Context, dateColumn string, cutoff *time.Time) (*time.Time, error)
+	DeleteOlderThan(ctx context.Context, dateColumn string, cutoff time.Time) (int64, error)
 }
 
 // StaffAbsenceRepository defines operations for managing staff absences
@@ -304,6 +310,12 @@ type StaffAbsenceRepository interface {
 
 	// ListByStaffAndStatuses returns absences for one staff member filtered by status set
 	ListByStaffAndStatuses(ctx context.Context, staffID int64, statuses []string) ([]*StaffAbsence, error)
+
+	// Generic query helpers promoted from the embedded base repository.
+	// Used by the time-tracking retention cleanup.
+	CountWithOptions(ctx context.Context, options *base.QueryOptions) (int, error)
+	OldestBefore(ctx context.Context, dateColumn string, cutoff *time.Time) (*time.Time, error)
+	DeleteOlderThan(ctx context.Context, dateColumn string, cutoff time.Time) (int64, error)
 }
 
 type StaffAbsenceAuditRepository interface {

--- a/backend/models/active/student_status_day.go
+++ b/backend/models/active/student_status_day.go
@@ -79,6 +79,15 @@ func (s *StudentStatusDay) TableName() string       { return tableActiveStudentS
 
 type StudentStatusDayRepository interface {
 	UpsertReported(ctx context.Context, entry *StudentStatusDay) error
+	// ArchiveAndClearStatusFlag archives a legacy boolean student flag into
+	// student_status_days for the date and clears the flag on
+	// users.students. Returns the number of students cleared. Column names
+	// must be trusted constants, never user input.
+	ArchiveAndClearStatusFlag(ctx context.Context, flagColumn, sinceColumn, status string, date, reportedFallback time.Time, source string) (int64, error)
+	// CountActiveClassTripStudents counts distinct students with an
+	// uncleared class-trip entry for the date, excluding currently
+	// sick/excused students. Used by the dashboard analytics.
+	CountActiveClassTripStudents(ctx context.Context, date time.Time) (int, error)
 	MarkCleared(ctx context.Context, studentID int64, status string, date time.Time, clearedAt time.Time, source string) error
 	MarkClearedByID(ctx context.Context, id int64, clearedAt time.Time, source string) error
 	MarkClearedForDates(ctx context.Context, studentID int64, status string, dates []time.Time, clearedAt time.Time, source string) error

--- a/backend/models/activities/repository.go
+++ b/backend/models/activities/repository.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/users"
 )
 
 // CategoryRepository defines operations for managing activity categories
@@ -93,6 +94,10 @@ type ScheduleRepository interface {
 // SupervisorPlannedRepository defines operations for managing activity supervisors
 type SupervisorPlannedRepository interface {
 	base.Repository[*SupervisorPlanned]
+
+	// ListPlannedSupervisionBlockers returns planned activity supervisions
+	// as caregiver-capability blocker rows.
+	ListPlannedSupervisionBlockers(ctx context.Context, staffID, tenantID int64) ([]users.BlockerActivity, error)
 
 	// FindByStaffID finds all supervisions for a specific staff member
 	FindByStaffID(ctx context.Context, staffID int64) ([]*SupervisorPlanned, error)

--- a/backend/models/auth/repository.go
+++ b/backend/models/auth/repository.go
@@ -22,6 +22,9 @@ type AccountRepository interface {
 	FindAccountsWithRolesAndPermissions(ctx context.Context, filters map[string]interface{}) ([]*Account, error)
 	FindEmailsByAccountIDs(ctx context.Context, accountIDs []int64) (map[int64]string, error)
 	FindAvatarsByAccountIDs(ctx context.Context, accountIDs []int64) (map[int64]string, error)
+	// AnonymizeForDeletion overwrites the email with an anonymized
+	// placeholder and clears the username (GDPR person deletion).
+	AnonymizeForDeletion(ctx context.Context, accountID int64, anonymizedEmail string) error
 	// IncrementMFAAttempts atomically bumps mfa_attempts by one and sets
 	// mfa_locked_until = now() + lockoutDuration when the post-increment
 	// value reaches threshold. The CAS-style UPDATE means N concurrent

--- a/backend/models/education/repository.go
+++ b/backend/models/education/repository.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/users"
 )
 
 // GroupRepository defines operations for managing education groups
@@ -33,11 +34,17 @@ type GroupTeacherRepository interface {
 	FindByGroup(ctx context.Context, groupID int64) ([]*GroupTeacher, error)
 	FindByTeacher(ctx context.Context, teacherID int64) ([]*GroupTeacher, error)
 	FindByGroupIDs(ctx context.Context, groupIDs []int64) ([]*GroupTeacher, error)
+	// ListGroupTeacherBlockers returns group assignments as
+	// caregiver-capability blocker rows.
+	ListGroupTeacherBlockers(ctx context.Context, teacherID, tenantID int64) ([]users.BlockerGroup, error)
 }
 
 // GroupSubstitutionRepository defines operations for managing group substitutions
 type GroupSubstitutionRepository interface {
 	Create(ctx context.Context, substitution *GroupSubstitution) error
+	// ListActiveSubstitutionBlockers returns current/upcoming substitutions
+	// as caregiver-capability blocker rows.
+	ListActiveSubstitutionBlockers(ctx context.Context, staffID, tenantID int64) ([]users.BlockerSubstitution, error)
 	FindByID(ctx context.Context, id interface{}) (*GroupSubstitution, error)
 	Update(ctx context.Context, substitution *GroupSubstitution) error
 	Delete(ctx context.Context, id interface{}) error

--- a/backend/models/enrollment/request.go
+++ b/backend/models/enrollment/request.go
@@ -92,6 +92,13 @@ type RequestRepository interface {
 	// flows never call it.
 	ListAdmin(ctx context.Context, filters RequestListFilters) ([]*Request, error)
 
+	// UpdateGuardianData writes the guardian-editable fields (names, phone,
+	// consent flags, custom answers) and bumps updated_at.
+	UpdateGuardianData(ctx context.Context, req *Request) error
+
+	// MarkWithdrawn stamps withdrawn_at and bumps updated_at.
+	MarkWithdrawn(ctx context.Context, requestID int64, withdrawnAt time.Time) error
+
 	// FindActiveDuplicate returns the names of any children for which a
 	// non-terminal-rejected/withdrawn enrollment already exists for the
 	// same (phase_id, guardian_email). Empty result means safe to

--- a/backend/models/facilities/repository.go
+++ b/backend/models/facilities/repository.go
@@ -2,6 +2,9 @@ package facilities
 
 import (
 	"context"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
 )
 
 // RoomRepository defines the interface for room repository operations
@@ -14,6 +17,13 @@ type RoomRepository interface {
 
 	// FindByName retrieves a room by its name (case-insensitive).
 	FindByName(ctx context.Context, name string) (*Room, error)
+
+	// FindWithOccupancy returns the room plus its live occupancy aggregate.
+	FindWithOccupancy(ctx context.Context, id int64) (*RoomOccupancyRow, error)
+
+	// ListWithOccupancy returns rooms (optionally filtered) plus their live
+	// occupancy aggregates, ordered by name.
+	ListWithOccupancy(ctx context.Context, options *base.QueryOptions) ([]RoomOccupancyRow, error)
 
 	// FindByBuilding retrieves rooms by building
 	FindByBuilding(ctx context.Context, building string) ([]*Room, error)
@@ -32,4 +42,24 @@ type RoomRepository interface {
 
 	// List retrieves rooms matching the filters
 	List(ctx context.Context, filters map[string]interface{}) ([]*Room, error)
+}
+
+// RoomOccupancyRow is the room + live-occupancy projection returned by the
+// occupancy lookups; the service maps it onto its RoomWithOccupancy view.
+type RoomOccupancyRow struct {
+	ID        int64     `bun:"id"`
+	Name      string    `bun:"name"`
+	Building  string    `bun:"building"`
+	Floor     *int      `bun:"floor"`
+	Capacity  *int      `bun:"capacity"`
+	Category  *string   `bun:"category"`
+	Color     *string   `bun:"color"`
+	CreatedAt time.Time `bun:"created_at"`
+	UpdatedAt time.Time `bun:"updated_at"`
+
+	IsOccupied      bool    `bun:"is_occupied"`
+	GroupName       *string `bun:"group_name"`
+	CategoryName    *string `bun:"category_name"`
+	StudentCount    int     `bun:"student_count"`
+	SupervisorNames *string `bun:"supervisor_names"`
 }

--- a/backend/models/platform/operator_views.go
+++ b/backend/models/platform/operator_views.go
@@ -97,6 +97,11 @@ type OperatorPersonInfo struct {
 // query that participates in any transaction stored on the context via
 // modelBase.ContextWithTx, so it composes with TenantTx/AdminTx middleware.
 type OperatorSummariesRepository interface {
+	// ListDeviceRows returns the operator device listing (optionally
+	// filtered by device row, school, or organization), excluding devices
+	// of soft-deleted schools/organizations.
+	ListDeviceRows(ctx context.Context, filter OperatorDeviceFilter) ([]OperatorDeviceRow, error)
+
 	// Stats returns platform-wide counts (Träger, Schulen, Konten, Geräte).
 	// Konten count is DISTINCT account_id across all active account-tenant
 	// memberships; the same account active in multiple schools counts once.
@@ -122,4 +127,33 @@ type OperatorSummariesRepository interface {
 	// PersonsByOrganization returns non-deleted persons across every school
 	// belonging to the given organization with school/org context on each row.
 	PersonsByOrganization(ctx context.Context, organizationID int64) ([]OperatorPersonInfo, error)
+}
+
+// OperatorDeviceRow is one device in the operator device listings, joined
+// with its school and organization. MaskedAPIKey and IsOnline are derived
+// presentation fields the service computes after the read.
+type OperatorDeviceRow struct {
+	ID               int64      `bun:"id" json:"id"`
+	DeviceID         string     `bun:"device_id" json:"device_id"`
+	DeviceType       string     `bun:"device_type" json:"device_type"`
+	Name             *string    `bun:"name" json:"name,omitempty"`
+	Status           string     `bun:"status" json:"status"`
+	APIKey           *string    `bun:"api_key" json:"api_key,omitempty"`
+	MaskedAPIKey     string     `bun:"-" json:"masked_api_key"`
+	LastSeen         *time.Time `bun:"last_seen" json:"last_seen,omitempty"`
+	IsOnline         bool       `bun:"-" json:"is_online"`
+	SchoolID         int64      `bun:"school_id" json:"school_id"`
+	SchoolName       string     `bun:"school_name" json:"school_name"`
+	OrganizationID   int64      `bun:"organization_id" json:"organization_id"`
+	OrganizationName string     `bun:"organization_name" json:"organization_name"`
+	CreatedAt        time.Time  `bun:"created_at" json:"created_at"`
+	UpdatedAt        time.Time  `bun:"updated_at" json:"updated_at"`
+}
+
+// OperatorDeviceFilter narrows the operator device listing. At most one
+// field is set; the zero value lists every device.
+type OperatorDeviceFilter struct {
+	DeviceRowID    *int64
+	SchoolID       *int64
+	OrganizationID *int64
 }

--- a/backend/models/schedule/activity_exception.go
+++ b/backend/models/schedule/activity_exception.go
@@ -135,4 +135,10 @@ type ActivityExceptionRepository interface {
 	// inclusive range. Used by the materialization service to apply exceptions
 	// efficiently for an entire week.
 	FindByDateRange(ctx context.Context, from, to time.Time) ([]*ActivityException, error)
+
+	// Generic query helpers promoted from the embedded base repository.
+	// Used by the timetable retention cleanup.
+	CountWithOptions(ctx context.Context, options *base.QueryOptions) (int, error)
+	OldestBefore(ctx context.Context, dateColumn string, cutoff *time.Time) (*time.Time, error)
+	DeleteOlderThan(ctx context.Context, dateColumn string, cutoff time.Time) (int64, error)
 }

--- a/backend/models/schedule/activity_instance.go
+++ b/backend/models/schedule/activity_instance.go
@@ -166,6 +166,17 @@ type ActivityInstanceRepository interface {
 	// rows changed. Used by the scheduler's daily session-end bridge.
 	CompleteActiveByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64, completedAt time.Time) (int64, error)
 
+	// DeletePlannedNonSpontaneousInWindow removes still-planned,
+	// template-backed instances in the inclusive [from, to] window and
+	// returns the number of rows deleted. Used by ReplanWeek.
+	DeletePlannedNonSpontaneousInWindow(ctx context.Context, from, to time.Time) (int64, error)
+
+	// UpdateColumns is the generic partial-update helper promoted from the
+	// embedded base repository: updates only the named columns by primary
+	// key. Lifecycle transitions use it because SQL TIME columns do not
+	// round-trip safely through a full-row Update.
+	UpdateColumns(ctx context.Context, instance *ActivityInstance, columns ...string) (int64, error)
+
 	// Generic query helpers promoted from the embedded base repository.
 	// Used by the timetable retention cleanup.
 	CountWithOptions(ctx context.Context, options *base.QueryOptions) (int, error)

--- a/backend/models/schedule/activity_instance.go
+++ b/backend/models/schedule/activity_instance.go
@@ -160,4 +160,15 @@ type ActivityInstanceRepository interface {
 	// Update for DB-loaded instances because SQL TIME columns do not round-trip
 	// safely through Bun.
 	MarkCompleted(ctx context.Context, instanceID int64, completedAt time.Time) error
+
+	// CompleteActiveByActiveGroupIDs marks every still-active instance bridged
+	// to one of the given active.groups as completed and returns the number of
+	// rows changed. Used by the scheduler's daily session-end bridge.
+	CompleteActiveByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64, completedAt time.Time) (int64, error)
+
+	// Generic query helpers promoted from the embedded base repository.
+	// Used by the timetable retention cleanup.
+	CountWithOptions(ctx context.Context, options *base.QueryOptions) (int, error)
+	OldestBefore(ctx context.Context, dateColumn string, cutoff *time.Time) (*time.Time, error)
+	DeleteOlderThan(ctx context.Context, dateColumn string, cutoff time.Time) (int64, error)
 }

--- a/backend/models/schedule/instance_student.go
+++ b/backend/models/schedule/instance_student.go
@@ -215,4 +215,23 @@ type InstanceStudentRepository interface {
 	// non-cancelled materialized timetable row on the given date. Used by
 	// student search's "kommt heute" heuristic as an additive planning signal.
 	FindPlannedStudentIDsByDate(ctx context.Context, studentIDs []int64, date time.Time) ([]int64, error)
+
+	// MarkExpectedAbsentByActiveGroupIDs flips status 'expected' → 'absent'
+	// for students on still-active instances bridged to the given
+	// active.groups. Used by the scheduler's daily session-end bridge.
+	MarkExpectedAbsentByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64, updatedAt time.Time) error
+
+	// ListStudentInstanceRefsBefore returns (student_id, instance_id) pairs
+	// for attendance rows whose instance date is before the cutoff, ordered
+	// by student then instance. Custom projection (join on activity_instances)
+	// the generic filter shape cannot express; feeds the per-student audit
+	// rows of the timetable retention cleanup.
+	ListStudentInstanceRefsBefore(ctx context.Context, cutoff time.Time) ([]StudentInstanceRef, error)
+}
+
+// StudentInstanceRef is a minimal (student, instance) projection used by the
+// timetable retention cleanup's audit bookkeeping.
+type StudentInstanceRef struct {
+	StudentID  int64 `bun:"student_id"`
+	InstanceID int64 `bun:"instance_id"`
 }

--- a/backend/models/users/repository.go
+++ b/backend/models/users/repository.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -74,6 +75,10 @@ type PersonRepository interface {
 
 	// FindWithAccount retrieves a person with their associated account
 	FindWithAccount(ctx context.Context, id int64) (*Person, error)
+
+	// AnonymizeAndSoftDelete overwrites the person's PII with placeholder
+	// values and stamps deleted_at (GDPR person deletion).
+	AnonymizeAndSoftDelete(ctx context.Context, personID int64) error
 }
 
 // StudentRepository defines operations for managing students
@@ -113,6 +118,11 @@ type StudentRepository interface {
 
 	// CountWithOptions counts students matching the query options
 	CountWithOptions(ctx context.Context, options *base.QueryOptions) (int, error)
+
+	// UpdateColumns is the generic partial-update helper promoted from the
+	// embedded base repository: updates only the named columns by primary
+	// key and returns the number of rows affected.
+	UpdateColumns(ctx context.Context, student *Student, columns ...string) (int64, error)
 
 	// CountByGroupIDs counts students per group for multiple groups in a single query
 	CountByGroupIDs(ctx context.Context, groupIDs []int64) (map[int64]int, error)
@@ -221,6 +231,15 @@ type StaffRepository interface {
 type TeacherRepository interface {
 	// Create inserts a new teacher into the database
 	Create(ctx context.Context, teacher *Teacher) error
+
+	// ListActiveCaregivers returns every active caregiver for the tenant in
+	// context (teachers with an active account, tenant mapping, and system
+	// user/teacher role), ordered by name.
+	ListActiveCaregivers(ctx context.Context) ([]*ActiveCaregiver, error)
+
+	// FindActiveCaregiverByAccountID returns the active caregiver bound to
+	// the account, or nil when the account is not an active caregiver.
+	FindActiveCaregiverByAccountID(ctx context.Context, accountID int64) (*ActiveCaregiver, error)
 
 	// FindByID retrieves a teacher by their ID
 	FindByID(ctx context.Context, id interface{}) (*Teacher, error)
@@ -372,9 +391,22 @@ type PersonGuardianRepository interface {
 }
 
 // StudentGuardianRepository defines operations for managing student-guardian relationships
+// GuardianEmergencyContactRow is one (guardian, phone number) projection row
+// for the emergency contact list; the consumer aggregates rows per student.
+type GuardianEmergencyContactRow struct {
+	StudentID   int64          `bun:"student_id"`
+	FirstName   sql.NullString `bun:"first_name"`
+	LastName    sql.NullString `bun:"last_name"`
+	PhoneNumber sql.NullString `bun:"phone_number"`
+}
+
 type StudentGuardianRepository interface {
 	// Create inserts a new student-guardian relationship into the database
 	Create(ctx context.Context, relationship *StudentGuardian) error
+
+	// ListEmergencyContactRows returns guardian/phone rows for the given
+	// students, emergency contacts and primary entries first.
+	ListEmergencyContactRows(ctx context.Context, studentIDs []int64) ([]GuardianEmergencyContactRow, error)
 
 	// FindByID retrieves a relationship by its ID
 	FindByID(ctx context.Context, id interface{}) (*StudentGuardian, error)

--- a/backend/services/active/analytics_service.go
+++ b/backend/services/active/analytics_service.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"time"
 
-	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
-	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 )
 
@@ -95,22 +93,8 @@ func (s *service) GetDashboardAnalytics(ctx context.Context) (*DashboardAnalytic
 }
 
 func (s *service) countClassTripStudentsForDate(ctx context.Context, date time.Time) (int, error) {
-	if s.db == nil {
+	if s.studentStatusRepo == nil {
 		return 0, nil
 	}
-	var count int
-	query := repoBase.GetDB(ctx, s.db).NewSelect().
-		TableExpr(`active.student_status_days AS "student_status_day"`).
-		Join(`JOIN users.students AS "student" ON "student".id = "student_status_day".student_id AND "student".tenant_id = "student_status_day".tenant_id`).
-		Where(`"student_status_day".date = ?`, date).
-		Where(`"student_status_day".status = ?`, activeModel.StudentStatusDayClassTrip).
-		Where(`"student_status_day".cleared_at IS NULL`).
-		Where(`COALESCE("student".sick, FALSE) = FALSE`).
-		Where(`COALESCE("student".excused, FALSE) = FALSE`).
-		ColumnExpr(`COUNT(DISTINCT "student_status_day".student_id)`)
-	if where, val, ok := repoBase.TenantWhere(ctx, "student_status_day"); ok {
-		query = query.Where(where, val)
-	}
-	err := query.Scan(ctx, &count)
-	return count, err
+	return s.studentStatusRepo.CountActiveClassTripStudents(ctx, date)
 }

--- a/backend/services/active/cleanup_service.go
+++ b/backend/services/active/cleanup_service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/audit"
@@ -16,9 +15,6 @@ import (
 )
 
 const (
-	// attendanceTableName is the fully-qualified table name for attendance records
-	attendanceTableName = "active.attendance"
-
 	// supervisorTableName is the fully-qualified table name for group supervisor records
 	supervisorTableName = "active.group_supervisors"
 )
@@ -33,6 +29,7 @@ type ConsentRetentionResolver interface {
 // cleanupService implements the CleanupService interface
 type cleanupService struct {
 	visitRepo          active.VisitRepository
+	attendanceRepo     active.AttendanceRepository
 	privacyConsentRepo userModels.PrivacyConsentRepository
 	dataDeletionRepo   audit.DataDeletionRepository
 	consentRetention   ConsentRetentionResolver
@@ -44,6 +41,7 @@ type cleanupService struct {
 // NewCleanupService creates a new cleanup service instance
 func NewCleanupService(
 	visitRepo active.VisitRepository,
+	attendanceRepo active.AttendanceRepository,
 	privacyConsentRepo userModels.PrivacyConsentRepository,
 	dataDeletionRepo audit.DataDeletionRepository,
 	consentRetention ConsentRetentionResolver,
@@ -51,6 +49,7 @@ func NewCleanupService(
 ) CleanupService {
 	return &cleanupService{
 		visitRepo:          visitRepo,
+		attendanceRepo:     attendanceRepo,
 		privacyConsentRepo: privacyConsentRepo,
 		dataDeletionRepo:   dataDeletionRepo,
 		consentRetention:   consentRetention,
@@ -373,22 +372,7 @@ func (s *cleanupService) CleanupStaleAttendance(ctx context.Context) (*Attendanc
 	today := timezone.TodayUTC()
 
 	// Find all attendance records from before today that don't have check-out times
-	var staleRecords []struct {
-		ID          int64     `bun:"id"`
-		StudentID   int64     `bun:"student_id"`
-		Date        time.Time `bun:"date"`
-		CheckInTime time.Time `bun:"check_in_time"`
-	}
-
-	db := repoBase.GetDB(ctx, s.db)
-
-	err := db.NewSelect().
-		Table(attendanceTableName).
-		Column("id", "student_id", "date", "check_in_time").
-		Where("date < ?", today).
-		Where("check_out_time IS NULL").
-		Scan(ctx, &staleRecords)
-
+	staleRecords, err := s.attendanceRepo.FindStaleOpen(ctx, today)
 	if err != nil {
 		result.Success = false
 		result.CompletedAt = time.Now()
@@ -420,14 +404,9 @@ func (s *cleanupService) CleanupStaleAttendance(ctx context.Context) (*Attendanc
 		}
 
 		// Update the record
-		_, err := db.NewUpdate().
-			Table(attendanceTableName).
-			Set("check_out_time = ?", checkOutTime).
-			Set("updated_at = ?", time.Now()).
-			Where("id = ?", record.ID).
-			Exec(ctx)
-
-		if err != nil {
+		record.CheckOutTime = &checkOutTime
+		record.UpdatedAt = time.Now()
+		if _, err := s.attendanceRepo.UpdateColumns(ctx, record, "check_out_time", "updated_at"); err != nil {
 			errMsg := fmt.Sprintf("Failed to close attendance record %d: %v", record.ID, err)
 			result.Errors = append(result.Errors, errMsg)
 			result.Success = false
@@ -461,20 +440,7 @@ func (s *cleanupService) PreviewAttendanceCleanup(ctx context.Context) (*Attenda
 	today := timezone.TodayUTC()
 
 	// Find all stale attendance records
-	var staleRecords []struct {
-		StudentID int64     `bun:"student_id"`
-		Date      time.Time `bun:"date"`
-	}
-
-	db := repoBase.GetDB(ctx, s.db)
-
-	err := db.NewSelect().
-		Table(attendanceTableName).
-		Column("student_id", "date").
-		Where("date < ?", today).
-		Where("check_out_time IS NULL").
-		Scan(ctx, &staleRecords)
-
+	staleRecords, err := s.attendanceRepo.FindStaleOpen(ctx, today)
 	if err != nil {
 		return nil, fmt.Errorf("failed to preview stale attendance records: %w", err)
 	}

--- a/backend/services/active/combined_group_service.go
+++ b/backend/services/active/combined_group_service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 // Combined Group operations
@@ -145,29 +144,22 @@ func (s *service) CreateCombinedGroupWithGroups(ctx context.Context, group *acti
 		seen[gid] = true
 	}
 
-	// Get tx from context (handler's WithTenantTx provides it)
-	tx, ok := base.TxFromContext(ctx)
-	if !ok {
+	// The repository calls below join the handler's WithTenantTx transaction
+	// via the context; without it the multi-step create would not be atomic.
+	if _, ok := base.TxFromContext(ctx); !ok {
 		return &ActiveError{Op: "CreateCombinedGroupWithGroups", Err: fmt.Errorf("no transaction in context")}
 	}
 
 	// Step 1: Create the combined group
 	group.SetTenantID(tenant.FromContext(ctx))
-	_, err := (*tx).NewInsert().
-		Model(group).
-		ModelTableExpr("active.combined_groups").
-		Exec(ctx)
-	if err != nil {
+	if err := s.combinedGroupRepo.Create(ctx, group); err != nil {
 		return &ActiveError{Op: "CreateCombinedGroupWithGroups", Err: fmt.Errorf("%w: %v", ErrDatabaseOperation, err)}
 	}
 
 	// Step 2: Verify all active group IDs exist
-	var existCount int
-	err = (*tx).NewSelect().
-		TableExpr("active.groups").
-		ColumnExpr("COUNT(*)").
-		Where("id IN (?)", bun.List(groupIDs)).
-		Scan(ctx, &existCount)
+	existOptions := base.NewQueryOptions()
+	existOptions.Filter = base.NewFilter().In("id", int64Args(groupIDs)...)
+	existCount, err := s.groupRepo.CountWithOptions(ctx, existOptions)
 	if err != nil {
 		return &ActiveError{Op: "CreateCombinedGroupWithGroups", Err: fmt.Errorf("%w: %v", ErrDatabaseOperation, err)}
 	}
@@ -182,11 +174,7 @@ func (s *service) CreateCombinedGroupWithGroups(ctx context.Context, group *acti
 			ActiveGroupID:         gid,
 		}
 		mapping.SetTenantID(tenant.FromContext(ctx))
-		_, err := (*tx).NewInsert().
-			Model(mapping).
-			ModelTableExpr("active.group_mappings").
-			Exec(ctx)
-		if err != nil {
+		if err := s.groupMappingRepo.Create(ctx, mapping); err != nil {
 			return &ActiveError{Op: "CreateCombinedGroupWithGroups", Err: fmt.Errorf("%w: %v", ErrDatabaseOperation, err)}
 		}
 	}
@@ -243,4 +231,13 @@ func (s *service) GetGroupMappingsByCombinedGroupID(ctx context.Context, combine
 		return nil, &ActiveError{Op: "GetGroupMappingsByCombinedGroupID", Err: ErrDatabaseOperation}
 	}
 	return mappings, nil
+}
+
+// int64Args widens an int64 slice for the variadic Filter.In helper.
+func int64Args(ids []int64) []any {
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	return args
 }

--- a/backend/services/active/dashboard_helpers.go
+++ b/backend/services/active/dashboard_helpers.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
 	educationModels "github.com/moto-nrw/project-phoenix/models/education"
 	facilityModels "github.com/moto-nrw/project-phoenix/models/facilities"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
-	"github.com/uptrace/bun"
 )
 
 // dashboardBaseData holds the raw data fetched for dashboard analytics
@@ -177,20 +175,23 @@ func (s *service) buildRoomLookupMaps(allRooms []*facilityModels.Room) *dashboar
 	return data
 }
 
-// loadStudentsWithGroups batch loads students for the given IDs
+// loadStudentsWithGroups batch loads students for the given IDs. Consumers
+// only build lookup maps from the result, so the order is irrelevant.
 func (s *service) loadStudentsWithGroups(ctx context.Context, studentIDs []int64) ([]*userModels.Student, error) {
 	if len(studentIDs) == 0 {
 		return nil, nil
 	}
 
-	var studentsWithGroups []*userModels.Student
-	err := base.GetDB(ctx, s.db).NewSelect().
-		Model(&studentsWithGroups).
-		ModelTableExpr(`users.students AS "student"`).
-		Where(`"student".id IN (?)`, bun.List(studentIDs)).
-		Scan(ctx)
+	studentsByID, err := s.studentRepo.FindByIDs(ctx, studentIDs)
+	if err != nil {
+		return nil, err
+	}
 
-	return studentsWithGroups, err
+	studentsWithGroups := make([]*userModels.Student, 0, len(studentsByID))
+	for _, student := range studentsByID {
+		studentsWithGroups = append(studentsWithGroups, student)
+	}
+	return studentsWithGroups, nil
 }
 
 // buildEducationGroupMaps creates group-related lookup structures

--- a/backend/services/active/end_session_unit_test.go
+++ b/backend/services/active/end_session_unit_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/base"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -606,4 +607,18 @@ func TestGetAllActiveSupervisions_FiltersInactive(t *testing.T) {
 	// Only the active one (no end date) should remain after IsActive() filter
 	assert.Len(t, result, 1)
 	assert.Equal(t, int64(10), result[0].ID)
+}
+
+// Stub for the issue #585 refactor interface addition — unused here.
+func (m *mockGroupRepository) CountWithOptions(context.Context, *base.QueryOptions) (int, error) {
+	return 0, nil
+}
+
+// Stubs for the issue #585 refactor interface additions — unused here.
+func (m *mockVisitRepository) GetCurrentRoomNamesForStudents(context.Context, []int64) (map[int64]string, error) {
+	return nil, nil
+}
+
+func (m *mockGroupSupervisorRepository) ListActiveSupervisionBlockers(context.Context, int64, int64) ([]userModels.BlockerSupervision, error) {
+	return nil, nil
 }

--- a/backend/services/active/staff_absence_service_test.go
+++ b/backend/services/active/staff_absence_service_test.go
@@ -1226,3 +1226,29 @@ func TestAbsGetVacationQuotaSummary_SplitsCrossYearVacation(t *testing.T) {
 	assert.Equal(t, 2.0, summary.TakenDays)
 	assert.Equal(t, 28.0, summary.RemainingDays)
 }
+
+// Generic query helper stubs (interface additions for the issue #585
+// cleanup refactor) — unused by these tests.
+func (m *absStaffAbsenceRepoMock) CountWithOptions(context.Context, *base.QueryOptions) (int, error) {
+	return 0, nil
+}
+
+func (m *absStaffAbsenceRepoMock) OldestBefore(context.Context, string, *time.Time) (*time.Time, error) {
+	return nil, nil
+}
+
+func (m *absStaffAbsenceRepoMock) DeleteOlderThan(context.Context, string, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (m *absWorkSessionRepoMock) CountWithOptions(context.Context, *base.QueryOptions) (int, error) {
+	return 0, nil
+}
+
+func (m *absWorkSessionRepoMock) OldestBefore(context.Context, string, *time.Time) (*time.Time, error) {
+	return nil, nil
+}
+
+func (m *absWorkSessionRepoMock) DeleteOlderThan(context.Context, string, time.Time) (int64, error) {
+	return 0, nil
+}

--- a/backend/services/active/time_tracking_cleanup_service.go
+++ b/backend/services/active/time_tracking_cleanup_service.go
@@ -16,8 +16,8 @@
 //     No children, independent table.
 //
 //   - The caller establishes tenant context (WithTenantTx). RLS is the
-//     primary tenant boundary; explicit tenant_id = ? predicates are
-//     defense in depth.
+//     primary tenant boundary; the repositories add tenant_id predicates
+//     as defense in depth.
 //
 //   - Per-staff audit rows in audit.data_deletions, one row per affected
 //     staff member (not per deleted row). Uses the staff_id subject
@@ -36,12 +36,19 @@ import (
 	"log/slog"
 	"time"
 
-	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/audit"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/services/config"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
+)
+
+// workSessionDateColumn / staffAbsenceDateColumn are the retention-age
+// columns the cleanup predicates run on.
+const (
+	workSessionDateColumn  = "date"
+	staffAbsenceDateColumn = "date_end"
 )
 
 // timeTrackingRetentionDefaultDays is a last-resort fallback. In production
@@ -100,17 +107,19 @@ type TimeTrackingCleanupService interface {
 }
 
 type timeTrackingCleanupService struct {
-	db        *bun.DB
-	auditRepo audit.DataDeletionRepository
-	settings  config.SettingsService
-	logger    *slog.Logger
+	workSessionRepo  activeModel.WorkSessionRepository
+	staffAbsenceRepo activeModel.StaffAbsenceRepository
+	auditRepo        audit.DataDeletionRepository
+	settings         config.SettingsService
+	logger           *slog.Logger
 }
 
 // NewTimeTrackingCleanupService constructs the cleanup service. auditRepo
 // receives a per-staff data_deletions row per cleanup run; settings may be
 // nil in tests, in which case retention resolves to the last-resort default.
 func NewTimeTrackingCleanupService(
-	db *bun.DB,
+	workSessionRepo activeModel.WorkSessionRepository,
+	staffAbsenceRepo activeModel.StaffAbsenceRepository,
 	auditRepo audit.DataDeletionRepository,
 	settings config.SettingsService,
 	logger *slog.Logger,
@@ -119,10 +128,11 @@ func NewTimeTrackingCleanupService(
 		logger = slog.Default()
 	}
 	return &timeTrackingCleanupService{
-		db:        db,
-		auditRepo: auditRepo,
-		settings:  settings,
-		logger:    logger,
+		workSessionRepo:  workSessionRepo,
+		staffAbsenceRepo: staffAbsenceRepo,
+		auditRepo:        auditRepo,
+		settings:         settings,
+		logger:           logger,
 	}
 }
 
@@ -140,11 +150,10 @@ func (s *timeTrackingCleanupService) CleanupExpiredTimeTrackingData(ctx context.
 	start := time.Now()
 	retentionDays := s.resolveRetentionDays(ctx)
 	cutoff := cutoffForDays(retentionDays)
-	db := repoBase.GetDB(ctx, s.db)
 
 	// 1. Collect per-staff impact for the audit log. We need this before
 	//    the deletes so the audit rows can be written first.
-	staffCounts, sampleIDs, err := s.collectStaffImpact(ctx, db, tenantID, cutoff)
+	staffCounts, sampleIDs, err := s.collectStaffImpact(ctx, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("collect staff impact: %w", err)
 	}
@@ -155,21 +164,21 @@ func (s *timeTrackingCleanupService) CleanupExpiredTimeTrackingData(ctx context.
 	}
 
 	// 3. Delete work_sessions (CASCADE removes breaks + audit edits).
-	sessionsDeleted, err := deleteOldWorkSessions(ctx, db, tenantID, cutoff)
+	sessionsDeleted, err := s.workSessionRepo.DeleteOlderThan(ctx, workSessionDateColumn, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("delete work_sessions: %w", err)
 	}
 
 	// 4. Delete staff_absences (independent table).
-	absencesDeleted, err := deleteOldStaffAbsences(ctx, db, tenantID, cutoff)
+	absencesDeleted, err := s.staffAbsenceRepo.DeleteOlderThan(ctx, staffAbsenceDateColumn, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("delete staff_absences: %w", err)
 	}
 
 	result := &TimeTrackingCleanupResult{
 		Success:         true,
-		SessionsDeleted: sessionsDeleted,
-		AbsencesDeleted: absencesDeleted,
+		SessionsDeleted: int(sessionsDeleted),
+		AbsencesDeleted: int(absencesDeleted),
 		StaffAffected:   len(staffCounts),
 		RetentionDays:   retentionDays,
 		CutoffDate:      cutoff,
@@ -178,8 +187,8 @@ func (s *timeTrackingCleanupService) CleanupExpiredTimeTrackingData(ctx context.
 
 	s.logger.Info("time-tracking cleanup completed",
 		slog.Int64("tenant_id", tenantID),
-		slog.Int("sessions_deleted", sessionsDeleted),
-		slog.Int("absences_deleted", absencesDeleted),
+		slog.Int("sessions_deleted", result.SessionsDeleted),
+		slog.Int("absences_deleted", result.AbsencesDeleted),
 		slog.Int("staff_affected", result.StaffAffected),
 		slog.Int("retention_days", retentionDays),
 		slog.String("cutoff", cutoff.Format("2006-01-02")),
@@ -199,29 +208,28 @@ func (s *timeTrackingCleanupService) PreviewExpiredTimeTrackingData(ctx context.
 
 	retentionDays := s.resolveRetentionDays(ctx)
 	cutoff := cutoffForDays(retentionDays)
-	db := repoBase.GetDB(ctx, s.db)
 
-	sessionsToDelete, err := countOldWorkSessions(ctx, db, tenantID, cutoff)
+	sessionsToDelete, err := s.workSessionRepo.CountWithOptions(ctx, olderThanOptions(workSessionDateColumn, cutoff))
 	if err != nil {
 		return nil, fmt.Errorf("count work_sessions: %w", err)
 	}
-	absencesToDelete, err := countOldStaffAbsences(ctx, db, tenantID, cutoff)
+	absencesToDelete, err := s.staffAbsenceRepo.CountWithOptions(ctx, olderThanOptions(staffAbsenceDateColumn, cutoff))
 	if err != nil {
 		return nil, fmt.Errorf("count staff_absences: %w", err)
 	}
 	// Preview shares the impact-collection helper used by the real run so
 	// "what would happen" can never drift from "what actually happens".
-	staffCounts, _, err := s.collectStaffImpact(ctx, db, tenantID, cutoff)
+	staffCounts, _, err := s.collectStaffImpact(ctx, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("collect staff impact: %w", err)
 	}
 	staffAffected := len(staffCounts)
 
-	oldestSession, err := oldestWorkSession(ctx, db, tenantID, cutoff)
+	oldestSession, err := s.workSessionRepo.OldestBefore(ctx, workSessionDateColumn, &cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("oldest work_session: %w", err)
 	}
-	oldestAbsence, err := oldestStaffAbsence(ctx, db, tenantID, cutoff)
+	oldestAbsence, err := s.staffAbsenceRepo.OldestBefore(ctx, staffAbsenceDateColumn, &cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("oldest staff_absence: %w", err)
 	}
@@ -247,40 +255,28 @@ func (s *timeTrackingCleanupService) GetStats(ctx context.Context) (*TimeTrackin
 
 	retentionDays := s.resolveRetentionDays(ctx)
 	cutoff := cutoffForDays(retentionDays)
-	db := repoBase.GetDB(ctx, s.db)
 
-	type row struct {
-		Cnt int `bun:"cnt"`
-	}
-	var sessionRow row
-	if err := db.NewSelect().
-		TableExpr("active.work_sessions").
-		ColumnExpr("COUNT(*) AS cnt").
-		Where("tenant_id = ?", tenantID).
-		Scan(ctx, &sessionRow); err != nil {
+	totalSessions, err := s.workSessionRepo.CountWithOptions(ctx, nil)
+	if err != nil {
 		return nil, fmt.Errorf("count sessions: %w", err)
 	}
-	var absenceRow row
-	if err := db.NewSelect().
-		TableExpr("active.staff_absences").
-		ColumnExpr("COUNT(*) AS cnt").
-		Where("tenant_id = ?", tenantID).
-		Scan(ctx, &absenceRow); err != nil {
+	totalAbsences, err := s.staffAbsenceRepo.CountWithOptions(ctx, nil)
+	if err != nil {
 		return nil, fmt.Errorf("count absences: %w", err)
 	}
 
-	oldestSession, err := oldestWorkSession(ctx, db, tenantID, time.Now().AddDate(100, 0, 0))
+	oldestSession, err := s.workSessionRepo.OldestBefore(ctx, workSessionDateColumn, nil)
 	if err != nil {
 		return nil, fmt.Errorf("oldest session: %w", err)
 	}
-	oldestAbsence, err := oldestStaffAbsence(ctx, db, tenantID, time.Now().AddDate(100, 0, 0))
+	oldestAbsence, err := s.staffAbsenceRepo.OldestBefore(ctx, staffAbsenceDateColumn, nil)
 	if err != nil {
 		return nil, fmt.Errorf("oldest absence: %w", err)
 	}
 
 	return &TimeTrackingCleanupStats{
-		TotalSessions: sessionRow.Cnt,
-		TotalAbsences: absenceRow.Cnt,
+		TotalSessions: totalSessions,
+		TotalAbsences: totalAbsences,
 		OldestSession: oldestSession,
 		OldestAbsence: oldestAbsence,
 		RetentionDays: retentionDays,
@@ -317,6 +313,24 @@ func cutoffForDays(retentionDays int) time.Time {
 	return today.AddDate(0, 0, -retentionDays)
 }
 
+// olderThanOptions builds query options selecting rows whose dateColumn is
+// strictly before the cutoff.
+func olderThanOptions(dateColumn string, cutoff time.Time) *modelBase.QueryOptions {
+	options := modelBase.NewQueryOptions()
+	options.Filter = modelBase.NewFilter().LessThan(dateColumn, cutoff)
+	return options
+}
+
+// staffImpactOptions extends olderThanOptions with the (staff_id, id)
+// ordering the audit sample bookkeeping relies on.
+func staffImpactOptions(dateColumn string, cutoff time.Time) *modelBase.QueryOptions {
+	options := olderThanOptions(dateColumn, cutoff)
+	sorting := &modelBase.Sorting{}
+	sorting.AddField("staff_id", modelBase.SortAsc).AddField("id", modelBase.SortAsc)
+	options.Sorting = sorting
+	return options
+}
+
 // perStaffCounts maps staff_id to the number of rows older than cutoff (sessions
 // + absences combined). Used for one audit row per affected staff member.
 type perStaffCounts map[int64]int
@@ -332,63 +346,39 @@ type perStaffSampleIDs struct {
 }
 
 // collectStaffImpact returns per-staff counts of sessions and absences that
-// will be deleted, plus a bounded sample of their IDs. Two SELECTs (one per
-// table) keep the SQL readable; both are tenant-scoped explicitly even
-// though RLS would also enforce it.
+// will be deleted, plus a bounded sample of their IDs. Two repository reads
+// (one per table); tenant scoping comes from the repositories on top of the
+// caller's RLS transaction.
 func (s *timeTrackingCleanupService) collectStaffImpact(
 	ctx context.Context,
-	db bun.IDB,
-	tenantID int64,
 	cutoff time.Time,
 ) (perStaffCounts, perStaffSamples, error) {
 	counts := make(perStaffCounts)
 	samples := make(perStaffSamples)
 
-	type sessionRow struct {
-		StaffID   int64 `bun:"staff_id"`
-		SessionID int64 `bun:"id"`
-	}
-	var sessionRows []sessionRow
-	if err := db.NewSelect().
-		TableExpr("active.work_sessions AS w").
-		ColumnExpr("w.staff_id AS staff_id").
-		ColumnExpr("w.id AS id").
-		Where("w.tenant_id = ?", tenantID).
-		Where("w.date < ?", cutoff).
-		Order("w.staff_id", "w.id").
-		Scan(ctx, &sessionRows); err != nil {
+	sessions, err := s.workSessionRepo.List(ctx, staffImpactOptions(workSessionDateColumn, cutoff))
+	if err != nil {
 		return nil, nil, fmt.Errorf("scan work_sessions: %w", err)
 	}
-	for _, r := range sessionRows {
-		counts[r.StaffID]++
-		entry := samples[r.StaffID]
+	for _, session := range sessions {
+		counts[session.StaffID]++
+		entry := samples[session.StaffID]
 		if len(entry.SessionIDs) < auditStaffIDSampleCap {
-			entry.SessionIDs = append(entry.SessionIDs, r.SessionID)
-			samples[r.StaffID] = entry
+			entry.SessionIDs = append(entry.SessionIDs, session.ID)
+			samples[session.StaffID] = entry
 		}
 	}
 
-	type absenceRow struct {
-		StaffID   int64 `bun:"staff_id"`
-		AbsenceID int64 `bun:"id"`
-	}
-	var absenceRows []absenceRow
-	if err := db.NewSelect().
-		TableExpr("active.staff_absences AS a").
-		ColumnExpr("a.staff_id AS staff_id").
-		ColumnExpr("a.id AS id").
-		Where("a.tenant_id = ?", tenantID).
-		Where("a.date_end < ?", cutoff).
-		Order("a.staff_id", "a.id").
-		Scan(ctx, &absenceRows); err != nil {
+	absences, err := s.staffAbsenceRepo.List(ctx, staffImpactOptions(staffAbsenceDateColumn, cutoff))
+	if err != nil {
 		return nil, nil, fmt.Errorf("scan staff_absences: %w", err)
 	}
-	for _, r := range absenceRows {
-		counts[r.StaffID]++
-		entry := samples[r.StaffID]
+	for _, absence := range absences {
+		counts[absence.StaffID]++
+		entry := samples[absence.StaffID]
 		if len(entry.AbsenceIDs) < auditStaffIDSampleCap {
-			entry.AbsenceIDs = append(entry.AbsenceIDs, r.AbsenceID)
-			samples[r.StaffID] = entry
+			entry.AbsenceIDs = append(entry.AbsenceIDs, absence.ID)
+			samples[absence.StaffID] = entry
 		}
 	}
 
@@ -432,98 +422,4 @@ func (s *timeTrackingCleanupService) writeStaffAuditRows(
 		}
 	}
 	return nil
-}
-
-func deleteOldWorkSessions(ctx context.Context, db bun.IDB, tenantID int64, cutoff time.Time) (int, error) {
-	res, err := db.NewDelete().
-		Table("active.work_sessions").
-		Where("tenant_id = ?", tenantID).
-		Where("date < ?", cutoff).
-		Exec(ctx)
-	if err != nil {
-		return 0, err
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return 0, err
-	}
-	return int(n), nil
-}
-
-func deleteOldStaffAbsences(ctx context.Context, db bun.IDB, tenantID int64, cutoff time.Time) (int, error) {
-	res, err := db.NewDelete().
-		Table("active.staff_absences").
-		Where("tenant_id = ?", tenantID).
-		Where("date_end < ?", cutoff).
-		Exec(ctx)
-	if err != nil {
-		return 0, err
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return 0, err
-	}
-	return int(n), nil
-}
-
-func countOldWorkSessions(ctx context.Context, db bun.IDB, tenantID int64, cutoff time.Time) (int, error) {
-	type row struct {
-		Cnt int `bun:"cnt"`
-	}
-	var r row
-	err := db.NewSelect().
-		TableExpr("active.work_sessions").
-		ColumnExpr("COUNT(*) AS cnt").
-		Where("tenant_id = ?", tenantID).
-		Where("date < ?", cutoff).
-		Scan(ctx, &r)
-	return r.Cnt, err
-}
-
-func countOldStaffAbsences(ctx context.Context, db bun.IDB, tenantID int64, cutoff time.Time) (int, error) {
-	type row struct {
-		Cnt int `bun:"cnt"`
-	}
-	var r row
-	err := db.NewSelect().
-		TableExpr("active.staff_absences").
-		ColumnExpr("COUNT(*) AS cnt").
-		Where("tenant_id = ?", tenantID).
-		Where("date_end < ?", cutoff).
-		Scan(ctx, &r)
-	return r.Cnt, err
-}
-
-func oldestWorkSession(ctx context.Context, db bun.IDB, tenantID int64, cutoff time.Time) (*time.Time, error) {
-	type row struct {
-		Date *time.Time `bun:"date"`
-	}
-	var r row
-	err := db.NewSelect().
-		TableExpr("active.work_sessions").
-		ColumnExpr("MIN(date) AS date").
-		Where("tenant_id = ?", tenantID).
-		Where("date < ?", cutoff).
-		Scan(ctx, &r)
-	if err != nil {
-		return nil, err
-	}
-	return r.Date, nil
-}
-
-func oldestStaffAbsence(ctx context.Context, db bun.IDB, tenantID int64, cutoff time.Time) (*time.Time, error) {
-	type row struct {
-		DateEnd *time.Time `bun:"date_end"`
-	}
-	var r row
-	err := db.NewSelect().
-		TableExpr("active.staff_absences").
-		ColumnExpr("MIN(date_end) AS date_end").
-		Where("tenant_id = ?", tenantID).
-		Where("date_end < ?", cutoff).
-		Scan(ctx, &r)
-	if err != nil {
-		return nil, err
-	}
-	return r.DateEnd, nil
 }

--- a/backend/services/active/time_tracking_cleanup_service_test.go
+++ b/backend/services/active/time_tracking_cleanup_service_test.go
@@ -38,7 +38,7 @@ func TestTimeTrackingCleanup_DeletesOldSessions(t *testing.T) {
 	freshSessionID := insertSession(t, db, staff.ID, daysAgo(10))
 
 	repos := repoFactory.NewFactory(db)
-	svc := activeSvc.NewTimeTrackingCleanupService(db, repos.DataDeletion, nil, nil)
+	svc := activeSvc.NewTimeTrackingCleanupService(repos.WorkSession, repos.StaffAbsence, repos.DataDeletion, nil, nil)
 
 	result, err := svc.CleanupExpiredTimeTrackingData(ctx)
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestTimeTrackingCleanup_DeletesOldAbsences(t *testing.T) {
 	freshAbsenceID := insertAbsence(t, db, staff.ID, daysAgo(20))
 
 	repos := repoFactory.NewFactory(db)
-	svc := activeSvc.NewTimeTrackingCleanupService(db, repos.DataDeletion, nil, nil)
+	svc := activeSvc.NewTimeTrackingCleanupService(repos.WorkSession, repos.StaffAbsence, repos.DataDeletion, nil, nil)
 
 	result, err := svc.CleanupExpiredTimeTrackingData(ctx)
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestTimeTrackingCleanup_PreviewLeavesDataIntact(t *testing.T) {
 	oldAbsenceID := insertAbsence(t, db, staff.ID, daysAgo(900))
 
 	repos := repoFactory.NewFactory(db)
-	svc := activeSvc.NewTimeTrackingCleanupService(db, repos.DataDeletion, nil, nil)
+	svc := activeSvc.NewTimeTrackingCleanupService(repos.WorkSession, repos.StaffAbsence, repos.DataDeletion, nil, nil)
 
 	preview, err := svc.PreviewExpiredTimeTrackingData(ctx)
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestTimeTrackingCleanup_PreviewOldestOnlyShowsExpiredRows(t *testing.T) {
 	defer cleanupTimeTrackingRows(t, db, freshSessionID, freshAbsenceID)
 
 	repos := repoFactory.NewFactory(db)
-	svc := activeSvc.NewTimeTrackingCleanupService(db, repos.DataDeletion, nil, nil)
+	svc := activeSvc.NewTimeTrackingCleanupService(repos.WorkSession, repos.StaffAbsence, repos.DataDeletion, nil, nil)
 
 	preview, err := svc.PreviewExpiredTimeTrackingData(ctx)
 	require.NoError(t, err)
@@ -171,7 +171,7 @@ func TestTimeTrackingCleanup_NoOpWhenNothingExpired(t *testing.T) {
 	freshSessionID := insertSession(t, db, staff.ID, daysAgo(10))
 
 	repos := repoFactory.NewFactory(db)
-	svc := activeSvc.NewTimeTrackingCleanupService(db, repos.DataDeletion, nil, nil)
+	svc := activeSvc.NewTimeTrackingCleanupService(repos.WorkSession, repos.StaffAbsence, repos.DataDeletion, nil, nil)
 
 	result, err := svc.CleanupExpiredTimeTrackingData(ctx)
 	require.NoError(t, err)
@@ -194,7 +194,8 @@ func TestTimeTrackingCleanup_AuditRequired(t *testing.T) {
 	defer testpkg.CleanupActivityFixtures(t, db, staff.ID)
 	insertSession(t, db, staff.ID, daysAgo(800))
 
-	svc := activeSvc.NewTimeTrackingCleanupService(db, nil, nil, nil)
+	repos := repoFactory.NewFactory(db)
+	svc := activeSvc.NewTimeTrackingCleanupService(repos.WorkSession, repos.StaffAbsence, nil, nil, nil)
 	_, err := svc.CleanupExpiredTimeTrackingData(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "audit repo not configured")
@@ -214,7 +215,7 @@ func TestTimeTrackingCleanup_UsesBusinessDatesNotCreatedAt(t *testing.T) {
 	oldBusinessAbsenceID := insertAbsenceWithBusinessDates(t, db, staff.ID, daysAgo(10), daysAgo(900), daysAgo(900))
 
 	repos := repoFactory.NewFactory(db)
-	svc := activeSvc.NewTimeTrackingCleanupService(db, repos.DataDeletion, nil, nil)
+	svc := activeSvc.NewTimeTrackingCleanupService(repos.WorkSession, repos.StaffAbsence, repos.DataDeletion, nil, nil)
 
 	result, err := svc.CleanupExpiredTimeTrackingData(ctx)
 	require.NoError(t, err)

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -1995,3 +1995,29 @@ func TestWSUpdateSession_CannotEditActiveBreak(t *testing.T) {
 func wsStrPtr(s string) *string {
 	return &s
 }
+
+// Generic query helper stubs (interface additions for the issue #585
+// cleanup refactor) — unused by these tests.
+func (m *wsMockWorkSessionRepository) CountWithOptions(context.Context, *base.QueryOptions) (int, error) {
+	return 0, nil
+}
+
+func (m *wsMockWorkSessionRepository) OldestBefore(context.Context, string, *time.Time) (*time.Time, error) {
+	return nil, nil
+}
+
+func (m *wsMockWorkSessionRepository) DeleteOlderThan(context.Context, string, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (m *wsMockStaffAbsenceRepository) CountWithOptions(context.Context, *base.QueryOptions) (int, error) {
+	return 0, nil
+}
+
+func (m *wsMockStaffAbsenceRepository) OldestBefore(context.Context, string, *time.Time) (*time.Time, error) {
+	return nil, nil
+}
+
+func (m *wsMockStaffAbsenceRepository) DeleteOlderThan(context.Context, string, time.Time) (int64, error) {
+	return 0, nil
+}

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -2021,3 +2021,7 @@ func (m *wsMockStaffAbsenceRepository) OldestBefore(context.Context, string, *ti
 func (m *wsMockStaffAbsenceRepository) DeleteOlderThan(context.Context, string, time.Time) (int64, error) {
 	return 0, nil
 }
+
+func (m *wsMockGroupSupervisorRepository) ListActiveSupervisionBlockers(context.Context, int64, int64) ([]userModels.BlockerSupervision, error) {
+	return nil, nil
+}

--- a/backend/services/activities/activity_service.go
+++ b/backend/services/activities/activity_service.go
@@ -10,8 +10,8 @@ import (
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/base"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 // Service implements the ActivityService interface
@@ -22,7 +22,7 @@ type Service struct {
 	supervisorRepo  activities.SupervisorPlannedRepository
 	enrollmentRepo  activities.StudentEnrollmentRepository
 	activeGroupRepo activeModels.GroupRepository
-	db              *bun.DB
+	staffRepo       userModels.StaffRepository
 }
 
 // NewService creates a new activity service
@@ -33,7 +33,7 @@ func NewService(
 	supervisorRepo activities.SupervisorPlannedRepository,
 	enrollmentRepo activities.StudentEnrollmentRepository,
 	activeGroupRepo activeModels.GroupRepository,
-	db *bun.DB,
+	staffRepo userModels.StaffRepository,
 ) (*Service, error) {
 	return &Service{
 		categoryRepo:    categoryRepo,
@@ -42,7 +42,7 @@ func NewService(
 		supervisorRepo:  supervisorRepo,
 		enrollmentRepo:  enrollmentRepo,
 		activeGroupRepo: activeGroupRepo,
-		db:              db,
+		staffRepo:       staffRepo,
 	}, nil
 }
 

--- a/backend/services/activities/supervisor_operations.go
+++ b/backend/services/activities/supervisor_operations.go
@@ -8,7 +8,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 // ======== Supervisor Methods ========
@@ -98,20 +97,11 @@ func (s *Service) unsetPrimarySupervisorsInTx(ctx context.Context, txService Act
 
 // validateStaffExists checks if a staff member exists before creating supervisor
 func (s *Service) validateStaffExists(ctx context.Context, staffID int64) error {
-	queryDB := bun.IDB(s.db)
-	if tx, ok := base.TxFromContext(ctx); ok && tx != nil {
-		queryDB = *tx
-	}
-
-	exists, err := queryDB.NewSelect().
-		TableExpr("users.staff").
-		Where("id = ?", staffID).
-		Exists(ctx)
-	if err != nil {
+	if _, err := s.staffRepo.FindByID(ctx, staffID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrStaffNotFound
+		}
 		return &ActivityError{Op: "validate staff", Err: err}
-	}
-	if !exists {
-		return ErrStaffNotFound
 	}
 	return nil
 }

--- a/backend/services/auth/test_helpers_test.go
+++ b/backend/services/auth/test_helpers_test.go
@@ -1477,3 +1477,24 @@ func (r *stubSchoolRepository) CountNonDeletedByOrganizationID(context.Context, 
 func newDefaultFromEmail() email.Email {
 	return email.NewEmail("moto", "no-reply@moto.example")
 }
+
+// Stubs for the issue #585 refactor interface additions — unused by auth tests.
+func (r *stubAccountRepository) AnonymizeForDeletion(context.Context, int64, string) error {
+	return nil
+}
+
+func (r *stubPersonRepository) AnonymizeAndSoftDelete(context.Context, int64) error {
+	return nil
+}
+
+func (noopAccountRepository) AnonymizeForDeletion(context.Context, int64, string) error {
+	return nil
+}
+
+func (r *stubTeacherRepository) ListActiveCaregivers(context.Context) ([]*userModel.ActiveCaregiver, error) {
+	return nil, nil
+}
+
+func (r *stubTeacherRepository) FindActiveCaregiverByAccountID(context.Context, int64) (*userModel.ActiveCaregiver, error) {
+	return nil, nil
+}

--- a/backend/services/education/education_service.go
+++ b/backend/services/education/education_service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/facilities"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 // service implements the Education Service interface
@@ -23,7 +22,6 @@ type service struct {
 	teacherRepo      users.TeacherRepository
 	staffRepo        users.StaffRepository
 	studentRepo      users.StudentRepository
-	db               *bun.DB
 }
 
 // NewService creates a new education service instance
@@ -35,7 +33,6 @@ func NewService(
 	teacherRepo users.TeacherRepository,
 	staffRepo users.StaffRepository,
 	studentRepo users.StudentRepository,
-	db *bun.DB,
 ) Service {
 	return &service{
 		groupRepo:        groupRepo,
@@ -45,7 +42,6 @@ func NewService(
 		teacherRepo:      teacherRepo,
 		staffRepo:        staffRepo,
 		studentRepo:      studentRepo,
-		db:               db,
 	}
 }
 

--- a/backend/services/education/education_service_test.go
+++ b/backend/services/education/education_service_test.go
@@ -30,7 +30,6 @@ func setupEducationService(t *testing.T, db *bun.DB) educationSvc.Service {
 		repoFactory.Teacher,
 		repoFactory.Staff,
 		repoFactory.Student,
-		db,
 	)
 }
 

--- a/backend/services/education/grade_transition_service.go
+++ b/backend/services/education/grade_transition_service.go
@@ -737,27 +737,15 @@ func (s *gradeTransitionService) revertStudentClass(
 	ctx context.Context,
 	h *education.GradeTransitionHistory,
 ) (bool, error) {
-	// Use transaction from context if available
-	var db bun.IDB = s.db
-	if tx, ok := base.TxFromContext(ctx); ok && tx != nil {
-		db = tx
-	}
+	student := &users.Student{}
+	student.ID = h.StudentID
+	student.SchoolClass = h.FromClass
+	student.UpdatedAt = time.Now()
 
-	result, err := db.NewUpdate().
-		Model((*users.Student)(nil)).
-		ModelTableExpr(`users.students AS "student"`).
-		Set("school_class = ?", h.FromClass).
-		Set("updated_at = NOW()").
-		Where(`"student".id = ?`, h.StudentID).
-		Exec(ctx)
+	// The repository joins the transition transaction via the context.
+	rowsAffected, err := s.studentRepo.UpdateColumns(ctx, student, "school_class", "updated_at")
 	if err != nil {
 		// Real database error - return it to trigger rollback
-		return false, err
-	}
-
-	// Check if a row was actually updated
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
 		return false, err
 	}
 

--- a/backend/services/emergency/service.go
+++ b/backend/services/emergency/service.go
@@ -2,19 +2,15 @@ package emergency
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
 
-	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	userModel "github.com/moto-nrw/project-phoenix/models/users"
 	activeService "github.com/moto-nrw/project-phoenix/services/active"
 	"github.com/moto-nrw/project-phoenix/services/listexport"
-	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 const presenceModeBinary = "binary"
@@ -41,22 +37,32 @@ type activePresenceReader interface {
 	GetStudentsAttendanceStatuses(ctx context.Context, studentIDs []int64) (map[int64]*activeService.AttendanceStatus, error)
 }
 
+type visitLocationReader interface {
+	GetCurrentRoomNamesForStudents(ctx context.Context, studentIDs []int64) (map[int64]string, error)
+}
+
+type guardianContactReader interface {
+	ListEmergencyContactRows(ctx context.Context, studentIDs []int64) ([]userModel.GuardianEmergencyContactRow, error)
+}
+
 type Dependencies struct {
-	AttendanceRepo attendanceReader
-	StudentRepo    studentReader
-	PersonRepo     personReader
-	ActiveService  activePresenceReader
-	ListExport     listexport.Service
-	DB             *bun.DB
+	AttendanceRepo      attendanceReader
+	StudentRepo         studentReader
+	PersonRepo          personReader
+	VisitRepo           visitLocationReader
+	StudentGuardianRepo guardianContactReader
+	ActiveService       activePresenceReader
+	ListExport          listexport.Service
 }
 
 type service struct {
-	attendanceRepo attendanceReader
-	studentRepo    studentReader
-	personRepo     personReader
-	activeService  activePresenceReader
-	listExport     listexport.Service
-	db             *bun.DB
+	attendanceRepo      attendanceReader
+	studentRepo         studentReader
+	personRepo          personReader
+	visitRepo           visitLocationReader
+	studentGuardianRepo guardianContactReader
+	activeService       activePresenceReader
+	listExport          listexport.Service
 }
 
 type snapshotRow struct {
@@ -71,21 +77,15 @@ type snapshotRow struct {
 	GuardianPhone   string
 }
 
-type guardianContactRow struct {
-	StudentID   int64          `bun:"student_id"`
-	FirstName   sql.NullString `bun:"first_name"`
-	LastName    sql.NullString `bun:"last_name"`
-	PhoneNumber sql.NullString `bun:"phone_number"`
-}
-
 func NewService(deps Dependencies) Service {
 	return &service{
-		attendanceRepo: deps.AttendanceRepo,
-		studentRepo:    deps.StudentRepo,
-		personRepo:     deps.PersonRepo,
-		activeService:  deps.ActiveService,
-		listExport:     deps.ListExport,
-		db:             deps.DB,
+		attendanceRepo:      deps.AttendanceRepo,
+		studentRepo:         deps.StudentRepo,
+		personRepo:          deps.PersonRepo,
+		visitRepo:           deps.VisitRepo,
+		studentGuardianRepo: deps.StudentGuardianRepo,
+		activeService:       deps.ActiveService,
+		listExport:          deps.ListExport,
 	}
 }
 
@@ -98,7 +98,7 @@ func (s *service) RenderSnapshot(ctx context.Context) (listexport.File, error) {
 }
 
 func (s *service) BuildSnapshotDocument(ctx context.Context, generatedAt time.Time) (listexport.Document, error) {
-	if s.attendanceRepo == nil || s.studentRepo == nil || s.personRepo == nil || s.listExport == nil || s.db == nil {
+	if s.attendanceRepo == nil || s.studentRepo == nil || s.personRepo == nil || s.listExport == nil || s.visitRepo == nil || s.studentGuardianRepo == nil {
 		return listexport.Document{}, fmt.Errorf("emergency snapshot service is not configured")
 	}
 
@@ -212,38 +212,7 @@ func (s *service) loadCurrentLocations(ctx context.Context, studentIDs []int64) 
 		return s.loadBinaryLocations(ctx, studentIDs)
 	}
 
-	type currentLocationRow struct {
-		StudentID int64          `bun:"student_id"`
-		RoomName  sql.NullString `bun:"room_name"`
-	}
-
-	var rows []currentLocationRow
-	query := repoBase.GetDB(ctx, s.db).NewSelect().
-		TableExpr(`active.visits AS "visit"`).
-		ColumnExpr(`DISTINCT ON ("visit".student_id) "visit".student_id`).
-		ColumnExpr(`"room".name AS "room_name"`).
-		Join(`JOIN active.groups AS "group" ON "group".id = "visit".active_group_id AND "group".end_time IS NULL`).
-		Join(`JOIN facilities.rooms AS "room" ON "room".id = "group".room_id`).
-		Where(`"visit".student_id IN (?)`, bun.List(studentIDs)).
-		Where(`"visit".exit_time IS NULL`).
-		OrderExpr(`"visit".student_id ASC`).
-		OrderExpr(`"visit".entry_time DESC`)
-
-	if where, val, ok := repoBase.TenantWhere(ctx, "visit"); ok {
-		query = query.Where(where, val)
-	}
-
-	if err := query.Scan(ctx, &rows); err != nil {
-		return nil, err
-	}
-
-	locations := make(map[int64]string, len(rows))
-	for _, row := range rows {
-		if row.RoomName.Valid {
-			locations[row.StudentID] = row.RoomName.String
-		}
-	}
-	return locations, nil
+	return s.visitRepo.GetCurrentRoomNamesForStudents(ctx, studentIDs)
 }
 
 func (s *service) loadBinaryLocations(ctx context.Context, studentIDs []int64) (map[int64]string, error) {
@@ -279,31 +248,8 @@ type guardianContact struct {
 }
 
 func (s *service) loadGuardianContacts(ctx context.Context, studentIDs []int64) (map[int64]guardianContact, error) {
-	var rows []guardianContactRow
-	query := repoBase.GetDB(ctx, s.db).NewSelect().
-		TableExpr(`users.students_guardians AS "student_guardian"`).
-		ColumnExpr(`"student_guardian".student_id`).
-		ColumnExpr(`"guardian".first_name`).
-		ColumnExpr(`"guardian".last_name`).
-		ColumnExpr(`"phone".phone_number`).
-		Join(`JOIN users.guardian_profiles AS "guardian" ON "guardian".id = "student_guardian".guardian_profile_id`).
-		Join(`LEFT JOIN users.guardian_phone_numbers AS "phone" ON "phone".guardian_profile_id = "guardian".id`).
-		Where(`"student_guardian".student_id IN (?)`, bun.List(studentIDs)).
-		OrderExpr(`"student_guardian".is_emergency_contact DESC`).
-		OrderExpr(`"student_guardian".is_primary DESC`).
-		OrderExpr(`"student_guardian".emergency_priority ASC`).
-		OrderExpr(`"phone".is_primary DESC NULLS LAST`).
-		OrderExpr(`"phone".priority ASC NULLS LAST`).
-		OrderExpr(`"student_guardian".student_id ASC`).
-		OrderExpr(`"guardian".id ASC`)
-
-	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
-		query = query.Where(`"student_guardian".tenant_id = ?`, tenantID)
-		query = query.Where(`"guardian".tenant_id = ?`, tenantID)
-		query = query.Where(`("phone".tenant_id = ? OR "phone".tenant_id IS NULL)`, tenantID)
-	}
-
-	if err := query.Scan(ctx, &rows); err != nil {
+	rows, err := s.studentGuardianRepo.ListEmergencyContactRows(ctx, studentIDs)
+	if err != nil {
 		return nil, err
 	}
 

--- a/backend/services/emergency/service_test.go
+++ b/backend/services/emergency/service_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	activeRepo "github.com/moto-nrw/project-phoenix/database/repositories/active"
+	usersRepo "github.com/moto-nrw/project-phoenix/database/repositories/users"
 	"github.com/moto-nrw/project-phoenix/models/users"
 
 	activeService "github.com/moto-nrw/project-phoenix/services/active"
@@ -93,8 +95,9 @@ func TestBuildSnapshotDocumentLoadsCurrentRows(t *testing.T) {
 			301: {FirstName: "Mila", LastName: "Albrecht"},
 			302: {FirstName: "Max", LastName: "Schmitt"},
 		}},
-		ListExport: listexport.NewService(),
-		DB:         db,
+		ListExport:          listexport.NewService(),
+		VisitRepo:           activeRepo.NewVisitRepository(db),
+		StudentGuardianRepo: usersRepo.NewStudentGuardianRepository(db),
 	})
 
 	doc, err := svc.BuildSnapshotDocument(context.Background(), time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC))
@@ -138,8 +141,9 @@ func TestBuildSnapshotDocumentUsesBinaryLocations(t *testing.T) {
 				202: {Status: "on_yard"},
 			},
 		},
-		ListExport: listexport.NewService(),
-		DB:         db,
+		ListExport:          listexport.NewService(),
+		VisitRepo:           activeRepo.NewVisitRepository(db),
+		StudentGuardianRepo: usersRepo.NewStudentGuardianRepository(db),
 	})
 
 	doc, err := svc.BuildSnapshotDocument(context.Background(), time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC))
@@ -156,11 +160,12 @@ func TestBuildSnapshotDocumentWithNoStudents(t *testing.T) {
 	defer cleanup()
 
 	svc := NewService(Dependencies{
-		AttendanceRepo: stubAttendanceRepo{ids: []int64{}},
-		StudentRepo:    stubStudentRepo{},
-		PersonRepo:     stubPersonRepo{},
-		ListExport:     listexport.NewService(),
-		DB:             db,
+		AttendanceRepo:      stubAttendanceRepo{ids: []int64{}},
+		StudentRepo:         stubStudentRepo{},
+		PersonRepo:          stubPersonRepo{},
+		ListExport:          listexport.NewService(),
+		VisitRepo:           activeRepo.NewVisitRepository(db),
+		StudentGuardianRepo: usersRepo.NewStudentGuardianRepository(db),
 	})
 
 	doc, err := svc.BuildSnapshotDocument(context.Background(), time.Time{})
@@ -174,11 +179,12 @@ func TestRenderSnapshot(t *testing.T) {
 	defer cleanup()
 
 	svc := NewService(Dependencies{
-		AttendanceRepo: stubAttendanceRepo{ids: []int64{}},
-		StudentRepo:    stubStudentRepo{},
-		PersonRepo:     stubPersonRepo{},
-		ListExport:     listexport.NewService(),
-		DB:             db,
+		AttendanceRepo:      stubAttendanceRepo{ids: []int64{}},
+		StudentRepo:         stubStudentRepo{},
+		PersonRepo:          stubPersonRepo{},
+		ListExport:          listexport.NewService(),
+		VisitRepo:           activeRepo.NewVisitRepository(db),
+		StudentGuardianRepo: usersRepo.NewStudentGuardianRepository(db),
 	})
 
 	file, err := svc.RenderSnapshot(context.Background())

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -804,19 +804,8 @@ func (s *requestService) Edit(ctx context.Context, token string, patch EditPatch
 
 	tenantID := req.GetTenantID()
 	tenantCtx := tenant.WithTenantID(ctx, tenantID)
-	return tenant.WithTenantTx(tenantCtx, s.db, tenantID, func(txCtx context.Context, tx bun.Tx) error {
-		_, err := tx.NewUpdate().
-			Model(req).
-			ModelTableExpr(`enrollment.requests AS "request"`).
-			Set("guardian_first_name = ?", req.GuardianFirstName).
-			Set("guardian_last_name = ?", req.GuardianLastName).
-			Set("guardian_phone = ?", req.GuardianPhone).
-			Set("consent_flags = ?", req.ConsentFlags).
-			Set("custom_data = ?", req.CustomData).
-			Set("updated_at = NOW()").
-			Where(`"request".id = ?`, req.ID).
-			Exec(txCtx)
-		return err
+	return tenant.WithTenantTx(tenantCtx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
+		return s.requestRepo.UpdateGuardianData(txCtx, req)
 	})
 }
 
@@ -852,15 +841,7 @@ func (s *requestService) Withdraw(ctx context.Context, token string, childID int
 			anyWithdrawn = true
 		}
 		if childID == 0 && anyWithdrawn {
-			now := time.Now()
-			_, err := tx.NewUpdate().
-				Model((*enrollmentModels.Request)(nil)).
-				ModelTableExpr(`enrollment.requests AS "request"`).
-				Set("withdrawn_at = ?", now).
-				Set("updated_at = NOW()").
-				Where(`"request".id = ?`, req.ID).
-				Exec(txCtx)
-			return err
+			return s.requestRepo.MarkWithdrawn(txCtx, req.ID, time.Now())
 		}
 		return nil
 	})

--- a/backend/services/facilities/facility_service.go
+++ b/backend/services/facilities/facility_service.go
@@ -10,12 +10,10 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/constants"
-	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/facilities"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/driver/pgdriver"
 )
 
@@ -30,7 +28,6 @@ const (
 type service struct {
 	roomRepo        facilities.RoomRepository
 	activeGroupRepo active.GroupRepository
-	db              *bun.DB
 }
 
 // wcRoomAliasNames lists the accepted canonical toilet-room aliases in
@@ -45,11 +42,10 @@ type service struct {
 var wcRoomAliasNames = [...]string{constants.WCRoomName, constants.WCRoomAliasName}
 
 // NewService creates a new facilities service
-func NewService(roomRepo facilities.RoomRepository, activeGroupRepo active.GroupRepository, db *bun.DB) Service {
+func NewService(roomRepo facilities.RoomRepository, activeGroupRepo active.GroupRepository) Service {
 	return &service{
 		roomRepo:        roomRepo,
 		activeGroupRepo: activeGroupRepo,
-		db:              db,
 	}
 }
 
@@ -64,72 +60,7 @@ func (s *service) GetRoom(ctx context.Context, id int64) (*facilities.Room, erro
 
 // GetRoomWithOccupancy retrieves a room by its ID with occupancy status
 func (s *service) GetRoomWithOccupancy(ctx context.Context, id int64) (RoomWithOccupancy, error) {
-	// Define result structure for scanning
-	type roomQueryResult struct {
-		// Room fields
-		ID        int64     `bun:"id"`
-		Name      string    `bun:"name"`
-		Building  string    `bun:"building"`
-		Floor     *int      `bun:"floor"`
-		Capacity  *int      `bun:"capacity"`
-		Category  *string   `bun:"category"`
-		Color     *string   `bun:"color"`
-		CreatedAt time.Time `bun:"created_at"`
-		UpdatedAt time.Time `bun:"updated_at"`
-
-		// Occupancy fields
-		IsOccupied      bool    `bun:"is_occupied"`
-		GroupName       *string `bun:"group_name"`
-		CategoryName    *string `bun:"category_name"`
-		StudentCount    int     `bun:"student_count"`
-		SupervisorNames *string `bun:"supervisor_names"`
-	}
-
-	// Aggregate occupancy across ALL active groups in the room (not a single
-	// arbitrary one). The "Kinder im Raum" view in the room detail modal
-	// (#1374) unions visits from every active group in the room, so the
-	// header summary has to follow the same union — otherwise the header
-	// can read "1 Gruppe / 4 Kinder" while the section below lists 8.
-	// Rooms that legitimately host concurrent groups (Schulhof Freispiel +
-	// Garten, Sporthalle combined groups) make this visibly contradictory.
-	var result roomQueryResult
-	err := repoBase.GetDB(ctx, s.db).NewSelect().
-		TableExpr("facilities.rooms AS r").
-		ColumnExpr("r.id, r.name, r.building, r.floor, r.capacity, r.category, r.color, r.created_at, r.updated_at").
-		ColumnExpr(`EXISTS (
-			SELECT 1 FROM active.groups ag
-			WHERE ag.room_id = r.id AND ag.end_time IS NULL
-		) AS is_occupied`).
-		ColumnExpr(`(
-			SELECT string_agg(DISTINCT act_group.name, ', ' ORDER BY act_group.name)
-			FROM active.groups ag
-			INNER JOIN activities.groups act_group ON act_group.id = ag.group_id
-			WHERE ag.room_id = r.id AND ag.end_time IS NULL
-		) AS group_name`).
-		ColumnExpr(`(
-			SELECT string_agg(DISTINCT cat.name, ', ' ORDER BY cat.name)
-			FROM active.groups ag
-			INNER JOIN activities.groups act_group ON act_group.id = ag.group_id
-			INNER JOIN activities.categories cat ON cat.id = act_group.category_id
-			WHERE ag.room_id = r.id AND ag.end_time IS NULL
-		) AS category_name`).
-		ColumnExpr(`COALESCE((
-			SELECT COUNT(DISTINCT v.student_id)
-			FROM active.visits v
-			INNER JOIN active.groups ag ON ag.id = v.active_group_id
-			WHERE ag.room_id = r.id AND ag.end_time IS NULL AND v.exit_time IS NULL
-		), 0)::int AS student_count`).
-		ColumnExpr(`(
-			SELECT string_agg(DISTINCT CONCAT(p.first_name, ' ', p.last_name), ', ')
-			FROM active.group_supervisors gs
-			INNER JOIN active.groups ag ON ag.id = gs.group_id
-			INNER JOIN users.staff st ON st.id = gs.staff_id
-			INNER JOIN users.persons p ON p.id = st.person_id
-			WHERE ag.room_id = r.id AND ag.end_time IS NULL AND gs.end_date IS NULL
-		) AS supervisor_names`).
-		Where("r.id = ?", id).
-		Scan(ctx, &result)
-
+	result, err := s.roomRepo.FindWithOccupancy(ctx, id)
 	if err != nil {
 		// Only treat "no rows" as "room not found" - preserve other database errors
 		if errors.Is(err, sql.ErrNoRows) {
@@ -433,77 +364,8 @@ func (s *service) DeleteRoom(ctx context.Context, id int64) error {
 
 // ListRooms retrieves all rooms with occupancy status
 func (s *service) ListRooms(ctx context.Context, options *base.QueryOptions) ([]RoomWithOccupancy, error) {
-	// Define result structure for scanning
-	type roomQueryResult struct {
-		// Room fields
-		ID        int64     `bun:"id"`
-		Name      string    `bun:"name"`
-		Building  string    `bun:"building"`
-		Floor     *int      `bun:"floor"`
-		Capacity  *int      `bun:"capacity"`
-		Category  *string   `bun:"category"`
-		Color     *string   `bun:"color"`
-		CreatedAt time.Time `bun:"created_at"`
-		UpdatedAt time.Time `bun:"updated_at"`
-
-		// Occupancy fields
-		IsOccupied      bool    `bun:"is_occupied"`
-		GroupName       *string `bun:"group_name"`
-		CategoryName    *string `bun:"category_name"`
-		StudentCount    int     `bun:"student_count"`
-		SupervisorNames *string `bun:"supervisor_names"`
-	}
-
-	// Aggregate occupancy across ALL active groups in each room (not a
-	// single arbitrary one). See GetRoomWithOccupancy above for the
-	// motivation — same query shape so the list and detail surfaces stay
-	// consistent for multi-group rooms (#1374).
-	query := repoBase.GetDB(ctx, s.db).NewSelect().
-		TableExpr("facilities.rooms AS r").
-		ColumnExpr("r.id, r.name, r.building, r.floor, r.capacity, r.category, r.color, r.created_at, r.updated_at").
-		ColumnExpr(`EXISTS (
-			SELECT 1 FROM active.groups ag
-			WHERE ag.room_id = r.id AND ag.end_time IS NULL
-		) AS is_occupied`).
-		ColumnExpr(`(
-			SELECT string_agg(DISTINCT act_group.name, ', ' ORDER BY act_group.name)
-			FROM active.groups ag
-			INNER JOIN activities.groups act_group ON act_group.id = ag.group_id
-			WHERE ag.room_id = r.id AND ag.end_time IS NULL
-		) AS group_name`).
-		ColumnExpr(`(
-			SELECT string_agg(DISTINCT cat.name, ', ' ORDER BY cat.name)
-			FROM active.groups ag
-			INNER JOIN activities.groups act_group ON act_group.id = ag.group_id
-			INNER JOIN activities.categories cat ON cat.id = act_group.category_id
-			WHERE ag.room_id = r.id AND ag.end_time IS NULL
-		) AS category_name`).
-		ColumnExpr(`COALESCE((
-			SELECT COUNT(DISTINCT v.student_id)
-			FROM active.visits v
-			INNER JOIN active.groups ag ON ag.id = v.active_group_id
-			WHERE ag.room_id = r.id AND ag.end_time IS NULL AND v.exit_time IS NULL
-		), 0)::int AS student_count`).
-		ColumnExpr(`(
-			SELECT string_agg(DISTINCT CONCAT(p.first_name, ' ', p.last_name), ', ')
-			FROM active.group_supervisors gs
-			INNER JOIN active.groups ag ON ag.id = gs.group_id
-			INNER JOIN users.staff st ON st.id = gs.staff_id
-			INNER JOIN users.persons p ON p.id = st.person_id
-			WHERE ag.room_id = r.id AND ag.end_time IS NULL AND gs.end_date IS NULL
-		) AS supervisor_names`).
-		OrderExpr("r.name ASC")
-
-	// Apply filters if provided
-	if options != nil && options.Filter != nil {
-		// Set table alias for the filter and apply to query
-		options.Filter.WithTableAlias("r")
-		query = options.Filter.ApplyToQuery(query)
-	}
-
-	// Execute query
-	var results []roomQueryResult
-	if err := query.Scan(ctx, &results); err != nil {
+	results, err := s.roomRepo.ListWithOccupancy(ctx, options)
+	if err != nil {
 		// sql.ErrNoRows for list queries should return empty array, not error
 		if errors.Is(err, sql.ErrNoRows) {
 			return []RoomWithOccupancy{}, nil

--- a/backend/services/facilities/facility_service_test.go
+++ b/backend/services/facilities/facility_service_test.go
@@ -72,7 +72,6 @@ func setupFacilitiesService(t *testing.T, db *bun.DB) facilitiesSvc.Service {
 	return facilitiesSvc.NewService(
 		repoFactory.Room,
 		repoFactory.ActiveGroup,
-		db,
 	)
 }
 

--- a/backend/services/facilities/schulhof_service.go
+++ b/backend/services/facilities/schulhof_service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/facilities"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 	"github.com/moto-nrw/project-phoenix/services/activities"
-	"github.com/uptrace/bun"
 )
 
 // SchulhofService provides operations for managing the Schulhof (schoolyard) area.
@@ -77,7 +76,6 @@ type schulhofService struct {
 	facilityService Service
 	activityService activities.ActivityService
 	activeService   activeSvc.Service
-	db              *bun.DB
 	logger          *slog.Logger
 }
 
@@ -94,14 +92,12 @@ func NewSchulhofService(
 	facilityService Service,
 	activityService activities.ActivityService,
 	activeService activeSvc.Service,
-	db *bun.DB,
 	logger *slog.Logger,
 ) SchulhofService {
 	return &schulhofService{
 		facilityService: facilityService,
 		activityService: activityService,
 		activeService:   activeService,
-		db:              db,
 		logger:          logger,
 	}
 }

--- a/backend/services/facilities/schulhof_service_test.go
+++ b/backend/services/facilities/schulhof_service_test.go
@@ -59,7 +59,6 @@ func setupSchulhofService(t *testing.T, db *bun.DB) facilitiesSvc.SchulhofServic
 	facilityService := facilitiesSvc.NewService(
 		repoFactory.Room,
 		repoFactory.ActiveGroup,
-		db,
 	)
 
 	activityService, err := activitiesSvc.NewService(
@@ -69,7 +68,7 @@ func setupSchulhofService(t *testing.T, db *bun.DB) facilitiesSvc.SchulhofServic
 		repoFactory.ActivitySupervisor,
 		repoFactory.StudentEnrollment,
 		repoFactory.ActiveGroup,
-		db,
+		repoFactory.Staff,
 	)
 	require.NoError(t, err)
 
@@ -82,7 +81,6 @@ func setupSchulhofService(t *testing.T, db *bun.DB) facilitiesSvc.SchulhofServic
 		repoFactory.Teacher,
 		repoFactory.Staff,
 		repoFactory.Student,
-		db,
 	)
 
 	usersService := usersSvc.NewPersonService(usersSvc.PersonServiceDependencies{
@@ -122,7 +120,6 @@ func setupSchulhofService(t *testing.T, db *bun.DB) facilitiesSvc.SchulhofServic
 		facilityService,
 		activityService,
 		activeService,
-		db,
 		slog.Default(),
 	)
 }
@@ -447,7 +444,7 @@ func TestSchulhofService_ToggleSupervision_StartSuccess(t *testing.T) {
 	filter.Equal("name", constants.SchulhofActivityName)
 	options.Filter = filter
 	repoFactory := repositories.NewFactory(db)
-	activityService, _ := activitiesSvc.NewService(repoFactory.ActivityCategory, repoFactory.ActivityGroup, repoFactory.ActivitySchedule, repoFactory.ActivitySupervisor, repoFactory.StudentEnrollment, repoFactory.ActiveGroup, db)
+	activityService, _ := activitiesSvc.NewService(repoFactory.ActivityCategory, repoFactory.ActivityGroup, repoFactory.ActivitySchedule, repoFactory.ActivitySupervisor, repoFactory.StudentEnrollment, repoFactory.ActiveGroup, repoFactory.Staff)
 	groups, _ := activityService.ListGroups(ctx, options)
 	if len(groups) > 0 {
 		testpkg.CleanupActivityFixtures(t, db, groups[0].ID, groups[0].CategoryID)
@@ -492,7 +489,7 @@ func TestSchulhofService_ToggleSupervision_StopSuccess(t *testing.T) {
 	filter.Equal("name", constants.SchulhofActivityName)
 	options.Filter = filter
 	repoFactory := repositories.NewFactory(db)
-	activityService, _ := activitiesSvc.NewService(repoFactory.ActivityCategory, repoFactory.ActivityGroup, repoFactory.ActivitySchedule, repoFactory.ActivitySupervisor, repoFactory.StudentEnrollment, repoFactory.ActiveGroup, db)
+	activityService, _ := activitiesSvc.NewService(repoFactory.ActivityCategory, repoFactory.ActivityGroup, repoFactory.ActivitySchedule, repoFactory.ActivitySupervisor, repoFactory.StudentEnrollment, repoFactory.ActiveGroup, repoFactory.Staff)
 	groups, _ := activityService.ListGroups(ctx, options)
 	if len(groups) > 0 {
 		testpkg.CleanupActivityFixtures(t, db, groups[0].ID, groups[0].CategoryID)
@@ -635,7 +632,7 @@ func TestSchulhofService_GetOrCreateActiveGroup_Creates(t *testing.T) {
 	filter.Equal("name", constants.SchulhofActivityName)
 	options.Filter = filter
 	repoFactory := repositories.NewFactory(db)
-	activityService, _ := activitiesSvc.NewService(repoFactory.ActivityCategory, repoFactory.ActivityGroup, repoFactory.ActivitySchedule, repoFactory.ActivitySupervisor, repoFactory.StudentEnrollment, repoFactory.ActiveGroup, db)
+	activityService, _ := activitiesSvc.NewService(repoFactory.ActivityCategory, repoFactory.ActivityGroup, repoFactory.ActivitySchedule, repoFactory.ActivitySupervisor, repoFactory.StudentEnrollment, repoFactory.ActiveGroup, repoFactory.Staff)
 	groups, _ := activityService.ListGroups(ctx, options)
 	if len(groups) > 0 {
 		testpkg.CleanupActivityFixtures(t, db, groups[0].CategoryID)
@@ -673,7 +670,7 @@ func TestSchulhofService_GetOrCreateActiveGroup_ReturnsExisting(t *testing.T) {
 	filter.Equal("name", constants.SchulhofActivityName)
 	options.Filter = filter
 	repoFactory := repositories.NewFactory(db)
-	activityService, _ := activitiesSvc.NewService(repoFactory.ActivityCategory, repoFactory.ActivityGroup, repoFactory.ActivitySchedule, repoFactory.ActivitySupervisor, repoFactory.StudentEnrollment, repoFactory.ActiveGroup, db)
+	activityService, _ := activitiesSvc.NewService(repoFactory.ActivityCategory, repoFactory.ActivityGroup, repoFactory.ActivitySchedule, repoFactory.ActivitySupervisor, repoFactory.StudentEnrollment, repoFactory.ActiveGroup, repoFactory.Staff)
 	groups, _ := activityService.ListGroups(ctx, options)
 	if len(groups) > 0 {
 		testpkg.CleanupActivityFixtures(t, db, groups[0].CategoryID)
@@ -726,7 +723,6 @@ func TestSchulhofService_GetOrCreateActiveGroup_IgnoresEndedGroups(t *testing.T)
 		repoFactory.Teacher,
 		repoFactory.Staff,
 		repoFactory.Student,
-		db,
 	)
 
 	usersService := usersSvc.NewPersonService(usersSvc.PersonServiceDependencies{
@@ -915,7 +911,7 @@ func TestSchulhofService_GetOrCreateActiveGroup_EndsStaleGroups(t *testing.T) {
 	repoFactory := repositories.NewFactory(db)
 	educationService := educationSvc.NewService(
 		repoFactory.Group, repoFactory.GroupTeacher, repoFactory.GroupSubstitution,
-		repoFactory.Room, repoFactory.Teacher, repoFactory.Staff, repoFactory.Student, db,
+		repoFactory.Room, repoFactory.Teacher, repoFactory.Staff, repoFactory.Student,
 	)
 	usersService := usersSvc.NewPersonService(usersSvc.PersonServiceDependencies{
 		PersonRepo: repoFactory.Person, RFIDRepo: repoFactory.RFIDCard,

--- a/backend/services/facilities/wc_service_internal_test.go
+++ b/backend/services/facilities/wc_service_internal_test.go
@@ -24,7 +24,6 @@ func setupWCServiceInternal(t *testing.T, db *bun.DB) *wcService {
 	facilityService := NewService(
 		repoFactory.Room,
 		repoFactory.ActiveGroup,
-		db,
 	)
 
 	activityService, err := activitiesSvc.NewService(
@@ -34,7 +33,7 @@ func setupWCServiceInternal(t *testing.T, db *bun.DB) *wcService {
 		repoFactory.ActivitySupervisor,
 		repoFactory.StudentEnrollment,
 		repoFactory.ActiveGroup,
-		db,
+		repoFactory.Staff,
 	)
 	require.NoError(t, err)
 
@@ -155,7 +154,7 @@ func TestWCService_EnsureInfrastructure_PropagatesRoomErrors(t *testing.T) {
 		repositories.NewFactory(db).ActivitySupervisor,
 		repositories.NewFactory(db).StudentEnrollment,
 		repositories.NewFactory(db).ActiveGroup,
-		db,
+		repositories.NewFactory(db).Staff,
 	)
 	require.NoError(t, err)
 

--- a/backend/services/facilities/wc_service_test.go
+++ b/backend/services/facilities/wc_service_test.go
@@ -48,7 +48,6 @@ func setupWCService(t *testing.T, db *bun.DB) facilitiesSvc.WCService {
 	facilityService := facilitiesSvc.NewService(
 		repoFactory.Room,
 		repoFactory.ActiveGroup,
-		db,
 	)
 
 	activityService, err := activitiesSvc.NewService(
@@ -58,7 +57,7 @@ func setupWCService(t *testing.T, db *bun.DB) facilitiesSvc.WCService {
 		repoFactory.ActivitySupervisor,
 		repoFactory.StudentEnrollment,
 		repoFactory.ActiveGroup,
-		db,
+		repoFactory.Staff,
 	)
 	require.NoError(t, err)
 

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -433,7 +433,9 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	// and schedule.activity_exceptions older than the tenant's retention window.
 	// Per-student audit rows via DataDeletion; exceptions slog-only.
 	timetableCleanupService := schedule.NewTimetableCleanupService(
-		db,
+		repos.ActivityInstance,
+		repos.ActivityException,
+		repos.InstanceStudent,
 		repos.DataDeletion,
 		settingsService,
 		logger.With("service", "timetable-cleanup"),
@@ -445,7 +447,8 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	// tenant's retention window. Per-staff audit rows via DataDeletion
 	// (staff_id subject, added in migration 1.15.58).
 	timeTrackingCleanupService := active.NewTimeTrackingCleanupService(
-		db,
+		repos.WorkSession,
+		repos.StaffAbsence,
 		repos.DataDeletion,
 		settingsService,
 		logger.With("service", "time-tracking-cleanup"),
@@ -726,6 +729,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	privacyConsentService := users.NewPrivacyConsentService(settingsService, logger.With("service", "privacy-consent"))
 	activeCleanupService := active.NewCleanupService(
 		repos.ActiveVisit,
+		repos.Attendance,
 		repos.PrivacyConsent,
 		repos.DataDeletion,
 		privacyConsentService,

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -207,7 +207,6 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.Teacher,
 		repos.Staff,
 		repos.Student,
-		db,
 	)
 
 	// Initialize grade transition service
@@ -315,7 +314,6 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	// Initialize feedback service
 	feedbackService := feedback.NewService(
 		repos.FeedbackEntry,
-		db,
 	)
 
 	// Initialize suggestions service
@@ -336,7 +334,6 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	// Initialize IoT service
 	iotService := iot.NewService(
 		repos.Device,
-		db,
 	)
 
 	// Inject settings resolver into active service so auto-clear of sick /
@@ -356,7 +353,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.ActivitySupervisor,
 		repos.StudentEnrollment,
 		repos.ActiveGroup,
-		db,
+		repos.Staff,
 	)
 	if err != nil {
 		return nil, err
@@ -366,7 +363,6 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	facilitiesService := facilities.NewService(
 		repos.Room,
 		repos.ActiveGroup,
-		db,
 	)
 
 	// Initialize Schulhof service (depends on facilities, activities, and active services)
@@ -374,7 +370,6 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		facilitiesService,
 		activitiesService,
 		activeService,
-		db,
 		facilitiesLogger,
 	)
 
@@ -390,7 +385,6 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.Dateframe,
 		repos.Timeframe,
 		repos.RecurrenceRule,
-		db,
 	)
 
 	// Initialize pickup schedule service
@@ -398,13 +392,11 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.StudentPickupSchedule,
 		repos.StudentPickupException,
 		repos.StudentPickupNote,
-		db,
 	)
 
 	// Initialize calendar period service
 	calendarPeriodService := schedule.NewCalendarPeriodService(
 		repos.CalendarPeriod,
-		db,
 		logger.With("service", "calendar-period"),
 	)
 
@@ -424,7 +416,6 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.ActivityException,
 		repos.Timeframe,
 		calendarPeriodService,
-		db,
 		logger.With("service", "materialization"),
 	)
 
@@ -681,6 +672,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		TeacherRepo:            repos.Teacher,
 		GroupTeacherRepo:       repos.GroupTeacher,
 		GroupSubstitutionRepo:  repos.GroupSubstitution,
+		GroupSupervisorRepo:    repos.GroupSupervisor,
 		ActivitySupervisorRepo: repos.ActivitySupervisor,
 		AuthService:            authService,
 		DB:                     db,
@@ -720,7 +712,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		SupervisorRepo:     repos.GroupSupervisor,
 		ProfileRepo:        repos.Profile,
 		SubstitutionRepo:   repos.GroupSubstitution,
-	}, db, usercontextLogger)
+	}, usercontextLogger)
 
 	// Initialize database stats service
 	databaseService := database.NewService(repos, databaseLogger)
@@ -752,7 +744,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		},
 		db,
 	)
-	studentImportService := importService.NewImportService(studentImportConfig, db)
+	studentImportService := importService.NewImportService(studentImportConfig)
 
 	// Staff import bulk-creates invitations (reuses the invitation service);
 	// Person/Account/Staff/Teacher are created when each invitee accepts.
@@ -765,7 +757,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 			SchoolRepo:        repos.School,
 		},
 	)
-	staffImportService := importService.NewImportService(staffImportConfig, db)
+	staffImportService := importService.NewImportService(staffImportConfig)
 
 	// Email change tokens deliberately reuse PASSWORD_RESET_TOKEN_EXPIRY_MINUTES
 	// because both serve the same purpose (one-time verification links with the same
@@ -978,6 +970,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		AccountTenantRepo:   repos.AccountTenant,
 		PersonRepo:          repos.Person,
 		StaffRepo:           repos.Staff,
+		AccountRepo:         repos.Account,
 		TeacherRepo:         repos.Teacher,
 		GroupSupervisorRepo: repos.GroupSupervisor,
 		InvitationService:   invitationService,
@@ -989,12 +982,13 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 
 	listExportService := listexport.NewService()
 	emergencyService := emergency.NewService(emergency.Dependencies{
-		AttendanceRepo: repos.Attendance,
-		StudentRepo:    repos.Student,
-		PersonRepo:     repos.Person,
-		ActiveService:  activeService,
-		ListExport:     listExportService,
-		DB:             db,
+		AttendanceRepo:      repos.Attendance,
+		StudentRepo:         repos.Student,
+		PersonRepo:          repos.Person,
+		VisitRepo:           repos.ActiveVisit,
+		StudentGuardianRepo: repos.StudentGuardian,
+		ActiveService:       activeService,
+		ListExport:          listExportService,
 	})
 
 	factory := &Factory{

--- a/backend/services/feedback/feedback_service.go
+++ b/backend/services/feedback/feedback_service.go
@@ -6,20 +6,17 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/models/feedback"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 // feedbackService implements the Service interface
 type feedbackService struct {
-	db        *bun.DB
 	entryRepo feedback.EntryRepository
 }
 
 // NewService creates a new feedback service
-func NewService(entryRepo feedback.EntryRepository, db *bun.DB) Service {
+func NewService(entryRepo feedback.EntryRepository) Service {
 	return &feedbackService{
 		entryRepo: entryRepo,
-		db:        db,
 	}
 }
 

--- a/backend/services/feedback/feedback_service_test.go
+++ b/backend/services/feedback/feedback_service_test.go
@@ -21,7 +21,7 @@ func setupFeedbackService(t *testing.T, db *bun.DB) feedbackSvc.Service {
 
 	repoFactory := repositories.NewFactory(db)
 
-	return feedbackSvc.NewService(repoFactory.FeedbackEntry, db)
+	return feedbackSvc.NewService(repoFactory.FeedbackEntry)
 }
 
 // ============================================================================

--- a/backend/services/import/import_service.go
+++ b/backend/services/import/import_service.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	importModels "github.com/moto-nrw/project-phoenix/models/import"
-	"github.com/uptrace/bun"
 )
 
 // importerUserIDKey is a context key for the importing user's ID
@@ -28,15 +27,13 @@ func ImporterIDFromContext(ctx context.Context) int64 {
 // ImportService handles generic import logic for any entity type
 type ImportService[T any] struct {
 	config    importModels.ImportConfig[T]
-	db        *bun.DB
 	batchSize int
 }
 
 // NewImportService creates a new import service
-func NewImportService[T any](config importModels.ImportConfig[T], db *bun.DB) *ImportService[T] {
+func NewImportService[T any](config importModels.ImportConfig[T]) *ImportService[T] {
 	return &ImportService[T]{
 		config:    config,
-		db:        db,
 		batchSize: 100, // Default batch size
 	}
 }

--- a/backend/services/import/import_service_test.go
+++ b/backend/services/import/import_service_test.go
@@ -65,7 +65,7 @@ func TestNewImportService(t *testing.T) {
 		config := &mockImportConfig{}
 
 		// ACT
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 
 		// ASSERT
 		require.NotNil(t, service)
@@ -85,7 +85,7 @@ func TestImportService_Import(t *testing.T) {
 		config := &mockImportConfig{
 			preloadErr: errors.New("preload failed"),
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows: []testRow{{Name: "test", Value: "value"}},
 		}
@@ -104,7 +104,7 @@ func TestImportService_Import(t *testing.T) {
 		config := &mockImportConfig{
 			findExistingID: nil, // New entity
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test1", Value: "value1"}, {Name: "test2", Value: "value2"}},
 			DryRun: true,
@@ -127,7 +127,7 @@ func TestImportService_Import(t *testing.T) {
 		config := &mockImportConfig{
 			findExistingID: &existingID, // Existing entity
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test1", Value: "value1"}},
 			DryRun: true,
@@ -149,7 +149,7 @@ func TestImportService_Import(t *testing.T) {
 		config := &mockImportConfig{
 			findExistingID: &existingID,
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test1", Value: "value1"}},
 			DryRun: true,
@@ -174,7 +174,7 @@ func TestImportService_Import(t *testing.T) {
 			findExistingID: nil, // New entity
 			createID:       1,
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test", Value: "value"}},
 			DryRun: false,
@@ -196,7 +196,7 @@ func TestImportService_Import(t *testing.T) {
 		config := &mockImportConfig{
 			findExistingID: &existingID,
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test", Value: "value"}},
 			DryRun: false,
@@ -219,7 +219,7 @@ func TestImportService_Import(t *testing.T) {
 				{Field: "name", Message: "Name is required", Code: "required", Severity: importModels.ErrorSeverityError},
 			},
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "", Value: "value"}},
 			DryRun: false,
@@ -243,7 +243,7 @@ func TestImportService_Import(t *testing.T) {
 			},
 			createID: 1,
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test", Value: "value"}},
 			DryRun: false,
@@ -267,7 +267,7 @@ func TestImportService_Import(t *testing.T) {
 				{Field: "name", Message: "Invalid", Code: "invalid", Severity: importModels.ErrorSeverityError},
 			},
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:        []testRow{{Name: "test1"}, {Name: "test2"}},
 			DryRun:      false,
@@ -289,7 +289,7 @@ func TestImportService_Import(t *testing.T) {
 			findExistingID: nil,
 			createErr:      errors.New("creation failed"),
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test", Value: "value"}},
 			DryRun: false,
@@ -313,7 +313,7 @@ func TestImportService_Import(t *testing.T) {
 			findExistingID: &existingID,
 			updateErr:      errors.New("update failed"),
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test", Value: "value"}},
 			DryRun: false,
@@ -336,7 +336,7 @@ func TestImportService_Import(t *testing.T) {
 		config := &mockImportConfig{
 			findExistingErr: errors.New("db error"),
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test", Value: "value"}},
 			DryRun: false,
@@ -359,7 +359,7 @@ func TestImportService_Import(t *testing.T) {
 		config := &mockImportConfig{
 			findExistingID: &existingID,
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test", Value: "value"}},
 			DryRun: false,
@@ -381,7 +381,7 @@ func TestImportService_Import(t *testing.T) {
 		config := &mockImportConfig{
 			findExistingID: nil, // Not found
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test", Value: "value"}},
 			DryRun: false,
@@ -401,7 +401,7 @@ func TestImportService_Import(t *testing.T) {
 	t.Run("records timing information", func(t *testing.T) {
 		// ARRANGE
 		config := &mockImportConfig{}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test", Value: "value"}},
 			DryRun: true,
@@ -458,7 +458,7 @@ func TestGenerateBulkActions(t *testing.T) {
 	t.Run("generates bulk actions for repeated errors", func(t *testing.T) {
 		// ARRANGE
 		config := &mockImportConfig{}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 
 		errors := []importModels.ImportError[testRow]{
 			{
@@ -510,7 +510,7 @@ func TestGenerateBulkActions(t *testing.T) {
 	t.Run("ignores single occurrences", func(t *testing.T) {
 		// ARRANGE
 		config := &mockImportConfig{}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 
 		errors := []importModels.ImportError[testRow]{
 			{
@@ -541,7 +541,7 @@ func TestGenerateBulkActions(t *testing.T) {
 	t.Run("ignores errors without AutoFix", func(t *testing.T) {
 		// ARRANGE
 		config := &mockImportConfig{}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 
 		errors := []importModels.ImportError[testRow]{
 			{
@@ -590,7 +590,7 @@ func TestImportService_DryRunDuplicateCheckError(t *testing.T) {
 		config := &mockImportConfig{
 			findExistingErr: errors.New("db connection failed"),
 		}
-		service := NewImportService[testRow](config, nil)
+		service := NewImportService[testRow](config)
 		request := importModels.ImportRequest[testRow]{
 			Rows:   []testRow{{Name: "test", Value: "value"}},
 			DryRun: true,

--- a/backend/services/import/relationship_resolver_test.go
+++ b/backend/services/import/relationship_resolver_test.go
@@ -502,3 +502,12 @@ func TestRelationshipResolver_FindSimilarRooms(t *testing.T) {
 func int64Ptr(i int64) *int64 {
 	return &i
 }
+
+// Stubs for the issue #585 refactor interface additions — unused here.
+func (m *mockRoomRepo) FindWithOccupancy(context.Context, int64) (*facilities.RoomOccupancyRow, error) {
+	return nil, nil
+}
+
+func (m *mockRoomRepo) ListWithOccupancy(context.Context, *base.QueryOptions) ([]facilities.RoomOccupancyRow, error) {
+	return nil, nil
+}

--- a/backend/services/import/staff_import_config_test.go
+++ b/backend/services/import/staff_import_config_test.go
@@ -483,3 +483,8 @@ func TestStaffImportConfig_InvitationServiceCompileGuard(t *testing.T) {
 	var _ authModels.AccountTenantRepository = stubStaffAccountTenantRepo{}
 	var _ platformModels.SchoolRepository = stubStaffSchoolRepo{}
 }
+
+// Stub for the issue #585 refactor interface addition — unused here.
+func (r stubStaffAccountRepo) AnonymizeForDeletion(context.Context, int64, string) error {
+	return nil
+}

--- a/backend/services/iot/iot_service.go
+++ b/backend/services/iot/iot_service.go
@@ -13,7 +13,6 @@ import (
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/models/iot"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 // Error message constants to avoid string duplication
@@ -42,7 +41,6 @@ func isProtectedSystemDevice(device *iot.Device) bool {
 // service implements the Service interface
 type service struct {
 	deviceRepo iot.DeviceRepository
-	db         *bun.DB
 
 	// Optional: tenant-scoped settings resolver for the device-online window.
 	// When nil, IsDeviceOnline falls back to defaultDeviceOnlineWindow.
@@ -50,10 +48,9 @@ type service struct {
 }
 
 // NewService creates a new IoT service
-func NewService(deviceRepo iot.DeviceRepository, db *bun.DB) Service {
+func NewService(deviceRepo iot.DeviceRepository) Service {
 	return &service{
 		deviceRepo: deviceRepo,
-		db:         db,
 	}
 }
 

--- a/backend/services/platform/operator_provisioning_service.go
+++ b/backend/services/platform/operator_provisioning_service.go
@@ -98,23 +98,9 @@ type OperatorProvisioningService interface {
 type OperatorPersonInfo = platform.OperatorPersonInfo
 
 // OperatorDeviceInfo holds device information with school/org context for operator views.
-type OperatorDeviceInfo struct {
-	ID               int64      `bun:"id" json:"id"`
-	DeviceID         string     `bun:"device_id" json:"device_id"`
-	DeviceType       string     `bun:"device_type" json:"device_type"`
-	Name             *string    `bun:"name" json:"name,omitempty"`
-	Status           string     `bun:"status" json:"status"`
-	APIKey           *string    `bun:"api_key" json:"api_key,omitempty"`
-	MaskedAPIKey     string     `bun:"-" json:"masked_api_key"`
-	LastSeen         *time.Time `bun:"last_seen" json:"last_seen,omitempty"`
-	IsOnline         bool       `bun:"-" json:"is_online"`
-	SchoolID         int64      `bun:"school_id" json:"school_id"`
-	SchoolName       string     `bun:"school_name" json:"school_name"`
-	OrganizationID   int64      `bun:"organization_id" json:"organization_id"`
-	OrganizationName string     `bun:"organization_name" json:"organization_name"`
-	CreatedAt        time.Time  `bun:"created_at" json:"created_at"`
-	UpdatedAt        time.Time  `bun:"updated_at" json:"updated_at"`
-}
+// OperatorDeviceInfo is the device listing row; an alias of the repository
+// read model so derived presentation fields stay attached.
+type OperatorDeviceInfo = platform.OperatorDeviceRow
 
 // maskAPIKey returns the first 10 characters followed by ellipsis.
 func maskAPIKey(key *string) string {
@@ -149,6 +135,7 @@ type operatorProvisioningService struct {
 	accountTenantRepo   authModels.AccountTenantRepository
 	personRepo          userModels.PersonRepository
 	staffRepo           userModels.StaffRepository
+	accountRepo         authModels.AccountRepository
 	teacherRepo         userModels.TeacherRepository
 	groupSupervisorRepo activeModels.GroupSupervisorRepository
 	invitationService   authSvc.InvitationService
@@ -169,6 +156,7 @@ type OperatorProvisioningServiceConfig struct {
 	AccountTenantRepo   authModels.AccountTenantRepository
 	PersonRepo          userModels.PersonRepository
 	StaffRepo           userModels.StaffRepository
+	AccountRepo         authModels.AccountRepository
 	TeacherRepo         userModels.TeacherRepository
 	GroupSupervisorRepo activeModels.GroupSupervisorRepository
 	InvitationService   authSvc.InvitationService
@@ -193,6 +181,7 @@ func NewOperatorProvisioningService(cfg OperatorProvisioningServiceConfig) Opera
 		accountTenantRepo:   cfg.AccountTenantRepo,
 		personRepo:          cfg.PersonRepo,
 		staffRepo:           cfg.StaffRepo,
+		accountRepo:         cfg.AccountRepo,
 		teacherRepo:         cfg.TeacherRepo,
 		groupSupervisorRepo: cfg.GroupSupervisorRepo,
 		invitationService:   cfg.InvitationService,
@@ -684,52 +673,12 @@ func (s *operatorProvisioningService) ListAllAccounts(ctx context.Context) ([]au
 	return result, nil
 }
 
-const operatorDeviceQuery = `
-SELECT
-	"d".id,
-	"d".device_id,
-	"d".device_type,
-	"d".name,
-	"d".status,
-	"d".api_key,
-	"d".last_seen,
-	"d".created_at,
-	"d".updated_at,
-	"s".id AS school_id,
-	"s".name AS school_name,
-	"o".id AS organization_id,
-	"o".name AS organization_name
-FROM iot.devices AS "d"
-INNER JOIN platform.schools AS "s" ON "s".id = "d".tenant_id
-INNER JOIN platform.organizations AS "o" ON "o".id = "s".organization_id
-`
-
-// queryDevices runs the shared device query with an optional WHERE clause.
-// All callers pass static WHERE strings with parameterized args — no user input is concatenated.
-//
-// Devices belonging to a soft-deleted school or organization are filtered out
-// unconditionally so global listings (operator dashboard) never surface entries
-// for tenants that are in the Papierkorb. Detail endpoints (ListSchoolDevices,
-// ListOrganizationDevices) still reject deleted targets via their explicit
-// IsDeleted pre-check before reaching this query; the SQL filter is the
-// safety net for the global ListAllDevices path.
-func (s *operatorProvisioningService) queryDevices(adminCtx context.Context, whereClause string, args ...interface{}) ([]OperatorDeviceInfo, error) {
-	var db bun.IDB = s.txHandler.DB
-	if tx, ok := modelBase.TxFromContext(adminCtx); ok && tx != nil {
-		db = tx
-	}
-	q := operatorDeviceQuery + ` WHERE "s".deleted_at IS NULL AND "o".deleted_at IS NULL`
-	if whereClause != "" {
-		q += " AND " + whereClause
-	}
-	q += ` ORDER BY "o".name, "s".name, "d".device_id`
-
-	var result []OperatorDeviceInfo
-	if err := db.NewRaw(q, args...).Scan(adminCtx, &result); err != nil {
+// queryDevices runs the shared device listing through the summaries
+// repository and computes the derived presentation fields.
+func (s *operatorProvisioningService) queryDevices(adminCtx context.Context, filter platform.OperatorDeviceFilter) ([]OperatorDeviceInfo, error) {
+	result, err := s.summariesRepo.ListDeviceRows(adminCtx, filter)
+	if err != nil {
 		return nil, err
-	}
-	if result == nil {
-		result = []OperatorDeviceInfo{}
 	}
 	return enrichDeviceInfo(result), nil
 }
@@ -738,7 +687,7 @@ func (s *operatorProvisioningService) ListAllDevices(ctx context.Context) ([]Ope
 	var result []OperatorDeviceInfo
 	err := s.withAdminTx(ctx, func(adminCtx context.Context) error {
 		var queryErr error
-		result, queryErr = s.queryDevices(adminCtx, "")
+		result, queryErr = s.queryDevices(adminCtx, platform.OperatorDeviceFilter{})
 		return queryErr
 	})
 	return result, err
@@ -761,7 +710,7 @@ func (s *operatorProvisioningService) ListSchoolDevices(ctx context.Context, sch
 			return &SchoolAlreadyDeletedError{SchoolID: schoolID}
 		}
 		var queryErr error
-		result, queryErr = s.queryDevices(adminCtx, `"d".tenant_id = ?`, schoolID)
+		result, queryErr = s.queryDevices(adminCtx, platform.OperatorDeviceFilter{SchoolID: &schoolID})
 		return queryErr
 	})
 	return result, err
@@ -781,7 +730,7 @@ func (s *operatorProvisioningService) ListOrganizationDevices(ctx context.Contex
 			return &OrganizationDeletedError{OrganizationID: organizationID}
 		}
 		var queryErr error
-		result, queryErr = s.queryDevices(adminCtx, `"o".id = ?`, organizationID)
+		result, queryErr = s.queryDevices(adminCtx, platform.OperatorDeviceFilter{OrganizationID: &organizationID})
 		return queryErr
 	})
 	return result, err
@@ -843,15 +792,15 @@ func isAPIKeyConstraintViolation(err error) bool {
 }
 
 // queryDeviceSingle wraps queryDevices and returns a single result with zero-row guard.
-func (s *operatorProvisioningService) queryDeviceSingle(adminCtx context.Context, op, whereClause string, args ...interface{}) (*OperatorDeviceInfo, error) {
-	devices, err := s.queryDevices(adminCtx, whereClause, args...)
+func (s *operatorProvisioningService) queryDeviceSingle(adminCtx context.Context, op string, deviceRowID int64) (*OperatorDeviceInfo, error) {
+	devices, err := s.queryDevices(adminCtx, platform.OperatorDeviceFilter{DeviceRowID: &deviceRowID})
 	if err != nil {
 		return nil, fmt.Errorf("%s: re-query failed: %w", op, err)
 	}
 	if len(devices) == 0 {
 		s.getLogger().Error("device not found after successful write",
 			slog.String("op", op),
-			slog.String("where", whereClause),
+			slog.Int64("device_row_id", deviceRowID),
 		)
 		return nil, fmt.Errorf("%s: device not found after write (inconsistent state)", op)
 	}
@@ -942,7 +891,7 @@ func (s *operatorProvisioningService) CreateDevice(ctx context.Context, schoolID
 		})
 
 		var queryErr error
-		result, queryErr = s.queryDeviceSingle(adminCtx, "CreateDevice", `"d".id = ?`, device.ID)
+		result, queryErr = s.queryDeviceSingle(adminCtx, "CreateDevice", device.ID)
 		return queryErr
 	})
 	if err != nil {
@@ -1030,7 +979,7 @@ func (s *operatorProvisioningService) SetDeviceAPIKey(ctx context.Context, id in
 		})
 
 		var queryErr error
-		result, queryErr = s.queryDeviceSingle(adminCtx, "SetDeviceAPIKey", `"d".id = ?`, id)
+		result, queryErr = s.queryDeviceSingle(adminCtx, "SetDeviceAPIKey", id)
 		return queryErr
 	})
 	if err != nil {
@@ -1114,20 +1063,10 @@ func (s *operatorProvisioningService) SoftDeletePerson(ctx context.Context, pers
 	}
 
 	return s.withAdminTx(ctx, func(adminCtx context.Context) error {
-		var db bun.IDB = s.txHandler.DB
-		if tx, ok := modelBase.TxFromContext(adminCtx); ok && tx != nil {
-			db = tx
-		}
-
-		// Find person (cross-tenant, raw query bypasses tenant filter).
-		// WhereAllWithDeleted is not needed here — BUN auto-excludes soft-deleted rows.
-		var person userModels.Person
-		err := db.NewSelect().
-			ModelTableExpr(`users.persons AS "person"`).
-			ColumnExpr(`"person".*`).
-			Where(`"person".id = ?`, personID).
-			Where(`"person".deleted_at IS NULL`).
-			Scan(adminCtx, &person)
+		// Find person. Cross-tenant by design: the admin context carries no
+		// tenant ID, so the repository's tenant filter is a no-op, and BUN's
+		// soft-delete handling auto-excludes deleted rows.
+		person, err := s.personRepo.FindByID(adminCtx, personID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return &PersonNotFoundError{PersonID: personID}
@@ -1136,13 +1075,8 @@ func (s *operatorProvisioningService) SoftDeletePerson(ctx context.Context, pers
 		}
 
 		// If person is staff, check for active supervisions
-		var staff userModels.Staff
-		staffErr := db.NewSelect().
-			ModelTableExpr(`users.staff AS "staff"`).
-			ColumnExpr(`"staff".*`).
-			Where(`"staff".person_id = ?`, personID).
-			Scan(adminCtx, &staff)
-		if staffErr == nil {
+		staff, staffErr := s.staffRepo.FindByPersonID(adminCtx, personID)
+		if staffErr == nil && staff != nil {
 			// Staff exists — check active supervisions
 			if s.groupSupervisorRepo != nil {
 				supervisors, supErr := s.groupSupervisorRepo.FindActiveByStaffID(adminCtx, staff.ID)
@@ -1160,12 +1094,7 @@ func (s *operatorProvisioningService) SoftDeletePerson(ctx context.Context, pers
 
 		// Unlink RFID card
 		if person.TagID != nil {
-			_, err = db.NewUpdate().
-				ModelTableExpr(`users.persons AS "person"`).
-				Set(`tag_id = NULL`).
-				Where(`"person".id = ?`, personID).
-				Exec(adminCtx)
-			if err != nil {
+			if err := s.personRepo.UnlinkFromRFIDCard(adminCtx, personID); err != nil {
 				return fmt.Errorf("SoftDeletePerson: unlink rfid: %w", err)
 			}
 		}
@@ -1185,37 +1114,18 @@ func (s *operatorProvisioningService) SoftDeletePerson(ctx context.Context, pers
 
 			// Anonymize email
 			anonymizedEmail := fmt.Sprintf("deleted-%d@anonymized.local", personID)
-			_, err = db.NewUpdate().
-				ModelTableExpr(`auth.accounts AS "account"`).
-				Set(`email = ?`, anonymizedEmail).
-				Set(`username = NULL`).
-				Where(`"account".id = ?`, accountID).
-				Exec(adminCtx)
-			if err != nil {
+			if err := s.accountRepo.AnonymizeForDeletion(adminCtx, accountID, anonymizedEmail); err != nil {
 				return fmt.Errorf("SoftDeletePerson: anonymize account: %w", err)
 			}
 
 			// Unlink account from person
-			_, err = db.NewUpdate().
-				ModelTableExpr(`users.persons AS "person"`).
-				Set(`account_id = NULL`).
-				Where(`"person".id = ?`, personID).
-				Exec(adminCtx)
-			if err != nil {
+			if err := s.personRepo.UnlinkFromAccount(adminCtx, personID); err != nil {
 				return fmt.Errorf("SoftDeletePerson: unlink account: %w", err)
 			}
 		}
 
 		// Anonymize PII and soft delete
-		_, err = db.NewUpdate().
-			ModelTableExpr(`users.persons AS "person"`).
-			Set(`first_name = ?`, "Gelöscht").
-			Set(`last_name = ?`, "Benutzer").
-			Set(`birthday = NULL`).
-			Set(`deleted_at = NOW()`).
-			Where(`"person".id = ?`, personID).
-			Exec(adminCtx)
-		if err != nil {
+		if err := s.personRepo.AnonymizeAndSoftDelete(adminCtx, personID); err != nil {
 			return fmt.Errorf("SoftDeletePerson: anonymize and soft delete: %w", err)
 		}
 

--- a/backend/services/platform/operator_provisioning_service_internal_test.go
+++ b/backend/services/platform/operator_provisioning_service_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	platformRepo "github.com/moto-nrw/project-phoenix/database/repositories/platform"
 	activityModels "github.com/moto-nrw/project-phoenix/models/activities"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
@@ -1274,9 +1275,10 @@ func TestQueryDevices_NoWhereClause(t *testing.T) {
 	}))
 
 	svc := &operatorProvisioningService{
-		txHandler: modelBase.NewTxHandler(bunDB),
+		txHandler:     modelBase.NewTxHandler(bunDB),
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 	}
-	result, err := svc.queryDevices(context.Background(), "")
+	result, err := svc.queryDevices(context.Background(), platformModels.OperatorDeviceFilter{})
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
@@ -1298,9 +1300,10 @@ func TestQueryDevices_WithWhereClause(t *testing.T) {
 	}))
 
 	svc := &operatorProvisioningService{
-		txHandler: modelBase.NewTxHandler(bunDB),
+		txHandler:     modelBase.NewTxHandler(bunDB),
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 	}
-	result, err := svc.queryDevices(context.Background(), `"d".tenant_id = ?`, int64(42))
+	result, err := svc.queryDevices(context.Background(), platformModels.OperatorDeviceFilter{SchoolID: int64Ptr(42)})
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
@@ -1318,9 +1321,10 @@ func TestQueryDevices_ScanError(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnError(assert.AnError)
 
 	svc := &operatorProvisioningService{
-		txHandler: modelBase.NewTxHandler(bunDB),
+		txHandler:     modelBase.NewTxHandler(bunDB),
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 	}
-	result, err := svc.queryDevices(context.Background(), "")
+	result, err := svc.queryDevices(context.Background(), platformModels.OperatorDeviceFilter{})
 	require.Error(t, err)
 	assert.Nil(t, result)
 }
@@ -1348,9 +1352,10 @@ func TestQueryDevices_UsesTxFromContext(t *testing.T) {
 	}))
 
 	svc := &operatorProvisioningService{
-		txHandler: modelBase.NewTxHandler(bunDB),
+		txHandler:     modelBase.NewTxHandler(bunDB),
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 	}
-	result, err := svc.queryDevices(ctx, "")
+	result, err := svc.queryDevices(ctx, platformModels.OperatorDeviceFilter{})
 	require.NoError(t, err)
 	assert.Empty(t, result)
 
@@ -1383,7 +1388,8 @@ func TestListAllDevices_Success(t *testing.T) {
 	mock.ExpectCommit()
 
 	svc := &operatorProvisioningService{
-		txHandler: modelBase.NewTxHandler(bunDB),
+		txHandler:     modelBase.NewTxHandler(bunDB),
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 	}
 	result, err := svc.ListAllDevices(context.Background())
 	require.NoError(t, err)
@@ -1414,6 +1420,7 @@ func TestListSchoolDevices_Success(t *testing.T) {
 	mock.ExpectCommit()
 
 	svc := &operatorProvisioningService{
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 		schoolRepo: &internalSchoolRepoStub{
 			findByIDFn: func(context.Context, int64) (*platformModels.School, error) {
 				return &platformModels.School{
@@ -1457,6 +1464,7 @@ func TestListOrganizationDevices_Success(t *testing.T) {
 	mock.ExpectCommit()
 
 	svc := &operatorProvisioningService{
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 		organizationRepo: &internalOrgRepoStub{
 			findByIDFn: func(context.Context, int64) (*platformModels.Organization, error) {
 				return &platformModels.Organization{Model: modelBase.Model{ID: 5}, Name: "Org", Slug: "org", Active: true}, nil
@@ -1612,6 +1620,7 @@ func TestCreateDevice_Success_AutoKey(t *testing.T) {
 	mock.ExpectCommit()
 
 	svc := &operatorProvisioningService{
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 		schoolRepo: &internalSchoolRepoStub{
 			findByIDFn: func(context.Context, int64) (*platformModels.School, error) {
 				return &platformModels.School{
@@ -1683,6 +1692,7 @@ func TestCreateDevice_Success_ManualKey(t *testing.T) {
 	mock.ExpectCommit()
 
 	svc := &operatorProvisioningService{
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 		schoolRepo: &internalSchoolRepoStub{
 			findByIDFn: func(context.Context, int64) (*platformModels.School, error) {
 				return &platformModels.School{
@@ -1778,6 +1788,7 @@ func TestCreateDevice_AutoKeyCollisionRetry(t *testing.T) {
 	mock.ExpectCommit()
 
 	svc := &operatorProvisioningService{
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 		schoolRepo: &internalSchoolRepoStub{
 			findByIDFn: func(context.Context, int64) (*platformModels.School, error) {
 				return &platformModels.School{
@@ -1967,9 +1978,10 @@ func TestSetDeviceAPIKey_Success_AutoKey(t *testing.T) {
 				return &platformModels.School{Active: true}, nil
 			},
 		},
-		auditLogRepo: &internalAuditLogRepoStub{},
-		txHandler:    modelBase.NewTxHandler(bunDB),
-		logger:       slog.Default(),
+		auditLogRepo:  &internalAuditLogRepoStub{},
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
+		txHandler:     modelBase.NewTxHandler(bunDB),
+		logger:        slog.Default(),
 	}
 
 	result, err := svc.SetDeviceAPIKey(context.Background(), 10, nil, 1, net.IPv4(127, 0, 0, 1))
@@ -2014,6 +2026,7 @@ func TestSetDeviceAPIKey_Success_ManualKey(t *testing.T) {
 	mock.ExpectCommit()
 
 	svc := &operatorProvisioningService{
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 		deviceRepo: &internalDeviceRepoStub{
 			findByIDFn: func(_ context.Context, id interface{}) (*iotModels.Device, error) {
 				return &iotModels.Device{
@@ -2098,10 +2111,11 @@ func TestQueryDeviceSingle_RequeryFailure(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnError(assert.AnError)
 
 	svc := &operatorProvisioningService{
-		txHandler: modelBase.NewTxHandler(bunDB),
+		txHandler:     modelBase.NewTxHandler(bunDB),
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
 	}
 
-	result, err := svc.queryDeviceSingle(context.Background(), "CreateDevice", `"d".id = ?`, int64(10))
+	result, err := svc.queryDeviceSingle(context.Background(), "CreateDevice", int64(10))
 	require.Nil(t, result)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, assert.AnError)
@@ -2125,11 +2139,12 @@ func TestQueryDeviceSingle_NoRows(t *testing.T) {
 	}))
 
 	svc := &operatorProvisioningService{
-		txHandler: modelBase.NewTxHandler(bunDB),
-		logger:    slog.Default(),
+		summariesRepo: platformRepo.NewOperatorSummariesRepository(bunDB),
+		txHandler:     modelBase.NewTxHandler(bunDB),
+		logger:        slog.Default(),
 	}
 
-	result, err := svc.queryDeviceSingle(context.Background(), "SetDeviceAPIKey", `"d".id = ?`, int64(10))
+	result, err := svc.queryDeviceSingle(context.Background(), "SetDeviceAPIKey", int64(10))
 	require.Nil(t, result)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "SetDeviceAPIKey: device not found after write")
@@ -2536,3 +2551,5 @@ func TestGenerateRandomSuffix(t *testing.T) {
 		assert.NotEqual(t, a, b, "two random suffixes should differ")
 	})
 }
+
+func int64Ptr(v int64) *int64 { return &v }

--- a/backend/services/platform/operator_provisioning_service_test.go
+++ b/backend/services/platform/operator_provisioning_service_test.go
@@ -3797,3 +3797,19 @@ func TestOperatorProvisioningService_LoadActiveSchool_RejectsDeletedSchool(t *te
 	var deletedErr *platformSvc.SchoolAlreadyDeletedError
 	require.ErrorAs(t, err, &deletedErr)
 }
+
+// Stub for the issue #585 refactor interface addition — unused here.
+func (m *mockPersonRepo) AnonymizeAndSoftDelete(context.Context, int64) error { return nil }
+
+// Stub for the issue #585 refactor interface addition — unused here.
+func (m *mockSummariesRepo) ListDeviceRows(context.Context, platformModels.OperatorDeviceFilter) ([]platformModels.OperatorDeviceRow, error) {
+	return nil, nil
+}
+
+func (m *mockTeacherRepo) ListActiveCaregivers(context.Context) ([]*userModels.ActiveCaregiver, error) {
+	return nil, nil
+}
+
+func (m *mockTeacherRepo) FindActiveCaregiverByAccountID(context.Context, int64) (*userModels.ActiveCaregiver, error) {
+	return nil, nil
+}

--- a/backend/services/schedule/arrival_service.go
+++ b/backend/services/schedule/arrival_service.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
-	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -188,19 +187,9 @@ func (s *arrivalScheduleService) UpsertStudentArrivalSchedule(ctx context.Contex
 // This deletes existing schedules and inserts the new ones atomically,
 // ensuring that cleared weekdays are properly removed.
 func (s *arrivalScheduleService) UpsertBulkStudentArrivalSchedules(ctx context.Context, studentID int64, schedules []*schedule.StudentArrivalSchedule) error {
-	// Use transaction from context if available (handler's WithTenantTx), otherwise fall back to db
-	var db bun.IDB = s.db
-	if tx, ok := base.TxFromContext(ctx); ok && tx != nil {
-		db = tx
-	}
-
-	// Delete all existing schedules for this student first
-	_, err := db.NewDelete().
-		Model((*schedule.StudentArrivalSchedule)(nil)).
-		ModelTableExpr("schedule.student_arrival_schedules").
-		Where("student_id = ?", studentID).
-		Exec(ctx)
-	if err != nil {
+	// Delete all existing schedules for this student first. The repository
+	// joins the handler's WithTenantTx transaction via the context.
+	if err := s.scheduleRepo.DeleteByStudentID(ctx, studentID); err != nil {
 		return &ScheduleError{Op: opUpsertBulkStudentArrivalSchedules, Err: fmt.Errorf("failed to delete existing schedules: %w", err)}
 	}
 
@@ -212,12 +201,7 @@ func (s *arrivalScheduleService) UpsertBulkStudentArrivalSchedules(ctx context.C
 		}
 		sched.SetTenantID(tenant.FromContext(ctx))
 
-		_, err := db.NewInsert().
-			Model(sched).
-			ModelTableExpr("schedule.student_arrival_schedules").
-			Returning("id").
-			Exec(ctx)
-		if err != nil {
+		if err := s.scheduleRepo.Create(ctx, sched); err != nil {
 			return &ScheduleError{Op: opUpsertBulkStudentArrivalSchedules, Err: err}
 		}
 	}

--- a/backend/services/schedule/attendance_sync_service_unit_test.go
+++ b/backend/services/schedule/attendance_sync_service_unit_test.go
@@ -466,3 +466,29 @@ func TestAttendanceSync_NilLoggerUsesDefault(t *testing.T) {
 		assert.Nil(t, svc.LoadAttendanceForVisit(context.Background(), validVisit()))
 	})
 }
+
+// Stubs for the issue #585 cleanup refactor interface additions — unused by
+// the attendance-sync tests.
+func (f *fakeInstanceRepo) CompleteActiveByActiveGroupIDs(context.Context, []int64, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeInstanceRepo) CountWithOptions(context.Context, *modelsBase.QueryOptions) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeInstanceRepo) OldestBefore(context.Context, string, *time.Time) (*time.Time, error) {
+	return nil, nil
+}
+
+func (f *fakeInstanceRepo) DeleteOlderThan(context.Context, string, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeInstanceStudentRepo) MarkExpectedAbsentByActiveGroupIDs(context.Context, []int64, time.Time) error {
+	return nil
+}
+
+func (f *fakeInstanceStudentRepo) ListStudentInstanceRefsBefore(context.Context, time.Time) ([]scheduleModel.StudentInstanceRef, error) {
+	return nil, nil
+}

--- a/backend/services/schedule/attendance_sync_service_unit_test.go
+++ b/backend/services/schedule/attendance_sync_service_unit_test.go
@@ -492,3 +492,11 @@ func (f *fakeInstanceStudentRepo) MarkExpectedAbsentByActiveGroupIDs(context.Con
 func (f *fakeInstanceStudentRepo) ListStudentInstanceRefsBefore(context.Context, time.Time) ([]scheduleModel.StudentInstanceRef, error) {
 	return nil, nil
 }
+
+func (f *fakeInstanceRepo) DeletePlannedNonSpontaneousInWindow(context.Context, time.Time, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeInstanceRepo) UpdateColumns(context.Context, *scheduleModel.ActivityInstance, ...string) (int64, error) {
+	return 0, nil
+}

--- a/backend/services/schedule/auto_start_service_test.go
+++ b/backend/services/schedule/auto_start_service_test.go
@@ -200,3 +200,21 @@ func (s *autoStartInstanceStarter) Create(context.Context, CreateInstanceInput) 
 func (s *autoStartInstanceStarter) UpdatePlanned(context.Context, int64, UpdateInstanceInput) (*scheduleModel.ActivityInstance, error) {
 	return nil, nil
 }
+
+// Stubs for the issue #585 cleanup refactor interface additions — unused by
+// the auto-start tests.
+func (r *autoStartInstanceRepo) CompleteActiveByActiveGroupIDs(context.Context, []int64, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (r *autoStartInstanceRepo) CountWithOptions(context.Context, *base.QueryOptions) (int, error) {
+	return 0, nil
+}
+
+func (r *autoStartInstanceRepo) OldestBefore(context.Context, string, *time.Time) (*time.Time, error) {
+	return nil, nil
+}
+
+func (r *autoStartInstanceRepo) DeleteOlderThan(context.Context, string, time.Time) (int64, error) {
+	return 0, nil
+}

--- a/backend/services/schedule/auto_start_service_test.go
+++ b/backend/services/schedule/auto_start_service_test.go
@@ -218,3 +218,11 @@ func (r *autoStartInstanceRepo) OldestBefore(context.Context, string, *time.Time
 func (r *autoStartInstanceRepo) DeleteOlderThan(context.Context, string, time.Time) (int64, error) {
 	return 0, nil
 }
+
+func (r *autoStartInstanceRepo) DeletePlannedNonSpontaneousInWindow(context.Context, time.Time, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (r *autoStartInstanceRepo) UpdateColumns(context.Context, *scheduleModel.ActivityInstance, ...string) (int64, error) {
+	return 0, nil
+}

--- a/backend/services/schedule/calendar_period_service.go
+++ b/backend/services/schedule/calendar_period_service.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 // CalendarPeriodService defines operations for managing calendar periods
@@ -27,19 +26,16 @@ type CalendarPeriodService interface {
 // calendarPeriodService implements CalendarPeriodService
 type calendarPeriodService struct {
 	repo   schedule.CalendarPeriodRepository
-	db     *bun.DB
 	logger *slog.Logger
 }
 
 // NewCalendarPeriodService creates a new calendar period service
 func NewCalendarPeriodService(
 	repo schedule.CalendarPeriodRepository,
-	db *bun.DB,
 	logger *slog.Logger,
 ) CalendarPeriodService {
 	return &calendarPeriodService{
 		repo:   repo,
-		db:     db,
 		logger: logger,
 	}
 }

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -29,7 +29,6 @@ import (
 	"log/slog"
 	"time"
 
-	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
@@ -628,15 +627,7 @@ func (s *instanceService) updateLifecycleColumns(ctx context.Context, instance *
 	if len(columns) == 0 {
 		return nil
 	}
-	q := repoBase.GetDB(ctx, s.deps.DB).NewUpdate().
-		Model(instance).
-		ModelTableExpr(`schedule.activity_instances AS "activity_instance"`).
-		Where(`"activity_instance".id = ?`, instance.ID).
-		Where(`"activity_instance".tenant_id = ?`, tenant.FromContext(ctx))
-	for _, col := range columns {
-		q = q.Column(col)
-	}
-	_, err := q.Exec(ctx)
+	_, err := s.deps.InstanceRepo.UpdateColumns(ctx, instance, columns...)
 	return err
 }
 
@@ -661,18 +652,10 @@ func (s *instanceService) ReplanWeek(ctx context.Context, from, to time.Time) (*
 		return nil, &ScheduleError{Op: "replan week", Err: errors.New("no tenant in context")}
 	}
 
-	res, err := repoBase.GetDB(ctx, s.deps.DB).NewDelete().
-		Table("schedule.activity_instances").
-		Where("tenant_id = ?", tenantID).
-		Where("date >= ?", from).
-		Where("date <= ?", to).
-		Where("status = ?", scheduleModel.InstanceStatusPlanned).
-		Where("is_spontaneous = ?", false).
-		Exec(ctx)
+	deleted, err := s.deps.InstanceRepo.DeletePlannedNonSpontaneousInWindow(ctx, from, to)
 	if err != nil {
 		return nil, &ScheduleError{Op: "replan week: delete planned", Err: err}
 	}
-	deleted, _ := res.RowsAffected() // nil-driver-safe: fall through with 0
 
 	mat, err := s.deps.Materialization.MaterializeForTenant(ctx, from, to, MaterializationSourceManual)
 	if err != nil {

--- a/backend/services/schedule/materialization_integration_test.go
+++ b/backend/services/schedule/materialization_integration_test.go
@@ -106,7 +106,6 @@ func makeScenario(t *testing.T, weekday int, materializeDate time.Time) *scenari
 		repoFactory.ActivityException,
 		repoFactory.Timeframe,
 		serviceFactory.CalendarPeriod,
-		db,
 		slog.Default(),
 	)
 
@@ -336,7 +335,7 @@ func TestMaterializeForTenant_NoActivePeriod_ReturnsGracefully(t *testing.T) {
 		repoFactory.ActivityGroup, repoFactory.ActivitySchedule, repoFactory.StudentEnrollment,
 		repoFactory.ActivitySupervisor, repoFactory.CalendarPeriod, repoFactory.ActivityInstance,
 		repoFactory.InstanceStaff, repoFactory.InstanceStudent, repoFactory.ActivityException,
-		repoFactory.Timeframe, serviceFactory.CalendarPeriod, db, slog.Default(),
+		repoFactory.Timeframe, serviceFactory.CalendarPeriod, slog.Default(),
 	)
 
 	// Use a fresh tenant id that we know has no active periods.
@@ -373,7 +372,7 @@ func TestMaterializeForTenant_NoTemplates_ReturnsWarning(t *testing.T) {
 		repoFactory.ActivityGroup, repoFactory.ActivitySchedule, repoFactory.StudentEnrollment,
 		repoFactory.ActivitySupervisor, repoFactory.CalendarPeriod, repoFactory.ActivityInstance,
 		repoFactory.InstanceStaff, repoFactory.InstanceStudent, repoFactory.ActivityException,
-		repoFactory.Timeframe, serviceFactory.CalendarPeriod, db, slog.Default(),
+		repoFactory.Timeframe, serviceFactory.CalendarPeriod, slog.Default(),
 	)
 
 	const emptyTemplateTenantID = int64(990002)

--- a/backend/services/schedule/materialization_service.go
+++ b/backend/services/schedule/materialization_service.go
@@ -44,7 +44,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 // MaxMaterializationWindowDays caps how many civil days a single call may
@@ -136,7 +135,6 @@ type materializationService struct {
 	exceptionRepo   schedule.ActivityExceptionRepository
 	timeframeRepo   schedule.TimeframeRepository
 	calendarService CalendarPeriodService
-	db              *bun.DB
 	logger          *slog.Logger
 }
 
@@ -156,7 +154,6 @@ func NewMaterializationService(
 	exceptionRepo schedule.ActivityExceptionRepository,
 	timeframeRepo schedule.TimeframeRepository,
 	calendarService CalendarPeriodService,
-	db *bun.DB,
 	logger *slog.Logger,
 ) MaterializationService {
 	return &materializationService{
@@ -171,7 +168,6 @@ func NewMaterializationService(
 		exceptionRepo:   exceptionRepo,
 		timeframeRepo:   timeframeRepo,
 		calendarService: calendarService,
-		db:              db,
 		logger:          logger,
 	}
 }

--- a/backend/services/schedule/materialization_service_test.go
+++ b/backend/services/schedule/materialization_service_test.go
@@ -675,7 +675,6 @@ func TestMaterializeForTenant_PreconditionWarnings(t *testing.T) {
 			materializationFakeExceptionRepo{},
 			materializationFakeTimeframeRepo{},
 			materializationAllowCalendarService{},
-			nil,
 			slog.Default(),
 		)
 
@@ -705,7 +704,6 @@ func TestMaterializeForTenant_PreconditionWarnings(t *testing.T) {
 			materializationFakeExceptionRepo{},
 			materializationFakeTimeframeRepo{},
 			materializationAllowCalendarService{},
-			nil,
 			slog.Default(),
 		)
 
@@ -756,7 +754,6 @@ func TestMaterializeForTenant_ErrorBranches(t *testing.T) {
 			exceptionRepo,
 			timeframeRepo,
 			materializationAllowCalendarService{},
-			nil,
 			slog.Default(),
 		)
 	}
@@ -1018,7 +1015,6 @@ func newMaterializationBranchService(instanceRepo materializationFakeInstanceRep
 			Model:     modelBase.Model{ID: timeframeID},
 		}}},
 		materializationAllowCalendarService{},
-		nil,
 		slog.Default(),
 	)
 

--- a/backend/services/schedule/pickup_schedule_service.go
+++ b/backend/services/schedule/pickup_schedule_service.go
@@ -8,10 +8,8 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
-	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 // PickupScheduleService defines operations for managing student pickup schedules
@@ -86,7 +84,6 @@ type pickupScheduleService struct {
 	scheduleRepo  schedule.StudentPickupScheduleRepository
 	exceptionRepo schedule.StudentPickupExceptionRepository
 	noteRepo      schedule.StudentPickupNoteRepository
-	db            *bun.DB
 }
 
 // NewPickupScheduleService creates a new pickup schedule service
@@ -94,13 +91,11 @@ func NewPickupScheduleService(
 	scheduleRepo schedule.StudentPickupScheduleRepository,
 	exceptionRepo schedule.StudentPickupExceptionRepository,
 	noteRepo schedule.StudentPickupNoteRepository,
-	db *bun.DB,
 ) PickupScheduleService {
 	return &pickupScheduleService{
 		scheduleRepo:  scheduleRepo,
 		exceptionRepo: exceptionRepo,
 		noteRepo:      noteRepo,
-		db:            db,
 	}
 }
 
@@ -144,19 +139,9 @@ func (s *pickupScheduleService) UpsertStudentPickupSchedule(ctx context.Context,
 // This deletes existing schedules and inserts the new ones atomically,
 // ensuring that cleared weekdays are properly removed.
 func (s *pickupScheduleService) UpsertBulkStudentPickupSchedules(ctx context.Context, studentID int64, schedules []*schedule.StudentPickupSchedule) error {
-	// Use transaction from context if available (handler's WithTenantTx), otherwise fall back to db
-	var db bun.IDB = s.db
-	if tx, ok := base.TxFromContext(ctx); ok && tx != nil {
-		db = tx
-	}
-
-	// Delete all existing schedules for this student first
-	_, err := db.NewDelete().
-		Model((*schedule.StudentPickupSchedule)(nil)).
-		ModelTableExpr("schedule.student_pickup_schedules").
-		Where("student_id = ?", studentID).
-		Exec(ctx)
-	if err != nil {
+	// Delete all existing schedules for this student first. The repository
+	// joins the handler's WithTenantTx transaction via the context.
+	if err := s.scheduleRepo.DeleteByStudentID(ctx, studentID); err != nil {
 		return &ScheduleError{Op: opUpsertBulkStudentPickupSchedules, Err: fmt.Errorf("failed to delete existing schedules: %w", err)}
 	}
 
@@ -168,12 +153,7 @@ func (s *pickupScheduleService) UpsertBulkStudentPickupSchedules(ctx context.Con
 		}
 		sched.SetTenantID(tenant.FromContext(ctx))
 
-		_, err := db.NewInsert().
-			Model(sched).
-			ModelTableExpr("schedule.student_pickup_schedules").
-			Returning("id").
-			Exec(ctx)
-		if err != nil {
+		if err := s.scheduleRepo.Create(ctx, sched); err != nil {
 			return &ScheduleError{Op: opUpsertBulkStudentPickupSchedules, Err: err}
 		}
 	}

--- a/backend/services/schedule/schedule_service.go
+++ b/backend/services/schedule/schedule_service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 // Operation name constants to avoid string duplication
@@ -25,7 +24,6 @@ type service struct {
 	dateframeRepo      schedule.DateframeRepository
 	timeframeRepo      schedule.TimeframeRepository
 	recurrenceRuleRepo schedule.RecurrenceRuleRepository
-	db                 *bun.DB
 }
 
 // NewService creates a new schedule service
@@ -33,13 +31,11 @@ func NewService(
 	dateframeRepo schedule.DateframeRepository,
 	timeframeRepo schedule.TimeframeRepository,
 	recurrenceRuleRepo schedule.RecurrenceRuleRepository,
-	db *bun.DB,
 ) Service {
 	return &service{
 		dateframeRepo:      dateframeRepo,
 		timeframeRepo:      timeframeRepo,
 		recurrenceRuleRepo: recurrenceRuleRepo,
-		db:                 db,
 	}
 }
 

--- a/backend/services/schedule/schedule_service_test.go
+++ b/backend/services/schedule/schedule_service_test.go
@@ -25,7 +25,6 @@ func setupScheduleService(t *testing.T, db *bun.DB) scheduleSvc.Service {
 		repoFactory.Dateframe,
 		repoFactory.Timeframe,
 		repoFactory.RecurrenceRule,
-		db,
 	)
 }
 

--- a/backend/services/schedule/timetable_cleanup_gaps_test.go
+++ b/backend/services/schedule/timetable_cleanup_gaps_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	auditRepoPkg "github.com/moto-nrw/project-phoenix/database/repositories/audit"
+	scheduleRepoPkg "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	configModels "github.com/moto-nrw/project-phoenix/models/config"
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
@@ -76,7 +77,9 @@ func (s *stubSettingsService) ClearLoginImageURL(context.Context, int64) (string
 // buildSvc wires a TimetableCleanupService with the given settings stub.
 func buildSvc(db *bun.DB, settings configSvc.SettingsService) scheduleSvc.TimetableCleanupService {
 	return scheduleSvc.NewTimetableCleanupService(
-		db,
+		scheduleRepoPkg.NewActivityInstanceRepository(db),
+		scheduleRepoPkg.NewActivityExceptionRepository(db),
+		scheduleRepoPkg.NewInstanceStudentRepository(db),
 		auditRepoPkg.NewDataDeletionRepository(db),
 		settings,
 		slog.Default(),
@@ -268,7 +271,14 @@ func TestCleanup_NilAuditRepo_ReturnsError(t *testing.T) {
 	f.attachStudent(t, instID, stud.ID, nil)
 
 	// Build service with nil audit repo.
-	svc := scheduleSvc.NewTimetableCleanupService(f.db, nil, nil, slog.Default())
+	svc := scheduleSvc.NewTimetableCleanupService(
+		scheduleRepoPkg.NewActivityInstanceRepository(f.db),
+		scheduleRepoPkg.NewActivityExceptionRepository(f.db),
+		scheduleRepoPkg.NewInstanceStudentRepository(f.db),
+		nil,
+		nil,
+		slog.Default(),
+	)
 
 	_, err := svc.CleanupExpiredTimetableData(f.ctx)
 	require.Error(t, err)
@@ -288,7 +298,9 @@ func TestNewTimetableCleanupService_NilLogger_FallsBackToDefault(t *testing.T) {
 	// Pass nil logger — constructor must substitute slog.Default() so calls
 	// inside the service do not panic.
 	svc := scheduleSvc.NewTimetableCleanupService(
-		db,
+		scheduleRepoPkg.NewActivityInstanceRepository(db),
+		scheduleRepoPkg.NewActivityExceptionRepository(db),
+		scheduleRepoPkg.NewInstanceStudentRepository(db),
 		auditRepoPkg.NewDataDeletionRepository(db),
 		nil,
 		nil,

--- a/backend/services/schedule/timetable_cleanup_service.go
+++ b/backend/services/schedule/timetable_cleanup_service.go
@@ -18,8 +18,8 @@
 //
 //   - Caller supplies tenant context. The service trusts ctx has an active
 //     WithTenantTx — both deletes run inside the caller's transaction and
-//     RLS enforces the tenant boundary. Explicit `tenant_id = ?` predicates
-//     are defense-in-depth.
+//     RLS enforces the tenant boundary. The repositories add `tenant_id = ?`
+//     predicates as defense-in-depth.
 //
 //   - Per-student audit rows (one row per affected student, not per run).
 //     activity_exceptions carry no PII (template-scoped) and are not logged
@@ -38,12 +38,19 @@ import (
 	"log/slog"
 	"time"
 
-	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/models/audit"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/services/config"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
+)
+
+// instanceDateColumn / exceptionDateColumn are the retention-age columns the
+// cleanup predicates run on.
+const (
+	instanceDateColumn  = "date"
+	exceptionDateColumn = "exception_date"
 )
 
 // auditInstanceIDSampleCap bounds the number of instance IDs sampled into a
@@ -102,16 +109,20 @@ type TimetableCleanupService interface {
 
 // timetableCleanupService implements TimetableCleanupService.
 type timetableCleanupService struct {
-	db        *bun.DB
-	auditRepo audit.DataDeletionRepository
-	settings  config.SettingsService
-	logger    *slog.Logger
+	instanceRepo        scheduleModel.ActivityInstanceRepository
+	exceptionRepo       scheduleModel.ActivityExceptionRepository
+	instanceStudentRepo scheduleModel.InstanceStudentRepository
+	auditRepo           audit.DataDeletionRepository
+	settings            config.SettingsService
+	logger              *slog.Logger
 }
 
 // NewTimetableCleanupService constructs the cleanup service. settings may be
 // nil in tests; when nil, retention resolves to the last-resort default 365.
 func NewTimetableCleanupService(
-	db *bun.DB,
+	instanceRepo scheduleModel.ActivityInstanceRepository,
+	exceptionRepo scheduleModel.ActivityExceptionRepository,
+	instanceStudentRepo scheduleModel.InstanceStudentRepository,
 	auditRepo audit.DataDeletionRepository,
 	settings config.SettingsService,
 	logger *slog.Logger,
@@ -120,10 +131,12 @@ func NewTimetableCleanupService(
 		logger = slog.Default()
 	}
 	return &timetableCleanupService{
-		db:        db,
-		auditRepo: auditRepo,
-		settings:  settings,
-		logger:    logger,
+		instanceRepo:        instanceRepo,
+		exceptionRepo:       exceptionRepo,
+		instanceStudentRepo: instanceStudentRepo,
+		auditRepo:           auditRepo,
+		settings:            settings,
+		logger:              logger,
 	}
 }
 
@@ -140,10 +153,8 @@ func (s *timetableCleanupService) CleanupExpiredTimetableData(ctx context.Contex
 	retentionDays := s.resolveRetentionDays(ctx)
 	cutoff := cutoffFor(retentionDays)
 
-	db := repoBase.GetDB(ctx, s.db)
-
 	// 1. Collect per-student impact for the audit log.
-	studentCounts, sampleIDs, err := s.collectStudentImpact(ctx, db, tenantID, cutoff)
+	studentCounts, sampleIDs, err := s.collectStudentImpact(ctx, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("collect student impact: %w", err)
 	}
@@ -156,21 +167,21 @@ func (s *timetableCleanupService) CleanupExpiredTimetableData(ctx context.Contex
 	}
 
 	// 3. Delete activity_instances. CASCADE handles instance_staff + instance_students.
-	instancesDeleted, err := deleteOldInstances(ctx, db, tenantID, cutoff)
+	instancesDeleted, err := s.instanceRepo.DeleteOlderThan(ctx, instanceDateColumn, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("delete activity_instances: %w", err)
 	}
 
 	// 4. Delete activity_exceptions.
-	exceptionsDeleted, err := deleteOldExceptions(ctx, db, tenantID, cutoff)
+	exceptionsDeleted, err := s.exceptionRepo.DeleteOlderThan(ctx, exceptionDateColumn, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("delete activity_exceptions: %w", err)
 	}
 
 	result := &TimetableCleanupResult{
 		Success:           true,
-		InstancesDeleted:  instancesDeleted,
-		ExceptionsDeleted: exceptionsDeleted,
+		InstancesDeleted:  int(instancesDeleted),
+		ExceptionsDeleted: int(exceptionsDeleted),
 		StudentsAffected:  len(studentCounts),
 		RetentionDays:     retentionDays,
 		CutoffDate:        cutoff,
@@ -179,8 +190,8 @@ func (s *timetableCleanupService) CleanupExpiredTimetableData(ctx context.Contex
 
 	s.logger.Info("timetable cleanup completed",
 		slog.Int64("tenant_id", tenantID),
-		slog.Int("instances_deleted", instancesDeleted),
-		slog.Int("exceptions_deleted", exceptionsDeleted),
+		slog.Int("instances_deleted", result.InstancesDeleted),
+		slog.Int("exceptions_deleted", result.ExceptionsDeleted),
 		slog.Int("students_affected", result.StudentsAffected),
 		slog.Int("retention_days", retentionDays),
 		slog.String("cutoff_date", cutoff.Format("2006-01-02")),
@@ -199,40 +210,27 @@ func (s *timetableCleanupService) PreviewExpiredTimetableData(ctx context.Contex
 
 	retentionDays := s.resolveRetentionDays(ctx)
 	cutoff := cutoffFor(retentionDays)
-	db := repoBase.GetDB(ctx, s.db)
 
-	instancesToDelete, err := db.NewSelect().
-		Table("schedule.activity_instances").
-		Where("tenant_id = ?", tenantID).
-		Where("date < ?", cutoff).
-		Count(ctx)
+	instancesToDelete, err := s.instanceRepo.CountWithOptions(ctx, expiredOptions(instanceDateColumn, cutoff))
 	if err != nil {
 		return nil, fmt.Errorf("count activity_instances: %w", err)
 	}
 
-	exceptionsToDelete, err := db.NewSelect().
-		Table("schedule.activity_exceptions").
-		Where("tenant_id = ?", tenantID).
-		Where("exception_date < ?", cutoff).
-		Count(ctx)
+	exceptionsToDelete, err := s.exceptionRepo.CountWithOptions(ctx, expiredOptions(exceptionDateColumn, cutoff))
 	if err != nil {
 		return nil, fmt.Errorf("count activity_exceptions: %w", err)
 	}
 
-	studentCounts, _, err := s.collectStudentImpact(ctx, db, tenantID, cutoff)
+	studentCounts, _, err := s.collectStudentImpact(ctx, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("collect student impact: %w", err)
 	}
 
-	oldestInstance, err := scanOldestTimestamp(ctx, db,
-		`SELECT MIN(date) AS t FROM schedule.activity_instances WHERE tenant_id = ? AND date < ?`,
-		tenantID, cutoff)
+	oldestInstance, err := s.instanceRepo.OldestBefore(ctx, instanceDateColumn, &cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("oldest activity_instance: %w", err)
 	}
-	oldestException, err := scanOldestTimestamp(ctx, db,
-		`SELECT MIN(exception_date) AS t FROM schedule.activity_exceptions WHERE tenant_id = ? AND exception_date < ?`,
-		tenantID, cutoff)
+	oldestException, err := s.exceptionRepo.OldestBefore(ctx, exceptionDateColumn, &cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("oldest activity_exception: %w", err)
 	}
@@ -259,33 +257,22 @@ func (s *timetableCleanupService) GetStats(ctx context.Context) (*TimetableClean
 
 	retentionDays := s.resolveRetentionDays(ctx)
 	cutoff := cutoffFor(retentionDays)
-	db := repoBase.GetDB(ctx, s.db)
 
-	totalInstances, err := db.NewSelect().
-		Table("schedule.activity_instances").
-		Where("tenant_id = ?", tenantID).
-		Count(ctx)
+	totalInstances, err := s.instanceRepo.CountWithOptions(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("count activity_instances: %w", err)
 	}
 
-	totalExceptions, err := db.NewSelect().
-		Table("schedule.activity_exceptions").
-		Where("tenant_id = ?", tenantID).
-		Count(ctx)
+	totalExceptions, err := s.exceptionRepo.CountWithOptions(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("count activity_exceptions: %w", err)
 	}
 
-	oldestInstance, err := scanOldestTimestamp(ctx, db,
-		`SELECT MIN(date) AS t FROM schedule.activity_instances WHERE tenant_id = ?`,
-		tenantID)
+	oldestInstance, err := s.instanceRepo.OldestBefore(ctx, instanceDateColumn, nil)
 	if err != nil {
 		return nil, fmt.Errorf("oldest activity_instance: %w", err)
 	}
-	oldestException, err := scanOldestTimestamp(ctx, db,
-		`SELECT MIN(exception_date) AS t FROM schedule.activity_exceptions WHERE tenant_id = ?`,
-		tenantID)
+	oldestException, err := s.exceptionRepo.OldestBefore(ctx, exceptionDateColumn, nil)
 	if err != nil {
 		return nil, fmt.Errorf("oldest activity_exception: %w", err)
 	}
@@ -334,6 +321,14 @@ func cutoffFor(retentionDays int) time.Time {
 	return today.AddDate(0, 0, -retentionDays)
 }
 
+// expiredOptions builds query options selecting rows whose dateColumn is
+// strictly before the cutoff.
+func expiredOptions(dateColumn string, cutoff time.Time) *modelBase.QueryOptions {
+	options := modelBase.NewQueryOptions()
+	options.Filter = modelBase.NewFilter().LessThan(dateColumn, cutoff)
+	return options
+}
+
 // studentImpact holds the per-student count and a bounded sample of instance
 // IDs for the audit metadata.
 type perStudentCounts map[int64]int
@@ -344,34 +339,19 @@ type perStudentSamples map[int64][]int64
 // a bounded sample of instance IDs per student for forensic lookup.
 func (s *timetableCleanupService) collectStudentImpact(
 	ctx context.Context,
-	db bun.IDB,
-	tenantID int64,
 	cutoff time.Time,
 ) (perStudentCounts, perStudentSamples, error) {
-	type row struct {
-		StudentID  int64 `bun:"student_id"`
-		InstanceID int64 `bun:"instance_id"`
-	}
-	var rows []row
-	err := db.NewSelect().
-		TableExpr("schedule.instance_students AS i_s").
-		ColumnExpr("i_s.student_id AS student_id").
-		ColumnExpr("i_s.instance_id AS instance_id").
-		Join(`JOIN schedule.activity_instances AS i ON i.id = i_s.instance_id`).
-		Where("i.tenant_id = ?", tenantID).
-		Where("i.date < ?", cutoff).
-		Order("i_s.student_id", "i_s.instance_id").
-		Scan(ctx, &rows)
+	refs, err := s.instanceStudentRepo.ListStudentInstanceRefsBefore(ctx, cutoff)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	counts := make(perStudentCounts)
 	samples := make(perStudentSamples)
-	for _, r := range rows {
-		counts[r.StudentID]++
-		if len(samples[r.StudentID]) < auditInstanceIDSampleCap {
-			samples[r.StudentID] = append(samples[r.StudentID], r.InstanceID)
+	for _, ref := range refs {
+		counts[ref.StudentID]++
+		if len(samples[ref.StudentID]) < auditInstanceIDSampleCap {
+			samples[ref.StudentID] = append(samples[ref.StudentID], ref.InstanceID)
 		}
 	}
 	return counts, samples, nil
@@ -410,45 +390,4 @@ func (s *timetableCleanupService) writeStudentAuditRows(
 		}
 	}
 	return nil
-}
-
-// deleteOldInstances issues the DELETE and returns the affected count.
-func deleteOldInstances(ctx context.Context, db bun.IDB, tenantID int64, cutoff time.Time) (int, error) {
-	res, err := db.NewDelete().
-		Table("schedule.activity_instances").
-		Where("tenant_id = ?", tenantID).
-		Where("date < ?", cutoff).
-		Exec(ctx)
-	if err != nil {
-		return 0, err
-	}
-	affected, _ := res.RowsAffected()
-	return int(affected), nil
-}
-
-// deleteOldExceptions mirrors deleteOldInstances for exceptions.
-func deleteOldExceptions(ctx context.Context, db bun.IDB, tenantID int64, cutoff time.Time) (int, error) {
-	res, err := db.NewDelete().
-		Table("schedule.activity_exceptions").
-		Where("tenant_id = ?", tenantID).
-		Where("exception_date < ?", cutoff).
-		Exec(ctx)
-	if err != nil {
-		return 0, err
-	}
-	affected, _ := res.RowsAffected()
-	return int(affected), nil
-}
-
-// scanOldestTimestamp runs a MIN() query and returns nil when no rows match.
-// The caller must include `AS t` on the MIN() column so bun can map it.
-func scanOldestTimestamp(ctx context.Context, db bun.IDB, query string, args ...any) (*time.Time, error) {
-	var nt struct {
-		T *time.Time `bun:"t"`
-	}
-	err := db.NewRaw(query, args...).Scan(ctx, &nt)
-	if err != nil {
-		return nil, err
-	}
-	return nt.T, nil
 }

--- a/backend/services/schedule/timetable_cleanup_service_test.go
+++ b/backend/services/schedule/timetable_cleanup_service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	auditRepoPkg "github.com/moto-nrw/project-phoenix/database/repositories/audit"
+	scheduleRepoPkg "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
@@ -182,7 +183,9 @@ func setupFixture(t *testing.T) (*instFixture, int64) {
 // service with a stubSettingsService.
 func newCleanupSvc(db *bun.DB) scheduleSvc.TimetableCleanupService {
 	return scheduleSvc.NewTimetableCleanupService(
-		db,
+		scheduleRepoPkg.NewActivityInstanceRepository(db),
+		scheduleRepoPkg.NewActivityExceptionRepository(db),
+		scheduleRepoPkg.NewInstanceStudentRepository(db),
 		auditRepoPkg.NewDataDeletionRepository(db),
 		nil, // no settings — retention falls through to the 365-day default
 		slog.Default(),
@@ -309,7 +312,9 @@ func TestCleanup_RetentionOverride_UsesOverriddenDays(t *testing.T) {
 	// service provides when a school admin sets the value in the UI.
 	f, roomID := setupFixture(t)
 	svc := scheduleSvc.NewTimetableCleanupService(
-		f.db,
+		scheduleRepoPkg.NewActivityInstanceRepository(f.db),
+		scheduleRepoPkg.NewActivityExceptionRepository(f.db),
+		scheduleRepoPkg.NewInstanceStudentRepository(f.db),
 		auditRepoPkg.NewDataDeletionRepository(f.db),
 		&stubSettingsService{hasOverride: true, intVal: 30},
 		slog.Default(),
@@ -547,7 +552,9 @@ func TestCleanup_AuditWriteFailure_BubblesError(t *testing.T) {
 	f.attachStudent(t, instID, student.ID, nil)
 
 	svc := scheduleSvc.NewTimetableCleanupService(
-		f.db,
+		scheduleRepoPkg.NewActivityInstanceRepository(f.db),
+		scheduleRepoPkg.NewActivityExceptionRepository(f.db),
+		scheduleRepoPkg.NewInstanceStudentRepository(f.db),
 		&failingAuditRepo{err: errors.New("simulated audit failure")},
 		nil,
 		slog.Default(),

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -119,6 +119,7 @@ type Scheduler struct {
 	// does not emit `instance_overdue` every minute for the same planned
 	// row. Cleared explicitly on day boundary; see checkAndRunOverdue.
 	instanceRepo        scheduleModel.ActivityInstanceRepository
+	instanceStudentRepo scheduleModel.InstanceStudentRepository
 	overdueBroadcaster  realtime.Broadcaster
 	overdueEmitted      sync.Map // overdueKey{tenantID, instanceID} → time.Time
 	overdueEmittedDay   time.Time
@@ -260,6 +261,16 @@ func (s *Scheduler) SetSettingsService(svc SettingsResolver) {
 func (s *Scheduler) SetInstanceOverdueDeps(repo scheduleModel.ActivityInstanceRepository, broadcaster realtime.Broadcaster) {
 	s.instanceRepo = repo
 	s.overdueBroadcaster = broadcaster
+}
+
+// SetTimetableBridgeRepos wires the schedule-side repositories used by the
+// daily session-end bridge (completeTimetableInstancesForEndedSessions).
+// Independent of the overdue-tick wiring: it also sets instanceRepo so the
+// bridge works even when SetInstanceOverdueDeps was never called. Without
+// this wiring the bridge is a no-op.
+func (s *Scheduler) SetTimetableBridgeRepos(instanceStudents scheduleModel.InstanceStudentRepository, instances scheduleModel.ActivityInstanceRepository) {
+	s.instanceStudentRepo = instanceStudents
+	s.instanceRepo = instances
 }
 
 // forEachTenant executes fn for each active tenant inside a WithTenantTx.
@@ -647,43 +658,22 @@ func (s *Scheduler) executeSessionEnd(task *ScheduledTask) {
 // return the error so the active close rolls back too instead of leaving the
 // planner in a stale "active" state.
 func (s *Scheduler) completeTimetableInstancesForEndedSessions(ctx context.Context, result *active.DailySessionCleanupResult) (int, error) {
-	if result == nil || len(result.EndedActiveGroupIDs) == 0 || s.db == nil {
+	if result == nil || len(result.EndedActiveGroupIDs) == 0 {
+		return 0, nil
+	}
+	if s.instanceStudentRepo == nil || s.instanceRepo == nil {
 		return 0, nil
 	}
 
-	db := repoBase.GetDB(ctx, s.db)
 	now := time.Now()
 
-	if _, err := db.NewUpdate().
-		TableExpr(`schedule.instance_students AS "student"`).
-		Set("status = ?", scheduleModel.AttendanceStatusAbsent).
-		Set("updated_at = ?", now).
-		Where(`"student".status = ?`, scheduleModel.AttendanceStatusExpected).
-		Where(`"student".instance_id IN (
-			SELECT "instance".id
-			FROM schedule.activity_instances AS "instance"
-			WHERE "instance".status = ?
-				AND "instance".active_group_id IN (?)
-		)`, scheduleModel.InstanceStatusActive, bun.List(result.EndedActiveGroupIDs)).
-		Exec(ctx); err != nil {
+	if err := s.instanceStudentRepo.MarkExpectedAbsentByActiveGroupIDs(ctx, result.EndedActiveGroupIDs, now); err != nil {
 		return 0, fmt.Errorf("mark expected timetable students absent: %w", err)
 	}
 
-	res, err := db.NewUpdate().
-		TableExpr(`schedule.activity_instances AS "instance"`).
-		Set("status = ?", scheduleModel.InstanceStatusCompleted).
-		Set("completed_at = ?", now).
-		Set("updated_at = ?", now).
-		Where(`"instance".status = ?`, scheduleModel.InstanceStatusActive).
-		Where(`"instance".active_group_id IN (?)`, bun.List(result.EndedActiveGroupIDs)).
-		Exec(ctx)
+	rows, err := s.instanceRepo.CompleteActiveByActiveGroupIDs(ctx, result.EndedActiveGroupIDs, now)
 	if err != nil {
 		return 0, fmt.Errorf("complete active timetable instances: %w", err)
-	}
-
-	rows, err := res.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("complete active timetable instances rows affected: %w", err)
 	}
 	return int(rows), nil
 }

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
-	repoBase "github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
@@ -118,12 +117,13 @@ type Scheduler struct {
 	// Overdue instance tracking (WP-B9). Re-fire guard so the same instance
 	// does not emit `instance_overdue` every minute for the same planned
 	// row. Cleared explicitly on day boundary; see checkAndRunOverdue.
-	instanceRepo        scheduleModel.ActivityInstanceRepository
-	instanceStudentRepo scheduleModel.InstanceStudentRepository
-	overdueBroadcaster  realtime.Broadcaster
-	overdueEmitted      sync.Map // overdueKey{tenantID, instanceID} → time.Time
-	overdueEmittedDay   time.Time
-	overdueEmittedDayMu sync.Mutex
+	instanceRepo         scheduleModel.ActivityInstanceRepository
+	instanceStudentRepo  scheduleModel.InstanceStudentRepository
+	studentStatusDayRepo activeModel.StudentStatusDayRepository
+	overdueBroadcaster   realtime.Broadcaster
+	overdueEmitted       sync.Map // overdueKey{tenantID, instanceID} → time.Time
+	overdueEmittedDay    time.Time
+	overdueEmittedDayMu  sync.Mutex
 
 	// Student lifecycle (parent-enrollment PR 2). Wired via SetStudentLifecycleRepo.
 	// Nil → activate-students task does not register.
@@ -271,6 +271,12 @@ func (s *Scheduler) SetInstanceOverdueDeps(repo scheduleModel.ActivityInstanceRe
 func (s *Scheduler) SetTimetableBridgeRepos(instanceStudents scheduleModel.InstanceStudentRepository, instances scheduleModel.ActivityInstanceRepository) {
 	s.instanceStudentRepo = instanceStudents
 	s.instanceRepo = instances
+}
+
+// SetStudentStatusDayRepo wires the repository used by the nightly
+// status-flag clear (archive to student_status_days + clear legacy flags).
+func (s *Scheduler) SetStudentStatusDayRepo(repo activeModel.StudentStatusDayRepository) {
+	s.studentStatusDayRepo = repo
 }
 
 // forEachTenant executes fn for each active tenant inside a WithTenantTx.
@@ -1505,45 +1511,18 @@ func (s *Scheduler) checkAndRunStatusFlagClear(task *ScheduledTask) {
 // the current tenant transaction. Column names are trusted constants — the
 // caller picks them from a fixed set.
 func (s *Scheduler) clearStatusFlag(ctx context.Context, flagColumn, sinceColumn string) (int64, error) {
-	if s.db == nil {
-		return 0, fmt.Errorf("scheduler db not configured")
+	if s.studentStatusDayRepo == nil {
+		return 0, fmt.Errorf("scheduler student status day repo not configured")
 	}
 	status, err := statusForFlagColumn(flagColumn)
 	if err != nil {
 		return 0, err
 	}
-	now := time.Now()
-	today := timezone.TodayUTC()
-	db := repoBase.GetDB(ctx, s.db)
 
-	upsertQuery := fmt.Sprintf(`
-		INSERT INTO active.student_status_days
-			(tenant_id, student_id, date, status, reported_at, cleared_at, source)
-		SELECT tenant_id, id, ?, ?, COALESCE(%s, ?), ?, ?
-		FROM users.students
-		WHERE %s = TRUE
-		ON CONFLICT (tenant_id, student_id, date, status) DO UPDATE
-		SET reported_at = EXCLUDED.reported_at,
-		    cleared_at = EXCLUDED.cleared_at,
-		    source = EXCLUDED.source;
-	`, sinceColumn, flagColumn)
-	if _, err := db.NewRaw(upsertQuery, today, status, now, now, activeModel.StudentStatusSourceEndOfDay).Exec(ctx); err != nil {
-		return 0, err
-	}
-
-	clearQuery := fmt.Sprintf(
-		`UPDATE users.students SET %s = FALSE, %s = NULL WHERE %s = TRUE`,
-		flagColumn, sinceColumn, flagColumn,
+	return s.studentStatusDayRepo.ArchiveAndClearStatusFlag(
+		ctx, flagColumn, sinceColumn, status,
+		timezone.TodayUTC(), time.Now(), activeModel.StudentStatusSourceEndOfDay,
 	)
-	res, err := db.NewRaw(clearQuery).Exec(ctx)
-	if err != nil {
-		return 0, err
-	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return 0, err
-	}
-	return affected, nil
 }
 
 func statusForFlagColumn(flagColumn string) (string, error) {

--- a/backend/services/scheduler/scheduler_status_flag_test.go
+++ b/backend/services/scheduler/scheduler_status_flag_test.go
@@ -9,6 +9,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	activeRepo "github.com/moto-nrw/project-phoenix/database/repositories/active"
 	platformRepo "github.com/moto-nrw/project-phoenix/database/repositories/platform"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
@@ -45,7 +46,7 @@ func TestClearStatusFlag_ClearsSickFlag(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
 
-	s := &Scheduler{db: db}
+	s := &Scheduler{db: db, studentStatusDayRepo: activeRepo.NewStudentStatusDayRepository(db)}
 
 	// Create two students: one sick, one not, both in tenant 1.
 	sickStudent := testpkg.CreateTestStudent(t, db, "Clear", "SickFlag", "1a")
@@ -214,7 +215,7 @@ func TestClearStatusFlag_ClearsExcusedFlag(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
 
-	s := &Scheduler{db: db}
+	s := &Scheduler{db: db, studentStatusDayRepo: activeRepo.NewStudentStatusDayRepository(db)}
 
 	excStudent := testpkg.CreateTestStudent(t, db, "Clear", "ExcusedFlag", "1b")
 	defer testpkg.CleanupActivityFixtures(t, db, excStudent.ID)
@@ -321,8 +322,9 @@ func TestCheckAndRunStatusFlagClear_EndToEnd_ClearsBothFlags(t *testing.T) {
 	// forEachTenantSettings iterates every active tenant), fake settings
 	// resolver that pins the clock + both modes to what the task expects.
 	s := &Scheduler{
-		db:         db,
-		schoolRepo: platformRepo.NewSchoolRepository(db),
+		db:                   db,
+		schoolRepo:           platformRepo.NewSchoolRepository(db),
+		studentStatusDayRepo: activeRepo.NewStudentStatusDayRepository(db),
 		settings: &fakeStatusFlagSettings{
 			overrides: map[string]string{
 				"operations.status_flag_clear_time": nowHHMM,
@@ -379,8 +381,9 @@ func TestCheckAndRunStatusFlagClear_EndToEnd_RespectsModeSetting(t *testing.T) {
 	require.NoError(t, err)
 
 	s := &Scheduler{
-		db:         db,
-		schoolRepo: platformRepo.NewSchoolRepository(db),
+		db:                   db,
+		schoolRepo:           platformRepo.NewSchoolRepository(db),
+		studentStatusDayRepo: activeRepo.NewStudentStatusDayRepository(db),
 		settings: &fakeStatusFlagSettings{
 			overrides: map[string]string{
 				"operations.status_flag_clear_time": nowHHMM,
@@ -425,8 +428,9 @@ func TestCheckAndRunStatusFlagClear_EndToEnd_DoesNothingWhenTimeDoesNotMatch(t *
 
 	// Configure a clearly past time so timeMatchesNow always returns false.
 	s := &Scheduler{
-		db:         db,
-		schoolRepo: platformRepo.NewSchoolRepository(db),
+		db:                   db,
+		schoolRepo:           platformRepo.NewSchoolRepository(db),
+		studentStatusDayRepo: activeRepo.NewStudentStatusDayRepository(db),
 		settings: &fakeStatusFlagSettings{
 			overrides: map[string]string{
 				"operations.status_flag_clear_time": "25:99", // invalid, timeMatchesNow → false

--- a/backend/services/scheduler/session_end_timetable_test.go
+++ b/backend/services/scheduler/session_end_timetable_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
@@ -36,7 +37,11 @@ func TestCompleteTimetableInstancesForEndedSessions(t *testing.T) {
 		testpkg.CleanupActivityFixtures(t, db, activeGroup.ID, activity.ID, room.ID, student.ID)
 	})
 
-	s := &Scheduler{db: db, logger: slog.Default()}
+	s := &Scheduler{
+		instanceRepo:        scheduleRepo.NewActivityInstanceRepository(db),
+		instanceStudentRepo: scheduleRepo.NewInstanceStudentRepository(db),
+		logger:              slog.Default(),
+	}
 	completed, err := s.completeTimetableInstancesForEndedSessions(context.Background(), &activeSvc.DailySessionCleanupResult{
 		EndedActiveGroupIDs: []int64{activeGroup.ID},
 	})

--- a/backend/services/scheduler/setters_test.go
+++ b/backend/services/scheduler/setters_test.go
@@ -648,3 +648,11 @@ func (f *fakeInstanceRepo) OldestBefore(context.Context, string, *time.Time) (*t
 func (f *fakeInstanceRepo) DeleteOlderThan(context.Context, string, time.Time) (int64, error) {
 	return 0, nil
 }
+
+func (f *fakeInstanceRepo) DeletePlannedNonSpontaneousInWindow(context.Context, time.Time, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeInstanceRepo) UpdateColumns(context.Context, *scheduleModel.ActivityInstance, ...string) (int64, error) {
+	return 0, nil
+}

--- a/backend/services/scheduler/setters_test.go
+++ b/backend/services/scheduler/setters_test.go
@@ -630,3 +630,21 @@ func TestResolveIntSetting_OverrideZeroFallsThrough(t *testing.T) {
 	val := s.resolveIntSetting(context.Background(), "some.key", "NEVER_SET_EEE", 11)
 	assert.Equal(t, 11, val)
 }
+
+// Stubs for the issue #585 cleanup refactor interface additions — unused by
+// the setter tests.
+func (f *fakeInstanceRepo) CompleteActiveByActiveGroupIDs(context.Context, []int64, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeInstanceRepo) CountWithOptions(context.Context, *base.QueryOptions) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeInstanceRepo) OldestBefore(context.Context, string, *time.Time) (*time.Time, error) {
+	return nil, nil
+}
+
+func (f *fakeInstanceRepo) DeleteOlderThan(context.Context, string, time.Time) (int64, error) {
+	return 0, nil
+}

--- a/backend/services/usercontext/usercontext_service.go
+++ b/backend/services/usercontext/usercontext_service.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/uptrace/bun"
-
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
@@ -60,7 +58,6 @@ type userContextService struct {
 	supervisorRepo     active.GroupSupervisorRepository
 	profileRepo        users.ProfileRepository
 	substitutionRepo   education.GroupSubstitutionRepository
-	db                 *bun.DB
 	logger             *slog.Logger
 }
 
@@ -73,7 +70,7 @@ func (s *userContextService) getLogger() *slog.Logger {
 }
 
 // NewUserContextServiceWithRepos creates a new user context service using a repositories struct
-func NewUserContextServiceWithRepos(repos UserContextRepositories, db *bun.DB, logger *slog.Logger) UserContextService {
+func NewUserContextServiceWithRepos(repos UserContextRepositories, logger *slog.Logger) UserContextService {
 	return &userContextService{
 		accountRepo:        repos.AccountRepo,
 		personRepo:         repos.PersonRepo,
@@ -87,7 +84,6 @@ func NewUserContextServiceWithRepos(repos UserContextRepositories, db *bun.DB, l
 		supervisorRepo:     repos.SupervisorRepo,
 		profileRepo:        repos.ProfileRepo,
 		substitutionRepo:   repos.SubstitutionRepo,
-		db:                 db,
 		logger:             logger,
 	}
 }

--- a/backend/services/usercontext/usercontext_service_test.go
+++ b/backend/services/usercontext/usercontext_service_test.go
@@ -38,7 +38,7 @@ func setupUserContextService(t *testing.T, db *bun.DB) usercontextSvc.UserContex
 		SubstitutionRepo:   repoFactory.GroupSubstitution,
 	}
 
-	return usercontextSvc.NewUserContextServiceWithRepos(repos, db, slog.Default())
+	return usercontextSvc.NewUserContextServiceWithRepos(repos, slog.Default())
 }
 
 // contextWithClaims creates a context with JWT claims

--- a/backend/services/users/caregiver_capability.go
+++ b/backend/services/users/caregiver_capability.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
@@ -31,6 +32,7 @@ type CaregiverCapabilityServiceDependencies struct {
 	TeacherRepo            userModels.TeacherRepository
 	GroupTeacherRepo       educationModels.GroupTeacherRepository
 	GroupSubstitutionRepo  educationModels.GroupSubstitutionRepository
+	GroupSupervisorRepo    activeModels.GroupSupervisorRepository
 	ActivitySupervisorRepo activitiesModels.SupervisorPlannedRepository
 	AuthService            authSvc.AuthService
 	DB                     *bun.DB
@@ -46,10 +48,10 @@ type caregiverCapabilityService struct {
 	teacherRepo            userModels.TeacherRepository
 	groupTeacherRepo       educationModels.GroupTeacherRepository
 	groupSubstitutionRepo  educationModels.GroupSubstitutionRepository
+	groupSupervisorRepo    activeModels.GroupSupervisorRepository
 	activitySupervisorRepo activitiesModels.SupervisorPlannedRepository
 	authService            authSvc.AuthService
 	txHandler              *modelBase.TxHandler
-	db                     *bun.DB
 }
 
 type caregiverRoleFlags struct {
@@ -82,10 +84,10 @@ func NewCaregiverCapabilityService(
 		teacherRepo:            deps.TeacherRepo,
 		groupTeacherRepo:       deps.GroupTeacherRepo,
 		groupSubstitutionRepo:  deps.GroupSubstitutionRepo,
+		groupSupervisorRepo:    deps.GroupSupervisorRepo,
 		activitySupervisorRepo: deps.ActivitySupervisorRepo,
 		authService:            deps.AuthService,
 		txHandler:              modelBase.NewTxHandler(deps.DB),
-		db:                     deps.DB,
 	}
 }
 
@@ -611,23 +613,7 @@ func (s *caregiverCapabilityService) listActiveGroupSupervisions(
 	staffID int64,
 	tenantID int64,
 ) ([]userModels.BlockerSupervision, error) {
-	db := s.getDB(ctx)
-
-	var results []userModels.BlockerSupervision
-	err := db.NewRaw(`
-		SELECT gs.id, COALESCE(g.name, 'Unbekannte Gruppe') AS group_name,
-		       gs.start_date::text AS start_date
-		FROM active.group_supervisors AS gs
-		LEFT JOIN education.groups AS g ON g.id = gs.group_id AND g.tenant_id = gs.tenant_id
-		WHERE gs.tenant_id = ?
-		  AND gs.staff_id = ?
-		  AND (gs.end_date IS NULL OR gs.end_date > NOW())
-		ORDER BY gs.start_date DESC
-	`, tenantID, staffID).Scan(ctx, &results)
-	if err != nil {
-		return nil, err
-	}
-	return results, nil
+	return s.groupSupervisorRepo.ListActiveSupervisionBlockers(ctx, staffID, tenantID)
 }
 
 func (s *caregiverCapabilityService) listActiveGroupSubstitutions(
@@ -635,25 +621,7 @@ func (s *caregiverCapabilityService) listActiveGroupSubstitutions(
 	staffID int64,
 	tenantID int64,
 ) ([]userModels.BlockerSubstitution, error) {
-	db := s.getDB(ctx)
-
-	var results []userModels.BlockerSubstitution
-	err := db.NewRaw(`
-		SELECT gs.id, COALESCE(g.name, 'Unbekannte Gruppe') AS group_name,
-		       CASE WHEN gs.substitute_staff_id = ? THEN 'substitute' ELSE 'regular' END AS role,
-		       gs.start_date::text AS start_date,
-		       gs.end_date::text AS end_date
-		FROM education.group_substitution AS gs
-		LEFT JOIN education.groups AS g ON g.id = gs.group_id AND g.tenant_id = gs.tenant_id
-		WHERE gs.tenant_id = ?
-		  AND (gs.substitute_staff_id = ? OR gs.regular_staff_id = ?)
-		  AND gs.end_date >= CURRENT_DATE
-		ORDER BY gs.start_date DESC
-	`, staffID, tenantID, staffID, staffID).Scan(ctx, &results)
-	if err != nil {
-		return nil, err
-	}
-	return results, nil
+	return s.groupSubstitutionRepo.ListActiveSubstitutionBlockers(ctx, staffID, tenantID)
 }
 
 func (s *caregiverCapabilityService) listPlannedActivitySupervisions(
@@ -661,23 +629,7 @@ func (s *caregiverCapabilityService) listPlannedActivitySupervisions(
 	staffID int64,
 	tenantID int64,
 ) ([]userModels.BlockerActivity, error) {
-	db := s.getDB(ctx)
-
-	var results []userModels.BlockerActivity
-	err := db.NewRaw(`
-		SELECT s.id, s.group_id AS activity_id,
-		       COALESCE(ag.name, 'Unbekannte Aktivität') AS activity_name,
-		       COALESCE(s.is_primary, false) AS is_primary
-		FROM activities.supervisors AS s
-		LEFT JOIN activities.groups AS ag ON ag.id = s.group_id AND ag.tenant_id = s.tenant_id
-		WHERE s.tenant_id = ?
-		  AND s.staff_id = ?
-		ORDER BY ag.name ASC
-	`, tenantID, staffID).Scan(ctx, &results)
-	if err != nil {
-		return nil, err
-	}
-	return results, nil
+	return s.activitySupervisorRepo.ListPlannedSupervisionBlockers(ctx, staffID, tenantID)
 }
 
 func (s *caregiverCapabilityService) listGroupTeacherAssignments(
@@ -685,35 +637,5 @@ func (s *caregiverCapabilityService) listGroupTeacherAssignments(
 	teacherID int64,
 	tenantID int64,
 ) ([]userModels.BlockerGroup, error) {
-	db := s.getDB(ctx)
-
-	var results []userModels.BlockerGroup
-	err := db.NewRaw(`
-		SELECT gt.id,
-		       gt.group_id,
-		       COALESCE(g.name, 'Unbekannte Gruppe') AS group_name,
-		       gt.teacher_id,
-		       COALESCE((
-		           SELECT ARRAY_AGG(gt_all.teacher_id ORDER BY gt_all.id)
-		           FROM education.group_teacher AS gt_all
-		           WHERE gt_all.tenant_id = gt.tenant_id
-		             AND gt_all.group_id = gt.group_id
-		       ), '{}'::bigint[]) AS teacher_ids
-		FROM education.group_teacher AS gt
-		LEFT JOIN education.groups AS g ON g.id = gt.group_id AND g.tenant_id = gt.tenant_id
-		WHERE gt.tenant_id = ?
-		  AND gt.teacher_id = ?
-		ORDER BY g.name ASC
-	`, tenantID, teacherID).Scan(ctx, &results)
-	if err != nil {
-		return nil, err
-	}
-	return results, nil
-}
-
-func (s *caregiverCapabilityService) getDB(ctx context.Context) bun.IDB {
-	if tx, ok := modelBase.TxFromContext(ctx); ok && tx != nil {
-		return tx
-	}
-	return s.db
+	return s.groupTeacherRepo.ListGroupTeacherBlockers(ctx, teacherID, tenantID)
 }

--- a/backend/services/users/caregiver_directory.go
+++ b/backend/services/users/caregiver_directory.go
@@ -4,11 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	authModels "github.com/moto-nrw/project-phoenix/models/auth"
-	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
-	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/uptrace/bun"
 )
 
 // CaregiverDirectory exposes the canonical operational caregiver lookup.
@@ -20,75 +16,19 @@ type CaregiverDirectory interface {
 }
 
 func (s *personService) ListActiveCaregivers(ctx context.Context) ([]*userModels.ActiveCaregiver, error) {
-	var caregivers []*userModels.ActiveCaregiver
-	query := s.caregiverDirectoryQuery(ctx).
-		OrderExpr(`"person".first_name ASC, "person".last_name ASC, "staff".id ASC`)
-
-	if err := query.Scan(ctx, &caregivers); err != nil {
+	caregivers, err := s.teacherRepo.ListActiveCaregivers(ctx)
+	if err != nil {
 		return nil, &UsersError{Op: "list active caregivers", Err: err}
 	}
-
 	return caregivers, nil
 }
 
 func (s *personService) FindActiveCaregiverByAccountID(ctx context.Context, accountID int64) (*userModels.ActiveCaregiver, error) {
-	var caregivers []*userModels.ActiveCaregiver
-	query := s.caregiverDirectoryQuery(ctx).
-		Where(`"account".id = ?`, accountID).
-		Limit(1)
-
-	if err := query.Scan(ctx, &caregivers); err != nil {
+	caregiver, err := s.teacherRepo.FindActiveCaregiverByAccountID(ctx, accountID)
+	if err != nil {
 		return nil, &UsersError{Op: "find active caregiver by account ID", Err: err}
 	}
-
-	if len(caregivers) == 0 {
-		return nil, nil
-	}
-
-	return caregivers[0], nil
-}
-
-func (s *personService) caregiverDirectoryQuery(ctx context.Context) *bun.SelectQuery {
-	db := bun.IDB(s.db)
-	if tx, ok := modelBase.TxFromContext(ctx); ok && tx != nil {
-		db = tx
-	}
-
-	query := db.NewSelect().
-		Model((*userModels.ActiveCaregiver)(nil)).
-		ModelTableExpr(`users.teachers AS "teacher"`).
-		ColumnExpr(`"account".id AS account_id`).
-		ColumnExpr(`"person".id AS person_id`).
-		ColumnExpr(`"staff".id AS staff_id`).
-		ColumnExpr(`"teacher".id AS teacher_id`).
-		ColumnExpr(`"person".first_name`).
-		ColumnExpr(`"person".last_name`).
-		ColumnExpr(`"account".email`).
-		ColumnExpr(`"staff".created_at`).
-		ColumnExpr(`"staff".updated_at`).
-		Join(`INNER JOIN users.staff AS "staff" ON "staff".id = "teacher".staff_id`).
-		Join(`INNER JOIN users.persons AS "person" ON "person".id = "staff".person_id`).
-		Join(`INNER JOIN auth.accounts AS "account" ON "account".id = "person".account_id`).
-		Join(`INNER JOIN auth.account_tenants AS "at" ON "at".account_id = "account".id AND "at".tenant_id = "teacher".tenant_id`).
-		Join(`INNER JOIN auth.account_roles AS "ar" ON "ar".account_id = "account".id AND "ar".tenant_id = "teacher".tenant_id`).
-		Join(`INNER JOIN auth.roles AS "role" ON "role".id = "ar".role_id`).
-		Where(`"account".active = TRUE`).
-		Where(`"at".status = ?`, authModels.AccountTenantStatusActive).
-		Where(`"role".is_system = TRUE`).
-		Where(`"role".tenant_id IS NULL`).
-		Where(`LOWER("role".name) IN (?, ?)`, "user", "teacher").
-		Distinct()
-
-	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
-		query = query.
-			Where(`"at".tenant_id = ?`, tenantID).
-			Where(`"teacher".tenant_id = ?`, tenantID).
-			Where(`"staff".tenant_id = ?`, tenantID).
-			Where(`"person".tenant_id = ?`, tenantID).
-			Where(`"ar".tenant_id = ?`, tenantID)
-	}
-
-	return query
+	return caregiver, nil
 }
 
 func CaregiverDirectoryFromPersonService(personService PersonService) (CaregiverDirectory, error) {

--- a/backend/test/architecture_ratchet_test.go
+++ b/backend/test/architecture_ratchet_test.go
@@ -32,11 +32,10 @@ import (
 // but new ones still deserve the review friction of touching this list.
 var serviceQueryRatchetAllowlist = map[string]int{
 	"services/active/analytics_service.go":               1,
-	"services/active/cleanup_service.go":                 10,
+	"services/active/cleanup_service.go":                 7,
 	"services/active/combined_group_service.go":          3,
 	"services/active/dashboard_helpers.go":               1,
 	"services/active/session_service.go":                 3,
-	"services/active/time_tracking_cleanup_service.go":   10,
 	"services/activities/supervisor_operations.go":       1,
 	"services/education/grade_transition_service.go":     1,
 	"services/emergency/service.go":                      2,
@@ -48,8 +47,7 @@ var serviceQueryRatchetAllowlist = map[string]int{
 	"services/schedule/arrival_service.go":               2,
 	"services/schedule/instance_service.go":              2,
 	"services/schedule/pickup_schedule_service.go":       2,
-	"services/schedule/timetable_cleanup_service.go":     8,
-	"services/scheduler/scheduler.go":                    4,
+	"services/scheduler/scheduler.go":                    2,
 	"services/users/caregiver_capability.go":             5,
 	"services/users/caregiver_directory.go":              1,
 }

--- a/backend/test/architecture_ratchet_test.go
+++ b/backend/test/architecture_ratchet_test.go
@@ -1,0 +1,169 @@
+package test
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestServiceRepositoryRatchet enforces .claude/rules/backend-conventions.md
+// Rule 11: services MUST NOT construct database queries directly on a
+// bun.DB / bun.IDB / bun.Tx handle — all data access goes through
+// repositories. The violation count regrew from 12 (issue #585, Jan 2026) to
+// 71 because detection was docs-only; this test makes the count shrink-only.
+//
+// serviceQueryRatchetAllowlist holds the per-file count of currently tolerated
+// query-construction sites in backend/services/. The rules:
+//
+//   - A file NOT in the allowlist must have ZERO hits. Put the query in a
+//     repository under database/repositories/ instead.
+//   - A file may never exceed its allowed count.
+//   - When refactoring removes hits, the test fails until the allowlist entry
+//     is lowered/removed — the ratchet only turns one way. Never raise a number.
+//
+// Deliberately-kept transaction-control statements (SAVEPOINT / ROLLBACK TO /
+// RELEASE via ExecContext, pg_advisory_xact_lock, LOCK TABLE) count toward a
+// file's allowance: transaction orchestration is legitimately service-layer,
+// but new ones still deserve the review friction of touching this list.
+var serviceQueryRatchetAllowlist = map[string]int{
+	"services/active/analytics_service.go":               1,
+	"services/active/cleanup_service.go":                 10,
+	"services/active/combined_group_service.go":          3,
+	"services/active/dashboard_helpers.go":               1,
+	"services/active/session_service.go":                 3,
+	"services/active/time_tracking_cleanup_service.go":   10,
+	"services/activities/supervisor_operations.go":       1,
+	"services/education/grade_transition_service.go":     1,
+	"services/emergency/service.go":                      2,
+	"services/enrollment/request_service.go":             3,
+	"services/facilities/facility_service.go":            2,
+	"services/import/student_import_config.go":           3,
+	"services/platform/operator_provisioning_service.go": 7,
+	"services/platform/operator_suggestions_service.go":  3,
+	"services/schedule/arrival_service.go":               2,
+	"services/schedule/instance_service.go":              2,
+	"services/schedule/pickup_schedule_service.go":       2,
+	"services/schedule/timetable_cleanup_service.go":     8,
+	"services/scheduler/scheduler.go":                    4,
+	"services/users/caregiver_capability.go":             5,
+	"services/users/caregiver_directory.go":              1,
+}
+
+var (
+	// Query builder construction on a db/tx handle.
+	queryBuilderPattern = regexp.MustCompile(`\.New(Select|Update|Insert|Delete|Raw)\(`)
+	// Driver-level statement execution on a db/tx handle.
+	driverExecPattern = regexp.MustCompile(`\.(ExecContext|QueryContext|QueryRowContext)\(`)
+)
+
+func TestServiceRepositoryRatchet(t *testing.T) {
+	backendRoot, err := findBackendRoot()
+	if err != nil {
+		t.Skipf("Could not find backend root: %v", err)
+		return
+	}
+
+	counts, err := scanServiceQueryConstruction(backendRoot)
+	if err != nil {
+		t.Fatalf("scanning services/ failed: %v", err)
+	}
+
+	var violations []string
+
+	for file, got := range counts {
+		allowed, ok := serviceQueryRatchetAllowlist[file]
+		switch {
+		case !ok:
+			violations = append(violations, fmt.Sprintf(
+				"%s: %d query-construction site(s), but the file is not in the allowlist.\n"+
+					"  New direct queries in services/ are forbidden (Rule 11) — move the query\n"+
+					"  into a repository under database/repositories/.", file, got))
+		case got > allowed:
+			violations = append(violations, fmt.Sprintf(
+				"%s: %d query-construction site(s), allowed %d.\n"+
+					"  New direct queries in services/ are forbidden (Rule 11) — move the query\n"+
+					"  into a repository under database/repositories/. Never raise the allowlist.",
+				file, got, allowed))
+		case got < allowed:
+			violations = append(violations, fmt.Sprintf(
+				"%s: %d query-construction site(s), allowlist says %d.\n"+
+					"  Nice — sites were removed. Ratchet down: lower (or delete) the entry in\n"+
+					"  serviceQueryRatchetAllowlist so the improvement cannot regress.",
+				file, got, allowed))
+		}
+	}
+
+	for file, allowed := range serviceQueryRatchetAllowlist {
+		if _, ok := counts[file]; !ok {
+			violations = append(violations, fmt.Sprintf(
+				"%s: allowlisted with %d site(s) but has none (deleted or cleaned up?).\n"+
+					"  Remove the entry from serviceQueryRatchetAllowlist.", file, allowed))
+		}
+	}
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Errorf("Service→Repository ratchet check failed (%d issue(s)):\n\n%s",
+			len(violations), strings.Join(violations, "\n\n"))
+	}
+}
+
+// scanServiceQueryConstruction counts query-construction sites per file under
+// backend/services/, skipping test files and line comments.
+func scanServiceQueryConstruction(backendRoot string) (map[string]int, error) {
+	counts := make(map[string]int)
+	servicesDir := filepath.Join(backendRoot, "services")
+
+	err := filepath.WalkDir(servicesDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		hits, err := countQueryConstructionSites(path)
+		if err != nil {
+			return err
+		}
+		if hits > 0 {
+			rel, err := filepath.Rel(backendRoot, path)
+			if err != nil {
+				return err
+			}
+			counts[filepath.ToSlash(rel)] = hits
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return counts, nil
+}
+
+func countQueryConstructionSites(path string) (int, error) {
+	f, err := os.Open(path) // #nosec G304 -- test scans repo-local source files
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	hits := 0
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		hits += len(queryBuilderPattern.FindAllString(line, -1))
+		hits += len(driverExecPattern.FindAllString(line, -1))
+	}
+	return hits, scanner.Err()
+}

--- a/backend/test/architecture_ratchet_test.go
+++ b/backend/test/architecture_ratchet_test.go
@@ -31,25 +31,17 @@ import (
 // file's allowance: transaction orchestration is legitimately service-layer,
 // but new ones still deserve the review friction of touching this list.
 var serviceQueryRatchetAllowlist = map[string]int{
-	"services/active/analytics_service.go":               1,
-	"services/active/cleanup_service.go":                 7,
-	"services/active/combined_group_service.go":          3,
-	"services/active/dashboard_helpers.go":               1,
-	"services/active/session_service.go":                 3,
-	"services/activities/supervisor_operations.go":       1,
-	"services/education/grade_transition_service.go":     1,
-	"services/emergency/service.go":                      2,
-	"services/enrollment/request_service.go":             3,
-	"services/facilities/facility_service.go":            2,
-	"services/import/student_import_config.go":           3,
-	"services/platform/operator_provisioning_service.go": 7,
-	"services/platform/operator_suggestions_service.go":  3,
-	"services/schedule/arrival_service.go":               2,
-	"services/schedule/instance_service.go":              2,
-	"services/schedule/pickup_schedule_service.go":       2,
-	"services/scheduler/scheduler.go":                    2,
-	"services/users/caregiver_capability.go":             5,
-	"services/users/caregiver_directory.go":              1,
+	// Bare-pool tenant-tx escapes, deferred to a dedicated bug PR (the
+	// scoping fix is a behavior change). See issue #585.
+	"services/active/cleanup_service.go": 7,
+	"services/active/session_service.go": 3, // 2 bare-pool sites + 1 advisory lock
+
+	// Deliberately-kept transaction control (SAVEPOINT / advisory locks /
+	// LOCK TABLE) — transaction orchestration is service-layer per Rule 11.
+	"services/enrollment/request_service.go":            1,
+	"services/import/student_import_config.go":          3,
+	"services/platform/operator_suggestions_service.go": 3,
+	"services/users/caregiver_capability.go":            1,
 }
 
 var (

--- a/backend/test/hermetic_verification_test.go
+++ b/backend/test/hermetic_verification_test.go
@@ -328,6 +328,7 @@ func checkMissingSetupTestDB(t *testing.T, root string) []string {
 			"http_middleware_test.go",                           // Uses nil *bun.DB for unit testing middleware
 			"role_management_internal_test.go",                  // Uses hand-rolled stub repos injected via repositories.Factory, no real DB
 			"database/repositories/schedule/created_by_test.go", // Shared fixture helper; caller tests own DB setup
+			"test/architecture_ratchet_test.go",                 // Source-scanning ratchet; regex literals look like DB ops but no DB is used
 		}
 		skip := false
 		for _, sf := range skipFiles {


### PR DESCRIPTION
> [!NOTE]
> Accidentally merged before review and reverted in #1612. Re-landed — together with the two follow-up commits that finish #585 — in #1613.

Part of #585 (leave open — see the follow-up section below for what still has to land before the issue can be closed).

## What this PR does

Issue #585 originally counted 12 direct database calls in the service layer. A fresh audit of the current codebase found **71 hard violations across 19 service files** (plus 9 transaction-control statements and 12 dead `*bun.DB` struct fields). This PR removes 62 of the 71 by moving every query behind the repository layer, and adds a CI ratchet so the count can only shrink.

| Metric | Before | After |
|---|---|---|
| Query-builder calls (`NewSelect/NewUpdate/NewInsert/NewDelete/NewRaw`) in `services/` | 65+ across 19 files | **9**, all in 2 files, all allowlisted |
| Service structs whose `db` handle runs queries | 16 | 2 (the deferred files below) |
| Unused `*bun.DB` struct fields | 12 | 0 |
| Regression detection | docs only (`.claude/rules/backend-conventions.md` Rule 11) | `test/architecture_ratchet_test.go`, shrink-only allowlist |

## How to review: commit by commit

The unified diff is large (~115 files); each commit is self-contained and verified independently.

**Commit 1 — generic query helpers + ratchet** (`backend/database/repositories/base/`)
Four additions to `Repository[T]`: `CountWithOptions` (also retires the duplicated copies in Student/Group repos), `OldestBefore`, `DeleteOlderThan`, and `UpdateColumns` (the partial-update shape Rule 2 blesses but which did not exist). All use the standard `GetDB(ctx)` resolution + tenant defense-in-depth. Plus the ratchet test with the then-current allowlist, and hermetic tests for all four helpers including tenant isolation.

**Commit 2 — cleanup core** (`services/active/time_tracking_cleanup`, `services/schedule/timetable_cleanup`, attendance pair, scheduler session-end bridge)
Both GDPR cleanup services now contain zero query construction: counts/MIN-dates/retention-deletes ride the new generics, the impact collectors go through repository `List` with filters or one custom projection method, and both services dropped their `*bun.DB` field entirely. The scheduler's daily session-end bridge moved verbatim into two repo methods.

**Commit 3 — rewires + bespoke methods + dead-field deletion**
~16 sites rewired to repo methods that already existed (arrival/pickup upserts, combined-group create, dashboard batch-load, staff-exists probe, SoftDeletePerson lookups/unlinks). ~20 new justified custom methods (GDPR anonymize pair, operator device listing, status-flag archive+clear, room occupancy pair with shared builder, emergency loaders, caregiver directory + capability blockers, enrollment guardian-edit/withdraw, ReplanWeek delete). 14 dead `db` fields deleted.

## Behavioral equivalence

- `tenant.WithTenantTx`/`WithAdminTx` store their transaction in the context, and every repo method resolves its handle via `base.GetDB(ctx)` — the moved queries run the same SQL on the same connection/transaction as the hand-rolled `TxFromContext` swaps they replace.
- SQL moved verbatim wherever a bespoke method was created; repo-level `tenant_id` defense-in-depth predicates are no-ops under the RLS tenant transaction.
- Deliberately NOT converted: the attendance close loop keeps its per-row DST-sensitive Berlin `EndOfDay` logic in the service (writes via generic `UpdateColumns`), and the cold-path query sequences (caregiver blockers, SoftDeletePerson) stay sequential.
- Test changes are mechanical only: constructor signatures, mock stubs for new interface methods, and sqlmock tests now wiring real repositories over the same mock connection so the unchanged query expectations keep passing. No assertion was changed.

## Verification

- `go vet ./...` and `golangci-lint run ./...` clean.
- Full backend suite green except two pre-existing failures, both bisect-proven to fail identically on the unmodified tree: `TestStaffWorkScheduleReplaceSchedule_UsesExclusiveValidUntil` (repositories/config) and the flaky `TestGetDashboardAnalytics` class-trip subtest (stale shared-test-DB state; a `migrate reset` of the test DB clears them).
- `TestServiceRepositoryRatchet` and `TestHermeticTestPatterns` pass; the ratchet allowlist is at its end state for this PR.

## Deliberately left in services (allowlisted)

- **9 bare-pool sites** in `services/active/cleanup_service.go` (7: GDPR retention stats/preview, stale-supervisor cleanup) and `services/active/session_service.go` (2: orphaned-supervisor cleanup). These run on the bare `s.db` pool and **escape the scheduler's per-tenant transaction** — on the production serve pool (`phoenix_auth`, no `BYPASSRLS`, FORCE RLS) they likely fail or match zero rows, i.e. they are existing broken behavior. Moving them onto tenant-scoped repo methods CHANGES what the nightly cleanup does, so it is excluded from this strictly results-preserving PR.
- **8 transaction-control statements** (SAVEPOINT triplets in import + operator suggestions, `pg_advisory_xact_lock` in session start + enrollment submit, `LOCK TABLE` in caregiver capability). Transaction orchestration is service-layer per Rule 11; they stay, with review friction via the allowlist.

## Follow-up to finish #585

1. **Bug PR: tenant-scope the 9 bare-pool cleanup sites.** Move them onto tenant-scoped repo methods (siblings of the existing `VisitRepository.CountExpiredVisits` predicate for the retention stats; `PrivacyConsentRepository` list for the worklist; one shared `GroupSupervisorRepository.FindStaleOpen` + set-based close that also consolidates the duplicated supervisor cleanup in `cleanup_service.go` and `session_service.go`). This is a deliberate behavior fix (the nightly cleanup starts actually operating inside the tenant transaction) and needs its own tests + review. Afterwards shrink the ratchet allowlist entries for both files to their tx-control remainder.
2. **Close-out check:** after step 1, the issue's acceptance grep (`NewSelect|NewRaw` in `services/`) returns 0 and no service struct uses its `db` handle for queries. Note for the issue: the original criterion "no service struct has a `db *bun.DB` field" is stricter than Rule 11 intends — ~16 services legitimately keep `db` for `WithTenantTx`/`WithAdminTx`/`TxHandler` wiring only; the ratchet enforces the meaningful invariant (no query construction).
3. **Docs hygiene:** refresh the stale counts in `.claude/rules/backend-conventions.md` Rule 11 ("~50 hits across ~15 files") to point at the ratchet test as the source of truth.
4. **Test infra (optional):** reset the shared test database to clear the two pre-existing failures, and consider per-package tenant isolation for the suite's known cross-package flakes.

