### PR TITLE
Kalender: Dienstplan-Schichten für Mitarbeitende anzeigen

### DIFF
--- a/backend/models/calendar/appointment.go
+++ b/backend/models/calendar/appointment.go
@@ -27,6 +27,7 @@ const (
 
 	EventSourceAppointment = "appointment"
 	EventSourceTimetable   = "timetable"
+	EventSourceShift       = "shift"
 
 	TargetTypeStaff            = "staff"
 	TargetTypeGuardianProfile  = "guardian_profile"

--- a/backend/services/calendar/service.go
+++ b/backend/services/calendar/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	baseModels "github.com/moto-nrw/project-phoenix/models/base"
 	calModels "github.com/moto-nrw/project-phoenix/models/calendar"
 	educationModels "github.com/moto-nrw/project-phoenix/models/education"
 	parentModels "github.com/moto-nrw/project-phoenix/models/parent"
@@ -856,8 +857,13 @@ func (s *service) staffShiftEvents(ctx context.Context, staffID int64, from, to 
 			name, ok := typeNames[*shift.ShiftTypeID]
 			if !ok {
 				shiftType, err := s.cfg.ShiftTypeRepo.FindByID(ctx, *shift.ShiftTypeID)
-				if err == nil && shiftType != nil {
+				switch {
+				case err == nil && shiftType != nil:
 					name = shiftType.Name
+				case err != nil && !baseModels.IsNoRows(err):
+					// A concurrently deleted shift type is fine (fallback title);
+					// a real database error must not degrade into a 200.
+					return nil, err
 				}
 				typeNames[*shift.ShiftTypeID] = name
 			}

--- a/backend/services/calendar/service.go
+++ b/backend/services/calendar/service.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
-	baseModels "github.com/moto-nrw/project-phoenix/models/base"
 	calModels "github.com/moto-nrw/project-phoenix/models/calendar"
 	educationModels "github.com/moto-nrw/project-phoenix/models/education"
 	parentModels "github.com/moto-nrw/project-phoenix/models/parent"
@@ -833,11 +832,23 @@ func (s *service) staffTimetableEvents(ctx context.Context, staffID int64, from,
 	return events, nil
 }
 
+// shiftsReferenceTypes reports whether any shift carries a ShiftTypeID —
+// the guard that keeps windows without typed shifts free of the ListAll query.
+func shiftsReferenceTypes(shifts []*scheduleModels.StaffShift) bool {
+	for _, shift := range shifts {
+		if shift.ShiftTypeID != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // staffShiftEvents maps the staff member's Dienstplan shifts
 // (schedule.staff_shifts) in the window to calendar events. Cancelled shifts
 // stay hidden, mirroring how cancelled timetable instances are skipped. The
-// range finder does not load the ShiftType relation, so names are resolved
-// per distinct type id.
+// range finder does not load the ShiftType relation, so names come from one
+// batch ListAll (the tenant's shift-type table is small); a type missing from
+// the map (concurrently deleted) falls back to the generic title.
 func (s *service) staffShiftEvents(ctx context.Context, staffID int64, from, to timezone.Date) ([]Event, error) {
 	if s.cfg.StaffShiftRepo == nil {
 		return []Event{}, nil
@@ -846,28 +857,24 @@ func (s *service) staffShiftEvents(ctx context.Context, staffID int64, from, to 
 	if err != nil {
 		return nil, err
 	}
-	events := []Event{}
 	typeNames := map[int64]string{}
+	if s.cfg.ShiftTypeRepo != nil && shiftsReferenceTypes(shifts) {
+		shiftTypes, err := s.cfg.ShiftTypeRepo.ListAll(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, shiftType := range shiftTypes {
+			typeNames[shiftType.ID] = shiftType.Name
+		}
+	}
+	events := []Event{}
 	for _, shift := range shifts {
 		if shift.Cancelled {
 			continue
 		}
 		title := "Dienst"
-		if shift.ShiftTypeID != nil && s.cfg.ShiftTypeRepo != nil {
-			name, ok := typeNames[*shift.ShiftTypeID]
-			if !ok {
-				shiftType, err := s.cfg.ShiftTypeRepo.FindByID(ctx, *shift.ShiftTypeID)
-				switch {
-				case err == nil && shiftType != nil:
-					name = shiftType.Name
-				case err != nil && !baseModels.IsNoRows(err):
-					// A concurrently deleted shift type is fine (fallback title);
-					// a real database error must not degrade into a 200.
-					return nil, err
-				}
-				typeNames[*shift.ShiftTypeID] = name
-			}
-			if name != "" {
+		if shift.ShiftTypeID != nil {
+			if name := typeNames[*shift.ShiftTypeID]; name != "" {
 				title = name
 			}
 		}

--- a/backend/services/calendar/service.go
+++ b/backend/services/calendar/service.go
@@ -25,6 +25,7 @@ import (
 const (
 	EventSourceAppointment = calModels.EventSourceAppointment
 	EventSourceTimetable   = calModels.EventSourceTimetable
+	EventSourceShift       = calModels.EventSourceShift
 
 	maxCalendarWindowDays = 92
 
@@ -68,6 +69,8 @@ type Config struct {
 	InstanceStaffRepo    scheduleModels.InstanceStaffRepository
 	InstanceStudentRepo  scheduleModels.InstanceStudentRepository
 	ActivityInstanceRepo scheduleModels.ActivityInstanceRepository
+	StaffShiftRepo       scheduleModels.StaffShiftRepository
+	ShiftTypeRepo        scheduleModels.ShiftTypeRepository
 	// CareDays judges unfinished timetable blocks against the care plan; a
 	// completed block is read from its persisted marker instead (#1747).
 	CareDays    scheduleSvc.CareDayService
@@ -213,8 +216,13 @@ func (s *service) ListMyStaffEvents(ctx context.Context, from, to timezone.Date)
 	if err != nil {
 		return nil, err
 	}
+	shiftEvents, err := s.staffShiftEvents(ctx, staff.ID, from, to)
+	if err != nil {
+		return nil, err
+	}
 
 	events := append(appointmentEvents, timetableEvents...)
+	events = append(events, shiftEvents...)
 	sortEvents(events)
 	return events, nil
 }
@@ -820,6 +828,58 @@ func (s *service) staffTimetableEvents(ctx context.Context, staffID int64, from,
 				AllDay:      false,
 			})
 		}
+	}
+	return events, nil
+}
+
+// staffShiftEvents maps the staff member's Dienstplan shifts
+// (schedule.staff_shifts) in the window to calendar events. Cancelled shifts
+// stay hidden, mirroring how cancelled timetable instances are skipped. The
+// range finder does not load the ShiftType relation, so names are resolved
+// per distinct type id.
+func (s *service) staffShiftEvents(ctx context.Context, staffID int64, from, to timezone.Date) ([]Event, error) {
+	if s.cfg.StaffShiftRepo == nil {
+		return []Event{}, nil
+	}
+	shifts, err := s.cfg.StaffShiftRepo.FindByStaffAndDateRange(ctx, staffID, from, to)
+	if err != nil {
+		return nil, err
+	}
+	events := []Event{}
+	typeNames := map[int64]string{}
+	for _, shift := range shifts {
+		if shift.Cancelled {
+			continue
+		}
+		title := "Dienst"
+		if shift.ShiftTypeID != nil && s.cfg.ShiftTypeRepo != nil {
+			name, ok := typeNames[*shift.ShiftTypeID]
+			if !ok {
+				shiftType, err := s.cfg.ShiftTypeRepo.FindByID(ctx, *shift.ShiftTypeID)
+				if err == nil && shiftType != nil {
+					name = shiftType.Name
+				}
+				typeNames[*shift.ShiftTypeID] = name
+			}
+			if name != "" {
+				title = name
+			}
+		}
+		event := Event{
+			ID:        fmt.Sprintf("shift:%d", shift.ID),
+			Source:    EventSourceShift,
+			Title:     title,
+			StartDate: shift.Date.String(),
+			EndDate:   shift.Date.String(),
+			StartTime: formatClock(shift.StartTime),
+			EndTime:   formatClock(shift.EndTime),
+			AllDay:    false,
+		}
+		if shift.Notes != "" {
+			notes := shift.Notes
+			event.Description = &notes
+		}
+		events = append(events, event)
 	}
 	return events, nil
 }

--- a/backend/services/calendar/service_integration_test.go
+++ b/backend/services/calendar/service_integration_test.go
@@ -65,6 +65,8 @@ func setupCalendarService(t *testing.T, db *bun.DB) calendarSvc.Service {
 		InstanceStaffRepo:    repos.InstanceStaff,
 		InstanceStudentRepo:  repos.InstanceStudent,
 		ActivityInstanceRepo: repos.ActivityInstance,
+		StaffShiftRepo:       repos.StaffShift,
+		ShiftTypeRepo:        repos.ShiftType,
 		CareDays: scheduleSvc.NewCareDayService(scheduleSvc.CareDayDependencies{
 			ArrivalSchedules:  repos.StudentArrivalSchedule,
 			ArrivalExceptions: repos.StudentArrivalException,
@@ -879,6 +881,62 @@ func TestCalendarServiceIntegration_StaffCalendarIncludesAssignedTimetable(t *te
 	assert.Equal(t, "14:15", events[0].StartTime)
 	assert.Equal(t, "15:45", events[0].EndTime)
 	assert.False(t, events[0].CanRespond)
+}
+
+func TestCalendarServiceIntegration_StaffCalendarIncludesShifts(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	service := setupCalendarService(t, db)
+	staff, account := testpkg.CreateTestCalendarStaff(t, db, "Shift", "Staff")
+
+	shiftType := &scheduleModels.ShiftType{Name: "Frühdienst", Color: "#F78C10", IsActive: true}
+	shiftType.SetTenantID(1)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := db.NewInsert().Model(shiftType).ModelTableExpr(`schedule.shift_types`).Exec(ctx)
+	require.NoError(t, err)
+
+	day := timezone.NewDate(2026, 5, 4)
+	typed := testpkg.CreateTestStaffShift(t, db, staff.ID, day, testpkg.StaffShiftOpts{
+		StartHHMM:   "08:00",
+		EndHHMM:     "12:00",
+		Notes:       "Vertretung Gruppe B",
+		ShiftTypeID: &shiftType.ID,
+	})
+	untyped := testpkg.CreateTestStaffShift(t, db, staff.ID, day, testpkg.StaffShiftOpts{
+		StartHHMM: "13:00",
+		EndHHMM:   "16:00",
+	})
+	cancelled := testpkg.CreateTestStaffShift(t, db, staff.ID, day.AddDays(1), testpkg.StaffShiftOpts{
+		Cancelled: true,
+	})
+
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "schedule.staff_shifts", typed.ID, untyped.ID, cancelled.ID)
+		testpkg.CleanupTableRecords(t, db, "schedule.shift_types", shiftType.ID)
+		testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		testpkg.CleanupAuthFixtures(t, db, account.ID)
+	})
+
+	events, err := service.ListMyStaffEvents(calendarContext(account.ID), day, day.AddDays(1))
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+
+	assert.Equal(t, calModels.EventSourceShift, events[0].Source)
+	assert.Equal(t, "Frühdienst", events[0].Title)
+	assert.Equal(t, "08:00", events[0].StartTime)
+	assert.Equal(t, "12:00", events[0].EndTime)
+	require.NotNil(t, events[0].Description)
+	assert.Equal(t, "Vertretung Gruppe B", *events[0].Description)
+	assert.False(t, events[0].CanRespond)
+	assert.False(t, events[0].CanEdit)
+
+	assert.Equal(t, calModels.EventSourceShift, events[1].Source)
+	assert.Equal(t, "Dienst", events[1].Title)
+	assert.Equal(t, "13:00", events[1].StartTime)
+	assert.Equal(t, "16:00", events[1].EndTime)
+	assert.Nil(t, events[1].Description)
 }
 
 func TestCalendarServiceIntegration_ParentCalendarIncludesChildTimetable(t *testing.T) {

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1380,6 +1380,8 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		InstanceStaffRepo:    repos.InstanceStaff,
 		InstanceStudentRepo:  repos.InstanceStudent,
 		ActivityInstanceRepo: repos.ActivityInstance,
+		StaffShiftRepo:       repos.StaffShift,
+		ShiftTypeRepo:        repos.ShiftType,
 		CareDays:             careDayService,
 		UserContext:          userContextService,
 		DB:                   db,

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -2796,6 +2796,53 @@ func CreateTestActivityInstance(tb testing.TB, db *bun.DB, date timezone.Date, r
 	return row
 }
 
+// StaffShiftOpts controls optional fields for CreateTestStaffShift.
+type StaffShiftOpts struct {
+	StartHHMM   string // default "08:00"
+	EndHHMM     string // default "16:00"
+	Notes       string
+	Cancelled   bool
+	ShiftTypeID *int64
+}
+
+// CreateTestStaffShift inserts a Dienstplan shift (schedule.staff_shifts) for
+// the staff member on the given date, tenant 1. created_by is stamped with the
+// staff's own id. Cleanup: CleanupTableRecords(t, db, "schedule.staff_shifts", row.ID).
+func CreateTestStaffShift(tb testing.TB, db *bun.DB, staffID int64, date timezone.Date, opts StaffShiftOpts) *schedule.StaffShift {
+	tb.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	startHHMM := opts.StartHHMM
+	if startHHMM == "" {
+		startHHMM = "08:00"
+	}
+	endHHMM := opts.EndHHMM
+	if endHHMM == "" {
+		endHHMM = "16:00"
+	}
+
+	row := &schedule.StaffShift{
+		StaffID:     staffID,
+		Date:        date,
+		StartTime:   parseTimeHHMM(tb, startHHMM),
+		EndTime:     parseTimeHHMM(tb, endHHMM),
+		Notes:       opts.Notes,
+		Cancelled:   opts.Cancelled,
+		ShiftTypeID: opts.ShiftTypeID,
+		CreatedBy:   staffID,
+	}
+	row.SetTenantID(1)
+
+	_, err := db.NewInsert().
+		Model(row).
+		ModelTableExpr(`schedule.staff_shifts`).
+		Exec(ctx)
+	require.NoError(tb, err, "Failed to create test staff shift")
+	return row
+}
+
 // InstanceStudentOpts controls optional fields for CreateTestInstanceStudent.
 type InstanceStudentOpts struct {
 	// NotScheduled sets the #1747 non-booking marker ending a block stamps on

--- a/frontend/src/app/[tenant]/(protected)/calendar/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/calendar/page.tsx
@@ -429,7 +429,7 @@ export default function StaffCalendarPage() {
     <main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
       <PersonalCalendar
         title="Mein Kalender"
-        subtitle="Deine Termine, Einladungen und zugewiesenen Betreuungsangebote."
+        subtitle="Deine Termine, Einladungen, Dienstplan-Schichten und zugewiesenen Betreuungsangebote."
         // On a load error SWR may still hold the previous range's data; don't
         // render stale appointments under the new date label.
         events={calendarError ? [] : (data?.events ?? [])}

--- a/frontend/src/components/calendar/personal-calendar.test.tsx
+++ b/frontend/src/components/calendar/personal-calendar.test.tsx
@@ -101,6 +101,42 @@ describe("PersonalCalendar", () => {
     expect(onRespond).toHaveBeenCalledWith("42", "declined");
   });
 
+  it("hides weekend days by default and reveals them via the Sa/So toggle", () => {
+    const weekendEvent: CalendarEvent = {
+      id: "appointment:2:2026-01-10",
+      source: "appointment",
+      appointment_id: "2",
+      title: "Wochenend-Termin",
+      start_date: "2026-01-10",
+      end_date: "2026-01-10",
+      start_time: "09:00",
+      end_time: "10:00",
+      all_day: false,
+      can_respond: false,
+      can_edit: false,
+    };
+    render(
+      <PersonalCalendar
+        title="Mein Kalender"
+        events={[appointment, weekendEvent]}
+        weekStart={new Date(2026, 0, 5)}
+        onWeekChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Wochenend-Termin")).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole("button", { name: "Sa/So (1)" });
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(toggle);
+
+    expect(screen.getAllByText("Wochenend-Termin").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Sa/So" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
   it("supports week navigation and create action", () => {
     const onWeekChange = vi.fn();
     const onCreate = vi.fn();

--- a/frontend/src/components/calendar/personal-calendar.test.tsx
+++ b/frontend/src/components/calendar/personal-calendar.test.tsx
@@ -101,6 +101,48 @@ describe("PersonalCalendar", () => {
     expect(onRespond).toHaveBeenCalledWith("42", "declined");
   });
 
+  it("splits the column when an inflated short event visually overlaps the next one", () => {
+    // 30-Minuten-Termin mit RSVP: die gerenderte Karte ist höher als das
+    // Zeitfenster und ragt über 10:00 hinaus — der Folgetermin darf sie nicht
+    // überdecken, beide müssen sich die Spaltenbreite teilen.
+    const shortRsvp: CalendarEvent = {
+      ...appointment,
+      id: "appointment:3:2026-01-05",
+      appointment_id: "3",
+      title: "Kurzer RSVP-Termin",
+      start_time: "09:00",
+      end_time: "09:30",
+    };
+    const followUp: CalendarEvent = {
+      ...timetable,
+      id: "timetable:10",
+      timetable_id: "10",
+      title: "Direkt danach",
+      start_date: "2026-01-05",
+      end_date: "2026-01-05",
+      start_time: "10:00",
+      end_time: "11:00",
+    };
+    render(
+      <PersonalCalendar
+        title="Mein Kalender"
+        events={[shortRsvp, followUp]}
+        weekStart={new Date(2026, 0, 5)}
+        onWeekChange={vi.fn()}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    const shortBlock = screen
+      .getAllByText("Kurzer RSVP-Termin")[0]!
+      .closest("article");
+    const followBlock = screen
+      .getAllByText("Direkt danach")[0]!
+      .closest("article");
+    expect(shortBlock?.style.width).toBe("calc(50% - 4px)");
+    expect(followBlock?.style.width).toBe("calc(50% - 4px)");
+  });
+
   it("hides weekend days by default and reveals them via the Sa/So toggle", () => {
     const weekendEvent: CalendarEvent = {
       id: "appointment:2:2026-01-10",

--- a/frontend/src/components/calendar/personal-calendar.test.tsx
+++ b/frontend/src/components/calendar/personal-calendar.test.tsx
@@ -40,7 +40,39 @@ const timetable: CalendarEvent = {
   can_edit: false,
 };
 
+const shift: CalendarEvent = {
+  id: "shift:5",
+  source: "shift",
+  title: "Frühdienst",
+  description: "Vertretung Gruppe B",
+  start_date: "2026-01-07",
+  end_date: "2026-01-07",
+  start_time: "08:00",
+  end_time: "16:00",
+  all_day: false,
+  can_respond: false,
+  can_edit: false,
+};
+
 describe("PersonalCalendar", () => {
+  it("renders shift events with the Dienst badge", () => {
+    render(
+      <PersonalCalendar
+        title="Mein Kalender"
+        subtitle="Termine und Dienstplan"
+        events={[shift]}
+        weekStart={new Date(2026, 0, 5)}
+        onWeekChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("Frühdienst").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Dienst").length).toBeGreaterThan(0);
+    expect(
+      screen.queryByRole("button", { name: "Zusagen" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders appointment and timetable events with RSVP actions", () => {
     const onRespond = vi.fn();
     render(

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -155,7 +155,10 @@ function countWeekendEvents(
   return seen.size;
 }
 
-function gridHours(dayEvents: readonly CalendarEvent[]): {
+function gridHours(
+  dayEvents: readonly CalendarEvent[],
+  options: TimedLayoutOptions,
+): {
   startHour: number;
   endHour: number;
 } {
@@ -164,12 +167,11 @@ function gridHours(dayEvents: readonly CalendarEvent[]): {
   for (const event of dayEvents) {
     if (isAllDayLike(event)) continue;
     const startMinutes = clockToMinutes(event.start_time);
-    const endMinutes = Math.max(
-      clockToMinutes(event.end_time),
-      startMinutes + 30,
-    );
     startHour = Math.min(startHour, Math.floor(startMinutes / 60));
-    endHour = Math.max(endHour, Math.ceil(endMinutes / 60));
+    endHour = Math.max(
+      endHour,
+      Math.ceil(effectiveEndMinutes(event, options) / 60),
+    );
   }
   startHour = Math.max(0, startHour);
   endHour = Math.min(24, Math.max(endHour, startHour + 1));
@@ -215,6 +217,24 @@ function blockMinHeightPx(
   );
 }
 
+// Effektives Render-Ende eines Eintrags in Minuten: das spätere von
+// tatsächlichem Ende und der Mindesthöhe des gerenderten Inhalts. Rasterfenster
+// und Layout rechnen beide damit, sonst laufen späte Kurztermine unten heraus.
+function effectiveEndMinutes(
+  event: CalendarEvent,
+  options: TimedLayoutOptions,
+): number {
+  const startMinutes = clockToMinutes(event.start_time);
+  const minRenderMinutes =
+    event.source === "shift"
+      ? 30
+      : (blockMinHeightPx(event, options) / HOUR_PX) * 60;
+  return Math.max(
+    clockToMinutes(event.end_time),
+    startMinutes + minRenderMinutes,
+  );
+}
+
 // Klassisches Zeitraster-Layout: überlappende Einträge bilden ein Cluster und
 // teilen sich die Spaltenbreite; jeder Eintrag bekommt die erste freie Spalte.
 function layoutTimedEvents(
@@ -224,15 +244,10 @@ function layoutTimedEvents(
   const items: TimedPlacement[] = dayEvents
     .map((event) => {
       const startMinutes = clockToMinutes(event.start_time);
-      const minRenderMinutes =
-        (blockMinHeightPx(event, options) / HOUR_PX) * 60;
       return {
         event,
         startMinutes,
-        endMinutes: Math.max(
-          clockToMinutes(event.end_time),
-          startMinutes + minRenderMinutes,
-        ),
+        endMinutes: effectiveEndMinutes(event, options),
         column: 0,
         columnCount: 1,
       };
@@ -649,8 +664,13 @@ function CalendarTimeGrid({
     day,
     events: eventsForDay(events, day),
   }));
+  const layoutOptions: TimedLayoutOptions = {
+    hasRespond: Boolean(onRespond),
+    hasOverview: Boolean(onShowOverview),
+  };
   const { startHour, endHour } = gridHours(
     dayBuckets.flatMap((bucket) => bucket.events),
+    layoutOptions,
   );
   const gridStartMinutes = startHour * 60;
   const bodyHeight = (endHour - startHour) * HOUR_PX;

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -61,6 +61,11 @@ const sourceTone = {
     bar: LOCATION_COLORS.OTHER_ROOM,
     bg: "#EBF0FB",
   },
+  shift: {
+    label: "Dienst",
+    bar: LOCATION_COLORS.SCHOOLYARD,
+    bg: "#FEF3E7",
+  },
 } satisfies Record<
   CalendarEvent["source"],
   { label: string; bar: string; bg: string }

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import {
   CalendarDays,
   Check,
@@ -18,7 +19,7 @@ import type {
   CalendarEvent,
   CalendarResponseStatus,
 } from "~/lib/personal-calendar-api";
-import { toISODate } from "~/lib/date-helpers";
+import { parseISODate, toISODate } from "~/lib/date-helpers";
 import {
   formatDayHeader,
   formatWeekLabel,
@@ -102,6 +103,137 @@ function eventsForDay(
   return events
     .filter((event) => event.start_date <= iso && event.end_date >= iso)
     .sort((a, b) => eventSortValue(a).localeCompare(eventSortValue(b)));
+}
+
+const HOUR_PX = 64;
+const DEFAULT_GRID_START_HOUR = 8;
+const DEFAULT_GRID_END_HOUR = 17;
+
+function clockToMinutes(clock: string): number {
+  const [hours = 0, minutes = 0] = clock.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
+function isWeekendDay(day: Date): boolean {
+  const weekday = day.getDay();
+  return weekday === 0 || weekday === 6;
+}
+
+// Ganztägige und mehrtägige Einträge haben keine sinnvolle Position auf der
+// Zeitachse — sie wandern in die Ganztägig-Zeile über dem Raster.
+function isAllDayLike(event: CalendarEvent): boolean {
+  return event.all_day || event.start_date !== event.end_date;
+}
+
+// Ein Eintrag verschwindet mit ausgeblendetem Wochenende nur, wenn seine
+// gesamte Laufzeit auf Sa/So liegt — ein Fr–Sa-Termin bleibt sichtbar.
+function isWeekendOnlyEvent(event: CalendarEvent): boolean {
+  const start = parseISODate(event.start_date);
+  const end = parseISODate(event.end_date);
+  const spanDays = Math.min(
+    62,
+    Math.round((end.getTime() - start.getTime()) / 86_400_000) + 1,
+  );
+  for (let offset = 0; offset < spanDays; offset += 1) {
+    const day = new Date(start);
+    day.setDate(start.getDate() + offset);
+    if (!isWeekendDay(day)) return false;
+  }
+  return true;
+}
+
+function countWeekendEvents(
+  events: readonly CalendarEvent[],
+  weekendDays: readonly Date[],
+): number {
+  const seen = new Set<string>();
+  for (const day of weekendDays) {
+    for (const event of eventsForDay(events, day)) {
+      seen.add(event.id);
+    }
+  }
+  return seen.size;
+}
+
+function gridHours(dayEvents: readonly CalendarEvent[]): {
+  startHour: number;
+  endHour: number;
+} {
+  let startHour = DEFAULT_GRID_START_HOUR;
+  let endHour = DEFAULT_GRID_END_HOUR;
+  for (const event of dayEvents) {
+    if (isAllDayLike(event)) continue;
+    const startMinutes = clockToMinutes(event.start_time);
+    const endMinutes = Math.max(
+      clockToMinutes(event.end_time),
+      startMinutes + 30,
+    );
+    startHour = Math.min(startHour, Math.floor(startMinutes / 60));
+    endHour = Math.max(endHour, Math.ceil(endMinutes / 60));
+  }
+  startHour = Math.max(0, startHour);
+  endHour = Math.min(24, Math.max(endHour, startHour + 1));
+  return { startHour, endHour };
+}
+
+interface TimedPlacement {
+  event: CalendarEvent;
+  startMinutes: number;
+  endMinutes: number;
+  column: number;
+  columnCount: number;
+}
+
+// Klassisches Zeitraster-Layout: überlappende Einträge bilden ein Cluster und
+// teilen sich die Spaltenbreite; jeder Eintrag bekommt die erste freie Spalte.
+function layoutTimedEvents(
+  dayEvents: readonly CalendarEvent[],
+): TimedPlacement[] {
+  const items: TimedPlacement[] = dayEvents
+    .map((event) => {
+      const startMinutes = clockToMinutes(event.start_time);
+      return {
+        event,
+        startMinutes,
+        endMinutes: Math.max(clockToMinutes(event.end_time), startMinutes + 30),
+        column: 0,
+        columnCount: 1,
+      };
+    })
+    .sort(
+      (a, b) => a.startMinutes - b.startMinutes || b.endMinutes - a.endMinutes,
+    );
+
+  const placed: TimedPlacement[] = [];
+  let cluster: TimedPlacement[] = [];
+  let columnEnds: number[] = [];
+  let clusterEnd = -1;
+
+  const flushCluster = () => {
+    for (const item of cluster) {
+      item.columnCount = columnEnds.length;
+    }
+    placed.push(...cluster);
+    cluster = [];
+    columnEnds = [];
+    clusterEnd = -1;
+  };
+
+  for (const item of items) {
+    if (clusterEnd >= 0 && item.startMinutes >= clusterEnd) flushCluster();
+    let column = columnEnds.findIndex((end) => end <= item.startMinutes);
+    if (column === -1) {
+      column = columnEnds.length;
+      columnEnds.push(item.endMinutes);
+    } else {
+      columnEnds[column] = item.endMinutes;
+    }
+    item.column = column;
+    cluster.push(item);
+    clusterEnd = Math.max(clusterEnd, item.endMinutes);
+  }
+  flushCluster();
+  return placed;
 }
 
 function shiftDate(
@@ -214,6 +346,24 @@ export function PersonalCalendar({
     eventSortValue(a).localeCompare(eventSortValue(b)),
   );
   const label = periodLabel(referenceDate, viewMode, from, to);
+  const [showWeekend, setShowWeekend] = useState(false);
+  const visibleWeekDays = showWeekend
+    ? days
+    : days.filter((day) => !isWeekendDay(day));
+  const visibleMonthDays = showWeekend
+    ? monthDays
+    : monthDays.filter((day) => !isWeekendDay(day));
+  const hiddenWeekendDays =
+    viewMode === "month"
+      ? monthDays.filter(isWeekendDay)
+      : days.filter(isWeekendDay);
+  const hiddenWeekendCount = showWeekend
+    ? 0
+    : countWeekendEvents(events, hiddenWeekendDays);
+  const visibleSortedEvents =
+    showWeekend || viewMode === "day"
+      ? sortedEvents
+      : sortedEvents.filter((event) => !isWeekendOnlyEvent(event));
 
   return (
     <div className="space-y-4">
@@ -281,6 +431,19 @@ export function PersonalCalendar({
           >
             Heute
           </Button>
+          {viewMode !== "day" ? (
+            <Button
+              type="button"
+              variant={showWeekend ? "primary" : "outline"}
+              size="compact"
+              aria-pressed={showWeekend}
+              onClick={() => setShowWeekend((value) => !value)}
+            >
+              {hiddenWeekendCount > 0
+                ? `Sa/So (${hiddenWeekendCount})`
+                : "Sa/So"}
+            </Button>
+          ) : null}
           {onCreate ? (
             <Button type="button" size="compact" onClick={onCreate}>
               <Plus className="mr-1.5 h-4 w-4" aria-hidden />
@@ -304,36 +467,35 @@ export function PersonalCalendar({
         ) : null}
         {viewMode === "day" ? (
           <div className="hidden overflow-hidden rounded-lg border border-gray-200 bg-white lg:block">
-            <CalendarDayColumn
-              day={referenceDate}
-              events={eventsForDay(events, referenceDate)}
+            <CalendarTimeGrid
+              days={[referenceDate]}
+              events={events}
               onShowOverview={onShowOverview}
               onRespond={onRespond}
               respondingRecipientId={respondingRecipientId}
-              className="min-h-96"
             />
           </div>
         ) : null}
 
         {viewMode === "week" ? (
-          <div className="hidden overflow-hidden rounded-lg border border-gray-200 bg-white lg:grid lg:grid-cols-7">
-            {days.map((day) => (
-              <CalendarDayColumn
-                key={toISODate(day)}
-                day={day}
-                events={eventsForDay(events, day)}
-                onShowOverview={onShowOverview}
-                onRespond={onRespond}
-                respondingRecipientId={respondingRecipientId}
-                className="min-h-96 border-r border-gray-200 last:border-r-0"
-              />
-            ))}
+          <div className="hidden overflow-hidden rounded-lg border border-gray-200 bg-white lg:block">
+            <CalendarTimeGrid
+              days={visibleWeekDays}
+              events={events}
+              onShowOverview={onShowOverview}
+              onRespond={onRespond}
+              respondingRecipientId={respondingRecipientId}
+            />
           </div>
         ) : null}
 
         {viewMode === "month" ? (
-          <div className="hidden overflow-hidden rounded-lg border border-gray-200 bg-white lg:grid lg:grid-cols-7">
-            {monthDays.map((day) => {
+          <div
+            className={`hidden overflow-hidden rounded-lg border border-gray-200 bg-white lg:grid ${
+              showWeekend ? "lg:grid-cols-7" : "lg:grid-cols-5"
+            }`}
+          >
+            {visibleMonthDays.map((day) => {
               const inMonth = day.getMonth() === referenceDate.getMonth();
               return (
                 <CalendarDayColumn
@@ -353,10 +515,10 @@ export function PersonalCalendar({
         ) : null}
 
         <div className="space-y-3 lg:hidden">
-          {sortedEvents.length === 0 ? (
+          {visibleSortedEvents.length === 0 ? (
             <EmptyCalendarState viewMode={viewMode} />
           ) : (
-            sortedEvents.map((event) => (
+            visibleSortedEvents.map((event) => (
               <CalendarEventItem
                 key={event.id}
                 event={event}
@@ -368,7 +530,7 @@ export function PersonalCalendar({
           )}
         </div>
 
-        {!loading && sortedEvents.length === 0 ? (
+        {!loading && visibleSortedEvents.length === 0 ? (
           <div className="hidden lg:block">
             <EmptyCalendarState viewMode={viewMode} />
           </div>
@@ -429,6 +591,320 @@ function CalendarDayColumn({
         ))}
       </div>
     </section>
+  );
+}
+
+function CalendarTimeGrid({
+  days,
+  events,
+  onShowOverview,
+  onRespond,
+  respondingRecipientId,
+}: Readonly<{
+  days: readonly Date[];
+  events: readonly CalendarEvent[];
+  onShowOverview?: (appointmentId: string) => void;
+  onRespond?: (recipientId: string, status: "accepted" | "declined") => void;
+  respondingRecipientId?: string | null;
+}>) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const dayBuckets = days.map((day) => ({
+    day,
+    events: eventsForDay(events, day),
+  }));
+  const { startHour, endHour } = gridHours(
+    dayBuckets.flatMap((bucket) => bucket.events),
+  );
+  const gridStartMinutes = startHour * 60;
+  const bodyHeight = (endHour - startHour) * HOUR_PX;
+  const hours: number[] = [];
+  for (let hour = startHour; hour <= endHour; hour += 1) {
+    hours.push(hour);
+  }
+  const hasAllDay = dayBuckets.some((bucket) =>
+    bucket.events.some(isAllDayLike),
+  );
+  const columnTemplate = {
+    gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))`,
+  };
+
+  useEffect(() => {
+    const node = scrollRef.current;
+    if (!node) return;
+    node.scrollTop = Math.max(
+      0,
+      (DEFAULT_GRID_START_HOUR - startHour) * HOUR_PX - 8,
+    );
+  }, [startHour]);
+
+  return (
+    <div>
+      <div className="flex border-b border-gray-200">
+        <div className="w-14 shrink-0 border-r border-gray-200 bg-gray-50" />
+        <div className="grid flex-1" style={columnTemplate}>
+          {dayBuckets.map(({ day, events: dayEvents }) => (
+            <div
+              key={toISODate(day)}
+              className="border-r border-gray-200 bg-gray-50 px-3 py-2 last:border-r-0"
+            >
+              <div className="text-sm font-semibold text-gray-900">
+                {formatDayHeader(day)}
+              </div>
+              <div className="text-xs text-gray-500">
+                {dayEvents.length === 1
+                  ? "1 Eintrag"
+                  : `${dayEvents.length} Einträge`}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      {hasAllDay ? (
+        <div className="flex border-b border-gray-200">
+          <div className="w-14 shrink-0 border-r border-gray-200 px-1 py-2 text-right text-[11px] text-gray-400">
+            Ganztägig
+          </div>
+          <div className="grid flex-1" style={columnTemplate}>
+            {dayBuckets.map(({ day, events: dayEvents }) => (
+              <div
+                key={toISODate(day)}
+                className="space-y-1 border-r border-gray-200 p-1 last:border-r-0"
+              >
+                {dayEvents.filter(isAllDayLike).map((event) => (
+                  <CalendarEventItem
+                    key={`${event.id}-${toISODate(day)}`}
+                    event={event}
+                    onShowOverview={onShowOverview}
+                    onRespond={onRespond}
+                    respondingRecipientId={respondingRecipientId}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      <div ref={scrollRef} className="max-h-[70vh] overflow-y-auto">
+        <div className="flex" style={{ height: bodyHeight }}>
+          <div className="relative w-14 shrink-0 border-r border-gray-200">
+            {hours.map((hour) =>
+              hour === startHour ? null : (
+                <div
+                  key={hour}
+                  className="absolute right-1 -translate-y-1/2 text-[11px] text-gray-400"
+                  style={{ top: (hour - startHour) * HOUR_PX }}
+                >
+                  {`${String(hour).padStart(2, "0")}:00`}
+                </div>
+              ),
+            )}
+          </div>
+          <div className="grid flex-1" style={columnTemplate}>
+            {dayBuckets.map(({ day, events: dayEvents }) => (
+              <TimeGridDayBody
+                key={toISODate(day)}
+                events={dayEvents}
+                hours={hours}
+                startHour={startHour}
+                gridStartMinutes={gridStartMinutes}
+                bodyHeight={bodyHeight}
+                onShowOverview={onShowOverview}
+                onRespond={onRespond}
+                respondingRecipientId={respondingRecipientId}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TimeGridDayBody({
+  events,
+  hours,
+  startHour,
+  gridStartMinutes,
+  bodyHeight,
+  onShowOverview,
+  onRespond,
+  respondingRecipientId,
+}: Readonly<{
+  events: readonly CalendarEvent[];
+  hours: readonly number[];
+  startHour: number;
+  gridStartMinutes: number;
+  bodyHeight: number;
+  onShowOverview?: (appointmentId: string) => void;
+  onRespond?: (recipientId: string, status: "accepted" | "declined") => void;
+  respondingRecipientId?: string | null;
+}>) {
+  const shiftBands = events.filter(
+    (event) => event.source === "shift" && !isAllDayLike(event),
+  );
+  const timed = layoutTimedEvents(
+    events.filter((event) => event.source !== "shift" && !isAllDayLike(event)),
+  );
+  return (
+    <div
+      className="relative border-r border-gray-200 last:border-r-0"
+      style={{ height: bodyHeight }}
+    >
+      {hours.map((hour) =>
+        hour === startHour ? null : (
+          <div
+            key={hour}
+            className="absolute inset-x-0 border-t border-gray-100"
+            style={{ top: (hour - startHour) * HOUR_PX }}
+            aria-hidden
+          />
+        ),
+      )}
+      {shiftBands.map((event) => {
+        const tone = sourceTone[event.source];
+        const startMinutes = clockToMinutes(event.start_time);
+        const endMinutes = Math.max(
+          clockToMinutes(event.end_time),
+          startMinutes + 30,
+        );
+        return (
+          <div
+            key={event.id}
+            className="absolute inset-x-0.5 z-0 overflow-hidden rounded-md border px-1.5 py-1"
+            style={{
+              top: ((startMinutes - gridStartMinutes) / 60) * HOUR_PX + 1,
+              height: ((endMinutes - startMinutes) / 60) * HOUR_PX - 2,
+              backgroundColor: tone.bg,
+              borderColor: `${tone.bar}55`,
+            }}
+          >
+            <div className="flex flex-wrap items-center gap-1 text-[11px] text-gray-700">
+              <span className="rounded bg-white/80 px-1 py-0.5 font-semibold">
+                {tone.label}
+              </span>
+              <span className="font-semibold text-gray-900">{event.title}</span>
+              <span>{eventTime(event)}</span>
+            </div>
+            {event.description ? (
+              <p className="mt-0.5 truncate text-[11px] text-gray-600">
+                {event.description}
+              </p>
+            ) : null}
+          </div>
+        );
+      })}
+      {timed.map((placement) => (
+        <TimeGridEventBlock
+          key={placement.event.id}
+          placement={placement}
+          gridStartMinutes={gridStartMinutes}
+          onShowOverview={onShowOverview}
+          onRespond={onRespond}
+          respondingRecipientId={respondingRecipientId}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TimeGridEventBlock({
+  placement,
+  gridStartMinutes,
+  onShowOverview,
+  onRespond,
+  respondingRecipientId,
+}: Readonly<{
+  placement: TimedPlacement;
+  gridStartMinutes: number;
+  onShowOverview?: (appointmentId: string) => void;
+  onRespond?: (recipientId: string, status: "accepted" | "declined") => void;
+  respondingRecipientId?: string | null;
+}>) {
+  const { event, startMinutes, endMinutes, column, columnCount } = placement;
+  const tone = sourceTone[event.source];
+  const recipientId = event.recipient_id;
+  const responding =
+    Boolean(recipientId) && respondingRecipientId === recipientId;
+  const showRespond = Boolean(event.can_respond && recipientId && onRespond);
+  const showOverview = Boolean(
+    event.can_view_overview && event.appointment_id && onShowOverview,
+  );
+  const rawHeight = ((endMinutes - startMinutes) / 60) * HOUR_PX - 2;
+  // Blöcke mit Aktionen bekommen eine Mindesthöhe, damit die Buttons bedienbar
+  // bleiben — kurze Termine dürfen dafür optisch über ihr Zeitfenster hinausragen.
+  const minHeight = 56 + (showRespond ? 40 : 0) + (showOverview ? 36 : 0);
+  const height = Math.max(rawHeight, minHeight);
+  const widthPercent = 100 / columnCount;
+  return (
+    <article
+      className="absolute z-10 overflow-hidden rounded-md border border-gray-200 p-1.5 shadow-sm"
+      style={{
+        top: ((startMinutes - gridStartMinutes) / 60) * HOUR_PX + 1,
+        height,
+        left: `calc(${column * widthPercent}% + 2px)`,
+        width: `calc(${widthPercent}% - 4px)`,
+        borderLeft: `3px solid ${tone.bar}`,
+        backgroundColor: tone.bg,
+      }}
+    >
+      <div className="flex flex-wrap items-center gap-1">
+        <span className="rounded bg-white/80 px-1 py-0.5 text-[10px] font-semibold text-gray-700">
+          {tone.label}
+        </span>
+        {event.response_status ? (
+          <span className="rounded bg-white/80 px-1 py-0.5 text-[10px] font-semibold text-gray-700">
+            {responseLabel[event.response_status] ?? event.response_status}
+          </span>
+        ) : null}
+      </div>
+      <div className="truncate text-xs font-semibold text-gray-950">
+        {event.title}
+      </div>
+      <div className="text-[11px] text-gray-600">{eventTime(event)}</div>
+      {event.student_name || event.school_name ? (
+        <div className="truncate text-[11px] text-gray-600">
+          {[event.student_name, event.school_name].filter(Boolean).join(" · ")}
+        </div>
+      ) : null}
+      {showOverview ? (
+        <Button
+          type="button"
+          size="compact"
+          variant="ghost"
+          className="mt-1 w-full bg-white/50"
+          onClick={() => onShowOverview!(event.appointment_id!)}
+        >
+          <Users className="h-4 w-4" aria-hidden />
+          Teilnehmer
+        </Button>
+      ) : null}
+      {showRespond ? (
+        <div className="mt-1 flex gap-1">
+          <Button
+            type="button"
+            size="compact"
+            variant="outline"
+            className="flex-1"
+            disabled={responding}
+            onClick={() => onRespond!(recipientId!, "accepted")}
+          >
+            <Check className="h-4 w-4" aria-hidden />
+            Zusagen
+          </Button>
+          <Button
+            type="button"
+            size="compact"
+            variant="outline_danger"
+            className="flex-1"
+            disabled={responding}
+            onClick={() => onRespond!(recipientId!, "declined")}
+          >
+            <X className="h-4 w-4" aria-hidden />
+            Absagen
+          </Button>
+        </div>
+      ) : null}
+    </article>
   );
 }
 

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -179,23 +179,60 @@ function gridHours(dayEvents: readonly CalendarEvent[]): {
 interface TimedPlacement {
   event: CalendarEvent;
   startMinutes: number;
+  // Effektives Render-Ende: das spätere von tatsächlichem Ende und der
+  // Mindesthöhe des Karteninhalts. Layout UND Kartenhöhe rechnen mit diesem
+  // Wert, damit optisch verlängerte Karten nachfolgende nicht verdecken.
   endMinutes: number;
   column: number;
   columnCount: number;
+}
+
+interface TimedLayoutOptions {
+  hasRespond: boolean;
+  hasOverview: boolean;
+}
+
+// Mindesthöhe eines Zeitraster-Blocks in Pixeln, abhängig vom Inhalt. Muss zum
+// Markup in TimeGridEventBlock passen — Aktionen und Textzeilen brauchen Platz,
+// sonst wären sie bei kurzen Terminen abgeschnitten.
+function blockMinHeightPx(
+  event: CalendarEvent,
+  options: TimedLayoutOptions,
+): number {
+  const showRespond = Boolean(
+    event.can_respond && event.recipient_id && options.hasRespond,
+  );
+  const showOverview = Boolean(
+    event.can_view_overview && event.appointment_id && options.hasOverview,
+  );
+  return (
+    56 +
+    ((event.student_name ?? event.school_name) ? 16 : 0) +
+    (event.location ? 18 : 0) +
+    (event.description ? 36 : 0) +
+    (showRespond ? 40 : 0) +
+    (showOverview ? 36 : 0)
+  );
 }
 
 // Klassisches Zeitraster-Layout: überlappende Einträge bilden ein Cluster und
 // teilen sich die Spaltenbreite; jeder Eintrag bekommt die erste freie Spalte.
 function layoutTimedEvents(
   dayEvents: readonly CalendarEvent[],
+  options: TimedLayoutOptions,
 ): TimedPlacement[] {
   const items: TimedPlacement[] = dayEvents
     .map((event) => {
       const startMinutes = clockToMinutes(event.start_time);
+      const minRenderMinutes =
+        (blockMinHeightPx(event, options) / HOUR_PX) * 60;
       return {
         event,
         startMinutes,
-        endMinutes: Math.max(clockToMinutes(event.end_time), startMinutes + 30),
+        endMinutes: Math.max(
+          clockToMinutes(event.end_time),
+          startMinutes + minRenderMinutes,
+        ),
         column: 0,
         columnCount: 1,
       };
@@ -744,6 +781,7 @@ function TimeGridDayBody({
   );
   const timed = layoutTimedEvents(
     events.filter((event) => event.source !== "shift" && !isAllDayLike(event)),
+    { hasRespond: Boolean(onRespond), hasOverview: Boolean(onShowOverview) },
   );
   return (
     <div
@@ -829,11 +867,9 @@ function TimeGridEventBlock({
   const showOverview = Boolean(
     event.can_view_overview && event.appointment_id && onShowOverview,
   );
-  const rawHeight = ((endMinutes - startMinutes) / 60) * HOUR_PX - 2;
-  // Blöcke mit Aktionen bekommen eine Mindesthöhe, damit die Buttons bedienbar
-  // bleiben — kurze Termine dürfen dafür optisch über ihr Zeitfenster hinausragen.
-  const minHeight = 56 + (showRespond ? 40 : 0) + (showOverview ? 36 : 0);
-  const height = Math.max(rawHeight, minHeight);
+  // endMinutes ist bereits das effektive Render-Ende aus layoutTimedEvents —
+  // die Mindesthöhe steckt in der Platzierung, damit nichts überdeckt wird.
+  const height = ((endMinutes - startMinutes) / 60) * HOUR_PX - 2;
   const widthPercent = 100 / columnCount;
   return (
     <article
@@ -865,6 +901,17 @@ function TimeGridEventBlock({
         <div className="truncate text-[11px] text-gray-600">
           {[event.student_name, event.school_name].filter(Boolean).join(" · ")}
         </div>
+      ) : null}
+      {event.location ? (
+        <div className="flex items-center gap-1 text-[11px] text-gray-600">
+          <MapPin className="h-3 w-3 shrink-0" aria-hidden />
+          <span className="truncate">{event.location}</span>
+        </div>
+      ) : null}
+      {event.description ? (
+        <p className="mt-0.5 line-clamp-2 text-[11px] leading-4 text-gray-600">
+          {event.description}
+        </p>
       ) : null}
       {showOverview ? (
         <Button

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -830,8 +830,9 @@ export const appChapters: readonly GuideChapter[] = [
           "Zeigt persönliche Termine, Einladungen, eigene Dienstplan-Schichten und zugewiesene Betreuungsangebote. Mitarbeitende mit Verwaltungsrecht erstellen Termine für Team, Eltern oder ganze Gruppen.",
         steps: [
           "`Mein Kalender` öffnen.",
-          "Oben zwischen `Tag`, `Woche` und `Monat` wechseln und mit den Pfeilen oder `Heute` zum passenden Zeitraum springen.",
-          "Einträge an der Farbe unterscheiden: grüne Karten sind Termine (`Termin`), blaue Karten Betreuungsblöcke (`Betreuung`), orangefarbene Karten die eigenen Dienstplan-Schichten (`Dienst`). Schichten kommen aus dem Dienstplan und lassen sich hier nicht bearbeiten.",
+          "Oben zwischen `Tag`, `Woche` und `Monat` wechseln und mit den Pfeilen oder `Heute` zum passenden Zeitraum springen. Samstag und Sonntag sind standardmäßig ausgeblendet; über `Sa/So` blendest du sie ein — steht dort ein Zähler, liegen Einträge am Wochenende.",
+          "Die Tages- und Wochenansicht ordnen Einträge auf einer Stunden-Zeitachse an; Dienstplan-Schichten hinterlegen ihren Zeitraum als farbiges Band im Hintergrund, Termine und Betreuungsblöcke liegen darüber.",
+          "Einträge an der Farbe unterscheiden: grüne Karten sind Termine (`Termin`), blaue Karten Betreuungsblöcke (`Betreuung`), orangefarbene die eigenen Dienstplan-Schichten (`Dienst`). Schichten kommen aus dem Dienstplan und lassen sich hier nicht bearbeiten.",
           "Mit `Neuer Termin` den Dialog öffnen. Diese Schaltfläche sehen nur Personen mit dem Recht, Kalendertermine zu verwalten.",
           "`Titel`, Datum, Uhrzeit, Ort und Beschreibung eintragen. Bei ganztägigen Terminen `Ganztägig` aktivieren.",
           "Unter `Antwortregel` wählen, ob Eingeladene zusagen/absagen müssen oder nur informiert werden.",

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -827,10 +827,11 @@ export const appChapters: readonly GuideChapter[] = [
         title: "Mein Kalender",
         icon: CalendarRange,
         summary:
-          "Zeigt persönliche Termine, Einladungen und zugewiesene Betreuungsangebote. Mitarbeitende mit Verwaltungsrecht erstellen Termine für Team, Eltern oder ganze Gruppen.",
+          "Zeigt persönliche Termine, Einladungen, eigene Dienstplan-Schichten und zugewiesene Betreuungsangebote. Mitarbeitende mit Verwaltungsrecht erstellen Termine für Team, Eltern oder ganze Gruppen.",
         steps: [
           "`Mein Kalender` öffnen.",
           "Oben zwischen `Tag`, `Woche` und `Monat` wechseln und mit den Pfeilen oder `Heute` zum passenden Zeitraum springen.",
+          "Einträge an der Farbe unterscheiden: grüne Karten sind Termine (`Termin`), blaue Karten Betreuungsblöcke (`Betreuung`), orangefarbene Karten die eigenen Dienstplan-Schichten (`Dienst`). Schichten kommen aus dem Dienstplan und lassen sich hier nicht bearbeiten.",
           "Mit `Neuer Termin` den Dialog öffnen. Diese Schaltfläche sehen nur Personen mit dem Recht, Kalendertermine zu verwalten.",
           "`Titel`, Datum, Uhrzeit, Ort und Beschreibung eintragen. Bei ganztägigen Terminen `Ganztägig` aktivieren.",
           "Unter `Antwortregel` wählen, ob Eingeladene zusagen/absagen müssen oder nur informiert werden.",

--- a/frontend/src/lib/personal-calendar-api.ts
+++ b/frontend/src/lib/personal-calendar-api.ts
@@ -5,7 +5,7 @@ interface ApiEnvelope<T> {
   readonly data?: T;
 }
 
-type CalendarSource = "appointment" | "timetable";
+type CalendarSource = "appointment" | "timetable" | "shift";
 export type CalendarDeliveryMode = "rsvp_required" | "informational";
 export type CalendarOverviewVisibility = "organizer" | "staff" | "all";
 export type CalendarResponseStatus =


### PR DESCRIPTION
Closes #1957

## Was ändert sich

Der persönliche Kalender (`/calendar`, „Mein Kalender") zeigt jetzt zusätzlich die eigenen Dienstplan-Schichten aus `schedule.staff_shifts` als dritte Event-Quelle `source: "shift"` in `GET /api/calendar/my`. Dazu wurde die Tages- und Wochenansicht auf ein Zeitachsen-Raster umgebaut und das Wochenende standardmäßig ausgeblendet.

### Backend
- Neue Konstante `EventSourceShift = "shift"` (`models/calendar/appointment.go`)
- `services/calendar`: neue Quelle `staffShiftEvents` in `ListMyStaffEvents`, gespeist aus dem bestehenden `StaffShiftRepo.FindByStaffAndDateRange` (kein neuer Query-Pfad, tenant-gescoped, Wall-Clock-normalisiert)
- Titel = Name der Schichtart (per `ShiftTypeRepo` aufgelöst, gecacht pro Anfrage), Fallback `"Dienst"`; Notizen der Schicht werden zur Beschreibung
- Abgesagte Schichten (`cancelled`) erscheinen nicht, analog zu stornierten Betreuungsblöcken
- Kein Handler-, Proxy- oder Migrations-Change nötig; `api/calendar` ist source-agnostisch

### Frontend: neue Quelle „Dienst"
- `CalendarSource`-Union um `"shift"` erweitert; `sourceTone` bekommt eine orange `Dienst`-Darstellung (`LOCATION_COLORS.SCHOOLYARD` `#F78C10`) — damit sind Schicht (äußere geplante Anwesenheit) und Betreuungsblock (Aufgabe darin) klar unterscheidbar
- Untertitel der Kalenderseite und der Hilfe-Guide-Eintrag „Mein Kalender" erwähnen die Schichten

### Frontend: Zeitachsen-Raster (Tag + Woche)
- Einträge liegen auf einem Stundenraster (Standardfenster 08–17 Uhr, erweitert sich automatisch um frühere/spätere Einträge)
- Dienstplan-Schichten hinterlegen ihren Zeitraum als farbiges Band im Hintergrund; Termine und Betreuungsblöcke liegen als positionierte Blöcke darüber
- Überlappende Einträge teilen sich die Spaltenbreite nebeneinander; ganztägige und mehrtägige Einträge bekommen eine eigene Zeile über dem Raster
- Zusagen/Absagen und Teilnehmer bleiben direkt im Block bedienbar (Mindesthöhe; sehr kurze Termine ragen dafür optisch etwas über ihr Zeitfenster hinaus)
- Die Monatsansicht behält die kompakten Karten

### Frontend: Mo–Fr als Standard
- Wochen- und Monatsansicht blenden Samstag und Sonntag standardmäßig aus
- Der `Sa/So`-Schalter blendet sie ein und zeigt einen Zähler (z. B. `Sa/So (2)`), wenn ausgeblendete Wochenendtage Einträge enthalten — nichts verschwindet stillschweigend
- Die mobile Liste filtert konsistent mit; Einträge, die nur teilweise aufs Wochenende fallen (z. B. Fr–Sa), bleiben immer sichtbar

### Design-Entscheidungen
- Feste Farbe pro Quelle statt der individuellen Schichtart-Farbe: konsistent mit den beiden bestehenden Quellen, kein neues Feld im Event-Payload. Der Schichtart-Name bleibt über den Titel sichtbar.
- Keine Legende/Filter-UI — gibt es im Kalender bisher für keine Quelle, außerhalb des Issue-Scopes.

## Tests
- Neues Fixture `CreateTestStaffShift` (hermetisch, `test/fixtures.go`)
- `TestCalendarServiceIntegration_StaffCalendarIncludesShifts`: typisierte Schicht (Titel + Beschreibung), untypisierte Schicht (Fallback `Dienst`), abgesagte Schicht ausgeschlossen
- Frontend: neue Testfälle für die `Dienst`-Badge und den `Sa/So`-Toggle in `personal-calendar.test.tsx`; alle bestehenden Kalender-Tests unverändert grün
- `go test ./services/calendar/` grün, Ratchet-/Hermetik-/Date-Gates grün, `golangci-lint` 0 issues, `pnpm run check` + komplette Vitest-Suite (11 679 Tests) grün

## E2E-Verifikation
Lokal gegen den Docker-Stack geprüft: Schichten (mit/ohne Schichtart) erscheinen als orangefarbenes Hintergrund-Band in Tag- und Wochenansicht, Termine (grün) und Betreuung (blau) liegen zeitlich positioniert darüber; die abgesagte Schicht bleibt unsichtbar. Sa/So-Toggle, Monatsansicht mit 5 Spalten und mobile Liste geprüft. Screenshots im Kommentar unten.