### PR TITLE
fix: gate Schulhof status polling on groups:read permission (#846)

### DIFF
--- a/frontend/src/lib/auth-utils.test.ts
+++ b/frontend/src/lib/auth-utils.test.ts
@@ -3,6 +3,7 @@ import type { Session } from "next-auth";
 import {
   hasRole,
   hasAnyRole,
+  hasPermission,
   isAdmin,
   isCaregiver,
   isAuthenticated,
@@ -98,6 +99,107 @@ describe("auth-utils", () => {
 
       expect(hasAnyRole(session, ["user", "teacher"])).toBe(true);
       expect(hasAnyRole(session, ["teacher", "moderator"])).toBe(false);
+    });
+  });
+
+  describe("hasPermission", () => {
+    it("should return true when the user holds the permission", () => {
+      const session: Session = {
+        user: {
+          id: "1",
+          email: "test@example.com",
+          roles: ["user"],
+          permissions: ["groups:read", "groups:update"],
+          token: "token",
+        },
+        expires: "2024-12-31",
+      };
+
+      expect(hasPermission(session, "groups:read")).toBe(true);
+    });
+
+    it("should return false when the user lacks the permission", () => {
+      const session: Session = {
+        user: {
+          id: "1",
+          email: "test@example.com",
+          roles: ["guest"],
+          permissions: ["users:read", "rooms:read"],
+          token: "token",
+        },
+        expires: "2024-12-31",
+      };
+
+      expect(hasPermission(session, "groups:read")).toBe(false);
+    });
+
+    it("should return false when permissions are absent or session is null", () => {
+      const session = {
+        user: { id: "1", email: "test@example.com", token: "token" },
+        expires: "2024-12-31",
+      } as Session;
+
+      expect(hasPermission(session, "groups:read")).toBe(false);
+      expect(hasPermission(null, "groups:read")).toBe(false);
+    });
+
+    // The backend authorizer (backend/auth/authorize/permission.go) grants a
+    // permission via several wildcard forms. hasPermission must honour the
+    // same ones, or a legitimately-permitted user is wrongly treated as
+    // lacking access on the client.
+    const wildcardSession = (perms: string[]): Session => ({
+      user: {
+        id: "1",
+        email: "test@example.com",
+        permissions: perms,
+        token: "token",
+      },
+      expires: "2024-12-31",
+    });
+
+    it("should grant via the admin wildcards admin:* and *:*", () => {
+      expect(hasPermission(wildcardSession(["admin:*"]), "groups:read")).toBe(
+        true,
+      );
+      expect(hasPermission(wildcardSession(["*:*"]), "groups:read")).toBe(true);
+    });
+
+    // Resource-level wildcards (groups:*, group*) are NOT granted today: the
+    // permission catalog is a fixed set of literal resource:action strings plus
+    // admin:* / *:*, and AssignPermissionToRole takes a permission ID (FK), so
+    // no role can hold a string like groups:*. These cases therefore can't fire
+    // in production right now. We keep covering them on purpose: hasPermission
+    // mirrors the backend authorizer (backend/auth/authorize/permission.go), and
+    // the day a resource wildcard is ever seeded the gate must already honour it
+    // — otherwise a legitimately-permitted user is wrongly locked out (the exact
+    // failure mode of issue #846, just reintroduced).
+    it("should grant via a resource action-wildcard (groups:*)", () => {
+      expect(hasPermission(wildcardSession(["groups:*"]), "groups:read")).toBe(
+        true,
+      );
+    });
+
+    it("should grant via a prefix wildcard on a component (group*)", () => {
+      expect(
+        hasPermission(wildcardSession(["group*:read"]), "groups:read"),
+      ).toBe(true);
+    });
+
+    it("should not grant when a different resource wildcard is held", () => {
+      expect(hasPermission(wildcardSession(["users:*"]), "groups:read")).toBe(
+        false,
+      );
+    });
+
+    it("should reject malformed required permissions and entries", () => {
+      // Required string without a single resource:action split never matches.
+      expect(hasPermission(wildcardSession(["groups:read"]), "groups")).toBe(
+        false,
+      );
+      // A malformed entry in the list is ignored, not matched.
+      expect(hasPermission(wildcardSession(["groups"]), "groups:read")).toBe(
+        false,
+      );
     });
   });
 

--- a/frontend/src/lib/auth-utils.test.ts
+++ b/frontend/src/lib/auth-utils.test.ts
@@ -143,6 +143,10 @@ describe("auth-utils", () => {
       expect(hasPermission(null, "groups:read")).toBe(false);
     });
 
