### PR TITLE
Show enrollment history on student records

### DIFF
--- a/backend/api/enrollment/admin_decision_handlers.go
+++ b/backend/api/enrollment/admin_decision_handlers.go
@@ -216,58 +216,13 @@ func (rs *Resource) getAdminRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var summary *enrollmentService.RequestSummary
-	var schemaFields []AdminRequestSchemaField
-	var schemaLegalBlocks []AdminRequestSchemaLegalBlock
-	var childOfferings map[int64][]enrollmentService.ChildOfferingRow
+	var detail AdminRequestSummary
 	err = rs.runInTenantTx(r, func(ctx context.Context) error {
 		s, e := rs.DecisionService.Get(ctx, id)
 		if e != nil {
 			return e
 		}
-		summary = s
-		// Per-child offerings — best-effort; failure here doesn't kill
-		// the detail response, the admin just sees no Betreuungsangebote
-		// section.
-		if off, oerr := rs.DecisionService.ListChildOfferings(ctx, id); oerr == nil {
-			childOfferings = off
-		}
-		// Pull the form schema so the response can carry labels +
-		// targets alongside the raw custom_data values. Best-effort:
-		// a missing schema falls back to rendering raw keys on the
-		// frontend.
-		if rs.FormSchemaService != nil && s.Request != nil && s.Request.SchemaID != nil {
-			fs, ferr := rs.FormSchemaService.GetByID(ctx, *s.Request.SchemaID)
-			if ferr == nil && fs != nil {
-				schemaFields = make([]AdminRequestSchemaField, 0, len(fs.Fields))
-				for _, f := range fs.Fields {
-					// Information blocks collect no answer — omit them
-					// from the admin's per-submission field list.
-					if f.Type == enrollmentModels.FormFieldInfo {
-						continue
-					}
-					opts := make([]AdminRequestSchemaFieldOption, 0, len(f.Options))
-					for _, o := range f.Options {
-						opts = append(opts, AdminRequestSchemaFieldOption{Label: o.Label, Value: o.Value})
-					}
-					schemaFields = append(schemaFields, AdminRequestSchemaField{
-						Key:            f.Key,
-						Label:          f.Label,
-						Type:           string(f.Type),
-						AppliesToChild: f.AppliesToCh,
-						Target:         f.Target,
-						Options:        opts,
-					})
-				}
-				schemaLegalBlocks = make([]AdminRequestSchemaLegalBlock, 0, len(fs.LegalBlocks))
-				for _, b := range fs.LegalBlocks {
-					schemaLegalBlocks = append(schemaLegalBlocks, AdminRequestSchemaLegalBlock{
-						Key:   b.Key,
-						Title: b.Title,
-					})
-				}
-			}
-		}
+		detail = rs.toAdminRequestDetail(ctx, s)
 		return nil
 	})
 	if err != nil {
@@ -278,36 +233,107 @@ func (rs *Resource) getAdminRequest(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInternalServer(err))
 		return
 	}
