### PR TITLE
Fix IoT force-start activity transfer

### DIFF
--- a/backend/database/repositories/active/visits.go
+++ b/backend/database/repositories/active/visits.go
@@ -326,6 +326,40 @@ func (r *VisitRepository) TransferVisitsFromRecentSessions(ctx context.Context, 
 	return int(rowsAffected), nil
 }
 
+// TransferActiveVisitsBetweenGroups transfers only currently open visits from
+// one active group to another. The exit_time predicate makes the transfer safe
+// against concurrent checkout/timeout flows.
+func (r *VisitRepository) TransferActiveVisitsBetweenGroups(ctx context.Context, oldActiveGroupID, newActiveGroupID int64) (int, error) {
+	query := base.GetDB(ctx, r.db).NewUpdate().
+		Table(tableActiveVisits).
+		Set("active_group_id = ?", newActiveGroupID).
+		Set("updated_at = ?", time.Now()).
+		Where("active_group_id = ?", oldActiveGroupID).
+		Where("exit_time IS NULL")
+
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+
+	result, err := query.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "transfer active visits between groups",
+			Err: err,
+		}
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "get affected rows from active visit transfer",
+			Err: err,
+		}
+	}
+
+	return int(rowsAffected), nil
+}
+
 // DeleteExpiredVisits deletes visits older than retention days for a specific student
 func (r *VisitRepository) DeleteExpiredVisits(ctx context.Context, studentID int64, retentionDays int) (int64, error) {
 	cutoffDate := time.Now().AddDate(0, 0, -retentionDays)

--- a/backend/database/repositories/active/visits_repository_test.go
+++ b/backend/database/repositories/active/visits_repository_test.go
@@ -757,6 +757,71 @@ func TestVisitRepository_TransferVisitsFromRecentSessions(t *testing.T) {
 	})
 }
 
+func TestVisitRepository_TransferActiveVisitsBetweenGroups(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ActiveVisit
+	groupRepo := repositories.NewFactory(db).ActiveGroup
+	ctx := testpkg.TenantContext(1)
+	data := createVisitTestData(t, db)
+	defer cleanupVisitTestData(t, db, data)
+
+	now := time.Now()
+	oldGroup := &active.Group{
+		StartTime:      now.Add(-30 * time.Minute),
+		LastActivity:   now.Add(-10 * time.Minute),
+		TimeoutMinutes: 30,
+		GroupID:        base.Int64Ptr(data.ActivityGroup),
+		RoomID:         data.Room,
+	}
+	require.NoError(t, groupRepo.Create(ctx, oldGroup))
+	defer cleanupActiveGroupRecords(t, db, oldGroup.ID)
+
+	newGroup := &active.Group{
+		StartTime:      now,
+		LastActivity:   now,
+		TimeoutMinutes: 30,
+		GroupID:        base.Int64Ptr(data.ActivityGroup),
+		RoomID:         data.Room,
+	}
+	require.NoError(t, groupRepo.Create(ctx, newGroup))
+	defer cleanupActiveGroupRecords(t, db, newGroup.ID)
+
+	activeVisit := &active.Visit{
+		StudentID:     data.Student1.ID,
+		ActiveGroupID: oldGroup.ID,
+		EntryTime:     now.Add(-20 * time.Minute),
+	}
+	require.NoError(t, repo.Create(ctx, activeVisit))
+	defer testpkg.CleanupTableRecords(t, db, "active.visits", activeVisit.ID)
+
+	exitTime := now.Add(-5 * time.Minute)
+	endedVisit := &active.Visit{
+		StudentID:     data.Student2.ID,
+		ActiveGroupID: oldGroup.ID,
+		EntryTime:     now.Add(-25 * time.Minute),
+		ExitTime:      &exitTime,
+	}
+	require.NoError(t, repo.Create(ctx, endedVisit))
+	defer testpkg.CleanupTableRecords(t, db, "active.visits", endedVisit.ID)
+
+	transferred, err := repo.TransferActiveVisitsBetweenGroups(ctx, oldGroup.ID, newGroup.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, transferred)
+
+	foundActive, err := repo.FindByID(ctx, activeVisit.ID)
+	require.NoError(t, err)
+	assert.Equal(t, newGroup.ID, foundActive.ActiveGroupID)
+	assert.Nil(t, foundActive.ExitTime)
+
+	foundEnded, err := repo.FindByID(ctx, endedVisit.ID)
+	require.NoError(t, err)
+	assert.Equal(t, oldGroup.ID, foundEnded.ActiveGroupID)
+	require.NotNil(t, foundEnded.ExitTime)
+	assert.WithinDuration(t, exitTime, *foundEnded.ExitTime, time.Second)
+}
+
 func TestVisitRepository_GetVisitRetentionStats(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/backend/database/repositories/active/visits_repository_test.go
+++ b/backend/database/repositories/active/visits_repository_test.go
@@ -513,6 +513,180 @@ func TestVisitsRepository_GetCurrentByStudentIDs(t *testing.T) {
 	})
 }
 
