### PR TITLE
fix: retry caregiver capability disable when killed as deadlock victim

### DIFF
--- a/backend/services/users/caregiver_capability.go
+++ b/backend/services/users/caregiver_capability.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
@@ -18,6 +20,7 @@ import (
 	authSvc "github.com/moto-nrw/project-phoenix/services/auth"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/driver/pgdriver"
 )
 
 // CaregiverCapabilityServiceDependencies contains the repositories and services
@@ -69,6 +72,54 @@ var caregiverCapabilityBindingTables = []string{
 }
 
 const caregiverCapabilityAuditIP = "0.0.0.0"
+
+// caregiverDisableDeadlockAttempts bounds how often the disable transaction
+// is retried after Postgres aborts it as a deadlock victim (SQLSTATE 40P01).
+// The four SHARE ROW EXCLUSIVE locks in lockCaregiverCapabilityBindings can
+// deadlock against concurrent writers that touch the same tables in a
+// different order; Postgres resolves that by killing one side, and the
+// documented remedy is to retry the killed transaction.
+const caregiverDisableDeadlockAttempts = 3
+
+// isDeadlockError reports whether err is a Postgres deadlock abort (40P01).
+func isDeadlockError(err error) bool {
+	var pgErr pgdriver.Error
+	return errors.As(err, &pgErr) && pgErr.Field('C') == "40P01"
+}
+
+// runDisableTxWithDeadlockRetry executes fn via RunInTx and retries when the
+// transaction was aborted as a deadlock victim. It retries only when this
+// service owns the transaction: with an outer transaction in ctx the abort
+// has already poisoned the whole request transaction, so only the caller can
+// retry and we return the error unchanged.
+func (s *caregiverCapabilityService) runDisableTxWithDeadlockRetry(
+	ctx context.Context,
+	fn func(txCtx context.Context, tx bun.Tx) error,
+) error {
+	if _, hasOuterTx := modelBase.TxFromContext(ctx); hasOuterTx {
+		return s.txHandler.RunInTx(ctx, fn)
+	}
+
+	var err error
+	for attempt := 1; attempt <= caregiverDisableDeadlockAttempts; attempt++ {
+		err = s.txHandler.RunInTx(ctx, fn)
+		if err == nil || !isDeadlockError(err) {
+			return err
+		}
+		if attempt == caregiverDisableDeadlockAttempts {
+			break
+		}
+		slog.Default().WarnContext(ctx, "caregiver capability disable aborted as deadlock victim, retrying",
+			slog.Int("attempt", attempt),
+		)
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(time.Duration(attempt) * 50 * time.Millisecond):
+		}
+	}
+	return err
+}
 
 // NewCaregiverCapabilityService creates a tenant-scoped caregiver capability service.
 func NewCaregiverCapabilityService(
@@ -230,7 +281,7 @@ func (s *caregiverCapabilityService) DisableCaregiverCapability(
 	}
 
 	var result *userModels.CaregiverCapabilityState
-	if err := s.txHandler.RunInTx(ctx, func(txCtx context.Context, tx bun.Tx) error {
+	if err := s.runDisableTxWithDeadlockRetry(ctx, func(txCtx context.Context, tx bun.Tx) error {
 		if err := s.lockCaregiverCapabilityBindings(txCtx, tx); err != nil {
 			return err
 		}

--- a/backend/services/users/caregiver_capability_deadlock_test.go
+++ b/backend/services/users/caregiver_capability_deadlock_test.go
@@ -1,0 +1,172 @@
+package users
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// Tests for the deadlock-retry wrapper around DisableCaregiverCapability
+// (issue #1619). pgdriver.Error cannot be constructed outside the driver
+// package, so the classifier is exercised against a genuine deadlock
+// provoked between two transactions on private scratch tables; the captured
+// error then drives the retry-loop tests.
+
+var (
+	deadlockProbeOnce sync.Once
+	deadlockProbeErr  error
+)
+
+// provokeDeadlock forces a real 40P01 by locking two scratch tables in
+// opposite order from two transactions. The tables are private to this test
+// file, so no other package can contend on them.
+func provokeDeadlock(tb testing.TB, db *bun.DB) error {
+	tb.Helper()
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx,
+		"CREATE TABLE IF NOT EXISTS users_deadlock_probe_a (id int); CREATE TABLE IF NOT EXISTS users_deadlock_probe_b (id int)")
+	require.NoError(tb, err)
+	defer func() {
+		_, _ = db.ExecContext(context.Background(),
+			"DROP TABLE IF EXISTS users_deadlock_probe_a; DROP TABLE IF EXISTS users_deadlock_probe_b")
+	}()
+
+	tx1, err := db.BeginTx(ctx, nil)
+	require.NoError(tb, err)
+	defer func() { _ = tx1.Rollback() }()
+	tx2, err := db.BeginTx(ctx, nil)
+	require.NoError(tb, err)
+	defer func() { _ = tx2.Rollback() }()
+
+	_, err = tx1.ExecContext(ctx, "LOCK TABLE users_deadlock_probe_a IN ACCESS EXCLUSIVE MODE")
+	require.NoError(tb, err)
+	_, err = tx2.ExecContext(ctx, "LOCK TABLE users_deadlock_probe_b IN ACCESS EXCLUSIVE MODE")
+	require.NoError(tb, err)
+
+	errCh := make(chan error, 2)
+	go func() {
+		_, lockErr := tx1.ExecContext(ctx, "LOCK TABLE users_deadlock_probe_b IN ACCESS EXCLUSIVE MODE")
+		errCh <- lockErr
+	}()
+	go func() {
+		_, lockErr := tx2.ExecContext(ctx, "LOCK TABLE users_deadlock_probe_a IN ACCESS EXCLUSIVE MODE")
+		errCh <- lockErr
+	}()
+
+	first, second := <-errCh, <-errCh
+	if first != nil {
+		return first
+	}
+	return second
+}
+
+// capturedDeadlockError provokes the deadlock once per test binary and
+// returns the captured driver error.
+func capturedDeadlockError(t *testing.T, db *bun.DB) error {
+	t.Helper()
+	deadlockProbeOnce.Do(func() {
+		deadlockProbeErr = provokeDeadlock(t, db)
+	})
+	require.Error(t, deadlockProbeErr, "expected to capture a real deadlock error")
+	return deadlockProbeErr
+}
+
+func TestIsDeadlockError_ClassifiesRealDeadlock(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	deadlockErr := capturedDeadlockError(t, db)
+
+	assert.True(t, isDeadlockError(deadlockErr), "real 40P01 must be classified as deadlock, got: %v", deadlockErr)
+	assert.True(t, isDeadlockError(fmt.Errorf("users.disable caregiver capability: lock tables: %w", deadlockErr)),
+		"wrapped 40P01 must still be classified via errors.As")
+	assert.False(t, isDeadlockError(errors.New("deadlock detected")), "plain text must not satisfy the typed check")
+	assert.False(t, isDeadlockError(nil))
+}
+
+func TestRunDisableTxWithDeadlockRetry_RetriesThenSucceeds(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	deadlockErr := capturedDeadlockError(t, db)
+	svc := &caregiverCapabilityService{txHandler: modelBase.NewTxHandler(db)}
+
+	attempts := 0
+	err := svc.runDisableTxWithDeadlockRetry(context.Background(), func(context.Context, bun.Tx) error {
+		attempts++
+		if attempts < 3 {
+			return deadlockErr
+		}
+		return nil
+	})
+
+	require.NoError(t, err, "the third attempt succeeds, so the operation must succeed")
+	assert.Equal(t, 3, attempts)
+}
+
+func TestRunDisableTxWithDeadlockRetry_GivesUpAfterMaxAttempts(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	deadlockErr := capturedDeadlockError(t, db)
+	svc := &caregiverCapabilityService{txHandler: modelBase.NewTxHandler(db)}
+
+	attempts := 0
+	err := svc.runDisableTxWithDeadlockRetry(context.Background(), func(context.Context, bun.Tx) error {
+		attempts++
+		return deadlockErr
+	})
+
+	require.Error(t, err)
+	assert.True(t, isDeadlockError(err), "the final deadlock error must surface unchanged")
+	assert.Equal(t, caregiverDisableDeadlockAttempts, attempts)
+}
+
+func TestRunDisableTxWithDeadlockRetry_NonDeadlockErrorNotRetried(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc := &caregiverCapabilityService{txHandler: modelBase.NewTxHandler(db)}
+	boom := errors.New("validation failed")
+
+	attempts := 0
+	err := svc.runDisableTxWithDeadlockRetry(context.Background(), func(context.Context, bun.Tx) error {
+		attempts++
+		return boom
+	})
+
+	require.ErrorIs(t, err, boom)
+	assert.Equal(t, 1, attempts, "only deadlock aborts may be retried")
+}
+
+func TestRunDisableTxWithDeadlockRetry_NoRetryInsideOuterTx(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	deadlockErr := capturedDeadlockError(t, db)
+	svc := &caregiverCapabilityService{txHandler: modelBase.NewTxHandler(db)}
+
+	outerTx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	defer func() { _ = outerTx.Rollback() }()
+	ctx := modelBase.ContextWithTx(context.Background(), &outerTx)
+
+	attempts := 0
+	err = svc.runDisableTxWithDeadlockRetry(ctx, func(context.Context, bun.Tx) error {
+		attempts++
+		return deadlockErr
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 1, attempts,
+		"with an outer transaction the abort poisons the whole tx — retrying inside would re-run on a dead transaction")
+}


### PR DESCRIPTION
Part of #1619 (the dominant flake class: 2 of the last 4 CI runs on #1618 died on caregiver capability tests with `deadlock detected (SQLSTATE=40P01)`).

## Problem

`DisableCaregiverCapability` acquires `SHARE ROW EXCLUSIVE` locks on four binding tables in sequence (`education.group_teacher`, `education.group_substitution`, `active.group_supervisors`, `activities.supervisors`). Any concurrent transaction writing those tables in a different order can deadlock against it. Postgres resolves the cycle by aborting one side with SQLSTATE 40P01. In the parallel CI suite the caregiver tests are regular victims; in production the same abort can hit an admin disabling caregiver capability while a supervisor assignment commits.

## Fix

Retry the aborted transaction, which is the remedy the Postgres documentation prescribes for deadlock victims:

- `runDisableTxWithDeadlockRetry` wraps the disable transaction, retrying up to 3 times with short backoff when the error is a typed 40P01 (`pgdriver.Error.Field('C')`, the same detection pattern as `services/facilities/facility_service.go`).
- Retries happen only when the service owns the transaction. With an outer request transaction in context, the abort has already poisoned the whole transaction, so retrying inside would re-run on a dead transaction; the error surfaces unchanged for the caller to handle.
- Non-deadlock errors are never retried.
- A warning is logged per retry for observability.

The lock mode and ordering stay as they are: `SHARE ROW EXCLUSIVE` is the correct consistency barrier against concurrent binding inserts, and a global lock ordering cannot be imposed on every writer of those tables.

## Tests

`pgdriver.Error` cannot be constructed outside the driver package, so the classifier is tested against a real deadlock provoked between two transactions on scratch tables private to the test file (~1s once per test binary, no contention with other packages). The captured error then drives the retry-loop tests: retries then succeeds, gives up after max attempts, non-deadlock not retried, no retry inside an outer transaction.

## Verification

- `go test ./services/users/` green (including all caregiver capability tests)
- Hermetic pattern check green
- `golangci-lint` on the package: 0 issues