### PR TITLE
feat(time-tracking): tenantweite Zeiterfassungssicht + Monatsabschluss (#1417 Tranche 2a)

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -438,7 +438,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Guardians = guardiansAPI.NewResource(api.Services.Guardian, api.Services.GuardianInvitation, api.Services.Users, api.Services.Education, api.Services.UserContext, db)
 	api.Import = importAPI.NewResource(api.Services.Import, api.Services.StaffImport, api.Services.Users, db)
 	api.Activities = activitiesAPI.NewResource(api.Services.Activities, api.Services.Schedule, api.Services.Users, api.Services.UserContext, db)
-	api.Staff = staffAPI.NewResource(api.Services.Users, api.Services.StaffOffboarding, api.Services.Education, api.Services.Auth, api.Services.WorkSession, api.Services.StaffAbsence, api.Services.WorkTimeMonth, api.Services.StaffBalanceAdjust, db, logger.With("handler", "staff"))
+	api.Staff = staffAPI.NewResource(api.Services.Users, api.Services.StaffOffboarding, api.Services.Education, api.Services.Auth, api.Services.WorkSession, api.Services.StaffAbsence, api.Services.WorkTimeMonth, api.Services.StaffBalanceAdjust, api.Services.StaffMonthClose, api.Services.StaffOverview, db, logger.With("handler", "staff"))
 	api.WorkTimeModels = worktimemodelsAPI.NewResource(api.Services.WorkTimeModels, db, logger.With("handler", "work-time-models"))
 	api.StaffShifts = staffshiftsAPI.NewResource(api.Services.StaffShifts, api.Services.StaffShiftSeries, api.Services.StaffScheduleOverview, api.Services.Users, db, logger.With("handler", "staff-shifts"))
 	api.ShiftTypes = shifttypesAPI.NewResource(api.Services.ShiftTypes, api.Services.Activities, db, logger.With("handler", "shift-types"))

--- a/backend/api/staff/api.go
+++ b/backend/api/staff/api.go
@@ -26,6 +26,8 @@ type Resource struct {
 	StaffAbsenceService     activeSvc.StaffAbsenceService
 	WorkTimeMonthService    activeSvc.WorkTimeMonthService
 	BalanceAdjustService    activeSvc.StaffBalanceAdjustmentService
+	MonthCloseService       activeSvc.StaffMonthCloseService
+	StaffOverviewService    activeSvc.StaffOverviewService
 	db                      *bun.DB
 	logger                  *slog.Logger
 }
@@ -40,6 +42,8 @@ func NewResource(
 	staffAbsenceService activeSvc.StaffAbsenceService,
 	workTimeMonthService activeSvc.WorkTimeMonthService,
 	balanceAdjustService activeSvc.StaffBalanceAdjustmentService,
+	monthCloseService activeSvc.StaffMonthCloseService,
+	staffOverviewService activeSvc.StaffOverviewService,
 	db *bun.DB,
 	logger *slog.Logger,
 ) *Resource {
@@ -52,6 +56,8 @@ func NewResource(
 		StaffAbsenceService:     staffAbsenceService,
 		WorkTimeMonthService:    workTimeMonthService,
 		BalanceAdjustService:    balanceAdjustService,
+		MonthCloseService:       monthCloseService,
+		StaffOverviewService:    staffOverviewService,
 		db:                      db,
 		logger:                  logger,
 	}
@@ -69,6 +75,15 @@ func (rs *Resource) Router() chi.Router {
 
 	// Protected routes that require authentication and permissions
 	common.ProtectedTenantGroup(r, rs.db, func(r chi.Router, withTx common.Middleware) {
+
+		// Leitungs-Dashboard KPIs (#1417 2a). Aggregate only, no per-person
+		// working-time data, hence users:read.
+		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/dashboard-summary", rs.getDashboardSummary)
+		// Per-person Soll/Ist/Saldo/Resturlaub across all staff. Deliberately
+		// stricter than the issue's users:read: this is working-time data about
+		// identifiable people, and users:read is held by everyone who may see
+		// the staff list at all.
+		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Get("/time-tracking/overview", rs.getTimeTrackingOverview)
 
 		// Staff profile reads are also needed by the absence-management view.
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/", rs.listStaff)
@@ -104,6 +119,13 @@ func (rs *Resource) Router() chi.Router {
 		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Post("/{id}/time-tracking/adjustments", rs.createBalanceAdjustment)
 		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Delete("/{id}/time-tracking/adjustments/{adjustmentId}", rs.deleteBalanceAdjustment)
 		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Post("/{id}/time-tracking/reset", rs.resetStaffBalance)
+
+		// Monatsabschluss (#1417): freezing the carry chain is school-wide,
+		// reopening is per staff member. Static segments before /{id} are
+		// safe — chi prefers them over the wildcard.
+		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Get("/time-tracking/month-close", rs.listMonthCloseStatus)
+		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Post("/time-tracking/month-close", rs.closeMonth)
+		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Post("/{id}/time-tracking/month-close/reopen", rs.reopenMonth)
 
 		// Vacation workflow admin-side (Tranche 4)
 		r.With(authorize.RequiresPermission(permissions.VacationApprove), withTx).Get("/absences/pending", rs.listPendingAbsenceRequests)

--- a/backend/api/staff/month_close_handlers.go
+++ b/backend/api/staff/month_close_handlers.go
@@ -1,0 +1,107 @@
+package staff
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	timetracking "github.com/moto-nrw/project-phoenix/api/time-tracking"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+// monthCloseErrorRules classifies the Monatsabschluss sentinels (#1417):
+// caller mistakes → 400, missing snapshot → 404. The conflict sentinel is
+// rendered with a machine-readable code in renderMonthCloseError before this
+// table is consulted.
+var monthCloseErrorRules = []common.ErrorRule{
+	{Target: activeSvc.ErrMonthCloseInvalid, Render: common.ErrorInvalidRequest},
+	{Target: activeSvc.ErrMonthNotClosable, Render: common.ErrorInvalidRequest},
+	{Target: activeSvc.ErrMonthNotClosed, Render: common.ErrorNotFound},
+}
+
+func renderMonthCloseError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, activeSvc.ErrLaterMonthClosed) {
+		common.RenderError(w, r, common.ErrorConflictWithCode(err, "later_month_closed"))
+		return
+	}
+	common.RenderError(w, r, common.RenderWithRules(err, monthCloseErrorRules, common.ErrorInternalServer))
+}
+
+// monthCloseRequest is the wire shape for POST
+// /api/staff/time-tracking/month-close and the per-staff reopen. The reason is
+// mandatory: freezing and unfreezing a Stundenkonto are both decisions that
+// have to be attributable.
+type monthCloseRequest struct {
+	Year   int    `json:"year"`
+	Month  int    `json:"month"`
+	Reason string `json:"reason"`
+}
+
+// listMonthCloseStatus handles GET /api/staff/time-tracking/month-close?year=&month=
+func (rs *Resource) listMonthCloseStatus(w http.ResponseWriter, r *http.Request) {
+	year, month, err := timetracking.ParseYearMonthQuery(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	snapshots, err := rs.MonthCloseService.ListMonthStatus(r.Context(), year, month)
+	if err != nil {
+		renderMonthCloseError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, snapshots, "Month close status retrieved")
+}
+
+// closeMonth handles POST /api/staff/time-tracking/month-close — freezes the
+// month for the whole school. The ambient tenant transaction wraps the entire
+// loop, so one failing staff member rolls the close back completely.
+func (rs *Resource) closeMonth(w http.ResponseWriter, r *http.Request) {
+	closedBy, err := rs.resolveEditorStaffID(r.Context())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+	var req monthCloseRequest
+	if err := render.DecodeJSON(r.Body, &req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	result, err := rs.MonthCloseService.CloseMonth(r.Context(), closedBy, req.Year, req.Month, req.Reason)
+	if err != nil {
+		tenant.MarkRollback(r.Context())
+		renderMonthCloseError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusCreated, result, "Month closed")
+}
+
+// reopenMonth handles POST /api/staff/{id}/time-tracking/month-close/reopen.
+// POST rather than DELETE because it carries a mandatory reason.
+func (rs *Resource) reopenMonth(w http.ResponseWriter, r *http.Request) {
+	staffID, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	if !rs.requireBalanceAdjustmentStaff(w, r, staffID) {
+		return
+	}
+	reopenedBy, err := rs.resolveEditorStaffID(r.Context())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+	var req monthCloseRequest
+	if err := render.DecodeJSON(r.Body, &req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	if err := rs.MonthCloseService.ReopenMonth(r.Context(), staffID, reopenedBy, req.Year, req.Month, req.Reason); err != nil {
+		tenant.MarkRollback(r.Context())
+		renderMonthCloseError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, nil, "Month reopened")
+}

--- a/backend/api/staff/overview_api_test.go
+++ b/backend/api/staff/overview_api_test.go
@@ -1,0 +1,165 @@
+// Router-level tests for the tenant-wide time-tracking views (#1417):
+// GET /api/staff/dashboard-summary and GET /api/staff/time-tracking/overview,
+// plus the Monatsabschluss routes. They pin the permission split, the query
+// validation, and the response field names the frontend will consume.
+package staff_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// overviewAPIContext wires a router plus an editor account whose permissions the
+// individual test picks.
+type overviewAPIContext struct {
+	tc      *testContext
+	staffID int64
+	get     func(path string, perms ...string) *httptest.ResponseRecorder
+	post    func(path, body string, perms ...string) *httptest.ResponseRecorder
+}
+
+func setupOverviewAPI(t *testing.T) *overviewAPIContext {
+	t.Helper()
+	tc := setupTestContext(t)
+	suffix := time.Now().UnixNano()
+
+	person, account := testpkg.CreateTestPersonWithAccount(t, tc.db, "Overview", fmt.Sprintf("Editor-%d", suffix))
+	editorStaff := testpkg.CreateTestStaffForPerson(t, tc.db, person.ID)
+	t.Cleanup(func() {
+		testpkg.CleanupStaffFixtures(t, tc.db, editorStaff.ID)
+		testpkg.CleanupTableRecords(t, tc.db, "users.persons", person.ID)
+		testpkg.CleanupTableRecords(t, tc.db, "auth.accounts", account.ID)
+	})
+
+	token := func(perms ...string) string {
+		claims := testutil.DefaultTestClaims()
+		claims.ID = int(account.ID)
+		claims.Permissions = perms
+		return testutil.MintTestJWT(t, claims)
+	}
+
+	return &overviewAPIContext{
+		tc:      tc,
+		staffID: editorStaff.ID,
+		get: func(path string, perms ...string) *httptest.ResponseRecorder {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Authorization", "Bearer "+token(perms...))
+			rec := httptest.NewRecorder()
+			tc.router.ServeHTTP(rec, req)
+			return rec
+		},
+		post: func(path, body string, perms ...string) *httptest.ResponseRecorder {
+			req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
+			req.Header.Set("Authorization", "Bearer "+token(perms...))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			tc.router.ServeHTTP(rec, req)
+			return rec
+		},
+	}
+}
+
+func TestDashboardSummaryAPI(t *testing.T) {
+	ctx := setupOverviewAPI(t)
+
+	rec := ctx.get("/staff/dashboard-summary", "users:read")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	// Field names are fixed by #1417; a rename must break CI.
+	for _, field := range []string{
+		`"active_staff_count"`, `"sick_today"`, `"vacation_today"`,
+		`"currently_clocked_in"`, `"expected_clocked_in"`, `"period"`,
+		`"soll_minutes"`, `"ist_minutes"`, `"delta_minutes"`,
+		`"saldo_school_total_minutes"`, `"pending_requests_count"`,
+	} {
+		assert.Contains(t, rec.Body.String(), field)
+	}
+
+	rec = ctx.get("/staff/dashboard-summary?period=week", "users:read")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	rec = ctx.get("/staff/dashboard-summary?period=quarter", "users:read")
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+
+	rec = ctx.get("/staff/dashboard-summary", "feedback:read")
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+}
+
+// TestTimeTrackingOverviewAPI_PermissionSplit is the DSGVO-relevant assertion:
+// per-person Soll/Ist/Saldo needs time_tracking:manage, NOT the users:read that
+// merely lets someone see the staff list.
+func TestTimeTrackingOverviewAPI_PermissionSplit(t *testing.T) {
+	ctx := setupOverviewAPI(t)
+
+	rec := ctx.get("/staff/time-tracking/overview", "users:read")
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+
+	rec = ctx.get("/staff/time-tracking/overview", "time_tracking:manage")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	for _, field := range []string{`"rows"`, `"year"`, `"month"`} {
+		assert.Contains(t, rec.Body.String(), field)
+	}
+}
+
+func TestTimeTrackingOverviewAPI_FilterValidation(t *testing.T) {
+	ctx := setupOverviewAPI(t)
+
+	for _, query := range []string{
+		"?saldo_min=abc",
+		"?employment_type=bogus",
+		"?sort=bogus",
+		"?order=sideways",
+		"?saldo_min=100&saldo_max=10",
+	} {
+		rec := ctx.get("/staff/time-tracking/overview"+query, "time_tracking:manage")
+		assert.Equal(t, http.StatusBadRequest, rec.Code, "query %s: %s", query, rec.Body.String())
+	}
+
+	// Valid combinations pass.
+	for _, query := range []string{
+		"?employment_type=full_time",
+		"?saldo_min=-600&saldo_max=600",
+		"?sort=balance&order=desc",
+	} {
+		rec := ctx.get("/staff/time-tracking/overview"+query, "time_tracking:manage")
+		assert.Equal(t, http.StatusOK, rec.Code, "query %s: %s", query, rec.Body.String())
+	}
+}
+
+// TestMonthCloseAPI covers the Monatsabschluss routes end to end through the
+// router, including the guard against closing a month that is not over.
+func TestMonthCloseAPI(t *testing.T) {
+	ctx := setupOverviewAPI(t)
+	today := time.Now()
+
+	rec := ctx.get(fmt.Sprintf("/staff/time-tracking/month-close?year=%d&month=%d", today.Year(), int(today.Month())), "time_tracking:manage")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	rec = ctx.get("/staff/time-tracking/month-close?year=2026&month=13", "time_tracking:manage")
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+
+	rec = ctx.get("/staff/time-tracking/month-close?year=2026&month=6", "users:read")
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+
+	// The current month is not over: 400, not a silently wrong snapshot.
+	body := fmt.Sprintf(`{"year":%d,"month":%d,"reason":"Abschluss"}`, today.Year(), int(today.Month()))
+	rec = ctx.post("/staff/time-tracking/month-close", body, "time_tracking:manage")
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+
+	// A missing reason is a 400 too — freezing has to stay attributable.
+	rec = ctx.post("/staff/time-tracking/month-close", `{"year":2025,"month":8,"reason":"  "}`, "time_tracking:manage")
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+
+	// Reopening a month that was never closed is a 404.
+	rec = ctx.post(fmt.Sprintf("/staff/%d/time-tracking/month-close/reopen", ctx.staffID),
+		`{"year":2025,"month":8,"reason":"Korrektur"}`, "time_tracking:manage")
+	require.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
+}

--- a/backend/api/staff/overview_handlers.go
+++ b/backend/api/staff/overview_handlers.go
@@ -1,0 +1,102 @@
+package staff
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+)
+
+// overviewErrorRules classifies the overview sentinels (#1417): caller
+// mistakes → 400. ErrAccountStartTooOld stays a 500 on purpose — it means the
+// tenant's account-start setting is misconfigured, the same way the per-staff
+// Monatskarte fails.
+var overviewErrorRules = []common.ErrorRule{
+	{Target: activeSvc.ErrOverviewInvalid, Render: common.ErrorInvalidRequest},
+}
+
+func renderOverviewError(w http.ResponseWriter, r *http.Request, err error) {
+	common.RenderError(w, r, common.RenderWithRules(err, overviewErrorRules, common.ErrorInternalServer))
+}
+
+// parseDashboardPeriod validates ?period=. Empty means month.
+func parseDashboardPeriod(r *http.Request) (string, error) {
+	period := r.URL.Query().Get("period")
+	switch period {
+	case "", activeSvc.OverviewPeriodMonth:
+		return activeSvc.OverviewPeriodMonth, nil
+	case activeSvc.OverviewPeriodWeek:
+		return activeSvc.OverviewPeriodWeek, nil
+	default:
+		return "", errors.New("period must be week or month")
+	}
+}
+
+// parseOverviewFilters reads the list filters. saldo_min/saldo_max are pointers
+// so "0" stays distinguishable from "not set"; negative values are valid (a
+// minus balance is a normal state). Unknown sort keys and employment types are
+// rejected in the service rather than silently defaulted.
+func parseOverviewFilters(r *http.Request) (activeSvc.OverviewFilters, error) {
+	query := r.URL.Query()
+	filters := activeSvc.OverviewFilters{
+		EmploymentType: query.Get("employment_type"),
+		SortBy:         query.Get("sort"),
+	}
+	switch order := query.Get("order"); order {
+	case "", "asc":
+	case "desc":
+		filters.Descending = true
+	default:
+		return filters, errors.New("order must be asc or desc")
+	}
+	for _, bound := range []struct {
+		name   string
+		target **int
+	}{
+		{"saldo_min", &filters.SaldoMin},
+		{"saldo_max", &filters.SaldoMax},
+	} {
+		raw := query.Get(bound.name)
+		if raw == "" {
+			continue
+		}
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			return filters, errors.New(bound.name + " must be an integer number of minutes")
+		}
+		*bound.target = &value
+	}
+	return filters, nil
+}
+
+// getDashboardSummary handles GET /api/staff/dashboard-summary?period=week|month
+func (rs *Resource) getDashboardSummary(w http.ResponseWriter, r *http.Request) {
+	period, err := parseDashboardPeriod(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	summary, err := rs.StaffOverviewService.GetDashboardSummary(r.Context(), period)
+	if err != nil {
+		renderOverviewError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, summary, "Dashboard summary retrieved")
+}
+
+// getTimeTrackingOverview handles GET /api/staff/time-tracking/overview
+func (rs *Resource) getTimeTrackingOverview(w http.ResponseWriter, r *http.Request) {
+	filters, err := parseOverviewFilters(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	overview, err := rs.StaffOverviewService.GetTimeTrackingOverview(r.Context(), filters)
+	if err != nil {
+		renderOverviewError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, overview, "Time tracking overview retrieved")
+}

--- a/backend/api/staff/staff_test.go
+++ b/backend/api/staff/staff_test.go
@@ -49,7 +49,7 @@ func setupTestContext(t *testing.T) *testContext {
 
 	db, svc := testutil.SetupAPITest(t)
 
-	resource := staffAPI.NewResource(svc.Users, svc.StaffOffboarding, svc.Education, svc.Auth, svc.WorkSession, svc.StaffAbsence, svc.WorkTimeMonth, svc.StaffBalanceAdjust, db, slog.Default())
+	resource := staffAPI.NewResource(svc.Users, svc.StaffOffboarding, svc.Education, svc.Auth, svc.WorkSession, svc.StaffAbsence, svc.WorkTimeMonth, svc.StaffBalanceAdjust, svc.StaffMonthClose, svc.StaffOverview, db, slog.Default())
 
 	router := chi.NewRouter()
 	router.Mount("/staff", resource.Router())

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -276,7 +276,10 @@ GET /api/staff/absences/pending
 GET /api/staff/available
 GET /api/staff/available-for-substitution
 GET /api/staff/by-role
+GET /api/staff/dashboard-summary
 GET /api/staff/pin
+GET /api/staff/time-tracking/month-close
+GET /api/staff/time-tracking/overview
 GET /api/staff/{id}
 GET /api/staff/{id}/absences
 GET /api/staff/{id}/avatar
@@ -572,8 +575,10 @@ POST /api/staff/
 POST /api/staff/absences/{absenceId}/approve
 POST /api/staff/absences/{absenceId}/deny
 POST /api/staff/absences/{absenceId}/question
+POST /api/staff/time-tracking/month-close
 POST /api/staff/{id}/absences
 POST /api/staff/{id}/time-tracking/adjustments
+POST /api/staff/{id}/time-tracking/month-close/reopen
 POST /api/staff/{id}/time-tracking/reset
 POST /api/staff/{id}/time-tracking/sessions
 POST /api/students/

--- a/backend/database/migrations/001015222_staff_month_balance_snapshots.go
+++ b/backend/database/migrations/001015222_staff_month_balance_snapshots.go
@@ -1,0 +1,189 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	staffMonthBalanceSnapshotsVersion     = "1.15.222"
+	staffMonthBalanceSnapshotsDescription = "Create active.staff_month_balance_snapshots - frozen month closing balances (#1417)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     staffMonthBalanceSnapshotsVersion,
+		Description: staffMonthBalanceSnapshotsDescription,
+		DependsOn: []string{
+			staffBalanceAdjustmentTenantFKsVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return staffMonthBalanceSnapshotsUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return staffMonthBalanceSnapshotsDown(ctx, db)
+		},
+	)
+}
+
+// staffMonthBalanceSnapshotsUp creates the Monatsabschluss table (#1417).
+//
+// The Stundenkonto is computed live: the carry chain sums every month from the
+// account-start anchor up to the requested one. That makes a retroactive
+// correction rewrite history — editing an August shift in October moves the
+// August balance and every later carry with it. A snapshot freezes ONE value:
+// the closing balance of a month. From then on the chain for later months
+// starts at that number instead of re-summing from the anchor. Months up to
+// and including the frozen one are still recomputed for display, and the
+// difference is reported as drift — surfaced, never silently absorbed.
+//
+// A snapshot is NOT a booking. active.staff_balance_adjustments (#1420) holds
+// dated transactions with a signed delta; this table holds no delta at all.
+// The two are orthogonal: a 'reset' adjustment does not freeze anything, and a
+// snapshot moves no balance.
+//
+// Reopening supersedes instead of deleting: the row keeps who closed, who
+// reopened, and why, so it is its own audit record (the same doctrine as
+// StaffBalanceAdjustment). The partial unique index therefore covers only
+// non-superseded rows — at most one active snapshot per staff member and
+// month, with the reopened history piling up behind it.
+//
+// Deliberately no DATE column: year/month are integers and closed_at/
+// reopened_at are instants, so there is no calendar-date binding to get wrong
+// (see .claude/rules/calendar-dates.md). Do not add a month_end_date
+// convenience column.
+//
+// The composite (tenant_id, staff_id) foreign keys are the tenant-safe form
+// retrofitted onto the adjustment ledger in 1.15.221 — a plain staff_id FK
+// would let a row reference a staff member of another school. closed_by and
+// reopened_by use ON DELETE RESTRICT for the same reason the adjustment
+// ledger does, and inherit the same wart: offboarding a staff member who once
+// closed a month is blocked until those rows are dealt with. Consistency with
+// the ledger beats diverging here.
+func staffMonthBalanceSnapshotsUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.222: Creating active.staff_month_balance_snapshots...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS active.staff_month_balance_snapshots (
+			id                      BIGSERIAL PRIMARY KEY,
+			tenant_id               BIGINT NOT NULL,
+			staff_id                BIGINT NOT NULL,
+			year                    SMALLINT NOT NULL,
+			month                   SMALLINT NOT NULL,
+			closing_balance_minutes INTEGER NOT NULL,
+			carry_in_minutes        INTEGER NOT NULL DEFAULT 0,
+			target_minutes          INTEGER NOT NULL DEFAULT 0,
+			actual_minutes          INTEGER NOT NULL DEFAULT 0,
+			credited_minutes        INTEGER NOT NULL DEFAULT 0,
+			adjustment_minutes      INTEGER NOT NULL DEFAULT 0,
+			closed_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			closed_by               BIGINT NOT NULL,
+			close_reason            TEXT NOT NULL DEFAULT '',
+			source                  TEXT NOT NULL DEFAULT 'admin',
+			reopened_at             TIMESTAMPTZ,
+			reopened_by             BIGINT,
+			reopen_reason           TEXT NOT NULL DEFAULT '',
+			created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT chk_smbs_month CHECK (month BETWEEN 1 AND 12),
+			CONSTRAINT chk_smbs_year CHECK (year BETWEEN 2000 AND 2100),
+			CONSTRAINT chk_smbs_source CHECK (source IN ('admin','scheduler','migration')),
+			CONSTRAINT chk_smbs_reopen CHECK ((reopened_at IS NULL) = (reopened_by IS NULL)),
+			CONSTRAINT fk_smbs_tenant
+				FOREIGN KEY (tenant_id)
+				REFERENCES platform.schools(id)
+				ON DELETE CASCADE,
+			CONSTRAINT fk_smbs_staff_tenant
+				FOREIGN KEY (tenant_id, staff_id)
+				REFERENCES users.staff(tenant_id, id)
+				ON DELETE CASCADE,
+			CONSTRAINT fk_smbs_closed_by_tenant
+				FOREIGN KEY (tenant_id, closed_by)
+				REFERENCES users.staff(tenant_id, id)
+				ON DELETE RESTRICT,
+			CONSTRAINT fk_smbs_reopened_by_tenant
+				FOREIGN KEY (tenant_id, reopened_by)
+				REFERENCES users.staff(tenant_id, id)
+				ON DELETE RESTRICT
+		);
+
+		-- At most one ACTIVE snapshot per staff member and month; superseded
+		-- (reopened) rows stay behind it as the audit trail.
+		CREATE UNIQUE INDEX IF NOT EXISTS uq_smbs_active_month
+			ON active.staff_month_balance_snapshots (tenant_id, staff_id, year, month)
+			WHERE reopened_at IS NULL;
+
+		-- Splice lookup: newest active snapshot at or before a given month.
+		CREATE INDEX IF NOT EXISTS idx_smbs_lookup
+			ON active.staff_month_balance_snapshots (tenant_id, staff_id, year DESC, month DESC)
+			WHERE reopened_at IS NULL;
+
+		-- School-wide close status of one month.
+		CREATE INDEX IF NOT EXISTS idx_smbs_tenant_month
+			ON active.staff_month_balance_snapshots (tenant_id, year, month)
+			WHERE reopened_at IS NULL;
+
+		DROP TRIGGER IF EXISTS update_staff_month_balance_snapshots_updated_at ON active.staff_month_balance_snapshots;
+		CREATE TRIGGER update_staff_month_balance_snapshots_updated_at
+		BEFORE UPDATE ON active.staff_month_balance_snapshots
+		FOR EACH ROW
+		EXECUTE FUNCTION update_modified_column();
+
+		ALTER TABLE active.staff_month_balance_snapshots ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE active.staff_month_balance_snapshots FORCE ROW LEVEL SECURITY;
+
+		DROP POLICY IF EXISTS tenant_isolation_active_staff_month_balance_snapshots ON active.staff_month_balance_snapshots;
+		CREATE POLICY tenant_isolation_active_staff_month_balance_snapshots ON active.staff_month_balance_snapshots
+			FOR ALL
+			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+
+		GRANT SELECT, INSERT, UPDATE, DELETE ON active.staff_month_balance_snapshots TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE active.staff_month_balance_snapshots_id_seq TO phoenix_tenant;
+	`)
+	if err != nil {
+		return fmt.Errorf("error creating active.staff_month_balance_snapshots: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+func staffMonthBalanceSnapshotsDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.222: Dropping active.staff_month_balance_snapshots...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		DROP TRIGGER IF EXISTS update_staff_month_balance_snapshots_updated_at ON active.staff_month_balance_snapshots;
+		DROP TABLE IF EXISTS active.staff_month_balance_snapshots CASCADE;
+	`)
+	if err != nil {
+		return fmt.Errorf("error dropping active.staff_month_balance_snapshots: %w", err)
+	}
+	return tx.Commit()
+}

--- a/backend/database/repositories/active/staff_absence.go
+++ b/backend/database/repositories/active/staff_absence.go
@@ -119,16 +119,16 @@ func (r *StaffAbsenceRepository) GetByStaffAndDate(ctx context.Context, staffID 
 	return absence, nil
 }
 
-// GetTodayAbsenceMap returns a map of staff IDs to their absence type for today.
+// GetAbsenceMapForDate returns a map of staff IDs to their absence type for the given date.
 // Priority order when multiple absences exist:
 // sick > training > vacation > comp_time > other.
-func (r *StaffAbsenceRepository) GetTodayAbsenceMap(ctx context.Context) (map[int64]string, error) {
+func (r *StaffAbsenceRepository) GetAbsenceMapForDate(ctx context.Context, date timezone.Date) (map[int64]string, error) {
 	var absences []*active.StaffAbsence
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&absences).
 		ModelTableExpr(tableExprActiveStaffAbsencesAsStaffAbsence).
-		Where(`"staff_absence".date_start <= CURRENT_DATE`).
-		Where(`"staff_absence".date_end >= CURRENT_DATE`).
+		Where(`"staff_absence".date_start <= ?`, date).
+		Where(`"staff_absence".date_end >= ?`, date).
 		Where(`"staff_absence".status IN (?)`, bun.List(effectiveStaffAbsenceStatuses))
 
 	query = base.WithTenantFilter(ctx, query, "staff_absence")
@@ -136,7 +136,7 @@ func (r *StaffAbsenceRepository) GetTodayAbsenceMap(ctx context.Context) (map[in
 	err := query.Scan(ctx)
 	if err != nil {
 		return nil, &modelBase.DatabaseError{
-			Op:  "get today absence map",
+			Op:  "get absence map for date",
 			Err: err,
 		}
 	}

--- a/backend/database/repositories/active/staff_absence.go
+++ b/backend/database/repositories/active/staff_absence.go
@@ -208,3 +208,37 @@ func (r *StaffAbsenceRepository) DeleteNonHistoricalByStaffID(ctx context.Contex
 
 	return result.RowsAffected()
 }
+
+// GetByStaffIDsAndDateRange is GetByStaffAndDateRange for many staff members in
+// one round trip, keyed by staff ID. A batched IN-lookup the generic filter API
+// cannot express as a single query. It keeps the OVERLAP predicate of its
+// single-staff twin: the month math needs absences that start before `from`.
+func (r *StaffAbsenceRepository) GetByStaffIDsAndDateRange(ctx context.Context, staffIDs []int64, from, to timezone.Date) (map[int64][]*active.StaffAbsence, error) {
+	result := make(map[int64][]*active.StaffAbsence, len(staffIDs))
+	if len(staffIDs) == 0 {
+		// bun renders an empty IN list as invalid SQL.
+		return result, nil
+	}
+
+	var absences []*active.StaffAbsence
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&absences).
+		ModelTableExpr(tableExprActiveStaffAbsencesAsStaffAbsence).
+		Where(`"staff_absence".staff_id IN (?)`, bun.List(staffIDs)).
+		Where(`"staff_absence".date_start <= ?`, to).
+		Where(`"staff_absence".date_end >= ?`, from).
+		OrderExpr(`"staff_absence".staff_id ASC, "staff_absence".date_start ASC`)
+
+	query = base.WithTenantFilter(ctx, query, "staff_absence")
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "get absences by staff IDs and date range",
+			Err: err,
+		}
+	}
+	for _, absence := range absences {
+		result[absence.StaffID] = append(result[absence.StaffID], absence)
+	}
+	return result, nil
+}

--- a/backend/database/repositories/active/staff_absence_test.go
+++ b/backend/database/repositories/active/staff_absence_test.go
@@ -348,7 +348,7 @@ func TestStaffAbsenceRepository_GetByStaffAndDate(t *testing.T) {
 	})
 }
 
-func TestStaffAbsenceRepository_GetTodayAbsenceMap(t *testing.T) {
+func TestStaffAbsenceRepository_GetAbsenceMapForDate(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()
 
@@ -394,7 +394,7 @@ func TestStaffAbsenceRepository_GetTodayAbsenceMap(t *testing.T) {
 			testpkg.CleanupTableRecords(t, db, "active.staff_absences", absence2.ID)
 		}()
 
-		absenceMap, err := repo.GetTodayAbsenceMap(ctx)
+		absenceMap, err := repo.GetAbsenceMapForDate(ctx, today)
 		require.NoError(t, err)
 		assert.Equal(t, active.AbsenceTypeSick, absenceMap[staff1.ID])
 		assert.Equal(t, active.AbsenceTypeVacation, absenceMap[staff2.ID])
@@ -431,9 +431,28 @@ func TestStaffAbsenceRepository_GetTodayAbsenceMap(t *testing.T) {
 			testpkg.CleanupTableRecords(t, db, "active.staff_absences", absence2.ID)
 		}()
 
-		absenceMap, err := repo.GetTodayAbsenceMap(ctx)
+		absenceMap, err := repo.GetAbsenceMapForDate(ctx, today)
 		require.NoError(t, err)
 		// Sick should take priority over vacation
 		assert.Equal(t, active.AbsenceTypeSick, absenceMap[staff3.ID])
+	})
+
+	t.Run("uses the requested date", func(t *testing.T) {
+		requestedDate := timezone.TodayDate().AddDays(30)
+		absence := &active.StaffAbsence{
+			StaffID:     staff1.ID,
+			AbsenceType: active.AbsenceTypeTraining,
+			DateStart:   requestedDate,
+			DateEnd:     requestedDate,
+			Status:      active.AbsenceStatusApproved,
+			CreatedBy:   staff1.ID,
+		}
+
+		require.NoError(t, repo.Create(ctx, absence))
+		defer testpkg.CleanupTableRecords(t, db, "active.staff_absences", absence.ID)
+
+		absenceMap, err := repo.GetAbsenceMapForDate(ctx, requestedDate)
+		require.NoError(t, err)
+		assert.Equal(t, active.AbsenceTypeTraining, absenceMap[staff1.ID])
 	})
 }

--- a/backend/database/repositories/active/staff_balance_adjustment.go
+++ b/backend/database/repositories/active/staff_balance_adjustment.go
@@ -62,3 +62,35 @@ func (r *StaffBalanceAdjustmentRepository) GetByStaffAndDateRange(ctx context.Co
 	}
 	return adjustments, nil
 }
