### PR TITLE
fix(enrollment): warn when a care offering names one weekday but more days are selected

### DIFF
--- a/backend/services/enrollment/care_offering_service_test.go
+++ b/backend/services/enrollment/care_offering_service_test.go
@@ -596,6 +596,25 @@ func TestCareOfferingService_Update_RejectsPhaseOutsideTemplatePeriod(t *testing
 	assert.ErrorIs(t, err, enrollmentService.ErrCareOfferingTemplatePeriodMismatch)
 }
 
+func TestCareOfferingService_Update_RejectsUnavailableOfferingWeekday(t *testing.T) {
+	db, svc, phase, cleanup := setupCareTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+	period := createCareOfferingTestPeriod(t, db, "care-weekday-update-period",
+		timezone.NewDate(2026, 8, 1), timezone.NewDate(2027, 8, 31))
+	group := createCareOfferingTemplateGroup(t, db, "care-weekday-update-template")
+	createCareOfferingTemplateSchedule(t, db, group.ID, activitiesModels.WeekdayMonday, &period.ID)
+
+	created, err := svc.Create(ctx, baseLinkedOffering(phase.ID, group.ID))
+	require.NoError(t, err)
+
+	created.AvailableDays = []string{"mon", "tue"}
+	err = svc.Update(ctx, created)
+
+	require.ErrorIs(t, err, enrollmentService.ErrCareOfferingInvalid)
+	require.ErrorContains(t, err, "weekday")
+}
+
 func TestCareOfferingService_Clone_RepointsToTargetPhase(t *testing.T) {
 	db, svc, phase, cleanup := setupCareTest(t)
 	defer cleanup()

--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -282,6 +282,33 @@ function linkedTemplateWeekdayError(
   return `Der Regeltermin deckt die ausgewählten Angebotstage ${labels} nicht ab. Entferne die Verknüpfung oder ergänze passende Slots.`;
 }
 
+const GERMAN_WEEKDAY_NAME_PATTERNS: ReadonlyArray<[string, RegExp]> = [
+  ["mon", /\bmontags?\b/i],
+  ["tue", /\bdienstags?\b/i],
+  ["wed", /\bmittwochs?\b/i],
+  ["thu", /\bdonnerstags?\b/i],
+  ["fri", /\bfreitags?\b/i],
+  ["sat", /\b(?:samstags?|sonnabends?)\b/i],
+  ["sun", /\bsonntags?\b/i],
+];
+
+// Soft warning only: the name heuristic has documented false positives
+// ("Fußball (startet am Montag, 1.9.)"), so it must never block saving.
+// The hard guard for template-linked offerings is linkedTemplateWeekdayError.
+function nameWeekdayMismatchWarning(draft: CareOfferingInput): string | null {
+  const matches = GERMAN_WEEKDAY_NAME_PATTERNS.filter(([, pattern]) =>
+    pattern.test(draft.name),
+  );
+  // Zero or several weekday words: the name makes no single-day claim.
+  if (matches.length !== 1) return null;
+  const namedDay = matches[0]?.[0];
+  if (!namedDay) return null;
+  const extraDays = draft.available_days.filter((day) => day !== namedDay);
+  if (extraDays.length === 0) return null;
+  const labels = extraDays.map((day) => DAY_LABELS[day] ?? day).join(", ");
+  return `Der Name nennt nur einen Wochentag, ausgewählt sind zusätzlich ${labels}. Bitte prüfen, ob das Angebot wirklich an diesen Tagen stattfindet.`;
+}
+
 function hasUnverifiableTemplateChange(
   draft: CareOfferingInput,
   originalActivityGroupID: string | null,
@@ -1459,6 +1486,7 @@ function CareOfferingWeekdayFields({
       available_days: WEEKDAY_KEYS.filter((dayKey) => nextDays.has(dayKey)),
     });
   };
+  const nameMismatch = nameWeekdayMismatchWarning(draft);
 
   return (
     <fieldset className="rounded-xl border border-gray-200 p-4">
@@ -1485,6 +1513,11 @@ function CareOfferingWeekdayFields({
           );
         })}
       </div>
+      {nameMismatch ? (
+        <p className="mt-3 rounded-lg border border-[#F3B63F]/50 bg-[#F3B63F]/10 px-3 py-2 text-xs text-[#A66F00]">
+          {nameMismatch}
+        </p>
+      ) : null}
       <div className="mt-3">
         <CareOfferingCheckbox
           checked={draft.days_of_week_mode === "parent_choice"}

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -646,6 +646,109 @@ describe("CareOfferingsEditor", () => {
     expect(screen.getByRole("button", { name: "Erstellen" })).toBeEnabled();
   });
 
