### PR TITLE
fix: end open visits atomically with attendance checkout

### DIFF
--- a/backend/api/active/active_internal_test.go
+++ b/backend/api/active/active_internal_test.go
@@ -242,29 +242,24 @@ func TestCheckinError_Respond(t *testing.T) {
 // =============================================================================
 
 func TestCheckoutContext_Fields(t *testing.T) {
-	visit := &active.Visit{StudentID: 123}
 	attendance := &activeService.AttendanceStatus{Status: "checked_in"}
 
 	ctx := &checkoutContext{
 		StudentID:        123,
-		CurrentVisit:     visit,
 		AttendanceStatus: attendance,
 	}
 
 	assert.Equal(t, int64(123), ctx.StudentID)
-	assert.Equal(t, visit, ctx.CurrentVisit)
 	assert.Equal(t, attendance, ctx.AttendanceStatus)
 }
 
 func TestCheckoutContext_NilFields(t *testing.T) {
 	ctx := &checkoutContext{
 		StudentID:        456,
-		CurrentVisit:     nil,
 		AttendanceStatus: nil,
 	}
 
 	assert.Equal(t, int64(456), ctx.StudentID)
-	assert.Nil(t, ctx.CurrentVisit)
 	assert.Nil(t, ctx.AttendanceStatus)
 }
 

--- a/backend/api/active/checkin.go
+++ b/backend/api/active/checkin.go
@@ -171,14 +171,28 @@ func (rs *Resource) validateStudentForCheckin(ctx context.Context, studentID int
 			return &checkinError{http.StatusInternalServerError, "Failed to check current visit status"}
 		}
 	}
-	if currentVisit != nil {
-		return &checkinError{http.StatusConflict, "Student already has an active visit in another room"}
-	}
 
 	// Check attendance status
 	attendanceStatus, statusErr := rs.ActiveService.GetStudentAttendanceStatus(ctx, studentID)
 	if statusErr != nil {
 		return &checkinError{http.StatusInternalServerError, "Failed to get attendance status"}
+	}
+
+	if currentVisit != nil {
+		// Present states ("checked_in" and its yard sub-state) keep the
+		// genuine conflict: the student really is in another room.
+		if attendanceStatus.Status == "checked_in" || attendanceStatus.Status == "on_yard" {
+			return &checkinError{http.StatusConflict, "Student already has an active visit in another room"}
+		}
+
+		// Orphaned visit (issue #895): attendance says the student left, but
+		// a visit row is still open — the deadlock state left behind by a
+		// partial checkout. Heal it and proceed with the check-in; a failure
+		// returns 500 so TenantTxMiddleware rolls the request back.
+		if endErr := rs.ActiveService.EndVisit(ctx, currentVisit.ID); endErr != nil && !errors.Is(endErr, activeService.ErrVisitAlreadyEnded) {
+			return &checkinError{http.StatusInternalServerError, "Failed to check current visit status"}
+		}
+		return nil
 	}
 
 	if attendanceStatus.Status == "checked_in" {

--- a/backend/api/active/checkin_selfheal_integration_test.go
+++ b/backend/api/active/checkin_selfheal_integration_test.go
@@ -105,6 +105,41 @@ func TestCheckinStudent_SelfHealsOrphanVisit(t *testing.T) {
 		defer testpkg.CleanupActivityFixtures(t, db, openVisits[0].ID)
 	})
 