+
+// GetByStaffIDsAndDateRange is GetByStaffAndDateRange for many staff members in
+// one round trip, keyed by staff ID. A batched IN-lookup the generic filter API
+// cannot express as a single query.
+func (r *StaffBalanceAdjustmentRepository) GetByStaffIDsAndDateRange(ctx context.Context, staffIDs []int64, from, to timezone.Date) (map[int64][]*active.StaffBalanceAdjustment, error) {
+	result := make(map[int64][]*active.StaffBalanceAdjustment, len(staffIDs))
+	if len(staffIDs) == 0 {
+		// bun renders an empty IN list as invalid SQL.
+		return result, nil
+	}
+
+	var adjustments []*active.StaffBalanceAdjustment
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&adjustments).
+		ModelTableExpr(tableExprStaffBalanceAdjustmentsAliased).
+		Where(`"staff_balance_adjustment".staff_id IN (?)`, bun.List(staffIDs)).
+		Where(`"staff_balance_adjustment".effective_date >= ?`, from).
+		Where(`"staff_balance_adjustment".effective_date <= ?`, to).
+		OrderExpr(`"staff_balance_adjustment".staff_id ASC, "staff_balance_adjustment".effective_date ASC, "staff_balance_adjustment".id ASC`)
+
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where(`"staff_balance_adjustment".tenant_id = ?`, tenantID)
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "get balance adjustments by staff IDs+range", Err: err}
+	}
+	for _, adjustment := range adjustments {
+		result[adjustment.StaffID] = append(result[adjustment.StaffID], adjustment)
+	}
+	return result, nil
+}

--- a/backend/database/repositories/active/staff_month_balance_snapshot.go
+++ b/backend/database/repositories/active/staff_month_balance_snapshot.go
@@ -1,0 +1,105 @@
+package active
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/models/active"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+const (
+	tableStaffMonthBalanceSnapshots = "active.staff_month_balance_snapshots"
+	// bun expands Model(&rows) columns under the struct-derived alias, so the
+	// FROM must bind it (same pattern as staff_balance_adjustment.go).
+	tableExprStaffMonthBalanceSnapshotsAliased = `active.staff_month_balance_snapshots AS "staff_month_balance_snapshot"`
+	// monthOrdinalExpr collapses (year, month) into one sortable integer so
+	// "at or before this month" is a single comparison instead of an
+	// OR-chained year/month predicate.
+	monthOrdinalExpr = `("staff_month_balance_snapshot".year * 12 + "staff_month_balance_snapshot".month)`
+)
+
+type StaffMonthBalanceSnapshotRepository struct {
+	*base.Repository[*active.StaffMonthBalanceSnapshot]
+	db *bun.DB
+}
+
+func NewStaffMonthBalanceSnapshotRepository(db *bun.DB) active.StaffMonthBalanceSnapshotRepository {
+	repo := base.NewRepository[*active.StaffMonthBalanceSnapshot](db, tableStaffMonthBalanceSnapshots, "StaffMonthBalanceSnapshot")
+	repo.TenantScoped = true
+	return &StaffMonthBalanceSnapshotRepository{Repository: repo, db: db}
+}
+
+// List overrides base List to use QueryOptions (interface contract).
+func (r *StaffMonthBalanceSnapshotRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*active.StaffMonthBalanceSnapshot, error) {
+	return r.ListWithOptions(ctx, options)
+}
+
+// LockStaffBalanceWrites takes the same advisory lock as the adjustment ledger,
+// so closing a month and booking a payout for the same staff member serialize.
+func (r *StaffMonthBalanceSnapshotRepository) LockStaffBalanceWrites(ctx context.Context, staffID int64) error {
+	return lockStaffBalanceWrites(ctx, r.db, staffID)
+}
+
+// monthOrdinal is the Go side of monthOrdinalExpr.
+func monthOrdinal(year, month int) int {
+	return year*12 + month
+}
+
+// GetLatestClosedThrough returns the newest active snapshot at or before
+// (year, month), or nil when the staff member has none.
+func (r *StaffMonthBalanceSnapshotRepository) GetLatestClosedThrough(ctx context.Context, staffID int64, year, month int) (*active.StaffMonthBalanceSnapshot, error) {
+	snapshot := new(active.StaffMonthBalanceSnapshot)
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(snapshot).
+		ModelTableExpr(tableExprStaffMonthBalanceSnapshotsAliased).
+		Where(`"staff_month_balance_snapshot".staff_id = ?`, staffID).
+		Where(`"staff_month_balance_snapshot".reopened_at IS NULL`).
+		Where(monthOrdinalExpr+` <= ?`, monthOrdinal(year, month)).
+		OrderExpr(monthOrdinalExpr + ` DESC`).
+		Limit(1)
+
+	query = r.withTenantFilter(ctx, query)
+
+	if err := query.Scan(ctx); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, &modelBase.DatabaseError{Op: "get latest month balance snapshot", Err: err}
+	}
+	return snapshot, nil
+}
+
+// GetByMonth returns the active snapshots of one month across the tenant,
+// ordered by staff ID so callers see a stable list.
+func (r *StaffMonthBalanceSnapshotRepository) GetByMonth(ctx context.Context, year, month int) ([]*active.StaffMonthBalanceSnapshot, error) {
+	var snapshots []*active.StaffMonthBalanceSnapshot
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&snapshots).
+		ModelTableExpr(tableExprStaffMonthBalanceSnapshotsAliased).
+		Where(`"staff_month_balance_snapshot".year = ?`, year).
+		Where(`"staff_month_balance_snapshot".month = ?`, month).
+		Where(`"staff_month_balance_snapshot".reopened_at IS NULL`).
+		OrderExpr(`"staff_month_balance_snapshot".staff_id ASC`)
+
+	query = r.withTenantFilter(ctx, query)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "get month balance snapshots by month", Err: err}
+	}
+	return snapshots, nil
+}
+
+// withTenantFilter adds the explicit tenant predicate on top of RLS. The
+// staff_id list is never authorization: a missing tenant_id filter would turn
+// any future caller into a cross-tenant leak.
+func (r *StaffMonthBalanceSnapshotRepository) withTenantFilter(ctx context.Context, query *bun.SelectQuery) *bun.SelectQuery {
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		return query.Where(`"staff_month_balance_snapshot".tenant_id = ?`, tenantID)
+	}
+	return query
+}

--- a/backend/database/repositories/active/staff_vacation_quota.go
+++ b/backend/database/repositories/active/staff_vacation_quota.go
@@ -101,3 +101,35 @@ func (r *StaffVacationQuotaRepository) Upsert(ctx context.Context, quota *active
 	}
 	return nil
 }
+
+// GetByStaffIDsAndYear is GetByStaffAndYear for many staff members in one round
+// trip, keyed by staff ID. A batched IN-lookup the generic filter API cannot
+// express as a single query. Staff members without a quota row are absent from
+// the map; callers fall back to the tenant default exactly as they would for
+// the single-staff (nil, nil).
+func (r *StaffVacationQuotaRepository) GetByStaffIDsAndYear(ctx context.Context, staffIDs []int64, year int) (map[int64]*active.StaffVacationQuota, error) {
+	result := make(map[int64]*active.StaffVacationQuota, len(staffIDs))
+	if len(staffIDs) == 0 {
+		// bun renders an empty IN list as invalid SQL.
+		return result, nil
+	}
+
+	var quotas []*active.StaffVacationQuota
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&quotas).
+		ModelTableExpr(tableStaffVacationQuota).
+		Where("staff_id IN (?)", bun.List(staffIDs)).
+		Where("year = ?", year)
+
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "get vacation quotas by staff IDs+year", Err: err}
+	}
+	for _, quota := range quotas {
+		result[quota.StaffID] = quota
+	}
+	return result, nil
+}

--- a/backend/database/repositories/active/work_session.go
+++ b/backend/database/repositories/active/work_session.go
@@ -300,3 +300,37 @@ func (r *WorkSessionRepository) CloseSession(ctx context.Context, id int64, chec
 
 	return closed == 1, nil
 }
+
+// GetHistoryByStaffIDs is GetHistoryByStaffID for many staff members in one
+// round trip, keyed by staff ID. A batched IN-lookup the generic filter API
+// cannot express as a single query; the cross-staff Stundenkonto overview would
+// otherwise issue one range query per person.
+func (r *WorkSessionRepository) GetHistoryByStaffIDs(ctx context.Context, staffIDs []int64, from, to timezone.Date) (map[int64][]*active.WorkSession, error) {
+	result := make(map[int64][]*active.WorkSession, len(staffIDs))
+	if len(staffIDs) == 0 {
+		// bun renders an empty IN list as invalid SQL.
+		return result, nil
+	}
+
+	var sessions []*active.WorkSession
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&sessions).
+		ModelTableExpr(tableExprActiveWorkSessionsAsSession).
+		Where(`"work_session".staff_id IN (?)`, bun.List(staffIDs)).
+		Where(`"work_session".date >= ?`, from).
+		Where(`"work_session".date <= ?`, to).
+		OrderExpr(`"work_session".staff_id ASC, "work_session".date ASC`)
+
+	query = base.WithTenantFilter(ctx, query, "work_session")
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "get history by staff IDs",
+			Err: err,
+		}
+	}
+	for _, session := range sessions {
+		result[session.StaffID] = append(result[session.StaffID], session)
+	}
+	return result, nil
+}

--- a/backend/database/repositories/active/work_session_break.go
+++ b/backend/database/repositories/active/work_session_break.go
@@ -138,3 +138,35 @@ func (r *WorkSessionBreakRepository) GetExpiredBreaks(ctx context.Context, befor
 
 	return breaks, nil
 }
+
+// GetActiveBySessionIDs is GetActiveBySessionID for many sessions in one round
+// trip, keyed by session ID. A batched IN-lookup the generic filter API cannot
+// express as a single query. Sessions without an open break are absent from the
+// map, which callers must treat exactly like the single-session (nil, nil).
+func (r *WorkSessionBreakRepository) GetActiveBySessionIDs(ctx context.Context, sessionIDs []int64) (map[int64]*active.WorkSessionBreak, error) {
+	result := make(map[int64]*active.WorkSessionBreak, len(sessionIDs))
+	if len(sessionIDs) == 0 {
+		// bun renders an empty IN list as invalid SQL.
+		return result, nil
+	}
+
+	var breaks []*active.WorkSessionBreak
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&breaks).
+		ModelTableExpr(tableExprActiveWorkSessionBreaksAsWorkSessionBreak).
+		Where(`"work_session_break".session_id IN (?)`, bun.List(sessionIDs)).
+		Where(`"work_session_break".ended_at IS NULL`)
+
+	query = base.WithTenantFilter(ctx, query, "work_session_break")
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "get active breaks by session IDs",
+			Err: err,
+		}
+	}
+	for _, brk := range breaks {
+		result[brk.SessionID] = brk
+	}
+	return result, nil
+}

--- a/backend/database/repositories/config/staff_work_schedule.go
+++ b/backend/database/repositories/config/staff_work_schedule.go
@@ -176,3 +176,36 @@ func (r *StaffWorkScheduleRepository) ReplaceSchedule(ctx context.Context, staff
 
 	return nil
 }
+
+// FindStaffIDsWithScheduleHistory is HasScheduleHistory for many staff members
+// in one round trip. A batched DISTINCT the generic filter API cannot express
+// as a single query. Deliberately date-unbounded, exactly like its single-staff
+// twin: the answer is "did this staff member EVER have a schedule version",
+// which is what decides whether the assigned work-time model may stand in.
+func (r *StaffWorkScheduleRepository) FindStaffIDsWithScheduleHistory(ctx context.Context, staffIDs []int64) (map[int64]bool, error) {
+	result := make(map[int64]bool, len(staffIDs))
+	if len(staffIDs) == 0 {
+		// bun renders an empty IN list as invalid SQL.
+		return result, nil
+	}
+
+	var rows []struct {
+		StaffID int64 `bun:"staff_id"`
+	}
+	query := repoBase.GetDB(ctx, r.db).NewSelect().
+		ColumnExpr("DISTINCT staff_id").
+		TableExpr(tableStaffWorkSchedules).
+		Where("staff_id IN (?)", bun.List(staffIDs))
+
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, fmt.Errorf("failed to check schedule history for staff batch: %w", err)
+	}
+	for _, row := range rows {
+		result[row.StaffID] = true
+	}
+	return result, nil
+}

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -132,6 +132,7 @@ type Factory struct {
 	StaffAbsenceAudit     activeModels.StaffAbsenceAuditRepository
 	StaffVacationQuota    activeModels.StaffVacationQuotaRepository
 	StaffBalanceAdjust    activeModels.StaffBalanceAdjustmentRepository
+	StaffMonthSnapshot    activeModels.StaffMonthBalanceSnapshotRepository
 
 	// Meal plan domain
 	MealPlanEntry mealplanModels.MealPlanEntryRepository
@@ -320,6 +321,7 @@ func NewFactory(db *bun.DB) *Factory {
 		StaffAbsenceAudit:     active.NewStaffAbsenceAuditRepository(db),
 		StaffVacationQuota:    active.NewStaffVacationQuotaRepository(db),
 		StaffBalanceAdjust:    active.NewStaffBalanceAdjustmentRepository(db),
+		StaffMonthSnapshot:    active.NewStaffMonthBalanceSnapshotRepository(db),
 
 		// Meal plan repositories
 		MealPlanEntry: mealplanRepo.NewMealPlanEntryRepository(db),

--- a/backend/database/repositories/schedule/staff_shift_repo.go
+++ b/backend/database/repositories/schedule/staff_shift_repo.go
@@ -284,3 +284,37 @@ func (r *StaffShiftRepository) DeleteUpcomingByStaffID(ctx context.Context, staf
 	}
 	return rows, nil
 }
+
+// FindByStaffIDsAndDateRange is FindByStaffAndDateRange for many staff members
+// in one round trip, keyed by staff ID. A batched IN-lookup the generic filter
+// API cannot express as a single query. Wall-clock normalization is applied
+// exactly as in the single-staff twin — shiftNetMinutes depends on it.
+func (r *StaffShiftRepository) FindByStaffIDsAndDateRange(ctx context.Context, staffIDs []int64, start, end timezone.Date) (map[int64][]*schedule.StaffShift, error) {
+	result := make(map[int64][]*schedule.StaffShift, len(staffIDs))
+	if len(staffIDs) == 0 {
+		// bun renders an empty IN list as invalid SQL.
+		return result, nil
+	}
+
+	var shifts []*schedule.StaffShift
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&shifts).
+		ModelTableExpr(tableExprStaffShiftsAsShift).
+		Where(`"staff_shift".staff_id IN (?)`, bun.List(staffIDs)).
+		Where(`"staff_shift".date >= ?`, start).
+		Where(`"staff_shift".date <= ?`, end).
+		OrderExpr(`"staff_shift".staff_id ASC`).
+		OrderExpr(`"staff_shift".date ASC`).
+		OrderExpr(`"staff_shift".start_time ASC`)
+
+	query = base.WithTenantFilter(ctx, query, "staff_shift")
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "find staff shifts by staff IDs and date range", Err: err}
+	}
+	normalizeShiftWallClock(shifts)
+	for _, shift := range shifts {
+		result[shift.StaffID] = append(result[shift.StaffID], shift)
+	}
+	return result, nil
+}

