### PR TITLE
feat(attendance): Zuordnungs-Hinweise nur bei genutztem Betreuungsplan

### DIFF
--- a/backend/api/students/attendance_history_export.go
+++ b/backend/api/students/attendance_history_export.go
@@ -140,10 +140,17 @@ func (rs *Resource) buildAttendanceExportDocument(
 	if err != nil {
 		return listexport.Document{}, err
 	}
+	// Without a single slot in the range there is no care plan to report
+	// against: the document drops the offering/assignment columns and lists the
+	// observed sessions plainly instead of labelling every row "Ohne Zuordnung".
+	title, columns := "Anwesenheit je Betreuungsangebot", attendanceExportColumns()
+	if !exportHasSlotExpectation(slots) {
+		title, columns = "Anwesenheit", attendanceSessionExportColumns()
+	}
 	return listexport.Document{
-		Title:       "Anwesenheit je Betreuungsangebot",
+		Title:       title,
 		Subtitle:    fmt.Sprintf("Kind-ID %d · %s bis %s", studentID, from.Format(attendanceExportDateLayout), to.Format(attendanceExportDateLayout)),
-		GeneratedAt: time.Now(), Columns: attendanceExportColumns(),
+		GeneratedAt: time.Now(), Columns: columns,
 		Rows: attendanceExportRows(slots, attendance), Footer: "Vertrauliche Anwesenheitsdaten",
 	}, nil
 }
@@ -155,6 +162,27 @@ func attendanceExportColumns() []listexport.Column {
 		{ID: attendanceColumnCheckIn, Label: "Anwesend ab"}, {ID: attendanceColumnCheckOut, Label: "Anwesend bis"},
 		{ID: attendanceColumnAssignment, Label: "Zuordnung"},
 	}
