### PR TITLE
fix(enrollment): durchgängig Sie-Anrede im öffentlichen Anmeldeformular

### DIFF
--- a/frontend/src/components/enrollment/enrollment-form.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.test.tsx
@@ -315,7 +315,9 @@ describe("EnrollmentForm", () => {
     fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
 
     expect(
-      await screen.findByText("Bitte korrigiere die rot markierten Felder."),
+      await screen.findByText(
+        "Bitte korrigieren Sie die rot markierten Felder.",
+      ),
     ).toBeInTheDocument();
     expect(screen.getAllByText("Bitte Vornamen angeben.")).toHaveLength(2);
     expect(mockSubmitEnrollment).not.toHaveBeenCalled();
@@ -554,7 +556,7 @@ describe("EnrollmentForm", () => {
     fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
     expect(
       await screen.findByText(
-        "Bitte wähle für jedes Kind mindestens ein Betreuungsangebot aus.",
+        "Bitte wählen Sie für jedes Kind mindestens ein Betreuungsangebot aus.",
       ),
     ).toBeInTheDocument();
 
@@ -716,11 +718,11 @@ describe("EnrollmentForm", () => {
     // The pickup field gets the pickup copy, not the bus copy — guards the
     // regression where the shared weekday_boolean input hardcoded bus text.
     expect(
-      screen.getByText(/an denen das Kind abgeholt wird/),
+      screen.getByText(/an denen Ihr Kind abgeholt wird/),
     ).toBeInTheDocument();
     // The Buskind field still shows its own bus copy.
     expect(
-      screen.getByText(/an denen das Kind mit dem Bus fährt/),
+      screen.getByText(/an denen Ihr Kind mit dem Bus fährt/),
     ).toBeInTheDocument();
   });
 
@@ -898,7 +900,7 @@ describe("EnrollmentForm", () => {
     fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
     expect(
       await screen.findByText(
-        "Bitte wähle für jedes Kind genau ein Betreuungsangebot aus.",
+        "Bitte wählen Sie für jedes Kind genau ein Betreuungsangebot aus.",
       ),
     ).toBeInTheDocument();
     expect(mockSubmitEnrollment).not.toHaveBeenCalled();

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -604,19 +604,20 @@ export function EnrollmentForm({
         !hasOfferingIssue &&
         fieldErrorKeys.length > 0 &&
         fieldErrorKeys.every((key) => key.startsWith("consent_"));
-      let banner = "Bitte korrigiere die rot markierten Felder.";
+      let banner = "Bitte korrigieren Sie die rot markierten Felder.";
       if (fieldErrorKeys.length === 1 && !hasOfferingIssue) {
         banner = Object.values(newFieldErrors)[0] ?? banner;
       } else if (onlyConsents) {
-        banner = "Bitte bestätige alle erforderlichen Zustimmungen.";
+        banner = "Bitte bestätigen Sie alle erforderlichen Zustimmungen.";
       } else if (fieldErrorKeys.length === 0 && missingCareIndexes.length > 0) {
         banner =
-          "Bitte wähle für jedes Kind mindestens ein Betreuungsangebot aus.";
+          "Bitte wählen Sie für jedes Kind mindestens ein Betreuungsangebot aus.";
       } else if (
         fieldErrorKeys.length === 0 &&
         exactOneCareIndexes.length > 0
       ) {
-        banner = "Bitte wähle für jedes Kind genau ein Betreuungsangebot aus.";
+        banner =
+          "Bitte wählen Sie für jedes Kind genau ein Betreuungsangebot aus.";
       } else if (
         fieldErrorKeys.length === 0 &&
         dayErrorCount > 0 &&
@@ -1231,7 +1232,7 @@ export function EnrollmentForm({
           className="rounded-md border border-[#FF3130]/30 bg-[#FF3130]/5 p-3 text-sm text-[#CC2626]"
         >
           Die Anmeldung ist derzeit nicht möglich: Die Bot-Schutz-Konfiguration
-          ist unvollständig. Bitte wende dich an die OGS-Leitung.
+          ist unvollständig. Bitte wenden Sie sich an die OGS-Leitung.
         </div>
       )}
 
@@ -2296,8 +2297,8 @@ function WeekdayBooleanInput({
       )}
       <p className="text-xs text-gray-500">
         {field.target === "student.pickup_status"
-          ? "Wähle die Tage aus, an denen das Kind abgeholt wird. An nicht gewählten Tagen geht es alleine nach Hause."
-          : "Wähle die Tage aus, an denen das Kind mit dem Bus fährt."}
+          ? "Wählen Sie die Tage aus, an denen Ihr Kind abgeholt wird. An nicht gewählten Tagen geht es alleine nach Hause."
+          : "Wählen Sie die Tage aus, an denen Ihr Kind mit dem Bus fährt."}
       </p>
       <div className="mt-2 grid gap-2 sm:grid-cols-5">
         {WEEKDAYS.map((w) => {
@@ -2569,9 +2570,9 @@ function ExistingChildrenPanel({
     <div className="rounded-lg border border-[#83CD2D]/40 bg-[#83CD2D]/5 p-4">
       <h3 className="text-sm font-semibold text-gray-900">Bestehende Kinder</h3>
       <p className="mt-1 text-xs text-gray-600">
-        Diese Kinder sind schon bei der Schule erfasst. Klicke auf „Übernehmen"
-        um sie schnell in die Anmeldung einzutragen. Geburtsdatum musst du noch
-        eintragen.
+        Diese Kinder sind schon bei der Schule erfasst. Klicken Sie auf
+        „Übernehmen" um sie schnell in die Anmeldung einzutragen. Das
+        Geburtsdatum müssen Sie noch eintragen.
       </p>
       <ul className="mt-3 space-y-2">
         {existing.map((c) => {

--- a/frontend/src/components/enrollment/enrollment-status-view.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-status-view.test.tsx
@@ -163,7 +163,7 @@ describe("EnrollmentStatusView", () => {
 
     await waitFor(() => {
       expect(window.confirm).toHaveBeenCalledWith(
-        "Möchtest du diese Anmeldung wirklich zurückziehen?",
+        "Möchten Sie diese Anmeldung wirklich zurückziehen?",
       );
       expect(mockWithdrawStatus).toHaveBeenCalledWith("tok", "7");
     });

--- a/frontend/src/components/enrollment/enrollment-status-view.tsx
+++ b/frontend/src/components/enrollment/enrollment-status-view.tsx
@@ -158,8 +158,8 @@ export function EnrollmentStatusView({ token, justSubmitted = false }: Props) {
   const handleWithdraw = async (childID?: string) => {
     if (!status) return;
     const confirmMessage = childID
-      ? "Möchtest du diese Anmeldung wirklich zurückziehen?"
-      : "Möchtest du die gesamte Anmeldung zurückziehen?";
+      ? "Möchten Sie diese Anmeldung wirklich zurückziehen?"
+      : "Möchten Sie die gesamte Anmeldung zurückziehen?";
     if (!window.confirm(confirmMessage)) return;
     setWithdrawingChild(childID ?? "__all__");
     setError(null);
@@ -559,7 +559,7 @@ export function EnrollmentStatusView({ token, justSubmitted = false }: Props) {
         {!allEditable && !editing && (
           <p className="text-sm text-gray-500">
             Änderungen sind nur möglich, solange noch keine Entscheidung
-            getroffen wurde. Für Änderungen wende dich bitte an die OGS.
+            getroffen wurde. Für Änderungen wenden Sie sich bitte an die OGS.
           </p>
         )}
       </section>


### PR DESCRIPTION
## Kontext

Schul-Anfrage (Demo School / OGS): die Wochentags-Auswahl im öffentlichen Anmeldeformular soll siezen statt duzen.

> Statt „Wähle die Tage aus" hätten wir gerne „Wählen Sie die Tage aus, an denen Ihr Kind…"

## Änderung

Die zwei angefragten Stellen umformuliert **und** die restlichen Du-Reste im gesamten öffentlichen Anmelde-Flow auf Sie vereinheitlicht (das Formular siezte ohnehin schon überwiegend; die Du-Stellen waren Ausreißer).

**`enrollment-form.tsx`** (8 Stellen)
- Abholregelung + Buskind: „Wählen Sie die Tage aus, an denen **Ihr Kind** …" — die Anfrage, wortgenau
- 4 Fehlerbanner: korrigieren / bestätigen / 2× wählen Sie
- Captcha-Hinweis: „wenden Sie sich an die OGS-Leitung"
- „Bestehende Kinder"-Block: „Klicken Sie … müssen Sie noch eintragen"

**`enrollment-status-view.tsx`** (3 Stellen, Statusseite nach Absenden)
- 2 Zurückziehen-Bestätigungen: „Möchten Sie … zurückziehen?"
- OGS-Hinweis: „wenden Sie sich bitte an die OGS"

## Scope / Hinweise
- Reine UI-Strings (Deutsch), kein API-Contract, kein PyrePortal-Impact.
- Diese `EnrollmentForm` wird sowohl im öffentlichen `/enroll`-Pfad als auch im Eltern-Portal genutzt; Änderung greift in beiden (gewollt, beide elternfacing).
- `public-enrollment-shell.tsx` war bereits sauber.
- Verifiziert: `pnpm run check` (oxlint + tsc) grün; finaler Scan zeigt keine Du-Anrede mehr im öffentlichen Flow.

## Offen (separat, nicht in dieser PR)
Im Screenshot der Schule steht bei *Gesundheitsinformationen* „zum Gesundheitszustand **Ihre Kindes**" — Tippfehler, müsste „Ihres Kindes" sein. Liegt vermutlich in der Formular-/Phasen-Konfiguration, nicht in dieser Komponente.
