### PR TITLE
docs: DSGVO-Pflichtdokumente als Erstentwurf

### DIFF
--- a/docs/moto-dsgvo-dokumente/00-uebersicht.md
+++ b/docs/moto-dsgvo-dokumente/00-uebersicht.md
@@ -1,0 +1,118 @@
+# Übersicht der DSGVO-Dokumentation "moto"
+
+| | |
+|---|---|
+| **Dokument** | 00 Übersicht und konsolidierte Offene-Punkte-Liste |
+| **Version** | 1.0 |
+| **Stand** | 2026-07-07 |
+| **Status** | Arbeitsdokument, wird bei jeder Änderung der Reihe fortgeschrieben |
+
+---
+
+## 1. Dokumentenreihe
+
+Rollenverteilung in allen Dokumenten einheitlich: Die Schule bzw. der Schulträger ist **Verantwortlicher** (Art. 4 Nr. 7 DSGVO), moto ist **Auftragsverarbeiter** (Art. 4 Nr. 8, Art. 28 DSGVO). Alle Dokumente liegen in Version 1.0, Stand 2026-07-07, Status "Entwurf zur internen Prüfung" vor.
+
+| Nr. | Datei | Inhalt | Funktion |
+|---|---|---|---|
+| 01 | `01-auftragsverarbeitungsvertrag.md` | Auftragsverarbeitungsvertrag (AVV) nach Art. 28 Abs. 3 DSGVO | Vertragliche Grundlage; Anlage 1 = Dokument 04, Anlage 2 = Dokument 02, Anlage 3 = Dokument 03, Anlage 4 = Ansprechpartner (noch zu erstellen) |
+| 02 | `02-tom-dokumentation.md` | Technische und organisatorische Maßnahmen (Art. 32 DSGVO) | Anlage 2 zum AVV; Maßnahmen nach Kontrollbereichen mit Umsetzungsstand |
+| 03 | `03-subprozessorenliste.md` | Subprozessorenliste (Art. 28 Abs. 2 und 4 DSGVO) | Anlage 3 zum AVV; Hetzner, Cloudflare, SMTP-Dienst, Sentry, PostHog als Subunternehmer; GitHub nachrichtlich ohne Datenzugriff |
+| 04 | `04-verzeichnis-verarbeitungstaetigkeiten.md` | Verzeichnis von Verarbeitungstätigkeiten (Art. 30 Abs. 2 DSGVO) | Anlage 1 zum AVV (Beschreibung der Verarbeitung); Datenkategorien mit Tabellenbezug |
+| 05 | `05-loeschkonzept.md` | Löschkonzept und Aufbewahrungsfristen | Ergänzt Anlagen 1 und 2; Löschklassen, Fristen, Austritts- und Vertragsendeprozesse |
+| 06 | `06-dsfa-zuarbeit.md` | Zuarbeit zur Datenschutz-Folgenabschätzung (Art. 35 DSGVO) | Unterstützung des Verantwortlichen nach Art. 28 Abs. 3 lit. f DSGVO; Risikoanalyse R1 bis R10 |
+| 07 | `07-datenpannen-meldeprozess.md` | Datenpannen-Meldeprozess (Art. 33/34 DSGVO) | Interner Prozess; Meldung an den Verantwortlichen unverzüglich, Ziel 24 h (AVV-Obergrenze 48 h) |
+
+Hinweis: Die mehrfach referenzierte **Datenbestandsaufnahme** (tabellengenaue Aufstellung aller Datenfelder) ist ein gesondertes internes Arbeitsdokument und nicht Teil der nummerierten Reihe 01 bis 07.
+
+## 2. Konsolidierte offene Punkte
+
+Alle offenen Platzhalter und [PRÜFEN]-Punkte der Reihe, thematisch gruppiert und dedupliziert. Fundstellen in Klammern.
+
+### 2.1 Firmen-Stammdaten und Personen (vor Freigabe ausfüllen)
+
+- [ ] Rechtsform und Adresse von moto: `[RECHTSFORM UND ADRESSE]` bzw. `[RECHTSFORM, z. B. GmbH / UG (haftungsbeschränkt)]`, `[STRASSE, HAUSNUMMER]`, `[PLZ, ORT]`, `[REGISTERGERICHT, REGISTERNUMMER]` (Dok 01, 02, 03, 04, 05, 06, 07)
+- [ ] Firmenkontaktdaten: `[TELEFONNUMMER]`, `[E-MAIL-ADRESSE FÜR DATENSCHUTZANFRAGEN]`, `[WEBSITE]`, `[ADRESSE]` (Dok 04)
+- [ ] Vertretungsberechtigte: `[GESCHÄFTSFÜHRUNG / VERTRETUNGSBERECHTIGTE PERSON]` (Dok 01), `[NAME GESCHÄFTSFÜHRUNG]` / `[NAME GESCHÄFTSFÜHRUNG/VORSTAND]` (Dok 03, 04, 05, 07), `[NAME, FUNKTION VERTRETUNGSBERECHTIGTE PERSON MOTO]` (Dok 01)
+- [ ] Datenschutzkoordination: `[NAME DATENSCHUTZKOORDINATOR/IN]` bzw. `[NAME DATENSCHUTZKOORDINATOR MOTO]` (Dok 01, 02, 03, 04, 06)
+- [ ] Datenschutzbeauftragte/r moto: `[NAME DATENSCHUTZBEAUFTRAGTER]` mit `[KONTAKTDATEN DSB]` / `[KONTAKT DATENSCHUTZBEAUFTRAGTER]` / `[E-MAIL, TELEFON]` (Dok 01, 02, 03, 04, 05, 06, 07); zuvor Benennungspflicht nach Art. 37 DSGVO / § 38 BDSG abschließend bewerten (Dok 01 Vertragsparteien, Dok 04 Abschn. 2) und Bestellung dokumentieren (Dok 02 Abschn. 3.12)
+- [ ] Technische Leitung / Incident-Verantwortlicher und Vertretung DSB mit Telefon und E-Mail (Dok 07 Abschn. 3.2 und 11), Sammel-Meldeadresse `[MELDEADRESSE]` (Dok 07 Abschn. 11)
+- [ ] Trägerseite je Vertrag: `[NAME DES SCHULTRÄGERS / OGS-TRÄGERS]`, Rechtsform, Anschrift, Vertretung, Schulen/OGS-Standorte, DSB des Trägers (Dok 01 Vertragsparteien), `[NAME SCHULTRÄGER]` (Dok 06 Abschn. 9)
+
+### 2.2 Vertrag und Dokumentenverwaltung
+
+- [ ] `[DATUM HAUPTVERTRAG]` (Dok 01 Präambel) und `[DATUM AVV]` (Dok 06 Abschn. 1 und 9)
+- [ ] `[GERICHTSSTAND]` festlegen; bei kommunalen Trägern Verwaltungsrechtsweg und Vergaberecht berücksichtigen (Dok 01 § 14)
+- [ ] **Anlage 4 zum AVV** (weisungsberechtigte/-empfangende Personen, Kontaktstelle für Meldungen nach § 8, Erreichbarkeiten) vor Unterzeichnung erstellen (Dok 01 § 3 Abs. 4 und Anlagenverzeichnis)
+- [ ] Vergütungs-, Kosten- und Haftungsregelungen (Weisungs-Mehraufwände, anlassbezogene Audits, Freistellungs-/Haftungsbegrenzungsklauseln) mit dem Hauptvertrag abstimmen (Dok 01 § 3 Abs. 7, § 10 Abs. 6, § 12 Abs. 3)
+- [ ] Trägerkonstellation klären: Wer ist Verantwortlicher, ggf. Vereinbarung über gemeinsame Verantwortlichkeit nach Art. 26 DSGVO zwischen Schule und Träger (Dok 01 Präambel)
+- [ ] `[VERSION/DATUM AV-VERTRAGSMUSTER]` in Dok 04 Abschn. 3 eintragen; `[ORT], [DATUM]` und Unterschrift in Dok 04
+- [ ] Bereitstellungsweg für aktualisierte Subprozessorenliste festlegen (Dok 03 Abschn. 6 Nr. 5)
+- [ ] Freigaben nachholen: fachliche Prüfung und Freigabe Dok 05 (Kopfzeile), Freigabe Dok 03 (Fußzeile), `[DATUM FREIGABE]` Dok 07
+
+### 2.3 Subprozessoren und Drittlandtransfer
+
+- [ ] **SMTP-Anbieter benennen**: Name, Sitz, Serverstandort aus der Produktivkonfiguration ermitteln, AVV/DPA abschließen und referenzieren, Drittlandbewertung nachziehen (Dok 01 § 6, Dok 02 Abschn. 3.6, Dok 03 Nr. 4 und Abschn. 4.4, Dok 04 Abschn. 5/6, Dok 06 Punkt 4)
+- [ ] **Hetzner**: aktuelles ISO-27001-Zertifikat und AVV-Anlage beschaffen, beilegen und in Dokument 03 referenzieren; vertragliche Beschränkung auf deutsche Standorte dokumentieren; Datum der letzten Sichtung inkl. Subunternehmeranhang eintragen; Nachweis Datenträgervernichtung (Dok 01 § 10 Abs. 4, Dok 02 Abschn. 3.1, Dok 03 Abschn. 4.1, Dok 05 Abschn. 11 Nr. 5, Dok 06 Punkt 10)
+- [ ] **Cloudflare**: konkrete Vertragspartei (Inc. oder Germany GmbH) eintragen, DPF-Zertifizierungsstatus mit Prüfdatum dokumentieren, Nutzung der EU-Datenlokalisierung (Data Localization Suite) verifizieren, Betroffeneninformation im Anmeldeformular bei aktiviertem Turnstile (Dok 01 § 6, Dok 02, Dok 03 Abschn. 4.2, Dok 04, Dok 06 Punkt 5)
+- [ ] **Sentry**: produktiven Einsatz bestätigen (sonst Eintrag streichen), tatsächliche Projektregion (EU) im Konto verifizieren, DPA-Fassung sichten und ablegen (Dok 01 § 6, Dok 02, Dok 03 Abschn. 4.5, Dok 04, Dok 06 Punkt 6)
+- [ ] **PostHog**: produktiven Einsatz und konfigurierten Host (EU-Cloud) bestätigen, Event-Inhalte auf Kennungen/Namen von Kindern auditieren, DPA-Fassung sichten (Dok 01 § 6, Dok 02, Dok 03 Abschn. 4.6, Dok 04, Dok 06 Punkt 7)
+- [ ] **GitHub/Microsoft**: DPF-Zertifizierungsstatus mit Prüfdatum dokumentieren, SCC-Rückfallmechanismus im GitHub-DPA verifizieren (Dok 02, Dok 03 Abschn. 4.3 und 5, Dok 04, Dok 06 Punkt 8)
+- [ ] Adress-Platzhalter in Dok 03 füllen: `[ADRESSE CLOUDFLARE GERMANY]`, `[ADRESSE POSTHOG, USA]`; Anlagenverzeichnis Dok 03: alle `[DATUM DER SICHTUNG]` eintragen, DPA-Links verifizieren
+- [ ] DPF-Rechtsentwicklung beobachten (Trump v. Slaughter, Rechtssache C-703/25 P); jährliche Prüfung der DPF-Zertifizierungen (Dok 03 Abschn. 5)
+- [ ] Meldefristen (Kettenmeldepflicht bei Datenpannen) in allen Subprozessoren-DPAs verifizieren und in Dok 03 vermerken (Dok 07 Abschn. 3.1)
+- [ ] Schriftarten-Auslieferung: Ausschluss eines Laufzeit-Rückfalls auf externe Google-Server bestätigen (Dok 06 Punkt 9)
+
+### 2.4 Löschfristen und Speicherbegrenzung
+
+- [ ] Aufbewahrungsfristen für Audit-Tabellen ohne Löschfrist festlegen und technisch umsetzen: `audit.auth_events`, `audit.data_access_log`, `audit.data_deletions`, `audit.data_imports`, `audit.guardian_changes`, `audit.enrollment_offering_adjustment`, `platform.operator_audit_log` (Dok 02 Abschn. 3.5, Dok 04 Abschn. 4.7c, Dok 05 Abschn. 14 Nr. 1, Dok 06 R9)
+- [ ] Löschregel für Krank-/Entschuldigt-Tagesmeldungen `active.student_status_days` (Gesundheitsdaten) festlegen (Dok 05 Abschn. 14 Nr. 2)
+- [ ] Löschregel für Eltern-Nachrichten `users.parent_messages` festlegen (Dok 05 Abschn. 14 Nr. 3, Dok 06 R9)
+- [ ] Kurze rollierende Löschfrist für unregistrierte NFC-Scans `audit.unregistered_tag_scans` festlegen (Dok 05 Abschn. 14 Nr. 4, Dok 06 R5)
+- [ ] Löschregeln für genehmigte Anmeldungen (Ursprungsdatensätze) und `users.student_data_change_requests` festlegen (Dok 05 Abschn. 14 Nr. 5)
+- [ ] VO-DV-I-Einordnung der OGS-Anwesenheitsdaten verbindlich mit Schulen/Trägern, ggf. Bezirksregierung, abstimmen (Dok 01 § 9 Abs. 2, Dok 05 Abschn. 5 und 14 Nr. 6)
+- [ ] Regelweisung zur Stammdatenlöschung nach Schulaustritt je Schulträger im AVV fixieren (Dok 05 Abschn. 14 Nr. 7)
+- [ ] Kalenderbasierte Höchstvorhaltezeit für Backups festlegen (`[MAXIMALE BACKUP-VORHALTEZEIT IN TAGEN]`) und zeitgesteuerte, deploymentunabhängige Sicherung mit `[BACKUP-FREQUENZ UND -AUFBEWAHRUNGSDAUER]` einführen (Dok 02 Abschn. 3.7, Dok 05 Abschn. 14 Nr. 8)
+- [ ] Umfang und Frist der Nachweisaufbewahrung nach Vertragsende festlegen (Dok 05 Abschn. 14 Nr. 9)
+- [ ] Nachweisfrist für Einwilligungsnachweise nach Betreuungsende entscheiden (Dok 05 Abschn. 14 Nr. 10)
+- [ ] Entscheiden, ob das dauerhafte Abschalten der automatischen Bereinigung durch Schulen technisch unterbunden wird (Dok 05 Abschn. 14 Nr. 11)
+- [ ] Kiosk-Persistenz (keine lokale Speicherung) bei wesentlichen Software-Änderungen erneut verifizieren (Dok 01 § 9 Abs. 6, Dok 05 Abschn. 14 Nr. 12)
+
+### 2.5 Rechtliche Klärungen (überwiegend Verantwortlicher)
+
+- [ ] Erlaubnistatbestand nach Art. 9 Abs. 2 DSGVO für Gesundheitsangaben (Kinderprofil-Freitext, Krankmeldungen, Anmeldeformular) dokumentieren, ggf. Einwilligung einholen; Eingaberichtlinie (Dienstanweisung) für Freitextfelder erstellen (Dok 01 § 2 Abs. 5, Dok 04 Abschn. 3, Dok 06 R8 und Punkte 2, 12)
+- [ ] Abgleich der Standard-Datenfelder mit dem Datenkatalog der VO-DV I; Rechtsgrundlage für Foto, Gesundheitsangaben, Feedback klären (Dok 04 Abschn. 8, Dok 06 Punkt 2)
+- [ ] DSFA-Erforderlichkeit klären: aktuelle LDI-NRW-Positivliste beschaffen und einschlägige Positionen dokumentieren; Durchführung obliegt dem Verantwortlichen (Dok 01 § 8 Abs. 5, Dok 06 Abschn. 2 und Punkt 1)
+- [ ] LDI-NRW-Kontaktdaten und Formular-Link vor jeder Verwendung auf Aktualität prüfen (Dok 07 Abschn. 12)
+
+### 2.6 TOM und Sicherheit (moto)
+
+- [ ] Verschlüsselung ruhender Nutzdaten: Ist-Zustand feststellen, nachweisen oder als Maßnahme einführen (Dok 02 Abschn. 3.9)
+- [ ] Turnus und Verfahren der internen Wirksamkeitsprüfung der TOM festlegen und in Dokument 02 aufnehmen (Dok 01 § 5 Abs. 4, Dok 02 Abschn. 3.11)
+- [ ] Externe Sicherheitsüberprüfungen / Penetrationstests planen, Turnus festlegen, Nachweise führen (Dok 02 Abschn. 3.11, Dok 06 R3 und Punkt 11)
+- [ ] Turnusmäßige Wiederherstellungstests der Datenbanksicherungen dokumentieren (Dok 02 Abschn. 3.7)
+- [ ] `[ZERTIFIZIERUNGEN FALLS VORHANDEN]` ergänzen oder Feld streichen (Dok 02 Abschn. 3.11)
+
+### 2.7 Organisatorische Nachweise ([ORGANISATORISCH ZU BESTÄTIGEN], Dok 02)
+
+- [ ] Regelungen zur Absicherung der Endgeräte der Mitarbeitenden (Festplattenverschlüsselung, Bildschirmsperre) schriftlich fixieren (Abschn. 3.1)
+- [ ] Dokumentiertes Weisungs- und Kommunikationsverfahren mit den Verantwortlichen (Abschn. 3.6)
+- [ ] Schriftliche Vertraulichkeitsverpflichtungen aller Mitarbeitenden mit Datenzugriff (Abschn. 3.12, Abschn. 5)
+- [ ] Schulungen: `[SCHULUNGSINTERVALL MITARBEITENDE]` festlegen und Nachweise führen (Abschn. 3.12)
+- [ ] Dokumentiertes Meldeverfahren bei Datenschutzverletzungen bestätigen; Verweis auf Dokument 07 herstellen (Abschn. 3.12)
+- [ ] Organisatorisches Verfahren zur Bearbeitung von Betroffenenanfragen (Abschn. 3.12)
+- [ ] Verfahren zur Vergabe, Überprüfung und zum Entzug administrativer Zugänge bei Ein-/Austritt (Abschn. 3.12)
+- [ ] Überprüfungsturnus des TOM-Dokuments verbindlich festlegen und Verantwortlichkeit benennen (Abschn. 3.11)
+
+### 2.8 Datenpannen-Prozess (Dok 07)
+
+- [ ] `[SPEICHERORT VORFALLREGISTER]` festlegen (verschlüsselte Ablage außerhalb der Produktivinfrastruktur)
+- [ ] `[AUFBEWAHRUNGSDAUER]` der Vorfalldokumentation festlegen und mit Verjährungsfristen und AVV abstimmen (Abschn. 9)
+- [ ] `[REGELUNG RUFBEREITSCHAFT / ERREICHBARKEIT AUSSERHALB DER GESCHÄFTSZEITEN]` festlegen (Abschn. 11)
+- [ ] Kontakte laut Kundenstammdaten je Verantwortlichem hinterlegen (`[KONTAKT LAUT KUNDENSTAMMDATEN]`, Abschn. 7.2)
+- [ ] Jährliche Prozessübung durchführen und `[DATUM LETZTE ÜBUNG]` pflegen (Abschn. 10)
+- [ ] Fristen und Meldewege bei jeder AVV-Änderung mit der Meldeklausel (Dok 01 § 8) konsistent halten (Abschn. 1 und 7.1)
+
+## 3. Pflegehinweis
+
+Dieses Dokument wird bei jeder inhaltlichen Änderung eines Dokuments der Reihe sowie bei Erledigung offener Punkte aktualisiert. Erledigte Punkte werden abgehakt und mit Datum versehen, nicht gelöscht.

