### PR TITLE
feat(time-tracking): NFC-Stempeluhr am Kiosk (Backend)

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -465,6 +465,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.IoT = iotAPI.NewResource(iotAPI.ServiceDependencies{
 		IoTService:            api.Services.IoT,
 		CheckinService:        api.Services.Checkin,
+		StaffClockService:     api.Services.StaffClock,
 		UsersService:          api.Services.Users,
 		ActiveService:         api.Services.Active,
 		ActivitiesService:     api.Services.Activities,

--- a/backend/api/iot/api.go
+++ b/backend/api/iot/api.go
@@ -12,6 +12,7 @@ import (
 	checkinAPI "github.com/moto-nrw/project-phoenix/api/iot/checkin"
 	dataAPI "github.com/moto-nrw/project-phoenix/api/iot/data"
 	sessionsAPI "github.com/moto-nrw/project-phoenix/api/iot/sessions"
+	staffclockAPI "github.com/moto-nrw/project-phoenix/api/iot/staffclock"
 	"github.com/moto-nrw/project-phoenix/auth/device"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/realtime"
@@ -24,6 +25,7 @@ import (
 	feedbackSvc "github.com/moto-nrw/project-phoenix/services/feedback"
 	iotSvc "github.com/moto-nrw/project-phoenix/services/iot"
 	checkinSvc "github.com/moto-nrw/project-phoenix/services/iot/checkin"
+	staffclockSvc "github.com/moto-nrw/project-phoenix/services/iot/staffclock"
 	platformSvc "github.com/moto-nrw/project-phoenix/services/platform"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
 	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
@@ -43,6 +45,7 @@ func delegateHandler(router chi.Router) http.HandlerFunc {
 type ServiceDependencies struct {
 	IoTService            iotSvc.Service
 	CheckinService        *checkinSvc.CheckinService
+	StaffClockService     *staffclockSvc.Service
 	UsersService          usersSvc.PersonService
 	ActiveService         activeSvc.Service
 	ActivitiesService     activitiesSvc.ActivityService
@@ -154,6 +157,12 @@ func (rs *Resource) Router() chi.Router {
 		r.Post("/pickup-query", checkinHandler)
 		r.Post("/ping", checkinHandler)
 		r.Get("/status", checkinHandler)
+
+		// Pure staff time tracking, independent of activities or groups.
+		staffClockResource := staffclockAPI.NewResource(rs.StaffClockService)
+		staffClockHandler := delegateHandler(staffClockResource.Router())
+		r.Post("/staff-clock", staffClockHandler)
+		r.Post("/staff-clock/state", staffClockHandler)
 
 		// Feedback endpoint (device-based feedback submission)
 		feedbackResource := dataAPI.NewFeedbackResource(rs.IoTService, rs.UsersService, rs.FeedbackService, rs.SettingsService)

--- a/backend/api/iot/pyreportal_error_strings_test.go
+++ b/backend/api/iot/pyreportal_error_strings_test.go
@@ -124,6 +124,20 @@ var pyreportalErrorStrings = []string{
 	"student not found",
 }
 
+// Staff-clock screens branch on stable codes rather than English prose. Keep
+// those codes under the same cross-repository tripwire as legacy substrings.
+var pyreportalErrorCodes = []string{
+	"invalid_staff_clock_request",
+	"invalid_rfid_tag",
+	"rfid_tag_not_found",
+	"rfid_tag_inactive",
+	"rfid_tag_not_staff",
+	"reopen_status_conflict",
+	"planned_start_not_reached",
+	"deviation_reason_required",
+	"invalid_staff_clock_state",
+}
+
 // extraGuardSources are files OUTSIDE api/iot whose error strings surface
 // through IoT routes: device auth middleware, active-service sentinels
 // bubbled by the checkin/session workflows, and the api/common message
@@ -188,6 +202,13 @@ func TestPyrePortalErrorStringsGuard(t *testing.T) {
 				"PyrePortal's German translation for this error. If the change is "+
 				"intentional, update PyrePortal/src/services/apiErrors.ts "+
 				"ERROR_MESSAGE_MAPPINGS and this test in the same PR.",
+			want,
+		)
+	}
+	for _, want := range pyreportalErrorCodes {
+		assert.Containsf(t, corpus, want,
+			"PyrePortal branches on the stable IoT error code %q. Update the backend and "+
+				"PyrePortal mapping together if this contract changes.",
 			want,
 		)
 	}

--- a/backend/api/iot/staffclock/errors.go
+++ b/backend/api/iot/staffclock/errors.go
@@ -23,6 +23,10 @@ func classifyError(err error) render.Renderer {
 		return common.ErrorConflictWithCode(err, "rfid_tag_not_staff")
 	case errors.Is(err, staffclockSvc.ErrInvalidAction), errors.Is(err, staffclockSvc.ErrStatusRequired):
 		return common.ErrorInvalidRequestWithCode(err, "invalid_staff_clock_request")
+	case errors.Is(err, staffclockSvc.ErrCheckInRaced):
+		// A concurrent scan won the insert: the same state conflict the kiosk
+		// already knows how to recover from, not a server fault.
+		return common.ErrorConflictWithCode(err, "invalid_staff_clock_state")
 	}
 
 	var reopenConflict *activeSvc.ReopenStatusConflictError

--- a/backend/api/iot/staffclock/errors.go
+++ b/backend/api/iot/staffclock/errors.go
@@ -1,0 +1,62 @@
+package staffclock
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	staffclockSvc "github.com/moto-nrw/project-phoenix/services/iot/staffclock"
+)
+
+func classifyError(err error) render.Renderer {
+	switch {
+	case errors.Is(err, staffclockSvc.ErrInvalidRFIDTag):
+		return common.ErrorInvalidRequestWithCode(err, "invalid_rfid_tag")
+	case errors.Is(err, staffclockSvc.ErrRFIDTagNotFound):
+		return common.ErrorNotFoundWithCode(err, "rfid_tag_not_found")
+	case errors.Is(err, staffclockSvc.ErrRFIDTagInactive):
+		return common.ErrorConflictWithCode(err, "rfid_tag_inactive")
+	case errors.Is(err, staffclockSvc.ErrRFIDTagNotStaff):
+		return common.ErrorConflictWithCode(err, "rfid_tag_not_staff")
+	case errors.Is(err, staffclockSvc.ErrInvalidAction), errors.Is(err, staffclockSvc.ErrStatusRequired):
+		return common.ErrorInvalidRequestWithCode(err, "invalid_staff_clock_request")
+	}
+
+	var reopenConflict *activeSvc.ReopenStatusConflictError
+	if errors.As(err, &reopenConflict) {
+		return common.ErrorConflictWithDetails(err, "reopen_status_conflict", map[string]any{
+			"session_id":       strconv.FormatInt(reopenConflict.SessionID, 10),
+			"existing_status":  reopenConflict.ExistingStatus,
+			"requested_status": reopenConflict.RequestedStatus,
+		})
+	}
+	var plannedStart *activeSvc.PlannedStartNotReachedError
+	if errors.As(err, &plannedStart) {
+		return common.ErrorConflictWithDetails(err, "planned_start_not_reached", map[string]any{
+			"planned_start_time": plannedStart.PlannedStartTime,
+			"current_time":       plannedStart.CurrentTime,
+		})
+	}
+	var deviation *activeSvc.DeviationReasonRequiredError
+	if errors.As(err, &deviation) {
+		return common.ErrorConflictWithDetails(err, "deviation_reason_required", map[string]any{
+			"action":            deviation.Action,
+			"planned_time":      deviation.PlannedTime,
+			"actual_time":       deviation.ActualTime,
+			"deviation_minutes": strconv.Itoa(deviation.DeviationMinutes),
+		})
+	}
+
+	switch err.Error() {
+	case "already checked in", "already checked out today", "break already active",
+		"no active session found", "no session found for today", "no active break found":
+		return common.ErrorConflictWithCode(err, "invalid_staff_clock_state")
+	}
+	if strings.HasPrefix(err.Error(), "planned_duration_minutes must be") {
+		return common.ErrorInvalidRequestWithCode(err, "invalid_staff_clock_request")
+	}
+	return common.ErrorInternalServerWrap("staff clock operation failed", err)
+}

--- a/backend/api/iot/staffclock/resource.go
+++ b/backend/api/iot/staffclock/resource.go
@@ -1,0 +1,59 @@
+package staffclock
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	staffclockSvc "github.com/moto-nrw/project-phoenix/services/iot/staffclock"
+)
+
+type Resource struct {
+	service *staffclockSvc.Service
+}
+
+func NewResource(service *staffclockSvc.Service) *Resource {
+	return &Resource{service: service}
+}
+
+func (rs *Resource) Router() chi.Router {
+	r := chi.NewRouter()
+	r.Post("/staff-clock", rs.execute)
+	r.Post("/staff-clock/state", rs.getState)
+	return r
+}
+
+func (rs *Resource) getState(w http.ResponseWriter, r *http.Request) {
+	req := new(StateRequest)
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, "invalid_staff_clock_request"))
+		return
+	}
+	state, err := rs.service.GetState(r.Context(), req.RFIDTag)
+	if err != nil {
+		common.RenderError(w, r, classifyError(err))
+		return
+	}
+	common.Respond(w, r, http.StatusOK, state, "Staff clock state retrieved")
+}
+
+func (rs *Resource) execute(w http.ResponseWriter, r *http.Request) {
+	req := new(CommandRequest)
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, "invalid_staff_clock_request"))
+		return
+	}
+	state, err := rs.service.Execute(r.Context(), staffclockSvc.Command{
+		RFIDTag:                req.RFIDTag,
+		Action:                 req.Action,
+		Status:                 req.Status,
+		Reason:                 req.Reason,
+		PlannedDurationMinutes: req.PlannedDurationMinutes,
+	})
+	if err != nil {
+		common.RenderError(w, r, classifyError(err))
+		return
+	}
+	common.Respond(w, r, http.StatusOK, state, "Staff clock action completed")
+}

--- a/backend/api/iot/staffclock/staffclock_test.go
+++ b/backend/api/iot/staffclock/staffclock_test.go
@@ -1,0 +1,138 @@
+// Package staffclock_test exercises the staff-clock HTTP boundary with real
+// repositories and tenant-scoped transactions.
+package staffclock_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	staffclockAPI "github.com/moto-nrw/project-phoenix/api/iot/staffclock"
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	iotModels "github.com/moto-nrw/project-phoenix/models/iot"
+	"github.com/moto-nrw/project-phoenix/services"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+type testContext struct {
+	db       *bun.DB
+	services *services.Factory
+	device   *iotModels.Device
+}
+
+func setupTestContext(t *testing.T) *testContext {
+	t.Helper()
+	db, serviceFactory := testutil.SetupAPITest(t)
+	testDevice := testpkg.CreateTestDevice(t, db, "staff-clock-device")
+	return &testContext{db: db, services: serviceFactory, device: testDevice}
+}
+
+func (ctx *testContext) execute(t *testing.T, path string, body map[string]any) map[string]any {
+	t.Helper()
+	router := testutil.NewTenantRouter(ctx.db)
+	router.Mount("/", staffclockAPI.NewResource(ctx.services.StaffClock).Router())
+	req := testutil.NewAuthenticatedRequest(t, http.MethodPost, path, body, testutil.WithDeviceContext(ctx.device))
+	response := testutil.ExecuteRequest(router, req)
+	require.Equal(t, http.StatusOK, response.Code, "response: %s", response.Body.String())
+	return testutil.ParseJSONResponse(t, response.Body.Bytes())
+}
+
+func TestStaffClock_FullNFCFlow(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Nora", "Kiosk")
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, "A1654BEEF")
+	testpkg.LinkRFIDToStudent(t, ctx.db, staff.PersonID, card.ID)
+
+	initial := ctx.execute(t, "/staff-clock/state", map[string]any{"rfid_tag": card.ID})
+	initialData := initial["data"].(map[string]any)
+	assert.Equal(t, "checked_out", initialData["state"])
+	assert.Equal(t, "Nora Kiosk", initialData["staff_name"])
+
+	checkedIn := ctx.execute(t, "/staff-clock", map[string]any{
+		"rfid_tag": card.ID,
+		"action":   "checkin",
+		"status":   "present",
+	})
+	checkedInData := checkedIn["data"].(map[string]any)
+	assert.Equal(t, "checked_in", checkedInData["state"])
+	session := checkedInData["session"].(map[string]any)
+	assert.Equal(t, activeModels.WorkSessionSourceNFC, session["source"])
+	assert.Equal(t, activeModels.WorkSessionStatusPresent, session["status"])
+
+	duplicateRouter := testutil.NewTenantRouter(ctx.db)
+	duplicateRouter.Mount("/", staffclockAPI.NewResource(ctx.services.StaffClock).Router())
+	duplicateReq := testutil.NewAuthenticatedRequest(t, http.MethodPost, "/staff-clock", map[string]any{
+		"rfid_tag": card.ID,
+		"action":   "checkin",
+		"status":   "present",
+	}, testutil.WithDeviceContext(ctx.device))
+	duplicateResponse := testutil.ExecuteRequest(duplicateRouter, duplicateReq)
+	require.Equal(t, http.StatusConflict, duplicateResponse.Code, "response: %s", duplicateResponse.Body.String())
+	assert.Equal(t, "invalid_staff_clock_state", testutil.ParseJSONResponse(t, duplicateResponse.Body.Bytes())["code"])
+
+	onBreak := ctx.execute(t, "/staff-clock", map[string]any{
+		"rfid_tag": card.ID,
+		"action":   "break_start",
+	})
+	assert.Equal(t, "on_break", onBreak["data"].(map[string]any)["state"])
+
+	resumed := ctx.execute(t, "/staff-clock", map[string]any{
+		"rfid_tag": card.ID,
+		"action":   "break_end",
+	})
+	assert.Equal(t, "checked_in", resumed["data"].(map[string]any)["state"])
+
+	checkedOut := ctx.execute(t, "/staff-clock", map[string]any{
+		"rfid_tag": card.ID,
+		"action":   "checkout",
+	})
+	assert.Equal(t, "checked_out", checkedOut["data"].(map[string]any)["state"])
+
+	// Reopening with a different work location must never silently rewrite
+	// status. The first request returns a typed conflict; a reason-bearing
+	// retry reopens and records the audited status change atomically.
+	router := testutil.NewTenantRouter(ctx.db)
+	router.Mount("/", staffclockAPI.NewResource(ctx.services.StaffClock).Router())
+	conflictReq := testutil.NewAuthenticatedRequest(t, http.MethodPost, "/staff-clock", map[string]any{
+		"rfid_tag": card.ID,
+		"action":   "checkin",
+		"status":   "home_office",
+	}, testutil.WithDeviceContext(ctx.device))
+	conflictResponse := testutil.ExecuteRequest(router, conflictReq)
+	require.Equal(t, http.StatusConflict, conflictResponse.Code, "response: %s", conflictResponse.Body.String())
+	assert.Equal(t, "reopen_status_conflict", testutil.ParseJSONResponse(t, conflictResponse.Body.Bytes())["code"])
+
+	reopened := ctx.execute(t, "/staff-clock", map[string]any{
+		"rfid_tag": card.ID,
+		"action":   "checkin",
+		"status":   "home_office",
+		"reason":   "Nachmittags im Homeoffice",
+	})
+	reopenedSession := reopened["data"].(map[string]any)["session"].(map[string]any)
+	assert.Equal(t, activeModels.WorkSessionStatusHomeOffice, reopenedSession["status"])
+	assert.Equal(t, activeModels.WorkSessionSourceNFC, reopenedSession["source"])
+}
+
+func TestStaffClock_RejectsStudentCard(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Sam", "Schueler", "1a")
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, "B1654CAFE")
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	router := testutil.NewTenantRouter(ctx.db)
+	router.Mount("/", staffclockAPI.NewResource(ctx.services.StaffClock).Router())
+	req := testutil.NewAuthenticatedRequest(t, http.MethodPost, "/staff-clock/state", map[string]any{"rfid_tag": card.ID}, testutil.WithDeviceContext(ctx.device))
+	response := testutil.ExecuteRequest(router, req)
+
+	assert.Equal(t, http.StatusConflict, response.Code)
+	parsed := testutil.ParseJSONResponse(t, response.Body.Bytes())
+	assert.Equal(t, "rfid_tag_not_staff", parsed["code"])
+}

--- a/backend/api/iot/staffclock/types.go
+++ b/backend/api/iot/staffclock/types.go
@@ -1,0 +1,45 @@
+package staffclock
+
+import (
+	"errors"
+	"net/http"
+
+	validation "github.com/go-ozzo/ozzo-validation"
+	staffclockSvc "github.com/moto-nrw/project-phoenix/services/iot/staffclock"
+)
+
+type StateRequest struct {
+	RFIDTag string `json:"rfid_tag"`
+}
+
+func (req *StateRequest) Bind(_ *http.Request) error {
+	return validation.ValidateStruct(req,
+		validation.Field(&req.RFIDTag, validation.Required),
+	)
+}
+
+type CommandRequest struct {
+	RFIDTag                string `json:"rfid_tag"`
+	Action                 string `json:"action"`
+	Status                 string `json:"status,omitempty"`
+	Reason                 string `json:"reason,omitempty"`
+	PlannedDurationMinutes *int   `json:"planned_duration_minutes,omitempty"`
+}
+
+func (req *CommandRequest) Bind(_ *http.Request) error {
+	if err := validation.ValidateStruct(req,
+		validation.Field(&req.RFIDTag, validation.Required),
+		validation.Field(&req.Action, validation.Required, validation.In(
+			staffclockSvc.ActionCheckIn,
+			staffclockSvc.ActionCheckOut,
+			staffclockSvc.ActionBreakStart,
+			staffclockSvc.ActionBreakEnd,
+		)),
+	); err != nil {
+		return err
+	}
+	if req.Action == staffclockSvc.ActionCheckIn && req.Status == "" {
+		return errors.New("status is required for check-in")
+	}
+	return nil
+}