+	t.Run("still 409 when checked in without a visit", func(t *testing.T) {
+		handler := setupCheckinTestHandler(t, db)
+
+		webDevice := testpkg.EnsureWebManualDevice(t, db)
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, db, "NoVisit", "Teacher")
+		educationGroup := testpkg.CreateTestEducationGroup(t, db, "No Visit Conflict Group")
+		testpkg.CreateTestGroupTeacher(t, db, educationGroup.ID, teacher.ID)
+
+		student := testpkg.CreateTestStudent(t, db, "NoVisit", "Student", "5c")
+		testpkg.AssignStudentToGroup(t, db, student.ID, educationGroup.ID)
+
+		targetActivity := testpkg.CreateTestActivityGroup(t, db, "no-visit-target")
+		targetRoom := testpkg.CreateTestRoom(t, db, "No Visit Target Room")
+		targetGroup := testpkg.CreateTestActiveGroup(t, db, targetActivity.ID, targetRoom.ID)
+
+		defer testpkg.CleanupActivityFixtures(t, db, teacher.Staff.ID, teacher.Staff.PersonID, educationGroup.ID, student.ID,
+			targetActivity.ID, targetRoom.ID, targetGroup.ID, webDevice.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		// Checked in for the day but not in any room (open attendance, no visit).
+		checkInTime := time.Now().Add(-1 * time.Hour)
+		testpkg.CreateTestAttendance(t, db, student.ID, teacher.Staff.ID, webDevice.ID, checkInTime, nil)
+
+		token := testpkg.CreateTestJWT(t, account.ID, checkinPermissions)
+		body := active.CheckinRequest{ActiveGroupID: targetGroup.ID}
+		req := makeCheckinRequest(t, student.ID, body, token)
+
+		router := handler.Router()
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusConflict, rr.Code, "Response body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "Student is already checked in")
+	})
+
 	t.Run("still 409 when student is genuinely in another room", func(t *testing.T) {
 		handler := setupCheckinTestHandler(t, db)
 

--- a/backend/api/active/checkin_selfheal_integration_test.go
+++ b/backend/api/active/checkin_selfheal_integration_test.go
@@ -1,0 +1,157 @@
+// Package active_test tests the checkin stale-visit self-heal (issue #895).
+//
+// An orphaned visit (attendance "checked_out" but visit still open) used to
+// deadlock a student: checkin returned 409, checkout returned 404. The
+// checkin validation now heals the orphan (ends the stale visit) and lets the
+// check-in proceed, while genuine conflicts keep their 409 responses.
+package active_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/api/active"
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckinStudent_SelfHealsOrphanVisit(t *testing.T) {
+	setupViperForTest()
+
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	checkinPermissions := []string{permissions.VisitsUpdate}
+
+	t.Run("orphaned visit is healed and checkin proceeds", func(t *testing.T) {
+		handler := setupCheckinTestHandler(t, db)
+
+		webDevice := testpkg.EnsureWebManualDevice(t, db)
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, db, "SelfHeal", "Teacher")
+		educationGroup := testpkg.CreateTestEducationGroup(t, db, "Self Heal Group")
+		testpkg.CreateTestGroupTeacher(t, db, educationGroup.ID, teacher.ID)
+
+		student := testpkg.CreateTestStudent(t, db, "SelfHeal", "Student", "5a")
+		testpkg.AssignStudentToGroup(t, db, student.ID, educationGroup.ID)
+
+		// Two rooms: the orphaned visit is "stuck" in one, the new checkin
+		// targets the other.
+		orphanActivity := testpkg.CreateTestActivityGroup(t, db, "self-heal-orphan")
+		orphanRoom := testpkg.CreateTestRoom(t, db, "Self Heal Orphan Room")
+		orphanGroup := testpkg.CreateTestActiveGroup(t, db, orphanActivity.ID, orphanRoom.ID)
+		targetActivity := testpkg.CreateTestActivityGroup(t, db, "self-heal-target")
+		targetRoom := testpkg.CreateTestRoom(t, db, "Self Heal Target Room")
+		targetGroup := testpkg.CreateTestActiveGroup(t, db, targetActivity.ID, targetRoom.ID)
+
+		defer testpkg.CleanupActivityFixtures(t, db, teacher.Staff.ID, teacher.Staff.PersonID, educationGroup.ID, student.ID,
+			orphanActivity.ID, orphanRoom.ID, orphanGroup.ID, targetActivity.ID, targetRoom.ID, targetGroup.ID, webDevice.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		// The issue #895 deadlock state: attendance closed, visit still open.
+		checkInTime := time.Now().Add(-2 * time.Hour)
+		checkOutTime := time.Now().Add(-30 * time.Minute)
+		testpkg.CreateTestAttendance(t, db, student.ID, teacher.Staff.ID, webDevice.ID, checkInTime, &checkOutTime)
+		orphanVisit := testpkg.CreateTestVisit(t, db, student.ID, orphanGroup.ID, checkInTime, nil)
+		defer testpkg.CleanupActivityFixtures(t, db, orphanVisit.ID)
+
+		token := testpkg.CreateTestJWT(t, account.ID, checkinPermissions)
+		body := active.CheckinRequest{ActiveGroupID: targetGroup.ID}
+		req := makeCheckinRequest(t, student.ID, body, token)
+
+		router := handler.Router()
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		// Pre-fix this was a 409 deadlock; now the orphan is healed.
+		require.Equal(t, http.StatusOK, rr.Code, "Response body: %s", rr.Body.String())
+
+		var response map[string]interface{}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+		data, ok := response["data"].(map[string]interface{})
+		require.True(t, ok, "data should be a map")
+		assert.Equal(t, "checked_in", data["action"])
+		assert.NotZero(t, data["visit_id"])
+
+		// The orphaned visit is closed...
+		healedVisit := new(activeModels.Visit)
+		err := db.NewSelect().
+			Model(healedVisit).
+			ModelTableExpr(`active.visits AS "visit"`).
+			Where(`"visit".id = ?`, orphanVisit.ID).
+			Scan(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, healedVisit.ExitTime, "orphaned visit must be ended during checkin (issue #895)")
+
+		// ...and exactly one new open visit exists, in the target group.
+		var openVisits []*activeModels.Visit
+		err = db.NewSelect().
+			Model(&openVisits).
+			ModelTableExpr(`active.visits AS "visit"`).
+			Where(`"visit".student_id = ?`, student.ID).
+			Where(`"visit".exit_time IS NULL`).
+			Scan(context.Background())
+		require.NoError(t, err)
+		require.Len(t, openVisits, 1)
+		assert.Equal(t, targetGroup.ID, openVisits[0].ActiveGroupID)
+
+		// Cleanup the visit created by the request.
+		defer testpkg.CleanupActivityFixtures(t, db, openVisits[0].ID)
+	})
+
+	t.Run("still 409 when student is genuinely in another room", func(t *testing.T) {
+		handler := setupCheckinTestHandler(t, db)
+
+		webDevice := testpkg.EnsureWebManualDevice(t, db)
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, db, "Genuine", "Teacher")
+		educationGroup := testpkg.CreateTestEducationGroup(t, db, "Genuine Conflict Group")
+		testpkg.CreateTestGroupTeacher(t, db, educationGroup.ID, teacher.ID)
+
+		student := testpkg.CreateTestStudent(t, db, "Genuine", "Student", "5b")
+		testpkg.AssignStudentToGroup(t, db, student.ID, educationGroup.ID)
+
+		currentActivity := testpkg.CreateTestActivityGroup(t, db, "genuine-current")
+		currentRoom := testpkg.CreateTestRoom(t, db, "Genuine Current Room")
+		currentGroup := testpkg.CreateTestActiveGroup(t, db, currentActivity.ID, currentRoom.ID)
+		targetActivity := testpkg.CreateTestActivityGroup(t, db, "genuine-target")
+		targetRoom := testpkg.CreateTestRoom(t, db, "Genuine Target Room")
+		targetGroup := testpkg.CreateTestActiveGroup(t, db, targetActivity.ID, targetRoom.ID)
+
+		defer testpkg.CleanupActivityFixtures(t, db, teacher.Staff.ID, teacher.Staff.PersonID, educationGroup.ID, student.ID,
+			currentActivity.ID, currentRoom.ID, currentGroup.ID, targetActivity.ID, targetRoom.ID, targetGroup.ID, webDevice.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		// Genuinely present: attendance open AND visit open.
+		checkInTime := time.Now().Add(-1 * time.Hour)
+		testpkg.CreateTestAttendance(t, db, student.ID, teacher.Staff.ID, webDevice.ID, checkInTime, nil)
+		visit := testpkg.CreateTestVisit(t, db, student.ID, currentGroup.ID, checkInTime, nil)
+		defer testpkg.CleanupActivityFixtures(t, db, visit.ID)
+
+		token := testpkg.CreateTestJWT(t, account.ID, checkinPermissions)
+		body := active.CheckinRequest{ActiveGroupID: targetGroup.ID}
+		req := makeCheckinRequest(t, student.ID, body, token)
+
+		router := handler.Router()
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusConflict, rr.Code, "Response body: %s", rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "Student already has an active visit in another room")
+
+		// The genuine visit must remain open — no healing here.
+		untouched := new(activeModels.Visit)
+		err := db.NewSelect().
+			Model(untouched).
+			ModelTableExpr(`active.visits AS "visit"`).
+			Where(`"visit".id = ?`, visit.ID).
+			Scan(context.Background())
+		require.NoError(t, err)
+		assert.Nil(t, untouched.ExitTime, "genuine active visit must not be ended by validation")
+	})
+}

--- a/backend/api/active/checkout_helpers.go
+++ b/backend/api/active/checkout_helpers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/moto-nrw/project-phoenix/auth/device"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
-	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	activeService "github.com/moto-nrw/project-phoenix/services/active"
 )
