### PR TITLE
fix: keep operator passkey login public

### DIFF
--- a/backend/api/operator/api.go
+++ b/backend/api/operator/api.go
@@ -202,13 +202,16 @@ func (rs *Resource) Router() chi.Router {
 		r.Use(jwt.Authenticator)
 		r.Use(RequiresOperatorScope)
 
-		r.Route("/auth/passkeys", func(r chi.Router) {
-			r.Get("/", rs.PasskeyList)
-			r.Post("/enrollment/challenge", rs.PasskeyEnrollmentChallenge)
-			r.Post("/register/options", rs.PasskeyRegisterOptions)
-			r.Post("/register/verify", rs.PasskeyRegisterVerify)
-			r.Delete("/{passkeyId}", rs.PasskeyRevoke)
-		})
+		// Passkey management for the currently-authenticated operator.
+		// Keep these as individual leaves instead of r.Route("/auth/passkeys", ...)
+		// because public passkey login also lives under /auth/passkeys/login/*.
+		// A protected subtree on /auth/passkeys shadows those public login
+		// routes in chi and makes anonymous passkey login fail with 401.
+		r.Get("/auth/passkeys/", rs.PasskeyList)
+		r.Post("/auth/passkeys/enrollment/challenge", rs.PasskeyEnrollmentChallenge)
+		r.Post("/auth/passkeys/register/options", rs.PasskeyRegisterOptions)
+		r.Post("/auth/passkeys/register/verify", rs.PasskeyRegisterVerify)
+		r.Delete("/auth/passkeys/{passkeyId}", rs.PasskeyRevoke)
 
 		r.Get("/accounts", rs.provisioningResource.ListAllAccounts)
 		r.Get("/roles", rs.provisioningResource.ListSystemRoles)

--- a/backend/api/operator/passkeys_test.go
+++ b/backend/api/operator/passkeys_test.go
@@ -116,6 +116,26 @@ func TestOperatorPasskeyLoginHandlers(t *testing.T) {
 	assert.JSONEq(t, `{"status":"authenticated","access_token":"operator-access","refresh_token":"operator-refresh"}`, w.Body.String())
 }
 
+func TestOperatorPasskeyLoginRoutesArePublic(t *testing.T) {
+	tokenAuth, err := jwt.NewTokenAuth()
+	require.NoError(t, err)
+
+	svc := &operatorPasskeyServiceStub{}
+	router := NewResource(ResourceConfig{
+		PasskeyService: svc,
+		TokenAuth:      tokenAuth,
+	}).Router()
+
+	req := operatorPasskeyJSONRequest("/auth/passkeys/login/options", `{}`)
+	req.Header.Set(headerOperatorFrontendOrigin, "https://operator.localhost")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "https://operator.localhost", svc.beginLoginOrigin)
+	assert.JSONEq(t, `{"session_id":"operator-login","options":{"challenge":"login"}}`, w.Body.String())
+}
+
 func TestOperatorPasskeyAuthenticatedHandlers(t *testing.T) {
 	svc := &operatorPasskeyServiceStub{}
 	rs := &Resource{passkeyService: svc}


### PR DESCRIPTION
## Summary
- keep protected operator passkey management routes from shadowing public passkey login endpoints
- add a router-level regression test for anonymous operator passkey login options

## Verification
- go test ./api/operator -run TestOperatorPasskey
- git diff --check
- pre-push hook: go-vet, go-deadcode, golangci-lint