### PR TITLE
feat(time-tracking): Begründungspflicht bei Abweichung vom Dienstplan (F9/F8)

### DIFF
--- a/backend/api/time-tracking/api.go
+++ b/backend/api/time-tracking/api.go
@@ -3,6 +3,7 @@ package timetracking
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -97,9 +98,18 @@ func (rs *Resource) Router() chi.Router {
 	return r
 }
 
-// CheckInRequest represents a check-in request
+// CheckInRequest represents a check-in request. Reason is the optional F9
+// deviation reason; it is only required when the backend answered a previous
+// attempt with the "deviation_reason_required" conflict.
 type CheckInRequest struct {
 	Status string `json:"status"` // "present" or "home_office"
+	Reason string `json:"reason"`
+}
+
+// CheckOutRequest is the optional check-out body. Existing clients send no
+// body at all; the handler treats an empty body as an empty request.
+type CheckOutRequest struct {
+	Reason string `json:"reason"`
 }
 
 type ConfigResponse struct {
@@ -181,7 +191,7 @@ func (rs *Resource) checkIn(w http.ResponseWriter, r *http.Request) {
 	var session *activeModels.WorkSession
 	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
 		var txErr error
-		session, txErr = rs.WorkSessionService.CheckIn(ctx, staffID, req.Status, activeModels.WorkSessionSourceApp)
+		session, txErr = rs.WorkSessionService.CheckIn(ctx, staffID, req.Status, activeModels.WorkSessionSourceApp, req.Reason)
 		return txErr
 	}); err != nil {
 		common.RenderError(w, r, classifyServiceError(err))
@@ -193,6 +203,14 @@ func (rs *Resource) checkIn(w http.ResponseWriter, r *http.Request) {
 
 // checkOut handles POST /api/time-tracking/check-out
 func (rs *Resource) checkOut(w http.ResponseWriter, r *http.Request) {
+	// The body is optional (legacy clients POST without one); an empty body
+	// is an empty request, anything else must be valid JSON.
+	req := &CheckOutRequest{}
+	if err := render.DecodeJSON(r.Body, req); err != nil && !errors.Is(err, io.EOF) {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
 	// Get staff ID from JWT claims
 	userClaims := jwt.ClaimsFromCtx(r.Context())
 	staffID, err := rs.getStaffIDFromClaims(r.Context(), userClaims)
@@ -206,7 +224,7 @@ func (rs *Resource) checkOut(w http.ResponseWriter, r *http.Request) {
 	var session *activeModels.WorkSession
 	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
 		var txErr error
-		session, txErr = rs.WorkSessionService.CheckOut(ctx, staffID)
+		session, txErr = rs.WorkSessionService.CheckOut(ctx, staffID, req.Reason)
 		return txErr
 	}); err != nil {
 		common.RenderError(w, r, classifyServiceError(err))

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -32,8 +32,8 @@ import (
 // --- Mock WorkSessionService ---
 
 type mockWorkSessionService struct {
-	checkInFn            func(ctx context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error)
-	checkOutFn           func(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
+	checkInFn            func(ctx context.Context, staffID int64, status, source, reason string) (*activeModels.WorkSession, error)
+	checkOutFn           func(ctx context.Context, staffID int64, reason string) (*activeModels.WorkSession, error)
 	startBreakFn         func(ctx context.Context, staffID int64, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
 	endBreakFn           func(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
 	getSessionBreaksFn   func(ctx context.Context, staffID, sessionID int64) ([]*activeModels.WorkSessionBreak, error)
@@ -46,15 +46,15 @@ type mockWorkSessionService struct {
 	autoEndExpiredBreaks func(ctx context.Context) (int, error)
 }
 
-func (m *mockWorkSessionService) CheckIn(ctx context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error) {
+func (m *mockWorkSessionService) CheckIn(ctx context.Context, staffID int64, status, source, reason string) (*activeModels.WorkSession, error) {
 	if m.checkInFn != nil {
-		return m.checkInFn(ctx, staffID, status, source)
+		return m.checkInFn(ctx, staffID, status, source, reason)
 	}
 	return &activeModels.WorkSession{}, nil
 }
-func (m *mockWorkSessionService) CheckOut(ctx context.Context, staffID int64) (*activeModels.WorkSession, error) {
+func (m *mockWorkSessionService) CheckOut(ctx context.Context, staffID int64, reason string) (*activeModels.WorkSession, error) {
 	if m.checkOutFn != nil {
-		return m.checkOutFn(ctx, staffID)
+		return m.checkOutFn(ctx, staffID, reason)
 	}
 	return &activeModels.WorkSession{}, nil
 }
@@ -417,7 +417,7 @@ func TestCheckIn_Success(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	wsSvc := &mockWorkSessionService{
-		checkInFn: func(_ context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error) {
+		checkInFn: func(_ context.Context, staffID int64, status, source, _ string) (*activeModels.WorkSession, error) {
 			assert.Equal(t, int64(100), staffID)
 			assert.Equal(t, "present", status)
 			assert.Equal(t, activeModels.WorkSessionSourceApp, source)
@@ -476,7 +476,7 @@ func TestCheckIn_ServiceConflict(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	wsSvc := &mockWorkSessionService{
-		checkInFn: func(_ context.Context, _ int64, _, _ string) (*activeModels.WorkSession, error) {
+		checkInFn: func(_ context.Context, _ int64, _, _, _ string) (*activeModels.WorkSession, error) {
 			return nil, errors.New("already checked in")
 		},
 	}
@@ -504,7 +504,7 @@ func TestCheckIn_ReopenStatusConflict(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	wsSvc := &mockWorkSessionService{
-		checkInFn: func(_ context.Context, _ int64, _, _ string) (*activeModels.WorkSession, error) {
+		checkInFn: func(_ context.Context, _ int64, _, _, _ string) (*activeModels.WorkSession, error) {
 			return nil, &activeSvc.ReopenStatusConflictError{
 				SessionID:       42,
 				ExistingStatus:  activeModels.WorkSessionStatusPresent,
@@ -550,7 +550,7 @@ func TestCheckIn_PlannedStartNotReached(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	wsSvc := &mockWorkSessionService{
-		checkInFn: func(_ context.Context, _ int64, _, _ string) (*activeModels.WorkSession, error) {
+		checkInFn: func(_ context.Context, _ int64, _, _, _ string) (*activeModels.WorkSession, error) {
 			return nil, &activeSvc.PlannedStartNotReachedError{
 				PlannedStartTime: "09:00",
 				CurrentTime:      "08:45",
@@ -589,7 +589,7 @@ func TestCheckOut_Success(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	wsSvc := &mockWorkSessionService{
-		checkOutFn: func(_ context.Context, staffID int64) (*activeModels.WorkSession, error) {
+		checkOutFn: func(_ context.Context, staffID int64, _ string) (*activeModels.WorkSession, error) {
 			assert.Equal(t, int64(100), staffID)
 			ws := &activeModels.WorkSession{}
 			ws.ID = 1
@@ -611,7 +611,7 @@ func TestCheckOut_NoActiveSession(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	wsSvc := &mockWorkSessionService{
-		checkOutFn: func(_ context.Context, _ int64) (*activeModels.WorkSession, error) {
+		checkOutFn: func(_ context.Context, _ int64, _ string) (*activeModels.WorkSession, error) {
 			return nil, errors.New("no active session found")
 		},
 	}
@@ -1586,4 +1586,157 @@ func TestParseDateRange_BothMissing(t *testing.T) {
 	_, _, ok := parseDateRange(w, r)
 	assert.False(t, ok)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- F9 deviation-reason wire format ---
+
+// The frontend branches on this code via DEVIATION_REASON_REQUIRED_CODE and
+// drives the reason dialog from the details payload; both are wire contracts.
+func TestCheckIn_DeviationReasonRequired(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	wsSvc := &mockWorkSessionService{
+		checkInFn: func(_ context.Context, _ int64, _, _, _ string) (*activeModels.WorkSession, error) {
+			return nil, &activeSvc.DeviationReasonRequiredError{
+				Action:           "check_in",
+				PlannedTime:      "08:00",
+				ActualTime:       "07:30",
+				DeviationMinutes: 30,
+			}
+		},
+	}
+	rs := testResource(wsSvc, &mockStaffAbsenceService{}, defaultPersonSvc(), db)
+
+	body := bytes.NewBufferString(`{"status":"present"}`)
+	r := httptest.NewRequest(http.MethodPost, "/check-in", body)
+	r.Header.Set("Content-Type", "application/json")
+	r = withClaims(r, validClaims())
+	w := httptest.NewRecorder()
+
+	rs.checkIn(w, r)
+	require.Equal(t, http.StatusConflict, w.Code)
+
+	var resp struct {
+		Status  string         `json:"status"`
+		Code    string         `json:"code"`
+		Details map[string]any `json:"details"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "error", resp.Status)
+	assert.Equal(t, "deviation_reason_required", resp.Code)
+	require.NotNil(t, resp.Details)
+	assert.Equal(t, "check_in", resp.Details["action"])
+	assert.Equal(t, "08:00", resp.Details["planned_time"])
+	assert.Equal(t, "07:30", resp.Details["actual_time"])
+	assert.Equal(t, "30", resp.Details["deviation_minutes"],
+		"minutes are serialized as string, consistent with the reopen-conflict details")
+}
+
+func TestCheckOut_DeviationReasonRequired(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	wsSvc := &mockWorkSessionService{
+		checkOutFn: func(_ context.Context, _ int64, _ string) (*activeModels.WorkSession, error) {
+			return nil, &activeSvc.DeviationReasonRequiredError{
+				Action:           "check_out",
+				PlannedTime:      "16:00",
+				ActualTime:       "16:30",
+				DeviationMinutes: 30,
+			}
+		},
+	}
+	rs := testResource(wsSvc, &mockStaffAbsenceService{}, defaultPersonSvc(), db)
+
+	r := httptest.NewRequest(http.MethodPost, "/check-out", nil)
+	r = withClaims(r, validClaims())
+	w := httptest.NewRecorder()
+
+	rs.checkOut(w, r)
+	require.Equal(t, http.StatusConflict, w.Code)
+
+	var resp struct {
+		Code    string         `json:"code"`
+		Details map[string]any `json:"details"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "deviation_reason_required", resp.Code)
+	require.NotNil(t, resp.Details)
+	assert.Equal(t, "check_out", resp.Details["action"])
+	assert.Equal(t, "16:00", resp.Details["planned_time"])
+	assert.Equal(t, "16:30", resp.Details["actual_time"])
+	assert.Equal(t, "30", resp.Details["deviation_minutes"])
+}
+
+func TestCheckIn_ForwardsReason(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	var gotReason string
+	wsSvc := &mockWorkSessionService{
+		checkInFn: func(_ context.Context, _ int64, _, _, reason string) (*activeModels.WorkSession, error) {
+			gotReason = reason
+			return &activeModels.WorkSession{}, nil
+		},
+	}
+	rs := testResource(wsSvc, &mockStaffAbsenceService{}, defaultPersonSvc(), db)
+
+	body := bytes.NewBufferString(`{"status":"present","reason":"Frühdienst übernommen"}`)
+	r := httptest.NewRequest(http.MethodPost, "/check-in", body)
+	r.Header.Set("Content-Type", "application/json")
+	r = withClaims(r, validClaims())
+	w := httptest.NewRecorder()
+
+	rs.checkIn(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "Frühdienst übernommen", gotReason)
+}
+
+func TestCheckOut_ForwardsReason(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	var gotReason string
+	wsSvc := &mockWorkSessionService{
+		checkOutFn: func(_ context.Context, _ int64, reason string) (*activeModels.WorkSession, error) {
+			gotReason = reason
+			return &activeModels.WorkSession{}, nil
+		},
+	}
+	rs := testResource(wsSvc, &mockStaffAbsenceService{}, defaultPersonSvc(), db)
+
+	body := bytes.NewBufferString(`{"reason":"Elterngespräch lief länger"}`)
+	r := httptest.NewRequest(http.MethodPost, "/check-out", body)
+	r.Header.Set("Content-Type", "application/json")
+	r = withClaims(r, validClaims())
+	w := httptest.NewRecorder()
+
+	rs.checkOut(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "Elterngespräch lief länger", gotReason)
+}
+
+func TestCheckOut_MalformedBodyRejected(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	called := false
+	wsSvc := &mockWorkSessionService{
+		checkOutFn: func(_ context.Context, _ int64, _ string) (*activeModels.WorkSession, error) {
+			called = true
+			return &activeModels.WorkSession{}, nil
+		},
+	}
+	rs := testResource(wsSvc, &mockStaffAbsenceService{}, defaultPersonSvc(), db)
+
+	body := bytes.NewBufferString(`{"reason":`)
+	r := httptest.NewRequest(http.MethodPost, "/check-out", body)
+	r.Header.Set("Content-Type", "application/json")
+	r = withClaims(r, validClaims())
+	w := httptest.NewRecorder()
+
+	rs.checkOut(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.False(t, called, "a malformed body must not reach the service")
 }

--- a/backend/api/time-tracking/errors.go
+++ b/backend/api/time-tracking/errors.go
@@ -37,6 +37,19 @@ func classifyServiceError(err error) render.Renderer {
 		})
 	}
 
+	// Typed F9 deviation gate: 409 with a stable code plus the deviation
+	// facts, so the frontend can prompt "Du stempelst N Minuten nach
+	// Planende aus" and retry the same stamp with a reason.
+	var deviation *activeSvc.DeviationReasonRequiredError
+	if errors.As(err, &deviation) {
+		return common.ErrorConflictWithDetails(err, "deviation_reason_required", map[string]any{
+			"action":            deviation.Action,
+			"planned_time":      deviation.PlannedTime,
+			"actual_time":       deviation.ActualTime,
+			"deviation_minutes": strconv.Itoa(deviation.DeviationMinutes),
+		})
+	}
+
 	msg := err.Error()
 
 	switch {
@@ -58,6 +71,7 @@ func classifyServiceError(err error) render.Renderer {
 	case strings.HasPrefix(msg, "status must be"),
 		strings.HasPrefix(msg, "source must be"),
 		msg == "notes required when changing status",
+		msg == "notes required when changing recorded times",
 		msg == "break minutes cannot be negative",
 		msg == "break duration cannot be negative",
 		msg == "invalid session data: check-in time must be before check-out time",

--- a/backend/models/audit/work_session_edit.go
+++ b/backend/models/audit/work_session_edit.go
@@ -37,6 +37,11 @@ const (
 	FieldBreakDuration = "break_duration"
 	FieldStatus        = "status"
 	FieldNotes         = "notes"
+	// FieldDeviationReason records the mandatory reason for stamping outside
+	// the tolerance window around the planned shift window (F9). OldValue
+	// holds the planned wall-clock time, NewValue the actual one, Notes the
+	// reason given by the staff member.
+	FieldDeviationReason = "deviation_reason"
 )
 
 // Validate ensures the edit record is valid
@@ -56,7 +61,7 @@ func (e *WorkSessionEdit) Validate() error {
 	}
 
 	switch e.FieldName {
-	case FieldDate, FieldCheckInTime, FieldCheckOutTime, FieldBreakMinutes, FieldBreakDuration, FieldStatus, FieldNotes:
+	case FieldDate, FieldCheckInTime, FieldCheckOutTime, FieldBreakMinutes, FieldBreakDuration, FieldStatus, FieldNotes, FieldDeviationReason:
 		// Valid field names
 	default:
 		return errors.New("invalid field name")

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -149,7 +149,11 @@ const (
 	KeyParentNewsEnabled               = "operations.parent_news_enabled"
 	KeyTimeTrackingAccountStartDate    = "operations.time_tracking_account_start_date"
 	KeyTimeTrackingEnforcePlannedStart = "operations.time_tracking_enforce_planned_start"
-	KeyMealPlanEnabled                 = "operations.meal_plan_enabled"
+	// F9: stamping outside the tolerance window around the planned shift
+	// window requires a reason; the tolerance is configurable per school.
+	KeyTimeTrackingRequireDeviationReason    = "operations.time_tracking_require_deviation_reason"
+	KeyTimeTrackingDeviationToleranceMinutes = "operations.time_tracking_deviation_tolerance_minutes"
+	KeyMealPlanEnabled                       = "operations.meal_plan_enabled"
 )
 
 // PresenceMode option values for KeyPresenceMode.

--- a/backend/models/schedule/staff_shift.go
+++ b/backend/models/schedule/staff_shift.go
@@ -96,6 +96,14 @@ func (s *StaffShift) Overlaps(other *StaffShift) bool {
 	return aStart.Before(bEnd) && bStart.Before(aEnd)
 }
 
+// StartInstant returns the shift's planned start as an absolute instant in
+// Berlin time (Date + wall-clock StartTime). time.Date normalizes values
+// that fall into a DST gap.
+func (s *StaffShift) StartInstant() time.Time {
+	wc := timezone.WallClock(s.StartTime)
+	return time.Date(s.Date.Year, s.Date.Month, s.Date.Day, wc.Hour(), wc.Minute(), wc.Second(), 0, timezone.Berlin)
+}
+
 // EndInstant returns the shift's planned end as an absolute instant in
 // Berlin time (Date + wall-clock EndTime). time.Date normalizes values that
 // fall into a DST gap.

--- a/backend/services/active/session_service_internal_test.go
+++ b/backend/services/active/session_service_internal_test.go
@@ -96,10 +96,10 @@ type workSessionServiceForSessionUnitTest struct {
 	ensureCheckedInFunc func(ctx context.Context, staffID int64, source string) (*activeModels.WorkSession, error)
 }
 
-func (w *workSessionServiceForSessionUnitTest) CheckIn(context.Context, int64, string, string) (*activeModels.WorkSession, error) {
+func (w *workSessionServiceForSessionUnitTest) CheckIn(context.Context, int64, string, string, string) (*activeModels.WorkSession, error) {
 	return nil, nil
 }
-func (w *workSessionServiceForSessionUnitTest) CheckOut(context.Context, int64) (*activeModels.WorkSession, error) {
+func (w *workSessionServiceForSessionUnitTest) CheckOut(context.Context, int64, string) (*activeModels.WorkSession, error) {
 	return nil, nil
 }
 func (w *workSessionServiceForSessionUnitTest) StartBreak(context.Context, int64, *int) (*activeModels.WorkSessionBreak, error) {

--- a/backend/services/active/work_session_export_test.go
+++ b/backend/services/active/work_session_export_test.go
@@ -1156,7 +1156,7 @@ func TestWSCheckOut_BreakCheckError(t *testing.T) {
 		return nil, errors.New("break check error")
 	}
 
-	session, err := svc.CheckOut(context.Background(), 100)
+	session, err := svc.CheckOut(context.Background(), 100, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "failed to check active break")
@@ -1181,7 +1181,7 @@ func TestWSCheckOut_CloseSessionError(t *testing.T) {
 		return false, errors.New("close error")
 	}
 
-	session, err := svc.CheckOut(context.Background(), 100)
+	session, err := svc.CheckOut(context.Background(), 100, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "failed to close session")
@@ -1214,7 +1214,7 @@ func TestWSCheckOut_FindByIDError(t *testing.T) {
 		return nil, errors.New("find error")
 	}
 
-	session, err := svc.CheckOut(context.Background(), 100)
+	session, err := svc.CheckOut(context.Background(), 100, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "failed to retrieve updated session")
@@ -1347,7 +1347,7 @@ func TestWSCheckIn_CreateError(t *testing.T) {
 		return errors.New("create error")
 	}
 
-	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
+	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "failed to create work session")

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -145,8 +145,30 @@ func (e *PlannedStartNotReachedError) Error() string {
 	return "planned start not reached"
 }
 
+// DeviationReasonRequiredError is returned by CheckIn/CheckOut when the
+// tenant requires a reason for stamping outside the tolerance window around
+// the planned shift window (F9) and the request carried none. The API layer
+// renders it as HTTP 409 with the stable code "deviation_reason_required"
+// produced by api/time-tracking/errors.go.
+type DeviationReasonRequiredError struct {
+	Action           string // deviationActionCheckIn or deviationActionCheckOut
+	PlannedTime      string // planned reference as Berlin wall clock, "15:04"
+	ActualTime       string // actual stamp time as Berlin wall clock, "15:04"
+	DeviationMinutes int
+}
+
+func (e *DeviationReasonRequiredError) Error() string {
+	return "deviation reason required"
+}
+
+const (
+	deviationActionCheckIn  = "check_in"
+	deviationActionCheckOut = "check_out"
+)
+
 type settingsResolver interface {
 	ResolveBool(ctx context.Context, key string) (bool, error)
+	ResolveInt(ctx context.Context, key string) (int, error)
 }
 
 // WorkSessionService defines operations for staff time tracking
@@ -162,8 +184,15 @@ type WorkSessionService interface {
 	// UpdateSession (which gates on a notes reason). If `status` differs
 	// from the existing session's status, CheckIn returns
 	// *ReopenStatusConflictError instead of silently overwriting.
-	CheckIn(ctx context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error)
-	CheckOut(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
+	//
+	// `reason` is the F9 deviation reason. It is only consulted when the
+	// tenant setting operations.time_tracking_require_deviation_reason is
+	// active AND the stamp falls outside the tolerance window around the
+	// planned shift window of the day; an empty reason then yields
+	// *DeviationReasonRequiredError, a non-empty one is written to
+	// audit.work_session_edits. Same contract on CheckOut.
+	CheckIn(ctx context.Context, staffID int64, status, source, reason string) (*activeModels.WorkSession, error)
+	CheckOut(ctx context.Context, staffID int64, reason string) (*activeModels.WorkSession, error)
 	StartBreak(ctx context.Context, staffID int64, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
 	EndBreak(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
 	GetSessionBreaks(ctx context.Context, staffID, sessionID int64) ([]*activeModels.WorkSessionBreak, error)
@@ -272,7 +301,17 @@ func (s *workSessionService) now() time.Time {
 // CheckIn creates a new work session for the staff member.
 // Status must be explicitly chosen. Empty values are rejected so the caller
 // (HTTP handler or internal worker) cannot accidentally fall back to "present".
-func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status, source string) (*activeModels.WorkSession, error) {
+func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status, source, reason string) (*activeModels.WorkSession, error) {
+	return s.checkIn(ctx, staffID, status, source, reason, true)
+}
+
+// checkIn is the shared body behind CheckIn and EnsureCheckedIn.
+// enforceDeviationGate switches the F9 reason requirement: deliberate
+// stamping (the time-tracking page) enforces it, auto-stamps triggered by
+// starting a supervision (EnsureCheckedIn) bypass it — those flows have no
+// way to collect a reason, and refusing the stamp would leave a supervisor
+// row without a matching work session.
+func (s *workSessionService) checkIn(ctx context.Context, staffID int64, status, source, reason string, enforceDeviationGate bool) (*activeModels.WorkSession, error) {
 	if status != activeModels.WorkSessionStatusPresent && status != activeModels.WorkSessionStatusHomeOffice {
 		return nil, fmt.Errorf("status must be 'present' or 'home_office'")
 	}
@@ -317,6 +356,21 @@ func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status,
 		return nil, err
 	}
 
+	// F9: checking in more than the tolerance before the planned shift start
+	// needs a reason ("früher kommen"). The reopen path above is exempt —
+	// resuming after an accidental checkout is not a new arrival.
+	var deviation *plannedDeviation
+	if enforceDeviationGate {
+		var err error
+		deviation, err = s.detectPlannedDeviation(ctx, staffID, today, now, deviationActionCheckIn)
+		if err != nil {
+			return nil, err
+		}
+		if deviation != nil && strings.TrimSpace(reason) == "" {
+			return nil, deviation.requiredError()
+		}
+	}
+
 	// Create new session
 	session := &activeModels.WorkSession{
 		StaffID:      staffID,
@@ -336,6 +390,12 @@ func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status,
 	session.SetTenantID(tenant.FromContext(ctx))
 	if err := s.repo.Create(ctx, session); err != nil {
 		return nil, fmt.Errorf("failed to create work session: %w", err)
+	}
+
+	if deviation != nil {
+		if err := s.recordDeviationReason(ctx, session, deviation, reason, now); err != nil {
+			return nil, err
+		}
 	}
 
 	return session, nil
@@ -415,7 +475,7 @@ func (s *workSessionService) reopenSession(ctx context.Context, session *activeM
 }
 
 // CheckOut ends the current work session for the staff member
-func (s *workSessionService) CheckOut(ctx context.Context, staffID int64) (*activeModels.WorkSession, error) {
+func (s *workSessionService) CheckOut(ctx context.Context, staffID int64, reason string) (*activeModels.WorkSession, error) {
 	// Get current active session
 	session, err := s.repo.GetCurrentByStaffID(ctx, staffID)
 	if err != nil {
@@ -429,8 +489,21 @@ func (s *workSessionService) CheckOut(ctx context.Context, staffID int64) (*acti
 		return nil, errors.New(errNoActiveSession)
 	}
 
+	now := s.now()
+
+	// F9: checking out more than the tolerance after the planned shift end
+	// needs a reason ("später gehen"). Referenced against the session's own
+	// date so a forgotten session from yesterday is measured against
+	// yesterday's plan.
+	deviation, err := s.detectPlannedDeviation(ctx, staffID, session.Date, now, deviationActionCheckOut)
+	if err != nil {
+		return nil, err
+	}
+	if deviation != nil && strings.TrimSpace(reason) == "" {
+		return nil, deviation.requiredError()
+	}
+
 	// End any active break before checkout
-	now := time.Now()
 	if err := s.endActiveBreakIfExists(ctx, session.ID, now); err != nil {
 		return nil, err
 	}
@@ -444,6 +517,12 @@ func (s *workSessionService) CheckOut(ctx context.Context, staffID int64) (*acti
 		return nil, errors.New(errNoActiveSession)
 	}
 
+	if deviation != nil {
+		if err := s.recordDeviationReason(ctx, session, deviation, reason, now); err != nil {
+			return nil, err
+		}
+	}
+
 	// End all active supervisions for this staff member (fire-and-forget)
 	s.endActiveSupervisionsOnCheckout(ctx, staffID)
 
@@ -454,6 +533,118 @@ func (s *workSessionService) CheckOut(ctx context.Context, staffID int64) (*acti
 	}
 
 	return updatedSession, nil
+}
+
+// plannedDeviation describes a stamp that falls outside the tolerance window
+// around the planned shift window of the day (F9).
+type plannedDeviation struct {
+	action  string
+	planned time.Time
+	actual  time.Time
+	minutes int
+}
+
+func (d *plannedDeviation) requiredError() *DeviationReasonRequiredError {
+	return &DeviationReasonRequiredError{
+		Action:           d.action,
+		PlannedTime:      d.planned.In(timezone.Berlin).Format("15:04"),
+		ActualTime:       d.actual.In(timezone.Berlin).Format("15:04"),
+		DeviationMinutes: d.minutes,
+	}
+}
+
+// detectPlannedDeviation implements the F9 rule: with the tenant setting
+// active, a check-in earlier than the earliest planned shift start minus the
+// tolerance, or a check-out later than the latest planned shift end plus the
+// tolerance, is a deviation that needs a reason. The plan source is
+// schedule.staff_shifts (real start AND end times); days without a shift
+// never deviate ("kein Plan, keine Abweichung"). Late arrivals and early
+// leaves are deliberately not gated — F9 targets unnoticed extra hours
+// ("früher kommen oder später gehen"), and missing time is already visible
+// in the saldo.
+func (s *workSessionService) detectPlannedDeviation(ctx context.Context, staffID int64, day timezone.Date, now time.Time, action string) (*plannedDeviation, error) {
+	if s.settings == nil || s.staffShiftRepo == nil {
+		return nil, nil
+	}
+	enabled, err := s.settings.ResolveBool(ctx, configModels.KeyTimeTrackingRequireDeviationReason)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve deviation-reason setting: %w", err)
+	}
+	if !enabled {
+		return nil, nil
+	}
+
+	shifts, err := s.staffShiftRepo.FindByStaffIDsAndDate(ctx, []int64{staffID}, day)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load planned shifts: %w", err)
+	}
+	if len(shifts) == 0 {
+		return nil, nil
+	}
+
+	toleranceMinutes, err := s.settings.ResolveInt(ctx, configModels.KeyTimeTrackingDeviationToleranceMinutes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve deviation-tolerance setting: %w", err)
+	}
+
+	var planned time.Time
+	var delta time.Duration
+	switch action {
+	case deviationActionCheckIn:
+		planned = shifts[0].StartInstant()
+		for _, shift := range shifts[1:] {
+			if start := shift.StartInstant(); start.Before(planned) {
+				planned = start
+			}
+		}
+		delta = planned.Sub(now) // positive when arriving early
+	case deviationActionCheckOut:
+		planned = shifts[0].EndInstant()
+		for _, shift := range shifts[1:] {
+			if end := shift.EndInstant(); end.After(planned) {
+				planned = end
+			}
+		}
+		delta = now.Sub(planned) // positive when leaving late
+	default:
+		return nil, fmt.Errorf("unknown deviation action %q", action)
+	}
+
+	if delta <= time.Duration(toleranceMinutes)*time.Minute {
+		return nil, nil
+	}
+
+	return &plannedDeviation{
+		action:  action,
+		planned: planned,
+		actual:  now,
+		minutes: int(math.Round(delta.Minutes())),
+	}, nil
+}
+
+// recordDeviationReason persists the F9 reason as an audit edit on the
+// session: old value = planned wall clock, new value = actual wall clock,
+// notes = the reason. The stamp and its audit row share the handler's tenant
+// transaction, so a failed audit write rolls the stamp back.
+func (s *workSessionService) recordDeviationReason(ctx context.Context, session *activeModels.WorkSession, dev *plannedDeviation, reason string, now time.Time) error {
+	planned := dev.planned.In(timezone.Berlin).Format("15:04")
+	actual := dev.actual.In(timezone.Berlin).Format("15:04")
+	trimmed := strings.TrimSpace(reason)
+	edit := &auditModels.WorkSessionEdit{
+		SessionID: session.ID,
+		StaffID:   session.StaffID,
+		EditedBy:  session.StaffID,
+		FieldName: auditModels.FieldDeviationReason,
+		OldValue:  &planned,
+		NewValue:  &actual,
+		Notes:     &trimmed,
+		CreatedAt: now,
+	}
+	edit.SetTenantID(tenant.FromContext(ctx))
+	if err := s.auditRepo.CreateBatch(ctx, []*auditModels.WorkSessionEdit{edit}); err != nil {
+		return fmt.Errorf("failed to record deviation reason: %w", err)
+	}
+	return nil
 }
 
 // endActiveBreakIfExists ends any active break for a session at endAt and
@@ -685,7 +876,55 @@ func (s *workSessionService) UpdateSession(ctx context.Context, staffID int64, s
 		}
 	}
 
+	// F8: with the deviation-reason setting active, self-edits of the
+	// recorded times (check-in, check-out, break minutes — including
+	// per-break duration edits, which are break-minute changes) need notes
+	// too, not only status changes. For the scalar fields the change
+	// detection mirrors applyTimeFieldUpdates/applyBreakUpdates, so an
+	// unchanged resend never trips the gate; a non-empty per-break list
+	// always counts as an edit intent (comparing it against stored rows
+	// would need an extra query before the ownership checks ran).
+	if s.selfEditChangesRecordedTimes(session, updates) {
+		if updates.Notes == nil || strings.TrimSpace(*updates.Notes) == "" {
+			required, err := s.deviationReasonRequired(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if required {
+				return nil, fmt.Errorf("notes required when changing recorded times")
+			}
+		}
+	}
+
 	return s.applySessionUpdate(ctx, staffID, session, updates)
+}
+
+// deviationReasonRequired resolves the F8/F9 tenant setting; nil settings
+// (tests, minimal wiring) mean the gate is off.
+func (s *workSessionService) deviationReasonRequired(ctx context.Context) (bool, error) {
+	if s.settings == nil {
+		return false, nil
+	}
+	enabled, err := s.settings.ResolveBool(ctx, configModels.KeyTimeTrackingRequireDeviationReason)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve deviation-reason setting: %w", err)
+	}
+	return enabled, nil
+}
+
+// selfEditChangesRecordedTimes reports whether the update would change
+// check_in_time, check_out_time, or break minutes on the session.
+func (s *workSessionService) selfEditChangesRecordedTimes(session *activeModels.WorkSession, updates SessionUpdateRequest) bool {
+	if updates.CheckInTime != nil && !session.CheckInTime.Equal(*updates.CheckInTime) {
+		return true
+	}
+	if updates.CheckOutTime != nil && (session.CheckOutTime == nil || !session.CheckOutTime.Equal(*updates.CheckOutTime)) {
+		return true
+	}
+	if updates.BreakMinutes != nil && *updates.BreakMinutes != session.BreakMinutes {
+		return true
+	}
+	return len(updates.Breaks) > 0
 }
 
 // UpdateSessionAsAdmin applies an admin correction. editorStaffID is the
@@ -1557,7 +1796,10 @@ func (s *workSessionService) EnsureCheckedIn(ctx context.Context, staffID int64,
 	}
 
 	// No session today, create one with the channel the caller passed in.
-	return s.CheckIn(ctx, staffID, activeModels.WorkSessionStatusPresent, source)
+	// The F9 deviation gate is bypassed: this auto-stamp fires because the
+	// staff member started a supervision, and that flow cannot collect a
+	// reason (see checkIn).
+	return s.checkIn(ctx, staffID, activeModels.WorkSessionStatusPresent, source, "", false)
 }
 
 // German weekday names for export

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -12,6 +12,7 @@ import (
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	configModels "github.com/moto-nrw/project-phoenix/models/config"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
@@ -219,6 +220,7 @@ func (m *wsMockWorkTimeModelRepository) Delete(ctx context.Context, id int64) er
 
 type wsMockSettingsResolver struct {
 	resolveBoolFunc func(ctx context.Context, key string) (bool, error)
+	resolveIntFunc  func(ctx context.Context, key string) (int, error)
 }
 
 func (m *wsMockSettingsResolver) ResolveBool(ctx context.Context, key string) (bool, error) {
@@ -226,6 +228,13 @@ func (m *wsMockSettingsResolver) ResolveBool(ctx context.Context, key string) (b
 		return m.resolveBoolFunc(ctx, key)
 	}
 	return false, nil
+}
+
+func (m *wsMockSettingsResolver) ResolveInt(ctx context.Context, key string) (int, error) {
+	if m.resolveIntFunc != nil {
+		return m.resolveIntFunc(ctx, key)
+	}
+	return 0, nil
 }
 
 // ============================================================================
@@ -613,7 +622,7 @@ func TestWSCheckIn_Success(t *testing.T) {
 		return nil
 	}
 
-	session, err := svc.CheckIn(ctx, staffID, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
+	session, err := svc.CheckIn(ctx, staffID, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp, "")
 	require.NoError(t, err)
 	require.NotNil(t, session)
 	assert.Equal(t, staffID, session.StaffID)
@@ -723,7 +732,7 @@ func TestWSCheckIn_PlannedStartEnforcement(t *testing.T) {
 				return nil
 			}
 
-			session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
+			session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp, "")
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Nil(t, session)
@@ -796,7 +805,7 @@ func TestWSCheckIn_RejectsEmptyStatus(t *testing.T) {
 		return nil
 	}
 
-	session, err := svc.CheckIn(ctx, 100, "", activeModels.WorkSessionSourceApp)
+	session, err := svc.CheckIn(ctx, 100, "", activeModels.WorkSessionSourceApp, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "status must be")
@@ -813,7 +822,7 @@ func TestWSCheckIn_AlreadyCheckedIn(t *testing.T) {
 		}, nil
 	}
 
-	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
+	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "already checked in")
@@ -846,7 +855,7 @@ func TestWSCheckIn_ReopenCheckedOutSession(t *testing.T) {
 		return nil
 	}
 
-	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
+	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp, "")
 	require.NoError(t, err)
 	require.NotNil(t, session)
 	assert.Nil(t, session.CheckOutTime)
@@ -887,7 +896,7 @@ func TestWSCheckIn_ReopenPreservesOriginalSourceAndStatus(t *testing.T) {
 
 	// Reopen via App with the SAME status — both Source and Status survive.
 	session, err := svc.CheckIn(context.Background(), 100,
-		activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
+		activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp, "")
 	require.NoError(t, err)
 	require.NotNil(t, session)
 	assert.Equal(t, activeModels.WorkSessionSourceNFC, capturedSource,
@@ -924,7 +933,7 @@ func TestWSCheckIn_ReopenStatusMismatchReturnsTypedConflict(t *testing.T) {
 	}
 
 	session, err := svc.CheckIn(context.Background(), 100,
-		activeModels.WorkSessionStatusHomeOffice, activeModels.WorkSessionSourceApp)
+		activeModels.WorkSessionStatusHomeOffice, activeModels.WorkSessionSourceApp, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 
@@ -938,7 +947,7 @@ func TestWSCheckIn_ReopenStatusMismatchReturnsTypedConflict(t *testing.T) {
 func TestWSCheckIn_InvalidStatus(t *testing.T) {
 	svc, _, _, _, _ := wsCreateTestService()
 
-	session, err := svc.CheckIn(context.Background(), 100, "invalid_status", activeModels.WorkSessionSourceApp)
+	session, err := svc.CheckIn(context.Background(), 100, "invalid_status", activeModels.WorkSessionSourceApp, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "status must be")
@@ -955,7 +964,7 @@ func TestWSCheckIn_InvalidSource(t *testing.T) {
 	svc, _, _, _, _ := wsCreateTestService()
 
 	session, err := svc.CheckIn(context.Background(), 100,
-		activeModels.WorkSessionStatusPresent, "bogus")
+		activeModels.WorkSessionStatusPresent, "bogus", "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "source must be",
@@ -972,7 +981,7 @@ func TestWSCheckIn_RejectsUnknownSource(t *testing.T) {
 	svc, _, _, _, _ := wsCreateTestService()
 
 	session, err := svc.CheckIn(context.Background(), 100,
-		activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceUnknown)
+		activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceUnknown, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "source must be",
@@ -1045,7 +1054,7 @@ func TestWSReopenThenUpdateSession_EmitsFieldStatusEdit(t *testing.T) {
 
 	// Step 1: reopen at existing status — no audit edit.
 	reopened, err := svc.CheckIn(ctx, staffID,
-		activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
+		activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp, "")
 	require.NoError(t, err)
 	require.NotNil(t, reopened)
 	require.Nil(t, reopened.CheckOutTime, "reopen must clear CheckOutTime")
@@ -1088,7 +1097,7 @@ func TestWSCheckIn_RepoError(t *testing.T) {
 		return nil, errors.New("database error")
 	}
 
-	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp)
+	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "failed to check existing session")
@@ -1134,7 +1143,7 @@ func TestWSCheckOut_Success(t *testing.T) {
 		}, nil
 	}
 
-	session, err := svc.CheckOut(ctx, staffID)
+	session, err := svc.CheckOut(ctx, staffID, "")
 	require.NoError(t, err)
 	require.NotNil(t, session)
 	assert.NotNil(t, session.CheckOutTime)
@@ -1147,7 +1156,7 @@ func TestWSCheckOut_NoActiveSession(t *testing.T) {
 		return nil, sql.ErrNoRows
 	}
 
-	session, err := svc.CheckOut(context.Background(), 100)
+	session, err := svc.CheckOut(context.Background(), 100, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "no active session found")
@@ -1160,7 +1169,7 @@ func TestWSCheckOut_NilSession(t *testing.T) {
 		return nil, nil
 	}
 
-	session, err := svc.CheckOut(context.Background(), 100)
+	session, err := svc.CheckOut(context.Background(), 100, "")
 	require.Error(t, err)
 	assert.Nil(t, session)
 	assert.Contains(t, err.Error(), "no active session found")
@@ -1216,7 +1225,7 @@ func TestWSCheckOut_WithActiveBreak(t *testing.T) {
 		}, nil
 	}
 
-	session, err := svc.CheckOut(context.Background(), staffID)
+	session, err := svc.CheckOut(context.Background(), staffID, "")
 	require.NoError(t, err)
 	require.NotNil(t, session)
 	assert.NotNil(t, session.CheckOutTime)
@@ -2350,4 +2359,489 @@ func (m *wsMockGroupSupervisorRepository) FindStaleOpen(context.Context, timezon
 
 func (m *wsMockGroupSupervisorRepository) UpdateColumns(context.Context, *activeModels.GroupSupervisor, ...string) (int64, error) {
 	return 0, nil
+}
+
+// ============================================================================
+// F9 Deviation-Reason Gate Tests (CheckIn/CheckOut vs. planned shifts)
+// ============================================================================
+
+// wsDeviationSettings enables operations.time_tracking_require_deviation_reason
+// and answers the tolerance lookup; every other bool setting (e.g. the
+// planned-start enforcement consulted on the same code path) stays off.
+func wsDeviationSettings(toleranceMinutes int) *wsMockSettingsResolver {
+	return &wsMockSettingsResolver{
+		resolveBoolFunc: func(_ context.Context, key string) (bool, error) {
+			return key == configModels.KeyTimeTrackingRequireDeviationReason, nil
+		},
+		resolveIntFunc: func(_ context.Context, key string) (int, error) {
+			return toleranceMinutes, nil
+		},
+	}
+}
+
+func TestWSCheckOut_DeviationGate(t *testing.T) {
+	day := timezone.NewDate(2026, 7, 6) // Monday
+	shift := shiftFor(100, day, 8, 16)  // planned 08:00-16:00
+
+	tests := []struct {
+		name         string
+		now          time.Time
+		shifts       []*scheduleModels.StaffShift
+		settings     *wsMockSettingsResolver
+		reason       string
+		wantErr      bool
+		wantMinutes  int
+		wantAudit    bool
+		wantAuditOld string
+		wantAuditNew string
+	}{
+		{
+			name:     "within tolerance saves without reason",
+			now:      time.Date(2026, time.July, 6, 16, 10, 0, 0, timezone.Berlin),
+			shifts:   []*scheduleModels.StaffShift{shift},
+			settings: wsDeviationSettings(15),
+		},
+		{
+			name:        "outside tolerance without reason rejects",
+			now:         time.Date(2026, time.July, 6, 16, 30, 0, 0, timezone.Berlin),
+			shifts:      []*scheduleModels.StaffShift{shift},
+			settings:    wsDeviationSettings(15),
+			wantErr:     true,
+			wantMinutes: 30,
+		},
+		{
+			name:         "outside tolerance with reason saves and audits",
+			now:          time.Date(2026, time.July, 6, 16, 30, 0, 0, timezone.Berlin),
+			shifts:       []*scheduleModels.StaffShift{shift},
+			settings:     wsDeviationSettings(15),
+			reason:       "Elterngespräch lief länger",
+			wantAudit:    true,
+			wantAuditOld: "16:00",
+			wantAuditNew: "16:30",
+		},
+		{
+			name:     "no shift that day skips the gate",
+			now:      time.Date(2026, time.July, 6, 22, 0, 0, 0, timezone.Berlin),
+			shifts:   nil,
+			settings: wsDeviationSettings(15),
+		},
+		{
+			// Leaving early is missing time, visible in the saldo — F9 only
+			// gates "später gehen".
+			name:     "early leave is not gated",
+			now:      time.Date(2026, time.July, 6, 15, 0, 0, 0, timezone.Berlin),
+			shifts:   []*scheduleModels.StaffShift{shift},
+			settings: wsDeviationSettings(15),
+		},
+		{
+			name:   "latest shift end is the reference",
+			now:    time.Date(2026, time.July, 6, 16, 30, 0, 0, timezone.Berlin),
+			shifts: []*scheduleModels.StaffShift{shiftFor(100, day, 8, 12), shift},
+			// 16:30 vs latest end 16:00 = 30 min > 15 → reject without reason
+			settings:    wsDeviationSettings(15),
+			wantErr:     true,
+			wantMinutes: 30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, sessionRepo, breakRepo, auditRepo, supervisorRepo := wsCreateTestService()
+			svc.nowFunc = func() time.Time { return tt.now }
+			svc.settings = tt.settings
+			shiftRepo := &wsMockStaffShiftRepository{}
+			shiftRepo.findByStaffIDsAndDateFunc = func(_ context.Context, staffIDs []int64, date timezone.Date) ([]*scheduleModels.StaffShift, error) {
+				assert.Equal(t, []int64{100}, staffIDs)
+				assert.Equal(t, day, date)
+				return tt.shifts, nil
+			}
+			svc.SetStaffShiftRepo(shiftRepo)
+
+			sessionRepo.getCurrentByStaffIDFunc = func(_ context.Context, _ int64) (*activeModels.WorkSession, error) {
+				return &activeModels.WorkSession{
+					Model:       base.Model{ID: 1},
+					StaffID:     100,
+					Date:        day,
+					CheckInTime: time.Date(2026, time.July, 6, 8, 0, 0, 0, timezone.Berlin),
+				}, nil
+			}
+			breakRepo.getActiveBySessionIDFunc = func(_ context.Context, _ int64) (*activeModels.WorkSessionBreak, error) {
+				return nil, nil
+			}
+			closed := false
+			sessionRepo.closeSessionFunc = func(_ context.Context, _ int64, _ time.Time, _ bool) (bool, error) {
+				closed = true
+				return true, nil
+			}
+			supervisorRepo.endAllActiveByStaffIDFunc = func(_ context.Context, _ int64) (int, error) {
+				return 0, nil
+			}
+			sessionRepo.findByIDFunc = func(_ context.Context, id any) (*activeModels.WorkSession, error) {
+				checkOut := tt.now
+				return &activeModels.WorkSession{
+					Model:        base.Model{ID: id.(int64)},
+					StaffID:      100,
+					Date:         day,
+					CheckInTime:  time.Date(2026, time.July, 6, 8, 0, 0, 0, timezone.Berlin),
+					CheckOutTime: &checkOut,
+				}, nil
+			}
+			var capturedEdits []*auditModels.WorkSessionEdit
+			auditRepo.createBatchFunc = func(_ context.Context, edits []*auditModels.WorkSessionEdit) error {
+				capturedEdits = edits
+				return nil
+			}
+
+			session, err := svc.CheckOut(context.Background(), 100, tt.reason)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, session)
+				var devErr *DeviationReasonRequiredError
+				require.ErrorAs(t, err, &devErr)
+				assert.Equal(t, "check_out", devErr.Action)
+				assert.Equal(t, "16:00", devErr.PlannedTime)
+				assert.Equal(t, "16:30", devErr.ActualTime)
+				assert.Equal(t, tt.wantMinutes, devErr.DeviationMinutes)
+				assert.False(t, closed, "a rejected check-out must not close the session")
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, session)
+			assert.True(t, closed)
+			if tt.wantAudit {
+				require.Len(t, capturedEdits, 1)
+				edit := capturedEdits[0]
+				assert.Equal(t, auditModels.FieldDeviationReason, edit.FieldName)
+				require.NotNil(t, edit.OldValue)
+				assert.Equal(t, tt.wantAuditOld, *edit.OldValue)
+				require.NotNil(t, edit.NewValue)
+				assert.Equal(t, tt.wantAuditNew, *edit.NewValue)
+				require.NotNil(t, edit.Notes)
+				assert.Equal(t, tt.reason, *edit.Notes)
+				assert.Equal(t, int64(100), edit.EditedBy)
+			} else {
+				assert.Empty(t, capturedEdits, "no deviation, no audit edit")
+			}
+		})
+	}
+}
+
+func TestWSCheckOut_DeviationGateOffSkipsShiftLookup(t *testing.T) {
+	svc, sessionRepo, breakRepo, _, supervisorRepo := wsCreateTestService()
+	svc.settings = &wsMockSettingsResolver{} // setting resolves to false
+	lookedUp := false
+	shiftRepo := &wsMockStaffShiftRepository{}
+	shiftRepo.findByStaffIDsAndDateFunc = func(_ context.Context, _ []int64, _ timezone.Date) ([]*scheduleModels.StaffShift, error) {
+		lookedUp = true
+		return nil, nil
+	}
+	svc.SetStaffShiftRepo(shiftRepo)
+
+	sessionRepo.getCurrentByStaffIDFunc = func(_ context.Context, _ int64) (*activeModels.WorkSession, error) {
+		return &activeModels.WorkSession{
+			Model:       base.Model{ID: 1},
+			StaffID:     100,
+			Date:        timezone.TodayDate(),
+			CheckInTime: time.Now().Add(-4 * time.Hour),
+		}, nil
+	}
+	breakRepo.getActiveBySessionIDFunc = func(_ context.Context, _ int64) (*activeModels.WorkSessionBreak, error) {
+		return nil, nil
+	}
+	sessionRepo.closeSessionFunc = func(_ context.Context, _ int64, _ time.Time, _ bool) (bool, error) {
+		return true, nil
+	}
+	supervisorRepo.endAllActiveByStaffIDFunc = func(_ context.Context, _ int64) (int, error) {
+		return 0, nil
+	}
+	sessionRepo.findByIDFunc = func(_ context.Context, id any) (*activeModels.WorkSession, error) {
+		checkOut := time.Now()
+		return &activeModels.WorkSession{
+			Model:        base.Model{ID: id.(int64)},
+			StaffID:      100,
+			CheckOutTime: &checkOut,
+		}, nil
+	}
+
+	session, err := svc.CheckOut(context.Background(), 100, "")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.False(t, lookedUp, "disabled setting must not load shifts")
+}
+
+func TestWSCheckIn_DeviationGate(t *testing.T) {
+	day := timezone.NewDate(2026, 7, 6) // Monday
+	shift := shiftFor(100, day, 8, 16)
+
+	tests := []struct {
+		name        string
+		now         time.Time
+		reason      string
+		extraShift  bool
+		wantErr     bool
+		wantMinutes int
+		wantAudit   bool
+	}{
+		{
+			name:        "early beyond tolerance without reason rejects",
+			now:         time.Date(2026, time.July, 6, 7, 30, 0, 0, timezone.Berlin),
+			wantErr:     true,
+			wantMinutes: 30,
+		},
+		{
+			name:      "early beyond tolerance with reason saves and audits",
+			now:       time.Date(2026, time.July, 6, 7, 30, 0, 0, timezone.Berlin),
+			reason:    "Frühdienst übernommen",
+			wantAudit: true,
+		},
+		{
+			name: "early within tolerance saves without reason",
+			now:  time.Date(2026, time.July, 6, 7, 50, 0, 0, timezone.Berlin),
+		},
+		{
+			name: "late arrival is not gated",
+			now:  time.Date(2026, time.July, 6, 8, 30, 0, 0, timezone.Berlin),
+		},
+		{
+			// With a second, later shift the EARLIEST start stays the
+			// check-in reference.
+			name:        "earliest shift start is the reference",
+			now:         time.Date(2026, time.July, 6, 7, 30, 0, 0, timezone.Berlin),
+			extraShift:  true,
+			wantErr:     true,
+			wantMinutes: 30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, sessionRepo, _, auditRepo, _ := wsCreateTestService()
+			svc.nowFunc = func() time.Time { return tt.now }
+			svc.settings = wsDeviationSettings(15)
+			shiftRepo := &wsMockStaffShiftRepository{}
+			shiftRepo.findByStaffIDsAndDateFunc = func(_ context.Context, _ []int64, _ timezone.Date) ([]*scheduleModels.StaffShift, error) {
+				shifts := []*scheduleModels.StaffShift{shift}
+				if tt.extraShift {
+					shifts = append(shifts, shiftFor(100, day, 13, 16))
+				}
+				return shifts, nil
+			}
+			svc.SetStaffShiftRepo(shiftRepo)
+
+			sessionRepo.getByStaffAndDateFunc = func(_ context.Context, _ int64, _ timezone.Date) (*activeModels.WorkSession, error) {
+				return nil, sql.ErrNoRows
+			}
+			created := false
+			sessionRepo.createFunc = func(_ context.Context, entity *activeModels.WorkSession) error {
+				created = true
+				entity.ID = 10
+				return nil
+			}
+			var capturedEdits []*auditModels.WorkSessionEdit
+			auditRepo.createBatchFunc = func(_ context.Context, edits []*auditModels.WorkSessionEdit) error {
+				capturedEdits = edits
+				return nil
+			}
+
+			session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp, tt.reason)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, session)
+				var devErr *DeviationReasonRequiredError
+				require.ErrorAs(t, err, &devErr)
+				assert.Equal(t, "check_in", devErr.Action)
+				assert.Equal(t, "08:00", devErr.PlannedTime)
+				assert.Equal(t, "07:30", devErr.ActualTime)
+				assert.Equal(t, tt.wantMinutes, devErr.DeviationMinutes)
+				assert.False(t, created, "a rejected check-in must not create a session")
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, session)
+			assert.True(t, created)
+			if tt.wantAudit {
+				require.Len(t, capturedEdits, 1)
+				assert.Equal(t, auditModels.FieldDeviationReason, capturedEdits[0].FieldName)
+				require.NotNil(t, capturedEdits[0].Notes)
+				assert.Equal(t, tt.reason, *capturedEdits[0].Notes)
+			} else {
+				assert.Empty(t, capturedEdits)
+			}
+		})
+	}
+}
+
+func TestWSCheckIn_ReopenSkipsDeviationGate(t *testing.T) {
+	// Reopening after an accidental checkout is not a new arrival: even far
+	// outside the tolerance window no reason is demanded.
+	now := time.Date(2026, time.July, 6, 16, 30, 0, 0, timezone.Berlin)
+	day := timezone.NewDate(2026, 7, 6)
+
+	svc, sessionRepo, _, _, _ := wsCreateTestService()
+	svc.nowFunc = func() time.Time { return now }
+	svc.settings = wsDeviationSettings(15)
+	shiftRepo := &wsMockStaffShiftRepository{}
+	shiftRepo.findByStaffIDsAndDateFunc = func(_ context.Context, _ []int64, _ timezone.Date) ([]*scheduleModels.StaffShift, error) {
+		t.Fatal("reopen must not consult the deviation gate")
+		return nil, nil
+	}
+	svc.SetStaffShiftRepo(shiftRepo)
+
+	checkOut := time.Date(2026, time.July, 6, 12, 0, 0, 0, timezone.Berlin)
+	sessionRepo.getByStaffAndDateFunc = func(_ context.Context, _ int64, _ timezone.Date) (*activeModels.WorkSession, error) {
+		return &activeModels.WorkSession{
+			Model:        base.Model{ID: 7},
+			StaffID:      100,
+			Date:         day,
+			CreatedBy:    100,
+			Status:       activeModels.WorkSessionStatusPresent,
+			Source:       activeModels.WorkSessionSourceApp,
+			CheckInTime:  time.Date(2026, time.July, 6, 8, 0, 0, 0, timezone.Berlin),
+			CheckOutTime: &checkOut,
+		}, nil
+	}
+	sessionRepo.updateFunc = func(_ context.Context, _ *activeModels.WorkSession) error { return nil }
+
+	session, err := svc.CheckIn(context.Background(), 100, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceApp, "")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.Nil(t, session.CheckOutTime, "session must be reopened")
+}
+
+func TestWSEnsureCheckedIn_SkipsDeviationGate(t *testing.T) {
+	// The supervision auto-stamp has no way to collect a reason; an early
+	// start must still produce a work session.
+	now := time.Date(2026, time.July, 6, 7, 0, 0, 0, timezone.Berlin)
+
+	svc, sessionRepo, _, _, _ := wsCreateTestService()
+	svc.nowFunc = func() time.Time { return now }
+	svc.settings = wsDeviationSettings(15)
+	shiftRepo := &wsMockStaffShiftRepository{}
+	shiftRepo.findByStaffIDsAndDateFunc = func(_ context.Context, _ []int64, _ timezone.Date) ([]*scheduleModels.StaffShift, error) {
+		t.Fatal("EnsureCheckedIn must not consult the deviation gate")
+		return nil, nil
+	}
+	svc.SetStaffShiftRepo(shiftRepo)
+
+	sessionRepo.getCurrentByStaffIDFunc = func(_ context.Context, _ int64) (*activeModels.WorkSession, error) {
+		return nil, sql.ErrNoRows
+	}
+	sessionRepo.getByStaffAndDateFunc = func(_ context.Context, _ int64, _ timezone.Date) (*activeModels.WorkSession, error) {
+		return nil, sql.ErrNoRows
+	}
+	created := false
+	sessionRepo.createFunc = func(_ context.Context, entity *activeModels.WorkSession) error {
+		created = true
+		entity.ID = 11
+		return nil
+	}
+
+	session, err := svc.EnsureCheckedIn(context.Background(), 100, activeModels.WorkSessionSourceNFC)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.True(t, created)
+}
+
+// ============================================================================
+// F8 Self-Edit Notes Gate Tests (UpdateSession time fields)
+// ============================================================================
+
+func TestWSUpdateSession_TimeChangeNotesGate(t *testing.T) {
+	staffID := int64(100)
+	sessionID := int64(100)
+	oldCheckIn := time.Date(2026, time.July, 6, 8, 0, 0, 0, timezone.Berlin)
+	newCheckIn := time.Date(2026, time.July, 6, 7, 0, 0, 0, timezone.Berlin)
+	newBreak := 45
+
+	tests := []struct {
+		name      string
+		settingOn bool
+		updates   SessionUpdateRequest
+		wantErr   bool
+	}{
+		{
+			name:      "check-in change without notes rejects when setting on",
+			settingOn: true,
+			updates:   SessionUpdateRequest{CheckInTime: &newCheckIn},
+			wantErr:   true,
+		},
+		{
+			name:      "check-in change with notes passes",
+			settingOn: true,
+			updates:   SessionUpdateRequest{CheckInTime: &newCheckIn, Notes: wsStrPtr("Bus verpasst")},
+		},
+		{
+			name:    "check-in change without notes passes when setting off",
+			updates: SessionUpdateRequest{CheckInTime: &newCheckIn},
+		},
+		{
+			name:      "unchanged resend without notes never trips the gate",
+			settingOn: true,
+			updates:   SessionUpdateRequest{CheckInTime: &oldCheckIn},
+		},
+		{
+			name:      "break-minutes change without notes rejects when setting on",
+			settingOn: true,
+			updates:   SessionUpdateRequest{BreakMinutes: &newBreak},
+			wantErr:   true,
+		},
+		{
+			name:      "per-break duration edit without notes rejects when setting on",
+			settingOn: true,
+			updates:   SessionUpdateRequest{Breaks: []BreakDurationUpdate{{ID: 5, DurationMinutes: 20}}},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, sessionRepo, breakRepo, auditRepo, _ := wsCreateTestService()
+			if tt.settingOn {
+				svc.settings = wsDeviationSettings(15)
+			}
+
+			checkOut := time.Date(2026, time.July, 6, 16, 0, 0, 0, timezone.Berlin)
+			sessionRepo.findByIDFunc = func(_ context.Context, _ any) (*activeModels.WorkSession, error) {
+				return &activeModels.WorkSession{
+					Model:        base.Model{ID: sessionID},
+					StaffID:      staffID,
+					CheckInTime:  oldCheckIn,
+					CheckOutTime: &checkOut,
+					BreakMinutes: 30,
+					Status:       activeModels.WorkSessionStatusPresent,
+					Date:         timezone.NewDate(2026, 7, 6),
+					CreatedBy:    staffID,
+				}, nil
+			}
+			sessionRepo.updateFunc = func(_ context.Context, _ *activeModels.WorkSession) error { return nil }
+			breakRepo.getBySessionIDFunc = func(_ context.Context, _ int64) ([]*activeModels.WorkSessionBreak, error) {
+				ended := checkOut
+				return []*activeModels.WorkSessionBreak{{
+					Model:           base.Model{ID: 5},
+					SessionID:       sessionID,
+					StartedAt:       oldCheckIn.Add(4 * time.Hour),
+					EndedAt:         &ended,
+					DurationMinutes: 30,
+				}}, nil
+			}
+			sessionRepo.updateBreakMinutesFunc = func(_ context.Context, _ int64, _ int) error { return nil }
+			breakRepo.updateFunc = func(_ context.Context, _ *activeModels.WorkSessionBreak) error { return nil }
+			auditRepo.createBatchFunc = func(_ context.Context, _ []*auditModels.WorkSessionEdit) error { return nil }
+
+			session, err := svc.UpdateSession(context.Background(), staffID, sessionID, tt.updates)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, session)
+				assert.Contains(t, err.Error(), "notes required when changing recorded times")
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, session)
+		})
+	}
 }

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -76,6 +76,9 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"operations.care_concept",
 		"operations.time_tracking_account_start_date",
 		"operations.time_tracking_enforce_planned_start",
+		// F9 deviation-reason gate (Planung redesign, Inkrement 6A).
+		"operations.time_tracking_require_deviation_reason",
+		"operations.time_tracking_deviation_tolerance_minutes",
 		// Student photo feature (Datenverwaltung): per-school opt-in toggle.
 		"operations.student_photos_enabled",
 		// 2FA / MFA work package (issue #1308): mode toggle + trusted-device pair.
@@ -317,6 +320,38 @@ func TestTimeTrackingEnforcePlannedStartSetting(t *testing.T) {
 	assert.Equal(t, "operations", def.Tab)
 	assert.Equal(t, "zeiterfassung", def.Category)
 	assert.Equal(t, "config:update", def.WritePermission)
+}
+
+func TestTimeTrackingRequireDeviationReasonSetting(t *testing.T) {
+	def := config.GetDefinition(config.KeyTimeTrackingRequireDeviationReason)
+	require.NotNil(t, def, "operations.time_tracking_require_deviation_reason should be registered")
+	assert.Equal(t, config.FieldBoolean, def.Type)
+	assert.Equal(t, false, def.Default, "deviation-reason gate must be opt-in")
+	assert.Equal(t, config.AccessShared, def.AccessPolicy)
+	assert.Equal(t, "operations", def.Tab)
+	assert.Equal(t, "zeiterfassung", def.Category)
+	assert.Equal(t, "config:update", def.WritePermission)
+	assert.Nil(t, def.DependsOn)
+}
+
+func TestTimeTrackingDeviationToleranceSetting(t *testing.T) {
+	def := config.GetDefinition(config.KeyTimeTrackingDeviationToleranceMinutes)
+	require.NotNil(t, def, "operations.time_tracking_deviation_tolerance_minutes should be registered")
+	assert.Equal(t, config.FieldNumber, def.Type)
+	assert.Equal(t, 15, def.Default, "default mirrors the fixed 15-minute frontend tolerance of getDeltaStatus")
+	assert.Equal(t, config.AccessShared, def.AccessPolicy)
+	assert.Equal(t, "operations", def.Tab)
+	assert.Equal(t, "zeiterfassung", def.Category)
+	assert.Equal(t, "config:update", def.WritePermission)
+	require.NotNil(t, def.Validation)
+	require.NotNil(t, def.Validation.Min)
+	assert.Equal(t, float64(0), *def.Validation.Min)
+	require.NotNil(t, def.Validation.Max)
+	assert.Equal(t, float64(120), *def.Validation.Max)
+	require.NotNil(t, def.DependsOn, "tolerance is only visible while the gate is active")
+	assert.Equal(t, config.KeyTimeTrackingRequireDeviationReason, def.DependsOn.Key)
+	assert.Equal(t, "eq", def.DependsOn.Condition)
+	assert.Equal(t, true, def.DependsOn.Value)
 }
 
 func TestTimetableSettings_Types(t *testing.T) {

--- a/backend/services/config/defaults/operations.go
+++ b/backend/services/config/defaults/operations.go
@@ -203,6 +203,34 @@ func init() {
 		SortOrder:       2,
 	})
 
+	config.Register(config.Definition{
+		Key:             config.KeyTimeTrackingRequireDeviationReason,
+		Label:           "Begründung bei Abweichung vom Dienstplan",
+		Description:     "Wenn aktiviert, verlangt das Ein- und Ausstempeln außerhalb des Toleranzfensters um die geplante Schichtzeit eine Begründung. Gilt auch für nachträgliche Änderungen eigener Zeiten. Tage ohne geplante Schicht bleiben unverändert.",
+		Type:            config.FieldBoolean,
+		Default:         false,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "zeiterfassung",
+		SortOrder:       3,
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyTimeTrackingDeviationToleranceMinutes,
+		Label:           "Toleranzfenster für Abweichungen (Minuten)",
+		Description:     "So viele Minuten darf die Ist-Zeit von der geplanten Schichtzeit abweichen, bevor eine Begründung verlangt wird.",
+		Type:            config.FieldNumber,
+		Default:         15,
+		Validation:      config.Range(0, 120),
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "zeiterfassung",
+		SortOrder:       4,
+		DependsOn:       config.DependsOnEq(config.KeyTimeTrackingRequireDeviationReason, true),
+	})
+
 	// Break auto-end interval is NOT registered here. It controls a global ticker
 	// and is configured via BREAK_AUTO_END_INTERVAL_SECONDS env var only.
 

--- a/frontend/e2e/time-tracking-deviation.spec.ts
+++ b/frontend/e2e/time-tracking-deviation.spec.ts
@@ -1,0 +1,200 @@
+import { expect, type Page, test } from "@playwright/test";
+import { todayISO } from "../src/lib/date-helpers";
+
+// F9 (Planung-Redesign Inkrement 6A): stamping outside the tolerance window
+// around the planned shift window requires a reason that lands in the
+// session's audit log. The flow under test mirrors docs/08-zeiterfassung.md
+// section 13: enable the setting, plan a shift, check out too late, fill the
+// reason dialog, verify the audit entry; then disable the setting and verify
+// the same stamp passes without a dialog.
+
+// Test credentials from environment variables (never commit real credentials!).
+// No fallback defaults per the repo no-fallback policy — the suite skips when
+// either is unset (see beforeEach) rather than substituting an empty string.
+const TEST_EMAIL = process.env.E2E_TEST_EMAIL;
+const TEST_PASSWORD = process.env.E2E_TEST_PASSWORD;
+
+const REQUIRE_KEY = "operations.time_tracking_require_deviation_reason";
+const TOLERANCE_KEY = "operations.time_tracking_deviation_tolerance_minutes";
+
+async function login(page: Page, email: string, password: string) {
+  await page.goto("/");
+  await page.waitForSelector('input[type="email"]');
+  await page.fill('input[type="email"]', email);
+  await page.fill('input[type="password"]', password);
+  await page.click('button:has-text("Anmelden")');
+  await page.waitForURL(
+    (url) => !url.pathname.includes("login") && url.pathname !== "/",
+    { timeout: 15000 },
+  );
+}
+
+async function setSetting(page: Page, key: string, value: unknown) {
+  const response = await page.request.put(`/api/settings/values/${key}`, {
+    data: { value },
+  });
+  expect(response.ok(), `setting ${key} should update`).toBeTruthy();
+}
+
+async function resetSetting(page: Page, key: string) {
+  // DELETE removes the tenant override so later runs (and the school) fall
+  // back to the registry default.
+  await page.request.delete(`/api/settings/values/${key}`);
+}
+
+// Clicks "Einstempeln" and confirms the optional "Trotzdem einstempeln"
+// follow-up (shown when today's session was manually edited or an absence
+// exists) so the stamp actually happens.
+async function checkIn(page: Page) {
+  await page.getByText("In der OGS").first().click();
+  await page.getByLabel("Einstempeln").click();
+  const confirm = page.getByRole("button", { name: "Trotzdem einstempeln" });
+  try {
+    await confirm.waitFor({ state: "visible", timeout: 2000 });
+    await confirm.click();
+  } catch {
+    // No confirmation modal — the stamp went through directly.
+  }
+  await expect(page.getByLabel("Ausstempeln")).toBeVisible({ timeout: 10000 });
+}
+
+test.describe("Time tracking deviation reason (F9)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.skip(
+      !TEST_EMAIL || !TEST_PASSWORD,
+      "E2E_TEST_EMAIL and E2E_TEST_PASSWORD must be set",
+    );
+    if (!TEST_EMAIL || !TEST_PASSWORD) return;
+    await login(page, TEST_EMAIL, TEST_PASSWORD);
+  });
+
+  test("late check-out demands a reason that lands in the audit log; disabled setting stays silent", async ({
+    page,
+  }) => {
+    // The planned shift ends at 00:02; a check-out before ~00:03 would not
+    // deviate yet. Skip the sub-3-minute window right after midnight instead
+    // of producing a false red.
+    const berlinNow = new Date(
+      new Date().toLocaleString("en-US", { timeZone: "Europe/Berlin" }),
+    );
+    test.skip(
+      berlinNow.getHours() === 0 && berlinNow.getMinutes() < 5,
+      "planned shift end 00:02 is not in the past yet",
+    );
+
+    const reason = `Playwright F9 Begründung ${Date.now()}`;
+    let createdShiftId: string | null = null;
+
+    try {
+      // Baseline: gate off, so setup stamps never trigger the dialog.
+      await setSetting(page, REQUIRE_KEY, false);
+
+      await page.goto("/time-tracking");
+      // Wait until the stamp card resolved the current session before
+      // branching, otherwise a slow session fetch reads as "not checked in".
+      await expect(
+        page.getByLabel("Einstempeln").or(page.getByLabel("Ausstempeln")),
+      ).toBeVisible({ timeout: 15000 });
+      // A leftover active session from a previous run is stamped out first
+      // (setting is off, so this cannot open the dialog).
+      if (await page.getByLabel("Ausstempeln").isVisible()) {
+        await page.getByLabel("Ausstempeln").click();
+        await expect(page.getByLabel("Einstempeln")).toBeVisible({
+          timeout: 10000,
+        });
+      }
+
+      // Check in without a planned shift (or long after its start — late
+      // arrivals are not gated), then read the session for staff id and
+      // audit lookups.
+      await checkIn(page);
+      const currentResponse = await page.request.get(
+        "/api/time-tracking/current",
+      );
+      expect(currentResponse.ok()).toBeTruthy();
+      const current = (await currentResponse.json()) as {
+        data: { id: number; staff_id: number };
+      };
+      const sessionId = current.data.id;
+      const staffId = current.data.staff_id;
+
+      // Plan a shift that ended just after midnight, so "now" is past the
+      // planned end. A 409 means a suitable shift is left over from an
+      // earlier run — equally fine.
+      const shiftResponse = await page.request.post("/api/staff/shifts", {
+        data: {
+          staff_id: staffId,
+          date: todayISO(),
+          start_time: "00:01",
+          end_time: "00:02",
+          break_minutes: 0,
+          shift_type_id: null,
+        },
+      });
+      expect(
+        shiftResponse.ok() || shiftResponse.status() === 409,
+        "shift creation should succeed or already exist",
+      ).toBeTruthy();
+      if (shiftResponse.ok()) {
+        const shift = (await shiftResponse.json()) as {
+          data: { id: number };
+        };
+        createdShiftId = String(shift.data.id);
+      }
+
+      // Arm the gate with zero tolerance.
+      await setSetting(page, REQUIRE_KEY, true);
+      await setSetting(page, TOLERANCE_KEY, 0);
+
+      // Late check-out → reason dialog with the deviation facts.
+      await page.getByLabel("Ausstempeln").click();
+      await expect(page.getByText("Abweichung vom Dienstplan")).toBeVisible();
+      await expect(
+        page.getByText(/nach deinem geplanten Dienstende/),
+      ).toBeVisible();
+      const confirmButton = page.getByRole("button", {
+        name: "Mit Begründung ausstempeln",
+      });
+      await expect(confirmButton).toBeDisabled();
+
+      await page.getByLabel("Grund").fill(reason);
+      await confirmButton.click();
+      await expect(page.getByText("Abweichung vom Dienstplan")).toBeHidden({
+        timeout: 10000,
+      });
+      await expect(page.getByLabel("Einstempeln")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // The reason is readable in the session's audit log.
+      const editsResponse = await page.request.get(
+        `/api/time-tracking/${sessionId}/edits`,
+      );
+      expect(editsResponse.ok()).toBeTruthy();
+      const edits = (await editsResponse.json()) as {
+        data: Array<{ field_name: string; notes: string | null }>;
+      };
+      const deviationEdit = edits.data.find(
+        (edit) => edit.field_name === "deviation_reason",
+      );
+      expect(deviationEdit, "deviation_reason audit entry").toBeTruthy();
+      expect(deviationEdit?.notes).toBe(reason);
+
+      // Second case: with the setting off, the same stamp passes silently.
+      await setSetting(page, REQUIRE_KEY, false);
+      await checkIn(page); // reopens today's session
+      await page.getByLabel("Ausstempeln").click();
+      await expect(page.getByLabel("Einstempeln")).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.getByText("Abweichung vom Dienstplan")).toBeHidden();
+    } finally {
+      // Leave the tenant in its default state for reruns and other suites.
+      if (createdShiftId) {
+        await page.request.delete(`/api/staff/shifts/${createdShiftId}`);
+      }
+      await resetSetting(page, REQUIRE_KEY);
+      await resetSetting(page, TOLERANCE_KEY);
+    }
+  });
+});

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -61,6 +61,7 @@ vi.mock("~/contexts/ToastContext", () => ({
 }));
 
 vi.mock("~/lib/time-tracking-api", () => ({
+  DEVIATION_REASON_REQUIRED_CODE: "deviation_reason_required",
   PLANNED_START_NOT_REACHED_CODE: "planned_start_not_reached",
   REOPEN_STATUS_CONFLICT_CODE: "reopen_status_conflict",
   timeTrackingService: mockTimeTrackingService,
@@ -4597,5 +4598,163 @@ describe("TimeTrackingPage", () => {
       // Should not show check-in button at all when session is active
       expect(screen.queryByLabelText("Einstempeln")).not.toBeInTheDocument();
     });
+  });
+});
+
+// F9: the backend rejects stamps outside the tolerance window around the
+// planned shift window with code "deviation_reason_required". The page must
+// prompt for a reason and retry the SAME stamp with the reason attached
+// (see api/time-tracking/errors.go and work_session_service.go).
+describe("deviation-reason gate (F9)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeDeviationError(action: "check_in" | "check_out"): Error & {
+    code?: string;
+    status?: number;
+    details?: Record<string, unknown>;
+  } {
+    const err = new Error("deviation reason required") as Error & {
+      code?: string;
+      status?: number;
+      details?: Record<string, unknown>;
+    };
+    err.code = "deviation_reason_required";
+    err.status = 409;
+    err.details =
+      action === "check_in"
+        ? {
+            action,
+            planned_time: "08:00",
+            actual_time: "07:30",
+            deviation_minutes: "30",
+          }
+        : {
+            action,
+            planned_time: "16:00",
+            actual_time: "16:30",
+            deviation_minutes: "30",
+          };
+    return err;
+  }
+
+  it("opens the reason dialog when check-out deviates from the plan", async () => {
+    setupDefaultMocks({ currentSession: mockActiveSession });
+    vi.mocked(timeTrackingService.checkOut).mockRejectedValueOnce(
+      makeDeviationError("check_out"),
+    );
+    render(<TimeTrackingPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ausstempeln"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Abweichung vom Dienstplan")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/30 Minuten/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/nach deinem geplanten Dienstende/),
+    ).toBeInTheDocument();
+    // Confirm stays disabled until a reason is entered.
+    expect(screen.getByText("Mit Begründung ausstempeln")).toBeDisabled();
+  });
+
+  it("retries the check-out with the entered reason", async () => {
+    setupDefaultMocks({ currentSession: mockActiveSession });
+    vi.mocked(timeTrackingService.checkOut)
+      .mockRejectedValueOnce(makeDeviationError("check_out"))
+      .mockResolvedValueOnce(mockCheckedOutSession);
+    render(<TimeTrackingPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ausstempeln"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Abweichung vom Dienstplan")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Grund"), {
+      target: { value: "Elterngespräch lief länger" },
+    });
+    const confirmBtn = screen.getByText("Mit Begründung ausstempeln");
+    expect(confirmBtn).not.toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(timeTrackingService.checkOut).toHaveBeenLastCalledWith(
+        "Elterngespräch lief länger",
+      );
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Abweichung vom Dienstplan"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("retries the check-in with status and reason", async () => {
+    setupDefaultMocks();
+    vi.mocked(timeTrackingService.checkIn)
+      .mockRejectedValueOnce(makeDeviationError("check_in"))
+      .mockResolvedValueOnce(mockActiveSession);
+    render(<TimeTrackingPage />);
+
+    fireEvent.click(screen.getByText("In der OGS"));
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Einstempeln"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Abweichung vom Dienstplan")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/vor deinem geplanten Dienstbeginn/),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Grund"), {
+      target: { value: "Frühdienst übernommen" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Mit Begründung einstempeln"));
+    });
+
+    await waitFor(() => {
+      expect(timeTrackingService.checkIn).toHaveBeenLastCalledWith(
+        "present",
+        "Frühdienst übernommen",
+      );
+    });
+  });
+
+  it("keeps the dialog open when the retry fails", async () => {
+    setupDefaultMocks({ currentSession: mockActiveSession });
+    vi.mocked(timeTrackingService.checkOut)
+      .mockRejectedValueOnce(makeDeviationError("check_out"))
+      .mockRejectedValueOnce(new Error("network down"));
+    render(<TimeTrackingPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ausstempeln"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Abweichung vom Dienstplan")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Grund"), {
+      target: { value: "Elterngespräch" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Mit Begründung ausstempeln"));
+    });
+
+    await waitFor(() => {
+      expect(timeTrackingService.checkOut).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByText("Abweichung vom Dienstplan")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -53,6 +53,7 @@ import {
   toDateKey,
 } from "~/lib/staff-metrics-helpers";
 import {
+  DEVIATION_REASON_REQUIRED_CODE,
   PLANNED_START_NOT_REACHED_CODE,
   REOPEN_STATUS_CONFLICT_CODE,
   timeTrackingService,
@@ -2905,6 +2906,24 @@ function TimeTrackingContent() {
     setReopenStatusChangeReason("");
   }, []);
 
+  // F9 deviation-reason prompt. Set when the backend rejects a stamp with
+  // DEVIATION_REASON_REQUIRED_CODE because it falls outside the tolerance
+  // window around the planned shift window. The modal collects the reason
+  // and retries the same stamp; the backend stores it in the audit log.
+  const [pendingDeviation, setPendingDeviation] = useState<{
+    action: "check_in" | "check_out";
+    status?: SessionStatus;
+    plannedTime?: string;
+    actualTime?: string;
+    deviationMinutes?: string;
+  } | null>(null);
+  const [deviationReason, setDeviationReason] = useState("");
+  const [deviationSubmitting, setDeviationSubmitting] = useState(false);
+  const handleClosePendingDeviation = useCallback(() => {
+    setPendingDeviation(null);
+    setDeviationReason("");
+  }, []);
+
   // Calculate date range for data fetching
   // - Chart shows trailing 10 workdays ending at reference date
   // - WeekView shows calendar week containing reference date, so the
@@ -3145,6 +3164,27 @@ function TimeTrackingContent() {
         toast.success("Erfolgreich eingestempelt");
       } catch (err) {
         const apiErr = err as ApiError;
+        if (apiErr.code === DEVIATION_REASON_REQUIRED_CODE) {
+          const details = apiErr.details;
+          setDeviationReason("");
+          setPendingDeviation({
+            action: "check_in",
+            status,
+            plannedTime:
+              typeof details?.planned_time === "string"
+                ? details.planned_time
+                : undefined,
+            actualTime:
+              typeof details?.actual_time === "string"
+                ? details.actual_time
+                : undefined,
+            deviationMinutes:
+              typeof details?.deviation_minutes === "string"
+                ? details.deviation_minutes
+                : undefined,
+          });
+          return;
+        }
         if (apiErr.code === REOPEN_STATUS_CONFLICT_CODE) {
           // Audit-trail gate: silent status change on reopen is forbidden.
           // Surface the prompt; the user supplies a reason and we route
@@ -3312,12 +3352,76 @@ function TimeTrackingContent() {
       ]);
       toast.success("Erfolgreich ausgestempelt");
     } catch (err) {
+      const apiErr = err as ApiError;
+      if (apiErr.code === DEVIATION_REASON_REQUIRED_CODE) {
+        const details = apiErr.details;
+        setDeviationReason("");
+        setPendingDeviation({
+          action: "check_out",
+          plannedTime:
+            typeof details?.planned_time === "string"
+              ? details.planned_time
+              : undefined,
+          actualTime:
+            typeof details?.actual_time === "string"
+              ? details.actual_time
+              : undefined,
+          deviationMinutes:
+            typeof details?.deviation_minutes === "string"
+              ? details.deviation_minutes
+              : undefined,
+        });
+        return;
+      }
       logger.error("check_out_failed", {
         error: err instanceof Error ? err.message : String(err),
       });
       toast.error(friendlyError(err, "Fehler beim Ausstempeln"));
     }
   }, [mutateCurrentSession, mutateHistory, refreshTableData, toast]);
+
+  // Retry the rejected stamp with the collected reason. The modal stays open
+  // when the retry fails so the reason isn't lost.
+  const confirmDeviationReason = useCallback(async () => {
+    const pending = pendingDeviation;
+    if (!pending) return;
+    const reason = deviationReason.trim();
+    if (!reason) return;
+
+    setDeviationSubmitting(true);
+    try {
+      if (pending.action === "check_in" && pending.status) {
+        await timeTrackingService.checkIn(pending.status, reason);
+        toast.success("Erfolgreich eingestempelt");
+      } else {
+        await timeTrackingService.checkOut(reason);
+        setCurrentBreaks([]);
+        toast.success("Erfolgreich ausgestempelt");
+      }
+      await Promise.all([
+        mutateCurrentSession(),
+        mutateHistory(),
+        refreshTableData(),
+      ]);
+      setPendingDeviation(null);
+      setDeviationReason("");
+    } catch (err) {
+      logger.error("deviation_reason_submit_failed", {
+        error: err instanceof Error ? err.message : String(err),
+        action: pending.action,
+      });
+      toast.error(friendlyError(err, "Fehler beim Stempeln"));
+    } finally {
+      setDeviationSubmitting(false);
+    }
+  }, [
+    pendingDeviation,
+    deviationReason,
+    mutateCurrentSession,
+    mutateHistory,
+    refreshTableData,
+    toast,
+  ]);
 
   const handleStartBreak = useCallback(
     async (durationMinutes: number) => {
@@ -3708,6 +3812,91 @@ function TimeTrackingContent() {
             onChange={(e) => setReopenStatusChangeReason(e.target.value)}
             disabled={reopenStatusChangeSubmitting}
             placeholder="z. B. Mittags ins Homeoffice gewechselt"
+            rows={3}
+            className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-gray-500 focus:ring-1 focus:ring-gray-500 focus:outline-none disabled:opacity-50"
+          />
+        </div>
+      </Modal>
+
+      {/* F9: stamping outside the tolerance window around the planned shift
+          needs a reason that lands in the audit trail. */}
+      <Modal
+        isOpen={pendingDeviation !== null}
+        onClose={handleClosePendingDeviation}
+        title="Abweichung vom Dienstplan"
+        footer={
+          <div className="flex w-full flex-col-reverse gap-3 sm:flex-row">
+            <button
+              onClick={handleClosePendingDeviation}
+              disabled={deviationSubmitting}
+              className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-all duration-200 hover:border-gray-400 hover:bg-gray-50 disabled:opacity-50"
+            >
+              Abbrechen
+            </button>
+            <button
+              onClick={confirmDeviationReason}
+              disabled={deviationSubmitting || deviationReason.trim() === ""}
+              className="flex-1 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-all duration-200 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {pendingDeviation?.action === "check_in"
+                ? "Mit Begründung einstempeln"
+                : "Mit Begründung ausstempeln"}
+            </button>
+          </div>
+        }
+      >
+        <div className="py-2">
+          <p className="text-sm text-gray-600">
+            {pendingDeviation?.action === "check_in" ? (
+              <>
+                Du stempelst
+                {pendingDeviation?.deviationMinutes ? (
+                  <span className="font-medium text-gray-900">
+                    {" "}
+                    {pendingDeviation.deviationMinutes} Minuten
+                  </span>
+                ) : (
+                  " deutlich"
+                )}{" "}
+                vor deinem geplanten Dienstbeginn
+                {pendingDeviation?.plannedTime
+                  ? ` (${pendingDeviation.plannedTime} Uhr)`
+                  : ""}{" "}
+                ein.
+              </>
+            ) : (
+              <>
+                Du stempelst
+                {pendingDeviation?.deviationMinutes ? (
+                  <span className="font-medium text-gray-900">
+                    {" "}
+                    {pendingDeviation.deviationMinutes} Minuten
+                  </span>
+                ) : (
+                  " deutlich"
+                )}{" "}
+                nach deinem geplanten Dienstende
+                {pendingDeviation?.plannedTime
+                  ? ` (${pendingDeviation.plannedTime} Uhr)`
+                  : ""}{" "}
+                aus.
+              </>
+            )}{" "}
+            Bitte gib einen kurzen Grund an. Er wird im Audit-Trail der Sitzung
+            gespeichert.
+          </p>
+          <label
+            htmlFor="deviation-reason"
+            className="mt-4 block text-xs font-medium text-gray-700"
+          >
+            Grund
+          </label>
+          <textarea
+            id="deviation-reason"
+            value={deviationReason}
+            onChange={(e) => setDeviationReason(e.target.value)}
+            disabled={deviationSubmitting}
+            placeholder="z. B. Elterngespräch lief länger"
             rows={3}
             className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-gray-500 focus:ring-1 focus:ring-gray-500 focus:outline-none disabled:opacity-50"
           />

--- a/frontend/src/app/api/time-tracking/check-in/route.ts
+++ b/frontend/src/app/api/time-tracking/check-in/route.ts
@@ -2,6 +2,8 @@ import { proxyPost } from "~/lib/route-proxy.server";
 
 interface CheckInRequest {
   status: "present" | "home_office";
+  /** Optional F9 deviation reason, sent after a deviation_reason_required conflict. */
+  reason?: string;
 }
 
 /**

--- a/frontend/src/app/api/time-tracking/check-out/route.test.ts
+++ b/frontend/src/app/api/time-tracking/check-out/route.test.ts
@@ -112,3 +112,27 @@ describe("POST /api/time-tracking/check-out", () => {
     expect(json.data).toEqual(mockCheckOutData);
   });
 });
+
+describe("POST /api/time-tracking/check-out with F9 reason", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(defaultSession);
+  });
+
+  it("forwards the deviation reason to the backend", async () => {
+    mockApiPost.mockResolvedValueOnce({ data: { session_id: 123 } });
+
+    const request = createMockRequest("/api/time-tracking/check-out", {
+      method: "POST",
+      body: { reason: "Elterngespräch lief länger" },
+    });
+    const response = await POST(request, createMockContext());
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/time-tracking/check-out",
+      "test-token",
+      { reason: "Elterngespräch lief länger" },
+    );
+    expect(response.status).toBe(200);
+  });
+});

--- a/frontend/src/app/api/time-tracking/check-out/route.ts
+++ b/frontend/src/app/api/time-tracking/check-out/route.ts
@@ -2,16 +2,25 @@ import type { NextRequest } from "next/server";
 import { apiPost } from "~/lib/api-helpers.server";
 import { createPostHandler } from "~/lib/route-wrapper.server";
 
+interface CheckOutRequest {
+  reason?: string;
+}
+
 /**
  * POST /api/time-tracking/check-out
- * Check out from work
+ * Check out from work. The body is optional; `reason` carries the F9
+ * deviation reason when the backend demanded one. Without a reason the
+ * request is forwarded body-less, exactly like before the F9 extension.
  */
-export const POST = createPostHandler<unknown, never>(
-  async (_request: NextRequest, _body: never, token: string) => {
-    const response = await apiPost<{ data: unknown }>(
-      "/api/time-tracking/check-out",
-      token,
-    );
+export const POST = createPostHandler<unknown, CheckOutRequest>(
+  async (_request: NextRequest, body: CheckOutRequest, token: string) => {
+    const response = body.reason
+      ? await apiPost<{ data: unknown }>(
+          "/api/time-tracking/check-out",
+          token,
+          { reason: body.reason },
+        )
+      : await apiPost<{ data: unknown }>("/api/time-tracking/check-out", token);
     return response.data;
   },
 );

--- a/frontend/src/lib/time-tracking-api.ts
+++ b/frontend/src/lib/time-tracking-api.ts
@@ -35,6 +35,12 @@ interface ApiResponse<T> {
  */
 export const REOPEN_STATUS_CONFLICT_CODE = "reopen_status_conflict";
 export const PLANNED_START_NOT_REACHED_CODE = "planned_start_not_reached";
+/**
+ * Stable error code surfaced when a check-in/check-out deviates from the
+ * planned shift window by more than the configured tolerance (F9). The page
+ * prompts for a reason and retries the same stamp with `reason` set.
+ */
+export const DEVIATION_REASON_REQUIRED_CODE = "deviation_reason_required";
 
 /**
  * Update session request body
@@ -136,21 +142,25 @@ class TimeTrackingService {
     }
   }
 
-  async checkIn(status: "present" | "home_office"): Promise<WorkSession> {
+  async checkIn(
+    status: "present" | "home_office",
+    reason?: string,
+  ): Promise<WorkSession> {
     const result = await this.request<WorkSession>(
       "/check-in",
       "POST",
       "Failed to check in",
-      { status },
+      reason ? { status, reason } : { status },
     );
     return mapWorkSessionResponse(result.data as never);
   }
 
-  async checkOut(): Promise<WorkSession> {
+  async checkOut(reason?: string): Promise<WorkSession> {
     const result = await this.request<WorkSession>(
       "/check-out",
       "POST",
       "Failed to check out",
+      reason ? { reason } : undefined,
     );
     return mapWorkSessionResponse(result.data as never);
   }


### PR DESCRIPTION
## Worum es geht

Rückmeldung aus der OGS-Leitung zur Zeiterfassung (F9): Wer früher kommt oder später geht, sammelt heute unbemerkt Stunden. Dieser PR führt eine per Schule zuschaltbare Begründungspflicht ein: Weicht das Ein- oder Ausstempeln um mehr als ein Toleranzfenster vom geplanten Schichtfenster des Tages ab, verlangt das System eine Begründung, die im Audit-Log der Sitzung landet. Zusätzlich wird die bestehende Notes-Pflicht bei Selbstbearbeitung eigener Zeiten von Statuswechseln auf Zeitfeld-Änderungen ausgedehnt (F8-Lücke).

Referenz für das Soll-Zeitfenster ist der Dienstplan (`schedule.staff_shifts`), weil nur er echte Start- und Endzeiten kennt: beim Einstempeln zählt der Start der frühesten Schicht des Tages, beim Ausstempeln das Ende der spätesten. Ohne geplante Schicht greift keine Pflicht (kein Plan, keine Abweichung). Verspätetes Kommen und früheres Gehen bleiben bewusst ungesperrt, denn F9 zielt wörtlich auf "früher kommen oder später gehen"; fehlende Zeit ist ohnehin im Saldo sichtbar.

## Settings (Registry, kein Env-Var)

| Key | Typ | Default |
|---|---|---|
| `operations.time_tracking_require_deviation_reason` | boolean | `false` |
| `operations.time_tracking_deviation_tolerance_minutes` | number, Range 0 bis 120, sichtbar nur bei aktiver Pflicht (DependsOn) | `15` |

Der Default 15 spiegelt die feste 15-Minuten-Toleranz der Frontend-Ampel (`getDeltaStatus`), damit Ampel und Begründungspflicht dieselbe Schwelle meinen.

## Änderungen im Detail

**Backend**
- `work_session_service.go`: F9-Prüfung in `CheckIn`/`CheckOut` (`detectPlannedDeviation`), strukturierter Fehler `DeviationReasonRequiredError`, Persistenz der Begründung als `audit.work_session_edits`-Eintrag (neue Konstante `deviation_reason`; old/new tragen Plan- und Ist-Uhrzeit, die Notiz die Begründung). Stempel und Audit-Zeile teilen die Tenant-Transaktion des Handlers. F8: `UpdateSession` verlangt bei aktivem Setting Notes für Änderungen an `check_in_time`, `check_out_time`, `break_minutes` und Einzelpausen; ein unveränderter Resend löst nie aus.
- Bewusste Ausnahmen: Der Reopen-Pfad (versehentliches Ausstempeln) und `EnsureCheckedIn` (NFC-Auto-Stempel beim Aufsichtsstart) umgehen die Sperre; beide Flows können keine Begründung einsammeln, und ein verweigerter Auto-Stempel hinterließe eine Aufsicht ohne Arbeitssitzung.
- Wire-Format nach dem Reopen-Vorbild: `POST /check-in` und `/check-out` nehmen ein optionales `reason`-Feld an; Abweichungen antworten mit 409 und Code `deviation_reason_required` plus `action`, `planned_time`, `actual_time`, `deviation_minutes` in den Details. `/check-out` toleriert weiterhin leere Bodies (Bestandsclients unverändert). Kein neuer Endpunkt, `/api/iot/*` unberührt (PyrePortal nicht betroffen).
- `CheckOut` nutzt jetzt die injizierbare Uhr `s.now()` statt `time.Now()` (produktiv identisch, testbar deterministisch).

**Frontend**
- Stempeluhr fängt den neuen Code ab und öffnet einen Begründungsdialog im Stil des bestehenden Reopen-Status-Dialogs ("Du stempelst N Minuten nach deinem geplanten Dienstende (HH:MM Uhr) aus"), Submit erst mit Grund; der Retry sendet denselben Stempel mit `reason`. Bei fehlgeschlagenem Retry bleibt der Dialog offen.
- `check-out`-Proxy reicht den optionalen Body weiter; ohne `reason` bleibt der Aufruf exakt wie bisher (Bestandstest unverändert grün).

## Tests

- Service-Ebene (Tabellen-Tests, injizierte Uhr): innerhalb/außerhalb Toleranz, mit/ohne Begründung inkl. Audit-Inhalt, kein Plan, Setting aus (inkl. "kein Shift-Lookup"), späteste/früheste Schicht als Referenz, Late-Arrival ungesperrt, Reopen- und EnsureCheckedIn-Bypass, F8-Gate in beide Richtungen.
- API-Ebene: 409-Wire-Format (Code + Details) für beide Stempelrichtungen, `reason`-Durchreichung, leerer und kaputter Body.
- Settings: Registrierung, Typ, Default, Range, DependsOn in `defaults_test.go`.
- Frontend: 4 neue Vitest-Fälle (Dialog öffnet mit Abweichungstext, Retry mit Grund für beide Richtungen, Dialog bleibt bei Fehler offen); neue Proxy-Route-Testfälle.
- Neu: `frontend/e2e/time-tracking-deviation.spec.ts` (Playwright, kompletter F9-Flow inkl. Audit-Prüfung und Gegentest mit deaktiviertem Setting).
- `go test ./...` grün (ein bekannter Contention-Flake in `database/repositories/platform`, isoliert grün); `golangci-lint` 0 Issues; `pnpm run check`, `knip`, `test:run` grün bis auf den vorbestehenden, lokal Locale-abhängigen `chart.test.tsx` (auf sauberem development identisch, in CI grün).

**Hinweis zu bestehenden Tests:** Die Signaturen `CheckIn`/`CheckOut` haben einen `reason`-Parameter bekommen. Bestehende Test-Aufrufstellen und Interface-Mocks wurden ausschließlich mechanisch um das neue Argument erweitert (Compile-Anpassung nach Refactor, keine Assertion geändert); der Settings-Mock `wsMockSettingsResolver` kann jetzt zusätzlich `ResolveInt`.

## Manuell verifiziert (lokaler Stack)

Kompletter Roundtrip am laufenden System: Setting aktiviert, Schicht angelegt, spätes Ausstempeln zeigt den Dialog mit Abweichung in Minuten und Planzeit, Submit erst mit Grund möglich, danach Audit-Eintrag `deviation_reason` mit Plan-/Ist-Uhrzeit, Begründung und `is_self_edit` sichtbar; mit deaktiviertem Setting läuft derselbe Stempelvorgang ohne Dialog durch. Screenshot des Dialogs folgt als Kommentar.

Teil der Planung-Redesign-Umsetzung (Inkrement 6A, `docs/planung-redesign/docs/08-zeiterfassung.md`); der OriginChip-Teil (6B) folgt separat, die Umstellung der Soll-Quelle ist ausdrücklich nicht Teil dieses PRs.
