### PR TITLE
fix(guardians): prevent guardian deletion from cascading to siblings (#819)

### DIFF
--- a/backend/api/guardians/api.go
+++ b/backend/api/guardians/api.go
@@ -75,6 +75,10 @@ func (rs *Resource) Router() chi.Router {
 		// Security enforced when linking guardians to students
 		r.With(withTx).Post("/", rs.createGuardian)
 		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Put("/{id}", rs.updateGuardian)
+		// Read-only preview of a full delete's blast radius (admin-only check in
+		// the handler). Lets the UI show the affected children before confirming
+		// without the old destructive "probe DELETE" (#819).
+		r.With(authorize.RequiresPermission(permissions.UsersDelete), withTx).Get("/{id}/delete-preview", rs.guardianDeletePreview)
 		r.With(authorize.RequiresPermission(permissions.UsersDelete), withTx).Delete("/{id}", rs.deleteGuardian)
 
 		// Guardian invitations

--- a/backend/api/guardians/api.go
+++ b/backend/api/guardians/api.go
@@ -92,6 +92,11 @@ func (rs *Resource) Router() chi.Router {
 
 		// Create/Update/Delete relationships - custom supervisor permissions checked in handlers
 		r.With(withTx).Post("/students/{studentId}/guardians", rs.linkGuardianToStudent)
+		// Atomic create-or-link of one or more guardians for an existing student
+		// (#819): the whole batch succeeds or rolls back as one transaction, so a
+		// partially-created guardian is never orphaned and the frontend needs no
+		// client-side rollback. Supervisor gate checked in the handler.
+		r.With(withTx).Post("/students/{studentId}/guardians/batch", rs.createStudentGuardians)
 		r.With(withTx).Put("/relationships/{relationshipId}", rs.updateStudentGuardianRelationship)
 		r.With(withTx).Delete("/students/{studentId}/guardians/{guardianId}", rs.removeGuardianFromStudent)
 

--- a/backend/api/guardians/delete_warning_internal_test.go
+++ b/backend/api/guardians/delete_warning_internal_test.go
@@ -1,0 +1,41 @@
+package guardians
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGuardianFullDeleteWarning locks the German wording of the full-delete
+// blast-radius warning (#819). It must read as a warning about what the delete
+// WOULD do — never as if the deletion already happened — because the same text
+// backs both the pre-confirmation preview and the admin 409 body.
+func TestGuardianFullDeleteWarning(t *testing.T) {
+	t.Run("no links", func(t *testing.T) {
+		msg := guardianFullDeleteWarning(nil)
+		if !strings.Contains(msg, "keinem Kind") {
+			t.Fatalf("expected a no-links message, got %q", msg)
+		}
+	})
+
+	t.Run("single link does not list the child", func(t *testing.T) {
+		msg := guardianFullDeleteWarning([]string{"Anna Müller"})
+		if !strings.Contains(msg, "nur mit diesem Kind") {
+			t.Fatalf("expected the single-link reassurance, got %q", msg)
+		}
+		if strings.Contains(msg, "Anna Müller") {
+			t.Fatalf("the sole child (the one the caller came from) must not be listed, got %q", msg)
+		}
+	})
+
+	t.Run("multiple links names every affected child", func(t *testing.T) {
+		msg := guardianFullDeleteWarning([]string{"Anna Müller", "Ben Müller"})
+		for _, name := range []string{"Anna Müller", "Ben Müller"} {
+			if !strings.Contains(msg, name) {
+				t.Fatalf("expected %q in the multi-link warning, got %q", name, msg)
+			}
+		}
+		if !strings.Contains(msg, "2 Kindern") {
+			t.Fatalf("expected the affected count in the multi-link warning, got %q", msg)
+		}
+	})
+}

--- a/backend/api/guardians/guardians_test.go
+++ b/backend/api/guardians/guardians_test.go
@@ -18,6 +18,7 @@ import (
 	guardiansAPI "github.com/moto-nrw/project-phoenix/api/guardians"
 	"github.com/moto-nrw/project-phoenix/api/testutil"
 	"github.com/moto-nrw/project-phoenix/services"
+	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
 
@@ -450,6 +451,278 @@ func TestDeleteGuardian_InvalidID(t *testing.T) {
 	rr := testutil.ExecuteRequest(router, req)
 
 	testutil.AssertBadRequest(t, rr)
+}
+
+func TestGuardianDeletePreview_NotFound(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	router := chi.NewRouter()
+	router.Get("/guardians/{id}/delete-preview", ctx.resource.GuardianDeletePreviewHandler())
+
+	req := testutil.NewAuthenticatedRequest(t, "GET", "/guardians/99999/delete-preview", nil,
+		testutil.WithClaims(testutil.AdminTestClaims(999)),
+		testutil.WithPermissions("admin:*"),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertNotFound(t, rr)
+}
+
+func TestGuardianDeletePreview_SuccessIncludesAffectedLinkIDs(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	guardianID, studentID := createLinkedGuardian(t, ctx, "delete-preview")
+	defer cleanupGuardian(t, ctx.db, guardianID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, studentID)
+
+	router := chi.NewRouter()
+	router.Get("/guardians/{id}/delete-preview", ctx.resource.GuardianDeletePreviewHandler())
+
+	req := testutil.NewAuthenticatedRequest(t, "GET", fmt.Sprintf("/guardians/%d/delete-preview", guardianID), nil,
+		testutil.WithClaims(testutil.AdminTestClaims(999)),
+		testutil.WithPermissions("admin:*"),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	data, ok := response["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object in response: %s", rr.Body.String())
+	assert.Equal(t, float64(1), data["linked_count"])
+	assert.Len(t, data["affected_names"], 1)
+	assert.Len(t, data["affected_link_ids"], 1)
+}
+
+// createLinkedGuardian creates a guardian profile linked to a fresh student in
+// tenant 1 and returns both IDs. The caller is responsible for cleanup
+// (cleanupGuardian removes the link + guardian; the student is left for the
+// test's own teardown).
+func createLinkedGuardian(t *testing.T, ctx *testContext, emailSeed string) (guardianID, studentID int64) {
+	t.Helper()
+	tenantCtx := testpkg.TenantContext(1)
+	guardian := testpkg.CreateTestGuardianProfile(t, ctx.db, emailSeed)
+	student := testpkg.CreateTestStudent(t, ctx.db, "Linked", "Child", "1a")
+	_, err := ctx.services.Guardian.LinkGuardianToStudent(tenantCtx, usersSvc.StudentGuardianCreateRequest{
+		StudentID:         student.ID,
+		GuardianProfileID: guardian.ID,
+		RelationshipType:  "parent",
+		EmergencyPriority: 1,
+	})
+	require.NoError(t, err)
+	return guardian.ID, student.ID
+}
+
+func linkedGuardianErrorText(t *testing.T, rrBody string) string {
+	t.Helper()
+	response := testutil.ParseJSONResponse(t, []byte(rrBody))
+	text, ok := response["error"].(string)
+	require.True(t, ok, "expected error text in response: %s", rrBody)
+	return text
+}
+
+// TestDeleteGuardian_WithLinks_Conflict verifies that deleting a guardian that
+// is still linked to a student, WITHOUT ?force=true, is refused with 409 rather
+// than silently unlinking siblings (#819).
+func TestDeleteGuardian_WithLinks_Conflict(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	guardianID, studentID := createLinkedGuardian(t, ctx, "delete-conflict")
+	defer cleanupGuardian(t, ctx.db, guardianID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, studentID)
+
+	sibling := testpkg.CreateTestStudent(t, ctx.db, "Linked", "Sibling", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, sibling.ID)
+	_, err := ctx.services.Guardian.LinkGuardianToStudent(testpkg.TenantContext(1), usersSvc.StudentGuardianCreateRequest{
+		StudentID:         sibling.ID,
+		GuardianProfileID: guardianID,
+		RelationshipType:  "parent",
+		EmergencyPriority: 2,
+	})
+	require.NoError(t, err)
+
+	router := chi.NewRouter()
+	router.Delete("/guardians/{id}", ctx.resource.DeleteGuardianHandler())
+
+	req := testutil.NewAuthenticatedRequest(t, "DELETE", fmt.Sprintf("/guardians/%d", guardianID), nil,
+		testutil.WithClaims(testutil.AdminTestClaims(999)),
+		testutil.WithPermissions("admin:*"),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertErrorResponse(t, rr, http.StatusConflict)
+	assert.Contains(t, linkedGuardianErrorText(t, rr.Body.String()), "Linked Child")
+
+	// Guardian must still exist after the refused delete.
+	survivor, err := ctx.services.Guardian.GetGuardianByID(testpkg.TenantContext(1), guardianID)
+	require.NoError(t, err)
+	assert.NotNil(t, survivor)
+}
+
+func TestDeleteGuardian_WithLinks_NonAdminConflictDoesNotExposeNames(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, ctx.db, "Delete", "Supervisor")
+	defer testpkg.CleanupAuthFixtures(t, ctx.db, account.ID)
+
+	group := testpkg.CreateTestEducationGroup(t, ctx.db, "DeletePrivacy")
+	testpkg.CreateTestGroupTeacher(t, ctx.db, group.ID, teacher.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, group.ID, teacher.Staff.ID, teacher.ID)
+
+	guardian := testpkg.CreateTestGuardianProfile(t, ctx.db, "delete-privacy")
+	defer cleanupGuardian(t, ctx.db, guardian.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Private", "Child", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+	_, err := ctx.db.NewUpdate().
+		TableExpr("users.students").
+		Set("group_id = ?", group.ID).
+		Where("id = ?", student.ID).
+		Where("tenant_id = ?", 1).
+		Exec(testpkg.TenantContext(1))
+	require.NoError(t, err)
+
+	_, err = ctx.services.Guardian.LinkGuardianToStudent(testpkg.TenantContext(1), usersSvc.StudentGuardianCreateRequest{
+		StudentID:         student.ID,
+		GuardianProfileID: guardian.ID,
+		RelationshipType:  "parent",
+		EmergencyPriority: 1,
+	})
+	require.NoError(t, err)
+
+	router := chi.NewRouter()
+	router.Delete("/guardians/{id}", ctx.resource.DeleteGuardianHandler())
+
+	req := testutil.NewAuthenticatedRequest(t, "DELETE", fmt.Sprintf("/guardians/%d", guardian.ID), nil,
+		testutil.WithClaims(testutil.TeacherTestClaims(int(account.ID))),
+		testutil.WithPermissions("users:delete"),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertErrorResponse(t, rr, http.StatusConflict)
+	errText := linkedGuardianErrorText(t, rr.Body.String())
+	assert.Contains(t, errText, "Noch mit Schüler/innen verknüpft")
+	assert.NotContains(t, errText, "Private")
+	assert.NotContains(t, errText, "Child")
+}
+
+// TestDeleteGuardian_WithLinks_ForceAdmin_Success verifies that an admin can
+// fully delete a linked guardian with ?force=true: the guardian and all its
+// student links are removed.
+func TestDeleteGuardian_WithLinks_ForceAdmin_Success(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	guardianID, studentID := createLinkedGuardian(t, ctx, "delete-force")
+	defer cleanupGuardian(t, ctx.db, guardianID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, studentID)
+
+	router := chi.NewRouter()
+	router.Delete("/guardians/{id}", ctx.resource.DeleteGuardianHandler())
+
+	impact, err := ctx.services.Guardian.GetGuardianDeleteImpact(testpkg.TenantContext(1), guardianID)
+	require.NoError(t, err)
+	require.Len(t, impact.LinkIDs, 1)
+
+	req := testutil.NewAuthenticatedRequest(t, "DELETE", fmt.Sprintf("/guardians/%d?force=true&expected_link_ids=%d", guardianID, impact.LinkIDs[0]), nil,
+		testutil.WithClaims(testutil.AdminTestClaims(999)),
+		testutil.WithPermissions("admin:*"),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+
+	// Guardian is gone.
+	gone, _ := ctx.services.Guardian.GetGuardianByID(testpkg.TenantContext(1), guardianID)
+	assert.Nil(t, gone)
+}
+
+func TestDeleteGuardian_WithLinks_ForceAdminRejectsStalePreview(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	guardianID, studentID := createLinkedGuardian(t, ctx, "delete-force-stale")
+	defer cleanupGuardian(t, ctx.db, guardianID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, studentID)
+
+	router := chi.NewRouter()
+	router.Delete("/guardians/{id}", ctx.resource.DeleteGuardianHandler())
+
+	req := testutil.NewAuthenticatedRequest(t, "DELETE", fmt.Sprintf("/guardians/%d?force=true&expected_link_ids=999999", guardianID), nil,
+		testutil.WithClaims(testutil.AdminTestClaims(999)),
+		testutil.WithPermissions("admin:*"),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertErrorResponse(t, rr, http.StatusConflict)
+	assert.Contains(t, linkedGuardianErrorText(t, rr.Body.String()), "Vorschau")
+
+	survivor, err := ctx.services.Guardian.GetGuardianByID(testpkg.TenantContext(1), guardianID)
+	require.NoError(t, err)
+	assert.NotNil(t, survivor)
+}
+
+// TestDeleteGuardian_WithLinks_ForceNonAdmin_Forbidden verifies that a
+// non-admin supervisor cannot full-delete a linked guardian even with
+// ?force=true: the full delete reaches across siblings they may not supervise,
+// so the blast radius is restricted to admins (403). The guardian survives.
+func TestDeleteGuardian_WithLinks_ForceNonAdmin_Forbidden(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, ctx.db, "Force", "Supervisor")
+	defer testpkg.CleanupAuthFixtures(t, ctx.db, account.ID)
+
+	group := testpkg.CreateTestEducationGroup(t, ctx.db, "ForceForbidden")
+	testpkg.CreateTestGroupTeacher(t, ctx.db, group.ID, teacher.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, group.ID, teacher.Staff.ID, teacher.ID)
+
+	guardian := testpkg.CreateTestGuardianProfile(t, ctx.db, "force-forbidden")
+	defer cleanupGuardian(t, ctx.db, guardian.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Force", "Child", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+	_, err := ctx.db.NewUpdate().
+		TableExpr("users.students").
+		Set("group_id = ?", group.ID).
+		Where("id = ?", student.ID).
+		Where("tenant_id = ?", 1).
+		Exec(testpkg.TenantContext(1))
+	require.NoError(t, err)
+
+	_, err = ctx.services.Guardian.LinkGuardianToStudent(testpkg.TenantContext(1), usersSvc.StudentGuardianCreateRequest{
+		StudentID:         student.ID,
+		GuardianProfileID: guardian.ID,
+		RelationshipType:  "parent",
+		EmergencyPriority: 1,
+	})
+	require.NoError(t, err)
+
+	router := chi.NewRouter()
+	router.Delete("/guardians/{id}", ctx.resource.DeleteGuardianHandler())
+
+	req := testutil.NewAuthenticatedRequest(t, "DELETE", fmt.Sprintf("/guardians/%d?force=true", guardian.ID), nil,
+		testutil.WithClaims(testutil.TeacherTestClaims(int(account.ID))),
+		testutil.WithPermissions("users:delete"),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertErrorResponse(t, rr, http.StatusForbidden)
+
+	// Guardian must still exist after the refused force delete.
+	survivor, err := ctx.services.Guardian.GetGuardianByID(testpkg.TenantContext(1), guardian.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, survivor)
 }
 
 // =============================================================================

--- a/backend/api/guardians/handlers.go
+++ b/backend/api/guardians/handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -583,6 +584,14 @@ func (rs *Resource) updateGuardian(w http.ResponseWriter, r *http.Request) {
 	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
 		return rs.GuardianService.UpdateGuardian(ctx, id, updateReq)
 	}); err != nil {
+		// A duplicate email comes back as a ValidationError carrying a German
+		// message — render it as 400 (mirrors createGuardian), not the 500
+		// catch-all. The tenant tx already rolled back.
+		var validationErr *guardianSvc.ValidationError
+		if errors.As(err, &validationErr) {
+			common.RenderError(w, r, common.ErrorInvalidRequest(validationErr))
+			return
+		}
 		common.RenderError(w, r, common.ErrorInternalServer(err))
 		return
 	}
@@ -647,6 +656,100 @@ func applyGuardianUpdates(updateReq *guardianSvc.GuardianCreateRequest, req *Gua
 	}
 }
 
+// GuardianDeletePreview is the read-only answer to "what would a full delete of
+// this guardian affect?" — the children that would lose the guardian plus a
+// ready-to-show German warning. It backs GET /guardians/{id}/delete-preview.
+type GuardianDeletePreview struct {
+	LinkedCount     int      `json:"linked_count"`
+	AffectedNames   []string `json:"affected_names"`
+	AffectedLinkIDs []int64  `json:"affected_link_ids"`
+	Warning         string   `json:"warning"`
+}
+
+// guardianFullDeleteWarning builds the German warning describing the blast
+// radius of a deliberate full delete. It is shown in the confirmation step
+// (via the delete-preview endpoint) and as the body of the admin 409 a blind
+// delete returns. The wording is phrased as a warning about what the full
+// delete WOULD do — never as if the deletion has already happened — so it reads
+// correctly both as a pre-confirmation hint and as a 409 error body.
+func guardianFullDeleteWarning(names []string) string {
+	switch len(names) {
+	case 0:
+		return "Die Person ist mit keinem Kind verknüpft und wird mit dem Profil vollständig gelöscht."
+	case 1:
+		return "Die Person ist nur mit diesem Kind verknüpft und wird mit dem Profil vollständig gelöscht."
+	default:
+		return fmt.Sprintf(
+			"Die Person ist mit %d Kindern verknüpft und wird bei allen entfernt: %s.",
+			len(names), strings.Join(names, ", "))
+	}
+}
+
+// guardianDeletePreview returns the children a full delete would affect, plus a
+// ready-to-show German warning. Read-only: it replaces the old destructive
+// "probe DELETE" the frontend used to discover the affected children (#819), so
+// opening the full-delete confirmation never deletes anything by itself.
+//
+// Admin-only, mirroring who may actually perform the full delete — a full
+// delete reaches across siblings the caller may not supervise, so non-admins
+// have no use for (and must not see) the affected children.
+func (rs *Resource) guardianDeletePreview(w http.ResponseWriter, r *http.Request) {
+	id, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New(errInvalidGuardianID)))
+		return
+	}
+
+	if !common.HasAdminPermissions(jwt.PermissionsFromCtx(r.Context())) {
+		common.RenderError(w, r, common.ErrorForbidden(errors.New("only administrators can preview a full guardian delete")))
+		return
+	}
+
+	if _, err := rs.GuardianService.GetGuardianByID(r.Context(), id); err != nil {
+		if errors.Is(err, users.ErrGuardianProfileNotFound) {
+			common.RenderError(w, r, common.ErrorNotFound(errors.New("guardian not found")))
+			return
+		}
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	impact, err := rs.GuardianService.GetGuardianDeleteImpact(r.Context(), id)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, &GuardianDeletePreview{
+		LinkedCount:     len(impact.StudentNames),
+		AffectedNames:   impact.StudentNames,
+		AffectedLinkIDs: impact.LinkIDs,
+		Warning:         guardianFullDeleteWarning(impact.StudentNames),
+	}, "Guardian delete preview retrieved successfully")
+}
+
+func parseExpectedGuardianLinkIDs(r *http.Request) ([]int64, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get("expected_link_ids"))
+	if raw == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(raw, ",")
+	ids := make([]int64, 0, len(parts))
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			return nil, errors.New("expected_link_ids must contain only numeric IDs")
+		}
+		id, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || id <= 0 {
+			return nil, errors.New("expected_link_ids must contain only positive numeric IDs")
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
 // deleteGuardian handles deleting a guardian and all their relationships
 func (rs *Resource) deleteGuardian(w http.ResponseWriter, r *http.Request) {
 	// Parse ID from URL
@@ -663,12 +766,63 @@ func (rs *Resource) deleteGuardian(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Delete guardian
+	// "force" requests the deliberate full delete (guardian + all links). Without
+	// it, a guardian still linked to students is refused with a 409 listing the
+	// affected children — the single-student unlink lives at
+	// DELETE /students/{id}/guardians/{gid}.
+	force := r.URL.Query().Get("force") == "true"
+	isAdmin := common.HasAdminPermissions(jwt.PermissionsFromCtx(r.Context()))
+
+	impact, err := rs.GuardianService.GetGuardianDeleteImpact(r.Context(), id)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+	linkedNames := impact.StudentNames
+
+	if len(linkedNames) > 0 {
+		if !force {
+			message := "Erziehungsberechtigte/r kann nicht gelöscht werden: Noch mit Schüler/innen verknüpft"
+			if isAdmin {
+				message = guardianFullDeleteWarning(linkedNames)
+			}
+			common.RenderError(w, r, common.ErrorConflictMessage(message))
+			return
+		}
+		// A full delete reaches across every linked student — including siblings
+		// in groups the caller may not supervise. Restrict that blast radius to
+		// admins; group supervisors must use the per-student unlink instead.
+		if !isAdmin {
+			common.RenderError(w, r, common.ErrorForbidden(errors.New("only administrators can fully delete a guardian linked to students")))
+			return
+		}
+	}
+
+	expectedLinkIDs, err := parseExpectedGuardianLinkIDs(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	// Delete guardian. With links present (force+admin) remove the links first
+	// to satisfy the RESTRICT FK; otherwise a plain delete. Both run in one
+	// tenant transaction so a failure leaves guardian and links intact.
 	tenantID := tenant.FromContext(r.Context())
 	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		if len(linkedNames) > 0 {
+			return rs.GuardianService.DeleteGuardianWithLinks(ctx, id, expectedLinkIDs)
+		}
 		return rs.GuardianService.DeleteGuardian(ctx, id)
 	}); err != nil {
+		if errors.Is(err, guardianSvc.ErrGuardianDeletePreviewChanged) {
+			tenant.MarkRollback(r.Context())
+			common.RenderError(w, r, common.ErrorConflictMessage(err.Error()))
+			return
+		}
+		// Safety net: a link added between the check above and the delete trips
+		// the RESTRICT FK — surface it as the same 409 rather than a 500.
 		if common.IsConstraintViolation(err) {
+			tenant.MarkRollback(r.Context())
 			common.RenderError(w, r, common.ErrorConflictMessage("Erziehungsberechtigte/r kann nicht gelöscht werden: Noch mit Schüler/innen verknüpft"))
 			return
 		}
@@ -1117,6 +1271,11 @@ func (rs *Resource) UpdateGuardianHandler() http.HandlerFunc { return rs.updateG
 
 // DeleteGuardianHandler returns the delete guardian handler
 func (rs *Resource) DeleteGuardianHandler() http.HandlerFunc { return rs.deleteGuardian }
+
+// GuardianDeletePreviewHandler returns the guardian delete-preview handler.
+func (rs *Resource) GuardianDeletePreviewHandler() http.HandlerFunc {
+	return rs.guardianDeletePreview
+}
 
 // ListGuardiansWithoutAccountHandler returns the list guardians without account handler
 func (rs *Resource) ListGuardiansWithoutAccountHandler() http.HandlerFunc {

--- a/backend/api/guardians/handlers.go
+++ b/backend/api/guardians/handlers.go
@@ -238,6 +238,63 @@ func (req *StudentGuardianLinkRequest) Bind(_ *http.Request) error {
 	return nil
 }
 
+// GuardianPhoneInput is one phone number for a guardian created in the atomic
+// add-guardians-to-student request. Plain DTO (no per-element Bind): the service
+// layer validates via ValidateNewGuardians.
+type GuardianPhoneInput struct {
+	PhoneNumber string `json:"phone_number"`
+	PhoneType   string `json:"phone_type,omitempty"` // mobile, home, work, other
+	Label       string `json:"label,omitempty"`
+	IsPrimary   bool   `json:"is_primary,omitempty"`
+}
+
+// GuardianWithRelationshipInput is one guardian to attach to an EXISTING student
+// in a single atomic request: either a NEW profile (name/contact + phone
+// numbers) or an EXISTING one (GuardianProfileID, sibling case), plus the
+// relationship flags for THIS student. Mirrors one row of the student detail
+// page's guardian form and the GuardianInput used by the student-create flow.
+type GuardianWithRelationshipInput struct {
+	// GuardianProfileID, when set, links an EXISTING guardian profile instead of
+	// creating a new one (sibling case, #1513). The profile/phone fields below
+	// are then ignored and the existing profile is never mutated — only the
+	// relationship flags apply to the new link.
+	GuardianProfileID *int64 `json:"guardian_profile_id,omitempty"`
+
+	// Profile (used only when GuardianProfileID is nil)
+	FirstName              string `json:"first_name"`
+	LastName               string `json:"last_name"`
+	Email                  string `json:"email,omitempty"`
+	AddressStreet          string `json:"address_street,omitempty"`
+	AddressCity            string `json:"address_city,omitempty"`
+	AddressPostalCode      string `json:"address_postal_code,omitempty"`
+	PreferredContactMethod string `json:"preferred_contact_method,omitempty"`
+	LanguagePreference     string `json:"language_preference,omitempty"`
+	Notes                  string `json:"notes,omitempty"`
+
+	// Relationship to the student
+	RelationshipType   string `json:"relationship_type"`
+	IsPrimary          bool   `json:"is_primary,omitempty"`
+	IsEmergencyContact bool   `json:"is_emergency_contact,omitempty"`
+	CanPickup          bool   `json:"can_pickup,omitempty"`
+	PickupNotes        string `json:"pickup_notes,omitempty"`
+	EmergencyPriority  int    `json:"emergency_priority,omitempty"`
+
+	PhoneNumbers []GuardianPhoneInput `json:"phone_numbers,omitempty"`
+}
+
+// CreateStudentGuardiansRequest is the body of POST /students/{studentId}/guardians/batch.
+type CreateStudentGuardiansRequest struct {
+	Guardians []GuardianWithRelationshipInput `json:"guardians"`
+}
+
+// Bind validates the atomic add-guardians request.
+func (req *CreateStudentGuardiansRequest) Bind(_ *http.Request) error {
+	if len(req.Guardians) == 0 {
+		return errors.New("at least one guardian is required")
+	}
+	return nil
+}
+
 // newGuardianResponse converts a guardian profile model to a response
 func newGuardianResponse(profile *users.GuardianProfile) *GuardianResponse {
 	response := &GuardianResponse{
@@ -660,10 +717,24 @@ func applyGuardianUpdates(updateReq *guardianSvc.GuardianCreateRequest, req *Gua
 // this guardian affect?" — the children that would lose the guardian plus a
 // ready-to-show German warning. It backs GET /guardians/{id}/delete-preview.
 type GuardianDeletePreview struct {
-	LinkedCount     int      `json:"linked_count"`
-	AffectedNames   []string `json:"affected_names"`
-	AffectedLinkIDs []int64  `json:"affected_link_ids"`
+	LinkedCount   int      `json:"linked_count"`
+	AffectedNames []string `json:"affected_names"`
+	// AffectedLinkIDs are serialized as strings, not JSON numbers: students_guardians.id
+	// is an int64 and could exceed JavaScript's safe-integer range, where the frontend
+	// would silently round the value before echoing it back as expected_link_ids — making
+	// the confirm look like a stale preview. Strings cross the API boundary losslessly
+	// (repo convention: int64 IDs are strings to the client).
+	AffectedLinkIDs []string `json:"affected_link_ids"`
 	Warning         string   `json:"warning"`
+}
+
+// stringifyLinkIDs renders int64 link IDs as decimal strings for the API boundary.
+func stringifyLinkIDs(ids []int64) []string {
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[i] = strconv.FormatInt(id, 10)
+	}
+	return out
 }
 
 // guardianFullDeleteWarning builds the German warning describing the blast
@@ -723,7 +794,7 @@ func (rs *Resource) guardianDeletePreview(w http.ResponseWriter, r *http.Request
 	common.Respond(w, r, http.StatusOK, &GuardianDeletePreview{
 		LinkedCount:     len(impact.StudentNames),
 		AffectedNames:   impact.StudentNames,
-		AffectedLinkIDs: impact.LinkIDs,
+		AffectedLinkIDs: stringifyLinkIDs(impact.LinkIDs),
 		Warning:         guardianFullDeleteWarning(impact.StudentNames),
 	}, "Guardian delete preview retrieved successfully")
 }
@@ -1068,6 +1139,121 @@ func (rs *Resource) linkGuardianToStudent(w http.ResponseWriter, r *http.Request
 	}
 
 	common.Respond(w, r, http.StatusCreated, relationship, "Guardian linked to student successfully")
+}
+
+// trimToNil returns a pointer to the trimmed string, or nil when empty, so
+// optional JSON fields map cleanly onto nullable model columns.
+func trimToNil(s string) *string {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+// toNewStudentGuardians maps the request DTOs onto the service input used by
+// GuardianService.AddGuardiansToStudent.
+func toNewStudentGuardians(inputs []GuardianWithRelationshipInput) []guardianSvc.NewStudentGuardian {
+	out := make([]guardianSvc.NewStudentGuardian, 0, len(inputs))
+	for i := range inputs {
+		in := inputs[i]
+		out = append(out, guardianSvc.NewStudentGuardian{
+			Profile: guardianSvc.GuardianCreateRequest{
+				FirstName:              strings.TrimSpace(in.FirstName),
+				LastName:               strings.TrimSpace(in.LastName),
+				Email:                  trimToNil(in.Email),
+				AddressStreet:          trimToNil(in.AddressStreet),
+				AddressCity:            trimToNil(in.AddressCity),
+				AddressPostalCode:      trimToNil(in.AddressPostalCode),
+				PreferredContactMethod: in.PreferredContactMethod,
+				LanguagePreference:     in.LanguagePreference,
+				Notes:                  trimToNil(in.Notes),
+			},
+			Relationship: guardianSvc.StudentGuardianRelationship{
+				RelationshipType:   in.RelationshipType,
+				IsPrimary:          in.IsPrimary,
+				IsEmergencyContact: in.IsEmergencyContact,
+				CanPickup:          in.CanPickup,
+				PickupNotes:        trimToNil(in.PickupNotes),
+				EmergencyPriority:  in.EmergencyPriority,
+			},
+			PhoneNumbers:      toPhoneCreateRequests(in.PhoneNumbers),
+			ExistingProfileID: in.GuardianProfileID,
+		})
+	}
+	return out
+}
+
+// toPhoneCreateRequests maps phone DTOs onto the service phone-number requests.
+func toPhoneCreateRequests(phones []GuardianPhoneInput) []guardianSvc.PhoneNumberCreateRequest {
+	if len(phones) == 0 {
+		return nil
+	}
+	out := make([]guardianSvc.PhoneNumberCreateRequest, 0, len(phones))
+	for i := range phones {
+		p := phones[i]
+		out = append(out, guardianSvc.PhoneNumberCreateRequest{
+			PhoneNumber: strings.TrimSpace(p.PhoneNumber),
+			PhoneType:   p.PhoneType,
+			Label:       trimToNil(p.Label),
+			IsPrimary:   p.IsPrimary,
+		})
+	}
+	return out
+}
+
+// createStudentGuardians atomically creates (or links) one or more guardians for
+// an EXISTING student in a single tenant transaction. It is the server-side
+// replacement for the frontend's old create→link→add-phones sequence: any
+// failure rolls the whole transaction back, so a partially-created guardian can
+// never be orphaned — and there is no client-side compensating delete to
+// authorize (which a non-admin supervisor could not perform once the guardian
+// had no remaining links). See #819.
+//
+// Auth mirrors the single-link endpoint (linkGuardianToStudent): only
+// supervisors of the student's group, or admins, may attach guardians. That one
+// gate is sufficient and grants no extra reach — the endpoint only ever links to
+// the {studentId} in the path, and creating the profile + linking it + adding
+// its phones are all writes scoped to that student's guardian, exactly what
+// "may I modify this student's guardians?" already authorizes.
+func (rs *Resource) createStudentGuardians(w http.ResponseWriter, r *http.Request) {
+	studentID, err := common.ParseIDParam(r, "studentId")
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New(common.MsgInvalidStudentID)))
+		return
+	}
+
+	canModify, err := rs.canModifyStudent(r.Context(), studentID)
+	if !canModify {
+		common.RenderError(w, r, common.ErrorForbidden(err))
+		return
+	}
+
+	req := &CreateStudentGuardiansRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	guardians := toNewStudentGuardians(req.Guardians)
+
+	tenantID := tenant.FromContext(r.Context())
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return rs.GuardianService.AddGuardiansToStudent(ctx, studentID, guardians)
+	}); err != nil {
+		// AddGuardiansToStudent validates before any write, so a ValidationError
+		// means nothing was persisted; the explicit tenant tx also rolls back on
+		// any other error. Surface bad input as 400, everything else as 500.
+		var validationErr *guardianSvc.ValidationError
+		if errors.As(err, &validationErr) {
+			common.RenderError(w, r, common.ErrorInvalidRequest(validationErr))
+			return
+		}
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusCreated, nil, "Guardians added successfully")
 }
 
 // updateStudentGuardianRelationship handles updating a student-guardian relationship (SUPERVISOR only)

--- a/backend/api/guardians/student_guardians_batch_test.go
+++ b/backend/api/guardians/student_guardians_batch_test.go
@@ -1,0 +1,122 @@
+// Package guardians_test — tests for the atomic add-guardians-to-student
+// endpoint (POST /students/{studentId}/guardians/batch, #819).
+//
+// These exercise the handler through the real Resource.Router() with a minted
+// JWT so the production middleware chain (Verifier → Authenticator →
+// TenantMiddleware → TenantTxMiddleware) runs, rather than via a test-export
+// handler wrapper (backend conventions Rule 5).
+package guardians_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+func init() {
+	// Ensure a JWT secret exists so MintTestJWT and Router()'s MustNewTokenAuth
+	// agree (no-op when AUTH_JWT_SECRET is already in the environment).
+	testutil.SeedTestJWTConfig()
+}
+
+// TestCreateStudentGuardians_Admin_Success creates a brand-new guardian (with a
+// phone number) for an existing student in one atomic request and verifies it is
+// persisted and linked.
+func TestCreateStudentGuardians_Admin_Success(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Batch", "Child", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	router := ctx.resource.Router()
+
+	body := map[string]any{
+		"guardians": []map[string]any{
+			{
+				"first_name":         "Atomic",
+				"last_name":          "Guardian",
+				"email":              "batch-guardian-" + time.Now().Format("150405.000000") + "@test.com",
+				"relationship_type":  "parent",
+				"emergency_priority": 1,
+				"phone_numbers": []map[string]any{
+					{"phone_number": "+49 123 456", "phone_type": "mobile", "is_primary": true},
+				},
+			},
+		},
+	}
+
+	claims := testutil.AdminTestClaims(999)
+	req := testutil.NewAuthenticatedRequest(t, "POST",
+		fmt.Sprintf("/students/%d/guardians/batch", student.ID), body,
+		testutil.WithJWTBearer(testutil.MintTestJWT(t, claims)),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusCreated)
+
+	// The guardian is created and linked to the student.
+	linked, err := ctx.services.Guardian.GetStudentGuardians(testpkg.TenantContext(1), student.ID)
+	require.NoError(t, err)
+	require.Len(t, linked, 1, "expected exactly one linked guardian")
+	assert.Equal(t, "Atomic", linked[0].Profile.FirstName)
+	defer cleanupGuardian(t, ctx.db, linked[0].Profile.ID)
+}
+
+// TestCreateStudentGuardians_EmptyGuardians_BadRequest rejects an empty batch.
+func TestCreateStudentGuardians_EmptyGuardians_BadRequest(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Empty", "Batch", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	router := ctx.resource.Router()
+
+	body := map[string]any{"guardians": []map[string]any{}}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST",
+		fmt.Sprintf("/students/%d/guardians/batch", student.ID), body,
+		testutil.WithJWTBearer(testutil.MintTestJWT(t, testutil.AdminTestClaims(999))),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertBadRequest(t, rr)
+}
+
+// TestCreateStudentGuardians_Forbidden_NonStaff verifies a non-admin caller with
+// no staff record cannot attach guardians (same supervisor gate as the
+// single-link endpoint).
+func TestCreateStudentGuardians_Forbidden_NonStaff(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Forbidden", "Batch", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	router := ctx.resource.Router()
+
+	body := map[string]any{
+		"guardians": []map[string]any{
+			{"first_name": "X", "last_name": "Y", "relationship_type": "parent", "emergency_priority": 1},
+		},
+	}
+
+	// Authenticated but not admin and not a staff member → canModifyStudent fails.
+	nonStaff := jwt.AppClaims{ID: 555, Sub: "nonstaff@test.com", TenantID: 1, Roles: []string{"user"}, Permissions: []string{"users:read"}}
+	req := testutil.NewAuthenticatedRequest(t, "POST",
+		fmt.Sprintf("/students/%d/guardians/batch", student.ID), body,
+		testutil.WithJWTBearer(testutil.MintTestJWT(t, nonStaff)),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertForbidden(t, rr)
+}

--- a/backend/database/migrations/001015127_guardian_fk_restrict.go
+++ b/backend/database/migrations/001015127_guardian_fk_restrict.go
@@ -1,0 +1,84 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	guardianFKRestrictVersion     = "1.15.127"
+	guardianFKRestrictDescription = "Change students_guardians → guardian_profiles FK from ON DELETE CASCADE to RESTRICT to prevent unintended sibling unlinking on guardian deletion (#819)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     guardianFKRestrictVersion,
+		Description: guardianFKRestrictDescription,
+		DependsOn:   []string{"1.15.126", "1.15.2"}, // composite FKs created in 1.15.2
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return setGuardianLinkFKOnDelete(ctx, db, "RESTRICT")
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return setGuardianLinkFKOnDelete(ctx, db, "CASCADE")
+		},
+	)
+}
+
+// setGuardianLinkFKOnDelete drops and recreates the composite FK
+// fk_students_guardians_guardian_tenant with the given ON DELETE action.
+//
+// Why RESTRICT (up): under the original CASCADE, DELETE /guardians/{id} silently
+// removed every students_guardians row for that guardian — including links to
+// SIBLINGS the caller never intended to touch (#819). RESTRICT turns a blind
+// guardian delete into a hard error when links still exist, which is what makes
+// the handler's existing 409 ("Noch mit Schüler/innen verknüpft") branch
+// reachable. Deliberate full deletion removes the link rows first, then the
+// guardian, inside one tenant transaction.
+//
+// Only this one inbound FK is changed. The guardian's OWN dependents
+// (guardian_phone_numbers, guardian_invitations) keep CASCADE — deleting a
+// guardian SHOULD clean those up; the danger was only the shared link table.
+func setGuardianLinkFKOnDelete(ctx context.Context, db *bun.DB, onDelete string) error {
+	fmt.Printf("Migration %s: setting fk_students_guardians_guardian_tenant ON DELETE %s...\n",
+		guardianFKRestrictVersion, onDelete)
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil &&
+			err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	// Drop the existing composite FK (created in 1.15.2). It is named, so a
+	// direct DROP is safe; IF EXISTS keeps the migration idempotent.
+	if _, err := tx.ExecContext(ctx,
+		`ALTER TABLE users.students_guardians DROP CONSTRAINT IF EXISTS fk_students_guardians_guardian_tenant`,
+	); err != nil {
+		return fmt.Errorf("failed to drop fk_students_guardians_guardian_tenant: %w", err)
+	}
+
+	// Recreate it in the exact composite shape from 1.15.2, only swapping the
+	// ON DELETE action.
+	addSQL := fmt.Sprintf(
+		`ALTER TABLE users.students_guardians
+		 ADD CONSTRAINT fk_students_guardians_guardian_tenant
+		 FOREIGN KEY (tenant_id, guardian_profile_id)
+		 REFERENCES users.guardian_profiles(tenant_id, id)
+		 ON DELETE %s`, onDelete)
+	if _, err := tx.ExecContext(ctx, addSQL); err != nil {
+		return fmt.Errorf("failed to recreate fk_students_guardians_guardian_tenant with ON DELETE %s: %w", onDelete, err)
+	}
+
+	return tx.Commit()
+}

--- a/backend/database/repositories/users/guardian_profile.go
+++ b/backend/database/repositories/users/guardian_profile.go
@@ -74,6 +74,28 @@ func (r *GuardianProfileRepository) FindByID(ctx context.Context, id int64) (*us
 	return profile, nil
 }
 
+// LockByIDForUpdate locks a guardian profile row for the current transaction.
+func (r *GuardianProfileRepository) LockByIDForUpdate(ctx context.Context, id int64) error {
+	var profileID int64
+	query := repoBase.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`users.guardian_profiles AS "guardian_profile"`).
+		ColumnExpr(`"guardian_profile".id`).
+		Where(`"guardian_profile".id = ?`, id).
+		For("UPDATE")
+
+	if where, tenantID, ok := repoBase.TenantWhere(ctx, "guardian_profile"); ok {
+		query.Where(where, tenantID)
+	}
+
+	if err := query.Scan(ctx, &profileID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return users.ErrGuardianProfileNotFound
+		}
+		return fmt.Errorf("failed to lock guardian profile: %w", err)
+	}
+	return nil
+}
+
 // FindByEmail retrieves a guardian profile by their email address
 func (r *GuardianProfileRepository) FindByEmail(ctx context.Context, email string) (*users.GuardianProfile, error) {
 	profile := new(users.GuardianProfile)

--- a/backend/database/repositories/users/guardian_profile_repository_test.go
+++ b/backend/database/repositories/users/guardian_profile_repository_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -635,4 +636,36 @@ func TestGuardianProfileRepository_FindByAccountID_PrefersExplicitPortalLocale(t
 	require.NotNil(t, found.PortalLocale, "the row with an explicit portal_locale must win over the NULL one")
 	assert.Equal(t, "en", *found.PortalLocale)
 	assert.Equal(t, newer.ID, found.ID, "ordering must prefer the explicit-locale row, not the lowest id")
+}
+
+// ============================================================================
+// LockByIDForUpdate
+// ============================================================================
+
+func TestGuardianProfileRepository_LockByIDForUpdate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).GuardianProfile
+
+	t.Run("locks an existing guardian within a tenant transaction", func(t *testing.T) {
+		guardian := testpkg.CreateTestGuardianProfile(t, db, "lock-existing")
+		defer testpkg.CleanupActivityFixtures(t, db, guardian.ID)
+
+		// The full-delete flow takes this lock inside a tenant tx; exercise the
+		// real contract rather than a bare autocommit call.
+		err := tenant.WithTenantTx(testpkg.TenantContext(1), db, 1, func(txCtx context.Context, _ bun.Tx) error {
+			return repo.LockByIDForUpdate(txCtx, guardian.ID)
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("returns ErrGuardianProfileNotFound for a missing guardian", func(t *testing.T) {
+		// A non-existent id must surface as the typed not-found error, not a raw
+		// sql.ErrNoRows — the delete handler maps it to a clean 404/409.
+		err := tenant.WithTenantTx(testpkg.TenantContext(1), db, 1, func(txCtx context.Context, _ bun.Tx) error {
+			return repo.LockByIDForUpdate(txCtx, 999999999)
+		})
+		assert.ErrorIs(t, err, users.ErrGuardianProfileNotFound)
+	})
 }

--- a/backend/models/users/repository.go
+++ b/backend/models/users/repository.go
@@ -542,6 +542,10 @@ type GuardianProfileRepository interface {
 	// FindByID retrieves a guardian profile by their ID
 	FindByID(ctx context.Context, id int64) (*GuardianProfile, error)
 
+	// LockByIDForUpdate locks a guardian profile row for the current
+	// transaction. Used by full-delete flows to block concurrent link inserts.
+	LockByIDForUpdate(ctx context.Context, id int64) error
+
 	// FindByEmail retrieves a guardian profile by their email address
 	FindByEmail(ctx context.Context, email string) (*GuardianProfile, error)
 

--- a/backend/services/parent/parent_service_test.go
+++ b/backend/services/parent/parent_service_test.go
@@ -219,6 +219,7 @@ func (s *stubGuardianProfileRepo) Create(context.Context, *userModels.GuardianPr
 func (s *stubGuardianProfileRepo) FindByID(context.Context, int64) (*userModels.GuardianProfile, error) {
 	return nil, nil
 }
+func (s *stubGuardianProfileRepo) LockByIDForUpdate(context.Context, int64) error { return nil }
 func (s *stubGuardianProfileRepo) FindByEmail(context.Context, string) (*userModels.GuardianProfile, error) {
 	return nil, nil
 }

--- a/backend/services/users/errors.go
+++ b/backend/services/users/errors.go
@@ -54,6 +54,10 @@ var (
 
 	// ErrGuardianHasStudents indicates guardian is still linked to students
 	ErrGuardianHasStudents = errors.New("Erziehungsberechtigte/r kann nicht gelöscht werden: Noch mit Schüler/innen verknüpft") //nolint:staticcheck // ST1005: user-facing German message
+
+	// ErrGuardianDeletePreviewChanged indicates the affected guardian links no
+	// longer match the set the admin confirmed.
+	ErrGuardianDeletePreviewChanged = errors.New("Die Verknüpfungen haben sich seit der Vorschau geändert. Bitte erneut prüfen.") //nolint:staticcheck // ST1005: user-facing German message
 )
 
 // UsersError represents an error in the users service

--- a/backend/services/users/guardian_interface.go
+++ b/backend/services/users/guardian_interface.go
@@ -127,6 +127,14 @@ type GuardianPickerMatch struct {
 	Children []*users.GuardianLinkedChild
 }
 
+// GuardianDeleteImpact is the exact current blast radius of a full guardian
+// delete. LinkIDs is the concurrency token the frontend sends back on confirm;
+// StudentNames is display-only warning text.
+type GuardianDeleteImpact struct {
+	LinkIDs      []int64
+	StudentNames []string
+}
+
 // StudentWithRelationship represents a student with guardian relationship details
 type StudentWithRelationship struct {
 	Student      *users.Student
@@ -156,8 +164,25 @@ type GuardianService interface {
 	// UpdateGuardian updates a guardian profile
 	UpdateGuardian(ctx context.Context, id int64, req GuardianCreateRequest) error
 
-	// DeleteGuardian removes a guardian profile (and all relationships)
+	// DeleteGuardian removes a guardian profile without touching its student
+	// links. Fails with a FK violation (→ 409 at the handler) when links remain,
+	// because the FK is ON DELETE RESTRICT since migration 1.15.127.
 	DeleteGuardian(ctx context.Context, id int64) error
+
+	// DeleteGuardianWithLinks deletes a guardian together with all of its
+	// student↔guardian links (the deliberate "Komplett löschen" path, #819).
+	// Must run inside a tenant transaction; the handler gates it to admins.
+	// expectedLinkIDs must be the exact link set returned by the delete preview.
+	DeleteGuardianWithLinks(ctx context.Context, id int64, expectedLinkIDs []int64) error
+
+	// GetLinkedStudentNames returns the full names of every student linked to
+	// the guardian. Empty means a plain delete is safe; non-empty drives the
+	// 409 warning listing the affected children.
+	GetLinkedStudentNames(ctx context.Context, guardianProfileID int64) ([]string, error)
+
+	// GetGuardianDeleteImpact returns the exact current affected link IDs and
+	// student names for the admin full-delete confirmation.
+	GetGuardianDeleteImpact(ctx context.Context, guardianProfileID int64) (*GuardianDeleteImpact, error)
 
 	// SendInvitation sends an invitation to a guardian
 	SendInvitation(ctx context.Context, req GuardianInvitationRequest) (*authModels.GuardianInvitation, error)

--- a/backend/services/users/guardian_service.go
+++ b/backend/services/users/guardian_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	authService "github.com/moto-nrw/project-phoenix/services/auth"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/driver/pgdriver"
 )
 
 const (
@@ -24,7 +26,20 @@ const (
 	errMsgGuardianNotFound = "guardian profile not found: %w"
 	// errMsgPhoneNotFound is the error message format for phone number not found errors
 	errMsgPhoneNotFound = "phone number not found: %w"
+	// emailInUseMsgFmt is the user-facing German message (with a %q placeholder
+	// for the email) returned as a 400 when a guardian email collides with an
+	// existing profile. Single source of truth so the wording stays identical
+	// across the create, update, and batch-validate paths (#819).
+	emailInUseMsgFmt = "E-Mail-Adresse %q ist bereits vergeben – bitte die vorhandene Person über die Suche auswählen"
 )
+
+// newEmailInUseError builds the 400 ValidationError for a duplicate guardian
+// email. email is trimmed for display so the message matches what the unique
+// pre-check compared.
+func newEmailInUseError(email string) *ValidationError {
+	//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
+	return &ValidationError{Err: fmt.Errorf(emailInUseMsgFmt, strings.TrimSpace(email))}
+}
 
 // GuardianServiceDependencies contains all dependencies required by the guardian service
 type GuardianServiceDependencies struct {
@@ -137,12 +152,18 @@ func (s *guardianService) CreateGuardian(ctx context.Context, req GuardianCreate
 	// as strict as the index and never lets a colliding email slip through.
 	if profile.Email != nil && strings.TrimSpace(*profile.Email) != "" {
 		if existing, err := s.guardianProfileRepo.FindByEmail(ctx, strings.TrimSpace(*profile.Email)); err == nil && existing != nil {
-			//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
-			return nil, &ValidationError{Err: fmt.Errorf("E-Mail-Adresse %q ist bereits vergeben – bitte die vorhandene Person über die Suche auswählen", strings.TrimSpace(*profile.Email))}
+			return nil, newEmailInUseError(*profile.Email)
 		}
 	}
 
 	if err := s.guardianProfileRepo.Create(ctx, profile); err != nil {
+		// TOCTOU guard: two concurrent creates can both pass the FindByEmail
+		// pre-check above and then race on the UNIQUE(tenant_id, email) index.
+		// The loser gets a raw 23505 — classify it as the same bad-input
+		// ValidationError (HTTP 400) the pre-check produces, never a 500.
+		if isGuardianUniqueViolation(err) && profile.Email != nil {
+			return nil, newEmailInUseError(*profile.Email)
+		}
 		return nil, fmt.Errorf("failed to create guardian profile: %w", err)
 	}
 
@@ -206,6 +227,17 @@ func (s *guardianService) UpdateGuardian(ctx context.Context, id int64, req Guar
 		return err
 	}
 
+	// Reject assigning an email already owned by a DIFFERENT guardian. Without
+	// this the UNIQUE(tenant_id, email) index fires on Update and the handler
+	// maps it to a raw 500. The existing.ID != id guard is essential: saving the
+	// guardian without changing the email must NOT collide with the row itself.
+	// FindByEmail is case-insensitive (LOWER=LOWER), matching CreateGuardian.
+	if req.Email != nil && strings.TrimSpace(*req.Email) != "" {
+		if existing, ferr := s.guardianProfileRepo.FindByEmail(ctx, strings.TrimSpace(*req.Email)); ferr == nil && existing != nil && existing.ID != id {
+			return newEmailInUseError(*req.Email)
+		}
+	}
+
 	// Update fields (phone numbers are managed separately)
 	profile.FirstName = req.FirstName
 	profile.LastName = req.LastName
@@ -222,13 +254,108 @@ func (s *guardianService) UpdateGuardian(ctx context.Context, id int64, req Guar
 		profile.LanguagePreference = req.LanguagePreference
 	}
 
-	return s.guardianProfileRepo.Update(ctx, profile)
+	if err := s.guardianProfileRepo.Update(ctx, profile); err != nil {
+		// TOCTOU guard mirroring CreateGuardian: a concurrent writer can claim
+		// the email between the check above and this Update.
+		if isGuardianUniqueViolation(err) && profile.Email != nil {
+			return newEmailInUseError(*profile.Email)
+		}
+		return err
+	}
+	return nil
 }
 
-// DeleteGuardian removes a guardian profile
+// DeleteGuardian removes a guardian profile WITHOUT touching its student links.
+//
+// Since migration 1.15.127 the students_guardians → guardian_profiles FK is
+// ON DELETE RESTRICT, so this fails with a foreign-key violation when the
+// guardian is still linked to any student — the handler turns that into a 409.
+// Use this only for guardians with no remaining links; for the deliberate
+// full delete use DeleteGuardianWithLinks.
 func (s *guardianService) DeleteGuardian(ctx context.Context, id int64) error {
-	// CASCADE will handle student_guardians relationships
 	return s.guardianProfileRepo.Delete(ctx, id)
+}
+
+// DeleteGuardianWithLinks deletes a guardian together with all of its
+// student↔guardian links. Under the RESTRICT FK (1.15.127) the link rows MUST
+// be removed before the guardian, so order matters. The caller is expected to
+// run this inside a tenant transaction (the HTTP handler does, via
+// WithTenantTx) so the two steps commit atomically — a mid-way failure rolls
+// back and leaves the guardian and its links intact.
+//
+// This is the "Komplett löschen" path from #819 and is gated to admins at the
+// handler, because it reaches across every linked student — including siblings
+// in groups the caller may not supervise.
+func (s *guardianService) DeleteGuardianWithLinks(ctx context.Context, id int64, expectedLinkIDs []int64) error {
+	if err := s.guardianProfileRepo.LockByIDForUpdate(ctx, id); err != nil {
+		return fmt.Errorf("failed to lock guardian profile %d: %w", id, err)
+	}
+
+	links, err := s.studentGuardianRepo.FindByGuardianProfileID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to load guardian links: %w", err)
+	}
+	currentLinkIDs := make([]int64, 0, len(links))
+	for _, link := range links {
+		currentLinkIDs = append(currentLinkIDs, link.ID)
+	}
+	if !sameInt64Set(currentLinkIDs, expectedLinkIDs) {
+		return ErrGuardianDeletePreviewChanged
+	}
+	for _, link := range links {
+		if err := s.studentGuardianRepo.Delete(ctx, link.ID); err != nil {
+			return fmt.Errorf("failed to remove guardian link %d: %w", link.ID, err)
+		}
+	}
+	return s.guardianProfileRepo.Delete(ctx, id)
+}
+
+// GetLinkedStudentNames returns the full names of every student currently
+// linked to the guardian. Backs the delete-confirmation flow: an empty slice
+// means a plain delete is safe, a non-empty one drives the 409 warning that
+// lists exactly which children (incl. siblings) would lose the guardian.
+func (s *guardianService) GetLinkedStudentNames(ctx context.Context, guardianProfileID int64) ([]string, error) {
+	impact, err := s.GetGuardianDeleteImpact(ctx, guardianProfileID)
+	if err != nil {
+		return nil, err
+	}
+	return impact.StudentNames, nil
+}
+
+// GetGuardianDeleteImpact returns the exact current affected links and display
+// names for a full guardian delete preview.
+func (s *guardianService) GetGuardianDeleteImpact(ctx context.Context, guardianProfileID int64) (*GuardianDeleteImpact, error) {
+	return s.getGuardianDeleteImpact(ctx, guardianProfileID)
+}
+
+func sameInt64Set(a, b []int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	aCopy := slices.Clone(a)
+	bCopy := slices.Clone(b)
+	slices.Sort(aCopy)
+	slices.Sort(bCopy)
+	return slices.Equal(aCopy, bCopy)
+}
+
+// isGuardianUniqueViolation reports whether err (or a wrapped DatabaseError)
+// carries PostgreSQL code 23505 (unique_violation) — used to classify a raced
+// duplicate-email insert/update as bad input rather than a 500.
+func isGuardianUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var dbErr *base.DatabaseError
+	if errors.As(err, &dbErr) {
+		err = dbErr.Err
+	}
+	var pgErr pgdriver.Error
+	if errors.As(err, &pgErr) {
+		return pgErr.IntegrityViolation() && pgErr.Field('C') == "23505"
+	}
+	return false
 }
 
 // SendInvitation sends an invitation to a guardian.
@@ -344,13 +471,25 @@ func (s *guardianService) sendInvitationEmail(ctx context.Context, invitation *a
 // Returns an error if the guardian-student relationships cannot be loaded or if any student/person
 // lookup fails. This ensures callers can distinguish between "no students" and "data retrieval failure".
 func (s *guardianService) getStudentNamesForGuardian(ctx context.Context, guardianProfileID int64) ([]string, error) {
+	impact, err := s.getGuardianDeleteImpact(ctx, guardianProfileID)
+	if err != nil {
+		return nil, err
+	}
+	return impact.StudentNames, nil
+}
+
+// getGuardianDeleteImpact retrieves the link IDs and full names of all students
+// linked to a guardian from the same relationship snapshot.
+func (s *guardianService) getGuardianDeleteImpact(ctx context.Context, guardianProfileID int64) (*GuardianDeleteImpact, error) {
 	relationships, err := s.studentGuardianRepo.FindByGuardianProfileID(ctx, guardianProfileID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load guardian-student relationships: %w", err)
 	}
 
+	linkIDs := make([]int64, 0, len(relationships))
 	studentNames := make([]string, 0, len(relationships))
 	for _, rel := range relationships {
+		linkIDs = append(linkIDs, rel.ID)
 		student, err := s.studentRepo.FindByID(ctx, rel.StudentID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load student %d: %w", rel.StudentID, err)
@@ -369,7 +508,10 @@ func (s *guardianService) getStudentNamesForGuardian(ctx context.Context, guardi
 		studentNames = append(studentNames, person.GetFullName())
 	}
 
-	return studentNames, nil
+	return &GuardianDeleteImpact{
+		LinkIDs:      linkIDs,
+		StudentNames: studentNames,
+	}, nil
 }
 
 // ValidateInvitation validates an invitation token.
@@ -825,7 +967,7 @@ func (s *guardianService) ValidateNewGuardians(ctx context.Context, guardians []
 			}
 			if existing, err := s.guardianProfileRepo.FindByEmail(ctx, email); err == nil && existing != nil {
 				//nolint:staticcheck // ST1005: user-facing German message rendered in the 400 response
-				return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: E-Mail-Adresse %q ist bereits vergeben – bitte die vorhandene Person über die Suche auswählen", i+1, email)}
+				return &ValidationError{Err: fmt.Errorf("Erziehungsberechtigte/r %d: "+emailInUseMsgFmt, i+1, email)}
 			}
 			seenEmails[email] = struct{}{}
 		}

--- a/backend/services/users/guardian_service_internal_test.go
+++ b/backend/services/users/guardian_service_internal_test.go
@@ -1,0 +1,274 @@
+// Package users internal tests cover the unexported helpers and the error
+// branches of the guardian service that a real database cannot reach
+// deterministically (forced repository failures). These are regression tests:
+// each one fails if the corresponding guard is removed or weakened.
+package users
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fakes -----------------------------------------------------------------
+//
+// Each fake embeds the full repository interface so it satisfies the type;
+// only the methods a given test exercises are overridden. Any un-overridden
+// method panics (nil interface) — which is exactly what we want, since calling
+// one would mean the code under test took an unexpected path.
+
+type fakeProfileRepo struct {
+	users.GuardianProfileRepository
+	findByEmailFn func(ctx context.Context, email string) (*users.GuardianProfile, error)
+	createFn      func(ctx context.Context, p *users.GuardianProfile) error
+	findByIDFn    func(ctx context.Context, id int64) (*users.GuardianProfile, error)
+	updateFn      func(ctx context.Context, p *users.GuardianProfile) error
+	lockFn        func(ctx context.Context, id int64) error
+	deleteFn      func(ctx context.Context, id int64) error
+}
+
+func (f *fakeProfileRepo) FindByEmail(ctx context.Context, email string) (*users.GuardianProfile, error) {
+	return f.findByEmailFn(ctx, email)
+}
+func (f *fakeProfileRepo) Create(ctx context.Context, p *users.GuardianProfile) error {
+	return f.createFn(ctx, p)
+}
+func (f *fakeProfileRepo) FindByID(ctx context.Context, id int64) (*users.GuardianProfile, error) {
+	return f.findByIDFn(ctx, id)
+}
+func (f *fakeProfileRepo) Update(ctx context.Context, p *users.GuardianProfile) error {
+	return f.updateFn(ctx, p)
+}
+func (f *fakeProfileRepo) LockByIDForUpdate(ctx context.Context, id int64) error {
+	return f.lockFn(ctx, id)
+}
+func (f *fakeProfileRepo) Delete(ctx context.Context, id int64) error {
+	return f.deleteFn(ctx, id)
+}
+
+type fakeStudentGuardianRepo struct {
+	users.StudentGuardianRepository
+	findByGuardianFn func(ctx context.Context, guardianProfileID int64) ([]*users.StudentGuardian, error)
+	deleteFn         func(ctx context.Context, id interface{}) error
+}
+
+func (f *fakeStudentGuardianRepo) FindByGuardianProfileID(ctx context.Context, guardianProfileID int64) ([]*users.StudentGuardian, error) {
+	return f.findByGuardianFn(ctx, guardianProfileID)
+}
+func (f *fakeStudentGuardianRepo) Delete(ctx context.Context, id interface{}) error {
+	return f.deleteFn(ctx, id)
+}
+
+type fakeStudentRepo struct {
+	users.StudentRepository
+	findByIDFn func(ctx context.Context, id interface{}) (*users.Student, error)
+}
+
+func (f *fakeStudentRepo) FindByID(ctx context.Context, id interface{}) (*users.Student, error) {
+	return f.findByIDFn(ctx, id)
+}
+
+type fakePersonRepo struct {
+	users.PersonRepository
+	findByIDFn func(ctx context.Context, id interface{}) (*users.Person, error)
+}
+
+func (f *fakePersonRepo) FindByID(ctx context.Context, id interface{}) (*users.Person, error) {
+	return f.findByIDFn(ctx, id)
+}
+
+// --- unexported helpers ----------------------------------------------------
+
+func TestSameInt64Set(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []int64
+		want bool
+	}{
+		{"equal same order", []int64{1, 2, 3}, []int64{1, 2, 3}, true},
+		{"equal different order", []int64{3, 1, 2}, []int64{1, 2, 3}, true},
+		{"both empty", []int64{}, []int64{}, true},
+		{"different length", []int64{1, 2}, []int64{1, 2, 3}, false},
+		{"same length different elements", []int64{1, 2, 3}, []int64{1, 2, 4}, false},
+		{"duplicates differ", []int64{1, 1, 2}, []int64{1, 2, 2}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sameInt64Set(tc.a, tc.b))
+		})
+	}
+}
+
+func TestIsGuardianUniqueViolation(t *testing.T) {
+	t.Run("nil error is not a violation", func(t *testing.T) {
+		assert.False(t, isGuardianUniqueViolation(nil))
+	})
+	t.Run("plain error is not a violation", func(t *testing.T) {
+		assert.False(t, isGuardianUniqueViolation(errors.New("boom")))
+	})
+	t.Run("wrapped non-pg DatabaseError is not a violation", func(t *testing.T) {
+		// Exercises the DatabaseError-unwrap branch: it must unwrap and then
+		// still report false because the inner error is not a pg integrity error.
+		err := &base.DatabaseError{Op: "create", Err: errors.New("connection reset")}
+		assert.False(t, isGuardianUniqueViolation(err))
+	})
+}
+
+// --- forced-failure service branches ---------------------------------------
+
+func TestCreateGuardian_NonUniqueCreateErrorIsWrapped(t *testing.T) {
+	email := "new-guardian@example.com"
+	svc := &guardianService{
+		guardianProfileRepo: &fakeProfileRepo{
+			// Pre-check finds no existing guardian, so creation proceeds.
+			findByEmailFn: func(_ context.Context, _ string) (*users.GuardianProfile, error) {
+				return nil, users.ErrGuardianProfileNotFound
+			},
+			// Insert fails with a NON-unique error: must surface as a wrapped
+			// internal error, NOT be misclassified as a duplicate-email 400.
+			createFn: func(_ context.Context, _ *users.GuardianProfile) error {
+				return errors.New("connection refused")
+			},
+		},
+	}
+
+	_, err := svc.CreateGuardian(context.Background(), GuardianCreateRequest{
+		FirstName: "New", LastName: "Guardian", Email: &email,
+	})
+
+	require.Error(t, err)
+	var validationErr *ValidationError
+	assert.False(t, errors.As(err, &validationErr),
+		"a non-unique DB failure must not be classified as a validation (400) error")
+	assert.Contains(t, err.Error(), "failed to create guardian profile")
+}
+
+func TestUpdateGuardian_NonUniqueUpdateErrorIsReturned(t *testing.T) {
+	email := "edited@example.com"
+	svc := &guardianService{
+		guardianProfileRepo: &fakeProfileRepo{
+			findByIDFn: func(_ context.Context, _ int64) (*users.GuardianProfile, error) {
+				return &users.GuardianProfile{}, nil
+			},
+			// No other guardian owns the email → pre-check passes.
+			findByEmailFn: func(_ context.Context, _ string) (*users.GuardianProfile, error) {
+				return nil, users.ErrGuardianProfileNotFound
+			},
+			updateFn: func(_ context.Context, _ *users.GuardianProfile) error {
+				return errors.New("connection refused")
+			},
+		},
+	}
+
+	err := svc.UpdateGuardian(context.Background(), 1, GuardianCreateRequest{
+		FirstName: "Edited", LastName: "Name", Email: &email,
+	})
+
+	require.Error(t, err)
+	var validationErr *ValidationError
+	assert.False(t, errors.As(err, &validationErr),
+		"a non-unique update failure must not be classified as a 400")
+}
+
+func TestDeleteGuardianWithLinks_LockError(t *testing.T) {
+	svc := &guardianService{
+		guardianProfileRepo: &fakeProfileRepo{
+			lockFn: func(_ context.Context, _ int64) error { return errors.New("lock timeout") },
+		},
+	}
+	err := svc.DeleteGuardianWithLinks(context.Background(), 1, []int64{1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to lock guardian profile")
+}
+
+func TestDeleteGuardianWithLinks_LoadLinksError(t *testing.T) {
+	svc := &guardianService{
+		guardianProfileRepo: &fakeProfileRepo{
+			lockFn: func(_ context.Context, _ int64) error { return nil },
+		},
+		studentGuardianRepo: &fakeStudentGuardianRepo{
+			findByGuardianFn: func(_ context.Context, _ int64) ([]*users.StudentGuardian, error) {
+				return nil, errors.New("query failed")
+			},
+		},
+	}
+	err := svc.DeleteGuardianWithLinks(context.Background(), 1, []int64{1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load guardian links")
+}
+
+func TestDeleteGuardianWithLinks_LinkDeleteError(t *testing.T) {
+	link := &users.StudentGuardian{StudentID: 7, GuardianProfileID: 1}
+	link.ID = 5
+	svc := &guardianService{
+		guardianProfileRepo: &fakeProfileRepo{
+			lockFn: func(_ context.Context, _ int64) error { return nil },
+		},
+		studentGuardianRepo: &fakeStudentGuardianRepo{
+			findByGuardianFn: func(_ context.Context, _ int64) ([]*users.StudentGuardian, error) {
+				return []*users.StudentGuardian{link}, nil
+			},
+			deleteFn: func(_ context.Context, _ interface{}) error {
+				return errors.New("delete failed")
+			},
+		},
+	}
+	// expectedLinkIDs matches the current set, so the stale-preview guard passes
+	// and execution reaches the link-deletion loop, which then fails.
+	err := svc.DeleteGuardianWithLinks(context.Background(), 1, []int64{5})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove guardian link")
+}
+
+func TestGetLinkedStudentNames_StudentLoadError(t *testing.T) {
+	rel := &users.StudentGuardian{StudentID: 7, GuardianProfileID: 1}
+	rel.ID = 5
+	svc := &guardianService{
+		studentGuardianRepo: &fakeStudentGuardianRepo{
+			findByGuardianFn: func(_ context.Context, _ int64) ([]*users.StudentGuardian, error) {
+				return []*users.StudentGuardian{rel}, nil
+			},
+		},
+		studentRepo: &fakeStudentRepo{
+			findByIDFn: func(_ context.Context, _ interface{}) (*users.Student, error) {
+				return nil, errors.New("student gone")
+			},
+		},
+	}
+	_, err := svc.GetLinkedStudentNames(context.Background(), 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load student")
+}
+
+func TestGetGuardianDeleteImpact_NilPersonIsRejected(t *testing.T) {
+	rel := &users.StudentGuardian{StudentID: 7, GuardianProfileID: 1}
+	rel.ID = 5
+	student := &users.Student{PersonID: 9}
+	svc := &guardianService{
+		studentGuardianRepo: &fakeStudentGuardianRepo{
+			findByGuardianFn: func(_ context.Context, _ int64) ([]*users.StudentGuardian, error) {
+				return []*users.StudentGuardian{rel}, nil
+			},
+		},
+		studentRepo: &fakeStudentRepo{
+			findByIDFn: func(_ context.Context, _ interface{}) (*users.Student, error) {
+				return student, nil
+			},
+		},
+		personRepo: &fakePersonRepo{
+			// Some repositories return (nil, nil) for a missing row — the impact
+			// builder must treat that as a hard error, not a nil-pointer panic.
+			findByIDFn: func(_ context.Context, _ interface{}) (*users.Person, error) {
+				return nil, nil
+			},
+		},
+	}
+	_, err := svc.GetGuardianDeleteImpact(context.Background(), 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "person record")
+}

--- a/backend/services/users/guardian_service_test.go
+++ b/backend/services/users/guardian_service_test.go
@@ -2,6 +2,7 @@
 package users_test
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	usermodels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/services"
 	"github.com/moto-nrw/project-phoenix/services/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -288,6 +290,53 @@ func TestGuardianService_UpdateGuardian(t *testing.T) {
 		// ASSERT
 		require.Error(t, err)
 	})
+
+	t.Run("rejects an email already owned by another guardian", func(t *testing.T) {
+		// ARRANGE — two distinct guardians.
+		other := testpkg.CreateTestGuardianProfile(t, db, "update-dedup-other")
+		target := testpkg.CreateTestGuardianProfile(t, db, "update-dedup-target")
+		defer testpkg.CleanupActivityFixtures(t, db, other.ID, target.ID)
+
+		req := users.GuardianCreateRequest{
+			FirstName:              "Target",
+			LastName:               "Guardian",
+			Email:                  other.Email, // steal the other guardian's email
+			PreferredContactMethod: "email",
+			LanguagePreference:     "de",
+		}
+
+		// ACT
+		err := service.UpdateGuardian(ctx, target.ID, req)
+
+		// ASSERT — must be a ValidationError (→ 400), never a raw 500 from 23505.
+		require.Error(t, err)
+		var validationErr *users.ValidationError
+		require.ErrorAs(t, err, &validationErr, "duplicate email on update must be a ValidationError → 400")
+		assert.Contains(t, err.Error(), "bereits vergeben")
+	})
+
+	t.Run("allows saving a guardian without changing its own email (self-exclusion)", func(t *testing.T) {
+		// ARRANGE — a guardian kept at its own email is NOT a collision with itself.
+		profile := testpkg.CreateTestGuardianProfile(t, db, "update-self")
+		defer testpkg.CleanupActivityFixtures(t, db, profile.ID)
+
+		req := users.GuardianCreateRequest{
+			FirstName:              "Renamed",
+			LastName:               "Same-Email",
+			Email:                  profile.Email, // unchanged
+			PreferredContactMethod: "email",
+			LanguagePreference:     "de",
+		}
+
+		// ACT
+		err := service.UpdateGuardian(ctx, profile.ID, req)
+
+		// ASSERT
+		require.NoError(t, err, "re-saving a guardian with its own email must not collide")
+		updated, err := service.GetGuardianByID(ctx, profile.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Renamed", updated.FirstName)
+	})
 }
 
 // =============================================================================
@@ -316,6 +365,115 @@ func TestGuardianService_DeleteGuardian(t *testing.T) {
 		result, _ := service.GetGuardianByID(ctx, profile.ID)
 		assert.Nil(t, result)
 	})
+
+	t.Run("plain delete is refused while the guardian is still linked (RESTRICT)", func(t *testing.T) {
+		// ARRANGE — guardian linked to a student. Since migration 1.15.127 the
+		// students_guardians → guardian_profiles FK is ON DELETE RESTRICT, so a
+		// blind delete must fail instead of silently cascading the link away
+		// (the #819 sibling-data-loss bug).
+		guardian := testpkg.CreateTestGuardianProfile(t, db, "restrict-linked")
+		student := testpkg.CreateTestStudent(t, db, "Restrict", "Linked", "1a")
+		defer testpkg.CleanupActivityFixtures(t, db, guardian.ID, student.ID)
+		_, err := service.LinkGuardianToStudent(ctx, users.StudentGuardianCreateRequest{
+			StudentID:         student.ID,
+			GuardianProfileID: guardian.ID,
+			RelationshipType:  "parent",
+			EmergencyPriority: 1,
+		})
+		require.NoError(t, err)
+
+		// ACT
+		err = service.DeleteGuardian(ctx, guardian.ID)
+
+		// ASSERT — the FK violation surfaces; the guardian survives.
+		require.Error(t, err, "RESTRICT FK must block deleting a linked guardian")
+		survivor, _ := service.GetGuardianByID(ctx, guardian.ID)
+		assert.NotNil(t, survivor, "guardian must still exist after a refused delete")
+	})
+}
+
+// =============================================================================
+// DeleteGuardianWithLinks + GetLinkedStudentNames Tests (#819)
+// =============================================================================
+
+func TestGuardianService_DeleteGuardianWithLinks(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupGuardianService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	// ARRANGE — guardian linked to two students (the sibling case #819 is about).
+	guardian := testpkg.CreateTestGuardianProfile(t, db, "force-delete")
+	siblingA := testpkg.CreateTestStudent(t, db, "Sibling", "Aaa", "1a")
+	siblingB := testpkg.CreateTestStudent(t, db, "Sibling", "Bbb", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, siblingA.ID, siblingB.ID)
+	for _, s := range []int64{siblingA.ID, siblingB.ID} {
+		_, err := service.LinkGuardianToStudent(ctx, users.StudentGuardianCreateRequest{
+			StudentID:         s,
+			GuardianProfileID: guardian.ID,
+			RelationshipType:  "parent",
+			EmergencyPriority: 1,
+		})
+		require.NoError(t, err)
+	}
+
+	// GetLinkedStudentNames reports both children before deletion.
+	names, err := service.GetLinkedStudentNames(ctx, guardian.ID)
+	require.NoError(t, err)
+	assert.Len(t, names, 2, "both linked children must be reported for the 409 warning")
+	impact, err := service.GetGuardianDeleteImpact(ctx, guardian.ID)
+	require.NoError(t, err)
+	require.Len(t, impact.LinkIDs, 2, "both link IDs must be returned as the delete concurrency token")
+
+	// ACT — the deliberate full delete removes links first, then the guardian.
+	// Run inside a tenant transaction: DeleteGuardianWithLinks documents that it
+	// MUST run in one (the SELECT ... FOR UPDATE row lock and the link-then-
+	// guardian ordering are only meaningful/atomic within a single tx), and the
+	// HTTP handler wraps it that way. Exercising the real contract here.
+	err = tenant.WithTenantTx(ctx, db, 1, func(txCtx context.Context, _ bun.Tx) error {
+		return service.DeleteGuardianWithLinks(txCtx, guardian.ID, impact.LinkIDs)
+	})
+
+	// ASSERT — guardian gone, and no links survive.
+	require.NoError(t, err)
+	gone, _ := service.GetGuardianByID(ctx, guardian.ID)
+	assert.Nil(t, gone, "guardian must be deleted by the force path")
+	remaining, err := service.GetLinkedStudentNames(ctx, guardian.ID)
+	require.NoError(t, err)
+	assert.Empty(t, remaining, "all student links must be removed")
+}
+
+func TestGuardianService_DeleteGuardianWithLinks_RejectsChangedPreview(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupGuardianService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	guardian := testpkg.CreateTestGuardianProfile(t, db, "force-delete-stale")
+	student := testpkg.CreateTestStudent(t, db, "Preview", "Changed", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	_, err := service.LinkGuardianToStudent(ctx, users.StudentGuardianCreateRequest{
+		StudentID:         student.ID,
+		GuardianProfileID: guardian.ID,
+		RelationshipType:  "parent",
+		EmergencyPriority: 1,
+	})
+	require.NoError(t, err)
+
+	err = tenant.WithTenantTx(ctx, db, 1, func(txCtx context.Context, _ bun.Tx) error {
+		return service.DeleteGuardianWithLinks(txCtx, guardian.ID, []int64{999999})
+	})
+
+	require.ErrorIs(t, err, users.ErrGuardianDeletePreviewChanged)
+	survivor, err := service.GetGuardianByID(ctx, guardian.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, survivor, "guardian must survive when preview token is stale")
+	remaining, err := service.GetLinkedStudentNames(ctx, guardian.ID)
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1, "link must survive when preview token is stale")
 }
 
 // =============================================================================

--- a/backend/tenant/http_middleware.go
+++ b/backend/tenant/http_middleware.go
@@ -36,12 +36,16 @@ func TenantTxMiddleware(db *bun.DB) func(http.Handler) http.Handler {
 			sw := &statusWriter{ResponseWriter: w}
 
 			err := WithTenantTx(r.Context(), db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+				ctx = withRollbackMarker(ctx)
 				next.ServeHTTP(sw, r.WithContext(ctx))
 
 				// Roll back if the handler signalled a server error so that
 				// any partial writes inside the transaction are not committed.
 				if sw.status >= http.StatusInternalServerError {
 					return fmt.Errorf("tenant: handler returned %d; rolling back tx", sw.status)
+				}
+				if rollbackRequested(ctx) {
+					return fmt.Errorf("tenant: handler requested rollback after status %d", sw.statusCode())
 				}
 				return nil
 			})

--- a/backend/tenant/rollback.go
+++ b/backend/tenant/rollback.go
@@ -1,0 +1,32 @@
+package tenant
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type rollbackMarkerKey struct{}
+
+type rollbackMarker struct {
+	requested atomic.Bool
+}
+
+func withRollbackMarker(ctx context.Context) context.Context {
+	if _, ok := ctx.Value(rollbackMarkerKey{}).(*rollbackMarker); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, rollbackMarkerKey{}, &rollbackMarker{})
+}
+
+// MarkRollback requests rollback of the surrounding tenant transaction even
+// when the handler has already rendered a non-5xx response.
+func MarkRollback(ctx context.Context) {
+	if marker, ok := ctx.Value(rollbackMarkerKey{}).(*rollbackMarker); ok && marker != nil {
+		marker.requested.Store(true)
+	}
+}
+
+func rollbackRequested(ctx context.Context) bool {
+	marker, ok := ctx.Value(rollbackMarkerKey{}).(*rollbackMarker)
+	return ok && marker != nil && marker.requested.Load()
+}

--- a/backend/tenant/rollback_internal_test.go
+++ b/backend/tenant/rollback_internal_test.go
@@ -1,0 +1,39 @@
+package tenant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRollbackMarker_Lifecycle covers the unexported marker plumbing that lets a
+// handler request a tx rollback even after rendering a non-5xx response.
+func TestRollbackMarker_Lifecycle(t *testing.T) {
+	t.Run("marker is added once and reused on re-wrap", func(t *testing.T) {
+		base := context.Background()
+		ctx1 := withRollbackMarker(base)
+		assert.False(t, rollbackRequested(ctx1), "a fresh marker must start un-requested")
+
+		// Re-wrapping must NOT install a second marker — MarkRollback on the
+		// re-wrapped ctx has to flip the SAME flag the outer ctx observes.
+		ctx2 := withRollbackMarker(ctx1)
+		MarkRollback(ctx2)
+		assert.True(t, rollbackRequested(ctx1),
+			"re-wrap must reuse the existing marker so the outer ctx sees the request")
+	})
+
+	t.Run("MarkRollback flips the flag", func(t *testing.T) {
+		ctx := withRollbackMarker(context.Background())
+		assert.False(t, rollbackRequested(ctx))
+		MarkRollback(ctx)
+		assert.True(t, rollbackRequested(ctx))
+	})
+
+	t.Run("MarkRollback without a marker is a safe no-op", func(t *testing.T) {
+		// A handler running outside the tenant tx middleware (no marker in ctx)
+		// must not panic when it calls MarkRollback.
+		assert.NotPanics(t, func() { MarkRollback(context.Background()) })
+		assert.False(t, rollbackRequested(context.Background()))
+	})
+}

--- a/backend/tenant/rollback_middleware_test.go
+++ b/backend/tenant/rollback_middleware_test.go
@@ -1,0 +1,87 @@
+package tenant_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTenantTxMiddleware_MarkRollback proves the end-to-end contract of
+// tenant.MarkRollback: a handler can render a non-5xx response and STILL have
+// the enclosing tenant transaction rolled back, so its writes never persist.
+// This backs the guardian full-delete 409 path (#819), where the handler must
+// reject with a 409 without committing any partial link deletions.
+func TestTenantTxMiddleware_MarkRollback(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).GuardianProfile
+
+	newProfile := func() *users.GuardianProfile {
+		email := fmt.Sprintf("rollback-mw-%d@test.local", time.Now().UnixNano())
+		return &users.GuardianProfile{
+			FirstName:              "Rollback",
+			LastName:               "Marker",
+			Email:                  &email,
+			PreferredContactMethod: "email",
+			LanguagePreference:     "de",
+		}
+	}
+
+	serve := func(t *testing.T, handler http.HandlerFunc) {
+		t.Helper()
+		mw := tenant.TenantTxMiddleware(db)(handler)
+		req := httptest.NewRequest(http.MethodPost, "/api/guardians", nil)
+		req = req.WithContext(tenant.WithTenantID(req.Context(), 1))
+		mw.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	t.Run("MarkRollback discards the write despite a 200 response", func(t *testing.T) {
+		profile := newProfile()
+		var rec *httptest.ResponseRecorder
+
+		mw := tenant.TenantTxMiddleware(db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Write inside the request-scoped tenant tx.
+			require.NoError(t, repo.Create(r.Context(), profile))
+			require.Greater(t, profile.ID, int64(0), "insert must assign an id inside the tx")
+			// Ask for a rollback, then return a perfectly successful status.
+			tenant.MarkRollback(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}))
+		req := httptest.NewRequest(http.MethodPost, "/api/guardians", nil)
+		req = req.WithContext(tenant.WithTenantID(req.Context(), 1))
+		rec = httptest.NewRecorder()
+		mw.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code, "the client still sees the 200")
+
+		// The row must NOT survive: the tx was rolled back.
+		_, err := repo.FindByID(testpkg.TenantContext(1), profile.ID)
+		assert.ErrorIs(t, err, users.ErrGuardianProfileNotFound,
+			"MarkRollback must prevent the insert from committing")
+	})
+
+	t.Run("without MarkRollback the same write commits", func(t *testing.T) {
+		// Contrast case: proves the rollback above is caused by MarkRollback and
+		// not by some unrelated failure to persist.
+		profile := newProfile()
+		serve(t, func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, repo.Create(r.Context(), profile))
+			w.WriteHeader(http.StatusOK)
+		})
+		defer testpkg.CleanupActivityFixtures(t, db, profile.ID)
+
+		found, err := repo.FindByID(testpkg.TenantContext(1), profile.ID)
+		require.NoError(t, err)
+		assert.Equal(t, profile.ID, found.ID, "a normal 200 commits the write")
+	})
+}

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -653,6 +653,20 @@ func CleanupActivityFixturesForTenant(tb testing.TB, db *bun.DB, tenantID int64,
 			Where("tenant_id = ?", tenantID),
 			"users.persons_guardians")
 
+		// Delete from users.students_guardians before users.guardian_profiles.
+		// Since migration 1.15.127 the link → guardian FK is ON DELETE RESTRICT
+		// (was CASCADE), so a guardian that is still linked cannot be deleted.
+		// Clearing the link here keeps teardown order-independent: without it,
+		// deleting guardian_profiles ahead of the student in the id list would
+		// trip the FK and leave an orphan. (The link → student FK is CASCADE, so
+		// deleting the student also clears it, but that only helps when the
+		// student id is processed first.)
+		cleanupDelete(tb, db.NewDelete().
+			TableExpr("users.students_guardians").
+			Where("student_id = ? OR guardian_profile_id = ?", id, id).
+			Where("tenant_id = ?", tenantID),
+			"users.students_guardians")
+
 		// Delete from users.guardian_profiles
 		cleanupDelete(tb, db.NewDelete().
 			TableExpr("users.guardian_profiles").

--- a/frontend/src/app/api/guardians/[id]/delete-preview/route.ts
+++ b/frontend/src/app/api/guardians/[id]/delete-preview/route.ts
@@ -1,0 +1,18 @@
+import { createGetHandler } from "@/lib/route-wrapper.server";
+import { apiGet } from "@/lib/api-helpers.server";
+
+// GET /api/guardians/[id]/delete-preview - Read-only blast radius of a full
+// delete (admin-only on the backend). Lets the confirmation modal show the
+// affected children without the old destructive "probe DELETE" (#819).
+export const GET = createGetHandler(async (request, token, params) => {
+  const { id } = params;
+  const guardianId = String(id);
+
+  const response = await apiGet(
+    `/api/guardians/${guardianId}/delete-preview`,
+    token,
+  );
+  // @ts-expect-error - API helper returns unknown type
+
+  return response.data;
+});

--- a/frontend/src/app/api/guardians/[id]/route.ts
+++ b/frontend/src/app/api/guardians/[id]/route.ts
@@ -28,10 +28,18 @@ export const PUT = createPutHandler(async (request, body, token, params) => {
 });
 
 // DELETE /api/guardians/[id] - Delete guardian
+// Forwards the optional `force` query param: without it the backend refuses a
+// guardian still linked to students (409); with `force=true` it performs the
+// deliberate full delete (admin-only, enforced in the backend handler).
 export const DELETE = createDeleteHandler(async (request, token, params) => {
   const { id } = params;
   const guardianId = String(id);
 
-  await apiDelete(`/api/guardians/${guardianId}`, token);
+  const queryString = request.nextUrl.searchParams.toString();
+  const endpoint = queryString
+    ? `/api/guardians/${guardianId}?${queryString}`
+    : `/api/guardians/${guardianId}`;
+
+  await apiDelete(endpoint, token);
   return null;
 });

--- a/frontend/src/app/api/guardians/students/[studentId]/guardians/batch/route.test.ts
+++ b/frontend/src/app/api/guardians/students/[studentId]/guardians/batch/route.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Session } from "next-auth";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+interface ExtendedSession extends Session {
+  user: Session["user"] & { token?: string };
+}
+
+const { mockAuth, mockApiPost } = vi.hoisted(() => ({
+  mockAuth: vi.fn<() => Promise<ExtendedSession | null>>(),
+  mockApiPost: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("@/lib/api-helpers.server", () => ({
+  apiGet: vi.fn(),
+  apiPost: mockApiPost,
+  apiPut: vi.fn(),
+  apiDelete: vi.fn(),
+  handleApiError: vi.fn((error: unknown) => {
+    const message =
+      error instanceof Error ? error.message : "Internal Server Error";
+    const status = message.includes("(401)")
+      ? 401
+      : message.includes("(400)")
+        ? 400
+        : 500;
+    return new Response(JSON.stringify({ error: message }), { status });
+  }),
+}));
+
+function createMockRequest(
+  path: string,
+  options: { method?: string; body?: unknown } = {},
+): NextRequest {
+  const url = new URL(path, "http://localhost:3000");
+  const requestInit: { method: string; body?: string; headers?: HeadersInit } =
+    {
+      method: options.method ?? "GET",
+    };
+
+  if (options.body) {
+    requestInit.body = JSON.stringify(options.body);
+    requestInit.headers = { "Content-Type": "application/json" };
+  }
+
+  return new NextRequest(url, requestInit);
+}
+
+function createMockContext(
+  params: Record<string, string | string[] | undefined> = {},
+) {
+  return { params: Promise.resolve(params) };
+}
+
+const defaultSession: ExtendedSession = {
+  user: { id: "1", token: "test-token", name: "Test User" },
+  expires: "2099-01-01",
+};
+
+describe("POST /api/guardians/students/[studentId]/guardians/batch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(defaultSession);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+
+    const request = createMockRequest(
+      "/api/guardians/students/5/guardians/batch",
+      { method: "POST", body: { guardians: [] } },
+    );
+    const response = await POST(request, createMockContext({ studentId: "5" }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("proxies the batch body to the backend batch endpoint", async () => {
+    const batchBody = {
+      guardians: [
+        { first_name: "A", last_name: "B", relationship_type: "parent" },
+      ],
+    };
+    mockApiPost.mockResolvedValueOnce({ data: null });
+
+    const request = createMockRequest(
+      "/api/guardians/students/5/guardians/batch",
+      { method: "POST", body: batchBody },
+    );
+    const response = await POST(request, createMockContext({ studentId: "5" }));
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/guardians/students/5/guardians/batch",
+      "test-token",
+      batchBody,
+    );
+    expect(response.status).toBe(200);
+  });
+});

--- a/frontend/src/app/api/guardians/students/[studentId]/guardians/batch/route.ts
+++ b/frontend/src/app/api/guardians/students/[studentId]/guardians/batch/route.ts
@@ -1,0 +1,18 @@
+import { createPostHandler } from "@/lib/route-wrapper.server";
+import { apiPost } from "@/lib/api-helpers.server";
+
+// POST /api/guardians/students/[studentId]/guardians/batch
+// Atomically creates (or links) one or more guardians for an existing student
+// in a single backend transaction (#819).
+export const POST = createPostHandler(async (request, body, token, params) => {
+  const { studentId } = params;
+
+  const response = await apiPost(
+    `/api/guardians/students/${String(studentId)}/guardians/batch`,
+    token,
+    body,
+  );
+  // @ts-expect-error - API helper returns unknown type
+
+  return response.data;
+});

--- a/frontend/src/components/guardians/guardian-delete-modal.test.tsx
+++ b/frontend/src/components/guardians/guardian-delete-modal.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Tests for GuardianDeleteModal
- * Tests the rendering and functionality of the guardian delete confirmation modal
+ * Covers the three steps: choose (two option cards), the per-child unlink
+ * confirmation, and the admin-only full-delete confirmation.
  */
 import {
   render,
@@ -12,187 +13,217 @@ import {
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GuardianDeleteModal } from "./guardian-delete-modal";
 
-// Mock Modal component
+// Mock Modal component — renders title + footer so the kit-driven chrome is
+// observable in tests.
 vi.mock("~/components/ui/modal", () => ({
   Modal: ({
     isOpen,
     onClose,
+    title,
     children,
+    footer,
   }: {
     isOpen: boolean;
     onClose: () => void;
     title: string;
     children: React.ReactNode;
+    footer?: React.ReactNode;
   }) =>
     isOpen ? (
       <div data-testid="modal">
+        {title && <h2>{title}</h2>}
         <button onClick={onClose}>Close</button>
         {children}
+        {footer}
       </div>
     ) : null,
 }));
 
-describe("GuardianDeleteModal", () => {
-  const mockOnClose = vi.fn();
-  const mockOnConfirm = vi.fn();
+const handlers = {
+  onClose: vi.fn(),
+  onSelectUnlink: vi.fn(),
+  onSelectFullDelete: vi.fn(),
+  onConfirmUnlink: vi.fn(),
+  onConfirmFullDelete: vi.fn(),
+  onBack: vi.fn(),
+};
 
+function renderModal(
+  props: Partial<React.ComponentProps<typeof GuardianDeleteModal>> = {},
+) {
+  return render(
+    <GuardianDeleteModal
+      isOpen={true}
+      guardianName="John Doe"
+      {...handlers}
+      {...props}
+    />,
+  );
+}
+
+describe("GuardianDeleteModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("renders the modal when open", async () => {
-    render(
-      <GuardianDeleteModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onConfirm={mockOnConfirm}
-        guardianName="John Doe"
-      />,
-    );
+  describe("choose step", () => {
+    it("renders the modal when open", async () => {
+      renderModal();
+      await waitFor(() => {
+        expect(screen.getByTestId("modal")).toBeInTheDocument();
+      });
+    });
 
-    await waitFor(() => {
-      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    it("does not render when closed", () => {
+      renderModal({ isOpen: false });
+      expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+    });
+
+    it("shows the guardian name in the title and the choice prompt", async () => {
+      renderModal();
+      await waitFor(() => {
+        expect(screen.getByText("John Doe entfernen")).toBeInTheDocument();
+        expect(screen.getByText("Was möchten Sie tun?")).toBeInTheDocument();
+      });
+    });
+
+    it("calls onSelectUnlink when the unlink card is clicked", async () => {
+      renderModal();
+      await act(async () => {
+        fireEvent.click(screen.getByText("Nur von diesem Kind entfernen"));
+      });
+      expect(handlers.onSelectUnlink).toHaveBeenCalledTimes(1);
+    });
+
+    it("hides the full-delete card for non-admins", () => {
+      renderModal({ canFullDelete: false });
+      expect(screen.queryByText("Vollständig löschen")).not.toBeInTheDocument();
+    });
+
+    it("offers the full-delete card to admins and calls onSelectFullDelete", async () => {
+      renderModal({ canFullDelete: true });
+      await act(async () => {
+        fireEvent.click(screen.getByText("Vollständig löschen"));
+      });
+      expect(handlers.onSelectFullDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose when cancel is clicked", async () => {
+      renderModal();
+      await act(async () => {
+        fireEvent.click(screen.getByText("Abbrechen"));
+      });
+      expect(handlers.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("disables the option cards when loading", async () => {
+      renderModal({ canFullDelete: true, isLoading: true });
+      await waitFor(() => {
+        expect(
+          screen.getByText("Nur von diesem Kind entfernen").closest("button"),
+        ).toBeDisabled();
+        expect(
+          screen.getByText("Vollständig löschen").closest("button"),
+        ).toBeDisabled();
+      });
     });
   });
 
-  it("does not render when closed", () => {
-    render(
-      <GuardianDeleteModal
-        isOpen={false}
-        onClose={mockOnClose}
-        onConfirm={mockOnConfirm}
-        guardianName="John Doe"
-      />,
-    );
+  describe("confirm-unlink step", () => {
+    it("shows the unlink confirmation copy", async () => {
+      renderModal({ step: "confirm-unlink" });
+      await waitFor(() => {
+        expect(
+          screen.getByText("Von diesem Kind entfernen?"),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/Für eventuelle Geschwister bleibt/i),
+        ).toBeInTheDocument();
+      });
+    });
 
-    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
-  });
+    it("calls onConfirmUnlink when the remove button is clicked", async () => {
+      renderModal({ step: "confirm-unlink" });
+      await act(async () => {
+        fireEvent.click(screen.getByText("Entfernen"));
+      });
+      expect(handlers.onConfirmUnlink).toHaveBeenCalledTimes(1);
+    });
 
-  it("displays the guardian name", async () => {
-    render(
-      <GuardianDeleteModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onConfirm={mockOnConfirm}
-        guardianName="John Doe"
-      />,
-    );
+    it("labels back as Abbrechen for non-admins and calls onBack", async () => {
+      renderModal({ step: "confirm-unlink", canFullDelete: false });
+      await act(async () => {
+        fireEvent.click(screen.getByText("Abbrechen"));
+      });
+      expect(handlers.onBack).toHaveBeenCalledTimes(1);
+    });
 
-    await waitFor(() => {
-      expect(screen.getByText(/John Doe/)).toBeInTheDocument();
+    it("labels back as Zurück for admins", () => {
+      renderModal({ step: "confirm-unlink", canFullDelete: true });
+      expect(screen.getByText("Zurück")).toBeInTheDocument();
+    });
+
+    it("shows loading text and disables buttons when loading", async () => {
+      renderModal({ step: "confirm-unlink", isLoading: true });
+      await waitFor(() => {
+        const loading = screen.getByText("Wird entfernt...");
+        expect(loading.closest("button")).toBeDisabled();
+      });
     });
   });
 
-  it("displays warning message", async () => {
-    render(
-      <GuardianDeleteModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onConfirm={mockOnConfirm}
-        guardianName="John Doe"
-      />,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Diese Aktion kann nicht rückgängig gemacht werden/i),
-      ).toBeInTheDocument();
-    });
-  });
-
-  it("displays delete confirmation heading", async () => {
-    render(
-      <GuardianDeleteModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onConfirm={mockOnConfirm}
-        guardianName="John Doe"
-      />,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Erziehungsberechtigte\/n entfernen\?/i),
-      ).toBeInTheDocument();
-    });
-  });
-
-  it("calls onClose when cancel button is clicked", async () => {
-    render(
-      <GuardianDeleteModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onConfirm={mockOnConfirm}
-        guardianName="John Doe"
-      />,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText("Abbrechen")).toBeInTheDocument();
+  describe("confirm-full step", () => {
+    it("shows the full-delete heading and the backend warning", async () => {
+      renderModal({
+        step: "confirm-full",
+        fullDeleteWarning: "Noch mit 2 Kind(ern) verknüpft: Anna, Ben.",
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/Komplett löschen\?/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Noch mit 2 Kind\(ern\) verknüpft/),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(
+            /Diese Aktion kann nicht rückgängig gemacht werden/i,
+          ),
+        ).toBeInTheDocument();
+      });
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByText("Abbrechen"));
+    it("shows a loading hint and disables the delete button while the warning loads", async () => {
+      renderModal({ step: "confirm-full", isWarningLoading: true });
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Betroffene Kinder werden geprüft/i),
+        ).toBeInTheDocument();
+        expect(screen.getByText("Endgültig löschen")).toBeDisabled();
+      });
     });
 
-    expect(mockOnClose).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls onConfirm when delete button is clicked", async () => {
-    render(
-      <GuardianDeleteModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onConfirm={mockOnConfirm}
-        guardianName="John Doe"
-      />,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText("Entfernen")).toBeInTheDocument();
+    it("calls onConfirmFullDelete when the final delete button is clicked", async () => {
+      renderModal({ step: "confirm-full" });
+      await act(async () => {
+        fireEvent.click(screen.getByText("Endgültig löschen"));
+      });
+      expect(handlers.onConfirmFullDelete).toHaveBeenCalledTimes(1);
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByText("Entfernen"));
+    it("calls onBack when back is clicked", async () => {
+      renderModal({ step: "confirm-full" });
+      await act(async () => {
+        fireEvent.click(screen.getByText("Zurück"));
+      });
+      expect(handlers.onBack).toHaveBeenCalledTimes(1);
     });
 
-    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
-  });
-
-  it("disables buttons when loading", async () => {
-    render(
-      <GuardianDeleteModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onConfirm={mockOnConfirm}
-        guardianName="John Doe"
-        isLoading={true}
-      />,
-    );
-
-    await waitFor(() => {
-      const cancelButton = screen.getByText("Abbrechen");
-      expect(cancelButton).toBeDisabled();
-      // The "Wird entfernt..." text is inside a span, check the parent button
-      const confirmText = screen.getByText("Wird entfernt...");
-      const confirmButton = confirmText.closest("button");
-      expect(confirmButton).toBeDisabled();
-    });
-  });
-
-  it("shows loading text when loading", async () => {
-    render(
-      <GuardianDeleteModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onConfirm={mockOnConfirm}
-        guardianName="John Doe"
-        isLoading={true}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText("Wird entfernt...")).toBeInTheDocument();
+    it("shows full-delete loading text and disables buttons when loading", async () => {
+      renderModal({ step: "confirm-full", isLoading: true });
+      await waitFor(() => {
+        expect(screen.getByText("Zurück")).toBeDisabled();
+        const loading = screen.getByText("Wird gelöscht...");
+        expect(loading.closest("button")).toBeDisabled();
+      });
     });
   });
 });

--- a/frontend/src/components/guardians/guardian-delete-modal.tsx
+++ b/frontend/src/components/guardians/guardian-delete-modal.tsx
@@ -1,118 +1,262 @@
 "use client";
 
+import { ChevronRight, Loader2, Trash2, UserMinus } from "lucide-react";
 import { Modal } from "~/components/ui/modal";
+import { Button } from "~/components/ui/button";
+
+type DeleteStep = "choose" | "confirm-unlink" | "confirm-full";
 
 interface GuardianDeleteModalProps {
   readonly isOpen: boolean;
   readonly onClose: () => void;
-  readonly onConfirm: () => void;
   readonly guardianName: string;
   readonly isLoading?: boolean;
+  /** Which step of the flow is shown. */
+  readonly step?: DeleteStep;
+  /**
+   * Whether the current user may fully delete a guardian (admins only). Drives
+   * both the second option card and whether the confirm step can step "back"
+   * to a choice screen (non-admins have none).
+   */
+  readonly canFullDelete?: boolean;
+  /**
+   * Backend warning for the full-delete confirmation step — lists the children
+   * (incl. siblings) that would lose this guardian. Shown on the "confirm-full"
+   * step.
+   */
+  readonly fullDeleteWarning?: string | null;
+  /**
+   * True while the affected-children warning is still being fetched. The
+   * confirm-full step opens instantly (so there is no dead "loading" gap) and
+   * fills the warning in when it arrives; "Endgültig löschen" stays disabled
+   * until then, so nobody confirms before seeing who is affected.
+   */
+  readonly isWarningLoading?: boolean;
+  /** Choice: go to the per-child unlink confirmation. */
+  readonly onSelectUnlink: () => void;
+  /** Choice: start the full-delete flow (probes for the affected children). */
+  readonly onSelectFullDelete: () => void;
+  /** Confirm the per-child unlink. */
+  readonly onConfirmUnlink: () => void;
+  /** Confirm the full delete (force) once the warning has been shown. */
+  readonly onConfirmFullDelete: () => void;
+  /** Back from a confirmation step (→ choice for admins, → close otherwise). */
+  readonly onBack: () => void;
 }
+
+// Selectable action row used on the choice step. The kit has no option-card
+// primitive, so this is a small local component styled with kit tokens
+// (rounded-xl, gray borders, brand red `#FF3130` = LOCATION_COLORS.HOME).
+function OptionCard({
+  icon,
+  title,
+  subtitle,
+  badge,
+  danger = false,
+  disabled = false,
+  onClick,
+}: {
+  readonly icon: React.ReactNode;
+  readonly title: string;
+  readonly subtitle: string;
+  readonly badge?: React.ReactNode;
+  readonly danger?: boolean;
+  readonly disabled?: boolean;
+  readonly onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`group flex w-full items-center gap-3 rounded-xl border p-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+        danger
+          ? "border-[#FF3130]/30 hover:bg-[#FF3130]/5"
+          : "border-gray-200 hover:border-gray-300 hover:bg-gray-50"
+      }`}
+    >
+      <span
+        className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${
+          danger
+            ? "bg-[#FF3130]/10 text-[#CC2626]"
+            : "bg-gray-100 text-gray-600"
+        }`}
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2">
+          <span
+            className={`text-sm font-semibold ${
+              danger ? "text-[#CC2626]" : "text-gray-900"
+            }`}
+          >
+            {title}
+          </span>
+          {badge}
+        </span>
+        <span className="mt-0.5 block text-xs text-gray-600">{subtitle}</span>
+      </span>
+      <ChevronRight className="h-4 w-4 shrink-0 text-gray-400 transition-transform group-hover:translate-x-0.5" />
+    </button>
+  );
+}
+
+const STEP_TITLES: Record<DeleteStep, (name: string) => string> = {
+  choose: (name) => `${name} entfernen`,
+  "confirm-unlink": () => "Von diesem Kind entfernen?",
+  "confirm-full": () => "Komplett löschen?",
+};
 
 export function GuardianDeleteModal({
   isOpen,
   onClose,
-  onConfirm,
   guardianName,
   isLoading = false,
+  step = "choose",
+  canFullDelete = false,
+  fullDeleteWarning = null,
+  isWarningLoading = false,
+  onSelectUnlink,
+  onSelectFullDelete,
+  onConfirmUnlink,
+  onConfirmFullDelete,
+  onBack,
 }: GuardianDeleteModalProps) {
-  return (
-    <Modal isOpen={isOpen} onClose={onClose} title="">
-      <div className="space-y-6">
-        {/* Warning Icon */}
-        <div className="flex justify-center">
-          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
-            <svg
-              className="h-8 w-8 text-red-600"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-              />
-            </svg>
-          </div>
-        </div>
+  let footer: React.ReactNode;
+  if (step === "choose") {
+    footer = (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onClose}
+        disabled={isLoading}
+      >
+        Abbrechen
+      </Button>
+    );
+  } else if (step === "confirm-unlink") {
+    footer = (
+      <>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onBack}
+          disabled={isLoading}
+        >
+          {canFullDelete ? "Zurück" : "Abbrechen"}
+        </Button>
+        <Button
+          type="button"
+          variant="danger"
+          size="sm"
+          onClick={onConfirmUnlink}
+          isLoading={isLoading}
+          loadingText="Wird entfernt..."
+        >
+          Entfernen
+        </Button>
+      </>
+    );
+  } else {
+    footer = (
+      <>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onBack}
+          disabled={isLoading}
+        >
+          Zurück
+        </Button>
+        <Button
+          type="button"
+          variant="danger"
+          size="sm"
+          onClick={onConfirmFullDelete}
+          isLoading={isLoading}
+          loadingText="Wird gelöscht..."
+          disabled={isLoading || isWarningLoading}
+        >
+          Endgültig löschen
+        </Button>
+      </>
+    );
+  }
 
-        {/* Confirmation Message */}
-        <div className="space-y-3 text-center">
-          <h3 className="text-xl font-bold text-gray-900">
-            Erziehungsberechtigte/n entfernen?
-          </h3>
-          <p className="text-sm text-gray-700">
-            Möchten Sie <strong>{guardianName}</strong> wirklich von diesem
-            Schüler entfernen?
-          </p>
-          <p className="text-sm font-medium text-red-600">
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={STEP_TITLES[step](guardianName)}
+      footer={footer}
+    >
+      {step === "choose" && (
+        <div className="space-y-3">
+          <p className="text-sm text-gray-700">Was möchten Sie tun?</p>
+
+          <OptionCard
+            icon={<UserMinus className="h-5 w-5" />}
+            title="Nur von diesem Kind entfernen"
+            subtitle="Bleibt für eventuelle Geschwister erhalten."
+            disabled={isLoading}
+            onClick={onSelectUnlink}
+          />
+
+          {/* Full delete — admins only. Reaches across every linked child.
+              Kept visually neutral here on purpose; the destructive emphasis
+              lives in the confirmation step, not in the choice. */}
+          {canFullDelete && (
+            <OptionCard
+              icon={<Trash2 className="h-5 w-5" />}
+              title="Vollständig löschen"
+              subtitle="Entfernt die Person bei allen Kindern und löscht das Profil."
+              badge={
+                <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-semibold tracking-wide text-gray-500 uppercase">
+                  Admin
+                </span>
+              }
+              disabled={isLoading}
+              onClick={onSelectFullDelete}
+            />
+          )}
+        </div>
+      )}
+
+      {step === "confirm-unlink" && (
+        <p className="text-sm text-gray-700">
+          Möchten Sie <strong>{guardianName}</strong> von diesem Kind entfernen?
+          Für eventuelle Geschwister bleibt die Person erhalten.
+        </p>
+      )}
+
+      {step === "confirm-full" && (
+        <div className="space-y-3">
+          {fullDeleteWarning ? (
+            // Backend message — count-aware (singular vs. multiple children).
+            // Brand red (LOCATION_COLORS.HOME), same surface the kit
+            // ConfirmDeleteModal uses for destructive warnings.
+            <p className="rounded-lg bg-[#FF3130]/10 px-3 py-2 text-sm text-[#CC2626]">
+              {fullDeleteWarning}
+            </p>
+          ) : isWarningLoading ? (
+            <p className="flex items-center gap-2 rounded-lg bg-gray-100 px-3 py-2 text-sm text-gray-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Betroffene Kinder werden geprüft…
+            </p>
+          ) : (
+            <p className="text-sm text-gray-700">
+              <strong>{guardianName}</strong> wird vollständig gelöscht.
+            </p>
+          )}
+          <p className="text-sm font-medium text-[#FF3130]">
             Diese Aktion kann nicht rückgängig gemacht werden.
           </p>
         </div>
-
-        {/* Action Buttons */}
-        <div className="flex gap-3 border-t border-gray-100 pt-4">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={isLoading}
-            className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-all duration-200 hover:scale-105 hover:border-gray-400 hover:bg-gray-50 hover:shadow-md active:scale-100 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            Abbrechen
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            disabled={isLoading}
-            className="flex-1 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-all duration-200 hover:scale-105 hover:bg-red-700 hover:shadow-lg active:scale-100 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {isLoading ? (
-              <span className="flex items-center justify-center gap-2">
-                <svg
-                  className="h-4 w-4 animate-spin text-white"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  />
-                </svg>
-                Wird entfernt...
-              </span>
-            ) : (
-              <span className="flex items-center justify-center gap-2">
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
-                Entfernen
-              </span>
-            )}
-          </button>
-        </div>
-      </div>
+      )}
     </Modal>
   );
 }

--- a/frontend/src/components/guardians/student-guardian-manager.test.tsx
+++ b/frontend/src/components/guardians/student-guardian-manager.test.tsx
@@ -12,6 +12,7 @@ import type { GuardianWithRelationship } from "@/lib/guardian-helpers";
 // Mock all guardian API functions with proper typing
 const mockFetchStudentGuardians = vi.fn();
 const mockCreateGuardian = vi.fn();
+const mockCreateStudentGuardians = vi.fn();
 const mockUpdateGuardian = vi.fn();
 const mockLinkGuardianToStudent = vi.fn();
 const mockUpdateStudentGuardianRelationship = vi.fn();
@@ -41,6 +42,8 @@ const { mockGuardianApiError } = vi.hoisted(() => ({
 vi.mock("@/lib/guardian-api", () => ({
   fetchStudentGuardians: () => mockFetchStudentGuardians(),
   createGuardian: (data: unknown) => mockCreateGuardian(data),
+  createStudentGuardians: (studentId: string, guardians: unknown) =>
+    mockCreateStudentGuardians(studentId, guardians),
   updateGuardian: (id: string, data: unknown) => mockUpdateGuardian(id, data),
   linkGuardianToStudent: (studentId: string, data: unknown) =>
     mockLinkGuardianToStudent(studentId, data),
@@ -366,6 +369,11 @@ describe("StudentGuardianManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetchStudentGuardians.mockResolvedValue(mockGuardians);
+    mockCreateStudentGuardians.mockResolvedValue(undefined);
+    // Deterministic default: phone adds (used by the edit flow) resolve to a row
+    // with an id. clearAllMocks() clears call records but NOT implementations, so
+    // setting this here avoids depending on another test's leaked mockResolvedValue.
+    mockAddGuardianPhoneNumber.mockResolvedValue({ id: "new-phone-1" });
     mockPermissions = [];
   });
 
@@ -495,11 +503,11 @@ describe("StudentGuardianManager", () => {
       expect(screen.getByText("Create Guardian")).toBeInTheDocument();
     });
 
-    it("creates guardian with phone numbers and shows success toast", async () => {
-      mockCreateGuardian.mockResolvedValue({ id: "new-guardian-1" });
-      mockLinkGuardianToStudent.mockResolvedValue(undefined);
-      mockAddGuardianPhoneNumber.mockResolvedValue({ id: "new-phone-1" });
-
+    it("creates guardian with phone numbers atomically and shows success toast", async () => {
+      // The create flow now goes through ONE atomic backend call
+      // (createStudentGuardians) instead of separate create→link→add-phones
+      // calls — the whole batch succeeds or rolls back server-side (#819), so
+      // there is no client-side rollback to orphan a profile.
       render(<StudentGuardianManager studentId="student-123" />);
 
       await waitFor(() => {
@@ -512,26 +520,26 @@ describe("StudentGuardianManager", () => {
       fireEvent.click(screen.getByTestId("submit-form"));
 
       await waitFor(() => {
-        expect(mockCreateGuardian).toHaveBeenCalledWith({
-          firstName: "Test",
-          lastName: "Guardian",
-        });
+        expect(mockCreateStudentGuardians).toHaveBeenCalledWith("student-123", [
+          expect.objectContaining({
+            firstName: "Test",
+            lastName: "Guardian",
+            relationshipType: "parent",
+            phoneNumbers: [
+              expect.objectContaining({
+                phoneNumber: "+49 123 456",
+                phoneType: "mobile",
+                isPrimary: true,
+              }),
+            ],
+          }),
+        ]);
       });
 
-      expect(mockLinkGuardianToStudent).toHaveBeenCalledWith("student-123", {
-        guardianProfileId: "new-guardian-1",
-        relationshipType: "parent",
-      });
-
-      expect(mockAddGuardianPhoneNumber).toHaveBeenCalledWith(
-        "new-guardian-1",
-        {
-          phoneNumber: "+49 123 456",
-          phoneType: "mobile",
-          isPrimary: true,
-          label: undefined,
-        },
-      );
+      // No per-step orchestration any more.
+      expect(mockCreateGuardian).not.toHaveBeenCalled();
+      expect(mockLinkGuardianToStudent).not.toHaveBeenCalled();
+      expect(mockAddGuardianPhoneNumber).not.toHaveBeenCalled();
 
       await waitFor(() => {
         expect(mockToastSuccess).toHaveBeenCalledWith(
@@ -542,9 +550,6 @@ describe("StudentGuardianManager", () => {
 
     it("calls onUpdate callback after successful creation", async () => {
       const mockOnUpdate = vi.fn();
-      mockCreateGuardian.mockResolvedValue({ id: "new-guardian-1" });
-      mockLinkGuardianToStudent.mockResolvedValue(undefined);
-      mockAddGuardianPhoneNumber.mockResolvedValue({ id: "new-phone-1" });
 
       render(
         <StudentGuardianManager

--- a/frontend/src/components/guardians/student-guardian-manager.test.tsx
+++ b/frontend/src/components/guardians/student-guardian-manager.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import StudentGuardianManager from "./student-guardian-manager";
 import type { GuardianWithRelationship } from "@/lib/guardian-helpers";
@@ -10,10 +16,27 @@ const mockUpdateGuardian = vi.fn();
 const mockLinkGuardianToStudent = vi.fn();
 const mockUpdateStudentGuardianRelationship = vi.fn();
 const mockRemoveGuardianFromStudent = vi.fn();
+const mockDeleteGuardian = vi.fn();
+const mockFetchGuardianDeletePreview = vi.fn();
 const mockAddGuardianPhoneNumber = vi.fn();
 const mockUpdateGuardianPhoneNumber = vi.fn();
 const mockDeleteGuardianPhoneNumber = vi.fn();
 const mockSetGuardianPrimaryPhone = vi.fn();
+
+// Real subclass exported from the guardian-api mock so any code path that
+// branches on `err instanceof GuardianApiError` still resolves against the
+// mocked module. Built via vi.hoisted so it exists before the hoisted vi.mock
+// factory runs.
+const { mockGuardianApiError } = vi.hoisted(() => ({
+  mockGuardianApiError: class extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "GuardianApiError";
+      this.status = status;
+    }
+  },
+}));
 
 vi.mock("@/lib/guardian-api", () => ({
   fetchStudentGuardians: () => mockFetchStudentGuardians(),
@@ -25,6 +48,13 @@ vi.mock("@/lib/guardian-api", () => ({
     mockUpdateStudentGuardianRelationship(relationshipId, data),
   removeGuardianFromStudent: (studentId: string, guardianId: string) =>
     mockRemoveGuardianFromStudent(studentId, guardianId),
+  deleteGuardian: (
+    guardianId: string,
+    opts?: { force?: boolean; expectedAffectedLinkIds?: readonly string[] },
+  ) => mockDeleteGuardian(guardianId, opts),
+  fetchGuardianDeletePreview: (guardianId: string) =>
+    mockFetchGuardianDeletePreview(guardianId),
+  GuardianApiError: mockGuardianApiError,
   addGuardianPhoneNumber: (guardianId: string, data: unknown) =>
     mockAddGuardianPhoneNumber(guardianId, data),
   updateGuardianPhoneNumber: (
@@ -36,6 +66,17 @@ vi.mock("@/lib/guardian-api", () => ({
     mockDeleteGuardianPhoneNumber(guardianId, phoneId),
   setGuardianPrimaryPhone: (guardianId: string, phoneId: string) =>
     mockSetGuardianPrimaryPhone(guardianId, phoneId),
+}));
+
+// Session mock — drives the admin-only "Komplett löschen" affordance. Default
+// is a non-admin session; tests needing the full-delete path push an admin
+// wildcard into mockPermissions before rendering.
+let mockPermissions: string[] = [];
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: { user: { permissions: mockPermissions } },
+    status: "authenticated",
+  }),
 }));
 
 // Mock toast context
@@ -190,23 +231,78 @@ vi.mock("./guardian-delete-modal", () => ({
   GuardianDeleteModal: ({
     isOpen,
     onClose,
-    onConfirm,
+    onSelectUnlink,
+    onSelectFullDelete,
+    onConfirmUnlink,
+    onConfirmFullDelete,
+    onBack,
     guardianName,
+    step,
+    canFullDelete,
+    fullDeleteWarning,
+    isWarningLoading,
   }: {
     isOpen: boolean;
     onClose: () => void;
-    onConfirm: () => void;
+    onSelectUnlink: () => void;
+    onSelectFullDelete: () => void;
+    onConfirmUnlink: () => void;
+    onConfirmFullDelete: () => void;
+    onBack: () => void;
     guardianName: string;
+    step?: "choose" | "confirm-unlink" | "confirm-full";
+    canFullDelete?: boolean;
+    fullDeleteWarning?: string | null;
+    isWarningLoading?: boolean;
   }) =>
     isOpen ? (
-      <div data-testid="guardian-delete-modal">
+      <div data-testid="guardian-delete-modal" data-step={step}>
         <p data-testid="delete-guardian-name">Delete {guardianName}?</p>
+        {fullDeleteWarning && (
+          <p data-testid="full-delete-warning">{fullDeleteWarning}</p>
+        )}
         <button onClick={onClose} data-testid="cancel-delete">
           Cancel
         </button>
-        <button onClick={onConfirm} data-testid="confirm-delete">
-          Confirm Delete
-        </button>
+        {step === "choose" && (
+          <>
+            <button onClick={onSelectUnlink} data-testid="select-unlink">
+              Choose Unlink
+            </button>
+            {canFullDelete && (
+              <button
+                onClick={onSelectFullDelete}
+                data-testid="select-full-delete"
+              >
+                Choose Full Delete
+              </button>
+            )}
+          </>
+        )}
+        {step === "confirm-unlink" && (
+          <>
+            <button onClick={onBack} data-testid="back">
+              Back
+            </button>
+            <button onClick={onConfirmUnlink} data-testid="confirm-delete">
+              Confirm Unlink
+            </button>
+          </>
+        )}
+        {step === "confirm-full" && (
+          <>
+            <button onClick={onBack} data-testid="back">
+              Back
+            </button>
+            <button
+              onClick={onConfirmFullDelete}
+              data-testid="confirm-full-delete"
+              disabled={isWarningLoading}
+            >
+              Confirm Full Delete
+            </button>
+          </>
+        )}
       </div>
     ) : null,
 }));
@@ -270,6 +366,7 @@ describe("StudentGuardianManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetchStudentGuardians.mockResolvedValue(mockGuardians);
+    mockPermissions = [];
   });
 
   describe("Initial Loading", () => {
@@ -623,6 +720,243 @@ describe("StudentGuardianManager", () => {
       // Edit buttons should not be shown in readOnly mode
       expect(screen.queryByTestId("edit-guardian-1")).not.toBeInTheDocument();
       expect(screen.queryByTestId("edit-guardian-2")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Full Delete Flow", () => {
+    async function openDeleteModal(guardianId = "guardian-1") {
+      await waitFor(() => {
+        expect(screen.getByTestId(`edit-${guardianId}`)).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByTestId(`edit-${guardianId}`));
+      fireEvent.click(screen.getByTestId("modal-delete-button"));
+      expect(screen.getByTestId("guardian-delete-modal")).toBeInTheDocument();
+    }
+
+    function deferred<T>() {
+      let resolve!: (value: T) => void;
+      const promise = new Promise<T>((res) => {
+        resolve = res;
+      });
+      return { promise, resolve };
+    }
+
+    it("sends non-admins straight to the unlink confirmation, with no choice screen", async () => {
+      render(<StudentGuardianManager studentId="student-123" />);
+      await openDeleteModal();
+
+      // No choice screen → goes directly to the unlink confirmation.
+      expect(screen.getByTestId("guardian-delete-modal")).toHaveAttribute(
+        "data-step",
+        "confirm-unlink",
+      );
+      expect(
+        screen.queryByTestId("select-full-delete"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("admins choosing unlink still pass through the unlink confirmation", async () => {
+      mockPermissions = ["admin:*"];
+      mockRemoveGuardianFromStudent.mockResolvedValue(undefined);
+
+      render(<StudentGuardianManager studentId="student-123" />);
+      await openDeleteModal();
+
+      // Admin starts on the choice screen.
+      expect(screen.getByTestId("guardian-delete-modal")).toHaveAttribute(
+        "data-step",
+        "choose",
+      );
+
+      fireEvent.click(screen.getByTestId("select-unlink"));
+      await waitFor(() => {
+        expect(screen.getByTestId("guardian-delete-modal")).toHaveAttribute(
+          "data-step",
+          "confirm-unlink",
+        );
+      });
+
+      fireEvent.click(screen.getByTestId("confirm-delete"));
+      await waitFor(() => {
+        expect(mockRemoveGuardianFromStudent).toHaveBeenCalledWith(
+          "student-123",
+          "guardian-1",
+        );
+      });
+    });
+
+    it("admins choose full delete, get the affected-children warning, then force delete", async () => {
+      mockPermissions = ["admin:*"];
+      // Read-only preview returns the affected children (no delete happens yet).
+      mockFetchGuardianDeletePreview.mockResolvedValue({
+        linkedCount: 2,
+        affectedNames: ["Anna Müller", "Ben Müller"],
+        affectedLinkIds: ["10", "20"],
+        warning:
+          "Die Person ist mit 2 Kindern verknüpft und wird bei allen entfernt: Anna Müller, Ben Müller.",
+      });
+      mockDeleteGuardian.mockResolvedValue(undefined);
+
+      render(<StudentGuardianManager studentId="student-123" />);
+      await openDeleteModal();
+
+      // Admin picks the full-delete option from the choice screen.
+      fireEvent.click(screen.getByTestId("select-full-delete"));
+
+      // The read-only preview ran and surfaced the warning — no destructive
+      // delete was attempted while merely opening the confirmation.
+      await waitFor(() => {
+        expect(mockFetchGuardianDeletePreview).toHaveBeenCalledWith(
+          "guardian-1",
+        );
+      });
+      expect(mockDeleteGuardian).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(screen.getByTestId("full-delete-warning")).toHaveTextContent(
+          "mit 2 Kindern verknüpft",
+        );
+      });
+      expect(screen.getByTestId("guardian-delete-modal")).toHaveAttribute(
+        "data-step",
+        "confirm-full",
+      );
+
+      // Confirm → force delete + success toast.
+      fireEvent.click(screen.getByTestId("confirm-full-delete"));
+
+      await waitFor(() => {
+        expect(mockDeleteGuardian).toHaveBeenCalledWith("guardian-1", {
+          force: true,
+          expectedAffectedLinkIds: ["10", "20"],
+        });
+      });
+      await waitFor(() => {
+        expect(mockToastSuccess).toHaveBeenCalledWith(
+          "Anna Müller wurde vollständig gelöscht",
+        );
+      });
+    });
+
+    it("can step back from the full-delete confirmation to the choice step", async () => {
+      mockPermissions = ["admin:*"];
+      mockFetchGuardianDeletePreview.mockResolvedValue({
+        linkedCount: 1,
+        affectedNames: ["Anna Müller"],
+        affectedLinkIds: ["10"],
+        warning:
+          "Die Person ist nur mit diesem Kind verknüpft und wird mit dem Profil vollständig gelöscht.",
+      });
+
+      render(<StudentGuardianManager studentId="student-123" />);
+      await openDeleteModal();
+
+      fireEvent.click(screen.getByTestId("select-full-delete"));
+      await waitFor(() => {
+        expect(screen.getByTestId("guardian-delete-modal")).toHaveAttribute(
+          "data-step",
+          "confirm-full",
+        );
+      });
+
+      fireEvent.click(screen.getByTestId("back"));
+      await waitFor(() => {
+        expect(screen.getByTestId("guardian-delete-modal")).toHaveAttribute(
+          "data-step",
+          "choose",
+        );
+      });
+      // Choice screen is back, force delete was never called.
+      expect(screen.getByTestId("select-unlink")).toBeInTheDocument();
+      expect(mockDeleteGuardian).not.toHaveBeenCalledWith("guardian-1", {
+        force: true,
+      });
+    });
+
+    it("ignores stale full-delete previews from a previously selected guardian", async () => {
+      mockPermissions = ["admin:*"];
+      const guardianOnePreview = deferred<{
+        linkedCount: number;
+        affectedNames: string[];
+        affectedLinkIds: string[];
+        warning: string;
+      }>();
+      const guardianTwoPreview = deferred<{
+        linkedCount: number;
+        affectedNames: string[];
+        affectedLinkIds: string[];
+        warning: string;
+      }>();
+      mockFetchGuardianDeletePreview.mockImplementation((guardianId) => {
+        if (guardianId === "guardian-1") return guardianOnePreview.promise;
+        if (guardianId === "guardian-2") return guardianTwoPreview.promise;
+        throw new Error(`Unexpected guardian id: ${guardianId}`);
+      });
+      mockDeleteGuardian.mockResolvedValue(undefined);
+
+      render(<StudentGuardianManager studentId="student-123" />);
+      await openDeleteModal("guardian-1");
+
+      fireEvent.click(screen.getByTestId("select-full-delete"));
+      await waitFor(() => {
+        expect(mockFetchGuardianDeletePreview).toHaveBeenCalledWith(
+          "guardian-1",
+        );
+      });
+
+      fireEvent.click(screen.getByTestId("cancel-delete"));
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("guardian-delete-modal"),
+        ).not.toBeInTheDocument();
+      });
+
+      await openDeleteModal("guardian-2");
+      fireEvent.click(screen.getByTestId("select-full-delete"));
+      await waitFor(() => {
+        expect(mockFetchGuardianDeletePreview).toHaveBeenCalledWith(
+          "guardian-2",
+        );
+      });
+
+      await act(async () => {
+        guardianOnePreview.resolve({
+          linkedCount: 1,
+          affectedNames: ["Anna Müller"],
+          affectedLinkIds: ["10"],
+          warning: "STALE guardian-1 warning",
+        });
+        await guardianOnePreview.promise;
+      });
+
+      expect(
+        screen.queryByText("STALE guardian-1 warning"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("confirm-full-delete")).toBeDisabled();
+
+      await act(async () => {
+        guardianTwoPreview.resolve({
+          linkedCount: 2,
+          affectedNames: ["Hans Müller", "Ben Müller"],
+          affectedLinkIds: ["20", "30"],
+          warning: "CURRENT guardian-2 warning",
+        });
+        await guardianTwoPreview.promise;
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("full-delete-warning")).toHaveTextContent(
+          "CURRENT guardian-2 warning",
+        );
+      });
+      expect(screen.getByTestId("confirm-full-delete")).not.toBeDisabled();
+
+      fireEvent.click(screen.getByTestId("confirm-full-delete"));
+      await waitFor(() => {
+        expect(mockDeleteGuardian).toHaveBeenCalledWith("guardian-2", {
+          force: true,
+          expectedAffectedLinkIds: ["20", "30"],
+        });
+      });
     });
   });
 

--- a/frontend/src/components/guardians/student-guardian-manager.tsx
+++ b/frontend/src/components/guardians/student-guardian-manager.tsx
@@ -16,7 +16,7 @@ import { getGuardianFullName } from "@/lib/guardian-helpers";
 import type { RelationshipFormData } from "./guardian-form-modal";
 import {
   fetchStudentGuardians,
-  createGuardian,
+  createStudentGuardians,
   updateGuardian,
   deleteGuardian,
   linkGuardianToStudent,
@@ -114,7 +114,17 @@ export default function StudentGuardianManager({
     });
   }, [loadGuardians]);
 
-  // Handle create guardian(s) - supports multiple guardians at once
+  // Handle create guardian(s) - supports multiple guardians at once.
+  //
+  // The whole batch is created in ONE backend transaction (#819): every guardian
+  // profile, its link to the student, and its phone numbers succeed together or
+  // roll back together server-side. This replaces the old per-guardian
+  // create→link→add-phones sequence with its client-side rollback, which could
+  // orphan a freshly-created profile — a non-admin supervisor cannot delete a
+  // guardian once it has no remaining links, so the compensating delete would
+  // 403 and leave the profile behind. On any failure nothing is persisted and we
+  // rethrow so the form modal shows the (translated) error and keeps the entries
+  // for a retry.
   const handleCreateGuardians = async (
     guardians: Array<{
       id: string;
@@ -127,80 +137,41 @@ export default function StudentGuardianManager({
         isPrimary: boolean;
       }>;
     }>,
-    onEntryCreated?: (entryId: string) => void,
+    _onEntryCreated?: (entryId: string) => void,
   ) => {
-    let successCount = 0;
-    try {
-      // Create all guardians sequentially to ensure proper error handling
-      for (const {
-        id,
-        guardianData,
-        relationshipData,
-        phoneNumbers,
-      } of guardians) {
-        // Create guardian profile
-        const newGuardian = await createGuardian(guardianData);
+    await createStudentGuardians(
+      studentId,
+      guardians.map(({ guardianData, relationshipData, phoneNumbers }) => ({
+        firstName: guardianData.firstName,
+        lastName: guardianData.lastName,
+        email: guardianData.email,
+        addressStreet: guardianData.addressStreet,
+        addressCity: guardianData.addressCity,
+        addressPostalCode: guardianData.addressPostalCode,
+        languagePreference: guardianData.languagePreference,
+        notes: guardianData.notes,
+        relationshipType: relationshipData.relationshipType,
+        isPrimary: relationshipData.isPrimary,
+        isEmergencyContact: relationshipData.isEmergencyContact,
+        canPickup: relationshipData.canPickup,
+        pickupNotes: relationshipData.pickupNotes,
+        emergencyPriority: relationshipData.emergencyPriority,
+        phoneNumbers: phoneNumbers?.map((phone) => ({
+          phoneNumber: phone.phoneNumber,
+          phoneType: phone.phoneType,
+          label: phone.label,
+          isPrimary: phone.isPrimary,
+        })),
+      })),
+    );
 
-        try {
-          // Link to student
-          await linkGuardianToStudent(studentId, {
-            guardianProfileId: newGuardian.id,
-            ...relationshipData,
-          });
-
-          // Add phone numbers if provided
-          if (phoneNumbers && phoneNumbers.length > 0) {
-            for (const phone of phoneNumbers) {
-              await addGuardianPhoneNumber(newGuardian.id, {
-                phoneNumber: phone.phoneNumber,
-                phoneType: phone.phoneType,
-                label: phone.label,
-                isPrimary: phone.isPrimary,
-              });
-            }
-          }
-        } catch (innerError) {
-          // Rollback: delete the just-created guardian to prevent orphaned
-          // records. The student↔guardian FK is ON DELETE RESTRICT (backend
-          // migration 1.15.127), so a guardian that was already linked above
-          // cannot be deleted directly — unlink first (best-effort: the link
-          // may not exist if linkGuardianToStudent itself failed), then delete.
-          try {
-            try {
-              await removeGuardianFromStudent(studentId, newGuardian.id);
-            } catch {
-              // No link to remove (link step failed) — deletion below proceeds.
-            }
-            await deleteGuardian(newGuardian.id);
-          } catch (rollbackError) {
-            logger.error("guardian_rollback_failed", {
-              error:
-                rollbackError instanceof Error
-                  ? rollbackError.message
-                  : String(rollbackError),
-              guardian_id: newGuardian.id,
-            });
-          }
-          throw innerError;
-        }
-
-        // Remove successfully created entry from modal (enables retry without duplicates)
-        onEntryCreated?.(id);
-        successCount++;
-      }
-    } finally {
-      // Only reload and notify parent if at least one guardian was created
-      // This prevents false success signals on complete failure
-      if (successCount > 0) {
-        await loadGuardians();
-        onUpdate?.();
-        toastSuccess(
-          successCount === 1
-            ? "Erziehungsberechtigte/r erfolgreich hinzugefügt"
-            : `${successCount} Erziehungsberechtigte erfolgreich hinzugefügt`,
-        );
-      }
-    }
+    await loadGuardians();
+    onUpdate?.();
+    toastSuccess(
+      guardians.length === 1
+        ? "Erziehungsberechtigte/r erfolgreich hinzugefügt"
+        : `${guardians.length} Erziehungsberechtigte erfolgreich hinzugefügt`,
+    );
   };
 
   // Link an existing guardian chosen from the picker (sibling case). Unlike the

--- a/frontend/src/components/guardians/student-guardian-manager.tsx
+++ b/frontend/src/components/guardians/student-guardian-manager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Loader2, Plus, Search } from "lucide-react";
 import GuardianList from "./guardian-list";
 import GuardianFormModal from "./guardian-form-modal";
@@ -26,9 +26,11 @@ import {
   updateGuardianPhoneNumber,
   deleteGuardianPhoneNumber,
   setGuardianPrimaryPhone,
+  fetchGuardianDeletePreview,
 } from "@/lib/guardian-api";
 import { useToast } from "~/contexts/ToastContext";
 import { createLogger } from "~/lib/logger";
+import { useSession } from "next-auth/react";
 
 const logger = createLogger({ component: "StudentGuardianManager" });
 
@@ -55,8 +57,33 @@ export default function StudentGuardianManager({
   const [deletingGuardian, setDeletingGuardian] = useState<
     GuardianWithRelationship | undefined
   >();
+  const [deleteStep, setDeleteStep] = useState<
+    "choose" | "confirm-unlink" | "confirm-full"
+  >("choose");
+  const [fullDeleteWarning, setFullDeleteWarning] = useState<string | null>(
+    null,
+  );
+  const [fullDeleteAffectedLinkIds, setFullDeleteAffectedLinkIds] = useState<
+    string[]
+  >([]);
+  const [isWarningLoading, setIsWarningLoading] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const deletePreviewRequestIdRef = useRef(0);
   const { success: toastSuccess, error: toastError } = useToast();
+
+  // The full "Komplett löschen" path reaches across every linked child
+  // (siblings included), so the backend restricts it to admin wildcards
+  // (admin:* / *:*) — mirror that here to only offer it when it would succeed.
+  const { data: session } = useSession();
+  const canFullDelete = (session?.user?.permissions ?? []).some(
+    (p) => p === "admin:*" || p === "*:*",
+  );
+
+  useEffect(() => {
+    return () => {
+      deletePreviewRequestIdRef.current += 1;
+    };
+  }, []);
 
   // Load guardians
   const loadGuardians = useCallback(async () => {
@@ -132,8 +159,17 @@ export default function StudentGuardianManager({
             }
           }
         } catch (innerError) {
-          // Rollback: delete the guardian profile to prevent orphaned records
+          // Rollback: delete the just-created guardian to prevent orphaned
+          // records. The student↔guardian FK is ON DELETE RESTRICT (backend
+          // migration 1.15.127), so a guardian that was already linked above
+          // cannot be deleted directly — unlink first (best-effort: the link
+          // may not exist if linkGuardianToStudent itself failed), then delete.
           try {
+            try {
+              await removeGuardianFromStudent(studentId, newGuardian.id);
+            } catch {
+              // No link to remove (link step failed) — deletion below proceeds.
+            }
             await deleteGuardian(newGuardian.id);
           } catch (rollbackError) {
             logger.error("guardian_rollback_failed", {
@@ -325,14 +361,21 @@ export default function StudentGuardianManager({
     }
   };
 
-  // Handle delete guardian - open confirmation modal
+  // Handle delete guardian - open the modal. Admins get the choice screen;
+  // everyone else goes straight to the per-child unlink confirmation (their
+  // only option), so they never see a single-option "choice".
   const handleDeleteClick = (guardian: GuardianWithRelationship) => {
+    deletePreviewRequestIdRef.current += 1;
     setDeletingGuardian(guardian);
+    setDeleteStep(canFullDelete ? "choose" : "confirm-unlink");
+    setFullDeleteWarning(null);
+    setIsWarningLoading(false);
     setShowDeleteModal(true);
   };
 
-  // Confirm delete guardian
-  const handleConfirmDelete = async () => {
+  // Confirm the per-child unlink. Sibling links and the guardian profile itself
+  // are untouched.
+  const handleConfirmUnlink = async () => {
     if (!deletingGuardian) return;
 
     const deletedName = getGuardianFullName(deletingGuardian);
@@ -349,7 +392,7 @@ export default function StudentGuardianManager({
         error: err instanceof Error ? err.message : String(err),
         student_id: studentId,
       });
-      alert(
+      toastError(
         err instanceof Error
           ? err.message
           : "Fehler beim Entfernen der/des Erziehungsberechtigten",
@@ -359,10 +402,108 @@ export default function StudentGuardianManager({
     }
   };
 
+  // Choice → full-delete flow. Switch to the confirmation step IMMEDIATELY (so
+  // the modal feels as instant as the unlink path), then fetch the
+  // affected-children warning via the READ-ONLY delete-preview endpoint. This
+  // never deletes anything by itself — the actual force delete happens only on
+  // explicit confirmation in handleConfirmFullDelete. "Endgültig löschen" stays
+  // disabled until the warning loads.
+  const handleSelectFullDelete = async () => {
+    if (!deletingGuardian) return;
+
+    const guardianId = deletingGuardian.id;
+    const requestId = deletePreviewRequestIdRef.current + 1;
+    deletePreviewRequestIdRef.current = requestId;
+
+    setFullDeleteWarning(null);
+    setFullDeleteAffectedLinkIds([]);
+    setDeleteStep("confirm-full");
+    setIsWarningLoading(true);
+    try {
+      const preview = await fetchGuardianDeletePreview(guardianId);
+      if (deletePreviewRequestIdRef.current !== requestId) return;
+      setFullDeleteWarning(preview.warning);
+      setFullDeleteAffectedLinkIds(preview.affectedLinkIds);
+    } catch (err) {
+      if (deletePreviewRequestIdRef.current !== requestId) return;
+
+      logger.error("guardian_full_delete_preview_failed", {
+        error: err instanceof Error ? err.message : String(err),
+        guardian_id: guardianId,
+        student_id: studentId,
+      });
+      toastError(
+        err instanceof Error
+          ? err.message
+          : "Fehler beim Prüfen der betroffenen Kinder",
+      );
+      // Preview failed — drop back to the choice rather than letting the user
+      // confirm a delete whose blast radius we never showed.
+      handleBack();
+    } finally {
+      if (deletePreviewRequestIdRef.current === requestId) {
+        setIsWarningLoading(false);
+      }
+    }
+  };
+
+  // Confirm the full delete (force): removes the guardian and all of its links.
+  const handleConfirmFullDelete = async () => {
+    if (!deletingGuardian || !fullDeleteWarning) return;
+
+    const deletedName = getGuardianFullName(deletingGuardian);
+    setIsDeleting(true);
+    try {
+      await deleteGuardian(deletingGuardian.id, {
+        force: true,
+        expectedAffectedLinkIds: fullDeleteAffectedLinkIds,
+      });
+      await loadGuardians();
+      onUpdate?.();
+      setShowDeleteModal(false);
+      setDeletingGuardian(undefined);
+      setDeleteStep("choose");
+      setFullDeleteWarning(null);
+      setFullDeleteAffectedLinkIds([]);
+      toastSuccess(`${deletedName} wurde vollständig gelöscht`);
+    } catch (err) {
+      logger.error("guardian_full_delete_failed", {
+        error: err instanceof Error ? err.message : String(err),
+        student_id: studentId,
+      });
+      toastError(
+        err instanceof Error
+          ? err.message
+          : "Fehler beim Löschen der/des Erziehungsberechtigten",
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  // Back from a confirmation step. Admins return to the choice screen; everyone
+  // else has no choice screen, so "back" just closes the modal.
+  const handleBack = () => {
+    deletePreviewRequestIdRef.current += 1;
+    if (canFullDelete) {
+      setDeleteStep("choose");
+      setFullDeleteWarning(null);
+      setFullDeleteAffectedLinkIds([]);
+      setIsWarningLoading(false);
+    } else {
+      handleCancelDelete();
+    }
+  };
+
   // Cancel delete
   const handleCancelDelete = () => {
+    deletePreviewRequestIdRef.current += 1;
     setShowDeleteModal(false);
     setDeletingGuardian(undefined);
+    setDeleteStep("choose");
+    setFullDeleteWarning(null);
+    setFullDeleteAffectedLinkIds([]);
+    setIsWarningLoading(false);
   };
 
   // Open modal for creating
@@ -520,11 +661,19 @@ export default function StudentGuardianManager({
       <GuardianDeleteModal
         isOpen={showDeleteModal}
         onClose={handleCancelDelete}
-        onConfirm={handleConfirmDelete}
         guardianName={
           deletingGuardian ? getGuardianFullName(deletingGuardian) : ""
         }
         isLoading={isDeleting}
+        step={deleteStep}
+        canFullDelete={canFullDelete}
+        fullDeleteWarning={fullDeleteWarning}
+        isWarningLoading={isWarningLoading}
+        onSelectUnlink={() => setDeleteStep("confirm-unlink")}
+        onSelectFullDelete={handleSelectFullDelete}
+        onConfirmUnlink={handleConfirmUnlink}
+        onConfirmFullDelete={handleConfirmFullDelete}
+        onBack={handleBack}
       />
     </div>
   );

--- a/frontend/src/components/guardians/student-guardian-manager.tsx
+++ b/frontend/src/components/guardians/student-guardian-manager.tsx
@@ -27,6 +27,7 @@ import {
   deleteGuardianPhoneNumber,
   setGuardianPrimaryPhone,
   fetchGuardianDeletePreview,
+  GuardianApiError,
 } from "@/lib/guardian-api";
 import { useToast } from "~/contexts/ToastContext";
 import { createLogger } from "~/lib/logger";
@@ -429,14 +430,23 @@ export default function StudentGuardianManager({
 
       logger.error("guardian_full_delete_preview_failed", {
         error: err instanceof Error ? err.message : String(err),
+        status: err instanceof GuardianApiError ? err.status : undefined,
         guardian_id: guardianId,
         student_id: studentId,
       });
-      toastError(
-        err instanceof Error
-          ? err.message
-          : "Fehler beim Prüfen der betroffenen Kinder",
-      );
+      // A 403 means the account may not fully delete a guardian — surface that
+      // explicitly rather than the generic "could not check children" message.
+      if (err instanceof GuardianApiError && err.status === 403) {
+        toastError(
+          "Sie haben keine Berechtigung, diese Person vollständig zu löschen.",
+        );
+      } else {
+        toastError(
+          err instanceof Error
+            ? err.message
+            : "Fehler beim Prüfen der betroffenen Kinder",
+        );
+      }
       // Preview failed — drop back to the choice rather than letting the user
       // confirm a delete whose blast radius we never showed.
       handleBack();

--- a/frontend/src/lib/guardian-api.test.ts
+++ b/frontend/src/lib/guardian-api.test.ts
@@ -7,6 +7,7 @@ import {
   createGuardian,
   updateGuardian,
   deleteGuardian,
+  fetchGuardianDeletePreview,
   linkGuardianToStudent,
   updateStudentGuardianRelationship,
   removeGuardianFromStudent,
@@ -629,6 +630,81 @@ describe("guardian-api functions", () => {
       await expect(deleteGuardian("1")).rejects.toThrow(
         "Cannot delete guardian with linked students",
       );
+    });
+
+    it("appends force=true and expected link IDs to the URL for a full delete", async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+
+      await expect(
+        deleteGuardian("1", {
+          force: true,
+          expectedAffectedLinkIds: ["10", "20"],
+        }),
+      ).resolves.toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/guardians/1?force=true&expected_link_ids=10%2C20",
+        {
+          method: "DELETE",
+        },
+      );
+    });
+
+    it("throws a GuardianApiError carrying the HTTP status on conflict", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        statusText: "Conflict",
+        json: () => Promise.resolve({ error: "Noch mit Kindern verknüpft" }),
+      });
+
+      await expect(deleteGuardian("1")).rejects.toMatchObject({
+        name: "GuardianApiError",
+        status: 409,
+        message: "Noch mit Kindern verknüpft",
+      });
+    });
+  });
+
+  describe("fetchGuardianDeletePreview", () => {
+    it("maps the snake_case preview payload to camelCase", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status: "success",
+            data: {
+              linked_count: 2,
+              affected_names: ["Anna Müller", "Ben Müller"],
+              affected_link_ids: [10, 20],
+              warning: "Die Person ist mit 2 Kindern verknüpft …",
+            },
+          }),
+      });
+
+      await expect(fetchGuardianDeletePreview("1")).resolves.toEqual({
+        linkedCount: 2,
+        affectedNames: ["Anna Müller", "Ben Müller"],
+        affectedLinkIds: ["10", "20"],
+        warning: "Die Person ist mit 2 Kindern verknüpft …",
+      });
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/guardians/1/delete-preview",
+      );
+    });
+
+    it("throws a GuardianApiError carrying the status when the backend forbids it", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        json: () => Promise.resolve({ error: "nur Administratoren" }),
+      });
+
+      await expect(fetchGuardianDeletePreview("1")).rejects.toMatchObject({
+        name: "GuardianApiError",
+        status: 403,
+        message: "nur Administratoren",
+      });
     });
   });
 

--- a/frontend/src/lib/guardian-api.test.ts
+++ b/frontend/src/lib/guardian-api.test.ts
@@ -7,6 +7,7 @@ import {
   createGuardian,
   updateGuardian,
   deleteGuardian,
+  createStudentGuardians,
   fetchGuardianDeletePreview,
   linkGuardianToStudent,
   updateStudentGuardianRelationship,
@@ -705,6 +706,92 @@ describe("guardian-api functions", () => {
         status: 403,
         message: "nur Administratoren",
       });
+    });
+  });
+
+  describe("createStudentGuardians", () => {
+    it("posts the batch as snake_case to the /batch endpoint", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 201,
+        json: () => Promise.resolve({ status: "success" }),
+      });
+
+      await expect(
+        createStudentGuardians("123", [
+          {
+            firstName: "Atomic",
+            lastName: "Guardian",
+            email: "a@b.de",
+            relationshipType: "parent",
+            isPrimary: true,
+            isEmergencyContact: false,
+            canPickup: true,
+            emergencyPriority: 1,
+            phoneNumbers: [
+              {
+                phoneNumber: "+49 1",
+                phoneType: "mobile",
+                isPrimary: true,
+              },
+            ],
+          },
+        ]),
+      ).resolves.toBeUndefined();
+
+      const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock
+        .calls[0] as [string, RequestInit];
+      expect(url).toBe("/api/guardians/students/123/guardians/batch");
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(init.body as string)).toEqual({
+        guardians: [
+          expect.objectContaining({
+            first_name: "Atomic",
+            last_name: "Guardian",
+            email: "a@b.de",
+            relationship_type: "parent",
+            is_primary: true,
+            can_pickup: true,
+            emergency_priority: 1,
+            phone_numbers: [
+              expect.objectContaining({
+                phone_number: "+49 1",
+                phone_type: "mobile",
+                is_primary: true,
+              }),
+            ],
+          }),
+        ],
+      });
+    });
+
+    it("translates a duplicate-email 400 into the German guidance message", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        json: () =>
+          Promise.resolve({
+            error:
+              'Erziehungsberechtigte/r 1: E-Mail-Adresse "a@b.de" ist bereits vergeben',
+          }),
+      });
+
+      await expect(
+        createStudentGuardians("123", [
+          {
+            firstName: "A",
+            lastName: "B",
+            relationshipType: "parent",
+            isPrimary: false,
+            isEmergencyContact: false,
+            canPickup: false,
+            emergencyPriority: 1,
+          },
+        ]),
+      ).rejects.toThrow(
+        "Diese E-Mail-Adresse ist bereits vergeben. Bitte die vorhandene Person über die Suche auswählen.",
+      );
     });
   });
 

--- a/frontend/src/lib/guardian-api.ts
+++ b/frontend/src/lib/guardian-api.ts
@@ -11,6 +11,7 @@ import type {
   BackendGuardianPickerResponse,
   BackendGuardianWithRelationship,
   PhoneNumber,
+  PhoneType,
   PhoneNumberCreateRequest,
   PhoneNumberUpdateRequest,
   BackendPhoneNumber,
@@ -459,7 +460,9 @@ export async function fetchGuardianDeletePreview(
   const result = (await response.json()) as ApiResponse<{
     linked_count: number;
     affected_names: string[];
-    affected_link_ids: number[];
+    // The backend sends int64 link IDs as strings (lossless across the JS
+    // safe-integer boundary); tolerate legacy numbers defensively.
+    affected_link_ids: Array<string | number>;
     warning: string;
   }>;
 
@@ -471,7 +474,7 @@ export async function fetchGuardianDeletePreview(
     linkedCount: result.data.linked_count,
     affectedNames: result.data.affected_names ?? [],
     affectedLinkIds: (result.data.affected_link_ids ?? []).map((id) =>
-      id.toString(),
+      String(id),
     ),
     warning: result.data.warning,
   };
@@ -516,6 +519,113 @@ export async function linkGuardianToStudent(
 
   if (result.status === "error") {
     throw new Error(result.error ?? "Failed to link guardian");
+  }
+}
+
+/**
+ * One guardian to create and link to an existing student in a single atomic
+ * request. This flow always creates a NEW profile; the sibling/existing-guardian
+ * case is handled separately by {@link linkGuardianToStudent} via the picker.
+ */
+export interface NewStudentGuardianInput {
+  firstName: string;
+  lastName: string;
+  email?: string;
+  addressStreet?: string;
+  addressCity?: string;
+  addressPostalCode?: string;
+  languagePreference?: string;
+  notes?: string;
+  relationshipType: string;
+  isPrimary: boolean;
+  isEmergencyContact: boolean;
+  canPickup: boolean;
+  pickupNotes?: string;
+  emergencyPriority: number;
+  phoneNumbers?: Array<{
+    phoneNumber: string;
+    phoneType: PhoneType;
+    label?: string;
+    isPrimary: boolean;
+  }>;
+}
+
+/**
+ * Atomically create one or more guardians for an existing student.
+ *
+ * The backend creates every guardian profile, links it to the student, and adds
+ * its phone numbers inside ONE transaction (#819). Any failure rolls the whole
+ * batch back server-side, so there are no orphaned profiles and the client needs
+ * no compensating delete (which a non-admin supervisor could not perform once a
+ * guardian had lost its links). Bad input (e.g. a duplicate email) comes back as
+ * a 400 with a German message, translated for display.
+ */
+export async function createStudentGuardians(
+  studentId: string,
+  guardians: NewStudentGuardianInput[],
+): Promise<void> {
+  const body = {
+    guardians: guardians.map((g) => ({
+      first_name: g.firstName,
+      last_name: g.lastName,
+      email: g.email,
+      address_street: g.addressStreet,
+      address_city: g.addressCity,
+      address_postal_code: g.addressPostalCode,
+      language_preference: g.languagePreference,
+      notes: g.notes,
+      relationship_type: g.relationshipType,
+      is_primary: g.isPrimary,
+      is_emergency_contact: g.isEmergencyContact,
+      can_pickup: g.canPickup,
+      pickup_notes: g.pickupNotes,
+      emergency_priority: g.emergencyPriority,
+      phone_numbers: g.phoneNumbers?.map((p) => ({
+        phone_number: p.phoneNumber,
+        phone_type: p.phoneType,
+        label: p.label,
+        is_primary: p.isPrimary,
+      })),
+    })),
+  };
+
+  const response = await fetch(
+    `/api/guardians/students/${studentId}/guardians/batch`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!response.ok) {
+    const error: unknown = await response.json().catch((err) => {
+      logger.debug("json_parse_failed", {
+        error: err instanceof Error ? err.message : String(err),
+        status: response.status,
+        operation: "create_student_guardians",
+      });
+      return { error: "Failed to create guardians" };
+    });
+    const errorMessage = isErrorResponse(error)
+      ? translateApiError(error.error)
+      : translateApiError(`Failed to create guardians: ${response.statusText}`);
+    throw new Error(errorMessage);
+  }
+
+  // 201 Created with no meaningful body — the caller reloads the guardian list.
+  if (response.status === 204) {
+    return;
+  }
+
+  const result = (await response.json()) as ApiResponse<null>;
+
+  if (result.status === "error") {
+    throw new Error(
+      translateApiError(result.error ?? "Failed to create guardians"),
+    );
   }
 }
 

--- a/frontend/src/lib/guardian-api.ts
+++ b/frontend/src/lib/guardian-api.ts
@@ -64,6 +64,20 @@ function isErrorResponse(value: unknown): value is ErrorResponse {
   );
 }
 
+// Error carrying the HTTP status so callers can branch on it. The guardian
+// delete flow needs to tell a 409 (still linked — show the affected children
+// and offer a full delete) apart from a 403 (not allowed to fully delete) and
+// a generic failure.
+export class GuardianApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "GuardianApiError";
+    this.status = status;
+  }
+}
+
 // Error message translations (English backend -> German frontend)
 // Exported for testing
 export const errorTranslations: Record<string, string> = {
@@ -343,10 +357,34 @@ export async function updateGuardian(
 }
 
 /**
- * Delete a guardian profile
+ * Delete a guardian profile.
+ *
+ * By default this is a guarded delete: the backend refuses (409) a guardian
+ * that is still linked to any student. Pass `{ force: true }` to perform the
+ * deliberate full delete that also removes every student link — the backend
+ * restricts that to administrators (403 otherwise). On any non-OK response a
+ * {@link GuardianApiError} carrying the HTTP status is thrown so the caller can
+ * branch on 409 / 403.
  */
-export async function deleteGuardian(guardianId: string): Promise<void> {
-  const response = await fetch(`/api/guardians/${guardianId}`, {
+export async function deleteGuardian(
+  guardianId: string,
+  opts: { force?: boolean; expectedAffectedLinkIds?: readonly string[] } = {},
+): Promise<void> {
+  const searchParams = new URLSearchParams();
+  if (opts.force) {
+    searchParams.set("force", "true");
+  }
+  if (opts.expectedAffectedLinkIds?.length) {
+    searchParams.set(
+      "expected_link_ids",
+      opts.expectedAffectedLinkIds.join(","),
+    );
+  }
+  const queryString = searchParams.toString();
+  const url = queryString
+    ? `/api/guardians/${guardianId}?${queryString}`
+    : `/api/guardians/${guardianId}`;
+  const response = await fetch(url, {
     method: "DELETE",
   });
 
@@ -362,7 +400,7 @@ export async function deleteGuardian(guardianId: string): Promise<void> {
     const errorMessage = isErrorResponse(error)
       ? error.error
       : `Failed to delete guardian: ${response.statusText}`;
-    throw new Error(errorMessage);
+    throw new GuardianApiError(errorMessage, response.status);
   }
 
   // 204 No Content means successful deletion with no response body
@@ -376,6 +414,67 @@ export async function deleteGuardian(guardianId: string): Promise<void> {
   if (result.status === "error") {
     throw new Error(result.error ?? "Failed to delete guardian");
   }
+}
+
+/** Read-only preview of what a full guardian delete would affect. */
+export interface GuardianDeletePreview {
+  /** How many students are still linked to the guardian. */
+  linkedCount: number;
+  /** Full names of the affected children. */
+  affectedNames: string[];
+  /** Relationship row IDs the server will compare on confirm. */
+  affectedLinkIds: string[];
+  /** Ready-to-show German warning describing the blast radius. */
+  warning: string;
+}
+
+/**
+ * Fetch the blast radius of a full guardian delete WITHOUT deleting anything.
+ *
+ * Backs the admin "Komplett löschen" confirmation: the modal shows
+ * {@link GuardianDeletePreview.warning} (which children would lose the
+ * guardian) before the user confirms the force delete. Admin-only on the
+ * backend (403 otherwise), exposed via {@link GuardianApiError}.
+ */
+export async function fetchGuardianDeletePreview(
+  guardianId: string,
+): Promise<GuardianDeletePreview> {
+  const response = await fetch(`/api/guardians/${guardianId}/delete-preview`);
+
+  if (!response.ok) {
+    const error: unknown = await response.json().catch((err) => {
+      logger.debug("json_parse_failed", {
+        error: err instanceof Error ? err.message : String(err),
+        status: response.status,
+        operation: "fetch_guardian_delete_preview",
+      });
+      return { error: "Failed to load delete preview" };
+    });
+    const errorMessage = isErrorResponse(error)
+      ? error.error
+      : `Failed to load delete preview: ${response.statusText}`;
+    throw new GuardianApiError(errorMessage, response.status);
+  }
+
+  const result = (await response.json()) as ApiResponse<{
+    linked_count: number;
+    affected_names: string[];
+    affected_link_ids: number[];
+    warning: string;
+  }>;
+
+  if (result.status === "error" || !result.data) {
+    throw new Error(result.error ?? "Failed to load delete preview");
+  }
+
+  return {
+    linkedCount: result.data.linked_count,
+    affectedNames: result.data.affected_names ?? [],
+    affectedLinkIds: (result.data.affected_link_ids ?? []).map((id) =>
+      id.toString(),
+    ),
+    warning: result.data.warning,
+  };
 }
 
 /**


### PR DESCRIPTION
Closes #819

## Problem
`DELETE /guardians/{id}` cascaded across **every** linked student because the `students_guardians → guardian_profiles` FK was `ON DELETE CASCADE`. Deleting a guardian silently removed sibling links too (unintended data loss). The handler's existing 409 guard was unreachable for the same reason — a CASCADE FK never throws.

This addresses all three problems from the issue (problems 2 and 3 were already fixed on `development`; this PR closes problem 1 and tidies the remaining problem-2 edge cases).

## Changes

### Backend
- **Migration 1.15.127**: flip the `fk_students_guardians_guardian_tenant` FK from `CASCADE` to `RESTRICT`, making a delete with remaining links fail loudly (reversible down-migration restores `CASCADE`). Only this one inbound FK changes; the guardian's own dependents (phones, invitations) keep `CASCADE`.
- **`DELETE /guardians/{id}?force=true`** performs the deliberate full delete (admin-only). Without `force` and with existing links → **409** listing the affected children. Per-student unlink stays at `DELETE /students/{id}/guardians/{gid}`.
- **`GET /guardians/{id}/delete-preview`** (new, read-only) replaces the old destructive "probe DELETE": returns the affected children + a link-ID concurrency token. `DeleteGuardianWithLinks` rechecks that token under `SELECT … FOR UPDATE` before deleting (TOCTOU-safe; stale token → 409).
- **`tenant.MarkRollback`** lets the handler roll back the tenant transaction on a non-5xx (409) response.
- Email dedup in `CreateGuardian`/`UpdateGuardian` → **400** with a shared German message + a `23505` unique-violation fallback against races.

### Frontend
- Three-step delete modal: "nur von diesem Kind entfernen" vs. admin "vollständig löschen", with the affected-children warning fetched from the preview endpoint before confirm. A 403 on preview now shows an explicit permission message.

## Safety
No automated process hard-deletes `guardian_profiles`: staff offboarding preserves guardians, school deletion is soft-delete, no retention/cleanup job touches them, and student deletion still cascades the link rows (student→link FK stays `CASCADE`). The `RESTRICT` change therefore only affects the manual delete endpoint — exactly where the guard is wanted.

## Tests
- Service error paths (forced-failure fakes), `LockByIDForUpdate`, the rollback marker + middleware (rolls back despite a 200), the full delete flow, and the frontend modal/API client.
- New-code coverage on the SonarQube-counted files ≈ **93%** (≥ 85% gate).

## Cross-repo
No IoT/auth error strings or headers changed → no PyrePortal coordination needed.