--- a/backend/api/testdata/iot_auth_matrix.golden
+++ b/backend/api/testdata/iot_auth_matrix.golden
@@ -37,6 +37,8 @@ POST /api/iot/session/end -> 401 {"status":"error","error":"device API key is re
 POST /api/iot/session/start -> 401 {"status":"error","error":"device API key is required"}
 POST /api/iot/session/timeout -> 401 {"status":"error","error":"device API key is required"}
 POST /api/iot/session/validate-timeout -> 401 {"status":"error","error":"device API key is required"}
+POST /api/iot/staff-clock -> 401 {"status":"error","error":"device API key is required"}
+POST /api/iot/staff-clock/state -> 401 {"status":"error","error":"device API key is required"}
 POST /api/iot/staff/{staffId}/rfid -> 401 {"status":"error","error":"device API key is required"}
 PUT /api/iot/*/{id} -> 401 {"status":"error","error":"token unauthorized"}
 PUT /api/iot/session/{sessionId}/supervisors -> 401 {"status":"error","error":"device API key is required"}

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -527,6 +527,8 @@ POST /api/iot/session/end
 POST /api/iot/session/start
 POST /api/iot/session/timeout
 POST /api/iot/session/validate-timeout
+POST /api/iot/staff-clock
+POST /api/iot/staff-clock/state
 POST /api/iot/staff/{staffId}/rfid
 POST /api/me/profile/avatar
 POST /api/messages/threads

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -73,6 +73,18 @@ func (m *mockWorkSessionService) EndBreak(ctx context.Context, staffID int64) (*
 	}
 	return &activeModels.WorkSession{}, nil
 }
+func (m *mockWorkSessionService) CheckOutOn(ctx context.Context, staffID int64, _ timezone.Date, reason string) (*activeModels.WorkSession, error) {
+	return m.CheckOut(ctx, staffID, reason)
+}
+
+func (m *mockWorkSessionService) StartBreakOn(ctx context.Context, staffID int64, _ timezone.Date, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error) {
+	return m.StartBreak(ctx, staffID, plannedDurationMinutes)
+}
+
+func (m *mockWorkSessionService) EndBreakOn(ctx context.Context, staffID int64, _ timezone.Date) (*activeModels.WorkSession, error) {
+	return m.EndBreak(ctx, staffID)
+}
+
 func (m *mockWorkSessionService) GetSessionBreaks(ctx context.Context, staffID, sessionID int64) ([]*activeModels.WorkSessionBreak, error) {
 	if m.getSessionBreaksFn != nil {
 		return m.getSessionBreaksFn(ctx, staffID, sessionID)

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -55,6 +55,9 @@ func (m *mockWorkSessionService) CheckIn(ctx context.Context, staffID int64, sta
 	}
 	return &activeModels.WorkSession{}, nil
 }
+func (m *mockWorkSessionService) CheckInOn(ctx context.Context, staffID int64, _ timezone.Date, status, source, reason string) (*activeModels.WorkSession, error) {
+	return m.CheckIn(ctx, staffID, status, source, reason)
+}
 func (m *mockWorkSessionService) CheckOut(ctx context.Context, staffID int64, reason string) (*activeModels.WorkSession, error) {
 	if m.checkOutFn != nil {
 		return m.checkOutFn(ctx, staffID, reason)
@@ -102,6 +105,9 @@ func (m *mockWorkSessionService) GetCurrentSession(ctx context.Context, staffID 
 		return m.getCurrentSessionFn(ctx, staffID)
 	}
 	return nil, nil
+}
+func (m *mockWorkSessionService) GetLatestOpenSession(ctx context.Context, staffID int64) (*activeModels.WorkSession, error) {
+	return m.GetCurrentSession(ctx, staffID)
 }
 func (m *mockWorkSessionService) GetHistory(ctx context.Context, staffID int64, from, to timezone.Date) (*activeSvc.HistoryResponse, error) {
 	if m.getHistoryFn != nil {

--- a/backend/database/repositories/active/work_session.go
+++ b/backend/database/repositories/active/work_session.go
@@ -101,6 +101,34 @@ func (r *WorkSessionRepository) getOpenByStaffAndDate(ctx context.Context, staff
 	return session, nil
 }
 
+// GetLatestOpenByStaffID returns the most recent not-checked-out session of a
+// staff member, regardless of the day it was opened on. Unlike
+// GetCurrentByStaffID it does not filter on today, so a session that was opened
+// before Berlin midnight and is still running stays visible after the rollover
+// instead of looking like "no session today".
+func (r *WorkSessionRepository) GetLatestOpenByStaffID(ctx context.Context, staffID int64) (*active.WorkSession, error) {
+	session := new(active.WorkSession)
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(session).
+		ModelTableExpr(tableExprActiveWorkSessionsAsSession).
+		Where(`"work_session".staff_id = ?`, staffID).
+		Where(`"work_session".check_out_time IS NULL`).
+		OrderExpr(`"work_session".date DESC`).
+		Limit(1)
+
+	query = base.WithTenantFilter(ctx, query, "work_session")
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "get latest open by staff ID",
+			Err: err,
+		}
+	}
+
+	return session, nil
+}
+
 // LockOpenByIDForUpdate returns and locks an open session row by ID.
 func (r *WorkSessionRepository) LockOpenByIDForUpdate(ctx context.Context, id int64) (*active.WorkSession, error) {
 	session := new(active.WorkSession)

--- a/backend/database/repositories/active/work_session.go
+++ b/backend/database/repositories/active/work_session.go
@@ -62,11 +62,6 @@ func (r *WorkSessionRepository) GetCurrentByStaffID(ctx context.Context, staffID
 	return r.getOpenByStaffAndDate(ctx, staffID, timezone.TodayDate(), false)
 }
 
-// GetCurrentByStaffIDForUpdate returns the active session for a staff member today and locks it.
-func (r *WorkSessionRepository) GetCurrentByStaffIDForUpdate(ctx context.Context, staffID int64) (*active.WorkSession, error) {
-	return r.getOpenByStaffAndDate(ctx, staffID, timezone.TodayDate(), true)
-}
-
 // GetOpenByStaffAndDate returns the not-checked-out session of a staff member on
 // an explicit calendar day. Callers that must not re-derive "today" mid-request
 // (a kiosk stamp can straddle Berlin midnight) use this instead of

--- a/backend/database/repositories/active/work_session.go
+++ b/backend/database/repositories/active/work_session.go
@@ -59,23 +59,35 @@ func (r *WorkSessionRepository) GetByStaffAndDate(ctx context.Context, staffID i
 
 // GetCurrentByStaffID returns the active (not checked out) session for a staff member today
 func (r *WorkSessionRepository) GetCurrentByStaffID(ctx context.Context, staffID int64) (*active.WorkSession, error) {
-	return r.getCurrentByStaffID(ctx, staffID, false)
+	return r.getOpenByStaffAndDate(ctx, staffID, timezone.TodayDate(), false)
 }
 
 // GetCurrentByStaffIDForUpdate returns the active session for a staff member today and locks it.
 func (r *WorkSessionRepository) GetCurrentByStaffIDForUpdate(ctx context.Context, staffID int64) (*active.WorkSession, error) {
-	return r.getCurrentByStaffID(ctx, staffID, true)
+	return r.getOpenByStaffAndDate(ctx, staffID, timezone.TodayDate(), true)
 }
 
-func (r *WorkSessionRepository) getCurrentByStaffID(ctx context.Context, staffID int64, forUpdate bool) (*active.WorkSession, error) {
+// GetOpenByStaffAndDate returns the not-checked-out session of a staff member on
+// an explicit calendar day. Callers that must not re-derive "today" mid-request
+// (a kiosk stamp can straddle Berlin midnight) use this instead of
+// GetCurrentByStaffID.
+func (r *WorkSessionRepository) GetOpenByStaffAndDate(ctx context.Context, staffID int64, date timezone.Date) (*active.WorkSession, error) {
+	return r.getOpenByStaffAndDate(ctx, staffID, date, false)
+}
+
+// GetOpenByStaffAndDateForUpdate is GetOpenByStaffAndDate with a row lock.
+func (r *WorkSessionRepository) GetOpenByStaffAndDateForUpdate(ctx context.Context, staffID int64, date timezone.Date) (*active.WorkSession, error) {
+	return r.getOpenByStaffAndDate(ctx, staffID, date, true)
+}
+
+func (r *WorkSessionRepository) getOpenByStaffAndDate(ctx context.Context, staffID int64, date timezone.Date, forUpdate bool) (*active.WorkSession, error) {
 	session := new(active.WorkSession)
-	today := timezone.TodayDate()
 
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(session).
 		ModelTableExpr(tableExprActiveWorkSessionsAsSession).
 		Where(`"work_session".staff_id = ?`, staffID).
-		Where(`"work_session".date = ?`, today).
+		Where(`"work_session".date = ?`, date).
 		Where(`"work_session".check_out_time IS NULL`)
 
 	query = base.WithTenantFilter(ctx, query, "work_session")

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -291,9 +291,6 @@ type WorkSessionRepository interface {
 	// GetCurrentByStaffID returns the active (not checked out) session for a staff member
 	GetCurrentByStaffID(ctx context.Context, staffID int64) (*WorkSession, error)
 
-	// GetCurrentByStaffIDForUpdate returns and locks the active session row for a staff member.
-	GetCurrentByStaffIDForUpdate(ctx context.Context, staffID int64) (*WorkSession, error)
-
 	// GetOpenByStaffAndDate returns the not-checked-out session of a staff
 	// member on an explicit calendar day, for callers that must not re-derive
 	// "today" while the request is running.

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -291,6 +291,11 @@ type WorkSessionRepository interface {
 	// GetCurrentByStaffID returns the active (not checked out) session for a staff member
 	GetCurrentByStaffID(ctx context.Context, staffID int64) (*WorkSession, error)
 
+	// GetLatestOpenByStaffID returns the most recent not-checked-out session of
+	// a staff member across all days. Callers that must not lose sight of a
+	// session opened before midnight use this instead of GetCurrentByStaffID.
+	GetLatestOpenByStaffID(ctx context.Context, staffID int64) (*WorkSession, error)
+
 	// GetOpenByStaffAndDate returns the not-checked-out session of a staff
 	// member on an explicit calendar day, for callers that must not re-derive
 	// "today" while the request is running.

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -294,6 +294,14 @@ type WorkSessionRepository interface {
 	// GetCurrentByStaffIDForUpdate returns and locks the active session row for a staff member.
 	GetCurrentByStaffIDForUpdate(ctx context.Context, staffID int64) (*WorkSession, error)
 
+	// GetOpenByStaffAndDate returns the not-checked-out session of a staff
+	// member on an explicit calendar day, for callers that must not re-derive
+	// "today" while the request is running.
+	GetOpenByStaffAndDate(ctx context.Context, staffID int64, date timezone.Date) (*WorkSession, error)
+
+	// GetOpenByStaffAndDateForUpdate is GetOpenByStaffAndDate with a row lock.
+	GetOpenByStaffAndDateForUpdate(ctx context.Context, staffID int64, date timezone.Date) (*WorkSession, error)
+
 	// LockOpenByIDForUpdate returns and locks an open session row by ID.
 	LockOpenByIDForUpdate(ctx context.Context, id int64) (*WorkSession, error)
 

--- a/backend/services/active/labor_time_policy.go
+++ b/backend/services/active/labor_time_policy.go
@@ -27,6 +27,35 @@ const (
 	breakLongRequiredMinutes = 45
 )
 
+// LaborTimeEvaluation is the shared, as-of-now view used by both the web app
+// and device flows. Keeping these values behind one function prevents the
+// kiosk from reimplementing ArbZG thresholds or mishandling a running break.
+type LaborTimeEvaluation struct {
+	NetMinutes           int
+	BreakMinutes         int
+	RequiredBreakMinutes int
+	IsBreakCompliant     bool
+}
+
+// EvaluateLaborTime applies the same work/break calculations used by session
+// history to a single session. A running break is included up to now.
+func EvaluateLaborTime(ws *activeModels.WorkSession, breaks []*activeModels.WorkSessionBreak, now time.Time) LaborTimeEvaluation {
+	net := netMinutesWithBreaks(ws, breaks, now)
+	taken := totalBreakMinutes(ws, breaks, now)
+	required := 0
+	if net > breakShortThresholdMinutes {
+		required = breakLongRequiredMinutes
+	} else if net > breakNoneThresholdMinutes {
+		required = breakShortRequiredMinutes
+	}
+	return LaborTimeEvaluation{
+		NetMinutes:           net,
+		BreakMinutes:         taken,
+		RequiredBreakMinutes: required,
+		IsBreakCompliant:     taken >= required,
+	}
+}
+
 // grossMinutes is the wall-clock span of a session. For an open session (no
 // check-out) it measures against now.
 func grossMinutes(ws *activeModels.WorkSession, now time.Time) int {
@@ -118,14 +147,5 @@ func isOvertime(ws *activeModels.WorkSession, breaks []*activeModels.WorkSession
 // cache alone would flag a staff member as non-compliant *while* they are
 // taking the very break that makes them compliant.
 func isBreakCompliant(ws *activeModels.WorkSession, breaks []*activeModels.WorkSessionBreak, now time.Time) bool {
-	net := netMinutesWithBreaks(ws, breaks, now)
-	taken := totalBreakMinutes(ws, breaks, now)
-	if net <= breakNoneThresholdMinutes { // <= 6h: no break required
-		return true
-	}
-	if net <= breakShortThresholdMinutes { // <= 9h: 30 min break required
-		return taken >= breakShortRequiredMinutes
-	}
-	// > 9h: 45 min break required
-	return taken >= breakLongRequiredMinutes
+	return EvaluateLaborTime(ws, breaks, now).IsBreakCompliant
 }

--- a/backend/services/active/session_service_internal_test.go
+++ b/backend/services/active/session_service_internal_test.go
@@ -109,6 +109,15 @@ func (w *workSessionServiceForSessionUnitTest) StartBreak(context.Context, int64
 func (w *workSessionServiceForSessionUnitTest) EndBreak(context.Context, int64) (*activeModels.WorkSession, error) {
 	return nil, nil
 }
+func (w *workSessionServiceForSessionUnitTest) CheckOutOn(context.Context, int64, timezone.Date, string) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) StartBreakOn(context.Context, int64, timezone.Date, *int) (*activeModels.WorkSessionBreak, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) EndBreakOn(context.Context, int64, timezone.Date) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
 func (w *workSessionServiceForSessionUnitTest) GetSessionBreaks(context.Context, int64, int64) ([]*activeModels.WorkSessionBreak, error) {
 	return nil, nil
 }

--- a/backend/services/active/session_service_internal_test.go
+++ b/backend/services/active/session_service_internal_test.go
@@ -100,6 +100,9 @@ type workSessionServiceForSessionUnitTest struct {
 func (w *workSessionServiceForSessionUnitTest) CheckIn(context.Context, int64, string, string, string) (*activeModels.WorkSession, error) {
 	return nil, nil
 }
+func (w *workSessionServiceForSessionUnitTest) CheckInOn(context.Context, int64, timezone.Date, string, string, string) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
 func (w *workSessionServiceForSessionUnitTest) CheckOut(context.Context, int64, string) (*activeModels.WorkSession, error) {
 	return nil, nil
 }
@@ -131,6 +134,9 @@ func (w *workSessionServiceForSessionUnitTest) CreateSessionAsAdmin(context.Cont
 	return nil, nil
 }
 func (w *workSessionServiceForSessionUnitTest) GetCurrentSession(context.Context, int64) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+func (w *workSessionServiceForSessionUnitTest) GetLatestOpenSession(context.Context, int64) (*activeModels.WorkSession, error) {
 	return nil, nil
 }
 func (w *workSessionServiceForSessionUnitTest) GetHistory(context.Context, int64, timezone.Date, timezone.Date) (*HistoryResponse, error) {

--- a/backend/services/active/staff_absence_service_test.go
+++ b/backend/services/active/staff_absence_service_test.go
@@ -225,10 +225,6 @@ func (m *absWorkSessionRepoMock) GetCurrentByStaffID(ctx context.Context, staffI
 	return nil, nil
 }
 
-func (m *absWorkSessionRepoMock) GetCurrentByStaffIDForUpdate(ctx context.Context, staffID int64) (*activeModels.WorkSession, error) {
-	return m.GetCurrentByStaffID(ctx, staffID)
-}
-
 func (m *absWorkSessionRepoMock) GetOpenByStaffAndDate(ctx context.Context, staffID int64, _ timezone.Date) (*activeModels.WorkSession, error) {
 	return m.GetCurrentByStaffID(ctx, staffID)
 }

--- a/backend/services/active/staff_absence_service_test.go
+++ b/backend/services/active/staff_absence_service_test.go
@@ -229,6 +229,14 @@ func (m *absWorkSessionRepoMock) GetCurrentByStaffIDForUpdate(ctx context.Contex
 	return m.GetCurrentByStaffID(ctx, staffID)
 }
 
+func (m *absWorkSessionRepoMock) GetOpenByStaffAndDate(ctx context.Context, staffID int64, _ timezone.Date) (*activeModels.WorkSession, error) {
+	return m.GetCurrentByStaffID(ctx, staffID)
+}
+
+func (m *absWorkSessionRepoMock) GetOpenByStaffAndDateForUpdate(ctx context.Context, staffID int64, _ timezone.Date) (*activeModels.WorkSession, error) {
+	return m.GetCurrentByStaffID(ctx, staffID)
+}
+
 func (m *absWorkSessionRepoMock) LockOpenByIDForUpdate(ctx context.Context, id int64) (*activeModels.WorkSession, error) {
 	session, err := m.FindByID(ctx, id)
 	if err != nil {

--- a/backend/services/active/staff_absence_service_test.go
+++ b/backend/services/active/staff_absence_service_test.go
@@ -229,6 +229,10 @@ func (m *absWorkSessionRepoMock) GetOpenByStaffAndDate(ctx context.Context, staf
 	return m.GetCurrentByStaffID(ctx, staffID)
 }
 
+func (m *absWorkSessionRepoMock) GetLatestOpenByStaffID(ctx context.Context, staffID int64) (*activeModels.WorkSession, error) {
+	return m.GetCurrentByStaffID(ctx, staffID)
+}
+
 func (m *absWorkSessionRepoMock) GetOpenByStaffAndDateForUpdate(ctx context.Context, staffID int64, _ timezone.Date) (*activeModels.WorkSession, error) {
 	return m.GetCurrentByStaffID(ctx, staffID)
 }

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -377,11 +377,13 @@ func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status,
 	return s.checkIn(ctx, staffID, timezone.DateFromTime(s.now()), status, source, reason, true)
 }
 
-// CheckInOn creates or reopens the session of an explicit calendar day instead
-// of deriving the day from the server clock. A kiosk that resolved its day
-// before stamping must write on that day: re-deriving it inside the write can
-// land the row on the next day when the request straddles Berlin midnight,
-// after which the caller's own day-pinned reads no longer see it.
+// CheckInOn resolves the existing session of an explicit calendar day instead
+// of deriving that day from the server clock: a kiosk that pinned its day
+// before stamping must reopen the row it saw, and its day-pinned reads have to
+// keep seeing it.
+//
+// The pin covers the lookup only. A session that is newly created is filed on
+// the day its own stamp falls on — see checkIn.
 func (s *workSessionService) CheckInOn(ctx context.Context, staffID int64, day timezone.Date, status, source, reason string) (*activeModels.WorkSession, error) {
 	return s.checkIn(ctx, staffID, day, status, source, reason, true)
 }
@@ -392,7 +394,14 @@ func (s *workSessionService) CheckInOn(ctx context.Context, staffID int64, day t
 // starting a supervision (EnsureCheckedIn) bypass it — those flows have no
 // way to collect a reason, and refusing the stamp would leave a supervisor
 // row without a matching work session.
-func (s *workSessionService) checkIn(ctx context.Context, staffID int64, today timezone.Date, status, source, reason string, enforceDeviationGate bool) (*activeModels.WorkSession, error) {
+//
+// `lookupDay` selects the session this call acts on; it may have been resolved
+// by the caller before the request reached here. A session that is created
+// fresh is filed on the day of its own check_in_time instead: storing a
+// pre-midnight day next to a post-midnight stamp would misfile the session in
+// the daily history, in shift and deviation lookups, and in every total built
+// from the date column.
+func (s *workSessionService) checkIn(ctx context.Context, staffID int64, lookupDay timezone.Date, status, source, reason string, enforceDeviationGate bool) (*activeModels.WorkSession, error) {
 	if status != activeModels.WorkSessionStatusPresent && status != activeModels.WorkSessionStatusHomeOffice {
 		return nil, fmt.Errorf("status must be 'present' or 'home_office'")
 	}
@@ -402,8 +411,8 @@ func (s *workSessionService) checkIn(ctx context.Context, staffID int64, today t
 
 	now := s.now()
 
-	// Check if there's already a session today
-	existingSession, err := s.repo.GetByStaffAndDate(ctx, staffID, today)
+	// Check if there's already a session on the day this call acts on
+	existingSession, err := s.repo.GetByStaffAndDate(ctx, staffID, lookupDay)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("failed to check existing session: %w", err)
 	}
@@ -412,7 +421,7 @@ func (s *workSessionService) checkIn(ctx context.Context, staffID int64, today t
 		if existingSession.IsActive() {
 			return nil, fmt.Errorf("already checked in")
 		}
-		if err := s.ensurePlannedStartReached(ctx, staffID, today, now); err != nil {
+		if err := s.ensurePlannedStartReached(ctx, staffID, lookupDay, now); err != nil {
 			return nil, err
 		}
 		// A status mismatch on reopen would silently rewrite an audit-relevant
@@ -431,7 +440,13 @@ func (s *workSessionService) checkIn(ctx context.Context, staffID int64, today t
 		return s.reopenSession(ctx, existingSession, staffID)
 	}
 
-	if err := s.ensurePlannedStartReached(ctx, staffID, today, now); err != nil {
+	// From here the session is created, so it belongs to the day of its own
+	// stamp: the schedule and deviation checks below have to be read on that
+	// same day, or a stamp taken just after midnight is measured against the
+	// previous day's shift.
+	stampDay := timezone.DateFromTime(now)
+
+	if err := s.ensurePlannedStartReached(ctx, staffID, stampDay, now); err != nil {
 		return nil, err
 	}
 
@@ -441,7 +456,7 @@ func (s *workSessionService) checkIn(ctx context.Context, staffID int64, today t
 	var deviation *plannedDeviation
 	if enforceDeviationGate {
 		var err error
-		deviation, err = s.detectPlannedDeviation(ctx, staffID, today, now, deviationActionCheckIn)
+		deviation, err = s.detectPlannedDeviation(ctx, staffID, stampDay, now, deviationActionCheckIn)
 		if err != nil {
 			return nil, err
 		}
@@ -453,7 +468,7 @@ func (s *workSessionService) checkIn(ctx context.Context, staffID int64, today t
 	// Create new session
 	session := &activeModels.WorkSession{
 		StaffID:      staffID,
-		Date:         today,
+		Date:         stampDay,
 		Status:       status,
 		Source:       source,
 		CheckInTime:  now,

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -204,6 +204,16 @@ type WorkSessionService interface {
 	CheckOut(ctx context.Context, staffID int64, reason string) (*activeModels.WorkSession, error)
 	StartBreak(ctx context.Context, staffID int64, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
 	EndBreak(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
+
+	// The *On variants act on the open session of an explicit calendar day
+	// instead of re-deriving "today" from the server clock. A caller whose
+	// request straddles Berlin midnight (a kiosk stamp at 23:59:59) would
+	// otherwise look up a day the session was never written on and fail with
+	// "no active session found". The day-less forms above delegate here with
+	// the current day and keep their behaviour.
+	CheckOutOn(ctx context.Context, staffID int64, day timezone.Date, reason string) (*activeModels.WorkSession, error)
+	StartBreakOn(ctx context.Context, staffID int64, day timezone.Date, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
+	EndBreakOn(ctx context.Context, staffID int64, day timezone.Date) (*activeModels.WorkSession, error)
 	GetSessionBreaks(ctx context.Context, staffID, sessionID int64) ([]*activeModels.WorkSessionBreak, error)
 	UpdateSession(ctx context.Context, staffID int64, sessionID int64, updates SessionUpdateRequest) (*activeModels.WorkSession, error)
 	// UpdateSessionAsAdmin is the admin-facing counterpart. editorStaffID is
@@ -533,8 +543,13 @@ func (s *workSessionService) reopenSession(ctx context.Context, session *activeM
 
 // CheckOut ends the current work session for the staff member
 func (s *workSessionService) CheckOut(ctx context.Context, staffID int64, reason string) (*activeModels.WorkSession, error) {
-	// Get current active session
-	session, err := s.repo.GetCurrentByStaffID(ctx, staffID)
+	return s.CheckOutOn(ctx, staffID, timezone.TodayDate(), reason)
+}
+
+// CheckOutOn ends the open session of an explicit calendar day.
+func (s *workSessionService) CheckOutOn(ctx context.Context, staffID int64, day timezone.Date, reason string) (*activeModels.WorkSession, error) {
+	// Get the open session of the requested day
+	session, err := s.repo.GetOpenByStaffAndDate(ctx, staffID, day)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, errors.New(errNoActiveSession)
@@ -763,8 +778,13 @@ func (s *workSessionService) endActiveSupervisionsOnCheckout(ctx context.Context
 // StartBreak starts a new break for the current session
 // If plannedDurationMinutes is provided (1-240), sets planned_end_time for auto-end
 func (s *workSessionService) StartBreak(ctx context.Context, staffID int64, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error) {
-	// Get today's active session
-	session, err := s.repo.GetCurrentByStaffIDForUpdate(ctx, staffID)
+	return s.StartBreakOn(ctx, staffID, timezone.TodayDate(), plannedDurationMinutes)
+}
+
+// StartBreakOn starts a break on the open session of an explicit calendar day.
+func (s *workSessionService) StartBreakOn(ctx context.Context, staffID int64, day timezone.Date, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error) {
+	// Get the open session of the requested day
+	session, err := s.repo.GetOpenByStaffAndDateForUpdate(ctx, staffID, day)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, errors.New(errNoActiveSession)
@@ -817,8 +837,13 @@ func (s *workSessionService) StartBreak(ctx context.Context, staffID int64, plan
 
 // EndBreak ends the current active break for the staff member's session
 func (s *workSessionService) EndBreak(ctx context.Context, staffID int64) (*activeModels.WorkSession, error) {
-	// Get today's active session
-	session, err := s.repo.GetCurrentByStaffID(ctx, staffID)
+	return s.EndBreakOn(ctx, staffID, timezone.TodayDate())
+}
+
+// EndBreakOn ends the active break on the open session of an explicit calendar day.
+func (s *workSessionService) EndBreakOn(ctx context.Context, staffID int64, day timezone.Date) (*activeModels.WorkSession, error) {
+	// Get the open session of the requested day
+	session, err := s.repo.GetOpenByStaffAndDate(ctx, staffID, day)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, errors.New(errNoActiveSession)

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -211,6 +211,7 @@ type WorkSessionService interface {
 	// otherwise look up a day the session was never written on and fail with
 	// "no active session found". The day-less forms above delegate here with
 	// the current day and keep their behaviour.
+	CheckInOn(ctx context.Context, staffID int64, day timezone.Date, status, source, reason string) (*activeModels.WorkSession, error)
 	CheckOutOn(ctx context.Context, staffID int64, day timezone.Date, reason string) (*activeModels.WorkSession, error)
 	StartBreakOn(ctx context.Context, staffID int64, day timezone.Date, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
 	EndBreakOn(ctx context.Context, staffID int64, day timezone.Date) (*activeModels.WorkSession, error)
@@ -228,6 +229,10 @@ type WorkSessionService interface {
 	// Notes are required to preserve the audit trail's "Verlässlichkeit".
 	CreateSessionAsAdmin(ctx context.Context, editorStaffID, targetStaffID int64, req AdminCreateSessionRequest) (*activeModels.WorkSession, error)
 	GetCurrentSession(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
+	// GetLatestOpenSession is GetCurrentSession without the "today" filter: it
+	// finds a session that is still running even when it was opened on an
+	// earlier calendar day.
+	GetLatestOpenSession(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
 	GetHistory(ctx context.Context, staffID int64, from, to timezone.Date) (*HistoryResponse, error)
 	GetSessionEdits(ctx context.Context, staffID, sessionID int64) ([]*WorkSessionEditView, error)
 	// GetSessionEditsForStaff returns the audit trail of a session for a
@@ -369,7 +374,16 @@ func (s *workSessionService) now() time.Time {
 // Status must be explicitly chosen. Empty values are rejected so the caller
 // (HTTP handler or internal worker) cannot accidentally fall back to "present".
 func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status, source, reason string) (*activeModels.WorkSession, error) {
-	return s.checkIn(ctx, staffID, status, source, reason, true)
+	return s.checkIn(ctx, staffID, timezone.DateFromTime(s.now()), status, source, reason, true)
+}
+
+// CheckInOn creates or reopens the session of an explicit calendar day instead
+// of deriving the day from the server clock. A kiosk that resolved its day
+// before stamping must write on that day: re-deriving it inside the write can
+// land the row on the next day when the request straddles Berlin midnight,
+// after which the caller's own day-pinned reads no longer see it.
+func (s *workSessionService) CheckInOn(ctx context.Context, staffID int64, day timezone.Date, status, source, reason string) (*activeModels.WorkSession, error) {
+	return s.checkIn(ctx, staffID, day, status, source, reason, true)
 }
 
 // checkIn is the shared body behind CheckIn and EnsureCheckedIn.
@@ -378,7 +392,7 @@ func (s *workSessionService) CheckIn(ctx context.Context, staffID int64, status,
 // starting a supervision (EnsureCheckedIn) bypass it — those flows have no
 // way to collect a reason, and refusing the stamp would leave a supervisor
 // row without a matching work session.
-func (s *workSessionService) checkIn(ctx context.Context, staffID int64, status, source, reason string, enforceDeviationGate bool) (*activeModels.WorkSession, error) {
+func (s *workSessionService) checkIn(ctx context.Context, staffID int64, today timezone.Date, status, source, reason string, enforceDeviationGate bool) (*activeModels.WorkSession, error) {
 	if status != activeModels.WorkSessionStatusPresent && status != activeModels.WorkSessionStatusHomeOffice {
 		return nil, fmt.Errorf("status must be 'present' or 'home_office'")
 	}
@@ -387,8 +401,6 @@ func (s *workSessionService) checkIn(ctx context.Context, staffID int64, status,
 	}
 
 	now := s.now()
-	// Today's Berlin calendar day for the PostgreSQL DATE column
-	today := timezone.DateFromTime(now)
 
 	// Check if there's already a session today
 	existingSession, err := s.repo.GetByStaffAndDate(ctx, staffID, today)
@@ -1324,6 +1336,22 @@ func (s *workSessionService) GetCurrentSession(ctx context.Context, staffID int6
 	return session, nil
 }
 
+// GetLatestOpenSession returns the most recent still-running session of a staff
+// member across all days, or nil when none is open. It answers "is this person
+// clocked in right now" without assuming the session was opened today — a night
+// stamp survives the Berlin midnight rollover.
+func (s *workSessionService) GetLatestOpenSession(ctx context.Context, staffID int64) (*activeModels.WorkSession, error) {
+	session, err := s.repo.GetLatestOpenByStaffID(ctx, staffID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get latest open session: %w", err)
+	}
+
+	return session, nil
+}
+
 // GetHistory returns work sessions for a staff member in a date range with weekly aggregation
 func (s *workSessionService) GetHistory(ctx context.Context, staffID int64, from, to timezone.Date) (*HistoryResponse, error) {
 	sessions, err := s.repo.GetHistoryByStaffID(ctx, staffID, from, to)
@@ -1908,7 +1936,7 @@ func (s *workSessionService) EnsureCheckedIn(ctx context.Context, staffID int64,
 	// The F9 deviation gate is bypassed: this auto-stamp fires because the
 	// staff member started a supervision, and that flow cannot collect a
 	// reason (see checkIn).
-	return s.checkIn(ctx, staffID, activeModels.WorkSessionStatusPresent, source, "", false)
+	return s.checkIn(ctx, staffID, today, activeModels.WorkSessionStatusPresent, source, "", false)
 }
 
 // German weekday names for export

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -410,11 +410,25 @@ func (s *workSessionService) checkIn(ctx context.Context, staffID int64, lookupD
 	}
 
 	now := s.now()
+	stampDay := timezone.DateFromTime(now)
 
 	// Check if there's already a session on the day this call acts on
 	existingSession, err := s.repo.GetByStaffAndDate(ctx, staffID, lookupDay)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("failed to check existing session: %w", err)
+	}
+
+	// A pinned day that no longer matches the stamp may only carry a session
+	// that is still running: that is a night shift the caller is right to act
+	// on. A closed row on that day is finished business from a day this stamp
+	// does not belong to, and reopening it would move yesterday's arrival and
+	// erase yesterday's departure. Act on the stamp's own day instead.
+	if existingSession != nil && !existingSession.IsActive() && lookupDay != stampDay {
+		lookupDay = stampDay
+		existingSession, err = s.repo.GetByStaffAndDate(ctx, staffID, lookupDay)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("failed to check existing session: %w", err)
+		}
 	}
 
 	if existingSession != nil {
@@ -444,8 +458,6 @@ func (s *workSessionService) checkIn(ctx context.Context, staffID int64, lookupD
 	// stamp: the schedule and deviation checks below have to be read on that
 	// same day, or a stamp taken just after midnight is measured against the
 	// previous day's shift.
-	stampDay := timezone.DateFromTime(now)
-
 	if err := s.ensurePlannedStartReached(ctx, staffID, stampDay, now); err != nil {
 		return nil, err
 	}

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -94,6 +94,10 @@ func (m *wsMockWorkSessionRepository) GetOpenByStaffAndDate(ctx context.Context,
 	return m.GetCurrentByStaffID(ctx, staffID)
 }
 
+func (m *wsMockWorkSessionRepository) GetLatestOpenByStaffID(ctx context.Context, staffID int64) (*activeModels.WorkSession, error) {
+	return m.GetCurrentByStaffID(ctx, staffID)
+}
+
 func (m *wsMockWorkSessionRepository) GetOpenByStaffAndDateForUpdate(ctx context.Context, staffID int64, _ timezone.Date) (*activeModels.WorkSession, error) {
 	if m.getCurrentForUpdateFunc != nil {
 		return m.getCurrentForUpdateFunc(ctx, staffID)

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -2868,6 +2868,41 @@ func TestWSCheckIn_ReopenSkipsDeviationGate(t *testing.T) {
 	assert.Nil(t, session.CheckOutTime, "session must be reopened")
 }
 
+// A kiosk resolves its calendar day before it stamps. When the request crosses
+// Berlin midnight on the way in, the day it pinned selects the row to reopen —
+// but a session created fresh belongs to the day of its own check_in_time.
+// Storing 21.07 next to a 22.07 stamp misfiles the session in the daily
+// history, in shift and deviation lookups, and in every total keyed on the date
+// column.
+func TestWSCheckInOn_NewSessionUsesTheStampDay(t *testing.T) {
+	pinnedDay := timezone.NewDate(2026, 7, 21)
+	stampedAt := time.Date(2026, time.July, 22, 0, 0, 1, 0, timezone.Berlin)
+
+	svc, sessionRepo, _, _, _ := wsCreateTestService()
+	svc.nowFunc = func() time.Time { return stampedAt }
+
+	var lookedUp timezone.Date
+	sessionRepo.getByStaffAndDateFunc = func(_ context.Context, _ int64, day timezone.Date) (*activeModels.WorkSession, error) {
+		lookedUp = day
+		return nil, sql.ErrNoRows
+	}
+	var created *activeModels.WorkSession
+	sessionRepo.createFunc = func(_ context.Context, entity *activeModels.WorkSession) error {
+		created = entity
+		entity.ID = 5
+		return nil
+	}
+
+	session, err := svc.CheckInOn(context.Background(), 100, pinnedDay, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceNFC, "")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	assert.Equal(t, pinnedDay, lookedUp, "the pinned day still selects the session to reopen")
+	require.NotNil(t, created)
+	assert.Equal(t, timezone.DateFromTime(stampedAt), created.Date)
+	assert.Equal(t, timezone.DateFromTime(created.CheckInTime), created.Date)
+}
+
 func TestWSEnsureCheckedIn_SkipsDeviationGate(t *testing.T) {
 	// The supervision auto-stamp has no way to collect a reason; an early
 	// start must still produce a work session.

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -2903,6 +2903,60 @@ func TestWSCheckInOn_NewSessionUsesTheStampDay(t *testing.T) {
 	assert.Equal(t, timezone.DateFromTime(created.CheckInTime), created.Date)
 }
 
+// The pinned day may be stale by the time the stamp is written. A session that
+// is still running on it is a night shift and stays the caller's business, but
+// a closed row belongs to a day this arrival is no longer part of: reopening it
+// would move yesterday's check-in and delete yesterday's checkout. The stamp
+// must open its own day instead.
+func TestWSCheckInOn_StalePinnedDayDoesNotReopenYesterday(t *testing.T) {
+	pinnedDay := timezone.NewDate(2026, 7, 21)
+	stampedAt := time.Date(2026, time.July, 22, 0, 0, 1, 0, timezone.Berlin)
+	stampDay := timezone.DateFromTime(stampedAt)
+
+	svc, sessionRepo, _, _, _ := wsCreateTestService()
+	svc.nowFunc = func() time.Time { return stampedAt }
+
+	checkOut := time.Date(2026, time.July, 21, 16, 0, 0, 0, timezone.Berlin)
+	yesterday := &activeModels.WorkSession{
+		Model:        base.Model{ID: 9},
+		StaffID:      100,
+		Date:         pinnedDay,
+		CreatedBy:    100,
+		Status:       activeModels.WorkSessionStatusPresent,
+		Source:       activeModels.WorkSessionSourceNFC,
+		CheckInTime:  time.Date(2026, time.July, 21, 8, 0, 0, 0, timezone.Berlin),
+		CheckOutTime: &checkOut,
+	}
+
+	var lookedUp []timezone.Date
+	sessionRepo.getByStaffAndDateFunc = func(_ context.Context, _ int64, day timezone.Date) (*activeModels.WorkSession, error) {
+		lookedUp = append(lookedUp, day)
+		if day == pinnedDay {
+			return yesterday, nil
+		}
+		return nil, sql.ErrNoRows
+	}
+	sessionRepo.updateFunc = func(_ context.Context, _ *activeModels.WorkSession) error {
+		t.Fatal("a closed session of a past day must never be reopened")
+		return nil
+	}
+	var created *activeModels.WorkSession
+	sessionRepo.createFunc = func(_ context.Context, entity *activeModels.WorkSession) error {
+		created = entity
+		entity.ID = 11
+		return nil
+	}
+
+	session, err := svc.CheckInOn(context.Background(), 100, pinnedDay, activeModels.WorkSessionStatusPresent, activeModels.WorkSessionSourceNFC, "")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	assert.Equal(t, []timezone.Date{pinnedDay, stampDay}, lookedUp, "the stale day is re-resolved to the stamp's own day")
+	require.NotNil(t, created)
+	assert.Equal(t, stampDay, created.Date)
+	assert.NotNil(t, yesterday.CheckOutTime, "yesterday's departure stays recorded")
+}
+
 func TestWSEnsureCheckedIn_SkipsDeviationGate(t *testing.T) {
 	// The supervision auto-stamp has no way to collect a reason; an early
 	// start must still produce a work session.

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -90,19 +90,15 @@ func (m *wsMockWorkSessionRepository) GetCurrentByStaffID(ctx context.Context, s
 	return nil, sql.ErrNoRows
 }
 
-func (m *wsMockWorkSessionRepository) GetCurrentByStaffIDForUpdate(ctx context.Context, staffID int64) (*activeModels.WorkSession, error) {
-	if m.getCurrentForUpdateFunc != nil {
-		return m.getCurrentForUpdateFunc(ctx, staffID)
-	}
-	return m.GetCurrentByStaffID(ctx, staffID)
-}
-
 func (m *wsMockWorkSessionRepository) GetOpenByStaffAndDate(ctx context.Context, staffID int64, _ timezone.Date) (*activeModels.WorkSession, error) {
 	return m.GetCurrentByStaffID(ctx, staffID)
 }
 
 func (m *wsMockWorkSessionRepository) GetOpenByStaffAndDateForUpdate(ctx context.Context, staffID int64, _ timezone.Date) (*activeModels.WorkSession, error) {
-	return m.GetCurrentByStaffIDForUpdate(ctx, staffID)
+	if m.getCurrentForUpdateFunc != nil {
+		return m.getCurrentForUpdateFunc(ctx, staffID)
+	}
+	return m.GetCurrentByStaffID(ctx, staffID)
 }
 
 func (m *wsMockWorkSessionRepository) LockOpenByIDForUpdate(ctx context.Context, id int64) (*activeModels.WorkSession, error) {

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -97,6 +97,14 @@ func (m *wsMockWorkSessionRepository) GetCurrentByStaffIDForUpdate(ctx context.C
 	return m.GetCurrentByStaffID(ctx, staffID)
 }
 
+func (m *wsMockWorkSessionRepository) GetOpenByStaffAndDate(ctx context.Context, staffID int64, _ timezone.Date) (*activeModels.WorkSession, error) {
+	return m.GetCurrentByStaffID(ctx, staffID)
+}
+
+func (m *wsMockWorkSessionRepository) GetOpenByStaffAndDateForUpdate(ctx context.Context, staffID int64, _ timezone.Date) (*activeModels.WorkSession, error) {
+	return m.GetCurrentByStaffIDForUpdate(ctx, staffID)
+}
+
 func (m *wsMockWorkSessionRepository) LockOpenByIDForUpdate(ctx context.Context, id int64) (*activeModels.WorkSession, error) {
 	if m.lockOpenByIDFunc != nil {
 		return m.lockOpenByIDFunc(ctx, id)

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -40,6 +40,7 @@ import (
 	importService "github.com/moto-nrw/project-phoenix/services/import"
 	"github.com/moto-nrw/project-phoenix/services/iot"
 	iotcheckin "github.com/moto-nrw/project-phoenix/services/iot/checkin"
+	staffclock "github.com/moto-nrw/project-phoenix/services/iot/staffclock"
 	"github.com/moto-nrw/project-phoenix/services/listexport"
 	"github.com/moto-nrw/project-phoenix/services/mealplan"
 	"github.com/moto-nrw/project-phoenix/services/messaging"
@@ -76,6 +77,7 @@ type Factory struct {
 	Suggestions              suggestions.Service
 	IoT                      iot.Service
 	Checkin                  *iotcheckin.CheckinService
+	StaffClock               *staffclock.Service
 	Settings                 config.SettingsService
 	Schedule                 schedule.Service
 	StaffShifts              schedule.StaffShiftService
@@ -337,6 +339,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	workSessionService := active.NewWorkSessionService(repos.WorkSession, repos.WorkSessionBreak, repos.WorkSessionEdit, repos.StaffAbsence, repos.GroupSupervisor, repos.Staff, repos.StaffWorkSchedule, repos.WorkTimeModel, settingsService, activeLogger)
 	// Planned-shift lookups for the auto-checkout job (#1798).
 	workSessionService.SetStaffShiftRepo(repos.StaffShift)
+	staffClockService := staffclock.NewService(usersService, repos.RFIDCard, workSessionService)
 
 	// Monatskarte read model (#1842) — everything computed on read, the
 	// Übertrag is live.
@@ -1489,6 +1492,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Suggestions:              suggestionsService,
 		IoT:                      iotService,
 		Checkin:                  checkinService,
+		StaffClock:               staffClockService,
 		Settings:                 settingsService,
 		Schedule:                 scheduleService,
 		StaffShifts:              staffShiftService,

--- a/backend/services/iot/staffclock/service.go
+++ b/backend/services/iot/staffclock/service.go
@@ -11,10 +11,17 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
 	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
 )
+
+// workSessionDateConstraint is the unique index behind one work session per
+// staff member and day (migration 1.10.1). Two kiosks scanning the same card at
+// once both find no session and both insert; the loser hits this constraint.
+const workSessionDateConstraint = "uq_work_sessions_staff_date"
 
 const (
 	ActionCheckIn    = "checkin"
@@ -34,6 +41,9 @@ var (
 	ErrRFIDTagNotStaff = errors.New("RFID tag is not assigned to staff")
 	ErrInvalidAction   = errors.New("invalid staff clock action")
 	ErrStatusRequired  = errors.New("status is required for check-in")
+	// ErrCheckInRaced reports that a concurrent scan of the same card already
+	// created today's session. It is a state conflict, not a server fault.
+	ErrCheckInRaced = errors.New("check-in for today was already recorded")
 )
 
 type personService interface {
@@ -153,29 +163,7 @@ func (s *Service) Execute(ctx context.Context, command Command) (*State, error) 
 
 	switch command.Action {
 	case ActionCheckIn:
-		if command.Status == "" {
-			return nil, ErrStatusRequired
-		}
-		if command.Status != activeModels.WorkSessionStatusPresent && command.Status != activeModels.WorkSessionStatusHomeOffice {
-			return nil, fmt.Errorf("%w: status must be 'present' or 'home_office'", ErrStatusRequired)
-		}
-		_, err = s.workSessions.CheckIn(ctx, staff.ID, command.Status, activeModels.WorkSessionSourceNFC, command.Reason)
-		var conflict *activeSvc.ReopenStatusConflictError
-		if errors.As(err, &conflict) {
-			if strings.TrimSpace(command.Reason) == "" {
-				return nil, conflict
-			}
-			if _, err = s.workSessions.CheckIn(ctx, staff.ID, conflict.ExistingStatus, activeModels.WorkSessionSourceNFC, command.Reason); err != nil {
-				return nil, fmt.Errorf("reopen session with existing status: %w", err)
-			}
-			reason := strings.TrimSpace(command.Reason)
-			status := command.Status
-			if _, err = s.workSessions.UpdateSession(ctx, staff.ID, conflict.SessionID, activeSvc.SessionUpdateRequest{Status: &status, Notes: &reason}); err != nil {
-				// The request transaction must roll back the successful reopen if
-				// this audit-bearing status update cannot be persisted.
-				return nil, fmt.Errorf("update reopened session status: %w", err)
-			}
-		}
+		err = s.checkIn(ctx, staff.ID, command)
 	case ActionCheckOut:
 		_, err = s.workSessions.CheckOut(ctx, staff.ID, command.Reason)
 	case ActionBreakStart:
@@ -190,6 +178,53 @@ func (s *Service) Execute(ctx context.Context, command Command) (*State, error) 
 	}
 
 	return s.loadState(ctx, person, staff)
+}
+
+// checkIn stamps the arrival, resolving the reopen-status conflict when the
+// caller supplied a reason.
+//
+// A concurrent scan of the same card is reported as ErrCheckInRaced rather than
+// bubbling the raw unique violation out as a 500: both requests read "no
+// session today" before either inserted, so the loser is looking at a state
+// conflict the winner just created. The duplicate INSERT also leaves the
+// request transaction aborted — nothing can be re-read or retried on it — so
+// the rollback is requested explicitly and the kiosk is told to rescan for
+// authoritative state.
+func (s *Service) checkIn(ctx context.Context, staffID int64, command Command) error {
+	if command.Status == "" {
+		return ErrStatusRequired
+	}
+	if command.Status != activeModels.WorkSessionStatusPresent && command.Status != activeModels.WorkSessionStatusHomeOffice {
+		return fmt.Errorf("%w: status must be 'present' or 'home_office'", ErrStatusRequired)
+	}
+
+	_, err := s.workSessions.CheckIn(ctx, staffID, command.Status, activeModels.WorkSessionSourceNFC, command.Reason)
+	var conflict *activeSvc.ReopenStatusConflictError
+	if errors.As(err, &conflict) {
+		if strings.TrimSpace(command.Reason) == "" {
+			return conflict
+		}
+		if _, err = s.workSessions.CheckIn(ctx, staffID, conflict.ExistingStatus, activeModels.WorkSessionSourceNFC, command.Reason); err != nil {
+			return s.classifyCheckInError(ctx, fmt.Errorf("reopen session with existing status: %w", err))
+		}
+		reason := strings.TrimSpace(command.Reason)
+		status := command.Status
+		if _, err = s.workSessions.UpdateSession(ctx, staffID, conflict.SessionID, activeSvc.SessionUpdateRequest{Status: &status, Notes: &reason}); err != nil {
+			// The request transaction must roll back the successful reopen if
+			// this audit-bearing status update cannot be persisted.
+			return fmt.Errorf("update reopened session status: %w", err)
+		}
+		return nil
+	}
+	return s.classifyCheckInError(ctx, err)
+}
+
+func (s *Service) classifyCheckInError(ctx context.Context, err error) error {
+	if modelBase.IsUniqueViolationOn(err, workSessionDateConstraint) {
+		tenant.MarkRollback(ctx)
+		return ErrCheckInRaced
+	}
+	return err
 }
 
 func (s *Service) resolveStaff(ctx context.Context, rawTag string) (*userModels.Person, *userModels.Staff, error) {

--- a/backend/services/iot/staffclock/service.go
+++ b/backend/services/iot/staffclock/service.go
@@ -1,0 +1,248 @@
+// Package staffclock coordinates NFC-based staff time tracking for kiosks.
+package staffclock
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
+)
+
+const (
+	ActionCheckIn    = "checkin"
+	ActionCheckOut   = "checkout"
+	ActionBreakStart = "break_start"
+	ActionBreakEnd   = "break_end"
+
+	StateCheckedOut = "checked_out"
+	StateCheckedIn  = "checked_in"
+	StateOnBreak    = "on_break"
+)
+
+var (
+	ErrInvalidRFIDTag  = errors.New("invalid RFID tag")
+	ErrRFIDTagNotFound = errors.New("RFID tag not found")
+	ErrRFIDTagInactive = errors.New("RFID tag is inactive")
+	ErrRFIDTagNotStaff = errors.New("RFID tag is not assigned to staff")
+	ErrInvalidAction   = errors.New("invalid staff clock action")
+	ErrStatusRequired  = errors.New("status is required for check-in")
+)
+
+type personService interface {
+	FindByTagID(ctx context.Context, tagID string) (*userModels.Person, error)
+	GetStaffByPersonID(ctx context.Context, personID int64) (*userModels.Staff, error)
+}
+
+type workSessionService interface {
+	CheckIn(ctx context.Context, staffID int64, status, source, reason string) (*activeModels.WorkSession, error)
+	CheckOut(ctx context.Context, staffID int64, reason string) (*activeModels.WorkSession, error)
+	StartBreak(ctx context.Context, staffID int64, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
+	EndBreak(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
+	GetSessionBreaks(ctx context.Context, staffID, sessionID int64) ([]*activeModels.WorkSessionBreak, error)
+	UpdateSession(ctx context.Context, staffID int64, sessionID int64, updates activeSvc.SessionUpdateRequest) (*activeModels.WorkSession, error)
+	GetCurrentSession(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
+	GetHistory(ctx context.Context, staffID int64, from, to timezone.Date) (*activeSvc.HistoryResponse, error)
+}
+
+// Service owns the pure NFC stamp workflow. It deliberately accepts narrow
+// interfaces so its state machine can be tested without HTTP or a database.
+type Service struct {
+	people       personService
+	cards        userModels.RFIDCardRepository
+	workSessions workSessionService
+	now          func() time.Time
+}
+
+type State struct {
+	StaffID              int64                          `json:"staff_id"`
+	StaffName            string                         `json:"staff_name"`
+	State                string                         `json:"state"`
+	AllowedActions       []string                       `json:"allowed_actions"`
+	Session              *activeModels.WorkSession      `json:"session,omitempty"`
+	ActiveBreak          *activeModels.WorkSessionBreak `json:"active_break,omitempty"`
+	NetMinutes           int                            `json:"net_minutes"`
+	BreakMinutes         int                            `json:"break_minutes"`
+	RequiredBreakMinutes int                            `json:"required_break_minutes"`
+	IsBreakCompliant     bool                           `json:"is_break_compliant"`
+}
+
+type Command struct {
+	RFIDTag                string
+	Action                 string
+	Status                 string
+	Reason                 string
+	PlannedDurationMinutes *int
+}
+
+func NewService(people personService, cards userModels.RFIDCardRepository, workSessions workSessionService) *Service {
+	return &Service{people: people, cards: cards, workSessions: workSessions}
+}
+
+func (s *Service) currentTime() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+// GetState resolves a staff card and returns the authoritative kiosk state.
+func (s *Service) GetState(ctx context.Context, rawTag string) (*State, error) {
+	person, staff, err := s.resolveStaff(ctx, rawTag)
+	if err != nil {
+		return nil, err
+	}
+	return s.loadState(ctx, person, staff)
+}
+
+// Execute performs one explicit stamp action with source=nfc, then reloads
+// state so the kiosk never has to predict the result locally.
+func (s *Service) Execute(ctx context.Context, command Command) (*State, error) {
+	person, staff, err := s.resolveStaff(ctx, command.RFIDTag)
+	if err != nil {
+		return nil, err
+	}
+
+	switch command.Action {
+	case ActionCheckIn:
+		if command.Status == "" {
+			return nil, ErrStatusRequired
+		}
+		if command.Status != activeModels.WorkSessionStatusPresent && command.Status != activeModels.WorkSessionStatusHomeOffice {
+			return nil, fmt.Errorf("%w: status must be 'present' or 'home_office'", ErrStatusRequired)
+		}
+		_, err = s.workSessions.CheckIn(ctx, staff.ID, command.Status, activeModels.WorkSessionSourceNFC, command.Reason)
+		var conflict *activeSvc.ReopenStatusConflictError
+		if errors.As(err, &conflict) {
+			if strings.TrimSpace(command.Reason) == "" {
+				return nil, conflict
+			}
+			if _, err = s.workSessions.CheckIn(ctx, staff.ID, conflict.ExistingStatus, activeModels.WorkSessionSourceNFC, command.Reason); err != nil {
+				return nil, fmt.Errorf("reopen session with existing status: %w", err)
+			}
+			reason := strings.TrimSpace(command.Reason)
+			status := command.Status
+			if _, err = s.workSessions.UpdateSession(ctx, staff.ID, conflict.SessionID, activeSvc.SessionUpdateRequest{Status: &status, Notes: &reason}); err != nil {
+				// The request transaction must roll back the successful reopen if
+				// this audit-bearing status update cannot be persisted.
+				return nil, fmt.Errorf("update reopened session status: %w", err)
+			}
+		}
+	case ActionCheckOut:
+		_, err = s.workSessions.CheckOut(ctx, staff.ID, command.Reason)
+	case ActionBreakStart:
+		_, err = s.workSessions.StartBreak(ctx, staff.ID, command.PlannedDurationMinutes)
+	case ActionBreakEnd:
+		_, err = s.workSessions.EndBreak(ctx, staff.ID)
+	default:
+		return nil, ErrInvalidAction
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return s.loadState(ctx, person, staff)
+}
+
+func (s *Service) resolveStaff(ctx context.Context, rawTag string) (*userModels.Person, *userModels.Staff, error) {
+	normalized := userModels.NormalizeTagID(rawTag)
+	cardCandidate := &userModels.RFIDCard{}
+	cardCandidate.ID = normalized
+	if err := cardCandidate.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("%w: %v", ErrInvalidRFIDTag, err)
+	}
+
+	card, err := s.cards.FindByID(ctx, normalized)
+	if err != nil {
+		return nil, nil, fmt.Errorf("look up RFID card: %w", err)
+	}
+	if card == nil {
+		return nil, nil, ErrRFIDTagNotFound
+	}
+	if !card.Active {
+		return nil, nil, ErrRFIDTagInactive
+	}
+
+	person, err := s.people.FindByTagID(ctx, normalized)
+	if err != nil {
+		if errors.Is(err, usersSvc.ErrPersonNotFound) {
+			return nil, nil, ErrRFIDTagNotFound
+		}
+		return nil, nil, fmt.Errorf("look up person by RFID tag: %w", err)
+	}
+	staff, err := s.people.GetStaffByPersonID(ctx, person.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, ErrRFIDTagNotStaff
+		}
+		return nil, nil, fmt.Errorf("look up staff for RFID tag: %w", err)
+	}
+	if staff == nil {
+		return nil, nil, ErrRFIDTagNotStaff
+	}
+	return person, staff, nil
+}
+
+func (s *Service) loadState(ctx context.Context, person *userModels.Person, staff *userModels.Staff) (*State, error) {
+	result := &State{
+		StaffID:          staff.ID,
+		StaffName:        person.GetFullName(),
+		State:            StateCheckedOut,
+		AllowedActions:   []string{ActionCheckIn},
+		IsBreakCompliant: true,
+	}
+	session, err := s.workSessions.GetCurrentSession(ctx, staff.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load current work session: %w", err)
+	}
+	if session == nil {
+		today := timezone.DateFromTime(s.currentTime())
+		history, historyErr := s.workSessions.GetHistory(ctx, staff.ID, today, today)
+		if historyErr != nil {
+			return nil, fmt.Errorf("load today's work session: %w", historyErr)
+		}
+		if history != nil && len(history.Sessions) > 0 {
+			todaySession := history.Sessions[0]
+			result.Session = todaySession.WorkSession
+			result.NetMinutes = todaySession.NetMinutes
+			result.BreakMinutes = todaySession.BreakMinutes
+			result.IsBreakCompliant = todaySession.IsBreakCompliant
+			result.RequiredBreakMinutes = activeSvc.EvaluateLaborTime(
+				todaySession.WorkSession,
+				todaySession.Breaks,
+				s.currentTime(),
+			).RequiredBreakMinutes
+		}
+		return result, nil
+	}
+
+	breaks, err := s.workSessions.GetSessionBreaks(ctx, staff.ID, session.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load work session breaks: %w", err)
+	}
+	result.Session = session
+	result.State = StateCheckedIn
+	result.AllowedActions = []string{ActionBreakStart, ActionCheckOut}
+	for _, workBreak := range breaks {
+		if workBreak.IsActive() {
+			result.State = StateOnBreak
+			result.ActiveBreak = workBreak
+			result.AllowedActions = []string{ActionBreakEnd, ActionCheckOut}
+			break
+		}
+	}
+
+	evaluation := activeSvc.EvaluateLaborTime(session, breaks, s.currentTime())
+	result.NetMinutes = evaluation.NetMinutes
+	result.BreakMinutes = evaluation.BreakMinutes
+	result.RequiredBreakMinutes = evaluation.RequiredBreakMinutes
+	result.IsBreakCompliant = evaluation.IsBreakCompliant
+	return result, nil
+}

--- a/backend/services/iot/staffclock/service.go
+++ b/backend/services/iot/staffclock/service.go
@@ -150,16 +150,24 @@ func (s *Service) GetState(ctx context.Context, rawTag string) (*State, error) {
 	if err != nil {
 		return nil, err
 	}
-	return s.loadState(ctx, person, staff)
+	return s.loadState(ctx, person, staff, s.currentTime())
 }
 
 // Execute performs one explicit stamp action with source=nfc, then reloads
 // state so the kiosk never has to predict the result locally.
+//
+// The request timestamp is taken once, before the stamp, and the reload is
+// evaluated against that same calendar day. Deriving the day a second time
+// after the write would let a stamp placed at 23:59:59 be read back on the
+// following day: the session exists on yesterday's date, today's read finds
+// nothing, and the kiosk would be told to check in again while the first
+// session stays open.
 func (s *Service) Execute(ctx context.Context, command Command) (*State, error) {
 	person, staff, err := s.resolveStaff(ctx, command.RFIDTag)
 	if err != nil {
 		return nil, err
 	}
+	now := s.currentTime()
 
 	switch command.Action {
 	case ActionCheckIn:
@@ -177,7 +185,7 @@ func (s *Service) Execute(ctx context.Context, command Command) (*State, error) 
 		return nil, err
 	}
 
-	return s.loadState(ctx, person, staff)
+	return s.loadState(ctx, person, staff, now)
 }
 
 // checkIn stamps the arrival, resolving the reopen-status conflict when the
@@ -266,7 +274,10 @@ func (s *Service) resolveStaff(ctx context.Context, rawTag string) (*userModels.
 	return person, staff, nil
 }
 
-func (s *Service) loadState(ctx context.Context, person *userModels.Person, staff *userModels.Staff) (*State, error) {
+// loadState renders the kiosk state of the calendar day `now` falls in. It
+// never derives that day itself — the caller pins one timestamp per request so
+// stamp and reload cannot land on different dates.
+func (s *Service) loadState(ctx context.Context, person *userModels.Person, staff *userModels.Staff, now time.Time) (*State, error) {
 	result := &State{
 		StaffID:          staff.ID,
 		StaffName:        person.GetFullName(),
@@ -274,51 +285,64 @@ func (s *Service) loadState(ctx context.Context, person *userModels.Person, staf
 		AllowedActions:   []string{ActionCheckIn},
 		IsBreakCompliant: true,
 	}
-	session, err := s.workSessions.GetCurrentSession(ctx, staff.ID)
+
+	session, breaks, err := s.resolveDay(ctx, staff.ID, timezone.DateFromTime(now))
 	if err != nil {
-		return nil, fmt.Errorf("load current work session: %w", err)
+		return nil, err
 	}
 	if session == nil {
-		today := timezone.DateFromTime(s.currentTime())
-		history, historyErr := s.workSessions.GetHistory(ctx, staff.ID, today, today)
-		if historyErr != nil {
-			return nil, fmt.Errorf("load today's work session: %w", historyErr)
-		}
-		if history != nil && len(history.Sessions) > 0 {
-			todaySession := history.Sessions[0]
-			result.Session = newSession(todaySession.WorkSession)
-			result.NetMinutes = todaySession.NetMinutes
-			result.BreakMinutes = todaySession.BreakMinutes
-			result.IsBreakCompliant = todaySession.IsBreakCompliant
-			result.RequiredBreakMinutes = activeSvc.EvaluateLaborTime(
-				todaySession.WorkSession,
-				todaySession.Breaks,
-				s.currentTime(),
-			).RequiredBreakMinutes
-		}
 		return result, nil
 	}
 
-	breaks, err := s.workSessions.GetSessionBreaks(ctx, staff.ID, session.ID)
-	if err != nil {
-		return nil, fmt.Errorf("load work session breaks: %w", err)
-	}
 	result.Session = newSession(session)
-	result.State = StateCheckedIn
-	result.AllowedActions = []string{ActionBreakStart, ActionCheckOut}
-	for _, workBreak := range breaks {
-		if workBreak.IsActive() {
-			result.State = StateOnBreak
-			result.ActiveBreak = newBreak(workBreak)
-			result.AllowedActions = []string{ActionBreakEnd, ActionCheckOut}
-			break
+	if session.CheckOutTime == nil {
+		result.State = StateCheckedIn
+		result.AllowedActions = []string{ActionBreakStart, ActionCheckOut}
+		for _, workBreak := range breaks {
+			if workBreak.IsActive() {
+				result.State = StateOnBreak
+				result.ActiveBreak = newBreak(workBreak)
+				result.AllowedActions = []string{ActionBreakEnd, ActionCheckOut}
+				break
+			}
 		}
 	}
 
-	evaluation := activeSvc.EvaluateLaborTime(session, breaks, s.currentTime())
+	evaluation := activeSvc.EvaluateLaborTime(session, breaks, now)
 	result.NetMinutes = evaluation.NetMinutes
 	result.BreakMinutes = evaluation.BreakMinutes
 	result.RequiredBreakMinutes = evaluation.RequiredBreakMinutes
 	result.IsBreakCompliant = evaluation.IsBreakCompliant
 	return result, nil
+}
+
+// resolveDay returns the session of `day` together with its breaks.
+//
+// The fast path is the open session, but that lookup is scoped to the server's
+// current date. When the day rolled over between the stamp and this read it
+// finds nothing, so the pinned day is asked explicitly — that query returns the
+// row whether it is still open or already closed, which keeps a session stamped
+// seconds before midnight visible to the kiosk instead of silently vanishing.
+func (s *Service) resolveDay(ctx context.Context, staffID int64, day timezone.Date) (*activeModels.WorkSession, []*activeModels.WorkSessionBreak, error) {
+	session, err := s.workSessions.GetCurrentSession(ctx, staffID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load current work session: %w", err)
+	}
+	if session != nil {
+		breaks, breaksErr := s.workSessions.GetSessionBreaks(ctx, staffID, session.ID)
+		if breaksErr != nil {
+			return nil, nil, fmt.Errorf("load work session breaks: %w", breaksErr)
+		}
+		return session, breaks, nil
+	}
+
+	history, err := s.workSessions.GetHistory(ctx, staffID, day, day)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load work session of the day: %w", err)
+	}
+	if history == nil || len(history.Sessions) == 0 {
+		return nil, nil, nil
+	}
+	daySession := history.Sessions[0]
+	return daySession.WorkSession, daySession.Breaks, nil
 }

--- a/backend/services/iot/staffclock/service.go
+++ b/backend/services/iot/staffclock/service.go
@@ -62,16 +62,57 @@ type Service struct {
 }
 
 type State struct {
-	StaffID              int64                          `json:"staff_id"`
-	StaffName            string                         `json:"staff_name"`
-	State                string                         `json:"state"`
-	AllowedActions       []string                       `json:"allowed_actions"`
-	Session              *activeModels.WorkSession      `json:"session,omitempty"`
-	ActiveBreak          *activeModels.WorkSessionBreak `json:"active_break,omitempty"`
-	NetMinutes           int                            `json:"net_minutes"`
-	BreakMinutes         int                            `json:"break_minutes"`
-	RequiredBreakMinutes int                            `json:"required_break_minutes"`
-	IsBreakCompliant     bool                           `json:"is_break_compliant"`
+	StaffID              int64    `json:"staff_id"`
+	StaffName            string   `json:"staff_name"`
+	State                string   `json:"state"`
+	AllowedActions       []string `json:"allowed_actions"`
+	Session              *Session `json:"session,omitempty"`
+	ActiveBreak          *Break   `json:"active_break,omitempty"`
+	NetMinutes           int      `json:"net_minutes"`
+	BreakMinutes         int      `json:"break_minutes"`
+	RequiredBreakMinutes int      `json:"required_break_minutes"`
+	IsBreakCompliant     bool     `json:"is_break_compliant"`
+}
+
+// Session is the kiosk projection of a work session. The persistence model
+// carries tenant, audit and free-text note columns — status-change and
+// administrative notes among them — that a shared device in a hallway has no
+// use for and must not receive, so only the rendered fields are exposed.
+type Session struct {
+	ID           int64      `json:"id"`
+	StaffID      int64      `json:"staff_id"`
+	CheckInTime  time.Time  `json:"check_in_time"`
+	CheckOutTime *time.Time `json:"check_out_time,omitempty"`
+	Status       string     `json:"status"`
+	Source       string     `json:"source"`
+}
+
+// Break is the kiosk projection of an active break: enough to show that one is
+// running, nothing more.
+type Break struct {
+	ID        int64     `json:"id"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+func newSession(session *activeModels.WorkSession) *Session {
+	if session == nil {
+		return nil
+	}
+	return &Session{
+		ID:           session.ID,
+		StaffID:      session.StaffID,
+		CheckInTime:  session.CheckInTime,
+		CheckOutTime: session.CheckOutTime,
+		Status:       session.Status,
+		Source:       session.Source,
+	}
+}
+
+func newBreak(workBreak *activeModels.WorkSessionBreak) *Break {
+	if workBreak == nil {
+		return nil
+	}
+	return &Break{ID: workBreak.ID, StartedAt: workBreak.StartedAt}
 }
 
 type Command struct {
@@ -210,7 +251,7 @@ func (s *Service) loadState(ctx context.Context, person *userModels.Person, staf
 		}
 		if history != nil && len(history.Sessions) > 0 {
 			todaySession := history.Sessions[0]
-			result.Session = todaySession.WorkSession
+			result.Session = newSession(todaySession.WorkSession)
 			result.NetMinutes = todaySession.NetMinutes
 			result.BreakMinutes = todaySession.BreakMinutes
 			result.IsBreakCompliant = todaySession.IsBreakCompliant
@@ -227,13 +268,13 @@ func (s *Service) loadState(ctx context.Context, person *userModels.Person, staf
 	if err != nil {
 		return nil, fmt.Errorf("load work session breaks: %w", err)
 	}
-	result.Session = session
+	result.Session = newSession(session)
 	result.State = StateCheckedIn
 	result.AllowedActions = []string{ActionBreakStart, ActionCheckOut}
 	for _, workBreak := range breaks {
 		if workBreak.IsActive() {
 			result.State = StateOnBreak
-			result.ActiveBreak = workBreak
+			result.ActiveBreak = newBreak(workBreak)
 			result.AllowedActions = []string{ActionBreakEnd, ActionCheckOut}
 			break
 		}

--- a/backend/services/iot/staffclock/service.go
+++ b/backend/services/iot/staffclock/service.go
@@ -223,7 +223,13 @@ func (s *Service) Execute(ctx context.Context, command Command) (*State, error) 
 		day = stamped.Date
 	}
 
-	return s.loadState(ctx, person, staff, day, now)
+	// The labor-time figures are read against the clock as it stands after the
+	// write, not against the instant the request was admitted. `now` selected
+	// the day and is deliberately left alone; reusing it here would measure the
+	// session from before its own check-in whenever the stamp crossed midnight,
+	// reporting zero elapsed work and a break requirement computed for the
+	// wrong point in the shift.
+	return s.loadState(ctx, person, staff, day, s.currentTime())
 }
 
 // checkIn stamps the arrival, resolving the reopen-status conflict when the
@@ -307,6 +313,13 @@ func (s *Service) resolveStaff(ctx context.Context, rawTag string) (*userModels.
 			return nil, nil, ErrRFIDTagNotFound
 		}
 		return nil, nil, fmt.Errorf("look up person by RFID tag: %w", err)
+	}
+	// An active card that is not linked to anybody resolves to no person. The
+	// kiosk gets the same stable "unknown tag" answer it gets for a card the
+	// system has never seen — dereferencing the nil would turn an unassigned
+	// card into a 500 at the terminal.
+	if person == nil {
+		return nil, nil, ErrRFIDTagNotFound
 	}
 	staff, err := s.people.GetStaffByPersonID(ctx, person.ID)
 	if err != nil {

--- a/backend/services/iot/staffclock/service.go
+++ b/backend/services/iot/staffclock/service.go
@@ -56,11 +56,12 @@ type personService interface {
 // the same calendar day, so a stamp cannot be written on one day and looked up
 // on the next when the request straddles Berlin midnight.
 type workSessionService interface {
-	CheckIn(ctx context.Context, staffID int64, status, source, reason string) (*activeModels.WorkSession, error)
+	CheckInOn(ctx context.Context, staffID int64, day timezone.Date, status, source, reason string) (*activeModels.WorkSession, error)
 	CheckOutOn(ctx context.Context, staffID int64, day timezone.Date, reason string) (*activeModels.WorkSession, error)
 	StartBreakOn(ctx context.Context, staffID int64, day timezone.Date, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
 	EndBreakOn(ctx context.Context, staffID int64, day timezone.Date) (*activeModels.WorkSession, error)
 	UpdateSession(ctx context.Context, staffID int64, sessionID int64, updates activeSvc.SessionUpdateRequest) (*activeModels.WorkSession, error)
+	GetLatestOpenSession(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
 	GetHistory(ctx context.Context, staffID int64, from, to timezone.Date) (*activeSvc.HistoryResponse, error)
 }
 
@@ -153,34 +154,59 @@ func (s *Service) GetState(ctx context.Context, rawTag string) (*State, error) {
 		return nil, err
 	}
 	now := s.currentTime()
-	return s.loadState(ctx, person, staff, timezone.DateFromTime(now), now)
+	day, err := s.clockDay(ctx, staff.ID, now)
+	if err != nil {
+		return nil, err
+	}
+	return s.loadState(ctx, person, staff, day, now)
+}
+
+// clockDay is the calendar day one kiosk request works on: the day carried by
+// the session that is still running, or today when nobody is clocked in.
+//
+// Taking "today" unconditionally would hide a session opened before Berlin
+// midnight. The kiosk would report checked_out to somebody who is demonstrably
+// still at work, offer a second check-in on the new day, and leave the first
+// session with no way to be closed through this flow at all.
+func (s *Service) clockDay(ctx context.Context, staffID int64, now time.Time) (timezone.Date, error) {
+	open, err := s.workSessions.GetLatestOpenSession(ctx, staffID)
+	if err != nil {
+		return timezone.Date{}, fmt.Errorf("look up running work session: %w", err)
+	}
+	if open != nil {
+		return open.Date, nil
+	}
+	return timezone.DateFromTime(now), nil
 }
 
 // Execute performs one explicit stamp action with source=nfc, then reloads
 // state so the kiosk never has to predict the result locally.
 //
-// One calendar day serves the whole request. It is taken from the clock once,
-// before the stamp, and handed to the action so its lookup cannot drift onto
-// the next day mid-request — an unpinned lookup at 00:00:00 would miss the
-// session opened at 23:59 and refuse the checkout with "no active session
-// found". The reload day then comes from the persisted row itself, which is
-// authoritative even when the write landed on the day after the one the
-// request started on. Re-deriving the day from the clock after the write,
-// which the previous shape did, reported "checked_out, no session" for a
-// check-in placed just before midnight: the kiosk would invite a second
-// check-in and leave the first session open overnight.
+// One calendar day serves the whole request: it is resolved once, up front,
+// and handed to every write and read the request performs. Nothing downstream
+// re-derives it from the clock, because two places asking the clock
+// independently disagree the moment a request straddles Berlin midnight — the
+// stamp lands on one day while the lookup searches the other, and a valid scan
+// fails with "no active session found" or reports "checked_out" right after a
+// successful check-in.
+//
+// The day is the running session's own day when there is one (a night shift
+// keeps working on the day it started), otherwise today.
 func (s *Service) Execute(ctx context.Context, command Command) (*State, error) {
 	person, staff, err := s.resolveStaff(ctx, command.RFIDTag)
 	if err != nil {
 		return nil, err
 	}
 	now := s.currentTime()
-	day := timezone.DateFromTime(now)
+	day, err := s.clockDay(ctx, staff.ID, now)
+	if err != nil {
+		return nil, err
+	}
 
 	var stamped *activeModels.WorkSession
 	switch command.Action {
 	case ActionCheckIn:
-		stamped, err = s.checkIn(ctx, staff.ID, command)
+		stamped, err = s.checkIn(ctx, staff.ID, day, command)
 	case ActionCheckOut:
 		stamped, err = s.workSessions.CheckOutOn(ctx, staff.ID, day, command.Reason)
 	case ActionBreakStart:
@@ -210,10 +236,12 @@ func (s *Service) Execute(ctx context.Context, command Command) (*State, error) 
 // request transaction aborted — nothing can be re-read or retried on it — so
 // the rollback is requested explicitly and the kiosk is told to rescan for
 // authoritative state.
+// Both the first stamp and the reopen retry are pinned to the day the request
+// resolved, so the retry cannot land on a fresh session of the following day
+// while the status update it is paired with rewrites the previous day's row.
 // The stamped session is returned so the caller can read the state back on the
-// day the row actually carries, rather than on whatever day the clock shows
-// once the write is done.
-func (s *Service) checkIn(ctx context.Context, staffID int64, command Command) (*activeModels.WorkSession, error) {
+// day the row actually carries.
+func (s *Service) checkIn(ctx context.Context, staffID int64, day timezone.Date, command Command) (*activeModels.WorkSession, error) {
 	if command.Status == "" {
 		return nil, ErrStatusRequired
 	}
@@ -221,13 +249,13 @@ func (s *Service) checkIn(ctx context.Context, staffID int64, command Command) (
 		return nil, fmt.Errorf("%w: status must be 'present' or 'home_office'", ErrStatusRequired)
 	}
 
-	session, err := s.workSessions.CheckIn(ctx, staffID, command.Status, activeModels.WorkSessionSourceNFC, command.Reason)
+	session, err := s.workSessions.CheckInOn(ctx, staffID, day, command.Status, activeModels.WorkSessionSourceNFC, command.Reason)
 	var conflict *activeSvc.ReopenStatusConflictError
 	if errors.As(err, &conflict) {
 		if strings.TrimSpace(command.Reason) == "" {
 			return nil, conflict
 		}
-		if _, err = s.workSessions.CheckIn(ctx, staffID, conflict.ExistingStatus, activeModels.WorkSessionSourceNFC, command.Reason); err != nil {
+		if _, err = s.workSessions.CheckInOn(ctx, staffID, day, conflict.ExistingStatus, activeModels.WorkSessionSourceNFC, command.Reason); err != nil {
 			return nil, s.classifyCheckInError(ctx, fmt.Errorf("reopen session with existing status: %w", err))
 		}
 		reason := strings.TrimSpace(command.Reason)

--- a/backend/services/iot/staffclock/service.go
+++ b/backend/services/iot/staffclock/service.go
@@ -51,14 +51,16 @@ type personService interface {
 	GetStaffByPersonID(ctx context.Context, personID int64) (*userModels.Staff, error)
 }
 
+// workSessionService is the day-pinned subset of the work session service. The
+// kiosk deliberately uses the *On variants: every action of one request acts on
+// the same calendar day, so a stamp cannot be written on one day and looked up
+// on the next when the request straddles Berlin midnight.
 type workSessionService interface {
 	CheckIn(ctx context.Context, staffID int64, status, source, reason string) (*activeModels.WorkSession, error)
-	CheckOut(ctx context.Context, staffID int64, reason string) (*activeModels.WorkSession, error)
-	StartBreak(ctx context.Context, staffID int64, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
-	EndBreak(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
-	GetSessionBreaks(ctx context.Context, staffID, sessionID int64) ([]*activeModels.WorkSessionBreak, error)
+	CheckOutOn(ctx context.Context, staffID int64, day timezone.Date, reason string) (*activeModels.WorkSession, error)
+	StartBreakOn(ctx context.Context, staffID int64, day timezone.Date, plannedDurationMinutes *int) (*activeModels.WorkSessionBreak, error)
+	EndBreakOn(ctx context.Context, staffID int64, day timezone.Date) (*activeModels.WorkSession, error)
 	UpdateSession(ctx context.Context, staffID int64, sessionID int64, updates activeSvc.SessionUpdateRequest) (*activeModels.WorkSession, error)
-	GetCurrentSession(ctx context.Context, staffID int64) (*activeModels.WorkSession, error)
 	GetHistory(ctx context.Context, staffID int64, from, to timezone.Date) (*activeSvc.HistoryResponse, error)
 }
 
@@ -150,42 +152,52 @@ func (s *Service) GetState(ctx context.Context, rawTag string) (*State, error) {
 	if err != nil {
 		return nil, err
 	}
-	return s.loadState(ctx, person, staff, s.currentTime())
+	now := s.currentTime()
+	return s.loadState(ctx, person, staff, timezone.DateFromTime(now), now)
 }
 
 // Execute performs one explicit stamp action with source=nfc, then reloads
 // state so the kiosk never has to predict the result locally.
 //
-// The request timestamp is taken once, before the stamp, and the reload is
-// evaluated against that same calendar day. Deriving the day a second time
-// after the write would let a stamp placed at 23:59:59 be read back on the
-// following day: the session exists on yesterday's date, today's read finds
-// nothing, and the kiosk would be told to check in again while the first
-// session stays open.
+// One calendar day serves the whole request. It is taken from the clock once,
+// before the stamp, and handed to the action so its lookup cannot drift onto
+// the next day mid-request — an unpinned lookup at 00:00:00 would miss the
+// session opened at 23:59 and refuse the checkout with "no active session
+// found". The reload day then comes from the persisted row itself, which is
+// authoritative even when the write landed on the day after the one the
+// request started on. Re-deriving the day from the clock after the write,
+// which the previous shape did, reported "checked_out, no session" for a
+// check-in placed just before midnight: the kiosk would invite a second
+// check-in and leave the first session open overnight.
 func (s *Service) Execute(ctx context.Context, command Command) (*State, error) {
 	person, staff, err := s.resolveStaff(ctx, command.RFIDTag)
 	if err != nil {
 		return nil, err
 	}
 	now := s.currentTime()
+	day := timezone.DateFromTime(now)
 
+	var stamped *activeModels.WorkSession
 	switch command.Action {
 	case ActionCheckIn:
-		err = s.checkIn(ctx, staff.ID, command)
+		stamped, err = s.checkIn(ctx, staff.ID, command)
 	case ActionCheckOut:
-		_, err = s.workSessions.CheckOut(ctx, staff.ID, command.Reason)
+		stamped, err = s.workSessions.CheckOutOn(ctx, staff.ID, day, command.Reason)
 	case ActionBreakStart:
-		_, err = s.workSessions.StartBreak(ctx, staff.ID, command.PlannedDurationMinutes)
+		_, err = s.workSessions.StartBreakOn(ctx, staff.ID, day, command.PlannedDurationMinutes)
 	case ActionBreakEnd:
-		_, err = s.workSessions.EndBreak(ctx, staff.ID)
+		stamped, err = s.workSessions.EndBreakOn(ctx, staff.ID, day)
 	default:
 		return nil, ErrInvalidAction
 	}
 	if err != nil {
 		return nil, err
 	}
+	if stamped != nil {
+		day = stamped.Date
+	}
 
-	return s.loadState(ctx, person, staff, now)
+	return s.loadState(ctx, person, staff, day, now)
 }
 
 // checkIn stamps the arrival, resolving the reopen-status conflict when the
@@ -198,33 +210,40 @@ func (s *Service) Execute(ctx context.Context, command Command) (*State, error) 
 // request transaction aborted — nothing can be re-read or retried on it — so
 // the rollback is requested explicitly and the kiosk is told to rescan for
 // authoritative state.
-func (s *Service) checkIn(ctx context.Context, staffID int64, command Command) error {
+// The stamped session is returned so the caller can read the state back on the
+// day the row actually carries, rather than on whatever day the clock shows
+// once the write is done.
+func (s *Service) checkIn(ctx context.Context, staffID int64, command Command) (*activeModels.WorkSession, error) {
 	if command.Status == "" {
-		return ErrStatusRequired
+		return nil, ErrStatusRequired
 	}
 	if command.Status != activeModels.WorkSessionStatusPresent && command.Status != activeModels.WorkSessionStatusHomeOffice {
-		return fmt.Errorf("%w: status must be 'present' or 'home_office'", ErrStatusRequired)
+		return nil, fmt.Errorf("%w: status must be 'present' or 'home_office'", ErrStatusRequired)
 	}
 
-	_, err := s.workSessions.CheckIn(ctx, staffID, command.Status, activeModels.WorkSessionSourceNFC, command.Reason)
+	session, err := s.workSessions.CheckIn(ctx, staffID, command.Status, activeModels.WorkSessionSourceNFC, command.Reason)
 	var conflict *activeSvc.ReopenStatusConflictError
 	if errors.As(err, &conflict) {
 		if strings.TrimSpace(command.Reason) == "" {
-			return conflict
+			return nil, conflict
 		}
 		if _, err = s.workSessions.CheckIn(ctx, staffID, conflict.ExistingStatus, activeModels.WorkSessionSourceNFC, command.Reason); err != nil {
-			return s.classifyCheckInError(ctx, fmt.Errorf("reopen session with existing status: %w", err))
+			return nil, s.classifyCheckInError(ctx, fmt.Errorf("reopen session with existing status: %w", err))
 		}
 		reason := strings.TrimSpace(command.Reason)
 		status := command.Status
-		if _, err = s.workSessions.UpdateSession(ctx, staffID, conflict.SessionID, activeSvc.SessionUpdateRequest{Status: &status, Notes: &reason}); err != nil {
+		updated, updateErr := s.workSessions.UpdateSession(ctx, staffID, conflict.SessionID, activeSvc.SessionUpdateRequest{Status: &status, Notes: &reason})
+		if updateErr != nil {
 			// The request transaction must roll back the successful reopen if
 			// this audit-bearing status update cannot be persisted.
-			return fmt.Errorf("update reopened session status: %w", err)
+			return nil, fmt.Errorf("update reopened session status: %w", updateErr)
 		}
-		return nil
+		return updated, nil
 	}
-	return s.classifyCheckInError(ctx, err)
+	if err != nil {
+		return nil, s.classifyCheckInError(ctx, err)
+	}
+	return session, nil
 }
 
 func (s *Service) classifyCheckInError(ctx context.Context, err error) error {
@@ -274,10 +293,10 @@ func (s *Service) resolveStaff(ctx context.Context, rawTag string) (*userModels.
 	return person, staff, nil
 }
 
-// loadState renders the kiosk state of the calendar day `now` falls in. It
-// never derives that day itself — the caller pins one timestamp per request so
-// stamp and reload cannot land on different dates.
-func (s *Service) loadState(ctx context.Context, person *userModels.Person, staff *userModels.Staff, now time.Time) (*State, error) {
+// loadState renders the kiosk state of `day`. It never derives that day itself:
+// the caller passes the day the session was written on, while `now` is only the
+// reference instant for the labor-time figures.
+func (s *Service) loadState(ctx context.Context, person *userModels.Person, staff *userModels.Staff, day timezone.Date, now time.Time) (*State, error) {
 	result := &State{
 		StaffID:          staff.ID,
 		StaffName:        person.GetFullName(),
@@ -286,7 +305,7 @@ func (s *Service) loadState(ctx context.Context, person *userModels.Person, staf
 		IsBreakCompliant: true,
 	}
 
-	session, breaks, err := s.resolveDay(ctx, staff.ID, timezone.DateFromTime(now))
+	session, breaks, err := s.resolveDay(ctx, staff.ID, day)
 	if err != nil {
 		return nil, err
 	}
@@ -318,24 +337,12 @@ func (s *Service) loadState(ctx context.Context, person *userModels.Person, staf
 
 // resolveDay returns the session of `day` together with its breaks.
 //
-// The fast path is the open session, but that lookup is scoped to the server's
-// current date. When the day rolled over between the stamp and this read it
-// finds nothing, so the pinned day is asked explicitly — that query returns the
-// row whether it is still open or already closed, which keeps a session stamped
-// seconds before midnight visible to the kiosk instead of silently vanishing.
+// The day is asked for explicitly instead of going through the open-session
+// lookup, which is scoped to the server's current date and would come back
+// empty for a session stamped seconds before midnight. This query returns the
+// row whether it is still open or already closed, so open and closed state are
+// derived from check_out_time rather than from which read happened to hit.
 func (s *Service) resolveDay(ctx context.Context, staffID int64, day timezone.Date) (*activeModels.WorkSession, []*activeModels.WorkSessionBreak, error) {
-	session, err := s.workSessions.GetCurrentSession(ctx, staffID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("load current work session: %w", err)
-	}
-	if session != nil {
-		breaks, breaksErr := s.workSessions.GetSessionBreaks(ctx, staffID, session.ID)
-		if breaksErr != nil {
-			return nil, nil, fmt.Errorf("load work session breaks: %w", breaksErr)
-		}
-		return session, breaks, nil
-	}
-
 	history, err := s.workSessions.GetHistory(ctx, staffID, day, day)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load work session of the day: %w", err)

--- a/backend/services/iot/staffclock/service_internal_test.go
+++ b/backend/services/iot/staffclock/service_internal_test.go
@@ -67,6 +67,11 @@ type stubWorkSessions struct {
 	checkInErr     error
 	checkInCall    int
 	checkInSession *activeModels.WorkSession
+	// checkInDays records the calendar day every check-in attempt was pinned to.
+	checkInDays []timezone.Date
+	// latestOpen is the still-running session the day resolution starts from,
+	// whatever day it was opened on.
+	latestOpen *activeModels.WorkSession
 	// actionDays records the calendar day every mutating action was pinned to.
 	actionDays []timezone.Date
 	// openSessionByDay mirrors the day-scoped lookup inside the work session
@@ -77,12 +82,19 @@ type stubWorkSessions struct {
 	historyByDay map[string]*activeSvc.SessionResponse
 }
 
-func (s *stubWorkSessions) CheckIn(context.Context, int64, string, string, string) (*activeModels.WorkSession, error) {
+func (s *stubWorkSessions) CheckInOn(_ context.Context, _ int64, day timezone.Date, _, _, _ string) (*activeModels.WorkSession, error) {
 	s.checkInCall++
-	if s.checkInErr != nil {
+	s.checkInDays = append(s.checkInDays, day)
+	// Only the first attempt fails: the reopen retry that follows a status
+	// conflict has to be able to succeed.
+	if s.checkInErr != nil && s.checkInCall == 1 {
 		return nil, s.checkInErr
 	}
 	return s.checkInSession, nil
+}
+
+func (s *stubWorkSessions) GetLatestOpenSession(context.Context, int64) (*activeModels.WorkSession, error) {
+	return s.latestOpen, nil
 }
 
 // openOn is the stand-in for the day-pinned lookup the real service performs.
@@ -218,6 +230,7 @@ func TestExecute_ActionsPinTheLookupToTheRequestDay(t *testing.T) {
 	for _, action := range []string{ActionCheckOut, ActionBreakStart, ActionBreakEnd} {
 		t.Run(action, func(t *testing.T) {
 			service, sessions := newRacedService(nil)
+			sessions.latestOpen = open
 			sessions.openSessionByDay = map[string]*activeModels.WorkSession{requestDay.String(): open}
 			sessions.historyByDay = map[string]*activeSvc.SessionResponse{
 				requestDay.String(): {WorkSession: open},
@@ -241,6 +254,108 @@ func TestExecute_ActionsPinTheLookupToTheRequestDay(t *testing.T) {
 			assert.Equal(t, []timezone.Date{requestDay}, sessions.actionDays)
 		})
 	}
+}
+
+// nightSession is a session opened the evening before and still running after
+// the Berlin midnight rollover.
+func nightSession(openedAt time.Time) *activeModels.WorkSession {
+	session := &activeModels.WorkSession{
+		StaffID:     7,
+		Date:        timezone.DateFromTime(openedAt),
+		Status:      activeModels.WorkSessionStatusPresent,
+		Source:      activeModels.WorkSessionSourceNFC,
+		CheckInTime: openedAt,
+	}
+	session.ID = 91
+	return session
+}
+
+// Somebody who clocked in yesterday evening and never clocked out is still at
+// work after midnight. Reading only today's row reported checked_out, offered a
+// second check-in on the new day, and left yesterday's session with no way to be
+// closed from the kiosk at all.
+func TestGetState_OpenSessionFromPreviousDayStaysCheckedIn(t *testing.T) {
+	service, sessions := newRacedService(nil)
+
+	openedAt := time.Date(2026, 7, 21, 22, 30, 0, 0, timezone.Berlin)
+	open := nightSession(openedAt)
+	sessions.latestOpen = open
+	sessions.historyByDay = map[string]*activeSvc.SessionResponse{
+		open.Date.String(): {WorkSession: open},
+	}
+	service.now = func() time.Time { return openedAt.Add(3 * time.Hour) } // 01:30 the next day
+
+	state, err := service.GetState(context.Background(), "A1654BEEF")
+
+	require.NoError(t, err)
+	require.NotNil(t, state.Session)
+	assert.Equal(t, open.ID, state.Session.ID)
+	assert.Equal(t, StateCheckedIn, state.State)
+	assert.Equal(t, []string{ActionBreakStart, ActionCheckOut}, state.AllowedActions)
+}
+
+// The stamp that ends such a night session must be dispatched on the day the
+// session carries. Pinning it to the new day looks up a day the session was
+// never written on and refuses a valid scan with "no active session found".
+func TestExecute_ActionsAfterMidnightUseTheOpenSessionDay(t *testing.T) {
+	openedAt := time.Date(2026, 7, 21, 22, 30, 0, 0, timezone.Berlin)
+	open := nightSession(openedAt)
+	afterMidnight := openedAt.Add(3 * time.Hour)
+	require.NotEqual(t, open.Date, timezone.DateFromTime(afterMidnight))
+
+	for _, action := range []string{ActionCheckOut, ActionBreakStart, ActionBreakEnd} {
+		t.Run(action, func(t *testing.T) {
+			service, sessions := newRacedService(nil)
+			sessions.latestOpen = open
+			sessions.openSessionByDay = map[string]*activeModels.WorkSession{open.Date.String(): open}
+			sessions.historyByDay = map[string]*activeSvc.SessionResponse{
+				open.Date.String(): {WorkSession: open},
+			}
+			service.now = func() time.Time { return afterMidnight }
+
+			state, err := service.Execute(context.Background(), Command{RFIDTag: "A1654BEEF", Action: action})
+
+			require.NoError(t, err)
+			require.NotNil(t, state.Session)
+			assert.Equal(t, []timezone.Date{open.Date}, sessions.actionDays)
+		})
+	}
+}
+
+// The reopen retry after a status conflict has to stay on the day that produced
+// the conflict. Letting it re-derive the day opens a fresh session on the new
+// day while the paired status update rewrites the previous day's closed row.
+func TestExecute_ReopenRetryStaysOnTheConflictedDay(t *testing.T) {
+	requestedAt := time.Date(2026, 7, 21, 23, 59, 59, 0, timezone.Berlin)
+	requestDay := timezone.DateFromTime(requestedAt)
+
+	service, sessions := newRacedService(&activeSvc.ReopenStatusConflictError{
+		SessionID:       91,
+		ExistingStatus:  activeModels.WorkSessionStatusHomeOffice,
+		RequestedStatus: activeModels.WorkSessionStatusPresent,
+	})
+	sessions.historyByDay = map[string]*activeSvc.SessionResponse{
+		requestDay.String(): {WorkSession: nightSession(requestedAt.Add(-8 * time.Hour))},
+	}
+
+	// The clock crosses midnight between the conflicting stamp and the retry.
+	calls := 0
+	service.now = func() time.Time {
+		calls++
+		if calls == 1 {
+			return requestedAt
+		}
+		return requestedAt.Add(2 * time.Second)
+	}
+
+	command := checkInCommand()
+	command.Reason = "Statuswechsel nach Rücksprache"
+
+	state, err := service.Execute(context.Background(), command)
+
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, []timezone.Date{requestDay, requestDay}, sessions.checkInDays)
 }
 
 // A unique violation on another constraint is a genuine fault and must keep

--- a/backend/services/iot/staffclock/service_internal_test.go
+++ b/backend/services/iot/staffclock/service_internal_test.go
@@ -2,6 +2,7 @@ package staffclock
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -63,8 +64,14 @@ func (s *stubCards) List(context.Context, map[string]any) ([]*userModels.RFIDCar
 func (s *stubCards) Deactivate(context.Context, string) error { return nil }
 
 type stubWorkSessions struct {
-	checkInErr  error
-	checkInCall int
+	checkInErr     error
+	checkInCall    int
+	checkInSession *activeModels.WorkSession
+	// actionDays records the calendar day every mutating action was pinned to.
+	actionDays []timezone.Date
+	// openSessionByDay mirrors the day-scoped lookup inside the work session
+	// service: an action only finds the session on the day it was written on.
+	openSessionByDay map[string]*activeModels.WorkSession
 	// historyByDay mirrors the date-scoped read: only the day the session was
 	// stamped on returns it.
 	historyByDay map[string]*activeSvc.SessionResponse
@@ -72,30 +79,38 @@ type stubWorkSessions struct {
 
 func (s *stubWorkSessions) CheckIn(context.Context, int64, string, string, string) (*activeModels.WorkSession, error) {
 	s.checkInCall++
-	return nil, s.checkInErr
+	if s.checkInErr != nil {
+		return nil, s.checkInErr
+	}
+	return s.checkInSession, nil
 }
 
-func (s *stubWorkSessions) CheckOut(context.Context, int64, string) (*activeModels.WorkSession, error) {
-	return nil, nil
+// openOn is the stand-in for the day-pinned lookup the real service performs.
+func (s *stubWorkSessions) openOn(day timezone.Date) (*activeModels.WorkSession, error) {
+	s.actionDays = append(s.actionDays, day)
+	session, ok := s.openSessionByDay[day.String()]
+	if !ok {
+		return nil, errors.New("no active session found")
+	}
+	return session, nil
 }
 
-func (s *stubWorkSessions) StartBreak(context.Context, int64, *int) (*activeModels.WorkSessionBreak, error) {
-	return nil, nil
+func (s *stubWorkSessions) CheckOutOn(_ context.Context, _ int64, day timezone.Date, _ string) (*activeModels.WorkSession, error) {
+	return s.openOn(day)
 }
 
-func (s *stubWorkSessions) EndBreak(context.Context, int64) (*activeModels.WorkSession, error) {
-	return nil, nil
+func (s *stubWorkSessions) StartBreakOn(_ context.Context, _ int64, day timezone.Date, _ *int) (*activeModels.WorkSessionBreak, error) {
+	if _, err := s.openOn(day); err != nil {
+		return nil, err
+	}
+	return &activeModels.WorkSessionBreak{}, nil
 }
 
-func (s *stubWorkSessions) GetSessionBreaks(context.Context, int64, int64) ([]*activeModels.WorkSessionBreak, error) {
-	return nil, nil
+func (s *stubWorkSessions) EndBreakOn(_ context.Context, _ int64, day timezone.Date) (*activeModels.WorkSession, error) {
+	return s.openOn(day)
 }
 
 func (s *stubWorkSessions) UpdateSession(context.Context, int64, int64, activeSvc.SessionUpdateRequest) (*activeModels.WorkSession, error) {
-	return nil, nil
-}
-
-func (s *stubWorkSessions) GetCurrentSession(context.Context, int64) (*activeModels.WorkSession, error) {
 	return nil, nil
 }
 
@@ -147,36 +162,33 @@ func TestExecute_ConcurrentCheckInReportsStateConflict(t *testing.T) {
 	assert.True(t, tenant.RollbackRequested(ctx))
 }
 
-// A stamp placed just before midnight must be read back on the day it was
-// written. Re-deriving the day after the write reported "checked_out, no
-// session", which invites the kiosk to check in again and leaves the first
-// session open overnight.
-func TestExecute_CheckInBeforeMidnightReportsTheStampedDay(t *testing.T) {
+// A check-in that straddles Berlin midnight is persisted on the day the write
+// happened, and that day — not the day the request started on — decides what is
+// read back. Anchoring the reload to the request clock reported "checked_out, no
+// session" for a successful stamp, which invites the kiosk to check in a second
+// time and leaves the first session open overnight.
+func TestExecute_CheckInAcrossMidnightReportsTheStampedDay(t *testing.T) {
 	service, sessions := newRacedService(nil)
 
-	stampedAt := time.Date(2026, 7, 21, 23, 59, 59, 0, timezone.Berlin)
+	requestedAt := time.Date(2026, 7, 21, 23, 59, 59, 0, timezone.Berlin)
+	stampedAt := requestedAt.Add(2 * time.Second) // the write lands after midnight
 	stampedDay := timezone.DateFromTime(stampedAt)
+	require.NotEqual(t, timezone.DateFromTime(requestedAt), stampedDay)
+
+	stamped := &activeModels.WorkSession{
+		StaffID:     7,
+		Date:        stampedDay,
+		Status:      activeModels.WorkSessionStatusPresent,
+		Source:      activeModels.WorkSessionSourceNFC,
+		CheckInTime: stampedAt,
+	}
+	sessions.checkInSession = stamped
+	// Only the day the row carries returns it — the request day is empty.
 	sessions.historyByDay = map[string]*activeSvc.SessionResponse{
-		stampedDay.String(): {
-			WorkSession: &activeModels.WorkSession{
-				StaffID:     7,
-				Date:        stampedDay,
-				Status:      activeModels.WorkSessionStatusPresent,
-				Source:      activeModels.WorkSessionSourceNFC,
-				CheckInTime: stampedAt,
-			},
-		},
+		stampedDay.String(): {WorkSession: stamped},
 	}
 
-	// The clock crosses midnight between the stamp and the reload; GetCurrentSession
-	// is date-scoped and no longer sees yesterday's open session.
-	clock := []time.Time{stampedAt, stampedAt.Add(2 * time.Second)}
-	call := 0
-	service.now = func() time.Time {
-		tick := clock[min(call, len(clock)-1)]
-		call++
-		return tick
-	}
+	service.now = func() time.Time { return requestedAt }
 
 	state, err := service.Execute(context.Background(), checkInCommand())
 
@@ -185,6 +197,50 @@ func TestExecute_CheckInBeforeMidnightReportsTheStampedDay(t *testing.T) {
 	assert.Equal(t, stampedDay, timezone.DateFromTime(state.Session.CheckInTime))
 	assert.Equal(t, StateCheckedIn, state.State)
 	assert.Equal(t, []string{ActionBreakStart, ActionCheckOut}, state.AllowedActions)
+}
+
+// Check-out, break start and break end must look up the session on the day the
+// request was taken on. An unpinned lookup re-derives "today" while the request
+// runs and misses the session opened seconds before midnight, refusing a valid
+// stamp with "no active session found".
+func TestExecute_ActionsPinTheLookupToTheRequestDay(t *testing.T) {
+	requestedAt := time.Date(2026, 7, 21, 23, 59, 59, 0, timezone.Berlin)
+	requestDay := timezone.DateFromTime(requestedAt)
+
+	open := &activeModels.WorkSession{
+		StaffID:     7,
+		Date:        requestDay,
+		Status:      activeModels.WorkSessionStatusPresent,
+		Source:      activeModels.WorkSessionSourceNFC,
+		CheckInTime: requestedAt.Add(-8 * time.Hour),
+	}
+
+	for _, action := range []string{ActionCheckOut, ActionBreakStart, ActionBreakEnd} {
+		t.Run(action, func(t *testing.T) {
+			service, sessions := newRacedService(nil)
+			sessions.openSessionByDay = map[string]*activeModels.WorkSession{requestDay.String(): open}
+			sessions.historyByDay = map[string]*activeSvc.SessionResponse{
+				requestDay.String(): {WorkSession: open},
+			}
+
+			// The clock rolls past midnight right after the request timestamp is
+			// taken; every lookup must still land on the request day.
+			calls := 0
+			service.now = func() time.Time {
+				calls++
+				if calls == 1 {
+					return requestedAt
+				}
+				return requestedAt.Add(2 * time.Second)
+			}
+
+			state, err := service.Execute(context.Background(), Command{RFIDTag: "A1654BEEF", Action: action})
+
+			require.NoError(t, err)
+			require.NotNil(t, state.Session)
+			assert.Equal(t, []timezone.Date{requestDay}, sessions.actionDays)
+		})
+	}
 }
 
 // A unique violation on another constraint is a genuine fault and must keep

--- a/backend/services/iot/staffclock/service_internal_test.go
+++ b/backend/services/iot/staffclock/service_internal_test.go
@@ -65,6 +65,9 @@ func (s *stubCards) Deactivate(context.Context, string) error { return nil }
 type stubWorkSessions struct {
 	checkInErr  error
 	checkInCall int
+	// historyByDay mirrors the date-scoped read: only the day the session was
+	// stamped on returns it.
+	historyByDay map[string]*activeSvc.SessionResponse
 }
 
 func (s *stubWorkSessions) CheckIn(context.Context, int64, string, string, string) (*activeModels.WorkSession, error) {
@@ -96,7 +99,10 @@ func (s *stubWorkSessions) GetCurrentSession(context.Context, int64) (*activeMod
 	return nil, nil
 }
 
-func (s *stubWorkSessions) GetHistory(context.Context, int64, timezone.Date, timezone.Date) (*activeSvc.HistoryResponse, error) {
+func (s *stubWorkSessions) GetHistory(_ context.Context, _ int64, from, _ timezone.Date) (*activeSvc.HistoryResponse, error) {
+	if session, ok := s.historyByDay[from.String()]; ok {
+		return &activeSvc.HistoryResponse{Sessions: []*activeSvc.SessionResponse{session}}, nil
+	}
 	return &activeSvc.HistoryResponse{}, nil
 }
 
@@ -139,6 +145,46 @@ func TestExecute_ConcurrentCheckInReportsStateConflict(t *testing.T) {
 	// The duplicate INSERT left the request transaction aborted, so the partial
 	// work must never be committed alongside the 409.
 	assert.True(t, tenant.RollbackRequested(ctx))
+}
+
+// A stamp placed just before midnight must be read back on the day it was
+// written. Re-deriving the day after the write reported "checked_out, no
+// session", which invites the kiosk to check in again and leaves the first
+// session open overnight.
+func TestExecute_CheckInBeforeMidnightReportsTheStampedDay(t *testing.T) {
+	service, sessions := newRacedService(nil)
+
+	stampedAt := time.Date(2026, 7, 21, 23, 59, 59, 0, timezone.Berlin)
+	stampedDay := timezone.DateFromTime(stampedAt)
+	sessions.historyByDay = map[string]*activeSvc.SessionResponse{
+		stampedDay.String(): {
+			WorkSession: &activeModels.WorkSession{
+				StaffID:     7,
+				Date:        stampedDay,
+				Status:      activeModels.WorkSessionStatusPresent,
+				Source:      activeModels.WorkSessionSourceNFC,
+				CheckInTime: stampedAt,
+			},
+		},
+	}
+
+	// The clock crosses midnight between the stamp and the reload; GetCurrentSession
+	// is date-scoped and no longer sees yesterday's open session.
+	clock := []time.Time{stampedAt, stampedAt.Add(2 * time.Second)}
+	call := 0
+	service.now = func() time.Time {
+		tick := clock[min(call, len(clock)-1)]
+		call++
+		return tick
+	}
+
+	state, err := service.Execute(context.Background(), checkInCommand())
+
+	require.NoError(t, err)
+	require.NotNil(t, state.Session)
+	assert.Equal(t, stampedDay, timezone.DateFromTime(state.Session.CheckInTime))
+	assert.Equal(t, StateCheckedIn, state.State)
+	assert.Equal(t, []string{ActionBreakStart, ActionCheckOut}, state.AllowedActions)
 }
 
 // A unique violation on another constraint is a genuine fault and must keep

--- a/backend/services/iot/staffclock/service_internal_test.go
+++ b/backend/services/iot/staffclock/service_internal_test.go
@@ -403,3 +403,58 @@ func TestExecute_UnrelatedUniqueViolationStaysAnError(t *testing.T) {
 	assert.NotErrorIs(t, err, ErrCheckInRaced)
 	assert.False(t, tenant.RollbackRequested(ctx))
 }
+
+// An RFID card that is active but linked to nobody resolves to no person. The
+// terminal must be told the tag is unknown, the same answer a never-seen card
+// gets — dereferencing the missing person turned an unassigned card into a 500.
+func TestGetState_UnassignedCardIsReportedAsUnknownTag(t *testing.T) {
+	card := &userModels.RFIDCard{Active: true}
+	card.ID = "A1654BEEF"
+	service := NewService(&stubPeople{}, &stubCards{card: card}, &stubWorkSessions{})
+
+	state, err := service.GetState(context.Background(), "A1654BEEF")
+
+	require.ErrorIs(t, err, ErrRFIDTagNotFound)
+	assert.Nil(t, state)
+}
+
+// The labor-time figures belong to the clock as it stands after the stamp. The
+// instant that resolved the day is older than the write it preceded, so reusing
+// it measures a session from before its own check-in: zero elapsed work and a
+// break requirement computed for the wrong point in the shift.
+func TestExecute_LaborTimeIsEvaluatedAfterTheStamp(t *testing.T) {
+	requestedAt := time.Date(2026, 7, 21, 23, 59, 59, 0, timezone.Berlin)
+	stampedAt := requestedAt.Add(2 * time.Second) // the write lands after midnight
+	evaluatedAt := stampedAt.Add(10 * time.Minute)
+
+	service, sessions := newRacedService(nil)
+	stamped := &activeModels.WorkSession{
+		StaffID:     7,
+		Date:        timezone.DateFromTime(stampedAt),
+		Status:      activeModels.WorkSessionStatusPresent,
+		Source:      activeModels.WorkSessionSourceNFC,
+		CheckInTime: stampedAt,
+	}
+	stamped.ID = 93
+	sessions.historyByDay = map[string]*activeSvc.SessionResponse{
+		stamped.Date.String(): {WorkSession: stamped},
+	}
+
+	// The clock the request resolved its day on, the clock the write landed on,
+	// and the clock the state is rendered against are three distinct instants.
+	instants := []time.Time{requestedAt, stampedAt, evaluatedAt}
+	calls := 0
+	setClock(service, sessions, func() time.Time {
+		if calls < len(instants) {
+			calls++
+		}
+		return instants[calls-1]
+	})
+
+	state, err := service.Execute(context.Background(), checkInCommand())
+
+	require.NoError(t, err)
+	require.NotNil(t, state.Session)
+	assert.Equal(t, StateCheckedIn, state.State)
+	assert.Equal(t, 10, state.NetMinutes, "elapsed work is measured against the clock after the write")
+}

--- a/backend/services/iot/staffclock/service_internal_test.go
+++ b/backend/services/iot/staffclock/service_internal_test.go
@@ -1,0 +1,157 @@
+package staffclock
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun/driver/pgdriver"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+// pgUniqueViolation builds the driver error a duplicate INSERT produces. The
+// pgdriver fields are unexported, so the map is written through reflection —
+// same approach as api/timetable/instances_update_test.go.
+func pgUniqueViolation(constraint string) error {
+	pgErr := pgdriver.Error{}
+	v := reflect.ValueOf(&pgErr).Elem()
+	field := v.FieldByName("m")
+	ptr := unsafe.Pointer(field.UnsafeAddr()) //nolint:gosec // test-only field access
+	*(*map[byte]string)(ptr) = map[byte]string{'C': "23505", 'n': constraint}
+	return pgErr
+}
+
+type stubPeople struct {
+	person *userModels.Person
+	staff  *userModels.Staff
+}
+
+func (s *stubPeople) FindByTagID(context.Context, string) (*userModels.Person, error) {
+	return s.person, nil
+}
+
+func (s *stubPeople) GetStaffByPersonID(context.Context, int64) (*userModels.Staff, error) {
+	return s.staff, nil
+}
+
+type stubCards struct {
+	card *userModels.RFIDCard
+}
+
+func (s *stubCards) FindByID(context.Context, string) (*userModels.RFIDCard, error) {
+	return s.card, nil
+}
+
+func (s *stubCards) Create(context.Context, *userModels.RFIDCard) error { return nil }
+func (s *stubCards) Update(context.Context, *userModels.RFIDCard) error {
+	return nil
+}
+func (s *stubCards) Delete(context.Context, string) error { return nil }
+func (s *stubCards) List(context.Context, map[string]any) ([]*userModels.RFIDCard, error) {
+	return nil, nil
+}
+func (s *stubCards) Deactivate(context.Context, string) error { return nil }
+
+type stubWorkSessions struct {
+	checkInErr  error
+	checkInCall int
+}
+
+func (s *stubWorkSessions) CheckIn(context.Context, int64, string, string, string) (*activeModels.WorkSession, error) {
+	s.checkInCall++
+	return nil, s.checkInErr
+}
+
+func (s *stubWorkSessions) CheckOut(context.Context, int64, string) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+
+func (s *stubWorkSessions) StartBreak(context.Context, int64, *int) (*activeModels.WorkSessionBreak, error) {
+	return nil, nil
+}
+
+func (s *stubWorkSessions) EndBreak(context.Context, int64) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+
+func (s *stubWorkSessions) GetSessionBreaks(context.Context, int64, int64) ([]*activeModels.WorkSessionBreak, error) {
+	return nil, nil
+}
+
+func (s *stubWorkSessions) UpdateSession(context.Context, int64, int64, activeSvc.SessionUpdateRequest) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+
+func (s *stubWorkSessions) GetCurrentSession(context.Context, int64) (*activeModels.WorkSession, error) {
+	return nil, nil
+}
+
+func (s *stubWorkSessions) GetHistory(context.Context, int64, timezone.Date, timezone.Date) (*activeSvc.HistoryResponse, error) {
+	return &activeSvc.HistoryResponse{}, nil
+}
+
+func newRacedService(checkInErr error) (*Service, *stubWorkSessions) {
+	person := &userModels.Person{FirstName: "Nora", LastName: "Kiosk"}
+	person.ID = 42
+	staff := &userModels.Staff{PersonID: person.ID}
+	staff.ID = 7
+	card := &userModels.RFIDCard{Active: true}
+	card.ID = "A1654BEEF"
+
+	sessions := &stubWorkSessions{checkInErr: checkInErr}
+	service := NewService(&stubPeople{person: person, staff: staff}, &stubCards{card: card}, sessions)
+	service.now = func() time.Time { return time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC) }
+	return service, sessions
+}
+
+func checkInCommand() Command {
+	return Command{
+		RFIDTag: "A1654BEEF",
+		Action:  ActionCheckIn,
+		Status:  activeModels.WorkSessionStatusPresent,
+	}
+}
+
+// Two kiosks scanning the same card at the same moment both see "no session
+// today" and both insert. The loser must learn it lost the race, not that the
+// server broke.
+func TestExecute_ConcurrentCheckInReportsStateConflict(t *testing.T) {
+	service, sessions := newRacedService(
+		&modelBase.DatabaseError{Op: "create", Err: pgUniqueViolation(workSessionDateConstraint)},
+	)
+	ctx := tenant.WithRollbackMarker(context.Background())
+
+	state, err := service.Execute(ctx, checkInCommand())
+
+	require.ErrorIs(t, err, ErrCheckInRaced)
+	assert.Nil(t, state)
+	assert.Equal(t, 1, sessions.checkInCall)
+	// The duplicate INSERT left the request transaction aborted, so the partial
+	// work must never be committed alongside the 409.
+	assert.True(t, tenant.RollbackRequested(ctx))
+}
+
+// A unique violation on another constraint is a genuine fault and must keep
+// its 500 classification instead of being dressed up as a state conflict.
+func TestExecute_UnrelatedUniqueViolationStaysAnError(t *testing.T) {
+	service, _ := newRacedService(
+		&modelBase.DatabaseError{Op: "create", Err: pgUniqueViolation("uq_something_else")},
+	)
+	ctx := tenant.WithRollbackMarker(context.Background())
+
+	_, err := service.Execute(ctx, checkInCommand())
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrCheckInRaced)
+	assert.False(t, tenant.RollbackRequested(ctx))
+}

--- a/backend/services/iot/staffclock/service_internal_test.go
+++ b/backend/services/iot/staffclock/service_internal_test.go
@@ -64,9 +64,11 @@ func (s *stubCards) List(context.Context, map[string]any) ([]*userModels.RFIDCar
 func (s *stubCards) Deactivate(context.Context, string) error { return nil }
 
 type stubWorkSessions struct {
-	checkInErr     error
-	checkInCall    int
-	checkInSession *activeModels.WorkSession
+	checkInErr  error
+	checkInCall int
+	// now is the same clock the service reads, so a stamp taken while the test
+	// clock crosses midnight is filed the way the work session service files it.
+	now func() time.Time
 	// checkInDays records the calendar day every check-in attempt was pinned to.
 	checkInDays []timezone.Date
 	// latestOpen is the still-running session the day resolution starts from,
@@ -82,7 +84,7 @@ type stubWorkSessions struct {
 	historyByDay map[string]*activeSvc.SessionResponse
 }
 
-func (s *stubWorkSessions) CheckInOn(_ context.Context, _ int64, day timezone.Date, _, _, _ string) (*activeModels.WorkSession, error) {
+func (s *stubWorkSessions) CheckInOn(_ context.Context, staffID int64, day timezone.Date, status, source, _ string) (*activeModels.WorkSession, error) {
 	s.checkInCall++
 	s.checkInDays = append(s.checkInDays, day)
 	// Only the first attempt fails: the reopen retry that follows a status
@@ -90,7 +92,19 @@ func (s *stubWorkSessions) CheckInOn(_ context.Context, _ int64, day timezone.Da
 	if s.checkInErr != nil && s.checkInCall == 1 {
 		return nil, s.checkInErr
 	}
-	return s.checkInSession, nil
+	if existing, ok := s.openSessionByDay[day.String()]; ok {
+		return existing, nil
+	}
+	// Mirrors the work session service: the pinned day selects the session to
+	// reopen, but a session created fresh carries the day of its own stamp.
+	stampedAt := s.now()
+	return &activeModels.WorkSession{
+		StaffID:     staffID,
+		Date:        timezone.DateFromTime(stampedAt),
+		Status:      status,
+		Source:      source,
+		CheckInTime: stampedAt,
+	}, nil
 }
 
 func (s *stubWorkSessions) GetLatestOpenSession(context.Context, int64) (*activeModels.WorkSession, error) {
@@ -143,8 +157,16 @@ func newRacedService(checkInErr error) (*Service, *stubWorkSessions) {
 
 	sessions := &stubWorkSessions{checkInErr: checkInErr}
 	service := NewService(&stubPeople{person: person, staff: staff}, &stubCards{card: card}, sessions)
-	service.now = func() time.Time { return time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC) }
+	setClock(service, sessions, func() time.Time { return time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC) })
 	return service, sessions
+}
+
+// setClock keeps the kiosk service and the work session stub on one clock: both
+// read the time independently in production too, and the midnight cases only
+// mean anything when the stub can drift with the service.
+func setClock(service *Service, sessions *stubWorkSessions, clock func() time.Time) {
+	service.now = clock
+	sessions.now = clock
 }
 
 func checkInCommand() Command {
@@ -187,25 +209,34 @@ func TestExecute_CheckInAcrossMidnightReportsTheStampedDay(t *testing.T) {
 	stampedDay := timezone.DateFromTime(stampedAt)
 	require.NotEqual(t, timezone.DateFromTime(requestedAt), stampedDay)
 
-	stamped := &activeModels.WorkSession{
-		StaffID:     7,
-		Date:        stampedDay,
-		Status:      activeModels.WorkSessionStatusPresent,
-		Source:      activeModels.WorkSessionSourceNFC,
-		CheckInTime: stampedAt,
-	}
-	sessions.checkInSession = stamped
-	// Only the day the row carries returns it — the request day is empty.
+	// Only the day the row carries returns it — the request day is empty. The
+	// stub builds that row itself from the clock, exactly as the work session
+	// service does, so this cannot pass on a session the test handed it.
 	sessions.historyByDay = map[string]*activeSvc.SessionResponse{
-		stampedDay.String(): {WorkSession: stamped},
+		stampedDay.String(): {WorkSession: &activeModels.WorkSession{
+			StaffID:     7,
+			Date:        stampedDay,
+			Status:      activeModels.WorkSessionStatusPresent,
+			Source:      activeModels.WorkSessionSourceNFC,
+			CheckInTime: stampedAt,
+		}},
 	}
 
-	service.now = func() time.Time { return requestedAt }
+	// The clock crosses midnight between the request timestamp and the write.
+	calls := 0
+	setClock(service, sessions, func() time.Time {
+		calls++
+		if calls == 1 {
+			return requestedAt
+		}
+		return stampedAt
+	})
 
 	state, err := service.Execute(context.Background(), checkInCommand())
 
 	require.NoError(t, err)
 	require.NotNil(t, state.Session)
+	assert.Equal(t, []timezone.Date{timezone.DateFromTime(requestedAt)}, sessions.checkInDays)
 	assert.Equal(t, stampedDay, timezone.DateFromTime(state.Session.CheckInTime))
 	assert.Equal(t, StateCheckedIn, state.State)
 	assert.Equal(t, []string{ActionBreakStart, ActionCheckOut}, state.AllowedActions)
@@ -239,13 +270,13 @@ func TestExecute_ActionsPinTheLookupToTheRequestDay(t *testing.T) {
 			// The clock rolls past midnight right after the request timestamp is
 			// taken; every lookup must still land on the request day.
 			calls := 0
-			service.now = func() time.Time {
+			setClock(service, sessions, func() time.Time {
 				calls++
 				if calls == 1 {
 					return requestedAt
 				}
 				return requestedAt.Add(2 * time.Second)
-			}
+			})
 
 			state, err := service.Execute(context.Background(), Command{RFIDTag: "A1654BEEF", Action: action})
 
@@ -283,7 +314,7 @@ func TestGetState_OpenSessionFromPreviousDayStaysCheckedIn(t *testing.T) {
 	sessions.historyByDay = map[string]*activeSvc.SessionResponse{
 		open.Date.String(): {WorkSession: open},
 	}
-	service.now = func() time.Time { return openedAt.Add(3 * time.Hour) } // 01:30 the next day
+	setClock(service, sessions, func() time.Time { return openedAt.Add(3 * time.Hour) }) // 01:30 the next day
 
 	state, err := service.GetState(context.Background(), "A1654BEEF")
 
@@ -311,7 +342,7 @@ func TestExecute_ActionsAfterMidnightUseTheOpenSessionDay(t *testing.T) {
 			sessions.historyByDay = map[string]*activeSvc.SessionResponse{
 				open.Date.String(): {WorkSession: open},
 			}
-			service.now = func() time.Time { return afterMidnight }
+			setClock(service, sessions, func() time.Time { return afterMidnight })
 
 			state, err := service.Execute(context.Background(), Command{RFIDTag: "A1654BEEF", Action: action})
 
@@ -340,13 +371,13 @@ func TestExecute_ReopenRetryStaysOnTheConflictedDay(t *testing.T) {
 
 	// The clock crosses midnight between the conflicting stamp and the retry.
 	calls := 0
-	service.now = func() time.Time {
+	setClock(service, sessions, func() time.Time {
 		calls++
 		if calls == 1 {
 			return requestedAt
 		}
 		return requestedAt.Add(2 * time.Second)
-	}
+	})
 
 	command := checkInCommand()
 	command.Reason = "Statuswechsel nach Rücksprache"

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1537,11 +1537,44 @@ export const nfcChapters: readonly GuideChapter[] = [
             image: "/help/screens/nfc-tablet-pin.webp",
             caption: "PIN-Eingabe: 4-stellige PIN über das Zahlenfeld.",
           },
-          {
-            image: "/help/screens/nfc-tablet-menue.webp",
-            caption: "Menü nach erfolgreicher Anmeldung.",
-          },
         ],
+      },
+    ],
+  },
+  {
+    id: "nfc-mitarbeiter-stempeln",
+    title: "Arbeitszeit am Tablet stempeln",
+    description:
+      "Mitarbeitende können mit ihrem persönlichen NFC-Armband ein- und ausstempeln sowie Pausen erfassen. Dafür ist keine Aktivität oder Gruppe nötig.",
+    icon: Clock3,
+    tone: "blue",
+    steps: [
+      {
+        id: "nfc-mitarbeiter-arbeitszeit",
+        title: "Ein-, ausstempeln und Pause erfassen",
+        summary:
+          "Über `Mitarbeiter-Stempeln` liest das Tablet den aktuellen Stand aus und bietet nur die Aktionen an, die gerade möglich sind.",
+        steps: [
+          "Im `Menü` auf `Mitarbeiter-Stempeln` tippen und `Armband scannen` wählen.",
+          "Das persönliche Armband an den NFC-Sensor halten. Kinderarmbänder und nicht zugewiesene Armbänder werden abgewiesen.",
+          "Beim Einstempeln `Vor Ort` oder `Homeoffice` wählen und auf `Einstempeln` tippen.",
+          "Im Zustand `Eingestempelt` entweder `Pause starten` oder `Ausstempeln` wählen.",
+          "Im Zustand `In Pause` die Pause mit `Pause beenden` fortsetzen oder direkt ausstempeln.",
+          "Verlangt der Dienstplan eine Begründung für die Abweichung, den Grund eingeben und den Stempelvorgang erneut bestätigen.",
+        ],
+        callout: {
+          title: "Persönliches Armband erforderlich",
+          body: "Die Zeiterfassung funktioniert nur mit einem aktiven NFC-Armband, das dem jeweiligen Mitarbeitenden zugewiesen ist. Die allgemeine Geräte-PIN identifiziert die Person nicht. Fehlt die Zuweisung, wenden Sie sich an Ihre OGS-Leitung.",
+          tone: "orange",
+        },
+        checklist: [
+          "Nach dem Einstempeln steht der Status auf `Eingestempelt`.",
+          "Eine laufende Pause wird als `In Pause` angezeigt.",
+          "Ab mehr als sechs Stunden Arbeitszeit erscheint der Hinweis zur erforderlichen Pause, solange sie noch nicht vollständig genommen wurde.",
+          "Die Einträge erscheinen parallel in der Zeiterfassung der Web-App mit der Quelle `NFC`.",
+        ],
+        screenshot:
+          "Tablet-Seite Mitarbeiter-Stempeln mit Name, aktuellem Zustand, Arbeitsort-Auswahl und den jeweils erlaubten Aktionen.",
       },
     ],
   },
@@ -1830,7 +1863,6 @@ export const nfcChapters: readonly GuideChapter[] = [
           tone: "gray",
         },
         screenshot: "Tablet-`Menü` mit `Aufsicht beenden` und `Abmelden`.",
-        image: "/help/screens/nfc-tablet-menue.webp",
       },
       {
         id: "nfc-team-anpassen",

--- a/frontend/src/lib/staff-metrics-helpers.test.ts
+++ b/frontend/src/lib/staff-metrics-helpers.test.ts
@@ -5,7 +5,9 @@ import type {
   StaffHistorySession,
   StaffSchedule,
 } from "./staff-api";
+import type { WorkSessionHistory } from "./time-tracking-helpers";
 import {
+  adaptHistorySessionForMetrics,
   computePeriodTotalsFromTargets,
   computeStaffMetrics,
   getDeltaStatus,
@@ -508,5 +510,48 @@ describe("indexAbsenceCreditByDay", () => {
     ]);
 
     expect(byDay.get("2026-06-06")).toBe(0);
+  });
+});
+
+describe("adaptHistorySessionForMetrics", () => {
+  const historySession = (
+    overrides: Partial<WorkSessionHistory> = {},
+  ): WorkSessionHistory => ({
+    id: "42",
+    staffId: "100",
+    date: "2026-07-21",
+    status: "home_office",
+    checkInTime: "2026-07-21T13:30:00Z",
+    checkOutTime: null,
+    breakMinutes: 0,
+    notes: "",
+    autoCheckedOut: false,
+    createdBy: "100",
+    updatedBy: null,
+    createdAt: "2026-07-21T13:30:00Z",
+    updatedAt: "2026-07-21T13:30:00Z",
+    netMinutes: 5,
+    isOvertime: false,
+    isBreakCompliant: true,
+    restPeriodWarning: null,
+    breaks: [],
+    editCount: 0,
+    ...overrides,
+  });
+
+  // A kiosk stamp must stay recognisable as one in the staff member's OWN
+  // view, not just in the admin view: the source column previously dropped
+  // the field here and rendered every NFC session as "App".
+  it("keeps an NFC stamp attributed to NFC", () => {
+    expect(
+      adaptHistorySessionForMetrics(historySession({ source: "nfc" })).source,
+    ).toBe("nfc");
+  });
+
+  it("keeps a legacy row's unknown source unknown", () => {
+    expect(
+      adaptHistorySessionForMetrics(historySession({ source: "unknown" }))
+        .source,
+    ).toBe("unknown");
   });
 });

--- a/frontend/src/lib/staff-metrics-helpers.ts
+++ b/frontend/src/lib/staff-metrics-helpers.ts
@@ -566,7 +566,7 @@ export function adaptHistorySessionForMetrics(
     id: session.id ? Number(session.id) : undefined,
     date: session.date,
     status: session.status,
-    source: undefined,
+    source: session.source,
     net_minutes: session.netMinutes,
     check_in_time: session.checkInTime,
     check_out_time: session.checkOutTime,

--- a/frontend/src/lib/time-tracking-helpers.test.ts
+++ b/frontend/src/lib/time-tracking-helpers.test.ts
@@ -87,6 +87,20 @@ describe("mapWorkSessionResponse", () => {
     expect(result.updatedBy).toBeNull();
   });
 
+  it("carries source through to the own-portal view", () => {
+    const backend = createMockBackendSession({ source: "nfc" });
+    const result = mapWorkSessionResponse(backend);
+
+    expect(result.source).toBe("nfc");
+  });
+
+  it("leaves source undefined when the payload predates the column", () => {
+    const backend = createMockBackendSession();
+    const result = mapWorkSessionResponse(backend);
+
+    expect(result.source).toBeUndefined();
+  });
+
   it("handles empty notes string", () => {
     const backend = createMockBackendSession({ notes: "" });
     const result = mapWorkSessionResponse(backend);

--- a/frontend/src/lib/time-tracking-helpers.ts
+++ b/frontend/src/lib/time-tracking-helpers.ts
@@ -6,6 +6,9 @@ export interface BackendWorkSession {
   staff_id: number;
   date: string;
   status: "present" | "home_office";
+  // Channel the row was created on (active.work_sessions.source, Issue #1368).
+  // Optional because pre-#1368 payloads predate the column.
+  source?: "app" | "nfc" | "unknown";
   check_in_time: string;
   check_out_time: string | null;
   break_minutes: number;
@@ -160,6 +163,7 @@ export interface WorkSession {
   staffId: string;
   date: string;
   status: "present" | "home_office";
+  source?: "app" | "nfc" | "unknown";
   checkInTime: string;
   checkOutTime: string | null;
   breakMinutes: number;
@@ -227,6 +231,7 @@ export function mapWorkSessionResponse(data: BackendWorkSession): WorkSession {
     staffId: data.staff_id.toString(),
     date: data.date.split("T")[0] ?? data.date,
     status: data.status,
+    source: data.source,
     checkInTime: data.check_in_time,
     checkOutTime: data.check_out_time ?? null,
     breakMinutes: data.break_minutes,


### PR DESCRIPTION
Backend für #1654: ein dedizierter NFC-Stempel-Flow am Kiosk, ohne Umweg über eine Aktivitäts- oder Gruppen-Session.

Gehört zu moto-nrw/PyrePortal#388 (Kiosk-Screen). Die beiden PRs müssen koordiniert gemergt werden — Fehlertexte sind in `PyrePortal/src/services/api.ts` hart gemappt.

## Was drin ist

- `POST /api/iot/staff-clock` und `POST /api/iot/staff-clock/state` (Device-Auth), Aktionen `checkin` / `checkout` / `break_start` / `break_end`
- `services/iot/staffclock`: eigener Service für die reine Stempel-Zustandsmaschine, absichtlich gegen schmale Interfaces gebaut, damit er ohne HTTP und ohne DB testbar ist. Schreibt über die bestehenden `WorkSessionService`-Methoden mit `source=nfc`
- Identifikation über die persönliche RFID-Karte (Option A aus dem Issue), konsistent zum Schüler-Pattern
- Reopen-Konflikt bei geändertem Arbeitsort: mit Begründung wird erst mit dem bestehenden Status reopened und dann per `UpdateSession` umgestellt, damit die Statusänderung eine Audit-Spur bekommt statt still zu passieren
- Fehler-Klassifizierung mit stabilen Codes, gegen die PyrePortal seine deutschen Texte mappt

## Warum ein eigenes DTO

`GetState` und `Execute` geben eine Kiosk-Projektion zurück, nicht das Session-Modell. Das Modell trägt Tenant-, Audit- und Freitext-Notizspalten, darunter administrative Notizen — ein Gerät im Flur hat damit nichts zu tun und darf sie nicht bekommen.

## Quelle-Spalte in der eigenen Ansicht

Akzeptanzkriterium 3 verlangt, dass die Session mit Quelle „NFC" sichtbar ist. In der Admin-Sicht stimmte das, in der eigenen `/time-tracking`-Ansicht nicht: `adaptHistorySessionForMetrics` hat `source: undefined` hart gesetzt, weil die camelCase-Typen die Spalte nie kannten — obwohl der Wire-Payload sie seit #1368 liefert. `SourceBadge` fällt bei `undefined` auf „App" zurück, aus dem verlorenen Feld wurde also keine Lücke, sondern eine falsche Aussage: dieselbe Zeile behauptete in zwei Ansichten Verschiedenes.

Der Fix reicht `source` durch die camelCase-Typen und den Adapter durch. Vorbestehend auf `development`, aber ohne den Fix geht das Feature mit einem unerfüllten Akzeptanzkriterium raus.

## Test

- Hermetische Service-Tests für die Zustandsmaschine, Golden-Files für Route-Table und IoT-Auth-Matrix aktualisiert
- Frontend: Regressionstests für den Adapter und den Mapper. Gegenprobe gemacht — mit zurückgedrehtem Fix fallen genau die Adapter-Tests um
- E2E lokal: Kiosk-Flow checkin -> Pause -> checkout -> Reopen-Konflikt mit Begründung; DB zeigt `source=nfc`, Break-Row und Notiz

## Screens

<details>
<summary>Web-App: Quelle-Spalte</summary>
<img width="1800" height="950" alt="20-web-admin-staffdetail-nfc" src="https://github.com/user-attachments/assets/4009cacc-3978-42f2-ad31-280226e8058b" />
<img width="1800" height="950" alt="21-web-own-timetracking-table" src="https://github.com/user-attachments/assets/e2cd7153-5fad-4c87-870e-c80b599164b9" />


</details>

Closes #1654
