### PR TITLE
feat(messaging): show OGS staff sender name to parents (per-school opt-in)

### DIFF
--- a/backend/api/parent/child_messages_handlers.go
+++ b/backend/api/parent/child_messages_handlers.go
@@ -18,8 +18,10 @@ import (
 
 // MessageResponse is one message in a conversation. IDs stringified per the
 // int64 -> string frontend convention. sender_kind is "guardian" or "staff".
-// For staff messages sender_name is the OGS/school label, never an individual
-// staff member's name — the parent talks to "the OGS", not to a person.
+// For staff messages sender_name is either the neutral OGS/school label or the
+// individual staff member as "first name + last initial", depending on whether
+// the message froze staff-name visibility on at send time (see toMessageResponses
+// and operations.parent_message_staff_name_visible).
 type MessageResponse struct {
 	ID             string         `json:"id"`
 	SenderKind     string         `json:"sender_kind"`
@@ -130,15 +132,45 @@ func ogsLabel(schoolName string) string {
 	return strings.TrimSpace("OGS " + schoolName)
 }
 
-// toMessageResponses maps messages for the parent portal, replacing staff
-// sender names with the OGS/school label so individual staff names never leave
-// the backend.
+// staffShortName renders a staff member's stored full name as first name + last
+// initial (e.g. "Anna Müller" -> "Anna M.") for the guardian view: enough to
+// attribute a reply to a person without exposing the full surname. A single-token
+// name (or the "OGS-Team" fallback resolveStaffName stamps when no person is
+// linked) is returned unchanged. Rune-based so a non-ASCII surname initial (Ö, Ü)
+// is taken as one character, not a broken byte.
+func staffShortName(full string) string {
+	parts := strings.Fields(full)
+	if len(parts) < 2 {
+		return full
+	}
+	last := []rune(parts[len(parts)-1])
+	if len(last) == 0 {
+		return parts[0]
+	}
+	return parts[0] + " " + string(last[0]) + "."
+}
+
+// toMessageResponses maps messages for the parent portal. A staff sender is
+// shown as the individual person (first name + last initial) only when that
+// message froze StaffNameVisible=true at send time; otherwise it collapses to
+// the neutral "OGS [Schulname]" label. Guardian/system rows pass through
+// unchanged.
 func toMessageResponses(messages []*usersModels.ParentMessage, counterpart string, diffs map[int64][]messagingService.RequestDiffEntry) []MessageResponse {
 	out := make([]MessageResponse, 0, len(messages))
 	for _, m := range messages {
 		senderName := m.SenderName
 		if m.SenderKind == usersModels.ParentMessageSenderStaff {
-			senderName = counterpart
+			// StaffNameVisible is frozen per message at send time (see the model +
+			// the operations.parent_message_staff_name_visible setting): true only
+			// on replies written while the school had staff-name attribution on. So
+			// older replies (and every reply when the school keeps it off) still
+			// collapse to the neutral "OGS [Schulname]" label, while opted-in
+			// replies show the person as "Vorname N.".
+			if m.StaffNameVisible {
+				senderName = staffShortName(m.SenderName)
+			} else {
+				senderName = counterpart
+			}
 		}
 		refID := ""
 		if m.RefID != nil {

--- a/backend/api/parent/handler_helpers_test.go
+++ b/backend/api/parent/handler_helpers_test.go
@@ -17,6 +17,7 @@ import (
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
 	parentModels "github.com/moto-nrw/project-phoenix/models/parent"
 	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
+	usersModels "github.com/moto-nrw/project-phoenix/models/users"
 	authService "github.com/moto-nrw/project-phoenix/services/auth"
 	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
 	platformSvc "github.com/moto-nrw/project-phoenix/services/platform"
@@ -351,4 +352,60 @@ func TestToChildResponse_StringifiesIDs(t *testing.T) {
 	require.NotNil(t, out.EnrolledFrom)
 	assert.Equal(t, now, *out.EnrolledFrom)
 	assert.Nil(t, out.EnrolledUntil, "nil pointers pass through unchanged")
+}
+
+// --- staffShortName ------------------------------------------------------
+
+func TestStaffShortName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Anna Müller", "Anna M."},
+		{"Sabine Schneider", "Sabine S."},
+		{"Anna-Lena Öztürk", "Anna-Lena Ö."}, // rune-based initial, not a broken byte
+		{"Anna von Berg", "Anna B."},         // multi-token: first + LAST initial
+		{"Olivia", "Olivia"},                 // single token unchanged
+		{"OGS-Team", "OGS-Team"},             // resolveStaffName fallback unchanged
+		{"", ""},                             // empty stays empty
+	}
+	for _, tc := range cases {
+		assert.Equalf(t, tc.want, staffShortName(tc.in), "staffShortName(%q)", tc.in)
+	}
+}
+
+// --- toMessageResponses staff-name masking -------------------------------
+
+func TestToMessageResponses_StaffNameMaskedUnlessVisible(t *testing.T) {
+	counterpart := "OGS Sonnenschule"
+	messages := []*usersModels.ParentMessage{
+		{
+			// Frozen visible=false (older reply / school opted out): stays anonymous.
+			SenderKind:       usersModels.ParentMessageSenderStaff,
+			SenderName:       "Sabine Schneider",
+			StaffNameVisible: false,
+			Body:             "hidden",
+		},
+		{
+			// Frozen visible=true (reply written while the setting was on): shows the
+			// person as first name + last initial, never the full surname.
+			SenderKind:       usersModels.ParentMessageSenderStaff,
+			SenderName:       "Sabine Schneider",
+			StaffNameVisible: true,
+			Body:             "shown",
+		},
+		{
+			// Guardian messages are never masked and never short-formed.
+			SenderKind:       usersModels.ParentMessageSenderGuardian,
+			SenderName:       "Olivia Berg",
+			StaffNameVisible: false,
+			Body:             "parent",
+		},
+	}
+
+	out := toMessageResponses(messages, counterpart, nil)
+	require.Len(t, out, 3)
+	assert.Equal(t, counterpart, out[0].SenderName, "masked staff reply collapses to the OGS label")
+	assert.Equal(t, "Sabine S.", out[1].SenderName, "visible staff reply shows first name + last initial")
+	assert.Equal(t, "Olivia Berg", out[2].SenderName, "guardian name passes through unchanged")
 }

--- a/backend/database/migrations/001015157_parent_message_staff_name_visibility.go
+++ b/backend/database/migrations/001015157_parent_message_staff_name_visibility.go
@@ -1,0 +1,86 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	parentMessageStaffNameVisibilityVersion     = "1.15.157"
+	parentMessageStaffNameVisibilityDescription = "Per-message frozen flag for showing the staff sender's name to guardians (#1672)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     parentMessageStaffNameVisibilityVersion,
+		Description: parentMessageStaffNameVisibilityDescription,
+		DependsOn:   []string{parentMessagingRequestsVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return parentMessageStaffNameVisibilityUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return parentMessageStaffNameVisibilityDown(ctx, db)
+		},
+	)
+}
+
+func parentMessageStaffNameVisibilityUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.157: Adding staff_name_visible to parent messages...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	// DEFAULT false backfills every EXISTING row to "keep the OGS label". Those
+	// replies were written while individual staff names never left the backend, so
+	// they must stay anonymous even after a school enables the setting — the
+	// "reveal only from activation onwards" rule. New staff messages get their
+	// value stamped explicitly by the send path (frozen at write time), so the
+	// column default only ever applies to this backfill.
+	_, err = tx.ExecContext(ctx, `
+		ALTER TABLE users.parent_messages
+			ADD COLUMN IF NOT EXISTS staff_name_visible BOOLEAN NOT NULL DEFAULT false;
+	`)
+	if err != nil {
+		return fmt.Errorf("error adding users.parent_messages.staff_name_visible: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+func parentMessageStaffNameVisibilityDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.157: Removing parent_messages.staff_name_visible...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		ALTER TABLE users.parent_messages
+			DROP COLUMN IF EXISTS staff_name_visible;
+	`)
+	if err != nil {
+		return fmt.Errorf("error removing users.parent_messages.staff_name_visible: %w", err)
+	}
+
+	return tx.Commit()
+}

--- a/backend/database/migrations/001015158_parent_message_staff_name_visibility.go
+++ b/backend/database/migrations/001015158_parent_message_staff_name_visibility.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	parentMessageStaffNameVisibilityVersion     = "1.15.157"
+	parentMessageStaffNameVisibilityVersion     = "1.15.158"
 	parentMessageStaffNameVisibilityDescription = "Per-message frozen flag for showing the staff sender's name to guardians (#1672)"
 )
 
@@ -32,7 +32,7 @@ func init() {
 }
 
 func parentMessageStaffNameVisibilityUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.157: Adding staff_name_visible to parent messages...")
+	fmt.Println("Migration 1.15.158: Adding staff_name_visible to parent messages...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
@@ -62,7 +62,7 @@ func parentMessageStaffNameVisibilityUp(ctx context.Context, db *bun.DB) error {
 }
 
 func parentMessageStaffNameVisibilityDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.157: Removing parent_messages.staff_name_visible...")
+	fmt.Println("Rolling back migration 1.15.158: Removing parent_messages.staff_name_visible...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -125,6 +125,7 @@ const (
 	KeyCareConcept                     = "operations.care_concept"
 	KeyParentSickNoteEnabled           = "operations.parent_sick_note_enabled"
 	KeyParentNotesEnabled              = "operations.parent_notes_enabled"
+	KeyParentMessageStaffNameVisible   = "operations.parent_message_staff_name_visible"
 	KeyParentPickupChangeEnabled       = "operations.parent_pickup_change_enabled"
 	KeyParentGuardianManagementEnabled = "operations.parent_guardian_management_enabled"
 	KeyParentMasterDataEditEnabled     = "operations.parent_master_data_edit_enabled"

--- a/backend/models/users/parent_message.go
+++ b/backend/models/users/parent_message.go
@@ -34,7 +34,17 @@ type ParentMessage struct {
 	SenderAccountID int64  `bun:"sender_account_id,notnull" json:"sender_account_id"`
 	SenderKind      string `bun:"sender_kind,notnull" json:"sender_kind"`
 	SenderName      string `bun:"sender_name,notnull" json:"sender_name"`
-	Body            string `bun:"body,notnull" json:"body"`
+	// StaffNameVisible freezes, at send time, whether this staff message may show
+	// the individual sender's name to guardians (the value of the
+	// operations.parent_message_staff_name_visible setting when the row was
+	// written). Frozen per-row — exactly like SenderName — so toggling the setting
+	// later never retroactively reveals or re-hides already-sent replies: only
+	// messages written while the setting was on carry true. Meaningful only for
+	// sender_kind='staff'; always false on guardian/system rows. The parent-facing
+	// serializer shows the person's name only when this is true, else the neutral
+	// "OGS [Schulname]" label.
+	StaffNameVisible bool   `bun:"staff_name_visible,notnull,default:false" json:"staff_name_visible"`
+	Body             string `bun:"body,notnull" json:"body"`
 	// Kind discriminates a plain chat message ('message') from a system event
 	// ('event', e.g. a quick-action pill posting a Raumwechsel/Abholung notice
 	// into the thread) and a structured change request ('request'). Defaults to

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -113,6 +113,7 @@ func TestAllSettingsRegistered(t *testing.T) {
 		// Parents-portal write features.
 		"operations.parent_sick_note_enabled",
 		"operations.parent_notes_enabled",
+		"operations.parent_message_staff_name_visible",
 		"operations.parent_pickup_change_enabled",
 		"operations.parent_guardian_management_enabled",
 		"operations.parent_master_data_edit_enabled",
@@ -176,6 +177,23 @@ func TestGuardianRelatedAccountsSettings(t *testing.T) {
 	assert.Equal(t, config.KeyGuardianParentInviteMode, removeDef.DependsOn.Key)
 	assert.Equal(t, "neq", removeDef.DependsOn.Condition)
 	assert.Equal(t, config.ParentInviteModeDisabled, removeDef.DependsOn.Value)
+}
+
+func TestParentMessageStaffNameVisibleSetting(t *testing.T) {
+	def := config.GetDefinition(config.KeyParentMessageStaffNameVisible)
+	require.NotNil(t, def, "operations.parent_message_staff_name_visible should be registered")
+	assert.Equal(t, config.FieldBoolean, def.Type)
+	// Default ON: a messaging-active school attributes team replies to a person
+	// by default. "Only from activation" is enforced per-message at send time
+	// (staff_name_visible column), not by a restrictive default here.
+	assert.Equal(t, true, def.Default, "staff-name visibility must default on")
+	assert.Equal(t, "config:update", def.WritePermission)
+	assert.Equal(t, "operations", def.Tab)
+	// Hidden unless messaging itself is on — it only affects those messages.
+	require.NotNil(t, def.DependsOn, "should be hidden when parent messaging is off")
+	assert.Equal(t, config.KeyParentNotesEnabled, def.DependsOn.Key)
+	assert.Equal(t, "eq", def.DependsOn.Condition)
+	assert.Equal(t, true, def.DependsOn.Value)
 }
 
 func TestWebCheckinAccessSetting(t *testing.T) {

--- a/backend/services/config/defaults/operations.go
+++ b/backend/services/config/defaults/operations.go
@@ -487,6 +487,32 @@ func init() {
 		SortOrder:       61,
 	})
 
+	// Whether a guardian sees the individual staff member's name (first name +
+	// last initial, e.g. "Anna M.") on team replies instead of the neutral
+	// "OGS [Schulname]" label. Defaults ON so a messaging-active school attributes
+	// replies to a person by default. Only messages SENT while this is on are
+	// revealed: the per-message visibility is frozen at send time on
+	// users.parent_messages.staff_name_visible, so enabling it never retroactively
+	// exposes older replies written under anonymity. Hidden in the UI unless
+	// messaging (parent_notes_enabled) is on, since it only affects those messages.
+	config.Register(config.Definition{
+		Key:             config.KeyParentMessageStaffNameVisible,
+		Label:           "Name des Teammitglieds in Nachrichten anzeigen",
+		Description:     "Wenn aktiviert, sehen Eltern bei Antworten des Teams den Vornamen und den ersten Buchstaben des Nachnamens der antwortenden Person (z. B. „Anna M.“) statt nur „OGS [Schulname]“. Gilt nur für Nachrichten, die ab der Aktivierung geschrieben werden; ältere Nachrichten bleiben anonym. Bereits mit Namen gesendete Nachrichten bleiben sichtbar, wenn die Funktion später wieder deaktiviert wird.",
+		Type:            config.FieldBoolean,
+		Default:         true,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "elternportal",
+		SortOrder:       62,
+		DependsOn: &config.Dependency{
+			Key:       config.KeyParentNotesEnabled,
+			Condition: "eq",
+			Value:     true,
+		},
+	})
+
 	// Related-accounts management. Whether a parent may invite further
 	// guardians to their own child, and whether they may revoke another
 	// account's access. Sensitive (controls access to child data) -> manage.
@@ -500,7 +526,7 @@ func init() {
 		WritePermission: "config:manage",
 		Tab:             "operations",
 		Category:        "elternportal",
-		SortOrder:       62,
+		SortOrder:       63,
 		Options: &config.SelectOptions{
 			Static: []config.SelectOption{
 				{Label: "Deaktiviert", Value: config.ParentInviteModeDisabled},
@@ -520,7 +546,7 @@ func init() {
 		WritePermission: "config:manage",
 		Tab:             "operations",
 		Category:        "elternportal",
-		SortOrder:       63,
+		SortOrder:       64,
 		DependsOn: &config.Dependency{
 			Key:       config.KeyGuardianParentInviteMode,
 			Condition: "neq",
@@ -538,7 +564,7 @@ func init() {
 		WritePermission: "config:update",
 		Tab:             "operations",
 		Category:        "elternportal",
-		SortOrder:       64,
+		SortOrder:       65,
 	})
 
 	config.Register(config.Definition{
@@ -551,7 +577,7 @@ func init() {
 		WritePermission: "config:manage",
 		Tab:             "operations",
 		Category:        "elternportal",
-		SortOrder:       65,
+		SortOrder:       66,
 	})
 
 	// Defaults ON, like the other parents-portal write features. The
@@ -574,7 +600,7 @@ func init() {
 		WritePermission: "config:manage",
 		Tab:             "operations",
 		Category:        "elternportal",
-		SortOrder:       66,
+		SortOrder:       67,
 	})
 
 	config.Register(config.Definition{
@@ -587,6 +613,6 @@ func init() {
 		WritePermission: "config:update",
 		Tab:             "operations",
 		Category:        "elternportal",
-		SortOrder:       67,
+		SortOrder:       68,
 	})
 }

--- a/backend/services/messaging/service.go
+++ b/backend/services/messaging/service.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	configModels "github.com/moto-nrw/project-phoenix/models/config"
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/realtime"
 	configService "github.com/moto-nrw/project-phoenix/services/config"
@@ -624,13 +625,14 @@ func (s *service) ListStudentThreads(ctx context.Context, studentID int64) ([]*u
 // created_at" rule).
 func (s *service) appendStaffMessage(ctx context.Context, thread *usersModels.ParentMessageThread, accountID int64, body string) error {
 	msg := &usersModels.ParentMessage{
-		ThreadID:        thread.ID,
-		StudentID:       thread.StudentID,
-		SenderAccountID: accountID,
-		SenderKind:      usersModels.ParentMessageSenderStaff,
-		SenderName:      s.resolveStaffName(ctx, accountID),
-		Body:            body,
-		Kind:            usersModels.ParentMessageKindMessage,
+		ThreadID:         thread.ID,
+		StudentID:        thread.StudentID,
+		SenderAccountID:  accountID,
+		SenderKind:       usersModels.ParentMessageSenderStaff,
+		SenderName:       s.resolveStaffName(ctx, accountID),
+		StaffNameVisible: s.staffNameVisibleToParents(ctx),
+		Body:             body,
+		Kind:             usersModels.ParentMessageKindMessage,
 	}
 	msg.SetTenantID(thread.TenantID)
 	if err := parentmessaging.AppendMessage(ctx, s.messageRepo, s.threadRepo, msg); err != nil {
@@ -666,6 +668,27 @@ func (s *service) resolveStaffName(ctx context.Context, accountID int64) string 
 		name = full
 	}
 	return name
+}
+
+// staffNameVisibleToParents resolves whether team replies should attribute the
+// individual staff member to guardians, to be FROZEN onto the message at send
+// time (users.parent_messages.staff_name_visible). It is read only here, on the
+// write path: the parent-facing read path trusts the stamped column, so a later
+// toggle never rewrites history. Fails to the registry default direction (true)
+// on a transient config-DB error, mirroring MessagingEnabled's fail-open — a
+// blip must not silently strip attribution the school opted into by default.
+func (s *service) staffNameVisibleToParents(ctx context.Context) bool {
+	if s.settings == nil {
+		return true
+	}
+	visible, err := s.settings.ResolveBool(ctx, configModels.KeyParentMessageStaffNameVisible)
+	if err != nil {
+		s.logger.Warn("messaging: resolve staff-name visibility failed, defaulting to visible",
+			slog.String("error", err.Error()),
+		)
+		return true
+	}
+	return visible
 }
 
 // broadcastAfterCommit queues the SSE wake-up to fire only AFTER the request

--- a/backend/services/messaging/service.go
+++ b/backend/services/messaging/service.go
@@ -674,19 +674,21 @@ func (s *service) resolveStaffName(ctx context.Context, accountID int64) string 
 // individual staff member to guardians, to be FROZEN onto the message at send
 // time (users.parent_messages.staff_name_visible). It is read only here, on the
 // write path: the parent-facing read path trusts the stamped column, so a later
-// toggle never rewrites history. Fails to the registry default direction (true)
-// on a transient config-DB error, mirroring MessagingEnabled's fail-open — a
-// blip must not silently strip attribution the school opted into by default.
+// toggle never rewrites history. Unlike MessagingEnabled it fails CLOSED (false,
+// anonymous) on a transient config-DB error: the flag exposes staff personal
+// data and is frozen per message, so a blip must not permanently reveal a name
+// for a school that explicitly opted out. Anonymizing one message is
+// recoverable and privacy-safe; a wrongful disclosure is neither.
 func (s *service) staffNameVisibleToParents(ctx context.Context) bool {
 	if s.settings == nil {
-		return true
+		return false
 	}
 	visible, err := s.settings.ResolveBool(ctx, configModels.KeyParentMessageStaffNameVisible)
 	if err != nil {
-		s.logger.Warn("messaging: resolve staff-name visibility failed, defaulting to visible",
+		s.logger.Warn("messaging: resolve staff-name visibility failed, defaulting to anonymous",
 			slog.String("error", err.Error()),
 		)
-		return true
+		return false
 	}
 	return visible
 }

--- a/backend/services/messaging/service_test.go
+++ b/backend/services/messaging/service_test.go
@@ -48,6 +48,10 @@ import (
 type stubSettings struct {
 	configService.SettingsService
 	messagingEnabled bool
+	// staffNameVisible answers operations.parent_message_staff_name_visible, the
+	// flag the send path freezes onto each staff message. Defaults false so
+	// existing tests exercise the masked ("OGS") path unchanged.
+	staffNameVisible bool
 	// dataScope, when set, makes the gdpr.student_data_scope lookups report an
 	// override of this value so CanReadStudent relaxes reads (e.g. "all_staff").
 	// Empty (the default) keeps the restrictive group-supervisors-only behavior.
@@ -55,10 +59,14 @@ type stubSettings struct {
 }
 
 func (s stubSettings) ResolveBool(_ context.Context, key string) (bool, error) {
-	if key == configModels.KeyParentNotesEnabled {
+	switch key {
+	case configModels.KeyParentNotesEnabled:
 		return s.messagingEnabled, nil
+	case configModels.KeyParentMessageStaffNameVisible:
+		return s.staffNameVisible, nil
+	default:
+		return false, nil
 	}
-	return false, nil
 }
 
 func (s stubSettings) HasTenantOverride(_ context.Context, key string) (bool, error) {
@@ -143,7 +151,7 @@ func newPersons(repos *repositories.Factory, db *bun.DB) usersService.PersonServ
 	})
 }
 
-func buildMessaging(t *testing.T, enabled bool) (messaging.Service, *captureBroadcaster, *repositories.Factory, *bun.DB) {
+func buildMessagingWithSettings(t *testing.T, settings stubSettings) (messaging.Service, *captureBroadcaster, *repositories.Factory, *bun.DB) {
 	t.Helper()
 	db := testpkg.SetupTestDB(t)
 	t.Cleanup(func() { _ = db.Close() })
@@ -161,7 +169,7 @@ func buildMessaging(t *testing.T, enabled bool) (messaging.Service, *captureBroa
 		Persons:     newPersons(repos, db),
 		Arrival:     serviceFactory.ArrivalSchedule,
 		Pickup:      serviceFactory.PickupSchedule,
-		Settings:    stubSettings{messagingEnabled: enabled},
+		Settings:    settings,
 		Broadcaster: bc,
 		DB:          db,
 		Logger:      slog.Default(),
@@ -185,8 +193,12 @@ func claimsCtx(accountID int64, perms []string) context.Context {
 // newFixture wires the full messaging stack plus a parent→child chain and a
 // distinct staff reader account, with cleanup registered.
 func newFixture(t *testing.T, enabled bool) *fixture {
+	return newFixtureWithSettings(t, stubSettings{messagingEnabled: enabled})
+}
+
+func newFixtureWithSettings(t *testing.T, settings stubSettings) *fixture {
 	t.Helper()
-	svc, bc, _, db := buildMessaging(t, enabled)
+	svc, bc, _, db := buildMessagingWithSettings(t, settings)
 	chain := testpkg.CreateTestParentGuardianChain(t, db)
 	t.Cleanup(func() { testpkg.CleanupParentGuardianChain(t, db, chain) })
 	staff, staffAccount := testpkg.CreateTestStaffWithAccount(t, db, "Olivia", "Berg")
@@ -258,6 +270,29 @@ func TestStartThread_CreatesConversationAndBroadcasts(t *testing.T) {
 	assert.Equal(t, "Guten Tag, bitte um Rückruf", detail.Messages[0].Body)
 
 	assert.Equal(t, 1, f.bc.countOf(realtime.EventParentMessage), "a staff send wakes the guardian with a new-message event")
+}
+
+// TestStartThread_StampsStaffNameVisibleFromSetting proves the send path FREEZES
+// the operations.parent_message_staff_name_visible setting onto each staff
+// message at write time (users.parent_messages.staff_name_visible). That frozen
+// column — not a live re-read — is what the parent view later uses, so a message
+// keeps the visibility it was sent with even if the school toggles the setting.
+func TestStartThread_StampsStaffNameVisibleFromSetting(t *testing.T) {
+	t.Run("setting on -> stamped visible", func(t *testing.T) {
+		f := newFixtureWithSettings(t, stubSettings{messagingEnabled: true, staffNameVisible: true})
+		detail, err := f.svc.StartThread(adminCtx(f.staffAccount), f.chain.StudentID, f.chain.AccountID, "Hallo")
+		require.NoError(t, err)
+		require.Len(t, detail.Messages, 1)
+		assert.True(t, detail.Messages[0].StaffNameVisible, "reply sent while the setting is on must be stamped visible")
+	})
+
+	t.Run("setting off -> stamped hidden", func(t *testing.T) {
+		f := newFixtureWithSettings(t, stubSettings{messagingEnabled: true, staffNameVisible: false})
+		detail, err := f.svc.StartThread(adminCtx(f.staffAccount), f.chain.StudentID, f.chain.AccountID, "Hallo")
+		require.NoError(t, err)
+		require.Len(t, detail.Messages, 1)
+		assert.False(t, detail.Messages[0].StaffNameVisible, "reply sent while the setting is off stays anonymous")
+	})
 }
 
 // TestStartThread_IsGetOrCreate verifies the chat model: a second StartThread for

--- a/frontend/src/components/messaging/chat-bubble.tsx
+++ b/frontend/src/components/messaging/chat-bubble.tsx
@@ -18,6 +18,7 @@ export function ChatBubble({
   senderName,
   createdAt,
   readReceiptLabel,
+  showOwnSenderName = true,
 }: Readonly<{
   body: string;
   own: boolean;
@@ -26,7 +27,15 @@ export function ChatBubble({
   // Shown after the timestamp on an own message the other side has read, e.g.
   // "Gelesen". Omit to show no read receipt.
   readReceiptLabel?: string;
+  // Whether to print the sender's name on the viewer's OWN bubbles. The parent
+  // view sets this false: a thread has a single guardian account, so every own
+  // (guardian) bubble is the logged-in parent — the name is pure noise there.
+  // The staff view keeps it true: several colleagues share a thread, so the
+  // name disambiguates which one replied. Only affects own bubbles; the other
+  // side's name always shows.
+  showOwnSenderName?: boolean;
 }>) {
+  const hideName = own && !showOwnSenderName;
   return (
     <div className={`flex flex-col ${own ? "items-end" : "items-start"}`}>
       <div
@@ -37,7 +46,8 @@ export function ChatBubble({
         {body}
       </div>
       <p className="mt-1 px-1 text-xs text-gray-400">
-        {senderName} · {formatChatTime(createdAt)}
+        {hideName ? "" : `${senderName} · `}
+        {formatChatTime(createdAt)}
         {readReceiptLabel ? ` · ${readReceiptLabel}` : ""}
       </p>
     </div>

--- a/frontend/src/components/parent/ogs-conversation.tsx
+++ b/frontend/src/components/parent/ogs-conversation.tsx
@@ -314,6 +314,10 @@ export function OgsConversation({
                   own={message.sender_kind === "guardian"}
                   senderName={message.sender_name}
                   createdAt={message.created_at}
+                  // The parent's own bubbles are always the logged-in guardian
+                  // (one guardian account per thread), so drop the redundant name
+                  // and keep just the time. Staff bubbles still show "Vorname N.".
+                  showOwnSenderName={false}
                   readReceiptLabel={
                     message.sender_kind === "guardian" && message.read_by_staff
                       ? t("readByStaff")


### PR DESCRIPTION
Closes #1801

## Was

Eltern sehen im Nachrichten-Chat bisher nur das anonyme Label „OGS [Schulname]". Dieser PR macht sichtbar, welche OGS-Kraft geantwortet hat, als „Vorname N." (z. B. „Anna M.").

**Standard: AN.** Für jede Schule mit aktiviertem Messaging ist die Namensanzeige per Registry-Default (`operations.parent_message_staff_name_visible = true`) eingeschaltet — es ist ein **Opt-out**: eine Schule kann es in den Einstellungen abschalten, dann bleibt es beim neutralen „OGS [Schulname]".

## Details

- **Pro Nachricht eingefroren:** Beim Senden wird der damalige Zustand der Einstellung auf die Zeile gestempelt (`users.parent_messages.staff_name_visible`). Ein späteres Umschalten verändert bereits gesendete Antworten also **nicht** rückwirkend.
- **Bestehende Nachrichten bleiben anonym:** Die Migration backfillt alle Alt-Zeilen mit `false`. Obwohl der Default AN ist, tragen nur *ab jetzt* geschriebene Antworten den Namen — Altbestand wird nicht rückwirkend enthüllt.
- **Datenschutz:** Der volle Nachname verlässt das Backend nie; die Serialisierung kürzt auf Vorname + Anfangsbuchstabe (rune-basiert, damit Ö/Ü sauber sind). Fallback auf „OGS [Schulname]", wenn keine Person auflösbar ist.
- **Fail closed:** Bei einem Config-DB-Fehler auf dem Schreibpfad wird `false` (anonym) eingefroren — eine versehentliche Namensfreigabe soll ausgeschlossen sein.
- **Eltern-UX-Politur:** In der Eltern-Ansicht wird der eigene Name auf **ausgehenden** Nachrichten nicht mehr angezeigt (ein Thread hat genau ein Guardian-Konto → der eigene Name ist redundant). Die geteilte `ChatBubble` bekommt dafür `showOwnSenderName` (Default `true`); nur die Eltern-Ansicht optet aus, die OGS-Ansicht behält die Kollegennamen.

## Migration

`1.15.157` — fügt `users.parent_messages.staff_name_visible` (BOOLEAN NOT NULL DEFAULT false) hinzu. Bestehende Zeilen bleiben anonym.

## Test

- Backend: Service- und Handler-Tests für Namensauflösung + Sichtbarkeit erweitert; Settings-Defaults-Tests angepasst.
- Frontend: `pnpm run check` grün (verify-locales + oxlint + tsc).
- Manuell im Eltern-Portal geprüft (AN → „Anna M.", abgeschaltet → „OGS Demo School"; eigene Nachricht ohne Namen, „Gelesen"-Badge intakt). Screenshots reiche ich am PR nach.

## QA offen

- [ ] Operator-/Einstellungs-UI zum Umschalten sichten
- [ ] Verhalten bei entferntem Konto (Fallback „OGS") in Ruhe gegenprüfen