### PR TITLE
fix(timetable): preserve deviations across template splits

### DIFF
--- a/backend/api/timetable/templates_split_test.go
+++ b/backend/api/timetable/templates_split_test.go
@@ -51,6 +51,7 @@ func attachSplitServiceWithValidator(
 		InstanceRepo:               scheduleRepo.NewActivityInstanceRepository(s.db),
 		TimeframeRepo:              scheduleRepo.NewTimeframeRepository(s.db),
 		Materialization:            mat,
+		InstanceService:            s.res.InstanceService,
 		ValidateCareOfferingSeries: validate,
 		DB:                         s.db,
 	})

--- a/backend/api/timetable/templates_test.go
+++ b/backend/api/timetable/templates_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/database/repositories"
 	activitiesRepo "github.com/moto-nrw/project-phoenix/database/repositories/activities"
 	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	"github.com/moto-nrw/project-phoenix/internal/schoolclass"
@@ -21,6 +23,7 @@ import (
 	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/services"
 	"github.com/moto-nrw/project-phoenix/services/config/configtest"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -78,11 +81,15 @@ func buildTemplateSetup(t *testing.T, mat scheduleSvc.MaterializationService) *t
 	staffB := testpkg.CreateTestStaff(t, db, "Tpl", fmt.Sprintf("StaffB-%d", suffix))
 	studentA := testpkg.CreateTestStudent(t, db, "Tpl", fmt.Sprintf("StudentA-%d", suffix), "3a")
 	studentB := testpkg.CreateTestStudent(t, db, "Tpl", fmt.Sprintf("StudentB-%d", suffix), "3a")
+	repoFactory := repositories.NewFactory(db)
+	serviceFactory, err := services.NewFactory(repoFactory, db, slog.Default())
+	require.NoError(t, err)
 
 	res := NewResource(Dependencies{
 		TimetableData:          testTimetableData(db),
 		CalendarPeriodService:  scheduleSvc.NewCalendarPeriodService(scheduleRepo.NewCalendarPeriodRepository(db), nil),
 		MaterializationService: mat,
+		InstanceService:        serviceFactory.Instance,
 		SettingsService:        templateGradeSettings(schoolclass.DefaultGradeLevelMax, nil),
 		DB:                     db,
 	})

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -583,6 +583,27 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		logger.With("service", "materialization"),
 	)
 
+	// Initialize instance lifecycle before template split: the split reuses its
+	// deviation snapshot/reapply machinery when replacing future occurrences.
+	instanceService := schedule.NewInstanceService(schedule.InstanceServiceDependencies{
+		InstanceRepo:      repos.ActivityInstance,
+		InstanceStaffRepo: repos.InstanceStaff,
+		InstanceStudents:  repos.InstanceStudent,
+		ExceptionRepo:     repos.ActivityException,
+		ActiveGroupRepo:   repos.ActiveGroup,
+		SupervisorRepo:    repos.GroupSupervisor,
+		VisitRepo:         repos.ActiveVisit,
+		RoomRepo:          repos.Room,
+		ActivityGroupRepo: repos.ActivityGroup,
+		StaffRepo:         repos.Staff,
+		StudentRepo:       repos.Student,
+		ActiveService:     activeService,
+		Materialization:   materializationService,
+		Broadcaster:       realtimeHub,
+		DB:                db,
+		Logger:            logger.With("service", "instance-lifecycle"),
+	})
+
 	// Initialize template split service (WP-B3). "Dieser und alle folgenden":
 	// caps the old template's schedules + rosters at an effective date,
 	// creates a successor template and re-plans the affected window via the
@@ -595,6 +616,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		InstanceRepo:               repos.ActivityInstance,
 		TimeframeRepo:              repos.Timeframe,
 		Materialization:            materializationService,
+		InstanceService:            instanceService,
 		ValidateCareOfferingSeries: careOfferingSeriesValidator.ValidateTemplateSeries,
 		Logger:                     logger.With("service", "template-split"),
 		DB:                         db,
