### PR TITLE
Fix dashboard absence counts

### DIFF
--- a/backend/api/students/status_day_internal_test.go
+++ b/backend/api/students/status_day_internal_test.go
@@ -605,6 +605,6 @@ func (r *fakeStatusDayRepo) ArchiveAndClearStatusFlag(context.Context, string, s
 	return 0, nil
 }
 
-func (r *fakeStatusDayRepo) CountActiveClassTripStudents(context.Context, timezone.Date) (int, error) {
-	return 0, nil
+func (r *fakeStatusDayRepo) CountEffectiveDashboardAbsences(context.Context, timezone.Date) (*active.StudentStatusCounts, error) {
+	return &active.StudentStatusCounts{}, nil
 }

--- a/backend/database/repositories/active/student_status_day.go
+++ b/backend/database/repositories/active/student_status_day.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	usersModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
@@ -284,29 +285,59 @@ func (r *StudentStatusDayRepository) ArchiveAndClearStatusFlag(
 	return affected, nil
 }
 
-// CountActiveClassTripStudents counts distinct students with an uncleared
-// class-trip status entry for the date, excluding students currently flagged
-// sick or excused. Custom method (backend-conventions Rule 2): join on
-// users.students with COALESCE flag predicates for the dashboard analytics.
-func (r *StudentStatusDayRepository) CountActiveClassTripStudents(ctx context.Context, date timezone.Date) (int, error) {
-	var count int
-	query := base.GetDB(ctx, r.db).NewSelect().
-		TableExpr(`active.student_status_days AS "student_status_day"`).
-		Join(`JOIN users.students AS "student" ON "student".id = "student_status_day".student_id AND "student".tenant_id = "student_status_day".tenant_id`).
-		Where(`"student_status_day".date = ?`, date).
-		Where(`"student_status_day".status = ?`, active.StudentStatusDayClassTrip).
-		Where(`"student_status_day".cleared_at IS NULL`).
-		Where(`COALESCE("student".sick, FALSE) = FALSE`).
-		Where(`COALESCE("student".excused, FALSE) = FALSE`).
-		ColumnExpr(`COUNT(DISTINCT "student_status_day".student_id)`)
-	if where, val, ok := base.TenantWhere(ctx, "student_status_day"); ok {
-		query = query.Where(where, val)
+// CountEffectiveDashboardAbsences counts the dashboard's effective absence
+// buckets for one date. It bridges the legacy live flags on users.students and
+// the newer date-scoped rows in active.student_status_days without double
+// counting overlaps. Sick wins over excused/class_trip, matching
+// api/students/status_days_response.go.
+func (r *StudentStatusDayRepository) CountEffectiveDashboardAbsences(ctx context.Context, date timezone.Date) (*active.StudentStatusCounts, error) {
+	counts := &active.StudentStatusCounts{}
+	db := base.GetDB(ctx, r.db)
+
+	perStudent := db.NewSelect().
+		TableExpr(`users.students AS "student"`).
+		ColumnExpr(`"student".id`).
+		ColumnExpr(`COALESCE("student".sick, FALSE) AS flag_sick`).
+		ColumnExpr(`COALESCE("student".excused, FALSE) AS flag_excused`).
+		ColumnExpr(`COALESCE(BOOL_OR("student_status_day".status = ?), FALSE) AS day_sick`, active.StudentStatusDaySick).
+		ColumnExpr(`COALESCE(BOOL_OR("student_status_day".status = ?), FALSE) AS day_excused`, active.StudentStatusDayExcused).
+		ColumnExpr(`COALESCE(BOOL_OR("student_status_day".status = ?), FALSE) AS day_class_trip`, active.StudentStatusDayClassTrip).
+		Join(`
+			LEFT JOIN active.student_status_days AS "student_status_day"
+				ON "student_status_day".tenant_id = "student".tenant_id
+				AND "student_status_day".student_id = "student".id
+				AND "student_status_day".date = ?
+				AND "student_status_day".cleared_at IS NULL
+		`, date).
+		Where(`"student".status = ?`, string(usersModels.StudentStatusActive)).
+		GroupExpr(`"student".id, "student".sick, "student".excused`)
+	if where, val, ok := base.TenantWhere(ctx, "student"); ok {
+		perStudent = perStudent.Where(where, val)
 	}
-	if err := query.Scan(ctx, &count); err != nil {
-		return 0, &modelBase.DatabaseError{
-			Op:  "count active class trip students",
+
+	query := db.NewSelect().
+		TableExpr(`(?) AS "effective_student_status"`, perStudent).
+		ColumnExpr(`
+			COUNT(*) FILTER (
+				WHERE "effective_student_status".flag_sick
+					OR "effective_student_status".day_sick
+			) AS sick_count
+		`).
+		ColumnExpr(`
+			COUNT(*) FILTER (
+				WHERE NOT ("effective_student_status".flag_sick OR "effective_student_status".day_sick)
+					AND (
+						"effective_student_status".flag_excused
+						OR "effective_student_status".day_excused
+						OR "effective_student_status".day_class_trip
+					)
+			) AS excused_count
+		`)
+	if err := query.Scan(ctx, counts); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "count effective dashboard absences",
 			Err: err,
 		}
 	}
-	return count, nil
+	return counts, nil
 }

--- a/backend/database/repositories/active/student_status_day_test.go
+++ b/backend/database/repositories/active/student_status_day_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	usersModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
@@ -154,6 +155,93 @@ func TestStudentStatusDayRepository_TenantScope(t *testing.T) {
 	rows, err = repo.FindActiveByStudentAndDateRange(testpkg.TenantContext(1), student.ID, date, date)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
+}
+
+func TestStudentStatusDayRepository_CountEffectiveDashboardAbsences(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).StudentStatusDay
+	tenantA := testpkg.UniqueTestTenantID(t)
+	tenantB := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantA)
+	testpkg.EnsureTestTenant(t, db, tenantB)
+	ctxA := testpkg.TenantContext(tenantA)
+	ctxB := testpkg.TenantContext(tenantB)
+
+	today := timezone.TodayDate()
+	now := time.Now()
+	trueValue := true
+	studentIDs := make([]int64, 0, 10)
+	create := func(first, last string) int64 {
+		student := testpkg.CreateTestStudentForTenant(t, db, tenantA, first, last, "DA1")
+		studentIDs = append(studentIDs, student.ID)
+		return student.ID
+	}
+	setFlag := func(studentID int64, flag string) {
+		_, err := db.NewUpdate().
+			TableExpr(`users.students`).
+			Set(flag+" = ?", trueValue).
+			Where("id = ?", studentID).
+			Exec(ctxA)
+		require.NoError(t, err)
+	}
+	report := func(ctx context.Context, studentID int64, status string) {
+		require.NoError(t, repo.UpsertReported(ctx, &active.StudentStatusDay{
+			StudentID:  studentID,
+			Date:       today,
+			Status:     status,
+			ReportedAt: now,
+			Source:     active.StudentStatusSourcePlanned,
+		}))
+	}
+
+	setFlag(create("FlagSick", "Dashboard"), "sick")
+	report(ctxA, create("PlannedSick", "Dashboard"), active.StudentStatusDaySick)
+	report(ctxA, create("PlannedExcused", "Dashboard"), active.StudentStatusDayExcused)
+	setFlag(create("FlagExcused", "Dashboard"), "excused")
+
+	overlap := create("Overlap", "Dashboard")
+	setFlag(overlap, "excused")
+	report(ctxA, overlap, active.StudentStatusDayExcused)
+
+	report(ctxA, create("ClassTrip", "Dashboard"), active.StudentStatusDayClassTrip)
+
+	sickWins := create("SickWins", "Dashboard")
+	report(ctxA, sickWins, active.StudentStatusDaySick)
+	report(ctxA, sickWins, active.StudentStatusDayExcused)
+	report(ctxA, sickWins, active.StudentStatusDayClassTrip)
+
+	cleared := create("Cleared", "Dashboard")
+	report(ctxA, cleared, active.StudentStatusDayExcused)
+	require.NoError(t, repo.MarkCleared(ctxA, cleared, active.StudentStatusDayExcused, today, now, active.StudentStatusSourceManual))
+
+	inactive := create("Inactive", "Dashboard")
+	report(ctxA, inactive, active.StudentStatusDayExcused)
+	_, err := db.NewUpdate().
+		TableExpr(`users.students`).
+		Set("status = ?", string(usersModels.StudentStatusInactive)).
+		Where("id = ?", inactive).
+		Exec(ctxA)
+	require.NoError(t, err)
+
+	otherTenantStudent := testpkg.CreateTestStudentForTenant(t, db, tenantB, "OtherTenant", "Dashboard", "DB1")
+	studentIDs = append(studentIDs, otherTenantStudent.ID)
+	report(ctxB, otherTenantStudent.ID, active.StudentStatusDayExcused)
+
+	defer testpkg.CleanupActivityFixtures(t, db, studentIDs...)
+
+	counts, err := repo.CountEffectiveDashboardAbsences(ctxA, today)
+	require.NoError(t, err)
+	require.NotNil(t, counts)
+	assert.Equal(t, 3, counts.Sick)
+	assert.Equal(t, 4, counts.Excused)
+
+	otherCounts, err := repo.CountEffectiveDashboardAbsences(ctxB, today)
+	require.NoError(t, err)
+	require.NotNil(t, otherCounts)
+	assert.Equal(t, 0, otherCounts.Sick)
+	assert.Equal(t, 1, otherCounts.Excused)
 }
 
 func TestStudentStatusDayRepository_UpsertNil(t *testing.T) {

--- a/backend/models/active/student_status_day.go
+++ b/backend/models/active/student_status_day.go
@@ -78,6 +78,11 @@ func (s *StudentStatusDay) GetCreatedAt() time.Time { return s.CreatedAt }
 func (s *StudentStatusDay) GetUpdatedAt() time.Time { return s.UpdatedAt }
 func (s *StudentStatusDay) TableName() string       { return tableActiveStudentStatusDays }
 
+type StudentStatusCounts struct {
+	Sick    int `bun:"sick_count"`
+	Excused int `bun:"excused_count"`
+}
+
 type StudentStatusDayRepository interface {
 	UpsertReported(ctx context.Context, entry *StudentStatusDay) error
 	// ArchiveAndClearStatusFlag archives a legacy boolean student flag into
@@ -85,10 +90,10 @@ type StudentStatusDayRepository interface {
 	// users.students. Returns the number of students cleared. Column names
 	// must be trusted constants, never user input.
 	ArchiveAndClearStatusFlag(ctx context.Context, flagColumn, sinceColumn, status string, date timezone.Date, reportedFallback time.Time, source string) (int64, error)
-	// CountActiveClassTripStudents counts distinct students with an
-	// uncleared class-trip entry for the date, excluding currently
-	// sick/excused students. Used by the dashboard analytics.
-	CountActiveClassTripStudents(ctx context.Context, date timezone.Date) (int, error)
+	// CountEffectiveDashboardAbsences counts today's effective dashboard
+	// absence buckets from live flags and status-day rows, applying the same
+	// precedence as student responses: sick wins, class trip counts as excused.
+	CountEffectiveDashboardAbsences(ctx context.Context, date timezone.Date) (*StudentStatusCounts, error)
 	MarkCleared(ctx context.Context, studentID int64, status string, date timezone.Date, clearedAt time.Time, source string) error
 	MarkClearedByID(ctx context.Context, id int64, clearedAt time.Time, source string) error
 	MarkClearedForDates(ctx context.Context, studentID int64, status string, dates []timezone.Date, clearedAt time.Time, source string) error

--- a/backend/services/active/analytics_service.go
+++ b/backend/services/active/analytics_service.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
-	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 )
 
 // Analytics and statistics
@@ -30,24 +29,13 @@ func (s *service) GetDashboardAnalytics(ctx context.Context) (*DashboardAnalytic
 	analytics.ActivityCategories = baseData.activityCategories
 	analytics.SupervisorsToday = baseData.supervisorsToday
 
-	sickOpts := modelBase.NewQueryOptions()
-	sickOpts.Filter.Equal("sick", true)
-	if sickCount, err := s.studentRepo.CountWithOptions(ctx, sickOpts); err == nil {
-		analytics.StudentsSick = sickCount
-	}
-
-	excusedOpts := modelBase.NewQueryOptions()
-	excusedOpts.Filter.Equal("excused", true)
-	if excusedCount, err := s.studentRepo.CountWithOptions(ctx, excusedOpts); err == nil {
-		classTripCount, classTripErr := s.countClassTripStudentsForDate(ctx, today)
-		if classTripErr == nil {
-			excusedCount += classTripCount
-		} else {
-			s.getLogger().Warn("failed to count class trip students for dashboard",
-				"error", classTripErr.Error(),
-			)
-		}
-		analytics.StudentsExcused = excusedCount
+	if statusCounts, err := s.countEffectiveAbsencesForDate(ctx, today); err == nil {
+		analytics.StudentsSick = statusCounts.Sick
+		analytics.StudentsExcused = statusCounts.Excused
+	} else {
+		s.getLogger().Warn("failed to count effective student absences for dashboard",
+			"error", err.Error(),
+		)
 	}
 
 	// Phase 3: Build room lookup maps
@@ -91,9 +79,24 @@ func (s *service) GetDashboardAnalytics(ctx context.Context) (*DashboardAnalytic
 	return analytics, nil
 }
 
-func (s *service) countClassTripStudentsForDate(ctx context.Context, date timezone.Date) (int, error) {
+func (s *service) countEffectiveAbsencesForDate(ctx context.Context, date timezone.Date) (studentStatusCounts, error) {
 	if s.studentStatusRepo == nil {
-		return 0, nil
+		return studentStatusCounts{}, nil
 	}
-	return s.studentStatusRepo.CountActiveClassTripStudents(ctx, date)
+	counts, err := s.studentStatusRepo.CountEffectiveDashboardAbsences(ctx, date)
+	if err != nil {
+		return studentStatusCounts{}, err
+	}
+	if counts == nil {
+		return studentStatusCounts{}, nil
+	}
+	return studentStatusCounts{
+		Sick:    counts.Sick,
+		Excused: counts.Excused,
+	}, nil
+}
+
+type studentStatusCounts struct {
+	Sick    int
+	Excused int
 }

--- a/backend/services/active/analytics_service_test.go
+++ b/backend/services/active/analytics_service_test.go
@@ -50,6 +50,43 @@ func TestGetDashboardAnalytics(t *testing.T) {
 		assert.GreaterOrEqual(t, analytics.ActiveActivities, 1, "Should have at least 1 active activity")
 	})
 
+	t.Run("counts planned excused students for today", func(t *testing.T) {
+		// ARRANGE
+		before, err := service.GetDashboardAnalytics(ctx)
+		require.NoError(t, err)
+
+		statusRepo := repositories.NewFactory(db).StudentStatusDay
+		plannedExcusedStudent := testpkg.CreateTestStudent(t, db, "PlannedExcused", "Dashboard", "PE1")
+		legacyOverlapStudent := testpkg.CreateTestStudent(t, db, "LegacyOverlap", "Dashboard", "PE2")
+		defer testpkg.CleanupActivityFixtures(t, db, plannedExcusedStudent.ID, legacyOverlapStudent.ID)
+
+		flagTrue := true
+		_, err = db.NewUpdate().
+			Model(legacyOverlapStudent).
+			Set("excused = ?", flagTrue).
+			Where("id = ?", legacyOverlapStudent.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		now := time.Now()
+		for _, studentID := range []int64{plannedExcusedStudent.ID, legacyOverlapStudent.ID} {
+			require.NoError(t, statusRepo.UpsertReported(ctx, &activeModels.StudentStatusDay{
+				StudentID:  studentID,
+				Date:       timezone.TodayDate(),
+				Status:     activeModels.StudentStatusDayExcused,
+				ReportedAt: now,
+				Source:     activeModels.StudentStatusSourcePlanned,
+			}))
+		}
+
+		// ACT
+		after, err := service.GetDashboardAnalytics(ctx)
+
+		// ASSERT
+		require.NoError(t, err)
+		assert.Equal(t, before.StudentsExcused+2, after.StudentsExcused)
+	})
+
 	t.Run("counts class trip students as excused without counting sick overlaps", func(t *testing.T) {
 		// ARRANGE
 		before, err := service.GetDashboardAnalytics(ctx)


### PR DESCRIPTION
## Summary
- Count dashboard sick/excused KPIs from effective daily status, not only legacy live flags.
- Include today’s uncleared `active.student_status_days` rows, legacy `users.students` flags, and class trips as excused.
- Preserve sick-over-excused precedence and avoid double-counting overlaps.

## Root Cause
The dashboard counted `users.students.excused = true`, but planned and parent-reported excused days are stored in `active.student_status_days`. Schools with many planned absences could therefore see the dashboard count miss most of today’s excused children.

## Validation
- `cd backend && go test ./database/repositories/active ./services/active ./api/students`
- `cd backend && go test ./api/active`
- `git diff --check`
- Pre-push hook: `git-secrets`, `go-vet`, `go-deadcode`, `golangci-lint`

## Notes
- `cd backend && go test ./...` was run. It reached unrelated failures in `services/parent` because the local test DB is missing `audit.guardian_changes`; the changed packages passed.