+  it("warns when the offering name says one weekday but more days are selected", async () => {
+    mocks.listPhases.mockResolvedValue([phase()]);
+    mocks.listCareOfferings.mockResolvedValue([offering()]);
+
+    render(<CareOfferingsEditor />);
+    expect(await screen.findByText("Regelbetreuung")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Neues Betreuungsangebot" }),
+    );
+    fireEvent.change(await waitForInputByName("name"), {
+      target: {
+        value:
+          "Montags: Betreuung bis zum Beginn des privaten Musikunterrichts",
+      },
+    });
+    for (const day of ["Mo", "Di", "Mi", "Do", "Fr"]) {
+      fireEvent.click(screen.getByRole("button", { name: day }));
+    }
+
+    const warning = screen.getByText(
+      /Der Name nennt nur einen Wochentag, ausgewählt sind zusätzlich Di, Mi, Do, Fr\./,
+    );
+    expect(warning).toBeVisible();
+    // Soft hint, not an error: saving stays possible.
+    expect(warning).not.toHaveAttribute("role", "alert");
+    expect(screen.getByRole("button", { name: "Erstellen" })).toBeEnabled();
+
+    // Deselecting the extra days resolves the mismatch.
+    for (const day of ["Di", "Mi", "Do", "Fr"]) {
+      fireEvent.click(screen.getByRole("button", { name: day }));
+    }
+    expect(
+      screen.queryByText(/Der Name nennt nur einen Wochentag/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not warn for names without a single-weekday claim", async () => {
+    mocks.listPhases.mockResolvedValue([phase()]);
+    mocks.listCareOfferings.mockResolvedValue([offering()]);
+
+    render(<CareOfferingsEditor />);
+    expect(await screen.findByText("Regelbetreuung")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Neues Betreuungsangebot" }),
+    );
+    const nameInput = await waitForInputByName("name");
+    for (const day of ["Mo", "Mi", "Fr"]) {
+      fireEvent.click(screen.getByRole("button", { name: day }));
+    }
+
+    // Two weekday words: the name makes no single-day claim.
+    fireEvent.change(nameInput, {
+      target: { value: "Montag und Mittwoch AG" },
+    });
+    expect(
+      screen.queryByText(/Der Name nennt nur einen Wochentag/),
+    ).not.toBeInTheDocument();
+
+    // No weekday word at all.
+    fireEvent.change(nameInput, { target: { value: "Fußball AG" } });
+    expect(
+      screen.queryByText(/Der Name nennt nur einen Wochentag/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not block saving while the name-weekday warning shows", async () => {
+    mocks.listPhases.mockResolvedValue([phase()]);
+    mocks.listCareOfferings.mockResolvedValue([offering()]);
+    mocks.createCareOffering.mockResolvedValue(
+      offering({ id: "new", name: "Montags-Club" }),
+    );
+
+    render(<CareOfferingsEditor />);
+    expect(await screen.findByText("Regelbetreuung")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Neues Betreuungsangebot" }),
+    );
+    fireEvent.change(await waitForInputByName("name"), {
+      target: { value: "Montags-Club" },
+    });
+    for (const day of ["Mo", "Di"]) {
+      fireEvent.click(screen.getByRole("button", { name: day }));
+    }
+    expect(
+      screen.getByText(/Der Name nennt nur einen Wochentag/),
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Erstellen" }));
+
+    await waitFor(() => {
+      expect(mocks.createCareOffering).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Montags-Club",
+          available_days: ["mon", "tue"],
+        }),
+      );
+    });
+    expect(mocks.toast.error).not.toHaveBeenCalled();
+  });
+
   it("offers Regeltermine whose resolved period contains the phase", async () => {
     mocks.listPhases.mockResolvedValue([phase()]);
     mocks.listCareOfferings.mockResolvedValue([]);


### PR DESCRIPTION
## Worum es geht

Nachzug zu #1834: Eine Schule legte das Angebot "Montags: Betreuung bis zum Beginn des privaten Musikunterrichts" an, hakte aber Mo bis Fr an. Eltern konnten das Angebot dadurch an Tagen buchen, an denen es nicht existiert (dokumentiert in `backend/database/audits/care_offering_weekday_name_vs_available_days.sql`). Die Elternstrecke ist seit #1885 doppelt abgesichert; die Lücke lag in der Admin-Pflege, wo nichts den Angebotsnamen gegen die angehakten Tage abgleicht.

Der Editor zeigt jetzt eine weiche, übergehbare Warnung, wenn der Name genau ein Wochentagswort nennt und zusätzliche Tage angehakt sind. Die Warnung blockiert das Speichern bewusst nicht: die Namens-Heuristik hat dokumentierte False Positives (etwa "Fußball (startet am Montag, 1.9.)").

## Änderungen

- `care-offerings-editor.tsx`: modul-lokale Heuristik `nameWeekdayMismatchWarning` (Wortgrenzen-Regex je Wochentag, warnt nur bei genau einem Treffer im Namen) plus Warnbox im etablierten Hinweisbox-Muster unterhalb der Tages-Buttons. Kein `role="alert"`, kein Eingriff in `handleSave`; der harte Blocker `linkedTemplateWeekdayError` für verknüpfte Regeltermine bleibt unverändert.
- Die serverseitige Regeltermin-Deckungsprüfung existiert seit b5967b94a und wird nicht dupliziert. Ergänzt wird nur der bisher fehlende hermetische Update-Pfad-Test `TestCareOfferingService_Update_RejectsUnavailableOfferingWeekday` (der Create-Pfad war bereits getestet).

## Tests

- Vitest im bestehenden `CareOfferingsEditor`-Block: Produktionsfall-Reproduktion (Warnung listet Di, Mi, Do, Fr), False-Positive-Abgrenzung (zwei Wochentagswörter bzw. kein Wochentagswort), Übergehbarkeit (Speichern trotz Warnung, kein Fehler-Toast). Der Abgrenzungsfall harter Template-Block ist durch den bestehenden Test abgedeckt und unverändert.
- Backend hermetisch: `go test ./services/enrollment/ -run TestCareOfferingService` grün.
- `pnpm run check` und `pnpm run knip` warnungsfrei. Hinweis: `src/components/ui/chart.test.tsx` schlägt lokal auch auf sauberem development fehl (Locale-abhängige Zahlformatierung, in CI grün) und ist von diesem PR unabhängig.

## Screenshot

Screenshot der Warnbox im Editor folgt als Kommentar.