--- a/docs/moto-dsgvo-dokumente/01-auftragsverarbeitungsvertrag.md
+++ b/docs/moto-dsgvo-dokumente/01-auftragsverarbeitungsvertrag.md
@@ -1,0 +1,329 @@
+# Auftragsverarbeitungsvertrag nach Art. 28 DSGVO
+
+| | |
+|---|---|
+| **Dokument** | 01 Auftragsverarbeitungsvertrag (AVV) |
+| **Version** | 1.0 |
+| **Stand** | 2026-07-07 |
+| **Status** | Entwurf zur internen Prüfung |
+| **Verantwortlich (intern)** | [NAME DATENSCHUTZKOORDINATOR MOTO] |
+| **Zugehörige Anlagen** | Dokument 04 (Verzeichnis von Verarbeitungstätigkeiten, Beschreibung der Verarbeitung), Dokument 02 (Technische und organisatorische Maßnahmen), Dokument 03 (Unterauftragsverarbeiter) |
+
+---
+
+## Vertragsparteien
+
+**Verantwortlicher** im Sinne des Art. 4 Nr. 7 DSGVO (nachfolgend "Verantwortlicher"):
+
+> [NAME DES SCHULTRÄGERS / OGS-TRÄGERS]
+> [RECHTSFORM DES TRÄGERS, z. B. Kommune, eingetragener Verein, gGmbH]
+> [STRASSE, HAUSNUMMER]
+> [PLZ, ORT]
+> vertreten durch: [VERTRETUNGSBERECHTIGTE PERSON, FUNKTION]
+> betroffene Einrichtung(en): [NAME UND ANSCHRIFT DER SCHULE(N) / OGS-STANDORTE]
+> Datenschutzbeauftragte/r des Verantwortlichen: [NAME UND KONTAKT DSB DES TRÄGERS]
+
+**Auftragsverarbeiter** im Sinne des Art. 4 Nr. 8 DSGVO (nachfolgend "Auftragsverarbeiter" oder "moto"):
+
+> moto [RECHTSFORM, z. B. GmbH / UG (haftungsbeschränkt)]
+> [STRASSE, HAUSNUMMER]
+> [PLZ, ORT]
+> vertreten durch: [GESCHÄFTSFÜHRUNG / VERTRETUNGSBERECHTIGTE PERSON]
+> Handelsregister: [REGISTERGERICHT, REGISTERNUMMER]
+> Datenschutzbeauftragte/r: [NAME DATENSCHUTZBEAUFTRAGTER MOTO, KONTAKTDATEN] [PRÜFEN: Benennungspflicht nach Art. 37 DSGVO / § 38 BDSG anhand Mitarbeiterzahl und Kerntätigkeit klären]
+
+Verantwortlicher und Auftragsverarbeiter werden nachfolgend gemeinsam als "Parteien" bezeichnet.
+
+---
+
+## Präambel
+
+Der Verantwortliche betreibt an einer oder mehreren Grundschulen in Nordrhein-Westfalen Angebote des Offenen Ganztags (OGS). Zur Unterstützung der Betreuungsorganisation setzt der Verantwortliche die Software "moto" ein, eine NFC/RFID-gestützte Anwendung zur Anwesenheitserfassung und Raumverwaltung. Die Software wird vom Auftragsverarbeiter als gehosteter Dienst bereitgestellt und umfasst ein Portal für Schule beziehungsweise Träger, ein Elternportal, ein Betreiberportal des Auftragsverarbeiters sowie eine Kiosk-Anwendung (PyrePortal) auf stationären Geräten in den Einrichtungen.
+
+Grundlage der Zusammenarbeit ist der zwischen den Parteien geschlossene Vertrag über die Nutzung der Software (nachfolgend "Hauptvertrag") vom [DATUM HAUPTVERTRAG]. Dieser Auftragsverarbeitungsvertrag konkretisiert die datenschutzrechtlichen Pflichten der Parteien aus dem Hauptvertrag und setzt die Anforderungen des Art. 28 Abs. 3 DSGVO um.
+
+Der Verantwortliche bleibt für die Rechtmäßigkeit der Verarbeitung verantwortlich (Art. 5 Abs. 2, Art. 24 DSGVO). Die Rechtsgrundlage der Verarbeitung im Kernbetrieb ist Art. 6 Abs. 1 lit. e DSGVO in Verbindung mit §§ 120 bis 122 SchulG NRW und der VO-DV I; die Prüfung und Dokumentation der Rechtsgrundlage einschließlich der Zulässigkeit einzelner Datenarten nach VO-DV I obliegt dem Verantwortlichen. [PRÜFEN: Bei Trägerkonstellationen, in denen Schule und OGS-Träger getrennte Stellen sind, ist vor Vertragsschluss zu klären, wer Verantwortlicher ist; gegebenenfalls ist ergänzend eine Vereinbarung über gemeinsame Verantwortlichkeit nach Art. 26 DSGVO zwischen Schule und Träger erforderlich, sofern Datenflüsse zwischen Unterrichts- und Betreuungsbereich bestehen.]
+
+---
+
+## § 1 Gegenstand und Dauer des Auftrags
+
+(1) Gegenstand des Auftrags ist die Bereitstellung und der Betrieb der Software "moto" zur Anwesenheitserfassung und Raumverwaltung im Offenen Ganztag, einschließlich
+
+a) der Erfassung von An- und Abmeldungen der betreuten Kinder über NFC/RFID-Lesegeräte (Kiosk-Anwendung PyrePortal) sowie über die Weboberfläche,
+b) der Verwaltung von Gruppen-, Raum- und Aufenthaltsinformationen der betreuten Kinder,
+c) der Verwaltung von Stammdaten der Kinder, ihrer Erziehungsberechtigten und des Betreuungspersonals,
+d) des Elternportals (unter anderem Krankmeldungen, Abholinformationen, Nachrichten an die Betreuung, Einsicht in eigene Daten),
+e) der Online-Anmeldung zur Betreuung (Enrollment),
+f) der Zeiterfassung des Betreuungspersonals,
+g) des Feedback-Moduls (zum Beispiel Mensa-Bewertungen),
+h) der zugehörigen Hosting-, Wartungs-, Support- und Datensicherungsleistungen.
+
+(2) Die Verarbeitung erfolgt ausschließlich zur Erfüllung des Hauptvertrags. Eine Verarbeitung zu eigenen Zwecken des Auftragsverarbeiters findet nicht statt.
+
+(3) Die Dauer dieses Vertrags entspricht der Laufzeit des Hauptvertrags. Er endet ohne gesonderte Kündigung mit dessen Beendigung. Die Pflichten aus § 9 (Löschung und Rückgabe) sowie fortgeltende Vertraulichkeitspflichten bestehen über das Vertragsende hinaus.
+
+(4) Der Ort der Verarbeitung ist die Bundesrepublik Deutschland (Rechenzentrum in Nürnberg, Hosting-Anbieter gemäß Anlage 3). Verarbeitungen in Drittländern finden nur unter den Voraussetzungen des § 3 Abs. 5 und des § 6 statt und sind in Anlage 3 ausgewiesen.
+
+---
+
+## § 2 Art und Zweck der Verarbeitung, Datenkategorien, betroffene Personen
+
+(1) **Art der Verarbeitung**: Erheben, Erfassen, Ordnen, Speichern, Verändern, Auslesen, Abfragen, Verwenden, Übermitteln an den Verantwortlichen und von ihm benannte Berechtigte, Einschränken, Löschen und Vernichten personenbezogener Daten im Rahmen des Betriebs der in § 1 Abs. 1 beschriebenen Software.
+
+(2) **Zweck der Verarbeitung**: Organisation und Dokumentation der Betreuung im Offenen Ganztag, insbesondere Anwesenheits- und Aufenthaltsnachweis der betreuten Kinder, Kommunikation mit Erziehungsberechtigten, Verwaltung der Anmeldungen sowie Personaleinsatz- und Arbeitszeitdokumentation des Betreuungspersonals.
+
+(3) **Kategorien betroffener Personen**:
+
+a) Schülerinnen und Schüler (betreute Kinder; besonders schutzbedürftige Personen im Sinne des Erwägungsgrunds 38 DSGVO),
+b) Eltern und sonstige Erziehungsberechtigte sowie abhol- und notfallberechtigte Personen,
+c) Beschäftigte des Verantwortlichen beziehungsweise des Betreuungsträgers (pädagogisches Personal, Verwaltung, Vertretungskräfte, externe Kursleitungen),
+d) Beschäftigte des Auftragsverarbeiters mit Zugang zum Betreiberportal,
+e) sonstige natürliche Personen, deren RFID-Transponder an einem Lesegerät erfasst wird, ohne einer registrierten Person zugeordnet zu sein (unregistrierte Scans).
+
+(4) **Kategorien personenbezogener Daten** (Detailaufstellung mit Tabellen- und Feldbezug in Anlage 1):
+
+a) Stammdaten der Kinder (Name, Geburtsdatum, Anschrift, Schulklasse, Gruppenzuordnung, Betreuungsstatus, Foto sofern eingewilligt),
+b) Anwesenheits- und Bewegungsdaten der Kinder (An- und Abmeldezeiten, Aufenthaltsraum, Raumwechsel, Schulhofstatus, jeweils mit Zeitstempel und erfassendem Gerät),
+c) Abhol- und Heimwegregelungen einschließlich Freitextangaben zu Begleitpersonen,
+d) Kontakt- und Beziehungsdaten der Erziehungsberechtigten (Name, Anschrift, E-Mail, Telefonnummern, Beziehung zum Kind, Abholberechtigung, Notfallkontakt-Kennzeichnung, Portalberechtigungen),
+e) Anmeldedaten aus dem Online-Anmeldeverfahren einschließlich Freitextfeldern,
+f) Einwilligungs- und Datenschutzangaben je Kind (unter anderem Fotoeinwilligung, individuelle Aufbewahrungsdauer der Besuchsdaten),
+g) Nachrichten zwischen Erziehungsberechtigten und Betreuung,
+h) Beschäftigtendaten des Betreuungspersonals (Stammdaten, Beschäftigungsart, Arbeitszeitmodell, Zeiterfassung mit Kommen/Gehen/Pausen, Abwesenheiten einschließlich Krankheit und Urlaub, interne Notizen),
+i) Konto- und Anmeldedaten aller Nutzerkonten (E-Mail, Benutzername, Passwort- und PIN-Hashes, MFA- und Passkey-Daten, Login-Historie einschließlich IP-Adresse und User-Agent),
+j) RFID-Transponderkennungen (Tag-UID) als pseudonyme Identifikatoren; biometrische Daten werden nicht verarbeitet,
+k) Protokoll- und Auditdaten (Datenzugriffs-, Änderungs-, Import- und Löschprotokolle),
+l) Feedback-Einträge der Kinder mit Zeitstempel.
+
+(5) **Besondere Kategorien personenbezogener Daten (Art. 9 DSGVO)**: Die Verarbeitung umfasst Gesundheitsdaten in folgendem Umfang: Gesundheitsangaben zum Kind als Freitext (zum Beispiel Allergien, Medikation), strukturierte Krank- und Entschuldigtmeldungen der Kinder einschließlich optionaler Freitextnotiz, Krankmeldungen des Betreuungspersonals einschließlich Freitextnotiz sowie Gesundheitsangaben im Online-Anmeldeformular, sofern der Verantwortliche ein entsprechendes Formularfeld aktiviert. Der Verantwortliche stellt sicher, dass für diese Verarbeitungen eine Ausnahme nach Art. 9 Abs. 2 DSGVO vorliegt und die Erhebung nach VO-DV I zulässig ist. [PRÜFEN: Zulässigkeit und einschlägiger Erlaubnistatbestand für Gesundheitsangaben zu Kindern im OGS-Kontext nach VO-DV I und Art. 9 Abs. 2 DSGVO durch den Verantwortlichen dokumentieren, gegebenenfalls Einwilligung nach Art. 9 Abs. 2 lit. a DSGVO einholen]
+
+(6) Weitere Angaben zu Gegenstand, Zweck, Datenkategorien und Betroffenengruppen ergeben sich aus **Anlage 1** (Dokument 04, Verzeichnis von Verarbeitungstätigkeiten). Bei Widersprüchen zwischen diesem Paragrafen und Anlage 1 geht die Anlage 1 als speziellere Regelung vor.
+
+---
+
+## § 3 Rechte und Pflichten des Verantwortlichen, Weisungen
+
+(1) Der Verantwortliche ist im Rahmen dieses Vertrags allein für die Beurteilung der Zulässigkeit der Verarbeitung sowie für die Wahrung der Rechte der betroffenen Personen verantwortlich. Er ist Herr der Daten.
+
+(2) Der Auftragsverarbeiter verarbeitet personenbezogene Daten ausschließlich auf dokumentierte Weisung des Verantwortlichen (Art. 28 Abs. 3 lit. a DSGVO), sofern er nicht durch das Recht der Union oder der Mitgliedstaaten zur Verarbeitung verpflichtet ist. In einem solchen Fall teilt der Auftragsverarbeiter dem Verantwortlichen diese rechtlichen Anforderungen vor der Verarbeitung mit, sofern das betreffende Recht eine solche Mitteilung nicht wegen eines wichtigen öffentlichen Interesses verbietet.
+
+(3) Als dokumentierte Weisungen gelten:
+
+a) dieser Vertrag einschließlich seiner Anlagen,
+b) der Hauptvertrag,
+c) die durch berechtigte Administratorinnen und Administratoren des Verantwortlichen im Verwaltungsbereich der Software vorgenommenen Konfigurationen (insbesondere Berechtigungsvergabe, Sichtbarkeits- und Protokolleinstellungen sowie Aufbewahrungs- und Löschfristen im Einstellungsbereich); diese gelten als dokumentierte Dauerweisungen, ihre Änderungen werden systemseitig protokolliert,
+d) Einzelweisungen in Textform (E-Mail genügt) an die in Anlage 4 benannte Kontaktstelle des Auftragsverarbeiters. Mündliche Weisungen sind unverzüglich in Textform zu bestätigen.
+
+(4) Weisungsberechtigte Personen des Verantwortlichen und weisungsempfangende Personen des Auftragsverarbeiters werden in **Anlage 4** benannt. Wechsel sind der jeweils anderen Partei unverzüglich in Textform mitzuteilen. [PLATZHALTER: Anlage 4 mit Ansprechpartnern und Meldewegen ist vor Unterzeichnung zu erstellen]
+
+(5) Weisungen, die eine Übermittlung personenbezogener Daten in ein Drittland oder an eine internationale Organisation zum Gegenstand haben oder zur Folge hätten, bedürfen einer ausdrücklichen Weisung in Textform. Die bei Vertragsschluss bestehenden Drittlandbezüge einzelner Unterauftragsverarbeiter sind in Anlage 3 ausgewiesen und gelten mit Unterzeichnung dieses Vertrags als genehmigt, sofern die Voraussetzungen des Kapitels V DSGVO erfüllt sind.
+
+(6) Ist der Auftragsverarbeiter der Auffassung, dass eine Weisung gegen die DSGVO oder gegen andere Datenschutzbestimmungen der Union oder der Mitgliedstaaten verstößt, informiert er den Verantwortlichen unverzüglich (Art. 28 Abs. 3 UAbs. 2 DSGVO). Der Auftragsverarbeiter ist berechtigt, die Durchführung der betreffenden Weisung auszusetzen, bis der Verantwortliche sie bestätigt oder ändert.
+
+(7) Mehraufwände durch Weisungen, die über den vertraglich vereinbarten Leistungsumfang hinausgehen, kann der Auftragsverarbeiter nach den Sätzen des Hauptvertrags in Rechnung stellen. [PRÜFEN: Vergütungsregelung mit dem Hauptvertrag abstimmen]
+
+---
+
+## § 4 Vertraulichkeit (Art. 28 Abs. 3 lit. b DSGVO)
+
+(1) Der Auftragsverarbeiter gewährleistet, dass sich alle zur Verarbeitung personenbezogener Daten befugten Personen zur Vertraulichkeit verpflichtet haben oder einer angemessenen gesetzlichen Verschwiegenheitspflicht unterliegen. Die Verpflichtung erfolgt vor Aufnahme der Tätigkeit in Textform und besteht nach Beendigung der Tätigkeit fort. Nachweise werden dem Verantwortlichen auf Anforderung vorgelegt.
+
+(2) Der Auftragsverarbeiter beschränkt den Zugang zu personenbezogenen Daten auf diejenigen Beschäftigten, die ihn zur Vertragserfüllung benötigen (Need-to-know-Prinzip). Zugriffe von Beschäftigten des Auftragsverarbeiters auf Mandantendaten erfolgen ausschließlich über das dafür vorgesehene Betreiberportal mit eigener Authentifizierung und werden protokolliert.
+
+(3) Der Verantwortliche weist darauf hin, dass die Bedienung der Kiosk-Anwendung in den Einrichtungen durch sein eigenes Personal erfolgt; die Verpflichtung dieses Personals auf Vertraulichkeit und Datengeheimnis obliegt dem Verantwortlichen.
+
+---
+
+## § 5 Technische und organisatorische Maßnahmen (Art. 28 Abs. 3 lit. c, Art. 32 DSGVO)
+
+(1) Der Auftragsverarbeiter trifft die in **Anlage 2** (Dokument 02, Technische und organisatorische Maßnahmen) beschriebenen Maßnahmen zur Sicherheit der Verarbeitung nach Art. 32 DSGVO. Anlage 2 dokumentiert den bei Vertragsschluss umgesetzten Stand.
+
+(2) Zu den Maßnahmen gehören insbesondere:
+
+a) **Mandantentrennung**: Trennung der Daten je Schule beziehungsweise Träger auf Datenbankebene durch Row Level Security der PostgreSQL-Datenbank, mandantengebundene Datenbankrollen mit minimalen Rechten sowie mandantenbezogene Transaktionsführung je Anfrage,
+b) **Zugangskontrolle**: Authentifizierung über JWT-basierte Sitzungen mit kurzer Gültigkeitsdauer, Mehr-Faktor-Authentifizierung, Passwort-Hashing nach Stand der Technik (Argon2id), konfigurierbare Kontosperrung bei Fehlversuchen, Geräteauthentifizierung der Kiosk-Geräte über gerätegebundene API-Schlüssel in Verbindung mit persönlicher PIN des Personals,
+c) **Zugriffskontrolle**: rollen- und berechtigungsbasiertes Zugriffsmodell, getrennte Berechtigungssysteme für Personal und Erziehungsberechtigte, konfigurierbare Einschränkung der Sichtbarkeit von Kinderdaten und Anwesenheitsprotokollen,
+d) **Trennung der Portale**: drei technisch isolierte Zugänge (Schule/Träger, Betreiber, Eltern) mit getrennten Sitzungen,
+e) **Transportverschlüsselung**: TLS-Terminierung am Reverse Proxy, verschlüsselte Datenbankverbindungen mit Zertifikatsprüfung,
+f) **Eingabekontrolle**: Protokollierung von Datenzugriffen auf sensible Daten, Änderungsprotokolle für Kontakt- und Abholdaten, Zeiterfassungskorrekturen, Einstellungsänderungen und Löschvorgänge,
+g) **Verfügbarkeitskontrolle**: automatisierte Datensicherungen vor jeder Systemänderung mit definiertem Wiederherstellungsverfahren, Aufbewahrung mehrerer Sicherungsstände, aktive Systemüberwachung,
+h) **Datenminimierung**: konfigurierbare Aufbewahrungs- und Sichtbarkeitsfenster, automatisierte tägliche Löschläufe, keine Klarnamen betreuter Kinder in Systemprotokollen der Standardstufe,
+i) **Verwaltung von Zugangsgeheimnissen**: verschlüsselte Ablage von Konfigurationsgeheimnissen, keine Klartextspeicherung von Passwörtern oder PINs.
+
+(3) Die Maßnahmen unterliegen dem technischen Fortschritt. Der Auftragsverarbeiter darf sie weiterentwickeln, sofern das vereinbarte Schutzniveau nicht unterschritten wird. Wesentliche Änderungen dokumentiert der Auftragsverarbeiter in einer aktualisierten Fassung der Anlage 2 und stellt sie dem Verantwortlichen zur Verfügung.
+
+(4) Der Auftragsverarbeiter überprüft die Wirksamkeit der Maßnahmen regelmäßig (Art. 32 Abs. 1 lit. d DSGVO) und dokumentiert die Überprüfungen. [PRÜFEN: Turnus und Verfahren der internen Wirksamkeitsprüfung festlegen und in Dokument 02 aufnehmen]
+
+---
+
+## § 6 Unterauftragsverhältnisse (Art. 28 Abs. 3 lit. d, Abs. 2 und 4 DSGVO)
+
+(1) Der Verantwortliche erteilt dem Auftragsverarbeiter die **allgemeine Genehmigung** zur Einschaltung weiterer Auftragsverarbeiter (Unterauftragsverarbeiter). Die bei Vertragsschluss eingesetzten Unterauftragsverarbeiter ergeben sich aus **Anlage 3** (Dokument 03, Unterauftragsverarbeiter) und gelten mit Unterzeichnung als genehmigt.
+
+(2) Der Auftragsverarbeiter informiert den Verantwortlichen über jede beabsichtigte Hinzuziehung oder Ersetzung eines Unterauftragsverarbeiters in Textform mindestens **30 Kalendertage** vor deren Wirksamwerden. Der Verantwortliche kann der Änderung innerhalb dieser Frist aus wichtigem datenschutzrechtlichem Grund in Textform widersprechen. Im Fall des Widerspruchs suchen die Parteien einvernehmlich eine Lösung; kommt keine zustande, ist der Verantwortliche zur außerordentlichen Kündigung des Hauptvertrags berechtigt, soweit die Leistung ohne den betreffenden Unterauftragsverarbeiter nicht erbracht werden kann.
+
+(3) Der Auftragsverarbeiter legt jedem Unterauftragsverarbeiter durch Vertrag dieselben Datenschutzpflichten auf, die in diesem Vertrag festgelegt sind (Art. 28 Abs. 4 DSGVO), insbesondere hinreichende Garantien für technische und organisatorische Maßnahmen. Kommt ein Unterauftragsverarbeiter seinen Datenschutzpflichten nicht nach, haftet der Auftragsverarbeiter gegenüber dem Verantwortlichen für die Einhaltung der Pflichten des Unterauftragsverarbeiters.
+
+(4) Nicht als Unterauftragsverhältnisse gelten Nebenleistungen ohne Zugriff auf personenbezogene Daten der betroffenen Personen (zum Beispiel Bereitstellung von Quellcode- und Container-Registrierungsdiensten für Softwareartefakte, Telekommunikation, Reinigung, Wartung ohne Datenzugriff). Solche Dienste sind in Anlage 3 nachrichtlich ausgewiesen.
+
+(5) **Drittlandbezug**: Der Kernbetrieb (Anwendung, Datenbank, Protokollierung, Überwachung) erfolgt auf Servern in Deutschland. Einzelne Dienste weisen einen Drittlandbezug auf (Stand bei Vertragsschluss, Einzelheiten in Anlage 3):
+
+a) DNS und vorgeschaltete Auslieferung einschließlich Überlastschutz (Cloudflare; Verarbeitung von Verbindungsmetadaten einschließlich IP-Adressen der Portalnutzer), [PRÜFEN: Transfermechanismus nach Kapitel V DSGVO, DPF-Zertifizierung oder Standardvertragsklauseln von Cloudflare, Nutzung der EU-Datenlokalisierungsoptionen]
+b) Bot-Schutz des öffentlichen Anmeldeformulars (Cloudflare Turnstile, nur bei Aktivierung durch den Verantwortlichen; Verarbeitung von IP-Adresse und Browsersignalen), [PRÜFEN: Transfermechanismus nach Kapitel V DSGVO, DPF-Zertifizierung oder Standardvertragsklauseln von Cloudflare, gegebenenfalls EU-Datenlokalisierung]
+c) Fehlerprotokollierung (Sentry, konfiguriert für EU-Datenregion, mit technischer Entfernung von IP-Adressen, E-Mail-Adressen und Anmeldedaten vor Übertragung), [PRÜFEN: tatsächliche Projektregion im Anbieterkonto verifizieren]
+d) Nutzungsanalyse (PostHog, konfiguriert für EU-Cloud). [PRÜFEN: produktive Konfiguration und erfasste Ereignisinhalte verifizieren]
+
+Für jeden Dienst mit Drittlandbezug stellt der Auftragsverarbeiter sicher, dass geeignete Garantien nach Art. 44 ff. DSGVO bestehen, und weist diese dem Verantwortlichen auf Anforderung nach. Der Verantwortliche kann die optionalen Dienste nach lit. b bis d über die Konfiguration beziehungsweise durch Weisung abwählen, soweit technisch vorgesehen.
+
+(6) Der Auftragsverarbeiter führt ein aktuelles Verzeichnis der Unterauftragsverarbeiter (Anlage 3) und stellt es dem Verantwortlichen auf Anforderung sowie bei jeder Änderung zur Verfügung.
+
+---
+
+## § 7 Unterstützung bei den Rechten der betroffenen Personen (Art. 28 Abs. 3 lit. e DSGVO)
+
+(1) Der Auftragsverarbeiter unterstützt den Verantwortlichen mit geeigneten technischen und organisatorischen Maßnahmen dabei, seiner Pflicht zur Beantwortung von Anträgen betroffener Personen nach Kapitel III der DSGVO (Art. 12 bis 22) nachzukommen.
+
+(2) Die Software stellt hierfür insbesondere bereit:
+
+a) Einsichts- und Selbstverwaltungsfunktionen im Elternportal für die dort hinterlegten Daten,
+b) ein Verfahren für Datenänderungsanfragen der Erziehungsberechtigten mit Prüfung durch den Verantwortlichen,
+c) administrative Funktionen zur Berichtigung und Löschung von Datensätzen einschließlich eines Löschprotokolls als Nachweis,
+d) konfigurierbare Aufbewahrungs- und Einwilligungsverwaltung je Kind.
+
+(3) Anträge betroffener Personen, die unmittelbar beim Auftragsverarbeiter eingehen, leitet dieser unverzüglich an den Verantwortlichen weiter und beantwortet sie nicht selbst, es sei denn, der Verantwortliche weist ihn dazu an.
+
+(4) Soweit eine Auskunft, Berichtigung, Löschung, Einschränkung oder Datenübertragung nicht durch den Verantwortlichen selbst über die Software ausgeführt werden kann, führt der Auftragsverarbeiter die erforderlichen Maßnahmen auf Weisung des Verantwortlichen innerhalb angemessener Frist aus, in der Regel innerhalb von zehn Arbeitstagen, damit der Verantwortliche die Monatsfrist des Art. 12 Abs. 3 DSGVO einhalten kann.
+
+---
+
+## § 8 Unterstützungspflichten nach Art. 32 bis 36 DSGVO, Meldung von Verletzungen (Art. 28 Abs. 3 lit. f DSGVO)
+
+(1) Der Auftragsverarbeiter unterstützt den Verantwortlichen unter Berücksichtigung der Art der Verarbeitung und der ihm zur Verfügung stehenden Informationen bei der Einhaltung der Pflichten aus Art. 32 bis 36 DSGVO (Sicherheit der Verarbeitung, Meldung von Verletzungen an die Aufsichtsbehörde, Benachrichtigung betroffener Personen, Datenschutz-Folgenabschätzung, vorherige Konsultation).
+
+(2) Der Auftragsverarbeiter meldet dem Verantwortlichen jede Verletzung des Schutzes personenbezogener Daten, die im Rahmen dieses Auftrags verarbeitete Daten betrifft, **unverzüglich nach Kenntniserlangung, spätestens innerhalb von 48 Stunden**, an die in Anlage 4 benannte Kontaktstelle. Die Meldung enthält, soweit bereits verfügbar, die Angaben nach Art. 33 Abs. 3 DSGVO (Art der Verletzung, betroffene Kategorien und ungefähre Zahl der betroffenen Personen und Datensätze, wahrscheinliche Folgen, ergriffene und vorgeschlagene Abhilfemaßnahmen). Nicht sofort verfügbare Informationen werden ohne unangemessene Verzögerung nachgereicht.
+
+(3) Die Bewertung der Meldepflicht gegenüber der Aufsichtsbehörde (Art. 33 DSGVO) und der Benachrichtigungspflicht gegenüber betroffenen Personen (Art. 34 DSGVO) obliegt dem Verantwortlichen. Der Auftragsverarbeiter meldet Verletzungen nicht selbst an die Aufsichtsbehörde, es sei denn, er ist hierzu gesetzlich verpflichtet.
+
+(4) Der Auftragsverarbeiter dokumentiert Verletzungen einschließlich der Umstände, Auswirkungen und Abhilfemaßnahmen und ergreift unverzüglich Maßnahmen zur Sicherung der Daten und zur Minderung möglicher nachteiliger Folgen.
+
+(5) Für eine vom Verantwortlichen durchzuführende Datenschutz-Folgenabschätzung (Art. 35 DSGVO), insbesondere im Hinblick auf die systematische Anwesenheits- und Aufenthaltserfassung von Kindern, stellt der Auftragsverarbeiter die erforderlichen Informationen über die Verarbeitung und die Schutzmaßnahmen zur Verfügung (Anlagen 1 bis 3, ergänzende Auskünfte auf Anforderung). [PRÜFEN: Erforderlichkeit einer Datenschutz-Folgenabschätzung für den Einsatz des Systems anhand der Muss-Liste der Datenschutzkonferenz und der Einschätzung der LDI NRW klären; die Durchführung obliegt dem Verantwortlichen]
+
+---
+
+## § 9 Löschung und Rückgabe personenbezogener Daten (Art. 28 Abs. 3 lit. g DSGVO)
+
+(1) Während der Vertragslaufzeit löscht der Auftragsverarbeiter personenbezogene Daten nach Maßgabe der im System konfigurierten Aufbewahrungsfristen (dokumentierte Dauerweisung im Sinne des § 3 Abs. 3 lit. c). Die Standardwerte und Einstellbereiche der automatisierten Löschläufe sind in Anlage 1 dokumentiert; dazu gehören insbesondere die kurzfristige Löschung der Besuchs- und Anwesenheitsrohdaten (Standard 30 Tage, je Kind individuell einstellbar), die Löschung von Feedback-Einträgen, abgelehnten Anmeldungen und abgelaufenen Zugangstoken sowie die längerfristige Aufbewahrung der Zeiterfassungsdaten des Personals nach arbeits- und steuerrechtlichen Vorgaben.
+
+(2) Der Verantwortliche konfiguriert die Aufbewahrungsfristen so, dass sie den für ihn geltenden Vorgaben entsprechen, insbesondere den Lösch- und Aufbewahrungsfristen der VO-DV I sowie den arbeitszeit-, steuer- und handelsrechtlichen Aufbewahrungspflichten für Beschäftigtendaten. Der Auftragsverarbeiter legt keine eigenen, davon abweichenden Fristen fest. [PRÜFEN: Zuordnung der einzelnen Datenarten zu den Fristen der VO-DV I durch den Verantwortlichen dokumentieren; für Protokolldaten ohne konfigurierte Löschfrist (Audit-Protokolle, Eltern-Nachrichten, unregistrierte Scans) ist eine Aufbewahrungsregelung festzulegen, siehe offene Punkte in Anlage 1]
+
+(3) Nach Abschluss der Erbringung der Verarbeitungsleistungen löscht der Auftragsverarbeiter nach Wahl des Verantwortlichen alle personenbezogenen Daten oder gibt sie zurück und löscht vorhandene Kopien, sofern nicht nach dem Recht der Union oder der Mitgliedstaaten eine Pflicht zur Speicherung besteht. Der Verantwortliche übt sein Wahlrecht spätestens vier Wochen vor Vertragsende in Textform aus; äußert er sich nicht, werden die Daten gelöscht.
+
+(4) Eine Rückgabe erfolgt in einem gängigen, strukturierten und maschinenlesbaren Format. Die Modalitäten (Format, Übergabeweg, Frist) stimmen die Parteien rechtzeitig ab.
+
+(5) Die Löschung umfasst auch Datensicherungen nach Ablauf der regulären Sicherungsrotation. Der Auftragsverarbeiter bestätigt dem Verantwortlichen die vollständige Löschung in Textform unter Angabe des Löschdatums. Gesetzlich aufzubewahrende Daten werden für die weitere Verarbeitung gesperrt und nach Ablauf der Aufbewahrungspflicht gelöscht; der Auftragsverarbeiter teilt dem Verantwortlichen Umfang und Rechtsgrund der Aufbewahrung mit.
+
+(6) Auf den Kiosk-Geräten in den Einrichtungen werden keine personenbezogenen Datenbestände dauerhaft gespeichert; die Außerbetriebnahme und Rückgabe der Geräte regelt der Hauptvertrag. [PRÜFEN: lokale Zwischenspeicher der Kiosk-Anwendung im Rahmen der technischen Dokumentation bestätigen]
+
+---
+
+## § 10 Nachweis- und Kontrollrechte (Art. 28 Abs. 3 lit. h DSGVO)
+
+(1) Der Auftragsverarbeiter stellt dem Verantwortlichen alle Informationen zur Verfügung, die zum Nachweis der Einhaltung der in Art. 28 DSGVO niedergelegten Pflichten erforderlich sind. Hierzu gehören insbesondere die jeweils aktuelle Fassung der Anlagen 1 bis 3, die Dokumentation der internen Überprüfungen nach § 5 Abs. 4 sowie vorhandene Prüfberichte und Zertifizierungen des Auftragsverarbeiters und seiner Unterauftragsverarbeiter.
+
+(2) Der Verantwortliche ist berechtigt, die Einhaltung dieses Vertrags zu überprüfen (Audit). Überprüfungen können durchgeführt werden durch:
+
+a) Einholung von Selbstauskünften und Dokumentation des Auftragsverarbeiters,
+b) Vorlage aktueller Testate, Prüfberichte oder Zertifizierungen unabhängiger Stellen, auch der Unterauftragsverarbeiter (insbesondere des Rechenzentrumsbetreibers),
+c) Inspektionen beim Auftragsverarbeiter, auch vor Ort, durch den Verantwortlichen selbst oder einen von ihm beauftragten, zur Verschwiegenheit verpflichteten Prüfer, der nicht in einem Wettbewerbsverhältnis zum Auftragsverarbeiter stehen darf.
+
+(3) Vor-Ort-Kontrollen erfolgen nach vorheriger Ankündigung mit angemessener Frist, in der Regel 14 Kalendertage, zu den üblichen Geschäftszeiten, ohne den Betrieb unverhältnismäßig zu stören und höchstens einmal je Kalenderjahr. Bei konkretem Anlass, insbesondere nach einer Verletzung des Schutzes personenbezogener Daten oder auf Verlangen einer Aufsichtsbehörde, sind Kontrollen auch kurzfristig und anlassbezogen zulässig.
+
+(4) Soweit die Kontrolle den Betrieb des Rechenzentrums des Hosting-Anbieters betrifft, genügt der Auftragsverarbeiter seiner Pflicht durch Vorlage aktueller Nachweise des Rechenzentrumsbetreibers (zum Beispiel Zertifizierungen nach ISO/IEC 27001, Auditberichte); ein unmittelbares Zutrittsrecht des Verantwortlichen zum Rechenzentrum besteht nicht. [PRÜFEN: verfügbare Zertifikate des Hosting-Anbieters beschaffen und in Dokument 03 referenzieren]
+
+(5) Der Auftragsverarbeiter duldet Kontrollen der zuständigen Aufsichtsbehörde nach Art. 58 DSGVO und wirkt an ihnen mit, soweit sie diesen Auftrag betreffen.
+
+(6) Die Kosten eigener Mitwirkung an einer turnusmäßigen Kontrolle nach Abs. 3 Satz 1 trägt jede Partei selbst. [PRÜFEN: Kostenregelung für anlassbezogene und wiederholte Audits mit dem Hauptvertrag abstimmen]
+
+---
+
+## § 11 Mitteilungspflichten, Anfragen Dritter
+
+(1) Der Auftragsverarbeiter informiert den Verantwortlichen unverzüglich über
+
+a) Kontrollhandlungen und Maßnahmen der Aufsichtsbehörde, soweit sie diesen Auftrag betreffen,
+b) Ermittlungen staatlicher Stellen mit Bezug zu den im Auftrag verarbeiteten Daten, soweit eine Mitteilung rechtlich zulässig ist,
+c) Anfragen Dritter auf Auskunft oder Herausgabe der im Auftrag verarbeiteten Daten.
+
+(2) Der Auftragsverarbeiter erteilt Dritten keine Auskünfte über die im Auftrag verarbeiteten Daten und gibt keine Daten heraus, es sei denn, er ist hierzu gesetzlich verpflichtet. Betroffene Personen verweist er an den Verantwortlichen (§ 7 Abs. 3).
+
+(3) Der Auftragsverarbeiter führt für die im Auftrag durchgeführten Verarbeitungen ein Verzeichnis nach Art. 30 Abs. 2 DSGVO und stellt der Aufsichtsbehörde die dort vorgesehenen Angaben auf Anforderung zur Verfügung.
+
+---
+
+## § 12 Haftung
+
+(1) Für die Haftung im Außenverhältnis gegenüber betroffenen Personen gilt Art. 82 DSGVO. Verantwortlicher und Auftragsverarbeiter haften danach gegenüber betroffenen Personen als Gesamtschuldner nach Maßgabe des Art. 82 Abs. 4 DSGVO.
+
+(2) Im Innenverhältnis haftet jede Partei nur für den Teil des Schadens, der auf ihre eigene Verantwortlichkeit entfällt (Art. 82 Abs. 5 DSGVO). Der Auftragsverarbeiter haftet dem Verantwortlichen insbesondere für Schäden, die durch eine weisungswidrige oder gegen diesen Vertrag verstoßende Verarbeitung entstehen; der Verantwortliche haftet insbesondere für Schäden aus der Unzulässigkeit der von ihm angewiesenen Verarbeitung.
+
+(3) Für Bußgelder gilt: Jede Partei trägt gegen sie verhängte Bußgelder selbst. Ein Innenausgleich findet insoweit nicht statt. [PRÜFEN: Zulässigkeit und Reichweite von Freistellungs- und Haftungsbegrenzungsklauseln mit der Haftungsregelung des Hauptvertrags abstimmen; gegenüber kommunalen Trägern sind Haftungsbegrenzungen häufig verhandlungsrelevant]
+
+(4) Im Übrigen gelten die Haftungsregelungen des Hauptvertrags.
+
+---
+
+## § 13 Laufzeit, Kündigung
+
+(1) Dieser Vertrag tritt mit Unterzeichnung durch beide Parteien in Kraft, frühestens jedoch mit Beginn des Hauptvertrags, und läuft für die Dauer des Hauptvertrags (§ 1 Abs. 3).
+
+(2) Eine isolierte ordentliche Kündigung dieses Vertrags ist ausgeschlossen. Das Recht zur außerordentlichen Kündigung des Hauptvertrags aus wichtigem Grund bleibt unberührt. Ein wichtiger Grund liegt für den Verantwortlichen insbesondere vor, wenn der Auftragsverarbeiter schwerwiegend oder trotz Abmahnung wiederholt gegen diesen Vertrag oder gegen Art. 28 DSGVO verstößt.
+
+(3) Solange der Auftragsverarbeiter nach Vertragsende noch personenbezogene Daten im Sinne des § 9 Abs. 5 aufbewahrt, gelten die Pflichten dieses Vertrags für diese Daten fort.
+
+---
+
+## § 14 Schlussbestimmungen
+
+(1) Änderungen und Ergänzungen dieses Vertrags einschließlich dieser Klausel bedürfen der Textform. Die Anlagen 2 und 3 können nach den in § 5 Abs. 3 und § 6 Abs. 2 geregelten Verfahren aktualisiert werden.
+
+(2) Bei Widersprüchen zwischen diesem Vertrag und dem Hauptvertrag gehen hinsichtlich der Verarbeitung personenbezogener Daten die Regelungen dieses Vertrags vor. Zwingende gesetzliche Regelungen, insbesondere die DSGVO, das DSG NRW, das SchulG NRW und die VO-DV I, bleiben unberührt und gehen entgegenstehenden Regelungen dieses Vertrags vor.
+
+(3) Sollte eine Bestimmung dieses Vertrags unwirksam sein oder werden, bleibt die Wirksamkeit der übrigen Bestimmungen unberührt. An die Stelle der unwirksamen Bestimmung tritt eine Regelung, die dem Zweck der unwirksamen Bestimmung und den Anforderungen des Art. 28 DSGVO am nächsten kommt.
+
+(4) Es gilt das Recht der Bundesrepublik Deutschland. Gerichtsstand ist, soweit gesetzlich zulässig, [GERICHTSSTAND]. [PRÜFEN: Bei kommunalen Trägern Verwaltungsrechtsweg und vergaberechtliche Vorgaben zum Gerichtsstand berücksichtigen]
+
+(5) Die Einhaltung dieses Vertrags durch den Auftragsverarbeiter überwacht dessen Datenschutzbeauftragte/r: [NAME DATENSCHUTZBEAUFTRAGTER MOTO, E-MAIL, TELEFON]. Zuständige Aufsichtsbehörde für den Verantwortlichen ist die Landesbeauftragte für Datenschutz und Informationsfreiheit Nordrhein-Westfalen (LDI NRW).
+
+---
+
+## Anlagen
+
+Die folgenden Anlagen sind Bestandteil dieses Vertrags:
+
+| Anlage | Dokument | Inhalt |
+|---|---|---|
+| **Anlage 1** | Dokument 04: Verzeichnis von Verarbeitungstätigkeiten (Beschreibung der Verarbeitung) | Gegenstand, Zweck und Umfang der Verarbeitung, Kategorien betroffener Personen und personenbezogener Daten mit Feldbezug, besondere Kategorien nach Art. 9 DSGVO, Protokoll- und Bewegungsdaten, konfigurierte Aufbewahrungs- und Löschfristen einschließlich offener Prüfpunkte |
+| **Anlage 2** | Dokument 02: Technische und organisatorische Maßnahmen | Maßnahmen nach Art. 32 DSGVO, gegliedert nach Zutritts-, Zugangs-, Zugriffs-, Trennungs-, Weitergabe-, Eingabe- und Verfügbarkeitskontrolle sowie Datenminimierung, mit Umsetzungsstand und bekannten Lücken |
+| **Anlage 3** | Dokument 03: Subprozessorenliste (Unterauftragsverarbeiter) | Verzeichnis der Unterauftragsverarbeiter und nachrichtlich geführten Dienste ohne Datenzugriff, jeweils mit Anbieter, Sitz, Leistung, Datenkategorien und Drittlandbewertung einschließlich offener Prüfpunkte |
+| **Anlage 4** | Ansprechpartner und Meldewege | [PLATZHALTER: vor Unterzeichnung zu erstellen; weisungsberechtigte und weisungsempfangende Personen, Kontaktstelle für Meldungen nach § 8, Erreichbarkeiten] |
+
+---
+
+## Unterschriften
+
+**Für den Verantwortlichen**
+
+Ort, Datum: ______________________
+
+Name, Funktion: [NAME, FUNKTION VERTRETUNGSBERECHTIGTE PERSON TRÄGER]
+
+Unterschrift: ______________________
+
+**Für den Auftragsverarbeiter**
+
+Ort, Datum: ______________________
+
+Name, Funktion: [NAME, FUNKTION VERTRETUNGSBERECHTIGTE PERSON MOTO]
+
+Unterschrift: ______________________

