### PR TITLE
fix(operator): restore no-slash GET /auth/passkeys route

### DIFF
--- a/backend/api/operator/api.go
+++ b/backend/api/operator/api.go
@@ -207,6 +207,14 @@ func (rs *Resource) Router() chi.Router {
 		// because public passkey login also lives under /auth/passkeys/login/*.
 		// A protected subtree on /auth/passkeys shadows those public login
 		// routes in chi and makes anonymous passkey login fail with 401.
+		//
+		// Register the list endpoint under BOTH the no-slash and trailing-slash
+		// forms: chi treats "/auth/passkeys" and "/auth/passkeys/" as distinct
+		// patterns (no RedirectSlashes on this router), and the old
+		// r.Route("/auth/passkeys").Get("/") form answered both. The proxy
+		// sends the slash form, but direct authenticated operator clients hit
+		// the no-slash form, so dropping it 404s them.
+		r.Get("/auth/passkeys", rs.PasskeyList)
 		r.Get("/auth/passkeys/", rs.PasskeyList)
 		r.Post("/auth/passkeys/enrollment/challenge", rs.PasskeyEnrollmentChallenge)
 		r.Post("/auth/passkeys/register/options", rs.PasskeyRegisterOptions)

--- a/backend/api/operator/passkeys_test.go
+++ b/backend/api/operator/passkeys_test.go
@@ -136,6 +136,32 @@ func TestOperatorPasskeyLoginRoutesArePublic(t *testing.T) {
 	assert.JSONEq(t, `{"session_id":"operator-login","options":{"challenge":"login"}}`, w.Body.String())
 }
 
+// TestOperatorPasskeyListRouteAcceptsBothSlashForms pins the compatibility
+// fix: GET /auth/passkeys (no slash) and GET /auth/passkeys/ (slash) must both
+// be routed to PasskeyList. chi has no RedirectSlashes on this router, so the
+// two are distinct patterns; an UNregistered path 404s before any middleware
+// runs, while a registered protected path reaches the auth middleware and 401s
+// without a token. Asserting 401 (not 404) for both forms proves both are
+// registered. Regression guard for the route dropped in PR #1690.
+func TestOperatorPasskeyListRouteAcceptsBothSlashForms(t *testing.T) {
+	tokenAuth, err := jwt.NewTokenAuth()
+	require.NoError(t, err)
+
+	router := NewResource(ResourceConfig{
+		PasskeyService: &operatorPasskeyServiceStub{},
+		TokenAuth:      tokenAuth,
+	}).Router()
+
+	for _, path := range []string{"/auth/passkeys", "/auth/passkeys/"} {
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+		require.NotEqual(t, http.StatusNotFound, w.Code,
+			"GET %s must be a registered route, not 404", path)
+		assert.Equal(t, http.StatusUnauthorized, w.Code,
+			"GET %s is protected, so an unauthenticated request must 401", path)
+	}
+}
+
 func TestOperatorPasskeyAuthenticatedHandlers(t *testing.T) {
 	svc := &operatorPasskeyServiceStub{}
 	rs := &Resource{passkeyService: svc}


### PR DESCRIPTION
## Where this stems from

Surfaced in the code review of **#1697** (enrollment form rename). The reviewer flagged it as an unrelated, pre-existing regression, so it is split out here rather than bundled into that PR.

The actual regression was introduced by **#1690 — "keep operator passkey login public"** (commit `d0f5f2c75`). That PR replaced

```go
r.Route("/auth/passkeys", func(r chi.Router) { r.Get("/", rs.PasskeyList) })
```

with an exact leaf

```go
r.Get("/auth/passkeys/", rs.PasskeyList)
```

to stop the protected `/auth/passkeys` subtree from shadowing the **public** `/auth/passkeys/login/*` routes. That fixed the shadowing, but narrowed the list endpoint to the **trailing-slash form only**.

## The bug

This router has no `RedirectSlashes` middleware, so chi treats `/auth/passkeys` and `/auth/passkeys/` as **distinct patterns**. The old `r.Route(...).Get("/")` form answered both; the new exact leaf answers only the slash form.

- The frontend proxy sends the slash form, so the UI is unaffected.
- **Direct authenticated operator clients** hitting `GET /auth/passkeys` (no slash) now get a **404**.

## The fix

Register the list endpoint under **both** forms, still as individual leaves so the public login routes stay reachable (no protected subtree on `/auth/passkeys`):

```go
r.Get("/auth/passkeys", rs.PasskeyList)
r.Get("/auth/passkeys/", rs.PasskeyList)
```

## Test

Added `TestOperatorPasskeyListRouteAcceptsBothSlashForms`: drives the real `Router()` and asserts both forms reach the auth middleware (**401, not 404**) — an unregistered path 404s before middleware runs, a registered protected path 401s without a token. Pins the compatibility detail so it can't silently regress again.

- `go test ./api/operator/...` green.

Draft until #1697 lands / reviewer confirms scope.