### PR TITLE
test(time-tracking): Zeitabhängigkeit im Auszahlungs-Fixture beseitigen

### DIFF
--- a/backend/api/staff/balance_adjustment_api_test.go
+++ b/backend/api/staff/balance_adjustment_api_test.go
@@ -232,11 +232,29 @@ func TestBalanceAdjustmentAPI(t *testing.T) {
 	})
 
 	t.Run("delete removes the adjustment", func(t *testing.T) {
-		checkIn := time.Date(today.Year, today.Month, today.Day, 8, 0, 0, 0, time.UTC)
-		checkOut := checkIn.Add(time.Hour)
+		// The session must fund the comp-time booking below, so its window has
+		// to be OVER when the test runs AND must lie entirely inside its own
+		// calendar day. The month math caps a session both at "now"
+		// (workedMinutesUpTo) and at the end of session.Date, so the previous
+		// fixed 08:00-09:00 UTC window contributed nothing on any run before
+		// 09:00 UTC: the balance stayed 0 after the reset and the booking was
+		// rejected for lack of capacity.
+		//
+		// Four hours ending a minute ago satisfies both caps for any run from
+		// 04:01 local onwards; earlier than that the window would reach back
+		// past midnight and the day-end cap would trim most of it, so it moves
+		// to the previous day instead (which is past, hence uncapped).
+		sessionDate := today
+		checkOut := timezone.Now().Add(-time.Minute)
+		checkIn := checkOut.Add(-4 * time.Hour)
+		if checkIn.Before(today.BerlinMidnight()) {
+			sessionDate = today.AddDays(-1)
+			checkIn = sessionDate.BerlinMidnight().Add(8 * time.Hour)
+			checkOut = checkIn.Add(4 * time.Hour)
+		}
 		session := &activeModels.WorkSession{
 			StaffID:      subject.ID,
-			Date:         today,
+			Date:         sessionDate,
 			Status:       activeModels.WorkSessionStatusPresent,
 			Source:       activeModels.WorkSessionSourceApp,
 			CheckInTime:  checkIn,


### PR DESCRIPTION
`TestBalanceAdjustmentAPI/delete_removes_the_adjustment` schlägt bei jedem Lauf vor 09:00 UTC fehl. `development` war deshalb heute morgen rot (Run 30149160250), gestern Nachmittag um 16:44 UTC noch grün.

## Ursache

Der Teiltest finanziert eine Freizeitausgleich-Buchung mit einer Arbeitssession, die er auf feste `08:00-09:00 UTC` des heutigen Tages datierte.

Die Monatsmathematik kappt eine Session bewusst zweifach: bei `now` (`workedMinutesUpTo`) und am Ende von `session.Date`. Lief der Test vor 09:00 UTC, lag das Fenster ganz oder teilweise in der Zukunft und trug entsprechend wenig oder nichts bei. Da der vorangehende Teiltest den Saldo per Reset auf 0 setzt, blieb damit keine Kapazität übrig, und die Buchung wurde korrekt mit 409 abgelehnt:

```
requested reduction of 30 minutes exceeds available capacity of 0 minutes
```

Nachgewiesen mit einem temporären Debug-Test: bei einem Lauf um 07:4x UTC meldet die Monatskarte `actual=240` statt `300` — die heute datierte Stunde fehlt vollständig.

## Fix

Das Fenster wird aus der aktuellen Zeit abgeleitet (vier Stunden, endet eine Minute vor jetzt) und liegt damit immer in der Vergangenheit. Reicht es vor Mitternacht zurück, würde die Tagesgrenze es beschneiden — dann wandert es komplett in den Vortag, der als abgeschlossener Tag ungekappt zählt. Beide Zweige sind verifiziert, der Fallback-Zweig durch temporäres Erzwingen der Bedingung.

**Kein Produktionscode geändert.** Die Kappung ist gewollt: sie verhindert, dass Arbeitszeit gezählt wird, die noch nicht stattgefunden hat, und passt zu `addActualMinutes`, das zukunftsdatierte Sessions ohnehin überspringt. Der Fehler lag ausschließlich im Fixture.

## Verifikation

- `TestBalanceAdjustmentAPI` grün, in beiden Zeitzweigen.
- `go test ./api/... ./test/`: 42 Pakete grün, keine weiteren Ausfälle.
- `golangci-lint run ./api/...`: 0 issues.

Blockiert aktuell #1986; danach sollte dessen `ci-gate` ohne weitere Änderung grün werden.
