### PR TITLE
test: isolate backend packages with cloned databases

### DIFF
--- a/backend/test/db_clone.go
+++ b/backend/test/db_clone.go
@@ -1,0 +1,135 @@
+package test
+
+import (
+	"context"
+	"crypto/sha1"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/uptrace/bun/driver/pgdriver"
+)
+
+const (
+	testDBCloneAdvisoryLockKey = int64(914735692)
+	testDBClonePrefix          = "phx_test_pkg_"
+)
+
+var (
+	packageTestDBOnce sync.Once
+	packageTestDBDSN  string
+	packageTestDBErr  error
+)
+
+func packageIsolatedTestDSN(tb testing.TB, sourceDSN string) string {
+	tb.Helper()
+
+	packageTestDBOnce.Do(func() {
+		packageTestDBDSN, packageTestDBErr = ensurePackageTestDB(sourceDSN)
+	})
+	if packageTestDBErr != nil {
+		tb.Fatalf("setup package-isolated test database: %v", packageTestDBErr)
+	}
+	return packageTestDBDSN
+}
+
+func ensurePackageTestDB(sourceDSN string) (string, error) {
+	sourceURL, err := parsePostgresDSN(sourceDSN)
+	if err != nil {
+		return "", err
+	}
+
+	sourceDB := databaseNameFromURL(sourceURL)
+	if sourceDB == "" {
+		return "", fmt.Errorf("TEST_DB_DSN must include a database name")
+	}
+
+	cloneDB, err := packageCloneDatabaseName()
+	if err != nil {
+		return "", err
+	}
+
+	maintenanceDSN := withDatabaseName(sourceURL, "postgres").String()
+	cloneDSN := withDatabaseName(sourceURL, cloneDB).String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(maintenanceDSN)))
+	defer func() { _ = sqldb.Close() }()
+
+	if err := sqldb.PingContext(ctx); err != nil {
+		return "", fmt.Errorf("connect to postgres maintenance database: %w", err)
+	}
+
+	if _, err := sqldb.ExecContext(ctx, fmt.Sprintf(`SELECT pg_advisory_lock(%d)`, testDBCloneAdvisoryLockKey)); err != nil {
+		return "", fmt.Errorf("acquire package test DB clone lock: %w", err)
+	}
+	defer func() {
+		unlockCtx, unlockCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer unlockCancel()
+		_, _ = sqldb.ExecContext(unlockCtx, fmt.Sprintf(`SELECT pg_advisory_unlock(%d)`, testDBCloneAdvisoryLockKey))
+	}()
+
+	if _, err := sqldb.ExecContext(ctx, `DROP DATABASE IF EXISTS `+quoteIdentifier(cloneDB)+` WITH (FORCE)`); err != nil {
+		return "", fmt.Errorf("drop stale package test database %q: %w", cloneDB, err)
+	}
+	if _, err := sqldb.ExecContext(ctx, `CREATE DATABASE `+quoteIdentifier(cloneDB)+` TEMPLATE `+quoteIdentifier(sourceDB)); err != nil {
+		return "", fmt.Errorf("clone test database %q from %q: %w", cloneDB, sourceDB, err)
+	}
+
+	return cloneDSN, nil
+}
+
+func parsePostgresDSN(dsn string) (*url.URL, error) {
+	if strings.TrimSpace(dsn) == "" {
+		return nil, fmt.Errorf("TEST_DB_DSN is empty")
+	}
+
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("parse TEST_DB_DSN: %w", err)
+	}
+	if parsed.Scheme != "postgres" && parsed.Scheme != "postgresql" {
+		return nil, fmt.Errorf("TEST_DB_DSN must use postgres/postgresql scheme, got %q", parsed.Scheme)
+	}
+	if databaseNameFromURL(parsed) == "" {
+		return nil, fmt.Errorf("TEST_DB_DSN must include a database name")
+	}
+	return parsed, nil
+}
+
+func packageCloneDatabaseName() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("determine package working directory: %w", err)
+	}
+
+	normalized := filepath.ToSlash(wd)
+	sum := sha1.Sum([]byte(normalized))
+	hash := hex.EncodeToString(sum[:])[:16]
+
+	return testDBClonePrefix + hash, nil
+}
+
+func databaseNameFromURL(parsed *url.URL) string {
+	return strings.Trim(strings.TrimPrefix(parsed.Path, "/"), "/")
+}
+
+func withDatabaseName(source *url.URL, dbName string) *url.URL {
+	clone := *source
+	clone.Path = "/" + dbName
+	clone.RawPath = ""
+	return &clone
+}
+
+func quoteIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}

