### PR TITLE
Fix Sentry enrollment and time tracking errors

### DIFF
--- a/backend/api/common/errors.go
+++ b/backend/api/common/errors.go
@@ -1,9 +1,12 @@
 package common
 
 import (
+	"context"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 
@@ -264,6 +267,33 @@ func ErrorTooManyRequests(err error) render.Renderer {
 // the request without globally locking other callers out.
 func ErrorServiceUnavailable(err error) render.Renderer {
 	return newErrResponse(http.StatusServiceUnavailable, err)
+}
+
+// IsTransientDatabaseError reports whether err represents a temporary database
+// connectivity failure rather than a domain validation error. Callers can use
+// this to retry a whole transaction once or return 503 after retry exhaustion.
+func IsTransientDatabaseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, driver.ErrBadConn) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	var pgErr pgdriver.Error
+	if errors.As(err, &pgErr) {
+		code := pgErr.Field('C')
+		return len(code) >= 2 && code[:2] == "08"
+	}
+
+	return strings.Contains(err.Error(), "driver: bad connection")
 }
 
 // IsConstraintViolation checks if an error is a PostgreSQL constraint violation

--- a/backend/api/common/errors.go
+++ b/backend/api/common/errors.go
@@ -47,6 +47,8 @@ var (
 	ErrGone             = errors.New("resource no longer available")
 )
 
+const statusClientClosedRequest = 499
+
 // LogRenderError is the format string for logging render errors
 const LogRenderError = "Error rendering error response: %v"
 
@@ -261,6 +263,18 @@ func ErrorTooManyRequests(err error) render.Renderer {
 	return newErrResponse(http.StatusTooManyRequests, err)
 }
 
+// ErrorRequestTimeout returns a 408 Request Timeout response for request
+// contexts whose deadline expired before the handler could complete.
+func ErrorRequestTimeout(err error) render.Renderer {
+	return newErrResponse(http.StatusRequestTimeout, err)
+}
+
+// ErrorClientClosed returns the de-facto 499 status for a client-canceled
+// request. Keeping this below 500 avoids Sentry noise for disconnects.
+func ErrorClientClosed(err error) render.Renderer {
+	return newErrResponse(statusClientClosedRequest, err)
+}
+
 // ErrorServiceUnavailable returns a 503 Service Unavailable response. Used
 // when a transient dependency (settings DB, MFA-credentials lookup, etc.)
 // makes a security decision impossible and the safe behaviour is to refuse
@@ -276,9 +290,10 @@ func IsTransientDatabaseError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, driver.ErrBadConn) ||
-		errors.Is(err, context.DeadlineExceeded) ||
-		errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, driver.ErrBadConn) {
 		return true
 	}
 

