### PR TITLE
Delete future timetable series appointments

### DIFF
--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -223,6 +223,11 @@ func (rs *Resource) Router() chi.Router {
 		// effective date and continue with a successor template.
 		r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
 			Post("/templates/{id}/split", rs.splitTemplate)
+		// "Dieser und alle folgenden löschen" — cap the template at the
+		// effective date without creating a successor and remove planned
+		// future instances.
+		r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
+			Post("/templates/{id}/end", rs.endTemplate)
 		r.With(authorize.RequiresPermission(permissions.SchedulesManage), withTx).
 			Delete("/templates/{id}", rs.archiveTemplate)
 	})

--- a/backend/api/timetable/instances.go
+++ b/backend/api/timetable/instances.go
@@ -129,9 +129,9 @@ func (rs *Resource) cancelInstance(w http.ResponseWriter, r *http.Request) {
 	common.Respond(w, r, http.StatusOK, resp, "Instance cancelled")
 }
 
-// deleteInstance handles DELETE /instances/{id}. Only already-cancelled
-// instances can be deleted; other statuses return the same 409 contract as
-// lifecycle transitions.
+// deleteInstance handles DELETE /instances/{id}. Planned and cancelled
+// instances can be deleted; active/completed history stays protected and
+// returns the same 409 contract as lifecycle transitions.
 func (rs *Resource) deleteInstance(w http.ResponseWriter, r *http.Request) {
 	id, err := common.ParseID(r)
 	if err != nil {

--- a/backend/api/timetable/instances.go
+++ b/backend/api/timetable/instances.go
@@ -162,6 +162,11 @@ func renderInstanceLifecycleError(w http.ResponseWriter, r *http.Request, err er
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 	case errors.Is(err, scheduleSvc.ErrInvalidInstanceTransition):
 		common.RenderError(w, r, common.ErrorConflictWithCode(err, "invalid_transition"))
+	case errors.Is(err, scheduleSvc.ErrAmbiguousTemplateInstanceDelete):
+		common.RenderError(w, r, common.ErrorConflictWithCode(
+			errors.New("dieser Termin kann nicht einzeln gelöscht werden, weil die Vorlage an diesem Tag mehrere Termine hat"),
+			"ambiguous_template_instance_delete",
+		))
 	case isUniqueViolationOnConstraint(err, "idx_activity_instances_template_unique"):
 		common.RenderError(w, r, common.ErrorConflictWithCode(
 			errors.New("instance already exists for this template/date/start_time"),

--- a/backend/api/timetable/instances_test.go
+++ b/backend/api/timetable/instances_test.go
@@ -676,6 +676,19 @@ func TestDeleteInstance_InvalidTransition(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "invalid_transition")
 }
 
+func TestDeleteInstance_AmbiguousTemplateInstanceDelete(t *testing.T) {
+	mock := &mockInstanceService{deleteErr: &wrappedErr{inner: scheduleSvc.ErrAmbiguousTemplateInstanceDelete}}
+	rs := NewResource(Dependencies{InstanceService: mock})
+	router := chi.NewRouter()
+	router.Delete("/instances/{id}", rs.deleteInstance)
+
+	w := doDelete(t, router, "/instances/1")
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "ambiguous_template_instance_delete")
+	assert.Contains(t, w.Body.String(), "mehrere Termine")
+}
+
 func TestDeleteInstance_InternalError(t *testing.T) {
 	mock := &mockInstanceService{deleteErr: errors.New("db failure")}
 	rs := NewResource(Dependencies{InstanceService: mock})
@@ -1036,6 +1049,14 @@ func TestRenderInstanceLifecycleError(t *testing.T) {
 		renderInstanceLifecycleError(w, r, scheduleSvc.ErrInvalidInstanceTransition)
 		assert.Equal(t, http.StatusConflict, w.Code)
 		assert.Contains(t, w.Body.String(), "invalid_transition")
+	})
+
+	t.Run("ambiguous-template-instance-delete", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		renderInstanceLifecycleError(w, r, scheduleSvc.ErrAmbiguousTemplateInstanceDelete)
+		assert.Equal(t, http.StatusConflict, w.Code)
+		assert.Contains(t, w.Body.String(), "ambiguous_template_instance_delete")
 	})
 
 	t.Run("unknown-error-500", func(t *testing.T) {

--- a/backend/api/timetable/templates_end.go
+++ b/backend/api/timetable/templates_end.go
@@ -1,0 +1,80 @@
+// Package timetable — POST /api/timetable/templates/{id}/end handler.
+//
+// "Dieser und alle folgenden löschen": caps the template's schedules and
+// rosters at the effective date, then deletes planned future materialized
+// instances. Historical rows remain untouched.
+package timetable
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+)
+
+type endTemplateRequest struct {
+	EffectiveDate string `json:"effective_date"`
+}
+
+func (req *endTemplateRequest) Bind(_ *http.Request) error {
+	if req.EffectiveDate == "" {
+		return errors.New("effective_date is required (YYYY-MM-DD)")
+	}
+	return nil
+}
+
+type endTemplateResponse struct {
+	TemplateID       int64  `json:"template_id"`
+	EffectiveDate    string `json:"effective_date"`
+	DeletedInstances int    `json:"deleted_instances"`
+}
+
+func (rs *Resource) endTemplate(w http.ResponseWriter, r *http.Request) {
+	id, ok := templateIDFromRequest(w, r)
+	if !ok {
+		return
+	}
+	if rs.templateSplitService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("template split service not wired")))
+		return
+	}
+	req := &endTemplateRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	effectiveDate, err := timezone.ParseDate(req.EffectiveDate)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid effective_date format, expected YYYY-MM-DD")))
+		return
+	}
+
+	result, err := rs.templateSplitService.EndFromDate(r.Context(), scheduleSvc.TemplateEndInput{
+		TemplateID:    id,
+		EffectiveDate: effectiveDate,
+	})
+	if err != nil {
+		renderTemplateEndError(w, r, err)
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, endTemplateResponse{
+		TemplateID:       result.TemplateID,
+		EffectiveDate:    result.EffectiveDate.String(),
+		DeletedInstances: result.DeletedInstances,
+	}, "Template ended")
+}
+
+func renderTemplateEndError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, scheduleSvc.ErrSplitTemplateNotFound):
+		common.RenderError(w, r, common.ErrorNotFound(errors.New("template not found")))
+	case errors.Is(err, scheduleSvc.ErrSplitInvalidInput):
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+	default:
+		common.RenderError(w, r, common.ErrorInternalServerWrap("end template failed", err))
+	}
+}

--- a/backend/api/timetable/templates_split_test.go
+++ b/backend/api/timetable/templates_split_test.go
@@ -57,6 +57,8 @@ func splitRouter(parentCtx context.Context, res *Resource, perms []string) chi.R
 	r.Post("/templates", res.createTemplate)
 	r.With(authorize.RequiresPermission(permissions.SchedulesManage)).
 		Post("/templates/{id}/split", res.splitTemplate)
+	r.With(authorize.RequiresPermission(permissions.SchedulesManage)).
+		Post("/templates/{id}/end", res.endTemplate)
 	return r
 }
 
