### PR TITLE
Fix enrollment phase hover animation

### DIFF
--- a/frontend/src/app/[tenant]/(public)/enroll/page.tsx
+++ b/frontend/src/app/[tenant]/(public)/enroll/page.tsx
@@ -128,7 +128,7 @@ export default function EnrollPhasePickerPage() {
                     <li key={phase.id}>
                       <Link
                         href={`/enroll/${encodeURIComponent(phase.id)}`}
-                        className="group moto-content-surface flex flex-col gap-4 rounded-xl border p-4 text-left shadow-sm transition-[border-color,background-color,box-shadow,transform] duration-150 hover:border-gray-300 hover:shadow-sm focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none sm:flex-row sm:items-center sm:justify-between sm:p-5 md:hover:-translate-y-0.5"
+                        className="group moto-content-surface moto-hover-elevated flex flex-col gap-4 rounded-xl border p-4 text-left shadow-sm focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none sm:flex-row sm:items-center sm:justify-between sm:p-5"
                       >
                         <div className="min-w-0">
                           <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary
- replaces the custom enrollment phase card hover transition with the shared `moto-hover-elevated` pattern
- removes the upward translate hover movement that made the card feel jumpy under the cursor

## Validation
- `cd frontend && pnpm run check`
- pre-commit: git-secrets, frontend-lint
- pre-push: git-secrets, frontend-knip, frontend-check
