### PR TITLE
Seed parent portal enrollment flows

### DIFF
--- a/backend/api/guardians/guardians_test.go
+++ b/backend/api/guardians/guardians_test.go
@@ -1221,35 +1221,40 @@ func TestSendInvitation_Unauthorized_NoClaims(t *testing.T) {
 	testutil.AssertUnauthorized(t, rr)
 }
 
-func TestSendInvitation_SeedTokenHeaderDoesNotExposeTokenInProduction(t *testing.T) {
+func TestSendInvitation_SeedTokenHeaderDoesNotExposeTokenOutsideLocalDev(t *testing.T) {
 	ctx := setupTestContext(t)
 	defer func() { _ = ctx.db.Close() }()
 
 	prevEnv := viper.GetString("app_env")
-	viper.Set("app_env", "production")
 	t.Cleanup(func() { viper.Set("app_env", prevEnv) })
-
-	guardian := testpkg.CreateTestGuardianProfile(t, ctx.db, "invite-production")
-	defer cleanupGuardian(t, ctx.db, guardian.ID)
 
 	router := chi.NewRouter()
 	router.Post("/guardians/{id}/invite", ctx.resource.SendInvitationHandler())
 
-	req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/guardians/%d/invite", guardian.ID), nil,
-		testutil.WithClaims(testutil.DefaultTestClaims()),
-		testutil.WithPermissions("users:create"),
-	)
-	req.Header.Set("X-Phoenix-Seed-Token", "true")
+	for _, appEnv := range []string{"production", "staging", "preview", "developement", ""} {
+		t.Run(fmt.Sprintf("app_env=%q", appEnv), func(t *testing.T) {
+			viper.Set("app_env", appEnv)
 
-	rr := testutil.ExecuteRequest(router, req)
+			guardian := testpkg.CreateTestGuardianProfile(t, ctx.db, "invite-"+appEnv)
+			defer cleanupGuardian(t, ctx.db, guardian.ID)
 
-	testutil.AssertSuccessResponse(t, rr, http.StatusCreated)
+			req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/guardians/%d/invite", guardian.ID), nil,
+				testutil.WithClaims(testutil.DefaultTestClaims()),
+				testutil.WithPermissions("users:create"),
+			)
+			req.Header.Set("X-Phoenix-Seed-Token", "true")
 
-	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
-	data, ok := response["data"].(map[string]any)
-	require.True(t, ok, "Expected data to be an object")
-	assert.NotZero(t, data["id"])
-	assert.NotContains(t, data, "token")
+			rr := testutil.ExecuteRequest(router, req)
+
+			testutil.AssertSuccessResponse(t, rr, http.StatusCreated)
+
+			response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+			data, ok := response["data"].(map[string]any)
+			require.True(t, ok, "Expected data to be an object")
+			assert.NotZero(t, data["id"])
+			assert.NotContains(t, data, "token")
+		})
+	}
 }
 
 // =============================================================================

--- a/backend/api/guardians/guardians_test.go
+++ b/backend/api/guardians/guardians_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
@@ -1218,6 +1219,37 @@ func TestSendInvitation_Unauthorized_NoClaims(t *testing.T) {
 	rr := testutil.ExecuteRequest(router, req)
 
 	testutil.AssertUnauthorized(t, rr)
+}
+
+func TestSendInvitation_SeedTokenHeaderDoesNotExposeTokenInProduction(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	prevEnv := viper.GetString("app_env")
+	viper.Set("app_env", "production")
+	t.Cleanup(func() { viper.Set("app_env", prevEnv) })
+
+	guardian := testpkg.CreateTestGuardianProfile(t, ctx.db, "invite-production")
+	defer cleanupGuardian(t, ctx.db, guardian.ID)
+
+	router := chi.NewRouter()
+	router.Post("/guardians/{id}/invite", ctx.resource.SendInvitationHandler())
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/guardians/%d/invite", guardian.ID), nil,
+		testutil.WithClaims(testutil.DefaultTestClaims()),
+		testutil.WithPermissions("users:create"),
+	)
+	req.Header.Set("X-Phoenix-Seed-Token", "true")
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertSuccessResponse(t, rr, http.StatusCreated)
+
+	response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
+	data, ok := response["data"].(map[string]any)
+	require.True(t, ok, "Expected data to be an object")
+	assert.NotZero(t, data["id"])
+	assert.NotContains(t, data, "token")
 }
 
 // =============================================================================

--- a/backend/api/guardians/handlers.go
+++ b/backend/api/guardians/handlers.go
@@ -27,6 +27,7 @@ const (
 	errInvalidPhoneID       = "invalid phone ID"
 	errPhoneNotFound        = "phone number not found"
 	errPhoneNotBelongsGuard = "phone number does not belong to this guardian"
+	seedTokenHeader         = "X-Phoenix-Seed-Token"
 )
 
 // Note: "log" import kept for non-RenderError logging (e.g., line 741)
@@ -997,6 +998,9 @@ func (rs *Resource) sendInvitation(w http.ResponseWriter, r *http.Request) {
 		"guardian_profile_id": invitation.GuardianProfileID,
 		"expires_at":          invitation.ExpiresAt,
 		"email_sent":          invitation.EmailSentAt != nil,
+	}
+	if strings.EqualFold(strings.TrimSpace(r.Header.Get(seedTokenHeader)), "true") {
+		response["token"] = invitation.Token
 	}
 
 	common.Respond(w, r, http.StatusCreated, response, "Invitation sent successfully")

--- a/backend/api/guardians/handlers.go
+++ b/backend/api/guardians/handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/users"
 	guardianSvc "github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/spf13/viper"
 	"github.com/uptrace/bun"
 )
 
@@ -999,11 +1000,18 @@ func (rs *Resource) sendInvitation(w http.ResponseWriter, r *http.Request) {
 		"expires_at":          invitation.ExpiresAt,
 		"email_sent":          invitation.EmailSentAt != nil,
 	}
-	if strings.EqualFold(strings.TrimSpace(r.Header.Get(seedTokenHeader)), "true") {
+	if shouldExposeSeedInvitationToken(r) {
 		response["token"] = invitation.Token
 	}
 
 	common.Respond(w, r, http.StatusCreated, response, "Invitation sent successfully")
+}
+
+func shouldExposeSeedInvitationToken(r *http.Request) bool {
+	if !strings.EqualFold(strings.TrimSpace(r.Header.Get(seedTokenHeader)), "true") {
+		return false
+	}
+	return strings.ToLower(strings.TrimSpace(viper.GetString("app_env"))) != "production"
 }
 
 // listPendingInvitations handles listing all pending guardian invitations

--- a/backend/api/guardians/handlers.go
+++ b/backend/api/guardians/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/internal/seedtoken"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/users"
@@ -28,7 +29,6 @@ const (
 	errInvalidPhoneID       = "invalid phone ID"
 	errPhoneNotFound        = "phone number not found"
 	errPhoneNotBelongsGuard = "phone number does not belong to this guardian"
-	seedTokenHeader         = "X-Phoenix-Seed-Token"
 )
 
 // Note: "log" import kept for non-RenderError logging (e.g., line 741)
@@ -1008,10 +1008,7 @@ func (rs *Resource) sendInvitation(w http.ResponseWriter, r *http.Request) {
 }
 
 func shouldExposeSeedInvitationToken(r *http.Request) bool {
-	if !strings.EqualFold(strings.TrimSpace(r.Header.Get(seedTokenHeader)), "true") {
-		return false
-	}
-	return strings.ToLower(strings.TrimSpace(viper.GetString("app_env"))) != "production"
+	return seedtoken.ShouldExposeInvitationToken(r, viper.GetString("app_env"))
 }
 
 // listPendingInvitations handles listing all pending guardian invitations

--- a/backend/api/operator/provisioning.go
+++ b/backend/api/operator/provisioning.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/internal/seedtoken"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
@@ -22,7 +23,7 @@ import (
 	"github.com/uptrace/bun"
 )
 
-const seedTokenHeader = "X-Phoenix-Seed-Token"
+const seedTokenHeader = seedtoken.Header
 
 // ProvisioningResource handles operator tenant provisioning endpoints.
 type ProvisioningResource struct {
@@ -888,8 +889,5 @@ func (rs *ProvisioningResource) SoftDeletePerson(w http.ResponseWriter, r *http.
 }
 
 func shouldExposeSeedInvitationToken(r *http.Request) bool {
-	if !strings.EqualFold(strings.TrimSpace(r.Header.Get(seedTokenHeader)), "true") {
-		return false
-	}
-	return strings.ToLower(strings.TrimSpace(viper.GetString("app_env"))) != "production"
+	return seedtoken.ShouldExposeInvitationToken(r, viper.GetString("app_env"))
 }

--- a/backend/api/operator/provisioning_internal_test.go
+++ b/backend/api/operator/provisioning_internal_test.go
@@ -434,8 +434,11 @@ func TestProvisioningResource_InviteSchoolAdmin(t *testing.T) {
 		},
 	})
 
+	prevEnv := viper.GetString("app_env")
 	viper.Set("app_env", "development")
-	req := httptest.NewRequest(http.MethodPost, "/operator/schools/12/invite-admin", bytes.NewBufferString(`{"email":" PRINCIPAL@example.com ","first_name":" Ada ","last_name":" Lovelace ","position":" Principal ","caregiver_enabled":true}`))
+	t.Cleanup(func() { viper.Set("app_env", prevEnv) })
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/operator/schools/12/invite-admin", bytes.NewBufferString(`{"email":" PRINCIPAL@example.com ","first_name":" Ada ","last_name":" Lovelace ","position":" Principal ","caregiver_enabled":true}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(seedTokenHeader, "true")
 	req.RemoteAddr = "203.0.113.5:9999"