--- a/backend/test/db_clone_test.go
+++ b/backend/test/db_clone_test.go
@@ -1,0 +1,94 @@
+package test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageTestDBDSNRewrite(t *testing.T) {
+	parsed, err := parsePostgresDSN("postgres://user:pass@localhost:5433/phoenix_test?sslmode=disable&application_name=tests")
+	require.NoError(t, err)
+
+	assert.Equal(t, "phoenix_test", databaseNameFromURL(parsed))
+
+	rewritten := withDatabaseName(parsed, "phx_test_pkg_abc123").String()
+	assert.Equal(t,
+		"postgres://user:pass@localhost:5433/phx_test_pkg_abc123?sslmode=disable&application_name=tests",
+		rewritten)
+}
+
+func TestParsePostgresDSNRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name string
+		dsn  string
+	}{
+		{name: "empty", dsn: ""},
+		{name: "wrong scheme", dsn: "mysql://user:pass@localhost/db"},
+		{name: "missing database", dsn: "postgres://user:pass@localhost:5433/"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parsePostgresDSN(tc.dsn)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestPackageCloneDatabaseNameIsValidPostgresIdentifier(t *testing.T) {
+	name, err := packageCloneDatabaseName()
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(name, testDBClonePrefix))
+	assert.LessOrEqual(t, len(name), 63)
+	assert.NotContains(t, name, "-")
+	assert.NotContains(t, name, "/")
+}
+
+func TestQuoteIdentifierEscapesDoubleQuotes(t *testing.T) {
+	assert.Equal(t, `"plain"`, quoteIdentifier("plain"))
+	assert.Equal(t, `"has""quote"`, quoteIdentifier(`has"quote`))
+}
+
+func TestSetupTestDBUsesPackageClone(t *testing.T) {
+	db := SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	var currentDB string
+	err := db.NewRaw(`SELECT current_database()`).Scan(context.Background(), &currentDB)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(currentDB, testDBClonePrefix), "current database = %s", currentDB)
+
+	var tenantExists bool
+	err = db.NewRaw(`SELECT EXISTS (SELECT 1 FROM platform.schools WHERE id = 1)`).Scan(context.Background(), &tenantExists)
+	require.NoError(t, err)
+	assert.True(t, tenantExists, "default tenant fixture should exist in the package clone")
+}
+
+func TestNewTenantScopeCreatesTenantAndContext(t *testing.T) {
+	db := SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	scope := NewTenantScope(t, db)
+	require.NotZero(t, scope.TenantID)
+	assert.Equal(t, scope.TenantID, tenantIDFromContextForTest(t, scope.Context()))
+
+	var exists bool
+	err := db.NewRaw(`SELECT EXISTS (SELECT 1 FROM platform.schools WHERE id = ?)`, scope.TenantID).
+		Scan(context.Background(), &exists)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func tenantIDFromContextForTest(t *testing.T, ctx context.Context) int64 {
+	t.Helper()
+
+	tenantID := tenant.FromContext(ctx)
+	require.NotZero(t, tenantID)
+	return tenantID
+}

--- a/backend/test/helpers.go
+++ b/backend/test/helpers.go
@@ -108,6 +108,8 @@ To run integration tests:
 For CI, set TEST_DB_DSN as an environment variable.`)
 	}
 
+	dsn = packageIsolatedTestDSN(t, dsn)
+
 	viper.Set("db_dsn", dsn)
 	viper.Set("db_debug", false) // Set to true for SQL debugging
 	// Cap per-test pool size. Each call to SetupTestDB opens a fresh
@@ -294,6 +296,27 @@ func CleanupRateLimitsByEmail(tb testing.TB, db *bun.DB, emails ...string) {
 // FK constraints on tenant-scoped tables.
 func TenantContext(tenantID int64) context.Context {
 	return tenant.WithTenantID(context.Background(), tenantID)
+}
+
+// TenantScope owns a unique tenant for a test and provides the matching context.
+type TenantScope struct {
+	TenantID int64
+}
+
+// NewTenantScope creates a unique tenant and returns a scope for tests that
+// assert counts or shared-table state and therefore must not use tenant_id=1.
+func NewTenantScope(tb testing.TB, db *bun.DB) TenantScope {
+	tb.Helper()
+
+	tenantID := UniqueTestTenantID(tb)
+	EnsureTestTenant(tb, db, tenantID)
+
+	return TenantScope{TenantID: tenantID}
+}
+
+// Context returns a background context scoped to the test tenant.
+func (s TenantScope) Context() context.Context {
+	return TenantContext(s.TenantID)
 }
 
 var uniqueTestTenantCounter int64


### PR DESCRIPTION
## Summary
- clone the migrated test database once per Go test package inside `SetupTestDB`
- keep existing test call sites unchanged while removing cross-package shared-state interference
- add `NewTenantScope` for future tests that should avoid `tenant_id=1`

## Why
Backend CI flakes in #1619 come from parallel packages sharing one Postgres database, mostly under `tenant_id=1`. Package-scoped database clones move the isolation boundary below all existing fixtures and cleanup helpers, so packages no longer contend on shared rows, locks, or global platform state.

## Validation
- `cd backend && go test ./test/ -run 'TestPackageTestDBDSNRewrite|TestParsePostgresDSNRejectsInvalidInput|TestPackageCloneDatabaseNameIsValidPostgresIdentifier|TestQuoteIdentifierEscapesDoubleQuotes' -v`
- `cd backend && TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable go test ./test/ -run 'TestSetupTestDBUsesPackageClone|TestNewTenantScopeCreatesTenantAndContext' -v`
- `cd backend && TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable go test ./test/ -run TestHermeticTestPatterns -v`
- `cd backend && TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable AUTH_JWT_SECRET=ci-test-secret-must-be-at-least-32-chars-long FRONTEND_URL=http://localhost:3000 PARENTS_URL=http://parents.localhost:3000 go test ./services/users ./services/schedule ./database/repositories/platform ./database/repositories/enrollment -count=1 -p=4 -v`
- `cd backend && TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable AUTH_JWT_SECRET=ci-test-secret-must-be-at-least-32-chars-long FRONTEND_URL=http://localhost:3000 PARENTS_URL=http://parents.localhost:3000 go test ./...`

Closes #1619
