### PR TITLE
fix: complete breadcrumb labels for new nav routes

### DIFF
--- a/frontend/src/components/dashboard/header.tsx
+++ b/frontend/src/components/dashboard/header.tsx
@@ -37,6 +37,10 @@ import {
   getPageTypeInfo,
 } from "./header/breadcrumb-utils";
 
+function isPathSegment(path: string, basePath: string): boolean {
+  return path === basePath || path.startsWith(`${basePath}/`);
+}
+
 export function Header() {
   const { breadcrumb } = useBreadcrumb();
   const {
@@ -85,10 +89,6 @@ export function Header() {
     return null;
   })();
   const displayedPageTitle = parentPageTitle ?? pageTitle;
-
-  function isPathSegment(path: string, basePath: string): boolean {
-    return path === basePath || path.startsWith(`${basePath}/`);
-  }
 
   // Derive user info from ShellAuth context
   const userName = user?.name ?? "Benutzer";

--- a/frontend/src/components/dashboard/header.tsx
+++ b/frontend/src/components/dashboard/header.tsx
@@ -75,9 +75,20 @@ export function Header() {
     if (pathname === "/parents/children") return tParentNav("children");
     if (pathname.startsWith("/parents/children/"))
       return tParentNav("childProfile");
+    if (isPathSegment(pathname, "/parents/messages"))
+      return tParentNav("messages");
+    if (isPathSegment(pathname, "/messages")) return tParentNav("messages");
+    if (pathname === "/parents/news" || pathname === "/news")
+      return tParentNav("news");
+    if (pathname === "/parents/meal-plan" || pathname === "/meal-plan")
+      return tParentNav("mealPlan");
     return null;
   })();
   const displayedPageTitle = parentPageTitle ?? pageTitle;
+
+  function isPathSegment(path: string, basePath: string): boolean {
+    return path === basePath || path.startsWith(`${basePath}/`);
+  }
 
   // Derive user info from ShellAuth context
   const userName = user?.name ?? "Benutzer";

--- a/frontend/src/components/dashboard/header/breadcrumb-utils.test.ts
+++ b/frontend/src/components/dashboard/header/breadcrumb-utils.test.ts
@@ -136,6 +136,44 @@ describe("breadcrumb-utils", () => {
         expect(getPageTitle("/enrollment-form")).toBe("Anmeldeformulare");
       });
 
+      it("should return titles for staff admin request pages", () => {
+        expect(getPageTitle("/admin/guardian-approvals")).toBe(
+          "Konto-Anfragen",
+        );
+        expect(getPageTitle("/admin/change-requests")).toBe(
+          "Änderungsanfragen",
+        );
+      });
+
+      it("should return titles for recent staff navigation entries", () => {
+        expect(getPageTitle("/messages")).toBe("Nachrichten");
+        expect(getPageTitle("/messages/thread-1")).toBe("Nachrichten");
+        expect(getPageTitle("/parent-announcements")).toBe(
+          "Elternmitteilungen",
+        );
+        expect(getPageTitle("/meal-plan")).toBe("Essensplan");
+        expect(getPageTitle("/suggestions")).toBe("Feedback");
+      });
+
+      it("should return titles for operator navigation entries", () => {
+        expect(getPageTitle("/operator/organizations")).toBe("Träger");
+        expect(getPageTitle("/operator/schools")).toBe("Schulen");
+        expect(getPageTitle("/operator/accounts")).toBe("Konten");
+        expect(getPageTitle("/operator/devices")).toBe("Geräte");
+        expect(getPageTitle("/operator/persons")).toBe("Personen");
+        expect(getPageTitle("/operator/unregistered-tags")).toBe(
+          "Unbekannte RFID",
+        );
+        expect(getPageTitle("/operator/operators")).toBe("Operatoren");
+        expect(getPageTitle("/operator/announcements")).toBe("Ankündigungen");
+      });
+
+      it("should return German fallback titles for parent navigation entries", () => {
+        expect(getPageTitle("/parents/messages")).toBe("Nachrichten");
+        expect(getPageTitle("/parents/news")).toBe("Neuigkeiten");
+        expect(getPageTitle("/parents/meal-plan")).toBe("Essensplan");
+      });
+
       it("should return 'Home' for unknown route", () => {
         expect(getPageTitle("/unknown-route")).toBe("Home");
       });

