### PR TITLE
feat(frontend): responsive skeleton loading states for all pages

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/activities/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.test.tsx
@@ -17,6 +17,20 @@ vi.mock("~/lib/swr", () => ({
   useTenantMutate: vi.fn(() => vi.fn()),
 }));
 
+// The page requires a session and redirects unauthenticated visitors; the
+// tests exercise the authenticated state.
+vi.mock("next-auth/react", () => ({
+  useSession: vi.fn(() => ({
+    data: { user: { token: "test-token" } },
+    status: "authenticated",
+    update: vi.fn(),
+  })),
+}));
+
+vi.mock("~/lib/tenant-router", () => ({
+  useTenantRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
 vi.mock("~/contexts/ToastContext", () => ({
   useToast: () => ({
     success: mockToastSuccess,

--- a/frontend/src/app/[tenant]/(protected)/activities/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.test.tsx
@@ -8,8 +8,9 @@ import {
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import ActivitiesPage from "./page";
 
-const { mockToastSuccess } = vi.hoisted(() => ({
+const { mockToastSuccess, mockPush } = vi.hoisted(() => ({
   mockToastSuccess: vi.fn(),
+  mockPush: vi.fn(),
 }));
 
 vi.mock("~/lib/swr", () => ({
@@ -28,7 +29,7 @@ vi.mock("next-auth/react", () => ({
 }));
 
 vi.mock("~/lib/tenant-router", () => ({
-  useTenantRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useTenantRouter: () => ({ push: mockPush, replace: vi.fn() }),
 }));
 
 vi.mock("~/contexts/ToastContext", () => ({
@@ -139,6 +140,13 @@ vi.mock("~/components/activities/quick-create-modal", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { useSession } from "next-auth/react";
+
+const authenticatedSession = {
+  data: { user: { token: "test-token" } },
+  status: "authenticated",
+  update: vi.fn(),
+} as never;
 
 const mockActivities = [
   {
@@ -206,6 +214,7 @@ describe("ActivitiesPage", () => {
     vi.clearAllMocks();
     mockMutate.mockClear();
     mockToastSuccess.mockClear();
+    vi.mocked(useSession).mockReturnValue(authenticatedSession);
     vi.mocked(useSWRAuth).mockReturnValue({
       data: {
         activities: mockActivities,
@@ -382,6 +391,46 @@ describe("ActivitiesPage", () => {
     expect(screen.getByText("Schach")).toBeInTheDocument();
     expect(screen.getByText("Anna Meyer")).toBeInTheDocument();
   });
+
+  it("redirects when session error is RefreshTokenExpired", async () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { token: "test-token" }, error: "RefreshTokenExpired" },
+      status: "authenticated",
+      update: vi.fn(),
+    } as never);
+    vi.mocked(useSWRAuth).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      mutate: mockMutate,
+    } as never);
+
+    render(<ActivitiesPage />);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/");
+    });
+  });
+
+  it("redirects when authenticated session has no token", async () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: {} },
+      status: "authenticated",
+      update: vi.fn(),
+    } as never);
+    vi.mocked(useSWRAuth).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      mutate: mockMutate,
+    } as never);
+
+    render(<ActivitiesPage />);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/");
+    });
+  });
 });
 
 describe("ActivitiesPage modal interactions", () => {
@@ -390,6 +439,7 @@ describe("ActivitiesPage modal interactions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockMutate.mockClear();
+    vi.mocked(useSession).mockReturnValue(authenticatedSession);
     vi.mocked(useSWRAuth).mockReturnValue({
       data: {
         activities: mockActivities,

--- a/frontend/src/app/[tenant]/(protected)/activities/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.test.tsx
@@ -273,7 +273,7 @@ describe("ActivitiesPage", () => {
 
     render(<ActivitiesPage />);
 
-    expect(screen.getByLabelText("Lädt...")).toBeInTheDocument();
+    expect(screen.getByTestId("activities-skeleton")).toBeInTheDocument();
   });
 
   it("shows error state when fetch fails", () => {

--- a/frontend/src/app/[tenant]/(protected)/activities/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback } from "react";
+import { useSession } from "next-auth/react";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import type {
   FilterConfig,
@@ -22,6 +23,7 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { useSWRAuth } from "~/lib/swr";
 import { createLogger } from "~/lib/logger";
 import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
+import { useTenantRouter } from "~/lib/tenant-router";
 import { NfcModeGuard } from "~/components/tenant/nfc-mode-guard";
 
 const logger = createLogger({ component: "ActivitiesPage" });
@@ -32,7 +34,6 @@ function ActivitiesSkeleton() {
   return (
     <div
       role="status"
-      aria-live="polite"
       aria-busy="true"
       aria-label="Aktivitäten werden geladen"
       data-testid="activities-skeleton"
@@ -91,6 +92,18 @@ function ActivitiesPageContent() {
   const [isQuickCreateOpen, setIsQuickCreateOpen] = useState(false);
   const { success: toastSuccess } = useToast();
   const [isMobile, setIsMobile] = useState(false);
+  const router = useTenantRouter();
+
+  // useSWRAuth silently disables the fetch when there is no authenticated
+  // session (data stays undefined, isLoading stays false). Require a session
+  // here so a direct visit after logout/expiry redirects instead of showing
+  // the skeleton forever.
+  const { status } = useSession({
+    required: true,
+    onUnauthenticated() {
+      router.push("/");
+    },
+  });
 
   // Fetch activities, categories, and current staff with SWR
   const {
@@ -287,10 +300,16 @@ function ActivitiesPageContent() {
     return filters;
   }, [searchTerm, categoryFilter, myActivitiesFilter, categories]);
 
-  // Also cover the session-loading phase, where useSWRAuth has not started
-  // fetching yet (isLoading is false but no data exists) — otherwise the
-  // empty state flashes before the first fetch begins.
-  if (isLoading || (pageData === undefined && !fetchError)) {
+  // Session loading is gated explicitly via status; the data clause covers
+  // the render tick between "authenticated" and SWR starting its first fetch
+  // (isLoading is still false there but no data exists yet). Unauthenticated
+  // visits redirect via the required-session guard above, so this cannot
+  // show the skeleton indefinitely.
+  if (
+    status === "loading" ||
+    isLoading ||
+    (pageData === undefined && !fetchError)
+  ) {
     return <ActivitiesSkeleton />;
   }
 

--- a/frontend/src/app/[tenant]/(protected)/activities/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.tsx
@@ -18,13 +18,43 @@ import { QuickCreateActivityModal } from "~/components/activities/quick-create-m
 import { userContextService } from "~/lib/usercontext-api";
 import type { Staff } from "~/lib/usercontext-helpers";
 import { useToast } from "~/contexts/ToastContext";
-import { Loading } from "~/components/ui/loading";
+import { Skeleton } from "~/components/ui/skeleton";
 import { useSWRAuth } from "~/lib/swr";
 import { createLogger } from "~/lib/logger";
 import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
 import { NfcModeGuard } from "~/components/tenant/nfc-mode-guard";
 
 const logger = createLogger({ component: "ActivitiesPage" });
+
+// Content-shaped placeholder mirroring the activity row cards, so there is no
+// layout shift once the list loads.
+function ActivitiesSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Aktivitäten werden geladen"
+      data-testid="activities-skeleton"
+      className="w-full space-y-3"
+    >
+      {[0, 1, 2, 3].map((item) => (
+        <div
+          key={item}
+          className="moto-content-surface rounded-2xl border border-gray-200 p-5"
+        >
+          <div className="flex items-center justify-between">
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-5 w-2/5 rounded-full" />
+              <Skeleton className="h-3.5 w-1/3 rounded-full" />
+            </div>
+            <Skeleton className="ml-4 h-10 w-10 flex-shrink-0 rounded-full" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 // SWR cache key for activities page data
 const ACTIVITIES_PAGE_KEY = "activities-page";
@@ -257,8 +287,11 @@ function ActivitiesPageContent() {
     return filters;
   }, [searchTerm, categoryFilter, myActivitiesFilter, categories]);
 
-  if (isLoading) {
-    return <Loading fullPage={false} />;
+  // Also cover the session-loading phase, where useSWRAuth has not started
+  // fetching yet (isLoading is false but no data exists) — otherwise the
+  // empty state flashes before the first fetch begins.
+  if (isLoading || (pageData === undefined && !fetchError)) {
+    return <ActivitiesSkeleton />;
   }
 
   return (

--- a/frontend/src/app/[tenant]/(protected)/activities/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.tsx
@@ -98,12 +98,31 @@ function ActivitiesPageContent() {
   // session (data stays undefined, isLoading stays false). Require a session
   // here so a direct visit after logout/expiry redirects instead of showing
   // the skeleton forever.
-  const { status } = useSession({
+  const { data: session, status } = useSession({
     required: true,
     onUnauthenticated() {
       router.push("/");
     },
   });
+
+  // The session callback can keep status "authenticated" while clearing the
+  // token and setting session.error (expired refresh token). useSWRAuth never
+  // starts without a token, so redirect instead of showing the skeleton
+  // forever — same pattern as the dashboard.
+  useEffect(() => {
+    if (status === "authenticated" && session) {
+      if (session.error === "RefreshTokenExpired") {
+        logger.info("session refresh token expired, redirecting to login");
+        router.push("/");
+        return;
+      }
+
+      if (!session.user?.token) {
+        logger.info("no valid token in session, redirecting to login");
+        router.push("/");
+      }
+    }
+  }, [status, session, router]);
 
   // Fetch activities, categories, and current staff with SWR
   const {
@@ -303,8 +322,9 @@ function ActivitiesPageContent() {
   // Session loading is gated explicitly via status; the data clause covers
   // the render tick between "authenticated" and SWR starting its first fetch
   // (isLoading is still false there but no data exists yet). Unauthenticated
-  // visits redirect via the required-session guard above, so this cannot
-  // show the skeleton indefinitely.
+  // visits redirect via the required-session guard, and expired/tokenless
+  // sessions redirect via the effect above, so this cannot show the skeleton
+  // indefinitely.
   if (
     status === "loading" ||
     isLoading ||

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.test.tsx
@@ -58,12 +58,6 @@ vi.mock("~/lib/usercontext-context", () => ({
   ),
 }));
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: ({ fullPage }: { fullPage?: boolean }) => (
-    <div data-testid="loading" data-fullpage={fullPage} aria-label="Lädt..." />
-  ),
-}));
-
 const mockDashboardData = {
   studentsPresent: 150,
   studentsInRooms: 120,
@@ -193,7 +187,9 @@ describe("DashboardPage", () => {
 
     render(<DashboardPage />);
 
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    // RoleGuard intercepts session-loading and renders the page's skeleton
+    // via its fallback prop.
+    expect(screen.getByTestId("dashboard-skeleton")).toBeInTheDocument();
   });
 
   it("displays dashboard data after loading", async () => {

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
@@ -28,7 +28,6 @@ function DashboardSkeleton() {
   return (
     <div
       role="status"
-      aria-live="polite"
       aria-busy="true"
       aria-label="Übersicht wird geladen"
       data-testid="dashboard-skeleton"

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
@@ -17,9 +17,68 @@ import { useSWRAuth } from "~/lib/swr/hooks";
 import { RoleGuard } from "~/components/auth/role-guard";
 import { useNFCEnabled, usePresenceMode } from "~/lib/tenant-context";
 
-import { Loading } from "~/components/ui/loading";
+import { Skeleton } from "~/components/ui/skeleton";
 
 const logger = createLogger({ component: "DashboardPage" });
+
+// Content-shaped placeholder for the auth-session loading gate — mirrors the
+// real shell (greeting, stat-card grid, info-card grid) so there is no layout
+// shift once data arrives.
+function DashboardSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Übersicht wird geladen"
+      data-testid="dashboard-skeleton"
+      className="mx-auto w-full max-w-7xl"
+    >
+      <div className="mb-6 md:mb-8">
+        <div className="ml-6 space-y-2">
+          <Skeleton className="h-8 w-64 rounded-full" />
+          <Skeleton className="h-4 w-48 rounded-full" />
+        </div>
+      </div>
+
+      <div className="mb-6 grid grid-cols-2 gap-3 md:mb-8 md:grid-cols-3 md:gap-4 xl:grid-cols-5">
+        {[0, 1, 2, 3, 4].map((item) => (
+          <div
+            key={item}
+            className="moto-content-surface rounded-3xl border p-4 shadow-sm md:p-6"
+          >
+            <div className="mb-3 flex items-start justify-between">
+              <Skeleton className="h-10 w-10 rounded-2xl md:h-12 md:w-12" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-2/3 rounded-full" />
+              <Skeleton className="h-7 w-1/2 rounded-full" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 items-stretch gap-4 md:gap-6 lg:grid-cols-2">
+        {[0, 1, 2, 3].map((item) => (
+          <div
+            key={item}
+            className="moto-content-surface rounded-3xl border p-4 shadow-sm md:p-6"
+          >
+            <div className="mb-4 flex items-center gap-2">
+              <Skeleton className="h-8 w-8 rounded-xl" />
+              <Skeleton className="h-5 w-32 rounded-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-12 w-full rounded-xl" />
+              <Skeleton className="h-12 w-full rounded-xl" />
+              <Skeleton className="h-12 w-full rounded-xl" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 // Helper function to get time-based greeting
 function getTimeBasedGreeting(): string {
@@ -300,7 +359,7 @@ function DashboardContent() {
   }, [status, session, router]);
 
   if (status === "loading") {
-    return <Loading fullPage={false} />;
+    return <DashboardSkeleton />;
   }
 
   const firstName = session?.user?.name?.split(" ")[0] ?? "User";
@@ -652,7 +711,7 @@ function DashboardContent() {
 // Main Dashboard Page Component
 export default function DashboardPage() {
   return (
-    <RoleGuard variant="adminOnly">
+    <RoleGuard variant="adminOnly" fallback={<DashboardSkeleton />}>
       <UserContextProvider>
         <DashboardContent />
       </UserContextProvider>

--- a/frontend/src/app/[tenant]/(protected)/database/layout.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/layout.test.tsx
@@ -25,8 +25,10 @@ vi.mock("~/lib/auth-utils", () => ({
   },
 }));
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: () => <div data-testid="loading">Loading...</div>,
+vi.mock("~/components/database/master-detail-skeleton", () => ({
+  MasterDetailSkeleton: () => (
+    <div data-testid="master-detail-skeleton">Loading...</div>
+  ),
 }));
 
 describe("DatabaseLayout", () => {
@@ -82,6 +84,6 @@ describe("DatabaseLayout", () => {
       </DatabaseLayout>,
     );
 
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(screen.getByTestId("master-detail-skeleton")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/database/layout.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { RoleGuard } from "~/components/auth/role-guard";
+import { MasterDetailSkeleton } from "~/components/database/master-detail-skeleton";
 
 export default function DatabaseLayout({
   children,
@@ -11,6 +12,7 @@ export default function DatabaseLayout({
     <RoleGuard
       variant="adminOnly"
       message="Du verfügst nicht über die notwendigen Berechtigungen, um die Datenverwaltung aufzurufen."
+      fallback={<MasterDetailSkeleton />}
     >
       {children}
     </RoleGuard>

--- a/frontend/src/app/[tenant]/(protected)/messages/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/page.tsx
@@ -7,6 +7,7 @@ import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWith
 import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/alert";
 import { Loading } from "~/components/ui/loading";
+import { Skeleton } from "~/components/ui/skeleton";
 import { UnreadBadge } from "~/components/messaging/unread-badge";
 import { useTenant, useTenantSlugSafe } from "~/lib/tenant-context";
 import { useTenantRouter } from "~/lib/tenant-router";
@@ -21,6 +22,40 @@ import { createLogger } from "~/lib/logger";
 import { formatChatDateTime } from "~/lib/date-helpers";
 
 const logger = createLogger({ component: "MessagesInboxPage" });
+
+// Content-shaped placeholder mirroring the thread-list rows, so there is no
+// layout shift once the inbox loads.
+function MessagesSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Nachrichten werden geladen"
+      data-testid="messages-skeleton"
+      className="-mt-1.5 w-full"
+    >
+      <ul className="space-y-3">
+        {[0, 1, 2, 3, 4].map((item) => (
+          <li key={item}>
+            <div className="moto-content-surface rounded-2xl border border-gray-200 bg-white p-4 sm:p-5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex min-w-0 flex-1 items-start gap-3">
+                  <Skeleton className="h-10 w-10 flex-shrink-0 rounded-full" />
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <Skeleton className="h-4 w-2/5 rounded-full" />
+                    <Skeleton className="h-3.5 w-3/5 rounded-full" />
+                  </div>
+                </div>
+                <Skeleton className="h-3 w-10 flex-shrink-0 rounded-full" />
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
 
 function MessagesInboxContent() {
   const router = useTenantRouter();
@@ -84,7 +119,7 @@ function MessagesInboxContent() {
 
   // Skeleton only on the very first load (no cached data yet).
   if (isLoading && !threads) {
-    return <Loading fullPage={false} />;
+    return <MessagesSkeleton />;
   }
 
   return (

--- a/frontend/src/app/[tenant]/(protected)/messages/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/page.tsx
@@ -6,7 +6,6 @@ import { MessageCircle } from "lucide-react";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/alert";
-import { Loading } from "~/components/ui/loading";
 import { Skeleton } from "~/components/ui/skeleton";
 import { UnreadBadge } from "~/components/messaging/unread-badge";
 import { useTenant, useTenantSlugSafe } from "~/lib/tenant-context";
@@ -29,7 +28,6 @@ function MessagesSkeleton() {
   return (
     <div
       role="status"
-      aria-live="polite"
       aria-busy="true"
       aria-label="Nachrichten werden geladen"
       data-testid="messages-skeleton"
@@ -262,7 +260,7 @@ function MessagesInboxContent() {
 
 export default function MessagesPage() {
   return (
-    <Suspense fallback={<Loading fullPage={false} />}>
+    <Suspense fallback={<MessagesSkeleton />}>
       <MessagesInboxContent />
     </Suspense>
   );

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -87,11 +87,6 @@ vi.mock("~/lib/breadcrumb-context", () => ({
   ),
 }));
 
-// Mock Loading component
-vi.mock("~/components/ui/loading", () => ({
-  Loading: () => <div data-testid="loading">Loading...</div>,
-}));
-
 // Mock PageHeaderWithSearch — renders filters, activeFilters, and the
 // overflow-menu items so the existing "Gruppe übergeben" assertions keep
 // working. The real OverflowMenu requires a click to expose its items, but
@@ -476,8 +471,8 @@ describe("OGSGroupPage", () => {
   it("shows loading state initially", async () => {
     render(<OGSGroupPage />);
 
-    // Initial loading state should show loading component
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    // Initial loading state should show the page-shell skeleton
+    expect(screen.getByTestId("ogs-groups-skeleton")).toBeInTheDocument();
   });
 
   it("renders with SSE error boundary wrapper", () => {
@@ -549,8 +544,8 @@ describe("OGSGroupPage", () => {
 
     render(<OGSGroupPage />);
 
-    // Should show loading state while SWR is loading
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    // Should show the page-shell skeleton while SWR is loading
+    expect(screen.getByTestId("ogs-groups-skeleton")).toBeInTheDocument();
   });
 
   it("displays group data when available", async () => {

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -46,7 +46,7 @@ import { useSWRAuth } from "~/lib/swr";
 import { useUserContext } from "~/lib/hooks/use-user-context";
 import { useGroupAttendanceCounts } from "~/lib/group-attendance-count-context";
 
-import { Loading } from "~/components/ui/loading";
+import { Skeleton } from "~/components/ui/skeleton";
 import { StudentPresenceBadge } from "@/components/ui/student-presence-badge";
 import { EmptyStudentResults } from "~/components/ui/empty-student-results";
 import {
@@ -55,6 +55,7 @@ import {
   ArrivalTimeRow,
   StudentAbsenceRow,
 } from "~/components/students/student-card";
+import { StudentCardGridSkeleton } from "~/components/students/student-card-skeleton";
 import { SchoolCheckinFab } from "~/components/students/school-checkin-fab";
 import { SchoolCheckinModeMobile } from "~/components/students/school-checkin-mode-mobile";
 import {
@@ -83,6 +84,30 @@ import {
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "OgsGroupsPage" });
+
+/**
+ * Page-shell skeleton for the OGS-groups gate/Suspense states: a
+ * PageHeaderWithSearch placeholder followed by the student-card grid, so
+ * swapping in the real content causes no layout shift.
+ */
+function OgsGroupsPageSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Gruppe wird geladen"
+      data-testid="ogs-groups-skeleton"
+      className="-mt-1.5 w-full"
+    >
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <Skeleton className="h-10 w-full max-w-md rounded-lg" />
+        <Skeleton className="h-10 w-32 flex-shrink-0 rounded-lg" />
+      </div>
+      <StudentCardGridSkeleton />
+    </div>
+  );
+}
 
 // Backend pickup time response (from BFF)
 interface BackendPickupTime {
@@ -1168,7 +1193,7 @@ function OGSGroupPageContent() {
   }, [sortMode, searchTerm, attendanceFilter]);
 
   if (status === "loading" || isLoading || hasAccess === null) {
-    return <Loading fullPage={false} />;
+    return <OgsGroupsPageSkeleton />;
   }
 
   // If user doesn't have access, show empty state
@@ -1272,7 +1297,7 @@ function OGSGroupPageContent() {
   // Render helper for student grid content
   const renderStudentContent = () => {
     if (isLoading) {
-      return <Loading fullPage={false} />;
+      return <StudentCardGridSkeleton />;
     }
     if (students.length === 0) {
       return (
@@ -1613,8 +1638,8 @@ function OGSGroupPageContent() {
 // Main component with Suspense wrapper
 export default function OGSGroupPage() {
   return (
-    <RoleGuard variant="staffOnly">
-      <Suspense fallback={<Loading fullPage={false} />}>
+    <RoleGuard variant="staffOnly" fallback={<OgsGroupsPageSkeleton />}>
+      <Suspense fallback={<OgsGroupsPageSkeleton />}>
         <SSEErrorBoundary>
           <OGSGroupPageContent />
         </SSEErrorBoundary>

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -46,7 +46,6 @@ import { useSWRAuth } from "~/lib/swr";
 import { useUserContext } from "~/lib/hooks/use-user-context";
 import { useGroupAttendanceCounts } from "~/lib/group-attendance-count-context";
 
-import { Skeleton } from "~/components/ui/skeleton";
 import { StudentPresenceBadge } from "@/components/ui/student-presence-badge";
 import { EmptyStudentResults } from "~/components/ui/empty-student-results";
 import {
@@ -55,7 +54,10 @@ import {
   ArrivalTimeRow,
   StudentAbsenceRow,
 } from "~/components/students/student-card";
-import { StudentCardGridSkeleton } from "~/components/students/student-card-skeleton";
+import {
+  StudentCardGridSkeleton,
+  StudentCardPageSkeleton,
+} from "~/components/students/student-card-skeleton";
 import { SchoolCheckinFab } from "~/components/students/school-checkin-fab";
 import { SchoolCheckinModeMobile } from "~/components/students/school-checkin-mode-mobile";
 import {
@@ -85,27 +87,13 @@ import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "OgsGroupsPage" });
 
-/**
- * Page-shell skeleton for the OGS-groups gate/Suspense states: a
- * PageHeaderWithSearch placeholder followed by the student-card grid, so
- * swapping in the real content causes no layout shift.
- */
+// Page-shell skeleton for the OGS-groups gate/Suspense states.
 function OgsGroupsPageSkeleton() {
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      aria-label="Gruppe wird geladen"
-      data-testid="ogs-groups-skeleton"
-      className="-mt-1.5 w-full"
-    >
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <Skeleton className="h-10 w-full max-w-md rounded-lg" />
-        <Skeleton className="h-10 w-32 flex-shrink-0 rounded-lg" />
-      </div>
-      <StudentCardGridSkeleton />
-    </div>
+    <StudentCardPageSkeleton
+      label="Gruppe wird geladen"
+      testId="ogs-groups-skeleton"
+    />
   );
 }
 

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.test.tsx
@@ -198,7 +198,9 @@ describe("RoomsPage", () => {
 
     render(<RoomsPage />);
 
-    expect(screen.getByLabelText("Lädt...")).toBeInTheDocument();
+    // Session loading now shows the same grid skeleton as the data-loading
+    // branch instead of the generic spinner.
+    expect(screen.getByTestId("rooms-grid-skeleton")).toBeInTheDocument();
   });
 
   it("filters rooms by search, building, and occupancy", async () => {

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -843,7 +843,7 @@ function RoomsPageContent() {
 export default function RoomsPage() {
   return (
     <BinaryModeGuard>
-      <Suspense fallback={<Loading fullPage={false} />}>
+      <Suspense fallback={<RoomsGridSkeleton />}>
         <RoomsPageContent />
       </Suspense>
     </BinaryModeGuard>

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -32,7 +32,6 @@ import {
   Footprints,
 } from "lucide-react";
 
-import { Loading } from "~/components/ui/loading";
 import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
 import { RoomDetailModal } from "~/components/rooms/room-detail-modal";
 import { TRANSIT_ROOM_ID } from "~/components/rooms/room-detail-modal";
@@ -551,11 +550,12 @@ function RoomsPageContent() {
     [exportTargetCount, handleExport, isExporting, loading],
   );
 
-  // Auth-loading: nothing to render until NextAuth resolves the session
-  // (the `useSession({ required: true })` callback redirects on
-  // unauthenticated). Keep the existing loader for this branch.
+  // Auth-loading: show the same skeleton as the Suspense fallback and the
+  // data-loading branch, so the cold-load sequence stays skeleton -> content
+  // without a spinner flash in between. The `useSession({ required: true })`
+  // callback redirects on unauthenticated.
   if (status === "loading") {
-    return <Loading fullPage={false} />;
+    return <RoomsGridSkeleton />;
   }
 
   return (

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
@@ -16,12 +16,71 @@ import { getInitials } from "~/lib/format-utils";
 import { useSWRAuth } from "~/lib/swr";
 import { isAdmin } from "~/lib/auth-utils";
 import { Tabs, TabsList, TabsTrigger } from "~/components/ui/tabs";
-import { Loading } from "~/components/ui/loading";
+import { Skeleton } from "~/components/ui/skeleton";
 import { AbwesenheitenTab } from "~/components/staff/abwesenheiten-tab";
 import { ArbeitszeitmodellTab } from "~/components/staff/arbeitszeitmodell-tab";
 import { UebersichtTab } from "~/components/staff/uebersicht-tab";
 import { ZeiterfassungTab } from "~/components/staff/zeiterfassung-tab";
 import { staffAbsenceService } from "~/lib/staff-api";
+
+// ─── Loading skeleton ────────────────────────────────────────────────────────
+
+function StaffDetailSkeleton() {
+  // Mirrors StaffHeader (avatar + name block + status badge) and the
+  // TabsList line, then two DataGrid-shaped field sections for the
+  // Übersicht tab body, so the loaded page swaps in without layout shift.
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Mitarbeiter wird geladen"
+      data-testid="staff-detail-skeleton"
+      className="-mt-1.5 w-full"
+    >
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 flex-1 items-start gap-4">
+          <Skeleton className="h-14 w-14 flex-shrink-0 rounded-full sm:h-16 sm:w-16" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-3 w-32 rounded" />
+            <Skeleton className="h-7 w-48 rounded" />
+            <Skeleton className="h-4 w-40 rounded" />
+          </div>
+        </div>
+        <div className="flex flex-shrink-0 items-center gap-2">
+          <Skeleton className="h-7 w-24 rounded-full" />
+          <Skeleton className="h-10 w-10 rounded-full" />
+        </div>
+      </div>
+
+      <div className="mb-6 flex gap-6 border-b border-gray-200 pb-px">
+        {Array.from({ length: 4 }, (_, i) => (
+          <Skeleton key={i} className="h-5 w-24 rounded" />
+        ))}
+      </div>
+
+      <div className="space-y-6">
+        {Array.from({ length: 2 }, (_, section) => (
+          <div
+            key={section}
+            className="rounded-3xl border border-gray-100/50 bg-white/90 p-6 shadow-sm"
+          >
+            <Skeleton className="mb-4 h-5 w-40 rounded" />
+            <dl className="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">
+              {Array.from({ length: 4 }, (_, field) => (
+                <div key={field} className="space-y-1.5">
+                  <Skeleton className="h-3 w-20 rounded" />
+                  <Skeleton className="h-4 w-32 rounded" />
+                </div>
+              ))}
+            </dl>
+          </div>
+        ))}
+      </div>
+      <span className="sr-only">Mitarbeiter wird geladen</span>
+    </div>
+  );
+}
 
 // ─── Labels & constants ──────────────────────────────────────────────────────
 
@@ -276,12 +335,12 @@ function StaffDetailContent() {
   }, [menuOpen]);
 
   if (sessionStatus === "loading" || isLoading) {
-    return <Loading fullPage={false} />;
+    return <StaffDetailSkeleton />;
   }
 
   if (!canEdit) {
     router.replace("/staff");
-    return <Loading fullPage={false} />;
+    return <StaffDetailSkeleton />;
   }
 
   if (error || !staff) {
@@ -394,7 +453,7 @@ function StaffDetailContent() {
 
 export default function StaffDetailPage() {
   return (
-    <Suspense fallback={<Loading fullPage={false} />}>
+    <Suspense fallback={<StaffDetailSkeleton />}>
       <StaffDetailContent />
     </Suspense>
   );

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
@@ -32,7 +32,6 @@ function StaffDetailSkeleton() {
   return (
     <div
       role="status"
-      aria-live="polite"
       aria-busy="true"
       aria-label="Mitarbeiter wird geladen"
       data-testid="staff-detail-skeleton"
@@ -77,7 +76,6 @@ function StaffDetailSkeleton() {
           </div>
         ))}
       </div>
-      <span className="sr-only">Mitarbeiter wird geladen</span>
     </div>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/staff/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/page.test.tsx
@@ -112,7 +112,9 @@ describe("StaffPage", () => {
 
     render(<StaffPage />);
 
-    expect(screen.getByLabelText("Lädt...")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Mitarbeitende werden geladen"),
+    ).toBeInTheDocument();
   });
 
   it("filters staff by search and location", async () => {
@@ -240,7 +242,9 @@ describe("StaffPage", () => {
 
     render(<StaffPage />);
 
-    expect(screen.getByLabelText("Lädt...")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Mitarbeitende werden geladen"),
+    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/app/[tenant]/(protected)/staff/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/page.tsx
@@ -20,8 +20,67 @@ import {
 import { useSWRAuth } from "~/lib/swr";
 import { useTenantRouter } from "~/lib/tenant-router";
 import { isAdmin } from "~/lib/auth-utils";
+import { Skeleton } from "~/components/ui/skeleton";
 
-import { Loading } from "~/components/ui/loading";
+function StaffCardSkeleton() {
+  // Mirrors the staff card: avatar-less header (name lines + status badge),
+  // supervision/qualification rows, footer hint — same p-5 pb-4 surface.
+  return (
+    <div className="moto-content-surface w-full overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <div className="p-5 pb-4">
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-5 w-2/3 rounded" />
+            <Skeleton className="h-4 w-1/2 rounded" />
+            <Skeleton className="h-3 w-2/5 rounded" />
+          </div>
+          <Skeleton className="h-6 w-20 flex-shrink-0 rounded-full" />
+        </div>
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-3.5 w-4/5 rounded" />
+          <div className="flex flex-wrap gap-2">
+            <Skeleton className="h-5 w-16 rounded" />
+            <Skeleton className="h-5 w-20 rounded" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StaffPageSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Mitarbeitende werden geladen"
+      data-testid="staff-page-skeleton"
+      className="-mt-1.5 w-full"
+    >
+      {/* PageHeaderWithSearch placeholder: title + search field + filter chips */}
+      <div className="mb-4 flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-3">
+          <Skeleton className="h-6 w-32 rounded" />
+          <Skeleton className="h-10 w-full max-w-sm flex-1 rounded-lg sm:max-w-md" />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 5 }, (_, i) => (
+            <Skeleton key={i} className="h-8 w-24 rounded-full" />
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
+        {Array.from({ length: 6 }, (_, i) => (
+          <StaffCardSkeleton key={i} />
+        ))}
+      </div>
+      <span className="sr-only">Mitarbeitende werden geladen</span>
+    </div>
+  );
+}
+
 function StaffPageContent() {
   const { data: session, status } = useSession({
     required: true,
@@ -198,7 +257,7 @@ function StaffPageContent() {
   }, [searchTerm, locationFilter]);
 
   if (status === "loading" || isLoading) {
-    return <Loading fullPage={false} />;
+    return <StaffPageSkeleton />;
   }
 
   return (
@@ -409,7 +468,7 @@ function StaffPageContent() {
 // Main component with Suspense wrapper
 export default function StaffPage() {
   return (
-    <Suspense fallback={<Loading fullPage={false} />}>
+    <Suspense fallback={<StaffPageSkeleton />}>
       <StaffPageContent />
     </Suspense>
   );

--- a/frontend/src/app/[tenant]/(protected)/staff/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/page.tsx
@@ -52,7 +52,6 @@ function StaffPageSkeleton() {
   return (
     <div
       role="status"
-      aria-live="polite"
       aria-busy="true"
       aria-label="Mitarbeitende werden geladen"
       data-testid="staff-page-skeleton"
@@ -76,7 +75,6 @@ function StaffPageSkeleton() {
           <StaffCardSkeleton key={i} />
         ))}
       </div>
-      <span className="sr-only">Mitarbeitende werden geladen</span>
     </div>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
@@ -43,13 +43,6 @@ vi.mock("~/lib/breadcrumb-context", () => ({
   ),
 }));
 
-// Mock Loading component
-vi.mock("~/components/ui/loading", () => ({
-  Loading: ({ message }: { message?: string }) => (
-    <div data-testid="loading">{message ?? "Loading..."}</div>
-  ),
-}));
-
 // Mock Alert component
 vi.mock("~/components/ui/alert", () => ({
   Alert: ({ message, type }: { message: string; type: string }) => (
@@ -566,8 +559,8 @@ describe("StudentDetailPage", () => {
 
       render(<StudentDetailPage />);
 
-      expect(screen.getByTestId("loading")).toBeInTheDocument();
-      expect(screen.getByText("Laden...")).toBeInTheDocument();
+      expect(screen.getByTestId("student-detail-skeleton")).toBeInTheDocument();
+      expect(screen.getByLabelText("Kind wird geladen")).toBeInTheDocument();
     });
   });
 
@@ -1825,7 +1818,7 @@ describe("StudentDetailPage", () => {
       });
 
       const { rerender } = render(<StudentDetailPage />);
-      expect(screen.getByTestId("loading")).toBeInTheDocument();
+      expect(screen.getByTestId("student-detail-skeleton")).toBeInTheDocument();
 
       // Same component instance now finishes loading with full access.
       mockUseStudentData.mockReturnValue({

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -250,7 +250,6 @@ function StudentDetailSkeleton() {
   return (
     <div
       role="status"
-      aria-live="polite"
       aria-busy="true"
       aria-label="Kind wird geladen"
       data-testid="student-detail-skeleton"
@@ -298,7 +297,6 @@ function StudentDetailSkeleton() {
           </dl>
         </div>
       </div>
-      <span className="sr-only">Kind wird geladen</span>
     </div>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -14,7 +14,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { useSetBreadcrumb } from "~/lib/breadcrumb-context";
 import { Alert } from "~/components/ui/alert";
 import { useToast } from "~/contexts/ToastContext";
-import { Loading } from "~/components/ui/loading";
+import { Skeleton } from "~/components/ui/skeleton";
 import { ConfirmationModal } from "~/components/ui/modal";
 import { BackButton } from "~/components/ui/back-button";
 import { studentService } from "~/lib/api";
@@ -237,6 +237,70 @@ function mergeStatusDays(
     byId.set(day.id, day);
   }
   return Array.from(byId.values()).sort((a, b) => a.date.localeCompare(b.date));
+}
+
+// =============================================================================
+// LOADING SKELETON
+// =============================================================================
+
+// Mirrors StudentDetailHeader (avatar + name + meta rows + location badge),
+// the checkout/checkin action-card row, the tab bar, and a Stammdaten-shaped
+// field section, so the loaded page swaps in without layout shift.
+function StudentDetailSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Kind wird geladen"
+      data-testid="student-detail-skeleton"
+      className="mx-auto max-w-7xl"
+    >
+      <Skeleton className="mb-4 h-9 w-24 rounded-lg" />
+
+      <div className="mb-6 flex items-end justify-between gap-4">
+        <div className="ml-6 flex flex-1 items-center gap-4">
+          <Skeleton className="h-16 w-16 flex-shrink-0 rounded-full" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-7 w-48 rounded" />
+            <Skeleton className="h-4 w-32 rounded" />
+            <Skeleton className="h-4 w-56 rounded" />
+          </div>
+        </div>
+        <div className="mr-4 flex-shrink-0 pb-3">
+          <Skeleton className="h-8 w-28 rounded-full" />
+        </div>
+      </div>
+
+      <div className="mb-4 flex gap-3 sm:mb-6 sm:gap-4">
+        <Skeleton className="h-20 w-full rounded-2xl" />
+        <Skeleton className="h-20 w-full rounded-2xl" />
+      </div>
+
+      <div className="overflow-x-auto border-b border-gray-200">
+        <div className="flex w-max gap-6 pb-px">
+          {Array.from({ length: 5 }, (_, i) => (
+            <Skeleton key={i} className="h-5 w-24 rounded" />
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-4 sm:mt-6 sm:space-y-6">
+        <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
+          <Skeleton className="mb-4 h-5 w-40 rounded" />
+          <dl className="grid grid-cols-1 gap-x-3 gap-y-2 sm:grid-cols-2 md:gap-x-4 md:gap-y-3">
+            {Array.from({ length: 6 }, (_, field) => (
+              <div key={field} className="space-y-1.5">
+                <Skeleton className="h-3 w-20 rounded" />
+                <Skeleton className="h-4 w-32 rounded" />
+              </div>
+            ))}
+          </dl>
+        </div>
+      </div>
+      <span className="sr-only">Kind wird geladen</span>
+    </div>
+  );
 }
 
 // =============================================================================
@@ -540,7 +604,7 @@ export default function StudentDetailPage() {
 
   // Show loading state
   if (loading) {
-    return <Loading message="Laden..." fullPage={false} />;
+    return <StudentDetailSkeleton />;
   }
 
   // Show error state

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -41,13 +41,6 @@ vi.mock("~/lib/breadcrumb-context", () => ({
   ),
 }));
 
-// Mock Loading component
-vi.mock("~/components/ui/loading", () => ({
-  Loading: ({ fullPage }: { fullPage?: boolean }) => (
-    <div data-testid={fullPage ? "loading-full" : "loading"}>Loading...</div>
-  ),
-}));
-
 // Mock Alert component
 vi.mock("~/components/ui/alert", () => ({
   Alert: ({ message, type }: { message: string; type: string }) => (
@@ -1144,7 +1137,9 @@ describe("StudentSearchPage", () => {
 
       render(<StudentSearchPage />);
 
-      expect(screen.getByTestId("loading")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("students-search-skeleton"),
+      ).toBeInTheDocument();
     });
 
     it("shows loading state while fetching students", async () => {
@@ -1161,7 +1156,9 @@ describe("StudentSearchPage", () => {
       render(<StudentSearchPage />);
 
       await waitFor(() => {
-        expect(screen.getByTestId("loading")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("student-card-grid-skeleton"),
+        ).toBeInTheDocument();
       });
     });
   });
@@ -1602,7 +1599,9 @@ describe("StudentSearchPage", () => {
       render(<StudentSearchPage />);
 
       // Should show loading, NOT empty state
-      expect(screen.getByTestId("loading")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("students-search-skeleton"),
+      ).toBeInTheDocument();
       expect(
         screen.queryByText("Keine Kinder gefunden"),
       ).not.toBeInTheDocument();
@@ -1664,9 +1663,11 @@ describe("StudentSearchPage", () => {
         render(<StudentSearchPage />);
       });
 
-      // P2 FIX: Should show loading spinner, NOT "Keine Kinder gefunden"
+      // P2 FIX: Should show the grid skeleton, NOT "Keine Kinder gefunden"
       // because we're in initialization phase (groupsLoaded = false)
-      expect(screen.getByTestId("loading")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("student-card-grid-skeleton"),
+      ).toBeInTheDocument();
       expect(
         screen.queryByText("Keine Kinder gefunden"),
       ).not.toBeInTheDocument();

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -24,7 +24,6 @@ import { DetailIcons } from "~/components/ui/detail-modal-components";
 import { studentService, groupService, roomService } from "~/lib/api";
 import type { Student, Group, Room } from "~/lib/api";
 import { useUserContext } from "~/lib/hooks/use-user-context";
-import { Skeleton } from "~/components/ui/skeleton";
 import { StudentPresenceBadge } from "@/components/ui/student-presence-badge";
 import {
   LOCATION_STATUSES,
@@ -48,7 +47,10 @@ import {
   StudentAbsenceRow,
 } from "~/components/students/student-card";
 import { StudentExportModal } from "~/components/students/student-export-modal";
-import { StudentCardGridSkeleton } from "~/components/students/student-card-skeleton";
+import {
+  StudentCardGridSkeleton,
+  StudentCardPageSkeleton,
+} from "~/components/students/student-card-skeleton";
 import { SchoolCheckinFab } from "~/components/students/school-checkin-fab";
 import { SchoolCheckinModeMobile } from "~/components/students/school-checkin-mode-mobile";
 import {
@@ -83,27 +85,13 @@ import {
 const logger = createLogger({ component: "StudentSearchPage" });
 const EMPTY_STRING_ARRAY: string[] = [];
 
-/**
- * Page-shell skeleton for the student-search gate/Suspense states: a
- * PageHeaderWithSearch placeholder followed by the student-card grid, so
- * swapping in the real content causes no layout shift.
- */
+// Page-shell skeleton for the student-search gate/Suspense states.
 function StudentSearchPageSkeleton() {
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      aria-label="Kindersuche wird geladen"
-      data-testid="students-search-skeleton"
-      className="-mt-1.5 w-full"
-    >
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <Skeleton className="h-10 w-full max-w-md rounded-lg" />
-        <Skeleton className="h-10 w-32 flex-shrink-0 rounded-lg" />
-      </div>
-      <StudentCardGridSkeleton />
-    </div>
+    <StudentCardPageSkeleton
+      label="Kindersuche wird geladen"
+      testId="students-search-skeleton"
+    />
   );
 }
 

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -24,7 +24,7 @@ import { DetailIcons } from "~/components/ui/detail-modal-components";
 import { studentService, groupService, roomService } from "~/lib/api";
 import type { Student, Group, Room } from "~/lib/api";
 import { useUserContext } from "~/lib/hooks/use-user-context";
-import { Loading } from "~/components/ui/loading";
+import { Skeleton } from "~/components/ui/skeleton";
 import { StudentPresenceBadge } from "@/components/ui/student-presence-badge";
 import {
   LOCATION_STATUSES,
@@ -48,6 +48,7 @@ import {
   StudentAbsenceRow,
 } from "~/components/students/student-card";
 import { StudentExportModal } from "~/components/students/student-export-modal";
+import { StudentCardGridSkeleton } from "~/components/students/student-card-skeleton";
 import { SchoolCheckinFab } from "~/components/students/school-checkin-fab";
 import { SchoolCheckinModeMobile } from "~/components/students/school-checkin-mode-mobile";
 import {
@@ -81,6 +82,30 @@ import {
 
 const logger = createLogger({ component: "StudentSearchPage" });
 const EMPTY_STRING_ARRAY: string[] = [];
+
+/**
+ * Page-shell skeleton for the student-search gate/Suspense states: a
+ * PageHeaderWithSearch placeholder followed by the student-card grid, so
+ * swapping in the real content causes no layout shift.
+ */
+function StudentSearchPageSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Kindersuche wird geladen"
+      data-testid="students-search-skeleton"
+      className="-mt-1.5 w-full"
+    >
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <Skeleton className="h-10 w-full max-w-md rounded-lg" />
+        <Skeleton className="h-10 w-32 flex-shrink-0 rounded-lg" />
+      </div>
+      <StudentCardGridSkeleton />
+    </div>
+  );
+}
 
 type StatusFilter =
   | "all"
@@ -1882,7 +1907,7 @@ function SearchPageContent() {
   // Fix P2: Show loading during initialization (prevents empty state flash)
   // Note: With required: true, unauthenticated users are auto-redirected to login
   if (isInitializing || isAuthError) {
-    return <Loading />;
+    return <StudentSearchPageSkeleton />;
   }
 
   return (
@@ -1977,7 +2002,7 @@ function SearchPageContent() {
         {(() => {
           // Fix P2: Show loading while first fetch is in progress (not yet hasFetchedOnce)
           if (isSearching && !hasFetchedOnce) {
-            return <Loading fullPage={false} />;
+            return <StudentCardGridSkeleton />;
           }
           if (errorMessage) {
             return (
@@ -2241,7 +2266,7 @@ function SearchPageContent() {
 // Main component with Suspense wrapper
 export default function StudentSearchPage() {
   return (
-    <Suspense fallback={<Loading fullPage={false} />}>
+    <Suspense fallback={<StudentSearchPageSkeleton />}>
       <SearchPageContent />
     </Suspense>
   );

--- a/frontend/src/components/auth/role-guard.tsx
+++ b/frontend/src/components/auth/role-guard.tsx
@@ -10,9 +10,16 @@ interface RoleGuardProps {
   readonly variant: "adminOnly" | "staffOnly";
   readonly children: React.ReactNode;
   readonly message?: string;
+  /** Rendered while the session loads; pages pass their skeleton to avoid a spinner flash. */
+  readonly fallback?: React.ReactNode;
 }
 
-export function RoleGuard({ variant, children, message }: RoleGuardProps) {
+export function RoleGuard({
+  variant,
+  children,
+  message,
+  fallback,
+}: RoleGuardProps) {
   const { data: session, status } = useSession({
     required: true,
     onUnauthenticated() {
@@ -21,7 +28,7 @@ export function RoleGuard({ variant, children, message }: RoleGuardProps) {
   });
 
   if (status === "loading") {
-    return <Loading fullPage={false} />;
+    return <>{fallback ?? <Loading fullPage={false} />}</>;
   }
 
   const isAllowed =

--- a/frontend/src/components/database/database-page-layout.test.tsx
+++ b/frontend/src/components/database/database-page-layout.test.tsx
@@ -3,11 +3,9 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { DatabasePageLayout } from "./database-page-layout";
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: ({ fullPage }: { fullPage?: boolean }) => (
-    <div data-testid="loading" data-full-page={String(fullPage)}>
-      Loading...
-    </div>
+vi.mock("./master-detail-skeleton", () => ({
+  MasterDetailSkeleton: () => (
+    <div data-testid="master-detail-skeleton">Loading...</div>
   ),
 }));
 
@@ -23,7 +21,7 @@ describe("DatabasePageLayout", () => {
       </DatabasePageLayout>,
     );
 
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(screen.getByTestId("master-detail-skeleton")).toBeInTheDocument();
     expect(screen.queryByText("Content")).not.toBeInTheDocument();
   });
 
@@ -34,7 +32,7 @@ describe("DatabasePageLayout", () => {
       </DatabasePageLayout>,
     );
 
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(screen.getByTestId("master-detail-skeleton")).toBeInTheDocument();
   });
 
   it("renders children and mobile back button when not loading", () => {
@@ -44,7 +42,9 @@ describe("DatabasePageLayout", () => {
       </DatabasePageLayout>,
     );
 
-    expect(screen.queryByTestId("loading")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("master-detail-skeleton"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Content")).toBeInTheDocument();
     expect(screen.getByTestId("mobile-back")).toBeInTheDocument();
   });

--- a/frontend/src/components/database/database-page-layout.tsx
+++ b/frontend/src/components/database/database-page-layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { Loading } from "~/components/ui/loading";
+import { MasterDetailSkeleton } from "./master-detail-skeleton";
 import { MobileBackButton } from "~/components/ui/mobile-back-button";
 
 interface DatabasePageLayoutProps {
@@ -28,7 +28,7 @@ export function DatabasePageLayout({
   className = "w-full",
 }: Readonly<DatabasePageLayoutProps>) {
   if (sessionLoading || loading) {
-    return <Loading fullPage={false} />;
+    return <MasterDetailSkeleton />;
   }
 
   return (

--- a/frontend/src/components/database/master-detail-skeleton.tsx
+++ b/frontend/src/components/database/master-detail-skeleton.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { MasterDetailLayout } from "./master-detail-layout";
+import { Skeleton } from "~/components/ui/skeleton";
+
+function ListRowSkeleton() {
+  // Mirrors DatabaseListItem: title + subtitle lines, chevron slot.
+  return (
+    <div className="flex w-full items-center gap-3 border-b border-gray-100 px-4 py-2.5">
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <Skeleton className="h-4 w-2/3 rounded" />
+        <Skeleton className="h-3 w-1/2 rounded" />
+      </div>
+      <Skeleton className="h-4 w-4 shrink-0 rounded" />
+    </div>
+  );
+}
+
+/**
+ * Loading placeholder for database master/detail pages. Renders the page
+ * header strip plus the real MasterDetailLayout containers (identical
+ * width/height behavior, including the mobile single-column variant) filled
+ * with row skeletons, so the loaded page swaps in without layout shift.
+ * All database pages use unselectedBehavior="expand", so the skeleton shows
+ * the full-width list state that appears when data arrives.
+ */
+export function MasterDetailSkeleton({
+  rowCount = 8,
+  label = "Daten werden geladen",
+}: Readonly<{ rowCount?: number; label?: string }>) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label={label}
+      data-testid="master-detail-skeleton"
+      className="-mt-1.5 flex w-full flex-col"
+    >
+      {/* PageHeaderWithSearch placeholder: search field + action button row */}
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <Skeleton className="h-10 w-full max-w-md rounded-lg" />
+        <Skeleton className="h-10 w-32 flex-shrink-0 rounded-lg" />
+      </div>
+      <div className="min-h-0 flex-1 pb-4">
+        <MasterDetailLayout
+          selectedId={null}
+          onDeselect={() => undefined}
+          unselectedBehavior="expand"
+          list={
+            <div>
+              {Array.from({ length: rowCount }, (_, i) => (
+                <ListRowSkeleton key={i} />
+              ))}
+            </div>
+          }
+          detail={null}
+        />
+      </div>
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/database/master-detail-skeleton.tsx
+++ b/frontend/src/components/database/master-detail-skeleton.tsx
@@ -2,6 +2,7 @@
 
 import { MasterDetailLayout } from "./master-detail-layout";
 import { Skeleton } from "~/components/ui/skeleton";
+import { PageHeaderSkeleton } from "~/components/ui/page-header/PageHeaderSkeleton";
 
 function ListRowSkeleton() {
   // Mirrors DatabaseListItem: title + subtitle lines, chevron slot.
@@ -31,17 +32,12 @@ export function MasterDetailSkeleton({
   return (
     <div
       role="status"
-      aria-live="polite"
       aria-busy="true"
       aria-label={label}
       data-testid="master-detail-skeleton"
       className="-mt-1.5 flex w-full flex-col"
     >
-      {/* PageHeaderWithSearch placeholder: search field + action button row */}
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <Skeleton className="h-10 w-full max-w-md rounded-lg" />
-        <Skeleton className="h-10 w-32 flex-shrink-0 rounded-lg" />
-      </div>
+      <PageHeaderSkeleton />
       <div className="min-h-0 flex-1 pb-4">
         <MasterDetailLayout
           selectedId={null}
@@ -57,7 +53,6 @@ export function MasterDetailSkeleton({
           detail={null}
         />
       </div>
-      <span className="sr-only">{label}</span>
     </div>
   );
 }

--- a/frontend/src/components/students/student-card-skeleton.tsx
+++ b/frontend/src/components/students/student-card-skeleton.tsx
@@ -1,0 +1,58 @@
+// components/students/student-card-skeleton.tsx
+// Skeleton mirror of StudentCard, shared by the OGS groups and student
+// search pages so their loading state keeps the exact card-grid footprint.
+
+import { Skeleton } from "~/components/ui/skeleton";
+
+/**
+ * Mirrors StudentCard's surface (rounded-2xl border, p-6 pb-5) and header
+ * layout (avatar + name lines, badge pill right, meta rows, bottom hint)
+ * so swapping in real cards causes no layout shift.
+ */
+function StudentCardSkeleton() {
+  return (
+    <div className="moto-content-surface w-full overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <div className="p-6 pb-5">
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-start gap-3">
+              <Skeleton className="h-10 w-10 flex-shrink-0 rounded-full" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-5 w-2/3 rounded" />
+                <Skeleton className="h-4 w-1/2 rounded" />
+              </div>
+            </div>
+            <Skeleton className="mt-3 h-3.5 w-3/5 rounded" />
+          </div>
+          <Skeleton className="h-6 w-20 flex-shrink-0 rounded-full" />
+        </div>
+        <Skeleton className="h-3 w-28 rounded" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Grid of StudentCardSkeletons using the same responsive grid classes as
+ * the real student-card grids in ogs-groups and students/search.
+ */
+export function StudentCardGridSkeleton({
+  count = 6,
+  label = "Kinder werden geladen",
+}: Readonly<{ count?: number; label?: string }>) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label={label}
+      data-testid="student-card-grid-skeleton"
+      className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3"
+    >
+      {Array.from({ length: count }, (_, i) => (
+        <StudentCardSkeleton key={i} />
+      ))}
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/students/student-card-skeleton.tsx
+++ b/frontend/src/components/students/student-card-skeleton.tsx
@@ -3,6 +3,7 @@
 // search pages so their loading state keeps the exact card-grid footprint.
 
 import { Skeleton } from "~/components/ui/skeleton";
+import { PageHeaderSkeleton } from "~/components/ui/page-header/PageHeaderSkeleton";
 
 /**
  * Mirrors StudentCard's surface (rounded-2xl border, p-6 pb-5) and header
@@ -32,9 +33,21 @@ function StudentCardSkeleton() {
   );
 }
 
+// Same responsive grid classes as the real student-card grids in
+// ogs-groups and students/search.
+function StudentCardGrid({ count }: Readonly<{ count: number }>) {
+  return (
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
+      {Array.from({ length: count }, (_, i) => (
+        <StudentCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
 /**
- * Grid of StudentCardSkeletons using the same responsive grid classes as
- * the real student-card grids in ogs-groups and students/search.
+ * Standalone grid of StudentCardSkeletons with its own status role, for
+ * data-loading branches that replace only the card grid.
  */
 export function StudentCardGridSkeleton({
   count = 6,
@@ -43,16 +56,35 @@ export function StudentCardGridSkeleton({
   return (
     <div
       role="status"
-      aria-live="polite"
       aria-busy="true"
       aria-label={label}
       data-testid="student-card-grid-skeleton"
-      className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3"
     >
-      {Array.from({ length: count }, (_, i) => (
-        <StudentCardSkeleton key={i} />
-      ))}
-      <span className="sr-only">{label}</span>
+      <StudentCardGrid count={count} />
+    </div>
+  );
+}
+
+/**
+ * Page-shell skeleton for the gate/Suspense states of the student-card
+ * pages (ogs-groups, students/search): a PageHeaderWithSearch placeholder
+ * followed by the card grid, so swapping in the real content causes no
+ * layout shift. Owns the single status role for the whole shell.
+ */
+export function StudentCardPageSkeleton({
+  label,
+  testId,
+}: Readonly<{ label: string; testId: string }>) {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label={label}
+      data-testid={testId}
+      className="-mt-1.5 w-full"
+    >
+      <PageHeaderSkeleton />
+      <StudentCardGrid count={6} />
     </div>
   );
 }

--- a/frontend/src/components/ui/page-header/PageHeaderSkeleton.tsx
+++ b/frontend/src/components/ui/page-header/PageHeaderSkeleton.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from "~/components/ui/skeleton";
+
+/**
+ * Placeholder for the PageHeaderWithSearch strip (search field + action
+ * button), shared by page-shell skeletons so the loaded header swaps in
+ * without layout shift.
+ */
+export function PageHeaderSkeleton() {
+  return (
+    <div className="mb-4 flex items-center justify-between gap-3">
+      <Skeleton className="h-10 w-full max-w-md rounded-lg" />
+      <Skeleton className="h-10 w-32 flex-shrink-0 rounded-lg" />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #793

## What

Replaces the generic centered `<Loading>` spinner with content-shaped, mobile-responsive skeleton loading states across the tenant app, so pages render without layout shift. Follows the established pattern from suggestions/rooms/settings/timetables (`Skeleton` atom, wrapper mirrors the real markup's grid classes, `role="status"` + `aria-busy` + German `aria-label` + `data-testid`).

## Pages

- **Dashboard** – shell skeleton (greeting, 5-col stat grid, info-card grid)
- **Meine Gruppe (ogs-groups)** + **Kindersuche** – shared `StudentCardGridSkeleton`, used in the loading gate, the content branch, and the Suspense fallback
- **Aktivitäten** – row-card skeleton; also fixes a pre-existing empty-state flash during session load (`useSWRAuth` reports `isLoading: false` before the session is ready)
- **Nachrichten** – thread-list skeleton
- **Mitarbeiter** + **Mitarbeiter-Detail** + **Kind-Detail** – card grid / detail skeletons
- **Räume** – Suspense fallback now reuses the existing `RoomsGridSkeleton` (one-line change)
- **Datenverwaltung (all 8 pages)** – one `MasterDetailSkeleton` wired into `DatabasePageLayout`
- **Einstellungen** already had a skeleton; **Einladungen** is a pure redirect – no changes

## New shared components (per frontend-ui-kit rule)

Two additions instead of inlined one-offs, both justified by multi-page reuse:

1. `components/students/student-card-skeleton.tsx` – `StudentCardGridSkeleton`, reused by ogs-groups and students/search (identical card grids). Domain-scoped next to `student-card.tsx`, like `compact-student-card.tsx`.
2. `components/database/master-detail-skeleton.tsx` – `MasterDetailSkeleton`, reused verbatim by all 8 database pages via the `DatabasePageLayout` chokepoint. It renders the real `MasterDetailLayout` container (with `unselectedBehavior="expand"`, matching every consumer) so the swap is pixel-stable, including the mobile single-column variant.

## RoleGuard change

`RoleGuard` rendered the spinner before any page skeleton could appear (it wraps dashboard, ogs-groups, and the database section). It now accepts an optional `fallback` node; those three sites pass their skeleton. Default behavior unchanged for all other consumers.

## Verification

- `pnpm run check` – zero warnings
- `pnpm vitest run` – 772 files, 10,595 tests green (loading-state assertions updated to the new test ids)
- Visually verified against the running app at 1440px and 375px (throttled first-load): skeleton bounding boxes match loaded content on dashboard, staff, ogs-groups, activities, database (Kinder + Gruppen), mobile variants – no visible shift
- Modals keep the generic `Loading`, per issue requirement

Screenshots: skeleton/loaded pairs captured locally; will attach below.