### PR TITLE
feat(enrollment): rename form-schema templates in place

### DIFF
--- a/backend/api/enrollment/api.go
+++ b/backend/api/enrollment/api.go
@@ -110,6 +110,7 @@ func (rs *Resource) Router() chi.Router {
 			r.With(authorize.RequiresPermission("config:read")).Get("/{id}", rs.getSchemaByID)
 			r.With(authorize.RequiresPermission("config:manage")).Post("/", rs.publishSchema)
 			r.With(authorize.RequiresPermission("config:manage")).Put("/{id}", rs.updateSchema)
+			r.With(authorize.RequiresPermission("config:manage")).Patch("/{id}", rs.renameSchema)
 			r.With(authorize.RequiresPermission("config:manage")).Delete("/{id}", rs.deleteSchema)
 		})
 

--- a/backend/api/enrollment/schema_handlers.go
+++ b/backend/api/enrollment/schema_handlers.go
@@ -508,6 +508,17 @@ func (rs *Resource) publishSchema(w http.ResponseWriter, r *http.Request) {
 	common.Respond(w, r, http.StatusCreated, toFormSchemaResponse(schema), "Form schema published")
 }
 
+// renameFailure tags an error as originating from the lineage-rename step of
+// a combined rename+publish save (PUT /schema/{id}). It lets the handler map
+// a rename *infrastructure* failure (lock/read/exec) to a 5xx — matching the
+// dedicated PATCH rename handler — instead of letting it fall through to the
+// publish path's 400 contract. It unwraps so errors.Is still matches the
+// rename sentinels (name-exists, not-found).
+type renameFailure struct{ err error }
+
+func (e renameFailure) Error() string { return e.err.Error() }
+func (e renameFailure) Unwrap() error { return e.err }
+
 // updateSchema publishes a new version of an existing named schema.
 // PUT /schema/{id} — id refers to any prior version of the schema;
 // the new row inherits its name and is written with version+1.