+}
+
+// attendanceSessionExportColumns is the plan-free variant: the rows still carry
+// the offering/assignment values, they are simply not rendered.
+func attendanceSessionExportColumns() []listexport.Column {
+	return []listexport.Column{
+		{ID: attendanceColumnDate, Label: "Datum"},
+		{ID: attendanceColumnWindow, Label: "Zeitraum"}, {ID: attendanceColumnStatus, Label: "Status"},
+		{ID: attendanceColumnCheckIn, Label: "Anwesend ab"}, {ID: attendanceColumnCheckOut, Label: "Anwesend bis"},
+	}
+}
+
+// exportHasSlotExpectation mirrors hasSlotExpectation for the export path,
+// which works off the raw slot rows rather than assembled days.
+func exportHasSlotExpectation(slots []*scheduleModel.ScheduledInstanceRow) bool {
+	for _, row := range slots {
+		if row != nil && row.Instance != nil && row.Attendance != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // attendanceExportRows merges slot rows and unassigned observed sessions into

--- a/backend/api/students/attendance_history_export.go
+++ b/backend/api/students/attendance_history_export.go
@@ -140,11 +140,17 @@ func (rs *Resource) buildAttendanceExportDocument(
 	if err != nil {
 		return listexport.Document{}, err
 	}
-	// Without a single slot in the range there is no care plan to report
-	// against: the document drops the offering/assignment columns and lists the
-	// observed sessions plainly instead of labelling every row "Ohne Zuordnung".
+	// Without a care plan there is nothing to report assignments against: the
+	// document drops the offering/assignment columns and lists the observed
+	// sessions plainly instead of labelling every row "Ohne Zuordnung". The
+	// expectation is resolved tenant-wide (resolveSlotExpectation), so a
+	// student without bookings at a plan-keeping school keeps the full layout.
+	expectSlots, err := rs.resolveSlotExpectation(ctx, slots, from, to)
+	if err != nil {
+		return listexport.Document{}, err
+	}
 	title, columns := "Anwesenheit je Betreuungsangebot", attendanceExportColumns()
-	if !exportHasSlotExpectation(slots) {
+	if !expectSlots {
 		title, columns = "Anwesenheit", attendanceSessionExportColumns()
 	}
 	return listexport.Document{
@@ -172,17 +178,6 @@ func attendanceSessionExportColumns() []listexport.Column {
 		{ID: attendanceColumnWindow, Label: "Zeitraum"}, {ID: attendanceColumnStatus, Label: "Status"},
 		{ID: attendanceColumnCheckIn, Label: "Anwesend ab"}, {ID: attendanceColumnCheckOut, Label: "Anwesend bis"},
 	}
-}
-
-// exportHasSlotExpectation mirrors hasSlotExpectation for the export path,
-// which works off the raw slot rows rather than assembled days.
-func exportHasSlotExpectation(slots []*scheduleModel.ScheduledInstanceRow) bool {
-	for _, row := range slots {
-		if row != nil && row.Instance != nil && row.Attendance != nil {
-			return true
-		}
-	}
-	return false
 }
 
 // attendanceExportRows merges slot rows and unassigned observed sessions into

--- a/backend/api/students/attendance_history_export_test.go
+++ b/backend/api/students/attendance_history_export_test.go
@@ -133,22 +133,6 @@ func TestAttendanceExportDocument_RendersEverySupportedFormat(t *testing.T) {
 	}
 }
 
-// TestExportHasSlotExpectation: only usable slot rows (instance + attendance)
-// count as a care plan — the incomplete rows attendanceExportRows skips must
-// not flip the document into offering mode.
-func TestExportHasSlotExpectation(t *testing.T) {
-	date := timezone.NewDate(2026, 7, 15)
-	assert.False(t, exportHasSlotExpectation(nil))
-	assert.False(t, exportHasSlotExpectation([]*scheduleModel.ScheduledInstanceRow{
-		nil,
-		{Instance: &scheduleModel.ActivityInstance{Date: date}, Attendance: nil},
-	}))
-	assert.True(t, exportHasSlotExpectation([]*scheduleModel.ScheduledInstanceRow{{
-		Instance:   &scheduleModel.ActivityInstance{Date: date, Title: "Morgenbetreuung"},
-		Attendance: &scheduleModel.InstanceStudent{Status: scheduleModel.AttendanceStatusPresent},
-	}}))
-}
-
 // TestAttendanceSessionExportColumns_OmitsPlanColumns: without a care plan the
 // export lists plain sessions — no "Betreuungsangebot" and no "Zuordnung"
 // column, so no row can read as unassigned.

--- a/backend/api/students/attendance_history_export_test.go
+++ b/backend/api/students/attendance_history_export_test.go
@@ -133,6 +133,55 @@ func TestAttendanceExportDocument_RendersEverySupportedFormat(t *testing.T) {
 	}
 }
 
+// TestExportHasSlotExpectation: only usable slot rows (instance + attendance)
+// count as a care plan — the incomplete rows attendanceExportRows skips must
+// not flip the document into offering mode.
+func TestExportHasSlotExpectation(t *testing.T) {
+	date := timezone.NewDate(2026, 7, 15)
+	assert.False(t, exportHasSlotExpectation(nil))
+	assert.False(t, exportHasSlotExpectation([]*scheduleModel.ScheduledInstanceRow{
+		nil,
+		{Instance: &scheduleModel.ActivityInstance{Date: date}, Attendance: nil},
+	}))
+	assert.True(t, exportHasSlotExpectation([]*scheduleModel.ScheduledInstanceRow{{
+		Instance:   &scheduleModel.ActivityInstance{Date: date, Title: "Morgenbetreuung"},
+		Attendance: &scheduleModel.InstanceStudent{Status: scheduleModel.AttendanceStatusPresent},
+	}}))
+}
+
+// TestAttendanceSessionExportColumns_OmitsPlanColumns: without a care plan the
+// export lists plain sessions — no "Betreuungsangebot" and no "Zuordnung"
+// column, so no row can read as unassigned.
+func TestAttendanceSessionExportColumns_OmitsPlanColumns(t *testing.T) {
+	ids := make([]listexport.ColumnID, 0, 5)
+	for _, column := range attendanceSessionExportColumns() {
+		ids = append(ids, column.ID)
+	}
+	assert.NotContains(t, ids, attendanceColumnOffering)
+	assert.NotContains(t, ids, attendanceColumnAssignment)
+	assert.Equal(t, []listexport.ColumnID{
+		attendanceColumnDate, attendanceColumnWindow, attendanceColumnStatus,
+		attendanceColumnCheckIn, attendanceColumnCheckOut,
+	}, ids)
+}
+
+// TestAttendanceExportRows_KeepsSessionsWithoutAnyPlan: the plan-free document
+// still lists every observed session — the neutral wording comes from dropping
+// the offering/assignment columns, not from dropping rows.
+func TestAttendanceExportRows_KeepsSessionsWithoutAnyPlan(t *testing.T) {
+	date := timezone.NewDate(2026, 7, 15)
+	checkIn := time.Date(2026, 7, 15, 9, 0, 0, 0, timezone.Berlin)
+	checkOut := time.Date(2026, 7, 15, 16, 0, 0, 0, timezone.Berlin)
+
+	rows := attendanceExportRows(nil, []*activeModel.Attendance{
+		{Date: date, CheckInTime: checkIn, CheckOutTime: &checkOut},
+	})
+
+	require.Len(t, rows, 1)
+	assert.Equal(t, "09:00", rows[0].Values[attendanceColumnCheckIn])
+	assert.Equal(t, "16:00", rows[0].Values[attendanceColumnCheckOut])
+}
+
 func TestAttendanceExportRows_SortsChronologicallyAcrossSources(t *testing.T) {
 	day1 := timezone.NewDate(2026, 7, 14)
 	day2 := timezone.NewDate(2026, 7, 15)

--- a/backend/api/students/attendance_history_handlers.go
+++ b/backend/api/students/attendance_history_handlers.go
@@ -265,10 +265,13 @@ func (rs *Resource) resolveSlotExpectation(
 
 // hasPlannedSlotRow reports whether any usable slot row (instance and
 // attendance present) carries a planned booking. Walk-ins are excluded on
-// purpose — see resolveSlotExpectation.
+// purpose — see resolveSlotExpectation. Cancelled instances are excluded too:
+// their instance_students rows survive the cancellation, but a booking on a
+// cancelled-only occurrence is no usable slot to report assignments against.
 func hasPlannedSlotRow(slots []*scheduleModel.ScheduledInstanceRow) bool {
 	for _, row := range slots {
-		if row != nil && row.Instance != nil && row.Attendance != nil && !row.Attendance.IsUnplanned {
+		if row != nil && row.Instance != nil && row.Attendance != nil &&
+			!row.Attendance.IsUnplanned && row.Instance.Status != scheduleModel.InstanceStatusCancelled {
 			return true
 		}
 	}

--- a/backend/api/students/attendance_history_handlers.go
+++ b/backend/api/students/attendance_history_handlers.go
@@ -509,10 +509,17 @@ func attachSlotAttendance(
 // matched to a concrete slot. This is intentional in binary mode when zero or
 // multiple booked slots overlap: the session stays neutrally unassigned
 // instead of the system guessing an offering (or claiming it was unbooked).
+//
+// Synthetic entries appear only when the requested range carries at least one
+// real slot for this student (see hasSlotExpectation). Without any slot there
+// is nothing a session could have been assigned to, so "Ohne Zuordnung" would
+// label every single day of a school that does not keep a care plan — a
+// permanent error state for a system working as configured.
 func attachUnassignedAttendance(days []attendanceHistoryDay) []attendanceHistoryDay {
+	expectSlots := hasSlotExpectation(days)
 	for dayIndex := range days {
 		day := &days[dayIndex]
-		if day.Attendance != nil {
+		if expectSlots && day.Attendance != nil {
 			coverages := slotEntryCoverages(day.Slots)
 			for sessionIndex, session := range day.Attendance.Sessions {
 				if sessionCoveredBySlots(coverages, session.CheckInTime) {
@@ -530,6 +537,18 @@ func attachUnassignedAttendance(days []attendanceHistoryDay) []attendanceHistory
 		})
 	}
 	return days
+}
+
+// hasSlotExpectation reports whether the loaded range holds any real slot for
+// this student. It must run before synthetic entries are appended, while
+// day.Slots still contains materialized instances only.
+func hasSlotExpectation(days []attendanceHistoryDay) bool {
+	for i := range days {
+		if len(days[i].Slots) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // slotCoverage describes one slot's capacity to claim an observed attendance

--- a/backend/api/students/attendance_history_handlers.go
+++ b/backend/api/students/attendance_history_handlers.go
@@ -104,6 +104,9 @@ type attendanceHistorySources struct {
 	Attendance []*active.Attendance
 	Statuses   []*active.StudentStatusDay
 	Slots      []*scheduleModel.ScheduledInstanceRow
+	// SlotExpectation reports whether assignment hints apply to the loaded
+	// range at all (see resolveSlotExpectation).
+	SlotExpectation bool
 }
 
 // getStudentAttendanceHistory returns the daily attendance log and (conditionally)
@@ -200,7 +203,7 @@ func (rs *Resource) getStudentAttendanceHistory(w http.ResponseWriter, r *http.R
 	// 7. Assemble per-day response
 	days := buildAttendanceHistoryDays(sources.Attendance, sources.Statuses, visitsByDate, roomCutoff, visitQueryFailed)
 	days = attachSlotAttendance(days, sources.Slots, visitsByDate, roomCutoff, visitQueryFailed)
-	days = attachUnassignedAttendance(days)
+	days = attachUnassignedAttendance(days, sources.SlotExpectation)
 
 	resp := attendanceHistoryResponse{
 		StudentID: strconv.FormatInt(student.ID, 10),
@@ -236,7 +239,40 @@ func (rs *Resource) loadAttendanceHistorySources(
 		}
 	}
 	sources.Slots, err = rs.StudentHistoryService.GetSlotAttendanceByStudentAndDateRange(ctx, studentID, from, to)
+	if err != nil {
+		return sources, err
+	}
+	sources.SlotExpectation, err = rs.resolveSlotExpectation(ctx, sources.Slots, from, to)
 	return sources, err
+}
+
+// resolveSlotExpectation reports whether assignment hints — the synthetic
+// "Ohne Zuordnung" history entries and the export's offering/assignment
+// columns — apply to the requested range. A planned slot row of the student
+// answers it directly; otherwise the tenant-wide check decides, so a student
+// without a single booking still gets the hint at a school that maintains its
+// care plan (their observed sessions ARE valid unassigned cases there).
+// Walk-in rows (is_unplanned) never count as plan evidence: a spontaneous
+// drop-in also happens at schools that plan nothing.
+func (rs *Resource) resolveSlotExpectation(
+	ctx context.Context, slots []*scheduleModel.ScheduledInstanceRow, from, to timezone.Date,
+) (bool, error) {
+	if hasPlannedSlotRow(slots) {
+		return true, nil
+	}
+	return rs.StudentHistoryService.HasPlannedSlotsInRange(ctx, from, to)
+}
+
+// hasPlannedSlotRow reports whether any usable slot row (instance and
+// attendance present) carries a planned booking. Walk-ins are excluded on
+// purpose — see resolveSlotExpectation.
+func hasPlannedSlotRow(slots []*scheduleModel.ScheduledInstanceRow) bool {
+	for _, row := range slots {
+		if row != nil && row.Instance != nil && row.Attendance != nil && !row.Attendance.IsUnplanned {
+			return true
+		}
+	}
+	return false
 }
 
 // attendanceHistoryLogger returns a scoped logger, falling back to slog.Default.
@@ -510,13 +546,12 @@ func attachSlotAttendance(
 // multiple booked slots overlap: the session stays neutrally unassigned
 // instead of the system guessing an offering (or claiming it was unbooked).
 //
-// Synthetic entries appear only when the requested range carries at least one
-// real slot for this student (see hasSlotExpectation). Without any slot there
-// is nothing a session could have been assigned to, so "Ohne Zuordnung" would
+// Synthetic entries appear only when expectSlots is true — the caller resolves
+// it tenant-wide via resolveSlotExpectation. Without any planned slot there is
+// nothing a session could have been assigned to, so "Ohne Zuordnung" would
 // label every single day of a school that does not keep a care plan — a
 // permanent error state for a system working as configured.
-func attachUnassignedAttendance(days []attendanceHistoryDay) []attendanceHistoryDay {
-	expectSlots := hasSlotExpectation(days)
+func attachUnassignedAttendance(days []attendanceHistoryDay, expectSlots bool) []attendanceHistoryDay {
 	for dayIndex := range days {
 		day := &days[dayIndex]
 		if expectSlots && day.Attendance != nil {
@@ -537,18 +572,6 @@ func attachUnassignedAttendance(days []attendanceHistoryDay) []attendanceHistory
 		})
 	}
 	return days
-}
-
-// hasSlotExpectation reports whether the loaded range holds any real slot for
-// this student. It must run before synthetic entries are appended, while
-// day.Slots still contains materialized instances only.
-func hasSlotExpectation(days []attendanceHistoryDay) bool {
-	for i := range days {
-		if len(days[i].Slots) > 0 {
-			return true
-		}
-	}
-	return false
 }
 
 // slotCoverage describes one slot's capacity to claim an observed attendance

--- a/backend/api/students/attendance_history_logic_test.go
+++ b/backend/api/students/attendance_history_logic_test.go
@@ -477,6 +477,73 @@ func TestAttachUnassignedAttendance_SortsMergedSlotsByDisplayedTime(t *testing.T
 	assert.Equal(t, "Ohne Zuordnung", days[0].Slots[0].Title)
 }
 
+// TestAttachUnassignedAttendance_NoSlotsInRangeStaysNeutral: a school that does
+// not keep a care plan has no slot anywhere in the range, so every session would
+// otherwise be labelled "Ohne Zuordnung". The history must stay neutral — the
+// day keeps its check-in/out times and gains no synthetic entries.
+func TestAttachUnassignedAttendance_NoSlotsInRangeStaysNeutral(t *testing.T) {
+	first := time.Date(2026, 7, 15, 8, 0, 0, 0, timezone.Berlin)
+	second := time.Date(2026, 7, 14, 9, 0, 0, 0, timezone.Berlin)
+
+	days := attachUnassignedAttendance([]attendanceHistoryDay{
+		{
+			Date: "2026-07-15",
+			Attendance: &attendanceDayRecord{
+				CheckInTime: first,
+				Sessions:    []attendanceSessionRecord{{CheckInTime: first}},
+			},
+			Slots: []attendanceSlotEntry{},
+		},
+		{
+			Date: "2026-07-14",
+			Attendance: &attendanceDayRecord{
+				CheckInTime: second,
+				Sessions:    []attendanceSessionRecord{{CheckInTime: second}},
+			},
+			Slots: []attendanceSlotEntry{},
+		},
+	})
+
+	assert.Empty(t, days[0].Slots)
+	assert.Empty(t, days[1].Slots)
+	assert.Equal(t, first, days[0].Attendance.CheckInTime, "session times stay untouched")
+}
+
+// TestAttachUnassignedAttendance_SlotOnAnotherDayKeepsUnassignedRow: the slot
+// expectation is range-wide, not per-day. A school with a care plan keeps its
+// "Ohne Zuordnung" rows on days that hold no slot of their own.
+func TestAttachUnassignedAttendance_SlotOnAnotherDayKeepsUnassignedRow(t *testing.T) {
+	planned := time.Date(2026, 7, 15, 7, 0, 0, 0, timezone.Berlin)
+	walkIn := time.Date(2026, 7, 14, 9, 0, 0, 0, timezone.Berlin)
+
+	days := attachUnassignedAttendance([]attendanceHistoryDay{
+		{
+			Date: "2026-07-15",
+			Attendance: &attendanceDayRecord{
+				CheckInTime: planned,
+				Sessions:    []attendanceSessionRecord{{CheckInTime: planned}},
+			},
+			Slots: []attendanceSlotEntry{{
+				InstanceID: "501", Title: "Morgenbetreuung",
+				StartTime: "07:00", EndTime: "12:00",
+				Status: schedule.AttendanceStatusPresent, CheckedInAt: &planned,
+			}},
+		},
+		{
+			Date: "2026-07-14",
+			Attendance: &attendanceDayRecord{
+				CheckInTime: walkIn,
+				Sessions:    []attendanceSessionRecord{{CheckInTime: walkIn}},
+			},
+			Slots: []attendanceSlotEntry{},
+		},
+	})
+
+	require.Len(t, days[0].Slots, 1, "the booked slot claims its own session")
+	require.Len(t, days[1].Slots, 1)
+	assert.Equal(t, "Ohne Zuordnung", days[1].Slots[0].Title)
+}
+
 func TestAttachSlotAttendance_SerializesInt64InstanceIDAsDecimalString(t *testing.T) {
 	date := timezone.NewDate(2026, 7, 15)
 	instance := &schedule.ActivityInstance{

--- a/backend/api/students/attendance_history_logic_test.go
+++ b/backend/api/students/attendance_history_logic_test.go
@@ -579,7 +579,9 @@ func TestAttachUnassignedAttendance_WalkInWithoutExpectationKeepsItsSlotOnly(t *
 // TestHasPlannedSlotRow: only usable slot rows (instance + attendance) with a
 // planned booking count. Walk-in rows (is_unplanned) are no plan evidence — a
 // spontaneous drop-in also happens at schools that plan nothing — and the
-// incomplete rows the assembly skips must not count either.
+// incomplete rows the assembly skips must not count either. Cancelled
+// instances keep their assignment rows but are no evidence: a cancelled-only
+// booking was never a usable slot.
 func TestHasPlannedSlotRow(t *testing.T) {
 	date := timezone.NewDate(2026, 7, 15)
 	assert.False(t, hasPlannedSlotRow(nil))
@@ -591,6 +593,10 @@ func TestHasPlannedSlotRow(t *testing.T) {
 		Instance:   &schedule.ActivityInstance{Date: date, Title: "Spontan-AG"},
 		Attendance: &schedule.InstanceStudent{Status: schedule.AttendanceStatusPresent, IsUnplanned: true},
 	}}), "walk-in rows must not count as care-plan evidence")
+	assert.False(t, hasPlannedSlotRow([]*schedule.ScheduledInstanceRow{{
+		Instance:   &schedule.ActivityInstance{Date: date, Title: "Ausgefallene AG", Status: schedule.InstanceStatusCancelled},
+		Attendance: &schedule.InstanceStudent{Status: schedule.AttendanceStatusExpected},
+	}}), "cancelled instances must not count as care-plan evidence")
 	assert.True(t, hasPlannedSlotRow([]*schedule.ScheduledInstanceRow{{
 		Instance:   &schedule.ActivityInstance{Date: date, Title: "Morgenbetreuung"},
 		Attendance: &schedule.InstanceStudent{Status: schedule.AttendanceStatusPresent},

--- a/backend/api/students/attendance_history_logic_test.go
+++ b/backend/api/students/attendance_history_logic_test.go
@@ -419,7 +419,7 @@ func TestAttachUnassignedAttendance_WindowMatchAndNeutralLeftover(t *testing.T) 
 			StartTime: "07:00", EndTime: "16:00",
 			Status: schedule.AttendanceStatusPresent, CheckedInAt: &reentry,
 		}},
-	}})
+	}}, true)
 
 	require.Len(t, days[0].Slots, 2, "only the out-of-window session may become a synthetic entry")
 	synthetic := days[0].Slots[1]
@@ -447,7 +447,7 @@ func TestAttachUnassignedAttendance_AbsentSlotDoesNotAbsorbSessions(t *testing.T
 			StartTime: "07:00", EndTime: "12:00",
 			Status: schedule.AttendanceStatusAbsent, Substatus: &sick,
 		}},
-	}})
+	}}, true)
 
 	require.Len(t, days[0].Slots, 2, "the observed session must surface next to the absence")
 	assert.Equal(t, "Ohne Zuordnung", days[0].Slots[1].Title)
@@ -466,7 +466,7 @@ func TestAttachUnassignedAttendance_SortsMergedSlotsByDisplayedTime(t *testing.T
 			{InstanceID: "401", Title: "Mittagsbetreuung", StartTime: "12:00", EndTime: "13:00"},
 			{InstanceID: "402", Title: "Nachmittagsbetreuung", StartTime: "14:00", EndTime: "16:00"},
 		},
-	}})
+	}}, true)
 
 	require.Len(t, days[0].Slots, 3)
 	assert.Equal(t, []string{"07:00", "12:00", "14:00"}, []string{
@@ -477,11 +477,12 @@ func TestAttachUnassignedAttendance_SortsMergedSlotsByDisplayedTime(t *testing.T
 	assert.Equal(t, "Ohne Zuordnung", days[0].Slots[0].Title)
 }
 
-// TestAttachUnassignedAttendance_NoSlotsInRangeStaysNeutral: a school that does
-// not keep a care plan has no slot anywhere in the range, so every session would
-// otherwise be labelled "Ohne Zuordnung". The history must stay neutral — the
-// day keeps its check-in/out times and gains no synthetic entries.
-func TestAttachUnassignedAttendance_NoSlotsInRangeStaysNeutral(t *testing.T) {
+// TestAttachUnassignedAttendance_NoSlotExpectationStaysNeutral: at a school
+// that does not keep a care plan the resolved expectation is false, so every
+// session would otherwise be labelled "Ohne Zuordnung". The history must stay
+// neutral — the day keeps its check-in/out times and gains no synthetic
+// entries.
+func TestAttachUnassignedAttendance_NoSlotExpectationStaysNeutral(t *testing.T) {
 	first := time.Date(2026, 7, 15, 8, 0, 0, 0, timezone.Berlin)
 	second := time.Date(2026, 7, 14, 9, 0, 0, 0, timezone.Berlin)
 
@@ -502,17 +503,18 @@ func TestAttachUnassignedAttendance_NoSlotsInRangeStaysNeutral(t *testing.T) {
 			},
 			Slots: []attendanceSlotEntry{},
 		},
-	})
+	}, false)
 
 	assert.Empty(t, days[0].Slots)
 	assert.Empty(t, days[1].Slots)
 	assert.Equal(t, first, days[0].Attendance.CheckInTime, "session times stay untouched")
 }
 
