### PR TITLE
Harden production deploy gates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,10 @@
 
 # Global owner for all files
 * @yungweng
+
+# Deployment and production-state controls require board visibility.
+/.github/workflows/ @yungweng @moto-nrw/moto-vorstand
+/scripts/deploy-remote.sh @yungweng @moto-nrw/moto-vorstand
+/scripts/rollback-remote.sh @yungweng @moto-nrw/moto-vorstand
+/environments/ @yungweng @moto-nrw/moto-vorstand
+/backend/database/migrations/ @yungweng @moto-nrw/moto-vorstand

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -432,6 +432,8 @@ jobs:
       group: deploy-production
       cancel-in-progress: false
     runs-on: ubuntu-latest
+    environment:
+      name: production
     permissions:
       contents: read
       pull-requests: read
@@ -440,6 +442,20 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.ref }}
+
+      - name: Guard production source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref }}
+        run: |
+          if [[ "$REF_NAME" != "refs/heads/main" ]]; then
+            echo "Production deploys must run from refs/heads/main, got $REF_NAME"
+            exit 1
+          fi
+          if [[ "$EVENT_NAME" != "push" && "$EVENT_NAME" != "workflow_dispatch" ]]; then
+            echo "Production deploys only allow push or workflow_dispatch, got $EVENT_NAME"
+            exit 1
+          fi
 
       - name: Install SOPS
         run: |

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -31,6 +31,8 @@ env:
 jobs:
   rollback:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
     permissions:
       contents: read
       packages: read
@@ -42,10 +44,15 @@ jobs:
         id: env
         env:
           ENVIRONMENT: ${{ inputs.environment }}
+          REF_NAME: ${{ github.ref }}
         run: |
+          if [ "$ENVIRONMENT" = "production" ] && [ "$REF_NAME" != "refs/heads/main" ]; then
+            echo "Production rollbacks must run from refs/heads/main, got $REF_NAME"
+            exit 1
+          fi
           case "$ENVIRONMENT" in
-            staging)    echo "dir=staging" >> $GITHUB_OUTPUT ;;
-            production) echo "dir=production" >> $GITHUB_OUTPUT ;;
+            staging)    echo "dir=staging" >> "$GITHUB_OUTPUT" ;;
+            production) echo "dir=production" >> "$GITHUB_OUTPUT" ;;
           esac
 
       - name: Setup SSH


### PR DESCRIPTION
## Summary
- Require the `production` GitHub Environment for production deploys.
- Refuse production deploys unless the workflow is running from `refs/heads/main` on `push` or `workflow_dispatch`.
- Require the selected GitHub Environment for manual rollbacks, and refuse production rollback runs from non-main refs.
- Add CODEOWNERS entries for workflows, deploy scripts, environments, and migrations so release-control changes request board visibility.

## Pareto Setup Required
Before relying on this, configure GitHub Settings → Environments → `production`:
- Required reviewers: `@moto-nrw/moto-vorstand` or the board users
- Prevent self-review: enabled
- Deployment branches/tags: selected branches only → `main`

That is the high-impact piece. Without the protected environment settings, the YAML environment name is only tracking metadata.

## Validation
- `yq '.' .github/workflows/build.yml`\n- `yq '.' .github/workflows/rollback.yml`\n- `git diff --check`\n- `actionlint -ignore 'label "blacksmith-4vcpu-ubuntu-2404" is unknown' -ignore 'SC2086' .github/workflows/build.yml .github/workflows/rollback.yml`