### PR TITLE
Refresh student status days on SSE updates

### DIFF
--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -592,7 +592,7 @@ describe("useGlobalSSE", () => {
       expect(matcher("student-detail-99")).toBe(false);
     });
 
-    it("student_updated invalidates student list, detail, and dashboard caches", () => {
+    it("student_updated invalidates student list, detail, status-day, and dashboard caches", () => {
       renderHook(() => useGlobalSSE());
 
       const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
@@ -630,6 +630,15 @@ describe("useGlobalSSE", () => {
         );
       });
       expect(studentDetailCall).toBeDefined();
+
+      const studentDetailMatcher = studentDetailCall![0] as (
+        key: string,
+      ) => boolean;
+      expect(
+        studentDetailMatcher(
+          "my-tenant:student-status-days-42-2026-06-01-2026-06-30",
+        ),
+      ).toBe(true);
 
       const dashboardCall = mutateCalls.find((call) => {
         const matcher = call[0];

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -157,7 +157,10 @@ export function useGlobalSSE(): SSEHookState {
 
     if (hasPendingStudentUpdateEvent.current) {
       mutate(
-        (key) => typeof key === "string" && key.includes("student-detail-"),
+        (key) =>
+          typeof key === "string" &&
+          (key.includes("student-detail-") ||
+            key.includes("student-status-days-")),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## Summary
- invalidate student status-day SWR caches when student_updated SSE events arrive
- add regression coverage for tenant-prefixed student-status-days cache keys

## Tests
- cd frontend && pnpm test:run src/lib/hooks/__tests__/use-global-sse.test.ts src/lib/hooks/__tests__/use-sse.test.ts src/lib/hooks/__tests__/use-settings-cache-bridge.test.tsx src/lib/hooks/use-student-data.test.ts

Fixes #1344