### PR TITLE
Fix login smart redirect indicator

### DIFF
--- a/frontend/src/app/[tenant]/page.test.tsx
+++ b/frontend/src/app/[tenant]/page.test.tsx
@@ -442,6 +442,12 @@ describe("HomePage (Login)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("smart-redirect")).toBeInTheDocument();
     });
+    expect(
+      screen.getByText("Sie sind bereits angemeldet."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("moto öffnet Ihre OGS...")).toBeInTheDocument();
+    expect(screen.queryByTestId("input-email")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("input-password")).not.toBeInTheDocument();
   });
 
   it("disables submit button while loading", async () => {

--- a/frontend/src/app/[tenant]/page.tsx
+++ b/frontend/src/app/[tenant]/page.tsx
@@ -187,6 +187,10 @@ function LoginForm() {
   }, [searchParams]);
 
   const isCheckingAuth = checkingAuth || status === "loading";
+  const isSmartRedirecting =
+    awaitingRedirect &&
+    status === "authenticated" &&
+    Boolean(session?.user?.token);
   const isSubmitting = isLoading || awaitingRedirect;
 
   // seedSessionWithTokens hands an already-minted access/refresh pair to
@@ -301,7 +305,21 @@ function LoginForm() {
         <div
           className={`transition-opacity duration-300 ${isCheckingAuth ? "pointer-events-none hidden" : "opacity-100"}`}
         >
-          {mfaStep ? (
+          {isSmartRedirecting ? (
+            <div className="flex items-center justify-center py-12">
+              <div className="flex flex-col items-center gap-4 text-center">
+                <div className="h-10 w-10 animate-spin rounded-full border-2 border-gray-200 border-t-gray-950" />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-gray-900">
+                    Sie sind bereits angemeldet.
+                  </p>
+                  <p className="text-sm text-gray-500">
+                    moto öffnet Ihre OGS...
+                  </p>
+                </div>
+              </div>
+            </div>
+          ) : mfaStep ? (
             <MFAChallengeForm
               scope="tenant"
               challengeToken={mfaStep.challengeToken}


### PR DESCRIPTION
## Summary
- Show a dedicated redirect indicator when an already-authenticated tenant user hits the login page.
- Hide the credential fields during the authenticated SmartRedirect state so the page does not look interactive.
- Keep the existing SmartRedirect destination logic, login flow, MFA flow, branding, and tenant selection unchanged.

Closes #1485

## Tests
- `cd frontend && pnpm test -- 'src/app/[tenant]/page.test.tsx'`
- `cd frontend && pnpm exec prettier --check 'src/app/[tenant]/page.tsx' 'src/app/[tenant]/page.test.tsx'`
- pre-push: `frontend-knip`
- pre-push: `frontend-check`
