### PR TITLE
fix(frontend): match remaining route skeletons to real content

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
@@ -298,10 +298,6 @@ function DashboardContent() {
     }
   }, [status, session, router]);
 
-  if (status === "loading") {
-    return <DashboardSkeleton />;
-  }
-
   const firstName = session?.user?.name?.split(" ")[0] ?? "User";
   const greeting = getTimeBasedGreeting();
 

--- a/frontend/src/app/[tenant]/(protected)/messages/[threadId]/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/[threadId]/loading.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ThreadSkeleton } from "./page-skeleton";
+
+export default function MessageThreadLoading() {
+  return <ThreadSkeleton />;
+}

--- a/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page-skeleton.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Skeleton } from "~/components/ui/skeleton";
+
+// Mirrors the real thread layout: back-nav, header row (guardian name +
+// subtitle vs. "Zum Kinderprofil" button), the scrollable chat bubble list,
+// and the composer bar, so the loaded page swaps in without layout shift.
+export function ThreadSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Unterhaltung wird geladen"
+      data-testid="thread-skeleton"
+      className="-mt-1.5 flex min-h-[20rem] w-full flex-col overflow-hidden"
+    >
+      <Skeleton className="mb-4 h-5 w-40 rounded" />
+
+      <div className="moto-content-surface flex min-h-0 flex-1 flex-col rounded-2xl border p-4 backdrop-blur-sm sm:p-6">
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-6 w-40 rounded" />
+            <Skeleton className="h-4 w-56 rounded" />
+          </div>
+          <Skeleton className="h-9 w-36 flex-shrink-0 rounded-lg" />
+        </div>
+
+        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+          {Array.from({ length: 5 }, (_, i) => (
+            <Skeleton
+              key={i}
+              className={`h-12 rounded-2xl ${
+                i % 2 === 0 ? "w-2/3" : "ml-auto w-1/2"
+              }`}
+            />
+          ))}
+        </div>
+
+        <div className="mt-4">
+          <Skeleton className="h-12 w-full rounded-full" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import useSWR, { unstable_serialize, useSWRConfig } from "swr";
 import { ArrowLeft, User } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/alert";
-import { Loading } from "~/components/ui/loading";
 import { BackButton } from "~/components/ui/back-button";
 import { MessageComposer } from "~/components/messaging/message-composer";
 import { ChatBubble, ChatEventCard } from "~/components/messaging/chat-bubble";
@@ -29,6 +28,7 @@ import { staffRequestStatusLabel } from "~/lib/messaging-status";
 import { hasPermission, isAdmin } from "~/lib/auth-utils";
 import { createLogger } from "~/lib/logger";
 import { formatChatDateTime } from "~/lib/date-helpers";
+import { ThreadSkeleton } from "./page-skeleton";
 
 const logger = createLogger({ component: "MessageThreadPage" });
 
@@ -221,9 +221,9 @@ function MessageThreadContent() {
     Boolean(thread) && !isLoading,
   );
 
