### PR TITLE
fix(parents): reuse shared Modal (background blur + scroll lock)

### DIFF
--- a/frontend/src/components/parent/child-care.test.tsx
+++ b/frontend/src/components/parent/child-care.test.tsx
@@ -18,7 +18,7 @@ function renderModal(
   const onSubmit = vi.fn().mockResolvedValue(undefined);
   const onRemove = vi.fn().mockResolvedValue(undefined);
   const onClose = vi.fn();
-  const { container } = render(
+  render(
     <PickupTimeModal
       careExceptions={[]}
       careExceptionsLoaded
@@ -29,10 +29,12 @@ function renderModal(
       {...overrides}
     />,
   );
+  // The shared Modal renders via createPortal to document.body, so the fields
+  // live outside the render container — query the document instead.
   const dateInput =
-    container.querySelector<HTMLInputElement>('input[type="date"]')!;
+    document.querySelector<HTMLInputElement>('input[type="date"]')!;
   const timeInputs = Array.from(
-    container.querySelectorAll<HTMLInputElement>('input[type="time"]'),
+    document.querySelectorAll<HTMLInputElement>('input[type="time"]'),
   );
   // Field order in the modal is arrival, then pickup.
   const [arrivalInput, pickupInput] = timeInputs;

--- a/frontend/src/components/parent/child-care.tsx
+++ b/frontend/src/components/parent/child-care.tsx
@@ -2,15 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
-import {
-  CalendarClock,
-  HeartPulse,
-  Loader2,
-  MessageCircle,
-  Send,
-  Trash2,
-  X,
-} from "lucide-react";
+import { Loader2, Send, Trash2 } from "lucide-react";
+import { Modal } from "~/components/ui/modal";
 import {
   type CareException,
   type ChildFeatures,
@@ -229,54 +222,6 @@ export function useChildCare(studentId: string): ChildCare {
   };
 }
 
-// --- modal shell ---
-
-function ModalShell({
-  title,
-  accent,
-  icon,
-  onClose,
-  children,
-}: Readonly<{
-  title: string;
-  accent: string;
-  icon: React.ReactNode;
-  onClose: () => void;
-  children: React.ReactNode;
-}>) {
-  const t = useTranslations("parentChildCare");
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-label={title}
-    >
-      <div className="w-full max-w-lg overflow-hidden rounded-t-3xl bg-white shadow-xl sm:rounded-2xl">
-        <div className="flex items-center justify-between gap-3 border-b border-gray-100 px-5 py-4">
-          <div className="flex items-center gap-3">
-            <span
-              className={`flex h-10 w-10 items-center justify-center rounded-xl ${accent}`}
-            >
-              {icon}
-            </span>
-            <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="flex h-9 w-9 items-center justify-center rounded-lg text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
-            aria-label={t("close")}
-          >
-            <X className="h-5 w-5" aria-hidden="true" />
-          </button>
-        </div>
-        <div className="px-5 py-5">{children}</div>
-      </div>
-    </div>
-  );
-}
-
 // --- sick-note modal ---
 
 export function SickNoteModal({
@@ -314,11 +259,11 @@ export function SickNoteModal({
   };
 
   return (
-    <ModalShell
-      title={t("sick.title")}
-      accent="bg-[#D6373E]/10 text-[#D6373E]"
-      icon={<HeartPulse className="h-5 w-5" aria-hidden="true" />}
+    <Modal
+      isOpen
       onClose={onClose}
+      title={t("sick.title")}
+      closeLabel={t("close")}
     >
       <div className="space-y-4">
         <p className="text-sm leading-6 text-gray-600">{t("sick.intro")}</p>
@@ -393,7 +338,7 @@ export function SickNoteModal({
           </button>
         </div>
       </div>
-    </ModalShell>
+    </Modal>
   );
 }
 
@@ -435,11 +380,11 @@ export function NotesModal({
   };
 
   return (
-    <ModalShell
-      title={t("notes.title")}
-      accent="bg-[#F78C10]/10 text-[#F78C10]"
-      icon={<MessageCircle className="h-5 w-5" aria-hidden="true" />}
+    <Modal
+      isOpen
       onClose={onClose}
+      title={t("notes.title")}
+      closeLabel={t("close")}
     >
       <div className="space-y-4">
         <label className="block">
@@ -501,7 +446,7 @@ export function NotesModal({
           </div>
         )}
       </div>
-    </ModalShell>
+    </Modal>
   );
 }
 
@@ -628,11 +573,11 @@ export function PickupTimeModal({
   };
 
   return (
-    <ModalShell
-      title={t("pickup.title")}
-      accent="bg-[#5080D8]/10 text-[#5080D8]"
-      icon={<CalendarClock className="h-5 w-5" aria-hidden="true" />}
+    <Modal
+      isOpen
       onClose={onClose}
+      title={t("pickup.title")}
+      closeLabel={t("close")}
     >
       <div className="space-y-4">
         <p className="text-sm leading-6 text-gray-600">{t("pickup.intro")}</p>
@@ -744,7 +689,7 @@ export function PickupTimeModal({
           </div>
         </div>
       </div>
-    </ModalShell>
+    </Modal>
   );
 }
 

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -20,6 +20,16 @@ interface ModalProps {
    * views that need more horizontal space.
    */
   readonly widthClass?: string;
+  /**
+   * Accessible label for the close button. Defaults to German; pass a
+   * translated string on localized surfaces (e.g. the parents portal).
+   */
+  readonly closeLabel?: string;
+  /**
+   * Accessible label for the dismiss-on-tap backdrop. Defaults to German;
+   * pass a translated string on localized surfaces.
+   */
+  readonly backdropLabel?: string;
 }
 
 export function Modal({
@@ -29,7 +39,12 @@ export function Modal({
   children,
   footer,
   widthClass = "mx-4 w-[calc(100%-2rem)] max-w-lg",
+  closeLabel = "Modal schließen",
+  backdropLabel = "Hintergrund - Klicken zum Schließen",
 }: ModalProps) {
+  // Stable id so the dialog can reference its heading via aria-labelledby,
+  // giving the dialog an accessible name (role="dialog" alone has none).
+  const titleId = React.useId();
   const [isAnimating, setIsAnimating] = React.useState(false);
   const [isExiting, setIsExiting] = React.useState(false);
   const { openModal, closeModal } = useModal();
@@ -126,7 +141,7 @@ export function Modal({
           type="button"
           tabIndex={-1}
           onClick={handleClose}
-          aria-label="Hintergrund - Klicken zum Schließen"
+          aria-label={backdropLabel}
           className={`absolute inset-0 cursor-default border-none bg-transparent p-0 transition-all duration-200 ease-out ${
             isAnimating && !isExiting ? "bg-black/40" : "bg-black/0"
           }`}
@@ -141,6 +156,7 @@ export function Modal({
         <div
           className={`relative ${widthClass} transform overflow-hidden rounded-2xl border border-gray-200/50 shadow-2xl ${getModalAnimationClass(isAnimating, isExiting)}`}
           {...dialogAriaProps}
+          aria-labelledby={title ? titleId : undefined}
           style={{
             background:
               "linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(248,250,252,0.98) 100%)",
@@ -153,13 +169,16 @@ export function Modal({
           {/* Header with close button - only show border if title exists */}
           {title ? (
             <div className="flex items-center justify-between border-b border-gray-100 p-4 sm:p-6">
-              <h3 className="pr-4 text-lg font-semibold text-gray-900 sm:text-xl">
+              <h3
+                id={titleId}
+                className="pr-4 text-lg font-semibold text-gray-900 sm:text-xl"
+              >
                 {title}
               </h3>
               <button
                 onClick={handleClose}
                 className="group relative flex-shrink-0 rounded-xl p-2 text-gray-400 transition-all duration-200 hover:scale-105 hover:bg-gray-100 hover:text-gray-600 active:scale-95"
-                aria-label="Modal schließen"
+                aria-label={closeLabel}
               >
                 {/* Animated X icon */}
                 <svg
@@ -190,7 +209,7 @@ export function Modal({
             <button
               onClick={handleClose}
               className="group absolute top-4 right-4 z-10 rounded-xl p-2 text-gray-400 transition-all duration-200 hover:scale-105 hover:bg-gray-100 hover:text-gray-600 active:scale-95"
-              aria-label="Modal schließen"
+              aria-label={closeLabel}
             >
               {/* Animated X icon */}
               <svg


### PR DESCRIPTION
## Problem

The parents-portal child-care modals (Krank melden / Nachricht / Abholzeit ändern) used a hand-rolled `ModalShell` that bypassed the shared modal infrastructure: **no background blur**, **no scroll lock**, no portal/high z-index, no focus trap, no ESC handling. Opening one left the page behind sharp and scrollable — unlike every tenant-portal modal.

## Fix

Replace `ModalShell` with the shared `ui/Modal`, so the parents modals get the **exact same chrome as the tenant portal** from a single source of truth: blur (via `ModalProvider`/`BackgroundWrapper`, already mounted in the root layout), `useScrollLock`, `createPortal` + `z-[9999]`, focus trap, ESC, enter/exit animation.

Also two small, additive improvements to the shared `Modal`:
- **i18n:** optional `closeLabel` / `backdropLabel` props (defaults unchanged → no regression for existing German callers); the localized parents modals pass `t("close")`.
- **a11y:** link the dialog to its heading via `aria-labelledby` so `role="dialog"` finally has an accessible name (it had none before).

> Scope note: only the modal **chrome** was swapped. The action buttons inside the parents forms keep their semantic brand colors (sick = red, pickup = blue, notes = orange) and stay inline rather than using the kit `Button`/`footer` slot — intentional, unchanged from before.

## Screenshots

**Vorher** (hand-rolled ModalShell — Hintergrund scharf, kein Blur):

<img width="1440" height="900" alt="01-vorher-modal-offen" src="https://github.com/user-attachments/assets/c0fa986c-5e4f-4248-a209-da9c634f7b9c" />


**Nachher** (geteiltes ui/Modal — Hintergrund verblurrt, Tenant-Chrome):

<img width="1440" height="900" alt="02-nachher-modal-offen" src="https://github.com/user-attachments/assets/547ec90d-6408-4463-acc3-37f7b9c81b31" />


## Verification

- `pnpm run check` (verify-locales + oxlint + tsc) — green.
- Affected tests green: `child-care`, `parent-portal`, `ui/modal` (30/30). `parent-portal`'s `findByRole("dialog", { name })` confirms the new `aria-labelledby`.
- Live: parents modal now blurs + locks scroll, matching the tenant portal.

## Test note

`child-care.test.tsx` queries moved from `container.querySelector` to `document.querySelector` — the shared Modal renders via `createPortal` to `document.body`, so the fields live outside the render container. Assertions are unchanged; only the DOM query root moved.