### PR TITLE
fix(iot): gate capacity error details behind tenant settings

### DIFF
--- a/backend/api/iot/checkin/capacity_errors.go
+++ b/backend/api/iot/checkin/capacity_errors.go
@@ -7,11 +7,14 @@ package checkin
 // WIRE CONTRACT (PyrePortal): the Code values, Message strings, and details
 // field names below are substring-matched by the kiosk
 // (PyrePortal/src/services/apiErrors.ts) and pinned byte-for-byte by
-// wire_format_test.go. Note the activity-capacity details keys are
-// current_occupancy/max_capacity while PyrePortal reads
-// current_participants/max_participants — a known mismatch preserved
-// deliberately; fixing it requires a coordinated backend+PyrePortal change
-// (tracked separately, issue #575 follow-up).
+// wire_format_test.go. Since issue #1879 PyrePortal reads the activity
+// details via current_occupancy/max_capacity (same keys as the room error).
+//
+// Whether the capacity 409s carry the `details` object at all is gated per
+// tenant by the checkin.*_capacity_details_enabled settings — see
+// renderCheckinError in workflow.go. When a setting is off the *NoDetails
+// renderer variants below are used and the kiosk falls back to its generic
+// German message.
 
 import (
 	"errors"
@@ -110,6 +113,43 @@ func ErrorActivityCapacityExceeded(activityID int64, activityName string, curren
 			CurrentOccupancy: currentOccupancy,
 			MaxCapacity:      maxCapacity,
 		},
+	}
+}
+
+// capacityErrorNoDetails is the details-omitted variant of the capacity 409
+// bodies, emitted when the tenant's capacity-detail disclosure setting is off
+// (issue #1879): same status/code/message, but no `details` field exists on
+// the struct at all, so the key is absent from the JSON and PyrePortal falls
+// back to its generic German message.
+type capacityErrorNoDetails struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Code    string `json:"code"`
+}
+
+// Render implements the render.Renderer interface
+func (e *capacityErrorNoDetails) Render(_ http.ResponseWriter, r *http.Request) error {
+	render.Status(r, http.StatusConflict)
+	return nil
+}
+
+// ErrorRoomCapacityExceededNoDetails returns the ROOM_CAPACITY_EXCEEDED 409
+// without the details object.
+func ErrorRoomCapacityExceededNoDetails() render.Renderer {
+	return &capacityErrorNoDetails{
+		Status:  "error",
+		Message: "Room capacity exceeded",
+		Code:    "ROOM_CAPACITY_EXCEEDED",
+	}
+}
+
+// ErrorActivityCapacityExceededNoDetails returns the ACTIVITY_CAPACITY_EXCEEDED
+// 409 without the details object.
+func ErrorActivityCapacityExceededNoDetails() render.Renderer {
+	return &capacityErrorNoDetails{
+		Status:  "error",
+		Message: "Activity capacity exceeded",
+		Code:    "ACTIVITY_CAPACITY_EXCEEDED",
 	}
 }
 

