### PR TITLE
fix: batch SSE checkout events on session end (#848)

### DIFF
--- a/backend/api/sse/sse_helpers.go
+++ b/backend/api/sse/sse_helpers.go
@@ -199,7 +199,7 @@ func (conn *sseConnection) sendHeartbeat() error {
 // createAndRegisterClient creates the SSE client and registers it with the hub
 func (rs *Resource) createAndRegisterClient(conn *sseConnection) {
 	conn.client = &realtime.Client{
-		Channel:          make(chan realtime.Event, 10), // Buffer up to 10 events
+		Channel:          make(chan realtime.Event, 32), // Buffer up to 32 events (issue #848: headroom for bursts, e.g. admin-overview clients subscribed to every group)
 		UserID:           conn.staffID,
 		TenantID:         conn.tenantID,
 		SubscribedGroups: make(map[string]bool),

--- a/backend/realtime/events.go
+++ b/backend/realtime/events.go
@@ -14,6 +14,17 @@ const (
 	EventStudentCheckOut EventType = "student_checkout"
 	EventStudentUpdated  EventType = "student_updated"
 
+	// Bulk checkout event — emitted when a whole session ends (manual end or
+	// scheduler timeout) and every active visit is closed at once. One event
+	// per affected topic carrying all student IDs, instead of one
+	// student_checkout per student, so a single client receives one trigger
+	// rather than N (issue #848: per-student bursts overflowed the SSE channel
+	// buffer and dropped events). Single-student checkouts keep emitting
+	// EventStudentCheckOut. Like all SSE events this is a trigger, not a
+	// payload — the client refetches via bulk endpoints; StudentIDs only drives
+	// per-student detail-cache invalidation.
+	EventBulkStudentCheckOut EventType = "bulk_student_checkout"
+
 	// Activity session lifecycle events
 	EventActivityStart  EventType = "activity_start"
 	EventActivityEnd    EventType = "activity_end"
@@ -72,6 +83,11 @@ type EventData struct {
 	StudentName *string `json:"student_name,omitempty"`
 	SchoolClass *string `json:"school_class,omitempty"`
 	GroupName   *string `json:"group_name,omitempty"` // Student's OGS group, not active group
+
+	// StudentIDs carries the affected students on a bulk_student_checkout event
+	// (whole-session end). The client adds each to its per-student
+	// detail-cache invalidation set; the refetch itself is topic-driven.
+	StudentIDs *[]string `json:"student_ids,omitempty"`
 
 	// Activity session fields (for activity_start/end/update events)
 	ActivityName  *string   `json:"activity_name,omitempty"`

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -816,51 +816,62 @@ func (s *service) broadcastToEducationalGroup(ctx context.Context, student *user
 	}
 }
 
-// broadcastStudentCheckoutEvents sends checkout SSE events for each visit.
-// This helper reduces cognitive complexity in session timeout processing.
-//
-// TODO(wp-b11-or-later): batch if hot. Each visit triggers two independent
-// schedule queries inside LoadAttendanceForVisit (FindByActiveGroupID,
-// FindByInstanceAndStudent). A session timeout flushing N students = 2N
-// queries. Not catastrophic at v1 scale, but if schools grow we should add
-// a batched FindByInstanceAndStudentIDs path. Not scoped into WP-B10.
+// broadcastStudentCheckoutEvents sends a batched checkout SSE notification when
+// a whole session ends. All visits in the batch share one active_group_id (the
+// session). Instead of one student_checkout per student — which produced 2N+
+// events on a single client channel and overflowed its 10-slot buffer
+// (issue #848) — this emits one bulk_student_checkout per affected topic:
+// one to the active-group topic carrying every student, and one per distinct
+// educational group carrying that group's students. SSE events are triggers,
+// not payloads (the client refetches via bulk endpoints), so the per-student
+// attendance snapshot the old loop computed — at a cost of 2N schedule queries
+// — is dropped; only the student IDs are carried, to drive the client's
+// per-student detail-cache invalidation.
 func (s *service) broadcastStudentCheckoutEvents(ctx context.Context, sessionIDStr string, visitsToNotify []visitSSEData) {
-	// Parse session ID once — all visits in this batch share the same
-	// active_group_id, which IS the session. We construct a minimal Visit
-	// per student for the snapshot lookup.
-	var sessionID int64
-	if parsed, perr := strconv.ParseInt(sessionIDStr, 10, 64); perr == nil {
-		sessionID = parsed
+	if len(visitsToNotify) == 0 {
+		return
 	}
 
+	// Collect every student ID for the active-group topic, and bucket them by
+	// educational group for the per-edu-group topics. eduReps keeps one student
+	// per group so broadcastToEducationalGroup can derive the edu:{id} topic.
+	allStudentIDs := make([]string, 0, len(visitsToNotify))
+	eduGroups := make(map[int64][]string)
+	eduReps := make(map[int64]*userModels.Student)
 	for _, visitData := range visitsToNotify {
-		studentIDStr := fmt.Sprintf("%d", visitData.StudentID)
-		studentName := visitData.Name
-
-		data := realtime.EventData{
-			StudentID:   &studentIDStr,
-			StudentName: &studentName,
+		idStr := strconv.FormatInt(visitData.StudentID, 10)
+		allStudentIDs = append(allStudentIDs, idStr)
+		if visitData.Student != nil && visitData.Student.GroupID != nil {
+			gid := *visitData.Student.GroupID
+			eduGroups[gid] = append(eduGroups[gid], idStr)
+			if eduReps[gid] == nil {
+				eduReps[gid] = visitData.Student
+			}
 		}
-		if s.attendanceSyncer != nil && sessionID > 0 {
-			snapshot := s.attendanceSyncer.LoadAttendanceForVisit(ctx, &active.Visit{
-				StudentID:     visitData.StudentID,
-				ActiveGroupID: sessionID,
-			})
-			applyAttendanceSnapshot(&data, snapshot)
-		}
-
-		checkoutEvent := realtime.NewEvent(
-			realtime.EventStudentCheckOut,
-			sessionIDStr,
-			data,
-		)
-
-		s.broadcastWithLogging(ctx, sessionIDStr, studentIDStr, checkoutEvent, "student_checkout")
-		s.broadcastToEducationalGroup(ctx, visitData.Student, checkoutEvent)
 	}
 
-	// Single global broadcast for the entire batch
-	if len(visitsToNotify) > 0 && s.broadcaster != nil {
+	// One event to the active-group topic carrying every checked-out student.
+	activeEvent := realtime.NewEvent(
+		realtime.EventBulkStudentCheckOut,
+		sessionIDStr,
+		realtime.EventData{StudentIDs: &allStudentIDs},
+	)
+	s.broadcastWithLogging(ctx, sessionIDStr, "", activeEvent, "bulk_student_checkout")
+
+	// One event per distinct educational group, carrying only that group's
+	// students so each subscribed client invalidates the right detail caches.
+	for gid, ids := range eduGroups {
+		groupIDs := ids
+		eduEvent := realtime.NewEvent(
+			realtime.EventBulkStudentCheckOut,
+			sessionIDStr,
+			realtime.EventData{StudentIDs: &groupIDs},
+		)
+		s.broadcastToEducationalGroup(ctx, eduReps[gid], eduEvent)
+	}
+
+	// Single global broadcast for the entire batch.
+	if s.broadcaster != nil {
 		_ = s.broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
 		s.broadcastActiveSupervisionChanged(ctx, sessionIDStr, "", activeSupervisionReasonStudentMoved)
 	}

--- a/backend/services/active/broadcast_test.go
+++ b/backend/services/active/broadcast_test.go
@@ -14,22 +14,46 @@ import (
 	"github.com/moto-nrw/project-phoenix/realtime"
 	active "github.com/moto-nrw/project-phoenix/services/active"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/uptrace/bun"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// mockBroadcaster records all broadcast calls for assertion.
-type mockBroadcaster struct {
-	mu       sync.Mutex
-	allCalls []realtime.Event
+// groupBroadcastCall records a BroadcastToGroup call with the topic it targeted,
+// so tests can assert which edu:{id} topic an event was routed to (not just that
+// some group broadcast happened).
+type groupBroadcastCall struct {
+	topic string
+	event realtime.Event
 }
 
-func (m *mockBroadcaster) BroadcastToGroup(_ int64, _ string, event realtime.Event) error {
+// mockBroadcaster records all broadcast calls for assertion.
+type mockBroadcaster struct {
+	mu         sync.Mutex
+	allCalls   []realtime.Event
+	groupCalls []groupBroadcastCall
+}
+
+func (m *mockBroadcaster) BroadcastToGroup(_ int64, topic string, event realtime.Event) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.allCalls = append(m.allCalls, event)
+	m.groupCalls = append(m.groupCalls, groupBroadcastCall{topic: topic, event: event})
 	return nil
+}
+
+// groupCallsForTopic returns every BroadcastToGroup call routed to the given topic.
+func (m *mockBroadcaster) groupCallsForTopic(topic string) []groupBroadcastCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]groupBroadcastCall, 0)
+	for _, c := range m.groupCalls {
+		if c.topic == topic {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func (m *mockBroadcaster) BroadcastToAll(event realtime.Event) error {
@@ -323,6 +347,102 @@ func TestBroadcast_EndActivitySessionBatchesCheckouts(t *testing.T) {
 	// students still yield two — independent of how many were checked out.
 	assert.Len(t, broadcaster.eventsOfType(realtime.EventDashboardCountsChanged), 2,
 		"session end fires a fixed number of dashboard refreshes regardless of student count")
+}
+
+// TestBroadcast_EndActivitySessionBatchesPerEducationGroup verifies the edu-group
+// fan-out of the issue #848 batch: when checked-out students belong to different
+// OGS groups, each edu:{groupID} topic must receive its OWN bulk_student_checkout
+// carrying only that group's students — so a client watching one OGS group
+// invalidates exactly its students' caches, not the whole session's. The
+// active-group topic still carries every student.
+func TestBroadcast_EndActivitySessionBatchesPerEducationGroup(t *testing.T) {
+	svc, broadcaster := setupServiceWithBroadcaster(t)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	room := testpkg.CreateTestRoom(t, db, "Edu Batch Room")
+	staff := testpkg.CreateTestStaff(t, db, "Edu", "BatchEnder")
+	activityGroup := testpkg.CreateTestActivityGroup(t, db, "edu-batch-end")
+	session := testpkg.CreateTestActiveGroup(t, db, activityGroup.ID, room.ID)
+	_ = testpkg.CreateTestGroupSupervisor(t, db, staff.ID, session.ID, "supervisor")
+
+	// Two OGS groups: A+B in groupX, C in groupY.
+	groupX := testpkg.CreateTestEducationGroup(t, db, "OGS-Batch-X")
+	groupY := testpkg.CreateTestEducationGroup(t, db, "OGS-Batch-Y")
+	studentA := testpkg.CreateTestStudent(t, db, "Edu", "BatchA", "2a")
+	studentB := testpkg.CreateTestStudent(t, db, "Edu", "BatchB", "2b")
+	studentC := testpkg.CreateTestStudent(t, db, "Edu", "BatchC", "2c")
+	assignStudentToEducationGroup(t, db, ctx, studentA.ID, groupX.ID)
+	assignStudentToEducationGroup(t, db, ctx, studentB.ID, groupX.ID)
+	assignStudentToEducationGroup(t, db, ctx, studentC.ID, groupY.ID)
+
+	visitA := testpkg.CreateTestVisit(t, db, studentA.ID, session.ID, time.Now(), nil)
+	visitB := testpkg.CreateTestVisit(t, db, studentB.ID, session.ID, time.Now(), nil)
+	visitC := testpkg.CreateTestVisit(t, db, studentC.ID, session.ID, time.Now(), nil)
+	// Students must be cleaned up before their education groups: the composite
+	// students.group_id FK is ON DELETE SET NULL, and deleting a still-referenced
+	// group nulls students.tenant_id (NOT NULL) and errors. Cleanup processes IDs
+	// in order, so list students/visits ahead of the groups.
+	defer testpkg.CleanupActivityFixtures(t, db,
+		studentA.ID, studentB.ID, studentC.ID,
+		visitA.ID, visitB.ID, visitC.ID,
+		groupX.ID, groupY.ID,
+		session.ID, activityGroup.ID, room.ID, staff.ID,
+	)
+
+	broadcaster.mu.Lock()
+	broadcaster.allCalls = nil
+	broadcaster.groupCalls = nil
+	broadcaster.mu.Unlock()
+
+	err := svc.EndActivitySession(testpkg.TenantContext(1), session.ID)
+	require.NoError(t, err)
+
+	idA := strconv.FormatInt(studentA.ID, 10)
+	idB := strconv.FormatInt(studentB.ID, 10)
+	idC := strconv.FormatInt(studentC.ID, 10)
+
+	// edu:{groupX} gets one bulk event carrying A and B only.
+	groupXCalls := broadcaster.groupCallsForTopic("edu:" + strconv.FormatInt(groupX.ID, 10))
+	require.Len(t, groupXCalls, 1, "groupX edu topic must receive exactly one bulk event")
+	require.Equal(t, realtime.EventBulkStudentCheckOut, groupXCalls[0].event.Type)
+	require.NotNil(t, groupXCalls[0].event.Data.StudentIDs)
+	assert.ElementsMatch(t, []string{idA, idB}, *groupXCalls[0].event.Data.StudentIDs,
+		"groupX event must carry only groupX's students")
+
+	// edu:{groupY} gets one bulk event carrying C only — not A/B.
+	groupYCalls := broadcaster.groupCallsForTopic("edu:" + strconv.FormatInt(groupY.ID, 10))
+	require.Len(t, groupYCalls, 1, "groupY edu topic must receive exactly one bulk event")
+	require.NotNil(t, groupYCalls[0].event.Data.StudentIDs)
+	assert.ElementsMatch(t, []string{idC}, *groupYCalls[0].event.Data.StudentIDs,
+		"groupY event must carry only groupY's student")
+
+	// The active-group topic still carries every student.
+	sessionIDStr := strconv.FormatInt(session.ID, 10)
+	var activeTopicBulk *realtime.Event
+	for _, e := range broadcaster.eventsOfType(realtime.EventBulkStudentCheckOut) {
+		if e.ActiveGroupID == sessionIDStr && e.Data.StudentIDs != nil && len(*e.Data.StudentIDs) == 3 {
+			evt := e
+			activeTopicBulk = &evt
+		}
+	}
+	require.NotNil(t, activeTopicBulk, "active-group topic must carry a bulk event with all students")
+	assert.ElementsMatch(t, []string{idA, idB, idC}, *activeTopicBulk.Data.StudentIDs)
+}
+
+// assignStudentToEducationGroup sets a student's OGS group_id in the DB so the
+// SSE collection step (which reads student.GroupID) routes the student to its
+// edu:{groupID} topic. Mirrors the assignment used in attendance_service_test.go.
+func assignStudentToEducationGroup(tb testing.TB, db *bun.DB, ctx context.Context, studentID, groupID int64) {
+	tb.Helper()
+	_, err := db.NewUpdate().
+		Table("users.students").
+		Set("group_id = ?", groupID).
+		Where("id = ?", studentID).
+		Exec(ctx)
+	require.NoError(tb, err, "failed to assign student to education group")
 }
 
 func TestBroadcast_DailyCheckoutSendsDashboardCounts(t *testing.T) {

--- a/backend/services/active/broadcast_test.go
+++ b/backend/services/active/broadcast_test.go
@@ -262,6 +262,69 @@ func TestBroadcast_EndActivitySessionSendsDashboardCounts(t *testing.T) {
 		"expected active_supervision_changed after EndActivitySession")
 }
 
+// TestBroadcast_EndActivitySessionBatchesCheckouts verifies the issue #848 fix:
+// ending a session with multiple active visits emits ONE bulk_student_checkout
+// per topic carrying every student ID, instead of one student_checkout per
+// student. This is what keeps a single client's SSE channel buffer from
+// overflowing during a whole-session checkout.
+func TestBroadcast_EndActivitySessionBatchesCheckouts(t *testing.T) {
+	svc, broadcaster := setupServiceWithBroadcaster(t)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	room := testpkg.CreateTestRoom(t, db, "Broadcast Batch Room")
+	staff := testpkg.CreateTestStaff(t, db, "Broadcast", "BatchEnder")
+	activityGroup := testpkg.CreateTestActivityGroup(t, db, "broadcast-batch-end")
+	session := testpkg.CreateTestActiveGroup(t, db, activityGroup.ID, room.ID)
+	_ = testpkg.CreateTestGroupSupervisor(t, db, staff.ID, session.ID, "supervisor")
+	studentA := testpkg.CreateTestStudent(t, db, "Broadcast", "BatchA", "2a")
+	studentB := testpkg.CreateTestStudent(t, db, "Broadcast", "BatchB", "2b")
+	visitA := testpkg.CreateTestVisit(t, db, studentA.ID, session.ID, time.Now(), nil)
+	visitB := testpkg.CreateTestVisit(t, db, studentB.ID, session.ID, time.Now(), nil)
+	defer testpkg.CleanupActivityFixtures(t, db,
+		room.ID, staff.ID, activityGroup.ID, session.ID,
+		studentA.ID, studentB.ID, visitA.ID, visitB.ID,
+	)
+
+	broadcaster.mu.Lock()
+	broadcaster.allCalls = nil
+	broadcaster.mu.Unlock()
+
+	err := svc.EndActivitySession(testpkg.TenantContext(1), session.ID)
+	require.NoError(t, err)
+
+	// No per-student student_checkout events on the bulk path — those would be
+	// the 2N burst that overflowed the channel buffer.
+	assert.Empty(t, broadcaster.eventsOfType(realtime.EventStudentCheckOut),
+		"bulk session end must not emit per-student student_checkout events")
+
+	// Exactly one bulk_student_checkout on the active-group topic, carrying both
+	// students. (Edu-group topics get their own events only when students have an
+	// OGS group assigned; the active-group topic always fires.)
+	sessionIDStr := strconv.FormatInt(session.ID, 10)
+	var activeTopicBulk *realtime.Event
+	for _, e := range broadcaster.eventsOfType(realtime.EventBulkStudentCheckOut) {
+		if e.ActiveGroupID == sessionIDStr {
+			evt := e
+			activeTopicBulk = &evt
+		}
+	}
+	require.NotNil(t, activeTopicBulk,
+		"expected a bulk_student_checkout on the active-group topic")
+	require.NotNil(t, activeTopicBulk.Data.StudentIDs,
+		"bulk event must carry student_ids")
+	assert.ElementsMatch(t,
+		[]string{strconv.FormatInt(studentA.ID, 10), strconv.FormatInt(studentB.ID, 10)},
+		*activeTopicBulk.Data.StudentIDs,
+		"active-topic bulk event must list every checked-out student")
+
+	// Dashboard refreshes are constant per batch, not one-per-student: the
+	// checkout batch fires one and broadcastActivityEndEvent fires one, so two
+	// students still yield two — independent of how many were checked out.
+	assert.Len(t, broadcaster.eventsOfType(realtime.EventDashboardCountsChanged), 2,
+		"session end fires a fixed number of dashboard refreshes regardless of student count")
+}
+
 func TestBroadcast_DailyCheckoutSendsDashboardCounts(t *testing.T) {
 	svc, broadcaster := setupServiceWithBroadcaster(t)
 	db := testpkg.SetupTestDB(t)

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -304,6 +304,46 @@ describe("useGlobalSSE", () => {
       expect(dashboardCall).toBeDefined();
     });
 
+    it("invalidates group and per-student caches on bulk_student_checkout event", () => {
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      // Whole-session end (#848): one event carries every affected student.
+      onMessage?.({
+        type: "bulk_student_checkout",
+        active_group_id: "123",
+        data: { student_ids: ["42", "77"] },
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+
+      const mutateCalls = vi.mocked(mutate).mock.calls;
+
+      // Group (active_group_id) drives supervision-visits invalidation.
+      const supervisionCall = mutateCalls.find((call) => {
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)("tenant:supervision-visits-123")
+        );
+      });
+      expect(supervisionCall).toBeDefined();
+
+      // Every student in the batch gets its detail cache invalidated.
+      for (const id of ["42", "77"]) {
+        const detailCall = mutateCalls.find((call) => {
+          const matcher = call[0];
+          return (
+            typeof matcher === "function" &&
+            (matcher as (key: string) => boolean)(`tenant:student-detail-${id}`)
+          );
+        });
+        expect(detailCall).toBeDefined();
+      }
+    });
+
     it("invalidates activity caches on activity_start event", () => {
       renderHook(() => useGlobalSSE());
 

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -344,6 +344,36 @@ describe("useGlobalSSE", () => {
       }
     });
 
+    it("handles a bulk_student_checkout with no active_group_id and no student_ids without invalidating those caches", () => {
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      // Defensive path: a malformed/empty bulk event must not throw and must
+      // not invalidate group or per-student caches (both guard conditions are
+      // false). It still schedules a flush — the dashboard refresh is harmless.
+      onMessage?.({
+        type: "bulk_student_checkout",
+        active_group_id: "",
+        data: {},
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+
+      const mutateCalls = vi.mocked(mutate).mock.calls;
+
+      const touchedSupervisionOrStudent = mutateCalls.some((call) => {
+        const matcher = call[0];
+        if (typeof matcher !== "function") return false;
+        const fn = matcher as (key: string) => boolean;
+        return (
+          fn("tenant:supervision-visits-123") || fn("tenant:student-detail-42")
+        );
+      });
+      expect(touchedSupervisionOrStudent).toBe(false);
+    });
+
     it("invalidates activity caches on activity_start event", () => {
       renderHook(() => useGlobalSSE());
 

--- a/frontend/src/lib/hooks/__tests__/use-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-sse.test.ts
@@ -45,6 +45,16 @@ class MockEventSource {
     this.readyState = this.CLOSED;
   }
 
+  // Test helper: is a named-event listener registered? Mirrors real
+  // EventSource semantics — a `event: <type>` frame is only delivered when a
+  // listener for that exact type was added; otherwise it is dropped (it does
+  // NOT fall back to onmessage). Lets tests assert that use-sse subscribed to a
+  // given backend event type (issue #848: bulk_student_checkout was emitted but
+  // never listened for, so the client silently ignored it).
+  hasListener(type: string): boolean {
+    return (this.eventListeners.get(type)?.length ?? 0) > 0;
+  }
+
   // Test helper methods
   triggerOpen(): void {
     this.readyState = this.OPEN;
@@ -213,6 +223,38 @@ describe("useSSE Hook", () => {
       };
 
       mockEventSource?.triggerMessage(testEvent, "student_checkin");
+
+      await waitFor(
+        () => {
+          expect(onMessage).toHaveBeenCalledWith(testEvent);
+        },
+        { timeout: 500 },
+      );
+    });
+
+    it("subscribes to bulk_student_checkout named events (issue #848)", async () => {
+      const onMessage = vi.fn();
+      renderHook(() => useSSE("/api/sse/events", { onMessage }));
+
+      await waitForEventSource();
+      mockEventSource?.triggerOpen();
+
+      // The backend writes `event: bulk_student_checkout` named frames. Browser
+      // EventSource delivers named events ONLY to a matching addEventListener —
+      // never to onmessage. If use-sse forgets to register this type the client
+      // silently drops the whole-session-end batch (the original #848 gap).
+      expect(
+        requireLatestEventSource().hasListener("bulk_student_checkout"),
+      ).toBe(true);
+
+      const testEvent: SSEEvent = {
+        type: "bulk_student_checkout",
+        active_group_id: "123",
+        data: { student_ids: ["42", "77"] },
+        timestamp: new Date().toISOString(),
+      };
+
+      mockEventSource?.triggerMessage(testEvent, "bulk_student_checkout");
 
       await waitFor(
         () => {

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -301,6 +301,23 @@ export function useGlobalSSE(): SSEHookState {
           break;
         }
 
+        case "bulk_student_checkout": {
+          // Whole-session end (#848): one event per topic carrying every
+          // affected student. Mirror student_checkout — invalidate the
+          // session's group caches plus each student's detail cache — but read
+          // the batched student_ids list instead of a single student_id.
+          if (event.active_group_id) {
+            pendingGroupIds.current.add(event.active_group_id);
+          }
+          if (event.data.student_ids) {
+            for (const id of event.data.student_ids) {
+              pendingStudentIds.current.add(id);
+            }
+          }
+          scheduleFlush();
+          break;
+        }
+
         case "student_updated": {
           hasPendingStudentUpdateEvent.current = true;
           scheduleFlush();

--- a/frontend/src/lib/hooks/use-sse.ts
+++ b/frontend/src/lib/hooks/use-sse.ts
@@ -146,6 +146,7 @@ export function useSSE(
         const eventTypes = [
           "student_checkin",
           "student_checkout",
+          "bulk_student_checkout",
           "student_updated",
           "activity_start",
           "activity_end",

--- a/frontend/src/lib/sse-types.ts
+++ b/frontend/src/lib/sse-types.ts
@@ -3,6 +3,10 @@
 type SSEEventType =
   | "student_checkin"
   | "student_checkout"
+  // Batched checkout emitted when a whole session ends (manual end or
+  // scheduler timeout). One event per topic carries all affected student IDs
+  // instead of one student_checkout per student — see backend issue #848.
+  | "bulk_student_checkout"
   | "student_updated"
   | "activity_start"
   | "activity_end"
@@ -28,6 +32,9 @@ interface SSEEventData {
   student_name?: string;
   school_class?: string;
   group_name?: string; // Student's OGS group
+
+  // Affected students on a bulk_student_checkout event (whole-session end).
+  student_ids?: string[];
 
   // Activity session fields (for activity_start/end/update events)
   activity_name?: string;


### PR DESCRIPTION
Fixes #848.

## Problem

On a whole-session checkout, `broadcastStudentCheckoutEvents` looped per student and emitted **2N+1** SSE events onto a single client's channel (one `student_checkout` to the active-group topic + one to the edu-group topic per student, plus a global dashboard refresh). The client channel buffer was only 10 slots, so any session with >5 students dropped events ("SSE client channel full", 35x in the production log that filed the issue).

## Fix (approaches A + B from the issue; C intentionally out of scope)

**B — batch the events (root cause):**
- New event type `bulk_student_checkout`. On session end we now emit **one event per topic**: one to the active-group topic carrying every student ID, and one per distinct edu group carrying that group's IDs. `2N+1` → `~3` events.
- Single-student checkout is unchanged (still `student_checkout` via `broadcastVisitCheckout`).
- The per-student attendance snapshot the old loop computed (at a cost of 2N schedule queries) is dropped — SSE events are triggers, not payloads; the client refetches, and the frontend never read those fields.

**A — buffer headroom:**
- Client channel buffer `10 → 32`.

**Frontend:**
- Handle `bulk_student_checkout` (mirrors `student_checkout` invalidation: group cache + each student's detail cache).
- Register the named-event listener in `use-sse.ts`; sync `sse-types.ts`.

**C (sequence numbers / client gap detection):** intentionally not implemented — over-engineering for this issue.

## Verification

- `go build ./...` clean; `go test ./services/active/` passes incl. new `TestBroadcast_EndActivitySessionBatchesCheckouts`.
- Frontend `pnpm run check` clean; 68 SSE hook tests pass (incl. new bulk-checkout coverage in `use-sse` + `use-global-sse`).