### PR TITLE
fix: wrap mobile master-detail list pane

### DIFF
--- a/frontend/src/components/database/master-detail-layout.tsx
+++ b/frontend/src/components/database/master-detail-layout.tsx
@@ -72,7 +72,9 @@ export function MasterDetailLayout({
         style={{ height }}
         className={cn("flex w-full flex-col", className)}
       >
-        <div className="min-h-0 flex-1 overflow-auto">{list}</div>
+        <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-gray-200 bg-white">
+          <div className="h-full overflow-auto">{list}</div>
+        </div>
         <Drawer
           open={selectedId !== null}
           onOpenChange={(open) => {
@@ -80,7 +82,7 @@ export function MasterDetailLayout({
           }}
         >
           <DrawerContent
-            className="max-h-[90vh]"
+            className="max-h-[90vh] bg-white"
             aria-describedby={undefined}
             // Modals (Edit/Confirmation) portal to document.body and therefore
             // live outside the drawer's DOM. Without these guards Vaul's


### PR DESCRIPTION
## Summary
- Wrap the mobile master-detail list pane in the same bordered white container treatment used elsewhere
- Set the drawer content background to white

## Notes
- This branch is cherry-picked directly from `development` so it contains only the UI tweak and no slot-list feature history.