@@ -74,6 +76,10 @@ func splitBody(s *templateSetup, name string, effective timezone.Date) map[strin
 	delete(body, "materialize_from")
 	delete(body, "materialize_to")
 	return body
+}
+
+func endBody(effective timezone.Date) map[string]any {
+	return map[string]any{"effective_date": effective.String()}
 }
 
 func TestTemplateSplitHandler_HappyPath(t *testing.T) {
@@ -164,5 +170,83 @@ func TestTemplateSplitHandler_ForbiddenForReadOnly(t *testing.T) {
 	body := splitBody(s, "Tpl-Split-NurLesenNeu", timezone.TodayDate().AddDays(7))
 	w := doTemplateJSON(t, readOnlyRouter, http.MethodPost,
 		fmt.Sprintf("/templates/%d/split", created.TemplateID), body)
+	assert.Equal(t, http.StatusForbidden, w.Code, "body=%s", w.Body.String())
+}
+
+func TestTemplateEndHandler_HappyPath(t *testing.T) {
+	mat := &mockMaterializationService{result: &scheduleSvc.MaterializationResult{}}
+	s := buildTemplateSetup(t, mat)
+	defer s.cleanupFn()
+	attachSplitService(s, mat)
+	router := splitRouter(s.ctx, s.res, []string{permissions.SchedulesManage})
+
+	created := createSourceTemplate(t, router, s, "Tpl-End-Quelle")
+	effective := timezone.TodayDate().AddDays(7)
+
+	w := doTemplateJSON(t, router, http.MethodPost,
+		fmt.Sprintf("/templates/%d/end", created.TemplateID), endBody(effective))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	resp := decodeTemplateData[endTemplateResponse](t, w)
+	assert.Equal(t, created.TemplateID, resp.TemplateID)
+	assert.Equal(t, effective.String(), resp.EffectiveDate)
+	assert.Equal(t, 0, resp.DeletedInstances)
+}
+
+func TestTemplateEndHandler_BadEffectiveDate(t *testing.T) {
+	mat := &mockMaterializationService{result: &scheduleSvc.MaterializationResult{}}
+	s := buildTemplateSetup(t, mat)
+	defer s.cleanupFn()
+	attachSplitService(s, mat)
+	router := splitRouter(s.ctx, s.res, []string{permissions.SchedulesManage})
+
+	created := createSourceTemplate(t, router, s, "Tpl-End-DatumQuelle")
+
+	t.Run("malformed date", func(t *testing.T) {
+		w := doTemplateJSON(t, router, http.MethodPost,
+			fmt.Sprintf("/templates/%d/end", created.TemplateID),
+			map[string]any{"effective_date": "12.07.2026"})
+		assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("missing date", func(t *testing.T) {
+		w := doTemplateJSON(t, router, http.MethodPost,
+			fmt.Sprintf("/templates/%d/end", created.TemplateID), map[string]any{})
+		assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("past date", func(t *testing.T) {
+		w := doTemplateJSON(t, router, http.MethodPost,
+			fmt.Sprintf("/templates/%d/end", created.TemplateID),
+			endBody(timezone.TodayDate().AddDays(-1)))
+		assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+}
+
+func TestTemplateEndHandler_UnknownTemplate(t *testing.T) {
+	mat := &mockMaterializationService{result: &scheduleSvc.MaterializationResult{}}
+	s := buildTemplateSetup(t, mat)
+	defer s.cleanupFn()
+	attachSplitService(s, mat)
+	router := splitRouter(s.ctx, s.res, []string{permissions.SchedulesManage})
+
+	w := doTemplateJSON(t, router, http.MethodPost, "/templates/999999999/end",
+		endBody(timezone.TodayDate().AddDays(7)))
+	assert.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+}
+
+func TestTemplateEndHandler_ForbiddenForReadOnly(t *testing.T) {
+	mat := &mockMaterializationService{result: &scheduleSvc.MaterializationResult{}}
+	s := buildTemplateSetup(t, mat)
+	defer s.cleanupFn()
+	attachSplitService(s, mat)
+
+	adminRouter := splitRouter(s.ctx, s.res, []string{permissions.SchedulesManage})
+	created := createSourceTemplate(t, adminRouter, s, "Tpl-End-NurLesen")
+
+	readOnlyRouter := splitRouter(s.ctx, s.res, []string{permissions.SchedulesRead})
+	w := doTemplateJSON(t, readOnlyRouter, http.MethodPost,
+		fmt.Sprintf("/templates/%d/end", created.TemplateID),
+		endBody(timezone.TodayDate().AddDays(7)))
 	assert.Equal(t, http.StatusForbidden, w.Code, "body=%s", w.Body.String())
 }

--- a/backend/api/timetable/templates_split_test.go
+++ b/backend/api/timetable/templates_split_test.go
@@ -55,6 +55,9 @@ func splitRouter(parentCtx context.Context, res *Resource, perms []string) chi.R
 		})
 	})
 	r.Post("/templates", res.createTemplate)
+	r.Get("/templates", res.listTemplates)
+	r.Get("/templates/{id}", res.getTemplate)
+	r.Put("/templates/{id}", res.updateTemplate)
 	r.With(authorize.RequiresPermission(permissions.SchedulesManage)).
 		Post("/templates/{id}/split", res.splitTemplate)
 	r.With(authorize.RequiresPermission(permissions.SchedulesManage)).
@@ -191,6 +194,37 @@ func TestTemplateEndHandler_HappyPath(t *testing.T) {
 	assert.Equal(t, created.TemplateID, resp.TemplateID)
 	assert.Equal(t, effective.String(), resp.EffectiveDate)
 	assert.Equal(t, 0, resp.DeletedInstances)
+}
+
+func TestTemplateEndHandler_RemovesTemplateFromActiveCRUD(t *testing.T) {
+	mat := &mockMaterializationService{result: &scheduleSvc.MaterializationResult{}}
+	s := buildTemplateSetup(t, mat)
+	defer s.cleanupFn()
+	attachSplitService(s, mat)
+	router := splitRouter(s.ctx, s.res, []string{permissions.SchedulesManage})
+
+	created := createSourceTemplate(t, router, s, "Tpl-End-Hidden")
+	effective := timezone.TodayDate().AddDays(7)
+
+	w := doTemplateJSON(t, router, http.MethodPost,
+		fmt.Sprintf("/templates/%d/end", created.TemplateID), endBody(effective))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	listW := doTemplateJSON(t, router, http.MethodGet, "/templates", nil)
+	require.Equal(t, http.StatusOK, listW.Code, "body=%s", listW.Body.String())
+	list := decodeTemplateData[listTemplatesResponse](t, listW)
+	for _, tpl := range list.Templates {
+		assert.NotEqual(t, created.TemplateID, tpl.ID, "ended template must not remain in the active template list")
+	}
+
+	getW := doTemplateJSON(t, router, http.MethodGet,
+		fmt.Sprintf("/templates/%d", created.TemplateID), nil)
+	assert.Equal(t, http.StatusNotFound, getW.Code, "body=%s", getW.Body.String())
+
+	updateBody := createTemplateBody(s, "Tpl-End-Hidden-Resurrected")
+	putW := doTemplateJSON(t, router, http.MethodPut,
+		fmt.Sprintf("/templates/%d", created.TemplateID), updateBody)
+	assert.Equal(t, http.StatusNotFound, putW.Code, "body=%s", putW.Body.String())
 }
 
 func TestTemplateEndHandler_BadEffectiveDate(t *testing.T) {

--- a/backend/database/repositories/activities/group.go
+++ b/backend/database/repositories/activities/group.go
@@ -558,9 +558,10 @@ func (r *GroupRepository) ListTemplateRows(ctx context.Context, templateID *int6
 				) AS active_supervisors
 				GROUP BY group_id
 			) AS supervisors ON supervisors.group_id = g.id
-		WHERE g.tenant_id = ?
-		  AND g.is_template = true
-		  AND g.archived_at IS NULL`
+	WHERE g.tenant_id = ?
+	  AND g.is_template = true
+	  AND g.archived_at IS NULL
+	  AND s.valid_until IS NULL`
 	args := []any{tenantID, tenantID, tenantID}
 	if templateID != nil {
 		query += ` AND g.id = ?`
@@ -607,9 +608,10 @@ func (r *GroupRepository) ListTemplateRowsForPeriod(ctx context.Context, periodI
 				) AS active_supervisors
 				GROUP BY group_id
 			) AS supervisors ON supervisors.group_id = g.id
-		WHERE g.tenant_id = ?
-		  AND g.is_template = true
-		  AND g.archived_at IS NULL`
+	WHERE g.tenant_id = ?
+	  AND g.is_template = true
+	  AND g.archived_at IS NULL
+	  AND s.valid_until IS NULL`
 
 	args := []any{tenantID}
 	args = append(args, tenantID)

--- a/backend/services/schedule/instance_move_exception_test.go
+++ b/backend/services/schedule/instance_move_exception_test.go
@@ -97,6 +97,33 @@ func TestUpdatePlanned_DateMove_WritesExceptionAndBlocksRematerialization(t *tes
 	assert.Empty(t, listInstancesForDate(t, s.db, s.template.ID, origDate))
 }
 
+func TestDeletePlanned_WritesExceptionAndBlocksRematerialization(t *testing.T) {
+	origDate := timezone.NewDate(2026, time.April, 20) // Mon
+	s := makeScenario(t, activitiesModels.WeekdayMonday, origDate)
+	defer s.runCleanup(t)
+
+	r0, err := s.svc.MaterializeForTenant(s.ctx, origDate, origDate, scheduleSvc.MaterializationSourceManual)
+	require.NoError(t, err)
+	require.Equal(t, 1, r0.InstancesCreated)
+	rows := listInstancesForDate(t, s.db, s.template.ID, origDate)
+	require.Len(t, rows, 1)
+	inst := rows[0]
+	s.registerCleanup("schedule.activity_instances", inst.ID)
+
+	require.NoError(t, s.factory.Instance.DeleteCancelled(s.ctx, inst.ID))
+
+	excs := loadExceptions(t, s, s.template.ID)
+	require.Len(t, excs, 1, "delete must consume the original slot")
+	assert.Equal(t, origDate, excs[0].ExceptionDate)
+	assert.Equal(t, scheduleModels.ActivityExceptionCancelled, excs[0].ExceptionType)
+
+	r1, err := s.svc.MaterializeForTenant(s.ctx, origDate, origDate, scheduleSvc.MaterializationSourceManual)
+	require.NoError(t, err)
+	assert.Zero(t, r1.InstancesCreated, "deleted slot must stay consumed")
+	assert.Equal(t, 1, r1.CandidatesSkippedException)
+	assert.Empty(t, listInstancesForDate(t, s.db, s.template.ID, origDate))
+}
+
 func TestUpdatePlanned_StartTimeOnlyMove_WritesException(t *testing.T) {
 	origDate := timezone.NewDate(2026, time.April, 20)
 	s := makeScenario(t, activitiesModels.WeekdayMonday, origDate)

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -57,6 +57,13 @@ var (
 	// tenant-scoped foreign id that does not resolve in the current tenant.
 	// Handlers map this to 400.
 	ErrInvalidInstanceReference = errors.New("invalid instance reference")
+
+	// ErrAmbiguousTemplateInstanceDelete is returned when a single-instance
+	// delete would need to persist a date-wide cancellation exception but the
+	// template has multiple materialized slots on that date. Handlers map this
+	// to 409 so the UI can explain that the user must delete the series or keep
+	// the slots unchanged until slot-scoped exceptions exist.
+	ErrAmbiguousTemplateInstanceDelete = errors.New("template instance delete is ambiguous")
 )
 
 // ActiveSessionEnder is the subset of active.Service used by Complete and
@@ -382,6 +389,9 @@ func (s *instanceService) DeleteCancelled(ctx context.Context, instanceID int64)
 	}
 
 	if instance.ActivityGroupID != nil && !instance.IsSpontaneous {
+		if err := s.rejectAmbiguousTemplateDelete(ctx, *instance.ActivityGroupID, instance.Date); err != nil {
+			return err
+		}
 		if err := s.ensureCancelledSlotException(ctx, *instance.ActivityGroupID, instance.Date, deletedSlotReason); err != nil {
 			return err
 		}
@@ -396,6 +406,23 @@ func (s *instanceService) DeleteCancelled(ctx context.Context, instanceID int64)
 		slog.String("date", instance.Date.String()),
 		slog.String("status", instance.Status),
 	)
+	return nil
+}
+
+func (s *instanceService) rejectAmbiguousTemplateDelete(ctx context.Context, activityGroupID int64, date timezone.Date) error {
+	rows, err := s.deps.InstanceRepo.FindByActivityGroupAndDate(ctx, activityGroupID, date)
+	if err != nil {
+		return &ScheduleError{Op: "delete instance: check same-day template slots", Err: err}
+	}
+	templateBacked := 0
+	for _, row := range rows {
+		if row != nil && !row.IsSpontaneous {
+			templateBacked++
+		}
+	}
+	if templateBacked > 1 {
+		return fmt.Errorf("%w: template has %d same-day slots", ErrAmbiguousTemplateInstanceDelete, templateBacked)
+	}
 	return nil
 }
 

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -363,25 +363,38 @@ func (s *instanceService) Cancel(ctx context.Context, instanceID int64) (*schedu
 	return instance, nil
 }
 
-// DeleteCancelled permanently removes a cancelled instance. Planned, active,
-// and completed instances stay protected: deleting those would hide scheduled
-// work, live sessions, or attendance history without the explicit cancellation
-// audit step.
+// DeleteCancelled permanently removes a planned or cancelled instance.
+// Historical name retained for compatibility with existing handlers. Active
+// and completed instances stay protected: deleting those would hide live
+// sessions or attendance history. For materialized template occurrences,
+// write a cancelled activity_exception first so materialization cannot
+// resurrect the deleted single occurrence.
 func (s *instanceService) DeleteCancelled(ctx context.Context, instanceID int64) error {
 	instance, err := s.loadForTransition(ctx, instanceID)
 	if err != nil {
 		return err
 	}
-	if instance.Status != scheduleModel.InstanceStatusCancelled {
+	switch instance.Status {
+	case scheduleModel.InstanceStatusPlanned, scheduleModel.InstanceStatusCancelled:
+		// allowed
+	default:
 		return fmt.Errorf("%w: cannot delete instance in status %q", ErrInvalidInstanceTransition, instance.Status)
 	}
-	if err := s.deps.InstanceRepo.Delete(ctx, instance.ID); err != nil {
-		return &ScheduleError{Op: "delete cancelled instance", Err: err}
+
+	if instance.ActivityGroupID != nil && !instance.IsSpontaneous {
+		if err := s.ensureCancelledSlotException(ctx, *instance.ActivityGroupID, instance.Date, deletedSlotReason); err != nil {
+			return err
+		}
 	}
-	s.getLogger().Info("cancelled instance deleted",
+
+	if err := s.deps.InstanceRepo.Delete(ctx, instance.ID); err != nil {
+		return &ScheduleError{Op: "delete instance", Err: err}
+	}
+	s.getLogger().Info("instance deleted",
 		slog.Int64("tenant_id", tenant.FromContext(ctx)),
 		slog.Int64("instance_id", instance.ID),
 		slog.String("date", instance.Date.String()),
+		slog.String("status", instance.Status),
 	)
 	return nil
 }
@@ -572,6 +585,10 @@ type capturedSlot struct {
 // admins can tell it apart from manually entered cancellations.
 const movedSlotReason = "Einzeltermin verschoben"
 
+// deletedSlotReason is stored on per-date cancellation exceptions created by
+// DeleteCancelled for a deleted materialized occurrence.
+const deletedSlotReason = "Einzeltermin gelöscht"
+
 // consumeMovedSlot writes a cancelled activity_exception for the original
 // (template, date) when an UpdatePlanned call moved a template-backed
 // instance to a different date or start time. Without it the original slot
@@ -629,6 +646,47 @@ func (s *instanceService) consumeMovedSlot(ctx context.Context, orig capturedSlo
 		slog.String("original_date", orig.Date.String()),
 		slog.String("original_start", orig.StartHHMMSS),
 		slog.String("new_date", req.Date.String()),
+	)
+	return nil
+}
+
+func (s *instanceService) ensureCancelledSlotException(ctx context.Context, activityGroupID int64, date timezone.Date, reason string) error {
+	existing, err := s.deps.ExceptionRepo.FindByActivityGroupAndDate(ctx, activityGroupID, date)
+	if err != nil {
+		return &ScheduleError{Op: "delete instance: check slot exception", Err: err}
+	}
+	if existing != nil {
+		if existing.ExceptionType == scheduleModel.ActivityExceptionCancelled {
+			return nil
+		}
+		existing.ExceptionType = scheduleModel.ActivityExceptionCancelled
+		existing.StartTime = nil
+		existing.EndTime = nil
+		existing.RoomID = nil
+		existing.Reason = &reason
+		if err := s.deps.ExceptionRepo.Update(ctx, existing); err != nil {
+			return &ScheduleError{Op: "delete instance: cancel existing exception", Err: err}
+		}
+		s.getLogger().Info("deleted instance: existing exception converted to cancellation",
+			slog.Int64("activity_group_id", activityGroupID),
+			slog.String("date", date.String()),
+		)
+		return nil
+	}
+
+	exc := &scheduleModel.ActivityException{
+		ActivityGroupID: activityGroupID,
+		ExceptionDate:   date,
+		ExceptionType:   scheduleModel.ActivityExceptionCancelled,
+		Reason:          &reason,
+	}
+	exc.SetTenantID(tenant.FromContext(ctx))
+	if err := s.deps.ExceptionRepo.Create(ctx, exc); err != nil {
+		return &ScheduleError{Op: "delete instance: create cancellation exception", Err: err}
+	}
+	s.getLogger().Info("deleted instance: slot consumed via cancelled exception",
+		slog.Int64("activity_group_id", activityGroupID),
+		slog.String("date", date.String()),
 	)
 	return nil
 }

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -931,15 +931,35 @@ func TestInstance_DeleteCancelled_PlannedOrCancelled(t *testing.T) {
 		assert.False(t, instanceExists(t, s, id))
 		assert.Empty(t, loadLifecycleExceptions(t, s))
 	})
+
+	t.Run("rejects single delete when template has multiple same-day slots", func(t *testing.T) {
+		s := buildLifecycle(t)
+		date := timezone.NewDate(2026, 4, 20)
+		firstID := insertInstanceAt(t, s, date, scheduleModels.InstanceStatusPlanned, false, 14)
+		secondID := insertInstanceAt(t, s, date, scheduleModels.InstanceStatusPlanned, false, 15)
+
+		err := s.svc.DeleteCancelled(s.ctx, firstID)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, scheduleSvc.ErrAmbiguousTemplateInstanceDelete)
+		assert.True(t, instanceExists(t, s, firstID))
+		assert.True(t, instanceExists(t, s, secondID))
+		assert.Empty(t, loadLifecycleExceptions(t, s))
+	})
 }
 
 func insertInstance(t *testing.T, s *lifecycleSetup, date timezone.Date, status string, spontaneous bool) int64 {
 	t.Helper()
+	return insertInstanceAt(t, s, date, status, spontaneous, 14)
+}
+
+func insertInstanceAt(t *testing.T, s *lifecycleSetup, date timezone.Date, status string, spontaneous bool, startHour int) int64 {
+	t.Helper()
+	endHour := startHour + 1
 	row := &scheduleModels.ActivityInstance{
 		Date:          date,
 		Title:         fmt.Sprintf("Row-%s-%d", status, time.Now().UnixNano()),
-		StartTime:     time.Date(1, 1, 1, 14, 0, 0, 0, time.UTC),
-		EndTime:       time.Date(1, 1, 1, 15, 0, 0, 0, time.UTC),
+		StartTime:     time.Date(1, 1, 1, startHour, 0, 0, 0, time.UTC),
+		EndTime:       time.Date(1, 1, 1, endHour, 0, 0, 0, time.UTC),
 		RoomID:        s.roomID,
 		Status:        status,
 		IsSpontaneous: spontaneous,
@@ -950,6 +970,9 @@ func insertInstance(t *testing.T, s *lifecycleSetup, date timezone.Date, status 
 	row.SetTenantID(1)
 	_, err := s.db.NewInsert().Model(row).ModelTableExpr(`schedule.activity_instances`).Exec(s.ctx)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", row.ID)
+	})
 	return row.ID
 }
 

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -882,9 +882,8 @@ func TestInstance_UpdatePlanned_RejectsNonPlanned(t *testing.T) {
 	}
 }
 
-func TestInstance_DeleteCancelled_OnlyCancelled(t *testing.T) {
+func TestInstance_DeleteCancelled_PlannedOrCancelled(t *testing.T) {
 	for _, status := range []string{
-		scheduleModels.InstanceStatusPlanned,
 		scheduleModels.InstanceStatusActive,
 		scheduleModels.InstanceStatusCompleted,
 	} {
@@ -900,13 +899,37 @@ func TestInstance_DeleteCancelled_OnlyCancelled(t *testing.T) {
 		})
 	}
 
-	t.Run("deletes cancelled", func(t *testing.T) {
+	t.Run("deletes planned template occurrence and writes cancellation exception", func(t *testing.T) {
+		s := buildLifecycle(t)
+		ai := seedInstance(t, s, false, false)
+
+		require.NoError(t, s.svc.DeleteCancelled(s.ctx, ai.ID))
+		assert.False(t, instanceExists(t, s, ai.ID))
+
+		exceptions := loadLifecycleExceptions(t, s)
+		require.Len(t, exceptions, 1)
+		assert.Equal(t, s.tmplID, exceptions[0].ActivityGroupID)
+		assert.Equal(t, ai.Date, exceptions[0].ExceptionDate)
+		assert.Equal(t, scheduleModels.ActivityExceptionCancelled, exceptions[0].ExceptionType)
+	})
+
+	t.Run("deletes cancelled template occurrence", func(t *testing.T) {
 		s := buildLifecycle(t)
 		ai := seedInstance(t, s, false, false)
 		forceSetInstanceStatus(t, s, ai.ID, scheduleModels.InstanceStatusCancelled)
 
 		require.NoError(t, s.svc.DeleteCancelled(s.ctx, ai.ID))
 		assert.False(t, instanceExists(t, s, ai.ID))
+		assert.Len(t, loadLifecycleExceptions(t, s), 1)
+	})
+
+	t.Run("deletes spontaneous planned occurrence without exception", func(t *testing.T) {
+		s := buildLifecycle(t)
+		id := insertInstance(t, s, timezone.NewDate(2026, 4, 20), scheduleModels.InstanceStatusPlanned, true)
+
+		require.NoError(t, s.svc.DeleteCancelled(s.ctx, id))
+		assert.False(t, instanceExists(t, s, id))
+		assert.Empty(t, loadLifecycleExceptions(t, s))
 	})
 }
 
@@ -954,6 +977,25 @@ func instanceExists(t *testing.T, s *lifecycleSetup, id int64) bool {
 		Scan(s.ctx, &count)
 	require.NoError(t, err)
 	return count > 0
+}
+
+func loadLifecycleExceptions(t *testing.T, s *lifecycleSetup) []*scheduleModels.ActivityException {
+	t.Helper()
+	var rows []*scheduleModels.ActivityException
+	err := s.db.NewSelect().
+		Model(&rows).
+		ModelTableExpr(`schedule.activity_exceptions AS "activity_exception"`).
+		Where(`"activity_exception".tenant_id = ?`, 1).
+		Order("exception_date ASC").
+		Scan(s.ctx)
+	require.NoError(t, err)
+	for _, row := range rows {
+		id := row.ID
+		t.Cleanup(func() {
+			testpkg.CleanupTableRecords(t, s.db, "schedule.activity_exceptions", id)
+		})
+	}
+	return rows
 }
 
 // --- B10 follow-up: Complete marks remaining expected as absent -------------

--- a/backend/services/schedule/instance_service_unit_test.go
+++ b/backend/services/schedule/instance_service_unit_test.go
@@ -1,0 +1,272 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceDelete_PlannedTemplateBackedCreatesCancellationException(t *testing.T) {
+	ctx := tenant.WithTenantID(context.Background(), 7301)
+	groupID := int64(410)
+	date := timezone.NewDate(2026, 7, 6)
+	inst := deleteUnitInstance(101, &groupID, date, scheduleModel.InstanceStatusPlanned, false)
+	instanceRepo := &deleteUnitInstanceRepo{instance: inst, sameDayRows: []*scheduleModel.ActivityInstance{inst}}
+	exceptionRepo := &deleteUnitExceptionRepo{}
+	svc := deleteUnitService(instanceRepo, exceptionRepo)
+
+	err := svc.DeleteCancelled(ctx, inst.ID)
+
+	require.NoError(t, err)
+	assert.Equal(t, []int64{inst.ID}, instanceRepo.deleted)
+	require.Len(t, exceptionRepo.created, 1)
+	created := exceptionRepo.created[0]
+	assert.Equal(t, groupID, created.ActivityGroupID)
+	assert.Equal(t, date, created.ExceptionDate)
+	assert.Equal(t, scheduleModel.ActivityExceptionCancelled, created.ExceptionType)
+	require.NotNil(t, created.Reason)
+	assert.Equal(t, deletedSlotReason, *created.Reason)
+	assert.Equal(t, int64(7301), created.TenantID)
+}
+
+func TestInstanceDelete_AmbiguousTemplateBackedDateDoesNotDelete(t *testing.T) {
+	ctx := tenant.WithTenantID(context.Background(), 7302)
+	groupID := int64(411)
+	date := timezone.NewDate(2026, 7, 7)
+	inst := deleteUnitInstance(102, &groupID, date, scheduleModel.InstanceStatusPlanned, false)
+	otherSlot := deleteUnitInstance(103, &groupID, date, scheduleModel.InstanceStatusPlanned, false)
+	instanceRepo := &deleteUnitInstanceRepo{instance: inst, sameDayRows: []*scheduleModel.ActivityInstance{inst, nil, otherSlot}}
+	exceptionRepo := &deleteUnitExceptionRepo{}
+	svc := deleteUnitService(instanceRepo, exceptionRepo)
+
+	err := svc.DeleteCancelled(ctx, inst.ID)
+
+	require.ErrorIs(t, err, ErrAmbiguousTemplateInstanceDelete)
+	assert.Empty(t, instanceRepo.deleted)
+	assert.Empty(t, exceptionRepo.created)
+	assert.Empty(t, exceptionRepo.updated)
+}
+
+func TestInstanceDelete_SpontaneousTemplateLinkedSkipsException(t *testing.T) {
+	ctx := tenant.WithTenantID(context.Background(), 7303)
+	groupID := int64(412)
+	inst := deleteUnitInstance(104, &groupID, timezone.NewDate(2026, 7, 8), scheduleModel.InstanceStatusPlanned, true)
+	instanceRepo := &deleteUnitInstanceRepo{instance: inst}
+	exceptionRepo := &deleteUnitExceptionRepo{}
+	svc := deleteUnitService(instanceRepo, exceptionRepo)
+
+	err := svc.DeleteCancelled(ctx, inst.ID)
+
+	require.NoError(t, err)
+	assert.Equal(t, []int64{inst.ID}, instanceRepo.deleted)
+	assert.Zero(t, instanceRepo.sameDayCalls)
+	assert.Zero(t, exceptionRepo.findCalls)
+	assert.Empty(t, exceptionRepo.created)
+}
+
+func TestInstanceDelete_ExistingModifiedExceptionIsConvertedToCancellation(t *testing.T) {
+	ctx := tenant.WithTenantID(context.Background(), 7304)
+	groupID := int64(413)
+	date := timezone.NewDate(2026, 7, 9)
+	inst := deleteUnitInstance(105, &groupID, date, scheduleModel.InstanceStatusCancelled, false)
+	start := time.Date(2000, 1, 1, 14, 0, 0, 0, time.UTC)
+	end := time.Date(2000, 1, 1, 15, 0, 0, 0, time.UTC)
+	roomID := int64(900)
+	reason := "Raumwechsel"
+	existing := &scheduleModel.ActivityException{
+		ActivityGroupID: groupID,
+		ExceptionDate:   date,
+		ExceptionType:   scheduleModel.ActivityExceptionModified,
+		StartTime:       &start,
+		EndTime:         &end,
+		RoomID:          &roomID,
+		Reason:          &reason,
+	}
+	instanceRepo := &deleteUnitInstanceRepo{instance: inst, sameDayRows: []*scheduleModel.ActivityInstance{inst}}
+	exceptionRepo := &deleteUnitExceptionRepo{existing: existing}
+	svc := deleteUnitService(instanceRepo, exceptionRepo)
+
+	err := svc.DeleteCancelled(ctx, inst.ID)
+
+	require.NoError(t, err)
+	assert.Equal(t, []int64{inst.ID}, instanceRepo.deleted)
+	assert.Empty(t, exceptionRepo.created)
+	require.Len(t, exceptionRepo.updated, 1)
+	updated := exceptionRepo.updated[0]
+	assert.Equal(t, scheduleModel.ActivityExceptionCancelled, updated.ExceptionType)
+	assert.Nil(t, updated.StartTime)
+	assert.Nil(t, updated.EndTime)
+	assert.Nil(t, updated.RoomID)
+	require.NotNil(t, updated.Reason)
+	assert.Equal(t, deletedSlotReason, *updated.Reason)
+}
+
+func TestInstanceDelete_ErrorBranches(t *testing.T) {
+	ctx := tenant.WithTenantID(context.Background(), 7305)
+	groupID := int64(414)
+	date := timezone.NewDate(2026, 7, 10)
+	inst := deleteUnitInstance(106, &groupID, date, scheduleModel.InstanceStatusPlanned, false)
+
+	tests := []struct {
+		name          string
+		instanceRepo  *deleteUnitInstanceRepo
+		exceptionRepo *deleteUnitExceptionRepo
+		wantOp        string
+	}{
+		{
+			name:          "same-day lookup error",
+			instanceRepo:  &deleteUnitInstanceRepo{instance: inst, sameDayErr: errors.New("same-day failed")},
+			exceptionRepo: &deleteUnitExceptionRepo{},
+			wantOp:        "delete instance: check same-day template slots",
+		},
+		{
+			name:          "exception lookup error",
+			instanceRepo:  &deleteUnitInstanceRepo{instance: inst, sameDayRows: []*scheduleModel.ActivityInstance{inst}},
+			exceptionRepo: &deleteUnitExceptionRepo{findErr: errors.New("exception lookup failed")},
+			wantOp:        "delete instance: check slot exception",
+		},
+		{
+			name:          "exception create error",
+			instanceRepo:  &deleteUnitInstanceRepo{instance: inst, sameDayRows: []*scheduleModel.ActivityInstance{inst}},
+			exceptionRepo: &deleteUnitExceptionRepo{createErr: errors.New("insert failed")},
+			wantOp:        "delete instance: create cancellation exception",
+		},
+		{
+			name:          "delete error",
+			instanceRepo:  &deleteUnitInstanceRepo{instance: inst, sameDayRows: []*scheduleModel.ActivityInstance{inst}, deleteErr: errors.New("delete failed")},
+			exceptionRepo: &deleteUnitExceptionRepo{},
+			wantOp:        "delete instance",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := deleteUnitService(tt.instanceRepo, tt.exceptionRepo)
+
+			err := svc.DeleteCancelled(ctx, inst.ID)
+
+			require.Error(t, err)
+			var scheduleErr *ScheduleError
+			require.ErrorAs(t, err, &scheduleErr)
+			assert.Equal(t, tt.wantOp, scheduleErr.Op)
+		})
+	}
+}
+
+func TestInstanceDelete_RejectsProtectedStatuses(t *testing.T) {
+	ctx := tenant.WithTenantID(context.Background(), 7306)
+	for _, status := range []string{scheduleModel.InstanceStatusActive, scheduleModel.InstanceStatusCompleted} {
+		t.Run(status, func(t *testing.T) {
+			inst := deleteUnitInstance(107, nil, timezone.NewDate(2026, 7, 11), status, false)
+			instanceRepo := &deleteUnitInstanceRepo{instance: inst}
+			svc := deleteUnitService(instanceRepo, &deleteUnitExceptionRepo{})
+
+			err := svc.DeleteCancelled(ctx, inst.ID)
+
+			require.ErrorIs(t, err, ErrInvalidInstanceTransition)
+			assert.Empty(t, instanceRepo.deleted)
+		})
+	}
+}
+
+func deleteUnitService(instanceRepo *deleteUnitInstanceRepo, exceptionRepo *deleteUnitExceptionRepo) *instanceService {
+	return &instanceService{deps: InstanceServiceDependencies{
+		InstanceRepo:  instanceRepo,
+		ExceptionRepo: exceptionRepo,
+		Logger:        slog.New(slog.DiscardHandler),
+	}}
+}
+
+func deleteUnitInstance(id int64, groupID *int64, date timezone.Date, status string, spontaneous bool) *scheduleModel.ActivityInstance {
+	inst := &scheduleModel.ActivityInstance{
+		Date:            date,
+		ActivityGroupID: groupID,
+		Title:           "Delete unit test",
+		StartTime:       time.Date(2000, 1, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:         time.Date(2000, 1, 1, 15, 0, 0, 0, time.UTC),
+		RoomID:          501,
+		Status:          status,
+		IsSpontaneous:   spontaneous,
+	}
+	inst.ID = id
+	return inst
+}
+
+type deleteUnitInstanceRepo struct {
+	scheduleModel.ActivityInstanceRepository
+	instance     *scheduleModel.ActivityInstance
+	findErr      error
+	sameDayRows  []*scheduleModel.ActivityInstance
+	sameDayErr   error
+	sameDayCalls int
+	deleteErr    error
+	deleted      []int64
+}
+
+func (r *deleteUnitInstanceRepo) FindByID(_ context.Context, _ any) (*scheduleModel.ActivityInstance, error) {
+	if r.findErr != nil {
+		return nil, r.findErr
+	}
+	return r.instance, nil
+}
+
+func (r *deleteUnitInstanceRepo) FindByActivityGroupAndDate(_ context.Context, _ int64, _ timezone.Date) ([]*scheduleModel.ActivityInstance, error) {
+	r.sameDayCalls++
+	if r.sameDayErr != nil {
+		return nil, r.sameDayErr
+	}
+	return r.sameDayRows, nil
+}
+
+func (r *deleteUnitInstanceRepo) Delete(_ context.Context, id any) error {
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	if v, ok := id.(int64); ok {
+		r.deleted = append(r.deleted, v)
+	}
+	return nil
+}
+
+type deleteUnitExceptionRepo struct {
+	scheduleModel.ActivityExceptionRepository
+	existing  *scheduleModel.ActivityException
+	findErr   error
+	createErr error
+	updateErr error
+	findCalls int
+	created   []*scheduleModel.ActivityException
+	updated   []*scheduleModel.ActivityException
+}
+
+func (r *deleteUnitExceptionRepo) FindByActivityGroupAndDate(_ context.Context, _ int64, _ timezone.Date) (*scheduleModel.ActivityException, error) {
+	r.findCalls++
+	if r.findErr != nil {
+		return nil, r.findErr
+	}
+	return r.existing, nil
+}
+
+func (r *deleteUnitExceptionRepo) Create(_ context.Context, exc *scheduleModel.ActivityException) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.created = append(r.created, exc)
+	return nil
+}
+
+func (r *deleteUnitExceptionRepo) Update(_ context.Context, exc *scheduleModel.ActivityException) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	r.updated = append(r.updated, exc)
+	return nil
+}

--- a/backend/services/schedule/template_end_service_unit_test.go
+++ b/backend/services/schedule/template_end_service_unit_test.go
@@ -1,0 +1,290 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateEndInputValidation(t *testing.T) {
+	future := timezone.TodayDate().AddDays(1)
+
+	tests := []struct {
+		name string
+		in   TemplateEndInput
+	}{
+		{
+			name: "missing template id",
+			in:   TemplateEndInput{EffectiveDate: future},
+		},
+		{
+			name: "missing effective date",
+			in:   TemplateEndInput{TemplateID: 10},
+		},
+		{
+			name: "past effective date",
+			in:   TemplateEndInput{TemplateID: 10, EffectiveDate: timezone.TodayDate().AddDays(-1)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTemplateEndInput(tt.in)
+
+			require.ErrorIs(t, err, ErrSplitInvalidInput)
+		})
+	}
+
+	require.NoError(t, validateTemplateEndInput(TemplateEndInput{TemplateID: 10, EffectiveDate: future}))
+}
+
+func TestTemplateEndFromDate_RequiresTenantBeforeMutation(t *testing.T) {
+	future := timezone.TodayDate().AddDays(1)
+	groupRepo := &templateEndUnitGroupRepo{group: templateEndUnitGroup(201)}
+	svc := templateEndUnitService(
+		groupRepo,
+		&templateEndUnitScheduleRepo{},
+		&templateEndUnitEnrollmentRepo{},
+		&templateEndUnitSupervisorRepo{},
+		&templateEndUnitInstanceRepo{},
+	)
+
+	_, err := svc.EndFromDate(context.Background(), TemplateEndInput{TemplateID: 201, EffectiveDate: future})
+
+	require.Error(t, err)
+	var scheduleErr *ScheduleError
+	require.ErrorAs(t, err, &scheduleErr)
+	assert.Equal(t, "end template", scheduleErr.Op)
+	assert.Zero(t, groupRepo.findCalls)
+}
+
+func TestTemplateEndFromDate_ReturnsSummaryAndDeletesOpenEndedWindow(t *testing.T) {
+	ctx := tenant.WithTenantID(context.Background(), 7401)
+	future := timezone.TodayDate().AddDays(1)
+	group := templateEndUnitGroup(202)
+	scheduleRepo := &templateEndUnitScheduleRepo{capped: 2}
+	enrollmentRepo := &templateEndUnitEnrollmentRepo{capped: 3}
+	supervisorRepo := &templateEndUnitSupervisorRepo{capped: 4}
+	instanceRepo := &templateEndUnitInstanceRepo{deleted: 5}
+	svc := templateEndUnitService(
+		&templateEndUnitGroupRepo{group: group},
+		scheduleRepo,
+		enrollmentRepo,
+		supervisorRepo,
+		instanceRepo,
+	)
+
+	res, err := svc.EndFromDate(ctx, TemplateEndInput{TemplateID: group.ID, EffectiveDate: future})
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, group.ID, res.TemplateID)
+	assert.Equal(t, future, res.EffectiveDate)
+	assert.Equal(t, 5, res.DeletedInstances)
+	assert.EqualValues(t, 2, res.CappedSchedules)
+	assert.EqualValues(t, 3, res.CappedEnrollments)
+	assert.EqualValues(t, 4, res.CappedSupervisors)
+	assert.Equal(t, group.ID, scheduleRepo.groupID)
+	assert.Equal(t, future, scheduleRepo.validUntil)
+	assert.Equal(t, group.ID, enrollmentRepo.groupID)
+	assert.Equal(t, group.ID, supervisorRepo.groupID)
+	require.NotNil(t, instanceRepo.activityGroupID)
+	assert.Equal(t, group.ID, *instanceRepo.activityGroupID)
+	assert.Equal(t, future, instanceRepo.from)
+	assert.Nil(t, instanceRepo.to)
+}
+
+func TestTemplateEndFromDate_ErrorBranches(t *testing.T) {
+	ctx := tenant.WithTenantID(context.Background(), 7402)
+	future := timezone.TodayDate().AddDays(1)
+	group := templateEndUnitGroup(203)
+
+	tests := []struct {
+		name           string
+		groupRepo      *templateEndUnitGroupRepo
+		scheduleRepo   *templateEndUnitScheduleRepo
+		enrollmentRepo *templateEndUnitEnrollmentRepo
+		supervisorRepo *templateEndUnitSupervisorRepo
+		instanceRepo   *templateEndUnitInstanceRepo
+		wantErr        error
+		wantOp         string
+	}{
+		{
+			name:           "template not found",
+			groupRepo:      &templateEndUnitGroupRepo{},
+			scheduleRepo:   &templateEndUnitScheduleRepo{},
+			enrollmentRepo: &templateEndUnitEnrollmentRepo{},
+			supervisorRepo: &templateEndUnitSupervisorRepo{},
+			instanceRepo:   &templateEndUnitInstanceRepo{},
+			wantErr:        ErrSplitTemplateNotFound,
+		},
+		{
+			name:           "cap schedules error",
+			groupRepo:      &templateEndUnitGroupRepo{group: group},
+			scheduleRepo:   &templateEndUnitScheduleRepo{err: errors.New("cap schedules failed")},
+			enrollmentRepo: &templateEndUnitEnrollmentRepo{},
+			supervisorRepo: &templateEndUnitSupervisorRepo{},
+			instanceRepo:   &templateEndUnitInstanceRepo{},
+			wantOp:         "end template: cap schedules",
+		},
+		{
+			name:           "cap enrollments error",
+			groupRepo:      &templateEndUnitGroupRepo{group: group},
+			scheduleRepo:   &templateEndUnitScheduleRepo{},
+			enrollmentRepo: &templateEndUnitEnrollmentRepo{err: errors.New("cap enrollments failed")},
+			supervisorRepo: &templateEndUnitSupervisorRepo{},
+			instanceRepo:   &templateEndUnitInstanceRepo{},
+			wantOp:         "end template: cap enrollments",
+		},
+		{
+			name:           "cap supervisors error",
+			groupRepo:      &templateEndUnitGroupRepo{group: group},
+			scheduleRepo:   &templateEndUnitScheduleRepo{},
+			enrollmentRepo: &templateEndUnitEnrollmentRepo{},
+			supervisorRepo: &templateEndUnitSupervisorRepo{err: errors.New("cap supervisors failed")},
+			instanceRepo:   &templateEndUnitInstanceRepo{},
+			wantOp:         "end template: cap supervisors",
+		},
+		{
+			name:           "delete instances error",
+			groupRepo:      &templateEndUnitGroupRepo{group: group},
+			scheduleRepo:   &templateEndUnitScheduleRepo{},
+			enrollmentRepo: &templateEndUnitEnrollmentRepo{},
+			supervisorRepo: &templateEndUnitSupervisorRepo{},
+			instanceRepo:   &templateEndUnitInstanceRepo{err: errors.New("delete failed")},
+			wantOp:         "end template: delete planned instances",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := templateEndUnitService(tt.groupRepo, tt.scheduleRepo, tt.enrollmentRepo, tt.supervisorRepo, tt.instanceRepo)
+
+			_, err := svc.EndFromDate(ctx, TemplateEndInput{TemplateID: 203, EffectiveDate: future})
+
+			require.Error(t, err)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			var scheduleErr *ScheduleError
+			require.ErrorAs(t, err, &scheduleErr)
+			assert.Equal(t, tt.wantOp, scheduleErr.Op)
+		})
+	}
+}
+
+func templateEndUnitService(
+	groupRepo *templateEndUnitGroupRepo,
+	scheduleRepo *templateEndUnitScheduleRepo,
+	enrollmentRepo *templateEndUnitEnrollmentRepo,
+	supervisorRepo *templateEndUnitSupervisorRepo,
+	instanceRepo *templateEndUnitInstanceRepo,
+) *templateSplitService {
+	return &templateSplitService{deps: TemplateSplitDependencies{
+		GroupRepo:      groupRepo,
+		ScheduleRepo:   scheduleRepo,
+		EnrollmentRepo: enrollmentRepo,
+		SupervisorRepo: supervisorRepo,
+		InstanceRepo:   instanceRepo,
+		Logger:         slog.New(slog.DiscardHandler),
+	}}
+}
+
+func templateEndUnitGroup(id int64) *activitiesModel.Group {
+	group := &activitiesModel.Group{
+		Name:       "Template end unit",
+		IsTemplate: true,
+	}
+	group.ID = id
+	return group
+}
+
+type templateEndUnitGroupRepo struct {
+	activitiesModel.GroupRepository
+	group     *activitiesModel.Group
+	err       error
+	findCalls int
+}
+
+func (r *templateEndUnitGroupRepo) FindByID(_ context.Context, _ any) (*activitiesModel.Group, error) {
+	r.findCalls++
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.group, nil
+}
+
+type templateEndUnitScheduleRepo struct {
+	activitiesModel.ScheduleRepository
+	capped     int64
+	err        error
+	groupID    int64
+	validUntil timezone.Date
+}
+
+func (r *templateEndUnitScheduleRepo) CapValidUntil(_ context.Context, groupID int64, validUntil timezone.Date) (int64, error) {
+	r.groupID = groupID
+	r.validUntil = validUntil
+	if r.err != nil {
+		return 0, r.err
+	}
+	return r.capped, nil
+}
+
+type templateEndUnitEnrollmentRepo struct {
+	activitiesModel.StudentEnrollmentRepository
+	capped  int64
+	err     error
+	groupID int64
+}
+
+func (r *templateEndUnitEnrollmentRepo) CapActiveByGroup(_ context.Context, groupID int64, _ timezone.Date) (int64, error) {
+	r.groupID = groupID
+	if r.err != nil {
+		return 0, r.err
+	}
+	return r.capped, nil
+}
+
+type templateEndUnitSupervisorRepo struct {
+	activitiesModel.SupervisorPlannedRepository
+	capped  int64
+	err     error
+	groupID int64
+}
+
+func (r *templateEndUnitSupervisorRepo) CapActiveByGroup(_ context.Context, groupID int64, _ timezone.Date) (int64, error) {
+	r.groupID = groupID
+	if r.err != nil {
+		return 0, r.err
+	}
+	return r.capped, nil
+}
+
+type templateEndUnitInstanceRepo struct {
+	scheduleModel.ActivityInstanceRepository
+	deleted         int64
+	err             error
+	from            timezone.Date
+	to              *timezone.Date
+	activityGroupID *int64
+}
+
+func (r *templateEndUnitInstanceRepo) DeletePlannedNonSpontaneousInWindow(_ context.Context, from timezone.Date, to *timezone.Date, activityGroupID *int64) (int64, error) {
+	r.from = from
+	r.to = to
+	r.activityGroupID = activityGroupID
+	if r.err != nil {
+		return 0, r.err
+	}
+	return r.deleted, nil
+}