--- a/frontend/src/components/dashboard/header/breadcrumb-utils.ts
+++ b/frontend/src/components/dashboard/header/breadcrumb-utils.ts
@@ -9,6 +9,26 @@ export function getPageTitle(pathname: string): string {
     return "Dienstplan";
   }
 
+  if (pathname === "/admin/guardian-approvals") {
+    return "Konto-Anfragen";
+  }
+
+  if (pathname === "/admin/change-requests") {
+    return "Änderungsanfragen";
+  }
+
+  if (matchesPathSegment(pathname, "/messages")) {
+    return "Nachrichten";
+  }
+
+  if (pathname === "/parent-announcements") {
+    return "Elternmitteilungen";
+  }
+
+  if (pathname === "/meal-plan") {
+    return "Essensplan";
+  }
+
   // Check for /students/search first before other /students/ paths
   if (pathname === "/students/search") {
     return "Kindersuche";
@@ -48,6 +68,10 @@ function getStudentPageTitle(pathname: string): string {
   if (pathname.includes("/feedback-history")) return "Feedback Historie";
   if (pathname.includes("/room-history")) return "Anwesenheitsprotokoll";
   return "Kinder Details";
+}
+
+function matchesPathSegment(pathname: string, basePath: string): boolean {
+  return pathname === basePath || pathname.startsWith(`${basePath}/`);
 }
 
 function getDatabasePageTitle(pathname: string): string {
@@ -92,8 +116,19 @@ function getMainRouteTitle(pathname: string): string {
     "/care-offerings": "Betreuungsangebote",
     "/enrollment-form": "Anmeldeformulare",
     "/time-tracking": "Zeiterfassung",
+    "/suggestions": "Feedback",
     "/operator/suggestions": "Vorschläge",
     "/operator/announcements": "Ankündigungen",
+    "/operator/organizations": "Träger",
+    "/operator/schools": "Schulen",
+    "/operator/accounts": "Konten",
+    "/operator/devices": "Geräte",
+    "/operator/persons": "Personen",
+    "/operator/unregistered-tags": "Unbekannte RFID",
+    "/operator/operators": "Operatoren",
+    "/parents/messages": "Nachrichten",
+    "/parents/news": "Neuigkeiten",
+    "/parents/meal-plan": "Essensplan",
   };
 
   return mainRoutes[pathname] ?? "Home";

--- a/frontend/src/components/dashboard/header/breadcrumb-utils.ts
+++ b/frontend/src/components/dashboard/header/breadcrumb-utils.ts
@@ -1,53 +1,50 @@
 // Breadcrumb utilities for header navigation
 // Extracted to reduce cognitive complexity in header.tsx
 
-/**
- * Get page title based on pathname
- */
+const exactPageTitles: Record<string, string> = {
+  "/staff/dienstplan": "Dienstplan",
+  "/admin/guardian-approvals": "Konto-Anfragen",
+  "/admin/change-requests": "Änderungsanfragen",
+  "/parent-announcements": "Elternmitteilungen",
+  "/meal-plan": "Essensplan",
+  "/students/search": "Kindersuche",
+};
+
+const segmentPageTitles: Record<string, string> = {
+  "/messages": "Nachrichten",
+};
+
+const detailRouteTitles: Array<{
+  basePath: string;
+  rootPath: string;
+  title: string;
+}> = [
+  {
+    basePath: "/staff/",
+    rootPath: "/staff",
+    title: "Mitarbeiter Details",
+  },
+  {
+    basePath: "/rooms/",
+    rootPath: "/rooms",
+    title: "Raum Details",
+  },
+];
+
 export function getPageTitle(pathname: string): string {
-  if (pathname === "/staff/dienstplan") {
-    return "Dienstplan";
-  }
+  const exactTitle = exactPageTitles[pathname];
+  if (exactTitle) return exactTitle;
 
-  if (pathname === "/admin/guardian-approvals") {
-    return "Konto-Anfragen";
-  }
-
-  if (pathname === "/admin/change-requests") {
-    return "Änderungsanfragen";
-  }
-
-  if (matchesPathSegment(pathname, "/messages")) {
-    return "Nachrichten";
-  }
-
-  if (pathname === "/parent-announcements") {
-    return "Elternmitteilungen";
-  }
-
-  if (pathname === "/meal-plan") {
-    return "Essensplan";
-  }
-
-  // Check for /students/search first before other /students/ paths
-  if (pathname === "/students/search") {
-    return "Kindersuche";
-  }
+  const segmentTitle = getSegmentPageTitle(pathname);
+  if (segmentTitle) return segmentTitle;
 
   // Handle student detail pages
   if (pathname.startsWith("/students/") && pathname !== "/students") {
     return getStudentPageTitle(pathname);
   }
 
-  // Handle staff detail pages
-  if (pathname.startsWith("/staff/") && pathname !== "/staff") {
-    return "Mitarbeiter Details";
-  }
-
-  // Handle room detail pages
-  if (pathname.startsWith("/rooms/") && pathname !== "/rooms") {
-    return "Raum Details";
-  }
+  const detailTitle = getDetailRouteTitle(pathname);
+  if (detailTitle) return detailTitle;
 
   // Handle database sub-pages
   if (pathname.startsWith("/database/")) {
@@ -68,6 +65,21 @@ function getStudentPageTitle(pathname: string): string {
   if (pathname.includes("/feedback-history")) return "Feedback Historie";
   if (pathname.includes("/room-history")) return "Anwesenheitsprotokoll";
   return "Kinder Details";
+}
+
+function getSegmentPageTitle(pathname: string): string | null {
+  for (const [basePath, title] of Object.entries(segmentPageTitles)) {
+    if (matchesPathSegment(pathname, basePath)) return title;
+  }
+  return null;
+}
+
+function getDetailRouteTitle(pathname: string): string | null {
+  const route = detailRouteTitles.find(
+    ({ basePath, rootPath }) =>
+      pathname.startsWith(basePath) && pathname !== rootPath,
+  );
+  return route?.title ?? null;
 }
 
 function matchesPathSegment(pathname: string, basePath: string): boolean {


### PR DESCRIPTION
## Summary

Adds missing header breadcrumb labels for recently added staff, parent, and operator navigation routes so the header no longer falls back to Home on those pages.

## Root cause

The persistent header resolves titles through a central route map unless a page provides custom breadcrumb context. New navigation routes such as Konto-Anfragen, Änderungsanfragen, Nachrichten, Elternmitteilungen, Essensplan, Feedback, and parent portal pages were not all present in that map.

## Changes

- Added route labels for the new staff admin request pages, messaging, parent announcements, meal plan, suggestions, and operator navigation pages.
- Added localized parent portal title overrides for messages, news, and meal plan paths.
- Extended breadcrumb utility tests for the newly covered route labels.

## Validation

- `./node_modules/.bin/vitest run src/components/dashboard/header/breadcrumb-utils.test.ts src/components/dashboard/header.test.tsx`
- `node scripts/verify-locales.mjs && ./node_modules/.bin/oxlint . && ./node_modules/.bin/tsc --noEmit`
- Browser smoke against the seeded local stack on the final commit:
  - Staff: `/admin/guardian-approvals`, `/admin/change-requests`, `/messages`, `/parent-announcements`, `/meal-plan`, `/suggestions`
  - Parents: `/messages`, `/news`, `/meal-plan`
- Pre-push hook via Devbox: git-secrets, frontend-knip, frontend-depcruise, frontend-check, go-deadcode, go-vet, golangci-lint