### PR TITLE
fix: parent child-detail desktop layout fits on tablet widths

### DIFF
--- a/frontend/src/components/parent/child-detail.tsx
+++ b/frontend/src/components/parent/child-detail.tsx
@@ -225,7 +225,7 @@ function ChildDetailContent({ child }: Readonly<{ child: Child }>) {
       />
 
       <section className="hidden overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm lg:block">
-        <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_24rem] xl:grid-cols-[minmax(0,1fr)_30rem]">
+        <div className="grid gap-0 lg:grid-cols-[minmax(0,1.25fr)_minmax(20rem,0.75fr)] xl:grid-cols-[minmax(0,1.35fr)_minmax(22rem,0.8fr)]">
           <div>
             <BackBar />
             <div className="p-5 sm:p-6 lg:p-8">
@@ -248,7 +248,7 @@ function ChildDetailContent({ child }: Readonly<{ child: Child }>) {
                   </p>
                 </div>
               </div>
-              <div className="mt-7 grid max-w-3xl gap-3 sm:grid-cols-3">
+              <div className="mt-7 grid max-w-3xl grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] gap-3">
                 {CHILD_ACTIONS.slice(0, 3).map((action) => (
                   <DesktopQuickAction
                     key={action.key}
@@ -523,7 +523,7 @@ function DesktopQuickAction({
       >
         <Icon className="h-5 w-5" aria-hidden="true" />
       </span>
-      <span className="min-w-0">
+      <span className="min-w-0 [overflow-wrap:anywhere]">
         <span className="block text-sm font-semibold text-gray-900">
           {label}
         </span>


### PR DESCRIPTION
## Problem

Im Eltern-Portal ragte auf der Kind-Detail-Seite Text (z. B. "Abholzeit") aus den Aktions-Kacheln, am deutlichsten auf dem **iPad Air im Querformat (1180px logisch)**.

## Ursache

Die Desktop-Hero-Ansicht (`lg:block`) reservierte eine **hart fixe** Seitenspalte (`24rem`/`30rem`). Zusammen mit der 256px-Sidebar blieb im `lg`->`xl`-Band zu wenig für die linke Spalte. Die drei Aktions-Kacheln wurden zudem per **Viewport**-Breakpoint (`sm:grid-cols-3`) auf 3-spaltig gezwungen, unabhängig von der echten Containerbreite -> deutsche Komposita liefen über.

Zum Vergleich: das Eltern-**Dashboard** nutzt fürs selbe Muster eine *flexible* Seitenspalte (`minmax(20rem,0.75fr)`) und hatte das Problem nie. Diese Seite war die Abweichung.

## Fix (3 className-Zeilen, eine Datei)

- **Seitenspalte flexibel** statt fix (`minmax`-Floor + Fraction), analog zum Dashboard -> linke Spalte kollabiert nicht mehr.
- **Kacheln reflowen** via `grid-cols-[repeat(auto-fit,minmax(11rem,1fr))]` statt Viewport-Breakpoint: 3-up auf echtem Desktop, 2/1 wenn eng. Nichts wird versteckt.
- **`overflow-wrap:anywhere`** am Text-Wrapper: senkt die min-content-Breite, sodass ein langes Wort beim Resize garantiert bricht statt rauszuragen.

Der Mobile-Pfad (`MobileChildAppView`, < `lg`) ist **nicht** angefasst.

## Test

- `pnpm run check` grün (verify-locales + oxlint 0 Warnings + tsc).
- Parent-Component-Tests: 18/18 grün.
- Visuell per Resize geprüft (iPad-Landscape 1180, Desktop ≥1400, schmales Band).

Kein zusätzlicher automatischer Test: reine Responsive-CSS-Änderung, jsdom hat keine Layout-Engine; ein className-Assertion-Test wäre eine Tautologie und ein Visual-Regression-Setup existiert hier nicht / wäre überdimensioniert.

VORHER:
<img width="2360" height="1640" alt="14-elternapp-kind-detail" src="https://github.com/user-attachments/assets/064e3f10-003f-47fa-a5b0-039d47ceff03" />

NACHHER:
<img width="2360" height="1639" alt="parents localhost_3000_parents_children_1(iPad Air)" src="https://github.com/user-attachments/assets/b898381f-c5f1-4e23-9ad8-f01329aac686" />