### PR TITLE
Handle Schulhof room conflicts

### DIFF
--- a/backend/api/active/schulhof_handlers.go
+++ b/backend/api/active/schulhof_handlers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 	"github.com/moto-nrw/project-phoenix/services/facilities"
 	"github.com/moto-nrw/project-phoenix/services/usercontext"
 )
@@ -133,6 +134,10 @@ func (rs *SchulhofResource) toggleSchulhofSupervision(w http.ResponseWriter, r *
 		// Check for specific error messages
 		errMsg := err.Error()
 		if errMsg == "user is not currently supervising the Schulhof" {
+			common.RenderError(w, r, common.ErrorConflict(err))
+			return
+		}
+		if errors.Is(err, activeSvc.ErrRoomConflict) {
 			common.RenderError(w, r, common.ErrorConflict(err))
 			return
 		}

--- a/backend/api/active/schulhof_handlers_test.go
+++ b/backend/api/active/schulhof_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,6 +23,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/auth"
 	"github.com/moto-nrw/project-phoenix/models/education"
 	"github.com/moto-nrw/project-phoenix/models/users"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 	"github.com/moto-nrw/project-phoenix/services/facilities"
 )
 
@@ -498,6 +500,34 @@ func TestToggleSchulhofSupervision_NotCurrentlySupervisingError(t *testing.T) {
 
 	assert.Equal(t, http.StatusConflict, rr.Code)
 	assert.Contains(t, rr.Body.String(), "user is not currently supervising the Schulhof")
+}
+
+func TestToggleSchulhofSupervision_RoomConflict(t *testing.T) {
+	mockSchulhof := &mockSchulhofService{
+		toggleSupervisionFunc: func(ctx context.Context, staffID int64, action string) (*facilities.SupervisionResult, error) {
+			return nil, fmt.Errorf("failed to get/create active group: %w", activeSvc.ErrRoomConflict)
+		},
+	}
+
+	mockUserContext := &mockUserContextService{
+		getCurrentStaffFunc: func(ctx context.Context) (*users.Staff, error) {
+			return &users.Staff{PersonID: 10}, nil
+		},
+	}
+
+	resource := NewSchulhofResource(mockSchulhof, mockUserContext)
+	router := setupSchulhofTestRouter(resource)
+	body := map[string]interface{}{
+		"action": "start",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/supervise", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := executeSchulhofRequest(router, req, testutil.AdminTestClaims(1), []string{"schulhof:write"})
+
+	assert.Equal(t, http.StatusConflict, rr.Code)
+	assert.Contains(t, rr.Body.String(), "room is already occupied by another active group")
 }
 
 func TestToggleSchulhofSupervision_ServiceError(t *testing.T) {

--- a/backend/services/facilities/schulhof_service.go
+++ b/backend/services/facilities/schulhof_service.go
@@ -4,6 +4,7 @@ package facilities
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -334,6 +335,18 @@ func (s *schulhofService) GetOrCreateActiveGroup(ctx context.Context, createdBy 
 	}
 
 	if err := s.activeService.CreateActiveGroup(ctx, newActiveGroup); err != nil {
+		if errors.Is(err, activeSvc.ErrRoomConflict) {
+			existingGroup, findErr := s.findTodayActiveGroup(ctx, room.ID, activityGroup.ID)
+			if findErr != nil {
+				return nil, fmt.Errorf("failed to refetch Schulhof active group after room conflict: %w", findErr)
+			}
+			if existingGroup != nil {
+				s.getLogger().Info("reused concurrently created schulhof active group",
+					slog.String("component", "schulhof"),
+					slog.Int64("active_group_id", existingGroup.ID))
+				return existingGroup, nil
+			}
+		}
 		return nil, fmt.Errorf("failed to create Schulhof active group: %w", err)
 	}
 

--- a/backend/services/facilities/schulhof_service_conflict_test.go
+++ b/backend/services/facilities/schulhof_service_conflict_test.go
@@ -1,0 +1,168 @@
+package facilities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/active"
+	activityModels "github.com/moto-nrw/project-phoenix/models/activities"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	facilityModels "github.com/moto-nrw/project-phoenix/models/facilities"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	activitySvc "github.com/moto-nrw/project-phoenix/services/activities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type schulhofConflictFacilityService struct {
+	Service
+	room *facilityModels.Room
+}
+
+func (s *schulhofConflictFacilityService) FindRoomByName(context.Context, string) (*facilityModels.Room, error) {
+	return s.room, nil
+}
+
+type schulhofConflictActivityService struct {
+	activitySvc.ActivityService
+	group *activityModels.Group
+}
+
+func (s *schulhofConflictActivityService) ListGroups(context.Context, *base.QueryOptions) ([]*activityModels.Group, error) {
+	if s.group == nil {
+		return []*activityModels.Group{}, nil
+	}
+	return []*activityModels.Group{s.group}, nil
+}
+
+type schulhofConflictActiveService struct {
+	activeSvc.Service
+
+	findGroupsByCall [][]*active.Group
+	findErrorsByCall []error
+	createErr        error
+
+	createCalls int
+	findCalls   int
+	endedIDs    []int64
+}
+
+func (s *schulhofConflictActiveService) FindActiveGroupsByRoomID(context.Context, int64) ([]*active.Group, error) {
+	call := s.findCalls
+	s.findCalls++
+
+	if call < len(s.findErrorsByCall) && s.findErrorsByCall[call] != nil {
+		return nil, s.findErrorsByCall[call]
+	}
+	if call < len(s.findGroupsByCall) {
+		return s.findGroupsByCall[call], nil
+	}
+	return []*active.Group{}, nil
+}
+
+func (s *schulhofConflictActiveService) EndActiveGroupSession(_ context.Context, id int64) error {
+	s.endedIDs = append(s.endedIDs, id)
+	return nil
+}
+
+func (s *schulhofConflictActiveService) CreateActiveGroup(context.Context, *active.Group) error {
+	s.createCalls++
+	return s.createErr
+}
+
+func newSchulhofConflictService(activeService *schulhofConflictActiveService, room *facilityModels.Room, activityGroup *activityModels.Group) *schulhofService {
+	return &schulhofService{
+		facilityService: &schulhofConflictFacilityService{room: room},
+		activityService: &schulhofConflictActivityService{group: activityGroup},
+		activeService:   activeService,
+		logger:          slog.New(slog.DiscardHandler),
+	}
+}
+
+func TestSchulhofService_GetOrCreateActiveGroup_ReusesConcurrentSchulhofGroupAfterRoomConflict(t *testing.T) {
+	ctx := context.Background()
+	room := &facilityModels.Room{Model: base.Model{ID: 42}}
+	activityGroup := &activityModels.Group{Model: base.Model{ID: 77}, PlannedRoomID: &room.ID}
+	concurrentGroup := &active.Group{
+		Model:     base.Model{ID: 88},
+		GroupID:   &activityGroup.ID,
+		RoomID:    room.ID,
+		StartTime: time.Now(),
+	}
+	activeService := &schulhofConflictActiveService{
+		findGroupsByCall: [][]*active.Group{
+			{},
+			{},
+			{concurrentGroup},
+		},
+		createErr: fmt.Errorf("create raced with another supervisor: %w", activeSvc.ErrRoomConflict),
+	}
+	service := newSchulhofConflictService(activeService, room, activityGroup)
+
+	result, err := service.GetOrCreateActiveGroup(ctx, 123)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, concurrentGroup.ID, result.ID)
+	assert.Equal(t, 1, activeService.createCalls)
+	assert.Equal(t, 3, activeService.findCalls)
+	assert.Empty(t, activeService.endedIDs)
+}
+
+func TestSchulhofService_GetOrCreateActiveGroup_ReturnsRefetchErrorAfterRoomConflict(t *testing.T) {
+	ctx := context.Background()
+	room := &facilityModels.Room{Model: base.Model{ID: 42}}
+	activityGroup := &activityModels.Group{Model: base.Model{ID: 77}, PlannedRoomID: &room.ID}
+	refetchErr := errors.New("refetch failed")
+	activeService := &schulhofConflictActiveService{
+		findGroupsByCall: [][]*active.Group{
+			{},
+			{},
+			nil,
+		},
+		findErrorsByCall: []error{
+			nil,
+			nil,
+			refetchErr,
+		},
+		createErr: fmt.Errorf("create raced with another supervisor: %w", activeSvc.ErrRoomConflict),
+	}
+	service := newSchulhofConflictService(activeService, room, activityGroup)
+
+	result, err := service.GetOrCreateActiveGroup(ctx, 123)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, refetchErr)
+	assert.Contains(t, err.Error(), "failed to refetch Schulhof active group after room conflict")
+	assert.Equal(t, 1, activeService.createCalls)
+	assert.Equal(t, 3, activeService.findCalls)
+}
+
+func TestSchulhofService_GetOrCreateActiveGroup_PropagatesRoomConflictWhenRefetchFindsNoGroup(t *testing.T) {
+	ctx := context.Background()
+	room := &facilityModels.Room{Model: base.Model{ID: 42}}
+	activityGroup := &activityModels.Group{Model: base.Model{ID: 77}, PlannedRoomID: &room.ID}
+	activeService := &schulhofConflictActiveService{
+		findGroupsByCall: [][]*active.Group{
+			{},
+			{},
+			{},
+		},
+		createErr: &activeSvc.ActiveError{Op: "CreateActiveGroup", Err: activeSvc.ErrRoomConflict},
+	}
+	service := newSchulhofConflictService(activeService, room, activityGroup)
+
+	result, err := service.GetOrCreateActiveGroup(ctx, 123)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, activeSvc.ErrRoomConflict)
+	assert.Contains(t, err.Error(), "failed to create Schulhof active group")
+	assert.Equal(t, 1, activeService.createCalls)
+	assert.Equal(t, 3, activeService.findCalls)
+}


### PR DESCRIPTION
## Summary
- Return Schulhof room conflicts as HTTP 409 instead of reporting them as 500s to Sentry.
- Reuse a concurrently created Schulhof active group when a start request races another request.
- Add regression coverage for the wrapped room-conflict error path.

## Root cause
The Schulhof supervision handler treated wrapped `ErrRoomConflict` values as internal server errors. In production, a normal room conflict in the Schulhof room became a Sentry issue instead of a client-visible conflict response.

This PR only contains the Sentry/error-handling patch. The separate product decision about blocking Schulhof in spontaneous activities stays out of scope here.

Refs #1764

## Validation
- `cd backend && go test ./api/active -run ^TestToggleSchulhofSupervision -count=1`
- `cd backend && go test ./services/facilities -run ^$ -count=1`
- `git diff --check`
- pre-push: `git-secrets`, `go-deadcode`, `go-vet`, `golangci-lint`