--- a/backend/api/common/errors_test.go
+++ b/backend/api/common/errors_test.go
@@ -2,6 +2,7 @@ package common_test
 
 import (
 	"context"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -540,6 +541,18 @@ func TestErrorInternalServerWrap(t *testing.T) {
 	wrapped, ok := renderer.(*common.ErrResponse)
 	require.True(t, ok)
 	assert.ErrorIs(t, wrapped.Err, cause)
+}
+
+func TestIsTransientDatabaseError_DetectsBadConnection(t *testing.T) {
+	err := fmt.Errorf("decision: list child offerings: %w", driver.ErrBadConn)
+
+	assert.True(t, common.IsTransientDatabaseError(err))
+}
+
+func TestIsTransientDatabaseError_IgnoresDomainValidation(t *testing.T) {
+	err := errors.New("invalid session data: check-in time must be before check-out time")
+
+	assert.False(t, common.IsTransientDatabaseError(err))
 }
 
 // =============================================================================

--- a/backend/api/common/errors_test.go
+++ b/backend/api/common/errors_test.go
@@ -549,6 +549,11 @@ func TestIsTransientDatabaseError_DetectsBadConnection(t *testing.T) {
 	assert.True(t, common.IsTransientDatabaseError(err))
 }
 
+func TestIsTransientDatabaseError_IgnoresRequestContextCancellation(t *testing.T) {
+	assert.False(t, common.IsTransientDatabaseError(context.Canceled))
+	assert.False(t, common.IsTransientDatabaseError(context.DeadlineExceeded))
+}
+
 func TestIsTransientDatabaseError_IgnoresDomainValidation(t *testing.T) {
 	err := errors.New("invalid session data: check-in time must be before check-out time")
 

--- a/backend/api/enrollment/admin_decision_handlers.go
+++ b/backend/api/enrollment/admin_decision_handlers.go
@@ -369,17 +369,28 @@ func (rs *Resource) decideAdminChild(w http.ResponseWriter, r *http.Request) {
 	reviewedBy := int64(claims.ID)
 
 	var outcome *enrollmentService.DecideOutcome
-	err = rs.runInTenantTx(r, func(ctx context.Context) error {
-		out, e := rs.DecisionService.Decide(ctx, enrollmentService.DecideInput{
-			RequestID:  requestID,
-			ChildID:    childID,
-			Status:     enrollmentService.DecisionStatus(body.Status),
-			Reason:     body.Reason,
-			ReviewedBy: reviewedBy,
+	for attempt := 0; attempt < 2; attempt++ {
+		outcome = nil
+		err = rs.runInTenantTx(r, func(ctx context.Context) error {
+			out, e := rs.DecisionService.Decide(ctx, enrollmentService.DecideInput{
+				RequestID:  requestID,
+				ChildID:    childID,
+				Status:     enrollmentService.DecisionStatus(body.Status),
+				Reason:     body.Reason,
+				ReviewedBy: reviewedBy,
+			})
+			outcome = out
+			return e
 		})
-		outcome = out
-		return e
-	})
+		if err == nil || !common.IsTransientDatabaseError(err) || attempt == 1 {
+			break
+		}
+		slog.WarnContext(r.Context(), "transient enrollment decision failure, retrying",
+			slog.Int64("request_id", requestID),
+			slog.Int64("child_id", childID),
+			slog.String("error", err.Error()),
+		)
+	}
 	if err != nil {
 		switch {
 		case errors.Is(err, enrollmentService.ErrDecisionChildNotFound),
@@ -389,6 +400,8 @@ func (rs *Resource) decideAdminChild(w http.ResponseWriter, r *http.Request) {
 			errors.Is(err, enrollmentService.ErrDecisionAlreadyTerminal),
 			errors.Is(err, enrollmentService.ErrDecisionInvalidData):
 			common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		case common.IsTransientDatabaseError(err):
+			common.RenderError(w, r, common.ErrorServiceUnavailable(err))
 		default:
 			common.RenderError(w, r, common.ErrorInternalServer(err))
 		}

--- a/backend/api/enrollment/admin_decision_handlers.go
+++ b/backend/api/enrollment/admin_decision_handlers.go
@@ -371,6 +371,7 @@ func (rs *Resource) decideAdminChild(w http.ResponseWriter, r *http.Request) {
 	var outcome *enrollmentService.DecideOutcome
 	for attempt := 0; attempt < 2; attempt++ {
 		outcome = nil
+		decisionBodySucceeded := false
 		err = rs.runInTenantTx(r, func(ctx context.Context) error {
 			out, e := rs.DecisionService.Decide(ctx, enrollmentService.DecideInput{
 				RequestID:  requestID,
@@ -379,10 +380,21 @@ func (rs *Resource) decideAdminChild(w http.ResponseWriter, r *http.Request) {
 				Reason:     body.Reason,
 				ReviewedBy: reviewedBy,
 			})
+			if e != nil {
+				return e
+			}
 			outcome = out
-			return e
+			decisionBodySucceeded = true
+			return nil
 		})
-		if err == nil || !common.IsTransientDatabaseError(err) || attempt == 1 {
+		if err == nil {
+			break
+		}
+		if reqErr := r.Context().Err(); reqErr != nil {
+			err = reqErr
+			break
+		}
+		if decisionBodySucceeded || !common.IsTransientDatabaseError(err) || attempt == 1 {
 			break
 		}
 		slog.WarnContext(r.Context(), "transient enrollment decision failure, retrying",
@@ -393,6 +405,10 @@ func (rs *Resource) decideAdminChild(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		switch {
+		case errors.Is(err, context.Canceled):
+			common.RenderError(w, r, common.ErrorClientClosed(err))
+		case errors.Is(err, context.DeadlineExceeded):
+			common.RenderError(w, r, common.ErrorRequestTimeout(err))
 		case errors.Is(err, enrollmentService.ErrDecisionChildNotFound),
 			errors.Is(err, enrollmentService.ErrDecisionRequestNotFound):
 			common.RenderError(w, r, common.ErrorNotFound(err))

--- a/backend/api/enrollment/admin_decision_handlers_test.go
+++ b/backend/api/enrollment/admin_decision_handlers_test.go
@@ -3,8 +3,10 @@ package enrollment
 import (
 	"bytes"
 	"context"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -45,7 +47,9 @@ type mockDecisionService struct {
 	listChildOffErr    error
 
 	decideInput  enrollmentService.DecideInput
+	decideCalls  int
 	decideResult *enrollmentService.DecideOutcome
+	decideErrs   []error
 	decideErr    error
 
 	// ExportPhase: records the args the handler forwards (so a handler
@@ -82,6 +86,12 @@ func (m *mockDecisionService) Get(_ context.Context, id int64) (*enrollmentServi
 
 func (m *mockDecisionService) Decide(_ context.Context, input enrollmentService.DecideInput) (*enrollmentService.DecideOutcome, error) {
 	m.decideInput = input
+	m.decideCalls++
+	if len(m.decideErrs) > 0 {
+		err := m.decideErrs[0]
+		m.decideErrs = m.decideErrs[1:]
+		return m.decideResult, err
+	}
 	return m.decideResult, m.decideErr
 }
 
@@ -417,6 +427,44 @@ func TestDecideAdminChildHandler_HappyPathReturns200(t *testing.T) {
 	assert.Equal(t, enrollmentService.DecisionApproved, mock.decideInput.Status)
 	assert.Equal(t, "OK", mock.decideInput.Reason)
 	assert.Contains(t, w.Body.String(), `"status":"approved"`)
+}
+
+func TestDecideAdminChildHandler_RetriesTransientDatabaseError(t *testing.T) {
+	mock := &mockDecisionService{
+		decideResult: &enrollmentService.DecideOutcome{
+			Child: makeChildSummary(99, "Lara", "Beispiel", enrollmentModels.ChildStatusApproved),
+		},
+		decideErrs: []error{
+			fmt.Errorf("decision: list child offerings: %w", driver.ErrBadConn),
+			nil,
+		},
+	}
+	router := buildAdminDecisionRouter(mock)
+
+	w := executeAdminJSON(t, router, http.MethodPost,
+		"/enrollment/admin/requests/1234/children/99/decide",
+		map[string]any{"status": "approved"})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 2, mock.decideCalls)
+	assert.Contains(t, w.Body.String(), `"status":"approved"`)
+}
+
+func TestDecideAdminChildHandler_TransientDatabaseErrorMapsTo503AfterRetry(t *testing.T) {
+	mock := &mockDecisionService{
+		decideErrs: []error{
+			fmt.Errorf("decision: list child offerings: %w", driver.ErrBadConn),
+			fmt.Errorf("decision: list child offerings: %w", driver.ErrBadConn),
+		},
+	}
+	router := buildAdminDecisionRouter(mock)
+
+	w := executeAdminJSON(t, router, http.MethodPost,
+		"/enrollment/admin/requests/1234/children/99/decide",
+		map[string]any{"status": "approved"})
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Equal(t, 2, mock.decideCalls)
 }
 
 func TestDecideAdminChildHandler_ChildNotFoundMapsTo404(t *testing.T) {

--- a/backend/api/enrollment/admin_decision_handlers_test.go
+++ b/backend/api/enrollment/admin_decision_handlers_test.go
@@ -450,6 +450,82 @@ func TestDecideAdminChildHandler_RetriesTransientDatabaseError(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"status":"approved"`)
 }
 
+func TestDecideAdminChildHandler_DoesNotRetryAfterDecisionBodySucceeded(t *testing.T) {
+	mock := &mockDecisionService{
+		decideResult: &enrollmentService.DecideOutcome{
+			Child: makeChildSummary(99, "Lara", "Beispiel", enrollmentModels.ChildStatusApproved),
+		},
+	}
+	rs := &Resource{
+		DecisionService: mock,
+		runInTenantTxForTest: func(r *http.Request, fn func(ctx context.Context) error) error {
+			if err := fn(r.Context()); err != nil {
+				return err
+			}
+			return fmt.Errorf("commit failed: %w", driver.ErrBadConn)
+		},
+	}
+	router := chi.NewRouter()
+	router.Use(render.SetContentType(render.ContentTypeJSON))
+	router.Post("/enrollment/admin/requests/{id}/children/{childId}/decide", rs.decideAdminChild)
+
+	w := executeAdminJSON(t, router, http.MethodPost,
+		"/enrollment/admin/requests/1234/children/99/decide",
+		map[string]any{"status": "approved"})
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Equal(t, 1, mock.decideCalls,
+		"commit-boundary errors after a successful decision body must not replay the approval")
+}
+
+func TestDecideAdminChildHandler_DoesNotRetryCanceledRequestContext(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupCtx   func(context.Context) (context.Context, context.CancelFunc)
+		wantStatus int
+	}{
+		{
+			name: "canceled",
+			setupCtx: func(parent context.Context) (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(parent)
+				cancel()
+				return ctx, func() {}
+			},
+			wantStatus: 499,
+		},
+		{
+			name: "deadline exceeded",
+			setupCtx: func(parent context.Context) (context.Context, context.CancelFunc) {
+				return context.WithDeadline(parent, time.Now().Add(-time.Second))
+			},
+			wantStatus: http.StatusRequestTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDecisionService{
+				decideErrs: []error{fmt.Errorf("decision: list child offerings: %w", driver.ErrBadConn)},
+			}
+			router := buildAdminDecisionRouter(mock)
+
+			req := httptest.NewRequest(http.MethodPost,
+				"/enrollment/admin/requests/1234/children/99/decide",
+				strings.NewReader(`{"status":"approved"}`))
+			req.Header.Set("Content-Type", "application/json")
+			ctx, cancel := tt.setupCtx(req.Context())
+			defer cancel()
+			req = req.WithContext(ctx)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			assert.Equal(t, 1, mock.decideCalls)
+		})
+	}
+}
+
 func TestDecideAdminChildHandler_TransientDatabaseErrorMapsTo503AfterRetry(t *testing.T) {
 	mock := &mockDecisionService{
 		decideErrs: []error{

--- a/backend/api/enrollment/api.go
+++ b/backend/api/enrollment/api.go
@@ -4,6 +4,9 @@
 package enrollment
 
 import (
+	"context"
+	"net/http"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/go-chi/render"
@@ -33,8 +36,9 @@ type Resource struct {
 	// ListExportService renders the compact per-phase registration
 	// export (PDF blocks + XLSX flat table). Set as a field after
 	// construction (mirrors api/rooms), not via the constructor.
-	ListExportService listexport.Service
-	db                *bun.DB
+	ListExportService    listexport.Service
+	db                   *bun.DB
+	runInTenantTxForTest func(r *http.Request, fn func(ctx context.Context) error) error
 }
 
 // NewResource constructs the enrollment API resource. PR 7 added the

--- a/backend/api/enrollment/schema_handlers.go
+++ b/backend/api/enrollment/schema_handlers.go
@@ -697,6 +697,9 @@ const (
 // transaction so the service's repo calls hit the right RLS scope.
 // Tests use a nil DB and skip the transaction wrap.
 func (rs *Resource) runInTenantTx(r *http.Request, fn func(ctx context.Context) error) error {
+	if rs.runInTenantTxForTest != nil {
+		return rs.runInTenantTxForTest(r, fn)
+	}
 	ctx := r.Context()
 	if rs.db == nil {
 		return fn(ctx)

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -1617,6 +1617,7 @@ func TestClassifyServiceError(t *testing.T) {
 		{"forbidden - own sessions", "can only update own sessions", http.StatusForbidden},
 		{"bad request - status", "status must be present or home_office", http.StatusBadRequest},
 		{"bad request - break minutes", "break minutes cannot be negative", http.StatusBadRequest},
+		{"bad request - invalid session data", "invalid session data: check-in time must be before check-out time", http.StatusBadRequest},
 		{"internal server - unknown", "some unknown error", http.StatusInternalServerError},
 	}
 

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -1618,6 +1618,9 @@ func TestClassifyServiceError(t *testing.T) {
 		{"bad request - status", "status must be present or home_office", http.StatusBadRequest},
 		{"bad request - break minutes", "break minutes cannot be negative", http.StatusBadRequest},
 		{"bad request - invalid session data", "invalid session data: check-in time must be before check-out time", http.StatusBadRequest},
+		{"bad request - admin create time range", "check_out_time must be after check_in_time", http.StatusBadRequest},
+		{"internal server - invalid session missing creator", "invalid session data: created_by is required", http.StatusInternalServerError},
+		{"internal server - invalid session missing staff", "invalid session data: staff ID is required", http.StatusInternalServerError},
 		{"internal server - unknown", "some unknown error", http.StatusInternalServerError},
 	}
 

--- a/backend/api/time-tracking/errors.go
+++ b/backend/api/time-tracking/errors.go
@@ -52,7 +52,8 @@ func classifyServiceError(err error) render.Renderer {
 		msg == "notes required when changing status",
 		msg == "break minutes cannot be negative",
 		msg == "break duration cannot be negative",
-		strings.HasPrefix(msg, "invalid session data:"),
+		msg == "invalid session data: check-in time must be before check-out time",
+		msg == "check_out_time must be after check_in_time",
 		strings.HasPrefix(msg, "planned_duration_minutes must be"),
 		strings.HasPrefix(msg, "break ") && strings.Contains(msg, "does not belong to this session"),
 		msg == "cannot edit duration of an active break":

--- a/backend/api/time-tracking/errors.go
+++ b/backend/api/time-tracking/errors.go
@@ -52,6 +52,7 @@ func classifyServiceError(err error) render.Renderer {
 		msg == "notes required when changing status",
 		msg == "break minutes cannot be negative",
 		msg == "break duration cannot be negative",
+		strings.HasPrefix(msg, "invalid session data:"),
 		strings.HasPrefix(msg, "planned_duration_minutes must be"),
 		strings.HasPrefix(msg, "break ") && strings.Contains(msg, "does not belong to this session"),
 		msg == "cannot edit duration of an active break":

--- a/backend/cmd/serve.go
+++ b/backend/cmd/serve.go
@@ -43,14 +43,7 @@ var serveCmd = &cobra.Command{
 				Dsn:         dsn,
 				Environment: sentryEnv,
 				BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
-					if event.Request != nil {
-						for _, key := range []string{"X-Staff-PIN", "X-Staff-Id", "X-Device-Key"} {
-							if _, ok := event.Request.Headers[key]; ok {
-								event.Request.Headers[key] = "[filtered]"
-							}
-						}
-					}
-					return event
+					return scrubSentryEvent(event)
 				},
 			})
 			if err != nil {
@@ -68,6 +61,19 @@ var serveCmd = &cobra.Command{
 		}
 		server.Start()
 	},
+}
+
+func scrubSentryEvent(event *sentry.Event) *sentry.Event {
+	if event == nil || event.Request == nil {
+		return event
+	}
+	event.Request.Data = ""
+	for _, key := range []string{"X-Staff-PIN", "X-Staff-Id", "X-Device-Key"} {
+		if _, ok := event.Request.Headers[key]; ok {
+			event.Request.Headers[key] = "[filtered]"
+		}
+	}
+	return event
 }
 
 func init() {

--- a/backend/cmd/serve_test.go
+++ b/backend/cmd/serve_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -115,6 +116,25 @@ func TestValidateServeConfig_SentryEnvironmentPasses(t *testing.T) {
 	viper.Set("sentry_environment", "staging")
 
 	require.NoError(t, validateServeConfig())
+}
+
+func TestScrubSentryEvent_RemovesRequestDataAndSensitiveHeaders(t *testing.T) {
+	event := &sentry.Event{
+		Request: &sentry.Request{
+			Data: `{"notes":"person names and free text"}`,
+			Headers: map[string]string{
+				"X-Staff-PIN": "1234",
+				"Accept":      "application/json",
+			},
+		},
+	}
+
+	scrubbed := scrubSentryEvent(event)
+
+	require.NotNil(t, scrubbed.Request)
+	assert.Empty(t, scrubbed.Request.Data)
+	assert.Equal(t, "[filtered]", scrubbed.Request.Headers["X-Staff-PIN"])
+	assert.Equal(t, "application/json", scrubbed.Request.Headers["Accept"])
 }
 
 func resetServeConfig(t *testing.T) {

--- a/backend/database/repositories/enrollment/care_offering_repository.go
+++ b/backend/database/repositories/enrollment/care_offering_repository.go
@@ -150,6 +150,26 @@ func (r *CareOfferingRepository) ListByPhase(ctx context.Context, phaseID int64)
 	return offerings, nil
 }
 
+// ListByIDs returns the exact care offerings referenced by ids. It is not
+// phase-scoped because rollover request children can intentionally carry
+// source-phase offering IDs into the target phase.
+func (r *CareOfferingRepository) ListByIDs(ctx context.Context, ids []int64) ([]*enrollment.CareOffering, error) {
+	if len(ids) == 0 {
+		return []*enrollment.CareOffering{}, nil
+	}
+	var offerings []*enrollment.CareOffering
+	err := base.GetDB(ctx, r.db).NewSelect().
+		Model(&offerings).
+		ModelTableExpr(careOfferingTableExpr).
+		Where(`"care_offering".id IN (?)`, bun.List(ids)).
+		OrderExpr(`"care_offering".sort_order, "care_offering".id`).
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list care offerings by ids: %w", err)
+	}
+	return offerings, nil
+}
+
 // CountByPhaseID returns how many care offerings belong to the phase.
 // Powers the phase-delete confirmation modal ("Y Betreuungsangebote
 // werden gelöscht"). Tenant-scoped via RLS.

--- a/backend/database/repositories/enrollment/care_offering_repository_test.go
+++ b/backend/database/repositories/enrollment/care_offering_repository_test.go
@@ -306,6 +306,55 @@ func TestCareOfferingRepository_ListByPhase_ScopesToPhase(t *testing.T) {
 	}
 }
 
+func TestCareOfferingRepository_ListByIDs_LoadsExactIDsAcrossPhases(t *testing.T) {
+	db, repo, tenantID, phaseA := setupCareOfferingRepoTest(t)
+	defer wipeOfferings(db, tenantID, phaseA)
+
+	phaseRepo := enrollmentRepo.NewPhaseRepository(db)
+	other := makeValidPhase(uniquePhaseName("ids-otherphase"))
+	other.ServiceStartDate = timezone.NewDate(2027, 9, 1)
+	other.ServiceEndDate = timezone.NewDate(2028, 7, 31)
+	require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		return phaseRepo.Create(ctx, other)
+	}))
+	t.Cleanup(func() {
+		wipeOfferings(db, tenantID, other.ID)
+		wipePhases(db, tenantID, other.Name)
+	})
+
+	first := makeOffering(phaseA, uniqueOfferingName("idsA"))
+	second := makeOffering(other.ID, uniqueOfferingName("idsB"))
+	unrequested := makeOffering(phaseA, uniqueOfferingName("idsSkip"))
+	for _, offering := range []*enrollmentModels.CareOffering{first, second, unrequested} {
+		require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+			return repo.Create(ctx, offering)
+		}))
+	}
+
+	var empty []*enrollmentModels.CareOffering
+	require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		var lErr error
+		empty, lErr = repo.ListByIDs(ctx, nil)
+		return lErr
+	}))
+	assert.Empty(t, empty)
+
+	var list []*enrollmentModels.CareOffering
+	require.NoError(t, runInTenantTx(t, db, tenantID, func(ctx context.Context) error {
+		var lErr error
+		list, lErr = repo.ListByIDs(ctx, []int64{first.ID, second.ID})
+		return lErr
+	}))
+	require.Len(t, list, 2)
+	gotIDs := make(map[int64]bool, len(list))
+	for _, offering := range list {
+		gotIDs[offering.ID] = true
+	}
+	assert.True(t, gotIDs[first.ID])
+	assert.True(t, gotIDs[second.ID])
+	assert.False(t, gotIDs[unrequested.ID])
+}
+
 func TestCareOfferingRepository_ListActiveByPhase_FiltersInactive(t *testing.T) {
 	db, repo, tenantID, phaseID := setupCareOfferingRepoTest(t)
 	defer wipeOfferings(db, tenantID, phaseID)

--- a/backend/models/enrollment/care_offering.go
+++ b/backend/models/enrollment/care_offering.go
@@ -158,6 +158,10 @@ type CareOfferingRepository interface {
 	// don't need their own time filter.
 	ListActiveByPhase(ctx context.Context, phaseID int64) ([]*CareOffering, error)
 
+	// ListByIDs returns the exact care offerings referenced by ids,
+	// regardless of phase. Empty input returns an empty slice.
+	ListByIDs(ctx context.Context, ids []int64) ([]*CareOffering, error)
+
 	// CountByPhaseID returns how many care offerings belong to the phase.
 	// Powers the phase-delete confirmation modal.
 	CountByPhaseID(ctx context.Context, phaseID int64) (int, error)

--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -1594,9 +1594,18 @@ func (s *decisionService) materializeEnrollments(
 	if len(links) == 0 {
 		return nil
 	}
-	offerings, err := s.careOfferingRepo.ListByPhase(ctx, phase.ID)
+	offeringIDs := make([]int64, 0, len(links))
+	seenOfferingIDs := make(map[int64]bool, len(links))
+	for _, link := range links {
+		if link.CareOfferingID <= 0 || seenOfferingIDs[link.CareOfferingID] {
+			continue
+		}
+		seenOfferingIDs[link.CareOfferingID] = true
+		offeringIDs = append(offeringIDs, link.CareOfferingID)
+	}
+	offerings, err := s.careOfferingRepo.ListByIDs(ctx, offeringIDs)
 	if err != nil {
-		return fmt.Errorf("decision: list phase care offerings: %w", err)
+		return fmt.Errorf("decision: list linked care offerings: %w", err)
 	}
 	offeringByID := make(map[int64]*enrollmentModels.CareOffering, len(offerings))
 	for _, offering := range offerings {

--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -1591,6 +1591,17 @@ func (s *decisionService) materializeEnrollments(
 	if err != nil {
 		return fmt.Errorf("decision: list child offerings: %w", err)
 	}
+	if len(links) == 0 {
+		return nil
+	}
+	offerings, err := s.careOfferingRepo.ListByPhase(ctx, phase.ID)
+	if err != nil {
+		return fmt.Errorf("decision: list phase care offerings: %w", err)
+	}
+	offeringByID := make(map[int64]*enrollmentModels.CareOffering, len(offerings))
+	for _, offering := range offerings {
+		offeringByID[offering.ID] = offering
+	}
 
 	validFrom := phase.ServiceStartDate
 	validUntil := phase.ServiceEndDate
@@ -1603,8 +1614,8 @@ func (s *decisionService) materializeEnrollments(
 	drafts := make(map[int64]*enrollmentDraft)
 
 	for _, link := range links {
-		offering, err := s.careOfferingRepo.FindByID(ctx, link.CareOfferingID)
-		if err != nil || offering == nil {
+		offering := offeringByID[link.CareOfferingID]
+		if offering == nil {
 			s.logger.Warn("decision: care offering missing for child link",
 				slog.Int64("request_child_id", requestChildID),
 				slog.Int64("care_offering_id", link.CareOfferingID))

--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -1447,8 +1447,8 @@ func (s *decisionService) linkAdditionalGuardians(
 		if err := rel.Validate(); err != nil {
 			return fmt.Errorf("validate co-guardian student_guardian: %w", err)
 		}
-		if err := s.studentGuardianRepo.Create(ctx, rel); err != nil {
-			return fmt.Errorf("create co-guardian student_guardian: %w", err)
+		if _, err := s.studentGuardianRepo.LinkIfNotExists(ctx, rel); err != nil {
+			return fmt.Errorf("link co-guardian student_guardian: %w", err)
 		}
 		// Persist the co-guardian's phone number, mirroring the primary
 		// guardian. A co-guardian can be a phone-only contact (no email),
@@ -2487,7 +2487,7 @@ func (s *decisionService) dispatchContactList(ctx context.Context, raw any, stud
 		if c.EmergencyPriority > 0 {
 			rel.EmergencyPriority = c.EmergencyPriority
 		}
-		if err := s.studentGuardianRepo.Create(ctx, rel); err != nil {
+		if _, err := s.studentGuardianRepo.LinkIfNotExists(ctx, rel); err != nil {
 			return fmt.Errorf("link contact to student: %w", err)
 		}
 	}

--- a/backend/services/enrollment/decision_service_test.go
+++ b/backend/services/enrollment/decision_service_test.go
@@ -966,6 +966,115 @@ func TestDecisionService_Decide_ApprovedPreservesLegacyNonTemplateLinkedOffering
 	assert.Empty(t, rows[0].SelectedWeekdays)
 }
 
+func TestDecisionService_Decide_RolloverApprovalMaterializesSourcePhaseOffering(t *testing.T) {
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	category := testpkg.CreateTestActivityCategory(t, env.db, "Decision-Rollover-Linked")
+	group := &activitiesModels.Group{
+		Name:            "Decision Rollover Linked",
+		Type:            activitiesModels.GroupTypeCare,
+		CategoryID:      category.ID,
+		MaxParticipants: 20,
+		IsOpen:          true,
+		IsTemplate:      false,
+	}
+	group.SetTenantID(1)
+	require.NoError(t, env.repos.ActivityGroup.Create(ctx, group))
+	defer func() {
+		testpkg.CleanupTableRecords(t, env.db, "activities.groups", group.ID)
+		testpkg.CleanupTableRecords(t, env.db, "activities.categories", category.ID)
+	}()
+
+	offering := &enrollmentModels.CareOffering{
+		PhaseID:         env.sourcePhase.ID,
+		ActivityGroupID: &group.ID,
+		Name:            "Rollover Source Linked",
+		DaysOfWeekMode:  enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:   []string{"mon", "wed"},
+		IsActive:        true,
+	}
+	offering.SetTenantID(1)
+	require.NoError(t, env.repos.CareOffering.Create(ctx, offering))
+
+	submitted, err := env.requestSvc.Submit(ctx, enrollmentService.SubmitRequest{
+		TenantID:          1,
+		PhaseID:           env.sourcePhase.ID,
+		GuardianFirstName: "Eltern",
+		GuardianLastName:  "Rollover",
+		GuardianEmail:     "rollover-linked@example.com",
+		ConsentFlags: map[string]any{
+			"agb":             true,
+			"data_processing": true,
+			"email_contact":   true,
+			"photo":           true,
+		},
+		Children: []enrollmentService.SubmitChild{
+			{
+				FirstName:        "Rina",
+				LastName:         "Rollover",
+				DateOfBirth:      timezone.NewDate(2018, 4, 15),
+				TargetGradeLevel: testpkg.Int16Ptr(2),
+				OfferingIDs:      []int64{offering.ID},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, submitted.Children, 1)
+
+	sourceOutcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
+		RequestID:  submitted.Request.ID,
+		ChildID:    submitted.Children[0].ID,
+		Status:     enrollmentService.DecisionApproved,
+		ReviewedBy: env.creatorID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sourceOutcome.Child.CreatedStudentID)
+	studentID := *sourceOutcome.Child.CreatedStudentID
+
+	result, err := env.rolloverSvc.CreatePhaseFromSource(ctx,
+		validRolloverRequest(env.rolloverTestEnv, enrollmentModels.PhaseRolloverModeOptOut, true))
+	require.NoError(t, err)
+	require.NotNil(t, result.Phase)
+
+	rolledChildren, err := env.repos.RequestChild.ListByPhaseAndStatuses(ctx, result.Phase.ID,
+		[]string{enrollmentModels.ChildStatusAutoRenewed})
+	require.NoError(t, err)
+	require.Len(t, rolledChildren, 1)
+	rolled := rolledChildren[0]
+	require.NotNil(t, rolled.RolloverSourceChildID)
+	assert.Equal(t, submitted.Children[0].ID, *rolled.RolloverSourceChildID)
+
+	rolledLinks, err := env.repos.RequestChildOffering.ListByRequestChildID(ctx, rolled.ID)
+	require.NoError(t, err)
+	require.Len(t, rolledLinks, 1)
+	assert.Equal(t, offering.ID, rolledLinks[0].CareOfferingID,
+		"rollover intentionally copies the source-phase offering id")
+
+	rolloverOutcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
+		RequestID:  rolled.RequestID,
+		ChildID:    rolled.ID,
+		Status:     enrollmentService.DecisionApproved,
+		ReviewedBy: env.creatorID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, rolloverOutcome.Child.CreatedStudentID)
+	assert.Equal(t, studentID, *rolloverOutcome.Child.CreatedStudentID)
+
+	count, err := env.db.NewSelect().
+		Model((*activitiesModels.StudentEnrollment)(nil)).
+		ModelTableExpr(`activities.student_enrollments AS "student_enrollment"`).
+		Where(`"student_enrollment".tenant_id = ?`, 1).
+		Where(`"student_enrollment".student_id = ?`, studentID).
+		Where(`"student_enrollment".activity_group_id = ?`, group.ID).
+		Where(`"student_enrollment".valid_from = ?`, result.Phase.ServiceStartDate).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count,
+		"rollover approval must materialize the copied source-phase offering for the target phase window")
+}
+
 func TestDecisionService_Decide_ApprovedRejectsEmptyDaysForTemplateOffering(t *testing.T) {
 	env, cleanup := setupDecisionTest(t)
 	defer cleanup()

--- a/backend/services/enrollment/decision_service_test.go
+++ b/backend/services/enrollment/decision_service_test.go
@@ -535,6 +535,83 @@ func TestDecisionService_Decide_PersistsCoGuardianPhone(t *testing.T) {
 	}
 }
 
+func TestDecisionService_Decide_ContactListSelfGuardianDoesNotAbortApproval(t *testing.T) {
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	schemaSvc := enrollmentService.NewFormSchemaService(enrollmentService.FormSchemaServiceConfig{
+		Repo:   env.repos.FormSchema,
+		Logger: slog.Default(),
+	})
+	schema, err := schemaSvc.PublishVersion(ctx, []enrollmentModels.FormField{{
+		Key:         "contacts",
+		Label:       "Weitere Kontakte",
+		Type:        enrollmentModels.FormFieldContactList,
+		Target:      enrollmentModels.TargetStudentContacts,
+		AppliesToCh: true,
+		SortOrder:   0,
+	}}, env.creatorID)
+	require.NoError(t, err)
+	env.sourcePhase.FormSchemaID = &schema.ID
+	require.NoError(t, env.repos.Phase.Update(ctx, env.sourcePhase))
+
+	guardianEmail := "self-contact@example.com"
+	guardianPhone := "015126829060"
+	grade := int16(2)
+	res, err := env.requestSvc.Submit(ctx, enrollmentService.SubmitRequest{
+		TenantID:          1,
+		PhaseID:           env.sourcePhase.ID,
+		GuardianFirstName: "Franziska",
+		GuardianLastName:  "Bahnemann",
+		GuardianEmail:     guardianEmail,
+		GuardianPhone:     &guardianPhone,
+		ConsentFlags: map[string]any{
+			"agb":             true,
+			"data_processing": true,
+			"email_contact":   true,
+			"photo":           true,
+		},
+		Children: []enrollmentService.SubmitChild{{
+			FirstName:        "Self",
+			LastName:         "Contact",
+			DateOfBirth:      timezone.NewDate(2018, 4, 15),
+			TargetGradeLevel: &grade,
+			CustomData: map[string]any{
+				"contacts": []any{map[string]any{
+					"first_name":           "Franziska",
+					"last_name":            "Bahnemann",
+					"email":                guardianEmail,
+					"relationship_type":    "parent",
+					"is_emergency_contact": true,
+					"can_pickup":           true,
+				}},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Children, 1)
+
+	outcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
+		RequestID:  res.Request.ID,
+		ChildID:    res.Children[0].ID,
+		Status:     enrollmentService.DecisionApproved,
+		ReviewedBy: env.creatorID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Child.CreatedStudentID)
+
+	links, err := env.repos.StudentGuardian.FindByStudentID(ctx, *outcome.Child.CreatedStudentID)
+	require.NoError(t, err)
+	require.Len(t, links, 1, "self-contact must reuse the primary guardian link instead of aborting the tx")
+	assert.True(t, links[0].IsPrimary)
+
+	phones, err := env.repos.GuardianPhoneNumber.FindByGuardianID(ctx, links[0].GuardianProfileID)
+	require.NoError(t, err, "auto guardian_phone runs after contact dispatch; this proves the tx stayed usable")
+	require.Len(t, phones, 1)
+	assert.Equal(t, guardianPhone, phones[0].PhoneNumber)
+}
+
 // TestDecisionService_Decide_AppliesDepartureField verifies the unified
 // weekday_mode departure field (#1610) flows from the enrollment submission
 // onto the approved student's departure_days, deriving the legacy mirrors.

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -2357,6 +2357,33 @@ describe("TimeTrackingPage", () => {
       expect(saveBtn).not.toBeDisabled();
     });
 
+    it("blocks saving when end time is not after start time", async () => {
+      await openEditModal(makePastSession());
+      vi.mocked(timeTrackingService.updateSession).mockClear();
+
+      fireEvent.click(screen.getByText("Zeitkorrektur"));
+      fireEvent.change(screen.getByLabelText("Start"), {
+        target: { value: "12:30" },
+      });
+      fireEvent.change(screen.getByLabelText("Ende"), {
+        target: { value: "12:00" },
+      });
+
+      expect(
+        screen.getByText("Ende muss nach Start liegen."),
+      ).toBeInTheDocument();
+
+      const saveButtons = screen.getAllByText("Speichern");
+      const saveBtn = saveButtons[saveButtons.length - 1]!;
+      expect(saveBtn).toBeDisabled();
+
+      await act(async () => {
+        fireEvent.click(saveBtn);
+      });
+
+      expect(timeTrackingService.updateSession).not.toHaveBeenCalled();
+    });
+
     it("calls onSave with correct data when saved without individual breaks", async () => {
       const mockToast = {
         success: vi.fn(),

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -169,6 +169,9 @@ function friendlyError(err: unknown, fallback: string): string {
   ) {
     return "Für diesen Zeitraum ist bereits eine andere Abwesenheitsart eingetragen.";
   }
+  if (code.startsWith("invalid session data:")) {
+    return "Bitte prüfe Start- und Endzeit.";
+  }
 
   return fallback;
 }
@@ -1710,6 +1713,23 @@ function WeekChart({
 
 const BREAK_DURATION_OPTIONS = [0, 15, 30, 45, 60] as const;
 
+function timeInputToMinutes(value: string): number | null {
+  const [hoursRaw, minutesRaw] = value.split(":");
+  const hours = Number(hoursRaw);
+  const minutes = Number(minutesRaw);
+  if (
+    !Number.isInteger(hours) ||
+    !Number.isInteger(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return null;
+  }
+  return hours * 60 + minutes;
+}
+
 /** Calculate compliance warnings for edited session times */
 function calcEditComplianceWarnings(
   startTime: string,
@@ -1902,6 +1922,10 @@ function EditSessionModal({
 
   // Compliance check for the edited values
   const warnings = calcEditComplianceWarnings(startTime, endTime, editedBreak);
+  const startMinutes = timeInputToMinutes(startTime);
+  const endMinutes = timeInputToMinutes(endTime);
+  const hasInvalidTimeRange =
+    startMinutes !== null && endMinutes !== null && endMinutes <= startMinutes;
 
   const handleBreakDurationChange = (breakId: string, minutes: number) => {
     setBreakDurations((prev) => {
@@ -1913,6 +1937,7 @@ function EditSessionModal({
 
   const handleSave = async () => {
     if (!session) return;
+    if (hasInvalidTimeRange) return;
     setSaving(true);
     try {
       // Use session's actual date, not the clicked day (they may differ)
@@ -2002,7 +2027,7 @@ function EditSessionModal({
       </button>
       <button
         onClick={handleSave}
-        disabled={saving || !startTime || !notes.trim()}
+        disabled={saving || !startTime || !notes.trim() || hasInvalidTimeRange}
         className="flex-1 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-all duration-200 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {saving ? "Speichern..." : "Speichern"}
@@ -2106,6 +2131,12 @@ function EditSessionModal({
                 />
               </div>
             </div>
+
+            {hasInvalidTimeRange && (
+              <p className="text-xs font-medium text-red-600">
+                Ende muss nach Start liegen.
+              </p>
+            )}
 
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               {/* Break section */}


### PR DESCRIPTION
## Summary
- retry enrollment admin child decisions once when the database connection is transiently bad, then return 503 if it still fails
- make enrollment approval idempotent when a guardian is also submitted as an extra contact / emergency contact
- classify invalid time-tracking session ranges as bad requests and prevent submitting impossible ranges in the UI
- scrub Sentry request bodies while preserving sensitive header filtering

## Root Cause
- Production logs for request 16 / child 19 showed the Sentry `driver: bad connection` was a follow-on error after PostgreSQL had already aborted the transaction.
- The first failure was `duplicate key value violates unique constraint "idx_students_guardians_tenant"` while dispatching `student.contacts`; the submitted contact reused the same guardian profile that approval had already linked as the primary guardian.
- After that unique violation, later writes/reads in the same transaction failed with `current transaction is aborted` / `driver: bad connection`, which is what Sentry surfaced at `list child offerings`.
- The fix switches additional guardian/contact-list linking to the existing `LinkIfNotExists` repository path so duplicate guardian links are no-ops instead of transaction-poisoning SQL errors.
- The time-tracking validator returned the right domain error, but the HTTP classifier let it fall through to the generic 500 path.
- Sentry events could include request bodies with notes or other user-entered data.

## Validation
- go test ./services/enrollment -run 'TestDecodeStructured|TestContactGuardianRole'
- go test ./api/common ./api/enrollment -run 'TestIsTransientDatabaseError|TestDecideAdminChildHandler_(RetriesTransientDatabaseError|TransientDatabaseErrorMapsTo503AfterRetry|DoesNotRetryAfterDecisionBodySucceeded|DoesNotRetryCanceledRequestContext)$'
- go test ./api/common -run 'TestIsTransientDatabaseError|TestRenderError'
- go test ./api/enrollment -run 'TestDecideAdminChildHandler_(RetriesTransientDatabaseError|TransientDatabaseErrorMapsTo503AfterRetry|HappyPathReturns200)'
- go test ./api/time-tracking -run TestClassifyServiceError
- go test ./cmd -run 'TestScrubSentryEvent|TestValidateServeConfig_Sentry'
- go test ./... -run '^$'
- cd frontend && pnpm test:run 'src/app/[tenant]/(protected)/time-tracking/page.test.tsx'
- cd frontend && pnpm run check
- pre-push hook: git-secrets, go vet, golangci-lint, go-deadcode

Note: the new regression test `TestDecisionService_Decide_ContactListSelfGuardianDoesNotAbortApproval` is an integration test that requires TEST_DB_DSN/test Postgres. CI should run it; this local checkout does not have TEST_DB_DSN configured.
