### PR TITLE
fix(reminders): precise real-time timer for time-based reminders

### DIFF
--- a/backend/database/repositories/users/student.go
+++ b/backend/database/repositories/users/student.go
@@ -128,6 +128,44 @@ func (r *StudentRepository) FindByIDs(ctx context.Context, ids []int64) (map[int
 	return result, nil
 }
 
+// FindReadScopeByIDs retrieves a lightweight projection of the given students —
+// only id, group_id, person_id, and school_class — in a single primary-key
+// IN-list query. Unlike FindByIDs it does NOT run hydrateBusDaysIfPresent, so it
+// avoids the extra information_schema column probe and jsonb weekday-hydration
+// round-trip. Callers that only gate read access and display a name (e.g. the
+// reminders header, polled per browser every 60s) get just those small rows and
+// nothing they never read. The returned *Student values have ONLY those four
+// fields populated — do not use them where full student data is expected.
+func (r *StudentRepository) FindReadScopeByIDs(ctx context.Context, ids []int64) (map[int64]*users.Student, error) {
+	if len(ids) == 0 {
+		return make(map[int64]*users.Student), nil
+	}
+
+	var students []*users.Student
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&students).
+		ModelTableExpr(`users.students AS "student"`).
+		Column("id", "group_id", "person_id", "school_class").
+		Where(`"student".id IN (?)`, bun.List(ids))
+
+	if where, val, ok := base.TenantWhere(ctx, "student"); ok {
+		query = query.Where(where, val)
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find read scope by IDs",
+			Err: err,
+		}
+	}
+
+	result := make(map[int64]*users.Student, len(students))
+	for _, student := range students {
+		result[student.ID] = student
+	}
+	return result, nil
+}
+
 // FindByGroupID retrieves students by their group ID
 func (r *StudentRepository) FindByGroupID(ctx context.Context, groupID int64) ([]*users.Student, error) {
 	var students []*users.Student

--- a/backend/models/users/repository.go
+++ b/backend/models/users/repository.go
@@ -96,6 +96,15 @@ type StudentRepository interface {
 	// FindByIDs retrieves multiple students by their IDs in a single query
 	FindByIDs(ctx context.Context, ids []int64) (map[int64]*Student, error)
 
+	// FindReadScopeByIDs retrieves a lightweight projection of the given students
+	// — only id, group_id, person_id, and school_class — without the weekday
+	// bus-day / departure hydration FindByIDs performs. It exists for callers that
+	// only need read-access gating and name display (e.g. the frequently-polled
+	// reminders service) and must not pay for schema probing and jsonb hydration
+	// on data they never read. The returned *Student values have ONLY those four
+	// fields populated.
+	FindReadScopeByIDs(ctx context.Context, ids []int64) (map[int64]*Student, error)
+
 	// FindByPersonID retrieves a student by their person ID
 	FindByPersonID(ctx context.Context, personID int64) (*Student, error)
 

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -385,10 +385,25 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 		return nil, nextChange, err
 	}
 
-	// Compute the due set (upcoming/overdue) BEFORE hydrating names or checking
-	// read access. A large school may have hundreds of students present but only
-	// a handful whose pickup is actually within the window, and the header polls
-	// every 60s — hydrating every present student would be wasteful.
+	// Apply the read-access gate BEFORE deriving anything from the pickup times,
+	// including the next-change boundaries. studentIDs is presence-scoped only and
+	// may contain children the caller may not read (binary mode's all-present
+	// list, or a non-supervised child sharing a supervised room). Computing a
+	// boundary from an unreadable child's pickup would leak that child's exact
+	// future pickup minute through next_change_at even though no reminder for them
+	// is ever returned — so only students that pass the same gdpr.student_data_scope
+	// gate as the emitted reminders may influence this response at all. Names are
+	// still hydrated only for the due subset below (a large school may have many
+	// present students but only a handful actually within the window, and the
+	// header polls every 60s), so the wasteful person lookups stay bounded.
+	readable, err := s.readableStudents(ctx, scope, studentIDs)
+	if err != nil {
+		return nil, nextChange, err
+	}
+	if len(readable) == 0 {
+		return nil, nextChange, nil
+	}
+
 	type duePickup struct {
 		id        int64
 		pickupMin int
@@ -397,22 +412,34 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 	}
 	dues := make([]duePickup, 0)
 	for _, id := range studentIDs {
+		if _, ok := readable[id]; !ok {
+			// Not readable under gdpr.student_data_scope — must contribute neither
+			// a reminder nor a next-change boundary.
+			continue
+		}
 		effective := times[id]
 		if effective == nil || effective.PickupTime == nil {
 			continue
 		}
 		pickupMin := minutesOfDay(*effective.PickupTime)
 
-		// Next-change boundaries are tracked for EVERY present student's pickup,
+		// Next-change boundaries are tracked for EVERY readable student's pickup,
 		// not just the currently-due ones: a pickup still outside its lead window
 		// contributes the moment it will enter (pickupMin-lead) and the moment it
-		// flips upcoming->overdue (pickupMin). This is what lets the frontend time
-		// the first appearance of a reminder that isn't in this response yet.
+		// flips upcoming->overdue. The flip happens the first minute pickupMin is
+		// in the past — pickupMin+1, NOT pickupMin: at exactly pickupMin the diff
+		// is 0, which is still "upcoming" (and, when only upcoming is enabled, the
+		// upcoming reminder itself only disappears at pickupMin+1). Scheduling
+		// pickupMin would refetch a minute early (nothing changed yet) and, since
+		// that boundary is then no longer in the future, drop the real pickupMin+1
+		// boundary — leaving the overdue reminder to surface only on the next 60s
+		// poll. This is what lets the frontend time the first appearance of a
+		// reminder that isn't in this response yet.
 		if upcoming {
 			nextChange = minFuture(nextChange, futureBoundary(pickupMin-lead, nowMin))
 		}
 		if upcoming || overdue {
-			nextChange = minFuture(nextChange, futureBoundary(pickupMin, nowMin))
+			nextChange = minFuture(nextChange, futureBoundary(pickupMin+1, nowMin))
 		}
 
 		diff := pickupMin - nowMin
@@ -432,8 +459,8 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 		dueIDs[i] = d.id
 	}
 
-	// Hydrate names + apply the read-access gate for the due students only.
-	infos, err := s.readableStudentInfo(ctx, scope, dueIDs)
+	// Hydrate display names for the due students only (all already read-gated).
+	infos, err := s.hydrateNames(ctx, readable, dueIDs)
 	if err != nil {
 		return nil, nextChange, err
 	}
@@ -442,8 +469,8 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 	for _, d := range dues {
 		info, ok := infos[d.id]
 		if !ok {
-			// Not readable under gdpr.student_data_scope, or the record is
-			// missing — skip silently rather than leak an unauthorized pickup.
+			// The student record went missing between the read gate and name
+			// hydration — skip silently rather than emit an empty-title reminder.
 			continue
 		}
 		reminderType := TypePickupUpcoming
@@ -539,27 +566,26 @@ type studentNameInfo struct {
 	class string
 }
 
-// readableStudentInfo hydrates the display name + school class for each due
-// student the caller is allowed to read. It enforces the same
-// gdpr.student_data_scope gate the pickup-schedule endpoints use: room presence
-// alone does not grant visibility of a student's pickup data — a caregiver must
-// supervise the student's education group (unless the tenant runs the all_staff
-// scope, or the caller is an admin).
+// readableStudents loads the given students and returns only those the caller is
+// allowed to read. It enforces the same gdpr.student_data_scope gate the
+// pickup-schedule endpoints use: room presence alone does not grant visibility
+// of a student's pickup data — a caregiver must supervise the student's
+// education group (unless the tenant runs the all_staff scope, or the caller is
+// an admin).
 //
-// A DB/RLS lookup error is propagated: the pickup-reminder API contract
-// promises a student name as the title, so a failed read must fail the request
-// rather than emit unusable reminders with empty titles.
-func (s *service) readableStudentInfo(ctx context.Context, scope Scope, ids []int64) (map[int64]studentNameInfo, error) {
-	result := make(map[int64]studentNameInfo, len(ids))
+// A DB/RLS lookup error or a settings-resolution error is propagated rather than
+// treated as no-access, so a broken read fails the request instead of silently
+// hiding (or exposing) reminders.
+func (s *service) readableStudents(ctx context.Context, scope Scope, ids []int64) (map[int64]*userModel.Student, error) {
 	if s.student == nil {
 		// Without a student reader we can neither verify read access nor build a
 		// title. Fail closed (return nothing) rather than expose unverified data.
-		return result, nil
+		return map[int64]*userModel.Student{}, nil
 	}
 
 	students, err := s.student.FindByIDs(ctx, ids)
 	if err != nil {
-		return nil, fmt.Errorf("load student names: %w", err)
+		return nil, fmt.Errorf("load students: %w", err)
 	}
 
 	allowed, err := s.pickupReadPredicate(ctx, scope)
@@ -568,23 +594,43 @@ func (s *service) readableStudentInfo(ctx context.Context, scope Scope, ids []in
 	}
 
 	readable := make(map[int64]*userModel.Student, len(students))
-	personIDs := make([]int64, 0, len(students))
 	for id, st := range students {
 		if st == nil || !allowed(st) {
 			continue
 		}
 		readable[id] = st
-		personIDs = append(personIDs, st.PersonID)
+	}
+	return readable, nil
+}
+
+// hydrateNames builds the display name + school class for the given (already
+// read-gated) students. Only the due subset is hydrated: the pickup-reminder API
+// contract promises a student name as the title, so a failed person read must
+// fail the request rather than emit unusable reminders with empty titles.
+func (s *service) hydrateNames(ctx context.Context, readable map[int64]*userModel.Student, ids []int64) (map[int64]studentNameInfo, error) {
+	result := make(map[int64]studentNameInfo, len(ids))
+
+	personIDs := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if st := readable[id]; st != nil {
+			personIDs = append(personIDs, st.PersonID)
+		}
 	}
 
 	var persons map[int64]*userModel.Person
 	if s.person != nil && len(personIDs) > 0 {
+		var err error
 		persons, err = s.person.FindByIDs(ctx, personIDs)
 		if err != nil {
 			return nil, fmt.Errorf("load persons for student names: %w", err)
 		}
 	}
-	for id, st := range readable {
+
+	for _, id := range ids {
+		st := readable[id]
+		if st == nil {
+			continue
+		}
 		info := studentNameInfo{class: st.SchoolClass}
 		if persons != nil {
 			if p := persons[st.PersonID]; p != nil {

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -467,12 +467,10 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 
 	out := make([]Reminder, 0, len(dues))
 	for _, d := range dues {
-		info, ok := infos[d.id]
-		if !ok {
-			// The student record went missing between the read gate and name
-			// hydration — skip silently rather than emit an empty-title reminder.
-			continue
-		}
+		// dueIDs is a subset of the read-gated `readable` set and hydrateNames
+		// populates an entry for every one of them, so infos[d.id] is always
+		// present here — no missing-key guard is needed.
+		info := infos[d.id]
 		reminderType := TypePickupUpcoming
 		if d.isOverdue {
 			reminderType = TypePickupOverdue
@@ -525,11 +523,16 @@ func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []
 
 		// Track the boundaries at which this instance's reminder state flips, so
 		// the frontend can refetch exactly then instead of waiting for the poll:
-		//   upcoming: enters the window at startMin-lead, leaves it at startMin
+		//   upcoming: enters the window at startMin-lead, leaves it at startMin+1
 		//   overdue:  appears at startMin+overdueThreshold, disappears at endMin
+		// The upcoming exit is startMin+1, NOT startMin: at exactly startMin the
+		// diff is 0, which is still "upcoming" (diff >= 0); the reminder only
+		// disappears the first minute startMin is in the past. Scheduling startMin
+		// would refetch a minute early (nothing changed) and drop the real
+		// startMin+1 boundary — same reasoning as the pickup flip below.
 		if upcoming {
 			nextChange = minFuture(nextChange, futureBoundary(startMin-lead, nowMin))
-			nextChange = minFuture(nextChange, futureBoundary(startMin, nowMin))
+			nextChange = minFuture(nextChange, futureBoundary(startMin+1, nowMin))
 		}
 		if overdue {
 			overdueStart := startMin + overdueThreshold

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -50,6 +50,14 @@ type Result struct {
 	Reminders []Reminder `json:"reminders"`
 	Count     int        `json:"count"`
 	Enabled   bool       `json:"enabled"`
+	// NextChangeAt is the wall-clock "HH:MM" of the soonest future moment at
+	// which this list would change purely by time passing — the next pickup or
+	// activity entering/leaving its window. The frontend schedules a timer to
+	// exactly this time to refetch, so a reminder appears on its threshold
+	// instead of only on the next fixed poll. Omitted when nothing time-based is
+	// pending (the poll then remains the only cadence). Data-driven changes
+	// (check-ins, edits) are still delivered via the SSE-stale event, not this.
+	NextChangeAt string `json:"next_change_at,omitempty"`
 }
 
 // Scope describes whose reminders to compute. Admins see all present children
@@ -185,6 +193,9 @@ func (s *service) Compute(ctx context.Context, scope Scope) (*Result, error) {
 	nowMin := minutesOfDay(timezone.Now())
 
 	reminders := make([]Reminder, 0)
+	// -1 = no future time-based change pending. Both branches feed their soonest
+	// boundary in; the earliest across pickups and activities wins.
+	nextChange := -1
 
 	// Pickup and activity scopes are resolved independently so an activity-only
 	// tenant never pays for (or fails on) student-presence resolution, and a
@@ -198,11 +209,12 @@ func (s *service) Compute(ctx context.Context, scope Scope) (*Result, error) {
 		if lerr != nil {
 			return nil, lerr
 		}
-		pickupReminders, perr := s.pickupReminders(ctx, scope, studentIDs, today, nowMin, lead, pickupUpcoming, pickupOverdue)
+		pickupReminders, pickupNext, perr := s.pickupReminders(ctx, scope, studentIDs, today, nowMin, lead, pickupUpcoming, pickupOverdue)
 		if perr != nil {
 			return nil, perr
 		}
 		reminders = append(reminders, pickupReminders...)
+		nextChange = minFuture(nextChange, pickupNext)
 	}
 
 	if activityStart || activityOverdue {
@@ -224,11 +236,12 @@ func (s *service) Compute(ctx context.Context, scope Scope) (*Result, error) {
 		if oerr != nil {
 			return nil, oerr
 		}
-		activityReminders, aerr := s.activityReminders(ctx, scope, roomIDs, today, nowMin, lead, overdueThreshold, activityStart, activityOverdue)
+		activityReminders, activityNext, aerr := s.activityReminders(ctx, scope, roomIDs, today, nowMin, lead, overdueThreshold, activityStart, activityOverdue)
 		if aerr != nil {
 			return nil, aerr
 		}
 		reminders = append(reminders, activityReminders...)
+		nextChange = minFuture(nextChange, activityNext)
 	}
 
 	// Most urgent first (overdue is negative, soonest upcoming next).
@@ -236,7 +249,11 @@ func (s *service) Compute(ctx context.Context, scope Scope) (*Result, error) {
 		return reminders[i].MinutesAway < reminders[j].MinutesAway
 	})
 
-	return &Result{Reminders: reminders, Count: len(reminders), Enabled: true}, nil
+	result := &Result{Reminders: reminders, Count: len(reminders), Enabled: true}
+	if nextChange >= 0 {
+		result.NextChangeAt = formatMinutes(nextChange)
+	}
+	return result, nil
 }
 
 // pickupScopeStudentIDs returns the IDs of currently present students whose
@@ -358,13 +375,14 @@ func (s *service) presentStudentsInRooms(ctx context.Context, roomIDs []int64) (
 	return studentIDs, nil
 }
 
-func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs []int64, today timezone.Date, nowMin, lead int, upcoming, overdue bool) ([]Reminder, error) {
+func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs []int64, today timezone.Date, nowMin, lead int, upcoming, overdue bool) ([]Reminder, int, error) {
+	nextChange := -1
 	if len(studentIDs) == 0 || s.pickup == nil {
-		return nil, nil
+		return nil, nextChange, nil
 	}
 	times, err := s.pickup.GetBulkEffectivePickupTimesForDate(ctx, studentIDs, today)
 	if err != nil {
-		return nil, err
+		return nil, nextChange, err
 	}
 
 	// Compute the due set (upcoming/overdue) BEFORE hydrating names or checking
@@ -384,6 +402,19 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 			continue
 		}
 		pickupMin := minutesOfDay(*effective.PickupTime)
+
+		// Next-change boundaries are tracked for EVERY present student's pickup,
+		// not just the currently-due ones: a pickup still outside its lead window
+		// contributes the moment it will enter (pickupMin-lead) and the moment it
+		// flips upcoming->overdue (pickupMin). This is what lets the frontend time
+		// the first appearance of a reminder that isn't in this response yet.
+		if upcoming {
+			nextChange = minFuture(nextChange, futureBoundary(pickupMin-lead, nowMin))
+		}
+		if upcoming || overdue {
+			nextChange = minFuture(nextChange, futureBoundary(pickupMin, nowMin))
+		}
+
 		diff := pickupMin - nowMin
 		switch {
 		case diff < 0 && overdue:
@@ -393,7 +424,7 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 		}
 	}
 	if len(dues) == 0 {
-		return nil, nil
+		return nil, nextChange, nil
 	}
 
 	dueIDs := make([]int64, len(dues))
@@ -404,7 +435,7 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 	// Hydrate names + apply the read-access gate for the due students only.
 	infos, err := s.readableStudentInfo(ctx, scope, dueIDs)
 	if err != nil {
-		return nil, err
+		return nil, nextChange, err
 	}
 
 	out := make([]Reminder, 0, len(dues))
@@ -428,16 +459,17 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 			MinutesAway: d.diff,
 		})
 	}
-	return out, nil
+	return out, nextChange, nil
 }
 
-func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []int64, today timezone.Date, nowMin, lead, overdueThreshold int, upcoming, overdue bool) ([]Reminder, error) {
+func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []int64, today timezone.Date, nowMin, lead, overdueThreshold int, upcoming, overdue bool) ([]Reminder, int, error) {
+	nextChange := -1
 	if s.instance == nil {
-		return nil, nil
+		return nil, nextChange, nil
 	}
 	instances, err := s.instance.FindByTenantAndDate(ctx, today)
 	if err != nil {
-		return nil, err
+		return nil, nextChange, err
 	}
 
 	var roomFilter map[int64]struct{}
@@ -464,6 +496,22 @@ func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []
 		endMin := minutesOfDay(inst.EndTime)
 		diff := startMin - nowMin
 
+		// Track the boundaries at which this instance's reminder state flips, so
+		// the frontend can refetch exactly then instead of waiting for the poll:
+		//   upcoming: enters the window at startMin-lead, leaves it at startMin
+		//   overdue:  appears at startMin+overdueThreshold, disappears at endMin
+		if upcoming {
+			nextChange = minFuture(nextChange, futureBoundary(startMin-lead, nowMin))
+			nextChange = minFuture(nextChange, futureBoundary(startMin, nowMin))
+		}
+		if overdue {
+			overdueStart := startMin + overdueThreshold
+			if overdueStart < endMin {
+				nextChange = minFuture(nextChange, futureBoundary(overdueStart, nowMin))
+				nextChange = minFuture(nextChange, futureBoundary(endMin, nowMin))
+			}
+		}
+
 		switch {
 		case upcoming && diff >= 0 && diff <= lead:
 			out = append(out, Reminder{
@@ -483,7 +531,7 @@ func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []
 			})
 		}
 	}
-	return out, nil
+	return out, nextChange, nil
 }
 
 type studentNameInfo struct {
@@ -630,6 +678,29 @@ func (s *service) overdueThresholdMinutes(ctx context.Context) (int, error) {
 		return fallback, nil
 	}
 	return v, nil
+}
+
+// futureBoundary returns boundaryMin when it is strictly after nowMin, else -1
+// (the "no candidate" sentinel). Used to feed only genuinely-upcoming state
+// flips into the next-change accumulator.
+func futureBoundary(boundaryMin, nowMin int) int {
+	if boundaryMin > nowMin {
+		return boundaryMin
+	}
+	return -1
+}
+
+// minFuture keeps the smaller of two minute-of-day candidates, treating -1 as
+// "absent". Both inputs are already restricted to future boundaries by
+// futureBoundary, so the result is the soonest upcoming change (-1 if none).
+func minFuture(cur, cand int) int {
+	if cand < 0 {
+		return cur
+	}
+	if cur < 0 || cand < cur {
+		return cand
+	}
+	return cur
 }
 
 // minutesOfDay returns the wall-clock minute of t. TIME columns are stored as a

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -471,6 +471,18 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 		// populates an entry for every one of them, so infos[d.id] is always
 		// present here — no missing-key guard is needed.
 		info := infos[d.id]
+		if info.name == "" {
+			// The student passed the read gate but its person record could not be
+			// resolved (a not-found row rather than a read error — e.g. the person
+			// was soft-deleted mid-day while the student still has an open
+			// attendance row). A reminder with a blank title is an unidentifiable
+			// card, so skip it: this upholds the same "no unusable empty-title
+			// reminders" guarantee the person-read-error path enforces by failing.
+			if s.logger != nil {
+				s.logger.Debug("skipping pickup reminder with unresolved name", "student_id", d.id)
+			}
+			continue
+		}
 		reminderType := TypePickupUpcoming
 		if d.isOverdue {
 			reminderType = TypePickupOverdue

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -92,7 +92,13 @@ type instanceReader interface {
 }
 
 type studentReader interface {
-	FindByIDs(ctx context.Context, ids []int64) (map[int64]*userModel.Student, error)
+	// FindReadScopeByIDs returns only the id/group_id/person_id/school_class
+	// projection this service needs — read-access gating plus name display. It
+	// deliberately avoids the repository's full FindByIDs hydration (weekday
+	// bus-day / departure jsonb + an information_schema probe), which would run on
+	// every 60s header poll for the whole present population and buys this service
+	// nothing.
+	FindReadScopeByIDs(ctx context.Context, ids []int64) (map[int64]*userModel.Student, error)
 }
 
 type personReader interface {
@@ -399,12 +405,14 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 	//
 	// This gate necessarily loads every present student (the read predicate needs
 	// each Student's group to decide readability, and a boundary is tracked for
-	// EVERY readable student, not just the due ones), so the FindByIDs below scales
-	// with the present population rather than the due subset. That is a deliberate
-	// trade-off for a correct next_change_at: it is a single primary-key IN-list
-	// lookup returning small rows, bounded by how many children are physically
-	// present, so it stays cheap even at a large school. The expensive part —
-	// person-name hydration — remains scoped to the due subset.
+	// EVERY readable student, not just the due ones), so the read below scales with
+	// the present population rather than the due subset. That is a deliberate
+	// trade-off for a correct next_change_at, kept cheap on purpose: readableStudents
+	// uses FindReadScopeByIDs — a single primary-key IN-list projection of
+	// id/group_id/person_id/school_class only, with NONE of FindByIDs' weekday
+	// bus-day hydration or information_schema probing — so a 60s poll over the whole
+	// present population stays a small-row lookup. The expensive part — person-name
+	// hydration — remains scoped to the due subset.
 	readable, err := s.readableStudents(ctx, scope, studentIDs)
 	if err != nil {
 		return nil, nextChange, err
@@ -607,7 +615,7 @@ func (s *service) readableStudents(ctx context.Context, scope Scope, ids []int64
 		return map[int64]*userModel.Student{}, nil
 	}
 
-	students, err := s.student.FindByIDs(ctx, ids)
+	students, err := s.student.FindReadScopeByIDs(ctx, ids)
 	if err != nil {
 		return nil, fmt.Errorf("load students: %w", err)
 	}

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -396,6 +396,15 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 	// still hydrated only for the due subset below (a large school may have many
 	// present students but only a handful actually within the window, and the
 	// header polls every 60s), so the wasteful person lookups stay bounded.
+	//
+	// This gate necessarily loads every present student (the read predicate needs
+	// each Student's group to decide readability, and a boundary is tracked for
+	// EVERY readable student, not just the due ones), so the FindByIDs below scales
+	// with the present population rather than the due subset. That is a deliberate
+	// trade-off for a correct next_change_at: it is a single primary-key IN-list
+	// lookup returning small rows, bounded by how many children are physically
+	// present, so it stays cheap even at a large school. The expensive part —
+	// person-name hydration — remains scoped to the due subset.
 	readable, err := s.readableStudents(ctx, scope, studentIDs)
 	if err != nil {
 		return nil, nextChange, err

--- a/backend/services/reminders/service_internal_test.go
+++ b/backend/services/reminders/service_internal_test.go
@@ -703,13 +703,14 @@ func TestPickupNextChange(t *testing.T) {
 	})
 
 	t.Run("an in-window upcoming pickup schedules its flip-to-overdue moment", func(t *testing.T) {
-		// pickup 5 min away: window-entry (595) is already past, so the next change
-		// is the flip to overdue at pickupMin = 605.
+		// pickup 5 min away: window-entry (595) is already past. At pickupMin (605)
+		// the diff is still 0 (upcoming); the flip to overdue is the first minute
+		// pickupMin is in the past, pickupMin+1 = 606.
 		svc := newSvc(map[int64]*scheduleService.EffectivePickupTime{1: pickupAt(605)})
 		out, next, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.NoError(t, err)
 		require.Len(t, out, 1)
-		assert.Equal(t, 605, next)
+		assert.Equal(t, 606, next)
 	})
 
 	t.Run("an already-overdue pickup has no future time-based change", func(t *testing.T) {
@@ -725,8 +726,40 @@ func TestPickupNextChange(t *testing.T) {
 		svc := newSvc(map[int64]*scheduleService.EffectivePickupTime{1: pickupAt(620)})
 		_, next, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, false, true)
 		require.NoError(t, err)
-		assert.Equal(t, 620, next, "overdue-only: no window entry, only the flip at pickupMin")
+		assert.Equal(t, 621, next, "overdue-only: no window entry, only the flip at pickupMin+1 (first overdue minute)")
 	})
+}
+
+// TestPickupNextChangeExcludesUnreadableStudents guards the GDPR gate on the
+// next-change timer: a child the caregiver may not read must not leak its future
+// pickup minute through next_change_at, even though its reminder is never
+// emitted. Student 2 (a non-supervised group) has the SOONER boundary; only
+// student 1's must survive.
+func TestPickupNextChangeExcludesUnreadableStudents(t *testing.T) {
+	const nowMin = 600 // 10:00
+	const lead = 10
+	g100 := int64(100)
+	g200 := int64(200)
+
+	svc := &service{
+		pickup: fakePickup{times: map[int64]*scheduleService.EffectivePickupTime{
+			1: pickupAt(660), // supervised: enters its window at 650
+			2: pickupAt(620), // NOT supervised: would enter at 610 (sooner) — must not leak
+		}},
+		student: fakeStudent{students: map[int64]*userModel.Student{
+			1: {PersonID: 11, SchoolClass: "1a", GroupID: &g100},
+			2: {PersonID: 12, SchoolClass: "1b", GroupID: &g200},
+		}},
+		person:   fakePerson{persons: map[int64]*userModel.Person{11: {FirstName: "Anna", LastName: "A"}}},
+		settings: fakeSettings{}, // no override → group_supervisors_only
+		groups:   fakeGroups{groups: []*educationModel.Group{eduGroup(100)}},
+	}
+	caregiver := Scope{IsAdmin: false, StaffID: 7}
+
+	out, next, err := svc.pickupReminders(context.Background(), caregiver, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, true, true)
+	require.NoError(t, err)
+	assert.Empty(t, out, "neither pickup is inside its window yet")
+	assert.Equal(t, 650, next, "only the readable child's boundary may schedule the refetch")
 }
 
 func TestActivityNextChange(t *testing.T) {

--- a/backend/services/reminders/service_internal_test.go
+++ b/backend/services/reminders/service_internal_test.go
@@ -769,7 +769,7 @@ func TestActivityNextChange(t *testing.T) {
 	adminScope := Scope{IsAdmin: true}
 
 	t.Run("an activity starting beyond the window schedules its earliest boundary", func(t *testing.T) {
-		// start 620, end 700. Boundaries: window entry 610, start 620,
+		// start 620, end 700. Boundaries: window entry 610, upcoming exit 621,
 		// overdue 625, slot end 700. The soonest is 610.
 		svc := &service{instance: fakeInstance{instances: []*scheduleModel.ActivityInstance{
 			plannedInstance("Schach", 1, 620, 700),
@@ -778,6 +778,21 @@ func TestActivityNextChange(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, out)
 		assert.Equal(t, 610, next)
+	})
+
+	t.Run("an in-window upcoming activity schedules its flip-out at startMin+1", func(t *testing.T) {
+		// now 615, window [610, 620]: entry already past. The start reminder is
+		// still shown at exactly startMin (diff 0 is upcoming); it disappears the
+		// first minute start is in the past, startMin+1 = 621 — NOT startMin.
+		// Upcoming-only isolates that boundary from the overdue ones.
+		const nowMin = 615
+		svc := &service{instance: fakeInstance{instances: []*scheduleModel.ActivityInstance{
+			plannedInstance("Schach", 1, 620, 700),
+		}}}
+		out, next, err := svc.activityReminders(context.Background(), adminScope, nil, timezone.TodayDate(), nowMin, lead, overdueThreshold, true, false)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, 621, next, "upcoming exit is startMin+1, not startMin")
 	})
 
 	t.Run("nil instance reader yields no scheduled change", func(t *testing.T) {

--- a/backend/services/reminders/service_internal_test.go
+++ b/backend/services/reminders/service_internal_test.go
@@ -95,7 +95,7 @@ type fakeStudent struct {
 	err      error
 }
 
-func (f fakeStudent) FindByIDs(_ context.Context, _ []int64) (map[int64]*userModel.Student, error) {
+func (f fakeStudent) FindReadScopeByIDs(_ context.Context, _ []int64) (map[int64]*userModel.Student, error) {
 	return f.students, f.err
 }
 

--- a/backend/services/reminders/service_internal_test.go
+++ b/backend/services/reminders/service_internal_test.go
@@ -179,7 +179,7 @@ func TestPickupReminders(t *testing.T) {
 
 	t.Run("upcoming within lead is reported", func(t *testing.T) {
 		svc := newSvc(map[int64]*scheduleService.EffectivePickupTime{1: pickupAt(605)})
-		out, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
+		out, _, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.NoError(t, err)
 		require.Len(t, out, 1)
 		assert.Equal(t, TypePickupUpcoming, out[0].Type)
@@ -193,7 +193,7 @@ func TestPickupReminders(t *testing.T) {
 
 	t.Run("overdue is reported with negative minutes", func(t *testing.T) {
 		svc := newSvc(map[int64]*scheduleService.EffectivePickupTime{1: pickupAt(595)})
-		out, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
+		out, _, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.NoError(t, err)
 		require.Len(t, out, 1)
 		assert.Equal(t, TypePickupOverdue, out[0].Type)
@@ -203,7 +203,7 @@ func TestPickupReminders(t *testing.T) {
 
 	t.Run("beyond lead window is ignored", func(t *testing.T) {
 		svc := newSvc(map[int64]*scheduleService.EffectivePickupTime{1: pickupAt(615)}) // +15 > lead 10
-		out, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
+		out, _, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.NoError(t, err)
 		assert.Empty(t, out)
 	})
@@ -225,12 +225,12 @@ func TestPickupReminders(t *testing.T) {
 			}},
 		}
 
-		upcomingOnly, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, true, false)
+		upcomingOnly, _, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, true, false)
 		require.NoError(t, err)
 		require.Len(t, upcomingOnly, 1)
 		assert.Equal(t, TypePickupUpcoming, upcomingOnly[0].Type)
 
-		overdueOnly, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, false, true)
+		overdueOnly, _, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, false, true)
 		require.NoError(t, err)
 		require.Len(t, overdueOnly, 1)
 		assert.Equal(t, TypePickupOverdue, overdueOnly[0].Type)
@@ -238,21 +238,21 @@ func TestPickupReminders(t *testing.T) {
 
 	t.Run("student without an effective pickup time is skipped", func(t *testing.T) {
 		svc := newSvc(map[int64]*scheduleService.EffectivePickupTime{1: nil})
-		out, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
+		out, _, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.NoError(t, err)
 		assert.Empty(t, out)
 	})
 
 	t.Run("empty student list returns nothing", func(t *testing.T) {
 		svc := newSvc(map[int64]*scheduleService.EffectivePickupTime{1: pickupAt(605)})
-		out, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, nil, timezone.TodayDate(), nowMin, lead, true, true)
+		out, _, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, nil, timezone.TodayDate(), nowMin, lead, true, true)
 		require.NoError(t, err)
 		assert.Empty(t, out)
 	})
 
 	t.Run("propagates a pickup lookup error", func(t *testing.T) {
 		svc := &service{pickup: fakePickup{err: errors.New("boom")}}
-		_, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
+		_, _, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.Error(t, err)
 	})
 
@@ -261,7 +261,7 @@ func TestPickupReminders(t *testing.T) {
 			pickup:  fakePickup{times: map[int64]*scheduleService.EffectivePickupTime{1: pickupAt(605)}},
 			student: fakeStudent{err: errors.New("boom")},
 		}
-		_, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
+		_, _, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.Error(t, err)
 	})
 
@@ -271,7 +271,7 @@ func TestPickupReminders(t *testing.T) {
 			student: fakeStudent{students: students},
 			person:  fakePerson{err: errors.New("boom")},
 		}
-		_, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
+		_, _, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.Error(t, err)
 	})
 
@@ -302,7 +302,7 @@ func TestPickupReminders(t *testing.T) {
 			settings: fakeSettings{}, // no override → group_supervisors_only
 			groups:   fakeGroups{groups: []*educationModel.Group{eduGroup(100)}},
 		}
-		out, err := svc.pickupReminders(context.Background(), caregiver, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, true, true)
+		out, _, err := svc.pickupReminders(context.Background(), caregiver, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.NoError(t, err)
 		require.Len(t, out, 1)
 		require.NotNil(t, out[0].StudentID)
@@ -320,7 +320,7 @@ func TestPickupReminders(t *testing.T) {
 			}},
 			groups: fakeGroups{}, // supervised groups irrelevant under all_staff
 		}
-		out, err := svc.pickupReminders(context.Background(), caregiver, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, true, true)
+		out, _, err := svc.pickupReminders(context.Background(), caregiver, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.NoError(t, err)
 		require.Len(t, out, 2)
 	})
@@ -333,7 +333,7 @@ func TestPickupReminders(t *testing.T) {
 			settings: fakeSettings{},
 			groups:   fakeGroups{groups: nil},
 		}
-		out, err := svc.pickupReminders(context.Background(), caregiver, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, true, true)
+		out, _, err := svc.pickupReminders(context.Background(), caregiver, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.NoError(t, err)
 		assert.Empty(t, out)
 	})
@@ -347,7 +347,7 @@ func TestPickupReminders(t *testing.T) {
 			settings: fakeSettings{strErr: resolveErr},
 			groups:   fakeGroups{groups: []*educationModel.Group{eduGroup(100)}},
 		}
-		_, err := svc.pickupReminders(context.Background(), caregiver, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, true, true)
+		_, _, err := svc.pickupReminders(context.Background(), caregiver, []int64{1, 2}, timezone.TodayDate(), nowMin, lead, true, true)
 		require.ErrorIs(t, err, resolveErr)
 	})
 }
@@ -374,7 +374,7 @@ func TestActivityReminders(t *testing.T) {
 		instances = append(instances, active)
 
 		svc := &service{instance: fakeInstance{instances: instances}}
-		out, err := svc.activityReminders(context.Background(), adminScope, nil, timezone.TodayDate(), nowMin, lead, overdueThreshold, true, true)
+		out, _, err := svc.activityReminders(context.Background(), adminScope, nil, timezone.TodayDate(), nowMin, lead, overdueThreshold, true, true)
 		require.NoError(t, err)
 		require.Len(t, out, 2)
 
@@ -398,12 +398,12 @@ func TestActivityReminders(t *testing.T) {
 		}
 		svc := &service{instance: fakeInstance{instances: instances}}
 
-		upcomingOnly, err := svc.activityReminders(context.Background(), adminScope, nil, timezone.TodayDate(), nowMin, lead, overdueThreshold, true, false)
+		upcomingOnly, _, err := svc.activityReminders(context.Background(), adminScope, nil, timezone.TodayDate(), nowMin, lead, overdueThreshold, true, false)
 		require.NoError(t, err)
 		require.Len(t, upcomingOnly, 1)
 		assert.Equal(t, TypeActivityStart, upcomingOnly[0].Type)
 
-		overdueOnly, err := svc.activityReminders(context.Background(), adminScope, nil, timezone.TodayDate(), nowMin, lead, overdueThreshold, false, true)
+		overdueOnly, _, err := svc.activityReminders(context.Background(), adminScope, nil, timezone.TodayDate(), nowMin, lead, overdueThreshold, false, true)
 		require.NoError(t, err)
 		require.Len(t, overdueOnly, 1)
 		assert.Equal(t, TypeActivityOverdue, overdueOnly[0].Type)
@@ -415,7 +415,7 @@ func TestActivityReminders(t *testing.T) {
 			plannedInstance("Fußball", 99, 605, 700), // room 99 — not supervised
 		}
 		svc := &service{instance: fakeInstance{instances: instances}}
-		out, err := svc.activityReminders(context.Background(), Scope{IsAdmin: false}, []int64{10}, timezone.TodayDate(), nowMin, lead, overdueThreshold, true, true)
+		out, _, err := svc.activityReminders(context.Background(), Scope{IsAdmin: false}, []int64{10}, timezone.TodayDate(), nowMin, lead, overdueThreshold, true, true)
 		require.NoError(t, err)
 		require.Len(t, out, 1)
 		assert.Equal(t, "Schach", out[0].Title)
@@ -423,7 +423,7 @@ func TestActivityReminders(t *testing.T) {
 
 	t.Run("nil instance reader yields nothing", func(t *testing.T) {
 		svc := &service{}
-		out, err := svc.activityReminders(context.Background(), adminScope, nil, timezone.TodayDate(), nowMin, lead, overdueThreshold, true, true)
+		out, _, err := svc.activityReminders(context.Background(), adminScope, nil, timezone.TodayDate(), nowMin, lead, overdueThreshold, true, true)
 		require.NoError(t, err)
 		assert.Empty(t, out)
 	})
@@ -659,6 +659,128 @@ func TestComputeSortsMostUrgentFirst(t *testing.T) {
 	assert.Equal(t, TypePickupOverdue, res.Reminders[0].Type)
 	assert.Equal(t, TypePickupUpcoming, res.Reminders[1].Type)
 	assert.Less(t, res.Reminders[0].MinutesAway, res.Reminders[1].MinutesAway)
+}
+
+// --- next-change (time-based refresh scheduling) -----------------------------
+// The frontend schedules a timer to NextChangeAt to refetch exactly when a
+// reminder crosses a threshold, instead of only on its fixed poll. These tests
+// pin the boundary math the timer depends on.
+
+func TestNextChangeMinFutureHelper(t *testing.T) {
+	assert.Equal(t, -1, futureBoundary(600, 600), "a boundary at now is not in the future")
+	assert.Equal(t, -1, futureBoundary(590, 600), "a past boundary yields the absent sentinel")
+	assert.Equal(t, 610, futureBoundary(610, 600))
+
+	assert.Equal(t, 5, minFuture(-1, 5), "first candidate replaces the absent sentinel")
+	assert.Equal(t, 5, minFuture(5, -1), "an absent candidate leaves the current value")
+	assert.Equal(t, 5, minFuture(8, 5), "the sooner candidate wins")
+	assert.Equal(t, 5, minFuture(5, 8))
+	assert.Equal(t, -1, minFuture(-1, -1), "nothing pending stays absent")
+}
+
+func TestPickupNextChange(t *testing.T) {
+	const nowMin = 600 // 10:00
+	const lead = 10
+
+	students := map[int64]*userModel.Student{1: {PersonID: 11, SchoolClass: "1a"}}
+	persons := map[int64]*userModel.Person{11: {FirstName: "Anna", LastName: "A"}}
+	newSvc := func(times map[int64]*scheduleService.EffectivePickupTime) *service {
+		return &service{
+			pickup:  fakePickup{times: times},
+			student: fakeStudent{students: students},
+			person:  fakePerson{persons: persons},
+		}
+	}
+
+	t.Run("a pickup outside the window schedules its window-entry moment", func(t *testing.T) {
+		// pickup 20 min away, lead 10 → not due yet, but enters the window at
+		// pickupMin-lead = 610. That is the next change even though `out` is empty.
+		svc := newSvc(map[int64]*scheduleService.EffectivePickupTime{1: pickupAt(620)})
+		out, next, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
+		require.NoError(t, err)
+		assert.Empty(t, out)
+		assert.Equal(t, 610, next)
+	})
+
+	t.Run("an in-window upcoming pickup schedules its flip-to-overdue moment", func(t *testing.T) {
+		// pickup 5 min away: window-entry (595) is already past, so the next change
+		// is the flip to overdue at pickupMin = 605.
+		svc := newSvc(map[int64]*scheduleService.EffectivePickupTime{1: pickupAt(605)})
+		out, next, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, 605, next)
+	})
+
+	t.Run("an already-overdue pickup has no future time-based change", func(t *testing.T) {
+		// Overdue persists until the child is picked up (a data event, not a clock
+		// tick), so there is nothing to schedule.
+		svc := newSvc(map[int64]*scheduleService.EffectivePickupTime{1: pickupAt(595)})
+		_, next, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, true, true)
+		require.NoError(t, err)
+		assert.Equal(t, -1, next)
+	})
+
+	t.Run("overdue-only schedules the flip, never the window entry", func(t *testing.T) {
+		svc := newSvc(map[int64]*scheduleService.EffectivePickupTime{1: pickupAt(620)})
+		_, next, err := svc.pickupReminders(context.Background(), Scope{IsAdmin: true}, []int64{1}, timezone.TodayDate(), nowMin, lead, false, true)
+		require.NoError(t, err)
+		assert.Equal(t, 620, next, "overdue-only: no window entry, only the flip at pickupMin")
+	})
+}
+
+func TestActivityNextChange(t *testing.T) {
+	const nowMin = 600 // 10:00
+	const lead = 10
+	const overdueThreshold = 5
+	adminScope := Scope{IsAdmin: true}
+
+	t.Run("an activity starting beyond the window schedules its earliest boundary", func(t *testing.T) {
+		// start 620, end 700. Boundaries: window entry 610, start 620,
+		// overdue 625, slot end 700. The soonest is 610.
+		svc := &service{instance: fakeInstance{instances: []*scheduleModel.ActivityInstance{
+			plannedInstance("Schach", 1, 620, 700),
+		}}}
+		out, next, err := svc.activityReminders(context.Background(), adminScope, nil, timezone.TodayDate(), nowMin, lead, overdueThreshold, true, true)
+		require.NoError(t, err)
+		assert.Empty(t, out)
+		assert.Equal(t, 610, next)
+	})
+
+	t.Run("nil instance reader yields no scheduled change", func(t *testing.T) {
+		svc := &service{}
+		_, next, err := svc.activityReminders(context.Background(), adminScope, nil, timezone.TodayDate(), nowMin, lead, overdueThreshold, true, true)
+		require.NoError(t, err)
+		assert.Equal(t, -1, next)
+	})
+}
+
+func TestComputeExposesNextChangeAt(t *testing.T) {
+	now := timezone.Now()
+	nowMin := now.Hour()*60 + now.Minute()
+	// Guard the wall-clock arithmetic against day wrap near midnight.
+	if nowMin < 30 || nowMin > 1400 {
+		t.Skip("skipping wall-clock-relative next-change test near midnight")
+	}
+
+	svc := &service{
+		settings: fakeSettings{bools: map[string]bool{
+			configModel.KeyRemindersPickupUpcomingEnabled: true,
+		}},
+		attendance: fakeAttendance{ids: []int64{1}},
+		pickup: fakePickup{times: map[int64]*scheduleService.EffectivePickupTime{
+			1: pickupAt(nowMin + 20), // outside the default 10-min lead window
+		}},
+		student: fakeStudent{students: map[int64]*userModel.Student{1: {PersonID: 11, SchoolClass: "1a"}}},
+		person:  fakePerson{persons: map[int64]*userModel.Person{11: {FirstName: "Anna", LastName: "A"}}},
+	}
+
+	res, err := svc.Compute(context.Background(), Scope{IsAdmin: true})
+	require.NoError(t, err)
+	assert.True(t, res.Enabled)
+	assert.Empty(t, res.Reminders, "the pickup is still outside its window, so nothing is due yet")
+	// It enters the window (lead 10) at (nowMin+20)-10 = nowMin+10.
+	assert.Equal(t, formatMinutes(nowMin+10), res.NextChangeAt)
 }
 
 // --- pure helpers ------------------------------------------------------------

--- a/frontend/src/lib/hooks/use-reminders.test.ts
+++ b/frontend/src/lib/hooks/use-reminders.test.ts
@@ -114,3 +114,106 @@ describe("useReminders — phoenix:reminders-stale revalidation", () => {
     expect(mockMutate).not.toHaveBeenCalled();
   });
 });
