### PR TITLE
fix: render staff change-requests labels as German instead of raw i18n keys

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useTranslations } from "next-intl";
 import { MasterDataReviewList } from "~/components/students/master-data-review-list";
 import { PageHeaderWithSearch } from "~/components/ui/page-header";
 import { Loading } from "~/components/ui/loading";
@@ -8,7 +7,6 @@ import { DesktopOnlyNotice } from "~/components/ui/desktop-only-notice";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 
 export default function AdminChangeRequestsPage() {
-  const t = useTranslations("staffMasterDataReview");
   const { isReady } = useRequireAdmin();
   if (!isReady) return <Loading fullPage={false} />;
 
@@ -16,8 +14,11 @@ export default function AdminChangeRequestsPage() {
     <div className="-mt-1.5 w-full">
       <DesktopOnlyNotice />
       <div className="hidden lg:block">
-        <PageHeaderWithSearch title={t("title")} />
-        <p className="mb-4 text-sm text-gray-600">{t("subtitle")}</p>
+        <PageHeaderWithSearch title="Änderungsanfragen" />
+        <p className="mb-4 text-sm text-gray-600">
+          Von Eltern eingereichte Änderungen an Stammdaten, die eine Freigabe
+          benötigen.
+        </p>
         <MasterDataReviewList />
       </div>
     </div>

--- a/frontend/src/components/students/master-data-review-list.tsx
+++ b/frontend/src/components/students/master-data-review-list.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useTranslations } from "next-intl";
 
 import { Button } from "~/components/ui/button";
 import { DataTable, type DataTableColumn } from "~/components/ui/data-table";
@@ -15,27 +14,30 @@ import {
 
 const logger = createLogger({ component: "MasterDataReviewList" });
 
-type ReviewTranslator = ReturnType<
-  typeof useTranslations<"staffMasterDataReview">
->;
+// German-only staff UI: the staff shell ships a minimal client message catalog
+// (parentNav only — see shell-nav-intl-provider.tsx), so this page hardcodes its
+// German strings like the rest of the staff/admin surface instead of using
+// useTranslations, which would resolve to raw keys here.
+const EMPTY_VALUE = "—";
 
-function fieldLabel(field: string, t: ReviewTranslator): string {
-  // The known field keys all have labels; fall back to the raw key.
-  const known = new Set([
-    "first_name",
-    "last_name",
-    "birthday",
-    "health_info",
-    "email",
-    "primary",
-    "address_street",
-    "address_city",
-    "address_postal_code",
-    "preferred_contact_method",
-    "language_preference",
-    "allowed_departure_modes",
-  ]);
-  return known.has(field) ? t(`fields.${field}`) : field;
+const FIELD_LABELS: Record<string, string> = {
+  first_name: "Vorname",
+  last_name: "Nachname",
+  birthday: "Geburtsdatum",
+  health_info: "Gesundheitshinweise",
+  email: "E-Mail",
+  primary: "Telefonnummer",
+  address_street: "Straße",
+  address_city: "Ort",
+  address_postal_code: "PLZ",
+  preferred_contact_method: "Kontaktweg",
+  language_preference: "Sprache",
+  allowed_departure_modes: "Dauerhafte Gehzeiten",
+};
+
+function fieldLabel(field: string): string {
+  // Known field keys have German labels; fall back to the raw key.
+  return FIELD_LABELS[field] ?? field;
 }
 
 function formatValue(value: unknown, empty: string): string {
@@ -53,7 +55,6 @@ function formatValue(value: unknown, empty: string): string {
 }
 
 export function MasterDataReviewList() {
-  const t = useTranslations("staffMasterDataReview");
   const [rows, setRows] = useState<StaffMasterDataChange[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -91,26 +92,26 @@ export function MasterDataReviewList() {
           reasons[row.id]?.trim() || undefined,
         );
         setRows((prev) => prev.filter((r) => r.id !== row.id));
-        setNotice(approve ? t("approved") : t("rejected"));
+        setNotice(approve ? "Änderung übernommen" : "Änderung abgelehnt");
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         logger.warn("master_data_review_decide_failed", {
           error: message,
           request_id: row.id,
         });
-        setError(t("decideError"));
+        setError("Die Entscheidung konnte nicht gespeichert werden.");
       } finally {
         setBusyId(null);
       }
     },
-    [reasons, t],
+    [reasons],
   );
 
   const columns = useMemo<DataTableColumn<StaffMasterDataChange>[]>(
     () => [
       {
         key: "child",
-        header: t("columns.child"),
+        header: "Kind",
         render: (row) => (
           <span className="font-medium text-gray-900">
             {row.first_name} {row.last_name}
@@ -120,27 +121,27 @@ export function MasterDataReviewList() {
       },
       {
         key: "field",
-        header: t("columns.field"),
-        render: (row) => fieldLabel(row.field_key, t),
+        header: "Feld",
+        render: (row) => fieldLabel(row.field_key),
       },
       {
         key: "change",
-        header: t("columns.change"),
+        header: "Änderung",
         render: (row) => (
           <span className="text-sm">
             <span className="text-gray-500 line-through">
-              {formatValue(row.old_value, t("empty_value"))}
+              {formatValue(row.old_value, EMPTY_VALUE)}
             </span>
             <span className="mx-2 text-gray-400">→</span>
             <span className="font-medium text-gray-900">
-              {formatValue(row.new_value, t("empty_value"))}
+              {formatValue(row.new_value, EMPTY_VALUE)}
             </span>
           </span>
         ),
       },
       {
         key: "actions",
-        header: t("columns.actions"),
+        header: "Aktion",
         align: "right",
         render: (row) => (
           <div className="flex flex-col items-end gap-2">
@@ -150,7 +151,7 @@ export function MasterDataReviewList() {
               onChange={(e) =>
                 setReasons((prev) => ({ ...prev, [row.id]: e.target.value }))
               }
-              placeholder={t("reason")}
+              placeholder="Begründung (optional)"
               className="h-8 w-44 rounded-md border-0 bg-white px-2 text-sm text-gray-900 ring-1 ring-gray-200 ring-inset focus:ring-2 focus:ring-gray-400 focus:outline-none"
             />
             <div className="flex gap-2">
@@ -161,7 +162,7 @@ export function MasterDataReviewList() {
                 disabled={busyId === row.id}
                 onClick={() => void decide(row, true)}
               >
-                {t("approve")}
+                Freigeben
               </Button>
               <Button
                 type="button"
@@ -170,14 +171,14 @@ export function MasterDataReviewList() {
                 disabled={busyId === row.id}
                 onClick={() => void decide(row, false)}
               >
-                {t("reject")}
+                Ablehnen
               </Button>
             </div>
           </div>
         ),
       },
     ],
-    [t, reasons, busyId, decide],
+    [reasons, busyId, decide],
   );
 
   if (loading) return <Loading fullPage={false} />;
@@ -198,7 +199,11 @@ export function MasterDataReviewList() {
         columns={columns}
         rows={rows}
         getRowKey={(row) => row.id}
-        emptyState={<span className="text-sm text-gray-500">{t("empty")}</span>}
+        emptyState={
+          <span className="text-sm text-gray-500">
+            Keine offenen Änderungsanfragen.
+          </span>
+        }
       />
     </div>
   );

--- a/frontend/src/i18n/messages/de.json
+++ b/frontend/src/i18n/messages/de.json
@@ -888,40 +888,6 @@
       "fri": "Fr"
     }
   },
-  "staffMasterDataReview": {
-    "title": "Änderungsanfragen",
-    "subtitle": "Von Eltern eingereichte Änderungen an Stammdaten, die eine Freigabe benötigen.",
-    "loadError": "Die Änderungsanfragen konnten nicht geladen werden.",
-    "empty": "Keine offenen Änderungsanfragen.",
-    "columns": {
-      "child": "Kind",
-      "field": "Feld",
-      "change": "Änderung",
-      "submitted": "Eingereicht",
-      "actions": "Aktion"
-    },
-    "fields": {
-      "first_name": "Vorname",
-      "last_name": "Nachname",
-      "birthday": "Geburtsdatum",
-      "health_info": "Gesundheitshinweise",
-      "email": "E-Mail",
-      "primary": "Telefonnummer",
-      "address_street": "Straße",
-      "address_city": "Ort",
-      "address_postal_code": "PLZ",
-      "preferred_contact_method": "Kontaktweg",
-      "language_preference": "Sprache",
-      "allowed_departure_modes": "Dauerhafte Gehzeiten"
-    },
-    "empty_value": "—",
-    "approve": "Freigeben",
-    "reject": "Ablehnen",
-    "reason": "Begründung (optional)",
-    "approved": "Änderung übernommen",
-    "rejected": "Änderung abgelehnt",
-    "decideError": "Die Entscheidung konnte nicht gespeichert werden."
-  },
   "parentOgsMessaging": {
     "readByStaff": "Gelesen"
   }

--- a/frontend/src/i18n/messages/en.json
+++ b/frontend/src/i18n/messages/en.json
@@ -888,40 +888,6 @@
       "fri": "Fri"
     }
   },
-  "staffMasterDataReview": {
-    "title": "Change requests",
-    "subtitle": "Master-data changes submitted by parents that need approval.",
-    "loadError": "The change requests could not be loaded.",
-    "empty": "No open change requests.",
-    "columns": {
-      "child": "Child",
-      "field": "Field",
-      "change": "Change",
-      "submitted": "Submitted",
-      "actions": "Action"
-    },
-    "fields": {
-      "first_name": "First name",
-      "last_name": "Last name",
-      "birthday": "Date of birth",
-      "health_info": "Health notes",
-      "email": "Email",
-      "primary": "Phone number",
-      "address_street": "Street",
-      "address_city": "City",
-      "address_postal_code": "Postal code",
-      "preferred_contact_method": "Contact method",
-      "language_preference": "Language",
-      "allowed_departure_modes": "Permanent ways home"
-    },
-    "empty_value": "—",
-    "approve": "Approve",
-    "reject": "Reject",
-    "reason": "Reason (optional)",
-    "approved": "Change applied",
-    "rejected": "Change rejected",
-    "decideError": "The decision could not be saved."
-  },
   "parentOgsMessaging": {
     "readByStaff": "Read"
   }

--- a/frontend/src/i18n/messages/ru.json
+++ b/frontend/src/i18n/messages/ru.json
@@ -888,40 +888,6 @@
       "fri": "Fr"
     }
   },
-  "staffMasterDataReview": {
-    "title": "Änderungsanfragen",
-    "subtitle": "Von Eltern eingereichte Änderungen an Stammdaten, die eine Freigabe benötigen.",
-    "loadError": "Die Änderungsanfragen konnten nicht geladen werden.",
-    "empty": "Keine offenen Änderungsanfragen.",
-    "columns": {
-      "child": "Kind",
-      "field": "Feld",
-      "change": "Änderung",
-      "submitted": "Eingereicht",
-      "actions": "Aktion"
-    },
-    "fields": {
-      "first_name": "Vorname",
-      "last_name": "Nachname",
-      "birthday": "Geburtsdatum",
-      "health_info": "Gesundheitshinweise",
-      "email": "E-Mail",
-      "primary": "Telefonnummer",
-      "address_street": "Straße",
-      "address_city": "Ort",
-      "address_postal_code": "PLZ",
-      "preferred_contact_method": "Kontaktweg",
-      "language_preference": "Sprache",
-      "allowed_departure_modes": "Dauerhafte Gehzeiten"
-    },
-    "empty_value": "—",
-    "approve": "Freigeben",
-    "reject": "Ablehnen",
-    "reason": "Begründung (optional)",
-    "approved": "Änderung übernommen",
-    "rejected": "Änderung abgelehnt",
-    "decideError": "Die Entscheidung konnte nicht gespeichert werden."
-  },
   "parentOgsMessaging": {
     "readByStaff": "Прочитано"
   }

--- a/frontend/src/i18n/messages/sq.json
+++ b/frontend/src/i18n/messages/sq.json
@@ -888,40 +888,6 @@
       "fri": "Fr"
     }
   },
