### PR TITLE
fix: repair production migration collision on 001015148

### DIFF
--- a/backend/database/migrations/001015149_parent_messaging.go
+++ b/backend/database/migrations/001015149_parent_messaging.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	parentMessagingVersion     = "1.15.148"
-	parentMessagingDescription = "Create parent-OGS messaging tables (threads, messages, reads), backfill from student_parent_notes, then drop that table"
+	parentMessagingVersion     = "1.15.149"
+	parentMessagingDescription = "Create parent-OGS messaging tables (threads, messages, reads), backfill from student_parent_notes, then drop that table. Fully idempotent: a production/staging environment that already ran this under the burned 001015148 bun name re-runs it as a safe no-op."
 )
 
 func init() {
@@ -39,7 +39,7 @@ func init() {
 }
 
 func parentMessagingUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.148: Creating parent messaging tables...")
+	fmt.Println("Migration 1.15.149: Creating parent messaging tables...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
@@ -165,16 +165,30 @@ func parentMessagingUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("error creating updated_at triggers: %w", err)
 	}
 
-	// RLS — tenant isolation, same shape as student_parent_notes.
+	// RLS — tenant isolation, same shape as student_parent_notes. CREATE POLICY has
+	// no IF NOT EXISTS in PostgreSQL, so guard it with a pg_policies existence check
+	// (mirrors 001015148_enrollment_change_requests): an environment that already ran
+	// parent messaging under the burned 001015148 bun name re-runs this without
+	// "policy already exists". ENABLE/FORCE RLS and GRANT are naturally idempotent.
 	for _, table := range []string{"parent_message_threads", "parent_messages", "parent_message_reads"} {
 		_, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			ALTER TABLE users.%[1]s ENABLE ROW LEVEL SECURITY;
 			ALTER TABLE users.%[1]s FORCE ROW LEVEL SECURITY;
 
-			CREATE POLICY tenant_isolation_users_%[1]s ON users.%[1]s
-				FOR ALL
-				USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
-				WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+			DO $$
+			BEGIN
+				IF NOT EXISTS (
+					SELECT 1 FROM pg_policies
+					WHERE schemaname = 'users'
+						AND tablename = '%[1]s'
+						AND policyname = 'tenant_isolation_users_%[1]s'
+				) THEN
+					CREATE POLICY tenant_isolation_users_%[1]s ON users.%[1]s
+						FOR ALL
+						USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+						WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+				END IF;
+			END $$;
 
 			GRANT SELECT, INSERT, UPDATE, DELETE ON users.%[1]s TO phoenix_tenant;
 		`, table))
@@ -191,28 +205,44 @@ func parentMessagingUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("error granting sequence usage: %w", err)
 	}
 
-	// Backfill from existing parent notes. The migration runs as the superuser
-	// (bypasses RLS), so it sees every tenant's notes. One thread per
-	// (tenant, student, guardian); each note becomes a guardian message with
-	// the guardian's name frozen from their profile at migration time.
-	//
-	// Two things the naive backfill got wrong:
-	//   1. last_sender_kind='guardian' on every thread flooded the staff inbox
-	//      with "awaiting OGS reply" for notes already handled in the old UI.
-	//      Seed it NULL (a neutral "nobody is waiting" state the CHECK permits)
-	//      instead.
-	//   2. No read cursor meant every historical note counted as unread, so a
-	//      school that used notes for months saw its inbox badge inflated by the
-	//      entire backlog. Seed a read cursor (below) so migrated history starts
-	//      read for everyone who already has access.
-	//
-	// Backfill EVERY note (no students_guardians filter): a guardian deliberately
-	// unlinked from the child since writing a note must not have that free-text
-	// silently destroyed when the source table is dropped below. The thread is
-	// still created, but the parent-portal read paths gate on a live link with
-	// parent_portal.access (guardianStillLinked), so an unlinked guardian never
-	// sees the resurrected thread — staff keep the history, nothing is lost.
-	_, err = tx.ExecContext(ctx, `
+	// Backfill only when the legacy source table still exists. The existence of
+	// users.student_parent_notes IS the "backfill not yet done" flag: on a fresh DB
+	// and on an environment that ran *enrollment* under the burned 001015148 bun
+	// name (notes left intact) it is present -> run the one-time backfill below; on
+	// the environment that already ran *parent messaging* under 001015148 the table
+	// was dropped at the end of that run, so it is absent here -> skip the whole
+	// backfill. This makes the re-run safe (no "relation does not exist") and
+	// non-duplicating (the threads/messages/cursors from the first run stay as-is).
+	var notesExist bool
+	if err = tx.QueryRowContext(ctx,
+		`SELECT to_regclass('users.student_parent_notes') IS NOT NULL`,
+	).Scan(&notesExist); err != nil {
+		return fmt.Errorf("error checking for users.student_parent_notes: %w", err)
+	}
+
+	if notesExist {
+		// Backfill from existing parent notes. The migration runs as the superuser
+		// (bypasses RLS), so it sees every tenant's notes. One thread per
+		// (tenant, student, guardian); each note becomes a guardian message with
+		// the guardian's name frozen from their profile at migration time.
+		//
+		// Two things the naive backfill got wrong:
+		//   1. last_sender_kind='guardian' on every thread flooded the staff inbox
+		//      with "awaiting OGS reply" for notes already handled in the old UI.
+		//      Seed it NULL (a neutral "nobody is waiting" state the CHECK permits)
+		//      instead.
+		//   2. No read cursor meant every historical note counted as unread, so a
+		//      school that used notes for months saw its inbox badge inflated by the
+		//      entire backlog. Seed a read cursor (below) so migrated history starts
+		//      read for everyone who already has access.
+		//
+		// Backfill EVERY note (no students_guardians filter): a guardian deliberately
+		// unlinked from the child since writing a note must not have that free-text
+		// silently destroyed when the source table is dropped below. The thread is
+		// still created, but the parent-portal read paths gate on a live link with
+		// parent_portal.access (guardianStillLinked), so an unlinked guardian never
+		// sees the resurrected thread — staff keep the history, nothing is lost.
+		_, err = tx.ExecContext(ctx, `
 		INSERT INTO users.parent_message_threads
 			(tenant_id, student_id, guardian_account_id, last_message_at, last_sender_kind, created_at, updated_at)
 		SELECT n.tenant_id, n.student_id, n.guardian_account_id,
@@ -234,18 +264,18 @@ func parentMessagingUp(ctx context.Context, db *bun.DB) error {
 			ON gp.account_id = n.guardian_account_id
 			AND gp.tenant_id = n.tenant_id;
 	`)
-	if err != nil {
-		return fmt.Errorf("error backfilling parent messages from notes: %w", err)
-	}
+		if err != nil {
+			return fmt.Errorf("error backfilling parent messages from notes: %w", err)
+		}
 
-	// Denormalize the inbox preview (last_message_body) and the composite
-	// tie-breaker (last_message_id) onto each backfilled thread so the staff
-	// inbox projection reads them off the thread row instead of a correlated
-	// subquery. Pick the newest message per thread (created_at, then id as a
-	// deterministic tiebreaker), mirroring the projection's ORDER BY created_at
-	// DESC, id DESC — and seed last_message_id from that SAME row so the
-	// TouchLastMessage monotonic guard has the right (created_at, id) baseline.
-	_, err = tx.ExecContext(ctx, `
+		// Denormalize the inbox preview (last_message_body) and the composite
+		// tie-breaker (last_message_id) onto each backfilled thread so the staff
+		// inbox projection reads them off the thread row instead of a correlated
+		// subquery. Pick the newest message per thread (created_at, then id as a
+		// deterministic tiebreaker), mirroring the projection's ORDER BY created_at
+		// DESC, id DESC — and seed last_message_id from that SAME row so the
+		// TouchLastMessage monotonic guard has the right (created_at, id) baseline.
+		_, err = tx.ExecContext(ctx, `
 		UPDATE users.parent_message_threads t
 		SET last_message_body = lm.body,
 		    last_message_id = lm.id
@@ -256,34 +286,34 @@ func parentMessagingUp(ctx context.Context, db *bun.DB) error {
 		) lm
 		WHERE lm.thread_id = t.id;
 	`)
-	if err != nil {
-		return fmt.Errorf("error backfilling thread last_message_body: %w", err)
-	}
+		if err != nil {
+			return fmt.Errorf("error backfilling thread last_message_body: %w", err)
+		}
 
-	// Seed a read cursor at each backfilled thread's newest message for every
-	// account currently active in the tenant. Migrated history therefore starts
-	// READ for all existing staff (no backlog badge) and for the guardian
-	// themselves; only messages sent AFTER the migration count as unread. New
-	// accounts created later have no cursor and will see migrated history as
-	// unread on first open — acceptable, since they have not reviewed it yet.
-	//
-	// Accepted tradeoff: the parent portal's "OGS hat gelesen" indicator derives
-	// from the newest read cursor of a STAFF account (LatestReadCursorByOther gates
-	// positively on users.staff membership at the thread's tenant), so seeding
-	// staff cursors here makes every migrated note render as read by the OGS. That
-	// is truthful — staff saw these notes in the old notes UI before migration.
-	// Seeding guardian / other-parent cursors too is harmless to that indicator
-	// (they are not staff, so they are never counted); they only serve the
-	// backlog-badge suppression. The two indicators share this single cursor
-	// table, so suppressing the staff backlog badge (above) and hiding the parent
-	// indicator cannot both be satisfied. The badge suppression is the more
-	// important UX, so it wins.
-	// Seed last_read_message_id alongside last_read_at at the thread's newest
-	// message (by created_at DESC, id DESC — the same ordering the inbox preview
-	// backfill above uses), so the seeded cursor is the exact composite the unread
-	// predicates compare against. Threads always have a backfilled message here,
-	// but COALESCE keeps the seed safe (0) if somehow none exists.
-	_, err = tx.ExecContext(ctx, `
+		// Seed a read cursor at each backfilled thread's newest message for every
+		// account currently active in the tenant. Migrated history therefore starts
+		// READ for all existing staff (no backlog badge) and for the guardian
+		// themselves; only messages sent AFTER the migration count as unread. New
+		// accounts created later have no cursor and will see migrated history as
+		// unread on first open — acceptable, since they have not reviewed it yet.
+		//
+		// Accepted tradeoff: the parent portal's "OGS hat gelesen" indicator derives
+		// from the newest read cursor of a STAFF account (LatestReadCursorByOther gates
+		// positively on users.staff membership at the thread's tenant), so seeding
+		// staff cursors here makes every migrated note render as read by the OGS. That
+		// is truthful — staff saw these notes in the old notes UI before migration.
+		// Seeding guardian / other-parent cursors too is harmless to that indicator
+		// (they are not staff, so they are never counted); they only serve the
+		// backlog-badge suppression. The two indicators share this single cursor
+		// table, so suppressing the staff backlog badge (above) and hiding the parent
+		// indicator cannot both be satisfied. The badge suppression is the more
+		// important UX, so it wins.
+		// Seed last_read_message_id alongside last_read_at at the thread's newest
+		// message (by created_at DESC, id DESC — the same ordering the inbox preview
+		// backfill above uses), so the seeded cursor is the exact composite the unread
+		// predicates compare against. Threads always have a backfilled message here,
+		// but COALESCE keeps the seed safe (0) if somehow none exists.
+		_, err = tx.ExecContext(ctx, `
 		INSERT INTO users.parent_message_reads (tenant_id, thread_id, account_id, last_read_at, last_read_message_id)
 		SELECT t.tenant_id, t.id, atn.account_id,
 		       COALESCE(t.last_message_at, t.created_at),
@@ -301,9 +331,10 @@ func parentMessagingUp(ctx context.Context, db *bun.DB) error {
 		) lm ON true
 		ON CONFLICT (thread_id, account_id) DO NOTHING;
 	`)
-	if err != nil {
-		return fmt.Errorf("error seeding parent message read cursors: %w", err)
-	}
+		if err != nil {
+			return fmt.Errorf("error seeding parent message read cursors: %w", err)
+		}
+	} // end if notesExist
 
 	// Drop the old one-way notes table now that ALL of its content lives in
 	// parent_messages — the backfill above migrated every note (including those
@@ -321,7 +352,7 @@ func parentMessagingUp(ctx context.Context, db *bun.DB) error {
 }
 
 func parentMessagingDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.148: Dropping parent messaging tables...")
+	fmt.Println("Rolling back migration 1.15.149: Dropping parent messaging tables...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
@@ -387,12 +418,13 @@ func parentMessagingDown(ctx context.Context, db *bun.DB) error {
 	// is non-blank.
 	//
 	// Filter ONLY on sender_kind = 'guardian'. The `kind` column does not exist at
-	// this migration's own schema level — it is added by 1.15.149, whose down
-	// migration (which DependsOn 1.15.148, so it runs first on a reverse-order
-	// rollback) has already DROP COLUMN'd it by the time this runs. Referencing
-	// m.kind here would fail with "column m.kind does not exist" and abort the whole
-	// rollback, restoring zero notes. At the 1.15.148 schema every guardian row is a
-	// plain message; the few guardian-authored request rows (added by 1.15.149) carry
+	// this migration's own schema level — it is added by the later #1672 requests
+	// migration (expected 1.15.151), whose down migration (which DependsOn 1.15.149,
+	// so it runs first on a reverse-order rollback) has already DROP COLUMN'd it by
+	// the time this runs. Referencing m.kind here would fail with "column m.kind does
+	// not exist" and abort the whole rollback, restoring zero notes. At the 1.15.149
+	// schema every guardian row is a plain message; the few guardian-authored request
+	// rows (added by 1.15.151) carry
 	// human-readable German bodies ("Anfrage: …"), so restoring them as notes is
 	// harmless and there is no surviving column to distinguish them anyway.
 	_, err = tx.ExecContext(ctx, `

--- a/backend/database/migrations/001015150_repair_enrollment_change_requests.go
+++ b/backend/database/migrations/001015150_repair_enrollment_change_requests.go
@@ -1,0 +1,143 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	repairEnrollmentChangeRequestsVersion     = "1.15.150"
+	repairEnrollmentChangeRequestsDescription = "Idempotently (re)create the enrollment change-request tables. Repairs environments where the original 001015148_enrollment_change_requests never ran because the bun migration name 001015148 was already burned by an out-of-band parent-messaging deploy."
+)
+
+// Why this migration exists
+//
+// bun tracks applied migrations by the numeric filename prefix (extractMigrationName
+// in uptrace/bun's migrate package returns the leading digits as the migration name).
+// Two migrations were authored with the prefix 001015148:
+// 001015148_parent_messaging and 001015148_enrollment_change_requests. An out-of-band
+// deploy ran parent messaging first and marked bun name "001015148" applied; bun then
+// permanently skips the enrollment migration in that environment, so
+// enrollment.change_requests / enrollment.change_request_messages were never created
+// there.
+//
+// Parent messaging is renumbered to 001015149 (and made re-run-safe) so it stops
+// colliding. The enrollment migration keeps 001015148 — on a fresh DB it still creates
+// the tables. This migration carries a brand-new bun name (001015150) that no
+// environment has applied, so it runs everywhere and idempotently brings the
+// enrollment change-request schema up: present-and-correct on fresh DBs (no-op),
+// created on the damaged environment. The DDL mirrors 001015148_enrollment_change_requests
+// exactly and is safe on both.
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     repairEnrollmentChangeRequestsVersion,
+		Description: repairEnrollmentChangeRequestsDescription,
+		DependsOn: []string{
+			enrollmentChangeRequestsVersion, // 1.15.148 — the original definition this repairs
+			parentMessagingVersion,          // 1.15.149 — order after the renumbered messaging migration
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Migration 1.15.150: Repairing enrollment.change_requests tables (idempotent)...")
+			if _, err := db.NewRaw(`
+				CREATE TABLE IF NOT EXISTS enrollment.change_requests (
+					id BIGSERIAL PRIMARY KEY,
+					tenant_id BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+					request_id BIGINT NOT NULL REFERENCES enrollment.requests(id) ON DELETE CASCADE,
+					request_child_id BIGINT REFERENCES enrollment.request_children(id) ON DELETE SET NULL,
+					status TEXT NOT NULL DEFAULT 'pending_review'
+						CHECK (status IN ('pending_review', 'needs_parent_response', 'approved', 'rejected', 'cancelled')),
+					parent_note TEXT,
+					admin_decision_note TEXT,
+					base_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+					proposed_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+					diff_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+					created_by_account_id BIGINT REFERENCES auth.accounts(id) ON DELETE SET NULL,
+					reviewed_by_account_id BIGINT REFERENCES auth.accounts(id) ON DELETE SET NULL,
+					reviewed_at TIMESTAMPTZ,
+					created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+				);
+
+				CREATE INDEX IF NOT EXISTS idx_enrollment_change_requests_request
+					ON enrollment.change_requests (tenant_id, request_id, created_at DESC);
+				CREATE INDEX IF NOT EXISTS idx_enrollment_change_requests_status
+					ON enrollment.change_requests (tenant_id, status, created_at DESC);
+				CREATE INDEX IF NOT EXISTS idx_enrollment_change_requests_child
+					ON enrollment.change_requests (tenant_id, request_child_id, created_at DESC)
+					WHERE request_child_id IS NOT NULL;
+
+				CREATE TABLE IF NOT EXISTS enrollment.change_request_messages (
+					id BIGSERIAL PRIMARY KEY,
+					tenant_id BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+					change_request_id BIGINT NOT NULL REFERENCES enrollment.change_requests(id) ON DELETE CASCADE,
+					author_type TEXT NOT NULL CHECK (author_type IN ('parent', 'staff', 'system')),
+					author_account_id BIGINT REFERENCES auth.accounts(id) ON DELETE SET NULL,
+					body TEXT NOT NULL,
+					internal_only BOOLEAN NOT NULL DEFAULT FALSE,
+					created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+				);
+
+				CREATE INDEX IF NOT EXISTS idx_enrollment_change_request_messages_request
+					ON enrollment.change_request_messages (tenant_id, change_request_id, created_at ASC);
+
+				ALTER TABLE enrollment.change_requests ENABLE ROW LEVEL SECURITY;
+				ALTER TABLE enrollment.change_requests FORCE ROW LEVEL SECURITY;
+				ALTER TABLE enrollment.change_request_messages ENABLE ROW LEVEL SECURITY;
+				ALTER TABLE enrollment.change_request_messages FORCE ROW LEVEL SECURITY;
+
+				DO $$
+				BEGIN
+					IF NOT EXISTS (
+						SELECT 1 FROM pg_policies
+						WHERE schemaname = 'enrollment'
+							AND tablename = 'change_requests'
+							AND policyname = 'tenant_isolation_enrollment_change_requests'
+					) THEN
+						CREATE POLICY tenant_isolation_enrollment_change_requests
+							ON enrollment.change_requests
+							FOR ALL
+							USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+							WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+					END IF;
+
+					IF NOT EXISTS (
+						SELECT 1 FROM pg_policies
+						WHERE schemaname = 'enrollment'
+							AND tablename = 'change_request_messages'
+							AND policyname = 'tenant_isolation_enrollment_change_request_messages'
+					) THEN
+						CREATE POLICY tenant_isolation_enrollment_change_request_messages
+							ON enrollment.change_request_messages
+							FOR ALL
+							USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+							WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+					END IF;
+				END $$;
+
+				GRANT SELECT, INSERT, UPDATE ON enrollment.change_requests TO phoenix_tenant;
+				GRANT SELECT, INSERT ON enrollment.change_request_messages TO phoenix_tenant;
+				GRANT USAGE ON SEQUENCE enrollment.change_requests_id_seq TO phoenix_tenant;
+				GRANT USAGE ON SEQUENCE enrollment.change_request_messages_id_seq TO phoenix_tenant;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed repairing enrollment change-request tables: %w", err)
+			}
+			return nil
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			// Intentional no-op. This is a forward repair, not a schema owner: the
+			// enrollment change-request tables are conceptually owned by
+			// 001015148_enrollment_change_requests, whose own down migration drops
+			// them. Dropping them here too would double-drop on a full reverse
+			// migration and would destroy tables this migration may only have
+			// found (not created) on a fresh DB.
+			fmt.Println("Rolling back migration 1.15.150: no-op (enrollment change-request tables are owned by 1.15.148)")
+			return nil
+		},
+	)
+}


### PR DESCRIPTION
## Problem

An out-of-band prerelease deploy ran **parent messaging** under bun migration name `001015148` in production. The real release later reused `001015148` for the **enrollment change-request** tables. Bun identifies Go migrations by their numeric filename prefix and skips any name already marked applied, so production ended up in a damaged state:

- `bun_migrations` has `001015148` marked APPLIED
- `users.parent_message_threads` / `parent_messages` / `parent_message_reads` exist (5 threads, 7 messages in prod)
- `users.student_parent_notes` was dropped by that run
- `enrollment.change_requests` / `enrollment.change_request_messages` were **never created** (bun skipped the enrollment migration on the burned `001015148` name)

We must fix forward, not delete rows from `bun_migrations`.

## Changes

1. **Renumber parent messaging** `1.15.148` → `1.15.149` / `001015149_parent_messaging.go` so it no longer collides with enrollment change requests on `001015148`. No file now shares a semantic version or numeric filename prefix.
2. **Make parent messaging idempotent / production-aware**: `CREATE TABLE IF NOT EXISTS`, triggers via `DROP ... IF EXISTS` + `CREATE`, RLS policies behind `pg_policies` existence checks, naturally idempotent grants. The one-time backfill is gated on `users.student_parent_notes` still existing, so an environment that already ran parent messaging (notes dropped) re-runs as a **safe no-op and cannot duplicate messages**. It does not assume the notes table still exists.
3. **Add `001015150_repair_enrollment_change_requests.go`** (`1.15.150`): a brand-new bun name no environment has applied. Idempotently (re)creates the enrollment change-request tables, indexes, RLS policies, grants and sequence-usage grants (`IF NOT EXISTS` + policy existence checks). No-op on fresh DBs, repairs production's damaged DB. DDL mirrors the original `001015148_enrollment_change_requests` exactly.

Parent messaging is intentionally shipping in this release (option "yes"): app code stays, migration made safe. The `001015149` down-migration restores `student_parent_notes` and backfills guardian free-text before dropping the messaging tables, so a rollback is not data-loss.

## Validation

- `go run . migrate validate` → **All migrations validated successfully!**
- `go test ./database/migrations/ -run TestNoDuplicateMigrationVersions` → **PASS** (no semantic-version or bun-name collision; file count == registry count)
- **End-to-end simulation against a reconstructed damaged DB** (`001015148` applied, messaging tables present with 7 messages, `student_parent_notes` missing, enrollment tables missing):
  - `148` skipped (the bug), `149` ran clean despite existing tables + missing notes, `150` created the enrollment tables
  - `to_regclass('enrollment.change_requests')` / `change_request_messages` → not null
  - `parent_messages` count **7 → 7** (no duplication)
  - `149` + `150` marked applied under their new names
  - RLS policies + `phoenix_tenant` CRUD grants present (grant-identical to a fresh migrate via the `enrollment` schema default ACL)
  - re-run reports **no pending migrations** (stable)

## Residual risk to check before release

The simulation assumes prod's messaging tables have the same column structure as the current `001015149` DDL. If the prerelease created them from an older schema, `CREATE TABLE IF NOT EXISTS` would not reconcile the difference. Cheap to confirm: `\d users.parent_messages` on staging/prod before the release.

Refs #1672.