+
+describe("useReminders — next_change_at precise timer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // 10:00:00 local — reminders reason in wall-clock time.
+    vi.setSystemTime(new Date(2026, 6, 4, 10, 0, 0));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("refetches exactly at the next-change wall-clock minute (plus buffer)", () => {
+    mockUseSWRAuth.mockReturnValue(
+      swrReturn({
+        reminders: [],
+        count: 0,
+        enabled: true,
+        next_change_at: "10:05",
+      }),
+    );
+
+    renderHook(() => useReminders());
+    expect(mockMutate).not.toHaveBeenCalled();
+
+    // Just shy of the target (5 min) + most of the 2s buffer: still nothing.
+    act(() => {
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1000);
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+
+    // Crossing the buffered boundary fires exactly once.
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not schedule a timer when the feature is disabled", () => {
+    mockUseSWRAuth.mockReturnValue(
+      swrReturn({
+        reminders: [],
+        count: 0,
+        enabled: false,
+        next_change_at: "10:05",
+      }),
+    );
+
+    renderHook(() => useReminders());
+    act(() => {
+      vi.advanceTimersByTime(60 * 60 * 1000);
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("does not schedule a timer when next_change_at is absent", () => {
+    mockUseSWRAuth.mockReturnValue(
+      swrReturn({ reminders: [], count: 0, enabled: true }),
+    );
+
+    renderHook(() => useReminders());
+    act(() => {
+      vi.advanceTimersByTime(60 * 60 * 1000);
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("refetches promptly when the next change is already in the past", () => {
+    // Clock skew or a stale cache can hand us a boundary in the past; refetch
+    // soon rather than a whole day later.
+    mockUseSWRAuth.mockReturnValue(
+      swrReturn({
+        reminders: [],
+        count: 0,
+        enabled: true,
+        next_change_at: "09:55",
+      }),
+    );
+
+    renderHook(() => useReminders());
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the scheduled timer on unmount", () => {
+    mockUseSWRAuth.mockReturnValue(
+      swrReturn({
+        reminders: [],
+        count: 0,
+        enabled: true,
+        next_change_at: "10:05",
+      }),
+    );
+
+    const { unmount } = renderHook(() => useReminders());
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(10 * 60 * 1000);
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/hooks/use-reminders.test.ts
+++ b/frontend/src/lib/hooks/use-reminders.test.ts
@@ -244,4 +244,35 @@ describe("useReminders — next_change_at precise timer", () => {
     });
     expect(mockMutate).not.toHaveBeenCalled();
   });
+
+  it("measures the delay in real time across a Berlin DST spring-forward", () => {
+    // 2026-03-29 01:00 CET (+01:00); at 02:00 the clock jumps to 03:00 CEST
+    // (+02:00). A "04:00" boundary is 3h of wall-clock away but only 2h of REAL
+    // elapsed time, because the 02:00→03:00 hour never occurs. The delay must be
+    // the real 2h (a naive wall-clock subtraction would wait 3h and fire an hour
+    // late). TZ is pinned to Europe/Berlin (vitest.config.ts).
+    vi.setSystemTime(new Date(2026, 2, 29, 1, 0, 0));
+    mockUseSWRAuth.mockReturnValue(
+      swrReturn({
+        reminders: [],
+        count: 0,
+        enabled: true,
+        next_change_at: "04:00",
+      }),
+    );
+
+    renderHook(() => useReminders());
+
+    // Just before the real 2h boundary + most of the buffer: nothing yet.
+    act(() => {
+      vi.advanceTimersByTime(2 * 60 * 60 * 1000 + 1000);
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+
+    // Crossing the buffered 2h boundary fires exactly once (not at 3h).
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/lib/hooks/use-reminders.test.ts
+++ b/frontend/src/lib/hooks/use-reminders.test.ts
@@ -275,4 +275,37 @@ describe("useReminders — next_change_at precise timer", () => {
     });
     expect(mockMutate).toHaveBeenCalledTimes(1);
   });
+
+  it("re-arms across midnight when next_change_at repeats verbatim", () => {
+    // A tenant whose only time-based boundary is an end-of-day flip gets the
+    // same next_change_at = "24:00" every day. The one-shot timer must be
+    // re-armed for the NEXT midnight after it fires, not left dangling because
+    // the day-agnostic string is unchanged — otherwise the precise refresh
+    // silently degrades to the 60s poll from the first midnight on.
+    vi.setSystemTime(new Date(2026, 6, 4, 23, 0, 0)); // 23:00 Berlin (CEST)
+    mockUseSWRAuth.mockReturnValue(
+      swrReturn({
+        reminders: [],
+        count: 0,
+        enabled: true,
+        next_change_at: "24:00",
+      }),
+    );
+
+    const { rerender } = renderHook(() => useReminders());
+
+    // First boundary: 1h to midnight + the 2s buffer.
+    act(() => {
+      vi.advanceTimersByTime(60 * 60 * 1000 + 3000);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+
+    // The refetch returns the identical "24:00"; a re-render now past midnight
+    // (new Berlin day) must schedule the next midnight rather than nothing.
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(2);
+  });
 });

--- a/frontend/src/lib/hooks/use-reminders.test.ts
+++ b/frontend/src/lib/hooks/use-reminders.test.ts
@@ -308,4 +308,71 @@ describe("useReminders — next_change_at precise timer", () => {
     });
     expect(mockMutate).toHaveBeenCalledTimes(2);
   });
+
+  it("re-arms across midnight WITHOUT any re-render (self-sustaining timer)", () => {
+    // The production hazard the re-arm guards against: a persistent end-of-day
+    // "24:00" refetches to a payload SWR compares deep-equal and does NOT
+    // re-render on, so the effect never re-runs. The timer must therefore
+    // reschedule itself from inside its own callback rather than depending on a
+    // render. This test never calls rerender() — the data (and thus the hook's
+    // dependencies) is frozen for the whole run, exactly as SWR would leave it.
+    vi.setSystemTime(new Date(2026, 6, 4, 23, 0, 0)); // 23:00 Berlin (CEST)
+    mockUseSWRAuth.mockReturnValue(
+      swrReturn({
+        reminders: [],
+        count: 0,
+        enabled: true,
+        next_change_at: "24:00",
+      }),
+    );
+
+    renderHook(() => useReminders());
+
+    // First midnight: 1h to the boundary + the 2s buffer.
+    act(() => {
+      vi.advanceTimersByTime(60 * 60 * 1000 + 3000);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+
+    // No rerender. A whole day later the self-armed timer must fire again.
+    act(() => {
+      vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(2);
+
+    // And again the day after — the timer keeps re-arming indefinitely.
+    act(() => {
+      vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not re-arm (nor busy-refetch) a within-day boundary that is now past", () => {
+    // After a normal within-day boundary fires, re-computing it yields a PAST
+    // instant. The timer must not reschedule that spent one-shot — otherwise a
+    // frozen (non-re-rendering) payload would refetch every 500ms forever. The
+    // next boundary arrives via the effect re-running on a fresh string, not via
+    // self-re-arm. Here the data is frozen, so exactly one refetch must happen.
+    mockUseSWRAuth.mockReturnValue(
+      swrReturn({
+        reminders: [],
+        count: 0,
+        enabled: true,
+        next_change_at: "10:05",
+      }),
+    );
+
+    renderHook(() => useReminders());
+
+    act(() => {
+      vi.advanceTimersByTime(5 * 60 * 1000 + 3000);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+
+    // Ten more minutes with a frozen payload: no busy-refetch loop.
+    act(() => {
+      vi.advanceTimersByTime(10 * 60 * 1000);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/lib/hooks/use-reminders.test.ts
+++ b/frontend/src/lib/hooks/use-reminders.test.ts
@@ -199,6 +199,34 @@ describe("useReminders — next_change_at precise timer", () => {
     expect(mockMutate).toHaveBeenCalledTimes(1);
   });
 
+  it("schedules an end-of-day '24:00' boundary at the next midnight", () => {
+    // The backend emits "24:00" from formatMinutes(1440) for a boundary at the
+    // top of the day (e.g. a 23:59 pickup flipping overdue). It must not be
+    // dropped: the timer fires at the next midnight, 14h after the 10:00 clock.
+    mockUseSWRAuth.mockReturnValue(
+      swrReturn({
+        reminders: [],
+        count: 0,
+        enabled: true,
+        next_change_at: "24:00",
+      }),
+    );
+
+    renderHook(() => useReminders());
+
+    // Just before next midnight (14h from 10:00) + most of the buffer: nothing.
+    act(() => {
+      vi.advanceTimersByTime(14 * 60 * 60 * 1000 + 1000);
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+
+    // Crossing the buffered midnight boundary fires exactly once.
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+
   it("clears the scheduled timer on unmount", () => {
     mockUseSWRAuth.mockReturnValue(
       swrReturn({

--- a/frontend/src/lib/hooks/use-reminders.ts
+++ b/frontend/src/lib/hooks/use-reminders.ts
@@ -111,6 +111,24 @@ function msUntilNextChange(hhmm: string): number | null {
   return delay > 0 ? delay : 500;
 }
 
+// berlinDateKey returns the current Berlin calendar day as "YYYY-MM-DD",
+// independent of the browser's own timezone. It discriminates the scheduling
+// effect across midnight: next_change_at is a day-agnostic "HH:MM", so a
+// boundary that recurs at the same wall-clock time on consecutive days (a
+// persistent end-of-day "24:00", or any daily fixed threshold) would otherwise
+// hand the effect an identical dependency and never re-arm the one-shot timer
+// after it fires once. Folding the Berlin date in makes a repeated HH:MM on a
+// new day a fresh dependency. It stays constant within a day, so a boundary
+// that resolves in the past still refetches only once (no busy loop).
+function berlinDateKey(now: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: BERLIN_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}
+
 /**
  * useReminders fetches the current visual reminders for the authenticated user.
  * The /reminders page renders the full list; the header bell reads the count
@@ -135,6 +153,11 @@ export function useReminders() {
 
   const enabled = data?.enabled ?? false;
   const nextChangeAt = data?.next_change_at;
+  // Re-armed per response (data identity changes on every refetch) but only
+  // observably different across a Berlin midnight, so a repeated next_change_at
+  // still schedules the next day's boundary — see berlinDateKey / the effect.
+  const nextChangeDay =
+    enabled && nextChangeAt ? berlinDateKey(new Date()) : null;
 
   // Event-driven refresh. useGlobalSSE() runs above TenantProvider and cannot
   // build the tenant-prefixed reminders SWR key, so it dispatches
@@ -159,13 +182,18 @@ export function useReminders() {
   // window). The timer refetches on the threshold; because it fires one buffer
   // past the boundary, the server excludes the just-passed minute and the fresh
   // response carries a strictly-later next_change_at — a new string that
-  // re-runs this effect and schedules the following boundary. Gating on the
-  // string identity (not every refetch) is deliberate: it prevents a
-  // busy-refetch loop if a boundary ever resolves in the past. Backstops for the
-  // residual cases: while the tab is hidden the browser throttles/freezes this
-  // timer AND SWR pauses the refreshInterval poll (refreshWhenHidden defaults
-  // off), so neither runs — the `revalidateOnFocus: true` above is what refetches
-  // the moment the tab is refocused. Client clock skew larger than the buffer is
+  // re-runs this effect and schedules the following boundary. The effect key
+  // also folds in the Berlin day (nextChangeDay): within a day the string alone
+  // advances, but across midnight a boundary can repeat verbatim (a persistent
+  // end-of-day "24:00", or a daily fixed threshold), and without the date that
+  // identical string would never re-arm the fired one-shot timer — the feature
+  // would silently fall back to the 60s poll from the next midnight on. The date
+  // is stable within a day, so a boundary that resolves in the past still
+  // refetches only once (no busy-refetch loop). Backstops for the residual
+  // cases: while the tab is hidden the browser throttles/freezes this timer AND
+  // SWR pauses the refreshInterval poll (refreshWhenHidden defaults off), so
+  // neither runs — the `revalidateOnFocus: true` above is what refetches the
+  // moment the tab is refocused. Client clock skew larger than the buffer is
   // caught by the next 60s poll once the tab is visible again.
   useEffect(() => {
     if (!enabled || !nextChangeAt) return;
@@ -175,7 +203,7 @@ export function useReminders() {
       void mutate();
     }, delay);
     return () => clearTimeout(timer);
-  }, [enabled, nextChangeAt, mutate]);
+  }, [enabled, nextChangeAt, nextChangeDay, mutate]);
 
   return {
     reminders: data?.reminders ?? [],

--- a/frontend/src/lib/hooks/use-reminders.ts
+++ b/frontend/src/lib/hooks/use-reminders.ts
@@ -31,6 +31,11 @@ const NEXT_CHANGE_BUFFER_MS = 2000;
 // time-based change. Returns null for an unparseable value. When the target is
 // already in the past (clock skew, or the timer resolving at the exact minute),
 // it returns a short delay so we refetch promptly rather than a whole day later.
+//
+// "24:00" is accepted: the backend emits it from formatMinutes(1440) for a
+// boundary at end-of-day (e.g. a 23:59 pickup flipping overdue at minute 1440).
+// setHours(24, 0) normalizes to the next day's midnight, which is that exact
+// instant — so the timer still fires on the boundary instead of being dropped.
 function msUntilNextChange(hhmm: string): number | null {
   const match = /^(\d{2}):(\d{2})$/.exec(hhmm);
   if (!match) return null;
@@ -39,7 +44,8 @@ function msUntilNextChange(hhmm: string): number | null {
   if (
     Number.isNaN(hours) ||
     Number.isNaN(minutes) ||
-    hours > 23 ||
+    hours > 24 ||
+    (hours === 24 && minutes > 0) ||
     minutes > 59
   ) {
     return null;

--- a/frontend/src/lib/hooks/use-reminders.ts
+++ b/frontend/src/lib/hooks/use-reminders.ts
@@ -26,6 +26,11 @@ const IDLE_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 // of a wall-clock minute, and client/server clocks can drift by a second or two.
 const NEXT_CHANGE_BUFFER_MS = 2000;
 
+// When the flagged boundary is already in the past (client clock skew, or the
+// timer resolving at the exact minute), refetch after this short delay rather
+// than a whole day later.
+const PAST_BOUNDARY_REFETCH_MS = 500;
+
 // The backend reports next_change_at in Berlin wall-clock time (formatMinutes on
 // timezone.Now()), so the timer delay must be measured against Berlin time, NOT
 // the browser's local zone. A device on a different timezone (traveling staff, a
@@ -53,34 +58,62 @@ function berlinSecondsOfDay(now: Date): number {
 
 // berlinUtcOffsetSeconds returns Europe/Berlin's UTC offset in seconds at the
 // given instant: +7200 in summer (CEST) or +3600 in winter (CET). Used to
-// correct the scheduled delay across a DST transition (see msUntilNextChange).
+// correct the scheduled delay across a DST transition (see nextChangeDelay).
+//
+// The offset is derived by formatting the instant as Berlin wall-clock fields
+// and differencing that against the real instant. This relies only on Intl
+// timeZone support (already required by berlinSecondsOfDay), NOT the newer
+// "longOffset" option — so it stays correct on older WebViews instead of
+// silently falling back to no DST correction (which would fire the refetch ~1h
+// off on the two transition nights per year).
 function berlinUtcOffsetSeconds(at: Date): number {
-  const tzName = new Intl.DateTimeFormat("en-US", {
+  const parts = new Intl.DateTimeFormat("en-GB", {
     timeZone: BERLIN_TIME_ZONE,
-    timeZoneName: "longOffset",
-  })
-    .formatToParts(at)
-    .find((p) => p.type === "timeZoneName")?.value;
-  // longOffset renders a zero-padded "GMT+02:00" / "GMT-01:00" (bare "GMT" for
-  // UTC, which Berlin never is). Anything unexpected falls back to 0 rather than
-  // NaN-poisoning the delay.
-  const match = /GMT([+-])(\d{2}):(\d{2})/.exec(tzName ?? "");
-  if (!match) return 0;
-  const sign = match[1] === "-" ? -1 : 1;
-  return sign * (Number(match[2]) * 3600 + Number(match[3]) * 60);
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(at);
+  const value = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value ?? "0");
+  // Some engines render midnight as "24" under hour12:false; normalize to 0.
+  const asUtc = Date.UTC(
+    value("year"),
+    value("month") - 1,
+    value("day"),
+    value("hour") % 24,
+    value("minute"),
+    value("second"),
+  );
+  return Math.round((asUtc - at.getTime()) / 1000);
 }
 
-// msUntilNextChange returns how long to wait before refetching so the refetch
+interface NextChangeDelay {
+  // How long to wait before refetching, in ms.
+  delayMs: number;
+  // Whether the flagged boundary is a genuine future instant. Drives whether the
+  // one-shot timer re-arms itself after firing (see the effect): a boundary that
+  // is still in the future after the refetch — a day-agnostic "24:00" that maps
+  // to the *next* midnight — must recur; one that has fallen into the past is a
+  // spent one-shot for this occurrence.
+  inFuture: boolean;
+}
+
+// nextChangeDelay computes how long to wait before refetching so the refetch
 // lands just after the Berlin wall-clock "HH:MM" the backend flagged as the next
-// time-based change. Returns null for an unparseable value. When the target is
-// already in the past (clock skew, or the timer resolving at the exact minute),
-// it returns a short delay so we refetch promptly rather than a whole day later.
+// time-based change, and whether that boundary is still in the future. Returns
+// null for an unparseable value. When the target is already in the past (clock
+// skew, or the timer resolving at the exact minute) it returns a short delay
+// (inFuture: false) so we refetch promptly rather than a whole day later.
 //
 // "24:00" is accepted: the backend emits it from formatMinutes(1440) for a
 // boundary at end-of-day (e.g. a 23:59 pickup flipping overdue at minute 1440).
 // It maps to 86400 seconds — one full day of Berlin seconds ahead of midnight —
 // so the timer fires at the next midnight instead of being dropped.
-function msUntilNextChange(hhmm: string): number | null {
+function nextChangeDelay(hhmm: string): NextChangeDelay | null {
   const match = /^(\d{2}):(\d{2})$/.exec(hhmm);
   if (!match) return null;
   const hours = Number(match[1]);
@@ -107,26 +140,13 @@ function msUntilNextChange(hhmm: string): number | null {
   const estTarget = new Date(now.getTime() + wallDeltaSec * 1000);
   const offsetTarget = berlinUtcOffsetSeconds(estTarget);
   const realDeltaSec = wallDeltaSec - (offsetTarget - offsetNow);
-  const delay = realDeltaSec * 1000 + NEXT_CHANGE_BUFFER_MS;
-  return delay > 0 ? delay : 500;
-}
-
-// berlinDateKey returns the current Berlin calendar day as "YYYY-MM-DD",
-// independent of the browser's own timezone. It discriminates the scheduling
-// effect across midnight: next_change_at is a day-agnostic "HH:MM", so a
-// boundary that recurs at the same wall-clock time on consecutive days (a
-// persistent end-of-day "24:00", or any daily fixed threshold) would otherwise
-// hand the effect an identical dependency and never re-arm the one-shot timer
-// after it fires once. Folding the Berlin date in makes a repeated HH:MM on a
-// new day a fresh dependency. It stays constant within a day, so a boundary
-// that resolves in the past still refetches only once (no busy loop).
-function berlinDateKey(now: Date): string {
-  return new Intl.DateTimeFormat("en-CA", {
-    timeZone: BERLIN_TIME_ZONE,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(now);
+  if (realDeltaSec <= 0) {
+    return { delayMs: PAST_BOUNDARY_REFETCH_MS, inFuture: false };
+  }
+  return {
+    delayMs: realDeltaSec * 1000 + NEXT_CHANGE_BUFFER_MS,
+    inFuture: true,
+  };
 }
 
 /**
@@ -153,11 +173,6 @@ export function useReminders() {
 
   const enabled = data?.enabled ?? false;
   const nextChangeAt = data?.next_change_at;
-  // Re-armed per response (data identity changes on every refetch) but only
-  // observably different across a Berlin midnight, so a repeated next_change_at
-  // still schedules the next day's boundary — see berlinDateKey / the effect.
-  const nextChangeDay =
-    enabled && nextChangeAt ? berlinDateKey(new Date()) : null;
 
   // Event-driven refresh. useGlobalSSE() runs above TenantProvider and cannot
   // build the tenant-prefixed reminders SWR key, so it dispatches
@@ -179,31 +194,58 @@ export function useReminders() {
   // no backend event, so instead of only catching them on the 60s poll we
   // schedule a single timer to the exact Berlin wall-clock minute the backend
   // reported as the next change (a pickup/activity entering or leaving its
-  // window). The timer refetches on the threshold; because it fires one buffer
-  // past the boundary, the server excludes the just-passed minute and the fresh
-  // response carries a strictly-later next_change_at — a new string that
-  // re-runs this effect and schedules the following boundary. The effect key
-  // also folds in the Berlin day (nextChangeDay): within a day the string alone
-  // advances, but across midnight a boundary can repeat verbatim (a persistent
-  // end-of-day "24:00", or a daily fixed threshold), and without the date that
-  // identical string would never re-arm the fired one-shot timer — the feature
-  // would silently fall back to the 60s poll from the next midnight on. The date
-  // is stable within a day, so a boundary that resolves in the past still
-  // refetches only once (no busy-refetch loop). Backstops for the residual
-  // cases: while the tab is hidden the browser throttles/freezes this timer AND
-  // SWR pauses the refreshInterval poll (refreshWhenHidden defaults off), so
-  // neither runs — the `revalidateOnFocus: true` above is what refetches the
-  // moment the tab is refocused. Client clock skew larger than the buffer is
-  // caught by the next 60s poll once the tab is visible again.
+  // window). Because it fires one buffer past the boundary, the server excludes
+  // the just-passed minute and the fresh response carries a later next_change_at
+  // in the normal within-day case — a new string that re-runs this effect for
+  // the following boundary.
+  //
+  // The one-shot timer RE-ARMS ITSELF after firing rather than relying on that
+  // re-run, because the re-run is not guaranteed: a day-agnostic boundary can
+  // repeat verbatim across midnight (a persistent end-of-day "24:00", or a daily
+  // fixed threshold), and the refetch then returns a payload SWR compares equal
+  // and does not re-render on — so the effect would never re-run and the timer
+  // would never re-arm, silently degrading to the 60s poll from the first
+  // midnight on. Rescheduling in the callback makes the timer self-sustaining.
+  // We only re-arm when the boundary is still in the future (the "24:00" case,
+  // which now maps to the *next* midnight); a boundary that has fallen into the
+  // past is a spent one-shot, and re-arming it would busy-refetch under large
+  // clock skew, so we let the refreshed response drive the next arm instead.
+  //
+  // Backstops for the residual cases: while the tab is hidden the browser
+  // throttles/freezes this timer AND SWR pauses the refreshInterval poll
+  // (refreshWhenHidden defaults off), so neither runs — the
+  // `revalidateOnFocus: true` above is what refetches the moment the tab is
+  // refocused. Client clock skew larger than the buffer is caught by the next
+  // 60s poll once the tab is visible again.
   useEffect(() => {
     if (!enabled || !nextChangeAt) return;
-    const delay = msUntilNextChange(nextChangeAt);
-    if (delay === null) return;
-    const timer = setTimeout(() => {
-      void mutate();
-    }, delay);
-    return () => clearTimeout(timer);
-  }, [enabled, nextChangeAt, nextChangeDay, mutate]);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const arm = (isReArm: boolean) => {
+      const next = nextChangeDelay(nextChangeAt);
+      if (next === null) return;
+      if (!next.inFuture) {
+        // The boundary is already in the past. On the initial arm (clock skew,
+        // or mounting at the exact minute) refetch once soon. When reached via a
+        // re-arm after a fire, the just-fired mutate already covered this
+        // occurrence — scheduling another would busy-refetch a perpetually-past
+        // value, so stop and let the refreshed response re-arm via the effect.
+        if (!isReArm) {
+          timer = setTimeout(() => {
+            void mutate();
+          }, next.delayMs);
+        }
+        return;
+      }
+      timer = setTimeout(() => {
+        void mutate();
+        arm(true);
+      }, next.delayMs);
+    };
+    arm(false);
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [enabled, nextChangeAt, mutate]);
 
   return {
     reminders: data?.reminders ?? [],

--- a/frontend/src/lib/hooks/use-reminders.ts
+++ b/frontend/src/lib/hooks/use-reminders.ts
@@ -21,6 +21,36 @@ const ACTIVE_REFRESH_INTERVAL_MS = 60 * 1000;
 // in the disabled case cuts the pointless background load ~5x.
 const IDLE_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
+// Small cushion added to the scheduled refresh so the server-side minute
+// boundary has definitely elapsed before we refetch: next_change_at is the top
+// of a wall-clock minute, and client/server clocks can drift by a second or two.
+const NEXT_CHANGE_BUFFER_MS = 2000;
+
+// msUntilNextChange returns how long to wait before refetching so the refetch
+// lands just after the wall-clock "HH:MM" the backend flagged as the next
+// time-based change. Returns null for an unparseable value. When the target is
+// already in the past (clock skew, or the timer resolving at the exact minute),
+// it returns a short delay so we refetch promptly rather than a whole day later.
+function msUntilNextChange(hhmm: string): number | null {
+  const match = /^(\d{2}):(\d{2})$/.exec(hhmm);
+  if (!match) return null;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (
+    Number.isNaN(hours) ||
+    Number.isNaN(minutes) ||
+    hours > 23 ||
+    minutes > 59
+  ) {
+    return null;
+  }
+  const now = new Date();
+  const target = new Date(now);
+  target.setHours(hours, minutes, 0, 0);
+  const delay = target.getTime() + NEXT_CHANGE_BUFFER_MS - now.getTime();
+  return delay > 0 ? delay : 500;
+}
+
 /**
  * useReminders fetches the current visual reminders for the authenticated user.
  * The /reminders page renders the full list; the header bell reads the count
@@ -34,10 +64,17 @@ export function useReminders() {
     {
       refreshInterval: (latest) =>
         latest?.enabled ? ACTIVE_REFRESH_INTERVAL_MS : IDLE_REFRESH_INTERVAL_MS,
+      // The global SWR config disables focus revalidation (SSE covers most
+      // freshness). Reminders are the exception: a backgrounded tab pauses the
+      // refreshInterval poll entirely, so without this a threshold crossed while
+      // the tab was hidden would not surface until a manual reload. Re-enable it
+      // for this key so returning to the tab refetches immediately.
+      revalidateOnFocus: true,
     },
   );
 
   const enabled = data?.enabled ?? false;
+  const nextChangeAt = data?.next_change_at;
 
   // Event-driven refresh. useGlobalSSE() runs above TenantProvider and cannot
   // build the tenant-prefixed reminders SWR key, so it dispatches
@@ -54,6 +91,23 @@ export function useReminders() {
     window.addEventListener("phoenix:reminders-stale", handler);
     return () => window.removeEventListener("phoenix:reminders-stale", handler);
   }, [enabled, mutate]);
+
+  // Precise time-based refresh. Time-based reminders cross their threshold with
+  // no backend event, so instead of only catching them on the 60s poll we
+  // schedule a single timer to the exact wall-clock minute the backend reported
+  // as the next change (a pickup/activity entering or leaving its window). The
+  // timer refetches on the threshold; the fresh response carries the following
+  // next_change_at, which reschedules this effect. The poll stays as a backstop
+  // for the case where a hidden tab throttles this timer.
+  useEffect(() => {
+    if (!enabled || !nextChangeAt) return;
+    const delay = msUntilNextChange(nextChangeAt);
+    if (delay === null) return;
+    const timer = setTimeout(() => {
+      void mutate();
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [enabled, nextChangeAt, mutate]);
 
   return {
     reminders: data?.reminders ?? [],

--- a/frontend/src/lib/hooks/use-reminders.ts
+++ b/frontend/src/lib/hooks/use-reminders.ts
@@ -26,16 +26,41 @@ const IDLE_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 // of a wall-clock minute, and client/server clocks can drift by a second or two.
 const NEXT_CHANGE_BUFFER_MS = 2000;
 
+// The backend reports next_change_at in Berlin wall-clock time (formatMinutes on
+// timezone.Now()), so the timer delay must be measured against Berlin time, NOT
+// the browser's local zone. A device on a different timezone (traveling staff, a
+// misconfigured tablet, a UTC browser) would otherwise schedule the refetch at
+// the wrong instant. Intl resolves the offset — including DST — for us.
+const BERLIN_TIME_ZONE = "Europe/Berlin";
+
+// berlinSecondsOfDay returns the current wall-clock time in Europe/Berlin as
+// seconds since local midnight (0..86399), independent of the browser's own
+// timezone.
+function berlinSecondsOfDay(now: Date): number {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: BERLIN_TIME_ZONE,
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(now);
+  const value = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value ?? "0");
+  // Some engines render midnight as "24" under hour12:false; normalize to 0.
+  const hour = value("hour") % 24;
+  return hour * 3600 + value("minute") * 60 + value("second");
+}
+
 // msUntilNextChange returns how long to wait before refetching so the refetch
-// lands just after the wall-clock "HH:MM" the backend flagged as the next
+// lands just after the Berlin wall-clock "HH:MM" the backend flagged as the next
 // time-based change. Returns null for an unparseable value. When the target is
 // already in the past (clock skew, or the timer resolving at the exact minute),
 // it returns a short delay so we refetch promptly rather than a whole day later.
 //
 // "24:00" is accepted: the backend emits it from formatMinutes(1440) for a
 // boundary at end-of-day (e.g. a 23:59 pickup flipping overdue at minute 1440).
-// setHours(24, 0) normalizes to the next day's midnight, which is that exact
-// instant — so the timer still fires on the boundary instead of being dropped.
+// It maps to 86400 seconds — one full day of Berlin seconds ahead of midnight —
+// so the timer fires at the next midnight instead of being dropped.
 function msUntilNextChange(hhmm: string): number | null {
   const match = /^(\d{2}):(\d{2})$/.exec(hhmm);
   if (!match) return null;
@@ -50,10 +75,10 @@ function msUntilNextChange(hhmm: string): number | null {
   ) {
     return null;
   }
+  const targetSec = hours * 3600 + minutes * 60; // 24:00 → 86400
   const now = new Date();
-  const target = new Date(now);
-  target.setHours(hours, minutes, 0, 0);
-  const delay = target.getTime() + NEXT_CHANGE_BUFFER_MS - now.getTime();
+  const delaySec = targetSec - berlinSecondsOfDay(now);
+  const delay = delaySec * 1000 + NEXT_CHANGE_BUFFER_MS;
   return delay > 0 ? delay : 500;
 }
 
@@ -100,11 +125,16 @@ export function useReminders() {
 
   // Precise time-based refresh. Time-based reminders cross their threshold with
   // no backend event, so instead of only catching them on the 60s poll we
-  // schedule a single timer to the exact wall-clock minute the backend reported
-  // as the next change (a pickup/activity entering or leaving its window). The
-  // timer refetches on the threshold; the fresh response carries the following
-  // next_change_at, which reschedules this effect. The poll stays as a backstop
-  // for the case where a hidden tab throttles this timer.
+  // schedule a single timer to the exact Berlin wall-clock minute the backend
+  // reported as the next change (a pickup/activity entering or leaving its
+  // window). The timer refetches on the threshold; because it fires one buffer
+  // past the boundary, the server excludes the just-passed minute and the fresh
+  // response carries a strictly-later next_change_at — a new string that
+  // re-runs this effect and schedules the following boundary. Gating on the
+  // string identity (not every refetch) is deliberate: it prevents a
+  // busy-refetch loop if a boundary ever resolves in the past. The 60s poll
+  // backstops the residual cases — a hidden tab throttling this timer, or client
+  // clock skew larger than the buffer.
   useEffect(() => {
     if (!enabled || !nextChangeAt) return;
     const delay = msUntilNextChange(nextChangeAt);

--- a/frontend/src/lib/hooks/use-reminders.ts
+++ b/frontend/src/lib/hooks/use-reminders.ts
@@ -51,6 +51,25 @@ function berlinSecondsOfDay(now: Date): number {
   return hour * 3600 + value("minute") * 60 + value("second");
 }
 
+// berlinUtcOffsetSeconds returns Europe/Berlin's UTC offset in seconds at the
+// given instant: +7200 in summer (CEST) or +3600 in winter (CET). Used to
+// correct the scheduled delay across a DST transition (see msUntilNextChange).
+function berlinUtcOffsetSeconds(at: Date): number {
+  const tzName = new Intl.DateTimeFormat("en-US", {
+    timeZone: BERLIN_TIME_ZONE,
+    timeZoneName: "longOffset",
+  })
+    .formatToParts(at)
+    .find((p) => p.type === "timeZoneName")?.value;
+  // longOffset renders a zero-padded "GMT+02:00" / "GMT-01:00" (bare "GMT" for
+  // UTC, which Berlin never is). Anything unexpected falls back to 0 rather than
+  // NaN-poisoning the delay.
+  const match = /GMT([+-])(\d{2}):(\d{2})/.exec(tzName ?? "");
+  if (!match) return 0;
+  const sign = match[1] === "-" ? -1 : 1;
+  return sign * (Number(match[2]) * 3600 + Number(match[3]) * 60);
+}
+
 // msUntilNextChange returns how long to wait before refetching so the refetch
 // lands just after the Berlin wall-clock "HH:MM" the backend flagged as the next
 // time-based change. Returns null for an unparseable value. When the target is
@@ -77,8 +96,18 @@ function msUntilNextChange(hhmm: string): number | null {
   }
   const targetSec = hours * 3600 + minutes * 60; // 24:00 → 86400
   const now = new Date();
-  const delaySec = targetSec - berlinSecondsOfDay(now);
-  const delay = delaySec * 1000 + NEXT_CHANGE_BUFFER_MS;
+  // wallDeltaSec is a wall-clock delta, but setTimeout counts real elapsed ms.
+  // On a Berlin DST-transition day the two diverge by 3600s across the boundary
+  // (spring-forward loses an hour, fall-back gains one), so a raw wall-clock
+  // subtraction would fire ~1h early or late. Correct by the change in UTC
+  // offset between now and the (estimated) target instant — Berlin's offset is
+  // piecewise-constant, so a single estimate lands in the right region.
+  const wallDeltaSec = targetSec - berlinSecondsOfDay(now);
+  const offsetNow = berlinUtcOffsetSeconds(now);
+  const estTarget = new Date(now.getTime() + wallDeltaSec * 1000);
+  const offsetTarget = berlinUtcOffsetSeconds(estTarget);
+  const realDeltaSec = wallDeltaSec - (offsetTarget - offsetNow);
+  const delay = realDeltaSec * 1000 + NEXT_CHANGE_BUFFER_MS;
   return delay > 0 ? delay : 500;
 }
 
@@ -132,9 +161,12 @@ export function useReminders() {
   // response carries a strictly-later next_change_at — a new string that
   // re-runs this effect and schedules the following boundary. Gating on the
   // string identity (not every refetch) is deliberate: it prevents a
-  // busy-refetch loop if a boundary ever resolves in the past. The 60s poll
-  // backstops the residual cases — a hidden tab throttling this timer, or client
-  // clock skew larger than the buffer.
+  // busy-refetch loop if a boundary ever resolves in the past. Backstops for the
+  // residual cases: while the tab is hidden the browser throttles/freezes this
+  // timer AND SWR pauses the refreshInterval poll (refreshWhenHidden defaults
+  // off), so neither runs — the `revalidateOnFocus: true` above is what refetches
+  // the moment the tab is refocused. Client clock skew larger than the buffer is
+  // caught by the next 60s poll once the tab is visible again.
   useEffect(() => {
     if (!enabled || !nextChangeAt) return;
     const delay = msUntilNextChange(nextChangeAt);

--- a/frontend/src/lib/reminders-api.ts
+++ b/frontend/src/lib/reminders-api.ts
@@ -22,6 +22,12 @@ export interface RemindersResult {
   // True when the tenant has enabled at least one reminder type. Drives
   // whether the header bell (the only entry point to /reminders) renders at all.
   enabled: boolean;
+  // Wall-clock "HH:MM" of the soonest future moment this list changes purely by
+  // time passing (a pickup/activity entering or leaving its window). The hook
+  // schedules a timer to exactly this time so a reminder appears on its
+  // threshold instead of only on the next poll. Absent when nothing time-based
+  // is pending. Data-driven changes still arrive via the SSE-stale event.
+  next_change_at?: string;
 }
 
 // Proxy route wrapper envelope: { success: true, data: <payload> }.

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,6 +2,14 @@ import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
 
+// Pin the test process to Berlin time. The app reasons in Europe/Berlin
+// wall-clock (backend timestamps, reminder thresholds, calendar-date handling),
+// and several tests drive fake system time and assert against wall-clock
+// boundaries. Without a fixed zone those assertions depend on the CI machine's
+// timezone; forcing Berlin makes them deterministic and matches production
+// semantics. Set before workers spawn so Date's local-zone cache picks it up.
+process.env.TZ = "Europe/Berlin";
+
 export default defineConfig({
   plugins: [react()],
   test: {


### PR DESCRIPTION
## Summary

Visual reminders (pickup upcoming/overdue, activity start/overdue) change state purely as wall-clock time passes, with **no backend event** to trigger a refetch. Previously the frontend only caught these transitions on its fixed 60s poll, so a reminder could appear up to ~1 minute late.

This branch makes time-based reminders surface **exactly on their threshold** by scheduling a precise client-side timer to the next change minute reported by the backend, instead of relying on the poll.

## How it works

- **Backend** now returns `next_change_at` on the reminders result: the wall-clock `"HH:MM"` of the soonest future moment the list would change purely by time passing (next pickup/activity entering or leaving its window). Omitted when nothing time-based is pending. Data-driven changes (check-ins, edits) continue to arrive via the existing SSE-stale event.
- **Frontend** computes the delay to that minute and fires a single timer to refetch, replacing "wait for the next poll."

## Hardening (the bulk of the commits)

The precise timer has to survive real-world conditions, so most commits harden it:

- **Berlin time, not browser time** — the delay is measured against `Europe/Berlin` via `Intl`, so a misconfigured tablet, traveling staff, or a UTC browser still fires at the right instant.
- **DST correction** — corrects the wall-clock-vs-real-elapsed divergence so the refetch doesn't fire ~1h off on the two transition nights per year, without depending on the newer `longOffset` Intl option (stays correct on older WebViews).
- **Self-re-arming one-shot** — the timer reschedules itself in its callback. A day-agnostic boundary (persistent end-of-day `24:00`, or a fixed daily threshold) can return a payload SWR compares equal, which would never re-run the effect; without self-re-arm the timer would silently degrade to the 60s poll from the first midnight on.
- **`24:00` boundary** — accepted from `formatMinutes(1440)` (e.g. a 23:59 pickup flipping overdue at end of day) and mapped to the next midnight instead of being dropped.
- **Backgrounded tab** — the timer and the SWR poll both freeze while the tab is hidden; `revalidateOnFocus: true` refetches the moment the tab is refocused.

## Correctness / security

- The pickup **read-access gate is applied before** deriving any next-change boundary, so an unreadable child's exact future pickup minute can't leak through `next_change_at` even though no reminder for them is emitted.

## Performance

- The read-access gate uses a new lightweight `FindReadScopeByIDs` projection (id/group_id/person_id/school_class) instead of the repository's full `FindByIDs` hydration (weekday bus-day/departure jsonb + an `information_schema` probe), which would otherwise run on every 60s header poll for the whole present population. Name lookups stay bounded to the due subset.

## Tests

- Backend service internal tests extended for `next_change_at` boundaries and the read gate.
- New frontend `use-reminders` tests covering delay computation, DST, `24:00`, past-boundary, and self-re-arm.

## Test plan

- [ ] `cd backend && go test ./services/reminders/...`
- [ ] `cd frontend && pnpm run check` and vitest for `use-reminders`
- [ ] Manually verify a pickup reminder appears on its exact threshold minute (not up to a minute late)
