### PR TITLE
Fix enrollment schedule reviewer staff resolution

### DIFF
--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -292,6 +292,7 @@ type DecisionServiceConfig struct {
 	OfferingAdjustmentRepo   auditModels.EnrollmentOfferingAdjustmentRepository
 	SchoolRepo               platformModels.SchoolRepository
 	PersonRepo               users.PersonRepository
+	StaffRepo                users.StaffRepository
 	StudentRepo              users.StudentRepository
 	StudentGuardianRepo      users.StudentGuardianRepository
 	GuardianProfileRepo      users.GuardianProfileRepository
@@ -325,6 +326,7 @@ type decisionService struct {
 	offeringAdjustmentRepo   auditModels.EnrollmentOfferingAdjustmentRepository
 	schoolRepo               platformModels.SchoolRepository
 	personRepo               users.PersonRepository
+	staffRepo                users.StaffRepository
 	studentRepo              users.StudentRepository
 	studentGuardianRepo      users.StudentGuardianRepository
 	guardianProfileRepo      users.GuardianProfileRepository
@@ -363,6 +365,7 @@ func NewDecisionService(cfg DecisionServiceConfig) DecisionService {
 		offeringAdjustmentRepo:   cfg.OfferingAdjustmentRepo,
 		schoolRepo:               cfg.SchoolRepo,
 		personRepo:               cfg.PersonRepo,
+		staffRepo:                cfg.StaffRepo,
 		studentRepo:              cfg.StudentRepo,
 		studentGuardianRepo:      cfg.StudentGuardianRepo,
 		guardianProfileRepo:      cfg.GuardianProfileRepo,
@@ -2415,6 +2418,33 @@ func decodeStructured(raw any, out any) error {
 	return json.Unmarshal(bs, out)
 }
 
+func (s *decisionService) resolveReviewerStaffID(ctx context.Context, reviewerAccountID int64) (int64, error) {
+	if reviewerAccountID <= 0 {
+		return 0, fmt.Errorf("reviewer account id is required")
+	}
+	if s.personRepo == nil || s.staffRepo == nil {
+		return 0, fmt.Errorf("reviewer staff lookup is unavailable")
+	}
+	person, err := s.personRepo.FindByAccountID(ctx, reviewerAccountID)
+	if err != nil {
+		return 0, fmt.Errorf("find reviewer person: %w", err)
+	}
+	if person == nil {
+		return 0, fmt.Errorf("reviewer account %d has no linked person", reviewerAccountID)
+	}
+	staff, err := s.staffRepo.FindByPersonID(ctx, person.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, fmt.Errorf("reviewer account %d has no linked staff", reviewerAccountID)
+		}
+		return 0, fmt.Errorf("find reviewer staff: %w", err)
+	}
+	if staff == nil {
+		return 0, fmt.Errorf("reviewer account %d has no linked staff", reviewerAccountID)
+	}
+	return staff.ID, nil
+}
+
 // dispatchWeekdaySchedule inserts one pickup or arrival schedule row
 // per non-empty weekday entry. isPickup=true targets pickup_schedules,
 // false targets arrival_schedules.
@@ -2429,16 +2459,16 @@ func (s *decisionService) dispatchWeekdaySchedule(ctx context.Context, raw any, 
 	if err := sched.Validate(); err != nil {
 		return err
 	}
+	createdBy, err := s.resolveReviewerStaffID(ctx, reviewedBy)
+	if err != nil {
+		return err
+	}
 	weekdayInt := map[string]int{
 		"mon": scheduleModels.WeekdayMonday,
 		"tue": scheduleModels.WeekdayTuesday,
 		"wed": scheduleModels.WeekdayWednesday,
 		"thu": scheduleModels.WeekdayThursday,
 		"fri": scheduleModels.WeekdayFriday,
-	}
-	createdBy := reviewedBy
-	if createdBy <= 0 {
-		createdBy = 1 // fallback for legacy tests with no actor
 	}
 	for day, hhmm := range sched {
 		hhmm = strings.TrimSpace(hhmm)

--- a/backend/services/enrollment/decision_service_test.go
+++ b/backend/services/enrollment/decision_service_test.go
@@ -76,6 +76,7 @@ func setupDecisionTestWithSettings(
 		FormSchemaRepo:           repoFactory.FormSchema,
 		OfferingAdjustmentRepo:   repoFactory.EnrollmentOfferingAdjustment,
 		PersonRepo:               repoFactory.Person,
+		StaffRepo:                repoFactory.Staff,
 		StudentRepo:              repoFactory.Student,
 		StudentGuardianRepo:      repoFactory.StudentGuardian,
 		GuardianProfileRepo:      repoFactory.GuardianProfile,
@@ -104,6 +105,18 @@ func setupDecisionTestWithSettings(
 // drive Decide against a known row.
 func submitOneChild(t *testing.T, env *decisionTestEnv, guardianEmail, childFirst, childLast string) (requestID, childID int64) {
 	t.Helper()
+	return submitOneChildWithCustomData(t, env, guardianEmail, childFirst, childLast, nil)
+}
+
+func submitOneChildWithCustomData(
+	t *testing.T,
+	env *decisionTestEnv,
+	guardianEmail string,
+	childFirst string,
+	childLast string,
+	customData map[string]any,
+) (requestID, childID int64) {
+	t.Helper()
 	ctx := testpkg.TenantContext(1)
 	grade := int16(2)
 	res, err := env.requestSvc.Submit(ctx, enrollmentService.SubmitRequest{
@@ -124,12 +137,57 @@ func submitOneChild(t *testing.T, env *decisionTestEnv, guardianEmail, childFirs
 				LastName:         childLast,
 				DateOfBirth:      timezone.NewDate(2018, 4, 15),
 				TargetGradeLevel: &grade,
+				CustomData:       customData,
 			},
 		},
 	})
 	require.NoError(t, err)
 	require.Len(t, res.Children, 1)
 	return res.Request.ID, res.Children[0].ID
+}
+
+func publishDecisionScheduleSchema(t *testing.T, env *decisionTestEnv, key, target string) {
+	t.Helper()
+	ctx := testpkg.TenantContext(1)
+	schemaSvc := enrollmentService.NewFormSchemaService(enrollmentService.FormSchemaServiceConfig{
+		Repo:   env.repos.FormSchema,
+		Logger: slog.Default(),
+	})
+	field := enrollmentModels.FormField{
+		Key:         key,
+		Label:       "Schedule",
+		Type:        enrollmentModels.FormFieldWeekdaySchedule,
+		AppliesToCh: true,
+		Target:      target,
+		SortOrder:   0,
+	}
+	if target == enrollmentModels.TargetSchedulePickup {
+		field.AllowedTimes = []string{
+			"07:45",
+			"14:45",
+			"16:00",
+		}
+	}
+	schema, err := schemaSvc.PublishVersion(ctx, []enrollmentModels.FormField{
+		field,
+	}, env.creatorID)
+	require.NoError(t, err)
+	env.sourcePhase.FormSchemaID = &schema.ID
+	require.NoError(t, env.repos.Phase.Update(ctx, env.sourcePhase))
+}
+
+func createReviewerStaffWithDistinctAccount(t *testing.T, env *decisionTestEnv) (*usersModels.Staff, int64) {
+	t.Helper()
+	for i := 0; i < 5; i++ {
+		_ = testpkg.CreateTestStaff(t, env.db, "ReviewerOffset", "Staff")
+		staff, account := testpkg.CreateTestStaffWithAccount(t, env.db, "Reviewer", "Schedule")
+		if staff.ID != account.ID {
+			return staff, account.ID
+		}
+	}
+	staff, account := testpkg.CreateTestStaffWithAccount(t, env.db, "Reviewer", "ScheduleFinal")
+	require.NotEqual(t, staff.ID, account.ID, "test setup must prove account id and staff id are not interchangeable")
+	return staff, account.ID
 }
 
 func setSourcePhaseServiceStartDate(t *testing.T, env *decisionTestEnv, serviceStartDate timezone.Date) {
@@ -1059,6 +1117,89 @@ func TestDecisionService_Decide_ApprovedStampsConsentTimestamps(t *testing.T) {
 	require.NotNil(t, student.PhotoConsentGivenBy)
 	assert.Equal(t, env.creatorID, *student.PhotoConsentGivenBy,
 		"photo_consent_given_by must reference the reviewer account")
+}
+
+func TestDecisionService_Decide_SchedulePickupUsesReviewerStaffID(t *testing.T) {
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+	publishDecisionScheduleSchema(t, env, "pickup_times", enrollmentModels.TargetSchedulePickup)
+	reviewerStaff, reviewerAccountID := createReviewerStaffWithDistinctAccount(t, env)
+
+	reqID, childID := submitOneChildWithCustomData(t, env, "pickup-schedule-author@example.com", "Anna", "Pickup", map[string]any{
+		"pickup_times": map[string]any{"mon": "14:45", "wed": "16:00"},
+	})
+	outcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
+		RequestID:  reqID,
+		ChildID:    childID,
+		Status:     enrollmentService.DecisionApproved,
+		ReviewedBy: reviewerAccountID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Child.CreatedStudentID)
+
+	rows, err := env.repos.StudentPickupSchedule.FindByStudentID(ctx, *outcome.Child.CreatedStudentID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	for _, row := range rows {
+		assert.Equal(t, reviewerStaff.ID, row.CreatedBy,
+			"pickup schedule created_by must reference users.staff, not the reviewer account")
+		assert.NotEqual(t, reviewerAccountID, row.CreatedBy,
+			"the regression requires account id and staff id to stay distinct")
+	}
+}
+
+func TestDecisionService_Decide_ScheduleArrivalUsesReviewerStaffID(t *testing.T) {
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+	publishDecisionScheduleSchema(t, env, "arrival_times", enrollmentModels.TargetScheduleArrival)
+	reviewerStaff, reviewerAccountID := createReviewerStaffWithDistinctAccount(t, env)
+
+	reqID, childID := submitOneChildWithCustomData(t, env, "arrival-schedule-author@example.com", "Anna", "Arrival", map[string]any{
+		"arrival_times": map[string]any{"mon": "07:45"},
+	})
+	outcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
+		RequestID:  reqID,
+		ChildID:    childID,
+		Status:     enrollmentService.DecisionApproved,
+		ReviewedBy: reviewerAccountID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Child.CreatedStudentID)
+
+	rows, err := env.repos.StudentArrivalSchedule.FindByStudentID(ctx, *outcome.Child.CreatedStudentID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, reviewerStaff.ID, rows[0].CreatedBy,
+		"arrival schedule created_by must reference users.staff, not the reviewer account")
+	assert.NotEqual(t, reviewerAccountID, rows[0].CreatedBy,
+		"the regression requires account id and staff id to stay distinct")
+}
+
+func TestDecisionService_Decide_ScheduleTargetWithoutReviewerStaffDoesNotAbortApproval(t *testing.T) {
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+	publishDecisionScheduleSchema(t, env, "pickup_times", enrollmentModels.TargetSchedulePickup)
+	reviewerAccount := testpkg.CreateTestAccount(t, env.db, "reviewer-without-staff")
+
+	reqID, childID := submitOneChildWithCustomData(t, env, "pickup-no-staff@example.com", "Anna", "NoStaff", map[string]any{
+		"pickup_times": map[string]any{"mon": "14:45"},
+	})
+	outcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
+		RequestID:  reqID,
+		ChildID:    childID,
+		Status:     enrollmentService.DecisionApproved,
+		ReviewedBy: reviewerAccount.ID,
+	})
+	require.NoError(t, err, "targeted-field schedule failures must not poison the approval transaction")
+	require.NotNil(t, outcome.Child.CreatedStudentID)
+	assert.Equal(t, enrollmentModels.ChildStatusApproved, outcome.Child.Status)
+
+	rows, err := env.repos.StudentPickupSchedule.FindByStudentID(ctx, *outcome.Child.CreatedStudentID)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "without a staff author, schedule dispatch should skip before inserting")
 }
 
 func TestDecisionService_Decide_ApprovedIsIdempotent(t *testing.T) {

--- a/backend/services/enrollment/rollover_autoapprove_integration_test.go
+++ b/backend/services/enrollment/rollover_autoapprove_integration_test.go
@@ -49,6 +49,7 @@ func setupAutoApproveIntegrationEnvWithSettings(
 		CareOfferingRepo:         repoFactory.CareOffering,
 		PhaseRepo:                repoFactory.Phase,
 		PersonRepo:               repoFactory.Person,
+		StaffRepo:                repoFactory.Staff,
 		StudentRepo:              repoFactory.Student,
 		StudentGuardianRepo:      repoFactory.StudentGuardian,
 		GuardianProfileRepo:      repoFactory.GuardianProfile,

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1001,6 +1001,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		OfferingAdjustmentRepo:   repos.EnrollmentOfferingAdjustment,
 		SchoolRepo:               repos.School,
 		PersonRepo:               repos.Person,
+		StaffRepo:                repos.Staff,
 		StudentRepo:              repos.Student,
 		StudentGuardianRepo:      repos.StudentGuardian,
 		GuardianProfileRepo:      repos.GuardianProfile,

--- a/environments/staging.sops.env
+++ b/environments/staging.sops.env
@@ -12,7 +12,7 @@ PHOENIX_AUTH_PASSWORD=ENC[AES256_GCM,data:sfRqSVB/XBETobrGp2vZZeR6GIZIzS7t5A==,i
 PORT=ENC[AES256_GCM,data:jGlyNg==,iv:eEx/bd18/0iHzov3V65HhlyCBYAD4DSemegmCnRopKI=,tag:KnPuObNIuYvSgilTHSuzQQ==,type:str]
 LOG_LEVEL=ENC[AES256_GCM,data:wBoANXE=,iv:Pcqb7YmHsmIDhMLtLuzxFyUa440/fpzWj82UMe0gXm4=,tag:Tcu/qbGNkVo0ie2SDWN1/w==,type:str]
 LOG_TEXTLOGGING=ENC[AES256_GCM,data:qeDA/A==,iv:jhtDzg2KoYyXrOLs1Dv4h3cSPQ6E9iEc2SFZ1+zbv6Q=,tag:0DaJXDQNbbykhexflIFoQQ==,type:str]
-APP_ENV=ENC[AES256_GCM,data:da2RLpqCjSu0uA==,iv:3t/MDz+0JlGyjRNoE/04+OVKB1KVDNLMCfLjQfsuYT8=,tag:kFIBTTHtQfEKNuHa0HXNYA==,type:str]
+APP_ENV=ENC[AES256_GCM,data:DC6sKrPuwA==,iv:2GEXNWO3jEoYNHJM8sPqY9hXh0R90GNvyZNwF5RLpZM=,tag:WThbxPzxfg8Lv688JzX7fA==,type:str]
 DB_DEBUG=ENC[AES256_GCM,data:a96WBQ==,iv:maRsjieTY/XCmw9WUZHKSpW4M+eL77oprkAUaWnl7m4=,tag:YlXv9ag5pJvRO2gCYvKdlw==,type:str]
 ENABLE_CORS=ENC[AES256_GCM,data:GcMEuQ==,iv:+hk7KoT1WvCLYTSjgRMJVwXV1Hy0Eimga24SEUZkuIs=,tag:UhEnCBCXXwKgfv/FePgxLQ==,type:str]
 CORS_ALLOWED_ORIGINS=ENC[AES256_GCM,data:tqSPZNSiHVaVB1/PEZEVwIqHuu1TywkTmdOBGIFckSBXBDZo1UJE0W9Rhf0sG9HaMQsMViJeLil0+njFWA==,iv:NDOlYZF/bA/0k0Nya98KifeSE98Z4QqjZZ+Zon7WlfI=,tag:PlstZ3WSsNla1XALLnmSKQ==,type:str]
@@ -90,7 +90,7 @@ sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb2
 sops_age__list_1__map_recipient=age1qmh8rfsxle4jpmw07yzy9qts8eq8txapmlk6h63nn6lv9unr9qasvymvcd
 sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArcWxGRUxMdFhNdExNNU1t\nYXZRYUhDbnRDOURRM1ZqTm1rRE8zdmFqZG4wCndVbkpNcWRlUnBxZW15RzdCN093\nWm96VlcwNisvVmVtWlZaME1namlMbm8KLS0tIGdWNDdLc25Bb1FrUHdTQTQxOVpy\nMUFPT2lOa3ZqNUc1U2NkcXRTVG82c0kKBcQND6+V/o8x26sKB+sPDdO8rplNeoAX\nmxWc7tkiTnrBReTu/CvLYLnVYMNtfAFGn3dUwKs5gxb1Wi39dkLgpQ==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_2__map_recipient=age14h38gsugzt0pfla4g54k76uvrqsxe5x0yp7762jnmpndl6q3guxsnvgs6h
-sops_lastmodified=2026-06-22T23:25:05Z
-sops_mac=ENC[AES256_GCM,data:6qpZNn1OX9NyOKbQ2rX5rV0OWbtzco8KU5M1C1nghZbFQQgALnEKLysjuOZmJaOcAg5Ns6E4NYrPwt7Xie8EWAkQhedNCxCfLh1bbGK6A9YVdum7OWAeSMLarYM/e7hJ09mDMGiMs1Fph+QoxrAQzrlKuHRhRcIxuoeRVY/cRAU=,iv:mFFabv2rUjnU3eRk8F4+3kgFodRO13f7q211eYtdtpw=,tag:19ghSxgno20GReOYUxcfFw==,type:str]
+sops_lastmodified=2026-06-25T08:39:14Z
+sops_mac=ENC[AES256_GCM,data:UlErpgLBO5UJDNsrMrwgXs5AA9Zqb+FBBa5IgpQ2JLGSytRcs0+cE6b50pDBraf0261+wsaatD3+MlJUpvtFwCFh+mijCupzsGZsRCKsife6D71jdOeqeVsbH5thTdFIaJISRDvtIX2ZkMMYy6Mnsy2VGWLJb+nGtvSRn0PHQbY=,iv:IzCEZzDAvc9Bn6Oq2pkm1I6KJ7A+AIGBE5KeGJEwe5w=,tag:mKG4vjMP341jhU1bxcDDSA==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.2


### PR DESCRIPTION
## Summary
- resolve enrollment schedule targeted-field authors from reviewer account -> person -> staff before writing pickup/arrival schedules
- remove the unsafe `createdBy = 1` fallback so missing staff mapping cannot poison the transaction with an FK failure
- set staging `APP_ENV` to `staging` in the encrypted SOPS env while leaving production as `production`

## Verification
- `cd backend && go test ./services/enrollment -run 'TestDecisionService_Decide_Schedule' -count=1`
- `cd backend && go test ./services/enrollment -count=1`
- `./scripts/env-check.sh`
- pre-push hooks: `go vet`, `golangci-lint`, `go-deadcode`

## Notes
- `cd backend && go test ./...` still fails in unrelated `services/parent` tests with `ERROR: relation "audit.guardian_changes" does not exist (SQLSTATE=42P01)` and one existing guardian-profile constraint expectation failure. The enrollment package and this regression path pass cleanly.
