### PR TITLE
refactor(active-supervisions): rebuild spontaneous activity modal on UI kit

### DIFF
--- a/frontend/src/components/active-supervisions/spontaneous-activity-start.test.tsx
+++ b/frontend/src/components/active-supervisions/spontaneous-activity-start.test.tsx
@@ -21,22 +21,75 @@ vi.mock("~/lib/staff-api", () => ({
   },
 }));
 
-vi.mock("~/components/ui/modal", () => ({
-  Modal: ({
-    isOpen,
-    children,
-    title,
-  }: {
-    isOpen: boolean;
-    children: React.ReactNode;
-    title: string;
-  }) =>
-    isOpen ? (
-      <div data-testid="modal" data-title={title}>
-        {children}
-      </div>
-    ) : null,
-}));
+// The modal renders to a portal with animations in the real kit component;
+// stub it to a plain container so tests stay synchronous. The footer is a
+// separate prop from the body, so render both (the submit/cancel buttons live
+// in the footer). The stub keeps the real kit's document-level Escape handler
+// (form-modal.tsx) so the autocomplete-vs-modal Escape regression is covered.
+vi.mock("~/components/ui/form-modal", async () => {
+  const { useEffect } = await import("react");
+  return {
+    FormModal: ({
+      isOpen,
+      onClose,
+      children,
+      footer,
+      title,
+    }: {
+      isOpen: boolean;
+      onClose: () => void;
+      children: React.ReactNode;
+      footer?: React.ReactNode;
+      title: string;
+    }) => {
+      useEffect(() => {
+        if (!isOpen) return;
+        const handleEscKey = (event: KeyboardEvent) => {
+          if (event.key === "Escape") onClose();
+        };
+        document.addEventListener("keydown", handleEscKey);
+        return () => document.removeEventListener("keydown", handleEscKey);
+      }, [isOpen, onClose]);
+      return isOpen ? (
+        <div data-testid="modal" data-title={title}>
+          {children}
+          {footer}
+        </div>
+      ) : null;
+    },
+  };
+});
+
+// The kit room picker (CustomSelect) is a listbox button, not a native
+// <select>: options only render once the trigger is opened, and the submit
+// button lives outside the <form> (wired via the form="" attribute), so we
+// submit the form element directly.
+function getRoomCombobox(): HTMLElement {
+  return screen.getByRole("combobox", { name: "Raum" });
+}
+
+async function openModalAndWaitForRefs(): Promise<void> {
+  fireEvent.click(
+    screen.getByRole("button", { name: /Spontane Aktivität starten/ }),
+  );
+  await screen.findByTestId("modal");
+  // References load asynchronously; the room picker is disabled until then
+  // (and the default room is auto-selected at the same moment).
+  await waitFor(() => expect(getRoomCombobox()).toBeEnabled());
+}
+
+function selectRoom(optionName: string): void {
+  fireEvent.click(getRoomCombobox());
+  fireEvent.click(screen.getByRole("option", { name: optionName }));
+}
+
+function submitForm(): void {
+  const form = screen
+    .getByPlaceholderText("Aktivität suchen oder neu eingeben")
+    .closest("form");
+  if (!form) throw new Error("spontaneous activity form not found");
+  fireEvent.submit(form);
+}
 
 describe("SpontaneousActivityStart", () => {
   beforeEach(() => {
@@ -72,22 +125,16 @@ describe("SpontaneousActivityStart", () => {
       />,
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /Spontane Aktivität starten/ }),
-    );
-
-    await screen.findByTestId("modal");
+    await openModalAndWaitForRefs();
     fireEvent.change(
       screen.getByPlaceholderText("Aktivität suchen oder neu eingeben"),
       {
         target: { value: "Basteln" },
       },
     );
-    fireEvent.change(screen.getByLabelText("Raum"), {
-      target: { value: "3" },
-    });
+    selectRoom("Mensa");
     fireEvent.click(screen.getByLabelText("Ben Staff"));
-    fireEvent.click(screen.getByRole("button", { name: "Aktivität starten" }));
+    submitForm();
 
     await waitFor(() => {
       expect(onStart).toHaveBeenCalledWith({
@@ -118,25 +165,21 @@ describe("SpontaneousActivityStart", () => {
       />,
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /Spontane Aktivität starten/ }),
-    );
-
-    await screen.findByTestId("modal");
+    await openModalAndWaitForRefs();
+    fireEvent.click(getRoomCombobox());
     expect(screen.getByRole("option", { name: "Mensa" })).toBeInTheDocument();
     expect(
       screen.getByRole("option", { name: "Haus A - Atelier" }),
     ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("option", { name: "Mensa" }));
+
     fireEvent.change(
       screen.getByPlaceholderText("Aktivität suchen oder neu eingeben"),
       {
         target: { value: "Tennis" },
       },
     );
-    fireEvent.change(screen.getByLabelText("Raum"), {
-      target: { value: "3" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Aktivität starten" }));
+    submitForm();
 
     await waitFor(() => {
       expect(onStart).toHaveBeenCalledWith({
@@ -158,18 +201,14 @@ describe("SpontaneousActivityStart", () => {
       />,
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /Spontane Aktivität starten/ }),
-    );
-
-    await screen.findByTestId("modal");
+    await openModalAndWaitForRefs();
     fireEvent.change(
       screen.getByPlaceholderText("Aktivität suchen oder neu eingeben"),
       {
         target: { value: " spontane Lego-Werkstatt " },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Aktivität starten" }));
+    submitForm();
 
     await waitFor(() => {
       expect(onStart).toHaveBeenCalledWith({
@@ -192,11 +231,8 @@ describe("SpontaneousActivityStart", () => {
       />,
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /Spontane Aktivität starten/ }),
-    );
-
-    await screen.findByTestId("modal");
+    await openModalAndWaitForRefs();
+    fireEvent.click(getRoomCombobox());
     expect(
       screen.getByRole("option", { name: "Mensa (belegt)" }),
     ).toBeDisabled();
@@ -226,15 +262,11 @@ describe("SpontaneousActivityStart", () => {
       />,
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /Spontane Aktivität starten/ }),
-    );
-
-    await screen.findByTestId("modal");
+    await openModalAndWaitForRefs();
     fireEvent.click(screen.getByRole("button", { name: "Freispiel" }));
     fireEvent.click(screen.getByLabelText("Ben Staff"));
     fireEvent.click(screen.getByLabelText("Ben Staff"));
-    fireEvent.click(screen.getByRole("button", { name: "Aktivität starten" }));
+    submitForm();
 
     await waitFor(() => {
       expect(onStart).toHaveBeenCalledWith({
@@ -256,23 +288,16 @@ describe("SpontaneousActivityStart", () => {
 
     render(<SpontaneousActivityStart onStart={vi.fn()} />);
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /Spontane Aktivität starten/ }),
-    );
-
-    await screen.findByTestId("modal");
-    await waitFor(() => {
-      expect(
-        screen.getByRole("option", { name: "Raum auswählen" }),
-      ).toBeInTheDocument();
-    });
+    await openModalAndWaitForRefs();
+    // No rooms loaded -> the picker shows its placeholder and has no options.
+    expect(screen.getByText("Raum auswählen")).toBeInTheDocument();
     expect(screen.queryByText("Weitere Betreuer")).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Aktivität starten" }),
     ).toBeDisabled();
   });
 
-  it("shows an error when submitting an occupied selected room", async () => {
+  it("disables an occupied room so it cannot be selected for a new activity", async () => {
     const onStart = vi.fn();
     render(
       <SpontaneousActivityStart
@@ -282,29 +307,16 @@ describe("SpontaneousActivityStart", () => {
       />,
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /Spontane Aktivität starten/ }),
-    );
-
-    await screen.findByTestId("modal");
-    fireEvent.change(
-      screen.getByPlaceholderText("Aktivität suchen oder neu eingeben"),
-      {
-        target: { value: "Tennis" },
-      },
-    );
-    fireEvent.change(screen.getByLabelText("Raum"), {
-      target: { value: "3" },
-    });
-    fireEvent.submit(
-      screen
-        .getByRole("button", { name: "Aktivität starten" })
-        .closest("form")!,
-    );
-
+    await openModalAndWaitForRefs();
+    fireEvent.click(getRoomCombobox());
+    // The occupied room is rendered but not selectable.
     expect(
-      await screen.findByText("Der Raum ist bereits belegt."),
-    ).toBeInTheDocument();
+      screen.getByRole("option", { name: "Mensa (belegt)" }),
+    ).toBeDisabled();
+    // The remaining free room stays usable.
+    expect(
+      screen.getByRole("option", { name: "Haus A - Atelier" }),
+    ).toBeEnabled();
     expect(onStart).not.toHaveBeenCalled();
   });
 
@@ -317,11 +329,7 @@ describe("SpontaneousActivityStart", () => {
       />,
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /Spontane Aktivität starten/ }),
-    );
-
-    await screen.findByTestId("modal");
+    await openModalAndWaitForRefs();
     fireEvent.change(
       screen.getByPlaceholderText("Aktivität suchen oder neu eingeben"),
       {
@@ -329,13 +337,127 @@ describe("SpontaneousActivityStart", () => {
       },
     );
     fireEvent.click(screen.getByRole("button", { name: "Abbrechen" }));
-    fireEvent.click(
-      screen.getByRole("button", { name: /Spontane Aktivität starten/ }),
-    );
-
-    await screen.findByTestId("modal");
+    await openModalAndWaitForRefs();
     expect(
       screen.getByPlaceholderText("Aktivität suchen oder neu eingeben"),
     ).toHaveValue("");
+  });
+
+  it("dismisses the activity suggestions on Escape without closing the modal", async () => {
+    const onStart = vi.fn();
+    render(
+      <SpontaneousActivityStart
+        currentStaffId="11"
+        defaultRoomId="3"
+        onStart={onStart}
+      />,
+    );
+
+    await openModalAndWaitForRefs();
+    const activityInput = screen.getByPlaceholderText(
+      "Aktivität suchen oder neu eingeben",
+    );
+    fireEvent.change(activityInput, { target: { value: "Bast" } });
+    // The suggestion list is open (the listbox option, not the chip button).
+    expect(screen.getByRole("option", { name: "Basteln" })).toBeInTheDocument();
+
+    fireEvent.keyDown(activityInput, { key: "Escape" });
+
+    // Escape only closes the suggestion list...
+    expect(
+      screen.queryByRole("option", { name: "Basteln" }),
+    ).not.toBeInTheDocument();
+    // ...the modal stays open and the draft survives (no bubble to the
+    // FormModal document-level Escape handler).
+    expect(screen.getByTestId("modal")).toBeInTheDocument();
+    expect(activityInput).toHaveValue("Bast");
+  });
+
+  it("lets Escape close the modal when no activity suggestions are visible", async () => {
+    const onStart = vi.fn();
+    render(
+      <SpontaneousActivityStart
+        currentStaffId="11"
+        defaultRoomId="3"
+        onStart={onStart}
+      />,
+    );
+
+    await openModalAndWaitForRefs();
+    const activityInput = screen.getByPlaceholderText(
+      "Aktivität suchen oder neu eingeben",
+    );
+    fireEvent.change(activityInput, { target: { value: "ZZZ" } });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    fireEvent.keyDown(activityInput, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes activity suggestions when keyboard focus leaves the field", async () => {
+    const onStart = vi.fn();
+    render(
+      <SpontaneousActivityStart
+        currentStaffId="11"
+        defaultRoomId="3"
+        onStart={onStart}
+      />,
+    );
+
+    await openModalAndWaitForRefs();
+    const activityInput = screen.getByPlaceholderText(
+      "Aktivität suchen oder neu eingeben",
+    );
+    fireEvent.change(activityInput, { target: { value: "Bast" } });
+    expect(screen.getByRole("option", { name: "Basteln" })).toBeInTheDocument();
+
+    fireEvent.blur(activityInput, { relatedTarget: getRoomCombobox() });
+
+    expect(
+      screen.queryByRole("option", { name: "Basteln" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("modal")).toBeInTheDocument();
+  });
+
+  it("submits the typed title on Enter instead of replacing it with the highlighted suggestion", async () => {
+    const onStart = vi.fn();
+    render(
+      <SpontaneousActivityStart
+        currentStaffId="11"
+        defaultRoomId="3"
+        onStart={onStart}
+      />,
+    );
+
+    await openModalAndWaitForRefs();
+    const activityInput = screen.getByPlaceholderText(
+      "Aktivität suchen oder neu eingeben",
+    );
+    fireEvent.change(activityInput, { target: { value: "Bas" } });
+    // A suggestion is highlighted, but Enter must NOT adopt it (datalist
+    // parity): the typed text stays untouched.
+    expect(screen.getByRole("option", { name: "Basteln" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    fireEvent.keyDown(activityInput, { key: "Enter" });
+    expect(activityInput).toHaveValue("Bas");
+
+    // Submitting sends the partial text verbatim as a new activity title
+    // (jsdom does not perform native implicit submission on Enter, so the
+    // form submit is triggered directly here).
+    submitForm();
+    await waitFor(() => {
+      expect(onStart).toHaveBeenCalledWith({
+        title: "Bas",
+        roomId: "3",
+        activityGroupId: undefined,
+        additionalStaffIds: [],
+      });
+    });
   });
 });

--- a/frontend/src/components/active-supervisions/spontaneous-activity-start.test.tsx
+++ b/frontend/src/components/active-supervisions/spontaneous-activity-start.test.tsx
@@ -422,7 +422,12 @@ describe("SpontaneousActivityStart", () => {
     expect(screen.getByTestId("modal")).toBeInTheDocument();
   });
 
-  it("submits the typed title on Enter instead of replacing it with the highlighted suggestion", async () => {
+  it("selects the active activity suggestion on Enter before submitting", async () => {
+    mocks.getActivities.mockResolvedValueOnce([
+      { id: "5", name: "Ballspiele" },
+      { id: "9", name: "Basteln" },
+      { id: "7", name: "Freispiel" },
+    ]);
     const onStart = vi.fn();
     render(
       <SpontaneousActivityStart
@@ -436,26 +441,27 @@ describe("SpontaneousActivityStart", () => {
     const activityInput = screen.getByPlaceholderText(
       "Aktivität suchen oder neu eingeben",
     );
-    fireEvent.change(activityInput, { target: { value: "Bas" } });
-    // A suggestion is highlighted, but Enter must NOT adopt it (datalist
-    // parity): the typed text stays untouched.
+    fireEvent.change(activityInput, { target: { value: "Ba" } });
+    expect(screen.getByRole("option", { name: "Ballspiele" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    fireEvent.keyDown(activityInput, { key: "ArrowDown" });
     expect(screen.getByRole("option", { name: "Basteln" })).toHaveAttribute(
       "aria-selected",
       "true",
     );
 
     fireEvent.keyDown(activityInput, { key: "Enter" });
-    expect(activityInput).toHaveValue("Bas");
+    expect(activityInput).toHaveValue("Basteln");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
 
-    // Submitting sends the partial text verbatim as a new activity title
-    // (jsdom does not perform native implicit submission on Enter, so the
-    // form submit is triggered directly here).
     submitForm();
     await waitFor(() => {
       expect(onStart).toHaveBeenCalledWith({
-        title: "Bas",
+        title: "Basteln",
         roomId: "3",
-        activityGroupId: undefined,
+        activityGroupId: "9",
         additionalStaffIds: [],
       });
     });

--- a/frontend/src/components/active-supervisions/spontaneous-activity-start.test.tsx
+++ b/frontend/src/components/active-supervisions/spontaneous-activity-start.test.tsx
@@ -466,4 +466,42 @@ describe("SpontaneousActivityStart", () => {
       });
     });
   });
+
+  it("selects an activity suggestion on pointer-down even when the input blurs with no relatedTarget (Safari/iOS)", async () => {
+    const onStart = vi.fn();
+    render(
+      <SpontaneousActivityStart
+        currentStaffId="11"
+        defaultRoomId="3"
+        onStart={onStart}
+      />,
+    );
+
+    await openModalAndWaitForRefs();
+    const activityInput = screen.getByPlaceholderText(
+      "Aktivität suchen oder neu eingeben",
+    );
+    fireEvent.change(activityInput, { target: { value: "Bast" } });
+    const option = screen.getByRole("option", { name: "Basteln" });
+
+    // Safari/iOS does not focus a clicked button, so the input blurs with a
+    // null relatedTarget. Selection must happen on pointer-down (which the
+    // component preventDefaults to keep focus on the input) BEFORE that blur
+    // can close the menu and unmount the option.
+    fireEvent.pointerDown(option, { button: 0, pointerType: "mouse" });
+    fireEvent.blur(activityInput, { relatedTarget: null });
+
+    expect(activityInput).toHaveValue("Basteln");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    submitForm();
+    await waitFor(() => {
+      expect(onStart).toHaveBeenCalledWith({
+        title: "Basteln",
+        roomId: "3",
+        activityGroupId: "9",
+        additionalStaffIds: [],
+      });
+    });
+  });
 });

--- a/frontend/src/components/active-supervisions/spontaneous-activity-start.tsx
+++ b/frontend/src/components/active-supervisions/spontaneous-activity-start.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { Plus, Search, UserPlus } from "lucide-react";
-import type { FormEvent } from "react";
-import { useEffect, useMemo, useState } from "react";
+import type { FormEvent, KeyboardEvent } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
-import { Modal } from "~/components/ui/modal";
+import { Alert } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import { CustomSelect } from "~/components/ui/custom-select";
+import { FormModal } from "~/components/ui/form-modal";
+import { Input } from "~/components/ui/input";
 import { activityService } from "~/lib/activity-service";
 import type { Activity } from "~/lib/activity-helpers";
 import { createLogger } from "~/lib/logger";
@@ -76,6 +81,15 @@ function findSelectedActivity(
   );
 }
 
+function consumeListboxEscape(event: KeyboardEvent): void {
+  // Keep Escape from reaching FormModal's document-level handler (which would
+  // close the whole modal and wipe the draft). stopImmediatePropagation is
+  // required because that listener sits on the same document node as React's
+  // delegated listener, where plain stopPropagation would not stop it.
+  event.preventDefault();
+  event.nativeEvent.stopImmediatePropagation();
+}
+
 export function SpontaneousActivityStart({
   currentStaffId,
   defaultRoomId,
@@ -93,6 +107,9 @@ export function SpontaneousActivityStart({
   const [roomId, setRoomId] = useState(defaultRoomId ?? "");
   const [additionalStaffIds, setAdditionalStaffIds] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [activityMenuOpen, setActivityMenuOpen] = useState(false);
+  const [activeActivityIndex, setActiveActivityIndex] = useState(0);
+  const activityFieldRef = useRef<HTMLDivElement>(null);
   const occupiedRoomIdSet = useMemo(
     () => new Set(occupiedRoomIds),
     [occupiedRoomIds],
@@ -160,6 +177,21 @@ export function SpontaneousActivityStart({
       .finally(() => setIsLoadingRefs(false));
   }, [currentStaffId, defaultRoomId, isOpen, occupiedRoomIdSet]);
 
+  // Close the activity suggestions when clicking outside the field.
+  useEffect(() => {
+    if (!activityMenuOpen) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      if (
+        activityFieldRef.current &&
+        !activityFieldRef.current.contains(event.target as Node)
+      ) {
+        setActivityMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [activityMenuOpen]);
+
   const selectedActivity = useMemo(
     () => findSelectedActivity(activities, activityInput),
     [activities, activityInput],
@@ -173,6 +205,37 @@ export function SpontaneousActivityStart({
     !isSelectedRoomOccupied &&
     !isStarting;
   const suggestedActivities = activities.slice(0, 5);
+  const filteredActivities = useMemo(() => {
+    const query = activityInput.trim().toLocaleLowerCase("de");
+    const matches = query
+      ? activities.filter((activity) =>
+          activity.name.toLocaleLowerCase("de").includes(query),
+        )
+      : activities;
+    return matches.slice(0, 8);
+  }, [activities, activityInput]);
+  const activityListboxOpen = activityMenuOpen && filteredActivities.length > 0;
+  const roomOptions = useMemo(
+    () =>
+      rooms.map((room) => ({
+        value: room.id,
+        label: `${room.building ? `${room.building} - ` : ""}${room.name}${
+          occupiedRoomIdSet.has(room.id) ? " (belegt)" : ""
+        }`,
+        disabled: occupiedRoomIdSet.has(room.id),
+      })),
+    [rooms, occupiedRoomIdSet],
+  );
+
+  useEffect(() => {
+    if (!activityListboxOpen) {
+      setActiveActivityIndex(0);
+      return;
+    }
+    setActiveActivityIndex((prev) =>
+      Math.min(prev, filteredActivities.length - 1),
+    );
+  }, [activityListboxOpen, filteredActivities.length]);
 
   function toggleStaff(staffId: string) {
     setAdditionalStaffIds((prev) =>
@@ -187,6 +250,14 @@ export function SpontaneousActivityStart({
     setActivityInput("");
     setAdditionalStaffIds([]);
     setError(null);
+    setActivityMenuOpen(false);
+    setActiveActivityIndex(0);
+  }
+
+  function selectActivitySuggestion(activity: Activity) {
+    setActivityInput(activity.name);
+    setActivityMenuOpen(false);
+    setActiveActivityIndex(0);
   }
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -231,44 +302,165 @@ export function SpontaneousActivityStart({
         </button>
       </section>
 
-      <Modal
+      <FormModal
         isOpen={isOpen}
         onClose={resetAndClose}
         title="Spontane Aktivität"
-        widthClass="mx-3 w-[calc(100%-1.5rem)] max-w-xl"
+        size="md"
+        mobilePosition="center"
+        footer={
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              size="md"
+              onClick={resetAndClose}
+            >
+              Abbrechen
+            </Button>
+            <Button
+              type="submit"
+              form="spontaneous-activity-form"
+              variant="primary"
+              size="md"
+              isLoading={isStarting}
+              loadingText="Startet ..."
+              disabled={!canSubmit || isLoadingRefs}
+            >
+              Aktivität starten
+            </Button>
+          </>
+        }
       >
-        <form className="space-y-4" onSubmit={handleSubmit}>
-          {error ? (
-            <div className="rounded-md border border-[#E5484D]/30 bg-[#E5484D]/10 px-3 py-2 text-sm text-[#A32020]">
-              {error}
-            </div>
-          ) : null}
+        <form
+          id="spontaneous-activity-form"
+          className="space-y-4"
+          onSubmit={handleSubmit}
+        >
+          {error ? <Alert type="error" message={error} /> : null}
 
-          <label className="block">
-            <span className="mb-1 block text-xs font-semibold text-gray-700">
+          <div
+            ref={activityFieldRef}
+            onBlur={(event) => {
+              const nextFocusedNode = event.relatedTarget;
+              if (
+                !(nextFocusedNode instanceof Node) ||
+                !event.currentTarget.contains(nextFocusedNode)
+              ) {
+                setActivityMenuOpen(false);
+              }
+            }}
+          >
+            <label
+              htmlFor="activity"
+              className="mb-2 block text-sm font-medium text-gray-700"
+            >
               Aktivität
-            </span>
+            </label>
             <div className="relative">
               <Search
-                className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400"
+                className="pointer-events-none absolute top-1/2 left-3 z-10 h-4 w-4 -translate-y-1/2 text-gray-400"
                 aria-hidden="true"
               />
-              <input
+              <Input
+                name="activity"
+                controlSize="compact"
+                className="pl-9"
                 value={activityInput}
-                onChange={(event) => setActivityInput(event.target.value)}
-                list="spontaneous-activity-options"
+                onChange={(event) => {
+                  setActivityInput(event.target.value);
+                  setActivityMenuOpen(true);
+                  setActiveActivityIndex(0);
+                }}
+                onFocus={() => {
+                  setActivityMenuOpen(true);
+                  setActiveActivityIndex(0);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "Escape" && activityListboxOpen) {
+                    consumeListboxEscape(event);
+                    setActivityMenuOpen(false);
+                    return;
+                  }
+                  if (!activityListboxOpen) return;
+
+                  if (event.key === "ArrowDown") {
+                    event.preventDefault();
+                    setActiveActivityIndex(
+                      (prev) => (prev + 1) % filteredActivities.length,
+                    );
+                    return;
+                  }
+                  if (event.key === "ArrowUp") {
+                    event.preventDefault();
+                    setActiveActivityIndex(
+                      (prev) =>
+                        (prev - 1 + filteredActivities.length) %
+                        filteredActivities.length,
+                    );
+                    return;
+                  }
+                  if (event.key === "Home") {
+                    event.preventDefault();
+                    setActiveActivityIndex(0);
+                    return;
+                  }
+                  if (event.key === "End") {
+                    event.preventDefault();
+                    setActiveActivityIndex(filteredActivities.length - 1);
+                    return;
+                  }
+                  // Enter intentionally falls through to the form's implicit
+                  // submission (matching the previous datalist behaviour):
+                  // the typed text is submitted as-is instead of being
+                  // replaced by the highlighted suggestion. Suggestions are
+                  // picked via hover/click or the chips below.
+                }}
                 placeholder="Aktivität suchen oder neu eingeben"
-                className="min-h-11 w-full rounded-md border border-gray-300 bg-white pr-3 pl-9 text-sm focus:border-[#5080D8] focus:ring-2 focus:ring-[#5080D8]/20 focus:outline-none"
                 autoComplete="off"
+                role="combobox"
+                tabIndex={0}
+                aria-expanded={activityListboxOpen}
+                aria-controls="spontaneous-activity-listbox"
+                aria-activedescendant={
+                  activityListboxOpen
+                    ? `spontaneous-activity-option-${filteredActivities[activeActivityIndex]?.id}`
+                    : undefined
+                }
+                aria-autocomplete="list"
                 required
               />
+              {activityListboxOpen ? (
+                <ul
+                  id="spontaneous-activity-listbox"
+                  role="listbox"
+                  className="absolute top-full left-0 z-50 mt-1 max-h-60 w-full overflow-y-auto rounded-xl border border-gray-200 bg-white py-1 shadow-lg"
+                >
+                  {filteredActivities.map((activity, index) => (
+                    <li key={activity.id} role="presentation">
+                      <button
+                        id={`spontaneous-activity-option-${activity.id}`}
+                        type="button"
+                        role="option"
+                        // Keep options out of the tab order: focus stays on the
+                        // combobox input (aria-activedescendant drives the active
+                        // option). Otherwise Tab lands on an option button, where
+                        // Escape would bubble to FormModal's document listener and
+                        // close the whole modal instead of just the listbox.
+                        tabIndex={-1}
+                        aria-selected={index === activeActivityIndex}
+                        onMouseEnter={() => setActiveActivityIndex(index)}
+                        onClick={() => selectActivitySuggestion(activity)}
+                        className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-gray-50 aria-selected:bg-gray-100 aria-selected:text-gray-900"
+                      >
+                        {activity.name}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
             </div>
-            <datalist id="spontaneous-activity-options">
-              {activities.map((activity) => (
-                <option key={activity.id} value={activity.name} />
-              ))}
-            </datalist>
-          </label>
+          </div>
 
           {suggestedActivities.length > 0 ? (
             <div className="flex flex-wrap gap-2">
@@ -285,57 +477,42 @@ export function SpontaneousActivityStart({
             </div>
           ) : null}
 
-          <label className="block">
-            <span className="mb-1 block text-xs font-semibold text-gray-700">
+          <div>
+            <span className="mb-2 block text-sm font-medium text-gray-700">
               Raum
             </span>
-            <select
+            <CustomSelect
               value={roomId}
-              onChange={(event) => setRoomId(event.target.value)}
+              options={roomOptions}
+              onChange={setRoomId}
+              ariaLabel="Raum"
               disabled={isLoadingRefs}
-              className="min-h-11 w-full rounded-md border border-gray-300 bg-white px-3 text-sm focus:border-[#5080D8] focus:ring-2 focus:ring-[#5080D8]/20 focus:outline-none disabled:bg-gray-100"
               required
-            >
-              <option value="">
-                {isLoadingRefs ? "Lade Räume ..." : "Raum auswählen"}
-              </option>
-              {rooms.map((room) => (
-                <option
-                  key={room.id}
-                  value={room.id}
-                  disabled={occupiedRoomIdSet.has(room.id)}
-                >
-                  {room.building
-                    ? `${room.building} - ${room.name}`
-                    : room.name}
-                  {occupiedRoomIdSet.has(room.id) ? " (belegt)" : ""}
-                </option>
-              ))}
-            </select>
+              invalid={isSelectedRoomOccupied}
+              placeholder={isLoadingRefs ? "Lade Räume ..." : "Raum auswählen"}
+            />
             {isSelectedRoomOccupied ? (
               <span className="mt-1 block text-xs text-[#A32020]">
                 Dieser Raum ist bereits belegt.
               </span>
             ) : null}
-          </label>
+          </div>
 
           {staff.length > 0 ? (
             <div>
-              <div className="mb-2 flex items-center gap-2 text-xs font-semibold text-gray-700">
+              <div className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700">
                 <UserPlus className="h-4 w-4" aria-hidden="true" />
                 Weitere Betreuer
               </div>
-              <div className="grid max-h-44 gap-2 overflow-y-auto rounded-md border border-gray-200 bg-gray-50 p-2">
+              <div className="grid max-h-44 gap-2 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 p-2">
                 {staff.map((item) => (
                   <label
                     key={item.id}
-                    className="flex min-h-10 items-center gap-3 rounded-md bg-white px-3 py-2 text-sm text-gray-800"
+                    className="flex min-h-10 cursor-pointer items-center gap-3 rounded-md bg-white px-3 py-2 text-sm text-gray-800"
                   >
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={additionalStaffIds.includes(item.id)}
                       onChange={() => toggleStaff(item.id)}
-                      className="h-4 w-4 rounded border-gray-300 text-[#83CD2D] focus:ring-[#83CD2D]"
                     />
                     <span className="truncate">{staffLabel(item)}</span>
                   </label>
@@ -343,25 +520,8 @@ export function SpontaneousActivityStart({
               </div>
             </div>
           ) : null}
-
-          <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end">
-            <button
-              type="button"
-              onClick={resetAndClose}
-              className="min-h-11 rounded-md border border-gray-300 px-4 text-sm font-medium text-gray-700 hover:bg-gray-50"
-            >
-              Abbrechen
-            </button>
-            <button
-              type="submit"
-              disabled={!canSubmit || isLoadingRefs}
-              className="min-h-11 rounded-md bg-[#83CD2D] px-4 text-sm font-semibold text-white hover:bg-[#6FB624] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {isStarting ? "Startet ..." : "Aktivität starten"}
-            </button>
-          </div>
         </form>
-      </Modal>
+      </FormModal>
     </>
   );
 }

--- a/frontend/src/components/active-supervisions/spontaneous-activity-start.tsx
+++ b/frontend/src/components/active-supervisions/spontaneous-activity-start.tsx
@@ -410,11 +410,14 @@ export function SpontaneousActivityStart({
                     setActiveActivityIndex(filteredActivities.length - 1);
                     return;
                   }
-                  // Enter intentionally falls through to the form's implicit
-                  // submission (matching the previous datalist behaviour):
-                  // the typed text is submitted as-is instead of being
-                  // replaced by the highlighted suggestion. Suggestions are
-                  // picked via hover/click or the chips below.
+                  if (event.key === "Enter") {
+                    const activeActivity =
+                      filteredActivities[activeActivityIndex];
+                    if (activeActivity) {
+                      event.preventDefault();
+                      selectActivitySuggestion(activeActivity);
+                    }
+                  }
                 }}
                 placeholder="Aktivität suchen oder neu eingeben"
                 autoComplete="off"

--- a/frontend/src/components/active-supervisions/spontaneous-activity-start.tsx
+++ b/frontend/src/components/active-supervisions/spontaneous-activity-start.tsx
@@ -453,7 +453,18 @@ export function SpontaneousActivityStart({
                         tabIndex={-1}
                         aria-selected={index === activeActivityIndex}
                         onMouseEnter={() => setActiveActivityIndex(index)}
-                        onClick={() => selectActivitySuggestion(activity)}
+                        // Select on pointer-down and keep focus on the input.
+                        // Safari/iOS does not focus a clicked button, so the
+                        // input would blur with relatedTarget === null, the
+                        // blur handler would close the menu, and the option
+                        // would unmount before its click fired — making pointer
+                        // selection unreliable on touch. preventDefault stops
+                        // the focus shift (no blur, menu stays open); we run the
+                        // selection here so a missed onClick can't drop it.
+                        onPointerDown={(event) => {
+                          event.preventDefault();
+                          selectActivitySuggestion(activity);
+                        }}
                         className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-gray-50 aria-selected:bg-gray-100 aria-selected:text-gray-900"
                       >
                         {activity.name}

--- a/frontend/src/components/ui/custom-select.test.tsx
+++ b/frontend/src/components/ui/custom-select.test.tsx
@@ -80,6 +80,57 @@ describe("CustomSelect", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
+  it("keeps Escape from reaching document listeners while the trigger owns an open listbox", () => {
+    const onDocumentKeyDown = vi.fn();
+    document.addEventListener("keydown", onDocumentKeyDown);
+
+    try {
+      render(
+        <CustomSelect
+          value=""
+          options={options}
+          onChange={vi.fn()}
+          ariaLabel="Auswahl"
+        />,
+      );
+
+      const trigger = screen.getByRole("combobox", { name: "Auswahl" });
+      fireEvent.click(trigger);
+      fireEvent.keyDown(trigger, { key: "Escape" });
+
+      expect(onDocumentKeyDown).not.toHaveBeenCalled();
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    } finally {
+      document.removeEventListener("keydown", onDocumentKeyDown);
+    }
+  });
+
+  it("keeps Escape from reaching document listeners while an option owns focus", () => {
+    const onDocumentKeyDown = vi.fn();
+    document.addEventListener("keydown", onDocumentKeyDown);
+
+    try {
+      render(
+        <CustomSelect
+          value=""
+          options={options}
+          onChange={vi.fn()}
+          ariaLabel="Auswahl"
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("combobox", { name: "Auswahl" }));
+      fireEvent.keyDown(screen.getByRole("option", { name: "Erste Option" }), {
+        key: "Escape",
+      });
+
+      expect(onDocumentKeyDown).not.toHaveBeenCalled();
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    } finally {
+      document.removeEventListener("keydown", onDocumentKeyDown);
+    }
+  });
+
   it("ignores disabled options", () => {
     const onChange = vi.fn();
     render(

--- a/frontend/src/components/ui/form-modal.test.tsx
+++ b/frontend/src/components/ui/form-modal.test.tsx
@@ -48,6 +48,24 @@ describe("FormModal", () => {
     expect(screen.getByText("Modal content")).toBeInTheDocument();
   });
 
+  it("uses the visible title as the dialog accessible name", async () => {
+    render(
+      <TestWrapper>
+        <FormModal isOpen={true} onClose={vi.fn()} title="Test Modal">
+          <p>Modal content</p>
+        </FormModal>
+      </TestWrapper>,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(20);
+    });
+
+    const dialog = screen.getByRole("dialog", { name: "Test Modal" });
+    const title = screen.getByRole("heading", { name: "Test Modal" });
+    expect(dialog).toHaveAttribute("aria-labelledby", title.id);
+  });
+
   it("should call onClose when close button is clicked", async () => {
     const onClose = vi.fn();
     render(

--- a/frontend/src/components/ui/form-modal.tsx
+++ b/frontend/src/components/ui/form-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useCallback, useState, useRef } from "react";
+import { useEffect, useCallback, useState, useRef, useId } from "react";
 import type { ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { FocusScope } from "@radix-ui/react-focus-scope";
@@ -31,6 +31,7 @@ export function FormModal({
 }: FormModalProps) {
   const [isAnimating, setIsAnimating] = useState(false);
   const [isExiting, setIsExiting] = useState(false);
+  const titleId = useId();
   const { openModal, closeModal } = useModal();
 
   // Store functions in refs to avoid effect re-runs
@@ -153,6 +154,7 @@ export function FormModal({
             return "translate-y-8 scale-75 -rotate-1 opacity-0";
           })()}`}
           {...dialogAriaProps}
+          aria-labelledby={title ? titleId : undefined}
           style={{
             background:
               "linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(248,250,252,0.98) 100%)",
@@ -165,7 +167,10 @@ export function FormModal({
           {/* Header with close button */}
           <div className="flex items-center justify-between border-b border-gray-100 p-4 md:p-6">
             {title && (
-              <h3 className="pr-4 text-lg font-semibold text-gray-900 md:text-xl">
+              <h3
+                id={titleId}
+                className="pr-4 text-lg font-semibold text-gray-900 md:text-xl"
+              >
                 {title}
               </h3>
             )}

--- a/frontend/src/components/ui/listbox-dropdown.tsx
+++ b/frontend/src/components/ui/listbox-dropdown.tsx
@@ -75,6 +75,12 @@ function nextEnabledIndex<K extends string>(
   return -1;
 }
 
+function consumeEscape(event: KeyboardEvent<HTMLButtonElement>): void {
+  event.preventDefault();
+  event.stopPropagation();
+  event.nativeEvent.stopImmediatePropagation();
+}
+
 export function ListboxDropdown<K extends string>({
   value,
   options,
@@ -148,7 +154,7 @@ export function ListboxDropdown<K extends string>({
   const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
     if (disabled) return;
     if (event.key === "Escape" && open) {
-      event.preventDefault();
+      consumeEscape(event);
       setOpen(false);
       return;
     }
@@ -209,7 +215,7 @@ export function ListboxDropdown<K extends string>({
         selectAt(focusIndex);
         break;
       case "Escape":
-        event.preventDefault();
+        consumeEscape(event);
         closeAndReturnFocus();
         break;
       case "Tab":


### PR DESCRIPTION
## Was

Baut das **„Spontane Aktivität"-Modal** (`active-supervisions`) konsequent auf das geteilte UI-Kit um, statt handgerollter Chrome.

- Modal-Shell → Kit `FormModal` (inkl. neuem `aria-labelledby` auf dem Titel)
- Aktionen → Kit `Button` (`size="md"` für Modal-Footer-Höhe)
- Raum-Auswahl → Kit `CustomSelect`
- „Weitere Betreuer" → Kit `Checkbox`
- Aktivitäts-Suche → Kit `Input` + `Search`-Icon-Overlay (`pl-9`), wie `guardian-picker-panel` / `SearchBar`
- Aktivitäts-Vorschläge als ARIA-Combobox mit Listbox (ersetzt `<datalist>`); Dropdown-Optik 1:1 wie Kit-`CustomSelect`-Menü
- `listbox-dropdown`: Escape wird via `stopImmediatePropagation` geschluckt, damit Escape im Dropdown nur die Liste schließt, nicht das ganze Modal (+ Draft bleibt erhalten)

## UI-Kit-Kohärenz

Gegen Kit und bestehende App-Muster geprüft — Shell, Buttons, Suchfeld, Dropdown, Select, Checkbox und Chip-Form sind konsistent. Einzige bewusste Abweichung: die Vorschlags-Chips nutzen `hover:text-[#315EA8]` (abgedunkeltes Brand-Blau), ein undokumentierter Einzelwert außerhalb von `LOCATION_COLORS`. Kosmetisch, kann in einem Follow-up auf `#5080D8` gezogen werden.

## Screenshots

### Vorher
<!-- TODO: 1 Screenshot des alten Modals einfügen -->
| Alt |
|-----|
|<img width="1459" height="869" alt="Bildschirmfoto 2026-06-27 um 11 31 33" src="https://github.com/user-attachments/assets/0b1b766b-37aa-4a4f-9065-c9fa38ee1221" />|

### Nachher
<!-- TODO: 2 Screenshots des neuen Modals einfügen -->
| Modal offen | Such-Dropdown offen |
|-------------|---------------------|
| <img width="1440" height="900" alt="01-modal-open" src="https://github.com/user-attachments/assets/de1ccc3c-7970-4e73-8c61-b678f5e423d2" /> | <img width="1440" height="900" alt="02-modal-search-dropdown" src="https://github.com/user-attachments/assets/c106d2f1-e917-4718-bb68-d3e0ba664287" /> |

## Test Plan

- [ ] `cd frontend && pnpm run check` (zero warnings)
- [ ] `pnpm run test` — `spontaneous-activity-start`, `custom-select`, `form-modal`
- [ ] Manuell: als Betreuer unter aktiver Aufsicht „Spontane Aktivität starten" → Suche, Vorschlag wählen, Raum belegen, Betreuer hinzufügen, starten
- [ ] Escape im Such-Dropdown schließt nur die Liste, nicht das Modal
