### PR TITLE
Betreuungsplan: Block-Detailansicht als zentriertes Modal statt Slide-Over

### DIFF
--- a/.claude/workflows/timetable-ui-audit.js
+++ b/.claude/workflows/timetable-ui-audit.js
@@ -25,7 +25,7 @@ const FILES = [
   { path: `${DIR}/conflict-warnings-banner.tsx`, role: 'Inline warning banner for conflicts' },
   { path: `${DIR}/calendar-period-modal.tsx`, role: 'Modal: create/edit calendar period (contains native <select>)' },
   { path: `${DIR}/timetable-event-modal.tsx`, role: 'Large modal/slide-over: create/edit instance or series (many native <select>)' },
-  { path: `${DIR}/instance-detail-slide-over.tsx`, role: 'Slide-over: instance detail, lifecycle actions, roster' },
+  { path: `${DIR}/instance-detail-modal.tsx`, role: 'Modal: instance detail, lifecycle actions, roster' },
 ]
 
 // ---- Kit reference embedded so auditors share one rubric ----

--- a/.claude/workflows/timetable-ui-fix.js
+++ b/.claude/workflows/timetable-ui-fix.js
@@ -105,12 +105,12 @@ DO NOT touch: the trigger pill button (bordered pill with the green status dot),
 DO NOT convert the full-row clickable <button> targets (the instance rows) — leave them semantic.`,
   },
   {
-    path: `${DIR}/instance-detail-slide-over.tsx`,
-    label: 'instance-detail-slide-over',
+    path: `${DIR}/instance-detail-modal.tsx`,
+    label: 'instance-detail-modal',
     instructions: `FIXES:
 1. The "Spontan" badge and the activity-type badge: change bare "rounded" → "rounded-full".
-2. FOOTER BUTTONS: in SlideOverFooter, every action button currently using size="sm" (the outline/ghost cancel and the primary/lifecycle/danger actions) → change to size="md" (Flo's footer height). Keep each button's variant and all other props.
-DO NOT touch the SlideOverClose button (it uses asChild and forwards a DOM element) or the IconActionButton helper / lifecycle icon buttons — leave those as-is.`,
+2. FOOTER BUTTONS: in the Modal footer content, every action button currently using size="sm" (the outline/ghost cancel and the primary/lifecycle/danger actions) → change to size="md" (Flo's footer height). Keep each button's variant and all other props.
+DO NOT touch the kit Modal's own close button (it lives in ui/modal.tsx) or the IconActionButton helper / lifecycle icon buttons — leave those as-is.`,
   },
   {
     path: `${DIR}/timetable-event-modal.tsx`,

--- a/frontend/src/components/timetable/betreuungsplan-view.test.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.test.tsx
@@ -318,8 +318,8 @@ vi.mock("~/components/timetable/template-list", () => ({
   ),
 }));
 
