### PR TITLE
fix: repair is_system backfill for staff-provisioned Schulhof activities

### DIFF
--- a/backend/database/migrations/001015169_repair_schulhof_is_system_backfill.go
+++ b/backend/database/migrations/001015169_repair_schulhof_is_system_backfill.go
@@ -1,0 +1,72 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	repairSchulhofIsSystemVersion     = "1.15.169"
+	repairSchulhofIsSystemDescription = "Repair the 1.15.168 is_system backfill: flag Schulhof activities provisioned via ToggleSupervision, which carry a staff created_by and were skipped by the created_by IS NULL predicate (issue #923 review)."
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     repairSchulhofIsSystemVersion,
+		Description: repairSchulhofIsSystemDescription,
+		DependsOn: []string{
+			addIsSystemFlagsVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error { return repairSchulhofIsSystemBackfillUp(ctx, db) },
+		func(ctx context.Context, db *bun.DB) error { return repairSchulhofIsSystemBackfillDown(ctx, db) },
+	)
+}
+
+func repairSchulhofIsSystemBackfillUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.169: Repairing is_system backfill for staff-provisioned Schulhof activities...")
+
+	// 1.15.168 flagged activity groups only where created_by IS NULL, but
+	// created_by does not cleanly separate system from staff rows for
+	// Schulhof: ToggleSupervision calls EnsureInfrastructure(ctx, staffID),
+	// so an auto-provisioned 'Schulhof Freispiel' can carry a staff
+	// created_by. Provisioning always links the activity to the tenant's
+	// 'Schulhof' category (UNIQUE(tenant_id, name)), so flag rows that are
+	// either system-created (settings-toggle path, already covered by
+	// 1.15.168) or linked to that category — without catching unrelated
+	// staff activities that merely share the name.
+	//
+	// WC needs no repair: its provisioning (wc_service.go and the IoT
+	// checkin paths) never sets created_by, so 1.15.168 already flagged
+	// every system WC row.
+	if _, err := db.NewRaw(`
+		UPDATE activities.groups g
+		SET is_system = TRUE
+		WHERE g.name = 'Schulhof Freispiel'
+		  AND g.is_system = FALSE
+		  AND (
+			g.created_by IS NULL
+			OR EXISTS (
+				SELECT 1 FROM activities.categories c
+				WHERE c.id = g.category_id
+				  AND c.tenant_id = g.tenant_id
+				  AND c.name = 'Schulhof'
+			)
+		  );
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed repairing Schulhof system activity flags: %w", err)
+	}
+	return nil
+}
+
+func repairSchulhofIsSystemBackfillDown(ctx context.Context, db *bun.DB) error {
+	// Intentionally a no-op: the repaired rows are indistinguishable from
+	// rows 1.15.168 flagged, and the 1.15.168 down migration drops the
+	// is_system columns entirely.
+	fmt.Println("Rolling back migration 1.15.169 (no-op)...")
+	return nil
+}

--- a/backend/database/migrations/001015169_repair_schulhof_is_system_backfill_test.go
+++ b/backend/database/migrations/001015169_repair_schulhof_is_system_backfill_test.go
@@ -1,0 +1,117 @@
+package migrations
+
+// Regression coverage for the 1.15.169 repair (issue #923 review finding):
+// a 'Schulhof Freispiel' activity provisioned through ToggleSupervision ->
+// EnsureInfrastructure(ctx, staffID) carries a staff created_by, so the
+// 1.15.168 backfill (created_by IS NULL) skipped it and left it visible in
+// staff-facing lists. The repair flags such rows via their link to the
+// tenant's 'Schulhof' category, while leaving staff activities that merely
+// share a system name untouched.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// insertIsSystemTestCategory inserts a category directly via SQL so the test
+// can stage a pre-repair state with an exact name — the fixture helpers
+// uniquify names, which would defeat the migration's name-based predicate.
+// Returns the inserted row id.
+func insertIsSystemTestCategory(t *testing.T, db *bun.DB, tenantID int64, name string, isSystem bool) int64 {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var id int64
+	err := db.NewRaw(`
+		INSERT INTO activities.categories (tenant_id, name, is_system)
+		VALUES (?, ?, ?)
+		RETURNING id;
+	`, tenantID, name, isSystem).Scan(ctx, &id)
+	require.NoError(t, err, "insert category %q", name)
+	return id
+}
+
+// insertIsSystemTestGroup inserts an activity group directly via SQL with an
+// explicit is_system value. createdBy may be nil (system-created) or a staff
+// id in the same tenant. Returns the row id.
+func insertIsSystemTestGroup(t *testing.T, db *bun.DB, tenantID int64, name string, categoryID int64, createdBy *int64, isSystem bool) int64 {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var id int64
+	err := db.NewRaw(`
+		INSERT INTO activities.groups (tenant_id, name, max_participants, is_open, category_id, created_by, is_system)
+		VALUES (?, ?, 20, TRUE, ?, ?, ?)
+		RETURNING id;
+	`, tenantID, name, categoryID, createdBy, isSystem).Scan(ctx, &id)
+	require.NoError(t, err, "insert activity group %q", name)
+	return id
+}
+
+func groupIsSystem(t *testing.T, db *bun.DB, groupID int64) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var isSystem bool
+	err := db.NewRaw(`SELECT is_system FROM activities.groups WHERE id = ?;`, groupID).Scan(ctx, &isSystem)
+	require.NoError(t, err, "load is_system for group %d", groupID)
+	return isSystem
+}
+
+// TestRepairSchulhofIsSystemBackfill_FlagsStaffProvisionedRows stages the
+// exact state 1.15.168 leaves behind on a deployed database and runs the
+// repair. The load-bearing fixture is the staff-provisioned Schulhof
+// activity: created_by set to a real staff id, linked to the tenant's
+// 'Schulhof' category, still is_system = FALSE — the row the created_by IS
+// NULL predicate skipped.
+func TestRepairSchulhofIsSystemBackfill_FlagsStaffProvisionedRows(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	ctx := context.Background()
+
+	const tenantID int64 = 9106
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	defer testpkg.CleanupTenantTestData(t, db, tenantID)
+
+	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Schulhof", "Supervisor")
+
+	// 1.15.168 already flagged the category (name-based, unambiguous).
+	schulhofCategory := insertIsSystemTestCategory(t, db, tenantID, "Schulhof", true)
+	craftCategory := insertIsSystemTestCategory(t, db, tenantID, "Basteln", false)
+
+	// The review blocker: ToggleSupervision -> EnsureInfrastructure(ctx, staffID)
+	// provisioned the system activity with the supervising staff's id, so
+	// 1.15.168 left it unflagged.
+	staffProvisioned := insertIsSystemTestGroup(t, db, tenantID, "Schulhof Freispiel", schulhofCategory, &staff.ID, false)
+	// Settings-toggle provisioning (created_by NULL): 1.15.168 already
+	// flagged these; the repair must keep them flagged.
+	alreadyFlagged := insertIsSystemTestGroup(t, db, tenantID, "Schulhof Freispiel", schulhofCategory, nil, true)
+	// A staff member's own activity that merely shares the name must stay
+	// visible in staff-facing lists.
+	staffOwnSameName := insertIsSystemTestGroup(t, db, tenantID, "Schulhof Freispiel", craftCategory, &staff.ID, false)
+	// A staff-owned activity named 'WC' is out of the repair's scope
+	// entirely and must stay unflagged.
+	staffOwnWC := insertIsSystemTestGroup(t, db, tenantID, "WC", craftCategory, &staff.ID, false)
+
+	require.NoError(t, repairSchulhofIsSystemBackfillUp(ctx, db))
+
+	assert.True(t, groupIsSystem(t, db, staffProvisioned),
+		"staff-provisioned Schulhof activity (created_by set) must be flagged via its category link")
+	assert.True(t, groupIsSystem(t, db, alreadyFlagged),
+		"rows 1.15.168 already flagged must stay flagged")
+	assert.False(t, groupIsSystem(t, db, staffOwnSameName),
+		"staff activity sharing the name but not the Schulhof category must stay unflagged")
+	assert.False(t, groupIsSystem(t, db, staffOwnWC),
+		"staff-owned activity named 'WC' must stay unflagged")
+
+	// Idempotency: a second run must not change any verdict.
+	require.NoError(t, repairSchulhofIsSystemBackfillUp(ctx, db))
+	assert.True(t, groupIsSystem(t, db, staffProvisioned))
+	assert.False(t, groupIsSystem(t, db, staffOwnSameName))
+	assert.False(t, groupIsSystem(t, db, staffOwnWC))
+}


### PR DESCRIPTION
## Context

PR #1853 was merged before its review blocker was addressed. The 1.15.168 backfill flags activity groups only where `created_by IS NULL`, but `ToggleSupervision` provisions the Schulhof activity via `EnsureInfrastructure(ctx, staffID)` (`backend/services/facilities/schulhof_service.go:197`), so existing `Schulhof Freispiel` rows can carry a staff `created_by`. Those rows keep `is_system = false` and stay visible and enrollable in staff-facing lists.

Since `development` auto-deploys to staging, 1.15.168 is (or will shortly be) recorded as applied there — editing the migration in place would never re-run. The fix therefore ships as a follow-up **repair migration 1.15.169** that re-runs the corrected backfill; 1.15.168 stays untouched.

## Changes

- **`001015169_repair_schulhof_is_system_backfill.go`**: idempotent UPDATE that flags `Schulhof Freispiel` rows which are either system-created (`created_by IS NULL`) or linked to the tenant's `Schulhof` category. The category link is the discriminator the review suggested: provisioning always sets it, and categories are `UNIQUE(tenant_id, name)`, so unrelated staff activities that merely share the name are not caught. WC needs no repair — its provisioning (`wc_service.go` and both IoT checkin paths) never sets `created_by`, so 1.15.168 already flagged every system WC row.
- **`001015169_repair_schulhof_is_system_backfill_test.go`**: regression test with the exact fixture the review asked for — a `Schulhof Freispiel` row with a non-null `created_by` that must end up `is_system = TRUE` — plus an already-flagged row, staff-owned same-name activities that must stay unflagged, and an idempotency check. Follows the named-up-function migration-test pattern (1.15.48 / 1.15.165).

## Verification

- `go test ./database/migrations/...` and `go test ./test/` pass (incl. hermetic-pattern gate)
- `migrate validate`: graph OK, 1.15.169 depends on 1.15.168, no version collision
- `golangci-lint run ./database/migrations/...`: 0 issues

## Known trade-off

A staff member who deliberately built a duplicate `Schulhof Freispiel` activity inside the Schulhof category would get flagged. Accepted: the runtime lookup (`findSchulhofActivity`) matches by name only and already conflates such a row with the system activity.