### PR TITLE
fix: restore smooth scroll edges on touch devices

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -563,12 +563,6 @@ html {
   background: #ffffff;
   overflow-y: scroll;
   scrollbar-gutter: stable;
-  /* html is the document scroll container. Without this, touch devices
-     rubber-band (bounce) past the top/bottom and sideways even when there is
-     nothing more to scroll — which reads as a stutter at the end of a page and
-     lets short pages be dragged in both axes. Contain the overscroll so the
-     document never chains into the native bounce. */
-  overscroll-behavior: none;
 }
 
 body {


### PR DESCRIPTION
## What

Removes the global `overscroll-behavior: none` on `html` (in `globals.css`).

## Why

The lock was added to stop horizontal drag and overscroll on short pages. But it also disables the native elastic bounce, so on iOS every scroll boundary (top, bottom, and sides) felt like a hard wall instead of springing back softly.

The original short-page issue (Notfall page) is already handled by the emergency-page mobile layout fix that fits the card within the viewport. The lock is therefore no longer needed, and the hard-edge regression outweighs it.

## Scope

Only removes the lock. No other changes are bundled in this PR.

## Test

- [ ] iOS: hit top/bottom/sides, it springs back softly (no hard wall)
- [ ] Notfall page stays within the viewport (no unwanted scrolling)