@@ -19,7 +18,6 @@ import (
 // checkoutContext holds all context needed for a checkout operation
 type checkoutContext struct {
 	StudentID        int64
-	CurrentVisit     *active.Visit
 	AttendanceStatus *activeService.AttendanceStatus
 }
 
@@ -43,11 +41,8 @@ func parseStudentIDFromRequest(r *http.Request) (int64, error) {
 	return strconv.ParseInt(studentIDStr, 10, 64)
 }
 
-// getCheckoutContext retrieves the current visit and attendance status for a student
+// getCheckoutContext retrieves the attendance status for a student
 func (rs *Resource) getCheckoutContext(ctx context.Context, studentID int64) (*checkoutContext, error) {
-	// Get current visit (may be nil if student not in a room)
-	currentVisit, _ := rs.ActiveService.GetStudentCurrentVisit(ctx, studentID)
-
 	// Get attendance status (required)
 	attendanceStatus, err := rs.ActiveService.GetStudentAttendanceStatus(ctx, studentID)
 	if err != nil {
@@ -61,7 +56,6 @@ func (rs *Resource) getCheckoutContext(ctx context.Context, studentID int64) (*c
 
 	return &checkoutContext{
 		StudentID:        studentID,
-		CurrentVisit:     currentVisit,
 		AttendanceStatus: attendanceStatus,
 	}, nil
 }
@@ -95,16 +89,15 @@ func (rs *Resource) executeStudentCheckout(
 	staff *users.Staff,
 	checkoutCtx *checkoutContext,
 ) (*checkoutResult, error) {
-	// Embed staff in context for EndVisit recording
+	// Embed staff in context for visit-end recording
 	actionCtx := context.WithValue(ctx, device.CtxStaff, staff)
 
-	// End active visit if exists
-	rs.endActiveVisit(actionCtx, checkoutCtx.CurrentVisit)
-
-	// Toggle attendance to checked out
-	result, err := rs.ActiveService.ToggleStudentAttendance(
-		ctx, checkoutCtx.StudentID, staff.ID, 0, true,
-	)
+	// Action-explicit, race-safe checkout (issue #895). The service closes
+	// the attendance row AND ends any open visit in the same request
+	// transaction; any failure propagates so the handler responds 500 and
+	// TenantTxMiddleware rolls the whole request back — never a checked-out
+	// attendance row alongside an orphaned open visit.
+	result, err := rs.ActiveService.CheckOutStudent(actionCtx, checkoutCtx.StudentID, staff.ID, true)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrCheckoutFailed, err)
 	}
@@ -116,20 +109,6 @@ func (rs *Resource) executeStudentCheckout(
 		Result:            result,
 		UpdatedAttendance: updatedAttendance,
 	}, nil
-}
-
-// endActiveVisit ends the current visit if one exists (fire-and-forget)
-func (rs *Resource) endActiveVisit(ctx context.Context, currentVisit *active.Visit) {
-	if currentVisit == nil {
-		return
-	}
-
-	if err := rs.ActiveService.EndVisit(ctx, currentVisit.ID); err != nil {
-		rs.getLogger().WarnContext(ctx, "failed to end visit during checkout",
-			slog.Int64("visit_id", currentVisit.ID),
-			slog.String("error", err.Error()),
-		)
-	}
 }
 
 // getUpdatedAttendanceStatus fetches the updated attendance status (optional)

--- a/backend/api/active/checkout_integration_test.go
+++ b/backend/api/active/checkout_integration_test.go
@@ -1,0 +1,151 @@
+// Package active_test tests the web checkout flow end-to-end (issue #895).
+//
+// The checkout handler must close the attendance row AND end any open room
+// visit in one request transaction — never the partial state where attendance
+// says "checked_out" while a visit stays open (the orphaned-visit deadlock).
+package active_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeCheckoutRequest creates an HTTP request with JWT auth for the checkout endpoint
+func makeCheckoutRequest(t *testing.T, studentID int64, token string) *http.Request {
+	t.Helper()
+
+	path := "/visits/student/" + strconv.FormatInt(studentID, 10) + "/checkout"
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	return req
+}
+
+func TestCheckoutStudent_Integration(t *testing.T) {
+	setupViperForTest()
+
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	checkoutPermissions := []string{permissions.VisitsUpdate}
+
+	t.Run("closes attendance and ends open visit in one request", func(t *testing.T) {
+		handler := setupCheckinTestHandler(t, db)
+
+		staff, account := testpkg.CreateTestStaffWithAccount(t, db, "Checkout", "Staff")
+		student := testpkg.CreateTestStudent(t, db, "Checkout", "Student", "5a")
+		device := testpkg.CreateTestDevice(t, db, "web-checkout-device-001")
+		activity := testpkg.CreateTestActivityGroup(t, db, "web-checkout-test")
+		room := testpkg.CreateTestRoom(t, db, "Web Checkout Room")
+		activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+
+		defer testpkg.CleanupActivityFixtures(t, db, staff.ID, staff.PersonID, student.ID, device.ID, activity.ID, room.ID, activeGroup.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		// Student is checked in AND in a room (open attendance + open visit).
+		checkInTime := time.Now().Add(-1 * time.Hour)
+		testpkg.CreateTestAttendance(t, db, student.ID, staff.ID, device.ID, checkInTime, nil)
+		visit := testpkg.CreateTestVisit(t, db, student.ID, activeGroup.ID, checkInTime, nil)
+		defer testpkg.CleanupActivityFixtures(t, db, visit.ID)
+
+		token := testpkg.CreateTestJWT(t, account.ID, checkoutPermissions)
+		req := makeCheckoutRequest(t, student.ID, token)
+
+		router := handler.Router()
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code, "Response body: %s", rr.Body.String())
+
+		// Attendance row is closed...
+		var records []*activeModels.Attendance
+		err := db.NewSelect().
+			Model(&records).
+			ModelTableExpr(`active.attendance AS "attendance"`).
+			Where(`"attendance".student_id = ?`, student.ID).
+			Where(`"attendance".date = ?`, timezone.TodayDate()).
+			Scan(context.Background())
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+		require.NotNil(t, records[0].CheckOutTime, "checkout must close the attendance row")
+
+		// ...AND the visit is ended in the same request (issue #895).
+		endedVisit := new(activeModels.Visit)
+		err = db.NewSelect().
+			Model(endedVisit).
+			ModelTableExpr(`active.visits AS "visit"`).
+			Where(`"visit".id = ?`, visit.ID).
+			Scan(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, endedVisit.ExitTime, "checkout must end the open room visit (issue #895)")
+	})
+
+	t.Run("second checkout is a safe no-op", func(t *testing.T) {
+		handler := setupCheckinTestHandler(t, db)
+
+		staff, account := testpkg.CreateTestStaffWithAccount(t, db, "DoubleCheckout", "Staff")
+		student := testpkg.CreateTestStudent(t, db, "DoubleCheckout", "Student", "5b")
+		device := testpkg.CreateTestDevice(t, db, "web-checkout-device-002")
+		activity := testpkg.CreateTestActivityGroup(t, db, "web-double-checkout-test")
+		room := testpkg.CreateTestRoom(t, db, "Web Double Checkout Room")
+		activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+
+		defer testpkg.CleanupActivityFixtures(t, db, staff.ID, staff.PersonID, student.ID, device.ID, activity.ID, room.ID, activeGroup.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		checkInTime := time.Now().Add(-1 * time.Hour)
+		testpkg.CreateTestAttendance(t, db, student.ID, staff.ID, device.ID, checkInTime, nil)
+		visit := testpkg.CreateTestVisit(t, db, student.ID, activeGroup.ID, checkInTime, nil)
+		defer testpkg.CleanupActivityFixtures(t, db, visit.ID)
+
+		token := testpkg.CreateTestJWT(t, account.ID, checkoutPermissions)
+		router := handler.Router()
+
+		// First checkout succeeds.
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, makeCheckoutRequest(t, student.ID, token))
+		require.Equal(t, http.StatusOK, rr.Code, "Response body: %s", rr.Body.String())
+
+		// Second checkout: student is no longer checked in → 404 per the
+		// handler contract. Crucially it must NOT flip into a fresh check-in
+		// (the pre-fix Toggle bug) and must NOT leave any open state behind.
+		rr = httptest.NewRecorder()
+		router.ServeHTTP(rr, makeCheckoutRequest(t, student.ID, token))
+		assert.Equal(t, http.StatusNotFound, rr.Code, "Response body: %s", rr.Body.String())
+
+		// Still exactly one attendance row, still closed.
+		var records []*activeModels.Attendance
+		err := db.NewSelect().
+			Model(&records).
+			ModelTableExpr(`active.attendance AS "attendance"`).
+			Where(`"attendance".student_id = ?`, student.ID).
+			Where(`"attendance".date = ?`, timezone.TodayDate()).
+			Scan(context.Background())
+		require.NoError(t, err)
+		require.Len(t, records, 1, "second checkout must not create a new attendance row")
+		require.NotNil(t, records[0].CheckOutTime)
+
+		// No open visit either.
+		openCount, err := db.NewSelect().
+			ModelTableExpr(`active.visits AS "visit"`).
+			Where(`"visit".student_id = ?`, student.ID).
+			Where(`"visit".exit_time IS NULL`).
+			Count(context.Background())
+		require.NoError(t, err)
+		assert.Zero(t, openCount, "no open visit may remain after checkout")
+	})
+}

--- a/backend/api/active/checkout_test.go
+++ b/backend/api/active/checkout_test.go
@@ -203,14 +203,3 @@ func TestHandleAuthorizationError_OtherError(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
-
-// =============================================================================
-// endActiveVisit Tests
-// =============================================================================
-
-func TestEndActiveVisit_NilVisit(_ *testing.T) {
-	rs := &Resource{}
-
-	// Should not panic when visit is nil
-	rs.endActiveVisit(context.Background(), nil)
-}

--- a/backend/api/iot/attendance/attendance_test.go
+++ b/backend/api/iot/attendance/attendance_test.go
@@ -879,3 +879,141 @@ func TestToggleAttendance_PersonNotStudent(t *testing.T) {
 // NOTE: Full success paths for toggleAttendance and confirm_daily_checkout require
 // complex staff context setup and active visits/groups. The tests above cover
 // these scenarios with real database fixtures.
+
+// =============================================================================
+// CHECKOUT ENDS OPEN VISIT TESTS (issue #895)
+// =============================================================================
+
+// TestToggleAttendance_DailyCheckoutZuhause_EndsOpenVisit verifies that the
+// daily checkout ("zuhause") not only closes the attendance row but also ends
+// a still-open room visit in the same request. Before issue #895 was fixed,
+// the visit stayed open and deadlocked the student (checkin 409 / checkout 404).
+func TestToggleAttendance_DailyCheckoutZuhause_EndsOpenVisit(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	// ARRANGE: checked-in student with RFID and a still-open room visit
+	testDevice := testpkg.CreateTestDevice(t, ctx.db, "daily-zuhause-visit-device")
+	student := testpkg.CreateTestStudent(t, ctx.db, "Zuhause", "OpenVisit", "5f")
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Zuhause", "Staff3")
+	rfidCard := testpkg.CreateTestRFIDCard(t, ctx.db, "TESTRFID_ZUHAUSE_VISIT01")
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, rfidCard.ID)
+
+	checkInTime := time.Now().Add(-2 * time.Hour)
+	testpkg.CreateTestAttendance(t, ctx.db, student.ID, staff.ID, testDevice.ID, checkInTime, nil)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "daily-zuhause-visit-activity")
+	room := testpkg.CreateTestRoom(t, ctx.db, "Daily Zuhause Visit Room")
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, room.ID)
+	visit := testpkg.CreateTestVisit(t, ctx.db, student.ID, activeGroup.ID, checkInTime, nil)
+
+	router := testutil.NewTenantRouter(ctx.db)
+	router.Post("/toggle", ctx.resource.ToggleAttendanceHandler())
+
+	dest := "zuhause"
+	body := map[string]interface{}{
+		"rfid":        rfidCard.ID,
+		"action":      "confirm_daily_checkout",
+		"destination": dest,
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/toggle", body,
+		testutil.WithDeviceContext(testDevice),
+	)
+
+	// ACT
+	rr := testutil.ExecuteRequest(router, req)
+
+	// ASSERT: success, attendance closed AND visit ended
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	var records []*activeModel.Attendance
+	err := ctx.db.NewSelect().
+		Model(&records).
+		ModelTableExpr(`active.attendance AS "attendance"`).
+		Where(`"attendance".student_id = ?`, student.ID).
+		Where(`"attendance".date = ?`, timezone.TodayDate()).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.NotNil(t, records[0].CheckOutTime, "daily checkout must close the attendance row")
+
+	endedVisit := new(activeModel.Visit)
+	err = ctx.db.NewSelect().
+		Model(endedVisit).
+		ModelTableExpr(`active.visits AS "visit"`).
+		Where(`"visit".id = ?`, visit.ID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, endedVisit.ExitTime, "daily checkout must end the open room visit (issue #895)")
+}
+
+// TestToggleAttendance_NormalToggle_CheckoutEndsOpenVisit verifies that the
+// normal kiosk toggle's checkout branch also ends a still-open room visit.
+func TestToggleAttendance_NormalToggle_CheckoutEndsOpenVisit(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	// ARRANGE: full toggle setup (device-linked session + supervisor) with a
+	// checked-in student who still has an open visit in the session's room.
+	testDevice := testpkg.CreateTestDevice(t, ctx.db, "normal-toggle-visit-device")
+	student := testpkg.CreateTestStudent(t, ctx.db, "NormalToggle", "OpenVisit", "5g")
+	staff := testpkg.CreateTestStaff(t, ctx.db, "NormalToggle", "Staff2")
+	rfidCard := testpkg.CreateTestRFIDCard(t, ctx.db, "TESTRFID_NORMALTOGGLE02")
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, rfidCard.ID)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "normal-toggle-visit-activity")
+	room := testpkg.CreateTestRoom(t, ctx.db, "Normal Toggle Visit Room")
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, room.ID)
+
+	_, err := ctx.db.NewUpdate().
+		Model(activeGroup).
+		ModelTableExpr(`active.groups`).
+		Set("device_id = ?", testDevice.ID).
+		Where("id = ?", activeGroup.ID).
+		Exec(context.Background())
+	require.NoError(t, err)
+
+	testpkg.CreateTestGroupSupervisor(t, ctx.db, staff.ID, activeGroup.ID, "supervisor")
+
+	checkInTime := time.Now().Add(-1 * time.Hour)
+	testpkg.CreateTestAttendance(t, ctx.db, student.ID, staff.ID, testDevice.ID, checkInTime, nil)
+	visit := testpkg.CreateTestVisit(t, ctx.db, student.ID, activeGroup.ID, checkInTime, nil)
+
+	router := testutil.NewTenantRouter(ctx.db)
+	router.Post("/toggle", ctx.resource.ToggleAttendanceHandler())
+
+	body := map[string]interface{}{
+		"rfid":   rfidCard.ID,
+		"action": "confirm",
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/toggle", body,
+		testutil.WithDeviceContext(testDevice),
+		testutil.WithStaffContext(staff),
+		func(r *http.Request) {
+			reqCtx := context.WithValue(r.Context(), device.CtxIsIoTDevice, true)
+			*r = *r.WithContext(reqCtx)
+		},
+	)
+
+	// ACT: student is checked_in, so the toggle performs a checkout
+	rr := testutil.ExecuteRequest(router, req)
+
+	// ASSERT: success with checked_out action AND the visit is ended
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	if data, ok := response["data"].(map[string]interface{}); ok {
+		assert.Equal(t, "checked_out", data["action"])
+	}
+
+	endedVisit := new(activeModel.Visit)
+	err = ctx.db.NewSelect().
+		Model(endedVisit).
+		ModelTableExpr(`active.visits AS "visit"`).
+		Where(`"visit".id = ?`, visit.ID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, endedVisit.ExitTime, "toggle checkout must end the open room visit (issue #895)")
+}