-  "staffMasterDataReview": {
-    "title": "Änderungsanfragen",
-    "subtitle": "Von Eltern eingereichte Änderungen an Stammdaten, die eine Freigabe benötigen.",
-    "loadError": "Die Änderungsanfragen konnten nicht geladen werden.",
-    "empty": "Keine offenen Änderungsanfragen.",
-    "columns": {
-      "child": "Kind",
-      "field": "Feld",
-      "change": "Änderung",
-      "submitted": "Eingereicht",
-      "actions": "Aktion"
-    },
-    "fields": {
-      "first_name": "Vorname",
-      "last_name": "Nachname",
-      "birthday": "Geburtsdatum",
-      "health_info": "Gesundheitshinweise",
-      "email": "E-Mail",
-      "primary": "Telefonnummer",
-      "address_street": "Straße",
-      "address_city": "Ort",
-      "address_postal_code": "PLZ",
-      "preferred_contact_method": "Kontaktweg",
-      "language_preference": "Sprache",
-      "allowed_departure_modes": "Dauerhafte Gehzeiten"
-    },
-    "empty_value": "—",
-    "approve": "Freigeben",
-    "reject": "Ablehnen",
-    "reason": "Begründung (optional)",
-    "approved": "Änderung übernommen",
-    "rejected": "Änderung abgelehnt",
-    "decideError": "Die Entscheidung konnte nicht gespeichert werden."
-  },
   "parentOgsMessaging": {
     "readByStaff": "Lexuar"
   }


