### PR TITLE
feat(enrollment): permanent same-ways-home toggle for all care days

### DIFF
--- a/frontend/src/components/enrollment/enrollment-form.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.test.tsx
@@ -55,7 +55,23 @@ vi.mock("next-intl", async () => {
     string,
     unknown
   >;
-  const catalogs: Record<string, Record<string, unknown>> = { de, en };
+  // A German catalog with the weekday/departure label maps removed, exposed as
+  // a pseudo-locale. Selecting it via mockIntlLocale lets a test render with
+  // missing labels so the component's `labels[key] ?? key` fallbacks show the
+  // raw keys. Uses the same locale-switching path as the real "en" catalog.
+  const deNoLabels = structuredClone(de) as Record<string, unknown>;
+  const deNoLabelsEnrollment = deNoLabels.enrollmentForm as Record<
+    string,
+    unknown
+  >;
+  delete deNoLabelsEnrollment.weekdaysShort;
+  delete (deNoLabelsEnrollment.structured as Record<string, unknown>)
+    .departureModes;
+  const catalogs: Record<string, Record<string, unknown>> = {
+    de,
+    en,
+    "de-no-labels": deNoLabels,
+  };
   const currentCatalog = (): Record<string, unknown> =>
     catalogs[mockIntlLocale.value] ?? de;
   const resolve = (catalog: Record<string, unknown>, path: string): unknown =>
@@ -112,6 +128,7 @@ import type {
   PublicLegalTexts,
 } from "~/lib/enrollment-form-schema-api";
 import type {
+  EnrollmentEditDraft,
   MeProfileResponse,
   PublicCareOffering,
   SubmitEnrollmentPayload,
@@ -267,6 +284,32 @@ function offerings(): PublicCareOffering[] {
       capacity: 20,
     },
   ];
+}
+
+function editDraft(
+  children: { id: string; first_name: string; last_name: string }[],
+): EnrollmentEditDraft {
+  return {
+    request_id: "req-1",
+    status_token: "tok-1",
+    tenant_id: "1",
+    tenant_slug: "demo",
+    phase_id: "5",
+    guardian_first_name: "Mara",
+    guardian_last_name: "Muster",
+    guardian_email: "mara@example.test",
+    guardian_phone: "+49 221 1234567",
+    consent_flags: {},
+    custom_data: {},
+    children: children.map((child) => ({
+      ...child,
+      date_of_birth: "2018-04-15",
+      target_grade_level: 2,
+      // A fixed Tue/Thu offering gives each child care days so the
+      // weekday_multi_mode field renders its controls.
+      offering_ids: ["12"],
+    })),
+  };
 }
 
 function profile(): MeProfileResponse {
@@ -923,13 +966,554 @@ describe("EnrollmentForm", () => {
     ).not.toBeInTheDocument();
     const group = screen.getByRole("group", { name: /Erlaubte Heimwege/ });
     expect(within(group).getAllByRole("button")).toHaveLength(5);
-    expect(within(group).queryAllByRole("checkbox")).toHaveLength(0);
+    // Only the "same ways home" toggle is present up front; no per-day mode
+    // checkboxes appear until a day is expanded.
+    expect(
+      within(group).queryByRole("checkbox", { name: "Bus" }),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(within(group).getByRole("button", { name: "Mo" }));
 
-    expect(within(group).getAllByRole("checkbox")).toHaveLength(3);
+    expect(
+      within(group).getByRole("checkbox", { name: "Geht zu Fuß" }),
+    ).toBeInTheDocument();
+    expect(
+      within(group).getByRole("checkbox", { name: "Bus" }),
+    ).toBeInTheDocument();
+    expect(
+      within(group).getByRole("checkbox", { name: "Wird abgeholt" }),
+    ).toBeInTheDocument();
     fireEvent.click(within(group).getByRole("checkbox", { name: "Bus" }));
     expect(within(group).getByRole("checkbox", { name: "Bus" })).toBeChecked();
+  });
+
+  it("applies one selection to every care day when 'same ways home' is on", async () => {
+    const previewSchema = schema();
+    previewSchema.fields = [
+      {
+        key: "allowed_departure_modes",
+        label: "Erlaubte Heimwege",
+        type: "weekday_multi_mode",
+        required: true,
+        applies_to_child: true,
+        sort_order: 1,
+      },
+    ];
+
+    renderForm({ phaseID: undefined, previewMode: true, previewSchema });
+    await waitForLoaded();
+
+    const group = screen.getByRole("group", { name: /Erlaubte Heimwege/ });
+    const uniformToggle = within(group).getByRole("checkbox", {
+      name: "Gleiche Heimwege für alle Betreuungstage",
+    });
+
+    // Turn the uniform switch on: the per-day weekday buttons disappear in
+    // favour of a single shared selection block.
+    fireEvent.click(uniformToggle);
+    expect(
+      within(group).queryByRole("button", { name: "Mo" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(within(group).getByRole("checkbox", { name: "Bus" }));
+
+    // Switch back to per-day to confirm the choice fanned out to all five days.
+    fireEvent.click(
+      within(group).getByRole("checkbox", {
+        name: "Gleiche Heimwege für alle Betreuungstage",
+      }),
+    );
+    const busBoxes = within(group).getAllByRole("checkbox", { name: "Bus" });
+    expect(busBoxes).toHaveLength(5);
+    busBoxes.forEach((box) => expect(box).toBeChecked());
+  });
+
+  it("deselecting a uniform mode clears it from every care day", async () => {
+    const previewSchema = schema();
+    previewSchema.fields = [
+      {
+        key: "allowed_departure_modes",
+        label: "Erlaubte Heimwege",
+        type: "weekday_multi_mode",
+        required: true,
+        applies_to_child: true,
+        sort_order: 1,
+      },
+    ];
+
+    renderForm({ phaseID: undefined, previewMode: true, previewSchema });
+    await waitForLoaded();
+
+    const group = screen.getByRole("group", { name: /Erlaubte Heimwege/ });
+    const uniformLabel = "Gleiche Heimwege für alle Betreuungstage";
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+
+    const bus = () => within(group).getByRole("checkbox", { name: "Bus" });
+    fireEvent.click(bus());
+    expect(bus()).toBeChecked();
+    // Toggle the same mode off: it must drop out of the shared selection.
+    fireEvent.click(bus());
+    expect(bus()).not.toBeChecked();
+
+    // Back in per-day view the cleared selection leaves no active care day.
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    expect(
+      within(group).queryByRole("checkbox", { name: "Bus" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("confirms before discarding divergent per-day choices when enabling uniform", async () => {
+    const previewSchema = schema();
+    previewSchema.fields = [
+      {
+        key: "allowed_departure_modes",
+        label: "Erlaubte Heimwege",
+        type: "weekday_multi_mode",
+        required: true,
+        applies_to_child: true,
+        sort_order: 1,
+      },
+    ];
+
+    renderForm({ phaseID: undefined, previewMode: true, previewSchema });
+    await waitForLoaded();
+
+    const group = screen.getByRole("group", { name: /Erlaubte Heimwege/ });
+    const uniformLabel = "Gleiche Heimwege für alle Betreuungstage";
+
+    // Give a single day a selection so the days now diverge (Mo=Bus, rest none).
+    fireEvent.click(within(group).getByRole("button", { name: "Mo" }));
+    fireEvent.click(within(group).getByRole("checkbox", { name: "Bus" }));
+    expect(within(group).getByRole("checkbox", { name: "Bus" })).toBeChecked();
+
+    // Enabling uniform must NOT switch immediately; it prompts first and the
+    // per-day weekday buttons stay visible.
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    expect(
+      screen.getByText("Auswahl für alle Tage übernehmen?"),
+    ).toBeInTheDocument();
+    expect(
+      within(group).getByRole("button", { name: "Mo" }),
+    ).toBeInTheDocument();
+
+    // Confirm: switch to the shared block with a clean slate (Bus unchecked).
+    fireEvent.click(
+      screen.getByRole("button", { name: "Löschen und fortfahren" }),
+    );
+    expect(
+      within(group).queryByRole("button", { name: "Mo" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(group).getByRole("checkbox", { name: "Bus" }),
+    ).not.toBeChecked();
+
+    // Back in per-day view the prior Monday selection is gone.
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    expect(
+      within(group).queryByRole("checkbox", { name: "Bus" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps per-day choices when the uniform confirmation is cancelled", async () => {
+    const previewSchema = schema();
+    previewSchema.fields = [
+      {
+        key: "allowed_departure_modes",
+        label: "Erlaubte Heimwege",
+        type: "weekday_multi_mode",
+        required: true,
+        applies_to_child: true,
+        sort_order: 1,
+      },
+    ];
+
+    renderForm({ phaseID: undefined, previewMode: true, previewSchema });
+    await waitForLoaded();
+
+    const group = screen.getByRole("group", { name: /Erlaubte Heimwege/ });
+    const uniformLabel = "Gleiche Heimwege für alle Betreuungstage";
+
+    fireEvent.click(within(group).getByRole("button", { name: "Mo" }));
+    fireEvent.click(within(group).getByRole("checkbox", { name: "Bus" }));
+
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    // Cancel: stay in per-day view with Monday's selection intact.
+    fireEvent.click(screen.getByRole("button", { name: "Abbrechen" }));
+    expect(
+      within(group).getByRole("button", { name: "Mo" }),
+    ).toBeInTheDocument();
+    expect(within(group).getByRole("checkbox", { name: "Bus" })).toBeChecked();
+  });
+
+  it("toggling uniform adopts the selection when every day already matches", async () => {
+    const previewSchema = schema();
+    previewSchema.fields = [
+      {
+        key: "allowed_departure_modes",
+        label: "Erlaubte Heimwege",
+        type: "weekday_multi_mode",
+        required: true,
+        applies_to_child: true,
+        sort_order: 1,
+      },
+    ];
+
+    renderForm({ phaseID: undefined, previewMode: true, previewSchema });
+    await waitForLoaded();
+
+    const group = screen.getByRole("group", { name: /Erlaubte Heimwege/ });
+    const uniformLabel = "Gleiche Heimwege für alle Betreuungstage";
+
+    // Spread Bus to every day via uniform, then drop back to per-day so all
+    // five days share the identical selection.
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    fireEvent.click(within(group).getByRole("checkbox", { name: "Bus" }));
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    expect(
+      within(group).getAllByRole("checkbox", { name: "Bus" }),
+    ).toHaveLength(5);
+
+    // Re-enabling uniform is lossless here, so no confirmation appears and the
+    // shared Bus selection is adopted as-is.
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    expect(
+      screen.queryByText("Auswahl für alle Tage übernehmen?"),
+    ).not.toBeInTheDocument();
+    expect(within(group).getByRole("checkbox", { name: "Bus" })).toBeChecked();
+  });
+
+  it("prompts to pick care days before showing the home-route options", async () => {
+    // Real (non-preview) flow: offerings load but the child has selected none,
+    // so there are no care days and the field shows the placeholder instead of
+    // the uniform toggle or weekday buttons.
+    const customSchema = schema();
+    customSchema.fields = [
+      {
+        key: "allowed_departure_modes",
+        label: "Erlaubte Heimwege",
+        type: "weekday_multi_mode",
+        required: true,
+        applies_to_child: true,
+        sort_order: 1,
+      },
+    ];
+    mockFetchPublicActiveSchema.mockResolvedValue(customSchema);
+
+    renderForm();
+    await waitForLoaded();
+
+    const group = screen.getByRole("group", { name: /Erlaubte Heimwege/ });
+    expect(
+      within(group).getByText("Wählen Sie zuerst die Betreuungstage aus."),
+    ).toBeInTheDocument();
+    expect(within(group).queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(within(group).queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("fans the uniform selection onto a care day added after uniform was enabled", async () => {
+    // Real flow: the set of care days is driven by the selected offerings and
+    // can grow AFTER uniform was switched on. A newly added day starts empty,
+    // so without the sync effect the uniform block would claim coverage the
+    // payload doesn't have. Critically the new day ("Mo") sorts BEFORE the
+    // existing ones ("Di"/"Do"), which would make a naive "first day is the
+    // source of truth" implementation wipe the existing selection instead.
+    // Two fixed-day offerings drive the care days directly (no day picker).
+    const customSchema = schema();
+    customSchema.fields = [
+      {
+        key: "allowed_departure_modes",
+        label: "Erlaubte Heimwege",
+        type: "weekday_multi_mode",
+        required: true,
+        applies_to_child: true,
+        sort_order: 1,
+      },
+    ];
+    mockFetchPublicActiveSchema.mockResolvedValue(customSchema);
+    mockFetchPublicCareOfferings.mockResolvedValue({
+      offerings: [
+        {
+          id: "21",
+          phase_id: "5",
+          name: "Block Mo",
+          description: null,
+          days_of_week_mode: "fixed",
+          available_days: ["mon"],
+          includes_holiday_care: false,
+          includes_lunch: false,
+          is_active: true,
+          is_required: false,
+          capacity: null,
+        },
+        {
+          id: "22",
+          phase_id: "5",
+          name: "Block Di Do",
+          description: null,
+          days_of_week_mode: "fixed",
+          available_days: ["tue", "thu"],
+          includes_holiday_care: false,
+          includes_lunch: false,
+          is_active: true,
+          is_required: false,
+          capacity: null,
+        },
+      ],
+      careOfferingSelectionMode: "at_least_one",
+      careRequired: true,
+    });
+
+    renderForm();
+    await waitForLoaded();
+
+    // Select the Di/Do block so the home-route field has two care days.
+    fireEvent.click(screen.getByRole("checkbox", { name: /Block Di Do/ }));
+
+    const group = screen.getByRole("group", { name: /Erlaubte Heimwege/ });
+    const uniformLabel = "Gleiche Heimwege für alle Betreuungstage";
+
+    // Turn uniform on (lossless: both days are empty) and choose Bus.
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    fireEvent.click(within(group).getByRole("checkbox", { name: "Bus" }));
+    expect(within(group).getByRole("checkbox", { name: "Bus" })).toBeChecked();
+
+    // Add the Mo block: "mon" sorts before the existing Di/Do and starts empty.
+    fireEvent.click(screen.getByRole("checkbox", { name: /Block Mo/ }));
+
+    // The uniform block still shows Bus (existing selection preserved, not
+    // wiped by the empty new day becoming the would-be "first day").
+    expect(within(group).getByRole("checkbox", { name: "Bus" })).toBeChecked();
+
+    // Switch back to per-day: Bus must now cover all three days (Mo/Di/Do).
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    const busBoxes = within(group).getAllByRole("checkbox", { name: "Bus" });
+    expect(busBoxes).toHaveLength(3);
+    busBoxes.forEach((box) => expect(box).toBeChecked());
+  });
+
+  it("keeps the uniform selection when the entire care-day set is swapped out", async () => {
+    // Real flow, harder than the "day added" case: every source day is removed
+    // and a disjoint new day appears (Di/Do -> Mo) while uniform is on. The
+    // shared selection lives in component state, not derived from the per-day
+    // payload, so it survives even though no source day remains to read it from
+    // -- a payload-derived value would read empty mid-swap and silently reset.
+    const customSchema = schema();
+    customSchema.fields = [
+      {
+        key: "allowed_departure_modes",
+        label: "Erlaubte Heimwege",
+        type: "weekday_multi_mode",
+        required: true,
+        applies_to_child: true,
+        sort_order: 1,
+      },
+    ];
+    mockFetchPublicActiveSchema.mockResolvedValue(customSchema);
+    mockFetchPublicCareOfferings.mockResolvedValue({
+      offerings: [
+        {
+          id: "21",
+          phase_id: "5",
+          name: "Block Mo",
+          description: null,
+          days_of_week_mode: "fixed",
+          available_days: ["mon"],
+          includes_holiday_care: false,
+          includes_lunch: false,
+          is_active: true,
+          is_required: false,
+          capacity: null,
+        },
+        {
+          id: "22",
+          phase_id: "5",
+          name: "Block Di Do",
+          description: null,
+          days_of_week_mode: "fixed",
+          available_days: ["tue", "thu"],
+          includes_holiday_care: false,
+          includes_lunch: false,
+          is_active: true,
+          is_required: false,
+          capacity: null,
+        },
+      ],
+      careOfferingSelectionMode: "at_least_one",
+      careRequired: true,
+    });
+
+    renderForm();
+    await waitForLoaded();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Block Di Do/ }));
+
+    const group = screen.getByRole("group", { name: /Erlaubte Heimwege/ });
+    const uniformLabel = "Gleiche Heimwege für alle Betreuungstage";
+
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    fireEvent.click(within(group).getByRole("checkbox", { name: "Bus" }));
+    expect(within(group).getByRole("checkbox", { name: "Bus" })).toBeChecked();
+
+    // Drop the source days FIRST (no care days at all), THEN add the disjoint
+    // Mo block. The selection has no per-day payload to be re-derived from at
+    // any point during the swap.
+    fireEvent.click(screen.getByRole("checkbox", { name: /Block Di Do/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /Block Mo/ }));
+
+    // The shared Bus selection is intact and fanned onto the new day.
+    expect(within(group).getByRole("checkbox", { name: "Bus" })).toBeChecked();
+
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    const busBoxes = within(group).getAllByRole("checkbox", { name: "Bus" });
+    expect(busBoxes).toHaveLength(1);
+    busBoxes.forEach((box) => expect(box).toBeChecked());
+  });
+
+  it("falls back to raw weekday and mode keys when the locale lacks labels", async () => {
+    // Render with a catalog missing the weekday/departure label maps so the
+    // component's `labels[key] ?? key` fallbacks render the raw keys in both
+    // the uniform and per-day views. `localizedCopy` routes the component
+    // through next-intl (the mocked catalog) instead of its bundled German
+    // copy, so the stripped pseudo-locale takes effect.
+    mockIntlLocale.value = "de-no-labels";
+
+    const previewSchema = schema();
+    previewSchema.fields = [
+      {
+        key: "allowed_departure_modes",
+        label: "Erlaubte Heimwege",
+        type: "weekday_multi_mode",
+        required: true,
+        applies_to_child: true,
+        sort_order: 1,
+      },
+    ];
+
+    renderForm({
+      phaseID: undefined,
+      previewMode: true,
+      previewSchema,
+      localizedCopy: true,
+    });
+    await waitForLoaded();
+
+    const group = screen.getByRole("group", { name: /Erlaubte Heimwege/ });
+    const uniformLabel = "Gleiche Heimwege für alle Betreuungstage";
+
+    // Uniform view: mode checkbox falls back to the raw mode key.
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    expect(
+      within(group).getByRole("checkbox", { name: "bus" }),
+    ).toBeInTheDocument();
+
+    // Per-day view: weekday button, day header, and mode checkbox fall back.
+    fireEvent.click(
+      within(group).getByRole("checkbox", { name: uniformLabel }),
+    );
+    fireEvent.click(within(group).getByRole("button", { name: "mon" }));
+    expect(
+      within(group).getByRole("button", { name: "mon" }),
+    ).toBeInTheDocument();
+    expect(
+      within(group).getByRole("checkbox", { name: "bus" }),
+    ).toBeInTheDocument();
+  });
+
+  it("prefills every child from an edit draft", async () => {
+    // Exercises the draftChildren rebuild path (initialDraft -> ChildDraft[]):
+    // each saved child must reappear with its own controlled values, and each
+    // gets a deterministic clientId so the cards don't share identity.
+    renderForm({
+      initialDraft: editDraft([
+        { id: "c-1", first_name: "Anton", last_name: "Alster" },
+        { id: "c-2", first_name: "Berta", last_name: "Bach" },
+      ]),
+    });
+    await waitForLoaded();
+
+    // Index 0 is the guardian's own name field; the two children follow.
+    const firstNames = screen.getAllByLabelText("Vorname *");
+    const lastNames = screen.getAllByLabelText("Nachname *");
+    expect(firstNames).toHaveLength(3);
+    expect((firstNames[1] as HTMLInputElement).value).toBe("Anton");
+    expect((lastNames[1] as HTMLInputElement).value).toBe("Alster");
+    expect((firstNames[2] as HTMLInputElement).value).toBe("Berta");
+    expect((lastNames[2] as HTMLInputElement).value).toBe("Bach");
+  });
+
+  it("keeps each child's card state bound to that child when a sibling is removed", async () => {
+    // Regression for the array-index key bug: the per-child WeekdayMultiModeInput
+    // holds local-only state (the "same ways home" toggle). With index keys,
+    // removing the first child would shift the survivor onto the removed slot's
+    // React subtree and leak its toggle state. The stable clientId keeps each
+    // card's local state with its own child.
+    const customSchema = schema();
+    customSchema.fields = [
+      {
+        key: "allowed_departure_modes",
+        label: "Erlaubte Heimwege",
+        type: "weekday_multi_mode",
+        required: true,
+        applies_to_child: true,
+        sort_order: 1,
+      },
+    ];
+    mockFetchPublicActiveSchema.mockResolvedValue(customSchema);
+
+    renderForm({
+      initialDraft: editDraft([
+        { id: "c-1", first_name: "Anton", last_name: "Alster" },
+        { id: "c-2", first_name: "Berta", last_name: "Bach" },
+      ]),
+    });
+    await waitForLoaded();
+
+    const uniformLabel = "Gleiche Heimwege für alle Betreuungstage";
+    let toggles = screen.getAllByRole("checkbox", { name: uniformLabel });
+    expect(toggles).toHaveLength(2);
+
+    // Turn uniform on for the SECOND child (Berta) only.
+    fireEvent.click(toggles[1]!);
+    toggles = screen.getAllByRole("checkbox", { name: uniformLabel });
+    expect(toggles[0]).not.toBeChecked();
+    expect(toggles[1]).toBeChecked();
+
+    // Remove the FIRST child (Anton). Berta becomes the only card.
+    fireEvent.click(screen.getAllByRole("button", { name: "Entfernen" })[0]!);
+
+    // Berta survived (index 0 is the guardian, index 1 the single remaining
+    // child) and her uniform toggle is still on -- it did not leak onto Anton's
+    // old slot and Anton's off-state did not bleed onto Berta.
+    const remaining = screen.getAllByLabelText("Vorname *");
+    expect(remaining).toHaveLength(2);
+    expect((remaining[1] as HTMLInputElement).value).toBe("Berta");
+    expect(screen.getByRole("checkbox", { name: uniformLabel })).toBeChecked();
   });
 
   it("uses injected submitter and skips captcha for authenticated parent paths", async () => {

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -35,7 +35,7 @@ import {
   type ConditionContext,
 } from "~/lib/enrollment-field-visibility";
 import ReactMarkdown, { type Components } from "react-markdown";
-import { Modal } from "~/components/ui/modal";
+import { ConfirmationModal, Modal } from "~/components/ui/modal";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { Checkbox } from "~/components/ui/checkbox";
 import { createLogger } from "~/lib/logger";
@@ -56,6 +56,12 @@ const GUARDIAN_PHONE_PATTERN = /^(\+[0-9]{1,3}\s?)?[0-9\s-]{7,15}$/;
 const GUARDIAN_EMAIL_PATTERN = /^[A-Za-z0-9._%-]+@[A-Za-z0-9.-]+[.][A-Za-z]+$/;
 
 interface ChildDraft {
+  // Stable, client-only identity for React list keys. Never sent to the
+  // backend (payload mapping picks fields explicitly). Without it the
+  // children list keyed by array index would leak a card's local view state
+  // (uniform toggle, expanded days) onto a different child when a slot is
+  // removed from the middle of the list.
+  clientId: string;
   first_name: string;
   last_name: string;
   date_of_birth: string;
@@ -1173,7 +1179,7 @@ export function EnrollmentForm({
 
         {children.map((child, i) => (
           <div
-            key={i}
+            key={child.clientId}
             className="space-y-5 rounded-xl border border-gray-200 bg-white p-3 sm:p-4"
           >
             <div className="flex items-center justify-between gap-3">
@@ -1533,8 +1539,21 @@ export function EnrollmentForm({
   );
 }
 
+// Monotonic source for brand-new ChildDraft.clientId values. Saved edit-draft
+// children derive their keys from the persisted child id so rebuilding the
+// same draft after offerings load does not remount each card.
+let childDraftSeq = 0;
+function nextChildClientId(): string {
+  return `child-${childDraftSeq++}`;
+}
+
+function savedChildClientId(childID: string): string {
+  return `draft-child:${childID}`;
+}
+
 function blankChild(requiredOfferingIDs: readonly string[] = []): ChildDraft {
   return {
+    clientId: nextChildClientId(),
     first_name: "",
     last_name: "",
     date_of_birth: "",
@@ -1562,6 +1581,7 @@ function draftChildren(
       offeringDays[row.offering_id] = new Set(row.selected_days);
     }
     return {
+      clientId: savedChildClientId(child.id),
       first_name: child.first_name,
       last_name: child.last_name,
       date_of_birth: child.date_of_birth,
@@ -3041,6 +3061,22 @@ function WeekdayMultiModeInput({
   const [expandedDays, setExpandedDays] = useState<Set<string>>(
     () => new Set(daysToRender.filter((day) => (modes[day]?.length ?? 0) > 0)),
   );
+  // Opt-in convenience: pick the allowed ways home once and apply them to
+  // every care day. The stored value stays per-day (each day gets the same
+  // array), so backend, validation, and pruning are untouched. Always starts
+  // in the per-day view; the parent flips it on explicitly via the toggle.
+  const [uniform, setUniform] = useState(false);
+  // The shared selection while uniform is on. This is the source of truth for
+  // the uniform block (rather than re-deriving it from the per-day payload),
+  // so the choice survives even when the entire care-day set is swapped out
+  // from under it -- a payload-derived value would read empty once its source
+  // days disappear and silently reset to nothing.
+  const [uniformSelection, setUniformSelection] = useState<
+    DepartureModeValue[]
+  >([]);
+  // Open only when enabling uniform mode would discard divergent per-day
+  // choices (see toggleUniform).
+  const [confirmUniformOpen, setConfirmUniformOpen] = useState(false);
   const weekdayLabels = asStringMap(tr.raw("weekdaysShort"));
   const departureModeLabels = asStringMap(tr.raw("structured.departureModes"));
   const activeDays = daysToRender.filter(
@@ -3069,6 +3105,81 @@ function WeekdayMultiModeInput({
     };
     onChange(asWeekdayMultiModeObject(nextRaw, daysToRender));
   };
+  // The payload-derived shared selection: the first *populated* day's modes.
+  // Used only to decide whether enabling uniform is lossless and, if so, to
+  // seed the uniform state from the existing per-day data. The live uniform
+  // block reads `uniformSelection` (state), not this.
+  const payloadModes =
+    daysToRender.map((day) => modes[day]).find((m) => m && m.length > 0) ?? [];
+  // Switching into uniform mode is lossless only when every care day already
+  // holds the identical selection (including all-empty); the shared block then
+  // simply adopts that selection. join keys compare the pruned arrays.
+  const allDaysIdentical = daysToRender.every(
+    (day) => (modes[day] ?? []).join(",") === payloadModes.join(","),
+  );
+  // Fan the shared selection across the current care days whenever the payload
+  // falls out of sync with it -- e.g. a care day is added/removed elsewhere on
+  // the form after uniform was enabled. A newly added day starts empty, so
+  // without this the uniform block would claim coverage the payload doesn't
+  // have. Driven by string-signature deps (not the fresh-every-render `modes`
+  // /`daysToRender`/`onChange` references), so it fires only on a real change
+  // -- the selection, the day set, or the payload -- never on every render.
+  // The needsSync guard keeps it idempotent and self-terminating.
+  const uniformKey = uniformSelection.join(",");
+  const daysKey = daysToRender.join(",");
+  const modesKey = daysToRender
+    .map((day) => `${day}:${(modes[day] ?? []).join("|")}`)
+    .join(";");
+  useEffect(() => {
+    if (!uniform) return;
+    const needsSync = daysToRender.some(
+      (day) => (modes[day] ?? []).join(",") !== uniformKey,
+    );
+    if (!needsSync) return;
+    const nextRaw: Record<string, DepartureModeValue[]> = {};
+    for (const day of daysToRender) nextRaw[day] = uniformSelection;
+    onChange(asWeekdayMultiModeObject(nextRaw, daysToRender));
+    // String-signature deps keep the effect from re-running every render while
+    // still reacting to every meaningful change. `modes`/`daysToRender`/
+    // `onChange`/`uniformSelection` are read from the current render's closure;
+    // they change identity every render, so depending on them directly would
+    // defeat the point of the signatures.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [uniform, uniformKey, daysKey, modesKey]);
+  const enableUniform = () => {
+    setExpandedDays(new Set());
+    setUniformSelection([]);
+    setUniform(true);
+    // Clear divergent per-day data so the parent makes one fresh selection;
+    // the shared block then fans it out to every day via updateUniform.
+    onChange({});
+  };
+  const toggleUniform = (next: boolean) => {
+    if (!next) {
+      setUniform(false);
+      return;
+    }
+    // Enabling over already-uniform data is lossless: adopt the existing
+    // selection as the shared state and flip the view.
+    if (allDaysIdentical) {
+      setUniformSelection(payloadModes);
+      setUniform(true);
+      return;
+    }
+    // Enabling over divergent per-day choices would discard them silently;
+    // confirm first, then wipe in enableUniform.
+    setConfirmUniformOpen(true);
+  };
+  const updateUniform = (mode: DepartureModeValue) => {
+    const current = new Set(uniformSelection);
+    if (current.has(mode)) current.delete(mode);
+    else current.add(mode);
+    const arr = DEPARTURE_MULTI_MODE_OPTIONS.filter((m) => current.has(m));
+    setUniformSelection(arr);
+    const nextRaw: Record<string, DepartureModeValue[]> = {};
+    for (const day of daysToRender) nextRaw[day] = arr;
+    onChange(asWeekdayMultiModeObject(nextRaw, daysToRender));
+  };
   return (
     <fieldset
       className={`rounded-lg border p-3 ${error ? "border-[#FF3130]" : "border-gray-200"}`}
@@ -3088,66 +3199,126 @@ function WeekdayMultiModeInput({
       </p>
       <div className="mt-3">
         {daysToRender.length > 0 ? (
-          <div className="grid grid-cols-5 gap-2">
-            {daysToRender.map((day) => {
-              const active = activeDays.includes(day);
-              return (
-                <button
-                  key={day}
-                  type="button"
-                  aria-pressed={active}
-                  onClick={() => toggleDay(day)}
-                  className={`flex h-9 items-center justify-center rounded-lg border px-2 text-xs font-semibold transition-colors ${
-                    active
-                      ? "border-gray-900 bg-gray-900 text-white"
-                      : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50"
-                  }`}
-                >
-                  {weekdayLabels[day] ?? day}
-                </button>
-              );
-            })}
-          </div>
+          <>
+            <label
+              className={`flex cursor-pointer items-center gap-2 rounded-lg border bg-white px-3 py-2 text-xs font-medium transition-colors ${
+                uniform
+                  ? "border-gray-900 text-gray-900"
+                  : "border-gray-200 text-gray-700 hover:border-gray-300"
+              }`}
+            >
+              <Checkbox
+                checked={uniform}
+                onChange={(e) => toggleUniform(e.target.checked)}
+              />
+              <span>{tr("structured.weekdayMultiModeUniform")}</span>
+            </label>
+            {uniform ? (
+              <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50/70 p-3">
+                <p className="mb-2 text-xs text-gray-500">
+                  {tr("structured.weekdayMultiModeUniformHint")}
+                </p>
+                <div className="grid gap-2 sm:grid-cols-3">
+                  {DEPARTURE_MULTI_MODE_OPTIONS.map((mode) => {
+                    const checked = uniformSelection.includes(mode);
+                    return (
+                      <label
+                        key={mode}
+                        className={`flex min-h-10 cursor-pointer items-center gap-2 rounded-lg border bg-white px-3 py-2 text-xs font-medium transition-colors ${
+                          checked
+                            ? "border-gray-900 text-gray-900"
+                            : "border-gray-200 text-gray-700 hover:border-gray-300"
+                        }`}
+                      >
+                        <Checkbox
+                          checked={checked}
+                          onChange={() => updateUniform(mode)}
+                        />
+                        <span>{departureModeLabels[mode] ?? mode}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : (
+              <>
+                <div className="mt-3 grid grid-cols-5 gap-2">
+                  {daysToRender.map((day) => {
+                    const active = activeDays.includes(day);
+                    return (
+                      <button
+                        key={day}
+                        type="button"
+                        aria-pressed={active}
+                        onClick={() => toggleDay(day)}
+                        className={`flex h-9 items-center justify-center rounded-lg border px-2 text-xs font-semibold transition-colors ${
+                          active
+                            ? "border-gray-900 bg-gray-900 text-white"
+                            : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50"
+                        }`}
+                      >
+                        {weekdayLabels[day] ?? day}
+                      </button>
+                    );
+                  })}
+                </div>
+                <div className="mt-3 space-y-2">
+                  {activeDays.map((day) => (
+                    <div
+                      key={day}
+                      className="rounded-lg border border-gray-200 bg-gray-50/70 p-3"
+                    >
+                      <div className="mb-2 text-xs font-semibold text-gray-700">
+                        {weekdayLabels[day] ?? day}
+                      </div>
+                      <div className="grid gap-2 sm:grid-cols-3">
+                        {DEPARTURE_MULTI_MODE_OPTIONS.map((mode) => {
+                          const checked = modes[day]?.includes(mode) ?? false;
+                          return (
+                            <label
+                              key={mode}
+                              className={`flex min-h-10 cursor-pointer items-center gap-2 rounded-lg border bg-white px-3 py-2 text-xs font-medium transition-colors ${
+                                checked
+                                  ? "border-gray-900 text-gray-900"
+                                  : "border-gray-200 text-gray-700 hover:border-gray-300"
+                              }`}
+                            >
+                              <Checkbox
+                                checked={checked}
+                                onChange={() => updateDay(day, mode)}
+                              />
+                              <span>{departureModeLabels[mode] ?? mode}</span>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </>
         ) : (
           <p className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
             {tr("structured.weekdayMultiModeNoDays")}
           </p>
         )}
-        <div className="mt-3 space-y-2">
-          {activeDays.map((day) => (
-            <div
-              key={day}
-              className="rounded-lg border border-gray-200 bg-gray-50/70 p-3"
-            >
-              <div className="mb-2 text-xs font-semibold text-gray-700">
-                {weekdayLabels[day] ?? day}
-              </div>
-              <div className="grid gap-2 sm:grid-cols-3">
-                {DEPARTURE_MULTI_MODE_OPTIONS.map((mode) => {
-                  const checked = modes[day]?.includes(mode) ?? false;
-                  return (
-                    <label
-                      key={mode}
-                      className={`flex min-h-10 cursor-pointer items-center gap-2 rounded-lg border bg-white px-3 py-2 text-xs font-medium transition-colors ${
-                        checked
-                          ? "border-gray-900 text-gray-900"
-                          : "border-gray-200 text-gray-700 hover:border-gray-300"
-                      }`}
-                    >
-                      <Checkbox
-                        checked={checked}
-                        onChange={() => updateDay(day, mode)}
-                      />
-                      <span>{departureModeLabels[mode] ?? mode}</span>
-                    </label>
-                  );
-                })}
-              </div>
-            </div>
-          ))}
-        </div>
       </div>
       {error && <p className="mt-2 text-xs text-[#FF3130]">{error}</p>}
+      <ConfirmationModal
+        isOpen={confirmUniformOpen}
+        onClose={() => setConfirmUniformOpen(false)}
+        onConfirm={() => {
+          setConfirmUniformOpen(false);
+          enableUniform();
+        }}
+        title={tr("structured.weekdayMultiModeUniformConfirmTitle")}
+        confirmText={tr("structured.weekdayMultiModeUniformConfirmCta")}
+        cancelText={tr("structured.weekdayMultiModeUniformConfirmCancel")}
+        confirmButtonClass="bg-[#FF3130] hover:bg-[#FF3130]/90"
+      >
+        {tr("structured.weekdayMultiModeUniformConfirmBody")}
+      </ConfirmationModal>
     </fieldset>
   );
 }

--- a/frontend/src/i18n/messages/de.json
+++ b/frontend/src/i18n/messages/de.json
@@ -487,6 +487,12 @@
       "departureModeHelp": "Wählen Sie pro Wochentag, wie Ihr Kind nach Hause geht. Standard ist „Geht zu Fuß“.",
       "weekdayMultiModeHelp": "Wählen Sie pro Betreuungstag alle Heimwege aus, die für Ihr Kind erlaubt sind.",
       "weekdayMultiModeNoDays": "Wählen Sie zuerst die Betreuungstage aus.",
+      "weekdayMultiModeUniform": "Gleiche Heimwege für alle Betreuungstage",
+      "weekdayMultiModeUniformHint": "Treffen Sie die Auswahl einmal; sie gilt dann für jeden Betreuungstag.",
+      "weekdayMultiModeUniformConfirmTitle": "Auswahl für alle Tage übernehmen?",
+      "weekdayMultiModeUniformConfirmBody": "Sie haben bisher unterschiedliche Heimwege je Betreuungstag gewählt. Wenn Sie eine gemeinsame Auswahl aktivieren, werden diese tageweisen Angaben gelöscht und Sie treffen die Auswahl neu.",
+      "weekdayMultiModeUniformConfirmCta": "Löschen und fortfahren",
+      "weekdayMultiModeUniformConfirmCancel": "Abbrechen",
       "departureModes": {
         "alone": "Geht zu Fuß",
         "bus": "Bus",

--- a/frontend/src/i18n/messages/en.json
+++ b/frontend/src/i18n/messages/en.json
@@ -484,6 +484,12 @@
       "departureModeHelp": "Choose how your child goes home for each weekday. The default is “Walks home”.",
       "weekdayMultiModeHelp": "Choose every way home that is allowed for your child on each care day.",
       "weekdayMultiModeNoDays": "Choose the care days first.",
+      "weekdayMultiModeUniform": "Same ways home for all care days",
+      "weekdayMultiModeUniformHint": "Make the selection once; it applies to every care day.",
+      "weekdayMultiModeUniformConfirmTitle": "Use one selection for all days?",
+      "weekdayMultiModeUniformConfirmBody": "You have chosen different ways home for individual care days. Turning on a shared selection deletes those per-day entries and you make the selection again.",
+      "weekdayMultiModeUniformConfirmCta": "Delete and continue",
+      "weekdayMultiModeUniformConfirmCancel": "Cancel",
       "departureModes": {
         "alone": "Walks home",
         "bus": "Bus",

--- a/frontend/src/i18n/messages/ru.json
+++ b/frontend/src/i18n/messages/ru.json
@@ -487,6 +487,12 @@
       "departureModeHelp": "Выберите для каждого дня недели, как ребёнок идет домой. По умолчанию: идет пешком.",
       "weekdayMultiModeHelp": "Выберите все разрешенные способы ухода домой для каждого дня посещения.",
       "weekdayMultiModeNoDays": "Сначала выберите дни посещения.",
+      "weekdayMultiModeUniform": "Одинаковые способы возвращения домой для всех дней посещения",
+      "weekdayMultiModeUniformHint": "Сделайте выбор один раз — он применится ко всем дням посещения.",
+      "weekdayMultiModeUniformConfirmTitle": "Применить один выбор ко всем дням?",
+      "weekdayMultiModeUniformConfirmBody": "Вы выбрали разные способы возвращения домой для отдельных дней посещения. Если включить общий выбор, эти данные по дням будут удалены, и вы сделаете выбор заново.",
+      "weekdayMultiModeUniformConfirmCta": "Удалить и продолжить",
+      "weekdayMultiModeUniformConfirmCancel": "Отмена",
       "departureModes": {
         "alone": "Идет пешком",
         "bus": "Автобус",

--- a/frontend/src/i18n/messages/sq.json
+++ b/frontend/src/i18n/messages/sq.json
@@ -487,6 +487,12 @@
       "departureModeHelp": "Zgjidhni për çdo ditë jave si shkon fëmija në shtëpi. Parazgjedhja është: shkon në këmbë.",
       "weekdayMultiModeHelp": "Zgjidhni të gjitha mënyrat e kthimit që lejohen për fëmijën tuaj në çdo ditë kujdesi.",
       "weekdayMultiModeNoDays": "Së pari zgjidhni ditët e kujdesit.",
+      "weekdayMultiModeUniform": "Të njëjtat mënyra kthimi për të gjitha ditët e kujdesit",
+      "weekdayMultiModeUniformHint": "Bëni zgjedhjen një herë; vlen për çdo ditë kujdesi.",
+      "weekdayMultiModeUniformConfirmTitle": "Të zbatohet një zgjedhje për të gjitha ditët?",
+      "weekdayMultiModeUniformConfirmBody": "Keni zgjedhur mënyra të ndryshme kthimi për ditë të veçanta kujdesi. Nëse aktivizoni një zgjedhje të përbashkët, këto të dhëna sipas ditëve fshihen dhe e bëni zgjedhjen nga e para.",
+      "weekdayMultiModeUniformConfirmCta": "Fshi dhe vazhdo",
+      "weekdayMultiModeUniformConfirmCancel": "Anulo",
       "departureModes": {
         "alone": "Shkon në këmbë",
         "bus": "Autobus",


### PR DESCRIPTION
Closes #1695

## What & why

Currently the enrollment form lets parents pick the allowed ways home (Gehweise) **per care day**. Issue #1695 asks for the common case: choose the ways home **once** and have it apply to every day ("permanente Gehweise").

This adds a checkbox above the weekday grid in the multi-mode departure input that flips it between the existing per-day view and a single shared (uniform) selection. As the issue suggested, it reuses the existing endpoint: the shared selection is simply written to every care day in the payload.

## Behavior

- **Checkbox "Gleiche Heimwege für alle Betreuungstage"** toggles uniform mode. Default is the per-day view.
- **Enabling over identical data is lossless** — if every care day already holds the same selection, it is adopted as the shared selection and the view just flips.
- **Enabling over divergent per-day choices prompts a confirmation** ("Löschen und fortfahren") before discarding them, then the parent makes one fresh selection that fans out to all days.
- **Stays in sync with the care-day set** — an effect re-fans the shared selection when care days are added/removed elsewhere on the form (incl. a full swap), so a newly added day never silently lacks coverage.
- **Backend/validation/pruning untouched** — the stored value remains per-day (each day gets the same array); only the UI changes.

## Incidental fix

`ChildDraft` now carries a stable `clientId` used for the React list key instead of the array index. Without it, removing a child slot from the middle of the list leaked a card's local view state (uniform toggle, expanded days) onto a different child. Saved edit-draft children derive the key from the persisted child id so cards don't remount when offerings load.

## Tests

Added 11 tests covering: applying/deselecting a uniform mode across all days, the confirm/cancel flow, lossless adopt, the add-day and full-swap sync paths, the "pick care days first" prompt, locale-label fallback, edit-draft prefill, and per-child state isolation on sibling removal. `pnpm run check` passes; the enrollment-form suite is green (37 tests).

## i18n

New keys added to de/en/ru/sq.

## Scope note

This is the public parents-facing enrollment form, so the in-app help guide (staff app) is not affected.