### PR TITLE
fix: keep enrollment dropdowns above form sections

### DIFF
--- a/frontend/src/components/ui/custom-select.test.tsx
+++ b/frontend/src/components/ui/custom-select.test.tsx
@@ -43,6 +43,24 @@ describe("CustomSelect", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
+  it("keeps the listbox inside the local select container", () => {
+    render(
+      <div data-testid="surface" className="moto-content-surface">
+        <CustomSelect
+          value=""
+          options={options}
+          onChange={vi.fn()}
+          ariaLabel="Auswahl"
+        />
+      </div>,
+    );
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Auswahl" }));
+
+    const listbox = screen.getByRole("listbox");
+    expect(screen.getByTestId("surface")).toContainElement(listbox);
+  });
+
   it("closes with Escape", () => {
     render(
       <CustomSelect

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -388,6 +388,11 @@
   -webkit-backdrop-filter: blur(8px);
 }
 
+.moto-content-surface:has([aria-expanded="true"]) {
+  position: relative;
+  z-index: 60;
+}
+
 /* Print rules reset unlayered page styles that Tailwind print utilities cannot
    override, then add a dedicated guide background for PDF exports. */
 @media print {


### PR DESCRIPTION
## Summary
- Fix dropdown layering on the public enrollment form
- Raise the active `.moto-content-surface` while a dropdown is open so the menu stays visible above following form sections
- Add a regression test to ensure `CustomSelect` listboxes stay rendered in their local container

Closes #1707

## Testing
- `node scripts/verify-locales.mjs`
- `docker compose exec frontend pnpm exec oxlint .`
- `docker compose exec frontend pnpm exec tsc --noEmit --pretty false`
- `docker compose exec frontend pnpm exec vitest run src/components/ui/custom-select.test.tsx`