### PR TITLE
fix(audit): make the audit schema append-only for phoenix_tenant (#1924)

### DIFF
--- a/backend/database/migrations/001015225_audit_append_only_grants.go
+++ b/backend/database/migrations/001015225_audit_append_only_grants.go
@@ -129,6 +129,25 @@ func auditAppendOnlyGrantsUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("failed revoking tenant privileges on audit migration backups: %w", err)
 	}
 
+	// The table REVOKE above does not reach their BIGSERIAL sequences: those
+	// are separate objects, and 1.14.1's "ALTER DEFAULT PRIVILEGES IN SCHEMA
+	// audit GRANT USAGE ON SEQUENCES TO phoenix_tenant" handed them out when
+	// 1.15.45/1.15.48 created the tables. USAGE permits nextval, i.e. mutating
+	// the counter of a cross-tenant backup object the role must not touch at
+	// all. Revoke ALL (USAGE, SELECT, UPDATE) so the isolation is complete.
+	//
+	// Only these two sequences: every other audit table is INSERT-able by
+	// design and needs its sequence's USAGE to make that INSERT work, so the
+	// schema-wide sequence default stays as it is.
+	if _, err := db.NewRaw(`
+		REVOKE ALL ON SEQUENCE
+			audit.room_color_migration_backup_id_seq,
+			audit.wc_alias_migration_backup_id_seq
+		FROM phoenix_tenant;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed revoking tenant privileges on audit migration backup sequences: %w", err)
+	}
+
 	// Root cause: stop the schema-wide default ACL from handing UPDATE/DELETE
 	// to every future audit table. New tables now start append-only and a
 	// migration that genuinely needs more has to grant it explicitly — which
@@ -215,6 +234,18 @@ func auditAppendOnlyGrantsDown(ctx context.Context, db *bun.DB) error {
 		TO phoenix_tenant;
 	`).Exec(ctx); err != nil {
 		return fmt.Errorf("failed restoring tenant privileges on audit migration backups: %w", err)
+	}
+
+	// Only USAGE goes back: that is what 1.14.1's sequence default granted.
+	// SELECT and UPDATE on these sequences were never held, so re-granting
+	// them would leave a state the database was never in.
+	if _, err := db.NewRaw(`
+		GRANT USAGE ON SEQUENCE
+			audit.room_color_migration_backup_id_seq,
+			audit.wc_alias_migration_backup_id_seq
+		TO phoenix_tenant;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed restoring tenant privileges on audit migration backup sequences: %w", err)
 	}
 
 	return nil

--- a/backend/database/migrations/001015225_audit_append_only_grants.go
+++ b/backend/database/migrations/001015225_audit_append_only_grants.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/uptrace/bun"
 )
@@ -138,6 +139,40 @@ func auditAppendOnlyGrantsUp(ctx context.Context, db *bun.DB) error {
 			REVOKE UPDATE, DELETE, TRUNCATE ON TABLES FROM phoenix_tenant;
 	`).Exec(ctx); err != nil {
 		return fmt.Errorf("failed narrowing default privileges on schema audit: %w", err)
+	}
+
+	// Verify the ALTER actually landed. ALTER DEFAULT PRIVILEGES without
+	// FOR ROLE is implicitly FOR ROLE current_user: it narrows only the
+	// pg_default_acl row whose grantor is the migrating superuser. If 1.14.1
+	// was applied under a different role than this migration runs as, the
+	// REVOKE above creates a *second* row and the original arwd default
+	// survives — every future audit table would silently inherit
+	// UPDATE/DELETE again while this migration reports success. The guard
+	// tests only ever see the test database, so fail loudly here instead.
+	var defaultACL []string
+	if err := db.NewRaw(`
+		SELECT acl::text
+		FROM pg_default_acl d
+		JOIN pg_namespace n ON n.oid = d.defaclnamespace
+		CROSS JOIN LATERAL unnest(d.defaclacl) AS acl
+		WHERE n.nspname = 'audit'
+		  AND d.defaclobjtype = 'r'
+		  AND acl::text LIKE 'phoenix_tenant=%';
+	`).Scan(ctx, &defaultACL); err != nil {
+		return fmt.Errorf("failed reading back default privileges on schema audit: %w", err)
+	}
+	for _, item := range defaultACL {
+		// aclitem text form: "grantee=privileges/grantor".
+		privileges, _, _ := strings.Cut(strings.TrimPrefix(item, "phoenix_tenant="), "/")
+		// Privilege letters (case-sensitive): w=UPDATE, d=DELETE, D=TRUNCATE.
+		if strings.ContainsAny(privileges, "wdD") {
+			return fmt.Errorf(
+				"default privileges on schema audit still grant phoenix_tenant UPDATE/DELETE/TRUNCATE (%s); "+
+					"the ALTER DEFAULT PRIVILEGES above is scoped to the grantor role, so a row created by a "+
+					"different superuser survives — re-run the REVOKE as that role "+
+					"(ALTER DEFAULT PRIVILEGES FOR ROLE <grantor> IN SCHEMA audit ...)",
+				item)
+		}
 	}
 
 	fmt.Println("  ✓ audit schema is append-only for phoenix_tenant (DELETE kept on deviation_events + unregistered_tag_scans for retention)")