+func TestVisitRepository_CountActiveByStudentID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ActiveVisit
+	ctx := testpkg.TenantContext(1)
+	data := createVisitTestData(t, db)
+	defer cleanupVisitTestData(t, db, data)
+
+	now := time.Now()
+	activeVisit := testpkg.CreateTestVisit(t, db, data.Student1.ID, data.ActiveGroup.ID, now.Add(-30*time.Minute), nil)
+	exitTime := now.Add(-10 * time.Minute)
+	endedVisit := testpkg.CreateTestVisit(t, db, data.Student1.ID, data.ActiveGroup.ID, now.Add(-2*time.Hour), &exitTime)
+	otherStudentVisit := testpkg.CreateTestVisit(t, db, data.Student2.ID, data.ActiveGroup.ID, now.Add(-20*time.Minute), nil)
+	defer func() {
+		testpkg.CleanupTableRecords(t, db, "active.visits", activeVisit.ID, endedVisit.ID, otherStudentVisit.ID)
+	}()
+
+	count, err := repo.CountActiveByStudentID(ctx, data.Student1.ID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestVisitRepository_GetTodayVisitNamesForStudents(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ActiveVisit
+	ctx := testpkg.TenantContext(1)
+	data := createVisitTestData(t, db)
+	defer cleanupVisitTestData(t, db, data)
+
+	visit := testpkg.CreateTestVisit(t, db, data.Student1.ID, data.ActiveGroup.ID, time.Now().Add(-30*time.Minute), nil)
+	defer testpkg.CleanupTableRecords(t, db, "active.visits", visit.ID)
+
+	t.Run("empty input short-circuits", func(t *testing.T) {
+		names, err := repo.GetTodayVisitNamesForStudents(ctx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, names)
+	})
+
+	t.Run("returns activity and room names for today's visits", func(t *testing.T) {
+		names, err := repo.GetTodayVisitNamesForStudents(ctx, []int64{data.Student1.ID, data.Student1.ID})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, names)
+
+		var found bool
+		for _, row := range names {
+			if row.StudentID == data.Student1.ID {
+				found = true
+				assert.NotEmpty(t, row.ActivityGroupName)
+				assert.NotEmpty(t, row.RoomName)
+			}
+		}
+		assert.True(t, found)
+	})
+}
+
+func TestVisitRepository_GetCurrentRoomNamesForStudents(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ActiveVisit
+	ctx := testpkg.TenantContext(1)
+	data := createVisitTestData(t, db)
+	defer cleanupVisitTestData(t, db, data)
+
+	t.Run("empty input returns empty map", func(t *testing.T) {
+		locations, err := repo.GetCurrentRoomNamesForStudents(ctx, nil)
+		require.NoError(t, err)
+		assert.Empty(t, locations)
+	})
+
+	t.Run("returns newest active room per student", func(t *testing.T) {
+		secondRoom := testpkg.CreateTestRoom(t, db, "VisitRoomCurrent")
+		secondActivity := testpkg.CreateTestActivityGroup(t, db, "VisitActivityCurrent")
+		secondGroup := testpkg.CreateTestActiveGroup(t, db, secondActivity.ID, secondRoom.ID)
+		defer func() {
+			cleanupActiveGroupRecords(t, db, secondGroup.ID)
+			testpkg.CleanupActivityFixtures(t, db, secondActivity.ID, secondRoom.ID)
+		}()
+
+		oldExit := time.Now().Add(-90 * time.Minute)
+		oldVisit := testpkg.CreateTestVisit(t, db, data.Student1.ID, data.ActiveGroup.ID, time.Now().Add(-2*time.Hour), &oldExit)
+		newVisit := testpkg.CreateTestVisit(t, db, data.Student1.ID, secondGroup.ID, time.Now().Add(-10*time.Minute), nil)
+		otherVisit := testpkg.CreateTestVisit(t, db, data.Student2.ID, data.ActiveGroup.ID, time.Now().Add(-20*time.Minute), nil)
+		defer func() {
+			testpkg.CleanupTableRecords(t, db, "active.visits", oldVisit.ID, newVisit.ID, otherVisit.ID)
+		}()
+
+		locations, err := repo.GetCurrentRoomNamesForStudents(ctx, []int64{data.Student1.ID, data.Student2.ID})
+
+		require.NoError(t, err)
+		assert.Equal(t, secondRoom.Name, locations[data.Student1.ID])
+		assert.NotEmpty(t, locations[data.Student2.ID])
+	})
+
+	t.Run("ended active group is excluded", func(t *testing.T) {
+		endedAt := time.Now()
+		endedGroup := testpkg.CreateTestActiveGroup(t, db, data.ActivityGroup, data.Room)
+		endedGroup.EndTime = &endedAt
+		_, err := db.NewUpdate().
+			Model(endedGroup).
+			ModelTableExpr(`active.groups`).
+			Column("end_time").
+			Where("id = ?", endedGroup.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+		defer cleanupActiveGroupRecords(t, db, endedGroup.ID)
+
+		visit := testpkg.CreateTestVisit(t, db, data.Student1.ID, endedGroup.ID, time.Now().Add(-10*time.Minute), nil)
+		defer testpkg.CleanupTableRecords(t, db, "active.visits", visit.ID)
+
+		locations, err := repo.GetCurrentRoomNamesForStudents(ctx, []int64{data.Student1.ID})
+
+		require.NoError(t, err)
+		assert.NotContains(t, locations, data.Student1.ID)
+	})
+}
+
+func TestVisitRepository_FindActiveWithStudentDisplayByGroup(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ActiveVisit
+	ctx := testpkg.TenantContext(1)
+	data := createVisitTestData(t, db)
+	defer cleanupVisitTestData(t, db, data)
+
+	educationGroup := testpkg.CreateTestEducationGroup(t, db, "Visit Display Group")
+	_, err := db.NewUpdate().
+		Table("users.students").
+		Set("group_id = ?", educationGroup.ID).
+		Where("id = ?", data.Student1.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = db.NewUpdate().
+			Table("users.students").
+			Set("group_id = NULL").
+			Where("id = ?", data.Student1.ID).
+			Exec(ctx)
+		_, _ = db.NewDelete().
+			Table("education.groups").
+			Where("id = ?", educationGroup.ID).
+			Exec(ctx)
+	}()
+
+	activeVisit := testpkg.CreateTestVisit(t, db, data.Student1.ID, data.ActiveGroup.ID, time.Now().Add(-10*time.Minute), nil)
+	exitTime := time.Now().Add(-5 * time.Minute)
+	endedVisit := testpkg.CreateTestVisit(t, db, data.Student2.ID, data.ActiveGroup.ID, time.Now().Add(-20*time.Minute), &exitTime)
+	defer func() {
+		testpkg.CleanupTableRecords(t, db, "active.visits", activeVisit.ID, endedVisit.ID)
+	}()
+
+	results, err := repo.FindActiveWithStudentDisplayByGroup(ctx, data.ActiveGroup.ID)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	row := results[0]
+	assert.Equal(t, activeVisit.ID, row.VisitID)
+	assert.Equal(t, data.Student1.ID, row.StudentID)
+	assert.Equal(t, data.ActiveGroup.ID, row.ActiveGroupID)
+	assert.Equal(t, "Visit", row.FirstName)
+	assert.Equal(t, "Student1", row.LastName)
+	assert.Equal(t, "1a", row.SchoolClass)
+	require.NotNil(t, row.GroupID)
+	assert.Equal(t, educationGroup.ID, *row.GroupID)
+	assert.Equal(t, educationGroup.Name, row.OGSGroupName)
+	assert.Nil(t, row.ExitTime)
+}
+
 // ============================================================================
 // Visit End Tests
 // ============================================================================

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -137,6 +137,11 @@ type VisitRepository interface {
 	// TransferVisitsFromRecentSessions transfers active visits from recent ended sessions on the same device to a new session
 	TransferVisitsFromRecentSessions(ctx context.Context, newActiveGroupID, deviceID int64) (int, error)
 
+	// TransferActiveVisitsBetweenGroups moves still-open visits from one active
+	// group to another. Ended visits are ignored so stale callers cannot reopen
+	// a checkout by writing an old NULL exit_time back to the row.
+	TransferActiveVisitsBetweenGroups(ctx context.Context, oldActiveGroupID, newActiveGroupID int64) (int, error)
+
 	// Cleanup operations for data retention
 	// DeleteExpiredVisits deletes visits older than retention days for a specific student
 	DeleteExpiredVisits(ctx context.Context, studentID int64, retentionDays int) (int64, error)

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -70,6 +70,12 @@ type SettingsResolver interface {
 	ResolveInt(ctx context.Context, key string) (int, error)
 }
 
+// TimetableBridgeCompleter marks timetable instances that are still bridged
+// to active groups as completed. Implemented by schedule.ActivityInstanceRepository.
+type TimetableBridgeCompleter interface {
+	CompleteActiveByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64, completedAt time.Time) (int64, error)
+}
+
 // ServiceDependencies contains all dependencies required by the active service
 type ServiceDependencies struct {
 	// Active domain repositories
@@ -113,6 +119,9 @@ type ServiceDependencies struct {
 	// SSE events with attendance status/substatus/note.
 	AttendanceSyncer AttendanceSyncer
 
+	// Optional: Timetable bridge cleanup for force-ended IoT sessions.
+	TimetableBridgeCompleter TimetableBridgeCompleter
+
 	// Optional: Structured logger (nil-safe, Phase 2b will add logging calls)
 	Logger *slog.Logger
 }
@@ -155,6 +164,9 @@ type service struct {
 
 	// Optional: Attendance sync (WP-B10)
 	attendanceSyncer AttendanceSyncer
+
+	// Optional: Timetable bridge cleanup for force-ended IoT sessions.
+	timetableBridgeCompleter TimetableBridgeCompleter
 
 	// Optional: Tenant-scoped settings resolver for auto-clear logic.
 	// When nil, auto-clear falls back to the registry default behavior.
@@ -207,30 +219,31 @@ func (s *service) getLogger() *slog.Logger {
 // NewService creates a new active service instance
 func NewService(deps ServiceDependencies) Service {
 	return &service{
-		groupRepo:          deps.GroupRepo,
-		visitRepo:          deps.VisitRepo,
-		supervisorRepo:     deps.SupervisorRepo,
-		combinedGroupRepo:  deps.CombinedGroupRepo,
-		groupMappingRepo:   deps.GroupMappingRepo,
-		crossTenantRepo:    deps.CrossTenantRepo,
-		studentRepo:        deps.StudentRepo,
-		roomRepo:           deps.RoomRepo,
-		activityGroupRepo:  deps.ActivityGroupRepo,
-		activityCatRepo:    deps.ActivityCatRepo,
-		educationGroupRepo: deps.EducationGroupRepo,
-		personRepo:         deps.PersonRepo,
-		deviceRepo:         deps.DeviceRepo,
-		attendanceRepo:     deps.AttendanceRepo,
-		studentStatusRepo:  deps.StudentStatusRepo,
-		educationService:   deps.EducationService,
-		usersService:       deps.UsersService,
-		teacherRepo:        deps.TeacherRepo,
-		staffRepo:          deps.StaffRepo,
-		db:                 deps.DB,
-		broadcaster:        deps.Broadcaster,
-		workSessionService: deps.WorkSessionService,
-		attendanceSyncer:   deps.AttendanceSyncer,
-		logger:             deps.Logger,
+		groupRepo:                deps.GroupRepo,
+		visitRepo:                deps.VisitRepo,
+		supervisorRepo:           deps.SupervisorRepo,
+		combinedGroupRepo:        deps.CombinedGroupRepo,
+		groupMappingRepo:         deps.GroupMappingRepo,
+		crossTenantRepo:          deps.CrossTenantRepo,
+		studentRepo:              deps.StudentRepo,
+		roomRepo:                 deps.RoomRepo,
+		activityGroupRepo:        deps.ActivityGroupRepo,
+		activityCatRepo:          deps.ActivityCatRepo,
+		educationGroupRepo:       deps.EducationGroupRepo,
+		personRepo:               deps.PersonRepo,
+		deviceRepo:               deps.DeviceRepo,
+		attendanceRepo:           deps.AttendanceRepo,
+		studentStatusRepo:        deps.StudentStatusRepo,
+		educationService:         deps.EducationService,
+		usersService:             deps.UsersService,
+		teacherRepo:              deps.TeacherRepo,
+		staffRepo:                deps.StaffRepo,
+		db:                       deps.DB,
+		broadcaster:              deps.Broadcaster,
+		workSessionService:       deps.WorkSessionService,
+		attendanceSyncer:         deps.AttendanceSyncer,
+		timetableBridgeCompleter: deps.TimetableBridgeCompleter,
+		logger:                   deps.Logger,
 	}
 }
 

--- a/backend/services/active/active_service_wrappers_internal_test.go
+++ b/backend/services/active/active_service_wrappers_internal_test.go
@@ -1,0 +1,246 @@
+package active
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	facilityModels "github.com/moto-nrw/project-phoenix/models/facilities"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type attendanceRepoForActiveWrapperTest struct {
+	activeModels.AttendanceRepository
+	has     bool
+	err     error
+	gotDate timezone.Date
+}
+
+func (r *attendanceRepoForActiveWrapperTest) HasOpenAttendanceOn(_ context.Context, date timezone.Date) (bool, error) {
+	r.gotDate = date
+	return r.has, r.err
+}
+
+type roomRepoForActiveWrapperTest struct {
+	facilityModels.RoomRepository
+	rooms  []*facilityModels.Room
+	err    error
+	gotIDs []int64
+}
+
+func (r *roomRepoForActiveWrapperTest) FindByIDs(_ context.Context, ids []int64) ([]*facilityModels.Room, error) {
+	r.gotIDs = append([]int64(nil), ids...)
+	return r.rooms, r.err
+}
+
+type visitRepoForActiveWrapperTest struct {
+	activeModels.VisitRepository
+	rows             []*activeModels.VisitWithStudentDisplay
+	err              error
+	gotActiveGroupID int64
+}
+
+func (r *visitRepoForActiveWrapperTest) FindActiveWithStudentDisplayByGroup(_ context.Context, activeGroupID int64) ([]*activeModels.VisitWithStudentDisplay, error) {
+	r.gotActiveGroupID = activeGroupID
+	return r.rows, r.err
+}
+
+type crossTenantRepoForActiveWrapperTest struct {
+	students           []activeModels.CrossTenantStudent
+	err                error
+	gotHostingTenantID int64
+}
+
+func (r *crossTenantRepoForActiveWrapperTest) FindCrossTenantStudents(_ context.Context, hostingTenantID int64) ([]activeModels.CrossTenantStudent, error) {
+	r.gotHostingTenantID = hostingTenantID
+	return r.students, r.err
+}
+
+type staffRepoForActiveWrapperTest struct {
+	userModels.StaffRepository
+	staff *userModels.Staff
+	err   error
+	gotID interface{}
+}
+
+func (r *staffRepoForActiveWrapperTest) FindByID(_ context.Context, id interface{}) (*userModels.Staff, error) {
+	r.gotID = id
+	return r.staff, r.err
+}
+
+type groupRepoForActiveWrapperTest struct {
+	activeModels.GroupRepository
+	groups map[int64]*activeModels.Group
+	err    error
+	gotIDs []int64
+}
+
+func (r *groupRepoForActiveWrapperTest) FindByIDs(_ context.Context, ids []int64) (map[int64]*activeModels.Group, error) {
+	r.gotIDs = append([]int64(nil), ids...)
+	return r.groups, r.err
+}
+
+func TestActiveServiceThinDelegates(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("has open attendance delegates date and result", func(t *testing.T) {
+		date := timezone.DateFromTime(timezone.Now())
+		repo := &attendanceRepoForActiveWrapperTest{has: true}
+		svc := &service{attendanceRepo: repo}
+
+		hasOpen, err := svc.HasOpenAttendanceOn(ctx, date)
+
+		require.NoError(t, err)
+		assert.True(t, hasOpen)
+		assert.Equal(t, date, repo.gotDate)
+	})
+
+	t.Run("has open attendance preserves repository error", func(t *testing.T) {
+		expectedErr := errors.New("attendance lookup failed")
+		repo := &attendanceRepoForActiveWrapperTest{err: expectedErr}
+		svc := &service{attendanceRepo: repo}
+
+		hasOpen, err := svc.HasOpenAttendanceOn(ctx, timezone.TodayDate())
+
+		require.ErrorIs(t, err, expectedErr)
+		assert.False(t, hasOpen)
+	})
+
+	t.Run("get rooms by ids delegates ids and result", func(t *testing.T) {
+		rooms := []*facilityModels.Room{{Name: "Aula"}}
+		repo := &roomRepoForActiveWrapperTest{rooms: rooms}
+		svc := &service{roomRepo: repo}
+
+		got, err := svc.GetRoomsByIDs(ctx, []int64{10, 20})
+
+		require.NoError(t, err)
+		assert.Equal(t, rooms, got)
+		assert.Equal(t, []int64{10, 20}, repo.gotIDs)
+	})
+
+	t.Run("get active group visits with display delegates active group id", func(t *testing.T) {
+		rows := []*activeModels.VisitWithStudentDisplay{{VisitID: 90, StudentID: 91}}
+		repo := &visitRepoForActiveWrapperTest{rows: rows}
+		svc := &service{visitRepo: repo}
+
+		got, err := svc.GetActiveGroupVisitsWithDisplay(ctx, 80)
+
+		require.NoError(t, err)
+		assert.Equal(t, rows, got)
+		assert.Equal(t, int64(80), repo.gotActiveGroupID)
+	})
+}
+
+func TestGetActiveGroupsByIDs_Branches(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty input returns empty map without repository call", func(t *testing.T) {
+		repo := &groupRepoForActiveWrapperTest{}
+		svc := &service{groupRepo: repo}
+
+		groups, err := svc.GetActiveGroupsByIDs(ctx, nil)
+
+		require.NoError(t, err)
+		assert.Empty(t, groups)
+		assert.Nil(t, repo.gotIDs)
+	})
+
+	t.Run("nil repository map becomes empty map", func(t *testing.T) {
+		repo := &groupRepoForActiveWrapperTest{}
+		svc := &service{groupRepo: repo}
+
+		groups, err := svc.GetActiveGroupsByIDs(ctx, []int64{10, 20})
+
+		require.NoError(t, err)
+		assert.Empty(t, groups)
+		assert.Equal(t, []int64{10, 20}, repo.gotIDs)
+	})
+
+	t.Run("repository error maps to database operation", func(t *testing.T) {
+		repo := &groupRepoForActiveWrapperTest{err: errors.New("group lookup failed")}
+		svc := &service{groupRepo: repo}
+
+		groups, err := svc.GetActiveGroupsByIDs(ctx, []int64{10})
+
+		require.Error(t, err)
+		assert.Nil(t, groups)
+		assert.Contains(t, err.Error(), ErrDatabaseOperation.Error())
+	})
+}
+
+func TestValidateStaffExists_Branches(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		repo := &staffRepoForActiveWrapperTest{staff: &userModels.Staff{}}
+		svc := &service{staffRepo: repo}
+
+		err := svc.validateStaffExists(ctx, 42)
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), repo.gotID)
+	})
+
+	t.Run("database no rows maps to staff not found", func(t *testing.T) {
+		repo := &staffRepoForActiveWrapperTest{
+			err: &modelBase.DatabaseError{Op: "find staff", Err: sql.ErrNoRows},
+		}
+		svc := &service{staffRepo: repo}
+
+		err := svc.validateStaffExists(ctx, 42)
+
+		require.ErrorIs(t, err, ErrStaffNotFound)
+	})
+
+	t.Run("unexpected repository error is preserved", func(t *testing.T) {
+		expectedErr := errors.New("staff repository unavailable")
+		repo := &staffRepoForActiveWrapperTest{err: expectedErr}
+		svc := &service{staffRepo: repo}
+
+		err := svc.validateStaffExists(ctx, 42)
+
+		require.ErrorIs(t, err, expectedErr)
+	})
+}
+
+func TestGetCrossTenantStudents_Branches(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil repository returns empty slice", func(t *testing.T) {
+		svc := &service{}
+
+		students, err := svc.GetCrossTenantStudents(ctx, 10)
+
+		require.NoError(t, err)
+		assert.Empty(t, students)
+	})
+
+	t.Run("repository error is wrapped", func(t *testing.T) {
+		expectedErr := errors.New("cross tenant lookup failed")
+		svc := &service{crossTenantRepo: &crossTenantRepoForActiveWrapperTest{err: expectedErr}}
+
+		students, err := svc.GetCrossTenantStudents(ctx, 10)
+
+		require.Error(t, err)
+		assert.Nil(t, students)
+		assert.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("returns repository rows", func(t *testing.T) {
+		rows := []activeModels.CrossTenantStudent{{StudentID: 20}}
+		repo := &crossTenantRepoForActiveWrapperTest{students: rows}
+		svc := &service{crossTenantRepo: repo}
+
+		students, err := svc.GetCrossTenantStudents(ctx, 10)
+
+		require.NoError(t, err)
+		assert.Equal(t, rows, students)
+		assert.Equal(t, int64(10), repo.gotHostingTenantID)
+	})
+}

--- a/backend/services/active/end_session_unit_test.go
+++ b/backend/services/active/end_session_unit_test.go
@@ -17,8 +17,15 @@ import (
 
 // mockGroupRepository is a minimal mock implementation of active.GroupRepository
 type mockGroupRepository struct {
-	findByIDFunc   func(ctx context.Context, id interface{}) (*active.Group, error)
-	endSessionFunc func(ctx context.Context, id int64) error
+	findByIDFunc                    func(ctx context.Context, id interface{}) (*active.Group, error)
+	listFunc                        func(ctx context.Context, options *base.QueryOptions) ([]*active.Group, error)
+	findActiveByDeviceIDFunc        func(ctx context.Context, deviceID int64) (*active.Group, error)
+	findActiveByGroupIDFunc         func(ctx context.Context, groupID int64) ([]*active.Group, error)
+	endSessionFunc                  func(ctx context.Context, id int64) error
+	updateLastActivityFunc          func(ctx context.Context, id int64, lastActivity time.Time) error
+	findActiveSessionsOlderThanFunc func(ctx context.Context, cutoffTime time.Time) ([]*active.Group, error)
+	checkRoomConflictFunc           func(ctx context.Context, roomID int64, excludeGroupID int64) (bool, *active.Group, error)
+	endSessionsByIDsFunc            func(ctx context.Context, ids []int64) (int64, error)
 }
 
 func (m *mockGroupRepository) Create(ctx context.Context, entity *active.Group) error {
@@ -43,6 +50,9 @@ func (m *mockGroupRepository) Delete(ctx context.Context, id interface{}) error 
 }
 
 func (m *mockGroupRepository) List(ctx context.Context, options *base.QueryOptions) ([]*active.Group, error) {
+	if m.listFunc != nil {
+		return m.listFunc(ctx, options)
+	}
 	return nil, nil
 }
 
@@ -55,6 +65,9 @@ func (m *mockGroupRepository) FindActiveByRoomIDAndDeviceID(ctx context.Context,
 }
 
 func (m *mockGroupRepository) FindActiveByGroupID(ctx context.Context, groupID int64) ([]*active.Group, error) {
+	if m.findActiveByGroupIDFunc != nil {
+		return m.findActiveByGroupIDFunc(ctx, groupID)
+	}
 	return nil, nil
 }
 
@@ -90,6 +103,9 @@ func (m *mockGroupRepository) FindActiveByGroupIDWithDevice(ctx context.Context,
 }
 
 func (m *mockGroupRepository) FindActiveByDeviceID(ctx context.Context, deviceID int64) (*active.Group, error) {
+	if m.findActiveByDeviceIDFunc != nil {
+		return m.findActiveByDeviceIDFunc(ctx, deviceID)
+	}
 	return nil, nil
 }
 
@@ -102,14 +118,23 @@ func (m *mockGroupRepository) FindActiveByDeviceIDWithNames(ctx context.Context,
 }
 
 func (m *mockGroupRepository) CheckRoomConflict(ctx context.Context, roomID int64, excludeGroupID int64) (bool, *active.Group, error) {
+	if m.checkRoomConflictFunc != nil {
+		return m.checkRoomConflictFunc(ctx, roomID, excludeGroupID)
+	}
 	return false, nil, nil
 }
 
 func (m *mockGroupRepository) UpdateLastActivity(ctx context.Context, id int64, lastActivity time.Time) error {
+	if m.updateLastActivityFunc != nil {
+		return m.updateLastActivityFunc(ctx, id, lastActivity)
+	}
 	return nil
 }
 
 func (m *mockGroupRepository) FindActiveSessionsOlderThan(ctx context.Context, cutoffTime time.Time) ([]*active.Group, error) {
+	if m.findActiveSessionsOlderThanFunc != nil {
+		return m.findActiveSessionsOlderThanFunc(ctx, cutoffTime)
+	}
 	return nil, nil
 }
 
@@ -138,6 +163,9 @@ func (m *mockGroupRepository) GetOccupiedActivityGroupIDs(ctx context.Context, g
 }
 
 func (m *mockGroupRepository) EndSessionsByIDs(ctx context.Context, ids []int64) (int64, error) {
+	if m.endSessionsByIDsFunc != nil {
+		return m.endSessionsByIDsFunc(ctx, ids)
+	}
 	return 0, nil
 }
 
@@ -157,6 +185,7 @@ type mockVisitRepository struct {
 	countActiveByGroupIDFunc          func(ctx context.Context, activeGroupID int64) (int, error)
 	listActiveStudentIDsByRoomIDFunc  func(ctx context.Context, roomID int64) ([]int64, error)
 	getTodayVisitNamesFunc            func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error)
+	endVisitsByActiveGroupIDsFunc     func(ctx context.Context, activeGroupIDs []int64) (int64, error)
 }
 
 func (m *mockVisitRepository) Create(ctx context.Context, entity *active.Visit) error {
@@ -283,6 +312,9 @@ func (m *mockVisitRepository) FindActiveVisits(ctx context.Context) ([]*active.V
 }
 
 func (m *mockVisitRepository) EndVisitsByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64) (int64, error) {
+	if m.endVisitsByActiveGroupIDsFunc != nil {
+		return m.endVisitsByActiveGroupIDsFunc(ctx, activeGroupIDs)
+	}
 	return 0, nil
 }
 
@@ -299,11 +331,15 @@ func (m *mockVisitRepository) GetTodayVisitNamesForStudents(ctx context.Context,
 
 // mockGroupSupervisorRepository is a minimal mock implementation of active.GroupSupervisorRepository
 type mockGroupSupervisorRepository struct {
-	findByActiveGroupIDFunc func(ctx context.Context, activeGroupID int64, activeOnly bool) ([]*active.GroupSupervisor, error)
-	endSupervisionFunc      func(ctx context.Context, id int64) error
-	createFunc              func(ctx context.Context, entity *active.GroupSupervisor) error
-	createBulkFunc          func(ctx context.Context, supervisors []*active.GroupSupervisor) error
-	findAllActiveFunc       func(ctx context.Context) ([]*active.GroupSupervisor, error)
+	findByActiveGroupIDFunc  func(ctx context.Context, activeGroupID int64, activeOnly bool) ([]*active.GroupSupervisor, error)
+	endSupervisionFunc       func(ctx context.Context, id int64) error
+	createFunc               func(ctx context.Context, entity *active.GroupSupervisor) error
+	createBulkFunc           func(ctx context.Context, supervisors []*active.GroupSupervisor) error
+	findAllActiveFunc        func(ctx context.Context) ([]*active.GroupSupervisor, error)
+	updateFunc               func(ctx context.Context, entity *active.GroupSupervisor) error
+	endSupervisionsByIDsFunc func(ctx context.Context, activeGroupIDs []int64) (int64, error)
+	findStaleOpenFunc        func(ctx context.Context, before timezone.Date) ([]*active.GroupSupervisor, error)
+	updateColumnsFunc        func(ctx context.Context, supervisor *active.GroupSupervisor, columns ...string) (int64, error)
 }
 
 func (m *mockGroupSupervisorRepository) Create(ctx context.Context, entity *active.GroupSupervisor) error {
@@ -318,6 +354,9 @@ func (m *mockGroupSupervisorRepository) FindByID(ctx context.Context, id interfa
 }
 
 func (m *mockGroupSupervisorRepository) Update(ctx context.Context, entity *active.GroupSupervisor) error {
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, entity)
+	}
 	return nil
 }
 
@@ -367,6 +406,9 @@ func (m *mockGroupSupervisorRepository) CreateBulk(ctx context.Context, supervis
 }
 
 func (m *mockGroupSupervisorRepository) EndSupervisionsByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64) (int64, error) {
+	if m.endSupervisionsByIDsFunc != nil {
+		return m.endSupervisionsByIDsFunc(ctx, activeGroupIDs)
+	}
 	return 0, nil
 }
 
