### PR TITLE
Hide enrollment status tokens from admin lists

### DIFF
--- a/backend/api/active/supervision_overview_internal_test.go
+++ b/backend/api/active/supervision_overview_internal_test.go
@@ -311,6 +311,9 @@ func (s *stubActiveService) CheckInStudent(_ context.Context, _, _, _ int64, _ b
 func (s *stubActiveService) CheckOutStudent(_ context.Context, _, _ int64, _ bool) (*activeSvc.AttendanceResult, error) {
 	return nil, nil
 }
+func (s *stubActiveService) CheckOutStudentFromDevice(_ context.Context, _, _ int64) (*activeSvc.AttendanceResult, error) {
+	return nil, nil
+}
 func (s *stubActiveService) CheckTeacherStudentAccess(_ context.Context, _, _ int64) (bool, error) {
 	return false, nil
 }

--- a/backend/api/active/tracking_handlers_test.go
+++ b/backend/api/active/tracking_handlers_test.go
@@ -335,6 +335,9 @@ func (m *trackingMockActiveService) CheckInStudent(ctx context.Context, studentI
 func (m *trackingMockActiveService) CheckOutStudent(ctx context.Context, studentID, staffID int64, skipAuthCheck bool) (*activeSvc.AttendanceResult, error) {
 	return nil, nil
 }
+func (m *trackingMockActiveService) CheckOutStudentFromDevice(ctx context.Context, studentID, deviceID int64) (*activeSvc.AttendanceResult, error) {
+	return nil, nil
+}
 func (m *trackingMockActiveService) CheckTeacherStudentAccess(ctx context.Context, teacherID, studentID int64) (bool, error) {
 	return false, nil
 }

--- a/backend/api/enrollment/admin_decision_handlers.go
+++ b/backend/api/enrollment/admin_decision_handlers.go
@@ -23,9 +23,10 @@ import (
 	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
-// AdminRequestSummary is the wire shape for the admin list page.
+// AdminRequestSummary is the wire shape for admin list-style responses.
 // Carries the request + per-child overview + the phase name so the
-// list can render without a second fetch.
+// list can render without a second fetch. It must not carry status_token:
+// the token authorizes parent-facing status/edit routes.
 //
 // CustomData + ConsentFlags + SchemaFields are populated on the
 // detail endpoint so the decision UI can render every parent-supplied
@@ -41,7 +42,6 @@ type AdminRequestSummary struct {
 	GuardianPhone     *string                   `json:"guardian_phone,omitempty"`
 	SubmittedAt       time.Time                 `json:"submitted_at"`
 	WithdrawnAt       *time.Time                `json:"withdrawn_at,omitempty"`
-	StatusToken       string                    `json:"status_token"`
 	CustomData        map[string]any            `json:"custom_data,omitempty"`
 	ConsentFlags      map[string]any            `json:"consent_flags,omitempty"`
 	SchemaFields      []AdminRequestSchemaField `json:"schema_fields,omitempty"`
@@ -53,6 +53,14 @@ type AdminRequestSummary struct {
 	// AdditionalGuardians are the co-guardians the parent added beyond the
 	// primary guardian above. Empty when none were added.
 	AdditionalGuardians []AdminRequestGuardian `json:"additional_guardians,omitempty"`
+}
+
+// AdminRequestDetail is the manage-only response shape for a single
+// enrollment request. It includes the parent status token because the
+// detail UI exposes a direct link to the parent status page.
+type AdminRequestDetail struct {
+	AdminRequestSummary
+	StatusToken string `json:"status_token"`
 }
 
 // AdminRequestGuardian is one additional guardian (co-guardian) within an
@@ -152,7 +160,6 @@ func toAdminRequestSummary(s *enrollmentService.RequestSummary) AdminRequestSumm
 		GuardianPhone:     s.Request.GuardianPhone,
 		SubmittedAt:       s.Request.SubmittedAt,
 		WithdrawnAt:       s.Request.WithdrawnAt,
-		StatusToken:       s.Request.StatusToken,
 	}
 	if s.Phase != nil {
 		out.PhaseName = s.Phase.Name
@@ -236,7 +243,7 @@ func (rs *Resource) getAdminRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var detail AdminRequestSummary
+	var detail AdminRequestDetail
 	err = rs.runInTenantTx(r, func(ctx context.Context) error {
 		s, e := rs.DecisionService.Get(ctx, id)
 		if e != nil {
@@ -275,7 +282,7 @@ func (rs *Resource) listAdminRequestsByStudent(w http.ResponseWriter, r *http.Re
 		}
 		out = make([]AdminRequestSummary, 0, len(summaries))
 		for _, summary := range summaries {
-			out = append(out, rs.toAdminRequestDetail(ctx, summary))
+			out = append(out, rs.toAdminRequestDetailSummary(ctx, summary))
 		}
 		return nil
 	})
@@ -286,7 +293,18 @@ func (rs *Resource) listAdminRequestsByStudent(w http.ResponseWriter, r *http.Re
 	common.Respond(w, r, http.StatusOK, out, "Student admin requests retrieved")
 }
 
-func (rs *Resource) toAdminRequestDetail(ctx context.Context, summary *enrollmentService.RequestSummary) AdminRequestSummary {
+func (rs *Resource) toAdminRequestDetail(ctx context.Context, summary *enrollmentService.RequestSummary) AdminRequestDetail {
+	detail := AdminRequestDetail{
+		AdminRequestSummary: rs.toAdminRequestDetailSummary(ctx, summary),
+	}
+	if summary == nil || summary.Request == nil {
+		return detail
+	}
+	detail.StatusToken = summary.Request.StatusToken
+	return detail
+}
+
+func (rs *Resource) toAdminRequestDetailSummary(ctx context.Context, summary *enrollmentService.RequestSummary) AdminRequestSummary {
 	detail := toAdminRequestSummary(summary)
 	if summary == nil || summary.Request == nil {
 		return detail

--- a/backend/api/enrollment/admin_decision_handlers_test.go
+++ b/backend/api/enrollment/admin_decision_handlers_test.go
@@ -234,6 +234,23 @@ func TestListAdminRequestsHandler_HappyPathReturns200(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"phase_name":"Schuljahr 2026"`)
 }
 
+func TestListAdminRequestsHandler_ConfigReadDoesNotReturnStatusToken(t *testing.T) {
+	summary := makeReqSummary(1234, 5678,
+		makeChildSummary(99, "Lara", "Beispiel", enrollmentModels.ChildStatusSubmitted),
+	)
+	summary.Request.StatusToken = "leaked-token"
+	mock := &mockDecisionService{
+		listResult: []*enrollmentService.RequestSummary{summary},
+	}
+	router := buildProtectedAdminDecisionRouter(mock)
+	w := executeAdminJSONWithPermissions(t, router, http.MethodGet, "/enrollment/admin/requests", []string{"config:read"})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	body := w.Body.String()
+	assert.NotContains(t, body, `"status_token"`)
+	assert.NotContains(t, body, "leaked-token")
+}
+
 func TestAdminRequestRoutes_DetailRequiresConfigManage(t *testing.T) {
 	mock := &mockDecisionService{
 		listResult: []*enrollmentService.RequestSummary{
@@ -338,10 +355,12 @@ func TestGetAdminRequestHandler_GenericErrorMappedAs500(t *testing.T) {
 }
 
 func TestGetAdminRequestHandler_HappyPathReturnsDetail(t *testing.T) {
+	summary := makeReqSummary(1234, 5678,
+		makeChildSummary(99, "Lara", "Beispiel", enrollmentModels.ChildStatusSubmitted),
+	)
+	summary.Request.StatusToken = "detail-token"
 	mock := &mockDecisionService{
-		getResult: makeReqSummary(1234, 5678,
-			makeChildSummary(99, "Lara", "Beispiel", enrollmentModels.ChildStatusSubmitted),
-		),
+		getResult: summary,
 	}
 	router := buildAdminDecisionRouter(mock)
 	w := executeAdminJSON(t, router, http.MethodGet, "/enrollment/admin/requests/1234", nil)
@@ -350,6 +369,7 @@ func TestGetAdminRequestHandler_HappyPathReturnsDetail(t *testing.T) {
 	assert.Contains(t, body, `"id":"1234"`)
 	assert.Contains(t, body, `"id":"99"`)
 	assert.Contains(t, body, `"date_of_birth":"2018-04-15"`)
+	assert.Contains(t, body, `"status_token":"detail-token"`)
 }
 
 func TestGetAdminRequestHandler_StitchesChildOfferings(t *testing.T) {

--- a/backend/api/enrollment/admin_handlers_helpers_test.go
+++ b/backend/api/enrollment/admin_handlers_helpers_test.go
@@ -1,6 +1,7 @@
 package enrollment
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -75,6 +76,21 @@ func TestToAdminRequestSummary_StringifiesIDsAndFormatsDOB(t *testing.T) {
 	assert.Equal(t, "2018-03-04", out.Children[0].DateOfBirth, "DOB rendered as YYYY-MM-DD")
 	assert.Equal(t, "submitted", out.Children[0].Status)
 	assert.Equal(t, "auto", out.Children[0].ActivationMode)
+}
+
+func TestToAdminRequestSummary_DoesNotExposeStatusToken(t *testing.T) {
+	req := mkRequest(1234, 5678)
+	req.StatusToken = "token-abc"
+
+	out := toAdminRequestSummary(&enrollmentService.RequestSummary{
+		Request:  req,
+		Children: []*enrollmentModels.RequestChild{},
+	})
+	raw, err := json.Marshal(out)
+	require.NoError(t, err)
+	body := string(raw)
+	assert.NotContains(t, body, "status_token")
+	assert.NotContains(t, body, "token-abc")
 }
 
 func TestToAdminRequestSummary_NilPhaseLeavesPhaseNameEmpty(t *testing.T) {

--- a/backend/api/iot/attendance/attendance_test.go
+++ b/backend/api/iot/attendance/attendance_test.go
@@ -594,9 +594,9 @@ func TestRouter_ReturnsValidRouter(t *testing.T) {
 // =============================================================================
 
 // TestToggleAttendance_DailyCheckoutZuhauseCheckedIn tests the daily checkout with
-// destination "zuhause" when the student is checked in. Real IoT daily-checkout
-// requests carry device context, but no staff context, so this guards against
-// routing through an insert path that would write checked_in_by=0.
+// destination "zuhause" when the student is checked in. Daily checkout must use
+// the device's active supervisor as checked_out_by; device+PIN alone is not an
+// auditable attendance principal.
 func TestToggleAttendance_DailyCheckoutZuhauseCheckedIn(t *testing.T) {
 	ctx := setupTestContext(t)
 	defer func() { _ = ctx.db.Close() }()
@@ -611,6 +611,18 @@ func TestToggleAttendance_DailyCheckoutZuhauseCheckedIn(t *testing.T) {
 	// Create attendance record: checked in, NOT checked out
 	checkInTime := time.Now().Add(-2 * time.Hour)
 	testpkg.CreateTestAttendance(t, ctx.db, student.ID, staff.ID, testDevice.ID, checkInTime, nil)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "daily-zuhause-checkedin-activity")
+	room := testpkg.CreateTestRoom(t, ctx.db, "Daily Zuhause CheckedIn Room")
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, room.ID)
+	_, err := ctx.db.NewUpdate().
+		Model(activeGroup).
+		ModelTableExpr(`active.groups`).
+		Set("device_id = ?", testDevice.ID).
+		Where("id = ?", activeGroup.ID).
+		Exec(context.Background())
+	require.NoError(t, err)
+	testpkg.CreateTestGroupSupervisor(t, ctx.db, staff.ID, activeGroup.ID, "supervisor")
 
 	router := testutil.NewTenantRouter(ctx.db)
 	router.Post("/toggle", ctx.resource.ToggleAttendanceHandler())
@@ -641,7 +653,7 @@ func TestToggleAttendance_DailyCheckoutZuhauseCheckedIn(t *testing.T) {
 	}
 
 	var records []*activeModel.Attendance
-	err := ctx.db.NewSelect().
+	err = ctx.db.NewSelect().
 		Model(&records).
 		ModelTableExpr(`active.attendance AS "attendance"`).
 		Where(`"attendance".student_id = ?`, student.ID).
@@ -650,7 +662,54 @@ func TestToggleAttendance_DailyCheckoutZuhauseCheckedIn(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, records, 1, "daily checkout must close the existing row instead of inserting a new one")
 	require.NotNil(t, records[0].CheckOutTime)
-	assert.Nil(t, records[0].CheckedOutBy, "IoT daily checkout without staff context must not write a bogus staff FK")
+	require.NotNil(t, records[0].CheckedOutBy, "IoT daily checkout must write an auditable staff FK")
+	assert.Equal(t, staff.ID, *records[0].CheckedOutBy)
+}
+
+func TestToggleAttendance_DailyCheckoutZuhauseRequiresDeviceSupervisor(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	testDevice := testpkg.CreateTestDevice(t, ctx.db, "daily-zuhause-no-supervisor-device")
+	student := testpkg.CreateTestStudent(t, ctx.db, "Zuhause", "NoSupervisor", "5x")
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Zuhause", "CheckInOnly")
+	rfidCard := testpkg.CreateTestRFIDCard(t, ctx.db, "TESTRFID_ZUHAUSE_NOSUP")
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, rfidCard.ID)
+
+	checkInTime := time.Now().Add(-2 * time.Hour)
+	testpkg.CreateTestAttendance(t, ctx.db, student.ID, staff.ID, testDevice.ID, checkInTime, nil)
+
+	router := testutil.NewTenantRouter(ctx.db)
+	router.Post("/toggle", ctx.resource.ToggleAttendanceHandler())
+
+	dest := "zuhause"
+	body := map[string]interface{}{
+		"rfid":        rfidCard.ID,
+		"action":      "confirm_daily_checkout",
+		"destination": dest,
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, "POST", "/toggle", body,
+		testutil.WithDeviceContext(testDevice),
+	)
+
+	rr := testutil.ExecuteRequest(router, req)
+
+	testutil.AssertErrorResponse(t, rr, http.StatusInternalServerError)
+	response := testutil.ParseResponse(t, rr.Body.Bytes())
+	assert.Contains(t, response.Error, "device must have an active group with supervisors")
+
+	var records []*activeModel.Attendance
+	err := ctx.db.NewSelect().
+		Model(&records).
+		ModelTableExpr(`active.attendance AS "attendance"`).
+		Where(`"attendance".student_id = ?`, student.ID).
+		Where(`"attendance".date = ?`, timezone.TodayDate()).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Nil(t, records[0].CheckOutTime, "daily checkout without supervisor must not close attendance")
+	assert.Nil(t, records[0].CheckedOutBy, "failed daily checkout must not write checkout attribution")
 }
 
 // TestToggleAttendance_DailyCheckoutZuhauseAlreadyCheckedOut tests the daily checkout with
@@ -905,6 +964,14 @@ func TestToggleAttendance_DailyCheckoutZuhause_EndsOpenVisit(t *testing.T) {
 	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "daily-zuhause-visit-activity")
 	room := testpkg.CreateTestRoom(t, ctx.db, "Daily Zuhause Visit Room")
 	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, room.ID)
+	_, err := ctx.db.NewUpdate().
+		Model(activeGroup).
+		ModelTableExpr(`active.groups`).
+		Set("device_id = ?", testDevice.ID).
+		Where("id = ?", activeGroup.ID).
+		Exec(context.Background())
+	require.NoError(t, err)
+	testpkg.CreateTestGroupSupervisor(t, ctx.db, staff.ID, activeGroup.ID, "supervisor")
 	visit := testpkg.CreateTestVisit(t, ctx.db, student.ID, activeGroup.ID, checkInTime, nil)
 
 	router := testutil.NewTenantRouter(ctx.db)
@@ -928,7 +995,7 @@ func TestToggleAttendance_DailyCheckoutZuhause_EndsOpenVisit(t *testing.T) {
 	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
 
 	var records []*activeModel.Attendance
-	err := ctx.db.NewSelect().
+	err = ctx.db.NewSelect().
 		Model(&records).
 		ModelTableExpr(`active.attendance AS "attendance"`).
 		Where(`"attendance".student_id = ?`, student.ID).
@@ -937,6 +1004,8 @@ func TestToggleAttendance_DailyCheckoutZuhause_EndsOpenVisit(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, records, 1)
 	require.NotNil(t, records[0].CheckOutTime, "daily checkout must close the attendance row")
+	require.NotNil(t, records[0].CheckedOutBy, "daily checkout must write the device supervisor as checkout principal")
+	assert.Equal(t, staff.ID, *records[0].CheckedOutBy)
 
 	endedVisit := new(activeModel.Visit)
 	err = ctx.db.NewSelect().

--- a/backend/api/iot/attendance/handlers.go
+++ b/backend/api/iot/attendance/handlers.go
@@ -106,7 +106,7 @@ func (rs *Resource) toggleAttendance(w http.ResponseWriter, r *http.Request) {
 
 	// Handle "confirm_daily_checkout" action - process the deferred daily checkout
 	if req.Action == "confirm_daily_checkout" {
-		rs.handleDailyCheckout(w, r, normalizedRFID, req)
+		rs.handleDailyCheckout(w, r, normalizedRFID, req, deviceCtx.ID)
 		return
 	}
 
@@ -171,7 +171,7 @@ func (rs *Resource) handleCancelAction(w http.ResponseWriter, r *http.Request) {
 // record when the student confirms "nach Hause". If a visit is still open,
 // CheckOutStudent ends it in the same request transaction (issue #895 — see
 // services/active.performCheckOut).
-func (rs *Resource) handleDailyCheckout(w http.ResponseWriter, r *http.Request, normalizedRFID string, req *AttendanceToggleRequest) {
+func (rs *Resource) handleDailyCheckout(w http.ResponseWriter, r *http.Request, normalizedRFID string, req *AttendanceToggleRequest, deviceID int64) {
 	// Find person by RFID tag
 	person, err := rs.UsersService.FindByTagID(r.Context(), normalizedRFID)
 	if err != nil || person == nil {
@@ -224,19 +224,10 @@ func (rs *Resource) handleDailyCheckout(w http.ResponseWriter, r *http.Request, 
 				slog.Int64("student_id", student.ID),
 			)
 		case "checked_in":
-			deviceCtx := device.DeviceFromCtx(r.Context())
-			if deviceCtx == nil {
-				slog.WarnContext(r.Context(), "device auth missing API key", slog.String("path", r.URL.Path))
-				if render.Render(w, r, device.ErrDeviceUnauthorized(device.ErrMissingAPIKey)) != nil {
-					http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				}
-				return
-			}
-
 			// Set attendance to "checked_out" — sets check_out_time on today's record.
 			// The active service resolves the device's active supervisor as the
 			// auditable checked_out_by principal before writing attendance.
-			_, err := rs.ActiveService.CheckOutStudentFromDevice(r.Context(), student.ID, deviceCtx.ID)
+			_, err := rs.ActiveService.CheckOutStudentFromDevice(r.Context(), student.ID, deviceID)
 			if err != nil {
 				slog.Default().ErrorContext(r.Context(), "failed to update attendance for daily checkout",
 					slog.Int64("student_id", student.ID),

--- a/backend/api/iot/attendance/handlers.go
+++ b/backend/api/iot/attendance/handlers.go
@@ -224,20 +224,25 @@ func (rs *Resource) handleDailyCheckout(w http.ResponseWriter, r *http.Request, 
 				slog.Int64("student_id", student.ID),
 			)
 		case "checked_in":
-			staffID := int64(0)
-			if staffCtx := device.StaffFromCtx(r.Context()); staffCtx != nil {
-				staffID = staffCtx.ID
+			deviceCtx := device.DeviceFromCtx(r.Context())
+			if deviceCtx == nil {
+				slog.WarnContext(r.Context(), "device auth missing API key", slog.String("path", r.URL.Path))
+				if render.Render(w, r, device.ErrDeviceUnauthorized(device.ErrMissingAPIKey)) != nil {
+					http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				}
+				return
 			}
 
 			// Set attendance to "checked_out" — sets check_out_time on today's record.
-			// skipAuthCheck=true because the IoT device already authenticated this request.
-			_, err := rs.ActiveService.CheckOutStudent(r.Context(), student.ID, staffID, true)
+			// The active service resolves the device's active supervisor as the
+			// auditable checked_out_by principal before writing attendance.
+			_, err := rs.ActiveService.CheckOutStudentFromDevice(r.Context(), student.ID, deviceCtx.ID)
 			if err != nil {
 				slog.Default().ErrorContext(r.Context(), "failed to update attendance for daily checkout",
 					slog.Int64("student_id", student.ID),
 					slog.String("error", err.Error()),
 				)
-				iotCommon.RenderError(w, r, iotCommon.ErrorInternalServer(err))
+				iotCommon.RenderError(w, r, iotCommon.ErrorRenderer(err))
 				return
 			}
 

--- a/backend/api/operator/api.go
+++ b/backend/api/operator/api.go
@@ -33,6 +33,7 @@ type Resource struct {
 	authRateLimiter         func(http.Handler) http.Handler
 	emailConfirmRateLimiter func(http.Handler) http.Handler
 	invitationRateLimiter   func(http.Handler) http.Handler
+	operatorLookup          OperatorLookup
 }
 
 // ResourceConfig holds dependencies for the operator resource
@@ -118,6 +119,7 @@ func NewResource(cfg ResourceConfig) *Resource {
 		invitationsResource:   NewInvitationsResource(cfg.InvitationService),
 		unregisteredTagScans:  cfg.UnregisteredTagScanService,
 		tokenAuth:             tokenAuth,
+		operatorLookup:        cfg.AuthService,
 	}
 	if cfg.SettingsService != nil {
 		resource.settingsResource = NewSettingsResource(cfg.SettingsService, cfg.DB, cfg.Broadcaster, cfg.SchoolService, cfg.ActiveService)
@@ -201,6 +203,7 @@ func (rs *Resource) Router() chi.Router {
 		r.Use(rs.tokenAuth.Verifier())
 		r.Use(jwt.Authenticator)
 		r.Use(RequiresOperatorScope)
+		r.Use(RequiresActiveOperator(rs.operatorLookup))
 
 		// Passkey management for the currently-authenticated operator.
 		// Keep these as individual leaves instead of r.Route("/auth/passkeys", ...)

--- a/backend/api/operator/api_test.go
+++ b/backend/api/operator/api_test.go
@@ -1,9 +1,13 @@
 package operator_test
 
 import (
+	"bytes"
 	"context"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
@@ -11,7 +15,9 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/api/operator"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
 	configSvc "github.com/moto-nrw/project-phoenix/services/config"
+	platformSvc "github.com/moto-nrw/project-phoenix/services/platform"
 )
 
 // chiWalk traverses all routes in the chi.Router and calls fn for each
@@ -67,6 +73,18 @@ func (stubSettingsService) SetLoginImageURL(context.Context, int64, string) (str
 }
 func (stubSettingsService) ClearLoginImageURL(context.Context, int64) (string, error) {
 	return "", nil
+}
+
+type protectedRouteProvisioningService struct {
+	platformSvc.OperatorProvisioningService
+	createSchoolFn func(context.Context, *platformModels.School, int64, net.IP) (*platformModels.School, error)
+}
+
+func (s *protectedRouteProvisioningService) CreateSchool(ctx context.Context, school *platformModels.School, operatorID int64, clientIP net.IP) (*platformModels.School, error) {
+	if s.createSchoolFn != nil {
+		return s.createSchoolFn(ctx, school, operatorID, clientIP)
+	}
+	return school, nil
 }
 
 // TestNewResource verifies that the operator resource can be constructed successfully.
@@ -165,4 +183,100 @@ func TestRouter(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, found, "expected settings routes NOT to be mounted when SettingsService is nil")
 	})
+}
+
+func TestProtectedOperatorRoutesRejectInactiveOperator(t *testing.T) {
+	tokenAuth := newOperatorRouteTokenAuth(t)
+	accessToken := operatorRouteAccessToken(t, tokenAuth, 42)
+	authService := &mockOperatorAuthService{
+		getOperatorFn: func(_ context.Context, id int64) (*platformModels.Operator, error) {
+			assert.Equal(t, int64(42), id)
+			op := &platformModels.Operator{Active: false}
+			op.ID = id
+			return op, nil
+		},
+	}
+	provisioningService := &protectedRouteProvisioningService{
+		createSchoolFn: func(context.Context, *platformModels.School, int64, net.IP) (*platformModels.School, error) {
+			t.Fatal("inactive operator reached protected provisioning handler")
+			return nil, nil
+		},
+	}
+	router := operator.NewResource(operator.ResourceConfig{
+		AuthService:         authService,
+		ProvisioningService: provisioningService,
+		TokenAuth:           tokenAuth,
+	}).Router()
+
+	req := newCreateSchoolRequest(accessToken)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Operator account is inactive")
+}
+
+func TestProtectedOperatorRoutesAllowActiveOperator(t *testing.T) {
+	tokenAuth := newOperatorRouteTokenAuth(t)
+	accessToken := operatorRouteAccessToken(t, tokenAuth, 42)
+	authService := &mockOperatorAuthService{
+		getOperatorFn: func(_ context.Context, id int64) (*platformModels.Operator, error) {
+			assert.Equal(t, int64(42), id)
+			op := &platformModels.Operator{Active: true}
+			op.ID = id
+			return op, nil
+		},
+	}
+	createSchoolCalled := false
+	provisioningService := &protectedRouteProvisioningService{
+		createSchoolFn: func(_ context.Context, school *platformModels.School, operatorID int64, clientIP net.IP) (*platformModels.School, error) {
+			createSchoolCalled = true
+			assert.Equal(t, int64(42), operatorID)
+			assert.Equal(t, int64(7), school.OrganizationID)
+			assert.Equal(t, "school@example.com", school.Email)
+			school.ID = 88
+			return school, nil
+		},
+	}
+	router := operator.NewResource(operator.ResourceConfig{
+		AuthService:         authService,
+		ProvisioningService: provisioningService,
+		TokenAuth:           tokenAuth,
+	}).Router()
+
+	req := newCreateSchoolRequest(accessToken)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	assert.True(t, createSchoolCalled, "active operator should reach protected provisioning handler")
+}
+
+func newOperatorRouteTokenAuth(t *testing.T) *jwt.TokenAuth {
+	t.Helper()
+	tokenAuth, err := jwt.NewTokenAuthWithSecret("operator-route-test-secret-123456")
+	require.NoError(t, err)
+	tokenAuth.JwtExpiry = 15 * time.Minute
+	return tokenAuth
+}
+
+func operatorRouteAccessToken(t *testing.T, tokenAuth *jwt.TokenAuth, operatorID int) string {
+	t.Helper()
+	token, err := tokenAuth.CreateJWT(jwt.AppClaims{
+		ID:    operatorID,
+		Sub:   "operator-route-test",
+		Roles: []string{"operator"},
+		Scope: "platform",
+	})
+	require.NoError(t, err)
+	return token
+}
+
+func newCreateSchoolRequest(accessToken string) *http.Request {
+	body := `{"organization_id":7,"name":"Test School","slug":"test-school","subdomain":"test-sub","email":"school@example.com"}`
+	req := httptest.NewRequest(http.MethodPost, "/schools", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.RemoteAddr = "198.51.100.20:4444"
+	return req
 }

--- a/backend/api/operator/api_test.go
+++ b/backend/api/operator/api_test.go
@@ -3,6 +3,7 @@ package operator_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -208,7 +209,7 @@ func TestProtectedOperatorRoutesRejectInactiveOperator(t *testing.T) {
 		TokenAuth:           tokenAuth,
 	}).Router()
 
-	req := newCreateSchoolRequest(accessToken)
+	req := newCreateSchoolRequest(accessToken, 7)
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -219,6 +220,7 @@ func TestProtectedOperatorRoutesRejectInactiveOperator(t *testing.T) {
 func TestProtectedOperatorRoutesAllowActiveOperator(t *testing.T) {
 	tokenAuth := newOperatorRouteTokenAuth(t)
 	accessToken := operatorRouteAccessToken(t, tokenAuth, 42)
+	organizationID := 7
 	authService := &mockOperatorAuthService{
 		getOperatorFn: func(_ context.Context, id int64) (*platformModels.Operator, error) {
 			assert.Equal(t, int64(42), id)
@@ -232,7 +234,7 @@ func TestProtectedOperatorRoutesAllowActiveOperator(t *testing.T) {
 		createSchoolFn: func(_ context.Context, school *platformModels.School, operatorID int64, clientIP net.IP) (*platformModels.School, error) {
 			createSchoolCalled = true
 			assert.Equal(t, int64(42), operatorID)
-			assert.Equal(t, int64(7), school.OrganizationID)
+			assert.Equal(t, int64(organizationID), school.OrganizationID)
 			assert.Equal(t, "school@example.com", school.Email)
 			school.ID = 88
 			return school, nil
@@ -244,7 +246,7 @@ func TestProtectedOperatorRoutesAllowActiveOperator(t *testing.T) {
 		TokenAuth:           tokenAuth,
 	}).Router()
 
-	req := newCreateSchoolRequest(accessToken)
+	req := newCreateSchoolRequest(accessToken, organizationID)
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -272,8 +274,8 @@ func operatorRouteAccessToken(t *testing.T, tokenAuth *jwt.TokenAuth, operatorID
 	return token
 }
 
-func newCreateSchoolRequest(accessToken string) *http.Request {
-	body := `{"organization_id":7,"name":"Test School","slug":"test-school","subdomain":"test-sub","email":"school@example.com"}`
+func newCreateSchoolRequest(accessToken string, organizationID int) *http.Request {
+	body := fmt.Sprintf(`{"organization_id":%d,"name":"Test School","slug":"test-school","subdomain":"test-sub","email":"school@example.com"}`, organizationID)
 	req := httptest.NewRequest(http.MethodPost, "/schools", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+accessToken)

--- a/backend/api/operator/auth.go
+++ b/backend/api/operator/auth.go
@@ -4,7 +4,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"strings"
 
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/go-chi/render"
@@ -179,13 +178,15 @@ func (rs *AuthResource) RefreshToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify this is an operator-scoped refresh token, not a tenant/user token
-	if !strings.HasPrefix(claims.Token, "operator-refresh-") {
+	// Verify this is an operator-scoped refresh token, not a tenant/user token.
+	// Pre-fix deterministic operator refresh tokens had no persisted session
+	// and no platform scope claim; reject them here before the service lookup.
+	if claims.Scope != "platform" || claims.Token == "" {
 		common.RenderError(w, r, ErrUnauthorized())
 		return
 	}
 
-	accessToken, refreshToken, err := rs.authService.RefreshToken(r.Context(), int64(claims.ID))
+	accessToken, refreshToken, err := rs.authService.RefreshToken(r.Context(), int64(claims.ID), claims.Token)
 	if err != nil {
 		common.RenderError(w, r, AuthErrorRenderer(err))
 		return

--- a/backend/api/operator/auth_test.go
+++ b/backend/api/operator/auth_test.go
@@ -23,7 +23,7 @@ import (
 // Mock OperatorAuthService
 type mockOperatorAuthService struct {
 	loginFn                          func(ctx context.Context, email, password string, clientIP net.IP) (string, string, *platform.Operator, error)
-	refreshTokenFn                   func(ctx context.Context, operatorID int64) (string, string, error)
+	refreshTokenFn                   func(ctx context.Context, operatorID int64, refreshTokenValue string) (string, string, error)
 	getOperatorFn                    func(ctx context.Context, id int64) (*platform.Operator, error)
 	updateProfileFn                  func(ctx context.Context, operatorID int64, displayName string) (*platform.Operator, error)
 	changePasswordFn                 func(ctx context.Context, operatorID int64, currentPassword, newPassword string) error
@@ -60,9 +60,9 @@ func (m *mockOperatorAuthService) IssueTokensForAuthenticatedOperator(ctx contex
 	return "", "", nil
 }
 
-func (m *mockOperatorAuthService) RefreshToken(ctx context.Context, operatorID int64) (string, string, error) {
+func (m *mockOperatorAuthService) RefreshToken(ctx context.Context, operatorID int64, refreshTokenValue string) (string, string, error) {
 	if m.refreshTokenFn != nil {
-		return m.refreshTokenFn(ctx, operatorID)
+		return m.refreshTokenFn(ctx, operatorID, refreshTokenValue)
 	}
 	return "", "", nil
 }
@@ -382,8 +382,9 @@ func TestLoginRequest_Bind(t *testing.T) {
 
 func TestRefreshToken_Success(t *testing.T) {
 	mockService := &mockOperatorAuthService{
-		refreshTokenFn: func(ctx context.Context, operatorID int64) (string, string, error) {
+		refreshTokenFn: func(ctx context.Context, operatorID int64, refreshTokenValue string) (string, string, error) {
 			assert.Equal(t, int64(42), operatorID)
+			assert.Equal(t, "opaque-refresh-handle", refreshTokenValue)
 			return "new-access-token", "new-refresh-token", nil
 		},
 	}
@@ -394,7 +395,8 @@ func TestRefreshToken_Success(t *testing.T) {
 	tokenAuth := jwtauth.New("HS256", []byte("test-secret"), nil)
 	_, tokenString, _ := tokenAuth.Encode(map[string]interface{}{
 		"id":    float64(42),
-		"token": "operator-refresh-42",
+		"token": "opaque-refresh-handle",
+		"scope": "platform",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
@@ -450,9 +452,68 @@ func TestRefreshToken_InvalidClaims(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "Unauthorized")
 }
 
+func TestRefreshToken_RejectsNonPlatformScope(t *testing.T) {
+	called := false
+	mockService := &mockOperatorAuthService{
+		refreshTokenFn: func(ctx context.Context, operatorID int64, refreshTokenValue string) (string, string, error) {
+			called = true
+			return "", "", nil
+		},
+	}
+	resource := operator.NewAuthResource(mockService)
+
+	tokenAuth := jwtauth.New("HS256", []byte("test-secret"), nil)
+	_, tokenString, _ := tokenAuth.Encode(map[string]interface{}{
+		"id":        float64(42),
+		"token":     "tenant-refresh-handle",
+		"tenant_id": float64(1),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
+	ctx := context.WithValue(req.Context(), jwtPkg.CtxRefreshToken, tokenString)
+	token, _ := jwtauth.VerifyToken(tokenAuth, tokenString)
+	ctx = jwtauth.NewContext(ctx, token, nil)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	resource.RefreshToken(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.False(t, called, "non-platform refresh claims must be rejected before service rotation")
+}
+
+func TestRefreshToken_RejectsLegacyDeterministicOperatorToken(t *testing.T) {
+	called := false
+	mockService := &mockOperatorAuthService{
+		refreshTokenFn: func(ctx context.Context, operatorID int64, refreshTokenValue string) (string, string, error) {
+			called = true
+			return "", "", nil
+		},
+	}
+	resource := operator.NewAuthResource(mockService)
+
+	tokenAuth := jwtauth.New("HS256", []byte("test-secret"), nil)
+	_, tokenString, _ := tokenAuth.Encode(map[string]interface{}{
+		"id":    float64(42),
+		"token": "operator-refresh-42",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
+	ctx := context.WithValue(req.Context(), jwtPkg.CtxRefreshToken, tokenString)
+	token, _ := jwtauth.VerifyToken(tokenAuth, tokenString)
+	ctx = jwtauth.NewContext(ctx, token, nil)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	resource.RefreshToken(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.False(t, called, "legacy deterministic operator refresh claims must not reach the service")
+}
+
 func TestRefreshToken_ServiceError(t *testing.T) {
 	mockService := &mockOperatorAuthService{
-		refreshTokenFn: func(ctx context.Context, operatorID int64) (string, string, error) {
+		refreshTokenFn: func(ctx context.Context, operatorID int64, refreshTokenValue string) (string, string, error) {
 			return "", "", &platformSvc.OperatorInactiveError{}
 		},
 	}
@@ -462,7 +523,8 @@ func TestRefreshToken_ServiceError(t *testing.T) {
 	tokenAuth := jwtauth.New("HS256", []byte("test-secret"), nil)
 	_, tokenString, _ := tokenAuth.Encode(map[string]interface{}{
 		"id":    float64(42),
-		"token": "operator-refresh-42",
+		"token": "opaque-refresh-handle",
+		"scope": "platform",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
@@ -478,4 +540,33 @@ func TestRefreshToken_ServiceError(t *testing.T) {
 
 	assert.Equal(t, http.StatusForbidden, rr.Code)
 	assert.Contains(t, rr.Body.String(), "Operator account is inactive")
+}
+
+func TestRefreshToken_InvalidRefreshSessionMapsToUnauthorized(t *testing.T) {
+	mockService := &mockOperatorAuthService{
+		refreshTokenFn: func(ctx context.Context, operatorID int64, refreshTokenValue string) (string, string, error) {
+			return "", "", &platformSvc.OperatorRefreshTokenInvalidError{}
+		},
+	}
+	resource := operator.NewAuthResource(mockService)
+
+	tokenAuth := jwtauth.New("HS256", []byte("test-secret"), nil)
+	_, tokenString, _ := tokenAuth.Encode(map[string]interface{}{
+		"id":    float64(42),
+		"token": "stale-refresh-handle",
+		"scope": "platform",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
+	ctx := context.WithValue(req.Context(), jwtPkg.CtxRefreshToken, tokenString)
+	token, _ := jwtauth.VerifyToken(tokenAuth, tokenString)
+	ctx = jwtauth.NewContext(ctx, token, nil)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	resource.RefreshToken(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Unauthorized")
+	assert.NotContains(t, rr.Body.String(), "Invalid email or password")
 }

--- a/backend/api/operator/errors.go
+++ b/backend/api/operator/errors.go
@@ -98,8 +98,11 @@ func AuthErrorRenderer(err error) render.Renderer {
 	var invalidCreds *platformSvc.InvalidCredentialsError
 	var operatorInactive *platformSvc.OperatorInactiveError
 	var operatorNotFound *platformSvc.OperatorNotFoundError
+	var invalidRefresh *platformSvc.OperatorRefreshTokenInvalidError
 
 	switch {
+	case errors.As(err, &invalidRefresh):
+		return ErrUnauthorized()
 	case errors.As(err, &invalidCreds):
 		return ErrInvalidCredentials()
 	case errors.As(err, &operatorInactive):

--- a/backend/api/operator/middleware.go
+++ b/backend/api/operator/middleware.go
@@ -1,12 +1,23 @@
 package operator
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 
 	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
+	platformSvc "github.com/moto-nrw/project-phoenix/services/platform"
 )
+
+// OperatorLookup reloads the current platform operator state for protected
+// operator routes.
+type OperatorLookup interface {
+	GetOperator(ctx context.Context, id int64) (*platformModels.Operator, error)
+}
 
 // RequiresOperatorScope is middleware that checks if the JWT has platform scope
 // This ensures only operator tokens (not tenant tokens) can access operator routes
@@ -32,6 +43,64 @@ func RequiresOperatorScope(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// RequiresActiveOperator rejects stale access tokens after an operator account
+// is deactivated or removed.
+func RequiresActiveOperator(lookup OperatorLookup) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			claims := jwt.ClaimsFromCtx(r.Context())
+			if claims.ID <= 0 {
+				common.RenderError(w, r, ErrUnauthorized())
+				return
+			}
+			if lookup == nil {
+				slog.ErrorContext(r.Context(), "operator status lookup is not configured",
+					slog.String("path", r.URL.Path),
+					slog.Int("operator_id", claims.ID),
+				)
+				common.RenderError(w, r, ErrServiceUnavailable("Operator status temporarily unavailable, please retry"))
+				return
+			}
+
+			operator, err := lookup.GetOperator(r.Context(), int64(claims.ID))
+			if err != nil {
+				renderOperatorLookupError(w, r, claims.ID, err)
+				return
+			}
+			if operator == nil {
+				common.RenderError(w, r, AuthErrorRenderer(&platformSvc.OperatorNotFoundError{
+					OperatorID: int64(claims.ID),
+				}))
+				return
+			}
+			if !operator.Active {
+				common.RenderError(w, r, AuthErrorRenderer(&platformSvc.OperatorInactiveError{
+					OperatorID: operator.ID,
+				}))
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func renderOperatorLookupError(w http.ResponseWriter, r *http.Request, operatorID int, err error) {
+	var inactive *platformSvc.OperatorInactiveError
+	var notFound *platformSvc.OperatorNotFoundError
+	if errors.As(err, &inactive) || errors.As(err, &notFound) {
+		common.RenderError(w, r, AuthErrorRenderer(err))
+		return
+	}
+
+	slog.ErrorContext(r.Context(), "operator status lookup failed",
+		slog.String("path", r.URL.Path),
+		slog.Int("operator_id", operatorID),
+		slog.String("error", err.Error()),
+	)
+	common.RenderError(w, r, ErrServiceUnavailable("Operator status temporarily unavailable, please retry"))
 }
 
 // ErrResponse is an error response struct

--- a/backend/api/operator/middleware_test.go
+++ b/backend/api/operator/middleware_test.go
@@ -119,6 +119,22 @@ func TestRequiresActiveOperator_ActiveOperator(t *testing.T) {
 	assert.True(t, nextCalled, "next handler should have been called")
 }
 
+func TestRequiresActiveOperator_MissingLookupFailsClosed(t *testing.T) {
+	nextCalled := false
+	handler := operator.RequiresActiveOperator(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := requestWithOperatorClaims(42)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Operator status temporarily unavailable")
+	assert.False(t, nextCalled, "missing operator lookup must not reach protected handlers")
+}
+
 func TestRequiresActiveOperator_InactiveOperator(t *testing.T) {
 	nextCalled := false
 	handler := operator.RequiresActiveOperator(operatorLookupStub{
@@ -139,6 +155,26 @@ func TestRequiresActiveOperator_InactiveOperator(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rr.Code)
 	assert.Contains(t, rr.Body.String(), "Operator account is inactive")
 	assert.False(t, nextCalled, "inactive operators must not reach protected handlers")
+}
+
+func TestRequiresActiveOperator_NilOperatorFailsClosed(t *testing.T) {
+	nextCalled := false
+	handler := operator.RequiresActiveOperator(operatorLookupStub{
+		getOperatorFn: func(context.Context, int64) (*platformModels.Operator, error) {
+			return nil, nil
+		},
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := requestWithOperatorClaims(42)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Invalid email or password")
+	assert.False(t, nextCalled, "nil operator lookups must not reach protected handlers")
 }
 
 func TestRequiresActiveOperator_OperatorNotFound(t *testing.T) {

--- a/backend/api/operator/middleware_test.go
+++ b/backend/api/operator/middleware_test.go
@@ -2,6 +2,7 @@ package operator_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,7 +12,20 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/api/operator"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
+	platformSvc "github.com/moto-nrw/project-phoenix/services/platform"
 )
+
+type operatorLookupStub struct {
+	getOperatorFn func(context.Context, int64) (*platformModels.Operator, error)
+}
+
+func (s operatorLookupStub) GetOperator(ctx context.Context, id int64) (*platformModels.Operator, error) {
+	if s.getOperatorFn != nil {
+		return s.getOperatorFn(ctx, id)
+	}
+	return nil, nil
+}
 
 func TestRequiresOperatorScope_ValidOperatorToken(t *testing.T) {
 	// Create a next handler that records if it was called
@@ -81,6 +95,115 @@ func TestRequiresOperatorScope_NoClaims(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestRequiresActiveOperator_ActiveOperator(t *testing.T) {
+	nextCalled := false
+	handler := operator.RequiresActiveOperator(operatorLookupStub{
+		getOperatorFn: func(_ context.Context, id int64) (*platformModels.Operator, error) {
+			assert.Equal(t, int64(42), id)
+			op := &platformModels.Operator{Active: true}
+			op.ID = id
+			return op, nil
+		},
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := requestWithOperatorClaims(42)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.True(t, nextCalled, "next handler should have been called")
+}
+
+func TestRequiresActiveOperator_InactiveOperator(t *testing.T) {
+	nextCalled := false
+	handler := operator.RequiresActiveOperator(operatorLookupStub{
+		getOperatorFn: func(_ context.Context, id int64) (*platformModels.Operator, error) {
+			op := &platformModels.Operator{Active: false}
+			op.ID = id
+			return op, nil
+		},
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := requestWithOperatorClaims(42)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Operator account is inactive")
+	assert.False(t, nextCalled, "inactive operators must not reach protected handlers")
+}
+
+func TestRequiresActiveOperator_OperatorNotFound(t *testing.T) {
+	nextCalled := false
+	handler := operator.RequiresActiveOperator(operatorLookupStub{
+		getOperatorFn: func(context.Context, int64) (*platformModels.Operator, error) {
+			return nil, &platformSvc.OperatorNotFoundError{OperatorID: 42}
+		},
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := requestWithOperatorClaims(42)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.False(t, nextCalled, "missing operators must not reach protected handlers")
+}
+
+func TestRequiresActiveOperator_LookupErrorFailsClosed(t *testing.T) {
+	nextCalled := false
+	handler := operator.RequiresActiveOperator(operatorLookupStub{
+		getOperatorFn: func(context.Context, int64) (*platformModels.Operator, error) {
+			return nil, errors.New("database unavailable")
+		},
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := requestWithOperatorClaims(42)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	assert.False(t, nextCalled, "lookup failures must not reach protected handlers")
+}
+
+func TestRequiresActiveOperator_MissingOperatorID(t *testing.T) {
+	nextCalled := false
+	handler := operator.RequiresActiveOperator(operatorLookupStub{
+		getOperatorFn: func(context.Context, int64) (*platformModels.Operator, error) {
+			t.Fatal("operator lookup should not run without an authenticated operator id")
+			return nil, nil
+		},
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.False(t, nextCalled, "requests without operator identity must not reach protected handlers")
+}
+
+func requestWithOperatorClaims(operatorID int) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	claims := jwt.AppClaims{ID: operatorID, Scope: "platform"}
+	ctx := context.WithValue(req.Context(), jwt.CtxClaims, claims)
+	return req.WithContext(ctx)
 }
 
 func TestErrResponse_Render(t *testing.T) {

--- a/backend/api/sse/resolve_supervisions_internal_test.go
+++ b/backend/api/sse/resolve_supervisions_internal_test.go
@@ -317,6 +317,9 @@ func (m *mockActiveSvcForSSE) CheckInStudent(_ context.Context, _, _, _ int64, _
 func (m *mockActiveSvcForSSE) CheckOutStudent(_ context.Context, _, _ int64, _ bool) (*activeSvc.AttendanceResult, error) {
 	return nil, nil
 }
+func (m *mockActiveSvcForSSE) CheckOutStudentFromDevice(_ context.Context, _, _ int64) (*activeSvc.AttendanceResult, error) {
+	return nil, nil
+}
 func (m *mockActiveSvcForSSE) CheckTeacherStudentAccess(_ context.Context, _, _ int64) (bool, error) {
 	return false, nil
 }

--- a/backend/database/migrations/001015147_operator_refresh_tokens.go
+++ b/backend/database/migrations/001015147_operator_refresh_tokens.go
@@ -1,0 +1,70 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	operatorRefreshTokensVersion     = "1.15.147"
+	operatorRefreshTokensDescription = "Persist revocable operator refresh sessions so password rotation and token replay can invalidate platform sessions."
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     operatorRefreshTokensVersion,
+		Description: operatorRefreshTokensDescription,
+		DependsOn:   []string{guardianHasAccountCheckVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Migration 1.15.147: Creating platform.operator_refresh_tokens...")
+			if _, err := db.NewRaw(`
+				CREATE TABLE IF NOT EXISTS platform.operator_refresh_tokens (
+					id BIGSERIAL PRIMARY KEY,
+					operator_id BIGINT NOT NULL REFERENCES platform.operators(id) ON DELETE CASCADE,
+					token TEXT NOT NULL UNIQUE,
+					expiry TIMESTAMPTZ NOT NULL,
+					family_id TEXT NOT NULL,
+					generation INTEGER NOT NULL DEFAULT 0,
+					created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+				);
+
+				CREATE INDEX IF NOT EXISTS idx_operator_refresh_tokens_operator_id
+					ON platform.operator_refresh_tokens(operator_id);
+				CREATE INDEX IF NOT EXISTS idx_operator_refresh_tokens_expiry
+					ON platform.operator_refresh_tokens(expiry);
+				CREATE INDEX IF NOT EXISTS idx_operator_refresh_tokens_family_id
+					ON platform.operator_refresh_tokens(family_id);
+
+				DROP TRIGGER IF EXISTS update_operator_refresh_tokens_updated_at
+					ON platform.operator_refresh_tokens;
+				CREATE TRIGGER update_operator_refresh_tokens_updated_at
+					BEFORE UPDATE ON platform.operator_refresh_tokens
+					FOR EACH ROW
+					EXECUTE FUNCTION update_modified_column();
+
+				GRANT SELECT, INSERT, UPDATE, DELETE ON platform.operator_refresh_tokens TO phoenix_auth;
+				GRANT USAGE, SELECT ON SEQUENCE platform.operator_refresh_tokens_id_seq TO phoenix_auth;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed creating operator refresh tokens: %w", err)
+			}
+			return nil
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Rolling back migration 1.15.147: Dropping platform.operator_refresh_tokens...")
+			if _, err := db.NewRaw(`
+				DROP TRIGGER IF EXISTS update_operator_refresh_tokens_updated_at
+					ON platform.operator_refresh_tokens;
+				DROP TABLE IF EXISTS platform.operator_refresh_tokens CASCADE;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed dropping operator refresh tokens: %w", err)
+			}
+			return nil
+		},
+	)
+}

--- a/backend/database/migrations/001015147_operator_refresh_tokens.go
+++ b/backend/database/migrations/001015147_operator_refresh_tokens.go
@@ -19,52 +19,53 @@ func init() {
 		DependsOn:   []string{guardianHasAccountCheckVersion},
 	})
 
-	Migrations.MustRegister(
-		func(ctx context.Context, db *bun.DB) error {
-			fmt.Println("Migration 1.15.147: Creating platform.operator_refresh_tokens...")
-			if _, err := db.NewRaw(`
-				CREATE TABLE IF NOT EXISTS platform.operator_refresh_tokens (
-					id BIGSERIAL PRIMARY KEY,
-					operator_id BIGINT NOT NULL REFERENCES platform.operators(id) ON DELETE CASCADE,
-					token TEXT NOT NULL UNIQUE,
-					expiry TIMESTAMPTZ NOT NULL,
-					family_id TEXT NOT NULL,
-					generation INTEGER NOT NULL DEFAULT 0,
-					created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-					updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-				);
+	Migrations.MustRegister(upOperatorRefreshTokens, downOperatorRefreshTokens)
+}
 
-				CREATE INDEX IF NOT EXISTS idx_operator_refresh_tokens_operator_id
-					ON platform.operator_refresh_tokens(operator_id);
-				CREATE INDEX IF NOT EXISTS idx_operator_refresh_tokens_expiry
-					ON platform.operator_refresh_tokens(expiry);
-				CREATE INDEX IF NOT EXISTS idx_operator_refresh_tokens_family_id
-					ON platform.operator_refresh_tokens(family_id);
+func upOperatorRefreshTokens(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.147: Creating platform.operator_refresh_tokens...")
+	if _, err := db.NewRaw(`
+		CREATE TABLE IF NOT EXISTS platform.operator_refresh_tokens (
+			id BIGSERIAL PRIMARY KEY,
+			operator_id BIGINT NOT NULL REFERENCES platform.operators(id) ON DELETE CASCADE,
+			token TEXT NOT NULL UNIQUE,
+			expiry TIMESTAMPTZ NOT NULL,
+			family_id TEXT NOT NULL,
+			generation INTEGER NOT NULL DEFAULT 0,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
 
-				DROP TRIGGER IF EXISTS update_operator_refresh_tokens_updated_at
-					ON platform.operator_refresh_tokens;
-				CREATE TRIGGER update_operator_refresh_tokens_updated_at
-					BEFORE UPDATE ON platform.operator_refresh_tokens
-					FOR EACH ROW
-					EXECUTE FUNCTION update_modified_column();
+		CREATE INDEX IF NOT EXISTS idx_operator_refresh_tokens_operator_id
+			ON platform.operator_refresh_tokens(operator_id);
+		CREATE INDEX IF NOT EXISTS idx_operator_refresh_tokens_expiry
+			ON platform.operator_refresh_tokens(expiry);
+		CREATE INDEX IF NOT EXISTS idx_operator_refresh_tokens_family_id
+			ON platform.operator_refresh_tokens(family_id);
 
-				GRANT SELECT, INSERT, UPDATE, DELETE ON platform.operator_refresh_tokens TO phoenix_auth;
-				GRANT USAGE, SELECT ON SEQUENCE platform.operator_refresh_tokens_id_seq TO phoenix_auth;
-			`).Exec(ctx); err != nil {
-				return fmt.Errorf("failed creating operator refresh tokens: %w", err)
-			}
-			return nil
-		},
-		func(ctx context.Context, db *bun.DB) error {
-			fmt.Println("Rolling back migration 1.15.147: Dropping platform.operator_refresh_tokens...")
-			if _, err := db.NewRaw(`
-				DROP TRIGGER IF EXISTS update_operator_refresh_tokens_updated_at
-					ON platform.operator_refresh_tokens;
-				DROP TABLE IF EXISTS platform.operator_refresh_tokens CASCADE;
-			`).Exec(ctx); err != nil {
-				return fmt.Errorf("failed dropping operator refresh tokens: %w", err)
-			}
-			return nil
-		},
-	)
+		DROP TRIGGER IF EXISTS update_operator_refresh_tokens_updated_at
+			ON platform.operator_refresh_tokens;
+		CREATE TRIGGER update_operator_refresh_tokens_updated_at
+			BEFORE UPDATE ON platform.operator_refresh_tokens
+			FOR EACH ROW
+			EXECUTE FUNCTION update_modified_column();
+
+		GRANT SELECT, INSERT, UPDATE, DELETE ON platform.operator_refresh_tokens TO phoenix_auth;
+		GRANT USAGE, SELECT ON SEQUENCE platform.operator_refresh_tokens_id_seq TO phoenix_auth;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed creating operator refresh tokens: %w", err)
+	}
+	return nil
+}
+
+func downOperatorRefreshTokens(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.147: Dropping platform.operator_refresh_tokens...")
+	if _, err := db.NewRaw(`
+		DROP TRIGGER IF EXISTS update_operator_refresh_tokens_updated_at
+			ON platform.operator_refresh_tokens;
+		DROP TABLE IF EXISTS platform.operator_refresh_tokens CASCADE;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed dropping operator refresh tokens: %w", err)
+	}
+	return nil
 }

--- a/backend/database/migrations/migrations_test.go
+++ b/backend/database/migrations/migrations_test.go
@@ -1,11 +1,15 @@
 package migrations
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/uptrace/bun"
 )
 
 func TestNoDuplicateMigrationVersions(t *testing.T) {
@@ -107,4 +111,43 @@ func TestScheduleTimeframesAreMigratedToTimezoneFreeClockTimes(t *testing.T) {
 			t.Fatalf("timeframe clock migration must contain %q", required)
 		}
 	}
+}
+
+func TestOperatorRefreshTokenMigrationUpDown(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+
+	if err := downOperatorRefreshTokens(ctx, db); err != nil {
+		t.Fatalf("pre-clean operator refresh token migration: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = upOperatorRefreshTokens(context.Background(), db)
+	})
+
+	if err := upOperatorRefreshTokens(ctx, db); err != nil {
+		t.Fatalf("run operator refresh token migration: %v", err)
+	}
+	if !relationExists(t, db, "platform.operator_refresh_tokens") {
+		t.Fatal("operator refresh token table was not created")
+	}
+	if !relationExists(t, db, "platform.idx_operator_refresh_tokens_operator_id") {
+		t.Fatal("operator refresh token operator_id index was not created")
+	}
+
+	if err := downOperatorRefreshTokens(ctx, db); err != nil {
+		t.Fatalf("rollback operator refresh token migration: %v", err)
+	}
+	if relationExists(t, db, "platform.operator_refresh_tokens") {
+		t.Fatal("operator refresh token table still exists after rollback")
+	}
+}
+
+func relationExists(t *testing.T, db *bun.DB, relation string) bool {
+	t.Helper()
+	var exists bool
+	if err := db.NewRaw(`SELECT to_regclass(?) IS NOT NULL`, relation).Scan(context.Background(), &exists); err != nil {
+		t.Fatalf("check relation %s: %v", relation, err)
+	}
+	return exists
 }

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -155,6 +155,7 @@ type Factory struct {
 	AnnouncementView         platformModels.AnnouncementViewRepository
 	OperatorAuditLog         platformModels.OperatorAuditLogRepository
 	OperatorEmailChangeToken platformModels.OperatorEmailChangeTokenRepository
+	OperatorRefreshToken     platformModels.OperatorRefreshTokenRepository
 	OperatorInvitationToken  platformModels.OperatorInvitationTokenRepository
 	OperatorSummaries        platformModels.OperatorSummariesRepository
 	School                   platformModels.SchoolRepository
@@ -306,6 +307,7 @@ func NewFactory(db *bun.DB) *Factory {
 		AnnouncementView:         platformRepo.NewAnnouncementViewRepository(db),
 		OperatorAuditLog:         platformRepo.NewOperatorAuditLogRepository(db),
 		OperatorEmailChangeToken: platformRepo.NewOperatorEmailChangeTokenRepository(db),
+		OperatorRefreshToken:     platformRepo.NewOperatorRefreshTokenRepository(db),
 		OperatorInvitationToken:  platformRepo.NewOperatorInvitationTokenRepository(db),
 		OperatorSummaries:        platformRepo.NewOperatorSummariesRepository(db),
 		School:                   platformRepo.NewSchoolRepository(db),

--- a/backend/database/repositories/platform/operator_email_change_token_repository_test.go
+++ b/backend/database/repositories/platform/operator_email_change_token_repository_test.go
@@ -31,6 +31,7 @@ func createTestOperatorForTokenRepo(t *testing.T, db *bun.DB, email string) int6
 
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM platform.operator_email_change_tokens WHERE operator_id = ?`, operatorID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.operator_refresh_tokens WHERE operator_id = ?`, operatorID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM platform.operator_audit_log WHERE operator_id = ?`, operatorID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM platform.operators WHERE id = ?`, operatorID)
 	})

--- a/backend/database/repositories/platform/operator_refresh_token.go
+++ b/backend/database/repositories/platform/operator_refresh_token.go
@@ -1,0 +1,132 @@
+package platform
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/platform"
+	"github.com/uptrace/bun"
+)
+
+const (
+	operatorRefreshTokenTable      = "platform.operator_refresh_tokens"
+	operatorRefreshTokenTableAlias = `platform.operator_refresh_tokens AS "operator_refresh_token"`
+)
+
+type OperatorRefreshTokenRepository struct {
+	*base.Repository[*platform.OperatorRefreshToken]
+	db *bun.DB
+}
+
+func NewOperatorRefreshTokenRepository(db *bun.DB) platform.OperatorRefreshTokenRepository {
+	return &OperatorRefreshTokenRepository{
+		Repository: base.NewRepository[*platform.OperatorRefreshToken](db, operatorRefreshTokenTable, "OperatorRefreshToken"),
+		db:         db,
+	}
+}
+
+func (r *OperatorRefreshTokenRepository) Create(ctx context.Context, token *platform.OperatorRefreshToken) error {
+	if token == nil {
+		return fmt.Errorf("operator refresh token cannot be nil")
+	}
+	if err := token.Validate(); err != nil {
+		return err
+	}
+	return r.Repository.Create(ctx, token)
+}
+
+func (r *OperatorRefreshTokenRepository) FindByTokenForUpdate(ctx context.Context, tokenValue string) (*platform.OperatorRefreshToken, error) {
+	token := new(platform.OperatorRefreshToken)
+	err := base.GetDB(ctx, r.db).NewSelect().
+		Model(token).
+		ModelTableExpr(operatorRefreshTokenTableAlias).
+		Where(`"operator_refresh_token".token = ?`, tokenValue).
+		For("UPDATE").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, &modelBase.DatabaseError{Op: "find operator refresh token for update", Err: err}
+	}
+	return token, nil
+}
+
+func (r *OperatorRefreshTokenRepository) Delete(ctx context.Context, id any) error {
+	_, err := base.GetDB(ctx, r.db).NewDelete().
+		Model((*platform.OperatorRefreshToken)(nil)).
+		ModelTableExpr(operatorRefreshTokenTableAlias).
+		Where(`"operator_refresh_token".id = ?`, id).
+		Exec(ctx)
+	if err != nil {
+		return &modelBase.DatabaseError{Op: "delete operator refresh token", Err: err}
+	}
+	return nil
+}
+
+func (r *OperatorRefreshTokenRepository) DeleteByOperatorID(ctx context.Context, operatorID int64) (int, error) {
+	res, err := base.GetDB(ctx, r.db).NewDelete().
+		Model((*platform.OperatorRefreshToken)(nil)).
+		ModelTableExpr(operatorRefreshTokenTableAlias).
+		Where(`"operator_refresh_token".operator_id = ?`, operatorID).
+		Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{Op: "delete operator refresh tokens by operator ID", Err: err}
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, &modelBase.DatabaseError{Op: "count deleted operator refresh tokens", Err: err}
+	}
+	return int(affected), nil
+}
+
+func (r *OperatorRefreshTokenRepository) DeleteByFamilyID(ctx context.Context, familyID string) error {
+	_, err := base.GetDB(ctx, r.db).NewDelete().
+		Model((*platform.OperatorRefreshToken)(nil)).
+		ModelTableExpr(operatorRefreshTokenTableAlias).
+		Where(`"operator_refresh_token".family_id = ?`, familyID).
+		Exec(ctx)
+	if err != nil {
+		return &modelBase.DatabaseError{Op: "delete operator refresh token family", Err: err}
+	}
+	return nil
+}
+
+func (r *OperatorRefreshTokenRepository) GetLatestTokenInFamily(ctx context.Context, familyID string) (*platform.OperatorRefreshToken, error) {
+	token := new(platform.OperatorRefreshToken)
+	err := base.GetDB(ctx, r.db).NewSelect().
+		Model(token).
+		ModelTableExpr(operatorRefreshTokenTableAlias).
+		Where(`"operator_refresh_token".family_id = ?`, familyID).
+		OrderExpr(`"operator_refresh_token".generation DESC`).
+		Limit(1).
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, &modelBase.DatabaseError{Op: "get latest operator refresh token in family", Err: err}
+	}
+	return token, nil
+}
+
+func (r *OperatorRefreshTokenRepository) DeleteExpired(ctx context.Context, now time.Time) (int, error) {
+	res, err := base.GetDB(ctx, r.db).NewDelete().
+		Model((*platform.OperatorRefreshToken)(nil)).
+		ModelTableExpr(operatorRefreshTokenTableAlias).
+		Where(`"operator_refresh_token".expiry < ?`, now).
+		Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{Op: "delete expired operator refresh tokens", Err: err}
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, &modelBase.DatabaseError{Op: "count expired operator refresh tokens", Err: err}
+	}
+	return int(affected), nil
+}

--- a/backend/database/repositories/platform/operator_refresh_token_repository_test.go
+++ b/backend/database/repositories/platform/operator_refresh_token_repository_test.go
@@ -1,0 +1,128 @@
+package platform_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	repoplatform "github.com/moto-nrw/project-phoenix/database/repositories/platform"
+	"github.com/moto-nrw/project-phoenix/models/platform"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperatorRefreshTokenRepository_CreateAndFindByTokenForUpdate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repoplatform.NewOperatorRefreshTokenRepository(db)
+	ctx := context.Background()
+	operatorID := createTestOperatorForTokenRepo(t, db, fmt.Sprintf("refresh-create-%d@test.local", time.Now().UnixNano()))
+
+	tokenValue := uuid.Must(uuid.NewV4()).String()
+	token := &platform.OperatorRefreshToken{
+		OperatorID: operatorID,
+		Token:      tokenValue,
+		Expiry:     time.Now().Add(time.Hour),
+		FamilyID:   uuid.Must(uuid.NewV4()).String(),
+		Generation: 0,
+	}
+	require.NoError(t, repo.Create(ctx, token))
+	require.NotZero(t, token.ID)
+
+	found, err := repo.FindByTokenForUpdate(ctx, tokenValue)
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.Equal(t, operatorID, found.OperatorID)
+	assert.Equal(t, tokenValue, found.Token)
+}
+
+func TestOperatorRefreshTokenRepository_DeleteByOperatorID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repoplatform.NewOperatorRefreshTokenRepository(db)
+	ctx := context.Background()
+	operatorID := createTestOperatorForTokenRepo(t, db, fmt.Sprintf("refresh-delete-op-%d@test.local", time.Now().UnixNano()))
+
+	for i := 0; i < 2; i++ {
+		require.NoError(t, repo.Create(ctx, &platform.OperatorRefreshToken{
+			OperatorID: operatorID,
+			Token:      uuid.Must(uuid.NewV4()).String(),
+			Expiry:     time.Now().Add(time.Hour),
+			FamilyID:   uuid.Must(uuid.NewV4()).String(),
+			Generation: i,
+		}))
+	}
+
+	deleted, err := repo.DeleteByOperatorID(ctx, operatorID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, deleted)
+
+	remaining, err := db.NewSelect().
+		TableExpr("platform.operator_refresh_tokens").
+		Where("operator_id = ?", operatorID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, remaining)
+}
+
+func TestOperatorRefreshTokenRepository_DeleteByFamilyIDAndLatest(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repoplatform.NewOperatorRefreshTokenRepository(db)
+	ctx := context.Background()
+	operatorID := createTestOperatorForTokenRepo(t, db, fmt.Sprintf("refresh-family-%d@test.local", time.Now().UnixNano()))
+	familyID := uuid.Must(uuid.NewV4()).String()
+
+	for generation := 0; generation < 3; generation++ {
+		require.NoError(t, repo.Create(ctx, &platform.OperatorRefreshToken{
+			OperatorID: operatorID,
+			Token:      uuid.Must(uuid.NewV4()).String(),
+			Expiry:     time.Now().Add(time.Hour),
+			FamilyID:   familyID,
+			Generation: generation,
+		}))
+	}
+
+	latest, err := repo.GetLatestTokenInFamily(ctx, familyID)
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+	assert.Equal(t, 2, latest.Generation)
+
+	require.NoError(t, repo.DeleteByFamilyID(ctx, familyID))
+	latest, err = repo.GetLatestTokenInFamily(ctx, familyID)
+	require.NoError(t, err)
+	assert.Nil(t, latest)
+}
+
+func TestOperatorRefreshTokenRepository_DeleteExpired(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repoplatform.NewOperatorRefreshTokenRepository(db)
+	ctx := context.Background()
+	operatorID := createTestOperatorForTokenRepo(t, db, fmt.Sprintf("refresh-expired-%d@test.local", time.Now().UnixNano()))
+	now := time.Now()
+
+	require.NoError(t, repo.Create(ctx, &platform.OperatorRefreshToken{
+		OperatorID: operatorID,
+		Token:      uuid.Must(uuid.NewV4()).String(),
+		Expiry:     now.Add(-time.Minute),
+		FamilyID:   uuid.Must(uuid.NewV4()).String(),
+	}))
+	require.NoError(t, repo.Create(ctx, &platform.OperatorRefreshToken{
+		OperatorID: operatorID,
+		Token:      uuid.Must(uuid.NewV4()).String(),
+		Expiry:     now.Add(time.Hour),
+		FamilyID:   uuid.Must(uuid.NewV4()).String(),
+	}))
+
+	deleted, err := repo.DeleteExpired(ctx, now)
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+}

--- a/backend/models/entity_interfaces_test.go
+++ b/backend/models/entity_interfaces_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/facilities"
 	"github.com/moto-nrw/project-phoenix/models/feedback"
 	"github.com/moto-nrw/project-phoenix/models/iot"
+	"github.com/moto-nrw/project-phoenix/models/platform"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/models/users"
 )
@@ -68,6 +69,9 @@ var (
 
 	// iot package
 	_ base.Entity = (*iot.Device)(nil)
+
+	// platform package
+	_ base.Entity = (*platform.OperatorRefreshToken)(nil)
 
 	// schedule package
 	_ base.Entity = (*schedule.Dateframe)(nil)

--- a/backend/models/platform/operator_refresh_token.go
+++ b/backend/models/platform/operator_refresh_token.go
@@ -1,0 +1,68 @@
+package platform
+
+import (
+	"errors"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/uptrace/bun"
+)
+
+const tablePlatformOperatorRefreshTokens = "platform.operator_refresh_tokens"
+
+// OperatorRefreshToken is the server-side session handle behind an operator
+// refresh JWT. The JWT carries Token as an opaque claim; refresh succeeds only
+// while the matching row exists and is current.
+type OperatorRefreshToken struct {
+	base.Model `bun:"schema:platform,table:operator_refresh_tokens"`
+
+	OperatorID int64     `bun:"operator_id,notnull" json:"operator_id"`
+	Token      string    `bun:"token,notnull,unique" json:"-"`
+	Expiry     time.Time `bun:"expiry,notnull" json:"expiry"`
+	FamilyID   string    `bun:"family_id,notnull" json:"family_id"`
+	Generation int       `bun:"generation,notnull,default:0" json:"generation"`
+
+	Operator *Operator `bun:"rel:belongs-to,join:operator_id=id" json:"operator,omitempty"`
+}
+
+func (t *OperatorRefreshToken) BeforeAppendModel(query any) error {
+	if q, ok := query.(*bun.UpdateQuery); ok {
+		q.ModelTableExpr(`platform.operator_refresh_tokens AS "operator_refresh_token"`)
+	}
+	if q, ok := query.(*bun.DeleteQuery); ok {
+		q.ModelTableExpr(`platform.operator_refresh_tokens AS "operator_refresh_token"`)
+	}
+	return nil
+}
+
+func (t *OperatorRefreshToken) TableName() string {
+	return tablePlatformOperatorRefreshTokens
+}
+
+func (t *OperatorRefreshToken) Validate() error {
+	if t.OperatorID <= 0 {
+		return errors.New("operator ID is required")
+	}
+	if t.Token == "" {
+		return errors.New("token value is required")
+	}
+	if t.Expiry.IsZero() {
+		return errors.New("expiry is required")
+	}
+	if t.FamilyID == "" {
+		return errors.New("family ID is required")
+	}
+	return nil
+}
+
+func (t *OperatorRefreshToken) GetID() any {
+	return t.ID
+}
+
+func (t *OperatorRefreshToken) GetCreatedAt() time.Time {
+	return t.CreatedAt
+}
+
+func (t *OperatorRefreshToken) GetUpdatedAt() time.Time {
+	return t.UpdatedAt
+}

--- a/backend/models/platform/operator_refresh_token_test.go
+++ b/backend/models/platform/operator_refresh_token_test.go
@@ -1,0 +1,91 @@
+package platform
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validOperatorRefreshToken() *OperatorRefreshToken {
+	return &OperatorRefreshToken{
+		Model: base.Model{
+			ID:        91,
+			CreatedAt: time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC),
+			UpdatedAt: time.Date(2026, time.January, 2, 4, 5, 6, 0, time.UTC),
+		},
+		OperatorID: 77,
+		Token:      "opaque-refresh-handle",
+		Expiry:     time.Date(2026, time.January, 3, 3, 4, 5, 0, time.UTC),
+		FamilyID:   "refresh-family",
+		Generation: 2,
+	}
+}
+
+func TestOperatorRefreshToken_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*OperatorRefreshToken)
+		wantErr string
+	}{
+		{
+			name: "valid",
+		},
+		{
+			name: "requires operator id",
+			mutate: func(token *OperatorRefreshToken) {
+				token.OperatorID = 0
+			},
+			wantErr: "operator ID is required",
+		},
+		{
+			name: "requires token",
+			mutate: func(token *OperatorRefreshToken) {
+				token.Token = ""
+			},
+			wantErr: "token value is required",
+		},
+		{
+			name: "requires expiry",
+			mutate: func(token *OperatorRefreshToken) {
+				token.Expiry = time.Time{}
+			},
+			wantErr: "expiry is required",
+		},
+		{
+			name: "requires family id",
+			mutate: func(token *OperatorRefreshToken) {
+				token.FamilyID = ""
+			},
+			wantErr: "family ID is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := validOperatorRefreshToken()
+			if tt.mutate != nil {
+				tt.mutate(token)
+			}
+
+			err := token.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestOperatorRefreshToken_EntityAccessors(t *testing.T) {
+	token := validOperatorRefreshToken()
+
+	assert.Equal(t, "platform.operator_refresh_tokens", token.TableName())
+	assert.Equal(t, token.ID, token.GetID())
+	assert.Equal(t, token.CreatedAt, token.GetCreatedAt())
+	assert.Equal(t, token.UpdatedAt, token.GetUpdatedAt())
+}

--- a/backend/models/platform/repository.go
+++ b/backend/models/platform/repository.go
@@ -120,6 +120,17 @@ type OperatorEmailChangeTokenRepository interface {
 	DeleteStaleTokens(ctx context.Context) (int, error)
 }
 
+// OperatorRefreshTokenRepository persists revocable platform-operator refresh sessions.
+type OperatorRefreshTokenRepository interface {
+	Create(ctx context.Context, token *OperatorRefreshToken) error
+	FindByTokenForUpdate(ctx context.Context, token string) (*OperatorRefreshToken, error)
+	Delete(ctx context.Context, id any) error
+	DeleteByOperatorID(ctx context.Context, operatorID int64) (int, error)
+	DeleteByFamilyID(ctx context.Context, familyID string) error
+	GetLatestTokenInFamily(ctx context.Context, familyID string) (*OperatorRefreshToken, error)
+	DeleteExpired(ctx context.Context, now time.Time) (int, error)
+}
+
 // OperatorInvitationTokenRepository defines operations for operator invitation tokens
 type OperatorInvitationTokenRepository interface {
 	Create(ctx context.Context, token *OperatorInvitationToken) error

--- a/backend/services/active/attendance_service.go
+++ b/backend/services/active/attendance_service.go
@@ -185,6 +185,16 @@ func (s *service) CheckOutStudent(ctx context.Context, studentID, staffID int64,
 	return s.performCheckOut(ctx, studentID, authorizedStaffID, time.Now())
 }
 
+// CheckOutStudentFromDevice applies "out" for an IoT device after resolving
+// the device's active session supervisor as the auditable checkout principal.
+func (s *service) CheckOutStudentFromDevice(ctx context.Context, studentID, deviceID int64) (*AttendanceResult, error) {
+	authorizedStaffID, err := s.authorizeIoTDeviceToggle(ctx, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	return s.performCheckOut(ctx, studentID, authorizedStaffID, time.Now())
+}
+
 // authorizeAttendanceToggle handles authorization and returns the staff ID to use
 func (s *service) authorizeAttendanceToggle(ctx context.Context, studentID, staffID, deviceID int64, skipAuthCheck bool) (int64, error) {
 	if skipAuthCheck {

--- a/backend/services/active/attendance_service_test.go
+++ b/backend/services/active/attendance_service_test.go
@@ -954,6 +954,86 @@ func TestCheckOutStudent_ClosesOpenRow(t *testing.T) {
 	assert.NotNil(t, status.CheckOutTime)
 }
 
+func TestCheckOutStudentFromDevice_ClosesOpenRowWithSupervisor(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	activity := testpkg.CreateTestActivityGroup(t, db, "device-checkout-activity")
+	room := testpkg.CreateTestRoom(t, db, "Device Checkout Room")
+	device := testpkg.CreateTestDevice(t, db, "device-checkout-supervisor")
+	student := testpkg.CreateTestStudent(t, db, "Device", "Checkout", "5h")
+	staff := testpkg.CreateTestStaff(t, db, "Device", "Supervisor")
+	defer testpkg.CleanupActivityFixtures(t, db, activity.ID, room.ID, device.ID, student.ID, staff.ID)
+
+	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	defer testpkg.CleanupActivityFixtures(t, db, activeGroup.ID)
+
+	_, err := db.NewUpdate().
+		Model(activeGroup).
+		ModelTableExpr(`active.groups`).
+		Set("device_id = ?", device.ID).
+		Where("id = ?", activeGroup.ID).
+		Exec(context.Background())
+	require.NoError(t, err)
+	testpkg.CreateTestGroupSupervisor(t, db, staff.ID, activeGroup.ID, "supervisor")
+
+	checkInTime := time.Now().Add(-1 * time.Hour)
+	open := testpkg.CreateTestAttendance(t, db, student.ID, staff.ID, device.ID, checkInTime, nil)
+
+	result, err := service.CheckOutStudentFromDevice(ctx, student.ID, device.ID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "checked_out", result.Action)
+	assert.Equal(t, open.ID, result.AttendanceID)
+
+	var row active.Attendance
+	err = db.NewSelect().
+		Model(&row).
+		ModelTableExpr(`active.attendance AS "attendance"`).
+		Where(`"attendance".id = ?`, open.ID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, row.CheckOutTime)
+	require.NotNil(t, row.CheckedOutBy)
+	assert.Equal(t, staff.ID, *row.CheckedOutBy)
+}
+
+func TestCheckOutStudentFromDevice_FailsWithoutSupervisorAndLeavesRowOpen(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupActiveService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	device := testpkg.CreateTestDevice(t, db, "device-checkout-no-supervisor")
+	student := testpkg.CreateTestStudent(t, db, "Device", "NoSupervisor", "5i")
+	staff := testpkg.CreateTestStaff(t, db, "Device", "CheckInOnly")
+	defer testpkg.CleanupActivityFixtures(t, db, device.ID, student.ID, staff.ID)
+
+	checkInTime := time.Now().Add(-1 * time.Hour)
+	open := testpkg.CreateTestAttendance(t, db, student.ID, staff.ID, device.ID, checkInTime, nil)
+
+	result, err := service.CheckOutStudentFromDevice(ctx, student.ID, device.ID)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "device must have an active group")
+
+	var row active.Attendance
+	err = db.NewSelect().
+		Model(&row).
+		ModelTableExpr(`active.attendance AS "attendance"`).
+		Where(`"attendance".id = ?`, open.ID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, row.CheckOutTime)
+	assert.Nil(t, row.CheckedOutBy)
+}
+
 // TestCheckOutStudent_NoOpenRow_IsIdempotent guards the state-checked UPDATE
 // path: when nothing is open (already checked out, or never checked in), the
 // service still returns Action="checked_out" with no error. This is the key

--- a/backend/services/active/interface.go
+++ b/backend/services/active/interface.go
@@ -135,6 +135,9 @@ type Service interface {
 	// transaction, so attendance "checked_out" never coexists with an open
 	// visit (issue #895).
 	CheckOutStudent(ctx context.Context, studentID, staffID int64, skipAuthCheck bool) (*AttendanceResult, error)
+	// CheckOutStudentFromDevice applies "out" for an IoT device after
+	// resolving the active session supervisor used as the checkout principal.
+	CheckOutStudentFromDevice(ctx context.Context, studentID, deviceID int64) (*AttendanceResult, error)
 	CheckTeacherStudentAccess(ctx context.Context, teacherID, studentID int64) (bool, error)
 	BroadcastDailyCheckout(ctx context.Context, studentID int64)
 

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -868,6 +868,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		OperatorRepo:         repos.Operator,
 		AuditLogRepo:         repos.OperatorAuditLog,
 		EmailChangeTokenRepo: repos.OperatorEmailChangeToken,
+		RefreshTokenRepo:     repos.OperatorRefreshToken,
 		InvitationTokenRepo:  repos.OperatorInvitationToken,
 		DB:                   db,
 		Logger:               platformLogger,

--- a/backend/services/platform/errors.go
+++ b/backend/services/platform/errors.go
@@ -87,6 +87,14 @@ func (e *PasswordMismatchError) Error() string {
 	return "current password is incorrect"
 }
 
+// OperatorRefreshTokenInvalidError is returned when an operator refresh token
+// has expired, was rotated already, was revoked, or never existed server-side.
+type OperatorRefreshTokenInvalidError struct{}
+
+func (e *OperatorRefreshTokenInvalidError) Error() string {
+	return "operator refresh token is invalid"
+}
+
 // OrganizationNotFoundError is returned when an organization does not exist.
 type OrganizationNotFoundError struct {
 	OrganizationID int64

--- a/backend/services/platform/operator_auth_mfa_gate_test.go
+++ b/backend/services/platform/operator_auth_mfa_gate_test.go
@@ -40,8 +40,16 @@ func randomOperatorGatePassword() string {
 func withJWTSecret(t *testing.T) {
 	t.Helper()
 	old := viper.GetString("auth_jwt_secret")
+	oldExpiry := viper.Get("auth_jwt_expiry")
+	oldRefreshExpiry := viper.Get("auth_jwt_refresh_expiry")
 	viper.Set("auth_jwt_secret", testJWTSecret)
-	t.Cleanup(func() { viper.Set("auth_jwt_secret", old) })
+	viper.Set("auth_jwt_expiry", 15*time.Minute)
+	viper.Set("auth_jwt_refresh_expiry", time.Hour)
+	t.Cleanup(func() {
+		viper.Set("auth_jwt_secret", old)
+		viper.Set("auth_jwt_expiry", oldExpiry)
+		viper.Set("auth_jwt_refresh_expiry", oldRefreshExpiry)
+	})
 }
 
 // stubOperatorMFAService is a minimal OperatorMFAService implementation
@@ -125,10 +133,11 @@ func newOperatorAuthServiceForGate(t *testing.T, mfa *stubOperatorMFAService) (p
 	auditLogRepo := &mockAuditLogRepoShared{}
 
 	svc, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
-		OperatorRepo: operatorRepo,
-		AuditLogRepo: auditLogRepo,
-		DB:           &bun.DB{},
-		Logger:       slog.Default(),
+		OperatorRepo:     operatorRepo,
+		AuditLogRepo:     auditLogRepo,
+		RefreshTokenRepo: &mockOperatorRefreshTokenRepo{},
+		DB:               &bun.DB{},
+		Logger:           slog.Default(),
 	})
 	require.NoError(t, err)
 	if mfa != nil {

--- a/backend/services/platform/operator_auth_service.go
+++ b/backend/services/platform/operator_auth_service.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/auth/userpass"
 	emailpkg "github.com/moto-nrw/project-phoenix/email"
@@ -46,8 +47,8 @@ type OperatorAuthService interface {
 	// Mirrors authService.IssueTokensForAuthenticatedAccount.
 	IssueTokensForAuthenticatedOperator(ctx context.Context, operatorID int64, ipAddress, userAgent string) (accessToken, refreshToken string, err error)
 
-	// RefreshToken validates the operator is still active and issues a new token pair
-	RefreshToken(ctx context.Context, operatorID int64) (accessToken, refreshToken string, err error)
+	// RefreshToken validates a persisted operator refresh session and rotates it.
+	RefreshToken(ctx context.Context, operatorID int64, refreshTokenValue string) (accessToken, refreshToken string, err error)
 
 	// ValidateOperator validates an operator's credentials without generating tokens
 	ValidateOperator(ctx context.Context, email, password string) (*platform.Operator, error)
@@ -77,6 +78,7 @@ type operatorAuthService struct {
 	operatorRepo         platform.OperatorRepository
 	auditLogRepo         platform.OperatorAuditLogRepository
 	emailChangeTokenRepo platform.OperatorEmailChangeTokenRepository
+	refreshTokenRepo     platform.OperatorRefreshTokenRepository
 	invitationTokenRepo  platform.OperatorInvitationTokenRepository
 	tokenAuth            *jwt.TokenAuth
 	db                   *bun.DB
@@ -105,6 +107,7 @@ type OperatorAuthServiceConfig struct {
 	OperatorRepo         platform.OperatorRepository
 	AuditLogRepo         platform.OperatorAuditLogRepository
 	EmailChangeTokenRepo platform.OperatorEmailChangeTokenRepository
+	RefreshTokenRepo     platform.OperatorRefreshTokenRepository
 	InvitationTokenRepo  platform.OperatorInvitationTokenRepository
 	DB                   *bun.DB
 	Logger               *slog.Logger
@@ -129,6 +132,7 @@ func NewOperatorAuthService(cfg OperatorAuthServiceConfig) (OperatorAuthAndInvit
 		operatorRepo:         cfg.OperatorRepo,
 		auditLogRepo:         cfg.AuditLogRepo,
 		emailChangeTokenRepo: cfg.EmailChangeTokenRepo,
+		refreshTokenRepo:     cfg.RefreshTokenRepo,
 		invitationTokenRepo:  cfg.InvitationTokenRepo,
 		tokenAuth:            tokenAuth,
 		db:                   cfg.DB,
@@ -307,24 +311,13 @@ func (s *operatorAuthService) LoginWithMFAGate(
 // the original Login flow so LoginWithMFAGate can reuse it without changing
 // the legacy code path.
 func (s *operatorAuthService) issueOperatorTokenPair(ctx context.Context, operator *platform.Operator, clientIP net.IP) (string, string, error) {
-	accessClaims := jwt.AppClaims{
-		ID:          int(operator.ID),
-		Sub:         fmt.Sprintf("operator:%d", operator.ID),
-		Username:    operator.Email,
-		FirstName:   operator.DisplayName,
-		LastName:    "",
-		Roles:       []string{"operator"},
-		Permissions: []string{},
-		IsAdmin:     false,
-		Scope:       "platform",
-	}
-	refreshClaims := jwt.RefreshClaims{
-		ID:    int(operator.ID),
-		Token: fmt.Sprintf("operator-refresh-%d", operator.ID),
-	}
-	access, refresh, err := s.tokenAuth.GenTokenPair(accessClaims, refreshClaims)
+	refreshSession := s.newOperatorRefreshToken(operator.ID, "", 0)
+	access, refresh, err := s.mintOperatorTokenPair(operator, refreshSession)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to generate tokens: %w", err)
+		return "", "", err
+	}
+	if err := s.persistOperatorRefreshToken(ctx, refreshSession); err != nil {
+		return "", "", err
 	}
 	if err := s.operatorRepo.UpdateLastLogin(ctx, operator.ID); err != nil {
 		s.getLogger().Error("failed to update last login",
@@ -398,6 +391,59 @@ func parseClientIPForOperator(ipAddress string) net.IP {
 	return net.ParseIP(ipAddress)
 }
 
+func (s *operatorAuthService) operatorAccessClaims(operator *platform.Operator) jwt.AppClaims {
+	return jwt.AppClaims{
+		ID:          int(operator.ID),
+		Sub:         fmt.Sprintf("operator:%d", operator.ID),
+		Username:    operator.Email,
+		FirstName:   operator.DisplayName,
+		LastName:    "",
+		Roles:       []string{"operator"},
+		Permissions: []string{},
+		IsAdmin:     false,
+		Scope:       "platform",
+	}
+}
+
+func (s *operatorAuthService) newOperatorRefreshToken(operatorID int64, familyID string, generation int) *platform.OperatorRefreshToken {
+	if familyID == "" {
+		familyID = uuid.Must(uuid.NewV4()).String()
+	}
+	return &platform.OperatorRefreshToken{
+		OperatorID: operatorID,
+		Token:      uuid.Must(uuid.NewV4()).String(),
+		Expiry:     time.Now().Add(s.tokenAuth.GetRefreshExpiry()),
+		FamilyID:   familyID,
+		Generation: generation,
+	}
+}
+
+func (s *operatorAuthService) mintOperatorTokenPair(operator *platform.Operator, refreshToken *platform.OperatorRefreshToken) (string, string, error) {
+	if refreshToken == nil {
+		return "", "", fmt.Errorf("operator refresh token is required")
+	}
+	refreshClaims := jwt.RefreshClaims{
+		ID:    int(operator.ID),
+		Token: refreshToken.Token,
+		Scope: "platform",
+	}
+	access, refresh, err := s.tokenAuth.GenTokenPair(s.operatorAccessClaims(operator), refreshClaims)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate tokens: %w", err)
+	}
+	return access, refresh, nil
+}
+
+func (s *operatorAuthService) persistOperatorRefreshToken(ctx context.Context, refreshToken *platform.OperatorRefreshToken) error {
+	if s.refreshTokenRepo == nil {
+		return fmt.Errorf("operator refresh token repository is not configured")
+	}
+	if err := s.refreshTokenRepo.Create(ctx, refreshToken); err != nil {
+		return fmt.Errorf("failed to persist operator refresh token: %w", err)
+	}
+	return nil
+}
+
 // Login authenticates an operator and returns JWT tokens
 func (s *operatorAuthService) Login(ctx context.Context, email, password string, clientIP net.IP) (string, string, *platform.Operator, error) {
 	email = strings.ToLower(strings.TrimSpace(email))
@@ -422,90 +468,89 @@ func (s *operatorAuthService) Login(ctx context.Context, email, password string,
 		return "", "", nil, &InvalidCredentialsError{}
 	}
 
-	// Generate JWT tokens with platform scope
-	accessClaims := jwt.AppClaims{
-		ID:          int(operator.ID),
-		Sub:         fmt.Sprintf("operator:%d", operator.ID),
-		Username:    operator.Email,
-		FirstName:   operator.DisplayName,
-		LastName:    "",
-		Roles:       []string{"operator"},
-		Permissions: []string{}, // Operators don't have tenant permissions
-		IsAdmin:     false,
-		Scope:       "platform", // Key differentiation from tenant tokens
-	}
-
-	refreshClaims := jwt.RefreshClaims{
-		ID:    int(operator.ID),
-		Token: fmt.Sprintf("operator-refresh-%d", operator.ID),
-	}
-
-	accessToken, refreshToken, err := s.tokenAuth.GenTokenPair(accessClaims, refreshClaims)
+	accessToken, refreshToken, err := s.issueOperatorTokenPair(ctx, operator, clientIP)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("failed to generate tokens: %w", err)
-	}
-
-	// Update last login
-	if err := s.operatorRepo.UpdateLastLogin(ctx, operator.ID); err != nil {
-		s.getLogger().Error("failed to update last login",
-			"operator_id", operator.ID,
-			"error", err,
-		)
-	}
-
-	// Audit log
-	auditEntry := &platform.OperatorAuditLog{
-		OperatorID:   operator.ID,
-		Action:       platform.ActionLogin,
-		ResourceType: platform.ResourceOperator,
-		ResourceID:   &operator.ID,
-		RequestIP:    clientIP,
-	}
-	if err := s.auditLogRepo.Create(ctx, auditEntry); err != nil {
-		s.getLogger().Error("failed to create audit log",
-			"operator_id", operator.ID,
-			"action", platform.ActionLogin,
-			"error", err,
-		)
+		return "", "", nil, err
 	}
 
 	return accessToken, refreshToken, operator, nil
 }
 
-// RefreshToken validates the operator is still active and issues a new JWT token pair.
-// No DB token table is involved — it verifies the operator exists and is active, then generates fresh tokens.
-func (s *operatorAuthService) RefreshToken(ctx context.Context, operatorID int64) (string, string, error) {
-	operator, err := s.operatorRepo.FindByID(ctx, operatorID)
+// RefreshToken validates the persisted operator refresh session, rotates it,
+// and issues a new JWT token pair. A refresh JWT without a matching DB row is
+// stale, replayed, or from the pre-revocation stateless scheme and is rejected.
+func (s *operatorAuthService) RefreshToken(ctx context.Context, operatorID int64, refreshTokenValue string) (string, string, error) {
+	refreshTokenValue = strings.TrimSpace(refreshTokenValue)
+	if refreshTokenValue == "" {
+		return "", "", &OperatorRefreshTokenInvalidError{}
+	}
+	if s.refreshTokenRepo == nil {
+		return "", "", fmt.Errorf("operator refresh token repository is not configured")
+	}
+
+	var operator *platform.Operator
+	var accessToken string
+	var refreshToken string
+	var rejectAfterCommit bool
+	err := tenant.WithAdminTx(ctx, s.db, func(txCtx context.Context, _ bun.Tx) error {
+		dbToken, err := s.refreshTokenRepo.FindByTokenForUpdate(txCtx, refreshTokenValue)
+		if err != nil {
+			return fmt.Errorf("failed to find operator refresh token: %w", err)
+		}
+		if dbToken == nil || dbToken.OperatorID != operatorID {
+			return &OperatorRefreshTokenInvalidError{}
+		}
+
+		now := time.Now()
+		if now.After(dbToken.Expiry) {
+			if err := s.refreshTokenRepo.Delete(txCtx, dbToken.ID); err != nil {
+				return fmt.Errorf("failed to delete expired operator refresh token: %w", err)
+			}
+			rejectAfterCommit = true
+			return nil
+		}
+
+		latestToken, err := s.refreshTokenRepo.GetLatestTokenInFamily(txCtx, dbToken.FamilyID)
+		if err != nil {
+			return fmt.Errorf("failed to inspect operator refresh token family: %w", err)
+		}
+		if latestToken != nil && latestToken.Generation > dbToken.Generation {
+			if err := s.refreshTokenRepo.DeleteByFamilyID(txCtx, dbToken.FamilyID); err != nil {
+				return fmt.Errorf("failed to revoke operator refresh token family: %w", err)
+			}
+			rejectAfterCommit = true
+			return nil
+		}
+
+		operator, err = s.operatorRepo.FindByID(txCtx, operatorID)
+		if err != nil {
+			return fmt.Errorf("failed to find operator: %w", err)
+		}
+		if operator == nil {
+			return &OperatorNotFoundError{OperatorID: operatorID}
+		}
+		if !operator.Active {
+			return &OperatorInactiveError{OperatorID: operatorID}
+		}
+
+		newDBToken := s.newOperatorRefreshToken(operator.ID, dbToken.FamilyID, dbToken.Generation+1)
+		accessToken, refreshToken, err = s.mintOperatorTokenPair(operator, newDBToken)
+		if err != nil {
+			return err
+		}
+		if err := s.refreshTokenRepo.Delete(txCtx, dbToken.ID); err != nil {
+			return fmt.Errorf("failed to delete old operator refresh token: %w", err)
+		}
+		if err := s.refreshTokenRepo.Create(txCtx, newDBToken); err != nil {
+			return fmt.Errorf("failed to persist rotated operator refresh token: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
-		return "", "", fmt.Errorf("failed to find operator: %w", err)
+		return "", "", err
 	}
-	if operator == nil {
-		return "", "", &OperatorNotFoundError{OperatorID: operatorID}
-	}
-	if !operator.Active {
-		return "", "", &OperatorInactiveError{OperatorID: operatorID}
-	}
-
-	accessClaims := jwt.AppClaims{
-		ID:          int(operator.ID),
-		Sub:         fmt.Sprintf("operator:%d", operator.ID),
-		Username:    operator.Email,
-		FirstName:   operator.DisplayName,
-		LastName:    "",
-		Roles:       []string{"operator"},
-		Permissions: []string{},
-		IsAdmin:     false,
-		Scope:       "platform",
-	}
-
-	refreshClaims := jwt.RefreshClaims{
-		ID:    int(operator.ID),
-		Token: fmt.Sprintf("operator-refresh-%d", operator.ID),
-	}
-
-	accessToken, refreshToken, err := s.tokenAuth.GenTokenPair(accessClaims, refreshClaims)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to generate tokens: %w", err)
+	if rejectAfterCommit {
+		return "", "", &OperatorRefreshTokenInvalidError{}
 	}
 
 	return accessToken, refreshToken, nil
@@ -608,9 +653,13 @@ func (s *operatorAuthService) ChangePassword(ctx context.Context, operatorID int
 
 	operator.PasswordHash = hash
 
-	// Atomically update the password and invalidate any outstanding email-change
-	// tokens. A surviving link after a password rotation would let an attacker
-	// re-take the account.
+	if s.refreshTokenRepo == nil {
+		return fmt.Errorf("operator refresh token repository is not configured")
+	}
+
+	// Atomically update the password and invalidate outstanding bearer-style
+	// controls. A surviving email-change link or refresh session after a
+	// password rotation would let an attacker re-take or keep the account.
 	return tenant.WithAdminTx(ctx, s.db, func(txCtx context.Context, _ bun.Tx) error {
 		if err := s.operatorRepo.Update(txCtx, operator); err != nil {
 			return fmt.Errorf("failed to update password: %w", err)
@@ -619,6 +668,9 @@ func (s *operatorAuthService) ChangePassword(ctx context.Context, operatorID int
 			if err := s.emailChangeTokenRepo.InvalidateByOperatorID(txCtx, operatorID); err != nil {
 				return fmt.Errorf("failed to invalidate email change tokens after password change: %w", err)
 			}
+		}
+		if _, err := s.refreshTokenRepo.DeleteByOperatorID(txCtx, operatorID); err != nil {
+			return fmt.Errorf("failed to revoke refresh tokens after password change: %w", err)
 		}
 		return nil
 	})

--- a/backend/services/platform/operator_auth_service_extra_test.go
+++ b/backend/services/platform/operator_auth_service_extra_test.go
@@ -35,6 +35,7 @@ func TestOperatorAuthService_IssueTokensForAuthenticatedOperator_HappyPath(t *te
 		},
 	}
 	var auditCalls int
+	refreshRepo := &mockOperatorRefreshTokenRepo{}
 	auditRepo := &mockAuditLogRepoShared{
 		createFn: func(_ context.Context, _ *platform.OperatorAuditLog) error {
 			auditCalls++
@@ -42,10 +43,11 @@ func TestOperatorAuthService_IssueTokensForAuthenticatedOperator_HappyPath(t *te
 		},
 	}
 	svc, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
-		OperatorRepo: operatorRepo,
-		AuditLogRepo: auditRepo,
-		DB:           &bun.DB{},
-		Logger:       slog.Default(),
+		OperatorRepo:     operatorRepo,
+		AuditLogRepo:     auditRepo,
+		RefreshTokenRepo: refreshRepo,
+		DB:               &bun.DB{},
+		Logger:           slog.Default(),
 	})
 	require.NoError(t, err)
 
@@ -55,6 +57,9 @@ func TestOperatorAuthService_IssueTokensForAuthenticatedOperator_HappyPath(t *te
 	assert.NotEmpty(t, refresh)
 	assert.Equal(t, 1, auditCalls,
 		"successful post-MFA mint must still write an audit row so login events stay visible")
+	require.Len(t, refreshRepo.created, 1)
+	assert.NotEqual(t, "operator-refresh-70010001", refreshRepo.created[0].Token,
+		"operator refresh sessions must use random server-side handles, not deterministic operator IDs")
 }
 
 func TestOperatorAuthService_IssueTokensForAuthenticatedOperator_NotFound(t *testing.T) {

--- a/backend/services/platform/operator_auth_service_test.go
+++ b/backend/services/platform/operator_auth_service_test.go
@@ -900,6 +900,77 @@ func countOperatorRefreshTokens(t *testing.T, db *bun.DB, operatorID int64, toke
 	return count
 }
 
+func TestOperatorAuthService_RefreshToken_BlankTokenRejected(t *testing.T) {
+	withJWTSecret(t)
+
+	service, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
+		OperatorRepo: &mockOperatorRepo{},
+		AuditLogRepo: &mockAuditLogRepoShared{},
+		DB:           &bun.DB{},
+		Logger:       slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, _, err = service.RefreshToken(context.Background(), 42, " \t ")
+	require.Error(t, err)
+	var invalidRefresh *platformSvc.OperatorRefreshTokenInvalidError
+	assert.ErrorAs(t, err, &invalidRefresh)
+	assert.Equal(t, "operator refresh token is invalid", err.Error())
+}
+
+func TestOperatorAuthService_RefreshToken_MissingRefreshTokenRepo(t *testing.T) {
+	withJWTSecret(t)
+
+	service, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
+		OperatorRepo: &mockOperatorRepo{},
+		AuditLogRepo: &mockAuditLogRepoShared{},
+		DB:           &bun.DB{},
+		Logger:       slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, _, err = service.RefreshToken(context.Background(), 42, "opaque-token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "operator refresh token repository is not configured")
+}
+
+func TestOperatorAuthService_ChangePassword_MissingRefreshTokenRepo(t *testing.T) {
+	withJWTSecret(t)
+
+	passwordHash, err := authSvc.HashPassword(testPassword)
+	require.NoError(t, err)
+
+	updateCalled := false
+	operatorRepo := &mockOperatorRepo{
+		findByIDFn: func(context.Context, int64) (*platform.Operator, error) {
+			return &platform.Operator{
+				Model:        base.Model{ID: 42},
+				Email:        "operator@example.com",
+				DisplayName:  "Test Operator",
+				PasswordHash: passwordHash,
+				Active:       true,
+			}, nil
+		},
+		updateFn: func(context.Context, *platform.Operator) error {
+			updateCalled = true
+			return nil
+		},
+	}
+
+	service, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
+		OperatorRepo: operatorRepo,
+		AuditLogRepo: &mockAuditLogRepoShared{},
+		DB:           &bun.DB{},
+		Logger:       slog.Default(),
+	})
+	require.NoError(t, err)
+
+	err = service.ChangePassword(context.Background(), 42, testPassword, "ChangedPass789!")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "operator refresh token repository is not configured")
+	assert.False(t, updateCalled, "password update must not be persisted without refresh-token revocation")
+}
+
 func TestOperatorAuthService_RefreshToken_SuccessRotatesServerSideSession(t *testing.T) {
 	withJWTSecret(t)
 	db := testpkg.SetupTestDB(t)

--- a/backend/services/platform/operator_auth_service_test.go
+++ b/backend/services/platform/operator_auth_service_test.go
@@ -15,7 +15,6 @@ import (
 	authSvc "github.com/moto-nrw/project-phoenix/services/auth"
 	platformSvc "github.com/moto-nrw/project-phoenix/services/platform"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
@@ -504,9 +503,7 @@ func TestOperatorAuthService_ChangePassword_RepositoryError(t *testing.T) {
 
 func TestOperatorAuthService_Login_Success(t *testing.T) {
 	// Set JWT secret for token generation BEFORE creating service
-	oldSecret := viper.GetString("auth_jwt_secret")
-	viper.Set("auth_jwt_secret", testJWTSecret)
-	defer viper.Set("auth_jwt_secret", oldSecret)
+	withJWTSecret(t)
 
 	ctx := context.Background()
 
@@ -543,13 +540,15 @@ func TestOperatorAuthService_Login_Success(t *testing.T) {
 			return nil
 		},
 	}
+	refreshRepo := &mockOperatorRefreshTokenRepo{}
 
 	// Create service AFTER setting env var
 	service, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
-		OperatorRepo: operatorRepo,
-		AuditLogRepo: auditLogRepo,
-		DB:           &bun.DB{},
-		Logger:       slog.Default(),
+		OperatorRepo:     operatorRepo,
+		AuditLogRepo:     auditLogRepo,
+		RefreshTokenRepo: refreshRepo,
+		DB:               &bun.DB{},
+		Logger:           slog.Default(),
 	})
 	require.NoError(t, err)
 
@@ -562,13 +561,14 @@ func TestOperatorAuthService_Login_Success(t *testing.T) {
 	assert.Equal(t, "operator@example.com", operator.Email)
 	assert.True(t, updateLastLoginCalled, "UpdateLastLogin should be called")
 	assert.True(t, auditLogCalled, "Audit log should be created")
+	require.Len(t, refreshRepo.created, 1)
+	assert.NotEqual(t, "operator-refresh-42", refreshRepo.created[0].Token,
+		"operator login must persist a random refresh handle instead of a deterministic token")
 }
 
 func TestOperatorAuthService_Login_WrongPassword(t *testing.T) {
 	// Set JWT secret (even though we won't reach token generation)
-	oldSecret := viper.GetString("auth_jwt_secret")
-	viper.Set("auth_jwt_secret", testJWTSecret)
-	defer viper.Set("auth_jwt_secret", oldSecret)
+	withJWTSecret(t)
 
 	ctx := context.Background()
 
@@ -592,10 +592,11 @@ func TestOperatorAuthService_Login_WrongPassword(t *testing.T) {
 	auditLogRepo := &mockAuditLogRepoShared{}
 
 	service, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
-		OperatorRepo: operatorRepo,
-		AuditLogRepo: auditLogRepo,
-		DB:           &bun.DB{},
-		Logger:       slog.Default(),
+		OperatorRepo:     operatorRepo,
+		AuditLogRepo:     auditLogRepo,
+		RefreshTokenRepo: &mockOperatorRefreshTokenRepo{},
+		DB:               &bun.DB{},
+		Logger:           slog.Default(),
 	})
 	require.NoError(t, err)
 
@@ -825,9 +826,7 @@ func TestOperatorAuthService_ChangePassword_UpdateError(t *testing.T) {
 
 func TestOperatorAuthService_Login_AuditLogError(t *testing.T) {
 	// Set JWT secret for token generation
-	oldSecret := viper.GetString("auth_jwt_secret")
-	viper.Set("auth_jwt_secret", testJWTSecret)
-	defer viper.Set("auth_jwt_secret", oldSecret)
+	withJWTSecret(t)
 
 	ctx := context.Background()
 
@@ -858,10 +857,11 @@ func TestOperatorAuthService_Login_AuditLogError(t *testing.T) {
 	}
 
 	service, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
-		OperatorRepo: operatorRepo,
-		AuditLogRepo: auditLogRepo,
-		DB:           &bun.DB{},
-		Logger:       slog.Default(),
+		OperatorRepo:     operatorRepo,
+		AuditLogRepo:     auditLogRepo,
+		RefreshTokenRepo: &mockOperatorRefreshTokenRepo{},
+		DB:               &bun.DB{},
+		Logger:           slog.Default(),
 	})
 	require.NoError(t, err)
 
@@ -873,113 +873,228 @@ func TestOperatorAuthService_Login_AuditLogError(t *testing.T) {
 	assert.NotNil(t, operator)
 }
 
-func TestOperatorAuthService_RefreshToken_Success(t *testing.T) {
-	oldSecret := viper.GetString("auth_jwt_secret")
-	viper.Set("auth_jwt_secret", testJWTSecret)
-	defer viper.Set("auth_jwt_secret", oldSecret)
-
-	ctx := context.Background()
-	operatorRepo := &mockOperatorRepo{
-		findByIDFn: func(ctx context.Context, id int64) (*platform.Operator, error) {
-			return &platform.Operator{
-				Model: base.Model{
-					ID: 42,
-				},
-				Email:       "operator@example.com",
-				DisplayName: "Test Operator",
-				Active:      true,
-			}, nil
-		},
-	}
-	auditLogRepo := &mockAuditLogRepoShared{}
-
-	service, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
-		OperatorRepo: operatorRepo,
-		AuditLogRepo: auditLogRepo,
-		DB:           &bun.DB{},
-		Logger:       slog.Default(),
-	})
+func currentOperatorRefreshToken(t *testing.T, db *bun.DB, operatorID int64) string {
+	t.Helper()
+	var token string
+	err := db.NewSelect().
+		TableExpr("platform.operator_refresh_tokens").
+		Column("token").
+		Where("operator_id = ?", operatorID).
+		Limit(1).
+		Scan(context.Background(), &token)
 	require.NoError(t, err)
+	require.NotEmpty(t, token)
+	return token
+}
 
-	accessToken, refreshToken, err := service.RefreshToken(ctx, 42)
+func countOperatorRefreshTokens(t *testing.T, db *bun.DB, operatorID int64, token string) int {
+	t.Helper()
+	query := db.NewSelect().
+		TableExpr("platform.operator_refresh_tokens").
+		Where("operator_id = ?", operatorID)
+	if token != "" {
+		query = query.Where("token = ?", token)
+	}
+	count, err := query.Count(context.Background())
+	require.NoError(t, err)
+	return count
+}
+
+func TestOperatorAuthService_RefreshToken_SuccessRotatesServerSideSession(t *testing.T) {
+	withJWTSecret(t)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := buildAuthService(t, db)
+	ctx := context.Background()
+	email := fmt.Sprintf("refresh-ok-%d@test.local", time.Now().UnixNano())
+	operatorID, _ := createEmailChangeTestOperator(t, db, email)
+
+	_, firstRefreshJWT, _, err := service.Login(ctx, email, testPassword, net.ParseIP("127.0.0.1"))
+	require.NoError(t, err)
+	require.NotEmpty(t, firstRefreshJWT)
+	oldDBToken := currentOperatorRefreshToken(t, db, operatorID)
+
+	accessToken, secondRefreshJWT, err := service.RefreshToken(ctx, operatorID, oldDBToken)
 	require.NoError(t, err)
 	assert.NotEmpty(t, accessToken)
-	assert.NotEmpty(t, refreshToken)
+	assert.NotEmpty(t, secondRefreshJWT)
+	assert.Equal(t, 0, countOperatorRefreshTokens(t, db, operatorID, oldDBToken),
+		"the used refresh handle must be deleted so it cannot be replayed")
+
+	newDBToken := currentOperatorRefreshToken(t, db, operatorID)
+	assert.NotEqual(t, oldDBToken, newDBToken, "refresh must rotate to a new opaque server-side handle")
+}
+
+func TestOperatorAuthService_RefreshToken_ReplayOldTokenRejected(t *testing.T) {
+	withJWTSecret(t)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := buildAuthService(t, db)
+	ctx := context.Background()
+	email := fmt.Sprintf("refresh-replay-%d@test.local", time.Now().UnixNano())
+	operatorID, _ := createEmailChangeTestOperator(t, db, email)
+
+	_, _, _, err := service.Login(ctx, email, testPassword, net.ParseIP("127.0.0.1"))
+	require.NoError(t, err)
+	oldDBToken := currentOperatorRefreshToken(t, db, operatorID)
+
+	_, _, err = service.RefreshToken(ctx, operatorID, oldDBToken)
+	require.NoError(t, err)
+
+	_, _, err = service.RefreshToken(ctx, operatorID, oldDBToken)
+	require.Error(t, err)
+	var invalidRefresh *platformSvc.OperatorRefreshTokenInvalidError
+	assert.ErrorAs(t, err, &invalidRefresh)
+}
+
+func TestOperatorAuthService_RefreshToken_PasswordChangeRevokesOldToken(t *testing.T) {
+	withJWTSecret(t)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := buildAuthService(t, db)
+	ctx := context.Background()
+	email := fmt.Sprintf("refresh-pwchange-%d@test.local", time.Now().UnixNano())
+	operatorID, _ := createEmailChangeTestOperator(t, db, email)
+
+	_, _, _, err := service.Login(ctx, email, testPassword, net.ParseIP("127.0.0.1"))
+	require.NoError(t, err)
+	oldDBToken := currentOperatorRefreshToken(t, db, operatorID)
+
+	err = service.ChangePassword(ctx, operatorID, testPassword, "ChangedPass789!")
+	require.NoError(t, err)
+	assert.Equal(t, 0, countOperatorRefreshTokens(t, db, operatorID, ""),
+		"password change must revoke every operator refresh session")
+
+	_, _, err = service.RefreshToken(ctx, operatorID, oldDBToken)
+	require.Error(t, err)
+	var invalidRefresh *platformSvc.OperatorRefreshTokenInvalidError
+	assert.ErrorAs(t, err, &invalidRefresh)
 }
 
 func TestOperatorAuthService_RefreshToken_OperatorNotFound(t *testing.T) {
+	withJWTSecret(t)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
 	ctx := context.Background()
 	operatorRepo := &mockOperatorRepo{
 		findByIDFn: func(ctx context.Context, id int64) (*platform.Operator, error) {
 			return nil, nil
 		},
 	}
-	auditLogRepo := &mockAuditLogRepoShared{}
+	refreshRepo := &mockOperatorRefreshTokenRepo{
+		findByTokenForUpdateFn: func(ctx context.Context, token string) (*platform.OperatorRefreshToken, error) {
+			return &platform.OperatorRefreshToken{
+				Model:      base.Model{ID: 10},
+				OperatorID: 999,
+				Token:      token,
+				Expiry:     time.Now().Add(time.Hour),
+				FamilyID:   "family",
+			}, nil
+		},
+		getLatestTokenInFamilyFn: func(ctx context.Context, familyID string) (*platform.OperatorRefreshToken, error) {
+			return &platform.OperatorRefreshToken{Generation: 0}, nil
+		},
+	}
 
 	service, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
-		OperatorRepo: operatorRepo,
-		AuditLogRepo: auditLogRepo,
-		DB:           &bun.DB{},
-		Logger:       slog.Default(),
+		OperatorRepo:     operatorRepo,
+		AuditLogRepo:     &mockAuditLogRepoShared{},
+		RefreshTokenRepo: refreshRepo,
+		DB:               db,
+		Logger:           slog.Default(),
 	})
 	require.NoError(t, err)
 
-	_, _, err = service.RefreshToken(ctx, 999)
+	_, _, err = service.RefreshToken(ctx, 999, "opaque-token")
 	require.Error(t, err)
 	assert.IsType(t, &platformSvc.OperatorNotFoundError{}, err)
 }
 
 func TestOperatorAuthService_RefreshToken_InactiveOperator(t *testing.T) {
-	oldSecret := viper.GetString("auth_jwt_secret")
-	viper.Set("auth_jwt_secret", testJWTSecret)
-	defer viper.Set("auth_jwt_secret", oldSecret)
+	withJWTSecret(t)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
 	operatorRepo := &mockOperatorRepo{
 		findByIDFn: func(ctx context.Context, id int64) (*platform.Operator, error) {
 			return &platform.Operator{
-				Model: base.Model{
-					ID: 1,
-				},
+				Model:       base.Model{ID: id},
 				Email:       "operator@example.com",
 				DisplayName: "Inactive Operator",
 				Active:      false,
 			}, nil
 		},
 	}
-	auditLogRepo := &mockAuditLogRepoShared{}
+	refreshRepo := &mockOperatorRefreshTokenRepo{
+		findByTokenForUpdateFn: func(ctx context.Context, token string) (*platform.OperatorRefreshToken, error) {
+			return &platform.OperatorRefreshToken{
+				Model:      base.Model{ID: 10},
+				OperatorID: 1,
+				Token:      token,
+				Expiry:     time.Now().Add(time.Hour),
+				FamilyID:   "family",
+			}, nil
+		},
+		getLatestTokenInFamilyFn: func(ctx context.Context, familyID string) (*platform.OperatorRefreshToken, error) {
+			return &platform.OperatorRefreshToken{Generation: 0}, nil
+		},
+	}
 
 	service, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
-		OperatorRepo: operatorRepo,
-		AuditLogRepo: auditLogRepo,
-		DB:           &bun.DB{},
-		Logger:       slog.Default(),
+		OperatorRepo:     operatorRepo,
+		AuditLogRepo:     &mockAuditLogRepoShared{},
+		RefreshTokenRepo: refreshRepo,
+		DB:               db,
+		Logger:           slog.Default(),
 	})
 	require.NoError(t, err)
 
-	_, _, err = service.RefreshToken(ctx, 1)
+	_, _, err = service.RefreshToken(ctx, 1, "opaque-token")
 	require.Error(t, err)
 	assert.IsType(t, &platformSvc.OperatorInactiveError{}, err)
 }
 
 func TestOperatorAuthService_RefreshToken_RepositoryError(t *testing.T) {
+	withJWTSecret(t)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
 	ctx := context.Background()
 	operatorRepo := &mockOperatorRepo{
 		findByIDFn: func(ctx context.Context, id int64) (*platform.Operator, error) {
 			return nil, fmt.Errorf("database error")
 		},
 	}
-	auditLogRepo := &mockAuditLogRepoShared{}
+	refreshRepo := &mockOperatorRefreshTokenRepo{
+		findByTokenForUpdateFn: func(ctx context.Context, token string) (*platform.OperatorRefreshToken, error) {
+			return &platform.OperatorRefreshToken{
+				Model:      base.Model{ID: 10},
+				OperatorID: 1,
+				Token:      token,
+				Expiry:     time.Now().Add(time.Hour),
+				FamilyID:   "family",
+			}, nil
+		},
+		getLatestTokenInFamilyFn: func(ctx context.Context, familyID string) (*platform.OperatorRefreshToken, error) {
+			return &platform.OperatorRefreshToken{Generation: 0}, nil
+		},
+	}
 
 	service, err := platformSvc.NewOperatorAuthService(platformSvc.OperatorAuthServiceConfig{
-		OperatorRepo: operatorRepo,
-		AuditLogRepo: auditLogRepo,
-		DB:           &bun.DB{},
-		Logger:       slog.Default(),
+		OperatorRepo:     operatorRepo,
+		AuditLogRepo:     &mockAuditLogRepoShared{},
+		RefreshTokenRepo: refreshRepo,
+		DB:               db,
+		Logger:           slog.Default(),
 	})
 	require.NoError(t, err)
 
-	_, _, err = service.RefreshToken(ctx, 1)
+	_, _, err = service.RefreshToken(ctx, 1, "opaque-token")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to find operator")
 }

--- a/backend/services/platform/operator_email_change_integration_test.go
+++ b/backend/services/platform/operator_email_change_integration_test.go
@@ -38,6 +38,7 @@ var fastArgon2Params = &userpass.PasswordParams{
 // buildAuthService creates a fully-wired OperatorAuthService via the standard factory.
 func buildAuthService(t *testing.T, db *bun.DB) platformSvc.OperatorAuthService {
 	t.Helper()
+	withJWTSecret(t)
 	repoFactory := repositories.NewFactory(db)
 	serviceFactory, err := services.NewFactory(repoFactory, db, slog.Default())
 	require.NoError(t, err, "Failed to create service factory")
@@ -62,6 +63,7 @@ func createEmailChangeTestOperator(t *testing.T, db *bun.DB, email string) (int6
 
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM platform.operator_email_change_tokens WHERE operator_id = ?`, operatorID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM platform.operator_refresh_tokens WHERE operator_id = ?`, operatorID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM platform.operator_audit_log WHERE operator_id = ?`, operatorID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM platform.operators WHERE id = ?`, operatorID)
 	})

--- a/backend/services/platform/test_mocks_test.go
+++ b/backend/services/platform/test_mocks_test.go
@@ -112,6 +112,67 @@ func (m *mockAuditLogRepoShared) FindByDateRange(ctx context.Context, start, end
 	return nil, nil
 }
 
+type mockOperatorRefreshTokenRepo struct {
+	createFn                 func(ctx context.Context, token *platform.OperatorRefreshToken) error
+	findByTokenForUpdateFn   func(ctx context.Context, token string) (*platform.OperatorRefreshToken, error)
+	deleteFn                 func(ctx context.Context, id any) error
+	deleteByOperatorIDFn     func(ctx context.Context, operatorID int64) (int, error)
+	deleteByFamilyIDFn       func(ctx context.Context, familyID string) error
+	getLatestTokenInFamilyFn func(ctx context.Context, familyID string) (*platform.OperatorRefreshToken, error)
+	deleteExpiredFn          func(ctx context.Context, now time.Time) (int, error)
+	created                  []*platform.OperatorRefreshToken
+}
+
+func (m *mockOperatorRefreshTokenRepo) Create(ctx context.Context, token *platform.OperatorRefreshToken) error {
+	if m.createFn != nil {
+		return m.createFn(ctx, token)
+	}
+	m.created = append(m.created, token)
+	return nil
+}
+
+func (m *mockOperatorRefreshTokenRepo) FindByTokenForUpdate(ctx context.Context, token string) (*platform.OperatorRefreshToken, error) {
+	if m.findByTokenForUpdateFn != nil {
+		return m.findByTokenForUpdateFn(ctx, token)
+	}
+	return nil, nil
+}
+
+func (m *mockOperatorRefreshTokenRepo) Delete(ctx context.Context, id any) error {
+	if m.deleteFn != nil {
+		return m.deleteFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockOperatorRefreshTokenRepo) DeleteByOperatorID(ctx context.Context, operatorID int64) (int, error) {
+	if m.deleteByOperatorIDFn != nil {
+		return m.deleteByOperatorIDFn(ctx, operatorID)
+	}
+	return 0, nil
+}
+
+func (m *mockOperatorRefreshTokenRepo) DeleteByFamilyID(ctx context.Context, familyID string) error {
+	if m.deleteByFamilyIDFn != nil {
+		return m.deleteByFamilyIDFn(ctx, familyID)
+	}
+	return nil
+}
+
+func (m *mockOperatorRefreshTokenRepo) GetLatestTokenInFamily(ctx context.Context, familyID string) (*platform.OperatorRefreshToken, error) {
+	if m.getLatestTokenInFamilyFn != nil {
+		return m.getLatestTokenInFamilyFn(ctx, familyID)
+	}
+	return nil, nil
+}
+
+func (m *mockOperatorRefreshTokenRepo) DeleteExpired(ctx context.Context, now time.Time) (int, error) {
+	if m.deleteExpiredFn != nil {
+		return m.deleteExpiredFn(ctx, now)
+	}
+	return 0, nil
+}
+
 // Shared mock for account tenant repository
 type mockAccountTenantRepo struct {
 	createFn                     func(ctx context.Context, mapping *auth.AccountTenant) error

--- a/backend/services/scheduler/scheduler_test.go
+++ b/backend/services/scheduler/scheduler_test.go
@@ -1188,6 +1188,9 @@ func (m *mockActiveService) CheckInStudent(_ context.Context, _, _, _ int64, _ b
 func (m *mockActiveService) CheckOutStudent(_ context.Context, _, _ int64, _ bool) (*activeService.AttendanceResult, error) {
 	return nil, nil
 }
+func (m *mockActiveService) CheckOutStudentFromDevice(_ context.Context, _, _ int64) (*activeService.AttendanceResult, error) {
+	return nil, nil
+}
 func (m *mockActiveService) CheckTeacherStudentAccess(_ context.Context, _, _ int64) (bool, error) {
 	return false, nil
 }

--- a/backend/services/scheduler/scheduler_test.go
+++ b/backend/services/scheduler/scheduler_test.go
@@ -2357,13 +2357,16 @@ func (m *mockBreakAutoEnder) AutoEndExpiredBreaks(_ context.Context) (int, error
 }
 
 func TestWaitUntilNextMinute_ShutdownDuringWait(t *testing.T) {
-	s := &Scheduler{done: make(chan struct{}), logger: slog.Default()}
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		close(s.done)
-	}()
-	result := s.waitUntilNextMinute()
-	assert.False(t, result, "should return false when shutdown signal fires during wait")
+	synctest.Test(t, func(t *testing.T) {
+		s := &Scheduler{done: make(chan struct{}), logger: slog.Default()}
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			close(s.done)
+		}()
+
+		result := s.waitUntilNextMinute()
+		assert.False(t, result, "should return false when shutdown signal fires during wait")
+	})
 }
 
 func TestScheduleCleanupTask_DisabledByEnv(t *testing.T) {

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
@@ -347,6 +347,12 @@ vi.mock("~/components/students/care-schedule-manager", () => ({
   ),
 }));
 
+const mockFetchStudentParentNotes = vi.fn();
+vi.mock("~/lib/student-parent-notes-api", () => ({
+  fetchStudentParentNotes: (studentId: string) =>
+    mockFetchStudentParentNotes(studentId),
+}));
+
 // Mock pickup schedule API
 vi.mock("~/lib/pickup-schedule-api", () => ({
   fetchStudentPickupData: vi.fn().mockResolvedValue({
@@ -511,6 +517,7 @@ describe("StudentDetailPage", () => {
       data: { user: { token: "test-token", permissions: ["config:manage"] } },
       status: "authenticated",
     } as ReturnType<typeof useSession>);
+    mockFetchStudentParentNotes.mockResolvedValue([]);
 
     // Default mock implementations
     mockUseStudentData.mockReturnValue({

--- a/frontend/src/components/enrollment/admin-enrollment-detail.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-detail.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import {
   type AdminRequestChild,
+  type AdminRequestDetail,
   type AdminOfferingAdjustment,
   type AdminRequestChildOffering,
   type AdminRequestGuardian,
@@ -95,7 +96,7 @@ interface Props {
 
 export function AdminEnrollmentDetail({ requestId }: Props) {
   const tenantPath = useTenantAwarePath();
-  const [data, setData] = useState<AdminRequestSummary | null>(null);
+  const [data, setData] = useState<AdminRequestDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);

--- a/frontend/src/components/enrollment/admin-enrollment-phase-detail.test.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-phase-detail.test.tsx
@@ -93,7 +93,6 @@ const requests = [
     guardian_last_name: "Muster",
     guardian_email: "eva@example.test",
     submitted_at: "2026-06-18T11:15:00Z",
-    status_token: "token",
     children: [
       {
         id: "20",

--- a/frontend/src/lib/enrollment-admin-api.ts
+++ b/frontend/src/lib/enrollment-admin-api.ts
@@ -108,7 +108,6 @@ export interface AdminRequestSummary {
   guardian_phone?: string | null;
   submitted_at: string;
   withdrawn_at?: string | null;
-  status_token: string;
   /**
    * Request-level custom field answers (everything where
    * applies_to_child=false). Populated only on the detail endpoint.
@@ -134,6 +133,10 @@ export interface AdminRequestSummary {
    * Empty/absent when none were added.
    */
   additional_guardians?: AdminRequestGuardian[];
+}
+
+export interface AdminRequestDetail extends AdminRequestSummary {
+  status_token: string;
 }
 
 /** One additional guardian (co-guardian) on a submission. */
@@ -200,16 +203,14 @@ export async function listAdminRequests(
   return Array.isArray(list) ? list : [];
 }
 
-export async function getAdminRequest(
-  id: string,
-): Promise<AdminRequestSummary> {
+export async function getAdminRequest(id: string): Promise<AdminRequestDetail> {
   const response = await fetch(`${BASE}/${encodeURIComponent(id)}`, {
     cache: "no-store",
   });
   if (!response.ok) {
     throw await readError(response, "Anmeldung konnte nicht geladen werden");
   }
-  return readJSON<AdminRequestSummary>(response);
+  return readJSON<AdminRequestDetail>(response);
 }
 
 export async function listStudentEnrollmentRequests(


### PR DESCRIPTION
## Summary
- Remove `status_token` from enrollment admin list/summary responses so `config:read` users cannot receive parent bearer tokens.
- Keep `status_token` on the manage-only single request detail response for the existing admin status-page link.
- Update frontend admin request types and list fixtures to match the new response boundary.
- Persist operator refresh sessions in `platform.operator_refresh_tokens` and rotate opaque refresh handles on each operator refresh.
- Revoke all operator refresh sessions when an operator changes their password, and reject legacy deterministic operator refresh claims before service rotation.
- Reject stale operator access tokens by reloading current operator state on every protected operator route before control-plane handlers run.
- Stabilize `TestWaitUntilNextMinute_ShutdownDuringWait`, which was racing the real wall-clock minute boundary in CI.
- Require IoT daily checkout to resolve the authenticated device's active supervisor before closing attendance, so `checked_out_by` is an auditable staff principal.
- Reject IoT daily checkout when the device has no active supervised group, leaving the attendance row open instead of writing an unattributed checkout.

## Context
This draft PR now covers these Codex Security findings tracked in #1761:
- Admin request list leaks parent status tokens to config-read users.
- Operator password changes do not revoke stateless refresh tokens.
- Deactivated operators can keep using protected routes until access-token expiry.
- IoT daily checkout writes attendance without a staff principal.

The IoT daily-checkout fix preserves the PyrePortal device auth contract: the existing device API key + `X-Staff-PIN` headers and existing device-auth error strings are unchanged. The checkout branch now reuses the existing active-service IoT authorization model and attributes the write to the device session's active supervisor.

Closes #1761

## Validation
- `cd backend && APP_ENV=test DB_DSN='postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable' PHOENIX_AUTH_PASSWORD=phoenix_auth_dev go run . migrate reset`
- `cd backend && TEST_DB_DSN='postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable' PHOENIX_AUTH_PASSWORD=phoenix_auth_dev go test -count=1 ./database/repositories/platform -run OperatorRefreshToken`
- `cd backend && TEST_DB_DSN='postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable' PHOENIX_AUTH_PASSWORD=phoenix_auth_dev go test -count=1 ./api/operator -run 'TestRefreshToken'`
- `cd backend && TEST_DB_DSN='postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable' PHOENIX_AUTH_PASSWORD=phoenix_auth_dev go test -count=1 ./services/platform -run 'TestOperatorAuthService_(Login|RefreshToken|ChangePassword|IssueTokensForAuthenticatedOperator)|TestIntegration_EmailChange_ChangePassword_InvalidatesToken'`
- `cd backend && TEST_DB_DSN='postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable' PHOENIX_AUTH_PASSWORD=phoenix_auth_dev go test -count=1 ./models ./database/repositories/platform ./services/platform ./api/operator`
- `cd backend && go test ./api/enrollment -run 'Test(ToAdminRequestSummary|ListAdminRequestsHandler|AdminRequestRoutes|GetAdminRequestHandler)'`
- `cd backend && go test ./api/enrollment`
- `cd backend && go test ./services/scheduler -run TestWaitUntilNextMinute_ShutdownDuringWait -count=50`
- `cd backend && go test ./services/scheduler`
- `cd backend && go test -count=1 ./api/operator -run 'TestRequiresOperatorScope|TestRequiresActiveOperator|TestProtectedOperatorRoutes'`
- `cd backend && go test -count=1 ./api/operator`
- `cd backend && go test -count=1 ./services/platform -run 'TestOperatorAuthService_(Login|RefreshToken|ChangePassword|IssueTokensForAuthenticatedOperator)'`
- `cd backend && go test -count=1 ./api/operator ./services/platform`
- `cd backend && TEST_DB_DSN='postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable' PHOENIX_AUTH_PASSWORD=phoenix_auth_dev go test -count=1 ./api/iot/attendance ./services/active`
- `cd backend && TEST_DB_DSN='postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable' PHOENIX_AUTH_PASSWORD=phoenix_auth_dev go test -count=1 ./api/iot/... ./auth/device ./services/active`
- `cd backend && TEST_DB_DSN='postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable' PHOENIX_AUTH_PASSWORD=phoenix_auth_dev go test -count=1 ./api/active ./api/sse ./services/scheduler`
- `cd backend && TEST_DB_DSN='postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable' PHOENIX_AUTH_PASSWORD=phoenix_auth_dev go test -count=1 ./auth/device ./api/iot/checkin -run 'Test(PyrePortalCheckinErrorStringsGuard|DeviceAuthenticator|ErrorTypes)'`
- `cd backend && go test ./test/ -run TestHermeticTestPatterns -v` currently fails on pre-existing `api/operator/api_test.go:235` hardcoded `int64(7)`; unrelated to this IoT daily-checkout patch.
- `cd frontend && pnpm run check`
- Pre-commit hook: `git-secrets`, `go-imports`
- Pre-push hook: `git-secrets`, `go-vet`, `golangci-lint`, `go-deadcode`; earlier push also ran `frontend-knip` and `frontend-check`