--- a/backend/database/migrations/001015225_audit_append_only_grants.go
+++ b/backend/database/migrations/001015225_audit_append_only_grants.go
@@ -58,6 +58,14 @@ func init() {
 // table's RLS, so revoking here does not break the cascade paths
 // (audit.work_session_edits via active.work_sessions,
 // audit.deviation_events.instance_id, audit.data_access_log.student_id, …).
+//
+// Two audit tables are deliberately absent from every statement below, and
+// their absence is not a gap: audit.enrollment_deletions (revoked in 1.15.200,
+// the same migration that creates it) and audit.enrollment_offering_adjustments
+// (revoked in 1.15.201) already hold SELECT, INSERT only. Re-revoking would be
+// a no-op that implies the earlier migrations left something undone. The guard
+// test does not take that on trust — it enumerates every table in the audit
+// schema from pg_class, so both are asserted append-only there like all others.
 func auditAppendOnlyGrantsUp(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Migration 1.15.225: Making the audit schema append-only for phoenix_tenant...")
 

--- a/backend/database/migrations/001015225_audit_append_only_grants.go
+++ b/backend/database/migrations/001015225_audit_append_only_grants.go
@@ -71,8 +71,13 @@ func auditAppendOnlyGrantsUp(ctx context.Context, db *bun.DB) error {
 	//   work_session_edits   — time-tracking edit trail; rows disappear only
 	//                          through the ON DELETE CASCADE from
 	//                          active.work_sessions during retention cleanup.
+	//
+	// TRUNCATE is revoked alongside them. The 1.14.1 default ACL never handed
+	// it out, so this is a no-op today — but a table nobody may DELETE from is
+	// not append-only while it can still be emptied in one statement, and
+	// stating it here makes the guarantee explicit rather than accidental.
 	if _, err := db.NewRaw(`
-		REVOKE UPDATE, DELETE ON
+		REVOKE UPDATE, DELETE, TRUNCATE ON
 			audit.auth_events,
 			audit.data_access_log,
 			audit.data_deletions,
@@ -81,7 +86,7 @@ func auditAppendOnlyGrantsUp(ctx context.Context, db *bun.DB) error {
 			audit.work_session_edits
 		FROM phoenix_tenant;
 	`).Exec(ctx); err != nil {
-		return fmt.Errorf("failed revoking tenant UPDATE/DELETE on append-only audit tables: %w", err)
+		return fmt.Errorf("failed revoking tenant UPDATE/DELETE/TRUNCATE on append-only audit tables: %w", err)
 	}
 
 	// Append-only plus tenant-scoped retention: DELETE must stay.
@@ -95,13 +100,17 @@ func auditAppendOnlyGrantsUp(ctx context.Context, db *bun.DB) error {
 	//                            Resolve(), is an operator-portal action and runs
 	//                            under phoenix_admin (operator requests carry no
 	//                            tenant, so TenantTxMiddleware opens no tenant tx).
+	//
+	// The retention jobs delete row by row (DeleteOlderThan with a date
+	// predicate), so TRUNCATE goes here too — wiping the whole table is never
+	// a legitimate tenant operation.
 	if _, err := db.NewRaw(`
-		REVOKE UPDATE ON
+		REVOKE UPDATE, TRUNCATE ON
 			audit.deviation_events,
 			audit.unregistered_tag_scans
 		FROM phoenix_tenant;
 	`).Exec(ctx); err != nil {
-		return fmt.Errorf("failed revoking tenant UPDATE on retention-cleaned audit tables: %w", err)
+		return fmt.Errorf("failed revoking tenant UPDATE/TRUNCATE on retention-cleaned audit tables: %w", err)
 	}
 
 	// One-off migration backups (1.15.45 room colours, 1.15.48 WC aliases).
@@ -122,10 +131,11 @@ func auditAppendOnlyGrantsUp(ctx context.Context, db *bun.DB) error {
 	// Root cause: stop the schema-wide default ACL from handing UPDATE/DELETE
 	// to every future audit table. New tables now start append-only and a
 	// migration that genuinely needs more has to grant it explicitly — which
-	// is exactly the decision a reviewer should see.
+	// is exactly the decision a reviewer should see. TRUNCATE is included so
+	// the default cannot start handing it out either.
 	if _, err := db.NewRaw(`
 		ALTER DEFAULT PRIVILEGES IN SCHEMA audit
-			REVOKE UPDATE, DELETE ON TABLES FROM phoenix_tenant;
+			REVOKE UPDATE, DELETE, TRUNCATE ON TABLES FROM phoenix_tenant;
 	`).Exec(ctx); err != nil {
 		return fmt.Errorf("failed narrowing default privileges on schema audit: %w", err)
 	}
@@ -136,6 +146,10 @@ func auditAppendOnlyGrantsUp(ctx context.Context, db *bun.DB) error {
 
 func auditAppendOnlyGrantsDown(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Rolling back migration 1.15.225: Restoring tenant UPDATE/DELETE on the audit schema...")
+
+	// TRUNCATE is deliberately NOT restored anywhere below: the 1.14.1 default
+	// ACL never granted it, so re-granting would leave the database in a state
+	// it was never in before this migration.
 
 	if _, err := db.NewRaw(`
 		ALTER DEFAULT PRIVILEGES IN SCHEMA audit

--- a/backend/database/migrations/001015225_audit_append_only_grants.go
+++ b/backend/database/migrations/001015225_audit_append_only_grants.go
@@ -1,0 +1,172 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	auditAppendOnlyGrantsVersion     = "1.15.225"
+	auditAppendOnlyGrantsDescription = "Make the audit schema append-only for phoenix_tenant: revoke inherited UPDATE/DELETE and close the schema-wide default ACL (#1924)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     auditAppendOnlyGrantsVersion,
+		Description: auditAppendOnlyGrantsDescription,
+		DependsOn: []string{
+			createTenantRolesVersion,
+			enrollmentDeletionsAuditVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return auditAppendOnlyGrantsUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return auditAppendOnlyGrantsDown(ctx, db)
+		},
+	)
+}
+
+// auditAppendOnlyGrantsUp closes the gap described in issue #1924.
+//
+// Migration 1.14.1 set a schema-wide default ACL granting phoenix_tenant
+// SELECT, INSERT, UPDATE, DELETE on every table created later in the audit
+// schema. Because migrations run as the postgres superuser, that default
+// applied to all audit tables, and the deliberately narrow
+// "GRANT SELECT, INSERT" statements in the later table-creating migrations
+// were purely additive: the inherited UPDATE/DELETE stayed. None of the
+// audit tables were append-only at the database level.
+//
+// The RLS policies on these tables are FOR ALL, so a request running under
+// phoenix_tenant could UPDATE/DELETE its own tenant's audit rows. No
+// application code issues such statements, which makes this defense in
+// depth rather than a reachable hole — but the append-only guarantee these
+// tables claim (GDPR deletion log, guardian change audit, data access log)
+// has to hold in the database, not only by convention.
+//
+// DELETE stays for two tables whose GDPR retention jobs run per tenant
+// inside the server's phoenix_tenant transactions (see the table map
+// below). Rows removed through ON DELETE CASCADE and columns nulled through
+// ON DELETE SET NULL need no privilege at all: referential actions execute
+// with the privileges of the table owner and are not subject to the child
+// table's RLS, so revoking here does not break the cascade paths
+// (audit.work_session_edits via active.work_sessions,
+// audit.deviation_events.instance_id, audit.data_access_log.student_id, …).
+func auditAppendOnlyGrantsUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.225: Making the audit schema append-only for phoenix_tenant...")
+
+	// Append-only: insert and read, never change or remove.
+	//
+	//   auth_events          — written by the login/MFA flows, read by the
+	//                          security views. No update or delete path.
+	//   data_access_log      — GDPR read-access trail, insert-only repository.
+	//   data_deletions       — GDPR deletion log written by the cleanup services.
+	//   data_imports         — import audit, insert-only repository.
+	//   guardian_changes     — guardian change audit, insert + list only.
+	//   work_session_edits   — time-tracking edit trail; rows disappear only
+	//                          through the ON DELETE CASCADE from
+	//                          active.work_sessions during retention cleanup.
+	if _, err := db.NewRaw(`
+		REVOKE UPDATE, DELETE ON
+			audit.auth_events,
+			audit.data_access_log,
+			audit.data_deletions,
+			audit.data_imports,
+			audit.guardian_changes,
+			audit.work_session_edits
+		FROM phoenix_tenant;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed revoking tenant UPDATE/DELETE on append-only audit tables: %w", err)
+	}
+
+	// Append-only plus tenant-scoped retention: DELETE must stay.
+	//
+	//   deviation_events       — TimetableCleanupService.CleanupExpiredTimetableData
+	//                            deletes by occurrence_date; the scheduler runs it
+	//                            per tenant inside WithTenantTx (already documented
+	//                            in migration 1.15.193).
+	//   unregistered_tag_scans — UnregisteredTagScanService.DeleteOlderThan (90-day
+	//                            retention) runs the same way. Its only UPDATE,
+	//                            Resolve(), is an operator-portal action and runs
+	//                            under phoenix_admin (operator requests carry no
+	//                            tenant, so TenantTxMiddleware opens no tenant tx).
+	if _, err := db.NewRaw(`
+		REVOKE UPDATE ON
+			audit.deviation_events,
+			audit.unregistered_tag_scans
+		FROM phoenix_tenant;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed revoking tenant UPDATE on retention-cleaned audit tables: %w", err)
+	}
+
+	// One-off migration backups (1.15.45 room colours, 1.15.48 WC aliases).
+	// Both are the documented manual-restore source for those migrations'
+	// rollbacks and must NOT be dropped. They are also the only audit tables
+	// without RLS, so any phoenix_tenant SELECT would cross tenant borders.
+	// No application code touches them; restores run as phoenix_admin or the
+	// superuser. Revoke everything.
+	if _, err := db.NewRaw(`
+		REVOKE ALL ON
+			audit.room_color_migration_backup,
+			audit.wc_alias_migration_backup
+		FROM phoenix_tenant;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed revoking tenant privileges on audit migration backups: %w", err)
+	}
+
+	// Root cause: stop the schema-wide default ACL from handing UPDATE/DELETE
+	// to every future audit table. New tables now start append-only and a
+	// migration that genuinely needs more has to grant it explicitly — which
+	// is exactly the decision a reviewer should see.
+	if _, err := db.NewRaw(`
+		ALTER DEFAULT PRIVILEGES IN SCHEMA audit
+			REVOKE UPDATE, DELETE ON TABLES FROM phoenix_tenant;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed narrowing default privileges on schema audit: %w", err)
+	}
+
+	fmt.Println("  ✓ audit schema is append-only for phoenix_tenant (DELETE kept on deviation_events + unregistered_tag_scans for retention)")
+	return nil
+}
+
+func auditAppendOnlyGrantsDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.225: Restoring tenant UPDATE/DELETE on the audit schema...")
+
+	if _, err := db.NewRaw(`
+		ALTER DEFAULT PRIVILEGES IN SCHEMA audit
+			GRANT UPDATE, DELETE ON TABLES TO phoenix_tenant;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed restoring default privileges on schema audit: %w", err)
+	}
+
+	if _, err := db.NewRaw(`
+		GRANT UPDATE, DELETE ON
+			audit.auth_events,
+			audit.data_access_log,
+			audit.data_deletions,
+			audit.data_imports,
+			audit.guardian_changes,
+			audit.work_session_edits,
+			audit.deviation_events,
+			audit.unregistered_tag_scans
+		TO phoenix_tenant;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed restoring tenant UPDATE/DELETE on audit tables: %w", err)
+	}
+
+	if _, err := db.NewRaw(`
+		GRANT SELECT, INSERT, UPDATE, DELETE ON
+			audit.room_color_migration_backup,
+			audit.wc_alias_migration_backup
+		TO phoenix_tenant;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed restoring tenant privileges on audit migration backups: %w", err)
+	}
+
+	return nil
+}

--- a/backend/database/migrations/001015225_audit_append_only_grants_test.go
+++ b/backend/database/migrations/001015225_audit_append_only_grants_test.go
@@ -33,6 +33,15 @@ var auditDeleteAllowlist = map[string]string{
 // actions run with the table owner's privileges.
 var auditUpdateAllowlist = map[string]string{}
 
+// allTablePrivileges is the complete PostgreSQL 17 table privilege set. Checking
+// only SELECT/INSERT/UPDATE/DELETE would let a lone TRUNCATE (or REFERENCES,
+// TRIGGER, MAINTAIN) grant slip through an assertion that claims "no privilege
+// at all".
+var allTablePrivileges = []string{
+	"SELECT", "INSERT", "UPDATE", "DELETE",
+	"TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN",
+}
+
 func auditSchemaTables(t *testing.T, db *bun.DB) []string {
 	t.Helper()
 	var tables []string
@@ -44,6 +53,23 @@ func auditSchemaTables(t *testing.T, db *bun.DB) []string {
 		ORDER BY c.relname
 	`).Scan(context.Background(), &tables))
 	return tables
+}
+
+// tenantACLEntries returns the raw aclitem strings granted to phoenix_tenant on
+// an audit table, e.g. "phoenix_tenant=arD/postgres". Empty means the role holds
+// no directly granted privilege of any kind.
+func tenantACLEntries(t *testing.T, db *bun.DB, table string) []string {
+	t.Helper()
+	var entries []string
+	require.NoError(t, db.NewRaw(`
+		SELECT acl::text
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		CROSS JOIN LATERAL unnest(COALESCE(c.relacl, '{}'::aclitem[])) AS acl
+		WHERE n.nspname = 'audit' AND c.relname = ?
+		  AND acl::text LIKE 'phoenix_tenant=%'
+	`, table).Scan(context.Background(), &entries))
+	return entries
 }
 
 func tenantHasPrivilege(t *testing.T, db *bun.DB, relation, privilege string) bool {
@@ -75,22 +101,46 @@ func TestAuditSchemaAppendOnlyForTenantRole(t *testing.T) {
 					"granted it explicitly.", relation)
 		}
 
-		if _, allowed := auditDeleteAllowlist[table]; !allowed {
+		if reason, allowed := auditDeleteAllowlist[table]; allowed {
+			// The allowlist is a requirement, not an exemption: revoking DELETE
+			// from one of these breaks the nightly retention job with
+			// "permission denied" — a failure that surfaces in production logs
+			// at 02:00, not in CI. Assert the privilege is actually there.
+			assert.Truef(t, tenantHasPrivilege(t, db, relation, "DELETE"),
+				"%s: phoenix_tenant MUST hold DELETE — %s. Without it the job fails under "+
+					"phoenix_tenant. Drop the allowlist entry only together with the job.", relation, reason)
+		} else {
 			assert.Falsef(t, tenantHasPrivilege(t, db, relation, "DELETE"),
 				"%s: phoenix_tenant must not hold DELETE. If a retention job needs it, add the "+
 					"table to auditDeleteAllowlist with a reason; if rows expire through an "+
 					"ON DELETE CASCADE, no privilege is required.", relation)
 		}
+
+		// TRUNCATE has no allowlist: the retention jobs delete row by row with a
+		// date predicate, so nothing legitimately empties an audit table under
+		// the tenant role — and an append-only table that can be truncated in
+		// one statement is not append-only.
+		assert.Falsef(t, tenantHasPrivilege(t, db, relation, "TRUNCATE"),
+			"%s: phoenix_tenant must not hold TRUNCATE — it erases the whole audit table "+
+				"in one statement, DELETE-allowlist or not.", relation)
 	}
 
 	// The one-off migration backups carry no RLS, so any tenant-role access
 	// would cross tenant borders. Restores run as phoenix_admin/superuser.
+	// Check the COMPLETE PostgreSQL table privilege set, not just the four
+	// obvious ones: TRUNCATE alone would let the tenant role erase the
+	// cross-tenant backup contents.
 	for _, table := range []string{"room_color_migration_backup", "wc_alias_migration_backup"} {
 		relation := "audit." + table
-		for _, privilege := range []string{"SELECT", "INSERT", "UPDATE", "DELETE"} {
+		for _, privilege := range allTablePrivileges {
 			assert.Falsef(t, tenantHasPrivilege(t, db, relation, privilege),
 				"%s: phoenix_tenant must hold no %s — the table has no RLS policy", relation, privilege)
 		}
+		// Belt and braces against a privilege type a future PostgreSQL adds and
+		// allTablePrivileges does not know about yet: the table ACL must carry
+		// no phoenix_tenant entry whatsoever.
+		assert.Emptyf(t, tenantACLEntries(t, db, table), //nolint:testifylint // Empty reads better than Len(…, 0) here
+			"audit.%s: table ACL still carries a phoenix_tenant grant", table)
 	}
 }
 
@@ -116,11 +166,12 @@ func TestAuditSchemaDefaultACLIsAppendOnly(t *testing.T) {
 			continue
 		}
 		privileges, _, _ := strings.Cut(rest, "/")
-		assert.NotContainsf(t, privileges, "w",
-			"default ACL on schema audit still grants phoenix_tenant UPDATE (%s) — "+
-				"every future audit table would start mutable", item)
-		assert.NotContainsf(t, privileges, "d",
-			"default ACL on schema audit still grants phoenix_tenant DELETE (%s) — "+
-				"every future audit table would start deletable", item)
+		// aclitem privilege letters (case-sensitive): w=UPDATE, d=DELETE,
+		// D=TRUNCATE. r=SELECT and a=INSERT are what an audit table needs.
+		for letter, privilege := range map[string]string{"w": "UPDATE", "d": "DELETE", "D": "TRUNCATE"} {
+			assert.NotContainsf(t, privileges, letter,
+				"default ACL on schema audit still grants phoenix_tenant %s (%s) — "+
+					"every future audit table would start with it", privilege, item)
+		}
 	}
 }

--- a/backend/database/migrations/001015225_audit_append_only_grants_test.go
+++ b/backend/database/migrations/001015225_audit_append_only_grants_test.go
@@ -42,6 +42,12 @@ var allTablePrivileges = []string{
 	"TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN",
 }
 
+// allSequencePrivileges is the complete PostgreSQL sequence privilege set. A
+// sequence is a separate object from its table: "REVOKE ALL ON <table>" leaves
+// it untouched, so a backup table locked down at the table level can still have
+// its counter moved via nextval (USAGE).
+var allSequencePrivileges = []string{"USAGE", "SELECT", "UPDATE"}
+
 func auditSchemaTables(t *testing.T, db *bun.DB) []string {
 	t.Helper()
 	var tables []string
@@ -78,6 +84,29 @@ func tenantHasPrivilege(t *testing.T, db *bun.DB, relation, privilege string) bo
 	require.NoError(t, db.NewRaw(`SELECT has_table_privilege('phoenix_tenant', ?, ?)`, relation, privilege).
 		Scan(context.Background(), &granted))
 	return granted
+}
+
+func tenantHasSequencePrivilege(t *testing.T, db *bun.DB, sequence, privilege string) bool {
+	t.Helper()
+	var granted bool
+	require.NoError(t, db.NewRaw(`SELECT has_sequence_privilege('phoenix_tenant', ?, ?)`, sequence, privilege).
+		Scan(context.Background(), &granted))
+	return granted
+}
+
+// tenantSequenceACLEntries is the sequence counterpart of tenantACLEntries.
+func tenantSequenceACLEntries(t *testing.T, db *bun.DB, sequence string) []string {
+	t.Helper()
+	var entries []string
+	require.NoError(t, db.NewRaw(`
+		SELECT acl::text
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		CROSS JOIN LATERAL unnest(COALESCE(c.relacl, '{}'::aclitem[])) AS acl
+		WHERE n.nspname = 'audit' AND c.relname = ? AND c.relkind = 'S'
+		  AND acl::text LIKE 'phoenix_tenant=%'
+	`, sequence).Scan(context.Background(), &entries))
+	return entries
 }
 
 // TestAuditSchemaAppendOnlyForTenantRole is the ratchet for issue #1924. The
@@ -141,6 +170,19 @@ func TestAuditSchemaAppendOnlyForTenantRole(t *testing.T) {
 		// no phoenix_tenant entry whatsoever.
 		assert.Emptyf(t, tenantACLEntries(t, db, table), //nolint:testifylint // Empty reads better than Len(…, 0) here
 			"audit.%s: table ACL still carries a phoenix_tenant grant", table)
+
+		// Same for the BIGSERIAL sequence behind the table. It is a distinct
+		// object that the table-level REVOKE does not reach, and 1.14.1's
+		// sequence default ACL granted USAGE on it — enough to move the
+		// counter of a table the role must not touch at all.
+		sequence := table + "_id_seq"
+		for _, privilege := range allSequencePrivileges {
+			assert.Falsef(t, tenantHasSequencePrivilege(t, db, "audit."+sequence, privilege),
+				"audit.%s: phoenix_tenant must hold no %s — the backing table has no RLS policy "+
+					"and REVOKE ALL on the table does not cover its sequence", sequence, privilege)
+		}
+		assert.Emptyf(t, tenantSequenceACLEntries(t, db, sequence), //nolint:testifylint // Empty reads better than Len(…, 0) here
+			"audit.%s: sequence ACL still carries a phoenix_tenant grant", sequence)
 	}
 }
 

--- a/backend/database/migrations/001015225_audit_append_only_grants_test.go
+++ b/backend/database/migrations/001015225_audit_append_only_grants_test.go
@@ -1,0 +1,126 @@
+package migrations
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// auditDeleteAllowlist names the audit tables phoenix_tenant may still DELETE
+// from, because their GDPR retention job runs per tenant inside a
+// WithTenantTx (SET LOCAL ROLE phoenix_tenant):
+//
+//   - deviation_events:       TimetableCleanupService.CleanupExpiredTimetableData
+//   - unregistered_tag_scans: UnregisteredTagScanService.DeleteOlderThan
+//
+// Shrink-only. Adding an entry means a new table is no longer append-only —
+// justify it in the PR description or find another way to expire the rows
+// (an ON DELETE CASCADE from the owning table needs no privilege at all).
+var auditDeleteAllowlist = map[string]string{
+	"deviation_events":       "timetable GDPR retention runs under phoenix_tenant",
+	"unregistered_tag_scans": "90-day scan retention runs under phoenix_tenant",
+}
+
+// auditUpdateAllowlist is intentionally EMPTY: no application path modifies an
+// existing audit row under the tenant role. ON DELETE SET NULL columns
+// (deviation_events.instance_id, data_access_log.student_id,
+// unregistered_tag_scans.device_id, …) do not need UPDATE — referential
+// actions run with the table owner's privileges.
+var auditUpdateAllowlist = map[string]string{}
+
+func auditSchemaTables(t *testing.T, db *bun.DB) []string {
+	t.Helper()
+	var tables []string
+	require.NoError(t, db.NewRaw(`
+		SELECT c.relname
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'audit' AND c.relkind = 'r'
+		ORDER BY c.relname
+	`).Scan(context.Background(), &tables))
+	return tables
+}
+
+func tenantHasPrivilege(t *testing.T, db *bun.DB, relation, privilege string) bool {
+	t.Helper()
+	var granted bool
+	require.NoError(t, db.NewRaw(`SELECT has_table_privilege('phoenix_tenant', ?, ?)`, relation, privilege).
+		Scan(context.Background(), &granted))
+	return granted
+}
+
+// TestAuditSchemaAppendOnlyForTenantRole is the ratchet for issue #1924. The
+// audit schema must stay append-only for phoenix_tenant: never UPDATE, and
+// DELETE only where a tenant-scoped retention job needs it.
+func TestAuditSchemaAppendOnlyForTenantRole(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tables := auditSchemaTables(t, db)
+	require.NotEmpty(t, tables, "expected tables in the audit schema")
+
+	for _, table := range tables {
+		relation := "audit." + table
+
+		if _, allowed := auditUpdateAllowlist[table]; !allowed {
+			assert.Falsef(t, tenantHasPrivilege(t, db, relation, "UPDATE"),
+				"%s: phoenix_tenant must not hold UPDATE — audit rows are append-only. "+
+					"A new table inherits this from the schema default ACL only if migration "+
+					"1.15.225's ALTER DEFAULT PRIVILEGES was undone; otherwise some migration "+
+					"granted it explicitly.", relation)
+		}
+
+		if _, allowed := auditDeleteAllowlist[table]; !allowed {
+			assert.Falsef(t, tenantHasPrivilege(t, db, relation, "DELETE"),
+				"%s: phoenix_tenant must not hold DELETE. If a retention job needs it, add the "+
+					"table to auditDeleteAllowlist with a reason; if rows expire through an "+
+					"ON DELETE CASCADE, no privilege is required.", relation)
+		}
+	}
+
+	// The one-off migration backups carry no RLS, so any tenant-role access
+	// would cross tenant borders. Restores run as phoenix_admin/superuser.
+	for _, table := range []string{"room_color_migration_backup", "wc_alias_migration_backup"} {
+		relation := "audit." + table
+		for _, privilege := range []string{"SELECT", "INSERT", "UPDATE", "DELETE"} {
+			assert.Falsef(t, tenantHasPrivilege(t, db, relation, privilege),
+				"%s: phoenix_tenant must hold no %s — the table has no RLS policy", relation, privilege)
+		}
+	}
+}
+
+// TestAuditSchemaDefaultACLIsAppendOnly guards the root cause: without this,
+// the next audit table silently inherits UPDATE/DELETE again and only the
+// per-table assertions above would catch it — after the fact.
+func TestAuditSchemaDefaultACLIsAppendOnly(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	var aclItems []string
+	require.NoError(t, db.NewRaw(`
+		SELECT unnest(d.defaclacl)::text
+		FROM pg_default_acl d
+		JOIN pg_namespace n ON n.oid = d.defaclnamespace
+		WHERE n.nspname = 'audit' AND d.defaclobjtype = 'r'
+	`).Scan(context.Background(), &aclItems))
+
+	for _, item := range aclItems {
+		// aclitem text form: "grantee=privileges/grantor", e.g. "phoenix_tenant=ar/postgres".
+		grantee, rest, found := strings.Cut(item, "=")
+		if !found || grantee != "phoenix_tenant" {
+			continue
+		}
+		privileges, _, _ := strings.Cut(rest, "/")
+		assert.NotContainsf(t, privileges, "w",
+			"default ACL on schema audit still grants phoenix_tenant UPDATE (%s) — "+
+				"every future audit table would start mutable", item)
+		assert.NotContainsf(t, privileges, "d",
+			"default ACL on schema audit still grants phoenix_tenant DELETE (%s) — "+
+				"every future audit table would start deletable", item)
+	}
+}


### PR DESCRIPTION
Closes #1924.

## Problem

Migration 1.14.1 sets a schema-wide default ACL:

```sql
ALTER DEFAULT PRIVILEGES IN SCHEMA ... audit
    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO phoenix_tenant;
```

Migrations run as the postgres superuser, so that default applied to every table created later in the `audit` schema. The deliberately narrow `GRANT SELECT, INSERT` statements in the later table-creating migrations were purely additive — the inherited UPDATE/DELETE stayed. Together with the `FOR ALL` RLS policies, a request running under `phoenix_tenant` could have changed or removed its own tenant's audit rows.

State before this PR (verified against a live DB):

| table | phoenix_tenant |
|---|---|
| `auth_events`, `data_access_log`, `data_deletions`, `data_imports`, `deviation_events`, `guardian_changes`, `unregistered_tag_scans`, `work_session_edits`, `room_color_migration_backup`, `wc_alias_migration_backup` | SELECT, INSERT, **UPDATE, DELETE** |
| `enrollment_deletions`, `enrollment_offering_adjustments` | SELECT, INSERT (already fixed by 1.15.200 / 1.15.201) |

No application code issues such statements, so this is a defense-in-depth gap rather than a reachable hole — but the append-only guarantee these tables claim (GDPR deletion log, guardian change audit, data access log) has to hold in the database, not only by convention.

## Change

Migration **1.15.225** (`001015225_audit_append_only_grants.go`):

| table(s) | action |
|---|---|
| `auth_events`, `data_access_log`, `data_deletions`, `data_imports`, `guardian_changes`, `work_session_edits` | `REVOKE UPDATE, DELETE` |
| `deviation_events`, `unregistered_tag_scans` | `REVOKE UPDATE` — DELETE stays |
| `room_color_migration_backup`, `wc_alias_migration_backup` | `REVOKE ALL` |
| schema `audit` | `ALTER DEFAULT PRIVILEGES ... REVOKE UPDATE, DELETE ON TABLES` |

The down migration restores all of it.

### Why DELETE stays on two tables

The issue proposed revoking DELETE on `unregistered_tag_scans` as well. That would break the nightly cleanup. Both of these run their GDPR retention per tenant inside `WithTenantTx`, i.e. as `phoenix_tenant`:

- `deviation_events` — `TimetableCleanupService.CleanupExpiredTimetableData`
- `unregistered_tag_scans` — `UnregisteredTagScanService.DeleteOlderThan` (90 days), called from `scheduler.go` inside `forEachTenant`

Migration 1.15.193 already documents this for `deviation_events`. The only UPDATE on `unregistered_tag_scans`, `Resolve()`, is an operator-portal action: operator requests carry no tenant, `TenantTxMiddleware` opens no tenant transaction, and the service wraps the write in `WithAdminTxOrDirect` → `phoenix_admin`. So UPDATE can go, DELETE cannot.

### Why the cascade paths are unaffected

Several audit tables hang off FKs with `ON DELETE CASCADE` (`work_session_edits` → `active.work_sessions`, deleted by the time-tracking retention job under the tenant role) and `ON DELETE SET NULL` (`deviation_events.instance_id`, `data_access_log.student_id`, `unregistered_tag_scans.device_id`, …). `SET NULL` is technically an UPDATE on the audit table.

Verified empirically on PostgreSQL 17 (throwaway schema, inside a transaction, rolled back): referential actions execute with the privileges of the table owner and are not subject to the child table's RLS, even with `FORCE ROW LEVEL SECURITY`. Both the cascade delete and the SET NULL update succeeded while the acting role held neither DELETE nor UPDATE on the child. Migration 1.15.201 already relies on the same property.

### Why the backup tables lose everything, and are not dropped

`room_color_migration_backup` (1.15.45) and `wc_alias_migration_backup` (1.15.48) are the **only** audit tables with no RLS and no policy, while holding a `tenant_id` column. Any `phoenix_tenant` SELECT would have crossed tenant borders — a different, slightly worse problem than the one this issue is about, even though no code queries them today. Hence `REVOKE ALL` rather than just UPDATE/DELETE.

They are **not** dropped: both migrations document them as the manual-restore source for their own rollback ("Rollback drops the index but does NOT restore cleared colors — use the backup table for manual restore"), and the down migrations carry the restore SQL as a comment. Restores run as `phoenix_admin` or the superuser, which keep full access.

## Guard tests

`001015225_audit_append_only_grants_test.go` ratchets the invariant so the next audit table cannot drift back:

- `TestAuditSchemaAppendOnlyForTenantRole` — iterates every table in `audit.*` and asserts `phoenix_tenant` holds no UPDATE (allowlist deliberately **empty**) and no DELETE (allowlist: exactly the two retention tables, with reasons). Backup tables must hold no privilege at all.
- `TestAuditSchemaDefaultACLIsAppendOnly` — asserts the schema default ACL itself no longer hands out `w`/`d`. Without this, a new table would silently inherit the rights again and only the per-table assertions would catch it, after the fact.

Both allowlists are shrink-only. A future table that genuinely needs UPDATE has to add an entry with a justification, which is exactly the decision a reviewer should see.

## Verification

Migration applied to the test DB, resulting privileges:

```
                        sel ins upd del
auth_events              t   t   f   f
data_access_log          t   t   f   f
data_deletions           t   t   f   f
data_imports             t   t   f   f
deviation_events         t   t   f   t   <- retention
enrollment_deletions     t   t   f   f
enrollment_offering_adj  t   t   f   f
guardian_changes         t   t   f   f
unregistered_tag_scans   t   t   f   t   <- retention
work_session_edits       t   t   f   f
room_color_migration_backup   f f f f
wc_alias_migration_backup     f f f f

default ACL: phoenix_tenant=ar/postgres
```

Behaviour checked directly under `SET ROLE phoenix_tenant` against the real tables: UPDATE denied everywhere, DELETE denied on `work_session_edits`, permitted on the two retention tables, INSERT still permitted (fails on NOT NULL, not on privileges).

Both guard tests were negative-checked: with a temporarily restored `GRANT UPDATE` (and separately, a restored default ACL) they fail with the intended message, and pass again after the revoke.

Green: `./database/migrations/`, `./database/repositories/audit/`, `./services/audit/`, `./services/active -run 'Cleanup|TimeTracking'`, `./services/schedule -run 'Cleanup|Deviation'`, the CI ratchets in `./test/`, `golangci-lint` (0 issues).

## Note on the migration number

Numbered **1.15.225**, not 1.15.222, although `development` currently tops out at 1.15.221: three in-flight branches already claim 222–224 locally. Since bun identifies migrations by their numeric file prefix, a colliding prefix that another branch already applied to a shared database is silently skipped — the same failure mode as #1720. 225 is free.