--- a/backend/api/iot/checkin/capacity_gating_internal_test.go
+++ b/backend/api/iot/checkin/capacity_gating_internal_test.go
@@ -1,0 +1,115 @@
+// Package checkin internal tests for the per-tenant capacity-detail gating in
+// renderCheckinError (issue #1879). Pure renderer tests — no database; the
+// settings service is the shared configtest.Mock.
+package checkin
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
+	checkinSvc "github.com/moto-nrw/project-phoenix/services/iot/checkin"
+)
+
+// renderGatedError drives rs.renderCheckinError with the given typed error and
+// returns the recorded response body.
+func renderGatedError(t *testing.T, rs *Resource, err error) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	rs.renderCheckinError(w, req, err)
+	assert.Equal(t, 409, w.Code)
+	return w.Body.String()
+}
+
+// settingsMock returns a SettingsService mock resolving the two capacity
+// detail keys to the given values.
+func settingsMock(activityEnabled, roomEnabled bool) *configtest.Mock {
+	return &configtest.Mock{
+		ResolveBoolFn: func(_ context.Context, key string) (bool, error) {
+			switch key {
+			case configModel.KeyCheckinActivityCapacityDetailsEnabled:
+				return activityEnabled, nil
+			case configModel.KeyCheckinRoomCapacityDetailsEnabled:
+				return roomEnabled, nil
+			default:
+				return false, nil
+			}
+		},
+	}
+}
+
+func activityCapacityErr() error {
+	return &checkinSvc.ActivityCapacityError{
+		ActivityID:       7,
+		ActivityName:     "Bastelraum",
+		CurrentOccupancy: 5,
+		MaxCapacity:      4,
+	}
+}
+
+func roomCapacityErr() error {
+	return &checkinSvc.RoomCapacityError{
+		RoomID:           42,
+		RoomName:         "Room A",
+		CurrentOccupancy: 15,
+		MaxCapacity:      10,
+	}
+}
+
+func TestRenderCheckinError_ActivityCapacity_SettingOn_IncludesDetails(t *testing.T) {
+	rs := &Resource{SettingsService: settingsMock(true, true)}
+	body := renderGatedError(t, rs, activityCapacityErr())
+
+	assert.Contains(t, body, "\"details\"")
+	assert.Contains(t, body, "\"current_occupancy\":5")
+	assert.Contains(t, body, "\"max_capacity\":4")
+	assert.Contains(t, body, "\"activity_name\":\"Bastelraum\"")
+	assert.Contains(t, body, "ACTIVITY_CAPACITY_EXCEEDED")
+}
+
+func TestRenderCheckinError_ActivityCapacity_SettingOff_OmitsDetails(t *testing.T) {
+	rs := &Resource{SettingsService: settingsMock(false, true)}
+	body := renderGatedError(t, rs, activityCapacityErr())
+
+	assert.NotContains(t, body, "\"details\"")
+	assert.Contains(t, body, "\"code\":\"ACTIVITY_CAPACITY_EXCEEDED\"")
+	assert.Contains(t, body, "\"message\":\"Activity capacity exceeded\"")
+}
+
+func TestRenderCheckinError_RoomCapacity_SettingOn_IncludesDetails(t *testing.T) {
+	rs := &Resource{SettingsService: settingsMock(false, true)}
+	body := renderGatedError(t, rs, roomCapacityErr())
+
+	assert.Contains(t, body, "\"details\"")
+	assert.Contains(t, body, "\"current_occupancy\":15")
+	assert.Contains(t, body, "\"max_capacity\":10")
+	assert.Contains(t, body, "\"room_name\":\"Room A\"")
+	assert.Contains(t, body, "ROOM_CAPACITY_EXCEEDED")
+}
+
+func TestRenderCheckinError_RoomCapacity_SettingOff_OmitsDetails(t *testing.T) {
+	rs := &Resource{SettingsService: settingsMock(false, false)}
+	body := renderGatedError(t, rs, roomCapacityErr())
+
+	assert.NotContains(t, body, "\"details\"")
+	assert.Contains(t, body, "\"code\":\"ROOM_CAPACITY_EXCEEDED\"")
+	assert.Contains(t, body, "\"message\":\"Room capacity exceeded\"")
+}
+
+// A nil settings service (bare-struct construction) must fall back to the
+// registry defaults: activity details hidden, room details shown.
+func TestRenderCheckinError_NilSettingsService_UsesPerKeyDefaults(t *testing.T) {
+	rs := &Resource{}
+
+	activityBody := renderGatedError(t, rs, activityCapacityErr())
+	assert.NotContains(t, activityBody, "\"details\"", "activity details must default to hidden")
+
+	roomBody := renderGatedError(t, rs, roomCapacityErr())
+	assert.Contains(t, roomBody, "\"details\"", "room details must default to shown")
+	assert.Contains(t, roomBody, "\"current_occupancy\":15")
+}

--- a/backend/api/iot/checkin/handlers.go
+++ b/backend/api/iot/checkin/handlers.go
@@ -279,7 +279,7 @@ func (rs *Resource) deviceCheckin(w http.ResponseWriter, r *http.Request) {
 		var err error
 		checkoutVisitID, previousRoomName, err = rs.Checkin.ProcessCheckout(ctx, student, person, currentVisit)
 		if err != nil {
-			renderCheckinError(w, r, err)
+			rs.renderCheckinError(w, r, err)
 			return
 		}
 		checkedOut = true
@@ -302,7 +302,7 @@ func (rs *Resource) deviceCheckin(w http.ResponseWriter, r *http.Request) {
 		CurrentVisit: currentVisit,
 	})
 	if err != nil {
-		renderCheckinError(w, r, err)
+		rs.renderCheckinError(w, r, err)
 		return
 	}
 	newVisitID := checkinResult.NewVisitID