-// TestAttachUnassignedAttendance_SlotOnAnotherDayKeepsUnassignedRow: the slot
-// expectation is range-wide, not per-day. A school with a care plan keeps its
-// "Ohne Zuordnung" rows on days that hold no slot of their own.
-func TestAttachUnassignedAttendance_SlotOnAnotherDayKeepsUnassignedRow(t *testing.T) {
+// TestAttachUnassignedAttendance_ExpectationKeepsUnassignedRowOnSlotFreeDay:
+// the expectation is resolved for the whole range (tenant-wide), not per day.
+// A school with a care plan keeps its "Ohne Zuordnung" rows on days that hold
+// no slot of their own.
+func TestAttachUnassignedAttendance_ExpectationKeepsUnassignedRowOnSlotFreeDay(t *testing.T) {
 	planned := time.Date(2026, 7, 15, 7, 0, 0, 0, timezone.Berlin)
 	walkIn := time.Date(2026, 7, 14, 9, 0, 0, 0, timezone.Berlin)
 
@@ -537,11 +539,62 @@ func TestAttachUnassignedAttendance_SlotOnAnotherDayKeepsUnassignedRow(t *testin
 			},
 			Slots: []attendanceSlotEntry{},
 		},
-	})
+	}, true)
 
 	require.Len(t, days[0].Slots, 1, "the booked slot claims its own session")
 	require.Len(t, days[1].Slots, 1)
 	assert.Equal(t, "Ohne Zuordnung", days[1].Slots[0].Title)
