### PR TITLE
Fix midnight-window visit names test

### DIFF
--- a/backend/database/repositories/active/visits_repository_test.go
+++ b/backend/database/repositories/active/visits_repository_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	activeRepo "github.com/moto-nrw/project-phoenix/database/repositories/active"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/users"
@@ -546,7 +547,7 @@ func TestVisitRepository_GetTodayVisitNamesForStudents(t *testing.T) {
 	data := createVisitTestData(t, db)
 	defer cleanupVisitTestData(t, db, data)
 
-	visit := testpkg.CreateTestVisit(t, db, data.Student1.ID, data.ActiveGroup.ID, time.Now().Add(-30*time.Minute), nil)
+	visit := testpkg.CreateTestVisit(t, db, data.Student1.ID, data.ActiveGroup.ID, timezone.Today().Add(30*time.Minute), nil)
 	defer testpkg.CleanupTableRecords(t, db, "active.visits", visit.ID)
 
 	t.Run("empty input short-circuits", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Stabilize `TestVisitRepository_GetTodayVisitNamesForStudents` by creating the fixture after Berlin midnight.
- Keep production visit query behavior unchanged.

## Root Cause
The test inserted a visit with `time.Now().Add(-30 * time.Minute)`. When CI runs between 00:00 and 00:30 Berlin time, that fixture belongs to the previous Berlin calendar day, while `GetTodayVisitNamesForStudents` correctly filters from Berlin midnight.

## Validation
- `cd backend && APP_ENV=test go test ./database/repositories/active -run TestVisitRepository_GetTodayVisitNamesForStudents -count=1`
- pre-push: git-secrets, go-vet, golangci-lint, go-deadcode