--- a/backend/api/iot/checkin/wire_format_test.go
+++ b/backend/api/iot/checkin/wire_format_test.go
@@ -13,13 +13,11 @@
 // JSON, and appends a trailing newline) and asserts the literal body
 // string, including the "code" values and the exact "details" key names.
 //
-// IMPORTANT: the activity-capacity response's details keys are pinned
-// AS THEY ARE TODAY, even though there is a known, deliberately-preserved
-// mismatch between what this handler emits and what PyrePortal's client
-// code expects for that specific response. Do NOT "fix" that mismatch via
-// this golden — any such fix is a deliberate behavior change that belongs
-// in its own commit coordinated with the PyrePortal repo, not a side
-// effect of the B1 error-consolidation refactor.
+// Since issue #1879 PyrePortal reads the activity-capacity details via
+// current_occupancy/max_capacity (the keys pinned here), and the capacity
+// 409s additionally have per-tenant NoDetails variants (details omitted
+// when the checkin.*_capacity_details_enabled setting is off) — pinned by
+// the *_NoDetails goldens below.
 //
 // Changing an expectation in this file requires proof that the wire format
 // change is intentional — not just "the refactor made the test fail."
@@ -58,10 +56,32 @@ func TestWireFormat_IoTCommon_ErrorActivityCapacityExceeded(t *testing.T) {
 	renderer := iotCommon.ErrorActivityCapacityExceeded(7, "Bastelraum", 5, 4)
 	gotStatus, gotBody := renderWireIoTCommon(t, renderer)
 	assert.Equal(t, 409, gotStatus)
-	// Pinned as-is: see the file-top comment re: the known, deliberately
-	// preserved details-key mismatch for this response.
 	assert.Equal(t,
 		"{\"status\":\"error\",\"message\":\"Activity capacity exceeded\",\"code\":\"ACTIVITY_CAPACITY_EXCEEDED\",\"details\":{\"activity_id\":7,\"activity_name\":\"Bastelraum\",\"current_occupancy\":5,\"max_capacity\":4}}\n",
+		gotBody,
+	)
+}
+
+func TestWireFormat_IoTCommon_ErrorRoomCapacityExceeded_NoDetails(t *testing.T) {
+	// Emitted when checkin.room_capacity_details_enabled is off (issue #1879):
+	// same status/code/message, no `details` key at all.
+	renderer := iotCommon.ErrorRoomCapacityExceededNoDetails()
+	gotStatus, gotBody := renderWireIoTCommon(t, renderer)
+	assert.Equal(t, 409, gotStatus)
+	assert.Equal(t,
+		"{\"status\":\"error\",\"message\":\"Room capacity exceeded\",\"code\":\"ROOM_CAPACITY_EXCEEDED\"}\n",
+		gotBody,
+	)
+}
+
+func TestWireFormat_IoTCommon_ErrorActivityCapacityExceeded_NoDetails(t *testing.T) {
+	// Emitted when checkin.activity_capacity_details_enabled is off — the
+	// default (issue #1879): same status/code/message, no `details` key.
+	renderer := iotCommon.ErrorActivityCapacityExceededNoDetails()
+	gotStatus, gotBody := renderWireIoTCommon(t, renderer)
+	assert.Equal(t, 409, gotStatus)
+	assert.Equal(t,
+		"{\"status\":\"error\",\"message\":\"Activity capacity exceeded\",\"code\":\"ACTIVITY_CAPACITY_EXCEEDED\"}\n",
 		gotBody,
 	)
 }

--- a/backend/api/iot/checkin/workflow.go
+++ b/backend/api/iot/checkin/workflow.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/api/common"
 	shared "github.com/moto-nrw/project-phoenix/api/iot/internal/shared"
 	"github.com/moto-nrw/project-phoenix/auth/device"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/models/iot"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	checkinSvc "github.com/moto-nrw/project-phoenix/services/iot/checkin"