--- a/docs/moto-dsgvo-dokumente/02-tom-dokumentation.md
+++ b/docs/moto-dsgvo-dokumente/02-tom-dokumentation.md
@@ -1,0 +1,235 @@
+# Technische und organisatorische Maßnahmen (TOM) nach Art. 32 DSGVO
+
+| | |
+|---|---|
+| **Dokument** | 02 Technische und organisatorische Maßnahmen gemäß Art. 32 DSGVO |
+| **Auftragsverarbeiter** | moto [RECHTSFORM UND ADRESSE] |
+| **Verarbeitungssystem** | moto (internes Projektkürzel "Project Phoenix"), NFC/RFID-gestütztes Anwesenheits- und Raumverwaltungssystem für den Offenen Ganztag (OGS) |
+| **Version** | 1.0 |
+| **Stand** | 2026-07-07 |
+| **Status** | Entwurf zur internen Prüfung |
+| **Letzte Überprüfung** | 2026-07-07 (Erstfassung) |
+| **Verantwortlich für dieses Dokument** | [NAME DATENSCHUTZKOORDINATOR/IN], Datenschutzkoordination moto |
+| **Datenschutzbeauftragte/r** | [NAME DATENSCHUTZBEAUFTRAGTER], [KONTAKTDATEN DSB] |
+
+---
+
+## 1. Zweck und Geltungsbereich
+
+Dieses Dokument beschreibt die technischen und organisatorischen Maßnahmen, die moto als Auftragsverarbeiter im Sinne des Art. 28 DSGVO für das System moto ("Project Phoenix") getroffen hat. Es dient als Anlage zum Auftragsverarbeitungsvertrag zwischen dem jeweiligen Schulträger bzw. der Schule als Verantwortlichem (Art. 4 Nr. 7 DSGVO) und moto und erbringt den Nachweis nach Art. 28 Abs. 3 lit. c in Verbindung mit Art. 32 DSGVO sowie im Rahmen der Rechenschaftspflicht nach Art. 5 Abs. 2 DSGVO.
+
+Der Einsatz des Systems erfolgt im Anwendungsbereich der §§ 120 bis 122 SchulG NRW und der VO-DV I NRW. Rechtsgrundlage des Kernbetriebs ist Art. 6 Abs. 1 lit. e DSGVO. § 2 Abs. 1 VO-DV I knüpft die Zulässigkeit der automatisierten Verarbeitung ausdrücklich an das Vorhandensein technischer und organisatorischer Maßnahmen, die die Sicherheit der Verarbeitung gewährleisten. Die hier beschriebenen Maßnahmen sind damit Voraussetzung des zulässigen Betriebs, nicht bloße Ergänzung.
+
+Beschrieben werden ausschließlich Maßnahmen, die im System tatsächlich implementiert sind oder die sich aus dem Hosting-Setup ergeben. Organisatorische Maßnahmen, deren schriftliche Fixierung noch aussteht, sind mit dem Hinweis [ORGANISATORISCH ZU BESTÄTIGEN] gekennzeichnet. Rechtlich oder tatsächlich noch zu verifizierende Punkte sind mit [PRÜFEN] markiert.
+
+## 2. Risikoorientierung (Art. 32 Abs. 1 und Abs. 2 DSGVO)
+
+Die Auswahl der Maßnahmen berücksichtigt Art, Umfang, Umstände und Zwecke der Verarbeitung sowie Eintrittswahrscheinlichkeit und Schwere der Risiken. Für das System ergeben sich insbesondere folgende risikoerhöhende Faktoren:
+
+1. **Betroffene sind überwiegend Kinder** (Grundschulkinder in der OGS-Betreuung), daneben Erziehungsberechtigte und Beschäftigte der Träger.
+2. **Gesundheitsdaten nach Art. 9 DSGVO** werden verarbeitet: Freitextfeld zu Gesundheitsinformationen des Kindes, strukturierte Krankmeldungen von Kindern sowie Krankheitsabwesenheiten des Personals.
+3. **Anwesenheits- und Aufenthaltsdaten** (Check-in/Check-out, Raumaufenthalte) erlauben Rückschlüsse auf das tagesaktuelle Bewegungsverhalten von Kindern.
+4. **Mehrmandantenbetrieb**: Daten mehrerer Schulen werden in einer gemeinsamen Infrastruktur verarbeitet; eine Vermischung oder mandantenübergreifende Offenlegung ist als Hauptrisiko der Architektur adressiert (Abschnitt 3.8).
+
+Die Maßnahmen sind entsprechend auf die Schutzziele Vertraulichkeit, Integrität, Verfügbarkeit und Belastbarkeit (Art. 32 Abs. 1 lit. b DSGVO) sowie auf den Schutz vor Vernichtung, Verlust, Veränderung, unbefugter Offenlegung und unbefugtem Zugang (Art. 32 Abs. 2 DSGVO) ausgerichtet.
+
+## 3. Maßnahmen nach Kontrollbereichen
+
+Die Gliederung folgt den in der Prüfpraxis kommunaler IT-Dienstleister etablierten acht Kontrollbereichen, ergänzt um die DSGVO-spezifischen Kategorien aus Art. 32 Abs. 1. Eine Zuordnungstabelle zu Art. 32 Abs. 1 DSGVO enthält Abschnitt 4.
+
+### 3.1 Zutrittskontrolle (physische Sicherheit)
+
+Ziel: Unbefugten den physischen Zutritt zu Datenverarbeitungsanlagen verwehren.
+
+| Maßnahme | Umsetzung |
+|---|---|
+| Rechenzentrumsbetrieb | Die Produktions- und Staging-Systeme werden auf dedizierten Servern der Hetzner Online GmbH am Standort Nürnberg (Deutschland) betrieben. moto betreibt keine eigenen Serverräume. |
+| Zutrittskontrolle im Rechenzentrum | Die physische Zutrittskontrolle (Zutrittsregelung, Videoüberwachung, Sicherheitsdienst) liegt beim Rechenzentrumsbetreiber. Hetzner ist für den Rechenzentrumsbetrieb nach ISO/IEC 27001 zertifiziert. Der Nachweis erfolgt über den Auftragsverarbeitungsvertrag mit Hetzner und die dort referenzierten Zertifikate. [PRÜFEN: aktuelles ISO-27001-Zertifikat und AVV-Anlage von Hetzner der TOM-Dokumentation beilegen] |
+| Endgeräte der Mitarbeitenden | Regelungen zu Verschlüsselung und Absicherung von Arbeitsgeräten der moto-Mitarbeitenden (Festplattenverschlüsselung, Bildschirmsperre) [ORGANISATORISCH ZU BESTÄTIGEN] |
+| Kiosk-Geräte an den Schulen | Die NFC-Kioskgeräte (Raspberry Pi) an den Schulen speichern keine personenbezogenen Datenbestände lokal vor; sie kommunizieren über authentifizierte Schnittstellen mit dem Server (Abschnitt 3.2). Die physische Sicherung der Geräte in den Schulräumen obliegt dem Verantwortlichen. |
+
+### 3.2 Zugangskontrolle (Authentifizierung)
+
+Ziel: Nutzung der Systeme durch Unbefugte verhindern.
+
+| Maßnahme | Umsetzung |
+|---|---|
+| Passwortspeicherung | Passwörter und Personal-PINs werden ausschließlich als Argon2id-Hashes gespeichert (Speicherparameter 64 MB, 3 Iterationen, Parallelität 2, 16 Byte Salt). Die Verifikation erfolgt mit konstantem Zeitvergleich zur Abwehr von Timing-Angriffen. Eine Klartextspeicherung findet an keiner Stelle statt. |
+| Sitzungsverwaltung | Die Authentifizierung erfolgt über JWT mit kurzer Gültigkeit: Access-Token 15 Minuten, Refresh-Token 168 Stunden. Ein in der Produktionsumgebung fehlendes oder unsicheres JWT-Secret verhindert den Serverstart (Fail-fast-Prinzip). |
+| Mehrfaktor-Authentifizierung (MFA) | Für Schul- und Betreiberkonten steht ein MFA-Subsystem zur Verfügung: E-Mail-Einmalcodes, Wiederherstellungscodes, vertrauenswürdige Geräte (Standardgültigkeit 90 Tage, konfigurierbar 1 bis 180 Tage) sowie Passkeys (WebAuthn). Fehlversuche führen zu einer MFA-Sperre auf Kontoebene. |
+| Kontosperrung bei Fehlversuchen | Schwellenwert und Sperrdauer für fehlgeschlagene Anmeldeversuche sind je Schule konfigurierbar (Einstellungsregistrierung, keine hartkodierten Werte). |
+| Kiosk-Authentifizierung (NFC-Geräte) | Jedes Kioskgerät authentifiziert sich mit einem gerätespezifischen API-Schlüssel (Bearer-Token); zusätzlich ist für betreuungsrelevante Aktionen die persönliche PIN der aufsichtführenden Fachkraft erforderlich (Zwei-Komponenten-Charakter: Gerätemerkmal plus persönliches Merkmal). Der Schlüsselvergleich erfolgt zeitkonstant; deaktivierte Geräte werden abgewiesen. |
+| Ratenbegrenzung | Anfragen werden serverseitig ratenbegrenzt (Token-Bucket je Client-IP). Für Passwort-Zurücksetzungen und öffentliche Anmeldeformulare bestehen zusätzliche, datenbankgestützte Ratenbegrenzungen. |
+| Datenbankzugang nach Minimalprinzip | Der Anwendungsserver verbindet sich mit einer eigens angelegten Datenbankrolle mit minimalen, tabellenweise vergebenen Rechten. Administrative Rollen sind hiervon getrennt (Abschnitt 3.8). |
+| Portaltrennung beim Login | Schul-, Betreiber- und Elternportal verwenden getrennte Anmeldeinstanzen mit jeweils eigenem Sitzungs-Cookie. Elternkonten werden am Schulportal abgewiesen; das Elternportal akzeptiert ausschließlich Konten mit Erziehungsberechtigten-Rolle. |
+
+### 3.3 Zugriffskontrolle (Autorisierung)
+
+Ziel: Sicherstellen, dass Berechtigte ausschließlich auf die ihrer Aufgabe entsprechenden Daten zugreifen können (Need-to-know).
+
+| Maßnahme | Umsetzung |
+|---|---|
+| Rollen- und Berechtigungsmodell | Zugriffe werden über ein zentrales Rollen- und Berechtigungsmodell mit einer eigenen Autorisierungskomponente (Policy-Engine) gesteuert. Berechtigungen sind kontobezogen und mandantenbezogen zugeordnet. |
+| Zweistufiges Berechtigungssystem | Berechtigungen des Personals (rollenbasiert) und Berechtigungen von Erziehungsberechtigten sind getrennte Systeme. Eltern-Berechtigungen werden je Kind-Beziehung einzeln gespeichert und geprüft. Eine Abholberechtigung oder Notfallkontakt-Kennzeichnung begründet keinen automatischen Portalzugriff auf Kinddaten. |
+| Datensichtbarkeit Kinderdaten | Der Lesezugriff auf vollständige Kinderdaten (Profil, Aufenthaltsort, Datenschutzangaben, Abholpläne) ist je Schule konfigurierbar; Voreinstellung ist die Beschränkung auf die Gruppenbetreuung. Der Schreibzugriff bleibt unabhängig davon stets auf die Gruppenbetreuung beschränkt (Trennung von Lese- und Schreibrechten). |
+| Anwesenheitsprotokoll standardmäßig deaktiviert | Das rückblickende Anwesenheits- und Raumprotokoll für Mitarbeitende ist in der Voreinstellung abgeschaltet und muss vom Verantwortlichen bewusst aktiviert werden. Sichtbarkeitsfenster (Voreinstellung 30 Tage für An-/Abmeldezeiten, 7 Tage für Raumdetails) und der berechtigte Personenkreis sind konfigurierbar. |
+| Zugriffsschutz der Systemeinstellungen | Einstellungen sind zweidimensional geschützt: über Berechtigungen (getrennte Rechte für operative und für datenschutz-/sicherheitsrelevante Einstellungen) und über Sichtbarkeitsrichtlinien (bestimmte Einstellungen nur für Schuladministration, andere nur für den Plattformbetreiber sichtbar). |
+| Architektonische Absicherung | Ein automatisierter Architektur-Test in der Build-Pipeline verhindert, dass HTTP-Handler unter Umgehung der Service- und Autorisierungsschicht direkt auf die Datenzugriffsschicht zugreifen. |
+
+### 3.4 Weitergabekontrolle (Transport und Übermittlung)
+
+Ziel: Schutz personenbezogener Daten bei elektronischer Übertragung.
+
+| Maßnahme | Umsetzung |
+|---|---|
+| Transportverschlüsselung extern | Sämtliche externen Verbindungen zu den Portalen und Schnittstellen werden über einen Reverse Proxy (Caddy) TLS-verschlüsselt terminiert. DNS und vorgeschaltete Auslieferung erfolgen über Cloudflare. |
+| Transportverschlüsselung zur Datenbank | Die Verbindung des Anwendungsservers zur PostgreSQL-Datenbank ist in der Produktionsumgebung TLS-verschlüsselt mit Zertifikatsprüfung (sslmode=verify-ca mit hinterlegtem Wurzelzertifikat). |
+| Cookie-Härtung | Alle Sitzungs-Cookies sind httpOnly und in der Produktionsumgebung secure. Das Eltern-Portal-Cookie ist zusätzlich mit SameSite=Strict gesetzt (CSRF-Schutz beim Zugriff auf Kinddaten). Betreiber- und Eltern-Cookies sind host-gebunden und damit nicht subdomainübergreifend lesbar. |
+| Schutz von Zugangsdaten in Protokollen | Die Zugriffprotokolle des Reverse Proxy maskieren die Header Authorization, Cookie, X-Device-Key und X-Staff-PIN und kürzen IP-Adressen (Maskierung auf /24 bzw. /56). Zugangsdaten gelangen dadurch nicht in Protokolldateien. |
+| Secrets-Verwaltung | Zugangsdaten und Konfigurationsgeheimnisse der Staging- und Produktionsumgebung liegen ausschließlich SOPS/age-verschlüsselt in der Versionsverwaltung. Die Build-Pipeline prüft vor jedem Deployment automatisiert, dass keine Klartextwerte enthalten sind. Ein Pre-Commit-Hook (git-secrets) prüft lokal auf versehentlich eingecheckte Zugangsdaten. |
+| Datenträgertransport | Ein physischer Transport von Datenträgern mit personenbezogenen Daten findet im Regelbetrieb nicht statt. |
+
+### 3.5 Eingabekontrolle (Protokollierung und Nachvollziehbarkeit)
+
+Ziel: Nachträglich feststellen können, wer wann welche personenbezogenen Daten eingegeben, verändert, eingesehen oder gelöscht hat.
+
+| Maßnahme | Umsetzung |
+|---|---|
+| Datenzugriffsprotokoll | Lesezugriffe auf sensible Historien- und Anwesenheitsdaten werden protokolliert (handelndes Konto, Rolle, Ressourcentyp, betroffenes Kind, Zeitraum, Zeitpunkt), einschließlich Exporten. Das Protokoll ist mandantengetrennt gespeichert. |
+| Anmeldeereignisse | Anmeldungen, Abmeldungen, Fehlversuche und MFA-Ereignisse werden je Konto mit Ereignistyp, Erfolg, IP-Adresse, User-Agent und Zeitpunkt protokolliert. |
+| Änderungsprotokolle | Fachliche Änderungen werden in dedizierten, nur anfügbaren Protokolltabellen festgehalten: Änderungen an Kontakt- und Abholdaten der Erziehungsberechtigten, Korrekturen an Zeiterfassungseinträgen (Alt-/Neuwert je Feld, editierende Person), administrative Korrekturen an Anmeldedaten sowie Datenimporte (wer, wann, welche Datei). |
+| Löschprotokoll | Löschvorgänge an Kind- und Personaldaten werden mit Löschart, Anzahl gelöschter Datensätze, Löschgrund, ausführender Person und Zeitpunkt protokolliert (Nachweis für Art. 17 DSGVO). |
+| Einstellungs-Änderungsprotokoll | Jede Änderung an Systemeinstellungen wird nur anfügbar protokolliert (Aktion, alter und neuer Wert); Passwortwerte werden im Protokoll geschwärzt. |
+| Betreiberprotokoll | Aktionen des Plattformbetreibers werden in einem eigenen Audit-Protokoll festgehalten. |
+| Datenschutzgerechte Anwendungsprotokolle | Die Anwendung protokolliert strukturiert. Es gilt die kodifizierte Vorgabe, dass Namen von Kindern nicht auf der regulären Protokollstufe erscheinen; verwendet werden numerische Kennungen. |
+
+Hinweis zur Speicherbegrenzung der Protokolle: Für die Audit-Protokolle selbst besteht derzeit keine automatisierte Löschfrist; sie werden als Nachweis-Trail unbegrenzt vorgehalten. [PRÜFEN: Aufbewahrungskonzept für Audit-Protokolle festlegen und mit dem Grundsatz der Speicherbegrenzung (Art. 5 Abs. 1 lit. e DSGVO) abgleichen]
+
+### 3.6 Auftragskontrolle (Weisungsbindung und Unterauftragsverarbeiter)
+
+Ziel: Verarbeitung nur nach dokumentierter Weisung des Verantwortlichen; Kontrolle der eingesetzten weiteren Auftragsverarbeiter.
+
+| Maßnahme | Umsetzung |
+|---|---|
+| Weisungsbindung | Die Verarbeitung erfolgt ausschließlich zur Erbringung der vertraglich vereinbarten Leistung. Ein dokumentiertes Weisungs- und Kommunikationsverfahren mit den Verantwortlichen [ORGANISATORISCH ZU BESTÄTIGEN] |
+| Mandantenkonfiguration durch den Verantwortlichen | Datenschutzrelevante Betriebsparameter (Aufbewahrungsfristen, Protokollumfang, Sichtbarkeitskreise) werden je Schule durch den Verantwortlichen selbst konfiguriert; moto gibt datenschutzfreundliche Voreinstellungen vor (Abschnitt 3.9). |
+| Unterauftragsverarbeiter | Siehe nachstehende Übersicht. Die vollständige, vertraglich gepflegte Liste einschließlich AVV-Status wird als eigene Anlage zum Auftragsverarbeitungsvertrag geführt: Dokument 03 (Subprozessorenliste, Anlage 3 zum AVV) |
+
+Eingesetzte Dienste (Ist-Stand):
+
+| Dienst | Anbieter, Sitz | Zweck | Personenbezug | Drittlandbezug |
+|---|---|---|---|---|
+| Server-Hosting | Hetzner Online GmbH, Deutschland (Rechenzentrum Nürnberg) | Betrieb von Anwendung, Datenbank und Monitoring | Alle im System verarbeiteten Datenkategorien | Nein (Verarbeitung in Deutschland) |
+| DNS / vorgeschaltete Auslieferung | Cloudflare, Inc., USA | DNS, CDN, Schutz vor Überlastangriffen | Verbindungsmetadaten (IP-Adressen) der Portalnutzer beim Verbindungsaufbau | Ja. [PRÜFEN: Cloudflare-DPA, EU-Datenlokalisierungsoptionen und Transfermechanismus (EU-US Data Privacy Framework / Standardvertragsklauseln) dokumentieren] |
+| Cloudflare Turnstile (Captcha) | Cloudflare, Inc., USA | Bot-Schutz des öffentlichen Anmeldeformulars; in der Voreinstellung deaktiviert, je Schule aktivierbar | IP-Adresse und Browsersignale der ausfüllenden Person | Ja, nur bei Aktivierung. [PRÜFEN: Transfermechanismus; Information der Betroffenen im Anmeldeformular] |
+| GitHub / GitHub Container Registry | GitHub, Inc. (Microsoft), USA | Quellcodeverwaltung, Build-Pipeline, Auslieferung der Container-Images | Keine Daten der Endnutzer; nur Anwendungscode und Build-Artefakte | Ja, ohne Endnutzerdaten. [PRÜFEN: DPF-Status von GitHub/Microsoft dokumentieren] |
+| E-Mail-Versand (SMTP) | [SMTP-ANBIETER UND SITZ] | Versand von Einladungs-, Passwort-, MFA- und Anmelde-E-Mails | E-Mail-Adressen, Namen in der Anrede, Einladungs- und Zurücksetzungslinks | [PRÜFEN: Anbieter und Serverstandort verifizieren, AVV abschließen] |
+| Fehlerprotokollierung (Sentry, optional) | Functional Software, Inc., USA; Konfiguration verweist auf EU-Region | Fehler- und Ausnahmeüberwachung | Stacktraces und Request-Metadaten; implementierte Bereinigung entfernt vor dem Versand Authorization- und Cookie-Header sowie IP-Adresse, E-Mail und Benutzername | [PRÜFEN: tatsächliche Projektregion (EU) im Sentry-Konto verifizieren] |
+| Produktnutzungsanalyse (PostHog, optional) | PostHog, Inc.; konfiguriert auf EU-Cloud (eu.i.posthog.com) | Nutzungsanalyse der Weboberfläche | Nutzungsereignisse angemeldeter Nutzer | [PRÜFEN: produktiven Hostwert und Ereignisinhalte verifizieren] |
+| Monitoring (Grafana, Loki, Alloy, Prometheus) | Eigenbetrieb auf demselben Hetzner-Server | Protokollaggregation, Metriken, Alarmierung | Anwendungsprotokolle (ohne Kindernamen, IP-maskiert, Zugangsdaten geschwärzt) | Nein (Eigenbetrieb, Deutschland) |
+
+### 3.7 Verfügbarkeitskontrolle und Wiederherstellbarkeit (Art. 32 Abs. 1 lit. b und c)
+
+Ziel: Schutz vor Zerstörung und Verlust; rasche Wiederherstellung nach Zwischenfällen.
+
+| Maßnahme | Umsetzung |
+|---|---|
+| Datensicherung vor jeder Änderung am Datenbestand | Der automatisierte Deployment-Prozess erstellt vor jeder Datenbankmigration eine vollständige Sicherung: Sicherung der Datenbankrollen und globalen Objekte, vollständiger Datenbank-Dump im wiederherstellbaren Custom-Format sowie Sicherung des Datei-Uploads-Volumes. Bei leerer oder fehlgeschlagener Sicherung wird das Deployment abgebrochen. |
+| Automatischer Rollback | Schlägt eine Migration oder der anschließende Funktionstest fehl, stellt der Deployment-Prozess den vorherigen Stand automatisch aus der Sicherung wieder her. Die Ergebniszustände sind über definierte Exit-Codes maschinell auswertbar; ein fehlgeschlagener Rollback wird als kritisches Ereignis behandelt. Für manuelle Rücknahmen existiert ein eigener Rollback-Workflow in der Build-Pipeline. |
+| Aufbewahrung der Sicherungen | Sicherungen werden serverseitig vorgehalten und automatisch rotiert (Aufbewahrung: 3 Generationen Staging, 7 Generationen Produktion). Die Sicherungsdatei der Datenbankrollen ist mit restriktiven Dateirechten (nur Eigentümer) geschützt. |
+| Regelmäßige, deploymentunabhängige Sicherungen | [PRÜFEN: Sicherungen sind derzeit an Deployments gekoppelt; eine zeitgesteuerte, deploymentunabhängige Sicherung mit dokumentierter Frequenz ist festzulegen: [BACKUP-FREQUENZ UND -AUFBEWAHRUNGSDAUER]] |
+| Wiederherstellungstests | [ORGANISATORISCH ZU BESTÄTIGEN: turnusmäßige Wiederherstellungstests der Datenbanksicherungen dokumentieren] |
+| Überwachung und Alarmierung | Zentrale Protokoll- und Metriküberwachung (Grafana/Loki/Prometheus) mit Alarmregeln. Der Anwendungsserver stellt einen Health-Endpunkt bereit, der von dedizierten Prüf-Containern für Produktion und Staging minütlich aktiv abgefragt wird; ein Ausfall wird innerhalb weniger Minuten alarmiert. |
+| Ressourcenschutz | Konfigurierte Verbindungspool-Grenzen der Datenbankanbindung verhindern Ressourcenerschöpfung; Ratenbegrenzungen (Abschnitt 3.2) begrenzen Lastspitzen durch einzelne Clients. Vorgeschalteter Überlastschutz durch Cloudflare. |
+| Getrennte Umgebungen | Staging- und Produktionsumgebung sind vollständig getrennt (eigene Server-Verzeichnisse, eigene verschlüsselte Konfigurationsbestände, eigene Sicherungen). Testdatenbanken laufen in isolierten Netzen; Testdaten-Generatoren sind technisch auf Entwicklungsumgebungen beschränkt. |
+
+### 3.8 Trennungskontrolle (Mandantentrennung)
+
+Ziel: Getrennte Verarbeitung der Daten unterschiedlicher Verantwortlicher (Schulen) im Mehrmandantenbetrieb.
+
+| Maßnahme | Umsetzung |
+|---|---|
+| Row Level Security auf Datenbankebene | Alle mandantenbezogenen Tabellen (über 58 Tabellen in 15 fachlichen Datenbankschemata) tragen eine Mandantenkennung und sind durch PostgreSQL Row Level Security geschützt. Die Richtlinien sind mit FORCE ROW LEVEL SECURITY erzwungen und binden jede Zeile an die Mandantenkennung der aktuellen Sitzung. Ein Zugriff über Mandantengrenzen hinweg ist damit auf Datenbankebene ausgeschlossen, nicht nur auf Anwendungsebene. |
+| Mandantentransaktion je Anfrage | Eine zentrale Middleware wickelt jede mandantenbezogene Anfrage in eine eigene Datenbanktransaktion: Sie setzt die Sitzungsrolle auf die RLS-pflichtige Mandantenrolle und die Mandantenkennung als Sitzungsvariable und rollt die Transaktion bei Serverfehlern automatisch zurück. Teilschreibvorgänge bei Fehlern werden dadurch verhindert. |
+| Getrennte Datenbankrollen | Die RLS-pflichtige Mandantenrolle (Zugriff nur auf den eigenen Mandanten) ist von der administrativen Rolle (nur für Betreiberfunktionen, Migrationen) getrennt. Rechte sind tabellenweise minimal vergeben. |
+| Mandantenkennung im Datenmodell | Die Mandantenkennung ist als Pflichtfeld im Basisdatenmodell verankert und wird über den gesamten Anfragezyklus im Anwendungskontext mitgeführt und automatisch befüllt. |
+| Portal- und Bereichstrennung | Drei getrennte Portale (Schule/Träger, Betreiber, Eltern) mit eigenen Anmeldeinstanzen, eigenen Cookies und eigenen JWT-Geltungsbereichen. Serverseitige Middleware weist Eltern-Token an Schul-Endpunkten und Nicht-Eltern-Token an Eltern-Endpunkten zurück (mehrschichtige Absicherung zusätzlich zur Cookie-Trennung). |
+| Betreiberdaten getrennt | Konten und Protokolle des Plattformbetreibers liegen in einer eigenen, nicht mandantengebundenen Tabellenfamilie mit eigenem Portal. |
+
+### 3.9 Pseudonymisierung und Verschlüsselung (Art. 32 Abs. 1 lit. a)
+
+| Maßnahme | Umsetzung |
+|---|---|
+| RFID-Kennungen ohne Personenbezug auf dem Medium | Die eingesetzten RFID/NFC-Medien enthalten ausschließlich eine technische Kennung (Tag-UID). Die Zuordnung zur Person erfolgt allein serverseitig in der Datenbank. Auf dem Medium selbst sind keine Namen, Gesundheits- oder Anwesenheitsdaten gespeichert. |
+| Pseudonyme Kennungen in Protokollen | Anwendungsprotokolle verwenden numerische Kennungen statt Namen; IP-Adressen in Proxy-Protokollen werden maskiert (Abschnitt 3.4 und 3.5). |
+| Hashing von Geheimnissen | Passwörter und PINs ausschließlich als Argon2id-Hashes (Abschnitt 3.2). |
+| Verschlüsselung bei Übertragung | TLS für alle externen Verbindungen und für die Datenbankanbindung (Abschnitt 3.4). |
+| Verschlüsselung von Konfigurationsgeheimnissen | SOPS/age-Verschlüsselung sämtlicher Umgebungsgeheimnisse (Abschnitt 3.4). |
+| Verschlüsselung ruhender Nutzdaten | [PRÜFEN: Eine Datenträger- oder Datenbankverschlüsselung der Produktionsserver ist im Systembestand nicht dokumentiert. Ist-Zustand feststellen und entweder nachweisen oder als Maßnahme einführen] |
+
+### 3.10 Datenminimierung und Speicherbegrenzung (Art. 5 Abs. 1 lit. c und e, Art. 25 DSGVO)
+
+| Maßnahme | Umsetzung |
+|---|---|
+| Automatisierte tägliche Datenbereinigung | Ein Scheduler führt täglich (Voreinstellung 02:00 Uhr) je Schule automatisierte Löschläufe aus. Die Bereinigung ist in der Voreinstellung aktiviert. |
+| Aufbewahrung von Anwesenheits- und Aufenthaltsdaten | Voreinstellung 30 Tage, einstellbar 1 bis 31 Tage. Individuelle, je Kind dokumentierte Einwilligungen können innerhalb dieses Rahmens eine eigene Frist setzen. |
+| Aufbewahrung von Feedback-Einträgen | Voreinstellung 90 Tage (1 bis 365 Tage). |
+| Aufbewahrung abgelehnter Anmeldungen | Voreinstellung 90 Tage (höchstens 730 Tage). |
+| Aufbewahrung der Personalzeiterfassung | Voreinstellung 730 Tage (2 Jahre), wählbar bis 2920 Tage; die Stufen orientieren sich an den gesetzlichen Aufbewahrungspflichten (§ 16 Abs. 2 ArbZG, § 41 EStG, § 147 AO). |
+| Aufbewahrung abgeschlossener Betreuungsplan-Termine | Voreinstellung 365 Tage (1 bis 1825 Tage). |
+| Token-Bereinigung | Abgelaufene Sitzungs-, Zurücksetzungs- und Einladungstoken werden automatisiert gelöscht. Eltern-Einladungslinks sind in der Voreinstellung 48 Stunden gültig (höchstens eine Woche). |
+| Datenschutzfreundliche Voreinstellungen | Rückblickendes Anwesenheitsprotokoll in der Voreinstellung deaktiviert; Sichtbarkeit von Kinderdaten in der Voreinstellung auf die Gruppenbetreuung beschränkt; Captcha-Drittdienst in der Voreinstellung deaktiviert (Art. 25 Abs. 2 DSGVO). |
+| Löschnachweis | Jeder Löschlauf wird im Löschprotokoll dokumentiert (Abschnitt 3.5). |
+| Offene Fristen | Für einzelne Datenbestände (Eltern-Nachrichten, unregistrierte Tag-Scans, Audit-Protokolle) besteht noch keine automatisierte Löschfrist. [PRÜFEN: Löschkonzept um diese Bestände ergänzen] |
+
+### 3.11 Verfahren zur regelmäßigen Überprüfung, Bewertung und Evaluierung (Art. 32 Abs. 1 lit. d)
+
+| Maßnahme | Umsetzung |
+|---|---|
+| Automatisierte Qualitäts- und Architekturprüfungen | Jede Codeänderung durchläuft eine Build-Pipeline mit automatisierten Tests, statischer Analyse und Architektur-Prüfungen, die sicherheitsrelevante Konventionen erzwingen (u. a. Schichtentrennung, keine Datenbankzugriffe unter Umgehung der Zugriffsschicht, Konfigurations-Synchronisationsprüfung der verschlüsselten Umgebungsdateien). |
+| Vier-Augen-Prinzip bei Änderungen | Codeänderungen werden über Pull Requests mit Review eingebracht; direkte Änderungen an Produktionsumgebungen ohne Versionsverwaltung sind durch den SOPS-Prozess ausgeschlossen. |
+| Überprüfung dieses Dokuments | Dieses Dokument wird mindestens jährlich sowie anlassbezogen bei Architekturänderungen überprüft und fortgeschrieben. [ORGANISATORISCH ZU BESTÄTIGEN: Überprüfungsturnus verbindlich festlegen und Verantwortlichkeit benennen] |
+| Externe Sicherheitsüberprüfungen | [PRÜFEN: Penetrationstests oder externe Sicherheitsaudits sind bislang nicht dokumentiert; Planung und Turnus festlegen] |
+| Zertifizierungen (Art. 32 Abs. 3 DSGVO) | moto verfügt derzeit über keine eigene Zertifizierung nach Art. 42 DSGVO und beruft sich nicht auf einen genehmigten Verhaltenskodex nach Art. 40 DSGVO. Der Rechenzentrumsbetreiber Hetzner ist nach ISO/IEC 27001 zertifiziert. [ZERTIFIZIERUNGEN FALLS VORHANDEN] |
+
+### 3.12 Organisatorische Rahmenmaßnahmen und Incident-Response
+
+| Maßnahme | Umsetzung |
+|---|---|
+| Datenschutzbeauftragte/r | [NAME DATENSCHUTZBEAUFTRAGTER], erreichbar unter [KONTAKTDATEN DSB]. [ORGANISATORISCH ZU BESTÄTIGEN: Bestellung dokumentieren] |
+| Verpflichtung auf Vertraulichkeit | Alle Mitarbeitenden von moto mit Zugriff auf personenbezogene Daten werden auf die Vertraulichkeit nach Art. 28 Abs. 3 lit. b, Art. 29 DSGVO verpflichtet. [ORGANISATORISCH ZU BESTÄTIGEN: schriftliche Verpflichtungserklärungen] |
+| Schulungen | Mitarbeitende werden zu Datenschutz und Informationssicherheit geschult, Turnus: [SCHULUNGSINTERVALL MITARBEITENDE]. [ORGANISATORISCH ZU BESTÄTIGEN] |
+| Meldeverfahren bei Datenschutzverletzungen | Technische Grundlage: aktive Überwachung mit Alarmierung (Abschnitt 3.7) ermöglicht die zeitnahe Erkennung von Störungen und Auffälligkeiten. Ein dokumentiertes Verfahren zur Bewertung und zur Unterstützung des Verantwortlichen bei Meldungen nach Art. 33 und 34 DSGVO (Meldung an den Verantwortlichen ohne unangemessene Verzögerung) [ORGANISATORISCH ZU BESTÄTIGEN] |
+| Unterstützung bei Betroffenenrechten | Das System stellt technische Grundlagen für die Erfüllung von Betroffenenrechten bereit: dokumentierte Einwilligungen je Kind, elterninitiierte Datenänderungsanfragen mit Prüfworkflow, protokollierte Löschvorgänge. Das organisatorische Verfahren zur Bearbeitung von Betroffenenanfragen über den Verantwortlichen [ORGANISATORISCH ZU BESTÄTIGEN] |
+| Berechtigungsvergabe intern | Verfahren zur Vergabe, Überprüfung und zum Entzug administrativer Zugänge (Server, Versionsverwaltung, SOPS-Schlüssel) bei Ein- und Austritt von Mitarbeitenden [ORGANISATORISCH ZU BESTÄTIGEN]. Technische Grundlage: der SOPS-Altersschlüssel wird ausschließlich über sichere Kanäle geteilt; die Deploy-Zugänge liegen als geschützte Secrets in der Build-Pipeline. |
+
+## 4. Zuordnung zu Art. 32 Abs. 1 DSGVO
+
+| Anforderung Art. 32 Abs. 1 | Abgedeckt durch Abschnitt |
+|---|---|
+| lit. a Pseudonymisierung und Verschlüsselung | 3.4, 3.9 |
+| lit. b Vertraulichkeit | 3.1, 3.2, 3.3, 3.4, 3.8 |
+| lit. b Integrität | 3.5, 3.8 (Transaktions-Rollback), 3.11 |
+| lit. b Verfügbarkeit und Belastbarkeit | 3.7 |
+| lit. c rasche Wiederherstellbarkeit | 3.7 (Sicherung, automatischer Rollback, Rollback-Workflow) |
+| lit. d regelmäßige Überprüfung und Evaluierung | 3.11 |
+| Abs. 2 Risikoangemessenheit | 2 |
+| Abs. 3 Verhaltenskodex/Zertifizierung | 3.11 (nicht zutreffend für moto selbst; ISO 27001 des Rechenzentrumsbetreibers) |
+
+Ergänzend abgedeckt: Art. 25 DSGVO (datenschutzfreundliche Voreinstellungen, Abschnitt 3.10), Art. 28 Abs. 3 lit. b DSGVO (Vertraulichkeitsverpflichtung, Abschnitt 3.12), Art. 33/34 DSGVO (Meldeverfahren, Abschnitt 3.12), Art. 5 Abs. 1 lit. c und e DSGVO (Abschnitt 3.10).
+
+## 5. Nachweise und referenzierte Unterlagen
+
+Die folgenden Unterlagen ergänzen dieses Dokument und werden auf Anforderung des Verantwortlichen vorgelegt, soweit vorhanden:
+
+- Auftragsverarbeitungsvertrag und Zertifikatsnachweise des Rechenzentrumsbetreibers Hetzner [PRÜFEN: beilegen]
+- Verzeichnis der Unterauftragsverarbeiter mit AVV-Status: Dokument 03 (Subprozessorenliste)
+- Datenbestandsaufnahme (gesondertes internes Dokument) und Löschkonzept (Dokument 05 dieser Reihe)
+- Verzeichnis von Verarbeitungstätigkeiten nach Art. 30 Abs. 2 DSGVO (Dokument 04 dieser Reihe)
+- Nachweise über Vertraulichkeitsverpflichtungen und Schulungen [ORGANISATORISCH ZU BESTÄTIGEN]
+
+## 6. Änderungshistorie
+
+| Version | Datum | Änderung | Bearbeitung |
+|---|---|---|---|
+| 1.0 | 2026-07-07 | Erstfassung, Entwurf zur internen Prüfung | Datenschutzkoordination moto |

--- a/docs/moto-dsgvo-dokumente/03-subprozessorenliste.md
+++ b/docs/moto-dsgvo-dokumente/03-subprozessorenliste.md
@@ -1,0 +1,127 @@
+# Liste der Subunternehmer (Subprozessoren)
+
+**Dokument 03 der Datenschutzdokumentation — Anlage 3 zum Vertrag über die Auftragsverarbeitung (Art. 28 DSGVO)**
+
+| | |
+|---|---|
+| Auftragsverarbeiter | moto, [RECHTSFORM UND ADRESSE] |
+| Produkt | moto (NFC/RFID-gestütztes Anwesenheits- und Raumverwaltungssystem für den Offenen Ganztag) |
+| Verantwortlicher | Die jeweilige Schule bzw. der jeweilige Schulträger gemäß Hauptvertrag |
+| Datenschutzbeauftragter des Auftragsverarbeiters | [NAME DATENSCHUTZBEAUFTRAGTER], [KONTAKTDATEN DATENSCHUTZBEAUFTRAGTER] |
+| Version | 1.0 |
+| Stand | 2026-07-07 |
+| Status | Entwurf zur internen Prüfung |
+
+---
+
+## 1. Zweck und Geltungsbereich
+
+Diese Liste benennt gemäß Art. 28 Abs. 2 und Abs. 4 DSGVO alle weiteren Auftragsverarbeiter (Subunternehmer), die moto zur Erbringung der vertraglich vereinbarten Leistungen einsetzt. Sie ist Bestandteil des Vertrages über die Auftragsverarbeitung zwischen dem Verantwortlichen (Schule/Schulträger) und moto und konkretisiert die dort erteilte allgemeine schriftliche Genehmigung im Sinne des Art. 28 Abs. 2 Satz 1 DSGVO.
+
+moto legt jedem Subunternehmer durch Vertrag dieselben Datenschutzpflichten auf, die im Auftragsverarbeitungsvertrag zwischen dem Verantwortlichen und moto vereinbart sind (Art. 28 Abs. 4 DSGVO). Kommt ein Subunternehmer seinen Datenschutzpflichten nicht nach, haftet moto gegenüber dem Verantwortlichen für die Einhaltung der Pflichten dieses Subunternehmers.
+
+Die Beauftragung von Subunternehmern erfolgt im Einklang mit § 2 Abs. 3 VO-DV I NRW: Die Verarbeitung durch Subunternehmer erfolgt ausschließlich weisungsgebunden und zweckgebunden für die jeweilige Schule.
+
+## 2. Grundsatz der Datenhaltung
+
+Sämtliche produktiven Nutzdaten (Stammdaten von Schülerinnen und Schülern, Erziehungsberechtigten und Personal, Anwesenheits- und Aufenthaltsdaten, Einwilligungen, Protokolldaten) werden ausschließlich in der PostgreSQL-Datenbank auf Servern der Hetzner Online GmbH am Standort Nürnberg (Deutschland) gespeichert. Kein anderer in dieser Liste genannter Dienstleister erhält dauerhaften Zugriff auf diese Datenbank.
+
+Die übrigen Subunternehmer sind vorgelagerte Infrastruktur- bzw. Werkzeugdienste mit deutlich reduziertem oder ohne Personenbezug. Diese Abgrenzung ist in der Übersichtstabelle (Spalte "Datenkategorien") und in den Einzeldarstellungen (Abschnitt 4) ausgewiesen.
+
+## 3. Übersichtstabelle
+
+| Nr. | Anbieter | Sitz | Zweck der Verarbeitung | Datenkategorien | Drittlandtransfer / Transfergarantie | AVV/DPA des Anbieters |
+|---|---|---|---|---|---|---|
+| 1 | Hetzner Online GmbH | Industriestraße 25, 91710 Gunzenhausen, Deutschland; Rechenzentrum: Nürnberg, Deutschland | Hosting der gesamten Systeminfrastruktur (Backend, Frontend, Datenbank, selbst gehostetes Monitoring), Datenbank-Backups | Alle im System verarbeiteten personenbezogenen Daten, einschließlich Gesundheitsangaben in Freitextfeldern (Art. 9 DSGVO), Anwesenheits- und Bewegungsdaten, Zugangsdaten (nur als Hashes) | Nein. Verarbeitung ausschließlich in deutschen Rechenzentren. [PRÜFEN: vertragliche Beschränkung auf deutsche Standorte im Hetzner-AVV dokumentieren] | https://www.hetzner.com/AV/DPA_de.pdf (Abschluss über das Hetzner-Kundenportal) |
+| 2 | Cloudflare, Inc. bzw. Cloudflare Germany GmbH [PRÜFEN: konkrete Vertragspartei laut Cloudflare-DPA] | Cloudflare, Inc., 101 Townsend St, San Francisco, CA 94107, USA; EU-Gesellschaft: Cloudflare Germany GmbH, [ADRESSE CLOUDFLARE GERMANY] | DNS-Auflösung, Content Delivery, DDoS-Schutz (dem Hosting vorgelagert); zusätzlich Bot-Schutz (Turnstile-Captcha) für das öffentliche Anmeldeformular, sofern je Schule aktiviert | Verbindungs- und Metadaten aller Portalnutzer (IP-Adressen, HTTP-Metadaten); bei aktiviertem Turnstile zusätzlich IP-Adresse und Browsersignale der Erziehungsberechtigten. Keine dauerhafte Speicherung von Inhaltsdaten | Ja, USA. Transfergarantie: Angemessenheitsbeschluss (EU) 2023/1795 (EU-US Data Privacy Framework), DPF-Zertifizierung von Cloudflare [PRÜFEN: Zertifizierungsstatus unter dataprivacyframework.gov, Prüfdatum eintragen]; hilfsweise Standardvertragsklauseln gemäß Durchführungsbeschluss (EU) 2021/914, im Cloudflare-DPA enthalten. Risikohinweis siehe Abschnitt 5 | https://www.cloudflare.com/cloudflare-customer-dpa/ (Version 6.4, April 2026); Subprozessoren: https://www.cloudflare.com/gdpr/subprocessors/ |
+| 3 | GitHub, Inc. bzw. GitHub B.V. (Microsoft-Konzern) | GitHub, Inc., 88 Colin P Kelly Jr St, San Francisco, CA 94107, USA | Quellcodeverwaltung, CI/CD-Pipeline (Build und Deployment), Container-Registry (GHCR), Verwaltung verschlüsselter Deploy-Zugangsdaten | Keine personenbezogenen Daten von Schülerinnen und Schülern, Erziehungsberechtigten oder Schulpersonal. Verarbeitet werden ausschließlich Entwicklungsartefakte (Quellcode, Container-Images, Build-Protokolle) sowie Daten der Entwickler von moto | Ja, USA. Transfergarantie: Angemessenheitsbeschluss (EU) 2023/1795 (EU-US Data Privacy Framework), DPF-Zertifizierung von GitHub [PRÜFEN: Zertifizierungsstatus unter dataprivacyframework.gov, Prüfdatum eintragen]. Risikohinweis siehe Abschnitt 5 | https://github.com/customer-terms/github-data-protection-agreement (Fassung Oktober 2025); Subprozessoren: https://docs.github.com/en/site-policy/privacy-policies/github-subprocessors |
+| 4 | [NAME SMTP-ANBIETER] [PRÜFEN: Anbieter, Sitz und Serverstandort klären] | [SITZ SMTP-ANBIETER] | Versand von System-E-Mails (Einladungen, Passwort-Zurücksetzung, MFA-Codes, Anmeldebestätigungen, Benachrichtigungen) | E-Mail-Adressen, Namen in der Anrede, Einladungs- und Zurücksetzungs-Token; in Anmeldebestätigungen ggf. der Name des Kindes | [PRÜFEN: abhängig vom Anbieter und Serverstandort] | [PRÜFEN: AVV/DPA des Anbieters referenzieren] |
+| 5 | Functional Software, Inc. (Sentry) [PRÜFEN: produktiver Einsatz bestätigen] | 45 Fremont Street, San Francisco, CA 94105, USA; Datenhaltung laut Konfiguration: EU-Region | Fehler- und Ausnahmeprotokollierung (Error-Tracking) für Backend und Frontend | Fehlermeldungen, Stacktraces, technische Request-Metadaten. Vor Übermittlung werden Authentifizierungs-Header, Cookies, IP-Adressen, E-Mail-Adressen und Benutzernamen technisch entfernt (Scrubbing im Quellcode implementiert) | Datenhaltung in der EU-Region von Sentry vorgesehen [PRÜFEN: tatsächliche Projekt-Region im Sentry-Konto verifizieren]. Bei EU-Region kein regelmäßiger Drittlandtransfer der Ereignisdaten; Restrisiko Konzernzugriff USA, hilfsweise DPF/SCC laut Sentry-DPA [PRÜFEN: aktuelle Fassung sichten] | https://sentry.io/legal/dpa/ [PRÜFEN: Link und Fassung verifizieren] |
+| 6 | PostHog, Inc. [PRÜFEN: produktiver Einsatz und produktiv konfigurierter Host bestätigen] | [ADRESSE POSTHOG, USA]; Datenhaltung laut Konfiguration: EU Cloud (eu.i.posthog.com) | Produkt- und Nutzungsanalyse des Web-Frontends (nur bei gesetztem Analyse-Schlüssel aktiv) | Nutzungsereignisse und Interaktionsdaten angemeldeter Nutzer (Personal, ggf. Eltern-Portal). [PRÜFEN: Event-Inhalte auditieren, insbesondere ob Namen oder Kennungen von Kindern in Ereignis-Eigenschaften gelangen] | Datenhaltung in der EU-Cloud-Instanz vorgesehen [PRÜFEN: produktiven Konfigurationswert bestätigen]. Bei EU-Cloud kein regelmäßiger Drittlandtransfer; Restrisiko Konzernzugriff USA, hilfsweise DPF/SCC laut PostHog-DPA [PRÜFEN: aktuelle Fassung sichten] | https://posthog.com/dpa [PRÜFEN: Link und Fassung verifizieren] |
+
+## 4. Einzeldarstellung
+
+### 4.1 Hetzner Online GmbH (Hosting)
+
+Hetzner betreibt die für moto genutzte Serverinfrastruktur ausschließlich im Rechenzentrum Nürnberg (Deutschland). Auf dieser Infrastruktur laufen sämtliche Systemkomponenten: das Go-Backend, das Next.js-Frontend, die PostgreSQL-Datenbank (mit Transportverschlüsselung, Row Level Security und mandantengetrennter Datenhaltung je Schule), der Reverse Proxy (Caddy) sowie das selbst betriebene Monitoring (Grafana, Loki). Ein Drittlandtransfer findet insoweit nicht statt.
+
+Hetzner erhält keinen inhaltlichen Zugriff auf die verarbeiteten Daten; die Verarbeitung beschränkt sich auf die Bereitstellung und den Betrieb der Infrastruktur. Datenbank-Backups verbleiben auf derselben Infrastruktur. Der Abschluss der Auftragsverarbeitungsvereinbarung erfolgt über das Hetzner-Kundenportal; die im Anhang des Hetzner-AVV benannten eigenen Subunternehmer von Hetzner (Konzerngesellschaften, Supportdienstleister) sind bei der jährlichen Überprüfung dieser Liste mitzusichten. [PRÜFEN: Datum der letzten Sichtung des Hetzner-AVV inkl. Subunternehmeranhang eintragen]
+
+Hinweis zum Monitoring: Grafana, Loki und die zugehörigen Komponenten werden von moto selbst auf der Hetzner-Infrastruktur betrieben und begründen keinen weiteren Subunternehmer. In den Zugriffsprotokollen des Reverse Proxy werden IP-Adressen maskiert; Authentifizierungsdaten (Authorization-Header, Cookies, Geräteschlüssel, Personal-PINs) werden vor der Protokollierung entfernt.
+
+### 4.2 Cloudflare (DNS, CDN, DDoS-Schutz, Turnstile)
+
+Cloudflare ist der Hetzner-Infrastruktur als Netzwerkdienst vorgelagert und erbringt DNS-Auflösung, Content Delivery und Schutz vor Überlastungsangriffen. Der Web-Verkehr aller drei Portale (Schule/Träger, Betreiber, Eltern) wird über das Cloudflare-Netz geleitet. Cloudflare verarbeitet dabei Verbindungsmetadaten, insbesondere IP-Adressen und HTTP-Metadaten der Portalnutzer. Eine dauerhafte Speicherung von Inhaltsdaten bei Cloudflare erfolgt nicht.
+
+Zusätzlich wird der Cloudflare-Dienst Turnstile als Bot-Schutz für das öffentliche Online-Anmeldeformular eingesetzt. Turnstile ist standardmäßig deaktiviert und wird je Schule einzeln aktiviert. Bei aktiviertem Turnstile wird das Prüf-Skript direkt im Browser der Erziehungsberechtigten von Cloudflare geladen; Cloudflare erhält in diesem Fall die IP-Adresse und technische Browsersignale der ausfüllenden Person. Zusätzlich übermittelt das Backend zur Verifikation die IP-Adresse an den Cloudflare-Prüfdienst.
+
+Drittlandtransfer: Cloudflare, Inc. ist ein Unternehmen mit Sitz in den USA. Rechtsgrundlage des Transfers ist der Angemessenheitsbeschluss (EU) 2023/1795 der EU-Kommission (EU-US Data Privacy Framework) in Verbindung mit der DPF-Zertifizierung von Cloudflare; hilfsweise gelten die im Cloudflare-DPA enthaltenen Standardvertragsklauseln gemäß Durchführungsbeschluss (EU) 2021/914. Zum Risikohinweis bezüglich des Fortbestands des Angemessenheitsbeschlusses siehe Abschnitt 5.
+
+[PRÜFEN: Cloudflare bietet mit der Data Localization Suite (Regional Services, Customer Metadata Boundary) die Möglichkeit, TLS-Terminierung und Metadatenspeicherung auf die EU zu beschränken. Ob diese Beschränkung für die moto-Konfiguration aktiviert ist, ist zu verifizieren. Ohne aktivierte Datenlokalisierung ist von einer Verarbeitung mit potenziellem US-Bezug auszugehen; diese Liste geht bis zur Verifikation vom Standardfall ohne Datenlokalisierung aus.]
+
+[PRÜFEN: Konkrete Vertragspartei (Cloudflare, Inc. oder Cloudflare Germany GmbH) laut abgeschlossenem Vertrag eintragen.]
+
+### 4.3 GitHub (Quellcodeverwaltung, CI/CD, Container-Registry)
+
+GitHub wird ausschließlich als Entwicklungs- und Auslieferungswerkzeug genutzt: Quellcodeverwaltung, automatisierte Build- und Deploy-Prozesse sowie die Bereitstellung der Container-Images über die GitHub Container Registry (GHCR). Zugangsdaten für die Zielserver liegen ausschließlich verschlüsselt vor.
+
+GitHub hat zu keinem Zeitpunkt Zugriff auf produktive personenbezogene Daten von Schülerinnen und Schülern, Erziehungsberechtigten oder Schulpersonal. Die Produktivdatenbank ist von GitHub aus nicht erreichbar. Betroffen sind ausschließlich Entwicklungsartefakte sowie personenbezogene Daten der moto-Entwickler (Accounts, Commit-Metadaten). Diese Kategorisierung ist für die Risikobewertung maßgeblich: GitHub ist ein Werkzeugdienstleister ohne Klardatenzugriff. Gemäß § 6 Abs. 4 des Auftragsverarbeitungsvertrags gilt GitHub damit nicht als Unterauftragsverhältnis im Sinne des Art. 28 Abs. 4 DSGVO und wird in dieser Liste nachrichtlich als Dienst ohne Zugriff auf personenbezogene Daten der betroffenen Personen geführt.
+
+Drittlandtransfer: GitHub, Inc. gehört zum Microsoft-Konzern (USA). Rechtsgrundlage des Transfers ist der Angemessenheitsbeschluss (EU) 2023/1795 (EU-US Data Privacy Framework) in Verbindung mit der DPF-Zertifizierung von GitHub. Zum Risikohinweis siehe Abschnitt 5. [PRÜFEN: DPF-Zertifizierungsstatus von GitHub unter dataprivacyframework.gov mit Prüfdatum dokumentieren.]
+
+### 4.4 SMTP-Dienstleister (E-Mail-Versand)
+
+Das System versendet Transaktions-E-Mails (Portal-Einladungen, Passwort-Zurücksetzung, MFA-Codes, Bestätigungen und Statusinformationen zur Online-Anmeldung, interne Benachrichtigungen). Übermittelt werden dabei E-Mail-Adressen, Namen in der Anrede, zeitlich befristete Token sowie in Anmeldebestätigungen ggf. der Name des angemeldeten Kindes.
+
+[PRÜFEN: Der konkrete SMTP-Anbieter ist zu benennen. Die Zugangsdaten liegen ausschließlich verschlüsselt in der Deployment-Konfiguration vor; Anbietername, Sitz, Serverstandort und AVV sind zu ermitteln und hier einzutragen. Bis zur Klärung kann keine Aussage zum Drittlandtransfer getroffen werden.]
+
+### 4.5 Sentry (Error-Tracking)
+
+Sentry dient der Fehler- und Ausnahmeprotokollierung in Backend und Frontend. Vor der Übermittlung an Sentry werden im Quellcode nachweisbar Authentifizierungs-Header und Cookies entfernt sowie IP-Adresse, E-Mail-Adresse und Benutzername aus den Ereignisdaten gelöscht. Übermittelt werden damit im Regelbetrieb technische Fehlerdaten ohne direkte Identifikatoren; ein Restrisiko personenbezogener Inhalte in Fehlermeldungstexten verbleibt.
+
+Die Konfiguration verweist auf die EU-Region von Sentry. [PRÜFEN: Die tatsächliche Region des produktiven Sentry-Projekts ist im Sentry-Konto zu verifizieren, da die Regionswahl beim Anbieter erfolgt und nicht technisch im Quellcode erzwungen ist. Ebenso ist zu bestätigen, ob Sentry produktiv überhaupt aktiviert ist; die Anbindung ist optional und nur bei gesetzter Konfiguration aktiv. Ist Sentry nicht produktiv im Einsatz, ist dieser Eintrag zu streichen.]
+
+### 4.6 PostHog (Produktanalyse)
+
+PostHog dient der Analyse der Nutzung des Web-Frontends und ist nur aktiv, wenn der zugehörige Analyse-Schlüssel in der Konfiguration gesetzt ist. Die Konfiguration verweist auf die EU-Cloud-Instanz (eu.i.posthog.com).
+
+[PRÜFEN: Der produktiv konfigurierte Host ist zu bestätigen (der Wert ist überschreibbar). Zusätzlich ist zu auditieren, welche Ereignisse und Eigenschaften konkret erfasst werden, insbesondere ob Namen oder Kennungen von Kindern in Ereignis-Eigenschaften gelangen können. Ist PostHog nicht produktiv im Einsatz, ist dieser Eintrag zu streichen.]
+
+## 5. Risikohinweis zum EU-US Data Privacy Framework
+
+Die Drittlandtransfers zu Cloudflare und GitHub stützen sich primär auf den Angemessenheitsbeschluss (EU) 2023/1795 der EU-Kommission (EU-US Data Privacy Framework, DPF). Hierzu besteht derzeit erhöhte Rechtsunsicherheit:
+
+1. Der US Supreme Court hat am 29.06.2026 in der Sache Trump v. Slaughter entschieden, dass die gesetzlich verankerte Unabhängigkeit der US Federal Trade Commission (FTC) mit der US-Verfassung nicht vereinbar ist. Die Unabhängigkeit der FTC ist eine der tragenden Annahmen des Angemessenheitsbeschlusses.
+2. Gegen den Angemessenheitsbeschluss ist beim Gerichtshof der Europäischen Union ein Rechtsmittel anhängig (Rechtssache C-703/25 P).
+
+Der Angemessenheitsbeschluss gilt formal fort, bis die EU-Kommission ihn zurücknimmt oder der EuGH ihn für nichtig erklärt. Eine Berufung auf das DPF ist daher gegenwärtig weiterhin zulässig. moto trifft folgende Vorkehrungen:
+
+- [NAME DATENSCHUTZBEAUFTRAGTER] beobachtet die Rechtsentwicklung fortlaufend und prüft den DPF-Zertifizierungsstatus der betroffenen Anbieter mindestens jährlich sowie anlassbezogen unter dataprivacyframework.gov.
+- Als Rückfallebene werden die Standardvertragsklauseln gemäß Durchführungsbeschluss (EU) 2021/914 vorgehalten. Bei Cloudflare sind diese Bestandteil des DPA. [PRÜFEN: SCC-Rückfallmechanismus im GitHub Data Protection Agreement verifizieren.]
+- Die betroffenen Dienste verarbeiten keine bzw. nur minimale personenbezogene Daten der betroffenen Kinder (GitHub: keine; Cloudflare: Verbindungsmetadaten ohne dauerhafte Inhaltsspeicherung). Die Nutzdaten verbleiben vollständig in Deutschland (Abschnitt 2).
+
+Entfällt der Angemessenheitsbeschluss, informiert moto den Verantwortlichen unverzüglich über die dann maßgebliche Transfergrundlage.
+
+## 6. Verfahren bei Änderungen (Art. 28 Abs. 2 Satz 2 DSGVO)
+
+1. moto informiert den Verantwortlichen in Textform (E-Mail an die in Anlage 4 zum Auftragsverarbeitungsvertrag benannte Kontaktstelle) über jede beabsichtigte Hinzufügung oder Ersetzung eines Subunternehmers.
+2. Die Information erfolgt mindestens 30 Kalendertage vor der geplanten Produktivsetzung. Diese Frist entspricht den Ankündigungsfristen, die die eingesetzten Vorlieferanten (Cloudflare, GitHub) ihrerseits in ihren Subprozessorenlisten anwenden, sodass moto Ankündigungen der eigenen Subunternehmer fristgerecht weiterreichen kann.
+3. Der Verantwortliche kann der Änderung innerhalb der Frist aus wichtigem datenschutzrechtlichem Grund in Textform widersprechen. Im Fall eines Widerspruchs stimmen die Parteien eine zumutbare Lösung ab; kommt eine solche nicht zustande, ist der Verantwortliche zur außerordentlichen Kündigung des Hauptvertrags berechtigt, soweit die Leistung ohne den betreffenden Subunternehmer nicht erbracht werden kann (§ 6 Abs. 2 des Auftragsverarbeitungsvertrags).
+4. Erfolgt innerhalb der Frist kein Widerspruch, gilt die Änderung als genehmigt.
+5. Diese Liste wird bei jeder Änderung mit neuer Versionsnummer und neuem Stand fortgeschrieben. Die jeweils aktuelle Fassung wird dem Verantwortlichen zur Verfügung gestellt. [PRÜFEN: Bereitstellungsweg festlegen, z. B. Kundenbereich oder Versand per E-Mail.]
+
+## 7. Anlagenverzeichnis
+
+| Anlage | Dokument | Fundstelle | Letzte Sichtung |
+|---|---|---|---|
+| A | Hetzner Auftragsverarbeitungsvereinbarung | https://www.hetzner.com/AV/DPA_de.pdf | [DATUM DER SICHTUNG] |
+| B | Cloudflare Data Processing Addendum, Version 6.4 (April 2026) | https://www.cloudflare.com/cloudflare-customer-dpa/ | [DATUM DER SICHTUNG] |
+| C | GitHub Data Protection Agreement (Fassung Oktober 2025) | https://github.com/customer-terms/github-data-protection-agreement | [DATUM DER SICHTUNG] |
+| D | AVV/DPA des SMTP-Anbieters | [PRÜFEN: nach Klärung des Anbieters ergänzen] | [DATUM DER SICHTUNG] |
+| E | Sentry Data Processing Addendum | https://sentry.io/legal/dpa/ [PRÜFEN: Link verifizieren] | [DATUM DER SICHTUNG] |
+| F | PostHog Data Processing Agreement | https://posthog.com/dpa [PRÜFEN: Link verifizieren] | [DATUM DER SICHTUNG] |
+
+---
+
+*Erstellt durch: [NAME DATENSCHUTZKOORDINATOR], moto, [RECHTSFORM UND ADRESSE]*
+*Freigabe durch: [NAME GESCHÄFTSFÜHRUNG] (ausstehend, Status: Entwurf zur internen Prüfung)*

