### PR TITLE
fix(parents): testimonial button aria-label FORMATTING_ERROR

### DIFF
--- a/frontend/src/app/parents/login/page.test.tsx
+++ b/frontend/src/app/parents/login/page.test.tsx
@@ -46,12 +46,19 @@ vi.mock("next-intl", async () => {
 
   const makeT = (namespace?: string) => {
     const prefix = namespace ? `${namespace}.` : "";
-    return (key: string, values?: Record<string, unknown>) => {
+    const t = (key: string, values?: Record<string, unknown>) => {
       const value = resolve(`${prefix}${key}`);
       return typeof value === "string"
         ? interpolate(value, values)
         : `${prefix}${key}`;
     };
+    // Mirror next-intl's `t.raw`: returns the message verbatim with no ICU
+    // formatting (the auth shell fills `{number}` itself via String.replace).
+    t.raw = (key: string) => {
+      const value = resolve(`${prefix}${key}`);
+      return typeof value === "string" ? value : `${prefix}${key}`;
+    };
+    return t;
   };
 
   const cache = new Map<string, ReturnType<typeof makeT>>();

--- a/frontend/src/components/auth/parent-auth-shell-copy.ts
+++ b/frontend/src/components/auth/parent-auth-shell-copy.ts
@@ -16,7 +16,14 @@ type ParentAuthShellMessageKey =
   | "testimonialButtonLabel"
   | `testimonials.${ParentAuthTestimonialKey}.${ParentAuthTestimonialField}`;
 
-type ParentAuthShellTranslate = (key: ParentAuthShellMessageKey) => string;
+// The shell stores `testimonialButtonLabel` as a raw "...{number}..." template
+// and fills the index itself via String.replace (see auth-shell.tsx). We must
+// therefore read that message *unformatted* — calling the translator normally
+// makes next-intl try to resolve the {number} ICU argument and throw
+// FORMATTING_ERROR. `raw` returns the literal template the shell expects.
+type ParentAuthShellTranslate = ((key: ParentAuthShellMessageKey) => string) & {
+  raw: (key: ParentAuthShellMessageKey) => string;
+};
 
 export function buildParentAuthShellCopy(
   t: ParentAuthShellTranslate,
@@ -26,7 +33,7 @@ export function buildParentAuthShellCopy(
       audience: t("badges.audience"),
       hosting: t("badges.hosting"),
     },
-    testimonialButtonLabel: t("testimonialButtonLabel"),
+    testimonialButtonLabel: t.raw("testimonialButtonLabel"),
     testimonials: parentAuthTestimonialKeys.map((key) => ({
       quote: t(`testimonials.${key}.quote`),
       author: t(`testimonials.${key}.author`),


### PR DESCRIPTION
## Problem

Opening the parents login page logs a next-intl `FORMATTING_ERROR` (visible as 2 issues in the Next.js dev overlay) and leaves the testimonial carousel dot buttons with a **broken accessible name**.

```
FORMATTING_ERROR: The intl string context variable "number" was not provided
to the string "Erfahrungsbericht {number} anzeigen"
  src/components/auth/parent-auth-shell-copy.ts:29
```

### Root cause

The shared `auth-shell` stores `testimonialButtonLabel` as a **raw template** `"Erfahrungsbericht {number} anzeigen"` and fills the index itself via `String.replace("{number}", i+1)` (`auth-shell.tsx:284`). Both hardcoded defaults supply that template verbatim — it is the shell's contract.

`buildParentAuthShellCopy` instead resolved the message through the normal translator (`t("testimonialButtonLabel")`). next-intl saw the `{number}` ICU argument, none was provided, threw `FORMATTING_ERROR`, and returned the message key as a fallback. The dot buttons then rendered `aria-label="parentAuthShell.testimonialButtonLabel"` (raw key read to screen readers) plus a console error on every login render.

## Fix

Read the message via `t.raw(...)` so the literal `{number}` template reaches the shell's `replace`, and widen the translate type to expose `raw`. One-line behavioural change.

## Verification

- `pnpm run check` (verify-locales + oxlint + tsc) — green.
- Live on the parents login page: no console error; dot buttons now expose `Erfahrungsbericht 1 anzeigen` … `4 anzeigen`.

## Scope

Pre-existing bug on `development`, unrelated to the parents-modal refactor (tracked separately). Also covers the `accept-guardian-invite` page, which uses the same builder.