### PR TITLE
Consolidate German weekday adverb helper

### DIFF
--- a/frontend/src/components/students/companion-picker.tsx
+++ b/frontend/src/components/students/companion-picker.tsx
@@ -18,6 +18,7 @@ import {
   type CompanionWeekday,
   type StudentCompanion,
 } from "~/lib/student-companion-api";
+import { getGermanWeekdayAdverb } from "~/lib/timetable-helpers";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "CompanionPicker" });
@@ -440,7 +441,7 @@ function missingAccompaniedDays(
 function formatDayList(days: CompanionWeekday[]): string {
   const labels = COMPANION_WEEKDAYS.filter((day) =>
     days.includes(day.value),
-  ).map((day) => `${day.label.toLowerCase()}s`);
+  ).map((day) => getGermanWeekdayAdverb(day.label));
   if (labels.length === 0) return "an diesen Tagen";
   if (labels.length === 1) return labels[0]!;
   return `${labels.slice(0, -1).join(", ")} und ${labels.at(-1)}`;

--- a/frontend/src/components/timetable/instance-detail-modal.tsx
+++ b/frontend/src/components/timetable/instance-detail-modal.tsx
@@ -44,6 +44,7 @@ import {
 import { berlinTodayISO, parseISODate } from "~/lib/date-helpers";
 import {
   getActivityTypeBadge,
+  getGermanWeekdayAdverb,
   getGermanWeekdayLong,
   getStatusLabel,
 } from "~/lib/timetable-helpers";
@@ -161,10 +162,9 @@ function germanFullDate(iso: string): string {
  */
 function regelterminOriginLabel(instance: EnrichedInstance): string {
   const weekdayLong = getGermanWeekdayLong(parseISODate(instance.date));
-  const weekdayAdverb = weekdayLong ? `${weekdayLong.toLowerCase()}s` : "";
   return [
     `aus Regeltermin ${instance.title},`,
-    weekdayAdverb,
+    getGermanWeekdayAdverb(weekdayLong),
     instance.startTime,
   ]
     .filter(Boolean)

--- a/frontend/src/components/timetable/substitution-slide-over.tsx
+++ b/frontend/src/components/timetable/substitution-slide-over.tsx
@@ -25,6 +25,7 @@ import { berlinTodayISO, formatDate, parseISODate } from "~/lib/date-helpers";
 import {
   deviationEventLabel,
   getActivityTypeBadge,
+  getGermanWeekdayAdverb,
   getGermanWeekdayLong,
   getStatusLabel,
   staffLabel,
@@ -1145,12 +1146,6 @@ function changeSummary(
   return null;
 }
 
-/** Wochentag als Wiederkehr-Adverb ("Montag" → "montags") für den Slot-Anker. */
-function weekdayAdverb(dateISO: string): string {
-  const long = getGermanWeekdayLong(parseISODate(dateISO));
-  return long ? `${long.toLowerCase()}s` : "";
-}
-
 function HistoryTab({
   instance,
   staffNames,
@@ -1183,7 +1178,7 @@ function HistoryTab({
   // Block-Anker behauptet, während tagesweit geladen wird (Instanzwechsel
   // ohne activityGroupId bei offenem Verlaufs-Reiter).
   const contextChip = slotFiltered
-    ? `Diese Position: ${instance.title}, ${weekdayAdverb(instance.date)} ${instance.startTime}`
+    ? `Diese Position: ${instance.title}, ${getGermanWeekdayAdverb(getGermanWeekdayLong(parseISODate(instance.date)))} ${instance.startTime}`
     : formatDate(instance.date);
 
   return (

--- a/frontend/src/lib/timetable-helpers.test.ts
+++ b/frontend/src/lib/timetable-helpers.test.ts
@@ -15,6 +15,7 @@ import {
   getActivityTypeBadge,
   getCurrentTimeOffset,
   getEventBlockPosition,
+  getGermanWeekdayAdverb,
   getGermanWeekdayLong,
   getGermanWeekdayShort,
   getMonthDays,
@@ -215,6 +216,19 @@ describe("date and range helpers", () => {
     expect(formatYearLabel(monday)).toBe("2026");
     expect(getGermanWeekdayLong(monday)).toBe("Montag");
     expect(getGermanWeekdayShort(monday)).toBe("Mo");
+  });
+
+  it.each([
+    ["Montag", "montags"],
+    ["Dienstag", "dienstags"],
+    ["Mittwoch", "mittwochs"],
+    ["Donnerstag", "donnerstags"],
+    ["Freitag", "freitags"],
+    ["Samstag", "samstags"],
+    ["Sonntag", "sonntags"],
+    ["", ""],
+  ])("formats %j as the recurring weekday adverb %j", (weekday, expected) => {
+    expect(getGermanWeekdayAdverb(weekday)).toBe(expected);
   });
 });
 

--- a/frontend/src/lib/timetable-helpers.ts
+++ b/frontend/src/lib/timetable-helpers.ts
@@ -252,6 +252,11 @@ export function getGermanWeekdayLong(d: Date): string {
   return GERMAN_WEEKDAY_LONG[d.getDay()] ?? "";
 }
 
+/** Converts a German weekday name to its recurring adverb ("Montag" → "montags"). */
+export function getGermanWeekdayAdverb(weekday: string): string {
+  return weekday ? `${weekday.toLowerCase()}s` : "";
+}
+
 export function getGermanWeekdayShort(d: Date): string {
   return GERMAN_WEEKDAY_SHORT[d.getDay()] ?? "";
 }


### PR DESCRIPTION
## Summary
- add `getGermanWeekdayAdverb` beside the existing German weekday helpers
- replace the three file-local conversions in the timetable detail, substitution history, and companion picker flows
- cover Monday through Sunday plus empty input with a table-driven test

## Tests
- `pnpm exec vitest run src/lib/timetable-helpers.test.ts src/components/timetable/substitution-slide-over.test.tsx src/components/timetable/instance-detail-modal.test.tsx src/components/students/companion-picker.test.tsx` — 119 passed
- `pnpm run test:run` — 11,998 passed across 868 files
- `pnpm run check`
- `pnpm run knip` with the Playwright config's required local host values
- pre-push `frontend-depcruise`, `frontend-knip`, and `frontend-check`

## Browser QA
Agent-browser verified the unchanged UI output in all three consumers:
- Betreuungsplan origin chip: `aus Regeltermin Mensa, montags 12:00`
- Vertretung history anchor: `Diese Position: Mensa, montags 12:00`
- Laufgemeinschaft prompt: `montags und dienstags`

The timetable reads used contract-shaped route interception because the shared local development database has pre-existing migration drift: migration 1.15.218 is recorded as applied while its `list_kind` columns are absent. The Laufgemeinschaft flow used the real seeded backend and did not save changes.

Closes #1932