@@ -48,16 +49,30 @@ func parseCheckinRequest(ctx context.Context, w http.ResponseWriter, r *http.Req
 
 // renderCheckinError maps a CheckinService typed error to the exact renderer the
 // pre-extraction handler emitted, keeping the PyrePortal wire contract intact.
-func renderCheckinError(w http.ResponseWriter, r *http.Request, err error) {
+// The capacity 409s carry their `details` object only when the tenant's
+// checkin.*_capacity_details_enabled setting allows it (issue #1879); when
+// off, the NoDetails variant is rendered and the kiosk shows its generic
+// German fallback.
+func (rs *Resource) renderCheckinError(w http.ResponseWriter, r *http.Request, err error) {
+	ctx := r.Context()
+
 	var roomCap *checkinSvc.RoomCapacityError
 	if errors.As(err, &roomCap) {
-		common.RenderError(w, r, ErrorRoomCapacityExceeded(roomCap.RoomID, roomCap.RoomName, roomCap.CurrentOccupancy, roomCap.MaxCapacity))
+		if rs.capacityDetailsEnabled(ctx, configModel.KeyCheckinRoomCapacityDetailsEnabled, true) {
+			common.RenderError(w, r, ErrorRoomCapacityExceeded(roomCap.RoomID, roomCap.RoomName, roomCap.CurrentOccupancy, roomCap.MaxCapacity))
+		} else {
+			common.RenderError(w, r, ErrorRoomCapacityExceededNoDetails())
+		}
 		return
 	}
 
 	var actCap *checkinSvc.ActivityCapacityError
 	if errors.As(err, &actCap) {
-		common.RenderError(w, r, ErrorActivityCapacityExceeded(actCap.ActivityID, actCap.ActivityName, actCap.CurrentOccupancy, actCap.MaxCapacity))
+		if rs.capacityDetailsEnabled(ctx, configModel.KeyCheckinActivityCapacityDetailsEnabled, false) {
+			common.RenderError(w, r, ErrorActivityCapacityExceeded(actCap.ActivityID, actCap.ActivityName, actCap.CurrentOccupancy, actCap.MaxCapacity))
+		} else {
+			common.RenderError(w, r, ErrorActivityCapacityExceededNoDetails())
+		}
 		return
 	}
 
@@ -84,6 +99,27 @@ func renderCheckinError(w http.ResponseWriter, r *http.Request, err error) {
 
 	// Fallback — no typed error matched (should not happen). Render a generic 500.
 	common.RenderError(w, r, common.ErrorInternalServer(err))
+}
+
+// capacityDetailsEnabled resolves a capacity-detail disclosure setting,
+// failing safe to `fallback` when the settings service is absent
+// (bare-struct tests) or resolution errors. The fallback must match the
+// registry default for the key (activity=false, room=true) so the fail-safe
+// path preserves default behavior instead of surfacing a 500.
+func (rs *Resource) capacityDetailsEnabled(ctx context.Context, key string, fallback bool) bool {
+	if rs.SettingsService == nil {
+		return fallback
+	}
+	val, err := rs.SettingsService.ResolveBool(ctx, key)
+	if err != nil {
+		rs.getLogger().WarnContext(ctx, "failed to resolve capacity detail setting; using fallback",
+			slog.String("setting_key", key),
+			slog.Bool("fallback", fallback),
+			slog.String("error", err.Error()),
+		)
+		return fallback
+	}
+	return val
 }
 
 // lookupPersonByRFID finds a person by RFID tag and validates the assignment
@@ -172,7 +208,7 @@ func (rs *Resource) handleSupervisorScan(w http.ResponseWriter, r *http.Request,
 
 	result, err := rs.Checkin.AddStaffAsSupervisor(ctx, deviceCtx.ID, deviceCtx.DeviceID, staff.ID)
 	if err != nil {
-		renderCheckinError(w, r, err)
+		rs.renderCheckinError(w, r, err)
 		return
 	}
 

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -82,6 +82,15 @@ const (
 	KeyCheckoutWCEnabled          = "checkout.wc_enabled"
 )
 
+// Checkin capacity-detail disclosure settings (issue #1879, devices tab).
+// Gate whether the 409 capacity-exceeded responses include the `details`
+// object PyrePortal renders as "{Name} ist voll (X/Y ...)". When off, the
+// backend omits `details` and the kiosk shows its generic German fallback.
+const (
+	KeyCheckinActivityCapacityDetailsEnabled = "checkin.activity_capacity_details_enabled"
+	KeyCheckinRoomCapacityDetailsEnabled     = "checkin.room_capacity_details_enabled"
+)
+
 // IoT device health-monitoring settings (issue #586 — Rule 12 extraction).
 // A device counts as "online" when its last_seen timestamp is within
 // KeyDeviceOnlineWindowMinutes of now. The 5-minute window moved off the

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -45,6 +45,9 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"checkout.raumwechsel_enabled",
 		"checkout.schulhof_enabled",
 		"checkout.wc_enabled",
+		// Capacity-detail disclosure toggles (issue #1879, devices tab).
+		"checkin.activity_capacity_details_enabled",
+		"checkin.room_capacity_details_enabled",
 		// Device online/offline window for health monitoring (issue #586, Rule 12).
 		"iot.device_online_window_minutes",
 		"tracking.indicators_enabled",
@@ -1162,6 +1165,34 @@ func TestDevicesSettings(t *testing.T) {
 	assert.Equal(t, false, wc.Default, "wc should default to false (opt-in)")
 }
 
+func TestCheckinCapacityDetailSettings(t *testing.T) {
+	keys := []string{
+		config.KeyCheckinActivityCapacityDetailsEnabled,
+		config.KeyCheckinRoomCapacityDetailsEnabled,
+	}
+	for _, key := range keys {
+		def := config.GetDefinition(key)
+		require.NotNilf(t, def, "setting %q should exist", key)
+		assert.Equal(t, config.FieldBoolean, def.Type, "setting %q should be boolean", key)
+		assert.Equal(t, "devices", def.Tab, "setting %q should be in devices tab", key)
+		assert.Equal(t, "kapazität", def.Category, "setting %q should be in kapazität category", key)
+		assert.Equal(t, "config:update", def.WritePermission, "setting %q should use config:update", key)
+		require.NotNil(t, def.DependsOn, "setting %q should be gated by nfc_enabled", key)
+		assert.Equal(t, config.KeyAttendanceNFCEnabled, def.DependsOn.Key)
+		assert.Equal(t, "eq", def.DependsOn.Condition)
+		assert.Equal(t, true, def.DependsOn.Value)
+	}
+
+	// Activity defaults to false: the rich kiosk message was never visible
+	// before issue #1879, so it stays opt-in.
+	activity := config.GetDefinition(config.KeyCheckinActivityCapacityDetailsEnabled)
+	assert.Equal(t, false, activity.Default, "activity capacity details should default to false (opt-in)")
+
+	// Room defaults to true: schools already see the rich room message today.
+	room := config.GetDefinition(config.KeyCheckinRoomCapacityDetailsEnabled)
+	assert.Equal(t, true, room.Default, "room capacity details should default to true (preserves existing behavior)")
+}
+
 func TestStudentDailyCheckoutTime_OptionalDefault(t *testing.T) {
 	def := config.GetDefinition("operations.student_daily_checkout_time")
 	require.NotNil(t, def)
@@ -1230,6 +1261,8 @@ func TestDefaults_HaveReasonableValues(t *testing.T) {
 		{"checkout.raumwechsel_enabled", true},
 		{"checkout.schulhof_enabled", false},
 		{"checkout.wc_enabled", false},
+		{"checkin.activity_capacity_details_enabled", false},
+		{"checkin.room_capacity_details_enabled", true},
 		{"tracking.indicators_enabled", false},
 		{"tracking.indicator_1", ""},
 		{"tracking.indicator_2", ""},

--- a/backend/services/config/defaults/devices.go
+++ b/backend/services/config/defaults/devices.go
@@ -47,6 +47,40 @@ func init() {
 		DependsOn:       config.DependsOnEq(config.KeyAttendanceNFCEnabled, true),
 	})
 
+	// Capacity-detail disclosure toggles (issue #1879). When enabled, the
+	// device checkin 409 includes the `details` object (name + occupancy)
+	// that the kiosk renders as a rich German message; when disabled, the
+	// response carries no details and the kiosk shows a generic hint.
+	// Activity defaults OFF (the rich message was never visible before);
+	// room defaults ON (preserves the behavior schools already have).
+	config.Register(config.Definition{
+		Key:             config.KeyCheckinActivityCapacityDetailsEnabled,
+		Label:           "Details bei voller Aktivität anzeigen",
+		Description:     "Zeigt beim Erreichen der Teilnehmergrenze den Namen der Aktivität und die Belegung auf dem Gerät an (z. B. Fußball AG ist voll (20/20 Teilnehmer)). Wenn deaktiviert, erscheint nur ein allgemeiner Hinweis.",
+		Type:            config.FieldBoolean,
+		Default:         false,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "devices",
+		Category:        "kapazität",
+		SortOrder:       13,
+		DependsOn:       config.DependsOnEq(config.KeyAttendanceNFCEnabled, true),
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyCheckinRoomCapacityDetailsEnabled,
+		Label:           "Details bei vollem Raum anzeigen",
+		Description:     "Zeigt beim Erreichen der Raumkapazität den Namen des Raums und die Belegung auf dem Gerät an (z. B. Turnhalle ist voll (30/30 Plätze belegt)). Wenn deaktiviert, erscheint nur ein allgemeiner Hinweis.",
+		Type:            config.FieldBoolean,
+		Default:         true,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "devices",
+		Category:        "kapazität",
+		SortOrder:       14,
+		DependsOn:       config.DependsOnEq(config.KeyAttendanceNFCEnabled, true),
+	})
+
 	// Device online/offline window (issue #586 — Rule 12 extraction). The
 	// number of minutes a device's last_seen timestamp may be in the past
 	// before it is treated as offline for health monitoring.


### PR DESCRIPTION
## Summary

Fixes the activity-capacity error contract from #1879: the rich German kiosk message "{Aktivität} ist voll (X/Y Teilnehmer)." could never render because the backend sends `details.current_occupancy`/`details.max_capacity` while PyrePortal read `details.current_participants`/`details.max_participants`.

Per owner decision, the disclosure of the `details` object is now gated behind **two separate tenant settings** (devices tab, category "Kapazität", visible when NFC attendance is on):

| Setting | Default | Rationale |
|---|---|---|
| `checkin.activity_capacity_details_enabled` | **off** | the rich message was never visible before, stays opt-in |
| `checkin.room_capacity_details_enabled` | **on** | preserves the room detail message schools already see |

When a setting is off, the 409 keeps the same status/code/message but omits `details` entirely — PyrePortal falls back to its generic German message through its existing `error.details` guard. The backend wire keys are unchanged; the PyrePortal side of the fix (reading `current_occupancy`/`max_capacity` for activities) is the companion PR moto-nrw/PyrePortal#380.

## Changes

- `models/config/keys.go` + `services/config/defaults/devices.go`: the two new boolean settings (schema-generated admin UI, no frontend work needed; no migration — registry defaults apply without `setting_values` rows)
- `api/iot/checkin/capacity_errors.go`: additive `ErrorRoomCapacityExceededNoDetails` / `ErrorActivityCapacityExceededNoDetails` renderers; the existing full-details renderers and their pinned goldens are untouched
- `api/iot/checkin/workflow.go`: `renderCheckinError` became a `Resource` method and picks the renderer per setting via a nil-safe `capacityDetailsEnabled` helper (fail-safe = registry default, never a 500); tenant context is already established by device auth + `TenantTxMiddleware`, so plain `ResolveBool` suffices
- `api/iot/checkin/handlers.go`: mechanical `rs.` at the two call sites

## Tests

- 2 new wire goldens pin the no-details shapes; the 4 existing goldens are byte-identical and untouched
- New `capacity_gating_internal_test.go`: on/off/nil-service cases for both capacity errors (via `configtest.Mock`, no DB)
- `defaults_test.go`: keys added to `TestAllSettingsRegistered` + new `TestCheckinCapacityDetailSettings` + defaults table entries
- Comment-only edits in `capacity_errors.go` / `wire_format_test.go` headers: the "known mismatch preserved deliberately" notes are stale once PyrePortal reads the real keys — no expectation changed

## Verification

- `go build ./...`, `golangci-lint run` on touched packages: clean
- `go test ./api/iot/... ./services/config/... ./services/iot/... ./models/config/...` against the test DB: all green
- PyrePortal error-string scanner, hermetic gate, handler ratchets: green

## Rollout

No lockstep needed: this PR alone changes nothing visible by default (activity kiosks already show the generic message today; room stays on). The PyrePortal fix is inert until a school enables the activity setting.

Closes #1879
