### PR TITLE
fix(enrollment): Wochentage als Pflichtauswahl statt stillem Mo-Fr-Default, Audit für Altdaten

### DIFF
--- a/backend/api/enrollment/care_offering_handlers.go
+++ b/backend/api/enrollment/care_offering_handlers.go
@@ -52,10 +52,16 @@ const ErrCodeCareOfferingTemplatePeriodMismatch = "enrollment.care_offering_temp
 // selections without exposing PostgreSQL constraint names to the client.
 const ErrCodeCareOfferingInUse = "enrollment.care_offering_in_use"
 
+// ErrCodeCareOfferingDaysRequired identifies a save without any weekday so
+// the admin editor can show a localized message (#1885).
+const ErrCodeCareOfferingDaysRequired = "enrollment.care_offering_days_required"
+
 func careOfferingWriteErrorRenderer(err error) render.Renderer {
 	switch {
 	case errors.Is(err, enrollmentService.ErrCareOfferingTemplatePeriodMismatch):
 		return common.ErrorInvalidRequestWithCode(err, ErrCodeCareOfferingTemplatePeriodMismatch)
+	case errors.Is(err, enrollmentModels.ErrCareOfferingDaysRequired):
+		return common.ErrorInvalidRequestWithCode(err, ErrCodeCareOfferingDaysRequired)
 	case errors.Is(err, enrollmentService.ErrCareOfferingInvalid),
 		errors.Is(err, enrollmentService.ErrCareOfferingGroupRuleConflict):
 		return common.ErrorInvalidRequest(err)

--- a/backend/api/enrollment/care_offering_handlers_test.go
+++ b/backend/api/enrollment/care_offering_handlers_test.go
@@ -270,6 +270,20 @@ func TestCreateCareOfferingHandler_TemplatePeriodMismatchReturnsStableCode(t *te
 	assert.JSONEq(t, `{"status":"error","error":"validate linked template: care offering phase must be within the linked timetable template period","code":"enrollment.care_offering_template_period_mismatch"}`, w.Body.String())
 }
 
+func TestCreateCareOfferingHandler_MissingDaysReturnsStableCode(t *testing.T) {
+	// The service wraps the model validation via wrapCareOfferingInvalid;
+	// the renderer must still resolve the specific sentinel so the admin
+	// editor can show the localized "pick at least one day" message (#1885).
+	mock := &mockCareOfferingService{createErr: fmt.Errorf("%w: validate care offering: %w",
+		enrollmentService.ErrCareOfferingInvalid, enrollmentModels.ErrCareOfferingDaysRequired)}
+	router := buildCareOfferingRouter(mock)
+	w := executeCareJSON(t, router, http.MethodPost, "/enrollment/care-offerings",
+		validOfferingBody(5678, "OGS"))
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), ErrCodeCareOfferingDaysRequired)
+}
+
 // --- updateCareOffering ---------------------------------------------
 
 func TestUpdateCareOfferingHandler_NilServiceReturns500(t *testing.T) {

--- a/backend/api/enrollment/submission_handlers.go
+++ b/backend/api/enrollment/submission_handlers.go
@@ -261,8 +261,8 @@ func int64PtrValue(v *int64) int64 {
 
 // Stable error codes returned in the JSON envelope so the frontend can
 // map to localized German messages without parsing free-form text. Keep
-// in sync with SUBMISSION_ERROR_MESSAGES in
-// frontend/src/lib/enrollment-submission-api.ts.
+// in sync with ENROLLMENT_CODE_MESSAGES in
+// frontend/src/lib/enrollment-error-messages.ts.
 const (
 	ErrCodeEnrollmentCareOfferingMissing         = "enrollment.care_offering_missing"
 	ErrCodeEnrollmentCareOfferingExactlyOne      = "enrollment.care_offering_exactly_one"
@@ -273,6 +273,9 @@ const (
 	ErrCodeEnrollmentInvalidEmail                = "enrollment.invalid_email"
 	ErrCodeEnrollmentPickupTimeNotAllowed        = "enrollment.pickup_time_not_allowed"
 	ErrCodeEnrollmentLateInviteInvalid           = "enrollment.late_invite_invalid"
+	ErrCodeEnrollmentSelectedDayNotAvailable     = "enrollment.selected_day_not_available"
+	ErrCodeEnrollmentDaySelectionRequired        = "enrollment.day_selection_required"
+	ErrCodeEnrollmentDaySelectionNotAllowed      = "enrollment.day_selection_not_allowed"
 )
 
 // MapSubmitError translates service-layer sentinel errors into HTTP
@@ -302,6 +305,14 @@ func MapSubmitError(w http.ResponseWriter, r *http.Request, err error) {
 	// error wraps ErrInvalidSubmission, so the specific match has to win.
 	case errors.Is(err, enrollmentService.ErrPickupTimeNotAllowed):
 		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, ErrCodeEnrollmentPickupTimeNotAllowed))
+	// The three offering-day errors (#1885) also wrap ErrInvalidSubmission,
+	// so their specific matches must precede the generic case below.
+	case errors.Is(err, enrollmentService.ErrSelectedDayNotAvailable):
+		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, ErrCodeEnrollmentSelectedDayNotAvailable))
+	case errors.Is(err, enrollmentService.ErrDaySelectionRequired):
+		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, ErrCodeEnrollmentDaySelectionRequired))
+	case errors.Is(err, enrollmentService.ErrDaySelectionNotAllowed):
+		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, ErrCodeEnrollmentDaySelectionNotAllowed))
 	case errors.Is(err, enrollmentService.ErrCareOfferingClosed),
 		errors.Is(err, enrollmentService.ErrInvalidSubmission):
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))