--- a/docs/moto-dsgvo-dokumente/04-verzeichnis-verarbeitungstaetigkeiten.md
+++ b/docs/moto-dsgvo-dokumente/04-verzeichnis-verarbeitungstaetigkeiten.md
@@ -1,0 +1,240 @@
+# Verzeichnis von Verarbeitungstätigkeiten nach Art. 30 Abs. 2 DSGVO
+
+**Dokument 04 der Datenschutzdokumentation**
+
+| | |
+|---|---|
+| Dokument | Verzeichnis von Verarbeitungstätigkeiten (Auftragsverarbeiter) |
+| Rechtsgrundlage der Dokumentationspflicht | Art. 30 Abs. 2 DSGVO |
+| Version | 1.0 |
+| Stand | 2026-07-07 |
+| Status | Entwurf zur internen Prüfung |
+| Verantwortlich für die Pflege | [NAME DATENSCHUTZKOORDINATOR/IN], Datenschutzkoordination moto |
+| Zugehörige Dokumente | Dokument 02 (Technische und organisatorische Maßnahmen), Dokument 05 (Löschkonzept und Aufbewahrungsfristen), Anlage A (Verzeichnis der Verantwortlichen), Anlage B (Subunternehmerliste, Dokument 03) |
+
+---
+
+## 1. Zweck und Anwendungsbereich
+
+Dieses Verzeichnis dokumentiert die Verarbeitungstätigkeiten, die die [FIRMENNAME UND RECHTSFORM] (nachfolgend "moto") als Auftragsverarbeiter im Sinne des Art. 4 Nr. 8 DSGVO im Auftrag von Schulen und Schulträgern durchführt. Es erfüllt die Pflicht aus Art. 30 Abs. 2 DSGVO und ist der Aufsichtsbehörde (Landesbeauftragte für Datenschutz und Informationsfreiheit Nordrhein-Westfalen, LDI NRW) auf Anfrage vorzulegen (Art. 30 Abs. 4 DSGVO).
+
+Gegenstand der Auftragsverarbeitung ist der Betrieb der Software "moto" (interner Projektname "Project Phoenix"), eines NFC/RFID-gestützten Anwesenheits- und Raumverwaltungssystems für den Offenen Ganztag (OGS) an Grundschulen in Nordrhein-Westfalen. Die Software wird als mandantenfähiger Dienst betrieben; jede Schule bildet einen technisch getrennten Mandanten.
+
+Die Ausnahme des Art. 30 Abs. 5 DSGVO greift nicht: Die Verarbeitung erfolgt nicht nur gelegentlich, sondern ist Kernzweck des Dienstes, betrifft überwiegend Daten von Kindern und schließt Gesundheitsangaben (Krankmeldungen, Gesundheitsinformationen im Kinderprofil) ein. Das Verzeichnis ist daher unabhängig von der Mitarbeiterzahl zu führen.
+
+Hinweis zur Abgrenzung: Dieses Verzeichnis ist das Verzeichnis des Auftragsverarbeiters nach Art. 30 Abs. 2 DSGVO. Rechtsgrundlagen der Verarbeitung, Zwecke im Einzelnen und Löschfristen sind Pflichtangaben des Verzeichnisses des jeweiligen Verantwortlichen nach Art. 30 Abs. 1 DSGVO (der Schule beziehungsweise des Schulträgers). Soweit solche Angaben hier ergänzend aufgenommen sind, dienen sie der Transparenz und der Unterstützung der Verantwortlichen.
+
+## 2. Angaben zum Auftragsverarbeiter (Art. 30 Abs. 2 lit. a DSGVO)
+
+| Angabe | Wert |
+|---|---|
+| Name/Firma | [FIRMENNAME UND RECHTSFORM] ("moto") |
+| Anschrift | [ADRESSE] |
+| Vertretungsberechtigte Person(en) | [NAME GESCHÄFTSFÜHRUNG/VORSTAND] |
+| Telefon | [TELEFONNUMMER] |
+| E-Mail | [E-MAIL-ADRESSE FÜR DATENSCHUTZANFRAGEN] |
+| Internet | [WEBSITE] |
+| Teil einer Firmengruppe | Nein [PRÜFEN: bei Gründung einer Holding oder Beteiligungsstruktur anpassen] |
+| Vertreter nach Art. 27 DSGVO | Entfällt (Sitz in der Europäischen Union) |
+| Datenschutzbeauftragte/r (Art. 37 DSGVO) | [NAME DATENSCHUTZBEAUFTRAGTER], [KONTAKTDATEN DSB] [PRÜFEN: Benennungspflicht nach Art. 37 Abs. 1 lit. b DSGVO und § 38 BDSG abschließend bewerten; angesichts der umfangreichen Verarbeitung von Kinderdaten wird die Benennung empfohlen] |
+
+## 3. Verantwortliche, in deren Auftrag verarbeitet wird (Art. 30 Abs. 2 lit. a DSGVO)
+
+Verantwortliche im Sinne des Art. 4 Nr. 7 DSGVO sind die jeweiligen Schulen beziehungsweise Schulträger, mit denen ein Auftragsverarbeitungsvertrag nach Art. 28 Abs. 3 DSGVO besteht. Die datenschutzrechtliche Verantwortlichkeit der Schulen für die Verarbeitung von Schülerdaten ergibt sich aus §§ 120 bis 122 SchulG NRW in Verbindung mit der VO-DV I; die Rechtsgrundlage des Kernbetriebs auf Seiten der Verantwortlichen ist regelmäßig Art. 6 Abs. 1 lit. e DSGVO (Wahrnehmung einer im öffentlichen Interesse liegenden Aufgabe), bei Gesundheitsangaben in Verbindung mit Art. 9 Abs. 2 DSGVO [PRÜFEN: einschlägiger Erlaubnistatbestand des Art. 9 Abs. 2 je Verarbeitung, insbesondere lit. a (Einwilligung) für das Feld Gesundheitsinformationen; Bewertung obliegt dem Verantwortlichen, Abstimmung im AV-Vertrag empfohlen].
+
+Da die Zahl der Verantwortlichen laufend wächst, werden die Verantwortlichen in diesem Verzeichnis generisch beschrieben. Die vollständige, aktuelle Liste aller Verantwortlichen mit Name, Anschrift und Kontaktdaten wird als **Anlage A (Verzeichnis der Verantwortlichen)** geführt und bei jedem Vertragsschluss beziehungsweise jeder Vertragsbeendigung aktualisiert. Anlage A ist Bestandteil dieses Verzeichnisses.
+
+| Angabe | Wert |
+|---|---|
+| Kategorie der Verantwortlichen | Öffentliche Schulen (Grundschulen mit Offenem Ganztag) und deren Schulträger (Kommunen) sowie Träger der OGS-Betreuung in Nordrhein-Westfalen |
+| Kontaktdaten | Je Vertrag, siehe Anlage A |
+| Datenschutzbeauftragte der Verantwortlichen | Je Vertrag, siehe Anlage A (in der Regel behördliche Datenschutzbeauftragte der Schulen/Kommunen) |
+| Vertragsgrundlage | Auftragsverarbeitungsvertrag nach Art. 28 Abs. 3 DSGVO, Musterversion [VERSION/DATUM AV-VERTRAGSMUSTER] |
+| Gemeinsame Auftragsverarbeiter | Keine. Subunternehmer (weitere Auftragsverarbeiter nach Art. 28 Abs. 2 und 4 DSGVO) siehe Abschnitt 6 und Anlage B |
+
+Die Verarbeitung erfolgt für alle Verantwortlichen in identischer Weise auf derselben mandantengetrennten Plattform. Die nachfolgenden Kategorien von Verarbeitungen (Abschnitt 4) gelten daher einheitlich für jeden Verantwortlichen; abweichende, je Schule konfigurierbare Parameter (etwa Aufbewahrungsfristen, Sichtbarkeitsregeln, optionale Funktionen wie Captcha-Schutz oder Anwesenheitsprotokoll) sind als solche gekennzeichnet und werden vom jeweiligen Verantwortlichen über die Mandanteneinstellungen gesteuert.
+
+## 4. Kategorien der im Auftrag durchgeführten Verarbeitungen (Art. 30 Abs. 2 lit. b DSGVO)
+
+Alle nachfolgend genannten Datenbanktabellen sind schema-qualifiziert benannt und entstammen der Datenbestandsaufnahme (gesondertes internes Dokument). Die Verarbeitung umfasst jeweils das Hosting, die Speicherung, die Anzeige für berechtigte Nutzer des Verantwortlichen, die Protokollierung und die fristgebundene Löschung.
+
+### 4.1 Anwesenheitserfassung (NFC/RFID-gestützt)
+
+**Beschreibung:** Erfassung von Kommen und Gehen der betreuten Kinder über NFC/RFID-Lesegeräte (Raspberry-Pi-Kioskgeräte mit der Anwendung PyrePortal) sowie manuell durch das Betreuungspersonal. Einschließlich Verwaltung von Tagesstatusmeldungen (krank, entschuldigt, Klassenfahrt) und Abholregelungen.
+
+**Betroffene Personen:** Schülerinnen und Schüler; mittelbar Betreuungspersonal (erfassende Person); nicht identifizierte Dritte bei Scans nicht zugeordneter RFID-Tags.
+
+**Datenkategorien:**
+
+- Stammdaten des Kindes: Vor- und Nachname, Geburtsdatum (`users.persons`), Schulklasse, Status, Gruppenzugehörigkeit (`users.students`)
+- RFID-Kartennummer (Tag-UID, hex-normalisiert) als pseudonymer Identifikator (`users.persons.tag_id`, `users.rfid_cards`)
+- An- und Abmeldezeiten je Tag, erfassendes Gerät, erfassende Person, Schulhof-Status (`active.attendance`)
+- Tagesstatusmeldungen krank/entschuldigt/Klassenfahrt einschließlich Meldequelle und optionalem Freitext (`active.student_status_days`); der Status "krank" ist ein Gesundheitsdatum nach Art. 9 DSGVO
+- Statisch hinterlegte Gesundheitsinformationen im Kinderprofil als Freitext (`users.students.health_info`); Gesundheitsdatum nach Art. 9 DSGVO
+- Abholregelungen je Wochentag, zugelassene Abholmodi, Begleitpersonen-Freitext (`users.students.departure_days`, `.allowed_departure_modes`, `.pickup_days`, `.bus_days`, `.departure_companion_note`)
+- Betreuer-Notizen und Zusatzinformationen (`users.students.supervisor_notes`, `.extra_info`)
+- Einwilligungs- und Aufbewahrungsangaben je Kind (`users.privacy_consents`)
+- Scans nicht registrierter RFID-Tags: Tag-UID, Gerät, Zeitpunkt, Auflösungsvermerk (`audit.unregistered_tag_scans`)
+
+**Konfigurierbare Parameter des Verantwortlichen:** Aufbewahrung der Besuchs- und Anwesenheitsdaten (Standard 30 Tage, individuell je Kind über die Einwilligung steuerbar, jeweils maximal 31 Tage), Freischaltung und Sichtbarkeitsfenster des Anwesenheitsprotokolls (standardmäßig deaktiviert), Sichtbarkeitskreis der Kinderdaten.
+
+### 4.2 Raum- und Gruppenverwaltung
+
+**Beschreibung:** Verwaltung von Räumen, Gruppen und Aktivitäten sowie Live-Abbildung des aktuellen Aufenthaltsorts der Kinder (Raumwechsel, Schulhof, WC, Heimweg) zur Erfüllung der Aufsichtspflicht.
+
+**Betroffene Personen:** Schülerinnen und Schüler; Betreuungspersonal (Gruppenzuordnung, Vertretungen).
+
+**Datenkategorien:**
+
+- Aktueller Aufenthaltsort und Raumverlauf: Eintritts- und Austrittszeit je Raum/Gruppe (`active.visits`)
+- Organisatorische Gruppenzugehörigkeit des Kindes (`users.students.group_id`)
+- Gruppenbetreuung und Vertretungen des Personals (`active.group_supervisor`, `education.group_teacher`, `education.group_substitution`)
+
+**Konfigurierbare Parameter des Verantwortlichen:** Sichtbarkeitsfenster für Raumdetails (Standard 7 Tage), Betriebsmodus der Anwesenheitsdarstellung (detailliert oder binär, durch den Plattformbetreiber je Schule konfiguriert).
+
+### 4.3 Elternportal
+
+**Beschreibung:** Separates Portal für Erziehungsberechtigte mit eigener, strikt getrennter Anmeldung. Funktionen: Einsicht in Daten des eigenen Kindes nach dem je Kind-Beziehung hinterlegten Berechtigungsumfang, Krankmeldungen, Nachrichten an die Betreuung, Datenänderungsanfragen.
+
+**Betroffene Personen:** Erziehungsberechtigte und weitere Bezugspersonen (Abholberechtigte, Notfallkontakte); mittelbar Schülerinnen und Schüler.
+
+**Datenkategorien:**
+
+- Profil der Erziehungsberechtigten: Name, E-Mail, Anschrift, typisierte Telefonnummern, Kontakt- und Sprachpräferenzen, interne Notizen des Personals (`users.guardian_profiles`, `users.guardian_phone_numbers`)
+- Beziehung zum Kind, Rolle, Abholberechtigung, Notfallkontakt-Kennzeichnung, Berechtigungen im Elternportal je Kind (`users.students_guardians` einschließlich `permissions`)
+- Portal-Konto: E-Mail, Passwort-Hash, MFA-Zustand, Passkeys, letzter Login (`auth.accounts`, `auth.mfa_*`, `auth.passkey_*`)
+- Nachrichten zwischen Erziehungsberechtigten und Betreuung (`users.parent_messages`)
+- Krankmeldungen durch Eltern (`active.student_status_days` mit Quelle "parent"); Gesundheitsdatum nach Art. 9 DSGVO
+- Datenänderungsanfragen zu Kinderdaten (`users.student_data_change_requests`)
+- Einladungen zum Portal mit befristeten Token (`auth.guardian_invitations`, Gültigkeit standardmäßig 48 Stunden, maximal eine Woche)
+- Änderungsprotokoll zu Kontakt- und Abholdaten (`audit.guardian_changes`, append-only)
+
+### 4.4 Anmeldung / Enrollment
+
+**Beschreibung:** Öffentliches, je Schule konfigurierbares Anmeldeformular für die OGS-Betreuung. Erhebung der Anmeldedaten vor Anlage des Kindes im System, Bearbeitung und Entscheidung durch die Schule, bei Genehmigung Übernahme in den Kinderdatenbestand.
+
+**Betroffene Personen:** Erziehungsberechtigte (Antragsteller und weitere Erziehungsberechtigte); anzumeldende Kinder.
+
+**Datenkategorien:**
+
+- Kontaktdaten der antragstellenden Person: Name, E-Mail, Telefon, Einwilligungsvermerke (`enrollment.requests`)
+- Weitere Erziehungsberechtigte: Name, E-Mail, Telefon (`enrollment.request_guardians`)
+- Kinddaten: Name, Geburtsdatum, Zielklassenstufe, Status, Freitextantworten aus schulindividuellen Formularfeldern (`enrollment.request_children.custom_data`); je nach Formularkonfiguration des Verantwortlichen können hier Gesundheitsangaben (etwa Allergien) erhoben werden, die bei Genehmigung in das Kinderprofil übernommen werden; insoweit Gesundheitsdaten nach Art. 9 DSGVO
+- Befristete Status- und Bearbeitungslinks (Token, Gültigkeit standardmäßig 365 Tage)
+- Bot-Schutz (optional, standardmäßig deaktiviert): bei Aktivierung durch den Verantwortlichen Verifikation über Cloudflare Turnstile einschließlich IP-Adresse der antragstellenden Person (siehe Abschnitt 5)
+- Korrekturprotokoll bei Anpassungen durch die Verwaltung (`audit.enrollment_offering_adjustment`)
+
+**Konfigurierbare Parameter des Verantwortlichen:** Formularfelder (Freitextfelder werden vom Verantwortlichen definiert), Captcha-Pflicht, Aufbewahrung abgelehnter Anmeldungen (Standard 90 Tage, maximal 730 Tage).
+
+### 4.5 Feedback
+
+**Beschreibung:** Erfassung einfacher Rückmeldungen der Kinder (etwa Mensa-Bewertungen) über die Kioskgeräte oder die Anwendung.
+
+**Betroffene Personen:** Schülerinnen und Schüler.
+
+**Datenkategorien:**
+
+- Feedback-Wert, Tag, Uhrzeit, Mensa-Kennzeichen, jeweils mit Kind-Bezug (`feedback.entries`)
+
+**Konfigurierbare Parameter des Verantwortlichen:** Aufbewahrungsdauer (Standard 90 Tage, maximal 365 Tage), automatische Löschung durch den Bereinigungsdienst.
+
+### 4.6 Geräteverwaltung (Kiosk-/IoT-Geräte)
+
+**Beschreibung:** Verwaltung der an den Schulen eingesetzten NFC-Lesegeräte (Raspberry-Pi-Kioskgeräte), einschließlich Authentifizierung der Geräte gegenüber der Plattform und Freigabe von Aktionen durch das Personal per PIN.
+
+**Betroffene Personen:** Betreuungspersonal (PIN-Nutzung); mittelbar alle Personen, deren RFID-Tags gescannt werden.
+
+**Datenkategorien:**
+
+- Gerätekennungen, Geräte-API-Schlüssel, Gerätestatus und Online-Zeitfenster (Schema `iot`)
+- Personal-PIN ausschließlich als Argon2id-Hash (`auth.accounts.pin_hash`)
+- Zuordnung von Scans zu Gerät und Zeitpunkt (`active.attendance.device_id`, `audit.unregistered_tag_scans.device_id`)
+
+**Konfigurierbare Parameter des Verantwortlichen:** Geräte-PIN (nur für Administratoren der Schule sichtbar), Online-Zeitfenster.
+
+### 4.7 Unterstützende Verarbeitungen (Querschnitt)
+
+Die folgenden Verarbeitungen erfolgen zur Bereitstellung und zum sicheren Betrieb der vorgenannten Kategorien:
+
+**a) Konten- und Zugriffsverwaltung:** Verwaltung der Benutzerkonten des Personals und der Erziehungsberechtigten (E-Mail, Benutzername, Passwort- und PIN-Hashes, Rollen und Berechtigungen, MFA-Merkmale einschließlich vertrauenswürdiger Geräte, Passkeys, Sitzungs- und Reset-Token; Schemata `auth`, teilweise `platform` für Betreiberkonten). Passwörter und PINs werden ausschließlich als Argon2id-Hash gespeichert.
+
+**b) Zeiterfassung und Abwesenheiten des Personals:** Kommen/Gehen, Pausen, Homeoffice-Kennzeichen, Korrekturen mit Änderungsprotokoll, Abwesenheiten einschließlich Krankheit (Gesundheitsdatum nach Art. 9 DSGVO), Urlaubskontingente (`active.work_sessions`, `active.work_session_breaks`, `active.staff_absences`, `active.staff_vacation_quota`, `audit.work_session_edits`). Aufbewahrung konfigurierbar zwischen 2 und 8 Jahren (Standard 2 Jahre), orientiert an § 16 Abs. 2 ArbZG, § 41 EStG, § 147 AO / § 257 HGB.
+
+**c) Protokollierung und Nachvollziehbarkeit:** Authentifizierungsereignisse einschließlich IP-Adresse und User-Agent (`audit.auth_events`), Protokoll lesender Zugriffe auf sensible Kinderdaten (`audit.data_access_log`), Lösch-, Import- und Änderungsprotokolle (`audit.data_deletions`, `audit.data_imports`, `audit.guardian_changes`), Einstellungs-Änderungsprotokoll (`config.setting_audit`, Passwortwerte geschwärzt). [PRÜFEN: Für mehrere Audit-Tabellen (`audit.auth_events`, `audit.data_access_log`, `audit.data_deletions`, `audit.data_imports`, `audit.guardian_changes`, `audit.enrollment_offering_adjustment`), die Eltern-Nachrichten (`users.parent_messages`) und die Scans nicht registrierter Tags (`audit.unregistered_tag_scans`) besteht derzeit keine automatisierte Löschfrist; `audit.work_session_edits` wird dagegen vom Löschlauf der Zeiterfassung miterfasst (Dokument 05, Abschnitt 6.6). Eine Aufbewahrungsregel ist festzulegen und technisch umzusetzen (Grundsatz der Speicherbegrenzung, Art. 5 Abs. 1 lit. e DSGVO).]
+
+**d) Automatisierte Datenlöschung:** Täglicher Bereinigungsdienst (Standard 02:00 Uhr, je Schule konfigurierbar), der Besuchs- und Anwesenheitsdaten, Feedback, abgelehnte Anmeldungen, abgeschlossene Betreuungsplan-Termine, Zeiterfassungsdaten und abgelaufene Token fristgerecht löscht. Löschvorgänge zu Kinder- und Personaldaten werden in `audit.data_deletions` nachgewiesen.
+
+**e) Betrieb, Fehleranalyse und Monitoring:** Selbst gehostetes Log- und Metrik-Monitoring (Grafana, Loki, Alloy, Prometheus auf eigener Infrastruktur), optionales Fehler-Tracking (Sentry) und optionale Produktnutzungsanalyse (PostHog), jeweils mit Datenminimierung (keine Klarnamen von Kindern in Logeinträgen auf Informationsebene, Entfernung von Authentifizierungs-Headern, E-Mail-Adressen und IP-Adressen vor Versand an das Fehler-Tracking, IP-Maskierung in Zugriffslogs).
+
+## 5. Übermittlungen in Drittländer oder an internationale Organisationen (Art. 30 Abs. 2 lit. c DSGVO)
+
+Die Kerndatenverarbeitung (Anwendung, Datenbank, Datei-Uploads, Backups, Monitoring) erfolgt vollständig auf Servern der Hetzner Online GmbH am Standort Nürnberg, Deutschland. Eine Übermittlung der in Abschnitt 4 genannten Bestandsdaten in ein Drittland findet im Regelbetrieb nicht statt.
+
+Für einzelne Hilfsdienste bestehen Drittlandbezüge oder offene Prüfpunkte:
+
+| Dienst | Anbieter, Sitz | Verarbeitete Daten | Drittlandtransfer und Garantien |
+|---|---|---|---|
+| DNS/CDN und TLS-Vorschaltung | Cloudflare Inc., USA | Verbindungs-Metadaten aller Portalnutzer (IP-Adressen, aufgerufene Hostnamen) | Ja, möglich (US-Anbieter). [PRÜFEN: Vertragsgrundlage (Cloudflare-DPA mit EU-Standardvertragsklauseln beziehungsweise Zertifizierung nach dem EU-US Data Privacy Framework) dokumentieren; Nutzung der EU-Datenlokalisierungsoptionen prüfen] |
+| Cloudflare Turnstile (Bot-Schutz Anmeldeformular, optional, standardmäßig deaktiviert) | Cloudflare Inc., USA | IP-Adresse und Browsersignale der antragstellenden Erziehungsberechtigten, serverseitig zusätzlich Verifikationsanfrage mit IP | Ja, möglich. Nur aktiv, wenn der Verantwortliche die Captcha-Pflicht einschaltet. [PRÜFEN: identisch zu Cloudflare-DPA oben; Verantwortliche bei Aktivierung auf den Drittlandbezug hinweisen (Datenschutzhinweise des Anmeldeformulars)] |
+| Sentry (Fehler-Tracking, optional) | Functional Software Inc. (Sentry), USA; EU-Region vorgesehen | Stacktraces und Request-Metadaten; Authentifizierungs-Header, E-Mail-Adressen, Benutzernamen und IP-Adressen werden vor Versand entfernt | Bei Nutzung der EU-Datenresidenz kein Regeltransfer. [PRÜFEN: tatsächliche Projekt-Region im Sentry-Konto verifizieren und DPA ablegen] |
+| PostHog (Produktnutzungsanalyse, optional) | PostHog Inc.; konfiguriert auf EU-Cloud (eu.i.posthog.com) | Nutzungsereignisse angemeldeter Nutzer | Bei EU-Cloud kein Regeltransfer. [PRÜFEN: produktiv konfigurierten Host bestätigen; erfasste Ereignis-Eigenschaften auf Personenbezug von Kindern prüfen] |
+| E-Mail-Versand (SMTP) | [SMTP-ANBIETER] [PRÜFEN: Anbieter und Serverstandort aus der Produktivkonfiguration ermitteln] | E-Mail-Adressen, Anrede-Namen, Einladungs- und Reset-Links, in Anmeldebenachrichtigungen auch Kindername | [PRÜFEN: Drittlandbewertung erst nach Identifikation des Anbieters möglich] |
+| GitHub / GitHub Container Registry | GitHub Inc. (Microsoft), USA | Keine personenbezogenen Daten der Endnutzer; Quellcode, Container-Images, Deployment-Secrets (verschlüsselt) | Ja (USA), betrifft jedoch keine Auftragsdaten der Verantwortlichen. [PRÜFEN: DPF-Zertifizierung von Microsoft/GitHub als Garantie dokumentieren] |
+
+Übermittlungen auf Grundlage von Art. 49 Abs. 1 UAbs. 2 DSGVO finden nicht statt.
+
+## 6. Weitere Auftragsverarbeiter (Subunternehmer)
+
+Die eingesetzten Subunternehmer nach Art. 28 Abs. 2 und 4 DSGVO werden in **Anlage B (Subunternehmerliste)** mit Name, Anschrift, Leistung und Vertragsgrundlage geführt und den Verantwortlichen gemäß AV-Vertrag mitgeteilt. Zusammenfassung:
+
+| Subunternehmer | Leistung | Standort der Verarbeitung |
+|---|---|---|
+| Hetzner Online GmbH | Server-Infrastruktur (Anwendung, Datenbank, Backups, Monitoring) | Nürnberg, Deutschland [PRÜFEN: AVV mit Hetzner ablegen und in Anlage B referenzieren] |
+| Cloudflare Inc. | DNS, CDN, optional Bot-Schutz | Weltweit verteilte Infrastruktur, siehe Abschnitt 5 |
+| [SMTP-ANBIETER] | Transaktionaler E-Mail-Versand | [PRÜFEN] |
+| Functional Software Inc. (Sentry) | Fehler-Tracking (optional) | EU-Region [PRÜFEN] |
+| PostHog Inc. | Nutzungsanalyse (optional) | EU-Cloud [PRÜFEN] |
+| GitHub Inc. | Code-Hosting, CI/CD, Container-Registry (keine Auftragsdaten) | USA |
+
+Selbst gehostete Komponenten (Grafana, Loki, Alloy, Prometheus, Caddy) sind keine Subunternehmer; sie laufen auf der Hetzner-Infrastruktur unter Kontrolle von moto.
+
+## 7. Allgemeine Beschreibung der technischen und organisatorischen Maßnahmen (Art. 30 Abs. 2 lit. d DSGVO)
+
+Die vollständige Beschreibung der technischen und organisatorischen Maßnahmen nach Art. 32 Abs. 1 DSGVO enthält **Dokument 02 (Technische und organisatorische Maßnahmen)** in der jeweils gültigen Fassung. Zusammenfassung der wesentlichen Maßnahmen:
+
+**Mandantentrennung:** Jede Schule bildet einen eigenen Mandanten. Die Trennung wird auf Datenbankebene durch PostgreSQL Row Level Security mit erzwungenen Isolationsrichtlinien auf allen mandantenbezogenen Tabellen durchgesetzt, ergänzt durch eine Least-Privilege-Rollentrennung der Datenbankzugänge und eine Transaktions-Middleware, die jede Anfrage an den Mandantenkontext bindet.
+
+**Zugangs- und Zugriffskontrolle:** Passwort- und PIN-Speicherung ausschließlich als Argon2id-Hash; JWT-basierte Sitzungen mit kurzer Gültigkeit; Mehr-Faktor-Authentifizierung einschließlich Passkeys; konfigurierbare Kontosperrung bei Fehlversuchen; rollen- und berechtigungsbasiertes Zugriffsmodell; für das Elternportal zusätzlich beziehungsbezogene Berechtigungen je Kind; drei strikt getrennte Portale (Schule, Betreiber, Eltern) mit getrennten Sitzungen und Cookies; Kioskgeräte authentifizieren sich mit Geräte-API-Schlüssel und Personal-PIN.
+
+**Transport- und Datenverschlüsselung:** TLS-Terminierung am Reverse Proxy; Datenbankverbindungen mit Zertifikatsprüfung; verschlüsselte Verwaltung sämtlicher Zugangsdaten und Konfigurationsgeheimnisse (SOPS/age).
+
+**Eingabekontrolle und Nachvollziehbarkeit:** Append-only-Protokolle für Zugriffe auf sensible Kinderdaten, Authentifizierungsereignisse, Datenänderungen, Importe und Löschungen; strukturiertes Logging ohne Klarnamen von Kindern; Maskierung von IP-Adressen und Entfernung von Zugangsdaten in Zugriffslogs.
+
+**Verfügbarkeit:** Automatisierte Datenbanksicherung vor jeder Migration mit definiertem Rollback-Verfahren; regelmäßige Backups mit Aufbewahrungsrotation; aktive Verfügbarkeitsüberwachung.
+
+**Datenminimierung und Speicherbegrenzung:** Kurze, je Schule konfigurierbare Aufbewahrungsfristen für Bewegungsdaten (Standard 30 Tage); standardmäßig deaktiviertes Anwesenheitsprotokoll; abgestufte Sichtbarkeit der Kinderdaten nach Rolle; täglicher automatisierter Löschlauf mit Löschnachweis.
+
+## 8. Ergänzende Angaben (freiwillig)
+
+Ohne Pflichtcharakter nach Art. 30 Abs. 2 DSGVO wird ergänzend dokumentiert:
+
+- **Löschkonzept:** Die je Schule konfigurierbaren Aufbewahrungsfristen und der automatisierte Bereinigungsdienst sind in Dokument 05 (Löschkonzept und Aufbewahrungsfristen) im Einzelnen aufgeführt. Offene Punkte zu Audit-Tabellen ohne Löschfrist siehe Abschnitt 4.7 lit. c.
+- **Besondere Kategorien (Art. 9 DSGVO):** Gesundheitsangaben werden in vier Zusammenhängen verarbeitet: statische Gesundheitsinformationen im Kinderprofil, Krankmeldungen der Kinder (strukturiert), Krankmeldungen des Personals, Gesundheitsangaben im Anmeldeformular (je nach Formularkonfiguration des Verantwortlichen). Biometrische Daten werden nicht verarbeitet; die RFID-Tag-UID ist ein technischer Identifikator und kein biometrisches Merkmal.
+- **Weisungsrahmen:** moto verarbeitet ausschließlich auf dokumentierte Weisung der Verantwortlichen im Rahmen des AV-Vertrags. Die Verantwortlichen steuern über die Mandanteneinstellungen wesentliche Verarbeitungsparameter selbst (Aufbewahrungsfristen, Sichtbarkeitsregeln, optionale Funktionen).
+- **VO-DV I:** Die im System vorgesehenen Datenkategorien orientieren sich am Rahmen der nach VO-DV I zulässigen Schülerdaten. Die Prüfung der Zulässigkeit je Datenfeld obliegt dem Verantwortlichen; frei konfigurierbare Formular- und Freitextfelder sind vom Verantwortlichen VO-DV-I-konform zu belegen. [PRÜFEN: Abgleich der Standard-Datenfelder mit den Anlagen der VO-DV I als eigener Prüfschritt, Ergebnis den Verantwortlichen als Arbeitshilfe bereitstellen]
+
+## 9. Pflege und Änderungshistorie
+
+Dieses Verzeichnis wird bei jeder Änderung der Verarbeitungstätigkeiten, beim Einsatz oder Wechsel von Subunternehmern sowie mindestens jährlich überprüft und aktualisiert. Anlage A wird laufend gepflegt.
+
+| Version | Datum | Änderung | Bearbeiter/in |
+|---|---|---|---|
+| 1.0 | 2026-07-07 | Ersterstellung, Entwurf zur internen Prüfung | [NAME DATENSCHUTZKOORDINATOR/IN] |
+
+---
+
+[ORT], den [DATUM]
+
+________________________________
+[NAME GESCHÄFTSFÜHRUNG/VORSTAND]
+[FIRMENNAME UND RECHTSFORM]

