### PR TITLE
fix(frontend): remove stacked/mismatched loading skeletons on /database

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/database/layout.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/layout.test.tsx
@@ -8,8 +8,10 @@ vi.mock("next-auth/react", () => ({
   useSession: (...args: unknown[]) => mockUseSession(...args),
 }));
 
+const mockUseSelectedLayoutSegment = vi.fn(() => null as string | null);
 vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
+  useSelectedLayoutSegment: () => mockUseSelectedLayoutSegment(),
 }));
 
 vi.mock("~/lib/auth-utils", () => ({
@@ -72,7 +74,24 @@ describe("DatabaseLayout", () => {
     expect(screen.queryByTestId("database-content")).not.toBeInTheDocument();
   });
 
-  it("shows loading state while session loads", () => {
+  it("shows the index card-grid skeleton while session loads on the index page", () => {
+    mockUseSelectedLayoutSegment.mockReturnValue(null);
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: "loading",
+    });
+
+    render(
+      <DatabaseLayout>
+        <div>Content</div>
+      </DatabaseLayout>,
+    );
+
+    expect(screen.getByTestId("database-index-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows the master-detail skeleton while session loads on a sub-route", () => {
+    mockUseSelectedLayoutSegment.mockReturnValue("students");
     mockUseSession.mockReturnValue({
       data: null,
       status: "loading",

--- a/frontend/src/app/[tenant]/(protected)/database/layout.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { RoleGuard } from "~/components/auth/role-guard";
-import { MasterDetailSkeleton } from "~/components/database/master-detail-skeleton";
+import { DatabaseSectionSkeleton } from "./section-skeleton";
 
 export default function DatabaseLayout({
   children,
@@ -12,7 +12,7 @@ export default function DatabaseLayout({
     <RoleGuard
       variant="adminOnly"
       message="Du verfügst nicht über die notwendigen Berechtigungen, um die Datenverwaltung aufzurufen."
-      fallback={<MasterDetailSkeleton />}
+      fallback={<DatabaseSectionSkeleton />}
     >
       {children}
     </RoleGuard>

--- a/frontend/src/app/[tenant]/(protected)/database/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/loading.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MasterDetailSkeleton } from "~/components/database/master-detail-skeleton";
+import { DatabaseSectionSkeleton } from "./section-skeleton";
 
 /**
  * Route-level loading UI: renders the same skeleton the page shows while its
@@ -8,5 +8,5 @@ import { MasterDetailSkeleton } from "~/components/database/master-detail-skelet
  * generic group-level Loading followed by the page skeleton.
  */
 export default function DatabaseLoading() {
-  return <MasterDetailSkeleton />;
+  return <DatabaseSectionSkeleton />;
 }

--- a/frontend/src/app/[tenant]/(protected)/database/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/page-skeleton.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Skeleton } from "~/components/ui/skeleton";
+
+function DatabaseCardSkeleton() {
+  // Mirrors a database section card: icon block, count badge, title,
+  // description, footer link.
+  return (
+    <div className="moto-content-surface w-full overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <div className="p-6">
+        <div className="mb-4 flex items-start justify-between">
+          <Skeleton className="h-12 w-12 rounded-2xl" />
+          <Skeleton className="h-6 w-16 rounded-full" />
+        </div>
+        <Skeleton className="mb-2 h-5 w-2/3 rounded" />
+        <Skeleton className="mb-4 h-4 w-full rounded" />
+        <Skeleton className="h-4 w-24 rounded" />
+      </div>
+    </div>
+  );
+}
+
+// Content-shaped placeholder for the /database index page — mirrors the real
+// card grid (DatabaseContent) so there is no layout shift once data arrives.
+export function DatabaseIndexSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Datenverwaltung wird geladen"
+      data-testid="database-index-skeleton"
+      className="w-full"
+    >
+      <div className="min-h-[60vh]">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 8 }, (_, i) => (
+            <DatabaseCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[tenant]/(protected)/database/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/page.test.tsx
@@ -35,12 +35,6 @@ vi.mock("~/components/ui/page-header/PageHeaderWithSearch", () => ({
   ),
 }));
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: ({ fullPage }: { fullPage?: boolean }) => (
-    <div data-testid="loading" data-fullpage={fullPage} aria-label="Lädt..." />
-  ),
-}));
-
 vi.mock("~/components/ui/hooks/useIsMobile", () => ({
   useIsMobile: vi.fn(() => false),
 }));
@@ -102,18 +96,6 @@ describe("DatabasePage", () => {
     await waitFor(() => {
       expect(screen.getByText("Kinder")).toBeInTheDocument();
     });
-  });
-
-  it("displays loading state initially", () => {
-    vi.mocked(useSession).mockReturnValue({
-      data: null,
-      status: "loading",
-      update: vi.fn(),
-    });
-
-    render(<DatabasePage />);
-
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
   });
 
   it("displays data sections with counts after loading", async () => {

--- a/frontend/src/app/[tenant]/(protected)/database/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/page.tsx
@@ -7,11 +7,10 @@ const logger = createLogger({ component: "DatabasePage" });
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
-import { Suspense, useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useIsMobile } from "~/components/ui/hooks/useIsMobile";
 import { LOCATION_COLORS } from "~/lib/location-helper";
 
-import { Loading } from "~/components/ui/loading";
 import { useNFCEnabled } from "~/lib/tenant-context";
 // Icon component
 const Icon: React.FC<{ path: string; className?: string }> = ({
@@ -100,7 +99,7 @@ const baseDataSections = [
 const NFC_ONLY_SECTION_IDS = new Set(["activities", "devices"]);
 
 function DatabaseContent() {
-  const { data: session, status } = useSession({ required: true });
+  const { data: session } = useSession();
   const isMobile = useIsMobile();
   const nfcEnabled = useNFCEnabled();
   const [counts, setCounts] = useState<{
@@ -243,10 +242,6 @@ function DatabaseContent() {
     }
   }, [session]);
 
-  if (status === "loading") {
-    return <Loading fullPage={false} />;
-  }
-
   if (!session?.user) {
     redirect("/");
   }
@@ -332,9 +327,5 @@ function DatabaseContent() {
 }
 
 export default function DatabasePage() {
-  return (
-    <Suspense fallback={<Loading fullPage={false} />}>
-      <DatabaseContent />
-    </Suspense>
-  );
+  return <DatabaseContent />;
 }

--- a/frontend/src/app/[tenant]/(protected)/database/section-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/section-skeleton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useSelectedLayoutSegment } from "next/navigation";
+import { MasterDetailSkeleton } from "~/components/database/master-detail-skeleton";
+import { DatabaseIndexSkeleton } from "./page-skeleton";
+
+/**
+ * Picks the skeleton matching whichever /database/* route is active: the
+ * card-grid skeleton for the index page, or the existing master-detail
+ * skeleton for every list/detail sub-route (students, personal, rooms, ...).
+ * Shared by loading.tsx (Next.js route-loading Suspense boundary) and
+ * layout.tsx (RoleGuard's client-side session-loading fallback) so both
+ * boundaries render the same shape — no flash between mismatched skeletons.
+ */
+export function DatabaseSectionSkeleton() {
+  const segment = useSelectedLayoutSegment();
+  return segment === null ? (
+    <DatabaseIndexSkeleton />
+  ) : (
+    <MasterDetailSkeleton />
+  );
+}


### PR DESCRIPTION
## Summary

On a hard refresh of `/database`, users saw 3-4 different, uncoordinated loading treatments stack or flash before the real content appeared:

- Root full-page overlay (`app/loading.tsx`) while the tenant resolves
- Generic protected-group skeleton (`(protected)/loading.tsx`)
- `database/loading.tsx` rendered `MasterDetailSkeleton` — a list-row skeleton, even though `/database`'s index page is actually a card grid, not a list
- `database/layout.tsx`'s `RoleGuard` independently re-rendered that same mismatched skeleton on its own client-side session check, causing a visible remount/re-flash separate from the Next.js route-level boundary
- `page.tsx` additionally wrapped its content in a dead `<Suspense>` boundary (the wrapped component never actually suspends) and had its own redundant `useSession`/`status === "loading"` branch — both unreachable dead code, since `RoleGuard` in the parent layout already gates rendering until the session resolves

## Changes

- Added `page-skeleton.tsx`: a card-grid skeleton matching the real `/database` index page layout
- Added `section-skeleton.tsx`: a single route-aware picker (`useSelectedLayoutSegment`) that renders the card-grid skeleton on the index page and the existing `MasterDetailSkeleton` on every list/detail sub-route (`/database/students`, etc.) — shared by both `loading.tsx` and `layout.tsx`'s `RoleGuard` fallback so the two boundaries can never disagree
- Removed the dead `Suspense` wrapper and the redundant `useSession` loading branch from `page.tsx`
- Updated `layout.test.tsx` (two cases: index skeleton vs. sub-route skeleton) and `page.test.tsx` (removed the now-impossible loading-state test)

## Test plan

- [x] `pnpm run check` (oxlint + tsc + locale verify) passes
- [x] All 17 tests in `layout.test.tsx` + `page.test.tsx` pass, including two new cases asserting the correct skeleton renders for the index route vs. sub-routes
- [x] Manually verified against a freshly seeded local tenant: `/database` renders the card grid correctly, `/database/students` still renders the master-detail list correctly, no console errors