+	common.Respond(w, r, http.StatusOK, detail, "Admin request retrieved")
+}
+
+func (rs *Resource) listAdminRequestsByStudent(w http.ResponseWriter, r *http.Request) {
+	if rs.DecisionService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("decision service not configured")))
+		return
+	}
+	studentID, err := strconv.ParseInt(chi.URLParam(r, "studentId"), 10, 64)
+	if err != nil || studentID <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid studentId")))
+		return
+	}
+
+	var out []AdminRequestSummary
+	err = rs.runInTenantTx(r, func(ctx context.Context) error {
+		summaries, listErr := rs.DecisionService.ListByStudent(ctx, studentID)
+		if listErr != nil {
+			return listErr
+		}
+		out = make([]AdminRequestSummary, 0, len(summaries))
+		for _, summary := range summaries {
+			out = append(out, rs.toAdminRequestDetail(ctx, summary))
+		}
+		return nil
+	})
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+	common.Respond(w, r, http.StatusOK, out, "Student admin requests retrieved")
+}
+
+func (rs *Resource) toAdminRequestDetail(ctx context.Context, summary *enrollmentService.RequestSummary) AdminRequestSummary {
 	detail := toAdminRequestSummary(summary)
+	if summary == nil || summary.Request == nil {
+		return detail
+	}
 	detail.CustomData = summary.Request.CustomData
 	detail.ConsentFlags = summary.Request.ConsentFlags
-	detail.SchemaFields = schemaFields
-	detail.SchemaLegalBlocks = schemaLegalBlocks
-	// Stitch per-child offerings onto the detail-response children.
-	// childOfferings is keyed by request_child.id as a raw int64; the
-	// summary's children carry their id as the original int64 too —
-	// just need to format it the same way the DTO stringifies the id.
-	if childOfferings != nil {
-		for i := range detail.Children {
-			cid := summary.Children[i].ID
-			rows := childOfferings[cid]
-			if len(rows) == 0 {
-				continue
-			}
-			out := make([]AdminRequestChildOffering, 0, len(rows))
-			for _, row := range rows {
-				out = append(out, AdminRequestChildOffering{
-					OfferingID:     strconv.FormatInt(row.OfferingID, 10),
-					OfferingName:   row.OfferingName,
-					DaysOfWeekMode: row.DaysOfWeekMode,
-					SelectedDays:   row.SelectedDays,
-					AvailableDays:  row.AvailableDays,
-				})
-			}
-			detail.Children[i].Offerings = out
+
+	if rs.FormSchemaService != nil && summary.Request.SchemaID != nil {
+		if fs, err := rs.FormSchemaService.GetByID(ctx, *summary.Request.SchemaID); err == nil && fs != nil {
+			detail.SchemaFields, detail.SchemaLegalBlocks = toAdminSchemaMetadata(fs)
 		}
 	}
-	common.Respond(w, r, http.StatusOK, detail, "Admin request retrieved")
+
+	if rs.DecisionService != nil {
+		if childOfferings, err := rs.DecisionService.ListChildOfferings(ctx, summary.Request.ID); err == nil {
+			for i := range detail.Children {
+				if i >= len(summary.Children) {
+					continue
+				}
+				rows := childOfferings[summary.Children[i].ID]
+				if len(rows) == 0 {
+					continue
+				}
+				out := make([]AdminRequestChildOffering, 0, len(rows))
+				for _, row := range rows {
+					out = append(out, AdminRequestChildOffering{
+						OfferingID:     strconv.FormatInt(row.OfferingID, 10),
+						OfferingName:   row.OfferingName,
+						DaysOfWeekMode: row.DaysOfWeekMode,
+						SelectedDays:   row.SelectedDays,
+						AvailableDays:  row.AvailableDays,
+					})
+				}
+				detail.Children[i].Offerings = out
+			}
+		}
+	}
+	return detail
+}
+
+func toAdminSchemaMetadata(fs *enrollmentModels.FormSchema) ([]AdminRequestSchemaField, []AdminRequestSchemaLegalBlock) {
+	schemaFields := make([]AdminRequestSchemaField, 0, len(fs.Fields))
+	for _, f := range fs.Fields {
+		if f.Type == enrollmentModels.FormFieldInfo {
+			continue
+		}
+		opts := make([]AdminRequestSchemaFieldOption, 0, len(f.Options))
+		for _, o := range f.Options {
+			opts = append(opts, AdminRequestSchemaFieldOption{Label: o.Label, Value: o.Value})
+		}
+		schemaFields = append(schemaFields, AdminRequestSchemaField{
+			Key:            f.Key,
+			Label:          f.Label,
+			Type:           string(f.Type),
+			AppliesToChild: f.AppliesToCh,
+			Target:         f.Target,
+			Options:        opts,
+		})
+	}
+	schemaLegalBlocks := make([]AdminRequestSchemaLegalBlock, 0, len(fs.LegalBlocks))
+	for _, b := range fs.LegalBlocks {
+		schemaLegalBlocks = append(schemaLegalBlocks, AdminRequestSchemaLegalBlock{
+			Key:   b.Key,
+			Title: b.Title,
+		})
+	}
+	return schemaFields, schemaLegalBlocks
 }
 
 // AdminDecideRequest is the body of POST .../children/{childId}/decide.

--- a/backend/api/enrollment/admin_decision_handlers_test.go
+++ b/backend/api/enrollment/admin_decision_handlers_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	baseModel "github.com/moto-nrw/project-phoenix/models/base"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
@@ -124,6 +126,19 @@ func buildAdminDecisionRouter(svc enrollmentService.DecisionService) chi.Router 
 	return r
 }
 
+func buildProtectedAdminDecisionRouter(svc enrollmentService.DecisionService) chi.Router {
+	rs := &Resource{
+		DecisionService: svc,
+		// db nil → runInTenantTx short-circuits straight to the closure.
+	}
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	r.With(authorize.RequiresPermission("config:read")).Get("/enrollment/admin/requests", rs.listAdminRequests)
+	r.With(authorize.RequiresPermission("config:manage")).Get("/enrollment/admin/requests/{id}", rs.getAdminRequest)
+	r.With(authorize.RequiresPermission("config:manage")).Get("/enrollment/admin/students/{studentId}/requests", rs.listAdminRequestsByStudent)
+	return r
+}
+
 func executeAdminJSON(t *testing.T, router chi.Router, method, path string, body any) *httptest.ResponseRecorder {
 	t.Helper()
 	var req *http.Request
@@ -135,6 +150,15 @@ func executeAdminJSON(t *testing.T, router chi.Router, method, path string, body
 	} else {
 		req = httptest.NewRequest(method, path, nil)
 	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func executeAdminJSONWithPermissions(t *testing.T, router chi.Router, method, path string, permissions []string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	req = req.WithContext(context.WithValue(req.Context(), jwt.CtxPermissions, permissions))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	return w
@@ -189,6 +213,34 @@ func TestListAdminRequestsHandler_HappyPathReturns200(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"id":"1234"`,
 		"int64 ID must be stringified per CLAUDE rule 4")
 	assert.Contains(t, w.Body.String(), `"phase_name":"Schuljahr 2026"`)
+}
+
+func TestAdminRequestRoutes_DetailRequiresConfigManage(t *testing.T) {
+	mock := &mockDecisionService{
+		listResult: []*enrollmentService.RequestSummary{
+			makeReqSummary(1234, 5678, makeChildSummary(99, "Lina", "Kind", enrollmentModels.ChildStatusSubmitted)),
+		},
+		getResult: makeReqSummary(1234, 5678, makeChildSummary(99, "Lina", "Kind", enrollmentModels.ChildStatusSubmitted)),
+		listStudentResult: []*enrollmentService.RequestSummary{
+			makeReqSummary(1234, 5678, makeChildSummary(99, "Lina", "Kind", enrollmentModels.ChildStatusSubmitted)),
+		},
+	}
+	router := buildProtectedAdminDecisionRouter(mock)
+
+	listReadOnly := executeAdminJSONWithPermissions(t, router, http.MethodGet, "/enrollment/admin/requests", []string{"config:read"})
+	assert.Equal(t, http.StatusOK, listReadOnly.Code)
+
+	requestDetailReadOnly := executeAdminJSONWithPermissions(t, router, http.MethodGet, "/enrollment/admin/requests/1234", []string{"config:read"})
+	assert.Equal(t, http.StatusForbidden, requestDetailReadOnly.Code)
+
+	studentDetailReadOnly := executeAdminJSONWithPermissions(t, router, http.MethodGet, "/enrollment/admin/students/777/requests", []string{"config:read"})
+	assert.Equal(t, http.StatusForbidden, studentDetailReadOnly.Code)
+
+	requestDetailManage := executeAdminJSONWithPermissions(t, router, http.MethodGet, "/enrollment/admin/requests/1234", []string{"config:manage"})
+	assert.Equal(t, http.StatusOK, requestDetailManage.Code)
+
+	studentDetailManage := executeAdminJSONWithPermissions(t, router, http.MethodGet, "/enrollment/admin/students/777/requests", []string{"config:manage"})
+	assert.Equal(t, http.StatusOK, studentDetailManage.Code)
 }
 
 func TestListAdminRequestsHandler_PhaseFilterParsed(t *testing.T) {

--- a/backend/api/enrollment/admin_decision_handlers_test.go
+++ b/backend/api/enrollment/admin_decision_handlers_test.go
@@ -28,13 +28,16 @@ import (
 // for when the second consumer shows up.
 type mockDecisionService struct {
 	// List
-	listFilters  enrollmentService.RequestFilters
-	listResult   []*enrollmentService.RequestSummary
-	listErr      error
-	listCalls    int
-	getRequestID int64
-	getResult    *enrollmentService.RequestSummary
-	getErr       error
+	listFilters       enrollmentService.RequestFilters
+	listResult        []*enrollmentService.RequestSummary
+	listErr           error
+	listCalls         int
+	listStudentID     int64
+	listStudentResult []*enrollmentService.RequestSummary
+	listStudentErr    error
+	getRequestID      int64
+	getResult         *enrollmentService.RequestSummary
+	getErr            error
 
 	listChildOffResult map[int64][]enrollmentService.ChildOfferingRow
 	listChildOffErr    error
@@ -46,20 +49,28 @@ type mockDecisionService struct {
 	// ExportPhase: records the args the handler forwards (so a handler
 	// test can assert the format + actor were threaded through) and
 	// replays a canned payload/error.
-	exportPhaseID     int64
-	exportActorID     int64
-	exportActorRole   string
-	exportFormat      string
-	exportChildStatus string
-	exportCalls       int
-	exportResult      *enrollmentService.PhaseExport
-	exportErr         error
+	exportPhaseID       int64
+	exportActorID       int64
+	exportActorRole     string
+	exportFormat        string
+	exportChildStatus   string
+	exportCalls         int
+	exportResult        *enrollmentService.PhaseExport
+	exportErr           error
+	exportStudentID     int64
+	exportStudentResult *enrollmentService.StudentEnrollmentExport
+	exportStudentErr    error
 }
 
 func (m *mockDecisionService) List(_ context.Context, f enrollmentService.RequestFilters) ([]*enrollmentService.RequestSummary, error) {
 	m.listFilters = f
 	m.listCalls++
 	return m.listResult, m.listErr
+}
+
+func (m *mockDecisionService) ListByStudent(_ context.Context, studentID int64) ([]*enrollmentService.RequestSummary, error) {
+	m.listStudentID = studentID
+	return m.listStudentResult, m.listStudentErr
 }
 
 func (m *mockDecisionService) Get(_ context.Context, id int64) (*enrollmentService.RequestSummary, error) {
@@ -86,6 +97,14 @@ func (m *mockDecisionService) ExportPhase(_ context.Context, phaseID, actorAccou
 	return m.exportResult, m.exportErr
 }
 
+func (m *mockDecisionService) ExportStudent(_ context.Context, studentID, actorAccountID int64, actorRole, format string) (*enrollmentService.StudentEnrollmentExport, error) {
+	m.exportStudentID = studentID
+	m.exportActorID = actorAccountID
+	m.exportActorRole = actorRole
+	m.exportFormat = format
+	return m.exportStudentResult, m.exportStudentErr
+}
+
 func (m *mockDecisionService) RecordPhaseExportAudit(_ context.Context, _ int64, _ string, _ *enrollmentModels.Phase, _, _ string, _, _ int) error {
 	return nil
 }
@@ -99,6 +118,8 @@ func buildAdminDecisionRouter(svc enrollmentService.DecisionService) chi.Router 
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 	r.Get("/enrollment/admin/requests", rs.listAdminRequests)
 	r.Get("/enrollment/admin/requests/{id}", rs.getAdminRequest)
+	r.Get("/enrollment/admin/students/{studentId}/requests", rs.listAdminRequestsByStudent)
+	r.Post("/enrollment/admin/students/{studentId}/requests/export", rs.exportStudentEnrollmentRequests)
 	r.Post("/enrollment/admin/requests/{id}/children/{childId}/decide", rs.decideAdminChild)
 	return r
 }

--- a/backend/api/enrollment/api.go
+++ b/backend/api/enrollment/api.go
@@ -168,18 +168,19 @@ func (rs *Resource) Router() chi.Router {
 		// the frontend can still cleanly render the form.
 		r.Get("/me/profile", rs.getMyProfile)
 
-		// PR 8 admin review surface. config:read for browse,
-		// config:manage to apply decisions. Decision writes audit
+		// PR 8 admin review surface. config:read for queue browse;
+		// config:manage for detail, export and decisions because those
+		// expose or mutate full enrollment PII. Decision writes audit
 		// reviewed_by/reviewed_at on each child row.
 		r.Route("/admin/requests", func(r chi.Router) {
 			r.With(authorize.RequiresPermission("config:read")).Get("/", rs.listAdminRequests)
 			r.Route("/{id}", func(r chi.Router) {
-				r.With(authorize.RequiresPermission("config:read")).Get("/", rs.getAdminRequest)
+				r.With(authorize.RequiresPermission("config:manage")).Get("/", rs.getAdminRequest)
 				r.With(authorize.RequiresPermission("config:manage")).Post("/children/{childId}/decide", rs.decideAdminChild)
 			})
 		})
 		r.Route("/admin/students/{studentId}/requests", func(r chi.Router) {
-			r.With(authorize.RequiresPermission("config:read")).Get("/", rs.listAdminRequestsByStudent)
+			r.With(authorize.RequiresPermission("config:manage")).Get("/", rs.listAdminRequestsByStudent)
 			r.With(authorize.RequiresPermission("config:manage")).Post("/export", rs.exportStudentEnrollmentRequests)
 		})
 	})

--- a/backend/api/enrollment/api.go
+++ b/backend/api/enrollment/api.go
@@ -178,6 +178,10 @@ func (rs *Resource) Router() chi.Router {
 				r.With(authorize.RequiresPermission("config:manage")).Post("/children/{childId}/decide", rs.decideAdminChild)
 			})
 		})
+		r.Route("/admin/students/{studentId}/requests", func(r chi.Router) {
+			r.With(authorize.RequiresPermission("config:read")).Get("/", rs.listAdminRequestsByStudent)
+			r.With(authorize.RequiresPermission("config:manage")).Post("/export", rs.exportStudentEnrollmentRequests)
+		})
 	})
 
 	return r

--- a/backend/api/enrollment/export_handlers.go
+++ b/backend/api/enrollment/export_handlers.go
@@ -183,6 +183,217 @@ func buildPhaseExportFile(svc listexport.Service, data *enrollmentService.PhaseE
 	}
 }
 
+func (rs *Resource) exportStudentEnrollmentRequests(w http.ResponseWriter, r *http.Request) {
+	if rs.ListExportService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("list export service not configured")))
+		return
+	}
+	if rs.DecisionService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("decision service not configured")))
+		return
+	}
+	studentID, err := strconv.ParseInt(chi.URLParam(r, "studentId"), 10, 64)
+	if err != nil || studentID <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid student id")))
+		return
+	}
+	format, _, err := parsePhaseExportRequest(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	claims := jwt.ClaimsFromCtx(r.Context())
+	actorAccountID := int64(claims.ID)
+	actorRole := strings.Join(claims.Roles, ",")
+
+	var data *enrollmentService.StudentEnrollmentExport
+	err = rs.runInTenantTx(r, func(ctx context.Context) error {
+		d, e := rs.DecisionService.ExportStudent(ctx, studentID, actorAccountID, actorRole, string(format))
+		if e != nil {
+			return e
+		}
+		data = d
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, enrollmentService.ErrExportTooLarge) {
+			common.RenderError(w, r, common.ErrorInvalidRequest(enrollmentService.ErrExportTooLarge))
+			return
+		}
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	file, err := buildStudentEnrollmentExportFile(rs.ListExportService, data, format)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	w.Header().Set("Content-Type", file.ContentType)
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, file.Filename))
+	w.Header().Set("Content-Length", strconv.Itoa(len(file.Data)))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(file.Data)
+}
+
+func buildStudentEnrollmentExportFile(svc listexport.Service, data *enrollmentService.StudentEnrollmentExport, format listexport.Format) (listexport.File, error) {
+	heading := studentEnrollmentExportHeading(data)
+	filename := heading
+	switch format {
+	case listexport.FormatDOCX:
+		return svc.RenderRecordsDOCX(buildStudentEnrollmentExportRecords(data, heading), filename)
+	case listexport.FormatXLSX:
+		return svc.Render(buildStudentEnrollmentExportTable(data, heading), listexport.FormatXLSX, filename)
+	case listexport.FormatPDF:
+		return svc.RenderRecords(buildStudentEnrollmentExportRecords(data, heading), filename)
+	default:
+		return listexport.File{}, fmt.Errorf("unsupported export format %q", format)
+	}
+}
+
+func studentEnrollmentExportHeading(data *enrollmentService.StudentEnrollmentExport) string {
+	if name := studentEnrollmentExportChildName(data); name != "" {
+		return "Anmeldungen " + name
+	}
+	return "Anmeldungen"
+}
+
+func studentEnrollmentExportChildName(data *enrollmentService.StudentEnrollmentExport) string {
+	if data == nil {
+		return ""
+	}
+	for _, row := range data.Rows {
+		for _, child := range row.Children {
+			if child.Child != nil {
+				return childFullName(child.Child)
+			}
+		}
+	}
+	return ""
+}
+
+func studentEnrollmentExportSubtitle(data *enrollmentService.StudentEnrollmentExport) string {
+	requests, children := data.Counts()
+	if requests == 1 {
+		return fmt.Sprintf("%d Anmeldung, %d Kind", requests, children)
+	}
+	return fmt.Sprintf("%d Anmeldungen, %d Kinder", requests, children)
+}
+
+func buildStudentEnrollmentExportRecords(data *enrollmentService.StudentEnrollmentExport, title string) listexport.RecordDocument {
+	guardianCustoms, childCustoms := collectCustomFields(data.Schemas)
+	records := make([]listexport.Record, 0, len(data.Rows))
+	for _, row := range data.Rows {
+		for _, child := range row.Children {
+			records = append(records, studentEnrollmentRecord(row.Request, data.Phases[row.Request.PhaseID], child, guardianCustoms, childCustoms))
+		}
+	}
+	return listexport.RecordDocument{
+		Title:       title,
+		Subtitle:    studentEnrollmentExportSubtitle(data),
+		GeneratedAt: time.Now(),
+		Footer:      exportConfidentialityNote,
+		Records:     records,
+	}
+}
+
+func studentEnrollmentRecord(req *enrollmentModels.Request, phase *enrollmentModels.Phase, ch enrollmentService.ExportChildRow, guardianCustoms, childCustoms []enrollmentModels.FormField) listexport.Record {
+	rec := listexport.Record{
+		Title:  childFullName(ch.Child),
+		Fields: childFields(ch, childCustoms),
+	}
+	rec.Fields = append(rec.Fields,
+		listexport.Field{Label: "Anmeldung", Value: phaseNameForExport(phase)},
+		listexport.Field{Label: "Eingereicht am", Value: req.SubmittedAt.Format("02.01.2006 15:04")},
+	)
+	if req.WithdrawnAt != nil {
+		rec.Fields = append(rec.Fields, listexport.Field{Label: "Zurückgezogen am", Value: timeOrEmpty(req.WithdrawnAt)})
+	}
+	rec.Fields = append(rec.Fields, listexport.Field{Label: "Zustimmungen", Value: consentSummary(req.ConsentFlags)})
+	for _, cf := range guardianCustoms {
+		if v, ok := req.CustomData[cf.Key]; ok {
+			rec.Fields = append(rec.Fields, listexport.Field{Label: cf.Label, Value: formatCustomValue(cf, v)})
+		}
+	}
+	return rec
+}
+
+func phaseNameForExport(phase *enrollmentModels.Phase) string {
+	if phase == nil || strings.TrimSpace(phase.Name) == "" {
+		return "Nicht zugeordnet"
+	}
+	return strings.TrimSpace(phase.Name)
+}
+
+func buildStudentEnrollmentExportTable(data *enrollmentService.StudentEnrollmentExport, title string) listexport.Document {
+	guardianCustoms, childCustoms := collectCustomFields(data.Schemas)
+	cols := []listexport.Column{
+		{ID: "phase", Label: "Anmeldung"},
+		{ID: "submitted_at", Label: "Eingereicht am"},
+		{ID: "child_last_name", Label: "Kind Nachname"},
+		{ID: "child_first_name", Label: "Kind Vorname"},
+		{ID: "child_dob", Label: "Geburtsdatum"},
+		{ID: "child_grade", Label: "Zielklasse"},
+		{ID: "child_status", Label: "Status"},
+		{ID: "child_status_reason", Label: "Status-Grund"},
+		{ID: "child_activation", Label: "Aktivierung"},
+		{ID: "child_offerings", Label: "Betreuungsangebote"},
+	}
+	for _, cf := range childCustoms {
+		cols = append(cols, listexport.Column{ID: listexport.ColumnID("custom_c_" + cf.Key), Label: cf.Label})
+	}
+	for _, cf := range guardianCustoms {
+		cols = append(cols, listexport.Column{ID: listexport.ColumnID("custom_g_" + cf.Key), Label: cf.Label})
+	}
+	cols = append(cols,
+		listexport.Column{ID: "consent_agb", Label: "Zustimmung AGB"},
+		listexport.Column{ID: "consent_data_processing", Label: "Zustimmung Datenverarbeitung"},
+		listexport.Column{ID: "consent_email_contact", Label: "Zustimmung E-Mail-Kontakt"},
+		listexport.Column{ID: "consent_photo", Label: "Zustimmung Foto"},
+	)
+
+	rows := make([]listexport.Row, 0, len(data.Rows))
+	for _, row := range data.Rows {
+		for _, child := range row.Children {
+			rows = append(rows, listexport.Row{
+				Values: studentEnrollmentRowValues(row.Request, data.Phases[row.Request.PhaseID], child, guardianCustoms, childCustoms),
+			})
+		}
+	}
+
+	return listexport.Document{
+		Title:       title,
+		Subtitle:    studentEnrollmentExportSubtitle(data),
+		GeneratedAt: time.Now(),
+		Columns:     cols,
+		Rows:        rows,
+		Footer:      exportConfidentialityNote,
+	}
+}
+
+func studentEnrollmentRowValues(req *enrollmentModels.Request, phase *enrollmentModels.Phase, ch enrollmentService.ExportChildRow, guardianCustoms, childCustoms []enrollmentModels.FormField) map[listexport.ColumnID]string {
+	values := map[listexport.ColumnID]string{
+		"phase":                   phaseNameForExport(phase),
+		"submitted_at":            req.SubmittedAt.Format("02.01.2006 15:04"),
+		"consent_agb":             consentLabel(req.ConsentFlags, enrollmentModels.ConsentKeyAGB),
+		"consent_data_processing": consentLabel(req.ConsentFlags, enrollmentModels.ConsentKeyDataProcessing),
+		"consent_email_contact":   consentLabel(req.ConsentFlags, enrollmentModels.ConsentKeyEmailContact),
+		"consent_photo":           consentLabel(req.ConsentFlags, enrollmentModels.ConsentKeyPhoto),
+	}
+	if req.WithdrawnAt != nil {
+		values["withdrawn_at"] = timeOrEmpty(req.WithdrawnAt)
+	}
+	for _, cf := range guardianCustoms {
+		if v, ok := req.CustomData[cf.Key]; ok {
+			values[listexport.ColumnID("custom_g_"+cf.Key)] = formatCustomValue(cf, v)
+		}
+	}
+	childValues := childRowValues(values, ch, childCustoms)
+	return childValues
+}
+
 // enrollmentExportFilterLabels turns the applied child-status filter into
 // the header label list (e.g. "Status: Angenommen"), mirroring the
 // students export's Document.Filters convention. Empty filter → no label.

--- a/backend/api/enrollment/export_handlers.go
+++ b/backend/api/enrollment/export_handlers.go
@@ -217,6 +217,10 @@ func (rs *Resource) exportStudentEnrollmentRequests(w http.ResponseWriter, r *ht
 		return nil
 	})
 	if err != nil {
+		if errors.Is(err, enrollmentService.ErrDecisionStudentNotFound) {
+			common.RenderError(w, r, common.ErrorNotFound(err))
+			return
+		}
 		if errors.Is(err, enrollmentService.ErrExportTooLarge) {
 			common.RenderError(w, r, common.ErrorInvalidRequest(enrollmentService.ErrExportTooLarge))
 			return
@@ -332,6 +336,7 @@ func buildStudentEnrollmentExportTable(data *enrollmentService.StudentEnrollment
 	cols := []listexport.Column{
 		{ID: "phase", Label: "Anmeldung"},
 		{ID: "submitted_at", Label: "Eingereicht am"},
+		{ID: "withdrawn_at", Label: "Zurückgezogen am"},
 		{ID: "child_last_name", Label: "Kind Nachname"},
 		{ID: "child_first_name", Label: "Kind Vorname"},
 		{ID: "child_dob", Label: "Geburtsdatum"},

--- a/backend/api/enrollment/export_handlers.go
+++ b/backend/api/enrollment/export_handlers.go
@@ -30,9 +30,9 @@ type phaseExportRequest struct {
 	ChildStatus string            `json:"child_status"`
 }
 
-// exportConfidentialityNote is stamped on printed phase exports because
-// the files contain full guardian and child PII.
-const exportConfidentialityNote = "Vertraulich, nur für berechtigte Personen. Nach Gebrauch sicher vernichten."
+// exportConfidentialityNote is stamped on enrollment exports because the
+// files contain child data and, for phase exports, guardian contact data.
+const exportConfidentialityNote = "Enthält personenbezogene Daten. Bitte nur intern verwenden."
 
 // exportPhaseRegistrations streams a compact export of every
 // registration in the phase. config:manage gated because one call bundles

--- a/backend/api/enrollment/export_handlers_test.go
+++ b/backend/api/enrollment/export_handlers_test.go
@@ -260,7 +260,7 @@ func TestBuildPhaseExportRecords_ChildIsPrimaryWithGuardianRepeated(t *testing.T
 	if len(rec.Subs) != 0 {
 		t.Errorf("subs = %d, want 0 (child blocks are flat, not nested)", len(rec.Subs))
 	}
-	if !strings.Contains(doc.Footer, "Vertraulich") {
+	if !strings.Contains(doc.Footer, "personenbezogene Daten") {
 		t.Errorf("footer = %q, want confidentiality handling note", doc.Footer)
 	}
 	if !strings.Contains(doc.Subtitle, "1 Anmeldungen") {

--- a/backend/api/enrollment/export_handlers_test.go
+++ b/backend/api/enrollment/export_handlers_test.go
@@ -124,6 +124,22 @@ func sampleExport() *enrollmentService.PhaseExport {
 	}
 }
 
+func sampleStudentEnrollmentExport() *enrollmentService.StudentEnrollmentExport {
+	data := sampleExport()
+	phase := data.Phase
+	phase.ID = 7801
+	data.Rows[0].Request.PhaseID = phase.ID
+	withdrawnAt := time.Date(2026, 6, 2, 9, 30, 0, 0, time.UTC)
+	data.Rows[0].Request.WithdrawnAt = &withdrawnAt
+
+	return &enrollmentService.StudentEnrollmentExport{
+		StudentID: 8801,
+		Schemas:   data.Schemas,
+		Phases:    map[int64]*enrollmentModels.Phase{phase.ID: phase},
+		Rows:      data.Rows,
+	}
+}
+
 func columnLabels(doc listexport.Document) map[listexport.ColumnID]string {
 	out := make(map[listexport.ColumnID]string, len(doc.Columns))
 	for _, c := range doc.Columns {
@@ -181,6 +197,23 @@ func TestBuildPhaseExportTable_FullRow(t *testing.T) {
 	}
 	if !strings.Contains(v["child_offerings"], "Kernzeit") {
 		t.Errorf("child_offerings = %q, want it to contain Kernzeit", v["child_offerings"])
+	}
+}
+
+func TestBuildStudentEnrollmentExportTable_IncludesWithdrawnAt(t *testing.T) {
+	doc := buildStudentEnrollmentExportTable(sampleStudentEnrollmentExport(), "Anmeldungen Kind")
+
+	labels := columnLabels(doc)
+	if labels["withdrawn_at"] != "Zurückgezogen am" {
+		t.Fatalf("withdrawn_at column label = %q, want Zurückgezogen am", labels["withdrawn_at"])
+	}
+
+	rows := tableDataRows(doc.Rows)
+	if len(rows) != 1 {
+		t.Fatalf("data rows = %d, want 1", len(rows))
+	}
+	if got := rows[0].Values["withdrawn_at"]; got != "02.06.2026 09:30" {
+		t.Errorf("withdrawn_at = %q, want 02.06.2026 09:30", got)
 	}
 }
 
@@ -647,6 +680,7 @@ func buildExportRouter(rs *Resource, claims jwt.AppClaims) chi.Router {
 		})
 	})
 	r.Post("/enrollment/phases/{id}/export", rs.exportPhaseRegistrations)
+	r.Post("/enrollment/admin/students/{studentId}/requests/export", rs.exportStudentEnrollmentRequests)
 	return r
 }
 
@@ -811,6 +845,26 @@ func TestExportPhaseRegistrations_ServiceErrorIs500(t *testing.T) {
 	// surface as 5xx so no file is served without a recorded disclosure.
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestExportStudentEnrollmentRequests_StudentNotFoundIs404(t *testing.T) {
+	mock := &mockDecisionService{exportStudentErr: enrollmentService.ErrDecisionStudentNotFound}
+	rs := &Resource{DecisionService: mock, ListExportService: listexport.NewService()}
+	router := buildExportRouter(rs, jwt.AppClaims{
+		ID:    exportTestActorID,
+		Roles: []string{"admin"},
+	})
+
+	req := httptest.NewRequest("POST", "/enrollment/admin/students/777/requests/export", strings.NewReader(`{"format":"pdf"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (body: %s)", w.Code, w.Body.String())
+	}
+	if mock.exportStudentID != 777 {
+		t.Errorf("student id = %d, want 777", mock.exportStudentID)
 	}
 }
 

--- a/backend/database/repositories/enrollment/request_repository.go
+++ b/backend/database/repositories/enrollment/request_repository.go
@@ -68,6 +68,9 @@ func (r *RequestRepository) ListAdmin(ctx context.Context, filters enrollment.Re
 	if filters.ChildStatus != "" {
 		q = q.Where(`EXISTS (SELECT 1 FROM enrollment.request_children rc WHERE rc.request_id = "request".id AND rc.status = ?)`, filters.ChildStatus)
 	}
+	if filters.CreatedStudentID > 0 {
+		q = q.Where(`EXISTS (SELECT 1 FROM enrollment.request_children rc WHERE rc.request_id = "request".id AND rc.created_student_id = ?)`, filters.CreatedStudentID)
+	}
 	q = q.OrderExpr(`"request".submitted_at DESC, "request".id DESC`)
 
 	if err := q.Scan(ctx); err != nil {

--- a/backend/models/audit/data_access_log.go
+++ b/backend/models/audit/data_access_log.go
@@ -15,6 +15,9 @@ const (
 	// the temporal span of the disclosed data — and metadata carries
 	// phase_id, format, request_count and child_count.
 	ResourceTypeEnrollmentPhaseExport = "enrollment_phase_export"
+	// ResourceTypeEnrollmentStudentExport records an export of enrollment
+	// answers attached to one student profile.
+	ResourceTypeEnrollmentStudentExport = "enrollment_student_export"
 )
 
 // DataAccessLog is an append-only record of a staff member viewing sensitive

--- a/backend/models/enrollment/request.go
+++ b/backend/models/enrollment/request.go
@@ -68,8 +68,9 @@ const (
 // carries the given status - handy for "show me everything still
 // awaiting a decision".
 type RequestListFilters struct {
-	PhaseID     int64
-	ChildStatus string
+	PhaseID          int64
+	ChildStatus      string
+	CreatedStudentID int64
 }
 
 // DuplicateChildKey identifies one (first_name, last_name) pair the

--- a/backend/services/enrollment/decision_export_integration_test.go
+++ b/backend/services/enrollment/decision_export_integration_test.go
@@ -37,6 +37,7 @@ func newExportDecisionService(env *decisionTestEnv, auditRepo auditModels.DataAc
 		PhaseRepo:                env.repos.Phase,
 		FormSchemaRepo:           env.repos.FormSchema,
 		DataAccessLogRepo:        auditRepo,
+		StudentRepo:              env.repos.Student,
 		Logger:                   slog.Default(),
 	})
 }
@@ -52,6 +53,14 @@ func (failingSchemaRepo) FindByID(_ context.Context, _ int64) (*enrollmentModels
 	return nil, errors.New("schema read failed")
 }
 
+type failingPhaseRepo struct {
+	enrollmentModels.PhaseRepository
+}
+
+func (failingPhaseRepo) FindByID(_ context.Context, _ int64) (*enrollmentModels.Phase, error) {
+	return nil, errors.New("phase read failed")
+}
+
 // newExportDecisionServiceFailingSchema mirrors newExportDecisionService
 // but swaps in a FormSchema repo whose FindByID always errors, so a test
 // can prove the export fails closed when a pinned schema cannot be loaded.
@@ -64,8 +73,38 @@ func newExportDecisionServiceFailingSchema(env *decisionTestEnv, auditRepo audit
 		PhaseRepo:                env.repos.Phase,
 		FormSchemaRepo:           failingSchemaRepo{env.repos.FormSchema},
 		DataAccessLogRepo:        auditRepo,
+		StudentRepo:              env.repos.Student,
 		Logger:                   slog.Default(),
 	})
+}
+
+func newExportDecisionServiceFailingPhase(env *decisionTestEnv, auditRepo auditModels.DataAccessLogRepository) enrollmentService.DecisionService {
+	return enrollmentService.NewDecisionService(enrollmentService.DecisionServiceConfig{
+		RequestRepo:              env.repos.Request,
+		RequestChildRepo:         env.repos.RequestChild,
+		RequestChildOfferingRepo: env.repos.RequestChildOffering,
+		CareOfferingRepo:         env.repos.CareOffering,
+		PhaseRepo:                failingPhaseRepo{env.repos.Phase},
+		FormSchemaRepo:           env.repos.FormSchema,
+		DataAccessLogRepo:        auditRepo,
+		StudentRepo:              env.repos.Student,
+		Logger:                   slog.Default(),
+	})
+}
+
+func approveOneChildForExport(t *testing.T, env *decisionTestEnv, email, firstName, lastName string) int64 {
+	t.Helper()
+	ctx := testpkg.TenantContext(1)
+	reqID, childID := submitOneChild(t, env, email, firstName, lastName)
+	outcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
+		RequestID:  reqID,
+		ChildID:    childID,
+		Status:     enrollmentService.DecisionApproved,
+		ReviewedBy: env.creatorID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Child.CreatedStudentID)
+	return *outcome.Child.CreatedStudentID
 }
 
 // A pinned schema that cannot be loaded must fail the whole export, not
@@ -190,4 +229,79 @@ func TestDecisionService_ExportPhase_ChildStatusFilter(t *testing.T) {
 	rReq, rChild := rejected.Counts()
 	assert.Equal(t, 0, rReq, "no request has a rejected child")
 	assert.Equal(t, 0, rChild)
+}
+
+func TestDecisionService_ExportStudent_LoadsDataAndRecordsAudit(t *testing.T) {
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	studentID := approveOneChildForExport(t, env, "student-export@example.com", "Sina", "Export")
+	audit := &stubAccessLogRepo{}
+
+	data, err := newExportDecisionService(env, audit).
+		ExportStudent(ctx, studentID, 4242, "admin", "xlsx")
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	assert.Equal(t, studentID, data.StudentID)
+	require.Len(t, data.Rows, 1)
+	require.Len(t, data.Rows[0].Children, 1)
+	assert.Equal(t, "Sina", data.Rows[0].Children[0].Child.FirstName)
+
+	require.Len(t, audit.entries, 1)
+	entry := audit.entries[0]
+	assert.Equal(t, auditModels.ResourceTypeEnrollmentStudentExport, entry.ResourceType)
+	require.NotNil(t, entry.StudentID)
+	assert.Equal(t, studentID, *entry.StudentID)
+	md := entry.GetMetadata()
+	assert.Equal(t, "xlsx", md["format"])
+	assert.Equal(t, 1, md["request_count"])
+	assert.Equal(t, 1, md["child_count"])
+}
+
+func TestDecisionService_ExportStudent_MissingStudentBlocksAudit(t *testing.T) {
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+	audit := &stubAccessLogRepo{}
+
+	data, err := newExportDecisionService(env, audit).
+		ExportStudent(ctx, 99_999_999, 4242, "admin", "pdf")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, enrollmentService.ErrDecisionStudentNotFound))
+	assert.Nil(t, data)
+	assert.Empty(t, audit.entries)
+}
+
+func TestDecisionService_ExportStudent_ForeignTenantStudentBlocksAudit(t *testing.T) {
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	const foreignTenantID = int64(9902)
+	testpkg.EnsureTestTenant(t, env.db, foreignTenantID)
+	defer testpkg.CleanupTenantTestData(t, env.db, foreignTenantID)
+
+	foreign := testpkg.CreateTestStudentForTenant(t, env.db, foreignTenantID, "Foreign", "Student", "1a")
+	audit := &stubAccessLogRepo{}
+
+	data, err := newExportDecisionService(env, audit).
+		ExportStudent(testpkg.TenantContext(1), foreign.ID, 4242, "admin", "pdf")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, enrollmentService.ErrDecisionStudentNotFound))
+	assert.Nil(t, data)
+	assert.Empty(t, audit.entries)
+}
+
+func TestDecisionService_ExportStudent_PhaseLoadFailureBlocksDisclosure(t *testing.T) {
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	studentID := approveOneChildForExport(t, env, "student-phasefail@example.com", "Paula", "PhaseFail")
+	audit := &stubAccessLogRepo{}
+
+	data, err := newExportDecisionServiceFailingPhase(env, audit).
+		ExportStudent(ctx, studentID, 4242, "admin", "pdf")
+	require.Error(t, err)
+	assert.Nil(t, data)
+	assert.Empty(t, audit.entries)
 }