@@ -625,30 +647,6 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		settingsService,
 		logger.With("service", "time-tracking-cleanup"),
 	)
-
-	// Initialize instance lifecycle service (WP-B9). Drives the state machine
-	// on schedule.activity_instances and its bridge to active.groups. Takes
-	// the active service as a dependency (for EndActivitySession) - when the
-	// bridge closes, visits + supervisors close and per-student checkout SSE
-	// events fire, matching today's observable behavior for a session ending.
-	instanceService := schedule.NewInstanceService(schedule.InstanceServiceDependencies{
-		InstanceRepo:      repos.ActivityInstance,
-		InstanceStaffRepo: repos.InstanceStaff,
-		InstanceStudents:  repos.InstanceStudent,
-		ExceptionRepo:     repos.ActivityException,
-		ActiveGroupRepo:   repos.ActiveGroup,
-		SupervisorRepo:    repos.GroupSupervisor,
-		VisitRepo:         repos.ActiveVisit,
-		RoomRepo:          repos.Room,
-		ActivityGroupRepo: repos.ActivityGroup,
-		StaffRepo:         repos.Staff,
-		StudentRepo:       repos.Student,
-		ActiveService:     activeService,
-		Materialization:   materializationService,
-		Broadcaster:       realtimeHub,
-		DB:                db,
-		Logger:            logger.With("service", "instance-lifecycle"),
-	})
 
 	autoStartService := schedule.NewAutoStartService(schedule.AutoStartDependencies{
 		InstanceRepo:      repos.ActivityInstance,

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -1229,7 +1229,7 @@ func (s *instanceService) ReplanWeek(ctx context.Context, from, to timezone.Date
 		return nil, &ScheduleError{Op: "replan week: materialize", Err: err}
 	}
 
-	reapplied, err := s.reapplyDeviations(ctx, snapshots, occurrences)
+	reapplied, err := s.reapplyDeviations(ctx, snapshots, occurrences, nil)
 	if err != nil {
 		return nil, &ScheduleError{Op: "replan week: reapply deviations", Err: err}
 	}
@@ -1389,7 +1389,12 @@ func (s *instanceService) snapshotDeviations(ctx context.Context, from, to timez
 // materialized occurrence, returning how many snapshots were reapplied. A
 // snapshot whose occurrence no longer materializes (template weekday/period
 // changed) is silently dropped — there is nothing to attach it to.
-func (s *instanceService) reapplyDeviations(ctx context.Context, snapshots []deviationSnapshot, occurrences map[groupDay]int) (int, error) {
+func (s *instanceService) reapplyDeviations(
+	ctx context.Context,
+	snapshots []deviationSnapshot,
+	occurrences map[groupDay]int,
+	targetActivityGroupID *int64,
+) (int, error) {
 	reapplied := 0
 	for _, snap := range snapshots {
 		// sole is true only when the group had exactly ONE planned occurrence on
@@ -1402,7 +1407,7 @@ func (s *instanceService) reapplyDeviations(ctx context.Context, snapshots []dev
 		// start_time match whenever the day had more than one slot, so a deleted
 		// slot's overrides are dropped rather than misattributed (#1840).
 		sole := occurrences[groupDay{snap.activityGroupID, snap.date}] == 1
-		inst, err := s.matchRegeneratedInstance(ctx, snap, sole)
+		inst, err := s.matchRegeneratedInstance(ctx, snap, sole, targetActivityGroupID)
 		if err != nil {
 			return reapplied, err
 		}
@@ -1536,8 +1541,17 @@ type groupDay struct {
 // none matches, so overrides from a deleted slot are never merged onto a
 // surviving block (a slot whose time changed cannot be mapped safely either)
 // (#1840).
-func (s *instanceService) matchRegeneratedInstance(ctx context.Context, snap deviationSnapshot, sole bool) (*scheduleModel.ActivityInstance, error) {
-	candidates, err := s.deps.InstanceRepo.FindByActivityGroupAndDate(ctx, snap.activityGroupID, snap.date)
+func (s *instanceService) matchRegeneratedInstance(
+	ctx context.Context,
+	snap deviationSnapshot,
+	sole bool,
+	targetActivityGroupID *int64,
+) (*scheduleModel.ActivityInstance, error) {
+	activityGroupID := snap.activityGroupID
+	if targetActivityGroupID != nil {
+		activityGroupID = *targetActivityGroupID
+	}
+	candidates, err := s.deps.InstanceRepo.FindByActivityGroupAndDate(ctx, activityGroupID, snap.date)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/services/schedule/template_split_deviation_test.go
+++ b/backend/services/schedule/template_split_deviation_test.go
@@ -1,0 +1,201 @@
+package schedule_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateSplit_PreservesDeviationsOnSuccessor(t *testing.T) {
+	effective := futureMonday(2)
+	before := effective.AddDays(-7)
+	s := makeScenario(t, activitiesModels.WeekdayMonday, before)
+	defer s.runCleanup(t)
+
+	secondStaff := testpkg.CreateTestStaffForTenant(
+		t, s.db, s.tenantID, "Second", fmt.Sprintf("Planned-%d", time.Now().UnixNano()),
+	)
+	substitute := testpkg.CreateTestStaffForTenant(
+		t, s.db, s.tenantID, "Sub", fmt.Sprintf("Stitute-%d", time.Now().UnixNano()),
+	)
+	secondSupervisor := &activitiesModels.SupervisorPlanned{
+		StaffID:   secondStaff.ID,
+		GroupID:   s.template.ID,
+		ValidFrom: before.AddDays(-30),
+	}
+	secondSupervisor.SetTenantID(s.tenantID)
+	_, err := s.db.NewInsert().Model(secondSupervisor).ModelTableExpr(`activities.supervisors`).Exec(s.ctx)
+	require.NoError(t, err)
+	s.registerCleanup("activities.supervisors", secondSupervisor.ID)
+	s.extraCleanups = append(s.extraCleanups, func() {
+		testpkg.CleanupTableRecords(t, s.db, "users.staff", secondStaff.ID, substitute.ID)
+		testpkg.CleanupTableRecords(t, s.db, "users.persons", secondStaff.PersonID, substitute.PersonID)
+	})
+
+	_, err = s.factory.Materialization.MaterializeForTenant(
+		s.ctx, before, effective, scheduleSvc.MaterializationSourceManual,
+	)
+	require.NoError(t, err)
+	beforeInstances := listInstancesForDate(t, s.db, s.template.ID, before)
+	targetInstances := listInstancesForDate(t, s.db, s.template.ID, effective)
+	require.Len(t, beforeInstances, 1)
+	require.Len(t, targetInstances, 1)
+	beforeInstance := beforeInstances[0]
+	targetInstance := targetInstances[0]
+	s.registerCleanup("schedule.activity_instances", beforeInstance.ID, targetInstance.ID)
+
+	beforeReason := "Fortbildung"
+	_, err = s.db.NewUpdate().
+		Model((*scheduleModels.InstanceStaff)(nil)).
+		ModelTableExpr(`schedule.instance_staff AS "instance_staff"`).
+		Set("is_absent = ?", true).
+		Set("absence_reason = ?", beforeReason).
+		Where(`"instance_staff".instance_id = ?`, beforeInstance.ID).
+		Where(`"instance_staff".staff_id = ?`, s.staffID).
+		Where(`"instance_staff".tenant_id = ?`, s.tenantID).
+		Exec(s.ctx)
+	require.NoError(t, err)
+
+	reasons := map[int64]string{
+		s.staffID:      "Krank",
+		secondStaff.ID: "Termin",
+	}
+	for staffID, reason := range reasons {
+		_, err = s.db.NewUpdate().
+			Model((*scheduleModels.InstanceStaff)(nil)).
+			ModelTableExpr(`schedule.instance_staff AS "instance_staff"`).
+			Set("is_absent = ?", true).
+			Set("absence_reason = ?", reason).
+			Where(`"instance_staff".instance_id = ?`, targetInstance.ID).
+			Where(`"instance_staff".staff_id = ?`, staffID).
+			Where(`"instance_staff".tenant_id = ?`, s.tenantID).
+			Exec(s.ctx)
+		require.NoError(t, err)
+	}
+
+	substituteRow := &scheduleModels.InstanceStaff{
+		InstanceID:   targetInstance.ID,
+		StaffID:      substitute.ID,
+		IsSubstitute: true,
+		IsPrimary:    true,
+	}
+	substituteRow.SetTenantID(s.tenantID)
+	_, err = s.db.NewInsert().Model(substituteRow).ModelTableExpr(`schedule.instance_staff`).Exec(s.ctx)
+	require.NoError(t, err)
+
+	ackNote := "Eine Position bleibt bewusst offen"
+	_, err = s.db.NewUpdate().
+		Model((*scheduleModels.ActivityInstance)(nil)).
+		ModelTableExpr(`schedule.activity_instances AS "activity_instance"`).
+		Set("understaffed_ack = ?", true).
+		Set("understaffed_note = ?", ackNote).
+		Set("required_staff = ?", 4).
+		Where(`"activity_instance".id = ?`, targetInstance.ID).
+		Where(`"activity_instance".tenant_id = ?`, s.tenantID).
+		Exec(s.ctx)
+	require.NoError(t, err)
+
+	in := baseSplitInput(s, effective, fmt.Sprintf("Renamed-%d", time.Now().UnixNano()))
+	in.MaterializeFrom = &effective
+	in.MaterializeTo = &effective
+	result, err := s.factory.TemplateSplit.Split(s.ctx, in)
+	require.NoError(t, err)
+	registerSuccessorCleanup(t, s, result.NewTemplateID)
+
+	require.False(t, splitInstanceExists(t, s, targetInstance.ID), "split must replace the old future instance")
+	successors := listInstancesForDate(t, s.db, result.NewTemplateID, effective)
+	require.Len(t, successors, 1)
+	successor := successors[0]
+	s.registerCleanup("schedule.activity_instances", successor.ID)
+	require.NotEqual(t, targetInstance.ID, successor.ID)
+	require.NotNil(t, successor.ActivityGroupID)
+	assert.Equal(t, result.NewTemplateID, *successor.ActivityGroupID)
+	assert.Equal(t, "15:00:00", successor.StartTime.Format("15:04:05"), "deviations must follow the sole occurrence when its time changes")
+	assert.True(t, successor.UnderstaffedAck)
+	require.NotNil(t, successor.UnderstaffedNote)
+	assert.Equal(t, ackNote, *successor.UnderstaffedNote)
+	require.NotNil(t, successor.RequiredStaff)
+	assert.Equal(t, 4, *successor.RequiredStaff)
+
+	rows := loadInstanceStaffRows(t, s.db, s.ctx, successor.ID)
+	require.Len(t, rows, 3)
+	for _, row := range rows {
+		switch row.StaffID {
+		case s.staffID, secondStaff.ID:
+			assert.False(t, row.IsSubstitute)
+			assert.True(t, row.IsAbsent)
+			require.NotNil(t, row.AbsenceReason)
+			assert.Equal(t, reasons[row.StaffID], *row.AbsenceReason)
+		case substitute.ID:
+			assert.True(t, row.IsSubstitute)
+			assert.False(t, row.IsAbsent)
+			assert.True(t, row.IsPrimary)
+		default:
+			t.Fatalf("unexpected staff row for staff %d", row.StaffID)
+		}
+	}
+
+	require.True(t, splitInstanceExists(t, s, beforeInstance.ID), "instance before the split date must survive")
+	beforeRows := loadInstanceStaffRows(t, s.db, s.ctx, beforeInstance.ID)
+	require.Len(t, beforeRows, 2)
+	var beforeDeviationFound bool
+	for _, row := range beforeRows {
+		if row.StaffID == s.staffID {
+			beforeDeviationFound = true
+			assert.True(t, row.IsAbsent)
+			require.NotNil(t, row.AbsenceReason)
+			assert.Equal(t, beforeReason, *row.AbsenceReason)
+		}
+	}
+	assert.True(t, beforeDeviationFound)
+}
+
+func TestTemplateSplit_DropsDeviationWhenWeekdayNoLongerExists(t *testing.T) {
+	effective := futureMonday(2)
+	tuesday := effective.AddDays(1)
+	s := makeScenario(t, activitiesModels.WeekdayMonday, effective)
+	defer s.runCleanup(t)
+
+	_, err := s.factory.Materialization.MaterializeForTenant(
+		s.ctx, effective, effective, scheduleSvc.MaterializationSourceManual,
+	)
+	require.NoError(t, err)
+	oldInstances := listInstancesForDate(t, s.db, s.template.ID, effective)
+	require.Len(t, oldInstances, 1)
+	old := oldInstances[0]
+	s.registerCleanup("schedule.activity_instances", old.ID)
+
+	_, err = s.db.NewUpdate().
+		Model((*scheduleModels.InstanceStaff)(nil)).
+		ModelTableExpr(`schedule.instance_staff AS "instance_staff"`).
+		Set("is_absent = ?", true).
+		Where(`"instance_staff".instance_id = ?`, old.ID).
+		Where(`"instance_staff".staff_id = ?`, s.staffID).
+		Where(`"instance_staff".tenant_id = ?`, s.tenantID).
+		Exec(s.ctx)
+	require.NoError(t, err)
+
+	in := baseSplitInput(s, effective, fmt.Sprintf("Tuesday-%d", time.Now().UnixNano()))
+	in.Weekdays = []int{activitiesModels.WeekdayTuesday}
+	in.MaterializeFrom = &effective
+	in.MaterializeTo = &tuesday
+	result, err := s.factory.TemplateSplit.Split(s.ctx, in)
+	require.NoError(t, err)
+	registerSuccessorCleanup(t, s, result.NewTemplateID)
+
+	assert.Empty(t, listInstancesForDate(t, s.db, result.NewTemplateID, effective))
+	tuesdayInstances := listInstancesForDate(t, s.db, result.NewTemplateID, tuesday)
+	require.Len(t, tuesdayInstances, 1)
+	s.registerCleanup("schedule.activity_instances", tuesdayInstances[0].ID)
+	rows := loadInstanceStaffRows(t, s.db, s.ctx, tuesdayInstances[0].ID)
+	require.Len(t, rows, 1)
+	assert.False(t, rows[0].IsAbsent, "a removed Monday's deviation must not move to Tuesday")
+	assert.False(t, rows[0].IsSubstitute)
+}

--- a/backend/services/schedule/template_split_service.go
+++ b/backend/services/schedule/template_split_service.go
@@ -165,6 +165,9 @@ type TemplateSplitDependencies struct {
 	InstanceRepo    scheduleModel.ActivityInstanceRepository
 	TimeframeRepo   scheduleModel.TimeframeRepository
 	Materialization MaterializationService
+	// InstanceService supplies the existing deviation snapshot/reapply machinery.
+	// The constructor narrows it to the package-private capability used by Split.
+	InstanceService InstanceService
 	// ValidateCareOfferingSeries runs after the successor and its schedules are
 	// visible inside the split transaction. It rejects a split that would make
 	// an existing care-offering link impossible to materialize later.
@@ -176,8 +179,18 @@ type TemplateSplitDependencies struct {
 // TemplateSplitService performs recurring-template scope operations.
 type TemplateSplitService struct {
 	deps                 TemplateSplitDependencies
+	deviations           splitDeviationPreserver
 	lockTenantRecurrence func(context.Context) error
 	runInTx              func(context.Context, func(context.Context) error) error
+}
+
+// splitDeviationPreserver is the existing instance-service machinery the split
+// needs around its delete/materialize cycle. Keeping this capability private
+// avoids adding snapshot types or split-only methods to the public service API.
+type splitDeviationPreserver interface {
+	acquireSubstituteDayLocks(context.Context, int64, timezone.Date, timezone.Date) error
+	snapshotDeviations(context.Context, timezone.Date, timezone.Date, *int64) ([]deviationSnapshot, map[groupDay]int, error)
+	reapplyDeviations(context.Context, []deviationSnapshot, map[groupDay]int, *int64) (int, error)
 }
 
 // NewTemplateSplitService constructs a TemplateSplitService. Panics if a
@@ -186,11 +199,17 @@ type TemplateSplitService struct {
 func NewTemplateSplitService(deps TemplateSplitDependencies) *TemplateSplitService {
 	if deps.GroupRepo == nil || deps.ScheduleRepo == nil || deps.EnrollmentRepo == nil ||
 		deps.SupervisorRepo == nil || deps.InstanceRepo == nil || deps.TimeframeRepo == nil ||
-		deps.Materialization == nil || deps.ValidateCareOfferingSeries == nil || deps.DB == nil {
+		deps.Materialization == nil || deps.InstanceService == nil ||
+		deps.ValidateCareOfferingSeries == nil || deps.DB == nil {
 		panic("schedule.NewTemplateSplitService: required dependency is nil")
 	}
+	deviations, ok := deps.InstanceService.(splitDeviationPreserver)
+	if !ok {
+		panic("schedule.NewTemplateSplitService: instance service does not support deviation preservation")
+	}
 	return &TemplateSplitService{
-		deps: deps,
+		deps:       deps,
+		deviations: deviations,
 		lockTenantRecurrence: func(ctx context.Context) error {
 			return lockTenantRecurrenceWrites(ctx, deps.DB)
 		},
@@ -272,6 +291,23 @@ func (s *TemplateSplitService) splitInTransaction(
 		)
 	}
 
+	var snapshots []deviationSnapshot
+	var occurrences map[groupDay]int
+	deviationFrom, deviationTo, preserveDeviations := splitMaterializationWindow(in)
+	if preserveDeviations {
+		if s.deviations == nil {
+			return nil, &ScheduleError{Op: "split template: preserve deviations", Err: errors.New("deviation preservation is not configured")}
+		}
+		if err := s.deviations.acquireSubstituteDayLocks(ctx, tenantID, deviationFrom, deviationTo); err != nil {
+			return nil, &ScheduleError{Op: "split template: lock deviation days", Err: err}
+		}
+		oldID := old.ID
+		snapshots, occurrences, err = s.deviations.snapshotDeviations(ctx, deviationFrom, deviationTo, &oldID)
+		if err != nil {
+			return nil, &ScheduleError{Op: "split template: snapshot deviations", Err: err}
+		}
+	}
+
 	// Remove ALL of the old template's still-planned future instances from
 	// the effective date onward — deliberately open-ended (nil `to`), NOT
 	// tied to the materialization window: the split must guarantee that no
@@ -293,6 +329,15 @@ func (s *TemplateSplitService) splitInTransaction(
 		return nil, err
 	}
 
+	reapplied := 0
+	if preserveDeviations {
+		newID := newGroup.ID
+		reapplied, err = s.deviations.reapplyDeviations(ctx, snapshots, occurrences, &newID)
+		if err != nil {
+			return nil, &ScheduleError{Op: "split template: reapply deviations", Err: err}
+		}
+	}
+
 	s.getLogger().Info("template split completed",
 		slog.Int64("tenant_id", tenantID),
 		slog.Int64("old_template_id", old.ID),
@@ -300,6 +345,8 @@ func (s *TemplateSplitService) splitInTransaction(
 		slog.String("effective_date", in.EffectiveDate.String()),
 		slog.Int("schedule_count", len(scheduleIDs)),
 		slog.Int64("deleted_instances", deleted),
+		slog.Int("deviations_snapshotted", len(snapshots)),
+		slog.Int("deviations_reapplied", reapplied),
 	)
 
 	return &TemplateSplitResult{
@@ -1245,25 +1292,33 @@ func unionSelectedWeekdays(rows []*activitiesModel.StudentEnrollment, preferred 
 // starts before the effective date. Requires both bounds; an inverted clamped
 // window is a silent no-op (nothing to materialize before the split point).
 func (s *TemplateSplitService) materializeWindow(ctx context.Context, in TemplateSplitInput) (*MaterializationResult, error) {
-	if in.MaterializeFrom == nil || in.MaterializeTo == nil {
+	from, to, ok := splitMaterializationWindow(in)
+	if !ok {
 		return nil, nil
+	}
+	mat, err := s.deps.Materialization.MaterializeForTenant(ctx, from, to, MaterializationSourceManual)
+	if err != nil {
+		return nil, &ScheduleError{Op: "split template: materialize", Err: err}
+	}
+	return mat, nil
+}
+
+// splitMaterializationWindow returns the exact inclusive window shared by
+// deviation preservation and materialization. It clamps the lower bound to the
+// split date because the predecessor remains authoritative before that date.
+func splitMaterializationWindow(in TemplateSplitInput) (timezone.Date, timezone.Date, bool) {
+	if in.MaterializeFrom == nil || in.MaterializeTo == nil {
+		return timezone.Date{}, timezone.Date{}, false
 	}
 	from := *in.MaterializeFrom
 	if from.Before(in.EffectiveDate) {
 		from = in.EffectiveDate
 	}
-	if from.After(*in.MaterializeTo) {
-		s.getLogger().Debug("template split: materialization window empty after clamping to effective date",
-			slog.String("from", from.String()),
-			slog.String("to", in.MaterializeTo.String()),
-		)
-		return nil, nil
+	to := *in.MaterializeTo
+	if from.After(to) {
+		return timezone.Date{}, timezone.Date{}, false
 	}
-	mat, err := s.deps.Materialization.MaterializeForTenant(ctx, from, *in.MaterializeTo, MaterializationSourceManual)
-	if err != nil {
-		return nil, &ScheduleError{Op: "split template: materialize", Err: err}
-	}
-	return mat, nil
+	return from, to, true
 }
 
 // FindOrCreateTimeframe returns the id of an existing schedule.timeframes row

--- a/frontend/src/components/timetable/timetable-event-modal.test.tsx
+++ b/frontend/src/components/timetable/timetable-event-modal.test.tsx
@@ -1539,6 +1539,57 @@ describe("TimetableEventModal", () => {
     );
   });
 
+  it("does not promote an occurrence substitute during an untouched following roster edit", async () => {
+    mockGetAllStaff.mockResolvedValue([
+      { id: "11", name: "Ada Staff" },
+      { id: "31", name: "QA Substitute" },
+    ]);
+    mockGetTemplate.mockResolvedValue({
+      ...template,
+      staffIds: ["11"],
+      primaryStaffId: "11",
+    });
+    renderModal({
+      initialInstance: {
+        ...savedInstance,
+        activityGroupId: "7",
+        staff: [
+          {
+            staffId: "11",
+            isPrimary: true,
+            isAbsent: true,
+            isSubstitute: false,
+          },
+          {
+            staffId: "31",
+            isPrimary: false,
+            isAbsent: false,
+            isSubstitute: true,
+          },
+        ],
+      },
+    });
+
+    await screen.findByText("QA Substitute");
+    fireEvent.change(screen.getByLabelText("Titel*"), {
+      target: { value: "Mensa umbenannt" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Speichern" }));
+    await screen.findByText("Wiederholenden Termin ändern");
+    fireEvent.click(screen.getByRole("button", { name: /Ab jetzt dauerhaft/ }));
+
+    await waitFor(() =>
+      expect(mockSplitTemplate).toHaveBeenCalledWith(
+        "7",
+        expect.objectContaining({
+          name: "Mensa umbenannt",
+          staff_ids: [11],
+          primary_staff_id: 11,
+        }),
+      ),
+    );
+  });
+
   it("checks all following occurrences and saves despite coverage warnings", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-05-04T10:00:00"));

--- a/frontend/src/components/timetable/timetable-event-modal.tsx
+++ b/frontend/src/components/timetable/timetable-event-modal.tsx
@@ -588,6 +588,11 @@ export function TimetableEventModal({
   // template override it may inherit. Remember user intent separately so an
   // unrelated all/following edit can preserve the freshly fetched template.
   const requiredStaffTouched = useRef(false);
+  // An occurrence may carry substitute rows that do not belong to the series
+  // roster. Preserve the fetched template roster for all/following edits until
+  // the user explicitly changes Personal; otherwise a title-only split would
+  // promote a substitute to planned series staff and erase its deviation role.
+  const staffRosterTouched = useRef(false);
   // Once the user picks Woche A/B explicitly, date or period changes must not
   // override that choice with the recomputed default parity — and the pick
   // survives switching the repeat mode away and back within the same modal
@@ -713,6 +718,7 @@ export function TimetableEventModal({
     setInitialStaffIDsSnapshot([...nextForm.staffIds]);
     setInitialPrimaryStaffIDSnapshot(nextForm.primaryStaffId);
     requiredStaffTouched.current = false;
+    staffRosterTouched.current = false;
     manualWeekPattern.current = null;
     setForm(nextForm);
     setValidationError(null);
@@ -1373,12 +1379,14 @@ export function TimetableEventModal({
     const templateStudentIDs = studentRosterEditable
       ? form.studentIds
       : template.studentIds;
-    const templateStaffIDs = staffRosterEditable
-      ? form.staffIds
-      : template.staffIds;
-    const primaryStaffId = staffRosterEditable
-      ? form.primaryStaffId || template.primaryStaffId
-      : template.primaryStaffId;
+    const templateStaffIDs =
+      staffRosterEditable && staffRosterTouched.current
+        ? form.staffIds
+        : template.staffIds;
+    const primaryStaffId =
+      staffRosterEditable && staffRosterTouched.current
+        ? form.primaryStaffId || template.primaryStaffId
+        : template.primaryStaffId;
     return {
       name: form.title.trim(),
       type: template.type,
@@ -2120,6 +2128,7 @@ export function TimetableEventModal({
           options={staff}
           value={form.staffIds}
           onChange={(ids) => {
+            staffRosterTouched.current = true;
             update("staffIds", ids);
             if (form.primaryStaffId && !ids.includes(form.primaryStaffId)) {
               update("primaryStaffId", "");
@@ -2133,7 +2142,10 @@ export function TimetableEventModal({
             <select
               id="event_primary_staff"
               value={form.primaryStaffId}
-              onChange={(event) => update("primaryStaffId", event.target.value)}
+              onChange={(event) => {
+                staffRosterTouched.current = true;
+                update("primaryStaffId", event.target.value);
+              }}
               className={FORM_SELECT_CLASS}
             >
               <option value="">Keine Auswahl</option>


### PR DESCRIPTION
## Summary

- snapshot future timetable deviations before a following template split deletes planned occurrences
- reapply absences, substitutes, understaffed acknowledgement and note, and per-occurrence required-staff pins against the successor template ID
- keep the fetched template roster for untouched series edits so occurrence substitutes are not promoted to planned series staff
- retain existing matching semantics: a sole occurrence follows a time change, while deviations are dropped when the old weekday occurrence no longer exists

## Verification

- regression test failed on development before the fix because the successor lost its acknowledgement and deviation data
- backend full test suite: go test ./...
- backend ratchets: go test ./test -v
- backend lint: golangci-lint run --timeout 10m
- frontend modal suite: 79 tests passed
- frontend check: locales, oxlint, and TypeScript passed
- pre-push: git-secrets, go vet, deadcode, dependency-cruise, knip, frontend check
- Docker Compose browser QA: absence plus substitute survived a title-only Ab jetzt dauerhaft split; the deviated occurrence before the cutoff remained unchanged

Fixes #1874

#1889 will build on the corrected split behavior in this PR.