--- a/backend/api/enrollment/submission_handlers_test.go
+++ b/backend/api/enrollment/submission_handlers_test.go
@@ -224,6 +224,45 @@ func TestMapSubmitError_WrappedPickupTimeNotAllowed400WithCode(t *testing.T) {
 	assert.Contains(t, w.Body.String(), ErrCodeEnrollmentPickupTimeNotAllowed)
 }
 
+func TestMapSubmitError_SelectedDayNotAvailable400WithCode(t *testing.T) {
+	// ErrSelectedDayNotAvailable wraps ErrInvalidSubmission, so its case
+	// must win over the generic branch to attach the stable code the
+	// enrollment form reads to localize the off-days message (#1885).
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/x", nil)
+	MapSubmitError(w, r, enrollmentService.ErrSelectedDayNotAvailable)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), ErrCodeEnrollmentSelectedDayNotAvailable)
+}
+
+func TestMapSubmitError_WrappedSelectedDayNotAvailable400WithCode(t *testing.T) {
+	// The service wraps the sentinel with the offending day; the mapper
+	// must still resolve the code via errors.Is traversal.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/x", nil)
+	wrapped := fmt.Errorf("%w: day %q is not in the offering's available_days",
+		enrollmentService.ErrSelectedDayNotAvailable, "tue")
+	MapSubmitError(w, r, wrapped)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), ErrCodeEnrollmentSelectedDayNotAvailable)
+}
+
+func TestMapSubmitError_DaySelectionRequired400WithCode(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/x", nil)
+	MapSubmitError(w, r, enrollmentService.ErrDaySelectionRequired)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), ErrCodeEnrollmentDaySelectionRequired)
+}
+
+func TestMapSubmitError_DaySelectionNotAllowed400WithCode(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/x", nil)
+	MapSubmitError(w, r, enrollmentService.ErrDaySelectionNotAllowed)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), ErrCodeEnrollmentDaySelectionNotAllowed)
+}
+
 func TestMapSubmitError_CareOfferingClosed400(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/x", nil)

--- a/backend/database/audits/care_offering_weekday_name_vs_available_days.sql
+++ b/backend/database/audits/care_offering_weekday_name_vs_available_days.sql
@@ -1,0 +1,151 @@
+-- Read-only audit for care offerings whose NAME names a single weekday but
+-- whose available_days allow more days than that (#1885).
+--
+-- Background: until #1885 the admin editor silently pre-selected Mo-Fr for
+-- every new offering. In production this produced offerings like
+-- "Montags: Betreuung bis zum Beginn des privaten Musikunterrichts"
+-- (tenant 5, offering 8) that were technically configured Mo-Fr, so the
+-- public form correctly offered - and the backend correctly accepted -
+-- Tuesday..Friday picks. Two child rows with non-Monday days were stored
+-- that way (request_child_offering_id 14 and 18, see
+-- https://github.com/moto-nrw/project-phoenix/issues/1834#issuecomment-4893612999).
+--
+-- Detection heuristic:
+--   * the offering name contains exactly ONE German weekday word
+--     (Montag/Montags, Dienstag(s), ..., also Sonnabend), case-insensitive,
+--     on a word boundary; and
+--   * available_days contains at least one day other than the named one.
+--
+-- Results are manual-review candidates, not proof. A name like
+-- "Fussball (startet am Montag, 1.9.)" legitimately names a weekday without
+-- restricting the offering to it, and offerings whose restriction lives only
+-- in the DESCRIPTION are not caught at all. Do not turn this into an UPDATE:
+-- whether an offering's available_days (and any stored child selections)
+-- should be narrowed is a per-school decision made with that school.
+--
+-- Run (read-only) via psql against the target database, e.g.:
+--   psql "$DB_DSN" -f backend/database/audits/care_offering_weekday_name_vs_available_days.sql
+
+-- ---------------------------------------------------------------------------
+-- Part 1: offerings whose name names exactly one weekday but whose
+-- available_days include other days.
+-- ---------------------------------------------------------------------------
+WITH weekday_words(day_key, pattern) AS (
+    VALUES
+        ('mon', '\mmontags?\M'),
+        ('tue', '\mdienstags?\M'),
+        ('wed', '\mmittwochs?\M'),
+        ('thu', '\mdonnerstags?\M'),
+        ('fri', '\mfreitags?\M'),
+        ('sat', '\m(samstags?|sonnabends?)\M'),
+        ('sun', '\msonntags?\M')
+), named_offerings AS (
+    SELECT
+        co.tenant_id,
+        co.id AS care_offering_id,
+        co.phase_id,
+        co.name,
+        co.days_of_week_mode,
+        co.available_days,
+        co.created_at,
+        ww.day_key AS named_day
+    FROM enrollment.care_offerings AS co
+    INNER JOIN weekday_words AS ww
+        ON co.name ~* ww.pattern
+), single_day_offerings AS (
+    -- Names mentioning two or more different weekdays ("Montag und Mittwoch")
+    -- carry no single-day expectation; skip them.
+    SELECT *
+    FROM named_offerings
+    WHERE (
+        SELECT count(*)
+        FROM named_offerings AS other
+        WHERE other.tenant_id = named_offerings.tenant_id
+          AND other.care_offering_id = named_offerings.care_offering_id
+    ) = 1
+), suspicious_offerings AS (
+    SELECT so.*
+    FROM single_day_offerings AS so
+    WHERE EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements_text(so.available_days) AS day(value)
+        WHERE day.value <> so.named_day
+    )
+)
+SELECT
+    so.tenant_id,
+    p.name AS phase_name,
+    so.care_offering_id,
+    so.name,
+    so.named_day,
+    so.days_of_week_mode,
+    so.available_days,
+    so.created_at
+FROM suspicious_offerings AS so
+LEFT JOIN enrollment.phases AS p
+    ON p.tenant_id = so.tenant_id
+    AND p.id = so.phase_id
+ORDER BY so.tenant_id, so.care_offering_id;
+
+-- ---------------------------------------------------------------------------
+-- Part 2: stored child selections on those offerings that picked days
+-- outside the weekday named by the offering. These are the rows a school
+-- may want to correct manually (covers the two known production rows).
+-- ---------------------------------------------------------------------------
+WITH weekday_words(day_key, pattern) AS (
+    VALUES
+        ('mon', '\mmontags?\M'),
+        ('tue', '\mdienstags?\M'),
+        ('wed', '\mmittwochs?\M'),
+        ('thu', '\mdonnerstags?\M'),
+        ('fri', '\mfreitags?\M'),
+        ('sat', '\m(samstags?|sonnabends?)\M'),
+        ('sun', '\msonntags?\M')
+), named_offerings AS (
+    SELECT
+        co.tenant_id,
+        co.id AS care_offering_id,
+        co.name,
+        ww.day_key AS named_day
+    FROM enrollment.care_offerings AS co
+    INNER JOIN weekday_words AS ww
+        ON co.name ~* ww.pattern
+), single_day_offerings AS (
+    SELECT *
+    FROM named_offerings
+    WHERE (
+        SELECT count(*)
+        FROM named_offerings AS other
+        WHERE other.tenant_id = named_offerings.tenant_id
+          AND other.care_offering_id = named_offerings.care_offering_id
+    ) = 1
+)
+SELECT
+    rco.tenant_id,
+    so.care_offering_id,
+    so.name AS offering_name,
+    so.named_day,
+    rco.id AS request_child_offering_id,
+    rco.request_child_id,
+    rc.request_id,
+    rc.status,
+    r.submission_source,
+    rco.selected_days,
+    rco.created_at
+FROM single_day_offerings AS so
+INNER JOIN enrollment.request_child_offerings AS rco
+    ON rco.tenant_id = so.tenant_id
+    AND rco.care_offering_id = so.care_offering_id
+INNER JOIN enrollment.request_children AS rc
+    ON rc.tenant_id = rco.tenant_id
+    AND rc.id = rco.request_child_id
+INNER JOIN enrollment.requests AS r
+    ON r.tenant_id = rc.tenant_id
+    AND r.id = rc.request_id
+WHERE rco.selected_days IS NOT NULL
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements_text(rco.selected_days) AS day(value)
+      WHERE day.value <> so.named_day
+  )
+ORDER BY rco.tenant_id, so.care_offering_id, rco.id;

--- a/backend/database/migrations/001015191_drop_care_offering_available_days_default.go
+++ b/backend/database/migrations/001015191_drop_care_offering_available_days_default.go
@@ -1,0 +1,48 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	dropCareOfferingAvailableDaysDefaultVersion     = "1.15.191"
+	dropCareOfferingAvailableDaysDefaultDescription = "Drop the Mo-Fr column default on enrollment.care_offerings.available_days"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     dropCareOfferingAvailableDaysDefaultVersion,
+		Description: dropCareOfferingAvailableDaysDefaultDescription,
+		DependsOn:   []string{staffShiftSeriesVersion},
+	})
+	Migrations.MustRegister(dropCareOfferingAvailableDaysDefaultUp, dropCareOfferingAvailableDaysDefaultDown)
+}
+
+// The application always writes available_days explicitly, so this DEFAULT
+// never fires from app code — but a hand-written INSERT omitting the column
+// would silently create a Mo-Fr offering, the exact misconfiguration behind
+// #1885. Without a default, such an INSERT fails loudly (column is NOT NULL).
+func dropCareOfferingAvailableDaysDefaultUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.191: Dropping Mo-Fr default on care_offerings.available_days...")
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE enrollment.care_offerings
+			ALTER COLUMN available_days DROP DEFAULT;
+	`); err != nil {
+		return fmt.Errorf("failed dropping available_days default: %w", err)
+	}
+	fmt.Println("Migration 1.15.191: Completed successfully")
+	return nil
+}
+
+func dropCareOfferingAvailableDaysDefaultDown(ctx context.Context, db *bun.DB) error {
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE enrollment.care_offerings
+			ALTER COLUMN available_days SET DEFAULT '["mon","tue","wed","thu","fri"]'::jsonb;
+	`); err != nil {
+		return fmt.Errorf("failed restoring available_days default: %w", err)
+	}
+	return nil
+}