--- a/backend/services/schedule/template_split_service.go
+++ b/backend/services/schedule/template_split_service.go
@@ -84,7 +84,25 @@ type TemplateSplitResult struct {
 	Materialization  *MaterializationResult
 }
 
-// TemplateSplitService performs the "Dieser und alle folgenden" template split.
+// TemplateEndInput describes the destructive "delete this and following"
+// recurrence action. EffectiveDate is inclusive for planned instance deletes
+// and exclusive for schedule/roster valid_until caps.
+type TemplateEndInput struct {
+	TemplateID    int64
+	EffectiveDate timezone.Date
+}
+
+// TemplateEndResult summarises one EndFromDate call.
+type TemplateEndResult struct {
+	TemplateID        int64
+	EffectiveDate     timezone.Date
+	DeletedInstances  int
+	CappedSchedules   int64
+	CappedEnrollments int64
+	CappedSupervisors int64
+}
+
+// TemplateSplitService performs recurring-template scope operations.
 type TemplateSplitService interface {
 	// Split caps the old template at in.EffectiveDate (exclusive), creates a
 	// successor template from the updated fields, deletes the old template's
@@ -92,6 +110,11 @@ type TemplateSplitService interface {
 	// The caller is expected to have established tenant context and a
 	// transaction.
 	Split(ctx context.Context, in TemplateSplitInput) (*TemplateSplitResult, error)
+
+	// EndFromDate caps a template from the effective date onward without
+	// creating a successor. Planned non-spontaneous future instances are
+	// deleted; active/completed/cancelled/spontaneous rows remain as history.
+	EndFromDate(ctx context.Context, in TemplateEndInput) (*TemplateEndResult, error)
 }
 
 // TemplateSplitDependencies aggregates wiring. All fields are required;
@@ -220,6 +243,61 @@ func (s *templateSplitService) Split(ctx context.Context, in TemplateSplitInput)
 	}, nil
 }
 
