### PR TITLE
fix: add enrollment attendance notice

### DIFF
--- a/frontend/src/components/enrollment/enrollment-form.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.test.tsx
@@ -345,6 +345,17 @@ describe("EnrollmentForm", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows the compulsory attendance notice near care offerings", async () => {
+    renderForm();
+    await waitForLoaded();
+
+    expect(
+      screen.getByText(
+        /Mit der Anmeldung zum Ganztagsangebot ist Ihr Kind laut Ganztagsschulerlass zu den angemeldeten Zeiten schulpflichtig\./,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("fails closed when the legal texts cannot be loaded", async () => {
     // A real load failure (settings/DB/JSON error) must reject the whole
     // form load so the parent never submits legally relevant consent

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -1015,7 +1015,10 @@ export function EnrollmentForm({
                         : careOfferingSelectionMode === "at_least_one"
                           ? "Wählen Sie mindestens ein Angebot aus, das für dieses Kind gewünscht ist."
                           : "Wählen Sie die Angebote aus, die für dieses Kind gewünscht sind."}{" "}
-                      Die OGS prüft freie Plätze nach dem Absenden.
+                      Die OGS prüft freie Plätze nach dem Absenden. Bitte
+                      beachten Sie: Mit der Anmeldung zum Ganztagsangebot ist
+                      Ihr Kind laut Ganztagsschulerlass zu den angemeldeten
+                      Zeiten schulpflichtig.
                     </p>
                     <div
                       aria-invalid={childOfferingErrors[i] ? true : undefined}


### PR DESCRIPTION
## Summary
- Adds the requested Ganztagsschulerlass notice below Betreuungsangebote in the shared enrollment form.
- Covers the text with a focused EnrollmentForm test.

## Verification
- `pnpm vitest run src/components/enrollment/enrollment-form.test.tsx`
- `pnpm run check`
- `git push` pre-push hook: git-secrets, frontend-knip, go-vet, golangci-lint, go-deadcode, frontend-check

## Screenshot
Captured with agent-browser from the parents enrollment route:

`/tmp/phoenix-screenshots/enrollment-care-offering-notice.png`