--- a/backend/models/enrollment/care_offering.go
+++ b/backend/models/enrollment/care_offering.go
@@ -54,6 +54,10 @@ var validSelectionRules = map[string]bool{
 // failure (HTTP 500) without introducing a service-package import cycle.
 var ErrCareOfferingInvalid = errors.New("invalid care offering configuration")
 
+// ErrCareOfferingDaysRequired marks the missing-weekday validation so the
+// HTTP layer can attach a stable error code for the admin editor (#1885).
+var ErrCareOfferingDaysRequired = errors.New("available_days must contain at least one day")
+
 // CareOffering is a row in enrollment.care_offerings - one care option
 // in the tenant's catalog. Admins build the catalog per calendar period
 // (typically a school year, occasionally a holiday); parents pick from
@@ -109,6 +113,13 @@ func (c *CareOffering) Validate() error {
 	}
 	if !validDaysOfWeekModes[c.DaysOfWeekMode] {
 		return fmt.Errorf("days_of_week_mode must be 'fixed' or 'parent_choice', got %q", c.DaysOfWeekMode)
+	}
+	// The weekday selection is a deliberate input: an offering that was
+	// silently saved with all (or no) days caused wrong enrollments in
+	// production (#1885). Existing rows are untouched — this runs only on
+	// admin create/update.
+	if len(c.AvailableDays) == 0 {
+		return ErrCareOfferingDaysRequired
 	}
 	for _, d := range c.AvailableDays {
 		if !canonicalDaySet[strings.ToLower(d)] {

--- a/backend/models/enrollment/care_offering_validate_test.go
+++ b/backend/models/enrollment/care_offering_validate_test.go
@@ -92,12 +92,16 @@ func TestCareOffering_Validate_AvailableDaysIsCaseInsensitive(t *testing.T) {
 	assert.NoError(t, c.Validate())
 }
 
-func TestCareOffering_Validate_EmptyAvailableDaysOK(t *testing.T) {
-	// No days = no care days configured yet; admin can save and add
-	// later. The submission service enforces availability separately.
+func TestCareOffering_Validate_EmptyAvailableDaysRejected(t *testing.T) {
+	// Business rule changed with #1885: the weekday selection is a
+	// deliberate, required input. An offering without days silently
+	// hid the misconfiguration that produced wrong enrollments in
+	// production (Mo-Fr default vs. "Montags" offering).
 	c := validCareOffering()
 	c.AvailableDays = nil
-	assert.NoError(t, c.Validate())
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "available_days")
 }
 
 func TestCareOffering_Validate_RejectsNegativeCapacity(t *testing.T) {

--- a/backend/services/enrollment/decision_service_test.go
+++ b/backend/services/enrollment/decision_service_test.go
@@ -2837,11 +2837,20 @@ func TestDecisionService_Decide_ApprovedRejectsEmptyDaysForTemplateOffering(t *t
 		ActivityGroupID: &group.ID,
 		Name:            "Empty Template Days",
 		DaysOfWeekMode:  enrollmentModels.DaysOfWeekModeFixed,
-		AvailableDays:   []string{},
+		AvailableDays:   []string{"tue"},
 		IsActive:        true,
 	}
 	offering.SetTenantID(1)
 	require.NoError(t, env.repos.CareOffering.Create(ctx, offering))
+	// Simulate a legacy row saved before #1885 made available_days
+	// mandatory: clear the days directly, bypassing Validate. Such rows
+	// still exist in production and Decide must keep rejecting them.
+	_, updErr := env.db.NewUpdate().
+		TableExpr("enrollment.care_offerings").
+		Set("available_days = '[]'::jsonb").
+		Where("id = ?", offering.ID).
+		Exec(ctx)
+	require.NoError(t, updErr)
 
 	submitted, err := env.requestSvc.Submit(ctx, enrollmentService.SubmitRequest{
 		TenantID:          1,

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -76,9 +76,15 @@ var (
 	// (enrollment.pickup_time_not_allowed) so the parent form can localize the
 	// message and highlight the offending schedule field.
 	ErrPickupTimeNotAllowed = fmt.Errorf("%w: pickup time not allowed", ErrInvalidSubmission)
-	ErrEditNotAllowed       = errors.New("request can no longer be edited")
-	ErrWithdrawNotAllowed   = errors.New("child cannot be withdrawn in its current state")
-	ErrDuplicateEnrollment  = errors.New("an active enrollment already exists for this parent and child in this phase")
+	// The three parent-input day errors (#1846/#1885) wrap
+	// ErrInvalidSubmission (HTTP 400) and carry their own identity so the
+	// handler can attach stable codes for localized form messages.
+	ErrSelectedDayNotAvailable = fmt.Errorf("%w: selected day is not available for this offering", ErrInvalidSubmission)
+	ErrDaySelectionRequired    = fmt.Errorf("%w: offering requires the parent to pick at least one day", ErrInvalidSubmission)
+	ErrDaySelectionNotAllowed  = fmt.Errorf("%w: offering does not allow parent day selection (days_of_week_mode=fixed)", ErrInvalidSubmission)
+	ErrEditNotAllowed          = errors.New("request can no longer be edited")
+	ErrWithdrawNotAllowed      = errors.New("child cannot be withdrawn in its current state")
+	ErrDuplicateEnrollment     = errors.New("an active enrollment already exists for this parent and child in this phase")
 )
 
 // Rate-limit thresholds. Hardcoded for now - if individual schools
@@ -3252,13 +3258,15 @@ func (s *requestService) enforceRateLimitBuckets(ctx context.Context, req Submit
 	return nil
 }
 
-var errParentChoiceOfferingMissingDays = fmt.Errorf("%w: offering requires the parent to pick at least one day", ErrInvalidSubmission)
+// errParentChoiceOfferingMissingDays aliases ErrDaySelectionRequired; the
+// sentinel became exported for the HTTP error-code mapping (#1885).
+var errParentChoiceOfferingMissingDays = ErrDaySelectionRequired
 
 func resolveManualSelectedDays(offering *enrollmentModels.CareOffering, picks []string) ([]string, error) {
 	switch offering.DaysOfWeekMode {
 	case enrollmentModels.DaysOfWeekModeFixed:
 		if len(picks) > 0 {
-			return nil, fmt.Errorf("%w: offering does not allow parent day selection (days_of_week_mode=fixed)", ErrInvalidSubmission)
+			return nil, ErrDaySelectionNotAllowed
 		}
 		return nil, nil
 	case enrollmentModels.DaysOfWeekModeParentChoice:
@@ -3270,7 +3278,7 @@ func resolveManualSelectedDays(offering *enrollmentModels.CareOffering, picks []
 		dedup := make([]string, 0, len(picks))
 		for _, d := range picks {
 			if !allowed[d] {
-				return nil, fmt.Errorf("%w: day %q is not in the offering's available_days", ErrInvalidSubmission, d)
+				return nil, fmt.Errorf("%w: day %q is not in the offering's available_days", ErrSelectedDayNotAvailable, d)
 			}
 			if seen[d] {
 				continue

--- a/backend/services/enrollment/resolve_selected_days_test.go
+++ b/backend/services/enrollment/resolve_selected_days_test.go
@@ -107,6 +107,22 @@ func TestResolveSelectedDays_ParentInputErrorsWrapInvalidSubmission(t *testing.T
 	}
 }
 
+// The three parent-input errors additionally carry their own sentinel so
+// the HTTP layer can attach stable codes for localized messages (#1885).
+func TestResolveSelectedDays_ParentInputErrorsCarrySpecificSentinels(t *testing.T) {
+	_, err := resolveManualSelectedDays(parentChoiceOffering("mon", "tue"), []string{"sat"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSelectedDayNotAvailable),
+		"subset violation must wrap ErrSelectedDayNotAvailable, got %q", err)
+
+	assert.True(t, errors.Is(errParentChoiceOfferingMissingDays, ErrDaySelectionRequired))
+
+	_, err = resolveManualSelectedDays(fixedOffering("mon"), []string{"mon"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrDaySelectionNotAllowed),
+		"fixed-mode picks must wrap ErrDaySelectionNotAllowed, got %q", err)
+}
+
 func TestResolveSelectedDays_RejectsUnknownMode(t *testing.T) {
 	bogus := &enrollmentModels.CareOffering{
 		DaysOfWeekMode: "weird",

--- a/backend/services/enrollment/rollover_autoapprove_integration_test.go
+++ b/backend/services/enrollment/rollover_autoapprove_integration_test.go
@@ -458,11 +458,20 @@ func TestRolloverService_AutoApprove_ValidationFailureRollsBackStudentUpdate(t *
 		ActivityGroupID: &group.ID,
 		Name:            "Invalid empty-day rollover offering",
 		DaysOfWeekMode:  enrollmentModels.DaysOfWeekModeFixed,
-		AvailableDays:   []string{},
+		AvailableDays:   []string{"tue"},
 		IsActive:        true,
 	}
 	offering.SetTenantID(1)
 	require.NoError(t, env.repos.CareOffering.Create(ctx, offering))
+	// Simulate a legacy row saved before #1885 made available_days
+	// mandatory: clear the days directly, bypassing Validate. The rollback
+	// behavior under test targets exactly such legacy-invalid rows.
+	_, updErr := env.db.NewUpdate().
+		TableExpr("enrollment.care_offerings").
+		Set("available_days = '[]'::jsonb").
+		Where("id = ?", offering.ID).
+		Exec(ctx)
+	require.NoError(t, updErr)
 	link := &enrollmentModels.RequestChildOffering{
 		RequestChildID: source.ID,
 		CareOfferingID: offering.ID,

--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -90,6 +90,8 @@ const UNVERIFIABLE_TEMPLATE_CHANGE_MESSAGE =
   "Die neue Regeltermin-Verknüpfung kann derzeit nicht geprüft werden. Entferne die Verknüpfung oder lade Regeltermine und Planungsperioden erneut.";
 const INACTIVE_TEMPLATE_PERIOD_MESSAGE =
   "Ein aktives Betreuungsangebot braucht einen aktiven Planungszeitraum. Aktiviere den Zeitraum, wähle einen anderen Regeltermin oder deaktiviere das Angebot.";
+const CARE_OFFERING_DAYS_REQUIRED_MESSAGE =
+  "Bitte wähle mindestens einen Wochentag für das Angebot aus.";
 
 type PlannerMetadataStatus = "loading" | "ready" | "unavailable";
 type TemplateCompatibility = "compatible" | "incompatible" | "unknown";
@@ -101,7 +103,10 @@ function blankInput(phaseId: number): CareOfferingInput {
     name: "",
     description: "",
     days_of_week_mode: "fixed",
-    available_days: WEEKDAY_KEYS,
+    // Deliberately empty: pre-selecting Mo-Fr caused offerings whose name
+    // said "Montags" to silently accept all weekdays (#1885). Picking the
+    // days is a required, conscious input.
+    available_days: [],
     includes_holiday_care: false,
     includes_lunch: false,
     capacity: null,
@@ -457,6 +462,11 @@ export function CareOfferingsEditor() {
   const handleSave = async (event: React.FormEvent) => {
     event.preventDefault();
     if (!draft) return;
+    if (draft.available_days.length === 0) {
+      setError(CARE_OFFERING_DAYS_REQUIRED_MESSAGE);
+      toast.error(CARE_OFFERING_DAYS_REQUIRED_MESSAGE);
+      return;
+    }
     const originalActivityGroupID =
       editingId && editingId !== "new"
         ? (offerings.find((offering) => offering.id === editingId)

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -394,11 +394,11 @@ describe("CareOfferingsEditor", () => {
     );
     expect(screen.getByText("Betreuungstage & Mitbuchung")).toBeVisible();
     expect(screen.getByText("Als Betreuungstage zählen")).toBeVisible();
+    // Weekdays start unselected (#1885): picking a day is a deliberate input.
     const mondayToggle = screen.getByRole("button", { name: "Mo" });
-    expect(mondayToggle).toHaveAttribute("aria-pressed", "true");
-    fireEvent.click(mondayToggle);
     expect(mondayToggle).toHaveAttribute("aria-pressed", "false");
     fireEvent.click(mondayToggle);
+    expect(mondayToggle).toHaveAttribute("aria-pressed", "true");
     fireEvent.change(await waitForInputByName("name"), {
       target: { value: "Frühbetreuung" },
     });
@@ -468,6 +468,8 @@ describe("CareOfferingsEditor", () => {
       target: { value: "Randstunde" },
     });
     fireEvent.click(screen.getByRole("checkbox", { name: /Ganztag/ }));
+    // Weekdays start unselected (#1885); save requires at least one day.
+    fireEvent.click(screen.getByRole("button", { name: "Mo" }));
     fireEvent.click(screen.getByRole("button", { name: "Erstellen" }));
 
     await waitFor(() => {
@@ -552,6 +554,8 @@ describe("CareOfferingsEditor", () => {
     fireEvent.click(screen.getByText("Pflicht"));
     expect(inputByName("capacity")).toBeDisabled();
 
+    // Weekdays start unselected (#1885); save requires at least one day.
+    fireEvent.click(screen.getByRole("button", { name: "Mo" }));
     fireEvent.click(screen.getByRole("button", { name: "Erstellen" }));
     await waitFor(() => {
       expect(mocks.createCareOffering).toHaveBeenCalledWith(
@@ -613,6 +617,11 @@ describe("CareOfferingsEditor", () => {
     fireEvent.change(await waitForInputByName("name"), {
       target: { value: "Lernzeitangebot" },
     });
+    // Weekdays start unselected (#1885); pick Mo-Fr explicitly so the
+    // template (Mon + Sat) misses the selected Tue-Fri as before.
+    for (const day of ["Mo", "Di", "Mi", "Do", "Fr"]) {
+      fireEvent.click(screen.getByRole("button", { name: day }));
+    }
     await chooseOption("Regeltermin", /Lernzeit/);
 
     expect(

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -961,7 +961,7 @@ export const appChapters: readonly GuideChapter[] = [
         steps: [
           "`Betreuungsangebote` öffnen und oben die `Anmeldephase` wählen.",
           "Auf `Neues Betreuungsangebot` klicken.",
-          "`Name`, `Beschreibung` und die möglichen `Wochentage` festlegen.",
+          "`Name`, `Beschreibung` und die möglichen `Wochentage` festlegen. Die Wochentage sind nicht vorausgewählt: mindestens ein Tag muss aktiv angeklickt werden, und nur die gewählten Tage sind später für Eltern auswählbar - ein Angebot nur für Montag darf also auch nur `Mo` gesetzt haben.",
           "Unter `Regeltermin` den passenden Regeltermin aus dem Betreuungsplan verknüpfen, wenn genehmigte Anmeldungen dort erwartet werden sollen. Für jeden angebotenen Wochentag muss die Regeltermin-Serie den gesamten Betreuungszeitraum der Anmeldephase lückenlos abdecken. Jeder Termin braucht eine vollständige Uhrzeit mit Ende und einen wirksamen Raum; eine Raum-Ausnahme gilt nur für ihr konkretes Datum. Bei einem aktiven Angebot müssen außerdem alle verwendeten Planungszeiträume aktiv sein.",
           "Unter `Betreuungstage & Mitbuchung` festlegen, ob das Angebot als Betreuungstage zählt und ob es mitgebucht wird, wenn Eltern bestimmte andere Angebote wählen.",
           "Bei der Mitbuchung die auslösenden Angebote auswählen und optional auf Klassenstufen eingrenzen.",

--- a/frontend/src/lib/enrollment-error-messages.ts
+++ b/frontend/src/lib/enrollment-error-messages.ts
@@ -37,6 +37,14 @@ const ENROLLMENT_CODE_MESSAGES: Record<string, string> = {
   "enrollment.invalid_email": "Bitte gib eine gültige E-Mail-Adresse ein.",
   "enrollment.pickup_time_not_allowed":
     "Bitte wähle bei den Abholzeiten nur Uhrzeiten aus der vorgegebenen Liste. Die markierte Zeit ist nicht mehr verfügbar.",
+  "enrollment.selected_day_not_available":
+    "Der gewählte Wochentag ist für dieses Angebot nicht verfügbar. Bitte wähle nur die angezeigten Tage aus.",
+  "enrollment.day_selection_required":
+    "Bitte wähle für dieses Angebot mindestens einen Wochentag aus.",
+  "enrollment.day_selection_not_allowed":
+    "Für dieses Angebot sind die Betreuungstage fest vorgegeben und können nicht ausgewählt werden.",
+  "enrollment.care_offering_days_required":
+    "Bitte wähle mindestens einen Wochentag für das Angebot aus.",
   "enrollment.late_invite_invalid":
     "Dieser Nachzügler-Link ist ungültig, abgelaufen oder wurde bereits verwendet. Bitte wende dich an die Schule.",
   "enrollment.schema_has_phases":


### PR DESCRIPTION
## Kontext

Produktionsrest aus #1834: Das Musik-Angebot der OGS am Berg hieß "Montags…", war aber technisch Mo-Fr konfiguriert, weil der Admin-Editor neue Angebote still mit allen Wochentagen vorbelegt hat. PR #1846 hat nur das Fehlerhandling (500→400) repariert. Dieser PR entschärft die Ursache und macht die Datenlage prüfbar.

## Änderungen

**1. Kein stiller Mo-Fr-Default mehr, Wochentage sind Pflicht**
- Frontend: `blankInput()` startet ohne vorbelegte Tage; Speichern ohne Tag wird mit "Bitte wähle mindestens einen Wochentag für das Angebot aus." abgelehnt.
- Backend: `CareOffering.Validate()` verlangt mindestens einen Tag bei Create/Update (400 mit Code `enrollment.care_offering_days_required`). Bestandszeilen bleiben unangetastet, die Validierung greift nur beim Schreiben.
- Der tote Mo-Fr-`DEFAULT` auf der DB-Spalte fällt weg (Migration 1.15.191) — App-Code schreibt die Spalte immer explizit; ohne Default schlägt handgeschriebenes SQL ohne Spalte laut fehl statt still Mo-Fr zu erzeugen.

**2. Datenlage prüfbar: Audit-Skript (keine automatische Bereinigung)**
- Neu: `backend/database/audits/care_offering_weekday_name_vs_available_days.sql` (read-only, Muster aus #1869).
- Teil 1 listet Angebote, deren Name genau einen Wochentag nennt ("Montags…"), deren `available_days` aber weitere Tage enthalten. Teil 2 listet die zugehörigen Kind-Zeilen mit Tagen außerhalb des genannten Wochentags (deckt die zwei bekannten Prod-Zeilen `request_child_offering_id` 14/18 ab).
- Die Bereinigung bleibt eine manuelle Entscheidung pro Schule; das Skript ist bewusst reines SELECT.

**3. Verständliche deutsche Fehlermeldungen**
- Die drei Eltern-Input-Tagesfehler aus #1846 tragen jetzt eigene Sentinels und stabile Codes (`enrollment.selected_day_not_available`, `enrollment.day_selection_required`, `enrollment.day_selection_not_allowed`), gemappt auf deutsche Texte in `enrollment-error-messages.ts` — wirksam im Tenant-Anmeldeformular UND im eingebetteten Eltern-Portal-Formular (gleiche Pipeline).

## Testanpassungen (Begründung)

- `TestCareOffering_Validate_EmptyAvailableDaysOK` → `…Rejected`: bewusste Änderung der Geschäftsregel (leer war "noch nicht konfiguriert", ist jetzt beim Schreiben verboten); vorab abgestimmt.
- Zwei Integrationstests (`TestDecisionService_Decide_ApprovedRejectsEmptyDaysForTemplateOffering`, `TestRolloverService_AutoApprove_ValidationFailureRollsBackStudentUpdate`) erzeugen ihre Legacy-Fixtures (leere Tage) jetzt per direktem SQL-Update statt über den validierten Create-Pfad. Die Assertions sind unverändert — genau dieses Legacy-Verhalten muss weiter funktionieren.
- Vier Frontend-Editor-Tests wählten den alten Mo-Fr-Default ab bzw. bauten darauf; sie wählen die Tage jetzt explizit. Assertions sonst unverändert.

## Verifikation

- Backend: `go test ./...` für models/services/api/database inkl. Ratchets grün; `golangci-lint` 0 issues auf den betroffenen Paketen. Migration lokal angewendet, `column_default` danach leer.
- Frontend: `pnpm run check` grün; Enrollment-Testsuiten grün (die 3 Fehler in `chart.test.tsx` bestehen auch auf sauberem `development`, unabhängig von diesem PR).
- Browser (docker compose Stack, Tenant + Eltern-Portal):
  - Neues Angebot: kein Tag vorbelegt, Speichern ohne Tag → deutsche Meldung, kein Request.
  - Nur-Montag-Angebot: öffentliches Formular zeigt nur `Mo`.
  - Realer Fehlerfall (Angebot serverseitig verengt, während das Formular offen war): Submit → HTTP 400 mit Code, im Formular erscheint "Der gewählte Wochentag ist für dieses Angebot nicht verfügbar. Bitte wähle nur die angezeigten Tage aus." — sowohl im Tenant-Formular als auch im eingebetteten Eltern-Portal-Formular (`/api/parent/enrollments/{slug}/submit` → 400).
- Audit-Skript gegen die Seed-DB: 0 Treffer (erwartet). Positivkontrolle in einer Transaktion mit ROLLBACK: ein eingefügtes "Montags…"-Angebot mit Mo-Fr wird in Teil 1 gefunden.

```text
 tenant_id |        phase_name        | care_offering_id |                    name                    | named_day | days_of_week_mode |           available_days
-----------+--------------------------+------------------+--------------------------------------------+-----------+-------------------+-------------------------------------
         2 | Demo Anmeldung 2026/2027 |                5 | Montags: Betreuung bis zum Musikunterricht | mon       | parent_choice     | ["mon", "tue", "wed", "thu", "fri"]
```

## Produktionsprüfung OGS am Berg

Das Audit-Skript read-only gegen die Produktions-DB ausführen (kein UPDATE!):

```bash
psql "$DB_DSN" -f backend/database/audits/care_offering_weekday_name_vs_available_days.sql
```

Erwartet: Teil 1 findet `care_offering_id = 8` (tenant 5), Teil 2 die Zeilen `request_child_offering_id` 14 (approved) und 18 (rejected). Ob `available_days` des Angebots und die zwei Kind-Zeilen auf `["mon"]` korrigiert werden, entscheidet die Schule; der Skript-Header enthält die Einordnung.

Fixes #1885
