### PR TITLE
fix: drop bot/scanner probe methods from request log (#850)

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -176,6 +176,13 @@ func setupBasicMiddleware(router chi.Router, logger *slog.Logger, httpMetrics *o
 		WithTraceID:      false,
 		Filters: []slogchi.Filter{
 			slogchi.IgnorePath("/health"),
+			// Bot/scanner probes use HTTP methods our API never serves
+			// (CONNECT tunneling, TRACE/XST, PRI HTTP/2 preface). They get a
+			// 404/405 but add only WARN-level log noise (issue #850). Drop the
+			// log lines; the Prometheus HTTP middleware runs earlier in the
+			// chain and still counts them, so volume-based scan alerting is
+			// unaffected. Legitimate 4xx on GET/POST/... routes keep logging.
+			slogchi.IgnoreMethod(http.MethodConnect, http.MethodTrace, "PRI"),
 		},
 	}))
 	router.Use(middleware.Recoverer)

--- a/backend/api/base_logging_test.go
+++ b/backend/api/base_logging_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// captureHandler is a minimal slog.Handler that records every emitted record
+// so tests can assert which requests the logging middleware logged.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *captureHandler) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.records)
+}
+
+// TestLoggingMiddlewareIgnoresScannerMethods guards the issue #850 fix: probe
+// methods our API never serves (CONNECT, TRACE, PRI) must not produce log
+// noise, while legitimate-method requests that 4xx must still be logged.
+func TestLoggingMiddlewareIgnoresScannerMethods(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantLogged bool
+	}{
+		{name: "CONNECT probe is dropped", method: http.MethodConnect, path: "/", wantLogged: false},
+		{name: "TRACE probe is dropped", method: http.MethodTrace, path: "/", wantLogged: false},
+		{name: "PRI HTTP/2 preface is dropped", method: "PRI", path: "*", wantLogged: false},
+		{name: "GET 404 on bogus path is logged", method: http.MethodGet, path: "/wp-login.php", wantLogged: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capture := &captureHandler{}
+			logger := slog.New(capture)
+
+			router := chi.NewRouter()
+			setupBasicMiddleware(router, logger, nil)
+			router.Get("/", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(tt.method, "http://example.com"+tt.path, nil)
+			router.ServeHTTP(httptest.NewRecorder(), req)
+
+			got := capture.count() > 0
+			if got != tt.wantLogged {
+				t.Fatalf("method %s path %s: logged=%v, want %v (records=%d)",
+					tt.method, tt.path, got, tt.wantLogged, capture.count())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

External bots/scanners probe production with HTTP methods our API never serves (`CONNECT` tunneling, `TRACE`/XST, `PRI` HTTP/2 preface). These get a 404/405 but add WARN-level log noise (~9/5h observed, issue #850).

This adds a second `slogchi` filter — `IgnoreMethod(CONNECT, TRACE, PRI)` — so those requests are no longer logged. Legitimate 4xx on normal methods (e.g. a `GET 404` on a bogus path) keep logging.

## Why drop instead of downgrade to DEBUG

These methods carry zero diagnostic value at any level. The Prometheus HTTP middleware runs **earlier** in the chain (`httpMetrics.Middleware` before the slog middleware) and still counts every request, so volume-based scan alerting is unaffected — only the per-event log lines disappear.

`HEAD /` is intentionally **not** touched: it resolves to the `GET /` handler and returns 200/INFO, so it never contributed to WARN noise.

## Scope

- Log-noise reduction only. Reverse-proxy (Caddy) filtering and per-IP probe rate-limiting from the issue's "steps to investigate" are infra concerns, left out of this code change.

## Test plan

- [x] `go test ./api/ -run TestLoggingMiddlewareIgnoresScannerMethods -v` — CONNECT/TRACE/PRI dropped, GET 404 still logged
- [x] `go build ./...`, `go vet ./api/`, `gofmt` clean

Closes #850