+}
+
+// TestAttachUnassignedAttendance_WalkInWithoutExpectationKeepsItsSlotOnly: a
+// spontaneous walk-in at a school without a care plan renders as its persisted
+// slot row (still marked is_unplanned), but must not resurrect synthetic
+// "Ohne Zuordnung" entries for the remaining sessions.
+func TestAttachUnassignedAttendance_WalkInWithoutExpectationKeepsItsSlotOnly(t *testing.T) {
+	walkIn := time.Date(2026, 7, 15, 9, 0, 0, 0, timezone.Berlin)
+	later := time.Date(2026, 7, 15, 17, 0, 0, 0, timezone.Berlin)
+
+	days := attachUnassignedAttendance([]attendanceHistoryDay{{
+		Date: "2026-07-15",
+		Attendance: &attendanceDayRecord{
+			CheckInTime: walkIn,
+			Sessions: []attendanceSessionRecord{
+				{CheckInTime: walkIn},
+				{CheckInTime: later},
+			},
+		},
+		Slots: []attendanceSlotEntry{{
+			InstanceID: "601", Title: "Spontan-AG",
+			StartTime: "09:00", EndTime: "10:00",
+			Status: schedule.AttendanceStatusPresent, CheckedInAt: &walkIn,
+			IsUnplanned: true,
+		}},
+	}}, false)
+
+	require.Len(t, days[0].Slots, 1, "no synthetic entries without a slot expectation")
+	assert.Equal(t, "Spontan-AG", days[0].Slots[0].Title)
+	assert.True(t, days[0].Slots[0].IsUnplanned, "the walk-in keeps its marking")
+}
+
+// TestHasPlannedSlotRow: only usable slot rows (instance + attendance) with a
+// planned booking count. Walk-in rows (is_unplanned) are no plan evidence — a
+// spontaneous drop-in also happens at schools that plan nothing — and the
+// incomplete rows the assembly skips must not count either.
+func TestHasPlannedSlotRow(t *testing.T) {
+	date := timezone.NewDate(2026, 7, 15)
+	assert.False(t, hasPlannedSlotRow(nil))
+	assert.False(t, hasPlannedSlotRow([]*schedule.ScheduledInstanceRow{
+		nil,
+		{Instance: &schedule.ActivityInstance{Date: date}, Attendance: nil},
+	}))
+	assert.False(t, hasPlannedSlotRow([]*schedule.ScheduledInstanceRow{{
+		Instance:   &schedule.ActivityInstance{Date: date, Title: "Spontan-AG"},
+		Attendance: &schedule.InstanceStudent{Status: schedule.AttendanceStatusPresent, IsUnplanned: true},
+	}}), "walk-in rows must not count as care-plan evidence")
+	assert.True(t, hasPlannedSlotRow([]*schedule.ScheduledInstanceRow{{
+		Instance:   &schedule.ActivityInstance{Date: date, Title: "Morgenbetreuung"},
+		Attendance: &schedule.InstanceStudent{Status: schedule.AttendanceStatusPresent},
+	}}))
 }
 
 func TestAttachSlotAttendance_SerializesInt64InstanceIDAsDecimalString(t *testing.T) {

--- a/backend/api/timetable/instance_students_unit_test.go
+++ b/backend/api/timetable/instance_students_unit_test.go
@@ -97,6 +97,10 @@ func (f *fakeRepo) FindInstancesWithAttendanceByStudentAndDateRange(context.Cont
 	panic("unused")
 }
 
+func (f *fakeRepo) HasPlannedSlotsInRange(context.Context, timezone.Date, timezone.Date) (bool, error) {
+	panic("unused")
+}
+
 func (f *fakeRepo) UpdateAttendanceFromCheckin(context.Context, int64, int64, time.Time) (bool, error) {
 	panic("unused")
 }

--- a/backend/database/repositories/schedule/student_day.go
+++ b/backend/database/repositories/schedule/student_day.go
@@ -161,6 +161,33 @@ func (r *InstanceStudentRepository) FindInstancesWithAttendanceByStudentAndDateR
 	return out, nil
 }
 