@@ -636,10 +678,16 @@ func (m *mockVisitRepository) ExpiredVisitMonthlyCounts(context.Context) (map[st
 	return nil, nil
 }
 
-func (m *mockGroupSupervisorRepository) FindStaleOpen(context.Context, timezone.Date) ([]*active.GroupSupervisor, error) {
+func (m *mockGroupSupervisorRepository) FindStaleOpen(ctx context.Context, before timezone.Date) ([]*active.GroupSupervisor, error) {
+	if m.findStaleOpenFunc != nil {
+		return m.findStaleOpenFunc(ctx, before)
+	}
 	return nil, nil
 }
 
-func (m *mockGroupSupervisorRepository) UpdateColumns(context.Context, *active.GroupSupervisor, ...string) (int64, error) {
+func (m *mockGroupSupervisorRepository) UpdateColumns(ctx context.Context, supervisor *active.GroupSupervisor, columns ...string) (int64, error) {
+	if m.updateColumnsFunc != nil {
+		return m.updateColumnsFunc(ctx, supervisor, columns...)
+	}
 	return 0, nil
 }

--- a/backend/services/active/end_session_unit_test.go
+++ b/backend/services/active/end_session_unit_test.go
@@ -17,6 +17,7 @@ import (
 
 // mockGroupRepository is a minimal mock implementation of active.GroupRepository
 type mockGroupRepository struct {
+	createFunc                      func(ctx context.Context, entity *active.Group) error
 	findByIDFunc                    func(ctx context.Context, id interface{}) (*active.Group, error)
 	listFunc                        func(ctx context.Context, options *base.QueryOptions) ([]*active.Group, error)
 	findActiveByDeviceIDFunc        func(ctx context.Context, deviceID int64) (*active.Group, error)
@@ -29,6 +30,9 @@ type mockGroupRepository struct {
 }
 
 func (m *mockGroupRepository) Create(ctx context.Context, entity *active.Group) error {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, entity)
+	}
 	return nil
 }
 
@@ -186,6 +190,7 @@ type mockVisitRepository struct {
 	listActiveStudentIDsByRoomIDFunc      func(ctx context.Context, roomID int64) ([]int64, error)
 	getTodayVisitNamesFunc                func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error)
 	endVisitsByActiveGroupIDsFunc         func(ctx context.Context, activeGroupIDs []int64) (int64, error)
+	transferVisitsFromRecentSessionsFunc  func(ctx context.Context, newActiveGroupID, deviceID int64) (int, error)
 	transferActiveVisitsBetweenGroupsFunc func(ctx context.Context, oldActiveGroupID, newActiveGroupID int64) (int, error)
 }
 
@@ -250,6 +255,9 @@ func (m *mockVisitRepository) EndVisit(ctx context.Context, id int64) error {
 }
 
 func (m *mockVisitRepository) TransferVisitsFromRecentSessions(ctx context.Context, newActiveGroupID, deviceID int64) (int, error) {
+	if m.transferVisitsFromRecentSessionsFunc != nil {
+		return m.transferVisitsFromRecentSessionsFunc(ctx, newActiveGroupID, deviceID)
+	}
 	return 0, nil
 }
 

--- a/backend/services/active/end_session_unit_test.go
+++ b/backend/services/active/end_session_unit_test.go
@@ -175,17 +175,18 @@ func (m *mockGroupRepository) AggregateRoomSessions(ctx context.Context, roomID 
 
 // mockVisitRepository is a minimal mock implementation of active.VisitRepository
 type mockVisitRepository struct {
-	findByActiveGroupIDFunc           func(ctx context.Context, activeGroupID int64) ([]*active.Visit, error)
-	findByIDFunc                      func(ctx context.Context, id interface{}) (*active.Visit, error)
-	updateFunc                        func(ctx context.Context, entity *active.Visit) error
-	endVisitFunc                      func(ctx context.Context, id int64) error
-	getCurrentByStudentIDFunc         func(ctx context.Context, studentID int64) (*active.Visit, error)
-	getCurrentByStudentIDWithRoomFunc func(ctx context.Context, studentID int64) (*active.Visit, error)
-	countActiveByRoomIDFunc           func(ctx context.Context, roomID int64) (int, error)
-	countActiveByGroupIDFunc          func(ctx context.Context, activeGroupID int64) (int, error)
-	listActiveStudentIDsByRoomIDFunc  func(ctx context.Context, roomID int64) ([]int64, error)
-	getTodayVisitNamesFunc            func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error)
-	endVisitsByActiveGroupIDsFunc     func(ctx context.Context, activeGroupIDs []int64) (int64, error)
+	findByActiveGroupIDFunc               func(ctx context.Context, activeGroupID int64) ([]*active.Visit, error)
+	findByIDFunc                          func(ctx context.Context, id interface{}) (*active.Visit, error)
+	updateFunc                            func(ctx context.Context, entity *active.Visit) error
+	endVisitFunc                          func(ctx context.Context, id int64) error
+	getCurrentByStudentIDFunc             func(ctx context.Context, studentID int64) (*active.Visit, error)
+	getCurrentByStudentIDWithRoomFunc     func(ctx context.Context, studentID int64) (*active.Visit, error)
+	countActiveByRoomIDFunc               func(ctx context.Context, roomID int64) (int, error)
+	countActiveByGroupIDFunc              func(ctx context.Context, activeGroupID int64) (int, error)
+	listActiveStudentIDsByRoomIDFunc      func(ctx context.Context, roomID int64) ([]int64, error)
+	getTodayVisitNamesFunc                func(ctx context.Context, studentIDs []int64) ([]active.VisitGroupNames, error)
+	endVisitsByActiveGroupIDsFunc         func(ctx context.Context, activeGroupIDs []int64) (int64, error)
+	transferActiveVisitsBetweenGroupsFunc func(ctx context.Context, oldActiveGroupID, newActiveGroupID int64) (int, error)
 }
 
 func (m *mockVisitRepository) Create(ctx context.Context, entity *active.Visit) error {
@@ -249,6 +250,13 @@ func (m *mockVisitRepository) EndVisit(ctx context.Context, id int64) error {
 }
 
 func (m *mockVisitRepository) TransferVisitsFromRecentSessions(ctx context.Context, newActiveGroupID, deviceID int64) (int, error) {
+	return 0, nil
+}
+
+func (m *mockVisitRepository) TransferActiveVisitsBetweenGroups(ctx context.Context, oldActiveGroupID, newActiveGroupID int64) (int, error) {
+	if m.transferActiveVisitsBetweenGroupsFunc != nil {
+		return m.transferActiveVisitsBetweenGroupsFunc(ctx, oldActiveGroupID, newActiveGroupID)
+	}
 	return 0, nil
 }
 

--- a/backend/services/active/session_conflict_test.go
+++ b/backend/services/active/session_conflict_test.go
@@ -95,7 +95,9 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/services"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
@@ -535,6 +537,21 @@ func TestForceStartActivitySessionWithSupervisors(t *testing.T) {
 		require.NoError(t, err)
 		visit := testpkg.CreateTestVisit(t, db, student.ID, session1.ID, time.Now().Add(-15*time.Minute), nil)
 		defer testpkg.CleanupActivityFixtures(t, db, visit.ID)
+		activeGroupID := session1.ID
+		mirroredInstance := &scheduleModels.ActivityInstance{
+			Date:            timezone.TodayDate(),
+			ActivityGroupID: &activityGroup.ID,
+			Title:           "Force Transfer Activity",
+			StartTime:       time.Date(2000, 1, 1, 14, 0, 0, 0, time.UTC),
+			EndTime:         time.Date(2000, 1, 1, 15, 0, 0, 0, time.UTC),
+			RoomID:          room1.ID,
+			Status:          scheduleModels.InstanceStatusActive,
+			ActiveGroupID:   &activeGroupID,
+			IsSpontaneous:   true,
+		}
+		mirroredInstance.SetTenantID(1)
+		require.NoError(t, repositories.NewFactory(db).ActivityInstance.Create(ctx, mirroredInstance))
+		defer testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", mirroredInstance.ID)
 
 		// ACT: Force-start the same activity on device 2
 		session2, err := service.ForceStartActivitySessionWithSupervisors(ctx, activityGroup.ID, device2.ID, []int64{newSupervisor.ID}, &room2.ID)
@@ -557,6 +574,11 @@ func TestForceStartActivitySessionWithSupervisors(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, session2.ID, transferredVisit.ActiveGroupID, "expected active visit to move to new session")
 		assert.Nil(t, transferredVisit.ExitTime, "expected transferred visit to remain open")
+
+		completedMirror, err := repositories.NewFactory(db).ActivityInstance.FindByID(ctx, mirroredInstance.ID)
+		require.NoError(t, err)
+		assert.Equal(t, scheduleModels.InstanceStatusCompleted, completedMirror.Status, "expected old timetable mirror to be completed")
+		assert.NotNil(t, completedMirror.CompletedAt, "expected completed mirror timestamp")
 
 		oldActiveSupervisors, err := service.FindSupervisorsByActiveGroupID(ctx, session1.ID)
 		require.NoError(t, err)

--- a/backend/services/active/session_conflict_test.go
+++ b/backend/services/active/session_conflict_test.go
@@ -92,6 +92,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	"github.com/moto-nrw/project-phoenix/models/active"
@@ -506,6 +507,71 @@ func TestForceStartActivitySessionWithSupervisors(t *testing.T) {
 		endedSession, err := service.GetActiveGroup(ctx, session1.ID)
 		require.NoError(t, err)
 		assert.NotNil(t, endedSession.EndTime, "Expected first session to be ended")
+	})
+
+	t.Run("force start transfers same activity session from another device", func(t *testing.T) {
+		// ARRANGE: Create a running activity on device 1 with an active student and supervisor
+		activityGroup := testpkg.CreateTestActivityGroup(t, db, "Force Transfer Activity")
+		device1 := testpkg.CreateTestDevice(t, db, "force-transfer-device-001")
+		device2 := testpkg.CreateTestDevice(t, db, "force-transfer-device-002")
+		room1 := testpkg.CreateTestRoom(t, db, "Force Transfer Room 1")
+		room2 := testpkg.CreateTestRoom(t, db, "Force Transfer Room 2")
+		student := testpkg.CreateTestStudent(t, db, "ForceTransfer", "Student", "3a")
+		oldSupervisor := testpkg.CreateTestStaff(t, db, "Old", "Supervisor")
+		newSupervisor := testpkg.CreateTestStaff(t, db, "New", "Supervisor")
+
+		defer testpkg.CleanupActivityFixtures(t, db,
+			activityGroup.ID,
+			device1.ID,
+			device2.ID,
+			room1.ID,
+			room2.ID,
+			student.ID,
+			oldSupervisor.ID,
+			newSupervisor.ID,
+		)
+
+		session1, err := service.StartActivitySessionWithSupervisors(ctx, activityGroup.ID, device1.ID, []int64{oldSupervisor.ID}, &room1.ID)
+		require.NoError(t, err)
+		visit := testpkg.CreateTestVisit(t, db, student.ID, session1.ID, time.Now().Add(-15*time.Minute), nil)
+		defer testpkg.CleanupActivityFixtures(t, db, visit.ID)
+
+		// ACT: Force-start the same activity on device 2
+		session2, err := service.ForceStartActivitySessionWithSupervisors(ctx, activityGroup.ID, device2.ID, []int64{newSupervisor.ID}, &room2.ID)
+
+		// ASSERT: The old session is ended and the active state moved to the new session
+		require.NoError(t, err)
+		require.NotNil(t, session2)
+		assert.NotEqual(t, session1.ID, session2.ID)
+
+		endedSession, err := service.GetActiveGroup(ctx, session1.ID)
+		require.NoError(t, err)
+		assert.NotNil(t, endedSession.EndTime, "expected old cross-device activity session to be ended")
+
+		activeSessions, err := service.FindActiveGroupsByGroupID(ctx, activityGroup.ID)
+		require.NoError(t, err)
+		require.Len(t, activeSessions, 1, "expected exactly one active session for the activity")
+		assert.Equal(t, session2.ID, activeSessions[0].ID)
+
+		transferredVisit, err := service.GetVisit(ctx, visit.ID)
+		require.NoError(t, err)
+		assert.Equal(t, session2.ID, transferredVisit.ActiveGroupID, "expected active visit to move to new session")
+		assert.Nil(t, transferredVisit.ExitTime, "expected transferred visit to remain open")
+
+		oldActiveSupervisors, err := service.FindSupervisorsByActiveGroupID(ctx, session1.ID)
+		require.NoError(t, err)
+		assert.Empty(t, oldActiveSupervisors, "expected old session to have no active supervisors")
+
+		newActiveSupervisors, err := service.FindSupervisorsByActiveGroupID(ctx, session2.ID)
+		require.NoError(t, err)
+		require.Len(t, newActiveSupervisors, 2, "expected old and new supervisors on the new session")
+
+		supervisorIDs := map[int64]bool{}
+		for _, supervisor := range newActiveSupervisors {
+			supervisorIDs[supervisor.StaffID] = true
+		}
+		assert.True(t, supervisorIDs[oldSupervisor.ID], "expected old supervisor to transfer")
+		assert.True(t, supervisorIDs[newSupervisor.ID], "expected requested supervisor to remain assigned")
 	})
 
 	t.Run("force start fails with empty supervisor list", func(t *testing.T) {

--- a/backend/services/active/session_conflict_test.go
+++ b/backend/services/active/session_conflict_test.go
@@ -562,6 +562,13 @@ func TestForceStartActivitySessionWithSupervisors(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, oldActiveSupervisors, "expected old session to have no active supervisors")
 
+		allOldSupervisors, err := repositories.NewFactory(db).GroupSupervisor.FindByActiveGroupID(ctx, session1.ID, false)
+		require.NoError(t, err)
+		require.Len(t, allOldSupervisors, 1, "expected old session supervisor history to be preserved")
+		assert.Equal(t, oldSupervisor.ID, allOldSupervisors[0].StaffID)
+		assert.Equal(t, session1.ID, allOldSupervisors[0].GroupID)
+		assert.NotNil(t, allOldSupervisors[0].EndDate, "expected old supervisor row to be ended, not moved")
+
 		newActiveSupervisors, err := service.FindSupervisorsByActiveGroupID(ctx, session2.ID)
 		require.NoError(t, err)
 		require.Len(t, newActiveSupervisors, 2, "expected old and new supervisors on the new session")
@@ -572,6 +579,56 @@ func TestForceStartActivitySessionWithSupervisors(t *testing.T) {
 		}
 		assert.True(t, supervisorIDs[oldSupervisor.ID], "expected old supervisor to transfer")
 		assert.True(t, supervisorIDs[newSupervisor.ID], "expected requested supervisor to remain assigned")
+	})
+
+	t.Run("force start deduplicates single-supervisor role casing during transfer", func(t *testing.T) {
+		// ARRANGE: Start through the single-supervisor path, which stores role "Supervisor".
+		activityGroup := testpkg.CreateTestActivityGroup(t, db, "Force Transfer Same Supervisor Activity")
+		device1 := testpkg.CreateTestDevice(t, db, "force-transfer-same-supervisor-device-001")
+		device2 := testpkg.CreateTestDevice(t, db, "force-transfer-same-supervisor-device-002")
+		room1 := testpkg.CreateTestRoom(t, db, "Force Transfer Same Supervisor Room 1")
+		room2 := testpkg.CreateTestRoom(t, db, "Force Transfer Same Supervisor Room 2")
+		staff := testpkg.CreateTestStaff(t, db, "Same", "Supervisor")
+
+		defer testpkg.CleanupActivityFixtures(t, db,
+			activityGroup.ID,
+			device1.ID,
+			device2.ID,
+			room1.ID,
+			room2.ID,
+			staff.ID,
+		)
+
+		session1, err := service.StartActivitySession(ctx, activityGroup.ID, device1.ID, staff.ID, &room1.ID)
+		require.NoError(t, err)
+
+		// ACT: Force-start with the same staff member through the multi-supervisor path,
+		// which creates role "supervisor" before transfer runs.
+		session2, err := service.ForceStartActivitySessionWithSupervisors(ctx, activityGroup.ID, device2.ID, []int64{staff.ID}, &room2.ID)
+
+		// ASSERT: The old row is ended in place, and the new session has one active row for the staff member.
+		require.NoError(t, err)
+		require.NotNil(t, session2)
+		assert.NotEqual(t, session1.ID, session2.ID)
+
+		oldActiveSupervisors, err := service.FindSupervisorsByActiveGroupID(ctx, session1.ID)
+		require.NoError(t, err)
+		assert.Empty(t, oldActiveSupervisors, "expected old session to have no active supervisors")
+
+		allOldSupervisors, err := repositories.NewFactory(db).GroupSupervisor.FindByActiveGroupID(ctx, session1.ID, false)
+		require.NoError(t, err)
+		require.Len(t, allOldSupervisors, 1, "expected supervisor row to remain on old session")
+		assert.Equal(t, staff.ID, allOldSupervisors[0].StaffID)
+		assert.Equal(t, session1.ID, allOldSupervisors[0].GroupID)
+		assert.Equal(t, "Supervisor", allOldSupervisors[0].Role)
+		assert.NotNil(t, allOldSupervisors[0].EndDate, "expected old supervisor row to be ended")
+
+		newActiveSupervisors, err := service.FindSupervisorsByActiveGroupID(ctx, session2.ID)
+		require.NoError(t, err)
+		require.Len(t, newActiveSupervisors, 1, "expected role casing mismatch not to duplicate the same staff member")
+		assert.Equal(t, staff.ID, newActiveSupervisors[0].StaffID)
+		assert.Equal(t, session2.ID, newActiveSupervisors[0].GroupID)
+		assert.Equal(t, "supervisor", newActiveSupervisors[0].Role)
 	})
 
 	t.Run("force start fails with empty supervisor list", func(t *testing.T) {

--- a/backend/services/active/session_service.go
+++ b/backend/services/active/session_service.go
@@ -73,13 +73,15 @@ func (s *service) assignSupervisorNonCritical(ctx context.Context, groupID, staf
 		StartDate: timezone.DateFromTime(startDate),
 	}
 	supervisor.SetTenantID(tenant.FromContext(ctx))
-	if err := s.supervisorRepo.Create(ctx, supervisor); err != nil {
+	s.runBestEffortDB(ctx, "assign_supervisor", func() error {
+		return s.supervisorRepo.Create(ctx, supervisor)
+	}, func(err error) {
 		s.getLogger().WarnContext(ctx, "supervisor assignment failed",
 			slog.Int64("staff_id", staffID),
 			slog.Int64("group_id", groupID),
 			slog.String("error", err.Error()),
 		)
-	}
+	})
 
 	// NFC auto-check-in: ensure staff member has a work session for today.
 	// This path runs from the IoT supervisor flow (kiosk-driven activity
@@ -91,19 +93,24 @@ func (s *service) assignSupervisorNonCritical(ctx context.Context, groupID, staf
 	// matching NFC stamp), so log it at INFO so a dispute can be traced
 	// later.
 	if s.workSessionService != nil {
-		session, err := s.workSessionService.EnsureCheckedIn(ctx, staffID, active.WorkSessionSourceNFC)
-		switch {
-		case err != nil:
+		s.runBestEffortDB(ctx, "nfc_auto_checkin", func() error {
+			session, err := s.workSessionService.EnsureCheckedIn(ctx, staffID, active.WorkSessionSourceNFC)
+			if err != nil {
+				return err
+			}
+			if session == nil {
+				s.getLogger().InfoContext(ctx, "NFC auto-check-in skipped: staff already checked out today",
+					slog.Int64("staff_id", staffID),
+					slog.Int64("group_id", groupID),
+				)
+			}
+			return nil
+		}, func(err error) {
 			s.getLogger().WarnContext(ctx, "NFC auto-check-in failed",
 				slog.Int64("staff_id", staffID),
 				slog.String("error", err.Error()),
 			)
-		case session == nil:
-			s.getLogger().InfoContext(ctx, "NFC auto-check-in skipped: staff already checked out today",
-				slog.Int64("staff_id", staffID),
-				slog.Int64("group_id", groupID),
-			)
-		}
+		})
 	}
 }
 
@@ -284,13 +291,15 @@ func (s *service) assignMultipleSupervisorsNonCritical(ctx context.Context, grou
 			StartDate: timezone.DateFromTime(startDate),
 		}
 		supervisor.SetTenantID(tenant.FromContext(ctx))
-		if err := s.supervisorRepo.Create(ctx, supervisor); err != nil {
+		s.runBestEffortDB(ctx, "assign_supervisor", func() error {
+			return s.supervisorRepo.Create(ctx, supervisor)
+		}, func(err error) {
 			s.getLogger().WarnContext(ctx, "supervisor assignment failed",
 				slog.Int64("staff_id", staffID),
 				slog.Int64("group_id", groupID),
 				slog.String("error", err.Error()),
 			)
-		}
+		})
 
 		// NFC auto-check-in (kiosk-driven multi-supervisor flow). Same
 		// asymmetric-audit caveat as the single-supervisor path: if the
@@ -298,43 +307,64 @@ func (s *service) assignMultipleSupervisorsNonCritical(ctx context.Context, grou
 		// (nil, nil) and we log it so a dispute over the supervisor row
 		// without a matching NFC stamp can be traced later.
 		if s.workSessionService != nil {
-			session, err := s.workSessionService.EnsureCheckedIn(ctx, staffID, active.WorkSessionSourceNFC)
-			switch {
-			case err != nil:
+			s.runBestEffortDB(ctx, "nfc_auto_checkin", func() error {
+				session, err := s.workSessionService.EnsureCheckedIn(ctx, staffID, active.WorkSessionSourceNFC)
+				if err != nil {
+					return err
+				}
+				if session == nil {
+					s.getLogger().InfoContext(ctx, "NFC auto-check-in skipped: staff already checked out today",
+						slog.Int64("staff_id", staffID),
+						slog.Int64("group_id", groupID),
+					)
+				}
+				return nil
+			}, func(err error) {
 				s.getLogger().WarnContext(ctx, "NFC auto-check-in failed",
 					slog.Int64("staff_id", staffID),
 					slog.Int64("group_id", groupID),
 					slog.String("error", err.Error()),
 				)
-			case session == nil:
-				s.getLogger().InfoContext(ctx, "NFC auto-check-in skipped: staff already checked out today",
-					slog.Int64("staff_id", staffID),
-					slog.Int64("group_id", groupID),
-				)
-			}
+			})
 		}
 	}
 }
 
 // ForceStartActivitySession starts an activity session with override capability
 func (s *service) ForceStartActivitySession(ctx context.Context, activityID, deviceID, staffID int64, roomID *int64) (*active.Group, error) {
-	if err := s.endExistingDeviceSessionIfPresent(ctx, deviceID); err != nil {
-		return nil, &ActiveError{Op: "ForceStartActivitySession", Err: err}
-	}
+	const operation = "ForceStartActivitySession"
+	txHandler := modelBase.NewTxHandler(s.db)
 
-	finalRoomID := s.determineRoomIDWithoutConflictCheck(ctx, activityID, roomID)
+	var newGroup *active.Group
+	err := txHandler.RunInTx(ctx, func(txCtx context.Context, tx bun.Tx) error {
+		if err := s.acquireActivitySessionLock(txCtx, tx, activityID, operation); err != nil {
+			return err
+		}
 
-	newGroup, err := s.createSessionWithSupervisorForceStart(ctx, activityID, deviceID, staffID, finalRoomID)
+		deviceEndedSessionID, err := s.endExistingDeviceSessionForForceStart(txCtx, deviceID)
+		if err != nil {
+			return &ActiveError{Op: operation, Err: err}
+		}
+
+		finalRoomID := s.determineRoomIDWithoutConflictCheck(txCtx, activityID, roomID)
+
+		group, err := s.createSessionWithSupervisorForceStart(txCtx, activityID, deviceID, staffID, finalRoomID)
+		if err != nil {
+			return &ActiveError{Op: operation, Err: err}
+		}
+
+		if err := s.completeForceEndedTimetableMirrors(txCtx, appendActiveGroupID(nil, deviceEndedSessionID)); err != nil {
+			return &ActiveError{Op: operation, Err: err}
+		}
+
+		newGroup = group
+		return nil
+	})
 	if err != nil {
-		return nil, &ActiveError{Op: "ForceStartActivitySession", Err: err}
+		return nil, err
 	}
 
 	return newGroup, nil
-}
-
-// endExistingDeviceSessionIfPresent ends any existing session for the device using simple cleanup
-func (s *service) endExistingDeviceSessionIfPresent(ctx context.Context, deviceID int64) error {
-	return s.endExistingDeviceSession(ctx, deviceID, false)
 }
 
 // determineRoomIDWithoutConflictCheck determines room ID without checking conflicts (for force start)
@@ -395,10 +425,49 @@ func (s *service) createSessionBase(ctx context.Context, activityID, deviceID, r
 // updateDeviceLocation updates the device's room_id to track its last-used location.
 // This is fire-and-forget: a failure here should not block session creation.
 func (s *service) updateDeviceLocation(ctx context.Context, deviceID, roomID int64) {
-	if err := s.deviceRepo.UpdateRoomID(ctx, deviceID, roomID); err != nil {
+	s.runBestEffortDB(ctx, "update_device_location", func() error {
+		return s.deviceRepo.UpdateRoomID(ctx, deviceID, roomID)
+	}, func(err error) {
 		s.getLogger().WarnContext(ctx, "failed to update device location",
 			slog.Int64("device_id", deviceID),
 			slog.Int64("room_id", roomID),
+			slog.String("error", err.Error()),
+		)
+	})
+}
+
+func (s *service) runBestEffortDB(ctx context.Context, label string, fn func() error, logFailure func(error)) {
+	tx, ok := modelBase.TxFromContext(ctx)
+	if !ok || tx == nil {
+		if err := fn(); err != nil {
+			logFailure(err)
+		}
+		return
+	}
+
+	savepointName := "sp_active_" + label
+	if _, err := (*tx).ExecContext(ctx, "SAVEPOINT "+savepointName); err != nil {
+		s.getLogger().WarnContext(ctx, "failed to create savepoint for best-effort operation",
+			slog.String("operation", label),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	if err := fn(); err != nil {
+		logFailure(err)
+		if _, rollbackErr := (*tx).ExecContext(ctx, "ROLLBACK TO SAVEPOINT "+savepointName); rollbackErr != nil {
+			s.getLogger().WarnContext(ctx, "failed to rollback savepoint for best-effort operation",
+				slog.String("operation", label),
+				slog.String("error", rollbackErr.Error()),
+			)
+		}
+		return
+	}
+
+	if _, err := (*tx).ExecContext(ctx, "RELEASE SAVEPOINT "+savepointName); err != nil {
+		s.getLogger().WarnContext(ctx, "failed to release savepoint for best-effort operation",
+			slog.String("operation", label),
 			slog.String("error", err.Error()),
 		)
 	}
@@ -439,7 +508,8 @@ func (s *service) forceStartActivitySessionTx(ctx context.Context, activityID, d
 		// without ending visits, so TransferVisitsFromRecentSessions can move them
 		// to the new session. Using fullCleanup=true would set exit_time on all visits
 		// first, causing the transfer to find nothing and losing all checked-in students.
-		if err := s.endExistingDeviceSessionIfPresent(txCtx, deviceID); err != nil {
+		deviceEndedSessionID, err := s.endExistingDeviceSessionForForceStart(txCtx, deviceID)
+		if err != nil {
 			return &ActiveError{Op: operation, Err: err}
 		}
 
@@ -447,6 +517,8 @@ func (s *service) forceStartActivitySessionTx(ctx context.Context, activityID, d
 		if err != nil {
 			return &ActiveError{Op: operation, Err: err}
 		}
+		endedSessionIDs := appendActiveGroupID(nil, deviceEndedSessionID)
+		endedSessionIDs = appendActiveGroupIDs(endedSessionIDs, conflictingSessionIDs...)
 
 		finalRoomID, err := s.determineRoomIDForForceStart(txCtx, activityID, roomID)
 		if err != nil {
@@ -462,9 +534,48 @@ func (s *service) forceStartActivitySessionTx(ctx context.Context, activityID, d
 			return &ActiveError{Op: operation, Err: err}
 		}
 
+		if err := s.completeForceEndedTimetableMirrors(txCtx, endedSessionIDs); err != nil {
+			return &ActiveError{Op: operation, Err: err}
+		}
+
 		*newGroup = group
 		return nil
 	})
+}
+
+func appendActiveGroupID(ids []int64, id int64) []int64 {
+	if id <= 0 {
+		return ids
+	}
+	for _, existing := range ids {
+		if existing == id {
+			return ids
+		}
+	}
+	return append(ids, id)
+}
+
+func appendActiveGroupIDs(ids []int64, more ...int64) []int64 {
+	for _, id := range more {
+		ids = appendActiveGroupID(ids, id)
+	}
+	return ids
+}
+
+func (s *service) completeForceEndedTimetableMirrors(ctx context.Context, endedSessionIDs []int64) error {
+	if s.timetableBridgeCompleter == nil || len(endedSessionIDs) == 0 {
+		return nil
+	}
+	completed, err := s.timetableBridgeCompleter.CompleteActiveByActiveGroupIDs(ctx, endedSessionIDs, time.Now())
+	if err != nil {
+		return fmt.Errorf("complete force-ended timetable mirrors: %w", err)
+	}
+	if completed > 0 {
+		s.getLogger().InfoContext(ctx, "completed timetable mirrors for force-ended activity sessions",
+			slog.Int64("count", completed),
+		)
+	}
+	return nil
 }
 
 func (s *service) endExistingActivitySessionsForForceStart(ctx context.Context, activityID int64) ([]int64, error) {
@@ -485,6 +596,23 @@ func (s *service) endExistingActivitySessionsForForceStart(ctx context.Context, 
 	}
 
 	return endedIDs, nil
+}
+
+func (s *service) endExistingDeviceSessionForForceStart(ctx context.Context, deviceID int64) (int64, error) {
+	existingSession, err := s.groupRepo.FindActiveByDeviceID(ctx, deviceID)
+	if err != nil {
+		return 0, err
+	}
+
+	if existingSession == nil {
+		return 0, nil
+	}
+
+	if err := s.groupRepo.EndSession(ctx, existingSession.ID); err != nil {
+		return 0, err
+	}
+
+	return existingSession.ID, nil
 }
 
 func (s *service) transferForceStartedActivityState(ctx context.Context, oldGroupIDs []int64, newGroupID int64, newGroupStartTime time.Time) error {
@@ -513,24 +641,7 @@ func (s *service) transferForceStartedActivityState(ctx context.Context, oldGrou
 }
 
 func (s *service) transferActiveVisitsBetweenGroups(ctx context.Context, oldGroupID, newGroupID int64) (int, error) {
-	visits, err := s.visitRepo.FindByActiveGroupID(ctx, oldGroupID)
-	if err != nil {
-		return 0, err
-	}
-
-	transferred := 0
-	for _, visit := range visits {
-		if visit == nil || visit.ExitTime != nil {
-			continue
-		}
-		visit.ActiveGroupID = newGroupID
-		if err := s.visitRepo.Update(ctx, visit); err != nil {
-			return transferred, err
-		}
-		transferred++
-	}
-
-	return transferred, nil
+	return s.visitRepo.TransferActiveVisitsBetweenGroups(ctx, oldGroupID, newGroupID)
 }
 
 func (s *service) transferActiveSupervisorsBetweenGroups(ctx context.Context, oldGroupID, newGroupID int64, newGroupStartTime time.Time) (int, error) {

--- a/backend/services/active/session_service.go
+++ b/backend/services/active/session_service.go
@@ -203,13 +203,8 @@ func (s *service) executeSessionStart(ctx context.Context, activityID, deviceID 
 	txHandler := modelBase.NewTxHandler(s.db)
 
 	return txHandler.RunInTx(ctx, func(txCtx context.Context, tx bun.Tx) error {
-		// Acquire advisory lock on (tenant_id, activity_id) to serialize concurrent session starts
-		// This prevents race conditions where two requests both pass conflict check before either creates a session
-		// Using two-argument form ensures locks are scoped per tenant and cannot collide across tenants
-		// The lock is automatically released when the transaction commits or rolls back
-		tenantID := tenant.FromContext(txCtx)
-		if _, err := tx.ExecContext(txCtx, "SELECT pg_advisory_xact_lock(?, ?)", tenantID, activityID); err != nil {
-			return &ActiveError{Op: operation, Err: fmt.Errorf("failed to acquire activity lock: %w", err)}
+		if err := s.acquireActivitySessionLock(txCtx, tx, activityID, operation); err != nil {
+			return err
 		}
 
 		// Check for conflicts inside the transaction with the lock held
@@ -229,6 +224,16 @@ func (s *service) executeSessionStart(ctx context.Context, activityID, deviceID 
 		_, err = createSession(txCtx, finalRoomID)
 		return err
 	})
+}
+
+func (s *service) acquireActivitySessionLock(ctx context.Context, tx bun.Tx, activityID int64, operation string) error {
+	// Acquire advisory lock on (tenant_id, activity_id) to serialize concurrent session starts.
+	// The two-argument form scopes locks per tenant; PostgreSQL releases it when the tx ends.
+	tenantID := tenant.FromContext(ctx)
+	if _, err := tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock(?, ?)", tenantID, activityID); err != nil {
+		return &ActiveError{Op: operation, Err: fmt.Errorf("failed to acquire activity lock: %w", err)}
+	}
+	return nil
 }
 
 // createSessionWithMultipleSupervisors creates a new session with multiple supervisors and transfers visits
@@ -411,25 +416,170 @@ func (s *service) ForceStartActivitySessionWithSupervisors(ctx context.Context, 
 		return nil, err
 	}
 
-	// Use simple cleanup (fullCleanup=false) to only mark the group as ended
-	// without ending visits, so TransferVisitsFromRecentSessions can move them
-	// to the new session. Using fullCleanup=true would set exit_time on all visits
-	// first, causing the transfer to find nothing and losing all checked-in students.
-	if err := s.endExistingDeviceSessionIfPresent(ctx, deviceID); err != nil {
-		return nil, &ActiveError{Op: "ForceStartActivitySessionWithSupervisors", Err: err}
-	}
-
-	finalRoomID, err := s.determineRoomIDForForceStart(ctx, activityID, roomID)
+	var newGroup *active.Group
+	err := s.forceStartActivitySessionTx(ctx, activityID, deviceID, supervisorIDs, roomID, &newGroup)
 	if err != nil {
-		return nil, &ActiveError{Op: "ForceStartActivitySessionWithSupervisors", Err: err}
-	}
-
-	newGroup, err := s.createSessionWithMultipleSupervisors(ctx, activityID, deviceID, supervisorIDs, finalRoomID)
-	if err != nil {
-		return nil, &ActiveError{Op: "ForceStartActivitySessionWithSupervisors", Err: err}
+		return nil, err
 	}
 
 	return newGroup, nil
+}
+
+func (s *service) forceStartActivitySessionTx(ctx context.Context, activityID, deviceID int64, supervisorIDs []int64, roomID *int64, newGroup **active.Group) error {
+	const operation = "ForceStartActivitySessionWithSupervisors"
+	txHandler := modelBase.NewTxHandler(s.db)
+
+	return txHandler.RunInTx(ctx, func(txCtx context.Context, tx bun.Tx) error {
+		if err := s.acquireActivitySessionLock(txCtx, tx, activityID, operation); err != nil {
+			return err
+		}
+
+		// Use simple cleanup (fullCleanup=false) to only mark the group as ended
+		// without ending visits, so TransferVisitsFromRecentSessions can move them
+		// to the new session. Using fullCleanup=true would set exit_time on all visits
+		// first, causing the transfer to find nothing and losing all checked-in students.
+		if err := s.endExistingDeviceSessionIfPresent(txCtx, deviceID); err != nil {
+			return &ActiveError{Op: operation, Err: err}
+		}
+
+		conflictingSessionIDs, err := s.endExistingActivitySessionsForForceStart(txCtx, activityID)
+		if err != nil {
+			return &ActiveError{Op: operation, Err: err}
+		}
+
+		finalRoomID, err := s.determineRoomIDForForceStart(txCtx, activityID, roomID)
+		if err != nil {
+			return &ActiveError{Op: operation, Err: err}
+		}
+
+		group, err := s.createSessionWithMultipleSupervisors(txCtx, activityID, deviceID, supervisorIDs, finalRoomID)
+		if err != nil {
+			return &ActiveError{Op: operation, Err: err}
+		}
+
+		if err := s.transferForceStartedActivityState(txCtx, conflictingSessionIDs, group.ID); err != nil {
+			return &ActiveError{Op: operation, Err: err}
+		}
+
+		*newGroup = group
+		return nil
+	})
+}
+
+func (s *service) endExistingActivitySessionsForForceStart(ctx context.Context, activityID int64) ([]int64, error) {
+	existingSessions, err := s.groupRepo.FindActiveByGroupID(ctx, activityID)
+	if err != nil {
+		return nil, err
+	}
+
+	endedIDs := make([]int64, 0, len(existingSessions))
+	for _, session := range existingSessions {
+		if session == nil || session.ID <= 0 {
+			continue
+		}
+		if err := s.groupRepo.EndSession(ctx, session.ID); err != nil {
+			return nil, err
+		}
+		endedIDs = append(endedIDs, session.ID)
+	}
+
+	return endedIDs, nil
+}
+
+func (s *service) transferForceStartedActivityState(ctx context.Context, oldGroupIDs []int64, newGroupID int64) error {
+	for _, oldGroupID := range oldGroupIDs {
+		visitsTransferred, err := s.transferActiveVisitsBetweenGroups(ctx, oldGroupID, newGroupID)
+		if err != nil {
+			return err
+		}
+
+		supervisorsTransferred, err := s.transferActiveSupervisorsBetweenGroups(ctx, oldGroupID, newGroupID)
+		if err != nil {
+			return err
+		}
+
+		if visitsTransferred > 0 || supervisorsTransferred > 0 {
+			s.getLogger().InfoContext(ctx, "transferred state from force-ended activity session",
+				slog.Int64("old_active_group_id", oldGroupID),
+				slog.Int64("new_active_group_id", newGroupID),
+				slog.Int("visits_transferred", visitsTransferred),
+				slog.Int("supervisors_transferred", supervisorsTransferred),
+			)
+		}
+	}
+
+	return nil
+}
+
+func (s *service) transferActiveVisitsBetweenGroups(ctx context.Context, oldGroupID, newGroupID int64) (int, error) {
+	visits, err := s.visitRepo.FindByActiveGroupID(ctx, oldGroupID)
+	if err != nil {
+		return 0, err
+	}
+
+	transferred := 0
+	for _, visit := range visits {
+		if visit == nil || visit.ExitTime != nil {
+			continue
+		}
+		visit.ActiveGroupID = newGroupID
+		if err := s.visitRepo.Update(ctx, visit); err != nil {
+			return transferred, err
+		}
+		transferred++
+	}
+
+	return transferred, nil
+}
+
+func (s *service) transferActiveSupervisorsBetweenGroups(ctx context.Context, oldGroupID, newGroupID int64) (int, error) {
+	oldSupervisors, err := s.supervisorRepo.FindByActiveGroupID(ctx, oldGroupID, true)
+	if err != nil {
+		return 0, err
+	}
+
+	newSupervisors, err := s.supervisorRepo.FindByActiveGroupID(ctx, newGroupID, true)
+	if err != nil {
+		return 0, err
+	}
+
+	existing := make(map[supervisorIdentity]bool, len(newSupervisors))
+	for _, supervisor := range newSupervisors {
+		if supervisor == nil {
+			continue
+		}
+		existing[supervisorIdentity{staffID: supervisor.StaffID, role: supervisor.Role}] = true
+	}
+
+	transferred := 0
+	for _, supervisor := range oldSupervisors {
+		if supervisor == nil {
+			continue
+		}
+
+		identity := supervisorIdentity{staffID: supervisor.StaffID, role: supervisor.Role}
+		if existing[identity] {
+			if err := s.supervisorRepo.EndSupervision(ctx, supervisor.ID); err != nil {
+				return transferred, err
+			}
+			continue
+		}
+
+		supervisor.GroupID = newGroupID
+		supervisor.UpdatedAt = time.Now()
+		if _, err := s.supervisorRepo.UpdateColumns(ctx, supervisor, "group_id", "updated_at"); err != nil {
+			return transferred, err
+		}
+		existing[identity] = true
+		transferred++
+	}
+
+	return transferred, nil
+}
+
+type supervisorIdentity struct {
+	staffID int64
+	role    string
 }
 
 // endExistingDeviceSession ends any existing session for the device

--- a/backend/services/active/session_service.go
+++ b/backend/services/active/session_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/uptrace/bun"
@@ -457,7 +458,7 @@ func (s *service) forceStartActivitySessionTx(ctx context.Context, activityID, d
 			return &ActiveError{Op: operation, Err: err}
 		}
 
-		if err := s.transferForceStartedActivityState(txCtx, conflictingSessionIDs, group.ID); err != nil {
+		if err := s.transferForceStartedActivityState(txCtx, conflictingSessionIDs, group.ID, group.StartTime); err != nil {
 			return &ActiveError{Op: operation, Err: err}
 		}
 
@@ -486,14 +487,14 @@ func (s *service) endExistingActivitySessionsForForceStart(ctx context.Context, 
 	return endedIDs, nil
 }
 
-func (s *service) transferForceStartedActivityState(ctx context.Context, oldGroupIDs []int64, newGroupID int64) error {
+func (s *service) transferForceStartedActivityState(ctx context.Context, oldGroupIDs []int64, newGroupID int64, newGroupStartTime time.Time) error {
 	for _, oldGroupID := range oldGroupIDs {
 		visitsTransferred, err := s.transferActiveVisitsBetweenGroups(ctx, oldGroupID, newGroupID)
 		if err != nil {
 			return err
 		}
 
-		supervisorsTransferred, err := s.transferActiveSupervisorsBetweenGroups(ctx, oldGroupID, newGroupID)
+		supervisorsTransferred, err := s.transferActiveSupervisorsBetweenGroups(ctx, oldGroupID, newGroupID, newGroupStartTime)
 		if err != nil {
 			return err
 		}
@@ -532,7 +533,7 @@ func (s *service) transferActiveVisitsBetweenGroups(ctx context.Context, oldGrou
 	return transferred, nil
 }
 
-func (s *service) transferActiveSupervisorsBetweenGroups(ctx context.Context, oldGroupID, newGroupID int64) (int, error) {
+func (s *service) transferActiveSupervisorsBetweenGroups(ctx context.Context, oldGroupID, newGroupID int64, newGroupStartTime time.Time) (int, error) {
 	oldSupervisors, err := s.supervisorRepo.FindByActiveGroupID(ctx, oldGroupID, true)
 	if err != nil {
 		return 0, err
@@ -543,12 +544,12 @@ func (s *service) transferActiveSupervisorsBetweenGroups(ctx context.Context, ol
 		return 0, err
 	}
 
-	existing := make(map[supervisorIdentity]bool, len(newSupervisors))
+	existingStaffIDs := make(map[int64]bool, len(newSupervisors))
 	for _, supervisor := range newSupervisors {
 		if supervisor == nil {
 			continue
 		}
-		existing[supervisorIdentity{staffID: supervisor.StaffID, role: supervisor.Role}] = true
+		existingStaffIDs[supervisor.StaffID] = true
 	}
 
 	transferred := 0
@@ -557,29 +558,36 @@ func (s *service) transferActiveSupervisorsBetweenGroups(ctx context.Context, ol
 			continue
 		}
 
-		identity := supervisorIdentity{staffID: supervisor.StaffID, role: supervisor.Role}
-		if existing[identity] {
-			if err := s.supervisorRepo.EndSupervision(ctx, supervisor.ID); err != nil {
-				return transferred, err
-			}
+		if err := s.supervisorRepo.EndSupervision(ctx, supervisor.ID); err != nil {
+			return transferred, err
+		}
+
+		if existingStaffIDs[supervisor.StaffID] {
 			continue
 		}
 
-		supervisor.GroupID = newGroupID
-		supervisor.UpdatedAt = time.Now()
-		if _, err := s.supervisorRepo.UpdateColumns(ctx, supervisor, "group_id", "updated_at"); err != nil {
+		transferredSupervisor := &active.GroupSupervisor{
+			StaffID:   supervisor.StaffID,
+			GroupID:   newGroupID,
+			Role:      normalizeTransferredSupervisorRole(supervisor.Role),
+			StartDate: timezone.DateFromTime(newGroupStartTime),
+		}
+		transferredSupervisor.SetTenantID(tenant.FromContext(ctx))
+		if err := s.supervisorRepo.Create(ctx, transferredSupervisor); err != nil {
 			return transferred, err
 		}
-		existing[identity] = true
+		existingStaffIDs[supervisor.StaffID] = true
 		transferred++
 	}
 
 	return transferred, nil
 }
 
-type supervisorIdentity struct {
-	staffID int64
-	role    string
+func normalizeTransferredSupervisorRole(role string) string {
+	if strings.EqualFold(role, "supervisor") {
+		return "supervisor"
+	}
+	return role
 }
 
 // endExistingDeviceSession ends any existing session for the device

--- a/backend/services/active/session_service_internal_test.go
+++ b/backend/services/active/session_service_internal_test.go
@@ -8,12 +8,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	configModels "github.com/moto-nrw/project-phoenix/models/config"
 	iotModels "github.com/moto-nrw/project-phoenix/models/iot"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
 )
 
 type deviceRepoForSessionUnitTest struct {
@@ -90,6 +95,106 @@ func (s *settingsResolverForSessionUnitTest) ResolveString(context.Context, stri
 }
 func (s *settingsResolverForSessionUnitTest) ResolveInt(context.Context, string) (int, error) {
 	return s.intVal, s.intErr
+}
+
+type workSessionServiceForSessionUnitTest struct {
+	ensureCheckedInFunc func(ctx context.Context, staffID int64, source string) (*activeModels.WorkSession, error)
+}
+
+func (w *workSessionServiceForSessionUnitTest) CheckIn(context.Context, int64, string, string) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) CheckOut(context.Context, int64) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) StartBreak(context.Context, int64, *int) (*activeModels.WorkSessionBreak, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) EndBreak(context.Context, int64) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) GetSessionBreaks(context.Context, int64, int64) ([]*activeModels.WorkSessionBreak, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) UpdateSession(context.Context, int64, int64, SessionUpdateRequest) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) UpdateSessionAsAdmin(context.Context, int64, int64, int64, SessionUpdateRequest) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) CreateSessionAsAdmin(context.Context, int64, int64, AdminCreateSessionRequest) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) GetCurrentSession(context.Context, int64) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) GetHistory(context.Context, int64, timezone.Date, timezone.Date) (*HistoryResponse, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) GetSessionEdits(context.Context, int64, int64) ([]*WorkSessionEditView, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) GetSessionEditsForStaff(context.Context, int64, int64) ([]*WorkSessionEditView, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) GetTodayPresenceMap(context.Context) (map[int64]string, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) CleanupOpenSessions(context.Context) (int, error) {
+	return 0, nil
+}
+func (w *workSessionServiceForSessionUnitTest) EnsureCheckedIn(ctx context.Context, staffID int64, source string) (*activeModels.WorkSession, error) {
+	if w.ensureCheckedInFunc != nil {
+		return w.ensureCheckedInFunc(ctx, staffID, source)
+	}
+	return &activeModels.WorkSession{}, nil
+}
+func (w *workSessionServiceForSessionUnitTest) ExportSessions(context.Context, int64, timezone.Date, timezone.Date, string) ([]byte, string, error) {
+	return nil, "", nil
+}
+func (w *workSessionServiceForSessionUnitTest) AutoEndExpiredBreaks(context.Context) (int, error) {
+	return 0, nil
+}
+func (w *workSessionServiceForSessionUnitTest) GetStaffIDsWithSupervisionToday(context.Context) ([]int64, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) GetWorkTimeModelByID(context.Context, int64) (*configModels.WorkTimeModel, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) GetCurrentScheduleRows(context.Context, int64) ([]*configModels.StaffWorkSchedule, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) AssignScheduleTemplate(context.Context, *userModels.Staff, int64) error {
+	return nil
+}
+func (w *workSessionServiceForSessionUnitTest) ApplyCustomScheduleRows(context.Context, *userModels.Staff, []*configModels.StaffWorkSchedule, timezone.Date) error {
+	return nil
+}
+func (w *workSessionServiceForSessionUnitTest) SaveCustomScheduleAsTemplate(context.Context, *userModels.Staff, string, int, timezone.Date, []*configModels.WorkTimeModelEntry) error {
+	return nil
+}
+
+func newSessionSQLMockDB(t *testing.T) (*bun.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	db := bun.NewDB(sqlDB, pgdialect.New())
+	t.Cleanup(func() {
+		mock.ExpectClose()
+		require.NoError(t, db.Close())
+	})
+	return db, mock
+}
+
+type timetableBridgeCompleterForSessionUnitTest struct {
+	completeFunc func(ctx context.Context, activeGroupIDs []int64, completedAt time.Time) (int64, error)
+}
+
+func (t *timetableBridgeCompleterForSessionUnitTest) CompleteActiveByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64, completedAt time.Time) (int64, error) {
+	if t.completeFunc != nil {
+		return t.completeFunc(ctx, activeGroupIDs, completedAt)
+	}
+	return 0, nil
 }
 
 func TestProcessSessionTimeoutByID_ContinuesWhenSSECollectionFails(t *testing.T) {
@@ -320,6 +425,155 @@ func TestUpdateDeviceLocationBestEffort(t *testing.T) {
 	svc.updateDeviceLocation(context.Background(), 50, 60)
 
 	assert.Equal(t, 1, calls)
+}
+
+func TestAssignSupervisorNonCritical_WorkSessionBestEffortBranches(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("supervisor insert and auto check-in errors are logged but swallowed", func(t *testing.T) {
+		var checkedStaffID int64
+		svc := &service{
+			logger: slog.Default(),
+			supervisorRepo: &mockGroupSupervisorRepository{
+				createFunc: func(context.Context, *activeModels.GroupSupervisor) error {
+					return errors.New("supervisor insert failed")
+				},
+			},
+			workSessionService: &workSessionServiceForSessionUnitTest{
+				ensureCheckedInFunc: func(_ context.Context, staffID int64, source string) (*activeModels.WorkSession, error) {
+					checkedStaffID = staffID
+					assert.Equal(t, activeModels.WorkSessionSourceNFC, source)
+					return nil, errors.New("auto check-in failed")
+				},
+			},
+		}
+
+		svc.assignSupervisorNonCritical(ctx, 77, 88, time.Now())
+
+		assert.Equal(t, int64(88), checkedStaffID)
+	})
+
+	t.Run("nil auto check-in session is accepted", func(t *testing.T) {
+		svc := &service{
+			logger:         slog.Default(),
+			supervisorRepo: &mockGroupSupervisorRepository{},
+			workSessionService: &workSessionServiceForSessionUnitTest{
+				ensureCheckedInFunc: func(context.Context, int64, string) (*activeModels.WorkSession, error) {
+					return nil, nil
+				},
+			},
+		}
+
+		svc.assignSupervisorNonCritical(ctx, 77, 88, time.Now())
+	})
+}
+
+func TestAssignMultipleSupervisorsNonCritical_WorkSessionBestEffortBranches(t *testing.T) {
+	ctx := context.Background()
+	checkInResults := map[int64]error{
+		10: errors.New("auto check-in failed"),
+		20: nil,
+	}
+	checked := map[int64]bool{}
+	created := map[int64]bool{}
+	svc := &service{
+		logger: slog.Default(),
+		supervisorRepo: &mockGroupSupervisorRepository{
+			createFunc: func(_ context.Context, supervisor *activeModels.GroupSupervisor) error {
+				created[supervisor.StaffID] = true
+				return nil
+			},
+		},
+		workSessionService: &workSessionServiceForSessionUnitTest{
+			ensureCheckedInFunc: func(_ context.Context, staffID int64, source string) (*activeModels.WorkSession, error) {
+				checked[staffID] = true
+				assert.Equal(t, activeModels.WorkSessionSourceNFC, source)
+				if err := checkInResults[staffID]; err != nil {
+					return nil, err
+				}
+				return nil, nil
+			},
+		},
+	}
+
+	svc.assignMultipleSupervisorsNonCritical(ctx, 99, []int64{10, 20, 10}, time.Now())
+
+	assert.Equal(t, map[int64]bool{10: true, 20: true}, created)
+	assert.Equal(t, map[int64]bool{10: true, 20: true}, checked)
+}
+
+func TestRunBestEffortDB_SavepointBranches(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("savepoint create failure skips operation", func(t *testing.T) {
+		db, mock := newSessionSQLMockDB(t)
+		mock.ExpectBegin()
+		tx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		txCtx := modelBase.ContextWithTx(ctx, &tx)
+		mock.ExpectExec("SAVEPOINT sp_active_assign_supervisor").WillReturnError(errors.New("savepoint failed"))
+		mock.ExpectRollback()
+
+		called := false
+		svc := &service{logger: slog.Default()}
+		svc.runBestEffortDB(txCtx, "assign_supervisor", func() error {
+			called = true
+			return nil
+		}, func(error) {
+			t.Fatal("operation failure logger must not run when savepoint creation fails")
+		})
+
+		assert.False(t, called)
+		require.NoError(t, tx.Rollback())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("operation failure rolls back to savepoint", func(t *testing.T) {
+		db, mock := newSessionSQLMockDB(t)
+		mock.ExpectBegin()
+		tx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		txCtx := modelBase.ContextWithTx(ctx, &tx)
+		mock.ExpectExec("SAVEPOINT sp_active_nfc_auto_checkin").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("ROLLBACK TO SAVEPOINT sp_active_nfc_auto_checkin").WillReturnError(errors.New("rollback failed"))
+		mock.ExpectRollback()
+
+		logged := false
+		svc := &service{logger: slog.Default()}
+		svc.runBestEffortDB(txCtx, "nfc_auto_checkin", func() error {
+			return errors.New("operation failed")
+		}, func(error) {
+			logged = true
+		})
+
+		assert.True(t, logged)
+		require.NoError(t, tx.Rollback())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("release failure is logged after successful operation", func(t *testing.T) {
+		db, mock := newSessionSQLMockDB(t)
+		mock.ExpectBegin()
+		tx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		txCtx := modelBase.ContextWithTx(ctx, &tx)
+		mock.ExpectExec("SAVEPOINT sp_active_update_device_location").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("RELEASE SAVEPOINT sp_active_update_device_location").WillReturnError(errors.New("release failed"))
+		mock.ExpectRollback()
+
+		called := false
+		svc := &service{logger: slog.Default()}
+		svc.runBestEffortDB(txCtx, "update_device_location", func() error {
+			called = true
+			return nil
+		}, func(error) {
+			t.Fatal("operation failure logger must not run on release failure")
+		})
+
+		assert.True(t, called)
+		require.NoError(t, tx.Rollback())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }
 
 func TestCreateSessionBase_Branches(t *testing.T) {
@@ -608,6 +862,23 @@ func TestTransferForceStartedActivityState_PropagatesTransferErrors(t *testing.T
 	})
 }
 
+func TestCompleteForceEndedTimetableMirrors_PropagatesRepositoryError(t *testing.T) {
+	expectedErr := errors.New("bridge update failed")
+	svc := &service{
+		timetableBridgeCompleter: &timetableBridgeCompleterForSessionUnitTest{
+			completeFunc: func(_ context.Context, activeGroupIDs []int64, _ time.Time) (int64, error) {
+				assert.Equal(t, []int64{10, 20}, activeGroupIDs)
+				return 0, expectedErr
+			},
+		},
+	}
+
+	err := svc.completeForceEndedTimetableMirrors(context.Background(), []int64{10, 20})
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Contains(t, err.Error(), "complete force-ended timetable mirrors")
+}
+
 func TestTransferActiveSupervisorsBetweenGroups_ErrorBranches(t *testing.T) {
 	ctx := context.Background()
 	today := timezone.TodayDate()
@@ -646,6 +917,69 @@ func TestTransferActiveSupervisorsBetweenGroups_ErrorBranches(t *testing.T) {
 					return []*activeModels.GroupSupervisor{}, nil
 				},
 				endSupervisionFunc: func(context.Context, int64) error {
+					return expectedErr
+				},
+			},
+		}
+
+		count, err := svc.transferActiveSupervisorsBetweenGroups(ctx, 1, 2, time.Now())
+
+		require.ErrorIs(t, err, expectedErr)
+		assert.Zero(t, count)
+	})
+
+	t.Run("skips nil and duplicate supervisors", func(t *testing.T) {
+		var ended []int64
+		var created []*activeModels.GroupSupervisor
+		svc := &service{
+			supervisorRepo: &mockGroupSupervisorRepository{
+				findByActiveGroupIDFunc: func(_ context.Context, activeGroupID int64, _ bool) ([]*activeModels.GroupSupervisor, error) {
+					if activeGroupID == 1 {
+						return []*activeModels.GroupSupervisor{
+							nil,
+							{Model: modelBase.Model{ID: 10}, StaffID: 20, Role: "Supervisor", StartDate: today},
+							{Model: modelBase.Model{ID: 11}, StaffID: 30, Role: "helper", StartDate: today},
+						}, nil
+					}
+					return []*activeModels.GroupSupervisor{
+						nil,
+						{Model: modelBase.Model{ID: 12}, StaffID: 20, Role: "supervisor", StartDate: today},
+					}, nil
+				},
+				endSupervisionFunc: func(_ context.Context, id int64) error {
+					ended = append(ended, id)
+					return nil
+				},
+				createFunc: func(_ context.Context, supervisor *activeModels.GroupSupervisor) error {
+					created = append(created, supervisor)
+					return nil
+				},
+			},
+		}
+
+		count, err := svc.transferActiveSupervisorsBetweenGroups(ctx, 1, 2, time.Now())
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+		assert.Equal(t, []int64{10, 11}, ended)
+		require.Len(t, created, 1)
+		assert.Equal(t, int64(30), created[0].StaffID)
+		assert.Equal(t, "helper", created[0].Role)
+	})
+
+	t.Run("create error returns partial count", func(t *testing.T) {
+		expectedErr := errors.New("create transferred supervisor failed")
+		svc := &service{
+			supervisorRepo: &mockGroupSupervisorRepository{
+				findByActiveGroupIDFunc: func(_ context.Context, activeGroupID int64, _ bool) ([]*activeModels.GroupSupervisor, error) {
+					if activeGroupID == 1 {
+						return []*activeModels.GroupSupervisor{
+							{Model: modelBase.Model{ID: 10}, StaffID: 20, Role: "Supervisor", StartDate: today},
+						}, nil
+					}
+					return []*activeModels.GroupSupervisor{}, nil
+				},
+				createFunc: func(context.Context, *activeModels.GroupSupervisor) error {
 					return expectedErr
 				},
 			},

--- a/backend/services/active/session_service_internal_test.go
+++ b/backend/services/active/session_service_internal_test.go
@@ -418,11 +418,8 @@ func TestTransferForceStartedActivityState_PropagatesTransferErrors(t *testing.T
 	t.Run("visit transfer error", func(t *testing.T) {
 		svc := &service{
 			visitRepo: &mockVisitRepository{
-				findByActiveGroupIDFunc: func(context.Context, int64) ([]*activeModels.Visit, error) {
-					return []*activeModels.Visit{{Model: modelBase.Model{ID: 10}, StudentID: 20}}, nil
-				},
-				updateFunc: func(context.Context, *activeModels.Visit) error {
-					return visitErr
+				transferActiveVisitsBetweenGroupsFunc: func(context.Context, int64, int64) (int, error) {
+					return 0, visitErr
 				},
 			},
 		}
@@ -498,23 +495,15 @@ func TestTransferActiveSupervisorsBetweenGroups_ErrorBranches(t *testing.T) {
 	})
 }
 
-func TestTransferActiveVisitsBetweenGroups_SkipsClosedAndInvalidVisits(t *testing.T) {
+func TestTransferActiveVisitsBetweenGroups_DelegatesToConditionalRepositoryTransfer(t *testing.T) {
 	ctx := context.Background()
-	exitTime := time.Now()
-	var updatedVisitIDs []int64
+	var gotOldGroupID, gotNewGroupID int64
 	svc := &service{
 		visitRepo: &mockVisitRepository{
-			findByActiveGroupIDFunc: func(context.Context, int64) ([]*activeModels.Visit, error) {
-				return []*activeModels.Visit{
-					nil,
-					{Model: modelBase.Model{ID: 10}, ExitTime: &exitTime},
-					{Model: modelBase.Model{ID: 11}},
-				}, nil
-			},
-			updateFunc: func(_ context.Context, visit *activeModels.Visit) error {
-				updatedVisitIDs = append(updatedVisitIDs, visit.ID)
-				assert.Equal(t, int64(200), visit.ActiveGroupID)
-				return nil
+			transferActiveVisitsBetweenGroupsFunc: func(_ context.Context, oldGroupID, newGroupID int64) (int, error) {
+				gotOldGroupID = oldGroupID
+				gotNewGroupID = newGroupID
+				return 3, nil
 			},
 		},
 	}
@@ -522,8 +511,9 @@ func TestTransferActiveVisitsBetweenGroups_SkipsClosedAndInvalidVisits(t *testin
 	count, err := svc.transferActiveVisitsBetweenGroups(ctx, 100, 200)
 
 	require.NoError(t, err)
-	assert.Equal(t, 1, count)
-	assert.Equal(t, []int64{11}, updatedVisitIDs)
+	assert.Equal(t, 3, count)
+	assert.Equal(t, int64(100), gotOldGroupID)
+	assert.Equal(t, int64(200), gotNewGroupID)
 }
 
 func TestEndExistingDeviceSession_Branches(t *testing.T) {

--- a/backend/services/active/session_service_internal_test.go
+++ b/backend/services/active/session_service_internal_test.go
@@ -322,6 +322,150 @@ func TestUpdateDeviceLocationBestEffort(t *testing.T) {
 	assert.Equal(t, 1, calls)
 }
 
+func TestCreateSessionBase_Branches(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("create failure is returned before side effects", func(t *testing.T) {
+		expectedErr := errors.New("group insert failed")
+		transferCalls := 0
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				createFunc: func(context.Context, *activeModels.Group) error {
+					return expectedErr
+				},
+			},
+			visitRepo: &mockVisitRepository{
+				transferVisitsFromRecentSessionsFunc: func(context.Context, int64, int64) (int, error) {
+					transferCalls++
+					return 0, nil
+				},
+			},
+		}
+
+		group, transferred, err := svc.createSessionBase(ctx, 10, 20, 30)
+
+		require.ErrorIs(t, err, expectedErr)
+		assert.Nil(t, group)
+		assert.Zero(t, transferred)
+		assert.Zero(t, transferCalls)
+	})
+
+	t.Run("transfer failure is returned after group creation", func(t *testing.T) {
+		expectedErr := errors.New("visit transfer failed")
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				createFunc: func(_ context.Context, group *activeModels.Group) error {
+					group.ID = 44
+					return nil
+				},
+			},
+			visitRepo: &mockVisitRepository{
+				transferVisitsFromRecentSessionsFunc: func(_ context.Context, newActiveGroupID, deviceID int64) (int, error) {
+					assert.Equal(t, int64(44), newActiveGroupID)
+					assert.Equal(t, int64(20), deviceID)
+					return 0, expectedErr
+				},
+			},
+			deviceRepo: &deviceRepoForSessionUnitTest{},
+		}
+
+		group, transferred, err := svc.createSessionBase(ctx, 10, 20, 30)
+
+		require.ErrorIs(t, err, expectedErr)
+		assert.Nil(t, group)
+		assert.Zero(t, transferred)
+	})
+
+	t.Run("success without device skips location update", func(t *testing.T) {
+		locationUpdates := 0
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				createFunc: func(_ context.Context, group *activeModels.Group) error {
+					group.ID = 45
+					return nil
+				},
+			},
+			visitRepo: &mockVisitRepository{
+				transferVisitsFromRecentSessionsFunc: func(_ context.Context, newActiveGroupID, deviceID int64) (int, error) {
+					assert.Equal(t, int64(45), newActiveGroupID)
+					assert.Zero(t, deviceID)
+					return 2, nil
+				},
+			},
+			deviceRepo: &deviceRepoForSessionUnitTest{
+				updateRoomIDFunc: func(context.Context, int64, int64) error {
+					locationUpdates++
+					return nil
+				},
+			},
+		}
+
+		group, transferred, err := svc.createSessionBase(ctx, 10, 0, 30)
+
+		require.NoError(t, err)
+		require.NotNil(t, group)
+		assert.Equal(t, int64(45), group.ID)
+		assert.Equal(t, 2, transferred)
+		assert.Zero(t, locationUpdates)
+	})
+}
+
+func TestCreateSessionWithSupervisor_TransferredVisitsBranch(t *testing.T) {
+	svc := &service{
+		logger: slog.Default(),
+		groupRepo: &mockGroupRepository{
+			createFunc: func(_ context.Context, group *activeModels.Group) error {
+				group.ID = 50
+				return nil
+			},
+		},
+		visitRepo: &mockVisitRepository{
+			transferVisitsFromRecentSessionsFunc: func(context.Context, int64, int64) (int, error) {
+				return 3, nil
+			},
+		},
+		supervisorRepo: &mockGroupSupervisorRepository{},
+		deviceRepo:     &deviceRepoForSessionUnitTest{},
+	}
+
+	group, err := svc.createSessionWithSupervisor(context.Background(), 11, 22, 33, 44)
+
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	assert.Equal(t, int64(50), group.ID)
+}
+
+func TestCreateSessionWithMultipleSupervisors_TransferredVisitsBranch(t *testing.T) {
+	var assigned []int64
+	svc := &service{
+		logger: slog.Default(),
+		groupRepo: &mockGroupRepository{
+			createFunc: func(_ context.Context, group *activeModels.Group) error {
+				group.ID = 60
+				return nil
+			},
+		},
+		visitRepo: &mockVisitRepository{
+			transferVisitsFromRecentSessionsFunc: func(context.Context, int64, int64) (int, error) {
+				return 2, nil
+			},
+		},
+		supervisorRepo: &mockGroupSupervisorRepository{
+			createFunc: func(_ context.Context, supervisor *activeModels.GroupSupervisor) error {
+				assigned = append(assigned, supervisor.StaffID)
+				return nil
+			},
+		},
+		deviceRepo: &deviceRepoForSessionUnitTest{},
+	}
+
+	group, err := svc.createSessionWithMultipleSupervisors(context.Background(), 11, 22, []int64{33, 44, 33}, 55)
+
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	assert.ElementsMatch(t, []int64{33, 44}, assigned)
+}
+
 func TestManualRoomSelectionStrategies(t *testing.T) {
 	ctx := context.Background()
 
@@ -407,6 +551,25 @@ func TestEndExistingActivitySessionsForForceStart_SkipsInvalidRowsAndStopsOnErro
 		require.Error(t, err)
 		assert.Nil(t, endedIDs)
 		assert.Contains(t, err.Error(), "active sessions lookup failed")
+	})
+
+	t.Run("end error stops immediately", func(t *testing.T) {
+		expectedErr := errors.New("end active session failed")
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findActiveByGroupIDFunc: func(context.Context, int64) ([]*activeModels.Group, error) {
+					return []*activeModels.Group{{Model: modelBase.Model{ID: 31}}}, nil
+				},
+				endSessionFunc: func(context.Context, int64) error {
+					return expectedErr
+				},
+			},
+		}
+
+		endedIDs, err := svc.endExistingActivitySessionsForForceStart(ctx, 500)
+
+		require.ErrorIs(t, err, expectedErr)
+		assert.Nil(t, endedIDs)
 	})
 }
 
@@ -566,6 +729,99 @@ func TestEndExistingDeviceSession_Branches(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []int64{300}, endedGroupIDs)
 	})
+
+	t.Run("simple cleanup ends the device session directly", func(t *testing.T) {
+		var ended []int64
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findActiveByDeviceIDFunc: func(context.Context, int64) (*activeModels.Group, error) {
+					return &activeModels.Group{Model: modelBase.Model{ID: 301}}, nil
+				},
+				endSessionFunc: func(_ context.Context, id int64) error {
+					ended = append(ended, id)
+					return nil
+				},
+			},
+		}
+
+		err := svc.endExistingDeviceSession(ctx, 100, false)
+
+		require.NoError(t, err)
+		assert.Equal(t, []int64{301}, ended)
+	})
+}
+
+func TestEndExistingDeviceSessionForForceStart_Branches(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("find error is returned", func(t *testing.T) {
+		expectedErr := errors.New("force device lookup failed")
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findActiveByDeviceIDFunc: func(context.Context, int64) (*activeModels.Group, error) {
+					return nil, expectedErr
+				},
+			},
+		}
+
+		endedID, err := svc.endExistingDeviceSessionForForceStart(ctx, 100)
+
+		require.ErrorIs(t, err, expectedErr)
+		assert.Zero(t, endedID)
+	})
+
+	t.Run("nil existing session is zero", func(t *testing.T) {
+		svc := &service{groupRepo: &mockGroupRepository{}}
+
+		endedID, err := svc.endExistingDeviceSessionForForceStart(ctx, 100)
+
+		require.NoError(t, err)
+		assert.Zero(t, endedID)
+	})
+
+	t.Run("end error is returned", func(t *testing.T) {
+		expectedErr := errors.New("force end failed")
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findActiveByDeviceIDFunc: func(context.Context, int64) (*activeModels.Group, error) {
+					return &activeModels.Group{Model: modelBase.Model{ID: 302}}, nil
+				},
+				endSessionFunc: func(context.Context, int64) error {
+					return expectedErr
+				},
+			},
+		}
+
+		endedID, err := svc.endExistingDeviceSessionForForceStart(ctx, 100)
+
+		require.ErrorIs(t, err, expectedErr)
+		assert.Zero(t, endedID)
+	})
+
+	t.Run("returns ended session id", func(t *testing.T) {
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findActiveByDeviceIDFunc: func(context.Context, int64) (*activeModels.Group, error) {
+					return &activeModels.Group{Model: modelBase.Model{ID: 303}}, nil
+				},
+			},
+		}
+
+		endedID, err := svc.endExistingDeviceSessionForForceStart(ctx, 100)
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(303), endedID)
+	})
+}
+
+func TestAppendActiveGroupID_DeduplicatesAndSkipsInvalid(t *testing.T) {
+	ids := appendActiveGroupID(nil, 0)
+	ids = appendActiveGroupID(ids, -1)
+	ids = appendActiveGroupID(ids, 10)
+	ids = appendActiveGroupID(ids, 10)
+	ids = appendActiveGroupIDs(ids, 11, 10, 12)
+
+	assert.Equal(t, []int64{10, 11, 12}, ids)
 }
 
 func TestSupervisorReplacement_ErrorBranches(t *testing.T) {

--- a/backend/services/active/session_service_internal_test.go
+++ b/backend/services/active/session_service_internal_test.go
@@ -1,0 +1,862 @@
+package active
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	iotModels "github.com/moto-nrw/project-phoenix/models/iot"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type deviceRepoForSessionUnitTest struct {
+	updateRoomIDFunc func(ctx context.Context, id int64, roomID int64) error
+}
+
+func (d *deviceRepoForSessionUnitTest) Create(context.Context, *iotModels.Device) error {
+	return nil
+}
+func (d *deviceRepoForSessionUnitTest) FindByID(context.Context, interface{}) (*iotModels.Device, error) {
+	return nil, nil
+}
+func (d *deviceRepoForSessionUnitTest) Update(context.Context, *iotModels.Device) error {
+	return nil
+}
+func (d *deviceRepoForSessionUnitTest) Delete(context.Context, interface{}) error {
+	return nil
+}
+func (d *deviceRepoForSessionUnitTest) List(context.Context, map[string]interface{}) ([]*iotModels.Device, error) {
+	return nil, nil
+}
+func (d *deviceRepoForSessionUnitTest) FindByDeviceID(context.Context, string) (*iotModels.Device, error) {
+	return nil, nil
+}
+func (d *deviceRepoForSessionUnitTest) FindByAPIKey(context.Context, string) (*iotModels.Device, error) {
+	return nil, nil
+}
+func (d *deviceRepoForSessionUnitTest) FindByType(context.Context, string) ([]*iotModels.Device, error) {
+	return nil, nil
+}
+func (d *deviceRepoForSessionUnitTest) FindByStatus(context.Context, iotModels.DeviceStatus) ([]*iotModels.Device, error) {
+	return nil, nil
+}
+func (d *deviceRepoForSessionUnitTest) FindByRegisteredBy(context.Context, int64) ([]*iotModels.Device, error) {
+	return nil, nil
+}
+func (d *deviceRepoForSessionUnitTest) UpdateLastSeen(context.Context, int64, time.Time) error {
+	return nil
+}
+func (d *deviceRepoForSessionUnitTest) UpdateRoomID(ctx context.Context, id int64, roomID int64) error {
+	if d.updateRoomIDFunc != nil {
+		return d.updateRoomIDFunc(ctx, id, roomID)
+	}
+	return nil
+}
+func (d *deviceRepoForSessionUnitTest) UpdateStatus(context.Context, string, iotModels.DeviceStatus) error {
+	return nil
+}
+func (d *deviceRepoForSessionUnitTest) FindActiveDevices(context.Context) ([]*iotModels.Device, error) {
+	return nil, nil
+}
+func (d *deviceRepoForSessionUnitTest) FindDevicesRequiringMaintenance(context.Context) ([]*iotModels.Device, error) {
+	return nil, nil
+}
+func (d *deviceRepoForSessionUnitTest) FindOfflineDevices(context.Context, time.Duration) ([]*iotModels.Device, error) {
+	return nil, nil
+}
+func (d *deviceRepoForSessionUnitTest) CountDevicesByType(context.Context) (map[string]int, error) {
+	return nil, nil
+}
+
+type settingsResolverForSessionUnitTest struct {
+	has    bool
+	hasErr error
+	intVal int
+	intErr error
+}
+
+func (s *settingsResolverForSessionUnitTest) HasTenantOverride(context.Context, string) (bool, error) {
+	return s.has, s.hasErr
+}
+func (s *settingsResolverForSessionUnitTest) ResolveString(context.Context, string) (string, error) {
+	return "", nil
+}
+func (s *settingsResolverForSessionUnitTest) ResolveInt(context.Context, string) (int, error) {
+	return s.intVal, s.intErr
+}
+
+func TestProcessSessionTimeoutByID_ContinuesWhenSSECollectionFails(t *testing.T) {
+	ctx := context.Background()
+	activityID := int64(200)
+	findCalls := 0
+	endedVisits := 0
+
+	svc := &service{
+		logger: slog.Default(),
+		groupRepo: &mockGroupRepository{
+			findByIDFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+				return &activeModels.Group{Model: modelBase.Model{ID: 100}, GroupID: &activityID}, nil
+			},
+		},
+		visitRepo: &mockVisitRepository{
+			findByActiveGroupIDFunc: func(context.Context, int64) ([]*activeModels.Visit, error) {
+				findCalls++
+				if findCalls == 1 {
+					return nil, errors.New("student lookup prefetch failed")
+				}
+				return []*activeModels.Visit{
+					{Model: modelBase.Model{ID: 300}, ActiveGroupID: 100, StudentID: 400},
+				}, nil
+			},
+			endVisitFunc: func(context.Context, int64) error {
+				endedVisits++
+				return nil
+			},
+		},
+	}
+
+	result, err := svc.ProcessSessionTimeoutByID(ctx, 100)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, activityID, *result.ActivityID)
+	assert.Equal(t, 1, result.StudentsCheckedOut)
+	assert.Equal(t, 1, endedVisits)
+}
+
+func TestProcessSessionTimeoutByID_ReturnsCheckoutAndEndErrors(t *testing.T) {
+	ctx := context.Background()
+	activeGroup := &activeModels.Group{Model: modelBase.Model{ID: 100}}
+
+	t.Run("checkout lookup failure", func(t *testing.T) {
+		findCalls := 0
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+					return activeGroup, nil
+				},
+			},
+			visitRepo: &mockVisitRepository{
+				findByActiveGroupIDFunc: func(context.Context, int64) ([]*activeModels.Visit, error) {
+					findCalls++
+					if findCalls == 1 {
+						return []*activeModels.Visit{}, nil
+					}
+					return nil, errors.New("visit checkout lookup failed")
+				},
+			},
+		}
+
+		result, err := svc.ProcessSessionTimeoutByID(ctx, 100)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "visit checkout lookup failed")
+	})
+
+	t.Run("session end failure", func(t *testing.T) {
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+					return activeGroup, nil
+				},
+				endSessionFunc: func(context.Context, int64) error {
+					return errors.New("session end failed")
+				},
+			},
+			visitRepo: &mockVisitRepository{},
+		}
+
+		result, err := svc.ProcessSessionTimeoutByID(ctx, 100)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "session end failed")
+	})
+}
+
+func TestUpdateSessionActivity_RepositoryMissesAreMapped(t *testing.T) {
+	ctx := context.Background()
+	missErr := &modelBase.DatabaseError{Op: "update last activity - session not found", Err: sql.ErrNoRows}
+
+	tests := []struct {
+		name      string
+		findFunc  func(context.Context, interface{}) (*activeModels.Group, error)
+		wantError string
+	}{
+		{
+			name: "find by id no rows becomes not found",
+			findFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+				return nil, &modelBase.DatabaseError{Op: "find by id", Err: sql.ErrNoRows}
+			},
+			wantError: ErrActiveGroupNotFound.Error(),
+		},
+		{
+			name: "nil session becomes not found",
+			findFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+				return nil, nil
+			},
+			wantError: ErrActiveGroupNotFound.Error(),
+		},
+		{
+			name: "ended session becomes already ended",
+			findFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+				endedAt := time.Now()
+				return &activeModels.Group{Model: modelBase.Model{ID: 100}, EndTime: &endedAt}, nil
+			},
+			wantError: ErrActiveGroupAlreadyEnded.Error(),
+		},
+		{
+			name: "unexpected lookup error is preserved",
+			findFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+				return nil, errors.New("lookup exploded")
+			},
+			wantError: "lookup exploded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &service{
+				groupRepo: &mockGroupRepository{
+					updateLastActivityFunc: func(context.Context, int64, time.Time) error {
+						return missErr
+					},
+					findByIDFunc: tt.findFunc,
+				},
+			}
+
+			err := svc.UpdateSessionActivity(ctx, 100)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+		})
+	}
+}
+
+func TestUpdateSessionActivity_NonMissUpdateErrorIsPreserved(t *testing.T) {
+	svc := &service{
+		groupRepo: &mockGroupRepository{
+			updateLastActivityFunc: func(context.Context, int64, time.Time) error {
+				return errors.New("deadlock")
+			},
+		},
+	}
+
+	err := svc.UpdateSessionActivity(context.Background(), 100)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deadlock")
+}
+
+func TestSessionDeviceOnlineWindowResolution(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("default without settings", func(t *testing.T) {
+		svc := &service{}
+		assert.Equal(t, defaultDeviceOnlineWindow, svc.deviceOnlineWindow(ctx))
+	})
+
+	t.Run("default when override check fails", func(t *testing.T) {
+		svc := &service{
+			logger:   slog.Default(),
+			settings: &settingsResolverForSessionUnitTest{hasErr: errors.New("settings db down")},
+		}
+		assert.Equal(t, defaultDeviceOnlineWindow, svc.deviceOnlineWindow(ctx))
+	})
+
+	t.Run("default without tenant override", func(t *testing.T) {
+		svc := &service{settings: &settingsResolverForSessionUnitTest{has: false, intVal: 2}}
+		assert.Equal(t, defaultDeviceOnlineWindow, svc.deviceOnlineWindow(ctx))
+	})
+
+	t.Run("default for invalid override", func(t *testing.T) {
+		svc := &service{settings: &settingsResolverForSessionUnitTest{has: true, intVal: 0}}
+		assert.Equal(t, defaultDeviceOnlineWindow, svc.deviceOnlineWindow(ctx))
+	})
+
+	t.Run("default when resolve fails", func(t *testing.T) {
+		svc := &service{settings: &settingsResolverForSessionUnitTest{has: true, intErr: errors.New("missing")}}
+		assert.Equal(t, defaultDeviceOnlineWindow, svc.deviceOnlineWindow(ctx))
+	})
+
+	t.Run("valid tenant override", func(t *testing.T) {
+		svc := &service{settings: &settingsResolverForSessionUnitTest{has: true, intVal: 2}}
+		assert.Equal(t, 2*time.Minute, svc.deviceOnlineWindow(ctx))
+	})
+}
+
+func TestSessionIsDeviceOnline(t *testing.T) {
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	recent := now.Add(-time.Minute)
+	old := now.Add(-10 * time.Minute)
+	svc := &service{settings: &settingsResolverForSessionUnitTest{has: true, intVal: 5}}
+
+	assert.False(t, svc.isDeviceOnline(context.Background(), nil, now))
+	assert.False(t, svc.isDeviceOnline(context.Background(), &iotModels.Device{}, now))
+	assert.True(t, svc.isDeviceOnline(context.Background(), &iotModels.Device{LastSeen: &recent}, now))
+	assert.False(t, svc.isDeviceOnline(context.Background(), &iotModels.Device{LastSeen: &old}, now))
+}
+
+func TestUpdateDeviceLocationBestEffort(t *testing.T) {
+	calls := 0
+	svc := &service{
+		logger: slog.Default(),
+		deviceRepo: &deviceRepoForSessionUnitTest{
+			updateRoomIDFunc: func(context.Context, int64, int64) error {
+				calls++
+				return errors.New("device table temporarily unavailable")
+			},
+		},
+	}
+
+	svc.updateDeviceLocation(context.Background(), 50, 60)
+
+	assert.Equal(t, 1, calls)
+}
+
+func TestManualRoomSelectionStrategies(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ignore strategy skips conflict check", func(t *testing.T) {
+		svc := &service{}
+		roomID, err := svc.validateManualRoomSelection(ctx, 10, RoomConflictIgnore)
+		require.NoError(t, err)
+		assert.Equal(t, int64(10), roomID)
+	})
+
+	t.Run("repository error is returned", func(t *testing.T) {
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				checkRoomConflictFunc: func(context.Context, int64, int64) (bool, *activeModels.Group, error) {
+					return false, nil, errors.New("conflict lookup failed")
+				},
+			},
+		}
+
+		roomID, err := svc.validateManualRoomSelection(ctx, 10, RoomConflictFail)
+
+		require.Error(t, err)
+		assert.Zero(t, roomID)
+		assert.Contains(t, err.Error(), "conflict lookup failed")
+	})
+
+	t.Run("warn strategy permits conflict", func(t *testing.T) {
+		svc := &service{
+			logger: slog.Default(),
+			groupRepo: &mockGroupRepository{
+				checkRoomConflictFunc: func(context.Context, int64, int64) (bool, *activeModels.Group, error) {
+					return true, &activeModels.Group{Model: modelBase.Model{ID: 20}}, nil
+				},
+			},
+		}
+
+		roomID, err := svc.validateManualRoomSelection(ctx, 10, RoomConflictWarn)
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(10), roomID)
+	})
+}
+
+func TestEndExistingActivitySessionsForForceStart_SkipsInvalidRowsAndStopsOnErrors(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("skips nil and invalid sessions", func(t *testing.T) {
+		var ended []int64
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findActiveByGroupIDFunc: func(context.Context, int64) ([]*activeModels.Group, error) {
+					return []*activeModels.Group{
+						nil,
+						{Model: modelBase.Model{ID: 0}},
+						{Model: modelBase.Model{ID: 30}},
+					}, nil
+				},
+				endSessionFunc: func(_ context.Context, id int64) error {
+					ended = append(ended, id)
+					return nil
+				},
+			},
+		}
+
+		endedIDs, err := svc.endExistingActivitySessionsForForceStart(ctx, 500)
+
+		require.NoError(t, err)
+		assert.Equal(t, []int64{30}, ended)
+		assert.Equal(t, []int64{30}, endedIDs)
+	})
+
+	t.Run("find error is returned", func(t *testing.T) {
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findActiveByGroupIDFunc: func(context.Context, int64) ([]*activeModels.Group, error) {
+					return nil, errors.New("active sessions lookup failed")
+				},
+			},
+		}
+
+		endedIDs, err := svc.endExistingActivitySessionsForForceStart(ctx, 500)
+
+		require.Error(t, err)
+		assert.Nil(t, endedIDs)
+		assert.Contains(t, err.Error(), "active sessions lookup failed")
+	})
+}
+
+func TestTransferForceStartedActivityState_PropagatesTransferErrors(t *testing.T) {
+	ctx := context.Background()
+	visitErr := errors.New("visit update failed")
+	supervisorErr := errors.New("supervisor lookup failed")
+
+	t.Run("visit transfer error", func(t *testing.T) {
+		svc := &service{
+			visitRepo: &mockVisitRepository{
+				findByActiveGroupIDFunc: func(context.Context, int64) ([]*activeModels.Visit, error) {
+					return []*activeModels.Visit{{Model: modelBase.Model{ID: 10}, StudentID: 20}}, nil
+				},
+				updateFunc: func(context.Context, *activeModels.Visit) error {
+					return visitErr
+				},
+			},
+		}
+
+		err := svc.transferForceStartedActivityState(ctx, []int64{1}, 2, time.Now())
+
+		require.ErrorIs(t, err, visitErr)
+	})
+
+	t.Run("supervisor transfer error", func(t *testing.T) {
+		svc := &service{
+			visitRepo: &mockVisitRepository{},
+			supervisorRepo: &mockGroupSupervisorRepository{
+				findByActiveGroupIDFunc: func(context.Context, int64, bool) ([]*activeModels.GroupSupervisor, error) {
+					return nil, supervisorErr
+				},
+			},
+		}
+
+		err := svc.transferForceStartedActivityState(ctx, []int64{1}, 2, time.Now())
+
+		require.ErrorIs(t, err, supervisorErr)
+	})
+}
+
+func TestTransferActiveSupervisorsBetweenGroups_ErrorBranches(t *testing.T) {
+	ctx := context.Background()
+	today := timezone.TodayDate()
+
+	t.Run("new supervisor lookup error", func(t *testing.T) {
+		call := 0
+		expectedErr := errors.New("new supervisor lookup failed")
+		svc := &service{
+			supervisorRepo: &mockGroupSupervisorRepository{
+				findByActiveGroupIDFunc: func(context.Context, int64, bool) ([]*activeModels.GroupSupervisor, error) {
+					call++
+					if call == 2 {
+						return nil, expectedErr
+					}
+					return []*activeModels.GroupSupervisor{}, nil
+				},
+			},
+		}
+
+		count, err := svc.transferActiveSupervisorsBetweenGroups(ctx, 1, 2, time.Now())
+
+		require.ErrorIs(t, err, expectedErr)
+		assert.Zero(t, count)
+	})
+
+	t.Run("end supervision error returns partial count", func(t *testing.T) {
+		expectedErr := errors.New("end supervision failed")
+		svc := &service{
+			supervisorRepo: &mockGroupSupervisorRepository{
+				findByActiveGroupIDFunc: func(_ context.Context, activeGroupID int64, _ bool) ([]*activeModels.GroupSupervisor, error) {
+					if activeGroupID == 1 {
+						return []*activeModels.GroupSupervisor{
+							{Model: modelBase.Model{ID: 10}, StaffID: 20, Role: "helper", StartDate: today},
+						}, nil
+					}
+					return []*activeModels.GroupSupervisor{}, nil
+				},
+				endSupervisionFunc: func(context.Context, int64) error {
+					return expectedErr
+				},
+			},
+		}
+
+		count, err := svc.transferActiveSupervisorsBetweenGroups(ctx, 1, 2, time.Now())
+
+		require.ErrorIs(t, err, expectedErr)
+		assert.Zero(t, count)
+	})
+}
+
+func TestTransferActiveVisitsBetweenGroups_SkipsClosedAndInvalidVisits(t *testing.T) {
+	ctx := context.Background()
+	exitTime := time.Now()
+	var updatedVisitIDs []int64
+	svc := &service{
+		visitRepo: &mockVisitRepository{
+			findByActiveGroupIDFunc: func(context.Context, int64) ([]*activeModels.Visit, error) {
+				return []*activeModels.Visit{
+					nil,
+					{Model: modelBase.Model{ID: 10}, ExitTime: &exitTime},
+					{Model: modelBase.Model{ID: 11}},
+				}, nil
+			},
+			updateFunc: func(_ context.Context, visit *activeModels.Visit) error {
+				updatedVisitIDs = append(updatedVisitIDs, visit.ID)
+				assert.Equal(t, int64(200), visit.ActiveGroupID)
+				return nil
+			},
+		},
+	}
+
+	count, err := svc.transferActiveVisitsBetweenGroups(ctx, 100, 200)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, []int64{11}, updatedVisitIDs)
+}
+
+func TestEndExistingDeviceSession_Branches(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("find error is returned", func(t *testing.T) {
+		expectedErr := errors.New("device session lookup failed")
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findActiveByDeviceIDFunc: func(context.Context, int64) (*activeModels.Group, error) {
+					return nil, expectedErr
+				},
+			},
+		}
+
+		err := svc.endExistingDeviceSession(ctx, 100, false)
+
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("nil existing session is a no-op", func(t *testing.T) {
+		svc := &service{groupRepo: &mockGroupRepository{}}
+
+		err := svc.endExistingDeviceSession(ctx, 100, false)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("full cleanup delegates to EndActivitySession", func(t *testing.T) {
+		endedGroupIDs := []int64{}
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findActiveByDeviceIDFunc: func(context.Context, int64) (*activeModels.Group, error) {
+					return &activeModels.Group{Model: modelBase.Model{ID: 300}}, nil
+				},
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+					return &activeModels.Group{Model: modelBase.Model{ID: 300}}, nil
+				},
+				endSessionFunc: func(_ context.Context, id int64) error {
+					endedGroupIDs = append(endedGroupIDs, id)
+					return nil
+				},
+			},
+			visitRepo:      &mockVisitRepository{},
+			supervisorRepo: &mockGroupSupervisorRepository{},
+		}
+
+		err := svc.endExistingDeviceSession(ctx, 100, true)
+
+		require.NoError(t, err)
+		assert.Equal(t, []int64{300}, endedGroupIDs)
+	})
+}
+
+func TestSupervisorReplacement_ErrorBranches(t *testing.T) {
+	ctx := context.Background()
+	startDate := timezone.TodayDate()
+
+	t.Run("current supervisor lookup error", func(t *testing.T) {
+		expectedErr := errors.New("current supervisors failed")
+		svc := &service{
+			supervisorRepo: &mockGroupSupervisorRepository{
+				findByActiveGroupIDFunc: func(context.Context, int64, bool) ([]*activeModels.GroupSupervisor, error) {
+					return nil, expectedErr
+				},
+			},
+		}
+
+		err := svc.replaceSupervisorsInTransaction(ctx, 100, map[int64]bool{10: true})
+
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("ending current supervisor error", func(t *testing.T) {
+		expectedErr := errors.New("end current supervisor failed")
+		svc := &service{
+			supervisorRepo: &mockGroupSupervisorRepository{
+				findByActiveGroupIDFunc: func(context.Context, int64, bool) ([]*activeModels.GroupSupervisor, error) {
+					return []*activeModels.GroupSupervisor{
+						{Model: modelBase.Model{ID: 20}, StaffID: 10, Role: "supervisor", StartDate: startDate},
+					}, nil
+				},
+				updateFunc: func(context.Context, *activeModels.GroupSupervisor) error {
+					return expectedErr
+				},
+			},
+		}
+
+		err := svc.replaceSupervisorsInTransaction(ctx, 100, map[int64]bool{10: true})
+
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("reactivate existing supervisor update error", func(t *testing.T) {
+		expectedErr := errors.New("reactivate failed")
+		endedDate := startDate.AddDays(-1)
+		supervisors := []*activeModels.GroupSupervisor{
+			{Model: modelBase.Model{ID: 20}, StaffID: 10, Role: "supervisor", StartDate: startDate, EndDate: &endedDate},
+		}
+		updateCalls := 0
+		svc := &service{
+			supervisorRepo: &mockGroupSupervisorRepository{
+				findByActiveGroupIDFunc: func(context.Context, int64, bool) ([]*activeModels.GroupSupervisor, error) {
+					return supervisors, nil
+				},
+				updateFunc: func(context.Context, *activeModels.GroupSupervisor) error {
+					updateCalls++
+					if updateCalls == 2 {
+						return expectedErr
+					}
+					return nil
+				},
+			},
+		}
+
+		err := svc.replaceSupervisorsInTransaction(ctx, 100, map[int64]bool{10: true})
+
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("create new supervisor error", func(t *testing.T) {
+		expectedErr := errors.New("create supervisor failed")
+		svc := &service{
+			supervisorRepo: &mockGroupSupervisorRepository{
+				findByActiveGroupIDFunc: func(context.Context, int64, bool) ([]*activeModels.GroupSupervisor, error) {
+					return []*activeModels.GroupSupervisor{}, nil
+				},
+				createFunc: func(context.Context, *activeModels.GroupSupervisor) error {
+					return expectedErr
+				},
+			},
+		}
+
+		err := svc.replaceSupervisorsInTransaction(ctx, 100, map[int64]bool{10: true})
+
+		require.ErrorIs(t, err, expectedErr)
+	})
+}
+
+func TestGetDeviceIDString(t *testing.T) {
+	deviceID := int64(42)
+
+	assert.Equal(t, "unknown", getDeviceIDString(nil))
+	assert.Equal(t, "42", getDeviceIDString(&deviceID))
+}
+
+func TestNormalizeTransferredSupervisorRole(t *testing.T) {
+	assert.Equal(t, "supervisor", normalizeTransferredSupervisorRole("Supervisor"))
+	assert.Equal(t, "helper", normalizeTransferredSupervisorRole("helper"))
+}
+
+func TestValidateSessionForTimeout_Branches(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("not found", func(t *testing.T) {
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+					return nil, errors.New("missing")
+				},
+			},
+		}
+
+		session, err := svc.validateSessionForTimeout(ctx, 100)
+
+		require.Error(t, err)
+		assert.Nil(t, session)
+		assert.Contains(t, err.Error(), ErrActiveGroupNotFound.Error())
+	})
+
+	t.Run("already ended", func(t *testing.T) {
+		endedAt := time.Now()
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				findByIDFunc: func(context.Context, interface{}) (*activeModels.Group, error) {
+					return &activeModels.Group{Model: modelBase.Model{ID: 100}, EndTime: &endedAt}, nil
+				},
+			},
+		}
+
+		session, err := svc.validateSessionForTimeout(ctx, 100)
+
+		require.Error(t, err)
+		assert.Nil(t, session)
+		assert.Contains(t, err.Error(), ErrActiveGroupAlreadyEnded.Error())
+	})
+}
+
+func TestEndDailySessions_RepositoryFailures(t *testing.T) {
+	ctx := context.Background()
+	activeGroup := &activeModels.Group{Model: modelBase.Model{ID: 100}}
+
+	t.Run("list failure returns active error", func(t *testing.T) {
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				listFunc: func(context.Context, *modelBase.QueryOptions) ([]*activeModels.Group, error) {
+					return nil, errors.New("list failed")
+				},
+			},
+		}
+
+		result, err := svc.EndDailySessions(ctx)
+
+		require.Error(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.Success)
+	})
+
+	t.Run("visit bulk failure aborts later bulk steps", func(t *testing.T) {
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				listFunc: func(context.Context, *modelBase.QueryOptions) ([]*activeModels.Group, error) {
+					return []*activeModels.Group{activeGroup}, nil
+				},
+			},
+			visitRepo: &mockVisitRepository{
+				endVisitsByActiveGroupIDsFunc: func(context.Context, []int64) (int64, error) {
+					return 0, errors.New("bulk visit close failed")
+				},
+			},
+			supervisorRepo: &mockGroupSupervisorRepository{},
+		}
+
+		result, err := svc.EndDailySessions(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.Success)
+		assert.Contains(t, result.Errors[0], "bulk visit close failed")
+	})
+
+	t.Run("session bulk failure records error and still tries supervisors", func(t *testing.T) {
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				listFunc: func(context.Context, *modelBase.QueryOptions) ([]*activeModels.Group, error) {
+					return []*activeModels.Group{activeGroup}, nil
+				},
+				endSessionsByIDsFunc: func(context.Context, []int64) (int64, error) {
+					return 0, errors.New("bulk session close failed")
+				},
+			},
+			visitRepo: &mockVisitRepository{
+				endVisitsByActiveGroupIDsFunc: func(context.Context, []int64) (int64, error) {
+					return 2, nil
+				},
+			},
+			supervisorRepo: &mockGroupSupervisorRepository{
+				endSupervisionsByIDsFunc: func(context.Context, []int64) (int64, error) {
+					return 3, nil
+				},
+			},
+		}
+
+		result, err := svc.EndDailySessions(ctx)
+
+		require.NoError(t, err)
+		assert.False(t, result.Success)
+		assert.Equal(t, 2, result.VisitsEnded)
+		assert.Equal(t, 3, result.SupervisorsEnded)
+		assert.Contains(t, result.Errors[0], "bulk session close failed")
+	})
+
+	t.Run("supervisor bulk failure records error", func(t *testing.T) {
+		svc := &service{
+			groupRepo: &mockGroupRepository{
+				listFunc: func(context.Context, *modelBase.QueryOptions) ([]*activeModels.Group, error) {
+					return []*activeModels.Group{activeGroup}, nil
+				},
+				endSessionsByIDsFunc: func(context.Context, []int64) (int64, error) {
+					return 1, nil
+				},
+			},
+			visitRepo: &mockVisitRepository{
+				endVisitsByActiveGroupIDsFunc: func(context.Context, []int64) (int64, error) {
+					return 2, nil
+				},
+			},
+			supervisorRepo: &mockGroupSupervisorRepository{
+				endSupervisionsByIDsFunc: func(context.Context, []int64) (int64, error) {
+					return 0, errors.New("bulk supervisor close failed")
+				},
+			},
+		}
+
+		result, err := svc.EndDailySessions(ctx)
+
+		require.NoError(t, err)
+		assert.False(t, result.Success)
+		assert.Equal(t, 1, result.SessionsEnded)
+		assert.Contains(t, result.Errors[0], "bulk supervisor close failed")
+	})
+}
+
+func TestCleanupOrphanedSupervisors_ErrorBranches(t *testing.T) {
+	ctx := context.Background()
+	today := timezone.TodayDate()
+
+	t.Run("find failure is captured", func(t *testing.T) {
+		result := &DailySessionCleanupResult{Success: true}
+		svc := &service{
+			supervisorRepo: &mockGroupSupervisorRepository{
+				findStaleOpenFunc: func(context.Context, timezone.Date) ([]*activeModels.GroupSupervisor, error) {
+					return nil, errors.New("stale lookup failed")
+				},
+			},
+		}
+
+		svc.cleanupOrphanedSupervisors(ctx, result)
+
+		assert.False(t, result.Success)
+		require.Len(t, result.Errors, 1)
+		assert.Contains(t, result.Errors[0], "stale lookup failed")
+	})
+
+	t.Run("update failure is captured", func(t *testing.T) {
+		result := &DailySessionCleanupResult{Success: true}
+		svc := &service{
+			supervisorRepo: &mockGroupSupervisorRepository{
+				findStaleOpenFunc: func(context.Context, timezone.Date) ([]*activeModels.GroupSupervisor, error) {
+					return []*activeModels.GroupSupervisor{
+						{Model: modelBase.Model{ID: 10}, StartDate: today.AddDays(-1)},
+					}, nil
+				},
+				updateColumnsFunc: func(context.Context, *activeModels.GroupSupervisor, ...string) (int64, error) {
+					return 0, errors.New("stale close failed")
+				},
+			},
+		}
+
+		svc.cleanupOrphanedSupervisors(ctx, result)
+
+		assert.False(t, result.Success)
+		require.Len(t, result.Errors, 1)
+		assert.Contains(t, result.Errors[0], "stale close failed")
+	})
+}

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -293,30 +293,31 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 
 	// Initialize active service with SSE broadcaster
 	activeService := active.NewService(active.ServiceDependencies{
-		GroupRepo:          repos.ActiveGroup,
-		VisitRepo:          repos.ActiveVisit,
-		SupervisorRepo:     repos.GroupSupervisor,
-		CombinedGroupRepo:  repos.CombinedGroup,
-		GroupMappingRepo:   repos.GroupMapping,
-		AttendanceRepo:     repos.Attendance,
-		StudentStatusRepo:  repos.StudentStatusDay,
-		CrossTenantRepo:    activeRepo.NewCrossTenantRepository(db),
-		StudentRepo:        repos.Student,
-		PersonRepo:         repos.Person,
-		TeacherRepo:        repos.Teacher,
-		StaffRepo:          repos.Staff,
-		RoomRepo:           repos.Room,
-		ActivityGroupRepo:  repos.ActivityGroup,
-		ActivityCatRepo:    repos.ActivityCategory,
-		EducationGroupRepo: repos.Group,
-		DeviceRepo:         repos.Device,
-		EducationService:   educationService,
-		UsersService:       usersService,
-		DB:                 db,
-		Broadcaster:        realtimeHub,           // Pass SSE broadcaster
-		WorkSessionService: workSessionService,    // NFC auto-check-in
-		AttendanceSyncer:   attendanceSyncService, // WP-B10 mirror + SSE enrichment
-		Logger:             activeLogger,
+		GroupRepo:                repos.ActiveGroup,
+		VisitRepo:                repos.ActiveVisit,
+		SupervisorRepo:           repos.GroupSupervisor,
+		CombinedGroupRepo:        repos.CombinedGroup,
+		GroupMappingRepo:         repos.GroupMapping,
+		AttendanceRepo:           repos.Attendance,
+		StudentStatusRepo:        repos.StudentStatusDay,
+		CrossTenantRepo:          activeRepo.NewCrossTenantRepository(db),
+		StudentRepo:              repos.Student,
+		PersonRepo:               repos.Person,
+		TeacherRepo:              repos.Teacher,
+		StaffRepo:                repos.Staff,
+		RoomRepo:                 repos.Room,
+		ActivityGroupRepo:        repos.ActivityGroup,
+		ActivityCatRepo:          repos.ActivityCategory,
+		EducationGroupRepo:       repos.Group,
+		DeviceRepo:               repos.Device,
+		EducationService:         educationService,
+		UsersService:             usersService,
+		DB:                       db,
+		Broadcaster:              realtimeHub,           // Pass SSE broadcaster
+		WorkSessionService:       workSessionService,    // NFC auto-check-in
+		AttendanceSyncer:         attendanceSyncService, // WP-B10 mirror + SSE enrichment
+		TimetableBridgeCompleter: repos.ActivityInstance,
+		Logger:                   activeLogger,
 	})
 
 	// Initialize feedback service

