### PR TITLE
chore: drop stale deadcode exclusions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,57 +65,18 @@ jobs:
           # mistaken for findings.
           DEADCODE_OUTPUT=$(go tool deadcode -test ./... 2>&1 | grep -v '^go: ' || true)
 
-          # Define exclusion patterns (false positives or planned-but-unwired code)
-          # cmd/root.go:Execute is the Cobra CLI entry point called by main()
-          # Multi-tenancy Phase 1 foundation primitives — wired in Phases 2-3
-          EXCLUSIONS=(
-            "cmd/root.go:.*Execute"
-            "tenant/context.go:.*IsOrgScope"
-            "tenant/context.go:.*NewContext"
-            "tenant/tx.go:.*WithAdminTx"
-            "database/repositories/base/helpers.go:.*AssertRowsAffected"
-            "database/repositories/base/tenant_db.go:.*GetDB"
-            "models/base/tenant.go:.*TenantModel"
-            "models/platform/organization.go:.*Organization"
-            "models/platform/school.go:.*School"
-            "models/auth/account_tenant.go:.*AccountTenant"
-            "test/fixtures.go:.*CreateTestOrganization"
-            "test/fixtures.go:.*CreateTestSchool"
-            "test/fixtures.go:.*CreateTestSchoolForOrg"
-            "test/fixtures.go:.*CreateTestAccountTenant"
-            "test/fixtures.go:.*CleanupTenantFixtures"
-          )
-
-          # Build grep exclusion pattern
-          EXCLUDE_PATTERN=""
-          for pattern in "${EXCLUSIONS[@]}"; do
-            if [[ -n "$EXCLUDE_PATTERN" ]]; then
-              EXCLUDE_PATTERN="$EXCLUDE_PATTERN|$pattern"
-            else
-              EXCLUDE_PATTERN="$pattern"
-            fi
-          done
-
-          # Filter out exclusions
-          if [[ -n "$EXCLUDE_PATTERN" ]]; then
-            FILTERED_OUTPUT=$(echo "$DEADCODE_OUTPUT" | grep -vE "$EXCLUDE_PATTERN" || true)
-          else
-            FILTERED_OUTPUT="$DEADCODE_OUTPUT"
-          fi
-
           # Check if any dead code remains
-          if [[ -n "$FILTERED_OUTPUT" ]]; then
+          if [[ -n "$DEADCODE_OUTPUT" ]]; then
             echo ""
             echo "❌ Dead code detected:"
             echo ""
-            echo "$FILTERED_OUTPUT" | while IFS= read -r line; do
+            echo "$DEADCODE_OUTPUT" | while IFS= read -r line; do
               if [[ -n "$line" ]]; then
                 echo "  $line"
               fi
             done
             echo ""
             echo "Please remove dead code or document why it should be kept."
-            echo "To add an exclusion, edit .github/workflows/lint.yml"
             exit 1
           else
             echo "No dead code detected"


### PR DESCRIPTION
## Summary
Remove the stale deadcode exclusion filter from the lint workflow now that the raw backend deadcode sweep is clean.

## Checks
- cd backend && go tool deadcode -test ./...
- cd frontend && CI=true corepack pnpm knip
- pre-push: git-secrets, frontend-knip, frontend-depcruise, go-deadcode, go-vet, golangci-lint, frontend-check

## Risk
Low. This only tightens CI deadcode detection and does not change application code.