@@ -491,6 +494,8 @@ func TestProvisioningResource_InviteSchoolAdmin_ServiceValidationError(t *testin
 func TestProvisioningHelpers(t *testing.T) {
 	errText := "boom"
 	now := time.Now()
+	prevEnv := viper.GetString("app_env")
+	t.Cleanup(func() { viper.Set("app_env", prevEnv) })
 
 	assert.Equal(t, int64(0), operatorInvitationCreatedByValue(nil))
 	assert.Equal(t, int64(9), operatorInvitationCreatedByValue(ptrInt64(9)))
@@ -499,12 +504,21 @@ func TestProvisioningHelpers(t *testing.T) {
 	assert.Equal(t, "sent", operatorInvitationDeliveryStatus(&now, &errText))
 
 	viper.Set("app_env", "development")
-	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/", nil)
 	assert.False(t, shouldExposeSeedInvitationToken(req))
 	req.Header.Set(seedTokenHeader, "true")
 	assert.True(t, shouldExposeSeedInvitationToken(req))
 	viper.Set("app_env", "production")
 	assert.False(t, shouldExposeSeedInvitationToken(req))
+	viper.Set("app_env", "staging")
+	assert.False(t, shouldExposeSeedInvitationToken(req))
+	viper.Set("app_env", "developement")
+	assert.False(t, shouldExposeSeedInvitationToken(req))
+
+	viper.Set("app_env", "development")
+	publicReq := httptest.NewRequest(http.MethodPost, "https://api-staging.moto-app.de/", nil)
+	publicReq.Header.Set(seedTokenHeader, "true")
+	assert.False(t, shouldExposeSeedInvitationToken(publicReq))
 }
 
 func TestProvisioningErrorRenderer_NotFoundAndFallbacks(t *testing.T) {

--- a/backend/integration/phoenixapi/adapter.go
+++ b/backend/integration/phoenixapi/adapter.go
@@ -259,12 +259,19 @@ func (a *Adapter) LoginTenant(ctx context.Context, email, password, tenantSlug s
 	}
 
 	var loginResp struct {
+		Data struct {
+			AccessToken string `json:"access_token"`
+		} `json:"data"`
 		AccessToken string `json:"access_token"`
 	}
 	if err := json.Unmarshal(respBody, &loginResp); err != nil {
 		return AuthRef{}, fmt.Errorf("parse login response: %w", err)
 	}
-	if loginResp.AccessToken == "" {
+	token := loginResp.Data.AccessToken
+	if token == "" {
+		token = loginResp.AccessToken
+	}
+	if token == "" {
 		return AuthRef{}, fmt.Errorf("no access token in login response")
 	}
 
@@ -275,7 +282,42 @@ func (a *Adapter) LoginTenant(ctx context.Context, email, password, tenantSlug s
 	return AuthRef{
 		Kind:  AuthBearer,
 		Label: label,
-		Token: loginResp.AccessToken,
+		Token: token,
+	}, nil
+}
+
+func (a *Adapter) LoginParent(ctx context.Context, email, password string) (AuthRef, error) {
+	body := map[string]string{
+		"email":    email,
+		"password": password,
+	}
+
+	respBody, _, err := a.Raw(ctx, AuthRef{}, http.MethodPost, "/parent/auth/login", body, nil)
+	if err != nil {
+		return AuthRef{}, fmt.Errorf("parent login request failed: %w", err)
+	}
+
+	var loginResp struct {
+		Data struct {
+			AccessToken string `json:"access_token"`
+		} `json:"data"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(respBody, &loginResp); err != nil {
+		return AuthRef{}, fmt.Errorf("parse parent login response: %w", err)
+	}
+	token := loginResp.Data.AccessToken
+	if token == "" {
+		token = loginResp.AccessToken
+	}
+	if token == "" {
+		return AuthRef{}, fmt.Errorf("no access token in parent login response")
+	}
+
+	return AuthRef{
+		Kind:  AuthBearer,
+		Label: "parent",
+		Token: token,
 	}, nil
 }
 

--- a/backend/integration/phoenixapi/adapter.go
+++ b/backend/integration/phoenixapi/adapter.go
@@ -258,18 +258,9 @@ func (a *Adapter) LoginTenant(ctx context.Context, email, password, tenantSlug s
 		return AuthRef{}, fmt.Errorf("login request failed: %w", err)
 	}
 
-	var loginResp struct {
-		Data struct {
-			AccessToken string `json:"access_token"`
-		} `json:"data"`
-		AccessToken string `json:"access_token"`
-	}
-	if err := json.Unmarshal(respBody, &loginResp); err != nil {
+	token, err := parseLoginToken(respBody)
+	if err != nil {
 		return AuthRef{}, fmt.Errorf("parse login response: %w", err)
-	}
-	token := loginResp.Data.AccessToken
-	if token == "" {
-		token = loginResp.AccessToken
 	}
 	if token == "" {
 		return AuthRef{}, fmt.Errorf("no access token in login response")
@@ -297,18 +288,9 @@ func (a *Adapter) LoginParent(ctx context.Context, email, password string) (Auth
 		return AuthRef{}, fmt.Errorf("parent login request failed: %w", err)
 	}
 
-	var loginResp struct {
-		Data struct {
-			AccessToken string `json:"access_token"`
-		} `json:"data"`
-		AccessToken string `json:"access_token"`
-	}
-	if err := json.Unmarshal(respBody, &loginResp); err != nil {
+	token, err := parseLoginToken(respBody)
+	if err != nil {
 		return AuthRef{}, fmt.Errorf("parse parent login response: %w", err)
-	}
-	token := loginResp.Data.AccessToken
-	if token == "" {
-		token = loginResp.AccessToken
 	}
 	if token == "" {
 		return AuthRef{}, fmt.Errorf("no access token in parent login response")
@@ -319,6 +301,26 @@ func (a *Adapter) LoginParent(ctx context.Context, email, password string) (Auth
 		Label: "parent",
 		Token: token,
 	}, nil
+}
+
+// parseLoginToken pulls the access token from a login response, tolerating both
+// the enveloped ({"data":{"access_token":...}}) and flat shapes. An empty
+// string (without an error) means no token was present.
+func parseLoginToken(respBody []byte) (string, error) {
+	var loginResp struct {
+		Data struct {
+			AccessToken string `json:"access_token"`
+		} `json:"data"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(respBody, &loginResp); err != nil {
+		return "", err
+	}
+	token := loginResp.Data.AccessToken
+	if token == "" {
+		token = loginResp.AccessToken
+	}
+	return token, nil
 }
 
 func DeviceAuth(apiKey, pin, label string) AuthRef {

--- a/backend/internal/seedtoken/seedtoken.go
+++ b/backend/internal/seedtoken/seedtoken.go
@@ -1,0 +1,67 @@
+package seedtoken
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+const Header = "X-Phoenix-Seed-Token"
+
+var allowedLocalHostnames = map[string]bool{
+	"localhost":               true,
+	"server":                  true,
+	"host.docker.internal":    true,
+	"gateway.docker.internal": true,
+}
+
+// ShouldExposeInvitationToken gates seed-only raw invitation token exposure.
+// API handlers call this only to support local demo seeding; deployed
+// environments must never receive tokens in normal invitation responses.
+func ShouldExposeInvitationToken(r *http.Request, appEnv string) bool {
+	if r == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(r.Header.Get(Header)), "true") {
+		return false
+	}
+	if !isAllowedEnvironment(appEnv) {
+		return false
+	}
+	return isLocalHost(requestHostname(r))
+}
+
+func isAllowedEnvironment(appEnv string) bool {
+	switch strings.ToLower(strings.TrimSpace(appEnv)) {
+	case "development", "dev", "local", "test":
+		return true
+	default:
+		return false
+	}
+}
+
+func requestHostname(r *http.Request) string {
+	host := ""
+	if r != nil {
+		host = strings.TrimSpace(r.Host)
+		if host == "" && r.URL != nil {
+			host = strings.TrimSpace(r.URL.Host)
+		}
+	}
+	if host == "" {
+		return ""
+	}
+
+	if hostname, _, err := net.SplitHostPort(host); err == nil {
+		return strings.ToLower(strings.Trim(hostname, "[]"))
+	}
+	return strings.ToLower(strings.Trim(host, "[]"))
+}
+
+func isLocalHost(hostname string) bool {
+	if allowedLocalHostnames[hostname] {
+		return true
+	}
+	ip := net.ParseIP(hostname)
+	return ip != nil && ip.IsLoopback()
+}

--- a/backend/internal/seedtoken/seedtoken_test.go
+++ b/backend/internal/seedtoken/seedtoken_test.go
@@ -1,0 +1,44 @@
+package seedtoken
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldExposeInvitationToken(t *testing.T) {
+	tests := []struct {
+		name   string
+		env    string
+		host   string
+		header string
+		want   bool
+	}{
+		{name: "missing header denies", env: "development", host: "localhost:8080", want: false},
+		{name: "development localhost allows", env: "development", host: "localhost:8080", header: "true", want: true},
+		{name: "dev loopback allows", env: "dev", host: "127.0.0.1:8080", header: "true", want: true},
+		{name: "test ipv6 loopback allows", env: "test", host: "[::1]:8080", header: "true", want: true},
+		{name: "local docker service allows", env: "local", host: "server:8080", header: "true", want: true},
+		{name: "case-insensitive header allows", env: "development", host: "localhost", header: "TRUE", want: true},
+		{name: "production denies", env: "production", host: "localhost:8080", header: "true", want: false},
+		{name: "staging denies", env: "staging", host: "localhost:8080", header: "true", want: false},
+		{name: "preview denies", env: "preview", host: "localhost:8080", header: "true", want: false},
+		{name: "typo denies", env: "developement", host: "localhost:8080", header: "true", want: false},
+		{name: "empty env denies", env: "", host: "localhost:8080", header: "true", want: false},
+		{name: "public host denies", env: "development", host: "api-staging.moto-app.de", header: "true", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://"+tt.host+"/", nil)
+			req.Host = tt.host
+			if tt.header != "" {
+				req.Header.Set(Header, tt.header)
+			}
+
+			assert.Equal(t, tt.want, ShouldExposeInvitationToken(req, tt.env))
+		})
+	}
+}

--- a/backend/seed/api/client.go
+++ b/backend/seed/api/client.go
@@ -75,6 +75,16 @@ func (c *Client) LoginOperator(email, password string) error {
 	return nil
 }
 
+// LoginParent authenticates with the parents portal API and stores the JWT token.
+func (c *Client) LoginParent(email, password string) error {
+	auth, err := c.adapter.LoginParent(context.Background(), email, password)
+	if err != nil {
+		return err
+	}
+	c.BindAuth(auth)
+	return nil
+}
+
 // Post makes an authenticated POST request
 func (c *Client) Post(path string, body any) ([]byte, error) {
 	return c.doRequestWithHeaders("POST", path, body, true, nil)
@@ -88,6 +98,22 @@ func (c *Client) PostPublic(path string, body any) ([]byte, error) {
 // PostWithHeaders makes an authenticated POST request with extra headers.
 func (c *Client) PostWithHeaders(path string, body any, headers map[string]string) ([]byte, error) {
 	return c.doRequestWithHeaders("POST", path, body, true, headers)
+}
+
+func (c *Client) GetWithAuth(auth phoenixapi.AuthRef, path string) ([]byte, error) {
+	return c.doRequestWithExplicitAuth("GET", path, nil, auth, nil)
+}
+
+func (c *Client) PostWithAuth(auth phoenixapi.AuthRef, path string, body any) ([]byte, error) {
+	return c.doRequestWithExplicitAuth("POST", path, body, auth, nil)
+}
+
+func (c *Client) PutWithAuth(auth phoenixapi.AuthRef, path string, body any) ([]byte, error) {
+	return c.doRequestWithExplicitAuth("PUT", path, body, auth, nil)
+}
+
+func (c *Client) PostWithAuthAndHeaders(auth phoenixapi.AuthRef, path string, body any, headers map[string]string) ([]byte, error) {
+	return c.doRequestWithExplicitAuth("POST", path, body, auth, headers)
 }
 
 // Get makes an authenticated GET request
@@ -112,6 +138,10 @@ func (c *Client) doRequestWithHeaders(method, path string, body any, auth bool, 
 			}
 		}
 	}
+	return c.doRequestWithExplicitAuth(method, path, body, authRef, headers)
+}
+
+func (c *Client) doRequestWithExplicitAuth(method, path string, body any, authRef phoenixapi.AuthRef, headers map[string]string) ([]byte, error) {
 	respBody, statusCode, err := c.adapter.Raw(context.Background(), authRef, method, path, body, headers)
 	if err != nil {
 		return nil, err

--- a/backend/seed/api/parent_enrollment.go
+++ b/backend/seed/api/parent_enrollment.go
@@ -76,6 +76,7 @@ func (s parentEnrollmentSeedStep) seedSettings(rt *Runtime, auth phoenixapi.Auth
 		configModels.KeyParentPickupChangeEnabled: true,
 		configModels.KeyGuardianParentInviteMode:  configModels.ParentInviteModeDirect,
 		configModels.KeyGuardianParentCanRemove:   true,
+		configModels.KeyEnrollmentRequireCaptcha:  false,
 	}
 	for key, value := range settings {
 		if _, err := rt.Client.PutWithAuth(auth, "/api/settings/values/"+key, map[string]any{"value": value}); err != nil {
@@ -141,7 +142,7 @@ func (s parentEnrollmentSeedStep) parentPassword() (string, error) {
 	if strings.TrimSpace(s.seeder.options.StaffPassword) != "" {
 		return s.seeder.options.StaffPassword, nil
 	}
-	return generateSeedPassword()
+	return defaultSeedParentPassword, nil
 }
 
 func (s parentEnrollmentSeedStep) inviteGuardian(rt *Runtime, auth phoenixapi.AuthRef, guardianID int64) (string, error) {

--- a/backend/seed/api/parent_enrollment.go
+++ b/backend/seed/api/parent_enrollment.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -207,12 +208,13 @@ func (s parentEnrollmentSeedStep) seedEnrollment(rt *Runtime, adminAuth phoenixa
 	}
 	state.Offerings = offerings
 
-	submissions := []struct {
+	type enrollmentSubmission struct {
 		source string
 		body   map[string]any
 		auth   phoenixapi.AuthRef
 		path   string
-	}{
+	}
+	submissions := []enrollmentSubmission{
 		{
 			source: "public",
 			path:   "/api/enrollment/" + rt.Bootstrap.TenantSlug + "/submit",
@@ -240,12 +242,7 @@ func (s parentEnrollmentSeedStep) seedEnrollment(rt *Runtime, adminAuth phoenixa
 	}
 	if len(parents) > 1 {
 		parent := parents[1]
-		submissions = append(submissions, struct {
-			source string
-			body   map[string]any
-			auth   phoenixapi.AuthRef
-			path   string
-		}{
+		submissions = append(submissions, enrollmentSubmission{
 			source: "parent",
 			auth:   parentAuths[parent.Email],
 			path:   "/parent/enrollments/" + rt.Bootstrap.TenantSlug + "/submit",
@@ -395,13 +392,13 @@ func (s parentEnrollmentSeedStep) enrollmentSubmission(phaseID int64, offerings 
 	phone := "+49 221 555 990"
 	additionalEmail := strings.ReplaceAll(strings.ToLower(guardianFirstName+"."+guardianLastName), " ", ".") + ".2@example.test"
 	offeringDays := []map[string]any{}
-	if containsInt64(offeringIDs, offerings["ogs-ganztag"]) {
+	if slices.Contains(offeringIDs, offerings["ogs-ganztag"]) {
 		offeringDays = append(offeringDays, map[string]any{
 			"offering_id":   offerings["ogs-ganztag"],
 			"selected_days": []string{"mon", "wed", "fri"},
 		})
 	}
-	if containsInt64(offeringIDs, offerings["ogs-kurz"]) {
+	if slices.Contains(offeringIDs, offerings["ogs-kurz"]) {
 		offeringDays = append(offeringDays, map[string]any{
 			"offering_id":   offerings["ogs-kurz"],
 			"selected_days": []string{"tue", "thu"},
@@ -615,13 +612,4 @@ func statusTokenFromURL(raw string) string {
 
 func intPtr(v int) *int {
 	return &v
-}
-
-func containsInt64(values []int64, needle int64) bool {
-	for _, value := range values {
-		if value == needle {
-			return true
-		}
-	}
-	return false
 }

--- a/backend/seed/api/parent_enrollment.go
+++ b/backend/seed/api/parent_enrollment.go
@@ -1,0 +1,627 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/integration/phoenixapi"
+	configModels "github.com/moto-nrw/project-phoenix/models/config"
+	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
+)
+
+type parentEnrollmentSeedStep struct {
+	seeder *Seeder
+}
+
+func (parentEnrollmentSeedStep) Name() string { return "Parent portal and enrollment seeding" }
+
+func (s parentEnrollmentSeedStep) Run(ctx context.Context, rt *Runtime) error {
+	if rt.FixedSeeder == nil {
+		return fmt.Errorf("fixed seeder not available")
+	}
+	if rt.Bootstrap == nil {
+		return fmt.Errorf("bootstrap state not available")
+	}
+
+	adminAuth, err := rt.Adapter.LoginTenant(ctx, rt.Bootstrap.AdminEmail, rt.Bootstrap.AdminPassword, rt.Bootstrap.TenantSlug)
+	if err != nil {
+		return fmt.Errorf("login seed school admin: %w", err)
+	}
+	rt.SetTenantAuth(adminAuth)
+
+	settings, err := s.seedSettings(rt, adminAuth)
+	if err != nil {
+		return err
+	}
+
+	parents, parentAuths, err := s.seedParentAccounts(ctx, rt, adminAuth)
+	if err != nil {
+		return err
+	}
+	rt.Parents = parents
+
+	enrollmentState, err := s.seedEnrollment(rt, adminAuth, parents, parentAuths)
+	if err != nil {
+		return err
+	}
+	enrollmentState.Settings = settings
+
+	if len(parents) > 0 {
+		actions, err := s.seedParentPortalActions(rt, parentAuths[parents[0].Email], parents[0])
+		if err != nil {
+			return err
+		}
+		enrollmentState.ParentActions = actions
+	}
+
+	rt.Enrollment = enrollmentState
+	rt.SetTenantAuth(adminAuth)
+	fmt.Printf("Seeded %d parent accounts and %d enrollment requests\n", len(rt.Parents), len(rt.Enrollment.Requests))
+	fmt.Println()
+	return nil
+}
+
+func (s parentEnrollmentSeedStep) seedSettings(rt *Runtime, auth phoenixapi.AuthRef) (map[string]any, error) {
+	settings := map[string]any{
+		configModels.KeyEnrollmentEnabled:         true,
+		configModels.KeyParentSickNoteEnabled:     true,
+		configModels.KeyParentNotesEnabled:        true,
+		configModels.KeyParentPickupChangeEnabled: true,
+		configModels.KeyGuardianParentInviteMode:  configModels.ParentInviteModeDirect,
+		configModels.KeyGuardianParentCanRemove:   true,
+	}
+	for key, value := range settings {
+		if _, err := rt.Client.PutWithAuth(auth, "/api/settings/values/"+key, map[string]any{"value": value}); err != nil {
+			return nil, fmt.Errorf("set setting %s: %w", key, err)
+		}
+	}
+	return settings, nil
+}
+
+func (s parentEnrollmentSeedStep) seedParentAccounts(ctx context.Context, rt *Runtime, adminAuth phoenixapi.AuthRef) ([]ParentCredentials, map[string]phoenixapi.AuthRef, error) {
+	password, err := s.parentPassword()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	guardianIndexes := []int{0, 5, 19, 32, 54}
+	parents := make([]ParentCredentials, 0, len(guardianIndexes))
+	parentAuths := make(map[string]phoenixapi.AuthRef, len(guardianIndexes))
+	for _, idx := range guardianIndexes {
+		if idx < 0 || idx >= len(DemoGuardians) {
+			return nil, nil, fmt.Errorf("demo guardian index %d out of range", idx)
+		}
+		guardian := DemoGuardians[idx]
+		guardianKey := fmt.Sprintf("%s %s", guardian.FirstName, guardian.LastName)
+		guardianID, ok := rt.FixedSeeder.guardianIDs[guardianKey]
+		if !ok || guardianID == 0 {
+			return nil, nil, fmt.Errorf("guardian %s was not created", guardianKey)
+		}
+		studentID, ok := rt.FixedSeeder.studentIDByIndex[guardian.StudentIndex]
+		if !ok || studentID == 0 {
+			return nil, nil, fmt.Errorf("student index %d for guardian %s was not created", guardian.StudentIndex, guardianKey)
+		}
+
+		token, err := s.inviteGuardian(rt, adminAuth, guardianID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invite guardian %s: %w", guardianKey, err)
+		}
+		accountID, err := s.acceptGuardianInvitation(rt, token, password)
+		if err != nil {
+			return nil, nil, fmt.Errorf("accept guardian invitation for %s: %w", guardianKey, err)
+		}
+
+		auth, err := rt.Adapter.LoginParent(ctx, guardian.Email, password)
+		if err != nil {
+			return nil, nil, fmt.Errorf("login parent %s: %w", guardian.Email, err)
+		}
+
+		parent := ParentCredentials{
+			Email:      guardian.Email,
+			Password:   password,
+			Name:       guardianKey,
+			AccountID:  accountID,
+			GuardianID: guardianID,
+			StudentIDs: []int64{studentID},
+		}
+		parents = append(parents, parent)
+		parentAuths[parent.Email] = auth
+	}
+	return parents, parentAuths, nil
+}
+
+func (s parentEnrollmentSeedStep) parentPassword() (string, error) {
+	if strings.TrimSpace(s.seeder.options.StaffPassword) != "" {
+		return s.seeder.options.StaffPassword, nil
+	}
+	return generateSeedPassword()
+}
+
+func (s parentEnrollmentSeedStep) inviteGuardian(rt *Runtime, auth phoenixapi.AuthRef, guardianID int64) (string, error) {
+	respBody, err := rt.Client.PostWithAuthAndHeaders(
+		auth,
+		fmt.Sprintf("/api/guardians/%d/invite", guardianID),
+		map[string]any{},
+		map[string]string{seedTokenHeader: "true"},
+	)
+	if err != nil {
+		return "", err
+	}
+	var resp struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	if err := parseJSON(respBody, &resp); err != nil {
+		return "", fmt.Errorf("parse guardian invitation response: %w", err)
+	}
+	if resp.Data.Token == "" {
+		return "", fmt.Errorf("guardian invitation response did not include seed token")
+	}
+	return resp.Data.Token, nil
+}
+
+func (s parentEnrollmentSeedStep) acceptGuardianInvitation(rt *Runtime, token, password string) (int64, error) {
+	respBody, err := rt.Client.PostPublic("/auth/guardian-invitations/"+token+"/accept", map[string]any{
+		"password":         password,
+		"confirm_password": password,
+	})
+	if err != nil {
+		return 0, err
+	}
+	var resp struct {
+		Data struct {
+			AccountID int64 `json:"account_id"`
+		} `json:"data"`
+	}
+	if err := parseJSON(respBody, &resp); err != nil {
+		return 0, fmt.Errorf("parse guardian invitation accept response: %w", err)
+	}
+	if resp.Data.AccountID == 0 {
+		return 0, fmt.Errorf("guardian invitation accept response did not include account_id")
+	}
+	return resp.Data.AccountID, nil
+}
+
+func (s parentEnrollmentSeedStep) seedEnrollment(rt *Runtime, adminAuth phoenixapi.AuthRef, parents []ParentCredentials, parentAuths map[string]phoenixapi.AuthRef) (SeedEnrollmentState, error) {
+	state := SeedEnrollmentState{
+		Offerings: make(map[string]int64),
+		Settings:  make(map[string]any),
+	}
+
+	phaseID, err := s.createEnrollmentPhase(rt, adminAuth)
+	if err != nil {
+		return state, err
+	}
+	state.PhaseID = phaseID
+
+	offerings, err := s.createCareOfferings(rt, adminAuth, phaseID)
+	if err != nil {
+		return state, err
+	}
+	state.Offerings = offerings
+
+	submissions := []struct {
+		source string
+		body   map[string]any
+		auth   phoenixapi.AuthRef
+		path   string
+	}{
+		{
+			source: "public",
+			path:   "/api/enrollment/" + rt.Bootstrap.TenantSlug + "/submit",
+			body: s.enrollmentSubmission(phaseID, offerings, "Lea", "Sommer", "2019-04-18", 1,
+				"Daniela", "Sommer", "daniela.sommer@example.test", "public-new-child",
+				[]int64{offerings["ogs-ganztag"], offerings["mittagessen"]},
+			),
+		},
+		{
+			source: "public",
+			path:   "/api/enrollment/" + rt.Bootstrap.TenantSlug + "/submit",
+			body: s.enrollmentSubmission(phaseID, offerings, "Mika", "Winter", "2018-11-03", 2,
+				"Robert", "Winter", "robert.winter@example.test", "public-waitlist",
+				[]int64{offerings["ferienbetreuung"], offerings["mittagessen"]},
+			),
+		},
+		{
+			source: "public",
+			path:   "/api/enrollment/" + rt.Bootstrap.TenantSlug + "/submit",
+			body: s.enrollmentSubmission(phaseID, offerings, "Nora", "Brandt", "2017-07-22", 3,
+				"Elena", "Brandt", "elena.brandt@example.test", "public-reject",
+				[]int64{offerings["ogs-kurz"], offerings["mittagessen"]},
+			),
+		},
+	}
+	if len(parents) > 1 {
+		parent := parents[1]
+		submissions = append(submissions, struct {
+			source string
+			body   map[string]any
+			auth   phoenixapi.AuthRef
+			path   string
+		}{
+			source: "parent",
+			auth:   parentAuths[parent.Email],
+			path:   "/parent/enrollments/" + rt.Bootstrap.TenantSlug + "/submit",
+			body: s.enrollmentSubmission(phaseID, offerings, "Lina", "Richter", "2019-02-14", 1,
+				"Thomas", "Richter", parent.Email, "parent-authenticated",
+				[]int64{offerings["ogs-ganztag"], offerings["mittagessen"]},
+			),
+		})
+	}
+
+	for _, submission := range submissions {
+		if submission.source == "parent" {
+			if _, err := rt.Client.GetWithAuth(submission.auth, "/parent/enrollments/"+rt.Bootstrap.TenantSlug+"/profile"); err != nil {
+				return state, fmt.Errorf("load parent enrollment profile before submit: %w", err)
+			}
+		}
+
+		var respBody []byte
+		var submitErr error
+		if submission.source == "parent" {
+			respBody, submitErr = rt.Client.PostWithAuth(submission.auth, submission.path, submission.body)
+		} else {
+			respBody, submitErr = rt.Client.PostPublic(submission.path, submission.body)
+		}
+		if submitErr != nil {
+			return state, fmt.Errorf("submit %s enrollment: %w", submission.source, submitErr)
+		}
+		request, err := parseEnrollmentSubmitResponse(respBody, submission.source)
+		if err != nil {
+			return state, err
+		}
+		detail, err := s.loadEnrollmentRequestDetail(rt, adminAuth, request.RequestID)
+		if err != nil {
+			return state, err
+		}
+		request.StatusToken = detail.StatusToken
+		request.ChildIDs = detail.ChildIDs
+		state.Requests = append(state.Requests, request)
+	}
+
+	decisions := []struct {
+		index  int
+		status string
+		reason string
+	}{
+		{index: 0, status: enrollmentModels.ChildStatusApproved, reason: "Demo-Zusage fuer die Elternapp"},
+		{index: 1, status: enrollmentModels.ChildStatusWaitlisted, reason: "Demo-Warteliste wegen begrenzter Plaetze"},
+		{index: 2, status: enrollmentModels.ChildStatusRejected, reason: "Demo-Absage fuer Testdaten"},
+	}
+	for _, decision := range decisions {
+		if decision.index >= len(state.Requests) || len(state.Requests[decision.index].ChildIDs) == 0 {
+			continue
+		}
+		request := &state.Requests[decision.index]
+		childID := request.ChildIDs[0]
+		if err := s.decideEnrollmentChild(rt, adminAuth, request.RequestID, childID, decision.status, decision.reason); err != nil {
+			return state, err
+		}
+		request.Status = decision.status
+	}
+	return state, nil
+}
+
+func (s parentEnrollmentSeedStep) createEnrollmentPhase(rt *Runtime, auth phoenixapi.AuthRef) (int64, error) {
+	now := time.Now().UTC()
+	openAt := now.Add(-24 * time.Hour).Format(time.RFC3339)
+	closeAt := now.AddDate(0, 2, 0).Format(time.RFC3339)
+	serviceStart := now.AddDate(0, 2, 0).Format("2006-01-02")
+	serviceEnd := now.AddDate(1, 1, 0).Format("2006-01-02")
+	body := map[string]any{
+		"name":                         fmt.Sprintf("Demo Anmeldung %d/%d", now.Year(), now.Year()+1),
+		"kind":                         enrollmentModels.PhaseKindSchoolYear,
+		"service_start_date":           serviceStart,
+		"service_end_date":             serviceEnd,
+		"enrollment_open_at":           openAt,
+		"enrollment_close_at":          closeAt,
+		"show_status_reason_to_parent": true,
+		"care_overflow_mode":           enrollmentModels.PhaseCareOverflowWaitlist,
+		"care_offering_selection_mode": enrollmentModels.PhaseCareOfferingSelectionAtLeastOne,
+		"is_active":                    true,
+	}
+	respBody, err := rt.Client.PostWithAuth(auth, "/api/enrollment/phases", body)
+	if err != nil {
+		return 0, fmt.Errorf("create enrollment phase: %w", err)
+	}
+	id, err := parseEnvelopeStringID(respBody)
+	if err != nil {
+		return 0, fmt.Errorf("parse enrollment phase response: %w", err)
+	}
+	return id, nil
+}
+
+func (s parentEnrollmentSeedStep) createCareOfferings(rt *Runtime, auth phoenixapi.AuthRef, phaseID int64) (map[string]int64, error) {
+	offerings := []struct {
+		key         string
+		name        string
+		description string
+		daysMode    string
+		days        []string
+		lunch       bool
+		required    bool
+		price       int
+		capacity    *int
+		sort        int
+	}{
+		{key: "ogs-ganztag", name: "OGS Ganztag", description: "Betreuung bis 16 Uhr", daysMode: enrollmentModels.DaysOfWeekModeParentChoice, days: []string{"mon", "tue", "wed", "thu", "fri"}, lunch: true, price: 16500, sort: 10},
+		{key: "ogs-kurz", name: "Kurzbetreuung", description: "Betreuung bis 14 Uhr", daysMode: enrollmentModels.DaysOfWeekModeParentChoice, days: []string{"mon", "tue", "wed", "thu", "fri"}, lunch: false, price: 9000, sort: 20},
+		{key: "mittagessen", name: "Mittagessen", description: "Warme Mahlzeit an Betreuungstagen", daysMode: enrollmentModels.DaysOfWeekModeFixed, days: []string{"mon", "tue", "wed", "thu", "fri"}, lunch: true, required: true, price: 5200, sort: 30},
+		{key: "ferienbetreuung", name: "Ferienbetreuung Herbst", description: "Plaetze fuer die Herbstferien", daysMode: enrollmentModels.DaysOfWeekModeFixed, days: []string{"mon", "tue", "wed", "thu", "fri"}, lunch: true, price: 7500, capacity: intPtr(2), sort: 40},
+	}
+
+	created := make(map[string]int64, len(offerings))
+	for _, offering := range offerings {
+		description := offering.description
+		price := offering.price
+		body := map[string]any{
+			"phase_id":              phaseID,
+			"name":                  offering.name,
+			"description":           description,
+			"days_of_week_mode":     offering.daysMode,
+			"available_days":        offering.days,
+			"includes_holiday_care": offering.key == "ferienbetreuung",
+			"includes_lunch":        offering.lunch,
+			"price_cents":           price,
+			"is_active":             true,
+			"is_required":           offering.required,
+			"sort_order":            offering.sort,
+			"selection_rule":        enrollmentModels.SelectionRuleOptional,
+		}
+		if offering.capacity != nil {
+			body["capacity"] = *offering.capacity
+		}
+		respBody, err := rt.Client.PostWithAuth(auth, "/api/enrollment/care-offerings", body)
+		if err != nil {
+			return nil, fmt.Errorf("create care offering %s: %w", offering.key, err)
+		}
+		id, err := parseEnvelopeStringID(respBody)
+		if err != nil {
+			return nil, fmt.Errorf("parse care offering %s response: %w", offering.key, err)
+		}
+		created[offering.key] = id
+	}
+	return created, nil
+}
+
+func (s parentEnrollmentSeedStep) enrollmentSubmission(phaseID int64, offerings map[string]int64, childFirstName, childLastName, dob string, grade int16, guardianFirstName, guardianLastName, guardianEmail, source string, offeringIDs []int64) map[string]any {
+	phone := "+49 221 555 990"
+	additionalEmail := strings.ReplaceAll(strings.ToLower(guardianFirstName+"."+guardianLastName), " ", ".") + ".2@example.test"
+	offeringDays := []map[string]any{}
+	if containsInt64(offeringIDs, offerings["ogs-ganztag"]) {
+		offeringDays = append(offeringDays, map[string]any{
+			"offering_id":   offerings["ogs-ganztag"],
+			"selected_days": []string{"mon", "wed", "fri"},
+		})
+	}
+	if containsInt64(offeringIDs, offerings["ogs-kurz"]) {
+		offeringDays = append(offeringDays, map[string]any{
+			"offering_id":   offerings["ogs-kurz"],
+			"selected_days": []string{"tue", "thu"},
+		})
+	}
+	return map[string]any{
+		"phase_id":            phaseID,
+		"guardian_first_name": guardianFirstName,
+		"guardian_last_name":  guardianLastName,
+		"guardian_email":      guardianEmail,
+		"guardian_phone":      phone,
+		"additional_guardians": []map[string]any{
+			{
+				"first_name": "Co",
+				"last_name":  guardianLastName,
+				"email":      additionalEmail,
+			},
+		},
+		"consent_flags": map[string]any{
+			"data_processing": true,
+			"photos":          source != "public-reject",
+		},
+		"custom_data": map[string]any{
+			"seed_source": source,
+			"note":        "Demo-Datensatz fuer Anmeldung und Elternportal",
+		},
+		"children": []map[string]any{
+			{
+				"first_name":         childFirstName,
+				"last_name":          childLastName,
+				"date_of_birth":      dob,
+				"target_grade_level": grade,
+				"offering_ids":       offeringIDs,
+				"offering_days":      offeringDays,
+				"custom_data": map[string]any{
+					"allergies": "keine",
+				},
+			},
+		},
+	}
+}
+
+func parseEnrollmentSubmitResponse(respBody []byte, source string) (SeedEnrollmentRequest, error) {
+	var resp struct {
+		Data struct {
+			RequestID string `json:"request_id"`
+			StatusURL string `json:"status_url"`
+		} `json:"data"`
+	}
+	if err := parseJSON(respBody, &resp); err != nil {
+		return SeedEnrollmentRequest{}, fmt.Errorf("parse enrollment submit response: %w", err)
+	}
+	requestID, err := strconv.ParseInt(resp.Data.RequestID, 10, 64)
+	if err != nil || requestID == 0 {
+		return SeedEnrollmentRequest{}, fmt.Errorf("enrollment submit response has invalid request_id %q", resp.Data.RequestID)
+	}
+	return SeedEnrollmentRequest{
+		RequestID:   requestID,
+		Source:      source,
+		StatusURL:   resp.Data.StatusURL,
+		StatusToken: statusTokenFromURL(resp.Data.StatusURL),
+	}, nil
+}
+
+type enrollmentRequestDetail struct {
+	StatusToken string
+	ChildIDs    []int64
+}
+
+func (s parentEnrollmentSeedStep) loadEnrollmentRequestDetail(rt *Runtime, auth phoenixapi.AuthRef, requestID int64) (enrollmentRequestDetail, error) {
+	respBody, err := rt.Client.GetWithAuth(auth, fmt.Sprintf("/api/enrollment/admin/requests/%d", requestID))
+	if err != nil {
+		return enrollmentRequestDetail{}, fmt.Errorf("load enrollment request %d: %w", requestID, err)
+	}
+	var resp struct {
+		Data struct {
+			StatusToken string `json:"status_token"`
+			Children    []struct {
+				ID string `json:"id"`
+			} `json:"children"`
+		} `json:"data"`
+	}
+	if err := parseJSON(respBody, &resp); err != nil {
+		return enrollmentRequestDetail{}, fmt.Errorf("parse enrollment request detail: %w", err)
+	}
+	detail := enrollmentRequestDetail{StatusToken: resp.Data.StatusToken}
+	for _, child := range resp.Data.Children {
+		childID, err := strconv.ParseInt(child.ID, 10, 64)
+		if err != nil || childID == 0 {
+			return enrollmentRequestDetail{}, fmt.Errorf("enrollment request %d has invalid child id %q", requestID, child.ID)
+		}
+		detail.ChildIDs = append(detail.ChildIDs, childID)
+	}
+	return detail, nil
+}
+
+func (s parentEnrollmentSeedStep) decideEnrollmentChild(rt *Runtime, auth phoenixapi.AuthRef, requestID, childID int64, status, reason string) error {
+	_, err := rt.Client.PostWithAuth(auth, fmt.Sprintf("/api/enrollment/admin/requests/%d/children/%d/decide", requestID, childID), map[string]any{
+		"status": status,
+		"reason": reason,
+	})
+	if err != nil {
+		return fmt.Errorf("decide enrollment request %d child %d as %s: %w", requestID, childID, status, err)
+	}
+	return nil
+}
+
+func (s parentEnrollmentSeedStep) seedParentPortalActions(rt *Runtime, parentAuth phoenixapi.AuthRef, parent ParentCredentials) ([]SeedParentPortalAction, error) {
+	if len(parent.StudentIDs) == 0 {
+		return nil, nil
+	}
+	studentID := parent.StudentIDs[0]
+	if _, err := rt.Client.GetWithAuth(parentAuth, "/parent/me/profile"); err != nil {
+		return nil, fmt.Errorf("load parent profile: %w", err)
+	}
+	if _, err := rt.Client.GetWithAuth(parentAuth, "/parent/me/children"); err != nil {
+		return nil, fmt.Errorf("load parent children: %w", err)
+	}
+	if _, err := rt.Client.GetWithAuth(parentAuth, fmt.Sprintf("/parent/me/children/%d/features", studentID)); err != nil {
+		return nil, fmt.Errorf("load parent child features: %w", err)
+	}
+
+	actions := []struct {
+		actionType string
+		path       string
+		body       map[string]any
+	}{
+		{
+			actionType: "sick-note",
+			path:       fmt.Sprintf("/parent/me/children/%d/sick-note", studentID),
+			body: map[string]any{
+				"dates":  []string{time.Now().AddDate(0, 0, 2).Format("2006-01-02")},
+				"reason": "Demo-Krankmeldung aus dem Elternportal",
+			},
+		},
+		{
+			actionType: "note",
+			path:       fmt.Sprintf("/parent/me/children/%d/notes", studentID),
+			body: map[string]any{
+				"body": "Demo-Nachricht: wird heute von Oma abgeholt.",
+			},
+		},
+		{
+			actionType: "care-exception",
+			path:       fmt.Sprintf("/parent/me/children/%d/care-exception", studentID),
+			body: map[string]any{
+				"date":        time.Now().AddDate(0, 0, 3).Format("2006-01-02"),
+				"pickup_time": "14:30",
+			},
+		},
+		{
+			actionType: "related-account",
+			path:       fmt.Sprintf("/parent/me/children/%d/related-accounts", studentID),
+			body: map[string]any{
+				"email":      "oma.schneider@example.test",
+				"first_name": "Elke",
+				"last_name":  "Schneider",
+			},
+		},
+	}
+
+	out := make([]SeedParentPortalAction, 0, len(actions))
+	for _, action := range actions {
+		if _, err := rt.Client.PostWithAuth(parentAuth, action.path, action.body); err != nil {
+			return nil, fmt.Errorf("create parent portal action %s: %w", action.actionType, err)
+		}
+		out = append(out, SeedParentPortalAction{
+			ParentEmail: parent.Email,
+			StudentID:   studentID,
+			Type:        action.actionType,
+		})
+	}
+	return out, nil
+}
+
+func parseEnvelopeStringID(respBody []byte) (int64, error) {
+	var resp struct {
+		Data struct {
+			ID any `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return 0, err
+	}
+	id, err := parseSeedID(resp.Data.ID)
+	if err != nil || id == 0 {
+		return 0, fmt.Errorf("invalid id %v", resp.Data.ID)
+	}
+	return id, nil
+}
+
+func parseSeedID(value any) (int64, error) {
+	switch v := value.(type) {
+	case string:
+		return strconv.ParseInt(v, 10, 64)
+	case float64:
+		return int64(v), nil
+	case json.Number:
+		return v.Int64()
+	default:
+		return 0, fmt.Errorf("unsupported id type %T", value)
+	}
+}
+
+func statusTokenFromURL(raw string) string {
+	if parsed, err := url.Parse(raw); err == nil {
+		return path.Base(parsed.Path)
+	}
+	return path.Base(raw)
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func containsInt64(values []int64, needle int64) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/seed/api/runtime.go
+++ b/backend/seed/api/runtime.go
@@ -17,6 +17,8 @@ type Runtime struct {
 	FixedSeeder      *FixedSeeder
 	Result           *SeedResult
 	State            *SeedState
+	Parents          []ParentCredentials
+	Enrollment       SeedEnrollmentState
 	Values           map[string]any
 }
 

--- a/backend/seed/api/seeder.go
+++ b/backend/seed/api/seeder.go
@@ -454,7 +454,7 @@ func (s *Seeder) printSuccessSummary(email, adminPassword string, result *SeedRe
 			fmt.Printf("  Enrollment phase: %d\n", state.Enrollment.PhaseID)
 		}
 		if len(state.Enrollment.Offerings) > 0 {
-			fmt.Printf("  Care offerings:   %d (%s)\n", len(state.Enrollment.Offerings), formatSeedIDMap(state.Enrollment.Offerings))
+			fmt.Printf("  Care offerings:   %d (%s)\n", len(state.Enrollment.Offerings), formatSortedCountMap(state.Enrollment.Offerings))
 		}
 		if len(state.Enrollment.Requests) > 0 {
 			fmt.Printf("  Enroll. requests: %d (%s)\n", len(state.Enrollment.Requests), formatEnrollmentStatusCounts(state.Enrollment.Requests))
@@ -482,7 +482,27 @@ func formatSeedIDList(ids []int64) string {
 	return strings.Join(parts, ", ")
 }
 
-func formatSeedIDMap(values map[string]int64) string {
+func formatEnrollmentStatusCounts(requests []SeedEnrollmentRequest) string {
+	return formatSortedCountMap(countBy(requests, func(request SeedEnrollmentRequest) string {
+		if status := strings.TrimSpace(request.Status); status != "" {
+			return status
+		}
+		return "submitted"
+	}))
+}
+
+func formatParentActionCounts(actions []SeedParentPortalAction) string {
+	return formatSortedCountMap(countBy(actions, func(action SeedParentPortalAction) string {
+		if actionType := strings.TrimSpace(action.Type); actionType != "" {
+			return actionType
+		}
+		return "unknown"
+	}))
+}
+
+// formatSortedCountMap renders a string->number map as "key=value" pairs sorted
+// by key, or "-" when empty.
+func formatSortedCountMap[V int | int64](values map[string]V) string {
 	if len(values) == 0 {
 		return "-"
 	}
@@ -498,45 +518,11 @@ func formatSeedIDMap(values map[string]int64) string {
 	return strings.Join(parts, ", ")
 }
 
-func formatEnrollmentStatusCounts(requests []SeedEnrollmentRequest) string {
-	if len(requests) == 0 {
-		return "-"
-	}
+// countBy tallies items by the string key derived from each element.
+func countBy[T any](items []T, key func(T) string) map[string]int {
 	counts := make(map[string]int)
-	for _, request := range requests {
-		status := strings.TrimSpace(request.Status)
-		if status == "" {
-			status = "submitted"
-		}
-		counts[status]++
+	for _, item := range items {
+		counts[key(item)]++
 	}
-	return formatSeedCountMap(counts)
-}
-
-func formatParentActionCounts(actions []SeedParentPortalAction) string {
-	if len(actions) == 0 {
-		return "-"
-	}
-	counts := make(map[string]int)
-	for _, action := range actions {
-		actionType := strings.TrimSpace(action.Type)
-		if actionType == "" {
-			actionType = "unknown"
-		}
-		counts[actionType]++
-	}
-	return formatSeedCountMap(counts)
-}
-
-func formatSeedCountMap(counts map[string]int) string {
-	keys := make([]string, 0, len(counts))
-	for key := range counts {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	parts := make([]string, 0, len(keys))
-	for _, key := range keys {
-		parts = append(parts, fmt.Sprintf("%s=%d", key, counts[key]))
-	}
-	return strings.Join(parts, ", ")
+	return counts
 }

--- a/backend/seed/api/seeder.go
+++ b/backend/seed/api/seeder.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/integration/phoenixapi"
+	"github.com/moto-nrw/project-phoenix/internal/seedtoken"
 )
 
 const (
@@ -19,7 +20,8 @@ const (
 	defaultSeedSchoolName       = "Demo School"
 	defaultSeedSchoolSlug       = "demo-school"
 	defaultSeedSchoolSubdomain  = "demo-school"
-	seedTokenHeader             = "X-Phoenix-Seed-Token"
+	seedTokenHeader             = seedtoken.Header
+	defaultSeedParentPassword   = "ParentSeed1234%"
 	seedPasswordAlphabet        = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789!@#$%"
 	seedPasswordLength          = 12
 )

--- a/backend/seed/api/seeder.go
+++ b/backend/seed/api/seeder.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -403,7 +404,7 @@ func (s *Seeder) formatError(stage string, err error) error {
 }
 
 // printSuccessSummary prints the final demo-ready status with all created data
-func (s *Seeder) printSuccessSummary(email, adminPassword string, result *SeedResult) {
+func (s *Seeder) printSuccessSummary(email, adminPassword string, result *SeedResult, state *SeedState) {
 	fmt.Println()
 	fmt.Println("=== DEMO READY ===")
 	fmt.Println()
@@ -424,6 +425,17 @@ func (s *Seeder) printSuccessSummary(email, adminPassword string, result *SeedRe
 	}
 	fmt.Println()
 
+	if state != nil && len(state.Parents) > 0 {
+		fmt.Println("PARENT ACCOUNTS:")
+		fmt.Println("  Name                 | Email                         | Password     | Student IDs")
+		fmt.Println("  " + "--------------------" + " | " + "-----------------------------" + " | " + "------------" + " | " + "-----------")
+		for _, parent := range state.Parents {
+			fmt.Printf("  %-20s | %-29s | %-12s | %s\n",
+				parent.Name, parent.Email, parent.Password, formatSeedIDList(parent.StudentIDs))
+		}
+		fmt.Println()
+	}
+
 	// Statistics
 	fmt.Println("CREATED DATA:")
 	fmt.Printf("  Rooms:            %d\n", result.Fixed.RoomCount)
@@ -436,10 +448,95 @@ func (s *Seeder) printSuccessSummary(email, adminPassword string, result *SeedRe
 	fmt.Printf("  Pickup schedules: %d\n", result.Fixed.PickupScheduleCount)
 	fmt.Printf("  Activities:       %d\n", result.Fixed.ActivityCount)
 	fmt.Printf("  IoT Devices:      %d\n", result.Fixed.DeviceCount)
+	if state != nil {
+		fmt.Printf("  Parent accounts:  %d\n", len(state.Parents))
+		if state.Enrollment.PhaseID != 0 {
+			fmt.Printf("  Enrollment phase: %d\n", state.Enrollment.PhaseID)
+		}
+		if len(state.Enrollment.Offerings) > 0 {
+			fmt.Printf("  Care offerings:   %d (%s)\n", len(state.Enrollment.Offerings), formatSeedIDMap(state.Enrollment.Offerings))
+		}
+		if len(state.Enrollment.Requests) > 0 {
+			fmt.Printf("  Enroll. requests: %d (%s)\n", len(state.Enrollment.Requests), formatEnrollmentStatusCounts(state.Enrollment.Requests))
+		}
+		if len(state.Enrollment.ParentActions) > 0 {
+			fmt.Printf("  Parent actions:   %d (%s)\n", len(state.Enrollment.ParentActions), formatParentActionCounts(state.Enrollment.ParentActions))
+		}
+	}
 	fmt.Println()
 
 	fmt.Println("OUTPUT FILES:")
 	fmt.Printf("  %s   (seed state with credentials & IDs)\n", DefaultSeedStatePath)
 	fmt.Println("  simulator.yaml  (simulator configuration)")
 	fmt.Println()
+}
+
+func formatSeedIDList(ids []int64) string {
+	if len(ids) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, fmt.Sprintf("%d", id))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatSeedIDMap(values map[string]int64) string {
+	if len(values) == 0 {
+		return "-"
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", key, values[key]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatEnrollmentStatusCounts(requests []SeedEnrollmentRequest) string {
+	if len(requests) == 0 {
+		return "-"
+	}
+	counts := make(map[string]int)
+	for _, request := range requests {
+		status := strings.TrimSpace(request.Status)
+		if status == "" {
+			status = "submitted"
+		}
+		counts[status]++
+	}
+	return formatSeedCountMap(counts)
+}
+
+func formatParentActionCounts(actions []SeedParentPortalAction) string {
+	if len(actions) == 0 {
+		return "-"
+	}
+	counts := make(map[string]int)
+	for _, action := range actions {
+		actionType := strings.TrimSpace(action.Type)
+		if actionType == "" {
+			actionType = "unknown"
+		}
+		counts[actionType]++
+	}
+	return formatSeedCountMap(counts)
+}
+
+func formatSeedCountMap(counts map[string]int) string {
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", key, counts[key]))
+	}
+	return strings.Join(parts, ", ")
 }

--- a/backend/seed/api/seeder_test.go
+++ b/backend/seed/api/seeder_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/moto-nrw/project-phoenix/integration/phoenixapi"
+	configModels "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,6 +32,45 @@ func TestGenerateSeedPassword(t *testing.T) {
 		assert.Regexp(t, `[0-9]`, password, "must contain digit")
 		assert.Regexp(t, `[^a-zA-Z0-9]`, password, "must contain special char")
 	}
+}
+
+func TestParentEnrollmentSeedSettingsDisableCaptcha(t *testing.T) {
+	seen := make(map[string]any)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+
+		var body struct {
+			Value any `json:"value"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		seen[strings.TrimPrefix(r.URL.Path, "/api/settings/values/")] = body.Value
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"status":"success","data":null}`)
+	}))
+	defer srv.Close()
+
+	rt := &Runtime{Client: NewClient(srv.URL, false)}
+	step := parentEnrollmentSeedStep{}
+
+	settings, err := step.seedSettings(rt, phoenixapi.AuthRef{})
+	require.NoError(t, err)
+
+	assert.Equal(t, false, settings[configModels.KeyEnrollmentRequireCaptcha])
+	assert.Equal(t, false, seen[configModels.KeyEnrollmentRequireCaptcha])
+}
+
+func TestParentEnrollmentParentPassword(t *testing.T) {
+	step := parentEnrollmentSeedStep{seeder: &Seeder{}}
+
+	password, err := step.parentPassword()
+	require.NoError(t, err)
+	assert.Equal(t, defaultSeedParentPassword, password)
+
+	step = parentEnrollmentSeedStep{seeder: &Seeder{options: SeedOptions{StaffPassword: "SharedPass1!"}}}
+	password, err = step.parentPassword()
+	require.NoError(t, err)
+	assert.Equal(t, "SharedPass1!", password)
 }
 
 func TestWrapConflictError(t *testing.T) {

--- a/backend/seed/api/seeder_test.go
+++ b/backend/seed/api/seeder_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/moto-nrw/project-phoenix/integration/phoenixapi"
@@ -354,7 +355,23 @@ func TestPrintSuccessSummary_DoesNotPanic(t *testing.T) {
 		},
 	}
 	// Should not panic
-	s.printSuccessSummary("admin@test.de", "generated-password", result)
+	state := &SeedState{
+		Parents: []ParentCredentials{
+			{Email: "parent@example.test", Password: "pass1", Name: "Demo Parent", StudentIDs: []int64{42}},
+		},
+		Enrollment: SeedEnrollmentState{
+			PhaseID:   1,
+			Offerings: map[string]int64{"ogs-ganztag": 2},
+			Requests: []SeedEnrollmentRequest{
+				{RequestID: 1, Source: "public", Status: "approved", ChildIDs: []int64{7}},
+				{RequestID: 2, Source: "parent", ChildIDs: []int64{8}},
+			},
+			ParentActions: []SeedParentPortalAction{
+				{ParentEmail: "parent@example.test", StudentID: 42, Type: "note"},
+			},
+		},
+	}
+	s.printSuccessSummary("admin@test.de", "generated-password", result, state)
 }
 
 // fullSeedAPIMock creates a comprehensive mock server for the full seed workflow.
@@ -366,6 +383,55 @@ func fullSeedAPIMock(t *testing.T) *httptest.Server {
 		idCounter++
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
+
+		if strings.HasPrefix(r.URL.Path, "/api/guardians/") && strings.HasSuffix(r.URL.Path, "/invite") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"id":                  idCounter,
+					"guardian_profile_id": idCounter,
+					"token":               fmt.Sprintf("guardian-invite-%d", idCounter),
+					"email_sent":          true,
+				},
+			})
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/auth/guardian-invitations/") && strings.HasSuffix(r.URL.Path, "/accept") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"account_id": idCounter,
+					"email":      "parent@example.test",
+				},
+			})
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/api/enrollment/admin/requests/") && strings.Contains(r.URL.Path, "/children/") && strings.HasSuffix(r.URL.Path, "/decide") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"id":            fmt.Sprintf("%d", idCounter),
+					"first_name":    "Demo",
+					"last_name":     "Child",
+					"date_of_birth": "2019-01-01",
+					"status":        "approved",
+				},
+			})
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/api/enrollment/admin/requests/") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"id":           fmt.Sprintf("%d", idCounter),
+					"status_token": fmt.Sprintf("status-token-%d", idCounter),
+					"children": []map[string]any{
+						{"id": fmt.Sprintf("%d", idCounter+1000)},
+					},
+				},
+			})
+			return
+		}
 
 		switch r.URL.Path {
 		case "/health":
@@ -428,6 +494,15 @@ func fullSeedAPIMock(t *testing.T) *httptest.Server {
 				"refresh_token": "refresh",
 			})
 
+		case "/parent/auth/login":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"access_token":  "parent-token",
+					"refresh_token": "parent-refresh",
+				},
+			})
+
 		case "/auth/roles":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"status": "success",
@@ -453,6 +528,31 @@ func fullSeedAPIMock(t *testing.T) *httptest.Server {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"status": "success",
 				"data":   []any{},
+			})
+
+		case "/api/enrollment/phases":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"id": "1001",
+				},
+			})
+
+		case "/api/enrollment/care-offerings":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"id": fmt.Sprintf("%d", idCounter),
+				},
+			})
+
+		case "/api/enrollment/demo-school/submit", "/parent/enrollments/demo-school/submit":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"request_id": fmt.Sprintf("%d", idCounter),
+					"status_url": fmt.Sprintf("https://parents.example.test/status/status-token-%d", idCounter),
+				},
 			})
 
 		default:

--- a/backend/seed/api/state.go
+++ b/backend/seed/api/state.go
@@ -18,11 +18,13 @@ type SeedState struct {
 	DevicePIN   string                `json:"device_pin"`
 	Bootstrap   SeedStateBootstrap    `json:"bootstrap"`
 	Accounts    SeedStateAccounts     `json:"accounts"`
+	Parents     []ParentCredentials   `json:"parents,omitempty"`
 	Devices     map[string]SeedDevice `json:"devices"`
 	Students    []SeedStudent         `json:"students"`
 	Rooms       map[string]int64      `json:"rooms"`
 	Activities  map[string]int64      `json:"activities"`
 	Groups      map[string]int64      `json:"groups"`
+	Enrollment  SeedEnrollmentState   `json:"enrollment,omitempty"`
 	Credentials SeedStateCredentials  `json:"credentials"`
 	Topology    SeedStateTopology     `json:"topology"`
 	Entities    SeedStateEntities     `json:"entities"`
@@ -34,6 +36,7 @@ type SeedStateCredentials struct {
 	Operator  *SeedOperatorCredentials `json:"operator,omitempty"`
 	DevicePIN string                   `json:"device_pin"`
 	Accounts  SeedStateAccounts        `json:"accounts"`
+	Parents   []ParentCredentials      `json:"parents,omitempty"`
 }
 
 type SeedOperatorCredentials struct {
@@ -48,9 +51,10 @@ type SeedStateTopology struct {
 }
 
 type SeedStateEntities struct {
-	Bootstrap SeedStateBootstrap    `json:"bootstrap"`
-	Devices   map[string]SeedDevice `json:"devices"`
-	Students  []SeedStudent         `json:"students"`
+	Bootstrap  SeedStateBootstrap    `json:"bootstrap"`
+	Devices    map[string]SeedDevice `json:"devices"`
+	Students   []SeedStudent         `json:"students"`
+	Enrollment SeedEnrollmentState   `json:"enrollment,omitempty"`
 }
 
 type SeedStateLookups struct {
@@ -78,6 +82,15 @@ type SeedStateBootstrap struct {
 type SeedStateAccounts struct {
 	Admin    []AccountCredentials `json:"admin"`
 	Betreuer []AccountCredentials `json:"betreuer"`
+}
+
+type ParentCredentials struct {
+	Email      string  `json:"email"`
+	Password   string  `json:"password"`
+	Name       string  `json:"name"`
+	AccountID  int64   `json:"account_id,omitempty"`
+	GuardianID int64   `json:"guardian_id"`
+	StudentIDs []int64 `json:"student_ids,omitempty"`
 }
 
 type BootstrapAdminCredentials struct {
@@ -108,6 +121,29 @@ type SeedStudent struct {
 	LastName  string `json:"last_name"`
 	GroupKey  string `json:"group_key"`
 	Class     string `json:"class"`
+}
+
+type SeedEnrollmentState struct {
+	PhaseID       int64                    `json:"phase_id,omitempty"`
+	Offerings     map[string]int64         `json:"offerings,omitempty"`
+	Requests      []SeedEnrollmentRequest  `json:"requests,omitempty"`
+	ParentActions []SeedParentPortalAction `json:"parent_actions,omitempty"`
+	Settings      map[string]any           `json:"settings,omitempty"`
+}
+
+type SeedEnrollmentRequest struct {
+	RequestID   int64   `json:"request_id"`
+	Source      string  `json:"source"`
+	Status      string  `json:"status,omitempty"`
+	StatusURL   string  `json:"status_url,omitempty"`
+	StatusToken string  `json:"status_token,omitempty"`
+	ChildIDs    []int64 `json:"child_ids,omitempty"`
+}
+
+type SeedParentPortalAction struct {
+	ParentEmail string `json:"parent_email"`
+	StudentID   int64  `json:"student_id"`
+	Type        string `json:"type"`
 }
 
 func WriteSeedState(state *SeedState, path string) error {
@@ -184,6 +220,12 @@ func (s *SeedState) Normalize() {
 	if len(s.Accounts.Admin) == 0 && len(s.Accounts.Betreuer) == 0 {
 		s.Accounts = s.Credentials.Accounts
 	}
+	if len(s.Credentials.Parents) == 0 && len(s.Parents) > 0 {
+		s.Credentials.Parents = append([]ParentCredentials(nil), s.Parents...)
+	}
+	if len(s.Parents) == 0 && len(s.Credentials.Parents) > 0 {
+		s.Parents = append([]ParentCredentials(nil), s.Credentials.Parents...)
+	}
 
 	if s.Entities.Bootstrap.OrganizationID == 0 && s.Bootstrap.OrganizationID != 0 {
 		s.Entities.Bootstrap = s.Bootstrap
@@ -204,6 +246,14 @@ func (s *SeedState) Normalize() {
 	}
 	if len(s.Students) == 0 && len(s.Entities.Students) > 0 {
 		s.Students = append([]SeedStudent(nil), s.Entities.Students...)
+	}
+	normalizeEnrollmentState(&s.Enrollment)
+	normalizeEnrollmentState(&s.Entities.Enrollment)
+	if s.Entities.Enrollment.PhaseID == 0 && s.Enrollment.PhaseID != 0 {
+		s.Entities.Enrollment = cloneEnrollmentState(s.Enrollment)
+	}
+	if s.Enrollment.PhaseID == 0 && s.Entities.Enrollment.PhaseID != 0 {
+		s.Enrollment = cloneEnrollmentState(s.Entities.Enrollment)
 	}
 
 	if len(s.Lookups.Rooms) == 0 && len(s.Rooms) > 0 {
@@ -256,6 +306,32 @@ func cloneSeedIDMap(src map[string]int64) map[string]int64 {
 	dst := make(map[string]int64, len(src))
 	for key, value := range src {
 		dst[key] = value
+	}
+	return dst
+}
+
+func normalizeEnrollmentState(state *SeedEnrollmentState) {
+	if state == nil {
+		return
+	}
+	if state.Offerings == nil {
+		state.Offerings = make(map[string]int64)
+	}
+	if state.Settings == nil {
+		state.Settings = make(map[string]any)
+	}
+}
+
+func cloneEnrollmentState(src SeedEnrollmentState) SeedEnrollmentState {
+	dst := SeedEnrollmentState{
+		PhaseID:       src.PhaseID,
+		Offerings:     cloneSeedIDMap(src.Offerings),
+		Requests:      append([]SeedEnrollmentRequest(nil), src.Requests...),
+		ParentActions: append([]SeedParentPortalAction(nil), src.ParentActions...),
+		Settings:      make(map[string]any, len(src.Settings)),
+	}
+	for key, value := range src.Settings {
+		dst.Settings[key] = value
 	}
 	return dst
 }

--- a/backend/seed/api/workflow_steps.go
+++ b/backend/seed/api/workflow_steps.go
@@ -105,6 +105,10 @@ func (s buildStateStep) Run(_ context.Context, rt *Runtime) error {
 	state.Topology.Mode = "full-demo"
 	state.Scenarios.DefaultPlayer = "pyreportal"
 	state.Scenarios.DefaultMode = "hybrid"
+	state.Parents = append([]ParentCredentials(nil), rt.Parents...)
+	state.Credentials.Parents = append([]ParentCredentials(nil), rt.Parents...)
+	state.Enrollment = cloneEnrollmentState(rt.Enrollment)
+	state.Entities.Enrollment = cloneEnrollmentState(rt.Enrollment)
 	state.Normalize()
 
 	rt.State = state
@@ -145,7 +149,7 @@ func (s printSummaryStep) Run(_ context.Context, rt *Runtime) error {
 	if rt.Result == nil {
 		return fmt.Errorf("seed result not available")
 	}
-	s.seeder.printSuccessSummary(rt.Bootstrap.AdminEmail, rt.Bootstrap.AdminPassword, rt.Result)
+	s.seeder.printSuccessSummary(rt.Bootstrap.AdminEmail, rt.Bootstrap.AdminPassword, rt.Result, rt.State)
 	return nil
 }
 
@@ -162,6 +166,7 @@ func fullDemoWorkflow(seeder *Seeder) Workflow {
 			seedAnnouncementsStep{},
 			seedSuggestionsStep{},
 			seedTimeTrackingHistoryStep{},
+			parentEnrollmentSeedStep{seeder: seeder},
 			buildStateStep{seeder: seeder},
 			writeSimulatorConfigStep{},
 			printSummaryStep{seeder: seeder},


### PR DESCRIPTION
## Summary
- extend the API-based demo seeder with parent portal and enrollment flows
- create guardian parent accounts through invitation acceptance and parent login
- seed enrollment settings, phase, care offerings, public/parent submissions, admin decisions, and parent portal actions
- print parent accounts and enrollment breakdowns in the final DEMO READY output

## Verification
- go test ./seed/api ./integration/phoenixapi
- go test ./api/guardians -run 'TestSendInvitation'
- git diff --check
- real fresh-DB seed smoke test via /app/tmp/main seed against local Docker server

## Note
- Full go test ./api/guardians still has an existing unrelated failure in TestListPendingInvitations_Success: column guardian_invitation.student_id does not exist.