### PR TITLE
Verweis auf das NFC-Betriebsbuch im Erste-Schritte-Onepager

### DIFF
--- a/frontend/src/app/help/nfc/erste-schritte/page.test.tsx
+++ b/frontend/src/app/help/nfc/erste-schritte/page.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import NfcQuickstartPage from "./page";
+
+// next/link -> plain anchor, next/image -> plain img (the page only needs the
+// rendered href/alt, not the Next.js runtime).
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src} />
+  ),
+}));
+
+vi.mock("~/components/help/help-search", () => ({
+  HelpSearchInline: () => <div data-testid="help-search-inline" />,
+}));
+
+describe("NfcQuickstartPage", () => {
+  it("verweist auf das ausführliche NFC-Betriebsbuch", () => {
+    render(<NfcQuickstartPage />);
+
+    const link = screen.getByRole("link", { name: /NFC-Betriebsbuch öffnen/i });
+    expect(link).toHaveAttribute("href", "/help/nfc");
+  });
+
+  it("nennt den Weg zum Betriebsbuch auch für den Ausdruck", () => {
+    render(<NfcQuickstartPage />);
+
+    expect(
+      screen.getByText(/unten links auf\s+Hilfe klicken/i),
+    ).toBeInTheDocument();
+  });
+
+  it("zeigt die drei Erste-Schritte-Karten", () => {
+    render(<NfcQuickstartPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Tablet montieren und einschalten" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Mit Geräte-PIN anmelden" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Armbänder zuweisen" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/help/nfc/erste-schritte/page.tsx
+++ b/frontend/src/app/help/nfc/erste-schritte/page.tsx
@@ -1,6 +1,9 @@
 import Image from "next/image";
+import Link from "next/link";
 import {
+  ArrowRight,
   BadgeCheck,
+  BookOpen,
   KeyRound,
   Nfc,
   PlugZap,
@@ -234,6 +237,39 @@ export default function NfcQuickstartPage() {
                   </div>
                 );
               })}
+            </section>
+
+            <section className="mt-6 rounded-3xl border border-gray-200 bg-[#F9FAFB] p-5 print:mt-4 print:rounded-2xl print:p-4">
+              <div className="flex items-start gap-4 print:gap-3">
+                <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-[#83CD2D]/16 text-[#3F6F12] print:h-10 print:w-10 print:rounded-xl">
+                  <BookOpen
+                    className="h-6 w-6 print:h-5 print:w-5"
+                    aria-hidden="true"
+                  />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <h2 className="text-[19px] leading-tight font-semibold tracking-normal print:text-[17px]">
+                    Weiter zum NFC-Betriebsbuch
+                  </h2>
+                  <p className="mt-2 text-sm leading-6 text-gray-700 print:mt-1.5 print:text-[13px] print:leading-5">
+                    Alles Weitere steht im ausführlichen Handbuch: Aufsicht
+                    starten und beenden, Kinder ein- und auschecken,
+                    Arbeitszeiten stempeln, Geräteeinstellungen und
+                    Fehlerbehebung.
+                  </p>
+                  <Link
+                    href="/help/nfc"
+                    className="mt-3 inline-flex items-center gap-2 rounded-lg bg-[#83CD2D] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#74b827] active:bg-[#669f21] print:hidden"
+                  >
+                    NFC-Betriebsbuch öffnen
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </Link>
+                  <p className="mt-2 hidden text-[12px] leading-5 font-medium text-gray-700 print:mt-2 print:block">
+                    So finden Sie es: moto im Browser öffnen, unten links auf
+                    Hilfe klicken und NFC &amp; Tablets wählen.
+                  </p>
+                </div>
+              </div>
             </section>
 
             <footer className="mt-auto flex items-end justify-between gap-6 pt-5 text-xs text-gray-500 print:pt-3 print:text-[11px]">


### PR DESCRIPTION
Schließt #1916.

## Kontext

Der Beileger für ausgelieferte Kiosk-Geräte ist bereits als eigene Hilfe-Seite umgesetzt (PR #1912): `/help/nfc/erste-schritte`, Einstiegskarte auf `/help`, Eintrag in der Hilfesuche, PDF-Export. Florian hat im Issue bestätigt, dass der Onepager bewusst nur die drei Auslieferungsschritte enthält und der komplette Betrieb ins ausführliche NFC-Betriebsbuch gehört.

Offen war damit genau ein Punkt: Beim Entfernen des QR-Codes ist der Weg vom Onepager zur ausführlichen Anleitung verloren gegangen. Die Seite enthielt keinen einzigen Verweis auf `/help/nfc`.

## Änderung

Ein Abschnitt "Weiter zum NFC-Betriebsbuch" am Seitenende:

- **Im Browser**: Button, der auf `/help/nfc` führt.
- **Im Druck/PDF**: statt des Buttons der Klickpfad ("moto im Browser öffnen, unten links auf Hilfe klicken und NFC & Tablets wählen"), weil ein Link auf Papier nichts nützt. Der Onepager landet im Versandkarton, dort muss der Hinweis lesbar bleiben.

Supportkontakt wurde bewusst weggelassen, wie im Issue abgestimmt: die anderen Anleitungen nennen ebenfalls keinen, und die Einrichtungen wissen, an wen sie sich wenden.

Kein neues UI-Element erfunden: der Abschnitt nutzt dieselben Karten-Radien, Grautöne und das Brand-Grün (`#83CD2D` / Hover `#74b827` / Active `#669f21`, aus `LOCATION_COLORS.GROUP_ROOM`) wie der Rest der Seite.

## Verifikation

- `pnpm run check` (verify-locales + oxlint + tsc): grün, keine Warnungen
- `pnpm vitest run src/app/help/nfc/erste-schritte src/components/help/`: 59/59 grün, davon 3 neue Tests für Link-Ziel, Druckhinweis und die drei Schritt-Karten
- Klickpfad im Browser gegen einen lokalen Dev-Server geprüft: Button führt auf `/help/nfc` ("moto NFC & Tablets")
- PDF-Render mit den exakten Optionen aus `scripts/generate-guides.ts` (A4, Rand 0, `printBackground`) nachgestellt: **weiterhin genau 1 Seite**, der Druckhinweis ist sichtbar. Das war das Hauptrisiko, weil die Seite auf `print:h-[296mm]` fixiert ist.

Screenshots hänge ich separat an.
