### PR TITLE
fix(parents): einheitliche volle Breite im Elternportal (max-w-7xl)

### DIFF
--- a/frontend/src/app/parents/messages/page.tsx
+++ b/frontend/src/app/parents/messages/page.tsx
@@ -337,7 +337,7 @@ function EmptyMessages() {
 
 function ParentMessagesSkeleton() {
   return (
-    <div className="mx-auto w-full max-w-5xl">
+    <div className="mx-auto w-full max-w-7xl">
       <Skeleton className="h-[calc(100dvh-13rem)] min-h-[20rem] rounded-2xl border border-gray-200 bg-white shadow-sm lg:h-[calc(100dvh-8.5rem)]" />
     </div>
   );

--- a/frontend/src/components/parent/child-master-data.tsx
+++ b/frontend/src/components/parent/child-master-data.tsx
@@ -72,7 +72,7 @@ export function ChildMasterDataView({ studentId }: Props) {
 
   if (loading) {
     return (
-      <div className="mx-auto w-full max-w-3xl space-y-4">
+      <div className="mx-auto w-full max-w-7xl space-y-4">
         <div className="h-40 animate-pulse rounded-2xl border border-gray-200 bg-white shadow-sm" />
         <div className="h-64 animate-pulse rounded-2xl border border-gray-200 bg-white shadow-sm" />
       </div>
@@ -81,7 +81,7 @@ export function ChildMasterDataView({ studentId }: Props) {
 
   if (error || !data || !features) {
     return (
-      <div className="mx-auto w-full max-w-3xl">
+      <div className="mx-auto w-full max-w-7xl">
         <BackBar studentId={studentId} />
         <div className="mt-4 rounded-2xl border border-[#FF3130]/20 bg-[#FF3130]/10 p-5 text-sm text-[#CC2626] shadow-sm">
           {t("loadError")}
@@ -144,7 +144,7 @@ function ChildMasterDataContent({
   );
 
   return (
-    <div className="mx-auto w-full max-w-3xl space-y-6">
+    <div className="mx-auto w-full max-w-7xl space-y-6">
       <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
         <BackBar studentId={studentId} />
         <div className="p-5 sm:p-6">

--- a/frontend/src/components/parent/ogs-conversation.tsx
+++ b/frontend/src/components/parent/ogs-conversation.tsx
@@ -255,7 +255,7 @@ export function OgsConversation({
   return (
     <div
       ref={containerRef}
-      className="mx-auto flex min-h-[20rem] w-full max-w-5xl flex-col gap-3 overflow-hidden"
+      className="mx-auto flex min-h-[20rem] w-full max-w-7xl flex-col gap-3 overflow-hidden"
     >
       {showBack ? <BackBar /> : null}
 

--- a/frontend/src/components/parent/parent-meal-plan-page.tsx
+++ b/frontend/src/components/parent/parent-meal-plan-page.tsx
@@ -234,7 +234,7 @@ export function ParentMealPlanPage() {
 
   if (loadingSchools) {
     return (
-      <div className="mx-auto w-full max-w-3xl">
+      <div className="mx-auto w-full max-w-7xl">
         <Loading fullPage={false} />
       </div>
     );


### PR DESCRIPTION
Das Elternportal hatte uneinheitliche Seitenbreiten. Hier vereinheitlicht auf `max-w-7xl` wie die Startseite (Stammdaten, Nachrichten, Essensplan-Ladezustand).