### PR TITLE
chore(email): consolidate moto branding into shared partial

### DIFF
--- a/backend/templates/email/guardian-invitation.html
+++ b/backend/templates/email/guardian-invitation.html
@@ -2,9 +2,7 @@
 {{template "header" .}}
 
 <div class="email-body">
-    <div class="brand">
-        <img src="{{.LogoURL}}" alt="moto Logo" style="max-width: 180px; height: auto; display: block; margin: 0 auto;" />
-    </div>
+    {{template "moto-brand" .}}
     <h1>Einladung zum Eltern-Portal</h1>
     {{if .FirstName}}
     <p>Sehr geehrte/r {{.FirstName}} {{.LastName}},</p>

--- a/backend/templates/email/header.html
+++ b/backend/templates/email/header.html
@@ -17,6 +17,12 @@
 
 {{end}}
 
+{{define "moto-brand"}}
+<div class="brand">
+    <img src="{{.LogoURL}}" alt="moto Logo" style="max-width: 180px; height: auto; display: block; margin: 0 auto;" />
+</div>
+{{end}}
+
 {{define "school-brand"}}
 <div class="school-brand">
     {{if .LogoURL}}

--- a/backend/templates/email/invitation.html
+++ b/backend/templates/email/invitation.html
@@ -2,9 +2,7 @@
 {{template "header" .}}
 
 <div class="email-body">
-    <div class="brand">
-        <img src="{{.LogoURL}}" alt="moto Logo" style="max-width: 180px; height: auto; display: block; margin: 0 auto;" />
-    </div>
+    {{template "moto-brand" .}}
     <h1>Einladung zu moto</h1>
     {{if .FirstName}}
     <p>Hallo {{.FirstName}},</p>

--- a/backend/templates/email/mfa-email-code.html
+++ b/backend/templates/email/mfa-email-code.html
@@ -2,9 +2,7 @@
 {{template "header" .}}
 
 <div class="email-body">
-    <div class="brand">
-        <img src="{{.LogoURL}}" alt="moto Logo" style="max-width: 180px; height: auto; display: block; margin: 0 auto;" />
-    </div>
+    {{template "moto-brand" .}}
     <h1>Ihr Anmeldecode</h1>
     <p>Hallo,</p>
     <p>jemand hat sich gerade mit Ihrer E-Mail-Adresse bei moto angemeldet und einen Bestätigungscode angefordert. Bitte geben Sie den folgenden Code in der moto-Anmeldemaske ein, um den Login abzuschließen:</p>

--- a/backend/templates/email/operator-email-change-confirmed.html
+++ b/backend/templates/email/operator-email-change-confirmed.html
@@ -2,9 +2,7 @@
 {{template "header" .}}
 
 <div class="email-body">
-    <div class="brand">
-        <img src="{{.LogoURL}}" alt="moto Logo" style="max-width: 180px; height: auto; display: block; margin: 0 auto;" />
-    </div>
+    {{template "moto-brand" .}}
     <h1>E-Mail-Adresse wurde geändert</h1>
     <p>Hallo {{.DisplayName}},</p>
     <p>die E-Mail-Adresse deines moto-Operator-Kontos wurde soeben erfolgreich geändert. Diese Adresse wird nicht mehr für die Anmeldung verwendet.</p>

--- a/backend/templates/email/operator-email-change-notify.html
+++ b/backend/templates/email/operator-email-change-notify.html
@@ -2,9 +2,7 @@
 {{template "header" .}}
 
 <div class="email-body">
-    <div class="brand">
-        <img src="{{.LogoURL}}" alt="moto Logo" style="max-width: 180px; height: auto; display: block; margin: 0 auto;" />
-    </div>
+    {{template "moto-brand" .}}
     <h1>E-Mail-Änderung angefordert</h1>
     <p>Hallo {{.DisplayName}},</p>
     <p>es wurde eine Änderung deiner E-Mail-Adresse für dein moto-Operator-Konto angefordert. Die neue E-Mail-Adresse lautet: <strong>{{.MaskedNewEmail}}</strong></p>

--- a/backend/templates/email/operator-email-change-verify.html
+++ b/backend/templates/email/operator-email-change-verify.html
@@ -2,9 +2,7 @@
 {{template "header" .}}
 
 <div class="email-body">
