### PR TITLE
fix(mobile-nav): make overflow 'Mehr' sheet scrollable

### DIFF
--- a/frontend/src/components/dashboard/mobile-bottom-nav.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.tsx
@@ -658,7 +658,7 @@ export function MobileBottomNav({ className = "" }: MobileBottomNavProps) {
       {/* shadcn/UI Drawer - Full-width on mobile */}
       <Drawer open={isOverflowMenuOpen} onOpenChange={setIsOverflowMenuOpen}>
         <DrawerContent className="bg-white">
-          <div className="w-full">
+          <div className="min-h-0 w-full flex-1 overflow-y-auto">
             {/* Hidden header for accessibility only */}
             <DrawerHeader className="sr-only">
               <DrawerTitle>Navigation</DrawerTitle>


### PR DESCRIPTION
## Problem

On mobile, opening the bottom-nav overflow menu (burger -> **Mehr**) showed a drawer whose item list was **clipped** below the viewport when there were many nav items. The last entries (e.g. *Essensplan*, *Berichte*) were unreachable — the sheet did not scroll.

## Cause

`DrawerContent` (bottom variant) is capped at `max-h-[90vh]` and is a `flex flex-col` container, but the inner item wrapper was a plain `<div className="w-full">` with no overflow handling. Once the list grew past 90vh it was simply cut off, with no scroll region beneath the cap.

## Fix

Make the item wrapper a real scroll region:

```diff
-          <div className="w-full">
+          <div className="min-h-0 w-full flex-1 overflow-y-auto">
```

- `min-h-0` + `flex-1` let the flex child shrink inside the `flex-col` sheet (required for `overflow-y-auto` to take effect)
- `overflow-y-auto` makes the list scroll within the existing height cap

Deliberately fixed at the **call site** (`mobile-bottom-nav.tsx`), not the shared `ui/drawer.tsx`, so the slide-over / side-panel drawer variants stay unaffected.

## Verification

Ran the dev stack, logged in on an iPhone-14 viewport as an admin account (12 overflow items):
- Measured wrapper: `scrollHeight 792 > clientHeight 740` -> scrollable
- Scrolled the sheet; the previously clipped **Berichte** item became fully visible, scrollbar appears
- `pnpm run check` (verify-locales + oxlint + tsc): green

Single-file, frontend-only change.