### PR TITLE
fix: prevent release-triggered production deploys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build and Push Docker Images
-run-name: Build ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+run-name: Build ${{ github.sha }}
 
 on:
   # Production: Build and deploy on push to main
@@ -29,10 +29,6 @@ on:
           - staging
           - production
 
-  # Build on release for version tags
-  release:
-    types: [published]
-
 permissions: {}
 
 env:
@@ -53,31 +49,29 @@ jobs:
         run: |
           # Production: Push to main
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "should_deploy=true" >> $GITHUB_OUTPUT
-            echo "is_staging=false" >> $GITHUB_OUTPUT
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            echo "is_staging=false" >> "$GITHUB_OUTPUT"
             echo "✅ Push to main - will build and deploy to production"
 
           # Staging: Push to development
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/development" ]]; then
-            echo "should_deploy=true" >> $GITHUB_OUTPUT
-            echo "is_staging=true" >> $GITHUB_OUTPUT
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            echo "is_staging=true" >> "$GITHUB_OUTPUT"
             echo "✅ Push to development - will build and deploy to staging"
 
           # Manual dispatch
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "should_deploy=true" >> $GITHUB_OUTPUT
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
             if [[ "${{ github.event.inputs.environment }}" == "staging" ]]; then
-              echo "is_staging=true" >> $GITHUB_OUTPUT
+              echo "is_staging=true" >> "$GITHUB_OUTPUT"
             else
-              echo "is_staging=false" >> $GITHUB_OUTPUT
+              if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+                echo "❌ Production manual deploys must run from main (current ref: ${{ github.ref }})"
+                exit 1
+              fi
+              echo "is_staging=false" >> "$GITHUB_OUTPUT"
             fi
             echo "✅ Manual trigger for ${{ github.event.inputs.environment }}"
-
-          # Release: Deploy to production
-          elif [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "should_deploy=true" >> $GITHUB_OUTPUT
-            echo "is_staging=false" >> $GITHUB_OUTPUT
-            echo "✅ Release - will build and deploy to production"
           fi
 
   validate-migrations:
@@ -147,9 +141,6 @@ jobs:
             type=raw,value=staging,enable=${{ needs.check-environment.outputs.is_staging == 'true' }}
             # 'latest' tag for production (main branch)
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            # Semantic version from release tags
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push backend
         uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2.2.0
@@ -208,9 +199,6 @@ jobs:
             type=raw,value=staging,enable=${{ needs.check-environment.outputs.is_staging == 'true' }}
             # 'latest' tag for production (main branch)
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            # Semantic version from release tags
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
 
       - name: Determine API URL
         id: api_url


### PR DESCRIPTION
## Summary
- remove the GitHub Release trigger from the build/deploy workflow
- prevent manual production deploys unless the workflow is run from `main`
- remove release semver image tags that are no longer produced

## Why
Publishing a prerelease from a feature branch triggered the production deploy path because every `release` event was treated as `is_staging=false`. That let PR head SHAs deploy to production and made Slack resolve the deployed SHA back to the open PR.

## Verification
- `git diff --check`
- `actionlint -shellcheck '\ -ignore 'label "blacksmith-4vcpu-ubuntu-2404" is unknown' .github/workflows/build.yml`\n\nNote: raw `actionlint .github/workflows/build.yml` still reports pre-existing warnings for the Blacksmith custom runner label and unrelated ShellCheck quoting later in the workflow.