### PR TITLE
Support late enrollment exceptions

### DIFF
--- a/backend/api/enrollment/admin_late_invite_handlers.go
+++ b/backend/api/enrollment/admin_late_invite_handlers.go
@@ -1,0 +1,341 @@
+package enrollment
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
+	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+type AdminCreateLateInviteRequest struct {
+	GuardianEmail     string     `json:"guardian_email"`
+	GuardianFirstName string     `json:"guardian_first_name,omitempty"`
+	GuardianLastName  string     `json:"guardian_last_name,omitempty"`
+	Reason            string     `json:"reason,omitempty"`
+	ExpiresAt         *time.Time `json:"expires_at,omitempty"`
+}
+
+func (req *AdminCreateLateInviteRequest) Bind(_ *http.Request) error { return nil }
+
+type AdminCreateLateInviteResponse struct {
+	ID                string    `json:"id"`
+	PhaseID           string    `json:"phase_id"`
+	GuardianEmail     string    `json:"guardian_email"`
+	GuardianFirstName *string   `json:"guardian_first_name,omitempty"`
+	GuardianLastName  *string   `json:"guardian_last_name,omitempty"`
+	ExpiresAt         time.Time `json:"expires_at"`
+	CreatedBy         string    `json:"created_by"`
+	Reason            *string   `json:"reason,omitempty"`
+	Token             string    `json:"token"`
+}
+
+func (rs *Resource) createLateInvite(w http.ResponseWriter, r *http.Request) {
+	if rs.RequestService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("enrollment request service not configured")))
+		return
+	}
+	phaseID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || phaseID <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid phase id")))
+		return
+	}
+	body := &AdminCreateLateInviteRequest{}
+	if err := render.Bind(r, body); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	claims := jwt.ClaimsFromCtx(r.Context())
+	createdBy := int64(claims.ID)
+	if createdBy <= 0 {
+		common.RenderError(w, r, common.ErrorUnauthorized(errors.New("no account ID in context")))
+		return
+	}
+
+	var result *enrollmentService.CreateLateInviteResult
+	err = rs.runInTenantTx(r, func(ctx context.Context) error {
+		out, createErr := rs.RequestService.CreateLateInvite(ctx, enrollmentService.CreateLateInviteInput{
+			PhaseID:           phaseID,
+			GuardianEmail:     body.GuardianEmail,
+			GuardianFirstName: body.GuardianFirstName,
+			GuardianLastName:  body.GuardianLastName,
+			Reason:            body.Reason,
+			ExpiresAt:         body.ExpiresAt,
+			CreatedBy:         createdBy,
+		})
+		if createErr != nil {
+			return createErr
+		}
+		result = out
+		return nil
+	})
+	if err != nil {
+		mapLateInviteAdminError(w, r, err)
+		return
+	}
+
+	invite := result.Invite
+	common.Respond(w, r, http.StatusCreated, AdminCreateLateInviteResponse{
+		ID:                strconv.FormatInt(invite.ID, 10),
+		PhaseID:           strconv.FormatInt(invite.PhaseID, 10),
+		GuardianEmail:     invite.GuardianEmail,
+		GuardianFirstName: invite.GuardianFirstName,
+		GuardianLastName:  invite.GuardianLastName,
+		ExpiresAt:         invite.ExpiresAt,
+		CreatedBy:         strconv.FormatInt(invite.CreatedBy, 10),
+		Reason:            invite.Reason,
+		Token:             result.Token,
+	}, "Late invite created")
+}
+
+type AdminManualApprovedEnrollmentRequest struct {
+	SubmitEnrollmentRequest
+	ExternalConsentConfirmed bool   `json:"external_consent_confirmed"`
+	Reason                   string `json:"reason"`
+	SendNotification         bool   `json:"send_notification"`
+}
+
+func (req *AdminManualApprovedEnrollmentRequest) Bind(r *http.Request) error {
+	return req.SubmitEnrollmentRequest.Bind(r)
+}
+
+type AdminManualApprovedEnrollmentResponse struct {
+	RequestID string `json:"request_id"`
+	ChildID   string `json:"child_id"`
+	StudentID string `json:"student_id,omitempty"`
+	Status    string `json:"status"`
+	StatusURL string `json:"status_url"`
+}
+
+func (rs *Resource) createManualApprovedEnrollment(w http.ResponseWriter, r *http.Request) {
+	if rs.RequestService == nil || rs.DecisionService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("manual enrollment services not configured")))
+		return
+	}
+	phaseID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || phaseID <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid phase id")))
+		return
+	}
+	body := &AdminManualApprovedEnrollmentRequest{}
+	if err := render.Bind(r, body); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	reason := strings.TrimSpace(body.Reason)
+	if reason == "" {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("reason is required")))
+		return
+	}
+	if !body.ExternalConsentConfirmed {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("external consent confirmation is required")))
+		return
+	}
+	if len(body.Children) != 1 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("manual approved enrollment requires exactly one child")))
+		return
+	}
+
+	claims := jwt.ClaimsFromCtx(r.Context())
+	actorID := int64(claims.ID)
+	if actorID <= 0 {
+		common.RenderError(w, r, common.ErrorUnauthorized(errors.New("no account ID in context")))
+		return
+	}
+	tenantID := tenant.FromContext(r.Context())
+	if tenantID <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("tenant context is required")))
+		return
+	}
+
+	body.PhaseID = phaseID
+	serviceReq, parseErr := buildServiceRequest(&body.SubmitEnrollmentRequest, tenantID, remoteIPFromRequest(r))
+	if parseErr != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(parseErr))
+		return
+	}
+	serviceReq.SkipRateLimit = true
+	serviceReq.AllowClosedPhase = true
+	serviceReq.SuppressSubmissionEmails = true
+	serviceReq.ExternalConsentConfirmed = true
+	serviceReq.SubmissionSource = enrollmentModels.RequestSourceAdminManual
+	serviceReq.SourceMetadata = map[string]any{
+		"external_consent_confirmed": true,
+		"admin_reason":               reason,
+		"send_notification":          body.SendNotification,
+		"actor_account_id":           actorID,
+	}
+
+	var (
+		submitResult *enrollmentService.SubmitResult
+		outcome      *enrollmentService.DecideOutcome
+	)
+	err = rs.runInTenantTx(r, func(ctx context.Context) error {
+		submitted, submitErr := rs.RequestService.Submit(ctx, serviceReq)
+		if submitErr != nil {
+			return submitErr
+		}
+		if len(submitted.Children) != 1 {
+			return fmtInvalidManualEnrollmentChildCount(len(submitted.Children))
+		}
+		decided, decideErr := rs.DecisionService.Decide(ctx, enrollmentService.DecideInput{
+			RequestID:                  submitted.Request.ID,
+			ChildID:                    submitted.Children[0].ID,
+			Status:                     enrollmentService.DecisionApproved,
+			Reason:                     reason,
+			ReviewedBy:                 actorID,
+			SuppressParentEmail:        !body.SendNotification,
+			SuppressGuardianInvitation: !body.SendNotification,
+		})
+		if decideErr != nil {
+			return decideErr
+		}
+		submitResult = submitted
+		outcome = decided
+		return nil
+	})
+	if err != nil {
+		mapManualEnrollmentError(w, r, err)
+		return
+	}
+
+	if outcome != nil && outcome.PendingInvite != nil && rs.GuardianInvitationService != nil {
+		go rs.dispatchPostDecisionInvite(r.Context(), outcome.PendingInvite)
+	}
+
+	child := outcome.Child
+	resp := AdminManualApprovedEnrollmentResponse{
+		RequestID: strconv.FormatInt(submitResult.Request.ID, 10),
+		ChildID:   strconv.FormatInt(child.ID, 10),
+		Status:    child.Status,
+		StatusURL: submitResult.StatusURL,
+	}
+	if child.CreatedStudentID != nil {
+		resp.StudentID = strconv.FormatInt(*child.CreatedStudentID, 10)
+	}
+	common.Respond(w, r, http.StatusCreated, resp, "Manual enrollment created and approved")
+}
+
+func (rs *Resource) getManualEnrollmentBootstrap(w http.ResponseWriter, r *http.Request) {
+	if rs.RequestService == nil || rs.FormSchemaService == nil || rs.CareOfferingService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("manual enrollment bootstrap services not configured")))
+		return
+	}
+	phaseID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || phaseID <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid phase id")))
+		return
+	}
+
+	var (
+		phase     *enrollmentModels.Phase
+		schema    *enrollmentModels.FormSchema
+		offerings []*enrollmentModels.CareOffering
+		texts     enrollmentService.LegalTexts
+	)
+	err = rs.runInTenantTx(r, func(ctx context.Context) error {
+		loadedPhase, phaseErr := rs.RequestService.LoadManualEnrollmentPhase(ctx, phaseID)
+		if phaseErr != nil {
+			return phaseErr
+		}
+		phase = loadedPhase
+		if phase.FormSchemaID != nil {
+			loadedSchema, schemaErr := rs.FormSchemaService.GetByID(ctx, *phase.FormSchemaID)
+			if schemaErr != nil {
+				if !errors.Is(schemaErr, enrollmentService.ErrFormSchemaNotFound) {
+					return schemaErr
+				}
+			} else {
+				schema = loadedSchema
+			}
+		}
+		list, listErr := rs.CareOfferingService.ListActiveByPhase(ctx, phaseID)
+		if listErr != nil {
+			return listErr
+		}
+		offerings = list
+		legalTexts, legalErr := rs.RequestService.LegalTextsForManualEnrollmentPhase(ctx, phaseID)
+		if legalErr != nil {
+			return legalErr
+		}
+		texts = legalTexts
+		return nil
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, enrollmentService.ErrEnrollmentDisabled),
+			errors.Is(err, enrollmentService.ErrInvalidSubmission):
+			common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		default:
+			common.RenderError(w, r, common.ErrorInternalServer(err))
+		}
+		return
+	}
+
+	items := make([]CareOfferingResponse, 0, len(offerings))
+	for _, o := range offerings {
+		items = append(items, toCareOfferingResponse(o))
+	}
+	common.Respond(w, r, http.StatusOK, PublicEnrollmentFormBootstrapResponse{
+		Phase:                     toPublicPhase(phase),
+		Schema:                    toPublicFormSchemaResponse(schema),
+		Offerings:                 items,
+		CareOfferingSelectionMode: phase.CareOfferingSelectionMode,
+		CareRequired:              phase.CareOfferingSelectionMode != enrollmentModels.PhaseCareOfferingSelectionOptional,
+		CaptchaConfig:             PublicCaptchaConfigResponse{},
+		LegalTexts: PublicLegalTextsResponse{
+			AGB:                 texts.AGB,
+			AGBDocumentURL:      texts.AGBDocumentURL,
+			AGBDisplayMode:      texts.AGBDisplayMode,
+			DSGVO:               texts.DSGVO,
+			EmailContact:        texts.EmailContact,
+			Photo:               texts.Photo,
+			TermsEnabled:        texts.TermsEnabled,
+			DSGVOEnabled:        texts.DSGVOEnabled,
+			EmailContactEnabled: texts.EmailContactEnabled,
+			PhotoEnabled:        texts.PhotoEnabled,
+			Blocks:              texts.Blocks,
+		},
+	}, "Manual enrollment bootstrap retrieved")
+}
+
+func fmtInvalidManualEnrollmentChildCount(count int) error {
+	return errors.New("manual approved enrollment produced " + strconv.Itoa(count) + " children")
+}
+
+func mapLateInviteAdminError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, enrollmentService.ErrEnrollmentDisabled),
+		errors.Is(err, enrollmentService.ErrInvalidSubmission),
+		errors.Is(err, enrollmentService.ErrInvalidGuardianEmail):
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+	default:
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+	}
+}
+
+func mapManualEnrollmentError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, enrollmentService.ErrDecisionChildNotFound),
+		errors.Is(err, enrollmentService.ErrDecisionRequestNotFound):
+		common.RenderError(w, r, common.ErrorNotFound(err))
+	case errors.Is(err, enrollmentService.ErrDecisionInvalidStatus),
+		errors.Is(err, enrollmentService.ErrDecisionAlreadyTerminal),
+		errors.Is(err, enrollmentService.ErrDecisionInvalidData):
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+	case common.IsTransientDatabaseError(err):
+		common.RenderError(w, r, common.ErrorServiceUnavailable(err))
+	default:
+		mapSubmitError(w, r, err)
+	}
+}