-    <div class="brand">
-        <img src="{{.LogoURL}}" alt="moto Logo" style="max-width: 180px; height: auto; display: block; margin: 0 auto;" />
-    </div>
+    {{template "moto-brand" .}}
     <h1>E-Mail-Adresse bestätigen</h1>
     <p>Hallo,</p>
     <p>es wurde eine Änderung der E-Mail-Adresse für dein moto-Operator-Konto angefordert. Klicke auf den Button unten, um die neue E-Mail-Adresse zu bestätigen.</p>

--- a/backend/templates/email/operator-invitation.html
+++ b/backend/templates/email/operator-invitation.html
@@ -2,9 +2,7 @@
 {{template "header" .}}
 
 <div class="email-body">
-    <div class="brand">
-        <img src="{{.LogoURL}}" alt="moto Logo" style="max-width: 180px; height: auto; display: block; margin: 0 auto;" />
-    </div>
+    {{template "moto-brand" .}}
     <h1>Einladung als Operator</h1>
     <p>Hallo,</p>
     <p>du wurdest von <strong>{{.InviterName}}</strong> als Operator zur moto-Plattform eingeladen. Klicke auf den Button unten, um dein Konto einzurichten.</p>

--- a/backend/templates/email/password-reset.html
+++ b/backend/templates/email/password-reset.html
@@ -2,9 +2,7 @@
 {{template "header" .}}
 
 <div class="email-body">
-    <div class="brand">
-        <img src="{{.LogoURL}}" alt="moto Logo" style="max-width: 180px; height: auto; display: block; margin: 0 auto;" />
-    </div>
+    {{template "moto-brand" .}}
     <h1>Passwort zurücksetzen</h1>
     <p>Hallo,</p>
     <p>wir haben eine Anfrage erhalten, dein Passwort für dein moto-Konto zurückzusetzen. Klicke auf den Button unten, um ein neues Passwort zu wählen.</p>

