### PR TITLE
feat(time-tracking): OGS-Schließtage mit Soll=0-Wirkung (#1418 3b)

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -490,8 +490,10 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.GradeTransitions = adminAPI.NewGradeTransitionResource(api.Services.GradeTransition, db)
 	api.TimeTracking = timeTrackingAPI.NewResource(api.Services.WorkSession, api.Services.StaffAbsence, api.Services.Users, api.Services.Settings, api.Services.StaffShifts, api.Services.StaffAssignments, api.Services.WorkTimeMonth, db)
 	api.TimeTracking.HolidayService = api.Services.Holidays
+	api.TimeTracking.ClosingDayService = api.Services.ClosingDays
 	api.Timetable = timetableAPI.NewResource(timetableAPI.Dependencies{
 		CalendarPeriodService:  api.Services.CalendarPeriod,
+		ClosingDayService:      api.Services.ClosingDays,
 		MaterializationService: api.Services.Materialization,
 		InstanceService:        api.Services.Instance,
 		OperationsService:      api.Services.TimetableOperations,

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -51,6 +51,7 @@ DELETE /api/suggestions/{id}
 DELETE /api/suggestions/{id}/comments/{commentId}
 DELETE /api/suggestions/{id}/vote
 DELETE /api/time-tracking/absences/{id}
+DELETE /api/timetable/closing-days/{id}
 DELETE /api/timetable/instances/{id}
 DELETE /api/timetable/periods/{id}
 DELETE /api/timetable/templates/{id}
@@ -314,6 +315,7 @@ GET /api/suggestions/{id}/comments/
 GET /api/time-tracking/absences
 GET /api/time-tracking/assignments
 GET /api/time-tracking/breaks/{sessionId}
+GET /api/time-tracking/closing-days
 GET /api/time-tracking/config
 GET /api/time-tracking/current
 GET /api/time-tracking/export
@@ -325,6 +327,7 @@ GET /api/time-tracking/schedule-targets
 GET /api/time-tracking/shifts
 GET /api/time-tracking/vacation/quota
 GET /api/time-tracking/{id}/edits
+GET /api/timetable/closing-days/
 GET /api/timetable/conflicts
 GET /api/timetable/deviations/history
 GET /api/timetable/exception-conflicts
@@ -589,6 +592,7 @@ POST /api/time-tracking/break/start
 POST /api/time-tracking/check-in
 POST /api/time-tracking/check-out
 POST /api/time-tracking/vacation/request
+POST /api/timetable/closing-days/
 POST /api/timetable/instances/
 POST /api/timetable/instances/re-plan-week
 POST /api/timetable/instances/{id}/acknowledge-understaffed
@@ -741,6 +745,7 @@ PUT /api/substitutions/{id}
 PUT /api/suggestions/{id}
 PUT /api/time-tracking/absences/{id}
 PUT /api/time-tracking/{id}
+PUT /api/timetable/closing-days/{id}
 PUT /api/timetable/instances/{id}
 PUT /api/timetable/periods/{id}
 PUT /api/timetable/templates/{id}

--- a/backend/api/time-tracking/api.go
+++ b/backend/api/time-tracking/api.go
@@ -46,7 +46,10 @@ type Resource struct {
 	// calendar marking and the holiday-session warning (#1418 3a). Injected
 	// as a field in api/base.go to keep the constructor signature stable.
 	HolidayService scheduleSvc.HolidayService
-	db             *bun.DB
+	// ClosingDayService backs GET /closing-days — the tenant's closure
+	// periods (#1418 3b). Injected as a field like HolidayService.
+	ClosingDayService scheduleSvc.ClosingDayService
+	db                *bun.DB
 }
 
 // NewResource creates a new time-tracking resource
@@ -81,6 +84,7 @@ func (rs *Resource) Router() chi.Router {
 		// endpoints it pairs with gate on TimeTrackingManage alone.
 		r.With(authorize.RequiresAnyPermission(permissions.TimeTrackingOwn, permissions.TimeTrackingManage), withTx).Get("/config", rs.getConfig)
 		r.With(authorize.RequiresAnyPermission(permissions.TimeTrackingOwn, permissions.TimeTrackingManage), withTx).Get("/holidays", rs.getHolidays)
+		r.With(authorize.RequiresAnyPermission(permissions.TimeTrackingOwn, permissions.TimeTrackingManage), withTx).Get("/closing-days", rs.getClosingDays)
 		r.With(authorize.RequiresPermission(permissions.TimeTrackingOwn), withTx).Get("/history", rs.getHistory)
 		r.With(authorize.RequiresPermission(permissions.TimeTrackingOwn), withTx).Put("/{id}", rs.updateSession)
 		r.With(authorize.RequiresPermission(permissions.TimeTrackingOwn), withTx).Get("/{id}/edits", rs.getSessionEdits)

--- a/backend/api/time-tracking/closing_days.go
+++ b/backend/api/time-tracking/closing_days.go
@@ -1,0 +1,60 @@
+package timetracking
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+// maxClosingDayRangeDays bounds the closing-days query window, mirroring the
+// holidays endpoint; the UI never needs more than a year plus surrounding
+// weeks at once.
+const maxClosingDayRangeDays = 400
+
+// closingDayRangeResponse is the wire shape of GET /closing-days: the stored
+// ranges overlapping the window. The frontend expands them into per-day
+// entries for badge display.
+type closingDayRangeResponse struct {
+	StartDate string `json:"start_date"`
+	EndDate   string `json:"end_date"`
+	Reason    string `json:"reason"`
+}
+
+// getClosingDays handles GET /api/time-tracking/closing-days?from=&to= — the
+// tenant's closure periods (#1418 3b) for calendar marking. Like /holidays,
+// the data is tenant-global, not staff-specific, so own- and manage-scoped
+// callers share the endpoint.
+func (rs *Resource) getClosingDays(w http.ResponseWriter, r *http.Request) {
+	from, to, err := ParseDateRangeQuery(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	if from.DaysUntil(to) > maxClosingDayRangeDays {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("range must not exceed 400 days")))
+		return
+	}
+
+	days, err := rs.ClosingDayService.ClosingDaysInRange(r.Context(), from, to)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	responses := make([]closingDayRangeResponse, len(days))
+	for i, d := range days {
+		responses[i] = mapClosingDayRange(d)
+	}
+
+	common.Respond(w, r, http.StatusOK, responses, "Closing days retrieved successfully")
+}
+
+func mapClosingDayRange(d *schedule.ClosingDay) closingDayRangeResponse {
+	return closingDayRangeResponse{
+		StartDate: d.StartDate.String(),
+		EndDate:   d.EndDate.String(),
+		Reason:    d.Reason,
+	}
+}

--- a/backend/api/time-tracking/closing_days_test.go
+++ b/backend/api/time-tracking/closing_days_test.go
@@ -1,0 +1,96 @@
+package timetracking
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+type mockClosingDayService struct {
+	days []*schedule.ClosingDay
+	err  error
+}
+
+func (m *mockClosingDayService) GetAll(_ context.Context) ([]*schedule.ClosingDay, error) {
+	return m.days, m.err
+}
+
+func (m *mockClosingDayService) GetByID(_ context.Context, _ int64) (*schedule.ClosingDay, error) {
+	return nil, m.err
+}
+
+func (m *mockClosingDayService) Create(_ context.Context, _ *schedule.ClosingDay) error {
+	return m.err
+}
+
+func (m *mockClosingDayService) Update(_ context.Context, _ *schedule.ClosingDay) error {
+	return m.err
+}
+
+func (m *mockClosingDayService) Delete(_ context.Context, _ int64) error {
+	return m.err
+}
+
+func (m *mockClosingDayService) ClosingDaysInRange(_ context.Context, _, _ timezone.Date) ([]*schedule.ClosingDay, error) {
+	return m.days, m.err
+}
+
+func (m *mockClosingDayService) ClosingDayDates(_ context.Context, _, _ timezone.Date) (map[timezone.Date]bool, error) {
+	return nil, m.err
+}
+
+func TestGetClosingDays(t *testing.T) {
+	rs := &Resource{ClosingDayService: &mockClosingDayService{days: []*schedule.ClosingDay{
+		{
+			StartDate: timezone.NewDate(2026, 12, 24),
+			EndDate:   timezone.NewDate(2026, 12, 31),
+			Reason:    "Weihnachtswoche",
+		},
+	}}}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/closing-days?from=2026-12-01&to=2026-12-31", nil)
+	rs.getClosingDays(w, r)
+
+	require.Equal(t, 200, w.Code)
+	var body struct {
+		Data []struct {
+			StartDate string `json:"start_date"`
+			EndDate   string `json:"end_date"`
+			Reason    string `json:"reason"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1)
+	assert.Equal(t, "2026-12-24", body.Data[0].StartDate)
+	assert.Equal(t, "2026-12-31", body.Data[0].EndDate)
+	assert.Equal(t, "Weihnachtswoche", body.Data[0].Reason)
+}
+
+func TestGetClosingDaysInvalidRange(t *testing.T) {
+	rs := &Resource{ClosingDayService: &mockClosingDayService{}}
+
+	w := httptest.NewRecorder()
+	rs.getClosingDays(w, httptest.NewRequest("GET", "/closing-days?from=nope&to=2026-05-31", nil))
+	assert.Equal(t, 400, w.Code)
+
+	w = httptest.NewRecorder()
+	rs.getClosingDays(w, httptest.NewRequest("GET", "/closing-days?from=2026-01-01&to=2027-12-31", nil))
+	assert.Equal(t, 400, w.Code, "ranges over 400 days are rejected")
+}
+
+func TestGetClosingDaysServiceError(t *testing.T) {
+	rs := &Resource{ClosingDayService: &mockClosingDayService{err: errors.New("boom")}}
+
+	w := httptest.NewRecorder()
+	rs.getClosingDays(w, httptest.NewRequest("GET", "/closing-days?from=2026-05-01&to=2026-05-31", nil))
+	assert.Equal(t, 500, w.Code)
+}

--- a/backend/api/time-tracking/closing_days_test.go
+++ b/backend/api/time-tracking/closing_days_test.go
@@ -12,49 +12,20 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/services/schedule/scheduletest"
 )
 
-type mockClosingDayService struct {
-	days []*schedule.ClosingDay
-	err  error
-}
-
-func (m *mockClosingDayService) GetAll(_ context.Context) ([]*schedule.ClosingDay, error) {
-	return m.days, m.err
-}
-
-func (m *mockClosingDayService) GetByID(_ context.Context, _ int64) (*schedule.ClosingDay, error) {
-	return nil, m.err
-}
-
-func (m *mockClosingDayService) Create(_ context.Context, _ *schedule.ClosingDay) error {
-	return m.err
-}
-
-func (m *mockClosingDayService) Update(_ context.Context, _ *schedule.ClosingDay) error {
-	return m.err
-}
-
-func (m *mockClosingDayService) Delete(_ context.Context, _ int64) error {
-	return m.err
-}
-
-func (m *mockClosingDayService) ClosingDaysInRange(_ context.Context, _, _ timezone.Date) ([]*schedule.ClosingDay, error) {
-	return m.days, m.err
-}
-
-func (m *mockClosingDayService) ClosingDayDates(_ context.Context, _, _ timezone.Date) (map[timezone.Date]bool, error) {
-	return nil, m.err
-}
-
 func TestGetClosingDays(t *testing.T) {
-	rs := &Resource{ClosingDayService: &mockClosingDayService{days: []*schedule.ClosingDay{
-		{
-			StartDate: timezone.NewDate(2026, 12, 24),
-			EndDate:   timezone.NewDate(2026, 12, 31),
-			Reason:    "Weihnachtswoche",
+	days := []*schedule.ClosingDay{{
+		StartDate: timezone.NewDate(2026, 12, 24),
+		EndDate:   timezone.NewDate(2026, 12, 31),
+		Reason:    "Weihnachtswoche",
+	}}
+	rs := &Resource{ClosingDayService: &scheduletest.ClosingDayServiceMock{
+		ClosingDaysInRangeFn: func(_ context.Context, _, _ timezone.Date) ([]*schedule.ClosingDay, error) {
+			return days, nil
 		},
-	}}}
+	}}
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/closing-days?from=2026-12-01&to=2026-12-31", nil)
@@ -76,7 +47,7 @@ func TestGetClosingDays(t *testing.T) {
 }
 
 func TestGetClosingDaysInvalidRange(t *testing.T) {
-	rs := &Resource{ClosingDayService: &mockClosingDayService{}}
+	rs := &Resource{ClosingDayService: &scheduletest.ClosingDayServiceMock{}}
 
 	w := httptest.NewRecorder()
 	rs.getClosingDays(w, httptest.NewRequest("GET", "/closing-days?from=nope&to=2026-05-31", nil))
@@ -88,7 +59,11 @@ func TestGetClosingDaysInvalidRange(t *testing.T) {
 }
 
 func TestGetClosingDaysServiceError(t *testing.T) {
-	rs := &Resource{ClosingDayService: &mockClosingDayService{err: errors.New("boom")}}
+	rs := &Resource{ClosingDayService: &scheduletest.ClosingDayServiceMock{
+		ClosingDaysInRangeFn: func(_ context.Context, _, _ timezone.Date) ([]*schedule.ClosingDay, error) {
+			return nil, errors.New("boom")
+		},
+	}}
 
 	w := httptest.NewRecorder()
 	rs.getClosingDays(w, httptest.NewRequest("GET", "/closing-days?from=2026-05-01&to=2026-05-31", nil))

--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -95,6 +95,7 @@ type Resource struct {
 // site.
 type Dependencies struct {
 	CalendarPeriodService  scheduleSvc.CalendarPeriodService
+	ClosingDayService      scheduleSvc.ClosingDayService
 	MaterializationService scheduleSvc.MaterializationService
 	InstanceService        scheduleSvc.InstanceService
 	OperationsService      scheduleSvc.TimetableOperationsService
@@ -132,6 +133,15 @@ func (rs *Resource) Router() chi.Router {
 			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).Get("/{id}", rs.getPeriod)
 			r.With(authorize.RequiresPermission(permissions.SchedulesUpdate), withTx).Put("/{id}", rs.updatePeriod)
 			r.With(authorize.RequiresPermission(permissions.SchedulesDelete), withTx).Delete("/{id}", rs.deletePeriod)
+		})
+
+		// OGS-Schließtage (#1418 3b): closure ranges maintained on the same
+		// admin page as the calendar periods, hence the same permissions.
+		r.Route("/closing-days", func(r chi.Router) {
+			r.With(authorize.RequiresPermission(permissions.SchedulesRead), withTx).Get("/", rs.listClosingDays)
+			r.With(authorize.RequiresPermission(permissions.SchedulesCreate), withTx).Post("/", rs.createClosingDay)
+			r.With(authorize.RequiresPermission(permissions.SchedulesUpdate), withTx).Put("/{id}", rs.updateClosingDay)
+			r.With(authorize.RequiresPermission(permissions.SchedulesDelete), withTx).Delete("/{id}", rs.deleteClosingDay)
 		})
 
 		// WP-B8: manual materialization. Admin-only — reuses SchedulesManage

--- a/backend/api/timetable/closing_days.go
+++ b/backend/api/timetable/closing_days.go
@@ -1,0 +1,190 @@
+package timetable
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+// ClosingDayRequest represents a create/update request for a closing day
+// range (#1418 3b).
+type ClosingDayRequest struct {
+	StartDate string `json:"start_date"`
+	EndDate   string `json:"end_date"`
+	Reason    string `json:"reason"`
+}
+
+// Bind validates the request
+func (req *ClosingDayRequest) Bind(_ *http.Request) error {
+	if req.Reason == "" {
+		return errors.New("reason is required")
+	}
+	if len(req.Reason) > schedule.ClosingDayReasonMaxLength {
+		return errors.New("reason cannot exceed 255 characters")
+	}
+	if req.StartDate == "" {
+		return errors.New("start_date is required")
+	}
+	if req.EndDate == "" {
+		return errors.New("end_date is required")
+	}
+	return nil
+}
+
+// ClosingDayResponse represents a closing day in API responses
+type ClosingDayResponse struct {
+	ID        int64  `json:"id"`
+	StartDate string `json:"start_date"`
+	EndDate   string `json:"end_date"`
+	Reason    string `json:"reason"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+func mapClosingDayToResponse(d *schedule.ClosingDay) ClosingDayResponse {
+	return ClosingDayResponse{
+		ID:        d.ID,
+		StartDate: d.StartDate.String(),
+		EndDate:   d.EndDate.String(),
+		Reason:    d.Reason,
+		CreatedAt: d.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: d.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// parseClosingDayDates extracts start_date and end_date from a request.
+// Returns parsed calendar dates and true on success, or renders an error and
+// returns false. A single closed day is a range with start_date = end_date,
+// hence Before (not !After) in the order check.
+func parseClosingDayDates(w http.ResponseWriter, r *http.Request, req *ClosingDayRequest) (startDate, endDate timezone.Date, ok bool) {
+	var err error
+	startDate, err = timezone.ParseDate(req.StartDate)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid start_date format, expected YYYY-MM-DD")))
+		return timezone.Date{}, timezone.Date{}, false
+	}
+
+	endDate, err = timezone.ParseDate(req.EndDate)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid end_date format, expected YYYY-MM-DD")))
+		return timezone.Date{}, timezone.Date{}, false
+	}
+
+	if endDate.Before(startDate) {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("end_date must not be before start_date")))
+		return timezone.Date{}, timezone.Date{}, false
+	}
+
+	return startDate, endDate, true
+}
+
+func (rs *Resource) listClosingDays(w http.ResponseWriter, r *http.Request) {
+	days, err := rs.ClosingDayService.GetAll(r.Context())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("Schließtage konnten nicht geladen werden", err))
+		return
+	}
+
+	responses := make([]ClosingDayResponse, len(days))
+	for i, d := range days {
+		responses[i] = mapClosingDayToResponse(d)
+	}
+
+	common.Respond(w, r, http.StatusOK, responses, "Closing days retrieved successfully")
+}
+
+func (rs *Resource) createClosingDay(w http.ResponseWriter, r *http.Request) {
+	req := &ClosingDayRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	startDate, endDate, ok := parseClosingDayDates(w, r, req)
+	if !ok {
+		return
+	}
+
+	day := &schedule.ClosingDay{
+		StartDate: startDate,
+		EndDate:   endDate,
+		Reason:    req.Reason,
+	}
+
+	if err := rs.ClosingDayService.Create(r.Context(), day); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("Schließtag konnte nicht angelegt werden", err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusCreated, mapClosingDayToResponse(day), "Closing day created successfully")
+}
+
+func (rs *Resource) updateClosingDay(w http.ResponseWriter, r *http.Request) {
+	id, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid closing day ID")))
+		return
+	}
+
+	req := &ClosingDayRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	startDate, endDate, ok := parseClosingDayDates(w, r, req)
+	if !ok {
+		return
+	}
+
+	day, err := rs.ClosingDayService.GetByID(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			common.RenderError(w, r, common.ErrorNotFound(errors.New("closing day not found")))
+		} else {
+			common.RenderError(w, r, common.ErrorInternalServerWrap("Schließtag konnte nicht geladen werden", err))
+		}
+		return
+	}
+
+	day.StartDate = startDate
+	day.EndDate = endDate
+	day.Reason = req.Reason
+
+	if err := rs.ClosingDayService.Update(r.Context(), day); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("Schließtag konnte nicht aktualisiert werden", err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, mapClosingDayToResponse(day), "Closing day updated successfully")
+}
+
+func (rs *Resource) deleteClosingDay(w http.ResponseWriter, r *http.Request) {
+	id, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid closing day ID")))
+		return
+	}
+
+	if _, err := rs.ClosingDayService.GetByID(r.Context(), id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			common.RenderError(w, r, common.ErrorNotFound(errors.New("closing day not found")))
+		} else {
+			common.RenderError(w, r, common.ErrorInternalServerWrap("Schließtag konnte nicht geladen werden", err))
+		}
+		return
+	}
+
+	if err := rs.ClosingDayService.Delete(r.Context(), id); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("Schließtag konnte nicht gelöscht werden", err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, nil, "Closing day deleted successfully")
+}