--- a/backend/api/iot/attendance/handlers.go
+++ b/backend/api/iot/attendance/handlers.go
@@ -165,8 +165,11 @@ func (rs *Resource) handleCancelAction(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleDailyCheckout handles the "confirm_daily_checkout" action.
-// The student's visit was already ended by the checkin handler (student is "unterwegs").
-// This endpoint only updates the attendance record when the student confirms "nach Hause".
+// Normally the student's visit was already ended by the checkin handler
+// (student is "unterwegs") and this endpoint only updates the attendance
+// record when the student confirms "nach Hause". If a visit is still open,
+// CheckOutStudent ends it in the same request transaction (issue #895 — see
+// services/active.performCheckOut).
 func (rs *Resource) handleDailyCheckout(w http.ResponseWriter, r *http.Request, normalizedRFID string, req *AttendanceToggleRequest) {
 	// Find person by RFID tag
 	person, err := rs.UsersService.FindByTagID(r.Context(), normalizedRFID)

--- a/backend/api/students/school_checkin_handlers.go
+++ b/backend/api/students/school_checkin_handlers.go
@@ -202,21 +202,12 @@ func (rs *Resource) applySchoolCheckinAction(
 			return nil, err
 		}
 	case schoolCheckinActionOut:
+		// CheckOutStudent also ends any open room visit in the same request
+		// transaction (issue #895 — see services/active.performCheckOut), so
+		// detailed-mode supervisor views never show "still in Room X" after
+		// a web checkout. No separate EndVisit call is needed here.
 		if _, err := rs.ActiveService.CheckOutStudent(ctx, student.ID, staffID, true); err != nil {
 			return nil, err
-		}
-		// End any open room visit so detailed-mode supervisor views don't
-		// show "still in Room X" after a web checkout. In binary mode
-		// EndVisit is a no-op (see services/active.EndVisit gate).
-		//
-		// Bubble any failure up so the TenantTxMiddleware rolls the whole
-		// request back — leaving an open visit while attendance says
-		// checked-out is exactly the inconsistency this PR exists to
-		// prevent.
-		if visit, vErr := rs.ActiveService.GetStudentCurrentVisit(ctx, student.ID); vErr == nil && visit != nil {
-			if endErr := rs.ActiveService.EndVisit(ctx, visit.ID); endErr != nil {
-				return nil, fmt.Errorf("end open visit on school checkout (visit_id=%d): %w", visit.ID, endErr)
-			}
 		}
 	}
 

--- a/backend/services/active/attendance_service.go
+++ b/backend/services/active/attendance_service.go
@@ -2,6 +2,7 @@ package active
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"time"
@@ -71,6 +72,9 @@ func deriveAttendanceStatus(a *active.Attendance) string {
 func (s *service) GetStudentAttendanceStatus(ctx context.Context, studentID int64) (*AttendanceStatus, error) {
 	attendance, err := s.attendanceRepo.GetStudentCurrentStatus(ctx, studentID)
 	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, &ActiveError{Op: "GetStudentAttendanceStatus", Err: ErrDatabaseOperation}
+		}
 		return &AttendanceStatus{
 			StudentID: studentID,
 			Status:    "not_checked_in",
@@ -330,7 +334,11 @@ func (s *service) endOpenVisitForStudent(ctx context.Context, studentID int64) e
 		}
 		return err
 	}
-	if err := s.EndVisit(ctx, visit.ID); err != nil && !errors.Is(err, ErrVisitAlreadyEnded) {
+	if err := s.visitRepo.EndVisit(ctx, visit.ID); err != nil {
+		latest, findErr := s.visitRepo.FindByID(ctx, visit.ID)
+		if findErr == nil && latest != nil && latest.ExitTime != nil {
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/backend/services/active/attendance_service.go
+++ b/backend/services/active/attendance_service.go
@@ -330,9 +330,6 @@ func (s *service) endOpenVisitForStudent(ctx context.Context, studentID int64) e
 		}
 		return err
 	}
-	if visit == nil {
-		return nil
-	}
 	if err := s.EndVisit(ctx, visit.ID); err != nil && !errors.Is(err, ErrVisitAlreadyEnded) {
 		return err
 	}

--- a/backend/services/active/attendance_service.go
+++ b/backend/services/active/attendance_service.go
@@ -168,7 +168,8 @@ func (s *service) CheckInStudent(ctx context.Context, studentID, staffID, device
 // never checked in, or another concurrent caller already closed it), returns
 // an idempotent successful result with Action="checked_out" and no
 // AttendanceID — the caller can re-fetch the latest status if they need
-// timestamps for display.
+// timestamps for display. Any open room visit is ended as part of the same
+// operation (issue #895) — callers don't need a separate EndVisit call.
 func (s *service) CheckOutStudent(ctx context.Context, studentID, staffID int64, skipAuthCheck bool) (*AttendanceResult, error) {
 	// Auth path is shared with the toggle — pass deviceID=0 because the
 	// caller is web-side (no kiosk involved); IsIoTDeviceRequest is false
@@ -316,8 +317,30 @@ func (s *service) performCheckIn(ctx context.Context, studentID, staffID, device
 	}, nil
 }
 
+// endOpenVisitForStudent enforces the invariant "attendance checked_out =>
+// no open visit" (issue #895). Returns nil when no open visit exists or a
+// concurrent caller already ended it; every other failure propagates so the
+// surrounding request transaction rolls back instead of committing a
+// checked-out attendance row alongside an orphaned open visit.
+func (s *service) endOpenVisitForStudent(ctx context.Context, studentID int64) error {
+	visit, err := s.GetStudentCurrentVisit(ctx, studentID)
+	if err != nil {
+		if errors.Is(err, ErrVisitNotFound) {
+			return nil
+		}
+		return err
+	}
+	if visit == nil {
+		return nil
+	}
+	if err := s.EndVisit(ctx, visit.ID); err != nil && !errors.Is(err, ErrVisitAlreadyEnded) {
+		return err
+	}
+	return nil
+}
+
 // performCheckOut closes the open attendance row for the student via a
-// state-checked UPDATE WHERE check_out_time IS NULL. Two key properties:
+// state-checked UPDATE WHERE check_out_time IS NULL. Three key properties:
 //
 //  1. Concurrency-safe: a second concurrent "out" call (or an "in" call that
 //     lost the race against another "out") simply finds no open row to
@@ -325,10 +348,17 @@ func (s *service) performCheckIn(ctx context.Context, studentID, staffID, device
 //  2. Yard sub-state is cleared as part of the same UPDATE so detailed-mode
 //     callers don't observe an inconsistent (CheckOutTime set, YardSince
 //     still set) row even briefly.
+//  3. Any open room visit is ended in the same request transaction (issue
+//     #895) — including on the idempotent no-open-row path, so a checkout of
+//     any kind heals an orphaned visit left behind by older code.
 func (s *service) performCheckOut(ctx context.Context, studentID, staffID int64, now time.Time) (*AttendanceResult, error) {
 	closed, err := s.attendanceRepo.CloseOpenForToday(ctx, studentID, now, staffID)
 	if err != nil {
 		return nil, &ActiveError{Op: "ToggleStudentAttendance", Err: fmt.Errorf("database error during state-checked checkout: %w", err)}
+	}
+
+	if err := s.endOpenVisitForStudent(ctx, studentID); err != nil {
+		return nil, &ActiveError{Op: "ToggleStudentAttendance", Err: fmt.Errorf("end open visit during checkout: %w", err)}
 	}
 
 	if closed == nil {

--- a/backend/services/active/attendance_service_test.go
+++ b/backend/services/active/attendance_service_test.go
@@ -109,6 +109,21 @@ func TestGetStudentAttendanceStatus_NotCheckedIn(t *testing.T) {
 	assert.Empty(t, result.CheckedOutBy)
 }
 
+func TestGetStudentAttendanceStatus_ReadFailureReturnsError(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+
+	service := setupActiveService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	student := testpkg.CreateTestStudent(t, db, "AttendanceRead", "Failure", "2a")
+	require.NoError(t, db.Close())
+
+	result, err := service.GetStudentAttendanceStatus(ctx, student.ID)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
 // TestGetStudentAttendanceStatus_CheckedIn tests the scenario where a student
 // has checked in today (active attendance record).
 func TestGetStudentAttendanceStatus_CheckedIn(t *testing.T) {

--- a/backend/services/active/attendance_service_test.go
+++ b/backend/services/active/attendance_service_test.go
@@ -989,3 +989,121 @@ func TestCheckOutStudent_AlreadyCheckedOut_IsIdempotent(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Equal(t, "checked_out", result.Action)
 }
+
+// =============================================================================
+// Checkout ends open visits — invariant tests (issue #895)
+// =============================================================================
+//
+// Every attendance checkout (CheckOutStudent and the toggle's "out" branch)
+// must also end any open room visit in the same operation, so attendance
+// "checked_out" never coexists with an open visit (the orphaned-visit
+// deadlock from issue #895).
+
+func TestCheckOutStudent_EndsOpenVisit(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	student := testpkg.CreateTestStudent(t, db, "Invariant", "CheckOut", "6a")
+	staff := testpkg.CreateTestStaff(t, db, "Invariant", "Staff1")
+	device := testpkg.CreateTestDevice(t, db, "invariant-device-001")
+	activity := testpkg.CreateTestActivityGroup(t, db, "invariant-checkout")
+	room := testpkg.CreateTestRoom(t, db, "Invariant Room 1")
+	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID, staff.ID, device.ID, activity.ID, room.ID, activeGroup.ID)
+
+	// Open attendance + open visit (student is in a room).
+	checkInTime := time.Now().Add(-1 * time.Hour)
+	testpkg.CreateTestAttendance(t, db, student.ID, staff.ID, device.ID, checkInTime, nil)
+	visit := testpkg.CreateTestVisit(t, db, student.ID, activeGroup.ID, checkInTime, nil)
+	defer testpkg.CleanupActivityFixtures(t, db, visit.ID)
+
+	result, err := service.CheckOutStudent(ctx, student.ID, staff.ID, true)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "checked_out", result.Action)
+
+	// Attendance is closed AND the visit is ended in the same operation.
+	status, err := service.GetStudentAttendanceStatus(ctx, student.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "checked_out", status.Status)
+
+	endedVisit, err := service.GetVisit(ctx, visit.ID)
+	require.NoError(t, err)
+	require.NotNil(t, endedVisit.ExitTime, "open visit must be ended by attendance checkout")
+}
+
+// TestCheckOutStudent_NoOpenAttendance_HealsOrphanVisit covers the
+// self-healing property: even when no open attendance row exists (the
+// idempotent checkout path), an orphaned open visit left behind by pre-fix
+// code is closed.
+func TestCheckOutStudent_NoOpenAttendance_HealsOrphanVisit(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	student := testpkg.CreateTestStudent(t, db, "Invariant", "Orphan", "6b")
+	staff := testpkg.CreateTestStaff(t, db, "Invariant", "Staff2")
+	device := testpkg.CreateTestDevice(t, db, "invariant-device-002")
+	activity := testpkg.CreateTestActivityGroup(t, db, "invariant-orphan")
+	room := testpkg.CreateTestRoom(t, db, "Invariant Room 2")
+	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID, staff.ID, device.ID, activity.ID, room.ID, activeGroup.ID)
+
+	// The orphan state from issue #895: attendance already closed, visit open.
+	checkInTime := time.Now().Add(-2 * time.Hour)
+	checkOutTime := time.Now().Add(-30 * time.Minute)
+	testpkg.CreateTestAttendance(t, db, student.ID, staff.ID, device.ID, checkInTime, &checkOutTime)
+	visit := testpkg.CreateTestVisit(t, db, student.ID, activeGroup.ID, checkInTime, nil)
+	defer testpkg.CleanupActivityFixtures(t, db, visit.ID)
+
+	result, err := service.CheckOutStudent(ctx, student.ID, staff.ID, true)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "checked_out", result.Action)
+	assert.Zero(t, result.AttendanceID, "no open attendance row → idempotent close")
+
+	healedVisit, err := service.GetVisit(ctx, visit.ID)
+	require.NoError(t, err)
+	require.NotNil(t, healedVisit.ExitTime, "orphaned visit must be healed even on the idempotent path")
+}
+
+// TestToggleStudentAttendance_CheckOut_EndsOpenVisit covers the IoT toggle's
+// "out" branch at service level: the kiosk toggle goes through the same
+// performCheckOut and must end the open visit too.
+func TestToggleStudentAttendance_CheckOut_EndsOpenVisit(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	student := testpkg.CreateTestStudent(t, db, "Invariant", "Toggle", "6c")
+	staff := testpkg.CreateTestStaff(t, db, "Invariant", "Staff3")
+	device := testpkg.CreateTestDevice(t, db, "invariant-device-003")
+	activity := testpkg.CreateTestActivityGroup(t, db, "invariant-toggle")
+	room := testpkg.CreateTestRoom(t, db, "Invariant Room 3")
+	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID, staff.ID, device.ID, activity.ID, room.ID, activeGroup.ID)
+
+	checkInTime := time.Now().Add(-1 * time.Hour)
+	testpkg.CreateTestAttendance(t, db, student.ID, staff.ID, device.ID, checkInTime, nil)
+	visit := testpkg.CreateTestVisit(t, db, student.ID, activeGroup.ID, checkInTime, nil)
+	defer testpkg.CleanupActivityFixtures(t, db, visit.ID)
+
+	result, err := service.ToggleStudentAttendance(ctx, student.ID, staff.ID, device.ID, true)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "checked_out", result.Action)
+
+	endedVisit, err := service.GetVisit(ctx, visit.ID)
+	require.NoError(t, err)
+	require.NotNil(t, endedVisit.ExitTime, "toggle checkout must end the open visit")
+}

--- a/backend/services/active/checkout_visit_invariant_mock_test.go
+++ b/backend/services/active/checkout_visit_invariant_mock_test.go
@@ -1,0 +1,91 @@
+package active
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Unit tests for the error branches of endOpenVisitForStudent (issue #895).
+// The happy paths (open visit ended, no visit at all) are covered by the
+// hermetic service and handler tests; the branches below need failure
+// injection, so they use the in-package mockVisitRepository like the other
+// *_mock_test.go files.
+
+func TestEndOpenVisitForStudent_LookupErrorPropagates(t *testing.T) {
+	lookupErr := errors.New("connection reset")
+	svc := &service{
+		visitRepo: &mockVisitRepository{
+			getCurrentByStudentIDFunc: func(context.Context, int64) (*activeModels.Visit, error) {
+				return nil, lookupErr
+			},
+		},
+	}
+
+	err := svc.endOpenVisitForStudent(context.Background(), 4711)
+
+	require.Error(t, err, "a non-NotFound lookup failure must propagate so the checkout transaction rolls back")
+	assert.False(t, errors.Is(err, ErrVisitNotFound))
+}
+
+func TestEndOpenVisitForStudent_AlreadyEndedIsTolerated(t *testing.T) {
+	// GetCurrentByStudentID still reports the visit as open, but by the time
+	// EndVisit re-reads it the exit time is set — the concurrent-caller race.
+	exitTime := time.Now()
+	endedVisit := &activeModels.Visit{
+		Model:     base.Model{ID: 4712},
+		StudentID: 4711,
+		EntryTime: time.Now().Add(-1 * time.Hour),
+		ExitTime:  &exitTime,
+	}
+	openView := *endedVisit
+	openView.ExitTime = nil
+
+	svc := &service{
+		visitRepo: &mockVisitRepository{
+			getCurrentByStudentIDFunc: func(context.Context, int64) (*activeModels.Visit, error) {
+				return &openView, nil
+			},
+			findByIDFunc: func(context.Context, interface{}) (*activeModels.Visit, error) {
+				return endedVisit, nil
+			},
+		},
+	}
+
+	err := svc.endOpenVisitForStudent(context.Background(), 4711)
+
+	require.NoError(t, err, "a visit ended by a concurrent caller is the desired end state, not an error")
+}
+
+func TestEndOpenVisitForStudent_EndVisitErrorPropagates(t *testing.T) {
+	openVisit := &activeModels.Visit{
+		Model:     base.Model{ID: 4713},
+		StudentID: 4711,
+		EntryTime: time.Now().Add(-1 * time.Hour),
+	}
+
+	svc := &service{
+		visitRepo: &mockVisitRepository{
+			getCurrentByStudentIDFunc: func(context.Context, int64) (*activeModels.Visit, error) {
+				return openVisit, nil
+			},
+			findByIDFunc: func(context.Context, interface{}) (*activeModels.Visit, error) {
+				return openVisit, nil
+			},
+			endVisitFunc: func(context.Context, int64) error {
+				return errors.New("disk full")
+			},
+		},
+	}
+
+	err := svc.endOpenVisitForStudent(context.Background(), 4711)
+
+	require.Error(t, err, "an EndVisit failure must propagate so attendance close and visit end stay atomic")
+	assert.False(t, errors.Is(err, ErrVisitAlreadyEnded))
+}

--- a/backend/services/active/checkout_visit_invariant_mock_test.go
+++ b/backend/services/active/checkout_visit_invariant_mock_test.go
@@ -63,6 +63,36 @@ func TestEndOpenVisitForStudent_AlreadyEndedIsTolerated(t *testing.T) {
 	require.NoError(t, err, "a visit ended by a concurrent caller is the desired end state, not an error")
 }
 
+func TestEndOpenVisitForStudent_BinaryModeStillEndsStaleVisit(t *testing.T) {
+	openVisit := &activeModels.Visit{
+		Model:     base.Model{ID: 4714},
+		StudentID: 4711,
+		EntryTime: time.Now().Add(-1 * time.Hour),
+	}
+	endCalled := false
+
+	svc := &service{
+		settings: &stubSettingsResolver{
+			stringValues: map[string]string{"operations.presence_mode": "binary"},
+		},
+		visitRepo: &mockVisitRepository{
+			getCurrentByStudentIDFunc: func(context.Context, int64) (*activeModels.Visit, error) {
+				return openVisit, nil
+			},
+			endVisitFunc: func(_ context.Context, id int64) error {
+				assert.Equal(t, openVisit.ID, id)
+				endCalled = true
+				return nil
+			},
+		},
+	}
+
+	err := svc.endOpenVisitForStudent(context.Background(), 4711)
+
+	require.NoError(t, err)
+	assert.True(t, endCalled, "checkout stale-visit healing must bypass the binary-mode EndVisit no-op")
+}
+
 func TestEndOpenVisitForStudent_EndVisitErrorPropagates(t *testing.T) {
 	openVisit := &activeModels.Visit{
 		Model:     base.Model{ID: 4713},

--- a/backend/services/active/interface.go
+++ b/backend/services/active/interface.go
@@ -118,7 +118,10 @@ type Service interface {
 	// CheckOutStudent applies "out" unconditionally via a state-checked
 	// UPDATE WHERE check_out_time IS NULL — closes the open row when one
 	// exists, returns idempotent success otherwise. Action is always
-	// "checked_out" on return.
+	// "checked_out" on return. Every checkout (this method and the toggle's
+	// "out" branch) also ends any open room visit in the same request
+	// transaction, so attendance "checked_out" never coexists with an open
+	// visit (issue #895).
 	CheckOutStudent(ctx context.Context, studentID, staffID int64, skipAuthCheck bool) (*AttendanceResult, error)
 	CheckTeacherStudentAccess(ctx context.Context, teacherID, studentID int64) (bool, error)
 	BroadcastDailyCheckout(ctx context.Context, studentID int64)


### PR DESCRIPTION
Closes #895

## Problem

The web checkout flow ended a student's room visit fire-and-forget (`endActiveVisit` only logged failures) and then called `ToggleStudentAttendance`, which the service interface explicitly forbids for web callers. When `EndVisit` failed, attendance committed as `checked_out` while `active.visits.exit_time` stayed NULL. The student was then deadlocked: check-in returned 409 ("active visit in another room"), checkout returned 404 ("not currently checked in"). The IoT daily checkout and kiosk toggle paths closed attendance without ever ending visits, and check-in had no recovery path for the orphan state.

## Approach

All affected routes already run inside one per-request transaction (`TenantTxMiddleware`, rollback on 5xx), so no new `RunInTx` was needed. The fix makes errors propagate and enforces a single invariant in the service layer: **after any attendance checkout succeeds, the student has no open visit.**

- `services/active`: `performCheckOut` now ends any open visit via the new `endOpenVisitForStudent` helper, on both branches. It also runs on the idempotent no-open-row path, so orphaned visits left by pre-fix data self-heal on the next checkout of any kind. Failures bubble up to a 500, which rolls the whole request back; visit end and attendance close commit or fail together. Every checkout caller funnels through this one place: web checkout, IoT daily checkout, kiosk toggle, binary-mode toggle, and the school check-in page.
- Web checkout (`api/active/checkout_helpers.go`): replaced fire-and-forget `EndVisit` plus `ToggleStudentAttendance` with action-explicit `CheckOutStudent`. A double click can no longer flip into a fresh check-in. The existing 404 contract for "not checked in" is unchanged.
- Web check-in (`api/active/checkin.go`): `validateStudentForCheckin` now heals an orphaned visit (visit open but attendance `checked_out`/`not_checked_in`) and proceeds with the check-in. Genuine conflicts (`checked_in` and the `on_yard` sub-state) keep their byte-identical 409 responses.
- School check-in handler: removed the handler-level `GetStudentCurrentVisit` + `EndVisit` block. After the service change it was dead code (the visit is already ended by `CheckOutStudent`); the existing `TestSchoolCheckin_CheckOut_AlsoEndsOpenVisit` integration test now proves the service-level move.
- IoT attendance handlers: no code changes needed, both paths are covered via `performCheckOut`. Stale comment updated. No error strings changed, so the PyrePortal contract is untouched.

## Existing test changes (deliberate, compile-forced)

Per `.claude/rules/no-test-modifications.md`, flagging the two existing test files that had to change:

- `TestEndActiveVisit_NilVisit` was deleted together with the `endActiveVisit` helper it tested. Its nil-tolerance behavior moved into `endOpenVisitForStudent` and is covered by the new service tests.
- The `checkoutContext` struct-shape tests in `active_internal_test.go` dropped the removed `CurrentVisit` field. They assert only that assigned fields hold their values, no business rule involved.

## New tests

- Service: `TestCheckOutStudent_EndsOpenVisit`, `TestCheckOutStudent_NoOpenAttendance_HealsOrphanVisit` (self-heal on the idempotent path), `TestToggleStudentAttendance_CheckOut_EndsOpenVisit`
- Web integration: checkout closes attendance and ends the visit in one request; second checkout returns 404 with no new attendance row and no open visit; check-in heals the orphan state and still 409s for genuine conflicts
- IoT integration: daily checkout ("zuhause") and normal toggle both end a still-open visit

## Verification

- `go build ./...`, full `go test ./...` green
- `go test -race` on `services/active` and `api/active` green
- `golangci-lint run` on all touched packages: 0 issues
- Hermetic pattern check (`TestHermeticTestPatterns`) green