### PR TITLE
Move operator settings into profile menu

### DIFF
--- a/frontend/src/components/dashboard/header.tsx
+++ b/frontend/src/components/dashboard/header.tsx
@@ -213,6 +213,9 @@ export function Header() {
                 displayAvatar={displayAvatar}
                 userEmail={userEmail}
                 profileUrl={profileUrl}
+                profileLabel={
+                  mode === "operator" ? "Profileinstellungen" : undefined
+                }
                 onClose={() => setIsProfileMenuOpen(false)}
                 onLogout={() => setIsLogoutModalOpen(true)}
               />

--- a/frontend/src/components/dashboard/header/profile-dropdown.test.tsx
+++ b/frontend/src/components/dashboard/header/profile-dropdown.test.tsx
@@ -196,6 +196,27 @@ describe("ProfileDropdownMenu", () => {
     expect(profileLink).toHaveAttribute("href", "/profile");
   });
 
+  it("renders a custom profile link label when provided", () => {
+    const onClose = vi.fn();
+    const onLogout = vi.fn();
+    render(
+      <ProfileDropdownMenu
+        isOpen={true}
+        displayName="Max Mustermann"
+        userEmail="max@example.com"
+        onClose={onClose}
+        onLogout={onLogout}
+        profileUrl="/operator/settings"
+        profileLabel="Profileinstellungen"
+      />,
+    );
+
+    const profileLink = screen.getByRole("link", {
+      name: /profileinstellungen/i,
+    });
+    expect(profileLink).toHaveAttribute("href", "/operator/settings");
+  });
+
   it("does not render profile link when profileUrl is not provided", () => {
     const onClose = vi.fn();
     const onLogout = vi.fn();

--- a/frontend/src/components/dashboard/header/profile-dropdown.tsx
+++ b/frontend/src/components/dashboard/header/profile-dropdown.tsx
@@ -137,6 +137,7 @@ interface ProfileDropdownMenuProps {
   readonly onClose: () => void;
   readonly onLogout: () => void;
   readonly profileUrl?: string | null;
+  readonly profileLabel?: string;
 }
 
 export function ProfileDropdownMenu({
@@ -147,6 +148,7 @@ export function ProfileDropdownMenu({
   onClose,
   onLogout,
   profileUrl,
+  profileLabel,
 }: ProfileDropdownMenuProps) {
   // parentNav carries German values in the staff/operator shells (via
   // ShellNavIntlProvider), so those portals render unchanged; only the parents
@@ -206,7 +208,7 @@ export function ProfileDropdownMenu({
               className="group flex items-center rounded-xl px-3 py-2.5 text-sm font-medium text-gray-700 transition-all duration-200 ease-out hover:bg-gray-100 hover:text-gray-900 active:bg-gray-900 active:text-white"
             >
               <ProfileIcon />
-              {t("profile")}
+              {profileLabel ?? t("profile")}
             </Link>
           )}
 

--- a/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
@@ -737,7 +737,7 @@ describe("MobileBottomNav", () => {
         mode: "operator",
         homeUrl: "/operator/suggestions",
 
-        profileUrl: null,
+        profileUrl: "/operator/settings",
       });
       mockUsePathname.mockReturnValue("/operator/suggestions");
     });
@@ -760,8 +760,7 @@ describe("MobileBottomNav", () => {
       // Issue #1282: the old operator bottom nav had no overflow because the
       // single /operator/provisioning page housed all Verwaltung tabs. After
       // the tabs were split into dedicated routes the overflow drawer must
-      // surface the remaining 4 sibling pages + Einstellungen so mobile users
-      // can reach them.
+      // surface the remaining sibling pages so mobile users can reach them.
       render(<MobileBottomNav />);
 
       const navButtons = screen.getAllByRole("button");
@@ -778,7 +777,7 @@ describe("MobileBottomNav", () => {
       expect(hrefs).toContain("/operator/accounts");
       expect(hrefs).toContain("/operator/devices");
       expect(hrefs).toContain("/operator/persons");
-      expect(hrefs).toContain("/operator/settings");
+      expect(hrefs).not.toContain("/operator/settings");
     });
 
     it("shows active label for current operator route", () => {

--- a/frontend/src/components/dashboard/mobile-bottom-nav.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.tsx
@@ -163,10 +163,10 @@ interface AdditionalNavItem {
 }
 
 // Operator-mode overflow items, everything reachable from the sidebar on
-// desktop that isn't already a main bottom-nav slot. The 4 sibling Verwaltung
-// pages (Schulen/Konten/Geräte/Personen) belong here since the bottom nav has
-// only one "Verwaltung" slot that lands on /operator/organizations, and
-// Einstellungen is otherwise unreachable on mobile.
+// desktop that isn't already a main bottom-nav slot. The 5 sibling Verwaltung
+// pages (Schulen/Konten/Geräte/Personen/Unbekannte RFID) belong here since
+// the bottom nav has only one "Verwaltung" slot that lands on
+// /operator/organizations.
 const OPERATOR_ADDITIONAL_ITEMS: AdditionalNavItem[] = [
   {
     href: "/operator/schools",
@@ -196,12 +196,6 @@ const OPERATOR_ADDITIONAL_ITEMS: AdditionalNavItem[] = [
     href: "/operator/unregistered-tags",
     label: "Unbekannte RFID",
     iconKey: "security",
-    alwaysShow: true,
-  },
-  {
-    href: "/operator/settings",
-    label: "Einstellungen",
-    iconKey: "settings",
     alwaysShow: true,
   },
 ];

--- a/frontend/src/components/dashboard/sidebar.test.tsx
+++ b/frontend/src/components/dashboard/sidebar.test.tsx
@@ -1316,7 +1316,7 @@ describe("Sidebar", () => {
         mode: "operator",
         homeUrl: "/operator/suggestions",
 
-        profileUrl: null,
+        profileUrl: "/operator/settings",
       });
       mockUsePathname.mockReturnValue("/operator/suggestions");
     });
@@ -1326,7 +1326,7 @@ describe("Sidebar", () => {
 
       expect(screen.getByText("Feedback")).toBeInTheDocument();
       expect(screen.getByText("Ankündigungen")).toBeInTheDocument();
-      expect(screen.getByText("Einstellungen")).toBeInTheDocument();
+      expect(screen.queryByText("Einstellungen")).not.toBeInTheDocument();
     });
 
     it("does not render teacher-specific items", () => {
@@ -1345,11 +1345,10 @@ describe("Sidebar", () => {
       expect(aside).toHaveClass("op-class");
     });
 
-    it("renders bottom pinned settings item", () => {
+    it("does not render settings in operator navigation", () => {
       render(<Sidebar />);
 
-      const settingsLink = screen.getByText("Einstellungen").closest("a");
-      expect(settingsLink).toHaveAttribute("href", "/operator/settings");
+      expect(screen.queryByText("Einstellungen")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/dashboard/sidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar.tsx
@@ -270,15 +270,6 @@ const OPERATOR_NAV_SECTIONS: readonly OperatorNavSection[] = [
   },
 ];
 
-const OPERATOR_BOTTOM_ITEM: NavItem = {
-  href: "/operator/settings",
-  label: "Einstellungen",
-  icon: navigationIcons.settings,
-  activeColor: "text-gray-500",
-  bottomPinned: true,
-  alwaysShow: true,
-};
-
 // Static sub-pages for Datenverwaltung accordion
 const DATABASE_SUB_PAGES = [
   { href: "/database/students", label: "Kinder" },
@@ -797,13 +788,6 @@ function SidebarContent({ className = "" }: SidebarProps) {
       })),
     [],
   );
-  const resolvedOperatorBottomItem = useMemo(
-    () => ({
-      ...OPERATOR_BOTTOM_ITEM,
-      href: operatorPath(OPERATOR_BOTTOM_ITEM.href),
-    }),
-    [],
-  );
   const operatorSuggestionsHref = useMemo(
     () => operatorPath("/operator/suggestions"),
     [],
@@ -860,10 +844,6 @@ function SidebarContent({ className = "" }: SidebarProps) {
                 </div>
               </div>
             ))}
-          </nav>
-
-          <nav className="space-y-1 border-t border-gray-200 p-3 lg:p-4 xl:p-3">
-            {renderOperatorItem(resolvedOperatorBottomItem)}
           </nav>
         </div>
       </aside>

--- a/frontend/src/components/settings/passkey-settings-section.test.tsx
+++ b/frontend/src/components/settings/passkey-settings-section.test.tsx
@@ -8,12 +8,14 @@ const {
   mockRegisterPasskey,
   mockRevokePasskey,
   mockStartPasskeyEnrollment,
+  mockSuggestCurrentDeviceLabel,
 } = vi.hoisted(() => ({
   mockIsPasskeySupported: vi.fn(),
   mockListPasskeys: vi.fn(),
   mockRegisterPasskey: vi.fn(),
   mockRevokePasskey: vi.fn(),
   mockStartPasskeyEnrollment: vi.fn(),
+  mockSuggestCurrentDeviceLabel: vi.fn(),
 }));
 
 vi.mock("~/lib/passkey-api", () => ({
@@ -24,10 +26,15 @@ vi.mock("~/lib/passkey-api", () => ({
   startPasskeyEnrollment: mockStartPasskeyEnrollment,
 }));
 
+vi.mock("~/lib/device-label", () => ({
+  suggestCurrentDeviceLabel: mockSuggestCurrentDeviceLabel,
+}));
+
 describe("PasskeySettingsSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsPasskeySupported.mockReturnValue(true);
+    mockSuggestCurrentDeviceLabel.mockReturnValue("Chrome auf macOS");
     mockListPasskeys.mockResolvedValue([]);
     mockStartPasskeyEnrollment.mockResolvedValue({
       challenge_token: "challenge-token",
@@ -35,7 +42,7 @@ describe("PasskeySettingsSection", () => {
     });
     mockRegisterPasskey.mockResolvedValue({
       id: "2",
-      name: "Dieses Gerät",
+      name: "Chrome auf macOS",
       created_at: "2026-06-15T10:00:00Z",
     });
     mockRevokePasskey.mockResolvedValue(undefined);
@@ -114,7 +121,7 @@ describe("PasskeySettingsSection", () => {
     expect(
       screen.getByText("Code gesendet an m***@example.test"),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText("Name")).toHaveValue("Dieses Gerät");
+    expect(screen.getByLabelText("Name")).toHaveValue("Chrome auf macOS");
 
     fireEvent.change(screen.getByLabelText("Code"), {
       target: { value: "123456" },

--- a/frontend/src/components/settings/passkey-settings-section.tsx
+++ b/frontend/src/components/settings/passkey-settings-section.tsx
@@ -5,6 +5,7 @@ import { KeyRound, Mail, Plus, Trash2 } from "lucide-react";
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
+import { suggestCurrentDeviceLabel } from "~/lib/device-label";
 import {
   isPasskeySupported,
   listPasskeys,
@@ -63,7 +64,7 @@ export function PasskeySettingsSection({
     try {
       const challenge = await startPasskeyEnrollment(scope);
       setMaskedEmail(challenge.masked_email);
-      setName("Dieses Gerät");
+      setName(suggestCurrentDeviceLabel());
       setCode("");
       setConfirmingEnrollment(false);
       setEnrolling(true);

--- a/frontend/src/components/settings/trusted-devices-section.tsx
+++ b/frontend/src/components/settings/trusted-devices-section.tsx
@@ -6,6 +6,7 @@ import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { Skeleton } from "~/components/ui/skeleton";
 import { useToast } from "~/contexts/ToastContext";
+import { formatDeviceLabelFromUserAgent } from "~/lib/device-label";
 import { createLogger } from "~/lib/logger";
 import {
   listTrustedDevices,
@@ -29,29 +30,6 @@ function formatGermanDate(iso: string): string {
   } catch {
     return iso;
   }
-}
-
-// shortenUA collapses the full User-Agent header to a readable summary —
-// "Chrome auf macOS" / "Safari auf iPhone" — so the list stays scannable.
-// Falls back to the raw header for unknown agents.
-function shortenUA(ua?: string): string {
-  if (!ua) return "Unbekanntes Gerät";
-  const lower = ua.toLowerCase();
-  let browser = "Browser";
-  if (lower.includes("edg/")) browser = "Edge";
-  else if (lower.includes("firefox")) browser = "Firefox";
-  else if (lower.includes("chrome") && !lower.includes("edg/"))
-    browser = "Chrome";
-  else if (lower.includes("safari") && !lower.includes("chrome"))
-    browser = "Safari";
-  let os = "";
-  if (lower.includes("iphone")) os = "iPhone";
-  else if (lower.includes("ipad")) os = "iPad";
-  else if (lower.includes("android")) os = "Android";
-  else if (lower.includes("mac os")) os = "macOS";
-  else if (lower.includes("windows")) os = "Windows";
-  else if (lower.includes("linux")) os = "Linux";
-  return os ? `${browser} auf ${os}` : browser;
 }
 
 interface TrustedDevicesSectionProps {
@@ -160,7 +138,7 @@ export function TrustedDevicesSection({
             >
               <div className="min-w-0 flex-1">
                 <div className="text-sm font-medium text-gray-900">
-                  {shortenUA(d.user_agent)}
+                  {formatDeviceLabelFromUserAgent(d.user_agent)}
                 </div>
                 <div className="mt-1 text-xs text-gray-500">
                   Hinzugefügt: {formatGermanDate(d.created_at)} · Gültig bis:{" "}

--- a/frontend/src/lib/device-label.test.ts
+++ b/frontend/src/lib/device-label.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { formatDeviceLabelFromUserAgent } from "./device-label";
+
+describe("formatDeviceLabelFromUserAgent", () => {
+  it("formats Chrome on macOS", () => {
+    expect(
+      formatDeviceLabelFromUserAgent(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      ),
+    ).toBe("Chrome auf macOS");
+  });
+
+  it("formats Safari on iPhone", () => {
+    expect(
+      formatDeviceLabelFromUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+      ),
+    ).toBe("Safari auf iPhone");
+  });
+
+  it("formats Firefox on Windows", () => {
+    expect(
+      formatDeviceLabelFromUserAgent(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:126.0) Gecko/20100101 Firefox/126.0",
+      ),
+    ).toBe("Firefox auf Windows");
+  });
+
+  it("falls back when the user agent is empty or unknown", () => {
+    expect(formatDeviceLabelFromUserAgent("")).toBe("Unbekanntes Gerät");
+    expect(formatDeviceLabelFromUserAgent("CustomAgent/1.0")).toBe(
+      "Unbekanntes Gerät",
+    );
+  });
+});

--- a/frontend/src/lib/device-label.ts
+++ b/frontend/src/lib/device-label.ts
@@ -1,0 +1,49 @@
+const UNKNOWN_DEVICE_LABEL = "Unbekanntes Gerät";
+
+export function formatDeviceLabelFromUserAgent(
+  userAgent?: string | null,
+): string {
+  const trimmed = userAgent?.trim();
+  if (!trimmed) return UNKNOWN_DEVICE_LABEL;
+
+  const lower = trimmed.toLowerCase();
+  const browser = detectBrowser(lower);
+  const os = detectOS(lower);
+
+  if (browser && os) return `${browser} auf ${os}`;
+  return browser ?? os ?? UNKNOWN_DEVICE_LABEL;
+}
+
+export function suggestCurrentDeviceLabel(): string {
+  if (typeof navigator === "undefined") return UNKNOWN_DEVICE_LABEL;
+  return formatDeviceLabelFromUserAgent(navigator.userAgent);
+}
+
+function detectBrowser(lowerUserAgent: string): string | null {
+  if (lowerUserAgent.includes("edg/")) return "Edge";
+  if (lowerUserAgent.includes("firefox/") || lowerUserAgent.includes("fxios/"))
+    return "Firefox";
+  if (lowerUserAgent.includes("crios/")) return "Chrome";
+  if (lowerUserAgent.includes("chrome/") && !lowerUserAgent.includes("edg/")) {
+    return "Chrome";
+  }
+  if (
+    lowerUserAgent.includes("safari/") &&
+    !lowerUserAgent.includes("chrome/") &&
+    !lowerUserAgent.includes("crios/")
+  ) {
+    return "Safari";
+  }
+  return null;
+}
+
+function detectOS(lowerUserAgent: string): string | null {
+  if (lowerUserAgent.includes("iphone")) return "iPhone";
+  if (lowerUserAgent.includes("ipad")) return "iPad";
+  if (lowerUserAgent.includes("android")) return "Android";
+  if (lowerUserAgent.includes("mac os") || lowerUserAgent.includes("macintosh"))
+    return "macOS";
+  if (lowerUserAgent.includes("windows")) return "Windows";
+  if (lowerUserAgent.includes("linux")) return "Linux";
+  return null;
+}

--- a/frontend/src/lib/shell-auth-context.test.tsx
+++ b/frontend/src/lib/shell-auth-context.test.tsx
@@ -296,7 +296,7 @@ describe("OperatorShellProvider", () => {
     expect(result.current.status).toBe("authenticated");
     expect(result.current.mode).toBe("operator");
     expect(result.current.homeUrl).toBe("/operator/suggestions");
-    expect(result.current.profileUrl).toBeNull();
+    expect(result.current.profileUrl).toBe("/operator/settings");
   });
 
   it("splits display name into first and last name", () => {

--- a/frontend/src/lib/shell-auth-context.tsx
+++ b/frontend/src/lib/shell-auth-context.tsx
@@ -170,7 +170,7 @@ export function OperatorShellProvider({
       },
       mode: "operator" as const,
       homeUrl: operatorPath("/operator/suggestions"),
-      profileUrl: null,
+      profileUrl: operatorPath("/operator/settings"),
     };
   }, [session, sessionStatus]);
 


### PR DESCRIPTION
## Summary
- move operator profile/settings access into the top-right profile menu
- remove operator settings from desktop sidebar and mobile overflow navigation
- use browser/OS-specific labels for passkey and trusted-device names

## Tests
- pnpm exec vitest run src/lib/device-label.test.ts src/components/settings/passkey-settings-section.test.tsx src/components/settings/trusted-devices-section.test.tsx src/components/dashboard/header/profile-dropdown.test.tsx src/components/dashboard/sidebar.test.tsx src/components/dashboard/mobile-bottom-nav.test.tsx src/lib/shell-auth-context.test.tsx
- pnpm run check
- pre-push: pnpm run knip

Closes #1688