### PR TITLE
Sort class lists with German collation (#1795)

### DIFF
--- a/backend/api/rooms/export_handlers.go
+++ b/backend/api/rooms/export_handlers.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/internal/collation"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/services/facilities"
 	"github.com/moto-nrw/project-phoenix/services/listexport"
@@ -262,7 +263,7 @@ func buildRoomSnapshotRows(locations []roomSnapshotLocation, studentsByID map[in
 			}
 		}
 		sort.SliceStable(students, func(i, j int) bool {
-			return strings.ToLower(students[i].Name) < strings.ToLower(students[j].Name)
+			return collation.CompareGerman(students[i].Name, students[j].Name) < 0
 		})
 
 		if len(students) == 0 {

--- a/backend/api/rooms/export_handlers_test.go
+++ b/backend/api/rooms/export_handlers_test.go
@@ -73,3 +73,27 @@ func TestRoomSnapshotSubtitleIncludesTransit(t *testing.T) {
 		t.Fatalf("subtitle = %q", subtitle)
 	}
 }
+
+func TestBuildRoomSnapshotRowsGermanNameOrder(t *testing.T) {
+	locations := []roomSnapshotLocation{
+		{Name: "Raum 101", StudentIDs: []int64{1, 2, 3, 4}},
+	}
+	students := map[int64]roomSnapshotStudent{
+		1: {ID: 1, Name: "Jan Zimmermann"},
+		2: {ID: 2, Name: "Emre Özdemir"},
+		3: {ID: 3, Name: "lena ärmel"},
+		4: {ID: 4, Name: "Ben Anders"},
+	}
+
+	rows := buildRoomSnapshotRows(locations, students)
+
+	want := []string{"Ben Anders", "Emre Özdemir", "Jan Zimmermann", "lena ärmel"}
+	if len(rows) != len(want) {
+		t.Fatalf("row count = %d, want %d", len(rows), len(want))
+	}
+	for i, name := range want {
+		if got := rows[i].Values[listexport.ColumnStudentName]; got != name {
+			t.Fatalf("row %d student = %q, want %q", i, got, name)
+		}
+	}
+}

--- a/backend/api/students/export_handlers.go
+++ b/backend/api/students/export_handlers.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/internal/collation"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/models/users"
@@ -246,10 +247,7 @@ func sortExportResponses(students []StudentResponse, sortMode string) {
 		if sortMode == "arrival" {
 			return timeValue(a.ArrivalTime) < timeValue(b.ArrivalTime)
 		}
-		if strings.EqualFold(a.LastName, b.LastName) {
-			return strings.ToLower(a.FirstName) < strings.ToLower(b.FirstName)
-		}
-		return strings.ToLower(a.LastName) < strings.ToLower(b.LastName)
+		return collation.CompareGermanNames(a.LastName, a.FirstName, b.LastName, b.FirstName) < 0
 	})
 }
 

--- a/backend/api/students/export_handlers_test.go
+++ b/backend/api/students/export_handlers_test.go
@@ -443,3 +443,51 @@ func TestDepartureSummary(t *testing.T) {
 		})
 	}
 }