+    it("should allow an empty required permission even without a session", () => {
+      expect(hasPermission(null, "")).toBe(true);
+    });
+
     // The backend authorizer (backend/auth/authorize/permission.go) grants a
     // permission via several wildcard forms. hasPermission must honour the
     // same ones, or a legitimately-permitted user is wrongly treated as

--- a/frontend/src/lib/auth-utils.ts
+++ b/frontend/src/lib/auth-utils.ts
@@ -15,6 +15,64 @@ export function hasAnyRole(
 }
 
 /**
+ * Match a single permission component (resource or action) against the value a
+ * required permission demands. Mirrors the backend's `matchesPattern`
+ * (backend/auth/authorize/permission.go): exact match, a bare `*`, or a
+ * prefix wildcard like `group*`.
+ */
+function matchesPattern(pattern: string, required: string): boolean {
+  if (pattern === required || pattern === "*") return true;
+  if (pattern.endsWith("*")) {
+    return required.startsWith(pattern.slice(0, -1));
+  }
+  return false;
+}
+
+/**
+ * Check if the user holds a specific permission (e.g. "groups:read").
+ *
+ * This is a faithful port of the backend authorizer
+ * (backend/auth/authorize/permission.go `hasPermission`), so a client-side
+ * capability check can never silently diverge from what the backend will
+ * actually allow. It honours the same wildcards the backend grants:
+ *   - the admin wildcards `admin:*` / `*:*` (grant everything),
+ *   - resource/action wildcards such as `groups:*` or `groups*`.
+ *
+ * Permissions are resolved server-side and carried in the JWT. Use this to
+ * gate client-side work (e.g. polling) on what the backend will allow, rather
+ * than firing requests that are guaranteed to 403.
+ */
+export function hasPermission(
+  session: Session | null,
+  permission: string,
+): boolean {
+  const permissions = session?.user?.permissions;
+  if (!permissions) return false;
+
+  // Empty requirement always matches (mirrors the backend short-circuit).
+  if (permission === "") return true;
+
+  // Admin wildcard grants everything.
+  if (permissions.some((perm) => perm === "admin:*" || perm === "*:*")) {
+    return true;
+  }
+
+  const requiredParts = permission.split(":");
+  if (requiredParts.length !== 2) return false; // invalid format
+  const [requiredResource, requiredAction] = requiredParts as [string, string];
+
+  return permissions.some((perm) => {
+    const parts = perm.split(":");
+    if (parts.length !== 2) return false; // invalid format
+    const [resource, action] = parts as [string, string];
+    return (
+      matchesPattern(resource, requiredResource) &&
+      matchesPattern(action, requiredAction)
+    );
+  });
+}
+
+/**
  * Check if the user is an admin
  */
 export function isAdmin(session: Session | null): boolean {

--- a/frontend/src/lib/auth-utils.ts
+++ b/frontend/src/lib/auth-utils.ts
@@ -46,11 +46,11 @@ export function hasPermission(
   session: Session | null,
   permission: string,
 ): boolean {
-  const permissions = session?.user?.permissions;
-  if (!permissions) return false;
-
   // Empty requirement always matches (mirrors the backend short-circuit).
   if (permission === "") return true;
+
+  const permissions = session?.user?.permissions;
+  if (!permissions) return false;
 
   // Admin wildcard grants everything.
   if (permissions.some((perm) => perm === "admin:*" || perm === "*:*")) {

--- a/frontend/src/lib/supervision-context.test.tsx
+++ b/frontend/src/lib/supervision-context.test.tsx
@@ -85,7 +85,15 @@ function setupFetchMock(overrides?: {
 }
 
 // Helper to create wrapper with session
-function createWrapper(token?: string, roles?: string[]) {
+// Default test subject is a real supervisor, who carries `groups:read` — the
+// permission the backend requires for /schulhof/status. Pass an empty array to
+// model a limited account (e.g. the `guest` role) that must NOT poll Schulhof.
+function createWrapper(
+  token?: string,
+  roles?: string[],
+  permissions: string[] = ["groups:read"],
+  includePermissions = true,
+) {
   return function Wrapper({ children }: { children: ReactNode }) {
     vi.mocked(useSession).mockReturnValue(
       (token
@@ -96,6 +104,7 @@ function createWrapper(token?: string, roles?: string[]) {
                 id: "1",
                 email: "test@example.com",
                 name: "Test User",
+                ...(includePermissions ? { permissions } : {}),
                 ...(roles ? { roles } : {}),
               },
               expires: "2099-12-31",
@@ -679,6 +688,115 @@ describe("SupervisionProvider Schulhof handling", () => {
     expect(result.current.isSupervising).toBe(true);
     expect(result.current.supervisedRooms).toHaveLength(1);
     expect(result.current.supervisedRooms[0]?.isSchulhof).toBe(true);
+  });
+
+  it("should NOT poll Schulhof status for accounts without groups:read (issue #846)", async () => {
+    // A limited account (e.g. the `guest` role) lacks groups:read. The backend
+    // gates /schulhof/status on that permission, so polling it only ever 403s
+    // and floods the logs. The provider must skip the fetch entirely.
+    setupFetchMock({
+      supervised: { data: [] },
+      schulhof: {
+        data: {
+          data: {
+            exists: true,
+            room_id: 100,
+            room_name: "Schulhof",
+            active_group_id: 200,
+            is_user_supervising: false,
+          },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useSupervision(), {
+      wrapper: createWrapper("test-token", ["guest"], []),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoadingSupervision).toBe(false);
+    });
+
+    const fetchCalls = mockFetch.mock.calls.map((call) => call[0] as string);
+    expect(fetchCalls).not.toContain("/api/active/schulhof/status");
+
+    // Even though the mock would report an existing Schulhof, no tab appears
+    // because the status was never fetched.
+    const schulhofRoom = result.current.supervisedRooms.find(
+      (r) => r.isSchulhof,
+    );
+    expect(schulhofRoom).toBeUndefined();
+  });
+
+  it("should poll Schulhof status for admins even without an explicit groups:read permission", async () => {
+    // Admins are gated in via the admin wildcard rather than an explicit
+    // grant; the isAdmin guard must keep Schulhof working for them.
+    setupFetchMock({
+      supervised: { data: [] },
+      schulhof: {
+        data: {
+          data: {
+            exists: true,
+            room_id: 100,
+            room_name: "Schulhof",
+            active_group_id: 200,
+            is_user_supervising: false,
+          },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useSupervision(), {
+      wrapper: createWrapper("test-token", ["admin"], []),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoadingSupervision).toBe(false);
+    });
+
+    const fetchCalls = mockFetch.mock.calls.map((call) => call[0] as string);
+    expect(fetchCalls).toContain("/api/active/schulhof/status");
+
+    const schulhofRoom = result.current.supervisedRooms.find(
+      (r) => r.isSchulhof,
+    );
+    expect(schulhofRoom).toBeDefined();
+  });
+
+  it("should poll Schulhof status for pre-existing staff sessions without a permissions claim", async () => {
+    // Sessions issued before the permissions claim existed still have a valid
+    // backend token. Role-based staff access must continue until refresh adds
+    // the explicit permissions list.
+    setupFetchMock({
+      supervised: { data: [] },
+      schulhof: {
+        data: {
+          data: {
+            exists: true,
+            room_id: 100,
+            room_name: "Schulhof",
+            active_group_id: 200,
+            is_user_supervising: false,
+          },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useSupervision(), {
+      wrapper: createWrapper("test-token", ["teacher"], [], false),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoadingSupervision).toBe(false);
+    });
+
+    const fetchCalls = mockFetch.mock.calls.map((call) => call[0] as string);
+    expect(fetchCalls).toContain("/api/active/schulhof/status");
+
+    const schulhofRoom = result.current.supervisedRooms.find(
+      (r) => r.isSchulhof,
+    );
+    expect(schulhofRoom).toBeDefined();
   });
 
   it("should not include Schulhof when it does not exist", async () => {

--- a/frontend/src/lib/supervision-context.tsx
+++ b/frontend/src/lib/supervision-context.tsx
@@ -9,7 +9,7 @@ import React, {
   useMemo,
 } from "react";
 import { useSession } from "next-auth/react";
-import { isAdmin } from "~/lib/auth-utils";
+import { hasPermission, isAdmin, isCaregiver } from "~/lib/auth-utils";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "SupervisionContext" });
@@ -108,6 +108,21 @@ export function SupervisionProvider({
   tokenRef.current = session?.user?.token;
   const isAdminRef = React.useRef<boolean>(isAdmin(session));
   isAdminRef.current = isAdmin(session);
+
+  // Whether the user may read group/supervision data. The Schulhof status
+  // endpoint is gated by `groups:read` on the backend, so accounts with an
+  // explicit permissions list that lacks it (e.g. the limited `guest` role)
+  // get skipped instead of flooding production with guaranteed 403s. Admins
+  // keep their role fallback; staff sessions issued before the permissions
+  // claim existed have no list at all, so keep their role-based access alive
+  // during that rollout window and let the backend remain the final authority.
+  const canReadGroupsRef = React.useRef<boolean>(false);
+  const sessionPermissions = session?.user?.permissions;
+  const hasExplicitPermissions = Array.isArray(sessionPermissions);
+  canReadGroupsRef.current =
+    isAdmin(session) ||
+    hasPermission(session, "groups:read") ||
+    (!hasExplicitPermissions && isCaregiver(session));
 
   // Use a ref for the refresh function to break dependency cycles
   const refreshRef = React.useRef<
@@ -250,13 +265,19 @@ export function SupervisionProvider({
         return adminResponse;
       };
 
-      // Fetch supervised groups and Schulhof status in parallel
+      // Fetch supervised groups and Schulhof status in parallel.
+      // Skip the Schulhof fetch for accounts without `groups:read`: the
+      // backend gates /schulhof/status on that permission, so polling it
+      // would only ever 403 (issue #846). The supervised-groups fetch below
+      // hits permission-less /me endpoints and is safe for everyone.
       const [response, schulhofResponse] = await Promise.all([
         fetchSupervisedGroups(),
-        fetch("/api/active/schulhof/status", {
-          headers: { "Content-Type": "application/json" },
-          cache: "no-store",
-        }).catch(() => null), // Schulhof is optional
+        canReadGroupsRef.current
+          ? fetch("/api/active/schulhof/status", {
+              headers: { "Content-Type": "application/json" },
+              cache: "no-store",
+            }).catch(() => null) // Schulhof is optional
+          : Promise.resolve(null),
       ]);
 
       // Parse Schulhof status

--- a/frontend/src/server/auth/config.test.ts
+++ b/frontend/src/server/auth/config.test.ts
@@ -148,6 +148,32 @@ describe("authConfig", () => {
       expect(result?.refreshTokenExpiry).toBeDefined();
     });
 
+    it("should carry permissions from user onto the token", async () => {
+      const user = {
+        id: "123",
+        name: "Test User",
+        email: "test@example.com",
+        token: "access-token",
+        refreshToken: "refresh-token",
+        roles: ["user"],
+        permissions: ["groups:read", "groups:update"],
+        firstName: "Test",
+        isAdmin: false,
+      };
+
+      const result = await authConfig.callbacks?.jwt?.({
+        token: {},
+        user,
+        account: null,
+        profile: undefined,
+        trigger: "signIn",
+        isNewUser: false,
+        session: undefined,
+      });
+
+      expect(result?.permissions).toEqual(["groups:read", "groups:update"]);
+    });
+
     it("should return token unchanged when no user", async () => {
       const token = {
         id: "123",
@@ -534,6 +560,29 @@ describe("authConfig", () => {
       expect(user?.roles).toEqual(["teacher"]);
       expect(user?.firstName).toBe("Test");
       expect(user?.isAdmin).toBe(false);
+    });
+
+    it("should expose permissions from the token on the session", () => {
+      const session = {
+        user: { id: "", email: "", name: "" },
+        expires: "2099-12-31",
+      };
+
+      const token = {
+        id: "123",
+        email: "test@example.com",
+        token: "access-token",
+        refreshToken: "refresh-token",
+        roles: ["user"],
+        permissions: ["groups:read"],
+        firstName: "Test",
+        isAdmin: false,
+      };
+
+      const result = callSessionCallback({ session, token });
+      const user = result?.user as Record<string, unknown> | undefined;
+
+      expect(user?.permissions).toEqual(["groups:read"]);
     });
 
     it("should return minimal session when token has error", () => {

--- a/frontend/src/server/auth/shared.ts
+++ b/frontend/src/server/auth/shared.ts
@@ -29,6 +29,7 @@ export interface JwtPayload {
   last_name?: string;
   email?: string;
   roles?: string[];
+  permissions?: string[];
   is_admin?: boolean;
   tenant_id?: number;
   org_id?: number;
@@ -46,6 +47,7 @@ declare module "next-auth" {
       token?: string;
       refreshToken?: string;
       roles?: string[];
+      permissions?: string[];
       firstName?: string;
       isAdmin?: boolean;
       tenantId?: number;
@@ -59,6 +61,7 @@ declare module "next-auth" {
     token?: string;
     refreshToken?: string;
     roles?: string[];
+    permissions?: string[];
     firstName?: string;
     isAdmin?: boolean;
     tenantId?: number;
@@ -71,6 +74,7 @@ declare module "next-auth" {
     token?: string;
     refreshToken?: string;
     roles?: string[];
+    permissions?: string[];
     firstName?: string;
     isAdmin?: boolean;
     tenantId?: number;
@@ -152,6 +156,7 @@ function syncTokenFromPayload(
   token.tenantId = payload.tenant_id;
   token.orgId = payload.org_id;
   token.roles = payload.roles ?? [];
+  token.permissions = payload.permissions ?? [];
   token.isAdmin = payload.is_admin ?? false;
   token.scope = payload.scope;
   token.name = buildDisplayName(payload, (token.email as string) ?? "");
@@ -173,6 +178,10 @@ export function buildAuthUser(
 ): User {
   const roles =
     payload.roles && Array.isArray(payload.roles) ? payload.roles : [];
+  const permissions =
+    payload.permissions && Array.isArray(payload.permissions)
+      ? payload.permissions
+      : [];
 
   return {
     id: String(payload.id),
@@ -181,6 +190,7 @@ export function buildAuthUser(
     token: token,
     refreshToken: refreshToken,
     roles: scope === "platform" ? ["operator"] : roles,
+    permissions: permissions,
     firstName: payload.first_name,
     isAdmin: payload.is_admin ?? false,
     tenantId: payload.tenant_id,
@@ -556,6 +566,7 @@ export const sharedJwtCallback: NonNullable<
     token.token = user.token ?? "";
     token.refreshToken = user.refreshToken ?? "";
     token.roles = user.roles;
+    token.permissions = user.permissions;
     token.firstName = user.firstName;
     token.isAdmin = user.isAdmin;
     token.tenantId = user.tenantId;
@@ -780,6 +791,7 @@ export const sharedSessionCallback: NonNullable<
         token: "",
         refreshToken: "",
         roles: [],
+        permissions: [],
         firstName: (token.firstName as string) || "",
         isAdmin: false,
         scope: token.scope as string | undefined,
@@ -797,6 +809,7 @@ export const sharedSessionCallback: NonNullable<
       token: token.token as string,
       refreshToken: token.refreshToken as string,
       roles: token.roles as string[],
+      permissions: token.permissions as string[],
       firstName: token.firstName as string,
       isAdmin: (token.isAdmin as boolean) ?? false,
       tenantId: token.tenantId as number | undefined,


### PR DESCRIPTION
Fixes #846.

## Problem
`SupervisionProvider` wraps the entire `[tenant]` layout and polls `GET /api/active/schulhof/status` every 60s for **every** authenticated tenant user. The backend gates that endpoint on `groups:read` (`api/active/api.go` → `RequiresPermission(permissions.GroupsRead)`), so accounts without it (e.g. the limited `guest` role) produced a guaranteed 403 on every poll — ~150 warnings per 5h in production, the noisiest log line. The client swallows the error (`.catch(() => null)`), so nothing broke in the UI; only the backend logs filled up.

## Fix
Stop the 403s at the source (issue's preferred option 1):
- Plumb the JWT `permissions` claim through token → session (`server/auth/shared.ts`).
- Port the backend authorizer to the client: `hasPermission()` in `auth-utils.ts` is a 1:1 mirror of `backend/auth/authorize/permission.go` (admin wildcards `admin:*`/`*:*`, resource/action wildcards, prefix wildcards), so the client gate can never diverge from what the backend allows.
- Skip the Schulhof fetch when the session lacks `groups:read`. Admins keep their role fallback; pre-rollout sessions without a `permissions` claim fall back to the caregiver role so they are not broken during the deploy window. The backend stays the final authority.

The other callers of the endpoint are not the flood source: `active-supervisions` page is an admin-only fallback path, the dashboard BFF route runs on a permission-gated page — neither is the "every user every 60s" poll.

## Tests
- `hasPermission` unit tests: exact match, missing, null session, admin wildcards, resource/prefix wildcards, malformed input.
- `supervision-context` integration: skips fetch without `groups:read`, still polls for admins and for legacy sessions without a permissions claim.
- `config` callbacks: permissions carried onto token and exposed on session.
- 218 tests pass; `tsc --noEmit` clean; `oxlint` 0 warnings.

## Notes
Intentionally the targeted fix, not the SSE migration also floated in the issue. Polling cadence is unchanged.