+// EndFromDate implements the "Dieser und alle folgenden löschen" flow. It is
+// intentionally the destructive half of Split without a successor template.
+func (s *templateSplitService) EndFromDate(ctx context.Context, in TemplateEndInput) (*TemplateEndResult, error) {
+	if err := validateTemplateEndInput(in); err != nil {
+		return nil, err
+	}
+	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		return nil, &ScheduleError{Op: "end template", Err: errors.New("no tenant in context")}
+	}
+
+	old, err := s.loadTemplate(ctx, in.TemplateID)
+	if err != nil {
+		return nil, err
+	}
+
+	cappedSchedules, err := s.deps.ScheduleRepo.CapValidUntil(ctx, old.ID, in.EffectiveDate)
+	if err != nil {
+		return nil, &ScheduleError{Op: "end template: cap schedules", Err: err}
+	}
+	cappedEnrollments, err := s.deps.EnrollmentRepo.CapActiveByGroup(ctx, old.ID, in.EffectiveDate)
+	if err != nil {
+		return nil, &ScheduleError{Op: "end template: cap enrollments", Err: err}
+	}
+	cappedSupervisors, err := s.deps.SupervisorRepo.CapActiveByGroup(ctx, old.ID, in.EffectiveDate)
+	if err != nil {
+		return nil, &ScheduleError{Op: "end template: cap supervisors", Err: err}
+	}
+
+	templateID := old.ID
+	deleted, err := s.deps.InstanceRepo.DeletePlannedNonSpontaneousInWindow(ctx, in.EffectiveDate, nil, &templateID)
+	if err != nil {
+		return nil, &ScheduleError{Op: "end template: delete planned instances", Err: err}
+	}
+
+	s.getLogger().Info("template ended from date",
+		slog.Int64("tenant_id", tenantID),
+		slog.Int64("template_id", old.ID),
+		slog.String("effective_date", in.EffectiveDate.String()),
+		slog.Int64("deleted_instances", deleted),
+		slog.Int64("capped_schedules", cappedSchedules),
+		slog.Int64("capped_enrollments", cappedEnrollments),
+		slog.Int64("capped_supervisors", cappedSupervisors),
+	)
+
+	return &TemplateEndResult{
+		TemplateID:        old.ID,
+		EffectiveDate:     in.EffectiveDate,
+		DeletedInstances:  int(deleted),
+		CappedSchedules:   cappedSchedules,
+		CappedEnrollments: cappedEnrollments,
+		CappedSupervisors: cappedSupervisors,
+	}, nil
+}
+
 // validateSplitInput checks the semantic rules the handler's Bind cannot:
 // dates, weekday range, week pattern, time order, activity type.
 func validateSplitInput(in TemplateSplitInput) error {
@@ -261,6 +339,19 @@ func validateSplitInput(in TemplateSplitInput) error {
 		return fmt.Errorf("%w: effective_date must not be in the past", ErrSplitInvalidInput)
 	}
 	return validateSplitMaterializationWindow(in)
+}
+
+func validateTemplateEndInput(in TemplateEndInput) error {
+	if in.TemplateID <= 0 {
+		return fmt.Errorf("%w: template id is required", ErrSplitInvalidInput)
+	}
+	if in.EffectiveDate.IsZero() {
+		return fmt.Errorf("%w: effective_date is required", ErrSplitInvalidInput)
+	}
+	if in.EffectiveDate.Before(timezone.TodayDate()) {
+		return fmt.Errorf("%w: effective_date must not be in the past", ErrSplitInvalidInput)
+	}
+	return nil
 }
 
 // validateSplitMaterializationWindow rejects self-inconsistent materialization