--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -2,6 +2,7 @@ package enrollment
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,6 +34,7 @@ const guardianRoleName = "guardian"
 var (
 	ErrDecisionRequestNotFound = errors.New("enrollment request not found")
 	ErrDecisionChildNotFound   = errors.New("request child not found")
+	ErrDecisionStudentNotFound = errors.New("student not found")
 	ErrDecisionInvalidStatus   = errors.New("invalid decision status")
 	ErrDecisionAlreadyTerminal = errors.New("child is already in a terminal status")
 	// ErrDecisionInvalidData marks an approval that failed because the
@@ -680,6 +682,15 @@ func (s *decisionService) exportStudentData(ctx context.Context, studentID int64
 	if studentID <= 0 {
 		return nil, fmt.Errorf("decision: export student: student_id required")
 	}
+	if s.studentRepo == nil {
+		return nil, fmt.Errorf("decision: export student: student repo not configured")
+	}
+	if _, err := s.studentRepo.FindByID(ctx, studentID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("decision: export student load student %d: %w", studentID, ErrDecisionStudentNotFound)
+		}
+		return nil, fmt.Errorf("decision: export student load student %d: %w", studentID, err)
+	}
 
 	requests, err := s.requestRepo.ListAdmin(ctx, enrollmentModels.RequestListFilters{CreatedStudentID: studentID})
 	if err != nil {
@@ -747,11 +758,7 @@ func (s *decisionService) exportStudentData(ctx context.Context, studentID int64
 	for phaseID := range phaseIDs {
 		phase, err := s.phaseRepo.FindByID(ctx, phaseID)
 		if err != nil {
-			s.logger.Warn("decision: student export phase lookup failed",
-				slog.Int64("student_id", studentID),
-				slog.Int64("phase_id", phaseID),
-				slog.String("error", err.Error()))
-			continue
+			return nil, fmt.Errorf("decision: export student load phase %d: %w", phaseID, err)
 		}
 		phases[phaseID] = phase
 	}

--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -139,6 +139,7 @@ type RequestFilters struct {
 // post-commit.
 type DecisionService interface {
 	List(ctx context.Context, filters RequestFilters) ([]*RequestSummary, error)
+	ListByStudent(ctx context.Context, studentID int64) ([]*RequestSummary, error)
 	Get(ctx context.Context, requestID int64) (*RequestSummary, error)
 	Decide(ctx context.Context, input DecideInput) (*DecideOutcome, error)
 
@@ -163,6 +164,7 @@ type DecisionService interface {
 	// mirroring the admin list's per-child status dropdown. Empty means
 	// "all". The audit row's counts reflect the filtered (disclosed) set.
 	ExportPhase(ctx context.Context, phaseID, actorAccountID int64, actorRole, format, childStatusFilter string) (*PhaseExport, error)
+	ExportStudent(ctx context.Context, studentID, actorAccountID int64, actorRole, format string) (*StudentEnrollmentExport, error)
 
 	// RecordPhaseExportAudit appends one append-only row to
 	// audit.data_access_log recording that an admin exported the full
@@ -191,6 +193,23 @@ type PhaseExport struct {
 // of truth for both the audit row's metadata (ExportPhase) and the
 // rendered document subtitle (the export handler).
 func (e *PhaseExport) Counts() (requests, children int) {
+	for _, row := range e.Rows {
+		children += len(row.Children)
+	}
+	return len(e.Rows), children
+}
+
+// StudentEnrollmentExport is the fully-assembled payload for exports from
+// one student's kartei tab. Rows contain only the matching request_child row,
+// even when the original parent submission included siblings.
+type StudentEnrollmentExport struct {
+	StudentID int64
+	Schemas   map[int64]*enrollmentModels.FormSchema
+	Phases    map[int64]*enrollmentModels.Phase
+	Rows      []ExportRequestRow
+}
+
+func (e *StudentEnrollmentExport) Counts() (requests, children int) {
 	for _, row := range e.Rows {
 		children += len(row.Children)
 	}
@@ -349,8 +368,9 @@ func NewDecisionService(cfg DecisionServiceConfig) DecisionService {
 
 func (s *decisionService) List(ctx context.Context, filters RequestFilters) ([]*RequestSummary, error) {
 	requests, err := s.requestRepo.ListAdmin(ctx, enrollmentModels.RequestListFilters{
-		PhaseID:     filters.PhaseID,
-		ChildStatus: filters.ChildStatus,
+		PhaseID:          filters.PhaseID,
+		ChildStatus:      filters.ChildStatus,
+		CreatedStudentID: 0,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("decision: list requests: %w", err)
@@ -365,6 +385,44 @@ func (s *decisionService) List(ctx context.Context, filters RequestFilters) ([]*
 		out = append(out, summary)
 	}
 	return out, nil
+}
+
+func (s *decisionService) ListByStudent(ctx context.Context, studentID int64) ([]*RequestSummary, error) {
+	if studentID <= 0 {
+		return nil, fmt.Errorf("decision: student_id required")
+	}
+	requests, err := s.requestRepo.ListAdmin(ctx, enrollmentModels.RequestListFilters{
+		CreatedStudentID: studentID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("decision: list requests by student: %w", err)
+	}
+
+	out := make([]*RequestSummary, 0, len(requests))
+	for _, req := range requests {
+		summary, err := s.assemble(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		filterRequestSummaryChildren(summary, studentID)
+		if len(summary.Children) > 0 {
+			out = append(out, summary)
+		}
+	}
+	return out, nil
+}
+
+func filterRequestSummaryChildren(summary *RequestSummary, studentID int64) {
+	if summary == nil || studentID <= 0 {
+		return
+	}
+	children := summary.Children[:0]
+	for _, child := range summary.Children {
+		if child != nil && child.CreatedStudentID != nil && *child.CreatedStudentID == studentID {
+			children = append(children, child)
+		}
+	}
+	summary.Children = children
 }
 
 func (s *decisionService) Get(ctx context.Context, requestID int64) (*RequestSummary, error) {
@@ -450,6 +508,18 @@ func (s *decisionService) ExportPhase(ctx context.Context, phaseID, actorAccount
 	}
 	requestCount, childCount := data.Counts()
 	if err := s.RecordPhaseExportAudit(ctx, actorAccountID, actorRole, data.Phase, format, childStatusFilter, requestCount, childCount); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (s *decisionService) ExportStudent(ctx context.Context, studentID, actorAccountID int64, actorRole, format string) (*StudentEnrollmentExport, error) {
+	data, err := s.exportStudentData(ctx, studentID)
+	if err != nil {
+		return nil, err
+	}
+	requestCount, childCount := data.Counts()
+	if err := s.recordStudentExportAudit(ctx, actorAccountID, actorRole, data, format, requestCount, childCount); err != nil {
 		return nil, err
 	}
 	return data, nil
@@ -606,6 +676,127 @@ func (s *decisionService) exportData(ctx context.Context, phaseID int64, childSt
 	return &PhaseExport{Phase: phase, Schemas: schemas, Rows: rows}, nil
 }
 
+func (s *decisionService) exportStudentData(ctx context.Context, studentID int64) (*StudentEnrollmentExport, error) {
+	if studentID <= 0 {
+		return nil, fmt.Errorf("decision: export student: student_id required")
+	}
+
+	requests, err := s.requestRepo.ListAdmin(ctx, enrollmentModels.RequestListFilters{CreatedStudentID: studentID})
+	if err != nil {
+		return nil, fmt.Errorf("decision: export student list requests: %w", err)
+	}
+	if len(requests) > maxExportRequests {
+		return nil, fmt.Errorf("decision: export student %d has %d requests (max %d): %w",
+			studentID, len(requests), maxExportRequests, ErrExportTooLarge)
+	}
+
+	reqIDs := make([]int64, 0, len(requests))
+	phaseIDs := make(map[int64]struct{}, len(requests))
+	for _, req := range requests {
+		reqIDs = append(reqIDs, req.ID)
+		phaseIDs[req.PhaseID] = struct{}{}
+	}
+
+	children, err := s.requestChildRepo.ListByRequestIDs(ctx, reqIDs)
+	if err != nil {
+		return nil, fmt.Errorf("decision: export student load children: %w", err)
+	}
+	filteredChildren := make([]*enrollmentModels.RequestChild, 0, len(children))
+	childIDs := make([]int64, 0, len(children))
+	for _, child := range children {
+		if child.CreatedStudentID == nil || *child.CreatedStudentID != studentID {
+			continue
+		}
+		filteredChildren = append(filteredChildren, child)
+		childIDs = append(childIDs, child.ID)
+	}
+
+	links, err := s.requestChildOfferingRepo.ListByRequestChildIDs(ctx, childIDs)
+	if err != nil {
+		return nil, fmt.Errorf("decision: export student load offerings: %w", err)
+	}
+
+	offeringByID := make(map[int64]*enrollmentModels.CareOffering)
+	for phaseID := range phaseIDs {
+		offerings, err := s.careOfferingRepo.ListByPhase(ctx, phaseID)
+		if err != nil {
+			return nil, fmt.Errorf("decision: export student load care offerings: %w", err)
+		}
+		for _, off := range offerings {
+			offeringByID[off.ID] = off
+		}
+	}
+
+	offeringsByChild := make(map[int64][]ChildOfferingRow, len(childIDs))
+	for _, link := range links {
+		row := ChildOfferingRow{OfferingID: link.CareOfferingID, SelectedDays: link.SelectedDays}
+		if off := offeringByID[link.CareOfferingID]; off != nil {
+			row.OfferingName = off.Name
+			row.DaysOfWeekMode = off.DaysOfWeekMode
+			row.AvailableDays = off.AvailableDays
+		}
+		offeringsByChild[link.RequestChildID] = append(offeringsByChild[link.RequestChildID], row)
+	}
+
+	childrenByRequest := make(map[int64][]*enrollmentModels.RequestChild, len(reqIDs))
+	for _, child := range filteredChildren {
+		childrenByRequest[child.RequestID] = append(childrenByRequest[child.RequestID], child)
+	}
+
+	phases := make(map[int64]*enrollmentModels.Phase, len(phaseIDs))
+	for phaseID := range phaseIDs {
+		phase, err := s.phaseRepo.FindByID(ctx, phaseID)
+		if err != nil {
+			s.logger.Warn("decision: student export phase lookup failed",
+				slog.Int64("student_id", studentID),
+				slog.Int64("phase_id", phaseID),
+				slog.String("error", err.Error()))
+			continue
+		}
+		phases[phaseID] = phase
+	}
+
+	schemas := make(map[int64]*enrollmentModels.FormSchema)
+	for _, req := range requests {
+		if req.SchemaID == nil {
+			continue
+		}
+		if _, ok := schemas[*req.SchemaID]; ok {
+			continue
+		}
+		if s.formSchemaRepo == nil {
+			return nil, fmt.Errorf("decision: export student schema repo not configured")
+		}
+		schema, err := s.formSchemaRepo.FindByID(ctx, *req.SchemaID)
+		if err != nil {
+			return nil, fmt.Errorf("decision: export student load schema %d: %w", *req.SchemaID, err)
+		}
+		schemas[*req.SchemaID] = schema
+	}
+
+	rows := make([]ExportRequestRow, 0, len(requests))
+	for _, req := range requests {
+		childRows := make([]ExportChildRow, 0, len(childrenByRequest[req.ID]))
+		for _, child := range childrenByRequest[req.ID] {
+			childRows = append(childRows, ExportChildRow{
+				Child:     child,
+				Offerings: offeringsByChild[child.ID],
+			})
+		}
+		if len(childRows) == 0 {
+			continue
+		}
+		rows = append(rows, ExportRequestRow{Request: req, Children: childRows})
+	}
+
+	return &StudentEnrollmentExport{
+		StudentID: studentID,
+		Schemas:   schemas,
+		Phases:    phases,
+		Rows:      rows,
+	}, nil
+}
+
 // RecordPhaseExportAudit writes the GDPR access-log row for a phase
 // export. Synchronous and blocking: the caller refuses to serve the
 // file when this errors. The DataAccessLog repo populates tenant_id
@@ -648,6 +839,56 @@ func (s *decisionService) RecordPhaseExportAudit(ctx context.Context, actorAccou
 
 	if err := s.dataAccessLogRepo.Create(ctx, entry); err != nil {
 		return fmt.Errorf("decision: export audit write: %w", err)
+	}
+	return nil
+}
+
+func (s *decisionService) recordStudentExportAudit(ctx context.Context, actorAccountID int64, actorRole string, data *StudentEnrollmentExport, format string, requestCount, childCount int) error {
+	if s.dataAccessLogRepo == nil {
+		return fmt.Errorf("decision: student export audit: data access log repo not configured")
+	}
+	if data == nil || data.StudentID <= 0 {
+		return fmt.Errorf("decision: student export audit: student required")
+	}
+	if actorAccountID <= 0 {
+		return fmt.Errorf("decision: student export audit: actor account id required")
+	}
+	if strings.TrimSpace(actorRole) == "" {
+		actorRole = "unknown"
+	}
+
+	now := time.Now()
+	rangeStart := now
+	rangeEnd := now
+	for _, phase := range data.Phases {
+		if phase == nil {
+			continue
+		}
+		start := phase.ServiceStartDate.BerlinMidnight()
+		end := phase.ServiceEndDate.EndOfDay()
+		if rangeStart.Equal(now) || start.Before(rangeStart) {
+			rangeStart = start
+		}
+		if rangeEnd.Equal(now) || end.After(rangeEnd) {
+			rangeEnd = end
+		}
+	}
+
+	entry := &auditModels.DataAccessLog{
+		ActorAccountID: actorAccountID,
+		ActorRole:      actorRole,
+		ResourceType:   auditModels.ResourceTypeEnrollmentStudentExport,
+		StudentID:      &data.StudentID,
+		RangeStart:     rangeStart,
+		RangeEnd:       rangeEnd,
+		AccessedAt:     now,
+	}
+	entry.SetMetadata("format", format)
+	entry.SetMetadata("request_count", requestCount)
+	entry.SetMetadata("child_count", childCount)
+
+	if err := s.dataAccessLogRepo.Create(ctx, entry); err != nil {
+		return fmt.Errorf("decision: student export audit write: %w", err)
 	}
 	return nil
 }

--- a/backend/services/enrollment/rollover_service_test.go
+++ b/backend/services/enrollment/rollover_service_test.go
@@ -641,6 +641,10 @@ func (f *fakeApproveDecisionService) List(_ context.Context, _ enrollmentService
 	return nil, nil
 }
 
+func (f *fakeApproveDecisionService) ListByStudent(_ context.Context, _ int64) ([]*enrollmentService.RequestSummary, error) {
+	return nil, nil
+}
+
 func (f *fakeApproveDecisionService) Get(_ context.Context, _ int64) (*enrollmentService.RequestSummary, error) {
 	return nil, nil
 }
@@ -650,6 +654,10 @@ func (f *fakeApproveDecisionService) ListChildOfferings(_ context.Context, _ int
 }
 
 func (f *fakeApproveDecisionService) ExportPhase(_ context.Context, _, _ int64, _, _, _ string) (*enrollmentService.PhaseExport, error) {
+	return nil, nil
+}
+
+func (f *fakeApproveDecisionService) ExportStudent(_ context.Context, _, _ int64, _, _ string) (*enrollmentService.StudentEnrollmentExport, error) {
 	return nil, nil
 }
 

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import StudentsPage from "./page";
+import { useSession } from "next-auth/react";
 
 // Mock next-auth/react
 vi.mock("next-auth/react", () => ({
@@ -145,6 +146,7 @@ vi.mock("@/components/students/students-master-detail", () => ({
     onSelect,
     onUpdateStudent,
     detailActions,
+    canViewEnrollments,
   }: {
     students: Array<{
       id: string;
@@ -160,8 +162,12 @@ vi.mock("@/components/students/students-master-detail", () => ({
       data: { first_name: string; second_name: string },
     ) => Promise<void>;
     detailActions?: ReactNode;
+    canViewEnrollments?: boolean;
   }) => (
-    <div data-testid="students-master-detail">
+    <div
+      data-testid="students-master-detail"
+      data-can-view-enrollments={String(Boolean(canViewEnrollments))}
+    >
       {students.map((s) => (
         <div key={s.id} data-testid={`student-entry-${s.id}`}>
           <button
@@ -274,6 +280,16 @@ vi.mock("~/components/ui/modal", () => ({
 // Import mocked modules
 import { useSWRAuth } from "~/lib/swr";
 
+function mockSessionWithPermissions(permissions: string[]) {
+  vi.mocked(useSession).mockReturnValue({
+    data: {
+      user: { id: "1", token: "test-token", permissions },
+      expires: "2099-01-01",
+    },
+    status: "authenticated",
+  } as ReturnType<typeof useSession>);
+}
+
 const mockStudents = [
   {
     id: "1",
@@ -312,6 +328,7 @@ describe("StudentsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setSelectedStudent(null);
+    mockSessionWithPermissions(["config:manage"]);
 
     // Default SWR mock - returns students data
     vi.mocked(useSWRAuth).mockImplementation((key: string | null) => {
@@ -349,6 +366,32 @@ describe("StudentsPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Max Mustermann")).toBeInTheDocument();
       expect(screen.getByText("Anna Schmidt")).toBeInTheDocument();
+    });
+  });
+
+  it("does not expose enrollment tab access for config read-only users", async () => {
+    mockSessionWithPermissions(["config:read"]);
+
+    render(<StudentsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("students-master-detail")).toHaveAttribute(
+        "data-can-view-enrollments",
+        "false",
+      );
+    });
+  });
+
+  it("exposes enrollment tab access for config manage users", async () => {
+    mockSessionWithPermissions(["config:manage"]);
+
+    render(<StudentsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("students-master-detail")).toHaveAttribute(
+        "data-can-view-enrollments",
+        "true",
+      );
     });
   });
 

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -34,6 +34,7 @@ import type { Student } from "@/lib/api";
 import type { StudentGuardianPayload } from "@/lib/guardian-helpers";
 import { useSWRAuth, useTenantMutate } from "~/lib/swr";
 import { createLogger } from "~/lib/logger";
+import { hasPermission } from "~/lib/auth-utils";
 
 const logger = createLogger({ component: "DatabaseStudentsPage" });
 
@@ -81,7 +82,7 @@ export default function StudentsPage() {
 
   const { success: toastSuccess, error: toastError } = useToast();
 
-  const { status } = useSession({
+  const { data: session, status } = useSession({
     required: true,
     onUnauthenticated() {
       redirect("/");
@@ -364,6 +365,7 @@ export default function StudentsPage() {
   }, [filteredStudents]);
 
   const canShowDetail = !loading && filteredStudents.length > 0;
+  const canViewEnrollments = hasPermission(session, "config:read");
 
   const detailActions = selectedStudent ? (
     <button
@@ -445,6 +447,7 @@ export default function StudentsPage() {
             onArrivalDataChanged={handleArrivalChanged}
             groups={allGroups}
             onUpdateStudent={handleUpdateStudent}
+            canViewEnrollments={canViewEnrollments}
             detailActions={detailActions}
           />
         </div>

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -365,7 +365,7 @@ export default function StudentsPage() {
   }, [filteredStudents]);
 
   const canShowDetail = !loading && filteredStudents.length > 0;
-  const canViewEnrollments = hasPermission(session, "config:read");
+  const canViewEnrollments = hasPermission(session, "config:manage");
 
   const detailActions = selectedStudent ? (
     <button

--- a/frontend/src/app/api/enrollment/admin/students/[studentId]/requests/export/route.ts
+++ b/frontend/src/app/api/enrollment/admin/students/[studentId]/requests/export/route.ts
@@ -1,0 +1,77 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { auth, uncachedAuth } from "~/server/auth";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({
+  component: "EnrollmentStudentRequestsExportRoute",
+});
+
+interface RouteContext {
+  params: Promise<{ studentId: string }>;
+}
+
+async function proxyExport(studentId: string, body: string, token: string) {
+  const response = await fetch(
+    `${getServerApiUrl()}/api/enrollment/admin/students/${encodeURIComponent(
+      studentId,
+    )}/requests/export`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body,
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    return NextResponse.json(
+      { error: await response.text() },
+      { status: response.status },
+    );
+  }
+
+  const contentType =
+    response.headers.get("content-type") ?? "application/octet-stream";
+  const disposition = response.headers.get("content-disposition");
+  const data = await response.arrayBuffer();
+  const headers = new Headers({
+    "Content-Type": contentType,
+    "Content-Length": String(data.byteLength),
+  });
+  if (disposition) headers.set("Content-Disposition", disposition);
+  return new NextResponse(data, { status: 200, headers });
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const session = await auth();
+    if (!session?.user?.token) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { studentId } = await context.params;
+    const body = await request.text();
+    const response = await proxyExport(studentId, body, session.user.token);
+    if (response.status !== 401) return response;
+
+    const refreshed = await uncachedAuth();
+    if (
+      !refreshed?.user?.token ||
+      refreshed.user.token === session.user.token
+    ) {
+      return response;
+    }
+    return proxyExport(studentId, body, refreshed.user.token);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Export failed";
+    logger.error("student_enrollment_requests_export_failed", {
+      error: message,
+    });
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/enrollment/admin/students/[studentId]/requests/route.ts
+++ b/frontend/src/app/api/enrollment/admin/students/[studentId]/requests/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { auth } from "~/server/auth";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "EnrollmentStudentRequestsRoute" });
+
+interface RouteContext {
+  params: Promise<{ studentId: string }>;
+}
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const session = await auth();
+  const token = session?.user?.token;
+  if (!token) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+
+  const { studentId } = await context.params;
+  try {
+    const response = await fetch(
+      `${getServerApiUrl()}/api/enrollment/admin/students/${encodeURIComponent(
+        studentId,
+      )}/requests`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: "no-store",
+      },
+    );
+    const payload = await response.json().catch(() => ({}));
+    return NextResponse.json(payload, { status: response.status });
+  } catch (error) {
+    logger.error("student_enrollment_requests_get_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/src/components/enrollment/admin-enrollment-detail.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-detail.tsx
@@ -250,7 +250,7 @@ export function AdminEnrollmentDetail({ requestId }: Props) {
   );
 }
 
-function StatusBadge({ status }: Readonly<{ status: ChildStatus }>) {
+export function StatusBadge({ status }: Readonly<{ status: ChildStatus }>) {
   const styles = STATUS_COLORS[status];
   return (
     <span
@@ -640,14 +640,14 @@ function summarizeChildren(children: AdminRequestChild[]) {
   return { open, approved };
 }
 
-function formatDateTime(
+export function formatDateTime(
   value: string,
   options?: Intl.DateTimeFormatOptions,
 ): string {
   return new Date(value).toLocaleString("de-DE", options);
 }
 
-function formatPlainDate(value: string): string {
+export function formatPlainDate(value: string): string {
   return new Date(`${value}T00:00:00`).toLocaleDateString("de-DE", {
     day: "2-digit",
     month: "2-digit",
@@ -662,7 +662,7 @@ const CONSENT_LABELS: Record<string, string> = {
   photo: "Fotos bei Schulveranstaltungen",
 };
 
-function RequestExtraSection({
+export function RequestExtraSection({
   request,
 }: Readonly<{ request: AdminRequestSummary }>) {
   const guardianFields = (request.schema_fields ?? []).filter(
@@ -759,7 +759,7 @@ const DAY_LABEL_DE: Record<string, string> = {
   sun: "So",
 };
 
-function ChildOfferings({
+export function ChildOfferings({
   offerings,
 }: Readonly<{ offerings?: AdminRequestChildOffering[] }>) {
   if (!offerings || offerings.length === 0) return null;
@@ -800,7 +800,7 @@ function ChildOfferings({
   );
 }
 
-function ChildExtraFields({
+export function ChildExtraFields({
   child,
   schemaFields,
 }: Readonly<{

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -402,7 +402,7 @@ export const appChapters: readonly GuideChapter[] = [
         title: "Kinderdetailansicht",
         icon: FileText,
         summary:
-          "In der `Kindersuche` auf die Karte eines Kindes klicken öffnet seine Detailansicht. Der Kopfbereich zeigt Name, Gruppe und den aktuellen Aufenthalt mit Uhrzeit sowie die heutige Ankunft und Abholung; darunter liegen vier Tabs.",
+          "In der `Kindersuche` auf die Karte eines Kindes klicken öffnet seine Detailansicht. Der Kopfbereich zeigt Name, Gruppe und den aktuellen Aufenthalt mit Uhrzeit sowie die heutige Ankunft und Abholung; darunter liegen die Tabs zur Kartei.",
         steps: [
           "In der `Kindersuche` auf die Karte des Kindes klicken.",
           "Im Kopfbereich den aktuellen Aufenthalt (z. B. `OGS-Raum 1 seit 12:00 Uhr`) sowie `Heutige Ankunft` und `Heutige Abholung` ablesen.",
@@ -412,6 +412,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Tab `Erziehungsberechtigte`: Bezugspersonen mit Kontaktdaten, Abholberechtigung und Notfallkontakten pflegen. Pro Person zeigt ein Status, ob sie ein Konto für das Elternportal hat (`Konto aktiv`, `Einladung offen` oder `Kein Konto`); mit `Einladen` laden Sie eine bereits hinterlegte Bezugsperson zum Elternportal ein, ohne die Daten erneut einzugeben.",
           "Tab `Betreuungszeiten`: die wöchentlichen Ankunfts- und Abholzeiten je Wochentag verwalten und einzelne Tage anpassen. Hat ein Elternteil über das Elternportal eine Ankunfts- oder Abholzeit für einen Tag geändert, ist dieser Tag mit `Von Eltern` markiert; beim Ändern oder Entfernen dieser Zeit fragt die App zur Sicherheit nach, damit die Angabe der Eltern nicht versehentlich überschrieben wird.",
           "Tab `Historie`: die Anwesenheits-Historie der letzten Tage mit Raum-Details nachvollziehen.",
+          "Tab `Anmeldungen` (nur Admins): Online-Anmeldungen anzeigen, die dieses Kind ins System gebracht haben. Dort sehen Sie Betreuungsangebote, Gesundheitsangaben, Notfallkontakte, Zustimmungen und Zusatzantworten; Erziehungsberechtigte stehen weiterhin im eigenen Tab. Die Angaben können dort auch exportiert werden.",
         ],
         callout: {
           title: "Krankmeldungen von Eltern",
@@ -419,7 +420,7 @@ export const appChapters: readonly GuideChapter[] = [
           tone: "blue",
         },
         screenshot:
-          "Kinderdetailansicht mit Statuskopf, den Aktionen Krank melden, Entschuldigen und weiteren Statusaktionen im Drei-Punkte-Menü, dem Tab Stammdaten mit Bereich Elternnachrichten sowie den Tabs Erziehungsberechtigte, Betreuungszeiten und Historie.",
+          "Kinderdetailansicht mit Statuskopf, den Aktionen Krank melden, Entschuldigen und weiteren Statusaktionen im Drei-Punkte-Menü, dem Tab Stammdaten mit Bereich Elternnachrichten sowie den Tabs Erziehungsberechtigte, Betreuungszeiten, Historie und Anmeldungen.",
         image: "/help/screens/kinderdetailansicht.webp",
       },
       {

--- a/frontend/src/components/students/student-enrollments-tab.tsx
+++ b/frontend/src/components/students/student-enrollments-tab.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { ReactNode } from "react";
+import { Download, FileText, FileSpreadsheet, FileType2 } from "lucide-react";
+import {
+  type AdminRequestSummary,
+  type EnrollmentRequestExportFormat,
+  exportStudentEnrollmentRequests,
+  listStudentEnrollmentRequests,
+} from "~/lib/enrollment-admin-api";
+import { useSWRAuth } from "~/lib/swr";
+import { useToast } from "~/contexts/ToastContext";
+import { Button } from "~/components/ui/button";
+import {
+  ChildExtraFields,
+  ChildOfferings,
+  RequestExtraSection,
+  StatusBadge,
+  formatDateTime,
+  formatPlainDate,
+} from "~/components/enrollment/admin-enrollment-detail";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "StudentEnrollmentsTab" });
+
+const EXPORT_FORMATS: Array<{
+  format: EnrollmentRequestExportFormat;
+  label: string;
+  icon: ReactNode;
+}> = [
+  { format: "pdf", label: "PDF", icon: <FileText className="h-4 w-4" /> },
+  { format: "docx", label: "DOCX", icon: <FileType2 className="h-4 w-4" /> },
+  {
+    format: "xlsx",
+    label: "XLSX",
+    icon: <FileSpreadsheet className="h-4 w-4" />,
+  },
+];
+
+interface StudentEnrollmentsTabProps {
+  studentId: string;
+}
+
+export function StudentEnrollmentsTab({
+  studentId,
+}: StudentEnrollmentsTabProps) {
+  const { success: toastSuccess, error: toastError } = useToast();
+  const [exporting, setExporting] =
+    useState<EnrollmentRequestExportFormat | null>(null);
+
+  const {
+    data: requests = [],
+    error,
+    isLoading,
+  } = useSWRAuth(`student-enrollments-${studentId}`, () =>
+    listStudentEnrollmentRequests(studentId),
+  );
+
+  const handleExport = useCallback(
+    async (format: EnrollmentRequestExportFormat) => {
+      setExporting(format);
+      try {
+        await exportStudentEnrollmentRequests(studentId, format);
+        toastSuccess("Export wurde erstellt.");
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Export fehlgeschlagen";
+        logger.error("student_enrollments_export_failed", {
+          error: message,
+          student_id: studentId,
+          format,
+        });
+        toastError(message);
+      } finally {
+        setExporting(null);
+      }
+    },
+    [studentId, toastError, toastSuccess],
+  );
+
+  if (isLoading) {
+    return (
+      <p className="text-sm text-gray-500">Anmeldungen werden geladen...</p>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-[#FF3130]/20 bg-[#FF3130]/10 p-3 text-sm text-[#CC2626]">
+        Anmeldungen konnten nicht geladen werden.
+      </div>
+    );
+  }
+
+  if (requests.length === 0) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-gray-50/70 p-4 text-sm text-gray-600">
+        Für dieses Kind ist keine angenommene oder übernommene Online-Anmeldung
+        verknüpft.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">
+            Online-Anmeldungen
+          </h3>
+          <p className="mt-1 text-sm text-gray-600">
+            Angaben aus der Halbjahresanmeldung, ohne Erziehungsberechtigte.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {EXPORT_FORMATS.map((item) => (
+            <Button
+              key={item.format}
+              type="button"
+              variant="outline"
+              size="compact"
+              disabled={exporting !== null}
+              onClick={() => void handleExport(item.format)}
+            >
+              {exporting === item.format ? (
+                <Download className="h-4 w-4 animate-pulse" aria-hidden />
+              ) : (
+                item.icon
+              )}
+              {item.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {requests.map((request) => (
+        <EnrollmentRequestCard key={request.id} request={request} />
+      ))}
+    </div>
+  );
+}
+
+function EnrollmentRequestCard({
+  request,
+}: Readonly<{ request: AdminRequestSummary }>) {
+  const submittedAt = formatDateTime(request.submitted_at, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return (
+    <article className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm">
+      <div className="flex flex-col gap-3 border-b border-gray-100 p-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold tracking-wide text-[#5080D8] uppercase">
+            Anmeldung
+          </p>
+          <h4 className="mt-1 text-base font-semibold text-gray-900">
+            {request.phase_name || "Nicht zugeordnet"}
+          </h4>
+          <p className="mt-1 text-sm text-gray-600">
+            Eingegangen am {submittedAt}
+          </p>
+        </div>
+        <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700">
+          {request.children.length} Kind
+          {request.children.length === 1 ? "" : "er"}
+        </span>
+      </div>
+
+      <div className="space-y-4 p-4">
+        {request.children.map((child) => (
+          <section
+            key={child.id}
+            className="rounded-xl border border-gray-100 bg-gray-50/70 p-3"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h5 className="text-sm font-semibold text-gray-900">
+                  {child.first_name} {child.last_name}
+                </h5>
+                <div className="mt-2 flex flex-wrap gap-2 text-xs text-gray-600">
+                  <span className="rounded-full bg-white px-2.5 py-1 font-medium text-gray-700">
+                    Geburtsdatum: {formatPlainDate(child.date_of_birth)}
+                  </span>
+                  {child.target_grade_level ? (
+                    <span className="rounded-full bg-white px-2.5 py-1 font-medium text-gray-700">
+                      {child.target_grade_level}. Klasse
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              <StatusBadge status={child.status} />
+            </div>
+
+            {child.status_reason ? (
+              <div className="mt-3 rounded-lg border border-gray-100 bg-white px-3 py-2 text-sm text-gray-700">
+                <span className="text-xs font-medium text-gray-500">
+                  Begründung:{" "}
+                </span>
+                {child.status_reason}
+              </div>
+            ) : null}
+
+            <ChildOfferings offerings={child.offerings} />
+            <ChildExtraFields
+              child={child}
+              schemaFields={request.schema_fields}
+            />
+          </section>
+        ))}
+
+        <RequestExtraSection request={request} />
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/students/students-master-detail.test.tsx
+++ b/frontend/src/components/students/students-master-detail.test.tsx
@@ -160,6 +160,10 @@ vi.mock("./student-historie-tab", () => ({
   StudentHistorieTab: () => <div data-testid="historie-tab" />,
 }));
 
+vi.mock("./student-enrollments-tab", () => ({
+  StudentEnrollmentsTab: () => <div data-testid="enrollments-tab" />,
+}));
+
 vi.mock("~/components/database/database-list-item", () => ({
   DatabaseListItem: (props: {
     title: string;
@@ -407,6 +411,35 @@ describe("StudentsMasterDetail", () => {
       "",
     );
     expect(screen.getByTestId("tab-content-master-data")).toBeInTheDocument();
+  });
+
+  it("shows Anmeldungen tab only when allowed", () => {
+    const { rerender } = render(
+      <StudentsMasterDetail
+        {...baseProps}
+        students={[makeStudent("1")]}
+        selectedId="1"
+        grouping="none"
+        studentsWithArrival={new Set(["1"])}
+        arrivalSummaryById={new Map()}
+      />,
+    );
+
+    expect(screen.queryByText("Anmeldungen")).not.toBeInTheDocument();
+
+    rerender(
+      <StudentsMasterDetail
+        {...baseProps}
+        students={[makeStudent("1")]}
+        selectedId="1"
+        grouping="none"
+        studentsWithArrival={new Set(["1"])}
+        arrivalSummaryById={new Map()}
+        canViewEnrollments
+      />,
+    );
+
+    expect(screen.getByText("Anmeldungen")).toBeInTheDocument();
   });
 
   it("shows warning in header when student has no arrival", () => {

--- a/frontend/src/components/students/students-master-detail.tsx
+++ b/frontend/src/components/students/students-master-detail.tsx
@@ -29,6 +29,7 @@ import { ArrivalScheduleManager } from "./arrival-schedule-manager";
 import { StudentAbholungTab } from "./student-abholung-tab";
 import { StudentGuardiansTab } from "./student-guardians-tab";
 import { StudentHistorieTab } from "./student-historie-tab";
+import { StudentEnrollmentsTab } from "./student-enrollments-tab";
 import { StudentStammdatenTab } from "./student-stammdaten-tab";
 import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled";
 import { getInitials } from "~/lib/format-utils";
@@ -46,6 +47,7 @@ interface StudentsMasterDetailProps {
   onArrivalDataChanged: () => void;
   groups: Array<{ value: string; label: string }>;
   onUpdateStudent: (studentId: string, data: Partial<Student>) => Promise<void>;
+  canViewEnrollments?: boolean;
   detailActions?: ReactNode;
 }
 
@@ -80,6 +82,7 @@ export function StudentsMasterDetail({
   onArrivalDataChanged,
   groups,
   onUpdateStudent,
+  canViewEnrollments = false,
   detailActions,
 }: StudentsMasterDetailProps) {
   const [activeTab, setActiveTab] = useState<string>("master-data");
@@ -273,6 +276,7 @@ export function StudentsMasterDetail({
         groups,
         onArrivalDataChanged,
         onUpdateStudent,
+        canViewEnrollments,
       })}
       activeTab={activeTab}
       onTabChange={setActiveTab}
@@ -323,6 +327,7 @@ interface BuildTabsArgs {
   groups: Array<{ value: string; label: string }>;
   onArrivalDataChanged: () => void;
   onUpdateStudent: (studentId: string, data: Partial<Student>) => Promise<void>;
+  canViewEnrollments: boolean;
 }
 
 function buildTabs({
@@ -330,9 +335,10 @@ function buildTabs({
   groups,
   onArrivalDataChanged,
   onUpdateStudent,
+  canViewEnrollments,
 }: BuildTabsArgs): DetailTab[] {
   const studentId = student.id;
-  return [
+  const tabs: DetailTab[] = [
     {
       id: "master-data",
       label: "Stammdaten",
@@ -383,6 +389,14 @@ function buildTabs({
       content: <StudentHistorieTab studentId={studentId} />,
     },
   ];
+  if (canViewEnrollments) {
+    tabs.push({
+      id: "enrollments",
+      label: "Anmeldungen",
+      content: <StudentEnrollmentsTab studentId={studentId} />,
+    });
+  }
+  return tabs;
 }
 
 interface GroupActionsMenuProps {

--- a/frontend/src/lib/enrollment-admin-api.ts
+++ b/frontend/src/lib/enrollment-admin-api.ts
@@ -20,6 +20,8 @@ export type DecisionStatus =
   | "rejected"
   | "under_review";
 
+export type EnrollmentRequestExportFormat = "pdf" | "docx" | "xlsx";
+
 export interface AdminRequestChildOffering {
   offering_id: string;
   offering_name: string;
@@ -178,6 +180,48 @@ export async function getAdminRequest(
   return readJSON<AdminRequestSummary>(response);
 }
 
+export async function listStudentEnrollmentRequests(
+  studentId: string,
+): Promise<AdminRequestSummary[]> {
+  const response = await fetch(
+    `/api/enrollment/admin/students/${encodeURIComponent(studentId)}/requests`,
+    { cache: "no-store" },
+  );
+  if (!response.ok) {
+    throw await readError(response, "Anmeldungen konnten nicht geladen werden");
+  }
+  const list = await readJSON<AdminRequestSummary[]>(response);
+  return Array.isArray(list) ? list : [];
+}
+
+export async function exportStudentEnrollmentRequests(
+  studentId: string,
+  format: EnrollmentRequestExportFormat,
+): Promise<void> {
+  const response = await fetch(
+    `/api/enrollment/admin/students/${encodeURIComponent(studentId)}/requests/export`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ format }),
+    },
+  );
+
+  if (!response.ok) {
+    throw await readError(response, "Export konnte nicht erstellt werden");
+  }
+
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filenameFromDisposition(response) ?? `anmeldungen.${format}`;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
 export async function decideAdminChild(
   requestId: string,
   childId: string,
@@ -205,4 +249,10 @@ export async function decideAdminChild(
     );
   }
   return readJSON<AdminRequestChild>(response);
+}
+
+function filenameFromDisposition(response: Response): string | null {
+  const disposition = response.headers.get("content-disposition");
+  const match = /filename="([^"]+)"/.exec(disposition ?? "");
+  return match?.[1] ?? null;
 }


### PR DESCRIPTION
## Summary
- add an admin-only Anmeldungen tab to student records for linked enrollment submissions
- show child-specific enrollment answers, offerings, consents, and custom fields without guardian contact details
- add student-scoped PDF/DOCX/XLSX enrollment exports with audit logging
- update the in-app help guide for the new tab

## Tests
- git diff --check
- cd backend && go test ./api/enrollment ./services/enrollment ./database/repositories/enrollment ./models/enrollment ./models/audit
- cd frontend && pnpm run check
- cd frontend && pnpm vitest run src/components/students/students-master-detail.test.tsx src/components/enrollment/admin-enrollment-detail.test.tsx
- cd frontend && pnpm knip
- pre-push: git-secrets, go-vet, golangci-lint, frontend-knip, go-deadcode, frontend-check

## Note
- Full backend `go test ./...` is currently blocked by existing test database schema drift around guardian invitation and student exception columns, unrelated to this change.