### PR TITLE
Consolidate client IP extraction

### DIFF
--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"slices"
 	"strconv"
@@ -23,6 +22,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/internal/clientip"
 	"github.com/moto-nrw/project-phoenix/internal/strutil"
 	authModel "github.com/moto-nrw/project-phoenix/models/auth"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
@@ -2201,29 +2201,5 @@ func (rs *Resource) listParentAccounts(w http.ResponseWriter, r *http.Request) {
 
 // getClientIP extracts the real client IP address from the request
 func getClientIP(r *http.Request) string {
-	// Check X-Real-IP header first (set by reverse proxy)
-	if ip := r.Header.Get("X-Real-IP"); ip != "" {
-		return ip
-	}
-
-	// Check X-Forwarded-For header
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// Split the header value on commas and trim each entry
-		ips := strings.Split(xff, ",")
-		for i, ip := range ips {
-			ips[i] = strings.TrimSpace(ip)
-		}
-		// Return the first IP in the list
-		if len(ips) > 0 {
-			return ips[0]
-		}
-	}
-
-	// Fall back to RemoteAddr
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-
-	return ip
+	return clientip.GetClientIPString(r)
 }

--- a/backend/api/auth/auth_internal_test.go
+++ b/backend/api/auth/auth_internal_test.go
@@ -3,10 +3,13 @@
 package auth
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/moto-nrw/project-phoenix/internal/strutil"
 	authModel "github.com/moto-nrw/project-phoenix/models/auth"
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -18,20 +21,21 @@ import (
 // getClientIP Tests
 // =============================================================================
 
-func TestGetClientIP_XRealIP(t *testing.T) {
+func TestGetClientIP_IgnoresRawXRealIP(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("X-Real-IP", "192.168.1.100")
+	req.RemoteAddr = "192.0.2.50:1234"
 
 	ip := getClientIP(req)
 
-	assert.Equal(t, "192.168.1.100", ip)
+	assert.Equal(t, "192.0.2.50", ip)
 }
 
 func TestGetClientIP_XForwardedFor_Single(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("X-Forwarded-For", "10.0.0.50")
 
-	ip := getClientIP(req)
+	ip := getClientIPThroughXFFMiddleware(req)
 
 	assert.Equal(t, "10.0.0.50", ip)
 }
@@ -40,19 +44,18 @@ func TestGetClientIP_XForwardedFor_Multiple(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("X-Forwarded-For", "10.0.0.1, 10.0.0.2, 10.0.0.3")
 
-	ip := getClientIP(req)
+	ip := getClientIPThroughXFFMiddleware(req)
 
-	// Should return first IP
-	assert.Equal(t, "10.0.0.1", ip)
+	assert.Equal(t, "10.0.0.3", ip)
 }
 
 func TestGetClientIP_XForwardedFor_WithSpaces(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("X-Forwarded-For", "  10.0.0.1  ,  10.0.0.2  ")
 
-	ip := getClientIP(req)
+	ip := getClientIPThroughXFFMiddleware(req)
 
-	assert.Equal(t, "10.0.0.1", ip)
+	assert.Equal(t, "10.0.0.2", ip)
 }
 
 func TestGetClientIP_RemoteAddr_WithPort(t *testing.T) {
@@ -83,16 +86,15 @@ func TestGetClientIP_RemoteAddr_NoPort(t *testing.T) {
 	assert.Equal(t, "192.168.1.1", ip)
 }
 
-func TestGetClientIP_XRealIP_TakesPrecedence(t *testing.T) {
+func TestGetClientIP_XForwardedForBeatsRawXRealIP(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("X-Real-IP", "1.1.1.1")
 	req.Header.Set("X-Forwarded-For", "2.2.2.2")
 	req.RemoteAddr = "3.3.3.3:1234"
 
-	ip := getClientIP(req)
+	ip := getClientIPThroughXFFMiddleware(req)
 
-	// X-Real-IP takes precedence
-	assert.Equal(t, "1.1.1.1", ip)
+	assert.Equal(t, "2.2.2.2", ip)
 }
 
 func TestGetClientIP_XForwardedFor_TakesPrecedence_OverRemoteAddr(t *testing.T) {
@@ -100,10 +102,21 @@ func TestGetClientIP_XForwardedFor_TakesPrecedence_OverRemoteAddr(t *testing.T) 
 	req.Header.Set("X-Forwarded-For", "2.2.2.2")
 	req.RemoteAddr = "3.3.3.3:1234"
 
-	ip := getClientIP(req)
+	ip := getClientIPThroughXFFMiddleware(req)
 
-	// X-Forwarded-For takes precedence over RemoteAddr
 	assert.Equal(t, "2.2.2.2", ip)
+}
+
+func getClientIPThroughXFFMiddleware(req *http.Request) string {
+	var ip string
+	router := chi.NewRouter()
+	router.Use(chimiddleware.ClientIPFromXFF())
+	router.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+		ip = getClientIP(r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	router.ServeHTTP(httptest.NewRecorder(), req)
+	return ip
 }
 
 // =============================================================================

--- a/backend/api/auth/mfa_cookie_helpers_internal_test.go
+++ b/backend/api/auth/mfa_cookie_helpers_internal_test.go
@@ -1,10 +1,13 @@
 package auth
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,27 +16,26 @@ import (
 // header-precedence refactor, so we lock its behaviour down here. (The
 // matching Secure flag is now a literal `true`, so no helper test is needed.)
 
-func TestParseClientIP_PrefersXRealIP(t *testing.T) {
+func TestParseClientIP_UsesChiXFFOverRawXRealIP(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/mfa", nil)
 	r.Header.Set("X-Real-IP", "203.0.113.10")
 	r.Header.Set("X-Forwarded-For", "198.51.100.7")
 	r.RemoteAddr = "10.0.0.1:54321"
 
-	ip := parseClientIP(r)
+	ip := parseClientIPThroughXFFMiddleware(r)
 	if assert.NotNil(t, ip) {
-		assert.Equal(t, "203.0.113.10", ip.String())
+		assert.Equal(t, "198.51.100.7", ip.String())
 	}
 }
 
-func TestParseClientIP_FallsBackToXForwardedForFirstHop(t *testing.T) {
+func TestParseClientIP_UsesRightmostXForwardedForHop(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/mfa", nil)
 	r.Header.Set("X-Forwarded-For", "198.51.100.7, 10.0.0.1, 172.16.0.1")
 	r.RemoteAddr = "10.0.0.1:54321"
 
-	ip := parseClientIP(r)
+	ip := parseClientIPThroughXFFMiddleware(r)
 	if assert.NotNil(t, ip) {
-		assert.Equal(t, "198.51.100.7", ip.String(),
-			"XFF must use the leftmost (client) hop, not the proxy hop")
+		assert.Equal(t, "172.16.0.1", ip.String())
 	}
 }
 
@@ -49,9 +51,9 @@ func TestParseClientIP_FallsBackToRemoteAddr(t *testing.T) {
 
 func TestParseClientIP_ParsesIPv6(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/mfa", nil)
-	r.Header.Set("X-Real-IP", "2001:db8::1")
+	r.Header.Set("X-Forwarded-For", "2001:db8::1")
 
-	ip := parseClientIP(r)
+	ip := parseClientIPThroughXFFMiddleware(r)
 	if assert.NotNil(t, ip) {
 		assert.Equal(t, "2001:db8::1", ip.String())
 	}
@@ -59,9 +61,10 @@ func TestParseClientIP_ParsesIPv6(t *testing.T) {
 
 func TestParseClientIP_ReturnsNilOnUnparseable(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/mfa", nil)
-	r.Header.Set("X-Real-IP", "not-an-ip")
+	r.Header.Set("X-Forwarded-For", "not-an-ip")
+	r.RemoteAddr = ""
 
-	assert.Nil(t, parseClientIP(r),
+	assert.Nil(t, parseClientIPThroughXFFMiddleware(r),
 		"unparseable IP strings must yield nil so callers don't bind garbage into the HMAC payload")
 }
 
@@ -71,4 +74,16 @@ func TestParseClientIP_ReturnsNilOnEmptyRequest(t *testing.T) {
 
 	assert.Nil(t, parseClientIP(r),
 		"no header + empty RemoteAddr must produce a nil IP")
+}
+
+func parseClientIPThroughXFFMiddleware(req *http.Request) net.IP {
+	var ip net.IP
+	router := chi.NewRouter()
+	router.Use(chimiddleware.ClientIPFromXFF())
+	router.Get("/mfa", func(w http.ResponseWriter, r *http.Request) {
+		ip = parseClientIP(r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	router.ServeHTTP(httptest.NewRecorder(), req)
+	return ip
 }

--- a/backend/api/auth/mfa_handlers.go
+++ b/backend/api/auth/mfa_handlers.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/internal/clientip"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	authService "github.com/moto-nrw/project-phoenix/services/auth"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -352,9 +353,5 @@ func (rs *Resource) issueTrustedDeviceCookie(w http.ResponseWriter, r *http.Requ
 // parseClientIP wraps getClientIP and parses the result as net.IP. Returns
 // nil when the header value is empty or unparseable.
 func parseClientIP(r *http.Request) net.IP {
-	raw := getClientIP(r)
-	if raw == "" {
-		return nil
-	}
-	return net.ParseIP(raw)
+	return clientip.ParseClientIP(r)
 }

--- a/backend/api/auth/mfa_verify_success_internal_test.go
+++ b/backend/api/auth/mfa_verify_success_internal_test.go
@@ -87,6 +87,7 @@ func verifyRequest(t *testing.T, body MFAVerifyRequest) *http.Request {
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("User-Agent", "test-ua")
 	r.Header.Set("X-Real-IP", "203.0.113.10")
+	r.RemoteAddr = "203.0.113.10:54321"
 	return r
 }
 

--- a/backend/api/auth/passkey_handlers.go
+++ b/backend/api/auth/passkey_handlers.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"errors"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -122,7 +121,7 @@ func (rs *Resource) passkeyEnrollmentChallenge(w http.ResponseWriter, r *http.Re
 	if !ok {
 		return
 	}
-	result, err := rs.PasskeyService.StartEnrollmentChallenge(r.Context(), int64(claims.ID), claims.TenantID, net.ParseIP(getClientIP(r)))
+	result, err := rs.PasskeyService.StartEnrollmentChallenge(r.Context(), int64(claims.ID), claims.TenantID, parseClientIP(r))
 	if err != nil {
 		mapPasskeyError(w, r, err)
 		return

--- a/backend/api/enrollment/submission_handlers.go
+++ b/backend/api/enrollment/submission_handlers.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	"github.com/uptrace/bun"
 
 	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/internal/clientip"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
 	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
@@ -328,20 +328,10 @@ func lateInviteTokenFromRequest(r *http.Request) string {
 	return strings.TrimSpace(r.URL.Query().Get("late_invite"))
 }
 
-// remoteIPFromRequest extracts the client IP for captcha verification +
-// future rate limiting. Honors X-Forwarded-For (first hop) when set.
+// remoteIPFromRequest returns the router-selected client IP for captcha
+// verification and submission rate limiting.
 func remoteIPFromRequest(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if comma := strings.IndexByte(xff, ','); comma >= 0 {
-			return strings.TrimSpace(xff[:comma])
-		}
-		return strings.TrimSpace(xff)
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
+	return clientip.GetClientIPString(r)
 }
 
 // --- status / edit / withdraw handlers (token-gated, public) ---

--- a/backend/api/enrollment/submission_handlers_test.go
+++ b/backend/api/enrollment/submission_handlers_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -270,25 +272,24 @@ func TestMapSubmitError_UnknownError500(t *testing.T) {
 
 // --- remoteIPFromRequest -------------------------------------------------
 
-func TestRemoteIPFromRequest_XForwardedForFirstHop(t *testing.T) {
+func TestRemoteIPFromRequest_XForwardedForRightmostHop(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/x", nil)
 	r.Header.Set("X-Forwarded-For", "203.0.113.5, 198.51.100.4, 192.0.2.1")
 	r.RemoteAddr = "10.0.0.1:54321"
-	assert.Equal(t, "203.0.113.5", remoteIPFromRequest(r),
-		"first hop wins — the rest is the proxy chain")
+	assert.Equal(t, "192.0.2.1", remoteIPFromRequestThroughXFFMiddleware(r))
 }
 
 func TestRemoteIPFromRequest_XForwardedForSingleEntry(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/x", nil)
 	r.Header.Set("X-Forwarded-For", "203.0.113.5")
 	r.RemoteAddr = "10.0.0.1:54321"
-	assert.Equal(t, "203.0.113.5", remoteIPFromRequest(r))
+	assert.Equal(t, "203.0.113.5", remoteIPFromRequestThroughXFFMiddleware(r))
 }
 
 func TestRemoteIPFromRequest_XForwardedForTrimsWhitespace(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/x", nil)
 	r.Header.Set("X-Forwarded-For", "  203.0.113.5  ,198.51.100.4")
-	assert.Equal(t, "203.0.113.5", remoteIPFromRequest(r))
+	assert.Equal(t, "198.51.100.4", remoteIPFromRequestThroughXFFMiddleware(r))
 }
 
 func TestRemoteIPFromRequest_FallsBackToRemoteAddrSansPort(t *testing.T) {
@@ -310,4 +311,16 @@ func TestRemoteIPFromRequest_IPv6BracketsHandled(t *testing.T) {
 	r.RemoteAddr = "[2001:db8::1]:54321"
 	// net.SplitHostPort strips brackets.
 	assert.Equal(t, "2001:db8::1", remoteIPFromRequest(r))
+}
+
+func remoteIPFromRequestThroughXFFMiddleware(req *http.Request) string {
+	var ip string
+	router := chi.NewRouter()
+	router.Use(chimiddleware.ClientIPFromXFF())
+	router.Post("/x", func(w http.ResponseWriter, r *http.Request) {
+		ip = remoteIPFromRequest(r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	router.ServeHTTP(httptest.NewRecorder(), req)
+	return ip
 }

--- a/backend/api/operator/auth.go
+++ b/backend/api/operator/auth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
 	jwtPkg "github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/internal/clientip"
 	platformSvc "github.com/moto-nrw/project-phoenix/services/platform"
 )
 
@@ -202,19 +203,5 @@ func (rs *AuthResource) RefreshToken(w http.ResponseWriter, r *http.Request) {
 
 // getClientIP extracts the client IP from the request
 func getClientIP(r *http.Request) net.IP {
-	// Check X-Forwarded-For header first
-	xff := r.Header.Get("X-Forwarded-For")
-	if xff != "" {
-		return net.ParseIP(xff)
-	}
-
-	// Check X-Real-IP header
-	xri := r.Header.Get("X-Real-IP")
-	if xri != "" {
-		return net.ParseIP(xri)
-	}
-
-	// Fall back to RemoteAddr
-	host, _, _ := net.SplitHostPort(r.RemoteAddr)
-	return net.ParseIP(host)
+	return clientip.ParseClientIP(r)
 }

--- a/backend/api/operator/auth_test.go
+++ b/backend/api/operator/auth_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -335,13 +337,13 @@ func TestLogin_ClientIPExtraction_XForwardedFor(t *testing.T) {
 	req.Header.Set("X-Forwarded-For", "192.168.1.100")
 	rr := httptest.NewRecorder()
 
-	resource.Login(rr, req)
+	serveOperatorLoginThroughXFFMiddleware(resource, rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "192.168.1.100", capturedIP)
 }
 
-func TestLogin_ClientIPExtraction_XRealIP(t *testing.T) {
+func TestLogin_ClientIPExtraction_IgnoresRawXRealIP(t *testing.T) {
 	var capturedIP string
 	mockService := &mockOperatorAuthService{
 		loginWithMFAGateFn: func(ctx context.Context, email, password, ipAddress, userAgent, trustedDeviceCookie string) (*platformSvc.OperatorLoginResult, error) {
@@ -364,12 +366,20 @@ func TestLogin_ClientIPExtraction_XRealIP(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewReader(jsonBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Real-IP", "10.0.0.50")
+	req.RemoteAddr = "192.0.2.55:1234"
 	rr := httptest.NewRecorder()
 
 	resource.Login(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, "10.0.0.50", capturedIP)
+	assert.Equal(t, "192.0.2.55", capturedIP)
+}
+
+func serveOperatorLoginThroughXFFMiddleware(resource *operator.AuthResource, rr *httptest.ResponseRecorder, req *http.Request) {
+	router := chi.NewRouter()
+	router.Use(chimiddleware.ClientIPFromXFF())
+	router.Post("/auth/login", resource.Login)
+	router.ServeHTTP(rr, req)
 }
 
 func TestLoginRequest_Bind(t *testing.T) {

--- a/backend/api/operator/mfa_verify_success_internal_test.go
+++ b/backend/api/operator/mfa_verify_success_internal_test.go
@@ -84,6 +84,7 @@ func opVerifyRequest(t *testing.T, body MFAVerifyRequest) *http.Request {
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("User-Agent", "operator-ua")
 	r.Header.Set("X-Forwarded-For", "203.0.113.99")
+	r.RemoteAddr = "203.0.113.99:54321"
 	return r
 }
 

--- a/backend/api/operator/passkeys.go
+++ b/backend/api/operator/passkeys.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"errors"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -84,7 +83,7 @@ func (rs *Resource) PasskeyEnrollmentChallenge(w http.ResponseWriter, r *http.Re
 		return
 	}
 	claims := jwt.ClaimsFromCtx(r.Context())
-	result, err := rs.passkeyService.StartEnrollmentChallenge(r.Context(), int64(claims.ID), net.ParseIP(clientIPString(r)))
+	result, err := rs.passkeyService.StartEnrollmentChallenge(r.Context(), int64(claims.ID), getClientIP(r))
 	if err != nil {
 		mapOperatorPasskeyError(w, r, err)
 		return
@@ -179,14 +178,6 @@ func operatorPasskeyExpectedOrigin(r *http.Request) string {
 		return origin
 	}
 	return strings.TrimSpace(r.Header.Get("Origin"))
-}
-
-func clientIPString(r *http.Request) string {
-	ip := getClientIP(r)
-	if ip == nil {
-		return ""
-	}
-	return ip.String()
 }
 
 func mapOperatorPasskeyError(w http.ResponseWriter, r *http.Request, err error) {

--- a/backend/api/parent/auth_handlers.go
+++ b/backend/api/parent/auth_handlers.go
@@ -3,7 +3,6 @@ package parent
 import (
 	"database/sql"
 	"errors"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/go-ozzo/ozzo-validation/is"
 
 	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/internal/clientip"
 	authService "github.com/moto-nrw/project-phoenix/services/auth"
 )
 
@@ -197,25 +197,7 @@ func (rs *Resource) resetPassword(w http.ResponseWriter, r *http.Request) {
 	common.Respond(w, r, http.StatusOK, nil, "Password reset successfully")
 }
 
-// getClientIP extracts the originating IP from common forwarding
-// headers. Local copy to avoid a circular import on api/auth's
-// helpers — same algorithm.
+// getClientIP returns the router-selected client IP for audit/rate-limit flows.
 func getClientIP(r *http.Request) string {
-	if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
-		parts := strings.Split(forwarded, ",")
-		if len(parts) > 0 {
-			candidate := strings.TrimSpace(parts[0])
-			if candidate != "" {
-				return candidate
-			}
-		}
-	}
-	if real := r.Header.Get("X-Real-IP"); real != "" {
-		return strings.TrimSpace(real)
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
+	return clientip.GetClientIPString(r)
 }

--- a/backend/api/parent/get_client_ip_test.go
+++ b/backend/api/parent/get_client_ip_test.go
@@ -5,59 +5,47 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/assert"
 )
 
-// getClientIP extracts the parent's real IP for login-attempt rate
-// limiting + audit logging. Honors X-Forwarded-For (first hop) and
-// X-Real-IP, with RemoteAddr as the final fallback. Differs from
-// api/enrollment.remoteIPFromRequest only by also honoring X-Real-IP
-// (used by older proxies).
+// getClientIP returns the router-selected client IP for login-attempt rate
+// limiting + audit logging. XFF semantics come from chi's ClientIPFromXFF.
 
-func TestGetClientIP_XForwardedForFirstHop(t *testing.T) {
+func TestGetClientIP_XForwardedForRightmostHop(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/x", nil)
 	r.Header.Set("X-Forwarded-For", "203.0.113.5, 198.51.100.4, 192.0.2.1")
 	r.RemoteAddr = "10.0.0.1:54321"
-	assert.Equal(t, "203.0.113.5", getClientIP(r),
-		"first XFF hop wins — the rest is the proxy chain")
+	assert.Equal(t, "192.0.2.1", getClientIPThroughXFFMiddleware(r))
 }
 
 func TestGetClientIP_XForwardedForTrimsWhitespace(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/x", nil)
 	r.Header.Set("X-Forwarded-For", "  203.0.113.5  , 198.51.100.4")
-	assert.Equal(t, "203.0.113.5", getClientIP(r))
+	assert.Equal(t, "198.51.100.4", getClientIPThroughXFFMiddleware(r))
 }
 
-func TestGetClientIP_XForwardedForBlankFirstHopFallsThrough(t *testing.T) {
-	// A degenerate XFF where the first comma-separated value is empty
-	// shouldn't return an empty string — fall through to X-Real-IP.
+func TestGetClientIP_MalformedXForwardedForFallsBackToRemoteAddr(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/x", nil)
-	r.Header.Set("X-Forwarded-For", ", 198.51.100.4")
-	r.Header.Set("X-Real-IP", "203.0.113.5")
-	assert.Equal(t, "203.0.113.5", getClientIP(r),
-		"blank XFF first hop must fall through, not return empty")
+	r.Header.Set("X-Forwarded-For", "203.0.113.5, not-an-ip")
+	r.Header.Set("X-Real-IP", "198.51.100.4")
+	r.RemoteAddr = "10.0.0.1:54321"
+	assert.Equal(t, "10.0.0.1", getClientIPThroughXFFMiddleware(r))
 }
 
-func TestGetClientIP_XRealIPSecondPriority(t *testing.T) {
+func TestGetClientIP_IgnoresRawXRealIP(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/x", nil)
 	r.Header.Set("X-Real-IP", "203.0.113.5")
 	r.RemoteAddr = "10.0.0.1:54321"
-	assert.Equal(t, "203.0.113.5", getClientIP(r))
+	assert.Equal(t, "10.0.0.1", getClientIP(r))
 }
 
 func TestGetClientIP_XForwardedForBeatsXRealIP(t *testing.T) {
-	// When both headers are present, XFF wins — it's the modern
-	// standard and our reverse proxy sets it.
 	r := httptest.NewRequest(http.MethodPost, "/x", nil)
 	r.Header.Set("X-Forwarded-For", "203.0.113.5")
 	r.Header.Set("X-Real-IP", "198.51.100.4")
-	assert.Equal(t, "203.0.113.5", getClientIP(r))
-}
-
-func TestGetClientIP_XRealIPTrimsWhitespace(t *testing.T) {
-	r := httptest.NewRequest(http.MethodPost, "/x", nil)
-	r.Header.Set("X-Real-IP", "  203.0.113.5  ")
-	assert.Equal(t, "203.0.113.5", getClientIP(r))
+	assert.Equal(t, "203.0.113.5", getClientIPThroughXFFMiddleware(r))
 }
 
 func TestGetClientIP_FallsBackToRemoteAddrSansPort(t *testing.T) {
@@ -84,4 +72,16 @@ func TestGetClientIP_NoHeadersNoAddrReturnsEmpty(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/x", nil)
 	r.RemoteAddr = ""
 	assert.Equal(t, "", getClientIP(r))
+}
+
+func getClientIPThroughXFFMiddleware(req *http.Request) string {
+	var ip string
+	router := chi.NewRouter()
+	router.Use(chimiddleware.ClientIPFromXFF())
+	router.Post("/x", func(w http.ResponseWriter, r *http.Request) {
+		ip = getClientIP(r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	router.ServeHTTP(httptest.NewRecorder(), req)
+	return ip
 }

--- a/backend/internal/clientip/clientip.go
+++ b/backend/internal/clientip/clientip.go
@@ -1,0 +1,40 @@
+package clientip
+
+import (
+	"net"
+	"net/http"
+
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+)
+
+// GetClientIPString returns the request client IP selected by the router's
+// client-IP middleware, falling back to RemoteAddr for tests and non-router
+// call sites.
+func GetClientIPString(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if ip := chimiddleware.GetClientIP(r.Context()); ip != "" {
+		return ip
+	}
+
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// ParseClientIP returns the selected request client IP as net.IP.
+func ParseClientIP(r *http.Request) net.IP {
+	return ParseIPString(GetClientIPString(r))
+}
+
+// ParseIPString parses a client IP string, preserving nil for empty or invalid
+// inputs so callers do not persist malformed inet values.
+func ParseIPString(ipAddress string) net.IP {
+	if ipAddress == "" {
+		return nil
+	}
+	return net.ParseIP(ipAddress)
+}

--- a/backend/internal/clientip/clientip_test.go
+++ b/backend/internal/clientip/clientip_test.go
@@ -1,0 +1,101 @@
+package clientip
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetClientIPString_ChiXFFSingleHop(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	req.RemoteAddr = "172.18.0.4:54321"
+
+	ip := getClientIPThroughMiddleware(req)
+
+	assert.Equal(t, "203.0.113.10", ip)
+}
+
+func TestGetClientIPString_ChiXFFUsesRightmostUntrustedHop(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10, 198.51.100.4, 192.0.2.1")
+	req.RemoteAddr = "172.18.0.4:54321"
+
+	ip := getClientIPThroughMiddleware(req)
+
+	assert.Equal(t, "192.0.2.1", ip)
+}
+
+func TestGetClientIPString_MalformedXFFFallsBackToRemoteAddr(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10, not-an-ip")
+	req.RemoteAddr = "172.18.0.4:54321"
+
+	ip := getClientIPThroughMiddleware(req)
+
+	assert.Equal(t, "172.18.0.4", ip)
+}
+
+func TestGetClientIPString_RemoteAddrWithPort(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.5:54321"
+
+	assert.Equal(t, "203.0.113.5", GetClientIPString(req))
+}
+
+func TestGetClientIPString_RemoteAddrWithoutPortReturnedRaw(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "no-port-here"
+
+	assert.Equal(t, "no-port-here", GetClientIPString(req))
+}
+
+func TestGetClientIPString_IPv6BracketsHandled(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "[2001:db8::1]:54321"
+
+	assert.Equal(t, "2001:db8::1", GetClientIPString(req))
+}
+
+func TestParseClientIP(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	req.RemoteAddr = "172.18.0.4:54321"
+
+	var ip string
+	router := chi.NewRouter()
+	router.Use(chimiddleware.ClientIPFromXFF())
+	router.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		parsed := ParseClientIP(r)
+		if parsed != nil {
+			ip = parsed.String()
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "203.0.113.10", ip)
+}
+
+func TestParseIPString(t *testing.T) {
+	assert.Nil(t, ParseIPString(""))
+	assert.Nil(t, ParseIPString("not-an-ip"))
+	assert.Equal(t, "203.0.113.10", ParseIPString("203.0.113.10").String())
+}
+
+func getClientIPThroughMiddleware(req *http.Request) string {
+	var ip string
+	router := chi.NewRouter()
+	router.Use(chimiddleware.ClientIPFromXFF())
+	router.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		ip = GetClientIPString(r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	router.ServeHTTP(httptest.NewRecorder(), req)
+	return ip
+}

--- a/backend/middleware/ratelimit.go
+++ b/backend/middleware/ratelimit.go
@@ -2,12 +2,11 @@ package middleware
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"sync"
 	"time"
 
-	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/moto-nrw/project-phoenix/internal/clientip"
 	"golang.org/x/time/rate"
 )
 
@@ -132,15 +131,5 @@ func (rl *RateLimiter) Middleware() func(http.Handler) http.Handler {
 
 // GetClientIP extracts the real client IP address from the request
 func GetClientIP(r *http.Request) string {
-	if ip := chimiddleware.GetClientIP(r.Context()); ip != "" {
-		return ip
-	}
-
-	// Fall back to RemoteAddr
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-
-	return ip
+	return clientip.GetClientIPString(r)
 }

--- a/backend/services/auth/auth_login.go
+++ b/backend/services/auth/auth_login.go
@@ -14,6 +14,7 @@ import (
 	jwx "github.com/lestrrat-go/jwx/v3/jwt"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/auth/userpass"
+	"github.com/moto-nrw/project-phoenix/internal/clientip"
 	"github.com/moto-nrw/project-phoenix/models/audit"
 	"github.com/moto-nrw/project-phoenix/models/auth"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
@@ -258,10 +259,7 @@ func MaskEmailForUX(email string) string {
 // don't get malformed inet values. Shared with the operator login flow in
 // services/platform.
 func ParseClientIP(ipAddress string) net.IP {
-	if ipAddress == "" {
-		return nil
-	}
-	return net.ParseIP(ipAddress)
+	return clientip.ParseIPString(ipAddress)
 }
 
 // IssueTokensForAuthenticatedAccount mints an access + refresh token pair for

--- a/frontend/src/app/api/auth/login/route.test.ts
+++ b/frontend/src/app/api/auth/login/route.test.ts
@@ -88,8 +88,6 @@ describe("POST /api/auth/login", () => {
       headers: {
         "Content-Type": "application/json",
         "User-Agent": "unknown",
-        "X-Forwarded-For": "unknown",
-        "X-Real-IP": "unknown",
       },
       body: JSON.stringify(loginPayload),
     });

--- a/frontend/src/app/api/auth/logout/route.test.ts
+++ b/frontend/src/app/api/auth/logout/route.test.ts
@@ -116,8 +116,6 @@ describe("POST /api/auth/logout", () => {
         Authorization: "Bearer test-refresh-token",
         "Content-Type": "application/json",
         "User-Agent": "unknown",
-        "X-Forwarded-For": "unknown",
-        "X-Real-IP": "unknown",
       },
     });
 

--- a/frontend/src/app/api/auth/password-reset/confirm/route.test.ts
+++ b/frontend/src/app/api/auth/password-reset/confirm/route.test.ts
@@ -89,8 +89,6 @@ describe("POST /api/auth/password-reset/confirm", () => {
       headers: {
         "Content-Type": "application/json",
         "User-Agent": "unknown",
-        "X-Forwarded-For": "unknown",
-        "X-Real-IP": "unknown",
       },
       body: JSON.stringify(requestBody),
     });

--- a/frontend/src/app/api/auth/password-reset/route.test.ts
+++ b/frontend/src/app/api/auth/password-reset/route.test.ts
@@ -82,8 +82,6 @@ describe("POST /api/auth/password-reset", () => {
       headers: {
         "Content-Type": "application/json",
         "User-Agent": "unknown",
-        "X-Forwarded-For": "unknown",
-        "X-Real-IP": "unknown",
       },
       body: JSON.stringify(requestBody),
     });

--- a/frontend/src/app/api/auth/register/route.test.ts
+++ b/frontend/src/app/api/auth/register/route.test.ts
@@ -115,8 +115,6 @@ describe("POST /api/auth/register", () => {
       headers: {
         "Content-Type": "application/json",
         "User-Agent": "unknown",
-        "X-Forwarded-For": "unknown",
-        "X-Real-IP": "unknown",
       },
       body: JSON.stringify(registrationPayload),
     });
@@ -166,8 +164,6 @@ describe("POST /api/auth/register", () => {
         "Content-Type": "application/json",
         Authorization: "Bearer admin-token",
         "User-Agent": "unknown",
-        "X-Forwarded-For": "unknown",
-        "X-Real-IP": "unknown",
       },
       body: JSON.stringify(registrationPayload),
     });

--- a/frontend/src/app/api/enrollment/[tenantSlug]/submit/route.test.ts
+++ b/frontend/src/app/api/enrollment/[tenantSlug]/submit/route.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+vi.mock("~/lib/server-api-url", () => ({
+  getServerApiUrl: () => "http://backend.test",
+}));
+
+vi.mock("~/lib/logger", () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+  }),
+}));
+
+const mockFetch = vi.fn();
+
+describe("enrollment submit proxy", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetAllMocks();
+  });
+
+  it("forwards only the canonical client IP", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: "ok" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const request = new NextRequest(
+      "http://school-a.localhost:3000/api/enrollment/school-a/submit",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-forwarded-for": "203.0.113.10, 172.20.0.4",
+          "x-real-ip": "198.51.100.25",
+        },
+        body: JSON.stringify({ child: "Ada" }),
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ tenantSlug: "school-a" }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://backend.test/api/enrollment/school-a/submit",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "X-Forwarded-For": "172.20.0.4",
+        }) as HeadersInit,
+      }),
+    );
+  });
+});

--- a/frontend/src/app/api/enrollment/[tenantSlug]/submit/route.ts
+++ b/frontend/src/app/api/enrollment/[tenantSlug]/submit/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { canonicalForwardedFor } from "~/lib/client-headers.server";
 import { getServerApiUrl } from "~/lib/server-api-url";
 import { createLogger } from "~/lib/logger";
 
@@ -19,14 +20,14 @@ export async function POST(request: NextRequest, context: RouteContext) {
   }
   try {
     const body = (await request.json()) as Record<string, unknown>;
-    const xff = request.headers.get("x-forwarded-for") ?? "";
+    const forwardedFor = canonicalForwardedFor(request.headers);
     const response = await fetch(
       `${getServerApiUrl()}/api/enrollment/${encodeURIComponent(tenantSlug)}/submit`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-Forwarded-For": xff,
+          ...(forwardedFor && { "X-Forwarded-For": forwardedFor }),
         },
         body: JSON.stringify(body),
       },

--- a/frontend/src/app/api/parent/auth/password-reset/confirm/route.test.ts
+++ b/frontend/src/app/api/parent/auth/password-reset/confirm/route.test.ts
@@ -87,8 +87,6 @@ describe("POST /api/parent/auth/password-reset/confirm", () => {
       headers: {
         "Content-Type": "application/json",
         "User-Agent": "unknown",
-        "X-Forwarded-For": "unknown",
-        "X-Real-IP": "unknown",
       },
       body: JSON.stringify(requestBody),
     });

--- a/frontend/src/app/api/parent/auth/password-reset/route.test.ts
+++ b/frontend/src/app/api/parent/auth/password-reset/route.test.ts
@@ -89,8 +89,6 @@ describe("POST /api/parent/auth/password-reset", () => {
       headers: {
         "Content-Type": "application/json",
         "User-Agent": "unknown",
-        "X-Forwarded-For": "unknown",
-        "X-Real-IP": "unknown",
       },
       body: JSON.stringify(requestBody),
     });

--- a/frontend/src/lib/api-helpers.server.ts
+++ b/frontend/src/lib/api-helpers.server.ts
@@ -2,6 +2,7 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { recordBackendProxyMetric } from "./backend-proxy-metrics";
+import { canonicalForwardedFor } from "./client-headers.server";
 import { createLogger } from "~/lib/logger";
 
 // Logger instance for API helpers
@@ -96,15 +97,12 @@ async function getIncomingForwardHeaders(): Promise<Record<string, string>> {
   try {
     const { headers } = await import("next/headers");
     const incomingHeaders = await headers();
-    const forwardedFor = incomingHeaders.get("x-forwarded-for");
-    const realIp = incomingHeaders.get("x-real-ip");
     const userAgent = incomingHeaders.get("user-agent");
-    const ip = forwardedFor?.split(",")[0]?.trim() ?? realIp;
+    const forwardedFor = canonicalForwardedFor(incomingHeaders);
 
     return {
-      ...(ip && {
-        "X-Forwarded-For": ip,
-        "X-Real-IP": ip,
+      ...(forwardedFor && {
+        "X-Forwarded-For": forwardedFor,
       }),
       ...(userAgent && { "User-Agent": userAgent }),
     };

--- a/frontend/src/lib/api-helpers.test.ts
+++ b/frontend/src/lib/api-helpers.test.ts
@@ -858,7 +858,7 @@ describe("apiGet (server-side)", () => {
     });
   });
 
-  it("forwards incoming client IP and user agent headers to the backend", async () => {
+  it("forwards the canonical client IP and user agent headers to the backend", async () => {
     mockNextHeaders.mockResolvedValueOnce(
       new Headers({
         "x-forwarded-for": "203.0.113.10, 172.20.0.4",
@@ -880,8 +880,7 @@ describe("apiGet (server-side)", () => {
         headers: expect.objectContaining({
           Authorization: "Bearer token",
           "Content-Type": "application/json",
-          "X-Forwarded-For": "203.0.113.10",
-          "X-Real-IP": "203.0.113.10",
+          "X-Forwarded-For": "172.20.0.4",
           "User-Agent": "Mozilla/5.0 Test Browser",
         }) as HeadersInit,
       }),
@@ -909,7 +908,6 @@ describe("apiGet (server-side)", () => {
           Authorization: "Bearer token",
           "Content-Type": "application/json",
           "X-Forwarded-For": "198.51.100.25",
-          "X-Real-IP": "198.51.100.25",
         },
       }),
     );

--- a/frontend/src/lib/client-headers.server.test.ts
+++ b/frontend/src/lib/client-headers.server.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { NextRequest } from "next/server";
-import { getClientForwardHeaders } from "./client-headers.server";
+import {
+  canonicalForwardedFor,
+  getClientForwardHeaders,
+} from "./client-headers.server";
 
 describe("getClientForwardHeaders", () => {
   it("uses the request host for the frontend origin on localhost subdomains", () => {
@@ -20,6 +23,38 @@ describe("getClientForwardHeaders", () => {
       "X-Forwarded-For": "203.0.113.10",
       "User-Agent": "browser",
     });
+    expect(getClientForwardHeaders(request)).not.toHaveProperty("X-Real-IP");
+  });
+
+  it("forwards the rightmost client IP from a forwarded-for chain", () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/auth/passkeys/login/options",
+      {
+        headers: {
+          "x-forwarded-for": "203.0.113.10, 172.20.0.4",
+        },
+      },
+    );
+
+    expect(getClientForwardHeaders(request)).toMatchObject({
+      "X-Forwarded-For": "172.20.0.4",
+    });
+    expect(getClientForwardHeaders(request)).not.toHaveProperty("X-Real-IP");
+  });
+
+  it("falls back to x-real-ip when forwarded-for is absent", () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/auth/passkeys/login/options",
+      {
+        headers: {
+          "x-real-ip": "198.51.100.25",
+        },
+      },
+    );
+
+    expect(getClientForwardHeaders(request)).toMatchObject({
+      "X-Forwarded-For": "198.51.100.25",
+    });
   });
 
   it("honors x-forwarded-proto when building the frontend origin", () => {
@@ -36,5 +71,54 @@ describe("getClientForwardHeaders", () => {
     expect(getClientForwardHeaders(request)["X-Moto-Frontend-Origin"]).toBe(
       "https://school-a.moto-app.de",
     );
+  });
+});
+
+describe("canonicalForwardedFor", () => {
+  it("uses the rightmost non-empty forwarded-for entry", () => {
+    expect(
+      canonicalForwardedFor(
+        new Headers({
+          "x-forwarded-for": " , 203.0.113.10, 172.20.0.4",
+          "x-real-ip": "198.51.100.25",
+        }),
+      ),
+    ).toBe("172.20.0.4");
+  });
+
+  it("rejects spoofed leftmost entries by selecting the rightmost valid entry", () => {
+    expect(
+      canonicalForwardedFor(
+        new Headers({
+          "x-forwarded-for": "spoofed, 203.0.113.10",
+        }),
+      ),
+    ).toBe("203.0.113.10");
+  });
+
+  it("fails closed when the rightmost forwarded-for entry is invalid", () => {
+    expect(
+      canonicalForwardedFor(
+        new Headers({
+          "x-forwarded-for": "203.0.113.10, not-an-ip",
+          "x-real-ip": "198.51.100.25",
+        }),
+      ),
+    ).toBe("");
+  });
+
+  it("omits invalid x-real-ip fallback values", () => {
+    expect(
+      canonicalForwardedFor(
+        new Headers({
+          "x-real-ip": "203.0.113.10:1234",
+        }),
+      ),
+    ).toBe("");
+  });
+
+  it("returns an empty string when no client IP headers are present", () => {
+    expect(canonicalForwardedFor(new Headers())).toBe("");
+    expect(canonicalForwardedFor(null)).toBe("");
   });
 });

--- a/frontend/src/lib/client-headers.server.ts
+++ b/frontend/src/lib/client-headers.server.ts
@@ -1,7 +1,28 @@
+import { isIP } from "node:net";
 import type { NextRequest } from "next/server";
 
-function firstHeaderValue(value: string | null): string {
-  return value?.split(",")[0]?.trim() ?? "";
+type HeaderReader = Pick<Headers, "get">;
+
+function firstHeaderValue(value: string | null | undefined): string {
+  return (
+    value
+      ?.split(",")
+      .map((part) => part.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function lastHeaderValue(value: string | null | undefined): string {
+  const parts = value?.split(",") ?? [];
+  for (let index = parts.length - 1; index >= 0; index -= 1) {
+    const part = parts[index]?.trim();
+    if (part) return part;
+  }
+  return "";
+}
+
+function isValidHeaderIP(value: string): boolean {
+  return isIP(value) !== 0;
 }
 
 function isSafeForwardedHost(value: string): boolean {
@@ -41,17 +62,21 @@ function frontendOrigin(request: NextRequest): string {
 export function getClientForwardHeaders(
   request: NextRequest,
 ): Record<string, string> {
-  const ip =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    request.headers.get("x-real-ip") ??
-    "unknown";
-
+  const forwardedFor = canonicalForwardedFor(request.headers);
   const userAgent = request.headers.get("user-agent") ?? "unknown";
 
   return {
-    "X-Forwarded-For": ip,
-    "X-Real-IP": ip,
+    ...(forwardedFor && { "X-Forwarded-For": forwardedFor }),
     "X-Moto-Frontend-Origin": frontendOrigin(request),
     "User-Agent": userAgent,
   };
+}
+
+export function canonicalForwardedFor(headers: HeaderReader | null): string {
+  const forwardedFor = lastHeaderValue(headers?.get("x-forwarded-for"));
+  if (forwardedFor) {
+    return isValidHeaderIP(forwardedFor) ? forwardedFor : "";
+  }
+  const realIp = firstHeaderValue(headers?.get("x-real-ip"));
+  return isValidHeaderIP(realIp) ? realIp : "";
 }

--- a/frontend/src/server/auth/config.test.ts
+++ b/frontend/src/server/auth/config.test.ts
@@ -1477,6 +1477,44 @@ describe("authConfig", () => {
       expect(result?.scope).toBe("platform");
     });
 
+    it("should forward only the canonical operator client IP", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          status: "success",
+          data: {
+            access_token: OPERATOR_JWT,
+            refresh_token: "op-refresh-token",
+            operator: {
+              id: 45,
+              email: "op@example.com",
+              display_name: "Op",
+            },
+          },
+        }),
+      });
+
+      const authorize = getOperatorAuthorize();
+      await authorize(
+        { email: "op@example.com", password: "correct" },
+        new Request("http://localhost:3000", {
+          headers: {
+            "x-forwarded-for": "203.0.113.10, 172.20.0.4",
+            "x-real-ip": "198.51.100.25",
+          },
+        }),
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://server:8080/operator/auth/login",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "X-Forwarded-For": "172.20.0.4",
+          }) as HeadersInit,
+        }),
+      );
+    });
+
     it("should return null for missing credentials", async () => {
       const authorize = getOperatorAuthorize();
       const result = await authorize({}, new Request("http://localhost:3000"));
@@ -1696,6 +1734,39 @@ describe("authConfig", () => {
 
       expect(result).not.toBeNull();
       expect(result?.scope).toBe("parent");
+    });
+
+    it("should forward only the canonical parent client IP", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          status: "success",
+          data: {
+            access_token: PARENT_JWT,
+            refresh_token: "parent-refresh-token",
+          },
+        }),
+      });
+
+      const authorize = getParentAuthorize();
+      await authorize(
+        { email: "parent@example.com", password: "correct" },
+        new Request("http://localhost:3000", {
+          headers: {
+            "x-forwarded-for": "203.0.113.10, 172.20.0.4",
+            "x-real-ip": "198.51.100.25",
+          },
+        }),
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://server:8080/parent/auth/login",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "X-Forwarded-For": "172.20.0.4",
+          }) as HeadersInit,
+        }),
+      );
     });
 
     it("should return null for missing credentials", async () => {

--- a/frontend/src/server/auth/operator-config.ts
+++ b/frontend/src/server/auth/operator-config.ts
@@ -12,6 +12,7 @@
 
 import type { NextAuthConfig } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
+import { canonicalForwardedFor } from "~/lib/client-headers.server";
 import {
   logger,
   parseJwtPayload,
@@ -69,10 +70,10 @@ export const operatorAuthConfig = {
 
         // Forward client IP headers for audit logs and rate limiting
         const forwardHeaders: Record<string, string> = {};
-        const forwarded = request?.headers.get("x-forwarded-for");
-        const realIp = request?.headers.get("x-real-ip");
-        if (forwarded) forwardHeaders["X-Forwarded-For"] = forwarded;
-        if (realIp) forwardHeaders["X-Real-IP"] = realIp;
+        const forwardedFor = canonicalForwardedFor(request?.headers ?? null);
+        if (forwardedFor) {
+          forwardHeaders["X-Forwarded-For"] = forwardedFor;
+        }
 
         const loginResult = await performOperatorLogin(
           creds.email,

--- a/frontend/src/server/auth/parent-config.ts
+++ b/frontend/src/server/auth/parent-config.ts
@@ -13,6 +13,7 @@
 
 import type { NextAuthConfig } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
+import { canonicalForwardedFor } from "~/lib/client-headers.server";
 import {
   logger,
   parseJwtPayload,
@@ -69,10 +70,10 @@ export const parentAuthConfig = {
         if (!creds?.email || !creds?.password) return null;
 
         const forwardHeaders: Record<string, string> = {};
-        const forwarded = request?.headers.get("x-forwarded-for");
-        const realIp = request?.headers.get("x-real-ip");
-        if (forwarded) forwardHeaders["X-Forwarded-For"] = forwarded;
-        if (realIp) forwardHeaders["X-Real-IP"] = realIp;
+        const forwardedFor = canonicalForwardedFor(request?.headers ?? null);
+        if (forwardedFor) {
+          forwardHeaders["X-Forwarded-For"] = forwardedFor;
+        }
 
         const loginResult = await performParentLogin(
           creds.email,


### PR DESCRIPTION
## Summary
- centralize backend client-IP extraction in `internal/clientip` and route auth, parent, operator, enrollment, and middleware callers through chi-selected IP semantics
- update tests to lock rightmost-untrusted XFF behavior and raw X-Real-IP non-trust
- canonicalize frontend-to-backend forwarding to one spoof-resistant `X-Forwarded-For` value using chi-aligned rightmost/fail-closed XFF selection

## Tests
- `cd backend && go test ./internal/clientip ./middleware ./api/auth ./api/parent ./api/enrollment ./api/operator -run 'Test(GetClientIP|ParseClientIP|RemoteIPFromRequest|Login_ClientIPExtraction|MFAVerify|OperatorMFAVerify|OperatorPasskeyLoginHandlers)'`
- `cd backend && go test ./internal/clientip ./middleware ./api/auth ./api/parent ./api/enrollment ./api/operator ./services/auth ./services/platform -run '^$'`
- `cd backend && go test ./api/operator -run '^$'`
- `cd frontend && pnpm run check`
- `cd frontend && pnpm test -- client-headers.server api-helpers server/auth/config app/api/enrollment`
- `cd frontend && pnpm test -- client-headers.server api-helpers app/api/auth/login app/api/auth/password-reset app/api/auth/register app/api/auth/logout app/api/parent/auth/password-reset`
- pre-push hooks: `git-secrets`, `frontend-depcruise`, `frontend-knip`, `frontend-check`; Go push hooks skipped on the final push because only frontend files changed

## Not run
- `cd backend && go test ./...` is blocked locally because `.env` / `TEST_DB_DSN` is not configured. The suite emits the standard test DB setup message: `docker compose --profile test up -d postgres-test`, then set `TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable`.

Closes #1857