--- a/backend/api/enrollment/api.go
+++ b/backend/api/enrollment/api.go
@@ -165,6 +165,9 @@ func (rs *Resource) Router() chi.Router {
 				// FROM this phase. Both require config:manage.
 				r.With(authorize.RequiresPermission("config:manage")).Post("/rollover", rs.createRollover)
 				r.With(authorize.RequiresPermission("config:read")).Get("/review", rs.listRolloverReview)
+				r.With(authorize.RequiresPermission("config:manage")).Get("/manual-bootstrap", rs.getManualEnrollmentBootstrap)
+				r.With(authorize.RequiresPermission("config:manage")).Post("/late-invites", rs.createLateInvite)
+				r.With(authorize.RequiresPermission("config:manage")).Post("/manual-approved-enrollments", rs.createManualApprovedEnrollment)
 				// Compact export of every registration in the phase
 				// (PDF for print, XLSX for data). Gated config:manage
 				// (not config:read like the review list): one call

--- a/backend/api/enrollment/care_offering_handlers.go
+++ b/backend/api/enrollment/care_offering_handlers.go
@@ -378,14 +378,16 @@ func (rs *Resource) listPublicCareOfferings(w http.ResponseWriter, r *http.Reque
 		offerings     []*enrollmentModels.CareOffering
 		selectionMode = enrollmentModels.PhaseCareOfferingSelectionOptional
 	)
+	lateInviteToken := lateInviteTokenFromRequest(r)
 	schoolID, err := rs.resolvePublicTenantID(r.Context(), slug)
 	if err == nil {
 		err = tenant.WithTenantTx(r.Context(), rs.db, schoolID, func(txCtx context.Context, _ bun.Tx) error {
 			if rs.RequestService == nil {
 				return errors.New("request service not configured")
 			}
-			// Shared public phase gate: enabled + active + open window.
-			phase, phaseErr := rs.RequestService.LoadOpenPublicPhase(txCtx, phaseID, time.Now())
+			// Shared public phase gate: enabled + active + open window, or
+			// a valid late-invite exception for this exact phase.
+			phase, phaseErr := rs.RequestService.LoadPublicPhaseWithLateInvite(txCtx, phaseID, time.Now(), lateInviteToken)
 			if phaseErr != nil {
 				return phaseErr
 			}
@@ -440,6 +442,10 @@ func renderPublicEnrollmentError(w http.ResponseWriter, r *http.Request, err err
 	}
 	if errors.Is(err, enrollmentService.ErrEnrollmentWindowClosed) {
 		common.RenderError(w, r, common.ErrorNotFoundWithCode(err, ErrCodeEnrollmentWindowClosed))
+		return
+	}
+	if errors.Is(err, enrollmentService.ErrLateInviteInvalid) {
+		common.RenderError(w, r, common.ErrorNotFoundWithCode(err, ErrCodeEnrollmentLateInviteInvalid))
 		return
 	}
 	common.RenderError(w, r, common.ErrorNotFound(err))
@@ -541,11 +547,13 @@ func (rs *Resource) publicFormBootstrap(w http.ResponseWriter, r *http.Request) 
 		captcha   PublicCaptchaConfigResponse
 		legalErr  error
 	)
+	lateInviteToken := lateInviteTokenFromRequest(r)
 	schoolID, resolveErr := rs.resolvePublicTenantID(r.Context(), slug)
 	if resolveErr == nil {
 		resolveErr = tenant.WithTenantTx(r.Context(), rs.db, schoolID, func(txCtx context.Context, _ bun.Tx) error {
-			// Shared public phase gate: enabled + active + open window.
-			loadedPhase, phaseErr := rs.RequestService.LoadOpenPublicPhase(txCtx, phaseID, time.Now())
+			// Shared public phase gate: enabled + active + open window, or
+			// a valid late-invite exception for this exact phase.
+			loadedPhase, phaseErr := rs.RequestService.LoadPublicPhaseWithLateInvite(txCtx, phaseID, time.Now(), lateInviteToken)
 			if phaseErr != nil {
 				return phaseErr
 			}
@@ -571,11 +579,12 @@ func (rs *Resource) publicFormBootstrap(w http.ResponseWriter, r *http.Request) 
 			offerings = list
 			captcha.Enabled = rs.CaptchaService.IsEnabled(txCtx)
 			captcha.SiteKey = rs.CaptchaService.SiteKey(txCtx)
-			legalTexts, legalTextErr := rs.RequestService.LegalTextsForPhase(txCtx, phaseID)
+			legalTexts, legalTextErr := rs.RequestService.LegalTextsForPhaseWithLateInvite(txCtx, phaseID, lateInviteToken)
 			if legalTextErr != nil {
 				if !errors.Is(legalTextErr, enrollmentService.ErrInvalidSubmission) &&
 					!errors.Is(legalTextErr, enrollmentService.ErrEnrollmentDisabled) &&
-					!errors.Is(legalTextErr, enrollmentService.ErrEnrollmentWindowClosed) {
+					!errors.Is(legalTextErr, enrollmentService.ErrEnrollmentWindowClosed) &&
+					!errors.Is(legalTextErr, enrollmentService.ErrLateInviteInvalid) {
 					legalErr = legalTextErr
 				}
 				return legalTextErr

--- a/backend/api/enrollment/legal_handlers.go
+++ b/backend/api/enrollment/legal_handlers.go
@@ -60,6 +60,7 @@ func (rs *Resource) publicLegalTexts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	out := PublicLegalTextsResponse{}
+	lateInviteToken := lateInviteTokenFromRequest(r)
 	// legalErr captures a genuine settings/DB/JSON resolve failure so we
 	// can return a 500 instead of the 404 path. These texts sit behind
 	// legally relevant blocks — on a real failure the endpoint must fail
@@ -77,14 +78,15 @@ func (rs *Resource) publicLegalTexts(w http.ResponseWriter, r *http.Request) {
 				err   error
 			)
 			if phaseID > 0 {
-				texts, err = rs.RequestService.LegalTextsForPhase(txCtx, phaseID)
+				texts, err = rs.RequestService.LegalTextsForPhaseWithLateInvite(txCtx, phaseID, lateInviteToken)
 			} else {
 				texts, err = rs.RequestService.LegalTexts(txCtx)
 			}
 			if err != nil {
 				if !errors.Is(err, enrollmentService.ErrInvalidSubmission) &&
 					!errors.Is(err, enrollmentService.ErrEnrollmentDisabled) &&
-					!errors.Is(err, enrollmentService.ErrEnrollmentWindowClosed) {
+					!errors.Is(err, enrollmentService.ErrEnrollmentWindowClosed) &&
+					!errors.Is(err, enrollmentService.ErrLateInviteInvalid) {
 					legalErr = err
 				}
 				return err

--- a/backend/api/enrollment/schema_handlers.go
+++ b/backend/api/enrollment/schema_handlers.go
@@ -254,14 +254,16 @@ func (rs *Resource) listPublicActiveSchema(w http.ResponseWriter, r *http.Reques
 	}
 
 	var schema *enrollmentModels.FormSchema
+	lateInviteToken := lateInviteTokenFromRequest(r)
 	schoolID, resolveErr := rs.resolvePublicTenantID(r.Context(), slug)
 	if resolveErr == nil {
 		resolveErr = tenant.WithTenantTx(r.Context(), rs.db, schoolID, func(txCtx context.Context, _ bun.Tx) error {
 			if rs.RequestService == nil {
 				return errors.New("request service not configured")
 			}
-			// Shared public phase gate: enabled + active + open window.
-			phase, phaseErr := rs.RequestService.LoadOpenPublicPhase(txCtx, phaseID, time.Now())
+			// Shared public phase gate: enabled + active + open window, or
+			// a valid late-invite exception for this exact phase.
+			phase, phaseErr := rs.RequestService.LoadPublicPhaseWithLateInvite(txCtx, phaseID, time.Now(), lateInviteToken)
 			if phaseErr != nil {
 				return phaseErr
 			}

--- a/backend/api/enrollment/submission_handlers.go
+++ b/backend/api/enrollment/submission_handlers.go
@@ -80,6 +80,7 @@ type SubmitEnrollmentRequest struct {
 	CustomData          map[string]any          `json:"custom_data,omitempty"`
 	Children            []SubmitChildRequest    `json:"children"`
 	CaptchaToken        string                  `json:"captcha_token,omitempty"`
+	LateInviteToken     string                  `json:"late_invite_token,omitempty"`
 }
 
 // Bind defaults nil maps + slices to empty so downstream code doesn't
@@ -128,6 +129,9 @@ func (rs *Resource) submitEnrollment(w http.ResponseWriter, r *http.Request) {
 	if err := render.Bind(r, wireReq); err != nil {
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 		return
+	}
+	if wireReq.LateInviteToken == "" {
+		wireReq.LateInviteToken = lateInviteTokenFromRequest(r)
 	}
 
 	remoteIP := remoteIPFromRequest(r)
@@ -202,6 +206,7 @@ func buildServiceRequest(wireReq *SubmitEnrollmentRequest, tenantID int64, remot
 		GuardianPhone:     wireReq.GuardianPhone,
 		ConsentFlags:      wireReq.ConsentFlags,
 		CustomData:        wireReq.CustomData,
+		LateInviteToken:   wireReq.LateInviteToken,
 	}
 	for _, g := range wireReq.AdditionalGuardians {
 		out.AdditionalGuardians = append(out.AdditionalGuardians, enrollmentService.SubmitGuardian{
@@ -256,6 +261,7 @@ const (
 	ErrCodeEnrollmentInvalidPhone                = "enrollment.invalid_phone"
 	ErrCodeEnrollmentInvalidEmail                = "enrollment.invalid_email"
 	ErrCodeEnrollmentPickupTimeNotAllowed        = "enrollment.pickup_time_not_allowed"
+	ErrCodeEnrollmentLateInviteInvalid           = "enrollment.late_invite_invalid"
 )
 
 // mapSubmitError translates service-layer sentinel errors into HTTP
@@ -265,6 +271,8 @@ func mapSubmitError(w http.ResponseWriter, r *http.Request, err error) {
 	case errors.Is(err, enrollmentService.ErrEnrollmentDisabled),
 		errors.Is(err, enrollmentService.ErrEnrollmentWindowClosed):
 		common.RenderError(w, r, common.ErrorForbidden(err))
+	case errors.Is(err, enrollmentService.ErrLateInviteInvalid):
+		common.RenderError(w, r, common.ErrorForbiddenWithCode(err, ErrCodeEnrollmentLateInviteInvalid))
 	case errors.Is(err, enrollmentService.ErrCareOfferingMissing):
 		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, ErrCodeEnrollmentCareOfferingMissing))
 	case errors.Is(err, enrollmentService.ErrCareOfferingExactlyOneRequired):
@@ -312,6 +320,10 @@ func mapSubmitError(w http.ResponseWriter, r *http.Request, err error) {
 		}
 		common.RenderError(w, r, common.ErrorInternalServer(err))
 	}
+}
+
+func lateInviteTokenFromRequest(r *http.Request) string {
+	return strings.TrimSpace(r.URL.Query().Get("late_invite"))
 }
 
 // remoteIPFromRequest extracts the client IP for captcha verification +

--- a/backend/api/parent/enrollment_handlers.go
+++ b/backend/api/parent/enrollment_handlers.go
@@ -213,6 +213,7 @@ type submitParentEnrollmentRequest struct {
 	ConsentFlags        map[string]any              `json:"consent_flags,omitempty"`
 	CustomData          map[string]any              `json:"custom_data,omitempty"`
 	Children            []submitParentChildRequest  `json:"children"`
+	LateInviteToken     string                      `json:"late_invite_token,omitempty"`
 }
 
 // submitParentResponse is what the embedded form receives after a
@@ -267,6 +268,9 @@ func (rs *Resource) submitParentEnrollment(w http.ResponseWriter, r *http.Reques
 	}
 	if wireReq.Children == nil {
 		wireReq.Children = []submitParentChildRequest{}
+	}
+	if wireReq.LateInviteToken == "" {
+		wireReq.LateInviteToken = strings.TrimSpace(r.URL.Query().Get("late_invite"))
 	}
 
 	var (
@@ -345,6 +349,7 @@ func buildParentServiceRequest(wireReq *submitParentEnrollmentRequest, tenantID,
 		CustomData:        wireReq.CustomData,
 		GuardianAccountID: &accountID,
 		RemoteIP:          remoteIP,
+		LateInviteToken:   wireReq.LateInviteToken,
 	}
 	for _, g := range wireReq.AdditionalGuardians {
 		out.AdditionalGuardians = append(out.AdditionalGuardians, enrollmentService.SubmitGuardian{
@@ -386,6 +391,8 @@ func mapParentSubmitError(w http.ResponseWriter, r *http.Request, err error) {
 	case errors.Is(err, enrollmentService.ErrEnrollmentDisabled),
 		errors.Is(err, enrollmentService.ErrEnrollmentWindowClosed):
 		common.RenderError(w, r, common.ErrorForbidden(err))
+	case errors.Is(err, enrollmentService.ErrLateInviteInvalid):
+		common.RenderError(w, r, common.ErrorForbiddenWithCode(err, "enrollment.late_invite_invalid"))
 	// Phone/email validation must precede the generic ErrInvalidSubmission
 	// branch below: ErrInvalidGuardianEmail wraps ErrInvalidSubmission, and
 	// ErrInvalidGuardianPhone does NOT wrap it at all — without these cases an

--- a/backend/api/parent/handler_helpers_test.go
+++ b/backend/api/parent/handler_helpers_test.go
@@ -62,6 +62,7 @@ func TestBuildParentServiceRequest_StampsTenantAndAccount(t *testing.T) {
 		GuardianEmail:     "anna@example.test",
 		ConsentFlags:      map[string]any{"photo": true},
 		CustomData:        map[string]any{"notes": "n"},
+		LateInviteToken:   "late-token-123",
 		Children: []submitParentChildRequest{
 			{FirstName: "Lara", LastName: "Beispiel", DateOfBirth: "2018-03-04"},
 		},
@@ -77,6 +78,8 @@ func TestBuildParentServiceRequest_StampsTenantAndAccount(t *testing.T) {
 	assert.True(t, out.ConsentFlags["photo"].(bool))
 	assert.Equal(t, "203.0.113.42", out.RemoteIP,
 		"RemoteIP is forwarded so per-IP rate limiting applies even on authenticated parent submits")
+	assert.Equal(t, "late-token-123", out.LateInviteToken,
+		"late invite token must survive the parent-authenticated submit path")
 	require.Len(t, out.Children, 1)
 	assert.Equal(t, timezone.NewDate(2018, 3, 4), out.Children[0].DateOfBirth)
 }
@@ -197,6 +200,7 @@ func TestSubmitParentEnrollment_AllowsMappedAccountWithoutExistingGuardianPermis
 		GuardianFirstName: "Anna",
 		GuardianLastName:  "Beispiel",
 		GuardianEmail:     "anna@example.test",
+		LateInviteToken:   "parent-late-token",
 		Children: []submitParentChildRequest{
 			{FirstName: "Lara", LastName: "Beispiel", DateOfBirth: "2018-03-04"},
 		},
@@ -218,6 +222,7 @@ func TestSubmitParentEnrollment_AllowsMappedAccountWithoutExistingGuardianPermis
 	require.NotNil(t, requestSvc.got.GuardianAccountID)
 	assert.Equal(t, int64(7777), *requestSvc.got.GuardianAccountID)
 	assert.Equal(t, tenantID, requestSvc.got.TenantID)
+	assert.Equal(t, "parent-late-token", requestSvc.got.LateInviteToken)
 }
 
 // --- mapParentSubmitError ------------------------------------------------
@@ -234,6 +239,14 @@ func TestMapParentSubmitError_EnrollmentWindowClosed403(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/x", nil)
 	mapParentSubmitError(w, r, enrollmentService.ErrEnrollmentWindowClosed)
 	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestMapParentSubmitError_LateInviteInvalid403WithCode(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/x", nil)
+	mapParentSubmitError(w, r, enrollmentService.ErrLateInviteInvalid)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "enrollment.late_invite_invalid")
 }
 
 func TestMapParentSubmitError_CareOfferingClosed400(t *testing.T) {

--- a/backend/database/migrations/001015151_late_invites_and_request_sources.go
+++ b/backend/database/migrations/001015151_late_invites_and_request_sources.go
@@ -1,0 +1,111 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	lateInvitesAndRequestSourcesVersion     = "1.15.151"
+	lateInvitesAndRequestSourcesDescription = "Add enrollment request sources and late invite tokens for closed-phase parent submissions"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     lateInvitesAndRequestSourcesVersion,
+		Description: lateInvitesAndRequestSourcesDescription,
+		DependsOn:   []string{repairEnrollmentChangeRequestsVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Migration 1.15.151: Adding enrollment late invites and request source fields...")
+			if _, err := db.NewRaw(`
+				ALTER TABLE enrollment.requests
+					ADD COLUMN IF NOT EXISTS submission_source TEXT NOT NULL DEFAULT 'public',
+					ADD COLUMN IF NOT EXISTS source_metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+				DO $$
+				BEGIN
+					IF NOT EXISTS (
+						SELECT 1 FROM pg_constraint
+						WHERE conname = 'chk_enrollment_requests_submission_source'
+							AND conrelid = 'enrollment.requests'::regclass
+					) THEN
+						ALTER TABLE enrollment.requests
+							ADD CONSTRAINT chk_enrollment_requests_submission_source
+							CHECK (submission_source IN ('public', 'late_invite', 'admin_manual'));
+					END IF;
+				END $$;
+
+				CREATE TABLE IF NOT EXISTS enrollment.late_invites (
+					id BIGSERIAL PRIMARY KEY,
+					tenant_id BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+					phase_id BIGINT NOT NULL REFERENCES enrollment.phases(id) ON DELETE CASCADE,
+					token_hash TEXT NOT NULL,
+					guardian_email TEXT NOT NULL,
+					guardian_first_name TEXT,
+					guardian_last_name TEXT,
+					expires_at TIMESTAMPTZ NOT NULL,
+					used_at TIMESTAMPTZ,
+					used_request_id BIGINT REFERENCES enrollment.requests(id) ON DELETE SET NULL,
+					created_by BIGINT NOT NULL REFERENCES auth.accounts(id) ON DELETE RESTRICT,
+					reason TEXT,
+					created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					CONSTRAINT uq_enrollment_late_invites_token_hash UNIQUE (tenant_id, token_hash),
+					CONSTRAINT chk_enrollment_late_invites_email CHECK (length(btrim(guardian_email)) > 0),
+					CONSTRAINT chk_enrollment_late_invites_expiry CHECK (expires_at > created_at)
+				);
+
+				CREATE INDEX IF NOT EXISTS idx_enrollment_late_invites_phase
+					ON enrollment.late_invites (tenant_id, phase_id, created_at DESC);
+				CREATE INDEX IF NOT EXISTS idx_enrollment_late_invites_usable
+					ON enrollment.late_invites (tenant_id, phase_id, token_hash, expires_at)
+					WHERE used_at IS NULL;
+				CREATE INDEX IF NOT EXISTS idx_enrollment_late_invites_email
+					ON enrollment.late_invites (tenant_id, phase_id, lower(guardian_email));
+
+				ALTER TABLE enrollment.late_invites ENABLE ROW LEVEL SECURITY;
+				ALTER TABLE enrollment.late_invites FORCE ROW LEVEL SECURITY;
+
+				DO $$
+				BEGIN
+					IF NOT EXISTS (
+						SELECT 1 FROM pg_policies
+						WHERE schemaname = 'enrollment'
+							AND tablename = 'late_invites'
+							AND policyname = 'tenant_isolation_enrollment_late_invites'
+					) THEN
+						CREATE POLICY tenant_isolation_enrollment_late_invites
+							ON enrollment.late_invites
+							FOR ALL
+							USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+							WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+					END IF;
+				END $$;
+
+				GRANT SELECT, INSERT, UPDATE ON enrollment.late_invites TO phoenix_tenant;
+				GRANT USAGE ON SEQUENCE enrollment.late_invites_id_seq TO phoenix_tenant;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed adding enrollment late invites: %w", err)
+			}
+			return nil
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Rolling back migration 1.15.151: Dropping enrollment late invites and request source fields...")
+			if _, err := db.NewRaw(`
+				DROP TABLE IF EXISTS enrollment.late_invites;
+				ALTER TABLE enrollment.requests
+					DROP CONSTRAINT IF EXISTS chk_enrollment_requests_submission_source,
+					DROP COLUMN IF EXISTS source_metadata,
+					DROP COLUMN IF EXISTS submission_source;
+			`).Exec(ctx); err != nil {
+				return fmt.Errorf("failed rolling back enrollment late invites: %w", err)
+			}
+			return nil
+		},
+	)
+}

--- a/backend/database/repositories/enrollment/late_invite_repository.go
+++ b/backend/database/repositories/enrollment/late_invite_repository.go
@@ -1,0 +1,83 @@
+package enrollment
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/models/enrollment"
+	"github.com/uptrace/bun"
+)
+
+const lateInviteTableExpr = `enrollment.late_invites AS "late_invite"`
+
+type LateInviteRepository struct {
+	db *bun.DB
+}
+
+func NewLateInviteRepository(db *bun.DB) enrollment.LateInviteRepository {
+	return &LateInviteRepository{db: db}
+}
+
+func (r *LateInviteRepository) Create(ctx context.Context, invite *enrollment.LateInvite) error {
+	base.EnsureTenantID(ctx, invite)
+	_, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(invite).
+		ModelTableExpr(lateInviteTableExpr).
+		Returning("*").
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create enrollment late invite: %w", err)
+	}
+	return nil
+}
+
+func (r *LateInviteRepository) FindUsableByTokenHash(ctx context.Context, tokenHash string, phaseID int64, now time.Time) (*enrollment.LateInvite, error) {
+	return r.findUsableByTokenHash(ctx, tokenHash, phaseID, now, false)
+}
+
+func (r *LateInviteRepository) FindUsableByTokenHashForUpdate(ctx context.Context, tokenHash string, phaseID int64, now time.Time) (*enrollment.LateInvite, error) {
+	return r.findUsableByTokenHash(ctx, tokenHash, phaseID, now, true)
+}
+
+func (r *LateInviteRepository) findUsableByTokenHash(ctx context.Context, tokenHash string, phaseID int64, now time.Time, lock bool) (*enrollment.LateInvite, error) {
+	invite := new(enrollment.LateInvite)
+	q := base.GetDB(ctx, r.db).NewSelect().
+		Model(invite).
+		ModelTableExpr(lateInviteTableExpr).
+		Where(`"late_invite".token_hash = ?`, tokenHash).
+		Where(`"late_invite".phase_id = ?`, phaseID).
+		Where(`"late_invite".used_at IS NULL`).
+		Where(`"late_invite".expires_at > ?`, now)
+	if lock {
+		q = q.For("UPDATE")
+	}
+	if err := q.Scan(ctx); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("late invite not found")
+		}
+		return nil, fmt.Errorf("failed to find enrollment late invite: %w", err)
+	}
+	return invite, nil
+}
+
+func (r *LateInviteRepository) MarkUsed(ctx context.Context, inviteID, requestID int64, usedAt time.Time) error {
+	res, err := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*enrollment.LateInvite)(nil)).
+		ModelTableExpr(lateInviteTableExpr).
+		Set(`used_at = ?`, usedAt).
+		Set(`used_request_id = ?`, requestID).
+		Where(`"late_invite".id = ?`, inviteID).
+		Where(`"late_invite".used_at IS NULL`).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to mark enrollment late invite used: %w", err)
+	}
+	if affected, _ := res.RowsAffected(); affected == 0 {
+		return fmt.Errorf("late invite was already used")
+	}
+	return nil
+}

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -173,6 +173,7 @@ type Factory struct {
 	Request              enrollmentModels.RequestRepository
 	RequestChild         enrollmentModels.RequestChildRepository
 	RequestGuardian      enrollmentModels.RequestGuardianRepository
+	LateInvite           enrollmentModels.LateInviteRepository
 	CareOffering         enrollmentModels.CareOfferingRepository
 	RequestChildOffering enrollmentModels.RequestChildOfferingRepository
 	ChangeRequest        enrollmentModels.ChangeRequestRepository
@@ -328,6 +329,7 @@ func NewFactory(db *bun.DB) *Factory {
 		Request:              enrollment.NewRequestRepository(db),
 		RequestChild:         enrollment.NewRequestChildRepository(db),
 		RequestGuardian:      enrollment.NewRequestGuardianRepository(db),
+		LateInvite:           enrollment.NewLateInviteRepository(db),
 		CareOffering:         enrollment.NewCareOfferingRepository(db),
 		RequestChildOffering: enrollment.NewRequestChildOfferingRepository(db),
 		ChangeRequest:        enrollment.NewChangeRequestRepository(db),

--- a/backend/models/enrollment/late_invite.go
+++ b/backend/models/enrollment/late_invite.go
@@ -1,0 +1,36 @@
+package enrollment
+
+import (
+	"context"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+)
+
+// LateInvite is a one-family exception token that lets parents submit a
+// request for a closed phase without reopening the phase globally.
+type LateInvite struct {
+	base.Model `bun:"schema:enrollment,table:late_invites"`
+	base.TenantModel
+	PhaseID           int64      `bun:"phase_id,notnull" json:"phase_id"`
+	TokenHash         string     `bun:"token_hash,notnull" json:"token_hash"`
+	GuardianEmail     string     `bun:"guardian_email,notnull" json:"guardian_email"`
+	GuardianFirstName *string    `bun:"guardian_first_name" json:"guardian_first_name,omitempty"`
+	GuardianLastName  *string    `bun:"guardian_last_name" json:"guardian_last_name,omitempty"`
+	ExpiresAt         time.Time  `bun:"expires_at,notnull" json:"expires_at"`
+	UsedAt            *time.Time `bun:"used_at" json:"used_at,omitempty"`
+	UsedRequestID     *int64     `bun:"used_request_id" json:"used_request_id,omitempty"`
+	CreatedBy         int64      `bun:"created_by,notnull" json:"created_by"`
+	Reason            *string    `bun:"reason" json:"reason,omitempty"`
+}
+
+func (l *LateInvite) TableName() string {
+	return "enrollment.late_invites"
+}
+
+type LateInviteRepository interface {
+	Create(ctx context.Context, invite *LateInvite) error
+	FindUsableByTokenHash(ctx context.Context, tokenHash string, phaseID int64, now time.Time) (*LateInvite, error)
+	FindUsableByTokenHashForUpdate(ctx context.Context, tokenHash string, phaseID int64, now time.Time) (*LateInvite, error)
+	MarkUsed(ctx context.Context, inviteID, requestID int64, usedAt time.Time) error
+}

--- a/backend/models/enrollment/request.go
+++ b/backend/models/enrollment/request.go
@@ -29,6 +29,8 @@ type Request struct {
 	GuardianAccountID  *int64         `bun:"guardian_account_id" json:"guardian_account_id,omitempty"`
 	ConsentFlags       map[string]any `bun:"consent_flags,type:jsonb,notnull,default:'{}'" json:"consent_flags"`
 	CustomData         map[string]any `bun:"custom_data,type:jsonb,notnull,default:'{}'" json:"custom_data"`
+	SubmissionSource   string         `bun:"submission_source,notnull,default:'public'" json:"submission_source"`
+	SourceMetadata     map[string]any `bun:"source_metadata,type:jsonb,notnull,default:'{}'" json:"source_metadata"`
 	StatusToken        string         `bun:"status_token,notnull,unique" json:"status_token"`
 	StatusTokenExpires *time.Time     `bun:"status_token_expires" json:"status_token_expires,omitempty"`
 	SubmittedAt        time.Time      `bun:"submitted_at,notnull,default:current_timestamp" json:"submitted_at"`
@@ -61,6 +63,12 @@ const (
 	RequestStatusPartial     = "partial"      // some children decided, others pending
 	RequestStatusFinalized   = "finalized"    // all children in a terminal status
 	RequestStatusWithdrawn   = "withdrawn"    // request withdrawn (withdrawn_at set)
+)
+
+const (
+	RequestSourcePublic      = "public"
+	RequestSourceLateInvite  = "late_invite"
+	RequestSourceAdminManual = "admin_manual"
 )
 
 // RequestListFilters narrows the admin list query. Zero-value fields

--- a/backend/services/enrollment/decision_service.go
+++ b/backend/services/enrollment/decision_service.go
@@ -85,11 +85,13 @@ var validDecisionStatuses = map[DecisionStatus]bool{
 
 // DecideInput carries the per-child decision the admin makes.
 type DecideInput struct {
-	RequestID  int64
-	ChildID    int64
-	Status     DecisionStatus
-	Reason     string // optional; surfaced to parent only when phase.show_status_reason_to_parent
-	ReviewedBy int64  // admin's auth account id
+	RequestID                  int64
+	ChildID                    int64
+	Status                     DecisionStatus
+	Reason                     string // optional; surfaced to parent only when phase.show_status_reason_to_parent
+	ReviewedBy                 int64  // admin's auth account id
+	SuppressParentEmail        bool
+	SuppressGuardianInvitation bool
 }
 
 type OfferingAdjustmentSelection struct {
@@ -1024,7 +1026,9 @@ func (s *decisionService) Decide(ctx context.Context, input DecideInput) (*Decid
 		if err != nil {
 			return nil, err
 		}
-		outcome.PendingInvite = invite
+		if !input.SuppressGuardianInvitation {
+			outcome.PendingInvite = invite
+		}
 	}
 
 	if err := s.requestChildRepo.UpdateStatus(ctx, target.ID, string(input.Status), reasonPtr, input.ReviewedBy); err != nil {
@@ -1044,7 +1048,9 @@ func (s *decisionService) Decide(ctx context.Context, input DecideInput) (*Decid
 	// so a hard failure WILL roll back - log+swallow keeps the
 	// behaviour aligned with submit's "delivery is downstream of the
 	// decision".)
-	s.enqueueDecisionEmail(ctx, request, target, phase, input.Status, reasonPtr)
+	if !input.SuppressParentEmail {
+		s.enqueueDecisionEmail(ctx, request, target, phase, input.Status, reasonPtr)
+	}
 
 	// Refetch to surface DB-managed fields (reviewed_at, updated_at).
 	refreshed, err := s.findChildByID(ctx, input.RequestID, input.ChildID)

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -3,8 +3,10 @@ package enrollment
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -29,6 +31,7 @@ import (
 var (
 	ErrEnrollmentDisabled     = errors.New("enrollment is not enabled for this tenant")
 	ErrEnrollmentWindowClosed = errors.New("enrollment window is closed")
+	ErrLateInviteInvalid      = errors.New("late invite is invalid")
 	ErrInvalidSubmission      = errors.New("invalid submission")
 	ErrCareOfferingClosed     = errors.New("one or more selected care offerings are not currently accepting applications")
 	ErrCareOfferingFull       = errors.New("one or more selected care offerings are at capacity")
@@ -95,6 +98,19 @@ type SubmitRequest struct {
 	// all possible.
 	RemoteIP string
 
+	// LateInviteToken opens a closed phase only for the token-bound guardian
+	// email. It is validated and consumed inside Submit's write transaction.
+	LateInviteToken string
+
+	// Internal admin paths set these. Public HTTP callers never deserialize
+	// them directly; handlers construct the service request.
+	SkipRateLimit            bool
+	AllowClosedPhase         bool
+	SuppressSubmissionEmails bool
+	ExternalConsentConfirmed bool
+	SubmissionSource         string
+	SourceMetadata           map[string]any
+
 	GuardianFirstName string
 	GuardianLastName  string
 	GuardianEmail     string
@@ -160,6 +176,21 @@ type SubmitResult struct {
 	StatusURL string
 }
 
+type CreateLateInviteInput struct {
+	PhaseID           int64
+	GuardianEmail     string
+	GuardianFirstName string
+	GuardianLastName  string
+	Reason            string
+	ExpiresAt         *time.Time
+	CreatedBy         int64
+}
+
+type CreateLateInviteResult struct {
+	Invite *enrollmentModels.LateInvite
+	Token  string
+}
+
 type materializedOfferingSelection struct {
 	OfferingID            int64
 	SelectedDays          []string
@@ -204,6 +235,7 @@ type EditPatch struct {
 // service builds on the same data.
 type RequestService interface {
 	Submit(ctx context.Context, req SubmitRequest) (*SubmitResult, error)
+	CreateLateInvite(ctx context.Context, input CreateLateInviteInput) (*CreateLateInviteResult, error)
 	GetByStatusToken(ctx context.Context, token string) (*enrollmentModels.Request, []*enrollmentModels.RequestChild, error)
 	EditModeForStatus(ctx context.Context, req *enrollmentModels.Request, children []*enrollmentModels.RequestChild) (string, error)
 	GetEditDraft(ctx context.Context, token string) (*EditDraft, error)
@@ -247,6 +279,8 @@ type RequestService interface {
 	// LoadOpenPublicPhase, so stale or closed phases surface the sentinel
 	// errors instead of an incomplete legal contract.
 	LegalTextsForPhase(ctx context.Context, phaseID int64) (LegalTexts, error)
+	LegalTextsForPhaseWithLateInvite(ctx context.Context, phaseID int64, lateInviteToken string) (LegalTexts, error)
+	LegalTextsForManualEnrollmentPhase(ctx context.Context, phaseID int64) (LegalTexts, error)
 
 	// LoadOpenPublicPhase is the shared public phase gate: every public
 	// form-load endpoint (schema, offerings, legal texts, bootstrap) calls
@@ -256,6 +290,8 @@ type RequestService interface {
 	// when the id is unknown, and ErrEnrollmentWindowClosed outside the
 	// phase's enrollment window. Caller must be inside a tenant-tx.
 	LoadOpenPublicPhase(ctx context.Context, phaseID int64, now time.Time) (*enrollmentModels.Phase, error)
+	LoadPublicPhaseWithLateInvite(ctx context.Context, phaseID int64, now time.Time, lateInviteToken string) (*enrollmentModels.Phase, error)
+	LoadManualEnrollmentPhase(ctx context.Context, phaseID int64) (*enrollmentModels.Phase, error)
 }
 
 // LegalTexts bundles the per-tenant legal texts surfaced on the public
@@ -303,6 +339,7 @@ type RequestServiceConfig struct {
 	RequestRepo              enrollmentModels.RequestRepository
 	RequestChildRepo         enrollmentModels.RequestChildRepository
 	RequestGuardianRepo      enrollmentModels.RequestGuardianRepository
+	LateInviteRepo           enrollmentModels.LateInviteRepository
 	RequestChildOfferingRepo enrollmentModels.RequestChildOfferingRepository
 	CareOfferingRepo         enrollmentModels.CareOfferingRepository
 	FormSchemaRepo           enrollmentModels.FormSchemaRepository
@@ -336,6 +373,7 @@ type requestService struct {
 	requestRepo              enrollmentModels.RequestRepository
 	requestChildRepo         enrollmentModels.RequestChildRepository
 	requestGuardianRepo      enrollmentModels.RequestGuardianRepository
+	lateInviteRepo           enrollmentModels.LateInviteRepository
 	requestChildOfferingRepo enrollmentModels.RequestChildOfferingRepository
 	careOfferingRepo         enrollmentModels.CareOfferingRepository
 	formSchemaRepo           enrollmentModels.FormSchemaRepository
@@ -362,6 +400,7 @@ func NewRequestService(cfg RequestServiceConfig) RequestService {
 		requestRepo:              cfg.RequestRepo,
 		requestChildRepo:         cfg.RequestChildRepo,
 		requestGuardianRepo:      cfg.RequestGuardianRepo,
+		lateInviteRepo:           cfg.LateInviteRepo,
 		requestChildOfferingRepo: cfg.RequestChildOfferingRepo,
 		careOfferingRepo:         cfg.CareOfferingRepo,
 		formSchemaRepo:           cfg.FormSchemaRepo,
@@ -392,15 +431,24 @@ func NewRequestService(cfg RequestServiceConfig) RequestService {
 // phase carries its own enrollment window, form-schema reference, and
 // care-overflow mode - all the things that used to be tenant-wide.
 func (s *requestService) Submit(ctx context.Context, req SubmitRequest) (*SubmitResult, error) {
-	if err := s.enforceRateLimit(ctx, req); err != nil {
-		return nil, err
+	if !req.SkipRateLimit {
+		if err := s.enforceRateLimit(ctx, req); err != nil {
+			return nil, err
+		}
 	}
+	if strings.TrimSpace(req.LateInviteToken) != "" {
+		req.AllowClosedPhase = true
+		req.SubmissionSource = enrollmentModels.RequestSourceLateInvite
+	}
+	submissionSource := normalizedSubmissionSource(req.SubmissionSource)
+	sourceMetadata := cloneSourceMetadata(req.SourceMetadata)
+
 	phase, err := s.loadPhaseForSubmission(ctx, req.PhaseID)
 	if err != nil {
 		return nil, err
 	}
 	now := time.Now()
-	if !IsEnrollmentWindowOpen(phase, now) {
+	if !req.AllowClosedPhase && !IsEnrollmentWindowOpen(phase, now) {
 		return nil, ErrEnrollmentWindowClosed
 	}
 
@@ -450,6 +498,9 @@ func (s *requestService) Submit(ctx context.Context, req SubmitRequest) (*Submit
 	legalBlocks, err := s.resolveSubmissionLegalBlocks(ctx, schema)
 	if err != nil {
 		return nil, fmt.Errorf("submit: resolve legal blocks: %w", err)
+	}
+	if req.ExternalConsentConfirmed {
+		req.ConsentFlags = ensureRequiredConsentFlags(req.ConsentFlags, legalBlocks)
 	}
 	// Normalize + validate additional guardians (co-guardians the parent
 	// added beyond the primary). Mutates req.AdditionalGuardians in place:
@@ -546,6 +597,16 @@ func (s *requestService) Submit(ctx context.Context, req SubmitRequest) (*Submit
 			return fmt.Errorf("submit: acquire dedup lock: %w", err)
 		}
 
+		var lateInvite *enrollmentModels.LateInvite
+		if strings.TrimSpace(req.LateInviteToken) != "" {
+			invite, inviteErr := s.findLateInviteForSubmit(txCtx, req.LateInviteToken, phase.ID, emailLC, now)
+			if inviteErr != nil {
+				return inviteErr
+			}
+			lateInvite = invite
+			sourceMetadata["late_invite_id"] = invite.ID
+		}
+
 		// Dedup check runs inside the lock so the result is stable for
 		// the rest of the tx. Different parents or different child
 		// names slip past untouched; rejected/withdrawn rows are
@@ -573,12 +634,19 @@ func (s *requestService) Submit(ctx context.Context, req SubmitRequest) (*Submit
 			GuardianPhone:      req.GuardianPhone,
 			ConsentFlags:       req.ConsentFlags,
 			CustomData:         req.CustomData,
+			SubmissionSource:   submissionSource,
+			SourceMetadata:     sourceMetadata,
 			StatusToken:        statusToken,
 			StatusTokenExpires: &statusExpiresAt,
 			SubmittedAt:        time.Now(),
 		}
 		if err := s.requestRepo.Create(txCtx, request); err != nil {
 			return fmt.Errorf("submit: create request: %w", err)
+		}
+		if lateInvite != nil {
+			if err := s.lateInviteRepo.MarkUsed(txCtx, lateInvite.ID, request.ID, time.Now()); err != nil {
+				return fmt.Errorf("submit: mark late invite used: %w", err)
+			}
 		}
 		createdRequest = request
 
@@ -642,7 +710,9 @@ func (s *requestService) Submit(ctx context.Context, req SubmitRequest) (*Submit
 	}
 
 	statusURL := s.statusURL(statusToken)
-	s.enqueueSubmissionEmails(ctx, req.TenantID, createdRequest, createdChildren, statusURL)
+	if !req.SuppressSubmissionEmails {
+		s.enqueueSubmissionEmails(ctx, req.TenantID, createdRequest, createdChildren, statusURL)
+	}
 
 	s.logger.Info("enrollment request submitted",
 		slog.Int64("request_id", createdRequest.ID),
@@ -654,6 +724,68 @@ func (s *requestService) Submit(ctx context.Context, req SubmitRequest) (*Submit
 		Children:  createdChildren,
 		StatusURL: statusURL,
 	}, nil
+}
+
+func (s *requestService) CreateLateInvite(ctx context.Context, input CreateLateInviteInput) (*CreateLateInviteResult, error) {
+	if s.lateInviteRepo == nil {
+		return nil, fmt.Errorf("late invite repository is not configured")
+	}
+	if input.PhaseID <= 0 {
+		return nil, fmt.Errorf("%w: phase_id is required", ErrInvalidSubmission)
+	}
+	if input.CreatedBy <= 0 {
+		return nil, fmt.Errorf("%w: created_by is required", ErrInvalidSubmission)
+	}
+	email, err := normalizeGuardianEmail(input.GuardianEmail)
+	if err != nil {
+		return nil, err
+	}
+	phase, err := s.loadPhaseForEditableRequest(ctx, input.PhaseID)
+	if err != nil {
+		return nil, err
+	}
+	token, err := newStatusToken()
+	if err != nil {
+		return nil, fmt.Errorf("late invite: generate token: %w", err)
+	}
+	expiresAt := time.Now().Add(14 * 24 * time.Hour)
+	if input.ExpiresAt != nil {
+		expiresAt = *input.ExpiresAt
+	}
+	if !expiresAt.After(time.Now()) {
+		return nil, fmt.Errorf("%w: expires_at must be in the future", ErrInvalidSubmission)
+	}
+	firstName := optionalTrimmedString(input.GuardianFirstName)
+	lastName := optionalTrimmedString(input.GuardianLastName)
+	reason := optionalTrimmedString(input.Reason)
+	invite := &enrollmentModels.LateInvite{
+		PhaseID:           phase.ID,
+		TokenHash:         lateInviteTokenHash(token),
+		GuardianEmail:     email,
+		GuardianFirstName: firstName,
+		GuardianLastName:  lastName,
+		ExpiresAt:         expiresAt,
+		CreatedBy:         input.CreatedBy,
+		Reason:            reason,
+	}
+	if err := s.lateInviteRepo.Create(ctx, invite); err != nil {
+		return nil, err
+	}
+	return &CreateLateInviteResult{Invite: invite, Token: token}, nil
+}
+
+func (s *requestService) findLateInviteForSubmit(ctx context.Context, token string, phaseID int64, guardianEmail string, now time.Time) (*enrollmentModels.LateInvite, error) {
+	if s.lateInviteRepo == nil {
+		return nil, fmt.Errorf("%w: late invite support is not configured", ErrLateInviteInvalid)
+	}
+	invite, err := s.lateInviteRepo.FindUsableByTokenHashForUpdate(ctx, lateInviteTokenHash(token), phaseID, now)
+	if err != nil {
+		return nil, ErrLateInviteInvalid
+	}
+	if strings.ToLower(strings.TrimSpace(invite.GuardianEmail)) != guardianEmail {
+		return nil, ErrLateInviteInvalid
+	}
+	return invite, nil
 }
 
 func (s *requestService) validateSubmission(ctx context.Context, req SubmitRequest, legalBlocks []LegalBlock) error {
@@ -2123,6 +2255,57 @@ func newStatusToken() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
+func lateInviteTokenHash(token string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(token)))
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizedSubmissionSource(source string) string {
+	switch strings.TrimSpace(source) {
+	case enrollmentModels.RequestSourceLateInvite:
+		return enrollmentModels.RequestSourceLateInvite
+	case enrollmentModels.RequestSourceAdminManual:
+		return enrollmentModels.RequestSourceAdminManual
+	default:
+		return enrollmentModels.RequestSourcePublic
+	}
+}
+
+func cloneSourceMetadata(src map[string]any) map[string]any {
+	out := make(map[string]any, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func ensureRequiredConsentFlags(flags map[string]any, legalBlocks []LegalBlock) map[string]any {
+	out := cloneSourceMetadata(flags)
+	for _, key := range requiredConsentKeys(legalBlocks) {
+		out[key] = true
+	}
+	return out
+}
+
+func optionalTrimmedString(value string) *string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func normalizeGuardianEmail(email string) (string, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(email))
+	if trimmed == "" {
+		return "", fmt.Errorf("%w: guardian email is required", ErrInvalidSubmission)
+	}
+	if err := users.ValidateOptionalEmail(trimmed); err != nil {
+		return "", ErrInvalidGuardianEmail
+	}
+	return trimmed, nil
+}
+
 func (s *requestService) statusURL(token string) string {
 	// Status link is parent-facing - sent in the submitted/approved/
 	// waitlisted/rejected emails. Routes to the parents portal.
@@ -2232,10 +2415,26 @@ func (s *requestService) LegalTexts(ctx context.Context) (LegalTexts, error) {
 }
 
 func (s *requestService) LegalTextsForPhase(ctx context.Context, phaseID int64) (LegalTexts, error) {
-	phase, err := s.LoadOpenPublicPhase(ctx, phaseID, time.Now())
+	return s.LegalTextsForPhaseWithLateInvite(ctx, phaseID, "")
+}
+
+func (s *requestService) LegalTextsForPhaseWithLateInvite(ctx context.Context, phaseID int64, lateInviteToken string) (LegalTexts, error) {
+	phase, err := s.LoadPublicPhaseWithLateInvite(ctx, phaseID, time.Now(), lateInviteToken)
 	if err != nil {
 		return LegalTexts{}, err
 	}
+	return s.legalTextsForLoadedPhase(ctx, phase)
+}
+
+func (s *requestService) LegalTextsForManualEnrollmentPhase(ctx context.Context, phaseID int64) (LegalTexts, error) {
+	phase, err := s.LoadManualEnrollmentPhase(ctx, phaseID)
+	if err != nil {
+		return LegalTexts{}, err
+	}
+	return s.legalTextsForLoadedPhase(ctx, phase)
+}
+
+func (s *requestService) legalTextsForLoadedPhase(ctx context.Context, phase *enrollmentModels.Phase) (LegalTexts, error) {
 	texts, err := s.LegalTexts(ctx)
 	if err != nil {
 		return LegalTexts{}, err
@@ -2260,14 +2459,30 @@ func (s *requestService) LegalTextsForPhase(ctx context.Context, phaseID int64) 
 // LoadOpenPublicPhase implements the shared public phase gate documented
 // on the RequestService interface.
 func (s *requestService) LoadOpenPublicPhase(ctx context.Context, phaseID int64, now time.Time) (*enrollmentModels.Phase, error) {
+	return s.LoadPublicPhaseWithLateInvite(ctx, phaseID, now, "")
+}
+
+func (s *requestService) LoadPublicPhaseWithLateInvite(ctx context.Context, phaseID int64, now time.Time, lateInviteToken string) (*enrollmentModels.Phase, error) {
 	phase, err := s.loadPhaseForEditableRequest(ctx, phaseID)
 	if err != nil {
 		return nil, err
 	}
 	if !IsEnrollmentWindowOpen(phase, now) {
-		return nil, ErrEnrollmentWindowClosed
+		if strings.TrimSpace(lateInviteToken) == "" {
+			return nil, ErrEnrollmentWindowClosed
+		}
+		if s.lateInviteRepo == nil {
+			return nil, ErrLateInviteInvalid
+		}
+		if _, err := s.lateInviteRepo.FindUsableByTokenHash(ctx, lateInviteTokenHash(lateInviteToken), phaseID, now); err != nil {
+			return nil, ErrLateInviteInvalid
+		}
 	}
 	return phase, nil
+}
+
+func (s *requestService) LoadManualEnrollmentPhase(ctx context.Context, phaseID int64) (*enrollmentModels.Phase, error) {
+	return s.loadPhaseForEditableRequest(ctx, phaseID)
 }
 
 func (s *requestService) loadPhaseForEditableRequest(ctx context.Context, phaseID int64) (*enrollmentModels.Phase, error) {

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1003,6 +1003,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		RequestRepo:              repos.Request,
 		RequestChildRepo:         repos.RequestChild,
 		RequestGuardianRepo:      repos.RequestGuardian,
+		LateInviteRepo:           repos.LateInvite,
 		RequestChildOfferingRepo: repos.RequestChildOffering,
 		CareOfferingRepo:         repos.CareOffering,
 		FormSchemaRepo:           repos.FormSchema,

--- a/frontend/src/app/[tenant]/(public)/enroll/[phaseId]/page.tsx
+++ b/frontend/src/app/[tenant]/(public)/enroll/[phaseId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useEffect, useMemo, useState } from "react";
 // eslint-disable-next-line no-restricted-imports -- public page; tenant-router not needed
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { CalendarDays, Check, Mail, ShieldCheck } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import {
@@ -42,6 +42,8 @@ export default function EnrollPhaseFormPage({ params }: PageProps) {
   const locale = useLocale();
   const { phaseId } = use(params);
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const lateInviteToken = searchParams.get("late_invite")?.trim();
   const { tenantSlug, tenant } = useTenant();
   const [bootstrap, setBootstrap] = useState<PublicEnrollmentBootstrap | null>(
     null,
@@ -53,7 +55,9 @@ export default function EnrollPhaseFormPage({ params }: PageProps) {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    void fetchPublicEnrollmentBootstrap(tenantSlug, phaseId)
+    void fetchPublicEnrollmentBootstrap(tenantSlug, phaseId, {
+      lateInviteToken,
+    })
       .then((result) => {
         if (!cancelled) setBootstrap(result);
       })
@@ -68,7 +72,7 @@ export default function EnrollPhaseFormPage({ params }: PageProps) {
     return () => {
       cancelled = true;
     };
-  }, [phaseId, tenantSlug, t]);
+  }, [lateInviteToken, phaseId, tenantSlug, t]);
 
   const phase = bootstrap?.phase ?? null;
   const prefetchedData = useMemo<
@@ -135,6 +139,7 @@ export default function EnrollPhaseFormPage({ params }: PageProps) {
               gradeLevelMax={4}
               onSubmitted={handleSubmitted}
               prefetchedData={prefetchedData}
+              lateInviteToken={lateInviteToken ?? undefined}
               localizedCopy
             />
           )}

--- a/frontend/src/app/api/enrollment/care-offerings/public/[tenantSlug]/[phaseId]/route.ts
+++ b/frontend/src/app/api/enrollment/care-offerings/public/[tenantSlug]/[phaseId]/route.ts
@@ -9,7 +9,7 @@ interface RouteContext {
   params: Promise<{ tenantSlug: string; phaseId: string }>;
 }
 
-export async function GET(_request: NextRequest, context: RouteContext) {
+export async function GET(request: NextRequest, context: RouteContext) {
   const { tenantSlug, phaseId } = await context.params;
   if (!tenantSlug || !phaseId) {
     return NextResponse.json(
@@ -18,12 +18,14 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     );
   }
   try {
-    const response = await fetch(
+    const lateInvite = request.nextUrl.searchParams.get("late_invite")?.trim();
+    const backendUrl = new URL(
       `${getServerApiUrl()}/api/enrollment/care-offerings/public/${encodeURIComponent(
         tenantSlug,
       )}/${encodeURIComponent(phaseId)}`,
-      { cache: "no-store" },
     );
+    if (lateInvite) backendUrl.searchParams.set("late_invite", lateInvite);
+    const response = await fetch(backendUrl, { cache: "no-store" });
     const payload = await response.json().catch(() => ({}));
     return NextResponse.json(payload, { status: response.status });
   } catch (error) {

--- a/frontend/src/app/api/enrollment/form-bootstrap/public/[tenantSlug]/[phaseId]/route.ts
+++ b/frontend/src/app/api/enrollment/form-bootstrap/public/[tenantSlug]/[phaseId]/route.ts
@@ -10,15 +10,17 @@ interface RouteContext {
   params: Promise<{ tenantSlug: string; phaseId: string }>;
 }
 
-export async function GET(_request: NextRequest, context: RouteContext) {
+export async function GET(request: NextRequest, context: RouteContext) {
   const { tenantSlug, phaseId } = await context.params;
   try {
-    const response = await fetch(
+    const lateInvite = request.nextUrl.searchParams.get("late_invite")?.trim();
+    const backendUrl = new URL(
       `${getServerApiUrl()}/api/enrollment/form-bootstrap/public/${encodeURIComponent(
         tenantSlug,
       )}/${encodeURIComponent(phaseId)}`,
-      { cache: "no-store" },
     );
+    if (lateInvite) backendUrl.searchParams.set("late_invite", lateInvite);
+    const response = await fetch(backendUrl, { cache: "no-store" });
     const payload = await response.json().catch(() => ({}));
     if (!response.ok) {
       return NextResponse.json(payload, { status: response.status });

--- a/frontend/src/app/api/enrollment/legal/[tenantSlug]/route.ts
+++ b/frontend/src/app/api/enrollment/legal/[tenantSlug]/route.ts
@@ -19,12 +19,15 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   }
   try {
     const phaseId = _request.nextUrl.searchParams.get("phaseId");
+    const lateInvite = _request.nextUrl.searchParams.get("late_invite")?.trim();
     const backendPath = phaseId
       ? `/api/enrollment/legal/${encodeURIComponent(
           tenantSlug,
         )}/${encodeURIComponent(phaseId)}`
       : `/api/enrollment/legal/${encodeURIComponent(tenantSlug)}`;
-    const response = await fetch(`${getServerApiUrl()}${backendPath}`, {
+    const backendUrl = new URL(`${getServerApiUrl()}${backendPath}`);
+    if (lateInvite) backendUrl.searchParams.set("late_invite", lateInvite);
+    const response = await fetch(backendUrl, {
       cache: "no-store",
     });
     const payload = await response.json().catch(() => ({}));

--- a/frontend/src/app/api/enrollment/phases/[id]/late-invites/route.ts
+++ b/frontend/src/app/api/enrollment/phases/[id]/late-invites/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { auth } from "~/server/auth";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "EnrollmentLateInviteRoute" });
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+async function bearerHeader() {
+  const session = await auth();
+  const token = session?.user?.token;
+  if (!token) return null;
+  return `Bearer ${token}`;
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const { id } = await context.params;
+  const authHeader = await bearerHeader();
+  if (!authHeader) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+  try {
+    const body = (await request.json()) as Record<string, unknown>;
+    const response = await fetch(
+      `${getServerApiUrl()}/api/enrollment/phases/${encodeURIComponent(
+        id,
+      )}/late-invites`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: authHeader,
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    const payload = await response.json().catch(() => ({}));
+    return NextResponse.json(payload, { status: response.status });
+  } catch (error) {
+    logger.error("late_invite_create_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/src/app/api/enrollment/phases/[id]/manual-approved-enrollments/route.ts
+++ b/frontend/src/app/api/enrollment/phases/[id]/manual-approved-enrollments/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { auth } from "~/server/auth";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({
+  component: "EnrollmentManualApprovedEnrollmentRoute",
+});
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+async function bearerHeader() {
+  const session = await auth();
+  const token = session?.user?.token;
+  if (!token) return null;
+  return `Bearer ${token}`;
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const { id } = await context.params;
+  const authHeader = await bearerHeader();
+  if (!authHeader) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+  try {
+    const body = (await request.json()) as Record<string, unknown>;
+    const response = await fetch(
+      `${getServerApiUrl()}/api/enrollment/phases/${encodeURIComponent(
+        id,
+      )}/manual-approved-enrollments`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: authHeader,
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    const payload = await response.json().catch(() => ({}));
+    return NextResponse.json(payload, { status: response.status });
+  } catch (error) {
+    logger.error("manual_approved_enrollment_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/src/app/api/enrollment/phases/[id]/manual-bootstrap/route.ts
+++ b/frontend/src/app/api/enrollment/phases/[id]/manual-bootstrap/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { auth } from "~/server/auth";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "EnrollmentManualBootstrapRoute" });
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+async function bearerHeader() {
+  const session = await auth();
+  const token = session?.user?.token;
+  if (!token) return null;
+  return `Bearer ${token}`;
+}
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const { id } = await context.params;
+  const authHeader = await bearerHeader();
+  if (!authHeader) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+  try {
+    const response = await fetch(
+      `${getServerApiUrl()}/api/enrollment/phases/${encodeURIComponent(
+        id,
+      )}/manual-bootstrap`,
+      {
+        headers: { Authorization: authHeader },
+        cache: "no-store",
+      },
+    );
+    const payload = await response.json().catch(() => ({}));
+    return NextResponse.json(payload, { status: response.status });
+  } catch (error) {
+    logger.error("manual_bootstrap_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/src/app/api/enrollment/schema/public/[tenantSlug]/[phaseId]/route.ts
+++ b/frontend/src/app/api/enrollment/schema/public/[tenantSlug]/[phaseId]/route.ts
@@ -9,7 +9,7 @@ interface RouteContext {
   params: Promise<{ tenantSlug: string; phaseId: string }>;
 }
 
-export async function GET(_request: NextRequest, context: RouteContext) {
+export async function GET(request: NextRequest, context: RouteContext) {
   const { tenantSlug, phaseId } = await context.params;
   if (!tenantSlug || !phaseId) {
     return NextResponse.json(
@@ -18,12 +18,14 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     );
   }
   try {
-    const response = await fetch(
+    const lateInvite = request.nextUrl.searchParams.get("late_invite")?.trim();
+    const backendUrl = new URL(
       `${getServerApiUrl()}/api/enrollment/schema/public/${encodeURIComponent(
         tenantSlug,
       )}/${encodeURIComponent(phaseId)}`,
-      { cache: "no-store" },
     );
+    if (lateInvite) backendUrl.searchParams.set("late_invite", lateInvite);
+    const response = await fetch(backendUrl, { cache: "no-store" });
     const payload = await response.json().catch(() => ({}));
     return NextResponse.json(payload, { status: response.status });
   } catch (error) {

--- a/frontend/src/app/parents/enroll/[tenantSlug]/[phaseId]/page.tsx
+++ b/frontend/src/app/parents/enroll/[tenantSlug]/[phaseId]/page.tsx
@@ -3,7 +3,7 @@
 import { use, useCallback } from "react";
 import Link from "next/link";
 // eslint-disable-next-line no-restricted-imports -- parent portal uses bare paths, no tenant-router
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { ArrowLeft } from "lucide-react";
 import { EnrollmentForm } from "~/components/enrollment/enrollment-form";
@@ -31,6 +31,8 @@ export default function ParentEnrollFormPage({ params }: PageProps) {
   const t = useTranslations("enrollmentPublic");
   const { tenantSlug, phaseId } = use(params);
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const lateInviteToken = searchParams.get("late_invite")?.trim();
 
   const handleSubmitted = (statusURL: string) => {
     try {
@@ -76,6 +78,7 @@ export default function ParentEnrollFormPage({ params }: PageProps) {
           onSubmitted={handleSubmitted}
           profileFetcher={profileFetcher}
           submitter={submitter}
+          lateInviteToken={lateInviteToken ?? undefined}
           skipCaptcha
           localizedCopy
         />

--- a/frontend/src/components/enrollment/admin-enrollments-list.test.tsx
+++ b/frontend/src/components/enrollment/admin-enrollments-list.test.tsx
@@ -138,6 +138,12 @@ describe("AdminEnrollmentsList setup guide", () => {
       name: "Anmeldungen ansehen",
     });
     expect(link).toHaveAttribute("href", "/demo/admin/enrollments/phases/12");
+    expect(
+      screen.queryByRole("button", { name: /Nachzügler/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Manuell/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows an unknown state when change requests fail to load", async () => {

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -11,6 +11,8 @@ import { StrictMode } from "react";
 
 const mocks = vi.hoisted(() => ({
   createCareOffering: vi.fn(),
+  createLateInvite: vi.fn(),
+  createManualApprovedEnrollment: vi.fn(),
   createPhase: vi.fn(),
   createSchema: vi.fn(),
   cloneCareOffering: vi.fn(),
@@ -18,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   deletePhase: vi.fn(),
   deleteSchema: vi.fn(),
   deleteEnrollmentLegalDocument: vi.fn(),
+  fetchManualEnrollmentBootstrap: vi.fn(),
   fetchPublicLegalTexts: vi.fn(),
   listCareOfferings: vi.fn(),
   listPhases: vi.fn(),
@@ -134,6 +137,16 @@ vi.mock("~/lib/timetable-api", () => ({
   },
 }));
 
+vi.mock("~/lib/enrollment-admin-api", () => ({
+  createLateInvite: mocks.createLateInvite,
+  createManualApprovedEnrollment: mocks.createManualApprovedEnrollment,
+  fetchManualEnrollmentBootstrap: mocks.fetchManualEnrollmentBootstrap,
+}));
+
+vi.mock("~/components/enrollment/enrollment-form", () => ({
+  EnrollmentForm: () => <div data-testid="manual-enrollment-form" />,
+}));
+
 import { CareOfferingsEditor } from "./care-offerings-editor";
 import {
   EnrollmentFormEditor,
@@ -244,6 +257,8 @@ function deferred<T>() {
 
 beforeEach(() => {
   mocks.createCareOffering.mockReset();
+  mocks.createLateInvite.mockReset();
+  mocks.createManualApprovedEnrollment.mockReset();
   mocks.createPhase.mockReset();
   mocks.createSchema.mockReset();
   mocks.cloneCareOffering.mockReset();
@@ -251,6 +266,14 @@ beforeEach(() => {
   mocks.deletePhase.mockReset();
   mocks.deleteSchema.mockReset();
   mocks.fetchPublicLegalTexts.mockReset();
+  mocks.fetchManualEnrollmentBootstrap.mockReset();
+  mocks.fetchManualEnrollmentBootstrap.mockResolvedValue({
+    schema: schema(),
+    offerings: [],
+    care_offering_selection_mode: "optional",
+    captcha_config: null,
+    legal_texts: { blocks: [] },
+  });
   // Without this mock the editor's loadAll() fires a real fetch
   // (ECONNREFUSED in CI). Empty blocks = no tenant legal texts
   // configured, so the standard blocks stay disabled by default.
@@ -667,6 +690,49 @@ describe("PhasesEditor", () => {
       name: /Anmeldungen ansehen/,
     });
     expect(link).toHaveAttribute("href", "/demo/admin/enrollments/phases/12");
+  });
+
+  it("opens late invite and manual enrollment actions from the phase action menu", async () => {
+    mocks.listPhases.mockResolvedValue([phase({ id: "12" })]);
+    mocks.listSchemas.mockResolvedValue([schema()]);
+
+    render(<PhasesEditor />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Aktionen für Schuljahr 2026/27",
+      }),
+    );
+
+    fireEvent.click(
+      await screen.findByRole("menuitem", {
+        name: "Nachzügler-Link erstellen",
+      }),
+    );
+    expect(
+      await screen.findByRole("dialog", {
+        name: "Nachzügler-Link erstellen",
+      }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Modal schließen" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Aktionen für Schuljahr 2026/27",
+      }),
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Manuelle Anmeldung" }),
+    );
+
+    expect(
+      await screen.findByRole("dialog", {
+        name: "Kind manuell über Anmeldung freigeben",
+      }),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mocks.fetchManualEnrollmentBootstrap).toHaveBeenCalledWith("12");
+    });
   });
 });
 

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   updateSchema: vi.fn(),
   uploadEnrollmentLegalDocument: vi.fn(),
   getTemplates: vi.fn(),
+  enrollmentFormProps: [] as Array<{ lockChildStructure?: boolean }>,
   searchParams: new URLSearchParams(),
   toast: {
     success: vi.fn(),
@@ -144,7 +145,15 @@ vi.mock("~/lib/enrollment-admin-api", () => ({
 }));
 
 vi.mock("~/components/enrollment/enrollment-form", () => ({
-  EnrollmentForm: () => <div data-testid="manual-enrollment-form" />,
+  EnrollmentForm: (props: { lockChildStructure?: boolean }) => {
+    mocks.enrollmentFormProps.push(props);
+    return (
+      <div
+        data-testid="manual-enrollment-form"
+        data-lock-child-structure={String(props.lockChildStructure)}
+      />
+    );
+  },
 }));
 
 import { CareOfferingsEditor } from "./care-offerings-editor";
@@ -301,6 +310,7 @@ beforeEach(() => {
   mocks.deleteEnrollmentLegalDocument.mockReset();
   mocks.getTemplates.mockReset();
   mocks.getTemplates.mockResolvedValue({ templates: [] });
+  mocks.enrollmentFormProps = [];
   mocks.toast.success.mockReset();
   mocks.toast.error.mockReset();
   mocks.searchParams = new URLSearchParams();
@@ -732,6 +742,11 @@ describe("PhasesEditor", () => {
     ).toBeInTheDocument();
     await waitFor(() => {
       expect(mocks.fetchManualEnrollmentBootstrap).toHaveBeenCalledWith("12");
+    });
+    const form = await screen.findByTestId("manual-enrollment-form");
+    expect(form).toHaveAttribute("data-lock-child-structure", "true");
+    expect(mocks.enrollmentFormProps.at(-1)).toMatchObject({
+      lockChildStructure: true,
     });
   });
 });

--- a/frontend/src/components/enrollment/enrollment-form.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.test.tsx
@@ -436,12 +436,16 @@ describe("EnrollmentForm", () => {
     expect(mockFetchPublicActiveSchema).toHaveBeenCalledWith(
       "test-tenant",
       "5",
+      { lateInviteToken: undefined },
     );
     expect(mockFetchPublicCareOfferings).toHaveBeenCalledWith(
       "test-tenant",
       "5",
+      { lateInviteToken: undefined },
     );
-    expect(mockFetchPublicLegalTexts).toHaveBeenCalledWith("test-tenant", "5");
+    expect(mockFetchPublicLegalTexts).toHaveBeenCalledWith("test-tenant", "5", {
+      lateInviteToken: undefined,
+    });
     expect(screen.getByText("Flexible Betreuung")).toBeInTheDocument();
     expect(screen.getByText("Abholhinweis")).toBeInTheDocument();
     expect(screen.getByText("Allergien")).toBeInTheDocument();

--- a/frontend/src/components/enrollment/enrollment-form.tsx
+++ b/frontend/src/components/enrollment/enrollment-form.tsx
@@ -104,6 +104,7 @@ interface Props {
   readonly gradeLevelMax: number;
   readonly onSubmitted: (statusURL: string) => void;
   readonly prefetchedData?: EnrollmentFormPrefetchedData;
+  readonly lateInviteToken?: string;
   readonly previewMode?: boolean;
   readonly previewSchema?: PublicFormSchema | null;
   /**
@@ -165,6 +166,7 @@ export function EnrollmentForm({
   gradeLevelMax,
   onSubmitted,
   prefetchedData,
+  lateInviteToken,
   previewMode = false,
   previewSchema,
   profileFetcher,
@@ -226,6 +228,10 @@ export function EnrollmentForm({
   // submit with the *same* unchanged message still scrolls back to it; on a
   // successful submit nothing is marked invalid so it's a no-op.
   const { formRef, errorRef, scrollToError } = useScrollToFirstError();
+  const lateInviteFetchOptions = useMemo(
+    () => ({ lateInviteToken }),
+    [lateInviteToken],
+  );
 
   const [guardianFirstName, setGuardianFirstName] = useState(
     initialDraft?.guardian_first_name ??
@@ -347,10 +353,18 @@ export function EnrollmentForm({
           previewSchema !== undefined
             ? Promise.resolve(previewSchema)
             : phaseID
-              ? fetchPublicActiveSchema(tenantSlug, phaseID).catch(() => null)
+              ? fetchPublicActiveSchema(
+                  tenantSlug,
+                  phaseID,
+                  lateInviteFetchOptions,
+                ).catch(() => null)
               : Promise.resolve(null),
           phaseID
-            ? fetchPublicCareOfferings(tenantSlug, phaseID)
+            ? fetchPublicCareOfferings(
+                tenantSlug,
+                phaseID,
+                lateInviteFetchOptions,
+              )
             : Promise.resolve({
                 offerings: [],
                 careOfferingSelectionMode: "optional" as const,
@@ -372,7 +386,11 @@ export function EnrollmentForm({
           previewSchema !== undefined
             ? resolvePreviewLegalTexts(tenantSlug, previewSchema)
             : phaseID
-              ? fetchPublicLegalTexts(tenantSlug, phaseID)
+              ? fetchPublicLegalTexts(
+                  tenantSlug,
+                  phaseID,
+                  lateInviteFetchOptions,
+                )
               : fetchPublicLegalTexts(tenantSlug),
         ]);
         if (cancelled) return;
@@ -424,6 +442,7 @@ export function EnrollmentForm({
     phaseID,
     prefetchedData,
     previewSchema,
+    lateInviteFetchOptions,
     profileFetcher,
     skipCaptcha,
     tr,
@@ -991,6 +1010,9 @@ export function EnrollmentForm({
         ),
         children: payloadChildren,
         captcha_token: skipCaptcha ? undefined : captchaToken || undefined,
+        late_invite_token: lateInviteToken?.trim()
+          ? lateInviteToken.trim()
+          : undefined,
       };
       const result = submitter
         ? await submitter(payload)

--- a/frontend/src/components/enrollment/phase-enrollment-actions.tsx
+++ b/frontend/src/components/enrollment/phase-enrollment-actions.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import {
+  createLateInvite,
+  createManualApprovedEnrollment,
+  fetchManualEnrollmentBootstrap,
+} from "~/lib/enrollment-admin-api";
+import type {
+  SubmitEnrollmentPayload,
+  SubmitEnrollmentResult,
+} from "~/lib/enrollment-submission-api";
+import type { Phase } from "~/lib/enrollment-phase-api";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Modal } from "~/components/ui/modal";
+import {
+  EnrollmentForm,
+  type EnrollmentFormPrefetchedData,
+} from "~/components/enrollment/enrollment-form";
+import { PublicLinkCopyButton } from "~/components/enrollment/public-link-copy-button";
+
+export function LateInviteModal({
+  isOpen,
+  onClose,
+  phase,
+  phaseUrl,
+}: Readonly<{
+  isOpen: boolean;
+  onClose: () => void;
+  phase: Phase;
+  phaseUrl: string;
+}>) {
+  const [guardianEmail, setGuardianEmail] = useState("");
+  const [guardianFirstName, setGuardianFirstName] = useState("");
+  const [guardianLastName, setGuardianLastName] = useState("");
+  const [reason, setReason] = useState("");
+  const [generatedUrl, setGeneratedUrl] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setGuardianEmail("");
+    setGuardianFirstName("");
+    setGuardianLastName("");
+    setReason("");
+    setGeneratedUrl("");
+    setError(null);
+    setLoading(false);
+  }, [isOpen]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    if (!phaseUrl) {
+      setError("Der öffentliche Phasenlink konnte nicht ermittelt werden.");
+      return;
+    }
+    setLoading(true);
+    try {
+      const result = await createLateInvite(phase.id, {
+        guardian_email: guardianEmail.trim(),
+        guardian_first_name: guardianFirstName.trim() || undefined,
+        guardian_last_name: guardianLastName.trim() || undefined,
+        reason: reason.trim() || undefined,
+      });
+      setGeneratedUrl(buildLateInviteUrl(phaseUrl, result.token));
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Nachzügler-Link konnte nicht erstellt werden",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Nachzügler-Link erstellen">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <p className="text-sm leading-6 text-gray-600">
+          {phase.name}: Der Link erlaubt genau dieser E-Mail-Adresse eine
+          Anmeldung, auch wenn die Frist geschlossen ist.
+        </p>
+        {error ? (
+          <div className="rounded-lg border border-[#FF3130]/20 bg-[#FF3130]/10 px-3 py-2 text-sm text-[#9F1F1E]">
+            {error}
+          </div>
+        ) : null}
+        <Input
+          name="late_invite_guardian_email"
+          type="email"
+          label="E-Mail der erziehungsberechtigten Person"
+          value={guardianEmail}
+          onChange={(event) => setGuardianEmail(event.target.value)}
+          required
+        />
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Input
+            name="late_invite_guardian_first_name"
+            label="Vorname"
+            value={guardianFirstName}
+            onChange={(event) => setGuardianFirstName(event.target.value)}
+          />
+          <Input
+            name="late_invite_guardian_last_name"
+            label="Nachname"
+            value={guardianLastName}
+            onChange={(event) => setGuardianLastName(event.target.value)}
+          />
+        </div>
+        <label className="block">
+          <span className="mb-2 block text-sm font-medium text-gray-700">
+            Interner Grund
+          </span>
+          <textarea
+            value={reason}
+            onChange={(event) => setReason(event.target.value)}
+            rows={3}
+            className="block w-full rounded-lg border-0 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 ring-inset placeholder:text-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+            placeholder="z. B. Frist verpasst, telefonisch geklärt"
+          />
+        </label>
+
+        {generatedUrl ? (
+          <div className="rounded-xl border border-[#83CD2D]/30 bg-[#83CD2D]/10 p-3">
+            <p className="text-sm font-medium text-[#365A10]">
+              Link wurde erstellt.
+            </p>
+            <div className="mt-3 flex items-center gap-2">
+              <input
+                readOnly
+                value={generatedUrl}
+                className="min-w-0 flex-1 rounded-lg border-0 bg-white px-3 py-2 text-xs text-gray-700 shadow-sm ring-1 ring-[#83CD2D]/30 ring-inset"
+              />
+              <PublicLinkCopyButton
+                url={generatedUrl}
+                componentId={`LateInvite:${phase.id}:${generatedUrl}`}
+                label="Nachzügler-Link kopieren"
+              />
+            </div>
+          </div>
+        ) : null}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="secondary" size="md" onClick={onClose}>
+            Schließen
+          </Button>
+          <Button
+            type="submit"
+            size="md"
+            isLoading={loading}
+            loadingText="Erstelle..."
+          >
+            Link erstellen
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+export function ManualApprovedEnrollmentModal({
+  isOpen,
+  onClose,
+  phase,
+}: Readonly<{
+  isOpen: boolean;
+  onClose: () => void;
+  phase: Phase;
+}>) {
+  const [prefetchedData, setPrefetchedData] =
+    useState<EnrollmentFormPrefetchedData | null>(null);
+  const [reason, setReason] = useState("");
+  const [externalConsentConfirmed, setExternalConsentConfirmed] =
+    useState(false);
+  const [sendNotification, setSendNotification] = useState(false);
+  const [statusUrl, setStatusUrl] = useState("");
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setPrefetchedData(null);
+    setReason("");
+    setExternalConsentConfirmed(false);
+    setSendNotification(false);
+    setStatusUrl("");
+    setLoadError(null);
+    setLoading(true);
+    void fetchManualEnrollmentBootstrap(phase.id)
+      .then((bootstrap) => {
+        if (!cancelled) setPrefetchedData(toManualPrefetchedData(bootstrap));
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setLoadError(
+            err instanceof Error
+              ? err.message
+              : "Formularvorlage konnte nicht geladen werden",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, phase.id]);
+
+  const submitter = async (
+    payload: SubmitEnrollmentPayload,
+  ): Promise<SubmitEnrollmentResult> => {
+    const trimmedReason = reason.trim();
+    if (!trimmedReason) {
+      throw new Error("Bitte einen internen Grund angeben.");
+    }
+    if (!externalConsentConfirmed) {
+      throw new Error(
+        "Bitte bestätigen, dass die Einwilligung extern vorliegt.",
+      );
+    }
+    const result = await createManualApprovedEnrollment(phase.id, {
+      ...payload,
+      external_consent_confirmed: true,
+      reason: trimmedReason,
+      send_notification: sendNotification,
+    });
+    setStatusUrl(result.status_url);
+    return result;
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Kind manuell über Anmeldung freigeben"
+      widthClass="mx-4 w-[calc(100%-2rem)] max-w-5xl"
+    >
+      <div className="space-y-4">
+        <p className="text-sm leading-6 text-gray-600">
+          {phase.name}: Diese Eingabe nutzt dieselbe Vorlage, dieselben
+          Betreuungsangebote und dieselbe Freigabe-Logik wie die
+          Online-Anmeldung. Nach dem Absenden wird das Kind direkt bestätigt.
+        </p>
+        {loadError ? (
+          <div className="rounded-lg border border-[#FF3130]/20 bg-[#FF3130]/10 px-3 py-2 text-sm text-[#9F1F1E]">
+            {loadError}
+          </div>
+        ) : null}
+        {statusUrl ? (
+          <div className="rounded-xl border border-[#83CD2D]/30 bg-[#83CD2D]/10 p-3">
+            <p className="text-sm font-medium text-[#365A10]">
+              Die manuelle Anmeldung wurde angelegt und freigegeben.
+            </p>
+            <div className="mt-3 flex items-center gap-2">
+              <input
+                readOnly
+                value={statusUrl}
+                className="min-w-0 flex-1 rounded-lg border-0 bg-white px-3 py-2 text-xs text-gray-700 shadow-sm ring-1 ring-[#83CD2D]/30 ring-inset"
+              />
+              <PublicLinkCopyButton
+                url={statusUrl}
+                componentId={`ManualEnrollment:${phase.id}:${statusUrl}`}
+                label="Statuslink kopieren"
+              />
+            </div>
+          </div>
+        ) : null}
+        <div className="grid gap-3 rounded-xl border border-gray-200 bg-white p-4 sm:grid-cols-[minmax(0,1fr)_16rem]">
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-gray-700">
+              Interner Grund
+            </span>
+            <textarea
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              rows={3}
+              className="block w-full rounded-lg border-0 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 ring-inset placeholder:text-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+              placeholder="z. B. verspätete Rückmeldung telefonisch bestätigt"
+            />
+          </label>
+          <div className="space-y-3 text-sm text-gray-700">
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={externalConsentConfirmed}
+                onChange={(event) =>
+                  setExternalConsentConfirmed(event.target.checked)
+                }
+                className="mt-1 h-4 w-4 rounded border-gray-300 text-gray-900 focus:ring-gray-400"
+              />
+              <span>Einwilligung der Eltern liegt extern vor.</span>
+            </label>
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={sendNotification}
+                onChange={(event) => setSendNotification(event.target.checked)}
+                className="mt-1 h-4 w-4 rounded border-gray-300 text-gray-900 focus:ring-gray-400"
+              />
+              <span>Eltern per E-Mail benachrichtigen.</span>
+            </label>
+          </div>
+        </div>
+        {loading ? (
+          <p className="text-sm text-gray-500">
+            Formularvorlage wird geladen...
+          </p>
+        ) : prefetchedData ? (
+          <EnrollmentForm
+            phaseID={phase.id}
+            gradeLevelMax={4}
+            onSubmitted={(url) => setStatusUrl(url)}
+            prefetchedData={prefetchedData}
+            submitter={submitter}
+            skipCaptcha
+            submitLabel="Kind anlegen und freigeben"
+          />
+        ) : null}
+      </div>
+    </Modal>
+  );
+}
+
+function toManualPrefetchedData(
+  bootstrap: Awaited<ReturnType<typeof fetchManualEnrollmentBootstrap>>,
+): EnrollmentFormPrefetchedData {
+  return {
+    schema: bootstrap.schema,
+    offerings: bootstrap.offerings,
+    careOfferingSelectionMode: bootstrap.care_offering_selection_mode,
+    captchaConfig: null,
+    legalTexts: {
+      ...bootstrap.legal_texts,
+      blocks: (bootstrap.legal_texts.blocks ?? []).map((block) => ({
+        ...block,
+        required: false,
+      })),
+    },
+    profile: null,
+  };
+}
+
+function buildLateInviteUrl(phaseUrl: string, token: string): string {
+  try {
+    const url = new URL(phaseUrl);
+    url.searchParams.set("late_invite", token);
+    return url.toString();
+  } catch {
+    const separator = phaseUrl.includes("?") ? "&" : "?";
+    return `${phaseUrl}${separator}late_invite=${encodeURIComponent(token)}`;
+  }
+}

--- a/frontend/src/components/enrollment/phase-enrollment-actions.tsx
+++ b/frontend/src/components/enrollment/phase-enrollment-actions.tsx
@@ -32,8 +32,6 @@ export function LateInviteModal({
   phaseUrl: string;
 }>) {
   const [guardianEmail, setGuardianEmail] = useState("");
-  const [guardianFirstName, setGuardianFirstName] = useState("");
-  const [guardianLastName, setGuardianLastName] = useState("");
   const [reason, setReason] = useState("");
   const [generatedUrl, setGeneratedUrl] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -42,8 +40,6 @@ export function LateInviteModal({
   useEffect(() => {
     if (!isOpen) return;
     setGuardianEmail("");
-    setGuardianFirstName("");
-    setGuardianLastName("");
     setReason("");
     setGeneratedUrl("");
     setError(null);
@@ -61,8 +57,6 @@ export function LateInviteModal({
     try {
       const result = await createLateInvite(phase.id, {
         guardian_email: guardianEmail.trim(),
-        guardian_first_name: guardianFirstName.trim() || undefined,
-        guardian_last_name: guardianLastName.trim() || undefined,
         reason: reason.trim() || undefined,
       });
       setGeneratedUrl(buildLateInviteUrl(phaseUrl, result.token));
@@ -97,20 +91,6 @@ export function LateInviteModal({
           onChange={(event) => setGuardianEmail(event.target.value)}
           required
         />
-        <div className="grid gap-3 sm:grid-cols-2">
-          <Input
-            name="late_invite_guardian_first_name"
-            label="Vorname"
-            value={guardianFirstName}
-            onChange={(event) => setGuardianFirstName(event.target.value)}
-          />
-          <Input
-            name="late_invite_guardian_last_name"
-            label="Nachname"
-            value={guardianLastName}
-            onChange={(event) => setGuardianLastName(event.target.value)}
-          />
-        </div>
         <label className="block">
           <span className="mb-2 block text-sm font-medium text-gray-700">
             Interner Grund

--- a/frontend/src/components/enrollment/phase-enrollment-actions.tsx
+++ b/frontend/src/components/enrollment/phase-enrollment-actions.tsx
@@ -299,6 +299,7 @@ export function ManualApprovedEnrollmentModal({
             prefetchedData={prefetchedData}
             submitter={submitter}
             skipCaptcha
+            lockChildStructure
             submitLabel="Kind anlegen und freigeben"
           />
         ) : null}

--- a/frontend/src/components/enrollment/phases-editor.tsx
+++ b/frontend/src/components/enrollment/phases-editor.tsx
@@ -13,10 +13,12 @@ import {
   Clock3,
   ExternalLink,
   FileText,
+  Link2,
   MoreVertical,
   Pencil,
   Power,
   Trash2,
+  UserCheck,
 } from "lucide-react";
 import {
   type Phase,
@@ -51,6 +53,10 @@ import {
   type DataTableColumn,
 } from "~/components/ui/data-table";
 import { CustomSelect } from "~/components/ui/custom-select";
+import {
+  LateInviteModal,
+  ManualApprovedEnrollmentModal,
+} from "~/components/enrollment/phase-enrollment-actions";
 
 const logger = createLogger({ component: "PhasesEditor" });
 
@@ -823,7 +829,7 @@ interface PhaseActionsMenuPosition {
   alignRight: boolean;
 }
 
-const PHASE_ACTIONS_MENU_HEIGHT = 220;
+const PHASE_ACTIONS_MENU_HEIGHT = 292;
 
 function PhaseActions({
   phase,
@@ -840,6 +846,8 @@ function PhaseActions({
   onDelete,
 }: PhaseActionsProps) {
   const [open, setOpen] = useState(false);
+  const [lateInviteOpen, setLateInviteOpen] = useState(false);
+  const [manualOpen, setManualOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
   const [position, setPosition] = useState<PhaseActionsMenuPosition>({
     top: 0,
@@ -955,6 +963,34 @@ function PhaseActions({
         Formular ansehen
       </a>
 
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          setOpen(false);
+          setLateInviteOpen(true);
+        }}
+        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={saving}
+      >
+        <Link2 className="h-4 w-4 text-gray-500" aria-hidden />
+        Nachzügler-Link erstellen
+      </button>
+
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          setOpen(false);
+          setManualOpen(true);
+        }}
+        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={saving}
+      >
+        <UserCheck className="h-4 w-4 text-gray-500" aria-hidden />
+        Manuelle Anmeldung
+      </button>
+
       <Link
         href={enrollmentsHref}
         role="menuitem"
@@ -1040,32 +1076,45 @@ function PhaseActions({
   );
 
   return (
-    <div className="flex justify-end gap-1.5">
-      {phaseUrl ? (
-        <PublicLinkCopyButton
-          url={phaseUrl}
-          componentId={`PhaseActions:${phase.id}`}
-        />
-      ) : null}
-      <div>
-        <button
-          ref={buttonRef}
-          type="button"
-          onClick={() => setOpen((prev) => !prev)}
-          aria-label={`Aktionen für ${phase.name}`}
-          aria-haspopup="menu"
-          aria-expanded={open}
-          className={`inline-flex h-8 w-8 items-center justify-center rounded-lg border bg-white text-gray-500 shadow-sm transition-colors hover:bg-gray-50 hover:text-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none ${
-            highlight
-              ? "border-[#83CD2D] bg-[#83CD2D]/10 text-[#5F9F20] shadow-[0_0_0_4px_rgba(131,205,45,0.18)]"
-              : "border-gray-200"
-          }`}
-        >
-          <MoreVertical className="h-4 w-4" aria-hidden="true" />
-        </button>
-        {mounted ? createPortal(menu, document.body) : null}
+    <>
+      <div className="flex justify-end gap-1.5">
+        {phaseUrl ? (
+          <PublicLinkCopyButton
+            url={phaseUrl}
+            componentId={`PhaseActions:${phase.id}`}
+          />
+        ) : null}
+        <div>
+          <button
+            ref={buttonRef}
+            type="button"
+            onClick={() => setOpen((prev) => !prev)}
+            aria-label={`Aktionen für ${phase.name}`}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            className={`inline-flex h-8 w-8 items-center justify-center rounded-lg border bg-white text-gray-500 shadow-sm transition-colors hover:bg-gray-50 hover:text-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none ${
+              highlight
+                ? "border-[#83CD2D] bg-[#83CD2D]/10 text-[#5F9F20] shadow-[0_0_0_4px_rgba(131,205,45,0.18)]"
+                : "border-gray-200"
+            }`}
+          >
+            <MoreVertical className="h-4 w-4" aria-hidden="true" />
+          </button>
+          {mounted ? createPortal(menu, document.body) : null}
+        </div>
       </div>
-    </div>
+      <LateInviteModal
+        isOpen={lateInviteOpen}
+        onClose={() => setLateInviteOpen(false)}
+        phase={phase}
+        phaseUrl={phaseUrl}
+      />
+      <ManualApprovedEnrollmentModal
+        isOpen={manualOpen}
+        onClose={() => setManualOpen(false)}
+        phase={phase}
+      />
+    </>
   );
 }
 

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -710,10 +710,12 @@ export const appChapters: readonly GuideChapter[] = [
           "`Anmeldungen` öffnen. Du landest im `Überblick` mit allen Anmeldephasen, der Zahl der Eingänge (`Gesamt`, `Offen`, `Bestätigt`, `Abgelehnt`) und dem Einstieg zu offenen Änderungsanfragen.",
           "Beim ersten Einrichten führt dich der Bereich `Einrichtung` (`Online-Anmeldung vorbereiten`) Schritt für Schritt durch alles Nötige. Zuerst `Online-Anmeldung aktivieren`: schaltet den Elternlink frei (in den `Einstellungen` unter `Anmeldung`).",
           "Unter `Einstellungen` -> `Anmeldung` -> `Rechtstexte` aktivierst du nur die Blöcke, die eure Einrichtung tatsächlich nutzt. Jeder Block hat denselben Ablauf: `Im Anmeldeformular anzeigen` einschalten, den Pflichttext im Dialog eintragen und speichern. Bei `AGB / Teilnahmebedingungen` wählst du zuerst die Quelle: `Text eingeben` oder `PDF-Datei hochladen`. Nur die gewählte Quelle erscheint im Elternformular; die andere Quelle kann gespeichert bleiben, wird aber nicht angezeigt. Ausgeschaltete Blöcke bleiben im Hintergrund gespeichert, erscheinen aber nicht im Elternformular. Eigene Formularvorlagen können diese Standardblöcke unter `Rechtstexte und Einwilligungen` je Vorlage ein- oder ausblenden, abweichend bearbeiten oder um eigene Einwilligungen ergänzen.",
+          "Für Familien, die die Frist verpasst haben, `Anmeldephasen` öffnen und in der passenden Phase im Drei-Punkte-Menü `Nachzügler-Link erstellen` wählen. E-Mail-Adresse der erziehungsberechtigten Person eintragen, optional einen internen Grund notieren und den erzeugten Link an die Familie schicken. Der Link öffnet genau diese Phase trotz geschlossener Frist und kann nur einmal erfolgreich genutzt werden.",
+          "Als letzte Absicherung kann ein Admin unter `Anmeldephasen` in der passenden Phase im Drei-Punkte-Menü `Manuelle Anmeldung` wählen. Dort wird dieselbe Formularvorlage wie für Eltern geladen; nach interner Begründung und Bestätigung, dass die Einwilligung extern vorliegt, wird das Kind direkt angelegt und freigegeben.",
         ],
         callout: {
           title: "So hängt alles zusammen",
-          body: "Alles hängt an der `Anmeldephase`: Sie legt den Zeitraum und das Anmeldefenster fest. `Betreuungsangebote` gehören zu einer Phase, und jede Phase nutzt ein `Anmeldeformular`. Richte deshalb in dieser Reihenfolge ein: zuerst die `Online-Anmeldung` in den Einstellungen aktivieren (sonst ist der Elternlink nicht erreichbar), dann eine Anmeldephase anlegen, danach die Betreuungsangebote, bei Bedarf ein eigenes Formular - am Ende die Elternansicht testen. Der `Überblick` enthält dafür den Bereich `Einrichtung`, der dich Schritt für Schritt führt.",
+          body: "Alles hängt an der `Anmeldephase`: Sie legt den Zeitraum und das Anmeldefenster fest. `Betreuungsangebote` gehören zu einer Phase, und jede Phase nutzt ein `Anmeldeformular`. Richte deshalb in dieser Reihenfolge ein: zuerst die `Online-Anmeldung` in den Einstellungen aktivieren (sonst ist der Elternlink nicht erreichbar), dann eine Anmeldephase anlegen, danach die Betreuungsangebote, bei Bedarf ein eigenes Formular - am Ende die Elternansicht testen. Für Nachzügler bleibt die Phase geschlossen; du erzeugst nur einen einzelnen Sonderlink oder nutzt die manuelle Freigabe.",
           tone: "blue",
         },
         screenshot:
@@ -731,6 +733,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Die Kennzahlen über der Tabelle zeigen, wie viele Kinder an einem, zwei, drei, vier oder fünf Tagen betreut werden. Die Karte `Einsatzplanung` zeigt zusätzlich, wie viele Kinder je Wochentag bis zu welcher Gehzeit bleiben.",
           "Für Klassenlehrkräfte unter `Klasse für Klassenliste` den Klassenverband wählen und `Klassenliste exportieren` nutzen. Die Liste enthält den gesamten Klassenverband, auch Kinder ohne bestätigte Anmeldung, und zeigt pro Wochentag die gebuchten Angebote, zum Beispiel `Randstunde` oder `Ganztag`, inklusive Abholzeit, Geh-/Abholweise und Kontaktdaten der Erziehungsberechtigten.",
           "Eine Anmeldung öffnen und Kind, erziehungsberechtigte Personen (Hauptkontakt und weitere erziehungsberechtigte Personen), gewähltes Betreuungsangebot und Formularangaben prüfen.",
+          "Wenn eine Familie nach der Frist nachgereicht hat, erscheint die Anmeldung nach Nutzung des Nachzügler-Links ganz normal in dieser Liste. Bei der manuellen Freigabe ist das Kind bereits bestätigt; prüfe anschließend bei Bedarf den Statuslink oder die Kinddetailseite.",
           "Mit `Bestätigen`, `Warteliste` oder `Ablehnen` entscheiden; mit `Zur Prüfung` für später vormerken.",
           "Bei bestätigten Kindern können Betreuungsangebote über `Betreuungsangebote bearbeiten` nachträglich korrigiert werden. Eine Begründung ist Pflicht; die Änderungshistorie zeigt danach, wer was wann angepasst hat.",
           "Wenn Eltern nach einer Entscheidung Daten korrigieren, erscheint die Anfrage unter `Änderungsanfragen`. Die Änderungsübersicht zeigt pro Kind oder erziehungsberechtigter Person, welche Felder von `Bisher` auf `Neu` geändert wurden. Dort kannst du Rückfragen senden, die Änderung freigeben oder mit Begründung ablehnen.",
@@ -784,7 +787,7 @@ export const appChapters: readonly GuideChapter[] = [
         ],
         callout: {
           title: "Das Anmeldefenster steuert die öffentliche Anmeldung",
-          body: "Das `Anmeldefenster` der Phase entscheidet, wann Familien absenden können. Über das Aktionsmenü öffnest du mit `Formular ansehen` den Elternlink, wechselst mit `Anmeldungen ansehen` zu den Eingängen oder bereitest mit `Anschlussphase erstellen` eine Folgephase vor.",
+          body: "Das `Anmeldefenster` der Phase entscheidet, wann Familien absenden können. Über das Aktionsmenü öffnest du mit `Formular ansehen` den Elternlink, wechselst mit `Anmeldungen ansehen` zu den Eingängen, erstellst einen `Nachzügler-Link`, startest eine `Manuelle Anmeldung` oder bereitest mit `Anschlussphase erstellen` eine Folgephase vor.",
           tone: "gray",
         },
         screenshot:

--- a/frontend/src/lib/enrollment-admin-api.ts
+++ b/frontend/src/lib/enrollment-admin-api.ts
@@ -1,5 +1,10 @@
 import { createLogger } from "~/lib/logger";
 import { readEnrollmentError } from "~/lib/enrollment-error-messages";
+import type {
+  PublicEnrollmentBootstrap,
+  SubmitEnrollmentPayload,
+  SubmitEnrollmentResult,
+} from "~/lib/enrollment-submission-api";
 
 const logger = createLogger({ component: "EnrollmentAdminAPI" });
 
@@ -192,6 +197,7 @@ interface BackendEnvelope<T> {
 
 const BASE = "/api/enrollment/admin/requests";
 const CHANGE_REQUEST_BASE = "/api/enrollment/admin/change-requests";
+const PHASE_BASE = "/api/enrollment/phases";
 
 async function readJSON<T>(response: Response): Promise<T> {
   const raw = (await response.json()) as BackendEnvelope<T>;
@@ -247,6 +253,90 @@ export async function getAdminRequest(id: string): Promise<AdminRequestDetail> {
     throw await readError(response, "Anmeldung konnte nicht geladen werden");
   }
   return readJSON<AdminRequestDetail>(response);
+}
+
+export interface CreateLateInviteInput {
+  guardian_email: string;
+  guardian_first_name?: string;
+  guardian_last_name?: string;
+  reason?: string;
+  expires_at?: string;
+}
+
+export interface CreateLateInviteResult {
+  id: string;
+  phase_id: string;
+  guardian_email: string;
+  guardian_first_name?: string | null;
+  guardian_last_name?: string | null;
+  expires_at: string;
+  created_by: string;
+  reason?: string | null;
+  token: string;
+}
+
+export async function createLateInvite(
+  phaseId: string,
+  input: CreateLateInviteInput,
+): Promise<CreateLateInviteResult> {
+  const response = await fetch(
+    `${PHASE_BASE}/${encodeURIComponent(phaseId)}/late-invites`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    },
+  );
+  if (!response.ok) {
+    throw await readError(
+      response,
+      "Nachzügler-Link konnte nicht erstellt werden",
+    );
+  }
+  return readJSON<CreateLateInviteResult>(response);
+}
+
+export async function fetchManualEnrollmentBootstrap(
+  phaseId: string,
+): Promise<PublicEnrollmentBootstrap> {
+  const response = await fetch(
+    `${PHASE_BASE}/${encodeURIComponent(phaseId)}/manual-bootstrap`,
+    { cache: "no-store" },
+  );
+  if (!response.ok) {
+    throw await readError(
+      response,
+      "Formularvorlage konnte nicht geladen werden",
+    );
+  }
+  return readJSON<PublicEnrollmentBootstrap>(response);
+}
+
+export interface CreateManualApprovedEnrollmentInput extends SubmitEnrollmentPayload {
+  external_consent_confirmed: boolean;
+  reason: string;
+  send_notification: boolean;
+}
+
+export async function createManualApprovedEnrollment(
+  phaseId: string,
+  input: CreateManualApprovedEnrollmentInput,
+): Promise<SubmitEnrollmentResult> {
+  const response = await fetch(
+    `${PHASE_BASE}/${encodeURIComponent(phaseId)}/manual-approved-enrollments`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    },
+  );
+  if (!response.ok) {
+    throw await readError(
+      response,
+      "Manuelle Anmeldung konnte nicht freigegeben werden",
+    );
+  }
+  return readJSON<SubmitEnrollmentResult>(response);
 }
 
 export async function listStudentEnrollmentRequests(

--- a/frontend/src/lib/enrollment-admin-api.ts
+++ b/frontend/src/lib/enrollment-admin-api.ts
@@ -257,8 +257,6 @@ export async function getAdminRequest(id: string): Promise<AdminRequestDetail> {
 
 export interface CreateLateInviteInput {
   guardian_email: string;
-  guardian_first_name?: string;
-  guardian_last_name?: string;
   reason?: string;
   expires_at?: string;
 }

--- a/frontend/src/lib/enrollment-error-messages.test.ts
+++ b/frontend/src/lib/enrollment-error-messages.test.ts
@@ -62,6 +62,15 @@ describe("enrollment-error-messages", () => {
     ).toContain("vorgegebenen Liste");
   });
 
+  it("maps the late-invite invalid code to a German message", () => {
+    expect(
+      translateEnrollmentErrorMessage(
+        "late invite is invalid",
+        "enrollment.late_invite_invalid",
+      ),
+    ).toContain("Nachzügler-Link");
+  });
+
   it("keeps already-German backend messages", () => {
     expect(
       translateEnrollmentErrorMessage("Bitte prüfe die eingegebenen Daten."),

--- a/frontend/src/lib/enrollment-error-messages.ts
+++ b/frontend/src/lib/enrollment-error-messages.ts
@@ -32,6 +32,8 @@ const ENROLLMENT_CODE_MESSAGES: Record<string, string> = {
   "enrollment.invalid_email": "Bitte gib eine gültige E-Mail-Adresse ein.",
   "enrollment.pickup_time_not_allowed":
     "Bitte wähle bei den Abholzeiten nur Uhrzeiten aus der vorgegebenen Liste. Die markierte Zeit ist nicht mehr verfügbar.",
+  "enrollment.late_invite_invalid":
+    "Dieser Nachzügler-Link ist ungültig, abgelaufen oder wurde bereits verwendet. Bitte wende dich an die Schule.",
   "enrollment.schema_has_phases":
     "Diese Formularvorlage wird noch in einer Anmeldephase verwendet.",
   "enrollment.schema_has_requests":

--- a/frontend/src/lib/enrollment-form-schema-api.ts
+++ b/frontend/src/lib/enrollment-form-schema-api.ts
@@ -419,9 +419,16 @@ export interface PublicLegalTexts {
 export async function fetchPublicLegalTexts(
   tenantSlug: string,
   phaseId?: string,
+  options: { lateInviteToken?: string } = {},
 ): Promise<PublicLegalTexts> {
   const path = `/api/enrollment/legal/${encodeURIComponent(tenantSlug)}`;
-  const url = phaseId ? `${path}?phaseId=${encodeURIComponent(phaseId)}` : path;
+  const params = new URLSearchParams();
+  if (phaseId) params.set("phaseId", phaseId);
+  if (options.lateInviteToken?.trim()) {
+    params.set("late_invite", options.lateInviteToken.trim());
+  }
+  const query = params.toString();
+  const url = query ? `${path}?${query}` : path;
   const response = await fetch(url, { cache: "no-store" });
   if (!response.ok) {
     throw await readEnrollmentError(
@@ -437,13 +444,16 @@ export async function fetchPublicLegalTexts(
 export async function fetchPublicActiveSchema(
   tenantSlug: string,
   phaseId: string,
+  options: { lateInviteToken?: string } = {},
 ): Promise<PublicFormSchema | null> {
-  const response = await fetch(
-    `/api/enrollment/schema/public/${encodeURIComponent(
-      tenantSlug,
-    )}/${encodeURIComponent(phaseId)}`,
-    { cache: "no-store" },
-  );
+  const path = `/api/enrollment/schema/public/${encodeURIComponent(
+    tenantSlug,
+  )}/${encodeURIComponent(phaseId)}`;
+  const trimmedToken = options.lateInviteToken?.trim();
+  const url = trimmedToken
+    ? `${path}?late_invite=${encodeURIComponent(trimmedToken)}`
+    : path;
+  const response = await fetch(url, { cache: "no-store" });
   if (response.status === 404) {
     return null;
   }

--- a/frontend/src/lib/enrollment-submission-api.ts
+++ b/frontend/src/lib/enrollment-submission-api.ts
@@ -87,6 +87,7 @@ export interface SubmitEnrollmentPayload {
   custom_data?: Record<string, unknown>;
   children: SubmitChildPayload[];
   captcha_token?: string;
+  late_invite_token?: string;
 }
 
 export interface SubmitEnrollmentResult {
@@ -218,6 +219,16 @@ export interface PublicCareOfferingsResult {
   careRequired: boolean;
 }
 
+export interface LateInviteFetchOptions {
+  lateInviteToken?: string;
+}
+
+function withLateInviteQuery(path: string, token?: string): string {
+  const trimmed = token?.trim();
+  if (!trimmed) return path;
+  return `${path}?late_invite=${encodeURIComponent(trimmed)}`;
+}
+
 /**
  * Fetches the public care-offering catalog for a given tenant slug
  * and phase. Returns the offerings plus the phase-level selection mode
@@ -227,11 +238,13 @@ export interface PublicCareOfferingsResult {
 export async function fetchPublicCareOfferings(
   tenantSlug: string,
   phaseId: string,
+  options: LateInviteFetchOptions = {},
 ): Promise<PublicCareOfferingsResult> {
+  const path = `/api/enrollment/care-offerings/public/${encodeURIComponent(
+    tenantSlug,
+  )}/${encodeURIComponent(phaseId)}`;
   const response = await fetch(
-    `/api/enrollment/care-offerings/public/${encodeURIComponent(
-      tenantSlug,
-    )}/${encodeURIComponent(phaseId)}`,
+    withLateInviteQuery(path, options.lateInviteToken),
     { cache: "no-store" },
   );
   if (!response.ok) {
@@ -318,11 +331,13 @@ export interface PublicEnrollmentBootstrap {
 export async function fetchPublicEnrollmentBootstrap(
   tenantSlug: string,
   phaseId: string,
+  options: LateInviteFetchOptions = {},
 ): Promise<PublicEnrollmentBootstrap> {
+  const path = `/api/enrollment/form-bootstrap/public/${encodeURIComponent(
+    tenantSlug,
+  )}/${encodeURIComponent(phaseId)}`;
   const response = await fetch(
-    `/api/enrollment/form-bootstrap/public/${encodeURIComponent(
-      tenantSlug,
-    )}/${encodeURIComponent(phaseId)}`,
+    withLateInviteQuery(path, options.lateInviteToken),
     { cache: "no-store" },
   );
   if (!response.ok) {

--- a/frontend/src/lib/parent-api.test.ts
+++ b/frontend/src/lib/parent-api.test.ts
@@ -281,6 +281,25 @@ describe("submitParentEnrollment", () => {
     ).rejects.toThrow(/Anmeldung bereits vorhanden/);
   });
 
+  it("preserves coded enrollment errors from the parent submit route", async () => {
+    mockFetch(async () =>
+      jsonResponse(
+        {
+          error: "late invite is invalid",
+          code: "enrollment.late_invite_invalid",
+        },
+        { status: 403 },
+      ),
+    );
+    await expect(
+      submitParentEnrollment("school", validPayload),
+    ).rejects.toMatchObject({
+      code: "enrollment.late_invite_invalid",
+      status: 403,
+      message: expect.stringContaining("Nachzügler-Link"),
+    });
+  });
+
   it("throws with German fallback when error body is malformed", async () => {
     mockFetch(async () => new Response("not json", { status: 500 }));
     await expect(

--- a/frontend/src/lib/parent-api.ts
+++ b/frontend/src/lib/parent-api.ts
@@ -11,6 +11,7 @@
 import { createLogger } from "~/lib/logger";
 import type { AppLocale } from "~/i18n/locales";
 import type { ChatMessage } from "~/lib/messaging-status";
+import { readEnrollmentError } from "~/lib/enrollment-error-messages";
 import type {
   MeProfileResponse,
   SubmitEnrollmentPayload,
@@ -377,19 +378,12 @@ export async function submitParentEnrollment(
     },
   );
   if (!response.ok) {
-    let message = "Anmeldung konnte nicht übermittelt werden";
-    try {
-      const body = (await response.json()) as { error?: string };
-      if (body.error) message = body.error;
-    } catch {
-      // Body was not JSON, keep the generic message.
-    }
-    logger.error("parent_submit_failed", {
-      tenant_slug: tenantSlug,
-      status: response.status,
-      message,
-    });
-    throw new Error(message);
+    throw await readEnrollmentError(
+      response,
+      "Anmeldung konnte nicht übermittelt werden",
+      logger,
+      "parent_submit_failed",
+    );
   }
   const json = (await response.json()) as {
     data?: SubmitEnrollmentResult;


### PR DESCRIPTION
## Summary
This adds a controlled way to handle families who missed an enrollment deadline without reopening the whole phase. The normal recovery path is a one-time parent link: an admin creates a Nachzügler-Link for the guardian, sends it to the family, and the parent completes the regular enrollment form themselves.

As a last line of defense, admins can also create and approve a manual enrollment from the phase action menu when the family has already provided the data and consent outside the online form. That path is deliberately stricter: it requires an internal reason and explicit confirmation that external consent exists.

## Why
A concrete case exposed the gap: Abigail Mitchell could be created after the deadline, but Franziska could not assign care times or register her for Randstunde because the enrollment phase was already closed. The system needed a narrow exception flow for late families, not a broad phase reopen.

## What Changed
- Added per-guardian late invite tokens for closed enrollment phases.
- Bound late invite use to the guardian email, stored only the token hash, and marked the invite used after a successful submission.
- Passed `late_invite` through the public and parents enrollment pages so the existing parent form can load schema, legal text, and care offerings for a closed phase.
- Added phase actions for `Nachzügler-Link erstellen` and `Manuelle Anmeldung`.
- Added manual approved enrollment endpoints that reuse the normal submit and approval logic, suppress public rate limits, and require admin reason plus external consent confirmation.
- Recorded `submission_source` and `source_metadata` on enrollment requests so late invites and manual admin entries remain auditable.
- Updated frontend helpers, tests, and the in-app help guide for both exception paths.

## Intended Flow
1. Admin opens the affected enrollment phase.
2. Admin chooses `Nachzügler-Link erstellen`, enters the guardian email, and sends the generated link to the family.
3. Parent completes the regular enrollment form, including care times and Randstunde selection.
4. Only if that is not possible, admin uses `Manuelle Anmeldung`, records why, confirms external consent, and creates the approved enrollment directly.

## Validation
- `cd backend && go test ./...`
- `cd frontend && pnpm run check`
- Pre-push hook passed: `go vet`, `pnpm run knip`, `pnpm run check`, `go-deadcode`, `golangci-lint`

## Risk Notes
- The late link does not reopen the phase globally. It only unlocks the matching phase for a valid, unused, unexpired invite token.
- Manual creation can bypass the parent form, so it is treated as the fallback path and requires an audit reason plus consent confirmation.