+
+func TestSortExportResponsesGermanNameOrder(t *testing.T) {
+	responses := []StudentResponse{
+		{FirstName: "Jan", LastName: "Zimmermann"},
+		{FirstName: "Emre", LastName: "Özdemir"},
+		{FirstName: "Lena", LastName: "Ärmel"},
+		{FirstName: "Ben", LastName: "Müller"},
+		{FirstName: "Anna", LastName: "Müller"},
+		{FirstName: "Tim", LastName: "Mueller"},
+		{FirstName: "Ida", LastName: "von Berg"},
+		{FirstName: "Ali", LastName: "anders"},
+	}
+
+	sortExportResponses(responses, "")
+
+	got := make([]string, 0, len(responses))
+	for _, r := range responses {
+		got = append(got, r.LastName+", "+r.FirstName)
+	}
+	want := []string{
+		"anders, Ali",
+		"Ärmel, Lena",
+		"Mueller, Tim",
+		"Müller, Anna",
+		"Müller, Ben",
+		"Özdemir, Emre",
+		"von Berg, Ida",
+		"Zimmermann, Jan",
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestSortExportResponsesPickupStaysTimeOnly(t *testing.T) {
+	early := "12:00"
+	late := "16:00"
+	responses := []StudentResponse{
+		{FirstName: "Jan", LastName: "Zimmermann", PickupTime: &late},
+		{FirstName: "Lena", LastName: "Ärmel", PickupTime: &late},
+		{FirstName: "Anna", LastName: "Müller", PickupTime: &early},
+	}
+
+	sortExportResponses(responses, "pickup")
+
+	// Times decide; equal times keep incoming order (stable sort, no name tiebreak).
+	assert.Equal(t, "Müller", responses[0].LastName)
+	assert.Equal(t, "Zimmermann", responses[1].LastName)
+	assert.Equal(t, "Ärmel", responses[2].LastName)
+}

--- a/backend/internal/collation/collation.go
+++ b/backend/internal/collation/collation.go
@@ -1,0 +1,41 @@
+// Package collation provides German-locale string comparison for
+// user-visible name sorting (class lists, exports). It uses CLDR
+// dictionary order (DIN 5007-1): umlauts group with their base letter
+// (Ärmel sorts between Anders and Becker) instead of after 'z' as with
+// byte-order comparison. This matches the frontend's
+// localeCompare(..., "de"), so UI lists and exports agree.
+package collation
+
+import (
+	"sync"
+
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
+)
+
+// collate.Collator is not safe for concurrent use (it keeps per-comparison
+// iterator state), so collators are pooled instead of shared.
+var germanCollators = sync.Pool{
+	New: func() any {
+		// IgnoreCase keeps diacritics significant (Müller != Muller)
+		// while ignoring letter case; Loose would drop diacritics too.
+		return collate.New(language.German, collate.IgnoreCase)
+	},
+}
+
+// CompareGerman compares two strings case-insensitively in German
+// dictionary order. It returns -1, 0, or +1.
+func CompareGerman(a, b string) int {
+	c := germanCollators.Get().(*collate.Collator)
+	defer germanCollators.Put(c)
+	return c.CompareString(a, b)
+}
+
+// CompareGermanNames compares two person names by last name, then first
+// name, using CompareGerman for both legs.
+func CompareGermanNames(aLast, aFirst, bLast, bFirst string) int {
+	if r := CompareGerman(aLast, bLast); r != 0 {
+		return r
+	}
+	return CompareGerman(aFirst, bFirst)
+}

--- a/backend/internal/collation/collation_test.go
+++ b/backend/internal/collation/collation_test.go
@@ -1,0 +1,106 @@
+package collation
+
+import (
+	"sort"
+	"sync"
+	"testing"
+)
+
+func TestCompareGermanUmlautsGroupWithBaseLetters(t *testing.T) {
+	// DIN 5007-1 dictionary order: ä/ö/ü sort with a/o/u, not after z.
+	ordered := []string{
+		"Anders",
+		"Ärmel",
+		"Becker",
+		"Nowak",
+		"Özdemir",
+		"Pauli",
+		"Übel",
+		"Vogel",
+		"Zimmermann",
+	}
+	for i := 0; i < len(ordered)-1; i++ {
+		if CompareGerman(ordered[i], ordered[i+1]) >= 0 {
+			t.Errorf("expected %q < %q", ordered[i], ordered[i+1])
+		}
+	}
+}
+
+func TestCompareGermanIsCaseInsensitive(t *testing.T) {
+	if got := CompareGerman("müller", "Müller"); got != 0 {
+		t.Errorf("CompareGerman(müller, Müller) = %d, want 0", got)
+	}
+	// A lowercase name must not sort after all uppercase names.
+	if CompareGerman("ahrens", "Becker") >= 0 {
+		t.Error("expected ahrens < Becker regardless of case")
+	}
+}
+
+func TestCompareGermanKeepsDiacriticsSignificant(t *testing.T) {
+	// Dictionary order (not phone-book): Mueller < Müller, and they are
+	// distinct — IgnoreCase must not collapse diacritics like Loose would.
+	if CompareGerman("Mueller", "Müller") >= 0 {
+		t.Error("expected Mueller < Müller under DIN 5007-1")
+	}
+	if CompareGerman("Muller", "Müller") == 0 {
+		t.Error("expected Muller != Müller (diacritics significant)")
+	}
+}
+
+func TestCompareGermanNames(t *testing.T) {
+	tests := []struct {
+		name                         string
+		aLast, aFirst, bLast, bFirst string
+		want                         int
+	}{
+		{"last name decides", "Ärmel", "Zoe", "Becker", "Anna", -1},
+		{"equal last, first decides", "Müller", "Anna", "Müller", "Ömer", -1},
+		{"fully equal", "Müller", "Anna", "müller", "anna", 0},
+		{"prefixed last names", "Uhl", "Jan", "von Berg", "Jan", -1},
+		{"von Berg before Weber", "von Berg", "Jan", "Weber", "Jan", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CompareGermanNames(tt.aLast, tt.aFirst, tt.bLast, tt.bFirst)
+			if got != tt.want {
+				t.Errorf("CompareGermanNames(%q,%q,%q,%q) = %d, want %d",
+					tt.aLast, tt.aFirst, tt.bLast, tt.bFirst, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareGermanSortIntegration(t *testing.T) {
+	names := []string{"Zimmermann", "Özdemir", "ahrens", "Ärmel", "Müller", "Mueller"}
+	sort.SliceStable(names, func(i, j int) bool {
+		return CompareGerman(names[i], names[j]) < 0
+	})
+	want := []string{"ahrens", "Ärmel", "Mueller", "Müller", "Özdemir", "Zimmermann"}
+	for i, name := range want {
+		if names[i] != name {
+			t.Fatalf("sorted order = %v, want %v", names, want)
+		}
+	}
+}
+
+func TestCompareGermanConcurrentUse(t *testing.T) {
+	// The pool must make concurrent comparisons safe; run with -race.
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				if CompareGerman("Ärmel", "Becker") >= 0 {
+					t.Error("expected Ärmel < Becker")
+					return
+				}
+				if CompareGermanNames("Müller", "Anna", "Müller", "Ben") >= 0 {
+					t.Error("expected Anna < Ben on equal last name")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/backend/services/emergency/service.go
+++ b/backend/services/emergency/service.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moto-nrw/project-phoenix/internal/collation"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	userModel "github.com/moto-nrw/project-phoenix/models/users"
 	activeService "github.com/moto-nrw/project-phoenix/services/active"
@@ -158,12 +159,7 @@ func (s *service) loadSnapshotRows(ctx context.Context, studentIDs []int64) ([]s
 	}
 
 	rows := buildSnapshotRows(studentIDs, students, persons, locations, contacts)
-	sort.SliceStable(rows, func(i, j int) bool {
-		if rows[i].Location != rows[j].Location {
-			return rows[i].Location < rows[j].Location
-		}
-		return rows[i].Name < rows[j].Name
-	})
+	sortSnapshotRows(rows)
 	return rows, nil
 }
 
@@ -205,6 +201,15 @@ func buildSnapshotRows(
 		rows = append(rows, row)
 	}
 	return rows
+}
+
+func sortSnapshotRows(rows []snapshotRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Location != rows[j].Location {
+			return rows[i].Location < rows[j].Location
+		}
+		return collation.CompareGerman(rows[i].Name, rows[j].Name) < 0
+	})
 }
 
 func (s *service) loadCurrentLocations(ctx context.Context, studentIDs []int64) (map[int64]string, error) {

--- a/backend/services/emergency/service_test.go
+++ b/backend/services/emergency/service_test.go
@@ -233,3 +233,28 @@ func TestBinaryLocationLabel(t *testing.T) {
 	assert.Equal(t, "Abwesend", binaryLocationLabel(&activeService.AttendanceStatus{Status: "checked_out"}))
 	assert.Equal(t, "Abwesend", binaryLocationLabel(nil))
 }
+
+func TestSortSnapshotRowsGermanNameOrder(t *testing.T) {
+	rows := []snapshotRow{
+		{Name: "Jan Zimmermann", Location: "Raum A"},
+		{Name: "emre özdemir", Location: "Raum A"},
+		{Name: "Lena Ärmel", Location: "Raum A"},
+		{Name: "Anna Müller", Location: "Unterwegs"},
+		{Name: "Ben Anders", Location: "Unterwegs"},
+	}
+
+	sortSnapshotRows(rows)
+
+	got := make([]string, 0, len(rows))
+	for _, row := range rows {
+		got = append(got, row.Location+"/"+row.Name)
+	}
+	want := []string{
+		"Raum A/emre özdemir",
+		"Raum A/Jan Zimmermann",
+		"Raum A/Lena Ärmel",
+		"Unterwegs/Anna Müller",
+		"Unterwegs/Ben Anders",
+	}
+	assert.Equal(t, want, got)
+}

--- a/backend/services/enrollment/report_service.go
+++ b/backend/services/enrollment/report_service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moto-nrw/project-phoenix/internal/collation"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	educationModels "github.com/moto-nrw/project-phoenix/models/education"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
@@ -343,10 +344,10 @@ func (s *reportService) CareUsage(ctx context.Context, filters CareUsageFilters)
 	}
 
 	sort.SliceStable(report.Rows, func(i, j int) bool {
-		if report.Rows[i].ChildLastName != report.Rows[j].ChildLastName {
-			return strings.ToLower(report.Rows[i].ChildLastName) < strings.ToLower(report.Rows[j].ChildLastName)
-		}
-		return strings.ToLower(report.Rows[i].ChildFirstName) < strings.ToLower(report.Rows[j].ChildFirstName)
+		return collation.CompareGermanNames(
+			report.Rows[i].ChildLastName, report.Rows[i].ChildFirstName,
+			report.Rows[j].ChildLastName, report.Rows[j].ChildFirstName,
+		) < 0
 	})
 	report.ByOffering = careUsageOfferingStats(offeringStats)
 	report.FilterOptions.GradeLevels = careUsageGradeOptions(gradeSeen)
@@ -504,17 +505,7 @@ func (s *reportService) ClassRoster(ctx context.Context, filters ClassRosterFilt
 		}
 		rows = append(rows, row)
 	}
-	sort.SliceStable(rows, func(i, j int) bool {
-		lastNameCompare := strings.Compare(strings.ToLower(rows[i].LastName), strings.ToLower(rows[j].LastName))
-		if lastNameCompare != 0 {
-			return lastNameCompare < 0
-		}
-		firstNameCompare := strings.Compare(strings.ToLower(rows[i].FirstName), strings.ToLower(rows[j].FirstName))
-		if firstNameCompare != 0 {
-			return firstNameCompare < 0
-		}
-		return rows[i].StudentID < rows[j].StudentID
-	})
+	sortClassRosterRows(rows)
 
 	report := &ClassRosterReport{
 		Phase: CareUsagePhase{ID: phase.ID, Name: phase.Name},
@@ -890,6 +881,15 @@ func (s *reportService) classRosterGroupNames(ctx context.Context, students []*u
 		return nil, fmt.Errorf("class roster report: load groups: %w", err)
 	}
 	return groups, nil
+}
+
+func sortClassRosterRows(rows []ClassRosterRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		if r := collation.CompareGermanNames(rows[i].LastName, rows[i].FirstName, rows[j].LastName, rows[j].FirstName); r != 0 {
+			return r < 0
+		}
+		return rows[i].StudentID < rows[j].StudentID
+	})
 }
 
 func classRosterGroupName(student *userModels.Student, groups map[int64]*educationModels.Group) string {

--- a/backend/services/enrollment/report_service_test.go
+++ b/backend/services/enrollment/report_service_test.go
@@ -1024,3 +1024,23 @@ type fakeClassRosterPhaseRepo struct {
 func (r *fakeClassRosterPhaseRepo) FindByID(_ context.Context, id int64) (*enrollmentModels.Phase, error) {
 	return &enrollmentModels.Phase{Model: baseModels.Model{ID: id}, Name: "Schuljahr 2026"}, nil
 }
+
+func TestSortClassRosterRowsGermanNameOrder(t *testing.T) {
+	rows := []ClassRosterRow{
+		{StudentID: 1, FirstName: "Jan", LastName: "Zimmermann"},
+		{StudentID: 2, FirstName: "Emre", LastName: "Özdemir"},
+		{StudentID: 3, FirstName: "Lena", LastName: "Ärmel"},
+		{StudentID: 5, FirstName: "Anna", LastName: "Müller"},
+		{StudentID: 4, FirstName: "Anna", LastName: "Müller"},
+		{StudentID: 6, FirstName: "Tim", LastName: "Mueller"},
+	}
+
+	sortClassRosterRows(rows)
+
+	wantIDs := []int64{3, 6, 4, 5, 2, 1}
+	gotIDs := make([]int64, 0, len(rows))
+	for _, row := range rows {
+		gotIDs = append(gotIDs, row.StudentID)
+	}
+	assert.Equal(t, wantIDs, gotIDs, "expected Ärmel, Mueller, Müller (ID tiebreak), Özdemir, Zimmermann")
+}

--- a/frontend/src/components/enrollment/admin-enrollment-phase-detail.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-phase-detail.tsx
@@ -155,7 +155,7 @@ const TERMINAL_STATUSES = new Set<ChildStatus>([
   "withdrawn",
 ]);
 
-const EXPORT_FORMAT_LABELS: Record<EnrollmentExportFormat, string> = {
+const EXPORT_MENU_LABELS: Record<EnrollmentExportFormat, string> = {
   pdf: "Als PDF exportieren",
   docx: "Als Word-Dokument exportieren",
   xlsx: "Als Excel-Datei exportieren",
@@ -165,12 +165,6 @@ const REPORT_EXPORT_LABELS: Record<EnrollmentReportFormat, string> = {
   docx: "Word",
   pdf: "PDF",
   xlsx: "Excel",
-};
-
-const REPORT_EXPORT_MENU_LABELS: Record<EnrollmentReportFormat, string> = {
-  docx: "Als Word-Dokument exportieren",
-  pdf: "Als PDF exportieren",
-  xlsx: "Als Excel-Datei exportieren",
 };
 
 const DAY_LABELS: Record<string, string> = {
@@ -616,7 +610,10 @@ export function AdminEnrollmentPhaseDetail({ phaseId }: Props) {
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            <ExportMenu
+            <ExportMenuButton
+              label="Anmeldungen exportieren"
+              menuAriaLabel="Exportformat auswählen"
+              formats={["pdf", "docx", "xlsx"]}
               exportingFormat={exportingFormat}
               onExport={(format) => void handleExport(format)}
             />
@@ -624,7 +621,7 @@ export function AdminEnrollmentPhaseDetail({ phaseId }: Props) {
               href={`/enroll/${encodeURIComponent(phase.id)}`}
               target="_blank"
               rel="noreferrer"
-              className="inline-flex h-9 items-center justify-center gap-2 rounded-lg bg-gray-900 px-3 text-sm font-medium text-white shadow-sm transition-colors hover:bg-gray-700 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+              className="inline-flex h-10 items-center justify-center gap-2 rounded-lg bg-gray-900 px-4 text-sm font-medium text-white shadow-sm transition-colors hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
             >
               Elternansicht öffnen
               <ExternalLink className="h-4 w-4" aria-hidden="true" />
@@ -874,12 +871,7 @@ function ClassRosterExportPanel({
   exportingFormat: EnrollmentReportFormat | null;
   onExport: (format: EnrollmentReportFormat) => void;
 }>) {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  useClickOutside(containerRef, () => setOpen(false), open);
-  const formats: readonly EnrollmentReportFormat[] = ["pdf", "docx", "xlsx"];
   const hasSelectedClass = selectedSchoolClass !== ALL_VALUE;
-  const disabled = exportingFormat !== null || !hasSelectedClass;
 
   return (
     <section className="moto-content-surface relative z-10 rounded-2xl border p-4 shadow-sm backdrop-blur-md">
@@ -910,51 +902,14 @@ function ClassRosterExportPanel({
           </SelectField>
         </div>
 
-        <div className="relative" ref={containerRef}>
-          <button
-            type="button"
-            onClick={() => setOpen((value) => !value)}
-            disabled={disabled}
-            aria-haspopup="menu"
-            aria-expanded={open}
-            className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            <Download className="h-4 w-4" aria-hidden="true" />
-            {exportingFormat === null
-              ? "Klassenliste exportieren"
-              : `Exportiere ${REPORT_EXPORT_LABELS[exportingFormat]}...`}
-            <ChevronDown
-              className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""}`}
-              aria-hidden="true"
-            />
-          </button>
-
-          {open ? (
-            <div
-              role="menu"
-              aria-label="Klassenliste exportieren"
-              className="absolute right-0 z-30 mt-2 min-w-64 overflow-hidden rounded-xl border border-gray-200 bg-white py-1 shadow-lg"
-            >
-              {formats.map((format) => (
-                <button
-                  key={format}
-                  type="button"
-                  role="menuitem"
-                  onClick={() => {
-                    setOpen(false);
-                    onExport(format);
-                  }}
-                  className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 active:bg-gray-100"
-                >
-                  <ExportFormatIcon format={format} />
-                  <span className="flex-1">
-                    {REPORT_EXPORT_MENU_LABELS[format]}
-                  </span>
-                </button>
-              ))}
-            </div>
-          ) : null}
-        </div>
+        <ExportMenuButton
+          label="Klassenliste exportieren"
+          menuAriaLabel="Klassenliste exportieren"
+          formats={["pdf", "docx", "xlsx"]}
+          exportingFormat={exportingFormat}
+          disabled={!hasSelectedClass}
+          onExport={onExport}
+        />
       </div>
     </section>
   );
@@ -1115,28 +1070,13 @@ function ReportExportCard({
           aria-label="Auswertung exportieren"
           className="absolute right-0 z-40 mt-2 min-w-64 overflow-hidden rounded-xl border border-gray-200 bg-white py-1 shadow-lg"
         >
-          {formats.map((format) => {
-            const Icon = format === "xlsx" ? FileSpreadsheet : FileText;
-            return (
-              <button
-                key={format}
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setOpen(false);
-                  onExport(format);
-                }}
-                className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 active:bg-gray-100"
-              >
-                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-gray-100 text-gray-600">
-                  <Icon className="h-4 w-4" aria-hidden="true" />
-                </span>
-                <span className="flex-1">
-                  {REPORT_EXPORT_MENU_LABELS[format]}
-                </span>
-              </button>
-            );
-          })}
+          <ExportMenuItems
+            formats={formats}
+            onSelect={(format) => {
+              setOpen(false);
+              onExport(format);
+            }}
+          />
         </div>
       ) : null}
     </div>
@@ -1212,36 +1152,64 @@ function formatDayCountLabel(count: number): string {
   return count === 1 ? "1 Tag" : `${count} Tage`;
 }
 
-function ExportMenu({
+function ExportMenuItems({
+  formats,
+  onSelect,
+}: {
+  readonly formats: readonly EnrollmentExportFormat[];
+  readonly onSelect: (format: EnrollmentExportFormat) => void;
+}) {
+  return (
+    <>
+      {formats.map((format) => (
+        <button
+          key={format}
+          type="button"
+          role="menuitem"
+          onClick={() => onSelect(format)}
+          className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 active:bg-gray-100"
+        >
+          <ExportFormatIcon format={format} />
+          <span className="flex-1">{EXPORT_MENU_LABELS[format]}</span>
+        </button>
+      ))}
+    </>
+  );
+}
+
+function ExportMenuButton({
+  label,
+  menuAriaLabel,
+  formats,
   exportingFormat,
+  disabled = false,
   onExport,
 }: {
+  readonly label: string;
+  readonly menuAriaLabel: string;
+  readonly formats: readonly EnrollmentExportFormat[];
   readonly exportingFormat: EnrollmentExportFormat | null;
+  readonly disabled?: boolean;
   readonly onExport: (format: EnrollmentExportFormat) => void;
 }) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
   useClickOutside(containerRef, () => setOpen(false), open);
 
-  const disabled = exportingFormat !== null;
-  const formats: readonly EnrollmentExportFormat[] = ["pdf", "docx", "xlsx"];
-  const triggerLabel =
-    exportingFormat === null
-      ? "Anmeldungen exportieren"
-      : `Exportiere ${exportingFormat.toUpperCase()}...`;
-
   return (
     <div className="relative" ref={containerRef}>
       <button
         type="button"
         onClick={() => setOpen((value) => !value)}
-        disabled={disabled}
+        disabled={disabled || exportingFormat !== null}
         aria-haspopup="menu"
         aria-expanded={open}
-        className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+        className="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
       >
         <Download className="h-4 w-4" aria-hidden="true" />
-        {triggerLabel}
+        {exportingFormat === null
+          ? label
+          : `Exportiere ${REPORT_EXPORT_LABELS[exportingFormat]}...`}
         <ChevronDown
           className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""}`}
           aria-hidden="true"
@@ -1251,24 +1219,16 @@ function ExportMenu({
       {open ? (
         <div
           role="menu"
-          aria-label="Exportformat auswählen"
+          aria-label={menuAriaLabel}
           className="absolute right-0 z-30 mt-2 min-w-64 overflow-hidden rounded-xl border border-gray-200 bg-white py-1 shadow-lg"
         >
-          {formats.map((format) => (
-            <button
-              key={format}
-              type="button"
-              role="menuitem"
-              onClick={() => {
-                setOpen(false);
-                onExport(format);
-              }}
-              className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 active:bg-gray-100"
-            >
-              <ExportFormatIcon format={format} />
-              <span className="flex-1">{EXPORT_FORMAT_LABELS[format]}</span>
-            </button>
-          ))}
+          <ExportMenuItems
+            formats={formats}
+            onSelect={(format) => {
+              setOpen(false);
+              onExport(format);
+            }}
+          />
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
Closes #1795

## Was und warum

Die Schule am Berg wollte Klassenlisten alphabetisch sortiert. Die UI-Listen (Kindersuche, Meine Gruppen, Datenverwaltung) sortieren bereits korrekt über `localeCompare("de")` — der eigentliche Fehler steckte in den Backend-Exporten: Dort wurden Namen per Byte-Vergleich auf `strings.ToLower` sortiert, wodurch Ärmel, Özdemir und Übel in jedem exportierten PDF/DOCX/XLSX hinter Zimmermann landeten.

## Änderungen

### Backend: gemeinsamer deutscher Kollations-Helper

Neues Paket `backend/internal/collation` (nutzt `golang.org/x/text/collate`, bereits direkte Abhängigkeit):

- **DIN 5007-1 Wörterbuchsortierung** (ä gruppiert bei a, Mueller < Müller) — identische Semantik wie `localeCompare("de")` im Frontend, UI und Exporte stimmen damit überein. Telefonbuch-Sortierung (ä→ae) wurde bewusst verworfen, weil sie der UI widersprechen würde.
- **`collate.IgnoreCase`**, nicht `Loose` — Groß-/Kleinschreibung wird ignoriert, Diakritika bleiben signifikant (Müller ≠ Muller).
- `collate.Collator` ist nicht nebenläufigkeitssicher → `sync.Pool`, mit Race-Test abgesichert.

Umgestellte Sortierstellen (alle Exporte laufen weiterhin über die gemeinsame `listexport`-Engine):

| Export | Stelle |
|---|---|
| Kindersuche-Export (inkl. Preset „Klassenliste") | `api/students/export_handlers.go` `sortExportResponses` |
| Anmeldephasen-Klassenliste | `services/enrollment/report_service.go` (extrahiert als testbares `sortClassRosterRows`, StudentID-Tiebreak erhalten) |
| Auswertungs-Report (Kind-Sortierung) | `services/enrollment/report_service.go` |
| Raum-Snapshot („Wer ist wo") | `api/rooms/export_handlers.go` |
| Notfallliste | `services/emergency/service.go` (behebt nebenbei einen bestehenden Case-Sensitivity-Bug: dort wurde vorher roh mit `<` verglichen) |

Pickup-/Arrival-Sortiermodi bleiben unverändert (zeitbasiert, kein Namens-Tiebreak — wie bisher).

### Frontend: Export-Menüs konsolidiert

Die Phasen-Detailseite hatte drei nahezu identische, handgerollte Export-Dropdowns („Anmeldungen exportieren", „Klassenliste exportieren", „Auswertung exportieren"). Jetzt eine gemeinsame `ExportMenuButton`/`ExportMenuItems`-Komponente, doppelte Label-Maps entfernt, Trigger auf die aktuellen Control-Tokens angeglichen (h-10, Hover-Border). Sichtbare Texte und ARIA-Labels unverändert.

Bewusst **nicht** gemacht: Zusammenlegung des Phasen-Klassenlisten-Exports mit dem Kindersuche-Export. Beide nutzen dieselbe Render-Engine, haben aber unterschiedliche Datenquellen (phasenbezogene Buchungen je Wochentag vs. aktuelle Stammdaten) und sind beide im Hilfe-Guide dokumentiert.

## Tests

- Neu: `internal/collation/collation_test.go` (Umlaut-Ordnung, Case-Insensitivity, Mueller<Müller, Nebenläufigkeit unter `-race`)
- Neue Sortier-Tests für alle vier Export-Stellen (nur ergänzt, keine bestehenden Erwartungen geändert)
- `go build ./... && go test -race` über alle betroffenen Pakete grün, `golangci-lint` 0 Findings
- Frontend: `pnpm run check` und komplette Vitest-Suite (11.121 Tests) grün

## Verifikation end-to-end

- Kindersuche-Export (XLSX, 116 Kinder Seed-Daten): Böhm sortiert zwischen Bergmann und Brandt, Günther zwischen Graf und Haas, Jäger zwischen Huber und Jung ✓
- Phasen-Klassenliste (XLSX, Klasse 1): korrekt nach Nachnamen (… Sommer < Sommerfeld < Wolf) ✓
- Export-Panel und Dropdowns im Browser geprüft (Screenshot unten manuell anhängen: `phase-detail-full.png` / `export-menu-open.png` im Session-Scratchpad)

## Follow-ups (nicht in diesem PR)

- `api/enrollment/export_handlers.go` (Phasen-Export „Anmeldungen") sortiert Namen noch über vorbereitete ToLower-Sortkeys
- DB-seitige `ORDER BY`-Namenssortierung in Listen-Endpoints (Postgres-Collation)