### PR TITLE
fix(enrollment): map care-offering day validation to HTTP 400

### DIFF
--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -2981,13 +2981,13 @@ func resolveSelectedDays(offering *enrollmentModels.CareOffering, picks []string
 	return days, nil
 }
 
-var errParentChoiceOfferingMissingDays = fmt.Errorf("offering requires the parent to pick at least one day")
+var errParentChoiceOfferingMissingDays = fmt.Errorf("%w: offering requires the parent to pick at least one day", ErrInvalidSubmission)
 
 func resolveManualSelectedDays(offering *enrollmentModels.CareOffering, picks []string) ([]string, error) {
 	switch offering.DaysOfWeekMode {
 	case enrollmentModels.DaysOfWeekModeFixed:
 		if len(picks) > 0 {
-			return nil, fmt.Errorf("offering does not allow parent day selection (days_of_week_mode=fixed)")
+			return nil, fmt.Errorf("%w: offering does not allow parent day selection (days_of_week_mode=fixed)", ErrInvalidSubmission)
 		}
 		return nil, nil
 	case enrollmentModels.DaysOfWeekModeParentChoice:
@@ -2999,7 +2999,7 @@ func resolveManualSelectedDays(offering *enrollmentModels.CareOffering, picks []
 		dedup := make([]string, 0, len(picks))
 		for _, d := range picks {
 			if !allowed[d] {
-				return nil, fmt.Errorf("day %q is not in the offering's available_days", d)
+				return nil, fmt.Errorf("%w: day %q is not in the offering's available_days", ErrInvalidSubmission, d)
 			}
 			if seen[d] {
 				continue

--- a/backend/services/enrollment/resolve_selected_days_test.go
+++ b/backend/services/enrollment/resolve_selected_days_test.go
@@ -1,6 +1,7 @@
 package enrollment
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -64,6 +65,35 @@ func TestResolveSelectedDays_ParentChoiceDedupes(t *testing.T) {
 	got, err := resolveSelectedDays(parentChoiceOffering("mon", "tue", "wed"), []string{"mon", "mon", "tue"})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"mon", "tue"}, got, "duplicate parent picks must collapse")
+}
+
+// Day-validation failures on parent input must map to a 400 at the HTTP
+// layer. mapSubmitError does that by matching ErrInvalidSubmission, so
+// these errors have to wrap it — otherwise a bad day pick surfaces as a
+// 500 (looks like a server bug, and the frontend has no German message).
+func TestResolveSelectedDays_ParentInputErrorsWrapInvalidSubmission(t *testing.T) {
+	cases := map[string]func() error{
+		"subset violation": func() error {
+			_, err := resolveSelectedDays(parentChoiceOffering("mon", "tue"), []string{"sat"})
+			return err
+		},
+		"missing picks": func() error {
+			_, err := resolveSelectedDays(parentChoiceOffering("mon", "tue"), nil)
+			return err
+		},
+		"fixed rejects picks": func() error {
+			_, err := resolveSelectedDays(fixedOffering("mon"), []string{"mon"})
+			return err
+		},
+	}
+	for name, run := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := run()
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrInvalidSubmission),
+				"parent day-validation error must wrap ErrInvalidSubmission so it maps to 400, got %q", err)
+		})
+	}
 }
 
 func TestResolveSelectedDays_RejectsUnknownMode(t *testing.T) {


### PR DESCRIPTION
## Kontext

Audit + Live-Verifikation zu #1834 ergab: das Feature (auswählbare Wochentage auf `available_days` beschränken) ist bereits vollständig implementiert und funktioniert Ende-zu-Ende (Admin-Editor setzt erlaubte Tage, Anmeldeformular zeigt nur diese, Backend lehnt Tage außerhalb `available_days` ab).

Einziger echter Defekt: die Ablehnung kam als **HTTP 500 statt 400**.

## Problem

Die Tag-Validierung in `resolveManualSelectedDays`/`resolveSelectedDays` gab nackte `fmt.Errorf`-Fehler zurück. Anders als die ~20 Geschwister-Validierungen sind sie nicht mit `ErrInvalidSubmission` umhüllt, fallen daher in den `default`-Zweig von `mapSubmitError` und werden als `ErrorInternalServer` (500) ausgegeben.

Folgen: sieht im Monitoring wie ein Serverfehler aus, und der deutsche Error-Mapper im Frontend hat keine passende Meldung (Fallback auf generisches „(HTTP 500)").

## Änderung

Die drei parent-input-getriebenen Tag-Fehler mit `ErrInvalidSubmission` umhüllt, damit die HTTP-Schicht sie als 400 klassifiziert:
- Subset-Verletzung (Tag nicht in `available_days`)
- fehlende Tagesauswahl bei `parent_choice`
- Tagesauswahl bei `fixed` (nicht erlaubt)

Der `unknown days_of_week_mode`-Fall bleibt bewusst 500 (Offering-Config-Integrität, kein Eltern-Input; per DB-CHECK ohnehin unerreichbar).

## Verifikation

- `go build` + `go vet` sauber
- Alle `TestResolveSelectedDays`-Tests grün, plus neuer Test `TestResolveSelectedDays_ParentInputErrorsWrapInvalidSubmission`, der die 400-Zusage via `errors.Is(err, ErrInvalidSubmission)` absichert
- Kein bestehender Test verändert; die 500-Tests im Package betreffen andere Pfade (export, rollover)
- Live gegen lokalen Stack: manipulierter Submit mit `selected_days=["tue"]` auf einem Mo-only-Angebot gibt jetzt `HTTP 400` (vorher 500)

Closes #1834