@@ -545,7 +556,7 @@ func (rs *Resource) updateSchema(w http.ResponseWriter, r *http.Request) {
 		// dedicated PATCH route owns blank-name rejection).
 		if req.Name != nil && strings.TrimSpace(*req.Name) != "" {
 			if _, renameErr := rs.FormSchemaService.RenameSchema(ctx, id, *req.Name); renameErr != nil {
-				return renameErr
+				return renameFailure{err: renameErr}
 			}
 		}
 
@@ -565,13 +576,23 @@ func (rs *Resource) updateSchema(w http.ResponseWriter, r *http.Request) {
 	})
 	if txErr != nil {
 		// A rename onto an existing name surfaces as a 409 with a stable code
-		// so the frontend shows "name already taken", same as the PATCH route.
+		// so the frontend shows "name already taken"; a missing lineage as a
+		// 404 — same as the PATCH route, regardless of which step raised it.
 		switch {
 		case errors.Is(txErr, enrollmentService.ErrFormSchemaNameExists):
 			common.RenderError(w, r, common.ErrorConflictWithCode(txErr, ErrCodeSchemaNameExists))
 			return
 		case errors.Is(txErr, enrollmentService.ErrFormSchemaNotFound):
 			common.RenderError(w, r, common.ErrorNotFound(txErr))
+			return
+		}
+		// A rename failure beyond those sentinels is infrastructure (lock/read/
+		// exec), not a client error: map it to 5xx like the PATCH handler so it
+		// takes the normal error-logging/Sentry path. Publish errors keep the
+		// existing 400 contract (validation; shared with POST /schema).
+		var rf renameFailure
+		if errors.As(txErr, &rf) {
+			common.RenderError(w, r, common.ErrorInternalServer(txErr))
 			return
 		}
 		common.RenderError(w, r, common.ErrorInvalidRequest(txErr))

--- a/backend/api/enrollment/schema_handlers.go
+++ b/backend/api/enrollment/schema_handlers.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -101,6 +102,21 @@ type UpdateSchemaRequest struct {
 func (req *UpdateSchemaRequest) Bind(_ *http.Request) error {
 	if req.Fields == nil {
 		req.Fields = []enrollmentModels.FormField{}
+	}
+	return nil
+}
+
+// RenameSchemaRequest is the wire shape PATCH /schema/{id} accepts. It
+// only renames the logical schema (all versions share one name) and
+// never publishes a new version or touches the form fields.
+type RenameSchemaRequest struct {
+	Name string `json:"name"`
+}
+
+func (req *RenameSchemaRequest) Bind(_ *http.Request) error {
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" {
+		return errors.New("name is required")
 	}
 	return nil
 }
@@ -544,6 +560,52 @@ func (rs *Resource) updateSchema(w http.ResponseWriter, r *http.Request) {
 	common.Respond(w, r, http.StatusCreated, toFormSchemaResponse(schema), "Form schema version added")
 }
 
+// renameSchema renames a logical schema (every version row sharing the
+// source's name) in place. PATCH /schema/{id} — id refers to any
+// version of the schema. Unlike updateSchema this publishes no new
+// version and leaves the form fields untouched.
+func (rs *Resource) renameSchema(w http.ResponseWriter, r *http.Request) {
+	if rs.FormSchemaService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("form schema service not configured")))
+		return
+	}
+
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid schema id")))
+		return
+	}
+
+	req := &RenameSchemaRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	var schema *enrollmentModels.FormSchema
+	txErr := rs.runInTenantTx(r, func(ctx context.Context) error {
+		s, innerErr := rs.FormSchemaService.RenameSchema(ctx, id, req.Name)
+		schema = s
+		return innerErr
+	})
+	if txErr != nil {
+		switch {
+		case errors.Is(txErr, enrollmentService.ErrFormSchemaNameExists):
+			common.RenderError(w, r, common.ErrorConflictWithCode(txErr, ErrCodeSchemaNameExists))
+			return
+		case errors.Is(txErr, enrollmentService.ErrFormSchemaNotFound):
+			common.RenderError(w, r, common.ErrorNotFound(txErr))
+			return
+		}
+		common.RenderError(w, r, common.ErrorInternalServer(txErr))
+		return
+	}
+
+	// The service already logs the rename (old + new name) via its
+	// injected logger; no duplicate handler-level log here.
+	common.Respond(w, r, http.StatusOK, toFormSchemaResponse(schema), "Form schema renamed")
+}
+
 func (rs *Resource) deleteSchema(w http.ResponseWriter, r *http.Request) {
 	if rs.FormSchemaService == nil {
 		common.RenderError(w, r, common.ErrorInternalServer(errors.New("form schema service not configured")))
@@ -580,6 +642,7 @@ func (rs *Resource) deleteSchema(w http.ResponseWriter, r *http.Request) {
 const (
 	ErrCodeSchemaHasPhases   = "enrollment.schema_has_phases"
 	ErrCodeSchemaHasRequests = "enrollment.schema_has_requests"
+	ErrCodeSchemaNameExists  = "enrollment.schema_name_exists"
 )
 
 // runInTenantTx wraps the request's tenant context in a tenant

--- a/backend/api/enrollment/schema_handlers.go
+++ b/backend/api/enrollment/schema_handlers.go
@@ -91,9 +91,14 @@ func (req *PublishSchemaRequest) Bind(_ *http.Request) error {
 }
 
 // UpdateSchemaRequest is the wire shape PUT /schema/{id} accepts.
-// Only the fields are mutable — name is inherited from the source
-// schema so all versions of a logical schema share the same name.
+// Name is optional: when present and different from the lineage's current
+// name, the handler renames the whole lineage AND publishes the new version
+// in one transaction (a combined "rename + edit" save), so a failed publish
+// rolls the rename back. When Name is absent, only the fields change and the
+// name is inherited from the source schema, keeping every version of a
+// logical schema under one shared name.
 type UpdateSchemaRequest struct {
+	Name             *string                            `json:"name,omitempty"`
 	Fields           []enrollmentModels.FormField       `json:"fields"`
 	CoreRequirements *enrollmentModels.CoreRequirements `json:"core_requirements,omitempty"`
 	LegalBlocks      *[]enrollmentModels.FormLegalBlock `json:"legal_blocks,omitempty"`
@@ -532,6 +537,18 @@ func (rs *Resource) updateSchema(w http.ResponseWriter, r *http.Request) {
 
 	var schema *enrollmentModels.FormSchema
 	txErr := rs.runInTenantTx(r, func(ctx context.Context) error {
+		// Combined "rename + edit" save: rename the lineage first, in the
+		// SAME transaction as the publish below. If the publish fails the
+		// whole tx rolls back, so the rename never commits on its own — no
+		// partial "renamed but content unchanged" state. RenameSchema is a
+		// no-op when the name is unchanged. A blank name is ignored (the
+		// dedicated PATCH route owns blank-name rejection).
+		if req.Name != nil && strings.TrimSpace(*req.Name) != "" {
+			if _, renameErr := rs.FormSchemaService.RenameSchema(ctx, id, *req.Name); renameErr != nil {
+				return renameErr
+			}
+		}
+
 		var (
 			s        *enrollmentModels.FormSchema
 			innerErr error
@@ -547,6 +564,16 @@ func (rs *Resource) updateSchema(w http.ResponseWriter, r *http.Request) {
 		return innerErr
 	})
 	if txErr != nil {
+		// A rename onto an existing name surfaces as a 409 with a stable code
+		// so the frontend shows "name already taken", same as the PATCH route.
+		switch {
+		case errors.Is(txErr, enrollmentService.ErrFormSchemaNameExists):
+			common.RenderError(w, r, common.ErrorConflictWithCode(txErr, ErrCodeSchemaNameExists))
+			return
+		case errors.Is(txErr, enrollmentService.ErrFormSchemaNotFound):
+			common.RenderError(w, r, common.ErrorNotFound(txErr))
+			return
+		}
 		common.RenderError(w, r, common.ErrorInvalidRequest(txErr))
 		return
 	}

--- a/backend/api/enrollment/schema_handlers_test.go
+++ b/backend/api/enrollment/schema_handlers_test.go
@@ -511,6 +511,69 @@ func TestUpdateSchemaHandler_ServiceErrorReturns400(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestUpdateSchemaHandler_WithNameRenamesThenPublishes(t *testing.T) {
+	// Combined "rename + edit" save: a name in the PUT body renames the
+	// lineage AND publishes the new version in one request, so the two are
+	// atomic (no separate rename round-trip the frontend has to undo on
+	// failure).
+	mock := &mockFormSchemaService{
+		renameResult: makeFormSchema(1234, "Ferienprogramm", 2),
+		updateResult: makeFormSchema(1234, "Ferienprogramm", 3),
+	}
+	router := buildSchemaRouter(mock)
+	w := executeSchemaJSON(t, router, http.MethodPut, "/enrollment/schema/1234",
+		map[string]any{
+			"name":   "Ferienprogramm",
+			"fields": []map[string]any{{"key": "x", "label": "X", "type": "text", "sort_order": 0}},
+		})
+	require.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, int64(1234), mock.renameID, "the rename must target the same lineage id")
+	assert.Equal(t, "Ferienprogramm", mock.renameName)
+	assert.Equal(t, int64(1234), mock.updateID, "the publish must run after the rename")
+}
+
+func TestUpdateSchemaHandler_BlankNameSkipsRename(t *testing.T) {
+	// A blank name in the PUT body is ignored (the dedicated PATCH route
+	// owns blank-name rejection); the publish still runs.
+	mock := &mockFormSchemaService{updateResult: makeFormSchema(1234, "Klassenanmeldung", 2)}
+	router := buildSchemaRouter(mock)
+	w := executeSchemaJSON(t, router, http.MethodPut, "/enrollment/schema/1234",
+		map[string]any{
+			"name":   "   ",
+			"fields": []map[string]any{{"key": "x", "label": "X", "type": "text", "sort_order": 0}},
+		})
+	require.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, int64(0), mock.renameID, "a blank name must not trigger a rename")
+	assert.Equal(t, int64(1234), mock.updateID)
+}
+
+func TestUpdateSchemaHandler_RenameNameCollisionReturns409WithCode(t *testing.T) {
+	// The rename half fails on a name already used by another lineage; the
+	// publish must NOT run and the response is the same 409 + stable code the
+	// PATCH route returns, so the frontend shows "name already taken".
+	mock := &mockFormSchemaService{renameErr: enrollmentService.ErrFormSchemaNameExists}
+	router := buildSchemaRouter(mock)
+	w := executeSchemaJSON(t, router, http.MethodPut, "/enrollment/schema/1234",
+		map[string]any{
+			"name":   "Schon vergeben",
+			"fields": []map[string]any{{"key": "x", "label": "X", "type": "text", "sort_order": 0}},
+		})
+	require.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), ErrCodeSchemaNameExists)
+	assert.Equal(t, int64(0), mock.updateID, "a failed rename must abort before the publish")
+}
+
+func TestUpdateSchemaHandler_RenameNotFoundReturns404(t *testing.T) {
+	mock := &mockFormSchemaService{renameErr: enrollmentService.ErrFormSchemaNotFound}
+	router := buildSchemaRouter(mock)
+	w := executeSchemaJSON(t, router, http.MethodPut, "/enrollment/schema/1234",
+		map[string]any{
+			"name":   "Neuer Name",
+			"fields": []map[string]any{{"key": "x", "label": "X", "type": "text", "sort_order": 0}},
+		})
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 // --- deleteSchema -----------------------------------------------------
 
 func TestDeleteSchemaHandler_NilServiceReturns500(t *testing.T) {

--- a/backend/api/enrollment/schema_handlers_test.go
+++ b/backend/api/enrollment/schema_handlers_test.go
@@ -72,6 +72,10 @@ type mockFormSchemaService struct {
 	updateErr        error
 	deleteID         int64
 	deleteErr        error
+	renameID         int64
+	renameName       string
+	renameResult     *enrollmentModels.FormSchema
+	renameErr        error
 	publishVResult   *enrollmentModels.FormSchema
 	publishVErr      error
 	publishVFields   []enrollmentModels.FormField
@@ -139,6 +143,11 @@ func (m *mockFormSchemaService) DeleteSchema(_ context.Context, id int64) error 
 	m.deleteID = id
 	return m.deleteErr
 }
+func (m *mockFormSchemaService) RenameSchema(_ context.Context, id int64, newName string) (*enrollmentModels.FormSchema, error) {
+	m.renameID = id
+	m.renameName = newName
+	return m.renameResult, m.renameErr
+}
 func (m *mockFormSchemaService) PublishVersion(_ context.Context, fields []enrollmentModels.FormField, createdBy int64, _ ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
 	m.publishVFields = fields
 	m.publishVCreated = createdBy
@@ -161,6 +170,7 @@ func buildSchemaRouter(svc enrollmentService.FormSchemaService) chi.Router {
 	r.Get("/enrollment/schema/{id}", rs.getSchemaByID)
 	r.Post("/enrollment/schema", rs.publishSchema)
 	r.Put("/enrollment/schema/{id}", rs.updateSchema)
+	r.Patch("/enrollment/schema/{id}", rs.renameSchema)
 	r.Delete("/enrollment/schema/{id}", rs.deleteSchema)
 	return r
 }
@@ -545,6 +555,69 @@ func TestDeleteSchemaHandler_NotFoundReturns404(t *testing.T) {
 	router := buildSchemaRouter(mock)
 	w := executeSchemaJSON(t, router, http.MethodDelete, "/enrollment/schema/1234", nil)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- renameSchema -----------------------------------------------------
+
+func TestRenameSchemaHandler_NilServiceReturns500(t *testing.T) {
+	router := buildSchemaRouter(nil)
+	w := executeSchemaJSON(t, router, http.MethodPatch, "/enrollment/schema/1234",
+		map[string]any{"name": "Neuer Name"})
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestRenameSchemaHandler_InvalidIDRejected(t *testing.T) {
+	router := buildSchemaRouter(&mockFormSchemaService{})
+	w := executeSchemaJSON(t, router, http.MethodPatch, "/enrollment/schema/notanumber",
+		map[string]any{"name": "Neuer Name"})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestRenameSchemaHandler_EmptyNameRejected(t *testing.T) {
+	router := buildSchemaRouter(&mockFormSchemaService{})
+	w := executeSchemaJSON(t, router, http.MethodPatch, "/enrollment/schema/1234",
+		map[string]any{"name": "   "})
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"a blank name must be rejected before reaching the service")
+}
+
+func TestRenameSchemaHandler_HappyPath(t *testing.T) {
+	mock := &mockFormSchemaService{renameResult: makeFormSchema(1234, "Ferienprogramm", 3)}
+	router := buildSchemaRouter(mock)
+	w := executeSchemaJSON(t, router, http.MethodPatch, "/enrollment/schema/1234",
+		map[string]any{"name": "  Ferienprogramm  "})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(1234), mock.renameID)
+	assert.Equal(t, "Ferienprogramm", mock.renameName,
+		"the handler must trim the name before handing it to the service")
+	assert.Contains(t, w.Body.String(), "Ferienprogramm")
+}
+
+func TestRenameSchemaHandler_NameExistsReturns409WithCode(t *testing.T) {
+	mock := &mockFormSchemaService{renameErr: enrollmentService.ErrFormSchemaNameExists}
+	router := buildSchemaRouter(mock)
+	w := executeSchemaJSON(t, router, http.MethodPatch, "/enrollment/schema/1234",
+		map[string]any{"name": "Schon vergeben"})
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), ErrCodeSchemaNameExists,
+		"a name collision must surface as a stable error code for the frontend")
+}
+
+func TestRenameSchemaHandler_NotFoundReturns404(t *testing.T) {
+	mock := &mockFormSchemaService{renameErr: enrollmentService.ErrFormSchemaNotFound}
+	router := buildSchemaRouter(mock)
+	w := executeSchemaJSON(t, router, http.MethodPatch, "/enrollment/schema/1234",
+		map[string]any{"name": "Neuer Name"})
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestRenameSchemaHandler_GenericErrorReturns500(t *testing.T) {
+	mock := &mockFormSchemaService{renameErr: errors.New("synthetic boom")}
+	router := buildSchemaRouter(mock)
+	w := executeSchemaJSON(t, router, http.MethodPatch, "/enrollment/schema/1234",
+		map[string]any{"name": "Neuer Name"})
+	assert.Equal(t, http.StatusInternalServerError, w.Code,
+		"an unmapped error is a server fault, not a bad request")
 }
 
 func TestDeleteSchemaHandler_GenericErrorReturns500(t *testing.T) {

--- a/backend/api/enrollment/schema_handlers_test.go
+++ b/backend/api/enrollment/schema_handlers_test.go
@@ -574,6 +574,22 @@ func TestUpdateSchemaHandler_RenameNotFoundReturns404(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+func TestUpdateSchemaHandler_RenameInfraErrorReturns500(t *testing.T) {
+	// A rename failure that is neither a name collision nor a missing lineage
+	// (a DB/lock/read fault) is infrastructure, not a client error. The
+	// combined save must surface it as a 5xx — matching the PATCH handler — so
+	// it takes the normal error-logging path, NOT the publish path's 400.
+	mock := &mockFormSchemaService{renameErr: errors.New("lineage lock failed")}
+	router := buildSchemaRouter(mock)
+	w := executeSchemaJSON(t, router, http.MethodPut, "/enrollment/schema/1234",
+		map[string]any{
+			"name":   "Neuer Name",
+			"fields": []map[string]any{{"key": "x", "label": "X", "type": "text", "sort_order": 0}},
+		})
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, int64(0), mock.updateID, "a failed rename must abort before the publish")
+}
+
 // --- deleteSchema -----------------------------------------------------
 
 func TestDeleteSchemaHandler_NilServiceReturns500(t *testing.T) {

--- a/backend/database/repositories/enrollment/form_schema_repository.go
+++ b/backend/database/repositories/enrollment/form_schema_repository.go
@@ -227,6 +227,24 @@ func (r *FormSchemaRepository) RenameByName(ctx context.Context, oldName, newNam
 	return nil
 }
 
+// LockLineages takes the per-tenant, transaction-scoped advisory lock that
+// serializes form-schema lineage mutations (publish, rename, delete) against
+// one another. Without it a rename and a concurrent version-publish can split
+// a lineage: the publish reads the pre-rename name and inserts a new row under
+// it while the rename moves the existing rows to the new name, leaving the
+// lineage's name no longer shared (migration 1.15.74's whole-lineage
+// invariant). Callers must already be inside the request's tenant transaction
+// (runInTenantTx / WithTenantTx); the lock releases automatically at
+// COMMIT/ROLLBACK. The key is namespaced per tenant so it never collides with
+// other advisory locks.
+func (r *FormSchemaRepository) LockLineages(ctx context.Context) error {
+	key := fmt.Sprintf("enrollment.form_schema_lineage:%d", tenant.FromContext(ctx))
+	if err := base.AcquireXactLock(ctx, r.db, key); err != nil {
+		return fmt.Errorf("failed to lock form schema lineages: %w", err)
+	}
+	return nil
+}
+
 // DeleteByName removes every version of a logical schema. Callers must
 // check phase and request references first.
 func (r *FormSchemaRepository) DeleteByName(ctx context.Context, name string) error {

--- a/backend/database/repositories/enrollment/form_schema_repository.go
+++ b/backend/database/repositories/enrollment/form_schema_repository.go
@@ -140,6 +140,25 @@ func (r *FormSchemaRepository) NextVersionForName(ctx context.Context, name stri
 	return maxVersion + 1, nil
 }
 
+// ExistsByName reports whether any version row already carries name for
+// the tenant in context. RenameSchema uses it to reject a rename onto an
+// existing logical schema before touching the (tenant_id, name, version)
+// unique index.
+func (r *FormSchemaRepository) ExistsByName(ctx context.Context, name string) (bool, error) {
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model((*enrollment.FormSchema)(nil)).
+		ModelTableExpr(formSchemaTableExpr).
+		Where(`"form_schema".name = ?`, name)
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where(`"form_schema".tenant_id = ?`, tenantID)
+	}
+	exists, err := query.Exists(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to check form schema name %q: %w", name, err)
+	}
+	return exists, nil
+}
+
 // DeactivatePrevious flips is_active=false on every schema for the tenant
 // in context. Used by the schema service before activating a new version.
 // The partial unique index uq_form_schemas_one_active_per_tenant enforces
@@ -178,6 +197,32 @@ func (r *FormSchemaRepository) UpdateActiveFlag(ctx context.Context, id int64, i
 	rows, _ := res.RowsAffected()
 	if rows == 0 {
 		return fmt.Errorf("form schema %d not found", id)
+	}
+	return nil
+}
+
+// RenameByName updates the name on every version row of a logical
+// schema for the tenant in context, keeping the whole version lineage
+// under one shared name. The service guarantees newName doesn't collide
+// with another lineage before calling this, so the
+// (tenant_id, name, version) unique index is never violated.
+func (r *FormSchemaRepository) RenameByName(ctx context.Context, oldName, newName string) error {
+	query := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*enrollment.FormSchema)(nil)).
+		ModelTableExpr(formSchemaTableExpr).
+		Set("name = ?", newName).
+		Set("updated_at = NOW()").
+		Where(`"form_schema".name = ?`, oldName)
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where(`"form_schema".tenant_id = ?`, tenantID)
+	}
+	res, err := query.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to rename form schema %q to %q: %w", oldName, newName, err)
+	}
+	rows, _ := res.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("form schema %q not found", oldName)
 	}
 	return nil
 }

--- a/backend/database/repositories/enrollment/form_schema_repository_test.go
+++ b/backend/database/repositories/enrollment/form_schema_repository_test.go
@@ -477,6 +477,76 @@ func TestFormSchemaRepository_DeleteByName_UnknownNameErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+// --- RenameByName -------------------------------------------------------
+
+func TestFormSchemaRepository_RenameByName_RenamesEveryVersion(t *testing.T) {
+	db, repo, tenantID, creator := setupSchemaRepoTest(t)
+	defer wipeSchemas(db, tenantID, creator)
+
+	oldName := uniqueSchemaName("renall")
+	for i := 1; i <= 3; i++ {
+		s := &enrollmentModels.FormSchema{
+			Name:      oldName,
+			Version:   i,
+			Fields:    validFields(),
+			IsActive:  i == 3,
+			CreatedBy: creator,
+		}
+		require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+			return repo.Create(ctx, s)
+		}))
+	}
+	// A row under a different name must keep its name untouched.
+	survivor := &enrollmentModels.FormSchema{
+		Name:      uniqueSchemaName("keep"),
+		Version:   1,
+		Fields:    validFields(),
+		IsActive:  true,
+		CreatedBy: creator,
+	}
+	require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		return repo.Create(ctx, survivor)
+	}))
+
+	newName := uniqueSchemaName("renamed")
+	require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		return repo.RenameByName(ctx, oldName, newName)
+	}))
+
+	// All three versions now carry the new name; old name is gone.
+	count, err := db.NewSelect().
+		TableExpr("enrollment.form_schemas").
+		Where("tenant_id = ? AND name = ?", tenantID, newName).
+		Count(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 3, count, "RenameByName must rename every version of the lineage")
+
+	count, err = db.NewSelect().
+		TableExpr("enrollment.form_schemas").
+		Where("tenant_id = ? AND name = ?", tenantID, oldName).
+		Count(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "no row may keep the old name")
+
+	// Survivor under a different name is unaffected.
+	count, err = db.NewSelect().
+		TableExpr("enrollment.form_schemas").
+		Where("tenant_id = ? AND name = ?", tenantID, survivor.Name).
+		Count(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "rows under other names must not be touched")
+}
+
+func TestFormSchemaRepository_RenameByName_UnknownNameErrors(t *testing.T) {
+	db, repo, tenantID, _ := setupSchemaRepoTest(t)
+
+	err := runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		return repo.RenameByName(ctx, "no-such-schema-name-"+t.Name(), "whatever")
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
 // --- Tenant isolation ---------------------------------------------------
 
 func TestFormSchemaRepository_RLS_TenantIsolation(t *testing.T) {

--- a/backend/models/enrollment/form_schema.go
+++ b/backend/models/enrollment/form_schema.go
@@ -848,6 +848,11 @@ type FormSchemaRepository interface {
 	// Callers must guard against colliding with an existing name first.
 	RenameByName(ctx context.Context, oldName, newName string) error
 	DeleteByName(ctx context.Context, name string) error
+	// LockLineages serializes lineage mutations (publish, rename, delete)
+	// for the tenant in context against one another, so a rename and a
+	// concurrent publish cannot split a version lineage. Transaction-scoped;
+	// the caller must already be inside the request's tenant transaction.
+	LockLineages(ctx context.Context) error
 }
 
 // SubmissionData is the reduced shape used by the legacy schema-service

--- a/backend/models/enrollment/form_schema.go
+++ b/backend/models/enrollment/form_schema.go
@@ -837,8 +837,16 @@ type FormSchemaRepository interface {
 	ListByTenant(ctx context.Context) ([]*FormSchema, error)
 	NextVersion(ctx context.Context) (int, error)
 	NextVersionForName(ctx context.Context, name string) (int, error)
+	// ExistsByName reports whether any version row already carries name
+	// for the tenant in context. Used to reject a rename onto an existing
+	// logical schema before touching the unique index.
+	ExistsByName(ctx context.Context, name string) (bool, error)
 	DeactivatePrevious(ctx context.Context) error
 	UpdateActiveFlag(ctx context.Context, id int64, isActive bool) error
+	// RenameByName renames every version of a logical schema in one
+	// atomic update, so the whole version lineage keeps a shared name.
+	// Callers must guard against colliding with an existing name first.
+	RenameByName(ctx context.Context, oldName, newName string) error
 	DeleteByName(ctx context.Context, name string) error
 }
 

--- a/backend/services/enrollment/decision_export_integration_test.go
+++ b/backend/services/enrollment/decision_export_integration_test.go
@@ -52,6 +52,11 @@ func (failingSchemaRepo) FindByID(_ context.Context, _ int64) (*enrollmentModels
 	return nil, errors.New("schema read failed")
 }
 
+// LockLineages is a no-op so this stub works when constructed with a nil
+// embedded repo (failingSchemaRepo{}); the lineage lock is irrelevant to the
+// FindByID-fault behavior the tests exercise.
+func (failingSchemaRepo) LockLineages(_ context.Context) error { return nil }
+
 // newExportDecisionServiceFailingSchema mirrors newExportDecisionService
 // but swaps in a FormSchema repo whose FindByID always errors, so a test
 // can prove the export fails closed when a pinned schema cannot be loaded.

--- a/backend/services/enrollment/form_schema_service.go
+++ b/backend/services/enrollment/form_schema_service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
 )
@@ -21,7 +22,16 @@ var (
 	ErrFormSchemaNotFound    = errors.New("form schema not found")
 	ErrFormSchemaHasPhases   = errors.New("form schema has enrollment phases")
 	ErrFormSchemaHasRequests = errors.New("form schema has enrollment requests")
+	// ErrFormSchemaNameExists is returned by RenameSchema when the target
+	// name already identifies a different logical schema for the tenant.
+	ErrFormSchemaNameExists = errors.New("a form schema with this name already exists")
 )
+
+// formSchemaNameVersionUniqueIndex is the Postgres unique index from
+// migration 1.15.74 (tenant_id, name, version). Kept as a string
+// constant — the migration declares it inline — so RenameSchema can
+// translate a 23505 race into ErrFormSchemaNameExists.
+const formSchemaNameVersionUniqueIndex = "uq_form_schemas_tenant_name_version"
 
 // FormSchemaService manages form-schema versioning. GetActive feeds the public
 // form renderer and admin pre-fill; PublishVersion creates a new active version
@@ -69,6 +79,13 @@ type FormSchemaService interface {
 	// schema reference intact.
 	UpdateSchema(ctx context.Context, id int64, fields []enrollmentModels.FormField, updatedBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error)
 	UpdateSchemaWithLegal(ctx context.Context, id int64, fields []enrollmentModels.FormField, updatedBy int64, coreRequirements *enrollmentModels.CoreRequirements, legalBlocks *[]enrollmentModels.FormLegalBlock) (*enrollmentModels.FormSchema, error)
+
+	// RenameSchema renames the logical schema selected by id. All version
+	// rows sharing the source's name are renamed atomically so the version
+	// lineage stays intact. Renaming to a name already used by a different
+	// schema returns ErrFormSchemaNameExists. The returned schema is the
+	// row identified by id with its updated name.
+	RenameSchema(ctx context.Context, id int64, newName string) (*enrollmentModels.FormSchema, error)
 
 	// DeleteSchema removes every version of the logical schema selected
 	// by id. It refuses deletion when any version is used by a phase or
@@ -212,6 +229,61 @@ func (s *formSchemaService) UpdateSchemaWithLegal(ctx context.Context, id int64,
 		nextLegalBlocks = *legalBlocks
 	}
 	return s.createOrVersion(ctx, source.Name, fields, updatedBy, nextCoreRequirements, nextLegalBlocks)
+}
+
+func (s *formSchemaService) RenameSchema(ctx context.Context, id int64, newName string) (*enrollmentModels.FormSchema, error) {
+	if id <= 0 {
+		return nil, ErrFormSchemaNotFound
+	}
+	newName = strings.TrimSpace(newName)
+	if newName == "" {
+		return nil, fmt.Errorf("schema name is required")
+	}
+
+	source, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %w", ErrFormSchemaNotFound, err)
+		}
+		return nil, fmt.Errorf("load source schema: %w", err)
+	}
+
+	// Renaming to the current name is a no-op; return the source unchanged
+	// so callers don't trip the collision check against the schema itself.
+	if source.Name == newName {
+		return source, nil
+	}
+
+	// Reject collisions with another logical schema before we touch the
+	// unique index. The same-name early return above means any hit here is
+	// a different lineage.
+	exists, err := s.repo.ExistsByName(ctx, newName)
+	if err != nil {
+		return nil, fmt.Errorf("check existing name: %w", err)
+	}
+	if exists {
+		return nil, ErrFormSchemaNameExists
+	}
+
+	oldName := source.Name
+	if err := s.repo.RenameByName(ctx, oldName, newName); err != nil {
+		// Race-safe fallback: if a concurrent rename claimed newName
+		// between the check above and this update, the unique index
+		// (tenant_id, name, version) raises 23505. Translate it to the
+		// sentinel so the handler still returns 409, not a generic 400.
+		if isUniqueViolationOn(err, formSchemaNameVersionUniqueIndex) {
+			return nil, ErrFormSchemaNameExists
+		}
+		return nil, fmt.Errorf("rename schema: %w", err)
+	}
+
+	s.logger.Info("form schema renamed",
+		slog.String("old_name", oldName),
+		slog.String("new_name", newName),
+		slog.Int64("schema_id", id))
+
+	source.Name = newName
+	return source, nil
 }
 
 func (s *formSchemaService) DeleteSchema(ctx context.Context, id int64) error {

--- a/backend/services/enrollment/form_schema_service.go
+++ b/backend/services/enrollment/form_schema_service.go
@@ -163,12 +163,18 @@ func (s *formSchemaService) ListVersions(ctx context.Context) ([]*enrollmentMode
 const defaultSchemaName = "Standardformular"
 
 func (s *formSchemaService) PublishVersion(ctx context.Context, fields []enrollmentModels.FormField, createdBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
+	if err := s.repo.LockLineages(ctx); err != nil {
+		return nil, err
+	}
 	return s.createOrVersion(ctx, defaultSchemaName, fields, createdBy, firstCoreRequirements(coreRequirements), nil)
 }
 
 func (s *formSchemaService) CreateSchema(ctx context.Context, name string, fields []enrollmentModels.FormField, createdBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
 	if name == "" {
 		return nil, fmt.Errorf("schema name is required")
+	}
+	if err := s.repo.LockLineages(ctx); err != nil {
+		return nil, err
 	}
 	// Refuse to overload an existing name. The admin should use
 	// UpdateSchema to add a new version instead. The
@@ -187,6 +193,9 @@ func (s *formSchemaService) CreateSchemaWithLegal(ctx context.Context, name stri
 	if name == "" {
 		return nil, fmt.Errorf("schema name is required")
 	}
+	if err := s.repo.LockLineages(ctx); err != nil {
+		return nil, err
+	}
 	existing, err := s.repo.NextVersionForName(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("check existing name: %w", err)
@@ -200,6 +209,12 @@ func (s *formSchemaService) CreateSchemaWithLegal(ctx context.Context, name stri
 func (s *formSchemaService) UpdateSchema(ctx context.Context, id int64, fields []enrollmentModels.FormField, updatedBy int64, coreRequirements ...enrollmentModels.CoreRequirements) (*enrollmentModels.FormSchema, error) {
 	if id <= 0 {
 		return nil, fmt.Errorf("schema id must be positive")
+	}
+	// Lock the lineage before reading its name: a concurrent rename must not
+	// move the lineage between this read and the new version's insert, or the
+	// new row is born under the stale name and splits the lineage.
+	if err := s.repo.LockLineages(ctx); err != nil {
+		return nil, err
 	}
 	source, err := s.repo.FindByID(ctx, id)
 	if err != nil {
@@ -215,6 +230,10 @@ func (s *formSchemaService) UpdateSchema(ctx context.Context, id int64, fields [
 func (s *formSchemaService) UpdateSchemaWithLegal(ctx context.Context, id int64, fields []enrollmentModels.FormField, updatedBy int64, coreRequirements *enrollmentModels.CoreRequirements, legalBlocks *[]enrollmentModels.FormLegalBlock) (*enrollmentModels.FormSchema, error) {
 	if id <= 0 {
 		return nil, fmt.Errorf("schema id must be positive")
+	}
+	// Lock the lineage before reading its name (see UpdateSchema).
+	if err := s.repo.LockLineages(ctx); err != nil {
+		return nil, err
 	}
 	source, err := s.repo.FindByID(ctx, id)
 	if err != nil {
@@ -238,6 +257,13 @@ func (s *formSchemaService) RenameSchema(ctx context.Context, id int64, newName 
 	newName = strings.TrimSpace(newName)
 	if newName == "" {
 		return nil, fmt.Errorf("schema name is required")
+	}
+
+	// Serialize against concurrent publishes of the same lineage: hold the
+	// lock across the load, the collision check, and the rename so a publish
+	// can't insert a new version under the old name mid-rename.
+	if err := s.repo.LockLineages(ctx); err != nil {
+		return nil, err
 	}
 
 	source, err := s.repo.FindByID(ctx, id)
@@ -292,6 +318,13 @@ func (s *formSchemaService) DeleteSchema(ctx context.Context, id int64) error {
 	}
 	if s.phaseRepo == nil || s.requestRepo == nil {
 		return fmt.Errorf("schema delete dependencies not configured")
+	}
+
+	// Serialize against a concurrent publish: deleting a lineage while a new
+	// version is being inserted under the same name would otherwise leave an
+	// orphan row behind.
+	if err := s.repo.LockLineages(ctx); err != nil {
+		return err
 	}
 
 	source, err := s.repo.FindByID(ctx, id)

--- a/backend/services/enrollment/form_schema_service_test.go
+++ b/backend/services/enrollment/form_schema_service_test.go
@@ -148,3 +148,179 @@ func TestFormSchemaService_ListVersions_ReturnsNewestFirst(t *testing.T) {
 	assert.True(t, list[1].IsActive)
 	assert.True(t, list[2].IsActive)
 }
+
+func TestFormSchemaService_RenameSchema_RenamesWholeLineage(t *testing.T) {
+	_, svc, creatorID, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
+
+	field := []enrollmentModels.FormField{
+		{Key: "allergies", Label: "Allergien", Type: enrollmentModels.FormFieldText, SortOrder: 0},
+	}
+	created, err := svc.CreateSchema(ctx, "Ferienbetreuung", field, creatorID)
+	require.NoError(t, err)
+	// Add a second version so we can assert the rename hits every row.
+	v2, err := svc.UpdateSchema(ctx, created.ID, field, creatorID)
+	require.NoError(t, err)
+	require.Equal(t, 2, v2.Version)
+
+	renamed, err := svc.RenameSchema(ctx, created.ID, "  Ferienprogramm  ")
+	require.NoError(t, err)
+	assert.Equal(t, "Ferienprogramm", renamed.Name, "service must trim the name")
+
+	list, err := svc.ListVersions(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+	for _, s := range list {
+		assert.Equal(t, "Ferienprogramm", s.Name,
+			"every version of the lineage must carry the new name")
+	}
+}
+
+func TestFormSchemaService_RenameSchema_RejectsCollisionWithOtherSchema(t *testing.T) {
+	_, svc, creatorID, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
+
+	field := []enrollmentModels.FormField{
+		{Key: "allergies", Label: "Allergien", Type: enrollmentModels.FormFieldText, SortOrder: 0},
+	}
+	a, err := svc.CreateSchema(ctx, "Schuljahr", field, creatorID)
+	require.NoError(t, err)
+	_, err = svc.CreateSchema(ctx, "Ferien", field, creatorID)
+	require.NoError(t, err)
+
+	_, err = svc.RenameSchema(ctx, a.ID, "Ferien")
+	require.ErrorIs(t, err, enrollmentService.ErrFormSchemaNameExists,
+		"renaming onto an existing schema name must be refused, not split the lineage")
+}
+
+func TestFormSchemaService_RenameSchema_SameNameIsNoOp(t *testing.T) {
+	_, svc, creatorID, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
+
+	field := []enrollmentModels.FormField{
+		{Key: "allergies", Label: "Allergien", Type: enrollmentModels.FormFieldText, SortOrder: 0},
+	}
+	created, err := svc.CreateSchema(ctx, "Schuljahr", field, creatorID)
+	require.NoError(t, err)
+
+	// Renaming to the unchanged name must not trip the collision check
+	// against the schema's own rows.
+	renamed, err := svc.RenameSchema(ctx, created.ID, "Schuljahr")
+	require.NoError(t, err)
+	assert.Equal(t, "Schuljahr", renamed.Name)
+}
+
+func TestFormSchemaService_RenameSchema_RejectsEmptyName(t *testing.T) {
+	_, svc, creatorID, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
+
+	created, err := svc.CreateSchema(ctx, "Schuljahr", []enrollmentModels.FormField{
+		{Key: "allergies", Label: "Allergien", Type: enrollmentModels.FormFieldText, SortOrder: 0},
+	}, creatorID)
+	require.NoError(t, err)
+
+	_, err = svc.RenameSchema(ctx, created.ID, "   ")
+	require.Error(t, err, "a blank name must be rejected")
+}
+
+func TestFormSchemaService_RenameSchema_RejectsNonPositiveID(t *testing.T) {
+	_, svc, _, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
+
+	_, err := svc.RenameSchema(ctx, 0, "Egal")
+	require.ErrorIs(t, err, enrollmentService.ErrFormSchemaNotFound,
+		"a non-positive id can never identify a schema")
+}
+
+func TestFormSchemaService_RenameSchema_MissingSchemaReturnsNotFound(t *testing.T) {
+	_, svc, _, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
+
+	// No row carries this id, so FindByID returns sql.ErrNoRows wrapped in a
+	// DatabaseError; the service must map that to the typed not-found sentinel.
+	_, err := svc.RenameSchema(ctx, 999999999, "Egal")
+	require.ErrorIs(t, err, enrollmentService.ErrFormSchemaNotFound)
+}
+
+// newSchemaServiceWithRepo builds a service around an arbitrary repo so a
+// test can inject failures into a single repository method. Mirrors the
+// minimal config setupSchemaTest uses (RenameSchema only touches s.repo).
+func newSchemaServiceWithRepo(repo enrollmentModels.FormSchemaRepository) enrollmentService.FormSchemaService {
+	return enrollmentService.NewFormSchemaService(enrollmentService.FormSchemaServiceConfig{
+		Repo:   repo,
+		Logger: slog.Default(),
+	})
+}
+
+// existsCheckFailsRepo delegates to a real repo (so FindByID returns the
+// source row) but fails the name-existence probe, exercising RenameSchema's
+// "check existing name" error branch.
+type existsCheckFailsRepo struct {
+	enrollmentModels.FormSchemaRepository
+}
+
+func (existsCheckFailsRepo) ExistsByName(context.Context, string) (bool, error) {
+	return false, errors.New("exists probe boom")
+}
+
+// renameExecFailsRepo reports no collision but fails the actual rename with a
+// plain (non-23505) error, exercising the generic rename error branch. The
+// 23505 race fallback needs a real concurrent unique-violation and is left to
+// the repository-level tests.
+type renameExecFailsRepo struct {
+	enrollmentModels.FormSchemaRepository
+}
+
+func (renameExecFailsRepo) ExistsByName(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func (renameExecFailsRepo) RenameByName(context.Context, string, string) error {
+	return errors.New("rename exec boom")
+}
+
+func TestFormSchemaService_RenameSchema_LoadErrorIsServerFault(t *testing.T) {
+	_, _, _, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
+
+	// failingSchemaRepo (decision_export_integration_test.go) makes FindByID
+	// fail with a non-ErrNoRows error — a transient read fault, not a 404.
+	svc := newSchemaServiceWithRepo(failingSchemaRepo{})
+	_, err := svc.RenameSchema(ctx, 42, "Egal")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, enrollmentService.ErrFormSchemaNotFound,
+		"a read fault must not be flattened into not-found")
+	assert.Contains(t, err.Error(), "load source schema")
+}
+
+func TestFormSchemaService_RenameSchema_ExistsCheckErrorPropagates(t *testing.T) {
+	db, svc, creatorID, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
+
+	created, err := svc.CreateSchema(ctx, "Schuljahr", []enrollmentModels.FormField{
+		{Key: "allergies", Label: "Allergien", Type: enrollmentModels.FormFieldText, SortOrder: 0},
+	}, creatorID)
+	require.NoError(t, err)
+
+	wrapped := newSchemaServiceWithRepo(existsCheckFailsRepo{repositories.NewFactory(db).FormSchema})
+	_, err = wrapped.RenameSchema(ctx, created.ID, "Ferien")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check existing name")
+}
+
+func TestFormSchemaService_RenameSchema_RenameExecErrorPropagates(t *testing.T) {
+	db, svc, creatorID, tenantID := setupSchemaTest(t)
+	ctx := testpkg.TenantContext(tenantID)
+
+	created, err := svc.CreateSchema(ctx, "Schuljahr", []enrollmentModels.FormField{
+		{Key: "allergies", Label: "Allergien", Type: enrollmentModels.FormFieldText, SortOrder: 0},
+	}, creatorID)
+	require.NoError(t, err)
+
+	wrapped := newSchemaServiceWithRepo(renameExecFailsRepo{repositories.NewFactory(db).FormSchema})
+	_, err = wrapped.RenameSchema(ctx, created.ID, "Ferien")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, enrollmentService.ErrFormSchemaNameExists,
+		"a plain rename failure is not a name collision")
+	assert.Contains(t, err.Error(), "rename schema")
+}

--- a/backend/services/enrollment/form_schema_service_test.go
+++ b/backend/services/enrollment/form_schema_service_test.go
@@ -3,12 +3,15 @@ package enrollment_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"sync"
 	"testing"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
 	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -323,4 +326,123 @@ func TestFormSchemaService_RenameSchema_RenameExecErrorPropagates(t *testing.T) 
 	require.NotErrorIs(t, err, enrollmentService.ErrFormSchemaNameExists,
 		"a plain rename failure is not a name collision")
 	assert.Contains(t, err.Error(), "rename schema")
+}
+
+// TestFormSchemaService_RenameAndPublishConcurrently_NeverSplitsLineage drives
+// a rename and a version-publish at the SAME id concurrently, each in its own
+// tenant transaction, many times. The per-lineage advisory lock must serialize
+// them: whichever runs first, the other sees the result, so every version row
+// always ends up under one shared name. Without the lock the publish can read
+// the pre-rename name and insert a new version under it while the rename moves
+// the existing rows — splitting the lineage across two names.
+func TestFormSchemaService_RenameAndPublishConcurrently_NeverSplitsLineage(t *testing.T) {
+	db, svc, creatorID, tenantID := setupSchemaTest(t)
+
+	field := []enrollmentModels.FormField{
+		{Key: "allergies", Label: "Allergien", Type: enrollmentModels.FormFieldText, SortOrder: 0},
+	}
+
+	// Seed a single-version lineage. lineageID is any version's id — it
+	// survives every publish (versions are never deleted) and every rename
+	// (rename keeps row ids), so both operations can reference it forever.
+	var lineageID int64
+	require.NoError(t, tenant.WithTenantTx(context.Background(), db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		created, err := svc.CreateSchema(ctx, "Konzert", field, creatorID)
+		if err != nil {
+			return err
+		}
+		lineageID = created.ID
+		return nil
+	}))
+
+	for i := 0; i < 15; i++ {
+		target := fmt.Sprintf("Konzert-%d", i)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		var renameErr, publishErr error
+		go func() {
+			defer wg.Done()
+			renameErr = tenant.WithTenantTx(context.Background(), db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+				_, err := svc.RenameSchema(ctx, lineageID, target)
+				return err
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			publishErr = tenant.WithTenantTx(context.Background(), db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+				_, err := svc.UpdateSchema(ctx, lineageID, field, creatorID)
+				return err
+			})
+		}()
+		wg.Wait()
+		require.NoError(t, renameErr, "iteration %d: rename", i)
+		require.NoError(t, publishErr, "iteration %d: publish", i)
+
+		names := make(map[string]struct{})
+		require.NoError(t, tenant.WithTenantTx(context.Background(), db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+			versions, err := svc.ListVersions(ctx)
+			if err != nil {
+				return err
+			}
+			for _, v := range versions {
+				names[v.Name] = struct{}{}
+			}
+			return nil
+		}))
+		require.Len(t, names, 1, "iteration %d: lineage split across names %v", i, names)
+	}
+}
+
+// TestFormSchemaService_RenameThenFailedPublish_RollsBackRename proves the
+// combined "rename + edit" save is atomic at the database level: the rename
+// and the version-publish ride in ONE tenant transaction (exactly as the
+// updateSchema handler wires them), so a publish failure rolls the rename
+// back. Without the shared transaction the rename would commit on its own and
+// leave a "renamed but content unchanged" lineage — the partial-save bug this
+// guards against. The publish is made to fail deterministically with a
+// reserved core-field key (same rejection as
+// TestFormSchemaService_PublishVersion_RejectsCoreFieldKey).
+func TestFormSchemaService_RenameThenFailedPublish_RollsBackRename(t *testing.T) {
+	db, svc, creatorID, tenantID := setupSchemaTest(t)
+
+	field := []enrollmentModels.FormField{
+		{Key: "allergies", Label: "Allergien", Type: enrollmentModels.FormFieldText, SortOrder: 0},
+	}
+
+	var lineageID int64
+	require.NoError(t, tenant.WithTenantTx(context.Background(), db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		created, err := svc.CreateSchema(ctx, "Sommerfest", field, creatorID)
+		if err != nil {
+			return err
+		}
+		lineageID = created.ID
+		return nil
+	}))
+
+	// One transaction, mirroring updateSchema's runInTenantTx: rename succeeds,
+	// then the publish fails on a reserved core key. The closure returns that
+	// error, so WithTenantTx rolls the whole transaction back.
+	txErr := tenant.WithTenantTx(context.Background(), db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		if _, err := svc.RenameSchema(ctx, lineageID, "Herbstfest"); err != nil {
+			return err
+		}
+		_, err := svc.UpdateSchema(ctx, lineageID, []enrollmentModels.FormField{
+			{Key: "guardian_email", Label: "Email", Type: enrollmentModels.FormFieldText, SortOrder: 0},
+		}, creatorID)
+		return err
+	})
+	require.Error(t, txErr, "the reserved-key publish must fail and abort the transaction")
+
+	// Neither change committed: the name is still the original and no new
+	// version row was inserted.
+	require.NoError(t, tenant.WithTenantTx(context.Background(), db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		versions, err := svc.ListVersions(ctx)
+		if err != nil {
+			return err
+		}
+		require.Len(t, versions, 1, "a rolled-back publish must not leave a new version")
+		assert.Equal(t, "Sommerfest", versions[0].Name,
+			"the rename must roll back when the publish in the same transaction fails")
+		return nil
+	}))
 }

--- a/frontend/src/app/api/enrollment/schema/[id]/route.test.ts
+++ b/frontend/src/app/api/enrollment/schema/[id]/route.test.ts
@@ -13,7 +13,7 @@ vi.mock("~/lib/server-api-url", () => ({
   getServerApiUrl: () => "http://backend.test",
 }));
 
-const { PUT } = await import("./route");
+const { PUT, PATCH } = await import("./route");
 
 function putRequest(body: unknown): NextRequest {
   return new NextRequest(
@@ -92,5 +92,68 @@ describe("PUT /api/enrollment/schema/[id]", () => {
       unknown
     >;
     expect("legal_blocks" in forwarded).toBe(false);
+  });
+});
+
+describe("PATCH /api/enrollment/schema/[id]", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    mockAuth.mockReset();
+    mockAuth.mockResolvedValue({
+      user: { id: "1", token: "test-token" },
+      expires: "2099-01-01",
+    });
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: {} }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  function patchRequest(body: unknown): NextRequest {
+    return new NextRequest(
+      new URL("http://localhost:3000/api/enrollment/schema/7"),
+      {
+        method: "PATCH",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  it("forwards the rename to the backend with PATCH + the name", async () => {
+    await PATCH(patchRequest({ name: "Ferienprogramm" }), context());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://backend.test/api/enrollment/schema/7");
+    expect(init.method).toBe("PATCH");
+    const forwarded = JSON.parse(init.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(forwarded.name).toBe("Ferienprogramm");
+  });
+
+  it("rejects an unauthenticated request with 401", async () => {
+    mockAuth.mockResolvedValue(null);
+    const response = await PATCH(patchRequest({ name: "X" }), context());
+    expect(response.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing/blank id with 400 before any backend call", async () => {
+    const response = await PATCH(patchRequest({ name: "X" }), {
+      params: Promise.resolve({ id: "" }),
+    });
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the upstream backend call throws", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+    const response = await PATCH(patchRequest({ name: "X" }), context());
+    expect(response.status).toBe(500);
   });
 });

--- a/frontend/src/app/api/enrollment/schema/[id]/route.test.ts
+++ b/frontend/src/app/api/enrollment/schema/[id]/route.test.ts
@@ -93,6 +93,31 @@ describe("PUT /api/enrollment/schema/[id]", () => {
     >;
     expect("legal_blocks" in forwarded).toBe(false);
   });
+
+  it("forwards name for a combined rename + edit save", async () => {
+    // The name rides along on the PUT so the backend renames + publishes in
+    // one transaction; the proxy must not drop it.
+    await PUT(putRequest({ name: "Ferienprogramm", fields: [] }), context());
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const forwarded = JSON.parse(init.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(forwarded.name).toBe("Ferienprogramm");
+  });
+
+  it("omits name on a content-only save", async () => {
+    // Absent name = pure content edit; the backend keeps the lineage name.
+    await PUT(putRequest({ fields: [] }), context());
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const forwarded = JSON.parse(init.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect("name" in forwarded).toBe(false);
+  });
 });
 
 describe("PATCH /api/enrollment/schema/[id]", () => {

--- a/frontend/src/app/api/enrollment/schema/[id]/route.ts
+++ b/frontend/src/app/api/enrollment/schema/[id]/route.ts
@@ -111,6 +111,48 @@ export async function PUT(
   }
 }
 
+export async function PATCH(
+  request: NextRequest,
+  context: {
+    params: Promise<Record<string, string | string[] | undefined>>;
+  },
+) {
+  const id = await resolveId(context);
+  if (!id) {
+    return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+  }
+  const authHeader = await bearerHeader();
+  if (!authHeader) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+  try {
+    const body = (await request.json()) as { name?: unknown };
+    const response = await fetch(
+      `${getServerApiUrl()}/api/enrollment/schema/${id}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: authHeader,
+        },
+        // Forward the name verbatim; the backend is the single source of
+        // truth for validation (it rejects a blank name with 400).
+        body: JSON.stringify({ name: body.name }),
+      },
+    );
+    const payload = await response.json().catch(() => ({}));
+    return NextResponse.json(payload, { status: response.status });
+  } catch (error) {
+    logger.error("schema_rename_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+}
+
 export async function DELETE(
   _request: NextRequest,
   context: {

--- a/frontend/src/app/api/enrollment/schema/[id]/route.ts
+++ b/frontend/src/app/api/enrollment/schema/[id]/route.ts
@@ -70,6 +70,7 @@ export async function PUT(
   }
   try {
     const body = (await request.json()) as {
+      name?: unknown;
       fields?: unknown;
       core_requirements?: unknown;
       legal_blocks?: unknown;
@@ -86,6 +87,9 @@ export async function PUT(
         // "absent = preserve existing" semantics still hold; sending it
         // makes the admin's guardian-phone-required toggle stick.
         body: JSON.stringify({
+          // name is present only for a combined "rename + edit" save; the
+          // backend renames the lineage and publishes in one transaction.
+          ...(body.name === undefined ? {} : { name: body.name }),
           fields: body.fields ?? [],
           ...(body.core_requirements === undefined
             ? {}

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -626,6 +626,8 @@ describe("EnrollmentFormEditor", () => {
         expect.arrayContaining([expect.objectContaining({ type: "textarea" })]),
         {},
         defaultLegalBlocksForSave,
+        // Content-only edit: no rename name rides along on the save.
+        undefined,
       );
     });
 
@@ -747,10 +749,9 @@ describe("EnrollmentFormEditor", () => {
     expect(mocks.updateSchema).not.toHaveBeenCalled();
   });
 
-  it("renames AND publishes a version when name and content both change", async () => {
+  it("renames AND publishes in one atomic request when name and content both change", async () => {
     mocks.listSchemas.mockResolvedValue([schema()]);
     mocks.listPhases.mockResolvedValue([]);
-    mocks.renameSchema.mockResolvedValue(schema({ name: "Ferienprogramm" }));
     mocks.updateSchema.mockResolvedValue(schema({ name: "Ferienprogramm" }));
 
     render(<EnrollmentFormEditor />);
@@ -766,8 +767,10 @@ describe("EnrollmentFormEditor", () => {
       await screen.findByRole("menuitem", { name: "Bearbeiten" }),
     );
 
-    // Change the name AND a base-field requirement: the name-only fast path
-    // must not swallow the content change, so both requests fire.
+    // Change the name AND a base-field requirement: the new name rides along
+    // on the single updateSchema request so the backend renames + publishes in
+    // one transaction. No separate rename round-trip the publish could leave
+    // half-applied on failure.
     fireEvent.change(
       await screen.findByPlaceholderText("z. B. Ferienbetreuung Sommer 2026"),
       { target: { value: "Ferienprogramm" } },
@@ -782,12 +785,60 @@ describe("EnrollmentFormEditor", () => {
     );
 
     await waitFor(() => {
-      expect(mocks.renameSchema).toHaveBeenCalledWith(
+      expect(mocks.updateSchema).toHaveBeenCalledWith(
         "schema-1",
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
         "Ferienprogramm",
       );
     });
-    expect(mocks.updateSchema).toHaveBeenCalled();
+    // The combined save must NOT fire a separate rename request — that is the
+    // non-atomic path the backend transaction replaced.
+    expect(mocks.renameSchema).not.toHaveBeenCalled();
+  });
+
+  it("does not rename separately when the combined save fails", async () => {
+    // Regression guard for the partial-save bug: a failed publish must not
+    // leave the lineage renamed. Because the rename now rides inside the
+    // single updateSchema transaction, the editor never calls renameSchema on
+    // its own, so a rejected updateSchema commits nothing.
+    mocks.listSchemas.mockResolvedValue([schema()]);
+    mocks.listPhases.mockResolvedValue([]);
+    mocks.updateSchema.mockRejectedValue(
+      new Error("Formularvorlage konnte nicht gespeichert werden"),
+    );
+
+    render(<EnrollmentFormEditor />);
+
+    expect(
+      await screen.findByText("Anmeldeformulare verwalten"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Aktionen für Regelformular" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Bearbeiten" }),
+    );
+
+    fireEvent.change(
+      await screen.findByPlaceholderText("z. B. Ferienbetreuung Sommer 2026"),
+      { target: { value: "Ferienprogramm" } },
+    );
+    fireEvent.click(
+      await screen.findByRole("switch", {
+        name: "Telefonnummer verpflichtend",
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Änderungen speichern" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.updateSchema).toHaveBeenCalled();
+    });
+    expect(mocks.renameSchema).not.toHaveBeenCalled();
   });
 
   it("does not rename when the builder name is left unchanged", async () => {

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   listCareOfferings: vi.fn(),
   listPhases: vi.fn(),
   listSchemas: vi.fn(),
+  renameSchema: vi.fn(),
   updateCareOffering: vi.fn(),
   updatePhase: vi.fn(),
   updateSchema: vi.fn(),
@@ -95,6 +96,7 @@ vi.mock("~/lib/enrollment-form-schema-api", async (importOriginal) => {
     deleteSchema: mocks.deleteSchema,
     fetchPublicLegalTexts: mocks.fetchPublicLegalTexts,
     listSchemas: mocks.listSchemas,
+    renameSchema: mocks.renameSchema,
     updateSchema: mocks.updateSchema,
   };
 });
@@ -241,6 +243,7 @@ beforeEach(() => {
   mocks.listCareOfferings.mockReset();
   mocks.listPhases.mockReset();
   mocks.listSchemas.mockReset();
+  mocks.renameSchema.mockReset();
   mocks.updateCareOffering.mockReset();
   mocks.updatePhase.mockReset();
   mocks.updateSchema.mockReset();
@@ -638,6 +641,188 @@ describe("EnrollmentFormEditor", () => {
     await waitFor(() => {
       expect(mocks.deleteSchema).toHaveBeenCalledWith("schema-1");
     });
+  });
+
+  it("renames a schema via the actions menu", async () => {
+    mocks.listSchemas.mockResolvedValue([schema()]);
+    mocks.listPhases.mockResolvedValue([]);
+    mocks.renameSchema.mockResolvedValue(schema({ name: "Ferienprogramm" }));
+
+    render(<EnrollmentFormEditor />);
+
+    expect(
+      await screen.findByText("Anmeldeformulare verwalten"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Aktionen für Regelformular" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Umbenennen" }),
+    );
+
+    const input = await screen.findByLabelText("Name");
+    fireEvent.change(input, { target: { value: "  Ferienprogramm  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Speichern" }));
+
+    await waitFor(() => {
+      // The trimmed name reaches the API; the lineage id (latest version)
+      // identifies which schema to rename.
+      expect(mocks.renameSchema).toHaveBeenCalledWith(
+        "schema-1",
+        "Ferienprogramm",
+      );
+    });
+  });
+
+  it("keeps the rename dialog open and shows the error when the name is taken", async () => {
+    mocks.listSchemas.mockResolvedValue([schema()]);
+    mocks.listPhases.mockResolvedValue([]);
+    mocks.renameSchema.mockRejectedValue(
+      new Error("Es gibt bereits ein Formular mit diesem Namen."),
+    );
+
+    render(<EnrollmentFormEditor />);
+
+    expect(
+      await screen.findByText("Anmeldeformulare verwalten"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Aktionen für Regelformular" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Umbenennen" }),
+    );
+
+    fireEvent.change(await screen.findByLabelText("Name"), {
+      target: { value: "Ferienprogramm" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Speichern" }));
+
+    expect(
+      await screen.findByText("Es gibt bereits ein Formular mit diesem Namen."),
+    ).toBeInTheDocument();
+    // Dialog stays open so the admin can correct the name.
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+  });
+
+  it("renames via the builder name field when saving an edited template", async () => {
+    mocks.listSchemas.mockResolvedValue([schema()]);
+    mocks.listPhases.mockResolvedValue([]);
+    mocks.renameSchema.mockResolvedValue(schema({ name: "Ferienprogramm" }));
+    mocks.updateSchema.mockResolvedValue(schema({ name: "Ferienprogramm" }));
+
+    render(<EnrollmentFormEditor />);
+
+    expect(
+      await screen.findByText("Anmeldeformulare verwalten"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Aktionen für Regelformular" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Bearbeiten" }),
+    );
+
+    // The name input is now editable in the builder header (not only on
+    // create). Changing ONLY the name and saving renames the lineage in
+    // place; it must NOT publish a redundant identical version, matching
+    // the standalone "Umbenennen" dialog's semantics.
+    fireEvent.change(
+      await screen.findByPlaceholderText("z. B. Ferienbetreuung Sommer 2026"),
+      { target: { value: "Ferienprogramm" } },
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Änderungen speichern" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.renameSchema).toHaveBeenCalledWith(
+        "schema-1",
+        "Ferienprogramm",
+      );
+    });
+    expect(mocks.updateSchema).not.toHaveBeenCalled();
+  });
+
+  it("renames AND publishes a version when name and content both change", async () => {
+    mocks.listSchemas.mockResolvedValue([schema()]);
+    mocks.listPhases.mockResolvedValue([]);
+    mocks.renameSchema.mockResolvedValue(schema({ name: "Ferienprogramm" }));
+    mocks.updateSchema.mockResolvedValue(schema({ name: "Ferienprogramm" }));
+
+    render(<EnrollmentFormEditor />);
+
+    expect(
+      await screen.findByText("Anmeldeformulare verwalten"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Aktionen für Regelformular" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Bearbeiten" }),
+    );
+
+    // Change the name AND a base-field requirement: the name-only fast path
+    // must not swallow the content change, so both requests fire.
+    fireEvent.change(
+      await screen.findByPlaceholderText("z. B. Ferienbetreuung Sommer 2026"),
+      { target: { value: "Ferienprogramm" } },
+    );
+    fireEvent.click(
+      await screen.findByRole("switch", {
+        name: "Telefonnummer verpflichtend",
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Änderungen speichern" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.renameSchema).toHaveBeenCalledWith(
+        "schema-1",
+        "Ferienprogramm",
+      );
+    });
+    expect(mocks.updateSchema).toHaveBeenCalled();
+  });
+
+  it("does not rename when the builder name is left unchanged", async () => {
+    mocks.listSchemas.mockResolvedValue([schema()]);
+    mocks.listPhases.mockResolvedValue([]);
+    mocks.updateSchema.mockResolvedValue(schema());
+
+    render(<EnrollmentFormEditor />);
+
+    expect(
+      await screen.findByText("Anmeldeformulare verwalten"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Aktionen für Regelformular" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Bearbeiten" }),
+    );
+
+    // Toggle a base-field requirement so there is something to save without
+    // touching the name.
+    fireEvent.click(
+      await screen.findByRole("switch", {
+        name: "Telefonnummer verpflichtend",
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Änderungen speichern" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.updateSchema).toHaveBeenCalled();
+    });
+    expect(mocks.renameSchema).not.toHaveBeenCalled();
   });
 
   it("activates a standard legal block when an admin enters legal text", async () => {

--- a/frontend/src/components/enrollment/enrollment-form-editor.tsx
+++ b/frontend/src/components/enrollment/enrollment-form-editor.tsx
@@ -27,10 +27,14 @@ import {
   Pencil,
   Plus,
   ShieldCheck,
+  TextCursorInput,
   Trash2,
 } from "lucide-react";
 import { useToast } from "~/contexts/ToastContext";
 import { ConfirmationModal } from "~/components/ui/modal";
+import { FormModal } from "~/components/ui/form-modal";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { BooleanField } from "~/components/settings/fields/boolean-field";
 import {
@@ -41,6 +45,7 @@ import {
   fetchPublicLegalTexts,
   latestSchemasByName,
   listSchemas,
+  renameSchema,
   updateSchema,
   RESERVED_TARGETS,
   type ConditionOperator,
@@ -296,6 +301,17 @@ const CORE_FIELDS: ReadonlyArray<CoreField> = [
   },
 ];
 
+// True when newName is a non-empty rename of schema's current name. The
+// single source of truth for "is this a rename?" shared by both entry
+// points: the builder's inline name field and the standalone rename dialog.
+function isRenameOf(
+  schema: FormSchema | null | undefined,
+  newName: string,
+): boolean {
+  const trimmed = newName.trim();
+  return Boolean(schema) && trimmed.length > 0 && trimmed !== schema?.name;
+}
+
 export function EnrollmentFormEditor() {
   const toast = useToast();
   const tenantSlug = useTenantSlugSafe();
@@ -321,6 +337,7 @@ export function EnrollmentFormEditor() {
     useState<PendingNavigation | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<FormSchema | null>(null);
   const [deletingSchemaId, setDeletingSchemaId] = useState<string | null>(null);
+  const [renameTarget, setRenameTarget] = useState<FormSchema | null>(null);
 
   const latestByName = useMemo(
     () => latestSchemasByName(allSchemas),
@@ -402,6 +419,25 @@ export function EnrollmentFormEditor() {
     } finally {
       setDeletingSchemaId(null);
     }
+  };
+
+  const requestRenameSchema = (schema: FormSchema) => {
+    setRenameTarget(schema);
+  };
+
+  // Rename touches every version row of the lineage in one PATCH; it
+  // does NOT publish a new version. Throws on failure so the dialog can
+  // surface the backend message (e.g. a name already in use).
+  const confirmRenameSchema = async (newName: string) => {
+    if (!renameTarget) return;
+    const updated = await renameSchema(renameTarget.id, newName);
+    await loadAll();
+    // Keep the builder's name field in sync if this template is open.
+    if (selectedKey === renameTarget.id) {
+      setName(updated.name);
+    }
+    toast.success(`Vorlage in „${updated.name}" umbenannt.`);
+    setRenameTarget(null);
   };
 
   const startNew = () => {
@@ -508,6 +544,15 @@ export function EnrollmentFormEditor() {
     () => legalBlocksSignature(standardLegalBlocks),
     [standardLegalBlocks],
   );
+  // Split the edit-mode dirty check into its two independent axes so the
+  // save path can tell a pure rename (name only) from a content change.
+  // A name-only edit must rename in place without publishing a redundant
+  // new version (which is what updateSchema does).
+  const editNameChanged = name.trim() !== (currentSchema?.name ?? "");
+  const editContentChanged =
+    currentFieldSignature !== savedFieldSignature ||
+    savedCoreRequirementSignature !== currentCoreRequirementSignature ||
+    savedLegalBlocksSignature !== currentLegalBlocksSignature;
   const hasUnsavedChanges =
     mode === "builder" &&
     (isCreating
@@ -515,13 +560,10 @@ export function EnrollmentFormEditor() {
         fields.length > 0 ||
         currentCoreRequirementSignature !== "{}" ||
         currentLegalBlocksSignature !== standardLegalBlocksSignature
-      : currentFieldSignature !== savedFieldSignature ||
-        savedCoreRequirementSignature !== currentCoreRequirementSignature ||
-        savedLegalBlocksSignature !== currentLegalBlocksSignature);
+      : editNameChanged || editContentChanged);
   const saveBlockedMessage = getSchemaDraftValidationMessage({
     fields,
     legalBlocks,
-    isCreating,
     name,
   });
 
@@ -534,7 +576,6 @@ export function EnrollmentFormEditor() {
       const validationMessage = getSchemaDraftValidationMessage({
         fields,
         legalBlocks,
-        isCreating,
         name,
       });
       if (validationMessage) {
@@ -553,7 +594,23 @@ export function EnrollmentFormEditor() {
           coreRequirements,
           legalBlocksForSave,
         );
+      } else if (isRenameOf(currentSchema, name) && !editContentChanged) {
+        // Name-only change: rename the lineage in place. We deliberately
+        // skip updateSchema here so a pure rename doesn't publish a
+        // redundant identical version (and re-point bound phases). This
+        // matches the standalone "Umbenennen" dialog's semantics.
+        result = await renameSchema(selectedKey, name.trim());
       } else {
+        // Rename and field-publish are two requests, not one transaction.
+        // Rename runs first because that order is retry-safe: if the rename
+        // throws (e.g. name already taken) we never publish, and if the
+        // publish fails after a successful rename, a retry re-runs the
+        // rename as a no-op and publishes exactly one new version. The
+        // reverse order would publish a redundant version on every retry.
+        // The new version is therefore always born under the new name.
+        if (isRenameOf(currentSchema, name)) {
+          await renameSchema(selectedKey, name.trim());
+        }
         result = await updateSchema(
           selectedKey,
           fieldsForSave,
@@ -677,6 +734,7 @@ export function EnrollmentFormEditor() {
           onCreate={startNew}
           onEdit={editSchema}
           onPreview={previewSchema}
+          onRename={requestRenameSchema}
           onDelete={requestRemoveSchema}
           error={error}
         />
@@ -685,6 +743,11 @@ export function EnrollmentFormEditor() {
           deleting={deletingSchemaId === deleteTarget?.id}
           onClose={() => setDeleteTarget(null)}
           onConfirm={confirmRemoveSchema}
+        />
+        <RenameSchemaDialog
+          schema={renameTarget}
+          onClose={() => setRenameTarget(null)}
+          onConfirm={confirmRenameSchema}
         />
       </>
     );
@@ -879,6 +942,7 @@ function EnrollmentFormsOverview({
   onCreate,
   onEdit,
   onPreview,
+  onRename,
   onDelete,
   error,
 }: Readonly<{
@@ -887,6 +951,7 @@ function EnrollmentFormsOverview({
   onCreate: () => void;
   onEdit: (schema: FormSchema) => void;
   onPreview: (schema: FormSchema) => void;
+  onRename: (schema: FormSchema) => void;
   onDelete: (schema: FormSchema) => void;
   error: string | null;
 }>) {
@@ -948,6 +1013,7 @@ function EnrollmentFormsOverview({
                 phases={phases}
                 onEdit={onEdit}
                 onPreview={onPreview}
+                onRename={onRename}
                 onDelete={onDelete}
               />
             </section>
@@ -970,12 +1036,14 @@ function TemplateOverviewList({
   phases,
   onEdit,
   onPreview,
+  onRename,
   onDelete,
 }: Readonly<{
   templates: FormSchema[];
   phases: Phase[];
   onEdit: (schema: FormSchema) => void;
   onPreview: (schema: FormSchema) => void;
+  onRename: (schema: FormSchema) => void;
   onDelete: (schema: FormSchema) => void;
 }>) {
   return (
@@ -988,6 +1056,7 @@ function TemplateOverviewList({
             schema={schema}
             onEdit={() => onEdit(schema)}
             onPreview={() => onPreview(schema)}
+            onRename={() => onRename(schema)}
             onDelete={() => onDelete(schema)}
             isAssigned={phases.some(
               (phase) => phase.form_schema_id === schema.id,
@@ -1042,12 +1111,14 @@ function TemplateOverviewRow({
   schema,
   onEdit,
   onPreview,
+  onRename,
   onDelete,
   isAssigned,
 }: Readonly<{
   schema: FormSchema;
   onEdit: () => void;
   onPreview: () => void;
+  onRename: () => void;
   onDelete: () => void;
   isAssigned: boolean;
 }>) {
@@ -1104,6 +1175,11 @@ function TemplateOverviewRow({
               label: "Bearbeiten",
               icon: <Pencil className="h-4 w-4" aria-hidden />,
               onClick: onEdit,
+            },
+            {
+              label: "Umbenennen",
+              icon: <TextCursorInput className="h-4 w-4" aria-hidden />,
+              onClick: onRename,
             },
             {
               label: "Löschen",
@@ -1590,6 +1666,103 @@ function DeleteSchemaDialog({
   );
 }
 
+function RenameSchemaDialog({
+  schema,
+  onClose,
+  onConfirm,
+}: Readonly<{
+  schema: FormSchema | null;
+  onClose: () => void;
+  onConfirm: (newName: string) => Promise<void>;
+}>) {
+  const [value, setValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset the field to the current name each time the dialog opens for a
+  // schema so the admin edits from the existing value.
+  useEffect(() => {
+    if (schema) {
+      setValue(schema.name);
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [schema]);
+
+  const isOpen = schema !== null;
+  const trimmed = value.trim();
+  const canSubmit = isRenameOf(schema, value) && !submitting;
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onConfirm(trimmed);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Umbenennen fehlgeschlagen",
+      );
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <FormModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Formular umbenennen"
+      size="sm"
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="md"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Abbrechen
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="md"
+            onClick={() => void submit()}
+            disabled={!canSubmit}
+            isLoading={submitting}
+          >
+            Speichern
+          </Button>
+        </div>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submit();
+        }}
+        className="space-y-3"
+      >
+        <Input
+          name="schema-name"
+          label="Name"
+          type="text"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          placeholder="z. B. Ferienbetreuung Sommer 2026"
+          error={error ?? undefined}
+          autoFocus
+        />
+        <p className="text-xs leading-5 text-gray-500">
+          Der neue Name gilt für alle Versionen dieser Vorlage. Bereits
+          abgeschickte Anmeldungen bleiben unverändert.
+        </p>
+      </form>
+    </FormModal>
+  );
+}
+
 function UnsavedChangesDialog({
   pendingNavigation,
   saving,
@@ -1774,11 +1947,11 @@ function BuilderTemplateSummary({
           <p className="mt-1 max-w-2xl text-sm text-gray-600">
             {isCreating
               ? "Gib der Vorlage einen eindeutigen Namen. Danach kannst du Pflichtangaben und Zusatzfragen festlegen."
-              : "Beim Speichern bleiben bestehende Anmeldungen nachvollziehbar."}
+              : "Der Name lässt sich hier ändern und gilt für alle Versionen. Bestehende Anmeldungen bleiben nachvollziehbar."}
           </p>
         </div>
 
-        {isCreating ? (
+        <div className="space-y-3">
           <label className="block">
             <span className="text-xs font-medium text-gray-700">
               Name der Vorlage
@@ -1792,19 +1965,20 @@ function BuilderTemplateSummary({
               className="mt-1 h-10 w-full rounded-lg border border-gray-200 px-3 text-sm shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none disabled:bg-gray-100 disabled:text-gray-600"
             />
           </label>
-        ) : (
-          <div className="flex flex-wrap content-start gap-2 text-xs text-gray-600">
-            <span className="rounded-full bg-gray-100 px-2.5 py-1 font-medium text-gray-700">
-              {fields.length} Zusatzfragen
-            </span>
-            <span className="rounded-full bg-gray-100 px-2.5 py-1 font-medium text-gray-700">
-              {requiredCount} Pflicht-Zusatzfragen
-            </span>
-            <span className="rounded-full bg-gray-100 px-2.5 py-1 font-medium text-gray-700">
-              {childFieldCount} pro Kind
-            </span>
-          </div>
-        )}
+          {!isCreating ? (
+            <div className="flex flex-wrap content-start gap-2 text-xs text-gray-600">
+              <span className="rounded-full bg-gray-100 px-2.5 py-1 font-medium text-gray-700">
+                {fields.length} Zusatzfragen
+              </span>
+              <span className="rounded-full bg-gray-100 px-2.5 py-1 font-medium text-gray-700">
+                {requiredCount} Pflicht-Zusatzfragen
+              </span>
+              <span className="rounded-full bg-gray-100 px-2.5 py-1 font-medium text-gray-700">
+                {childFieldCount} pro Kind
+              </span>
+            </div>
+          ) : null}
+        </div>
       </div>
 
       {currentSchema ? (
@@ -3914,15 +4088,13 @@ function getRequiredHint(field: FormField): string {
 function getSchemaDraftValidationMessage({
   fields,
   legalBlocks,
-  isCreating,
   name,
 }: Readonly<{
   fields: FormField[];
   legalBlocks: FormLegalBlock[];
-  isCreating: boolean;
   name: string;
 }>): string | null {
-  if (isCreating && name.trim() === "") {
+  if (name.trim() === "") {
     return "Bitte gib zuerst einen Namen für die Vorlage ein.";
   }
 

--- a/frontend/src/components/enrollment/enrollment-form-editor.tsx
+++ b/frontend/src/components/enrollment/enrollment-form-editor.tsx
@@ -601,21 +601,21 @@ export function EnrollmentFormEditor() {
         // matches the standalone "Umbenennen" dialog's semantics.
         result = await renameSchema(selectedKey, name.trim());
       } else {
-        // Rename and field-publish are two requests, not one transaction.
-        // Rename runs first because that order is retry-safe: if the rename
-        // throws (e.g. name already taken) we never publish, and if the
-        // publish fails after a successful rename, a retry re-runs the
-        // rename as a no-op and publishes exactly one new version. The
-        // reverse order would publish a redundant version on every retry.
-        // The new version is therefore always born under the new name.
-        if (isRenameOf(currentSchema, name)) {
-          await renameSchema(selectedKey, name.trim());
-        }
+        // Combined "rename + edit" save: pass the new name to updateSchema so
+        // the backend renames the lineage AND publishes the new version in ONE
+        // transaction. A failed publish rolls the rename back, so there is no
+        // partial "renamed but content unchanged" state and the local baseline
+        // can never drift from the database. renameTo is undefined when only
+        // the content changed, leaving the lineage name untouched.
+        const renameTo = isRenameOf(currentSchema, name)
+          ? name.trim()
+          : undefined;
         result = await updateSchema(
           selectedKey,
           fieldsForSave,
           coreRequirements,
           legalBlocksForSave,
+          renameTo,
         );
       }
       const refreshed = await loadAll();

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -806,6 +806,7 @@ export const appChapters: readonly GuideChapter[] = [
         steps: [
           "`Anmeldeformulare` öffnen. Das `Basisformular` fragt Elternteil, Kind, Klassenstufe und das gewünschte Betreuungsangebot ab.",
           "Nur bei zusätzlichem Bedarf über `Neue Vorlage` eine eigene Formularvorlage mit Zusatzfragen anlegen. Bei `Erlaubte Heimwege` wählen Eltern pro Betreuungstag alle zulässigen Wege aus, zum Beispiel zu Fuß, Bus oder Abholung; mehrere Optionen pro Tag sind möglich.",
+          "Den Namen einer Vorlage änderst du entweder beim `Bearbeiten` direkt oben im Editor oder über das Aktionsmenü (`⋮`) -> `Umbenennen`; dort kannst du eine Vorlage auch `Löschen`. Der Name gilt für alle Versionen der Vorlage; bereits abgeschickte Anmeldungen bleiben unverändert.",
           "Im Abschnitt `Rechtstexte und Einwilligungen` legst du je Vorlage fest, welche Zustimmungen und Hinweise Eltern sehen: Die Standardblöcke kommen aus den Einstellungen, können je Vorlage per Schalter ein- oder ausgeblendet und über das Stift-Symbol abweichend bearbeitet werden. Über `Eigene Zustimmung hinzufügen` ergänzt du zusätzliche Einwilligungen, etwa für Ausflüge oder Schwimmbadbesuche.",
           "Mit `Vorschau` prüfen, wie das Formular für Eltern aussieht.",
           "Die Vorlage wirkt erst, wenn du sie in einer `Anmeldephase` als Formular auswählst.",

--- a/frontend/src/lib/enrollment-error-messages.ts
+++ b/frontend/src/lib/enrollment-error-messages.ts
@@ -34,6 +34,8 @@ const ENROLLMENT_CODE_MESSAGES: Record<string, string> = {
     "Diese Formularvorlage wird noch in einer Anmeldephase verwendet.",
   "enrollment.schema_has_requests":
     "Diese Formularvorlage wurde bereits für Anmeldungen verwendet und kann nicht gelöscht werden.",
+  "enrollment.schema_name_exists":
+    "Es gibt bereits ein Formular mit diesem Namen.",
   "rollover.source_not_found": "Die Quellphase wurde nicht gefunden.",
   "rollover.invalid_request":
     "Die Eingaben sind unvollständig oder ungültig. Bitte alle Pflichtfelder prüfen.",

--- a/frontend/src/lib/enrollment-form-schema-api.test.ts
+++ b/frontend/src/lib/enrollment-form-schema-api.test.ts
@@ -512,6 +512,42 @@ describe("updateSchema", () => {
     expect(seenURL).toContain("a%2Fb");
   });
 
+  it("includes name for a combined rename + edit save", async () => {
+    // Passing newName sends the name on the PUT so the backend renames the
+    // lineage and publishes in one transaction.
+    let seenBody = "";
+    mockFetch(async (_, init) => {
+      seenBody = (init?.body as string) ?? "";
+      return jsonResponse(
+        { data: mkSchema("1234", "Ferienprogramm", 3, "x") },
+        { status: 201 },
+      );
+    });
+    await updateSchema(
+      "1234",
+      [blankField(0)],
+      {},
+      undefined,
+      "Ferienprogramm",
+    );
+    expect(seenBody).toContain(`"name":"Ferienprogramm"`);
+    expect(seenBody).toContain(`"fields":[`);
+  });
+
+  it("translates the name-collision code to a German message", async () => {
+    // A combined save that collides on the new name comes back as the same
+    // 409 + code the standalone rename returns.
+    mockFetch(async () =>
+      jsonResponse(
+        { error: "name exists", code: "enrollment.schema_name_exists" },
+        { status: 409 },
+      ),
+    );
+    await expect(
+      updateSchema("1234", [], {}, undefined, "Schon vergeben"),
+    ).rejects.toThrow(/bereits ein Formular mit diesem Namen/);
+  });
+
   it("translates schema validation errors on non-OK", async () => {
     mockFetch(async () =>
       jsonResponse({ error: "invalid schema" }, { status: 400 }),

--- a/frontend/src/lib/enrollment-form-schema-api.test.ts
+++ b/frontend/src/lib/enrollment-form-schema-api.test.ts
@@ -12,6 +12,7 @@ import {
   fetchPublicLegalTexts,
   createSchema,
   updateSchema,
+  renameSchema,
   deleteSchema,
   type FormSchema,
   type FormField,
@@ -517,6 +518,63 @@ describe("updateSchema", () => {
     );
     await expect(updateSchema("1234", [])).rejects.toThrow(
       /Formularvorlage ist ungültig/,
+    );
+  });
+});
+
+// --- renameSchema ----------------------------------------------------
+
+describe("renameSchema", () => {
+  it("PATCHes only the name to the id endpoint", async () => {
+    let seenMethod = "";
+    let seenBody = "";
+    mockFetch(async (_, init) => {
+      seenMethod = init?.method ?? "";
+      seenBody = (init?.body as string) ?? "";
+      return jsonResponse({
+        data: mkSchema("1234", "Ferienprogramm", 3, "2026-04-01T12:00:00Z"),
+      });
+    });
+
+    const result = await renameSchema("1234", "Ferienprogramm");
+
+    expect(seenMethod).toBe("PATCH");
+    // A rename must never carry fields/legal_blocks — name only.
+    expect(JSON.parse(seenBody)).toEqual({ name: "Ferienprogramm" });
+    expect(result.name).toBe("Ferienprogramm");
+  });
+
+  it("URL-encodes the id", async () => {
+    let seenURL = "";
+    mockFetch(async (input) => {
+      seenURL = typeof input === "string" ? input : input.toString();
+      return jsonResponse({ data: mkSchema("1", "X", 1, "x") });
+    });
+    await renameSchema("a/b", "X");
+    expect(seenURL).toContain("a%2Fb");
+  });
+
+  it("translates the name-collision code to a German message", async () => {
+    // The backend returns 409 + enrollment.schema_name_exists; the admin
+    // must see why, not a generic failure.
+    mockFetch(async () =>
+      jsonResponse(
+        {
+          code: "enrollment.schema_name_exists",
+          error: "a form schema with this name already exists",
+        },
+        { status: 409 },
+      ),
+    );
+    await expect(renameSchema("1234", "Schon vergeben")).rejects.toThrow(
+      /bereits ein Formular mit diesem Namen/,
+    );
+  });
+
+  it("falls back to a generic message on an uncoded error", async () => {
+    mockFetch(async () => jsonResponse({}, { status: 500 }));
+    await expect(renameSchema("1234", "X")).rejects.toThrow(
+      /konnte nicht umbenannt werden/,
     );
   });
 });

--- a/frontend/src/lib/enrollment-form-schema-api.ts
+++ b/frontend/src/lib/enrollment-form-schema-api.ts
@@ -487,18 +487,27 @@ export async function createSchema(
  * name. Older versions stay in place for historical submissions, and
  * phases using an older version of this template are moved to the new
  * schema_id.
+ *
+ * Pass `newName` to rename the whole lineage AND publish the new version
+ * in ONE backend transaction (a combined "rename + edit" save). A failed
+ * publish rolls the rename back, so there is no partial "renamed but
+ * content unchanged" state. A 409 (`enrollment.schema_name_exists`) is
+ * raised when the new name already identifies a different schema.
  */
 export async function updateSchema(
   id: string,
   fields: FormField[],
   coreRequirements?: CoreRequirements,
   legalBlocks?: FormLegalBlock[],
+  newName?: string,
 ): Promise<FormSchema> {
   const body: {
+    name?: string;
     fields: FormField[];
     core_requirements?: CoreRequirements;
     legal_blocks?: FormLegalBlock[];
   } = { fields };
+  if (newName !== undefined) body.name = newName;
   if (coreRequirements !== undefined) body.core_requirements = coreRequirements;
   if (legalBlocks !== undefined) body.legal_blocks = legalBlocks;
   const response = await fetch(`${SCHEMA_PATH}/${encodeURIComponent(id)}`, {

--- a/frontend/src/lib/enrollment-form-schema-api.ts
+++ b/frontend/src/lib/enrollment-form-schema-api.ts
@@ -517,6 +517,33 @@ export async function updateSchema(
   return readJSON<FormSchema>(response);
 }
 
+/**
+ * Renames a logical schema. Every version row sharing the source's name
+ * is renamed atomically, so the whole version lineage keeps one shared
+ * name. This publishes no new version and leaves the form fields
+ * untouched. The backend rejects (409) a name already used by a
+ * different schema.
+ */
+export async function renameSchema(
+  id: string,
+  name: string,
+): Promise<FormSchema> {
+  const response = await fetch(`${SCHEMA_PATH}/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!response.ok) {
+    throw await readEnrollmentError(
+      response,
+      "Formularvorlage konnte nicht umbenannt werden",
+      logger,
+      "schema_rename_failed",
+    );
+  }
+  return readJSON<FormSchema>(response);
+}
+
 export async function deleteSchema(id: string): Promise<void> {
   const response = await fetch(`${SCHEMA_PATH}/${encodeURIComponent(id)}`, {
     method: "DELETE",


### PR DESCRIPTION
Closes #1696

## What

Adds the ability to **rename an enrollment form-schema template** without publishing a new version or touching its fields. A logical schema spans multiple version rows sharing one `name`; this renames every version row atomically so the version lineage keeps one shared name.

Two entry points in the admin editor:
- A standalone **„Umbenennen"** dialog in the template actions menu (`⋮`).
- An **editable name field in the builder header**. A name-only save renames in place (no redundant version); a name+content save renames *then* publishes one new version — in that retry-safe order (a failed publish never leaves a redundant version; a retried rename is a no-op).

## How

**Backend** (Handler → Service → Repository):
- `PATCH /enrollment/schema/{id}` (`config:manage`) → `renameSchema` handler.
- `FormSchemaService.RenameSchema`: trims/validates, no-ops on same name, pre-checks collisions via `ExistsByName`, and translates a 23505 race on the `(tenant_id, name, version)` unique index into `ErrFormSchemaNameExists` → `409` with stable code `enrollment.schema_name_exists`.
- Repo `ExistsByName` + `RenameByName`, both tenant-scoped.

**Frontend**:
- `renameSchema` API client + Next.js PATCH proxy route.
- Mapped `enrollment.schema_name_exists` → a German message so a name collision shows *why*, not a generic failure (this code had **no mapping** before — a real UX gap).
- Help guide updated to document renaming.

## Tests

Existing happy-path/collision/no-op/empty coverage, plus added coverage for **every error branch** to clear the 85% new-code threshold:
- **Service**: non-positive id, not-found, load fault (not flattened to 404), exists-check fault, rename-exec fault.
- **Proxy route**: invalid id → 400, upstream throw → 500.
- **API client**: PATCH body shape, id URL-encoding, 409 code→German translation, generic fallback.

The `isUniqueViolationOn` 23505 race fallback is intentionally left to the repository-level DB tests (fabricating a `pgdriver.Error` in a unit test isn't practical) — noted in the test comments.

### Verification
- Backend: service / handler / repository rename tests green against the test DB.
- Frontend: 71/71 across the three touched test files; `pnpm run check` clean.

## Notes for review
- Rename + field-publish are two requests, not one transaction — deliberate and documented inline (`enrollment-form-editor.tsx`).
- Per-version rename keeps phase bindings (which pin schemas by id) intact.
