### PR TITLE
Fix operator profile email display

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -1367,7 +1367,7 @@
     },
     "nodejs_24@latest": {
       "last_modified": "2025-12-27T12:56:01Z",
-      "plugin_version": "0.0.2",
+      "plugin_version": "0.0.3",
       "resolved": "github:NixOS/nixpkgs/3edc4a30ed3903fdf6f90c837f961fa6b49582d1#nodejs_24",
       "source": "devbox-search",
       "version": "24.12.0",

--- a/frontend/src/app/operator/settings/page.test.tsx
+++ b/frontend/src/app/operator/settings/page.test.tsx
@@ -44,6 +44,12 @@ vi.mock("~/components/settings/trusted-devices-section", () => ({
 
 import OperatorSettingsPage from "./page";
 
+const defaultProfile = {
+  id: 1,
+  email: "mail@yannickwenger.de",
+  display_name: "yonnock",
+};
+
 describe("OperatorSettingsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -55,12 +61,40 @@ describe("OperatorSettingsPage", () => {
       status: "authenticated",
       update: mockUpdateSession,
     });
-    mockSessionFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        data: { id: 1, email: "test@example.com", display_name: "Test User" },
-      }),
-    } as Response);
+    mockSessionFetch.mockImplementation(
+      async (url: string, init?: RequestInit) => {
+        if (url === "/api/operator/profile" && init?.method === "GET") {
+          return {
+            ok: true,
+            json: async () => ({ data: defaultProfile }),
+          } as Response;
+        }
+        if (url === "/api/operator/profile" && init?.method === "PUT") {
+          const body = JSON.parse(String(init.body ?? "{}")) as {
+            display_name?: string;
+          };
+          return {
+            ok: true,
+            json: async () => ({
+              data: {
+                ...defaultProfile,
+                display_name: body.display_name ?? defaultProfile.display_name,
+              },
+            }),
+          } as Response;
+        }
+        if (url === "/api/operator/profile/email-change") {
+          return {
+            ok: true,
+            json: async () => ({ message: "Verification email sent" }),
+          } as Response;
+        }
+        return {
+          ok: true,
+          json: async () => ({ data: defaultProfile }),
+        } as Response;
+      },
+    );
   });
 
   it("shows loading state when auth is loading", async () => {
@@ -82,8 +116,50 @@ describe("OperatorSettingsPage", () => {
 
     await waitFor(() => {
       const displayNameInput = screen.getByLabelText("Anzeigename");
-      expect(displayNameInput).toHaveValue("John Doe");
+      expect(displayNameInput).toHaveValue("yonnock");
+      expect(screen.getByLabelText("E-Mail")).toHaveValue(
+        "mail@yannickwenger.de",
+      );
     });
+  });
+
+  it("loads canonical backend email instead of a platform token subject", async () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { name: "yonnock", email: "operator:2" },
+      },
+      status: "authenticated",
+      update: mockUpdateSession,
+    });
+
+    render(<OperatorSettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("E-Mail")).toHaveValue(
+        "mail@yannickwenger.de",
+      );
+    });
+    expect(screen.getByLabelText("E-Mail")).not.toHaveValue("operator:2");
+  });
+
+  it("does not show a non-email session fallback when profile loading fails", async () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { name: "yonnock", email: "operator:2" },
+      },
+      status: "authenticated",
+      update: mockUpdateSession,
+    });
+    mockSessionFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    render(<OperatorSettingsPage />);
+
+    await waitFor(() => {
+      expect(mockSessionFetch).toHaveBeenCalledWith("/api/operator/profile", {
+        method: "GET",
+      });
+    });
+    expect(screen.getByLabelText("E-Mail")).toHaveValue("");
   });
 
   it("updates profile on save", async () => {
@@ -116,10 +192,20 @@ describe("OperatorSettingsPage", () => {
   });
 
   it("handles save error gracefully", async () => {
-    mockSessionFetch.mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Something went wrong" }),
-    } as Response);
+    mockSessionFetch.mockImplementation(
+      async (url: string, init?: RequestInit) => {
+        if (url === "/api/operator/profile" && init?.method === "GET") {
+          return {
+            ok: true,
+            json: async () => ({ data: defaultProfile }),
+          } as Response;
+        }
+        return {
+          ok: false,
+          json: async () => ({ error: "Something went wrong" }),
+        } as Response;
+      },
+    );
 
     render(<OperatorSettingsPage />);
 
@@ -148,7 +234,7 @@ describe("OperatorSettingsPage", () => {
     fireEvent.click(screen.getByText("Abbrechen"));
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Anzeigename")).toHaveValue("John Doe");
+      expect(screen.getByLabelText("Anzeigename")).toHaveValue("yonnock");
     });
   });
 