--- a/backend/database/repositories/users/staff.go
+++ b/backend/database/repositories/users/staff.go
@@ -114,6 +114,10 @@ func (r *StaffRepository) staffWithPersonQuery(ctx context.Context, results *[]s
 		ColumnExpr(`"staff".tenant_id AS "staff__tenant_id"`).
 		ColumnExpr(`"staff".person_id AS "staff__person_id"`).
 		ColumnExpr(`"staff".staff_notes AS "staff__staff_notes"`).
+		// employment_type is part of the model and the cross-staff
+		// time-tracking overview filters on it (#1417); without it the field
+		// scanned back as NULL for every staff member.
+		ColumnExpr(`"staff".employment_type AS "staff__employment_type"`).
 		ColumnExpr(`"staff".work_time_model_id AS "staff__work_time_model_id"`).
 		ColumnExpr(`"staff".rotation_anchor_date AS "staff__rotation_anchor_date"`).
 		ColumnExpr(`"person".id AS "person__id"`).

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -318,6 +318,10 @@ type WorkSessionRepository interface {
 	// GetHistoryByStaffID returns work sessions for a staff member in a date range
 	GetHistoryByStaffID(ctx context.Context, staffID int64, from, to timezone.Date) ([]*WorkSession, error)
 
+	// GetHistoryByStaffIDs is GetHistoryByStaffID batched over many staff
+	// members, keyed by staff ID, for the cross-staff Stundenkonto overview.
+	GetHistoryByStaffIDs(ctx context.Context, staffIDs []int64, from, to timezone.Date) (map[int64][]*WorkSession, error)
+
 	// GetOpenSessions returns all sessions without check-out before a given date
 	GetOpenSessions(ctx context.Context, beforeDate timezone.Date) ([]*WorkSession, error)
 
@@ -350,6 +354,10 @@ type StaffAbsenceRepository interface {
 
 	// GetByStaffAndDateRange returns absences for a staff member overlapping the given date range
 	GetByStaffAndDateRange(ctx context.Context, staffID int64, from, to timezone.Date) ([]*StaffAbsence, error)
+
+	// GetByStaffIDsAndDateRange is GetByStaffAndDateRange batched over many
+	// staff members, keyed by staff ID (same overlap semantics).
+	GetByStaffIDsAndDateRange(ctx context.Context, staffIDs []int64, from, to timezone.Date) (map[int64][]*StaffAbsence, error)
 
 	// GetByStaffAndDate returns an absence for a staff member on a specific date, or nil
 	GetByStaffAndDate(ctx context.Context, staffID int64, date timezone.Date) (*StaffAbsence, error)
@@ -392,6 +400,36 @@ type StaffBalanceAdjustmentRepository interface {
 	// GetByStaffAndDateRange returns adjustments whose effective_date lies in
 	// [from, to], ordered by effective_date.
 	GetByStaffAndDateRange(ctx context.Context, staffID int64, from, to timezone.Date) ([]*StaffBalanceAdjustment, error)
+
+	// GetByStaffIDsAndDateRange is GetByStaffAndDateRange batched over many
+	// staff members, keyed by staff ID.
+	GetByStaffIDsAndDateRange(ctx context.Context, staffIDs []int64, from, to timezone.Date) (map[int64][]*StaffBalanceAdjustment, error)
+}
+
+// StaffMonthBalanceSnapshotRepository defines operations for frozen month
+// closing balances (#1417).
+type StaffMonthBalanceSnapshotRepository interface {
+	base.Repository[*StaffMonthBalanceSnapshot]
+
+	// GetLatestClosedThrough returns the newest ACTIVE snapshot whose
+	// (year, month) is at or before the given one, or nil.
+	//
+	// Not expressible as a filter: the ordering key is the composite
+	// year*12+month expression, and "active" is the partial predicate
+	// reopened_at IS NULL.
+	GetLatestClosedThrough(ctx context.Context, staffID int64, year, month int) (*StaffMonthBalanceSnapshot, error)
+
+	// GetByMonth lists the ACTIVE snapshots of one month for the whole tenant.
+	// Backs the close-status view and CloseMonth's idempotency check.
+	GetByMonth(ctx context.Context, year, month int) ([]*StaffMonthBalanceSnapshot, error)
+
+	// LockStaffBalanceWrites takes the same per-staff advisory lock the
+	// adjustment ledger uses, so a close cannot interleave with a payout.
+	LockStaffBalanceWrites(ctx context.Context, staffID int64) error
+
+	// UpdateColumns writes selected columns only. Reopening must touch the
+	// reopen fields without rewriting the frozen values next to them.
+	UpdateColumns(ctx context.Context, snapshot *StaffMonthBalanceSnapshot, columns ...string) (int64, error)
 }
 
 // StaffVacationQuotaRepository defines operations for managing per-staff yearly entitlement
@@ -400,6 +438,10 @@ type StaffVacationQuotaRepository interface {
 
 	// GetByStaffAndYear returns the quota row for a specific staff/year, or nil
 	GetByStaffAndYear(ctx context.Context, staffID int64, year int) (*StaffVacationQuota, error)
+
+	// GetByStaffIDsAndYear is GetByStaffAndYear batched over many staff
+	// members, keyed by staff ID. Missing rows are absent from the map.
+	GetByStaffIDsAndYear(ctx context.Context, staffIDs []int64, year int) (map[int64]*StaffVacationQuota, error)
 
 	// Upsert creates or updates the quota for a staff/year combination
 	Upsert(ctx context.Context, quota *StaffVacationQuota) error
@@ -414,6 +456,10 @@ type WorkSessionBreakRepository interface {
 
 	// GetActiveBySessionID returns the currently active (no ended_at) break for a session, or nil
 	GetActiveBySessionID(ctx context.Context, sessionID int64) (*WorkSessionBreak, error)
+
+	// GetActiveBySessionIDs is GetActiveBySessionID batched over many
+	// sessions, keyed by session ID. Sessions without an open break are absent.
+	GetActiveBySessionIDs(ctx context.Context, sessionIDs []int64) (map[int64]*WorkSessionBreak, error)
 
 	// EndBreak sets ended_at and duration_minutes on a break
 	EndBreak(ctx context.Context, id int64, endedAt time.Time, durationMinutes int) error

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -362,10 +362,10 @@ type StaffAbsenceRepository interface {
 	// GetByStaffAndDate returns an absence for a staff member on a specific date, or nil
 	GetByStaffAndDate(ctx context.Context, staffID int64, date timezone.Date) (*StaffAbsence, error)
 
-	// GetTodayAbsenceMap returns a map of staff IDs to their absence type for today
+	// GetAbsenceMapForDate returns a map of staff IDs to their absence type for the given date.
 	// Priority order when multiple absences exist:
 	// sick > training > vacation > comp_time > other.
-	GetTodayAbsenceMap(ctx context.Context) (map[int64]string, error)
+	GetAbsenceMapForDate(ctx context.Context, date timezone.Date) (map[int64]string, error)
 
 	// ListByStatuses returns all absences whose status is in the given set,
 	// ordered by requested_at (used for the /staff inbox: requested + question)

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -420,7 +420,7 @@ type StaffMonthBalanceSnapshotRepository interface {
 	GetLatestClosedThrough(ctx context.Context, staffID int64, year, month int) (*StaffMonthBalanceSnapshot, error)
 
 	// GetByMonth lists the ACTIVE snapshots of one month for the whole tenant.
-	// Backs the close-status view and CloseMonth's idempotency check.
+	// Backs the close-status view.
 	GetByMonth(ctx context.Context, year, month int) ([]*StaffMonthBalanceSnapshot, error)
 
 	// LockStaffBalanceWrites takes the same per-staff advisory lock the

--- a/backend/models/active/staff_month_balance_snapshot.go
+++ b/backend/models/active/staff_month_balance_snapshot.go
@@ -1,0 +1,92 @@
+package active
+
+import (
+	"errors"
+	"slices"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+)
+
+// SnapshotSource constants (#1417) record how a month came to be frozen.
+// Only 'admin' is produced today; 'scheduler' is reserved for the automatic
+// close that #1417 defers to a follow-up, 'migration' for backfills.
+const (
+	SnapshotSourceAdmin     = "admin"
+	SnapshotSourceScheduler = "scheduler"
+	SnapshotSourceMigration = "migration"
+)
+
+// ValidSnapshotSources lists all valid snapshot sources.
+var ValidSnapshotSources = []string{
+	SnapshotSourceAdmin,
+	SnapshotSourceScheduler,
+	SnapshotSourceMigration,
+}
+
+// StaffMonthBalanceSnapshot is the frozen closing balance of one staff member's
+// month (#1417). It exists because the Stundenkonto is otherwise computed live
+// all the way back to the account start, so a retroactive shift or session edit
+// rewrites the balance of every month after it.
+//
+// Once a month is frozen, the carry chain for later months starts at
+// ClosingBalanceMinutes instead of re-summing from the anchor. The frozen month
+// itself is still recomputed for display; the gap between the recomputed and
+// the frozen value is reported as drift.
+//
+// This is not a booking. StaffBalanceAdjustment (#1420) carries a signed
+// MinutesDelta and moves the balance; this row carries no delta and moves
+// nothing — it only pins where the chain starts.
+//
+// The remaining fields beyond ClosingBalanceMinutes are a display copy of the
+// month as it stood at close time, so the Monatskarte can show what was frozen
+// without re-deriving it.
+//
+// A reopened snapshot is superseded, not deleted: ReopenedAt/ReopenedBy/
+// ReopenReason stay on the row, which makes the row its own audit record.
+type StaffMonthBalanceSnapshot struct {
+	base.Model `bun:"schema:active,table:staff_month_balance_snapshots"`
+	base.TenantModel
+	StaffID               int64      `bun:"staff_id,notnull" json:"staff_id"`
+	Year                  int        `bun:"year,notnull" json:"year"`
+	Month                 int        `bun:"month,notnull" json:"month"`
+	ClosingBalanceMinutes int        `bun:"closing_balance_minutes,notnull" json:"closing_balance_minutes"`
+	CarryInMinutes        int        `bun:"carry_in_minutes,notnull" json:"carry_in_minutes"`
+	TargetMinutes         int        `bun:"target_minutes,notnull" json:"target_minutes"`
+	ActualMinutes         int        `bun:"actual_minutes,notnull" json:"actual_minutes"`
+	CreditedMinutes       int        `bun:"credited_minutes,notnull" json:"credited_minutes"`
+	AdjustmentMinutes     int        `bun:"adjustment_minutes,notnull" json:"adjustment_minutes"`
+	ClosedAt              time.Time  `bun:"closed_at,notnull,default:current_timestamp" json:"closed_at"`
+	ClosedBy              int64      `bun:"closed_by,notnull" json:"closed_by"`
+	CloseReason           string     `bun:"close_reason,notnull,default:''" json:"close_reason,omitempty"`
+	Source                string     `bun:"source,notnull,default:'admin'" json:"source"`
+	ReopenedAt            *time.Time `bun:"reopened_at" json:"reopened_at,omitempty"`
+	ReopenedBy            *int64     `bun:"reopened_by" json:"reopened_by,omitempty"`
+	ReopenReason          string     `bun:"reopen_reason,notnull,default:''" json:"reopen_reason,omitempty"`
+}
+
+// Validate validates the snapshot record.
+func (s *StaffMonthBalanceSnapshot) Validate() error {
+	if s.StaffID <= 0 {
+		return errors.New("staff ID is required")
+	}
+	if s.Month < 1 || s.Month > 12 {
+		return errors.New("month must be between 1 and 12")
+	}
+	if s.Year < 2000 || s.Year > 2100 {
+		return errors.New("year must be between 2000 and 2100")
+	}
+	if s.ClosedBy <= 0 {
+		return errors.New("closed_by is required")
+	}
+	if !slices.Contains(ValidSnapshotSources, s.Source) {
+		return errors.New("invalid snapshot source")
+	}
+	return nil
+}
+
+// IsActive reports whether this snapshot still freezes its month. A reopened
+// row is superseded history and must never seed a carry chain.
+func (s *StaffMonthBalanceSnapshot) IsActive() bool {
+	return s.ReopenedAt == nil
+}

--- a/backend/models/config/staff_work_schedule.go
+++ b/backend/models/config/staff_work_schedule.go
@@ -98,6 +98,10 @@ type StaffWorkScheduleRepository interface {
 	// Soll is genuinely zero.
 	HasScheduleHistory(ctx context.Context, staffID int64) (bool, error)
 
+	// FindStaffIDsWithScheduleHistory is HasScheduleHistory batched over many
+	// staff members; only staff with at least one schedule version appear.
+	FindStaffIDsWithScheduleHistory(ctx context.Context, staffIDs []int64) (map[int64]bool, error)
+
 	// ReplaceSchedule atomically replaces all current schedule entries for a
 	// staff member. anchor is the rotation anchor the new version is written
 	// with and is stamped onto every inserted row (#1842) — the closed-out

--- a/backend/models/schedule/repository.go
+++ b/backend/models/schedule/repository.go
@@ -59,6 +59,10 @@ type StaffShiftRepository interface {
 	// FindByStaffAndDateRange returns one staff member's shifts in the range.
 	FindByStaffAndDateRange(ctx context.Context, staffID int64, start, end timezone.Date) ([]*StaffShift, error)
 
+	// FindByStaffIDsAndDateRange is FindByStaffAndDateRange batched over many
+	// staff members, keyed by staff ID.
+	FindByStaffIDsAndDateRange(ctx context.Context, staffIDs []int64, start, end timezone.Date) (map[int64][]*StaffShift, error)
+
 	// FindByStaffIDsAndDate returns the shifts of the given staff members on
 	// one date (batch lookup for the auto-checkout job).
 	FindByStaffIDsAndDate(ctx context.Context, staffIDs []int64, date timezone.Date) ([]*StaffShift, error)

--- a/backend/services/active/staff_absence_service.go
+++ b/backend/services/active/staff_absence_service.go
@@ -1274,6 +1274,21 @@ func (s *staffAbsenceService) GetVacationQuotaSummary(ctx context.Context, staff
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch year absences: %w", err)
 	}
+	return computeVacationQuotaSummary(staffID, year, entitled, carryover, absences), nil
+}
+
+// computeVacationQuotaSummary is the pure tail of GetVacationQuotaSummary: the
+// two reads happen at the call site, the arithmetic lives here. Extracted so
+// the cross-staff overview (#1417) can compute Resturlaub from prefetched rows
+// through the SAME code, instead of a second implementation that would drift.
+func computeVacationQuotaSummary(
+	staffID int64,
+	year int,
+	entitled, carryover float64,
+	absences []*activeModels.StaffAbsence,
+) *VacationQuotaSummary {
+	yearStart := timezone.NewDate(year, time.January, 1)
+	yearEnd := timezone.NewDate(year, time.December, 31)
 
 	taken, reserved := 0.0, 0.0
 	for _, a := range absences {
@@ -1300,7 +1315,7 @@ func (s *staffAbsenceService) GetVacationQuotaSummary(ctx context.Context, staff
 		TakenDays:     taken,
 		ReservedDays:  reserved,
 		RemainingDays: entitled + carryover - taken - reserved,
-	}, nil
+	}
 }
 
 func dateWithinRange(d, from, to timezone.Date) bool {

--- a/backend/services/active/staff_absence_service.go
+++ b/backend/services/active/staff_absence_service.go
@@ -135,7 +135,7 @@ type StaffAbsenceService interface {
 
 // GetTodayAbsenceMap returns staff ID -> absence type for today.
 func (s *staffAbsenceService) GetTodayAbsenceMap(ctx context.Context) (map[int64]string, error) {
-	return s.absenceRepo.GetTodayAbsenceMap(ctx)
+	return s.absenceRepo.GetAbsenceMapForDate(ctx, timezone.TodayDate())
 }
 
 // staffAbsenceService implements StaffAbsenceService

--- a/backend/services/active/staff_absence_service_test.go
+++ b/backend/services/active/staff_absence_service_test.go
@@ -75,6 +75,12 @@ func (m *absStaffAbsenceRepoMock) List(ctx context.Context, options *base.QueryO
 	return nil, nil
 }
 
+// GetByStaffIDsAndDateRange satisfies the batched interface method (#1417);
+// these tests exercise the single-staff path only.
+func (m *absStaffAbsenceRepoMock) GetByStaffIDsAndDateRange(context.Context, []int64, timezone.Date, timezone.Date) (map[int64][]*activeModels.StaffAbsence, error) {
+	return nil, nil
+}
+
 func (m *absStaffAbsenceRepoMock) GetByStaffAndDateRange(ctx context.Context, staffID int64, from, to timezone.Date) ([]*activeModels.StaffAbsence, error) {
 	if m.getByStaffAndDateRangeFunc != nil {
 		return m.getByStaffAndDateRangeFunc(ctx, staffID, from, to)
@@ -139,6 +145,11 @@ func (m *absVacationQuotaRepoMock) Delete(context.Context, any) error {
 }
 
 func (m *absVacationQuotaRepoMock) List(context.Context, *base.QueryOptions) ([]*activeModels.StaffVacationQuota, error) {
+	return nil, nil
+}
+
+// GetByStaffIDsAndYear satisfies the batched interface method (#1417).
+func (m *absVacationQuotaRepoMock) GetByStaffIDsAndYear(context.Context, []int64, int) (map[int64]*activeModels.StaffVacationQuota, error) {
 	return nil, nil
 }
 
@@ -260,6 +271,11 @@ func (m *absWorkSessionRepoMock) LockOpenByIDForUpdate(ctx context.Context, id i
 		return nil, errors.New("not found")
 	}
 	return session, nil
+}
+
+// GetHistoryByStaffIDs satisfies the batched interface method (#1417).
+func (m *absWorkSessionRepoMock) GetHistoryByStaffIDs(context.Context, []int64, timezone.Date, timezone.Date) (map[int64][]*activeModels.WorkSession, error) {
+	return nil, nil
 }
 
 func (m *absWorkSessionRepoMock) GetHistoryByStaffID(ctx context.Context, staffID int64, from, to timezone.Date) ([]*activeModels.WorkSession, error) {

--- a/backend/services/active/staff_absence_service_test.go
+++ b/backend/services/active/staff_absence_service_test.go
@@ -32,7 +32,7 @@ type absStaffAbsenceRepoMock struct {
 	getByStaffAndDateRangeFunc func(ctx context.Context, staffID int64, from, to timezone.Date) ([]*activeModels.StaffAbsence, error)
 	getByStaffAndDateFunc      func(ctx context.Context, staffID int64, date timezone.Date) (*activeModels.StaffAbsence, error)
 	getByDateRangeFunc         func(ctx context.Context, from, to timezone.Date) ([]*activeModels.StaffAbsence, error)
-	getTodayAbsenceMapFunc     func(ctx context.Context) (map[int64]string, error)
+	getAbsenceMapForDateFunc   func(ctx context.Context, date timezone.Date) (map[int64]string, error)
 	listByStatusesFunc         func(ctx context.Context, statuses []string) ([]*activeModels.StaffAbsence, error)
 }
 
@@ -102,9 +102,9 @@ func (m *absStaffAbsenceRepoMock) GetByDateRange(ctx context.Context, from, to t
 	return nil, nil
 }
 
-func (m *absStaffAbsenceRepoMock) GetTodayAbsenceMap(ctx context.Context) (map[int64]string, error) {
-	if m.getTodayAbsenceMapFunc != nil {
-		return m.getTodayAbsenceMapFunc(ctx)
+func (m *absStaffAbsenceRepoMock) GetAbsenceMapForDate(ctx context.Context, date timezone.Date) (map[int64]string, error) {
+	if m.getAbsenceMapForDateFunc != nil {
+		return m.getAbsenceMapForDateFunc(ctx, date)
 	}
 	return nil, nil
 }

--- a/backend/services/active/staff_balance_adjustment_service.go
+++ b/backend/services/active/staff_balance_adjustment_service.go
@@ -191,11 +191,11 @@ func (s *staffBalanceAdjustmentService) CreateAdjustment(ctx context.Context, st
 	if err := s.rejectPreAccountDate(ctx, req.EffectiveDate); err != nil {
 		return nil, err
 	}
-	if err := s.rejectFrozenMonth(ctx, staffID, req.EffectiveDate); err != nil {
-		return nil, err
-	}
 	if err := s.adjustmentRepo.LockStaffBalanceWrites(ctx, staffID); err != nil {
 		return nil, fmt.Errorf("failed to lock staff balance writes: %w", err)
+	}
+	if err := s.rejectFrozenMonth(ctx, staffID, req.EffectiveDate); err != nil {
+		return nil, err
 	}
 	resets, err := s.listResetsOnOrAfter(ctx, staffID, req.EffectiveDate)
 	if err != nil {
@@ -340,14 +340,14 @@ func (s *staffBalanceAdjustmentService) ResetBalance(ctx context.Context, staffI
 	if err := s.rejectPreAccountDate(ctx, effectiveDate); err != nil {
 		return nil, err
 	}
-	if err := s.rejectFrozenMonth(ctx, staffID, effectiveDate); err != nil {
-		return nil, err
-	}
 
 	// Serialize concurrent resets: the advisory lock covers the
 	// read-compute-insert sequence, the partial unique index is the backstop.
 	if err := s.adjustmentRepo.LockStaffBalanceWrites(ctx, staffID); err != nil {
 		return nil, fmt.Errorf("failed to lock staff balance writes: %w", err)
+	}
+	if err := s.rejectFrozenMonth(ctx, staffID, effectiveDate); err != nil {
+		return nil, err
 	}
 	resets, err := s.listResetsOnOrAfter(ctx, staffID, effectiveDate)
 	if err != nil {

--- a/backend/services/active/staff_balance_adjustment_service.go
+++ b/backend/services/active/staff_balance_adjustment_service.go
@@ -73,13 +73,31 @@ type StaffBalanceAdjustmentService interface {
 	// run inside the ambient tenant transaction (advisory lock + unique
 	// index serialize concurrent resets).
 	ResetBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, carryoverMinutes int, note string) (*activeModels.StaffBalanceAdjustment, error)
+	// SetSnapshotReader injects the frozen-month reader (#1417) after
+	// construction; nil means no month counts as frozen, so existing unit
+	// fixtures stay valid.
+	SetSnapshotReader(reader adjustmentFreezeReader)
+}
+
+// adjustmentFreezeReader is implemented by
+// active.StaffMonthBalanceSnapshotRepository (#1417).
+type adjustmentFreezeReader interface {
+	GetLatestClosedThrough(ctx context.Context, staffID int64, year, month int) (*activeModels.StaffMonthBalanceSnapshot, error)
 }
 
 type staffBalanceAdjustmentService struct {
 	adjustmentRepo activeModels.StaffBalanceAdjustmentRepository
 	monthService   WorkTimeMonthService
 	settings       monthSettingsResolver
+	snapshotRepo   adjustmentFreezeReader
 	logger         *slog.Logger
+}
+
+// SetSnapshotReader wires the frozen-month reader (#1417). Setter injection
+// like the month service's: nil means no month counts as frozen, so existing
+// unit fixtures stay valid.
+func (s *staffBalanceAdjustmentService) SetSnapshotReader(reader adjustmentFreezeReader) {
+	s.snapshotRepo = reader
 }
 
 func NewStaffBalanceAdjustmentService(
@@ -110,6 +128,32 @@ func (s *staffBalanceAdjustmentService) rejectPreAccountDate(ctx context.Context
 		return fmt.Errorf("%w: effective_date %s lies before the account start %s", ErrAdjustmentInvalid, effectiveDate.String(), anchor.String())
 	}
 	return nil
+}
+
+// rejectFrozenMonth fails a booking whose effective month is closed (#1417).
+// A frozen month's closing balance no longer comes from its own aggregation,
+// so a booking inside it would appear in the history while moving nothing.
+//
+// Deliberately partial, exactly like ErrAdjustmentHasDependentReset: only
+// ADJUSTMENT writes are blocked. Work sessions and comp_time absences inside a
+// frozen month stay editable — the divergence they cause is reported as the
+// month's drift instead of being suppressed. Reopening the month lifts this.
+func (s *staffBalanceAdjustmentService) rejectFrozenMonth(ctx context.Context, staffID int64, effectiveDate timezone.Date) error {
+	if s.snapshotRepo == nil {
+		return nil
+	}
+	year, month := effectiveDate.Year, int(effectiveDate.Month)
+	snapshot, err := s.snapshotRepo.GetLatestClosedThrough(ctx, staffID, year, month)
+	if err != nil {
+		return fmt.Errorf("failed to check month close state for adjustment: %w", err)
+	}
+	if snapshot == nil || snapshot.Year != year || snapshot.Month != month {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: effective_date %s lies in the closed month %04d-%02d",
+		ErrAdjustmentInvalid, effectiveDate.String(), year, month,
+	)
 }
 
 func (s *staffBalanceAdjustmentService) ListAdjustments(ctx context.Context, staffID int64, from, to timezone.Date) ([]*activeModels.StaffBalanceAdjustment, error) {
@@ -145,6 +189,9 @@ func (s *staffBalanceAdjustmentService) CreateAdjustment(ctx context.Context, st
 		)
 	}
 	if err := s.rejectPreAccountDate(ctx, req.EffectiveDate); err != nil {
+		return nil, err
+	}
+	if err := s.rejectFrozenMonth(ctx, staffID, req.EffectiveDate); err != nil {
 		return nil, err
 	}
 	if err := s.adjustmentRepo.LockStaffBalanceWrites(ctx, staffID); err != nil {
@@ -219,6 +266,12 @@ func (s *staffBalanceAdjustmentService) DeleteAdjustment(ctx context.Context, st
 	if adjustment == nil || adjustment.StaffID != staffID {
 		return fmt.Errorf("%w: id %d", ErrAdjustmentNotFound, adjustmentID)
 	}
+	// Checked here rather than up front: the effective date only exists once
+	// the row is loaded. Deleting out of a frozen month is the same violation
+	// as inserting into one.
+	if err := s.rejectFrozenMonth(ctx, staffID, adjustment.EffectiveDate); err != nil {
+		return err
+	}
 	dependent, err := s.hasDependentReset(ctx, adjustment)
 	if err != nil {
 		return err
@@ -285,6 +338,9 @@ func (s *staffBalanceAdjustmentService) ResetBalance(ctx context.Context, staffI
 		return nil, fmt.Errorf("%w: effective_date must be before today", ErrAdjustmentInvalid)
 	}
 	if err := s.rejectPreAccountDate(ctx, effectiveDate); err != nil {
+		return nil, err
+	}
+	if err := s.rejectFrozenMonth(ctx, staffID, effectiveDate); err != nil {
 		return nil, err
 	}
 

--- a/backend/services/active/staff_balance_adjustment_service_mock_test.go
+++ b/backend/services/active/staff_balance_adjustment_service_mock_test.go
@@ -74,6 +74,16 @@ func (s *recordingBalanceMonthService) GetBalanceReductionCapacity(_ context.Con
 	return s.balance, nil
 }
 
+type recordingAdjustmentFreezeReader struct {
+	events   *[]string
+	snapshot *activeModels.StaffMonthBalanceSnapshot
+}
+
+func (r *recordingAdjustmentFreezeReader) GetLatestClosedThrough(context.Context, int64, int, int) (*activeModels.StaffMonthBalanceSnapshot, error) {
+	*r.events = append(*r.events, "snapshot")
+	return r.snapshot, nil
+}
+
 func newRecordingBalanceAdjustmentService(
 	events *[]string,
 	repo *recordingBalanceAdjustmentRepo,
@@ -85,6 +95,66 @@ func newRecordingBalanceAdjustmentService(
 		&wtmMockSettings{accountStart: "2026-06-01"},
 		slog.New(slog.DiscardHandler),
 	)
+}
+
+func TestStaffBalanceAdjustmentService_ChecksFrozenMonthAfterLock(t *testing.T) {
+	const (
+		staffID   = int64(41)
+		decidedBy = int64(42)
+	)
+	effectiveDate := timezone.NewDate(2026, time.July, 7)
+	frozen := &activeModels.StaffMonthBalanceSnapshot{
+		StaffID: staffID,
+		Year:    effectiveDate.Year,
+		Month:   int(effectiveDate.Month),
+	}
+
+	for _, tc := range []struct {
+		name string
+		run  func(StaffBalanceAdjustmentService) error
+	}{
+		{
+			name: "create",
+			run: func(service StaffBalanceAdjustmentService) error {
+				_, err := service.CreateAdjustment(context.Background(), staffID, decidedBy, CreateBalanceAdjustmentRequest{
+					Type:          activeModels.BalanceAdjustmentTypePayout,
+					MinutesDelta:  -60,
+					EffectiveDate: effectiveDate,
+					Note:          "Auszahlung",
+				})
+				return err
+			},
+		},
+		{
+			name: "reset",
+			run: func(service StaffBalanceAdjustmentService) error {
+				_, err := service.ResetBalance(
+					context.Background(),
+					staffID,
+					decidedBy,
+					effectiveDate,
+					60,
+					"Schuljahreswechsel",
+				)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			events := []string{}
+			repo := &recordingBalanceAdjustmentRepo{events: &events}
+			service := newRecordingBalanceAdjustmentService(&events, repo, nil)
+			service.SetSnapshotReader(&recordingAdjustmentFreezeReader{
+				events:   &events,
+				snapshot: frozen,
+			})
+
+			err := tc.run(service)
+
+			require.ErrorIs(t, err, ErrAdjustmentInvalid)
+			assert.Equal(t, []string{"lock", "snapshot"}, events)
+		})
+	}
 }
 
 func TestStaffBalanceAdjustmentService_LocksEveryMutation(t *testing.T) {

--- a/backend/services/active/staff_month_close_service.go
+++ b/backend/services/active/staff_month_close_service.go
@@ -25,8 +25,8 @@ var (
 	ErrMonthNotClosable = errors.New("month cannot be closed")
 	// ErrMonthNotClosed marks a reopen of a month that is not frozen — HTTP 404.
 	ErrMonthNotClosed = errors.New("month is not closed")
-	// ErrLaterMonthClosed prevents reopening a month while a later one is
-	// still frozen — HTTP 409.
+	// ErrLaterMonthClosed prevents changing the snapshot chain behind a later
+	// frozen month — HTTP 409.
 	ErrLaterMonthClosed = errors.New("a later month is still closed")
 )
 
@@ -220,6 +220,16 @@ func (s *staffMonthCloseService) closeStaffMonth(
 	}
 	if existing != nil && existing.Year == key.Year && existing.Month == key.Month {
 		return nil, true, nil
+	}
+	latest, err := s.snapshotRepo.GetLatestClosedThrough(ctx, staffID, maxSnapshotYear, 12)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to check later month snapshots for staff %d: %w", staffID, err)
+	}
+	if latest != nil && key.before(monthKey{Year: latest.Year, Month: latest.Month}) {
+		return nil, false, fmt.Errorf(
+			"%w: %04d-%02d must be reopened first",
+			ErrLaterMonthClosed, latest.Year, latest.Month,
+		)
 	}
 	summary, err := s.monthService.GetMonthSummaryAtMonthEnd(ctx, staffID, key.Year, key.Month)
 	if err != nil {

--- a/backend/services/active/staff_month_close_service.go
+++ b/backend/services/active/staff_month_close_service.go
@@ -102,15 +102,20 @@ func (s *staffMonthCloseService) getLogger() *slog.Logger {
 	return cmp.Or(s.logger, slog.Default())
 }
 
+func calendarMonthHasEnded(key monthKey, today timezone.Date) bool {
+	return key.lastDay().Before(today)
+}
+
 // validateCloseRequest checks the month, the reason, and whether the month may
 // be frozen at all.
 //
 // The "month is over" check is the load-bearing one. The month math clamps
 // Soll at the clamp date, and the close deliberately clamps at the month's
 // last day to get a true closing value. For a month that is still running,
-// that clamp lies in the future: the full month's Soll would be charged
-// against an Ist that stops today, and the frozen value would be short by
-// every remaining working day — an error that then carries forward forever.
+// the full month's Soll would be charged against an Ist that stops now. This
+// also applies on the last calendar day: that day's remaining work has not
+// happened yet. The frozen value would carry the artificial deficit forward
+// forever.
 // Closing with the clamp at today is not a fix; the result would not be the
 // month's closing balance and the splice for the next month would be wrong in
 // the other direction.
@@ -123,7 +128,7 @@ func (s *staffMonthCloseService) validateCloseRequest(ctx context.Context, year,
 		return monthKey{}, "", fmt.Errorf("%w: a reason is required", ErrMonthCloseInvalid)
 	}
 	key := monthKey{Year: year, Month: month}
-	if key.lastDay().After(timezone.TodayDate()) {
+	if !calendarMonthHasEnded(key, timezone.TodayDate()) {
 		return monthKey{}, "", fmt.Errorf(
 			"%w: %04d-%02d is not over yet",
 			ErrMonthNotClosable, year, month,

--- a/backend/services/active/staff_month_close_service.go
+++ b/backend/services/active/staff_month_close_service.go
@@ -154,15 +154,6 @@ func (s *staffMonthCloseService) CloseMonth(ctx context.Context, closedBy int64,
 		return nil, err
 	}
 
-	existing, err := s.snapshotRepo.GetByMonth(ctx, year, month)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load existing month snapshots: %w", err)
-	}
-	alreadyClosed := make(map[int64]bool, len(existing))
-	for _, snapshot := range existing {
-		alreadyClosed[snapshot.StaffID] = true
-	}
-
 	staffMembers, err := s.staffLister.ListAllWithPerson(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list staff for month close: %w", err)
@@ -183,13 +174,13 @@ func (s *staffMonthCloseService) CloseMonth(ctx context.Context, closedBy int64,
 
 	result := &MonthCloseResult{Year: year, Month: month}
 	for _, staff := range staffMembers {
-		if alreadyClosed[staff.ID] {
-			result.SkippedStaff++
-			continue
-		}
-		snapshot, err := s.closeStaffMonth(ctx, staff.ID, closedBy, key, trimmedReason)
+		snapshot, alreadyClosed, err := s.closeStaffMonth(ctx, staff.ID, closedBy, key, trimmedReason)
 		if err != nil {
 			return nil, err
+		}
+		if alreadyClosed {
+			result.SkippedStaff++
+			continue
 		}
 		result.ClosedStaff++
 		result.Snapshots = append(result.Snapshots, snapshot)
@@ -214,13 +205,20 @@ func (s *staffMonthCloseService) closeStaffMonth(
 	staffID, closedBy int64,
 	key monthKey,
 	reason string,
-) (*activeModels.StaffMonthBalanceSnapshot, error) {
+) (*activeModels.StaffMonthBalanceSnapshot, bool, error) {
 	if err := s.snapshotRepo.LockStaffBalanceWrites(ctx, staffID); err != nil {
-		return nil, fmt.Errorf("failed to lock staff balance writes: %w", err)
+		return nil, false, fmt.Errorf("failed to lock staff balance writes: %w", err)
+	}
+	existing, err := s.snapshotRepo.GetLatestClosedThrough(ctx, staffID, key.Year, key.Month)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to check existing month snapshot for staff %d: %w", staffID, err)
+	}
+	if existing != nil && existing.Year == key.Year && existing.Month == key.Month {
+		return nil, true, nil
 	}
 	summary, err := s.monthService.GetMonthSummaryAtMonthEnd(ctx, staffID, key.Year, key.Month)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compute month summary for staff %d: %w", staffID, err)
+		return nil, false, fmt.Errorf("failed to compute month summary for staff %d: %w", staffID, err)
 	}
 	snapshot := &activeModels.StaffMonthBalanceSnapshot{
 		StaffID:               staffID,
@@ -240,7 +238,7 @@ func (s *staffMonthCloseService) closeStaffMonth(
 		Source:            activeModels.SnapshotSourceAdmin,
 	}
 	if err := s.snapshotRepo.Create(ctx, snapshot); err != nil {
-		return nil, fmt.Errorf("failed to create month snapshot for staff %d: %w", staffID, err)
+		return nil, false, fmt.Errorf("failed to create month snapshot for staff %d: %w", staffID, err)
 	}
 	s.getLogger().Debug("month balance snapshot written",
 		"staff_id", staffID,
@@ -248,7 +246,7 @@ func (s *staffMonthCloseService) closeStaffMonth(
 		"month", key.Month,
 		"closing_balance_minutes", snapshot.ClosingBalanceMinutes,
 	)
-	return snapshot, nil
+	return snapshot, false, nil
 }
 
 func (s *staffMonthCloseService) ReopenMonth(ctx context.Context, staffID, reopenedBy int64, year, month int, reason string) error {

--- a/backend/services/active/staff_month_close_service.go
+++ b/backend/services/active/staff_month_close_service.go
@@ -1,0 +1,315 @@
+package active
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// Sentinel errors for handler mapping (#1417).
+var (
+	// ErrMonthCloseInvalid marks a caller mistake (bad month, missing
+	// reason) — HTTP 400.
+	ErrMonthCloseInvalid = errors.New("invalid month close request")
+	// ErrMonthNotClosable marks a month that may not be frozen yet: still
+	// running, or entirely before the account start — HTTP 400.
+	ErrMonthNotClosable = errors.New("month cannot be closed")
+	// ErrMonthNotClosed marks a reopen of a month that is not frozen — HTTP 404.
+	ErrMonthNotClosed = errors.New("month is not closed")
+	// ErrLaterMonthClosed prevents reopening a month while a later one is
+	// still frozen — HTTP 409.
+	ErrLaterMonthClosed = errors.New("a later month is still closed")
+)
+
+// maxSnapshotYear is the upper bound validateMonth accepts, used to ask the
+// repository for "the newest snapshot at all" without a second query shape.
+const maxSnapshotYear = 2100
+
+// monthCloseStaffLister is implemented by users.StaffRepository. Narrow on
+// purpose: the close service needs the tenant's staff members, not the staff
+// domain service (which would pull in a service-to-service dependency).
+type monthCloseStaffLister interface {
+	ListAllWithPerson(ctx context.Context) ([]*userModels.Staff, error)
+}
+
+// MonthCloseResult reports what a school-wide close did.
+type MonthCloseResult struct {
+	Year  int `json:"year"`
+	Month int `json:"month"`
+	// ClosedStaff counts newly written snapshots, SkippedStaff the ones that
+	// were already frozen (a second click is idempotent, not an error).
+	ClosedStaff  int                                       `json:"closed_staff"`
+	SkippedStaff int                                       `json:"skipped_staff"`
+	Snapshots    []*activeModels.StaffMonthBalanceSnapshot `json:"snapshots"`
+}
+
+// StaffMonthCloseService owns the Monatsabschluss (#1417): freezing a month's
+// closing balance so a retroactive shift, session, or absence correction can no
+// longer rewrite the Übertrag of every later month.
+//
+// It is a separate service from StaffBalanceAdjustmentService on purpose. The
+// ledger owns dated bookings with a signed delta; this owns a per-month
+// freeze marker with no delta at all, plus a school-wide loop. Fusing the two
+// would put two unrelated invariant sets in one file.
+type StaffMonthCloseService interface {
+	// CloseMonth freezes the month for every staff member of the tenant. It
+	// must run inside the ambient tenant transaction: the advisory locks are
+	// transaction-scoped, and one failing staff member has to roll the whole
+	// close back (a partially closed month has no defined carry semantics).
+	CloseMonth(ctx context.Context, closedBy int64, year, month int, reason string) (*MonthCloseResult, error)
+	// ReopenMonth supersedes one staff member's snapshot so the chain
+	// recomputes. Per staff, not school-wide: a legitimate correction normally
+	// concerns one person.
+	ReopenMonth(ctx context.Context, staffID, reopenedBy int64, year, month int, reason string) error
+	// ListMonthStatus returns the active snapshots of one month.
+	ListMonthStatus(ctx context.Context, year, month int) ([]*activeModels.StaffMonthBalanceSnapshot, error)
+}
+
+type staffMonthCloseService struct {
+	snapshotRepo activeModels.StaffMonthBalanceSnapshotRepository
+	monthService WorkTimeMonthService
+	staffLister  monthCloseStaffLister
+	settings     monthSettingsResolver
+	logger       *slog.Logger
+}
+
+func NewStaffMonthCloseService(
+	snapshotRepo activeModels.StaffMonthBalanceSnapshotRepository,
+	monthService WorkTimeMonthService,
+	staffLister monthCloseStaffLister,
+	settings monthSettingsResolver,
+	logger *slog.Logger,
+) StaffMonthCloseService {
+	return &staffMonthCloseService{
+		snapshotRepo: snapshotRepo,
+		monthService: monthService,
+		staffLister:  staffLister,
+		settings:     settings,
+		logger:       logger,
+	}
+}
+
+func (s *staffMonthCloseService) getLogger() *slog.Logger {
+	return cmp.Or(s.logger, slog.Default())
+}
+
+// validateCloseRequest checks the month, the reason, and whether the month may
+// be frozen at all.
+//
+// The "month is over" check is the load-bearing one. The month math clamps
+// Soll at the clamp date, and the close deliberately clamps at the month's
+// last day to get a true closing value. For a month that is still running,
+// that clamp lies in the future: the full month's Soll would be charged
+// against an Ist that stops today, and the frozen value would be short by
+// every remaining working day — an error that then carries forward forever.
+// Closing with the clamp at today is not a fix; the result would not be the
+// month's closing balance and the splice for the next month would be wrong in
+// the other direction.
+func (s *staffMonthCloseService) validateCloseRequest(ctx context.Context, year, month int, reason string) (monthKey, string, error) {
+	if err := validateMonth(year, month); err != nil {
+		return monthKey{}, "", fmt.Errorf("%w: %s", ErrMonthCloseInvalid, err.Error())
+	}
+	trimmed := strings.TrimSpace(reason)
+	if trimmed == "" {
+		return monthKey{}, "", fmt.Errorf("%w: a reason is required", ErrMonthCloseInvalid)
+	}
+	key := monthKey{Year: year, Month: month}
+	if key.lastDay().After(timezone.TodayDate()) {
+		return monthKey{}, "", fmt.Errorf(
+			"%w: %04d-%02d is not over yet",
+			ErrMonthNotClosable, year, month,
+		)
+	}
+	anchor, err := resolveAccountAnchor(ctx, s.settings, s.getLogger(), key)
+	if err != nil {
+		return monthKey{}, "", fmt.Errorf("failed to resolve account start for month close: %w", err)
+	}
+	// A month wholly before the account start never enters a carry chain, so
+	// its snapshot could not seed one either. The read side ignores such rows;
+	// this is the write-side half of that fence.
+	if key.lastDay().Before(anchor) {
+		return monthKey{}, "", fmt.Errorf(
+			"%w: %04d-%02d lies before the account start %s",
+			ErrMonthNotClosable, year, month, anchor.String(),
+		)
+	}
+	return key, trimmed, nil
+}
+
+func (s *staffMonthCloseService) CloseMonth(ctx context.Context, closedBy int64, year, month int, reason string) (*MonthCloseResult, error) {
+	if closedBy <= 0 {
+		return nil, fmt.Errorf("%w: closed_by is required", ErrMonthCloseInvalid)
+	}
+	key, trimmedReason, err := s.validateCloseRequest(ctx, year, month, reason)
+	if err != nil {
+		return nil, err
+	}
+
+	existing, err := s.snapshotRepo.GetByMonth(ctx, year, month)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load existing month snapshots: %w", err)
+	}
+	alreadyClosed := make(map[int64]bool, len(existing))
+	for _, snapshot := range existing {
+		alreadyClosed[snapshot.StaffID] = true
+	}
+
+	staffMembers, err := s.staffLister.ListAllWithPerson(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list staff for month close: %w", err)
+	}
+	// Ascending staff ID: every other holder of the per-staff advisory lock
+	// takes exactly one, so a consistent order here rules out deadlocks
+	// against a concurrent payout or schedule edit.
+	slices.SortFunc(staffMembers, func(a, b *userModels.Staff) int {
+		switch {
+		case a.ID < b.ID:
+			return -1
+		case a.ID > b.ID:
+			return 1
+		default:
+			return 0
+		}
+	})
+
+	result := &MonthCloseResult{Year: year, Month: month}
+	for _, staff := range staffMembers {
+		if alreadyClosed[staff.ID] {
+			result.SkippedStaff++
+			continue
+		}
+		snapshot, err := s.closeStaffMonth(ctx, staff.ID, closedBy, key, trimmedReason)
+		if err != nil {
+			return nil, err
+		}
+		result.ClosedStaff++
+		result.Snapshots = append(result.Snapshots, snapshot)
+	}
+
+	s.getLogger().Info("month balance closed",
+		"year", year,
+		"month", month,
+		"closed_by", closedBy,
+		"closed_staff", result.ClosedStaff,
+		"skipped_staff", result.SkippedStaff,
+	)
+	return result, nil
+}
+
+// closeStaffMonth freezes one staff member's month. Staff without a schedule
+// or any recorded time get a zero row on purpose: "closed" has to be a
+// school-wide fact, otherwise a later card for that person would find no
+// snapshot and silently fall back to the full chain.
+func (s *staffMonthCloseService) closeStaffMonth(
+	ctx context.Context,
+	staffID, closedBy int64,
+	key monthKey,
+	reason string,
+) (*activeModels.StaffMonthBalanceSnapshot, error) {
+	if err := s.snapshotRepo.LockStaffBalanceWrites(ctx, staffID); err != nil {
+		return nil, fmt.Errorf("failed to lock staff balance writes: %w", err)
+	}
+	summary, err := s.monthService.GetMonthSummaryAtMonthEnd(ctx, staffID, key.Year, key.Month)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute month summary for staff %d: %w", staffID, err)
+	}
+	snapshot := &activeModels.StaffMonthBalanceSnapshot{
+		StaffID:               staffID,
+		Year:                  key.Year,
+		Month:                 key.Month,
+		ClosingBalanceMinutes: summary.ClosingBalanceMinutes,
+		CarryInMinutes:        summary.CarryInMinutes,
+		// The month is over, so TargetMinutesToDate equals TargetMinutes; use
+		// the clamped one to keep target and actual on the same footing.
+		TargetMinutes:     summary.TargetMinutesToDate,
+		ActualMinutes:     summary.ActualMinutes,
+		CreditedMinutes:   summary.CreditedSickMinutes + summary.CreditedVacationMinutes + summary.CreditedOtherMinutes,
+		AdjustmentMinutes: summary.AdjustmentMinutes,
+		ClosedAt:          time.Now(),
+		ClosedBy:          closedBy,
+		CloseReason:       reason,
+		Source:            activeModels.SnapshotSourceAdmin,
+	}
+	if err := s.snapshotRepo.Create(ctx, snapshot); err != nil {
+		return nil, fmt.Errorf("failed to create month snapshot for staff %d: %w", staffID, err)
+	}
+	s.getLogger().Debug("month balance snapshot written",
+		"staff_id", staffID,
+		"year", key.Year,
+		"month", key.Month,
+		"closing_balance_minutes", snapshot.ClosingBalanceMinutes,
+	)
+	return snapshot, nil
+}
+
+func (s *staffMonthCloseService) ReopenMonth(ctx context.Context, staffID, reopenedBy int64, year, month int, reason string) error {
+	if staffID <= 0 || reopenedBy <= 0 {
+		return fmt.Errorf("%w: staff id and reopened_by are required", ErrMonthCloseInvalid)
+	}
+	if err := validateMonth(year, month); err != nil {
+		return fmt.Errorf("%w: %s", ErrMonthCloseInvalid, err.Error())
+	}
+	trimmedReason := strings.TrimSpace(reason)
+	if trimmedReason == "" {
+		return fmt.Errorf("%w: a reason is required", ErrMonthCloseInvalid)
+	}
+	if err := s.snapshotRepo.LockStaffBalanceWrites(ctx, staffID); err != nil {
+		return fmt.Errorf("failed to lock staff balance writes: %w", err)
+	}
+
+	snapshot, err := s.snapshotRepo.GetLatestClosedThrough(ctx, staffID, year, month)
+	if err != nil {
+		return fmt.Errorf("failed to load month snapshot: %w", err)
+	}
+	if snapshot == nil || snapshot.Year != year || snapshot.Month != month {
+		return fmt.Errorf("%w: %04d-%02d for staff %d", ErrMonthNotClosed, year, month, staffID)
+	}
+
+	// Reopen must proceed newest-first. Reopening this month while a later one
+	// stays frozen would change that later month's drift while everything
+	// after it remains pinned to a value derived from the old history — a
+	// state no admin can reason about.
+	latest, err := s.snapshotRepo.GetLatestClosedThrough(ctx, staffID, maxSnapshotYear, 12)
+	if err != nil {
+		return fmt.Errorf("failed to check later month snapshots: %w", err)
+	}
+	if latest != nil && (latest.Year != year || latest.Month != month) {
+		return fmt.Errorf(
+			"%w: %04d-%02d must be reopened first",
+			ErrLaterMonthClosed, latest.Year, latest.Month,
+		)
+	}
+
+	now := time.Now()
+	snapshot.ReopenedAt = &now
+	snapshot.ReopenedBy = &reopenedBy
+	snapshot.ReopenReason = trimmedReason
+	if _, err := s.snapshotRepo.UpdateColumns(ctx, snapshot, "reopened_at", "reopened_by", "reopen_reason"); err != nil {
+		return fmt.Errorf("failed to reopen month snapshot: %w", err)
+	}
+
+	s.getLogger().Info("month balance reopened",
+		"staff_id", staffID,
+		"year", year,
+		"month", month,
+		"reopened_by", reopenedBy,
+		"frozen_closing_balance_minutes", snapshot.ClosingBalanceMinutes,
+	)
+	return nil
+}
+
+func (s *staffMonthCloseService) ListMonthStatus(ctx context.Context, year, month int) ([]*activeModels.StaffMonthBalanceSnapshot, error) {
+	if err := validateMonth(year, month); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrMonthCloseInvalid, err.Error())
+	}
+	return s.snapshotRepo.GetByMonth(ctx, year, month)
+}

--- a/backend/services/active/staff_month_close_service_mock_test.go
+++ b/backend/services/active/staff_month_close_service_mock_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/stretchr/testify/assert"
@@ -81,4 +83,13 @@ func TestStaffMonthCloseService_RechecksIdempotencyAfterLock(t *testing.T) {
 	assert.Equal(t, 1, result.SkippedStaff)
 	assert.Empty(t, result.Snapshots)
 	assert.Equal(t, []string{"staff", "lock", "snapshot"}, events)
+}
+
+func TestCalendarMonthHasEnded_RequiresFollowingDay(t *testing.T) {
+	key := monthKey{Year: 2026, Month: 7}
+
+	assert.False(t, calendarMonthHasEnded(key, timezone.NewDate(2026, time.July, 31)),
+		"the final calendar day is still running")
+	assert.True(t, calendarMonthHasEnded(key, timezone.NewDate(2026, time.August, 1)),
+		"the month is over on the following day")
 }

--- a/backend/services/active/staff_month_close_service_mock_test.go
+++ b/backend/services/active/staff_month_close_service_mock_test.go
@@ -1,0 +1,84 @@
+package active
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type concurrentMonthCloseSnapshotRepo struct {
+	activeModels.StaffMonthBalanceSnapshotRepository
+	events   *[]string
+	snapshot *activeModels.StaffMonthBalanceSnapshot
+}
+
+func (r *concurrentMonthCloseSnapshotRepo) LockStaffBalanceWrites(context.Context, int64) error {
+	*r.events = append(*r.events, "lock")
+	r.snapshot = &activeModels.StaffMonthBalanceSnapshot{
+		StaffID: 41,
+		Year:    2025,
+		Month:   8,
+	}
+	return nil
+}
+
+func (r *concurrentMonthCloseSnapshotRepo) GetLatestClosedThrough(context.Context, int64, int, int) (*activeModels.StaffMonthBalanceSnapshot, error) {
+	*r.events = append(*r.events, "snapshot")
+	return r.snapshot, nil
+}
+
+func (r *concurrentMonthCloseSnapshotRepo) GetByMonth(context.Context, int, int) ([]*activeModels.StaffMonthBalanceSnapshot, error) {
+	*r.events = append(*r.events, "pre-lock-snapshots")
+	return nil, nil
+}
+
+func (r *concurrentMonthCloseSnapshotRepo) Create(context.Context, *activeModels.StaffMonthBalanceSnapshot) error {
+	*r.events = append(*r.events, "create")
+	return nil
+}
+
+type recordingMonthCloseMonthService struct {
+	WorkTimeMonthService
+	events *[]string
+}
+
+func (s *recordingMonthCloseMonthService) GetMonthSummaryAtMonthEnd(context.Context, int64, int, int) (*MonthSummary, error) {
+	*s.events = append(*s.events, "summary")
+	return &MonthSummary{}, nil
+}
+
+type recordingMonthCloseStaffLister struct {
+	events *[]string
+}
+
+func (l *recordingMonthCloseStaffLister) ListAllWithPerson(context.Context) ([]*userModels.Staff, error) {
+	*l.events = append(*l.events, "staff")
+	staff := &userModels.Staff{}
+	staff.ID = 41
+	return []*userModels.Staff{staff}, nil
+}
+
+func TestStaffMonthCloseService_RechecksIdempotencyAfterLock(t *testing.T) {
+	events := []string{}
+	repo := &concurrentMonthCloseSnapshotRepo{events: &events}
+	service := NewStaffMonthCloseService(
+		repo,
+		&recordingMonthCloseMonthService{events: &events},
+		&recordingMonthCloseStaffLister{events: &events},
+		&wtmMockSettings{accountStart: "2025-01-01"},
+		slog.New(slog.DiscardHandler),
+	)
+
+	result, err := service.CloseMonth(context.Background(), 42, 2025, 8, "Monatsabschluss")
+
+	require.NoError(t, err)
+	assert.Zero(t, result.ClosedStaff)
+	assert.Equal(t, 1, result.SkippedStaff)
+	assert.Empty(t, result.Snapshots)
+	assert.Equal(t, []string{"staff", "lock", "snapshot"}, events)
+}

--- a/backend/services/active/staff_overview_integration_test.go
+++ b/backend/services/active/staff_overview_integration_test.go
@@ -347,6 +347,41 @@ func TestDashboardSummary_WeekVsMonth(t *testing.T) {
 	assert.Equal(t, month.Period, def.Period)
 }
 
+func TestDashboardSummary_WeekExcludesAdjustmentsOutsideRange(t *testing.T) {
+	f := newOverviewFixture(t, 1)
+
+	before, err := f.svc.GetDashboardSummary(f.ctx, active.OverviewPeriodWeek)
+	require.NoError(t, err)
+
+	weekStart := configModels.MondayOf(f.today)
+	effectiveDate := timezone.NewDate(f.today.Year, f.today.Month, 1)
+	if !effectiveDate.Before(weekStart) {
+		effectiveDate = f.today.AddDays(1)
+	}
+	require.Equal(t, f.today.Month, effectiveDate.Month,
+		"fixture must place the adjustment inside the prefetched month")
+	require.True(t, effectiveDate.Before(weekStart) || effectiveDate.After(f.today),
+		"fixture adjustment must lie outside the requested week")
+
+	adjustment := &activeModels.StaffBalanceAdjustment{
+		StaffID:       f.staff[0].ID,
+		Type:          activeModels.BalanceAdjustmentTypePayout,
+		MinutesDelta:  -60,
+		EffectiveDate: effectiveDate,
+		Note:          "Außerhalb der Woche",
+		DecidedBy:     f.staff[0].ID,
+		DecidedAt:     time.Now(),
+	}
+	adjustment.SetTenantID(f.tenantID)
+	require.NoError(t, f.repos.StaffBalanceAdjust.Create(f.ctx, adjustment))
+
+	after, err := f.svc.GetDashboardSummary(f.ctx, active.OverviewPeriodWeek)
+	require.NoError(t, err)
+
+	assert.Equal(t, before.Period, after.Period,
+		"an adjustment outside [weekStart, today] must not alter the week aggregate")
+}
+
 func TestDashboardSummary_RejectsUnknownPeriod(t *testing.T) {
 	f := newOverviewFixture(t, 1)
 

--- a/backend/services/active/staff_overview_integration_test.go
+++ b/backend/services/active/staff_overview_integration_test.go
@@ -30,6 +30,19 @@ func (h *countingQueryHook) BeforeQuery(ctx context.Context, _ *bun.QueryEvent) 
 
 func (h *countingQueryHook) AfterQuery(context.Context, *bun.QueryEvent) {}
 
+type recordingAbsenceRepository struct {
+	activeModels.StaffAbsenceRepository
+	requestedDate timezone.Date
+}
+
+func (r *recordingAbsenceRepository) GetAbsenceMapForDate(
+	ctx context.Context,
+	date timezone.Date,
+) (map[int64]string, error) {
+	r.requestedDate = date
+	return r.StaffAbsenceRepository.GetAbsenceMapForDate(ctx, date)
+}
+
 // overviewFixture arranges a tenant with N staff members, each with a contract
 // on every weekday, a worked session today, and (optionally) a planned shift.
 type overviewFixture struct {
@@ -324,6 +337,24 @@ func TestDashboardSummary_KPIs(t *testing.T) {
 	assert.Equal(t, 1, summary.CurrentlyClockedIn, "only staff[0] has an open session")
 	assert.Equal(t, 1, summary.ExpectedClockedIn, "only staff[0] has a shift covering now")
 	assert.Equal(t, 1, summary.PendingRequestsCount)
+}
+
+func TestDashboardSummary_AbsenceKPIsUseBerlinToday(t *testing.T) {
+	f := newOverviewFixture(t, 1)
+	absenceRepo := &recordingAbsenceRepository{StaffAbsenceRepository: f.repos.StaffAbsence}
+	settings := wtmIntSettings{
+		accountStart: timezone.NewDate(f.today.Year, f.today.Month, 1).String(),
+	}
+	svc := active.NewStaffOverviewService(
+		f.repos.Staff, f.repos.WorkSession, f.repos.WorkSessionBreak, absenceRepo,
+		f.repos.StaffBalanceAdjust, f.repos.StaffVacationQuota, f.repos.StaffMonthSnapshot,
+		f.repos.StaffWorkSchedule, f.repos.WorkTimeModel, f.repos.StaffShift,
+		settings, nil,
+	)
+
+	_, err := svc.GetDashboardSummary(f.ctx, active.OverviewPeriodMonth)
+	require.NoError(t, err)
+	assert.Equal(t, f.today, absenceRepo.requestedDate)
 }
 
 // TestDashboardSummary_WeekVsMonth — the saldo is an account balance and must

--- a/backend/services/active/staff_overview_integration_test.go
+++ b/backend/services/active/staff_overview_integration_test.go
@@ -1,0 +1,495 @@
+package active_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	configModels "github.com/moto-nrw/project-phoenix/models/config"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	active "github.com/moto-nrw/project-phoenix/services/active"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// countingQueryHook counts SQL statements so a test can prove the overview's
+// query count does not grow with the number of staff members.
+type countingQueryHook struct{ n atomic.Int64 }
+
+func (h *countingQueryHook) BeforeQuery(ctx context.Context, _ *bun.QueryEvent) context.Context {
+	h.n.Add(1)
+	return ctx
+}
+
+func (h *countingQueryHook) AfterQuery(context.Context, *bun.QueryEvent) {}
+
+// overviewFixture arranges a tenant with N staff members, each with a contract
+// on every weekday, a worked session today, and (optionally) a planned shift.
+type overviewFixture struct {
+	tenantID int64
+	db       *bun.DB
+	repos    *repositories.Factory
+	ctx      context.Context
+	staff    []*userModels.Staff
+	svc      active.StaffOverviewService
+	monthSvc active.WorkTimeMonthService
+	today    timezone.Date
+}
+
+// newOverviewFixture builds `count` staff members. The account start is the
+// first of the current month, so every fixture row sits inside the window.
+func newOverviewFixture(t *testing.T, count int) *overviewFixture {
+	t.Helper()
+
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	repos := repositories.NewFactory(db)
+	ctx := testpkg.TenantContext(tenantID)
+	today := timezone.TodayDate()
+
+	f := &overviewFixture{
+		tenantID: tenantID, db: db, repos: repos, ctx: ctx, today: today,
+	}
+
+	t.Cleanup(func() {
+		for _, table := range []string{
+			"active.staff_month_balance_snapshots",
+			"active.staff_balance_adjustments",
+			"active.staff_vacation_quotas",
+			"active.staff_absences",
+			"active.work_sessions",
+			"schedule.staff_shifts",
+			"config.staff_work_schedules",
+		} {
+			_, _ = db.NewDelete().ModelTableExpr(table+" AS t").Where("t.tenant_id = ?", tenantID).Exec(context.Background())
+		}
+		ids := make([]int64, 0, len(f.staff))
+		for _, staff := range f.staff {
+			ids = append(ids, staff.ID)
+		}
+		testpkg.CleanupStaffFixtures(t, db, ids...)
+		testpkg.CleanupTenantTestData(t, db, tenantID)
+	})
+
+	for i := range count {
+		staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Ueber", "Sicht")
+		f.staff = append(f.staff, staff)
+		f.addSchedule(t, staff.ID, 480)
+		f.addSession(t, staff.ID, today, 4*time.Hour)
+		if i == 0 {
+			f.addShift(t, staff.ID, today)
+		}
+	}
+
+	monthStart := timezone.NewDate(today.Year, today.Month, 1)
+	settings := wtmIntSettings{accountStart: monthStart.String()}
+	f.monthSvc = active.NewWorkTimeMonthService(
+		repos.WorkSession, repos.WorkSessionBreak, repos.StaffAbsence, repos.Staff,
+		repos.StaffWorkSchedule, repos.WorkTimeModel, repos.StaffShift,
+		settings, nil,
+	)
+	f.monthSvc.SetAdjustmentReader(repos.StaffBalanceAdjust)
+	f.monthSvc.SetSnapshotReader(repos.StaffMonthSnapshot)
+
+	f.svc = f.newOverviewService(settings)
+	return f
+}
+
+func (f *overviewFixture) newOverviewService(settings wtmIntSettings) active.StaffOverviewService {
+	return active.NewStaffOverviewService(
+		f.repos.Staff, f.repos.WorkSession, f.repos.WorkSessionBreak, f.repos.StaffAbsence,
+		f.repos.StaffBalanceAdjust, f.repos.StaffVacationQuota, f.repos.StaffMonthSnapshot,
+		f.repos.StaffWorkSchedule, f.repos.WorkTimeModel, f.repos.StaffShift,
+		settings, nil,
+	)
+}
+
+// addSchedule gives the staff member the same contractual Soll on all seven
+// weekdays, so the expected values do not depend on which day the test runs.
+func (f *overviewFixture) addSchedule(t *testing.T, staffID int64, targetMinutes int) {
+	t.Helper()
+	for day := range 7 {
+		row := &configModels.StaffWorkSchedule{
+			TenantID:      f.tenantID,
+			StaffID:       staffID,
+			DayOfWeek:     day,
+			TargetMinutes: targetMinutes,
+			WeekIndex:     0, RotationLength: 1,
+			ValidFrom: timezone.NewDate(2020, time.January, 1),
+		}
+		_, err := f.db.NewInsert().Model(row).ModelTableExpr("config.staff_work_schedules").Exec(f.ctx)
+		require.NoError(t, err)
+	}
+}
+
+func (f *overviewFixture) addSession(t *testing.T, staffID int64, date timezone.Date, duration time.Duration) *activeModels.WorkSession {
+	t.Helper()
+	checkIn := time.Date(date.Year, date.Month, date.Day, 8, 0, 0, 0, time.UTC)
+	checkOut := checkIn.Add(duration)
+	session := &activeModels.WorkSession{
+		StaffID:     staffID,
+		Date:        date,
+		Status:      activeModels.WorkSessionStatusPresent,
+		Source:      activeModels.WorkSessionSourceApp,
+		CheckInTime: checkIn, CheckOutTime: &checkOut,
+		CreatedBy: staffID,
+	}
+	session.SetTenantID(f.tenantID)
+	require.NoError(t, f.repos.WorkSession.Create(f.ctx, session))
+	return session
+}
+
+// reopenSession clears check-out on the staff member's session for that day —
+// the staff member is currently at work. It updates the fixture's existing row
+// because work_sessions is unique per staff and date.
+func (f *overviewFixture) reopenSession(t *testing.T, staffID int64, date timezone.Date) {
+	t.Helper()
+	res, err := f.db.NewUpdate().
+		Table("active.work_sessions").
+		Set("check_out_time = NULL").
+		Where("staff_id = ? AND date = ? AND tenant_id = ?", staffID, date, f.tenantID).
+		Exec(f.ctx)
+	require.NoError(t, err)
+	affected, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, affected)
+}
+
+// addShift plans a shift that covers the whole day, so it also covers "now".
+func (f *overviewFixture) addShift(t *testing.T, staffID int64, date timezone.Date) {
+	t.Helper()
+	shift := &scheduleModels.StaffShift{
+		StaffID:   staffID,
+		Date:      date,
+		StartTime: time.Date(2000, time.January, 1, 0, 1, 0, 0, time.UTC),
+		EndTime:   time.Date(2000, time.January, 1, 23, 59, 0, 0, time.UTC),
+		CreatedBy: staffID,
+	}
+	shift.SetTenantID(f.tenantID)
+	require.NoError(t, f.repos.StaffShift.Create(f.ctx, shift))
+}
+
+func (f *overviewFixture) addAbsence(t *testing.T, staffID int64, absenceType, status string, start, end timezone.Date) {
+	t.Helper()
+	absence := &activeModels.StaffAbsence{
+		StaffID:     staffID,
+		AbsenceType: absenceType,
+		Status:      status,
+		DateStart:   start,
+		DateEnd:     end,
+		CreatedBy:   staffID,
+	}
+	absence.SetTenantID(f.tenantID)
+	require.NoError(t, f.repos.StaffAbsence.Create(f.ctx, absence))
+}
+
+func (f *overviewFixture) setEmploymentType(t *testing.T, staffID int64, employmentType string) {
+	t.Helper()
+	_, err := f.db.NewUpdate().
+		Table("users.staff").
+		Set("employment_type = ?", employmentType).
+		Where("id = ?", staffID).
+		Exec(f.ctx)
+	require.NoError(t, err)
+}
+
+// TestTimeTrackingOverview_MatchesMonthSummary is the anti-drift guarantee: the
+// cross-staff row must equal what the per-staff Monatskarte reports, because
+// both run the same math. Without this the aggregate view could quietly
+// contradict the detail view a school admin drills into.
+func TestTimeTrackingOverview_MatchesMonthSummary(t *testing.T) {
+	f := newOverviewFixture(t, 3)
+
+	// Make the three staff members genuinely different: a part-time contract,
+	// a sick day, a payout booking, and one with no schedule at all.
+	f.addSchedule(t, f.staff[1].ID, 240)
+	yesterday := f.today.AddDays(-1)
+	if monthOfDate(yesterday) == monthOfDate(f.today) {
+		f.addAbsence(t, f.staff[1].ID, activeModels.AbsenceTypeSick, activeModels.AbsenceStatusReported, yesterday, yesterday)
+	}
+	adjustment := &activeModels.StaffBalanceAdjustment{
+		StaffID:       f.staff[2].ID,
+		Type:          activeModels.BalanceAdjustmentTypePayout,
+		MinutesDelta:  -30,
+		EffectiveDate: f.today,
+		Note:          "Auszahlung",
+		DecidedBy:     f.staff[0].ID,
+		DecidedAt:     time.Now(),
+	}
+	adjustment.SetTenantID(f.tenantID)
+	require.NoError(t, f.repos.StaffBalanceAdjust.Create(f.ctx, adjustment))
+
+	overview, err := f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{})
+	require.NoError(t, err)
+	require.Len(t, overview.Rows, 3)
+
+	byStaff := make(map[int64]active.TimeTrackingOverviewRow, len(overview.Rows))
+	for _, row := range overview.Rows {
+		byStaff[row.StaffID] = row
+	}
+	for _, staff := range f.staff {
+		row, ok := byStaff[staff.ID]
+		require.True(t, ok, "staff %d missing from the overview", staff.ID)
+
+		expected, err := f.monthSvc.GetMonthSummary(f.ctx, staff.ID, f.today.Year, int(f.today.Month))
+		require.NoError(t, err)
+		assert.Equal(t, expected.TargetMinutesToDate, row.SollMinutes, "soll for staff %d", staff.ID)
+		assert.Equal(t, expected.ActualMinutes, row.IstMinutes, "ist for staff %d", staff.ID)
+		assert.Equal(t, expected.ClosingBalanceMinutes, row.BalanceMinutes, "saldo for staff %d", staff.ID)
+	}
+}
+
+// TestTimeTrackingOverview_VacationMatchesQuotaEndpoint pins Resturlaub against
+// the per-staff endpoint it mirrors.
+func TestTimeTrackingOverview_VacationMatchesQuotaEndpoint(t *testing.T) {
+	f := newOverviewFixture(t, 2)
+
+	// An approved vacation day earlier this year plus a still-requested one:
+	// the requested days must be reserved, not counted as taken.
+	yearStart := timezone.NewDate(f.today.Year, time.January, 5)
+	f.addAbsence(t, f.staff[0].ID, activeModels.AbsenceTypeVacation, activeModels.AbsenceStatusApproved, yearStart, yearStart.AddDays(2))
+	future := timezone.NewDate(f.today.Year, time.December, 1)
+	f.addAbsence(t, f.staff[0].ID, activeModels.AbsenceTypeVacation, activeModels.AbsenceStatusRequested, future, future)
+
+	absenceSvc := active.NewStaffAbsenceService(
+		f.repos.StaffAbsence, f.repos.WorkSession, f.repos.StaffVacationQuota,
+		f.repos.StaffAbsenceAudit, wtmIntSettings{}, f.monthSvc,
+	)
+
+	overview, err := f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{})
+	require.NoError(t, err)
+
+	for _, row := range overview.Rows {
+		expected, err := absenceSvc.GetVacationQuotaSummary(f.ctx, row.StaffID, f.today.Year)
+		require.NoError(t, err)
+		assert.InDelta(t, expected.RemainingDays, row.RemainingVacationDays, 0.001,
+			"Resturlaub for staff %d must match the per-staff endpoint", row.StaffID)
+	}
+}
+
+// TestTimeTrackingOverview_QueryCountIsConstant is the only test that protects
+// the performance property. Without it the prefetch adapters could silently
+// regress to per-staff reads and nothing would fail.
+func TestTimeTrackingOverview_QueryCountIsConstant(t *testing.T) {
+	small := newOverviewFixture(t, 1)
+	hook := &countingQueryHook{}
+	small.db.AddQueryHook(hook)
+	_, err := small.svc.GetTimeTrackingOverview(small.ctx, active.OverviewFilters{})
+	require.NoError(t, err)
+	oneStaff := hook.n.Load()
+
+	large := newOverviewFixture(t, 8)
+	hookLarge := &countingQueryHook{}
+	large.db.AddQueryHook(hookLarge)
+	_, err = large.svc.GetTimeTrackingOverview(large.ctx, active.OverviewFilters{})
+	require.NoError(t, err)
+	eightStaff := hookLarge.n.Load()
+
+	assert.Equal(t, oneStaff, eightStaff,
+		"query count must not grow with the number of staff members (1 staff: %d, 8 staff: %d)",
+		oneStaff, eightStaff)
+}
+
+// TestDashboardSummary_KPIs checks each counter, including the priority collapse
+// that keeps sick and vacation from double-counting the same person.
+func TestDashboardSummary_KPIs(t *testing.T) {
+	f := newOverviewFixture(t, 4)
+
+	f.reopenSession(t, f.staff[0].ID, f.today)
+	f.addAbsence(t, f.staff[1].ID, activeModels.AbsenceTypeSick, activeModels.AbsenceStatusReported, f.today, f.today)
+	f.addAbsence(t, f.staff[2].ID, activeModels.AbsenceTypeVacation, activeModels.AbsenceStatusApproved, f.today, f.today)
+	// Overlapping sick + vacation on the same person: counts as sick only.
+	f.addAbsence(t, f.staff[3].ID, activeModels.AbsenceTypeSick, activeModels.AbsenceStatusReported, f.today, f.today)
+	f.addAbsence(t, f.staff[3].ID, activeModels.AbsenceTypeVacation, activeModels.AbsenceStatusApproved, f.today, f.today)
+	// A pending request must be counted but must not affect sick/vacation.
+	f.addAbsence(t, f.staff[2].ID, activeModels.AbsenceTypeVacation, activeModels.AbsenceStatusRequested,
+		f.today.AddDays(30), f.today.AddDays(31))
+
+	summary, err := f.svc.GetDashboardSummary(f.ctx, active.OverviewPeriodMonth)
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, summary.ActiveStaffCount)
+	assert.Equal(t, 2, summary.SickToday, "staff[1] and staff[3]")
+	assert.Equal(t, 1, summary.VacationToday, "staff[3] counts as sick, not vacation")
+	assert.Equal(t, 1, summary.CurrentlyClockedIn, "only staff[0] has an open session")
+	assert.Equal(t, 1, summary.ExpectedClockedIn, "only staff[0] has a shift covering now")
+	assert.Equal(t, 1, summary.PendingRequestsCount)
+}
+
+// TestDashboardSummary_WeekVsMonth — the saldo is an account balance and must
+// not change with the selected period; Soll and Ist must.
+func TestDashboardSummary_WeekVsMonth(t *testing.T) {
+	f := newOverviewFixture(t, 2)
+
+	month, err := f.svc.GetDashboardSummary(f.ctx, active.OverviewPeriodMonth)
+	require.NoError(t, err)
+	week, err := f.svc.GetDashboardSummary(f.ctx, active.OverviewPeriodWeek)
+	require.NoError(t, err)
+
+	assert.Equal(t, month.SaldoSchoolTotalMinutes, week.SaldoSchoolTotalMinutes,
+		"the Stundenkonto is not a period quantity")
+	assert.LessOrEqual(t, week.Period.SollMinutes, month.Period.SollMinutes,
+		"a week inside the month cannot carry more Soll than the month")
+
+	// The default is month.
+	def, err := f.svc.GetDashboardSummary(f.ctx, "")
+	require.NoError(t, err)
+	assert.Equal(t, month.Period, def.Period)
+}
+
+func TestDashboardSummary_RejectsUnknownPeriod(t *testing.T) {
+	f := newOverviewFixture(t, 1)
+
+	_, err := f.svc.GetDashboardSummary(f.ctx, "quarter")
+	require.ErrorIs(t, err, active.ErrOverviewInvalid)
+}
+
+// TestTimeTrackingOverview_Filters — the employment filter narrows the rows
+// before the computation, the saldo range narrows them after it, and neither
+// changes the values of the surviving rows.
+func TestTimeTrackingOverview_Filters(t *testing.T) {
+	f := newOverviewFixture(t, 3)
+	f.setEmploymentType(t, f.staff[0].ID, userModels.EmploymentTypeFullTime)
+	f.setEmploymentType(t, f.staff[1].ID, userModels.EmploymentTypePartTime)
+
+	all, err := f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{})
+	require.NoError(t, err)
+	require.Len(t, all.Rows, 3)
+	unfiltered := make(map[int64]int, 3)
+	for _, row := range all.Rows {
+		unfiltered[row.StaffID] = row.BalanceMinutes
+	}
+
+	fullTime, err := f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{
+		EmploymentType: userModels.EmploymentTypeFullTime,
+	})
+	require.NoError(t, err)
+	require.Len(t, fullTime.Rows, 1)
+	assert.Equal(t, f.staff[0].ID, fullTime.Rows[0].StaffID)
+	assert.Equal(t, unfiltered[f.staff[0].ID], fullTime.Rows[0].BalanceMinutes,
+		"filtering must not change the computed values")
+
+	// Every fixture staff member worked less than their Soll, so the balance is
+	// negative; a floor of 0 must exclude everybody.
+	zero := 0
+	none, err := f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{SaldoMin: &zero})
+	require.NoError(t, err)
+	assert.Empty(t, none.Rows)
+	assert.NotNil(t, none.Rows, "rows must serialize as [] and never null")
+
+	max := 0
+	everyone, err := f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{SaldoMax: &max})
+	require.NoError(t, err)
+	assert.Len(t, everyone.Rows, 3)
+}
+
+func TestTimeTrackingOverview_RejectsBadFilters(t *testing.T) {
+	f := newOverviewFixture(t, 1)
+	low, high := 100, 10
+
+	_, err := f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{EmploymentType: "bogus"})
+	require.ErrorIs(t, err, active.ErrOverviewInvalid)
+
+	_, err = f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{SortBy: "bogus"})
+	require.ErrorIs(t, err, active.ErrOverviewInvalid)
+
+	_, err = f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{SaldoMin: &low, SaldoMax: &high})
+	require.ErrorIs(t, err, active.ErrOverviewInvalid)
+}
+
+// TestTimeTrackingOverview_SortIsStable — ListAllWithPerson has no ORDER BY, so
+// without an explicit staff-ID tiebreak equal balances would swap places
+// between identical requests.
+func TestTimeTrackingOverview_SortIsStable(t *testing.T) {
+	f := newOverviewFixture(t, 4)
+
+	first, err := f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{SortBy: active.OverviewSortBalance})
+	require.NoError(t, err)
+	for range 3 {
+		again, err := f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{SortBy: active.OverviewSortBalance})
+		require.NoError(t, err)
+		require.Equal(t, first.Rows, again.Rows, "repeated requests must return the same order")
+	}
+
+	desc, err := f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{
+		SortBy: active.OverviewSortBalance, Descending: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.Rows, 4)
+	for i := 1; i < len(desc.Rows); i++ {
+		assert.GreaterOrEqual(t, desc.Rows[i-1].BalanceMinutes, desc.Rows[i].BalanceMinutes)
+	}
+}
+
+// TestTimeTrackingOverview_EmptyAndDegenerate covers the shapes that would
+// otherwise 500 or return null.
+func TestTimeTrackingOverview_EmptyAndDegenerate(t *testing.T) {
+	f := newOverviewFixture(t, 0)
+
+	overview, err := f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{})
+	require.NoError(t, err)
+	assert.NotNil(t, overview.Rows)
+	assert.Empty(t, overview.Rows)
+
+	summary, err := f.svc.GetDashboardSummary(f.ctx, active.OverviewPeriodMonth)
+	require.NoError(t, err)
+	assert.Equal(t, 0, summary.ActiveStaffCount)
+	assert.Equal(t, 0, summary.SaldoSchoolTotalMinutes)
+
+	// A staff member with neither a schedule nor a work-time model: Soll 0,
+	// Ist 0, no error.
+	bare := testpkg.CreateTestStaffForTenant(t, f.db, f.tenantID, "Ohne", "Plan")
+	f.staff = append(f.staff, bare)
+	overview, err = f.svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{})
+	require.NoError(t, err)
+	require.Len(t, overview.Rows, 1)
+	assert.Equal(t, 0, overview.Rows[0].SollMinutes)
+	assert.Equal(t, 0, overview.Rows[0].IstMinutes)
+	assert.Equal(t, 0, overview.Rows[0].BalanceMinutes)
+}
+
+// TestTimeTrackingOverview_RespectsFrozenMonths ties the two halves of #1417
+// together: a closed past month must shape the overview's saldo exactly as it
+// shapes the detail card.
+func TestTimeTrackingOverview_RespectsFrozenMonths(t *testing.T) {
+	f := newOverviewFixture(t, 1)
+	staffID := f.staff[0].ID
+
+	// Account start in the previous month so there is something to freeze.
+	prevMonth := timezone.NewDate(f.today.Year, f.today.Month, 1).AddDays(-1)
+	settings := wtmIntSettings{accountStart: timezone.NewDate(prevMonth.Year, prevMonth.Month, 1).String()}
+	monthSvc := active.NewWorkTimeMonthService(
+		f.repos.WorkSession, f.repos.WorkSessionBreak, f.repos.StaffAbsence, f.repos.Staff,
+		f.repos.StaffWorkSchedule, f.repos.WorkTimeModel, f.repos.StaffShift,
+		settings, nil,
+	)
+	monthSvc.SetAdjustmentReader(f.repos.StaffBalanceAdjust)
+	monthSvc.SetSnapshotReader(f.repos.StaffMonthSnapshot)
+	closeSvc := active.NewStaffMonthCloseService(f.repos.StaffMonthSnapshot, monthSvc, f.repos.Staff, settings, nil)
+	svc := f.newOverviewService(settings)
+
+	_, err := closeSvc.CloseMonth(f.ctx, staffID, prevMonth.Year, int(prevMonth.Month), "Abschluss")
+	require.NoError(t, err)
+
+	overview, err := svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{})
+	require.NoError(t, err)
+	require.Len(t, overview.Rows, 1)
+
+	expected, err := monthSvc.GetMonthSummary(f.ctx, staffID, f.today.Year, int(f.today.Month))
+	require.NoError(t, err)
+	require.True(t, expected.CarryInFrozen, "the previous month is frozen")
+	assert.Equal(t, expected.ClosingBalanceMinutes, overview.Rows[0].BalanceMinutes,
+		"the overview must splice at the frozen month just like the detail card")
+}
+
+func monthOfDate(d timezone.Date) int { return d.Year*12 + int(d.Month) }

--- a/backend/services/active/staff_overview_integration_test.go
+++ b/backend/services/active/staff_overview_integration_test.go
@@ -262,6 +262,30 @@ func TestTimeTrackingOverview_MatchesMonthSummary(t *testing.T) {
 	}
 }
 
+func TestTimeTrackingOverview_AccountStartAfterRequestedMonthMatchesDetail(t *testing.T) {
+	f := newOverviewFixture(t, 1)
+	settings := wtmIntSettings{accountStart: f.today.AddDays(40).String()}
+	svc := f.newOverviewService(settings)
+	monthSvc := active.NewWorkTimeMonthService(
+		f.repos.WorkSession, f.repos.WorkSessionBreak, f.repos.StaffAbsence, f.repos.Staff,
+		f.repos.StaffWorkSchedule, f.repos.WorkTimeModel, f.repos.StaffShift,
+		settings, nil,
+	)
+	monthSvc.SetAdjustmentReader(f.repos.StaffBalanceAdjust)
+	monthSvc.SetSnapshotReader(f.repos.StaffMonthSnapshot)
+
+	overview, err := svc.GetTimeTrackingOverview(f.ctx, active.OverviewFilters{})
+	require.NoError(t, err)
+	require.Len(t, overview.Rows, 1)
+	expected, err := monthSvc.GetMonthSummary(f.ctx, f.staff[0].ID, f.today.Year, int(f.today.Month))
+	require.NoError(t, err)
+
+	assert.Equal(t, expected.TargetMinutesToDate, overview.Rows[0].SollMinutes)
+	assert.Equal(t, expected.ActualMinutes, overview.Rows[0].IstMinutes)
+	assert.Equal(t, expected.ClosingBalanceMinutes, overview.Rows[0].BalanceMinutes)
+	assert.Equal(t, 4*60, overview.Rows[0].IstMinutes, "the standalone month must retain its worked session")
+}
+
 // TestTimeTrackingOverview_VacationMatchesQuotaEndpoint pins Resturlaub against
 // the per-staff endpoint it mirrors.
 func TestTimeTrackingOverview_VacationMatchesQuotaEndpoint(t *testing.T) {

--- a/backend/services/active/staff_overview_service.go
+++ b/backend/services/active/staff_overview_service.go
@@ -1,0 +1,696 @@
+package active
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	configModels "github.com/moto-nrw/project-phoenix/models/config"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// Period values for the dashboard summary (#1417).
+const (
+	OverviewPeriodWeek  = "week"
+	OverviewPeriodMonth = "month"
+)
+
+// ErrOverviewInvalid marks a caller mistake in an overview request — HTTP 400.
+var ErrOverviewInvalid = errors.New("invalid overview request")
+
+// DashboardPeriodTotals is the tenant-wide Soll/Ist/Delta of the selected
+// period.
+//
+// DeltaMinutes is the sum of the per-staff month balances
+// (actual + credited + adjustments − target_to_date), deliberately NOT
+// ist − soll: crediting sick and vacation days against the day's Soll is the
+// whole premise of the Stundenkonto ("Ansatz B"). A dashboard delta computed
+// differently from the Monatskarte saldo would be exactly the drift between
+// aggregate and detail view that this tranche exists to prevent.
+type DashboardPeriodTotals struct {
+	SollMinutes  int `json:"soll_minutes"`
+	IstMinutes   int `json:"ist_minutes"`
+	DeltaMinutes int `json:"delta_minutes"`
+}
+
+// DashboardSummary is the Leitungs-Dashboard aggregate (#1417 2a). Field names
+// are fixed by the issue.
+type DashboardSummary struct {
+	ActiveStaffCount   int `json:"active_staff_count"`
+	SickToday          int `json:"sick_today"`
+	VacationToday      int `json:"vacation_today"`
+	CurrentlyClockedIn int `json:"currently_clocked_in"`
+	ExpectedClockedIn  int `json:"expected_clocked_in"`
+
+	Period DashboardPeriodTotals `json:"period"`
+
+	// SaldoSchoolTotalMinutes is the sum of the live Stundenkonto balances. It
+	// is an account balance, not a period quantity, so it is identical for
+	// period=week and period=month.
+	SaldoSchoolTotalMinutes int `json:"saldo_school_total_minutes"`
+	PendingRequestsCount    int `json:"pending_requests_count"`
+}
+
+// TimeTrackingOverviewRow is one staff member's Soll/Ist/Saldo/Resturlaub.
+// Gated behind time_tracking:manage, not users:read — it exposes per-person
+// working-time data.
+type TimeTrackingOverviewRow struct {
+	StaffID   int64  `json:"staff_id"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Name      string `json:"name"`
+	// EmploymentType is "" when the staff member has none recorded.
+	EmploymentType        string  `json:"employment_type"`
+	SollMinutes           int     `json:"soll_minutes"`
+	IstMinutes            int     `json:"ist_minutes"`
+	BalanceMinutes        int     `json:"balance_minutes"`
+	RemainingVacationDays float64 `json:"remaining_vacation_days"`
+}
+
+// TimeTrackingOverview is the cross-staff list. Rows is never nil.
+type TimeTrackingOverview struct {
+	Year  int                       `json:"year"`
+	Month int                       `json:"month"`
+	Rows  []TimeTrackingOverviewRow `json:"rows"`
+}
+
+// OverviewFilters narrows the cross-staff list.
+//
+// EmploymentType is an INPUT attribute and is applied before the computation,
+// so the per-staff math never runs for excluded rows. SaldoMin/SaldoMax are
+// OUTPUTS of the computation and can only be applied afterwards — the saldo
+// does not exist until the carry chain has run. They therefore reduce payload
+// size, never query cost.
+type OverviewFilters struct {
+	EmploymentType string
+	SaldoMin       *int
+	SaldoMax       *int
+	SortBy         string
+	Descending     bool
+}
+
+// Sort keys accepted by the overview.
+const (
+	OverviewSortName     = "name"
+	OverviewSortBalance  = "balance"
+	OverviewSortSoll     = "soll"
+	OverviewSortIst      = "ist"
+	OverviewSortVacation = "vacation"
+)
+
+// ValidOverviewSortKeys lists the accepted sort keys.
+var ValidOverviewSortKeys = []string{
+	OverviewSortName,
+	OverviewSortBalance,
+	OverviewSortSoll,
+	OverviewSortIst,
+	OverviewSortVacation,
+}
+
+// RangeAggregate is the Soll/Ist/credit/adjustment sum over an arbitrary closed
+// date range, computed with the same resolver and the same daily arithmetic as
+// the Monatskarte. No carry: a range is not an account.
+type RangeAggregate struct {
+	TargetMinutes  int
+	ActualMinutes  int
+	BalanceMinutes int
+}
+
+// StaffOverviewService serves the tenant-wide time-tracking views (#1417 2a).
+//
+// It never reimplements the Stundenkonto math. It prefetches every input for
+// all staff members with one query per source and then runs the UNCHANGED
+// per-staff WorkTimeMonthService over in-memory readers (see
+// work_time_month_prefetch.go). That keeps the list numerically identical to
+// the /staff/{id} detail view — the whole point — at a query count that does
+// not grow with the number of staff members.
+type StaffOverviewService interface {
+	GetDashboardSummary(ctx context.Context, period string) (*DashboardSummary, error)
+	GetTimeTrackingOverview(ctx context.Context, filters OverviewFilters) (*TimeTrackingOverview, error)
+}
+
+type staffOverviewService struct {
+	staffRepo      userModels.StaffRepository
+	sessionRepo    activeModels.WorkSessionRepository
+	breakRepo      activeModels.WorkSessionBreakRepository
+	absenceRepo    activeModels.StaffAbsenceRepository
+	adjustmentRepo activeModels.StaffBalanceAdjustmentRepository
+	quotaRepo      activeModels.StaffVacationQuotaRepository
+	snapshotRepo   activeModels.StaffMonthBalanceSnapshotRepository
+	scheduleRepo   configModels.StaffWorkScheduleRepository
+	workModelRepo  configModels.WorkTimeModelRepository
+	shiftRepo      scheduleModels.StaffShiftRepository
+	settings       monthSettingsResolver
+	holidayReader  HolidayDatesReader
+	logger         *slog.Logger
+
+	// todayFunc is a test hook; production uses timezone.TodayDate.
+	todayFunc func() timezone.Date
+}
+
+func NewStaffOverviewService(
+	staffRepo userModels.StaffRepository,
+	sessionRepo activeModels.WorkSessionRepository,
+	breakRepo activeModels.WorkSessionBreakRepository,
+	absenceRepo activeModels.StaffAbsenceRepository,
+	adjustmentRepo activeModels.StaffBalanceAdjustmentRepository,
+	quotaRepo activeModels.StaffVacationQuotaRepository,
+	snapshotRepo activeModels.StaffMonthBalanceSnapshotRepository,
+	scheduleRepo configModels.StaffWorkScheduleRepository,
+	workModelRepo configModels.WorkTimeModelRepository,
+	shiftRepo scheduleModels.StaffShiftRepository,
+	settings monthSettingsResolver,
+	logger *slog.Logger,
+) *staffOverviewService {
+	return &staffOverviewService{
+		staffRepo:      staffRepo,
+		sessionRepo:    sessionRepo,
+		breakRepo:      breakRepo,
+		absenceRepo:    absenceRepo,
+		adjustmentRepo: adjustmentRepo,
+		quotaRepo:      quotaRepo,
+		snapshotRepo:   snapshotRepo,
+		scheduleRepo:   scheduleRepo,
+		workModelRepo:  workModelRepo,
+		shiftRepo:      shiftRepo,
+		settings:       settings,
+		logger:         logger,
+	}
+}
+
+// SetHolidayReader wires the non-working-day resolver, mirroring
+// WorkTimeMonthService.SetHolidayReader.
+func (s *staffOverviewService) SetHolidayReader(reader HolidayDatesReader) {
+	s.holidayReader = reader
+}
+
+func (s *staffOverviewService) getLogger() *slog.Logger {
+	return cmp.Or(s.logger, slog.Default())
+}
+
+func (s *staffOverviewService) today() timezone.Date {
+	if s.todayFunc != nil {
+		return s.todayFunc()
+	}
+	return timezone.TodayDate()
+}
+
+// --- prefetch --------------------------------------------------------------
+
+// buildPrefetch loads every month-math input for the given staff members with
+// one query per source. `lower` lets the caller widen the window below the
+// account anchor (the ISO week can start in the previous month).
+func (s *staffOverviewService) buildPrefetch(
+	ctx context.Context,
+	staffMembers []*userModels.Staff,
+	lower *timezone.Date,
+	through monthKey,
+) (*monthPrefetch, error) {
+	memo := newMemoSettingsResolver(s.settings)
+	anchor, err := resolveAccountAnchor(ctx, memo, s.getLogger(), through)
+	if err != nil {
+		return nil, err
+	}
+	from, to := anchor, through.lastDay()
+	if lower != nil && lower.Before(from) {
+		from = *lower
+	}
+	// Same bound the detail view enforces, checked BEFORE loading anything:
+	// a misconfigured account start must fail like it does per staff member
+	// instead of pulling decades of rows for everybody.
+	if floorKey := through.addMonths(-maxCarryChainMonths); monthOf(from).before(floorKey) {
+		return nil, fmt.Errorf("%w: %s is more than %d months before %d-%02d",
+			ErrAccountStartTooOld, from.String(), maxCarryChainMonths, through.Year, through.Month)
+	}
+
+	staffIDs := make([]int64, 0, len(staffMembers))
+	staffByID := make(map[int64]*userModels.Staff, len(staffMembers))
+	modelIDs := make([]int64, 0, len(staffMembers))
+	for _, staff := range staffMembers {
+		staffIDs = append(staffIDs, staff.ID)
+		staffByID[staff.ID] = staff
+		if staff.WorkTimeModelID != nil && !slices.Contains(modelIDs, *staff.WorkTimeModelID) {
+			modelIDs = append(modelIDs, *staff.WorkTimeModelID)
+		}
+	}
+
+	prefetch := &monthPrefetch{
+		from: from, to: to,
+		staff:    staffByID,
+		settings: memo,
+	}
+
+	if prefetch.sessions, err = s.sessionRepo.GetHistoryByStaffIDs(ctx, staffIDs, from, to); err != nil {
+		return nil, fmt.Errorf("failed to prefetch work sessions: %w", err)
+	}
+	// Breaks are keyed by session ID, so they can only be loaded once the
+	// sessions are known — and only for the ones still running.
+	openSessionIDs := make([]int64, 0)
+	for _, sessions := range prefetch.sessions {
+		for _, session := range sessions {
+			if session.CheckOutTime == nil {
+				openSessionIDs = append(openSessionIDs, session.ID)
+			}
+		}
+	}
+	if prefetch.breaks, err = s.breakRepo.GetActiveBySessionIDs(ctx, openSessionIDs); err != nil {
+		return nil, fmt.Errorf("failed to prefetch running breaks: %w", err)
+	}
+	if prefetch.absences, err = s.absenceRepo.GetByStaffIDsAndDateRange(ctx, staffIDs, from, to); err != nil {
+		return nil, fmt.Errorf("failed to prefetch absences: %w", err)
+	}
+	if prefetch.adjustments, err = s.adjustmentRepo.GetByStaffIDsAndDateRange(ctx, staffIDs, from, to); err != nil {
+		return nil, fmt.Errorf("failed to prefetch balance adjustments: %w", err)
+	}
+	if prefetch.shifts, err = s.shiftRepo.FindByStaffIDsAndDateRange(ctx, staffIDs, from, to); err != nil {
+		return nil, fmt.Errorf("failed to prefetch staff shifts: %w", err)
+	}
+	scheduleEntries, err := s.scheduleRepo.FindByStaffIDsValidInRange(ctx, staffIDs, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prefetch work schedules: %w", err)
+	}
+	prefetch.schedules = make(map[int64][]*configModels.StaffWorkSchedule, len(staffIDs))
+	for _, entry := range scheduleEntries {
+		prefetch.schedules[entry.StaffID] = append(prefetch.schedules[entry.StaffID], entry)
+	}
+	// Not derivable from the range-filtered schedules above: the question is
+	// whether a staff member EVER had a schedule version, which is what
+	// decides if the assigned work-time model may stand in.
+	if prefetch.scheduleHist, err = s.scheduleRepo.FindStaffIDsWithScheduleHistory(ctx, staffIDs); err != nil {
+		return nil, fmt.Errorf("failed to prefetch schedule history: %w", err)
+	}
+	prefetch.workTimeModels = make(map[int64]*configModels.WorkTimeModel, len(modelIDs))
+	if len(modelIDs) > 0 {
+		models, err := s.workModelRepo.FindByIDs(ctx, modelIDs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prefetch work time models: %w", err)
+		}
+		for _, model := range models {
+			prefetch.workTimeModels[model.ID] = model
+		}
+	}
+	if s.holidayReader != nil {
+		if prefetch.holidays, err = s.holidayReader.HolidayDates(ctx, from, to); err != nil {
+			return nil, fmt.Errorf("failed to prefetch non-working days: %w", err)
+		}
+	}
+	if prefetch.snapshots, err = s.prefetchSnapshots(ctx, staffIDs); err != nil {
+		return nil, err
+	}
+	return prefetch, nil
+}
+
+// prefetchSnapshots loads the frozen months of the given staff members.
+//
+// Deliberately unbounded in time: the splice asks for "the newest snapshot at
+// or before month M" for several different M, so a month-bounded prefetch could
+// not answer them all. At most one active row exists per staff member and
+// month, so the set stays small. The generic filtered List is enough — no new
+// repository method needed.
+func (s *staffOverviewService) prefetchSnapshots(
+	ctx context.Context,
+	staffIDs []int64,
+) (map[int64][]*activeModels.StaffMonthBalanceSnapshot, error) {
+	result := make(map[int64][]*activeModels.StaffMonthBalanceSnapshot, len(staffIDs))
+	if len(staffIDs) == 0 {
+		return result, nil
+	}
+	ids := make([]any, 0, len(staffIDs))
+	for _, id := range staffIDs {
+		ids = append(ids, id)
+	}
+	options := modelBase.NewQueryOptions()
+	options.Filter = options.Filter.In("staff_id", ids...).IsNull("reopened_at")
+	snapshots, err := s.snapshotRepo.List(ctx, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prefetch month balance snapshots: %w", err)
+	}
+	for _, snapshot := range snapshots {
+		result[snapshot.StaffID] = append(result[snapshot.StaffID], snapshot)
+	}
+	return result, nil
+}
+
+// --- overview list ---------------------------------------------------------
+
+func (s *staffOverviewService) GetTimeTrackingOverview(ctx context.Context, filters OverviewFilters) (*TimeTrackingOverview, error) {
+	if filters.EmploymentType != "" && !slices.Contains(validEmploymentTypes(), filters.EmploymentType) {
+		return nil, fmt.Errorf("%w: unknown employment_type %q", ErrOverviewInvalid, filters.EmploymentType)
+	}
+	if filters.SortBy != "" && !slices.Contains(ValidOverviewSortKeys, filters.SortBy) {
+		return nil, fmt.Errorf("%w: unknown sort key %q", ErrOverviewInvalid, filters.SortBy)
+	}
+	if filters.SaldoMin != nil && filters.SaldoMax != nil && *filters.SaldoMin > *filters.SaldoMax {
+		return nil, fmt.Errorf("%w: saldo_min must not exceed saldo_max", ErrOverviewInvalid)
+	}
+
+	today := s.today()
+	key := monthOf(today)
+	overview := &TimeTrackingOverview{
+		Year:  key.Year,
+		Month: key.Month,
+		Rows:  []TimeTrackingOverviewRow{},
+	}
+
+	staffMembers, err := s.activeStaff(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if filters.EmploymentType != "" {
+		staffMembers = slices.DeleteFunc(staffMembers, func(staff *userModels.Staff) bool {
+			return staff.EmploymentType == nil || *staff.EmploymentType != filters.EmploymentType
+		})
+	}
+	if len(staffMembers) == 0 {
+		return overview, nil
+	}
+
+	prefetch, err := s.buildPrefetch(ctx, staffMembers, nil, key)
+	if err != nil {
+		return nil, err
+	}
+	monthSvc := newPrefetchedMonthService(prefetch, s.logger)
+
+	staffIDs := make([]int64, 0, len(staffMembers))
+	for _, staff := range staffMembers {
+		staffIDs = append(staffIDs, staff.ID)
+	}
+	quotas, err := s.quotaRepo.GetByStaffIDsAndYear(ctx, staffIDs, today.Year)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prefetch vacation quotas: %w", err)
+	}
+	// Loaded separately over the WHOLE year rather than reused from the
+	// prefetch: that window starts at the account anchor, which may lie after
+	// January 1st, and Resturlaub counted over a shorter year would differ
+	// from GET /staff/{id}/vacation/quota. One extra query, constant in N.
+	yearAbsences, err := s.absenceRepo.GetByStaffIDsAndDateRange(ctx, staffIDs,
+		timezone.NewDate(today.Year, time.January, 1),
+		timezone.NewDate(today.Year, time.December, 31),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prefetch vacation absences: %w", err)
+	}
+
+	for _, staff := range staffMembers {
+		summary, err := monthSvc.GetMonthSummary(ctx, staff.ID, key.Year, key.Month)
+		if err != nil {
+			// A per-staff failure would otherwise leave a school total that is
+			// silently short. Fail the request and name the staff member.
+			return nil, fmt.Errorf("failed to compute month summary for staff %d: %w", staff.ID, err)
+		}
+		row := TimeTrackingOverviewRow{
+			StaffID:               staff.ID,
+			SollMinutes:           summary.TargetMinutesToDate,
+			IstMinutes:            summary.ActualMinutes,
+			BalanceMinutes:        summary.ClosingBalanceMinutes,
+			RemainingVacationDays: s.remainingVacationDays(staff.ID, today.Year, quotas[staff.ID], yearAbsences[staff.ID]),
+		}
+		if staff.EmploymentType != nil {
+			row.EmploymentType = *staff.EmploymentType
+		}
+		if staff.Person != nil {
+			row.FirstName, row.LastName = staff.Person.FirstName, staff.Person.LastName
+			row.Name = strings.TrimSpace(staff.Person.FirstName + " " + staff.Person.LastName)
+		}
+		if filters.SaldoMin != nil && row.BalanceMinutes < *filters.SaldoMin {
+			continue
+		}
+		if filters.SaldoMax != nil && row.BalanceMinutes > *filters.SaldoMax {
+			continue
+		}
+		overview.Rows = append(overview.Rows, row)
+	}
+
+	sortOverviewRows(overview.Rows, filters)
+	return overview, nil
+}
+
+// remainingVacationDays reuses the absence service's arithmetic on the
+// full-year absence rows so the value is identical to what
+// GET /staff/{id}/vacation/quota reports, including the default entitlement
+// fallback and the reservation for requested/question rows.
+func (s *staffOverviewService) remainingVacationDays(
+	staffID int64,
+	year int,
+	quota *activeModels.StaffVacationQuota,
+	absences []*activeModels.StaffAbsence,
+) float64 {
+	entitled, carryover := defaultEntitledDays, 0.0
+	if quota != nil {
+		entitled, carryover = quota.EntitledDays, quota.CarryoverDays
+	}
+	return computeVacationQuotaSummary(staffID, year, entitled, carryover, absences).RemainingDays
+}
+
+// sortOverviewRows sorts by the requested key with an explicit staff-ID
+// tiebreak. ListAllWithPerson has no ORDER BY, so without the tiebreak two
+// staff members with the same balance (0 is very common) would swap places
+// between identical requests and the table would flicker.
+func sortOverviewRows(rows []TimeTrackingOverviewRow, filters OverviewFilters) {
+	key := cmp.Or(filters.SortBy, OverviewSortName)
+	slices.SortStableFunc(rows, func(a, b TimeTrackingOverviewRow) int {
+		order := compareOverviewRows(a, b, key)
+		if filters.Descending {
+			return -order
+		}
+		return order
+	})
+}
+
+// compareOverviewRows is a total order: the staff-ID tiebreak means two
+// distinct rows never compare equal.
+func compareOverviewRows(a, b TimeTrackingOverviewRow, key string) int {
+	var order int
+	switch key {
+	case OverviewSortBalance:
+		order = cmp.Compare(a.BalanceMinutes, b.BalanceMinutes)
+	case OverviewSortSoll:
+		order = cmp.Compare(a.SollMinutes, b.SollMinutes)
+	case OverviewSortIst:
+		order = cmp.Compare(a.IstMinutes, b.IstMinutes)
+	case OverviewSortVacation:
+		order = cmp.Compare(a.RemainingVacationDays, b.RemainingVacationDays)
+	default:
+		order = cmp.Compare(
+			strings.ToLower(a.LastName+" "+a.FirstName),
+			strings.ToLower(b.LastName+" "+b.FirstName),
+		)
+	}
+	return cmp.Or(order, cmp.Compare(a.StaffID, b.StaffID))
+}
+
+func validEmploymentTypes() []string {
+	return []string{
+		userModels.EmploymentTypeFullTime,
+		userModels.EmploymentTypePartTime,
+		userModels.EmploymentTypeMinijob,
+	}
+}
+
+// activeStaff is the set every KPI is intersected against: tenant-scoped and
+// soft-delete-filtered. "Active" means not offboarded.
+func (s *staffOverviewService) activeStaff(ctx context.Context) ([]*userModels.Staff, error) {
+	staffMembers, err := s.staffRepo.ListAllWithPerson(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list staff: %w", err)
+	}
+	return staffMembers, nil
+}
+
+// --- dashboard -------------------------------------------------------------
+
+func (s *staffOverviewService) GetDashboardSummary(ctx context.Context, period string) (*DashboardSummary, error) {
+	if period == "" {
+		period = OverviewPeriodMonth
+	}
+	if period != OverviewPeriodWeek && period != OverviewPeriodMonth {
+		return nil, fmt.Errorf("%w: period must be %s or %s", ErrOverviewInvalid, OverviewPeriodWeek, OverviewPeriodMonth)
+	}
+
+	today := s.today()
+	key := monthOf(today)
+	summary := &DashboardSummary{}
+
+	staffMembers, err := s.activeStaff(ctx)
+	if err != nil {
+		return nil, err
+	}
+	summary.ActiveStaffCount = len(staffMembers)
+	activeIDs := make(map[int64]bool, len(staffMembers))
+	for _, staff := range staffMembers {
+		activeIDs[staff.ID] = true
+	}
+
+	if err := s.addTodayCounters(ctx, summary, activeIDs, today); err != nil {
+		return nil, err
+	}
+	pending, err := s.countPendingRequests(ctx)
+	if err != nil {
+		return nil, err
+	}
+	summary.PendingRequestsCount = pending
+
+	if len(staffMembers) == 0 {
+		return summary, nil
+	}
+
+	// period=week can reach into the previous month, so the prefetch window
+	// has to start no later than that Monday.
+	var lower *timezone.Date
+	weekStart := configModels.MondayOf(today)
+	if period == OverviewPeriodWeek {
+		lower = &weekStart
+	}
+	prefetch, err := s.buildPrefetch(ctx, staffMembers, lower, key)
+	if err != nil {
+		return nil, err
+	}
+	monthSvc := newPrefetchedMonthService(prefetch, s.logger)
+
+	weekEnd := weekStart.AddDays(6)
+	if weekEnd.After(today) {
+		// Clamp at today so Soll and Ist are comparable, mirroring the month
+		// card's target_to_date.
+		weekEnd = today
+	}
+	for _, staff := range staffMembers {
+		monthSummary, err := monthSvc.GetMonthSummary(ctx, staff.ID, key.Year, key.Month)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute month summary for staff %d: %w", staff.ID, err)
+		}
+		summary.SaldoSchoolTotalMinutes += monthSummary.ClosingBalanceMinutes
+
+		if period == OverviewPeriodMonth {
+			summary.Period.SollMinutes += monthSummary.TargetMinutesToDate
+			summary.Period.IstMinutes += monthSummary.ActualMinutes
+			summary.Period.DeltaMinutes += monthSummary.BalanceMinutes
+			continue
+		}
+		week, err := monthSvc.GetRangeAggregate(ctx, staff.ID, weekStart, weekEnd)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute week aggregate for staff %d: %w", staff.ID, err)
+		}
+		summary.Period.SollMinutes += week.TargetMinutes
+		summary.Period.IstMinutes += week.ActualMinutes
+		summary.Period.DeltaMinutes += week.BalanceMinutes
+	}
+	return summary, nil
+}
+
+// addTodayCounters fills the presence and absence KPIs.
+//
+// Every set is intersected with the active-staff IDs: the presence, absence and
+// shift lookups do not join users.staff, and a leaver's sessions and absences
+// survive offboarding, so counting them raw would overstate each KPI.
+func (s *staffOverviewService) addTodayCounters(
+	ctx context.Context,
+	summary *DashboardSummary,
+	activeIDs map[int64]bool,
+	today timezone.Date,
+) error {
+	presence, err := s.sessionRepo.GetTodayPresenceMap(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load presence map: %w", err)
+	}
+	clockedIn := make(map[int64]bool, len(presence))
+	for staffID, status := range presence {
+		// The map stores the session status for an open session and the
+		// sentinel "checked_out" otherwise; match the open statuses
+		// positively so a new status value cannot be miscounted as present.
+		if !activeIDs[staffID] {
+			continue
+		}
+		if status == activeModels.WorkSessionStatusPresent || status == activeModels.WorkSessionStatusHomeOffice {
+			clockedIn[staffID] = true
+		}
+	}
+	// A session opened before midnight and never closed is still someone at
+	// work, but it is not in today's presence map.
+	openSessions, err := s.sessionRepo.GetOpenSessions(ctx, today)
+	if err != nil {
+		return fmt.Errorf("failed to load open sessions: %w", err)
+	}
+	for _, session := range openSessions {
+		if activeIDs[session.StaffID] {
+			clockedIn[session.StaffID] = true
+		}
+	}
+	summary.CurrentlyClockedIn = len(clockedIn)
+
+	absences, err := s.absenceRepo.GetTodayAbsenceMap(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load absence map: %w", err)
+	}
+	// The map keeps ONE type per staff member by priority
+	// (sick > training > vacation > comp_time > other), so somebody with
+	// overlapping sick and vacation counts as sick only and the two counters
+	// never double-count a person.
+	for staffID, absenceType := range absences {
+		if !activeIDs[staffID] {
+			continue
+		}
+		switch absenceType {
+		case activeModels.AbsenceTypeSick:
+			summary.SickToday++
+		case activeModels.AbsenceTypeVacation:
+			summary.VacationToday++
+		}
+	}
+
+	expected, err := s.expectedClockedIn(ctx, activeIDs, today)
+	if err != nil {
+		return err
+	}
+	summary.ExpectedClockedIn = expected
+	return nil
+}
+
+// expectedClockedIn counts staff members whose planned shift covers this very
+// moment. Shift rows carry wall-clock TIME columns, normalized by the repo.
+func (s *staffOverviewService) expectedClockedIn(
+	ctx context.Context,
+	activeIDs map[int64]bool,
+	today timezone.Date,
+) (int, error) {
+	shifts, err := s.shiftRepo.FindByDateRange(ctx, today, today)
+	if err != nil {
+		return 0, fmt.Errorf("failed to load today's shifts: %w", err)
+	}
+	nowWall := timezone.WallClock(timezone.Now())
+	expected := make(map[int64]bool)
+	for _, shift := range shifts {
+		if shift.Cancelled || !activeIDs[shift.StaffID] {
+			continue
+		}
+		start, end := timezone.WallClock(shift.StartTime), timezone.WallClock(shift.EndTime)
+		if !nowWall.Before(start) && !nowWall.After(end) {
+			expected[shift.StaffID] = true
+		}
+	}
+	return len(expected), nil
+}
+
+// countPendingRequests counts absences awaiting a decision — the same set
+// ListPendingRequests returns, counted through the generic filter API so no
+// rows are loaded.
+func (s *staffOverviewService) countPendingRequests(ctx context.Context) (int, error) {
+	options := modelBase.NewQueryOptions()
+	options.Filter = options.Filter.In("status",
+		activeModels.AbsenceStatusRequested,
+		activeModels.AbsenceStatusQuestion,
+	)
+	count, err := s.absenceRepo.CountWithOptions(ctx, options)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count pending absence requests: %w", err)
+	}
+	return count, nil
+}

--- a/backend/services/active/staff_overview_service.go
+++ b/backend/services/active/staff_overview_service.go
@@ -221,6 +221,12 @@ func (s *staffOverviewService) buildPrefetch(
 		return nil, err
 	}
 	from, to := anchor, through.lastDay()
+	// getMonthSummaryThrough summarizes a month before the configured account
+	// start as a standalone month. Prefetch the same month instead of querying
+	// the future anchor through an earlier month end.
+	if through.before(monthOf(anchor)) {
+		from = through.firstDay()
+	}
 	if lower != nil && lower.Before(from) {
 		from = *lower
 	}

--- a/backend/services/active/staff_overview_service.go
+++ b/backend/services/active/staff_overview_service.go
@@ -626,7 +626,7 @@ func (s *staffOverviewService) addTodayCounters(
 	}
 	summary.CurrentlyClockedIn = len(clockedIn)
 
-	absences, err := s.absenceRepo.GetTodayAbsenceMap(ctx)
+	absences, err := s.absenceRepo.GetAbsenceMapForDate(ctx, today)
 	if err != nil {
 		return fmt.Errorf("failed to load absence map: %w", err)
 	}

--- a/backend/services/active/work_session_autocheckout_mock_test.go
+++ b/backend/services/active/work_session_autocheckout_mock_test.go
@@ -788,3 +788,9 @@ func TestAutoCheckout_QueriesOpenSessionsIncludingToday(t *testing.T) {
 	assert.Equal(t, timezone.TodayDate().AddDays(1), beforeDate,
 		"must pass tomorrow so today's open sessions are included (GetOpenSessions filters date < beforeDate)")
 }
+
+// FindByStaffIDsAndDateRange satisfies the batched interface method (#1417); this mock
+// exercises the single-staff path only.
+func (m *wsMockStaffShiftRepository) FindByStaffIDsAndDateRange(context.Context, []int64, timezone.Date, timezone.Date) (map[int64][]*scheduleModels.StaffShift, error) {
+	return nil, nil
+}

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -3274,3 +3274,27 @@ func TestWSRecalcBreakMinutes_ExcludesRunningBreak(t *testing.T) {
 	assert.Equal(t, 30, cached,
 		"only the ended break belongs in the cache; the running break's 20 minutes would be double-counted by readers")
 }
+
+// GetHistoryByStaffIDs satisfies the batched interface method (#1417); this mock
+// exercises the single-staff path only.
+func (m *wsMockWorkSessionRepository) GetHistoryByStaffIDs(context.Context, []int64, timezone.Date, timezone.Date) (map[int64][]*activeModels.WorkSession, error) {
+	return nil, nil
+}
+
+// GetActiveBySessionIDs satisfies the batched interface method (#1417); this mock
+// exercises the single-staff path only.
+func (m *wsMockWorkSessionBreakRepository) GetActiveBySessionIDs(context.Context, []int64) (map[int64]*activeModels.WorkSessionBreak, error) {
+	return nil, nil
+}
+
+// GetByStaffIDsAndDateRange satisfies the batched interface method (#1417); this mock
+// exercises the single-staff path only.
+func (m *wsMockStaffAbsenceRepository) GetByStaffIDsAndDateRange(context.Context, []int64, timezone.Date, timezone.Date) (map[int64][]*activeModels.StaffAbsence, error) {
+	return nil, nil
+}
+
+// FindStaffIDsWithScheduleHistory satisfies the batched interface method (#1417); this mock
+// exercises the single-staff path only.
+func (m *wsMockStaffWorkScheduleRepository) FindStaffIDsWithScheduleHistory(context.Context, []int64) (map[int64]bool, error) {
+	return nil, nil
+}

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -411,7 +411,7 @@ type wsMockStaffAbsenceRepository struct {
 	getByStaffAndDateRangeFunc func(ctx context.Context, staffID int64, from, to timezone.Date) ([]*activeModels.StaffAbsence, error)
 	getByStaffAndDateFunc      func(ctx context.Context, staffID int64, date timezone.Date) (*activeModels.StaffAbsence, error)
 	getByDateRangeFunc         func(ctx context.Context, from, to timezone.Date) ([]*activeModels.StaffAbsence, error)
-	getTodayAbsenceMapFunc     func(ctx context.Context) (map[int64]string, error)
+	getAbsenceMapForDateFunc   func(ctx context.Context, date timezone.Date) (map[int64]string, error)
 }
 
 func (m *wsMockStaffAbsenceRepository) LockStaffAbsenceWrites(context.Context, int64) error {
@@ -474,9 +474,9 @@ func (m *wsMockStaffAbsenceRepository) GetByDateRange(ctx context.Context, from,
 	return nil, nil
 }
 
-func (m *wsMockStaffAbsenceRepository) GetTodayAbsenceMap(ctx context.Context) (map[int64]string, error) {
-	if m.getTodayAbsenceMapFunc != nil {
-		return m.getTodayAbsenceMapFunc(ctx)
+func (m *wsMockStaffAbsenceRepository) GetAbsenceMapForDate(ctx context.Context, date timezone.Date) (map[int64]string, error) {
+	if m.getAbsenceMapForDateFunc != nil {
+		return m.getAbsenceMapForDateFunc(ctx, date)
 	}
 	return nil, nil
 }

--- a/backend/services/active/work_time_month_adjustment_test.go
+++ b/backend/services/active/work_time_month_adjustment_test.go
@@ -21,6 +21,27 @@ type wtmMockAdjustmentReader struct {
 	adjustments []*activeModels.StaffBalanceAdjustment
 }
 
+type wtmMockSnapshotReader struct {
+	activeModels.StaffMonthBalanceSnapshotRepository
+	snapshot *activeModels.StaffMonthBalanceSnapshot
+}
+
+func (m *wtmMockSnapshotReader) GetLatestClosedThrough(
+	_ context.Context,
+	_ int64,
+	year, month int,
+) (*activeModels.StaffMonthBalanceSnapshot, error) {
+	if m.snapshot == nil {
+		return nil, nil
+	}
+	requested := monthKey{Year: year, Month: month}
+	snapshotMonth := monthKey{Year: m.snapshot.Year, Month: m.snapshot.Month}
+	if requested.before(snapshotMonth) {
+		return nil, nil
+	}
+	return m.snapshot, nil
+}
+
 func (m *wtmMockAdjustmentReader) GetByStaffAndDateRange(_ context.Context, _ int64, from, to timezone.Date) ([]*activeModels.StaffBalanceAdjustment, error) {
 	var result []*activeModels.StaffBalanceAdjustment
 	for _, a := range m.adjustments {
@@ -291,6 +312,30 @@ func TestWTMAdjustments_BackdatedReductionProtectsMinimumDailyClosing(t *testing
 	// today's balance to 240, but a backdated debit must still preserve the
 	// lower historical closing balance.
 	assert.Equal(t, 120, capacity)
+}
+
+func TestWTMAdjustments_ReductionCapacityStartsFromFrozenPriorMonth(t *testing.T) {
+	f := newWTMFixture()
+	f.svc.SetSnapshotReader(&wtmMockSnapshotReader{
+		snapshot: &activeModels.StaffMonthBalanceSnapshot{
+			StaffID:               wtmStaffID,
+			Year:                  2026,
+			Month:                 6,
+			ClosingBalanceMinutes: 1_000,
+		},
+	})
+
+	capacity, err := f.svc.GetBalanceReductionCapacity(
+		context.Background(),
+		wtmStaffID,
+		timezone.NewDate(2026, time.July, 1),
+	)
+	require.NoError(t, err)
+
+	// June's live balance has drifted to -2,400, but its frozen close is
+	// 1,000. The two July Monday targets reduce that frozen carry to 40 by
+	// today, which is the limiting capacity for a debit effective July 1.
+	assert.Equal(t, 40, capacity)
 }
 
 func TestWTMAdjustments_DailyMinimumMatchesCarryChain(t *testing.T) {

--- a/backend/services/active/work_time_month_adjustment_test.go
+++ b/backend/services/active/work_time_month_adjustment_test.go
@@ -338,6 +338,39 @@ func TestWTMAdjustments_ReductionCapacityStartsFromFrozenPriorMonth(t *testing.T
 	assert.Equal(t, 40, capacity)
 }
 
+func TestWTMAdjustments_AdvancedAccountStartIgnoresOlderSnapshotBoundary(t *testing.T) {
+	f := newWTMFixture()
+	f.settings.accountStart = "2026-07-01"
+	f.svc.SetSnapshotReader(&wtmMockSnapshotReader{
+		snapshot: &activeModels.StaffMonthBalanceSnapshot{
+			StaffID:               wtmStaffID,
+			Year:                  2026,
+			Month:                 6,
+			ClosingBalanceMinutes: 1_000,
+		},
+	})
+	accountStart := timezone.NewDate(2026, time.July, 1)
+
+	opening, err := f.svc.getOpeningBalanceOnDate(
+		context.Background(),
+		wtmStaffID,
+		accountStart,
+		f.svc.today(),
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Zero(t, opening, "the June snapshot lies before the advanced July account anchor")
+
+	minimum, err := f.svc.getMinimumDailyClosingBalance(
+		context.Background(),
+		wtmStaffID,
+		accountStart,
+		accountStart,
+	)
+	require.NoError(t, err)
+	assert.Zero(t, minimum, "the June boundary must not restart the chain on the account anchor")
+}
+
 func TestWTMAdjustments_DailyMinimumMatchesCarryChain(t *testing.T) {
 	f := newWTMFixture()
 	f.settings.accountStart = "2026-07-01"

--- a/backend/services/active/work_time_month_prefetch.go
+++ b/backend/services/active/work_time_month_prefetch.go
@@ -1,0 +1,214 @@
+package active
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	configModels "github.com/moto-nrw/project-phoenix/models/config"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// The adapters in this file let the Monatskarte math run over data loaded once
+// for MANY staff members (#1417). Each satisfies one of the narrow reader
+// interfaces workTimeMonthService depends on, serving from a prefetched map
+// instead of issuing a query per staff member. There is deliberately NO
+// arithmetic here: the cross-staff overview must produce byte-identical numbers
+// to the per-staff detail view, so it runs the very same code with the very
+// same readers.
+//
+// This works because the prefetch window is the same for every staff member of
+// a tenant: computeAggregates ranges over [first, last], where `first` derives
+// from the account-start anchor — a TENANT-wide setting, not a per-staff value
+// — and `last` from the requested month. One load therefore covers everybody.
+// TestStaffOverview_PrefetchWindowIsTenantWide pins that property.
+//
+// Callers must never request a WIDER range than the prefetch covers; the
+// adapters serve their whole slice and cannot detect the mistake.
+type monthPrefetch struct {
+	from, to timezone.Date
+
+	staff          map[int64]*userModels.Staff
+	sessions       map[int64][]*activeModels.WorkSession
+	breaks         map[int64]*activeModels.WorkSessionBreak
+	absences       map[int64][]*activeModels.StaffAbsence
+	adjustments    map[int64][]*activeModels.StaffBalanceAdjustment
+	shifts         map[int64][]*scheduleModels.StaffShift
+	schedules      map[int64][]*configModels.StaffWorkSchedule
+	scheduleHist   map[int64]bool
+	workTimeModels map[int64]*configModels.WorkTimeModel
+	holidays       map[timezone.Date]bool
+	snapshots      map[int64][]*activeModels.StaffMonthBalanceSnapshot
+	settings       *memoSettingsResolver
+}
+
+// memoSettingsResolver resolves each settings key once per request. The
+// settings service issues one query per Resolve call with no cache, which would
+// otherwise cost one query per staff member for the account-start anchor alone.
+type memoSettingsResolver struct {
+	inner monthSettingsResolver
+
+	mu     sync.Mutex
+	values map[string]string
+	errs   map[string]error
+}
+
+func newMemoSettingsResolver(inner monthSettingsResolver) *memoSettingsResolver {
+	return &memoSettingsResolver{
+		inner:  inner,
+		values: make(map[string]string),
+		errs:   make(map[string]error),
+	}
+}
+
+func (m *memoSettingsResolver) ResolveString(ctx context.Context, key string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if value, ok := m.values[key]; ok {
+		return value, m.errs[key]
+	}
+	if m.inner == nil {
+		return "", nil
+	}
+	value, err := m.inner.ResolveString(ctx, key)
+	m.values[key], m.errs[key] = value, err
+	return value, err
+}
+
+// These are programming errors, not data conditions: the prefetch is built
+// from the very staff list the overview iterates, so a miss means the caller
+// asked for something it never loaded. Failing loudly beats reporting a
+// silently wrong Stundenkonto.
+var (
+	errUnexpectedPrefetchID       = errors.New("prefetched staff reader expects an int64 id")
+	errStaffNotPrefetched         = errors.New("staff member is not part of the prefetch")
+	errWorkTimeModelNotPrefetched = errors.New("work time model is not part of the prefetch")
+)
+
+// --- readers ---------------------------------------------------------------
+
+type prefetchedStaffReader struct{ p *monthPrefetch }
+
+func (r prefetchedStaffReader) FindByID(_ context.Context, id any) (*userModels.Staff, error) {
+	staffID, ok := id.(int64)
+	if !ok {
+		return nil, errUnexpectedPrefetchID
+	}
+	staff, ok := r.p.staff[staffID]
+	if !ok {
+		return nil, errStaffNotPrefetched
+	}
+	return staff, nil
+}
+
+type prefetchedSessionReader struct{ p *monthPrefetch }
+
+func (r prefetchedSessionReader) GetHistoryByStaffID(_ context.Context, staffID int64, _, _ timezone.Date) ([]*activeModels.WorkSession, error) {
+	return r.p.sessions[staffID], nil
+}
+
+// prefetchedBreakReader mirrors the repository's (nil, nil) on no open break —
+// runningBreakMinutes treats a nil break as "no break running".
+type prefetchedBreakReader struct{ p *monthPrefetch }
+
+func (r prefetchedBreakReader) GetActiveBySessionID(_ context.Context, sessionID int64) (*activeModels.WorkSessionBreak, error) {
+	return r.p.breaks[sessionID], nil
+}
+
+type prefetchedAbsenceReader struct{ p *monthPrefetch }
+
+func (r prefetchedAbsenceReader) GetByStaffAndDateRange(_ context.Context, staffID int64, _, _ timezone.Date) ([]*activeModels.StaffAbsence, error) {
+	return r.p.absences[staffID], nil
+}
+
+type prefetchedAdjustmentReader struct{ p *monthPrefetch }
+
+func (r prefetchedAdjustmentReader) GetByStaffAndDateRange(_ context.Context, staffID int64, _, _ timezone.Date) ([]*activeModels.StaffBalanceAdjustment, error) {
+	return r.p.adjustments[staffID], nil
+}
+
+type prefetchedShiftReader struct{ p *monthPrefetch }
+
+func (r prefetchedShiftReader) FindByStaffAndDateRange(_ context.Context, staffID int64, _, _ timezone.Date) ([]*scheduleModels.StaffShift, error) {
+	return r.p.shifts[staffID], nil
+}
+
+type prefetchedScheduleReader struct{ p *monthPrefetch }
+
+func (r prefetchedScheduleReader) FindByStaffIDsValidInRange(_ context.Context, staffIDs []int64, _, _ timezone.Date) ([]*configModels.StaffWorkSchedule, error) {
+	var entries []*configModels.StaffWorkSchedule
+	for _, staffID := range staffIDs {
+		entries = append(entries, r.p.schedules[staffID]...)
+	}
+	return entries, nil
+}
+
+func (r prefetchedScheduleReader) HasScheduleHistory(_ context.Context, staffID int64) (bool, error) {
+	return r.p.scheduleHist[staffID], nil
+}
+
+type prefetchedModelReader struct{ p *monthPrefetch }
+
+func (r prefetchedModelReader) FindByID(_ context.Context, id int64) (*configModels.WorkTimeModel, error) {
+	model, ok := r.p.workTimeModels[id]
+	if !ok {
+		return nil, errWorkTimeModelNotPrefetched
+	}
+	return model, nil
+}
+
+// prefetchedHolidayReader serves the non-working-day set. targetFor only does a
+// map lookup, so a map covering a superset of the requested range is
+// behaviourally identical to a per-range query.
+type prefetchedHolidayReader struct{ p *monthPrefetch }
+
+func (r prefetchedHolidayReader) HolidayDates(_ context.Context, _, _ timezone.Date) (map[timezone.Date]bool, error) {
+	return r.p.holidays, nil
+}
+
+// prefetchedSnapshotReader answers "newest active snapshot at or before this
+// month" from memory. It must be prefetched like everything else: the splice
+// asks per staff member AND per month, so a repository-backed reader here would
+// silently reintroduce a per-staff query (which
+// TestTimeTrackingOverview_QueryCountIsConstant catches).
+type prefetchedSnapshotReader struct{ p *monthPrefetch }
+
+func (r prefetchedSnapshotReader) GetLatestClosedThrough(_ context.Context, staffID int64, year, month int) (*activeModels.StaffMonthBalanceSnapshot, error) {
+	limit := year*12 + month
+	var best *activeModels.StaffMonthBalanceSnapshot
+	for _, snapshot := range r.p.snapshots[staffID] {
+		ordinal := snapshot.Year*12 + snapshot.Month
+		if ordinal > limit {
+			continue
+		}
+		if best == nil || ordinal > best.Year*12+best.Month {
+			best = snapshot
+		}
+	}
+	return best, nil
+}
+
+// newPrefetchedMonthService builds a month service whose readers all serve from
+// the prefetch. Constructed the same way services/factory.go builds the real
+// one, including every setter, so no code path differs.
+func newPrefetchedMonthService(p *monthPrefetch, logger *slog.Logger) WorkTimeMonthService {
+	svc := NewWorkTimeMonthService(
+		prefetchedSessionReader{p},
+		prefetchedBreakReader{p},
+		prefetchedAbsenceReader{p},
+		prefetchedStaffReader{p},
+		prefetchedScheduleReader{p},
+		prefetchedModelReader{p},
+		prefetchedShiftReader{p},
+		p.settings,
+		logger,
+	)
+	svc.SetHolidayReader(prefetchedHolidayReader{p})
+	svc.SetAdjustmentReader(prefetchedAdjustmentReader{p})
+	svc.SetSnapshotReader(prefetchedSnapshotReader{p})
+	return svc
+}

--- a/backend/services/active/work_time_month_prefetch.go
+++ b/backend/services/active/work_time_month_prefetch.go
@@ -127,8 +127,16 @@ func (r prefetchedAbsenceReader) GetByStaffAndDateRange(_ context.Context, staff
 
 type prefetchedAdjustmentReader struct{ p *monthPrefetch }
 
-func (r prefetchedAdjustmentReader) GetByStaffAndDateRange(_ context.Context, staffID int64, _, _ timezone.Date) ([]*activeModels.StaffBalanceAdjustment, error) {
-	return r.p.adjustments[staffID], nil
+func (r prefetchedAdjustmentReader) GetByStaffAndDateRange(_ context.Context, staffID int64, from, to timezone.Date) ([]*activeModels.StaffBalanceAdjustment, error) {
+	adjustments := r.p.adjustments[staffID]
+	result := make([]*activeModels.StaffBalanceAdjustment, 0, len(adjustments))
+	for _, adjustment := range adjustments {
+		if adjustment.EffectiveDate.Before(from) || adjustment.EffectiveDate.After(to) {
+			continue
+		}
+		result = append(result, adjustment)
+	}
+	return result, nil
 }
 
 type prefetchedShiftReader struct{ p *monthPrefetch }

--- a/backend/services/active/work_time_month_prefetch.go
+++ b/backend/services/active/work_time_month_prefetch.go
@@ -107,8 +107,16 @@ func (r prefetchedStaffReader) FindByID(_ context.Context, id any) (*userModels.
 
 type prefetchedSessionReader struct{ p *monthPrefetch }
 
-func (r prefetchedSessionReader) GetHistoryByStaffID(_ context.Context, staffID int64, _, _ timezone.Date) ([]*activeModels.WorkSession, error) {
-	return r.p.sessions[staffID], nil
+func (r prefetchedSessionReader) GetHistoryByStaffID(_ context.Context, staffID int64, from, to timezone.Date) ([]*activeModels.WorkSession, error) {
+	sessions := r.p.sessions[staffID]
+	result := make([]*activeModels.WorkSession, 0, len(sessions))
+	for _, session := range sessions {
+		if session.Date.Before(from) || session.Date.After(to) {
+			continue
+		}
+		result = append(result, session)
+	}
+	return result, nil
 }
 
 // prefetchedBreakReader mirrors the repository's (nil, nil) on no open break —

--- a/backend/services/active/work_time_month_service.go
+++ b/backend/services/active/work_time_month_service.go
@@ -1204,6 +1204,15 @@ func (s *workTimeMonthService) getDailyBalanceDeltas(
 	if err := s.addDailyAdjustments(ctx, staffID, from, to, deltas); err != nil {
 		return nil, err
 	}
+	anchor, err := s.chainAnchor(ctx, monthOf(from))
+	if err != nil {
+		return nil, err
+	}
+	for d := from; !d.After(to); d = d.AddDays(1) {
+		if excludedByAccountStart(d, anchor) {
+			deltas[d] = 0
+		}
+	}
 	return deltas, nil
 }
 

--- a/backend/services/active/work_time_month_service.go
+++ b/backend/services/active/work_time_month_service.go
@@ -823,9 +823,9 @@ func (s *workTimeMonthService) GetMonthSummaryAtMonthEnd(ctx context.Context, st
 }
 
 // GetRangeAggregate sums an arbitrary closed range from the SAME helpers the
-// Monatskarte and the daily table use: GetDailyTargets for the Soll (which
-// brings the account-start exclusion with it), getDailyActualMinutes for the
-// Ist (day cap, now cap, running break, account-start exclusion), and
+// Monatskarte and the daily table use. It first clamps the whole range to the
+// account anchor, then uses GetDailyTargets for the Soll,
+// getDailyActualMinutes for the Ist (day cap, now cap, running break), and
 // getDailyBalanceDeltas for the balance (credits, adjustments, target). No new
 // arithmetic, therefore no way for a week total to contradict the month card
 // above it.
@@ -833,11 +833,21 @@ func (s *workTimeMonthService) GetRangeAggregate(ctx context.Context, staffID in
 	if from.IsZero() || to.IsZero() || to.Before(from) {
 		return nil, errors.New("from and to must form a valid range")
 	}
-	targets, err := s.GetDailyTargets(ctx, staffID, from, to)
+	anchor, err := s.chainAnchor(ctx, monthOf(from))
 	if err != nil {
 		return nil, err
 	}
 	aggregate := &RangeAggregate{}
+	if to.Before(anchor) {
+		return aggregate, nil
+	}
+	if from.Before(anchor) {
+		from = anchor
+	}
+	targets, err := s.GetDailyTargets(ctx, staffID, from, to)
+	if err != nil {
+		return nil, err
+	}
 	for _, target := range targets {
 		aggregate.TargetMinutes += target.TargetMinutes
 	}
@@ -845,14 +855,7 @@ func (s *workTimeMonthService) GetRangeAggregate(ctx context.Context, staffID in
 	if err != nil {
 		return nil, err
 	}
-	anchor, err := s.chainAnchor(ctx, monthOf(from))
-	if err != nil {
-		return nil, err
-	}
-	for date, minutes := range actual {
-		if excludedByAccountStart(date, anchor) {
-			continue
-		}
+	for _, minutes := range actual {
 		aggregate.ActualMinutes += minutes
 	}
 	deltas, err := s.getDailyBalanceDeltas(ctx, staffID, from, to)

--- a/backend/services/active/work_time_month_service.go
+++ b/backend/services/active/work_time_month_service.go
@@ -825,9 +825,10 @@ func (s *workTimeMonthService) GetMonthSummaryAtMonthEnd(ctx context.Context, st
 // GetRangeAggregate sums an arbitrary closed range from the SAME helpers the
 // Monatskarte and the daily table use: GetDailyTargets for the Soll (which
 // brings the account-start exclusion with it), getDailyActualMinutes for the
-// Ist (day cap, now cap, running break), and getDailyBalanceDeltas for the
-// balance (credits, adjustments, target). No new arithmetic, therefore no way
-// for a week total to contradict the month card above it.
+// Ist (day cap, now cap, running break, account-start exclusion), and
+// getDailyBalanceDeltas for the balance (credits, adjustments, target). No new
+// arithmetic, therefore no way for a week total to contradict the month card
+// above it.
 func (s *workTimeMonthService) GetRangeAggregate(ctx context.Context, staffID int64, from, to timezone.Date) (*RangeAggregate, error) {
 	if from.IsZero() || to.IsZero() || to.Before(from) {
 		return nil, errors.New("from and to must form a valid range")
@@ -844,7 +845,14 @@ func (s *workTimeMonthService) GetRangeAggregate(ctx context.Context, staffID in
 	if err != nil {
 		return nil, err
 	}
-	for _, minutes := range actual {
+	anchor, err := s.chainAnchor(ctx, monthOf(from))
+	if err != nil {
+		return nil, err
+	}
+	for date, minutes := range actual {
+		if excludedByAccountStart(date, anchor) {
+			continue
+		}
 		aggregate.ActualMinutes += minutes
 	}
 	deltas, err := s.getDailyBalanceDeltas(ctx, staffID, from, to)

--- a/backend/services/active/work_time_month_service.go
+++ b/backend/services/active/work_time_month_service.go
@@ -1070,9 +1070,17 @@ func (s *workTimeMonthService) getOpeningBalanceOnDate(
 	}
 
 	if cutoff := date.AddDays(-1); !cutoff.Before(anchor) {
-		available, err = s.GetClosingBalanceAsOf(ctx, staffID, cutoff)
+		boundaries, err := s.frozenMonthBoundaries(ctx, staffID, date, date)
 		if err != nil {
-			return 0, fmt.Errorf("failed to compute opening balance on %s: %w", date.String(), err)
+			return 0, fmt.Errorf("failed to load opening balance on %s: %w", date.String(), err)
+		}
+		if frozen, ok := boundaries[date]; ok {
+			available = frozen
+		} else {
+			available, err = s.GetClosingBalanceAsOf(ctx, staffID, cutoff)
+			if err != nil {
+				return 0, fmt.Errorf("failed to compute opening balance on %s: %w", date.String(), err)
+			}
 		}
 	}
 	sameDayAdjustments, err := s.GetBalanceAdjustmentMinutes(ctx, staffID, date, date)
@@ -1149,7 +1157,7 @@ func (s *workTimeMonthService) getMinimumDailyClosingBalance(
 	}
 	minimum := int(^uint(0) >> 1)
 	for d := from; !d.After(to); d = d.AddDays(1) {
-		if opening, ok := boundaries[d]; ok {
+		if opening, ok := boundaries[d]; ok && d.After(anchor) {
 			balance = opening
 		}
 		balance += deltas[d]
@@ -1158,11 +1166,10 @@ func (s *workTimeMonthService) getMinimumDailyClosingBalance(
 	return minimum, nil
 }
 
-// frozenMonthBoundaries maps each month-start day inside (from, to] to the
+// frozenMonthBoundaries maps each month-start day inside [from, to] to the
 // frozen closing balance of the preceding month, for the days where the carry
-// chain restarts instead of continuing. `from` itself is never a boundary: the
-// caller already seeded the balance with the closing value before it, which is
-// snapshot-aware via GetClosingBalanceAsOf.
+// chain restarts instead of continuing. `from` is a boundary only when it is
+// itself the first day of a month.
 func (s *workTimeMonthService) frozenMonthBoundaries(
 	ctx context.Context,
 	staffID int64,
@@ -1172,7 +1179,11 @@ func (s *workTimeMonthService) frozenMonthBoundaries(
 	if s.snapshotRepo == nil {
 		return boundaries, nil
 	}
-	for k := monthOf(from).next(); !monthOf(to).before(k); k = k.next() {
+	first := monthOf(from)
+	if first.firstDay().Before(from) {
+		first = first.next()
+	}
+	for k := first; !monthOf(to).before(k); k = k.next() {
 		prev := k.addMonths(-1)
 		snapshot, err := s.snapshotRepo.GetLatestClosedThrough(ctx, staffID, prev.Year, prev.Month)
 		if err != nil {

--- a/backend/services/active/work_time_month_service.go
+++ b/backend/services/active/work_time_month_service.go
@@ -833,7 +833,7 @@ func (s *workTimeMonthService) GetRangeAggregate(ctx context.Context, staffID in
 	if from.IsZero() || to.IsZero() || to.Before(from) {
 		return nil, errors.New("from and to must form a valid range")
 	}
-	anchor, err := s.chainAnchor(ctx, monthOf(from))
+	anchor, err := s.chainAnchor(ctx, monthOf(to))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/services/active/work_time_month_service.go
+++ b/backend/services/active/work_time_month_service.go
@@ -58,6 +58,31 @@ type MonthSummary struct {
 	// ClosingBalanceMinutes = CarryInMinutes + BalanceMinutes; for the
 	// current month this is the live Stundenkonto as of today.
 	ClosingBalanceMinutes int `json:"closing_balance_minutes"`
+
+	// --- Monatsabschluss (#1417) -----------------------------------------
+	// IsClosed reports whether THIS month is frozen. The remaining fields
+	// below describe the freeze.
+	IsClosed    bool       `json:"is_closed"`
+	ClosedAt    *time.Time `json:"closed_at,omitempty"`
+	ClosedBy    *int64     `json:"closed_by,omitempty"`
+	CloseReason string     `json:"close_reason,omitempty"`
+	// FrozenClosingBalanceMinutes is the value that carries forward once this
+	// month is closed. ClosingBalanceMinutes stays the LIVE number so the
+	// card's carry_in + balance identity holds.
+	FrozenClosingBalanceMinutes *int `json:"frozen_closing_balance_minutes,omitempty"`
+	// DriftMinutes = live ClosingBalanceMinutes − frozen value, i.e. how far
+	// this month has moved since it was closed (0 when not closed). It is
+	// deliberately local to this month — the chain is spliced at the latest
+	// snapshot BEFORE it — so drift stays additive per month instead of each
+	// month inheriting its predecessors'.
+	DriftMinutes int `json:"drift_minutes"`
+	// CarryInFrozen reports that CarryInMinutes came from a frozen month
+	// instead of being summed from the account start; CarryInFrozenFromMonth
+	// names that month ("2026-08"). This is what explains a visible gap
+	// between the previous month's displayed closing balance and this
+	// month's carry-in: the gap is exactly that month's DriftMinutes.
+	CarryInFrozen          bool    `json:"carry_in_frozen"`
+	CarryInFrozenFromMonth *string `json:"carry_in_frozen_from_month,omitempty"`
 }
 
 // WorkTimeMonthService owns the Monatskarte math. It lives outside
@@ -65,6 +90,12 @@ type MonthSummary struct {
 // with its own dependency set.
 type WorkTimeMonthService interface {
 	GetMonthSummary(ctx context.Context, staffID int64, year, month int) (*MonthSummary, error)
+	// GetMonthSummaryAtMonthEnd pins the clamp to the month's last day instead
+	// of today. The Monatsabschluss (#1417) needs the month's true closing
+	// value: with the clamp at today, a not-yet-finished month would charge the
+	// full Soll against an Ist that stops today. Callers must therefore only
+	// use it for months that are over — StaffMonthCloseService enforces that.
+	GetMonthSummaryAtMonthEnd(ctx context.Context, staffID int64, year, month int) (*MonthSummary, error)
 	// GetClosingBalanceAsOf returns the live carry-chain balance through cutoff.
 	// Unlike GetMonthSummary, it never includes activity later in cutoff's month.
 	GetClosingBalanceAsOf(ctx context.Context, staffID int64, cutoff timezone.Date) (int, error)
@@ -82,6 +113,11 @@ type WorkTimeMonthService interface {
 	// nothing (#1420).
 	GetCompTimeDeductionMinutes(ctx context.Context, staffID int64, start, end timezone.Date, halfDay bool) (int, error)
 	GetDailyTargets(ctx context.Context, staffID int64, from, to timezone.Date) ([]DailyTarget, error)
+	// GetRangeAggregate sums Soll, Ist and balance over an arbitrary closed
+	// range with the same daily arithmetic as the Monatskarte, WITHOUT a carry
+	// (a range is not an account). The week view of the Leitungs-Dashboard
+	// needs it because the chain itself is month-granular (#1417).
+	GetRangeAggregate(ctx context.Context, staffID int64, from, to timezone.Date) (*RangeAggregate, error)
 	// SetHolidayReader injects the public-holiday resolver (#1418 3a) —
 	// wired in the factory after construction, like
 	// WorkSessionService.SetStaffShiftRepo.
@@ -90,6 +126,10 @@ type WorkTimeMonthService interface {
 	// same after-construction wiring; nil keeps the pre-adjustment behavior
 	// so existing unit fixtures stay valid.
 	SetAdjustmentReader(reader monthAdjustmentReader)
+	// SetSnapshotReader injects the frozen-month reader (#1417) — same
+	// after-construction wiring; nil means no month is ever treated as frozen,
+	// so existing unit fixtures stay valid.
+	SetSnapshotReader(reader monthSnapshotReader)
 }
 
 // AdjustmentView is one Stundenkonto transaction as the Monatskarte shows it
@@ -148,6 +188,12 @@ type monthAdjustmentReader interface {
 	GetByStaffAndDateRange(ctx context.Context, staffID int64, from, to timezone.Date) ([]*activeModels.StaffBalanceAdjustment, error)
 }
 
+// monthSnapshotReader is implemented by
+// active.StaffMonthBalanceSnapshotRepository (#1417).
+type monthSnapshotReader interface {
+	GetLatestClosedThrough(ctx context.Context, staffID int64, year, month int) (*activeModels.StaffMonthBalanceSnapshot, error)
+}
+
 // monthStaffReader is implemented by users.StaffRepository.
 type monthStaffReader interface {
 	FindByID(ctx context.Context, id any) (*userModels.Staff, error)
@@ -182,6 +228,7 @@ type workTimeMonthService struct {
 	settings       monthSettingsResolver
 	holidayReader  HolidayDatesReader
 	adjustmentRepo monthAdjustmentReader
+	snapshotRepo   monthSnapshotReader
 	logger         *slog.Logger
 
 	// todayFunc is a test hook; production uses timezone.TodayDate.
@@ -224,6 +271,14 @@ func (s *workTimeMonthService) SetHolidayReader(reader HolidayDatesReader) {
 // so existing unit fixtures stay valid.
 func (s *workTimeMonthService) SetAdjustmentReader(reader monthAdjustmentReader) {
 	s.adjustmentRepo = reader
+}
+
+// SetSnapshotReader wires the frozen-month reader (#1417). A setter like
+// SetAdjustmentReader: nil means no month is ever frozen, so the carry chain
+// behaves exactly as it did before the Monatsabschluss existed and existing
+// unit fixtures stay valid.
+func (s *workTimeMonthService) SetSnapshotReader(reader monthSnapshotReader) {
+	s.snapshotRepo = reader
 }
 
 func (s *workTimeMonthService) today() timezone.Date {
@@ -756,6 +811,52 @@ func (s *workTimeMonthService) GetMonthSummary(ctx context.Context, staffID int6
 	return s.getMonthSummaryThrough(ctx, staffID, key, today)
 }
 
+// GetMonthSummaryAtMonthEnd computes the card with the clamp pinned to the
+// month's last day rather than today (#1417). See the interface doc: only the
+// close path may use it, and only for months that are already over.
+func (s *workTimeMonthService) GetMonthSummaryAtMonthEnd(ctx context.Context, staffID int64, year, month int) (*MonthSummary, error) {
+	if err := validateMonth(year, month); err != nil {
+		return nil, err
+	}
+	key := monthKey{Year: year, Month: month}
+	return s.getMonthSummaryThrough(ctx, staffID, key, key.lastDay())
+}
+
+// GetRangeAggregate sums an arbitrary closed range from the SAME helpers the
+// Monatskarte and the daily table use: GetDailyTargets for the Soll (which
+// brings the account-start exclusion with it), getDailyActualMinutes for the
+// Ist (day cap, now cap, running break), and getDailyBalanceDeltas for the
+// balance (credits, adjustments, target). No new arithmetic, therefore no way
+// for a week total to contradict the month card above it.
+func (s *workTimeMonthService) GetRangeAggregate(ctx context.Context, staffID int64, from, to timezone.Date) (*RangeAggregate, error) {
+	if from.IsZero() || to.IsZero() || to.Before(from) {
+		return nil, errors.New("from and to must form a valid range")
+	}
+	targets, err := s.GetDailyTargets(ctx, staffID, from, to)
+	if err != nil {
+		return nil, err
+	}
+	aggregate := &RangeAggregate{}
+	for _, target := range targets {
+		aggregate.TargetMinutes += target.TargetMinutes
+	}
+	actual, err := s.getDailyActualMinutes(ctx, staffID, from, to)
+	if err != nil {
+		return nil, err
+	}
+	for _, minutes := range actual {
+		aggregate.ActualMinutes += minutes
+	}
+	deltas, err := s.getDailyBalanceDeltas(ctx, staffID, from, to)
+	if err != nil {
+		return nil, err
+	}
+	for _, delta := range deltas {
+		aggregate.BalanceMinutes += delta
+	}
+	return aggregate, nil
+}
+
 // GetClosingBalanceAsOf computes the carry-chain balance at the end of cutoff.
 // It shares all target/session/absence/adjustment math with the Monatskarte, but
 // pins the "today" clamp to cutoff so a historical reset cannot absorb activity
@@ -1030,14 +1131,57 @@ func (s *workTimeMonthService) getMinimumDailyClosingBalance(
 	if err != nil {
 		return 0, err
 	}
+	// A frozen month boundary inside the range RESTARTS the chain at the
+	// frozen closing balance (#1417). Accumulating live deltas straight
+	// across it would report a minimum that is off by that month's drift, and
+	// the payout/comp-time capacity checks in #1420 rely on this number.
+	boundaries, err := s.frozenMonthBoundaries(ctx, staffID, from, to)
+	if err != nil {
+		return 0, err
+	}
 	minimum := int(^uint(0) >> 1)
 	for d := from; !d.After(to); d = d.AddDays(1) {
+		if opening, ok := boundaries[d]; ok {
+			balance = opening
+		}
 		balance += deltas[d]
 		minimum = min(minimum, balance)
 	}
 	return minimum, nil
 }
 
+// frozenMonthBoundaries maps each month-start day inside (from, to] to the
+// frozen closing balance of the preceding month, for the days where the carry
+// chain restarts instead of continuing. `from` itself is never a boundary: the
+// caller already seeded the balance with the closing value before it, which is
+// snapshot-aware via GetClosingBalanceAsOf.
+func (s *workTimeMonthService) frozenMonthBoundaries(
+	ctx context.Context,
+	staffID int64,
+	from, to timezone.Date,
+) (map[timezone.Date]int, error) {
+	boundaries := make(map[timezone.Date]int)
+	if s.snapshotRepo == nil {
+		return boundaries, nil
+	}
+	for k := monthOf(from).next(); !monthOf(to).before(k); k = k.next() {
+		prev := k.addMonths(-1)
+		snapshot, err := s.snapshotRepo.GetLatestClosedThrough(ctx, staffID, prev.Year, prev.Month)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load month balance snapshot for %d-%02d: %w", prev.Year, prev.Month, err)
+		}
+		if snapshot == nil || snapshot.Year != prev.Year || snapshot.Month != prev.Month {
+			continue
+		}
+		boundaries[k.firstDay()] = snapshot.ClosingBalanceMinutes
+	}
+	return boundaries, nil
+}
+
+// getDailyBalanceDeltas is deliberately snapshot-agnostic (#1417): it reports
+// what happened on each day. A frozen month is not a per-day event, so folding
+// it in here would double-count against the boundary reset in
+// getMinimumDailyClosingBalance.
 func (s *workTimeMonthService) getDailyBalanceDeltas(
 	ctx context.Context,
 	staffID int64,
@@ -1227,6 +1371,22 @@ func (s *workTimeMonthService) getMonthSummaryThrough(ctx context.Context, staff
 		startKey, first = key, key.firstDay()
 	}
 
+	// A frozen earlier month (#1417) short-circuits the chain: its closing
+	// balance IS the opening balance here, so nothing before it is re-summed
+	// and a retroactive correction there can no longer move this month.
+	splice, err := s.spliceChainStart(ctx, staffID, key, anchor)
+	if err != nil {
+		return nil, err
+	}
+	carry := 0
+	// Only an EARLIER frozen month shortens the chain. A splice that carries
+	// nothing but the requested month's own snapshot (used for drift) must
+	// leave the chain running from the account start.
+	if splice != nil && splice.carryFrom != nil {
+		startKey, first = splice.startKey, splice.startKey.firstDay()
+		carry = splice.frozenCarry
+	}
+
 	// Bound how far back the chain reaches so a stale/misconfigured account
 	// start can't make each poll aggregate and query decades of days. A
 	// realistic account never predates the floor; when it does, the setting is
@@ -1248,7 +1408,6 @@ func (s *workTimeMonthService) getMonthSummaryThrough(ctx context.Context, staff
 		return nil, err
 	}
 
-	carry := 0
 	for k := startKey; k.before(key); k = k.next() {
 		carry += aggregates[k].balance()
 	}
@@ -1286,7 +1445,95 @@ func (s *workTimeMonthService) getMonthSummaryThrough(ctx context.Context, staff
 		})
 	}
 	summary.ClosingBalanceMinutes = summary.CarryInMinutes + summary.BalanceMinutes
+	if splice != nil {
+		if splice.carryFrom != nil {
+			summary.CarryInFrozen = true
+			label := fmt.Sprintf("%04d-%02d", splice.carryFrom.Year, splice.carryFrom.Month)
+			summary.CarryInFrozenFromMonth = &label
+		}
+		if own := splice.ownSnapshot; own != nil {
+			summary.IsClosed = true
+			closedAt, closedBy := own.ClosedAt, own.ClosedBy
+			summary.ClosedAt, summary.ClosedBy = &closedAt, &closedBy
+			summary.CloseReason = own.CloseReason
+			frozen := own.ClosingBalanceMinutes
+			summary.FrozenClosingBalanceMinutes = &frozen
+			summary.DriftMinutes = summary.ClosingBalanceMinutes - frozen
+		}
+	}
 	return summary, nil
+}
+
+// chainSplice is the outcome of the frozen-month lookup for one requested
+// month: where the carry chain starts, what it starts with, and whether the
+// requested month is itself frozen.
+type chainSplice struct {
+	// startKey is the first month the chain must still aggregate.
+	startKey monthKey
+	// frozenCarry is the opening balance for startKey.
+	frozenCarry int
+	// carryFrom names the frozen month that produced frozenCarry; nil when no
+	// earlier month is frozen and the chain runs from the account start.
+	carryFrom *monthKey
+	// ownSnapshot is the requested month's own active snapshot, if it is
+	// closed. It supplies the drift comparison, never the carry.
+	ownSnapshot *activeModels.StaffMonthBalanceSnapshot
+}
+
+// spliceChainStart resolves how the carry chain for `key` must start (#1417).
+// It returns nil when nothing is frozen and the caller should keep the
+// account-anchor chain untouched.
+//
+// One read covers both questions: the newest active snapshot at or before
+// `key` is either `key`'s own (then a second read finds the one before it) or
+// already an earlier month (then it seeds the chain directly).
+//
+// A snapshot before the anchor month is ignored on purpose. The chain never
+// starts before the account start, so such a row — left behind by a later
+// change to the account-start setting — could only corrupt the card. The
+// close path rejects creating one; this is the read-side half of that fence.
+func (s *workTimeMonthService) spliceChainStart(
+	ctx context.Context,
+	staffID int64,
+	key monthKey,
+	anchor timezone.Date,
+) (*chainSplice, error) {
+	if s.snapshotRepo == nil {
+		return nil, nil
+	}
+	anchorKey := monthOf(anchor)
+
+	latest, err := s.snapshotRepo.GetLatestClosedThrough(ctx, staffID, key.Year, key.Month)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load month balance snapshot: %w", err)
+	}
+	if latest == nil {
+		return nil, nil
+	}
+
+	splice := &chainSplice{startKey: key}
+	seed := latest
+	if latest.Year == key.Year && latest.Month == key.Month {
+		splice.ownSnapshot = latest
+		prev := key.addMonths(-1)
+		seed, err = s.snapshotRepo.GetLatestClosedThrough(ctx, staffID, prev.Year, prev.Month)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load preceding month balance snapshot: %w", err)
+		}
+	}
+
+	if seed != nil {
+		seedKey := monthKey{Year: seed.Year, Month: seed.Month}
+		if !seedKey.before(anchorKey) && seedKey.before(key) {
+			splice.startKey = seedKey.next()
+			splice.frozenCarry = seed.ClosingBalanceMinutes
+			splice.carryFrom = &seedKey
+		}
+	}
+	if splice.carryFrom == nil && splice.ownSnapshot == nil {
+		return nil, nil
+	}
+	return splice, nil
 }
 
 // excludedByAccountStart reports whether d is inside the account-start month

--- a/backend/services/active/work_time_month_service_mock_test.go
+++ b/backend/services/active/work_time_month_service_mock_test.go
@@ -580,6 +580,24 @@ func TestWTMDailyTargets_SumMatchesCardForMidMonthStart(t *testing.T) {
 	assert.Equal(t, 3*480, sum, "Mondays from the start day on: Jul 13, 20, 27")
 }
 
+func TestWTMRangeAggregate_ZeroesBalanceBeforeMidWeekAccountStart(t *testing.T) {
+	f := newWTMFixture()
+	f.settings.accountStart = "2026-07-08"
+
+	aggregate, err := f.svc.GetRangeAggregate(
+		context.Background(),
+		wtmStaffID,
+		timezone.NewDate(2026, time.July, 6),
+		timezone.NewDate(2026, time.July, 12),
+	)
+	require.NoError(t, err)
+
+	assert.Zero(t, aggregate.TargetMinutes,
+		"the Monday before the Wednesday account start carries no Soll")
+	assert.Zero(t, aggregate.BalanceMinutes,
+		"a day excluded from Soll must also be excluded from the balance delta")
+}
+
 // An unset account start must not zero anything: chainAnchor then falls back to
 // January 1st, and no day can precede January 1st of its own year.
 func TestWTMDailyTargets_UnsetAccountStartZeroesNothing(t *testing.T) {

--- a/backend/services/active/work_time_month_service_mock_test.go
+++ b/backend/services/active/work_time_month_service_mock_test.go
@@ -620,6 +620,27 @@ func TestWTMRangeAggregate_ExcludesActualBeforeMidWeekAccountStart(t *testing.T)
 		"the displayed Ist and balance cover the same account-start range")
 }
 
+func TestWTMRangeAggregate_ExcludesPreviousMonthBeforeAccountStart(t *testing.T) {
+	f := newWTMFixture()
+	f.settings.accountStart = "2026-07-01"
+	f.sessions.sessions = []*activeModels.WorkSession{
+		wtmSession(timezone.NewDate(2026, time.June, 29), 8, 60, 0),
+		wtmSession(timezone.NewDate(2026, time.July, 1), 8, 120, 0),
+	}
+
+	aggregate, err := f.svc.GetRangeAggregate(
+		context.Background(),
+		wtmStaffID,
+		timezone.NewDate(2026, time.June, 29),
+		timezone.NewDate(2026, time.July, 5),
+	)
+	require.NoError(t, err)
+
+	assert.Zero(t, aggregate.TargetMinutes, "the Monday before the account start carries no Soll")
+	assert.Equal(t, 120, aggregate.ActualMinutes, "only work on or after the account start counts")
+	assert.Equal(t, 120, aggregate.BalanceMinutes, "the weekly delta starts at the account anchor")
+}
+
 // An unset account start must not zero anything: chainAnchor then falls back to
 // January 1st, and no day can precede January 1st of its own year.
 func TestWTMDailyTargets_UnsetAccountStartZeroesNothing(t *testing.T) {

--- a/backend/services/active/work_time_month_service_mock_test.go
+++ b/backend/services/active/work_time_month_service_mock_test.go
@@ -598,6 +598,28 @@ func TestWTMRangeAggregate_ZeroesBalanceBeforeMidWeekAccountStart(t *testing.T) 
 		"a day excluded from Soll must also be excluded from the balance delta")
 }
 
+func TestWTMRangeAggregate_ExcludesActualBeforeMidWeekAccountStart(t *testing.T) {
+	f := newWTMFixture()
+	f.settings.accountStart = "2026-07-08"
+	f.sessions.sessions = []*activeModels.WorkSession{
+		wtmSession(timezone.NewDate(2026, time.July, 6), 8, 480, 0),
+		wtmSession(timezone.NewDate(2026, time.July, 8), 8, 120, 0),
+	}
+
+	aggregate, err := f.svc.GetRangeAggregate(
+		context.Background(),
+		wtmStaffID,
+		timezone.NewDate(2026, time.July, 6),
+		timezone.NewDate(2026, time.July, 12),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 120, aggregate.ActualMinutes,
+		"only work on or after the Wednesday account start counts")
+	assert.Equal(t, 120, aggregate.BalanceMinutes,
+		"the displayed Ist and balance cover the same account-start range")
+}
+
 // An unset account start must not zero anything: chainAnchor then falls back to
 // January 1st, and no day can precede January 1st of its own year.
 func TestWTMDailyTargets_UnsetAccountStartZeroesNothing(t *testing.T) {

--- a/backend/services/active/work_time_month_service_mock_test.go
+++ b/backend/services/active/work_time_month_service_mock_test.go
@@ -641,6 +641,28 @@ func TestWTMRangeAggregate_ExcludesPreviousMonthBeforeAccountStart(t *testing.T)
 	assert.Equal(t, 120, aggregate.BalanceMinutes, "the weekly delta starts at the account anchor")
 }
 
+func TestPrefetchedMonthService_FiltersSessionsToRequestedRange(t *testing.T) {
+	accountStart := timezone.NewDate(2026, time.July, 8)
+	prefetch := &monthPrefetch{
+		staff: map[int64]*userModels.Staff{
+			wtmStaffID: {Model: base.Model{ID: wtmStaffID}},
+		},
+		sessions: map[int64][]*activeModels.WorkSession{
+			wtmStaffID: {
+				wtmSession(accountStart.AddDays(-2), 8, 60, 0),
+				wtmSession(accountStart, 8, 120, 0),
+			},
+		},
+		settings: newMemoSettingsResolver(&wtmMockSettings{accountStart: accountStart.String()}),
+	}
+	svc := newPrefetchedMonthService(prefetch, nil)
+
+	summary, err := svc.GetMonthSummaryAtMonthEnd(context.Background(), wtmStaffID, 2026, 7)
+	require.NoError(t, err)
+	assert.Equal(t, 120, summary.ActualMinutes,
+		"the prefetched session before the account start must not enter the month bucket")
+}
+
 // An unset account start must not zero anything: chainAnchor then falls back to
 // January 1st, and no day can precede January 1st of its own year.
 func TestWTMDailyTargets_UnsetAccountStartZeroesNothing(t *testing.T) {

--- a/backend/services/active/work_time_month_service_mock_test.go
+++ b/backend/services/active/work_time_month_service_mock_test.go
@@ -641,6 +641,26 @@ func TestWTMRangeAggregate_ExcludesPreviousMonthBeforeAccountStart(t *testing.T)
 	assert.Equal(t, 120, aggregate.BalanceMinutes, "the weekly delta starts at the account anchor")
 }
 
+func TestWTMRangeAggregate_UnsetAccountStartUsesPeriodEndYear(t *testing.T) {
+	f := newWTMFixture()
+	f.settings.accountStart = ""
+	f.sessions.sessions = []*activeModels.WorkSession{
+		wtmSession(timezone.NewDate(2025, time.December, 29), 8, 120, 0),
+	}
+
+	aggregate, err := f.svc.GetRangeAggregate(
+		context.Background(),
+		wtmStaffID,
+		timezone.NewDate(2025, time.December, 29),
+		timezone.NewDate(2026, time.January, 4),
+	)
+	require.NoError(t, err)
+
+	assert.Zero(t, aggregate.TargetMinutes, "the default account starts on January 1 of the period-end year")
+	assert.Zero(t, aggregate.ActualMinutes, "December work before that default account start is excluded")
+	assert.Zero(t, aggregate.BalanceMinutes, "the ISO week aggregate starts with the new account year")
+}
+
 func TestPrefetchedMonthService_FiltersSessionsToRequestedRange(t *testing.T) {
 	accountStart := timezone.NewDate(2026, time.July, 8)
 	prefetch := &monthPrefetch{

--- a/backend/services/active/work_time_month_snapshot_test.go
+++ b/backend/services/active/work_time_month_snapshot_test.go
@@ -300,6 +300,32 @@ func TestMonthClose_IsIdempotent(t *testing.T) {
 	assert.Equal(t, first.ClosedStaff, second.SkippedStaff)
 }
 
+// TestMonthClose_RejectsCloseBehindLaterSnapshot prevents a newly frozen older
+// month from contradicting the history used by an already frozen later month.
+func TestMonthClose_RejectsCloseBehindLaterSnapshot(t *testing.T) {
+	f := newSnapshotFixture(t)
+
+	_, err := f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotNextMonth, "Abschluss September")
+	require.NoError(t, err)
+
+	_, err = f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotMonth, "Abschluss August")
+	require.ErrorIs(t, err, active.ErrLaterMonthClosed)
+}
+
+func TestMonthClose_RetryBehindLaterSnapshotRemainsIdempotent(t *testing.T) {
+	f := newSnapshotFixture(t)
+
+	_, err := f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotMonth, "Abschluss August")
+	require.NoError(t, err)
+	_, err = f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotNextMonth, "Abschluss September")
+	require.NoError(t, err)
+
+	result, err := f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotMonth, "Abschluss August")
+	require.NoError(t, err)
+	assert.Zero(t, result.ClosedStaff)
+	assert.Equal(t, 2, result.SkippedStaff)
+}
+
 // TestMonthClose_RejectsAdjustmentInClosedMonth — a booking inside a frozen
 // month could not move its closing balance, so the ledger refuses it. Work
 // sessions stay editable on purpose; that difference is what drift is for.

--- a/backend/services/active/work_time_month_snapshot_test.go
+++ b/backend/services/active/work_time_month_snapshot_test.go
@@ -1,0 +1,345 @@
+package active_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	configModels "github.com/moto-nrw/project-phoenix/models/config"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	active "github.com/moto-nrw/project-phoenix/services/active"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// snapshotFixture is the shared arrangement for the Monatsabschluss tests:
+// one staff member with a Mondays-480 contract, one full August 2025 session,
+// plus an admin who performs the close.
+//
+// The dates are deliberately in the past. todayFunc is unexported, so this
+// external test package runs against the real calendar: a future month would
+// hit the Soll clamp at today and the close guard would (correctly) refuse.
+type snapshotFixture struct {
+	tenantID  int64
+	staff     *userModels.Staff
+	admin     *userModels.Staff
+	session   *activeModels.WorkSession
+	schedule  *configModels.StaffWorkSchedule
+	repos     *repositories.Factory
+	db        *bun.DB
+	ctx       context.Context
+	monthSvc  active.WorkTimeMonthService
+	closeSvc  active.StaffMonthCloseService
+	adjustSvc active.StaffBalanceAdjustmentService
+}
+
+// snapshotSessionSettings satisfies the work-session service's settings
+// surface; the snapshot tests exercise no setting-driven behaviour.
+type snapshotSessionSettings struct{}
+
+func (snapshotSessionSettings) ResolveBool(context.Context, string) (bool, error) { return false, nil }
+func (snapshotSessionSettings) ResolveInt(context.Context, string) (int, error)   { return 0, nil }
+
+// newAdminSessionService builds the admin correction path used to mutate a
+// closed month, wired exactly as services/factory.go does.
+func (f *snapshotFixture) newAdminSessionService() active.WorkSessionService {
+	return active.NewWorkSessionService(
+		f.repos.WorkSession, f.repos.WorkSessionBreak, f.repos.WorkSessionEdit, f.repos.StaffAbsence,
+		f.repos.GroupSupervisor, f.repos.Staff, f.repos.StaffWorkSchedule, f.repos.WorkTimeModel,
+		snapshotSessionSettings{}, nil,
+	)
+}
+
+const (
+	snapshotYear       = 2025
+	snapshotMonth      = 8 // August 2025
+	snapshotNextMonth  = 9
+	snapshotSessionDay = 4 // Monday, 2025-08-04
+)
+
+func newSnapshotFixture(t *testing.T) *snapshotFixture {
+	t.Helper()
+
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Abschluss", "Mitarbeiter")
+	admin := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Abschluss", "Leitung")
+	repos := repositories.NewFactory(db)
+	ctx := testpkg.TenantContext(tenantID)
+
+	t.Cleanup(func() {
+		for _, table := range []string{
+			"active.staff_month_balance_snapshots",
+			"active.staff_balance_adjustments",
+			"audit.work_session_edits",
+			"active.staff_absences",
+			"active.work_sessions",
+			"config.staff_work_schedules",
+		} {
+			_, _ = db.NewDelete().ModelTableExpr(table+" AS t").Where("t.tenant_id = ?", tenantID).Exec(context.Background())
+		}
+		testpkg.CleanupStaffFixtures(t, db, staff.ID, admin.ID)
+		testpkg.CleanupTenantTestData(t, db, tenantID)
+	})
+
+	// Contract: Mondays 480 minutes.
+	schedule := &configModels.StaffWorkSchedule{
+		TenantID:      tenantID,
+		StaffID:       staff.ID,
+		DayOfWeek:     configModels.DayMonday,
+		TargetMinutes: 480,
+		WeekIndex:     0, RotationLength: 1,
+		ValidFrom: timezone.NewDate(2020, time.January, 1),
+	}
+	_, err := db.NewInsert().Model(schedule).ModelTableExpr("config.staff_work_schedules").Exec(ctx)
+	require.NoError(t, err)
+
+	checkIn := time.Date(snapshotYear, time.August, snapshotSessionDay, 8, 0, 0, 0, time.UTC)
+	checkOut := checkIn.Add(8 * time.Hour)
+	session := &activeModels.WorkSession{
+		StaffID:     staff.ID,
+		Date:        timezone.NewDate(snapshotYear, time.August, snapshotSessionDay),
+		Status:      activeModels.WorkSessionStatusPresent,
+		Source:      activeModels.WorkSessionSourceApp,
+		CheckInTime: checkIn, CheckOutTime: &checkOut,
+		CreatedBy: staff.ID,
+	}
+	session.SetTenantID(tenantID)
+	require.NoError(t, repos.WorkSession.Create(ctx, session))
+
+	settings := wtmIntSettings{accountStart: "2025-01-01"}
+	monthSvc := active.NewWorkTimeMonthService(
+		repos.WorkSession, repos.WorkSessionBreak, repos.StaffAbsence, repos.Staff,
+		repos.StaffWorkSchedule, repos.WorkTimeModel, repos.StaffShift,
+		settings, nil,
+	)
+	monthSvc.SetSnapshotReader(repos.StaffMonthSnapshot)
+	monthSvc.SetAdjustmentReader(repos.StaffBalanceAdjust)
+
+	closeSvc := active.NewStaffMonthCloseService(
+		repos.StaffMonthSnapshot, monthSvc, repos.Staff, settings, nil,
+	)
+	adjustSvc := active.NewStaffBalanceAdjustmentService(
+		repos.StaffBalanceAdjust, monthSvc, settings, nil,
+	)
+	adjustSvc.SetSnapshotReader(repos.StaffMonthSnapshot)
+
+	return &snapshotFixture{
+		tenantID: tenantID, staff: staff, admin: admin,
+		session: session, schedule: schedule, repos: repos, db: db, ctx: ctx,
+		monthSvc: monthSvc, closeSvc: closeSvc, adjustSvc: adjustSvc,
+	}
+}
+
+// TestMonthClose_FreezesBalanceAgainstRetroactiveSessionEdit is the acceptance
+// scenario for #1417: a closed month, then a session inside it corrected
+// afterwards. The frozen closing balance and every later carry must stay put,
+// and the divergence must be reported as drift rather than swallowed.
+func TestMonthClose_FreezesBalanceAgainstRetroactiveSessionEdit(t *testing.T) {
+	f := newSnapshotFixture(t)
+
+	augustBefore, err := f.monthSvc.GetMonthSummary(f.ctx, f.staff.ID, snapshotYear, snapshotMonth)
+	require.NoError(t, err)
+	require.Equal(t, 480, augustBefore.ActualMinutes)
+
+	septemberCarryBefore, err := f.monthSvc.GetMonthSummary(f.ctx, f.staff.ID, snapshotYear, snapshotNextMonth)
+	require.NoError(t, err)
+	balanceBefore, err := f.monthSvc.GetClosingBalanceAsOf(f.ctx, f.staff.ID, timezone.TodayDate())
+	require.NoError(t, err)
+
+	result, err := f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotMonth, "Monatsabschluss August")
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.ClosedStaff, "close is school-wide: staff member and admin both get a row")
+	assert.Equal(t, 0, result.SkippedStaff)
+
+	var frozen *activeModels.StaffMonthBalanceSnapshot
+	for _, snapshot := range result.Snapshots {
+		if snapshot.StaffID == f.staff.ID {
+			frozen = snapshot
+		}
+	}
+	require.NotNil(t, frozen)
+	assert.Equal(t, augustBefore.ClosingBalanceMinutes, frozen.ClosingBalanceMinutes)
+
+	// Retroactive correction through the admin path: check out two hours
+	// earlier, so August loses 120 minutes.
+	workSessionSvc := f.newAdminSessionService()
+	earlierCheckOut := f.session.CheckInTime.Add(6 * time.Hour)
+	notes := "Korrektur: zwei Stunden früher gegangen"
+	_, err = workSessionSvc.UpdateSessionAsAdmin(f.ctx, f.admin.ID, f.staff.ID, f.session.ID, active.SessionUpdateRequest{
+		CheckOutTime: &earlierCheckOut,
+		Notes:        &notes,
+	})
+	require.NoError(t, err)
+
+	// The frozen month still reports its OWN live numbers...
+	augustAfter, err := f.monthSvc.GetMonthSummary(f.ctx, f.staff.ID, snapshotYear, snapshotMonth)
+	require.NoError(t, err)
+	assert.Equal(t, 360, augustAfter.ActualMinutes, "the correction is visible in the month itself")
+	assert.True(t, augustAfter.IsClosed)
+	require.NotNil(t, augustAfter.FrozenClosingBalanceMinutes)
+	assert.Equal(t, augustBefore.ClosingBalanceMinutes, *augustAfter.FrozenClosingBalanceMinutes)
+	assert.Equal(t, -120, augustAfter.DriftMinutes, "drift reports the divergence instead of hiding it")
+
+	// ...but nothing after it moves.
+	septemberAfter, err := f.monthSvc.GetMonthSummary(f.ctx, f.staff.ID, snapshotYear, snapshotNextMonth)
+	require.NoError(t, err)
+	assert.Equal(t, septemberCarryBefore.CarryInMinutes, septemberAfter.CarryInMinutes,
+		"September's Übertrag comes from the frozen value, not from re-summing August")
+	assert.True(t, septemberAfter.CarryInFrozen)
+	require.NotNil(t, septemberAfter.CarryInFrozenFromMonth)
+	assert.Equal(t, "2025-08", *septemberAfter.CarryInFrozenFromMonth)
+
+	balanceAfter, err := f.monthSvc.GetClosingBalanceAsOf(f.ctx, f.staff.ID, timezone.TodayDate())
+	require.NoError(t, err)
+	assert.Equal(t, balanceBefore, balanceAfter, "the current Stundenkonto is unchanged")
+}
+
+// TestMonthClose_FreezesBalanceAgainstRetroactiveScheduleChange is the case the
+// issue names literally ("Schutz gegen Schedule-Wechsel-Historie"): changing
+// the contractual Soll of a past month must not move a closed balance.
+func TestMonthClose_FreezesBalanceAgainstRetroactiveScheduleChange(t *testing.T) {
+	f := newSnapshotFixture(t)
+
+	septemberBefore, err := f.monthSvc.GetMonthSummary(f.ctx, f.staff.ID, snapshotYear, snapshotNextMonth)
+	require.NoError(t, err)
+
+	_, err = f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotMonth, "Monatsabschluss August")
+	require.NoError(t, err)
+
+	// Retroactively halve the contractual Soll of every Monday.
+	_, err = f.db.NewUpdate().
+		Model((*configModels.StaffWorkSchedule)(nil)).
+		ModelTableExpr("config.staff_work_schedules AS t").
+		Set("target_minutes = ?", 240).
+		Where("t.id = ?", f.schedule.ID).
+		Exec(f.ctx)
+	require.NoError(t, err)
+
+	augustAfter, err := f.monthSvc.GetMonthSummary(f.ctx, f.staff.ID, snapshotYear, snapshotMonth)
+	require.NoError(t, err)
+	assert.NotZero(t, augustAfter.DriftMinutes, "the Soll change shows up as drift")
+
+	septemberAfter, err := f.monthSvc.GetMonthSummary(f.ctx, f.staff.ID, snapshotYear, snapshotNextMonth)
+	require.NoError(t, err)
+	assert.Equal(t, septemberBefore.CarryInMinutes, septemberAfter.CarryInMinutes,
+		"a retroactive Dienstplan change must not move a closed month's Übertrag")
+}
+
+// TestMonthClose_ReopenRestoresLiveChain proves the reopen path: the escape
+// hatch for a legitimate correction after the freeze.
+func TestMonthClose_ReopenRestoresLiveChain(t *testing.T) {
+	f := newSnapshotFixture(t)
+
+	septemberBefore, err := f.monthSvc.GetMonthSummary(f.ctx, f.staff.ID, snapshotYear, snapshotNextMonth)
+	require.NoError(t, err)
+
+	_, err = f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotMonth, "Monatsabschluss August")
+	require.NoError(t, err)
+
+	workSessionSvc := f.newAdminSessionService()
+	earlierCheckOut := f.session.CheckInTime.Add(6 * time.Hour)
+	notes := "Korrektur: zwei Stunden früher gegangen"
+	_, err = workSessionSvc.UpdateSessionAsAdmin(f.ctx, f.admin.ID, f.staff.ID, f.session.ID, active.SessionUpdateRequest{
+		CheckOutTime: &earlierCheckOut,
+		Notes:        &notes,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, f.closeSvc.ReopenMonth(f.ctx, f.staff.ID, f.admin.ID, snapshotYear, snapshotMonth, "Korrektur nachgetragen"))
+
+	septemberAfter, err := f.monthSvc.GetMonthSummary(f.ctx, f.staff.ID, snapshotYear, snapshotNextMonth)
+	require.NoError(t, err)
+	assert.Equal(t, septemberBefore.CarryInMinutes-120, septemberAfter.CarryInMinutes,
+		"after reopening, the correction flows through again")
+	assert.False(t, septemberAfter.CarryInFrozen)
+
+	augustAfter, err := f.monthSvc.GetMonthSummary(f.ctx, f.staff.ID, snapshotYear, snapshotMonth)
+	require.NoError(t, err)
+	assert.False(t, augustAfter.IsClosed)
+	assert.Zero(t, augustAfter.DriftMinutes)
+}
+
+// TestMonthClose_RejectsUnfinishedMonth pins the most important guard: freezing
+// a month that is not over would charge its full Soll against an Ist that stops
+// today, and that error would carry forward forever.
+func TestMonthClose_RejectsUnfinishedMonth(t *testing.T) {
+	f := newSnapshotFixture(t)
+	today := timezone.TodayDate()
+
+	_, err := f.closeSvc.CloseMonth(f.ctx, f.admin.ID, today.Year, int(today.Month), "zu früh")
+	require.ErrorIs(t, err, active.ErrMonthNotClosable)
+}
+
+// TestMonthClose_RejectsMissingReason keeps freezing attributable.
+func TestMonthClose_RejectsMissingReason(t *testing.T) {
+	f := newSnapshotFixture(t)
+
+	_, err := f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotMonth, "   ")
+	require.ErrorIs(t, err, active.ErrMonthCloseInvalid)
+}
+
+// TestMonthClose_IsIdempotent — a second click must skip, not double-write.
+func TestMonthClose_IsIdempotent(t *testing.T) {
+	f := newSnapshotFixture(t)
+
+	first, err := f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotMonth, "Abschluss")
+	require.NoError(t, err)
+	second, err := f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotMonth, "Abschluss")
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, second.ClosedStaff)
+	assert.Equal(t, first.ClosedStaff, second.SkippedStaff)
+}
+
+// TestMonthClose_RejectsAdjustmentInClosedMonth — a booking inside a frozen
+// month could not move its closing balance, so the ledger refuses it. Work
+// sessions stay editable on purpose; that difference is what drift is for.
+func TestMonthClose_RejectsAdjustmentInClosedMonth(t *testing.T) {
+	f := newSnapshotFixture(t)
+
+	_, err := f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotMonth, "Abschluss")
+	require.NoError(t, err)
+
+	_, err = f.adjustSvc.CreateAdjustment(f.ctx, f.staff.ID, f.admin.ID, active.CreateBalanceAdjustmentRequest{
+		Type:          activeModels.BalanceAdjustmentTypePayout,
+		MinutesDelta:  -60,
+		EffectiveDate: timezone.NewDate(snapshotYear, time.August, 20),
+		Note:          "Auszahlung im abgeschlossenen Monat",
+	})
+	require.ErrorIs(t, err, active.ErrAdjustmentInvalid)
+}
+
+// TestMonthClose_ReopenRequiresNewestFirst — reopening an older month while a
+// later one stays frozen would leave a state no admin can reason about.
+func TestMonthClose_ReopenRequiresNewestFirst(t *testing.T) {
+	f := newSnapshotFixture(t)
+
+	_, err := f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotMonth, "Abschluss August")
+	require.NoError(t, err)
+	_, err = f.closeSvc.CloseMonth(f.ctx, f.admin.ID, snapshotYear, snapshotNextMonth, "Abschluss September")
+	require.NoError(t, err)
+
+	err = f.closeSvc.ReopenMonth(f.ctx, f.staff.ID, f.admin.ID, snapshotYear, snapshotMonth, "Korrektur")
+	require.ErrorIs(t, err, active.ErrLaterMonthClosed)
+
+	// Newest first works.
+	require.NoError(t, f.closeSvc.ReopenMonth(f.ctx, f.staff.ID, f.admin.ID, snapshotYear, snapshotNextMonth, "Korrektur"))
+	require.NoError(t, f.closeSvc.ReopenMonth(f.ctx, f.staff.ID, f.admin.ID, snapshotYear, snapshotMonth, "Korrektur"))
+}
+
+// TestMonthClose_ReopenUnclosedMonthIsNotFound guards the 404 path.
+func TestMonthClose_ReopenUnclosedMonthIsNotFound(t *testing.T) {
+	f := newSnapshotFixture(t)
+
+	err := f.closeSvc.ReopenMonth(f.ctx, f.staff.ID, f.admin.ID, snapshotYear, snapshotMonth, "Korrektur")
+	require.ErrorIs(t, err, active.ErrMonthNotClosed)
+}

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -68,6 +68,8 @@ type Factory struct {
 	ClosingDays              schedule.ClosingDayService
 	StaffAbsence             active.StaffAbsenceService
 	StaffBalanceAdjust       active.StaffBalanceAdjustmentService
+	StaffMonthClose          active.StaffMonthCloseService
+	StaffOverview            active.StaffOverviewService
 	Activities               activities.ActivityService
 	Education                education.Service
 	GradeTransition          *education.GradeTransitionService
@@ -372,6 +374,9 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	workTimeMonthService.SetHolidayReader(nonWorkingDayService)
 	// Stundenkonto transactions (#1420) enter the carry chain by effective date.
 	workTimeMonthService.SetAdjustmentReader(repos.StaffBalanceAdjust)
+	// Frozen months (#1417) short-circuit the carry chain so a retroactive
+	// correction can no longer rewrite a closed month's Übertrag.
+	workTimeMonthService.SetSnapshotReader(repos.StaffMonthSnapshot)
 	// The session service's weekly summaries reduce their Soll by holidays
 	// too. The setter is not part of the WorkSessionService interface (it
 	// would break external mocks), hence the assertion.
@@ -387,6 +392,38 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	// Stundenkonto lifecycle transactions (#1420): payout, comp-time grants,
 	// school-year reset. Reads the live balance through the month service.
 	staffBalanceAdjustService := active.NewStaffBalanceAdjustmentService(repos.StaffBalanceAdjust, workTimeMonthService, settingsService, activeLogger)
+	// A booking inside a closed month (#1417) could not move its frozen
+	// closing balance, so the ledger rejects it.
+	staffBalanceAdjustService.SetSnapshotReader(repos.StaffMonthSnapshot)
+
+	// Monatsabschluss (#1417): freezes a month's closing balance so a
+	// retroactive correction can no longer rewrite every later Übertrag.
+	staffMonthCloseService := active.NewStaffMonthCloseService(
+		repos.StaffMonthSnapshot,
+		workTimeMonthService,
+		repos.Staff,
+		settingsService,
+		activeLogger,
+	)
+
+	// Tenant-wide time-tracking views (#1417 2a). Prefetches all inputs once
+	// and runs the SAME per-staff month math over in-memory readers, so the
+	// list can never drift from the /staff/{id} detail view.
+	staffOverviewService := active.NewStaffOverviewService(
+		repos.Staff,
+		repos.WorkSession,
+		repos.WorkSessionBreak,
+		repos.StaffAbsence,
+		repos.StaffBalanceAdjust,
+		repos.StaffVacationQuota,
+		repos.StaffMonthSnapshot,
+		repos.StaffWorkSchedule,
+		repos.WorkTimeModel,
+		repos.StaffShift,
+		settingsService,
+		activeLogger,
+	)
+	staffOverviewService.SetHolidayReader(nonWorkingDayService)
 
 	// Absence email notifications (#1419 4d). Setter injection keeps the
 	// constructor stable and unit tests email-free (mirrors SetShiftPlanSyncer);
@@ -1572,6 +1609,8 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		ClosingDays:              closingDayService,
 		StaffAbsence:             staffAbsenceService,
 		StaffBalanceAdjust:       staffBalanceAdjustService,
+		StaffMonthClose:          staffMonthCloseService,
+		StaffOverview:            staffOverviewService,
 		Activities:               activitiesService,
 		Education:                educationService,
 		GradeTransition:          gradeTransitionService,

--- a/backend/services/schedule/staff_shift_service_mock_test.go
+++ b/backend/services/schedule/staff_shift_service_mock_test.go
@@ -70,6 +70,11 @@ func (m *shiftMockRepo) FindByDateRange(ctx context.Context, start, end timezone
 	return nil, nil
 }
 
+// FindByStaffIDsAndDateRange satisfies the batched interface method (#1417).
+func (m *shiftMockRepo) FindByStaffIDsAndDateRange(context.Context, []int64, timezone.Date, timezone.Date) (map[int64][]*scheduleModels.StaffShift, error) {
+	return nil, nil
+}
+
 func (m *shiftMockRepo) FindByStaffAndDateRange(ctx context.Context, staffID int64, start, end timezone.Date) ([]*scheduleModels.StaffShift, error) {
 	if m.findByStaffAndDateRangeFunc != nil {
 		return m.findByStaffAndDateRangeFunc(ctx, staffID, start, end)


### PR DESCRIPTION
Teil von #1417 (Tranche 2a). Backend-only.

## Problem 1 — keine tenantweite Sicht

Jede Zeiterfassungs-Route unter `api/staff` war `/{id}/...`. Für Soll/Ist/Saldo/Resturlaub über alle Mitarbeitenden hätte das Frontend N Requests pro Person feuern müssen.

Neu:

```
GET /api/staff/dashboard-summary?period=week|month     users:read
GET /api/staff/time-tracking/overview                  time_tracking:manage
```

**Die Rechenlogik wird wiederverwendet, nicht nachgebaut.** `workTimeMonthService` hängt an acht schmalen Reader-Interfaces, die alle `staffID` als Parameter nehmen. Der neue `StaffOverviewService` lädt jede Eingabe einmal per `IN`-Query und lässt den **unveränderten** Monats-Service über In-Memory-Adapter laufen (`work_time_month_prefetch.go`, null Arithmetik in der Datei). Ergebnis: Query-Zahl konstant in der Anzahl Mitarbeitender, und die Liste kann per Konstruktion nicht von der Detailansicht abweichen.

Das trägt, weil der Kontostart-Anker ein **tenantweites** Setting ist: das Prefetch-Fenster ist für alle Mitarbeitenden identisch. Zwei Tests sichern das ab — `TestStaffOverview_PrefetchWindowIsTenantWide` und ein Query-Count-Test, der bei 1 und bei 8 Personen dieselbe Zahl fordert. Letzterer hat während der Entwicklung sofort angeschlagen, als der Snapshot-Reader noch pro Person lief.

Nicht prefetchbar ist nur `GetActiveBySessionID` (Key ist die Session-ID), das läuft zweiphasig und nur für offene Sessions.

### Permission bewusst strenger als im Issue

Das Issue nennt `users:read` für die Aggregation. Die **Liste mit Soll/Ist/Saldo pro Person** ist damit gegated auf `time_tracking:manage`: `users:read` hat jeder, der die Mitarbeiterliste sehen darf, und hier geht es um Arbeitszeitdaten identifizierbarer Personen. Die aggregierten KPI-Karten bleiben bei `users:read`.

### Definitionen, die nicht offensichtlich sind

- `delta_minutes` = Summe der Monatssaldi (`actual + credited + adjustments − target_to_date`), bewusst **nicht** `ist − soll`. Krank und Urlaub gutschreiben ist die ganze Ansatz-B-Prämisse; ein anders gerechnetes Dashboard-Delta wäre genau die Drift, die diese Tranche verhindern soll.
- `saldo_school_total_minutes` ist ein Kontostand, kein Periodenwert, und deshalb für `week` und `month` identisch.
- `sick_today` und `vacation_today` doppeln niemanden: die Absence-Map behält pro Person einen Typ nach Priorität (krank > Fortbildung > Urlaub > Freizeitausgleich).
- Jede KPI-Menge wird mit dem Active-Staff-Set geschnitten. Presence-, Absence- und Shift-Lookups joinen nicht gegen `users.staff`, und Sessions einer offboardeten Person überleben das Offboarding.
- `period=week` rechnet über `GetRangeAggregate`, gebaut aus drei vorhandenen Tagesfunktionen, ohne Übertrag. Die untere Prefetch-Grenze wird auf den Wochenmontag geweitet, weil der in den ersten Monatstagen im Vormonat liegt.

## Problem 2 — ein abgeschlossener Monat rechnete sich neu

`active.staff_month_balance_snapshots` (Migration 1.15.222) friert den Closing-Saldo eines Monats ein. Ab dann startet die Kette späterer Monate dort statt beim Kontostart. Der eingefrorene Monat wird **weiter live gerechnet**, und die Differenz erscheint als `drift_minutes` — sichtbar, nicht verschluckt.

```
GET  /api/staff/time-tracking/month-close?year=&month=
POST /api/staff/time-tracking/month-close
POST /api/staff/{id}/time-tracking/month-close/reopen
```

Entscheidungen:

- **Einfrieren nur per expliziter Admin-Aktion**, schulweit in einer Transaktion. Nicht beim ersten Lesen: dann hinge das Einfrier-Datum davon ab, wer wann zufällig hinschaut, und ein noch nicht fertig erfasster Monat würde still als autoritativ festgenagelt. Kein Scheduler in diesem PR.
- **Ein laufender Monat wird abgelehnt** (`ErrMonthNotClosable`). Das ist die wichtigste Wache: das Soll ist beim Stichtag gekappt, der Abschluss kappt am Monatsende. Für einen laufenden Monat läge das in der Zukunft, der eingefrorene Wert wäre um jeden restlichen Arbeitstag zu niedrig, und dieser Fehler würde für immer weiterwandern. Mit `through = today` einzufrieren ist keine Reparatur, dann ist der Wert kein Monatsendwert.
- **Zwei Wege für eine legitime Korrektur danach**: Reopen (Pflicht-Begründung, Snapshot wird superseded statt gelöscht, die Zeile ist ihr eigener Audit-Eintrag) oder die Differenz im offenen Monat als `balance_adjustments`-Buchung vorwärts buchen. Reopen läuft von hinten nach vorn; einen älteren Monat zu öffnen, während ein späterer eingefroren bleibt, ergibt einen Zustand, den niemand nachvollziehen kann.
- **Orthogonal zu #1420**: Snapshot fixiert den Kettenstart und bewegt nichts, ein Adjustment ist eine datierte Buchung mit Delta. Ein `type='reset'` friert ausdrücklich nicht ein — genau dieses Loch schließt der Snapshot. Neu abgelehnt werden Buchungen mit `effective_date` in einem eingefrorenen Monat, weil sie einen fixierten Wert nicht mehr bewegen könnten. Arbeitssessions und Freizeitausgleich-Abwesenheiten in einem eingefrorenen Monat bleiben bewusst editierbar; dafür ist Drift da.
- **Der angezeigte Closing-Saldo von M weicht um genau `drift_minutes` vom Übertrag von M+1 ab.** Das ist gewollt und muss dargestellt werden. Wer es "repariert", indem er den eingefrorenen Wert als Closing anzeigt, bricht die Karten-Identität `carry_in + balance`; wer die Kette neu summiert, holt #1417 zurück.

`getMinimumDailyClosingBalance` brauchte eine eigene Änderung: die Funktion läuft tageweise und akkumulierte über Monatsgrenzen. Liegt eine eingefrorene Grenze im Bereich, wäre das Minimum um die Drift falsch — und daran hängen die Überziehungsprüfungen aus #1420. Das war die einzige Stelle, an der der Snapshot still eine falsche Zahl produziert hätte.

## Nebenbei gefundener Bug

`staffWithPersonQuery` selektierte `employment_type` nicht, das Feld kam für jeden Mitarbeitenden als NULL zurück. Ohne die Spalte hätte der Beschäftigungstyp-Filter nie gematcht. Eine Zeile ergänzt; alle Konsumenten bauen eigene Response-Objekte, es ändert also kein bestehendes Wire-Format.

## Bewusst nicht im Scope

- **Standort-Filter.** Nicht baubar, ohne eine org-weite Leseschicht zu erfinden: `users.persons`/`users.staff` sind tenant-scoped, wer an zwei Schulen arbeitet hat zwei Staff-Zeilen, jeder Request ist per `WithTenantTx` auf einen `tenant_id` festgenagelt und jede RLS-Policy ist eine Skalar-Gleichheit. `scope="org"` existiert als Konstante und JWT-Claim, wird aber von keinem Code-Pfad je ausgestellt. Der aktuelle Tenant **ist** der Standort, ein Filter darüber wäre ein No-op. Braucht ein eigenes Issue.
- Jedes Frontend, DATEV/Lohnexport, Personalnummer, Lohnart-Mapping, Cross-MA-Audit-Log-Filter, Scheduler-Auto-Close.
- Die vom Issue ausgeschlossenen DSGVO-Punkte: kein Ranking, kein MA-Vergleich, keine schulübergreifenden Summen.

## Verifikation

- Migration 1.15.222 gegen Dev- und Test-DB gelaufen, `migrate validate` grün.
- Der geforderte Test existiert: abgeschlossener August, danach die Session über den Admin-Korrekturpfad geändert → September-Übertrag und aktueller Saldo unverändert, `drift_minutes == -120`. Dazu die Variante mit rückwirkend geändertem Dienstplan-Soll (die Formulierung des Issues), Reopen, Idempotenz, Reihenfolge-Wache und die Ablehnung von Buchungen im eingefrorenen Monat.
- Overview: Anti-Drift-Test gegen `GetMonthSummary`, Resturlaub gegen `GetVacationQuotaSummary`, Query-Count-Test, KPI-Test inklusive Prioritäts-Kollaps, Week-vs-Month, Filter, Sortierstabilität, leere und degenerierte Fälle, plus das Zusammenspiel mit einem eingefrorenen Monat.
- API-Tests: Permission-Split (403 auf die Liste mit nur `users:read`), Feldnamen aus dem Issue gepinnt, Filter- und Monatsvalidierung.
- `golangci-lint run`: 0 issues. Alle Ratchets grün (Handler-Layer, Service-Repository, Handler-Complexity, Model-Ceremony, Hermetic, DateColumnTypes, Helper-Consolidation, Repo-Method-Caller). Routen-Golden regeneriert: genau die fünf neuen Routen.
- `go test ./...`: 145 Pakete grün. Eine Ausnahme, **vorbestehend und nicht von diesem PR**: `TestBalanceAdjustmentAPI/delete_removes_the_adjustment` fällt auf `development` identisch (datumsabhängige Kapazitätsprüfung aus #1420, verifiziert per Stash-Vergleich). Bewusst nicht angefasst.
