### PR TITLE
feat(calendar): full-width grid, iOS-style mobile agenda, tap-to-detail

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/calendar/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/calendar/page.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockUseSWRAuth,
@@ -112,6 +112,11 @@ function mockCalendarSWR() {
 describe("StaffCalendarPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The page derives its week from `new Date()`; pin the clock into the
+    // fixture week so events fall in the visible range (Date only, so waitFor's
+    // real timers keep working). Fake the clock BEFORE any render.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(2026, 0, 7));
     mockCalendarSWR();
     mockUseSession.mockReturnValue({
       data: { user: { permissions: ["calendar:own", "calendar:manage"] } },
@@ -121,6 +126,10 @@ describe("StaffCalendarPage", () => {
     mockCreateStaffAppointment.mockResolvedValue({ appointment: { id: "1" } });
     mockUpdateStaffAppointment.mockResolvedValue({ appointment: { id: "5" } });
     mockMutate.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("edits a recurring appointment using the series base date, not the clicked occurrence", async () => {
@@ -159,7 +168,12 @@ describe("StaffCalendarPage", () => {
           mutate: mockMutate,
         };
       }
-      return { data: undefined, error: null, isLoading: false, mutate: vi.fn() };
+      return {
+        data: undefined,
+        error: null,
+        isLoading: false,
+        mutate: vi.fn(),
+      };
     });
     mockGetStaffAppointmentDetail.mockResolvedValue({
       appointment: {
@@ -177,9 +191,15 @@ describe("StaffCalendarPage", () => {
       },
     });
 
+    // This fixture's occurrence sits in the week of 2026-01-19.
+    vi.setSystemTime(new Date(2026, 0, 21));
     render(<StaffCalendarPage />);
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Bearbeiten" })[0]!);
+    // Management actions now live in the event detail sheet: open it first.
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /Wöchentliche AG/ })[0]!,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Bearbeiten" }));
     // The modal opens once the detail resolves; the date input shows the BASE
     // series date, not the clicked occurrence date.
     const startInput = (await screen.findByLabelText(
@@ -208,7 +228,8 @@ describe("StaffCalendarPage", () => {
     render(<StaffCalendarPage />);
 
     expect(screen.getAllByText("Teamplanung").length).toBeGreaterThan(0);
-    fireEvent.click(screen.getAllByRole("button", { name: "Zusagen" })[0]!);
+    fireEvent.click(screen.getAllByRole("button", { name: /Teamplanung/ })[0]!);
+    fireEvent.click(screen.getByRole("button", { name: "Zusagen" }));
 
     await waitFor(() =>
       expect(mockRespondStaffCalendar).toHaveBeenCalledWith("42", "accepted"),

--- a/frontend/src/app/[tenant]/(protected)/calendar/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/calendar/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { FormEvent } from "react";
-import { CalendarPlus, Trash2 } from "lucide-react";
+import type { FormEvent, SelectHTMLAttributes } from "react";
+import { CalendarPlus, ChevronDown, Trash2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 
 import {
@@ -85,9 +85,29 @@ const weekdays = [
 ];
 
 // Native <select> styled to match the default Input control (same height,
-// radius, ring) so selects and inputs line up in the same grid rows.
+// radius, ring). appearance-none drops the browser arrow so we can place our
+// own chevron with controlled spacing (see ModalSelect); pr-10 keeps long
+// option text clear of it.
 const selectClassName =
-  "block w-full rounded-lg border-0 bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset focus:outline-none focus:ring-inset focus-visible:ring-2 focus-visible:ring-gray-400 disabled:bg-gray-50 disabled:text-gray-500";
+  "block w-full appearance-none rounded-lg border-0 bg-white px-4 py-3 pr-10 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset focus:outline-none focus:ring-inset focus-visible:ring-2 focus-visible:ring-gray-400 disabled:bg-gray-50 disabled:text-gray-500";
+
+// A kit-styled native select with a custom, consistently-placed chevron.
+function ModalSelect({
+  children,
+  ...props
+}: SelectHTMLAttributes<HTMLSelectElement>) {
+  return (
+    <div className="relative">
+      <select className={selectClassName} {...props}>
+        {children}
+      </select>
+      <ChevronDown
+        className="pointer-events-none absolute top-1/2 right-3.5 h-4 w-4 -translate-y-1/2 text-gray-400"
+        aria-hidden
+      />
+    </div>
+  );
+}
 
 function errorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
@@ -768,12 +788,12 @@ export default function StaffCalendarPage() {
 
           <div className={`grid gap-4 ${editingId ? "" : "md:grid-cols-2"}`}>
             {!editingId ? (
-              <label className="block">
+              <label className="block" htmlFor="calendar-delivery-mode">
                 <span className="mb-2 block text-sm font-medium text-gray-700">
                   Antwortregel
                 </span>
-                <select
-                  className={selectClassName}
+                <ModalSelect
+                  id="calendar-delivery-mode"
                   value={deliveryMode}
                   onChange={(event) =>
                     setDeliveryMode(event.target.value as CalendarDeliveryMode)
@@ -786,15 +806,15 @@ export default function StaffCalendarPage() {
                   <option value="informational">
                     Nur informieren: ohne Rückmeldung eintragen
                   </option>
-                </select>
+                </ModalSelect>
               </label>
             ) : null}
-            <label className="block">
+            <label className="block" htmlFor="calendar-overview-visibility">
               <span className="mb-2 block text-sm font-medium text-gray-700">
                 Teilnehmerübersicht
               </span>
-              <select
-                className={selectClassName}
+              <ModalSelect
+                id="calendar-overview-visibility"
                 value={overviewVisibility}
                 onChange={(event) =>
                   setOverviewVisibility(
@@ -806,7 +826,7 @@ export default function StaffCalendarPage() {
                 <option value="organizer">Nur ich</option>
                 <option value="staff">Mitarbeitende mit Termin</option>
                 <option value="all">Alle Eingeladenen</option>
-              </select>
+              </ModalSelect>
             </label>
           </div>
 
@@ -911,12 +931,12 @@ export default function StaffCalendarPage() {
           ) : null}
 
           <div className="grid gap-4 md:grid-cols-3">
-            <label className="block">
+            <label className="block" htmlFor="calendar-recurrence-frequency">
               <span className="mb-2 block text-sm font-medium text-gray-700">
                 Wiederholung
               </span>
-              <select
-                className={selectClassName}
+              <ModalSelect
+                id="calendar-recurrence-frequency"
                 value={frequency}
                 onChange={(event) =>
                   setFrequency(event.target.value as RecurrenceFrequency)
@@ -928,7 +948,7 @@ export default function StaffCalendarPage() {
                 <option value="weekly">Wöchentlich</option>
                 <option value="monthly">Monatlich</option>
                 <option value="yearly">Jährlich</option>
-              </select>
+              </ModalSelect>
             </label>
             <Input
               label="Intervall"

--- a/frontend/src/app/[tenant]/(protected)/calendar/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/calendar/page.tsx
@@ -609,7 +609,7 @@ export default function StaffCalendarPage() {
   };
 
   return (
-    <main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+    <div className="w-full">
       <PersonalCalendar
         title="Mein Kalender"
         subtitle="Deine Termine, Einladungen, Dienstplan-Schichten und zugewiesenen Betreuungsangebote."
@@ -1091,6 +1091,6 @@ export default function StaffCalendarPage() {
           </div>
         ) : null}
       </Modal>
-    </main>
+    </div>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/calendar/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/calendar/page.tsx
@@ -84,6 +84,11 @@ const weekdays = [
   { value: "sunday", label: "So" },
 ];
 
+// Native <select> styled to match the default Input control (same height,
+// radius, ring) so selects and inputs line up in the same grid rows.
+const selectClassName =
+  "block w-full rounded-lg border-0 bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset focus:outline-none focus:ring-inset focus-visible:ring-2 focus-visible:ring-gray-400 disabled:bg-gray-50 disabled:text-gray-500";
+
 function errorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
@@ -754,21 +759,21 @@ export default function StaffCalendarPage() {
               Beschreibung
             </span>
             <textarea
-              className="block min-h-24 w-full rounded-lg border-0 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset placeholder:text-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
+              className="block min-h-24 w-full rounded-lg border-0 bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset placeholder:text-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
               value={description}
               onChange={(event) => setDescription(event.target.value)}
               disabled={submitting}
             />
           </label>
 
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className={`grid gap-4 ${editingId ? "" : "md:grid-cols-2"}`}>
             {!editingId ? (
               <label className="block">
                 <span className="mb-2 block text-sm font-medium text-gray-700">
                   Antwortregel
                 </span>
                 <select
-                  className="block h-10 w-full rounded-lg border-0 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 ring-inset focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
+                  className={selectClassName}
                   value={deliveryMode}
                   onChange={(event) =>
                     setDeliveryMode(event.target.value as CalendarDeliveryMode)
@@ -789,7 +794,7 @@ export default function StaffCalendarPage() {
                 Teilnehmerübersicht
               </span>
               <select
-                className="block h-10 w-full rounded-lg border-0 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 ring-inset focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
+                className={selectClassName}
                 value={overviewVisibility}
                 onChange={(event) =>
                   setOverviewVisibility(
@@ -803,17 +808,6 @@ export default function StaffCalendarPage() {
                 <option value="all">Alle Eingeladenen</option>
               </select>
             </label>
-            {!editingId ? (
-              <Input
-                label="Ziele suchen"
-                name="calendar-target-search"
-                controlSize="compact"
-                value={targetSearch}
-                onChange={(event) => setTargetSearch(event.target.value)}
-                disabled={submitting}
-                placeholder="Name, Klasse oder Gruppe"
-              />
-            ) : null}
           </div>
 
           {!editingId ? (
@@ -826,6 +820,16 @@ export default function StaffCalendarPage() {
                   {targets.length} Ziel{targets.length === 1 ? "" : "e"}{" "}
                   ausgewählt
                 </span>
+              </div>
+              <div className="mb-3">
+                <Input
+                  label="Ziele suchen"
+                  name="calendar-target-search"
+                  value={targetSearch}
+                  onChange={(event) => setTargetSearch(event.target.value)}
+                  disabled={submitting}
+                  placeholder="Name, Klasse oder Gruppe"
+                />
               </div>
               <div className="grid gap-3 lg:grid-cols-2">
                 {targetGroups.map((group) => (
@@ -912,7 +916,7 @@ export default function StaffCalendarPage() {
                 Wiederholung
               </span>
               <select
-                className="block h-10 w-full rounded-lg border-0 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 ring-inset focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:bg-gray-50 disabled:text-gray-500"
+                className={selectClassName}
                 value={frequency}
                 onChange={(event) =>
                   setFrequency(event.target.value as RecurrenceFrequency)

--- a/frontend/src/app/parents/calendar/page.test.tsx
+++ b/frontend/src/app/parents/calendar/page.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockGetParentCalendar,
@@ -72,8 +72,17 @@ const calendarResponse: CalendarResponse = {
 describe("ParentCalendarPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The page derives its week from `new Date()`; pin the clock into the
+    // fixture week so the events fall in the visible range (Date only, so
+    // waitFor's real timers keep working). Fake the clock BEFORE any render.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(2026, 0, 7));
     mockGetParentCalendar.mockResolvedValue(calendarResponse);
     mockRespondParentCalendar.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("loads parent calendar events and stores RSVP responses", async () => {
@@ -86,7 +95,11 @@ describe("ParentCalendarPage", () => {
       expect.any(Date),
     );
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Absagen" })[0]!);
+    // RSVP now lives in the event detail sheet: open the appointment first.
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /Elterngespräch/ })[0]!,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Absagen" }));
 
     await waitFor(() =>
       expect(mockRespondParentCalendar).toHaveBeenCalledWith("77", "declined"),
@@ -106,7 +119,10 @@ describe("ParentCalendarPage", () => {
     render(<ParentCalendarPage />);
     expect(await screen.findAllByText("Elterngespräch")).not.toHaveLength(0);
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Zusagen" })[0]!);
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /Elterngespräch/ })[0]!,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Zusagen" }));
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith("no access"),
     );

--- a/frontend/src/app/parents/calendar/page.tsx
+++ b/frontend/src/app/parents/calendar/page.tsx
@@ -146,7 +146,7 @@ export default function ParentCalendarPage() {
   };
 
   return (
-    <main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+    <div className="mx-auto w-full max-w-7xl">
       <PersonalCalendar
         title="Familienkalender"
         subtitle="Termine, Einladungen und Betreuungsangebote Ihrer Kinder."
@@ -181,6 +181,6 @@ export default function ParentCalendarPage() {
           <CalendarOverviewList overview={overview} />
         ) : null}
       </Modal>
-    </main>
+    </div>
   );
 }

--- a/frontend/src/components/calendar/personal-calendar.test.tsx
+++ b/frontend/src/components/calendar/personal-calendar.test.tsx
@@ -54,6 +54,15 @@ const shift: CalendarEvent = {
   can_edit: false,
 };
 
+// RSVP, export, and management controls now live in the event detail sheet.
+// Open it by clicking the event surface (there are desktop + mobile copies;
+// either sets the same selected event).
+function openEvent(title: string) {
+  fireEvent.click(
+    screen.getAllByRole("button", { name: new RegExp(title) })[0]!,
+  );
+}
+
 describe("PersonalCalendar", () => {
   it("renders shift events with the Dienst badge", () => {
     render(
@@ -91,13 +100,15 @@ describe("PersonalCalendar", () => {
     ).toBeInTheDocument();
     expect(screen.getAllByText("Staff meeting").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Betreuung Gruppe A").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Termin").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Betreuung").length).toBeGreaterThan(0);
+    // The pending response badge is shown on the event surface.
     expect(screen.getAllByText("Offen").length).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Zusagen" })[0]!);
+    // RSVP lives in the detail sheet; it closes after each response.
+    openEvent("Staff meeting");
+    fireEvent.click(screen.getByRole("button", { name: "Zusagen" }));
     expect(onRespond).toHaveBeenCalledWith("42", "accepted");
-    fireEvent.click(screen.getAllByRole("button", { name: "Absagen" })[0]!);
+    openEvent("Staff meeting");
+    fireEvent.click(screen.getByRole("button", { name: "Absagen" }));
     expect(onRespond).toHaveBeenCalledWith("42", "declined");
   });
 
@@ -135,10 +146,10 @@ describe("PersonalCalendar", () => {
 
     const shortBlock = screen
       .getAllByText("Kurzer RSVP-Termin")[0]!
-      .closest("article");
+      .closest("button");
     const followBlock = screen
       .getAllByText("Direkt danach")[0]!
-      .closest("article");
+      .closest("button");
     expect(shortBlock?.style.width).toBe("calc(50% - 4px)");
     expect(followBlock?.style.width).toBe("calc(50% - 4px)");
   });
@@ -239,11 +250,11 @@ describe("PersonalCalendar", () => {
       />,
     );
 
-    const links = screen.getAllByRole("link", {
+    openEvent("Staff meeting");
+    const link = screen.getByRole("link", {
       name: "Zum Kalender hinzufügen",
     });
-    expect(links.length).toBeGreaterThan(0);
-    expect(links[0]).toHaveAttribute(
+    expect(link).toHaveAttribute(
       "href",
       "/api/parent/calendar/appointments/1/ics",
     );
@@ -266,9 +277,11 @@ describe("PersonalCalendar", () => {
       />,
     );
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Bearbeiten" })[0]!);
+    openEvent("Staff meeting");
+    fireEvent.click(screen.getByRole("button", { name: "Bearbeiten" }));
     expect(onEdit).toHaveBeenCalledWith(editable);
-    fireEvent.click(screen.getAllByRole("button", { name: "Löschen" })[0]!);
+    openEvent("Staff meeting");
+    fireEvent.click(screen.getByRole("button", { name: "Löschen" }));
     expect(onDelete).toHaveBeenCalledWith(editable);
   });
 
@@ -292,10 +305,9 @@ describe("PersonalCalendar", () => {
 
     // The backend rejects edits to cancelled appointments, so the button is gone;
     // Löschen stays available.
+    openEvent("Staff meeting");
     expect(screen.queryByRole("button", { name: "Bearbeiten" })).toBeNull();
-    expect(
-      screen.getAllByRole("button", { name: "Löschen" }).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Löschen" })).toBeInTheDocument();
   });
 
   it("shows empty and error states", () => {

--- a/frontend/src/components/calendar/personal-calendar.test.tsx
+++ b/frontend/src/components/calendar/personal-calendar.test.tsx
@@ -310,6 +310,34 @@ describe("PersonalCalendar", () => {
     expect(screen.getByRole("button", { name: "Löschen" })).toBeInTheDocument();
   });
 
+  it("shows times instead of ganztg. for multi-day timed events in the agenda", () => {
+    const multiDayTimed: CalendarEvent = {
+      ...appointment,
+      id: "appointment:4:2026-01-05",
+      appointment_id: "4",
+      title: "Klassenfahrt",
+      start_date: "2026-01-05",
+      end_date: "2026-01-07",
+      start_time: "09:00",
+      end_time: "15:00",
+      all_day: false,
+    };
+    render(
+      <PersonalCalendar
+        title="Mein Kalender"
+        events={[multiDayTimed]}
+        weekStart={new Date(2026, 0, 5)}
+        onWeekChange={vi.fn()}
+      />,
+    );
+
+    // The mobile agenda must respect all_day: a timed multi-day appointment
+    // renders its start/end times, never the ganztg. label.
+    expect(screen.queryByText("ganztg.")).not.toBeInTheDocument();
+    expect(screen.getAllByText("09:00").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("15:00").length).toBeGreaterThan(0);
+  });
+
   it("shows empty and error states", () => {
     render(
       <PersonalCalendar

--- a/frontend/src/components/calendar/personal-calendar.test.tsx
+++ b/frontend/src/components/calendar/personal-calendar.test.tsx
@@ -338,6 +338,37 @@ describe("PersonalCalendar", () => {
     expect(screen.getAllByText("15:00").length).toBeGreaterThan(0);
   });
 
+  it.each(["week", "month"] as const)(
+    "shows the full time range for multi-day timed events in the desktop %s view",
+    (viewMode) => {
+      const multiDayTimed: CalendarEvent = {
+        ...appointment,
+        id: "appointment:4:2026-01-05",
+        appointment_id: "4",
+        title: "Klassenfahrt",
+        start_date: "2026-01-05",
+        end_date: "2026-01-07",
+        start_time: "09:00",
+        end_time: "15:00",
+        all_day: false,
+      };
+      render(
+        <PersonalCalendar
+          title="Mein Kalender"
+          events={[multiDayTimed]}
+          referenceDate={new Date(2026, 0, 5)}
+          viewMode={viewMode}
+          onDateChange={vi.fn()}
+        />,
+      );
+
+      // EventPill renders only on desktop. The mobile agenda uses separate
+      // start/end spans, so this exact range proves the desktop surface keeps
+      // the time information in both layouts.
+      expect(screen.getAllByText("09:00–15:00").length).toBeGreaterThan(0);
+    },
+  );
+
   it("shows empty and error states", () => {
     render(
       <PersonalCalendar

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -1012,7 +1012,11 @@ function AgendaRow({
 }: Readonly<{ event: CalendarEvent; actions: CalendarEventActions }>) {
   const tone = sourceTone[event.source];
   const cancelled = event.cancelled === true;
-  const allDay = isAllDayLike(event);
+  // Präsentation hängt an event.all_day, nicht an der Datumsspanne: ein
+  // mehrtägiger Termin MIT Uhrzeiten zeigt seine Zeiten, nur echte
+  // Ganztägig-Einträge zeigen „ganztg.“ (isAllDayLike regelt nur die
+  // Positionierung, nicht die Darstellung).
+  const allDay = event.all_day;
   const badge = cancelled
     ? { label: "Abgesagt", cls: "bg-[#FF3130]/10 text-[#CC2626]" }
     : event.response_status

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -1085,15 +1085,21 @@ function AgendaRow({
   );
 }
 
-// Schmale einzeilige Pille für Ganztägig-Einträge (Wochen-/Tagesraster + Mobile)
-// und Monatszellen. Tap öffnet das Detail-Sheet.
+// Schmale einzeilige Pille für die Ganztägig-Zeile im Wochen-/Tagesraster und
+// für Monatszellen. Mehrtägige Einträge liegen aus Layout-Gründen ebenfalls in
+// dieser Zeile; zeitgebundene Einträge behalten dort aber ihre Zeitangabe.
+// Tap öffnet das Detail-Sheet.
 function EventPill({
   event,
   actions,
 }: Readonly<{ event: CalendarEvent; actions: CalendarEventActions }>) {
   const tone = sourceTone[event.source];
   const cancelled = event.cancelled === true;
-  const showTime = !event.all_day && event.start_date === event.end_date;
+  const timeLabel = event.all_day
+    ? null
+    : event.start_date === event.end_date
+      ? event.start_time
+      : `${event.start_time}–${event.end_time}`;
   return (
     <button
       type="button"
@@ -1115,9 +1121,9 @@ function EventPill({
       >
         {event.title}
       </span>
-      {showTime ? (
+      {timeLabel ? (
         <span className="shrink-0 text-[11px] text-gray-500 tabular-nums">
-          {event.start_time}
+          {timeLabel}
         </span>
       ) : null}
     </button>

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -18,6 +18,7 @@ import {
   X,
 } from "lucide-react";
 import { Button } from "~/components/ui/button";
+import { Modal } from "~/components/ui/modal";
 import type {
   CalendarAppointmentOverview,
   CalendarEvent,
@@ -65,6 +66,11 @@ interface PersonalCalendarProps {
 }
 
 interface CalendarEventActions {
+  // Opens the event detail sheet. Every event surface (agenda row, all-day
+  // pill, month pill, time-grid block) is a button that calls this instead of
+  // rendering inline actions — Apple-Calendar style: tap the event, act in the
+  // detail. Set internally by PersonalCalendar.
+  readonly onSelect?: (event: CalendarEvent) => void;
   readonly onShowOverview?: (appointmentId: string) => void;
   readonly onRespond?: (
     recipientId: string,
@@ -182,10 +188,7 @@ function countWeekendEvents(
   return seen.size;
 }
 
-function gridHours(
-  dayEvents: readonly CalendarEvent[],
-  options: TimedLayoutOptions,
-): {
+function gridHours(dayEvents: readonly CalendarEvent[]): {
   startHour: number;
   endHour: number;
 } {
@@ -195,10 +198,7 @@ function gridHours(
     if (isAllDayLike(event)) continue;
     const startMinutes = clockToMinutes(event.start_time);
     startHour = Math.min(startHour, Math.floor(startMinutes / 60));
-    endHour = Math.max(
-      endHour,
-      Math.ceil(effectiveEndMinutes(event, options) / 60),
-    );
+    endHour = Math.max(endHour, Math.ceil(effectiveEndMinutes(event) / 60));
   }
   startHour = Math.max(0, startHour);
   endHour = Math.min(24, Math.max(endHour, startHour + 1));
@@ -216,55 +216,25 @@ interface TimedPlacement {
   columnCount: number;
 }
 
-interface TimedLayoutOptions {
-  hasRespond: boolean;
-  hasOverview: boolean;
-  hasManage: boolean;
-  hasIcs: boolean;
-}
-
-// Mindesthöhe eines Zeitraster-Blocks in Pixeln, abhängig vom Inhalt. Muss zum
-// Markup in TimeGridEventBlock passen — Aktionen und Textzeilen brauchen Platz,
-// sonst wären sie bei kurzen Terminen abgeschnitten.
-function blockMinHeightPx(
-  event: CalendarEvent,
-  options: TimedLayoutOptions,
-): number {
-  const cancelled = event.cancelled === true;
-  const isAppointment =
-    event.source === "appointment" && Boolean(event.appointment_id);
-  const showRespond = Boolean(
-    !cancelled && event.can_respond && event.recipient_id && options.hasRespond,
-  );
-  const showOverview = Boolean(
-    event.can_view_overview && event.appointment_id && options.hasOverview,
-  );
-  const showIcs = Boolean(!cancelled && isAppointment && options.hasIcs);
-  const showManage = Boolean(isAppointment && event.can_edit && options.hasManage);
+// Mindesthöhe eines Zeitraster-Blocks in Pixeln, abhängig vom Inhalt. Blöcke
+// zeigen nur noch Titel, Zeit und optional Ort/Zuordnung — Aktionen leben im
+// Detail-Sheet (Klick), daher kein Button-Platz mehr. Muss zum Markup in
+// TimeGridEventBlock passen, sonst würde kurzer Text abgeschnitten.
+function blockMinHeightPx(event: CalendarEvent): number {
   return (
-    56 +
-    ((event.student_name ?? event.school_name) ? 16 : 0) +
-    (event.location ? 18 : 0) +
-    (event.description ? 36 : 0) +
-    (showRespond ? 40 : 0) +
-    (showOverview ? 36 : 0) +
-    (showIcs ? 36 : 0) +
-    (showManage ? 44 : 0)
+    38 +
+    ((event.student_name ?? event.school_name) ? 15 : 0) +
+    (event.location ? 15 : 0)
   );
 }
 
 // Effektives Render-Ende eines Eintrags in Minuten: das spätere von
 // tatsächlichem Ende und der Mindesthöhe des gerenderten Inhalts. Rasterfenster
 // und Layout rechnen beide damit, sonst laufen späte Kurztermine unten heraus.
-function effectiveEndMinutes(
-  event: CalendarEvent,
-  options: TimedLayoutOptions,
-): number {
+function effectiveEndMinutes(event: CalendarEvent): number {
   const startMinutes = clockToMinutes(event.start_time);
   const minRenderMinutes =
-    event.source === "shift"
-      ? 30
-      : (blockMinHeightPx(event, options) / HOUR_PX) * 60;
+    event.source === "shift" ? 30 : (blockMinHeightPx(event) / HOUR_PX) * 60;
   return Math.max(
     clockToMinutes(event.end_time),
     startMinutes + minRenderMinutes,
@@ -275,7 +245,6 @@ function effectiveEndMinutes(
 // teilen sich die Spaltenbreite; jeder Eintrag bekommt die erste freie Spalte.
 function layoutTimedEvents(
   dayEvents: readonly CalendarEvent[],
-  options: TimedLayoutOptions,
 ): TimedPlacement[] {
   const items: TimedPlacement[] = dayEvents
     .map((event) => {
@@ -283,7 +252,7 @@ function layoutTimedEvents(
       return {
         event,
         startMinutes,
-        endMinutes: effectiveEndMinutes(event, options),
+        endMinutes: effectiveEndMinutes(event),
         column: 0,
         columnCount: 1,
       };
@@ -429,7 +398,11 @@ export function PersonalCalendar({
   busyAppointmentId,
   icsHrefBase,
 }: PersonalCalendarProps) {
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(
+    null,
+  );
   const actions: CalendarEventActions = {
+    onSelect: setSelectedEvent,
     onShowOverview,
     onRespond,
     respondingRecipientId,
@@ -467,38 +440,28 @@ export function PersonalCalendar({
     showWeekend || viewMode === "day"
       ? sortedEvents
       : sortedEvents.filter((event) => !isWeekendOnlyEvent(event));
+  // Mobile lacks the space for the time grid, so it renders a per-day agenda.
+  // The day set mirrors the desktop view (single day / visible week / visible
+  // month) so the weekend toggle and range stay consistent across breakpoints.
+  const mobileDays =
+    viewMode === "day"
+      ? [referenceDate]
+      : viewMode === "month"
+        ? visibleMonthDays
+        : visibleWeekDays;
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-col gap-3 border-b border-gray-200 pb-4 lg:flex-row lg:items-end lg:justify-between">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
         <div>
-          <div className="flex items-center gap-2 text-sm font-semibold text-gray-500">
-            <CalendarDays className="h-4 w-4" aria-hidden />
-            Kalender
-          </div>
-          <h1 className="mt-1 text-2xl font-semibold text-gray-900">{title}</h1>
+          <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
           {subtitle ? (
             <p className="mt-1 text-sm leading-6 text-gray-600">{subtitle}</p>
           ) : null}
         </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="flex items-center gap-1 rounded-lg border border-gray-200 bg-white p-1 shadow-sm">
-            {viewOptions.map((option) => {
-              const selected = option.mode === viewMode;
-              return (
-                <Button
-                  key={option.mode}
-                  type="button"
-                  variant={selected ? "primary" : "ghost"}
-                  size="compact"
-                  aria-pressed={selected}
-                  onClick={() => handleViewModeChange(option.mode)}
-                >
-                  {option.label}
-                </Button>
-              );
-            })}
-          </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center lg:justify-end">
+          {/* Date navigation — full width on mobile so the range label has room
+              instead of being squeezed between wrapping buttons. */}
           <div className="flex items-center gap-1 rounded-lg border border-gray-200 bg-white p-1 shadow-sm">
             <Button
               type="button"
@@ -511,7 +474,7 @@ export function PersonalCalendar({
             >
               <ChevronLeft className="h-4 w-4" aria-hidden />
             </Button>
-            <div className="min-w-52 px-2 text-center text-sm font-semibold text-gray-900">
+            <div className="flex-1 px-2 text-center text-sm font-semibold text-gray-900 sm:min-w-52">
               {label}
             </div>
             <Button
@@ -526,33 +489,59 @@ export function PersonalCalendar({
               <ChevronRight className="h-4 w-4" aria-hidden />
             </Button>
           </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="compact"
-            onClick={() => handleDateChange(new Date())}
-          >
-            Heute
-          </Button>
-          {viewMode !== "day" ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="flex items-center gap-1 rounded-lg border border-gray-200 bg-white p-1 shadow-sm">
+              {viewOptions.map((option) => {
+                const selected = option.mode === viewMode;
+                return (
+                  <Button
+                    key={option.mode}
+                    type="button"
+                    variant={selected ? "primary" : "ghost"}
+                    size="compact"
+                    aria-pressed={selected}
+                    onClick={() => handleViewModeChange(option.mode)}
+                  >
+                    {option.label}
+                  </Button>
+                );
+              })}
+            </div>
             <Button
               type="button"
-              variant={showWeekend ? "primary" : "outline"}
+              variant="outline"
               size="compact"
-              aria-pressed={showWeekend}
-              onClick={() => setShowWeekend((value) => !value)}
+              className="bg-white"
+              onClick={() => handleDateChange(new Date())}
             >
-              {hiddenWeekendCount > 0
-                ? `Sa/So (${hiddenWeekendCount})`
-                : "Sa/So"}
+              Heute
             </Button>
-          ) : null}
-          {onCreate ? (
-            <Button type="button" size="compact" onClick={onCreate}>
-              <Plus className="mr-1.5 h-4 w-4" aria-hidden />
-              Neuer Termin
-            </Button>
-          ) : null}
+            {viewMode !== "day" ? (
+              <Button
+                type="button"
+                variant={showWeekend ? "primary" : "outline"}
+                size="compact"
+                className={showWeekend ? "" : "bg-white"}
+                aria-pressed={showWeekend}
+                onClick={() => setShowWeekend((value) => !value)}
+              >
+                {hiddenWeekendCount > 0
+                  ? `Sa/So (${hiddenWeekendCount})`
+                  : "Sa/So"}
+              </Button>
+            ) : null}
+            {onCreate ? (
+              <Button
+                type="button"
+                size="compact"
+                className="w-full justify-center sm:w-auto"
+                onClick={onCreate}
+              >
+                <Plus className="h-4 w-4" aria-hidden />
+                Neuer Termin
+              </Button>
+            ) : null}
+          </div>
         </div>
       </div>
 
@@ -611,18 +600,13 @@ export function PersonalCalendar({
           </div>
         ) : null}
 
-        <div className="space-y-3 lg:hidden">
-          {visibleSortedEvents.length === 0 ? (
-            <EmptyCalendarState viewMode={viewMode} />
-          ) : (
-            visibleSortedEvents.map((event) => (
-              <CalendarEventItem
-                key={event.id}
-                event={event}
-                actions={actions}
-              />
-            ))
-          )}
+        <div className="lg:hidden">
+          <MobileAgenda
+            days={mobileDays}
+            events={events}
+            viewMode={viewMode}
+            actions={actions}
+          />
         </div>
 
         {!loading && visibleSortedEvents.length === 0 ? (
@@ -631,6 +615,77 @@ export function PersonalCalendar({
           </div>
         ) : null}
       </div>
+
+      <Modal
+        isOpen={selectedEvent !== null}
+        onClose={() => setSelectedEvent(null)}
+        title="Termin"
+        widthClass="mx-4 w-[calc(100%-2rem)] max-w-lg"
+      >
+        {selectedEvent ? (
+          <CalendarEventDetail
+            event={selectedEvent}
+            actions={actions}
+            onClose={() => setSelectedEvent(null)}
+          />
+        ) : null}
+      </Modal>
+    </div>
+  );
+}
+
+// Mobile replacement for the desktop time grid: a per-day agenda. Events are
+// grouped under a sticky day header (weekday + date + count) so a full week no
+// longer collapses into one undifferentiated list where Monday can't be told
+// from Friday. Days without events are dropped entirely.
+function MobileAgenda({
+  days,
+  events,
+  viewMode,
+  actions,
+}: Readonly<{
+  days: readonly Date[];
+  events: readonly CalendarEvent[];
+  viewMode: CalendarViewMode;
+  actions: CalendarEventActions;
+}>) {
+  const groups = days
+    .map((day) => {
+      const dayEvents = eventsForDay(events, day);
+      return {
+        day,
+        allDay: dayEvents.filter(isAllDayLike),
+        timed: dayEvents.filter((event) => !isAllDayLike(event)),
+        count: dayEvents.length,
+      };
+    })
+    .filter((group) => group.count > 0);
+
+  if (groups.length === 0) {
+    return <EmptyCalendarState viewMode={viewMode} />;
+  }
+
+  return (
+    <div className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      {groups.map(({ day, allDay, timed, count }) => (
+        <section key={toISODate(day)} className="divide-y divide-gray-100">
+          <div className="flex items-baseline justify-between gap-2 bg-gray-50 px-4 py-2">
+            <h2 className="text-sm font-semibold text-gray-900">
+              {formatDayHeader(day)}
+            </h2>
+            <span className="shrink-0 text-xs text-gray-500">
+              {count === 1 ? "1 Eintrag" : `${count} Einträge`}
+            </span>
+          </div>
+          {[...allDay, ...timed].map((event) => (
+            <AgendaRow
+              key={`${event.id}-${toISODate(day)}`}
+              event={event}
+              actions={actions}
+            />
+          ))}
+        </section>
+      ))}
     </div>
   );
 }
@@ -670,9 +725,9 @@ function CalendarDayColumn({
           {events.length === 1 ? "1 Eintrag" : `${events.length} Einträge`}
         </div>
       </div>
-      <div className={`space-y-2 ${compact ? "p-1.5" : "p-2"}`}>
+      <div className={`space-y-1 ${compact ? "p-1.5" : "p-2"}`}>
         {events.map((event) => (
-          <CalendarEventItem
+          <EventPill
             key={`${event.id}-${toISODate(day)}`}
             event={event}
             actions={actions}
@@ -697,15 +752,8 @@ function CalendarTimeGrid({
     day,
     events: eventsForDay(events, day),
   }));
-  const layoutOptions: TimedLayoutOptions = {
-    hasRespond: Boolean(actions.onRespond),
-    hasOverview: Boolean(actions.onShowOverview),
-    hasManage: Boolean(actions.onEdit ?? actions.onCancel ?? actions.onDelete),
-    hasIcs: Boolean(actions.icsHrefBase),
-  };
   const { startHour, endHour } = gridHours(
     dayBuckets.flatMap((bucket) => bucket.events),
-    layoutOptions,
   );
   const gridStartMinutes = startHour * 60;
   const bodyHeight = (endHour - startHour) * HOUR_PX;
@@ -732,7 +780,7 @@ function CalendarTimeGrid({
   return (
     <div>
       <div className="flex border-b border-gray-200">
-        <div className="w-14 shrink-0 border-r border-gray-200 bg-gray-50" />
+        <div className="w-16 shrink-0 border-r border-gray-200 bg-gray-50" />
         <div className="grid flex-1" style={columnTemplate}>
           {dayBuckets.map(({ day, events: dayEvents }) => (
             <div
@@ -753,7 +801,7 @@ function CalendarTimeGrid({
       </div>
       {hasAllDay ? (
         <div className="flex border-b border-gray-200">
-          <div className="w-14 shrink-0 border-r border-gray-200 px-1 py-2 text-right text-[11px] text-gray-400">
+          <div className="w-16 shrink-0 border-r border-gray-200 px-1 py-2 text-center text-[11px] text-gray-400">
             Ganztägig
           </div>
           <div className="grid flex-1" style={columnTemplate}>
@@ -763,7 +811,7 @@ function CalendarTimeGrid({
                 className="space-y-1 border-r border-gray-200 p-1 last:border-r-0"
               >
                 {dayEvents.filter(isAllDayLike).map((event) => (
-                  <CalendarEventItem
+                  <EventPill
                     key={`${event.id}-${toISODate(day)}`}
                     event={event}
                     actions={actions}
@@ -776,12 +824,12 @@ function CalendarTimeGrid({
       ) : null}
       <div ref={scrollRef} className="max-h-[70vh] overflow-y-auto">
         <div className="flex" style={{ height: bodyHeight }}>
-          <div className="relative w-14 shrink-0 border-r border-gray-200">
+          <div className="relative w-16 shrink-0 border-r border-gray-200">
             {hours.map((hour) =>
               hour === startHour ? null : (
                 <div
                   key={hour}
-                  className="absolute right-1 -translate-y-1/2 text-[11px] text-gray-400"
+                  className="absolute inset-x-0 -translate-y-1/2 text-center text-[11px] text-gray-400"
                   style={{ top: (hour - startHour) * HOUR_PX }}
                 >
                   {`${String(hour).padStart(2, "0")}:00`}
@@ -828,12 +876,6 @@ function TimeGridDayBody({
   );
   const timed = layoutTimedEvents(
     events.filter((event) => event.source !== "shift" && !isAllDayLike(event)),
-    {
-      hasRespond: Boolean(actions.onRespond),
-      hasOverview: Boolean(actions.onShowOverview),
-      hasManage: Boolean(actions.onEdit ?? actions.onCancel ?? actions.onDelete),
-      hasIcs: Boolean(actions.icsHrefBase),
-    },
   );
   return (
     <div
@@ -858,9 +900,11 @@ function TimeGridDayBody({
           startMinutes + 30,
         );
         return (
-          <div
+          <button
             key={event.id}
-            className="absolute inset-x-0.5 z-0 overflow-hidden rounded-md border px-1.5 py-1"
+            type="button"
+            onClick={() => actions.onSelect?.(event)}
+            className="absolute inset-x-0.5 z-0 overflow-hidden rounded-md border px-1.5 py-1 text-left transition-[filter] hover:brightness-95"
             style={{
               top: ((startMinutes - gridStartMinutes) / 60) * HOUR_PX + 1,
               height: ((endMinutes - startMinutes) / 60) * HOUR_PX - 2,
@@ -869,18 +913,10 @@ function TimeGridDayBody({
             }}
           >
             <div className="flex flex-wrap items-center gap-1 text-[11px] text-gray-700">
-              <span className="rounded bg-white/80 px-1 py-0.5 font-semibold">
-                {tone.label}
-              </span>
               <span className="font-semibold text-gray-900">{event.title}</span>
               <span>{eventTime(event)}</span>
             </div>
-            {event.description ? (
-              <p className="mt-0.5 truncate text-[11px] text-gray-600">
-                {event.description}
-              </p>
-            ) : null}
-          </div>
+          </button>
         );
       })}
       {timed.map((placement) => (
@@ -904,53 +940,23 @@ function TimeGridEventBlock({
   gridStartMinutes: number;
   actions: CalendarEventActions;
 }>) {
-  const {
-    onShowOverview,
-    onRespond,
-    respondingRecipientId,
-    onEdit,
-    onCancel,
-    onDelete,
-    busyAppointmentId,
-    icsHrefBase,
-  } = actions;
   const { event, startMinutes, endMinutes, column, columnCount } = placement;
   const tone = sourceTone[event.source];
-  const recipientId = event.recipient_id;
   const cancelled = event.cancelled === true;
-  const responding =
-    Boolean(recipientId) && respondingRecipientId === recipientId;
-  // A cancelled appointment can no longer be answered — hide RSVP, matching
-  // CalendarEventItem.
-  const showRespond = Boolean(
-    !cancelled && event.can_respond && recipientId && onRespond,
-  );
-  const showOverview = Boolean(
-    event.can_view_overview && event.appointment_id && onShowOverview,
-  );
-  // Day/week timed blocks must offer the same management + export as the month
-  // and mobile CalendarEventItem, so organizers and parents never have to switch
-  // views to edit, cancel, delete, or download a timed appointment.
-  const canManage =
-    event.source === "appointment" &&
-    event.can_edit &&
-    Boolean(event.appointment_id) &&
-    Boolean(onEdit ?? onCancel ?? onDelete);
-  const managing =
-    Boolean(event.appointment_id) && busyAppointmentId === event.appointment_id;
-  const showIcs = Boolean(
-    !cancelled &&
-      event.source === "appointment" &&
-      event.appointment_id &&
-      icsHrefBase,
-  );
   // endMinutes ist bereits das effektive Render-Ende aus layoutTimedEvents —
   // die Mindesthöhe steckt in der Platzierung, damit nichts überdeckt wird.
   const height = ((endMinutes - startMinutes) / 60) * HOUR_PX - 2;
   const widthPercent = 100 / columnCount;
+  const subtitle = [event.student_name, event.school_name]
+    .filter(Boolean)
+    .join(" · ");
   return (
-    <article
-      className="absolute z-10 overflow-hidden rounded-md border border-gray-200 p-1.5 shadow-sm"
+    <button
+      type="button"
+      onClick={() => actions.onSelect?.(event)}
+      className={`absolute z-10 overflow-hidden rounded-md border border-gray-200 p-1.5 text-left shadow-sm transition-[filter] hover:brightness-95 ${
+        cancelled ? "opacity-70" : ""
+      }`}
       style={{
         top: ((startMinutes - gridStartMinutes) / 60) * HOUR_PX + 1,
         height,
@@ -960,137 +966,157 @@ function TimeGridEventBlock({
         backgroundColor: tone.bg,
       }}
     >
-      <div className="flex flex-wrap items-center gap-1">
-        <span className="rounded bg-white/80 px-1 py-0.5 text-[10px] font-semibold text-gray-700">
-          {tone.label}
-        </span>
-        {event.response_status ? (
-          <span className="rounded bg-white/80 px-1 py-0.5 text-[10px] font-semibold text-gray-700">
-            {responseLabel[event.response_status] ?? event.response_status}
-          </span>
-        ) : null}
-      </div>
-      <div className="truncate text-xs font-semibold text-gray-950">
+      <div
+        className={`truncate text-xs font-semibold text-gray-950 ${
+          cancelled ? "line-through" : ""
+        }`}
+      >
         {event.title}
       </div>
-      <div className="text-[11px] text-gray-600">{eventTime(event)}</div>
-      {event.student_name || event.school_name ? (
-        <div className="truncate text-[11px] text-gray-600">
-          {[event.student_name, event.school_name].filter(Boolean).join(" · ")}
-        </div>
-      ) : null}
+      <div className="truncate text-[11px] text-gray-600">
+        {eventTime(event)}
+      </div>
       {event.location ? (
-        <div className="flex items-center gap-1 text-[11px] text-gray-600">
+        <div className="flex items-center gap-1 text-[11px] text-gray-500">
           <MapPin className="h-3 w-3 shrink-0" aria-hidden />
           <span className="truncate">{event.location}</span>
         </div>
       ) : null}
-      {event.description ? (
-        <p className="mt-0.5 line-clamp-2 text-[11px] leading-4 text-gray-600">
-          {event.description}
-        </p>
+      {subtitle ? (
+        <div className="truncate text-[11px] text-gray-500">{subtitle}</div>
       ) : null}
-      {showOverview ? (
-        <Button
-          type="button"
-          size="compact"
-          variant="ghost"
-          className="mt-1 w-full bg-white/50"
-          onClick={() => onShowOverview!(event.appointment_id!)}
-        >
-          <Users className="h-4 w-4" aria-hidden />
-          Teilnehmer
-        </Button>
-      ) : null}
-      {showRespond ? (
-        <div className="mt-1 flex gap-1">
-          <Button
-            type="button"
-            size="compact"
-            variant="outline"
-            className="flex-1"
-            disabled={responding}
-            onClick={() => onRespond!(recipientId!, "accepted")}
-          >
-            <Check className="h-4 w-4" aria-hidden />
-            Zusagen
-          </Button>
-          <Button
-            type="button"
-            size="compact"
-            variant="outline_danger"
-            className="flex-1"
-            disabled={responding}
-            onClick={() => onRespond!(recipientId!, "declined")}
-          >
-            <X className="h-4 w-4" aria-hidden />
-            Absagen
-          </Button>
-        </div>
-      ) : null}
-      {showIcs ? (
-        <a
-          href={`${icsHrefBase}/${encodeURIComponent(event.appointment_id!)}/ics`}
-          download
-          className="mt-1 inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-md bg-white/50 px-2.5 text-xs font-medium text-gray-700 transition-colors hover:bg-white"
-        >
-          <CalendarPlus className="h-4 w-4" aria-hidden />
-          Zum Kalender hinzufügen
-        </a>
-      ) : null}
-      {canManage ? (
-        <div className="mt-1 flex flex-wrap gap-1 border-t border-white/60 pt-1.5">
-          {onEdit && !cancelled ? (
-            <Button
-              type="button"
-              size="compact"
-              variant="ghost"
-              className="bg-white/50"
-              disabled={managing}
-              onClick={() => onEdit(event)}
-            >
-              <Pencil className="h-4 w-4" aria-hidden />
-              Bearbeiten
-            </Button>
-          ) : null}
-          {onCancel && !cancelled ? (
-            <Button
-              type="button"
-              size="compact"
-              variant="ghost"
-              className="bg-white/50 text-[#CC2626]"
-              disabled={managing}
-              onClick={() => onCancel(event)}
-            >
-              <Ban className="h-4 w-4" aria-hidden />
-              Absagen
-            </Button>
-          ) : null}
-          {onDelete ? (
-            <Button
-              type="button"
-              size="compact"
-              variant="ghost"
-              className="bg-white/50 text-[#CC2626]"
-              disabled={managing}
-              onClick={() => onDelete(event)}
-            >
-              <Trash2 className="h-4 w-4" aria-hidden />
-              Löschen
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
-    </article>
+    </button>
   );
 }
 
-function CalendarEventItem({
+// Apple-Kalender-artige Agenda-Zeile: linksbündige Zeitspalte, farbige Leiste,
+// Titel + kompakte Unterzeile. Wird als Zeile INNERHALB des durchgehenden
+// Tages-Panels gerendert (kein eigenes Karten-Chrome). Tap öffnet das Detail.
+function AgendaRow({
   event,
   actions,
+}: Readonly<{ event: CalendarEvent; actions: CalendarEventActions }>) {
+  const tone = sourceTone[event.source];
+  const cancelled = event.cancelled === true;
+  const allDay = isAllDayLike(event);
+  const badge = cancelled
+    ? { label: "Abgesagt", cls: "bg-[#FF3130]/10 text-[#CC2626]" }
+    : event.response_status
+      ? {
+          label: responseLabel[event.response_status] ?? event.response_status,
+          cls: responseTone[event.response_status],
+        }
+      : null;
+  const subtitle = [
+    tone.label,
+    event.location,
+    event.student_name,
+    event.school_name,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  return (
+    <button
+      type="button"
+      onClick={() => actions.onSelect?.(event)}
+      className={`flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 ${
+        cancelled ? "opacity-70" : ""
+      }`}
+    >
+      <div className="flex w-12 shrink-0 flex-col items-start leading-tight tabular-nums">
+        {allDay ? (
+          <span className="text-[11px] font-medium text-gray-400">ganztg.</span>
+        ) : (
+          <>
+            <span className="text-sm font-semibold text-gray-900">
+              {event.start_time}
+            </span>
+            <span className="text-[11px] text-gray-400">{event.end_time}</span>
+          </>
+        )}
+      </div>
+      <span
+        className="h-9 w-1 shrink-0 rounded-full"
+        style={{ backgroundColor: tone.bar }}
+        aria-hidden
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span
+            className={`truncate text-sm font-semibold text-gray-950 ${
+              cancelled ? "line-through" : ""
+            }`}
+          >
+            {event.title}
+          </span>
+          {badge ? (
+            <span
+              className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold ${badge.cls}`}
+            >
+              {badge.label}
+            </span>
+          ) : null}
+        </div>
+        {subtitle ? (
+          <div className="mt-0.5 truncate text-xs text-gray-500">
+            {subtitle}
+          </div>
+        ) : null}
+      </div>
+    </button>
+  );
+}
+
+// Schmale einzeilige Pille für Ganztägig-Einträge (Wochen-/Tagesraster + Mobile)
+// und Monatszellen. Tap öffnet das Detail-Sheet.
+function EventPill({
+  event,
+  actions,
+}: Readonly<{ event: CalendarEvent; actions: CalendarEventActions }>) {
+  const tone = sourceTone[event.source];
+  const cancelled = event.cancelled === true;
+  const showTime = !event.all_day && event.start_date === event.end_date;
+  return (
+    <button
+      type="button"
+      onClick={() => actions.onSelect?.(event)}
+      className={`flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-left transition-[filter] hover:brightness-95 ${
+        cancelled ? "opacity-70" : ""
+      }`}
+      style={{ backgroundColor: tone.bg }}
+    >
+      <span
+        className="h-2 w-2 shrink-0 rounded-full"
+        style={{ backgroundColor: tone.bar }}
+        aria-hidden
+      />
+      <span
+        className={`min-w-0 flex-1 truncate text-xs font-medium text-gray-900 ${
+          cancelled ? "line-through" : ""
+        }`}
+      >
+        {event.title}
+      </span>
+      {showTime ? (
+        <span className="shrink-0 text-[11px] text-gray-500 tabular-nums">
+          {event.start_time}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+// Detail-Sheet, geöffnet beim Antippen eines Termins. Trägt alle Aktionen, die
+// früher inline auf jeder Karte lagen (Antworten, Teilnehmer, Export, Verwalten)
+// — so bleiben die Kalenderflächen selbst schlank und lesbar.
+function CalendarEventDetail({
+  event,
+  actions,
+  onClose,
 }: Readonly<{
   event: CalendarEvent;
   actions: CalendarEventActions;
+  onClose: () => void;
 }>) {
   const {
     onShowOverview,
@@ -1107,165 +1133,227 @@ function CalendarEventItem({
   const cancelled = event.cancelled === true;
   const responding =
     Boolean(recipientId) && respondingRecipientId === recipientId;
+  const managing =
+    Boolean(event.appointment_id) && busyAppointmentId === event.appointment_id;
   const canManage =
     event.source === "appointment" &&
     event.can_edit &&
     Boolean(event.appointment_id) &&
     Boolean(onEdit ?? onCancel ?? onDelete);
-  const managing =
-    Boolean(event.appointment_id) && busyAppointmentId === event.appointment_id;
+  const showOverview = Boolean(
+    event.can_view_overview && event.appointment_id && onShowOverview,
+  );
+  const showRespond = Boolean(
+    !cancelled && event.can_respond && recipientId && onRespond,
+  );
+  const showIcs = Boolean(
+    !cancelled &&
+    event.source === "appointment" &&
+    event.appointment_id &&
+    icsHrefBase,
+  );
+  const startDate = parseISODate(event.start_date);
+  const endDate = parseISODate(event.end_date);
+  const dateLabel =
+    event.start_date !== event.end_date
+      ? `${startDate.toLocaleDateString("de-DE", {
+          day: "2-digit",
+          month: "long",
+        })} – ${endDate.toLocaleDateString("de-DE", {
+          day: "2-digit",
+          month: "long",
+          year: "numeric",
+        })}`
+      : startDate.toLocaleDateString("de-DE", {
+          weekday: "long",
+          day: "2-digit",
+          month: "long",
+          year: "numeric",
+        });
+  const subtitle = [event.student_name, event.school_name]
+    .filter(Boolean)
+    .join(" · ");
+  const hasActions = showOverview || showRespond || showIcs || canManage;
   return (
-    <article
-      className={`rounded-lg border border-gray-200 bg-white p-3 shadow-sm ${
-        cancelled ? "opacity-70" : ""
-      }`}
-      style={{ borderLeft: `4px solid ${tone.bar}`, backgroundColor: tone.bg }}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-1.5">
-            <span className="rounded-md bg-white/80 px-1.5 py-0.5 text-[11px] font-semibold text-gray-700">
-              {tone.label}
-            </span>
-            {cancelled ? (
-              <span className="rounded-md bg-[#FF3130]/10 px-1.5 py-0.5 text-[11px] font-semibold text-[#CC2626]">
-                Abgesagt
-              </span>
-            ) : null}
-            {!cancelled && event.response_status ? (
-              <span className="rounded-md bg-white/80 px-1.5 py-0.5 text-[11px] font-semibold text-gray-700">
-                {responseLabel[event.response_status] ?? event.response_status}
-              </span>
-            ) : null}
-          </div>
-          <h2
-            className={`mt-1 truncate text-sm font-semibold text-gray-950 ${
-              cancelled ? "line-through" : ""
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span
+          className="rounded-md px-2 py-0.5 text-[11px] font-semibold text-gray-700"
+          style={{ backgroundColor: tone.bg }}
+        >
+          {tone.label}
+        </span>
+        {cancelled ? (
+          <span className="rounded-md bg-[#FF3130]/10 px-2 py-0.5 text-[11px] font-semibold text-[#CC2626]">
+            Abgesagt
+          </span>
+        ) : event.response_status ? (
+          <span
+            className={`rounded-md px-2 py-0.5 text-[11px] font-semibold ${
+              responseTone[event.response_status]
             }`}
           >
-            {event.title}
-          </h2>
-        </div>
+            {responseLabel[event.response_status] ?? event.response_status}
+          </span>
+        ) : null}
       </div>
-      <div className="mt-2 space-y-1 text-xs text-gray-700">
-        <div className="flex items-center gap-1.5">
-          <Clock className="h-3.5 w-3.5" aria-hidden />
+
+      <h3
+        className={`text-lg font-semibold text-gray-950 ${
+          cancelled ? "line-through" : ""
+        }`}
+      >
+        {event.title}
+      </h3>
+
+      <div className="space-y-2 text-sm text-gray-700">
+        <div className="flex items-center gap-2">
+          <CalendarDays
+            className="h-4 w-4 shrink-0 text-gray-400"
+            aria-hidden
+          />
+          <span>{dateLabel}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Clock className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
           <span>{eventTime(event)}</span>
         </div>
         {event.location ? (
-          <div className="flex items-center gap-1.5">
-            <MapPin className="h-3.5 w-3.5" aria-hidden />
-            <span className="truncate">{event.location}</span>
+          <div className="flex items-center gap-2">
+            <MapPin className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
+            <span>{event.location}</span>
           </div>
         ) : null}
-        {event.student_name || event.school_name ? (
-          <div className="truncate">
-            {[event.student_name, event.school_name]
-              .filter(Boolean)
-              .join(" · ")}
+        {subtitle ? (
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
+            <span>{subtitle}</span>
           </div>
         ) : null}
       </div>
+
       {event.description ? (
-        <p className="mt-2 line-clamp-3 text-xs leading-5 text-gray-700">
+        <p className="text-sm leading-6 whitespace-pre-line text-gray-700">
           {event.description}
         </p>
       ) : null}
-      {event.can_view_overview && event.appointment_id && onShowOverview ? (
-        <Button
-          type="button"
-          size="compact"
-          variant="ghost"
-          className="mt-3 w-full bg-white/50"
-          onClick={() => onShowOverview(event.appointment_id!)}
-        >
-          <Users className="h-4 w-4" aria-hidden />
-          Teilnehmer
-        </Button>
-      ) : null}
-      {!cancelled &&
-      event.source === "appointment" &&
-      event.appointment_id &&
-      icsHrefBase ? (
-        <a
-          href={`${icsHrefBase}/${encodeURIComponent(event.appointment_id)}/ics`}
-          download
-          className="mt-2 inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-md bg-white/50 px-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-white"
-        >
-          <CalendarPlus className="h-4 w-4" aria-hidden />
-          Zum Kalender hinzufügen
-        </a>
-      ) : null}
-      {!cancelled && event.can_respond && recipientId && onRespond ? (
-        <div className="mt-3 grid gap-1.5">
-          <Button
-            type="button"
-            size="compact"
-            variant="outline"
-            className="w-full"
-            disabled={responding}
-            onClick={() => onRespond(recipientId, "accepted")}
-          >
-            <Check className="h-4 w-4" aria-hidden />
-            Zusagen
-          </Button>
-          <Button
-            type="button"
-            size="compact"
-            variant="outline_danger"
-            className="w-full"
-            disabled={responding}
-            onClick={() => onRespond(recipientId, "declined")}
-          >
-            <X className="h-4 w-4" aria-hidden />
-            Absagen
-          </Button>
+
+      {hasActions ? (
+        <div className="flex flex-col gap-2 border-t border-gray-200 pt-4">
+          {showRespond ? (
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="md"
+                className="gap-2"
+                disabled={responding}
+                onClick={() => {
+                  onRespond!(recipientId!, "accepted");
+                  onClose();
+                }}
+              >
+                <Check className="h-4 w-4" aria-hidden />
+                Zusagen
+              </Button>
+              <Button
+                type="button"
+                variant="outline_danger"
+                size="md"
+                className="gap-2"
+                disabled={responding}
+                onClick={() => {
+                  onRespond!(recipientId!, "declined");
+                  onClose();
+                }}
+              >
+                <X className="h-4 w-4" aria-hidden />
+                Absagen
+              </Button>
+            </div>
+          ) : null}
+          {showIcs ? (
+            <a
+              href={`${icsHrefBase}/${encodeURIComponent(
+                event.appointment_id!,
+              )}/ics`}
+              download
+              className="inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-md bg-gray-100 px-4 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200"
+            >
+              <CalendarPlus className="h-4 w-4" aria-hidden />
+              Zum Kalender hinzufügen
+            </a>
+          ) : null}
+          {showOverview ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="md"
+              className="gap-2"
+              onClick={() => {
+                onShowOverview!(event.appointment_id!);
+                onClose();
+              }}
+            >
+              <Users className="h-4 w-4" aria-hidden />
+              Teilnehmer
+            </Button>
+          ) : null}
+          {canManage ? (
+            <div className="flex flex-wrap gap-2">
+              {onEdit && !cancelled ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="md"
+                  className="gap-2"
+                  disabled={managing}
+                  onClick={() => {
+                    onEdit(event);
+                    onClose();
+                  }}
+                >
+                  <Pencil className="h-4 w-4" aria-hidden />
+                  Bearbeiten
+                </Button>
+              ) : null}
+              {onCancel && !cancelled ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="md"
+                  className="gap-2 text-[#CC2626]"
+                  disabled={managing}
+                  onClick={() => {
+                    onCancel(event);
+                    onClose();
+                  }}
+                >
+                  <Ban className="h-4 w-4" aria-hidden />
+                  Absagen
+                </Button>
+              ) : null}
+              {onDelete ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="md"
+                  className="gap-2 text-[#CC2626]"
+                  disabled={managing}
+                  onClick={() => {
+                    onDelete(event);
+                    onClose();
+                  }}
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden />
+                  Löschen
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       ) : null}
-      {canManage ? (
-        <div className="mt-3 flex flex-wrap gap-1.5 border-t border-white/60 pt-2.5">
-          {onEdit && !cancelled ? (
-            <Button
-              type="button"
-              size="compact"
-              variant="ghost"
-              className="bg-white/50"
-              disabled={managing}
-              onClick={() => onEdit(event)}
-            >
-              <Pencil className="h-4 w-4" aria-hidden />
-              Bearbeiten
-            </Button>
-          ) : null}
-          {onCancel && !cancelled ? (
-            <Button
-              type="button"
-              size="compact"
-              variant="ghost"
-              className="bg-white/50 text-[#CC2626]"
-              disabled={managing}
-              onClick={() => onCancel(event)}
-            >
-              <Ban className="h-4 w-4" aria-hidden />
-              Absagen
-            </Button>
-          ) : null}
-          {onDelete ? (
-            <Button
-              type="button"
-              size="compact"
-              variant="ghost"
-              className="bg-white/50 text-[#CC2626]"
-              disabled={managing}
-              onClick={() => onDelete(event)}
-            >
-              <Trash2 className="h-4 w-4" aria-hidden />
-              Löschen
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
-    </article>
+    </div>
   );
 }
 

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -902,6 +902,10 @@ function TimeGridDayBody({
           />
         ),
       )}
+      {/* Das gesamte Dienst-Band ist der klickbare Bereich (z-0, unter den
+          Terminblöcken): Termine (z-10) gewinnen immer in ihrer eigenen
+          Fläche, jeder sichtbare Band-Pixel öffnet den Dienst — so bleiben
+          beide auch bei Überlappung bedienbar. */}
       {shiftBands.map((event) => {
         const tone = sourceTone[event.source];
         const startMinutes = clockToMinutes(event.start_time);
@@ -910,41 +914,14 @@ function TimeGridDayBody({
           startMinutes + 30,
         );
         return (
-          <div
-            key={`${event.id}-band`}
-            aria-hidden
-            className="absolute inset-x-0.5 z-0 rounded-md border"
-            style={{
-              top: ((startMinutes - gridStartMinutes) / 60) * HOUR_PX + 1,
-              height: ((endMinutes - startMinutes) / 60) * HOUR_PX - 2,
-              backgroundColor: tone.bg,
-              borderColor: `${tone.bar}55`,
-            }}
-          />
-        );
-      })}
-      {timed.map((placement) => (
-        <TimeGridEventBlock
-          key={placement.event.id}
-          placement={placement}
-          gridStartMinutes={gridStartMinutes}
-          actions={actions}
-        />
-      ))}
-      {/* Klickbare Dienst-Labels NACH den Terminblöcken (z-20), damit
-          überlappende Termine (z-10) den Dienst nicht unbedienbar machen —
-          die Fläche selbst bleibt als dekoratives Band im Hintergrund. */}
-      {shiftBands.map((event) => {
-        const tone = sourceTone[event.source];
-        const startMinutes = clockToMinutes(event.start_time);
-        return (
           <button
             key={event.id}
             type="button"
             onClick={() => actions.onSelect?.(event)}
-            className="absolute inset-x-0.5 z-20 overflow-hidden rounded-md border px-1.5 py-1 text-left transition-[filter] hover:brightness-95"
+            className="absolute inset-x-0.5 z-0 flex flex-col overflow-hidden rounded-md border px-1.5 py-1 text-left transition-[filter] hover:brightness-95"
             style={{
               top: ((startMinutes - gridStartMinutes) / 60) * HOUR_PX + 1,
+              height: ((endMinutes - startMinutes) / 60) * HOUR_PX - 2,
               backgroundColor: tone.bg,
               borderColor: `${tone.bar}55`,
             }}
@@ -956,6 +933,14 @@ function TimeGridDayBody({
           </button>
         );
       })}
+      {timed.map((placement) => (
+        <TimeGridEventBlock
+          key={placement.event.id}
+          placement={placement}
+          gridStartMinutes={gridStartMinutes}
+          actions={actions}
+        />
+      ))}
     </div>
   );
 }

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -218,13 +218,16 @@ interface TimedPlacement {
 
 // Mindesthöhe eines Zeitraster-Blocks in Pixeln, abhängig vom Inhalt. Blöcke
 // zeigen nur noch Titel, Zeit und optional Ort/Zuordnung — Aktionen leben im
-// Detail-Sheet (Klick), daher kein Button-Platz mehr. Muss zum Markup in
-// TimeGridEventBlock passen, sonst würde kurzer Text abgeschnitten.
+// Detail-Sheet (Klick). Der Wert muss zur tatsächlich gerenderten Box in
+// TimeGridEventBlock passen: 12px vertikales Padding (py-1.5) + 2px Rahmen +
+// eine Titelzeile (~16px) + eine Zeitzeile (~16px), plus je ~16px für Ort und
+// die Zuordnungs-Unterzeile. Der Block ist overflow-hidden — eine zu kleine
+// Höhe schneidet bei kurzen Terminen Zeit/Metadaten sichtbar ab.
 function blockMinHeightPx(event: CalendarEvent): number {
   return (
-    38 +
-    ((event.student_name ?? event.school_name) ? 15 : 0) +
-    (event.location ? 15 : 0)
+    54 +
+    (event.location ? 16 : 0) +
+    ((event.student_name ?? event.school_name) ? 16 : 0)
   );
 }
 
@@ -489,8 +492,12 @@ export function PersonalCalendar({
               <ChevronRight className="h-4 w-4" aria-hidden />
             </Button>
           </div>
+          {/* On mobile each control fills the row (no right-hand gap): the view
+              switch spans full width with equal segments, Heute/Sa-So share a
+              row, and 'Neuer Termin' spans its own. From sm up they collapse
+              back to a compact inline toolbar. */}
           <div className="flex flex-wrap items-center gap-2">
-            <div className="flex items-center gap-1 rounded-lg border border-gray-200 bg-white p-1 shadow-sm">
+            <div className="flex w-full items-center gap-1 rounded-lg border border-gray-200 bg-white p-1 shadow-sm sm:w-auto">
               {viewOptions.map((option) => {
                 const selected = option.mode === viewMode;
                 return (
@@ -499,6 +506,7 @@ export function PersonalCalendar({
                     type="button"
                     variant={selected ? "primary" : "ghost"}
                     size="compact"
+                    className="flex-1 justify-center sm:flex-none"
                     aria-pressed={selected}
                     onClick={() => handleViewModeChange(option.mode)}
                   >
@@ -511,7 +519,7 @@ export function PersonalCalendar({
               type="button"
               variant="outline"
               size="compact"
-              className="bg-white"
+              className="flex-1 justify-center bg-white sm:flex-none"
               onClick={() => handleDateChange(new Date())}
             >
               Heute
@@ -521,7 +529,9 @@ export function PersonalCalendar({
                 type="button"
                 variant={showWeekend ? "primary" : "outline"}
                 size="compact"
-                className={showWeekend ? "" : "bg-white"}
+                className={`flex-1 justify-center sm:flex-none ${
+                  showWeekend ? "" : "bg-white"
+                }`}
                 aria-pressed={showWeekend}
                 onClick={() => setShowWeekend((value) => !value)}
               >

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -910,14 +910,41 @@ function TimeGridDayBody({
           startMinutes + 30,
         );
         return (
+          <div
+            key={`${event.id}-band`}
+            aria-hidden
+            className="absolute inset-x-0.5 z-0 rounded-md border"
+            style={{
+              top: ((startMinutes - gridStartMinutes) / 60) * HOUR_PX + 1,
+              height: ((endMinutes - startMinutes) / 60) * HOUR_PX - 2,
+              backgroundColor: tone.bg,
+              borderColor: `${tone.bar}55`,
+            }}
+          />
+        );
+      })}
+      {timed.map((placement) => (
+        <TimeGridEventBlock
+          key={placement.event.id}
+          placement={placement}
+          gridStartMinutes={gridStartMinutes}
+          actions={actions}
+        />
+      ))}
+      {/* Klickbare Dienst-Labels NACH den Terminblöcken (z-20), damit
+          überlappende Termine (z-10) den Dienst nicht unbedienbar machen —
+          die Fläche selbst bleibt als dekoratives Band im Hintergrund. */}
+      {shiftBands.map((event) => {
+        const tone = sourceTone[event.source];
+        const startMinutes = clockToMinutes(event.start_time);
+        return (
           <button
             key={event.id}
             type="button"
             onClick={() => actions.onSelect?.(event)}
-            className="absolute inset-x-0.5 z-0 overflow-hidden rounded-md border px-1.5 py-1 text-left transition-[filter] hover:brightness-95"
+            className="absolute inset-x-0.5 z-20 overflow-hidden rounded-md border px-1.5 py-1 text-left transition-[filter] hover:brightness-95"
             style={{
               top: ((startMinutes - gridStartMinutes) / 60) * HOUR_PX + 1,
-              height: ((endMinutes - startMinutes) / 60) * HOUR_PX - 2,
               backgroundColor: tone.bg,
               borderColor: `${tone.bar}55`,
             }}
@@ -929,14 +956,6 @@ function TimeGridDayBody({
           </button>
         );
       })}
-      {timed.map((placement) => (
-        <TimeGridEventBlock
-          key={placement.event.id}
-          placement={placement}
-          gridStartMinutes={gridStartMinutes}
-          actions={actions}
-        />
-      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Was ist passiert

Redesign des geteilten `PersonalCalendar` (Mitarbeitenden- **und** Elternportal) plus Politur am „Termin erstellen"-Modal.

## Vorher (kurzer Nachruf 🕯️)

Sagen wir es so: der Kalender war die einzige Seite, die sich freiwillig auf `max-w-7xl` gekettet und mittig in der Leere geparkt hat, während jede andere Seite entspannt die volle Breite genoss. Dazu:

- **Ganztägig** wurde als Hochhaus gerendert — „Ausflug Zoo" kam mit fünf Buttons im Schlepptau und schob das Zeitraster in den Keller.
- **Jede** Event-Karte war ein Cockpit: Zusagen, Absagen, Teilnehmer, Bearbeiten, Absagen (nochmal), Löschen — inline, auf jeder einzelnen Karte, immer.
- **Mobile** war eine flache Liste, die die ganze Woche in einen Topf warf. Montag von Freitag zu unterscheiden? Detektivarbeit.
- Und der Charme obendrauf: durchscheinende Buttons, eine Icon-Eyebrow, die keine andere Seite hatte, und Dropdown-Pfeile, die sich rechts an den Rand klammerten.

Kurzum: es sah aus wie ein Kalender, den man aus Versehen gebaut hat. Jetzt sieht er aus wie einer, den man wollte.

## Nachher

- **Full width** auf der OGS-Seite (verschachteltes `<main>` + `max-w-7xl` raus) — wie jede andere Seite.
- **Mobile = eine durchgehende iOS-artige Agenda**: ein solides Panel, Tages-Header als Abschnittszeilen, Zeilen mit Zeitspalte + farbiger Leiste + Titel + Status-Badge. Kein Karten-Konfetti mehr.
- **Kompakte Event-Flächen überall** (Raster-Blöcke, Ganztägig-Pillen, Monats-Pillen, Agenda-Zeilen). Klick/Tap öffnet ein **Detail-Sheet**, das alle Aktionen trägt (Zusagen/Absagen, Teilnehmer, Export, Bearbeiten/Absagen/Löschen).
- **Ganztägig** als schlanke Pille statt Button-Turm.
- **Header aufgeräumt**: Icon-Eyebrow weg, Zeitachse + „Ganztägig" zentriert, Trennstrich über dem Raster entfernt, Toolbar-Buttons solide, „Neuer Termin" mobil full-width.
- **Create-Modal poliert**: Selects auf Input-Höhe (gemeinsame Klasse), ungerades 3-in-2-Grid entfernt, „Ziele suchen" in den Empfänger-Block, eigene konsistent platzierte Dropdown-Chevrons.

Beide Portale profitieren, weil geteilte Komponente.

## Review-Fixes (im Verlauf schon erledigt)

- Tests an das Detail-Sheet angepasst (Event öffnen, dann Aktion) und die Page-Suites in die Fixture-Woche gepinnt, da die Agenda jetzt korrekt auf den sichtbaren Zeitraum begrenzt ist. **17/17 grün.**
- `blockMinHeightPx` an die echte gerenderte Box angehoben → kurze `overflow-hidden`-Blöcke clippen nichts mehr.

## Hinweis: Event-Typ / Farben

Die Farbe hängt an der Herkunft (`event.source`), nicht an einer Auswahl: **Termin** (grün) = manuell angelegt, **Betreuung** (blau) = Stundenplan, **Dienst** (orange) = Dienstplan (`sourceTone` → `LOCATION_COLORS`). Ein eigener Kategorie-/Farbwähler für Termine wäre ein separates Feature (Backend-Feld nötig), bewusst nicht Teil dieses PRs.

## Checks

- `pnpm run check` (verify-locales + oxlint + tsc) ✅
- `pnpm vitest run --changed origin/development` → 17/17 ✅

## Screenshots

<details>
<summary>📸 </summary>
<img width="1440" height="900" alt="01-desktop-week" src="https://github.com/user-attachments/assets/922a7ca4-bae4-48d7-96fd-40fc5533d002" />
<img width="1440" height="900" alt="02-desktop-day" src="https://github.com/user-attachments/assets/2ef7551c-d7c1-4aeb-8a96-2cb628fd2e4a" />
<img width="1440" height="900" alt="03-desktop-month" src="https://github.com/user-attachments/assets/49fe0c6d-fc80-4230-9830-f77ace04017a" />
<img width="1440" height="900" alt="04-desktop-event-detail" src="https://github.com/user-attachments/assets/94331ff7-787c-4fcf-b062-d60327f5dc80" />
<img width="1440" height="1200" alt="05-desktop-create-modal" src="https://github.com/user-attachments/assets/c215441a-4166-4975-b452-e21a54f0fecf" />
<img width="390" height="844" alt="06-mobile-week" src="https://github.com/user-attachments/assets/4803fdfd-ac41-40a6-948e-5a52db9b4060" />
<img width="390" height="844" alt="07-mobile-day" src="https://github.com/user-attachments/assets/cd9fde37-6d72-4115-9733-3e4732a8e5a2" />
<img width="390" height="844" alt="08-mobile-month" src="https://github.com/user-attachments/assets/a4399fde-c869-45d8-816b-af475c70e30b" />
<img width="390" height="844" alt="09-mobile-event-detail" src="https://github.com/user-attachments/assets/356069de-2ea5-4b21-950a-5e0393775645" />


</details>