--- a/backend/api/timetable/closing_days.go
+++ b/backend/api/timetable/closing_days.go
@@ -4,7 +4,9 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
@@ -22,10 +24,11 @@ type ClosingDayRequest struct {
 
 // Bind validates the request
 func (req *ClosingDayRequest) Bind(_ *http.Request) error {
+	req.Reason = strings.TrimSpace(req.Reason)
 	if req.Reason == "" {
 		return errors.New("reason is required")
 	}
-	if len(req.Reason) > schedule.ClosingDayReasonMaxLength {
+	if utf8.RuneCountInString(req.Reason) > schedule.ClosingDayReasonMaxLength {
 		return errors.New("reason cannot exceed 255 characters")
 	}
 	if req.StartDate == "" {

--- a/backend/api/timetable/closing_days_test.go
+++ b/backend/api/timetable/closing_days_test.go
@@ -5,57 +5,15 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/services/schedule/scheduletest"
 	"github.com/stretchr/testify/assert"
 )
-
-// =============================================================================
-// Mock ClosingDayService
-// =============================================================================
-
-type mockClosingDayService struct {
-	days        []*schedule.ClosingDay
-	day         *schedule.ClosingDay
-	err         error
-	lastCreated *schedule.ClosingDay
-	lastUpdated *schedule.ClosingDay
-	lastDeleted int64
-}
-
-func (m *mockClosingDayService) GetAll(_ context.Context) ([]*schedule.ClosingDay, error) {
-	return m.days, m.err
-}
-
-func (m *mockClosingDayService) GetByID(_ context.Context, _ int64) (*schedule.ClosingDay, error) {
-	return m.day, m.err
-}
-
-func (m *mockClosingDayService) Create(_ context.Context, d *schedule.ClosingDay) error {
-	m.lastCreated = d
-	return m.err
-}
-
-func (m *mockClosingDayService) Update(_ context.Context, d *schedule.ClosingDay) error {
-	m.lastUpdated = d
-	return m.err
-}
-
-func (m *mockClosingDayService) Delete(_ context.Context, id int64) error {
-	m.lastDeleted = id
-	return m.err
-}
-
-func (m *mockClosingDayService) ClosingDaysInRange(_ context.Context, _, _ timezone.Date) ([]*schedule.ClosingDay, error) {
-	return m.days, m.err
-}
-
-func (m *mockClosingDayService) ClosingDayDates(_ context.Context, _, _ timezone.Date) (map[timezone.Date]bool, error) {
-	return nil, m.err
-}
 
 func newTestClosingDay() *schedule.ClosingDay {
 	d := &schedule.ClosingDay{
@@ -71,7 +29,11 @@ func newTestClosingDay() *schedule.ClosingDay {
 
 func TestListClosingDays(t *testing.T) {
 	t.Run("returns all closing days", func(t *testing.T) {
-		mock := &mockClosingDayService{days: []*schedule.ClosingDay{newTestClosingDay()}}
+		mock := &scheduletest.ClosingDayServiceMock{
+			GetAllFn: func(_ context.Context) ([]*schedule.ClosingDay, error) {
+				return []*schedule.ClosingDay{newTestClosingDay()}, nil
+			},
+		}
 		res := NewResource(Dependencies{ClosingDayService: mock})
 		router := setupTestRouter(res.listClosingDays, http.MethodGet, false)
 
@@ -83,7 +45,11 @@ func TestListClosingDays(t *testing.T) {
 	})
 
 	t.Run("returns 500 on service error", func(t *testing.T) {
-		mock := &mockClosingDayService{err: errors.New("db error: password=secret")}
+		mock := &scheduletest.ClosingDayServiceMock{
+			GetAllFn: func(_ context.Context) ([]*schedule.ClosingDay, error) {
+				return nil, errors.New("db error: password=secret")
+			},
+		}
 		res := NewResource(Dependencies{ClosingDayService: mock})
 		router := setupTestRouter(res.listClosingDays, http.MethodGet, false)
 
@@ -96,7 +62,13 @@ func TestListClosingDays(t *testing.T) {
 
 func TestCreateClosingDay(t *testing.T) {
 	t.Run("creates a closing day range", func(t *testing.T) {
-		mock := &mockClosingDayService{}
+		var created *schedule.ClosingDay
+		mock := &scheduletest.ClosingDayServiceMock{
+			CreateFn: func(_ context.Context, day *schedule.ClosingDay) error {
+				created = day
+				return nil
+			},
+		}
 		res := NewResource(Dependencies{ClosingDayService: mock})
 		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
 
@@ -107,13 +79,13 @@ func TestCreateClosingDay(t *testing.T) {
 		})
 
 		assert.Equal(t, http.StatusCreated, w.Code)
-		assert.NotNil(t, mock.lastCreated)
-		assert.Equal(t, timezone.NewDate(2026, 7, 20), mock.lastCreated.StartDate)
-		assert.Equal(t, "Sommerschließung", mock.lastCreated.Reason)
+		assert.NotNil(t, created)
+		assert.Equal(t, timezone.NewDate(2026, 7, 20), created.StartDate)
+		assert.Equal(t, "Sommerschließung", created.Reason)
 	})
 
 	t.Run("accepts single-day range (start = end)", func(t *testing.T) {
-		mock := &mockClosingDayService{}
+		mock := &scheduletest.ClosingDayServiceMock{}
 		res := NewResource(Dependencies{ClosingDayService: mock})
 		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
 
@@ -127,7 +99,7 @@ func TestCreateClosingDay(t *testing.T) {
 	})
 
 	t.Run("rejects missing reason", func(t *testing.T) {
-		res := NewResource(Dependencies{ClosingDayService: &mockClosingDayService{}})
+		res := NewResource(Dependencies{ClosingDayService: &scheduletest.ClosingDayServiceMock{}})
 		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
 
 		w := executeRequest(router, http.MethodPost, "/", ClosingDayRequest{
@@ -138,8 +110,50 @@ func TestCreateClosingDay(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
+	t.Run("rejects whitespace-only reason", func(t *testing.T) {
+		res := NewResource(Dependencies{ClosingDayService: &scheduletest.ClosingDayServiceMock{}})
+		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
+
+		w := executeRequest(router, http.MethodPost, "/", ClosingDayRequest{
+			StartDate: "2026-07-20",
+			EndDate:   "2026-08-07",
+			Reason:    " \t\n ",
+		})
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("counts reason length in characters and trims it", func(t *testing.T) {
+		var created *schedule.ClosingDay
+		mock := &scheduletest.ClosingDayServiceMock{
+			CreateFn: func(_ context.Context, day *schedule.ClosingDay) error {
+				created = day
+				return nil
+			},
+		}
+		res := NewResource(Dependencies{ClosingDayService: mock})
+		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
+
+		w := executeRequest(router, http.MethodPost, "/", ClosingDayRequest{
+			StartDate: "2026-07-20",
+			EndDate:   "2026-08-07",
+			Reason:    "  " + strings.Repeat("ä", schedule.ClosingDayReasonMaxLength) + "  ",
+		})
+
+		assert.Equal(t, http.StatusCreated, w.Code)
+		assert.NotNil(t, created)
+		assert.Equal(t, strings.Repeat("ä", schedule.ClosingDayReasonMaxLength), created.Reason)
+
+		w = executeRequest(router, http.MethodPost, "/", ClosingDayRequest{
+			StartDate: "2026-07-20",
+			EndDate:   "2026-08-07",
+			Reason:    strings.Repeat("ä", schedule.ClosingDayReasonMaxLength+1),
+		})
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
 	t.Run("rejects end before start", func(t *testing.T) {
-		res := NewResource(Dependencies{ClosingDayService: &mockClosingDayService{}})
+		res := NewResource(Dependencies{ClosingDayService: &scheduletest.ClosingDayServiceMock{}})
 		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
 
 		w := executeRequest(router, http.MethodPost, "/", ClosingDayRequest{
@@ -152,7 +166,7 @@ func TestCreateClosingDay(t *testing.T) {
 	})
 
 	t.Run("rejects invalid date format", func(t *testing.T) {
-		res := NewResource(Dependencies{ClosingDayService: &mockClosingDayService{}})
+		res := NewResource(Dependencies{ClosingDayService: &scheduletest.ClosingDayServiceMock{}})
 		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
 
 		w := executeRequest(router, http.MethodPost, "/", ClosingDayRequest{
@@ -167,7 +181,16 @@ func TestCreateClosingDay(t *testing.T) {
 
 func TestUpdateClosingDay(t *testing.T) {
 	t.Run("updates a closing day", func(t *testing.T) {
-		mock := &mockClosingDayService{day: newTestClosingDay()}
+		var updated *schedule.ClosingDay
+		mock := &scheduletest.ClosingDayServiceMock{
+			GetByIDFn: func(_ context.Context, _ int64) (*schedule.ClosingDay, error) {
+				return newTestClosingDay(), nil
+			},
+			UpdateFn: func(_ context.Context, day *schedule.ClosingDay) error {
+				updated = day
+				return nil
+			},
+		}
 		res := NewResource(Dependencies{ClosingDayService: mock})
 		router := setupTestRouter(res.updateClosingDay, http.MethodPut, true)
 
@@ -178,13 +201,13 @@ func TestUpdateClosingDay(t *testing.T) {
 		})
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.NotNil(t, mock.lastUpdated)
-		assert.Equal(t, timezone.NewDate(2027, 1, 2), mock.lastUpdated.EndDate)
-		assert.Equal(t, "Weihnachtsferien", mock.lastUpdated.Reason)
+		assert.NotNil(t, updated)
+		assert.Equal(t, timezone.NewDate(2027, 1, 2), updated.EndDate)
+		assert.Equal(t, "Weihnachtsferien", updated.Reason)
 	})
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
-		res := NewResource(Dependencies{ClosingDayService: &mockClosingDayService{}})
+		res := NewResource(Dependencies{ClosingDayService: &scheduletest.ClosingDayServiceMock{}})
 		router := setupTestRouter(res.updateClosingDay, http.MethodPut, true)
 
 		w := executeRequest(router, http.MethodPut, "/abc", ClosingDayRequest{
@@ -197,7 +220,11 @@ func TestUpdateClosingDay(t *testing.T) {
 	})
 
 	t.Run("returns 404 when not found", func(t *testing.T) {
-		mock := &mockClosingDayService{err: sql.ErrNoRows}
+		mock := &scheduletest.ClosingDayServiceMock{
+			GetByIDFn: func(_ context.Context, _ int64) (*schedule.ClosingDay, error) {
+				return nil, sql.ErrNoRows
+			},
+		}
 		res := NewResource(Dependencies{ClosingDayService: mock})
 		router := setupTestRouter(res.updateClosingDay, http.MethodPut, true)
 
@@ -213,18 +240,31 @@ func TestUpdateClosingDay(t *testing.T) {
 
 func TestDeleteClosingDay(t *testing.T) {
 	t.Run("deletes a closing day", func(t *testing.T) {
-		mock := &mockClosingDayService{day: newTestClosingDay()}
+		var deleted int64
+		mock := &scheduletest.ClosingDayServiceMock{
+			GetByIDFn: func(_ context.Context, _ int64) (*schedule.ClosingDay, error) {
+				return newTestClosingDay(), nil
+			},
+			DeleteFn: func(_ context.Context, id int64) error {
+				deleted = id
+				return nil
+			},
+		}
 		res := NewResource(Dependencies{ClosingDayService: mock})
 		router := setupTestRouter(res.deleteClosingDay, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/7", nil)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, int64(7), mock.lastDeleted)
+		assert.Equal(t, int64(7), deleted)
 	})
 
 	t.Run("returns 404 when not found", func(t *testing.T) {
-		mock := &mockClosingDayService{err: sql.ErrNoRows}
+		mock := &scheduletest.ClosingDayServiceMock{
+			GetByIDFn: func(_ context.Context, _ int64) (*schedule.ClosingDay, error) {
+				return nil, sql.ErrNoRows
+			},
+		}
 		res := NewResource(Dependencies{ClosingDayService: mock})
 		router := setupTestRouter(res.deleteClosingDay, http.MethodDelete, true)
 
@@ -234,7 +274,7 @@ func TestDeleteClosingDay(t *testing.T) {
 	})
 
 	t.Run("returns 400 for invalid ID", func(t *testing.T) {
-		res := NewResource(Dependencies{ClosingDayService: &mockClosingDayService{}})
+		res := NewResource(Dependencies{ClosingDayService: &scheduletest.ClosingDayServiceMock{}})
 		router := setupTestRouter(res.deleteClosingDay, http.MethodDelete, true)
 
 		w := executeRequest(router, http.MethodDelete, "/abc", nil)

--- a/backend/api/timetable/closing_days_test.go
+++ b/backend/api/timetable/closing_days_test.go
@@ -1,0 +1,244 @@
+package timetable
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/stretchr/testify/assert"
+)
+
+// =============================================================================
+// Mock ClosingDayService
+// =============================================================================
+
+type mockClosingDayService struct {
+	days        []*schedule.ClosingDay
+	day         *schedule.ClosingDay
+	err         error
+	lastCreated *schedule.ClosingDay
+	lastUpdated *schedule.ClosingDay
+	lastDeleted int64
+}
+
+func (m *mockClosingDayService) GetAll(_ context.Context) ([]*schedule.ClosingDay, error) {
+	return m.days, m.err
+}
+
+func (m *mockClosingDayService) GetByID(_ context.Context, _ int64) (*schedule.ClosingDay, error) {
+	return m.day, m.err
+}
+
+func (m *mockClosingDayService) Create(_ context.Context, d *schedule.ClosingDay) error {
+	m.lastCreated = d
+	return m.err
+}
+
+func (m *mockClosingDayService) Update(_ context.Context, d *schedule.ClosingDay) error {
+	m.lastUpdated = d
+	return m.err
+}
+
+func (m *mockClosingDayService) Delete(_ context.Context, id int64) error {
+	m.lastDeleted = id
+	return m.err
+}
+
+func (m *mockClosingDayService) ClosingDaysInRange(_ context.Context, _, _ timezone.Date) ([]*schedule.ClosingDay, error) {
+	return m.days, m.err
+}
+
+func (m *mockClosingDayService) ClosingDayDates(_ context.Context, _, _ timezone.Date) (map[timezone.Date]bool, error) {
+	return nil, m.err
+}
+
+func newTestClosingDay() *schedule.ClosingDay {
+	d := &schedule.ClosingDay{
+		StartDate: timezone.NewDate(2026, 12, 24),
+		EndDate:   timezone.NewDate(2026, 12, 31),
+		Reason:    "Weihnachtswoche",
+	}
+	d.ID = int64(7)
+	d.CreatedAt = time.Now()
+	d.UpdatedAt = time.Now()
+	return d
+}
+
+func TestListClosingDays(t *testing.T) {
+	t.Run("returns all closing days", func(t *testing.T) {
+		mock := &mockClosingDayService{days: []*schedule.ClosingDay{newTestClosingDay()}}
+		res := NewResource(Dependencies{ClosingDayService: mock})
+		router := setupTestRouter(res.listClosingDays, http.MethodGet, false)
+
+		w := executeRequest(router, http.MethodGet, "/", nil)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "Weihnachtswoche")
+		assert.Contains(t, w.Body.String(), "2026-12-24")
+	})
+
+	t.Run("returns 500 on service error", func(t *testing.T) {
+		mock := &mockClosingDayService{err: errors.New("db error: password=secret")}
+		res := NewResource(Dependencies{ClosingDayService: mock})
+		router := setupTestRouter(res.listClosingDays, http.MethodGet, false)
+
+		w := executeRequest(router, http.MethodGet, "/", nil)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.NotContains(t, w.Body.String(), "password=secret")
+	})
+}
+
+func TestCreateClosingDay(t *testing.T) {
+	t.Run("creates a closing day range", func(t *testing.T) {
+		mock := &mockClosingDayService{}
+		res := NewResource(Dependencies{ClosingDayService: mock})
+		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
+
+		w := executeRequest(router, http.MethodPost, "/", ClosingDayRequest{
+			StartDate: "2026-07-20",
+			EndDate:   "2026-08-07",
+			Reason:    "Sommerschließung",
+		})
+
+		assert.Equal(t, http.StatusCreated, w.Code)
+		assert.NotNil(t, mock.lastCreated)
+		assert.Equal(t, timezone.NewDate(2026, 7, 20), mock.lastCreated.StartDate)
+		assert.Equal(t, "Sommerschließung", mock.lastCreated.Reason)
+	})
+
+	t.Run("accepts single-day range (start = end)", func(t *testing.T) {
+		mock := &mockClosingDayService{}
+		res := NewResource(Dependencies{ClosingDayService: mock})
+		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
+
+		w := executeRequest(router, http.MethodPost, "/", ClosingDayRequest{
+			StartDate: "2027-02-08",
+			EndDate:   "2027-02-08",
+			Reason:    "Rosenmontag",
+		})
+
+		assert.Equal(t, http.StatusCreated, w.Code)
+	})
+
+	t.Run("rejects missing reason", func(t *testing.T) {
+		res := NewResource(Dependencies{ClosingDayService: &mockClosingDayService{}})
+		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
+
+		w := executeRequest(router, http.MethodPost, "/", ClosingDayRequest{
+			StartDate: "2026-07-20",
+			EndDate:   "2026-08-07",
+		})
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("rejects end before start", func(t *testing.T) {
+		res := NewResource(Dependencies{ClosingDayService: &mockClosingDayService{}})
+		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
+
+		w := executeRequest(router, http.MethodPost, "/", ClosingDayRequest{
+			StartDate: "2026-08-07",
+			EndDate:   "2026-07-20",
+			Reason:    "Verkehrt",
+		})
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("rejects invalid date format", func(t *testing.T) {
+		res := NewResource(Dependencies{ClosingDayService: &mockClosingDayService{}})
+		router := setupTestRouter(res.createClosingDay, http.MethodPost, false)
+
+		w := executeRequest(router, http.MethodPost, "/", ClosingDayRequest{
+			StartDate: "20.07.2026",
+			EndDate:   "2026-08-07",
+			Reason:    "Falsches Format",
+		})
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestUpdateClosingDay(t *testing.T) {
+	t.Run("updates a closing day", func(t *testing.T) {
+		mock := &mockClosingDayService{day: newTestClosingDay()}
+		res := NewResource(Dependencies{ClosingDayService: mock})
+		router := setupTestRouter(res.updateClosingDay, http.MethodPut, true)
+
+		w := executeRequest(router, http.MethodPut, "/7", ClosingDayRequest{
+			StartDate: "2026-12-23",
+			EndDate:   "2027-01-02",
+			Reason:    "Weihnachtsferien",
+		})
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.NotNil(t, mock.lastUpdated)
+		assert.Equal(t, timezone.NewDate(2027, 1, 2), mock.lastUpdated.EndDate)
+		assert.Equal(t, "Weihnachtsferien", mock.lastUpdated.Reason)
+	})
+
+	t.Run("returns 400 for invalid ID", func(t *testing.T) {
+		res := NewResource(Dependencies{ClosingDayService: &mockClosingDayService{}})
+		router := setupTestRouter(res.updateClosingDay, http.MethodPut, true)
+
+		w := executeRequest(router, http.MethodPut, "/abc", ClosingDayRequest{
+			StartDate: "2026-12-23",
+			EndDate:   "2027-01-02",
+			Reason:    "Weihnachtsferien",
+		})
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 404 when not found", func(t *testing.T) {
+		mock := &mockClosingDayService{err: sql.ErrNoRows}
+		res := NewResource(Dependencies{ClosingDayService: mock})
+		router := setupTestRouter(res.updateClosingDay, http.MethodPut, true)
+
+		w := executeRequest(router, http.MethodPut, "/999", ClosingDayRequest{
+			StartDate: "2026-12-23",
+			EndDate:   "2027-01-02",
+			Reason:    "Weihnachtsferien",
+		})
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
+func TestDeleteClosingDay(t *testing.T) {
+	t.Run("deletes a closing day", func(t *testing.T) {
+		mock := &mockClosingDayService{day: newTestClosingDay()}
+		res := NewResource(Dependencies{ClosingDayService: mock})
+		router := setupTestRouter(res.deleteClosingDay, http.MethodDelete, true)
+
+		w := executeRequest(router, http.MethodDelete, "/7", nil)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, int64(7), mock.lastDeleted)
+	})
+
+	t.Run("returns 404 when not found", func(t *testing.T) {
+		mock := &mockClosingDayService{err: sql.ErrNoRows}
+		res := NewResource(Dependencies{ClosingDayService: mock})
+		router := setupTestRouter(res.deleteClosingDay, http.MethodDelete, true)
+
+		w := executeRequest(router, http.MethodDelete, "/999", nil)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("returns 400 for invalid ID", func(t *testing.T) {
+		res := NewResource(Dependencies{ClosingDayService: &mockClosingDayService{}})
+		router := setupTestRouter(res.deleteClosingDay, http.MethodDelete, true)
+
+		w := executeRequest(router, http.MethodDelete, "/abc", nil)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}

--- a/backend/database/migrations/001015211_closing_days.go
+++ b/backend/database/migrations/001015211_closing_days.go
@@ -1,0 +1,120 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	closingDaysVersion     = "1.15.211"
+	closingDaysDescription = "Create schedule.closing_days - tenant-specific OGS closure periods with Soll=0 semantics"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     closingDaysVersion,
+		Description: closingDaysDescription,
+		DependsOn: []string{
+			deviationEventShiftAnchorVersion, // latest development migration before this branch
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return closingDaysUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return closingDaysDown(ctx, db)
+		},
+	)
+}
+
+// closingDaysUp creates the store for OGS-Schließtage (#1418 3b): closure
+// periods a school defines itself (pädagogische Tage, Weihnachtswoche,
+// Sommerschließung) on top of the computed public holidays (3a). Rows are
+// ranges, not single days — a three-week summer closure is one row, and a
+// single closed day is a range with start_date = end_date (hence <= in the
+// CHECK, unlike calendar_periods which requires strictly increasing ranges).
+//
+// There is deliberately no overlap EXCLUDE constraint: overlapping closure
+// ranges are harmless because Soll computation collapses them into one date
+// set, and avoiding btree_gist keeps the migration dependency-free.
+func closingDaysUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.211: Creating schedule.closing_days...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS schedule.closing_days (
+			id         BIGSERIAL PRIMARY KEY,
+			tenant_id  BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			start_date DATE NOT NULL,
+			end_date   DATE NOT NULL,
+			reason     TEXT NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT closing_days_range_ok CHECK (start_date <= end_date)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_closing_days_tenant_range
+			ON schedule.closing_days (tenant_id, start_date, end_date);
+
+		DROP TRIGGER IF EXISTS update_closing_days_updated_at ON schedule.closing_days;
+		CREATE TRIGGER update_closing_days_updated_at
+		BEFORE UPDATE ON schedule.closing_days
+		FOR EACH ROW
+		EXECUTE FUNCTION update_modified_column();
+
+		ALTER TABLE schedule.closing_days ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE schedule.closing_days FORCE ROW LEVEL SECURITY;
+
+		DROP POLICY IF EXISTS tenant_isolation_schedule_closing_days ON schedule.closing_days;
+		CREATE POLICY tenant_isolation_schedule_closing_days ON schedule.closing_days
+			FOR ALL
+			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+
+		GRANT SELECT, INSERT, UPDATE, DELETE ON schedule.closing_days TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE schedule.closing_days_id_seq TO phoenix_tenant;
+	`)
+	if err != nil {
+		return fmt.Errorf("error creating schedule.closing_days: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+func closingDaysDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.211: Dropping schedule.closing_days...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		DROP TRIGGER IF EXISTS update_closing_days_updated_at ON schedule.closing_days;
+		DROP TABLE IF EXISTS schedule.closing_days CASCADE;
+	`)
+	if err != nil {
+		return fmt.Errorf("error dropping schedule.closing_days: %w", err)
+	}
+	return tx.Commit()
+}

--- a/backend/database/migrations/001015216_closing_days.go
+++ b/backend/database/migrations/001015216_closing_days.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	closingDaysVersion     = "1.15.211"
+	closingDaysVersion     = "1.15.216"
 	closingDaysDescription = "Create schedule.closing_days - tenant-specific OGS closure periods with Soll=0 semantics"
 )
 
@@ -44,7 +44,7 @@ func init() {
 // ranges are harmless because Soll computation collapses them into one date
 // set, and avoiding btree_gist keeps the migration dependency-free.
 func closingDaysUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.211: Creating schedule.closing_days...")
+	fmt.Println("Migration 1.15.216: Creating schedule.closing_days...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
@@ -97,7 +97,7 @@ func closingDaysUp(ctx context.Context, db *bun.DB) error {
 }
 
 func closingDaysDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.211: Dropping schedule.closing_days...")
+	fmt.Println("Rolling back migration 1.15.216: Dropping schedule.closing_days...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -104,6 +104,7 @@ type Factory struct {
 	StaffShiftSeriesException scheduleModels.StaffShiftSeriesExceptionRepository
 	ShiftType                 scheduleModels.ShiftTypeRepository
 	CalendarPeriod            scheduleModels.CalendarPeriodRepository
+	ClosingDay                scheduleModels.ClosingDayRepository
 	ActivityInstance          scheduleModels.ActivityInstanceRepository
 	InstanceStaff             scheduleModels.InstanceStaffRepository
 	InstanceStudent           scheduleModels.InstanceStudentRepository
@@ -290,6 +291,7 @@ func NewFactory(db *bun.DB) *Factory {
 		StaffShiftSeriesException: schedule.NewStaffShiftSeriesExceptionRepository(db),
 		ShiftType:                 schedule.NewShiftTypeRepository(db),
 		CalendarPeriod:            schedule.NewCalendarPeriodRepository(db),
+		ClosingDay:                schedule.NewClosingDayRepository(db),
 		ActivityInstance:          schedule.NewActivityInstanceRepository(db),
 		InstanceStaff:             schedule.NewInstanceStaffRepository(db),
 		InstanceStudent:           schedule.NewInstanceStudentRepository(db),

--- a/backend/database/repositories/schedule/closing_day_repo.go
+++ b/backend/database/repositories/schedule/closing_day_repo.go
@@ -1,0 +1,101 @@
+package schedule
+
+import (
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/uptrace/bun"
+)
+
+const tableClosingDays = "schedule.closing_days"
+
+// ClosingDayRepository implements schedule.ClosingDayRepository
+type ClosingDayRepository struct {
+	*base.Repository[*schedule.ClosingDay]
+	db *bun.DB
+}
+
+// NewClosingDayRepository creates a new ClosingDayRepository
+func NewClosingDayRepository(db *bun.DB) schedule.ClosingDayRepository {
+	repo := base.NewRepository[*schedule.ClosingDay](db, tableClosingDays, "ClosingDay")
+	repo.TenantScoped = true
+	return &ClosingDayRepository{
+		Repository: repo,
+		db:         db,
+	}
+}
+
+// FindByTenantID finds all closing days for the current tenant
+func (r *ClosingDayRepository) FindByTenantID(ctx context.Context) ([]*schedule.ClosingDay, error) {
+	var days []*schedule.ClosingDay
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&days).
+		ModelTableExpr(`schedule.closing_days AS "closing_day"`).
+		Order("start_date ASC")
+
+	query = base.WithTenantFilter(ctx, query, "closing_day")
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by tenant id",
+			Err: err,
+		}
+	}
+
+	return days, nil
+}
+
+// FindOverlappingRange returns all closing days of the current tenant whose
+// [start_date, end_date] range overlaps [from, to] (inclusive on both ends).
+func (r *ClosingDayRepository) FindOverlappingRange(ctx context.Context, from, to timezone.Date) ([]*schedule.ClosingDay, error) {
+	var days []*schedule.ClosingDay
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&days).
+		ModelTableExpr(`schedule.closing_days AS "closing_day"`).
+		Where(`"closing_day".start_date <= ?`, to).
+		Where(`"closing_day".end_date >= ?`, from).
+		Order("start_date ASC")
+
+	query = base.WithTenantFilter(ctx, query, "closing_day")
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find overlapping range",
+			Err: err,
+		}
+	}
+
+	return days, nil
+}
+
+// FindByID overrides base method to ensure schema qualification
+func (r *ClosingDayRepository) FindByID(ctx context.Context, id any) (*schedule.ClosingDay, error) {
+	var day schedule.ClosingDay
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&day).
+		ModelTableExpr(`schedule.closing_days AS "closing_day"`).
+		Where(`"closing_day".id = ?`, id)
+
+	query = base.WithTenantFilter(ctx, query, "closing_day")
+
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  opFindByID,
+			Err: err,
+		}
+	}
+
+	return &day, nil
+}
+
+// List retrieves closing days matching the provided query options
+func (r *ClosingDayRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.ClosingDay, error) {
+	return r.ListWithOptions(ctx, options)
+}

--- a/backend/database/repositories/schedule/closing_day_repo_test.go
+++ b/backend/database/repositories/schedule/closing_day_repo_test.go
@@ -1,0 +1,162 @@
+package schedule_test
+
+import (
+	"testing"
+
+	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// ClosingDayRepository Tests (#1418 3b)
+// =============================================================================
+
+func createTestClosingDay(t *testing.T, repo scheduleModels.ClosingDayRepository, start, end timezone.Date, reason string) *scheduleModels.ClosingDay {
+	t.Helper()
+	ctx := testpkg.TenantContext(1)
+
+	day := &scheduleModels.ClosingDay{
+		StartDate: start,
+		EndDate:   end,
+		Reason:    reason,
+	}
+	day.SetTenantID(1)
+
+	err := repo.Create(ctx, day)
+	require.NoError(t, err)
+	require.Greater(t, day.ID, int64(0))
+	return day
+}
+
+func TestClosingDayRepository_CRUD(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewClosingDayRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates and reads a range", func(t *testing.T) {
+		day := createTestClosingDay(t, repo,
+			timezone.NewDate(2026, 12, 24), timezone.NewDate(2026, 12, 31), "Weihnachtswoche")
+		defer testpkg.CleanupTableRecords(t, db, "schedule.closing_days", day.ID)
+
+		found, err := repo.FindByID(ctx, day.ID)
+		require.NoError(t, err)
+		assert.Equal(t, timezone.NewDate(2026, 12, 24), found.StartDate)
+		assert.Equal(t, timezone.NewDate(2026, 12, 31), found.EndDate)
+		assert.Equal(t, "Weihnachtswoche", found.Reason)
+	})
+
+	t.Run("creates a single-day closing (start = end)", func(t *testing.T) {
+		day := createTestClosingDay(t, repo,
+			timezone.NewDate(2027, 2, 8), timezone.NewDate(2027, 2, 8), "Rosenmontag")
+		defer testpkg.CleanupTableRecords(t, db, "schedule.closing_days", day.ID)
+
+		found, err := repo.FindByID(ctx, day.ID)
+		require.NoError(t, err)
+		assert.Equal(t, found.StartDate, found.EndDate)
+	})
+
+	t.Run("fails validation on missing reason", func(t *testing.T) {
+		day := &scheduleModels.ClosingDay{
+			StartDate: timezone.NewDate(2026, 12, 24),
+			EndDate:   timezone.NewDate(2026, 12, 31),
+		}
+		day.SetTenantID(1)
+
+		err := repo.Create(ctx, day)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reason is required")
+	})
+
+	t.Run("updates and deletes", func(t *testing.T) {
+		day := createTestClosingDay(t, repo,
+			timezone.NewDate(2026, 10, 12), timezone.NewDate(2026, 10, 16), "Herbstschließung")
+		defer testpkg.CleanupTableRecords(t, db, "schedule.closing_days", day.ID)
+
+		day.EndDate = timezone.NewDate(2026, 10, 23)
+		day.Reason = "Herbstschließung verlängert"
+		require.NoError(t, repo.Update(ctx, day))
+
+		found, err := repo.FindByID(ctx, day.ID)
+		require.NoError(t, err)
+		assert.Equal(t, timezone.NewDate(2026, 10, 23), found.EndDate)
+		assert.Equal(t, "Herbstschließung verlängert", found.Reason)
+
+		require.NoError(t, repo.Delete(ctx, day.ID))
+		days, err := repo.FindByTenantID(ctx)
+		require.NoError(t, err)
+		for _, d := range days {
+			assert.NotEqual(t, day.ID, d.ID)
+		}
+	})
+}
+
+func TestClosingDayRepository_FindOverlappingRange(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := scheduleRepo.NewClosingDayRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	day := createTestClosingDay(t, repo,
+		timezone.NewDate(2026, 7, 20), timezone.NewDate(2026, 8, 7), "Sommerschließung")
+	defer testpkg.CleanupTableRecords(t, db, "schedule.closing_days", day.ID)
+
+	contains := func(days []*scheduleModels.ClosingDay) bool {
+		for _, d := range days {
+			if d.ID == day.ID {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("window fully inside the range", func(t *testing.T) {
+		days, err := repo.FindOverlappingRange(ctx, timezone.NewDate(2026, 7, 27), timezone.NewDate(2026, 7, 31))
+		require.NoError(t, err)
+		assert.True(t, contains(days))
+	})
+
+	t.Run("range overlaps the window edge", func(t *testing.T) {
+		days, err := repo.FindOverlappingRange(ctx, timezone.NewDate(2026, 8, 7), timezone.NewDate(2026, 8, 31))
+		require.NoError(t, err)
+		assert.True(t, contains(days), "inclusive end_date must match the window start")
+	})
+
+	t.Run("no hit outside the range", func(t *testing.T) {
+		days, err := repo.FindOverlappingRange(ctx, timezone.NewDate(2026, 8, 8), timezone.NewDate(2026, 8, 31))
+		require.NoError(t, err)
+		assert.False(t, contains(days))
+	})
+}
+
+func TestClosingDayRepository_TenantIsolation(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	testpkg.EnsureTestTenant(t, db, 2)
+
+	repo := scheduleRepo.NewClosingDayRepository(db)
+
+	day := createTestClosingDay(t, repo,
+		timezone.NewDate(2026, 11, 2), timezone.NewDate(2026, 11, 6), "Pädagogische Woche")
+	defer testpkg.CleanupTableRecords(t, db, "schedule.closing_days", day.ID)
+
+	ctxT2 := testpkg.TenantContext(2)
+	days, err := repo.FindByTenantID(ctxT2)
+	require.NoError(t, err)
+	for _, d := range days {
+		assert.NotEqual(t, day.ID, d.ID, "tenant 2 must not see tenant 1 closing days")
+	}
+
+	overlapping, err := repo.FindOverlappingRange(ctxT2, timezone.NewDate(2026, 11, 1), timezone.NewDate(2026, 11, 30))
+	require.NoError(t, err)
+	for _, d := range overlapping {
+		assert.NotEqual(t, day.ID, d.ID)
+	}
+}

--- a/backend/models/schedule/closing_day.go
+++ b/backend/models/schedule/closing_day.go
@@ -1,0 +1,59 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/base"
+)
+
+// ClosingDayReasonMaxLength is the maximum length of the reason field.
+const ClosingDayReasonMaxLength = 255
+
+// ClosingDay represents a tenant-defined OGS closure period (#1418 3b) —
+// pädagogische Tage, Weihnachtswoche, Sommerschließung. A row is a date
+// range; a single closed day has start_date = end_date. On these days the
+// staff Soll is 0, exactly like on public holidays.
+type ClosingDay struct {
+	base.Model `bun:"schema:schedule,table:closing_days"`
+	base.TenantModel
+
+	StartDate timezone.Date `bun:"start_date,notnull" json:"start_date"`
+	EndDate   timezone.Date `bun:"end_date,notnull" json:"end_date"`
+	Reason    string        `bun:"reason,notnull" json:"reason"`
+}
+
+// Validate ensures closing day data is valid
+func (c *ClosingDay) Validate() error {
+	if c.Reason == "" {
+		return errors.New("reason is required")
+	}
+	if len(c.Reason) > ClosingDayReasonMaxLength {
+		return errors.New("reason cannot exceed 255 characters")
+	}
+	if c.StartDate.IsZero() {
+		return errors.New("start_date is required")
+	}
+	if c.EndDate.IsZero() {
+		return errors.New("end_date is required")
+	}
+	if c.EndDate.Before(c.StartDate) {
+		return errors.New("end_date must not be before start_date")
+	}
+	return nil
+}
+
+// ClosingDayRepository defines operations for managing closing days
+type ClosingDayRepository interface {
+	base.Repository[*ClosingDay]
+
+	// FindByTenantID finds all closing days for the current tenant,
+	// ordered by start_date.
+	FindByTenantID(ctx context.Context) ([]*ClosingDay, error)
+
+	// FindOverlappingRange returns all closing days of the current tenant
+	// whose [start_date, end_date] range overlaps [from, to] (inclusive on
+	// both ends), ordered by start_date.
+	FindOverlappingRange(ctx context.Context, from, to timezone.Date) ([]*ClosingDay, error)
+}

--- a/backend/models/schedule/closing_day.go
+++ b/backend/models/schedule/closing_day.go
@@ -3,6 +3,8 @@ package schedule
 import (
 	"context"
 	"errors"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -26,10 +28,11 @@ type ClosingDay struct {
 
 // Validate ensures closing day data is valid
 func (c *ClosingDay) Validate() error {
-	if c.Reason == "" {
+	trimmedReason := strings.TrimSpace(c.Reason)
+	if trimmedReason == "" {
 		return errors.New("reason is required")
 	}
-	if len(c.Reason) > ClosingDayReasonMaxLength {
+	if utf8.RuneCountInString(trimmedReason) > ClosingDayReasonMaxLength {
 		return errors.New("reason cannot exceed 255 characters")
 	}
 	if c.StartDate.IsZero() {

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -64,6 +64,7 @@ type Factory struct {
 	WorkSession              active.WorkSessionService
 	WorkTimeMonth            active.WorkTimeMonthService
 	Holidays                 schedule.HolidayService
+	ClosingDays              schedule.ClosingDayService
 	StaffAbsence             active.StaffAbsenceService
 	Activities               activities.ActivityService
 	Education                education.Service
@@ -359,14 +360,20 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	// Public holidays per Bundesland (#1418 3a): computed from the
 	// operations.federal_state setting, zero the Soll of their day.
 	holidayService := schedule.NewHolidayService(settingsService, logger.With("service", "holidays"))
-	workTimeMonthService.SetHolidayReader(holidayService)
+	// Tenant closing days (#1418 3b) share the Soll=0 semantics of public
+	// holidays. The Soll consumers get the UNION of both via the composite
+	// reader; Factory.Holidays stays the plain holiday service so the
+	// /holidays endpoint keeps reporting only real public holidays.
+	closingDayService := schedule.NewClosingDayService(repos.ClosingDay)
+	nonWorkingDayService := schedule.NewNonWorkingDayResolver(holidayService, closingDayService)
+	workTimeMonthService.SetHolidayReader(nonWorkingDayService)
 	// The session service's weekly summaries reduce their Soll by holidays
 	// too. The setter is not part of the WorkSessionService interface (it
 	// would break external mocks), hence the assertion.
 	if holidayAware, ok := workSessionService.(interface {
 		SetHolidayReader(active.HolidayDatesReader)
 	}); ok {
-		holidayAware.SetHolidayReader(holidayService)
+		holidayAware.SetHolidayReader(nonWorkingDayService)
 	}
 
 	// Initialize staff absence service
@@ -606,7 +613,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Staff:         repos.Staff,
 		WorkSchedules: repos.StaffWorkSchedule,
 		WorkModels:    repos.WorkTimeModel,
-		Holidays:      holidayService,
+		Holidays:      nonWorkingDayService,
 	})
 
 	// Initialize pickup schedule service
@@ -1500,6 +1507,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		WorkSession:              workSessionService,
 		WorkTimeMonth:            workTimeMonthService,
 		Holidays:                 holidayService,
+		ClosingDays:              closingDayService,
 		StaffAbsence:             staffAbsenceService,
 		Activities:               activitiesService,
 		Education:                educationService,

--- a/backend/services/schedule/closing_day_service.go
+++ b/backend/services/schedule/closing_day_service.go
@@ -1,0 +1,118 @@
+package schedule
+
+import (
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+// ClosingDayService manages tenant-defined OGS closure periods (#1418 3b).
+// Closing days carry the same Soll=0 semantics as public holidays; the
+// union with holidays happens in NewNonWorkingDayResolver.
+type ClosingDayService interface {
+	// GetAll returns all closing days of the current tenant.
+	GetAll(ctx context.Context) ([]*schedule.ClosingDay, error)
+	// GetByID returns a single closing day of the current tenant.
+	GetByID(ctx context.Context, id int64) (*schedule.ClosingDay, error)
+	// Create validates and stores a new closing day.
+	Create(ctx context.Context, day *schedule.ClosingDay) error
+	// Update validates and updates an existing closing day.
+	Update(ctx context.Context, day *schedule.ClosingDay) error
+	// Delete removes a closing day.
+	Delete(ctx context.Context, id int64) error
+
+	// ClosingDaysInRange returns the closure periods overlapping [from, to]
+	// as stored ranges (for display).
+	ClosingDaysInRange(ctx context.Context, from, to timezone.Date) ([]*schedule.ClosingDay, error)
+	// ClosingDayDates expands the closure periods overlapping [from, to]
+	// into a date set clamped to [from, to] for O(1) lookups in Soll
+	// computations — the closing-day analog of HolidayService.HolidayDates.
+	ClosingDayDates(ctx context.Context, from, to timezone.Date) (map[timezone.Date]bool, error)
+}
+
+type closingDayService struct {
+	repo schedule.ClosingDayRepository
+}
+
+// NewClosingDayService creates the closing day service.
+func NewClosingDayService(repo schedule.ClosingDayRepository) ClosingDayService {
+	return &closingDayService{repo: repo}
+}
+
+func (s *closingDayService) GetAll(ctx context.Context) ([]*schedule.ClosingDay, error) {
+	days, err := s.repo.FindByTenantID(ctx)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get all closing days", Err: err}
+	}
+	return days, nil
+}
+
+func (s *closingDayService) GetByID(ctx context.Context, id int64) (*schedule.ClosingDay, error) {
+	day, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return nil, &ScheduleError{Op: "get closing day", Err: err}
+	}
+	return day, nil
+}
+
+func (s *closingDayService) Create(ctx context.Context, day *schedule.ClosingDay) error {
+	if err := day.Validate(); err != nil {
+		return err
+	}
+	if err := s.repo.Create(ctx, day); err != nil {
+		return &ScheduleError{Op: "create closing day", Err: err}
+	}
+	return nil
+}
+
+func (s *closingDayService) Update(ctx context.Context, day *schedule.ClosingDay) error {
+	if err := day.Validate(); err != nil {
+		return err
+	}
+	if err := s.repo.Update(ctx, day); err != nil {
+		return &ScheduleError{Op: "update closing day", Err: err}
+	}
+	return nil
+}
+
+func (s *closingDayService) Delete(ctx context.Context, id int64) error {
+	if err := s.repo.Delete(ctx, id); err != nil {
+		return &ScheduleError{Op: "delete closing day", Err: err}
+	}
+	return nil
+}
+
+func (s *closingDayService) ClosingDaysInRange(ctx context.Context, from, to timezone.Date) ([]*schedule.ClosingDay, error) {
+	days, err := s.repo.FindOverlappingRange(ctx, from, to)
+	if err != nil {
+		return nil, &ScheduleError{Op: "closing days in range", Err: err}
+	}
+	return days, nil
+}
+
+func (s *closingDayService) ClosingDayDates(ctx context.Context, from, to timezone.Date) (map[timezone.Date]bool, error) {
+	if to.Before(from) {
+		return map[timezone.Date]bool{}, nil
+	}
+	days, err := s.repo.FindOverlappingRange(ctx, from, to)
+	if err != nil {
+		return nil, &ScheduleError{Op: "closing day dates", Err: err}
+	}
+
+	set := make(map[timezone.Date]bool)
+	for _, day := range days {
+		start := day.StartDate
+		if start.Before(from) {
+			start = from
+		}
+		end := day.EndDate
+		if end.After(to) {
+			end = to
+		}
+		for d := start; !d.After(end); d = d.AddDays(1) {
+			set[d] = true
+		}
+	}
+	return set, nil
+}

--- a/backend/services/schedule/closing_day_service_internal_test.go
+++ b/backend/services/schedule/closing_day_service_internal_test.go
@@ -110,8 +110,18 @@ func TestClosingDayCreateRejectsInvalid(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reason is required")
 
+	err = svc.Create(context.Background(), closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), " \t\n "))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reason is required")
+
 	longReason := strings.Repeat("x", schedule.ClosingDayReasonMaxLength+1)
 	err = svc.Create(context.Background(), closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), longReason))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reason cannot exceed 255 characters")
+
+	unicodeReason := strings.Repeat("ä", schedule.ClosingDayReasonMaxLength)
+	require.NoError(t, svc.Create(context.Background(), closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), unicodeReason)))
+	err = svc.Create(context.Background(), closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), unicodeReason+"ä"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reason cannot exceed 255 characters")
 

--- a/backend/services/schedule/closing_day_service_internal_test.go
+++ b/backend/services/schedule/closing_day_service_internal_test.go
@@ -1,0 +1,92 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockClosingDayRepo overrides only the methods the service under test uses;
+// the embedded interface panics on anything else, which is exactly what we
+// want in a focused unit test.
+type mockClosingDayRepo struct {
+	schedule.ClosingDayRepository
+	days []*schedule.ClosingDay
+	err  error
+}
+
+func (m *mockClosingDayRepo) FindOverlappingRange(_ context.Context, _, _ timezone.Date) ([]*schedule.ClosingDay, error) {
+	return m.days, m.err
+}
+
+func (m *mockClosingDayRepo) Create(_ context.Context, _ *schedule.ClosingDay) error {
+	return m.err
+}
+
+func closingRange(start, end timezone.Date, reason string) *schedule.ClosingDay {
+	return &schedule.ClosingDay{StartDate: start, EndDate: end, Reason: reason}
+}
+
+func TestClosingDayDatesExpandsRanges(t *testing.T) {
+	svc := NewClosingDayService(&mockClosingDayRepo{days: []*schedule.ClosingDay{
+		closingRange(timezone.NewDate(2026, 12, 24), timezone.NewDate(2026, 12, 27), "Weihnachten"),
+		closingRange(timezone.NewDate(2026, 12, 31), timezone.NewDate(2026, 12, 31), "Silvester"),
+	}})
+
+	set, err := svc.ClosingDayDates(context.Background(), timezone.NewDate(2026, 12, 1), timezone.NewDate(2026, 12, 31))
+	require.NoError(t, err)
+
+	assert.Len(t, set, 5)
+	assert.True(t, set[timezone.NewDate(2026, 12, 24)])
+	assert.True(t, set[timezone.NewDate(2026, 12, 27)])
+	assert.True(t, set[timezone.NewDate(2026, 12, 31)])
+	assert.False(t, set[timezone.NewDate(2026, 12, 28)])
+}
+
+func TestClosingDayDatesClampsToWindow(t *testing.T) {
+	// Range extends past both window edges; only in-window days may appear.
+	svc := NewClosingDayService(&mockClosingDayRepo{days: []*schedule.ClosingDay{
+		closingRange(timezone.NewDate(2026, 7, 20), timezone.NewDate(2026, 8, 7), "Sommerschließung"),
+	}})
+
+	set, err := svc.ClosingDayDates(context.Background(), timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 3))
+	require.NoError(t, err)
+
+	assert.Len(t, set, 3)
+	assert.True(t, set[timezone.NewDate(2026, 8, 1)])
+	assert.True(t, set[timezone.NewDate(2026, 8, 3)])
+	assert.False(t, set[timezone.NewDate(2026, 7, 31)])
+	assert.False(t, set[timezone.NewDate(2026, 8, 4)])
+}
+
+func TestClosingDayDatesEmptyOnInvertedWindow(t *testing.T) {
+	svc := NewClosingDayService(&mockClosingDayRepo{})
+
+	set, err := svc.ClosingDayDates(context.Background(), timezone.NewDate(2026, 8, 3), timezone.NewDate(2026, 8, 1))
+	require.NoError(t, err)
+	assert.Empty(t, set)
+}
+
+func TestClosingDayDatesPropagatesRepoError(t *testing.T) {
+	svc := NewClosingDayService(&mockClosingDayRepo{err: errors.New("boom")})
+
+	_, err := svc.ClosingDayDates(context.Background(), timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 3))
+	require.Error(t, err)
+}
+
+func TestClosingDayCreateRejectsInvalid(t *testing.T) {
+	svc := NewClosingDayService(&mockClosingDayRepo{})
+
+	err := svc.Create(context.Background(), closingRange(timezone.NewDate(2026, 8, 7), timezone.NewDate(2026, 8, 1), "Verkehrt"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "end_date must not be before start_date")
+
+	err = svc.Create(context.Background(), closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), ""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reason is required")
+}

--- a/backend/services/schedule/closing_day_service_internal_test.go
+++ b/backend/services/schedule/closing_day_service_internal_test.go
@@ -3,6 +3,7 @@ package schedule
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
@@ -26,6 +27,25 @@ func (m *mockClosingDayRepo) FindOverlappingRange(_ context.Context, _, _ timezo
 
 func (m *mockClosingDayRepo) Create(_ context.Context, _ *schedule.ClosingDay) error {
 	return m.err
+}
+
+func (m *mockClosingDayRepo) Update(_ context.Context, _ *schedule.ClosingDay) error {
+	return m.err
+}
+
+func (m *mockClosingDayRepo) Delete(_ context.Context, _ any) error {
+	return m.err
+}
+
+func (m *mockClosingDayRepo) FindByTenantID(_ context.Context) ([]*schedule.ClosingDay, error) {
+	return m.days, m.err
+}
+
+func (m *mockClosingDayRepo) FindByID(_ context.Context, _ any) (*schedule.ClosingDay, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.days[0], nil
 }
 
 func closingRange(start, end timezone.Date, reason string) *schedule.ClosingDay {
@@ -89,4 +109,86 @@ func TestClosingDayCreateRejectsInvalid(t *testing.T) {
 	err = svc.Create(context.Background(), closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), ""))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reason is required")
+
+	longReason := strings.Repeat("x", schedule.ClosingDayReasonMaxLength+1)
+	err = svc.Create(context.Background(), closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), longReason))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reason cannot exceed 255 characters")
+
+	err = svc.Create(context.Background(), &schedule.ClosingDay{EndDate: timezone.NewDate(2026, 8, 7), Reason: "Ohne Start"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start_date is required")
+
+	err = svc.Create(context.Background(), &schedule.ClosingDay{StartDate: timezone.NewDate(2026, 8, 1), Reason: "Ohne Ende"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "end_date is required")
+}
+
+func TestClosingDayCreateWrapsRepoError(t *testing.T) {
+	svc := NewClosingDayService(&mockClosingDayRepo{err: errors.New("boom")})
+	valid := closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), "Sommerschließung")
+
+	err := svc.Create(context.Background(), valid)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create closing day")
+
+	require.NoError(t, NewClosingDayService(&mockClosingDayRepo{}).Create(context.Background(), valid))
+}
+
+func TestClosingDayUpdate(t *testing.T) {
+	valid := closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), "Sommerschließung")
+
+	require.NoError(t, NewClosingDayService(&mockClosingDayRepo{}).Update(context.Background(), valid))
+
+	err := NewClosingDayService(&mockClosingDayRepo{}).Update(context.Background(), closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), ""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reason is required")
+
+	err = NewClosingDayService(&mockClosingDayRepo{err: errors.New("boom")}).Update(context.Background(), valid)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "update closing day")
+}
+
+func TestClosingDayDelete(t *testing.T) {
+	require.NoError(t, NewClosingDayService(&mockClosingDayRepo{}).Delete(context.Background(), 1))
+
+	err := NewClosingDayService(&mockClosingDayRepo{err: errors.New("boom")}).Delete(context.Background(), 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete closing day")
+}
+
+func TestClosingDayGetAll(t *testing.T) {
+	day := closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), "Sommerschließung")
+
+	days, err := NewClosingDayService(&mockClosingDayRepo{days: []*schedule.ClosingDay{day}}).GetAll(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []*schedule.ClosingDay{day}, days)
+
+	_, err = NewClosingDayService(&mockClosingDayRepo{err: errors.New("boom")}).GetAll(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get all closing days")
+}
+
+func TestClosingDayGetByID(t *testing.T) {
+	day := closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), "Sommerschließung")
+
+	got, err := NewClosingDayService(&mockClosingDayRepo{days: []*schedule.ClosingDay{day}}).GetByID(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, day, got)
+
+	_, err = NewClosingDayService(&mockClosingDayRepo{err: errors.New("boom")}).GetByID(context.Background(), 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get closing day")
+}
+
+func TestClosingDaysInRange(t *testing.T) {
+	day := closingRange(timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 7), "Sommerschließung")
+
+	days, err := NewClosingDayService(&mockClosingDayRepo{days: []*schedule.ClosingDay{day}}).ClosingDaysInRange(context.Background(), timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 31))
+	require.NoError(t, err)
+	assert.Equal(t, []*schedule.ClosingDay{day}, days)
+
+	_, err = NewClosingDayService(&mockClosingDayRepo{err: errors.New("boom")}).ClosingDaysInRange(context.Background(), timezone.NewDate(2026, 8, 1), timezone.NewDate(2026, 8, 31))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "closing days in range")
 }

--- a/backend/services/schedule/non_working_day_reader.go
+++ b/backend/services/schedule/non_working_day_reader.go
@@ -1,0 +1,48 @@
+package schedule
+
+import (
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/internal/holidays"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+)
+
+// nonWorkingDayResolver unions public holidays (3a) and tenant closing days
+// (3b) into one date set. It implements HolidayService so it can replace the
+// plain holiday service at the Soll-computation injection points without any
+// change to the consuming loops — a day that is both a holiday and a closing
+// day collapses into a single boolean key, so it can never be subtracted
+// twice.
+//
+// HolidaysInRange stays a pure holiday passthrough: the /holidays endpoint
+// and the Feiertagsarbeit warning must not start reporting closing days.
+type nonWorkingDayResolver struct {
+	holidays HolidayService
+	closing  ClosingDayService
+}
+
+// NewNonWorkingDayResolver combines a holiday service and a closing day
+// service into a HolidayService whose HolidayDates returns the union of both
+// date sets.
+func NewNonWorkingDayResolver(h HolidayService, c ClosingDayService) HolidayService {
+	return &nonWorkingDayResolver{holidays: h, closing: c}
+}
+
+func (r *nonWorkingDayResolver) HolidaysInRange(ctx context.Context, from, to timezone.Date) ([]holidays.Holiday, error) {
+	return r.holidays.HolidaysInRange(ctx, from, to)
+}
+
+func (r *nonWorkingDayResolver) HolidayDates(ctx context.Context, from, to timezone.Date) (map[timezone.Date]bool, error) {
+	set, err := r.holidays.HolidayDates(ctx, from, to)
+	if err != nil {
+		return nil, err
+	}
+	closingSet, err := r.closing.ClosingDayDates(ctx, from, to)
+	if err != nil {
+		return nil, err
+	}
+	for d := range closingSet {
+		set[d] = true
+	}
+	return set, nil
+}

--- a/backend/services/schedule/non_working_day_reader_internal_test.go
+++ b/backend/services/schedule/non_working_day_reader_internal_test.go
@@ -1,0 +1,91 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/holidays"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubHolidayService struct {
+	list  []holidays.Holiday
+	dates map[timezone.Date]bool
+	err   error
+}
+
+func (s *stubHolidayService) HolidaysInRange(_ context.Context, _, _ timezone.Date) ([]holidays.Holiday, error) {
+	return s.list, s.err
+}
+
+func (s *stubHolidayService) HolidayDates(_ context.Context, _, _ timezone.Date) (map[timezone.Date]bool, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	// Copy so union mutation in the resolver cannot leak into the stub.
+	out := make(map[timezone.Date]bool, len(s.dates))
+	for d := range s.dates {
+		out[d] = true
+	}
+	return out, nil
+}
+
+type stubClosingDayService struct {
+	ClosingDayService
+	dates map[timezone.Date]bool
+	err   error
+}
+
+func (s *stubClosingDayService) ClosingDayDates(_ context.Context, _, _ timezone.Date) (map[timezone.Date]bool, error) {
+	return s.dates, s.err
+}
+
+func TestNonWorkingDayResolverUnionsDates(t *testing.T) {
+	holiday := timezone.NewDate(2026, 10, 3)
+	closing := timezone.NewDate(2026, 10, 12)
+	both := timezone.NewDate(2026, 11, 1) // Allerheiligen inside a closure week
+
+	resolver := NewNonWorkingDayResolver(
+		&stubHolidayService{dates: map[timezone.Date]bool{holiday: true, both: true}},
+		&stubClosingDayService{dates: map[timezone.Date]bool{closing: true, both: true}},
+	)
+
+	set, err := resolver.HolidayDates(context.Background(), timezone.NewDate(2026, 10, 1), timezone.NewDate(2026, 11, 30))
+	require.NoError(t, err)
+
+	assert.True(t, set[holiday])
+	assert.True(t, set[closing])
+	assert.True(t, set[both], "a day that is holiday AND closing day collapses into one entry")
+	assert.Len(t, set, 3)
+}
+
+func TestNonWorkingDayResolverPassthroughKeepsHolidaysPure(t *testing.T) {
+	resolver := NewNonWorkingDayResolver(
+		&stubHolidayService{list: []holidays.Holiday{{Date: timezone.NewDate(2026, 5, 1), Name: "Tag der Arbeit"}}},
+		&stubClosingDayService{dates: map[timezone.Date]bool{timezone.NewDate(2026, 5, 4): true}},
+	)
+
+	list, err := resolver.HolidaysInRange(context.Background(), timezone.NewDate(2026, 5, 1), timezone.NewDate(2026, 5, 31))
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "Tag der Arbeit", list[0].Name, "closing days must never leak into HolidaysInRange")
+}
+
+func TestNonWorkingDayResolverPropagatesErrors(t *testing.T) {
+	resolver := NewNonWorkingDayResolver(
+		&stubHolidayService{err: errors.New("holiday boom")},
+		&stubClosingDayService{},
+	)
+	_, err := resolver.HolidayDates(context.Background(), timezone.NewDate(2026, 5, 1), timezone.NewDate(2026, 5, 31))
+	require.Error(t, err)
+
+	resolver = NewNonWorkingDayResolver(
+		&stubHolidayService{dates: map[timezone.Date]bool{}},
+		&stubClosingDayService{err: errors.New("closing boom")},
+	)
+	_, err = resolver.HolidayDates(context.Background(), timezone.NewDate(2026, 5, 1), timezone.NewDate(2026, 5, 31))
+	require.Error(t, err)
+}

--- a/backend/services/schedule/scheduletest/mocks.go
+++ b/backend/services/schedule/scheduletest/mocks.go
@@ -1,0 +1,73 @@
+// Package scheduletest provides shared test doubles for schedule services.
+package scheduletest
+
+import (
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
+)
+
+// ClosingDayServiceMock is a func-field test double for
+// schedule.ClosingDayService. Nil functions return zero values.
+type ClosingDayServiceMock struct {
+	GetAllFn             func(ctx context.Context) ([]*scheduleModel.ClosingDay, error)
+	GetByIDFn            func(ctx context.Context, id int64) (*scheduleModel.ClosingDay, error)
+	CreateFn             func(ctx context.Context, day *scheduleModel.ClosingDay) error
+	UpdateFn             func(ctx context.Context, day *scheduleModel.ClosingDay) error
+	DeleteFn             func(ctx context.Context, id int64) error
+	ClosingDaysInRangeFn func(ctx context.Context, from, to timezone.Date) ([]*scheduleModel.ClosingDay, error)
+	ClosingDayDatesFn    func(ctx context.Context, from, to timezone.Date) (map[timezone.Date]bool, error)
+}
+
+var _ scheduleService.ClosingDayService = (*ClosingDayServiceMock)(nil)
+
+func (m *ClosingDayServiceMock) GetAll(ctx context.Context) ([]*scheduleModel.ClosingDay, error) {
+	if m.GetAllFn != nil {
+		return m.GetAllFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *ClosingDayServiceMock) GetByID(ctx context.Context, id int64) (*scheduleModel.ClosingDay, error) {
+	if m.GetByIDFn != nil {
+		return m.GetByIDFn(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *ClosingDayServiceMock) Create(ctx context.Context, day *scheduleModel.ClosingDay) error {
+	if m.CreateFn != nil {
+		return m.CreateFn(ctx, day)
+	}
+	return nil
+}
+
+func (m *ClosingDayServiceMock) Update(ctx context.Context, day *scheduleModel.ClosingDay) error {
+	if m.UpdateFn != nil {
+		return m.UpdateFn(ctx, day)
+	}
+	return nil
+}
+
+func (m *ClosingDayServiceMock) Delete(ctx context.Context, id int64) error {
+	if m.DeleteFn != nil {
+		return m.DeleteFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *ClosingDayServiceMock) ClosingDaysInRange(ctx context.Context, from, to timezone.Date) ([]*scheduleModel.ClosingDay, error) {
+	if m.ClosingDaysInRangeFn != nil {
+		return m.ClosingDaysInRangeFn(ctx, from, to)
+	}
+	return nil, nil
+}
+
+func (m *ClosingDayServiceMock) ClosingDayDates(ctx context.Context, from, to timezone.Date) (map[timezone.Date]bool, error) {
+	if m.ClosingDayDatesFn != nil {
+		return m.ClosingDayDatesFn(ctx, from, to)
+	}
+	return nil, nil
+}

--- a/backend/test/hermetic_verification_test.go
+++ b/backend/test/hermetic_verification_test.go
@@ -173,6 +173,7 @@ func checkHardcodedIDs(t *testing.T, root string) []string {
 		"api/iot/config_test.go",                                 // Uses mock settings service for unit testing config endpoint
 		"enrich_pickup_times_test.go",                            // Uses mock PickupScheduleService for unit testing enrichment
 		"api/timetable/api_test.go",                              // Uses mock CalendarPeriodService for unit testing handlers
+		"api/timetable/closing_days_test.go",                     // Uses mock ClosingDayService for unit testing handlers; int64 literals are fake IDs, not DB rows
 		"api/timetable/instances_test.go",                        // Uses mock InstanceService + PersonService for unit testing handlers
 		"api/timetable/understaffed_test.go",                     // Uses mock InstanceService for unit testing the acknowledge-understaffed handler (no DB); int64 literals are fake instance IDs, not DB rows
 		"api/timetable/instance_students_unit_test.go",           // Uses fake repo for unit testing attendance PATCH handler

--- a/frontend/src/app/[tenant]/(protected)/calendar-periods/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/calendar-periods/page.test.tsx
@@ -13,6 +13,10 @@ vi.mock("~/components/planning/calendar-periods-editor", () => ({
   CalendarPeriodsEditor: () => <div data-testid="calendar-periods-editor" />,
 }));
 
+vi.mock("~/components/planning/closing-days-editor", () => ({
+  ClosingDaysEditor: () => <div data-testid="closing-days-editor" />,
+}));
+
 vi.mock("~/components/ui/loading", () => ({
   Loading: () => <div data-testid="loading" />,
 }));

--- a/frontend/src/app/[tenant]/(protected)/calendar-periods/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/calendar-periods/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CalendarPeriodsEditor } from "~/components/planning/calendar-periods-editor";
+import { ClosingDaysEditor } from "~/components/planning/closing-days-editor";
 import { Loading } from "~/components/ui/loading";
 import { DesktopOnlyNotice } from "~/components/ui/desktop-only-notice";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
@@ -19,8 +20,14 @@ export default function CalendarPeriodsPage() {
   return (
     <div className="-mt-1.5 w-full">
       <DesktopOnlyNotice />
-      <div className="hidden lg:block">
+      <div className="hidden space-y-8 lg:block">
         <CalendarPeriodsEditor />
+        <section>
+          <h2 className="mb-3 text-base font-semibold text-gray-900">
+            Schließtage
+          </h2>
+          <ClosingDaysEditor />
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -1631,6 +1631,13 @@ function OwnZeiterfassungSection({
     () => timeTrackingService.getHolidays(visibleFromKey, visibleToKey),
     { keepPreviousData: true, revalidateOnFocus: false },
   );
+  // OGS-Schließtage im sichtbaren Zeitraum (#1418 3b): eigenes Badge in der
+  // Tabelle, Soll kommt bereits als 0 vom Server.
+  const { data: tableClosingDays } = useSWRAuth(
+    `time-tracking-closing-days-${visibleFromKey}-${visibleToKey}`,
+    () => timeTrackingService.getClosingDays(visibleFromKey, visibleToKey),
+    { keepPreviousData: true, revalidateOnFocus: false },
+  );
 
   const {
     data: monthSummary,
@@ -1878,6 +1885,7 @@ function OwnZeiterfassungSection({
             dailyTargetsError={dailyTargetsError != null}
             dailyTargetsPending={dailyTargetsLoading}
             holidays={tableHolidays}
+            closingDays={tableClosingDays}
             accountStartDate={timeTrackingConfig?.accountStartDate ?? null}
             accountStartDatePending={timeTrackingConfigLoading}
             accountStartDateError={

--- a/frontend/src/app/api/time-tracking/closing-days/route.ts
+++ b/frontend/src/app/api/time-tracking/closing-days/route.ts
@@ -1,0 +1,8 @@
+import { proxyGet } from "~/lib/route-proxy.server";
+
+/**
+ * GET /api/time-tracking/closing-days?from=&to=
+ * OGS-Schließtage des Tenants (schedule.closing_days) für die
+ * Kalender-Markierung in der Zeiterfassung (#1418 3b).
+ */
+export const GET = proxyGet("/api/time-tracking/closing-days");

--- a/frontend/src/app/api/timetable/closing-days/[id]/route.ts
+++ b/frontend/src/app/api/timetable/closing-days/[id]/route.ts
@@ -1,0 +1,17 @@
+// app/api/timetable/closing-days/[id]/route.ts
+//
+// PUT    /api/timetable/closing-days/{id} — update a closing day range
+// DELETE /api/timetable/closing-days/{id} — remove a closing day range
+//
+// Both strip the Go envelope ({ status, data, message }) so route-wrapper
+// produces a single envelope on the wire.
+import { proxyDelete, proxyPut } from "~/lib/route-proxy.server";
+import { requirePathSegmentParam } from "~/lib/route-wrapper-utils.server";
+
+export const PUT = proxyPut(
+  (params) => `/api/timetable/closing-days/${requirePathSegmentParam(params)}`,
+);
+
+export const DELETE = proxyDelete(
+  (params) => `/api/timetable/closing-days/${requirePathSegmentParam(params)}`,
+);

--- a/frontend/src/app/api/timetable/closing-days/route.ts
+++ b/frontend/src/app/api/timetable/closing-days/route.ts
@@ -1,0 +1,13 @@
+// app/api/timetable/closing-days/route.ts
+//
+// GET  /api/timetable/closing-days  - list all closing day ranges for the tenant
+// POST /api/timetable/closing-days  - create a new closing day range
+//
+// The Go backend (api/timetable/closing_days.go) wraps responses in
+// { status, data, message }. The proxies strip that envelope so
+// route-wrapper does not double-wrap the payload.
+import { proxyGet, proxyPost } from "~/lib/route-proxy.server";
+
+export const GET = proxyGet("/api/timetable/closing-days");
+
+export const POST = proxyPost("/api/timetable/closing-days");

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -756,6 +756,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Beim Anlegen einer `Anmeldephase` kann der Zeitraum ausgewählt werden; Beginn und Ende der Phase werden daraus übernommen.",
           "Die Verknüpfung geht auch andersherum: Beim Bearbeiten eines Zeitraums lassen sich unter `Verknüpfte Anmeldephasen` Phasen direkt an- und abwählen.",
           "Die Spalte `Verwendung` zeigt, welche Anmeldephasen und Regeltermine auf einen Zeitraum verweisen.",
+          "Im Abschnitt `Schließtage` darunter die OGS-Schließtage pflegen (z. B. pädagogische Tage, Weihnachtswoche, Sommerschließung): `Schließtag anlegen` klicken, Zeitraum und Grund eintragen. Für einen einzelnen Tag dasselbe Datum in `Von` und `Bis` wählen. An Schließtagen gilt in der Zeiterfassung für alle Mitarbeitenden Soll = 0, genau wie an gesetzlichen Feiertagen.",
         ],
         callout: {
           title: "Betreuungsplan ohne Planungszeitraum",
@@ -944,6 +945,7 @@ export const appChapters: readonly GuideChapter[] = [
           "In der Monatsansicht die eigene `Monatskarte` prüfen: Übertrag aus dem Vormonat, Summe Soll, Summe Ist, Gutschriften für Krankheit und Urlaub sowie der Monatssaldo stehen dort zusammen.",
           "Tageszeilen prüfen: Plan (geplante Schicht), Check-in, Check-out, Pause, Soll, Ist, Saldo, Status, Quelle und Hinweise zeigen, ob ein Tag vollständig erfasst wurde.",
           "Gesetzliche Feiertage (nach dem Bundesland der Einrichtung) tragen das Badge `Feiertag`. An diesen Tagen ist das Soll automatisch 0, es entstehen also keine Minusstunden. Wird an einem Feiertag trotzdem gestempelt, erscheint der Hinweis `Feiertagsarbeit`.",
+          "Von der Einrichtung hinterlegte OGS-Schließtage (z. B. pädagogische Tage oder die Sommerschließung) tragen das Badge `Schließtag` und setzen das Soll ebenfalls auf 0. Fällt ein Schließtag auf einen Feiertag, zeigt die Zeile das Feiertag-Badge.",
           "Über das Stift-Symbol eigene Arbeitszeiteinträge korrigieren oder fehlende Arbeitstage nachtragen. Bei jeder Arbeitszeit-Korrektur einen Grund angeben.",
           "Geänderte Tage aufklappen, um die Änderungshistorie zu sehen. Für Auswertungen den Export im Tabellenkopf nutzen.",
         ],

--- a/frontend/src/components/planning/closing-day-modal.test.tsx
+++ b/frontend/src/components/planning/closing-day-modal.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ClosingDay } from "~/lib/closing-day-helpers";
+
+const { mockCreate, mockUpdate } = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock("~/lib/closing-day-api", () => ({
+  closingDayService: {
+    create: mockCreate,
+    update: mockUpdate,
+  },
+}));
+
+vi.mock("~/lib/logger", () => ({
+  createLogger: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock("~/components/ui/form-modal", () => ({
+  FormModal: ({
+    isOpen,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    children: ReactNode;
+    footer?: ReactNode;
+  }) =>
+    isOpen ? (
+      <div>
+        {children}
+        {footer}
+      </div>
+    ) : null,
+}));
+
+import { ClosingDayModal } from "./closing-day-modal";
+
+const existingClosingDay: ClosingDay = {
+  id: "7",
+  startDate: "2026-12-24",
+  endDate: "2026-12-31",
+  reason: "Weihnachtswoche",
+};
+
+function renderModal(initial: ClosingDay | null = null) {
+  const onClose = vi.fn();
+  const onSaved = vi.fn();
+  render(
+    <ClosingDayModal
+      isOpen
+      onClose={onClose}
+      onSaved={onSaved}
+      initial={initial}
+    />,
+  );
+  return { onClose, onSaved };
+}
+
+describe("ClosingDayModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreate.mockResolvedValue(existingClosingDay);
+    mockUpdate.mockResolvedValue(existingClosingDay);
+  });
+
+  it("creates a closing day with a trimmed reason", async () => {
+    const { onClose, onSaved } = renderModal();
+
+    fireEvent.change(screen.getByLabelText("Grund"), {
+      target: { value: "  Pädagogischer Tag  " },
+    });
+    fireEvent.change(screen.getByLabelText("Von"), {
+      target: { value: "2026-09-14" },
+    });
+    fireEvent.change(screen.getByLabelText("Bis"), {
+      target: { value: "2026-09-14" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Speichern" }));
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith({
+        start_date: "2026-09-14",
+        end_date: "2026-09-14",
+        reason: "Pädagogischer Tag",
+      }),
+    );
+    expect(onSaved).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("updates the selected closing day", async () => {
+    const { onClose, onSaved } = renderModal(existingClosingDay);
+
+    fireEvent.change(screen.getByLabelText("Grund"), {
+      target: { value: "Weihnachtsferien" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Speichern" }));
+
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith("7", {
+        start_date: "2026-12-24",
+        end_date: "2026-12-31",
+        reason: "Weihnachtsferien",
+      }),
+    );
+    expect(onSaved).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a whitespace-only reason before calling the API", () => {
+    renderModal();
+
+    fireEvent.change(screen.getByLabelText("Grund"), {
+      target: { value: "   " },
+    });
+    fireEvent.change(screen.getByLabelText("Von"), {
+      target: { value: "2026-09-14" },
+    });
+    fireEvent.change(screen.getByLabelText("Bis"), {
+      target: { value: "2026-09-14" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Speichern" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Bitte einen Grund angeben.",
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/planning/closing-day-modal.tsx
+++ b/frontend/src/components/planning/closing-day-modal.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+/**
+ * ClosingDayModal creates or edits one OGS-Schließtag range (#1418 3b).
+ * A single closed day is entered as start = end. Kept deliberately small —
+ * unlike CalendarPeriodModal there is no type, cycle, or link section.
+ */
+
+import { useEffect, useState } from "react";
+
+import { Button } from "~/components/ui/button";
+import { FormModal } from "~/components/ui/form-modal";
+import { Input } from "~/components/ui/input";
+import { closingDayService } from "~/lib/closing-day-api";
+import { type ClosingDay } from "~/lib/closing-day-helpers";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "ClosingDayModal" });
+
+export function ClosingDayModal({
+  isOpen,
+  onClose,
+  onSaved,
+  initial,
+}: {
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onSaved: () => void;
+  readonly initial: ClosingDay | null;
+}) {
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [reason, setReason] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setStartDate(initial?.startDate ?? "");
+    setEndDate(initial?.endDate ?? "");
+    setReason(initial?.reason ?? "");
+    setError(null);
+  }, [isOpen, initial]);
+
+  const validate = (): string | null => {
+    if (!reason.trim()) return "Bitte einen Grund angeben.";
+    if (!startDate) return "Bitte ein Startdatum wählen.";
+    if (!endDate) return "Bitte ein Enddatum wählen.";
+    if (endDate < startDate)
+      return "Das Enddatum darf nicht vor dem Startdatum liegen.";
+    return null;
+  };
+
+  const handleSave = async () => {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    const body = {
+      start_date: startDate,
+      end_date: endDate,
+      reason: reason.trim(),
+    };
+    try {
+      if (initial) {
+        await closingDayService.update(initial.id, body);
+      } else {
+        await closingDayService.create(body);
+      }
+      onSaved();
+      onClose();
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Schließtag konnte nicht gespeichert werden";
+      logger.error("closing_day_save_failed", { error: message });
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <FormModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={initial ? "Schließtag bearbeiten" : "Schließtag anlegen"}
+      size="md"
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" size="md" onClick={onClose}>
+            Abbrechen
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="md"
+            onClick={() => void handleSave()}
+            disabled={saving}
+          >
+            {saving ? "Speichern..." : "Speichern"}
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        {error && (
+          <div
+            className="rounded-lg border border-[#FF3130]/20 bg-[#FF3130]/10 p-3 text-sm text-[#CC2626]"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+
+        <div>
+          <label
+            htmlFor="closing-day-reason"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            Grund
+          </label>
+          <Input
+            id="closing-day-reason"
+            type="text"
+            value={reason}
+            maxLength={255}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="z. B. Pädagogischer Tag, Sommerschließung"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label
+              htmlFor="closing-day-start"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              Von
+            </label>
+            <Input
+              id="closing-day-start"
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="closing-day-end"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              Bis
+            </label>
+            <Input
+              id="closing-day-end"
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <p className="text-xs text-gray-500">
+          Für einen einzelnen Schließtag dasselbe Datum in beide Felder
+          eintragen. An Schließtagen gilt für alle Mitarbeitenden Soll = 0,
+          genau wie an gesetzlichen Feiertagen.
+        </p>
+      </div>
+    </FormModal>
+  );
+}

--- a/frontend/src/components/planning/closing-days-editor.test.tsx
+++ b/frontend/src/components/planning/closing-days-editor.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ClosingDay } from "~/lib/closing-day-helpers";
+
+const { mockList, mockDelete, mockToastSuccess, mockToastError } = vi.hoisted(
+  () => ({
+    mockList: vi.fn(),
+    mockDelete: vi.fn(),
+    mockToastSuccess: vi.fn(),
+    mockToastError: vi.fn(),
+  }),
+);
+
+vi.mock("~/contexts/ToastContext", () => ({
+  useToast: () => ({ success: mockToastSuccess, error: mockToastError }),
+}));
+
+vi.mock("~/lib/logger", () => ({
+  createLogger: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock("~/lib/closing-day-api", () => ({
+  closingDayService: {
+    list: mockList,
+    delete: mockDelete,
+  },
+}));
+
+vi.mock("~/components/planning/closing-day-modal", () => ({
+  ClosingDayModal: ({
+    isOpen,
+    initial,
+  }: {
+    isOpen: boolean;
+    initial?: ClosingDay | null;
+  }) =>
+    isOpen ? (
+      <div
+        data-testid="closing-day-modal"
+        data-initial-reason={initial?.reason ?? ""}
+      />
+    ) : null,
+}));
+
+import { ClosingDaysEditor } from "./closing-days-editor";
+
+function makeClosingDay(overrides: Partial<ClosingDay> = {}): ClosingDay {
+  return {
+    id: "3",
+    startDate: "2026-12-24",
+    endDate: "2026-12-31",
+    reason: "Weihnachtswoche",
+    ...overrides,
+  };
+}
+
+describe("ClosingDaysEditor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("zeigt die Schließtage mit Zeitraum und Grund", async () => {
+    mockList.mockResolvedValue([makeClosingDay()]);
+
+    render(<ClosingDaysEditor />);
+
+    expect(await screen.findByText("Weihnachtswoche")).toBeInTheDocument();
+    expect(screen.getByText("24.12.2026 – 31.12.2026")).toBeInTheDocument();
+  });
+
+  it("zeigt für einen Eintages-Schließtag nur ein Datum", async () => {
+    mockList.mockResolvedValue([
+      makeClosingDay({
+        startDate: "2027-02-08",
+        endDate: "2027-02-08",
+        reason: "Rosenmontag",
+      }),
+    ]);
+
+    render(<ClosingDaysEditor />);
+
+    expect(await screen.findByText("08.02.2027")).toBeInTheDocument();
+    expect(
+      screen.queryByText("08.02.2027 – 08.02.2027"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("öffnet das Modal ohne Vorbelegung beim Anlegen", async () => {
+    mockList.mockResolvedValue([]);
+
+    render(<ClosingDaysEditor />);
+
+    const createButtons = await screen.findAllByRole("button", {
+      name: /Schließtag anlegen/,
+    });
+    fireEvent.click(createButtons[0]!);
+
+    expect(screen.getByTestId("closing-day-modal")).toHaveAttribute(
+      "data-initial-reason",
+      "",
+    );
+  });
+
+  it("öffnet das Modal mit Vorbelegung beim Bearbeiten", async () => {
+    mockList.mockResolvedValue([makeClosingDay()]);
+
+    render(<ClosingDaysEditor />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Bearbeiten" }));
+
+    expect(screen.getByTestId("closing-day-modal")).toHaveAttribute(
+      "data-initial-reason",
+      "Weihnachtswoche",
+    );
+  });
+
+  it("löscht nach Bestätigung und lädt die Liste neu", async () => {
+    mockList
+      .mockResolvedValueOnce([makeClosingDay()])
+      .mockResolvedValueOnce([]);
+    mockDelete.mockResolvedValue(undefined);
+
+    render(<ClosingDaysEditor />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Löschen" }));
+    // Bestätigungsdialog: der Confirm-Button trägt ebenfalls "Löschen".
+    const confirmButtons = screen.getAllByRole("button", { name: "Löschen" });
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]!);
+
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith("3"));
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    expect(mockToastSuccess).toHaveBeenCalled();
+  });
+
+  it("zeigt den Leerzustand ohne Schließtage", async () => {
+    mockList.mockResolvedValue([]);
+
+    render(<ClosingDaysEditor />);
+
+    expect(
+      await screen.findByText("Noch keine Schließtage"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/planning/closing-days-editor.tsx
+++ b/frontend/src/components/planning/closing-days-editor.tsx
@@ -39,9 +39,7 @@ export function ClosingDaysEditor() {
     setError(null);
     try {
       const data = await closingDayService.list();
-      setClosingDays(
-        [...data].sort((a, b) => a.startDate.localeCompare(b.startDate)),
-      );
+      setClosingDays(data);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unbekannter Fehler";
       logger.error("closing_days_load_failed", { error: message });

--- a/frontend/src/components/planning/closing-days-editor.tsx
+++ b/frontend/src/components/planning/closing-days-editor.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+/**
+ * ClosingDaysEditor is the admin list for OGS-Schließtage (#1418 3b) —
+ * closure ranges (pädagogische Tage, Weihnachtswoche, Sommerschließung) the
+ * school defines on top of the gesetzliche Feiertage. Rendered as a second
+ * section on the Kalenderzeiträume page.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { CalendarOff, Plus } from "lucide-react";
+
+import { ClosingDayModal } from "~/components/planning/closing-day-modal";
+import { Button } from "~/components/ui/button";
+import { DataTable, type DataTableColumn } from "~/components/ui/data-table";
+import { ConfirmationModal } from "~/components/ui/modal";
+import { closingDayService } from "~/lib/closing-day-api";
+import {
+  type ClosingDay,
+  formatClosingDayRange,
+} from "~/lib/closing-day-helpers";
+import { useToast } from "~/contexts/ToastContext";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "ClosingDaysEditor" });
+
+export function ClosingDaysEditor() {
+  const [closingDays, setClosingDays] = useState<ClosingDay[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<ClosingDay | null>(null);
+  const [deleting, setDeleting] = useState<ClosingDay | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const { success: toastSuccess, error: toastError } = useToast();
+
+  const load = useCallback(async (opts?: { silent?: boolean }) => {
+    if (!opts?.silent) setLoading(true);
+    setError(null);
+    try {
+      const data = await closingDayService.list();
+      setClosingDays(
+        [...data].sort((a, b) => a.startDate.localeCompare(b.startDate)),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unbekannter Fehler";
+      logger.error("closing_days_load_failed", { error: message });
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const beginCreate = () => {
+    setEditing(null);
+    setModalOpen(true);
+  };
+
+  const beginEdit = useCallback((day: ClosingDay) => {
+    setEditing(day);
+    setModalOpen(true);
+  }, []);
+
+  const handleDelete = useCallback(async () => {
+    if (!deleting) return;
+    setDeleteLoading(true);
+    try {
+      await closingDayService.delete(deleting.id);
+      toastSuccess(`Schließtag "${deleting.reason}" gelöscht`);
+      setDeleting(null);
+      await load({ silent: true });
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Schließtag konnte nicht gelöscht werden";
+      logger.error("closing_day_delete_failed", {
+        closing_day_id: deleting.id,
+        error: message,
+      });
+      toastError(message);
+    } finally {
+      setDeleteLoading(false);
+    }
+  }, [deleting, load, toastSuccess, toastError]);
+
+  const columns = useMemo<DataTableColumn<ClosingDay>[]>(
+    () => [
+      {
+        key: "range",
+        header: "Von – Bis",
+        sortValue: (day) => day.startDate,
+        render: (day) => (
+          <span className="text-sm whitespace-nowrap text-gray-600">
+            {formatClosingDayRange(day)}
+          </span>
+        ),
+      },
+      {
+        key: "reason",
+        header: "Grund",
+        sortValue: (day) => day.reason,
+        render: (day) => (
+          <p className="truncate font-medium text-gray-900">{day.reason}</p>
+        ),
+      },
+      {
+        key: "actions",
+        header: "",
+        align: "right",
+        render: (day) => (
+          <div className="flex justify-end gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="compact"
+              onClick={() => beginEdit(day)}
+            >
+              Bearbeiten
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="compact"
+              className="text-[#FF3130] hover:text-[#CC2626]"
+              onClick={() => setDeleting(day)}
+            >
+              Löschen
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [beginEdit],
+  );
+
+  if (loading) {
+    return (
+      <div className="moto-content-surface rounded-2xl border px-5 py-10 text-center text-sm text-gray-500 shadow-sm">
+        Schließtage werden geladen...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div
+          className="rounded-2xl border border-[#FF3130]/20 bg-[#FF3130]/10 p-4 text-sm text-[#CC2626]"
+          role="alert"
+          aria-live="polite"
+        >
+          {error}
+        </div>
+      )}
+
+      <section className="moto-content-surface rounded-2xl border p-4 shadow-sm backdrop-blur-md">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-gray-600">
+            OGS-Schließtage (z. B. pädagogische Tage, Weihnachtswoche,
+            Sommerschließung). An diesen Tagen gilt Soll = 0 wie an gesetzlichen
+            Feiertagen.
+          </p>
+          <Button
+            type="button"
+            variant="primary"
+            size="md"
+            onClick={beginCreate}
+            className="shrink-0 gap-2"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            Schließtag anlegen
+          </Button>
+        </div>
+      </section>
+
+      {closingDays.length === 0 ? (
+        <section className="moto-content-surface rounded-2xl border px-6 py-12 text-center shadow-sm backdrop-blur-md">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-[#83CD2D]/10 text-[#669f21]">
+            <CalendarOff className="h-6 w-6" aria-hidden="true" />
+          </div>
+          <h2 className="mt-4 text-base font-semibold text-gray-900">
+            Noch keine Schließtage
+          </h2>
+          <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-gray-600">
+            Hinterlege die Schließtage des Schuljahres, damit die Zeiterfassung
+            an diesen Tagen kein Soll ansetzt.
+          </p>
+          <Button
+            type="button"
+            variant="primary"
+            size="md"
+            onClick={beginCreate}
+            className="mt-5 gap-2"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            Schließtag anlegen
+          </Button>
+        </section>
+      ) : (
+        <DataTable
+          columns={columns}
+          rows={closingDays}
+          getRowKey={(day) => day.id}
+          defaultSortKey="range"
+          defaultSortDirection="asc"
+        />
+      )}
+
+      <ClosingDayModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSaved={() => void load({ silent: true })}
+        initial={editing}
+      />
+
+      <ConfirmationModal
+        isOpen={deleting !== null}
+        onClose={() => setDeleting(null)}
+        onConfirm={() => void handleDelete()}
+        title="Schließtag löschen"
+        confirmText="Löschen"
+        isConfirmLoading={deleteLoading}
+        confirmButtonClass="bg-[#FF3130] hover:bg-[#CC2626]"
+      >
+        {deleting && (
+          <p>
+            Soll der Schließtag &quot;{deleting.reason}&quot; (
+            {formatClosingDayRange(deleting)}) wirklich gelöscht werden? Das
+            Soll dieser Tage wird danach wieder regulär berechnet.
+          </p>
+        )}
+      </ConfirmationModal>
+    </div>
+  );
+}

--- a/frontend/src/components/staff/staff-session-table.targets.test.tsx
+++ b/frontend/src/components/staff/staff-session-table.targets.test.tsx
@@ -242,6 +242,7 @@ describe("StaffSessionTable Wochenendtage", () => {
     plannedShifts?: readonly StaffShift[];
     absences?: readonly StaffAbsenceRow[];
     holidays?: ReadonlyMap<string, string>;
+    closingDays?: ReadonlyMap<string, string>;
   };
 
   function WeekendTable(props: WeekendTableProps) {
@@ -257,6 +258,7 @@ describe("StaffSessionTable Wochenendtage", () => {
         accountStartDate="2026-01-08"
         dailyTargets={weekendTargets}
         holidays={props.holidays}
+        closingDays={props.closingDays}
         today={today}
         isAdminView
         accountStartDatePending={false}
@@ -292,6 +294,34 @@ describe("StaffSessionTable Wochenendtage", () => {
       "Ostersonntag",
     );
     expect(screen.queryByText("10.01.")).not.toBeInTheDocument();
+  });
+
+  // #1418 3b: Schließtage verhalten sich wie Feiertage (Soll 0, eigenes
+  // Badge), stehen aber bei Überschneidung hinter dem Feiertag zurück.
+  it("zeigt einen Schließtag am Wochenende mit Badge und Grund", () => {
+    renderWeekend({
+      closingDays: new Map([["2026-01-10", "Pädagogischer Tag"]]),
+    });
+
+    const row = screen.getByText("10.01.").closest("tr");
+    expect(row).not.toBeNull();
+    expect(within(row!).getByText("Schließtag")).toHaveAttribute(
+      "title",
+      "Pädagogischer Tag",
+    );
+    expect(screen.queryByText("11.01.")).not.toBeInTheDocument();
+  });
+
+  it("lässt den Feiertag gewinnen, wenn Feiertag und Schließtag zusammenfallen", () => {
+    renderWeekend({
+      holidays: new Map([["2026-01-11", "Ostersonntag"]]),
+      closingDays: new Map([["2026-01-11", "Ferienschließung"]]),
+    });
+
+    const row = screen.getByText("11.01.").closest("tr");
+    expect(row).not.toBeNull();
+    expect(within(row!).getByText("Feiertag")).toBeInTheDocument();
+    expect(within(row!).queryByText("Schließtag")).not.toBeInTheDocument();
   });
 
   it("zeigt einen Samstag mit Session als Zeile", () => {

--- a/frontend/src/components/staff/staff-session-table.tsx
+++ b/frontend/src/components/staff/staff-session-table.tsx
@@ -59,6 +59,7 @@ export function StaffSessionTable({
   dailyTargetsError,
   dailyTargetsPending,
   holidays,
+  closingDays,
   accountStartDate,
   accountStartDatePending,
   accountStartDateError,
@@ -99,6 +100,12 @@ export function StaffSessionTable({
   // Feiertagsarbeit-Warnung (§9 ArbZG). Das Soll dieser Tage kommt bereits
   // als 0 vom Server — die Map ist reine Anzeige, keine Rechengrundlage.
   readonly holidays?: ReadonlyMap<string, string>;
+  // OGS-Schließtage im sichtbaren Zeitraum, keyed YYYY-MM-DD → Grund
+  // (#1418 3b). Analog zu den Feiertagen: eigenes Status-Badge statt "Nicht
+  // erfasst", Soll kommt bereits als 0 vom Server, die Map ist reine
+  // Anzeige. Bei Überschneidung gewinnt der Feiertag (gesetzliche Grundlage
+  // vor Schulentscheidung).
+  readonly closingDays?: ReadonlyMap<string, string>;
   // `null` means no time-tracking config data is available; pending/error
   // distinguish whether that is temporary or a failed request. An empty
   // string means the loaded config has no explicit anchor. The distinction
@@ -234,6 +241,7 @@ export function StaffSessionTable({
           absencesByDate.has(key) ||
           (shiftsByDate.get(key)?.length ?? 0) > 0 ||
           holidays?.has(key) === true ||
+          closingDays?.has(key) === true ||
           displayed > 0 ||
           (unresolved && planned > 0);
         if (!hasContent) continue;
@@ -248,6 +256,7 @@ export function StaffSessionTable({
     absencesByDate,
     shiftsByDate,
     holidays,
+    closingDays,
     resolveDayTarget,
   ]);
 
@@ -326,6 +335,7 @@ export function StaffSessionTable({
               const session = sessionsByDate.get(key);
               const absence = absencesByDate.get(key);
               const holidayName = holidays?.get(key);
+              const closingReason = closingDays?.get(key);
               // Ein fehlgeschlagener ODER noch laufender Targets-Fetch darf
               // NICHT auf den aktuellen Plan zurückfallen (#1842): der Tag
               // bleibt ungelöst, damit die Tabelle keinen erfundenen
@@ -355,6 +365,7 @@ export function StaffSessionTable({
                 session,
                 absence,
                 holidayName,
+                closingReason,
                 target,
                 isFuture,
               );
@@ -650,6 +661,7 @@ type RowStatus =
   | { kind: "home-office" }
   | { kind: "absence"; absenceType: string }
   | { kind: "holiday"; name: string }
+  | { kind: "closing"; reason: string }
   | { kind: "missing" };
 
 // Renders the planned Dienstplan window(s) for one day: each active shift as
@@ -687,6 +699,7 @@ function computeRowStatus(
   session: StaffHistorySession | undefined,
   absence: StaffAbsenceRow | undefined,
   holidayName: string | undefined,
+  closingReason: string | undefined,
   target: number,
   isFuture: boolean,
 ): RowStatus | null {
@@ -702,6 +715,11 @@ function computeRowStatus(
   // Feiertagsarbeit hint.
   if (holidayName) {
     return { kind: "holiday", name: holidayName };
+  }
+  // Schließtag behaves like a holiday (Soll 0 for everyone, #1418 3b) but
+  // ranks below it: on overlap the gesetzliche Feiertag names the day.
+  if (closingReason) {
+    return { kind: "closing", reason: closingReason };
   }
   // Absence wins over "missing" so an admin sees Krank/Urlaub instead of a
   // misleading "Nicht erfasst" badge (the MA-side already does this).
@@ -756,6 +774,16 @@ function StatusBadge({ status }: { readonly status: RowStatus }) {
         className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
       >
         Feiertag
+      </span>
+    );
+  }
+  if (status.kind === "closing") {
+    return (
+      <span
+        title={status.reason}
+        className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600"
+      >
+        Schließtag
       </span>
     );
   }

--- a/frontend/src/components/staff/zeiterfassung-tab.tsx
+++ b/frontend/src/components/staff/zeiterfassung-tab.tsx
@@ -157,6 +157,14 @@ export function ZeiterfassungTab({ staffId }: { readonly staffId: string }) {
     { keepPreviousData: true, revalidateOnFocus: false },
   );
 
+  // OGS-Schließtage im sichtbaren Zeitraum (#1418 3b), analog zu den
+  // Feiertagen tenant-global über denselben Endpunkt-Pfad.
+  const { data: tableClosingDays } = useSWRAuth(
+    `time-tracking-closing-days-${visibleFromKey}-${visibleToKey}`,
+    () => timeTrackingService.getClosingDays(visibleFromKey, visibleToKey),
+    { keepPreviousData: true, revalidateOnFocus: false },
+  );
+
   // Monatskarte (#1842): server-computed month aggregate, only fetched in
   // month mode. Everything is live — the Übertrag recomputes automatically
   // when past months are corrected. Edits and backfills invalidate this key
@@ -301,6 +309,7 @@ export function ZeiterfassungTab({ staffId }: { readonly staffId: string }) {
               dailyTargetsError={dailyTargetsError != null}
               dailyTargetsPending={dailyTargetsLoading}
               holidays={tableHolidays}
+              closingDays={tableClosingDays}
               accountStartDate={timeTrackingConfig?.accountStartDate ?? null}
               accountStartDatePending={timeTrackingConfigLoading}
               accountStartDateError={

--- a/frontend/src/lib/closing-day-api.test.ts
+++ b/frontend/src/lib/closing-day-api.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/lib/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+import { closingDayService } from "./closing-day-api";
+import { formatClosingDayRange } from "./closing-day-helpers";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+const backendDay = {
+  id: 7,
+  start_date: "2026-12-24",
+  end_date: "2026-12-31",
+  reason: "Weihnachtsschließung",
+  created_at: "2026-07-01T08:00:00Z",
+  updated_at: "2026-07-01T08:00:00Z",
+};
+
+describe("closingDayService", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("lists and maps closing days", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [backendDay] }));
+
+    await expect(closingDayService.list()).resolves.toEqual([
+      {
+        id: "7",
+        startDate: "2026-12-24",
+        endDate: "2026-12-31",
+        reason: "Weihnachtsschließung",
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/timetable/closing-days",
+      expect.objectContaining({ method: "GET", credentials: "include" }),
+    );
+  });
+
+  it("lists to an empty array when the backend returns null data", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: null }));
+
+    await expect(closingDayService.list()).resolves.toEqual([]);
+  });
+
+  it("creates and updates a closing day with the expected body", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ data: backendDay }))
+      .mockResolvedValueOnce(jsonResponse({ data: backendDay }));
+
+    const body = {
+      start_date: "2026-12-24",
+      end_date: "2026-12-31",
+      reason: "Weihnachtsschließung",
+    };
+
+    await expect(closingDayService.create(body)).resolves.toMatchObject({
+      id: "7",
+    });
+    await expect(closingDayService.update("7", body)).resolves.toMatchObject({
+      id: "7",
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/timetable/closing-days",
+      expect.objectContaining({ method: "POST", body: JSON.stringify(body) }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/timetable/closing-days/7",
+      expect.objectContaining({ method: "PUT", body: JSON.stringify(body) }),
+    );
+  });
+
+  it("deletes closing days and accepts 204 without JSON", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await expect(closingDayService.delete("7")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/timetable/closing-days/7",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("surfaces backend error messages and generic non-JSON failures", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ error: "Zeitraum überlappt" }, { status: 409 }),
+    );
+    await expect(closingDayService.list()).rejects.toMatchObject({
+      message: "Zeitraum überlappt",
+      httpStatus: 409,
+    });
+
+    fetchMock.mockResolvedValueOnce(
+      new Response("bad gateway", {
+        status: 502,
+        headers: { "Content-Type": "text/plain" },
+      }),
+    );
+    await expect(closingDayService.delete("7")).rejects.toMatchObject({
+      message: "Anfrage fehlgeschlagen (HTTP 502)",
+      httpStatus: 502,
+    });
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ error: "Grund fehlt" }, { status: 400 }),
+    );
+    await expect(closingDayService.delete("7")).rejects.toMatchObject({
+      message: "Grund fehlt",
+      httpStatus: 400,
+    });
+  });
+});
+
+describe("formatClosingDayRange", () => {
+  it("collapses single-day ranges and joins multi-day ranges", () => {
+    expect(
+      formatClosingDayRange({
+        id: "1",
+        startDate: "2026-05-15",
+        endDate: "2026-05-15",
+        reason: "Pädagogischer Tag",
+      }),
+    ).toBe("15.05.2026");
+    expect(
+      formatClosingDayRange({
+        id: "2",
+        startDate: "2026-12-24",
+        endDate: "2026-12-31",
+        reason: "Weihnachtsschließung",
+      }),
+    ).toBe("24.12.2026 – 31.12.2026");
+  });
+});

--- a/frontend/src/lib/closing-day-api.ts
+++ b/frontend/src/lib/closing-day-api.ts
@@ -1,0 +1,113 @@
+// Closing day API client (#1418 3b). Talks to the Next.js proxy at
+// /api/timetable/closing-days, which forwards to the Go backend
+// /api/timetable/closing-days (CRUD via SchedulesRead/Create/Update/Delete).
+
+import { createLogger } from "~/lib/logger";
+import {
+  type BackendClosingDay,
+  type ClosingDay,
+  type ClosingDayInput,
+  mapClosingDay,
+  mapClosingDays,
+} from "./closing-day-helpers";
+
+const logger = createLogger({ component: "ClosingDayApi" });
+
+interface ApiEnvelope<T> {
+  status?: string;
+  message?: string;
+  data: T;
+}
+
+class ClosingDayApiError extends Error {
+  readonly httpStatus: number;
+
+  constructor(message: string, httpStatus: number) {
+    super(message);
+    this.name = "ClosingDayApiError";
+    this.httpStatus = httpStatus;
+  }
+}
+
+async function unwrap<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    let message = `Anfrage fehlgeschlagen (HTTP ${response.status})`;
+    try {
+      const body = (await response.json()) as { error?: string };
+      if (body.error) message = body.error;
+    } catch {
+      // Body wasn't JSON — keep the generic message.
+    }
+    throw new ClosingDayApiError(message, response.status);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const envelope = (await response.json()) as ApiEnvelope<T>;
+  return envelope.data;
+}
+
+class ClosingDayService {
+  async list(): Promise<ClosingDay[]> {
+    const response = await fetch("/api/timetable/closing-days", {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      credentials: "include",
+    });
+    const raw = await unwrap<BackendClosingDay[]>(response);
+    return mapClosingDays(raw ?? []);
+  }
+
+  async create(body: ClosingDayInput): Promise<ClosingDay> {
+    const response = await fetch("/api/timetable/closing-days", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify(body),
+    });
+    const raw = await unwrap<BackendClosingDay>(response);
+    logger.info("closing_day_created", { closing_day_id: raw.id });
+    return mapClosingDay(raw);
+  }
+
+  async update(id: string, body: ClosingDayInput): Promise<ClosingDay> {
+    const response = await fetch(`/api/timetable/closing-days/${id}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify(body),
+    });
+    const raw = await unwrap<BackendClosingDay>(response);
+    logger.info("closing_day_updated", { closing_day_id: raw.id });
+    return mapClosingDay(raw);
+  }
+
+  async delete(id: string): Promise<void> {
+    const response = await fetch(`/api/timetable/closing-days/${id}`, {
+      method: "DELETE",
+      headers: { Accept: "application/json" },
+      credentials: "include",
+    });
+    if (!response.ok && response.status !== 204) {
+      let message = `Anfrage fehlgeschlagen (HTTP ${response.status})`;
+      try {
+        const body = (await response.json()) as { error?: string };
+        if (body.error) message = body.error;
+      } catch {
+        // not JSON
+      }
+      throw new ClosingDayApiError(message, response.status);
+    }
+    logger.info("closing_day_deleted", { closing_day_id: id });
+  }
+}
+
+export const closingDayService = new ClosingDayService();

--- a/frontend/src/lib/closing-day-api.ts
+++ b/frontend/src/lib/closing-day-api.ts
@@ -96,16 +96,7 @@ class ClosingDayService {
       headers: { Accept: "application/json" },
       credentials: "include",
     });
-    if (!response.ok && response.status !== 204) {
-      let message = `Anfrage fehlgeschlagen (HTTP ${response.status})`;
-      try {
-        const body = (await response.json()) as { error?: string };
-        if (body.error) message = body.error;
-      } catch {
-        // not JSON
-      }
-      throw new ClosingDayApiError(message, response.status);
-    }
+    await unwrap<void>(response);
     logger.info("closing_day_deleted", { closing_day_id: id });
   }
 }

--- a/frontend/src/lib/closing-day-helpers.ts
+++ b/frontend/src/lib/closing-day-helpers.ts
@@ -1,0 +1,56 @@
+// OGS-Schließtage (#1418 3b) — domain types and mappers.
+//
+// Closing days are tenant-defined closure ranges (pädagogische Tage,
+// Weihnachtswoche, Sommerschließung) on top of the computed public holidays.
+// On these days the backend resolves the staff Soll to 0, exactly like on
+// holidays.
+//
+// Backend reference: backend/models/schedule/closing_day.go,
+// backend/api/timetable/closing_days.go (ClosingDayRequest / Response).
+
+import { formatDate } from "~/lib/date-helpers";
+
+/** Backend wire shape (snake_case, int64 IDs). */
+export interface BackendClosingDay {
+  id: number;
+  start_date: string; // YYYY-MM-DD
+  end_date: string; // YYYY-MM-DD
+  reason: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ClosingDay {
+  id: string;
+  startDate: string; // YYYY-MM-DD
+  endDate: string; // YYYY-MM-DD
+  reason: string;
+}
+
+/** Create/update payload — matches ClosingDayRequest on the backend. */
+export interface ClosingDayInput {
+  start_date: string;
+  end_date: string;
+  reason: string;
+}
+
+export function mapClosingDay(data: BackendClosingDay): ClosingDay {
+  return {
+    id: data.id.toString(),
+    startDate: data.start_date.slice(0, 10),
+    endDate: data.end_date.slice(0, 10),
+    reason: data.reason,
+  };
+}
+
+export function mapClosingDays(data: BackendClosingDay[]): ClosingDay[] {
+  return data.map(mapClosingDay);
+}
+
+/** "24.12.2026 – 31.12.2026", collapsed to one date for single-day ranges. */
+export function formatClosingDayRange(day: ClosingDay): string {
+  if (day.startDate === day.endDate) {
+    return formatDate(day.startDate);
+  }
+  return `${formatDate(day.startDate)} – ${formatDate(day.endDate)}`;
+}

--- a/frontend/src/lib/time-tracking-api.test.ts
+++ b/frontend/src/lib/time-tracking-api.test.ts
@@ -340,6 +340,51 @@ describe("TimeTrackingService", () => {
     });
   });
 
+  describe("getClosingDays", () => {
+    it("sends the date range and expands ranges day-wise", async () => {
+      global.fetch = mockFetchResponse({
+        success: true,
+        message: "",
+        data: [
+          {
+            start_date: "2026-12-24",
+            end_date: "2026-12-26",
+            reason: "Weihnachtsschließung",
+          },
+        ],
+      });
+
+      const result = await timeTrackingService.getClosingDays(
+        "2026-12-01",
+        "2026-12-31",
+      );
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/time-tracking/closing-days?from=2026-12-01&to=2026-12-31",
+        expect.objectContaining({ method: "GET" }),
+      );
+      expect(result).toEqual(
+        new Map([
+          ["2026-12-24", "Weihnachtsschließung"],
+          ["2026-12-25", "Weihnachtsschließung"],
+          ["2026-12-26", "Weihnachtsschließung"],
+        ]),
+      );
+    });
+
+    it("returns an empty map when the backend returns null", async () => {
+      global.fetch = mockFetchResponse({
+        success: true,
+        message: "",
+        data: null,
+      });
+
+      await expect(
+        timeTrackingService.getClosingDays("2026-12-01", "2026-12-31"),
+      ).resolves.toEqual(new Map());
+    });
+  });
+
   describe("updateSession", () => {
     it("sends PUT with updates and returns mapped session", async () => {
       global.fetch = mockFetchResponse({

--- a/frontend/src/lib/time-tracking-api.test.ts
+++ b/frontend/src/lib/time-tracking-api.test.ts
@@ -383,6 +383,29 @@ describe("TimeTrackingService", () => {
         timeTrackingService.getClosingDays("2026-12-01", "2026-12-31"),
       ).resolves.toEqual(new Map());
     });
+
+    it("maps the visible part of a stored range that starts over 400 days earlier", async () => {
+      global.fetch = mockFetchResponse({
+        success: true,
+        message: "",
+        data: [
+          {
+            start_date: "2020-01-01",
+            end_date: "2030-12-31",
+            reason: "Langzeit-Schließung",
+          },
+        ],
+      });
+
+      const result = await timeTrackingService.getClosingDays(
+        "2026-12-01",
+        "2026-12-31",
+      );
+
+      expect(result.size).toBe(31);
+      expect(result.get("2026-12-01")).toBe("Langzeit-Schließung");
+      expect(result.get("2026-12-31")).toBe("Langzeit-Schließung");
+    });
   });
 
   describe("updateSession", () => {

--- a/frontend/src/lib/time-tracking-api.ts
+++ b/frontend/src/lib/time-tracking-api.ts
@@ -3,6 +3,7 @@
 import { getSession } from "next-auth/react";
 import { buildApiError } from "./auth-api";
 import type {
+  BackendClosingDayRange,
   BackendDailyTarget,
   BackendHoliday,
   BackendMonthSummary,
@@ -15,6 +16,7 @@ import type {
   WorkSessionHistory,
 } from "./time-tracking-helpers";
 import {
+  mapClosingDaysResponse,
   mapDailyTargetsResponse,
   mapHistoryResponse,
   mapHolidaysResponse,
@@ -252,6 +254,22 @@ class TimeTrackingService {
       "Failed to get holidays",
     );
     return mapHolidaysResponse(result.data);
+  }
+
+  // OGS-Schließtage des Tenants (#1418 3b), keyed YYYY-MM-DD → Grund.
+  // Tenant-global wie die Feiertage; das Backend liefert Zeiträume, der
+  // Mapper expandiert sie tageweise.
+  async getClosingDays(
+    from: string,
+    to: string,
+  ): Promise<ReadonlyMap<string, string>> {
+    const params = new URLSearchParams({ from, to });
+    const result = await this.request<BackendClosingDayRange[] | null>(
+      `/closing-days?${params}`,
+      "GET",
+      "Failed to get closing days",
+    );
+    return mapClosingDaysResponse(result.data);
   }
 
   async updateSession(

--- a/frontend/src/lib/time-tracking-api.ts
+++ b/frontend/src/lib/time-tracking-api.ts
@@ -269,7 +269,7 @@ class TimeTrackingService {
       "GET",
       "Failed to get closing days",
     );
-    return mapClosingDaysResponse(result.data);
+    return mapClosingDaysResponse(result.data, from, to);
   }
 
   async updateSession(

--- a/frontend/src/lib/time-tracking-helpers.test.ts
+++ b/frontend/src/lib/time-tracking-helpers.test.ts
@@ -19,6 +19,7 @@ import {
   getWeekNumber,
   getComplianceWarnings,
   calculateNetMinutes,
+  mapClosingDaysResponse,
   mapHistoryResponse,
   mapHolidaysResponse,
 } from "./time-tracking-helpers";
@@ -315,6 +316,59 @@ describe("mapHolidaysResponse", () => {
 
   it.each([null, undefined])("returns an empty map for %s", (data) => {
     expect(mapHolidaysResponse(data)).toEqual(new Map());
+  });
+});
+
+describe("mapClosingDaysResponse", () => {
+  it("expands ranges into per-day entries with the reason", () => {
+    const result = mapClosingDaysResponse([
+      {
+        start_date: "2026-12-24",
+        end_date: "2026-12-27",
+        reason: "Weihnachtswoche",
+      },
+      {
+        start_date: "2027-02-08",
+        end_date: "2027-02-08",
+        reason: "Rosenmontag",
+      },
+    ]);
+
+    expect(result).toEqual(
+      new Map([
+        ["2026-12-24", "Weihnachtswoche"],
+        ["2026-12-25", "Weihnachtswoche"],
+        ["2026-12-26", "Weihnachtswoche"],
+        ["2026-12-27", "Weihnachtswoche"],
+        ["2027-02-08", "Rosenmontag"],
+      ]),
+    );
+  });
+
+  it("keeps the first reason when ranges overlap", () => {
+    const result = mapClosingDaysResponse([
+      { start_date: "2026-07-20", end_date: "2026-07-24", reason: "Sommer A" },
+      { start_date: "2026-07-24", end_date: "2026-07-28", reason: "Sommer B" },
+    ]);
+
+    expect(result.get("2026-07-24")).toBe("Sommer A");
+    expect(result.get("2026-07-25")).toBe("Sommer B");
+  });
+
+  it("crosses the DST boundary without skipping or doubling days", () => {
+    const result = mapClosingDaysResponse([
+      { start_date: "2026-03-28", end_date: "2026-03-30", reason: "Umbau" },
+    ]);
+
+    expect([...result.keys()]).toEqual([
+      "2026-03-28",
+      "2026-03-29",
+      "2026-03-30",
+    ]);
+  });
+
+  it.each([null, undefined])("returns an empty map for %s", (data) => {
+    expect(mapClosingDaysResponse(data)).toEqual(new Map());
   });
 });
 

--- a/frontend/src/lib/time-tracking-helpers.test.ts
+++ b/frontend/src/lib/time-tracking-helpers.test.ts
@@ -321,18 +321,22 @@ describe("mapHolidaysResponse", () => {
 
 describe("mapClosingDaysResponse", () => {
   it("expands ranges into per-day entries with the reason", () => {
-    const result = mapClosingDaysResponse([
-      {
-        start_date: "2026-12-24",
-        end_date: "2026-12-27",
-        reason: "Weihnachtswoche",
-      },
-      {
-        start_date: "2027-02-08",
-        end_date: "2027-02-08",
-        reason: "Rosenmontag",
-      },
-    ]);
+    const result = mapClosingDaysResponse(
+      [
+        {
+          start_date: "2026-12-24",
+          end_date: "2026-12-27",
+          reason: "Weihnachtswoche",
+        },
+        {
+          start_date: "2027-02-08",
+          end_date: "2027-02-08",
+          reason: "Rosenmontag",
+        },
+      ],
+      "2026-12-01",
+      "2027-02-28",
+    );
 
     expect(result).toEqual(
       new Map([
@@ -346,19 +350,39 @@ describe("mapClosingDaysResponse", () => {
   });
 
   it("keeps the first reason when ranges overlap", () => {
-    const result = mapClosingDaysResponse([
-      { start_date: "2026-07-20", end_date: "2026-07-24", reason: "Sommer A" },
-      { start_date: "2026-07-24", end_date: "2026-07-28", reason: "Sommer B" },
-    ]);
+    const result = mapClosingDaysResponse(
+      [
+        {
+          start_date: "2026-07-20",
+          end_date: "2026-07-24",
+          reason: "Sommer A",
+        },
+        {
+          start_date: "2026-07-24",
+          end_date: "2026-07-28",
+          reason: "Sommer B",
+        },
+      ],
+      "2026-07-01",
+      "2026-07-31",
+    );
 
     expect(result.get("2026-07-24")).toBe("Sommer A");
     expect(result.get("2026-07-25")).toBe("Sommer B");
   });
 
   it("crosses the DST boundary without skipping or doubling days", () => {
-    const result = mapClosingDaysResponse([
-      { start_date: "2026-03-28", end_date: "2026-03-30", reason: "Umbau" },
-    ]);
+    const result = mapClosingDaysResponse(
+      [
+        {
+          start_date: "2026-03-28",
+          end_date: "2026-03-30",
+          reason: "Umbau",
+        },
+      ],
+      "2026-03-28",
+      "2026-03-30",
+    );
 
     expect([...result.keys()]).toEqual([
       "2026-03-28",
@@ -368,7 +392,29 @@ describe("mapClosingDaysResponse", () => {
   });
 
   it.each([null, undefined])("returns an empty map for %s", (data) => {
-    expect(mapClosingDaysResponse(data)).toEqual(new Map());
+    expect(mapClosingDaysResponse(data, "2026-01-01", "2026-12-31")).toEqual(
+      new Map(),
+    );
+  });
+
+  it("clamps long stored ranges to the requested window before expansion", () => {
+    const result = mapClosingDaysResponse(
+      [
+        {
+          start_date: "2020-01-01",
+          end_date: "2030-12-31",
+          reason: "Langzeit-Schließung",
+        },
+      ],
+      "2026-12-01",
+      "2026-12-31",
+    );
+
+    expect(result.size).toBe(31);
+    expect(result.get("2026-12-01")).toBe("Langzeit-Schließung");
+    expect(result.get("2026-12-31")).toBe("Langzeit-Schließung");
+    expect(result.has("2026-11-30")).toBe(false);
+    expect(result.has("2027-01-01")).toBe(false);
   });
 });
 

--- a/frontend/src/lib/time-tracking-helpers.ts
+++ b/frontend/src/lib/time-tracking-helpers.ts
@@ -544,6 +544,47 @@ export function mapHolidaysResponse(
   return holidays;
 }
 
+export interface BackendClosingDayRange {
+  start_date: string;
+  end_date: string;
+  reason: string;
+}
+
+/**
+ * OGS-Schließtage im Zeitraum, keyed nach ISO-Tag (YYYY-MM-DD), Wert ist
+ * der Grund (#1418 3b). Das Backend liefert die gespeicherten Zeiträume;
+ * hier werden sie tageweise expandiert. An diesen Tagen liefert das
+ * Backend Soll = 0 — die Map ist reine Anzeige, keine Rechengrundlage.
+ */
+export function mapClosingDaysResponse(
+  data: BackendClosingDayRange[] | null | undefined,
+): ReadonlyMap<string, string> {
+  const closingDays = new Map<string, string>();
+  for (const entry of data ?? []) {
+    const start = entry.start_date.slice(0, 10);
+    const end = entry.end_date.slice(0, 10);
+    const startDate = new Date(`${start}T00:00:00`);
+    const endDate = new Date(`${end}T00:00:00`);
+    // Hard cap mirrors the backend's 400-day query window; a corrupt range
+    // must not blow up the map. Math.round (not floor) keeps the count
+    // DST-safe: across a spring-forward the midnight-to-midnight diff is an
+    // hour short of a full day multiple. setDate below walks calendar days.
+    const dayCount = Math.min(
+      Math.round((endDate.getTime() - startDate.getTime()) / 86_400_000) + 1,
+      400,
+    );
+    for (let offset = 0; offset < dayCount; offset++) {
+      const cursor = new Date(startDate);
+      cursor.setDate(cursor.getDate() + offset);
+      const key = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}-${String(cursor.getDate()).padStart(2, "0")}`;
+      if (!closingDays.has(key)) {
+        closingDays.set(key, entry.reason);
+      }
+    }
+  }
+  return closingDays;
+}
+
 export interface BackendMonthSummary {
   staff_id: number;
   year: number;

--- a/frontend/src/lib/time-tracking-helpers.ts
+++ b/frontend/src/lib/time-tracking-helpers.ts
@@ -550,6 +550,10 @@ export interface BackendClosingDayRange {
   reason: string;
 }
 
+// The backend accepts a maximum date distance of 400 days. Because both
+// endpoints are inclusive, that window contains up to 401 calendar dates.
+const MAX_CLOSING_DAY_WINDOW_DATES = 401;
+
 /**
  * OGS-Schließtage im Zeitraum, keyed nach ISO-Tag (YYYY-MM-DD), Wert ist
  * der Grund (#1418 3b). Das Backend liefert die gespeicherten Zeiträume;
@@ -558,20 +562,32 @@ export interface BackendClosingDayRange {
  */
 export function mapClosingDaysResponse(
   data: BackendClosingDayRange[] | null | undefined,
+  from: string,
+  to: string,
 ): ReadonlyMap<string, string> {
   const closingDays = new Map<string, string>();
+  const windowStart = from.slice(0, 10);
+  const windowEnd = to.slice(0, 10);
+  if (windowEnd < windowStart) return closingDays;
+
   for (const entry of data ?? []) {
-    const start = entry.start_date.slice(0, 10);
-    const end = entry.end_date.slice(0, 10);
+    const storedStart = entry.start_date.slice(0, 10);
+    const storedEnd = entry.end_date.slice(0, 10);
+    const start = storedStart < windowStart ? windowStart : storedStart;
+    const end = storedEnd > windowEnd ? windowEnd : storedEnd;
+    if (end < start) continue;
+
     const startDate = new Date(`${start}T00:00:00`);
     const endDate = new Date(`${end}T00:00:00`);
-    // Hard cap mirrors the backend's 400-day query window; a corrupt range
-    // must not blow up the map. Math.round (not floor) keeps the count
-    // DST-safe: across a spring-forward the midnight-to-midnight diff is an
-    // hour short of a full day multiple. setDate below walks calendar days.
+    // Clamp before applying the hard cap: stored ranges can be much longer
+    // than the requested window. Math.round (not floor) keeps the count
+    // DST-safe across 23/25-hour days; setDate walks local calendar days.
     const dayCount = Math.min(
-      Math.round((endDate.getTime() - startDate.getTime()) / 86_400_000) + 1,
-      400,
+      Math.max(
+        0,
+        Math.round((endDate.getTime() - startDate.getTime()) / 86_400_000) + 1,
+      ),
+      MAX_CLOSING_DAY_WINDOW_DATES,
     );
     for (let offset = 0; offset < dayCount; offset++) {
       const cursor = new Date(startDate);


### PR DESCRIPTION
Refs #1418 (Teil 3b).

## Was

Schulen können OGS-Schließtage (pädagogische Tage, Weihnachtswoche, Sommerschließung) als **Zeiträume** pflegen. An diesen Tagen gilt in der Zeiterfassung **Soll = 0**, exakt wie an gesetzlichen Feiertagen (3a, #1969).

- **Neue Tabelle** `schedule.closing_days` (Migration 1.15.211): tenant-scoped, `start_date`/`end_date`/`reason`, `CHECK (start_date <= end_date)` (Eintages-Schließtag = start = end), RLS + Grants. Bewusst kein EXCLUDE-Overlap-Constraint: Überlappungen sind durch die Set-Vereinigung harmlos.
- **Soll=0 per Union statt Parallelpfad**: `NewNonWorkingDayResolver` implementiert `schedule.HolidayService` und liefert bei `HolidayDates()` die Vereinigung aus Feiertagen und Schließtagen. Er ersetzt den Holiday-Service an den drei Soll-Injektionspunkten (`workTimeMonthService`, `workSessionService`-Wochensummen, `staffScheduleOverview`). Die Soll-Schleifen selbst sind unverändert; Feiertag+Schließtag am selben Tag kann strukturell nicht doppelt subtrahiert werden. `HolidaysInRange()` bleibt reiner Feiertags-Passthrough, der `/holidays`-Endpoint und die Feiertagsarbeit-Warnung sind unberührt.
- **API**: CRUD unter `/api/timetable/closing-days` (Schedules-Permissions, konsistent zur Perioden-Verwaltung derselben Seite); Read für die Badges unter `/api/time-tracking/closing-days?from&to` (TimeTrackingOwn/Manage, 400-Tage-Cap wie `/holidays`). `route_table.golden` per `-update-goldens` regeneriert.
- **Admin-UI**: zweite Sektion „Schließtage" auf der Kalenderzeiträume-Seite (`ClosingDaysEditor` + `ClosingDayModal`, UI-Kit, Lösch-Bestätigung).
- **Zeiterfassung**: neues Status-Badge `Schließtag` (graue Pill, Grund als Tooltip) in Admin- und MA-Ansicht. Priorität: Session → Feiertag → Schließtag → Abwesenheit → Nicht erfasst.
- **Hilfe-Guide**: Kalenderzeiträume-Step und Zeiterfassungs-Historie-Step ergänzt.

## Bewusste Abweichungen vom Issue-Text

- Zeiträume statt Einzeltage (`start_date`/`end_date` statt `date`) — drei Wochen Sommerschließung sind ein Eintrag statt 15 Zeilen.
- Default-Vorschläge (Rosenmontag, Weihnachtswoche, Sommerferien) bewusst nicht in v1.

## Tests

- Repo: CRUD, `FindOverlappingRange`-Grenzfälle, Tenant-Isolation (2 Tenants)
- Service: Validierung, Range-Expansion inkl. Fenster-Clamp
- Composite-Reader: Union, „Feiertag UND Schließtag → einmal true", kein Schließtag-Leak in `HolidaysInRange`
- Handler: CRUD-Fälle + 400er (timetable), 400-Tage-Cap + Response-Shape (time-tracking)
- Frontend: Editor/Modal (Vitest), Badge- und Prioritäts-Fälle in der Session-Tabelle, Mapper inkl. DST-Grenze
- Gates grün: Hermetik, `TestDateColumnTypes`, alle Ratchets, golangci-lint 0 Issues, `pnpm run check` warnungsfrei, komplette Frontend-Suite grün

In `calendar-periods/page.test.tsx` wurde nur ein `vi.mock` für die neue Kindkomponente ergänzt (ungemockter Fetch), die getestete Regel ist unverändert.

## QA

Browser-verifiziert gegen den lokalen Stack: Schließtag anlegen/bearbeiten/löschen auf /calendar-periods, Badge + Soll = 0 in der Zeiterfassung.