--- a/backend/test/architecture_ratchet_test.go
+++ b/backend/test/architecture_ratchet_test.go
@@ -33,7 +33,7 @@ import (
 var serviceQueryRatchetAllowlist = map[string]int{
 	// Deliberately-kept transaction control (SAVEPOINT / advisory locks /
 	// LOCK TABLE) — transaction orchestration is service-layer per Rule 11.
-	"services/active/session_service.go":                1, // advisory lock (pg_advisory_xact_lock)
+	"services/active/session_service.go":                4, // advisory lock + savepoints for best-effort DB side effects
 	"services/enrollment/request_service.go":            1,
 	"services/import/student_import_config.go":          3,
 	"services/platform/operator_suggestions_service.go": 3,


### PR DESCRIPTION
## Summary
- End conflicting active sessions for the same activity when an IoT force-start happens on another device.
- Transfer open visits and active supervisors from the force-ended activity session to the new session.
- Add a regression test covering the cross-device same-activity force-start path.

## Root Cause
ForceStartActivitySessionWithSupervisors only ended an existing session on the current device, so a same-activity session on another device could remain active.

## Validation
- cd backend && go test ./services/active -run TestForceStartActivitySessionWithSupervisors -count=1
- cd backend && go test ./... -run "^$"
- cd backend && go test ./services/active -count=1
- pre-push: git-secrets, go-vet, frontend-knip, go-deadcode, frontend-check, golangci-lint

Closes #693