### PR TITLE
fix: unblock development CI (frontend Docker build + Sonar quality gate)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,13 +8,13 @@ RUN apk add --no-cache tzdata && \
 # Install dependencies needed for all stages
 FROM base AS deps
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile --prod
 
 # Development dependencies
 FROM base AS dev-deps
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Development stage

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -9,7 +9,7 @@ WORKDIR /app
 
 FROM base AS deps
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 FROM base AS builder

--- a/frontend/src/app/[tenant]/(protected)/profile/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/profile/page.test.tsx
@@ -415,9 +415,7 @@ describe("ProfilePage", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /passwort ändern/i }));
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByRole("button", { name: "Success" }));
-      });
+      fireEvent.click(await screen.findByRole("button", { name: "Success" }));
 
       await waitFor(() => {
         expect(screen.queryByTestId("password-modal")).not.toBeInTheDocument();

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
@@ -1032,10 +1032,8 @@ describe("StudentDetailPage", () => {
       });
 
       // Wait for active groups to load and select one
-      await waitFor(() => {
-        const select = screen.getByRole("combobox");
-        fireEvent.change(select, { target: { value: "1" } });
-      });
+      const select = await screen.findByRole("combobox");
+      fireEvent.change(select, { target: { value: "1" } });
 
       const confirmButton = screen.getByTestId("modal-confirm");
       await act(async () => {
@@ -1064,10 +1062,8 @@ describe("StudentDetailPage", () => {
       });
 
       // Select a room first
-      await waitFor(() => {
-        const select = screen.getByRole("combobox");
-        fireEvent.change(select, { target: { value: "1" } });
-      });
+      const select = await screen.findByRole("combobox");
+      fireEvent.change(select, { target: { value: "1" } });
 
       const confirmButton = screen.getByTestId("modal-confirm");
       await act(async () => {

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -2179,12 +2179,8 @@ describe("TimeTrackingPage", () => {
 
       render(<TimeTrackingPage />);
 
-      await waitFor(() => {
-        const endBreakBtn = screen.queryByLabelText("Pause beenden");
-        if (endBreakBtn) {
-          fireEvent.click(endBreakBtn);
-        }
-      });
+      const endBreakBtn = await screen.findByLabelText("Pause beenden");
+      fireEvent.click(endBreakBtn);
 
       // Verify test setup was correct - breaks were loaded
       expect(timeTrackingService.getSessionBreaks).toHaveBeenCalled();
@@ -2977,12 +2973,10 @@ describe("TimeTrackingPage", () => {
       await openEditModal(pastSession, { absences: [pastAbsence] });
       fireEvent.click(screen.getByText("Abwesenheit"));
 
-      await waitFor(() => {
-        const toggle = screen.getByRole("switch");
-        expect(toggle.getAttribute("aria-checked")).toBe("false");
-        fireEvent.click(toggle);
-        expect(toggle.getAttribute("aria-checked")).toBe("true");
-      });
+      const toggle = await screen.findByRole("switch");
+      expect(toggle.getAttribute("aria-checked")).toBe("false");
+      fireEvent.click(toggle);
+      expect(toggle.getAttribute("aria-checked")).toBe("true");
     });
   });
 

--- a/frontend/src/app/operator/announcements/page.test.tsx
+++ b/frontend/src/app/operator/announcements/page.test.tsx
@@ -281,10 +281,7 @@ describe("OperatorAnnouncementsPage", () => {
     }
 
     // Click edit
-    await waitFor(() => {
-      const editButton = screen.getByText("Bearbeiten");
-      fireEvent.click(editButton);
-    });
+    fireEvent.click(await screen.findByText("Bearbeiten"));
 
     await waitFor(() => {
       const textInputs = screen.getAllByRole("textbox");
@@ -338,10 +335,7 @@ describe("OperatorAnnouncementsPage", () => {
     // Open create modal
     fireEvent.click(screen.getByText("Neue Ankündigung"));
 
-    await waitFor(() => {
-      const severityButton = screen.getByText("Info");
-      fireEvent.click(severityButton);
-    });
+    fireEvent.click(await screen.findByText("Info"));
 
     // Dropdown should be open
     await waitFor(() => {
@@ -420,9 +414,7 @@ describe("OperatorAnnouncementsPage", () => {
       fireEvent.click(menuButtons[0]);
     }
 
-    await waitFor(() => {
-      fireEvent.click(screen.getByText("Löschen"));
-    });
+    fireEvent.click(await screen.findByText("Löschen"));
 
     await waitFor(() => {
       expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
@@ -872,9 +864,7 @@ describe("OperatorAnnouncementsPage", () => {
         fireEvent.click(menuButtons[0]);
       }
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Bearbeiten"));
-      });
+      fireEvent.click(await screen.findByText("Bearbeiten"));
 
       await waitFor(() => {
         expect(screen.getByTestId("modal")).toBeInTheDocument();
@@ -951,9 +941,7 @@ describe("OperatorAnnouncementsPage", () => {
       const menuButtons = screen.getAllByLabelText("Menü öffnen");
       fireEvent.click(menuButtons[0]!);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Bearbeiten"));
-      });
+      fireEvent.click(await screen.findByText("Bearbeiten"));
 
       await waitFor(() => {
         expect(screen.getByTestId("modal")).toBeInTheDocument();
@@ -1159,9 +1147,7 @@ describe("OperatorAnnouncementsPage", () => {
       const menuButtons = screen.getAllByLabelText("Menü öffnen");
       fireEvent.click(menuButtons[0]!);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Löschen"));
-      });
+      fireEvent.click(await screen.findByText("Löschen"));
 
       await waitFor(() => {
         expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
@@ -1192,9 +1178,7 @@ describe("OperatorAnnouncementsPage", () => {
       const menuButtons = screen.getAllByLabelText("Menü öffnen");
       fireEvent.click(menuButtons[0]!);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Löschen"));
-      });
+      fireEvent.click(await screen.findByText("Löschen"));
 
       await waitFor(() => {
         expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
@@ -1332,9 +1316,7 @@ describe("OperatorAnnouncementsPage", () => {
       const menuButtons = screen.getAllByLabelText("Menü öffnen");
       fireEvent.click(menuButtons[0]!);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Löschen"));
-      });
+      fireEvent.click(await screen.findByText("Löschen"));
 
       await waitFor(() => {
         expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
@@ -1415,9 +1397,7 @@ describe("OperatorAnnouncementsPage", () => {
       const menuButtons = screen.getAllByLabelText("Menü öffnen");
       fireEvent.click(menuButtons[0]!);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Bearbeiten"));
-      });
+      fireEvent.click(await screen.findByText("Bearbeiten"));
 
       await waitFor(() => {
         expect(screen.getByTestId("modal")).toBeInTheDocument();

--- a/frontend/src/app/operator/settings/page.test.tsx
+++ b/frontend/src/app/operator/settings/page.test.tsx
@@ -174,10 +174,7 @@ describe("OperatorSettingsPage", () => {
   it("updates profile on save", async () => {
     render(<OperatorSettingsPage />);
 
-    await waitFor(() => {
-      const editButton = screen.getByText("Bearbeiten");
-      fireEvent.click(editButton);
-    });
+    fireEvent.click(await screen.findByText("Bearbeiten"));
 
     const displayNameInput = screen.getByLabelText("Anzeigename");
     fireEvent.change(displayNameInput, { target: { value: "Jane Doe" } });
@@ -222,9 +219,7 @@ describe("OperatorSettingsPage", () => {
 
     render(<OperatorSettingsPage />);
 
-    await waitFor(() => {
-      fireEvent.click(screen.getByText("Bearbeiten"));
-    });
+    fireEvent.click(await screen.findByText("Bearbeiten"));
 
     const saveButton = screen.getByText("Speichern");
     fireEvent.click(saveButton);
@@ -241,9 +236,7 @@ describe("OperatorSettingsPage", () => {
   it("cancels editing and restores original values", async () => {
     render(<OperatorSettingsPage />);
 
-    await waitFor(() => {
-      fireEvent.click(screen.getByText("Bearbeiten"));
-    });
+    fireEvent.click(await screen.findByText("Bearbeiten"));
 
     const displayNameInput = screen.getByLabelText("Anzeigename");
     fireEvent.change(displayNameInput, { target: { value: "Changed Name" } });
@@ -294,9 +287,7 @@ describe("OperatorSettingsPage", () => {
     it("shows email change button when editing", async () => {
       render(<OperatorSettingsPage />);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Bearbeiten"));
-      });
+      fireEvent.click(await screen.findByText("Bearbeiten"));
 
       expect(screen.getByText("E-Mail ändern")).toBeInTheDocument();
     });
@@ -314,9 +305,7 @@ describe("OperatorSettingsPage", () => {
     it("opens email change dialog with form fields", async () => {
       render(<OperatorSettingsPage />);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Bearbeiten"));
-      });
+      fireEvent.click(await screen.findByText("Bearbeiten"));
 
       fireEvent.click(screen.getByText("E-Mail ändern"));
 
@@ -335,9 +324,7 @@ describe("OperatorSettingsPage", () => {
     it("submits email change request successfully", async () => {
       render(<OperatorSettingsPage />);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Bearbeiten"));
-      });
+      fireEvent.click(await screen.findByText("Bearbeiten"));
 
       fireEvent.click(screen.getByText("E-Mail ändern"));
 
@@ -377,9 +364,7 @@ describe("OperatorSettingsPage", () => {
     it("closes dialog after successful submission", async () => {
       render(<OperatorSettingsPage />);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Bearbeiten"));
-      });
+      fireEvent.click(await screen.findByText("Bearbeiten"));
 
       fireEvent.click(screen.getByText("E-Mail ändern"));
 
@@ -425,9 +410,7 @@ describe("OperatorSettingsPage", () => {
 
       render(<OperatorSettingsPage />);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Bearbeiten"));
-      });
+      fireEvent.click(await screen.findByText("Bearbeiten"));
 
       fireEvent.click(screen.getByText("E-Mail ändern"));
 
@@ -481,9 +464,7 @@ describe("OperatorSettingsPage", () => {
 
       render(<OperatorSettingsPage />);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Bearbeiten"));
-      });
+      fireEvent.click(await screen.findByText("Bearbeiten"));
 
       fireEvent.click(screen.getByText("E-Mail ändern"));
 
@@ -528,9 +509,7 @@ describe("OperatorSettingsPage", () => {
 
       render(<OperatorSettingsPage />);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Bearbeiten"));
-      });
+      fireEvent.click(await screen.findByText("Bearbeiten"));
 
       fireEvent.click(screen.getByText("E-Mail ändern"));
 
@@ -563,9 +542,7 @@ describe("OperatorSettingsPage", () => {
     it("closes dialog and resets fields on cancel", async () => {
       render(<OperatorSettingsPage />);
 
-      await waitFor(() => {
-        fireEvent.click(screen.getByText("Bearbeiten"));
-      });
+      fireEvent.click(await screen.findByText("Bearbeiten"));
 
       fireEvent.click(screen.getByText("E-Mail ändern"));
 

--- a/frontend/src/app/operator/suggestions/[id]/page.test.tsx
+++ b/frontend/src/app/operator/suggestions/[id]/page.test.tsx
@@ -642,10 +642,7 @@ describe("OperatorSuggestionDetailPage", () => {
     const deleteButton = screen.getByLabelText("Kommentar löschen");
     fireEvent.click(deleteButton);
 
-    await waitFor(() => {
-      const confirmButton = screen.getByTestId("confirm-button");
-      fireEvent.click(confirmButton);
-    });
+    fireEvent.click(await screen.findByTestId("confirm-button"));
 
     await waitFor(() => {
       expect(consoleError).toHaveBeenCalledWith("comment_delete_failed", {

--- a/frontend/src/components/admin/invitation-form.test.tsx
+++ b/frontend/src/components/admin/invitation-form.test.tsx
@@ -196,10 +196,8 @@ describe("InvitationForm", () => {
   it("validates role field", async () => {
     render(<InvitationForm />);
 
-    await waitFor(() => {
-      const emailInput = screen.getByTestId("invitation-email");
-      fireEvent.change(emailInput, { target: { value: "test@example.com" } });
-    });
+    const emailInput = await screen.findByTestId("invitation-email");
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
 
     const submitButton = screen.getByText("Einladung senden");
     fireEvent.click(submitButton);

--- a/frontend/src/components/admin/pending-invitations-list.test.tsx
+++ b/frontend/src/components/admin/pending-invitations-list.test.tsx
@@ -156,12 +156,10 @@ describe("PendingInvitationsList", () => {
   it("calls resendInvitation when resend button clicked", async () => {
     render(<PendingInvitationsList refreshKey={0} />);
 
-    await waitFor(() => {
-      const resendButtons = screen.getAllByText("Erneut");
-      // Invitations are sorted by expiration date (earliest first)
-      // ID 2 (expired) comes first, so click the second button for ID 1 (not expired)
-      fireEvent.click(resendButtons[1]!);
-    });
+    // Invitations are sorted by expiration date (earliest first)
+    // ID 2 (expired) comes first, so click the second button for ID 1 (not expired)
+    const resendButtons = await screen.findAllByText("Erneut");
+    fireEvent.click(resendButtons[1]!);
 
     await waitFor(() => {
       expect(mockResendInvitation).toHaveBeenCalledWith(1);
@@ -171,10 +169,8 @@ describe("PendingInvitationsList", () => {
   it("opens confirmation modal when delete button clicked", async () => {
     render(<PendingInvitationsList refreshKey={0} />);
 
-    await waitFor(() => {
-      const deleteButtons = screen.getAllByText("Löschen");
-      fireEvent.click(deleteButtons[0]!);
-    });
+    const deleteButtons = await screen.findAllByText("Löschen");
+    fireEvent.click(deleteButtons[0]!);
 
     await waitFor(() => {
       expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
@@ -185,16 +181,12 @@ describe("PendingInvitationsList", () => {
   it("calls revokeInvitation when confirm button clicked", async () => {
     render(<PendingInvitationsList refreshKey={0} />);
 
-    await waitFor(() => {
-      const deleteButtons = screen.getAllByText("Löschen");
-      // Click the second delete button (ID 1, non-expired)
-      fireEvent.click(deleteButtons[1]!);
-    });
+    // Click the second delete button (ID 1, non-expired)
+    const deleteButtons = await screen.findAllByText("Löschen");
+    fireEvent.click(deleteButtons[1]!);
 
-    await waitFor(() => {
-      const confirmButton = screen.getByTestId("confirm-button");
-      fireEvent.click(confirmButton);
-    });
+    const confirmButton = await screen.findByTestId("confirm-button");
+    fireEvent.click(confirmButton);
 
     await waitFor(() => {
       expect(mockRevokeInvitation).toHaveBeenCalledWith(1);

--- a/frontend/src/components/auth/invitation-accept-form.test.tsx
+++ b/frontend/src/components/auth/invitation-accept-form.test.tsx
@@ -162,12 +162,10 @@ describe("InvitationAcceptForm", () => {
       <InvitationAcceptForm token="test-token" invitation={mockInvitation} />,
     );
 
-    await waitFor(() => {
-      const firstNameInput =
-        screen.getByTestId<HTMLInputElement>("input-firstName");
-      fireEvent.change(firstNameInput, { target: { value: "Jane" } });
-      expect(firstNameInput.value).toBe("Jane");
-    });
+    const firstNameInput =
+      await screen.findByTestId<HTMLInputElement>("input-firstName");
+    fireEvent.change(firstNameInput, { target: { value: "Jane" } });
+    expect(firstNameInput.value).toBe("Jane");
   });
 
   it("renders without crashing when position is not provided", async () => {

--- a/frontend/src/components/groups/group-transfer-modal.test.tsx
+++ b/frontend/src/components/groups/group-transfer-modal.test.tsx
@@ -170,10 +170,8 @@ describe("GroupTransferModal", () => {
       />,
     );
 
-    await waitFor(() => {
-      const select = screen.getByRole("combobox");
-      fireEvent.change(select, { target: { value: "p1" } });
-    });
+    const select = await screen.findByRole("combobox");
+    fireEvent.change(select, { target: { value: "p1" } });
 
     const transferButton = screen.getByText("Übergeben");
     fireEvent.click(transferButton);
@@ -213,10 +211,8 @@ describe("GroupTransferModal", () => {
       />,
     );
 
-    await waitFor(() => {
-      const select = screen.getByRole("combobox");
-      fireEvent.change(select, { target: { value: "p1" } });
-    });
+    const select = await screen.findByRole("combobox");
+    fireEvent.change(select, { target: { value: "p1" } });
 
     const transferButton = screen.getByText("Übergeben");
     fireEvent.click(transferButton);
@@ -239,10 +235,8 @@ describe("GroupTransferModal", () => {
       />,
     );
 
-    await waitFor(() => {
-      const removeButton = screen.getByText("Entfernen");
-      fireEvent.click(removeButton);
-    });
+    const removeButton = await screen.findByText("Entfernen");
+    fireEvent.click(removeButton);
 
     await waitFor(() => {
       expect(mockOnCancelTransfer).toHaveBeenCalledWith("s1");
@@ -299,10 +293,8 @@ describe("GroupTransferModal", () => {
       );
 
       // Select a user
-      await waitFor(() => {
-        const select = screen.getByRole("combobox");
-        fireEvent.change(select, { target: { value: "p1" } });
-      });
+      const select = await screen.findByRole("combobox");
+      fireEvent.change(select, { target: { value: "p1" } });
 
       const transferButton = screen.getByText("Übergeben");
       fireEvent.click(transferButton);

--- a/frontend/src/components/operator/status-dropdown.test.tsx
+++ b/frontend/src/components/operator/status-dropdown.test.tsx
@@ -39,14 +39,12 @@ describe("StatusDropdown", () => {
     const button = screen.getByRole("button");
     fireEvent.click(button);
 
-    await waitFor(() => {
-      const listbox = screen.getByRole("listbox");
-      const buttons = listbox.querySelectorAll("button");
-      const plannedButton = Array.from(buttons).find((btn) =>
-        btn.textContent?.includes("Geplant"),
-      );
-      fireEvent.click(plannedButton!);
-    });
+    const listbox = await screen.findByRole("listbox");
+    const buttons = listbox.querySelectorAll("button");
+    const plannedButton = Array.from(buttons).find((btn) =>
+      btn.textContent?.includes("Geplant"),
+    );
+    fireEvent.click(plannedButton!);
 
     expect(mockOnChange).toHaveBeenCalledWith("planned");
   });
@@ -57,14 +55,12 @@ describe("StatusDropdown", () => {
     const button = screen.getByRole("button");
     fireEvent.click(button);
 
-    await waitFor(() => {
-      const listbox = screen.getByRole("listbox");
-      const buttons = listbox.querySelectorAll("button");
-      const plannedButton = Array.from(buttons).find((btn) =>
-        btn.textContent?.includes("Geplant"),
-      );
-      fireEvent.click(plannedButton!);
-    });
+    const listbox = await screen.findByRole("listbox");
+    const buttons = listbox.querySelectorAll("button");
+    const plannedButton = Array.from(buttons).find((btn) =>
+      btn.textContent?.includes("Geplant"),
+    );
+    fireEvent.click(plannedButton!);
 
     await waitFor(() => {
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument();

--- a/frontend/src/components/shared/base-comment-accordion.test.tsx
+++ b/frontend/src/components/shared/base-comment-accordion.test.tsx
@@ -235,17 +235,18 @@ describe("BaseCommentAccordion", () => {
     const button = screen.getByRole("button", { name: /Kommentare/i });
     fireEvent.click(button);
 
-    await waitFor(() => {
-      const textarea = screen.getByPlaceholderText("Kommentar schreiben...");
-      fireEvent.change(textarea, { target: { value: "New comment" } });
-    });
+    const textarea = await screen.findByPlaceholderText(
+      "Kommentar schreiben...",
+    );
+    fireEvent.change(textarea, { target: { value: "New comment" } });
 
     const submitButton = screen.getByLabelText("Senden");
     fireEvent.click(submitButton);
 
     await waitFor(() => {
-      const textarea = screen.getByPlaceholderText("Kommentar schreiben...");
-      expect(textarea).toHaveValue("");
+      expect(screen.getByPlaceholderText("Kommentar schreiben...")).toHaveValue(
+        "",
+      );
     });
   });
 
@@ -300,10 +301,8 @@ describe("BaseCommentAccordion", () => {
     const button = screen.getByRole("button", { name: /Kommentare/i });
     fireEvent.click(button);
 
-    await waitFor(() => {
-      const deleteButtons = screen.getAllByLabelText("Kommentar löschen");
-      fireEvent.click(deleteButtons[0]!);
-    });
+    const deleteButtons = await screen.findAllByLabelText("Kommentar löschen");
+    fireEvent.click(deleteButtons[0]!);
 
     await waitFor(() => {
       expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
@@ -323,15 +322,11 @@ describe("BaseCommentAccordion", () => {
     const button = screen.getByRole("button", { name: /Kommentare/i });
     fireEvent.click(button);
 
-    await waitFor(() => {
-      const deleteButtons = screen.getAllByLabelText("Kommentar löschen");
-      fireEvent.click(deleteButtons[0]!);
-    });
+    const deleteButtons = await screen.findAllByLabelText("Kommentar löschen");
+    fireEvent.click(deleteButtons[0]!);
 
-    await waitFor(() => {
-      const confirmButton = screen.getByTestId("confirm-delete");
-      fireEvent.click(confirmButton);
-    });
+    const confirmButton = await screen.findByTestId("confirm-delete");
+    fireEvent.click(confirmButton);
 
     await waitFor(() => {
       expect(mockDeleteComment).toHaveBeenCalledWith("42", "1");
@@ -373,10 +368,10 @@ describe("BaseCommentAccordion", () => {
     const button = screen.getByRole("button", { name: /Kommentare/i });
     fireEvent.click(button);
 
-    await waitFor(() => {
-      const textarea = screen.getByPlaceholderText("Kommentar schreiben...");
-      fireEvent.change(textarea, { target: { value: "New comment" } });
-    });
+    const textarea = await screen.findByPlaceholderText(
+      "Kommentar schreiben...",
+    );
+    fireEvent.change(textarea, { target: { value: "New comment" } });
 
     const submitButton = screen.getByLabelText("Senden");
     fireEvent.click(submitButton);
@@ -443,11 +438,11 @@ describe("BaseCommentAccordion", () => {
     const button = screen.getByRole("button", { name: /Kommentare/i });
     fireEvent.click(button);
 
-    await waitFor(() => {
-      const textarea = screen.getByPlaceholderText("Kommentar schreiben...");
-      fireEvent.change(textarea, { target: { value: "New comment" } });
-      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
-    });
+    const textarea = await screen.findByPlaceholderText(
+      "Kommentar schreiben...",
+    );
+    fireEvent.change(textarea, { target: { value: "New comment" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
 
     await waitFor(() => {
       expect(mockCreateComment).toHaveBeenCalledWith("42", "New comment");
@@ -467,11 +462,11 @@ describe("BaseCommentAccordion", () => {
     const button = screen.getByRole("button", { name: /Kommentare/i });
     fireEvent.click(button);
 
-    await waitFor(() => {
-      const textarea = screen.getByPlaceholderText("Kommentar schreiben...");
-      fireEvent.change(textarea, { target: { value: "New comment" } });
-      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
-    });
+    const textarea = await screen.findByPlaceholderText(
+      "Kommentar schreiben...",
+    );
+    fireEvent.change(textarea, { target: { value: "New comment" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
 
     await waitFor(() => {
       expect(mockCreateComment).not.toHaveBeenCalled();


### PR DESCRIPTION
## Problem

CI on `development` is failing twice since the react-doctor merge (#1943):

1. **Build and Push Docker Images / build-frontend**: #1943 moved the pnpm config (`overrides`, `onlyBuiltDependencies`, `peerDependencyRules`) from `package.json` into a new `frontend/pnpm-workspace.yaml`, but the Docker install stages only copy `package.json` + `pnpm-lock.yaml`. Inside the image pnpm sees no overrides while the lockfile records seven, so `pnpm install --frozen-lockfile` aborts with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. This also blocks staging deploys.
2. **SonarCloud Quality Gate**: Reliability Rating on New Code = C (required A) — 46 `typescript:S8985` findings ("Avoid using side effects within `waitFor` callback") across 12 test files touched by #1943.

## Fix

- Add `pnpm-workspace.yaml` to the `COPY` lines of all three install stages (`Dockerfile.prod` deps, `Dockerfile` deps + dev-deps).
- Restructure the flagged `waitFor` callbacks: side effects (`fireEvent.*`) now wait for their target via `screen.findBy*` and run outside the callback; assertion-only `waitFor` blocks are untouched. No assertions or test semantics changed.

## Verification

- `docker build --target deps -f frontend/Dockerfile.prod frontend` → succeeds with frozen lockfile
- `pnpm vitest run` on all 12 touched files → 466/466 tests pass
- `pnpm run check` (verify-locales + oxlint + tsc) → clean