--- a/docs/moto-dsgvo-dokumente/05-loeschkonzept.md
+++ b/docs/moto-dsgvo-dokumente/05-loeschkonzept.md
@@ -1,0 +1,297 @@
+# Löschkonzept und Aufbewahrungsfristen
+
+| | |
+|---|---|
+| **Dokument** | 05 Löschkonzept und Aufbewahrungsfristen für das Verfahren "moto" (interne Bezeichnung: Project Phoenix) |
+| **Version** | 1.0 |
+| **Stand** | 2026-07-07 |
+| **Status** | Entwurf zur internen Prüfung |
+| **Herausgeber** | moto, [RECHTSFORM UND ADRESSE] |
+| **Erstellt durch** | Datenschutzkoordination moto |
+| **Fachlich geprüft durch** | [NAME DATENSCHUTZBEAUFTRAGTER] (ausstehend) |
+| **Freigabe durch** | [NAME GESCHÄFTSFÜHRUNG] (ausstehend) |
+| **Nächste Überprüfung** | spätestens 2027-07-07, zusätzlich anlassbezogen |
+
+---
+
+## 1. Zweck und Geltungsbereich
+
+Dieses Löschkonzept beschreibt, nach welchen Regeln personenbezogene Daten im System moto gelöscht werden, wie diese Regeln technisch umgesetzt sind und wie die Löschung nachgewiesen wird. Es konkretisiert den Grundsatz der Speicherbegrenzung (Art. 5 Abs. 1 lit. e DSGVO) und die Löschpflichten aus Art. 17 DSGVO für das Verfahren moto, ein NFC/RFID-gestütztes Anwesenheits- und Raumverwaltungssystem für den Offenen Ganztag (OGS) an Grundschulen in Nordrhein-Westfalen.
+
+Das Konzept gilt für alle personenbezogenen Daten, die moto im Auftrag der jeweiligen Schule bzw. des Schulträgers verarbeitet, einschließlich der Bewegungs-, Protokoll- und Sicherungsdaten. Es ist Bestandteil der Dokumentation der technischen und organisatorischen Maßnahmen nach Art. 32 DSGVO und ergänzt die Anlagen 1 und 2 des Auftragsverarbeitungsvertrags (Art. 28 DSGVO, Dokument 01).
+
+Die Gliederung orientiert sich an der DIN 66398 (Leitlinie zur Entwicklung eines Löschkonzepts): Datenarten-Inventar, Löschklassen, Löschregeln je Datenart, technische Umsetzung, Sonderfälle, Verantwortlichkeiten.
+
+## 2. Rollenverteilung und Löschentscheidung
+
+Die Schule bzw. der Schulträger ist Verantwortlicher im Sinne von Art. 4 Nr. 7 DSGVO. moto ist Auftragsverarbeiter nach Art. 28 DSGVO.
+
+Daraus folgt für die Löschung:
+
+1. **moto trifft keine eigene Löschentscheidung.** moto löscht personenbezogene Daten ausschließlich nach den in diesem Konzept dokumentierten, mit dem Verantwortlichen abgestimmten Fristen oder auf ausdrückliche Weisung des Verantwortlichen.
+2. **Die Regellöschfristen für Schülerdaten sind nicht frei verhandelbar.** Der Kernbetrieb stützt sich auf Art. 6 Abs. 1 lit. e DSGVO in Verbindung mit §§ 120 bis 122 SchulG NRW. Die zulässigen Datenarten und Aufbewahrungsfristen ergeben sich aus der VO-DV I. moto darf diese Fristen weder eigenmächtig verkürzen noch verlängern.
+3. **Archivrecht geht der Löschung vor.** Nach dem Archivgesetz NRW sind archivwürdige Unterlagen vor der Vernichtung dem zuständigen Archiv anzubieten. Diese Anbietungspflicht trifft die Schule bzw. den Schulträger, nicht moto. Die in diesem Konzept beschriebenen automatischen Löschläufe betreffen ausschließlich Datenarten, für die der Verantwortliche die Löschparameter selbst konfiguriert bzw. bestätigt hat. Löschungen von Stammdatenbeständen erfolgen nur auf Weisung, damit der Verantwortliche seine Anbietungspflicht erfüllen kann.
+4. **Betroffenenrechte laufen über den Verantwortlichen.** Löschverlangen von Eltern oder Beschäftigten der Schule werden an die Schule weitergeleitet; moto unterstützt die Umsetzung im Rahmen des Auftragsverarbeitungsvertrags.
+
+## 3. Rechtsgrundlagen
+
+| Norm | Bedeutung für dieses Konzept |
+|---|---|
+| Art. 5 Abs. 1 lit. e DSGVO | Speicherbegrenzung als Leitprinzip aller Löschregeln |
+| Art. 5 Abs. 2 DSGVO | Rechenschaftspflicht: Löschungen müssen nachweisbar sein (Löschprotokoll) |
+| Art. 17 DSGVO | Löschpflicht bei Zweckfortfall und auf Betroffenenverlangen |
+| Art. 28 Abs. 3 lit. g DSGVO | Löschung oder Rückgabe aller Daten nach Vertragsende, Wahlrecht des Verantwortlichen |
+| Art. 32 DSGVO | Löschkonzept als Teil der technischen und organisatorischen Maßnahmen |
+| §§ 120 bis 122 SchulG NRW | Landesrechtliche Grundlage der Datenverarbeitung an Schulen in NRW |
+| § 9 VO-DV I | Aufbewahrungsfristen für Schülerdaten in NRW (siehe Abschnitt 5) |
+| Archivgesetz NRW | Anbietungspflicht vor Vernichtung, Zuständigkeit beim Verantwortlichen |
+| § 16 Abs. 2 ArbZG, § 41 EStG, § 147 AO, § 257 HGB | Aufbewahrungspflichten für Arbeitszeit- und lohnrelevante Aufzeichnungen des OGS-Personals |
+
+## 4. Grundsätze
+
+1. **Automatisierung vor Einzelfallentscheidung.** Wiederkehrende Löschungen laufen als automatisierte, täglich ausgeführte Bereinigungsjobs; manuelle Löschungen sind die Ausnahme und werden protokolliert.
+2. **Mandantenscharfe Löschung.** Jede Löschung wirkt pro Schule (tenant_id). Die Mandantentrennung wird auf Datenbankebene durch Row Level Security abgesichert; Löschläufe können daher keine Daten anderer Schulen erfassen.
+3. **Kürzestmögliche Fristen für Bewegungsdaten.** Anwesenheits- und Aufenthaltsdaten der Kinder werden rollierend nach spätestens 31 Tagen gelöscht, Standard 30 Tage (siehe Abschnitt 7.2).
+4. **Konfiguration durch den Verantwortlichen.** Wo das Gesetz Spielräume lässt, legt die Schule die konkrete Frist innerhalb der im System hinterlegten Grenzen selbst fest (mandantenbezogene GDPR-Einstellungen).
+5. **Löschung ist Hard-Delete.** Regellöschungen entfernen die Datensätze physisch aus der Produktivdatenbank. Eine Sperrung (Statuswechsel ohne physische Löschung) erfolgt nur in den in Abschnitt 11 beschriebenen Sonderfällen.
+6. **Backups laufen aus, sie werden nicht durchsucht.** Gelöschte Daten verbleiben bis zum Ablauf der Backup-Rotation in den Datensicherungen und werden dort nicht einzeln entfernt (siehe Abschnitt 8).
+
+## 5. Fristvorgaben der VO-DV I
+
+Für Schülerdaten in NRW gibt die VO-DV I (§ 9) folgende Aufbewahrungsfristen vor. Fristbeginn ist grundsätzlich das Ende des Kalenderjahres, in dem der Datensatz abgeschlossen wurde, frühestens jedoch das Ende des Kalenderjahres, in dem die Schulpflicht endet.
+
+| Datenkategorie nach VO-DV I | Frist | Relevanz für moto |
+|---|---|---|
+| Schülerstammdaten (Schülerstammblatt) | 20 Jahre | Die schulische Stammakte führt die Schule. moto hält nur die für den OGS-Betrieb erforderlichen Stammdaten; deren Löschung richtet sich nach dem in Abschnitt 9 beschriebenen Prozess und der Weisung des Verantwortlichen. |
+| Zeugnisse, Klassenbucheinträge | 10 Jahre | Nicht relevant, moto verwaltet keine Zeugnisse und keine Klassenbücher. |
+| Abgangszeugnisse | bis zu 50 Jahre | Nicht relevant. |
+| Übrige Daten (Regelfall, hierunter werden Anwesenheitsnachweise, Atteste und Entschuldigungen typischerweise gefasst) | 5 Jahre | [PRÜFEN] Die Zuordnung von OGS-Anwesenheitsdaten (Check-in/Check-out, Raumwechsel) zu einer Kategorie der VO-DV I ist nicht eindeutig kodifiziert, da die OGS-Betreuung landesrechtlich anders verankert ist als der Pflichtunterricht. Die verbindliche Einordnung ist durch [NAME DATENSCHUTZBEAUFTRAGTER] mit der jeweiligen Schule bzw. dem Schulträger, gegebenenfalls unter Einbindung der zuständigen Bezirksregierung, abzustimmen und schriftlich zu dokumentieren. Bis dahin gilt die im System konfigurierte kurze Löschfrist von maximal 31 Tagen für die elektronischen Bewegungsdaten; sofern die Schule Anwesenheitsnachweise länger benötigt, hat sie diese vor Ablauf der Frist über die vorgesehenen Exportfunktionen in ihre eigene Aktenführung zu übernehmen. |
+| Daten auf privaten digitalen Endgeräten | 1 Jahr | Nur mittelbar relevant, da moto zentral hostet. Die Schule stellt sicher, dass Beschäftigte keine Exporte dauerhaft auf privaten Endgeräten speichern. |
+
+**Klarstellung zum Verhältnis der Fristen:** Die kurzen Löschfristen im System (z. B. 30 Tage für Bewegungsdaten) unterschreiten die VO-DV I nicht in unzulässiger Weise. Die VO-DV I begrenzt die Speicherdauer nach oben; sie verpflichtet nicht dazu, elektronische Bewegungsdaten über den Betreuungszweck hinaus vorzuhalten. Soweit die Schule einzelne Nachweise für ihre Aktenführung benötigt, erstellt sie diese vor Fristablauf; die zugehörigen Exportzugriffe werden im System protokolliert (audit.data_access_log).
+
+## 6. Löschklassen und Löschregeln je Datenkategorie
+
+Die Datenkategorien entsprechen der Datenbestandsaufnahme (gesondertes internes Dokument) und dem Verzeichnis von Verarbeitungstätigkeiten (Dokument 04). Alle Tabellenangaben sind schema-qualifiziert (PostgreSQL, 15 Domänen-Schemas).
+
+### 6.1 Löschklassen
+
+| Klasse | Beschreibung | Typische Frist |
+|---|---|---|
+| **A** Rollierende Kurzfrist | Bewegungs- und Aufenthaltsdaten, tägliche automatische Löschung | 1 bis 31 Tage |
+| **B** Operative Mittelfrist | Feedback, abgelehnte Anmeldungen, abgeschlossene Termine | 90 Tage bis 5 Jahre |
+| **C** Gesetzliche Aufbewahrung | Zeiterfassung des Personals, Stammdaten nach VO-DV I | 2 bis 20 Jahre |
+| **D** Ereignisgebundene Löschung | Tokens, Einladungen, Konten, Karten-Zuordnungen; Auslöser ist ein Ereignis (Ablauf, Austritt, Widerruf), keine Kalenderfrist | bei Ereigniseintritt |
+| **E** Aufbewahrung ohne definierte Frist | Audit- und Protokolltabellen ohne automatische Löschung; offener Prüfpunkt, siehe Abschnitt 14 | derzeit unbegrenzt [PRÜFEN] |
+
+### 6.2 Schülerdaten
+
+| Datenkategorie | Speicherort | Klasse | Löschregel |
+|---|---|---|---|
+| Anwesenheit (Check-in/Check-out) | active.attendance | A | Automatische Löschung nach Ablauf des Aufbewahrungsfensters: Standard 30 Tage, konfigurierbar 1 bis 31 Tage (gdpr.privacy_consent_retention_days). Liegt für ein Kind eine individuelle Einwilligung mit eigenem Wert vor (users.privacy_consents.data_retention_days, ebenfalls 1 bis 31 Tage), geht dieser vor. Täglicher Löschlauf, siehe Abschnitt 7. |
+| Aufenthaltsort und Raumwechsel | active.visits | A | Identische Regel wie active.attendance (gleiches Aufbewahrungsfenster, gleicher Löschlauf). |
+| Krank-, Entschuldigt- und Ausflugs-Tagesmeldungen | active.student_status_days | E | [PRÜFEN] Für diese Tabelle ist im System derzeit kein eigenes Aufbewahrungsfenster hinterlegt. Da Krankmeldungen Gesundheitsdaten (Art. 9 DSGVO) sind, ist eine dedizierte Löschregel festzulegen und technisch umzusetzen. Bis dahin erfolgt die Löschung mit dem Kind-Datensatz (Abschnitt 9). |
+| Stammdaten (Name, Geburtsdatum, Klasse, Adresse, Gruppenzugehörigkeit, Abholregelungen) | users.persons, users.students | C/D | Aufbewahrung für die Dauer des Betreuungsverhältnisses. Nach Schulaustritt: Prozess nach Abschnitt 9. Endgültige Löschung auf Weisung des Verantwortlichen unter Beachtung der VO-DV-I-Fristen und der Archivanbietungspflicht. |
+| Gesundheitsangaben (Freitext) | users.students.health_info | D | Löschung bzw. Leerung des Feldes spätestens mit dem Austrittsprozess nach Abschnitt 9. Eine über das Betreuungsende hinausgehende Aufbewahrung von Gesundheitsdaten findet nicht statt. Vorzeitige Löschung jederzeit auf Weisung der Schule oder auf begründetes Verlangen der Erziehungsberechtigten über die Schule. |
+| Betreuer-Notizen, Zusatzinformationen | users.students.supervisor_notes, .extra_info | D | Löschung mit dem Kind-Datensatz (Abschnitt 9); vorzeitig auf Weisung. |
+| Foto | users.students.photo_path (Einwilligung: .photo_consent_given_at/by) | D | Löschung der Bilddatei und des Pfadverweises unverzüglich bei Widerruf der Einwilligung, spätestens mit dem Austrittsprozess nach Abschnitt 9. |
+| Einwilligungsnachweise (Foto, AGB, Datenverarbeitung, E-Mail-Kontakt, Datenschutz-Einwilligung je Kind) | users.students.*_accepted_at, users.privacy_consents | D | Aufbewahrung als Nachweis für die Dauer des Betreuungsverhältnisses (Art. 5 Abs. 2, Art. 7 Abs. 1 DSGVO). Löschung mit dem Kind-Datensatz. [PRÜFEN] Ob Einwilligungsnachweise nach Betreuungsende für eine begrenzte Nachweisfrist (Verjährung) aufzubewahren sind, ist mit [NAME DATENSCHUTZBEAUFTRAGTER] festzulegen. |
+| RFID-Karten-Zuordnung | users.persons.tag_id, users.rfid_cards | D | Aufhebung der Zuordnung Tag zu Person mit dem Austrittsprozess (Abschnitt 9). Die Karte wird deaktiviert; die Tag-UID ohne Personenzuordnung ist kein dem Kind zuordenbares Datum mehr. |
+| Feedback-Einträge (z. B. Mensa-Bewertung) | feedback.entries | B | Automatische Löschung nach Ablauf des Aufbewahrungsfensters: Standard 90 Tage, konfigurierbar 1 bis 365 Tage (feedback.data_retention_days). |
+| Anmeldedaten vor Kind-Anlage (Enrollment) | enrollment.requests, enrollment.request_children, enrollment.request_guardians | B/D | Abgelehnte Anmeldungen: automatische Löschung nach Standard 90 Tagen, konfigurierbar bis 730 Tage (enrollment.rejected_retention_days). Genehmigte Anmeldungen: Übernahme der Daten in den Kind-Datensatz. [PRÜFEN] Für die Ursprungsdatensätze genehmigter Anmeldungen ist derzeit keine eigene automatische Löschfrist hinterlegt; eine Regel ist festzulegen. Status- und Bearbeitungslinks der Anmeldung verfallen nach Standard 365 Tagen, konfigurierbar bis 1825 Tage (enrollment.status_token_ttl_days). |
+| Datenänderungsanfragen der Eltern | users.student_data_change_requests | E | [PRÜFEN] Kein eigenes Aufbewahrungsfenster im System hinterlegt; Löschregel ist festzulegen. Bis dahin Löschung mit dem Kind-Datensatz. |
+| Betreuungsplan-Termine (abgeschlossen/abgesagt) | schedule (Timetable) | B | Automatische Löschung nach Standard 365 Tagen, konfigurierbar 1 bis 1825 Tage (gdpr.timetable_retention_days). |
+
+### 6.3 Daten der Eltern und Erziehungsberechtigten
+
+| Datenkategorie | Speicherort | Klasse | Löschregel |
+|---|---|---|---|
+| Profil (Name, E-Mail, Adresse, Telefonnummern, Präferenzen, interne Notizen) | users.guardian_profiles, users.guardian_phone_numbers | D | Aufbewahrung, solange mindestens eine aktive Zuordnung zu einem betreuten Kind besteht (users.students_guardians). Endet die letzte Zuordnung (Austritt des Kindes, Abschnitt 9), wird das Profil einschließlich Telefonnummern und Notizen gelöscht bzw. das zugehörige Portal-Konto deaktiviert und im Austrittsprozess entfernt. |
+| Kind-Zuordnung inkl. Abholberechtigung, Notfallkontakt, Portal-Berechtigungen | users.students_guardians | D | Löschung mit der Beendigung der Beziehung bzw. mit dem Kind-Datensatz (Abschnitt 9). |
+| Eltern-Portal-Konto | auth.accounts, auth.account_tenants | D | Deaktivierung mit Ende der letzten Kind-Zuordnung, Löschung im Austrittsprozess (Abschnitt 9). Bei Konten mit Zuordnungen zu mehreren Schulen wird nur die Zuordnung zur ausscheidenden Schule beendet. |
+| Portal-Einladungen | auth.guardian_invitations | D | Einladungslinks verfallen nach Standard 48 Stunden, konfigurierbar bis 168 Stunden (invitations.guardian_token_expiry_hours). Abgelaufene Einladungen werden durch einen automatischen Bereinigungsjob entfernt. |
+| Eltern-Chat mit der Betreuung | users.parent_messages | E | [PRÜFEN] Kein Aufbewahrungsfenster im System hinterlegt. Eine Löschregel (Vorschlag: Löschung mit dem Kind-Datensatz, zusätzlich rollierende Höchstfrist) ist festzulegen und technisch umzusetzen. |
+| Änderungsprotokoll Kontakt-/Abholdaten | audit.guardian_changes | E | Append-only-Protokoll, derzeit ohne automatische Löschung (siehe Abschnitt 14). Bei Kontaktänderungen werden die Werte selbst nicht gespeichert, nur bei Abholdaten. |
+
+### 6.4 Daten des Personals
+
+| Datenkategorie | Speicherort | Klasse | Löschregel |
+|---|---|---|---|
+| Zeiterfassung (Kommen/Gehen, Pausen, Homeoffice), Korrekturen, Abwesenheiten (inkl. Krankmeldungen), Urlaubskontingente | active.work_sessions, active.work_session_breaks, audit.work_session_edits, active.staff_absences, active.staff_vacation_quota | C | Automatische Löschung nach Ablauf des Aufbewahrungsfensters: Standard 730 Tage (2 Jahre), wählbar in Stufen 730/1095/1460/1825/2190/2555/2920 Tage (gdpr.time_tracking_retention_days). Die Bandbreite bildet die gesetzlichen Aufbewahrungspflichten ab: mindestens 2 Jahre nach § 16 Abs. 2 ArbZG, 6 Jahre bei Lohnkonto-Bezug nach § 41 EStG, bis 8 Jahre nach § 147 AO bzw. § 257 HGB. Die konkrete Frist legt die Schule bzw. der Träger entsprechend der eigenen lohnbuchhalterischen Einordnung fest. |
+| Stammdaten (Name, Geburtsdatum, Beschäftigungsart, Arbeitszeitmodell, Notizen) | users.persons, users.staff, config.work_time_models, config.staff_work_schedules | D | Aufbewahrung für die Dauer der Beschäftigung. Bei Ausscheiden: Deaktivierung des Kontos, Aufhebung der RFID-Zuordnung, Löschung der Stammdaten auf Weisung des Verantwortlichen nach Ablauf der zeiterfassungsbezogenen Aufbewahrungsfristen. |
+| Konto, PIN, Passwort | auth.accounts (password_hash, pin_hash, Argon2id) | D | Deaktivierung bei Ausscheiden, Löschung mit den Stammdaten. Passwörter und PINs liegen zu keinem Zeitpunkt im Klartext vor. |
+| Gruppenbetreuung, Vertretungen | active.group_supervisor, education.group_teacher, education.group_substitution | D | Löschung mit der organisatorischen Zuordnung bzw. mit den Stammdaten. |
+
+### 6.5 Konten- und Sicherheitsdaten (alle Kontotypen)
+
+| Datenkategorie | Speicherort | Klasse | Löschregel |
+|---|---|---|---|
+| Sessions und Refresh-Tokens | auth.tokens | D | Automatische Löschung abgelaufener Tokens durch einen regelmäßigen Bereinigungsjob. |
+| Passwort-Reset-Tokens und zugehörige Rate-Limits | auth.password_reset_tokens, auth.password_reset_rate_limits | D | Automatische Löschung abgelaufener Einträge durch regelmäßige Bereinigungsjobs. |
+| Einladungstokens (Personal, Operator, E-Mail-Änderung) | auth.invitation_tokens, platform.operator_invitation_token, platform.operator_email_change_token | D | Automatische Löschung abgelaufener Tokens durch regelmäßige Bereinigungsjobs. |
+| MFA: vertrauenswürdige Geräte | auth.mfa_trusted_devices | D | Verfall nach Standard 90 Tagen, konfigurierbar 1 bis 180 Tage (security.mfa_trusted_device_days). |
+| MFA-Daten, Passkeys | auth.mfa_credentials, auth.mfa_email_challenges, auth.passkey_credentials, auth.passkey_sessions | D | Löschung mit dem Konto bzw. bei Deregistrierung des Merkmals durch die Nutzerin oder den Nutzer. |
+| Login-Historie inkl. IP-Adresse | audit.auth_events | E | Derzeit ohne automatische Löschung (siehe Abschnitt 14). |
+
+### 6.6 Audit- und Protokolldaten
+
+| Datenkategorie | Speicherort | Klasse | Löschregel |
+|---|---|---|---|
+| Datenzugriffsprotokoll (wer hat wann welche sensiblen Daten eingesehen) | audit.data_access_log | E | Bewusst ohne automatische Löschung, dient dem Nachweis nach Art. 5 Abs. 2 und Art. 32 DSGVO. Eine Höchstfrist ist festzulegen (siehe Abschnitt 14). |
+| Löschprotokoll | audit.data_deletions | E | Aufbewahrung als Löschnachweis (Art. 5 Abs. 2 DSGVO). Das Protokoll enthält Art, Umfang, Grund, ausführende Person und Zeitpunkt der Löschung, jedoch nicht die gelöschten Inhalte selbst. Eine dauerhafte Aufbewahrung ist als Rechenschaftsnachweis vertretbar; eine Höchstfrist ist gleichwohl festzulegen (Abschnitt 14). |
+| Import-Protokoll | audit.data_imports | E | Derzeit ohne automatische Löschung (Abschnitt 14). |
+| Zeiterfassungs-Korrekturprotokoll | audit.work_session_edits | C | Wird vom Löschlauf der Zeiterfassung miterfasst (gdpr.time_tracking_retention_days, siehe 6.4). |
+| Enrollment-Korrekturprotokoll | audit.enrollment_offering_adjustment | E | Derzeit ohne automatische Löschung (Abschnitt 14). |
+| Unregistrierte NFC-Scans (Tag-UID ohne Personenzuordnung) | audit.unregistered_tag_scans | E | [PRÜFEN] Kein Aufbewahrungsfenster hinterlegt. Da die Tag-UID ein pseudonymes, potenziell re-identifizierbares Merkmal ist, ist eine kurze rollierende Löschfrist festzulegen und umzusetzen. |
+| Operator-Audit-Log | platform.operator_audit_log | E | Derzeit ohne automatische Löschung (Abschnitt 14). Betrifft ausschließlich Handlungen von Beschäftigten des Plattformbetreibers. |
+
+### 6.7 System-, Log- und Monitoring-Daten
+
+| Datenkategorie | Speicherort | Klasse | Löschregel |
+|---|---|---|---|
+| Anwendungs- und Zugriffslogs | zentrales Log-System (selbst gehostetes Loki auf dem Hetzner-Server) | A/B | Automatische Löschung nach 30 Tagen (Retention des Log-Systems). Die Anwendung protokolliert nach interner Vorgabe keine Klarnamen von Kindern auf Info-Level, sondern ausschließlich Kennungen; Zugriffs-Logs des Reverse Proxy maskieren IP-Adressen sowie Authentifizierungs-Header. |
+| Datenbank-Sicherungen | Backup-Verzeichnis auf dem Produktionsserver | siehe Abschnitt 8 | Rotation, keine Einzellöschung. |
+
+## 7. Technische Umsetzung
+
+### 7.1 Automatisierte Datenbereinigung (Scheduler)
+
+Die Regellöschung wird durch einen serverseitigen Scheduler ausgeführt. Der Bereinigungslauf ist mandantenbezogen konfigurierbar:
+
+| Einstellung | Standardwert | Grenzen | Funktion |
+|---|---|---|---|
+| gdpr.data_cleanup_enabled | aktiviert | | Automatische Datenbereinigung ein/aus |
+| gdpr.data_cleanup_time | 02:00 Uhr | | Uhrzeit des täglichen Bereinigungslaufs |
+| gdpr.data_cleanup_timeout_minutes | 30 Minuten | 5 bis 120 | Zeitbegrenzung des Laufs |
+
+Der Löschlauf arbeitet pro Schule (tenant_id) und iteriert über alle aktiven Mandanten. Jede Löschung wird im Löschprotokoll (audit.data_deletions) mit Art, Anzahl der gelöschten Datensätze, Grund und Zeitpunkt festgehalten.
+
+Organisatorische Vorgabe: Das Abschalten der automatischen Bereinigung (gdpr.data_cleanup_enabled) durch eine Schule ist nur nach dokumentierter Abstimmung mit [NAME DATENSCHUTZBEAUFTRAGTER] zulässig, da ansonsten die in diesem Konzept zugesicherten Fristen nicht eingehalten werden. [PRÜFEN] Ob technisch verhindert werden soll, dass Schulen die Bereinigung dauerhaft deaktivieren, ist zu entscheiden.
+
+### 7.2 Konfigurierbare Aufbewahrungsfenster (GDPR-Einstellungen)
+
+Die folgenden Fristen sind je Schule als Einstellung hinterlegt. Der Verantwortliche kann sie innerhalb der Systemgrenzen anpassen; jede Änderung wird in einem append-only Änderungsprotokoll (config.setting_audit) festgehalten.
+
+| Einstellung | Standard | Grenzen | Betroffene Daten |
+|---|---|---|---|
+| gdpr.privacy_consent_retention_days | 30 Tage | 1 bis 31 | Anwesenheits- und Aufenthaltsdaten der Kinder (active.attendance, active.visits); individuelle Einwilligungswerte je Kind (users.privacy_consents.data_retention_days, ebenfalls 1 bis 31 Tage) gehen vor |
+| gdpr.time_tracking_retention_days | 730 Tage | Stufen 730 bis 2920 | Zeiterfassung des Personals inkl. Pausen, Korrekturen, Abwesenheiten |
+| gdpr.timetable_retention_days | 365 Tage | 1 bis 1825 | Abgeschlossene und abgesagte Betreuungsplan-Termine |
+| feedback.data_retention_days | 90 Tage | 1 bis 365 | Feedback-Einträge der Kinder |
+| enrollment.rejected_retention_days | 90 Tage | bis 730 | Abgelehnte Anmeldungen |
+| enrollment.status_token_ttl_days | 365 Tage | bis 1825 | Status- und Bearbeitungslinks von Anmeldungen |
+| invitations.guardian_token_expiry_hours | 48 Stunden | bis 168 | Eltern-Einladungslinks |
+| security.mfa_trusted_device_days | 90 Tage | 1 bis 180 | Vertrauenswürdige Geräte (2FA-Ausnahme) |
+
+Ergänzend begrenzen zwei Sichtbarkeitsfenster den lesenden Zugriff auf noch nicht gelöschte Anwesenheitsdaten (Datenminimierung auf Zugriffsebene, keine Löschregeln im engeren Sinn): gdpr.attendance_visible_days (Standard 30 Tage, 1 bis 365) und gdpr.room_detail_visible_days (Standard 7 Tage, 1 bis 365). Das Anwesenheitsprotokoll ist standardmäßig vollständig deaktiviert (gdpr.attendance_log_enabled, Standard: aus) und der Leserkreis auf Gruppenbetreuende beschränkt (gdpr.attendance_log_scope, gdpr.student_data_scope).
+
+### 7.3 Nicht konfigurierbare Bereinigungsjobs
+
+Unabhängig von den Mandanten-Einstellungen laufen folgende technische Bereinigungen in festen Intervallen:
+
+- Löschung abgelaufener Sitzungs- und Refresh-Tokens (auth.tokens)
+- Löschung abgelaufener Passwort-Reset-Tokens und zugehöriger Rate-Limit-Einträge
+- Löschung abgelaufener Einladungen (auth.invitation_tokens, auth.guardian_invitations)
+- Löschung abgelaufener E-Mail-Änderungs- und Einladungstokens des Betreiberportals
+- Technische Aufräumjobs für nicht abgeschlossene Anwesenheits- und Aufsichtszuordnungen (Stale-Attendance, Stale-Supervisor); diese korrigieren Datenqualität und stellen kein eigenes Aufbewahrungsfenster im datenschutzrechtlichen Sinn dar
+
+### 7.4 Kiosk-Geräte (PyrePortal auf Raspberry Pi)
+
+Auf den Kiosk-Geräten in den Schulen werden personenbezogene Daten nicht dauerhaft gespeichert. Das Gerät hält lediglich seinen Geräte-API-Schlüssel und temporäre Sitzungsdaten; alle personenbezogenen Daten liegen ausschließlich in der zentralen Datenbank. Die Löschpflichten dieses Konzepts konzentrieren sich daher auf das Backend. [PRÜFEN] Die Aussage zur fehlenden lokalen Persistenz ist bei wesentlichen Änderungen der Kiosk-Software erneut zu verifizieren; bei Außerbetriebnahme eines Geräts wird der Geräte-API-Schlüssel serverseitig widerrufen.
+
+### 7.5 Mandantenschärfe und Nachvollziehbarkeit
+
+Alle mandantenbezogenen Tabellen tragen eine tenant_id mit Fremdschlüssel auf die Schule; Row Level Security auf Datenbankebene stellt sicher, dass Lösch- wie Leseoperationen die Mandantengrenze nicht überschreiten. Manuelle Löschungen durch Administratorinnen und Administratoren der Schule (z. B. Löschung eines Kind-Datensatzes) werden ebenso wie automatische Löschläufe im Löschprotokoll (audit.data_deletions) erfasst.
+
+## 8. Datensicherungen und ihr Verhältnis zur Löschung
+
+### 8.1 Sicherungsverfahren
+
+Vor jeder Änderung am Produktivsystem (Deployment mit Datenbankmigration) wird eine vollständige Datenbanksicherung erstellt (pg_dump im Custom-Format, zusätzlich Sicherung der Rollen- und Berechtigungsdefinitionen sowie der hochgeladenen Dateien). Die Sicherungen liegen auf demselben Server in einem zugriffsbeschränkten Verzeichnis (Dateiberechtigungen restriktiv gesetzt).
+
+### 8.2 Rotation
+
+Es werden die jeweils letzten sieben Sicherungen der Produktionsumgebung vorgehalten; ältere Sicherungen werden beim Erstellen einer neuen Sicherung automatisch gelöscht (Staging: drei Sicherungen). Da Sicherungen anlassbezogen bei Deployments entstehen, entspricht die Vorhaltezeit von sieben Sicherungen bei der üblichen Deployment-Frequenz einem Zeitraum in der Größenordnung von etwa einer Woche. [PRÜFEN] Ergänzend ist eine kalenderbasierte Höchstvorhaltezeit (z. B. Löschung jeder Sicherung, die älter als [MAXIMALE BACKUP-VORHALTEZEIT IN TAGEN] ist) festzulegen und technisch umzusetzen, damit die Vorhaltezeit auch bei geringer Deployment-Frequenz begrenzt bleibt.
+
+### 8.3 Verhältnis zur Löschung im Produktivsystem
+
+Personenbezogene Daten verbleiben nach ihrer Löschung im Produktivsystem noch bis zum Auslaufen der Rotation in den Datensicherungen. Eine gezielte Einzellöschung aus Sicherungen erfolgt nicht, da dies die Integrität und Wiederherstellbarkeit der Sicherung gefährden würde. Stattdessen gilt:
+
+1. Die maximale Vorhaltezeit der Sicherungen wird auf das technisch und organisatorisch notwendige Minimum begrenzt und dokumentiert (Abschnitt 8.2).
+2. Sicherungen werden ausschließlich zur Wiederherstellung nach Störungen verwendet, nicht zur Auswertung.
+3. Wird eine Sicherung zurückgespielt, die bereits gelöschte Daten enthält, werden die zwischenzeitlich fällig gewordenen Löschungen unmittelbar nach der Wiederherstellung durch den nächsten Bereinigungslauf nachgeholt; dies wird im Wiederherstellungsprotokoll vermerkt.
+4. Nach Vertragsende einer Schule laufen die letzten Sicherungen, die Daten dieser Schule enthalten, mit der Rotation aus (Abschnitt 10).
+
+## 9. Prozess bei Schulaustritt eines Kindes
+
+Auslöser ist das Ende des Betreuungsverhältnisses (Austritt, Schulwechsel, Ende der OGS-Teilnahme). Der Prozess läuft wie folgt:
+
+1. **Statuswechsel durch die Schule.** Die Schule setzt den Kind-Datensatz auf den Status inaktiv bzw. Alumnus und pflegt das Betreuungsende (users.students.status, enrolled_until). Ab diesem Zeitpunkt ist das Kind aus den operativen Ansichten (Anwesenheit, Gruppen, Kiosk) ausgeblendet.
+2. **Auslaufen der Bewegungsdaten.** Anwesenheits- und Aufenthaltsdaten (active.attendance, active.visits) laufen über das rollierende Aufbewahrungsfenster (maximal 31 Tage) automatisch aus; spätestens 31 Tage nach dem letzten Betreuungstag existieren keine Bewegungsdaten des Kindes mehr im Produktivsystem.
+3. **Aufhebung der RFID-Zuordnung.** Die Zuordnung der Tag-UID zur Person wird aufgehoben, die Karte deaktiviert und für die Wiederverwendung oder Vernichtung an die Schule zurückgegeben.
+4. **Gesundheitsdaten und Freitexte.** Gesundheitsangaben (users.students.health_info), Betreuer-Notizen und Abholregelungs-Freitexte werden im Zuge der Austrittsbearbeitung gelöscht; das Foto wird gelöscht.
+5. **Eltern-Zuordnungen.** Die Kind-Eltern-Zuordnungen (users.students_guardians) werden beendet. Besteht für einen Erziehungsberechtigten keine weitere aktive Kind-Zuordnung, werden Profil und Portal-Konto deaktiviert und im Rahmen der Stammdatenlöschung entfernt; laufende Chat-Verläufe (users.parent_messages) werden mitgelöscht, sobald die in Abschnitt 6.3 geforderte Löschregel umgesetzt ist [PRÜFEN].
+6. **Stammdatenlöschung auf Weisung.** Die endgültige Löschung der Stammdaten (users.persons, users.students und abhängige Datensätze) erfolgt auf Weisung des Verantwortlichen. Die Schule prüft zuvor, ob Daten für die eigene Aktenführung zu übernehmen sind (VO-DV I, Abschnitt 5) und ob die Archivanbietungspflicht greift. moto empfiehlt als Regelweisung die Löschung zum Ende des Kalenderjahres, das auf das Betreuungsende folgt; die verbindliche Festlegung trifft der Verantwortliche. [PRÜFEN] Diese Regelweisung ist je Schulträger im Auftragsverarbeitungsvertrag bzw. in dessen Anlage zu fixieren.
+7. **Protokollierung.** Jeder Löschschritt wird im Löschprotokoll (audit.data_deletions) mit Umfang, Grund und ausführender Person festgehalten. Auf Anforderung erhält die Schule eine Löschbestätigung.
+
+Sonderweg vorzeitige Löschung: Verlangen Erziehungsberechtigte die Löschung einzelner Daten (Art. 17 DSGVO), richtet sich das Verlangen an die Schule als Verantwortlichen. Die Schule prüft entgegenstehende Aufbewahrungspflichten und weist moto an; moto setzt die Weisung binnen der im Auftragsverarbeitungsvertrag vereinbarten Frist um und bestätigt die Ausführung.
+
+## 10. Prozess bei Vertragsende der Schule
+
+Endet der Vertrag zwischen moto und der Schule bzw. dem Schulträger, gilt nach Art. 28 Abs. 3 lit. g DSGVO:
+
+1. **Wahlrecht des Verantwortlichen.** Die Schule bzw. der Schulträger entscheidet, ob die Daten gelöscht oder zurückgegeben (exportiert) werden. Das Wahlrecht ist innerhalb von [30 TAGE NACH VERTRAGSENDE] nach Vertragsende auszuüben; übt der Verantwortliche das Wahlrecht nicht fristgerecht aus, erfolgt die Löschung nach vorheriger schriftlicher Ankündigung.
+2. **Rückgabe/Export.** Auf Wunsch stellt moto vor der Löschung einen vollständigen Export der Mandantendaten in einem strukturierten, gängigen Format bereit. Der Export wird verschlüsselt übergeben; die Übergabe wird dokumentiert.
+3. **Mandantenscharfe Löschung.** Anschließend löscht moto sämtliche personenbezogenen Daten des Mandanten aus dem Produktivsystem. Die Löschung erfolgt anhand der Mandantenkennung (tenant_id) über alle mandantenbezogenen Tabellen; die Mandantentrennung per Row Level Security stellt sicher, dass ausschließlich Daten der betroffenen Schule erfasst werden. Hochgeladene Dateien (z. B. Fotos, Login-Bild) werden mitgelöscht. Der Mandant (Schul-Eintrag) wird deaktiviert und nach Abschluss der Löschung entfernt.
+4. **Auslaufen der Sicherungen.** Datensicherungen, die Daten des Mandanten enthalten, werden nicht einzeln bereinigt, sondern laufen mit der Backup-Rotation aus (Abschnitt 8). Bis zum Auslaufen werden sie nicht wiederhergestellt, außer zur Abwehr eines Datenverlusts; in diesem Fall wird die Mandantenlöschung unmittelbar nach der Wiederherstellung wiederholt.
+5. **Audit- und Löschprotokolle.** Einträge im Löschprotokoll (audit.data_deletions) sowie mandantenbezogene Einträge in den übrigen Audit-Tabellen werden als Nachweis der ordnungsgemäßen Vertragsabwicklung aufbewahrt, soweit und solange dies zur Erfüllung der Rechenschaftspflicht erforderlich ist. [PRÜFEN] Umfang und Frist dieser Nachweisaufbewahrung sind mit [NAME DATENSCHUTZBEAUFTRAGTER] festzulegen; personenbeziehbare Inhalte, die für den Nachweis nicht erforderlich sind, werden gelöscht.
+6. **Löschbestätigung.** moto stellt dem Verantwortlichen nach Abschluss der Löschung und nach Auslaufen der letzten betroffenen Sicherung eine schriftliche Löschbestätigung aus, die Umfang, Zeitpunkte und Verfahren der Löschung benennt.
+7. **Unterauftragsverarbeiter.** moto stellt sicher, dass auch bei eingesetzten Unterauftragsverarbeitern (siehe Subprozessoren-Verzeichnis, Dokument 03) keine mandantenbezogenen personenbezogenen Daten über das Vertragsende hinaus verbleiben, soweit solche dort verarbeitet wurden (insbesondere E-Mail-Versand, Fehlerberichte).
+
+## 11. Sonderfälle
+
+1. **Sperrung statt Löschung.** Ist eine Löschung wegen eines laufenden Verfahrens (z. B. Rechtsstreit, aufsichtsbehördliche Prüfung) oder einer entgegenstehenden Aufbewahrungspflicht vorübergehend unzulässig, werden die betroffenen Datensätze gesperrt: Der Zugriff wird auf die für das Verfahren erforderlichen Personen beschränkt, die Datensätze werden von den automatischen Löschläufen ausgenommen und der Vorgang wird dokumentiert. Nach Wegfall des Sperrgrunds wird die Löschung nachgeholt.
+2. **Widerspruch und Einwilligungswiderruf.** Beruht eine Verarbeitung auf Einwilligung (insbesondere Fotos), führt der Widerruf zur unverzüglichen Löschung der betroffenen Daten, ohne die Rechtmäßigkeit der bisherigen Verarbeitung zu berühren.
+3. **Unvollständige oder fehlerhafte Anmeldungen.** Anmeldedaten, die nie zu einem Betreuungsverhältnis führen, unterliegen der automatischen Löschung abgelehnter Anmeldungen (Abschnitt 6.2).
+4. **Nicht zugeordnete RFID-Scans.** Scans unbekannter Tags (audit.unregistered_tag_scans) enthalten keine unmittelbare Personenzuordnung, sind aber pseudonym re-identifizierbar und werden daher der in Abschnitt 14 geforderten kurzen Löschfrist unterworfen [PRÜFEN].
+5. **Systemabbau und Migration.** Bei Ablösung von Systemkomponenten werden Altdatenbestände nach erfolgreicher Migration und Verifikation gelöscht; Datenträger werden vor Außerbetriebnahme sicher gelöscht bzw. vernichtet. Für die beim Hosting-Anbieter betriebene Infrastruktur gelten dessen zertifizierte Verfahren zur Datenträgervernichtung [PRÜFEN: Nachweis über Hosting-AVV beibringen].
+
+## 12. Protokollierung und Nachweis
+
+1. Jede automatische wie manuelle Löschung personenbezogener Daten wird im Löschprotokoll (audit.data_deletions) festgehalten: betroffener Datensatztyp, Anzahl der Datensätze, Löschgrund, ausführende Stelle, Zeitpunkt. Die gelöschten Inhalte selbst werden nicht protokolliert.
+2. Änderungen an den Aufbewahrungseinstellungen werden im Einstellungs-Änderungsprotokoll (config.setting_audit, append-only) festgehalten.
+3. Exporte und lesende Zugriffe auf Anwesenheitshistorien werden im Datenzugriffsprotokoll (audit.data_access_log) festgehalten.
+4. Auf Anforderung erhält der Verantwortliche Auszüge aus diesen Protokollen sowie Löschbestätigungen für konkrete Vorgänge.
+
+## 13. Verantwortlichkeiten und Pflege
+
+| Aufgabe | Zuständigkeit |
+|---|---|
+| Festlegung und Änderung der Aufbewahrungsfenster je Schule | Verantwortlicher (Schulleitung/Trägerverwaltung), technisch über die GDPR-Einstellungen |
+| Betrieb und Überwachung der Löschläufe | moto, Betrieb/Entwicklung |
+| Prüfung der Löschprotokolle (stichprobenweise, mindestens jährlich) | Datenschutzkoordination moto |
+| Freigabe von Ausnahmen (Sperrungen, Abschaltung der Bereinigung) | [NAME DATENSCHUTZBEAUFTRAGTER] |
+| Pflege dieses Konzepts, Abgleich mit dem Systemstand | Datenschutzkoordination moto, mindestens jährlich sowie bei jeder Änderung an Löschjobs oder Aufbewahrungseinstellungen |
+| Abstimmung der VO-DV-I-Einordnung mit Schulen/Trägern | [NAME DATENSCHUTZBEAUFTRAGTER] |
+
+## 14. Offene Punkte und Prüfaufträge
+
+Die folgenden Punkte sind vor der Freigabe dieses Konzepts zu klären bzw. umzusetzen. Sie ergeben sich aus dem Abgleich mit dem tatsächlichen Systemstand und werden hier bewusst transparent ausgewiesen (Art. 5 Abs. 1 lit. e und Abs. 2 DSGVO):
+
+1. **Audit-Tabellen ohne Löschfrist.** Für audit.auth_events, audit.data_access_log, audit.data_imports, audit.guardian_changes, audit.enrollment_offering_adjustment und platform.operator_audit_log existiert derzeit keine automatische Löschung. Für jede Tabelle ist eine begründete Höchstfrist festzulegen (Vorschlag zur Diskussion: 12 Monate für Login- und Zugriffshistorien, längere Fristen nur, wo der Nachweiszweck dies trägt) und technisch umzusetzen. [PRÜFEN]
+2. **Krank-/Entschuldigt-Tageshistorie (active.student_status_days).** Gesundheitsdaten ohne eigenes Aufbewahrungsfenster; dedizierte Löschregel festlegen und umsetzen. [PRÜFEN]
+3. **Eltern-Chat (users.parent_messages).** Löschregel festlegen und umsetzen. [PRÜFEN]
+4. **Unregistrierte NFC-Scans (audit.unregistered_tag_scans).** Kurze rollierende Löschfrist festlegen und umsetzen. [PRÜFEN]
+5. **Genehmigte Anmeldungen und Datenänderungsanfragen.** Löschregeln für die Ursprungsdatensätze genehmigter Anmeldungen sowie für users.student_data_change_requests festlegen. [PRÜFEN]
+6. **VO-DV-I-Einordnung der OGS-Anwesenheitsdaten.** Verbindliche Abstimmung mit Schulen/Trägern, gegebenenfalls Bezirksregierung, dokumentieren (Abschnitt 5). [PRÜFEN]
+7. **Regelweisung zur Stammdatenlöschung nach Austritt.** Je Schulträger im Auftragsverarbeitungsvertrag fixieren (Abschnitt 9 Nr. 6). [PRÜFEN]
+8. **Kalenderbasierte Höchstvorhaltezeit für Backups.** Ergänzend zur anzahlbasierten Rotation festlegen und umsetzen (Abschnitt 8.2). [PRÜFEN]
+9. **Nachweisaufbewahrung nach Vertragsende.** Umfang und Frist der aufbewahrten Lösch- und Audit-Nachweise festlegen (Abschnitt 10 Nr. 5). [PRÜFEN]
+10. **Einwilligungsnachweise nach Betreuungsende.** Entscheidung über eine begrenzte Nachweisfrist (Abschnitt 6.2). [PRÜFEN]
+11. **Deaktivierbarkeit der automatischen Bereinigung.** Entscheidung, ob das dauerhafte Abschalten durch Schulen technisch unterbunden wird (Abschnitt 7.1). [PRÜFEN]
+12. **Kiosk-Persistenz.** Verifikation der fehlenden lokalen Speicherung personenbezogener Daten bei wesentlichen Software-Änderungen (Abschnitt 7.4). [PRÜFEN]
+13. **Datenträgervernichtung beim Hosting-Anbieter.** Nachweis über den Hosting-Vertrag/AVV beibringen (Abschnitt 11 Nr. 5). [PRÜFEN]
+
+---
+
+*Dieses Dokument ist Teil der DSGVO-Dokumentation von moto. Es ergänzt insbesondere das Verzeichnis der Verarbeitungstätigkeiten (Dokument 04), die Datenbestandsaufnahme (gesondertes internes Dokument), die TOM-Dokumentation (Dokument 02) und das Subprozessoren-Verzeichnis (Dokument 03). Änderungen an Löschjobs, Aufbewahrungseinstellungen oder der Backup-Strategie erfordern eine Aktualisierung dieses Konzepts.*