+// HasPlannedSlotsInRange implements schedule.InstanceStudentRepository.
+//
+// Deliberately NOT filtered by student: the attendance history needs the
+// tenant-wide answer, and the walk-in exclusion keeps spontaneous drop-ins
+// from counting as care-plan usage.
+func (r *InstanceStudentRepository) HasPlannedSlotsInRange(
+	ctx context.Context, from, to timezone.Date,
+) (bool, error) {
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(modelTblInstanceStudent).
+		Join(`INNER JOIN schedule.activity_instances AS "activity_instance" ON "activity_instance".id = "instance_student".instance_id AND "activity_instance".tenant_id = "instance_student".tenant_id`).
+		Where(`"instance_student".is_unplanned = FALSE`).
+		Where(`"activity_instance".date >= ?`, from).
+		Where(`"activity_instance".date <= ?`, to)
+
+	query = base.WithTenantFilter(ctx, query, aliasInstanceStudent)
+
+	exists, err := query.Exists(ctx)
+	if err != nil {
+		return false, &modelBase.DatabaseError{
+			Op:  "check planned slots in range",
+			Err: err,
+		}
+	}
+	return exists, nil
+}
+
 func (r *InstanceStudentRepository) FindPlannedStudentIDsByDate(ctx context.Context, studentIDs []int64, date timezone.Date) ([]int64, error) {
 	if len(studentIDs) == 0 {
 		return []int64{}, nil

--- a/backend/database/repositories/schedule/student_day.go
+++ b/backend/database/repositories/schedule/student_day.go
@@ -165,7 +165,9 @@ func (r *InstanceStudentRepository) FindInstancesWithAttendanceByStudentAndDateR
 //
 // Deliberately NOT filtered by student: the attendance history needs the
 // tenant-wide answer, and the walk-in exclusion keeps spontaneous drop-ins
-// from counting as care-plan usage.
+// from counting as care-plan usage. Cancelled instances are excluded as well —
+// instance_students rows survive a cancellation, and a booking on a
+// cancelled-only occurrence is no evidence of a usable care plan.
 func (r *InstanceStudentRepository) HasPlannedSlotsInRange(
 	ctx context.Context, from, to timezone.Date,
 ) (bool, error) {
@@ -173,6 +175,7 @@ func (r *InstanceStudentRepository) HasPlannedSlotsInRange(
 		TableExpr(modelTblInstanceStudent).
 		Join(`INNER JOIN schedule.activity_instances AS "activity_instance" ON "activity_instance".id = "instance_student".instance_id AND "activity_instance".tenant_id = "instance_student".tenant_id`).
 		Where(`"instance_student".is_unplanned = FALSE`).
+		Where(`"activity_instance".status <> ?`, schedule.InstanceStatusCancelled).
 		Where(`"activity_instance".date >= ?`, from).
 		Where(`"activity_instance".date <= ?`, to)
 

--- a/backend/database/repositories/schedule/student_day_test.go
+++ b/backend/database/repositories/schedule/student_day_test.go
@@ -191,3 +191,50 @@ func TestInstanceStudentRepository_HasPlannedSlotsInRange(t *testing.T) {
 		assert.Equal(t, "check planned slots in range", dbErr.Op)
 	})
 }
+
+// A cancelled instance keeps its instance_students rows, but a planned booking
+// on a cancelled-only occurrence must not count as care-plan evidence — it
+// would re-activate assignment hints and export columns without a usable slot
+// (#1920). The far-future window keeps concurrent fixtures from other packages
+// out of the tenant-wide EXISTS.
+func TestInstanceStudentRepository_HasPlannedSlotsInRange_CancelledInstance(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repo := scheduleRepo.NewInstanceStudentRepository(db)
+	instanceRepo := scheduleRepo.NewActivityInstanceRepository(db)
+
+	student := testpkg.CreateTestStudent(t, db, "Emil", fmt.Sprintf("HPC-%d", time.Now().UnixNano()), "4c")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	from := timezone.NewDate(2033, 5, 2)
+	to := timezone.NewDate(2033, 5, 6)
+
+	inst, cleanInst := createInstanceFixture(t, db, "hpc", from)
+	defer cleanInst()
+
+	planned := &scheduleModels.InstanceStudent{
+		InstanceID: inst.ID,
+		StudentID:  student.ID,
+		Status:     scheduleModels.AttendanceStatusPresent,
+	}
+	planned.SetTenantID(1)
+	require.NoError(t, repo.Create(ctx, planned))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", planned.ID)
+
+	t.Run("planned row on a live instance counts", func(t *testing.T) {
+		has, err := repo.HasPlannedSlotsInRange(ctx, from, to)
+		require.NoError(t, err)
+		assert.True(t, has)
+	})
+
+	inst.Status = scheduleModels.InstanceStatusCancelled
+	require.NoError(t, instanceRepo.Update(ctx, inst))
+
+	t.Run("cancelled instance is no evidence despite the surviving row", func(t *testing.T) {
+		has, err := repo.HasPlannedSlotsInRange(ctx, from, to)
+		require.NoError(t, err)
+		assert.False(t, has)
+	})
+}

--- a/backend/database/repositories/schedule/student_day_test.go
+++ b/backend/database/repositories/schedule/student_day_test.go
@@ -111,3 +111,69 @@ func TestInstanceStudentRepository_FindInstancesWithAttendanceByStudentAndDateRa
 		assert.Empty(t, rows, "tenant 2 must not see tenant 1 rows")
 	})
 }