-  // Full-page loader only for a direct deep-link with no cached seed.
+  // Full-page skeleton only for a direct deep-link with no cached seed.
   if (!thread && isLoading) {
-    return <Loading fullPage={false} />;
+    return <ThreadSkeleton />;
   }
 
   if (!thread) {
@@ -404,9 +404,5 @@ function MessagesBackNav() {
 }
 
 export default function MessageThreadPage() {
-  return (
-    <Suspense fallback={<Loading fullPage={false} />}>
-      <MessageThreadContent />
-    </Suspense>
-  );
+  return <MessageThreadContent />;
 }

--- a/frontend/src/app/[tenant]/(protected)/messages/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import useSWR from "swr";
 import { MessageCircle } from "lucide-react";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
@@ -226,9 +226,5 @@ function MessagesInboxContent() {
 }
 
 export default function MessagesPage() {
-  return (
-    <Suspense fallback={<MessagesSkeleton />}>
-      <MessagesInboxContent />
-    </Suspense>
-  );
+  return <MessagesInboxContent />;
 }

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -232,7 +232,7 @@ function GroupAbsenceOverview({
 function OGSGroupPageContent() {
   const router = useTenantRouter();
   const searchParams = useSearchParams();
-  const { data: session, status } = useSession({
+  const { data: session } = useSession({
     required: true,
     onUnauthenticated() {
       router.push("/");
@@ -1168,7 +1168,7 @@ function OGSGroupPageContent() {
     return filters;
   }, [sortMode, searchTerm, attendanceFilter]);
 
-  if (status === "loading" || isLoading || hasAccess === null) {
+  if (isLoading || hasAccess === null) {
     return <OgsGroupsPageSkeleton />;
   }
 

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page-skeleton.tsx
@@ -2,12 +2,72 @@
 
 import { Skeleton } from "~/components/ui/skeleton";
 
-// ─── Loading skeleton ────────────────────────────────────────────────────────
+// ─── Übersicht tab skeleton ──────────────────────────────────────────────────
+// Mirrors uebersicht-tab.tsx: 3 KpiCards, then a 2-column chart-card grid
+// (Tagesvergleich line chart + Saldo-Verlauf area chart), then a donut +
+// legend card — so the loaded tab swaps in without layout shift.
+
+export function UebersichtTabSkeleton() {
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div
+            key={i}
+            className="rounded-3xl border border-gray-100/50 bg-white/90 p-5 shadow-sm"
+          >
+            <Skeleton className="h-3 w-24 rounded" />
+            <Skeleton className="mt-2 h-7 w-20 rounded" />
+            <Skeleton className="mt-3 h-3 w-32 rounded" />
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+        {Array.from({ length: 2 }, (_, i) => (
+          <div
+            key={i}
+            className="rounded-3xl border border-gray-100/50 bg-white/90 p-4 shadow-sm sm:p-6"
+          >
+            <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <Skeleton className="h-3 w-40 rounded" />
+              <Skeleton className="h-9 w-40 rounded-lg" />
+            </div>
+            <Skeleton className="h-64 w-full rounded-xl" />
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-3xl border border-gray-100/50 bg-white/90 p-4 shadow-sm sm:p-6">
+        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Skeleton className="h-3 w-32 rounded" />
+          <Skeleton className="h-9 w-40 rounded-lg" />
+        </div>
+        <div className="grid grid-cols-1 items-center gap-6 md:grid-cols-2">
+          <Skeleton className="mx-auto h-64 w-64 rounded-full" />
+          <div className="flex flex-col gap-3">
+            {Array.from({ length: 4 }, (_, i) => (
+              <div key={i} className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-2.5 w-2.5 rounded-full" />
+                  <Skeleton className="h-3 w-20 rounded" />
+                </div>
+                <Skeleton className="h-3 w-16 rounded" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Route-level loading skeleton ────────────────────────────────────────────
 
 export function StaffDetailSkeleton() {
   // Mirrors StaffHeader (avatar + name block + status badge) and the
-  // TabsList line, then two DataGrid-shaped field sections for the
-  // Übersicht tab body, so the loaded page swaps in without layout shift.
+  // TabsList line, then the Übersicht tab body, so the loaded page swaps in
+  // without layout shift.
   return (
     <div
       role="status"
@@ -37,24 +97,7 @@ export function StaffDetailSkeleton() {
         ))}
       </div>
 
-      <div className="space-y-6">
-        {Array.from({ length: 2 }, (_, section) => (
-          <div
-            key={section}
-            className="rounded-3xl border border-gray-100/50 bg-white/90 p-6 shadow-sm"
-          >
-            <Skeleton className="mb-4 h-5 w-40 rounded" />
-            <dl className="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">
-              {Array.from({ length: 4 }, (_, field) => (
-                <div key={field} className="space-y-1.5">
-                  <Skeleton className="h-3 w-20 rounded" />
-                  <Skeleton className="h-4 w-32 rounded" />
-                </div>
-              ))}
-            </dl>
-          </div>
-        ))}
-      </div>
+      <UebersichtTabSkeleton />
     </div>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page-skeleton.tsx
@@ -1,66 +1,7 @@
 "use client";
 
 import { Skeleton } from "~/components/ui/skeleton";
-
-// ─── Übersicht tab skeleton ──────────────────────────────────────────────────
-// Mirrors uebersicht-tab.tsx: 3 KpiCards, then a 2-column chart-card grid
-// (Tagesvergleich line chart + Saldo-Verlauf area chart), then a donut +
-// legend card — so the loaded tab swaps in without layout shift.
-
-export function UebersichtTabSkeleton() {
-  return (
-    <div className="space-y-5">
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        {Array.from({ length: 3 }, (_, i) => (
-          <div
-            key={i}
-            className="rounded-3xl border border-gray-100/50 bg-white/90 p-5 shadow-sm"
-          >
-            <Skeleton className="h-3 w-24 rounded" />
-            <Skeleton className="mt-2 h-7 w-20 rounded" />
-            <Skeleton className="mt-3 h-3 w-32 rounded" />
-          </div>
-        ))}
-      </div>
-
-      <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
-        {Array.from({ length: 2 }, (_, i) => (
-          <div
-            key={i}
-            className="rounded-3xl border border-gray-100/50 bg-white/90 p-4 shadow-sm sm:p-6"
-          >
-            <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <Skeleton className="h-3 w-40 rounded" />
-              <Skeleton className="h-9 w-40 rounded-lg" />
-            </div>
-            <Skeleton className="h-64 w-full rounded-xl" />
-          </div>
-        ))}
-      </div>
-
-      <div className="rounded-3xl border border-gray-100/50 bg-white/90 p-4 shadow-sm sm:p-6">
-        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <Skeleton className="h-3 w-32 rounded" />
-          <Skeleton className="h-9 w-40 rounded-lg" />
-        </div>
-        <div className="grid grid-cols-1 items-center gap-6 md:grid-cols-2">
-          <Skeleton className="mx-auto h-64 w-64 rounded-full" />
-          <div className="flex flex-col gap-3">
-            {Array.from({ length: 4 }, (_, i) => (
-              <div key={i} className="flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <Skeleton className="h-2.5 w-2.5 rounded-full" />
-                  <Skeleton className="h-3 w-20 rounded" />
-                </div>
-                <Skeleton className="h-3 w-16 rounded" />
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
+import { UebersichtTabSkeleton } from "~/components/staff/uebersicht-tab-skeleton";
 
 // ─── Route-level loading skeleton ────────────────────────────────────────────
 

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, Suspense } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useParams, redirect } from "next/navigation";
 import { useSession } from "next-auth/react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
@@ -213,7 +213,7 @@ function PlaceholderTab({ title }: { readonly title: string }) {
 
 // ─── Main Page ───────────────────────────────────────────────────────────────
 
-function StaffDetailContent() {
+export default function StaffDetailContent() {
   const { data: session, status: sessionStatus } = useSession({
     required: true,
     onUnauthenticated() {
@@ -389,13 +389,5 @@ function StaffDetailContent() {
         </TabsPrimitive.Content>
       </Tabs>
     </div>
-  );
-}
-
-export default function StaffDetailPage() {
-  return (
-    <Suspense fallback={<StaffDetailSkeleton />}>
-      <StaffDetailContent />
-    </Suspense>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/staff/dienstplan/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/dienstplan/loading.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { DienstplanPageSkeleton } from "./page-skeleton";
+
+/**
+ * Route-level loading UI: renders the same skeleton the page shows while its
+ * data loads, so navigation shows one continuous skeleton instead of the
+ * generic group-level Loading followed by the page skeleton.
+ */
+export default function DienstplanLoading() {
+  return <DienstplanPageSkeleton />;
+}

--- a/frontend/src/app/[tenant]/(protected)/staff/dienstplan/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/dienstplan/page-skeleton.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Skeleton } from "~/components/ui/skeleton";
+
+// Mirrors the real Dienstplan layout: the "Schichtarten verwalten" toolbar
+// button, the card's 3-col sub-header (helper text, week-nav, "Diese Woche"),
+// and the week grid (staff column + 5 weekday columns), so the loaded page
+// swaps in without layout shift.
+export function DienstplanPageSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Dienstplan wird geladen"
+      data-testid="dienstplan-skeleton"
+      className="space-y-4"
+    >
+      <div className="flex justify-end">
+        <Skeleton className="h-9 w-56 rounded-lg" />
+      </div>
+      <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
+        <div className="mb-4 flex flex-col gap-3 sm:grid sm:grid-cols-3 sm:items-center">
+          <Skeleton className="hidden h-3 w-64 rounded sm:block" />
+          <div className="flex min-w-0 items-center justify-center gap-2">
+            <Skeleton className="h-7 w-7 flex-shrink-0 rounded-full" />
+            <Skeleton className="h-4 w-40 rounded sm:w-56" />
+            <Skeleton className="h-7 w-7 flex-shrink-0 rounded-full" />
+          </div>
+          <div className="flex justify-center sm:justify-end">
+            <Skeleton className="h-6 w-24 rounded-full" />
+          </div>
+        </div>
+        <div className="max-w-full overflow-x-auto rounded-2xl border border-gray-100">
+          <table className="w-full min-w-[960px] border-collapse text-sm">
+            <tbody className="divide-y divide-gray-100">
+              {Array.from({ length: 6 }, (_, row) => (
+                <tr key={row} className="bg-white">
+                  <td className="px-4 py-2">
+                    <Skeleton className="h-4 w-32 rounded" />
+                  </td>
+                  {Array.from({ length: 5 }, (_, col) => (
+                    <td key={col} className="px-3 py-2">
+                      <Skeleton className="h-9 w-full rounded-md" />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[tenant]/(protected)/staff/dienstplan/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/dienstplan/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { redirect } from "next/navigation";
 import { useSession } from "next-auth/react";
 
@@ -14,7 +14,6 @@ import {
 import { ShiftTypeManageModal } from "~/components/staff/shift-type-manage-modal";
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
-import { Loading } from "~/components/ui/loading";
 import { isAdmin } from "~/lib/auth-utils";
 import { parseISODate, toISODate } from "~/lib/date-helpers";
 import { useBerlinToday } from "~/lib/hooks/use-berlin-today";
@@ -29,6 +28,8 @@ import { staffService, type Staff } from "~/lib/staff-api";
 import { useSWRAuth } from "~/lib/swr";
 import { useTenantRouter } from "~/lib/tenant-router";
 import { getWeekNumber } from "~/lib/time-tracking-helpers";
+
+import { DienstplanPageSkeleton } from "./page-skeleton";
 
 // Admin week view for planned staff shifts (Dienstplan, #1376 core slice).
 // One row per staff member, Mo–Fr columns, click-to-edit per cell. The
@@ -155,12 +156,12 @@ function DienstplanContent() {
   };
 
   if (sessionStatus === "loading") {
-    return <Loading fullPage={false} />;
+    return <DienstplanPageSkeleton />;
   }
 
   if (!canEdit) {
     router.replace("/staff");
-    return <Loading fullPage={false} />;
+    return <DienstplanPageSkeleton />;
   }
 
   return (
@@ -302,9 +303,5 @@ function DienstplanContent() {
 }
 
 export default function DienstplanPage() {
-  return (
-    <Suspense fallback={<Loading fullPage={false} />}>
-      <DienstplanContent />
-    </Suspense>
-  );
+  return <DienstplanContent />;
 }

--- a/frontend/src/app/[tenant]/(protected)/staff/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, Suspense, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import { redirect } from "next/navigation";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
@@ -406,11 +406,6 @@ function StaffPageContent() {
   );
 }
 
-// Main component with Suspense wrapper
 export default function StaffPage() {
-  return (
-    <Suspense fallback={<StaffPageSkeleton />}>
-      <StaffPageContent />
-    </Suspense>
-  );
+  return <StaffPageContent />;
 }

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/feedback-history/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/feedback-history/loading.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { FeedbackHistorySkeleton } from "./page-skeleton";
+
+/**
+ * Route-level loading UI: renders the same skeleton the page shows while its
+ * data loads, so navigation shows one continuous skeleton instead of the
+ * generic group-level Loading followed by the page skeleton.
+ */
+export default function StudentFeedbackHistoryLoading() {
+  return <FeedbackHistorySkeleton />;
+}

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/feedback-history/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/feedback-history/page-skeleton.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Skeleton } from "~/components/ui/skeleton";
+
+// Mirrors the header block, filter-pills row, and the proportion-bar +
+// legend + chart card of the real page, so it swaps in without layout shift.
+export function FeedbackHistorySkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Feedbackhistorie wird geladen"
+      data-testid="feedback-history-skeleton"
+      className="mx-auto max-w-7xl"
+    >
+      <Skeleton className="mb-4 h-9 w-24 rounded-lg" />
+
+      <div className="mb-6 ml-6 space-y-2">
+        <Skeleton className="h-8 w-48 rounded" />
+        <Skeleton className="h-4 w-32 rounded" />
+        <div className="mt-2 flex items-center gap-2">
+          <Skeleton className="h-4 w-4 rounded-full" />
+          <Skeleton className="h-4 w-56 rounded" />
+        </div>
+      </div>
+
+      <div className="mb-6 flex flex-wrap gap-2">
+        {Array.from({ length: 5 }, (_, i) => (
+          <Skeleton key={i} className="h-8 w-24 rounded-full" />
+        ))}
+      </div>
+
+      <div className="moto-content-surface overflow-hidden rounded-3xl border shadow-sm">
+        <div className="p-4 sm:p-6 md:p-8">
+          <Skeleton className="mb-4 h-5 w-40 rounded" />
+
+          <Skeleton className="mt-4 h-3 w-full rounded-full" />
+
+          <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1">
+            {Array.from({ length: 3 }, (_, i) => (
+              <div key={i} className="flex items-center gap-1.5">
+                <Skeleton className="h-2.5 w-2.5 rounded-full" />
+                <Skeleton className="h-4 w-16 rounded" />
+              </div>
+            ))}
+          </div>
+
+          <Skeleton className="mt-6 h-[180px] w-full rounded-lg sm:h-[220px]" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/feedback-history/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/feedback-history/page.test.tsx
@@ -147,7 +147,7 @@ describe("StudentFeedbackHistoryPage", () => {
   it("renders loading state initially", () => {
     render(<StudentFeedbackHistoryPage />);
 
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(screen.getByTestId("feedback-history-skeleton")).toBeInTheDocument();
   });
 
   it("renders student name as page heading", async () => {

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/feedback-history/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/feedback-history/page.tsx
@@ -9,7 +9,7 @@ import { getStartDateForTimeRange, toISODate } from "~/lib/date-helpers";
 import { useStudentHistoryBreadcrumb } from "~/lib/breadcrumb-context";
 import { useScrollToTop } from "~/lib/hooks/use-scroll-to-top";
 import { BackButton } from "~/components/ui/back-button";
-import { Loading } from "~/components/ui/loading";
+import { FeedbackHistorySkeleton } from "./page-skeleton";
 import { createLogger } from "~/lib/logger";
 import { fetchStudent } from "~/lib/student-api";
 import type { Student } from "~/lib/student-helpers";
@@ -200,7 +200,7 @@ export default function StudentFeedbackHistoryPage() {
   };
 
   if (loading) {
-    return <Loading fullPage={false} />;
+    return <FeedbackHistorySkeleton />;
   }
 
   if (error || !student) {

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/loading.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { RoomHistorySkeleton } from "./page-skeleton";
+
+/**
+ * Route-level loading UI: renders the same skeleton the page shows while its
+ * data loads, so navigation shows one continuous skeleton instead of the
+ * generic group-level Loading followed by the page skeleton.
+ */
+export default function RoomHistoryLoading() {
+  return <RoomHistorySkeleton />;
+}

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/page-skeleton.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Skeleton } from "~/components/ui/skeleton";
+
+// Mirrors the loaded page: back button, student header (name + plain
+// two-span meta line), a two-column chart grid, then the history table
+// (desktop table + mobile day-card list), so there's no layout shift.
+export function RoomHistorySkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Anwesenheitsprotokoll wird geladen"
+      data-testid="room-history-skeleton"
+      className="w-full"
+    >
+      <Skeleton className="mb-4 h-9 w-24 rounded-lg" />
+
+      <div className="mb-6 ml-6">
+        <Skeleton className="h-8 w-48 rounded" />
+        <div className="mt-2 flex items-center gap-2">
+          <Skeleton className="h-4 w-20 rounded" />
+          <Skeleton className="h-4 w-24 rounded" />
+        </div>
+      </div>
+
+      <div className="mb-4 grid grid-cols-1 gap-4 md:mb-6 md:grid-cols-2 md:gap-6">
+        {Array.from({ length: 2 }, (_, i) => (
+          <div
+            key={i}
+            className="moto-content-surface overflow-hidden rounded-3xl border shadow-sm"
+          >
+            <div className="p-4 sm:p-6">
+              <div className="mb-3 space-y-1.5">
+                <Skeleton className="h-5 w-32 rounded" />
+                <Skeleton className="h-3 w-40 rounded" />
+              </div>
+              <Skeleton className="h-[180px] w-full rounded-xl sm:h-[200px]" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="moto-content-surface overflow-hidden rounded-3xl border shadow-sm">
+        <div className="border-b border-gray-100 px-4 py-3 sm:px-6 sm:py-4">
+          <Skeleton className="h-5 w-48 rounded" />
+          <Skeleton className="mt-1.5 h-3 w-56 rounded" />
+        </div>
+
+        {/* Desktop table */}
+        <div className="hidden md:block">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-gray-100">
+                {["Tag", "Ankunft", "Abmeldung", "Dauer", "Räume"].map(
+                  (label) => (
+                    <th key={label} className="px-6 py-3 text-left">
+                      <Skeleton className="h-3 w-14 rounded" />
+                    </th>
+                  ),
+                )}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {Array.from({ length: 4 }, (_, row) => (
+                <tr key={row}>
+                  {Array.from({ length: 5 }, (_, cell) => (
+                    <td key={cell} className="px-6 py-3">
+                      <Skeleton className="h-4 w-16 rounded" />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Mobile day-card list */}
+        <div className="md:hidden">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between border-b border-gray-100 px-4 py-3 last:border-b-0"
+            >
+              <div className="flex items-center gap-3">
+                <Skeleton className="h-9 w-9 flex-shrink-0 rounded-full" />
+                <div className="space-y-1.5">
+                  <Skeleton className="h-4 w-16 rounded" />
+                  <Skeleton className="h-3 w-24 rounded" />
+                </div>
+              </div>
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/page.test.tsx
@@ -205,7 +205,7 @@ describe("StudentRoomHistoryPage", () => {
   it("renders loading state initially", () => {
     mockFetch.mockResolvedValue(mockStudentResponse());
     render(<StudentRoomHistoryPage />);
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(screen.getByTestId("room-history-skeleton")).toBeInTheDocument();
   });
 
   // ─── Student header ─────────────────────────────────────────────────────────

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/room-history/page.tsx
@@ -14,7 +14,6 @@ import {
 import { useTenantRouter } from "~/lib/tenant-router";
 import { BackButton } from "~/components/ui/back-button";
 import { Alert } from "~/components/ui/alert";
-import { Loading } from "~/components/ui/loading";
 import { useStudentHistoryBreadcrumb } from "~/lib/breadcrumb-context";
 import { useScrollToTop } from "~/lib/hooks/use-scroll-to-top";
 import { createLogger } from "~/lib/logger";
@@ -29,6 +28,7 @@ import {
   mapAttendanceHistoryResponse,
 } from "~/lib/attendance-history-helpers";
 import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
+import { RoomHistorySkeleton } from "./page-skeleton";
 
 const logger = createLogger({ component: "StudentRoomHistoryPage" });
 
@@ -45,10 +45,7 @@ interface Student {
 }
 
 type ErrorCode =
-  | "feature_disabled"
-  | "not_group_supervisor"
-  | "not_found"
-  | "generic";
+  "feature_disabled" | "not_group_supervisor" | "not_found" | "generic";
 
 const ERROR_MESSAGES: Record<ErrorCode, string> = {
   feature_disabled:
@@ -751,7 +748,7 @@ function StudentRoomHistoryPageContent() {
   }, [fetchStudent, fetchHistory]);
 
   if (loading) {
-    return <Loading fullPage={false} />;
+    return <RoomHistorySkeleton />;
   }
 
   if (errorCode !== null && errorCode !== "feature_disabled") {

--- a/frontend/src/app/[tenant]/(protected)/suggestions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/suggestions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback, Suspense } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import { useTenantRouter } from "~/lib/tenant-router";
 import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
@@ -327,15 +327,5 @@ function EmptyState({
 }
 
 export default function SuggestionsPage() {
-  return (
-    <Suspense
-      fallback={
-        <div className="-mt-1.5 w-full">
-          <SuggestionSkeletons />
-        </div>
-      }
-    >
-      <SuggestionsPageContent />
-    </Suspense>
-  );
+  return <SuggestionsPageContent />;
 }

--- a/frontend/src/components/staff/uebersicht-tab-skeleton.tsx
+++ b/frontend/src/components/staff/uebersicht-tab-skeleton.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Skeleton } from "~/components/ui/skeleton";
+
+// Mirrors uebersicht-tab.tsx: 3 KpiCards, then a 2-column chart-card grid
+// (Tagesvergleich line chart + Saldo-Verlauf area chart), then a donut +
+// legend card — so the loaded tab swaps in without layout shift. Lives in
+// components/ (not the staff/[id] route) so both the route-level skeleton
+// and the tab's own data-refetch loading state can import it.
+export function UebersichtTabSkeleton() {
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div
+            key={i}
+            className="rounded-3xl border border-gray-100/50 bg-white/90 p-5 shadow-sm"
+          >
+            <Skeleton className="h-3 w-24 rounded" />
+            <Skeleton className="mt-2 h-7 w-20 rounded" />
+            <Skeleton className="mt-3 h-3 w-32 rounded" />
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+        {Array.from({ length: 2 }, (_, i) => (
+          <div
+            key={i}
+            className="rounded-3xl border border-gray-100/50 bg-white/90 p-4 shadow-sm sm:p-6"
+          >
+            <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <Skeleton className="h-3 w-40 rounded" />
+              <Skeleton className="h-9 w-40 rounded-lg" />
+            </div>
+            <Skeleton className="h-64 w-full rounded-xl" />
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-3xl border border-gray-100/50 bg-white/90 p-4 shadow-sm sm:p-6">
+        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Skeleton className="h-3 w-32 rounded" />
+          <Skeleton className="h-9 w-40 rounded-lg" />
+        </div>
+        <div className="grid grid-cols-1 items-center gap-6 md:grid-cols-2">
+          <Skeleton className="mx-auto h-64 w-64 rounded-full" />
+          <div className="flex flex-col gap-3">
+            {Array.from({ length: 4 }, (_, i) => (
+              <div key={i} className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-2.5 w-2.5 rounded-full" />
+                  <Skeleton className="h-3 w-20 rounded" />
+                </div>
+                <Skeleton className="h-3 w-16 rounded" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/staff/uebersicht-tab.tsx
+++ b/frontend/src/components/staff/uebersicht-tab.tsx
@@ -28,7 +28,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "~/components/ui/chart";
-import { Loading } from "~/components/ui/loading";
+import { UebersichtTabSkeleton } from "~/app/[tenant]/(protected)/staff/[id]/page-skeleton";
 import {
   staffAbsenceService,
   staffHistoryService,
@@ -244,7 +244,7 @@ export function UebersichtTab({ staffId }: { readonly staffId: string }) {
     (accountSessions?.length ?? 0) + (accountAbsences?.length ?? 0) > 0;
 
   if (scheduleLoading || sessionsLoading || absencesLoading) {
-    return <Loading fullPage={false} />;
+    return <UebersichtTabSkeleton />;
   }
 
   const yearStartLabel = metrics.accountStart.toLocaleDateString("de-DE", {
@@ -339,8 +339,7 @@ export function UebersichtTab({ staffId }: { readonly staffId: string }) {
                       indicator="line"
                       labelFormatter={(_l, payload) => {
                         const p = payload?.[0]?.payload as
-                          | { fullLabel?: string }
-                          | undefined;
+                          { fullLabel?: string } | undefined;
                         return p?.fullLabel ?? "";
                       }}
                       formatter={(value) => formatSignedDuration(Number(value))}

--- a/frontend/src/components/staff/uebersicht-tab.tsx
+++ b/frontend/src/components/staff/uebersicht-tab.tsx
@@ -28,7 +28,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "~/components/ui/chart";
-import { UebersichtTabSkeleton } from "~/app/[tenant]/(protected)/staff/[id]/page-skeleton";
+import { UebersichtTabSkeleton } from "~/components/staff/uebersicht-tab-skeleton";
 import {
   staffAbsenceService,
   staffHistoryService,


### PR DESCRIPTION
## Summary

Follow-up to #1862 (`/database` skeleton fix). A workflow audit checked every other route touched by PR #1852 ("responsive skeleton loading states for all pages") and PR #1861 ("remove double-skeleton flash") for the same bug class — a route's `loading.tsx` (or an inherited parent `loading.tsx`) renders a shape that doesn't match what the page actually renders once loaded. Five routes had this genuinely, user-visibly wrong; several others had harmless leftover dead loading code from before #1861 landed.

### Shape mismatches fixed

- **`/staff/dienstplan`** — had no `loading.tsx` of its own, inherited `/staff`'s card-grid skeleton for what's actually a week-schedule table. Added a matching `page-skeleton.tsx` + `loading.tsx`.
- **`/staff/[id]`** — `StaffDetailSkeleton` faked two DataGrid label/value panels, but the real default tab (`UebersichtTab`) renders 3 KPI cards + 2 charts + a donut/legend card. Rebuilt the skeleton to match, and extracted the shared piece as `UebersichtTabSkeleton` (in `components/staff/`, not the route tree) so both the route-level skeleton and the tab's own data-refetch loading state render the identical shape instead of a generic spinner.
- **`/students/[id]/feedback-history`** and **`/students/[id]/room-history`** — both had no `loading.tsx`, inherited the parent's tabbed detail-page skeleton for what are actually a filter+chart page and a charts+table page respectively. Added matching skeletons + `loading.tsx` for each.
- **`/messages/[threadId]`** — had no `loading.tsx`, inherited the inbox-list skeleton for what's actually a chat/detail thread view. Added a matching skeleton + `loading.tsx`.

### Dead-code cleanup

Only removed where confirmed genuinely unreachable (a parent `RoleGuard` already blocks rendering until the session resolves — verified case by case, not assumed):

- `/dashboard` — removed a redundant `status === "loading"` branch already covered by `RoleGuard`.
- `/ogs-groups` — simplified a compound loading condition, dropping the `RoleGuard`-redundant clause.
- `/staff`, `/messages`, `/suggestions` — removed dead `<Suspense>` wrappers around components that never actually suspend.

Explicitly left untouched: `/rooms` (documented intentional in a code comment), `/activities` and `/timetables` (neither has a `RoleGuard`, so their session-loading branch is each page's only gate — not dead).

## Test plan

- [x] `pnpm run check` (locale verify + oxlint + tsc) passes
- [x] `dependency-cruise` passes (moved `UebersichtTabSkeleton` into `components/staff/` to respect the `components-not-to-app-or-api-routes` rule)
- [x] All 370 tests across the 12 touched test files pass, including 2 updated to assert the new shaped skeleton instead of the old generic spinner
- [x] Manually verified against a seeded local tenant: `/staff/dienstplan` (week grid), `/staff/[id]` (KPI/chart Übersicht tab), `/students/[id]/feedback-history`, `/students/[id]/room-history`, and `/messages` all render correctly with no console errors