### PR TITLE
style: soften avatar initials across portals

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/profile/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/profile/page.tsx
@@ -130,7 +130,7 @@ function ProfileContent() {
         {/* Avatar Section */}
         <div className="flex flex-col items-center pt-4">
           <div className="group relative">
-            <div className="relative flex h-28 w-28 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-gray-700 to-gray-900 text-white shadow-xl">
+            <div className="relative flex h-28 w-28 items-center justify-center overflow-hidden rounded-full bg-[#ECF8DF] text-[#5A8E1F]">
               {profile?.avatar ? (
                 <Image
                   src={profile.avatar}

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -15,8 +15,13 @@ interface AvatarProps {
   readonly className?: string;
 }
 
-// Single brand-green fallback background for every avatar (LOCATION_COLORS.GROUP_ROOM).
-const FALLBACK_BG = "#83CD2D";
+// Soft brand-green fallback for the initials state paired with the stronger
+// green letter color, matching the child cards in the parent portal. The
+// background is the OPAQUE equivalent of LOCATION_COLORS.GROUP_ROOM (#83CD2D)
+// at 15% over white — kept opaque so a dotted/colored page background never
+// shows through the avatar.
+const FALLBACK_BG = "#ECF8DF";
+const FALLBACK_TEXT = "#5A8E1F";
 
 const SIZE_CLASSES: Record<AvatarSize, string> = {
   xs: "w-6 h-6 text-[10px]",
@@ -42,10 +47,6 @@ export function Avatar({
 }: AvatarProps) {
   const initials = getInitials(name);
   const sizeClass = SIZE_CLASSES[size];
-  const ringClass =
-    size === "xs" || size === "sm"
-      ? "shadow-sm ring-2 ring-white"
-      : "shadow-md";
 
   // Stale URL → initials fallback instead of broken-image glyph. Reset on
   // imageUrl change so a fresh upload doesn't stay stuck in fallback state.
@@ -58,9 +59,10 @@ export function Avatar({
 
   return (
     <div
-      className={`relative ${sizeClass} ${ringClass} flex flex-shrink-0 items-center justify-center overflow-hidden rounded-full font-semibold text-white ${className ?? ""}`}
+      className={`relative ${sizeClass} flex flex-shrink-0 items-center justify-center overflow-hidden rounded-full font-semibold ${className ?? ""}`}
       style={{
         background: showImage ? "transparent" : FALLBACK_BG,
+        color: showImage ? undefined : FALLBACK_TEXT,
       }}
       aria-label={name}
     >


### PR DESCRIPTION
## Summary
- replace solid-green avatar fallbacks with the soft brand-green fill and stronger green initials
- remove the white ring/shadow treatment from shared avatars for a flatter look
- align the tenant profile page fallback avatar with the shared treatment

## Tests
- frontend-check via pre-push hook
- frontend-knip via pre-push hook
- git-secrets via pre-push hook

## Notes
- Backend test failures seen during review appeared tied to a stale/mismatched local test database schema, not these frontend-only changes.