### PR TITLE
feat: limit enrollment pickup times to selected care days

### DIFF
--- a/backend/services/enrollment/form_visibility.go
+++ b/backend/services/enrollment/form_visibility.go
@@ -217,13 +217,17 @@ func (s *requestService) validateRequiredCustomFields(
 				continue
 			}
 			if f.Type == enrollmentModels.FormFieldWeekdayMultiMode {
-				if !customAnswerSatisfiesRequiredWeekdayMultiMode(*f, child.CustomData, selectedCareDays(child, openByID)) {
+				// Care-day scoped exactly like weekday_schedule: a no-offerings
+				// phase renders all weekdays, so the required answer must cover
+				// them all. selectedCareDays alone would be empty there and
+				// wrongly exempt the field, letting a scripted client skip it.
+				if !customAnswerSatisfiesRequiredWeekdayMultiMode(*f, child.CustomData, relevantCareDaysForChild(child, openByID)) {
 					return fmt.Errorf("%w: child %d field %q is required", ErrInvalidSubmission, idx, f.Key)
 				}
 				continue
 			}
 			if f.Type == enrollmentModels.FormFieldWeekdaySchedule {
-				if !customAnswerSatisfiesRequiredWeekdaySchedule(*f, child.CustomData, scheduleWeekdaysForChild(child, openByID)) {
+				if !customAnswerSatisfiesRequiredWeekdaySchedule(*f, child.CustomData, relevantCareDaysForChild(child, openByID)) {
 					return fmt.Errorf("%w: child %d field %q is required", ErrInvalidSubmission, idx, f.Key)
 				}
 				continue
@@ -243,7 +247,11 @@ func (s *requestService) validateRequiredCustomFields(
 // Empty AllowedTimes means "no restriction" (free time entry) and such fields
 // are skipped. Hidden fields are skipped to match validateRequiredCustomFields
 // — their answers are dropped before persistence anyway, so rejecting them
-// would block an otherwise valid submit.
+// would block an otherwise valid submit. For the same reason a per-child
+// schedule is only checked on the child's schedulable weekdays
+// (relevantCareDaysForChild): an off-list time on a non-care day is stripped by
+// pruneChildScheduleAnswers before persistence, so the gate must not reject it
+// and block the submit.
 func (s *requestService) validateConstrainedSchedules(
 	schema *enrollmentModels.FormSchema,
 	req SubmitRequest,
@@ -254,7 +262,11 @@ func (s *requestService) validateConstrainedSchedules(
 	}
 	byKey := buildFieldsByKey(schema)
 
-	check := func(f *enrollmentModels.FormField, answers map[string]any, childIdx int) error {
+	// scheduleDays scopes which weekdays are inspected. A nil set means "all
+	// days" (guardian-level fields, which are not care-day scoped); a per-child
+	// field passes its schedulable days so non-care-day entries (pruned before
+	// persistence) can't trip the allowed-times gate.
+	check := func(f *enrollmentModels.FormField, answers map[string]any, childIdx int, scheduleDays map[string]bool) error {
 		raw, ok := answers[f.Key]
 		if !ok || raw == nil {
 			return nil
@@ -265,6 +277,15 @@ func (s *requestService) validateConstrainedSchedules(
 				return fmt.Errorf("%w: child %d field %q: invalid schedule", ErrInvalidSubmission, childIdx, f.Key)
 			}
 			return fmt.Errorf("%w: field %q: invalid schedule", ErrInvalidSubmission, f.Key)
+		}
+		if scheduleDays != nil {
+			scoped := make(enrollmentModels.WeekdaySchedule, len(sched))
+			for day, t := range sched {
+				if scheduleDays[day] {
+					scoped[day] = t
+				}
+			}
+			sched = scoped
 		}
 		if err := sched.ValidateAllowed(f.AllowedTimes); err != nil {
 			if childIdx >= 0 {
@@ -284,7 +305,7 @@ func (s *requestService) validateConstrainedSchedules(
 		if !fieldVisible(f, guardianCtx) {
 			continue
 		}
-		if err := check(f, req.CustomData, -1); err != nil {
+		if err := check(f, req.CustomData, -1, nil); err != nil {
 			return err
 		}
 	}
@@ -298,6 +319,7 @@ func (s *requestService) validateConstrainedSchedules(
 			offeringNames:   selectedOfferingNames(child, openByID),
 			fieldsByKey:     byKey,
 		}
+		scheduleDays := relevantCareDaysForChild(child, openByID)
 		for i := range schema.Fields {
 			f := &schema.Fields[i]
 			if f.Target != enrollmentModels.TargetSchedulePickup || len(f.AllowedTimes) == 0 || !f.AppliesToCh {
@@ -306,7 +328,7 @@ func (s *requestService) validateConstrainedSchedules(
 			if !fieldVisible(f, childCtx) {
 				continue
 			}
-			if err := check(f, child.CustomData, idx); err != nil {
+			if err := check(f, child.CustomData, idx, scheduleDays); err != nil {
 				return err
 			}
 		}
@@ -365,14 +387,16 @@ func customAnswerSatisfiesRequiredWeekdayMultiMode(field enrollmentModels.FormFi
 	return true
 }
 
-// scheduleWeekdaysForChild returns the weekdays a per-child weekday_schedule
-// field offers for this child, mirroring relevantCareDaysForChild in
-// enrollment-form.tsx: with no care offerings configured the field is
-// unconstrained (all weekdays), otherwise it is limited to the child's selected
-// care days (empty when the child picked none -- the form hides the input).
-// The result is read-only; callers must not mutate it (the no-offerings case
-// returns the shared ValidWeekdays map).
-func scheduleWeekdaysForChild(child SubmitChild, openByID map[int64]*enrollmentModels.CareOffering) map[string]bool {
+// relevantCareDaysForChild returns the weekdays every per-child day-scoped
+// field (weekday_schedule AND weekday_multi_mode) offers for this child. It is
+// the single server-side mirror of relevantCareDaysForChild in
+// enrollment-form.tsx, so all care-day-scoped paths share one rule and can't
+// drift: with no care offerings configured the field is unconstrained (all
+// weekdays), otherwise it is limited to the child's selected care days (empty
+// when the child picked none -- the form hides the input). The result is
+// read-only; callers must not mutate it (the no-offerings case returns the
+// shared ValidWeekdays map).
+func relevantCareDaysForChild(child SubmitChild, openByID map[int64]*enrollmentModels.CareOffering) map[string]bool {
 	if len(openByID) == 0 {
 		return enrollmentModels.ValidWeekdays
 	}
@@ -381,7 +405,7 @@ func scheduleWeekdaysForChild(child SubmitChild, openByID map[int64]*enrollmentM
 
 // customAnswerSatisfiesRequiredWeekdaySchedule mirrors the public form's
 // care-day-scoped rendering of a per-child weekday_schedule field. scheduleDays
-// is scheduleWeekdaysForChild: all weekdays when no offerings constrain the
+// is relevantCareDaysForChild: all weekdays when no offerings constrain the
 // form (the field is shown and must be answered), the child's care days when
 // offerings exist, or empty when offerings exist but the child selected none
 // (the form hides the input, so a required schedule is vacuously satisfied).

--- a/backend/services/enrollment/form_visibility.go
+++ b/backend/services/enrollment/form_visibility.go
@@ -222,6 +222,12 @@ func (s *requestService) validateRequiredCustomFields(
 				}
 				continue
 			}
+			if f.Type == enrollmentModels.FormFieldWeekdaySchedule {
+				if !customAnswerSatisfiesRequiredWeekdaySchedule(*f, child.CustomData, selectedCareDays(child, openByID)) {
+					return fmt.Errorf("%w: child %d field %q is required", ErrInvalidSubmission, idx, f.Key)
+				}
+				continue
+			}
 			if !customAnswerSatisfiesRequired(*f, child.CustomData) {
 				return fmt.Errorf("%w: child %d field %q is required", ErrInvalidSubmission, idx, f.Key)
 			}
@@ -357,6 +363,34 @@ func customAnswerSatisfiesRequiredWeekdayMultiMode(field enrollmentModels.FormFi
 		}
 	}
 	return true
+}
+
+// customAnswerSatisfiesRequiredWeekdaySchedule mirrors the public form's
+// care-day-scoped rendering of a per-child weekday_schedule field. The form
+// only shows the weekdays the child is in care on, so when the child has no
+// care days there is no fillable input and a required schedule is vacuously
+// satisfied (the form shows a "pick care days first" hint instead). With care
+// days present, at least one of them must carry a pickup time. Without this
+// exception the server would reject an otherwise-complete optional-care submit
+// that the form let through, with no visible field for the parent to correct.
+func customAnswerSatisfiesRequiredWeekdaySchedule(field enrollmentModels.FormField, answers map[string]any, careDays map[string]bool) bool {
+	if len(careDays) == 0 {
+		return true
+	}
+	value, present := answers[field.Key]
+	if !present {
+		return false
+	}
+	var sched enrollmentModels.WeekdaySchedule
+	if err := decodeStructured(value, &sched); err != nil {
+		return false
+	}
+	for day, t := range sched {
+		if careDays[day] && strings.TrimSpace(t) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // customValueSatisfiesRequired reports whether a required field's answer is

--- a/backend/services/enrollment/form_visibility.go
+++ b/backend/services/enrollment/form_visibility.go
@@ -223,7 +223,7 @@ func (s *requestService) validateRequiredCustomFields(
 				continue
 			}
 			if f.Type == enrollmentModels.FormFieldWeekdaySchedule {
-				if !customAnswerSatisfiesRequiredWeekdaySchedule(*f, child.CustomData, selectedCareDays(child, openByID)) {
+				if !customAnswerSatisfiesRequiredWeekdaySchedule(*f, child.CustomData, scheduleWeekdaysForChild(child, openByID)) {
 					return fmt.Errorf("%w: child %d field %q is required", ErrInvalidSubmission, idx, f.Key)
 				}
 				continue
@@ -365,16 +365,29 @@ func customAnswerSatisfiesRequiredWeekdayMultiMode(field enrollmentModels.FormFi
 	return true
 }
 
+// scheduleWeekdaysForChild returns the weekdays a per-child weekday_schedule
+// field offers for this child, mirroring relevantCareDaysForChild in
+// enrollment-form.tsx: with no care offerings configured the field is
+// unconstrained (all weekdays), otherwise it is limited to the child's selected
+// care days (empty when the child picked none -- the form hides the input).
+// The result is read-only; callers must not mutate it (the no-offerings case
+// returns the shared ValidWeekdays map).
+func scheduleWeekdaysForChild(child SubmitChild, openByID map[int64]*enrollmentModels.CareOffering) map[string]bool {
+	if len(openByID) == 0 {
+		return enrollmentModels.ValidWeekdays
+	}
+	return selectedCareDays(child, openByID)
+}
+
 // customAnswerSatisfiesRequiredWeekdaySchedule mirrors the public form's
-// care-day-scoped rendering of a per-child weekday_schedule field. The form
-// only shows the weekdays the child is in care on, so when the child has no
-// care days there is no fillable input and a required schedule is vacuously
-// satisfied (the form shows a "pick care days first" hint instead). With care
-// days present, at least one of them must carry a pickup time. Without this
-// exception the server would reject an otherwise-complete optional-care submit
-// that the form let through, with no visible field for the parent to correct.
-func customAnswerSatisfiesRequiredWeekdaySchedule(field enrollmentModels.FormField, answers map[string]any, careDays map[string]bool) bool {
-	if len(careDays) == 0 {
+// care-day-scoped rendering of a per-child weekday_schedule field. scheduleDays
+// is scheduleWeekdaysForChild: all weekdays when no offerings constrain the
+// form (the field is shown and must be answered), the child's care days when
+// offerings exist, or empty when offerings exist but the child selected none
+// (the form hides the input, so a required schedule is vacuously satisfied).
+// At least one schedulable day must carry a time otherwise.
+func customAnswerSatisfiesRequiredWeekdaySchedule(field enrollmentModels.FormField, answers map[string]any, scheduleDays map[string]bool) bool {
+	if len(scheduleDays) == 0 {
 		return true
 	}
 	value, present := answers[field.Key]
@@ -386,11 +399,45 @@ func customAnswerSatisfiesRequiredWeekdaySchedule(field enrollmentModels.FormFie
 		return false
 	}
 	for day, t := range sched {
-		if careDays[day] && strings.TrimSpace(t) != "" {
+		if scheduleDays[day] && strings.TrimSpace(t) != "" {
 			return true
 		}
 	}
 	return false
+}
+
+// pruneChildScheduleAnswers strips per-child weekday_schedule entries for
+// weekdays the child cannot schedule (non-care days, or weekend days a scripted
+// client smuggled in), keeping the schedulable days as-is. It is the
+// persistence-time counterpart of the public form's pruneWeekdayAnswers: the
+// decision service turns every persisted weekday into a pickup/arrival schedule
+// row, so an unpruned {"fri":"15:00"} for a Tue/Thu child would create a Friday
+// pickup the parent never had access to. Mutates answers in place.
+func pruneChildScheduleAnswers(schema *enrollmentModels.FormSchema, answers map[string]any, scheduleDays map[string]bool) {
+	if schema == nil || answers == nil {
+		return
+	}
+	for i := range schema.Fields {
+		f := &schema.Fields[i]
+		if !f.AppliesToCh || f.Type != enrollmentModels.FormFieldWeekdaySchedule {
+			continue
+		}
+		raw, ok := answers[f.Key]
+		if !ok || raw == nil {
+			continue
+		}
+		var sched enrollmentModels.WeekdaySchedule
+		if err := decodeStructured(raw, &sched); err != nil {
+			continue
+		}
+		pruned := make(map[string]any, len(sched))
+		for day, t := range sched {
+			if scheduleDays[day] {
+				pruned[day] = t
+			}
+		}
+		answers[f.Key] = pruned
+	}
 }
 
 // customValueSatisfiesRequired reports whether a required field's answer is

--- a/backend/services/enrollment/form_visibility_test.go
+++ b/backend/services/enrollment/form_visibility_test.go
@@ -169,6 +169,34 @@ func TestWeekdayMultiMode_RequiredHandling(t *testing.T) {
 	), "selected care days with modes are accepted")
 }
 
+func TestWeekdaySchedule_RequiredHandling(t *testing.T) {
+	pickup := enrollmentModels.FormField{
+		Key:    "dismissal",
+		Type:   enrollmentModels.FormFieldWeekdaySchedule,
+		Target: enrollmentModels.TargetSchedulePickup,
+	}
+
+	assert.True(t, customAnswerSatisfiesRequiredWeekdaySchedule(pickup, map[string]any{}, map[string]bool{}),
+		"no selected care days means there is nothing to schedule yet (mirrors the hidden form input)")
+	assert.False(t, customAnswerSatisfiesRequiredWeekdaySchedule(pickup, map[string]any{}, map[string]bool{"mon": true}),
+		"missing answer fails when a care day exists")
+	assert.False(t, customAnswerSatisfiesRequiredWeekdaySchedule(
+		pickup,
+		map[string]any{"dismissal": map[string]any{"mon": "", "tue": ""}},
+		map[string]bool{"mon": true, "tue": true},
+	), "an all-blank schedule on care days is not answered")
+	assert.False(t, customAnswerSatisfiesRequiredWeekdaySchedule(
+		pickup,
+		map[string]any{"dismissal": map[string]any{"fri": "15:00"}},
+		map[string]bool{"mon": true},
+	), "a time on a non-care day does not satisfy a care day requirement")
+	assert.True(t, customAnswerSatisfiesRequiredWeekdaySchedule(
+		pickup,
+		map[string]any{"dismissal": map[string]any{"mon": "15:00"}},
+		map[string]bool{"mon": true, "tue": true},
+	), "at least one care day with a time is accepted")
+}
+
 // ---- fieldVisible --------------------------------------------------------
 
 func TestFieldVisible_NoCondition(t *testing.T) {
@@ -405,6 +433,43 @@ func TestValidateRequiredCustomFields_ChildHiddenByCareOfferingExempt(t *testing
 	// Lunch selected → field visible + required + empty → error.
 	req2 := SubmitRequest{Children: []SubmitChild{{OfferingIDs: []int64{42}, CustomData: map[string]any{}}}}
 	require.Error(t, s.validateRequiredCustomFields(schema, req2, openByID))
+}
+
+func TestValidateRequiredCustomFields_ChildRequiredScheduleNoCareDaysExempt(t *testing.T) {
+	// The reviewer case: optional care + a required per-child weekday_schedule.
+	// The public form only renders the child's care weekdays, so a child in no
+	// care has no fillable input. The server must mirror that and not reject the
+	// otherwise-complete submit it let through.
+	s := &requestService{}
+	lunch := &enrollmentModels.CareOffering{
+		Name:           "Mittagessen",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"mon", "tue"},
+	}
+	lunch.ID = 42
+	openByID := map[int64]*enrollmentModels.CareOffering{42: lunch}
+
+	schema := &enrollmentModels.FormSchema{Fields: []enrollmentModels.FormField{
+		{Key: "dismissal", Label: "Abholzeiten", Type: enrollmentModels.FormFieldWeekdaySchedule,
+			Target: enrollmentModels.TargetSchedulePickup, Required: true, AppliesToCh: true},
+	}}
+
+	// No care offering selected → no care days → required schedule is exempt.
+	req := SubmitRequest{Children: []SubmitChild{{CustomData: map[string]any{}}}}
+	assert.NoError(t, s.validateRequiredCustomFields(schema, req, openByID))
+
+	// Care days present (mon/tue) but no schedule answer → required → error.
+	req2 := SubmitRequest{Children: []SubmitChild{{OfferingIDs: []int64{42}, CustomData: map[string]any{}}}}
+	err := s.validateRequiredCustomFields(schema, req2, openByID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dismissal")
+
+	// Care days present and a time on a care day → satisfied.
+	req3 := SubmitRequest{Children: []SubmitChild{{
+		OfferingIDs: []int64{42},
+		CustomData:  map[string]any{"dismissal": map[string]any{"mon": "15:00"}},
+	}}}
+	assert.NoError(t, s.validateRequiredCustomFields(schema, req3, openByID))
 }
 
 func TestValidateRequiredCustomFields_InfoFieldNeverRequired(t *testing.T) {

--- a/backend/services/enrollment/form_visibility_test.go
+++ b/backend/services/enrollment/form_visibility_test.go
@@ -197,6 +197,63 @@ func TestWeekdaySchedule_RequiredHandling(t *testing.T) {
 	), "at least one care day with a time is accepted")
 }
 
+func TestScheduleWeekdaysForChild(t *testing.T) {
+	fixed := &enrollmentModels.CareOffering{
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"tue", "thu"},
+	}
+	fixed.ID = 7
+	openByID := map[int64]*enrollmentModels.CareOffering{7: fixed}
+
+	// No offerings configured -> all weekdays (the form shows them all).
+	assert.Equal(t, enrollmentModels.ValidWeekdays,
+		scheduleWeekdaysForChild(SubmitChild{}, nil),
+		"no offerings means every weekday is schedulable")
+
+	// Offerings exist, child selected the Tue/Thu block -> just those days.
+	assert.Equal(t, map[string]bool{"tue": true, "thu": true},
+		scheduleWeekdaysForChild(SubmitChild{OfferingIDs: []int64{7}}, openByID))
+
+	// Offerings exist, child selected none -> empty (the form hides the input).
+	assert.Empty(t, scheduleWeekdaysForChild(SubmitChild{}, openByID))
+}
+
+func TestPruneChildScheduleAnswers(t *testing.T) {
+	schema := &enrollmentModels.FormSchema{Fields: []enrollmentModels.FormField{
+		{Key: "dismissal", Type: enrollmentModels.FormFieldWeekdaySchedule,
+			Target: enrollmentModels.TargetSchedulePickup, AppliesToCh: true},
+	}}
+
+	// Tue/Thu care: a smuggled Friday entry is stripped, Tue kept.
+	answers := map[string]any{"dismissal": map[string]any{"tue": "15:00", "fri": "15:00"}}
+	pruneChildScheduleAnswers(schema, answers, map[string]bool{"tue": true, "thu": true})
+	assert.Equal(t, map[string]any{"tue": "15:00"}, answers["dismissal"])
+
+	// No offerings (all weekdays schedulable): mon-fri kept, weekend dropped.
+	answers2 := map[string]any{"dismissal": map[string]any{"mon": "15:00", "sat": "09:00"}}
+	pruneChildScheduleAnswers(schema, answers2, enrollmentModels.ValidWeekdays)
+	assert.Equal(t, map[string]any{"mon": "15:00"}, answers2["dismissal"])
+}
+
+func TestValidateRequiredCustomFields_ChildRequiredScheduleNoOfferingsEnforced(t *testing.T) {
+	// P2: a phase with NO care offerings renders all weekdays for a required
+	// schedule, so the server must still enforce it (no empty-care-days
+	// exemption). openByID is empty in this configuration.
+	s := &requestService{}
+	schema := &enrollmentModels.FormSchema{Fields: []enrollmentModels.FormField{
+		{Key: "dismissal", Label: "Abholzeiten", Type: enrollmentModels.FormFieldWeekdaySchedule,
+			Target: enrollmentModels.TargetSchedulePickup, Required: true, AppliesToCh: true},
+	}}
+
+	req := SubmitRequest{Children: []SubmitChild{{CustomData: map[string]any{}}}}
+	err := s.validateRequiredCustomFields(schema, req, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dismissal")
+
+	req2 := SubmitRequest{Children: []SubmitChild{{CustomData: map[string]any{"dismissal": map[string]any{"mon": "15:00"}}}}}
+	assert.NoError(t, s.validateRequiredCustomFields(schema, req2, nil))
+}
+
 // ---- fieldVisible --------------------------------------------------------
 
 func TestFieldVisible_NoCondition(t *testing.T) {

--- a/backend/services/enrollment/form_visibility_test.go
+++ b/backend/services/enrollment/form_visibility_test.go
@@ -197,7 +197,7 @@ func TestWeekdaySchedule_RequiredHandling(t *testing.T) {
 	), "at least one care day with a time is accepted")
 }
 
-func TestScheduleWeekdaysForChild(t *testing.T) {
+func TestRelevantCareDaysForChild(t *testing.T) {
 	fixed := &enrollmentModels.CareOffering{
 		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
 		AvailableDays:  []string{"tue", "thu"},
@@ -207,15 +207,15 @@ func TestScheduleWeekdaysForChild(t *testing.T) {
 
 	// No offerings configured -> all weekdays (the form shows them all).
 	assert.Equal(t, enrollmentModels.ValidWeekdays,
-		scheduleWeekdaysForChild(SubmitChild{}, nil),
+		relevantCareDaysForChild(SubmitChild{}, nil),
 		"no offerings means every weekday is schedulable")
 
 	// Offerings exist, child selected the Tue/Thu block -> just those days.
 	assert.Equal(t, map[string]bool{"tue": true, "thu": true},
-		scheduleWeekdaysForChild(SubmitChild{OfferingIDs: []int64{7}}, openByID))
+		relevantCareDaysForChild(SubmitChild{OfferingIDs: []int64{7}}, openByID))
 
 	// Offerings exist, child selected none -> empty (the form hides the input).
-	assert.Empty(t, scheduleWeekdaysForChild(SubmitChild{}, openByID))
+	assert.Empty(t, relevantCareDaysForChild(SubmitChild{}, openByID))
 }
 
 func TestPruneChildScheduleAnswers(t *testing.T) {
@@ -252,6 +252,38 @@ func TestValidateRequiredCustomFields_ChildRequiredScheduleNoOfferingsEnforced(t
 
 	req2 := SubmitRequest{Children: []SubmitChild{{CustomData: map[string]any{"dismissal": map[string]any{"mon": "15:00"}}}}}
 	assert.NoError(t, s.validateRequiredCustomFields(schema, req2, nil))
+}
+
+func TestValidateRequiredCustomFields_ChildRequiredMultiModeNoOfferingsEnforced(t *testing.T) {
+	// Reviewer blocker: a phase with NO care offerings renders all weekdays for
+	// a required weekday_multi_mode field, so the server must still enforce it.
+	// selectedCareDays would be empty here and wrongly exempt the field, letting
+	// a scripted client skip a field the public form requires. openByID is empty.
+	s := &requestService{}
+	schema := &enrollmentModels.FormSchema{Fields: []enrollmentModels.FormField{
+		{Key: "allowed_departure", Label: "Abholarten", Type: enrollmentModels.FormFieldWeekdayMultiMode,
+			Target: enrollmentModels.TargetStudentAllowedDepartureModes, Required: true, AppliesToCh: true},
+	}}
+
+	// Missing answer -> must error (every weekday is relevant and required).
+	req := SubmitRequest{Children: []SubmitChild{{CustomData: map[string]any{}}}}
+	err := s.validateRequiredCustomFields(schema, req, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowed_departure")
+
+	// A partial answer (only some weekdays) is still rejected: with no
+	// offerings every weekday must carry at least one mode.
+	partial := map[string]any{"allowed_departure": map[string]any{"mon": []any{"bus"}}}
+	req2 := SubmitRequest{Children: []SubmitChild{{CustomData: partial}}}
+	require.Error(t, s.validateRequiredCustomFields(schema, req2, nil))
+
+	// A mode on every weekday -> satisfied.
+	full := map[string]any{"allowed_departure": map[string]any{
+		"mon": []any{"bus"}, "tue": []any{"bus"}, "wed": []any{"bus"},
+		"thu": []any{"bus"}, "fri": []any{"bus"},
+	}}
+	req3 := SubmitRequest{Children: []SubmitChild{{CustomData: full}}}
+	assert.NoError(t, s.validateRequiredCustomFields(schema, req3, nil))
 }
 
 // ---- fieldVisible --------------------------------------------------------
@@ -737,4 +769,37 @@ func TestValidateConstrainedSchedules_HiddenFieldExempt(t *testing.T) {
 		{CustomData: map[string]any{"needs_pickup": false, "pickup_times": map[string]any{"mon": "15:00"}}},
 	}}
 	assert.NoError(t, s.validateConstrainedSchedules(schema, req, nil))
+}
+
+func TestValidateConstrainedSchedules_OffListTimeOnNonCareDayIgnored(t *testing.T) {
+	// Reviewer blocker: the allowed-times gate must only inspect the child's
+	// schedulable (care) days. An off-list pickup time on a weekday the child
+	// has no care on is stripped before persistence (pruneChildScheduleAnswers),
+	// so rejecting it here would block an otherwise valid submit.
+	s := &requestService{}
+	schema := &enrollmentModels.FormSchema{Fields: []enrollmentModels.FormField{pickupSchedField()}}
+
+	fixed := &enrollmentModels.CareOffering{
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"tue", "thu"},
+	}
+	fixed.ID = 7
+	openByID := map[int64]*enrollmentModels.CareOffering{7: fixed}
+
+	// tue (care day) carries an allowed time; mon (non-care day) carries an
+	// off-list one -> mon is out of scope, so the submit is accepted.
+	ok := SubmitRequest{Children: []SubmitChild{{
+		OfferingIDs: []int64{7},
+		CustomData:  map[string]any{"pickup_times": map[string]any{"tue": "14:45", "mon": "15:00"}},
+	}}}
+	assert.NoError(t, s.validateConstrainedSchedules(schema, ok, openByID))
+
+	// An off-list time on a CARE day is still rejected.
+	bad := SubmitRequest{Children: []SubmitChild{{
+		OfferingIDs: []int64{7},
+		CustomData:  map[string]any{"pickup_times": map[string]any{"tue": "15:00"}},
+	}}}
+	err := s.validateConstrainedSchedules(schema, bad, openByID)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrPickupTimeNotAllowed))
 }

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -493,6 +493,13 @@ func (s *requestService) Submit(ctx context.Context, req SubmitRequest) (*Submit
 			req.Children[i].CustomData = sanitizeVisibleAnswers(
 				schema, true, req.Children[i].CustomData, childCtx,
 			)
+			// Server-side care-day enforcement: strip schedule entries for
+			// weekdays the child can't schedule so a stale/scripted submit
+			// can't persist (and later dispatch) a pickup on a non-care day.
+			pruneChildScheduleAnswers(
+				schema, req.Children[i].CustomData,
+				scheduleWeekdaysForChild(req.Children[i], openByID),
+			)
 		}
 		req.CustomData = sanitizeVisibleAnswers(
 			schema, false, rawGuardian,
@@ -1209,6 +1216,10 @@ func (s *requestService) ReplaceEditable(ctx context.Context, token string, inco
 					fieldsByKey:     byKey,
 				}
 				editReq.Children[i].CustomData = sanitizeVisibleAnswers(schema, true, editReq.Children[i].CustomData, childCtx)
+				pruneChildScheduleAnswers(
+					schema, editReq.Children[i].CustomData,
+					scheduleWeekdaysForChild(editReq.Children[i], openByID),
+				)
 			}
 			editReq.CustomData = sanitizeVisibleAnswers(schema, false, rawGuardian, fieldVisibilityContext{
 				guardianAnswers: rawGuardian,

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -498,7 +498,7 @@ func (s *requestService) Submit(ctx context.Context, req SubmitRequest) (*Submit
 			// can't persist (and later dispatch) a pickup on a non-care day.
 			pruneChildScheduleAnswers(
 				schema, req.Children[i].CustomData,
-				scheduleWeekdaysForChild(req.Children[i], openByID),
+				relevantCareDaysForChild(req.Children[i], openByID),
 			)
 		}
 		req.CustomData = sanitizeVisibleAnswers(
@@ -1218,7 +1218,7 @@ func (s *requestService) ReplaceEditable(ctx context.Context, token string, inco
 				editReq.Children[i].CustomData = sanitizeVisibleAnswers(schema, true, editReq.Children[i].CustomData, childCtx)
 				pruneChildScheduleAnswers(
 					schema, editReq.Children[i].CustomData,
-					scheduleWeekdaysForChild(editReq.Children[i], openByID),
+					relevantCareDaysForChild(editReq.Children[i], openByID),
 				)
 			}
 			editReq.CustomData = sanitizeVisibleAnswers(schema, false, rawGuardian, fieldVisibilityContext{

--- a/backend/services/enrollment/request_service_test.go
+++ b/backend/services/enrollment/request_service_test.go
@@ -2113,6 +2113,50 @@ func TestRequestService_Submit_AcceptsAllowedPickupTime(t *testing.T) {
 		"the constrained schedule answer must persist on the child")
 }
 
+// TestRequestService_Submit_PrunesNonCareDayPickupTimes is the server-side
+// guard for the care-day limit: a stale/scripted client that POSTs a pickup
+// time for a weekday the child has no care on must NOT get that weekday
+// persisted (the decision service would otherwise dispatch it into a pickup
+// schedule). Mirrors the public form's client-side pruneWeekdayAnswers.
+func TestRequestService_Submit_PrunesNonCareDayPickupTimes(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	// Free-entry schedule (no fixed times) so only the care-day prune, not the
+	// allowed-times gate, is exercised.
+	publishPickupSchema(t, env, nil)
+
+	// A fixed Tue/Thu offering -> the child's only care days are Tue and Thu.
+	repoFactory := repositories.NewFactory(env.db)
+	offering := &enrollmentModels.CareOffering{
+		PhaseID:        env.phaseID,
+		Name:           "Tue/Thu block",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"tue", "thu"},
+		IsActive:       true,
+	}
+	offering.SetTenantID(1)
+	require.NoError(t, repoFactory.CareOffering.Create(ctx, offering))
+
+	req := validSubmission(env.phaseID)
+	req.Children[0].OfferingIDs = []int64{offering.ID}
+	// The Friday pickup was never offered for a Tue/Thu child -> must be pruned.
+	req.Children[0].CustomData = map[string]any{
+		"schedule_pickup": map[string]any{"tue": "15:00", "fri": "15:00"},
+	}
+
+	result, err := env.svc.Submit(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, result.Children, 1)
+
+	sched, ok := result.Children[0].CustomData["schedule_pickup"].(map[string]any)
+	require.True(t, ok, "schedule answer must persist as a map")
+	assert.Equal(t, "15:00", sched["tue"], "the care-day pickup is kept")
+	_, hasFri := sched["fri"]
+	assert.False(t, hasFri, "the non-care-day Friday pickup must be pruned server-side")
+}
+
 // TestRequestService_Submit_RejectsOffListPickupTime is THE gate: a scripted
 // or stale client that POSTs a pickup time outside the field's fixed list is
 // rejected at submit, carrying the specific sentinel (so the handler attaches

--- a/backend/services/enrollment/request_service_test.go
+++ b/backend/services/enrollment/request_service_test.go
@@ -2179,6 +2179,50 @@ func TestRequestService_Submit_RejectsOffListPickupTime(t *testing.T) {
 		"and still be part of the broad invalid-submission category")
 }
 
+// TestRequestService_Submit_OffListPickupOnNonCareDayIsPrunedNotRejected is the
+// regression for the care-day / allowed-times ordering bug: with a fixed-times
+// schedule field, a stale or scripted off-list pickup time on a weekday the
+// child has no care on must be pruned (the public form drops it), not rejected
+// by the allowed-times gate -- rejecting it would block an otherwise valid
+// submit. Only the schedulable (care) days are gated; the rest are stripped.
+func TestRequestService_Submit_OffListPickupOnNonCareDayIsPrunedNotRejected(t *testing.T) {
+	env, cleanup := setupRequestTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+	publishPickupSchema(t, env, []string{"14:45", "16:00"})
+
+	// A fixed Tue/Thu offering -> the child's only care days are Tue and Thu.
+	repoFactory := repositories.NewFactory(env.db)
+	offering := &enrollmentModels.CareOffering{
+		PhaseID:        env.phaseID,
+		Name:           "Tue/Thu block",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"tue", "thu"},
+		IsActive:       true,
+	}
+	offering.SetTenantID(1)
+	require.NoError(t, repoFactory.CareOffering.Create(ctx, offering))
+
+	req := validSubmission(env.phaseID)
+	req.Children[0].OfferingIDs = []int64{offering.ID}
+	// tue: an allowed time on a care day. mon: an OFF-LIST time on a non-care
+	// day -- it must be pruned, not trip the allowed-times gate.
+	req.Children[0].CustomData = map[string]any{
+		"schedule_pickup": map[string]any{"tue": "14:45", "mon": "15:00"},
+	}
+
+	result, err := env.svc.Submit(ctx, req)
+	require.NoError(t, err,
+		"an off-list time on a non-care day must be pruned, not rejected")
+	require.Len(t, result.Children, 1)
+
+	sched, ok := result.Children[0].CustomData["schedule_pickup"].(map[string]any)
+	require.True(t, ok, "schedule answer must persist as a map")
+	assert.Equal(t, "14:45", sched["tue"], "the care-day pickup is kept")
+	_, hasMon := sched["mon"]
+	assert.False(t, hasMon, "the non-care-day off-list pickup must be pruned server-side")
+}
+
 // TestRequestService_ReplaceEditable_RejectsOffListPickupTime is the
 // regression guard for the edit path: the same fixed-times enforcement runs
 // when a parent edits an already-submitted request, not only on first submit.

--- a/frontend/src/components/enrollment/enrollment-form.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.test.tsx
@@ -758,7 +758,10 @@ describe("EnrollmentForm", () => {
 
     fireEvent.click(screen.getByRole("checkbox", { name: /Fixe Betreuung/ }));
 
-    fireEvent.change(screen.getByLabelText("Montag"), {
+    // The pickup field only renders the child's actual care days. "Fixe
+    // Betreuung" covers Tue/Thu, so Monday is not offered here -- enter the
+    // time on a care day instead.
+    fireEvent.change(screen.getByLabelText("Dienstag"), {
       target: { value: "15:00" },
     });
 
@@ -821,9 +824,99 @@ describe("EnrollmentForm", () => {
     expect(payload.children[0]?.custom_data).toMatchObject({
       allergies: "Nuesse",
       lunch: true,
-      dismissal: { mon: "15:00" },
+      dismissal: { tue: "15:00" },
     });
     expect(onSubmitted).toHaveBeenCalledWith("/status/abc");
+  });
+
+  it("limits pickup weekdays to the child's selected care days", async () => {
+    renderForm();
+    await waitForLoaded();
+
+    // Before any care offering is chosen there are no care days, so the
+    // pickup field prompts the parent to pick care days first instead of
+    // showing all weekdays.
+    expect(
+      screen.getByText("Wählen Sie zuerst die Betreuungstage aus."),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Montag")).not.toBeInTheDocument();
+
+    // "Fixe Betreuung" covers Tue/Thu only -> exactly those two weekdays
+    // appear under the pickup field; Mon/Wed/Fri stay hidden.
+    fireEvent.click(screen.getByRole("checkbox", { name: /Fixe Betreuung/ }));
+
+    expect(screen.getByLabelText("Dienstag")).toBeInTheDocument();
+    expect(screen.getByLabelText("Donnerstag")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Montag")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Mittwoch")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Freitag")).not.toBeInTheDocument();
+  });
+
+  it("drops pickup times for days the child is no longer in care", async () => {
+    // Two fixed offerings change the care-day set deterministically (no day
+    // picker needed).
+    mockFetchPublicCareOfferings.mockResolvedValueOnce({
+      offerings: [
+        {
+          id: "31",
+          phase_id: "5",
+          name: "Block Mo Di",
+          description: null,
+          days_of_week_mode: "fixed",
+          available_days: ["mon", "tue"],
+          includes_holiday_care: false,
+          includes_lunch: false,
+          is_active: true,
+          is_required: false,
+          capacity: null,
+        },
+        {
+          id: "32",
+          phase_id: "5",
+          name: "Block Do",
+          description: null,
+          days_of_week_mode: "fixed",
+          available_days: ["thu"],
+          includes_holiday_care: false,
+          includes_lunch: false,
+          is_active: true,
+          is_required: false,
+          capacity: null,
+        },
+      ],
+      careOfferingSelectionMode: "at_least_one",
+      careRequired: true,
+    });
+    const onSubmitted = vi.fn();
+    renderForm({ onSubmitted });
+    await waitForLoaded();
+
+    await fillRequiredFields();
+
+    // Mo/Di care -> enter pickup times for both days.
+    fireEvent.click(screen.getByRole("checkbox", { name: /Block Mo Di/ }));
+    fireEvent.change(screen.getByLabelText("Montag"), {
+      target: { value: "15:00" },
+    });
+    fireEvent.change(screen.getByLabelText("Dienstag"), {
+      target: { value: "15:30" },
+    });
+
+    // Add Do, then drop Mo/Di so only Thu remains a care day. The Mon/Tue
+    // times are now stale and must not survive into the payload.
+    fireEvent.click(screen.getByRole("checkbox", { name: /Block Do/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /Block Mo Di/ }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Anmeldung absenden" }));
+
+    await waitFor(() => {
+      expect(mockSubmitEnrollment).toHaveBeenCalledTimes(1);
+    });
+    const [, payload] = mockSubmitEnrollment.mock.calls[0] as [
+      string,
+      SubmitEnrollmentPayload,
+    ];
+    expect(payload.children[0]?.custom_data?.dismissal).toEqual({});
   });
 
   it("prefills from a parent profile and adopts an existing child", async () => {

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -845,7 +845,7 @@ export function EnrollmentForm({
         target_grade_level: Number(c.target_grade_level),
         // Strip answers to fields the parent couldn't see (hidden by a
         // show-if condition) so a stale value never reaches the backend.
-        custom_data: pruneWeekdayMultiModeAnswers(
+        custom_data: pruneWeekdayAnswers(
           visibleAnswerData(
             schema?.fields ?? [],
             true,
@@ -2371,8 +2371,10 @@ function customValueMissing(
     return contactListValueMissing(value);
   }
   if (field.type === "weekday_schedule") {
+    const days = relevantDays ?? WEEKDAYS;
+    if (days.length === 0) return false;
     const schedule = asScheduleObject(value);
-    return !Object.values(schedule).some((time) => time.trim() !== "");
+    return !days.some((day) => (schedule[day] ?? "").trim() !== "");
   }
   if (field.type === "weekday_boolean") {
     // Pickup: an explicit (touched) selection — even an empty one — is the
@@ -2589,6 +2591,7 @@ function CustomFieldInput({
         onChange={onChange}
         error={error}
         tr={tr}
+        relevantDays={relevantDays}
       />
     );
   }
@@ -2899,23 +2902,38 @@ function relevantCareDaysForChild(
   offerings: readonly PublicCareOffering[],
   previewMode: boolean,
 ): string[] {
-  if (previewMode && offerings.length === 0) {
+  // No offerings to derive care days from (care-offering feature unused, or
+  // template preview): every weekday is relevant so day-scoped fields stay
+  // usable. When offerings DO exist but the child has selected none, the
+  // result is empty on purpose -- the parent must pick care days first.
+  if (previewMode || offerings.length === 0) {
     return [...WEEKDAYS];
   }
   return selectedCareDaysForChild(child, offerings);
 }
 
-function pruneWeekdayMultiModeAnswers(
+function pruneWeekdayAnswers(
   data: Record<string, unknown>,
   fields: readonly PublicFormSchema["fields"][number][],
   relevantDays: readonly string[],
 ): Record<string, unknown> {
   const next = { ...data };
   for (const field of fields) {
-    if (field.type !== "weekday_multi_mode" || !(field.key in next)) {
-      continue;
+    if (!(field.key in next)) continue;
+    if (field.type === "weekday_multi_mode") {
+      next[field.key] = asWeekdayMultiModeObject(next[field.key], relevantDays);
+    } else if (field.type === "weekday_schedule") {
+      // Drop pickup times for days the child is no longer in care (e.g. an
+      // offering was deselected after a time was entered) so stale entries
+      // never reach the backend.
+      const schedule = asScheduleObject(next[field.key]);
+      const pruned: Record<string, string> = {};
+      for (const day of relevantDays) {
+        const time = schedule[day];
+        if (time !== undefined) pruned[day] = time;
+      }
+      next[field.key] = pruned;
     }
-    next[field.key] = asWeekdayMultiModeObject(next[field.key], relevantDays);
   }
   return next;
 }
@@ -2926,9 +2944,14 @@ function WeekdayScheduleInput({
   onChange,
   error,
   tr,
+  relevantDays,
 }: CustomFieldInputProps) {
   const sched = asScheduleObject(value);
   const weekdayLabels = asStringMap(tr.raw("weekdays"));
+  // Only offer the weekdays the child is actually in care on (derived from the
+  // selected care offerings). When no offerings constrain the form, relevantDays
+  // is undefined and all weekdays are shown (historical behaviour).
+  const daysToRender = relevantDays ?? WEEKDAYS;
   // When the field configures fixed pickup times, parents pick from a
   // dropdown limited to those values per weekday instead of a free time
   // input. Empty list = free entry (the historical behaviour).
@@ -2947,62 +2970,73 @@ function WeekdayScheduleInput({
           {field.help_text}
         </p>
       )}
-      <p className="text-xs text-gray-500">{tr("structured.emptySchedule")}</p>
-      <div className="mt-2 grid gap-2 sm:grid-cols-5">
-        {WEEKDAYS.map((weekday) => {
-          const current = sched[weekday] ?? "";
-          // A previously saved value that is no longer in the configured
-          // list (admin changed the times after the draft was saved) must
-          // still be shown, otherwise the dropdown silently blanks it and
-          // the parent never sees that their time was dropped. It is
-          // flagged "nicht mehr verfügbar" so the parent notices it has to
-          // be re-picked before submit — the backend rejects it anyway.
-          const isStale = Boolean(current) && !allowedTimes.includes(current);
-          return (
-            <label key={weekday} className="block text-xs">
-              <span className="block text-gray-600">
-                {weekdayLabels[weekday] ?? weekday}
-              </span>
-              {allowedTimes.length > 0 ? (
-                <CustomSelect
-                  value={current}
-                  onChange={(selected) =>
-                    onChange({ ...sched, [weekday]: selected })
-                  }
-                  ariaLabel={`${weekdayLabels[weekday] ?? weekday} – ${field.label}`}
-                  placeholder={tr("structured.selectTime")}
-                  invalid={Boolean(error) || isStale}
-                  className="mt-1 border-gray-200 bg-white"
-                  options={[
-                    { value: "", label: tr("structured.selectTime") },
-                    ...allowedTimes.map((time) => ({
-                      value: time,
-                      label: time,
-                    })),
-                    ...(isStale
-                      ? [
-                          {
-                            value: current,
-                            label: `${current} (${tr("structured.timeUnavailable")})`,
-                          },
-                        ]
-                      : []),
-                  ]}
-                />
-              ) : (
-                <input
-                  type="time"
-                  value={current}
-                  onChange={(e) =>
-                    onChange({ ...sched, [weekday]: e.target.value })
-                  }
-                  className="mt-1 h-9 w-full rounded-md border border-gray-200 bg-white px-2 text-sm"
-                />
-              )}
-            </label>
-          );
-        })}
-      </div>
+      {daysToRender.length === 0 ? (
+        <p className="mt-1 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+          {tr("structured.weekdayMultiModeNoDays")}
+        </p>
+      ) : (
+        <>
+          <p className="text-xs text-gray-500">
+            {tr("structured.emptySchedule")}
+          </p>
+          <div className="mt-2 grid gap-2 sm:grid-cols-5">
+            {daysToRender.map((weekday) => {
+              const current = sched[weekday] ?? "";
+              // A previously saved value that is no longer in the configured
+              // list (admin changed the times after the draft was saved) must
+              // still be shown, otherwise the dropdown silently blanks it and
+              // the parent never sees that their time was dropped. It is
+              // flagged "nicht mehr verfügbar" so the parent notices it has to
+              // be re-picked before submit — the backend rejects it anyway.
+              const isStale =
+                Boolean(current) && !allowedTimes.includes(current);
+              return (
+                <label key={weekday} className="block text-xs">
+                  <span className="block text-gray-600">
+                    {weekdayLabels[weekday] ?? weekday}
+                  </span>
+                  {allowedTimes.length > 0 ? (
+                    <CustomSelect
+                      value={current}
+                      onChange={(selected) =>
+                        onChange({ ...sched, [weekday]: selected })
+                      }
+                      ariaLabel={`${weekdayLabels[weekday] ?? weekday} – ${field.label}`}
+                      placeholder={tr("structured.selectTime")}
+                      invalid={Boolean(error) || isStale}
+                      className="mt-1 border-gray-200 bg-white"
+                      options={[
+                        { value: "", label: tr("structured.selectTime") },
+                        ...allowedTimes.map((time) => ({
+                          value: time,
+                          label: time,
+                        })),
+                        ...(isStale
+                          ? [
+                              {
+                                value: current,
+                                label: `${current} (${tr("structured.timeUnavailable")})`,
+                              },
+                            ]
+                          : []),
+                      ]}
+                    />
+                  ) : (
+                    <input
+                      type="time"
+                      value={current}
+                      onChange={(e) =>
+                        onChange({ ...sched, [weekday]: e.target.value })
+                      }
+                      className="mt-1 h-9 w-full rounded-md border border-gray-200 bg-white px-2 text-sm"
+                    />
+                  )}
+                </label>
+              );
+            })}
+          </div>
+        </>
+      )}
       {error && <p className="mt-2 text-xs text-[#FF3130]">{error}</p>}
     </fieldset>
   );


### PR DESCRIPTION
## Was & Warum

Schul-Anfrage: Bei den **Abholzeiten** im Anmeldeformular sollen nur noch die Wochentage erscheinen, die oben beim Betreuungsangebot gewählt wurden (statt immer Mo–Fr). Zusätzlich behebt der PR eine dadurch sichtbar gewordene Daten-Inkonsistenz: bisher konnte eine Abholzeit für einen betreuungsfreien Tag im Backend landen.

## Änderungen

**Frontend** (`enrollment-form.tsx`)
- Das Abholzeiten-Feld (`weekday_schedule`) rendert nur noch die aus den gewählten Angeboten abgeleiteten Betreuungstage (`relevantCareDaysForChild`), analog zum bestehenden `weekday_multi_mode`.
- Leere Auswahl → Hinweis „Wählen Sie zuerst die Betreuungstage aus." statt leerer Tagesreihe.
- Submit-Pruning + Pflichtvalidierung auf die gewählten Tage beschränkt.
- **Keine Angebote in der Phase / Guardian-Feld / Vorschau** → weiterhin alle Mo–Fr (unverändert).

**Backend** (`form_visibility.go`, `request_service.go`) — Defense-in-depth, Client-Logik ist nie die einzige Verteidigung:
- Pflicht-Schedule-Check ist care-day-bewusst (`scheduleWeekdaysForChild`): keine Angebote → alle Wochentage (erzwungen); Angebote vorhanden, keins gewählt → Feld versteckt → exempt.
- Server-seitiges Pruning (`pruneChildScheduleAnswers`) im Submit- und Edit-Pfad strippt Schedule-Einträge für nicht-planbare Wochentage, bevor sie persistiert (und beim Approval in Pickup-Schedules dispatcht) werden.

## Punkt „14:45–16:00" (separate Anfrage)
Kein Code nötig — über **Formular-Editor → Abholzeiten → „Feste Auswahlzeiten"** konfigurierbar (Dropdown begrenzt auf die hinterlegten Uhrzeiten, serverseitig validiert).

## Tests
- Frontend: nur gewählte Tage sichtbar, Pruning verwaister Zeiten, bestehender Test auf Care-Day umgestellt.
- Backend: `scheduleWeekdaysForChild`, `pruneChildScheduleAnswers`, no-offerings Required-Enforcement, End-to-End-Submit (Nicht-Care-Tag wird aus persistierten Daten gepruned).
- `pnpm run check` grün, `services/enrollment` + `api/enrollment` grün, golangci-lint 0 Issues.

## Review-Historie
Zwei Review-Runden behoben: (1) Backend-Required-Check an Frontend gespiegelt, (2) Care-Day-Grenze + no-offerings-Enforcement server-seitig durchgesetzt.