--- a/docs/moto-dsgvo-dokumente/06-dsfa-zuarbeit.md
+++ b/docs/moto-dsgvo-dokumente/06-dsfa-zuarbeit.md
@@ -1,0 +1,453 @@
+# Zuarbeit zur Datenschutz-Folgenabschätzung gemäß Art. 35 DSGVO
+
+**System: moto (NFC/RFID-gestütztes Anwesenheits- und Raumverwaltungssystem für den Offenen Ganztag)**
+
+| | |
+|---|---|
+| Dokument | 06 Zuarbeit des Auftragsverarbeiters zur Datenschutz-Folgenabschätzung |
+| Version | 1.0 |
+| Stand | 2026-07-07 |
+| Status | Entwurf zur internen Prüfung |
+| Ersteller | [NAME DATENSCHUTZKOORDINATOR], moto [RECHTSFORM UND ADRESSE] |
+| Datenschutzbeauftragter des Auftragsverarbeiters | [NAME DATENSCHUTZBEAUFTRAGTER], [KONTAKT DATENSCHUTZBEAUFTRAGTER] |
+| Adressat | Schulleitung und Schulträger als Verantwortliche, deren behördliche Datenschutzbeauftragte |
+| Vertraulichkeit | Intern / zur Weitergabe an den Verantwortlichen bestimmt |
+
+---
+
+## 1. Zweck und Geltungsbereich dieses Dokuments
+
+Dieses Dokument unterstützt die datenschutzrechtlich verantwortliche Stelle (Schule bzw. Schulträger) bei der Erstellung der Datenschutz-Folgenabschätzung (DSFA) gemäß Art. 35 DSGVO für den Einsatz des Systems moto im Offenen Ganztag (OGS).
+
+Es wird ausdrücklich klargestellt:
+
+1. Die **Durchführung, Bewertung und Freigabe der DSFA obliegt ausschließlich dem Verantwortlichen** im Sinne von Art. 4 Nr. 7, Art. 35 Abs. 1 DSGVO, also der Schule bzw. dem Schulträger. Dieses Dokument ist keine DSFA und ersetzt keine DSFA.
+2. moto handelt als **Auftragsverarbeiter** gemäß Art. 28 DSGVO. Grundlage dieser Zuarbeit ist die Unterstützungspflicht aus **Art. 28 Abs. 3 lit. f DSGVO**, wonach der Auftragsverarbeiter den Verantwortlichen unter Berücksichtigung der Art der Verarbeitung und der ihm zur Verfügung stehenden Informationen bei der Einhaltung der Pflichten aus Art. 32 bis 36 DSGVO unterstützt. Die entsprechende vertragliche Verankerung findet sich in § 8 Abs. 1 und 5 des Auftragsverarbeitungsvertrags (Dokument 01) vom [DATUM AVV].
+3. Der Umfang dieser Zuarbeit ist zweifach begrenzt: auf die Verarbeitungsvorgänge, die moto tatsächlich im Auftrag durchführt, und auf die Informationen, die moto aus technischer Sicht zur Verfügung stehen (Systemarchitektur, Datenkategorien, Datenflüsse, technische und organisatorische Maßnahmen, Unterauftragsverarbeiter). Die rechtliche Prüfung von Notwendigkeit und Verhältnismäßigkeit sowie die abschließende Risikoentscheidung bleiben dem Verantwortlichen vorbehalten. Dieses Dokument enthält keine Rechtsberatung.
+4. Sämtliche Risikoeinstufungen in Abschnitt 7 sind **Einschätzungsvorschläge aus technischer Anbietersicht**. Der Verantwortliche hat sie unter Berücksichtigung seiner örtlichen Gegebenheiten (Anzahl der Kinder, Personalstruktur, Räumlichkeiten, Aufstellung der Geräte) eigenständig zu prüfen und gegebenenfalls anzupassen.
+
+Grundlage der technischen Angaben ist der Softwarestand des Systems zum 07.07.2026. Ergänzend wird auf folgende Dokumente der Dokumentenreihe verwiesen: Datenbestandsaufnahme (Datenkategorien und Speicherfristen), TOM-Inventar (Anlage zum AVV) und Unterauftragsverarbeiterliste.
+
+---
+
+## 2. Anlass: Warum eine DSFA voraussichtlich erforderlich ist
+
+Die Entscheidung, ob eine DSFA durchzuführen ist, trifft der Verantwortliche. Aus Sicht des Auftragsverarbeiters sprechen die folgenden Gesichtspunkte dafür, dass die Schwelle des Art. 35 Abs. 1 DSGVO (voraussichtlich hohes Risiko) erreicht wird:
+
+Nach den von den deutschen Aufsichtsbehörden übernommenen Leitlinien der Art.-29-Datenschutzgruppe (WP 248 rev.01) gilt als Faustregel, dass eine DSFA regelmäßig erforderlich ist, wenn zwei oder mehr der dort genannten neun Kriterien zutreffen. Auf den Einsatz von moto treffen mindestens zu:
+
+1. **Daten besonders schutzbedürftiger Betroffener** (Kriterium 7): Die Kernbetroffenen sind Grundschulkinder. Kinder werden in WP 248 ausdrücklich als schutzbedürftige Betroffene genannt.
+2. **Systematische Überwachung** (Kriterium 3): Das System erfasst Anwesenheits- und Aufenthaltsdaten der Kinder systematisch und fortlaufend über den gesamten Betreuungszeitraum jedes Betreuungstages.
+3. **Innovative Nutzung neuer Technologien** (Kriterium 8): Der Einsatz von NFC/RFID-Kiosk-Geräten zur Anwesenheitserfassung von Kindern in der Schule ist eine im Schulumfeld neuartige Technologie.
+4. Gegebenenfalls **Verarbeitung in großem Umfang** (Kriterium 5), wenn mehrere Schulen eines Trägers auf derselben Instanz betrieben werden. Die Einschätzung hierzu obliegt dem Verantwortlichen.
+
+Ergänzend ist auf die Positivlisten nach Art. 35 Abs. 4 DSGVO hinzuweisen:
+
+- Für die Schule als **öffentliche Stelle in NRW** ist primär die Liste der LDI NRW für den öffentlichen Bereich maßgeblich. [PRÜFEN: Der aktuelle Wortlaut der LDI-NRW-Liste ist vor Fertigstellung der DSFA direkt unter ldi.nrw.de abzurufen und die einschlägigen Positionen sind durch den Verantwortlichen zu dokumentieren.]
+- Als Auslegungshilfe kann die abgestimmte Liste der Datenschutzkonferenz (DSK) für den nicht-öffentlichen Bereich (Version 1.1, Stand 17.10.2018) herangezogen werden. Dort sind unter Nr. 4 die umfangreiche Verarbeitung von Aufenthaltsdaten natürlicher Personen und unter Nr. 8 die Erstellung von Bewegungsprofilen per RFID (dort am Beispiel Beschäftigter) als DSFA-pflichtige Verarbeitungen genannt. Beide Regelbeispiele liegen inhaltlich nahe an der hier betrachteten Verarbeitung; bei Kindern ist der Schutzbedarf höher anzusetzen als beim Referenzbeispiel Beschäftigte.
+
+Das Fehlen einer Verarbeitung auf einer Positivliste entbindet nicht von der eigenständigen Prüfung nach Art. 35 Abs. 1 DSGVO.
+
+---
+
+## 3. Systematische Beschreibung der Verarbeitung (Zuarbeit zu Art. 35 Abs. 7 lit. a DSGVO)
+
+### 3.1 Systemüberblick
+
+moto ist ein mandantenfähiges Anwesenheits- und Raumverwaltungssystem für den Offenen Ganztag an Grundschulen. Es besteht aus folgenden Komponenten:
+
+| Komponente | Beschreibung |
+|---|---|
+| Backend | Serveranwendung (Go), zentrale Geschäftslogik und Schnittstellen |
+| Datenbank | PostgreSQL 17 mit Row Level Security (RLS) zur Mandantentrennung, 15 fachliche Schemata |
+| Web-Frontend | Browseranwendung (Next.js) mit drei strikt getrennten Portalen: Schulportal (Personal/Verwaltung), Betreiberportal (moto), Elternportal |
+| Kiosk-Gerät (PyrePortal) | Raspberry-Pi-Gerät mit NFC/RFID-Leser in den Betreuungsräumen bzw. am Eingang; authentifiziert sich gegenüber dem Backend mit einem gerätespezifischen API-Schlüssel, Bedienhandlungen des Personals erfordern zusätzlich eine persönliche PIN |
+| Hosting | Server bei Hetzner (Rechenzentrum Nürnberg, Deutschland); TLS-Terminierung über den Reverse Proxy Caddy; DNS/CDN über Cloudflare; Monitoring über selbst gehostetes Grafana/Loki auf demselben Server |
+
+Der Serverbetrieb erfolgt vollständig auf Infrastruktur in Deutschland. Auf dem Kiosk-Gerät selbst werden keine personenbezogenen Datenbestände dauerhaft gespeichert; das Gerät dient als Erfassungs- und Anzeigegerät gegenüber dem Backend.
+
+### 3.2 Ablauf eines RFID-Scans (Kernverarbeitung)
+
+1. Jedes Kind erhält einen passiven RFID/NFC-Tag (Karte oder Anhänger). Auf dem Tag ist ausschließlich die herstellerseitige Tag-Kennung (UID) enthalten; es werden keine Namen, Fotos oder sonstigen Daten auf den Tag geschrieben.
+2. Beim Vorhalten des Tags an ein Kiosk-Gerät liest das Gerät die Tag-UID und übermittelt sie zusammen mit der Gerätekennung über eine TLS-verschlüsselte Verbindung an das Backend.
+3. Das Backend ordnet die Tag-UID der hinterlegten Person zu (Tabelle `users.rfid_cards` über `users.persons.tag_id`) und erzeugt bzw. schließt einen Anwesenheitsdatensatz: Check-in bzw. Check-out mit Datum, Uhrzeit, erfassendem Gerät und gegebenenfalls der bestätigenden Betreuungskraft (`active.attendance`: `student_id`, `date`, `check_in_time`, `check_out_time`, `checked_in_by`, `checked_out_by`, `device_id`, `yard_since`).
+4. Bei Raumwechseln innerhalb der Betreuung wird der aktuelle Aufenthalt als Besuchsdatensatz geführt (`active.visits`: `student_id`, `active_group_id`, `entry_time`, `exit_time`). Dieser Datensatz beantwortet die betriebliche Frage, in welchem Betreuungsangebot bzw. Raum sich ein Kind gerade befindet.
+5. Wird ein Tag gescannt, der keiner Person zugeordnet ist, wird der Scan mit Tag-UID, Gerät und Zeitpunkt in einer gesonderten Tabelle protokolliert (`audit.unregistered_tag_scans`), damit Fehlzuordnungen und verwaiste Tags aufgeklärt werden können.
+
+Das System kennt zwei vom Betreiber je Schule konfigurierbare Erfassungsmodi: einen detaillierten Modus mit Raumzuordnung und einen binären Modus (nur anwesend/abwesend am Eingang, ohne Raumauswahl am Kiosk). Der binäre Modus reduziert die erfasste Datentiefe und ist im Rahmen der Verhältnismäßigkeitsprüfung des Verantwortlichen relevant (siehe Abschnitt 6).
+
+Abgrenzung, die für die Risikobeschreibung wesentlich ist: Das System führt **keine Ortung** durch. Es gibt keine GPS-, Funkzellen- oder sonstige kontinuierliche Standortverfolgung. Erfasst werden ausschließlich diskrete Ereignisse (Scan an einem stationären Gerät zu einem Zeitpunkt). Die Tag-UID ist ein technischer Identifikator und **kein biometrisches Merkmal**; biometrische Daten im Sinne von Art. 9 Abs. 1 DSGVO werden nicht verarbeitet.
+
+### 3.3 Zwecke der Verarbeitung
+
+Zweck der Kernverarbeitung ist die Wahrnehmung der Aufsichtspflicht und die ordnungsgemäße Organisation der Betreuung im Offenen Ganztag, insbesondere:
+
+- verlässliche Feststellung, welche Kinder anwesend sind (Anwesenheitskontrolle, Vermisstenfall, Evakuierung),
+- Zuordnung der Kinder zu Betreuungsangeboten und Räumen zur Sicherstellung der Aufsicht,
+- Abwicklung der Abholung entsprechend den hinterlegten Abholregelungen und Abholberechtigungen,
+- Kommunikation mit Erziehungsberechtigten (Krankmeldungen, Nachrichten, Anmeldeverfahren),
+- Personaleinsatz und Arbeitszeiterfassung des Betreuungspersonals,
+- Nachweis- und Protokollzwecke (Zugriffs-, Änderungs- und Löschprotokolle).
+
+Die abschließende Zweckfestlegung obliegt dem Verantwortlichen.
+
+### 3.4 Betroffenengruppen
+
+1. Schülerinnen und Schüler (Kinder in der Betreuung, besonders schutzbedürftige Betroffene),
+2. Eltern und Erziehungsberechtigte (teils mit Elternportal-Zugang),
+3. Personal (pädagogische Mitarbeitende, Verwaltung, Vertretungen, Gäste/externe Kursleitungen),
+4. Mitarbeitende des Plattformbetreibers (eigener Kontotyp, nicht mandantengebunden),
+5. natürliche Personen mit nicht zugeordnetem RFID-Tag (unregistrierte Scans, potentiell re-identifizierbar über die Tag-UID).
+
+### 3.5 Datenkategorien (Zusammenfassung)
+
+Die vollständige, tabellengenaue Aufstellung enthält die Datenbestandsaufnahme (gesondertes Dokument der Reihe). Zusammengefasst:
+
+**Kinder:** Stammdaten (Name, Geburtsdatum, Klasse, Adresse), Gruppen- und Raumzugehörigkeit, Abholregelungen je Wochentag einschließlich Freitextangaben zur Abholung, Krank-/Entschuldigt-Status, Betreuernotizen, Foto (nur mit dokumentierter Einwilligung), Einwilligungsdatensätze, RFID-Tag-Kennung, Anwesenheits- und Aufenthaltsdaten (Check-in/Check-out, Raumbesuche), Feedback-Einträge (z. B. Mensa-Bewertung), Anmeldedaten aus dem Aufnahmeverfahren sowie **Gesundheitsangaben als Freitext** (`users.students.health_info`, siehe 3.6).
+
+**Erziehungsberechtigte:** Name, E-Mail, Adresse, Telefonnummern, Beziehung zum Kind, Abholberechtigung und Notfallkontakt-Kennzeichnung, je Kind-Beziehung gespeicherte Portalberechtigungen, Portalnachrichten mit der Betreuung, Anmeldedaten.
+
+**Personal:** Stammdaten, Beschäftigungsart und Arbeitszeitmodell, Zeiterfassung (Kommen/Gehen, Pausen), Abwesenheiten einschließlich Krankmeldungen, interne Notizen, RFID-Kennung, Konto- und Anmeldedaten.
+
+**Konto- und Protokolldaten (alle Kontoinhaber):** E-Mail, Benutzername, Passwort- und PIN-Hash (Argon2id, nie im Klartext), MFA-Zustand, Passkeys, Anmeldehistorie einschließlich IP-Adresse und User-Agent (`audit.auth_events`), Sitzungs- und Einladungstoken.
+
+**Protokolldaten (Auditschema):** Datenzugriffsprotokoll (`audit.data_access_log`: wer hat wann welche sensiblen Daten welchen Kindes eingesehen), Löschprotokoll, Importprotokoll, Änderungsprotokolle zu Erziehungsberechtigten- und Zeiterfassungsdaten, unregistrierte Tag-Scans.
+
+### 3.6 Besondere Kategorien personenbezogener Daten (Art. 9 DSGVO)
+
+Das System verarbeitet Gesundheitsdaten in folgendem Umfang:
+
+| Datum | Fundstelle | Einordnung |
+|---|---|---|
+| Gesundheitsangaben zum Kind (Freitext, z. B. Allergien, Medikation) | `users.students.health_info`; kann bereits im Anmeldeformular abgefragt werden (Formularfeld `student.health_info`) | Gesundheitsdaten, Art. 9 |
+| Krankmeldungen des Kindes (strukturiert, tagesbezogen) | `active.student_status_days` mit Status `sick`, optional mit Freitextnotiz; Altbestand `users.students.sick/sick_since` | Gesundheitsdaten, Art. 9 |
+| Krankmeldungen des Personals | `active.staff_absences` mit `absence_type = sick`, Freitextfelder `note`/`decision_note` | Gesundheitsdaten eines Beschäftigten, Art. 9 |
+
+Die Freitextfelder unterliegen keiner strukturierten inhaltlichen Validierung; welcher Detailgrad tatsächlich erfasst wird, hängt von den Eingaben des Personals bzw. der Eltern ab. Der Verantwortliche sollte den zulässigen Inhalt dieser Felder durch Dienstanweisung eingrenzen (siehe Risiko R8 und Abschnitt 8). Weitere Kategorien nach Art. 9 (biometrische Daten, ethnische Herkunft, Religion u. a.) werden nicht verarbeitet.
+
+### 3.7 Zugriffsmodell: wer sieht was
+
+Der Datenzugriff ist mehrstufig beschränkt. Die folgenden Mechanismen sind im System implementiert und in der TOM-Anlage im Einzelnen beschrieben:
+
+**Mandantenebene:** Jede Schule ist ein eigener Mandant. Die Trennung ist auf Datenbankebene durch Row Level Security erzwungen (Policies auf allen mandantenbezogenen Tabellen, dedizierte Datenbankrollen mit minimalen Rechten, transaktionsgebundene Mandantenkennung je Anfrage). Personal einer Schule kann technisch nicht auf Daten einer anderen Schule zugreifen.
+
+**Portalebene:** Drei getrennte Portale mit jeweils eigener Sitzung, eigenem Cookie und eigenem Berechtigungsumfang (Schulportal, Betreiberportal, Elternportal). Eltern-Sitzungen werden auf Schulportal-Routen serverseitig zurückgewiesen und umgekehrt.
+
+**Rollen- und Rechteebene innerhalb der Schule:** Rollen- und Berechtigungsmodell für Personal und Verwaltung; zusätzlich zwei datenschutzspezifische, je Schule konfigurierbare Sichtbarkeitsregeln:
+
+| Einstellung | Standardwert | Wirkung |
+|---|---|---|
+| `gdpr.attendance_log_enabled` | **aus** | Historisches Anwesenheitsprotokoll/Raumverlauf ist für Mitarbeitende standardmäßig gar nicht einsehbar; die Freischaltung ist eine bewusste Entscheidung der Schule |
+| `gdpr.attendance_log_scope` | nur Gruppenbetreuende | Bei Freischaltung sehen nur die Betreuungskräfte der jeweiligen Gruppe das Protokoll |
+| `gdpr.attendance_visible_days` | 30 Tage (max. 365) | Sichtbarkeitsfenster für An-/Abmeldezeiten |
+| `gdpr.room_detail_visible_days` | 7 Tage (max. 365) | Kürzeres Sichtbarkeitsfenster für Raumdetails |
+| `gdpr.student_data_scope` | nur Gruppenbetreuende | Wer vollständige Kinderdaten (Profil, Aufenthaltsort, Abholpläne, Datenschutzangaben) lesen darf; Schreibzugriff bleibt stets auf Gruppenbetreuende beschränkt |
+
+**Elternportal:** Die Berechtigung eines Elternkontos ist je Kind-Beziehung gespeichert (`users.students_guardians.permissions`). Eine Person kann für ein Kind volle Portalrechte und für ein anderes Kind nur eine Abholberechtigung besitzen. Operative Kennzeichen (Abholberechtigung, Notfallkontakt) begründen keinen Portalzugriff.
+
+**Kiosk-Gerät:** Das Gerät zeigt im Regelbetrieb nur den unmittelbaren Scan-Kontext. Bedienhandlungen des Personals erfordern die persönliche PIN.
+
+**Betreiberportal (moto):** Zugriff nur für Betreiberpersonal mit eigenem Kontotyp, MFA und gesondertem Audit-Log (`platform.operator_audit_log`). Betreiberzugriffe erfolgen ausschließlich zu Betriebs-, Wartungs- und Supportzwecken im Rahmen des AVV.
+
+**Zugriffsprotokollierung:** Lesezugriffe auf Anwesenheits- und Historiendaten werden im Datenzugriffsprotokoll (`audit.data_access_log`) festgehalten (handelndes Konto, Rolle, betroffenes Kind, Datenart, Zeitraum, Zeitpunkt).
+
+### 3.8 Speicher- und Löschfristen
+
+Die Löschung erfolgt automatisiert durch einen täglichen Bereinigungslauf (standardmäßig aktiviert, 02:00 Uhr). Die wesentlichen Fristen sind je Schule konfigurierbar; Standardwerte:
+
+| Datenart | Frist (Standard) | Konfigurationsrahmen |
+|---|---|---|
+| Besuchs- und Anwesenheitsdaten (`active.visits`, `active.attendance`) | 30 Tage | 1 bis 31 Tage; individuelle Einwilligung je Kind kann eine eigene Frist im selben Rahmen setzen |
+| Feedback-Einträge | 90 Tage | 1 bis 365 Tage |
+| Zeiterfassung Personal | 730 Tage (2 Jahre) | wählbar bis 2920 Tage, orientiert an arbeits- und steuerrechtlichen Aufbewahrungspflichten |
+| Abgeschlossene Betreuungsplan-Termine | 365 Tage | 1 bis 1825 Tage |
+| Abgelehnte Anmeldungen | 90 Tage | bis 730 Tage |
+| Eltern-Einladungslinks | 48 Stunden | bis 168 Stunden |
+| Abgelaufene Sitzungs-, Reset- und Einladungstoken | laufende technische Bereinigung | fest |
+
+**Offener Punkt Speicherbegrenzung:** Für die Tabellen des Auditschemas (`audit.auth_events`, `audit.data_access_log`, `audit.data_deletions`, `audit.data_imports`, `audit.guardian_changes`, `audit.unregistered_tag_scans`) sowie für Elternportal-Nachrichten (`users.parent_messages`) besteht derzeit **keine automatisierte Löschfrist**; `audit.work_session_edits` wird dagegen vom Löschlauf der Zeiterfassung miterfasst (Dokument 05, Abschnitt 6.6). Diese Protokolle dienen der Nachvollziehbarkeit (Eingabekontrolle, Art. 5 Abs. 2 DSGVO), die zeitlich unbegrenzte Aufbewahrung ist jedoch gegen den Grundsatz der Speicherbegrenzung (Art. 5 Abs. 1 lit. e DSGVO) abzuwägen. [PRÜFEN: Festlegung angemessener Aufbewahrungsfristen für Audit-Protokolle und Elternnachrichten, gemeinsam durch Verantwortlichen und Auftragsverarbeiter; Umsetzung im System ist als Maßnahme einzuplanen.] Siehe Risiko R9.
+
+### 3.9 Empfänger und Unterauftragsverarbeiter
+
+Empfänger innerhalb des Verantwortungsbereichs der Schule sind das Betreuungspersonal und die Verwaltung nach Maßgabe des Zugriffsmodells (3.7) sowie die Erziehungsberechtigten für die Daten ihres Kindes über das Elternportal.
+
+Unterauftragsverarbeiter und Dienstleister (Details in der gesonderten Unterauftragsverarbeiterliste):
+
+| Dienst | Rolle | Drittlandbezug |
+|---|---|---|
+| Hetzner (Nürnberg, Deutschland) | Serverhosting, gesamte Datenhaltung | Nein; Nachweis über AVV und Zertifikate des Rechenzentrumsbetreibers [PRÜFEN: aktueller Hetzner-AVV und Zertifikatsstand beizulegen] |
+| Cloudflare | DNS/CDN vor dem System; zusätzlich optionaler Bot-Schutz (Turnstile) für das öffentliche Anmeldeformular, standardmäßig deaktiviert | Ja (US-Anbieter); bei aktiviertem Turnstile erhält Cloudflare IP-Adresse und Browsersignale der Erziehungsberechtigten [PRÜFEN: Cloudflare-DPA und Nutzung der EU-Datenlokalisierung] |
+| GitHub/GHCR (Microsoft) | Quellcode, Build-Artefakte, Container-Images; kein Zugriff auf personenbezogene Produktivdaten | Ja (US-Anbieter) [PRÜFEN: DPF-Zertifizierungsstatus] |
+| SMTP-Versanddienst | Versand von Einladungs-, Reset-, MFA- und Benachrichtigungs-E-Mails (E-Mail-Adressen, Namen, Token, ggf. Kindername in Anmeldebenachrichtigungen) | [PRÜFEN: konkreter SMTP-Anbieter und Serverstandort sind zu benennen] |
+| Sentry (Fehlerdiagnose, optional) | Fehler- und Ausnahmeberichte; im System ist eine Bereinigung implementiert, die Autorisierungs-Header, Cookies, IP-Adresse, E-Mail und Benutzername vor Versand entfernt | [PRÜFEN: tatsächliche Nutzung der EU-Region im Sentry-Konto] |
+| PostHog (Nutzungsanalyse, optional) | Nutzungsereignisse des Personals im Frontend; als EU-Cloud konfiguriert | [PRÜFEN: produktiver Konfigurationswert und Event-Inhalte, insbesondere Ausschluss von Kinderdaten in Ereignis-Eigenschaften] |
+| Grafana/Loki/Prometheus (selbst gehostet) | Monitoring und Protokollaggregation auf eigener Infrastruktur; IP-Maskierung und Entfernung von Zugangsdaten aus Zugriffslogs implementiert | Nein |
+
+Anwendungsprotokolle enthalten auf Info-Ebene keine Klarnamen von Kindern (nur technische Kennungen); dies ist als Projektregel im Entwicklungsprozess verankert.
+
+### 3.10 Rechtsgrundlage (Kontextinformation für den Verantwortlichen)
+
+Die Bestimmung der Rechtsgrundlage obliegt dem Verantwortlichen. Nach dem Einsatzkonzept ist für den Kernbetrieb (Anwesenheitserfassung, Raumzuordnung, Abholorganisation) folgende Grundlage vorgesehen:
+
+- **Art. 6 Abs. 1 lit. e DSGVO** (Wahrnehmung einer im öffentlichen Interesse liegenden Aufgabe) in Verbindung mit **§§ 120 bis 122 SchulG NRW**; die Zulässigkeit der einzelnen Datenkategorien richtet sich nach der **VO-DV I** (Verordnung über die zur Verarbeitung zugelassenen Daten von Schülerinnen und Schülern sowie Eltern). [PRÜFEN: Abgleich der in Abschnitt 3.5 aufgeführten Datenkategorien mit dem Datenkatalog der VO-DV I durch den Verantwortlichen; insbesondere für Foto, Gesundheitsangaben und Feedback-Einträge ist zu klären, ob eine Einwilligung nach Art. 6 Abs. 1 lit. a bzw. Art. 9 Abs. 2 lit. a DSGVO als ergänzende Grundlage erforderlich ist.]
+- Für die Verarbeitung von **Gesundheitsdaten** (3.6) ist zusätzlich eine Ausnahme nach **Art. 9 Abs. 2 DSGVO** erforderlich. [PRÜFEN: Einschlägige lit. (insbesondere lit. a Einwilligung oder landesrechtliche Grundlage) durch den Verantwortlichen festlegen und dokumentieren.]
+- Einzelne Funktionen stützen sich bereits systemseitig auf dokumentierte **Einwilligungen** (Foto: `photo_consent_given_at/by`; Datenschutz-Einwilligung mit individueller Aufbewahrungsfrist: `users.privacy_consents`).
+- Für die Zeiterfassung des Personals kommt Art. 6 Abs. 1 lit. b und c DSGVO in Verbindung mit arbeitsrechtlichen Vorschriften in Betracht; die Einordnung obliegt dem Verantwortlichen bzw. dem Träger als Arbeitgeber.
+
+Da die Kernverarbeitung auf Art. 6 Abs. 1 lit. e DSGVO gestützt werden soll, ist das Widerspruchsrecht nach Art. 21 DSGVO in der Betroffeneninformation zu berücksichtigen; die Bewertung obliegt dem Verantwortlichen.
+
+---
+
+## 4. Angaben zur Notwendigkeit und Verhältnismäßigkeit (Zuarbeit zu Art. 35 Abs. 7 lit. b DSGVO)
+
+Die Bewertung von Notwendigkeit und Verhältnismäßigkeit ist Sache des Verantwortlichen. Aus technischer Sicht werden folgende Gestaltungsmerkmale des Systems zur Verfügung gestellt, die in diese Bewertung einfließen können:
+
+1. **Abstufbare Datentiefe:** Der binäre Erfassungsmodus (nur anwesend/abwesend) steht als datensparsamere Alternative zum detaillierten Modus mit Raumzuordnung zur Verfügung. Die Schule kann den Modus wählen, der ihrem Aufsichtskonzept entspricht.
+2. **Standardmäßig restriktive Sichtbarkeit:** Das historische Anwesenheitsprotokoll ist ab Werk deaktiviert; Sichtbarkeitsfenster und berechtigter Personenkreis sind eng voreingestellt und nur bewusst erweiterbar (3.7).
+3. **Kurze Regelaufbewahrung der Bewegungsdaten:** Besuchs- und Anwesenheitsdaten werden standardmäßig nach 30 Tagen automatisiert gelöscht; die Obergrenze liegt bei 31 Tagen (3.8). Eine langfristige Historie der Aufenthalte entsteht im Regelbetrieb nicht.
+4. **Datenarme Tags:** Auf dem RFID-Tag selbst befinden sich keine personenbezogenen Daten; die Zuordnung erfolgt ausschließlich serverseitig. Ein verlorener Tag offenbart für sich genommen keine Daten und kann im System deaktiviert werden.
+5. **Zweckgetrennte Portale und Berechtigungen:** Eltern sehen nur die eigenen Kinder gemäß gespeicherter Beziehung; Personal sieht standardmäßig nur die eigene Gruppe; der Betreiber hat keinen fachlichen Regelzugriff.
+6. **Alternativenbetrachtung:** Die Alternative zur elektronischen Erfassung ist die papiergebundene Anwesenheitsliste. Deren Schwächen (fehlende Zugriffskontrolle, keine Löschautomatik, keine Protokollierung der Einsichtnahme, Verlustrisiko) sollten in der Verhältnismäßigkeitsabwägung des Verantwortlichen den Risiken der elektronischen Verarbeitung gegenübergestellt werden. Die Abwägung selbst trifft der Verantwortliche.
+
+---
+
+## 5. Methodik der Risikoanalyse
+
+Die Risiken werden aus der **Sicht der betroffenen Personen** betrachtet (Erwägungsgründe 75 und 76 DSGVO), nicht aus Sicht der Organisation. Bewertet werden je Risiko:
+
+- **Eintrittswahrscheinlichkeit** unter Berücksichtigung der implementierten Maßnahmen: gering / mittel / hoch,
+- **Schwere** der möglichen Folgen für die Betroffenen: gering / mittel / hoch,
+- die **implementierten Abhilfemaßnahmen** aus dem TOM-Inventar (Anlage zum AVV, dort mit Fundstellen im Quellcode belegt),
+- das aus technischer Sicht verbleibende **Restrisiko**.
+
+Die Einstufungen sind Vorschläge des Auftragsverarbeiters auf Grundlage der Systemarchitektur. Örtliche Faktoren (z. B. Geräteaufstellung, Personalfluktuation, Schulgröße) kann nur der Verantwortliche bewerten.
+
+---
+
+## 6. Risikoanalyse aus Betroffenensicht mit Abhilfemaßnahmen (Zuarbeit zu Art. 35 Abs. 7 lit. c und d DSGVO)
+
+### R1: Erstellung von Bewegungs- und Verhaltensprofilen von Kindern
+
+**Beschreibung:** Die fortlaufende Erfassung von Check-in, Check-out und Raumbesuchen könnte über längere Zeiträume zu einem Profil verdichtet werden (wann kommt das Kind, mit welchen Angeboten verbringt es Zeit, wann wird es abgeholt). Ein solches Profil beträfe ein Kind und wäre geeignet, Rückschlüsse auf Familienverhältnisse und Verhalten zu ermöglichen.
+
+**Betroffene:** Kinder (besonders schutzbedürftig). **Schwere:** hoch. **Eintrittswahrscheinlichkeit (mit Maßnahmen):** gering.
+
+**Implementierte Abhilfemaßnahmen:**
+
+- Automatisierte Löschung der Besuchs- und Anwesenheitsdaten nach standardmäßig 30, maximal 31 Tagen; eine langfristige Profilbildung ist damit datenseitig ausgeschlossen, sofern die Bereinigung aktiv ist (Standard: aktiv).
+- Historisches Anwesenheitsprotokoll standardmäßig vollständig deaktiviert (`gdpr.attendance_log_enabled = aus`); bei Aktivierung Sichtbarkeit nur für Gruppenbetreuende und nur innerhalb der konfigurierten Fenster (30 Tage An-/Abmeldezeiten, 7 Tage Raumdetails).
+- Binärer Erfassungsmodus als datensparsamere Betriebsart ohne Raumzuordnung wählbar.
+- Keine Ortungstechnik; ausschließlich diskrete Scan-Ereignisse an stationären Geräten (3.2).
+- Jeder Lesezugriff auf Historiendaten wird im Datenzugriffsprotokoll festgehalten und ist damit nachträglich kontrollierbar.
+
+**Restrisiko:** gering, solange die Standardkonfiguration beibehalten bzw. Abweichungen dokumentiert begründet werden. Die Entscheidung über Erfassungsmodus und Protokollfreischaltung ist eine risikorelevante Konfigurationsentscheidung des Verantwortlichen und sollte in der DSFA ausdrücklich festgehalten werden.
+
+### R2: Unberechtigte Kenntnisnahme durch internes Personal
+
+**Beschreibung:** Betreuungs- oder Verwaltungspersonal könnte Daten von Kindern einsehen, für die keine dienstliche Erforderlichkeit besteht (Kinder anderer Gruppen, Gesundheitsangaben, Abholregelungen, Historie).
+
+**Betroffene:** Kinder, Erziehungsberechtigte. **Schwere:** mittel bis hoch (bei Gesundheits- und Sorgerechtskontexten hoch). **Eintrittswahrscheinlichkeit (mit Maßnahmen):** gering bis mittel.
+
+**Implementierte Abhilfemaßnahmen:**
+
+- Rollen- und Berechtigungsmodell; Sichtbarkeit vollständiger Kinderdaten standardmäßig auf Gruppenbetreuende beschränkt (`gdpr.student_data_scope`), Schreibzugriff stets auf Gruppenbetreuende beschränkt.
+- Datenzugriffsprotokoll (`audit.data_access_log`) über Lesezugriffe auf sensible Daten mit handelndem Konto, Rolle, Kind und Zeitraum; abschreckende und aufklärende Wirkung.
+- Persönliche Konten mit Passwort (Argon2id-Hashing), optional Passkeys; MFA-Subsystem; konfigurierbare Kontosperre nach Fehlversuchen; PIN-Pflicht für Personalaktionen am Kiosk.
+- Änderungsprotokolle für Erziehungsberechtigten- und Zeiterfassungsdaten (append-only).
+
+**Restrisiko:** mittel. Technische Maßnahmen begrenzen den Zugriff, ersetzen aber nicht organisatorische Maßnahmen des Verantwortlichen: Vertraulichkeitsverpflichtung nach Art. 29, 32 Abs. 4 DSGVO, Dienstanweisung zur Nutzung, regelmäßige Kontrolle des Zugriffsprotokolls, zeitnahe Deaktivierung ausscheidender Mitarbeitender. Diese Maßnahmen sind in der DSFA als Pflichten des Verantwortlichen aufzuführen.
+
+### R3: Unberechtigter Zugriff von außen (Angriff, Diebstahl von Zugangsdaten)
+
+**Beschreibung:** Externe Angreifer könnten über gestohlene Zugangsdaten, Schwachstellen oder Brute-Force-Angriffe Zugriff auf Kinder- und Elterndaten erlangen. Wegen der Datenkategorien (Kinderdaten, Abholregelungen, Adressen, Gesundheitsangaben) wären die Folgen erheblich.
+
+**Betroffene:** alle Gruppen. **Schwere:** hoch. **Eintrittswahrscheinlichkeit (mit Maßnahmen):** gering.
+
+**Implementierte Abhilfemaßnahmen:**
+
+- Transportverschlüsselung durchgehend (TLS am Reverse Proxy; Datenbankverbindungen mit SSL und Zertifikatsprüfung in Produktion).
+- Passwort-Hashing mit Argon2id (64 MB Speicher, 3 Iterationen, Salt, zeitkonstanter Vergleich); PINs ausschließlich als Hash.
+- MFA für Schul- und Betreiberportal einschließlich E-Mail-Challenges, Recovery und begrenzt gültiger vertrauenswürdiger Geräte; Kontosperre nach konfigurierbarer Fehlversuchsschwelle.
+- Kurzlebige JWT-Zugriffstoken (15 Minuten) mit Refresh-Mechanismus; kein statisches Sitzungsgeheimnis im Code, Startabbruch bei fehlender sicherer Konfiguration.
+- Rate Limiting auf Anmelde-, Passwort-Reset- und Anmeldeformular-Endpunkten.
+- Kiosk-Geräte authentifizieren sich mit gerätespezifischem API-Schlüssel (zeitkonstanter Vergleich, Statusprüfung); zusätzlich Personal-PIN für Bedienaktionen.
+- Least-Privilege-Datenbankrollen; der Anwendungsserver verbindet sich nicht als Superuser.
+- Secrets ausschließlich verschlüsselt verwaltet (SOPS/age), keine Klartext-Zugangsdaten im Code; Anmeldehistorie mit IP und Ereignistyp (`audit.auth_events`) zur Angriffserkennung.
+- Sicherheitsrelevante Header (Autorisierung, Cookies, Geräteschlüssel, PIN) werden aus Zugriffsprotokollen entfernt, IP-Adressen dort maskiert.
+
+**Restrisiko:** gering bis mittel. Kein System ist gegen Angriffe vollständig geschützt; das Restrisiko wird zusätzlich durch Meldeprozesse (Art. 33, 34 DSGVO, im AVV geregelt) und Wiederherstellungsfähigkeit (R10) begrenzt. [PRÜFEN: Turnus externer Sicherheitsüberprüfungen/Penetrationstests festlegen und dokumentieren; im Repository ist kein solcher Nachweis enthalten.]
+
+### R4: Mandantenübergreifender Datenzugriff (Vermischung zwischen Schulen)
+
+**Beschreibung:** Auf einer gemeinsam betriebenen Instanz könnten Daten einer Schule für Personal einer anderen Schule sichtbar werden (Programmierfehler, fehlerhafte Abfrage).
+
+**Betroffene:** Kinder, Eltern, Personal aller Schulen der Instanz. **Schwere:** hoch. **Eintrittswahrscheinlichkeit (mit Maßnahmen):** gering.
+
+**Implementierte Abhilfemaßnahmen:**
+
+- Row Level Security auf Datenbankebene mit erzwungenen Policies (`FORCE ROW LEVEL SECURITY`) auf allen mandantenbezogenen Tabellen; die Mandantentrennung hängt damit nicht allein von der Korrektheit des Anwendungscodes ab.
+- Getrennte Datenbankrollen: die reguläre Anwendungsrolle unterliegt zwingend der RLS; eine RLS-umgehende Rolle ist auf Betreiber-, Migrations- und Wartungspfade beschränkt.
+- Je Anfrage transaktionsgebundene Mandantenkennung mit automatischem Rollback bei Serverfehlern; Mandantenkennung als Pflichtfeld auf allen betroffenen Datenmodellen.
+- Portaltrennung mit eigenem Sitzungs-Cookie je Portal; Token mit Eltern-Geltungsbereich werden auf Schulrouten serverseitig zurückgewiesen (mehrstufige Absicherung).
+- Automatisierte Architektur-Prüfungen im Entwicklungsprozess, die das Umgehen der Datenzugriffsschicht verhindern.
+
+**Restrisiko:** gering. Die Kombination aus datenbankseitiger Erzwingung und Anwendungslogik gilt als belastbare Trennung; verbleibendes Risiko sind Implementierungsfehler in Betreiber-Funktionen, die durch das Betreiber-Audit-Log nachvollziehbar bleiben.
+
+### R5: Verknüpfbarkeit und Re-Identifizierung über die RFID-Tag-Kennung
+
+**Beschreibung:** Die Tag-UID ist ein pseudonymes, dauerhaftes Kennzeichen. Wer die UID eines Kindes kennt und Lesezugriff auf Scandaten erlangt, kann Ereignisse einem Kind zuordnen. UIDs handelsüblicher Tags können zudem von Dritten mit eigenem Lesegerät im Vorbeigehen ausgelesen werden. Nicht zugeordnete Scans (`audit.unregistered_tag_scans`) betreffen potentiell unbeteiligte Dritte und sind derzeit ohne Löschfrist gespeichert.
+
+**Betroffene:** Kinder, Personal, Dritte mit RFID-Tags. **Schwere:** mittel. **Eintrittswahrscheinlichkeit:** gering.
+
+**Implementierte Abhilfemaßnahmen:**
+
+- Auf dem Tag befinden sich keine personenbezogenen Daten; die Zuordnung UID zu Person existiert nur serverseitig und unterliegt dem Zugriffsmodell (3.7) und der Mandantentrennung (R4).
+- Die Zuordnungstabelle ist nur für berechtigtes Verwaltungspersonal zugänglich; Scans ohne Zuordnung werden getrennt gespeichert und erst durch berechtigte Auflösung einer Person zugeordnet.
+- Verlorene oder entwendete Tags können deaktiviert und neu ausgegeben werden, ohne dass Altdaten auf dem Tag verbleiben.
+- Die kurze Aufbewahrung der Bewegungsdaten (R1) begrenzt den Wert einer erbeuteten UID erheblich.
+
+**Restrisiko:** gering bis mittel. Das Auslesen der bloßen UID durch Dritte lässt sich bei passiven Tags technisch nicht ausschließen, führt aber ohne Zugriff auf die serverseitige Zuordnung nicht zu einer Identifizierung. [PRÜFEN: Löschfrist für `audit.unregistered_tag_scans` festlegen; siehe R9.]
+
+### R6: Datenabfluss an Dritte und Drittlandübermittlung
+
+**Beschreibung:** Über eingebundene Dienstleister könnten personenbezogene Daten in Drittländer gelangen oder von Dritten eingesehen werden (E-Mail-Versand, CDN, optionale Diagnose- und Analysedienste, Bot-Schutz beim öffentlichen Anmeldeformular).
+
+**Betroffene:** vor allem Erziehungsberechtigte (E-Mail, IP-Adresse), mittelbar Kinder (Namen in Benachrichtigungen). **Schwere:** mittel. **Eintrittswahrscheinlichkeit:** mittel (dienstabhängig).
+
+**Implementierte Abhilfemaßnahmen:**
+
+- Primäre Datenhaltung vollständig auf Servern in Deutschland (Hetzner Nürnberg); Monitoring und Protokollaggregation selbst gehostet, kein Log-Versand an Dritte.
+- Bot-Schutz (Cloudflare Turnstile) standardmäßig deaktiviert und nur je Schule aktivierbar; Diagnose- (Sentry) und Analysediensten (PostHog) sind optional; für Sentry ist eine automatische Entfernung von IP-Adresse, E-Mail, Benutzername und Autorisierungsdaten vor Versand implementiert; PostHog ist auf die EU-Cloud konfiguriert.
+- Schriftarten werden zur Bauzeit eingebettet und selbst ausgeliefert; zur Laufzeit erfolgt kein Abruf bei Google.
+- Unterauftragsverarbeiter sind in der gesonderten Liste mit Zweck, Datenkategorien und Drittlandbewertung dokumentiert; Einbindung neuer Unterauftragsverarbeiter nach Maßgabe des AVV (Informations- und Widerspruchsverfahren).
+
+**Restrisiko:** mittel, bis die in der Unterauftragsverarbeiterliste markierten Punkte geklärt sind: [PRÜFEN: SMTP-Anbieter und Serverstandort; Cloudflare-Datenlokalisierung; Sentry-Projektregion; produktive PostHog-Konfiguration und Event-Inhalte; DPF-Status von GitHub/Microsoft; Ausschluss eines CDN-Rückfalls bei der Schriftarten-Auslieferung.] Der Verantwortliche sollte die Aktivierung der optionalen Dienste (Turnstile, Sentry, PostHog) als eigene Entscheidung in der DSFA dokumentieren.
+
+### R7: Missbrauch oder Verlust des Kiosk-Geräts
+
+**Beschreibung:** Ein Kiosk-Gerät könnte entwendet, manipuliert oder durch Unbefugte (auch Kinder) bedient werden; der Geräteschlüssel könnte extrahiert und für API-Zugriffe missbraucht werden.
+
+**Betroffene:** Kinder. **Schwere:** mittel. **Eintrittswahrscheinlichkeit:** gering.
+
+**Implementierte Abhilfemaßnahmen:**
+
+- Keine dauerhafte lokale Speicherung personenbezogener Datenbestände auf dem Gerät; das Gerät zeigt nur den unmittelbaren Scan-Kontext.
+- Gerätespezifischer API-Schlüssel mit serverseitiger Statusprüfung: ein kompromittiertes Gerät kann zentral deaktiviert werden; der Schlüssel berechtigt nur zu den Kiosk-Endpunkten, nicht zum Verwaltungszugriff.
+- Bedienaktionen des Personals (über den reinen Scan hinaus) erfordern die persönliche PIN; PIN-Vergleich zeitkonstant, PIN-Speicherung nur als Hash.
+- Geräteaktivität wird serverseitig protokolliert (letzter Kontakt, ohne personenbezogene Inhalte im Log).
+
+**Restrisiko:** gering. Die physische Sicherung der Geräte (Aufstellort, Befestigung, Beaufsichtigung) liegt im Verantwortungsbereich der Schule und ist in der DSFA als organisatorische Maßnahme des Verantwortlichen zu ergänzen.
+
+### R8: Unbefugte Offenlegung von Gesundheitsdaten (Art. 9)
+
+**Beschreibung:** Gesundheitsangaben zum Kind (Freitext, Krankmeldungen) und Krankmeldungen des Personals sind besonders sensibel. Risiken sind die Einsichtnahme durch nicht erforderliche Personen und die unkontrollierte Anreicherung der Freitextfelder mit übermäßigen Details.
+
+**Betroffene:** Kinder, Personal. **Schwere:** hoch. **Eintrittswahrscheinlichkeit (mit Maßnahmen):** gering bis mittel.
+
+**Implementierte Abhilfemaßnahmen:**
+
+- Zugriff auf vollständige Kinderdaten einschließlich Gesundheitsangaben standardmäßig nur für Gruppenbetreuende (`gdpr.student_data_scope`); Lesezugriffe werden protokolliert.
+- Krankmeldungen des Kindes sind tagesbezogen strukturiert; das Elternportal erlaubt die Meldung nur für Kinder mit entsprechender gespeicherter Berechtigung der meldenden Person.
+- Personal-Abwesenheiten unterliegen dem Rollenmodell; Genehmigungsvermerke werden personenbezogen protokolliert.
+- Mandantentrennung, Verschlüsselung und Zugangskontrollen gemäß R3/R4 gelten uneingeschränkt auch für diese Daten.
+
+**Restrisiko:** mittel. Freitextfelder lassen sich technisch nicht auf das Erforderliche begrenzen. Der Verantwortliche sollte per Dienstanweisung festlegen, welche Angaben in `health_info` und in Notizfeldern zulässig sind (Datenminimierung bei der Eingabe), und die Rechtsgrundlage nach Art. 9 Abs. 2 DSGVO dokumentieren (3.10). [PRÜFEN: Rechtsgrundlage Art. 9 Abs. 2 und Eingaberichtlinie des Verantwortlichen.]
+
+### R9: Überlange Speicherung von Protokoll- und Nachrichtendaten
+
+**Beschreibung:** Audit-Protokolle (Anmeldehistorie mit IP-Adressen, Datenzugriffs-, Änderungs- und Löschprotokolle, unregistrierte Tag-Scans) sowie Elternportal-Nachrichten haben derzeit keine automatisierte Löschfrist. Aus Betroffenensicht entsteht das Risiko einer zeitlich unbegrenzten Nachvollziehbarkeit von Verhalten (Anmeldezeiten des Personals, Kommunikationsinhalte der Eltern).
+
+**Betroffene:** Personal, Eltern, mittelbar Kinder (Nachrichteninhalte). **Schwere:** mittel. **Eintrittswahrscheinlichkeit:** hoch (der Zustand besteht, solange keine Frist definiert ist).
+
+**Implementierte Abhilfemaßnahmen:**
+
+- Die betroffenen Tabellen unterliegen der Mandantentrennung, dem Rollenmodell und sind append-only; ein fachlicher Regelzugriff auf sie besteht nicht.
+- Anmeldeprotokolle enthalten keine Klartext-Zugangsdaten; Anwendungslogs enthalten auf Info-Ebene keine Kindernamen; IP-Maskierung in Zugriffslogs des Reverse Proxy.
+- Für alle übrigen Datenarten bestehen automatisierte, konfigurierbare Löschfristen (3.8), der Bereinigungsmechanismus ist vorhanden und erprobt.
+
+**Restrisiko:** mittel und derzeit nicht abschließend behandelt. Dies ist der wesentliche bekannte offene Punkt dieser Zuarbeit. [PRÜFEN: Verantwortlicher und Auftragsverarbeiter legen Aufbewahrungsfristen für das Auditschema und Elternnachrichten fest (Vorschlagsbasis: Erforderlichkeit für Nachweiszwecke nach Art. 5 Abs. 2 DSGVO gegen Speicherbegrenzung nach Art. 5 Abs. 1 lit. e DSGVO abwägen); die technische Umsetzung wird von moto als Maßnahme eingeplant und der Umsetzungsstand dem Verantwortlichen mitgeteilt.]
+
+### R10: Verlust von Verfügbarkeit oder Integrität (Auswirkung auf die Aufsicht)
+
+**Beschreibung:** Fällt das System aus oder werden Daten verfälscht, kann die Schule sich bei der Aufsicht nicht auf die Anwesenheitsdaten verlassen. Aus Betroffenensicht droht mittelbar eine Gefährdung des Kindeswohls (Kind gilt fälschlich als anwesend oder abwesend).
+
+**Betroffene:** Kinder. **Schwere:** hoch (mittelbar). **Eintrittswahrscheinlichkeit:** gering.
+
+**Implementierte Abhilfemaßnahmen:**
+
+- Automatisierte Datenbanksicherung vor jeder Softwareaktualisierung mit definiertem Rollback-Verfahren; Abbruch der Aktualisierung bei fehlgeschlagener Sicherung; Sicherungsaufbewahrung mit Rotationsregel; restriktive Dateiberechtigungen auf Sicherungen.
+- Aktive Verfügbarkeitsüberwachung (Health-Checks im Minutentakt, Alarmierung), selbst gehostetes Monitoring.
+- Konsistenzmechanismen auf Datenbankebene (Transaktionen je Anfrage mit automatischem Rollback bei Fehlern); Änderungsprotokolle ermöglichen die Nachvollziehbarkeit nachträglicher Korrekturen.
+
+**Restrisiko:** gering. Organisatorische Rückfallebene des Verantwortlichen (Verfahren bei Systemausfall, z. B. papiergebundene Notliste) sollte im Betreuungskonzept beschrieben und in der DSFA erwähnt werden.
+
+### Risikoübersicht
+
+| Nr. | Risiko | Schwere | Eintrittswahrscheinlichkeit (mit Maßnahmen) | Restrisiko (Vorschlag) |
+|---|---|---|---|---|
+| R1 | Bewegungs-/Verhaltensprofile von Kindern | hoch | gering | gering |
+| R2 | Unberechtigte interne Kenntnisnahme | mittel bis hoch | gering bis mittel | mittel |
+| R3 | Externer Angriff / Zugangsdatendiebstahl | hoch | gering | gering bis mittel |
+| R4 | Mandantenübergreifender Zugriff | hoch | gering | gering |
+| R5 | Verknüpfbarkeit über Tag-UID | mittel | gering | gering bis mittel |
+| R6 | Datenabfluss an Dritte / Drittland | mittel | mittel | mittel (bis Klärung der Prüfpunkte) |
+| R7 | Missbrauch/Verlust Kiosk-Gerät | mittel | gering | gering |
+| R8 | Offenlegung von Gesundheitsdaten | hoch | gering bis mittel | mittel |
+| R9 | Überlange Speicherung von Protokolldaten | mittel | hoch | mittel (offener Punkt) |
+| R10 | Verfügbarkeits-/Integritätsverlust | hoch | gering | gering |
+
+---
+
+## 7. Restrisiko und Konsultation (Art. 36 DSGVO)
+
+Nach Einschätzung des Auftragsverarbeiters lässt sich bei Beibehaltung der restriktiven Standardkonfiguration und Umsetzung der beim Verantwortlichen liegenden organisatorischen Maßnahmen kein fortbestehendes hohes Restrisiko erkennen. Diese Einschätzung ersetzt nicht die eigene Bewertung des Verantwortlichen. Kommt der Verantwortliche in seiner DSFA zu einem fortbestehenden hohen Restrisiko, ist vor Aufnahme bzw. Fortführung der Verarbeitung die Aufsichtsbehörde zu konsultieren (Art. 36 DSGVO). Zuständige Aufsichtsbehörde für die Schule ist die Landesbeauftragte für Datenschutz und Informationsfreiheit Nordrhein-Westfalen (LDI NRW). moto unterstützt eine etwaige Konsultation im Rahmen von Art. 28 Abs. 3 lit. f DSGVO mit den erforderlichen technischen Auskünften.
+
+---
+
+## 8. Beim Verantwortlichen liegende Maßnahmen und Entscheidungen
+
+Für die Vollständigkeit der DSFA weist der Auftragsverarbeiter auf folgende Punkte hin, die nur der Verantwortliche regeln kann:
+
+1. Einbindung des behördlichen Datenschutzbeauftragten der Schule bzw. des Trägers (Art. 35 Abs. 2 DSGVO) und Entscheidung über die Einholung des Standpunkts betroffener Personen bzw. ihrer Vertretungen, etwa der Schulkonferenz oder Elternvertretung (Art. 35 Abs. 9 DSGVO).
+2. Abgleich der Datenkategorien mit der VO-DV I und Dokumentation der Rechtsgrundlagen einschließlich Art. 9 Abs. 2 DSGVO für Gesundheitsdaten (3.10).
+3. Entscheidung und Begründung zu risikorelevanten Konfigurationen: Erfassungsmodus (binär/detailliert), Freischaltung und Reichweite des Anwesenheitsprotokolls, Sichtbarkeitsumfang der Kinderdaten, Aufbewahrungsfristen innerhalb der konfigurierbaren Rahmen, Aktivierung optionaler Dienste (Bot-Schutz, Fehlerdiagnose, Nutzungsanalyse).
+4. Organisatorische Maßnahmen vor Ort: Vertraulichkeitsverpflichtungen des Personals, Dienstanweisung zur Systemnutzung und zu zulässigen Inhalten von Freitextfeldern, Verfahren zur zeitnahen Deaktivierung ausscheidender Nutzerkonten, regelmäßige Auswertung des Datenzugriffsprotokolls, physische Sicherung der Kiosk-Geräte, Ausfallverfahren.
+5. Betroffeneninformation nach Art. 13/14 DSGVO einschließlich Hinweis auf das Widerspruchsrecht nach Art. 21 DSGVO sowie Verfahren zur Bedienung der Betroffenenrechte (Auskunft, Berichtigung, Löschung); moto stellt hierfür die technischen Funktionen bereit (u. a. Datenänderungsanfragen der Eltern, dokumentierte Löschung mit Löschprotokoll).
+6. Aufnahme der Verarbeitung in das Verzeichnis der Verarbeitungstätigkeiten des Verantwortlichen (Art. 30 Abs. 1 DSGVO).
+7. Überprüfung und Fortschreibung der DSFA bei wesentlichen Änderungen (Art. 35 Abs. 11 DSGVO). moto informiert den Verantwortlichen über wesentliche Systemänderungen, die die Beschreibung in Abschnitt 3 berühren, und aktualisiert diese Zuarbeit entsprechend.
+
+---
+
+## 9. Anlagen und referenzierte Dokumente
+
+1. Auftragsverarbeitungsvertrag zwischen [NAME SCHULTRÄGER] und moto [RECHTSFORM UND ADRESSE] vom [DATUM AVV], einschließlich TOM-Anlage
+2. Datenbestandsaufnahme (Datenkategorien, Tabellen, Speicherfristen), gesondertes internes Dokument; Speicher- und Löschfristen zusätzlich in Dokument 05 (Löschkonzept) der Reihe
+3. TOM-Inventar mit Quellcode-Fundstellen, Dokument 02 der Reihe
+4. Unterauftragsverarbeiterliste, Dokument 03 der Reihe
+5. Verzeichnis der Verarbeitungstätigkeiten, Dokument 04 der Reihe
+6. Liste der LDI NRW nach Art. 35 Abs. 4 DSGVO für den öffentlichen Bereich [AKTUELLE FASSUNG BEIFÜGEN]
+7. DSK-Kurzpapier Nr. 5 (Datenschutz-Folgenabschätzung, Stand 17.12.2018) und DSK-Liste für den nicht-öffentlichen Bereich (Version 1.1, Stand 17.10.2018) als methodische Referenz
+
+---
+
+## 10. Offene Punkte (Sammelübersicht)
+
+| Nr. | Punkt | Zuständig |
+|---|---|---|
+| 1 | Aktuellen Wortlaut der LDI-NRW-Positivliste (öffentlicher Bereich) beschaffen und einschlägige Positionen dokumentieren | Verantwortlicher, mit Unterstützung moto |
+| 2 | Abgleich der Datenkategorien mit der VO-DV I; Rechtsgrundlage für Foto, Gesundheitsangaben, Feedback klären (Art. 6 Abs. 1 lit. a, Art. 9 Abs. 2 DSGVO) | Verantwortlicher |
+| 3 | Aufbewahrungsfristen für Auditschema (`audit.*`) und Elternnachrichten festlegen; technische Umsetzung einplanen | gemeinsam; Umsetzung moto |
+| 4 | SMTP-Anbieter und Serverstandort benennen und in der Unterauftragsverarbeiterliste nachtragen | moto |
+| 5 | Cloudflare: DPA-Konditionen und Nutzung der EU-Datenlokalisierung prüfen (relevant bei aktiviertem Turnstile) | moto |
+| 6 | Sentry: tatsächliche Projektregion (EU) im Konto verifizieren | moto |
+| 7 | PostHog: produktiven Konfigurationswert (EU-Cloud) bestätigen und Event-Inhalte auf Ausschluss von Kinderdaten prüfen | moto |
+| 8 | GitHub/GHCR: DPF-Zertifizierungsstatus dokumentieren | moto |
+| 9 | Schriftarten-Auslieferung: Ausschluss eines Laufzeit-Rückfalls auf externe Google-Server in der Build-Pipeline bestätigen | moto |
+| 10 | Hetzner-AVV und aktuelle Rechenzentrumszertifikate als Anlage beifügen | moto |
+| 11 | Turnus externer Sicherheitsüberprüfungen/Penetrationstests festlegen und Nachweise führen | moto |
+| 12 | Dienstanweisung zu Freitextfeldern (Gesundheitsangaben, Notizen) erstellen | Verantwortlicher |
+| 13 | Firmen-Stammdaten und Ansprechpartner in diesem Dokument vervollständigen ([RECHTSFORM UND ADRESSE], [NAME DATENSCHUTZKOORDINATOR], [NAME DATENSCHUTZBEAUFTRAGTER], [KONTAKT DATENSCHUTZBEAUFTRAGTER], [DATUM AVV], [NAME SCHULTRÄGER]) | moto |
+
+---
+
+*Ende des Dokuments. Version 1.0, Stand 2026-07-07, Status: Entwurf zur internen Prüfung.*