--- a/backend/services/schedule/template_split_service_test.go
+++ b/backend/services/schedule/template_split_service_test.go
@@ -307,6 +307,97 @@ func TestTemplateSplit_HappyPath_CarriesRosterAndProtectsHistory(t *testing.T) {
 	assert.Len(t, listInstancesForDate(t, s.db, res.NewTemplateID, secondMonday), 1)
 }
 
+func TestTemplateEndFromDate_CapsTemplateAndProtectsHistory(t *testing.T) {
+	effective := futureMonday(1)
+	secondMonday := effective.AddDays(7)
+	s := makeScenario(t, activitiesModels.WeekdayMonday, effective)
+	defer s.runCleanup(t)
+	suffix := time.Now().UnixNano()
+
+	r0, err := s.svc.MaterializeForTenant(s.ctx, effective, secondMonday, scheduleSvc.MaterializationSourceManual)
+	require.NoError(t, err)
+	require.Equal(t, 2, r0.InstancesCreated)
+
+	first := listInstancesForDate(t, s.db, s.template.ID, effective)
+	require.Len(t, first, 1)
+	second := listInstancesForDate(t, s.db, s.template.ID, secondMonday)
+	require.Len(t, second, 1)
+	s.registerCleanup("schedule.activity_instances", first[0].ID, second[0].ID)
+
+	_, err = s.db.NewUpdate().
+		Model((*scheduleModels.ActivityInstance)(nil)).
+		ModelTableExpr(`schedule.activity_instances AS "activity_instance"`).
+		Set("status = ?", scheduleModels.InstanceStatusActive).
+		Where(`"activity_instance".id = ?`, first[0].ID).
+		Where(`"activity_instance".tenant_id = ?`, s.tenantID).
+		Exec(s.ctx)
+	require.NoError(t, err)
+
+	completedID := splitInsertInstance(t, s, &s.template.ID, effective, scheduleModels.InstanceStatusCompleted, false, 9)
+	cancelledID := splitInsertInstance(t, s, &s.template.ID, effective, scheduleModels.InstanceStatusCancelled, false, 10)
+	spontaneousID := splitInsertInstance(t, s, &s.template.ID, effective, scheduleModels.InstanceStatusPlanned, true, 11)
+
+	roomID := s.roomID
+	otherGroup := &activitiesModels.Group{
+		Name:            fmt.Sprintf("End-Fremd-%d", suffix),
+		MaxParticipants: 10,
+		CategoryID:      s.categoryID,
+		PlannedRoomID:   &roomID,
+		IsTemplate:      true,
+	}
+	otherGroup.SetTenantID(s.tenantID)
+	_, err = s.db.NewInsert().Model(otherGroup).ModelTableExpr(`activities.groups AS "group"`).Exec(s.ctx)
+	require.NoError(t, err)
+	s.extraCleanups = append([]func(){func() {
+		testpkg.CleanupTableRecords(t, s.db, "activities.groups", otherGroup.ID)
+	}}, s.extraCleanups...)
+	otherPlannedID := splitInsertInstance(t, s, &otherGroup.ID, effective, scheduleModels.InstanceStatusPlanned, false, 12)
+
+	res, err := s.factory.TemplateSplit.EndFromDate(s.ctx, scheduleSvc.TemplateEndInput{
+		TemplateID:    s.template.ID,
+		EffectiveDate: effective,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, s.template.ID, res.TemplateID)
+	assert.Equal(t, effective, res.EffectiveDate)
+	assert.Equal(t, 1, res.DeletedInstances, "only still-planned non-spontaneous old-template rows are deleted")
+	assert.EqualValues(t, 1, res.CappedSchedules)
+	assert.EqualValues(t, 2, res.CappedEnrollments)
+	assert.EqualValues(t, 1, res.CappedSupervisors)
+
+	oldSchedule := reloadSplitSchedule(t, s, s.schedule.ID)
+	require.NotNil(t, oldSchedule.ValidUntil)
+	assert.Equal(t, effective, *oldSchedule.ValidUntil)
+
+	oldEnrollments := loadSplitEnrollments(t, s, s.template.ID)
+	expiredUntil := effective.AddDays(-1)
+	for _, e := range oldEnrollments {
+		require.NotNil(t, e.ValidUntil)
+		if e.StudentID == s.students[2] {
+			assert.Equal(t, expiredUntil, *e.ValidUntil)
+		} else {
+			assert.Equal(t, effective, *e.ValidUntil)
+		}
+	}
+	oldSupervisors := loadSplitSupervisors(t, s, s.template.ID)
+	require.Len(t, oldSupervisors, 1)
+	require.NotNil(t, oldSupervisors[0].ValidUntil)
+	assert.Equal(t, effective, *oldSupervisors[0].ValidUntil)
+
+	assert.True(t, splitInstanceExists(t, s, first[0].ID), "active instance survives")
+	assert.False(t, splitInstanceExists(t, s, second[0].ID), "planned future old-template instance deleted")
+	assert.True(t, splitInstanceExists(t, s, completedID), "completed instance survives")
+	assert.True(t, splitInstanceExists(t, s, cancelledID), "cancelled instance survives")
+	assert.True(t, splitInstanceExists(t, s, spontaneousID), "spontaneous instance survives")
+	assert.True(t, splitInstanceExists(t, s, otherPlannedID), "other group's planned instance survives")
+
+	r1, err := s.svc.MaterializeForTenant(s.ctx, effective, secondMonday, scheduleSvc.MaterializationSourceManual)
+	require.NoError(t, err)
+	assert.Zero(t, r1.InstancesCreated, "ended template must not re-create future appointments")
+	assert.Equal(t, 2, r1.CandidatesSkippedEnded)
+}
+
 func TestTemplateSplit_ExplicitRosterAndWeekPattern(t *testing.T) {
 	effective := futureMonday(1)
 	s := makeScenario(t, activitiesModels.WeekdayMonday, effective)

--- a/frontend/src/app/[tenant]/(protected)/timetables/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/timetables/page.test.tsx
@@ -16,6 +16,7 @@ const {
   mockSubstitute,
   mockPatchAttendance,
   mockDeleteCancelled,
+  mockEndTemplate,
   mockArchiveTemplate,
   mockBootstrap,
   mockEventModalProps,
@@ -36,6 +37,7 @@ const {
   mockSubstitute: vi.fn(),
   mockPatchAttendance: vi.fn(),
   mockDeleteCancelled: vi.fn(),
+  mockEndTemplate: vi.fn(),
   mockArchiveTemplate: vi.fn(),
   mockBootstrap: vi.fn(),
   mockEventModalProps: vi.fn(),
@@ -90,6 +92,7 @@ vi.mock("~/lib/timetable-api", () => ({
     substitute: mockSubstitute,
     patchAttendance: mockPatchAttendance,
     deleteCancelled: mockDeleteCancelled,
+    endTemplate: mockEndTemplate,
     archiveTemplate: mockArchiveTemplate,
   },
 }));
@@ -429,6 +432,7 @@ vi.mock("~/components/timetable/instance-detail-slide-over", () => ({
     onClose,
     onLifecycleAction,
     onDeleteCancelled,
+    onDeleteFollowing,
     onEdit,
     onRepeat,
     onAttendancePatch,
@@ -439,6 +443,11 @@ vi.mock("~/components/timetable/instance-detail-slide-over", () => ({
       action: "start" | "complete" | "cancel",
     ) => Promise<void>;
     onDeleteCancelled: (instance: { id: string }) => Promise<void>;
+    onDeleteFollowing: (instance: {
+      id: string;
+      activityGroupId?: string;
+      date?: string;
+    }) => Promise<void>;
     onEdit: (instance: { id: string }) => void;
     onRepeat: (instance: { id: string }) => void;
     onAttendancePatch: (
@@ -466,6 +475,9 @@ vi.mock("~/components/timetable/instance-detail-slide-over", () => ({
         </button>
         <button type="button" onClick={() => void onDeleteCancelled(instance)}>
           detail-delete
+        </button>
+        <button type="button" onClick={() => void onDeleteFollowing(instance)}>
+          detail-delete-following
         </button>
         <button type="button" onClick={() => onEdit(instance)}>
           detail-edit
@@ -570,6 +582,7 @@ const instance = {
   isSpontaneous: false,
   isLive: false,
   activityType: "care" as const,
+  activityGroupId: "7",
   roomId: "3",
   roomName: "Mensa",
   staff: [
@@ -718,6 +731,11 @@ describe("TimetablesPage", () => {
     });
     mockPatchAttendance.mockResolvedValue({});
     mockDeleteCancelled.mockResolvedValue({});
+    mockEndTemplate.mockResolvedValue({
+      templateId: "7",
+      effectiveDate: "2026-05-04",
+      deletedInstances: 3,
+    });
     mockArchiveTemplate.mockResolvedValue({});
     setupSWR();
     window.history.replaceState(null, "", "/acme/timetables");
@@ -795,6 +813,14 @@ describe("TimetablesPage", () => {
 
     fireEvent.click(screen.getByText("detail-delete"));
     await waitFor(() => expect(mockDeleteCancelled).toHaveBeenCalledWith("42"));
+
+    fireEvent.click(screen.getByText("week-grid"));
+    fireEvent.click(screen.getByText("detail-delete-following"));
+    await waitFor(() =>
+      expect(mockEndTemplate).toHaveBeenCalledWith("7", {
+        effective_date: "2026-05-04",
+      }),
+    );
   });
 
   it("handles series, month and year navigation callbacks", async () => {

--- a/frontend/src/app/[tenant]/(protected)/timetables/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/timetables/page.test.tsx
@@ -511,6 +511,11 @@ vi.mock("~/components/timetable/timetable-event-modal", () => ({
     defaultStartTime?: string;
     defaultEndTime?: string;
     defaultCalendarPeriodId?: string | null;
+    initialSeries?: { id: string } | null;
+    onDeleteSeries?: (
+      template: { id: string },
+      effectiveDate: string,
+    ) => Promise<void>;
   }) => {
     mockEventModalProps(props);
     return props.isOpen ? (
@@ -538,6 +543,16 @@ vi.mock("~/components/timetable/timetable-event-modal", () => ({
         >
           event-save-series
         </button>
+        {props.initialSeries && props.onDeleteSeries && (
+          <button
+            type="button"
+            onClick={() =>
+              void props.onDeleteSeries?.(props.initialSeries!, "2026-05-06")
+            }
+          >
+            event-delete-series
+          </button>
+        )}
       </div>
     ) : null;
   },
@@ -731,11 +746,14 @@ describe("TimetablesPage", () => {
     });
     mockPatchAttendance.mockResolvedValue({});
     mockDeleteCancelled.mockResolvedValue({});
-    mockEndTemplate.mockResolvedValue({
-      templateId: "7",
-      effectiveDate: "2026-05-04",
-      deletedInstances: 3,
-    });
+    mockEndTemplate.mockImplementation(
+      (_templateId: string, body: { effective_date: string }) =>
+        Promise.resolve({
+          templateId: "7",
+          effectiveDate: body.effective_date,
+          deletedInstances: 3,
+        }),
+    );
     mockArchiveTemplate.mockResolvedValue({});
     setupSWR();
     window.history.replaceState(null, "", "/acme/timetables");
@@ -834,6 +852,18 @@ describe("TimetablesPage", () => {
 
     fireEvent.click(screen.getByText("edit-template"));
     expect(screen.getByText("event-close")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("event-delete-series"));
+    await waitFor(() =>
+      expect(mockEndTemplate).toHaveBeenCalledWith("7", {
+        effective_date: "2026-05-06",
+      }),
+    );
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "Regeltermin ab 06.05.2026 gelöscht",
+    );
+    expect(mockTenantMutate).toHaveBeenCalledWith("timetable-templates-5");
+
+    fireEvent.click(screen.getByText("edit-template"));
     fireEvent.click(screen.getByText("event-close"));
 
     fireEvent.click(screen.getByText("apply-template"));

--- a/frontend/src/app/[tenant]/(protected)/timetables/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/timetables/page.tsx
@@ -1261,7 +1261,7 @@ function TimetablesContent() {
     async (instance: EnrichedInstance) => {
       try {
         await timetableService.deleteCancelled(instance.id);
-        toastSuccess("Abgesagter Termin gelöscht");
+        toastSuccess("Termin gelöscht");
         updateUrlParams({ instance: null });
         await tenantMutate(swrKey);
         await tenantMutate(gapsSWRKey);
@@ -1283,6 +1283,53 @@ function TimetablesContent() {
       exceptionConflictsSWRKey,
       gapsSWRKey,
       swrKey,
+      tenantMutate,
+      toastError,
+      toastSuccess,
+      updateUrlParams,
+    ],
+  );
+
+  const handleDeleteFollowingInstances = useCallback(
+    async (instance: EnrichedInstance) => {
+      if (!instance.activityGroupId) return;
+      try {
+        const result = await timetableService.endTemplate(
+          instance.activityGroupId,
+          {
+            effective_date: instance.date,
+          },
+        );
+        toastSuccess(
+          `Regeltermin ab ${formatDate(result.effectiveDate)} beendet`,
+        );
+        updateUrlParams({ instance: null });
+        if (templatePeriodID) {
+          await tenantMutate(`timetable-templates-${templatePeriodID}`);
+        }
+        await tenantMutate(swrKey);
+        await tenantMutate(gapsSWRKey);
+        await tenantMutate(exceptionConflictsSWRKey);
+      } catch (err) {
+        logger.error("template_end_failed", {
+          template_id: instance.activityGroupId,
+          instance_id: instance.id,
+          effective_date: instance.date,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        toastError(
+          err instanceof Error
+            ? err.message
+            : "Folgetermine konnten nicht gelöscht werden",
+        );
+        throw err;
+      }
+    },
+    [
+      exceptionConflictsSWRKey,
+      gapsSWRKey,
+      swrKey,
+      templatePeriodID,
       tenantMutate,
       toastError,
       toastSuccess,
@@ -1678,6 +1725,7 @@ function TimetablesContent() {
         onClose={() => handleSelectInstance(null)}
         onLifecycleAction={handleLifecycle}
         onDeleteCancelled={handleDeleteCancelledInstance}
+        onDeleteFollowing={handleDeleteFollowingInstances}
         onEdit={(instance) => {
           setEditingInstance(instance);
           setEditingTemplate(null);

--- a/frontend/src/app/[tenant]/(protected)/timetables/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/timetables/page.tsx
@@ -1337,6 +1337,50 @@ function TimetablesContent() {
     ],
   );
 
+  const handleDeleteSeriesTemplate = useCallback(
+    async (template: TimetableTemplate, effectiveDate: string) => {
+      try {
+        const result = await timetableService.endTemplate(template.id, {
+          effective_date: effectiveDate,
+        });
+        toastSuccess(
+          `Regeltermin ab ${formatDate(result.effectiveDate)} gelöscht`,
+        );
+        setEventModalOpen(false);
+        setEditingInstance(null);
+        setEditingTemplate(null);
+        setConvertingInstance(null);
+        if (templatePeriodID) {
+          await tenantMutate(`timetable-templates-${templatePeriodID}`);
+        }
+        await tenantMutate(swrKey);
+        await tenantMutate(gapsSWRKey);
+        await tenantMutate(exceptionConflictsSWRKey);
+      } catch (err) {
+        logger.error("template_delete_failed", {
+          template_id: template.id,
+          effective_date: effectiveDate,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        toastError(
+          err instanceof Error
+            ? err.message
+            : "Regeltermin konnte nicht gelöscht werden",
+        );
+        throw err;
+      }
+    },
+    [
+      exceptionConflictsSWRKey,
+      gapsSWRKey,
+      swrKey,
+      templatePeriodID,
+      tenantMutate,
+      toastError,
+      toastSuccess,
+    ],
+  );
+
   const openEventCreate = useCallback(() => {
     setEditingInstance(null);
     setEditingTemplate(null);
@@ -1772,6 +1816,7 @@ function TimetablesContent() {
         initialInstance={editingInstance}
         initialSeries={editingTemplate}
         convertInstance={convertingInstance}
+        onDeleteSeries={handleDeleteSeriesTemplate}
         defaultRepeat={eventDefaultRepeat}
         variant={quickPrefill ? "quick" : "full"}
         defaultStartTime={quickPrefill?.startTime}

--- a/frontend/src/app/[tenant]/(protected)/timetables/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/timetables/page.tsx
@@ -454,11 +454,7 @@ function TimetableDisabledState() {
 function TimetablesContent() {
   const searchParams = useSearchParams();
   const { status } = useSession({ required: true });
-  const {
-    success: toastSuccess,
-    error: toastError,
-    warning: toastWarning,
-  } = useToast();
+  const toast = useToast();
   const tenantMutate = useTenantMutate();
 
   const [view, setView] = useState<TimetableView>(() =>
@@ -919,8 +915,8 @@ function TimetablesContent() {
   useEffect(() => {
     if (!errorMessage) return;
     logger.error("week_load_failed", { error: errorMessage });
-    toastError(`Betreuungsplan konnte nicht geladen werden: ${errorMessage}`);
-  }, [errorMessage, toastError]);
+    toast.error(`Betreuungsplan konnte nicht geladen werden: ${errorMessage}`);
+  }, [errorMessage, toast]);
 
   useEffect(() => {
     if (!periodsError) return;
@@ -929,8 +925,8 @@ function TimetablesContent() {
         ? periodsError.message
         : String(periodsError);
     logger.error("periods_load_failed", { error: message });
-    toastError(`Planungszeiträume konnten nicht geladen werden: ${message}`);
-  }, [periodsError, toastError]);
+    toast.error(`Planungszeiträume konnten nicht geladen werden: ${message}`);
+  }, [periodsError, toast]);
 
   // Phase 2: silently create the default school-year period when the
   // tenant has none. The backend POST /periods/bootstrap is idempotent;
@@ -975,8 +971,8 @@ function TimetablesContent() {
     logger.error("plan_quality_load_failed", {
       error: planQualityErrorMessage,
     });
-    toastError("Planstatus konnte nicht vollständig geladen werden.");
-  }, [planQualityErrorMessage, toastError]);
+    toast.error("Planstatus konnte nicht vollständig geladen werden.");
+  }, [planQualityErrorMessage, toast]);
 
   // Memoise on data?.instances so the reference is stable between renders
   // when SWR returns the same response (the linter warns when arrays are
@@ -1144,18 +1140,18 @@ function TimetablesContent() {
         if (action === "start") {
           const res = await timetableService.start(selectedInstance.id);
           if (res.warnings.length > 0) {
-            toastSuccess(
+            toast.success(
               `Gestartet: ${res.warnings.length} Hinweis(e): ${res.warnings.map((w) => w.message).join(", ")}`,
             );
           } else {
-            toastSuccess("Aktivität gestartet");
+            toast.success("Aktivität gestartet");
           }
         } else if (action === "complete") {
           await timetableService.complete(selectedInstance.id);
-          toastSuccess("Aktivität beendet");
+          toast.success("Aktivität beendet");
         } else {
           await timetableService.cancel(selectedInstance.id);
-          toastSuccess("Aktivität abgesagt");
+          toast.success("Aktivität abgesagt");
         }
         await tenantMutate(swrKey);
         await tenantMutate(gapsSWRKey);
@@ -1166,7 +1162,7 @@ function TimetablesContent() {
           instance_id: selectedInstance.id,
           error: err instanceof Error ? err.message : String(err),
         });
-        toastError(
+        toast.error(
           err instanceof Error
             ? err.message
             : "Aktion konnte nicht durchgeführt werden",
@@ -1180,8 +1176,7 @@ function TimetablesContent() {
       gapsSWRKey,
       exceptionConflictsSWRKey,
       tenantMutate,
-      toastSuccess,
-      toastError,
+      toast,
     ],
   );
 
@@ -1193,11 +1188,11 @@ function TimetablesContent() {
           substituteStaffId,
           date,
         );
-        toastSuccess(
+        toast.success(
           `Ersatz eingetragen: ${result.affectedInstances.length} Termin(e) aktualisiert`,
         );
         if (result.warnings.length > 0) {
-          toastError(
+          toast.error(
             `${result.warnings.length} mögliche Zeitüberschneidung(en) prüfen.`,
           );
         }
@@ -1211,7 +1206,7 @@ function TimetablesContent() {
           date,
           error: err instanceof Error ? err.message : String(err),
         });
-        toastError(
+        toast.error(
           err instanceof Error
             ? err.message
             : "Ersatz konnte nicht eingetragen werden",
@@ -1219,14 +1214,7 @@ function TimetablesContent() {
         throw err;
       }
     },
-    [
-      exceptionConflictsSWRKey,
-      gapsSWRKey,
-      swrKey,
-      tenantMutate,
-      toastError,
-      toastSuccess,
-    ],
+    [exceptionConflictsSWRKey, gapsSWRKey, swrKey, tenantMutate, toast],
   );
 
   const handleAttendancePatch = useCallback(
@@ -1237,7 +1225,7 @@ function TimetablesContent() {
     ) => {
       try {
         await timetableService.patchAttendance(instanceId, studentId, body);
-        toastSuccess("Kinderstatus aktualisiert");
+        toast.success("Kinderstatus aktualisiert");
         await tenantMutate(swrKey);
         await tenantMutate(exceptionConflictsSWRKey);
       } catch (err) {
@@ -1246,7 +1234,7 @@ function TimetablesContent() {
           student_id: studentId,
           error: err instanceof Error ? err.message : String(err),
         });
-        toastError(
+        toast.error(
           err instanceof Error
             ? err.message
             : "Kinderstatus konnte nicht aktualisiert werden",
@@ -1254,14 +1242,14 @@ function TimetablesContent() {
         throw err;
       }
     },
-    [exceptionConflictsSWRKey, swrKey, tenantMutate, toastError, toastSuccess],
+    [exceptionConflictsSWRKey, swrKey, tenantMutate, toast],
   );
 
   const handleDeleteCancelledInstance = useCallback(
     async (instance: EnrichedInstance) => {
       try {
         await timetableService.deleteCancelled(instance.id);
-        toastSuccess("Termin gelöscht");
+        toast.success("Termin gelöscht");
         updateUrlParams({ instance: null });
         await tenantMutate(swrKey);
         await tenantMutate(gapsSWRKey);
@@ -1271,7 +1259,7 @@ function TimetablesContent() {
           instance_id: instance.id,
           error: err instanceof Error ? err.message : String(err),
         });
-        toastError(
+        toast.error(
           err instanceof Error
             ? err.message
             : "Termin konnte nicht gelöscht werden",
@@ -1284,8 +1272,7 @@ function TimetablesContent() {
       gapsSWRKey,
       swrKey,
       tenantMutate,
-      toastError,
-      toastSuccess,
+      toast,
       updateUrlParams,
     ],
   );
@@ -1300,7 +1287,7 @@ function TimetablesContent() {
             effective_date: instance.date,
           },
         );
-        toastSuccess(
+        toast.success(
           `Regeltermin ab ${formatDate(result.effectiveDate)} beendet`,
         );
         updateUrlParams({ instance: null });
@@ -1317,7 +1304,7 @@ function TimetablesContent() {
           effective_date: instance.date,
           error: err instanceof Error ? err.message : String(err),
         });
-        toastError(
+        toast.error(
           err instanceof Error
             ? err.message
             : "Folgetermine konnten nicht gelöscht werden",
@@ -1331,8 +1318,7 @@ function TimetablesContent() {
       swrKey,
       templatePeriodID,
       tenantMutate,
-      toastError,
-      toastSuccess,
+      toast,
       updateUrlParams,
     ],
   );
@@ -1343,7 +1329,7 @@ function TimetablesContent() {
         const result = await timetableService.endTemplate(template.id, {
           effective_date: effectiveDate,
         });
-        toastSuccess(
+        toast.success(
           `Regeltermin ab ${formatDate(result.effectiveDate)} gelöscht`,
         );
         setEventModalOpen(false);
@@ -1362,7 +1348,7 @@ function TimetablesContent() {
           effective_date: effectiveDate,
           error: err instanceof Error ? err.message : String(err),
         });
-        toastError(
+        toast.error(
           err instanceof Error
             ? err.message
             : "Regeltermin konnte nicht gelöscht werden",
@@ -1376,8 +1362,7 @@ function TimetablesContent() {
       swrKey,
       templatePeriodID,
       tenantMutate,
-      toastError,
-      toastSuccess,
+      toast,
     ],
   );
 
@@ -1449,7 +1434,7 @@ function TimetablesContent() {
         ? calendarPeriods.find((p) => p.id === periodId)
         : null;
       if (!period) {
-        toastWarning(
+        toast.warning(
           "Kein aktiver Planungszeitraum. Der Regeltermin kann nicht eingetragen werden.",
         );
         openPeriodCreate();
@@ -1479,13 +1464,13 @@ function TimetablesContent() {
         const warnings = Array.from(warningsByCode.values());
         if (warnings.length > 0) {
           for (const warning of warnings) {
-            toastWarning(warning.message);
+            toast.warning(warning.message);
           }
           if (warnings.some((w) => w.code === "no_active_period")) {
             openPeriodCreate();
           }
         } else {
-          toastSuccess(
+          toast.success(
             `${totalCreated} ${
               totalCreated === 1 ? "Termin" : "Termine"
             } für "${template.name}" angelegt`,
@@ -1499,7 +1484,7 @@ function TimetablesContent() {
           template_id: template.id,
           error: err instanceof Error ? err.message : String(err),
         });
-        toastError(
+        toast.error(
           err instanceof Error
             ? err.message
             : "Regeltermin konnte nicht eingetragen werden",
@@ -1514,9 +1499,7 @@ function TimetablesContent() {
       openPeriodCreate,
       swrKey,
       tenantMutate,
-      toastError,
-      toastWarning,
-      toastSuccess,
+      toast,
     ],
   );
 
@@ -1526,7 +1509,7 @@ function TimetablesContent() {
     setArchiveLoading(true);
     try {
       await timetableService.archiveTemplate(archivingTemplate.id);
-      toastSuccess(`Regeltermin "${archivingTemplate.name}" archiviert`);
+      toast.success(`Regeltermin "${archivingTemplate.name}" archiviert`);
       setArchivingTemplate(null);
       if (templatePeriodID) {
         await tenantMutate(`timetable-templates-${templatePeriodID}`);
@@ -1543,7 +1526,7 @@ function TimetablesContent() {
         template_id: archivingTemplate.id,
         error: message,
       });
-      toastError(message);
+      toast.error(message);
     } finally {
       setArchiveLoading(false);
     }
@@ -1554,8 +1537,7 @@ function TimetablesContent() {
     swrKey,
     templatePeriodID,
     tenantMutate,
-    toastError,
-    toastSuccess,
+    toast,
   ]);
 
   if (status === "loading") {
@@ -1779,7 +1761,7 @@ function TimetablesContent() {
         }}
         onRepeat={(instance) => {
           if (assignedPeriods.length === 0) {
-            toastWarning(
+            toast.warning(
               "Lege zuerst einen Planungszeitraum für diese Woche an.",
             );
             openPeriodCreate();

--- a/frontend/src/app/api/timetable/templates/[id]/end/route.ts
+++ b/frontend/src/app/api/timetable/templates/[id]/end/route.ts
@@ -1,0 +1,19 @@
+// app/api/timetable/templates/[id]/end/route.ts
+//
+// POST /api/timetable/templates/{id}/end
+//   Ends a recurring template at effective_date without creating a successor.
+import type { NextRequest } from "next/server";
+import { apiPost } from "~/lib/api-helpers.server";
+import { createPostHandler, isStringParam } from "~/lib/route-wrapper.server";
+
+export const POST = createPostHandler(
+  async (_request: NextRequest, body: unknown, token: string, params) => {
+    if (!isStringParam(params.id)) throw new Error("Invalid id parameter");
+    const response = await apiPost<{ data: unknown }>(
+      `/api/timetable/templates/${params.id}/end`,
+      token,
+      body ?? {},
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -616,7 +616,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Über `Weitere Optionen` `Personal` und `Kinder` zuordnen. Mit `Klasse/Gruppe komplett hinzufügen …` kommt eine ganze Klasse oder Gruppe auf einmal in die Auswahl.",
           "Speichern. Wiederholte Termine trägt Phoenix automatisch für das gesamte Schuljahr ein. Hinweise zu doppelt belegten Räumen, Personal oder Kindern können beim Ausfüllen erscheinen, verhindern das Speichern aber nicht.",
           "Beim Bearbeiten eines Termins aus einer Serie fragt die App, wofür die Änderung gilt: `Nur dieser Termin`, `Dieser und alle folgenden` oder `Alle Termine der Serie`.",
-          "Beim Löschen eines Serientermins wählen Sie zwischen `Nur dieser Termin` und `Dieser und alle folgenden`; frühere Termine bleiben erhalten.",
+          "Beim Löschen eines Serientermins wählen Sie zwischen `Nur dieser Termin` und `Dieser und alle folgenden`; frühere Termine bleiben erhalten. Einen Regeltermin löschen Sie über `Bearbeiten` -> `Löschen` und wählen dort das `Ab Datum`.",
           "Geplante Termine erscheinen zur Startzeit in der `Aktuellen Aufsicht` unter `Als Nächstes` und werden dort mit `Starten` begonnen.",
         ],
         callout: {

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -616,6 +616,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Über `Weitere Optionen` `Personal` und `Kinder` zuordnen. Mit `Klasse/Gruppe komplett hinzufügen …` kommt eine ganze Klasse oder Gruppe auf einmal in die Auswahl.",
           "Speichern. Wiederholte Termine trägt Phoenix automatisch für das gesamte Schuljahr ein. Hinweise zu doppelt belegten Räumen, Personal oder Kindern können beim Ausfüllen erscheinen, verhindern das Speichern aber nicht.",
           "Beim Bearbeiten eines Termins aus einer Serie fragt die App, wofür die Änderung gilt: `Nur dieser Termin`, `Dieser und alle folgenden` oder `Alle Termine der Serie`.",
+          "Beim Löschen eines Serientermins wählen Sie zwischen `Nur dieser Termin` und `Dieser und alle folgenden`; frühere Termine bleiben erhalten.",
           "Geplante Termine erscheinen zur Startzeit in der `Aktuellen Aufsicht` unter `Als Nächstes` und werden dort mit `Starten` begonnen.",
         ],
         callout: {

--- a/frontend/src/components/timetable/instance-detail-slide-over.test.tsx
+++ b/frontend/src/components/timetable/instance-detail-slide-over.test.tsx
@@ -274,7 +274,7 @@ describe("InstanceDetailSlideOver", () => {
 
     render(
       <InstanceDetailSlideOver
-        instance={instance({ activityGroupId: "7" })}
+        instance={instance({ activityGroupId: "7", isSpontaneous: false })}
         onClose={vi.fn()}
         onLifecycleAction={vi.fn()}
         onDeleteCancelled={onDeleteCancelled}
@@ -294,6 +294,39 @@ describe("InstanceDetailSlideOver", () => {
       ),
     );
     expect(onDeleteCancelled).not.toHaveBeenCalled();
+  });
+
+  it("uses single delete for spontaneous instances even when they have an activity group", async () => {
+    const onDeleteCancelled = vi.fn().mockResolvedValue(undefined);
+    const onDeleteFollowing = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <InstanceDetailSlideOver
+        instance={instance({ activityGroupId: "7", isSpontaneous: true })}
+        onClose={vi.fn()}
+        onLifecycleAction={vi.fn()}
+        onDeleteCancelled={onDeleteCancelled}
+        onDeleteFollowing={onDeleteFollowing}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Löschen/ }));
+    expect(
+      screen.queryByRole("dialog", { name: "Wiederholenden Termin löschen" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Termin löschen?")).toBeInTheDocument();
+
+    fireEvent.click(confirmDialogButton("Löschen"));
+    await waitFor(() =>
+      expect(onDeleteCancelled).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "42",
+          activityGroupId: "7",
+          isSpontaneous: true,
+        }),
+      ),
+    );
+    expect(onDeleteFollowing).not.toHaveBeenCalled();
   });
 
   it("renders completed, empty, and detailed attendance states", () => {

--- a/frontend/src/components/timetable/instance-detail-slide-over.test.tsx
+++ b/frontend/src/components/timetable/instance-detail-slide-over.test.tsx
@@ -268,6 +268,34 @@ describe("InstanceDetailSlideOver", () => {
     );
   });
 
+  it("asks for delete scope on recurring planned instances", async () => {
+    const onDeleteCancelled = vi.fn().mockResolvedValue(undefined);
+    const onDeleteFollowing = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <InstanceDetailSlideOver
+        instance={instance({ activityGroupId: "7" })}
+        onClose={vi.fn()}
+        onLifecycleAction={vi.fn()}
+        onDeleteCancelled={onDeleteCancelled}
+        onDeleteFollowing={onDeleteFollowing}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Löschen/ }));
+    expect(
+      screen.getByRole("dialog", { name: "Wiederholenden Termin löschen" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Dieser und alle folgenden"));
+    await waitFor(() =>
+      expect(onDeleteFollowing).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "42", activityGroupId: "7" }),
+      ),
+    );
+    expect(onDeleteCancelled).not.toHaveBeenCalled();
+  });
+
   it("renders completed, empty, and detailed attendance states", () => {
     const onClose = vi.fn();
     const { rerender } = render(

--- a/frontend/src/components/timetable/instance-detail-slide-over.tsx
+++ b/frontend/src/components/timetable/instance-detail-slide-over.tsx
@@ -29,6 +29,7 @@ import {
 
 import { Button } from "~/components/ui/button";
 import { useModal } from "~/components/dashboard/modal-context";
+import { ChoiceModal } from "~/components/ui/choice-modal";
 import { ConfirmationModal } from "~/components/ui/modal";
 import { LOCATION_COLORS } from "~/lib/location-helper";
 import {
@@ -93,6 +94,7 @@ interface InstanceDetailSlideOverProps {
   onClose: () => void;
   onLifecycleAction: (action: LifecycleAction) => Promise<void>;
   onDeleteCancelled?: (instance: EnrichedInstance) => Promise<void>;
+  onDeleteFollowing?: (instance: EnrichedInstance) => Promise<void>;
   onEdit?: (instance: EnrichedInstance) => void;
   onRepeat?: (instance: EnrichedInstance) => void;
   staffNames?: Map<string, string>;
@@ -199,6 +201,7 @@ export function InstanceDetailSlideOver({
   onClose,
   onLifecycleAction,
   onDeleteCancelled,
+  onDeleteFollowing,
   onEdit,
   onRepeat,
   staffNames = EMPTY_STAFF_NAMES,
@@ -213,6 +216,10 @@ export function InstanceDetailSlideOver({
   const [pendingConfirm, setPendingConfirm] =
     useState<PendingConfirmAction | null>(null);
   const [pendingDelete, setPendingDelete] = useState(false);
+  const [deleteScopeOpen, setDeleteScopeOpen] = useState(false);
+  const [pendingDeleteScope, setPendingDeleteScope] = useState<string | null>(
+    null,
+  );
   const [pendingStudentId, setPendingStudentId] = useState<string | null>(null);
   const students = useMemo(
     () =>
@@ -234,6 +241,8 @@ export function InstanceDetailSlideOver({
 
   useEffect(() => {
     setPendingConfirm(null);
+    setDeleteScopeOpen(false);
+    setPendingDeleteScope(null);
   }, [instance?.id]);
 
   const handleLifecycle = async (action: LifecycleAction) => {
@@ -255,6 +264,24 @@ export function InstanceDetailSlideOver({
     }
   };
 
+  const handleDeleteFollowing = async () => {
+    if (!instance || !onDeleteFollowing) return;
+    setPendingDelete(true);
+    try {
+      await onDeleteFollowing(instance);
+    } finally {
+      setPendingDelete(false);
+    }
+  };
+
+  const openDeleteFlow = () => {
+    if (instance?.activityGroupId && onDeleteFollowing) {
+      setDeleteScopeOpen(true);
+      return;
+    }
+    setPendingConfirm("delete");
+  };
+
   const handleConfirm = () => {
     const action = pendingConfirm;
     setPendingConfirm(null);
@@ -262,6 +289,20 @@ export function InstanceDetailSlideOver({
       void handleDeleteCancelled();
     } else if (action) {
       void handleLifecycle(action);
+    }
+  };
+
+  const handleDeleteScopeSelect = async (scope: string) => {
+    setPendingDeleteScope(scope);
+    try {
+      if (scope === "following") {
+        await handleDeleteFollowing();
+      } else {
+        await handleDeleteCancelled();
+      }
+      setDeleteScopeOpen(false);
+    } finally {
+      setPendingDeleteScope(null);
     }
   };
 
@@ -295,10 +336,14 @@ export function InstanceDetailSlideOver({
           // outside-click and closes the slide-over, unmounting the modal
           // before its buttons can fire. See issue #1358.
           onInteractOutside={(event) => {
-            if (isModalOpen || pendingConfirm !== null) event.preventDefault();
+            if (isModalOpen || pendingConfirm !== null || deleteScopeOpen) {
+              event.preventDefault();
+            }
           }}
           onEscapeKeyDown={(event) => {
-            if (isModalOpen || pendingConfirm !== null) event.preventDefault();
+            if (isModalOpen || pendingConfirm !== null || deleteScopeOpen) {
+              event.preventDefault();
+            }
           }}
         >
           <SlideOverHeader>
@@ -509,6 +554,22 @@ export function InstanceDetailSlideOver({
                   </span>
                 </Button>
               )}
+              {instance.status === "planned" && onDeleteCancelled && (
+                <Button
+                  variant="outline_danger"
+                  size="md"
+                  type="button"
+                  onClick={openDeleteFlow}
+                  isLoading={pendingDelete}
+                  loadingText="Lösche …"
+                  disabled={pendingAction !== null || pendingDelete}
+                >
+                  <span className="inline-flex items-center gap-2">
+                    <Trash2 className="h-4 w-4" />
+                    Löschen
+                  </span>
+                </Button>
+              )}
               {instance.status === "completed" && (
                 <span className="inline-flex items-center gap-2 text-xs text-gray-500">
                   <CheckCircle2 className="h-4 w-4" />
@@ -526,7 +587,7 @@ export function InstanceDetailSlideOver({
                       variant="outline_danger"
                       size="md"
                       type="button"
-                      onClick={() => setPendingConfirm("delete")}
+                      onClick={openDeleteFlow}
                       isLoading={pendingDelete}
                       loadingText="Lösche …"
                       disabled={pendingAction !== null || pendingDelete}
@@ -554,7 +615,11 @@ export function InstanceDetailSlideOver({
           isOpen
           onClose={() => setPendingConfirm(null)}
           onConfirm={handleConfirm}
-          title={CONFIRM_DIALOGS[pendingConfirm].title}
+          title={
+            pendingConfirm === "delete" && instance?.status === "planned"
+              ? "Termin löschen?"
+              : CONFIRM_DIALOGS[pendingConfirm].title
+          }
           confirmText={CONFIRM_DIALOGS[pendingConfirm].confirmText}
           cancelText="Abbrechen"
           confirmButtonClass={
@@ -564,9 +629,35 @@ export function InstanceDetailSlideOver({
           <p className="text-sm leading-relaxed text-gray-600">
             {pendingConfirm === "cancel" && instance?.status === "active"
               ? "Die laufende Betreuung wird gestoppt und der Termin als abgesagt markiert. Das kann nicht rückgängig gemacht werden."
-              : CONFIRM_DIALOGS[pendingConfirm].body}
+              : pendingConfirm === "delete" && instance?.status === "planned"
+                ? "Der geplante Termin wird dauerhaft entfernt."
+                : CONFIRM_DIALOGS[pendingConfirm].body}
           </p>
         </ConfirmationModal>
+      )}
+      {instance && (
+        <ChoiceModal
+          isOpen={deleteScopeOpen}
+          onClose={() => setDeleteScopeOpen(false)}
+          title="Wiederholenden Termin löschen"
+          description={`Der Termin am ${germanFullDate(instance.date)} gehört zu einem Regeltermin.`}
+          options={[
+            {
+              value: "single",
+              label: "Nur dieser Termin",
+              description:
+                "Löscht nur diesen Termin und verhindert, dass er erneut eingetragen wird.",
+            },
+            {
+              value: "following",
+              label: "Dieser und alle folgenden",
+              description:
+                "Beendet den Regeltermin ab diesem Datum; frühere Termine bleiben erhalten.",
+            },
+          ]}
+          onSelect={(value) => void handleDeleteScopeSelect(value)}
+          isBusy={pendingDeleteScope !== null}
+        />
       )}
     </SlideOver>
   );

--- a/frontend/src/components/timetable/instance-detail-slide-over.tsx
+++ b/frontend/src/components/timetable/instance-detail-slide-over.tsx
@@ -275,7 +275,11 @@ export function InstanceDetailSlideOver({
   };
 
   const openDeleteFlow = () => {
-    if (instance?.activityGroupId && onDeleteFollowing) {
+    if (
+      instance?.activityGroupId &&
+      !instance.isSpontaneous &&
+      onDeleteFollowing
+    ) {
       setDeleteScopeOpen(true);
       return;
     }

--- a/frontend/src/components/timetable/timetable-event-modal.test.tsx
+++ b/frontend/src/components/timetable/timetable-event-modal.test.tsx
@@ -4,6 +4,7 @@ import {
   fireEvent,
   render,
   screen,
+  within,
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -536,6 +537,57 @@ describe("TimetableEventModal", () => {
       seriesId: "8",
       linkedInstanceId: "42",
     });
+  });
+
+  it("deletes an existing series from an editable effective date", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-06T10:00:00"));
+    const onDeleteSeries = vi.fn().mockResolvedValue(undefined);
+    const { onClose } = renderModal({
+      initialSeries: template,
+      onDeleteSeries,
+    });
+
+    await screen.findByText("Regeltermin bearbeiten");
+    fireEvent.click(screen.getByRole("button", { name: "Löschen" }));
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Regeltermin löschen?",
+    });
+    const dateInput = within(dialog).getByLabelText(/Ab Datum/);
+    expect(dateInput).toHaveValue("2026-05-06");
+
+    fireEvent.change(dateInput, { target: { value: "" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Löschen" }));
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent(
+      "Bitte ein Datum auswählen.",
+    );
+    expect(onDeleteSeries).not.toHaveBeenCalled();
+
+    fireEvent.change(dateInput, { target: { value: "2026-05-05" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Löschen" }));
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent(
+      "Das Datum darf nicht in der Vergangenheit liegen.",
+    );
+    expect(onDeleteSeries).not.toHaveBeenCalled();
+
+    fireEvent.change(dateInput, { target: { value: "2026-05-07" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Löschen" }));
+
+    await waitFor(() =>
+      expect(onDeleteSeries).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "7" }),
+        "2026-05-07",
+      ),
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not show the series delete action while creating", async () => {
+    renderModal();
+
+    await screen.findByText("Haus A - Mensa");
+    expect(screen.queryByRole("button", { name: "Löschen" })).toBeNull();
   });
 
   it("surfaces save failures as validation errors", async () => {

--- a/frontend/src/components/timetable/timetable-event-modal.tsx
+++ b/frontend/src/components/timetable/timetable-event-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, Search } from "lucide-react";
+import { ChevronDown, Search, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useModal } from "~/components/dashboard/modal-context";
@@ -9,6 +9,7 @@ import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
 import { ChoiceModal } from "~/components/ui/choice-modal";
 import { Input } from "~/components/ui/input";
+import { ConfirmationModal } from "~/components/ui/modal";
 import { renderModalErrorAlert } from "~/components/ui/modal-utils";
 import {
   SlideOver,
@@ -123,6 +124,10 @@ interface TimetableEventModalProps {
   initialInstance?: EnrichedInstance | null;
   initialSeries?: TimetableTemplate | null;
   convertInstance?: EnrichedInstance | null;
+  onDeleteSeries?: (
+    template: TimetableTemplate,
+    effectiveDate: string,
+  ) => Promise<void>;
   defaultRepeat?: RepeatMode;
   /**
    * "quick" starts collapsed with only Titel, Datum/Zeiten, Raum and a
@@ -305,6 +310,7 @@ export function TimetableEventModal({
   initialInstance = null,
   initialSeries = null,
   convertInstance = null,
+  onDeleteSeries,
   defaultRepeat = "none",
   variant = "full",
   defaultStartTime,
@@ -334,6 +340,10 @@ export function TimetableEventModal({
   const [submitting, setSubmitting] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [deleteEffectiveDate, setDeleteEffectiveDate] = useState("");
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deletingSeries, setDeletingSeries] = useState(false);
   const [expanded, setExpanded] = useState(variant === "full");
   const [moreOpen, setMoreOpen] = useState(false);
   // Validated room id stashed while the Dreifach-Frage dialog (US-5) is open.
@@ -351,6 +361,7 @@ export function TimetableEventModal({
   const isConverting = convertInstance !== null;
   const isSeriesFlow = form.repeat !== "none" || isEditingSeries;
   const choiceDialogOpen = pendingSeriesEdit !== null;
+  const canDeleteSeries = isEditingSeries && initialSeries && onDeleteSeries;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -371,6 +382,10 @@ export function TimetableEventModal({
     );
     setValidationError(null);
     setFieldErrors({});
+    setDeleteConfirmOpen(false);
+    setDeleteEffectiveDate(todayISO());
+    setDeleteError(null);
+    setDeletingSeries(false);
     setExpanded(variant === "full");
     setMoreOpen(false);
     setPendingSeriesEdit(null);
@@ -1091,6 +1106,41 @@ export function TimetableEventModal({
     }
   };
 
+  const openSeriesDeleteConfirm = () => {
+    setDeleteEffectiveDate(todayISO());
+    setDeleteError(null);
+    setDeleteConfirmOpen(true);
+  };
+
+  const handleConfirmSeriesDelete = async () => {
+    if (!initialSeries || !onDeleteSeries || deletingSeries) return;
+    const minDate = todayISO();
+    if (!deleteEffectiveDate) {
+      setDeleteError("Bitte ein Datum auswählen.");
+      return;
+    }
+    if (deleteEffectiveDate < minDate) {
+      setDeleteError("Das Datum darf nicht in der Vergangenheit liegen.");
+      return;
+    }
+
+    setDeletingSeries(true);
+    setDeleteError(null);
+    try {
+      await onDeleteSeries(initialSeries, deleteEffectiveDate);
+      setDeleteConfirmOpen(false);
+      onClose();
+    } catch (err) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : "Regeltermin konnte nicht gelöscht werden";
+      setDeleteError(msg);
+    } finally {
+      setDeletingSeries(false);
+    }
+  };
+
   // Bulk-add entries for the Kinder field: every distinct class and group
   // present in the loaded students, each carrying its member ids.
   const studentBulkOptions = useMemo(() => {
@@ -1643,31 +1693,94 @@ export function TimetableEventModal({
           </div>
         )}
 
-        <SlideOverFooter className="flex-row items-center justify-end">
-          <Button
-            type="button"
-            variant="outline"
-            size="md"
-            onClick={onClose}
-            disabled={submitting}
-          >
-            Abbrechen
-          </Button>
-          <Button
-            type="submit"
-            form="timetable-event-form"
-            variant="primary"
-            size="md"
-            isLoading={submitting}
-            loadingText="Speichere …"
-            disabled={
-              submitting ||
-              (isEditingInstance && initialInstance?.status !== "planned")
-            }
-          >
-            Speichern
-          </Button>
+        <SlideOverFooter className="items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="order-2 sm:order-1">
+            {canDeleteSeries && (
+              <Button
+                type="button"
+                variant="outline_danger"
+                size="md"
+                onClick={openSeriesDeleteConfirm}
+                disabled={submitting || deletingSeries}
+                className="w-full sm:w-auto"
+              >
+                <span className="inline-flex items-center gap-2">
+                  <Trash2 className="h-4 w-4" aria-hidden />
+                  Löschen
+                </span>
+              </Button>
+            )}
+          </div>
+          <div className="order-1 flex items-center justify-end gap-3 sm:order-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="md"
+              onClick={onClose}
+              disabled={submitting || deletingSeries}
+            >
+              Abbrechen
+            </Button>
+            <Button
+              type="submit"
+              form="timetable-event-form"
+              variant="primary"
+              size="md"
+              isLoading={submitting}
+              loadingText="Speichere …"
+              disabled={
+                submitting ||
+                deletingSeries ||
+                (isEditingInstance && initialInstance?.status !== "planned")
+              }
+            >
+              Speichern
+            </Button>
+          </div>
         </SlideOverFooter>
+
+        {initialSeries && (
+          <ConfirmationModal
+            isOpen={deleteConfirmOpen}
+            onClose={() => {
+              if (!deletingSeries) setDeleteConfirmOpen(false);
+            }}
+            onConfirm={() => void handleConfirmSeriesDelete()}
+            title="Regeltermin löschen?"
+            confirmText="Löschen"
+            cancelText="Abbrechen"
+            isConfirmLoading={deletingSeries}
+            confirmButtonClass="bg-red-600 hover:bg-red-700"
+          >
+            <div className="flex flex-col gap-4">
+              <p className="text-sm leading-relaxed text-gray-600">
+                Der Regeltermin wird ab dem gewählten Datum gelöscht. Frühere
+                Termine bleiben erhalten.
+              </p>
+              <Field
+                label="Ab Datum"
+                htmlFor="series_delete_effective_date"
+                required
+                error={deleteError ?? undefined}
+              >
+                <Input
+                  id="series_delete_effective_date"
+                  type="date"
+                  value={deleteEffectiveDate}
+                  min={todayISO()}
+                  controlSize="compact"
+                  aria-invalid={deleteError ? true : undefined}
+                  disabled={deletingSeries}
+                  onChange={(event) => {
+                    setDeleteEffectiveDate(event.target.value);
+                    setDeleteError(null);
+                  }}
+                  required
+                />
+              </Field>
+            </div>
+          </ConfirmationModal>
+        )}
 
         {initialInstance && (
           <ChoiceModal

--- a/frontend/src/lib/timetable-api.test.ts
+++ b/frontend/src/lib/timetable-api.test.ts
@@ -266,7 +266,7 @@ describe("timetableService", () => {
     );
   });
 
-  it("loads a single template and splits a template from an effective date", async () => {
+  it("loads a single template, splits a template, and ends it from an effective date", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ data: backendTemplate }))
       .mockResolvedValueOnce(
@@ -277,6 +277,15 @@ describe("timetableService", () => {
             schedule_ids: [11, 12],
             deleted_instances: 4,
             instances_created: 6,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            template_id: 7,
+            effective_date: "2026-06-01",
+            deleted_instances: 4,
           },
         }),
       );
@@ -309,6 +318,15 @@ describe("timetableService", () => {
       deletedInstances: 4,
       instancesCreated: 6,
     });
+    await expect(
+      timetableService.endTemplate("7", {
+        effective_date: "2026-06-01",
+      }),
+    ).resolves.toEqual({
+      templateId: "7",
+      effectiveDate: "2026-06-01",
+      deletedInstances: 4,
+    });
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
@@ -321,6 +339,14 @@ describe("timetableService", () => {
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify(splitBody),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "/api/timetable/templates/7/end",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ effective_date: "2026-06-01" }),
       }),
     );
   });

--- a/frontend/src/lib/timetable-api.ts
+++ b/frontend/src/lib/timetable-api.ts
@@ -15,6 +15,7 @@ import type {
   BackendConflictCheckResult,
   BackendCreateTemplateResult,
   BackendAttendanceResponse,
+  BackendEndTemplateResult,
   BackendExceptionConflictsResponse,
   BackendEnrichedInstance,
   BackendGapsResponse,
@@ -34,6 +35,8 @@ import type {
   CreateInstanceBody,
   CreateTemplateBody,
   CreateTemplateResult,
+  EndTemplateBody,
+  EndTemplateResult,
   EnrichedInstance,
   ExceptionConflictsResponse,
   GapsResponse,
@@ -52,6 +55,7 @@ import type {
 import {
   mapConflictCheckResult,
   mapCreateTemplateResult,
+  mapEndTemplateResult,
   mapAttendance,
   mapExceptionConflicts,
   mapGaps,
@@ -244,6 +248,33 @@ class TimetableService {
       instances_created: raw.instances_created,
     });
     return mapSplitTemplateResult(raw);
+  }
+
+  /**
+   * POST /api/timetable/templates/{id}/end — "dieser und alle folgenden
+   * löschen". Ends the template at effective_date and removes still-planned
+   * future instances of that template.
+   */
+  async endTemplate(
+    templateId: string,
+    body: EndTemplateBody,
+  ): Promise<EndTemplateResult> {
+    const response = await fetch(`/api/timetable/templates/${templateId}/end`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify(body),
+    });
+    const raw = await unwrap<BackendEndTemplateResult>(response);
+    logger.info("template_ended", {
+      template_id: raw.template_id,
+      effective_date: raw.effective_date,
+      deleted_instances: raw.deleted_instances,
+    });
+    return mapEndTemplateResult(raw);
   }
 
   /**

--- a/frontend/src/lib/timetable-helpers.test.ts
+++ b/frontend/src/lib/timetable-helpers.test.ts
@@ -518,6 +518,7 @@ describe("backend mappers", () => {
                 end_time: "15:00",
                 week_pattern: 2,
                 calendar_period_id: 5,
+                valid_until: "2026-06-01",
               },
             ],
           },
@@ -529,7 +530,7 @@ describe("backend mappers", () => {
       studentIds: ["21"],
       staffIds: ["11"],
       primaryStaffId: "11",
-      schedules: [{ id: "9", calendarPeriodId: "5" }],
+      schedules: [{ id: "9", calendarPeriodId: "5", validUntil: "2026-06-01" }],
     });
   });
 

--- a/frontend/src/lib/timetable-helpers.ts
+++ b/frontend/src/lib/timetable-helpers.ts
@@ -612,6 +612,7 @@ export function mapTemplates(raw: BackendTemplatesResponse): TemplatesResponse {
           schedule.calendar_period_id !== null
             ? String(schedule.calendar_period_id)
             : undefined,
+        validUntil: schedule.valid_until,
       })),
     })),
   };

--- a/frontend/src/lib/timetable-helpers.ts
+++ b/frontend/src/lib/timetable-helpers.ts
@@ -14,6 +14,7 @@ import type {
   BackendConflictCheckResult,
   BackendCreateTemplateResult,
   BackendAttendanceResponse,
+  BackendEndTemplateResult,
   BackendExceptionConflictsResponse,
   BackendEnrichedInstance,
   BackendGapsResponse,
@@ -28,6 +29,7 @@ import type {
   AttendanceResponse,
   ConflictCheckResult,
   CreateTemplateResult,
+  EndTemplateResult,
   EnrichedInstance,
   ExceptionConflictsResponse,
   GapsResponse,
@@ -539,6 +541,16 @@ export function mapSplitTemplateResult(
     scheduleIds: (raw.schedule_ids ?? []).map(String),
     deletedInstances: raw.deleted_instances,
     instancesCreated: raw.instances_created,
+  };
+}
+
+export function mapEndTemplateResult(
+  raw: BackendEndTemplateResult,
+): EndTemplateResult {
+  return {
+    templateId: String(raw.template_id),
+    effectiveDate: raw.effective_date,
+    deletedInstances: raw.deleted_instances,
   };
 }
 

--- a/frontend/src/lib/timetable-types.ts
+++ b/frontend/src/lib/timetable-types.ts
@@ -556,6 +556,22 @@ export interface BackendSplitTemplateResult {
   instances_created: number;
 }
 
+export interface EndTemplateBody {
+  effective_date: string; // YYYY-MM-DD
+}
+
+export interface EndTemplateResult {
+  templateId: string;
+  effectiveDate: string;
+  deletedInstances: number;
+}
+
+export interface BackendEndTemplateResult {
+  template_id: number;
+  effective_date: string;
+  deleted_instances: number;
+}
+
 /**
  * Params for GET /api/timetable/conflict-check. Optional resource params
  * are omitted from the query string when empty — the backend treats a

--- a/frontend/src/lib/timetable-types.ts
+++ b/frontend/src/lib/timetable-types.ts
@@ -232,6 +232,7 @@ interface TemplateSchedule {
   endTime: string;
   weekPattern: number;
   calendarPeriodId?: string;
+  validUntil?: string;
 }
 
 export interface TimetableTemplate {
@@ -265,6 +266,7 @@ interface BackendTemplateSchedule {
   end_time: string;
   week_pattern: number;
   calendar_period_id?: number;
+  valid_until?: string;
 }
 
 export interface BackendTimetableTemplate {


### PR DESCRIPTION
## Summary
- add a template-end endpoint for deleting a recurring timetable appointment from a selected date onward
- make single planned/cancelled template-backed appointment deletes create a cancellation exception so materialization does not recreate them
- add delete flows for recurring appointments in both places admins expect them:
  - generated appointment detail: choose `Nur dieser Termin` or `Dieser und alle folgenden`
  - Regeltermin editor: click `Löschen`, choose an `Ab Datum`, then delete from that date onward
- update the Betreuungsplan help guide for the new Regeltermin delete flow

## Validation
- `pnpm --dir frontend exec vitest run src/components/timetable/timetable-event-modal.test.tsx 'src/app/[tenant]/(protected)/timetables/page.test.tsx'`
- `pnpm --dir frontend run check`
- `git diff --check`
- pre-commit hook: `git-secrets`, `frontend-lint`
- pre-push hook: `git-secrets`, `frontend-knip`, `frontend-check`

## Notes
- The Regeltermin editor delete action defaults `Ab Datum` to today and blocks empty or past dates before calling the backend.
- Earlier appointments and historical attendance remain untouched; the backend ends the template from the selected date and removes planned future generated appointments.