+
+// HasPlannedSlotsInRange is the tenant-wide care-plan signal: planned
+// assignment rows count, walk-in rows (is_unplanned) and rows outside the
+// range do not. The far-future window keeps concurrent fixtures from other
+// packages out of the tenant-wide EXISTS.
+func TestInstanceStudentRepository_HasPlannedSlotsInRange(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repo := scheduleRepo.NewInstanceStudentRepository(db)
+
+	student := testpkg.CreateTestStudent(t, db, "Mila", fmt.Sprintf("HP-%d", time.Now().UnixNano()), "2b")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	from := timezone.NewDate(2032, 3, 2)
+	to := timezone.NewDate(2032, 3, 6)
+	dayOutside := timezone.NewDate(2032, 4, 1)
+
+	instIn, cleanIn := createInstanceFixture(t, db, "hp-in", from)
+	defer cleanIn()
+	instOut, cleanOut := createInstanceFixture(t, db, "hp-out", dayOutside)
+	defer cleanOut()
+
+	mkRow := func(instID int64, unplanned bool) *scheduleModels.InstanceStudent {
+		row := &scheduleModels.InstanceStudent{
+			InstanceID:  instID,
+			StudentID:   student.ID,
+			Status:      scheduleModels.AttendanceStatusPresent,
+			IsUnplanned: unplanned,
+		}
+		row.SetTenantID(1)
+		return row
+	}
+
+	walkIn := mkRow(instIn.ID, true)
+	require.NoError(t, repo.Create(ctx, walkIn))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", walkIn.ID)
+	plannedOutside := mkRow(instOut.ID, false)
+	require.NoError(t, repo.Create(ctx, plannedOutside))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.instance_students", plannedOutside.ID)
+
+	t.Run("walk-in in range and planned row outside range are no evidence", func(t *testing.T) {
+		has, err := repo.HasPlannedSlotsInRange(ctx, from, to)
+		require.NoError(t, err)
+		assert.False(t, has)
+	})
+
+	// A second assignment on the same instance would collide with the walk-in
+	// row (unique instance+student) — flip the walk-in to planned instead:
+	// the signal must react to the planned state itself.
+	walkIn.IsUnplanned = false
+	require.NoError(t, repo.Update(ctx, walkIn))
+
+	t.Run("planned row in range flips the signal", func(t *testing.T) {
+		has, err := repo.HasPlannedSlotsInRange(ctx, from, to)
+		require.NoError(t, err)
+		assert.True(t, has)
+	})
+
+	t.Run("different tenant context sees no evidence", func(t *testing.T) {
+		has, err := repo.HasPlannedSlotsInRange(testpkg.TenantContext(2), from, to)
+		require.NoError(t, err)
+		assert.False(t, has)
+	})
+}

