### PR TITLE
fix: Heimweg-Anzeige als kompakte Wochentags-Matrix (Modal-Overflow)

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/students/[id]/components/PersonalInfoCard.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/components/PersonalInfoCard.test.tsx
@@ -103,7 +103,11 @@ describe("PersonalInfoCard", () => {
       />,
     );
 
-    expect(screen.getByText("Mi: Wird abgeholt")).toBeInTheDocument();
+    // Legacy pickup_days {wed} folds into an "Abgeholt" badge on the Mi row of
+    // the weekday matrix; the other weekdays fold to "Zu Fuß".
+    expect(screen.getByText("Mi")).toBeInTheDocument();
+    expect(screen.getAllByText("Abgeholt")).toHaveLength(1);
+    expect(screen.getAllByText("Zu Fuß")).toHaveLength(4);
   });
 
   it("shows sick badge when student is sick with full access", () => {

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/components/PersonalInfoCard.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/components/PersonalInfoCard.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { InfoItem } from "~/components/ui/info-card";
+import { AllowedDepartureModesDisplay } from "~/components/students/allowed-departure-modes-display";
 import type {
   AllowedDepartureModes,
   BusDays,
@@ -11,7 +12,6 @@ import type {
 import {
   allowedDepartureModesFromDeparture,
   departureDaysFromLegacy,
-  formatAllowedDepartureModes,
 } from "~/lib/student-helpers";
 
 interface ExtendedStudent {
@@ -106,13 +106,20 @@ function PersonalInfoDisplay({
       />
       <InfoItem
         label="Erlaubte Heimwege"
-        value={formatAllowedDepartureModes(
-          student.allowed_departure_modes ??
-            allowedDepartureModesFromDeparture(
-              student.departure_days ??
-                departureDaysFromLegacy(student.bus_days, student.pickup_days),
-            ),
-        )}
+        value={
+          <AllowedDepartureModesDisplay
+            value={
+              student.allowed_departure_modes ??
+              allowedDepartureModesFromDeparture(
+                student.departure_days ??
+                  departureDaysFromLegacy(
+                    student.bus_days,
+                    student.pickup_days,
+                  ),
+              )
+            }
+          />
+        }
       />
 
       {/* Sickness status - only for full access */}

--- a/frontend/src/components/students/allowed-departure-modes-display.test.tsx
+++ b/frontend/src/components/students/allowed-departure-modes-display.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { AllowedDepartureModes } from "~/lib/student-helpers";
+import { AllowedDepartureModesDisplay } from "./allowed-departure-modes-display";
+
+describe("AllowedDepartureModesDisplay", () => {
+  it("collapses to 'Geht immer alleine' when no bus/pickup is configured", () => {
+    render(<AllowedDepartureModesDisplay value={{}} />);
+    expect(screen.getByText("Geht immer alleine")).toBeInTheDocument();
+    // No weekday rows when there is nothing to show.
+    expect(screen.queryByText("Mo")).not.toBeInTheDocument();
+  });
+
+  it("renders bus + pickup on every weekday without truncation", () => {
+    // The exact case that overflowed the modal: both modes on all five days.
+    const everyDay: AllowedDepartureModes = {
+      mon: ["bus", "pickup"],
+      tue: ["bus", "pickup"],
+      wed: ["bus", "pickup"],
+      thu: ["bus", "pickup"],
+      fri: ["bus", "pickup"],
+    };
+    render(<AllowedDepartureModesDisplay value={everyDay} />);
+
+    for (const day of ["Mo", "Di", "Mi", "Do", "Fr"]) {
+      expect(screen.getByText(day)).toBeInTheDocument();
+    }
+    expect(screen.getAllByText("Bus")).toHaveLength(5);
+    expect(screen.getAllByText("Abgeholt")).toHaveLength(5);
+  });
+
+  it("folds unconfigured weekdays to a 'Zu Fuß' badge", () => {
+    render(<AllowedDepartureModesDisplay value={{ mon: ["bus"] }} />);
+    expect(screen.getByText("Bus")).toBeInTheDocument();
+    // Tue–Fri have no arrangement and fold to "Zu Fuß".
+    expect(screen.getAllByText("Zu Fuß")).toHaveLength(4);
+  });
+});

--- a/frontend/src/components/students/allowed-departure-modes-display.tsx
+++ b/frontend/src/components/students/allowed-departure-modes-display.tsx
@@ -1,0 +1,48 @@
+import {
+  type AllowedDepartureModes,
+  DEPARTURE_MODE_BADGE_CLASSES,
+  DEPARTURE_MODE_SHORT_LABELS,
+  departureMatrixRows,
+  hasAnyDepartureArrangement,
+} from "~/lib/student-helpers";
+
+/**
+ * Read-only "Erlaubte Heimwege" display for the student Stammdaten. Mirrors the
+ * editor's per-weekday layout: one row per weekday (Mo–Fr) with the allowed modes
+ * as brand-colored badges, reusing the same labels and colors as the edit form
+ * (DEPARTURE_MODE_* in student-helpers) so view and edit stay visually consistent.
+ *
+ * The badges wrap instead of forcing a single line, so a child with bus + pickup
+ * on every weekday renders cleanly instead of overflowing the card. When the child
+ * goes home alone every day the matrix collapses to a single "Geht immer alleine"
+ * line rather than five identical "Zu Fuß" rows.
+ */
+export function AllowedDepartureModesDisplay({
+  value,
+}: Readonly<{ value?: AllowedDepartureModes | null }>) {
+  if (!hasAnyDepartureArrangement(value)) {
+    return <span className="text-gray-900">Geht immer alleine</span>;
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {departureMatrixRows(value).map((row) => (
+        <div key={row.key} className="flex items-center gap-3">
+          <span className="w-7 shrink-0 text-xs font-semibold text-gray-500">
+            {row.short}
+          </span>
+          <div className="flex flex-wrap gap-1">
+            {row.modes.map((mode) => (
+              <span
+                key={mode}
+                className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${DEPARTURE_MODE_BADGE_CLASSES[mode]}`}
+              >
+                {DEPARTURE_MODE_SHORT_LABELS[mode]}
+              </span>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/students/student-detail-components.test.tsx
+++ b/frontend/src/components/students/student-detail-components.test.tsx
@@ -636,12 +636,18 @@ describe("PersonalInfoReadOnly", () => {
     expect(screen.getByText("Nicht angegeben")).toBeInTheDocument();
   });
 
-  it("renders bus days as the unified departure plan", () => {
-    // mockStudent has bus_days {mon, fri}; these fold into "Fährt Bus".
+  it("renders bus days as the weekday departure matrix", () => {
+    // mockStudent has bus_days {mon, fri}; these fold into a "Bus" badge on Mo
+    // and Fr, while the unconfigured weekdays fold to a "Zu Fuß" badge.
     render(<PersonalInfoReadOnly student={mockStudent} />);
+    expect(screen.getByText("Mo")).toBeInTheDocument();
+    expect(screen.getByText("Fr")).toBeInTheDocument();
+    expect(screen.getAllByText("Bus")).toHaveLength(2);
+    expect(screen.getAllByText("Zu Fuß")).toHaveLength(3);
+    // The verbose single-line sentence is gone.
     expect(
-      screen.getByText("Mo: Fährt Bus; Fr: Fährt Bus"),
-    ).toBeInTheDocument();
+      screen.queryByText("Mo: Fährt Bus; Fr: Fährt Bus"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders 'Geht immer alleine' when no bus/pickup days are set", () => {
@@ -656,16 +662,18 @@ describe("PersonalInfoReadOnly", () => {
     expect(screen.getByText("Geht immer alleine")).toBeInTheDocument();
   });
 
-  it("renders pickup weekdays as 'Wird abgeholt' in the departure plan", () => {
+  it("renders pickup weekdays as 'Abgeholt' badges in the departure matrix", () => {
     const pickedUp = {
       ...mockStudent,
       bus_days: {},
       pickup_days: { mon: true, wed: true },
     };
     render(<PersonalInfoReadOnly student={pickedUp} />);
+    expect(screen.getAllByText("Abgeholt")).toHaveLength(2);
+    expect(screen.getAllByText("Zu Fuß")).toHaveLength(3);
     expect(
-      screen.getByText("Mo: Wird abgeholt; Mi: Wird abgeholt"),
-    ).toBeInTheDocument();
+      screen.queryByText("Mo: Wird abgeholt; Mi: Wird abgeholt"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders health info when present", () => {

--- a/frontend/src/components/students/student-detail-components.tsx
+++ b/frontend/src/components/students/student-detail-components.tsx
@@ -17,8 +17,8 @@ import type { SupervisorContact } from "~/lib/student-helpers";
 import {
   allowedDepartureModesFromDeparture,
   departureDaysFromLegacy,
-  formatAllowedDepartureModes,
 } from "~/lib/student-helpers";
+import { AllowedDepartureModesDisplay } from "~/components/students/allowed-departure-modes-display";
 import { InfoCard, InfoItem } from "~/components/ui/info-card";
 import { Avatar } from "~/components/ui/avatar";
 import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled";
@@ -700,16 +700,20 @@ export function PersonalInfoReadOnly({
         <InfoItem label="Geburtsdatum" value={birthdayDisplay} />
         <InfoItem
           label="Erlaubte Heimwege"
-          value={formatAllowedDepartureModes(
-            student.allowed_departure_modes ??
-              allowedDepartureModesFromDeparture(
-                student.departure_days ??
-                  departureDaysFromLegacy(
-                    student.bus_days,
-                    student.pickup_days,
-                  ),
-              ),
-          )}
+          value={
+            <AllowedDepartureModesDisplay
+              value={
+                student.allowed_departure_modes ??
+                allowedDepartureModesFromDeparture(
+                  student.departure_days ??
+                    departureDaysFromLegacy(
+                      student.bus_days,
+                      student.pickup_days,
+                    ),
+                )
+              }
+            />
+          }
         />
         {student.health_info && (
           <InfoItem

--- a/frontend/src/components/students/student-form-fields.tsx
+++ b/frontend/src/components/students/student-form-fields.tsx
@@ -22,8 +22,9 @@ import {
   DEPARTURE_WEEKDAYS,
   type AllowedDepartureModes,
   type DepartureMode,
-  formatAllowedDepartureModes,
+  formatAllowedDepartureDays,
   normalizeAllowedDepartureModes,
+  DEPARTURE_MODE_BADGE_CLASSES,
 } from "~/lib/student-helpers";
 
 interface SelectOption {
@@ -701,15 +702,6 @@ const DEPARTURE_OPTIONS: ReadonlyArray<{
   { value: "bus", short: "Bus" },
   { value: "pickup", short: "Abgeholt" },
 ];
-
-// Active styling per mode, using MOTO brand hexes: pickup = brand green,
-// bus = brand blue, alone = neutral gray.
-const DEPARTURE_ACTIVE_CLASSES: Record<DepartureMode, string> = {
-  alone: "border-[#6B7280] bg-[#F3F4F6] text-[#374151]",
-  bus: "border-[#5080D8] bg-[#DCE7FA] text-[#2f5bb0]",
-  pickup: "border-[#83CD2D] bg-[#DCF5C1] text-[#4a7a15]",
-};
-
 export function DepartureSection({
   days,
   onChange,
@@ -733,7 +725,7 @@ export function DepartureSection({
         </h3>
         {anySelected && (
           <span className="hidden shrink-0 rounded-full bg-[#DCF5C1] px-2.5 py-1 text-xs font-medium text-[#4a7a15] sm:inline">
-            {formatAllowedDepartureModes(normalized)}
+            {formatAllowedDepartureDays(normalized)}
           </span>
         )}
       </div>
@@ -756,7 +748,7 @@ export function DepartureSection({
                       key={opt.value}
                       className={`flex h-8 cursor-pointer items-center justify-center gap-1.5 rounded-lg border px-1 text-xs font-semibold transition-colors ${
                         active
-                          ? DEPARTURE_ACTIVE_CLASSES[opt.value]
+                          ? DEPARTURE_MODE_BADGE_CLASSES[opt.value]
                           : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50"
                       }`}
                     >

--- a/frontend/src/lib/student-helpers.test.ts
+++ b/frontend/src/lib/student-helpers.test.ts
@@ -14,6 +14,7 @@ import {
   pickupDaysHaveAny,
   formatPickupDays,
   formatAllowedDepartureModes,
+  formatAllowedDepartureDays,
   normalizePickupDays,
   SCHOOL_YEAR_FILTER_OPTIONS,
   mapStudentResponse,
@@ -199,6 +200,28 @@ describe("allowed departure mode helpers", () => {
   it("formats an empty map as going alone", () => {
     expect(formatAllowedDepartureModes({})).toBe("Geht immer alleine");
     expect(formatAllowedDepartureModes(null)).toBe("Geht immer alleine");
+  });
+
+  it("summarizes only the weekdays as a compact day list", () => {
+    // The badge variant drops the per-day modes so it stays single-line even
+    // when every day carries both bus and pickup (the case that broke the modal).
+    expect(
+      formatAllowedDepartureDays({
+        mon: ["bus", "pickup"],
+        tue: ["bus", "pickup"],
+        wed: ["bus", "pickup"],
+        thu: ["bus", "pickup"],
+        fri: ["bus", "pickup"],
+      }),
+    ).toBe("Mo, Di, Mi, Do, Fr");
+    expect(formatAllowedDepartureDays({ mon: ["bus"], fri: ["pickup"] })).toBe(
+      "Mo, Fr",
+    );
+  });
+
+  it("formats an empty day summary as going alone", () => {
+    expect(formatAllowedDepartureDays({})).toBe("Geht immer alleine");
+    expect(formatAllowedDepartureDays(null)).toBe("Geht immer alleine");
   });
 });
 

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -138,6 +138,33 @@ const DEPARTURE_MODE_LABELS: Record<DepartureMode, string> = {
   pickup: "Wird abgeholt",
 };
 
+/** Short labels for the departure modes, used in compact badges (editor pills
+ *  and the read-only Stammdaten matrix). */
+export const DEPARTURE_MODE_SHORT_LABELS: Record<DepartureMode, string> = {
+  alone: "Zu Fuß",
+  bus: "Bus",
+  pickup: "Abgeholt",
+};
+
+/**
+ * Brand-hex badge classes per departure mode — the single source of truth shared
+ * by the editor pills (BusStatusSection/DepartureSection) and the read-only
+ * Stammdaten matrix, so edit and view stay visually identical: pickup = brand
+ * green, bus = brand blue, alone = neutral gray.
+ */
+export const DEPARTURE_MODE_BADGE_CLASSES: Record<DepartureMode, string> = {
+  alone: "border-[#6B7280] bg-[#F3F4F6] text-[#374151]",
+  bus: "border-[#5080D8] bg-[#DCE7FA] text-[#2f5bb0]",
+  pickup: "border-[#83CD2D] bg-[#DCF5C1] text-[#4a7a15]",
+};
+
+/** Canonical render order for departure modes (stable badge ordering). */
+const DEPARTURE_MODE_ORDER: readonly DepartureMode[] = [
+  "alone",
+  "bus",
+  "pickup",
+];
+
 export function normalizeDepartureDays(
   value?: DepartureDays | null,
 ): DepartureDays {
@@ -249,6 +276,72 @@ export function formatAllowedDepartureModes(
     ];
   });
   return parts.length > 0 ? parts.join("; ") : "Geht immer alleine";
+}
+
+/**
+ * Compact day-only summary for the "Erlaubte Heimwege" badge. Lists just the
+ * weekdays that have any departure mode configured (e.g. "Mo, Di, Fr"), mirroring
+ * formatBusDays/formatPickupDays. Unlike formatAllowedDepartureModes it omits the
+ * per-day modes, so the badge stays single-line even when every weekday has bus
+ * and pickup — the full breakdown lives in the editor rows right below it.
+ */
+export function formatAllowedDepartureDays(
+  value?: AllowedDepartureModes | null,
+): string {
+  const normalized = normalizeAllowedDepartureModes(value);
+  const labels = DEPARTURE_WEEKDAYS.filter(
+    (day) => (normalized[day.key]?.length ?? 0) > 0,
+  ).map((day) => day.label.slice(0, 2));
+  return labels.length > 0 ? labels.join(", ") : "Geht immer alleine";
+}
+
+export interface DepartureMatrixRow {
+  readonly key: DepartureDayKey;
+  /** Full weekday label, e.g. "Montag". */
+  readonly label: string;
+  /** Two-letter weekday label, e.g. "Mo". */
+  readonly short: string;
+  /** Allowed modes for the day in canonical order; never empty — a day with no
+   *  configured arrangement folds to ["alone"] (the child leaves on its own). */
+  readonly modes: DepartureMode[];
+}
+
+/**
+ * Builds the per-weekday rows for the read-only "Erlaubte Heimwege" matrix
+ * (Mo–Fr). A weekday with no configured mode folds to ["alone"], mirroring
+ * formatAllowedDepartureModes' "goes alone" semantics. Modes are returned in the
+ * canonical DEPARTURE_MODE_ORDER so badges render in a stable order.
+ */
+export function departureMatrixRows(
+  value?: AllowedDepartureModes | null,
+): DepartureMatrixRow[] {
+  const normalized = normalizeAllowedDepartureModes(value);
+  return DEPARTURE_WEEKDAYS.map((day) => {
+    const modes = normalized[day.key] ?? [];
+    const ordered = DEPARTURE_MODE_ORDER.filter((mode) => modes.includes(mode));
+    return {
+      key: day.key,
+      label: day.label,
+      short: day.label.slice(0, 2),
+      modes: ordered.length > 0 ? ordered : ["alone"],
+    };
+  });
+}
+
+/**
+ * True when at least one weekday has a bus or pickup arrangement, i.e. the child
+ * does not simply go home alone every day. Used to collapse the matrix to a
+ * single "Geht immer alleine" line when there is nothing meaningful to show.
+ */
+export function hasAnyDepartureArrangement(
+  value?: AllowedDepartureModes | null,
+): boolean {
+  const normalized = normalizeAllowedDepartureModes(value);
+  return DEPARTURE_WEEKDAYS.some((day) =>
+    (normalized[day.key] ?? []).some(
+      (mode) => mode === "bus" || mode === "pickup",
+    ),
+  );
 }
 
 /**


### PR DESCRIPTION
## Problem

Das Feld "Erlaubte Heimwege" wurde über `formatAllowedDepartureModes()` als ein langer, mit Semikolon verketteter Satz gerendert (`Mo: Fährt Bus, Wird abgeholt; Di: Fährt Bus, Wird abgeholt; …`). Bei Bus **und** Abholung über alle Wochentage lief das an zwei Stellen aus dem Layout:

1. **Read-only Stammdaten** (`PersonalInfoCard`, `PersonalInfoReadOnly`): das Detail-Modal scrollte horizontal.
2. **Editor-Header-Badge** (`DepartureSection`): die zusammengeklappte Pille überlief und drückte die Überschrift weg.

## Lösung

Statt des Satzes jetzt zwei kompakte Darstellungen plus eine geteilte Quelle für Labels und Farben, damit Ansicht und Editor identisch aussehen.

**Read-only: Wochentags-Matrix.** Neue Komponente `AllowedDepartureModesDisplay`:
- eine Zeile pro Wochentag (Mo bis Fr) mit den erlaubten Modi als markenfarbige Badges, die umbrechen statt überzulaufen
- Tag ohne Bus/Abholung faltet zu einem neutralen "Zu Fuß"-Badge
- geht das Kind jeden Tag allein, kollabiert die Matrix zu einer einzigen Zeile "Geht immer alleine"

**Editor-Header: kompakte Tagesliste.** Neues `formatAllowedDepartureDays()` zeigt nur die konfigurierten Wochentage (`"Mo, Di, Mi, Do, Fr"`) und bleibt einzeilig, auch wenn jeder Tag Bus und Abholung hat.

**Konsolidierung.** Badge-Farben und Kurzlabels lagen vorher doppelt vor (lokales `DEPARTURE_ACTIVE_CLASSES` im Editor plus `DEPARTURE_OPTIONS.short`). Beides liegt jetzt zentral in `lib/student-helpers.ts` und wird von Editor und Read-only-Matrix gemeinsam genutzt:
- `DEPARTURE_MODE_BADGE_CLASSES` (Marken-Hex: Abholung grün `#83CD2D`, Bus blau `#5080D8`, allein grau)
- `DEPARTURE_MODE_SHORT_LABELS`, `DEPARTURE_MODE_ORDER`
- `departureMatrixRows()` (Tag ohne Modus faltet zu `["alone"]`), `hasAnyDepartureArrangement()` (steuert das "Geht immer alleine"-Kollabieren)

## Geänderte Dateien

| Datei | Änderung |
|---|---|
| `lib/student-helpers.ts` | geteilte Helfer/Konstanten als Single Source of Truth |
| `components/students/allowed-departure-modes-display.tsx` *(neu)* | Read-only Wochentags-Matrix |
| `student-form-fields.tsx` | lokales `DEPARTURE_ACTIVE_CLASSES` entfernt, nutzt geteilte Konstante; Header-Badge nutzt `formatAllowedDepartureDays` |
| `PersonalInfoCard.tsx`, `student-detail-components.tsx` | Satz ersetzt durch `<AllowedDepartureModesDisplay>` |

## Screenshots

### Problem: Heimwege liefen aus dem Layout (Worst Case: Bus + Abholung an allen Wochentagen)
| Read-only Stammdaten (langer Satz) | Editor-Modal (Badge drückt die Überschrift weg) |
|---|---|
| <img width="1440" height="900" alt="01-vorher-readonly-satz" src="https://github.com/user-attachments/assets/cd97403d-eb57-44be-8c35-7762f8256aca" /> | <img width="1440" height="900" alt="05-vorher-badge-modal-overflow" src="https://github.com/user-attachments/assets/f2a1b292-1a3e-44ce-8692-155e71b01f0b" /> |

### Nachher (realistische Daten: Mo Bus, Di Abgeholt, Mi Zu Fuß, Do Bus+Abgeholt, Fr Bus)
| Read-only Wochentags-Matrix | Editor |
|---|---|
| <img width="1440" height="900" alt="07-nachher-readonly-realistisch" src="https://github.com/user-attachments/assets/2ccd6911-b8dd-4854-8737-5c849bf09602" /> | <img width="1440" height="900" alt="06-nachher-editor-realistisch" src="https://github.com/user-attachments/assets/e8349627-27d5-4e69-beed-c2a7da977065" /> |

> Auch der Worst Case rendert jetzt sauber als umbrechende Matrix: _02-nachher-readonly-matrix.png hier reinziehen_


## Tests
- *(neu)* `allowed-departure-modes-display.test.tsx`: Overflow-Fall (Bus und Abholung an allen 5 Tagen), "Zu Fuß"-Fold, "Geht immer alleine"-Kollaps.
- *(neu)* Unit-Tests für `formatAllowedDepartureDays`.
- *(angepasst)* Drei bestehende Read-only-Tests prüfen jetzt die Badge-Matrix statt des alten Satzes. Grund: das gerenderte Ergebnis hat sich bewusst geändert (Satz → Matrix), keine kaschierte Regression.

Lokal grün: `pnpm run check` + betroffene Vitest-Dateien (145 Tests).

## Offen
- Help-Guide (Kinderdetailansicht) ggf. mit neuem Screenshot aktualisieren, falls die Darstellung dort dokumentiert ist.