--- a/backend/templates/email/school_brand_test.go
+++ b/backend/templates/email/school_brand_test.go
@@ -1,0 +1,106 @@
+package email_test
+
+import (
+	"bytes"
+	"html/template"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchoolBrandTemplate_Renders verifies the school-brand branding variant.
+// Enrollment emails render the shared "school-brand" partial (school logo +
+// "Online-Anmeldung" kicker + school name) instead of the centered moto logo
+// used by every other transactional email. Together with
+// TestMFAEmailCodeTemplate_Renders (moto-brand variant) this covers both
+// branding partials defined in header.html. Issue #1687.
+func TestSchoolBrandTemplate_Renders(t *testing.T) {
+	templatesDir, err := filepath.Abs(".")
+	require.NoError(t, err)
+
+	pattern := filepath.Join(templatesDir, "*.html")
+	tpl, err := template.ParseGlob(pattern)
+	require.NoError(t, err, "parse all email templates")
+
+	require.NotNil(t, tpl.Lookup("enrollment-submitted.html"), "template must register under its filename")
+
+	tests := []struct {
+		name        string
+		data        map[string]any
+		mustContain []string
+		mustNotHave []string
+	}{
+		{
+			name: "school logo + name when LogoURL is set",
+			data: map[string]any{
+				"GuardianFirstName": "Erika",
+				"GuardianLastName":  "Mustermann",
+				"SchoolName":        "OGS Musterschule",
+				"StatusURL":         "https://parents.example.com/status/abc",
+				"LogoURL":           "https://example.com/school-logo.png",
+				"MotoLogoURL":       "https://example.com/images/moto_transparent.png",
+				"ChildNames":        []string{"Max Mustermann"},
+			},
+			mustContain: []string{
+				// school-brand partial markup
+				`class="school-brand"`,
+				"Online-Anmeldung",
+				"OGS Musterschule",
+				// school logo uses the provided URL
+				`class="school-logo"`,
+				"https://example.com/school-logo.png",
+				// footer chrome still present
+				"Unterstützt von",
+			},
+			mustNotHave: []string{
+				// must NOT fall back to the centered moto-brand logo block
+				`alt="moto Logo"`,
+				// no fallback placeholder element when a logo exists
+				// (the .school-logo-fallback CSS rule always ships in <style>,
+				// so assert on the rendered markup element, not the bare class
+				// name)
+				`class="school-logo-fallback"`,
+			},
+		},
+		{
+			name: "OGS fallback when LogoURL is empty",
+			data: map[string]any{
+				"GuardianFirstName": "Erika",
+				"GuardianLastName":  "Mustermann",
+				"SchoolName":        "OGS Musterschule",
+				"StatusURL":         "https://parents.example.com/status/abc",
+				"LogoURL":           "",
+				"MotoLogoURL":       "",
+				"ChildNames":        []string{"Max Mustermann"},
+			},
+			mustContain: []string{
+				`class="school-logo-fallback"`,
+				"OGS",
+				"Online-Anmeldung",
+				"OGS Musterschule",
+			},
+			mustNotHave: []string{
+				// no school-logo img element when there is no URL
+				`class="school-logo"`,
+				`alt="moto Logo"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			require.NoError(t, tpl.ExecuteTemplate(&buf, "enrollment-submitted.html", tt.data))
+			rendered := buf.String()
+
+			for _, snippet := range tt.mustContain {
+				assert.Contains(t, rendered, snippet, "rendered output must contain %q", snippet)
+			}
+			for _, snippet := range tt.mustNotHave {
+				assert.NotContains(t, rendered, snippet, "rendered output must NOT contain %q", snippet)
+			}
+		})
+	}
+}

--- a/backend/templates/email/suggestion-notification.html
+++ b/backend/templates/email/suggestion-notification.html
@@ -2,9 +2,7 @@
 {{template "header" .}}
 
 <div class="email-body">
-    <div class="brand">
-        <img src="{{.LogoURL}}" alt="moto Logo" style="max-width: 180px; height: auto; display: block; margin: 0 auto;" />
-    </div>
+    {{template "moto-brand" .}}
 
     {{if eq .Type "new_post"}}
     <h1>Neuer Vorschlag eingereicht</h1>

--- a/backend/templates/email/trusted-device-added.html
+++ b/backend/templates/email/trusted-device-added.html
@@ -2,9 +2,7 @@
 {{template "header" .}}
 
 <div class="email-body">
-    <div class="brand">
-        <img src="{{.LogoURL}}" alt="moto Logo" style="max-width: 180px; height: auto; display: block; margin: 0 auto;" />
-    </div>
+    {{template "moto-brand" .}}
     <h1>Neues vertrautes Gerät zu Ihrem Konto hinzugefügt</h1>
     <p>Hallo,</p>
     <p>auf Ihrem moto-Konto wurde gerade ein neues Gerät als vertrautes Gerät gespeichert. Auf diesem Gerät wird beim Login für die nächsten {{.TrustedDays}} Tage kein 2FA-Code mehr abgefragt.</p>


### PR DESCRIPTION
## Summary

Consolidates the duplicated moto branding markup across the backend transactional email templates, per #1687.

Every transactional email (MFA login code, staff/operator/guardian invitations, password reset, operator email-change flows, trusted-device, suggestion notification) previously repeated the same centered moto-logo block inline. This extracts it into a shared `{{define "moto-brand"}}` partial in `header.html`, sitting alongside the existing `school-brand` partial that enrollment emails already use. Future branding tweaks now happen in one place.

## Changes

- **`header.html`**: add the shared `moto-brand` partial (identical markup to the old inline block).
- **10 templates**: replace the inline `<div class="brand">…</div>` block with `{{template "moto-brand" .}}`.
- **`school_brand_test.go`** (new): render test for the `school-brand` variant (logo + "Online-Anmeldung" kicker + OGS fallback). Together with the existing MFA test (moto-brand variant), both branding partials are now covered.

## Visual output is unchanged

The partial holds byte-for-byte the same markup and is called with the same `.` data context, so escaping and rendering are identical. Verified empirically: rendered all 10 affected templates old (git HEAD, inline) vs new (partial) with identical data and diffed — **0 of 10 differ** (whitespace-normalized). No `styles.html` / CSS changes.

## Test plan

- [x] `go test ./templates/email/` — all pass (moto-brand + school-brand + trusted-device variants)
- [x] Old-vs-new render diff confirms identical output across all consolidated templates

Closes #1687