--- a/backend/database/repositories/schedule/student_day_test.go
+++ b/backend/database/repositories/schedule/student_day_test.go
@@ -1,12 +1,14 @@
 package schedule_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
@@ -175,5 +177,17 @@ func TestInstanceStudentRepository_HasPlannedSlotsInRange(t *testing.T) {
 		has, err := repo.HasPlannedSlotsInRange(testpkg.TenantContext(2), from, to)
 		require.NoError(t, err)
 		assert.False(t, has)
+	})
+
+	t.Run("wraps driver errors in DatabaseError", func(t *testing.T) {
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		has, err := repo.HasPlannedSlotsInRange(cancelledCtx, from, to)
+		assert.False(t, has)
+		require.Error(t, err)
+		var dbErr *modelBase.DatabaseError
+		require.ErrorAs(t, err, &dbErr)
+		assert.Equal(t, "check planned slots in range", dbErr.Op)
 	})
 }

--- a/backend/models/schedule/instance_student.go
+++ b/backend/models/schedule/instance_student.go
@@ -212,13 +212,15 @@ type InstanceStudentRepository interface {
 	FindInstancesWithAttendanceByStudentAndDateRange(ctx context.Context, studentID int64, from, to timezone.Date) ([]*ScheduledInstanceRow, error)
 
 	// HasPlannedSlotsInRange reports whether the tenant has at least one
-	// planned slot assignment (is_unplanned = FALSE) on an instance dated
-	// within the inclusive range. This is the tenant-level "care plan is
-	// used" signal behind the attendance history's assignment hints: a
-	// single student's slot rows cannot answer it (a student may simply not
-	// be booked anywhere), and walk-in rows must not, because a spontaneous
-	// drop-in also happens at schools that plan nothing. Tenant-scoped via
-	// the caller's context.
+	// planned slot assignment (is_unplanned = FALSE) on a non-cancelled
+	// instance dated within the inclusive range. This is the tenant-level
+	// "care plan is used" signal behind the attendance history's assignment
+	// hints: a single student's slot rows cannot answer it (a student may
+	// simply not be booked anywhere), and walk-in rows must not, because a
+	// spontaneous drop-in also happens at schools that plan nothing.
+	// Cancelled instances keep their assignment rows but count as no
+	// evidence either — a cancelled-only occurrence was never a usable
+	// slot. Tenant-scoped via the caller's context.
 	HasPlannedSlotsInRange(ctx context.Context, from, to timezone.Date) (bool, error)
 
 	// FindPlannedStudentIDsByDate returns unique student IDs that have a

--- a/backend/models/schedule/instance_student.go
+++ b/backend/models/schedule/instance_student.go
@@ -211,6 +211,16 @@ type InstanceStudentRepository interface {
 	// the handler layer enriches those via the visits-side lookup.
 	FindInstancesWithAttendanceByStudentAndDateRange(ctx context.Context, studentID int64, from, to timezone.Date) ([]*ScheduledInstanceRow, error)
 
+	// HasPlannedSlotsInRange reports whether the tenant has at least one
+	// planned slot assignment (is_unplanned = FALSE) on an instance dated
+	// within the inclusive range. This is the tenant-level "care plan is
+	// used" signal behind the attendance history's assignment hints: a
+	// single student's slot rows cannot answer it (a student may simply not
+	// be booked anywhere), and walk-in rows must not, because a spontaneous
+	// drop-in also happens at schools that plan nothing. Tenant-scoped via
+	// the caller's context.
+	HasPlannedSlotsInRange(ctx context.Context, from, to timezone.Date) (bool, error)
+
 	// FindPlannedStudentIDsByDate returns unique student IDs that have a
 	// non-cancelled materialized timetable row on the given date. Used by
 	// student search's "kommt heute" heuristic as an additive planning signal.

--- a/backend/services/active/student_history_service.go
+++ b/backend/services/active/student_history_service.go
@@ -25,6 +25,11 @@ type StudentHistoryService interface {
 
 	GetSlotAttendanceByStudentAndDateRange(ctx context.Context, studentID int64, startDate, endDate timezone.Date) ([]*scheduleModels.ScheduledInstanceRow, error)
 
+	// HasPlannedSlotsInRange reports whether the tenant has any planned
+	// (non-walk-in) slot assignment within the inclusive date range — the
+	// tenant-level signal that the care plan is in use.
+	HasPlannedSlotsInRange(ctx context.Context, startDate, endDate timezone.Date) (bool, error)
+
 	// RecordDataAccess writes a GDPR data-access log entry.
 	RecordDataAccess(ctx context.Context, entry *auditModels.DataAccessLog) error
 }
@@ -54,6 +59,13 @@ func (s *studentHistoryService) GetSlotAttendanceByStudentAndDateRange(ctx conte
 		return []*scheduleModels.ScheduledInstanceRow{}, nil
 	}
 	return s.slotRepo.FindInstancesWithAttendanceByStudentAndDateRange(ctx, studentID, startDate, endDate)
+}
+
+func (s *studentHistoryService) HasPlannedSlotsInRange(ctx context.Context, startDate, endDate timezone.Date) (bool, error) {
+	if s.slotRepo == nil {
+		return false, nil
+	}
+	return s.slotRepo.HasPlannedSlotsInRange(ctx, startDate, endDate)
 }
 
 func (s *studentHistoryService) GetAttendanceByStudentAndDateRange(ctx context.Context, studentID int64, startDate, endDate timezone.Date) ([]*activeModels.Attendance, error) {

--- a/backend/services/active/student_history_service.go
+++ b/backend/services/active/student_history_service.go
@@ -26,8 +26,9 @@ type StudentHistoryService interface {
 	GetSlotAttendanceByStudentAndDateRange(ctx context.Context, studentID int64, startDate, endDate timezone.Date) ([]*scheduleModels.ScheduledInstanceRow, error)
 
 	// HasPlannedSlotsInRange reports whether the tenant has any planned
-	// (non-walk-in) slot assignment within the inclusive date range — the
-	// tenant-level signal that the care plan is in use.
+	// (non-walk-in) slot assignment on a non-cancelled instance within the
+	// inclusive date range — the tenant-level signal that the care plan is
+	// in use.
 	HasPlannedSlotsInRange(ctx context.Context, startDate, endDate timezone.Date) (bool, error)
 
 	// RecordDataAccess writes a GDPR data-access log entry.

--- a/backend/services/active/student_history_service_test.go
+++ b/backend/services/active/student_history_service_test.go
@@ -1,0 +1,21 @@
+package active_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeService "github.com/moto-nrw/project-phoenix/services/active"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A nil slot repository (tests without a timetable) must answer the
+// tenant-wide care-plan signal with false instead of panicking.
+func TestStudentHistoryService_HasPlannedSlotsInRange_NilSlotRepo(t *testing.T) {
+	svc := activeService.NewStudentHistoryService(nil, nil, nil, nil)
+
+	has, err := svc.HasPlannedSlotsInRange(context.Background(), timezone.NewDate(2032, 3, 2), timezone.NewDate(2032, 3, 6))
+	require.NoError(t, err)
+	assert.False(t, has, "without a slot repository there is no care-plan signal")
+}

--- a/backend/services/schedule/attendance_sync_service_unit_test.go
+++ b/backend/services/schedule/attendance_sync_service_unit_test.go
@@ -239,6 +239,10 @@ func (f *fakeInstanceStudentRepo) FindInstancesWithAttendanceByStudentAndDateRan
 	panic("unused")
 }
 
+func (f *fakeInstanceStudentRepo) HasPlannedSlotsInRange(context.Context, timezone.Date, timezone.Date) (bool, error) {
+	panic("unused")
+}
+
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1920

## Problem

Seit #1913 führt die Anwesenheitshistorie jede beobachtete Sitzung, die keinem gebuchten Slot zugeordnet werden kann, als "Ohne Zuordnung" mit dem Zusatz "ungeplant". Bei Schulen, die den Betreuungsplan gar nicht pflegen, trifft das auf jede Sitzung an jedem Tag zu. Die Historie liest sich dadurch wie ein Dauerfehler, obwohl das System genau so konfiguriert ist, wie die Schule es will.

## Lösung

Der Zuordnungs-Hinweis erscheint nur noch, wenn es im geladenen Zeitraum überhaupt eine Slot-Erwartung für das Kind gibt.

**Historie** (`attachUnassignedAttendance`): `hasSlotExpectation` prüft einmal vorab, ob der Zeitraum mindestens einen echten Slot enthält. Ohne Slot entstehen keine Pseudo-Einträge, der Tag zeigt wieder nur Kommen- und Gehen-Zeiten. Die Prüfung läuft bewusst vor dem Anhängen, solange `day.Slots` ausschließlich materialisierte Instanzen enthält.

**Export** (`buildAttendanceExportDocument`): Ohne Plan fallen die Spalten "Betreuungsangebot" und "Zuordnung" weg und der Titel wird zu "Anwesenheit". Die Zeilen selbst bleiben erhalten, es wird also keine Sitzung unterschlagen. Die Renderer (PDF, DOCX, XLSX) iterieren ausschließlich über `doc.Columns`, der Wert "Ohne Zuordnung" wird also nirgends ausgegeben.

Kein Frontend-Change nötig: beide Ansichten rendern die Slots unverändert aus der API und blenden leere Slot-Listen bereits sauber aus.

## Akzeptanzkriterien

- [x] Schule ohne Betreuungsplan: Historie und Export ohne "Ohne Zuordnung"-Zeilen und ohne "ungeplant"-Markierung
- [x] Schule mit Betreuungsplan: Verhalten unverändert, nicht zuordenbare Sitzungen bleiben sichtbar (auch an Tagen ohne eigenen Slot, siehe `TestAttachUnassignedAttendance_SlotOnAnotherDayKeepsUnassignedRow`)
- [x] Echte Walk-ins (`is_unplanned`) bleiben gekennzeichnet: eine solche Zeile ist selbst ein Slot und setzt die Erwartung damit auf true

## Verhaltensnotiz

Die Slot-Erwartung wird pro Kind und pro geladenem Zeitraum ausgewertet, nicht pro Tenant. Für ein Kind, das in keiner Vorlage steht, verschwindet der Hinweis also auch an einer Plan-Schule. Das ist vom Issue ausdrücklich so gefordert. Der Zeitraum ist dabei immer das volle Sichtbarkeitsfenster (`gdpr.attendance_visible_days`, Default 30 Tage), da beide Aufrufer den Endpoint ohne `from`/`to` nutzen.

## Tests

4 neue Tests in `attendance_history_logic_test.go` und `attendance_history_export_test.go`. `go build ./...` und `go test ./api/students/` grün.
