### PR TITLE
fix(tenant): Tenant-Wechsel bei abweichendem Slug/Subdomain reparieren

### DIFF
--- a/frontend/src/components/tenant/tenant-guard.test.tsx
+++ b/frontend/src/components/tenant/tenant-guard.test.tsx
@@ -221,6 +221,41 @@ describe("TenantGuard", () => {
     expect(mockUpdate).toHaveBeenCalled();
   });
 
+  // Regression test for #1975: the auto-switch must send the subdomain,
+  // not the slug column — the two can legitimately differ.
+  it("auto-switches with the subdomain when slug differs (#1975)", async () => {
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    mockUseSession.mockReturnValue({
+      data: { user: { tenantId: 1, token: "access-token" } },
+      status: "authenticated",
+      update: mockUpdate,
+    });
+    mockUseTenant.mockReturnValue({
+      tenantSlug: "school-b",
+      tenant: { ...tenantB, slug: "ogs-school-b", subdomain: "school-b" },
+    });
+    mockPerformTenantSwitch.mockResolvedValue({
+      access_token: "new-access",
+      refresh_token: "new-refresh",
+    });
+
+    render(
+      <TenantGuard>
+        <div>Protected Content</div>
+      </TenantGuard>,
+    );
+
+    await waitFor(() => {
+      expect(mockPerformTenantSwitch).toHaveBeenCalledWith(
+        "school-b",
+        mockSignIn,
+        mockMutate,
+      );
+    });
+
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
   it("signs out when switchTenant reports access denied", async () => {
     mockUseSession.mockReturnValue({
       data: { user: { tenantId: 1, token: "access-token" } },

--- a/frontend/src/components/tenant/tenant-guard.tsx
+++ b/frontend/src/components/tenant/tenant-guard.tsx
@@ -52,6 +52,9 @@ export function TenantGuard({
   const sessionError = session?.error;
   const urlTenantId = tenant?.tenantId;
   const urlSlug = tenant?.slug;
+  // The backend resolves switch targets by subdomain, not by the slug
+  // column — the two can differ (#1975).
+  const urlSubdomain = tenant?.subdomain;
 
   // Auth.js can still report "authenticated" after the JWT callback has
   // stripped token/roles because refresh failed. Do not render tenant UI in
@@ -162,19 +165,19 @@ export function TenantGuard({
 
     void (async () => {
       try {
-        await performTenantSwitch(urlSlug!, signIn, mutate);
+        await performTenantSwitch(urlSubdomain!, signIn, mutate);
 
         // Refetch session to trigger re-render with new tenant
         await update();
 
         logger.info("tenant_auto_switched", {
           from_tenant_id: sessionTenantId,
-          to_slug: urlSlug,
+          to_slug: urlSubdomain,
         });
       } catch (err) {
         logger.error("tenant_auto_switch_failed", {
           error: err instanceof Error ? err.message : String(err),
-          target_slug: urlSlug,
+          target_slug: urlSubdomain,
         });
 
         if (err instanceof TenantSwitchError && err.code === "access_denied") {
@@ -189,6 +192,7 @@ export function TenantGuard({
     sessionTenantId,
     urlTenantId,
     urlSlug,
+    urlSubdomain,
     update,
     sessionToken,
     sessionError,

--- a/frontend/src/components/tenant/tenant-switcher.test.tsx
+++ b/frontend/src/components/tenant/tenant-switcher.test.tsx
@@ -274,6 +274,88 @@ describe("TenantSwitcher", () => {
     expect(screen.getByText("Org Beta")).toBeInTheDocument();
   });
 
+  // Regression tests for #1975: slug and subdomain are independent columns
+  // and can differ (prod example: slug "ogs-burbach", subdomain "burbach").
+  // The switch contract is subdomain-based.
+
+  it("sends the subdomain, not the slug, when they differ (#1975)", async () => {
+    const divergentTenantB = {
+      ...tenantB,
+      slug: "ogs-school-b",
+      subdomain: "school-b",
+    };
+    mockListAvailableTenants.mockResolvedValue([tenantA, divergentTenantB]);
+
+    render(<TenantSwitcher />);
+
+    await waitFor(() => {
+      expect(screen.getByText("School A")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("School A"));
+    fireEvent.click(screen.getByText("School B"));
+
+    await waitFor(() => {
+      expect(mockPerformTenantSwitch).toHaveBeenCalledWith(
+        "school-b",
+        mockSignIn,
+        mockMutate,
+      );
+    });
+
+    expect(window.location.href).toBe(
+      "http://school-b.localhost:3000/dashboard",
+    );
+  });
+
+  it("matches the current tenant by subdomain when slug differs (#1975)", async () => {
+    const divergentTenantA = {
+      ...tenantA,
+      slug: "ogs-school-a",
+      subdomain: "school-a",
+    };
+    mockListAvailableTenants.mockResolvedValue([divergentTenantA, tenantB]);
+
+    render(<TenantSwitcher />);
+
+    // currentSlug (URL) is "school-a" — must match via subdomain, so the
+    // trigger shows the school name, not the raw slug fallback.
+    await waitFor(() => {
+      expect(screen.getByText("School A")).toBeInTheDocument();
+    });
+
+    // The current tenant must not appear as a switch target.
+    fireEvent.click(screen.getByText("School A"));
+    expect(screen.getAllByText("School A")).toHaveLength(1);
+    expect(screen.getByText("School B")).toBeInTheDocument();
+  });
+
+  it("shows a visible error message when switching fails", async () => {
+    mockListAvailableTenants.mockResolvedValue([tenantA, tenantB]);
+    mockPerformTenantSwitch.mockRejectedValue(new Error("switch failed"));
+
+    render(<TenantSwitcher />);
+
+    await waitFor(() => {
+      expect(screen.getByText("School A")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("School A"));
+    fireEvent.click(screen.getByText("School B"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Wechsel zu School B fehlgeschlagen/),
+      ).toBeInTheDocument();
+    });
+
+    // Re-opening the dropdown clears the error.
+    fireEvent.click(screen.getByText("School A"));
+    expect(
+      screen.queryByText(/Wechsel zu School B fehlgeschlagen/),
+    ).not.toBeInTheDocument();
+  });
+
   it("logs error when listing tenants fails", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(vi.fn());
     mockListAvailableTenants.mockRejectedValue(new Error("fetch failed"));

--- a/frontend/src/components/tenant/tenant-switcher.tsx
+++ b/frontend/src/components/tenant/tenant-switcher.tsx
@@ -12,6 +12,7 @@ import { useTenantSlugSafe } from "~/lib/tenant-context";
 import { createLogger } from "~/lib/logger";
 import { trackEvent } from "~/lib/analytics";
 import { env } from "~/env";
+import { Alert } from "~/components/ui/alert";
 
 const logger = createLogger({ component: "TenantSwitcher" });
 
@@ -30,6 +31,7 @@ export function TenantSwitcher() {
   const [tenants, setTenants] = useState<TenantSummary[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
+  const [switchError, setSwitchError] = useState("");
   const dropdownRef = useRef<HTMLDivElement>(null);
   const currentSlug = useTenantSlugSafe();
   const { status } = useSession();
@@ -67,13 +69,17 @@ export function TenantSwitcher() {
       if (isSwitching) return;
       setIsSwitching(true);
       setIsOpen(false);
+      setSwitchError("");
 
       try {
-        await performTenantSwitch(targetTenant.slug, signIn, mutate);
+        // The backend resolves the switch target by SUBDOMAIN (same as
+        // login), so pass targetTenant.subdomain — the slug column can
+        // legitimately differ from it (#1975).
+        await performTenantSwitch(targetTenant.subdomain, signIn, mutate);
 
         const switchPayload = {
           from_slug: currentSlug ?? "unknown",
-          to_slug: targetTenant.slug,
+          to_slug: targetTenant.subdomain,
         };
         logger.info("tenant_switched", switchPayload);
         trackEvent("tenant_switched", switchPayload);
@@ -89,8 +95,11 @@ export function TenantSwitcher() {
       } catch (err) {
         logger.error("tenant_switch_failed", {
           error: err instanceof Error ? err.message : String(err),
-          target_slug: targetTenant.slug,
+          target_slug: targetTenant.subdomain,
         });
+        setSwitchError(
+          `Wechsel zu ${targetTenant.name} fehlgeschlagen. Bitte erneut versuchen oder direkt über die Schul-URL anmelden.`,
+        );
         setIsSwitching(false);
       }
     },
@@ -102,8 +111,10 @@ export function TenantSwitcher() {
     return null;
   }
 
-  const currentTenant = tenants.find((t) => t.slug === currentSlug);
-  const otherTenants = tenants.filter((t) => t.slug !== currentSlug);
+  // currentSlug comes from the URL, which is the tenant's subdomain — so
+  // match against subdomain, not the independent slug column (#1975).
+  const currentTenant = tenants.find((t) => t.subdomain === currentSlug);
+  const otherTenants = tenants.filter((t) => t.subdomain !== currentSlug);
 
   // Group other tenants by organization
   const grouped = new Map<string, TenantSummary[]>();
@@ -119,7 +130,10 @@ export function TenantSwitcher() {
       {/* Trigger button */}
       <button
         type="button"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => {
+          setSwitchError("");
+          setIsOpen(!isOpen);
+        }}
         disabled={isSwitching}
         className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:opacity-50"
       >
@@ -164,6 +178,14 @@ export function TenantSwitcher() {
               ))}
             </div>
           ))}
+        </div>
+      )}
+
+      {/* Visible feedback when a switch fails — a silent no-op here caused
+          #1975 to go unnoticed. */}
+      {switchError && !isOpen && (
+        <div className="absolute right-0 z-50 mt-1 w-72">
+          <Alert type="error" message={switchError} />
         </div>
       )}
     </div>

--- a/frontend/src/lib/tenant-api.ts
+++ b/frontend/src/lib/tenant-api.ts
@@ -325,7 +325,7 @@ async function parseErrorMessage(response: Response): Promise<string> {
  * 4. Clear session cache for fresh token resolution
  */
 export async function performTenantSwitch(
-  slug: string,
+  subdomain: string,
   signIn: (
     provider: string,
     options: Record<string, unknown>,
@@ -336,7 +336,7 @@ export async function performTenantSwitch(
     opts: { revalidate: boolean },
   ) => Promise<unknown>,
 ): Promise<SwitchTenantResponse> {
-  const tokens = await switchTenant(slug);
+  const tokens = await switchTenant(subdomain);
 
   await signIn("credentials", {
     redirect: false,
@@ -355,13 +355,17 @@ export async function performTenantSwitch(
 /**
  * Switch the current session to a different tenant.
  * Returns new JWT tokens scoped to the target tenant.
+ *
+ * Takes the tenant SUBDOMAIN, not the slug column: the backend resolves the
+ * wire field `tenant_slug` via FindBySubdomain (same as login), so passing
+ * the slug 404s for schools where slug != subdomain (#1975).
  */
 export async function switchTenant(
-  slug: string,
+  subdomain: string,
 ): Promise<SwitchTenantResponse> {
   const response = await sessionFetch("/api/auth/switch-tenant", {
     method: "POST",
-    body: JSON.stringify({ tenant_slug: slug }),
+    body: JSON.stringify({ tenant_slug: subdomain }),
   });
   if (!response.ok) {
     const message = await parseErrorMessage(response);

--- a/frontend/src/lib/tenant-context.test.tsx
+++ b/frontend/src/lib/tenant-context.test.tsx
@@ -301,6 +301,34 @@ describe("TenantProvider — cross-tab settings sync", () => {
     });
   });
 
+  it("ignores refetched values for a different subdomain", async () => {
+    mockResolveTenant.mockResolvedValue({
+      ...mockTenant,
+      subdomain: "other-school",
+      studentPhotosEnabled: true,
+    });
+
+    const observed: { value: TenantInfo | null } = { value: null };
+    function Probe() {
+      observed.value = useTenantSafe()?.tenant ?? null;
+      return null;
+    }
+
+    render(
+      <TenantProvider tenantSlug="demo-school" tenant={mockTenant}>
+        <Probe />
+      </TenantProvider>,
+    );
+
+    await act(async () => {
+      for (const handler of broadcastHandlers) handler();
+      await Promise.resolve();
+    });
+
+    expect(mockResolveTenant).toHaveBeenCalledWith("demo-school");
+    expect(observed.value).toEqual(mockTenant);
+  });
+
   it("ignores stale resolveTenant responses that finish out of order", async () => {
     // Bursting refetches (visibilitychange + SSE + BroadcastChannel
     // landing in the same tick) used to last-writer-wins on whichever

--- a/frontend/src/lib/tenant-context.test.tsx
+++ b/frontend/src/lib/tenant-context.test.tsx
@@ -52,7 +52,9 @@ const mockTenant: TenantInfo = {
   tenantId: 1,
   slug: "demo-school",
   name: "Demo School",
-  subdomain: "demo",
+  // The provider's tenantSlug prop is the URL segment, which is the
+  // school's SUBDOMAIN — keep the fixture consistent with that (#1975).
+  subdomain: "demo-school",
   organizationId: 10,
   organizationName: "Org A",
   settings: {},
@@ -262,6 +264,43 @@ describe("TenantProvider — cross-tab settings sync", () => {
     expect(mockResolveTenant).toHaveBeenCalledWith("demo-school");
   });
 
+  it("applies refetched values when the slug column differs from the subdomain (#1975)", async () => {
+    // slug and subdomain are independent columns (prod example: slug
+    // "ogs-burbach", subdomain "burbach"). The URL segment is the
+    // subdomain, so the freshness guard must compare subdomain — a
+    // slug compare silently dropped every settings refresh for such
+    // schools.
+    const divergentTenant: TenantInfo = {
+      ...mockTenant,
+      slug: "ogs-demo-school",
+      subdomain: "demo-school",
+    };
+    mockResolveTenant.mockResolvedValue({
+      ...divergentTenant,
+      studentPhotosEnabled: true,
+    });
+
+    const observed: { value: TenantInfo | null } = { value: null };
+    function Probe() {
+      observed.value = useTenantSafe()?.tenant ?? null;
+      return null;
+    }
+
+    render(
+      <TenantProvider tenantSlug="demo-school" tenant={divergentTenant}>
+        <Probe />
+      </TenantProvider>,
+    );
+
+    act(() => {
+      for (const handler of broadcastHandlers) handler();
+    });
+
+    await waitFor(() => {
+      expect(observed.value?.studentPhotosEnabled).toBe(true);
+    });
+  });
+
   it("ignores stale resolveTenant responses that finish out of order", async () => {
     // Bursting refetches (visibilitychange + SSE + BroadcastChannel
     // landing in the same tick) used to last-writer-wins on whichever
@@ -342,8 +381,18 @@ describe("TenantProvider — cross-tab settings sync", () => {
     // returns. Without the slug guard + monotonic counter, A's response
     // would land last and overwrite B's context, leaving the new tab
     // showing School A's metadata under School B's URL.
-    const tenantA: TenantInfo = { ...mockTenant, slug: "school-a", name: "A" };
-    const tenantB: TenantInfo = { ...mockTenant, slug: "school-b", name: "B" };
+    const tenantA: TenantInfo = {
+      ...mockTenant,
+      slug: "school-a",
+      subdomain: "school-a",
+      name: "A",
+    };
+    const tenantB: TenantInfo = {
+      ...mockTenant,
+      slug: "school-b",
+      subdomain: "school-b",
+      name: "B",
+    };
 
     let resolveForA: (v: TenantInfo) => void = () => {};
     let resolveForB: (v: TenantInfo) => void = () => {};
@@ -416,8 +465,18 @@ describe("TenantProvider — cross-tab settings sync", () => {
     //   fresh.slug === requestedSlug (both "school-a", captured at refetch time)
     // → setTenant(A) wins and overwrites B's server-provided context.
     // The cleanup-counter-bump prevents this.
-    const tenantA: TenantInfo = { ...mockTenant, slug: "school-a", name: "A" };
-    const tenantB: TenantInfo = { ...mockTenant, slug: "school-b", name: "B" };
+    const tenantA: TenantInfo = {
+      ...mockTenant,
+      slug: "school-a",
+      subdomain: "school-a",
+      name: "A",
+    };
+    const tenantB: TenantInfo = {
+      ...mockTenant,
+      slug: "school-b",
+      subdomain: "school-b",
+      name: "B",
+    };
 
     let resolveForA: (v: TenantInfo) => void = () => {};
     const aPromise = new Promise<TenantInfo>((r) => (resolveForA = r));

--- a/frontend/src/lib/tenant-context.tsx
+++ b/frontend/src/lib/tenant-context.tsx
@@ -76,12 +76,14 @@ export function TenantProvider({
       void resolveTenant(requestedSlug).then((fresh) => {
         if (token !== requestSeqRef.current) return;
         if (!fresh) return;
-        // Defence-in-depth: also drop responses whose payload slug
-        // doesn't match the slug we asked for. The counter-bump on
-        // slug change already invalidates stale responses, but the
-        // explicit slug compare guards against an upstream that
-        // returned data for a different slug than requested.
-        if (fresh.slug !== requestedSlug) return;
+        // Defence-in-depth: also drop responses whose payload doesn't
+        // match the tenant we asked for. The counter-bump on slug change
+        // already invalidates stale responses, but the explicit compare
+        // guards against an upstream that returned data for a different
+        // tenant than requested. Compare the SUBDOMAIN: the URL segment
+        // is the subdomain, while the payload slug column can
+        // legitimately differ from it (#1975).
+        if (fresh.subdomain !== requestedSlug) return;
         setTenant(fresh);
       });
     };


### PR DESCRIPTION
## Zusammenfassung

Fixes #1975.

Der Tenant-Umschalter und der TenantGuard sendeten die **Slug-Spalte** an `POST /auth/switch-tenant`, das Backend löst den Wert aber über die **Subdomain** auf (`FindBySubdomain`, identisch zum Login). Bei Schulen mit `slug != subdomain` (in Produktion: OGS Burbach, `slug=ogs-burbach`, `subdomain=burbach`) lief der Wechsel dadurch in einen stillen 404: Klick, nichts passiert.

## Änderungen (nur Frontend)

- **`tenant-switcher.tsx`**: sendet `targetTenant.subdomain` statt `.slug`; der aktuelle Tenant wird über `t.subdomain === currentSlug` gefiltert (der URL-Wert ist die Subdomain). Fehlgeschlagene Wechsel zeigen jetzt eine sichtbare Fehlermeldung (Kit-`Alert`) statt eines stillen No-Ops.
- **`tenant-guard.tsx`**: der Auto-Switch bei Session/URL-Mismatch sendet ebenfalls die Subdomain.
- **`tenant-context.tsx`**: der Freshness-Guard beim Settings-Refresh vergleicht `fresh.subdomain` statt `fresh.slug` — der Slug-Vergleich hat bei abweichenden Schulen jeden Settings-Refresh still verworfen.
- **`tenant-api.ts`**: Doku/Parameter klargestellt (Wire-Feld `tenant_slug` bleibt, Wert ist die Subdomain).

Backend bleibt unverändert (Kontrakt eindeutig subdomain-basiert, wie beim Login; ein globaler Slug-Fallback wäre mehrdeutig, da Slugs nur pro Träger unique sind). Prod-Daten bleiben unverändert — der Fix funktioniert mit den bestehenden Burbach-Daten.

## Tests

- Neue Regressionstests mit `slug != subdomain`-Fixtures: Switcher sendet Subdomain, Current-Tenant-Matching, sichtbarer Fehler-Alert, Guard-Auto-Switch, Settings-Refresh bei abweichendem Slug.
- Bestehende Fixtures in `tenant-context.test.tsx` wurden konsistent gemacht (das Provider-`tenantSlug`-Prop ist der URL-Wert = Subdomain); die getesteten Invarianten (Stale-Response-Dropping) sind unverändert.
- `pnpm run check` grün, kompletter Vitest-Lauf grün (ein bekannter Flake in `shell-auth-context.test.tsx`, in Isolation grün, unabhängig von diesem PR).

## End-to-End verifiziert (lokal)

Dev-DB mit exakter Prod-Konstellation (OGS Burbach: `slug=ogs-burbach`, `subdomain=burbach`; Konto mit Zugriff auf beide Schulen):

- API: `switch-tenant` mit `burbach` → 200, mit `ogs-burbach` → 404 (alter Payload)
- UI: Wechsel Wahlbach → Burbach landet auf `burbach.…/dashboard`; Umschalter zeigt auf der abweichenden Schule den Schulnamen korrekt an; Wechsel zurück funktioniert; bei blockiertem Request erscheint die neue Fehlermeldung

Screenshots werden als Kommentar/Anhang nachgereicht.

## Hinweis

Die verwandte Baustelle (Einladungs-/Enrollment-Links, die aus `school.Slug` gebaut werden und bei abweichender Subdomain brechen) ist bewusst nicht Teil dieses PRs — Follow-up-Issue folgt.