### PR TITLE
feat(time-tracking): OriginChip benennt die Soll-Quelle (Inkrement 6B)

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -29,6 +29,7 @@ import {
   ChartTooltipContent,
 } from "~/components/ui/chart";
 import { Modal } from "~/components/ui/modal";
+import { OriginChip } from "~/components/ui/origin-chip";
 import {
   formatSignedDuration,
   ViewToggle,
@@ -1067,6 +1068,15 @@ function ClockInCard({
         {metrics ? (
           <div className="mt-5 border-t border-gray-100 pt-4">
             <ClockInStatsStrip metrics={metrics} />
+            {/* Herkunfts-Chip am Soll-Wert (Planung-Redesign, docs/04 6.2):
+                genau einer pro Oberfläche, solange die Soll-Quellen-Frage
+                offen ist. */}
+            <div className="mt-3 flex justify-end">
+              <OriginChip
+                label="Soll aus Arbeitszeitmodell"
+                title="Wochensaldo und Stundenkonto rechnen gegen das im Arbeitszeitmodell hinterlegte Soll."
+              />
+            </div>
           </div>
         ) : (
           <div className="mt-4 flex flex-col gap-y-1 text-xs text-gray-400 sm:flex-row sm:flex-wrap sm:gap-x-6">

--- a/frontend/src/components/staff/staff-time-views.tsx
+++ b/frontend/src/components/staff/staff-time-views.tsx
@@ -5,6 +5,7 @@
 // time-tracking-helpers formatters, so the visual treatment stays consistent
 // regardless of where the cards or calendar are rendered.
 
+import { OriginChip } from "~/components/ui/origin-chip";
 import { formatDuration } from "~/lib/time-tracking-helpers";
 import {
   computeStaffMetrics,
@@ -86,43 +87,53 @@ export function KpiCards({
   });
 
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-      <KpiCard
-        label="Diese Woche"
-        primary={formatDuration(metrics.weekIst)}
-        secondary={`von ${formatDuration(metrics.weekSoll)} Soll`}
-        progressPct={weekPct}
-        color={getDeltaStatus(metrics.weekDelta)}
-      />
-      <KpiCard
-        label="Dieser Monat"
-        primary={formatDuration(metrics.monthIst)}
-        secondary={`von ${formatDuration(metrics.monthSoll)} Soll`}
-        progressPct={monthPct}
-        color={monthDeltaColor}
-      />
-      <KpiCard
-        label="Überstunden Monat"
-        primary={formatSignedDuration(metrics.monthDelta)}
-        secondary={
-          metrics.monthDelta === 0
-            ? "ausgeglichen"
-            : metrics.monthDelta > 0
-              ? "Überstunden"
-              : "Minusstunden"
-        }
-        color={monthDeltaColor}
-      />
-      <KpiCard
-        label="Stundenkonto"
-        primary={formatSignedDuration(metrics.accountBalance)}
-        secondary={
-          metrics.accountBalance === 0
-            ? `Soll und Ist ausgeglichen seit ${accountStartLabel}`
-            : `seit ${accountStartLabel}`
-        }
-        color={accountColor}
-      />
+    <div className="space-y-2">
+      {/* Herkunfts-Chip am Soll-Wert (Planung-Redesign, docs/04 6.2): genau
+          einer pro Oberfläche, solange die Soll-Quellen-Frage offen ist. */}
+      <div className="flex justify-end">
+        <OriginChip
+          label="Soll aus Arbeitszeitmodell"
+          title="Wochensaldo und Stundenkonto rechnen gegen das im Arbeitszeitmodell hinterlegte Soll."
+        />
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard
+          label="Diese Woche"
+          primary={formatDuration(metrics.weekIst)}
+          secondary={`von ${formatDuration(metrics.weekSoll)} Soll`}
+          progressPct={weekPct}
+          color={getDeltaStatus(metrics.weekDelta)}
+        />
+        <KpiCard
+          label="Dieser Monat"
+          primary={formatDuration(metrics.monthIst)}
+          secondary={`von ${formatDuration(metrics.monthSoll)} Soll`}
+          progressPct={monthPct}
+          color={monthDeltaColor}
+        />
+        <KpiCard
+          label="Überstunden Monat"
+          primary={formatSignedDuration(metrics.monthDelta)}
+          secondary={
+            metrics.monthDelta === 0
+              ? "ausgeglichen"
+              : metrics.monthDelta > 0
+                ? "Überstunden"
+                : "Minusstunden"
+          }
+          color={monthDeltaColor}
+        />
+        <KpiCard
+          label="Stundenkonto"
+          primary={formatSignedDuration(metrics.accountBalance)}
+          secondary={
+            metrics.accountBalance === 0
+              ? `Soll und Ist ausgeglichen seit ${accountStartLabel}`
+              : `seit ${accountStartLabel}`
+          }
+          color={accountColor}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/staff/zeiterfassung-tab.tsx
+++ b/frontend/src/components/staff/zeiterfassung-tab.tsx
@@ -28,10 +28,10 @@ import { StaffSessionTable } from "./staff-session-table";
 import { KpiCards, ViewToggle, type ViewMode } from "./staff-time-views";
 
 // Zeiterfassung tab. Day-row table comparing Soll vs Ist for each day in
-// the visible window (week or month). Click on a row opens a read-only
-// detail dialog. Inline corrections by the admin are blocked until the
-// time_tracking:manage endpoint ships in Tranche 1 (#1369); the dialog
-// surfaces this constraint instead of pretending to save.
+// the visible window (week or month). A row click expands the read-only
+// audit history; the pencil action opens admin-session-edit-modal, where
+// corrections and backfills go through the time_tracking:manage endpoints
+// with a mandatory audit reason.
 export function ZeiterfassungTab({ staffId }: { readonly staffId: string }) {
   const today = useMemo(() => new Date(), []);
 

--- a/frontend/src/components/ui/origin-chip.stories.tsx
+++ b/frontend/src/components/ui/origin-chip.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { OriginChip } from "./origin-chip";
+
+const meta = {
+  title: "components/ui/OriginChip",
+  component: OriginChip,
+  args: {
+    label: "Soll aus Arbeitszeitmodell",
+  },
+} satisfies Meta<typeof OriginChip>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithTooltip: Story = {
+  args: {
+    label: "Soll aus Arbeitszeitmodell",
+    title:
+      "Wochensaldo und Stundenkonto rechnen gegen das im Arbeitszeitmodell hinterlegte Soll.",
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    label: "Bedarf: Anmeldung HJ1",
+    icon: (
+      <svg width="12" height="12" viewBox="0 0 24 24" aria-hidden="true">
+        <circle
+          cx="12"
+          cy="12"
+          r="9"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        />
+        <path
+          d="M12 7v5l3 3"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        />
+      </svg>
+    ),
+  },
+};

--- a/frontend/src/components/ui/origin-chip.test.tsx
+++ b/frontend/src/components/ui/origin-chip.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { OriginChip } from "./origin-chip";
+
+describe("OriginChip", () => {
+  it("renders the source label as muted text without any brand color", () => {
+    render(<OriginChip label="Soll aus Arbeitszeitmodell" />);
+
+    const chip = screen.getByText("Soll aus Arbeitszeitmodell");
+    expect(chip).toBeInTheDocument();
+    // Anatomy from docs/04-designsprache.md 6.2: neutral grays only.
+    expect(chip.className).toContain("text-gray-600");
+    expect(chip.className).toContain("border-gray-200");
+    expect(chip.className).toContain("bg-gray-50");
+    expect(chip.className).toContain("rounded-full");
+  });
+
+  it("exposes the long form as a native tooltip", () => {
+    render(
+      <OriginChip
+        label="Soll aus Arbeitszeitmodell"
+        title="Wochensaldo und Stundenkonto rechnen gegen das im Arbeitszeitmodell hinterlegte Soll."
+      />,
+    );
+
+    expect(screen.getByText("Soll aus Arbeitszeitmodell")).toHaveAttribute(
+      "title",
+      "Wochensaldo und Stundenkonto rechnen gegen das im Arbeitszeitmodell hinterlegte Soll.",
+    );
+  });
+
+  it("renders an optional leading icon", () => {
+    render(
+      <OriginChip
+        label="Quelle"
+        icon={<svg data-testid="chip-icon" width="12" height="12" />}
+      />,
+    );
+
+    expect(screen.getByTestId("chip-icon")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/origin-chip.tsx
+++ b/frontend/src/components/ui/origin-chip.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+interface OriginChipProps {
+  /** Short source label, e.g. "Soll aus Arbeitszeitmodell". */
+  readonly label: string;
+  /** Optional long-form explanation, shown as native tooltip. */
+  readonly title?: string;
+  /** Optional 12px leading icon. */
+  readonly icon?: ReactNode;
+  readonly className?: string;
+}
+
+/**
+ * OriginChip names the data source of a figure ("Herkunfts-Chip"). It is
+ * deliberately dosed: the planning redesign allows it at exactly three
+ * spots — the Betreuungsplan header, the InstanceDetailSlideOver, and the
+ * Soll value of the time-tracking surfaces (docs/planung-redesign/docs/
+ * 04-designsprache.md section 6.2). Do not scatter it across arbitrary
+ * figures.
+ */
+export function OriginChip({ label, title, icon, className }: OriginChipProps) {
+  return (
+    <span
+      title={title}
+      className={`inline-flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[11px] text-gray-600 ${className ?? ""}`}
+    >
+      {icon}
+      {label}
+    </span>
+  );
+}


### PR DESCRIPTION
## Worum es geht

Die Zeiterfassung rechnet Wochensaldo und Stundenkonto gegen das Arbeitszeitmodell (`config.staff_work_schedules`), der neue Dienstplan plant aber in `schedule.staff_shifts`. Welche Quelle langfristig das Soll liefert, ist eine offene Product-Owner-Frage. Bis zur Entscheidung macht dieser PR den Übergangsstand sichtbar: Ein dezenter Herkunfts-Chip "Soll aus Arbeitszeitmodell" steht neben dem Soll-Wert, mit Tooltip-Langform. Kein Rechenweg ändert sich; der Chip benennt nur die Quelle.

## Änderungen

- **Neuer Kit-Baustein `ui/origin-chip.tsx`** (+ Test + Stories): grauer Pill-Chip (`rounded-full border-gray-200 bg-gray-50 text-[11px] text-gray-600`), optionales 12px-Icon, optionaler Tooltip. Bewusst dosiert: Die Planung-Redesign-Spezifikation erlaubt ihn an genau drei Standorten (Betreuungsplan-Kopfzeile, InstanceDetailSlideOver, Soll-Wert der Zeiterfassung); er wird nicht generisch an Kennzahlen gestreut. Props sind generisch (label, title, icon), keine Domänenbegriffe.
- **Selbstbedienung `/time-tracking`**: genau ein Chip unter dem Stats-Strip der Stempeluhr.
- **Admin-Sicht (Zeiterfassungs-Tab der Mitarbeiterdetailseite)**: genau ein Chip im Kopf der KPI-Karten (`KpiCards` in `staff-time-views.tsx`; einziger Konsument ist der Tab, die Übersicht nutzt nur die Einzelkarte und bleibt chipfrei).
- **`zeiterfassung-tab.tsx`**: veralteter Kommentar entfernt, der behauptete, der `time_tracking:manage`-Korrektur-Endpunkt sei noch nicht ausgeliefert; die Admin-Korrektur über `admin-session-edit-modal` existiert längst.

KPI-Karten, Fortschrittsbalken und Ampelfarben bleiben unverändert; Wochensaldo und Stundenkonto rechnen nachweislich weiter gegen `config.staff_work_schedules` (kein stiller Quellenwechsel, keine Backend-Änderung).

## Design-Abweichungen (frontend-ui-kit.md, Owner-Entscheidung Planung-Redesign 2026-07)

- Neuer Kit-Baustein `OriginChip`: Herkunfts-Kennzeichnung fehlt im Kit; Erweiterung gemäß "Kit gaps"-Abschnitt der Regel, Spezifikation in `docs/planung-redesign/docs/04-designsprache.md` Abschnitt 6.2. Der Baustein wird von den kommenden Planungs-Screens (Betreuungsplan-Kopfzeile, InstanceDetailSlideOver) wiederverwendet; wer zuerst liefert, legt ihn an.

## Tests

- `origin-chip.test.tsx`: Anatomie (neutrale Grautöne, kein Farbtext), Tooltip-Langform, optionales Icon.
- Bestehende Suiten (`staff-time-views`, `zeiterfassung-tab`, `page.test.tsx`) unverändert grün; `pnpm run check`, `knip` und `test:run` grün bis auf den vorbestehenden, lokal Locale-abhängigen `chart.test.tsx` (in CI grün, von diesem PR unabhängig).
- Visuell am lokalen Stack geprüft: je Oberfläche genau ein Chip, rechtsbündig am Soll-Wert, keine Layout-Verschiebung der Karten. Screenshots folgen als Kommentar.

Teil der Planung-Redesign-Umsetzung (Inkrement 6B, `docs/planung-redesign/docs/08-zeiterfassung.md` Abschnitt 3.2). Die Umstellung der Soll-Quelle auf `schedule.staff_shifts` ist ausdrücklich nicht Teil dieses PRs (offene Frage 1 der Synthese); sobald sie fällt, wechselt nur der Chip-Text auf "Soll aus Dienstplan".