@@ -156,7 +242,7 @@ describe("OperatorSettingsPage", () => {
     render(<OperatorSettingsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("JD")).toBeInTheDocument();
+      expect(screen.getByText("Y")).toBeInTheDocument();
     });
   });
 
@@ -168,6 +254,12 @@ describe("OperatorSettingsPage", () => {
       status: "authenticated",
       update: mockUpdateSession,
     });
+    mockSessionFetch.mockImplementation(async () => ({
+      ok: true,
+      json: async () => ({
+        data: { id: 1, email: "admin@example.com", display_name: "Admin" },
+      }),
+    }));
 
     render(<OperatorSettingsPage />);
 
@@ -224,11 +316,6 @@ describe("OperatorSettingsPage", () => {
     });
 
     it("submits email change request successfully", async () => {
-      mockSessionFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ message: "Verification email sent" }),
-      } as Response);
-
       render(<OperatorSettingsPage />);
 
       await waitFor(() => {
@@ -267,11 +354,6 @@ describe("OperatorSettingsPage", () => {
     });
 
     it("closes dialog after successful submission", async () => {
-      mockSessionFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ message: "OK" }),
-      } as Response);
-
       render(<OperatorSettingsPage />);
 
       await waitFor(() => {
@@ -303,12 +385,22 @@ describe("OperatorSettingsPage", () => {
     });
 
     it("sends error response without closing dialog on wrong password", async () => {
-      mockSessionFetch.mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({
-          error: "Das aktuelle Passwort ist falsch",
-        }),
-      } as Response);
+      mockSessionFetch.mockImplementation(
+        async (url: string, init?: RequestInit) => {
+          if (url === "/api/operator/profile" && init?.method === "GET") {
+            return {
+              ok: true,
+              json: async () => ({ data: defaultProfile }),
+            } as Response;
+          }
+          return {
+            ok: false,
+            json: async () => ({
+              error: "Das aktuelle Passwort ist falsch",
+            }),
+          } as Response;
+        },
+      );
 
       render(<OperatorSettingsPage />);
 
@@ -351,10 +443,20 @@ describe("OperatorSettingsPage", () => {
     });
 
     it("keeps dialog open on other API errors", async () => {
-      mockSessionFetch.mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({ error: "E-Mail bereits verwendet" }),
-      } as Response);
+      mockSessionFetch.mockImplementation(
+        async (url: string, init?: RequestInit) => {
+          if (url === "/api/operator/profile" && init?.method === "GET") {
+            return {
+              ok: true,
+              json: async () => ({ data: defaultProfile }),
+            } as Response;
+          }
+          return {
+            ok: false,
+            json: async () => ({ error: "E-Mail bereits verwendet" }),
+          } as Response;
+        },
+      );
 
       render(<OperatorSettingsPage />);
 
@@ -380,7 +482,10 @@ describe("OperatorSettingsPage", () => {
       fireEvent.click(screen.getByText("E-Mail-Änderung anfordern"));
 
       await waitFor(() => {
-        expect(mockSessionFetch).toHaveBeenCalledTimes(1);
+        expect(mockSessionFetch).toHaveBeenCalledWith(
+          "/api/operator/profile/email-change",
+          expect.objectContaining({ method: "POST" }),
+        );
       });
 
       // Dialog stays open on error
@@ -388,7 +493,17 @@ describe("OperatorSettingsPage", () => {
     });
 
     it("keeps dialog open on network error", async () => {
-      mockSessionFetch.mockRejectedValueOnce(new Error("Network error"));
+      mockSessionFetch.mockImplementation(
+        async (url: string, init?: RequestInit) => {
+          if (url === "/api/operator/profile" && init?.method === "GET") {
+            return {
+              ok: true,
+              json: async () => ({ data: defaultProfile }),
+            } as Response;
+          }
+          throw new Error("Network error");
+        },
+      );
 
       render(<OperatorSettingsPage />);
 
@@ -414,7 +529,10 @@ describe("OperatorSettingsPage", () => {
       fireEvent.click(screen.getByText("E-Mail-Änderung anfordern"));
 
       await waitFor(() => {
-        expect(mockSessionFetch).toHaveBeenCalledTimes(1);
+        expect(mockSessionFetch).toHaveBeenCalledWith(
+          "/api/operator/profile/email-change",
+          expect.objectContaining({ method: "POST" }),
+        );
       });
 
       // Dialog stays open on network error

--- a/frontend/src/app/operator/settings/page.tsx
+++ b/frontend/src/app/operator/settings/page.tsx
@@ -10,8 +10,20 @@ import { sessionFetch } from "~/lib/session-cache";
 import { TrustedDevicesSection } from "~/components/settings/trusted-devices-section";
 import { PasskeySettingsSection } from "~/components/settings/passkey-settings-section";
 
+interface OperatorProfile {
+  id: number;
+  email: string;
+  display_name: string;
+}
+
+function isEmail(value: string | null | undefined): value is string {
+  return typeof value === "string" && value.includes("@");
+}
+
 function OperatorSettingsContent() {
   const { data: session, status, update: updateSession } = useSession();
+  const sessionName = session?.user?.name ?? "";
+  const sessionEmail = session?.user?.email ?? "";
 
   const [showAlert, setShowAlert] = useState(false);
   const [alertMessage, setAlertMessage] = useState("");
@@ -24,6 +36,7 @@ function OperatorSettingsContent() {
     displayName: "",
     email: "",
   });
+  const [profileData, setProfileData] = useState<OperatorProfile | null>(null);
 
   // Email change state
   const [showEmailChangeDialog, setShowEmailChangeDialog] = useState(false);
@@ -41,13 +54,46 @@ function OperatorSettingsContent() {
   }, []);
 
   useEffect(() => {
-    if (session?.user) {
-      setFormData({
-        displayName: session.user.name ?? "",
-        email: session.user.email ?? "",
-      });
+    if (status !== "authenticated") {
+      return;
     }
-  }, [session]);
+
+    let ignore = false;
+    const sessionFallback = {
+      displayName: sessionName,
+      email: isEmail(sessionEmail) ? sessionEmail : "",
+    };
+
+    setFormData(sessionFallback);
+
+    const loadProfile = async () => {
+      try {
+        const response = await sessionFetch("/api/operator/profile", {
+          method: "GET",
+        });
+        if (!response.ok) return;
+
+        const data = (await response.json()) as { data?: OperatorProfile };
+        const profile = data.data;
+        if (!profile || ignore) return;
+
+        setProfileData(profile);
+        setFormData({
+          displayName: profile.display_name,
+          email: profile.email,
+        });
+      } catch {
+        // Keep the safe session fallback. The profile form should not surface
+        // token subjects like "operator:2" as an email address.
+      }
+    };
+
+    void loadProfile();
+
+    return () => {
+      ignore = true;
+    };
+  }, [status, sessionName, sessionEmail]);
 
   const handleSaveProfile = async () => {
     setIsSaving(true);
@@ -65,7 +111,21 @@ function OperatorSettingsContent() {
         );
       }
 
-      await updateSession({ name: formData.displayName });
+      const data = (await response.json()) as { data?: OperatorProfile };
+      const updatedProfile = data.data;
+      const nextDisplayName =
+        updatedProfile?.display_name ?? formData.displayName;
+      const nextEmail = updatedProfile?.email ?? formData.email;
+
+      if (updatedProfile) {
+        setProfileData(updatedProfile);
+      }
+      setFormData({
+        displayName: nextDisplayName,
+        email: nextEmail,
+      });
+
+      await updateSession({ name: nextDisplayName, email: nextEmail });
 
       setIsEditing(false);
       setAlertMessage("Profil erfolgreich aktualisiert");
@@ -225,10 +285,15 @@ function OperatorSettingsContent() {
                 <button
                   onClick={() => {
                     setIsEditing(false);
-                    if (session?.user) {
+                    if (profileData) {
                       setFormData({
-                        displayName: session.user.name ?? "",
-                        email: session.user.email ?? "",
+                        displayName: profileData.display_name,
+                        email: profileData.email,
+                      });
+                    } else if (status === "authenticated") {
+                      setFormData({
+                        displayName: sessionName,
+                        email: isEmail(sessionEmail) ? sessionEmail : "",
                       });
                     }
                   }}

--- a/frontend/src/server/auth/config.test.ts
+++ b/frontend/src/server/auth/config.test.ts
@@ -23,6 +23,12 @@ const OPERATOR_JWT =
 // { id: 45, sub: "operator:45", username: "op@example.com", first_name: "Op", roles: ["operator"], scope: "platform" }
 const OPERATOR_JWT_MINIMAL =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDUsInN1YiI6Im9wZXJhdG9yOjQ1IiwidXNlcm5hbWUiOiJvcEBleGFtcGxlLmNvbSIsImZpcnN0X25hbWUiOiJPcCIsInJvbGVzIjpbIm9wZXJhdG9yIl0sInNjb3BlIjoicGxhdGZvcm0ifQ.test";
+// { id: 45, sub: "operator:45", email: "legacy-op@example.com", first_name: "Op", roles: ["operator"], scope: "platform" }
+const OPERATOR_JWT_EMAIL_ONLY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDUsInN1YiI6Im9wZXJhdG9yOjQ1IiwiZW1haWwiOiJsZWdhY3ktb3BAZXhhbXBsZS5jb20iLCJmaXJzdF9uYW1lIjoiT3AiLCJyb2xlcyI6WyJvcGVyYXRvciJdLCJzY29wZSI6InBsYXRmb3JtIn0.test";
+// { id: 45, sub: "operator:45", first_name: "Op", roles: ["operator"], scope: "platform" }
+const OPERATOR_JWT_NO_EMAIL =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDUsInN1YiI6Im9wZXJhdG9yOjQ1IiwiZmlyc3RfbmFtZSI6Ik9wIiwicm9sZXMiOlsib3BlcmF0b3IiXSwic2NvcGUiOiJwbGF0Zm9ybSJ9.test";
 
 // Mock ~/env
 vi.mock("~/env", () => ({
@@ -1537,6 +1543,39 @@ describe("authConfig", () => {
       expect(result?.roles).toEqual(["operator"]);
       expect(result?.email).toBe("op@example.com");
       expect(result?.email).not.toBe("operator:45");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("should fall back to email claim for legacy operator internal refresh tokens", async () => {
+      const authorize = getOperatorAuthorize();
+      const result = await authorize(
+        {
+          internalRefresh: "true",
+          token: OPERATOR_JWT_EMAIL_ONLY,
+          refreshToken: "op-refresh",
+        },
+        new Request("http://localhost:3000"),
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.email).toBe("legacy-op@example.com");
+      expect(result?.email).not.toBe("operator:45");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("should not use operator subject as email when internal refresh token has no email claims", async () => {
+      const authorize = getOperatorAuthorize();
+      const result = await authorize(
+        {
+          internalRefresh: "true",
+          token: OPERATOR_JWT_NO_EMAIL,
+          refreshToken: "op-refresh",
+        },
+        new Request("http://localhost:3000"),
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.email).toBe("");
       expect(mockFetch).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/server/auth/config.test.ts
+++ b/frontend/src/server/auth/config.test.ts
@@ -17,12 +17,12 @@ const INTERNAL_REFRESH_JWT =
 // { id: 1, first_name: "John", email: "john@example.com" } (no last_name, no roles)
 const TEACHER_JWT_MINIMAL =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6IkpvaG4iLCJlbWFpbCI6ImpvaG5AZXhhbXBsZS5jb20ifQ.test";
-// { id: 45, first_name: "Op", email: "op@example.com", is_admin: true }
+// { id: 45, sub: "operator:45", username: "op@example.com", first_name: "Op", roles: ["operator"], permissions: [], scope: "platform", is_admin: false }
 const OPERATOR_JWT =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDUsImZpcnN0X25hbWUiOiJPcCIsImVtYWlsIjoib3BAZXhhbXBsZS5jb20iLCJpc19hZG1pbiI6dHJ1ZX0.test";
-// { id: 45, first_name: "Op", email: "op@example.com" } (no is_admin)
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDUsInN1YiI6Im9wZXJhdG9yOjQ1IiwidXNlcm5hbWUiOiJvcEBleGFtcGxlLmNvbSIsImZpcnN0X25hbWUiOiJPcCIsInJvbGVzIjpbIm9wZXJhdG9yIl0sInBlcm1pc3Npb25zIjpbXSwic2NvcGUiOiJwbGF0Zm9ybSIsImlzX2FkbWluIjpmYWxzZX0.test";
+// { id: 45, sub: "operator:45", username: "op@example.com", first_name: "Op", roles: ["operator"], scope: "platform" }
 const OPERATOR_JWT_MINIMAL =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDUsImZpcnN0X25hbWUiOiJPcCIsImVtYWlsIjoib3BAZXhhbXBsZS5jb20ifQ.test";
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDUsInN1YiI6Im9wZXJhdG9yOjQ1IiwidXNlcm5hbWUiOiJvcEBleGFtcGxlLmNvbSIsImZpcnN0X25hbWUiOiJPcCIsInJvbGVzIjpbIm9wZXJhdG9yIl0sInNjb3BlIjoicGxhdGZvcm0ifQ.test";
 
 // Mock ~/env
 vi.mock("~/env", () => ({
@@ -1535,6 +1535,8 @@ describe("authConfig", () => {
       expect(result).not.toBeNull();
       expect(result?.scope).toBe("platform");
       expect(result?.roles).toEqual(["operator"]);
+      expect(result?.email).toBe("op@example.com");
+      expect(result?.email).not.toBe("operator:45");
       expect(mockFetch).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/server/auth/operator-config.ts
+++ b/frontend/src/server/auth/operator-config.ts
@@ -54,7 +54,7 @@ export const operatorAuthConfig = {
           const payload = parseJwtPayload(creds.token);
           if (!payload) return null;
 
-          const email = payload.email ?? payload.sub ?? "";
+          const email = payload.username ?? payload.email ?? "";
           return buildAuthUser(
             payload,
             creds.token,


### PR DESCRIPTION
## Summary
- Load the canonical operator profile from `/api/operator/profile` before showing profile settings.
- Prefer the operator JWT `username` claim over `sub` so platform subjects like `operator:45` do not become session emails.
- Preserve the backend profile response after save and update the session with the canonical display name and email.

## Why
Operator JWTs can carry `sub` values such as `operator:45`. Falling back to that field as an email leaks an internal subject into the operator settings UI.

## Validation
- `cd frontend && pnpm test:run src/app/operator/settings/page.test.tsx src/server/auth/config.test.ts`
- `cd frontend && pnpm run check`
- pre-push hook: `frontend-knip`, `frontend-check`, `git-secrets`