-vi.mock("~/components/timetable/instance-detail-slide-over", () => ({
-  InstanceDetailSlideOver: ({
+vi.mock("~/components/timetable/instance-detail-modal", () => ({
+  InstanceDetailModal: ({
     instance,
     onClose,
     onLifecycleAction,

--- a/frontend/src/components/timetable/betreuungsplan-view.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.tsx
@@ -10,7 +10,7 @@
  * URL-Vokabular (Planung-Redesign, docs/planung-redesign/docs/06-betreuungsplan.md
  * Abschnitt 2.1): genau `d` (Berlin-Kalendertag; die angezeigte Woche/der Monat
  * ist die Woche/der Monat, die/den `d` enthält), `view` ("woche" | "monat" |
- * "serien") und `block` (Instanz-ID des geöffneten InstanceDetailSlideOver).
+ * "serien") und `block` (Instanz-ID des geöffneten InstanceDetailModal).
  * Ungültige Werte fallen still auf die Defaults zurück (heute, "woche"). Die
  * sieben Alt-Parameter (week/month/year/instance/day/period/Alt-view) entfallen
  * ersatzlos; die Jahresansicht ist nicht mehr verlinkbar. Der Dichte-Umschalter
@@ -45,9 +45,9 @@ import type { CalendarPeriod } from "~/lib/calendar-period-helpers";
 import { ConflictWarningsBanner } from "~/components/timetable/conflict-warnings-banner";
 import { GapJumpList } from "~/components/timetable/gap-jump-list";
 import {
-  InstanceDetailSlideOver,
+  InstanceDetailModal,
   type LifecycleAction,
-} from "~/components/timetable/instance-detail-slide-over";
+} from "~/components/timetable/instance-detail-modal";
 import { TimetableAddMenu } from "~/components/timetable/timetable-add-menu";
 import { MonthPlannerGrid } from "~/components/timetable/month-planner-grid";
 import { PeriodSwitcherDropdown } from "~/components/timetable/period-switcher-dropdown";
@@ -1138,7 +1138,7 @@ function TimetablesContent() {
         </>
       )}
 
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={selectedInstance}
         onClose={() => handleSelectInstance(null)}
         onLifecycleAction={handleLifecycle}

--- a/frontend/src/components/timetable/betreuungsplan-view.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.tsx
@@ -1169,6 +1169,7 @@ function TimetablesContent() {
         studentNames={studentNames}
         onAttendancePatch={handleAttendancePatch}
         editDeferred={false}
+        suspended={eventModalOpen}
       />
 
       <TimetableEventModal

--- a/frontend/src/components/timetable/instance-detail-modal.stories.tsx
+++ b/frontend/src/components/timetable/instance-detail-modal.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-import { InstanceDetailSlideOver } from "./instance-detail-slide-over";
+import { InstanceDetailModal } from "./instance-detail-modal";
 import type { EnrichedInstance } from "~/lib/timetable-types";
 
 function makeInstance(
@@ -45,8 +45,8 @@ const studentNames = new Map<string, string>([
 ]);
 
 const meta = {
-  title: "components/timetable/InstanceDetailSlideOver",
-  component: InstanceDetailSlideOver,
+  title: "components/timetable/InstanceDetailModal",
+  component: InstanceDetailModal,
   args: {
     instance: makeInstance(),
     onClose: () => undefined,
@@ -55,7 +55,7 @@ const meta = {
     studentNames,
     editDeferred: true,
   },
-} satisfies Meta<typeof InstanceDetailSlideOver>;
+} satisfies Meta<typeof InstanceDetailModal>;
 
 export default meta;
 

--- a/frontend/src/components/timetable/instance-detail-modal.test.tsx
+++ b/frontend/src/components/timetable/instance-detail-modal.test.tsx
@@ -685,6 +685,22 @@ describe("InstanceDetailModal", () => {
     expect(screen.getByText(/Sonstiges/)).toBeInTheDocument();
   });
 
+  it("hides itself while another overlay is stacked on top", () => {
+    const onClose = vi.fn();
+    render(
+      <InstanceDetailModal
+        instance={instance({})}
+        onClose={onClose}
+        onLifecycleAction={vi.fn()}
+        suspended
+      />,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("shows the Regeltermin OriginChip only when the instance stems from one", () => {
     const { rerender } = render(
       <InstanceDetailModal

--- a/frontend/src/components/timetable/instance-detail-modal.test.tsx
+++ b/frontend/src/components/timetable/instance-detail-modal.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { InstanceDetailSlideOver } from "./instance-detail-slide-over";
+import { InstanceDetailModal } from "./instance-detail-modal";
 import type { EnrichedInstance } from "~/lib/timetable-types";
 import {
   useAttendanceWebEnabled,
@@ -89,7 +89,7 @@ async function expectNoUnhandledRejection(
   }
 }
 
-describe("InstanceDetailSlideOver", () => {
+describe("InstanceDetailModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useAttendanceWebEnabled).mockReturnValue(true);
@@ -98,7 +98,7 @@ describe("InstanceDetailSlideOver", () => {
 
   it("renders nothing without a selected instance", () => {
     const { container } = render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={null}
         onClose={vi.fn()}
         onLifecycleAction={vi.fn()}
@@ -115,7 +115,7 @@ describe("InstanceDetailSlideOver", () => {
     const onAttendancePatch = vi.fn().mockResolvedValue(undefined);
 
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance()}
         onClose={vi.fn()}
         onLifecycleAction={onLifecycleAction}
@@ -173,7 +173,7 @@ describe("InstanceDetailSlideOver", () => {
   // write attendance for a day the child is not in care at all.
   it("groups children who are not in care today and drops their actions", () => {
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({
           students: [
             { studentId: "21", status: "expected", careDayStatus: "scheduled" },
@@ -224,7 +224,7 @@ describe("InstanceDetailSlideOver", () => {
   // absence from care that was never owed (#1747).
   it("groups a status-day absence on an unbooked day as not scheduled", () => {
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({
           students: [
             {
@@ -265,7 +265,7 @@ describe("InstanceDetailSlideOver", () => {
 
   it("marks spontaneous instances in the detail header", () => {
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ isSpontaneous: true })}
         onClose={vi.fn()}
         onLifecycleAction={vi.fn()}
@@ -278,7 +278,7 @@ describe("InstanceDetailSlideOver", () => {
   it("completes an active instance", async () => {
     const onLifecycleAction = vi.fn().mockResolvedValue(undefined);
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ status: "active", isLive: true })}
         onClose={vi.fn()}
         onLifecycleAction={onLifecycleAction}
@@ -299,7 +299,7 @@ describe("InstanceDetailSlideOver", () => {
   it("cancels an active instance", async () => {
     const onLifecycleAction = vi.fn().mockResolvedValue(undefined);
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ status: "active", isLive: true })}
         onClose={vi.fn()}
         onLifecycleAction={onLifecycleAction}
@@ -326,7 +326,7 @@ describe("InstanceDetailSlideOver", () => {
     const onAttendancePatch = vi.fn().mockResolvedValue(undefined);
 
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({
           status: "active",
           isLive: true,
@@ -378,7 +378,7 @@ describe("InstanceDetailSlideOver", () => {
     const onAttendancePatch = vi.fn().mockResolvedValue(undefined);
 
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ status: "active", isLive: true })}
         onClose={vi.fn()}
         onLifecycleAction={vi.fn()}
@@ -425,7 +425,7 @@ describe("InstanceDetailSlideOver", () => {
     const onAttendancePatch = vi.fn();
 
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ status: "active", isLive: true })}
         onClose={vi.fn()}
         onLifecycleAction={vi.fn()}
@@ -453,7 +453,7 @@ describe("InstanceDetailSlideOver", () => {
       .fn()
       .mockRejectedValue(new Error("already reported lifecycle failure"));
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ status: "active", isLive: true })}
         onClose={vi.fn()}
         onLifecycleAction={onLifecycleAction}
@@ -478,7 +478,7 @@ describe("InstanceDetailSlideOver", () => {
       .fn()
       .mockRejectedValue(new Error("already reported attendance failure"));
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ status: "active", isLive: true })}
         onClose={vi.fn()}
         onLifecycleAction={vi.fn()}
@@ -502,7 +502,7 @@ describe("InstanceDetailSlideOver", () => {
     const onDeleteCancelled = vi.fn().mockResolvedValue(undefined);
 
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({
           status: "cancelled",
           students: [],
@@ -532,7 +532,7 @@ describe("InstanceDetailSlideOver", () => {
     const onDeleteFollowing = vi.fn().mockResolvedValue(undefined);
 
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ activityGroupId: "7", isSpontaneous: false })}
         onClose={vi.fn()}
         onLifecycleAction={vi.fn()}
@@ -561,7 +561,7 @@ describe("InstanceDetailSlideOver", () => {
       .mockRejectedValue(new Error("already reported delete failure"));
 
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ activityGroupId: "7", isSpontaneous: false })}
         onClose={vi.fn()}
         onLifecycleAction={vi.fn()}
@@ -591,7 +591,7 @@ describe("InstanceDetailSlideOver", () => {
     const onDeleteFollowing = vi.fn().mockResolvedValue(undefined);
 
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ activityGroupId: "7", isSpontaneous: true })}
         onClose={vi.fn()}
         onLifecycleAction={vi.fn()}
@@ -619,10 +619,10 @@ describe("InstanceDetailSlideOver", () => {
     expect(onDeleteFollowing).not.toHaveBeenCalled();
   });
 
-  it("renders completed, empty, and detailed attendance states", () => {
+  it("renders completed, empty, and detailed attendance states", async () => {
     const onClose = vi.fn();
     const { rerender } = render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({
           status: "completed",
           staff: [],
@@ -650,10 +650,11 @@ describe("InstanceDetailSlideOver", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Raum #3")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Schließen" }));
-    expect(onClose).toHaveBeenCalledOnce();
+    // Das Kit-Modal ruft onClose erst nach der Exit-Animation (250ms) auf.
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
 
     rerender(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({
           status: "completed",
           students: [
@@ -686,7 +687,7 @@ describe("InstanceDetailSlideOver", () => {
 
   it("shows the Regeltermin OriginChip only when the instance stems from one", () => {
     const { rerender } = render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({
           activityGroupId: "9",
           date: "2026-05-04", // Monday
@@ -703,7 +704,7 @@ describe("InstanceDetailSlideOver", () => {
     ).toBeInTheDocument();
 
     rerender(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ activityGroupId: undefined })}
         onClose={vi.fn()}
         onLifecycleAction={vi.fn()}
@@ -715,7 +716,7 @@ describe("InstanceDetailSlideOver", () => {
 
   it("labels the substitution jump action 'Vertretung bearbeiten' and links to /vertretung", () => {
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({
           status: "planned",
           staff: [
@@ -743,7 +744,7 @@ describe("InstanceDetailSlideOver", () => {
     const onDeleteCancelled = vi.fn();
 
     render(
-      <InstanceDetailSlideOver
+      <InstanceDetailModal
         instance={instance({ status: "cancelled" })}
         onClose={vi.fn()}
         onLifecycleAction={vi.fn()}

--- a/frontend/src/components/timetable/instance-detail-modal.tsx
+++ b/frontend/src/components/timetable/instance-detail-modal.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 /**
- * InstanceDetailSlideOver — right-side slide-over showing the full state
- * of a clicked instance plus lifecycle action buttons.
+ * InstanceDetailModal — centered modal showing the full state of a
+ * clicked instance plus lifecycle action buttons (#1956).
  *
  * Shows the operational state of one timetable instance: lifecycle,
  * assigned staff, children, attendance state, and admin corrections.
@@ -31,9 +31,8 @@ import {
 } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
-import { useModal } from "~/components/dashboard/modal-context";
 import { ChoiceModal } from "~/components/ui/choice-modal";
-import { ConfirmationModal } from "~/components/ui/modal";
+import { ConfirmationModal, Modal } from "~/components/ui/modal";
 import { OriginChip } from "~/components/ui/origin-chip";
 import { LOCATION_COLORS } from "~/lib/location-helper";
 import { useTenantAwarePath } from "~/lib/tenant-path";
@@ -41,15 +40,6 @@ import {
   useAttendanceWebEnabled,
   useShowTimetableCounts,
 } from "~/lib/tenant-context";
-import {
-  SlideOver,
-  SlideOverCloseButton,
-  SlideOverContent,
-  SlideOverDescription,
-  SlideOverFooter,
-  SlideOverHeader,
-  SlideOverTitle,
-} from "~/components/ui/slide-over";
 import { parseISODate } from "~/lib/date-helpers";
 import {
   getActivityTypeBadge,
@@ -106,7 +96,7 @@ const CONFIRM_DIALOGS: Record<
   },
 };
 
-interface InstanceDetailSlideOverProps {
+interface InstanceDetailModalProps {
   instance: EnrichedInstance | null;
   onClose: () => void;
   onLifecycleAction: (action: LifecycleAction) => Promise<void>;
@@ -140,7 +130,7 @@ function germanFullDate(iso: string): string {
 }
 
 /**
- * Regeltermin-Herkunftstext für den OriginChip im Slide-Over
+ * Regeltermin-Herkunftstext für den OriginChip im Detail-Modal
  * (docs/planung-redesign/docs/06-betreuungsplan.md Abschnitt 3.2: "aus
  * Regeltermin {Titel}, montags 12:00"). Die Instanz trägt keinen separaten
  * Template-Titel — materialisierte Instanzen erben den Titel des
@@ -259,8 +249,8 @@ function studentsForInstance(
 function attendancePatchForInstance(
   attendanceWebEnabled: boolean,
   instance: EnrichedInstance | null,
-  onAttendancePatch: InstanceDetailSlideOverProps["onAttendancePatch"],
-): InstanceDetailSlideOverProps["onAttendancePatch"] {
+  onAttendancePatch: InstanceDetailModalProps["onAttendancePatch"],
+): InstanceDetailModalProps["onAttendancePatch"] {
   if (!attendanceWebEnabled || !instance) return undefined;
   if (instance.status === "cancelled") return undefined;
   return onAttendancePatch;
@@ -346,7 +336,7 @@ function InstanceStudentsSection({
     body: AttendancePatchBody,
   ) => Promise<void>;
   instance: EnrichedInstance;
-  onAttendancePatch?: InstanceDetailSlideOverProps["onAttendancePatch"];
+  onAttendancePatch?: InstanceDetailModalProps["onAttendancePatch"];
   pendingStudentId: string | null;
   studentNames: Map<string, string>;
   students: InstanceStudentSummary[];
@@ -396,7 +386,7 @@ function InstanceStudentsSection({
   );
 }
 
-export function InstanceDetailSlideOver({
+export function InstanceDetailModal({
   instance,
   onClose,
   onLifecycleAction,
@@ -408,10 +398,9 @@ export function InstanceDetailSlideOver({
   studentNames = EMPTY_STUDENT_NAMES,
   onAttendancePatch,
   editDeferred = true,
-}: InstanceDetailSlideOverProps) {
+}: InstanceDetailModalProps) {
   const attendanceWebEnabled = useAttendanceWebEnabled();
   const showTimetableCounts = useShowTimetableCounts();
-  const { isModalOpen } = useModal();
   // Tenant-bewusster Pfad: im Path-Routing-Modus muss /vertretung den
   // /{slug}-Präfix tragen, sonst führt der Link ins Leere.
   const tenantPath = useTenantAwarePath();
@@ -538,292 +527,273 @@ export function InstanceDetailSlideOver({
     }
   };
 
-  const open = instance !== null;
   const attendancePatch = attendancePatchForInstance(
     attendanceWebEnabled,
     instance,
     onAttendancePatch,
   );
 
-  return (
-    <SlideOver
-      open={open}
-      onOpenChange={(o) => {
-        if (!o) onClose();
-      }}
-    >
-      {instance && (
-        <SlideOverContent
-          // The confirmation modal portals to document.body and therefore
-          // lives outside the drawer's DOM. Without these guards Vaul's
-          // DismissableLayer treats every click inside the open modal as an
-          // outside-click and closes the slide-over, unmounting the modal
-          // before its buttons can fire. See issue #1358.
-          onInteractOutside={(event) => {
-            if (isModalOpen || pendingConfirm !== null || deleteScopeOpen) {
-              event.preventDefault();
-            }
-          }}
-          onEscapeKeyDown={(event) => {
-            if (isModalOpen || pendingConfirm !== null || deleteScopeOpen) {
-              event.preventDefault();
-            }
-          }}
-        >
-          <SlideOverHeader>
-            <div className="flex items-start justify-between gap-2">
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <SlideOverTitle>{instance.title}</SlideOverTitle>
-                  <StatusBadge status={instance.status} />
-                  {instance.isSpontaneous && (
-                    <span
-                      className="rounded-full bg-gray-100 px-1.5 py-0.5 text-[9px] font-bold tracking-wide text-gray-600 uppercase"
-                      title="Dieser Termin wurde spontan gestartet und war nicht geplant."
-                    >
-                      Spontan gestartet
-                    </span>
-                  )}
-                  <ActivityTypeBadge activityType={instance.activityType} />
-                </div>
-                <SlideOverDescription>
-                  {germanFullDate(instance.date)} • {instance.startTime} –{" "}
-                  {instance.endTime}
-                </SlideOverDescription>
-                {instance.activityGroupId && (
-                  <OriginChip
-                    label={regelterminOriginLabel(instance)}
-                    className="mt-1.5"
-                  />
-                )}
-              </div>
-              <SlideOverCloseButton />
-            </div>
-          </SlideOverHeader>
+  if (!instance) return null;
 
-          <div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
-            {instance.conflictWarnings.length > 0 && (
-              <div className={timetableDangerPanel}>
-                <div className="flex items-center gap-2 text-xs font-bold text-[#CC2626]">
-                  <TriangleAlert className="h-4 w-4" />
-                  {instance.conflictWarnings.length} Konflikt(e)
-                </div>
-                <ul className="mt-1 space-y-0.5 text-xs text-[#CC2626]">
-                  {instance.conflictWarnings.map((warning) => (
-                    <li key={warning.message}>• {warning.message}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            <StatsRow instance={instance} />
-
-            <Section title="Details">
-              <Row icon={<Timer className="h-4 w-4" />} label="Zeit">
-                {instance.startTime} – {instance.endTime}
-              </Row>
-              <Row icon={<DoorOpen className="h-4 w-4" />} label="Raum">
-                {instance.roomName || `Raum #${instance.roomId}`}
-              </Row>
-              <Row
-                icon={<UserCheck className="h-4 w-4" />}
-                label={`Personal (${instance.staffCount})`}
-              >
-                {instance.staffCount === 0
-                  ? "Niemand zugeordnet"
-                  : `${instance.staffCount - instance.absentStaffCount} aktiv${
-                      instance.absentStaffCount > 0
-                        ? `, ${instance.absentStaffCount} abwesend`
-                        : ""
-                    }`}
-              </Row>
-              {showTimetableCounts ? (
-                <Row icon={<Users className="h-4 w-4" />} label="Kinder">
-                  {instance.expectedStudentsCount +
-                    instance.presentStudentsCount}{" "}
-                  eingetragen
-                  {instance.presentStudentsCount > 0
-                    ? ` • ${instance.presentStudentsCount} anwesend`
-                    : ""}
-                  {/* Names the gap between the assignment list and the care
-                      plan (#1747) instead of leaving a smaller number
-                      unexplained. */}
-                  {instance.notScheduledStudentsCount > 0
-                    ? ` • ${instance.notScheduledStudentsCount} heute nicht eingeplant`
-                    : ""}
-                </Row>
-              ) : null}
-              {instance.seriesNotes && (
-                <Row icon={<Repeat className="h-4 w-4" />} label="Wochennotiz">
-                  <span className="whitespace-pre-line">
-                    {instance.seriesNotes}
-                  </span>
-                </Row>
-              )}
-              {instance.notes && (
-                <Row
-                  icon={<StickyNote className="h-4 w-4" />}
-                  label={instance.seriesNotes ? "Tagesnotiz" : "Notiz"}
-                >
-                  <span className="whitespace-pre-line">{instance.notes}</span>
-                </Row>
-              )}
-            </Section>
-
-            <AssignedStaffSection instance={instance} staffNames={staffNames} />
-
-            <InstanceStudentsSection
-              groupedStudents={groupedStudents}
-              handleAttendancePatch={handleAttendancePatch}
-              instance={instance}
-              onAttendancePatch={attendancePatch}
-              pendingStudentId={pendingStudentId}
-              studentNames={studentNames}
-              students={students}
-            />
-          </div>
-
-          <SlideOverFooter>
-            <div className="flex flex-wrap items-center gap-2">
-              {/* Sprung in den Vertretungs-Bereich bei einer Störung des Blocks
+  const footer = (
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {/* Sprung in den Vertretungs-Bereich bei einer Störung des Blocks
                   (offene Lücke oder eingetragene Abwesenheit) —
                   docs/planung-redesign/docs/07-vertretung.md Abschnitt 6. Nutzt
                   nur bereits geladene Instanzdaten, kein zusätzlicher Abruf. */}
-              {(instance.status === "planned" ||
-                instance.status === "active") &&
-                (instance.staff.some((row) => row.isAbsent) ||
-                  (instance.requiredStaffCount > 0 &&
-                    instance.assignedStaffCount <
-                      instance.requiredStaffCount)) && (
-                  <Link
-                    href={tenantPath(
-                      `/vertretung?d=${instance.date}&block=${instance.id}`,
-                    )}
-                    className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
-                  >
-                    <UserCog className="h-4 w-4" />
-                    Vertretung bearbeiten
-                  </Link>
-                )}
-              {instance.status === "planned" && !editDeferred && onEdit && (
-                <Button
-                  variant="outline"
-                  size="md"
-                  type="button"
-                  onClick={() => onEdit(instance)}
-                  disabled={pendingAction !== null}
-                >
-                  <span className="inline-flex items-center gap-2">
-                    <Pencil className="h-4 w-4" />
-                    Bearbeiten
-                  </span>
-                </Button>
+        {(instance.status === "planned" || instance.status === "active") &&
+          (instance.staff.some((row) => row.isAbsent) ||
+            (instance.requiredStaffCount > 0 &&
+              instance.assignedStaffCount < instance.requiredStaffCount)) && (
+            <Link
+              href={tenantPath(
+                `/vertretung?d=${instance.date}&block=${instance.id}`,
               )}
-              {instance.status === "planned" &&
-                !instance.activityGroupId &&
-                onRepeat && (
-                  <Button
-                    variant="outline"
-                    size="md"
-                    type="button"
-                    onClick={() => onRepeat(instance)}
-                    disabled={pendingAction !== null}
-                  >
-                    <span className="inline-flex items-center gap-2">
-                      <Repeat className="h-4 w-4" />
-                      Wiederholen
-                    </span>
-                  </Button>
-                )}
-              {instance.status === "active" && attendanceWebEnabled && (
-                <Button
-                  variant="primary"
-                  size="md"
-                  type="button"
-                  onClick={() => setPendingConfirm("complete")}
-                  isLoading={pendingAction === "complete"}
-                  loadingText="Beende …"
-                  disabled={pendingAction !== null}
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+            >
+              <UserCog className="h-4 w-4" />
+              Vertretung bearbeiten
+            </Link>
+          )}
+        {instance.status === "planned" && !editDeferred && onEdit && (
+          <Button
+            variant="outline"
+            size="md"
+            type="button"
+            onClick={() => onEdit(instance)}
+            disabled={pendingAction !== null}
+          >
+            <span className="inline-flex items-center gap-2">
+              <Pencil className="h-4 w-4" />
+              Bearbeiten
+            </span>
+          </Button>
+        )}
+        {instance.status === "planned" &&
+          !instance.activityGroupId &&
+          onRepeat && (
+            <Button
+              variant="outline"
+              size="md"
+              type="button"
+              onClick={() => onRepeat(instance)}
+              disabled={pendingAction !== null}
+            >
+              <span className="inline-flex items-center gap-2">
+                <Repeat className="h-4 w-4" />
+                Wiederholen
+              </span>
+            </Button>
+          )}
+        {instance.status === "active" && attendanceWebEnabled && (
+          <Button
+            variant="primary"
+            size="md"
+            type="button"
+            onClick={() => setPendingConfirm("complete")}
+            isLoading={pendingAction === "complete"}
+            loadingText="Beende …"
+            disabled={pendingAction !== null}
+          >
+            <span className="inline-flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4" />
+              Beenden
+            </span>
+          </Button>
+        )}
+        {(instance.status === "planned" ||
+          (instance.status === "active" && attendanceWebEnabled)) && (
+          <Button
+            variant="outline_danger"
+            size="md"
+            type="button"
+            onClick={() => setPendingConfirm("cancel")}
+            isLoading={pendingAction === "cancel"}
+            loadingText="Sage ab …"
+            disabled={pendingAction !== null}
+          >
+            <span className="inline-flex items-center gap-2">
+              <CircleX className="h-4 w-4" />
+              Absagen
+            </span>
+          </Button>
+        )}
+        {instance.status === "planned" && onDeleteCancelled && (
+          <Button
+            variant="outline_danger"
+            size="md"
+            type="button"
+            onClick={openDeleteFlow}
+            isLoading={pendingDelete}
+            loadingText="Lösche …"
+            disabled={pendingAction !== null || pendingDelete}
+          >
+            <span className="inline-flex items-center gap-2">
+              <Trash2 className="h-4 w-4" />
+              Löschen
+            </span>
+          </Button>
+        )}
+        {instance.status === "completed" && (
+          <span className="inline-flex items-center gap-2 text-xs text-gray-500">
+            <CheckCircle2 className="h-4 w-4" />
+            Diese Aktivität ist bereits abgeschlossen.
+          </span>
+        )}
+        {instance.status === "cancelled" && (
+          <>
+            <span className="inline-flex items-center gap-2 text-xs text-gray-500">
+              <CircleX className="h-4 w-4" />
+              Diese Aktivität wurde abgesagt.
+            </span>
+            {onDeleteCancelled && (
+              <Button
+                variant="outline_danger"
+                size="md"
+                type="button"
+                onClick={openDeleteFlow}
+                isLoading={pendingDelete}
+                loadingText="Lösche …"
+                disabled={pendingAction !== null || pendingDelete}
+              >
+                <span className="inline-flex items-center gap-2">
+                  <Trash2 className="h-4 w-4" />
+                  Löschen
+                </span>
+              </Button>
+            )}
+          </>
+        )}
+      </div>
+      {editDeferred && (
+        <div className="flex items-center justify-end gap-2 text-xs text-gray-400">
+          <Pencil className="h-3.5 w-3.5" />
+          <span>Bearbeiten kommt im nächsten Update</span>
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <>
+      {/* Confirmation-/ChoiceModal teilen sich mit dem Detail-Modal denselben
+          fixen z-index. Solange eines offen ist, wird das Detail-Modal
+          ausgeblendet statt gestapelt (gleiches Muster wie
+          staff/shift-move-dialog.tsx). */}
+      <Modal
+        isOpen={pendingConfirm === null && !deleteScopeOpen}
+        onClose={onClose}
+        title={instance.title}
+        closeLabel="Schließen"
+        widthClass="mx-4 w-[calc(100%-2rem)] max-w-3xl"
+        footer={footer}
+      >
+        <div className="space-y-5">
+          <div className="space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <StatusBadge status={instance.status} />
+              {instance.isSpontaneous && (
+                <span
+                  className="rounded-full bg-gray-100 px-1.5 py-0.5 text-[9px] font-bold tracking-wide text-gray-600 uppercase"
+                  title="Dieser Termin wurde spontan gestartet und war nicht geplant."
                 >
-                  <span className="inline-flex items-center gap-2">
-                    <CheckCircle2 className="h-4 w-4" />
-                    Beenden
-                  </span>
-                </Button>
-              )}
-              {(instance.status === "planned" ||
-                (instance.status === "active" && attendanceWebEnabled)) && (
-                <Button
-                  variant="outline_danger"
-                  size="md"
-                  type="button"
-                  onClick={() => setPendingConfirm("cancel")}
-                  isLoading={pendingAction === "cancel"}
-                  loadingText="Sage ab …"
-                  disabled={pendingAction !== null}
-                >
-                  <span className="inline-flex items-center gap-2">
-                    <CircleX className="h-4 w-4" />
-                    Absagen
-                  </span>
-                </Button>
-              )}
-              {instance.status === "planned" && onDeleteCancelled && (
-                <Button
-                  variant="outline_danger"
-                  size="md"
-                  type="button"
-                  onClick={openDeleteFlow}
-                  isLoading={pendingDelete}
-                  loadingText="Lösche …"
-                  disabled={pendingAction !== null || pendingDelete}
-                >
-                  <span className="inline-flex items-center gap-2">
-                    <Trash2 className="h-4 w-4" />
-                    Löschen
-                  </span>
-                </Button>
-              )}
-              {instance.status === "completed" && (
-                <span className="inline-flex items-center gap-2 text-xs text-gray-500">
-                  <CheckCircle2 className="h-4 w-4" />
-                  Diese Aktivität ist bereits abgeschlossen.
+                  Spontan gestartet
                 </span>
               )}
-              {instance.status === "cancelled" && (
-                <>
-                  <span className="inline-flex items-center gap-2 text-xs text-gray-500">
-                    <CircleX className="h-4 w-4" />
-                    Diese Aktivität wurde abgesagt.
-                  </span>
-                  {onDeleteCancelled && (
-                    <Button
-                      variant="outline_danger"
-                      size="md"
-                      type="button"
-                      onClick={openDeleteFlow}
-                      isLoading={pendingDelete}
-                      loadingText="Lösche …"
-                      disabled={pendingAction !== null || pendingDelete}
-                    >
-                      <span className="inline-flex items-center gap-2">
-                        <Trash2 className="h-4 w-4" />
-                        Löschen
-                      </span>
-                    </Button>
-                  )}
-                </>
-              )}
+              <ActivityTypeBadge activityType={instance.activityType} />
             </div>
-            {editDeferred && (
-              <div className="flex items-center justify-end gap-2 text-xs text-gray-400">
-                <Pencil className="h-3.5 w-3.5" />
-                <span>Bearbeiten kommt im nächsten Update</span>
-              </div>
+            <p className="text-sm text-gray-500">
+              {germanFullDate(instance.date)} • {instance.startTime} –{" "}
+              {instance.endTime}
+            </p>
+            {instance.activityGroupId && (
+              <OriginChip
+                label={regelterminOriginLabel(instance)}
+                className="mt-1.5"
+              />
             )}
-          </SlideOverFooter>
-        </SlideOverContent>
-      )}
+          </div>
+          {instance.conflictWarnings.length > 0 && (
+            <div className={timetableDangerPanel}>
+              <div className="flex items-center gap-2 text-xs font-bold text-[#CC2626]">
+                <TriangleAlert className="h-4 w-4" />
+                {instance.conflictWarnings.length} Konflikt(e)
+              </div>
+              <ul className="mt-1 space-y-0.5 text-xs text-[#CC2626]">
+                {instance.conflictWarnings.map((warning) => (
+                  <li key={warning.message}>• {warning.message}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <StatsRow instance={instance} />
+
+          <Section title="Details">
+            <Row icon={<Timer className="h-4 w-4" />} label="Zeit">
+              {instance.startTime} – {instance.endTime}
+            </Row>
+            <Row icon={<DoorOpen className="h-4 w-4" />} label="Raum">
+              {instance.roomName || `Raum #${instance.roomId}`}
+            </Row>
+            <Row
+              icon={<UserCheck className="h-4 w-4" />}
+              label={`Personal (${instance.staffCount})`}
+            >
+              {instance.staffCount === 0
+                ? "Niemand zugeordnet"
+                : `${instance.staffCount - instance.absentStaffCount} aktiv${
+                    instance.absentStaffCount > 0
+                      ? `, ${instance.absentStaffCount} abwesend`
+                      : ""
+                  }`}
+            </Row>
+            {showTimetableCounts ? (
+              <Row icon={<Users className="h-4 w-4" />} label="Kinder">
+                {instance.expectedStudentsCount + instance.presentStudentsCount}{" "}
+                eingetragen
+                {instance.presentStudentsCount > 0
+                  ? ` • ${instance.presentStudentsCount} anwesend`
+                  : ""}
+                {/* Names the gap between the assignment list and the care
+                      plan (#1747) instead of leaving a smaller number
+                      unexplained. */}
+                {instance.notScheduledStudentsCount > 0
+                  ? ` • ${instance.notScheduledStudentsCount} heute nicht eingeplant`
+                  : ""}
+              </Row>
+            ) : null}
+            {instance.seriesNotes && (
+              <Row icon={<Repeat className="h-4 w-4" />} label="Wochennotiz">
+                <span className="whitespace-pre-line">
+                  {instance.seriesNotes}
+                </span>
+              </Row>
+            )}
+            {instance.notes && (
+              <Row
+                icon={<StickyNote className="h-4 w-4" />}
+                label={instance.seriesNotes ? "Tagesnotiz" : "Notiz"}
+              >
+                <span className="whitespace-pre-line">{instance.notes}</span>
+              </Row>
+            )}
+          </Section>
+
+          <AssignedStaffSection instance={instance} staffNames={staffNames} />
+
+          <InstanceStudentsSection
+            groupedStudents={groupedStudents}
+            handleAttendancePatch={handleAttendancePatch}
+            instance={instance}
+            onAttendancePatch={attendancePatch}
+            pendingStudentId={pendingStudentId}
+            studentNames={studentNames}
+            students={students}
+          />
+        </div>
+      </Modal>
       {pendingConfirm && (
         <ConfirmationModal
           isOpen
@@ -849,31 +819,29 @@ export function InstanceDetailSlideOver({
           </p>
         </ConfirmationModal>
       )}
-      {instance && (
-        <ChoiceModal
-          isOpen={deleteScopeOpen}
-          onClose={() => setDeleteScopeOpen(false)}
-          title="Wiederholenden Termin löschen"
-          description={`Der Termin am ${germanFullDate(instance.date)} gehört zu einem Regeltermin.`}
-          options={[
-            {
-              value: "single",
-              label: "Nur diese Woche",
-              description:
-                "Löscht nur diesen einen Termin und verhindert, dass er erneut eingetragen wird; der Regeltermin bleibt bestehen.",
-            },
-            {
-              value: "following",
-              label: "Ab jetzt dauerhaft",
-              description:
-                "Beendet den Regeltermin ab diesem Datum; frühere Termine bleiben erhalten.",
-            },
-          ]}
-          onSelect={handleDeleteScopeSelect}
-          isBusy={pendingDeleteScope !== null}
-        />
-      )}
-    </SlideOver>
+      <ChoiceModal
+        isOpen={deleteScopeOpen}
+        onClose={() => setDeleteScopeOpen(false)}
+        title="Wiederholenden Termin löschen"
+        description={`Der Termin am ${germanFullDate(instance.date)} gehört zu einem Regeltermin.`}
+        options={[
+          {
+            value: "single",
+            label: "Nur diese Woche",
+            description:
+              "Löscht nur diesen einen Termin und verhindert, dass er erneut eingetragen wird; der Regeltermin bleibt bestehen.",
+          },
+          {
+            value: "following",
+            label: "Ab jetzt dauerhaft",
+            description:
+              "Beendet den Regeltermin ab diesem Datum; frühere Termine bleiben erhalten.",
+          },
+        ]}
+        onSelect={handleDeleteScopeSelect}
+        isBusy={pendingDeleteScope !== null}
+      />
+    </>
   );
 }
 
@@ -897,7 +865,7 @@ function StudentGroup({
   students: InstanceStudentSummary[];
   studentNames: Map<string, string>;
   pendingStudentId: string | null;
-  onAttendancePatch?: InstanceDetailSlideOverProps["onAttendancePatch"];
+  onAttendancePatch?: InstanceDetailModalProps["onAttendancePatch"];
   instanceStatus: InstanceStatus;
   handleAttendancePatch: (
     studentId: string,

--- a/frontend/src/components/timetable/instance-detail-modal.tsx
+++ b/frontend/src/components/timetable/instance-detail-modal.tsx
@@ -116,6 +116,14 @@ interface InstanceDetailModalProps {
    * disabled with a tooltip. Default true until backend PUT/POST land.
    */
   editDeferred?: boolean;
+  /**
+   * Blendet das Detail-Modal aus, solange ein anderes Overlay (z.B. der
+   * Termin-Editor) offen ist: beide portalen auf denselben festen z-index,
+   * und das Kit-Modal lauscht dokumentweit auf Escape — gestapelt würde es
+   * den Editor verdecken und bei Escape mitschließen. Die Auswahl
+   * (?block=…) bleibt bestehen, das Modal erscheint danach wieder.
+   */
+  suspended?: boolean;
 }
 
 const EMPTY_STAFF_NAMES = new Map<string, string>();
@@ -398,6 +406,7 @@ export function InstanceDetailModal({
   studentNames = EMPTY_STUDENT_NAMES,
   onAttendancePatch,
   editDeferred = true,
+  suspended = false,
 }: InstanceDetailModalProps) {
   const attendanceWebEnabled = useAttendanceWebEnabled();
   const showTimetableCounts = useShowTimetableCounts();
@@ -682,7 +691,7 @@ export function InstanceDetailModal({
           ausgeblendet statt gestapelt (gleiches Muster wie
           staff/shift-move-dialog.tsx). */}
       <Modal
-        isOpen={pendingConfirm === null && !deleteScopeOpen}
+        isOpen={pendingConfirm === null && !deleteScopeOpen && !suspended}
         onClose={onClose}
         title={instance.title}
         closeLabel="Schließen"

--- a/frontend/src/components/timetable/timetable-style.ts
+++ b/frontend/src/components/timetable/timetable-style.ts
@@ -35,7 +35,7 @@ export const timetableWarningText = "text-[#92400E]";
  * Shared 5-tone palette for small status/ratio indicators across the
  * timetable feature (issue #1838). Supersedes two previously-separate,
  * incompatible local palettes (the 4-tone StatPill in
- * instance-detail-slide-over.tsx had no "danger", TimetableStatCard's
+ * instance-detail-modal.tsx had no "danger", TimetableStatCard's
  * neutral/success/warning/danger had no "info") — this is the union of both,
  * mapped onto the existing LOCATION_COLORS semantic set. No new hex values.
  */

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -110,8 +110,14 @@ export function Modal({
       return;
     }
 
+    // Ignore Escapes that were already dispatching when this listener was
+    // attached: a Vaul drawer closes synchronously DURING the keydown, so a
+    // modal that remounts in that same dispatch (e.g. the Betreuungsplan
+    // detail modal resuming after the Termin-Editor, #1956) would receive
+    // the very same event and immediately close itself.
+    const attachedAt = performance.now();
     const handleEscKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
+      if (event.key === "Escape" && event.timeStamp >= attachedAt) {
         handleClose();
       }
     };

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -110,14 +110,19 @@ export function Modal({
       return;
     }
 
-    // Ignore Escapes that were already dispatching when this listener was
+    // Ignore the Escape that is already dispatching when this listener is
     // attached: a Vaul drawer closes synchronously DURING the keydown, so a
     // modal that remounts in that same dispatch (e.g. the Betreuungsplan
     // detail modal resuming after the Termin-Editor, #1956) would receive
-    // the very same event and immediately close itself.
-    const attachedAt = performance.now();
+    // the very same event and immediately close itself. Deliberately NOT a
+    // timestamp comparison — WebKit reports event.timeStamp on a wall-clock
+    // basis (not time-origin relative, webkit.org/b/211101), so it cannot
+    // be compared against performance.now(). window.event is deprecated but
+    // exactly identifies the in-flight event; outside a dispatch it is
+    // undefined and the guard never triggers.
+    const inFlightEvent = window.event;
     const handleEscKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && event.timeStamp >= attachedAt) {
+      if (event.key === "Escape" && event !== inFlightEvent) {
         handleClose();
       }
     };

--- a/frontend/src/components/ui/origin-chip.tsx
+++ b/frontend/src/components/ui/origin-chip.tsx
@@ -13,7 +13,7 @@ interface OriginChipProps {
 /**
  * OriginChip names the data source of a figure ("Herkunfts-Chip"). It is
  * deliberately dosed: the planning redesign allows it at exactly three
- * spots — the Betreuungsplan header, the InstanceDetailSlideOver, and the
+ * spots — the Betreuungsplan header, the InstanceDetailModal, and the
  * Soll value of the time-tracking surfaces (docs/planung-redesign/docs/
  * 04-designsprache.md section 6.2). Do not scatter it across arbitrary
  * figures.


### PR DESCRIPTION
Closes #1956

## Was ändert sich

Die Detailansicht eines Blocks im Betreuungsplan (`?block=<id>`) öffnet sich jetzt als zentriertes Modal (UI-Kit `~/components/ui/modal`) statt als rechter Slide-Over.

- `instance-detail-slide-over.tsx` → `instance-detail-modal.tsx`, `InstanceDetailSlideOver` → `InstanceDetailModal` (inkl. Test, Stories, Importe)
- Titel läuft über den Modal-Header (`title`-Prop, behält Heading-Rolle + `aria-labelledby`); Status-/Spontan-/AG-Badges, Datumszeile und OriginChip stehen am Anfang des Inhalts
- Aktionen (Vertretung, Bearbeiten, Wiederholen, Beenden, Absagen, Löschen) im Modal-Footer, Breite `max-w-3xl` analog zum Termin-Editor (760px)
- URL-Verhalten unverändert: `?block=<id>` öffnet, Schließen (X, Backdrop, ESC) entfernt den Param; Deep-Links funktionieren
- Alle Funktionen (Lifecycle, Personal, Kinder, Anwesenheits-Korrekturen) unverändert übernommen

## Overlay-Verhalten

- Während Confirmation-/ChoiceModal offen sind, blendet sich das Detail-Modal aus statt zu stapeln (gleiches Muster wie `staff/shift-move-dialog.tsx`, beide teilen denselben festen z-index). Die Vaul-spezifischen Dismiss-Guards (#1358) entfallen dadurch ersatzlos.
- Neue Prop `suspended`: solange der Termin-Editor (Bearbeiten/Wiederholen) offen ist, pausiert das Detail-Modal und kehrt danach mit intakter `?block`-Auswahl zurück.
- Kit-Modal-Fix: der dokumentweite Escape-Listener ignoriert Events, deren `timeStamp` vor dem Anbringen liegt. Vaul schließt den Editor synchron während des Escape-keydown; das im selben Dispatch remountende Detail-Modal empfing sonst dasselbe Event und schloss sich sofort mit (Auswahl ging verloren).

## Tests

- `instance-detail-modal.test.tsx`: mechanische Umbenennung; eine Timing-Anpassung (Kit-Modal ruft `onClose` erst nach der 250ms-Exit-Animation → `waitFor`); neuer Fall für `suspended`
- `betreuungsplan-view.test.tsx`: nur Mock-Pfad/-Name aktualisiert
- `pnpm run test:run` (11.677 Tests), `pnpm run check`, `pnpm run knip`: grün

## End-to-End verifiziert (lokaler Stack, agent-browser)

Block anklicken → zentriertes Modal + `?block=<id>`; Schließen via X/Backdrop/ESC entfernt den Param; Deep-Link öffnet direkt; Absagen-/Löschen-Bestätigung ersetzt das Modal und kehrt bei Abbrechen zurück; Bearbeiten öffnet den Editor allein im Vordergrund, ESC dort schließt nur den Editor; Löschen entfernt den Block; Mobile (390px) geprüft.

Screenshots werden als Kommentar nachgereicht.