### PR TITLE
Fix frontend image cache permissions

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -66,7 +66,10 @@ COPY --from=builder /app/public ./public
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nextjs -u 1001
+    adduser -S nextjs -u 1001 -G nodejs && \
+    mkdir -p .next/cache && \
+    chown -R nextjs:nodejs .next/cache && \
+    chmod 0750 .next/cache
 USER nextjs
 
 EXPOSE 3000

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -62,6 +62,13 @@ COPY --from=builder --chown=root:nodejs --chmod=0555 /app/.next/standalone ./
 COPY --from=builder --chown=root:nodejs --chmod=0555 /app/.next/static ./.next/static
 COPY --from=builder --chown=root:nodejs --chmod=0555 /app/public ./public
 
+# Next.js writes optimized images and incremental cache entries at runtime.
+# Keep application files read-only while allowing the non-root runtime user to
+# create cache entries under .next/cache.
+RUN mkdir -p .next/cache && \
+    chown -R nextjs:nodejs .next/cache && \
+    chmod 0750 .next/cache
+
 USER nextjs
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- create a writable `.next/cache` directory in the frontend production image
- keep the rest of the standalone Next.js app read-only while allowing the `nextjs` runtime user to write optimizer cache entries
- apply the same fix to the regular production Dockerfile stage

## Root cause
Next.js image optimization handles `/_next/image` by writing optimized assets under `/app/.next/cache`. The deployed image copied `.next` as read-only and then switched to the non-root `nextjs` user, so the first image optimizer request failed with `EACCES: permission denied, mkdir /app/.next/cache`.

## Impact
This should stop the staging/production Sentry errors for `GET /_next/image` without broadening write access to application files.

## Validation
- `docker build --check -f frontend/Dockerfile.prod frontend`
- `docker build --check -f frontend/Dockerfile frontend`
- full `frontend/Dockerfile.prod` image build with staging-like build args
- verified inside the built image as `nextjs` that `/app/.next/cache/images/...` is writable
- `git diff --check`