### PR DESCRIPTION
## Problem

Auf Staging zeigte die Admin-Seite **Änderungsanfragen** rohe i18n-Keys statt Text (`staffMasterDataReview.subtitle`, `…columns.field`, `…columns.change`, `…columns.actions`, `…empty`).

Ursache ist **kein** fehlender Übersetzungstext oder ein veralteter Deploy — die Keys sind in jedem deployten Build vorhanden. Die Seite (`change-requests/page.tsx`) und die Liste (`master-data-review-list.tsx`) sind Client-Komponenten (`"use client"`), die `useTranslations("staffMasterDataReview")` nutzen. Der deutschsprachige Staff-Bereich wird aber in `[tenant]/(protected)/layout.tsx` von `ShellNavIntlProvider` umschlossen, dessen `NextIntlClientProvider` **absichtlich nur** den `parentNav`-Namespace mitliefert (`NAV_MESSAGES`), um den Eltern-Katalog nicht in die Staff-Bundles zu schieben. Der Namespace `staffMasterDataReview` steht damit nie im Client-Provider-Kontext → next-intl rendert die rohen Key-Pfade.

Das Feature (#1787) ist von der Codebase-Konvention abgewichen: Staff-UI ist deutsch-only und **hartcodiert** ihre Strings (Sidebar-Labels in `sidebar.tsx`, die funktionierende Schwester-Seite `admin-enrollment-change-requests.tsx` nutzt 0× `useTranslations`).

## Fix

- `useTranslations("staffMasterDataReview")` aus `change-requests/page.tsx` und `master-data-review-list.tsx` entfernt; alle Texte hartcodiert in Deutsch (identische Strings wie im alten Namespace) — passend zum Rest der Staff-/Admin-UI.
- Feld-Labels in ein `FIELD_LABELS`-Record verschoben, `EMPTY_VALUE`-Konstante, `ReviewTranslator`-Typ entfernt, `t` aus den `useCallback`/`useMemo`-Deps genommen.
- Den jetzt verwaisten `staffMasterDataReview`-Namespace aus allen vier Locale-Katalogen (`de`/`en`/`sq`/`ru`) entfernt (Parität bleibt erhalten).

## Verifikation

- `pnpm run check` (verify-locales + oxlint + tsc): grün, keine Warnungen.
- Vollständige Vitest-Suite: 11000/11000 grün, inkl. der beiden betroffenen Testdateien. **Keine Tests geändert** — sie prüfen ohnehin die deutschen Strings, die identisch geblieben sind.