### PR TITLE
fix(header): enlarge brand logo so star tip stays visible

### DIFF
--- a/frontend/src/components/dashboard/header/brand-link.tsx
+++ b/frontend/src/components/dashboard/header/brand-link.tsx
@@ -32,9 +32,9 @@ export function BrandLink({
         <Image
           src="/images/moto_transparent.webp"
           alt=""
-          width={44}
-          height={32}
-          className="h-6 w-9 object-contain sm:h-8 sm:w-11"
+          width={56}
+          height={40}
+          className="h-8 w-11 object-contain sm:h-10 sm:w-14"
           priority
         />
       </div>


### PR DESCRIPTION
## Problem

Since the branding update on Jul 12 (1a603e73e), the header logo renders at only 24px (mobile) / 32px (desktop). At that size the star's thin tip dissolves into antialiasing and the logo looks cut off at the top ([reported on staging](https://test.staging.moto-app.de/ogs-groups)).

Analysis showed nothing is actually clipped: the rendered logo is pixel-identical to the full asset. The tip is simply sub-pixel at ~30px height. Before Jul 12 the logo rendered at 36px tall, where the tip was still visible.

## Fix

Bump the header logo in `brand-link.tsx` from `h-6 w-9 sm:h-8 sm:w-11` to `h-8 w-11 sm:h-10 sm:w-14` (the size already used on the auth screens), with `Image` width/height props raised to 56×40 so Next serves a matching optimized source. The header rows (48–64px incl. scrolled state) have room for it.

## Verification

- brand-link + header tests pass (26/26)
- `pnpm run check` clean

@fl0r14n28 flagging you since the small size came from the Jul 12 branding review — shout if it was intentional.