### PR TITLE
Add UI to change an existing staff member's system role

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/database/layout.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/layout.test.tsx
@@ -8,8 +8,10 @@ vi.mock("next-auth/react", () => ({
   useSession: (...args: unknown[]) => mockUseSession(...args),
 }));
 
+const mockUseSelectedLayoutSegment = vi.fn(() => null as string | null);
 vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
+  useSelectedLayoutSegment: () => mockUseSelectedLayoutSegment(),
 }));
 
 vi.mock("~/lib/auth-utils", () => ({
@@ -72,7 +74,24 @@ describe("DatabaseLayout", () => {
     expect(screen.queryByTestId("database-content")).not.toBeInTheDocument();
   });
 
-  it("shows loading state while session loads", () => {
+  it("shows the index card-grid skeleton while session loads on the index page", () => {
+    mockUseSelectedLayoutSegment.mockReturnValue(null);
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: "loading",
+    });
+
+    render(
+      <DatabaseLayout>
+        <div>Content</div>
+      </DatabaseLayout>,
+    );
+
+    expect(screen.getByTestId("database-index-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows the master-detail skeleton while session loads on a sub-route", () => {
+    mockUseSelectedLayoutSegment.mockReturnValue("students");
     mockUseSession.mockReturnValue({
       data: null,
       status: "loading",

--- a/frontend/src/app/[tenant]/(protected)/database/layout.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { RoleGuard } from "~/components/auth/role-guard";
-import { MasterDetailSkeleton } from "~/components/database/master-detail-skeleton";
+import { DatabaseSectionSkeleton } from "./section-skeleton";
 
 export default function DatabaseLayout({
   children,
@@ -12,7 +12,7 @@ export default function DatabaseLayout({
     <RoleGuard
       variant="adminOnly"
       message="Du verfügst nicht über die notwendigen Berechtigungen, um die Datenverwaltung aufzurufen."
-      fallback={<MasterDetailSkeleton />}
+      fallback={<DatabaseSectionSkeleton />}
     >
       {children}
     </RoleGuard>

--- a/frontend/src/app/[tenant]/(protected)/database/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/loading.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MasterDetailSkeleton } from "~/components/database/master-detail-skeleton";
+import { DatabaseSectionSkeleton } from "./section-skeleton";
 
 /**
  * Route-level loading UI: renders the same skeleton the page shows while its
@@ -8,5 +8,5 @@ import { MasterDetailSkeleton } from "~/components/database/master-detail-skelet
  * generic group-level Loading followed by the page skeleton.
  */
 export default function DatabaseLoading() {
-  return <MasterDetailSkeleton />;
+  return <DatabaseSectionSkeleton />;
 }

--- a/frontend/src/app/[tenant]/(protected)/database/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/page-skeleton.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Skeleton } from "~/components/ui/skeleton";
+
+function DatabaseCardSkeleton() {
+  // Mirrors a database section card: icon block, count badge, title,
+  // description, footer link.
+  return (
+    <div className="moto-content-surface w-full overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <div className="p-6">
+        <div className="mb-4 flex items-start justify-between">
+          <Skeleton className="h-12 w-12 rounded-2xl" />
+          <Skeleton className="h-6 w-16 rounded-full" />
+        </div>
+        <Skeleton className="mb-2 h-5 w-2/3 rounded" />
+        <Skeleton className="mb-4 h-4 w-full rounded" />
+        <Skeleton className="h-4 w-24 rounded" />
+      </div>
+    </div>
+  );
+}
+
+// Content-shaped placeholder for the /database index page — mirrors the real
+// card grid (DatabaseContent) so there is no layout shift once data arrives.
+export function DatabaseIndexSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Datenverwaltung wird geladen"
+      data-testid="database-index-skeleton"
+      className="w-full"
+    >
+      <div className="min-h-[60vh]">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 8 }, (_, i) => (
+            <DatabaseCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[tenant]/(protected)/database/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/page.test.tsx
@@ -35,12 +35,6 @@ vi.mock("~/components/ui/page-header/PageHeaderWithSearch", () => ({
   ),
 }));
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: ({ fullPage }: { fullPage?: boolean }) => (
-    <div data-testid="loading" data-fullpage={fullPage} aria-label="Lädt..." />
-  ),
-}));
-
 vi.mock("~/components/ui/hooks/useIsMobile", () => ({
   useIsMobile: vi.fn(() => false),
 }));
@@ -102,18 +96,6 @@ describe("DatabasePage", () => {
     await waitFor(() => {
       expect(screen.getByText("Kinder")).toBeInTheDocument();
     });
-  });
-
-  it("displays loading state initially", () => {
-    vi.mocked(useSession).mockReturnValue({
-      data: null,
-      status: "loading",
-      update: vi.fn(),
-    });
-
-    render(<DatabasePage />);
-
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
   });
 
   it("displays data sections with counts after loading", async () => {

--- a/frontend/src/app/[tenant]/(protected)/database/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/page.tsx
@@ -7,11 +7,10 @@ const logger = createLogger({ component: "DatabasePage" });
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
-import { Suspense, useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useIsMobile } from "~/components/ui/hooks/useIsMobile";
 import { LOCATION_COLORS } from "~/lib/location-helper";
 
-import { Loading } from "~/components/ui/loading";
 import { useNFCEnabled } from "~/lib/tenant-context";
 // Icon component
 const Icon: React.FC<{ path: string; className?: string }> = ({
@@ -100,7 +99,7 @@ const baseDataSections = [
 const NFC_ONLY_SECTION_IDS = new Set(["activities", "devices"]);
 
 function DatabaseContent() {
-  const { data: session, status } = useSession({ required: true });
+  const { data: session } = useSession();
   const isMobile = useIsMobile();
   const nfcEnabled = useNFCEnabled();
   const [counts, setCounts] = useState<{
@@ -243,10 +242,6 @@ function DatabaseContent() {
     }
   }, [session]);
 
-  if (status === "loading") {
-    return <Loading fullPage={false} />;
-  }
-
   if (!session?.user) {
     redirect("/");
   }
@@ -332,9 +327,5 @@ function DatabaseContent() {
 }
 
 export default function DatabasePage() {
-  return (
-    <Suspense fallback={<Loading fullPage={false} />}>
-      <DatabaseContent />
-    </Suspense>
-  );
+  return <DatabaseContent />;
 }

--- a/frontend/src/app/[tenant]/(protected)/database/personal/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/page.tsx
@@ -17,6 +17,7 @@ import type { ActiveFilter } from "~/components/ui/page-header/types";
 import { useToast } from "~/contexts/ToastContext";
 import { useIsMobile } from "~/components/ui/hooks/useIsMobile";
 import { CaregiverCapabilityModal } from "@/components/teachers/caregiver-capability-modal";
+import { RoleManagementModal } from "@/components/teachers/role-management-modal";
 import { StaffMasterDetail } from "@/components/teachers/staff-master-detail";
 import { TeacherEditModal } from "@/components/teachers/teacher-edit-modal";
 import { MFAAdminOverrideModal } from "~/components/auth/mfa-admin-override-modal";
@@ -83,6 +84,7 @@ export default function TeachersPage() {
   const [showEditModal, setShowEditModal] = useState(false);
   const [caregiverModalOpen, setCaregiverModalOpen] = useState(false);
   const [mfaModalOpen, setMfaModalOpen] = useState(false);
+  const [roleModalOpen, setRoleModalOpen] = useState(false);
   const [savingTeacher, setSavingTeacher] = useState(false);
 
   const {
@@ -215,6 +217,7 @@ export default function TeachersPage() {
     [],
   );
   const handleManageMFAClick = useCallback(() => setMfaModalOpen(true), []);
+  const handleManageRoleClick = useCallback(() => setRoleModalOpen(true), []);
 
   const handleEditTeacher = useCallback(
     async (data: Partial<Teacher> & { password?: string }) => {
@@ -373,6 +376,9 @@ export default function TeachersPage() {
             onManageMFA={
               selectedTeacher?.account_id ? handleManageMFAClick : undefined
             }
+            onManageRole={
+              selectedTeacher?.account_id ? handleManageRoleClick : undefined
+            }
           />
         </div>
       ) : !loading ? (
@@ -471,6 +477,18 @@ export default function TeachersPage() {
           bearerToken={accessToken}
           accountId={selectedTeacher.account_id.toString()}
           accountLabel={`${selectedTeacher.first_name} ${selectedTeacher.last_name}`}
+        />
+      )}
+
+      {selectedTeacher?.account_id && (
+        <RoleManagementModal
+          isOpen={roleModalOpen}
+          onClose={() => setRoleModalOpen(false)}
+          accountId={selectedTeacher.account_id.toString()}
+          accountLabel={`${selectedTeacher.first_name} ${selectedTeacher.last_name}`}
+          onUpdated={async () => {
+            await tenantMutate("database-teachers-list");
+          }}
         />
       )}
     </DatabasePageLayout>

--- a/frontend/src/app/[tenant]/(protected)/database/section-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/section-skeleton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useSelectedLayoutSegment } from "next/navigation";
+import { MasterDetailSkeleton } from "~/components/database/master-detail-skeleton";
+import { DatabaseIndexSkeleton } from "./page-skeleton";
+
+/**
+ * Picks the skeleton matching whichever /database/* route is active: the
+ * card-grid skeleton for the index page, or the existing master-detail
+ * skeleton for every list/detail sub-route (students, personal, rooms, ...).
+ * Shared by loading.tsx (Next.js route-loading Suspense boundary) and
+ * layout.tsx (RoleGuard's client-side session-loading fallback) so both
+ * boundaries render the same shape — no flash between mismatched skeletons.
+ */
+export function DatabaseSectionSkeleton() {
+  const segment = useSelectedLayoutSegment();
+  return segment === null ? (
+    <DatabaseIndexSkeleton />
+  ) : (
+    <MasterDetailSkeleton />
+  );
+}

--- a/frontend/src/components/admin/invitation-form.test.tsx
+++ b/frontend/src/components/admin/invitation-form.test.tsx
@@ -57,10 +57,23 @@ vi.mock("~/lib/invitation-api", () => ({
   createInvitation: (data: unknown): unknown => mockCreateInvitation(data),
 }));
 
-vi.mock("~/lib/auth-helpers", () => ({
-  getRoleDisplayName: (role: string) =>
-    role === "teacher" ? "Lehrkraft" : role === "user" ? "Betreuer" : role,
-}));
+vi.mock("~/lib/auth-helpers", () => {
+  const getRoleDisplayName = (role: string) =>
+    role === "teacher" ? "Lehrkraft" : role === "user" ? "Betreuer" : role;
+  return {
+    getRoleDisplayName,
+    toAssignableRoleOptions: (roles: { id: string; name: string }[]) =>
+      roles
+        .filter(
+          (role) => !["guardian", "teacher"].includes(role.name.toLowerCase()),
+        )
+        .map((role) => ({
+          id: Number(role.id),
+          name: role.name ? getRoleDisplayName(role.name) : `Rolle ${role.id}`,
+        }))
+        .filter((role) => !Number.isNaN(role.id)),
+  };
+});
 
 const mockRoles = [
   { id: "1", name: "user" },

--- a/frontend/src/components/admin/invitation-form.tsx
+++ b/frontend/src/components/admin/invitation-form.tsx
@@ -5,7 +5,7 @@ import { useToast } from "~/contexts/ToastContext";
 import { Input } from "~/components/ui/input";
 import { useScrollToError } from "~/lib/hooks/use-scroll-to-error";
 import { authService } from "~/lib/auth-service";
-import { getRoleDisplayName } from "~/lib/auth-helpers";
+import { toAssignableRoleOptions, type RoleOption } from "~/lib/auth-helpers";
 import { createInvitation } from "~/lib/invitation-api";
 import type {
   CreateInvitationRequest,
@@ -20,11 +20,6 @@ const logger = createLogger({ component: "InvitationForm" });
 interface InvitationFormProps {
   readonly onCreated?: (invitation: PendingInvitation) => void;
   readonly existingPositions?: readonly string[];
-}
-
-interface RoleOption {
-  id: number;
-  name: string;
 }
 
 const EMPTY_POSITIONS: readonly string[] = [];
@@ -62,22 +57,7 @@ export function InvitationForm({
         setIsLoadingRoles(true);
         const roleList = await authService.getRoles();
         if (cancelled) return;
-        // Legacy teacher + guardian roles are no longer assignable via invitations.
-        const options = roleList
-          .filter((role) => {
-            const normalizedName = role.name.toLowerCase();
-            return (
-              normalizedName !== "guardian" && normalizedName !== "teacher"
-            );
-          })
-          .map<RoleOption>((role) => ({
-            id: Number(role.id),
-            name: role.name
-              ? getRoleDisplayName(role.name)
-              : `Rolle ${role.id}`,
-          }))
-          .filter((role) => !Number.isNaN(role.id));
-        setRoles(options);
+        setRoles(toAssignableRoleOptions(roleList));
       } catch (err) {
         logger.error("failed to load roles", {
           error: err instanceof Error ? err.message : String(err),

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -191,6 +191,7 @@ export const setupChapters: readonly GuideChapter[] = [
           "`E-Mail` eintragen. Diese Adresse wird für die Anmeldung genutzt.",
           "Passende `System-Rolle` wählen. Admin-Rechte nur für Personen, die Stammdaten oder Einstellungen ändern sollen.",
           "Speichern und die Person zum Login auffordern.",
+          "Um die Rolle einer bereits angelegten Person nachträglich zu ändern (z. B. jemanden zur Administratorin zu machen), die Person in der Personal-Liste auswählen und in der Detailansicht `Rolle verwalten` nutzen.",
         ],
         screenshot: "Personalformular mit Vorname, Nachname, E-Mail und Rolle.",
         image: "/help/screens/mitarbeitende-anlegen.webp",

--- a/frontend/src/components/teachers/role-management-modal.test.tsx
+++ b/frontend/src/components/teachers/role-management-modal.test.tsx
@@ -1,0 +1,238 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RoleManagementModal } from "./role-management-modal";
+
+const {
+  mockToastSuccess,
+  mockGetAccountRoles,
+  mockGetRoles,
+  mockAssignRoleToAccount,
+  mockRemoveRoleFromAccount,
+} = vi.hoisted(() => ({
+  mockToastSuccess: vi.fn(),
+  mockGetAccountRoles: vi.fn(),
+  mockGetRoles: vi.fn(),
+  mockAssignRoleToAccount: vi.fn(),
+  mockRemoveRoleFromAccount: vi.fn(),
+}));
+
+vi.mock("~/components/ui/form-modal", async () => {
+  const { createElement } = await import("react");
+
+  return {
+    FormModal: ({
+      isOpen,
+      title,
+      footer,
+      children,
+    }: {
+      isOpen: boolean;
+      title: string;
+      footer: ReactNode;
+      children: ReactNode;
+    }) =>
+      isOpen
+        ? createElement(
+            "div",
+            { "data-testid": "form-modal" },
+            createElement("h1", null, title),
+            createElement("div", null, children),
+            createElement("div", null, footer),
+          )
+        : null,
+  };
+});
+
+vi.mock("~/components/ui/alert", async () => {
+  const { createElement } = await import("react");
+
+  return {
+    Alert: ({ message }: { message?: string }) =>
+      message
+        ? createElement("div", { "data-testid": "alert" }, message)
+        : null,
+  };
+});
+
+vi.mock("~/components/ui/detail-modal-components", async () => {
+  const { createElement } = await import("react");
+
+  return {
+    DataField: ({ label, children }: { label: string; children: ReactNode }) =>
+      createElement(
+        "div",
+        null,
+        createElement("span", null, label),
+        createElement("span", null, children),
+      ),
+    DataGrid: ({ children }: { children: ReactNode }) =>
+      createElement("div", null, children),
+    InfoSection: ({
+      title,
+      children,
+    }: {
+      title: string;
+      children: ReactNode;
+    }) =>
+      createElement(
+        "section",
+        null,
+        createElement("h2", null, title),
+        children,
+      ),
+    DetailIcons: {
+      person: createElement("span", null, "person"),
+    },
+  };
+});
+
+vi.mock("~/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: mockToastSuccess,
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("~/lib/logger", () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("~/lib/auth-service", () => ({
+  authService: {
+    getAccountRoles: mockGetAccountRoles,
+    getRoles: mockGetRoles,
+    assignRoleToAccount: mockAssignRoleToAccount,
+    removeRoleFromAccount: mockRemoveRoleFromAccount,
+  },
+}));
+
+function role(id: string, name: string) {
+  return {
+    id,
+    name,
+    description: "",
+    isSystem: true,
+    createdAt: "",
+    updatedAt: "",
+  };
+}
+
+const ALL_ROLES = [role("1", "admin"), role("2", "user")];
+
+describe("RoleManagementModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRoles.mockResolvedValue(ALL_ROLES);
+  });
+
+  it("loads the current role and assignable role options on open", async () => {
+    mockGetAccountRoles.mockResolvedValue([role("2", "user")]);
+
+    render(
+      <RoleManagementModal
+        isOpen={true}
+        onClose={vi.fn()}
+        accountId="42"
+        accountLabel="Ada Lovelace"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetAccountRoles).toHaveBeenCalledWith("42");
+    });
+    expect(screen.getAllByText("Betreuer").length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("option", { name: "Administrator" }),
+    ).toBeInTheDocument();
+  });
+
+  it("assigns the new role before removing the old one on save", async () => {
+    mockGetAccountRoles.mockResolvedValue([role("2", "user")]);
+    mockAssignRoleToAccount.mockResolvedValue(undefined);
+    mockRemoveRoleFromAccount.mockResolvedValue(undefined);
+
+    const onUpdated = vi.fn();
+    render(
+      <RoleManagementModal
+        isOpen={true}
+        onClose={vi.fn()}
+        accountId="42"
+        accountLabel="Ada Lovelace"
+        onUpdated={onUpdated}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetAccountRoles).toHaveBeenCalledWith("42");
+    });
+
+    fireEvent.change(screen.getByLabelText("Neue Rolle"), {
+      target: { value: "1" },
+    });
+    fireEvent.click(screen.getByText("Speichern"));
+
+    await waitFor(() => {
+      expect(mockRemoveRoleFromAccount).toHaveBeenCalledWith("42", "2");
+    });
+
+    const assignOrder = mockAssignRoleToAccount.mock.invocationCallOrder[0];
+    const removeOrder = mockRemoveRoleFromAccount.mock.invocationCallOrder[0];
+    expect(assignOrder).toBeDefined();
+    expect(removeOrder).toBeDefined();
+    expect(assignOrder as number).toBeLessThan(removeOrder as number);
+    expect(mockAssignRoleToAccount).toHaveBeenCalledWith("42", "1");
+    expect(onUpdated).toHaveBeenCalled();
+  });
+
+  it("disables save when the selected role matches the current role", async () => {
+    mockGetAccountRoles.mockResolvedValue([role("2", "user")]);
+
+    render(
+      <RoleManagementModal
+        isOpen={true}
+        onClose={vi.fn()}
+        accountId="42"
+        accountLabel="Ada Lovelace"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Speichern")).toBeDisabled();
+    });
+
+    expect(mockAssignRoleToAccount).not.toHaveBeenCalled();
+  });
+
+  it("shows an error alert without losing state when saving fails", async () => {
+    mockGetAccountRoles.mockResolvedValue([role("2", "user")]);
+    mockAssignRoleToAccount.mockRejectedValue(new Error("boom"));
+
+    render(
+      <RoleManagementModal
+        isOpen={true}
+        onClose={vi.fn()}
+        accountId="42"
+        accountLabel="Ada Lovelace"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetAccountRoles).toHaveBeenCalledWith("42");
+    });
+
+    fireEvent.change(screen.getByLabelText("Neue Rolle"), {
+      target: { value: "1" },
+    });
+    fireEvent.click(screen.getByText("Speichern"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("alert")).toHaveTextContent(
+        "Die Rolle konnte nicht aktualisiert werden.",
+      );
+    });
+    expect(mockRemoveRoleFromAccount).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/teachers/role-management-modal.tsx
+++ b/frontend/src/components/teachers/role-management-modal.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { FormModal } from "~/components/ui/form-modal";
+import { Alert } from "~/components/ui/alert";
+import {
+  DataField,
+  DataGrid,
+  DetailIcons,
+  InfoSection,
+} from "~/components/ui/detail-modal-components";
+import { useToast } from "~/contexts/ToastContext";
+import { authService } from "~/lib/auth-service";
+import {
+  getRoleDisplayName,
+  toAssignableRoleOptions,
+  type Role,
+  type RoleOption,
+} from "~/lib/auth-helpers";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "RoleManagementModal" });
+
+interface RoleManagementModalProps {
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly accountId: string;
+  readonly accountLabel: string;
+  readonly onUpdated?: () => void | Promise<void>;
+}
+
+export function RoleManagementModal({
+  isOpen,
+  onClose,
+  accountId,
+  accountLabel,
+  onUpdated,
+}: RoleManagementModalProps) {
+  const { success: toastSuccess } = useToast();
+  const [currentRoles, setCurrentRoles] = useState<Role[]>([]);
+  const [roleOptions, setRoleOptions] = useState<RoleOption[]>([]);
+  const [targetRoleId, setTargetRoleId] = useState<number | undefined>(
+    undefined,
+  );
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const loadState = useCallback(async () => {
+    if (!accountId) return;
+
+    try {
+      setLoading(true);
+      setErrorMessage("");
+
+      const [accountRoles, allRoles] = await Promise.all([
+        authService.getAccountRoles(accountId),
+        authService.getRoles(),
+      ]);
+
+      setCurrentRoles(accountRoles);
+      setRoleOptions(toAssignableRoleOptions(allRoles));
+      setTargetRoleId(
+        accountRoles.length > 0 ? Number(accountRoles[0]?.id) : undefined,
+      );
+    } catch (error) {
+      logger.error("failed to load account role state", {
+        error: error instanceof Error ? error.message : String(error),
+        accountId,
+      });
+      setErrorMessage("Die Rollen konnten nicht geladen werden.");
+    } finally {
+      setLoading(false);
+    }
+  }, [accountId]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    void loadState();
+  }, [isOpen, loadState]);
+
+  const currentRoleIds = currentRoles.map((role) => Number(role.id));
+  const isUnchanged =
+    targetRoleId !== undefined && currentRoleIds.includes(targetRoleId);
+
+  async function handleSave() {
+    if (!accountId || targetRoleId === undefined || isUnchanged) {
+      return;
+    }
+
+    try {
+      setSaving(true);
+      setErrorMessage("");
+
+      // Assign the new role before removing the old one so a mid-sequence
+      // failure leaves the account with an extra role rather than none.
+      await authService.assignRoleToAccount(accountId, String(targetRoleId));
+      for (const oldId of currentRoleIds.filter((id) => id !== targetRoleId)) {
+        await authService.removeRoleFromAccount(accountId, String(oldId));
+      }
+
+      toastSuccess("Rolle wurde aktualisiert.");
+      await onUpdated?.();
+      await loadState();
+      onClose();
+    } catch (error) {
+      logger.error("failed to update account role", {
+        error: error instanceof Error ? error.message : String(error),
+        accountId,
+        targetRoleId,
+      });
+      setErrorMessage("Die Rolle konnte nicht aktualisiert werden.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const currentRoleLabel =
+    currentRoles.length > 0
+      ? currentRoles.map((role) => getRoleDisplayName(role.name)).join(", ")
+      : "Keine Rolle hinterlegt";
+
+  return (
+    <FormModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`Rolle verwalten: ${accountLabel}`}
+      size="md"
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+          >
+            Schließen
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={saving || loading || isUnchanged || !targetRoleId}
+            className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {saving ? "Wird gespeichert..." : "Speichern"}
+          </button>
+        </>
+      }
+    >
+      {loading ? (
+        <div className="py-8 text-sm text-gray-500">Wird geladen...</div>
+      ) : (
+        <div className="space-y-4">
+          <InfoSection
+            title="Aktuelle Rolle"
+            icon={DetailIcons.person}
+            accentColor="purple"
+          >
+            <DataGrid>
+              <DataField label="Rolle">{currentRoleLabel}</DataField>
+            </DataGrid>
+          </InfoSection>
+
+          <div>
+            <label
+              htmlFor="target-role-select"
+              className="mb-1 block text-xs font-medium text-gray-700"
+            >
+              Neue Rolle
+            </label>
+            <div className="relative">
+              <select
+                id="target-role-select"
+                value={targetRoleId ?? ""}
+                onChange={(event) => {
+                  const value = Number(event.target.value);
+                  setTargetRoleId(
+                    event.target.value === "" ? undefined : value,
+                  );
+                }}
+                className="w-full appearance-none rounded-lg border border-gray-200 bg-white px-3 py-2 pr-10 text-sm transition-colors focus:border-gray-400 focus:ring-1 focus:ring-gray-200"
+                disabled={saving}
+              >
+                <option value="" disabled>
+                  Rolle auswählen...
+                </option>
+                {roleOptions.map((role) => (
+                  <option key={role.id} value={role.id}>
+                    {role.name}
+                  </option>
+                ))}
+              </select>
+              <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+                <svg
+                  className="h-4 w-4 text-gray-400"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          <Alert type="error" message={errorMessage} />
+        </div>
+      )}
+    </FormModal>
+  );
+}

--- a/frontend/src/components/teachers/staff-master-detail.test.tsx
+++ b/frontend/src/components/teachers/staff-master-detail.test.tsx
@@ -175,6 +175,39 @@ describe("StaffMasterDetail", () => {
     expect(onManageCaregiver).toHaveBeenCalled();
   });
 
+  it("shows the manage role button only when the callback is provided", () => {
+    const onManageRole = vi.fn();
+    const { rerender } = render(
+      <StaffMasterDetail
+        groupDefinitions={flatGroup([baseTeacher])}
+        selectedId="1"
+        selectedTeacher={baseTeacher}
+        onSelect={onSelect}
+        onEditClick={onEditClick}
+        onDeleteClick={onDeleteClick}
+        onUpdateNotes={onUpdateNotes}
+      />,
+    );
+
+    expect(screen.queryByText("Rolle verwalten")).not.toBeInTheDocument();
+
+    rerender(
+      <StaffMasterDetail
+        groupDefinitions={flatGroup([baseTeacher])}
+        selectedId="1"
+        selectedTeacher={baseTeacher}
+        onSelect={onSelect}
+        onEditClick={onEditClick}
+        onDeleteClick={onDeleteClick}
+        onUpdateNotes={onUpdateNotes}
+        onManageRole={onManageRole}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Rolle verwalten"));
+    expect(onManageRole).toHaveBeenCalled();
+  });
+
   it("hides the email and qualifications sections when fields are missing", () => {
     render(
       <StaffMasterDetail

--- a/frontend/src/components/teachers/staff-master-detail.tsx
+++ b/frontend/src/components/teachers/staff-master-detail.tsx
@@ -38,6 +38,7 @@ interface StaffMasterDetailProps {
   onUpdateNotes: (notes: string) => Promise<void>;
   onManageCaregiver?: () => void;
   onManageMFA?: () => void;
+  onManageRole?: () => void;
 }
 
 function keyForTeacher(teacher: Teacher): string {
@@ -98,6 +99,7 @@ export function StaffMasterDetail({
   onUpdateNotes,
   onManageCaregiver,
   onManageMFA,
+  onManageRole,
 }: StaffMasterDetailProps) {
   const renderItem = (teacher: Teacher) => (
     <DatabaseListItem
@@ -129,6 +131,7 @@ export function StaffMasterDetail({
       onUpdateNotes={onUpdateNotes}
       onManageCaregiver={onManageCaregiver}
       onManageMFA={onManageMFA}
+      onManageRole={onManageRole}
     />
   ) : (
     <EmptyDetailState
@@ -158,6 +161,7 @@ interface StaffDetailContentProps {
   onUpdateNotes: (notes: string) => Promise<void>;
   onManageCaregiver?: () => void;
   onManageMFA?: () => void;
+  onManageRole?: () => void;
 }
 
 function StaffDetailContent({
@@ -167,6 +171,7 @@ function StaffDetailContent({
   onUpdateNotes,
   onManageCaregiver,
   onManageMFA,
+  onManageRole,
 }: StaffDetailContentProps) {
   const [activeTab, setActiveTab] = useState<string>("master-data");
 
@@ -194,6 +199,7 @@ function StaffDetailContent({
           onUpdateNotes={onUpdateNotes}
           onManageCaregiver={onManageCaregiver}
           onManageMFA={onManageMFA}
+          onManageRole={onManageRole}
         />
       ),
     },
@@ -221,6 +227,7 @@ interface StaffStammdatenTabProps {
   onUpdateNotes: (notes: string) => Promise<void>;
   onManageCaregiver?: () => void;
   onManageMFA?: () => void;
+  onManageRole?: () => void;
 }
 
 function StaffStammdatenTab({
@@ -228,6 +235,7 @@ function StaffStammdatenTab({
   onUpdateNotes,
   onManageCaregiver,
   onManageMFA,
+  onManageRole,
 }: StaffStammdatenTabProps) {
   const trimmedQualifications = teacher.qualifications?.trim() ?? "";
 
@@ -324,8 +332,17 @@ function StaffStammdatenTab({
         </InfoSection>
       ) : null}
 
-      {(onManageCaregiver || onManageMFA) && (
+      {(onManageCaregiver || onManageMFA || onManageRole) && (
         <div className="flex flex-wrap justify-end gap-2">
+          {onManageRole ? (
+            <button
+              type="button"
+              onClick={onManageRole}
+              className="rounded-lg border border-[#7C3AED]/30 px-3 py-2 text-xs font-medium text-[#7C3AED] transition-all duration-200 hover:bg-[#7C3AED]/10 md:text-sm"
+            >
+              Rolle verwalten
+            </button>
+          ) : null}
           {onManageMFA ? (
             <button
               type="button"

--- a/frontend/src/components/teachers/teacher-form.test.tsx
+++ b/frontend/src/components/teachers/teacher-form.test.tsx
@@ -18,15 +18,28 @@ vi.mock("@/lib/auth-service", () => ({
   },
 }));
 
-vi.mock("@/lib/auth-helpers", () => ({
-  getRoleDisplayName: (name: string) => {
+vi.mock("@/lib/auth-helpers", () => {
+  const getRoleDisplayName = (name: string) => {
     const names: Record<string, string> = {
       admin: "Administrator",
       betreuer: "Betreuer",
     };
     return names[name] ?? name;
-  },
-}));
+  };
+  return {
+    getRoleDisplayName,
+    toAssignableRoleOptions: (roles: { id: string; name: string }[]) =>
+      roles
+        .filter(
+          (role) => !["guardian", "teacher"].includes(role.name.toLowerCase()),
+        )
+        .map((role) => ({
+          id: Number(role.id),
+          name: role.name ? getRoleDisplayName(role.name) : `Rolle ${role.id}`,
+        }))
+        .filter((role) => !Number.isNaN(role.id)),
+  };
+});
 
 vi.mock("~/lib/logger", () => ({
   createLogger: () => ({

--- a/frontend/src/components/teachers/teacher-form.tsx
+++ b/frontend/src/components/teachers/teacher-form.tsx
@@ -1,18 +1,13 @@
 import { useState, useEffect, useRef } from "react";
 import type { Teacher } from "@/lib/teacher-api";
 import { authService } from "@/lib/auth-service";
-import { getRoleDisplayName } from "@/lib/auth-helpers";
+import { toAssignableRoleOptions, type RoleOption } from "@/lib/auth-helpers";
 import { createLogger } from "~/lib/logger";
 import { useScrollToError } from "~/lib/hooks/use-scroll-to-error";
 
 const logger = createLogger({ component: "TeacherForm" });
 const EMPTY_RFID_CARDS: ReadonlyArray<{ id: string; label: string }> = [];
 const EMPTY_POSITIONS: readonly string[] = [];
-
-interface RoleOption {
-  id: number;
-  name: string;
-}
 
 interface TeacherFormProps {
   readonly initialData: Partial<Teacher>;
@@ -79,23 +74,7 @@ export function TeacherForm({
         const roleList = await authService.getRoles();
         if (cancelled) return;
 
-        // Legacy teacher + guardian roles are no longer assignable via staff creation.
-        const options = roleList
-          .filter((role) => {
-            const normalizedName = role.name.toLowerCase();
-            return (
-              normalizedName !== "guardian" && normalizedName !== "teacher"
-            );
-          })
-          .map<RoleOption>((role) => ({
-            id: Number(role.id),
-            name: role.name
-              ? getRoleDisplayName(role.name)
-              : `Rolle ${role.id}`,
-          }))
-          .filter((role) => !Number.isNaN(role.id));
-
-        setRoles(options);
+        setRoles(toAssignableRoleOptions(roleList));
       } catch (err) {
         logger.error("failed to load roles", {
           error: err instanceof Error ? err.message : String(err),

--- a/frontend/src/lib/auth-helpers.ts
+++ b/frontend/src/lib/auth-helpers.ts
@@ -262,7 +262,7 @@ export interface RoleOption {
 }
 
 /** System roles that are legacy/relationship-derived and not assignable to staff accounts. */
-export const NON_ASSIGNABLE_STAFF_ROLE_NAMES = new Set(["guardian", "teacher"]);
+const NON_ASSIGNABLE_STAFF_ROLE_NAMES = new Set(["guardian", "teacher"]);
 
 /**
  * Filters a role list down to staff-assignable roles and maps them to

--- a/frontend/src/lib/auth-helpers.ts
+++ b/frontend/src/lib/auth-helpers.ts
@@ -256,6 +256,31 @@ export function getRoleDisplayDescription(
   );
 }
 
+export interface RoleOption {
+  id: number;
+  name: string;
+}
+
+/** System roles that are legacy/relationship-derived and not assignable to staff accounts. */
+export const NON_ASSIGNABLE_STAFF_ROLE_NAMES = new Set(["guardian", "teacher"]);
+
+/**
+ * Filters a role list down to staff-assignable roles and maps them to
+ * display options. Shared by the invitation form, teacher-creation form,
+ * and the staff role-management modal to avoid re-deriving this list.
+ */
+export function toAssignableRoleOptions(roles: Role[]): RoleOption[] {
+  return roles
+    .filter(
+      (role) => !NON_ASSIGNABLE_STAFF_ROLE_NAMES.has(role.name.toLowerCase()),
+    )
+    .map((role) => ({
+      id: Number(role.id),
+      name: role.name ? getRoleDisplayName(role.name) : `Rolle ${role.id}`,
+    }))
+    .filter((role) => !Number.isNaN(role.id));
+}
+
 // Request/Response types
 export interface LoginRequest {
   email: string;


### PR DESCRIPTION
## Summary

Role selection previously only worked at invitation/creation time. If a staff member already had an account, there was no UI path to change their system role (e.g. promote to Administrator) — the detail view showed the role as read-only, and the "Rolle kann später geändert werden" text in the teacher-creation form was not actually true. The backend endpoints to assign/remove a role (`assignRoleToAccount`/`removeRoleFromAccount`/`getAccountRoles`) already existed but had no UI caller.

- Add a "Rolle verwalten" action + `RoleManagementModal` to the staff detail view (Datenverwaltung → Personal), reusing the existing backend endpoints. No backend changes needed.
- Sequencing: assign the new role before removing the old one, so a mid-sequence failure leaves an account with an extra role rather than none.
- Extract a shared `toAssignableRoleOptions` helper (guardian/teacher role filtering) into `auth-helpers.ts`, used by the invitation form, teacher-creation form, and the new modal — removes a previously duplicated filter.
- Document the new action in the in-app help guide (`mitarbeitende-anlegen` step).

## Test plan

- [x] `pnpm run check` (locales, oxlint, tsc) passes
- [x] Full frontend test suite passes (784 files / 10685 tests)
- [x] New tests: `role-management-modal.test.tsx`, new case in `staff-master-detail.test.tsx`
- [x] `dependency-cruise` and `knip` pass via pre-push hooks
- [ ] Manual browser verification (docker compose stack, click through as an admin, confirm forced re-authentication) — not yet run, recommended before merge