--- a/docs/moto-dsgvo-dokumente/07-datenpannen-meldeprozess.md
+++ b/docs/moto-dsgvo-dokumente/07-datenpannen-meldeprozess.md
@@ -1,0 +1,316 @@
+# Prozess zur Meldung von Datenschutzverletzungen (Art. 33/34 DSGVO)
+
+| | |
+|---|---|
+| **Dokument** | 07 Datenpannen-Meldeprozess |
+| **Verantwortlich** | [NAME DATENSCHUTZBEAUFTRAGTER], Datenschutzkoordination moto |
+| **Version** | 1.0 |
+| **Stand** | 2026-07-07 |
+| **Status** | Entwurf zur internen Prüfung |
+| **Geltungsbereich** | moto [RECHTSFORM UND ADRESSE], Produkt "moto" (internes Projekt "Project Phoenix") |
+| **Freigabe** | [NAME GESCHÄFTSFÜHRUNG], Datum: [DATUM FREIGABE] |
+
+---
+
+## 1. Zweck und Geltungsbereich
+
+Dieses Dokument regelt den internen Prozess von moto für den Umgang mit Verletzungen des Schutzes personenbezogener Daten (im Folgenden: Datenschutzverletzung) im Zusammenhang mit dem Betrieb des NFC/RFID-Anwesenheits- und Raumverwaltungssystems "moto" für den Offenen Ganztag (OGS) an Grundschulen in Nordrhein-Westfalen.
+
+moto ist gegenüber den Schulen bzw. Schulträgern **Auftragsverarbeiter** im Sinne von Art. 28 DSGVO. Verantwortlicher im Sinne von Art. 4 Nr. 7 DSGVO ist die jeweilige Schule bzw. der jeweilige Schulträger. Daraus ergibt sich die zentrale Weichenstellung dieses Prozesses:
+
+- moto meldet Datenschutzverletzungen **unverzüglich an den Verantwortlichen** (Art. 33 Abs. 2 DSGVO).
+- Die Meldung an die Aufsichtsbehörde (Art. 33 Abs. 1 DSGVO) und die Benachrichtigung betroffener Personen (Art. 34 DSGVO) sind **Pflichten des Verantwortlichen**. moto nimmt **keine eigene Meldung an die Aufsichtsbehörde vor** und benachrichtigt Betroffene nicht in eigenem Namen. moto unterstützt den Verantwortlichen bei diesen Pflichten nach Maßgabe des Auftragsverarbeitungsvertrags (Art. 28 Abs. 3 lit. f DSGVO).
+
+Der Prozess gilt für alle Mitarbeitenden von moto, für alle produktiven und stagingnahen Systeme (Backend, Frontend-Portale, Kiosk-Geräte, Datenbank, Monitoring, Deployment-Infrastruktur) sowie für Vorfälle bei Unterauftragsverarbeitern, soweit sie Daten aus dem Auftrag betreffen.
+
+Dieser Prozess konkretisiert die Meldepflichten aus dem Auftragsverarbeitungsvertrag zwischen moto und dem jeweiligen Verantwortlichen. Bei Widersprüchen gehen die vertraglichen Regelungen des jeweiligen AVV vor. [PRÜFEN: Fristen und Meldewege dieses Dokuments mit der Meldeklausel im AVV-Muster abgleichen und beide konsistent halten.]
+
+## 2. Begriffsbestimmung
+
+Eine **Verletzung des Schutzes personenbezogener Daten** ist nach Art. 4 Nr. 12 DSGVO eine Verletzung der Sicherheit, die, ob unbeabsichtigt oder unrechtmäßig, zur Vernichtung, zum Verlust, zur Veränderung oder zur unbefugten Offenlegung von beziehungsweise zum unbefugten Zugang zu personenbezogenen Daten führt, die übermittelt, gespeichert oder auf sonstige Weise verarbeitet wurden.
+
+Erfasst sind alle drei Schutzziele:
+
+1. **Vertraulichkeit**: unbefugte Offenlegung oder unbefugter Zugang (z. B. Datenabfluss, Fehlversand, Einsicht durch Unbefugte)
+2. **Integrität**: unbefugte oder unbeabsichtigte Veränderung von Daten
+3. **Verfügbarkeit**: unbeabsichtigter oder unrechtmäßiger Verlust des Zugangs zu Daten oder Vernichtung von Daten (auch vorübergehend, z. B. durch Ransomware oder Datenverlust ohne verwendbares Backup)
+
+### 2.1 Beispiele aus dem moto-Systemkontext
+
+Die folgenden Konstellationen sind als Datenschutzverletzung oder als meldeprozessauslösender Verdachtsfall zu behandeln:
+
+- Kompromittierung oder Abfluss eines Device-API-Keys eines Kiosk-Geräts (PyrePortal auf Raspberry Pi), insbesondere in Verbindung mit einer bekannt gewordenen Personal-PIN
+- Diebstahl oder Verlust eines Kiosk-Geräts aus einer Schule
+- Fehler in der mandantenbezogenen Zugriffstrennung (PostgreSQL Row Level Security, Tenant-Middleware), durch den Daten einer Schule für eine andere Schule oder für Unbefugte sichtbar werden
+- Ausnutzung einer Schwachstelle im Authentifizierungspfad (JWT, MFA, Passkeys, Passwort-Reset), die unbefugten Zugriff auf Konten von Personal, Eltern oder Operator ermöglicht
+- Kompromittierung von Zugangsdaten oder Schlüsselmaterial (JWT-Secret, SOPS/age-Schlüssel, Datenbank-Zugangsdaten, SSH-Deploy-Zugänge, GitHub-Zugänge)
+- Fehlkonfiguration des Reverse Proxy (Caddy) oder von Cloudflare, durch die interne Endpunkte oder Daten öffentlich erreichbar werden
+- Sicherheitsvorfall auf dem Hosting-Server (Hetzner, Nürnberg), z. B. Einbruch, Ransomware, unbefugter Zugriff auf Datenbank, Backups oder das dort mitbetriebene Monitoring (Grafana/Loki)
+- Versand personenbezogener Daten an falsche Empfänger (z. B. E-Mail an falsche Adresse mit Kindsdaten, fehlgeleitete Einladungs- oder Reset-Links)
+- Unbefugte Einsichtnahme in besonders geschützte Datenbestände, insbesondere Gesundheitsangaben zu Kindern (Freitextfeld Gesundheitsinformationen, strukturierte Krankmeldungen) und Krankmeldungen des Personals
+- Sicherheitsvorfall bei einem Unterauftragsverarbeiter (z. B. Hosting-Anbieter, Cloudflare, GitHub/GHCR, E-Mail-Versanddienst), der Daten aus dem Auftrag betrifft
+- Verlust oder Nichtwiederherstellbarkeit von Produktivdaten (fehlgeschlagene Migration ohne verwendbares Backup, defekte Datensicherung)
+
+Nicht jeder Sicherheitsvorfall ist eine Datenschutzverletzung (z. B. ein abgewehrter Angriffsversuch ohne Zugriff auf personenbezogene Daten). Die Abgrenzung trifft der Datenschutzbeauftragte gemeinsam mit der technischen Leitung im Rahmen der Bewertung nach Abschnitt 6. Im Zweifel ist der Vorfall als Datenschutzverletzung zu behandeln.
+
+### 2.2 Betroffene Datenkategorien im System
+
+Für die Bewertung und die Meldung ist relevant, welche Datenkategorien das System verarbeitet. Die vollständige Aufstellung enthält das Verzeichnis von Verarbeitungstätigkeiten (Dokument 04) auf Grundlage der Datenbestandsaufnahme (gesondertes internes Dokument). Zusammengefasst:
+
+| Betroffenengruppe | Wesentliche Datenkategorien |
+|---|---|
+| Schüler:innen | Stammdaten (Name, Geburtsdatum, Adresse, Klasse), Anwesenheits- und Bewegungsdaten (Check-in/Check-out, Raumaufenthalt), Abholregelungen, Foto, Einwilligungen, RFID-Tag-Kennung, Betreuernotizen, **Gesundheitsangaben (Freitext, Krankmeldungen; Art. 9 DSGVO)** |
+| Eltern / Erziehungsberechtigte | Name, E-Mail, Adresse, Telefonnummern, Beziehung zum Kind, Abholberechtigung, Notfallkontakt-Kennzeichnung, Portal-Account, Nachrichten mit der Betreuung, Anmeldedaten (Enrollment) |
+| Personal | Stammdaten, Beschäftigungsart, Zeiterfassung (Kommen/Gehen, Pausen), **Abwesenheiten inkl. Krankmeldungen (Art. 9 DSGVO)**, RFID-Tag-Kennung, Account- und PIN-Daten (gehasht) |
+| Alle Kontoinhaber | E-Mail, Passwort-/PIN-Hashes, Login-Historie inkl. IP-Adresse und User-Agent, MFA- und Passkey-Daten, Sessions/Tokens |
+| Nicht identifizierte Dritte | Unregistrierte RFID-Tag-Scans (Tag-UID, Gerät, Zeitpunkt) |
+
+Vorfälle, die Gesundheitsangaben von Kindern, Krankmeldungen, Abholberechtigungen oder Bewegungsdaten von Kindern betreffen, sind stets als potenziell hohes Risiko einzustufen und mit höchster Priorität zu behandeln. Die Betroffenen sind überwiegend Kinder; dies ist bei jeder Bewertung und in jeder Meldung ausdrücklich zu berücksichtigen.
+
+## 3. Rollen und Verantwortlichkeiten
+
+### 3.1 Rollenverteilung nach DSGVO
+
+| Rolle | Wer | Pflichten im Meldeprozess |
+|---|---|---|
+| Verantwortlicher | Schule bzw. Schulträger | Risikobewertung; Entscheidung über Meldung an die LDI NRW binnen 72 Stunden ab eigener Kenntnis (Art. 33 Abs. 1 DSGVO); Entscheidung über Benachrichtigung der Betroffenen (Art. 34 DSGVO); Dokumentation nach Art. 33 Abs. 5 DSGVO |
+| Auftragsverarbeiter | moto | Erkennung, Eindämmung, unverzügliche Meldung an den Verantwortlichen (Art. 33 Abs. 2 DSGVO), technische Aufklärung, Unterstützung des Verantwortlichen (Art. 28 Abs. 3 lit. f DSGVO), eigene Dokumentation |
+| Unterauftragsverarbeiter | Hosting-Anbieter, Cloudflare, GitHub/GHCR, E-Mail-Versanddienst, weitere gemäß Subprozessorenliste (Dokument 03) | Meldung an moto gemäß Unterauftragsverarbeitungsvertrag (Kettenmeldepflicht) [PRÜFEN: Meldefristen in allen Unterauftragsverarbeitungsverträgen bzw. DPAs verifizieren und in der Subprozessorenliste vermerken] |
+
+moto trifft im Rahmen von Art. 33 Abs. 2 DSGVO **keine eigene Risikobewertung als Meldevoraussetzung**. Die Meldepflicht des Auftragsverarbeiters an den Verantwortlichen ist voraussetzungslos: Jede bekannt gewordene Datenschutzverletzung, die Daten aus dem Auftrag betrifft, wird gemeldet. Die Bewertung, ob ein Risiko für die Rechte und Freiheiten der Betroffenen besteht und ob eine Meldung an die LDI NRW erfolgt, obliegt allein dem Verantwortlichen. Die interne Klassifizierung nach Abschnitt 6 dient ausschließlich der Priorisierung der Eindämmung und der Qualität der Meldung, nicht der Filterung meldepflichtiger Vorfälle.
+
+### 3.2 Interne Zuständigkeiten bei moto
+
+| Funktion | Person | Aufgaben |
+|---|---|---|
+| Datenschutzbeauftragter / Datenschutzkoordination | [NAME DATENSCHUTZBEAUFTRAGTER] | Prozessverantwortung, Bewertung, Freigabe und Versand der Meldung an den Verantwortlichen, Dokumentation, Ansprechpartner nach Art. 33 Abs. 3 lit. b DSGVO |
+| Technische Leitung / Incident-Verantwortlicher | [NAME TECHNISCHE LEITUNG] | Technische Aufklärung, Eindämmung, Beweissicherung, Wiederherstellung |
+| Geschäftsführung | [NAME GESCHÄFTSFÜHRUNG] | Gesamtverantwortung, Freigabe außerordentlicher Maßnahmen (z. B. Abschaltung des Produktivsystems), Kommunikation auf Leitungsebene |
+| Alle Mitarbeitenden | alle | Unverzügliche interne Meldung jedes Verdachtsfalls an die Kontaktkette (Abschnitt 11), keine eigenmächtige Außenkommunikation |
+
+Vertretungsregelung: Bei Abwesenheit einer Funktion greift die in Abschnitt 11 hinterlegte Vertretung. Kein Schritt dieses Prozesses darf an der Abwesenheit einer einzelnen Person scheitern.
+
+## 4. Erkennung von Datenschutzverletzungen
+
+Meldeprozessauslösende Erkenntnisse können aus folgenden Quellen stammen. Jede Quelle mündet in denselben Prozess (Abschnitt 5 ff.):
+
+1. **Eigenes Monitoring und Alerting**: selbst gehostetes Grafana/Loki auf der Hosting-Infrastruktur, inklusive Alarmregeln (u. a. Verfügbarkeits-/Healthcheck-Alarme, Fehlerraten, auffällige Log-Muster). Dies ist der primäre technische Erkennungsweg.
+2. **Audit- und Protokolldaten des Systems**: Login-Ereignisprotokoll inkl. Fehlversuchen, Datenzugriffsprotokoll für sensible Lesezugriffe, Änderungsprotokolle, Protokoll unregistrierter NFC-Scans. Auffälligkeiten in diesen Protokollen (z. B. gehäufte Fehlversuche, untypische Zugriffs- oder Exportmuster) sind als Verdachtsfall zu behandeln.
+3. **Feststellung durch Mitarbeitende**: im Rahmen von Entwicklung, Betrieb, Code-Review oder Deployment (z. B. entdeckte Sicherheitslücke, versehentlich veröffentlichtes Secret, fehlgeschlagene Migration mit Datenverlust).
+4. **Meldung durch den Verantwortlichen oder dessen Nutzer**: Support-Anfragen von Schulen, Personal oder Eltern (z. B. "ich sehe Daten eines fremden Kindes").
+5. **Externe Hinweise**: Sicherheitsforscher, Responsible-Disclosure-Meldungen, Hinweise Dritter, Presseanfragen.
+6. **Meldung eines Unterauftragsverarbeiters**: Sicherheits- oder Datenschutzvorfall bei Hosting, Cloudflare, GitHub/GHCR, E-Mail-Versanddienst oder weiteren Dienstleistern gemäß Subprozessorenliste.
+
+Für die Fristberechnung gilt: **Kenntnis** liegt vor, sobald eine für den Prozess zuständige Person (Abschnitt 3.2) mit hinreichender Sicherheit von einer Datenschutzverletzung weiß. Bei einem Verdachtsfall beginnt unverzüglich die Verifikation; die Verifikationsphase darf nicht dazu genutzt werden, die Meldung hinauszuzögern. Zeitpunkt der Kenntniserlangung ist im Vorfallprotokoll minutengenau festzuhalten.
+
+## 5. Sofortmaßnahmen (Eindämmung und Beweissicherung)
+
+Unmittelbar nach Feststellung eines Vorfalls oder eines konkreten Verdachts ergreift die technische Leitung, soweit einschlägig und ohne die Aufklärung zu gefährden, folgende Maßnahmen:
+
+1. **Eindämmung**
+   - Isolierung betroffener Systeme oder Container; im Extremfall Abschaltung des betroffenen Dienstes (Freigabe durch Geschäftsführung, wenn der Betrieb aller Schulen betroffen ist)
+   - Sperrung oder Deaktivierung kompromittierter Konten (Personal-, Eltern-, Operator-Konten), Invalidierung aktiver Sessions und Refresh-Tokens
+   - Rotation kompromittierter oder potenziell kompromittierter Zugangsdaten und Schlüssel: Device-API-Keys betroffener Kiosk-Geräte, Staff-PINs, JWT-Secret, Datenbank-Zugangsdaten, SOPS/age-Schlüssel, SSH-Deploy-Schlüssel, GitHub-Tokens
+   - Deaktivierung betroffener Kiosk-Geräte (bei Geräteverlust oder Key-Kompromittierung)
+   - Bei Fehlkonfiguration von Proxy/DNS: sofortige Korrektur der Konfiguration, danach Prüfung, ob und wie lange Daten erreichbar waren
+2. **Beweissicherung**
+   - Sicherung relevanter Log-Daten (Anwendungslogs, Zugriffs- und Auditprotokolle, Reverse-Proxy-Logs, Monitoring-Daten) auf ein vom Produktivsystem getrenntes Medium, bevor sie durch Rotation oder Retention überschrieben werden
+   - Sicherung eines Datenbankstands (Dump) zum Vorfallzeitpunkt, soweit zur Aufklärung erforderlich
+   - Festhalten aller Zeitpunkte, Beobachtungen und durchgeführten Maßnahmen im internen Vorfallprotokoll (Abschnitt 9), beginnend mit der ersten Feststellung
+3. **Keine vorschnelle Spurenvernichtung**: Systeme werden nicht neu aufgesetzt oder bereinigt, bevor die für die Aufklärung notwendigen Daten gesichert sind, es sei denn, die Eindämmung erfordert es zwingend.
+
+Die Sofortmaßnahmen laufen parallel zur Meldung nach Abschnitt 7. Die Meldung wartet nicht auf den Abschluss der Eindämmung.
+
+## 6. Interne Bewertung und Klassifizierung
+
+Der Datenschutzbeauftragte und die technische Leitung bewerten den Vorfall unverzüglich anhand folgender Fragen:
+
+1. **Liegt eine Datenschutzverletzung im Sinne von Art. 4 Nr. 12 DSGVO vor** oder ein reiner Sicherheitsvorfall ohne Bezug zu personenbezogenen Daten? Im Zweifel: Datenschutzverletzung.
+2. **Welche Mandanten (Schulen) sind betroffen?** Zu unterscheiden sind:
+   - **mandantenspezifische Vorfälle** (eine Schule betroffen, z. B. Verlust eines Kiosk-Geräts): Meldung an den betroffenen Verantwortlichen
+   - **plattformweite Vorfälle** (alle oder mehrere Schulen betroffen, z. B. Kompromittierung des Hosting-Servers, RLS-Fehler): Meldung an alle betroffenen Verantwortlichen, koordiniert und mit identischem Informationsstand
+3. **Welche Datenkategorien und Betroffenengruppen sind betroffen?** Besonders zu kennzeichnen: Gesundheitsangaben (Art. 9 DSGVO), Daten von Kindern, Abholberechtigungen und Notfallkontakte, Bewegungs-/Anwesenheitsdaten, Zugangsdaten.
+4. **Ungefähre Zahl der betroffenen Personen und Datensätze** (Größenordnung genügt zunächst; Präzisierung per Nachmeldung).
+5. **Zeitraum**: Beginn, Entdeckung, Ende bzw. andauernder Zustand.
+6. **Schweregrad zur internen Priorisierung** (nicht als Meldefilter):
+   - **Kritisch**: Art.-9-Daten oder Kindsdaten in größerem Umfang offengelegt, plattformweiter Vorfall, andauernder unbefugter Zugriff
+   - **Hoch**: begrenzte Offenlegung personenbezogener Daten, kompromittierte Einzelkonten, Geräteverlust
+   - **Mittel**: Integritäts- oder Verfügbarkeitsverletzung ohne Anhaltspunkt für Offenlegung
+   - Bei "Kritisch" informiert der Datenschutzbeauftragte unverzüglich zusätzlich die Geschäftsführung.
+
+Ergebnis der Bewertung ist die Feststellung, **an welche Verantwortlichen** mit **welchem Informationsstand** gemeldet wird. Die Bewertung ersetzt nicht die Risikobewertung des Verantwortlichen und wird in der Meldung ausdrücklich als Sachverhaltsdarstellung, nicht als abschließende Risikoeinschätzung gekennzeichnet.
+
+## 7. Meldung an den Verantwortlichen (Art. 33 Abs. 2 DSGVO)
+
+### 7.1 Frist
+
+Die Meldung an den Verantwortlichen erfolgt **unverzüglich nach Kenntniserlangung**, als interne Zielvorgabe **spätestens innerhalb von 24 Stunden**. Das AVV-Muster (Dokument 01, § 8 Abs. 2) sieht als vertragliche Obergrenze eine Meldung spätestens innerhalb von 48 Stunden vor; die interne Zielvorgabe unterschreitet diese Frist bewusst. [PRÜFEN: bei individuell abweichenden Fristen in einzelnen AVV ist die jeweils vereinbarte Frist maßgeblich.]
+
+Hintergrund: Der Verantwortliche muss seine eigene Meldung an die Aufsichtsbehörde binnen 72 Stunden ab **seiner** Kenntnis abgeben (Art. 33 Abs. 1 DSGVO). Da moto in der Regel Erstentdecker ist, muss die Meldung von moto so früh und so vollständig erfolgen, dass dem Verantwortlichen ausreichend Zeit für Bewertung und Behördenmeldung verbleibt.
+
+Die gesetzliche 72-Stunden-Frist gilt **nicht** für die Meldung von moto an den Verantwortlichen; sie ist keine Rechtfertigung für ein Zuwarten.
+
+### 7.2 Empfänger
+
+Die Meldung geht an die im jeweiligen AVV bzw. in den hinterlegten Kundenstammdaten benannten Stellen des Verantwortlichen, in der Regel:
+
+- Schulleitung der betroffenen Schule: [KONTAKT LAUT KUNDENSTAMMDATEN]
+- Datenschutzansprechpartner des Schulträgers bzw. behördlicher Datenschutzbeauftragter: [KONTAKT LAUT KUNDENSTAMMDATEN]
+- Bei kommunalem IT-Dienstleister als Betriebspartner des Trägers: zusätzlich dessen benannte Meldestelle [KONTAKT LAUT KUNDENSTAMMDATEN]
+
+Meldeweg: E-Mail an die hinterlegte Meldeadresse mit dem ausgefüllten Formular aus Anhang A, bei kritischen Vorfällen zusätzlich telefonische Vorabinformation. Wird der Versand über die möglicherweise kompromittierte eigene Infrastruktur als unsicher bewertet, erfolgt die Meldung über einen unabhängigen Kanal (Telefon plus alternatives E-Mail-Konto). Der Zugang der Meldung ist zu dokumentieren (Lesebestätigung, Telefonvermerk).
+
+### 7.3 Pflichtinhalte der Meldung
+
+Die Meldung enthält mindestens die folgenden Angaben. Sie orientiert sich an Art. 33 Abs. 3 lit. a bis d DSGVO, damit der Verantwortliche die Inhalte ohne Umformung für seine eigene Meldung an die LDI NRW übernehmen kann:
+
+1. **Art der Verletzung** (Sachverhaltsdarstellung): Was ist wann passiert, welches Schutzziel ist verletzt (Vertraulichkeit, Integrität, Verfügbarkeit), welche Systeme oder Komponenten sind betroffen, ist der Vorfall beendet oder andauernd.
+2. **Kategorien und ungefähre Zahl der betroffenen Personen** (Schüler:innen, Erziehungsberechtigte, Personal) **sowie Kategorien und ungefähre Zahl der betroffenen Datensätze**, mit ausdrücklicher Kennzeichnung besonderer Kategorien (Gesundheitsangaben) und des Umstands, dass Kinder betroffen sind.
+3. **Name und Kontaktdaten der Anlaufstelle bei moto**: [NAME DATENSCHUTZBEAUFTRAGTER], [KONTAKTDATEN DSB].
+4. **Beschreibung der wahrscheinlichen Folgen** der Verletzung, soweit aus Sicht von moto als Auftragsverarbeiter erkennbar (Sachverhaltsebene; die rechtliche Risikobewertung obliegt dem Verantwortlichen).
+5. **Ergriffene und vorgeschlagene Maßnahmen** zur Behebung der Verletzung und zur Abmilderung möglicher nachteiliger Auswirkungen (Eindämmung, Rotation von Zugangsdaten, Korrekturen, geplante Schritte).
+6. Zeitpunkt der Kenntniserlangung bei moto sowie Hinweis, ob und welche Angaben noch ausstehen.
+
+### 7.4 Gestaffelte Meldung
+
+Sind bei Fristablauf noch nicht alle Informationen verfügbar, wird **nicht gewartet**: Die Erstmeldung erfolgt mit dem vorhandenen Kenntnisstand und kennzeichnet offene Punkte ausdrücklich. Fehlende Angaben werden ohne unangemessene Verzögerung nachgemeldet (Rechtsgedanke des Art. 33 Abs. 4 DSGVO). Jede Nachmeldung verweist auf die Vorfallnummer der Erstmeldung.
+
+## 8. Unterstützung des Verantwortlichen (Art. 28 Abs. 3 lit. f DSGVO)
+
+moto unterstützt den Verantwortlichen nach Meldung des Vorfalls insbesondere durch:
+
+1. **Zulieferung für die Behördenmeldung**: Die Angaben aus Anhang A sind so strukturiert, dass der Verantwortliche sie in das Meldeformular der LDI NRW übertragen kann. moto beantwortet Rückfragen des Verantwortlichen und der Aufsichtsbehörde zum technischen Sachverhalt unverzüglich; die Kommunikation mit der Aufsichtsbehörde führt der Verantwortliche.
+2. **Unterstützung bei der Benachrichtigung Betroffener (Art. 34 DSGVO)**: Auf Anforderung des Verantwortlichen stellt moto Sachverhaltsbausteine in klarer, einfacher Sprache bereit und unterstützt bei der technischen Umsetzung der Benachrichtigung, etwa per E-Mail-Versand über die Systeminfrastruktur oder Hinweis im Elternportal, soweit die Infrastruktur nicht selbst kompromittiert ist. Die Entscheidung über das Ob, den Inhalt und den Zeitpunkt der Benachrichtigung trifft ausschließlich der Verantwortliche.
+3. **Hinweis auf Ausnahmen nach Art. 34 Abs. 3 DSGVO**: moto teilt dem Verantwortlichen mit, welche technischen Schutzmaßnahmen auf die betroffenen Daten angewendet waren (z. B. Verschlüsselung, gehashte Passwörter/PINs), damit der Verantwortliche prüfen kann, ob eine Benachrichtigungspflicht entfällt. Die rechtliche Bewertung nimmt der Verantwortliche vor.
+
+## 9. Dokumentation
+
+1. moto führt ein **internes Vorfallregister**, in dem jede Datenschutzverletzung und jeder ernsthafte Verdachtsfall dokumentiert wird: Vorfallnummer, Zeitpunkte (Feststellung, Kenntnis, Meldung, Abschluss), Sachverhalt, betroffene Mandanten, Datenkategorien und Betroffenenzahlen, ergriffene Maßnahmen, Kommunikationsverlauf mit dem Verantwortlichen und ggf. Unterauftragsverarbeitern, Ergebnis der Nachbereitung.
+2. Das Vorfallregister wird **getrennt vom Produktivsystem** geführt (Speicherort: [SPEICHERORT VORFALLREGISTER, z. B. verschlüsselte Ablage außerhalb der Produktivinfrastruktur]), damit die Dokumentation auch bei kompromittierter Infrastruktur verfügbar und beweissicher bleibt.
+3. Die Dokumentationspflicht nach Art. 33 Abs. 5 DSGVO trifft den Verantwortlichen. Die interne Dokumentation von moto dient der eigenen Rechenschafts- und Nachweispflicht als Auftragsverarbeiter (Art. 28 Abs. 3 lit. h DSGVO) und wird dem Verantwortlichen auf Anforderung für dessen Dokumentation zur Verfügung gestellt.
+4. Auch Vorfälle, die sich nach Prüfung **nicht** als Datenschutzverletzung erweisen, werden mit Begründung im Register festgehalten.
+5. Aufbewahrungsdauer der Vorfalldokumentation: [AUFBEWAHRUNGSDAUER, z. B. 5 Jahre ab Abschluss des Vorfalls] [PRÜFEN: Aufbewahrungsdauer festlegen und mit den Verjährungsfristen möglicher Haftungsansprüche sowie den Vorgaben des AVV abstimmen.]
+
+## 10. Nachbereitung
+
+Nach Abschluss jedes Vorfalls, bei kritischen Vorfällen spätestens vier Wochen nach Abschluss:
+
+1. **Ursachenanalyse** (Root Cause): technische und organisatorische Ursache, nicht nur Symptom.
+2. **Ableitung von Maßnahmen**: Anpassung technischer und organisatorischer Maßnahmen (TOM-Dokument aktualisieren), Codekorrekturen, Härtung, ggf. Anpassung von Monitoring-Alarmen, damit vergleichbare Vorfälle früher erkannt werden.
+3. **Prozessreview**: Prüfung, ob Fristen, Kontaktkette und Formulare funktioniert haben; Anpassung dieses Dokuments bei Bedarf.
+4. **Regelprüfung**: Dieser Prozess wird mindestens **jährlich** überprüft und mindestens einmal jährlich in einer Übung (Planspiel anhand eines fiktiven Szenarios, z. B. RLS-Fehler mit mandantenübergreifendem Zugriff) getestet. Verantwortlich: [NAME DATENSCHUTZBEAUFTRAGTER]. Letzte Übung: [DATUM LETZTE ÜBUNG].
+
+## 11. Kontaktkette (Eskalation)
+
+Jeder Verdachtsfall wird sofort an die erste erreichbare Stelle der Kette gemeldet. Erreichbarkeit außerhalb der Geschäftszeiten: [REGELUNG RUFBEREITSCHAFT / ERREICHBARKEIT AUSSERHALB DER GESCHÄFTSZEITEN].
+
+| Stufe | Funktion | Name | Telefon | E-Mail |
+|---|---|---|---|---|
+| 1 | Datenschutzbeauftragter / Datenschutzkoordination | [NAME DATENSCHUTZBEAUFTRAGTER] | [TELEFON DSB] | [E-MAIL DSB] |
+| 1 (parallel) | Technische Leitung / Incident-Verantwortlicher | [NAME TECHNISCHE LEITUNG] | [TELEFON TECHNISCHE LEITUNG] | [E-MAIL TECHNISCHE LEITUNG] |
+| 2 | Vertretung DSB | [NAME VERTRETUNG DSB] | [TELEFON VERTRETUNG] | [E-MAIL VERTRETUNG] |
+| 3 | Geschäftsführung | [NAME GESCHÄFTSFÜHRUNG] | [TELEFON GESCHÄFTSFÜHRUNG] | [E-MAIL GESCHÄFTSFÜHRUNG] |
+
+Sammel-Meldeadresse für interne und externe Hinweise: [MELDEADRESSE, z. B. datenschutz@moto-domain]
+
+## 12. Zuständige Aufsichtsbehörde
+
+Für die Schulen und Schulträger in Nordrhein-Westfalen als Verantwortliche ist zuständig:
+
+**Landesbeauftragte für Datenschutz und Informationsfreiheit Nordrhein-Westfalen (LDI NRW)**
+Kavalleriestraße 2-4, 40213 Düsseldorf
+Telefon: 0211 38424-0
+E-Mail: poststelle@ldi.nrw.de
+Meldung von Datenpannen: über das Online-Meldeformular der LDI NRW (Formularserver, erreichbar über www.ldi.nrw.de)
+
+[PRÜFEN: Kontaktdaten und Formular-Link vor jeder Verwendung auf der Website der LDI NRW auf Aktualität prüfen.]
+
+Die Meldung an die LDI NRW gibt der **Verantwortliche** ab. moto meldet nicht selbst an die LDI NRW. Sollte die LDI NRW moto direkt kontaktieren, informiert moto unverzüglich den betroffenen Verantwortlichen und stimmt die Beantwortung mit ihm ab.
+
+## 13. Mitgeltende Dokumente
+
+- Auftragsverarbeitungsvertrag (AVV, Dokument 01) mit dem jeweiligen Verantwortlichen, insbesondere die Meldeklausel (§ 8)
+- Dokument 04: Verzeichnis von Verarbeitungstätigkeiten (Datenkategorien und Speicherorte)
+- Dokument 02: Technische und organisatorische Maßnahmen (TOM)
+- Subprozessorenliste (Dokument 03) inkl. Meldepflichten der Unterauftragsverarbeiter
+- Rechtsrahmen: DSGVO (insb. Art. 4 Nr. 12, Art. 28, 33, 34), §§ 120 bis 122 SchulG NRW, VO-DV I
+
+---
+
+# Anhang A: Meldeformular Datenschutzverletzung (Meldung des Auftragsverarbeiters an den Verantwortlichen nach Art. 33 Abs. 2 DSGVO)
+
+*Dieses Formular wird von moto ausgefüllt und an den Verantwortlichen übermittelt. Die Gliederung folgt Art. 33 Abs. 3 lit. a bis d DSGVO, damit der Verantwortliche die Angaben unmittelbar für seine eigene Meldung an die LDI NRW verwenden kann. Noch nicht bekannte Angaben sind als "wird nachgemeldet" zu kennzeichnen.*
+
+## A.1 Verwaltungsangaben
+
+| Feld | Angabe |
+|---|---|
+| Vorfallnummer (moto-intern) | _______________________ |
+| Meldung | ☐ Erstmeldung  ☐ Nachmeldung zu Vorfallnummer: ______________ |
+| Datum und Uhrzeit dieser Meldung | _______________________ |
+| Auftragsverarbeiter | moto, [RECHTSFORM UND ADRESSE] |
+| Anlaufstelle bei moto (Art. 33 Abs. 3 lit. b) | [NAME DATENSCHUTZBEAUFTRAGTER], [KONTAKTDATEN DSB] |
+| Verantwortlicher (Empfänger dieser Meldung) | Schule/Schulträger: _______________________ |
+| Empfangende Stelle beim Verantwortlichen | _______________________ |
+| Betroffene weitere Verantwortliche (bei plattformweitem Vorfall) | ☐ nein  ☐ ja, Anzahl: ______ (jeweils gesonderte Meldung erfolgt) |
+
+## A.2 Art der Verletzung (Art. 33 Abs. 3 lit. a)
+
+| Feld | Angabe |
+|---|---|
+| Zeitpunkt des Beginns der Verletzung (soweit bekannt) | _______________________ |
+| Zeitpunkt der Feststellung / Kenntniserlangung bei moto | _______________________ |
+| Dauert die Verletzung an? | ☐ ja  ☐ nein, beendet am: ______________ |
+| Verletztes Schutzziel | ☐ Vertraulichkeit  ☐ Integrität  ☐ Verfügbarkeit |
+| Art des Vorfalls | ☐ unbefugter Zugriff  ☐ Datenabfluss/Offenlegung  ☐ Fehlversand  ☐ Verlust/Diebstahl Gerät  ☐ Fehlkonfiguration  ☐ Schadsoftware/Angriff  ☐ Datenverlust/-vernichtung  ☐ Vorfall bei Unterauftragsverarbeiter  ☐ Sonstiges: ______________ |
+| Betroffene Systeme/Komponenten | _______________________________________________ |
+| Sachverhaltsbeschreibung (was ist passiert, wie wurde es entdeckt) | _______________________________________________ _______________________________________________ _______________________________________________ |
+
+## A.3 Betroffene Personen und Datensätze (Art. 33 Abs. 3 lit. a)
+
+| Feld | Angabe |
+|---|---|
+| Kategorien betroffener Personen | ☐ Schüler:innen (Kinder)  ☐ Erziehungsberechtigte  ☐ Personal  ☐ sonstige: ______________ |
+| Ungefähre Zahl betroffener Personen | ______________ (☐ Schätzung, wird präzisiert) |
+| Kategorien betroffener Daten | ☐ Stammdaten (Name, Geburtsdatum, Adresse, Klasse) ☐ Kontaktdaten Erziehungsberechtigte (E-Mail, Telefon, Adresse) ☐ Anwesenheits-/Bewegungsdaten (Check-in/-out, Raumaufenthalt) ☐ Abholberechtigungen / Notfallkontakte ☐ **Gesundheitsangaben (Art. 9 DSGVO)**, z. B. Gesundheitsinfo-Freitext, Krankmeldungen ☐ Foto ☐ RFID-Tag-Kennungen ☐ Zugangsdaten (E-Mail, Passwort-/PIN-Hashes, Tokens) ☐ Login-/Protokolldaten (IP-Adressen, Zeitstempel) ☐ Zeiterfassung/Abwesenheiten Personal ☐ Anmeldedaten (Enrollment) ☐ Nachrichten Elternportal ☐ sonstige: ______________ |
+| Ungefähre Zahl betroffener Datensätze | ______________ (☐ Schätzung, wird präzisiert) |
+| Besondere Kategorien (Art. 9 DSGVO) betroffen? | ☐ ja  ☐ nein  ☐ noch unklar |
+| Daten von Kindern betroffen? | ☐ ja  ☐ nein  ☐ noch unklar |
+| Waren die betroffenen Daten technisch geschützt (z. B. verschlüsselt, gehasht)? | ☐ ja, wie: ______________  ☐ nein  ☐ teilweise: ______________ |
+
+## A.4 Wahrscheinliche Folgen (Art. 33 Abs. 3 lit. c)
+
+*Sachverhaltsbezogene Einschätzung von moto als Auftragsverarbeiter. Die Risikobewertung im Sinne von Art. 33 Abs. 1 und Art. 34 DSGVO nimmt der Verantwortliche vor.*
+
+| Feld | Angabe |
+|---|---|
+| Wahrscheinliche Folgen für die Betroffenen aus technischer Sicht | _______________________________________________ _______________________________________________ |
+| Anhaltspunkte für tatsächlichen Abruf/Missbrauch der Daten? | ☐ ja: ______________  ☐ nein  ☐ nicht feststellbar |
+
+## A.5 Ergriffene und vorgeschlagene Maßnahmen (Art. 33 Abs. 3 lit. d)
+
+| Feld | Angabe |
+|---|---|
+| Bereits ergriffene Maßnahmen (mit Zeitpunkt) | _______________________________________________ _______________________________________________ |
+| Geplante/vorgeschlagene weitere Maßnahmen | _______________________________________________ |
+| Ist die Ursache behoben? | ☐ ja  ☐ nein, voraussichtlich bis: ______________ |
+| Empfohlene Maßnahmen auf Seiten des Verantwortlichen (z. B. Information des Kollegiums, Passwortwechsel) | _______________________________________________ |
+
+## A.6 Offene Punkte und Nachmeldung
+
+| Feld | Angabe |
+|---|---|
+| Noch ausstehende Informationen | _______________________________________________ |
+| Voraussichtlicher Zeitpunkt der Nachmeldung | _______________________ |
+
+## A.7 Hinweise für den Verantwortlichen
+
+1. Die Frist für Ihre Meldung an die Aufsichtsbehörde (72 Stunden, Art. 33 Abs. 1 DSGVO) beginnt mit **Ihrer** Kenntnisnahme dieser Meldung, sofern die Verletzung voraussichtlich zu einem Risiko für die Rechte und Freiheiten natürlicher Personen führt.
+2. Zuständige Aufsichtsbehörde: Landesbeauftragte für Datenschutz und Informationsfreiheit Nordrhein-Westfalen (LDI NRW), Kavalleriestraße 2-4, 40213 Düsseldorf, Meldung über das Online-Meldeformular der LDI NRW (www.ldi.nrw.de).
+3. Die Entscheidung über eine Benachrichtigung der betroffenen Personen (Art. 34 DSGVO) obliegt Ihnen als Verantwortlichem. moto unterstützt Sie auf Anforderung gemäß Art. 28 Abs. 3 lit. f DSGVO.
+4. Für Rückfragen: [NAME DATENSCHUTZBEAUFTRAGTER], [KONTAKTDATEN DSB].
+
+| Unterschrift / Freigabe der Meldung (moto) | |
+|---|---|
+| Name, Funktion | _______________________ |
+| Datum, Uhrzeit | _______________________ |


