### PR TITLE
feat: allow fully disabling each enrollment consent block

### DIFF
--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -200,6 +200,14 @@ const (
 	// mandatory "AGB akzeptieren" checkbox. Schools that incorporate terms
 	// switch this on and fill in enrollment.legal_agb_text.
 	KeyEnrollmentLegalTermsEnabled = "enrollment.legal_terms_enabled"
+	// Per-block visibility toggles for the remaining three legal blocks.
+	// Default ON: a block is shown (and, for required blocks, enforced)
+	// whenever its text is configured, unless an admin explicitly switches
+	// it off — then it is neither rendered nor required on the public form.
+	// AGB is the exception above (opt-in, default off).
+	KeyEnrollmentLegalDSGVOEnabled        = "enrollment.legal_dsgvo_enabled"
+	KeyEnrollmentLegalEmailContactEnabled = "enrollment.legal_email_contact_enabled"
+	KeyEnrollmentLegalPhotoEnabled        = "enrollment.legal_photo_enabled"
 )
 
 // Enrollment select-option values.

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -457,17 +457,19 @@ func TestEnrollmentSettings_AllRegistered_OnEnrollmentTab(t *testing.T) {
 // multi-line editor for a full legal page), default to empty (so the
 // public form falls back to a plain consent label until an admin fills
 // them in), and use the stricter config:manage write permission
-// (legal/GDPR documents). The DSGVO, E-Mail and Foto texts hide behind
-// the enrollment.enabled master toggle; the AGB text instead hides
-// behind enrollment.legal_terms_enabled, since AGB is opt-in per Träger.
+// (legal/GDPR documents). Each text hides behind its own per-block toggle:
+// AGB behind enrollment.legal_terms_enabled, Datenschutz/E-Mail/Foto behind
+// their respective *_enabled toggles, so switching a block off also hides
+// its editor.
 func TestEnrollmentLegalTexts(t *testing.T) {
-	keys := []string{
-		config.KeyEnrollmentLegalAGBText,
-		config.KeyEnrollmentLegalDSGVOText,
-		config.KeyEnrollmentLegalEmailContactText,
-		config.KeyEnrollmentLegalPhotoText,
+	// Each legal text is gated by its own per-block toggle.
+	textToggleParent := map[string]string{
+		config.KeyEnrollmentLegalAGBText:          config.KeyEnrollmentLegalTermsEnabled,
+		config.KeyEnrollmentLegalDSGVOText:        config.KeyEnrollmentLegalDSGVOEnabled,
+		config.KeyEnrollmentLegalEmailContactText: config.KeyEnrollmentLegalEmailContactEnabled,
+		config.KeyEnrollmentLegalPhotoText:        config.KeyEnrollmentLegalPhotoEnabled,
 	}
-	for _, key := range keys {
+	for key, wantParent := range textToggleParent {
 		def := config.GetDefinition(key)
 		require.NotNilf(t, def, "setting %q should be registered", key)
 		assert.Equalf(t, config.FieldTextarea, def.Type, "setting %q should be textarea", key)
@@ -478,13 +480,36 @@ func TestEnrollmentLegalTexts(t *testing.T) {
 		assert.NotEmptyf(t, def.Label, "setting %q must have a German label", key)
 		assert.NotEmptyf(t, def.Description, "setting %q must have a German description", key)
 		require.NotNilf(t, def.DependsOn, "setting %q must declare a DependsOn parent", key)
-		// AGB is opt-in: its text is only shown once a Träger turns on the
-		// terms toggle. The remaining legal texts gate on the master flag.
-		wantParent := config.KeyEnrollmentEnabled
-		if key == config.KeyEnrollmentLegalAGBText {
-			wantParent = config.KeyEnrollmentLegalTermsEnabled
-		}
 		assert.Equalf(t, wantParent, def.DependsOn.Key, "setting %q has unexpected DependsOn parent", key)
+		assert.Equal(t, "eq", def.DependsOn.Condition)
+		assert.Equal(t, true, def.DependsOn.Value)
+	}
+}
+
+// TestEnrollmentLegalBlockToggles guards the three default-ON per-block
+// visibility toggles (Datenschutz, E-Mail-Hinweis, Foto). They are boolean,
+// default true (so existing tenants keep showing a block whenever its text is
+// configured), use config:manage, and themselves hide behind the
+// enrollment.enabled master flag. AGB has its own opt-in toggle
+// (TestEnrollmentLegalTermsEnabled) and is intentionally not in this set.
+func TestEnrollmentLegalBlockToggles(t *testing.T) {
+	keys := []string{
+		config.KeyEnrollmentLegalDSGVOEnabled,
+		config.KeyEnrollmentLegalEmailContactEnabled,
+		config.KeyEnrollmentLegalPhotoEnabled,
+	}
+	for _, key := range keys {
+		def := config.GetDefinition(key)
+		require.NotNilf(t, def, "setting %q should be registered", key)
+		assert.Equalf(t, config.FieldBoolean, def.Type, "setting %q should be boolean", key)
+		assert.Equalf(t, true, def.Default, "setting %q should default to true (shown unless turned off)", key)
+		assert.Equalf(t, "enrollment", def.Tab, "setting %q should be in enrollment tab", key)
+		assert.Equalf(t, "rechtstexte", def.Category, "setting %q should be in rechtstexte category", key)
+		assert.Equalf(t, "config:manage", def.WritePermission, "setting %q should use config:manage (legal/GDPR)", key)
+		assert.NotEmptyf(t, def.Label, "setting %q must have a German label", key)
+		assert.NotEmptyf(t, def.Description, "setting %q must have a German description", key)
+		require.NotNilf(t, def.DependsOn, "setting %q must hide behind enrollment.enabled", key)
+		assert.Equalf(t, config.KeyEnrollmentEnabled, def.DependsOn.Key, "setting %q should depend on enrollment.enabled", key)
 		assert.Equal(t, "eq", def.DependsOn.Condition)
 		assert.Equal(t, true, def.DependsOn.Value)
 	}

--- a/backend/services/config/defaults/enrollment.go
+++ b/backend/services/config/defaults/enrollment.go
@@ -460,17 +460,16 @@ func registerEnrollmentLegalTexts() {
 		},
 	})
 
+	// Datenschutz block: a master toggle (default ON) plus its text. Unlike
+	// AGB, this block is shown by default so existing tenants that filled in
+	// a Datenschutz text keep seeing it. Switching the toggle off removes the
+	// block entirely — it is neither rendered nor required on the public form.
 	config.Register(config.Definition{
-		Key:   config.KeyEnrollmentLegalDSGVOText,
-		Label: "Datenschutzinformation (Anmeldeformular)",
-		// Wording note: enrollment data is processed on a contractual /
-		// legal-obligation basis, NOT on consent. The form therefore asks
-		// parents to ACKNOWLEDGE (Kenntnisnahme) this information, it does
-		// not collect a DSGVO "Einwilligung". Keep this description aligned
-		// with the acknowledgement label rendered on the public form.
-		Description:     "Datenschutzinformation gemäß Art. 13 DSGVO, die Eltern bei der Anmeldung zur Kenntnis nehmen. Markdown wird unterstützt (Überschriften, Fettdruck, Listen, Links). Leer lassen, wenn kein separater Datenschutz-Block im Formular angezeigt werden soll.",
-		Type:            config.FieldTextarea,
-		Default:         "",
+		Key:             config.KeyEnrollmentLegalDSGVOEnabled,
+		Label:           "Datenschutzinformation abfragen",
+		Description:     "Blendet im Anmeldeformular einen verpflichtenden Datenschutz-Block ein, den Eltern zur Kenntnis nehmen. Standardmäßig aktiv. Deaktivieren, um den Block vollständig auszublenden — dann muss er nicht angeklickt werden.",
+		Type:            config.FieldBoolean,
+		Default:         true,
 		ReadPermission:  "config:read",
 		WritePermission: "config:manage",
 		Tab:             "enrollment",
@@ -480,9 +479,14 @@ func registerEnrollmentLegalTexts() {
 	})
 
 	config.Register(config.Definition{
-		Key:             config.KeyEnrollmentLegalEmailContactText,
-		Label:           "Hinweis zum E-Mail-Kontakt (Anmeldeformular)",
-		Description:     "Erläuterung, wozu die Schule die E-Mail-Adresse nutzt (Rückfragen, Status-Benachrichtigungen). Markdown wird unterstützt. Wird im Formular als Hinweis angezeigt — keine separate Zustimmung, da der E-Mail-Kontakt zur Durchführung der Anmeldung erforderlich ist. Leer lassen, um den Hinweis auszublenden.",
+		Key:   config.KeyEnrollmentLegalDSGVOText,
+		Label: "Datenschutzinformation (Anmeldeformular)",
+		// Wording note: enrollment data is processed on a contractual /
+		// legal-obligation basis, NOT on consent. The form therefore asks
+		// parents to ACKNOWLEDGE (Kenntnisnahme) this information, it does
+		// not collect a DSGVO "Einwilligung". Keep this description aligned
+		// with the acknowledgement label rendered on the public form.
+		Description:     "Datenschutzinformation gemäß Art. 13 DSGVO, die Eltern bei der Anmeldung zur Kenntnis nehmen. Markdown wird unterstützt (Überschriften, Fettdruck, Listen, Links). Nur sichtbar, wenn „Datenschutzinformation abfragen“ aktiviert ist.",
 		Type:            config.FieldTextarea,
 		Default:         "",
 		ReadPermission:  "config:read",
@@ -490,20 +494,76 @@ func registerEnrollmentLegalTexts() {
 		Tab:             "enrollment",
 		Category:        "rechtstexte",
 		SortOrder:       82,
-		DependsOn:       dependsOnEnabled,
+		DependsOn: &config.Dependency{
+			Key:       config.KeyEnrollmentLegalDSGVOEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
 	})
 
+	// E-Mail-Kontakt notice: master toggle (default ON) plus its text.
 	config.Register(config.Definition{
-		Key:             config.KeyEnrollmentLegalPhotoText,
-		Label:           "Hinweis zur Fotoeinwilligung (Anmeldeformular)",
-		Description:     "Erläuterung zur (optionalen, jederzeit widerrufbaren) Fotoeinwilligung (wo und wie Fotos verwendet werden). Markdown wird unterstützt. Wird im Formular über einen Link angezeigt. Leer lassen, um nur den Hinweistext ohne Link zu zeigen.",
-		Type:            config.FieldTextarea,
-		Default:         "",
+		Key:             config.KeyEnrollmentLegalEmailContactEnabled,
+		Label:           "Hinweis zum E-Mail-Kontakt anzeigen",
+		Description:     "Blendet im Anmeldeformular einen Hinweis ein, wozu die Schule die E-Mail-Adresse nutzt. Standardmäßig aktiv. Deaktivieren, um den Hinweis vollständig auszublenden.",
+		Type:            config.FieldBoolean,
+		Default:         true,
 		ReadPermission:  "config:read",
 		WritePermission: "config:manage",
 		Tab:             "enrollment",
 		Category:        "rechtstexte",
 		SortOrder:       83,
 		DependsOn:       dependsOnEnabled,
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyEnrollmentLegalEmailContactText,
+		Label:           "Hinweis zum E-Mail-Kontakt (Anmeldeformular)",
+		Description:     "Erläuterung, wozu die Schule die E-Mail-Adresse nutzt (Rückfragen, Status-Benachrichtigungen). Markdown wird unterstützt. Wird im Formular als Hinweis angezeigt — keine separate Zustimmung, da der E-Mail-Kontakt zur Durchführung der Anmeldung erforderlich ist. Nur sichtbar, wenn „Hinweis zum E-Mail-Kontakt anzeigen“ aktiviert ist.",
+		Type:            config.FieldTextarea,
+		Default:         "",
+		ReadPermission:  "config:read",
+		WritePermission: "config:manage",
+		Tab:             "enrollment",
+		Category:        "rechtstexte",
+		SortOrder:       84,
+		DependsOn: &config.Dependency{
+			Key:       config.KeyEnrollmentLegalEmailContactEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
+	// Fotoeinwilligung block: master toggle (default ON) plus its text.
+	config.Register(config.Definition{
+		Key:             config.KeyEnrollmentLegalPhotoEnabled,
+		Label:           "Fotoeinwilligung abfragen",
+		Description:     "Blendet im Anmeldeformular eine (freiwillige, jederzeit widerrufbare) Fotoeinwilligung ein. Standardmäßig aktiv. Deaktivieren, um den Block vollständig auszublenden — dann muss er nicht angeklickt werden.",
+		Type:            config.FieldBoolean,
+		Default:         true,
+		ReadPermission:  "config:read",
+		WritePermission: "config:manage",
+		Tab:             "enrollment",
+		Category:        "rechtstexte",
+		SortOrder:       85,
+		DependsOn:       dependsOnEnabled,
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyEnrollmentLegalPhotoText,
+		Label:           "Hinweis zur Fotoeinwilligung (Anmeldeformular)",
+		Description:     "Erläuterung zur (optionalen, jederzeit widerrufbaren) Fotoeinwilligung (wo und wie Fotos verwendet werden). Markdown wird unterstützt. Wird im Formular über einen Link angezeigt. Nur sichtbar, wenn „Fotoeinwilligung abfragen“ aktiviert ist.",
+		Type:            config.FieldTextarea,
+		Default:         "",
+		ReadPermission:  "config:read",
+		WritePermission: "config:manage",
+		Tab:             "enrollment",
+		Category:        "rechtstexte",
+		SortOrder:       86,
+		DependsOn: &config.Dependency{
+			Key:       config.KeyEnrollmentLegalPhotoEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
 	})
 }

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -190,8 +190,14 @@ type LegalTexts struct {
 	DSGVO        string
 	EmailContact string
 	Photo        string
-	TermsEnabled bool
-	Blocks       []LegalBlock
+	// TermsEnabled mirrors enrollment.legal_terms_enabled (AGB, opt-in,
+	// default off). The remaining three flags mirror their per-block toggles
+	// (default on); when false the block is neither rendered nor required.
+	TermsEnabled        bool
+	DSGVOEnabled        bool
+	EmailContactEnabled bool
+	PhotoEnabled        bool
+	Blocks              []LegalBlock
 }
 
 // LegalBlock is one configured legal row shown on the public enrollment
@@ -1079,12 +1085,27 @@ func (s *requestService) LegalTexts(ctx context.Context) (LegalTexts, error) {
 	if err != nil {
 		return LegalTexts{}, err
 	}
+	dsgvoEnabled, err := s.legalBlockEnabled(ctx, configModel.KeyEnrollmentLegalDSGVOEnabled)
+	if err != nil {
+		return LegalTexts{}, err
+	}
+	emailContactEnabled, err := s.legalBlockEnabled(ctx, configModel.KeyEnrollmentLegalEmailContactEnabled)
+	if err != nil {
+		return LegalTexts{}, err
+	}
+	photoEnabled, err := s.legalBlockEnabled(ctx, configModel.KeyEnrollmentLegalPhotoEnabled)
+	if err != nil {
+		return LegalTexts{}, err
+	}
 	texts := LegalTexts{
-		AGB:          strings.TrimSpace(agb),
-		DSGVO:        strings.TrimSpace(dsgvo),
-		EmailContact: strings.TrimSpace(emailContact),
-		Photo:        strings.TrimSpace(photo),
-		TermsEnabled: termsEnabled,
+		AGB:                 strings.TrimSpace(agb),
+		DSGVO:               strings.TrimSpace(dsgvo),
+		EmailContact:        strings.TrimSpace(emailContact),
+		Photo:               strings.TrimSpace(photo),
+		TermsEnabled:        termsEnabled,
+		DSGVOEnabled:        dsgvoEnabled,
+		EmailContactEnabled: emailContactEnabled,
+		PhotoEnabled:        photoEnabled,
 	}
 	texts.Blocks = buildLegalBlocks(texts)
 	return texts, nil
@@ -1102,7 +1123,7 @@ func buildLegalBlocks(texts LegalTexts) []LegalBlock {
 			Required: true,
 		})
 	}
-	if texts.DSGVO != "" {
+	if texts.DSGVOEnabled && texts.DSGVO != "" {
 		blocks = append(blocks, LegalBlock{
 			Key:      enrollmentModels.ConsentKeyDataProcessing,
 			Kind:     "privacy_notice",
@@ -1112,7 +1133,7 @@ func buildLegalBlocks(texts LegalTexts) []LegalBlock {
 			Required: true,
 		})
 	}
-	if texts.Photo != "" {
+	if texts.PhotoEnabled && texts.Photo != "" {
 		blocks = append(blocks, LegalBlock{
 			Key:      enrollmentModels.ConsentKeyPhoto,
 			Kind:     "consent",
@@ -1122,7 +1143,7 @@ func buildLegalBlocks(texts LegalTexts) []LegalBlock {
 			Required: false,
 		})
 	}
-	if texts.EmailContact != "" {
+	if texts.EmailContactEnabled && texts.EmailContact != "" {
 		blocks = append(blocks, LegalBlock{
 			Key:      enrollmentModels.ConsentKeyEmailContact,
 			Kind:     "notice",
@@ -1153,6 +1174,30 @@ func (s *requestService) legalTermsEnabled(ctx context.Context) (bool, error) {
 	v, err := s.settings.ResolveBool(ctx, configModel.KeyEnrollmentLegalTermsEnabled)
 	if err != nil {
 		return false, fmt.Errorf("resolve AGB terms setting: %w", err)
+	}
+	return v, nil
+}
+
+// legalBlockEnabled reports whether one of the default-on legal blocks
+// (Datenschutz, E-Mail-Hinweis, Foto) is switched on for the tenant. These
+// default ON: a missing override means enabled, so existing tenants keep
+// seeing a block whenever its text is configured. Settings errors fail closed
+// because this decides whether a (potentially required) legal block is
+// rendered and enforced.
+func (s *requestService) legalBlockEnabled(ctx context.Context, key string) (bool, error) {
+	if s.settings == nil {
+		return true, nil
+	}
+	has, err := s.settings.HasTenantOverride(ctx, key)
+	if err != nil {
+		return false, fmt.Errorf("check legal block toggle %q override: %w", key, err)
+	}
+	if !has {
+		return true, nil
+	}
+	v, err := s.settings.ResolveBool(ctx, key)
+	if err != nil {
+		return false, fmt.Errorf("resolve legal block toggle %q: %w", key, err)
 	}
 	return v, nil
 }

--- a/backend/services/enrollment/request_service_test.go
+++ b/backend/services/enrollment/request_service_test.go
@@ -447,6 +447,121 @@ func TestRequestService_Submit_PhotoLegalBlockIsOptional(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestRequestService_Submit_DSGVODisabledDropsRequiredConsent proves that
+// switching the Datenschutz block off fully removes it: even with a
+// configured text, the required data_processing consent is no longer
+// enforced, so a submission with no consent flags succeeds.
+func TestRequestService_Submit_DSGVODisabledDropsRequiredConsent(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	env.settings.stringValues[configModel.KeyEnrollmentLegalDSGVOText] = "Datenschutzinformation"
+	env.settings.boolValues[configModel.KeyEnrollmentLegalDSGVOEnabled] = false
+
+	req := validSubmission(env.phaseID)
+	req.ConsentFlags = map[string]any{}
+	_, err := env.svc.Submit(ctx, req)
+	require.NoError(t, err)
+}
+
+// TestRequestService_LegalTexts_DisabledBlocksAreNotRendered checks the
+// public-form view: a disabled block (here Foto) is absent from Blocks even
+// though its text is set, so the kiosk/web form renders no checkbox for it.
+func TestRequestService_LegalTexts_DisabledBlocksAreNotRendered(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	env.settings.stringValues[configModel.KeyEnrollmentLegalPhotoText] = "Fotoeinwilligung"
+	env.settings.boolValues[configModel.KeyEnrollmentLegalPhotoEnabled] = false
+	// A sibling block left on (default) confirms only the disabled one drops.
+	env.settings.stringValues[configModel.KeyEnrollmentLegalDSGVOText] = "Datenschutzinformation"
+
+	texts, err := env.svc.LegalTexts(ctx)
+	require.NoError(t, err)
+
+	keys := make([]string, 0, len(texts.Blocks))
+	for _, b := range texts.Blocks {
+		keys = append(keys, b.Key)
+	}
+	assert.NotContains(t, keys, enrollmentModels.ConsentKeyPhoto, "disabled photo block must not be rendered")
+	assert.Contains(t, keys, enrollmentModels.ConsentKeyDataProcessing, "enabled DSGVO block should still render")
+}
+
+// TestRequestService_LegalTexts_EmailContactDisabledHidesNotice covers the
+// e-mail-contact toggle: with text configured but the block switched off, the
+// notice is absent from Blocks (no checkbox / no notice rendered).
+func TestRequestService_LegalTexts_EmailContactDisabledHidesNotice(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	env.settings.stringValues[configModel.KeyEnrollmentLegalEmailContactText] = "E-Mail-Hinweis"
+	env.settings.boolValues[configModel.KeyEnrollmentLegalEmailContactEnabled] = false
+
+	texts, err := env.svc.LegalTexts(ctx)
+	require.NoError(t, err)
+
+	keys := make([]string, 0, len(texts.Blocks))
+	for _, b := range texts.Blocks {
+		keys = append(keys, b.Key)
+	}
+	assert.NotContains(t, keys, enrollmentModels.ConsentKeyEmailContact, "disabled e-mail-contact notice must not be rendered")
+}
+
+// TestRequestService_LegalTexts_DefaultOnRendersWithoutOverride proves the
+// default-on contract for the new toggles: with only the text configured and
+// no toggle override, the block still renders (existing tenants unaffected).
+func TestRequestService_LegalTexts_DefaultOnRendersWithoutOverride(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	env.settings.stringValues[configModel.KeyEnrollmentLegalEmailContactText] = "E-Mail-Hinweis"
+
+	texts, err := env.svc.LegalTexts(ctx)
+	require.NoError(t, err)
+
+	keys := make([]string, 0, len(texts.Blocks))
+	for _, b := range texts.Blocks {
+		keys = append(keys, b.Key)
+	}
+	assert.Contains(t, keys, enrollmentModels.ConsentKeyEmailContact, "default-on block should render when text is set and no override exists")
+}
+
+// TestRequestService_LegalTexts_BlockToggleResolveFailureFailsClosed proves
+// the per-block toggle helper fails closed: a ResolveBool error surfaces as a
+// server error, not a silently-rendered block.
+func TestRequestService_LegalTexts_BlockToggleResolveFailureFailsClosed(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	// Override present (so HasTenantOverride is true), but resolving it errors.
+	env.settings.boolValues[configModel.KeyEnrollmentLegalDSGVOEnabled] = true
+	env.settings.boolErrors[configModel.KeyEnrollmentLegalDSGVOEnabled] = errors.New("bad bool setting")
+
+	_, err := env.svc.LegalTexts(ctx)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "resolve legal block toggle")
+}
+
+// TestRequestService_LegalTexts_BlockToggleOverrideCheckFailureFailsClosed
+// proves the helper fails closed when the override existence check itself
+// errors (settings DB unavailable).
+func TestRequestService_LegalTexts_BlockToggleOverrideCheckFailureFailsClosed(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	env.settings.hasErrors[configModel.KeyEnrollmentLegalPhotoEnabled] = errors.New("settings db unavailable")
+
+	_, err := env.svc.LegalTexts(ctx)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "check legal block toggle")
+}
+
 // Regression for issue #1465: a guardian phone that fails the canonical
 // student phone format (e.g. "12345") must be rejected at submit with
 // ErrInvalidGuardianPhone, instead of being stored and later blocking


### PR DESCRIPTION
Add per-block visibility toggles for the Datenschutz, E-Mail-Kontakt and Foto consent blocks on the public enrollment form (AGB already had one). When a block is switched off it is no longer rendered, no longer required, and does not need to be clicked.

- New settings: enrollment.legal_{dsgvo,email_contact,photo}_enabled (boolean, default on, config:manage), each hiding its text editor behind the toggle like the existing AGB pattern.
- buildLegalBlocks gates each block on enabled && text; resolveRequiredConsents derives from the same list, so disabled blocks drop from server-side validation too.
- Defaults stay on so existing tenants are unaffected.

# Pull Request

## Description
<!-- Explain the changes you've made and why they're needed -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Configuration change
- [ ] Security improvement
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition/modification
- [ ] CI/CD improvement

## Related Issues
<!-- List any related issues using the following syntax:
- Fixes #123
- Addresses #456
- Related to #789
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Testing documentation updated

## Security Checklist
<!-- This section is mandatory for all PRs -->
- [ ] I have followed the [security guidelines](../docs/security.md)
- [ ] No sensitive information is committed (secrets, credentials, certificates)
- [ ] Environment variables are properly managed with templates
- [ ] Code does not contain hardcoded secrets
- [ ] No potential security vulnerabilities introduced

## Screenshots or Examples
<!-- Add screenshots or code examples if applicable -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have updated the documentation as needed
- [ ] If this PR changes a user-facing flow, I updated the in-app help guide (`guide-data.ts`) and any changed screenshot — or it doesn't apply (backend-only, operator/parents-portal-only, or pure-styling change)
- [ ] All tests are passing
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and resolved any merge conflicts

## Additional Notes
<!-- Add any other context about the PR here -->