### PR DESCRIPTION
## Worum geht es

Beim Meeting mit dem kommunalen IT-Dienstleister wurde eine DSGVO-Prüfung angekündigt. Das hier ist ein erster Aufschlag für die Dokumente, die dabei angefordert werden. Alle liegen unter `docs/moto-dsgvo-dokumente/`:

| Dokument | Inhalt |
|---|---|
| `00-uebersicht.md` | Übersicht + konsolidierte Checkliste aller offenen Punkte |
| `01-auftragsverarbeitungsvertrag.md` | AVV nach Art. 28 DSGVO (Schulträger = Verantwortlicher, moto = Auftragsverarbeiter) |
| `02-tom-dokumentation.md` | Technische und organisatorische Maßnahmen (Art. 32), basierend auf dem tatsächlich implementierten Stand (RLS, MFA, Backups, SOPS, ...) |
| `03-subprozessorenliste.md` | Hetzner, Cloudflare, GitHub, SMTP, Sentry, PostHog inkl. Drittlandbewertung |
| `04-verzeichnis-verarbeitungstaetigkeiten.md` | VVT nach Art. 30 Abs. 2 (Auftragsverarbeiter-Sicht) |
| `05-loeschkonzept.md` | Löschregeln je Datenkategorie inkl. der GDPR-Retention-Settings |
| `06-dsfa-zuarbeit.md` | Zuarbeit zur Datenschutz-Folgenabschätzung (Risikoanalyse RFID/Kinderdaten) |
| `07-datenpannen-meldeprozess.md` | Meldeprozess Art. 33/34 inkl. Meldeformular |

## Status

Das sind **Entwürfe zur internen Prüfung**, keine unterschriftsreifen Dokumente:

- Firmen-Stammdaten (Rechtsform, Adresse, Geschäftsführung, DSB) sind Platzhalter in eckigen Klammern
- Rechtlich unsichere Aussagen sind mit `[PRÜFEN]` markiert
- Der AVV muss vor Unterschrift juristisch geprüft werden

## Bei der Erstellung gefundene Baustellen

Die Bestandsaufnahme im Code hat ein paar Punkte aufgedeckt, die unabhängig vom Papierkram angegangen werden sollten (Details in `00-uebersicht.md`):

- **Retention-Lücke**: mehrere `audit.*`-Tabellen, `users.parent_messages` und `audit.unregistered_tag_scans` haben keine automatisierte Löschfrist (Art. 5 Abs. 1 lit. e)
- **Sentry/PostHog**: produktiver Einsatz und EU-Region müssen im jeweiligen Konto verifiziert werden
- **SMTP-Anbieter**: Name/Sitz/AVV-Status offen (nur SOPS-verschlüsselt hinterlegt)
- **Cloudflare**: DPF-Status und Vertragspartei prüfen, Data Localization Suite ist vermutlich nicht aktiv
- **Gesundheitsdaten** (`health_info`, Krankmeldungen): Art.-9-Erlaubnistatbestand mit dem Träger abstimmen

@fl0r14n28 magst du mal drüberschauen? Erster Aufschlag für die DSGVO-Thematik, Feedback gerne direkt an den Dokumenten.